### PR TITLE
Revert unintended pre-commit config changes from PR #250

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,9 +57,11 @@ repos:
     rev: v1.9.0
     hooks:
       - id: mypy
-        args: [--config-file, pyproject.toml, --explicit-package-bases, --follow-imports=skip]
+        args: [--config-file, pyproject.toml]
         additional_dependencies:
           - types-requests
+        pass_filenames: false
+        entry: mypy scripts/shared web.py cli.py
 
   # =============================================================================
   # Security Checks
@@ -97,12 +99,11 @@ repos:
         args: [--branch, main, --branch, master]
 
   # =============================================================================
-  # Documentation (disabled - project has too many legacy violations)
+  # Documentation
   # =============================================================================
-  # - repo: https://github.com/pycqa/pydocstyle
-  #   rev: 6.3.0
-  #   hooks:
-  #     - id: pydocstyle
-  #       language_version: python3.12
-  #       args: [--ignore-decorators]
-  #       exclude: ^tests/|^scripts/|^migrations/|^frontend/|^node_modules/
+  - repo: https://github.com/pycqa/pydocstyle
+    rev: 6.3.0
+    hooks:
+      - id: pydocstyle
+        args: [--ignore-decorators]
+        exclude: ^tests/|^scripts/


### PR DESCRIPTION
## Summary

Restore `.pre-commit-config.yaml` to the state before PR #250 was merged. PR #250 accidentally included tooling configuration changes that belong in a separate PR.

## Changes

| Change | Before (current) | After (restored) |
|--------|-----------------|-----------------|
| mypy args | `--explicit-package-bases --follow-imports=skip` | `--config-file pyproject.toml` |
| mypy scope | All staged files (entry removed) | `mypy scripts/shared web.py cli.py` with `pass_filenames: false` |
| pydocstyle | Commented out | Enabled |

### Why these reverts matter

- **`--follow-imports=skip`** effectively disables cross-module type checking, masking real type errors
- **Removing `entry`/`pass_filenames`** causes mypy to check all staged files instead of the intended scope
- **Disabling pydocstyle** by commenting out should be a deliberate decision in its own PR, not a side effect

Closes #251