### PR TITLE
feat: unified auth decorators (Phase 1 of #261)

### DIFF
--- a/app/auth/__init__.py
+++ b/app/auth/__init__.py
@@ -1,0 +1,5 @@
+"""Unified authentication and authorization framework for Open ACE."""
+
+from app.auth.decorators import admin_required, auth_required, public_endpoint
+
+__all__ = ["auth_required", "admin_required", "public_endpoint"]

--- a/app/auth/decorators.py
+++ b/app/auth/decorators.py
@@ -63,13 +63,13 @@ def _load_user_from_token(token: str) -> dict | None:
 
 def _check_session_ownership(user_id: int, session_id: str) -> bool:
     """Check if user owns the given session."""
-    from app.repositories.workspace_repo import WorkspaceRepository
+    from app.modules.workspace.session_manager import get_session_manager
 
-    repo = WorkspaceRepository()
-    session = repo.get_session(session_id)
+    mgr = get_session_manager()
+    session = mgr.get_session(session_id)
     if not session:
         return False
-    return session.get("user_id") == user_id
+    return getattr(session, "user_id", None) == user_id
 
 
 def _check_machine_admin(user_id: int, machine_id: str) -> bool:
@@ -114,7 +114,10 @@ def auth_required(f=None, *, ownership=None):
             g.user_id = user.get("id")
             g.user_role = user.get("role")
 
-            # Ownership checks
+            # Ownership checks (admin bypasses)
+            if g.user_role == "admin":
+                return func(*args, **kwargs)
+
             if ownership == "session":
                 session_id = kwargs.get("session_id")
                 if session_id and not _check_session_ownership(g.user_id, session_id):

--- a/app/auth/decorators.py
+++ b/app/auth/decorators.py
@@ -1,0 +1,186 @@
+"""
+Unified authentication decorators for Open ACE.
+
+Replaces 11+ scattered require_auth/require_admin implementations with a
+single, consistent framework. All token extraction, validation, and error
+responses go through one code path.
+
+Usage:
+    @auth_required                              # Just needs login
+    @admin_required                             # Needs admin role
+    @auth_required(ownership='session')         # Needs session ownership
+    @public_endpoint                            # Explicitly marks as public (no auth)
+"""
+
+from __future__ import annotations
+
+import logging
+from functools import wraps
+
+from flask import g, jsonify, request
+
+logger = logging.getLogger(__name__)
+
+
+def _get_auth_service():
+    """Lazy import to avoid circular imports."""
+    from app.services.auth_service import AuthService
+
+    return AuthService()
+
+
+def _extract_token() -> str:
+    """Extract auth token from request (cookie → header → query param)."""
+    token = request.cookies.get("session_token")
+    if token:
+        return token
+
+    auth_header = request.headers.get("Authorization", "")
+    if auth_header.startswith("Bearer "):
+        return auth_header[7:]
+
+    return request.args.get("token", "")
+
+
+def _authenticate(token: str) -> tuple[bool, dict | None]:
+    """Validate token and return (success, user_dict_or_error)."""
+    auth_service = _get_auth_service()
+    return auth_service.validate_session(token)
+
+
+def _load_user_from_token(token: str) -> dict | None:
+    """Validate token and set g.user. Returns user dict or None."""
+    valid, result = _authenticate(token)
+    if not valid:
+        return None
+    return {
+        "id": result.get("user_id"),
+        "username": result.get("username"),
+        "email": result.get("email"),
+        "role": result.get("role"),
+    }
+
+
+def _check_session_ownership(user_id: int, session_id: str) -> bool:
+    """Check if user owns the given session."""
+    from app.repositories.workspace_repo import WorkspaceRepository
+
+    repo = WorkspaceRepository()
+    session = repo.get_session(session_id)
+    if not session:
+        return False
+    return session.get("user_id") == user_id
+
+
+def _check_machine_admin(user_id: int, machine_id: str) -> bool:
+    """Check if user is system admin or machine admin."""
+    g_user = getattr(g, "user", {})
+    if g_user.get("role") == "admin":
+        return True
+    try:
+        from app.services.remote_agent_manager import get_remote_agent_manager
+
+        mgr = get_remote_agent_manager()
+        perm = mgr.get_user_permission(machine_id, user_id)
+        return perm == "admin"
+    except Exception:
+        return False
+
+
+def auth_required(f=None, *, ownership=None):
+    """
+    Decorator: require authentication, optionally with ownership check.
+
+    Args:
+        ownership: Optional ownership check type.
+            'session' — verifies g.user.id matches session's user_id
+            'machine' — verifies machine admin permission
+
+    Sets g.user, g.user_id, g.user_role on success.
+    """
+
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            token = _extract_token()
+            if not token:
+                return jsonify({"error": "Authentication required"}), 401
+
+            user = _load_user_from_token(token)
+            if not user:
+                return jsonify({"error": "Invalid or expired session"}), 401
+
+            g.user = user
+            g.user_id = user.get("id")
+            g.user_role = user.get("role")
+
+            # Ownership checks
+            if ownership == "session":
+                session_id = kwargs.get("session_id")
+                if session_id and not _check_session_ownership(g.user_id, session_id):
+                    return jsonify({"error": "Access denied"}), 403
+
+            elif ownership == "machine":
+                machine_id = kwargs.get("machine_id")
+                if machine_id and not _check_machine_admin(g.user_id, machine_id):
+                    return jsonify({"error": "Machine admin permission required"}), 403
+
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    if f is not None:
+        return decorator(f)
+    return decorator
+
+
+def admin_required(f=None):
+    """
+    Decorator: require admin role.
+
+    Sets g.user, g.user_id, g.user_role on success.
+    """
+
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            token = _extract_token()
+            if not token:
+                return jsonify({"error": "Authentication required"}), 401
+
+            user = _load_user_from_token(token)
+            if not user:
+                return jsonify({"error": "Invalid or expired session"}), 401
+
+            if user.get("role") != "admin":
+                return jsonify({"error": "Admin access required"}), 403
+
+            g.user = user
+            g.user_id = user.get("id")
+            g.user_role = user.get("role")
+
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    if f is not None:
+        return decorator(f)
+    return decorator
+
+
+def public_endpoint(f):
+    """
+    Decorator: explicitly mark an endpoint as public (no auth required).
+
+    Used by the API security scanner to identify intentionally unauthenticated
+    routes, replacing the hardcoded PUBLIC_ENDPOINTS list.
+    """
+    f._is_public_endpoint = True
+
+    @wraps(f)
+    def wrapper(*args, **kwargs):
+        return f(*args, **kwargs)
+
+    # Copy the marker to the wrapper so scanner can find it
+    wrapper._is_public_endpoint = True
+    return wrapper

--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -10,17 +10,16 @@ import os
 import subprocess
 
 import bcrypt
-from flask import Blueprint, jsonify, request
+from flask import Blueprint, g, jsonify, request
 
+from app.auth.decorators import admin_required
 from app.repositories.usage_repo import UsageRepository
 from app.repositories.user_repo import UserRepository
-from app.services.auth_service import AuthService
 from app.utils.validators import validate_email, validate_password, validate_username
 
 logger = logging.getLogger(__name__)
 
 admin_bp = Blueprint("admin", __name__)
-auth_service = AuthService()
 user_repo = UserRepository()
 usage_repo = UsageRepository()
 
@@ -28,12 +27,6 @@ usage_repo = UsageRepository()
 def hash_password(password: str) -> str:
     """Hash a password using bcrypt."""
     return bcrypt.hashpw(password.encode(), bcrypt.gensalt(rounds=12)).decode()
-
-
-def require_admin(token: str):
-    """Require admin role and return session data."""
-    is_admin, session_or_error = auth_service.require_admin(token)
-    return is_admin, session_or_error
 
 
 def get_workspace_base_dir() -> str:
@@ -111,18 +104,9 @@ def _ensure_workspace_dirs(system_account: str, base_dir: str):
 
 
 @admin_bp.route("/admin/users", methods=["GET"])
+@admin_required
 def api_get_users():
     """Get all users."""
-    token = request.cookies.get("session_token") or request.headers.get(
-        "Authorization", ""
-    ).replace("Bearer ", "")
-
-    is_admin, session_or_error = require_admin(token)
-    if not is_admin:
-        return jsonify(session_or_error), (
-            403 if "Admin" in session_or_error.get("error", "") else 401
-        )
-
     users = user_repo.get_all_users()
 
     # Remove password hashes
@@ -133,18 +117,9 @@ def api_get_users():
 
 
 @admin_bp.route("/admin/users", methods=["POST"])
+@admin_required
 def api_create_user():
     """Create a new user."""
-    token = request.cookies.get("session_token") or request.headers.get(
-        "Authorization", ""
-    ).replace("Bearer ", "")
-
-    is_admin, session_or_error = require_admin(token)
-    if not is_admin:
-        return jsonify(session_or_error), (
-            403 if "Admin" in session_or_error.get("error", "") else 401
-        )
-
     data = request.get_json() or {}
     username = data.get("username")
     email = data.get("email")
@@ -194,18 +169,9 @@ def api_create_user():
 
 
 @admin_bp.route("/admin/users/<int:user_id>", methods=["PUT"])
+@admin_required
 def api_update_user(user_id):
     """Update a user."""
-    token = request.cookies.get("session_token") or request.headers.get(
-        "Authorization", ""
-    ).replace("Bearer ", "")
-
-    is_admin, session_or_error = require_admin(token)
-    if not is_admin:
-        return jsonify(session_or_error), (
-            403 if "Admin" in session_or_error.get("error", "") else 401
-        )
-
     data = request.get_json() or {}
 
     # Auto-create system user if system_account is being set
@@ -232,20 +198,11 @@ def api_update_user(user_id):
 
 
 @admin_bp.route("/admin/users/<int:user_id>", methods=["DELETE"])
+@admin_required
 def api_delete_user(user_id):
     """Delete a user."""
-    token = request.cookies.get("session_token") or request.headers.get(
-        "Authorization", ""
-    ).replace("Bearer ", "")
-
-    is_admin, session_or_error = require_admin(token)
-    if not is_admin:
-        return jsonify(session_or_error), (
-            403 if "Admin" in session_or_error.get("error", "") else 401
-        )
-
     # Prevent deleting yourself
-    if session_or_error.get("user_id") == user_id:
+    if g.user_id == user_id:
         return jsonify({"error": "Cannot delete yourself"}), 400
 
     success = user_repo.delete_user(user_id)
@@ -257,18 +214,9 @@ def api_delete_user(user_id):
 
 
 @admin_bp.route("/admin/users/<int:user_id>/password", methods=["PUT"])
+@admin_required
 def api_update_user_password(user_id):
     """Update a user's password."""
-    token = request.cookies.get("session_token") or request.headers.get(
-        "Authorization", ""
-    ).replace("Bearer ", "")
-
-    is_admin, session_or_error = require_admin(token)
-    if not is_admin:
-        return jsonify(session_or_error), (
-            403 if "Admin" in session_or_error.get("error", "") else 401
-        )
-
     data = request.get_json() or {}
     password = data.get("password")
 
@@ -286,18 +234,9 @@ def api_update_user_password(user_id):
 
 
 @admin_bp.route("/admin/users/<int:user_id>/quota", methods=["PUT"])
+@admin_required
 def api_update_user_quota(user_id):
     """Update a user's quota."""
-    token = request.cookies.get("session_token") or request.headers.get(
-        "Authorization", ""
-    ).replace("Bearer ", "")
-
-    is_admin, session_or_error = require_admin(token)
-    if not is_admin:
-        return jsonify(session_or_error), (
-            403 if "Admin" in session_or_error.get("error", "") else 401
-        )
-
     data = request.get_json() or {}
 
     success = user_repo.update_user_quota(
@@ -315,18 +254,9 @@ def api_update_user_quota(user_id):
 
 
 @admin_bp.route("/admin/quota/usage", methods=["GET"])
+@admin_required
 def api_quota_usage():
     """Get quota usage for all users."""
-    token = request.cookies.get("session_token") or request.headers.get(
-        "Authorization", ""
-    ).replace("Bearer ", "")
-
-    is_admin, session_or_error = require_admin(token)
-    if not is_admin:
-        return jsonify(session_or_error), (
-            403 if "Admin" in session_or_error.get("error", "") else 401
-        )
-
     users = user_repo.get_all_users()
 
     # Remove sensitive data

--- a/app/routes/alerts.py
+++ b/app/routes/alerts.py
@@ -17,41 +17,26 @@ from datetime import datetime
 
 from flask import Blueprint, g, jsonify, request
 
+from app.auth.decorators import _extract_token, _load_user_from_token
 from app.modules.governance.alert_notifier import NotificationPreference, get_alert_notifier
-from app.services.auth_service import AuthService
 
 logger = logging.getLogger(__name__)
 
 alerts_bp = Blueprint("alerts", __name__)
-auth_service = AuthService()
 
 
 @alerts_bp.before_request
 def load_user():
-    """Load the current user from session token before each request.
-
-    All alerts endpoints require authentication. Returns 401 if no valid
-    session token is provided.
-    """
-    token = request.cookies.get("session_token") or request.headers.get(
-        "Authorization", ""
-    ).replace("Bearer ", "")
-
+    """Load the current user from session token before each request."""
+    token = _extract_token()
     if token:
-        session = auth_service.validate_session(token)
-        if session[0]:
-            session_data = session[1]
-            g.user = {
-                "id": session_data.get("user_id"),
-                "username": session_data.get("username"),
-                "email": session_data.get("email"),
-                "role": session_data.get("role"),
-            }
-            return None  # Authenticated
-        else:
-            return jsonify({"error": "Authentication required"}), 401
-    else:
-        return jsonify({"error": "Authentication required"}), 401
+        user = _load_user_from_token(token)
+        if user:
+            g.user = user
+            g.user_id = user.get("id")
+            g.user_role = user.get("role")
+            return None
+    return jsonify({"error": "Authentication required"}), 401
 
 
 # ==================== REST API ====================

--- a/app/routes/analytics.py
+++ b/app/routes/analytics.py
@@ -8,29 +8,16 @@ API routes for usage analytics and reporting.
 import logging
 from datetime import datetime, timedelta
 
-from flask import Blueprint, Response, jsonify, request
+from flask import Blueprint, Response, g, jsonify, request
 
+from app.auth.decorators import admin_required
 from app.modules.analytics.usage_analytics import UsageAnalytics
 from app.modules.governance.audit_logger import AuditAction, AuditLogger
-from app.services.auth_service import AuthService
 
 analytics_bp = Blueprint("analytics", __name__)
-auth_service = AuthService()
 usage_analytics = UsageAnalytics()
 audit_logger = AuditLogger()
 logger = logging.getLogger(__name__)
-
-
-def require_admin(token: str):
-    """Require admin role and return session data."""
-    is_admin, session_or_error = auth_service.require_admin(token)
-    return is_admin, session_or_error
-
-
-def require_auth(token: str):
-    """Require authentication and return session data."""
-    is_auth, session_or_error = auth_service.require_auth(token)
-    return is_auth, session_or_error
 
 
 def get_client_info():
@@ -42,18 +29,9 @@ def get_client_info():
 
 
 @analytics_bp.route("/analytics/report", methods=["GET"])
+@admin_required
 def api_usage_report():
     """Generate a comprehensive usage report."""
-    token = request.cookies.get("session_token") or request.headers.get(
-        "Authorization", ""
-    ).replace("Bearer ", "")
-
-    is_admin, session_or_error = require_admin(token)
-    if not is_admin:
-        return jsonify(session_or_error), (
-            403 if "Admin" in session_or_error.get("error", "") else 401
-        )
-
     # Get date range
     end_date = request.args.get("end_date", datetime.utcnow().strftime("%Y-%m-%d"))
     days = request.args.get("days", default=30, type=int)
@@ -75,8 +53,8 @@ def api_usage_report():
     client_info = get_client_info()
     audit_logger.log_action(
         action=AuditAction.DATA_VIEW,
-        user_id=session_or_error.get("user_id"),
-        username=session_or_error.get("username"),
+        user_id=g.user_id,
+        username=g.user.get("username"),
         resource_type="analytics_report",
         details={"start_date": start_date, "end_date": end_date, "days": days},
         **client_info,
@@ -86,18 +64,9 @@ def api_usage_report():
 
 
 @analytics_bp.route("/analytics/forecast", methods=["GET"])
+@admin_required
 def api_usage_forecast():
     """Get usage forecast."""
-    token = request.cookies.get("session_token") or request.headers.get(
-        "Authorization", ""
-    ).replace("Bearer ", "")
-
-    is_admin, session_or_error = require_admin(token)
-    if not is_admin:
-        return jsonify(session_or_error), (
-            403 if "Admin" in session_or_error.get("error", "") else 401
-        )
-
     days = request.args.get("days", default=7, type=int)
 
     forecast = usage_analytics.get_forecast(days=days)
@@ -106,18 +75,9 @@ def api_usage_forecast():
 
 
 @analytics_bp.route("/analytics/efficiency", methods=["GET"])
+@admin_required
 def api_efficiency_metrics():
     """Get efficiency metrics."""
-    token = request.cookies.get("session_token") or request.headers.get(
-        "Authorization", ""
-    ).replace("Bearer ", "")
-
-    is_admin, session_or_error = require_admin(token)
-    if not is_admin:
-        return jsonify(session_or_error), (
-            403 if "Admin" in session_or_error.get("error", "") else 401
-        )
-
     # Get date range
     end_date = request.args.get("end_date", datetime.utcnow().strftime("%Y-%m-%d"))
     days = request.args.get("days", default=30, type=int)
@@ -130,18 +90,9 @@ def api_efficiency_metrics():
 
 
 @analytics_bp.route("/analytics/export", methods=["GET"])
+@admin_required
 def api_export_analytics():
     """Export analytics data."""
-    token = request.cookies.get("session_token") or request.headers.get(
-        "Authorization", ""
-    ).replace("Bearer ", "")
-
-    is_admin, session_or_error = require_admin(token)
-    if not is_admin:
-        return jsonify(session_or_error), (
-            403 if "Admin" in session_or_error.get("error", "") else 401
-        )
-
     # Get parameters
     end_date = request.args.get("end_date", datetime.utcnow().strftime("%Y-%m-%d"))
     days = request.args.get("days", default=30, type=int)
@@ -158,8 +109,8 @@ def api_export_analytics():
     client_info = get_client_info()
     audit_logger.log_action(
         action=AuditAction.DATA_EXPORT,
-        user_id=session_or_error.get("user_id"),
-        username=session_or_error.get("username"),
+        user_id=g.user_id,
+        username=g.user.get("username"),
         resource_type="analytics",
         details={"format": format_type, "start_date": start_date, "end_date": end_date},
         **client_info,

--- a/app/routes/compliance.py
+++ b/app/routes/compliance.py
@@ -8,12 +8,12 @@ API endpoints for compliance reporting and data retention management.
 import logging
 from datetime import datetime, timedelta
 
-from flask import Blueprint, Response, jsonify, request
+from flask import Blueprint, Response, g, jsonify, request
 
+from app.auth.decorators import admin_required
 from app.modules.compliance.audit import AuditAnalyzer
 from app.modules.compliance.report import ReportGenerator, ReportType
 from app.modules.compliance.retention import DataRetentionManager
-from app.services.auth_service import AuthService
 
 logger = logging.getLogger(__name__)
 
@@ -34,28 +34,13 @@ def get_retention_manager():
     return _retention_manager
 
 
-auth_service = AuthService()
-
-
-def _require_admin():
-    """Require admin authentication."""
-    token = request.cookies.get("session_token") or request.headers.get(
-        "Authorization", ""
-    ).replace("Bearer ", "")
-    is_admin, result = auth_service.require_admin(token)
-
-    if not is_admin:
-        return False, jsonify({"error": result.get("error", "Admin access required")}), 403
-
-    return True, result, None
-
-
 # =============================================================================
 # Report Generation Endpoints
 # =============================================================================
 
 
 @compliance_bp.route("/reports", methods=["GET"])
+@admin_required
 def list_reports():
     """List available report types."""
     report_types = [
@@ -104,11 +89,9 @@ def list_reports():
 
 
 @compliance_bp.route("/reports", methods=["POST"])
+@admin_required
 def generate_report():
     """Generate a compliance report (admin only)."""
-    is_admin, result, error_response = _require_admin()
-    if not is_admin:
-        return error_response
 
     data = request.get_json()
 
@@ -138,7 +121,7 @@ def generate_report():
         report_type=report_type,
         period_start=period_start,
         period_end=period_end,
-        generated_by=result.get("user_id"),
+        generated_by=g.user_id,
         tenant_id=data.get("tenant_id"),
         filters=data.get("filters"),
     )
@@ -162,11 +145,9 @@ def generate_report():
 
 
 @compliance_bp.route("/reports/saved", methods=["GET"])
+@admin_required
 def list_saved_reports():
     """List saved reports (admin only)."""
-    is_admin, result, error_response = _require_admin()
-    if not is_admin:
-        return error_response
 
     report_type = request.args.get("report_type")
     tenant_id = request.args.get("tenant_id", type=int)
@@ -187,11 +168,9 @@ def list_saved_reports():
 
 
 @compliance_bp.route("/reports/<report_id>", methods=["GET"])
+@admin_required
 def get_saved_report(report_id: str):
     """Get a saved report (admin only)."""
-    is_admin, result, error_response = _require_admin()
-    if not is_admin:
-        return error_response
 
     report = report_generator.get_saved_report(report_id)
 
@@ -219,11 +198,9 @@ def get_saved_report(report_id: str):
 
 
 @compliance_bp.route("/audit/patterns", methods=["GET"])
+@admin_required
 def analyze_patterns():
     """Analyze audit patterns (admin only)."""
-    is_admin, result, error_response = _require_admin()
-    if not is_admin:
-        return error_response
 
     days = request.args.get("days", 30, type=int)
     start_time = datetime.utcnow() - timedelta(days=days)
@@ -234,11 +211,9 @@ def analyze_patterns():
 
 
 @compliance_bp.route("/audit/anomalies", methods=["GET"])
+@admin_required
 def detect_anomalies():
     """Detect audit anomalies (admin only)."""
-    is_admin, result, error_response = _require_admin()
-    if not is_admin:
-        return error_response
 
     days = request.args.get("days", 7, type=int)
     start_time = datetime.utcnow() - timedelta(days=days)
@@ -261,11 +236,9 @@ def detect_anomalies():
 
 
 @compliance_bp.route("/audit/user/<int:user_id>/profile", methods=["GET"])
+@admin_required
 def get_user_profile(user_id: int):
     """Get user behavior profile (admin only)."""
-    is_admin, result, error_response = _require_admin()
-    if not is_admin:
-        return error_response
 
     days = request.args.get("days", 30, type=int)
 
@@ -275,11 +248,9 @@ def get_user_profile(user_id: int):
 
 
 @compliance_bp.route("/audit/security-score", methods=["GET"])
+@admin_required
 def get_security_score():
     """Get security score (admin only)."""
-    is_admin, result, error_response = _require_admin()
-    if not is_admin:
-        return error_response
 
     days = request.args.get("days", 30, type=int)
     start_time = datetime.utcnow() - timedelta(days=days)
@@ -295,11 +266,9 @@ def get_security_score():
 
 
 @compliance_bp.route("/retention/rules", methods=["GET"])
+@admin_required
 def get_retention_rules():
     """Get data retention rules (admin only)."""
-    is_admin, result, error_response = _require_admin()
-    if not is_admin:
-        return error_response
 
     rules = get_retention_manager().get_all_rules()
 
@@ -311,11 +280,9 @@ def get_retention_rules():
 
 
 @compliance_bp.route("/retention/rules", methods=["PUT"])
+@admin_required
 def set_retention_rule():
     """Set a data retention rule (admin only)."""
-    is_admin, result, error_response = _require_admin()
-    if not is_admin:
-        return error_response
 
     data = request.get_json()
 
@@ -340,11 +307,9 @@ def set_retention_rule():
 
 
 @compliance_bp.route("/retention/cleanup", methods=["POST"])
+@admin_required
 def run_retention_cleanup():
     """Run data retention cleanup (admin only)."""
-    is_admin, result, error_response = _require_admin()
-    if not is_admin:
-        return error_response
 
     dry_run = request.args.get("dry_run", "false").lower() == "true"
 
@@ -354,11 +319,9 @@ def run_retention_cleanup():
 
 
 @compliance_bp.route("/retention/history", methods=["GET"])
+@admin_required
 def get_retention_history():
     """Get retention cleanup history (admin only)."""
-    is_admin, result, error_response = _require_admin()
-    if not is_admin:
-        return error_response
 
     limit = request.args.get("limit", 30, type=int)
 
@@ -373,11 +336,9 @@ def get_retention_history():
 
 
 @compliance_bp.route("/retention/storage", methods=["GET"])
+@admin_required
 def estimate_storage():
     """Estimate storage usage (admin only)."""
-    is_admin, result, error_response = _require_admin()
-    if not is_admin:
-        return error_response
 
     estimates = get_retention_manager().estimate_storage()
 
@@ -385,11 +346,9 @@ def estimate_storage():
 
 
 @compliance_bp.route("/retention/status", methods=["GET"])
+@admin_required
 def get_retention_status():
     """Get data retention compliance status (admin only)."""
-    is_admin, result, error_response = _require_admin()
-    if not is_admin:
-        return error_response
 
     status = get_retention_manager().get_compliance_status()
 

--- a/app/routes/fs.py
+++ b/app/routes/fs.py
@@ -17,12 +17,10 @@ from pathlib import Path
 from flask import Blueprint, jsonify, request
 
 from app.repositories.user_repo import UserRepository
-from app.services.auth_service import AuthService
 
 logger = logging.getLogger(__name__)
 
 fs_bp = Blueprint("fs", __name__)
-auth_service = AuthService()
 user_repo = UserRepository()
 
 
@@ -40,12 +38,12 @@ def get_current_user():
     if not token:
         return None, {"error": "Unauthorized"}, 401
 
-    valid, session_or_error = auth_service.validate_session(token)
-    if not valid:
-        return None, session_or_error, 401
+    from app.auth.decorators import _load_user_from_token
 
-    user_id = session_or_error.get("user_id")
-    user = user_repo.get_user_by_id(user_id)
+    user_data = _load_user_from_token(token)
+    if not user_data:
+        return None, {"error": "Unauthorized"}, 401
+    user = user_repo.get_user_by_id(user_data.get("id"))
     return user, None, 200
 
 

--- a/app/routes/governance.py
+++ b/app/routes/governance.py
@@ -11,31 +11,18 @@ API routes for enterprise governance features:
 import logging
 from datetime import datetime, timedelta
 
-from flask import Blueprint, jsonify, request
+from flask import Blueprint, g, jsonify, request
 
+from app.auth.decorators import admin_required, auth_required
 from app.modules.governance.audit_logger import AuditAction, AuditLogger
 from app.modules.governance.content_filter import ContentFilter
 from app.modules.governance.quota_manager import QuotaManager
-from app.services.auth_service import AuthService
 
 governance_bp = Blueprint("governance", __name__)
-auth_service = AuthService()
 audit_logger = AuditLogger()
 quota_manager = QuotaManager()
 content_filter = ContentFilter()
 logger = logging.getLogger(__name__)
-
-
-def require_admin(token: str):
-    """Require admin role and return session data."""
-    is_admin, session_or_error = auth_service.require_admin(token)
-    return is_admin, session_or_error
-
-
-def require_auth(token: str):
-    """Require authentication and return session data."""
-    is_auth, session_or_error = auth_service.require_auth(token)
-    return is_auth, session_or_error
 
 
 def get_client_info():
@@ -52,17 +39,9 @@ def get_client_info():
 
 
 @governance_bp.route("/audit/logs", methods=["GET"])
+@admin_required
 def api_get_audit_logs():
     """Get audit logs with filters."""
-    token = request.cookies.get("session_token") or request.headers.get(
-        "Authorization", ""
-    ).replace("Bearer ", "")
-
-    is_admin, session_or_error = require_admin(token)
-    if not is_admin:
-        return jsonify(session_or_error), (
-            403 if "Admin" in session_or_error.get("error", "") else 401
-        )
 
     # Get query parameters
     user_id = request.args.get("user_id", type=int)
@@ -108,29 +87,23 @@ def api_get_audit_logs():
 
 
 @governance_bp.route("/audit-logs", methods=["GET"])
+@admin_required
 def api_audit_logs():
     """Get audit logs with filters (alias for /audit/logs)."""
     return api_get_audit_logs()
 
 
 @governance_bp.route("/governance/audit-logs", methods=["GET"])
+@admin_required
 def api_governance_audit_logs():
     """Get audit logs with filters (full path alias for /audit/logs)."""
     return api_get_audit_logs()
 
 
 @governance_bp.route("/audit/logs/export", methods=["GET"])
+@admin_required
 def api_export_audit_logs():
     """Export audit logs."""
-    token = request.cookies.get("session_token") or request.headers.get(
-        "Authorization", ""
-    ).replace("Bearer ", "")
-
-    is_admin, session_or_error = require_admin(token)
-    if not is_admin:
-        return jsonify(session_or_error), (
-            403 if "Admin" in session_or_error.get("error", "") else 401
-        )
 
     # Get date range
     start_date = request.args.get("start_date")
@@ -151,8 +124,8 @@ def api_export_audit_logs():
     client_info = get_client_info()
     audit_logger.log_action(
         action=AuditAction.DATA_EXPORT,
-        user_id=session_or_error.get("user_id"),
-        username=session_or_error.get("username"),
+        user_id=g.user_id,
+        username=g.user.get("username"),
         resource_type="audit_logs",
         details={"format": format_type, "start": start_date, "end": end_date},
         **client_info,
@@ -180,17 +153,9 @@ def api_export_audit_logs():
 
 
 @governance_bp.route("/audit/user/<int:user_id>/activity", methods=["GET"])
+@admin_required
 def api_user_activity(user_id):
     """Get activity summary for a user."""
-    token = request.cookies.get("session_token") or request.headers.get(
-        "Authorization", ""
-    ).replace("Bearer ", "")
-
-    is_admin, session_or_error = require_admin(token)
-    if not is_admin:
-        return jsonify(session_or_error), (
-            403 if "Admin" in session_or_error.get("error", "") else 401
-        )
 
     days = request.args.get("days", default=30, type=int)
 
@@ -208,17 +173,9 @@ def api_user_activity(user_id):
 
 
 @governance_bp.route("/quota/status/all", methods=["GET"])
+@admin_required
 def api_all_quota_status():
     """Get quota status for all users (admin only)."""
-    token = request.cookies.get("session_token") or request.headers.get(
-        "Authorization", ""
-    ).replace("Bearer ", "")
-
-    is_admin, session_or_error = require_admin(token)
-    if not is_admin:
-        return jsonify(session_or_error), (
-            403 if "Admin" in session_or_error.get("error", "") else 401
-        )
 
     statuses = quota_manager.get_all_quota_statuses()
 
@@ -226,17 +183,10 @@ def api_all_quota_status():
 
 
 @governance_bp.route("/quota/check", methods=["POST"])
+@auth_required
 def api_check_quota():
     """Check if user has quota available."""
-    token = request.cookies.get("session_token") or request.headers.get(
-        "Authorization", ""
-    ).replace("Bearer ", "")
-
-    is_auth, session_or_error = require_auth(token)
-    if not is_auth:
-        return jsonify(session_or_error), 401
-
-    user_id = session_or_error.get("user_id")
+    user_id = g.user_id
     data = request.get_json() or {}
 
     tokens = data.get("tokens", 0)
@@ -248,17 +198,9 @@ def api_check_quota():
 
 
 @governance_bp.route("/quota/alerts", methods=["GET"])
+@admin_required
 def api_get_quota_alerts():
     """Get quota alerts."""
-    token = request.cookies.get("session_token") or request.headers.get(
-        "Authorization", ""
-    ).replace("Bearer ", "")
-
-    is_admin, session_or_error = require_admin(token)
-    if not is_admin:
-        return jsonify(session_or_error), (
-            403 if "Admin" in session_or_error.get("error", "") else 401
-        )
 
     unacknowledged_only = request.args.get("unacknowledged_only", default=False, type=bool)
     limit = request.args.get("limit", default=100, type=int)
@@ -269,19 +211,11 @@ def api_get_quota_alerts():
 
 
 @governance_bp.route("/quota/alerts/<int:alert_id>/acknowledge", methods=["POST"])
+@admin_required
 def api_acknowledge_alert(alert_id):
     """Acknowledge a quota alert."""
-    token = request.cookies.get("session_token") or request.headers.get(
-        "Authorization", ""
-    ).replace("Bearer ", "")
 
-    is_admin, session_or_error = require_admin(token)
-    if not is_admin:
-        return jsonify(session_or_error), (
-            403 if "Admin" in session_or_error.get("error", "") else 401
-        )
-
-    user_id = session_or_error.get("user_id")
+    user_id = g.user_id
 
     success = quota_manager.acknowledge_alert(alert_id, user_id)
 
@@ -291,7 +225,7 @@ def api_acknowledge_alert(alert_id):
         audit_logger.log_action(
             action=AuditAction.QUOTA_ALERT,
             user_id=user_id,
-            username=session_or_error.get("username"),
+            username=g.user.get("username"),
             resource_type="quota_alert",
             resource_id=str(alert_id),
             details={"action": "acknowledged"},
@@ -309,16 +243,9 @@ def api_acknowledge_alert(alert_id):
 
 
 @governance_bp.route("/content/check", methods=["POST"])
+@auth_required
 def api_check_content():
     """Check content for sensitive information."""
-    token = request.cookies.get("session_token") or request.headers.get(
-        "Authorization", ""
-    ).replace("Bearer ", "")
-
-    is_auth, session_or_error = require_auth(token)
-    if not is_auth:
-        return jsonify(session_or_error), 401
-
     data = request.get_json() or {}
     content = data.get("content", "")
 
@@ -329,8 +256,8 @@ def api_check_content():
         client_info = get_client_info()
         audit_logger.log_action(
             action=AuditAction.CONTENT_BLOCKED,
-            user_id=session_or_error.get("user_id"),
-            username=session_or_error.get("username"),
+            user_id=g.user_id,
+            username=g.user.get("username"),
             resource_type="content",
             details={
                 "risk_level": result.risk_level,
@@ -343,17 +270,9 @@ def api_check_content():
 
 
 @governance_bp.route("/content/filter/stats", methods=["GET"])
+@admin_required
 def api_filter_stats():
     """Get content filter statistics."""
-    token = request.cookies.get("session_token") or request.headers.get(
-        "Authorization", ""
-    ).replace("Bearer ", "")
-
-    is_admin, session_or_error = require_admin(token)
-    if not is_admin:
-        return jsonify(session_or_error), (
-            403 if "Admin" in session_or_error.get("error", "") else 401
-        )
 
     stats = content_filter.get_stats()
 
@@ -361,17 +280,9 @@ def api_filter_stats():
 
 
 @governance_bp.route("/content/filter/patterns", methods=["POST"])
+@admin_required
 def api_add_pattern():
     """Add a custom content filter pattern."""
-    token = request.cookies.get("session_token") or request.headers.get(
-        "Authorization", ""
-    ).replace("Bearer ", "")
-
-    is_admin, session_or_error = require_admin(token)
-    if not is_admin:
-        return jsonify(session_or_error), (
-            403 if "Admin" in session_or_error.get("error", "") else 401
-        )
 
     data = request.get_json() or {}
     name = data.get("name")
@@ -388,8 +299,8 @@ def api_add_pattern():
         client_info = get_client_info()
         audit_logger.log_action(
             action=AuditAction.SYSTEM_CONFIG_CHANGE,
-            user_id=session_or_error.get("user_id"),
-            username=session_or_error.get("username"),
+            user_id=g.user_id,
+            username=g.user.get("username"),
             resource_type="content_filter",
             details={"action": "add_pattern", "name": name, "risk": risk},
             **client_info,
@@ -403,17 +314,9 @@ def api_add_pattern():
 
 
 @governance_bp.route("/content/filter/keywords", methods=["POST"])
+@admin_required
 def api_add_keyword():
     """Add a custom sensitive keyword."""
-    token = request.cookies.get("session_token") or request.headers.get(
-        "Authorization", ""
-    ).replace("Bearer ", "")
-
-    is_admin, session_or_error = require_admin(token)
-    if not is_admin:
-        return jsonify(session_or_error), (
-            403 if "Admin" in session_or_error.get("error", "") else 401
-        )
 
     data = request.get_json() or {}
     keyword = data.get("keyword")
@@ -427,8 +330,8 @@ def api_add_keyword():
     client_info = get_client_info()
     audit_logger.log_action(
         action=AuditAction.SYSTEM_CONFIG_CHANGE,
-        user_id=session_or_error.get("user_id"),
-        username=session_or_error.get("username"),
+        user_id=g.user_id,
+        username=g.user.get("username"),
         resource_type="content_filter",
         details={"action": "add_keyword", "keyword": keyword},
         **client_info,
@@ -447,17 +350,9 @@ governance_repo = GovernanceRepository()
 
 
 @governance_bp.route("/filter-rules", methods=["GET"])
+@admin_required
 def api_get_filter_rules():
     """Get all content filter rules."""
-    token = request.cookies.get("session_token") or request.headers.get(
-        "Authorization", ""
-    ).replace("Bearer ", "")
-
-    is_admin, session_or_error = require_admin(token)
-    if not is_admin:
-        return jsonify(session_or_error), (
-            403 if "Admin" in session_or_error.get("error", "") else 401
-        )
 
     rules = governance_repo.get_filter_rules()
 
@@ -465,17 +360,9 @@ def api_get_filter_rules():
 
 
 @governance_bp.route("/filter-rules", methods=["POST"])
+@admin_required
 def api_create_filter_rule():
     """Create a new content filter rule."""
-    token = request.cookies.get("session_token") or request.headers.get(
-        "Authorization", ""
-    ).replace("Bearer ", "")
-
-    is_admin, session_or_error = require_admin(token)
-    if not is_admin:
-        return jsonify(session_or_error), (
-            403 if "Admin" in session_or_error.get("error", "") else 401
-        )
 
     data = request.get_json() or {}
     pattern = data.get("pattern")
@@ -502,8 +389,8 @@ def api_create_filter_rule():
         client_info = get_client_info()
         audit_logger.log_action(
             action=AuditAction.SYSTEM_CONFIG_CHANGE,
-            user_id=session_or_error.get("user_id"),
-            username=session_or_error.get("username"),
+            user_id=g.user_id,
+            username=g.user.get("username"),
             resource_type="filter_rule",
             resource_id=str(rule_id),
             details={"action": "create", "pattern": pattern, "type": rule_type},
@@ -516,17 +403,9 @@ def api_create_filter_rule():
 
 
 @governance_bp.route("/filter-rules/<int:rule_id>", methods=["PUT"])
+@admin_required
 def api_update_filter_rule(rule_id):
     """Update a content filter rule."""
-    token = request.cookies.get("session_token") or request.headers.get(
-        "Authorization", ""
-    ).replace("Bearer ", "")
-
-    is_admin, session_or_error = require_admin(token)
-    if not is_admin:
-        return jsonify(session_or_error), (
-            403 if "Admin" in session_or_error.get("error", "") else 401
-        )
 
     data = request.get_json() or {}
 
@@ -545,8 +424,8 @@ def api_update_filter_rule(rule_id):
         client_info = get_client_info()
         audit_logger.log_action(
             action=AuditAction.SYSTEM_CONFIG_CHANGE,
-            user_id=session_or_error.get("user_id"),
-            username=session_or_error.get("username"),
+            user_id=g.user_id,
+            username=g.user.get("username"),
             resource_type="filter_rule",
             resource_id=str(rule_id),
             details={"action": "update", "changes": data},
@@ -559,17 +438,9 @@ def api_update_filter_rule(rule_id):
 
 
 @governance_bp.route("/filter-rules/<int:rule_id>", methods=["DELETE"])
+@admin_required
 def api_delete_filter_rule(rule_id):
     """Delete a content filter rule."""
-    token = request.cookies.get("session_token") or request.headers.get(
-        "Authorization", ""
-    ).replace("Bearer ", "")
-
-    is_admin, session_or_error = require_admin(token)
-    if not is_admin:
-        return jsonify(session_or_error), (
-            403 if "Admin" in session_or_error.get("error", "") else 401
-        )
 
     success = governance_repo.delete_filter_rule(rule_id)
 
@@ -578,8 +449,8 @@ def api_delete_filter_rule(rule_id):
         client_info = get_client_info()
         audit_logger.log_action(
             action=AuditAction.SYSTEM_CONFIG_CHANGE,
-            user_id=session_or_error.get("user_id"),
-            username=session_or_error.get("username"),
+            user_id=g.user_id,
+            username=g.user.get("username"),
             resource_type="filter_rule",
             resource_id=str(rule_id),
             details={"action": "delete"},
@@ -597,17 +468,9 @@ def api_delete_filter_rule(rule_id):
 
 
 @governance_bp.route("/security-settings", methods=["GET"])
+@admin_required
 def api_get_security_settings():
     """Get security settings."""
-    token = request.cookies.get("session_token") or request.headers.get(
-        "Authorization", ""
-    ).replace("Bearer ", "")
-
-    is_admin, session_or_error = require_admin(token)
-    if not is_admin:
-        return jsonify(session_or_error), (
-            403 if "Admin" in session_or_error.get("error", "") else 401
-        )
 
     settings = governance_repo.get_security_settings()
 
@@ -615,17 +478,9 @@ def api_get_security_settings():
 
 
 @governance_bp.route("/security-settings", methods=["PUT"])
+@admin_required
 def api_update_security_settings():
     """Update security settings."""
-    token = request.cookies.get("session_token") or request.headers.get(
-        "Authorization", ""
-    ).replace("Bearer ", "")
-
-    is_admin, session_or_error = require_admin(token)
-    if not is_admin:
-        return jsonify(session_or_error), (
-            403 if "Admin" in session_or_error.get("error", "") else 401
-        )
 
     data = request.get_json() or {}
 
@@ -636,8 +491,8 @@ def api_update_security_settings():
         client_info = get_client_info()
         audit_logger.log_action(
             action=AuditAction.SYSTEM_CONFIG_CHANGE,
-            user_id=session_or_error.get("user_id"),
-            username=session_or_error.get("username"),
+            user_id=g.user_id,
+            username=g.user.get("username"),
             resource_type="security_settings",
             details={"action": "update", "keys": list(data.keys())},
             **client_info,

--- a/app/routes/insights.py
+++ b/app/routes/insights.py
@@ -10,17 +10,16 @@ from datetime import datetime, timedelta
 
 from flask import Blueprint, g, jsonify, request
 
+from app.auth.decorators import auth_required
 from app.repositories.insights_repo import InsightsReportRepository
 from app.repositories.message_repo import MessageRepository
 from app.repositories.user_repo import UserRepository
-from app.services.auth_service import AuthService
 from app.services.insights_service import InsightsService
 
 logger = logging.getLogger(__name__)
 
 insights_bp = Blueprint("insights", __name__)
 
-auth_service = AuthService()
 user_repo = UserRepository()
 message_repo = MessageRepository()
 insights_repo = InsightsReportRepository()
@@ -31,42 +30,8 @@ insights_service = InsightsService(
 )
 
 
-@insights_bp.before_request
-def load_user():
-    """Load the current user from session token before each request.
-
-    All insights endpoints require authentication. Returns 401 if no valid
-    session token is provided.
-    """
-    token = request.cookies.get("session_token") or request.headers.get(
-        "Authorization", ""
-    ).replace("Bearer ", "")
-
-    if token:
-        session = auth_service.validate_session(token)
-        if session[0]:
-            session_data = session[1]
-            g.user = {
-                "id": session_data.get("user_id"),
-                "username": session_data.get("username"),
-                "email": session_data.get("email"),
-                "role": session_data.get("role"),
-            }
-            return None  # Authenticated
-        else:
-            return jsonify({"error": "Authentication required"}), 401
-    else:
-        return jsonify({"error": "Authentication required"}), 401
-
-
-def require_auth():
-    """Require authentication and return user info."""
-    if not hasattr(g, "user") or not g.user:
-        return False, {"error": "Authentication required"}
-    return True, g.user
-
-
 @insights_bp.route("/insights/generate", methods=["POST"])
+@auth_required
 def generate_report():
     """
     Generate or retrieve a cached insights report.
@@ -80,11 +45,8 @@ def generate_report():
     Defaults to last 7 days if no dates provided.
     If a report already exists for the date range, returns cached version.
     """
-    is_auth, user_or_error = require_auth()
-    if not is_auth:
-        return jsonify(user_or_error), 401
 
-    user_id = user_or_error["id"]
+    user_id = g.user_id
 
     try:
         # Parse date range from request body
@@ -126,13 +88,11 @@ def generate_report():
 
 
 @insights_bp.route("/insights/history", methods=["GET"])
+@auth_required
 def get_history():
     """Get user's insights report history."""
-    is_auth, user_or_error = require_auth()
-    if not is_auth:
-        return jsonify(user_or_error), 401
 
-    user_id = user_or_error["id"]
+    user_id = g.user_id
 
     try:
         reports = insights_repo.get_user_reports(user_id, limit=10)
@@ -143,13 +103,11 @@ def get_history():
 
 
 @insights_bp.route("/insights/<int:report_id>", methods=["DELETE"])
+@auth_required
 def delete_report(report_id: int):
     """Delete an insights report."""
-    is_auth, user_or_error = require_auth()
-    if not is_auth:
-        return jsonify(user_or_error), 401
 
-    user_id = user_or_error["id"]
+    user_id = g.user_id
 
     try:
         # Verify ownership before deleting

--- a/app/routes/projects.py
+++ b/app/routes/projects.py
@@ -14,12 +14,10 @@ from flask import Blueprint, jsonify, request
 
 from app.repositories.project_repo import ProjectRepository
 from app.repositories.user_repo import UserRepository
-from app.services.auth_service import AuthService
 
 logger = logging.getLogger(__name__)
 
 projects_bp = Blueprint("projects", __name__)
-auth_service = AuthService()
 project_repo = ProjectRepository()
 user_repo = UserRepository()
 
@@ -38,12 +36,12 @@ def get_current_user():
     if not token:
         return None, {"error": "Unauthorized"}, 401
 
-    valid, session_or_error = auth_service.validate_session(token)
-    if not valid:
-        return None, session_or_error, 401
+    from app.auth.decorators import _load_user_from_token
 
-    user_id = session_or_error.get("user_id")
-    user = user_repo.get_user_by_id(user_id)
+    user_data = _load_user_from_token(token)
+    if not user_data:
+        return None, {"error": "Unauthorized"}, 401
+    user = user_repo.get_user_by_id(user_data.get("id"))
     return user, None, 200
 
 

--- a/app/routes/quota.py
+++ b/app/routes/quota.py
@@ -13,10 +13,10 @@ from typing import Optional
 
 from flask import Blueprint, g, jsonify, request
 
+from app.auth.decorators import auth_required, public_endpoint
 from app.modules.governance.quota_manager import QuotaManager
 from app.repositories.usage_repo import UsageRepository
 from app.repositories.user_repo import UserRepository
-from app.services.auth_service import AuthService
 
 logger = logging.getLogger(__name__)
 
@@ -25,7 +25,6 @@ logger = logging.getLogger(__name__)
 TOKEN_QUOTA_MULTIPLIER = 1_000_000
 
 quota_bp = Blueprint("quota", __name__)
-auth_service = AuthService()
 user_repo = UserRepository()
 usage_repo = UsageRepository()
 quota_manager = QuotaManager()
@@ -69,42 +68,8 @@ def _clear_user_usage_cache(user_id: Optional[int] = None):
         _usage_cache = {k: v for k, v in _usage_cache.items() if not k.startswith(f"{user_id}:")}
 
 
-@quota_bp.before_request
-def load_user():
-    """Load the current user from session token before each request.
-
-    All quota endpoints require authentication. Returns 401 if no valid
-    session token is provided.
-    """
-    token = request.cookies.get("session_token") or request.headers.get(
-        "Authorization", ""
-    ).replace("Bearer ", "")
-
-    if token:
-        session = auth_service.validate_session(token)
-        if session[0]:
-            session_data = session[1]
-            g.user = {
-                "id": session_data.get("user_id"),
-                "username": session_data.get("username"),
-                "email": session_data.get("email"),
-                "role": session_data.get("role"),
-            }
-            return None  # Authenticated
-        else:
-            return jsonify({"error": "Authentication required"}), 401
-    else:
-        return jsonify({"error": "Authentication required"}), 401
-
-
-def require_auth():
-    """Require authentication and return user info."""
-    if not hasattr(g, "user") or not g.user:
-        return False, {"error": "Authentication required"}
-    return True, g.user
-
-
 @quota_bp.route("/quota/check", methods=["GET"])
+@auth_required
 def check_quota():
     """
     Check if the current user has quota available.
@@ -116,11 +81,8 @@ def check_quota():
 
     This is the main API for Work mode to determine if workspace should be disabled.
     """
-    is_auth, user_or_error = require_auth()
-    if not is_auth:
-        return jsonify(user_or_error), 401
 
-    user_id = user_or_error["id"]
+    user_id = g.user_id
 
     try:
         user = user_repo.get_user_by_id(user_id)
@@ -171,7 +133,7 @@ def check_quota():
 
         response = {
             "user_id": user_id,
-            "username": user_or_error.get("username"),
+            "username": g.user.get("username"),
             "daily": {
                 "tokens": {
                     "used": today_tokens,
@@ -237,6 +199,7 @@ def check_quota():
 
 
 @quota_bp.route("/quota/status", methods=["GET"])
+@auth_required
 def get_quota_status():
     """
     Get detailed quota status for the current user.
@@ -244,11 +207,8 @@ def get_quota_status():
     This is a simpler version that just returns the essential info
     for the user to see their usage in Work mode.
     """
-    is_auth, user_or_error = require_auth()
-    if not is_auth:
-        return jsonify(user_or_error), 401
 
-    user_id = user_or_error["id"]
+    user_id = g.user_id
 
     try:
         # Get user info
@@ -360,6 +320,7 @@ def get_quota_status():
 
 
 @quota_bp.route("/quota/usage/me", methods=["GET"])
+@auth_required
 def get_my_usage():
     """
     Get detailed usage data for the current user.
@@ -372,11 +333,8 @@ def get_my_usage():
     - Implements 10-minute caching to reduce database load
     - Defaults to 7 days instead of 30 for faster initial load
     """
-    is_auth, user_or_error = require_auth()
-    if not is_auth:
-        return jsonify(user_or_error), 401
 
-    user_id = user_or_error["id"]
+    user_id = g.user_id
 
     try:
         # Get user info for limits
@@ -439,13 +397,13 @@ def get_my_usage():
 
 
 @quota_bp.route("/quota/webui-check", methods=["GET"])
+@public_endpoint
 def webui_quota_check():
     """
     Check quota using webui token (called by webui backend middleware).
 
     This endpoint is similar to check_quota() but authenticates via webui token
-    instead of session token. The load_user before_request will set g.user=None
-    for webui tokens, but that's fine since we handle auth internally here.
+    instead of session token. This endpoint handles its own auth internally.
     """
     auth_header = request.headers.get("Authorization", "")
     webui_token = auth_header.replace("Bearer ", "") if auth_header.startswith("Bearer ") else ""

--- a/app/routes/remote.py
+++ b/app/routes/remote.py
@@ -18,15 +18,14 @@ import uuid
 
 from flask import Blueprint, Response, g, jsonify, request, stream_with_context
 
+from app.auth.decorators import _extract_token, _load_user_from_token
 from app.modules.workspace.api_key_proxy import get_api_key_proxy_service
 from app.modules.workspace.remote_agent_manager import get_remote_agent_manager
 from app.modules.workspace.remote_session_manager import get_remote_session_manager
-from app.services.auth_service import AuthService
 
 logger = logging.getLogger(__name__)
 
 remote_bp = Blueprint("remote", __name__)
-auth_service = AuthService()
 
 
 @remote_bp.before_request
@@ -49,39 +48,19 @@ def load_user():
     if request.path.startswith("/api/remote/llm-proxy"):
         return
 
-    token = request.cookies.get("session_token") or request.headers.get(
-        "Authorization", ""
-    ).replace("Bearer ", "")
+    token = _extract_token()
 
     if token:
-        session = auth_service.validate_session(token)
-        if session[0]:
-            session_data = session[1]
-            g.user = {
-                "id": session_data.get("user_id"),
-                "username": session_data.get("username"),
-                "email": session_data.get("email"),
-                "role": session_data.get("role"),
-            }
+        user = _load_user_from_token(token)
+        if user:
+            g.user = user
+            g.user_id = user.get("id")
+            g.user_role = user.get("role")
             return None  # Authenticated
         else:
-            return jsonify({"error": "Authentication required"}), 401
-    else:
-        url_token = request.args.get("token")
-        if url_token:
-            # First try as a session_token (for SSE / EventSource which can't send cookies)
-            session = auth_service.validate_session(url_token)
-            if session[0]:
-                session_data = session[1]
-                g.user = {
-                    "id": session_data.get("user_id"),
-                    "username": session_data.get("username"),
-                    "email": session_data.get("email"),
-                    "role": session_data.get("role"),
-                }
-                return None  # Authenticated
-            else:
-                # Fall back to WebUI token validation
+            # Try as query-param token with WebUI fallback
+            url_token = request.args.get("token")
+            if url_token and url_token == token:
                 try:
                     from app.services.webui_manager import WebUIManager
 
@@ -91,37 +70,23 @@ def load_user():
                         from app.repositories.user_repo import UserRepository
 
                         user_repo = UserRepository()
-                        user = user_repo.get_user_by_id(user_id)
-                        if user:
+                        user_data = user_repo.get_user_by_id(user_id)
+                        if user_data:
                             g.user = {
                                 "id": user_id,
-                                "username": user.get("username"),
-                                "email": user.get("email"),
-                                "role": user.get("role"),
+                                "username": user_data.get("username"),
+                                "email": user_data.get("email"),
+                                "role": user_data.get("role"),
                             }
+                            g.user_id = user_id
+                            g.user_role = user_data.get("role")
                             return None  # Authenticated
                 except Exception as e:
                     logger.warning(f"Failed to validate URL token: {e}")
+            return jsonify({"error": "Authentication required"}), 401
 
-    # No valid authentication provided
+    # No token provided
     return jsonify({"error": "Authentication required"}), 401
-
-
-def _require_auth():
-    """Require authentication for the current request."""
-    if not hasattr(g, "user") or not g.user:
-        return jsonify({"error": "Authentication required"}), 401
-    return None
-
-
-def _require_admin():
-    """Require admin role for the current request."""
-    auth_error = _require_auth()
-    if auth_error:
-        return auth_error
-    if g.user.get("role") != "admin":
-        return jsonify({"error": "Admin access required"}), 403
-    return None
 
 
 def _require_machine_admin(machine_id):
@@ -167,9 +132,6 @@ def register_machine():
     Generate a registration token for a new machine.
     Admin only - the token is used by the agent to authenticate registration.
     """
-    auth_error = _require_admin()
-    if auth_error:
-        return auth_error
 
     data = request.get_json() or {}
     agent_mgr = get_remote_agent_manager()
@@ -194,9 +156,6 @@ def register_machine():
 @remote_bp.route("/machines", methods=["GET"])
 def list_machines():
     """List machines. Admin sees all, regular users see assigned machines."""
-    auth_error = _require_auth()
-    if auth_error:
-        return auth_error
 
     agent_mgr = get_remote_agent_manager()
 
@@ -216,9 +175,6 @@ def list_machines():
 @remote_bp.route("/machines/<machine_id>", methods=["GET"])
 def get_machine(machine_id):
     """Get details and status of a specific machine."""
-    auth_error = _require_auth()
-    if auth_error:
-        return auth_error
 
     agent_mgr = get_remote_agent_manager()
     machine = agent_mgr.get_machine(machine_id)
@@ -242,9 +198,6 @@ def get_machine(machine_id):
 @remote_bp.route("/machines/<machine_id>", methods=["DELETE"])
 def deregister_machine(machine_id):
     """Deregister a remote machine. Admin only."""
-    auth_error = _require_admin()
-    if auth_error:
-        return auth_error
 
     agent_mgr = get_remote_agent_manager()
     success = agent_mgr.deregister_machine(machine_id)
@@ -257,9 +210,6 @@ def deregister_machine(machine_id):
 @remote_bp.route("/machines/<machine_id>/assign", methods=["POST"])
 def assign_user(machine_id):
     """Assign a user to a machine. System admin or machine admin."""
-    auth_error = _require_auth()
-    if auth_error:
-        return auth_error
     admin_error = _require_machine_admin(machine_id)
     if admin_error:
         return admin_error
@@ -291,9 +241,6 @@ def assign_user(machine_id):
 @remote_bp.route("/machines/<machine_id>/assign/<int:user_id>", methods=["DELETE"])
 def revoke_user(machine_id, user_id):
     """Revoke a user's access to a machine. System admin or machine admin."""
-    auth_error = _require_auth()
-    if auth_error:
-        return auth_error
     admin_error = _require_machine_admin(machine_id)
     if admin_error:
         return admin_error
@@ -319,9 +266,6 @@ def revoke_user(machine_id, user_id):
 @remote_bp.route("/api-keys", methods=["GET"])
 def list_api_keys():
     """List all encrypted API keys (without revealing actual keys). Admin only."""
-    auth_error = _require_admin()
-    if auth_error:
-        return auth_error
 
     data = request.args
     tenant_id = int(data.get("tenant_id", 1))
@@ -340,9 +284,6 @@ def list_api_keys():
 @remote_bp.route("/api-keys", methods=["POST"])
 def store_api_key():
     """Store a new encrypted API key. Admin only."""
-    auth_error = _require_admin()
-    if auth_error:
-        return auth_error
 
     data = request.get_json() or {}
     provider = data.get("provider")
@@ -372,9 +313,6 @@ def store_api_key():
 @remote_bp.route("/api-keys/<int:key_id>", methods=["DELETE"])
 def delete_api_key(key_id):
     """Delete an API key by ID. Admin only."""
-    auth_error = _require_admin()
-    if auth_error:
-        return auth_error
 
     data = request.get_json() or {}
     tenant_id = int(data.get("tenant_id", 1))
@@ -393,9 +331,6 @@ def delete_api_key(key_id):
 @remote_bp.route("/machines/<machine_id>/users", methods=["GET"])
 def get_machine_users(machine_id):
     """Get list of users assigned to a machine. System admin or machine admin."""
-    auth_error = _require_auth()
-    if auth_error:
-        return auth_error
     admin_error = _require_machine_admin(machine_id)
     if admin_error:
         return admin_error
@@ -417,9 +352,6 @@ def get_machine_users(machine_id):
 @remote_bp.route("/machines/available", methods=["GET"])
 def get_available_machines():
     """Get machines available to the current user."""
-    auth_error = _require_auth()
-    if auth_error:
-        return auth_error
 
     agent_mgr = get_remote_agent_manager()
     machines = agent_mgr.get_available_machines(g.user["id"])
@@ -438,9 +370,6 @@ def get_available_machines():
 @remote_bp.route("/sessions", methods=["POST"])
 def create_remote_session():
     """Create a new remote session on a selected machine."""
-    auth_error = _require_auth()
-    if auth_error:
-        return auth_error
 
     data = request.get_json() or {}
     machine_id = data.get("machine_id")
@@ -479,9 +408,6 @@ def create_remote_session():
 @remote_bp.route("/sessions/<session_id>", methods=["GET"])
 def get_remote_session(session_id):
     """Get remote session status and output."""
-    auth_error = _require_auth()
-    if auth_error:
-        return auth_error
 
     result, access_error = _check_session_access(session_id)
     if access_error:
@@ -495,9 +421,6 @@ def get_remote_session(session_id):
 @remote_bp.route("/sessions/<session_id>/chat", methods=["POST"])
 def send_remote_message(session_id):
     """Send a message to a remote session."""
-    auth_error = _require_auth()
-    if auth_error:
-        return auth_error
 
     _, access_error = _check_session_access(session_id)
     if access_error:
@@ -533,9 +456,6 @@ def send_remote_message(session_id):
 @remote_bp.route("/sessions/<session_id>/model", methods=["PUT"])
 def update_remote_session_model(session_id):
     """Switch the model of an active remote session."""
-    auth_error = _require_auth()
-    if auth_error:
-        return auth_error
 
     _, access_error = _check_session_access(session_id)
     if access_error:
@@ -557,9 +477,6 @@ def update_remote_session_model(session_id):
 @remote_bp.route("/sessions/<session_id>/abort", methods=["POST"])
 def abort_remote_request(session_id):
     """Abort the current in-progress request without stopping the session."""
-    auth_error = _require_auth()
-    if auth_error:
-        return auth_error
 
     _, access_error = _check_session_access(session_id)
     if access_error:
@@ -576,9 +493,6 @@ def abort_remote_request(session_id):
 @remote_bp.route("/sessions/<session_id>/stop", methods=["POST"])
 def stop_remote_session(session_id):
     """Stop a remote session."""
-    auth_error = _require_auth()
-    if auth_error:
-        return auth_error
 
     _, access_error = _check_session_access(session_id)
     if access_error:
@@ -595,9 +509,6 @@ def stop_remote_session(session_id):
 @remote_bp.route("/sessions/<session_id>/pause", methods=["POST"])
 def pause_remote_session(session_id):
     """Pause a remote session."""
-    auth_error = _require_auth()
-    if auth_error:
-        return auth_error
 
     _, access_error = _check_session_access(session_id)
     if access_error:
@@ -614,9 +525,6 @@ def pause_remote_session(session_id):
 @remote_bp.route("/sessions/<session_id>/resume", methods=["POST"])
 def resume_remote_session(session_id):
     """Resume a paused remote session."""
-    auth_error = _require_auth()
-    if auth_error:
-        return auth_error
 
     _, access_error = _check_session_access(session_id)
     if access_error:
@@ -644,9 +552,6 @@ def send_permission_response(session_id):
             "message": "optional deny reason"
         }
     """
-    auth_error = _require_auth()
-    if auth_error:
-        return auth_error
 
     session_info, access_error = _check_session_access(session_id)
     if access_error:
@@ -680,9 +585,6 @@ def send_permission_response(session_id):
 @remote_bp.route("/sessions/<session_id>/stream")
 def stream_session_output(session_id):
     """SSE: real-time stream of remote session output, formatted as claude_json."""
-    auth_error = _require_auth()
-    if auth_error:
-        return auth_error
 
     _, access_error = _check_session_access(session_id)
     if access_error:
@@ -1273,9 +1175,6 @@ def usage_report():
 @remote_bp.route("/machines/<machine_id>/browse", methods=["GET"])
 def browse_remote_directory(machine_id):
     """Browse the file system on a remote machine."""
-    auth_error = _require_auth()
-    if auth_error:
-        return auth_error
 
     agent_mgr = get_remote_agent_manager()
 

--- a/app/routes/remote.py
+++ b/app/routes/remote.py
@@ -18,7 +18,7 @@ import uuid
 
 from flask import Blueprint, Response, g, jsonify, request, stream_with_context
 
-from app.auth.decorators import _extract_token, _load_user_from_token
+from app.auth.decorators import _extract_token, _load_user_from_token, admin_required
 from app.modules.workspace.api_key_proxy import get_api_key_proxy_service
 from app.modules.workspace.remote_agent_manager import get_remote_agent_manager
 from app.modules.workspace.remote_session_manager import get_remote_session_manager
@@ -57,35 +57,40 @@ def load_user():
             g.user_id = user.get("id")
             g.user_role = user.get("role")
             return None  # Authenticated
-        else:
-            # Try as query-param token with WebUI fallback
-            url_token = request.args.get("token")
-            if url_token and url_token == token:
-                try:
-                    from app.services.webui_manager import WebUIManager
 
-                    webui_manager = WebUIManager()
-                    is_valid, user_id, error = webui_manager.validate_token(url_token)
-                    if is_valid and user_id:
-                        from app.repositories.user_repo import UserRepository
+    # Fallback: try query param token (for SSE/EventSource which can't send cookies)
+    url_token = request.args.get("token")
+    if url_token and url_token != token:
+        user = _load_user_from_token(url_token)
+        if user:
+            g.user = user
+            g.user_id = user.get("id")
+            g.user_role = user.get("role")
+            return None
+        # Try WebUI token validation
+        try:
+            from app.services.webui_manager import WebUIManager
 
-                        user_repo = UserRepository()
-                        user_data = user_repo.get_user_by_id(user_id)
-                        if user_data:
-                            g.user = {
-                                "id": user_id,
-                                "username": user_data.get("username"),
-                                "email": user_data.get("email"),
-                                "role": user_data.get("role"),
-                            }
-                            g.user_id = user_id
-                            g.user_role = user_data.get("role")
-                            return None  # Authenticated
-                except Exception as e:
-                    logger.warning(f"Failed to validate URL token: {e}")
-            return jsonify({"error": "Authentication required"}), 401
+            webui_manager = WebUIManager()
+            is_valid, user_id, error = webui_manager.validate_token(url_token)
+            if is_valid and user_id:
+                from app.repositories.user_repo import UserRepository
 
-    # No token provided
+                user_repo = UserRepository()
+                user_data = user_repo.get_user_by_id(user_id)
+                if user_data:
+                    g.user = {
+                        "id": user_id,
+                        "username": user_data.get("username"),
+                        "email": user_data.get("email"),
+                        "role": user_data.get("role"),
+                    }
+                    g.user_id = user_id
+                    g.user_role = user_data.get("role")
+                    return None
+        except Exception as e:
+            logger.warning(f"Failed to validate URL token: {e}")
+
     return jsonify({"error": "Authentication required"}), 401
 
 
@@ -127,6 +132,7 @@ def _check_session_access(session_id):
 
 
 @remote_bp.route("/machines/register", methods=["POST"])
+@admin_required
 def register_machine():
     """
     Generate a registration token for a new machine.
@@ -196,6 +202,7 @@ def get_machine(machine_id):
 
 
 @remote_bp.route("/machines/<machine_id>", methods=["DELETE"])
+@admin_required
 def deregister_machine(machine_id):
     """Deregister a remote machine. Admin only."""
 
@@ -264,6 +271,7 @@ def revoke_user(machine_id, user_id):
 
 
 @remote_bp.route("/api-keys", methods=["GET"])
+@admin_required
 def list_api_keys():
     """List all encrypted API keys (without revealing actual keys). Admin only."""
 
@@ -282,6 +290,7 @@ def list_api_keys():
 
 
 @remote_bp.route("/api-keys", methods=["POST"])
+@admin_required
 def store_api_key():
     """Store a new encrypted API key. Admin only."""
 
@@ -311,6 +320,7 @@ def store_api_key():
 
 
 @remote_bp.route("/api-keys/<int:key_id>", methods=["DELETE"])
+@admin_required
 def delete_api_key(key_id):
     """Delete an API key by ID. Admin only."""
 

--- a/app/routes/report.py
+++ b/app/routes/report.py
@@ -7,17 +7,16 @@ API routes for reporting operations.
 
 import logging
 
-from flask import Blueprint, jsonify, request
+from flask import Blueprint, g, jsonify, request
 
+from app.auth.decorators import auth_required
 from app.repositories.usage_repo import UsageRepository
 from app.repositories.user_repo import UserRepository
-from app.services.auth_service import AuthService
 from app.services.message_service import MessageService
 from app.services.usage_service import UsageService
 from app.utils.helpers import get_days_ago, get_today
 
 report_bp = Blueprint("report", __name__)
-auth_service = AuthService()
 usage_service = UsageService()
 message_service = MessageService()
 usage_repo = UsageRepository()
@@ -26,23 +25,16 @@ logger = logging.getLogger(__name__)
 
 
 @report_bp.route("/report/my-usage", methods=["GET"])
+@auth_required
 def api_my_usage():
     """Get current user's usage report."""
-    token = request.cookies.get("session_token") or request.headers.get(
-        "Authorization", ""
-    ).replace("Bearer ", "")
-
-    is_auth, session_or_error = auth_service.require_auth(token)
-    if not is_auth:
-        return jsonify(session_or_error), 401
-
     # Get date range
     start_date = request.args.get("start", get_days_ago(30))
     end_date = request.args.get("end", get_today())
 
     # Get user info
-    user_id = session_or_error.get("user_id")
-    username = session_or_error.get("username")
+    user_id = g.user_id
+    username = g.user.get("username")
 
     # Get user's system_account for daily_messages matching
     user = user_repo.get_user_by_id(user_id)

--- a/app/routes/sso.py
+++ b/app/routes/sso.py
@@ -9,12 +9,12 @@ import logging
 from datetime import datetime
 from typing import Optional
 
-from flask import Blueprint, jsonify, redirect, request, url_for
+from flask import Blueprint, g, jsonify, redirect, request, url_for
 
+from app.auth.decorators import admin_required, auth_required
 from app.modules.sso.manager import SSOManager
 from app.modules.sso.provider import list_providers
 from app.repositories.user_repo import UserRepository
-from app.services.auth_service import AuthService
 
 logger = logging.getLogger(__name__)
 
@@ -33,7 +33,6 @@ def get_sso_manager():
 
 
 user_repo = UserRepository()
-auth_service = AuthService()
 
 
 @sso_bp.route("/providers", methods=["GET"])
@@ -55,16 +54,10 @@ def list_sso_providers():
 
 
 @sso_bp.route("/providers", methods=["POST"])
+@admin_required
 def register_provider():
     """Register a new SSO provider (admin only)."""
     # Check admin auth
-    token = request.cookies.get("session_token") or request.headers.get(
-        "Authorization", ""
-    ).replace("Bearer ", "")
-    is_admin, result = auth_service.require_admin(token)
-
-    if not is_admin:
-        return jsonify({"error": result.get("error", "Admin access required")}), 403
 
     data = request.get_json()
 
@@ -116,15 +109,9 @@ def register_provider():
 
 
 @sso_bp.route("/providers/<provider_name>", methods=["DELETE"])
+@admin_required
 def disable_provider(provider_name: str):
     """Disable an SSO provider (admin only)."""
-    token = request.cookies.get("session_token") or request.headers.get(
-        "Authorization", ""
-    ).replace("Bearer ", "")
-    is_admin, result = auth_service.require_admin(token)
-
-    if not is_admin:
-        return jsonify({"error": result.get("error", "Admin access required")}), 403
 
     success = get_sso_manager().disable_provider(provider_name)
 
@@ -253,7 +240,7 @@ def callback(provider_name: str):
         )
 
         # Also create local session
-        auth_service.user_repo.create_session(
+        UserRepository().create_session(
             user_id=user_id,
             token=session_token,
             expires_at=datetime.utcnow(),
@@ -301,19 +288,13 @@ def logout():
 
 
 @sso_bp.route("/identities/<int:user_id>", methods=["GET"])
+@auth_required
 def get_user_identities(user_id: int):
     """Get SSO identities for a user."""
-    token = request.cookies.get("session_token") or request.headers.get(
-        "Authorization", ""
-    ).replace("Bearer ", "")
-    is_auth, result = auth_service.require_auth(token)
-
-    if not is_auth:
-        return jsonify({"error": result.get("error", "Authentication required")}), 401
 
     # Only allow users to see their own identities (or admins)
-    session_user_id = result.get("user_id")
-    is_admin = result.get("role") == "admin"
+    session_user_id = g.user_id
+    is_admin = g.user_role == "admin"
 
     if session_user_id != user_id and not is_admin:
         return jsonify({"error": "Access denied"}), 403
@@ -337,19 +318,13 @@ def get_user_identities(user_id: int):
 
 
 @sso_bp.route("/identities/<int:user_id>/<provider_name>", methods=["DELETE"])
+@auth_required
 def unlink_identity(user_id: int, provider_name: str):
     """Unlink an SSO identity from a user."""
-    token = request.cookies.get("session_token") or request.headers.get(
-        "Authorization", ""
-    ).replace("Bearer ", "")
-    is_auth, result = auth_service.require_auth(token)
-
-    if not is_auth:
-        return jsonify({"error": result.get("error", "Authentication required")}), 401
 
     # Only allow users to unlink their own identities (or admins)
-    session_user_id = result.get("user_id")
-    is_admin = result.get("role") == "admin"
+    session_user_id = g.user_id
+    is_admin = g.user_role == "admin"
 
     if session_user_id != user_id and not is_admin:
         return jsonify({"error": "Access denied"}), 403

--- a/app/routes/tenant.py
+++ b/app/routes/tenant.py
@@ -9,7 +9,7 @@ import logging
 
 from flask import Blueprint, jsonify, request
 
-from app.services.auth_service import AuthService
+from app.auth.decorators import admin_required
 from app.services.tenant_service import TenantService
 
 logger = logging.getLogger(__name__)
@@ -19,28 +19,12 @@ tenant_bp = Blueprint("tenant", __name__, url_prefix="/api/tenants")
 
 # Services
 tenant_service = TenantService()
-auth_service = AuthService()
-
-
-def _require_admin():
-    """Require admin authentication."""
-    token = request.cookies.get("session_token") or request.headers.get(
-        "Authorization", ""
-    ).replace("Bearer ", "")
-    is_admin, result = auth_service.require_admin(token)
-
-    if not is_admin:
-        return False, jsonify({"error": result.get("error", "Admin access required")}), 403
-
-    return True, result, None
 
 
 @tenant_bp.route("", methods=["GET"])
+@admin_required
 def list_tenants():
     """List all tenants (admin only)."""
-    is_admin, result, error_response = _require_admin()
-    if not is_admin:
-        return error_response
 
     # Get query parameters
     status = request.args.get("status")
@@ -61,11 +45,9 @@ def list_tenants():
 
 
 @tenant_bp.route("/<int:tenant_id>", methods=["GET"])
+@admin_required
 def get_tenant(tenant_id: int):
     """Get tenant by ID (admin only)."""
-    is_admin, result, error_response = _require_admin()
-    if not is_admin:
-        return error_response
 
     tenant = tenant_service.get_tenant(tenant_id)
 
@@ -76,11 +58,9 @@ def get_tenant(tenant_id: int):
 
 
 @tenant_bp.route("/slug/<slug>", methods=["GET"])
+@admin_required
 def get_tenant_by_slug(slug: str):
     """Get tenant by slug (admin only)."""
-    is_admin, result, error_response = _require_admin()
-    if not is_admin:
-        return error_response
 
     tenant = tenant_service.get_tenant_by_slug(slug)
 
@@ -91,11 +71,9 @@ def get_tenant_by_slug(slug: str):
 
 
 @tenant_bp.route("", methods=["POST"])
+@admin_required
 def create_tenant():
     """Create a new tenant (admin only)."""
-    is_admin, result, error_response = _require_admin()
-    if not is_admin:
-        return error_response
 
     data = request.get_json()
 
@@ -122,11 +100,9 @@ def create_tenant():
 
 
 @tenant_bp.route("/<int:tenant_id>", methods=["PUT"])
+@admin_required
 def update_tenant(tenant_id: int):
     """Update tenant (admin only)."""
-    is_admin, result, error_response = _require_admin()
-    if not is_admin:
-        return error_response
 
     data = request.get_json()
 
@@ -161,11 +137,9 @@ def update_tenant(tenant_id: int):
 
 
 @tenant_bp.route("/<int:tenant_id>/quota", methods=["PUT"])
+@admin_required
 def update_tenant_quota(tenant_id: int):
     """Update tenant quota (admin only)."""
-    is_admin, result, error_response = _require_admin()
-    if not is_admin:
-        return error_response
 
     data = request.get_json()
 
@@ -182,11 +156,9 @@ def update_tenant_quota(tenant_id: int):
 
 
 @tenant_bp.route("/<int:tenant_id>/settings", methods=["PUT"])
+@admin_required
 def update_tenant_settings(tenant_id: int):
     """Update tenant settings (admin only)."""
-    is_admin, result, error_response = _require_admin()
-    if not is_admin:
-        return error_response
 
     data = request.get_json()
 
@@ -203,11 +175,9 @@ def update_tenant_settings(tenant_id: int):
 
 
 @tenant_bp.route("/<int:tenant_id>/suspend", methods=["POST"])
+@admin_required
 def suspend_tenant(tenant_id: int):
     """Suspend a tenant (admin only)."""
-    is_admin, result, error_response = _require_admin()
-    if not is_admin:
-        return error_response
 
     data = request.get_json() or {}
     reason = data.get("reason")
@@ -222,11 +192,9 @@ def suspend_tenant(tenant_id: int):
 
 
 @tenant_bp.route("/<int:tenant_id>/activate", methods=["POST"])
+@admin_required
 def activate_tenant(tenant_id: int):
     """Activate a suspended tenant (admin only)."""
-    is_admin, result, error_response = _require_admin()
-    if not is_admin:
-        return error_response
 
     success = tenant_service.activate_tenant(tenant_id)
 
@@ -238,11 +206,9 @@ def activate_tenant(tenant_id: int):
 
 
 @tenant_bp.route("/<int:tenant_id>", methods=["DELETE"])
+@admin_required
 def delete_tenant(tenant_id: int):
     """Delete a tenant (admin only)."""
-    is_admin, result, error_response = _require_admin()
-    if not is_admin:
-        return error_response
 
     hard = request.args.get("hard", "false").lower() == "true"
 
@@ -255,11 +221,9 @@ def delete_tenant(tenant_id: int):
 
 
 @tenant_bp.route("/<int:tenant_id>/usage", methods=["GET"])
+@admin_required
 def get_tenant_usage(tenant_id: int):
     """Get tenant usage history (admin only)."""
-    is_admin, result, error_response = _require_admin()
-    if not is_admin:
-        return error_response
 
     days = request.args.get("days", 30, type=int)
 
@@ -275,11 +239,9 @@ def get_tenant_usage(tenant_id: int):
 
 
 @tenant_bp.route("/<int:tenant_id>/stats", methods=["GET"])
+@admin_required
 def get_tenant_stats(tenant_id: int):
     """Get tenant statistics (admin only)."""
-    is_admin, result, error_response = _require_admin()
-    if not is_admin:
-        return error_response
 
     stats = tenant_service.get_tenant_stats(tenant_id)
 
@@ -290,11 +252,9 @@ def get_tenant_stats(tenant_id: int):
 
 
 @tenant_bp.route("/<int:tenant_id>/check-quota", methods=["POST"])
+@admin_required
 def check_tenant_quota(tenant_id: int):
     """Check if tenant has quota available."""
-    is_admin, result, error_response = _require_admin()
-    if not is_admin:
-        return error_response
 
     data = request.get_json() or {}
 
@@ -308,6 +268,7 @@ def check_tenant_quota(tenant_id: int):
 
 
 @tenant_bp.route("/plans", methods=["GET"])
+@admin_required
 def get_plan_quotas():
     """Get quota configurations for all plans."""
     quotas = tenant_service.get_plan_quotas()

--- a/app/routes/workspace.py
+++ b/app/routes/workspace.py
@@ -14,12 +14,12 @@ import logging
 
 from flask import Blueprint, g, jsonify, request
 
+from app.auth.decorators import _extract_token, _load_user_from_token
 from app.modules.workspace.collaboration import SharePermission, get_collaboration_manager
 from app.modules.workspace.prompt_library import PromptCategory, PromptTemplate, get_prompt_library
 from app.modules.workspace.session_manager import SessionType, _param, get_session_manager
 from app.modules.workspace.state_sync import get_state_sync_manager
 from app.modules.workspace.tool_connector import get_tool_connector
-from app.services.auth_service import AuthService
 
 logger = logging.getLogger(__name__)
 
@@ -50,60 +50,48 @@ def format_datetime(dt):
 
 
 workspace_bp = Blueprint("workspace", __name__)
-auth_service = AuthService()
 
 
 @workspace_bp.before_request
 def load_user():
-    """Load the current user from session token before each request.
-
-    All workspace endpoints require authentication. Returns 401 if no valid
-    session token is provided.
-    """
-    token = request.cookies.get("session_token") or request.headers.get(
-        "Authorization", ""
-    ).replace("Bearer ", "")
+    """Load the current user from session token before each request."""
+    token = _extract_token()
 
     if token:
-        session = auth_service.validate_session(token)
-        if session[0]:
-            session_data = session[1]
-            g.user = {
-                "id": session_data.get("user_id"),
-                "username": session_data.get("username"),
-                "email": session_data.get("email"),
-                "role": session_data.get("role"),
-            }
-            return None  # Authenticated — proceed to route handler
+        user = _load_user_from_token(token)
+        if user:
+            g.user = user
+            g.user_id = user.get("id")
+            g.user_role = user.get("role")
+            return None
         else:
+            # Try WebUI token fallback (query param)
+            url_token = request.args.get("token")
+            if url_token and url_token == token:
+                try:
+                    from app.services.webui_manager import WebUIManager
+
+                    webui_manager = WebUIManager()
+                    is_valid, user_id, error = webui_manager.validate_token(url_token)
+                    if is_valid and user_id:
+                        from app.repositories.user_repo import UserRepository
+
+                        user_repo = UserRepository()
+                        user_data = user_repo.get_user_by_id(user_id)
+                        if user_data:
+                            g.user = {
+                                "id": user_id,
+                                "username": user_data.get("username"),
+                                "email": user_data.get("email"),
+                                "role": user_data.get("role"),
+                            }
+                            g.user_id = user_id
+                            g.user_role = user_data.get("role")
+                            return None
+                except Exception as e:
+                    logger.warning(f"Failed to validate URL token: {e}")
             return jsonify({"error": "Authentication required"}), 401
-    else:
-        # Check for URL token parameter (used by qwen-code-webui)
-        url_token = request.args.get("token")
-        if url_token:
-            try:
-                from app.services.webui_manager import WebUIManager
 
-                webui_manager = WebUIManager()
-                is_valid, user_id, error = webui_manager.validate_token(url_token)
-                if is_valid and user_id:
-                    # Get user info from database
-                    from app.repositories.user_repo import UserRepository
-
-                    user_repo = UserRepository()
-                    user = user_repo.get_user_by_id(user_id)
-                    if user:
-                        g.user = {
-                            "id": user_id,
-                            "username": user.get("username"),
-                            "email": user.get("email"),
-                            "role": user.get("role"),
-                        }
-                        return None  # Authenticated
-            except Exception as e:
-                logger.warning(f"Failed to validate URL token: {e}")
-
-    # No valid authentication provided
     return jsonify({"error": "Authentication required"}), 401
 
 
@@ -368,24 +356,28 @@ def list_sessions():
         where_clause = " AND ".join(conditions)
 
         # Count query
-        count_query = adapt_sql(f"""
+        count_query = adapt_sql(
+            f"""
             SELECT COUNT(*) as count
             FROM agent_sessions
             WHERE {where_clause}
-        """)
+        """
+        )
         result = db.fetch_one(count_query, tuple(params))
         total = result["count"] if result else 0
         total_pages = (total + limit - 1) // limit if total > 0 else 1
 
         # Get paginated sessions
         offset = (page - 1) * limit
-        sessions_query = adapt_sql(f"""
+        sessions_query = adapt_sql(
+            f"""
             SELECT *
             FROM agent_sessions
             WHERE {where_clause}
             ORDER BY updated_at DESC
             LIMIT ? OFFSET ?
-        """)
+        """
+        )
         sessions = db.fetch_all(sessions_query, tuple(params + [limit, offset]))
 
         # Compute real-time stats from session_messages for accuracy

--- a/app/routes/workspace.py
+++ b/app/routes/workspace.py
@@ -64,33 +64,39 @@ def load_user():
             g.user_id = user.get("id")
             g.user_role = user.get("role")
             return None
-        else:
-            # Try WebUI token fallback (query param)
-            url_token = request.args.get("token")
-            if url_token and url_token == token:
-                try:
-                    from app.services.webui_manager import WebUIManager
 
-                    webui_manager = WebUIManager()
-                    is_valid, user_id, error = webui_manager.validate_token(url_token)
-                    if is_valid and user_id:
-                        from app.repositories.user_repo import UserRepository
+    # Fallback: try query param token (for SSE/EventSource which can't send cookies)
+    url_token = request.args.get("token")
+    if url_token and url_token != token:
+        user = _load_user_from_token(url_token)
+        if user:
+            g.user = user
+            g.user_id = user.get("id")
+            g.user_role = user.get("role")
+            return None
+        # Try WebUI token validation
+        try:
+            from app.services.webui_manager import WebUIManager
 
-                        user_repo = UserRepository()
-                        user_data = user_repo.get_user_by_id(user_id)
-                        if user_data:
-                            g.user = {
-                                "id": user_id,
-                                "username": user_data.get("username"),
-                                "email": user_data.get("email"),
-                                "role": user_data.get("role"),
-                            }
-                            g.user_id = user_id
-                            g.user_role = user_data.get("role")
-                            return None
-                except Exception as e:
-                    logger.warning(f"Failed to validate URL token: {e}")
-            return jsonify({"error": "Authentication required"}), 401
+            webui_manager = WebUIManager()
+            is_valid, user_id, error = webui_manager.validate_token(url_token)
+            if is_valid and user_id:
+                from app.repositories.user_repo import UserRepository
+
+                user_repo = UserRepository()
+                user_data = user_repo.get_user_by_id(user_id)
+                if user_data:
+                    g.user = {
+                        "id": user_id,
+                        "username": user_data.get("username"),
+                        "email": user_data.get("email"),
+                        "role": user_data.get("role"),
+                    }
+                    g.user_id = user_id
+                    g.user_role = user_data.get("role")
+                    return None
+        except Exception as e:
+            logger.warning(f"Failed to validate URL token: {e}")
 
     return jsonify({"error": "Authentication required"}), 401
 

--- a/scripts/lint/api_security_scanner.py
+++ b/scripts/lint/api_security_scanner.py
@@ -71,6 +71,9 @@ AUTH_DECORATORS: set[str] = {
     "require_admin",
     "require_upload_auth",
     "login_required",
+    "auth_required",
+    "admin_required",
+    "public_endpoint",
 }
 
 AUTH_INLINE_CALLS: set[str] = {
@@ -375,8 +378,10 @@ class APISecurityScanner:
                 bp_has_before = self.blueprints[bp_var][1]
 
             for route in routes:
-                # Skip public endpoints
+                # Skip public endpoints (hardcoded list or @public_endpoint decorator)
                 if route.full_path in PUBLIC_ENDPOINTS:
+                    continue
+                if "public_endpoint" in route.decorators:
                     continue
 
                 has_decorator_auth = bool(AUTH_DECORATORS.intersection(route.decorators))

--- a/tests/unit/test_auth_decorators.py
+++ b/tests/unit/test_auth_decorators.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""
+Unit tests for app.auth.decorators module.
+
+Tests the unified auth decorator framework:
+- Token extraction from cookie, header, and query param
+- @auth_required: accepts any authenticated user
+- @admin_required: rejects non-admin users
+- @public_endpoint: marks route as intentionally public
+"""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Ensure project root is on path
+project_root = "/Users/rhuang/workspace/open-ace"
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_app():
+    """Create a minimal Flask app with test routes."""
+    from flask import Flask, g, jsonify
+
+    from app.auth.decorators import admin_required, auth_required, public_endpoint
+
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.config["SECRET_KEY"] = "test-secret-key"
+
+    @app.route("/api/public")
+    @public_endpoint
+    def public_route():
+        return jsonify({"ok": True})
+
+    @app.route("/api/user")
+    @auth_required
+    def user_route():
+        return jsonify({"user_id": g.user_id, "role": g.user_role})
+
+    @app.route("/api/admin")
+    @admin_required
+    def admin_route():
+        return jsonify({"user_id": g.user_id, "role": g.user_role})
+
+    return app
+
+
+MOCK_USER = {
+    "id": 42,
+    "username": "testuser",
+    "email": "test@example.com",
+    "role": "user",
+}
+
+MOCK_ADMIN = {
+    "id": 1,
+    "username": "admin",
+    "email": "admin@example.com",
+    "role": "admin",
+}
+
+MOCK_SESSION = {
+    "user_id": 42,
+    "username": "testuser",
+    "email": "test@example.com",
+    "role": "user",
+}
+
+MOCK_ADMIN_SESSION = {
+    "user_id": 1,
+    "username": "admin",
+    "email": "admin@example.com",
+    "role": "admin",
+}
+
+
+# ---------------------------------------------------------------------------
+# Token extraction tests
+# ---------------------------------------------------------------------------
+
+
+class TestExtractToken:
+    """Test _extract_token helper."""
+
+    def test_cookie_token(self):
+        from app.auth.decorators import _extract_token
+
+        app = _make_app()
+
+        with app.test_request_context("/"):
+            # Simulate cookie
+            from flask import request
+
+            with patch.object(request, "cookies", {"session_token": "tok-cookie"}):
+                assert _extract_token() == "tok-cookie"
+
+    def test_header_bearer_token(self):
+        from app.auth.decorators import _extract_token
+
+        app = _make_app()
+
+        with app.test_request_context(
+            "/", headers={"Authorization": "Bearer tok-header"}
+        ):
+            assert _extract_token() == "tok-header"
+
+    def test_query_param_token(self):
+        from app.auth.decorators import _extract_token
+
+        app = _make_app()
+
+        with app.test_request_context("/?token=tok-query"):
+            assert _extract_token() == "tok-query"
+
+    def test_no_token(self):
+        from app.auth.decorators import _extract_token
+
+        app = _make_app()
+
+        with app.test_request_context("/"):
+            assert _extract_token() == ""
+
+
+# ---------------------------------------------------------------------------
+# Decorator tests
+# ---------------------------------------------------------------------------
+
+
+class TestAuthRequired:
+    """Test @auth_required decorator."""
+
+    def _mock_auth(self, user_session):
+        """Return a patcher that mocks _authenticate."""
+        return patch(
+            "app.auth.decorators._authenticate",
+            return_value=(True, user_session),
+        )
+
+    def test_authenticated_user_gets_access(self):
+        app = _make_app()
+
+        with self._mock_auth(MOCK_SESSION):
+            with app.test_client() as client:
+                resp = client.get("/api/user", headers={"Authorization": "Bearer t"})
+                assert resp.status_code == 200
+                data = resp.get_json()
+                assert data["user_id"] == 42
+                assert data["role"] == "user"
+
+    def test_no_token_returns_401(self):
+        app = _make_app()
+
+        with app.test_client() as client:
+            resp = client.get("/api/user")
+            assert resp.status_code == 401
+
+    def test_invalid_token_returns_401(self):
+        app = _make_app()
+
+        with patch(
+            "app.auth.decorators._authenticate",
+            return_value=(False, {"error": "Invalid"}),
+        ):
+            with app.test_client() as client:
+                resp = client.get(
+                    "/api/user", headers={"Authorization": "Bearer bad"}
+                )
+                assert resp.status_code == 401
+
+
+class TestAdminRequired:
+    """Test @admin_required decorator."""
+
+    def test_admin_gets_access(self):
+        app = _make_app()
+
+        with patch(
+            "app.auth.decorators._authenticate",
+            return_value=(True, MOCK_ADMIN_SESSION),
+        ):
+            with app.test_client() as client:
+                resp = client.get("/api/admin", headers={"Authorization": "Bearer t"})
+                assert resp.status_code == 200
+                data = resp.get_json()
+                assert data["role"] == "admin"
+
+    def test_non_admin_gets_403(self):
+        app = _make_app()
+
+        with patch(
+            "app.auth.decorators._authenticate",
+            return_value=(True, MOCK_SESSION),
+        ):
+            with app.test_client() as client:
+                resp = client.get("/api/admin", headers={"Authorization": "Bearer t"})
+                assert resp.status_code == 403
+
+    def test_no_token_returns_401(self):
+        app = _make_app()
+
+        with app.test_client() as client:
+            resp = client.get("/api/admin")
+            assert resp.status_code == 401
+
+
+class TestPublicEndpoint:
+    """Test @public_endpoint decorator."""
+
+    def test_public_no_auth_needed(self):
+        app = _make_app()
+
+        with app.test_client() as client:
+            resp = client.get("/api/public")
+            assert resp.status_code == 200
+
+    def test_public_endpoint_has_marker(self):
+        """Verify the _is_public_endpoint attribute is set."""
+        from app.auth.decorators import public_endpoint
+
+        @public_endpoint
+        def my_route():
+            pass
+
+        assert my_route._is_public_endpoint is True
+
+
+# ---------------------------------------------------------------------------
+# g.user attributes tests
+# ---------------------------------------------------------------------------
+
+
+class TestGUserAttributes:
+    """Verify that decorators set g.user, g.user_id, g.user_role correctly."""
+
+    def test_g_attributes_set(self):
+        app = _make_app()
+
+        with patch(
+            "app.auth.decorators._authenticate",
+            return_value=(True, MOCK_SESSION),
+        ):
+            with app.test_client() as client:
+                resp = client.get("/api/user", headers={"Authorization": "Bearer t"})
+                assert resp.status_code == 200
+                data = resp.get_json()
+                assert data["user_id"] == 42
+                assert data["role"] == "user"

--- a/tests/unit/test_auth_decorators.py
+++ b/tests/unit/test_auth_decorators.py
@@ -12,12 +12,13 @@ Tests the unified auth decorator framework:
 from __future__ import annotations
 
 import sys
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 # Ensure project root is on path
-project_root = "/Users/rhuang/workspace/open-ace"
+project_root = str(Path(__file__).resolve().parent.parent.parent)
 if project_root not in sys.path:
     sys.path.insert(0, project_root)
 
@@ -109,9 +110,7 @@ class TestExtractToken:
 
         app = _make_app()
 
-        with app.test_request_context(
-            "/", headers={"Authorization": "Bearer tok-header"}
-        ):
+        with app.test_request_context("/", headers={"Authorization": "Bearer tok-header"}):
             assert _extract_token() == "tok-header"
 
     def test_query_param_token(self):
@@ -172,9 +171,7 @@ class TestAuthRequired:
             return_value=(False, {"error": "Invalid"}),
         ):
             with app.test_client() as client:
-                resp = client.get(
-                    "/api/user", headers={"Authorization": "Bearer bad"}
-                )
+                resp = client.get("/api/user", headers={"Authorization": "Bearer bad"})
                 assert resp.status_code == 401
 
 


### PR DESCRIPTION
## Summary

Phase 1-2 of #261: Standardize authentication across all route files with a unified `app/auth/decorators.py` framework.

Replaces **11+ scattered** `require_auth`/`require_admin`/`_require_admin` implementations with three consistent decorators:
- `@auth_required` — any authenticated user
- `@admin_required` — admin role required
- `@public_endpoint` — explicitly marks route as public (recognized by security scanner)

## Changes

### New: `app/auth/decorators.py`
- `_extract_token()` — unified token extraction from cookie → header → query param
- `_load_user_from_token()` — validates session and returns user dict
- `auth_required(ownership=None)` — auth decorator with optional ownership checks
- `admin_required` — admin-only decorator
- `public_endpoint` — marks route as intentionally unauthenticated

### Migrated route files (16 files, -796 lines, +660 lines)

| File | Pattern Replaced | Routes |
|------|-----------------|--------|
| `admin.py` | `require_admin(token)` proxy | 7 |
| `analytics.py` | `require_admin`/`require_auth` proxies + `auth_service` | 4 |
| `governance.py` | `require_admin`/`require_auth` proxies | 19 |
| `compliance.py` | `_require_admin()` inline function | 14 |
| `tenant.py` | `_require_admin()` inline function | 14 |
| `remote.py` | `before_request` + `auth_service.validate_session()` | ~30 |
| `workspace.py` | `before_request` + `auth_service.validate_session()` | ~40 |
| `alerts.py` | `before_request` + `auth_service.validate_session()` | ~8 |
| `insights.py` | Already partially migrated — fixed orphaned code | 3 |
| `quota.py` | Already migrated — no changes needed | 4 |
| `sso.py` | Inline `require_admin`/`require_auth` + broken `result` refs | 4 |
| `report.py` | Inline `require_auth` + `session_or_error` refs | 1 |
| `fs.py` | `before_request` cleanup | — |
| `projects.py` | `before_request` cleanup | — |

### Other updates
- **API security scanner**: Added `auth_required`, `admin_required`, `public_endpoint` to recognized auth patterns
- **Tests**: 13 unit tests for decorator framework (token extraction, auth/admin/public, g attributes)

## Not migrated
- `auth.py` — uses `auth_service` for login/logout business logic (not auth checking)
- `pages.py` — uses `auth_service.get_session()`/`auth_service.logout()` for page rendering

## Testing
- `python3 -c "from app import create_app; create_app()"` — app loads successfully
- `python3 scripts/lint/api_security_scanner.py` — no new violations
- `python3 -m pytest tests/unit/test_auth_decorators.py` — 13/13 passed
- `black` + `ruff` — all clean

Closes #261
