### PR TITLE
fix: deduplicate Claude request_count by message_id

### DIFF
--- a/scripts/fetch_claude.py
+++ b/scripts/fetch_claude.py
@@ -228,6 +228,8 @@ def process_jsonl_file(
         }
     )
     messages: list[dict[str, Any]] = []
+    # Track seen message_ids per date to deduplicate request_count
+    seen_msg_ids: dict[str, set[str]] = defaultdict(set)
 
     # First pass: build message tree for conversation_id tracking
     # Key: message uuid, Value: (entry, parent_uuid)
@@ -392,7 +394,15 @@ def process_jsonl_file(
                 ):
                     # Still count requests even if tokens are 0 (e.g., cache hits)
                     if tokens["is_assistant_message"]:
-                        daily[date_key]["request_count"] += 1
+                        msg = entry.get("message", {})
+                        mid = (
+                            (msg.get("id") if isinstance(msg, dict) else None)
+                            or entry.get("id")
+                            or entry.get("uuid")
+                        )
+                        if mid and mid not in seen_msg_ids[date_key]:
+                            seen_msg_ids[date_key].add(mid)
+                            daily[date_key]["request_count"] += 1
                     continue
 
                 daily[date_key]["input_tokens"] += tokens["input_tokens"]
@@ -401,7 +411,15 @@ def process_jsonl_file(
                 daily[date_key]["cache_creation_tokens"] += tokens["cache_creation_tokens"]
 
                 if tokens["is_assistant_message"]:
-                    daily[date_key]["request_count"] += 1
+                    msg = entry.get("message", {})
+                    mid = (
+                        (msg.get("id") if isinstance(msg, dict) else None)
+                        or entry.get("id")
+                        or entry.get("uuid")
+                    )
+                    if mid and mid not in seen_msg_ids[date_key]:
+                        seen_msg_ids[date_key].add(mid)
+                        daily[date_key]["request_count"] += 1
 
                 if tokens["model"]:
                     daily[date_key]["models_used"].add(tokens["model"])


### PR DESCRIPTION
## Summary

Fixes #281 — Claude `daily_usage.request_count` was inflated by ~40-50% because `fetch_claude.py` counted every JSONL entry instead of deduplicating by `message_id`.

Claude JSONL logs have multiple `type=assistant` entries per API response (streaming chunks, etc.), each sharing the same `message.id`. The script incremented `request_count` per entry, while `daily_messages` deduplicates via UPSERT on `(date, tool_name, message_id, host_name)`.

### Fix

Track `seen_msg_ids` per date in `process_jsonl_file()`. Only increment `request_count` when a `message_id` is first encountered for that date.

### Verification

| Metric | Before | After |
|--------|--------|-------|
| 2026-05-05 `daily_usage.request_count` | 1157 | **652** |
| 2026-05-05 `daily_messages` assistant count | 652 | 652 |
| Diff | 505 (43.6%) | **0** |

## Test plan

- [x] Run `fetch_claude.py --days 1 --multi-user` — `request_count` matches `daily_messages WHERE role='assistant'`
- [ ] Run with `--days 7` to verify historical dedup works correctly
- [ ] Verify Qwen data unaffected (different JSONL format, no multi-entry issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)