### PR TITLE
fix: resolve SQL001/SQL003 lint warnings (23 sites)

### DIFF
--- a/app/modules/governance/quota_manager.py
+++ b/app/modules/governance/quota_manager.py
@@ -16,6 +16,7 @@ from app.repositories.database import (
     adapt_boolean_condition,
     adapt_boolean_value,
     adapt_sql,
+    escape_like,
 )
 from app.repositories.user_repo import UserRepository
 
@@ -545,7 +546,7 @@ class QuotaManager:
                       AND role = 'assistant'
                       AND (message_source IS NULL OR message_source != 'remote_workspace')
                 """,
-                    (f"{system_account}%", start_date, end_date),
+                    (f"{escape_like(system_account)}%", start_date, end_date),
                 )
                 local_tokens = int(local_result["tokens"]) if local_result else 0
                 local_requests = int(local_result["requests"]) if local_result else 0
@@ -662,7 +663,7 @@ class QuotaManager:
             system_account = user.get("system_account") or user.get("username", "")
             if system_account:
                 sender_conditions.append("sender_name LIKE ?")
-                sender_params.append(f"{system_account}%")
+                sender_params.append(f"{escape_like(system_account)}%")
 
         local_usage_lookup: dict[Any, dict[str, int]] = {}
         if sender_conditions:

--- a/app/modules/workspace/prompt_library.py
+++ b/app/modules/workspace/prompt_library.py
@@ -17,6 +17,7 @@ from app.repositories.database import (
     DB_PATH,
     adapt_boolean_condition,
     adapt_sql,
+    escape_like,
     get_database_url,
     is_postgresql,
 )
@@ -419,12 +420,12 @@ class PromptLibrary:
 
         if search:
             conditions.append("(name LIKE ? OR description LIKE ?)")
-            params.extend([f"%{search}%", f"%{search}%"])
+            params.extend([f"%{escape_like(search)}%", f"%{escape_like(search)}%"])
 
         if tags:
             for tag in tags:
                 conditions.append("tags LIKE ?")
-                params.append(f"%{tag}%")
+                params.append(f"%{escape_like(tag)}%")
 
         where_clause = " AND ".join(conditions) if conditions else "1=1"
 

--- a/app/modules/workspace/session_manager.py
+++ b/app/modules/workspace/session_manager.py
@@ -14,7 +14,7 @@ from datetime import datetime, timedelta
 from enum import Enum
 from typing import Any, Optional, Union
 
-from app.repositories.database import DB_PATH, get_database_url, is_postgresql
+from app.repositories.database import DB_PATH, escape_like, get_database_url, is_postgresql
 
 logger = logging.getLogger(__name__)
 
@@ -890,7 +890,7 @@ class SessionManager:
 
         if search:
             conditions.append(f"title LIKE {_param()}")
-            params.append(f"%{search}%")
+            params.append(f"%{escape_like(search)}%")
 
         where_clause = " AND ".join(conditions) if conditions else "1=1"
 

--- a/app/repositories/message_repo.py
+++ b/app/repositories/message_repo.py
@@ -7,7 +7,7 @@ Repository for message data access operations.
 import logging
 from typing import Any, Optional
 
-from app.repositories.database import Database
+from app.repositories.database import Database, escape_like
 
 logger = logging.getLogger(__name__)
 
@@ -226,7 +226,7 @@ class MessageRepository:
 
         if search:
             conditions.append("content LIKE ?")
-            params.append(f"%{search}%")
+            params.append(f"%{escape_like(search)}%")
 
         query = f"""
             SELECT * FROM daily_messages
@@ -295,7 +295,7 @@ class MessageRepository:
 
         if search:
             conditions.append("content LIKE ?")
-            params.append(f"%{search}%")
+            params.append(f"%{escape_like(search)}%")
 
         query = f"""
             SELECT * FROM daily_messages
@@ -611,7 +611,7 @@ class MessageRepository:
 
         if search:
             conditions.append("content LIKE ?")
-            params.append(f"%{search}%")
+            params.append(f"%{escape_like(search)}%")
 
         where_clause = f"WHERE {' AND '.join(conditions)}" if conditions else ""
 
@@ -1057,7 +1057,7 @@ class MessageRepository:
               AND sender_name LIKE ?
               AND role IN ('user', 'assistant')
         """
-        result = self.db.fetch_one(query, (start_date, end_date, f"{sender_prefix}%"))
+        result = self.db.fetch_one(query, (start_date, end_date, f"{escape_like(sender_prefix)}%"))
 
         if result:
             total_conversations = result["total_conversations"] or 0
@@ -1102,6 +1102,7 @@ class MessageRepository:
             List[Dict]: List of conversations, each with session_id and messages.
         """
         # Find distinct agent_session_ids that have user messages
+        safe_prefix = escape_like(sender_prefix)
         session_query = """
             SELECT DISTINCT COALESCE(agent_session_id, conversation_id) as session_id
             FROM daily_messages
@@ -1112,7 +1113,7 @@ class MessageRepository:
             LIMIT ?
         """
         sessions = self.db.fetch_all(
-            session_query, (start_date, end_date, f"{sender_prefix}%", limit)
+            session_query, (start_date, end_date, f"{safe_prefix}%", limit)
         )
 
         if not sessions:

--- a/app/repositories/project_repo.py
+++ b/app/repositories/project_repo.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from typing import Any, Optional, cast
 
 from app.models.project import Project, ProjectDailyStats, ProjectStats, UserProject
-from app.repositories.database import Database
+from app.repositories.database import Database, adapt_boolean_value
 
 logger = logging.getLogger(__name__)
 
@@ -65,8 +65,8 @@ class ProjectRepository:
                 project_id = result["id"] if result else None
             else:
                 # SQLite uses 1/0 for boolean columns
-                is_shared_int = 1 if is_shared else 0
-                is_active_int = 1
+                is_shared_int = adapt_boolean_value(is_shared)
+                is_active_int = adapt_boolean_value(True)
                 cursor = self.db.execute(
                     """
                     INSERT INTO projects (path, name, description, created_by, created_at,

--- a/app/repositories/usage_repo.py
+++ b/app/repositories/usage_repo.py
@@ -10,7 +10,7 @@ from datetime import datetime, timedelta
 from functools import lru_cache
 from typing import Optional, cast
 
-from app.repositories.database import Database
+from app.repositories.database import Database, escape_like
 
 logger = logging.getLogger(__name__)
 
@@ -672,7 +672,7 @@ class UsageRepository:
             # sender_name format is: {username}-{hostname}-{tool}
             # Use LIKE to match username prefix
             conditions.append("sender_name LIKE ?")
-            params.append(f"{user_name}%")
+            params.append(f"{escape_like(user_name)}%")
 
         query = f"""
             SELECT
@@ -764,7 +764,7 @@ class UsageRepository:
         # sender_name format is: {username}-{hostname}-{tool}
         # Use LIKE to match username prefix
         conditions = ["date >= ?", "date <= ?", "role = ?", "sender_name LIKE ?"]
-        params = [start_date, end_date, "assistant", f"{user_name}%"]
+        params = [start_date, end_date, "assistant", f"{escape_like(user_name)}%"]
 
         if host_name:
             conditions.append("host_name = ?")
@@ -892,7 +892,7 @@ class UsageRepository:
             # sender_name format is: {username}-{hostname}-{tool}
             # Use LIKE to match username prefix
             conditions.append("sender_name LIKE ?")
-            params.append(f"{user_name}%")
+            params.append(f"{escape_like(user_name)}%")
 
         query = f"""
             SELECT
@@ -954,7 +954,7 @@ class UsageRepository:
               AND role = 'assistant'
               AND (message_source IS NULL OR message_source != 'remote_workspace')
         """,
-            (f"{system_account}%", start_date, end_date),
+            (f"{escape_like(system_account)}%", start_date, end_date),
         )
 
         # Remote session usage from agent_sessions
@@ -1002,6 +1002,7 @@ class UsageRepository:
         Returns a list of daily records suitable for the user's usage report page.
         """
         # Local CLI usage from daily_messages
+        safe_account = escape_like(system_account)
         local_rows = self.db.fetch_all(
             """
             SELECT
@@ -1019,7 +1020,7 @@ class UsageRepository:
             GROUP BY date, tool_name
             ORDER BY date DESC
         """,
-            (f"{system_account}%", start_date, end_date),
+            (f"{safe_account}%", start_date, end_date),
         )
 
         # Remote session usage from agent_sessions + session_messages

--- a/app/repositories/user_repo.py
+++ b/app/repositories/user_repo.py
@@ -72,7 +72,7 @@ class UserRepository:
                 return result["id"] if result else None
             else:
                 # SQLite uses 1/0 for boolean columns
-                is_active_int = 1 if is_active else 0
+                is_active_int = adapt_boolean_value(is_active)
                 cursor = self.db.execute(
                     """
                     INSERT INTO users (username, email, password_hash, role, is_active, created_at, system_account)

--- a/app/services/data_fetch_scheduler.py
+++ b/app/services/data_fetch_scheduler.py
@@ -200,7 +200,7 @@ class DataFetchScheduler:
                     FROM user_daily_stats uds
                     JOIN users u ON uds.user_id = u.id
                     WHERE uds.date = ?
-                      AND u.is_active = 1
+                      AND {adapt_boolean_condition("u.is_active", True)}
                       AND (
                         uds.requests >= COALESCE(u.daily_request_quota, 999999)
                         OR uds.tokens >= COALESCE(u.daily_token_quota, 999999) * 1000000
@@ -222,7 +222,7 @@ class DataFetchScheduler:
                     FROM user_daily_stats uds
                     JOIN users u ON uds.user_id = u.id
                     WHERE uds.date >= ? AND uds.date <= ?
-                      AND u.is_active = 1
+                      AND {adapt_boolean_condition("u.is_active", True)}
                       AND u.monthly_token_quota IS NOT NULL
                       AND (
                         SUM(uds.requests) >= COALESCE(u.monthly_request_quota, 999999)

--- a/app/services/quota_enforcement_scheduler.py
+++ b/app/services/quota_enforcement_scheduler.py
@@ -128,7 +128,7 @@ class QuotaEnforcementScheduler:
                     FROM user_daily_stats uds
                     JOIN users u ON uds.user_id = u.id
                     WHERE uds.date = ?
-                      AND u.is_active = 1
+                      AND {adapt_boolean_condition("u.is_active", True)}
                       AND (
                         uds.requests >= COALESCE(u.daily_request_quota, 999999)
                         OR uds.tokens >= COALESCE(u.daily_token_quota, 999999) * 1000000
@@ -150,7 +150,7 @@ class QuotaEnforcementScheduler:
                     FROM user_daily_stats uds
                     JOIN users u ON uds.user_id = u.id
                     WHERE uds.date >= ? AND uds.date <= ?
-                      AND u.is_active = 1
+                      AND {adapt_boolean_condition("u.is_active", True)}
                       AND u.monthly_token_quota IS NOT NULL
                       AND (
                         SUM(uds.requests) >= COALESCE(u.monthly_request_quota, 999999)

--- a/app/services/user_stats_aggregator.py
+++ b/app/services/user_stats_aggregator.py
@@ -14,7 +14,7 @@ import logging
 from datetime import datetime, timedelta
 from typing import Optional, cast
 
-from app.repositories.database import Database, is_postgresql
+from app.repositories.database import Database, escape_like, is_postgresql
 from app.repositories.user_repo import UserRepository
 
 logger = logging.getLogger(__name__)
@@ -92,6 +92,7 @@ class UserDailyStatsAggregator:
         try:
             with self.db.connection() as conn:
                 cursor = conn.cursor()
+                safe_prefix = escape_like(sender_prefix)
 
                 if is_postgresql():
                     cursor.execute(
@@ -118,7 +119,7 @@ class UserDailyStatsAggregator:
                             output_tokens = EXCLUDED.output_tokens,
                             updated_at = CURRENT_TIMESTAMP
                     """,
-                        (user_id, start_str, end_str, f"{sender_prefix}%"),
+                        (user_id, start_str, end_str, f"{safe_prefix}%"),
                     )
                 else:
                     now = datetime.utcnow().isoformat()
@@ -140,7 +141,7 @@ class UserDailyStatsAggregator:
                           AND dm.role = 'assistant'
                         GROUP BY dm.date
                     """,
-                        (user_id, now, start_str, end_str, f"{sender_prefix}%"),
+                        (user_id, now, start_str, end_str, f"{escape_like(sender_prefix)}%"),
                     )
 
                 conn.commit()


### PR DESCRIPTION
## Summary

Fixes all 23 SQL compatibility lint warnings flagged by `sql_compat_checker.py` in CI.

### SQL001 (6 sites) — Boolean field compared with integer

- **4 sites** in `quota_enforcement_scheduler.py` and `data_fetch_scheduler.py`: `u.is_active = 1` → `adapt_boolean_condition("u.is_active", True)` wrapped in `adapt_sql()`
- **2 sites** in `project_repo.py` and `user_repo.py`: `var = 1 if cond else 0` → `adapt_boolean_value(cond)`

### SQL003 (17 sites) — LIKE without escape_like()

All LIKE pattern inputs now wrapped with `escape_like()`:
- 11 `sender_name LIKE` prefix matches across `usage_repo.py`, `message_repo.py`, `quota_manager.py`, `user_stats_aggregator.py`
- 6 search box `%search%` matches across `message_repo.py`, `prompt_library.py`, `session_manager.py`

For sites where `escape_like()` was >5 lines from the LIKE clause (outside linter's detection window), introduced local `safe_prefix`/`safe_account` variables.

## Test plan

- [x] `python3 scripts/lint/sql_compat_checker.py` — 0 new warnings
- [ ] CI lint job passes
- [ ] Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)