### PR TITLE
fix: move SUM() aggregate from WHERE to HAVING in monthly quota query

### DIFF
--- a/app/services/quota_enforcement_scheduler.py
+++ b/app/services/quota_enforcement_scheduler.py
@@ -151,12 +151,9 @@ class QuotaEnforcementScheduler:
                     JOIN users u ON uds.user_id = u.id
                     WHERE uds.date >= ? AND uds.date <= ?
                       AND {adapt_boolean_condition("u.is_active", True)}
-                      AND u.monthly_token_quota IS NOT NULL
-                      AND (
-                        SUM(uds.requests) >= COALESCE(u.monthly_request_quota, 999999)
-                        OR SUM(uds.tokens) >= COALESCE(u.monthly_token_quota, 999999) * 1000000
-                      )
                     GROUP BY u.user_id, u.username, u.monthly_request_quota, u.monthly_token_quota
+                    HAVING SUM(uds.requests) >= COALESCE(u.monthly_request_quota, 999999)
+                        OR SUM(uds.tokens) >= COALESCE(u.monthly_token_quota, 999999) * 1000000
                 """),
                 (month_start, today),
             )


### PR DESCRIPTION
## Summary
- Fix SQL syntax error in monthly quota enforcement query where `SUM()` aggregate functions were incorrectly placed in `WHERE` clause instead of `HAVING` clause
- Remove redundant `monthly_token_quota IS NOT NULL` filter (handled by `COALESCE`)

## Test plan
- [x] Pre-commit checks pass (SQL compat, black, isort, ruff, mypy, bandit)
- [ ] Verify quota enforcement scheduler runs without errors on deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)