### PR TITLE
fix: add tooltip help for content filter rules in Security Center (issue #208)

### DIFF
--- a/frontend/src/components/features/management/ContentFilter.tsx
+++ b/frontend/src/components/features/management/ContentFilter.tsx
@@ -20,6 +20,7 @@ import {
   Error,
   EmptyState,
   Badge,
+  Tooltip,
 } from '@/components/common';
 import type { ContentFilterRule, CreateFilterRuleRequest } from '@/api';
 
@@ -173,10 +174,25 @@ export const ContentFilter: React.FC = () => {
           <table className="table table-hover">
             <thead>
               <tr>
-                <th>{t('tablePattern', language)}</th>
-                <th>{t('tableType', language)}</th>
+                <th>
+                  {t('tablePattern', language)}
+                  <Tooltip content={t('patternHelp', language)} placement="top">
+                    <i className="bi bi-question-circle text-muted ms-1" style={{ cursor: 'pointer' }} />
+                  </Tooltip>
+                </th>
+                <th>
+                  {t('tableType', language)}
+                  <Tooltip content={`${t('keywordTypeHelp', language)}\n${t('regexTypeHelp', language)}\n${t('piiTypeHelp', language)}`} placement="top">
+                    <i className="bi bi-question-circle text-muted ms-1" style={{ cursor: 'pointer' }} />
+                  </Tooltip>
+                </th>
                 <th>{t('tableSeverity', language)}</th>
-                <th>{t('tableAction', language)}</th>
+                <th>
+                  {t('tableAction', language)}
+                  <Tooltip content={`${t('warnActionHelp', language)}\n${t('blockActionHelp', language)}\n${t('redactActionHelp', language)}`} placement="top">
+                    <i className="bi bi-question-circle text-muted ms-1" style={{ cursor: 'pointer' }} />
+                  </Tooltip>
+                </th>
                 <th>{t('tableStatus', language)}</th>
                 <th>{t('tableActions', language)}</th>
               </tr>
@@ -270,6 +286,7 @@ export const ContentFilter: React.FC = () => {
                 onChange={(value: string) => setFormData({ ...formData, pattern: value })}
                 placeholder={t('enterPattern', language)}
               />
+              <small className="text-muted">{t('patternHelp', language)}</small>
             </div>
             <div className="col-md-4">
               <label className="form-label">{t('tableType', language)}</label>
@@ -280,6 +297,11 @@ export const ContentFilter: React.FC = () => {
                   setFormData({ ...formData, type: value as CreateFilterRuleRequest['type'] })
                 }
               />
+              <small className="text-muted">
+                {formData.type === 'keyword' && t('keywordTypeHelp', language)}
+                {formData.type === 'regex' && t('regexTypeHelp', language)}
+                {formData.type === 'pii' && t('piiTypeHelp', language)}
+              </small>
             </div>
             <div className="col-md-4">
               <label className="form-label">{t('tableSeverity', language)}</label>
@@ -303,6 +325,11 @@ export const ContentFilter: React.FC = () => {
                   setFormData({ ...formData, action: value as CreateFilterRuleRequest['action'] })
                 }
               />
+              <small className="text-muted">
+                {formData.action === 'warn' && t('warnActionHelp', language)}
+                {formData.action === 'block' && t('blockActionHelp', language)}
+                {formData.action === 'redact' && t('redactActionHelp', language)}
+              </small>
             </div>
             <div className="col-12">
               <label className="form-label">{t('description', language)}</label>

--- a/frontend/src/components/features/management/ContentFilter.tsx
+++ b/frontend/src/components/features/management/ContentFilter.tsx
@@ -20,8 +20,8 @@ import {
   Error,
   EmptyState,
   Badge,
-  Tooltip,
 } from '@/components/common';
+import { FilterRuleTableHeader } from './FilterRuleTableHeader';
 import type { ContentFilterRule, CreateFilterRuleRequest } from '@/api';
 
 const TYPE_OPTIONS = [
@@ -172,31 +172,7 @@ export const ContentFilter: React.FC = () => {
       ) : (
         <div className="table-responsive">
           <table className="table table-hover">
-            <thead>
-              <tr>
-                <th>
-                  {t('tablePattern', language)}
-                  <Tooltip content={t('patternHelp', language)} placement="top">
-                    <i className="bi bi-question-circle text-muted ms-1" style={{ cursor: 'pointer' }} />
-                  </Tooltip>
-                </th>
-                <th>
-                  {t('tableType', language)}
-                  <Tooltip content={`${t('keywordTypeHelp', language)}\n${t('regexTypeHelp', language)}\n${t('piiTypeHelp', language)}`} placement="top">
-                    <i className="bi bi-question-circle text-muted ms-1" style={{ cursor: 'pointer' }} />
-                  </Tooltip>
-                </th>
-                <th>{t('tableSeverity', language)}</th>
-                <th>
-                  {t('tableAction', language)}
-                  <Tooltip content={`${t('warnActionHelp', language)}\n${t('blockActionHelp', language)}\n${t('redactActionHelp', language)}`} placement="top">
-                    <i className="bi bi-question-circle text-muted ms-1" style={{ cursor: 'pointer' }} />
-                  </Tooltip>
-                </th>
-                <th>{t('tableStatus', language)}</th>
-                <th>{t('tableActions', language)}</th>
-              </tr>
-            </thead>
+            <FilterRuleTableHeader />
             <tbody>
               {rules.map((rule) => (
                 <tr key={rule.id}>

--- a/frontend/src/components/features/management/FilterRuleTableHeader.tsx
+++ b/frontend/src/components/features/management/FilterRuleTableHeader.tsx
@@ -1,0 +1,70 @@
+/**
+ * FilterRuleTableHeader Component - Shared table header for content filter rules
+ */
+
+import React from 'react';
+import { useLanguage } from '@/store';
+import { t } from '@/i18n';
+import { Tooltip } from '@/components/common';
+
+export const FilterRuleTableHeader: React.FC = () => {
+  const language = useLanguage();
+
+  return (
+    <thead>
+      <tr>
+        <th>
+          {t('tablePattern', language)}
+          <Tooltip content={t('patternHelp', language)} placement="top">
+            <i
+              className="bi bi-question-circle text-muted ms-1"
+              style={{ cursor: 'pointer' }}
+              aria-label={t('patternHelp', language)}
+            />
+          </Tooltip>
+        </th>
+        <th>
+          {t('tableType', language)}
+          <Tooltip
+            content={
+              <div className="d-flex flex-column gap-1">
+                <div>{t('keywordTypeHelp', language)}</div>
+                <div>{t('regexTypeHelp', language)}</div>
+                <div>{t('piiTypeHelp', language)}</div>
+              </div>
+            }
+            placement="top"
+          >
+            <i
+              className="bi bi-question-circle text-muted ms-1"
+              style={{ cursor: 'pointer' }}
+              aria-label={`${t('keywordTypeHelp', language)}, ${t('regexTypeHelp', language)}, ${t('piiTypeHelp', language)}`}
+            />
+          </Tooltip>
+        </th>
+        <th>{t('tableSeverity', language)}</th>
+        <th>
+          {t('tableAction', language)}
+          <Tooltip
+            content={
+              <div className="d-flex flex-column gap-1">
+                <div>{t('warnActionHelp', language)}</div>
+                <div>{t('blockActionHelp', language)}</div>
+                <div>{t('redactActionHelp', language)}</div>
+              </div>
+            }
+            placement="top"
+          >
+            <i
+              className="bi bi-question-circle text-muted ms-1"
+              style={{ cursor: 'pointer' }}
+              aria-label={`${t('warnActionHelp', language)}, ${t('blockActionHelp', language)}, ${t('redactActionHelp', language)}`}
+            />
+          </Tooltip>
+        </th>
+        <th>{t('tableStatus', language)}</th>
+        <th>{t('tableActions', language)}</th>
+      </tr>
+    </thead>
+  );
+};

--- a/frontend/src/components/features/management/SecurityCenter.tsx
+++ b/frontend/src/components/features/management/SecurityCenter.tsx
@@ -29,6 +29,7 @@ import {
   Error,
   EmptyState,
   Badge,
+  Tooltip,
 } from '@/components/common';
 import { useToast } from '@/components/common';
 import type {
@@ -245,10 +246,25 @@ export const SecurityCenter: React.FC = () => {
             <table className="table table-hover">
               <thead>
                 <tr>
-                  <th>{t('tablePattern', language)}</th>
-                  <th>{t('tableType', language)}</th>
+                  <th>
+                    {t('tablePattern', language)}
+                    <Tooltip content={t('patternHelp', language)} placement="top">
+                      <i className="bi bi-question-circle text-muted ms-1" style={{ cursor: 'pointer' }} />
+                    </Tooltip>
+                  </th>
+                  <th>
+                    {t('tableType', language)}
+                    <Tooltip content={`${t('keywordTypeHelp', language)}\n${t('regexTypeHelp', language)}\n${t('piiTypeHelp', language)}`} placement="top">
+                      <i className="bi bi-question-circle text-muted ms-1" style={{ cursor: 'pointer' }} />
+                    </Tooltip>
+                  </th>
                   <th>{t('tableSeverity', language)}</th>
-                  <th>{t('tableAction', language)}</th>
+                  <th>
+                    {t('tableAction', language)}
+                    <Tooltip content={`${t('warnActionHelp', language)}\n${t('blockActionHelp', language)}\n${t('redactActionHelp', language)}`} placement="top">
+                      <i className="bi bi-question-circle text-muted ms-1" style={{ cursor: 'pointer' }} />
+                    </Tooltip>
+                  </th>
                   <th>{t('tableStatus', language)}</th>
                   <th>{t('tableActions', language)}</th>
                 </tr>
@@ -342,6 +358,7 @@ export const SecurityCenter: React.FC = () => {
                   onChange={(value: string) => setRuleFormData({ ...ruleFormData, pattern: value })}
                   placeholder={t('enterPattern', language)}
                 />
+                <small className="text-muted">{t('patternHelp', language)}</small>
               </div>
               <div className="col-md-4">
                 <label className="form-label">{t('tableType', language)}</label>
@@ -355,6 +372,11 @@ export const SecurityCenter: React.FC = () => {
                     })
                   }
                 />
+                <small className="text-muted">
+                  {ruleFormData.type === 'keyword' && t('keywordTypeHelp', language)}
+                  {ruleFormData.type === 'regex' && t('regexTypeHelp', language)}
+                  {ruleFormData.type === 'pii' && t('piiTypeHelp', language)}
+                </small>
               </div>
               <div className="col-md-4">
                 <label className="form-label">{t('tableSeverity', language)}</label>
@@ -381,6 +403,11 @@ export const SecurityCenter: React.FC = () => {
                     })
                   }
                 />
+                <small className="text-muted">
+                  {ruleFormData.action === 'warn' && t('warnActionHelp', language)}
+                  {ruleFormData.action === 'block' && t('blockActionHelp', language)}
+                  {ruleFormData.action === 'redact' && t('redactActionHelp', language)}
+                </small>
               </div>
               <div className="col-12">
                 <label className="form-label">{t('description', language)}</label>

--- a/frontend/src/components/features/management/SecurityCenter.tsx
+++ b/frontend/src/components/features/management/SecurityCenter.tsx
@@ -29,9 +29,9 @@ import {
   Error,
   EmptyState,
   Badge,
-  Tooltip,
 } from '@/components/common';
 import { useToast } from '@/components/common';
+import { FilterRuleTableHeader } from './FilterRuleTableHeader';
 import type {
   ContentFilterRule,
   CreateFilterRuleRequest,
@@ -244,31 +244,7 @@ export const SecurityCenter: React.FC = () => {
         ) : (
           <div className="table-responsive">
             <table className="table table-hover">
-              <thead>
-                <tr>
-                  <th>
-                    {t('tablePattern', language)}
-                    <Tooltip content={t('patternHelp', language)} placement="top">
-                      <i className="bi bi-question-circle text-muted ms-1" style={{ cursor: 'pointer' }} />
-                    </Tooltip>
-                  </th>
-                  <th>
-                    {t('tableType', language)}
-                    <Tooltip content={`${t('keywordTypeHelp', language)}\n${t('regexTypeHelp', language)}\n${t('piiTypeHelp', language)}`} placement="top">
-                      <i className="bi bi-question-circle text-muted ms-1" style={{ cursor: 'pointer' }} />
-                    </Tooltip>
-                  </th>
-                  <th>{t('tableSeverity', language)}</th>
-                  <th>
-                    {t('tableAction', language)}
-                    <Tooltip content={`${t('warnActionHelp', language)}\n${t('blockActionHelp', language)}\n${t('redactActionHelp', language)}`} placement="top">
-                      <i className="bi bi-question-circle text-muted ms-1" style={{ cursor: 'pointer' }} />
-                    </Tooltip>
-                  </th>
-                  <th>{t('tableStatus', language)}</th>
-                  <th>{t('tableActions', language)}</th>
-                </tr>
-              </thead>
+              <FilterRuleTableHeader />
               <tbody>
                 {rules.map((rule) => (
                   <tr key={rule.id}>

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -204,6 +204,13 @@ const translations: Record<Language, Translations> = {
     description: 'Description',
     enterDescription: 'Enter description',
     enabled: 'Enabled',
+    patternHelp: 'Enter the content to match. For keywords, use exact words; for regex, use valid patterns; for PII, select a type.',
+    keywordTypeHelp: 'Keyword: Match exact word or phrase',
+    regexTypeHelp: 'Regex: Match using regular expression patterns',
+    piiTypeHelp: 'PII: Detect personal identifiable information (email, phone, SSN, etc.)',
+    warnActionHelp: 'Warn: Log warning but allow the message',
+    blockActionHelp: 'Block: Prevent the message from being sent',
+    redactActionHelp: 'Redact: Replace sensitive content with placeholder',
 
     // Security Settings
     settingsSaved: 'Settings saved successfully',
@@ -927,6 +934,13 @@ const translations: Record<Language, Translations> = {
     description: '描述',
     enterDescription: '请输入描述',
     enabled: '启用',
+    patternHelp: '输入要匹配的内容。关键词类型使用精确词语；正则类型使用有效的正则表达式；PII类型选择个人信息类型。',
+    keywordTypeHelp: '关键词：精确匹配词语或短语',
+    regexTypeHelp: '正则表达式：使用正则表达式模式匹配',
+    piiTypeHelp: 'PII：检测个人隐私信息（邮箱、电话、身份证等）',
+    warnActionHelp: '警告：记录警告但允许消息发送',
+    blockActionHelp: '阻止：禁止消息发送',
+    redactActionHelp: '替换：将敏感内容替换为占位符',
 
     // Security Settings
     settingsSaved: '设置已保存',
@@ -1629,6 +1643,13 @@ const translations: Record<Language, Translations> = {
     description: '説明',
     enterDescription: '説明を入力',
     enabled: '有効',
+    patternHelp: 'マッチする内容を入力。キーワードは正確な単語、正規表現は有効なパターン、PIIはタイプを選択。',
+    keywordTypeHelp: 'キーワード：正確な単語またはフレーズにマッチ',
+    regexTypeHelp: '正規表現：正規表現パターンでマッチ',
+    piiTypeHelp: 'PII：個人識別情報（メール、電話、SSNなど）を検出',
+    warnActionHelp: '警告：警告をログに記録し、メッセージを許可',
+    blockActionHelp: 'ブロック：メッセージの送信を阻止',
+    redactActionHelp: '秘匿：機密内容をプレースホルダーで置換',
 
     // Security Settings
     settingsSaved: '設定を保存しました',
@@ -2051,6 +2072,13 @@ const translations: Record<Language, Translations> = {
     description: '설명',
     enterDescription: '설명 입력',
     enabled: '활성화',
+    patternHelp: '매치할 내용을 입력. 키워드는 정확한 단어, 정규식은 유효한 패턴, PII는 유형을 선택.',
+    keywordTypeHelp: '키워드: 정확한 단어 또는 문구 매치',
+    regexTypeHelp: '정규식: 정규식 패턴으로 매치',
+    piiTypeHelp: 'PII: 개인 식별 정보(이메일, 전화, SSN 등) 감지',
+    warnActionHelp: '경고: 경고를 로그하고 메시지 허용',
+    blockActionHelp: '차단: 메시지 전송 방지',
+    redactActionHelp: '수정: 민감한 내용을 플레이스홀더로 교체',
 
     // Security Settings
     settingsSaved: '설정이 저장되었습니다',

--- a/tests/ui/test_security_center_tooltip.py
+++ b/tests/ui/test_security_center_tooltip.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""
+Test Security Center Tooltip - Issue #208
+Verify that tooltip help icons are displayed in the filter rules table header
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+import time
+
+from playwright.sync_api import sync_playwright
+
+# Configuration
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+USERNAME = os.environ.get("USERNAME", "admin")
+PASSWORD = os.environ.get("PASSWORD", "admin123")
+HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
+SCREENSHOT_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "screenshots", "issues", "208"
+)
+
+os.makedirs(SCREENSHOT_DIR, exist_ok=True)
+
+
+def test_security_center_tooltip():
+    """Test Security Center Tooltip functionality"""
+    results = []
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=HEADLESS)
+        context = browser.new_context(viewport={"width": 1400, "height": 900})
+        page = context.new_page()
+
+        try:
+            # Step 1: Login
+            print("Step 1: Login...")
+            page.goto(f"{BASE_URL}/login")
+            page.fill("#username", USERNAME)
+            page.fill("#password", PASSWORD)
+            page.click('button[type="submit"]')
+            page.wait_for_url("**/", timeout=10000)
+            time.sleep(1)
+            results.append(("Login", "PASS"))
+            print("  ✓ Login successful")
+
+            # Step 2: Navigate to Management page (Security Center)
+            print("\nStep 2: Navigate to Security Center page...")
+            page.goto(f"{BASE_URL}/manage/security")
+            time.sleep(2)  # Wait for page to fully load
+            results.append(("Navigate to Security Center", "PASS"))
+            print("  ✓ Security Center page loaded")
+
+            # Step 3: Verify Security Center page loaded
+            print("\nStep 3: Verify Security Center page...")
+            # Wait for the page to render
+            page.wait_for_selector("h2", timeout=10000)
+            screenshot_path = os.path.join(SCREENSHOT_DIR, "01_security_center_page.png")
+            page.screenshot(path=screenshot_path)
+            print(f"  Screenshot saved: {screenshot_path}")
+            results.append(("Security Center page loaded", "PASS"))
+            print("  ✓ Security Center page verified")
+
+            # Step 4: Click on Content Filter tab
+            print("\nStep 4: Click on Content Filter tab...")
+            content_filter_tab = page.locator("text=Content Filter")
+            if content_filter_tab.count() > 0:
+                content_filter_tab.first.click()
+                time.sleep(1)
+                results.append(("Click Content Filter tab", "PASS"))
+                print("  ✓ Content Filter tab clicked")
+            else:
+                results.append(("Click Content Filter tab", "FAIL - Tab not found"))
+                print("  ✗ Content Filter tab not found")
+
+            # Step 5: Check for tooltip help icons in table header
+            print("\nStep 5: Check for tooltip help icons...")
+            screenshot_path = os.path.join(SCREENSHOT_DIR, "01_filter_rules_table.png")
+            page.screenshot(path=screenshot_path)
+            print(f"  Screenshot saved: {screenshot_path}")
+
+            # Check for question-circle icons in table headers
+            help_icons = page.locator("th .bi-question-circle")
+            icon_count = help_icons.count()
+            print(f"  Found {icon_count} help icons in table headers")
+
+            if icon_count >= 3:
+                results.append(("Check help icons in table header", "PASS"))
+                print("  ✓ Help icons found in table headers (Pattern, Type, Action)")
+            else:
+                results.append(
+                    ("Check help icons in table header", f"FAIL - Found {icon_count} icons")
+                )
+                print(f"  ✗ Expected at least 3 help icons, found {icon_count}")
+
+            # Step 6: Hover over Pattern help icon and check tooltip
+            print("\nStep 6: Hover over Pattern help icon...")
+            pattern_help_icon = page.locator("th .bi-question-circle").first
+            if pattern_help_icon.count() > 0:
+                pattern_help_icon.hover()
+                time.sleep(0.5)  # Wait for tooltip to appear
+
+                # Check if tooltip is visible
+                tooltip = page.locator(".tooltip.show, .tooltip-inner")
+                if tooltip.count() > 0:
+                    tooltip_text = tooltip.first.text_content()
+                    print(f"  Tooltip text: {tooltip_text}")
+                    screenshot_path = os.path.join(SCREENSHOT_DIR, "02_pattern_tooltip.png")
+                    page.screenshot(path=screenshot_path)
+                    print(f"  Screenshot saved: {screenshot_path}")
+
+                    if (
+                        "keyword" in tooltip_text.lower()
+                        or "关键词" in tooltip_text
+                        or "match" in tooltip_text.lower()
+                    ):
+                        results.append(("Pattern tooltip visible", "PASS"))
+                        print("  ✓ Pattern tooltip shows help text")
+                    else:
+                        results.append(("Pattern tooltip visible", "FAIL - Unexpected text"))
+                        print("  ✗ Tooltip text doesn't contain expected keywords")
+                else:
+                    results.append(("Pattern tooltip visible", "FAIL - Tooltip not visible"))
+                    print("  ✗ Tooltip not visible after hover")
+            else:
+                results.append(("Pattern tooltip hover", "FAIL - Icon not found"))
+                print("  ✗ Pattern help icon not found")
+
+            # Step 7: Hover over Type help icon and check tooltip
+            print("\nStep 7: Hover over Type help icon...")
+            type_help_icon = page.locator("th .bi-question-circle").nth(1)
+            if type_help_icon.count() > 0:
+                type_help_icon.hover()
+                time.sleep(0.5)
+
+                tooltip = page.locator(".tooltip.show, .tooltip-inner")
+                if tooltip.count() > 0:
+                    tooltip_text = tooltip.first.text_content()
+                    print(f"  Tooltip text: {tooltip_text}")
+                    screenshot_path = os.path.join(SCREENSHOT_DIR, "03_type_tooltip.png")
+                    page.screenshot(path=screenshot_path)
+                    print(f"  Screenshot saved: {screenshot_path}")
+
+                    if (
+                        "keyword" in tooltip_text.lower()
+                        or "regex" in tooltip_text.lower()
+                        or "pii" in tooltip_text.lower()
+                    ):
+                        results.append(("Type tooltip visible", "PASS"))
+                        print("  ✓ Type tooltip shows help text")
+                    else:
+                        results.append(("Type tooltip visible", "FAIL - Unexpected text"))
+                        print("  ✗ Tooltip text doesn't contain expected keywords")
+                else:
+                    results.append(("Type tooltip visible", "FAIL - Tooltip not visible"))
+                    print("  ✗ Tooltip not visible after hover")
+            else:
+                results.append(("Type tooltip hover", "FAIL - Icon not found"))
+                print("  ✗ Type help icon not found")
+
+            # Step 8: Hover over Action help icon and check tooltip
+            print("\nStep 8: Hover over Action help icon...")
+            action_help_icon = page.locator("th .bi-question-circle").nth(2)
+            if action_help_icon.count() > 0:
+                action_help_icon.hover()
+                time.sleep(0.5)
+
+                tooltip = page.locator(".tooltip.show, .tooltip-inner")
+                if tooltip.count() > 0:
+                    tooltip_text = tooltip.first.text_content()
+                    print(f"  Tooltip text: {tooltip_text}")
+                    screenshot_path = os.path.join(SCREENSHOT_DIR, "04_action_tooltip.png")
+                    page.screenshot(path=screenshot_path)
+                    print(f"  Screenshot saved: {screenshot_path}")
+
+                    if (
+                        "warn" in tooltip_text.lower()
+                        or "block" in tooltip_text.lower()
+                        or "redact" in tooltip_text.lower()
+                    ):
+                        results.append(("Action tooltip visible", "PASS"))
+                        print("  ✓ Action tooltip shows help text")
+                    else:
+                        results.append(("Action tooltip visible", "FAIL - Unexpected text"))
+                        print("  ✗ Tooltip text doesn't contain expected keywords")
+                else:
+                    results.append(("Action tooltip visible", "FAIL - Tooltip not visible"))
+                    print("  ✗ Tooltip not visible after hover")
+            else:
+                results.append(("Action tooltip hover", "FAIL - Icon not found"))
+                print("  ✗ Action help icon not found")
+
+            # Step 9: Click Add Rule button and check modal help text
+            print("\nStep 9: Click Add Rule button...")
+            add_rule_btn = page.locator("button:has-text('Add Rule'), button:has-text('添加规则')")
+            if add_rule_btn.count() > 0:
+                add_rule_btn.first.click()
+                time.sleep(1)
+
+                screenshot_path = os.path.join(SCREENSHOT_DIR, "05_add_rule_modal.png")
+                page.screenshot(path=screenshot_path)
+                print(f"  Screenshot saved: {screenshot_path}")
+
+                # Check for help text under Pattern input
+                pattern_help_text = page.locator("small.text-muted")
+                if pattern_help_text.count() > 0:
+                    first_help_text = pattern_help_text.first.text_content()
+                    print(f"  Pattern help text in modal: {first_help_text}")
+
+                    if (
+                        "keyword" in first_help_text.lower()
+                        or "关键词" in first_help_text
+                        or "match" in first_help_text.lower()
+                    ):
+                        results.append(("Modal Pattern help text visible", "PASS"))
+                        print("  ✓ Modal Pattern help text visible")
+                    else:
+                        results.append(
+                            ("Modal Pattern help text visible", "FAIL - Unexpected text")
+                        )
+                        print("  ✗ Help text doesn't contain expected keywords")
+                else:
+                    results.append(
+                        ("Modal Pattern help text visible", "FAIL - Help text not found")
+                    )
+                    print("  ✗ Pattern help text not found in modal")
+
+                # Close modal
+                close_btn = page.locator("button:has-text('Cancel'), button:has-text('取消')")
+                if close_btn.count() > 0:
+                    close_btn.first.click()
+                    time.sleep(0.5)
+            else:
+                results.append(("Click Add Rule button", "FAIL - Button not found"))
+                print("  ✗ Add Rule button not found")
+
+            # Final screenshot
+            screenshot_path = os.path.join(SCREENSHOT_DIR, "06_final_state.png")
+            page.screenshot(path=screenshot_path)
+            print(f"\nFinal screenshot saved: {screenshot_path}")
+
+        except Exception as e:
+            print(f"\nError: {e}")
+            results.append(("Test execution", f"FAIL - {str(e)}"))
+            screenshot_path = os.path.join(SCREENSHOT_DIR, "error_state.png")
+            page.screenshot(path=screenshot_path)
+
+        finally:
+            browser.close()
+
+    # Print results summary
+    print("\n" + "=" * 50)
+    print("UI Test Report - Issue #208: Security Center Tooltip")
+    print("=" * 50)
+
+    passed = sum(1 for _, status in results if "PASS" in status)
+    failed = sum(1 for _, status in results if "FAIL" in status)
+
+    print(f"\nTotal tests: {len(results)}")
+    print(f"Passed: {passed}")
+    print(f"Failed: {failed}")
+
+    print("\nDetails:")
+    for name, status in results:
+        symbol = "✓" if "PASS" in status else "✗"
+        print(f"  {symbol} {name}: {status}")
+
+    print("\n" + "=" * 50)
+    print(f"Screenshots saved in: {SCREENSHOT_DIR}")
+    print("=" * 50)
+
+    return failed == 0
+
+
+if __name__ == "__main__":
+    success = test_security_center_tooltip()
+    sys.exit(0 if success else 1)

--- a/tests/ui/test_security_center_tooltip.py
+++ b/tests/ui/test_security_center_tooltip.py
@@ -2,6 +2,17 @@
 """
 Test Security Center Tooltip - Issue #208
 Verify that tooltip help icons are displayed in the filter rules table header
+
+Dependencies:
+    pip install playwright
+    playwright install chromium
+
+Configuration:
+    Environment variables (optional):
+        BASE_URL: Target URL (default: http://localhost:5001)
+        USERNAME: Login username (default: admin)
+        PASSWORD: Login password (default: admin123)
+        HEADLESS: Run in headless mode (default: true)
 """
 
 import os
@@ -9,11 +20,9 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 
-import time
-
 from playwright.sync_api import sync_playwright
 
-# Configuration
+# Configuration - use environment variables or defaults
 BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
 USERNAME = os.environ.get("USERNAME", "admin")
 PASSWORD = os.environ.get("PASSWORD", "admin123")
@@ -42,21 +51,19 @@ def test_security_center_tooltip():
             page.fill("#password", PASSWORD)
             page.click('button[type="submit"]')
             page.wait_for_url("**/", timeout=10000)
-            time.sleep(1)
+            page.wait_for_timeout(500)  # Wait for page to stabilize
             results.append(("Login", "PASS"))
             print("  ✓ Login successful")
 
             # Step 2: Navigate to Management page (Security Center)
             print("\nStep 2: Navigate to Security Center page...")
             page.goto(f"{BASE_URL}/manage/security")
-            time.sleep(2)  # Wait for page to fully load
+            page.wait_for_selector("h2", timeout=10000)
             results.append(("Navigate to Security Center", "PASS"))
             print("  ✓ Security Center page loaded")
 
             # Step 3: Verify Security Center page loaded
             print("\nStep 3: Verify Security Center page...")
-            # Wait for the page to render
-            page.wait_for_selector("h2", timeout=10000)
             screenshot_path = os.path.join(SCREENSHOT_DIR, "01_security_center_page.png")
             page.screenshot(path=screenshot_path)
             print(f"  Screenshot saved: {screenshot_path}")
@@ -68,7 +75,7 @@ def test_security_center_tooltip():
             content_filter_tab = page.locator("text=Content Filter")
             if content_filter_tab.count() > 0:
                 content_filter_tab.first.click()
-                time.sleep(1)
+                page.wait_for_timeout(500)
                 results.append(("Click Content Filter tab", "PASS"))
                 print("  ✓ Content Filter tab clicked")
             else:
@@ -100,7 +107,7 @@ def test_security_center_tooltip():
             pattern_help_icon = page.locator("th .bi-question-circle").first
             if pattern_help_icon.count() > 0:
                 pattern_help_icon.hover()
-                time.sleep(0.5)  # Wait for tooltip to appear
+                page.wait_for_timeout(200)  # Wait for tooltip animation
 
                 # Check if tooltip is visible
                 tooltip = page.locator(".tooltip.show, .tooltip-inner")
@@ -133,7 +140,7 @@ def test_security_center_tooltip():
             type_help_icon = page.locator("th .bi-question-circle").nth(1)
             if type_help_icon.count() > 0:
                 type_help_icon.hover()
-                time.sleep(0.5)
+                page.wait_for_timeout(200)
 
                 tooltip = page.locator(".tooltip.show, .tooltip-inner")
                 if tooltip.count() > 0:
@@ -165,7 +172,7 @@ def test_security_center_tooltip():
             action_help_icon = page.locator("th .bi-question-circle").nth(2)
             if action_help_icon.count() > 0:
                 action_help_icon.hover()
-                time.sleep(0.5)
+                page.wait_for_timeout(200)
 
                 tooltip = page.locator(".tooltip.show, .tooltip-inner")
                 if tooltip.count() > 0:
@@ -197,7 +204,7 @@ def test_security_center_tooltip():
             add_rule_btn = page.locator("button:has-text('Add Rule'), button:has-text('添加规则')")
             if add_rule_btn.count() > 0:
                 add_rule_btn.first.click()
-                time.sleep(1)
+                page.wait_for_selector(".modal-content", timeout=5000)
 
                 screenshot_path = os.path.join(SCREENSHOT_DIR, "05_add_rule_modal.png")
                 page.screenshot(path=screenshot_path)
@@ -231,7 +238,7 @@ def test_security_center_tooltip():
                 close_btn = page.locator("button:has-text('Cancel'), button:has-text('取消')")
                 if close_btn.count() > 0:
                     close_btn.first.click()
-                    time.sleep(0.5)
+                    page.wait_for_timeout(300)
             else:
                 results.append(("Click Add Rule button", "FAIL - Button not found"))
                 print("  ✗ Add Rule button not found")


### PR DESCRIPTION
## Problem
Users didn't understand the content filter rule fields, especially the Pattern (matching pattern), Type, and Action fields. The table header lacked tooltip hints.

## Solution
- Add tooltip help icons (bi-question-circle) in table header for Pattern, Type, and Action columns
- Add dynamic help text under form fields in create/edit modal
- Add i18n support for 4 languages (en/zh/ja/ko)

## Changes
1. **SecurityCenter.tsx** - Add Tooltip components in table header, add help text in modal form
2. **ContentFilter.tsx** - Same changes for consistency
3. **i18n/index.ts** - Add 7 new i18n keys for help text in all 4 languages
4. **test_security_center_tooltip.py** - Add UI test script

## Screenshots
Test screenshots saved in: tests/screenshots/issues/208/

## Test Results
- Login: PASS
- Navigate to Security Center: PASS
- Content Filter tab: PASS
- Help icons in table header (3): PASS
- Pattern tooltip visible: PASS
- Type tooltip visible: PASS
- Action tooltip visible: PASS

Closes #208