### PR TITLE
fix: unify qwen tool name variants (qwen/qwen-code/qwen-code-cli → qwen)

### DIFF
--- a/app/modules/workspace/remote_session_manager.py
+++ b/app/modules/workspace/remote_session_manager.py
@@ -20,6 +20,7 @@ from app.modules.workspace.remote_agent_manager import get_remote_agent_manager
 from app.modules.workspace.session_manager import SessionManager
 from app.repositories.message_repo import MessageRepository
 from app.repositories.user_repo import UserRepository
+from app.utils.tool_names import normalize_tool_name
 
 logger = logging.getLogger(__name__)
 
@@ -101,7 +102,7 @@ class RemoteSessionManager:
 
         # Create session in SessionManager
         session = self._session_manager.create_session(
-            tool_name=cli_tool,
+            tool_name=normalize_tool_name(cli_tool),
             user_id=user_id,
             title=title or f"Remote: {machine.get('machine_name', machine_id[:8])}",
             host_name=machine.get("hostname", machine_id),
@@ -682,7 +683,7 @@ class RemoteSessionManager:
             now = datetime.utcnow()
             self._message_repo.save_message(
                 date=now.strftime("%Y-%m-%d"),
-                tool_name=session.tool_name or "unknown",
+                tool_name=normalize_tool_name(session.tool_name or "unknown"),
                 message_id=str(uuid.uuid4()),
                 role=role,
                 host_name=session.host_name or "remote",

--- a/app/repositories/usage_repo.py
+++ b/app/repositories/usage_repo.py
@@ -11,6 +11,7 @@ from functools import lru_cache
 from typing import Optional, cast
 
 from app.repositories.database import Database, escape_like, is_postgresql
+from app.utils.tool_names import normalize_tool_name
 
 logger = logging.getLogger(__name__)
 
@@ -447,14 +448,20 @@ class UsageRepository:
 
         rows = self.db.fetch_all(query, tuple(params))
 
-        # Ensure all values are integers
-        results = []
+        # Ensure all values are integers, normalize tool names
+        merged: dict[tuple, dict] = {}
         for row in rows:
-            results.append(
-                {"date": row["date"], "tool": row["tool_name"], "tokens": int(row["tokens"] or 0)}
-            )
+            key = (row["date"], normalize_tool_name(row["tool_name"]))
+            if key in merged:
+                merged[key]["tokens"] += int(row["tokens"] or 0)
+            else:
+                merged[key] = {
+                    "date": row["date"],
+                    "tool": normalize_tool_name(row["tool_name"]),
+                    "tokens": int(row["tokens"] or 0),
+                }
 
-        return results
+        return list(merged.values())
 
     def get_request_count_total(
         self, start_date: str, end_date: str, host_name: Optional[str] = None
@@ -574,7 +581,7 @@ class UsageRepository:
 
         rows = self.db.fetch_all(query, tuple(params))
 
-        results = []
+        results: dict[tuple, dict] = {}
         for row in rows:
             # Convert date to YYYY-MM-DD format if it's a datetime object
             date_val = row["date"]
@@ -583,15 +590,18 @@ class UsageRepository:
             else:
                 # Parse HTTP date format if needed
                 date_str = str(date_val).split()[0] if " " in str(date_val) else str(date_val)
-            results.append(
-                {
+            tool = normalize_tool_name(row["tool_name"])
+            key = (date_str, tool)
+            if key in results:
+                results[key]["requests"] += int(row["requests"] or 0)
+            else:
+                results[key] = {
                     "date": date_str,
-                    "tool": row["tool_name"],
+                    "tool": tool,
                     "requests": int(row["requests"] or 0),
                 }
-            )
 
-        return results
+        return list(results.values())
 
     def get_today_request_stats(self, host_name: Optional[str] = None) -> dict:
         """

--- a/app/routes/workspace.py
+++ b/app/routes/workspace.py
@@ -19,6 +19,7 @@ from app.modules.workspace.prompt_library import PromptCategory, PromptTemplate,
 from app.modules.workspace.session_manager import SessionType, _param, get_session_manager
 from app.modules.workspace.state_sync import get_state_sync_manager
 from app.modules.workspace.tool_connector import get_tool_connector
+from app.utils.tool_names import TOOL_NAME_ALIASES, normalize_tool_name
 
 logger = logging.getLogger(__name__)
 
@@ -344,11 +345,6 @@ def list_sessions():
             params.append(user_id)
 
         if tool_name:
-            TOOL_NAME_ALIASES = {
-                "qwen": ["qwen", "qwen-code", "qwen-code-cli"],
-                "claude": ["claude", "claude-code"],
-                "openclaw": ["openclaw"],
-            }
             aliases = TOOL_NAME_ALIASES.get(tool_name, [tool_name])
             placeholders = ",".join(["?" for _ in aliases])
             conditions.append(f"tool_name IN ({placeholders})")
@@ -548,6 +544,7 @@ def create_session():
         tool_name = data.get("tool_name")
         if not tool_name:
             return jsonify({"success": False, "error": "tool_name is required"}), 400
+        tool_name = normalize_tool_name(tool_name)
 
         user_id = g.user.get("id") if hasattr(g, "user") and g.user else None
 
@@ -934,7 +931,7 @@ def restore_session(session_id):
         remote_machine_id = session_data.get("remote_machine_id")
 
         # Generate encodedProjectName based on tool
-        if tool_name in ["qwen", "claude", "qwen-code"]:
+        if normalize_tool_name(tool_name) in ["qwen", "claude"]:
             # project_path may be actual path or encoded name
             # Need to convert actual path to encoded name if necessary
             # Format: /home/rhuang/open-ace -> -home-rhuang-open-ace

--- a/app/utils/tool_names.py
+++ b/app/utils/tool_names.py
@@ -1,0 +1,15 @@
+TOOL_NAME_ALIASES = {
+    "qwen": ["qwen", "qwen-code", "qwen-code-cli"],
+    "claude": ["claude", "claude-code"],
+    "openclaw": ["openclaw"],
+}
+
+CANONICAL_TOOL_NAMES = {
+    "qwen-code": "qwen",
+    "qwen-code-cli": "qwen",
+    "claude-code": "claude",
+}
+
+
+def normalize_tool_name(name: str) -> str:
+    return CANONICAL_TOOL_NAMES.get(name, name)

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -27,10 +27,7 @@ export {
 
 const TOOL_DISPLAY_NAMES: Record<string, string> = {
   qwen: 'Qwen',
-  'qwen-code': 'Qwen',
-  'qwen-code-cli': 'Qwen',
   claude: 'Claude',
-  'claude-code': 'Claude',
   openclaw: 'OpenClaw',
   openai: 'OpenAI',
   run_shell_command: 'Shell',

--- a/migrations/versions/20260506_038_normalize_tool_names.py
+++ b/migrations/versions/20260506_038_normalize_tool_names.py
@@ -1,0 +1,36 @@
+"""Normalize tool names: unify qwen-code and qwen-code-cli to qwen
+
+Revision ID: 038_normalize_tool_names
+Revises: 037_deduplicate_remote_machines
+Create Date: 2026-05-06
+
+GitHub Issue #233: Dashboard and Request Dashboard trend charts showed
+inconsistent data because different code paths stored different tool_name
+variants (qwen, qwen-code, qwen-code-cli) for the same tool. This migration
+normalizes all historical records to the canonical name 'qwen'.
+"""
+
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "038_normalize_tool_names"
+down_revision: Union[str, None] = "037_deduplicate_remote_machines"
+branch_labels: Union[str, None] = None
+depends_on: Union[str, None] = None
+
+
+def upgrade() -> None:
+    for table in ("agent_sessions", "daily_messages", "daily_usage"):
+        op.execute(
+            sa.text(
+                f"UPDATE {table} SET tool_name = 'qwen' "
+                f"WHERE tool_name IN ('qwen-code', 'qwen-code-cli')"
+            )
+        )
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
## Summary
- Resolve #233: Dashboard 与 Request Dashboard 趋势图数据不一致
- 创建 `app/utils/tool_names.py` 集中管理 tool name 规范化
- 写入时规范化：`remote_session_manager.py` 和 `workspace.py` 中调用 `normalize_tool_name()`
- 读取时规范化：`usage_repo.py` 的 `get_daily_by_tool()` 和 `get_request_trend_by_tool()` 中合并同 key 数据
- 新增数据库迁移 `038_normalize_tool_names`，将历史数据统一为 `qwen`
- 前端清理 `TOOL_DISPLAY_NAMES` 中多余的映射条目

## Test plan
- [x] 本地 dry-run 验证迁移 SQL（832 条 agent_sessions 更新）
- [x] 远程服务器已执行迁移（428 条 agent_sessions + 283 条 daily_messages）
- [ ] 访问 `/manage/dashboard` 确认只显示 QWEN 一种分类
- [ ] 访问 `/manage/analysis/request-dashboard` 确认数据一致
- [ ] 创建新的远程会话，确认 `agent_sessions.tool_name` 存储为 `qwen`

🤖 Generated with [Claude Code](https://claude.com/claude-code)