### PR TITLE
fix: project stats show zero tokens/requests due to data flow breakage

### DIFF
--- a/app/modules/workspace/remote_session_manager.py
+++ b/app/modules/workspace/remote_session_manager.py
@@ -700,6 +700,8 @@ class RemoteSessionManager:
                 message_source="remote_workspace",
                 agent_session_id=session_id,
                 conversation_id=session_id,
+                user_id=session.user_id,
+                project_path=session.project_path,
             )
         except Exception as e:
             logger.warning(f"Failed to mirror message to daily_messages for {session_id[:8]}: {e}")

--- a/app/repositories/message_repo.py
+++ b/app/repositories/message_repo.py
@@ -47,6 +47,8 @@ class MessageRepository:
         is_group_chat: Optional[int] = None,
         agent_session_id: Optional[str] = None,
         conversation_id: Optional[str] = None,
+        user_id: Optional[int] = None,
+        project_path: Optional[str] = None,
     ) -> bool:
         """
         Save a message to the database.
@@ -87,8 +89,8 @@ class MessageRepository:
                  full_entry, tokens_used, input_tokens, output_tokens, model,
                  timestamp, sender_id, sender_name, message_source,
                  feishu_conversation_id, group_subject, is_group_chat,
-                 agent_session_id, conversation_id)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 agent_session_id, conversation_id, user_id, project_path)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT (date, tool_name, host_name, message_id) DO UPDATE SET
                     parent_id = EXCLUDED.parent_id,
                     role = EXCLUDED.role,
@@ -106,7 +108,9 @@ class MessageRepository:
                     group_subject = EXCLUDED.group_subject,
                     is_group_chat = EXCLUDED.is_group_chat,
                     agent_session_id = EXCLUDED.agent_session_id,
-                    conversation_id = EXCLUDED.conversation_id
+                    conversation_id = EXCLUDED.conversation_id,
+                    user_id = EXCLUDED.user_id,
+                    project_path = EXCLUDED.project_path
             """,
                 (
                     date,
@@ -130,6 +134,8 @@ class MessageRepository:
                     is_group_chat,
                     agent_session_id,
                     conversation_id,
+                    user_id,
+                    project_path,
                 ),
             )
         else:
@@ -140,8 +146,8 @@ class MessageRepository:
                  full_entry, tokens_used, input_tokens, output_tokens, model,
                  timestamp, sender_id, sender_name, message_source,
                  feishu_conversation_id, group_subject, is_group_chat,
-                 agent_session_id, conversation_id)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 agent_session_id, conversation_id, user_id, project_path)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
                 (
                     date,
@@ -165,6 +171,8 @@ class MessageRepository:
                     is_group_chat,
                     agent_session_id,
                     conversation_id,
+                    user_id,
+                    project_path,
                 ),
             )
 

--- a/app/repositories/project_repo.py
+++ b/app/repositories/project_repo.py
@@ -461,15 +461,23 @@ class ProjectRepository:
                 p.path as project_path,
                 p.name as project_name,
                 p.is_shared,
-                COUNT(up.id) as total_users,
+                COUNT(DISTINCT up.user_id) as total_users,
                 COALESCE(SUM(up.total_sessions), 0) as total_sessions,
-                COALESCE(SUM(up.total_tokens), 0) as total_tokens,
-                COALESCE(SUM(up.total_requests), 0) as total_requests,
                 COALESCE(SUM(up.total_duration_seconds), 0) as total_duration_seconds,
                 MIN(up.first_access_at) as first_access,
-                MAX(up.last_access_at) as last_access
+                MAX(up.last_access_at) as last_access,
+                COALESCE(dm_stats.total_tokens, 0) as total_tokens,
+                COALESCE(dm_stats.total_requests, 0) as total_requests
             FROM projects p
             LEFT JOIN user_projects up ON p.id = up.project_id
+            LEFT JOIN (
+                SELECT project_path,
+                       SUM(tokens_used) as total_tokens,
+                       COUNT(*) as total_requests
+                FROM daily_messages
+                WHERE project_path IS NOT NULL
+                GROUP BY project_path
+            ) dm_stats ON p.path = dm_stats.project_path
             WHERE p.is_active IS TRUE
             GROUP BY p.id
             ORDER BY total_tokens DESC

--- a/app/routes/upload.py
+++ b/app/routes/upload.py
@@ -136,6 +136,8 @@ def api_upload_messages():
                 is_group_chat=msg.get("is_group_chat"),
                 agent_session_id=msg.get("agent_session_id"),
                 conversation_id=msg.get("conversation_id"),
+                user_id=msg.get("user_id"),
+                project_path=msg.get("project_path"),
             )
 
             if success:
@@ -224,6 +226,8 @@ def api_upload_batch():
                 is_group_chat=m.get("is_group_chat"),
                 agent_session_id=m.get("agent_session_id"),
                 conversation_id=m.get("conversation_id"),
+                user_id=m.get("user_id"),
+                project_path=m.get("project_path"),
             )
             if success:
                 results["messages"]["saved"] += 1

--- a/app/services/message_service.py
+++ b/app/services/message_service.py
@@ -267,6 +267,8 @@ class MessageService:
         is_group_chat: Optional[int] = None,
         agent_session_id: Optional[str] = None,
         conversation_id: Optional[str] = None,
+        user_id: Optional[int] = None,
+        project_path: Optional[str] = None,
     ) -> bool:
         """
         Save a message.
@@ -296,4 +298,6 @@ class MessageService:
             is_group_chat=is_group_chat,
             agent_session_id=agent_session_id,
             conversation_id=conversation_id,
+            user_id=user_id,
+            project_path=project_path,
         )

--- a/tests/210/e2e_project_stats_accuracy.py
+++ b/tests/210/e2e_project_stats_accuracy.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""
+Issue #210 - Project Stats Accuracy E2E Test
+
+Verifies that project stats correctly aggregate token/request data
+from daily_messages rather than showing zeros.
+
+Test plan:
+1. Login as admin
+2. Upload messages with project_path to daily_messages via upload API
+3. Call GET /api/projects/stats
+4. Verify the project's total_tokens and total_requests are non-zero
+
+Run:
+  HEADLESS=true  python tests/210/e2e_project_stats_accuracy.py
+  HEADLESS=false python tests/210/e2e_project_stats_accuracy.py
+"""
+
+import os
+import sys
+import uuid
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, PROJECT_ROOT)
+
+import requests
+
+# Config
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
+USERNAME = os.environ.get("TEST_USERNAME", "admin")
+PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
+
+
+def test_project_stats_accuracy():
+    print("=" * 60)
+    print("Issue #210 - Project Stats Accuracy E2E Test")
+    print("=" * 60)
+
+    # Login
+    print("\n[1] Login")
+    session = requests.Session()
+    r = session.post(
+        f"{BASE_URL}/api/auth/login",
+        json={"username": USERNAME, "password": PASSWORD},
+    )
+    assert r.status_code == 200, f"Login failed: {r.status_code}"
+    print("  OK - logged in")
+
+    # Get existing projects
+    print("\n[2] Get existing projects")
+    r = session.get(f"{BASE_URL}/api/projects/stats")
+    assert r.status_code == 200, f"Stats API failed: {r.status_code}"
+    data = r.json()
+    stats = data.get("stats", [])
+    print(f"  OK - {len(stats)} projects found")
+
+    if not stats:
+        print("  SKIP - no projects found, cannot test")
+        return
+
+    # Pick the first project and upload messages with its path
+    target_project = stats[0]
+    project_path = target_project["project_path"]
+    project_name = target_project.get("project_name") or project_path
+    print(f"\n[3] Upload messages with project_path={project_path}")
+
+    message_id = str(uuid.uuid4())
+    tokens_to_upload = 5000
+
+    # Use the upload API to insert a message with project_path
+    upload_payload = {
+        "date": "2026-05-06",
+        "tool_name": "test-tool",
+        "messages": [
+            {
+                "message_id": message_id,
+                "role": "assistant",
+                "content": "Test message for project stats accuracy",
+                "tokens_used": tokens_to_upload,
+                "input_tokens": 2000,
+                "output_tokens": 3000,
+                "project_path": project_path,
+            }
+        ],
+    }
+
+    # Try upload endpoint (may require auth token)
+    r = session.post(f"{BASE_URL}/api/upload/messages", json=upload_payload)
+    upload_ok = r.status_code == 200
+
+    if not upload_ok:
+        # Fallback: try batch upload
+        batch_payload = {
+            "messages": [
+                {
+                    "date": "2026-05-06",
+                    "tool_name": "test-tool",
+                    "message_id": message_id,
+                    "role": "assistant",
+                    "content": "Test message for project stats accuracy",
+                    "tokens_used": tokens_to_upload,
+                    "project_path": project_path,
+                }
+            ]
+        }
+        r = session.post(f"{BASE_URL}/api/upload/batch", json=batch_payload)
+        upload_ok = r.status_code == 200
+
+    if upload_ok:
+        print(f"  OK - uploaded message with {tokens_to_upload} tokens")
+    else:
+        print(f"  WARN - upload failed ({r.status_code}), checking existing data")
+
+    # Verify project stats now reflect the data
+    print("\n[4] Verify project stats")
+    r = session.get(f"{BASE_URL}/api/projects/stats")
+    assert r.status_code == 200, f"Stats API failed: {r.status_code}"
+    data = r.json()
+    stats_after = data.get("stats", [])
+
+    # Find our target project
+    target_after = None
+    for s in stats_after:
+        if s["project_path"] == project_path:
+            target_after = s
+            break
+
+    assert target_after is not None, f"Project {project_path} not found in stats"
+
+    total_tokens = target_after.get("total_tokens", 0)
+    total_requests = target_after.get("total_requests", 0)
+
+    print(f"  Project: {project_name}")
+    print(f"  total_tokens: {total_tokens}")
+    print(f"  total_requests: {total_requests}")
+
+    assert total_tokens > 0, (
+        f"total_tokens is still 0! The fix did not work. "
+        f"project_path={project_path}, upload_ok={upload_ok}"
+    )
+    assert total_requests > 0, (
+        f"total_requests is still 0! The fix did not work. "
+        f"project_path={project_path}, upload_ok={upload_ok}"
+    )
+
+    print("\n  OK - total_tokens and total_requests are non-zero!")
+
+    # Verify via browser that the UI shows the data correctly
+    if HEADLESS:
+        _test_browser_ui(session)
+
+    print("\n" + "=" * 60)
+    print("ALL TESTS PASSED")
+    print("=" * 60)
+
+
+def _test_browser_ui(session):
+    """Verify the project management page shows non-zero stats."""
+    from playwright.sync_api import sync_playwright
+
+    print("\n[5] Verify UI shows correct data")
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        context = browser.new_context(viewport={"width": 1400, "height": 900})
+        page = context.new_page()
+
+        # Login via browser
+        page.goto(f"{BASE_URL}/login", wait_until="domcontentloaded")
+        page.wait_for_timeout(1000)
+        page.fill('input[type="text"], input[name="username"]', USERNAME)
+        page.fill('input[type="password"], input[name="password"]', PASSWORD)
+        page.click('button[type="submit"]')
+        page.wait_for_url(lambda url: "/login" not in url, timeout=15000)
+
+        # Navigate to project management
+        page.goto(f"{BASE_URL}/manage/projects", wait_until="domcontentloaded")
+        page.wait_for_timeout(2000)
+        page.wait_for_selector("table", timeout=10000)
+
+        # Check that at least one row has non-zero token count (not "0")
+        rows = page.locator("table tbody tr")
+        found_nonzero = False
+        for i in range(rows.count()):
+            cells = rows.nth(i).locator("td")
+            if cells.count() >= 3:
+                token_text = cells.nth(2).inner_text().strip()
+                if token_text != "0":
+                    found_nonzero = True
+                    print(f"  Row {i}: tokens={token_text}")
+                    break
+
+        assert found_nonzero, "No row with non-zero tokens found in UI table"
+        print("  OK - UI shows non-zero token data")
+
+        browser.close()
+
+
+if __name__ == "__main__":
+    test_project_stats_accuracy()


### PR DESCRIPTION
## Summary
- Fix `save_message()` to write `user_id` and `project_path` to `daily_messages` (columns existed but were never populated)
- Fix `get_all_project_stats()` to aggregate `total_tokens` and `total_requests` from `daily_messages` via LEFT JOIN on `project_path`, instead of reading from `user_projects` which only gets data on workspace session close

Closes #210

## Root Cause
Data flow was broken:
1. `get_all_project_stats()` read token counts from `user_projects` (only populated on workspace session close)
2. `save_message()` never wrote `user_id` or `project_path` to `daily_messages`, so the real token data had no project association
3. Result: all projects showed `total_tokens=0` and `total_requests=0`

## Files Changed
- `app/repositories/message_repo.py` — add `user_id`, `project_path` params to `save_message()`
- `app/services/message_service.py` — pass through new params
- `app/modules/workspace/remote_session_manager.py` — pass `user_id` and `project_path` from session
- `app/routes/upload.py` — pass `user_id` and `project_path` from payload
- `app/repositories/project_repo.py` — LEFT JOIN `daily_messages` aggregate for real stats
- `tests/210/e2e_project_stats_accuracy.py` — E2E test verifying non-zero stats

## Test plan
- [x] Pre-commit hooks pass (black, ruff, mypy, bandit, SQL compat)
- [x] E2E test verifies `GET /api/projects/stats` returns non-zero `total_tokens` and `total_requests`
- [x] E2E test verifies UI table shows non-zero token data

🤖 Generated with [Claude Code](https://claude.com/claude-code)