### PR TITLE
fix: refresh usage_summary in scheduler to prevent stale dashboard data

### DIFF
--- a/app/services/data_fetch_scheduler.py
+++ b/app/services/data_fetch_scheduler.py
@@ -147,6 +147,9 @@ class DataFetchScheduler:
         # Safety net: aggregate user_daily_stats periodically
         self._aggregate_user_stats()
 
+        # Refresh usage_summary table
+        self._refresh_usage_summary()
+
         # Check quotas after data is fresh
         self._check_quotas()
 
@@ -177,6 +180,17 @@ class DataFetchScheduler:
             aggregate_user_stats_background()
         except Exception as e:
             logger.warning(f"Scheduled user stats aggregation failed: {e}")
+
+    def _refresh_usage_summary(self):
+        """Refresh usage_summary table after new data is fetched."""
+        from app.services.summary_service import SummaryService
+
+        try:
+            summary_service = SummaryService()
+            summary_service.refresh_summary()
+            logger.info("Usage summary refreshed")
+        except Exception as e:
+            logger.exception(f"Error refreshing usage summary: {e}")
 
     def _check_quotas(self):
         """Check all users' quotas and enforce limits after data refresh."""

--- a/app/services/data_fetch_scheduler.py
+++ b/app/services/data_fetch_scheduler.py
@@ -190,7 +190,7 @@ class DataFetchScheduler:
             summary_service.refresh_summary()
             logger.info("Usage summary refreshed")
         except Exception as e:
-            logger.exception(f"Error refreshing usage summary: {e}")
+            logger.warning(f"Usage summary refresh failed: {e}")
 
     def _check_quotas(self):
         """Check all users' quotas and enforce limits after data refresh."""


### PR DESCRIPTION
## Summary
- Add `summary_service.refresh_summary()` call in `DataFetchScheduler._run_fetch()` so the `usage_summary` table is refreshed every time the scheduler fetches new data (every 5 minutes)
- Previously the summary was only refreshed on-demand when users visited `/api/summary` and data was >1 hour old, causing stale dashboard data

Closes #216

## Test plan
- [ ] Verify scheduler logs show "Usage summary refreshed" after each fetch cycle
- [ ] Confirm `GET /api/summary` returns up-to-date data matching `daily_messages`

🤖 Generated with [Claude Code](https://claude.com/claude-code)