### PR TITLE
fix: fill missing dates in trend chart (#218)

### DIFF
--- a/frontend/src/components/common/Charts.tsx
+++ b/frontend/src/components/common/Charts.tsx
@@ -2,7 +2,7 @@
  * Charts Component - Chart.js integration with react-chartjs-2
  */
 
-import React from 'react';
+import React, { useMemo } from 'react';
 import {
   Chart as ChartJS,
   CategoryScale,
@@ -513,17 +513,57 @@ interface TokenTrendChartProps {
     tool: string;
     tokens: number;
   }>;
+  startDate?: string;
+  endDate?: string;
   height?: number;
   className?: string;
 }
 
 export const TokenTrendChart: React.FC<TokenTrendChartProps> = ({
   data,
+  startDate,
+  endDate,
   height = 300,
   className,
 }) => {
-  // Get unique dates and tools
-  const dates = [...new Set(data.map((d) => d.date))].sort();
+  // Generate complete date range if startDate and endDate are provided
+  const dates = useMemo(() => {
+    if (startDate && endDate) {
+      // Parse dates using local time to avoid timezone offset issues
+      const parseLocalDate = (dateStr: string): Date => {
+        const [year, month, day] = dateStr.split('-').map(Number);
+        return new Date(year, month - 1, day);
+      };
+
+      const formatDate = (d: Date): string => {
+        const y = d.getFullYear();
+        const m = String(d.getMonth() + 1).padStart(2, '0');
+        const day = String(d.getDate()).padStart(2, '0');
+        return `${y}-${m}-${day}`;
+      };
+
+      const start = parseLocalDate(startDate);
+      const end = parseLocalDate(endDate);
+
+      if (isNaN(start.getTime()) || isNaN(end.getTime())) {
+        return [...new Set(data.map((d) => d.date))].sort();
+      }
+
+      const dateArray: string[] = [];
+      const currentDate = new Date(start);
+
+      while (currentDate <= end) {
+        dateArray.push(formatDate(currentDate));
+        currentDate.setDate(currentDate.getDate() + 1);
+      }
+
+      return dateArray;
+    }
+
+    // Fallback: use unique dates from data
+    return [...new Set(data.map((d) => d.date))].sort();
+  }, [data, startDate, endDate]);
+
   const tools = [...new Set(data.map((d) => d.tool))];
 
   // Create a map for quick lookup

--- a/frontend/src/components/common/LazyCharts.tsx
+++ b/frontend/src/components/common/LazyCharts.tsx
@@ -87,6 +87,8 @@ export interface TokenTrendChartProps {
     tool: string;
     tokens: number;
   }>;
+  startDate?: string;
+  endDate?: string;
   height?: number;
   className?: string;
 }

--- a/frontend/src/components/features/Dashboard.tsx
+++ b/frontend/src/components/features/Dashboard.tsx
@@ -179,7 +179,7 @@ export const Dashboard: React.FC = () => {
           <div className="col-md-8 mb-4">
             <Card title={t('trendChart', language)}>
               {trendData && trendData.length > 0 ? (
-                <TokenTrendChart data={trendData} height={300} />
+                <TokenTrendChart data={trendData} startDate={startDate} endDate={endDate} height={300} />
               ) : (
                 <EmptyState icon="bi-graph-up" title={t('noData', language)} />
               )}

--- a/frontend/src/components/features/Report.tsx
+++ b/frontend/src/components/features/Report.tsx
@@ -181,7 +181,7 @@ export const Report: React.FC = () => {
         <div className="col-md-8 mb-4">
           <Card title={t('tokenTrend', language)}>
             {chartData.length > 0 ? (
-              <TokenTrendChart data={chartData} height={300} />
+              <TokenTrendChart data={chartData} startDate={startDate} endDate={endDate} height={300} />
             ) : (
               <EmptyState icon="bi-graph-up" title={t('noData', language)} />
             )}


### PR DESCRIPTION
## Summary
- 修复 Dashboard 趋势图因缺失日期数据导致的断裂显示问题
- `TokenTrendChart` 组件新增 `startDate`/`endDate` props，自动填充完整日期范围
- 缺失日期的数据点显示为 0，确保趋势线连续无断点

## Changes
- `Charts.tsx`: 用 `useMemo` 生成 startDate → endDate 完整日期序列，缺失日期自动补 0
- `LazyCharts.tsx`: 同步更新 `TokenTrendChartProps` 接口
- `Dashboard.tsx` / `Report.tsx`: 传递日期范围给图表组件

## Root Cause
后端 `GET /api/trend` 查询 `daily_stats` 预聚合表，只返回有数据记录的日期。前端 `TokenTrendChart` 直接使用 API 返回的日期列表作为 X 轴，导致无数据的日期完全缺失。

Closes #218