### PR TITLE
fix: show correct laptop icon for local workspace created from remote context

### DIFF
--- a/frontend/src/components/features/Workspace.tsx
+++ b/frontend/src/components/features/Workspace.tsx
@@ -1596,7 +1596,7 @@ export const Workspace: React.FC = () => {
         onClose={() => setShowNewSessionModal(false)}
         onCreateLocal={() => {
           setShowNewSessionModal(false);
-          createNewTab();
+          createNewTab(undefined, { workspaceType: 'local' });
         }}
         onCreateRemote={(params: {
           machineId: string;


### PR DESCRIPTION
Fixes #226

## Summary

When creating a local workspace from within a remote workspace context, the new tab incorrectly showed a cloud icon (remote workspace icon) instead of the laptop icon (local workspace icon).

## Root Cause

In Workspace.tsx, the onCreateLocal callback passed to NewSessionModal called createNewTab() without specifying workspaceType. This caused the new tab to inherit the current context's workspaceType (which was 'remote'), resulting in the wrong icon display.

## Fix

Explicitly pass { workspaceType: 'local' } to createNewTab() in the onCreateLocal callback.

## Reproduction Steps

1. Enter a remote workspace context
2. Click '+' to open NewSessionModal
3. Create a local workspace
4. Observe the new tab icon - it showed cloud icon (wrong) instead of laptop icon (expected)

## Test

After fix, the newly created local workspace tab correctly displays the laptop icon regardless of the current workspace context.