### PR TITLE
fix: load SECRET_KEY from config.json for API key encryption

### DIFF
--- a/scripts/shared/config.py
+++ b/scripts/shared/config.py
@@ -11,7 +11,7 @@ environment variables to override defaults.
 
 import json
 import os
-from typing import cast
+from typing import Optional, cast
 
 # Configuration directory path
 # This is the main configuration that should be set during installation
@@ -220,3 +220,24 @@ def get_quota_enforcement_config() -> dict:
     default_config = {"interval": 60, "enabled": True}
     default_config.update(enforcement_config)
     return default_config
+
+
+def get_secret_key() -> Optional[str]:
+    """
+    Get secret key with priority: environment variable > config file.
+
+    Returns:
+        Optional[str]: Secret key from config, or None if not configured or
+                    already set in environment.
+    """
+    # Priority 1: Environment variable (already set)
+    if os.environ.get("SECRET_KEY"):
+        return None  # Don't override environment variable
+
+    # Priority 2: Config file
+    user_config = _load_user_config()
+    secret_key = user_config.get("secret_key")
+    if secret_key:
+        return cast(str, secret_key)
+
+    return None

--- a/web.py
+++ b/web.py
@@ -31,6 +31,14 @@ project_root = os.path.dirname(os.path.abspath(__file__))
 if project_root not in sys.path:
     sys.path.insert(0, project_root)
 
+# Load secret_key from config.json before creating app
+# This ensures APIKeyProxyService can find the encryption key
+from scripts.shared.config import get_secret_key
+
+secret_key = get_secret_key()
+if secret_key:
+    os.environ["SECRET_KEY"] = secret_key
+
 # Create the Flask application using the factory
 from app import create_app
 


### PR DESCRIPTION
## Summary
- 添加 `get_secret_key()` 函数到 `scripts/shared/config.py`
- 修改 `web.py` 在创建 Flask app 前从 config.json 加载 secret_key 并设置环境变量
- 确保 `APIKeyProxyService` 可以找到加密密钥来加密远程 workspace 的 API keys

## 优先级顺序
1. 环境变量 `SECRET_KEY` (最高)
2. config.json 的 `secret_key` 字段
3. Flask 的 `dev-secret-key` fallback (仅开发环境)

## 用户需要做的
修改 `~/.open-ace/config.json`，添加 `secret_key` 字段：
```json
{
  "secret_key": "your-strong-secret-key-here",
  ...
}
```

## Test plan
- [ ] 添加 secret_key 到 config.json
- [ ] 重启服务器
- [ ] 访问 `/manage/remote/api-keys` 页面确认无错误
- [ ] 测试添加/删除 API key 功能

🤖 Generated with [Claude Code](https://claude.com/claude-code)