### PR TITLE
fix: show idle status as online in remote machines list

### DIFF
--- a/frontend/src/components/features/management/RemoteMachineManagement.tsx
+++ b/frontend/src/components/features/management/RemoteMachineManagement.tsx
@@ -232,7 +232,7 @@ export const RemoteMachineManagement: React.FC = () => {
 
   // Stats
   const totalMachines = machines.length;
-  const onlineCount = machines.filter((m) => m.status === 'online').length;
+  const onlineCount = machines.filter((m) => m.status === 'online' || m.status === 'idle').length;
   const offlineCount = totalMachines - onlineCount;
 
   if (isLoading) {
@@ -331,8 +331,8 @@ export const RemoteMachineManagement: React.FC = () => {
                     {machine.os_version ? ` ${machine.os_version}` : ''}
                   </td>
                   <td>
-                    <Badge variant={machine.status === 'online' ? 'success' : 'secondary'}>
-                      {machine.status === 'online' ? t('online', language) : t('offline', language)}
+                    <Badge variant={machine.status === 'online' || machine.status === 'idle' ? 'success' : 'secondary'}>
+                      {machine.status === 'online' || machine.status === 'idle' ? t('online', language) : t('offline', language)}
                     </Badge>
                   </td>
                   <td>{machine.agent_version ?? '-'}</td>
@@ -670,8 +670,8 @@ const MachineDetailsDialog: React.FC<MachineDetailsDialogProps> = ({
         <div className="col-md-6">
           <label className="text-muted small">{t('keyStatus', language)}</label>
           <div>
-            <Badge variant={machine.status === 'online' ? 'success' : 'secondary'}>
-              {machine.status === 'online' ? t('online', language) : t('offline', language)}
+            <Badge variant={machine.status === 'online' || machine.status === 'idle' ? 'success' : 'secondary'}>
+              {machine.status === 'online' || machine.status === 'idle' ? t('online', language) : t('offline', language)}
             </Badge>
             {machine.connected && (
               <Badge variant="info" className="ms-2">


### PR DESCRIPTION
## Summary
- Agent 发送 heartbeat 时 status 是 `idle`（空闲可用）
- 前端之前只把 `online` 视为在线，导致 `idle` 状态的机器显示为 offline
- 现在前端把 `idle` 也视为 online

## Changes
- `RemoteMachineManagement.tsx`: 将 `idle` 状态也显示为 online badge

## Test plan
- [ ] 查看远程机器列表页面，确认 idle 状态的机器显示为 online

🤖 Generated with [Claude Code](https://claude.com/claude-code)