### PR TITLE
fix: show idle/busy remote machines in available list

### DIFF
--- a/app/routes/remote.py
+++ b/app/routes/remote.py
@@ -373,8 +373,8 @@ def get_available_machines():
     agent_mgr = get_remote_agent_manager()
     machines = agent_mgr.get_available_machines(g.user["id"])
 
-    # Filter to only show online machines
-    available = [m for m in machines if m.get("status") == "online"]
+    # Filter out offline machines (show online/idle/busy)
+    available = [m for m in machines if m.get("status") != "offline"]
 
     return jsonify(
         {


### PR DESCRIPTION
## Summary
- Fix remote machines with "idle" or "busy" status not showing in the available machines list
- Change filter from `status == "online"` to `status != "offline"` so machines that are actively sending heartbeats are visible to users

## Root Cause
Remote agent sends heartbeat with status "idle" or "busy", which overwrites the initial "online" status in the database. The `get_available_machines` endpoint only returned machines with status "online", causing assigned machines to disappear from the list after the first heartbeat.

## Test Plan
- Login as a user with assigned remote machine
- Create remote session and verify the machine appears in the list