### PR TITLE
fix: forward remote session errors to frontend instead of silently hanging

### DIFF
--- a/app/routes/remote.py
+++ b/app/routes/remote.py
@@ -618,7 +618,13 @@ def stream_session_output(session_id):
                     for entry in new_output:
                         data = entry.get("data", "").strip()
                         stream = entry.get("stream", "stdout")
-                        if not data or stream == "stderr":
+                        if not data:
+                            last_index += 1
+                            continue
+                        if stream == "stderr":
+                            # Forward stderr as error events so the frontend
+                            # can display CLI errors instead of silently hanging.
+                            yield f"data: {json.dumps({'type': 'error', 'data': data})}\n\n"
                             last_index += 1
                             continue
                         try:

--- a/remote-agent/agent.py
+++ b/remote-agent/agent.py
@@ -6,13 +6,15 @@ Connects to the Open ACE server via HTTP polling, handles commands
 through the executor module, and sends heartbeats.
 """
 
+from __future__ import annotations
+
 import json
 import logging
 import os
 import signal
 import sys
 import time
-from typing import Any, Optional
+from typing import Any
 
 import requests
 from executor import ProcessExecutor
@@ -31,7 +33,7 @@ class RemoteAgent:
     manages CLI subprocesses, and reports output and status back.
     """
 
-    def __init__(self, config: Optional[AgentConfig] = None):
+    def __init__(self, config: AgentConfig | None = None):
         self.config = config or AgentConfig()
         self._executor = ProcessExecutor(
             server_url=self.config.server_url,
@@ -158,7 +160,7 @@ class RemoteAgent:
                 except Exception as e:
                     logger.error("Error handling command: %s", e)
 
-    def _http_send(self, message: dict[str, Any]) -> Optional[dict[str, Any]]:
+    def _http_send(self, message: dict[str, Any]) -> dict[str, Any] | None:
         """
         POST a message to the server's HTTP fallback endpoint.
 
@@ -261,7 +263,7 @@ class RemoteAgent:
             }
         )
 
-    def _send_session_status(self, session_id: str, status: str, pid: Optional[int] = None) -> None:
+    def _send_session_status(self, session_id: str, status: str, pid: int | None = None) -> None:
         """Send a session_status message to the server."""
         logger.info(
             "Sending session_status: session=%s status=%s pid=%s", session_id[:8], status, pid
@@ -385,10 +387,18 @@ class RemoteAgent:
 
         result = self._executor.send_message(session_id, content)
         if not result["success"]:
+            error_msg = result.get("error", "unknown error")
             logger.warning(
                 "Failed to send message to session %s: %s",
                 session_id[:8],
-                result.get("error"),
+                error_msg,
+            )
+            self._send_session_status(session_id, "error")
+            self._send_session_output(
+                session_id,
+                f"Failed to send message: {error_msg}",
+                "stderr",
+                is_complete=True,
             )
 
     def _cmd_stop_session(self, data: dict[str, Any]) -> None:

--- a/remote-agent/cli_adapters/base.py
+++ b/remote-agent/cli_adapters/base.py
@@ -6,8 +6,9 @@ Each adapter knows how to install, configure, and launch a specific
 CLI coding tool (e.g., qwen-code, claude-code, openclaw).
 """
 
+from __future__ import annotations
+
 import abc
-from typing import Optional
 
 
 class BaseCLIAdapter(abc.ABC):
@@ -33,9 +34,9 @@ class BaseCLIAdapter(abc.ABC):
         self,
         session_id: str,
         project_path: str,
-        model: Optional[str] = None,
-        permission_mode: Optional[str] = None,
-        allowed_tools: Optional[list[str]] = None,
+        model: str | None = None,
+        permission_mode: str | None = None,
+        allowed_tools: list[str] | None = None,
         resume: bool = False,
     ) -> list[str]:
         """Build the command-line arguments to start the CLI."""
@@ -56,7 +57,7 @@ class BaseCLIAdapter(abc.ABC):
         return True
 
     def build_single_shot_args(
-        self, prompt: str, project_path: str, model: Optional[str] = None
+        self, prompt: str, project_path: str, model: str | None = None
     ) -> list[str]:
         """Build args for a single-shot prompt execution (used when stdin is not supported)."""
         return [self.get_executable_name(), prompt]

--- a/remote-agent/cli_adapters/claude_code.py
+++ b/remote-agent/cli_adapters/claude_code.py
@@ -6,9 +6,10 @@ Uses ANTHROPIC_API_KEY and ANTHROPIC_BASE_URL environment variables to
 route requests through the Open ACE proxy.
 """
 
+from __future__ import annotations
+
 import logging
 import shutil
-from typing import Optional
 
 from .base import BaseCLIAdapter
 
@@ -48,9 +49,9 @@ class ClaudeCodeAdapter(BaseCLIAdapter):
         self,
         session_id: str,
         project_path: str,
-        model: Optional[str] = None,
-        permission_mode: Optional[str] = None,
-        allowed_tools: Optional[list[str]] = None,
+        model: str | None = None,
+        permission_mode: str | None = None,
+        allowed_tools: list[str] | None = None,
         resume: bool = False,
     ) -> list[str]:
         """

--- a/remote-agent/cli_adapters/openclaw.py
+++ b/remote-agent/cli_adapters/openclaw.py
@@ -6,9 +6,10 @@ API surface, so we route requests through the Open ACE proxy using
 OPENAI_API_KEY and OPENAI_BASE_URL environment variables.
 """
 
+from __future__ import annotations
+
 import logging
 import shutil
-from typing import Optional
 
 from .base import BaseCLIAdapter
 
@@ -59,9 +60,9 @@ class OpenClawAdapter(BaseCLIAdapter):
         self,
         session_id: str,
         project_path: str,
-        model: Optional[str] = None,
-        permission_mode: Optional[str] = None,
-        allowed_tools: Optional[list[str]] = None,
+        model: str | None = None,
+        permission_mode: str | None = None,
+        allowed_tools: list[str] | None = None,
         resume: bool = False,
     ) -> list[str]:
         """

--- a/remote-agent/cli_adapters/qwen_code.py
+++ b/remote-agent/cli_adapters/qwen_code.py
@@ -6,11 +6,12 @@ Uses OPENAI_API_KEY / OPENAI_BASE_URL environment variables to route
 requests through the Open ACE proxy.
 """
 
+from __future__ import annotations
+
 import json
 import logging
 import shutil
 from pathlib import Path
-from typing import Optional
 
 from .base import BaseCLIAdapter
 
@@ -54,9 +55,9 @@ class QwenCodeAdapter(BaseCLIAdapter):
         self,
         session_id: str,
         project_path: str,
-        model: Optional[str] = None,
-        permission_mode: Optional[str] = None,
-        allowed_tools: Optional[list[str]] = None,
+        model: str | None = None,
+        permission_mode: str | None = None,
+        allowed_tools: list[str] | None = None,
         resume: bool = False,
     ) -> list[str]:
         args = [
@@ -87,7 +88,7 @@ class QwenCodeAdapter(BaseCLIAdapter):
         return True
 
     def build_single_shot_args(
-        self, prompt: str, project_path: str, model: Optional[str] = None
+        self, prompt: str, project_path: str, model: str | None = None
     ) -> list[str]:
         args = [
             self.EXECUTABLE,
@@ -114,7 +115,7 @@ class QwenCodeAdapter(BaseCLIAdapter):
     # ------------------------------------------------------------------
 
     @staticmethod
-    def configure_settings(proxy_url: str, proxy_token: str) -> Optional[str]:
+    def configure_settings(proxy_url: str, proxy_token: str) -> str | None:
         """
         Write a minimal ~/.qwen/settings.json so that the CLI picks up
         the proxy even when environment variables are not the primary

--- a/remote-agent/config.py
+++ b/remote-agent/config.py
@@ -6,13 +6,15 @@ Config file location: ~/.open-ace-agent/config.json
 Environment variables take precedence over the config file.
 """
 
+from __future__ import annotations
+
 import json
 import logging
 import os
 import socket
 import uuid
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -41,7 +43,7 @@ class AgentConfig:
     3. Built-in defaults
     """
 
-    def __init__(self, config_path: Optional[str] = None):
+    def __init__(self, config_path: str | None = None):
         self._config_path = Path(config_path) if config_path else CONFIG_FILE
         self._data: dict[str, Any] = {}
         self._load()
@@ -93,7 +95,7 @@ class AgentConfig:
         return url.rstrip("/")
 
     @property
-    def agent_token(self) -> Optional[str]:
+    def agent_token(self) -> str | None:
         """
         Authentication token for the agent.
 

--- a/remote-agent/executor.py
+++ b/remote-agent/executor.py
@@ -9,6 +9,8 @@ Uses CLI adapters from cli_adapters to build per-tool command lines and
 environment variables.
 """
 
+from __future__ import annotations
+
 import contextlib
 import json
 import logging
@@ -19,10 +21,12 @@ import subprocess
 import threading
 import uuid
 from pathlib import Path
-from typing import Any, Callable, Optional
+from typing import TYPE_CHECKING, Any, Callable
 
 from cli_adapters import get_adapter
-from cli_adapters.base import BaseCLIAdapter
+
+if TYPE_CHECKING:
+    from cli_adapters.base import BaseCLIAdapter
 
 logger = logging.getLogger(__name__)
 
@@ -42,12 +46,12 @@ class SessionProcess:
         project_path: str,
         cli_tool: str,
         output_callback: Callable[[str, str, str, bool], None],
-        permission_callback: Optional[Callable[[str, dict], None]] = None,
-        usage_callback: Optional[Callable[[str, dict[str, int]], None]] = None,
-        env: Optional[dict[str, str]] = None,
-        model: Optional[str] = None,
-        permission_mode: Optional[str] = None,
-        allowed_tools: Optional[list[str]] = None,
+        permission_callback: Callable[[str, dict], None] | None = None,
+        usage_callback: Callable[[str, dict[str, int]], None] | None = None,
+        env: dict[str, str] | None = None,
+        model: str | None = None,
+        permission_mode: str | None = None,
+        allowed_tools: list[str] | None = None,
     ):
         self.session_id = session_id
         self.process = process
@@ -61,8 +65,8 @@ class SessionProcess:
         self.permission_mode = permission_mode
         self.allowed_tools: list[str] = list(allowed_tools) if allowed_tools else []
 
-        self._stdout_thread: Optional[threading.Thread] = None
-        self._stderr_thread: Optional[threading.Thread] = None
+        self._stdout_thread: threading.Thread | None = None
+        self._stderr_thread: threading.Thread | None = None
         self._stopped = threading.Event()
         self._restart_lock = threading.Lock()  # Prevents concurrent restarts
         self._paused = False
@@ -70,12 +74,12 @@ class SessionProcess:
 
         # SDK mode initialization tracking
         self._sdk_initialized = threading.Event()
-        self._init_request_id: Optional[str] = None
+        self._init_request_id: str | None = None
         # CLI's internal session_id (from SDK init response), used for --resume
-        self._cli_session_id: Optional[str] = None
+        self._cli_session_id: str | None = None
 
     @property
-    def pid(self) -> Optional[int]:
+    def pid(self) -> int | None:
         """Process ID, or None if the process has not started or has exited."""
         return self.process.pid if self.process.returncode is None else None
 
@@ -214,7 +218,7 @@ class SessionProcess:
             return False
 
     def send_permission_response(
-        self, request_id: str, behavior: str, message: Optional[str] = None
+        self, request_id: str, behavior: str, message: str | None = None
     ) -> bool:
         """
         Write a control_response to the subprocess stdin to approve/deny
@@ -428,7 +432,7 @@ class SessionProcess:
         except ImportError:
             return False
 
-    def wait_for_exit(self, timeout: float = 1.0) -> Optional[int]:
+    def wait_for_exit(self, timeout: float = 1.0) -> int | None:
         """
         Wait briefly for the process to exit and return its return code.
         Returns None if the process is still running.
@@ -514,9 +518,9 @@ class ProcessExecutor:
     def __init__(
         self,
         server_url: str,
-        output_callback: Optional[Callable] = None,
-        permission_callback: Optional[Callable] = None,
-        usage_callback: Optional[Callable] = None,
+        output_callback: Callable | None = None,
+        permission_callback: Callable | None = None,
+        usage_callback: Callable | None = None,
     ):
         """
         Args:
@@ -570,7 +574,7 @@ class ProcessExecutor:
         self,
         cli_tool: str,
         proxy_token: str,
-        model: Optional[str] = None,
+        model: str | None = None,
     ) -> dict[str, str]:
         """
         Build environment variables for the CLI subprocess.
@@ -610,7 +614,7 @@ class ProcessExecutor:
 
         return env
 
-    def _find_executable(self, cli_tool: str) -> Optional[str]:
+    def _find_executable(self, cli_tool: str) -> str | None:
         """
         Locate the CLI tool executable on the system.
 
@@ -689,9 +693,9 @@ class ProcessExecutor:
         cli_tool: str,
         session_id: str,
         project_path: str,
-        model: Optional[str] = None,
-        permission_mode: Optional[str] = None,
-        allowed_tools: Optional[list[str]] = None,
+        model: str | None = None,
+        permission_mode: str | None = None,
+        allowed_tools: list[str] | None = None,
         resume: bool = False,
     ) -> list[str]:
         adapter = get_adapter(cli_tool)
@@ -716,9 +720,9 @@ class ProcessExecutor:
         project_path: str,
         cli_tool: str,
         proxy_token: str,
-        model: Optional[str] = None,
-        permission_mode: Optional[str] = None,
-        allowed_tools: Optional[list[str]] = None,
+        model: str | None = None,
+        permission_mode: str | None = None,
+        allowed_tools: list[str] | None = None,
     ) -> dict[str, Any]:
         with self._lock:
             if session_id in self._sessions and self._sessions[session_id].is_running:
@@ -941,7 +945,7 @@ class ProcessExecutor:
         return {"success": False, "error": "Failed to write to process stdin"}
 
     def _run_single_shot(
-        self, session: "SessionProcess", content: str, adapter: BaseCLIAdapter
+        self, session: SessionProcess, content: str, adapter: BaseCLIAdapter
     ) -> dict[str, Any]:
         """Run a single-shot CLI command for tools that don't support stdin."""
         args = adapter.build_single_shot_args(content, session.project_path)
@@ -1232,7 +1236,7 @@ class ProcessExecutor:
         return {"success": True}
 
     def send_permission_response(
-        self, session_id: str, request_id: str, behavior: str, message: Optional[str] = None
+        self, session_id: str, request_id: str, behavior: str, message: str | None = None
     ) -> dict[str, Any]:
         """
         Send a permission response to a CLI subprocess.
@@ -1284,7 +1288,7 @@ class ProcessExecutor:
         self._save_sessions_meta()
         return {"success": True, "paused": session._paused, "pid": session.pid}
 
-    def get_session_info(self, session_id: str) -> Optional[dict[str, Any]]:
+    def get_session_info(self, session_id: str) -> dict[str, Any] | None:
         """Get information about a session."""
         with self._lock:
             session = self._sessions.get(session_id)

--- a/remote-agent/system_info.py
+++ b/remote-agent/system_info.py
@@ -4,6 +4,8 @@ Open ACE Remote Agent - System Capability Detection
 Gathers hardware info, OS details, and checks for installed CLI tools.
 """
 
+from __future__ import annotations
+
 import logging
 import os
 import platform


### PR DESCRIPTION
## Summary

- **SSE handler**: Forward stderr output as `{"type": "error", "data": ...}` events instead of silently dropping them — users now see CLI errors in the chat UI
- **Agent error reporting**: When `send_message` fails, report the error back to the server via `_send_session_status` and `_send_session_output` instead of only logging a warning
- **Python 3.8 compatibility**: Add `from __future__ import annotations` to all remote-agent modules so `dict[str, Any]` type hints work on Python 3.8 (used by agents on CentOS 7 / older systems)

## Root cause

Remote sessions on agents with incompatible CLI environments (e.g. node170 with glibc 2.17 vs Node.js requiring 2.27+) would silently hang in "thinking" state because:
1. CLI stderr output was discarded by the SSE handler
2. Agent only logged send_message failures without notifying the server
3. Python 3.8 crashed on modern type hint syntax

## Test plan

- [x] Deploy updated remote-agent to node170, verify agent starts successfully
- [x] Deploy updated SSE handler to server, verify stderr is forwarded as error events
- [x] Rebuild and deploy qwen-code-webui frontend with error event handling
- [ ] Verify: user creates remote session on node170, sends a message, sees a clear error instead of infinite "thinking"

🤖 Generated with [Claude Code](https://claude.com/claude-code)