### PR TITLE
fix: 添加缺失的配置项到 config.json.sample

### DIFF
--- a/config/config.json.sample
+++ b/config/config.json.sample
@@ -50,12 +50,21 @@
     "auth_type": "openai",
     "env": {
       "OPENAI_API_KEY": "<YOUR_API_KEY>",
-      "OPENAI_BASE_URL": "https://api.openai.com/v1"
+      "OPENAI_BASE_URL": "https://api.openai.com/v1",
+      "BAILIAN_CODING_PLAN_API_KEY": "<BAILIAN_API_KEY>"
     }
   },
   "insights": {
     "model": "glm-5",
     "temperature": 0.3,
     "max_tokens": 4096
+  },
+  "data_fetch": {
+    "interval": 300,
+    "enabled": true
+  },
+  "quota_enforcement": {
+    "interval": 60,
+    "enabled": true
   }
 }


### PR DESCRIPTION
## 问题描述

config.json.sample 配置样例文件缺少以下配置项，导致用户部署时无法完整配置所有功能。

## 修复内容

| 配置项 | 说明 |
|--------|------|
| `data_fetch` | 数据获取调度器配置（interval: 300秒, enabled: true） |
| `quota_enforcement` | 配额执行调度器配置（interval: 60秒, enabled: true） |
| `auth.env.BAILIAN_CODING_PLAN_API_KEY` | Insights 服务使用的备用 API Key |

## 相关 Issue

Closes #319