### PR TITLE
fix: fetch alerts on component mount for quota page

### DIFF
--- a/frontend/src/components/features/management/QuotaAlerts.tsx
+++ b/frontend/src/components/features/management/QuotaAlerts.tsx
@@ -119,12 +119,10 @@ export const QuotaAlerts: React.FC = () => {
     }
   }, [typeFilter, severityFilter, readFilter]);
 
-  // Fetch alerts when tab is active
+  // Fetch alerts on component mount
   useEffect(() => {
-    if (activeTab === 'alerts') {
-      fetchAlerts();
-    }
-  }, [activeTab, fetchAlerts]);
+    fetchAlerts();
+  }, [fetchAlerts]);
 
   // Fetch preferences
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Fix alert rules showing "no alerts" on quota management page
- Fetch alerts immediately when component mounts instead of waiting for tab switch

## Problem
The "alert rules" card displayed on the quota tab was showing "暂无告警" (no alerts) even when alerts existed in the system. This happened because alerts were only fetched when switching to the alerts tab.

## Solution
Changed the `useEffect` to fetch alerts on component mount, so the alert rules card always displays the latest alert data regardless of which tab is active.

## Test plan
- [ ] Navigate to `/manage/quota` page
- [ ] Verify alert rules card shows existing alerts (not "暂无告警")
- [ ] Switch to alerts tab and verify alerts load correctly
- [ ] Switch back to quota tab and verify alerts still display

Fixes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)