### PR TITLE
fix: correct HTTP method and remove unnecessary UI card

### DIFF
--- a/frontend/src/api/compliance.ts
+++ b/frontend/src/api/compliance.ts
@@ -176,7 +176,7 @@ export const complianceApi = {
     retention_days: number;
     action?: 'delete' | 'archive';
   }): Promise<RetentionRule> {
-    const response = await apiClient.post<{ rule: RetentionRule }>(
+    const response = await apiClient.put<{ rule: RetentionRule }>(
       '/api/compliance/retention/rules',
       data
     );

--- a/frontend/src/components/features/management/ComplianceMgmt.tsx
+++ b/frontend/src/components/features/management/ComplianceMgmt.tsx
@@ -257,49 +257,6 @@ export const ComplianceMgmt: React.FC = () => {
 
     return (
       <>
-        {/* Compliance Rules Overview */}
-        <Card title={t('complianceRules', language)} className="mb-4">
-          <div className="compliance-rules-list">
-            {Object.keys(rules).length === 0 ? (
-              <EmptyState icon="bi-shield-check" title={t('noComplianceRules', language)} />
-            ) : (
-              <div className="table-responsive">
-                <table className="table table-sm">
-                  <thead>
-                    <tr>
-                      <th>{t('dataType', language)}</th>
-                      <th>{t('retentionDays', language)}</th>
-                      <th>{t('action', language)}</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {Object.entries(rules)
-                      .slice(0, 5)
-                      .map(([dataType, rule]) => (
-                        <tr key={dataType}>
-                          <td>{dataType}</td>
-                          <td>
-                            {(rule as { retention_days: number }).retention_days}{' '}
-                            {t('days', language)}
-                          </td>
-                          <td>
-                            <Badge
-                              variant={
-                                (rule as { action: string }).action === 'delete' ? 'danger' : 'info'
-                              }
-                            >
-                              {(rule as { action: string }).action}
-                            </Badge>
-                          </td>
-                        </tr>
-                      ))}
-                  </tbody>
-                </table>
-              </div>
-            )}
-          </div>
-        </Card>
-
         {/* Report Type Selection */}
         <Card title={t('selectReportType', language)} className="mb-4">
           <div className="row g-3">


### PR DESCRIPTION
## Summary
- Fix HTTP method mismatch: change `apiClient.post` to `apiClient.put` for `setRetentionRule` API call
- Remove compliance rules overview card from reports tab as it displays empty state due to rules data not being loaded in that tab

## Changes
- `frontend/src/api/compliance.ts:179`: Changed POST to PUT to match backend API definition
- `frontend/src/components/features/management/ComplianceMgmt.tsx:260-301`: Removed the Compliance Rules Overview card from the reports tab

## Why
- **HTTP method mismatch**: The backend API endpoint `/api/compliance/retention/rules` uses PUT method for setting retention rules, but the frontend was using POST, causing the API call to fail
- **Empty UI card**: The reports tab was displaying a compliance rules overview card, but the rules data was only being loaded in the retention tab, resulting in an empty state being shown

## Test plan
- [ ] Verify that setting data retention rules now works correctly (previously failed due to HTTP method mismatch)
- [ ] Verify that the compliance report tab no longer shows an empty compliance rules card
- [ ] Verify that the retention tab still displays rules correctly

Fixes #204