### PR TITLE
fix: use API total count in conversation history page

### DIFF
--- a/frontend/src/components/features/ConversationHistory.tsx
+++ b/frontend/src/components/features/ConversationHistory.tsx
@@ -294,7 +294,7 @@ export const ConversationHistory: React.FC = () => {
           {/* Table Header with Column Selector and Fullscreen */}
           <div className="d-flex justify-content-between align-items-center mb-3">
             <span className="text-muted">
-              {t('total', language)}: {sortedConversations.length} {t('conversations', language)}
+              {t('total', language)}: {data?.total ?? 0} {t('conversations', language)}
             </span>
             <div className="d-flex gap-2">
               {/* Column Selector */}


### PR DESCRIPTION
## Summary
- 修复会话历史页面总数显示错误的问题
- 将 `sortedConversations.length`（当前页数据量，最多 20 条）改为 `data?.total ?? 0`（API 返回的实际总数）

## Changes
- `frontend/src/components/features/ConversationHistory.tsx`: 第 297 行使用 API 返回的 `data.total` 显示总数

## Related Issue
Fixes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)