### PR TITLE
fix: bypass system proxy in webui health check

### DIFF
--- a/app/services/webui_manager.py
+++ b/app/services/webui_manager.py
@@ -17,6 +17,7 @@ import subprocess
 import threading
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
@@ -89,9 +90,31 @@ class WebUIInstance:
             health_url = f"http://localhost:{self.port}/api/version"
             if self.token:
                 health_url += f"?token={self.token}"
-            req = urllib.request.Request(health_url)
-            with urllib.request.urlopen(req, timeout=3) as resp:
-                return cast("bool", resp.status == 200)
+            # Bypass system proxy for localhost — use direct socket connection
+            # to avoid proxy returning 502 on health checks
+            import socket as _socket
+
+            parsed = urllib.parse.urlparse(health_url)
+            host = parsed.hostname or "localhost"
+            port = parsed.port or 80
+            sock = _socket.create_connection((host, port), timeout=5)
+            try:
+                path = parsed.path
+                if parsed.query:
+                    path += f"?{parsed.query}"
+                request_line = f"GET {path} HTTP/1.0\r\nHost: {host}\r\nConnection: close\r\n\r\n"
+                sock.sendall(request_line.encode())
+                response = b""
+                while True:
+                    chunk = sock.recv(4096)
+                    if not chunk:
+                        break
+                    response += chunk
+                status_line = response.split(b"\r\n")[0].decode()
+                status_code = int(status_line.split(" ")[1])
+                return status_code == 200
+            finally:
+                sock.close()
         except Exception:
             return False
 


### PR DESCRIPTION
## Summary

macOS system HTTP proxy (`127.0.0.1:6454`) intercepted Python `urllib`'s localhost requests, returning 502 Bad Gateway. The health check to `/api/version` always failed, causing webui to be declared dead and restarted every ~5 minutes (after the consecutive failure counter from PR #336).

**Root cause chain:**
1. System HTTP proxy enabled → `urllib` sends localhost request through proxy
2. Proxy returns 502 → health check fails
3. 10 consecutive failures (~5 min) → webui declared dead → restarted
4. Active chat killed by SIGTERM → "Query aborted by user" / "Input closed"

**Fix:** Use raw `socket.create_connection()` instead of `urllib` for health check, bypassing system proxy entirely.

## Test plan

- [x] Manual test: raw socket health check returns 200 with valid token
- [x] Manual test: urllib health check returns 502 (proxy intercept)
- [x] Pre-commit hooks pass
- [ ] Deploy and verify health checks succeed in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)