### PR TITLE
fix: refresh session on workspace API activity to prevent 401

### DIFF
--- a/app/repositories/user_repo.py
+++ b/app/repositories/user_repo.py
@@ -463,6 +463,25 @@ class UserRepository:
             logger.error(f"Error deleting session: {e}")
             return False
 
+    def extend_session_expiry(self, token: str, new_expires_at: datetime) -> bool:
+        """Extend session expiry time.
+
+        Args:
+            token: Session token.
+            new_expires_at: New expiration time.
+
+        Returns:
+            bool: True if successful.
+        """
+        query = "UPDATE sessions SET expires_at = ? WHERE token = ?"
+
+        try:
+            self.db.execute(query, (new_expires_at, token))
+            return True
+        except Exception as e:
+            logger.error(f"Error extending session: {e}")
+            return False
+
     def cleanup_expired_sessions(self) -> int:
         """
         Delete expired sessions.

--- a/app/routes/workspace.py
+++ b/app/routes/workspace.py
@@ -10,6 +10,7 @@ API endpoints for workspace functionality including:
 """
 
 import logging
+from datetime import datetime, timedelta
 
 from flask import Blueprint, g, jsonify, request
 
@@ -67,6 +68,19 @@ def load_user():
             g.user = user
             g.user_id = user.get("id")
             g.user_role = user.get("role")
+
+            # Refresh session on activity to prevent premature expiry
+            try:
+                from app.repositories.user_repo import UserRepository
+                from app.services.auth_service import _get_session_timeout_hours
+
+                timeout_hours = _get_session_timeout_hours()
+                new_expires_at = datetime.utcnow() + timedelta(hours=timeout_hours)
+                UserRepository().extend_session_expiry(token, new_expires_at)
+                g._session_refresh_seconds = int(timeout_hours * 3600)
+            except Exception:
+                pass
+
             return None
 
         # Session token failed — try WebUI token validation
@@ -89,11 +103,39 @@ def load_user():
                     }
                     g.user_id = user_id
                     g.user_role = user_data.get("role")
+
+                    # Refresh session for WebUI-authenticated requests too
+                    try:
+                        from app.services.auth_service import _get_session_timeout_hours
+
+                        timeout_hours = _get_session_timeout_hours()
+                        new_expires_at = datetime.utcnow() + timedelta(hours=timeout_hours)
+                        user_repo.extend_session_expiry(token, new_expires_at)
+                        g._session_refresh_seconds = int(timeout_hours * 3600)
+                    except Exception:
+                        pass
+
                     return None
         except Exception as e:
             logger.warning(f"Failed to validate URL token: {e}")
 
     return jsonify({"error": "Authentication required"}), 401
+
+
+@workspace_bp.after_request
+def refresh_session_cookie(response):
+    """Refresh session cookie max_age on activity to prevent premature expiry."""
+    timeout_seconds = getattr(g, "_session_refresh_seconds", None)
+    if timeout_seconds and request.cookies.get("session_token"):
+        response.set_cookie(
+            "session_token",
+            request.cookies["session_token"],
+            httponly=True,
+            secure=request.is_secure,
+            samesite="Lax",
+            max_age=timeout_seconds,
+        )
+    return response
 
 
 # ==================== Prompt Templates ====================
@@ -661,8 +703,11 @@ def get_session(session_id):
             except Exception as e:
                 logger.warning(f"Failed to enrich session stats from daily_messages: {e}")
 
-            # If include_messages but session has no messages, try daily_messages
-            if include_messages and not session.messages:
+            # If include_messages but session has no messages, or messages lack content, try daily_messages
+            has_empty_content = session.messages and all(
+                not (m.content and m.content.strip()) for m in session.messages
+            )
+            if include_messages and (not session.messages or has_empty_content):
                 try:
                     msg_query = f"""
                         SELECT id, agent_session_id as session_id, role, content,

--- a/app/routes/workspace.py
+++ b/app/routes/workspace.py
@@ -28,6 +28,9 @@ logger = logging.getLogger(__name__)
 # Convert to actual tokens when comparing with usage
 TOKEN_QUOTA_MULTIPLIER = 1_000_000
 
+# Only refresh session when it has less than this many minutes remaining
+_SESSION_REFRESH_THRESHOLD_MINUTES = 10
+
 
 def format_datetime(dt):
     """Convert datetime to ISO 8601 string for proper timezone handling in frontend.
@@ -99,10 +102,6 @@ def load_user():
     return jsonify({"error": "Authentication required"}), 401
 
 
-# Only refresh when session has less than this many minutes remaining
-_SESSION_REFRESH_THRESHOLD_MINUTES = 10
-
-
 def _refresh_session(token: str, user_repo=None):
     """Extend DB session and cookie expiry when close to expiration.
 
@@ -114,21 +113,23 @@ def _refresh_session(token: str, user_repo=None):
         from app.services.auth_service import _get_session_timeout_hours
 
         repo = user_repo or UserRepository()
+
+        # Lightweight query — only need expires_at, no JOIN
+        row = repo.db.fetch_one("SELECT expires_at FROM sessions WHERE token = ?", (token,))
+        if not row or not row.get("expires_at"):
+            return
+
+        expires_at = row["expires_at"]
+        if isinstance(expires_at, str):
+            expires_at = datetime.fromisoformat(expires_at).replace(tzinfo=None)
+
+        remaining = (expires_at - datetime.utcnow()).total_seconds()
+        threshold = timedelta(minutes=_SESSION_REFRESH_THRESHOLD_MINUTES).total_seconds()
+        if remaining > threshold:
+            return
+
         timeout_hours = _get_session_timeout_hours()
-        threshold = timedelta(minutes=_SESSION_REFRESH_THRESHOLD_MINUTES)
         new_expires_at = datetime.utcnow() + timedelta(hours=timeout_hours)
-
-        # Only refresh if current expiry is within threshold
-        session = repo.get_session_by_token(token)
-        if session and session.get("expires_at"):
-            expires_at = session["expires_at"]
-            if isinstance(expires_at, str):
-
-                expires_at = datetime.fromisoformat(expires_at).replace(tzinfo=None)
-            remaining = (expires_at - datetime.utcnow()).total_seconds()
-            if remaining > threshold.total_seconds():
-                return
-
         repo.extend_session_expiry(token, new_expires_at)
         g._session_refresh_seconds = int(timeout_hours * 3600)
     except Exception as e:

--- a/app/routes/workspace.py
+++ b/app/routes/workspace.py
@@ -68,19 +68,7 @@ def load_user():
             g.user = user
             g.user_id = user.get("id")
             g.user_role = user.get("role")
-
-            # Refresh session on activity to prevent premature expiry
-            try:
-                from app.repositories.user_repo import UserRepository
-                from app.services.auth_service import _get_session_timeout_hours
-
-                timeout_hours = _get_session_timeout_hours()
-                new_expires_at = datetime.utcnow() + timedelta(hours=timeout_hours)
-                UserRepository().extend_session_expiry(token, new_expires_at)
-                g._session_refresh_seconds = int(timeout_hours * 3600)
-            except Exception:
-                pass
-
+            _refresh_session(token)
             return None
 
         # Session token failed — try WebUI token validation
@@ -103,18 +91,7 @@ def load_user():
                     }
                     g.user_id = user_id
                     g.user_role = user_data.get("role")
-
-                    # Refresh session for WebUI-authenticated requests too
-                    try:
-                        from app.services.auth_service import _get_session_timeout_hours
-
-                        timeout_hours = _get_session_timeout_hours()
-                        new_expires_at = datetime.utcnow() + timedelta(hours=timeout_hours)
-                        user_repo.extend_session_expiry(token, new_expires_at)
-                        g._session_refresh_seconds = int(timeout_hours * 3600)
-                    except Exception:
-                        pass
-
+                    _refresh_session(token, user_repo=user_repo)
                     return None
         except Exception as e:
             logger.warning(f"Failed to validate URL token: {e}")
@@ -122,9 +99,45 @@ def load_user():
     return jsonify({"error": "Authentication required"}), 401
 
 
+# Only refresh when session has less than this many minutes remaining
+_SESSION_REFRESH_THRESHOLD_MINUTES = 10
+
+
+def _refresh_session(token: str, user_repo=None):
+    """Extend DB session and cookie expiry when close to expiration.
+
+    Only refreshes if the session has less than _SESSION_REFRESH_THRESHOLD_MINUTES
+    remaining, avoiding a DB write on every request.
+    """
+    try:
+        from app.repositories.user_repo import UserRepository
+        from app.services.auth_service import _get_session_timeout_hours
+
+        repo = user_repo or UserRepository()
+        timeout_hours = _get_session_timeout_hours()
+        threshold = timedelta(minutes=_SESSION_REFRESH_THRESHOLD_MINUTES)
+        new_expires_at = datetime.utcnow() + timedelta(hours=timeout_hours)
+
+        # Only refresh if current expiry is within threshold
+        session = repo.get_session_by_token(token)
+        if session and session.get("expires_at"):
+            expires_at = session["expires_at"]
+            if isinstance(expires_at, str):
+
+                expires_at = datetime.fromisoformat(expires_at).replace(tzinfo=None)
+            remaining = (expires_at - datetime.utcnow()).total_seconds()
+            if remaining > threshold.total_seconds():
+                return
+
+        repo.extend_session_expiry(token, new_expires_at)
+        g._session_refresh_seconds = int(timeout_hours * 3600)
+    except Exception as e:
+        logger.warning(f"Failed to refresh session: {e}")
+
+
 @workspace_bp.after_request
 def refresh_session_cookie(response):
-    """Refresh session cookie max_age on activity to prevent premature expiry."""
+    """Refresh session cookie max_age only when session was actually refreshed."""
     timeout_seconds = getattr(g, "_session_refresh_seconds", None)
     if timeout_seconds and request.cookies.get("session_token"):
         response.set_cookie(
@@ -135,6 +148,7 @@ def refresh_session_cookie(response):
             samesite="Lax",
             max_age=timeout_seconds,
         )
+        g._session_refresh_seconds = None
     return response
 
 


### PR DESCRIPTION
## Summary
- Workspace API calls (`/api/workspace/status`, `/api/workspace/sessions`) returned 401 after session timeout (30 min) because there was no activity-based session refresh
- Added `extend_session_expiry()` to `UserRepository` to update session expiry in DB
- Added session refresh in workspace `load_user()` — each successful request extends both DB session `expires_at` and cookie `max_age`
- Also includes fix for empty content detection when loading session messages from `daily_messages`

## Test plan
- [ ] Log in to localhost:5001 and navigate to workspace page
- [ ] Verify browser console no longer shows 401 errors for `/api/workspace/status` and `/api/workspace/sessions`
- [ ] Wait >30 min and confirm API calls still succeed (session refreshed on activity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)