### PR TITLE
fix: use gevent-safe locks and fix quota SQL for PostgreSQL

### DIFF
--- a/app/modules/workspace/remote_agent_manager.py
+++ b/app/modules/workspace/remote_agent_manager.py
@@ -7,12 +7,14 @@ command dispatching, and message routing for remote workspace sessions.
 
 import json
 import logging
-import threading
 import time
 import uuid
 from contextlib import suppress
 from datetime import datetime, timedelta
 from typing import Any, Optional, cast
+
+import gevent
+from gevent.lock import Semaphore
 
 from app.repositories.database import DB_PATH, Database, is_postgresql
 
@@ -59,8 +61,8 @@ class RemoteAgentManager:
         self._session_end_flags: dict[str, bool] = {}
         # Heartbeat rate limiter: {machine_id: last_db_write_timestamp}
         self._last_heartbeat_db_write: dict[str, float] = {}
-        # Lock for thread safety
-        self._lock = threading.Lock()
+        # Lock for gevent coroutine safety
+        self._lock = Semaphore(1)
         self._restore_in_memory_state()
         self._cleanup_offline_sessions()
         self._start_heartbeat_monitor()
@@ -157,10 +159,9 @@ class RemoteAgentManager:
                     self._check_heartbeats()
                 except Exception as e:
                     logger.error(f"Heartbeat monitor error: {e}")
-                time.sleep(self.HEARTBEAT_CHECK_INTERVAL)
+                gevent.sleep(self.HEARTBEAT_CHECK_INTERVAL)
 
-        thread = threading.Thread(target=monitor, daemon=True, name="heartbeat-monitor")
-        thread.start()
+        gevent.spawn(monitor)
         logger.info("Heartbeat monitor started")
 
     def _check_heartbeats(self) -> None:

--- a/app/services/data_fetch_scheduler.py
+++ b/app/services/data_fetch_scheduler.py
@@ -238,11 +238,9 @@ class DataFetchScheduler:
                     WHERE uds.date >= ? AND uds.date <= ?
                       AND {adapt_boolean_condition("u.is_active", True)}
                       AND u.monthly_token_quota IS NOT NULL
-                      AND (
-                        SUM(uds.requests) >= COALESCE(u.monthly_request_quota, 999999)
-                        OR SUM(uds.tokens) >= COALESCE(u.monthly_token_quota, 999999) * 1000000
-                      )
                     GROUP BY u.id, u.username, u.monthly_request_quota, u.monthly_token_quota
+                    HAVING SUM(uds.requests) >= COALESCE(u.monthly_request_quota, 999999)
+                        OR SUM(uds.tokens) >= COALESCE(u.monthly_token_quota, 999999) * 1000000
                 """),
                 (month_start, today),
             )

--- a/app/services/webui_manager.py
+++ b/app/services/webui_manager.py
@@ -14,15 +14,16 @@ import platform
 import secrets
 import socket
 import subprocess
-import threading
 import time
 import urllib.error
 import urllib.parse
 import urllib.request
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
-from threading import RLock
 from typing import Any, Optional, cast
+
+import gevent
+from gevent import lock as gevent_lock
 
 logger = logging.getLogger(__name__)
 
@@ -167,8 +168,8 @@ class WebUIManager:
         self.config = config or self._load_config()
         self._instances: dict[int, WebUIInstance] = {}  # user_id -> instance
         self._port_allocations: dict[int, int] = {}  # port -> user_id
-        self._lock = RLock()  # Use reentrant lock to avoid deadlock
-        self._cleanup_thread: Optional[threading.Thread] = None
+        self._lock = gevent_lock.RLock()  # gevent-safe reentrant lock
+        self._cleanup_greenlet: Optional[gevent.Greenlet] = None
         self._running = False
 
         # Generate token secret if not configured
@@ -226,22 +227,21 @@ class WebUIManager:
             return WorkspaceConfig()
 
     def start_cleanup_thread(self):
-        """Start the background cleanup thread."""
-        if self._cleanup_thread is not None:
+        """Start the background cleanup greenlet."""
+        if self._cleanup_greenlet is not None:
             return
 
         self._running = True
-        self._cleanup_thread = threading.Thread(target=self._cleanup_loop, daemon=True)
-        self._cleanup_thread.start()
-        logger.info("Cleanup thread started")
+        self._cleanup_greenlet = gevent.spawn(self._cleanup_loop)
+        logger.info("Cleanup greenlet started")
 
     def stop_cleanup_thread(self):
-        """Stop the background cleanup thread."""
+        """Stop the background cleanup greenlet."""
         self._running = False
-        if self._cleanup_thread is not None:
-            self._cleanup_thread.join(timeout=5)
-            self._cleanup_thread = None
-        logger.info("Cleanup thread stopped")
+        if self._cleanup_greenlet is not None:
+            self._cleanup_greenlet.kill()
+            self._cleanup_greenlet = None
+        logger.info("Cleanup greenlet stopped")
 
     def _cleanup_loop(self):
         """Periodically clean up idle instances."""
@@ -827,9 +827,8 @@ class WebUIManager:
             except Exception as e:
                 logger.error(f"Failed to pre-start webui for user {user_id}: {e}")
 
-        thread = threading.Thread(target=start_in_background, daemon=True)
-        thread.start()
-        logger.info(f"Started background thread to pre-start webui for user {user_id}")
+        gevent.spawn(start_in_background)
+        logger.info(f"Spawned greenlet to pre-start webui for user {user_id}")
 
 
 # Global manager instance

--- a/app/utils/cache.py
+++ b/app/utils/cache.py
@@ -11,11 +11,12 @@ import hashlib
 import logging
 import os
 import pickle
-import threading
 import time
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any, Callable, TypeVar, cast
+
+from gevent.lock import RLock, Semaphore
 
 logger = logging.getLogger(__name__)
 
@@ -81,7 +82,7 @@ class MemoryCache(CacheBackend):
         self.max_size = max_size
         self.default_ttl = default_ttl
         self._cache: dict[str, CacheEntry] = {}
-        self._lock = threading.RLock()
+        self._lock = RLock()  # gevent-safe reentrant lock
         self._hits = 0
         self._misses = 0
 
@@ -315,7 +316,7 @@ class CacheManager:
     """
 
     _instance: CacheManager | None = None
-    _lock = threading.Lock()
+    _lock = Semaphore(1)  # gevent-safe semaphore for singleton
     _initialized: bool
     _backend: MemoryCache | RedisCache
 


### PR DESCRIPTION
## Summary
- Replace `threading.Lock/RLock` with `gevent.lock.Semaphore/RLock` in webui_manager, remote_agent_manager, and cache modules to prevent blocking the gevent event loop
- Fix quota enforcement SQL: move `SUM()` aggregate from WHERE clause to HAVING clause (PostgreSQL requirement)
- Replace `threading.Thread` with `gevent.spawn` for background tasks

## Background
When running under gevent, `threading.Lock` blocks the entire event loop, causing all other requests to wait. This was causing HTTPS login requests to timeout (~30 seconds) while remote agent message requests were holding locks.

Additionally, PostgreSQL does not allow aggregate functions like `SUM()` in WHERE clauses - they must be in HAVING clauses after GROUP BY.

## Test plan
- [x] Verified HTTPS login now works correctly (nginx config also fixed separately on server)
- [x] All pre-commit hooks pass
- [ ] Manual test: login via https://my.open-ace.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)