### PR TITLE
fix: HTTPS iframe URL for multi-user webui

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -9,6 +9,7 @@ import os
 
 from flask import Flask, jsonify, request
 from werkzeug.exceptions import HTTPException
+from werkzeug.middleware.proxy_fix import ProxyFix
 
 # Configure logging
 logging.basicConfig(
@@ -28,6 +29,12 @@ def create_app(config=None):
         Flask application instance.
     """
     app = Flask(__name__, static_folder="../static", template_folder="../templates")
+
+    # Trust nginx proxy headers for correct scheme detection
+    # x_proto=1: trust X-Forwarded-Proto header (https/http)
+    # x_for=1: trust X-Forwarded-For header
+    # This is needed for HTTPS iframe URL generation in multi-user mode
+    app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_proto=1)
 
     # Load configuration
     app.config["TEMPLATES_AUTO_RELOAD"] = True

--- a/app/routes/workspace.py
+++ b/app/routes/workspace.py
@@ -1572,6 +1572,17 @@ def get_user_webui_url():
 
         openace_url = flask_request.host_url.rstrip("/")
 
+        # For HTTPS requests in multi-user mode, convert URL to relative path
+        # to avoid mixed content blocking (HTTP iframe in HTTPS page)
+        if manager.config.multi_user_mode and flask_request.scheme == "https":
+            # Extract port from URL like "http://117.72.38.96:3100"
+            import re
+
+            port_match = re.search(r":(\d+)$", url)
+            if port_match:
+                port = port_match.group(1)
+                url = f"/webui/{port}/"
+
         return jsonify(
             {
                 "success": True,


### PR DESCRIPTION
## Summary

- 添加 `ProxyFix` middleware 让 Flask 正确识别 HTTPS scheme
- HTTPS 请求时返回 `/webui/{port}/` 而非 HTTP URL，避免浏览器 mixed content 阻止

## Root Cause

nginx 反向代理 HTTPS 到 HTTP 后端，Flask 无法识别原始 scheme，导致 iframe URL 生成错误。

## Test plan

- [ ] 部署到远程服务器
- [ ] 用 maya/maya1234 登录 https://my.open-ace.com/work
- [ ] 启动工作区，确认 iframe 正常加载

🤖 Generated with [Claude Code](https://claude.com/claude-code)