### PR TITLE
fix: unify request_count to count only assistant messages

### DIFF
--- a/app/modules/governance/quota_manager.py
+++ b/app/modules/governance/quota_manager.py
@@ -516,7 +516,7 @@ class QuotaManager:
                 COALESCE(SUM(
                     (SELECT COUNT(*) FROM session_messages sm
                      WHERE sm.session_id = agent_sessions.session_id
-                       AND sm.role IN ('assistant', 'toolResult'))
+                       AND sm.role = 'assistant'))
                 ), 0) as requests
             FROM agent_sessions
             WHERE user_id = ?
@@ -639,7 +639,7 @@ class QuotaManager:
                    COALESCE(SUM(
                        (SELECT COUNT(*) FROM session_messages sm
                         WHERE sm.session_id = agent_sessions.session_id
-                          AND sm.role IN ('assistant', 'toolResult'))
+                          AND sm.role = 'assistant'))
                    ), 0) as requests
             FROM agent_sessions
             WHERE user_id IN ({}) AND workspace_type = 'remote'

--- a/app/modules/workspace/session_manager.py
+++ b/app/modules/workspace/session_manager.py
@@ -121,7 +121,7 @@ class AgentSession:
     total_input_tokens: int = 0
     total_output_tokens: int = 0
     message_count: int = 0
-    request_count: int = 0  # Number of API requests (assistant/toolResult messages)
+    request_count: int = 0  # Number of API requests (assistant messages only)
     model: Optional[str] = None
     tags: list[str] = field(default_factory=list)
     created_at: Optional[datetime] = None
@@ -664,7 +664,8 @@ class SessionManager:
         )
 
         # Update session message count, request count and token count
-        request_count_increment = 1 if role in ("assistant", "toolResult") else 0
+        # Only assistant messages represent actual API requests (toolResult is local execution)
+        request_count_increment = 1 if role == "assistant" else 0
         cursor.execute(
             f"""
             UPDATE agent_sessions

--- a/app/repositories/usage_repo.py
+++ b/app/repositories/usage_repo.py
@@ -989,7 +989,7 @@ class UsageRepository:
                 COALESCE(SUM(
                     (SELECT COUNT(*) FROM session_messages sm
                      WHERE sm.session_id = agent_sessions.session_id
-                       AND sm.role IN ('assistant', 'toolResult'))
+                       AND sm.role = 'assistant'))
                 ), 0) as requests
             FROM agent_sessions
             WHERE user_id = ?
@@ -1051,7 +1051,7 @@ class UsageRepository:
                 SUM(
                     (SELECT COUNT(*) FROM session_messages sm
                      WHERE sm.session_id = s.session_id
-                       AND sm.role IN ('assistant', 'toolResult'))
+                       AND sm.role = 'assistant'))
                 ) as request_count
             FROM agent_sessions s
             WHERE s.user_id = ?

--- a/app/routes/workspace.py
+++ b/app/routes/workspace.py
@@ -524,7 +524,7 @@ def list_sessions():
                 stats_query = f"""
                     SELECT session_id,
                            COUNT(*) as actual_message_count,
-                           SUM(CASE WHEN role IN ('assistant', 'toolResult') THEN 1 ELSE 0 END) as actual_request_count,
+                           SUM(CASE WHEN role = 'assistant' THEN 1 ELSE 0 END) as actual_request_count,
                            SUM(tokens_used) as actual_total_tokens,
                            MAX(timestamp) as actual_updated_at
                     FROM session_messages
@@ -632,7 +632,7 @@ def list_sessions():
                         SUM(tokens_used) as dm_total_tokens,
                         SUM(input_tokens) as dm_input_tokens,
                         SUM(output_tokens) as dm_output_tokens,
-                        SUM(CASE WHEN role IN ('assistant', 'toolResult') THEN 1 ELSE 0 END) as dm_request_count,
+                        SUM(CASE WHEN role = 'assistant' THEN 1 ELSE 0 END) as dm_request_count,
                         MAX(timestamp) as dm_last_active,
                         MAX(model) as dm_model
                     FROM daily_messages
@@ -789,9 +789,10 @@ def get_session(session_id):
             p = get_param_placeholder()
 
             # Calculate request_count from messages if available
+            # Only assistant messages represent actual API requests (toolResult is local execution)
             if include_messages and session.messages:
                 session.request_count = sum(
-                    1 for m in session.messages if m.role in ("assistant", "toolResult")
+                    1 for m in session.messages if m.role == "assistant"
                 )
             else:
                 # Query request_count from session_messages table
@@ -802,7 +803,7 @@ def get_session(session_id):
                     SELECT COUNT(*) as request_count
                     FROM session_messages
                     WHERE session_id = {_param()}
-                    AND role IN ('assistant', 'toolResult')
+                    AND role = 'assistant'
                     """,
                     (session_id,),
                 )
@@ -818,7 +819,7 @@ def get_session(session_id):
                         SUM(tokens_used) as dm_total_tokens,
                         SUM(input_tokens) as dm_input_tokens,
                         SUM(output_tokens) as dm_output_tokens,
-                        SUM(CASE WHEN role IN ('assistant', 'toolResult') THEN 1 ELSE 0 END) as dm_request_count,
+                        SUM(CASE WHEN role = 'assistant' THEN 1 ELSE 0 END) as dm_request_count,
                         MAX(timestamp) as dm_last_active,
                         MAX(model) as dm_model
                     FROM daily_messages
@@ -905,7 +906,7 @@ def get_session(session_id):
                     MAX(sender_id) as sender_id,
                     MAX(date) as date,
                     COUNT(*) as message_count,
-                    SUM(CASE WHEN role IN ('assistant', 'toolResult') THEN 1 ELSE 0 END) as request_count,
+                    SUM(CASE WHEN role = 'assistant' THEN 1 ELSE 0 END) as request_count,
                     SUM(tokens_used) as total_tokens,
                     SUM(input_tokens) as total_input_tokens,
                     SUM(output_tokens) as total_output_tokens,

--- a/tests/issues/241/test_session_enrichment.py
+++ b/tests/issues/241/test_session_enrichment.py
@@ -226,7 +226,7 @@ class TestEnrichmentLogic:
                       SUM(tokens_used) as total_tokens,
                       SUM(input_tokens) as input_tokens,
                       SUM(output_tokens) as output_tokens,
-                      SUM(CASE WHEN role IN ('assistant', 'toolResult') THEN 1 ELSE 0 END) as req_count,
+                      SUM(CASE WHEN role = 'assistant' THEN 1 ELSE 0 END) as req_count,
                       MAX(model) as model
                FROM daily_messages WHERE agent_session_id = ?""",
             (sid,),


### PR DESCRIPTION
## Summary

Fixes #335: Workspace page left panel request count was inconsistent with bottom status bar request count.

### Root Cause Analysis (verified with PostgreSQL database)

| role | Description | tokens_used |
|------|-------------|-------------|
| **assistant** | LLM API response | ✓ Has tokens |
| **toolResult** | Tool execution result (bash output, file content) | **0** (no tokens) |

**Key finding**: `toolResult` messages are generated by local tool execution, NOT by calling the LLM API. Only `assistant` messages represent actual API requests.

### Data Verification (2026-03-24, session `openclaw_9dcbf2b0`)

| Location | Query | Result |
|----------|-------|--------|
| Left panel | `role IN ('assistant', 'toolResult')` | 480 (incorrect) |
| Bottom status bar | `role = 'assistant'` | 59 (correct) |

The left panel incorrectly counted 421 toolResult messages as "requests".

### Fix

Changed all request_count statistics from:
```sql
role IN ('assistant', 'toolResult')
```
to:
```sql
role = 'assistant'
```

### Modified Files

- `session_manager.py`: Fixed comment + `request_count_increment` logic
- `workspace.py`: 5 SQL queries and Python code
- `usage_repo.py`: 2 remote session SQL queries  
- `quota_manager.py`: 2 remote session SQL queries

### Test Plan

- [ ] Verify left panel session request_count matches bottom status bar
- [ ] Check that request_count no longer includes toolResult messages
- [ ] Verify existing sessions still display correctly

🤖 Generated with [Qwen Code](https://github.com/open-ace/open-ace)