### PR TITLE
fix: tab notification bugs - fallback and switchTab issues

### DIFF
--- a/frontend/src/components/features/Workspace.tsx
+++ b/frontend/src/components/features/Workspace.tsx
@@ -231,9 +231,9 @@ export const Workspace: React.FC = () => {
             }
           }
 
-          // If we couldn't find the source, use currentActiveTabId as fallback
-          sourceTabId ??= useAppStore.getState().workspaceActiveTabId;
-
+          // Only process notification if we can identify the source tab
+          // Do NOT use fallback to activeTabId - this prevents notifications from being
+          // incorrectly assigned to the current active tab when source cannot be matched
           if (sourceTabId) {
             setTabs((prev) =>
               prev.map((tab) =>
@@ -802,22 +802,41 @@ export const Workspace: React.FC = () => {
   // Switch to a tab
   const switchTab = useCallback(
     (tabId: string) => {
+      const previousTabId = activeTabId;
       setActiveTabId(tabId);
       // Update store (Issue #65)
       setStoredActiveTabId(tabId);
 
-      // Send focus message to iframe after tab switch
+      // Clear notification state for the tab we're leaving
+      // This prevents stale notifications when AI response completes after user switched away
+      if (previousTabId && previousTabId !== tabId) {
+        // Send tab-activated message to the previous tab's iframe to clear its internal state
+        const prevIframe = iframeRefs.current.get(previousTabId);
+        if (prevIframe?.contentWindow) {
+          prevIframe.contentWindow.postMessage({ type: 'openace-tab-activated' }, '*');
+        }
+        // Clear local notification state
+        setTabs((prev) =>
+          prev.map((tab) =>
+            tab.id === previousTabId ? { ...tab, waitingForUser: false, waitingType: null } : tab
+          )
+        );
+        useAppStore.getState().updateWorkspaceTab(previousTabId, {
+          waitingForUser: false,
+          waitingType: null,
+        });
+      }
+
+      // Send focus message to the new active iframe
       // Use setTimeout to ensure the iframe is visible before sending message
       setTimeout(() => {
         const iframe = iframeRefs.current.get(tabId);
         if (iframe?.contentWindow) {
           iframe.contentWindow.postMessage({ type: 'openace-focus-input' }, '*');
-          // Also send tab-activated to clear notification
-          iframe.contentWindow.postMessage({ type: 'openace-tab-activated' }, '*');
         }
       }, 100);
     },
-    [setStoredActiveTabId]
+    [activeTabId, setStoredActiveTabId]
   );
 
   // Rename a tab

--- a/frontend/src/components/features/Workspace.tsx
+++ b/frontend/src/components/features/Workspace.tsx
@@ -279,7 +279,7 @@ export const Workspace: React.FC = () => {
               const iframe = iframeRefs.current.get(targetTab.id);
               if (iframe?.contentWindow) {
                 iframe.contentWindow.postMessage({ type: 'openace-focus-input' }, '*');
-                iframe.contentWindow.postMessage({ type: 'openace-tab-activated' }, '*');
+                iframe.contentWindow.postMessage({ type: 'openace-clear-notification-state' }, '*');
               }
             }, 100);
           }
@@ -813,7 +813,7 @@ export const Workspace: React.FC = () => {
         // Send tab-activated message to the previous tab's iframe to clear its internal state
         const prevIframe = iframeRefs.current.get(previousTabId);
         if (prevIframe?.contentWindow) {
-          prevIframe.contentWindow.postMessage({ type: 'openace-tab-activated' }, '*');
+          prevIframe.contentWindow.postMessage({ type: 'openace-clear-notification-state' }, '*');
         }
         // Clear local notification state
         setTabs((prev) =>


### PR DESCRIPTION
This PR fixes two bugs in workspace tab notifications:

**Problem 1: Fallback bug**
- When event.source cannot identify iframe, the code incorrectly used currentActiveTabId as fallback
- This caused notifications to be wrongly assigned to the current active tab
- Fix: Remove the fallback logic - only process notifications when source can be identified

**Problem 2: SwitchTab bug**
- When switching tabs, the openace-tab-activated message was sent to the NEW tab (incorrectly)
- This meant the the tab being LEFT did not receive the clear message
- Result: Notifications appeared on the left tab after AI finished responding
- Fix: Send tab-activated message to the previous tab, and clear its notification state locally

Both issues caused stale notifications showing up when user was actively viewing a tab or after switching away from a tab.

🤖 Generated with Qwen Code (9-shotted by Qwen-Coder)