### PR TITLE
fix: prevent usage_summary row duplication on PostgreSQL

### DIFF
--- a/app/services/summary_service.py
+++ b/app/services/summary_service.py
@@ -113,7 +113,7 @@ class SummaryService:
             query_global = """
                 SELECT
                     tool_name,
-                    NULL as host_name,
+                    '' as host_name,
                     COUNT(DISTINCT date) as days_count,
                     SUM(tokens_used) as total_tokens,
                     SUM(tokens_used) / COUNT(DISTINCT date) as avg_tokens,
@@ -268,10 +268,10 @@ class SummaryService:
             """
             rows = self.db.fetch_all(query, (host_name,))
         else:
-            # Get global summary (host_name IS NULL)
+            # Get global summary (host_name = '' for global rows)
             query = """
                 SELECT * FROM usage_summary
-                WHERE host_name IS NULL
+                WHERE host_name = ''
                 ORDER BY total_tokens DESC
             """
             rows = self.db.fetch_all(query, ())
@@ -308,7 +308,7 @@ class SummaryService:
         """
         query = """
             SELECT * FROM usage_summary
-            WHERE host_name IS NOT NULL
+            WHERE host_name != ''
             ORDER BY host_name, total_tokens DESC
         """
         rows = self.db.fetch_all(query, ())
@@ -376,7 +376,7 @@ class SummaryService:
         query = """
             SELECT DISTINCT host_name
             FROM usage_summary
-            WHERE host_name IS NOT NULL
+            WHERE host_name != ''
             ORDER BY host_name
         """
         rows = self.db.fetch_all(query)


### PR DESCRIPTION
## Problem

Dashboard numbers inflate over time due to `usage_summary` row duplication. Root cause: PostgreSQL btree indexes treat `NULL` as non-equal values, so `ON CONFLICT (tool_name, host_name)` never matches when `host_name IS NULL`. Every scheduler run inserts a new row instead of updating.

## Example

| Metric | With duplicates | Correct |
|--------|----------------|---------|
| QWEN requests | 1,198,467 | 38,724 |
| OPENCLAW requests | 32,147 | 1,037 |
| QWEN tokens | 4.53B | 146.59M |

## Fix

Replace `NULL` with empty string `''` for global (all-hosts combined) rows in `usage_summary`. Changed all queries:

- `NULL as host_name` → `'' as host_name` (in `_calculate_aggregates`)
- `WHERE host_name IS NULL` → `WHERE host_name = ''` (in `get_summary`)
- `WHERE host_name IS NOT NULL` → `WHERE host_name != ''` (in `get_all_hosts_summary`, `get_hosts`)