### PR TITLE
refactor: address third-round review feedback

### DIFF
--- a/app/repositories/usage_repo.py
+++ b/app/repositories/usage_repo.py
@@ -135,11 +135,11 @@ class UsageRepository:
         logger.debug(f"Saved usage: {date} - {tool_name} - {host_name}")
         return True
 
-    def get_today_aggregated(
+    def get_usage_rows_by_date(
         self, date: str, tool_name: Optional[str] = None, host_name: Optional[str] = None
     ) -> list[dict]:
         """
-        Get aggregated usage from daily_usage for a specific date.
+        Get raw usage rows from daily_usage for a specific date.
 
         Queries daily_usage directly (few rows) instead of JOIN with
         daily_messages to avoid request_count multiplication.

--- a/app/services/summary_service.py
+++ b/app/services/summary_service.py
@@ -113,7 +113,7 @@ class SummaryService:
             query_global = """
                 SELECT
                     tool_name,
-                    NULL as host_name,
+                    '' as host_name,
                     COUNT(DISTINCT date) as days_count,
                     SUM(tokens_used) as total_tokens,
                     SUM(tokens_used) / COUNT(DISTINCT date) as avg_tokens,
@@ -172,6 +172,10 @@ class SummaryService:
 
         with self.db.connection() as conn:
             cursor = conn.cursor()
+
+            # Clean up stale NULL host_name rows (prevents accumulation
+            # from older versions that used NULL instead of empty string)
+            cursor.execute("DELETE FROM usage_summary WHERE host_name IS NULL")
 
             for agg in aggregates:
                 tool_name = agg["tool_name"]
@@ -268,10 +272,10 @@ class SummaryService:
             """
             rows = self.db.fetch_all(query, (host_name,))
         else:
-            # Get global summary (host_name IS NULL)
+            # Get global summary (host_name = '' for global rows)
             query = """
                 SELECT * FROM usage_summary
-                WHERE host_name IS NULL
+                WHERE host_name = ''
                 ORDER BY total_tokens DESC
             """
             rows = self.db.fetch_all(query, ())
@@ -308,7 +312,7 @@ class SummaryService:
         """
         query = """
             SELECT * FROM usage_summary
-            WHERE host_name IS NOT NULL
+            WHERE host_name != ''
             ORDER BY host_name, total_tokens DESC
         """
         rows = self.db.fetch_all(query, ())
@@ -376,7 +380,7 @@ class SummaryService:
         query = """
             SELECT DISTINCT host_name
             FROM usage_summary
-            WHERE host_name IS NOT NULL
+            WHERE host_name != ''
             ORDER BY host_name
         """
         rows = self.db.fetch_all(query)

--- a/app/services/usage_service.py
+++ b/app/services/usage_service.py
@@ -47,7 +47,7 @@ class UsageService:
             List[Dict]: List of usage records merged by normalized tool_name.
         """
         today = datetime.now().strftime("%Y-%m-%d")
-        rows = self.usage_repo.get_today_aggregated(today, tool_name, host_name)
+        rows = self.usage_repo.get_usage_rows_by_date(today, tool_name, host_name)
 
         # Aggregate by normalized tool name using dict for deduplication
         merged: dict[str, dict] = {}


### PR DESCRIPTION
## Changes

Addresses remaining items from PR #362 third-round review:

1. **Defensive NULL cleanup** — Added `DELETE FROM usage_summary WHERE host_name IS NULL` at the start of `_update_summary_table()`. Prevents stale rows from accumulating if any code path still writes NULL host_name.

2. **Rename `get_today_aggregated` → `get_usage_rows_by_date`** — The method returns filtered raw rows (no GROUP BY, no SUM), not aggregated results. Aggregation happens in the service layer. Updated docstring to match.

## Related

- PR #362: fix: correct dashboard request count display
- PR #364: fix: prevent usage_summary row duplication on PostgreSQL