### PR TITLE
fix: correct SQL syntax error in status bar query

### DIFF
--- a/app/repositories/usage_repo.py
+++ b/app/repositories/usage_repo.py
@@ -1031,7 +1031,7 @@ class UsageRepository:
                 COALESCE(SUM(
                     (SELECT COUNT(*) FROM session_messages sm
                      WHERE sm.session_id = agent_sessions.session_id
-                       AND sm.role = 'assistant'))
+                       AND sm.role = 'assistant')
                 ), 0) as requests
             FROM agent_sessions
             WHERE user_id = ?


### PR DESCRIPTION
## Problem
The status bar always showed `Token: 0 / 1.00M | Request: 0 / 1,000` regardless of actual usage and quota.

## Root Cause
The `get_combined_usage` method in `usage_repo.py` had an extra closing parenthesis in the remote session SQL subquery, causing PostgreSQL to raise a syntax error. This made `get_workspace_status` fall back to default values (`tokens_limit: 100000`).

## Fix
Remove the extra `)` from the subquery in the remote session usage SQL.

## Testing
- Verified locally: API returns correct quota (e.g., `tokens_limit: 300000000`)
- Deployed to remote server: confirmed `tokens_limit: 500000000` for user with `daily_token_quota=500`