### PR TITLE
feat: Add user settings modal with auto-fullscreen preference (Issue #121)

### DIFF
--- a/frontend/src/components/common/UserSettingsModal.tsx
+++ b/frontend/src/components/common/UserSettingsModal.tsx
@@ -1,9 +1,5 @@
 /**
- * UserSettingsModal Component - User personal settings dialog
- *
- * Features:
- * - Workspace settings (auto fullscreen, tab notifications)
- * - Extensible for future settings (profile, avatar, etc.)
+ * UserSettingsModal - User personal settings dialog
  */
 
 import React from 'react';

--- a/frontend/src/components/common/UserSettingsModal.tsx
+++ b/frontend/src/components/common/UserSettingsModal.tsx
@@ -1,0 +1,84 @@
+/**
+ * UserSettingsModal Component - User personal settings dialog
+ *
+ * Features:
+ * - Workspace settings (auto fullscreen, tab notifications)
+ * - Extensible for future settings (profile, avatar, etc.)
+ */
+
+import React from 'react';
+import { Modal } from './Modal';
+import { useLanguage, useAppStore } from '@/store';
+import { useAutoFullscreenOnEnterChat, useEnableTabNotifications } from '@/store';
+import { t } from '@/i18n';
+
+interface UserSettingsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({ isOpen, onClose }) => {
+  const language = useLanguage();
+  const autoFullscreenOnEnterChat = useAutoFullscreenOnEnterChat();
+  const enableTabNotifications = useEnableTabNotifications();
+  const { toggleAutoFullscreenOnEnterChat, toggleTabNotifications } = useAppStore();
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title={t('personalSettings', language)} size="md">
+      <div className="user-settings">
+        {/* Workspace Settings Section */}
+        <div className="mb-4">
+          <h6 className="text-muted mb-3">
+            <i className="bi bi-window-desktop me-2" />
+            {t('workspaceSettings', language)}
+          </h6>
+
+          {/* Auto fullscreen on enter chat */}
+          <div className="form-check form-switch mb-3 d-flex align-items-start">
+            <input
+              className="form-check-input mt-1"
+              type="checkbox"
+              id="autoFullscreenOnEnterChat"
+              checked={autoFullscreenOnEnterChat}
+              onChange={toggleAutoFullscreenOnEnterChat}
+            />
+            <div className="ms-2">
+              <label className="form-check-label fw-medium" htmlFor="autoFullscreenOnEnterChat">
+                {t('autoFullscreenOnEnterChat', language)}
+              </label>
+              <p className="text-muted small mb-0 mt-1">
+                {t('autoFullscreenOnEnterChatDesc', language)}
+              </p>
+            </div>
+          </div>
+
+          {/* Tab notifications */}
+          <div className="form-check form-switch mb-3 d-flex align-items-start">
+            <input
+              className="form-check-input mt-1"
+              type="checkbox"
+              id="enableTabNotifications"
+              checked={enableTabNotifications}
+              onChange={toggleTabNotifications}
+            />
+            <div className="ms-2">
+              <label className="form-check-label fw-medium" htmlFor="enableTabNotifications">
+                {t('tabNotifications', language)}
+              </label>
+              <p className="text-muted small mb-0 mt-1">{t('tabNotificationsDesc', language)}</p>
+            </div>
+          </div>
+        </div>
+
+        {/* Divider */}
+        <hr className="my-4" />
+
+        {/* Placeholder for future settings */}
+        <div className="text-muted small">
+          <i className="bi bi-person me-2" />
+          {t('moreSettingsComingSoon', language)}
+        </div>
+      </div>
+    </Modal>
+  );
+};

--- a/frontend/src/components/common/index.ts
+++ b/frontend/src/components/common/index.ts
@@ -32,6 +32,7 @@ export { Avatar, AvatarGroup } from './Avatar';
 export { Dropdown, SplitButton } from './Dropdown';
 export { Divider } from './Divider';
 export { SessionDetailContent } from './SessionDetailContent';
+export { UserSettingsModal } from './UserSettingsModal';
 
 // Mode Switcher - Dual-track system
 export { ModeSwitcher } from './ModeSwitcher';

--- a/frontend/src/components/features/Workspace.tsx
+++ b/frontend/src/components/features/Workspace.tsx
@@ -86,7 +86,6 @@ export const Workspace: React.FC = () => {
 
   // Tab notifications setting
   const enableTabNotifications = useEnableTabNotifications();
-  const { toggleTabNotifications } = useAppStore();
 
   // Refs for iframe elements (to send focus messages)
   const iframeRefs = useRef<Map<string, HTMLIFrameElement>>(new Map());
@@ -159,8 +158,11 @@ export const Workspace: React.FC = () => {
   useEffect(() => {
     const handleIframeMessage = (event: MessageEvent) => {
       // Validate message type for fullscreen request
+      // Issue #121: Only auto-fullscreen if setting is enabled
       if (event.data?.type === 'openace-enter-chat') {
-        useAppStore.getState().enterWorkspaceFullscreen(false, false);
+        if (useAppStore.getState().autoFullscreenOnEnterChat) {
+          useAppStore.getState().enterWorkspaceFullscreen(false, false);
+        }
       }
 
       // Listen for session ID update from qwen-code-webui iframe (Issue #65)
@@ -1206,28 +1208,6 @@ export const Workspace: React.FC = () => {
           )}
         </div>
         <div className="d-flex align-items-center gap-2">
-          {/* Tab notifications toggle */}
-          <button
-            className={cn(
-              'btn btn-sm',
-              enableTabNotifications ? 'btn-outline-primary' : 'btn-outline-secondary'
-            )}
-            onClick={toggleTabNotifications}
-            title={
-              enableTabNotifications
-                ? t('disableTabNotifications', language) || 'Disable tab notifications'
-                : t('enableTabNotifications', language) || 'Enable tab notifications'
-            }
-          >
-            <i
-              className={cn('bi me-1', enableTabNotifications ? 'bi-bell-fill' : 'bi-bell-slash')}
-            />
-            <span className="d-none d-sm-inline">
-              {enableTabNotifications
-                ? t('tabNotificationsOn', language) || 'Notifications On'
-                : t('tabNotificationsOff', language) || 'Off'}
-            </span>
-          </button>
           {/* Fullscreen toggle button */}
           <button
             className="btn btn-sm btn-outline-secondary fullscreen-toggle-btn"
@@ -1364,28 +1344,6 @@ export const Workspace: React.FC = () => {
             </button>
           </div>
 
-          {/* Tab notifications toggle - Show in fullscreen mode */}
-          {workspaceFullscreen && (
-            <button
-              className={cn(
-                'btn btn-sm px-3 py-1 mx-2',
-                enableTabNotifications ? 'btn-outline-primary' : 'btn-outline-secondary'
-              )}
-              onClick={toggleTabNotifications}
-              title={
-                enableTabNotifications
-                  ? t('disableTabNotifications', language)
-                  : t('enableTabNotifications', language)
-              }
-            >
-              <i
-                className={cn('bi me-1', enableTabNotifications ? 'bi-bell-fill' : 'bi-bell-slash')}
-              />
-              {enableTabNotifications
-                ? t('tabNotificationsOn', language)
-                : t('tabNotificationsOff', language)}
-            </button>
-          )}
           {/* Exit Fullscreen Button - Only show in fullscreen mode */}
           {workspaceFullscreen && (
             <button

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -2,12 +2,12 @@
  * Header Component - Top navigation header
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import { cn } from '@/utils';
 import { useAuth, useTheme, useLanguage, useGlobalFetch, useAppMode } from '@/hooks';
 import { useAppStore } from '@/store';
 import { t } from '@/i18n';
-import { Button } from '@/components/common';
+import { Button, UserSettingsModal } from '@/components/common';
 
 interface HeaderProps {
   compact?: boolean;
@@ -19,6 +19,7 @@ export const Header: React.FC<HeaderProps> = ({ compact = false }) => {
   const language = useLanguage();
   const appMode = useAppMode();
   const { status, autoRefresh, setAutoRefresh, refreshAll } = useGlobalFetch();
+  const [showSettings, setShowSettings] = useState(false);
 
   const handleThemeToggle = () => {
     const newTheme = theme === 'light' ? 'dark' : 'light';
@@ -114,6 +115,12 @@ export const Header: React.FC<HeaderProps> = ({ compact = false }) => {
               <hr className="dropdown-divider" />
             </li>
             <li>
+              <button className="dropdown-item" onClick={() => setShowSettings(true)}>
+                <i className="bi bi-gear me-2" />
+                {t('settings', language)}
+              </button>
+            </li>
+            <li>
               <button className="dropdown-item" onClick={logout}>
                 <i className="bi bi-box-arrow-right me-2" />
                 {t('logout', language)}
@@ -131,7 +138,12 @@ export const Header: React.FC<HeaderProps> = ({ compact = false }) => {
 
   // In compact mode (WorkLayout), just return the right content without wrapper
   if (compact) {
-    return rightContent;
+    return (
+      <>
+        {rightContent}
+        <UserSettingsModal isOpen={showSettings} onClose={() => setShowSettings(false)} />
+      </>
+    );
   }
 
   // In normal mode (ManageLayout), return full header with left and right content
@@ -184,6 +196,9 @@ export const Header: React.FC<HeaderProps> = ({ compact = false }) => {
 
       {/* Right side */}
       {rightContent}
+
+      {/* User Settings Modal */}
+      <UserSettingsModal isOpen={showSettings} onClose={() => setShowSettings(false)} />
     </header>
   );
 };

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -196,7 +196,8 @@ const translations: Record<Language, Translations> = {
     roleChangeThreshold: 'Role Change Threshold',
     roleChangeThresholdHelp: 'Number of role changes before triggering an anomaly alert',
     permissionChangeThreshold: 'Permission Change Threshold',
-    permissionChangeThresholdHelp: 'Number of permission changes before triggering an anomaly alert',
+    permissionChangeThresholdHelp:
+      'Number of permission changes before triggering an anomaly alert',
 
     // Audit Log
     allActions: 'All Actions',
@@ -517,6 +518,16 @@ const translations: Record<Language, Translations> = {
     complianceReport: 'Compliance Report',
     settings: 'Settings',
 
+    // Personal Settings (Issue #121)
+    personalSettings: 'Personal Settings',
+    workspaceSettings: 'Workspace Settings',
+    autoFullscreenOnEnterChat: 'Auto fullscreen when entering chat',
+    autoFullscreenOnEnterChatDesc:
+      'Automatically enter fullscreen mode when selecting a project to chat',
+    tabNotifications: 'Tab notifications',
+    tabNotificationsDesc: 'Show notifications when other tabs need attention',
+    moreSettingsComingSoon: 'More settings coming soon...',
+
     // Alert Management
     totalAlerts: 'Total Alerts',
     unreadAlerts: 'Unread Alerts',
@@ -598,7 +609,8 @@ const translations: Record<Language, Translations> = {
     roiPercentage: 'ROI %',
     roiDataAnomaly: 'Data anomaly detected',
     dataAnomalyDetected: 'Data Anomaly Detected',
-    tokenAccumulationWarning: 'Token counts may be inflated due to cumulative counting. Cost and ROI calculations may be inaccurate.',
+    tokenAccumulationWarning:
+      'Token counts may be inflated due to cumulative counting. Cost and ROI calculations may be inaccurate.',
     efficiencyScore: 'Efficiency Score',
     roiTrend: 'ROI Trend',
     roi: 'ROI',
@@ -1282,6 +1294,15 @@ const translations: Record<Language, Translations> = {
     complianceReport: '合规报告',
     settings: '设置',
 
+    // Personal Settings (Issue #121)
+    personalSettings: '个人设置',
+    workspaceSettings: '工作区设置',
+    autoFullscreenOnEnterChat: '进入聊天时自动全屏',
+    autoFullscreenOnEnterChatDesc: '选择项目进入聊天时自动进入全屏模式',
+    tabNotifications: '标签页通知',
+    tabNotificationsDesc: '当其他标签页需要关注时显示通知',
+    moreSettingsComingSoon: '更多设置即将推出...',
+
     // Alert Management
     totalAlerts: '总告警数',
     unreadAlerts: '未读告警',
@@ -1958,6 +1979,16 @@ const translations: Record<Language, Translations> = {
     loginError: 'ユーザー名またはパスワードが無効です',
     adminOnly: '管理者のみ',
 
+    // Personal Settings (Issue #121)
+    personalSettings: '個人設定',
+    workspaceSettings: 'ワークスペース設定',
+    autoFullscreenOnEnterChat: 'チャット入時に自動フルスクリーン',
+    autoFullscreenOnEnterChatDesc:
+      'プロジェクトを選択してチャット入時に自動的にフルスクリーンモードに入る',
+    tabNotifications: 'タブ通知',
+    tabNotificationsDesc: '他のタブが注目を必要とする時に通知を表示',
+    moreSettingsComingSoon: '近日中に更多の設定が追加されます...',
+
     // Theme
     lightTheme: 'ライト',
     darkTheme: 'ダーク',
@@ -2431,6 +2462,16 @@ const translations: Record<Language, Translations> = {
     password: '비밀번호',
     loginError: '사용자 이름 또는 비밀번호가 잘못되었습니다',
     adminOnly: '관리자 전용',
+
+    // Personal Settings (Issue #121)
+    personalSettings: '개인 설정',
+    workspaceSettings: '워크스페이스 설정',
+    autoFullscreenOnEnterChat: '채팅 вход 시 자동 전체 화면',
+    autoFullscreenOnEnterChatDesc:
+      '프로젝트를 선택하여 채팅에 입장할 때 자동으로 전체 화면 모드로 전환',
+    tabNotifications: '탭 알림',
+    tabNotificationsDesc: '다른 탭이 주의가 필요할 때 알림 표시',
+    moreSettingsComingSoon: '더 많은 설정이 곧 추가됩니다...',
 
     // Theme
     lightTheme: '라이트',

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -1982,12 +1982,12 @@ const translations: Record<Language, Translations> = {
     // Personal Settings (Issue #121)
     personalSettings: '個人設定',
     workspaceSettings: 'ワークスペース設定',
-    autoFullscreenOnEnterChat: 'チャット入時に自動フルスクリーン',
+    autoFullscreenOnEnterChat: 'チャット入室時に自動フルスクリーン',
     autoFullscreenOnEnterChatDesc:
-      'プロジェクトを選択してチャット入時に自動的にフルスクリーンモードに入る',
+      'プロジェクトを選択してチャットに入室する際に自動的にフルスクリーンモードに入る',
     tabNotifications: 'タブ通知',
     tabNotificationsDesc: '他のタブが注目を必要とする時に通知を表示',
-    moreSettingsComingSoon: '近日中に更多の設定が追加されます...',
+    moreSettingsComingSoon: 'さらに多くの設定が近日公開予定...',
 
     // Theme
     lightTheme: 'ライト',
@@ -2466,7 +2466,7 @@ const translations: Record<Language, Translations> = {
     // Personal Settings (Issue #121)
     personalSettings: '개인 설정',
     workspaceSettings: '워크스페이스 설정',
-    autoFullscreenOnEnterChat: '채팅 вход 시 자동 전체 화면',
+    autoFullscreenOnEnterChat: '채팅 입장 시 자동 전체 화면',
     autoFullscreenOnEnterChatDesc:
       '프로젝트를 선택하여 채팅에 입장할 때 자동으로 전체 화면 모드로 전환',
     tabNotifications: '탭 알림',

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -56,6 +56,9 @@ interface AppState {
   // Tab notification settings
   enableTabNotifications: boolean;
 
+  // Auto fullscreen on enter chat setting (Issue #121)
+  autoFullscreenOnEnterChat: boolean;
+
   // Actions
   setUser: (user: User | null) => void;
   setAuthenticated: (isAuthenticated: boolean) => void;
@@ -83,6 +86,10 @@ interface AppState {
   // Tab notification actions
   setEnableTabNotifications: (enabled: boolean) => void;
   toggleTabNotifications: () => void;
+
+  // Auto fullscreen actions (Issue #121)
+  setAutoFullscreenOnEnterChat: (enabled: boolean) => void;
+  toggleAutoFullscreenOnEnterChat: () => void;
 }
 
 export const useAppStore = create<AppState>()(
@@ -108,6 +115,9 @@ export const useAppStore = create<AppState>()(
 
       // Tab notification settings
       enableTabNotifications: true,
+
+      // Auto fullscreen on enter chat setting (Issue #121)
+      autoFullscreenOnEnterChat: false,
 
       // Actions
       setUser: (user) => set({ user }),
@@ -195,6 +205,11 @@ export const useAppStore = create<AppState>()(
       setEnableTabNotifications: (enabled) => set({ enableTabNotifications: enabled }),
       toggleTabNotifications: () =>
         set((state) => ({ enableTabNotifications: !state.enableTabNotifications })),
+
+      // Auto fullscreen actions (Issue #121)
+      setAutoFullscreenOnEnterChat: (enabled) => set({ autoFullscreenOnEnterChat: enabled }),
+      toggleAutoFullscreenOnEnterChat: () =>
+        set((state) => ({ autoFullscreenOnEnterChat: !state.autoFullscreenOnEnterChat })),
     }),
     {
       name: 'open-ace-store',
@@ -204,6 +219,7 @@ export const useAppStore = create<AppState>()(
         sidebarCollapsed: state.sidebarCollapsed,
         appMode: state.appMode,
         enableTabNotifications: state.enableTabNotifications,
+        autoFullscreenOnEnterChat: state.autoFullscreenOnEnterChat,
         // Issue #65: Persist workspace tabs state
         workspaceTabs: state.workspaceTabs,
         workspaceActiveTabId: state.workspaceActiveTabId,
@@ -222,6 +238,8 @@ export const useSidebarCollapsed = () => useAppStore((state) => state.sidebarCol
 export const useAppMode = () => useAppStore((state) => state.appMode);
 export const useWorkspaceFullscreen = () => useAppStore((state) => state.workspaceFullscreen);
 export const useEnableTabNotifications = () => useAppStore((state) => state.enableTabNotifications);
+export const useAutoFullscreenOnEnterChat = () =>
+  useAppStore((state) => state.autoFullscreenOnEnterChat);
 export const usePreviousPanelState = () =>
   useAppStore((state) => ({
     left: state.previousLeftPanelCollapsed,


### PR DESCRIPTION
## Summary

- Add user settings modal accessible from user avatar menu in header
- Add `autoFullscreenOnEnterChat` setting (default: false) to control workspace fullscreen behavior
- Move tab notifications toggle from Workspace header to user settings modal
- Support i18n translations (en, zh, ja, ko)

## Changes

### New Components
- `UserSettingsModal` - Personal settings dialog with workspace settings section

### Modified Files
- `store/index.ts` - Add `autoFullscreenOnEnterChat` state, actions, and persistence
- `Header.tsx` - Add "Settings" menu item in user dropdown
- `Workspace.tsx` - Respect autoFullscreen setting; remove tab notifications button
- `i18n/index.ts` - Add translations for new settings

### Settings Available
1. **Auto fullscreen when entering chat** (default: off) - Controls whether workspace automatically enters fullscreen when selecting a project
2. **Tab notifications** (default: on) - Controls whether other tabs show notification indicators

## Related Issues

Closes #121

## Test Plan

1. Login and click user avatar → Settings
2. Toggle "Auto fullscreen when entering chat" setting
3. Enter a workspace chat → verify fullscreen behavior matches setting
4. Toggle "Tab notifications" setting
5. Verify tab notification behavior matches setting