### PR TITLE
fix: resolve pre-existing CI lint failures

### DIFF
--- a/app/routes/workspace.py
+++ b/app/routes/workspace.py
@@ -454,16 +454,16 @@ def list_sessions():
                 FROM agent_sessions s
                 WHERE {base_where_clause}
                   AND (
-                    LOWER(s.title) LIKE {p}
-                    OR LOWER(s.session_id) LIKE {p}
+                    LOWER(s.title) LIKE {p}  -- escape_like used
+                    OR LOWER(s.session_id) LIKE {p}  -- escape_like used
                     OR EXISTS (
                       SELECT 1 FROM session_messages sm
                       WHERE sm.session_id = s.session_id
                         AND {time_cond}
-                        AND LOWER(sm.content) LIKE {p}
+                        AND LOWER(sm.content) LIKE {p}  -- escape_like used
                     )
                   )
-            """  # search_pattern uses escape_like(search.lower())
+            """
             count_params = base_params + [search_pattern, search_pattern, search_pattern]
             count_query = adapt_sql(count_sql)
             result = db.fetch_one(count_query, tuple(count_params))
@@ -474,18 +474,18 @@ def list_sessions():
                 FROM agent_sessions s
                 WHERE {base_where_clause}
                   AND (
-                    LOWER(s.title) LIKE {p}
-                    OR LOWER(s.session_id) LIKE {p}
+                    LOWER(s.title) LIKE {p}  -- escape_like used
+                    OR LOWER(s.session_id) LIKE {p}  -- escape_like used
                     OR EXISTS (
                       SELECT 1 FROM session_messages sm
                       WHERE sm.session_id = s.session_id
                         AND {time_cond}
-                        AND LOWER(sm.content) LIKE {p}
+                        AND LOWER(sm.content) LIKE {p}  -- escape_like used
                     )
                   )
                 ORDER BY s.updated_at DESC
                 LIMIT {p} OFFSET {p}
-            """  # search_pattern uses escape_like(search.lower())
+            """
             sessions_params = base_params + [
                 search_pattern,
                 search_pattern,

--- a/frontend/src/api/sessions.ts
+++ b/frontend/src/api/sessions.ts
@@ -51,7 +51,7 @@ export interface SessionFilters {
   status?: string;
   session_type?: string;
   search?: string;
-  search_days?: number;  // Limit message search to recent N days
+  search_days?: number; // Limit message search to recent N days
 }
 
 export interface SessionsListResponse {

--- a/frontend/src/components/features/ConversationHistory.tsx
+++ b/frontend/src/components/features/ConversationHistory.tsx
@@ -8,7 +8,13 @@
 
 import React, { useState, useMemo, useRef, useEffect } from 'react';
 import { cn } from '@/utils';
-import { useConversationHistory, useConversationTimeline, useHosts, useSenders, useTools } from '@/hooks';
+import {
+  useConversationHistory,
+  useConversationTimeline,
+  useHosts,
+  useSenders,
+  useTools,
+} from '@/hooks';
 import { useLanguage } from '@/store';
 import { t, type Language } from '@/i18n';
 import {
@@ -246,7 +252,7 @@ export const ConversationHistory: React.FC = () => {
       visibleCols
         .map((col) => {
           const val = conv[col.key as keyof ConversationHistoryType];
-          return escapeCSV(val != null ? String(val) : '');
+          return escapeCSV(val !== null && val !== undefined ? String(val) : '');
         })
         .join(',')
     );
@@ -353,11 +359,7 @@ export const ConversationHistory: React.FC = () => {
             <div className="d-flex gap-2">
               {/* Export Button */}
               <span title={t('exportCurrentPage', language)}>
-                <Button
-                  variant="outline-secondary"
-                  size="sm"
-                  onClick={handleExportCSV}
-                >
+                <Button variant="outline-secondary" size="sm" onClick={handleExportCSV}>
                   <i className="bi bi-download me-1" />
                   {t('export', language)}
                 </Button>
@@ -428,7 +430,7 @@ export const ConversationHistory: React.FC = () => {
             if (totalPages <= 1) return null;
             const maxVisible = 5;
             let start = Math.max(1, page - Math.floor(maxVisible / 2));
-            let end = Math.min(totalPages, start + maxVisible - 1);
+            const end = Math.min(totalPages, start + maxVisible - 1);
             if (end - start < maxVisible - 1) {
               start = Math.max(1, end - maxVisible + 1);
             }
@@ -449,7 +451,11 @@ export const ConversationHistory: React.FC = () => {
                     </li>
                     {pageNumbers.map((pageNum) => (
                       <li key={pageNum} className={cn('page-item', page === pageNum && 'active')}>
-                        <button type="button" className="page-link" onClick={() => setPage(pageNum)}>
+                        <button
+                          type="button"
+                          className="page-link"
+                          onClick={() => setPage(pageNum)}
+                        >
                           {pageNum}
                         </button>
                       </li>

--- a/frontend/src/components/features/Dashboard.tsx
+++ b/frontend/src/components/features/Dashboard.tsx
@@ -179,7 +179,12 @@ export const Dashboard: React.FC = () => {
           <div className="col-md-8 mb-4">
             <Card title={t('trendChart', language)}>
               {trendData && trendData.length > 0 ? (
-                <TokenTrendChart data={trendData} startDate={startDate} endDate={endDate} height={300} />
+                <TokenTrendChart
+                  data={trendData}
+                  startDate={startDate}
+                  endDate={endDate}
+                  height={300}
+                />
               ) : (
                 <EmptyState icon="bi-graph-up" title={t('noData', language)} />
               )}
@@ -283,9 +288,7 @@ export const Dashboard: React.FC = () => {
                         />
                       )}
                     </th>
-                    <th className="text-end">
-                      {t('tableRatio', language) || 'Ratio'}
-                    </th>
+                    <th className="text-end">{t('tableRatio', language) || 'Ratio'}</th>
                     <th
                       className="text-end sortable"
                       onClick={() => handleSort('days_count')}
@@ -316,7 +319,9 @@ export const Dashboard: React.FC = () => {
                       <td className="text-end">{formatTokens(stats.total_output_tokens ?? 0)}</td>
                       <td className="text-end">
                         {(stats.total_output_tokens ?? 0) > 0
-                          ? ((stats.total_input_tokens ?? 0) / (stats.total_output_tokens ?? 1)).toFixed(1)
+                          ? (
+                              (stats.total_input_tokens ?? 0) / (stats.total_output_tokens ?? 1)
+                            ).toFixed(1)
                           : '-'}
                       </td>
                       <td className="text-end">{stats.days_count}</td>

--- a/frontend/src/components/features/Prompts.tsx
+++ b/frontend/src/components/features/Prompts.tsx
@@ -180,7 +180,12 @@ export const Prompts: React.FC = () => {
       {error && templates.length > 0 && (
         <div className="alert alert-danger alert-dismissible fade show" role="alert">
           {error}
-          <button type="button" className="btn-close" onClick={() => setError(null)} aria-label="Close" />
+          <button
+            type="button"
+            className="btn-close"
+            onClick={() => setError(null)}
+            aria-label="Close"
+          />
         </div>
       )}
 

--- a/frontend/src/components/features/Report.tsx
+++ b/frontend/src/components/features/Report.tsx
@@ -181,7 +181,12 @@ export const Report: React.FC = () => {
         <div className="col-md-8 mb-4">
           <Card title={t('tokenTrend', language)}>
             {chartData.length > 0 ? (
-              <TokenTrendChart data={chartData} startDate={startDate} endDate={endDate} height={300} />
+              <TokenTrendChart
+                data={chartData}
+                startDate={startDate}
+                endDate={endDate}
+                height={300}
+              />
             ) : (
               <EmptyState icon="bi-graph-up" title={t('noData', language)} />
             )}

--- a/frontend/src/components/features/analysis/ROIAnalysis.tsx
+++ b/frontend/src/components/features/analysis/ROIAnalysis.tsx
@@ -393,8 +393,7 @@ export const ROIAnalysis: React.FC = () => {
       {roiMetrics && roiMetrics.roi_percentage < -100 && (
         <div className="alert alert-warning mb-4" role="alert">
           <i className="bi bi-exclamation-triangle me-2" />
-          <strong>{t('dataAnomalyDetected', language) || 'Data Anomaly Detected'}:</strong>
-          {' '}
+          <strong>{t('dataAnomalyDetected', language) || 'Data Anomaly Detected'}:</strong>{' '}
           {t('tokenAccumulationWarning', language) ||
             'Token counts may be inflated due to cumulative counting. Cost and ROI calculations may be inaccurate.'}
         </div>

--- a/frontend/src/components/features/management/AuditCenter.tsx
+++ b/frontend/src/components/features/management/AuditCenter.tsx
@@ -710,10 +710,7 @@ export const AuditCenter: React.FC = () => {
                   </thead>
                   <tbody>
                     {anomalies
-                      .slice(
-                        (anomalyPage - 1) * ANOMALY_PAGE_SIZE,
-                        anomalyPage * ANOMALY_PAGE_SIZE
-                      )
+                      .slice((anomalyPage - 1) * ANOMALY_PAGE_SIZE, anomalyPage * ANOMALY_PAGE_SIZE)
                       .map((anomaly, index) => (
                         <tr
                           key={`${anomaly.anomaly_type}-${index}`}
@@ -728,8 +725,7 @@ export const AuditCenter: React.FC = () => {
                               ? anomaly.affected_users
                                   .map(
                                     (uid) =>
-                                      users?.find((u) => u.id === uid)?.username ??
-                                      `ID:${uid}`
+                                      users?.find((u) => u.id === uid)?.username ?? `ID:${uid}`
                                   )
                                   .join(', ')
                               : '-'}
@@ -741,10 +737,7 @@ export const AuditCenter: React.FC = () => {
                           </td>
                           <td>
                             <span
-                              className={cn(
-                                'badge',
-                                `bg-${getSeverityVariant(anomaly.severity)}`
-                              )}
+                              className={cn('badge', `bg-${getSeverityVariant(anomaly.severity)}`)}
                             >
                               {anomaly.severity}
                             </span>
@@ -757,7 +750,7 @@ export const AuditCenter: React.FC = () => {
                                 'bg-secondary': !anomaly.status || anomaly.status === 'pending',
                               })}
                             >
-                              {t(anomaly.status || 'pending', language)}
+                              {t(anomaly.status ?? 'pending', language)}
                             </span>
                           </td>
                           <td>
@@ -817,30 +810,23 @@ export const AuditCenter: React.FC = () => {
                         const totalPages = Math.ceil(anomalies.length / ANOMALY_PAGE_SIZE);
                         const startPage = Math.max(1, anomalyPage - 2);
                         const endPage = Math.min(totalPages, startPage + 4);
-                        return Array.from(
-                          { length: endPage - startPage + 1 },
-                          (_, i) => {
-                            const pageNum = startPage + i;
-                            return (
-                              <li
-                                key={pageNum}
-                                className={`page-item ${anomalyPage === pageNum ? 'active' : ''}`}
-                              >
-                                <button
-                                  className="page-link"
-                                  onClick={() => setAnomalyPage(pageNum)}
-                                >
-                                  {pageNum}
-                                </button>
-                              </li>
-                            );
-                          }
-                        );
+                        return Array.from({ length: endPage - startPage + 1 }, (_, i) => {
+                          const pageNum = startPage + i;
+                          return (
+                            <li
+                              key={pageNum}
+                              className={`page-item ${anomalyPage === pageNum ? 'active' : ''}`}
+                            >
+                              <button className="page-link" onClick={() => setAnomalyPage(pageNum)}>
+                                {pageNum}
+                              </button>
+                            </li>
+                          );
+                        });
                       })()}
                       <li
                         className={`page-item ${
-                          anomalyPage ===
-                          Math.ceil(anomalies.length / ANOMALY_PAGE_SIZE)
+                          anomalyPage === Math.ceil(anomalies.length / ANOMALY_PAGE_SIZE)
                             ? 'disabled'
                             : ''
                         }`}
@@ -848,10 +834,7 @@ export const AuditCenter: React.FC = () => {
                         <button
                           className="page-link"
                           onClick={() => setAnomalyPage(anomalyPage + 1)}
-                          disabled={
-                            anomalyPage ===
-                            Math.ceil(anomalies.length / ANOMALY_PAGE_SIZE)
-                          }
+                          disabled={anomalyPage === Math.ceil(anomalies.length / ANOMALY_PAGE_SIZE)}
                         >
                           {t('next', language)}
                         </button>
@@ -874,7 +857,9 @@ export const AuditCenter: React.FC = () => {
               <select
                 className="form-select"
                 value={selectedUserId ?? ''}
-                onChange={(e) => setSelectedUserId(e.target.value ? parseInt(e.target.value) : null)}
+                onChange={(e) =>
+                  setSelectedUserId(e.target.value ? parseInt(e.target.value) : null)
+                }
                 disabled={usersLoading}
               >
                 <option value="">-- {t('selectUser', language)} --</option>
@@ -986,9 +971,10 @@ export const AuditCenter: React.FC = () => {
       rows.push([]);
       rows.push(['Anomaly Type', 'Description', 'Severity', 'Affected Users', 'First Seen']);
       anomalies.forEach((a) => {
-        const userNames = a.affected_users
-          ?.map((uid) => users?.find((u) => u.id === uid)?.username ?? `ID:${uid}`)
-          .join('; ') ?? '';
+        const userNames =
+          a.affected_users
+            ?.map((uid) => users?.find((u) => u.id === uid)?.username ?? `ID:${uid}`)
+            .join('; ') ?? '';
         rows.push([a.anomaly_type, a.description, a.severity, userNames, a.first_seen]);
       });
     }

--- a/frontend/src/components/features/management/RemoteMachineManagement.tsx
+++ b/frontend/src/components/features/management/RemoteMachineManagement.tsx
@@ -232,7 +232,9 @@ export const RemoteMachineManagement: React.FC = () => {
 
   // Stats
   const totalMachines = machines.length;
-  const onlineCount = machines.filter((m) => m.status === 'online' || m.status === 'idle' || m.status === 'busy').length;
+  const onlineCount = machines.filter(
+    (m) => m.status === 'online' || m.status === 'idle' || m.status === 'busy'
+  ).length;
   const offlineCount = totalMachines - onlineCount;
 
   if (isLoading) {
@@ -331,8 +333,20 @@ export const RemoteMachineManagement: React.FC = () => {
                     {machine.os_version ? ` ${machine.os_version}` : ''}
                   </td>
                   <td>
-                    <Badge variant={machine.status === 'online' || machine.status === 'idle' || machine.status === 'busy' ? 'success' : 'secondary'}>
-                      {machine.status === 'online' || machine.status === 'idle' || machine.status === 'busy' ? t('online', language) : t('offline', language)}
+                    <Badge
+                      variant={
+                        machine.status === 'online' ||
+                        machine.status === 'idle' ||
+                        machine.status === 'busy'
+                          ? 'success'
+                          : 'secondary'
+                      }
+                    >
+                      {machine.status === 'online' ||
+                      machine.status === 'idle' ||
+                      machine.status === 'busy'
+                        ? t('online', language)
+                        : t('offline', language)}
                     </Badge>
                   </td>
                   <td>{machine.agent_version ?? '-'}</td>
@@ -670,8 +684,18 @@ const MachineDetailsDialog: React.FC<MachineDetailsDialogProps> = ({
         <div className="col-md-6">
           <label className="text-muted small">{t('keyStatus', language)}</label>
           <div>
-            <Badge variant={machine.status === 'online' || machine.status === 'idle' || machine.status === 'busy' ? 'success' : 'secondary'}>
-              {machine.status === 'online' || machine.status === 'idle' || machine.status === 'busy' ? t('online', language) : t('offline', language)}
+            <Badge
+              variant={
+                machine.status === 'online' ||
+                machine.status === 'idle' ||
+                machine.status === 'busy'
+                  ? 'success'
+                  : 'secondary'
+              }
+            >
+              {machine.status === 'online' || machine.status === 'idle' || machine.status === 'busy'
+                ? t('online', language)
+                : t('offline', language)}
             </Badge>
             {machine.connected && (
               <Badge variant="info" className="ms-2">

--- a/frontend/src/components/features/management/TenantManagement.tsx
+++ b/frontend/src/components/features/management/TenantManagement.tsx
@@ -170,8 +170,7 @@ export const TenantManagement: React.FC = () => {
       handleCloseModal();
       fetchTenants();
     } catch (err) {
-      const errorMessage =
-        err instanceof Error ? (err as Error).message : 'Failed to save tenant';
+      const errorMessage = err instanceof Error ? (err as Error).message : 'Failed to save tenant';
       setFormError(errorMessage);
     }
   };
@@ -360,11 +359,11 @@ export const TenantManagement: React.FC = () => {
                                 'progress-bar',
                                 (tenant.total_tokens_used / tenant.quota.monthly_token_limit) *
                                   100 >=
-                                90
+                                  90
                                   ? 'bg-danger'
                                   : (tenant.total_tokens_used / tenant.quota.monthly_token_limit) *
-                                      100 >=
-                                    70
+                                        100 >=
+                                      70
                                     ? 'bg-warning'
                                     : 'bg-success'
                               )}

--- a/frontend/src/components/work/AssistPanel.css
+++ b/frontend/src/components/work/AssistPanel.css
@@ -190,7 +190,10 @@
   opacity: 0;
   visibility: hidden;
   transform: translateY(4px);
-  transition: opacity 0.05s ease, visibility 0.05s ease, transform 0.05s ease;
+  transition:
+    opacity 0.05s ease,
+    visibility 0.05s ease,
+    transform 0.05s ease;
   pointer-events: none;
   margin-top: 6px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
@@ -281,7 +284,7 @@
 }
 
 /* Dark mode support */
-[data-theme="dark"] {
+[data-theme='dark'] {
   .prompt-search .input-group {
     background: var(--bg-secondary);
     border-color: var(--border-color);
@@ -383,7 +386,7 @@
 }
 
 /* Dark mode for prompt detail */
-[data-theme="dark"] .prompt-detail {
+[data-theme='dark'] .prompt-detail {
   .prompt-variables-section {
     background: var(--bg-secondary);
 

--- a/frontend/src/components/work/AssistPanel.tsx
+++ b/frontend/src/components/work/AssistPanel.tsx
@@ -267,18 +267,13 @@ export const AssistPanel: React.FC<AssistPanelProps> = ({ collapsed = false }) =
         <ul className="prompt-list list-unstyled">
           {prompts.map((prompt) => (
             <li key={prompt.id}>
-              <div
-                className="prompt-item"
-                onClick={() => handlePromptClick(prompt)}
-              >
+              <div className="prompt-item" onClick={() => handlePromptClick(prompt)}>
                 {/* Left: Name with tooltip */}
                 <div className="prompt-item-name-wrapper">
                   <span className="prompt-item-name">{prompt.name}</span>
                   {/* Fast CSS tooltip */}
                   <div className="prompt-tooltip-fast">
-                    <div className="prompt-tooltip-content">
-                      {truncateContent(prompt.content)}
-                    </div>
+                    <div className="prompt-tooltip-content">{truncateContent(prompt.content)}</div>
                   </div>
                 </div>
 
@@ -301,11 +296,13 @@ export const AssistPanel: React.FC<AssistPanelProps> = ({ collapsed = false }) =
                   <button
                     className={`prompt-action-btn ${copiedPromptId === prompt.id ? 'copied' : hasRequiredVariables(prompt) ? 'disabled' : 'active'}`}
                     onClick={(e) => handleDirectCopy(e, prompt)}
-                    title={hasRequiredVariables(prompt)
-                      ? (t('fillVariablesFirst', language) || 'Fill variables first')
-                      : copiedPromptId === prompt.id
-                        ? t('copied', language)
-                        : (t('copy', language) || 'Copy')}
+                    title={
+                      hasRequiredVariables(prompt)
+                        ? t('fillVariablesFirst', language) || 'Fill variables first'
+                        : copiedPromptId === prompt.id
+                          ? t('copied', language)
+                          : t('copy', language) || 'Copy'
+                    }
                     disabled={hasRequiredVariables(prompt)}
                   >
                     {copiedPromptId === prompt.id ? (

--- a/frontend/src/components/work/DocumentViewer.tsx
+++ b/frontend/src/components/work/DocumentViewer.tsx
@@ -169,7 +169,7 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({ isOpen, onClose,
               pre: ({ children }) => <pre className="doc-pre">{children}</pre>,
               a: ({ href, children }) => {
                 // Handle anchor links for internal navigation
-                if (href && href.startsWith('#')) {
+                if (href?.startsWith('#')) {
                   const handleClick = (e: React.MouseEvent) => {
                     e.preventDefault();
                     const targetId = href.slice(1);

--- a/frontend/src/components/work/PromptDetailModal.tsx
+++ b/frontend/src/components/work/PromptDetailModal.tsx
@@ -103,7 +103,7 @@ export const PromptDetailModal: React.FC<PromptDetailModalProps> = ({
 
   // Copy content to clipboard and close modal
   const handleCopy = async () => {
-    const contentToCopy = hasVariables && hasRendered ? renderedContent : prompt?.content ?? '';
+    const contentToCopy = hasVariables && hasRendered ? renderedContent : (prompt?.content ?? '');
     if (!contentToCopy) return;
 
     try {
@@ -188,9 +188,7 @@ export const PromptDetailModal: React.FC<PromptDetailModalProps> = ({
                 {t('generate', language)}
               </button>
               {!allRequiredFilled && (
-                <small className="text-muted ms-2">
-                  {t('fillRequiredFirst', language)}
-                </small>
+                <small className="text-muted ms-2">{t('fillRequiredFirst', language)}</small>
               )}
             </div>
           </div>

--- a/frontend/src/components/work/SessionList.tsx
+++ b/frontend/src/components/work/SessionList.tsx
@@ -49,8 +49,8 @@ interface GroupedSessions {
 
 export const SessionList: React.FC<SessionListProps> = ({ collapsed = false, onSelectSession }) => {
   const language = useLanguage();
-  const [searchInput, setSearchInput] = useState('');  // User input in search box
-  const [debouncedSearch, setDebouncedSearch] = useState('');  // Debounced value for API
+  const [searchInput, setSearchInput] = useState(''); // User input in search box
+  const [debouncedSearch, setDebouncedSearch] = useState(''); // Debounced value for API
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Debounce search input
@@ -83,10 +83,12 @@ export const SessionList: React.FC<SessionListProps> = ({ collapsed = false, onS
   } = useSessions({
     page: 1,
     pageSize: 50,
-    filters: debouncedSearch ? {
-      search: debouncedSearch,
-      search_days: DEFAULT_SEARCH_DAYS,
-    } : undefined,
+    filters: debouncedSearch
+      ? {
+          search: debouncedSearch,
+          search_days: DEFAULT_SEARCH_DAYS,
+        }
+      : undefined,
   });
 
   // Auto refresh session list every 1 minute (Issue #64)

--- a/frontend/src/hooks/useMessages.ts
+++ b/frontend/src/hooks/useMessages.ts
@@ -77,8 +77,17 @@ export function useConversationHistory(options: UseConversationHistoryOptions = 
   const { date, startDate, endDate, tool, host, sender, pageSize = 20, page = 1 } = options;
 
   return useQuery({
-    queryKey: ['conversation-history', page, { date, startDate, endDate, tool, host, sender, pageSize }],
-    queryFn: () => messagesApi.getConversationHistory({ date, startDate, endDate, tool, host, sender }, page, pageSize),
+    queryKey: [
+      'conversation-history',
+      page,
+      { date, startDate, endDate, tool, host, sender, pageSize },
+    ],
+    queryFn: () =>
+      messagesApi.getConversationHistory(
+        { date, startDate, endDate, tool, host, sender },
+        page,
+        pageSize
+      ),
     staleTime: 60 * 1000, // 1 minute cache
   });
 }

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -2439,20 +2439,25 @@ link[rel='dns-prefetch'] {
   z-index: 1000;
   opacity: 0;
   visibility: hidden;
-  transition: opacity 0.15s ease, visibility 0.15s ease, transform 0.15s ease;
+  transition:
+    opacity 0.15s ease,
+    visibility 0.15s ease,
+    transform 0.15s ease;
   transition-delay: 0.3s;
   pointer-events: none;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4), 0 2px 8px rgba(0, 0, 0, 0.2);
+  box-shadow:
+    0 8px 32px rgba(0, 0, 0, 0.4),
+    0 2px 8px rgba(0, 0, 0, 0.2);
 }
 
 /* First two session items: show tooltip below instead of above */
-.session-group-items li:nth-child(-n+2) .session-tooltip {
+.session-group-items li:nth-child(-n + 2) .session-tooltip {
   bottom: auto;
   top: calc(100% + 6px);
   transform: translateX(-50%) translateY(-4px);
 }
 
-.session-group-items li:nth-child(-n+2) .session-tooltip::after {
+.session-group-items li:nth-child(-n + 2) .session-tooltip::after {
   top: auto;
   bottom: 100%;
   border-top: none;
@@ -2461,7 +2466,7 @@ link[rel='dns-prefetch'] {
   border-right: 1px solid rgba(255, 255, 255, 0.08);
 }
 
-.session-group-items li:nth-child(-n+2) .session-item:hover .session-tooltip {
+.session-group-items li:nth-child(-n + 2) .session-item:hover .session-tooltip {
   transform: translateX(-50%) translateY(0);
 }
 

--- a/scripts/lint/.sql_baseline
+++ b/scripts/lint/.sql_baseline
@@ -1,9 +1,3 @@
-{"rule": "SQL003", "file": "app/routes/workspace.py", "line": 435, "message": "LIKE query without escape_like() — special characters in user input will be treated as wildcards"}
-{"rule": "SQL003", "file": "app/routes/workspace.py", "line": 436, "message": "LIKE query without escape_like() — special characters in user input will be treated as wildcards"}
-{"rule": "SQL003", "file": "app/routes/workspace.py", "line": 455, "message": "LIKE query without escape_like() — special characters in user input will be treated as wildcards"}
-{"rule": "SQL003", "file": "app/routes/workspace.py", "line": 456, "message": "LIKE query without escape_like() — special characters in user input will be treated as wildcards"}
-{"rule": "SQL003", "file": "app/routes/workspace.py", "line": 475, "message": "LIKE query without escape_like() — special characters in user input will be treated as wildcards"}
-{"rule": "SQL003", "file": "app/routes/workspace.py", "line": 476, "message": "LIKE query without escape_like() — special characters in user input will be treated as wildcards"}
 {"rule": "SQL003", "file": "scripts/fetch_claude.py", "line": 728, "message": "LIKE query without escape_like() — special characters in user input will be treated as wildcards"}
 {"rule": "SQL001", "file": "scripts/shared/db.py", "line": 1485, "message": "Boolean value converted to int variable 'is_active_val' — use adapt_boolean_value() or adapt_boolean_condition()"}
 {"rule": "SQL001", "file": "scripts/shared/db.py", "line": 1486, "message": "Boolean value converted to int variable 'must_change_val' — use adapt_boolean_value() or adapt_boolean_condition()"}


### PR DESCRIPTION
## Summary
- Frontend: run `prettier --write` and `eslint --fix` on 14 files to fix formatting and lint errors
- Frontend: fix `eqeqeq` rule (`!=` → `!==`) in `ConversationHistory.tsx`
- Frontend: fix `prefer-nullish-coalescing` rule (`||` → `??`) in `AuditCenter.tsx`
- Backend: suppress SQL003 false positives in `workspace.py` with inline comments
- Update SQL baseline to remove already-fixed `workspace.py` entries

## Test plan
- [ ] CI Lint and lint jobs pass
- [ ] Type Check passes
- [ ] No functional changes — only formatting/lint fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)