### PR TITLE
fix: apply ESLint suggestions for null checks

### DIFF
--- a/frontend/src/components/features/ConversationHistory.tsx
+++ b/frontend/src/components/features/ConversationHistory.tsx
@@ -252,7 +252,7 @@ export const ConversationHistory: React.FC = () => {
       visibleCols
         .map((col) => {
           const val = conv[col.key as keyof ConversationHistoryType];
-          return escapeCSV(val !== null && val !== undefined ? String(val) : '');
+          return escapeCSV(val != null ? String(val) : '');
         })
         .join(',')
     );

--- a/frontend/src/components/features/management/AuditCenter.tsx
+++ b/frontend/src/components/features/management/AuditCenter.tsx
@@ -750,7 +750,7 @@ export const AuditCenter: React.FC = () => {
                                 'bg-secondary': !anomaly.status || anomaly.status === 'pending',
                               })}
                             >
-                              {t(anomaly.status ?? 'pending', language)}
+                              {t(anomaly.status || 'pending', language)}
                             </span>
                           </td>
                           <td>


### PR DESCRIPTION
## Summary
- `ConversationHistory.tsx`: simplify `!== null && !== undefined` to `!= null`
- `AuditCenter.tsx`: use `||` instead of `??` for string status fallback

Extracted from PR #373 (avatar feature) to keep its scope clean.

## Test plan
- [ ] Verify ConversationHistory CSV export still works correctly
- [ ] Verify AuditCenter anomaly status display still shows correct fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)