### PR TITLE
fix: 提示词列表 tooltip 遮挡、滚动条、数据同步

### DIFF
--- a/frontend/src/components/features/Prompts.tsx
+++ b/frontend/src/components/features/Prompts.tsx
@@ -5,7 +5,14 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import { cn } from '@/utils';
 import { promptsApi } from '@/api';
-import type { PromptTemplate, PromptVariable, CategoryInfo } from '@/api';
+import type { PromptTemplate, PromptVariable } from '@/api';
+import {
+  usePrompts,
+  usePromptCategories,
+  useCreatePrompt,
+  useUpdatePrompt,
+  useDeletePrompt,
+} from '@/hooks';
 import { useLanguage } from '@/store';
 import { t, type Language } from '@/i18n';
 import {
@@ -37,62 +44,36 @@ const categoryColors: Record<string, BadgeVariant> = {
 
 export const Prompts: React.FC = () => {
   const language = useLanguage() as Language;
-  const [templates, setTemplates] = useState<PromptTemplate[]>([]);
-  const [categories, setCategories] = useState<CategoryInfo[]>([]);
-  const [total, setTotal] = useState(0);
   const [page, setPage] = useState(1);
-  const [isLoading, setIsLoading] = useState(true);
-  const [isFetching, setIsFetching] = useState(false);
-  const [error, setError] = useState<string | null>(null);
   const [filters, setFilters] = useState<{ category?: string; search?: string }>({});
   const [selectedTemplate, setSelectedTemplate] = useState<PromptTemplate | null>(null);
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [showEditModal, setShowEditModal] = useState(false);
   const [showRenderModal, setShowRenderModal] = useState(false);
   const [renderResult, setRenderResult] = useState<string | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
 
-  // Load categories on mount
+  // React Query hooks
+  const { data: categories = [] } = usePromptCategories();
+  const {
+    data: promptsData,
+    isLoading,
+    error: queryError,
+  } = usePrompts({
+    ...filters,
+    page,
+    limit: ITEMS_PER_PAGE,
+  });
+  const deleteMutation = useDeletePrompt();
+
+  const templates = promptsData?.templates ?? [];
+  const total = promptsData?.total ?? 0;
+  const error = deleteError || queryError?.message || null;
+
+  // Reset page when filters change
   useEffect(() => {
-    const loadCategories = async () => {
-      try {
-        const cats = await promptsApi.getCategories();
-        setCategories(cats);
-      } catch (err) {
-        console.error('Failed to load categories:', err);
-      }
-    };
-    loadCategories();
-  }, []);
-
-  // Load templates
-  const loadTemplates = async (resetPage = false) => {
-    try {
-      setIsFetching(true);
-      setError(null);
-      const currentPage = resetPage ? 1 : page;
-      if (resetPage) setPage(1);
-
-      const result = await promptsApi.list({
-        ...filters,
-        page: currentPage,
-        limit: ITEMS_PER_PAGE,
-      });
-
-      setTemplates(result.templates);
-      setTotal(result.total);
-    } catch (err) {
-      const error = err as Error;
-      setError(error?.message || t('error', language));
-    } finally {
-      setIsLoading(false);
-      setIsFetching(false);
-    }
-  };
-
-  // Load on mount and when filters change
-  useEffect(() => {
-    loadTemplates(true);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    setPage(1);
+    setSelectedTemplate(null);
   }, [filters.category, filters.search]);
 
   // Category options
@@ -110,7 +91,6 @@ export const Prompts: React.FC = () => {
   // Handlers
   const handleFilterChange = (key: string, value: string) => {
     setFilters((prev) => ({ ...prev, [key]: value || undefined }));
-    setSelectedTemplate(null);
   };
 
   const handleSearch = (value: string) => {
@@ -132,26 +112,23 @@ export const Prompts: React.FC = () => {
       return;
     }
     try {
-      await promptsApi.delete(id);
-      loadTemplates();
+      setDeleteError(null);
+      await deleteMutation.mutateAsync(id);
       if (selectedTemplate?.id === id) {
         setSelectedTemplate(null);
       }
     } catch {
-      setError(t('deletePromptFailed', language) || 'Failed to delete prompt');
+      setDeleteError(t('deletePromptFailed', language) || 'Failed to delete prompt');
     }
   };
 
   const handleCreateSuccess = () => {
     setShowCreateModal(false);
-    loadTemplates();
   };
 
   const handleEditSuccess = () => {
     setShowEditModal(false);
-    loadTemplates();
     if (selectedTemplate) {
-      // Refresh selected template
       promptsApi.get(selectedTemplate.id).then(setSelectedTemplate);
     }
   };
@@ -162,7 +139,7 @@ export const Prompts: React.FC = () => {
       setRenderResult(result);
     } catch (err) {
       const error = err as Error;
-      setError(error?.message || t('error', language));
+      setDeleteError(error?.message || t('error', language));
     }
   };
 
@@ -171,7 +148,7 @@ export const Prompts: React.FC = () => {
   }
 
   if (error && templates.length === 0) {
-    return <Error message={error} onRetry={() => loadTemplates()} />;
+    return <Error message={error} onRetry={() => setFilters({})} />;
   }
 
   return (
@@ -183,7 +160,7 @@ export const Prompts: React.FC = () => {
           <button
             type="button"
             className="btn-close"
-            onClick={() => setError(null)}
+            onClick={() => setDeleteError(null)}
             aria-label="Close"
           />
         </div>
@@ -200,15 +177,6 @@ export const Prompts: React.FC = () => {
             icon={<i className="bi bi-plus-lg" />}
           >
             {t('addPrompt', language) || 'Add Prompt'}
-          </Button>
-          <Button
-            variant="outline-secondary"
-            size="sm"
-            onClick={() => loadTemplates()}
-            loading={isFetching}
-            icon={isFetching ? undefined : <i className="bi bi-arrow-clockwise" />}
-          >
-            {t('refresh', language)}
           </Button>
         </div>
       </div>
@@ -283,10 +251,7 @@ export const Prompts: React.FC = () => {
                 variant="outline-secondary"
                 size="sm"
                 disabled={page === 1}
-                onClick={() => {
-                  setPage(page - 1);
-                  loadTemplates();
-                }}
+                onClick={() => setPage(page - 1)}
               >
                 {t('previous', language)}
               </Button>
@@ -297,10 +262,7 @@ export const Prompts: React.FC = () => {
                 variant="outline-secondary"
                 size="sm"
                 disabled={page >= Math.ceil(total / ITEMS_PER_PAGE)}
-                onClick={() => {
-                  setPage(page + 1);
-                  loadTemplates();
-                }}
+                onClick={() => setPage(page + 1)}
               >
                 {t('next', language)}
               </Button>
@@ -467,8 +429,11 @@ const PromptFormModal: React.FC<PromptFormModalProps> = ({
   const [tags, setTags] = useState(template?.tags.join(', ') ?? '');
   const [isPublic, setIsPublic] = useState(template?.is_public ?? false);
   const [variables, setVariables] = useState<PromptVariable[]>(template?.variables ?? []);
-  const [isLoading, setIsLoading] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  const createMutation = useCreatePrompt();
+  const updateMutation = useUpdatePrompt();
 
   const isEdit = !!template;
 
@@ -494,7 +459,7 @@ const PromptFormModal: React.FC<PromptFormModalProps> = ({
     }
 
     try {
-      setIsLoading(true);
+      setIsSubmitting(true);
       setError(null);
 
       const data = {
@@ -511,9 +476,9 @@ const PromptFormModal: React.FC<PromptFormModalProps> = ({
       };
 
       if (isEdit && template) {
-        await promptsApi.update(template.id, data);
+        await updateMutation.mutateAsync({ id: template.id, data });
       } else {
-        await promptsApi.create(data);
+        await createMutation.mutateAsync(data);
       }
 
       onSuccess();
@@ -521,7 +486,7 @@ const PromptFormModal: React.FC<PromptFormModalProps> = ({
       const error = err as Error;
       setError(error?.message || t('error', language));
     } finally {
-      setIsLoading(false);
+      setIsSubmitting(false);
     }
   };
 
@@ -693,7 +658,7 @@ const PromptFormModal: React.FC<PromptFormModalProps> = ({
           <Button type="button" variant="outline-secondary" onClick={onClose}>
             {t('cancel', language)}
           </Button>
-          <Button type="submit" variant="primary" loading={isLoading}>
+          <Button type="submit" variant="primary" loading={isSubmitting}>
             {isEdit ? t('save', language) : t('create', language) || 'Create'}
           </Button>
         </div>

--- a/frontend/src/components/features/Prompts.tsx
+++ b/frontend/src/components/features/Prompts.tsx
@@ -70,7 +70,7 @@ export const Prompts: React.FC = () => {
 
   const templates = promptsData?.templates ?? [];
   const total = promptsData?.total ?? 0;
-  const error = actionError || queryError?.message || null;
+  const error = actionError || (queryError?.message ?? null);
 
   // Reset page when filters change
   useEffect(() => {

--- a/frontend/src/components/features/Prompts.tsx
+++ b/frontend/src/components/features/Prompts.tsx
@@ -70,7 +70,7 @@ export const Prompts: React.FC = () => {
 
   const templates = promptsData?.templates ?? [];
   const total = promptsData?.total ?? 0;
-  const error = actionError || (queryError?.message ?? null);
+  const error = actionError ?? queryError?.message ?? null;
 
   // Reset page when filters change
   useEffect(() => {

--- a/frontend/src/components/features/Prompts.tsx
+++ b/frontend/src/components/features/Prompts.tsx
@@ -51,13 +51,15 @@ export const Prompts: React.FC = () => {
   const [showEditModal, setShowEditModal] = useState(false);
   const [showRenderModal, setShowRenderModal] = useState(false);
   const [renderResult, setRenderResult] = useState<string | null>(null);
-  const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
 
   // React Query hooks
   const { data: categories = [] } = usePromptCategories();
   const {
     data: promptsData,
     isLoading,
+    isFetching,
+    refetch,
     error: queryError,
   } = usePrompts({
     ...filters,
@@ -68,7 +70,7 @@ export const Prompts: React.FC = () => {
 
   const templates = promptsData?.templates ?? [];
   const total = promptsData?.total ?? 0;
-  const error = deleteError || queryError?.message || null;
+  const error = actionError || queryError?.message || null;
 
   // Reset page when filters change
   useEffect(() => {
@@ -112,13 +114,13 @@ export const Prompts: React.FC = () => {
       return;
     }
     try {
-      setDeleteError(null);
+      setActionError(null);
       await deleteMutation.mutateAsync(id);
       if (selectedTemplate?.id === id) {
         setSelectedTemplate(null);
       }
     } catch {
-      setDeleteError(t('deletePromptFailed', language) || 'Failed to delete prompt');
+      setActionError(t('deletePromptFailed', language) || 'Failed to delete prompt');
     }
   };
 
@@ -139,7 +141,7 @@ export const Prompts: React.FC = () => {
       setRenderResult(result);
     } catch (err) {
       const error = err as Error;
-      setDeleteError(error?.message || t('error', language));
+      setActionError(error?.message || t('error', language));
     }
   };
 
@@ -160,7 +162,7 @@ export const Prompts: React.FC = () => {
           <button
             type="button"
             className="btn-close"
-            onClick={() => setDeleteError(null)}
+            onClick={() => setActionError(null)}
             aria-label="Close"
           />
         </div>
@@ -177,6 +179,15 @@ export const Prompts: React.FC = () => {
             icon={<i className="bi bi-plus-lg" />}
           >
             {t('addPrompt', language) || 'Add Prompt'}
+          </Button>
+          <Button
+            variant="outline-secondary"
+            size="sm"
+            onClick={() => refetch()}
+            loading={isFetching}
+            icon={isFetching ? undefined : <i className="bi bi-arrow-clockwise" />}
+          >
+            {t('refresh', language)}
           </Button>
         </div>
       </div>

--- a/frontend/src/components/work/AssistPanel.css
+++ b/frontend/src/components/work/AssistPanel.css
@@ -95,10 +95,10 @@
   }
 }
 
-/* Prompt List - Full height like session list */
+/* Prompt List */
 .prompt-list {
   flex: 1;
-  overflow-y: auto;
+  overflow-y: overlay;
   overflow-x: hidden;
   scrollbar-width: thin;
   padding: var(--spacing-xs) 0;
@@ -141,12 +141,6 @@
     .prompt-item-name {
       color: var(--color-primary);
     }
-
-    .prompt-tooltip-fast {
-      opacity: 1;
-      visibility: visible;
-      transform: translateY(0);
-    }
   }
 
   &:active {
@@ -154,11 +148,10 @@
   }
 }
 
-/* Prompt Item Name with Tooltip */
+/* Prompt Item Name */
 .prompt-item-name-wrapper {
   flex: 1;
   min-width: 0;
-  position: relative;
 }
 
 .prompt-item-name {
@@ -173,48 +166,7 @@
   transition: color var(--transition-fast);
 }
 
-/* Fast CSS Tooltip - Show below to avoid being clipped at top */
-.prompt-tooltip-fast {
-  position: absolute;
-  top: 100%;
-  left: 0;
-  z-index: 1000;
-  min-width: 200px;
-  max-width: 280px;
-  padding: 8px 12px;
-  background: var(--bg-tooltip, #212529);
-  color: white;
-  border-radius: var(--border-radius);
-  font-size: 12px;
-  line-height: 1.4;
-  opacity: 0;
-  visibility: hidden;
-  transform: translateY(4px);
-  transition:
-    opacity 0.05s ease,
-    visibility 0.05s ease,
-    transform 0.05s ease;
-  pointer-events: none;
-  margin-top: 6px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
-
-  /* Arrow pointing up */
-  &::before {
-    content: '';
-    position: absolute;
-    bottom: 100%;
-    left: 12px;
-    border: 6px solid transparent;
-    border-bottom-color: var(--bg-tooltip, #212529);
-  }
-}
-
-.prompt-tooltip-content {
-  white-space: pre-wrap;
-  word-break: break-word;
-}
-
-/* Prompt Item Actions - Fixed position */
+/* Prompt Item Actions */
 .prompt-item-actions {
   display: flex;
   gap: 4px;
@@ -309,14 +261,6 @@
 
     &:hover {
       background: var(--bg-hover);
-    }
-  }
-
-  .prompt-tooltip-fast {
-    background: var(--bg-tooltip);
-
-    &::before {
-      border-bottom-color: var(--bg-tooltip);
     }
   }
 }

--- a/frontend/src/components/work/AssistPanel.css
+++ b/frontend/src/components/work/AssistPanel.css
@@ -98,9 +98,10 @@
 /* Prompt List */
 .prompt-list {
   flex: 1;
-  overflow-y: overlay;
+  overflow-y: auto;
   overflow-x: hidden;
   scrollbar-width: thin;
+  scrollbar-gutter: stable;
   padding: var(--spacing-xs) 0;
 
   &::-webkit-scrollbar {

--- a/frontend/src/components/work/AssistPanel.tsx
+++ b/frontend/src/components/work/AssistPanel.tsx
@@ -224,11 +224,7 @@ export const AssistPanel: React.FC<AssistPanelProps> = ({ collapsed = false }) =
             <li key={prompt.id}>
               <div className="prompt-item" onClick={() => handlePromptClick(prompt)}>
                 {/* Left: Name with tooltip */}
-                <Tooltip
-                  content={truncateContent(prompt.content)}
-                  placement="bottom"
-                  delay={100}
-                >
+                <Tooltip content={truncateContent(prompt.content)} placement="bottom" delay={100}>
                   <div className="prompt-item-name-wrapper">
                     <span className="prompt-item-name">{prompt.name}</span>
                   </div>

--- a/frontend/src/components/work/AssistPanel.tsx
+++ b/frontend/src/components/work/AssistPanel.tsx
@@ -160,7 +160,7 @@ export const AssistPanel: React.FC<AssistPanelProps> = ({ collapsed = false }) =
 
     try {
       await navigator.clipboard.writeText(prompt.content);
-      copyPromptMutation.mutate(prompt.id);
+      await copyPromptMutation.mutateAsync(prompt.id);
       setCopiedPromptId(prompt.id);
       setTimeout(() => setCopiedPromptId(null), 1500);
       toast.success(t('copied', language), prompt.name);

--- a/frontend/src/components/work/AssistPanel.tsx
+++ b/frontend/src/components/work/AssistPanel.tsx
@@ -10,9 +10,9 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { useLanguage } from '@/store';
 import { t } from '@/i18n';
-import { promptsApi } from '@/api';
-import type { PromptTemplate, CategoryInfo } from '@/api/prompts';
-import { Loading, EmptyState, SimpleTabs, useToast } from '@/components/common';
+import { usePrompts, usePromptCategories, useCopyPrompt } from '@/hooks';
+import type { PromptTemplate } from '@/api/prompts';
+import { Loading, EmptyState, SimpleTabs, useToast, Tooltip } from '@/components/common';
 import { DocumentViewer } from './DocumentViewer';
 import { PromptDetailModal } from './PromptDetailModal';
 import './AssistPanel.css';
@@ -28,18 +28,16 @@ export const AssistPanel: React.FC<AssistPanelProps> = ({ collapsed = false }) =
   const language = useLanguage();
   const toast = useToast();
   const [activeTab, setActiveTab] = useState('prompts');
-  const [prompts, setPrompts] = useState<PromptTemplate[]>([]);
-  const [categories, setCategories] = useState<CategoryInfo[]>([]);
   const [selectedCategory, setSelectedCategory] = useState<string>('');
   const [searchInput, setSearchInput] = useState('');
   const [debouncedSearch, setDebouncedSearch] = useState('');
-  const [promptsLoading, setPromptsLoading] = useState(true);
   const [docViewerOpen, setDocViewerOpen] = useState(false);
   const [selectedDocId, setSelectedDocId] = useState<string>('');
   const [selectedPrompt, setSelectedPrompt] = useState<PromptTemplate | null>(null);
   const [promptModalOpen, setPromptModalOpen] = useState(false);
   const [copiedPromptId, setCopiedPromptId] = useState<number | null>(null);
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const copyPromptMutation = useCopyPrompt();
 
   // Debounce search input
   useEffect(() => {
@@ -56,55 +54,17 @@ export const AssistPanel: React.FC<AssistPanelProps> = ({ collapsed = false }) =
     };
   }, [searchInput]);
 
-  // Fetch categories
-  useEffect(() => {
-    const fetchCategories = async () => {
-      try {
-        const result = await promptsApi.getCategories();
-        setCategories(result);
-      } catch (err) {
-        console.error('Failed to fetch categories:', err);
-      }
-    };
-    fetchCategories();
-  }, []);
+  // Fetch categories via React Query
+  const { data: categories = [] } = usePromptCategories();
 
-  // Fetch prompts
-  useEffect(() => {
-    const fetchPrompts = async () => {
-      try {
-        setPromptsLoading(true);
-        const result = await promptsApi.list({
-          page: 1,
-          limit: 100, // Show all prompts
-          category: selectedCategory || undefined,
-          search: debouncedSearch || undefined,
-        });
-        // Already sorted by use_count DESC from backend
-        setPrompts(result.templates);
-      } catch (err) {
-        console.error('Failed to fetch prompts:', err);
-      } finally {
-        setPromptsLoading(false);
-      }
-    };
-    fetchPrompts();
-  }, [selectedCategory, debouncedSearch]);
-
-  // Refetch prompts after copy (to update use_count order)
-  const refetchPrompts = async () => {
-    try {
-      const result = await promptsApi.list({
-        page: 1,
-        limit: 100,
-        category: selectedCategory || undefined,
-        search: debouncedSearch || undefined,
-      });
-      setPrompts(result.templates);
-    } catch (err) {
-      console.error('Failed to refetch prompts:', err);
-    }
-  };
+  // Fetch prompts via React Query
+  const { data: promptsData, isLoading: promptsLoading } = usePrompts({
+    page: 1,
+    limit: 100,
+    category: selectedCategory || undefined,
+    search: debouncedSearch || undefined,
+  });
+  const prompts = promptsData?.templates ?? [];
 
   // AI Tools list
   const aiTools = [
@@ -196,19 +156,14 @@ export const AssistPanel: React.FC<AssistPanelProps> = ({ collapsed = false }) =
   // Direct copy (for prompts without required variables)
   const handleDirectCopy = async (e: React.MouseEvent, prompt: PromptTemplate) => {
     e.stopPropagation();
-    if (hasRequiredVariables(prompt)) return; // Cannot copy directly
+    if (hasRequiredVariables(prompt)) return;
 
     try {
       await navigator.clipboard.writeText(prompt.content);
-      // Increment use count
-      await promptsApi.copy(prompt.id);
-      // Show copied feedback on button
+      copyPromptMutation.mutate(prompt.id);
       setCopiedPromptId(prompt.id);
       setTimeout(() => setCopiedPromptId(null), 1500);
-      // Show toast
       toast.success(t('copied', language), prompt.name);
-      // Refetch to update order
-      refetchPrompts();
     } catch (err) {
       console.error('Failed to copy:', err);
       toast.error(t('copyFailed', language) || 'Copy failed');
@@ -269,13 +224,15 @@ export const AssistPanel: React.FC<AssistPanelProps> = ({ collapsed = false }) =
             <li key={prompt.id}>
               <div className="prompt-item" onClick={() => handlePromptClick(prompt)}>
                 {/* Left: Name with tooltip */}
-                <div className="prompt-item-name-wrapper">
-                  <span className="prompt-item-name">{prompt.name}</span>
-                  {/* Fast CSS tooltip */}
-                  <div className="prompt-tooltip-fast">
-                    <div className="prompt-tooltip-content">{truncateContent(prompt.content)}</div>
+                <Tooltip
+                  content={truncateContent(prompt.content)}
+                  placement="bottom"
+                  delay={100}
+                >
+                  <div className="prompt-item-name-wrapper">
+                    <span className="prompt-item-name">{prompt.name}</span>
                   </div>
-                </div>
+                </Tooltip>
 
                 {/* Right: Action buttons */}
                 <div className="prompt-item-actions">
@@ -394,7 +351,6 @@ export const AssistPanel: React.FC<AssistPanelProps> = ({ collapsed = false }) =
         isOpen={promptModalOpen}
         onClose={() => setPromptModalOpen(false)}
         prompt={selectedPrompt}
-        onCopySuccess={refetchPrompts}
       />
     </div>
   );

--- a/frontend/src/components/work/PromptDetailModal.tsx
+++ b/frontend/src/components/work/PromptDetailModal.tsx
@@ -7,23 +7,23 @@ import { useLanguage } from '@/store';
 import { t } from '@/i18n';
 import { promptsApi } from '@/api';
 import type { PromptTemplate, PromptVariable } from '@/api/prompts';
+import { useCopyPrompt } from '@/hooks';
 import { Modal, useToast } from '@/components/common';
 
 interface PromptDetailModalProps {
   isOpen: boolean;
   onClose: () => void;
   prompt: PromptTemplate | null;
-  onCopySuccess?: () => void;
 }
 
 export const PromptDetailModal: React.FC<PromptDetailModalProps> = ({
   isOpen,
   onClose,
   prompt,
-  onCopySuccess,
 }) => {
   const language = useLanguage();
   const toast = useToast();
+  const copyPromptMutation = useCopyPrompt();
   const [variableValues, setVariableValues] = useState<Record<string, string>>({});
   const [renderedContent, setRenderedContent] = useState<string>('');
   const [isRendering, setIsRendering] = useState(false);
@@ -87,11 +87,7 @@ export const PromptDetailModal: React.FC<PromptDetailModalProps> = ({
       const result = await promptsApi.render(prompt.id, variableValues);
       setRenderedContent(result);
       setHasRendered(true);
-      // Also increment use count via copy API
-      await promptsApi.copy(prompt.id);
-      if (onCopySuccess) {
-        onCopySuccess();
-      }
+      copyPromptMutation.mutate(prompt.id);
       toast.success(t('copied', language));
     } catch (err) {
       console.error('Failed to render prompt:', err);
@@ -108,16 +104,10 @@ export const PromptDetailModal: React.FC<PromptDetailModalProps> = ({
 
     try {
       await navigator.clipboard.writeText(contentToCopy);
-      // Increment use count and show toast
       if (prompt) {
-        await promptsApi.copy(prompt.id);
-        if (onCopySuccess) {
-          onCopySuccess();
-        }
+        copyPromptMutation.mutate(prompt.id);
       }
-      // Show copied state first
       setCopied(true);
-      // Close modal after delay so user can see the feedback
       setTimeout(() => {
         onClose();
       }, 800);

--- a/frontend/src/components/work/PromptDetailModal.tsx
+++ b/frontend/src/components/work/PromptDetailModal.tsx
@@ -87,7 +87,7 @@ export const PromptDetailModal: React.FC<PromptDetailModalProps> = ({
       const result = await promptsApi.render(prompt.id, variableValues);
       setRenderedContent(result);
       setHasRendered(true);
-      copyPromptMutation.mutate(prompt.id);
+      await copyPromptMutation.mutateAsync(prompt.id);
       toast.success(t('copied', language));
     } catch (err) {
       console.error('Failed to render prompt:', err);
@@ -105,7 +105,7 @@ export const PromptDetailModal: React.FC<PromptDetailModalProps> = ({
     try {
       await navigator.clipboard.writeText(contentToCopy);
       if (prompt) {
-        copyPromptMutation.mutate(prompt.id);
+        await copyPromptMutation.mutateAsync(prompt.id);
       }
       setCopied(true);
       setTimeout(() => {

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -81,6 +81,15 @@ export {
   useResumeRemoteSession,
 } from './useRemote';
 
+export {
+  usePrompts,
+  usePromptCategories,
+  useCreatePrompt,
+  useUpdatePrompt,
+  useDeletePrompt,
+  useCopyPrompt,
+} from './usePrompts';
+
 // Re-export store hooks
 export {
   useUser,

--- a/frontend/src/hooks/usePrompts.ts
+++ b/frontend/src/hooks/usePrompts.ts
@@ -1,0 +1,68 @@
+/**
+ * Prompts Hooks - Custom hooks for prompt template operations
+ */
+
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { promptsApi } from '@/api';
+import type { PromptFilters, CreatePromptRequest, UpdatePromptRequest } from '@/api';
+
+export function usePrompts(filters?: PromptFilters) {
+  return useQuery({
+    queryKey: ['prompts', filters],
+    queryFn: () => promptsApi.list(filters),
+    staleTime: 30 * 1000,
+  });
+}
+
+export function usePromptCategories() {
+  return useQuery({
+    queryKey: ['prompts', 'categories'],
+    queryFn: () => promptsApi.getCategories(),
+    staleTime: 5 * 60 * 1000,
+  });
+}
+
+export function useCreatePrompt() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (data: CreatePromptRequest) => promptsApi.create(data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['prompts'] });
+    },
+  });
+}
+
+export function useUpdatePrompt() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, data }: { id: number; data: UpdatePromptRequest }) =>
+      promptsApi.update(id, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['prompts'] });
+    },
+  });
+}
+
+export function useDeletePrompt() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: number) => promptsApi.delete(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['prompts'] });
+    },
+  });
+}
+
+export function useCopyPrompt() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: number) => promptsApi.copy(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['prompts'] });
+    },
+  });
+}

--- a/frontend/src/hooks/usePrompts.ts
+++ b/frontend/src/hooks/usePrompts.ts
@@ -8,7 +8,7 @@ import type { PromptFilters, CreatePromptRequest, UpdatePromptRequest } from '@/
 
 export function usePrompts(filters?: PromptFilters) {
   return useQuery({
-    queryKey: ['prompts', filters],
+    queryKey: ['prompts', filters?.category, filters?.search, filters?.page, filters?.limit],
     queryFn: () => promptsApi.list(filters),
     staleTime: 30 * 1000,
   });


### PR DESCRIPTION
## Summary
- 修复提示词列表 hover tooltip 被父容器 `overflow: hidden` 裁剪的问题，改用通用 Tooltip 组件（`createPortal` 到 `document.body`）
- 修复只有一个提示词时仍显示滚动条的问题（`overflow-y: overlay`）
- 修复管理页面增删改提示词后右侧 AssistPanel 不会自动刷新的问题，引入 React Query 共享缓存

## Changes
- **新建** `frontend/src/hooks/usePrompts.ts` — React Query hooks（usePrompts, usePromptCategories, useCreatePrompt, useUpdatePrompt, useDeletePrompt, useCopyPrompt）
- **改造** `AssistPanel.tsx` — 使用 React Query hooks + 通用 Tooltip 组件
- **改造** `Prompts.tsx` — 使用 React Query hooks，mutation 自动 invalidation
- **清理** `AssistPanel.css` — 删除废弃的 CSS tooltip 样式，修复滚动条

Closes #375

## Test plan
- [ ] 启动前端，验证右侧面板 hover tooltip 正常显示，不被裁剪
- [ ] 验证只有1个提示词时无滚动条
- [ ] 在管理页面新增/删除提示词，验证右侧面板自动更新
- [ ] 验证多提示词时列表可正常滚动

🤖 Generated with [Claude Code](https://claude.com/claude-code)