### PR TITLE
fix(sql): fix syntax error in get_user_daily_detail query

### DIFF
--- a/app/repositories/usage_repo.py
+++ b/app/repositories/usage_repo.py
@@ -1093,7 +1093,7 @@ class UsageRepository:
                 SUM(
                     (SELECT COUNT(*) FROM session_messages sm
                      WHERE sm.session_id = s.session_id
-                       AND sm.role = 'assistant'))
+                       AND sm.role = 'assistant')
                 ) as request_count
             FROM agent_sessions s
             WHERE s.user_id = ?


### PR DESCRIPTION
## Summary
- Fix SQL syntax error in `get_user_daily_detail` function
- Remove extra closing parenthesis in SUM subquery for request_count
- This was causing `sqlite3.OperationalError: near ")": syntax error` in E2E tests

## Changes
- Fixed `app/repositories/usage_repo.py` line 1096: removed extra `)` in SQL query

## Testing
- E2E tests should now pass without SQLite syntax errors