### PR TITLE
fix: add build dependencies check before installing Python packages

### DIFF
--- a/scripts/install-central/package-method/install.sh
+++ b/scripts/install-central/package-method/install.sh
@@ -190,6 +190,56 @@ check_build_dependencies() {
     print_success "Build dependencies installed"
 }
 
+
+# Check and install build dependencies on remote system (for deploy mode)
+check_build_dependencies_remote() {
+    local remote="$1"
+    print_info "Checking build dependencies on $remote..."
+
+    local missing_deps=""
+    local has_gcc=$(ssh "$remote" "command -v gcc >/dev/null 2>&1 && echo yes || echo no")
+    local has_make=$(ssh "$remote" "command -v make >/dev/null 2>&1 && echo yes || echo no")
+
+    # Determine remote package manager and python-dev package name
+    local remote_pkg=$(ssh "$remote" "command -v apt-get >/dev/null 2>&1 && echo apt || (command -v dnf >/dev/null 2>&1 && echo dnf) || (command -v yum >/dev/null 2>&1 && echo yum) || echo unknown")
+    local python_dev_pkg="python3-devel"
+    [ "$remote_pkg" = "apt" ] && python_dev_pkg="python3-dev"
+
+    # Check Python.h existence on remote
+    local has_python_h=$(ssh "$remote" 'python3 -c "import sysconfig,os; print(\"yes\" if os.path.exists(sysconfig.get_config_var(\"INCLUDEPY\")+\"/Python.h\") else \"no\")" 2>/dev/null || echo no')
+
+    # Build missing deps list
+    [ "$has_gcc" = "no" ] && missing_deps="$missing_deps gcc"
+    [ "$has_make" = "no" ] && missing_deps="$missing_deps make"
+    [ "$has_python_h" = "no" ] && missing_deps="$missing_deps $python_dev_pkg"
+    missing_deps=$(echo "$missing_deps" | sed 's/^ *//')
+
+    if [ -z "$missing_deps" ]; then
+        print_success "Build dependencies already installed on $remote"
+        return 0
+    fi
+
+    print_info "Missing build dependencies on $remote: $missing_deps"
+    print_info "Installing build dependencies on $remote..."
+
+    ssh "$remote" "
+        if [ '$remote_pkg' = 'apt' ]; then
+            sudo apt-get update -qq && sudo apt-get install -y $missing_deps
+        elif [ '$remote_pkg' = 'dnf' ]; then
+            sudo dnf install -y $missing_deps
+        elif [ '$remote_pkg' = 'yum' ]; then
+            sudo yum install -y $missing_deps
+        else
+            echo 'ERROR: Unsupported package manager on remote'
+            exit 1
+        fi
+    " || {
+        print_error "Failed to install build dependencies on $remote"
+        print_info "Please ensure sudo is available on remote, or install manually: $missing_deps"
+        return 1
+    }
+    print_success "Build dependencies installed on $remote"
+}
 # ============================================================================
 # User Detection and Creation
 # ============================================================================
@@ -3155,6 +3205,9 @@ do_fresh_install_remote() {
 
     # Create config directory
     ssh "$remote" "mkdir -p '~/.open-ace'"
+
+    # Check build dependencies before installing Python packages (gevent, bcrypt need gcc)
+    check_build_dependencies_remote "$remote"
 
     # Install Python dependencies
     print_info "Installing Python dependencies on remote..."

--- a/scripts/install-central/package-method/install.sh
+++ b/scripts/install-central/package-method/install.sh
@@ -241,6 +241,80 @@ check_build_dependencies_remote() {
     print_success "Build dependencies installed on $remote"
 }
 # ============================================================================
+
+# Check and install PostgreSQL client (psql) for schema execution
+check_psql_client() {
+    print_info "Checking PostgreSQL client (psql)..."
+    
+    # Check if psql is available
+    if command -v psql >/dev/null 2>&1; then
+        print_success "psql client already installed"
+        return 0
+    fi
+    
+    print_info "psql client not found, installing..."
+    
+    # Check if running as root
+    if [ "$EUID" -ne 0 ]; then
+        print_error "Root privileges required to install PostgreSQL client"
+        print_info "Please install manually:"
+        print_info "  CentOS/RHEL/Rocky: yum install postgresql"
+        print_info "  Ubuntu/Debian: apt install postgresql-client"
+        return 1
+    fi
+    
+    # Install PostgreSQL client based on OS
+    if command -v apt-get >/dev/null 2>&1; then
+        apt-get update -qq && apt-get install -y postgresql-client
+    elif command -v dnf >/dev/null 2>&1; then
+        dnf install -y postgresql
+    elif command -v yum >/dev/null 2>&1; then
+        yum install -y postgresql
+    else
+        print_error "Unsupported package manager"
+        return 1
+    fi
+    
+    print_success "PostgreSQL client installed"
+}
+
+# Check and install PostgreSQL client on remote system (for deploy mode)
+check_psql_client_remote() {
+    local remote="$1"
+    print_info "Checking PostgreSQL client on $remote..."
+    
+    # Check if psql is available on remote
+    local has_psql=$(ssh "$remote" "command -v psql >/dev/null 2>&1 && echo yes || echo no")
+    
+    if [ "$has_psql" = "yes" ]; then
+        print_success "psql client already installed on $remote"
+        return 0
+    fi
+    
+    print_info "psql client not found on $remote, installing..."
+    
+    # Determine remote package manager
+    local remote_pkg=$(ssh "$remote" "command -v apt-get >/dev/null 2>&1 && echo apt || (command -v dnf >/dev/null 2>&1 && echo dnf) || (command -v yum >/dev/null 2>&1 && echo yum) || echo unknown")
+    
+    ssh "$remote" "
+        if [ '$remote_pkg' = 'apt' ]; then
+            sudo apt-get update -qq && sudo apt-get install -y postgresql-client
+        elif [ '$remote_pkg' = 'dnf' ]; then
+            sudo dnf install -y postgresql
+        elif [ '$remote_pkg' = 'yum' ]; then
+            sudo yum install -y postgresql
+        else
+            echo 'ERROR: Unsupported package manager on remote'
+            exit 1
+        fi
+    " || {
+        print_error "Failed to install PostgreSQL client on $remote"
+        print_info "Please ensure sudo is available on remote, or install manually"
+        return 1
+    }
+    
+    print_success "PostgreSQL client installed on $remote"
+}
 # User Detection and Creation
 # ============================================================================
 
@@ -2785,6 +2859,8 @@ do_fresh_install() {
     local schema_file=""
     if [ "$db_type" = "postgresql" ]; then
         schema_file="$target_path/schema/schema-postgres.sql"
+        # Check psql client before executing schema
+        check_psql_client
     else
         schema_file="$target_path/schema/schema-sqlite.sql"
     fi
@@ -3208,6 +3284,8 @@ do_fresh_install_remote() {
 
     # Check build dependencies before installing Python packages (gevent, bcrypt need gcc)
     check_build_dependencies_remote "$remote"
+    # Check PostgreSQL client for schema execution
+    check_psql_client_remote "$remote"
 
     # Install Python dependencies
     print_info "Installing Python dependencies on remote..."

--- a/scripts/install-central/package-method/install.sh
+++ b/scripts/install-central/package-method/install.sh
@@ -123,6 +123,73 @@ check_python_version_remote() {
     return 0
 }
 
+
+# ============================================================================
+# Build Dependencies Check
+# ============================================================================
+
+# Check and install build dependencies (gcc, python-dev) for packages like gevent, bcrypt
+# These packages require C compilation and will fail without proper build tools
+check_build_dependencies() {
+    print_info "Checking build dependencies..."
+    local missing_deps=()
+    local python_dev_pkg=""
+
+    # Check gcc
+    if ! command -v gcc &>/dev/null; then
+        missing_deps+=("gcc")
+    fi
+
+    # Check make (required by gevent's libev configure)
+    if ! command -v make &>/dev/null; then
+        missing_deps+=("make")
+    fi
+
+    # Determine python-dev package name based on OS
+    if command -v apt-get &>/dev/null; then
+        python_dev_pkg="python3-dev"
+    elif command -v dnf &>/dev/null || command -v yum &>/dev/null; then
+        python_dev_pkg="python3-devel"
+    fi
+
+    # Check Python development headers
+    local python_include=$(python3 -c "import sysconfig; print(sysconfig.get_config_var('INCLUDEPY'))" 2>/dev/null)
+    if [ -n "$python_include" ] && [ ! -f "$python_include/Python.h" ]; then
+        if [ -n "$python_dev_pkg" ]; then
+            missing_deps+=("$python_dev_pkg")
+        fi
+    fi
+
+    # All dependencies satisfied
+    if [ ${#missing_deps[@]} -eq 0 ]; then
+        print_success "Build dependencies already installed"
+        return 0
+    fi
+
+    print_info "Missing build dependencies: ${missing_deps[*]}"
+
+    # Check if running as root
+    if [ "$EUID" -ne 0 ]; then
+        print_error "Root privileges required to install: ${missing_deps[*]}"
+        print_info "Please run as root, or install manually"
+        return 1
+    fi
+
+    # Install missing dependencies
+    print_info "Installing build dependencies..."
+    if command -v apt-get &>/dev/null; then
+        apt-get update -qq && apt-get install -y ${missing_deps[*]}
+    elif command -v dnf &>/dev/null; then
+        dnf install -y ${missing_deps[*]}
+    elif command -v yum &>/dev/null; then
+        yum install -y ${missing_deps[*]}
+    else
+        print_error "Unsupported package manager"
+        return 1
+    fi
+    print_success "Build dependencies installed"
+}
+
 # ============================================================================
 # User Detection and Creation
 # ============================================================================
@@ -2560,6 +2627,9 @@ do_fresh_install() {
         fi
     fi
 
+    # Check build dependencies before installing Python packages (gevent, bcrypt need gcc)
+    check_build_dependencies
+
     # Install Python dependencies
     print_info "Installing Python dependencies..."
 
@@ -2920,6 +2990,9 @@ with open('$config_dir/config.json', 'w') as f:
         fi
         update_config_workspace "$config_dir/config.json" "$webui_path"
     fi
+
+    # Check build dependencies before installing Python packages (gevent, bcrypt need gcc)
+    check_build_dependencies
 
     # Install Python dependencies
     print_info "Installing Python dependencies..."


### PR DESCRIPTION
## 问题描述

在 node236 上执行 install.sh 安装 Open ACE 时，Python 依赖安装失败：

```
ERROR: Could not build wheels for gevent
configure: error: no acceptable C compiler found in $PATH
```

## 问题原因

- gevent 和 bcrypt 需要编译 C 扩展 (libev/libuv)
- install.sh 未检测和安装编译依赖 (gcc, make, python3-devel)
- 缺少编译工具导致 pip 编译失败

## 修复方案

添加 `check_build_dependencies()` 函数：
- 检测 gcc、make 是否存在
- 检测 Python 开发头文件 (Python.h)
- 根据系统类型确定包名 (python3-dev / python3-devel)
- 自动安装缺失依赖（如果以 root 运行）

在安装 Python 依赖前调用该函数。

## 修改的文件

| 文件 | 修改内容 |
|------|----------|
| scripts/install-central/package-method/install.sh | 添加 `check_build_dependencies()` 函数，在 `do_fresh_install()` 和升级安装流程中调用 |

## 测试

脚本语法验证通过：`bash -n install.sh`

Closes #384
