### PR TITLE
feat: add mobile hamburger menu to toggle sidebar

### DIFF
--- a/frontend/e2e/accessibility.spec.ts
+++ b/frontend/e2e/accessibility.spec.ts
@@ -3,7 +3,7 @@
  */
 
 import { test, expect } from '@playwright/test';
-import { login, waitForApp } from './helpers';
+import { login, waitForApp, ensureSidebarVisible } from './helpers';
 
 test.describe('Accessibility', () => {
   test.beforeEach(async ({ page }) => {
@@ -22,6 +22,7 @@ test.describe('Accessibility', () => {
 
   test('should have navigation landmark', async ({ page }) => {
     await waitForApp(page);
+    await ensureSidebarVisible(page);
     const nav = page.locator('nav.sidebar');
     await expect(nav).toBeVisible({ timeout: 10000 });
   });

--- a/frontend/e2e/helpers.ts
+++ b/frontend/e2e/helpers.ts
@@ -38,3 +38,18 @@ export async function waitForApp(page: Page) {
   // Wait for main content to be visible
   await page.locator('main').waitFor({ state: 'visible', timeout: 10000 }).catch(() => {});
 }
+
+/**
+ * Open the sidebar on mobile viewports by clicking the hamburger button.
+ * On desktop viewports, the sidebar is always visible so this is a no-op.
+ */
+export async function ensureSidebarVisible(page: Page) {
+  const viewport = page.viewportSize();
+  if (viewport && viewport.width < 768) {
+    const hamburger = page.locator('.hamburger-btn');
+    if (await hamburger.isVisible()) {
+      await hamburger.click();
+      await page.locator('nav.sidebar').waitFor({ state: 'visible', timeout: 5000 });
+    }
+  }
+}

--- a/frontend/e2e/navigation.spec.ts
+++ b/frontend/e2e/navigation.spec.ts
@@ -3,7 +3,7 @@
  */
 
 import { test, expect } from '@playwright/test';
-import { login, waitForApp } from './helpers';
+import { login, waitForApp, ensureSidebarVisible } from './helpers';
 
 test.describe('Navigation', () => {
   test.beforeEach(async ({ page }) => {
@@ -12,12 +12,14 @@ test.describe('Navigation', () => {
 
   test('should display sidebar navigation', async ({ page }) => {
     await waitForApp(page);
+    await ensureSidebarVisible(page);
     const sidebar = page.locator('nav.sidebar').first();
     await expect(sidebar).toBeVisible({ timeout: 10000 });
   });
 
   test('should navigate to messages page', async ({ page }) => {
     await waitForApp(page);
+    await ensureSidebarVisible(page);
 
     // Find and click messages link (second nav item)
     const messagesLink = page.locator('nav.sidebar .nav-item:nth-child(2) .nav-link').first();
@@ -33,6 +35,7 @@ test.describe('Navigation', () => {
 
   test('should navigate to analysis page', async ({ page }) => {
     await waitForApp(page);
+    await ensureSidebarVisible(page);
 
     // Find and click analysis link (third nav item)
     const analysisLink = page.locator('nav.sidebar .nav-item:nth-child(3) .nav-link').first();
@@ -51,12 +54,11 @@ test.describe('Navigation', () => {
     await page.setViewportSize({ width: 375, height: 667 });
     await waitForApp(page);
 
-    // Find menu toggle button in header
-    const menuToggle = page.locator('.header button:has(.bi-list)').first();
+    // Click hamburger button to open sidebar
+    const menuToggle = page.locator('.hamburger-btn');
 
     if (await menuToggle.isVisible()) {
       await menuToggle.click();
-      await page.waitForTimeout(500);
 
       // Sidebar should be visible after toggle
       const sidebar = page.locator('nav.sidebar').first();

--- a/frontend/e2e/navigation.spec.ts
+++ b/frontend/e2e/navigation.spec.ts
@@ -65,4 +65,32 @@ test.describe('Navigation', () => {
       await expect(sidebar).toBeVisible();
     }
   });
+
+  test('should open and close sidebar via hamburger and overlay on mobile', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 667 });
+    await waitForApp(page);
+
+    const hamburger = page.locator('.hamburger-btn');
+    const sidebar = page.locator('nav.sidebar').first();
+    const overlay = page.locator('.sidebar-overlay');
+
+    // Open via hamburger
+    await expect(hamburger).toBeVisible();
+    await hamburger.click();
+    await expect(sidebar).toBeVisible();
+    await expect(overlay).toBeVisible();
+
+    // Close via overlay click
+    await overlay.click();
+    await expect(sidebar).not.toBeVisible();
+
+    // Open again
+    await hamburger.click();
+    await expect(sidebar).toBeVisible();
+
+    // Close via nav item click
+    const navLink = sidebar.locator('.nav-item .nav-link').first();
+    await navLink.click();
+    await expect(sidebar).not.toBeVisible();
+  });
 });

--- a/frontend/e2e/workspace.spec.ts
+++ b/frontend/e2e/workspace.spec.ts
@@ -7,7 +7,7 @@
  */
 
 import { test, expect } from '@playwright/test';
-import { login, waitForApp } from './helpers';
+import { login, waitForApp, ensureSidebarVisible } from './helpers';
 
 test.describe('Workspace Page', () => {
   test.beforeEach(async ({ page }) => {
@@ -75,6 +75,7 @@ test.describe('Workspace Page - Navigation', () => {
 
   test('should navigate to workspace from sidebar', async ({ page }) => {
     await waitForApp(page);
+    await ensureSidebarVisible(page);
 
     // Find workspace link in sidebar (8th nav item)
     const workspaceLink = page.locator('nav.sidebar .nav-item:nth-child(8) .nav-link').first();

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -48,8 +48,6 @@ export default defineConfig({
   },
 
   // Configure projects for major browsers
-  // Mobile viewports excluded from CI — sidebar is hidden on mobile (< 768px),
-  // causing consistent E2E failures. Run locally with: npx playwright test --project="Mobile Chrome"
   projects: [
     {
       name: 'chromium',
@@ -63,18 +61,15 @@ export default defineConfig({
       name: 'webkit',
       use: { ...devices['Desktop Safari'] },
     },
-    ...(!process.env.CI
-      ? [
-          {
-            name: 'Mobile Chrome',
-            use: { ...devices['Pixel 5'] },
-          },
-          {
-            name: 'Mobile Safari',
-            use: { ...devices['iPhone 12'] },
-          },
-        ]
-      : []),
+    // Mobile viewports — sidebar available via hamburger menu toggle
+    {
+      name: 'Mobile Chrome',
+      use: { ...devices['Pixel 5'] },
+    },
+    {
+      name: 'Mobile Safari',
+      use: { ...devices['iPhone 12'] },
+    },
   ],
 
   // Run local dev server before starting tests

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -153,8 +153,15 @@ export const Header: React.FC<HeaderProps> = ({ compact = false }) => {
   // In normal mode (ManageLayout), return full header with left and right content
   return (
     <header className="header">
-      {/* Left side - Refresh controls (only in manage mode) */}
+      {/* Left side - Hamburger + Refresh controls */}
       <div className="d-flex align-items-center">
+        <button
+          className="hamburger-btn d-md-none btn btn-link p-0 me-2"
+          onClick={() => useAppStore.getState().toggleMobileSidebar()}
+          aria-label="Toggle menu"
+        >
+          <i className="bi bi-list fs-4" />
+        </button>
         {showRefreshControls && (
           <>
             {/* Global Auto-refresh toggle */}

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -2,9 +2,10 @@
  * Layout Component - Main application layout
  */
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import { cn } from '@/utils';
-import { useSidebarCollapsed } from '@/store';
+import { useSidebarCollapsed, useMobileSidebarOpen } from '@/store';
+import { useAppStore } from '@/store';
 import { Sidebar } from './Sidebar';
 import { Header } from './Header';
 
@@ -17,10 +18,21 @@ interface LayoutProps {
 
 export const Layout: React.FC<LayoutProps> = ({ children, activeSection, onNavigate }) => {
   const collapsed = useSidebarCollapsed();
+  const mobileOpen = useMobileSidebarOpen();
+
+  useEffect(() => {
+    document.body.classList.toggle('sidebar-mobile-open', mobileOpen);
+    return () => document.body.classList.remove('sidebar-mobile-open');
+  }, [mobileOpen]);
+
+  const closeMobileSidebar = () => {
+    useAppStore.getState().setMobileSidebarOpen(false);
+  };
 
   return (
     <div className={cn('app-layout', collapsed && 'sidebar-collapsed')}>
-      <Sidebar activeSection={activeSection} onNavigate={onNavigate} />
+      <Sidebar activeSection={activeSection} onNavigate={onNavigate} mobileOpen={mobileOpen} />
+      {mobileOpen && <div className="sidebar-overlay" onClick={closeMobileSidebar} />}
       <div className="main-content d-flex flex-column">
         <Header />
         <main className="content-area flex-grow-1 p-3">{children}</main>

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -2,7 +2,7 @@
  * Layout Component - Main application layout
  */
 
-import React, { useEffect } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { cn } from '@/utils';
 import { useSidebarCollapsed, useMobileSidebarOpen } from '@/store';
 import { useAppStore } from '@/store';
@@ -20,14 +20,31 @@ export const Layout: React.FC<LayoutProps> = ({ children, activeSection, onNavig
   const collapsed = useSidebarCollapsed();
   const mobileOpen = useMobileSidebarOpen();
 
+  const closeMobileSidebar = useCallback(() => {
+    useAppStore.getState().setMobileSidebarOpen(false);
+  }, []);
+
   useEffect(() => {
     document.body.classList.toggle('sidebar-mobile-open', mobileOpen);
     return () => document.body.classList.remove('sidebar-mobile-open');
   }, [mobileOpen]);
 
-  const closeMobileSidebar = () => {
-    useAppStore.getState().setMobileSidebarOpen(false);
-  };
+  useEffect(() => {
+    if (!mobileOpen) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') closeMobileSidebar();
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [mobileOpen, closeMobileSidebar]);
+
+  useEffect(() => {
+    const handleResize = () => {
+      if (window.innerWidth >= 768) closeMobileSidebar();
+    };
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, [closeMobileSidebar]);
 
   return (
     <div className={cn('app-layout', collapsed && 'sidebar-collapsed')}>

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -31,9 +31,10 @@ const navItems: NavItem[] = [
 interface SidebarProps {
   activeSection: string;
   onNavigate: (section: string) => void;
+  mobileOpen?: boolean;
 }
 
-export const Sidebar: React.FC<SidebarProps> = ({ activeSection, onNavigate }) => {
+export const Sidebar: React.FC<SidebarProps> = ({ activeSection, onNavigate, mobileOpen }) => {
   const collapsed = useSidebarCollapsed();
   const language = useLanguage();
   const { user } = useAuth();
@@ -42,6 +43,7 @@ export const Sidebar: React.FC<SidebarProps> = ({ activeSection, onNavigate }) =
 
   const handleNavClick = (id: string, href?: string, disabled?: boolean) => {
     if (disabled) return;
+    useAppStore.getState().setMobileSidebarOpen(false);
     if (href) {
       window.location.href = href;
     } else {
@@ -54,7 +56,13 @@ export const Sidebar: React.FC<SidebarProps> = ({ activeSection, onNavigate }) =
   };
 
   return (
-    <nav className={cn('sidebar bg-dark text-white', collapsed ? 'sidebar-collapsed' : '')}>
+    <nav
+      className={cn(
+        'sidebar bg-dark text-white',
+        collapsed && 'sidebar-collapsed',
+        mobileOpen && 'show'
+      )}
+    >
       {/* Logo */}
       <div className="sidebar-header p-3 border-bottom border-secondary">
         <div className="d-flex align-items-center">

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -137,7 +137,7 @@ export const useAppStore = create<AppState>()(
       toggleSidebar: () => set((state) => ({ sidebarCollapsed: !state.sidebarCollapsed })),
       setSidebarCollapsed: (sidebarCollapsed) => set({ sidebarCollapsed }),
       toggleMobileSidebar: () => set((state) => ({ sidebarMobileOpen: !state.sidebarMobileOpen })),
-      setMobileSidebarOpen: (sidebarMobileOpen) => set({ sidebarMobileOpen }),
+      setMobileSidebarOpen: (open) => set({ sidebarMobileOpen: open }),
       setAppMode: (appMode) => set({ appMode }),
       logout: () =>
         set({

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -42,6 +42,7 @@ interface AppState {
   theme: Theme;
   language: Language;
   sidebarCollapsed: boolean;
+  sidebarMobileOpen: boolean;
   appMode: AppMode;
 
   // Workspace fullscreen state
@@ -67,6 +68,8 @@ interface AppState {
   setLanguage: (language: Language) => void;
   toggleSidebar: () => void;
   setSidebarCollapsed: (collapsed: boolean) => void;
+  toggleMobileSidebar: () => void;
+  setMobileSidebarOpen: (open: boolean) => void;
   setAppMode: (mode: AppMode) => void;
   logout: () => void;
 
@@ -102,6 +105,7 @@ export const useAppStore = create<AppState>()(
       theme: 'light',
       language: 'en',
       sidebarCollapsed: false,
+      sidebarMobileOpen: false,
       appMode: 'work',
 
       // Workspace fullscreen state
@@ -132,6 +136,8 @@ export const useAppStore = create<AppState>()(
       setLanguage: (language) => set({ language }),
       toggleSidebar: () => set((state) => ({ sidebarCollapsed: !state.sidebarCollapsed })),
       setSidebarCollapsed: (sidebarCollapsed) => set({ sidebarCollapsed }),
+      toggleMobileSidebar: () => set((state) => ({ sidebarMobileOpen: !state.sidebarMobileOpen })),
+      setMobileSidebarOpen: (sidebarMobileOpen) => set({ sidebarMobileOpen }),
       setAppMode: (appMode) => set({ appMode }),
       logout: () =>
         set({
@@ -235,6 +241,7 @@ export const useAuthLoading = () => useAppStore((state) => state.authLoading);
 export const useTheme = () => useAppStore((state) => state.theme);
 export const useLanguage = () => useAppStore((state) => state.language);
 export const useSidebarCollapsed = () => useAppStore((state) => state.sidebarCollapsed);
+export const useMobileSidebarOpen = () => useAppStore((state) => state.sidebarMobileOpen);
 export const useAppMode = () => useAppStore((state) => state.appMode);
 export const useWorkspaceFullscreen = () => useAppStore((state) => state.workspaceFullscreen);
 export const useEnableTabNotifications = () => useAppStore((state) => state.enableTabNotifications);

--- a/frontend/src/styles/responsive.css
+++ b/frontend/src/styles/responsive.css
@@ -113,6 +113,11 @@ body.sidebar-mobile-open {
   color: var(--color-primary);
 }
 
+.hamburger-btn:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
 /* Dashboard cards - Stack vertically with spacing */
 .dashboard .row,
 .messages .row,

--- a/frontend/src/styles/responsive.css
+++ b/frontend/src/styles/responsive.css
@@ -77,7 +77,6 @@ body {
 
 /* Mobile overlay for sidebar */
 .sidebar-overlay {
-  display: none;
   position: fixed;
   inset: 0;
   background: var(--bg-overlay);
@@ -86,8 +85,8 @@ body {
   animation: fadeIn 0.2s ease-out;
 }
 
-.sidebar.show + .sidebar-overlay {
-  display: block;
+body.sidebar-mobile-open {
+  overflow: hidden;
 }
 
 /* Header adjustments */
@@ -98,6 +97,20 @@ body {
 .header-title {
   font-size: 1.125rem;
   font-weight: var(--font-weight-semibold);
+}
+
+/* Hamburger button for mobile sidebar toggle */
+.hamburger-btn {
+  color: var(--text-primary);
+  font-size: 1.5rem;
+  line-height: 1;
+  border: none;
+  cursor: pointer;
+  padding: 0.25rem;
+}
+
+.hamburger-btn:hover {
+  color: var(--color-primary);
 }
 
 /* Dashboard cards - Stack vertically with spacing */


### PR DESCRIPTION
## Summary
- Add hamburger button in header for mobile viewports (<768px) to toggle sidebar as slide-in overlay
- Activate existing CSS infrastructure (`.sidebar.show`, `.sidebar-overlay`) from React layer
- Restore Mobile Chrome/Safari E2E projects in CI (previously excluded in PR #386)

## Changes
| File | Change |
|------|--------|
| `store/index.ts` | Add `sidebarMobileOpen` state + `toggleMobileSidebar`/`setMobileSidebarOpen` actions |
| `Sidebar.tsx` | Accept `mobileOpen` prop, toggle `show` class, close sidebar on nav click |
| `Layout.tsx` | Render overlay div, lock body scroll when sidebar open |
| `Header.tsx` | Add hamburger button (`d-md-none`) for non-compact mode |
| `responsive.css` | Add `.hamburger-btn` styles, body scroll lock, fix overlay CSS |
| `e2e/helpers.ts` | Add `ensureSidebarVisible()` helper for mobile tests |
| `e2e/*.spec.ts` | Update accessibility, navigation, workspace tests for mobile |
| `playwright.config.ts` | Restore Mobile Chrome/Safari projects |

## Test plan
- [ ] Desktop: sidebar visible as before, no hamburger button
- [ ] Mobile: hamburger button visible, clicks open sidebar overlay with backdrop
- [ ] Mobile: clicking overlay or nav item closes sidebar
- [ ] CI E2E tests pass including Mobile Chrome/Safari

🤖 Generated with [Claude Code](https://claude.com/claude-code)