### PR TITLE
fix: add endDate picker to Messages filter

### DIFF
--- a/frontend/src/components/features/Messages.tsx
+++ b/frontend/src/components/features/Messages.tsx
@@ -104,9 +104,9 @@ export const Messages: React.FC = () => {
 
       {/* Filters - Two row layout */}
       <Card className="mb-3">
-        {/* Row 1: Date, Host, Tool, Sender, Search */}
+        {/* Row 1: Start Date, End Date, Host, Tool, Sender */}
         <div className="d-flex flex-wrap align-items-center gap-3 mb-3">
-          {/* Date Filter */}
+          {/* Date Range Filter */}
           <div className="d-flex align-items-center gap-1">
             <small className="text-muted">{t('date', language)}:</small>
             <input
@@ -115,6 +115,14 @@ export const Messages: React.FC = () => {
               style={{ width: '150px' }}
               value={filters.startDate ?? ''}
               onChange={(e) => handleFilterChange('startDate', e.target.value)}
+            />
+            <span className="text-muted">-</span>
+            <input
+              type="date"
+              className="form-control form-control-sm"
+              style={{ width: '150px' }}
+              value={filters.endDate ?? ''}
+              onChange={(e) => handleFilterChange('endDate', e.target.value)}
             />
           </div>
           {/* Host Filter */}
@@ -155,20 +163,8 @@ export const Messages: React.FC = () => {
               style={{ width: '150px' } as React.CSSProperties}
             />
           </div>
-          {/* Search Filter */}
-          <div className="d-flex align-items-center gap-1 ms-auto">
-            <small className="text-muted">{t('search', language)}:</small>
-            <input
-              type="text"
-              className="form-control form-control-sm"
-              placeholder={t('searchMessages', language) ?? 'Search messages...'}
-              style={{ width: '250px' }}
-              value={filters.search ?? ''}
-              onChange={(e) => handleFilterChange('search', e.target.value)}
-            />
-          </div>
         </div>
-        {/* Row 2: Role */}
+        {/* Row 2: Role, Search */}
         <div className="d-flex flex-wrap align-items-center gap-2">
           {/* Role Filter */}
           <div className="d-flex align-items-center gap-1">
@@ -209,6 +205,18 @@ export const Messages: React.FC = () => {
                 System
               </label>
             </div>
+          </div>
+          {/* Search Filter */}
+          <div className="d-flex align-items-center gap-1 ms-auto">
+            <small className="text-muted">{t('search', language)}:</small>
+            <input
+              type="text"
+              className="form-control form-control-sm"
+              placeholder={t('searchMessages', language) ?? 'Search messages...'}
+              style={{ width: '250px' }}
+              value={filters.search ?? ''}
+              onChange={(e) => handleFilterChange('search', e.target.value)}
+            />
           </div>
         </div>
       </Card>

--- a/frontend/src/components/features/Messages.tsx
+++ b/frontend/src/components/features/Messages.tsx
@@ -87,7 +87,13 @@ export const Messages: React.FC = () => {
   };
 
   const handleFilterChange = (key: keyof MessageFilters, value: string) => {
-    setFilters((prev) => ({ ...prev, [key]: value || undefined }));
+    setFilters((prev) => {
+      const next = { ...prev, [key]: value || undefined };
+      if (next.startDate && next.endDate && next.endDate < next.startDate) {
+        next.endDate = undefined;
+      }
+      return next;
+    });
     setPage(1);
   };
 
@@ -104,24 +110,27 @@ export const Messages: React.FC = () => {
 
       {/* Filters - Two row layout */}
       <Card className="mb-3">
-        {/* Row 1: Start Date, End Date, Host, Tool, Sender */}
+        {/* Row 1: Date Range, Host, Tool, Sender */}
         <div className="d-flex flex-wrap align-items-center gap-3 mb-3">
           {/* Date Range Filter */}
           <div className="d-flex align-items-center gap-1">
-            <small className="text-muted">{t('date', language)}:</small>
+            <small className="text-muted">{t('startDate', language)}:</small>
             <input
               type="date"
               className="form-control form-control-sm"
               style={{ width: '150px' }}
               value={filters.startDate ?? ''}
+              aria-label={t('startDate', language)}
               onChange={(e) => handleFilterChange('startDate', e.target.value)}
             />
             <span className="text-muted">-</span>
+            <small className="text-muted">{t('endDate', language)}:</small>
             <input
               type="date"
               className="form-control form-control-sm"
               style={{ width: '150px' }}
               value={filters.endDate ?? ''}
+              aria-label={t('endDate', language)}
               onChange={(e) => handleFilterChange('endDate', e.target.value)}
             />
           </div>


### PR DESCRIPTION
## Summary
- Messages 页面缺少 endDate 日期选择器，导致选择过去的日期时 endDate 始终为今天，查到的仍是今天的消息
- 添加 endDate 日期选择器（与 startDate 并列，用 `-` 连接）
- 将搜索框从第一行移到第二行（角色复选框后面），布局更合理

## Test plan
- [ ] 选择昨天的 startDate 和 endDate，确认显示昨天的消息
- [ ] 选择 startDate=昨天, endDate=今天，确认显示两天的消息
- [ ] 确认搜索框在角色复选框同一行右侧
- [ ] 确认所有其他过滤器正常工作

🤖 Generated with [Claude Code](https://claude.com/claude-code)