### PR TITLE
fix: align Messages filter layout and remove date separator

### DIFF
--- a/frontend/src/components/features/Messages.tsx
+++ b/frontend/src/components/features/Messages.tsx
@@ -113,7 +113,7 @@ export const Messages: React.FC = () => {
         {/* Row 1: Date Range, Host, Tool, Sender */}
         <div className="d-flex flex-wrap align-items-center gap-3 mb-3">
           {/* Date Range Filter */}
-          <div className="d-flex align-items-center gap-1" style={{ minWidth: '382px' }}>
+          <div className="d-flex align-items-center gap-1" style={{ minWidth: '395px' }}>
             <small className="text-muted">{t('startDate', language)}:</small>
             <input
               type="date"
@@ -123,7 +123,7 @@ export const Messages: React.FC = () => {
               aria-label={t('startDate', language)}
               onChange={(e) => handleFilterChange('startDate', e.target.value)}
             />
-            <small className="text-muted">{t('endDate', language)}:</small>
+            <small className="text-muted ms-2">{t('endDate', language)}:</small>
             <input
               type="date"
               className="form-control form-control-sm"
@@ -173,9 +173,9 @@ export const Messages: React.FC = () => {
           </div>
         </div>
         {/* Row 2: Role, Search */}
-        <div className="d-flex flex-wrap align-items-center gap-2">
+        <div className="d-flex flex-wrap align-items-center gap-3">
           {/* Role Filter */}
-          <div className="d-flex align-items-center gap-1" style={{ minWidth: '382px' }}>
+          <div className="d-flex align-items-center gap-1" style={{ minWidth: '395px' }}>
             <small className="text-muted">{t('role', language)}:</small>
             <div className="form-check form-check-inline mb-0">
               <input
@@ -215,7 +215,7 @@ export const Messages: React.FC = () => {
             </div>
           </div>
           {/* Search Filter */}
-          <div className="d-flex align-items-center gap-1 ms-auto">
+          <div className="d-flex align-items-center gap-1">
             <small className="text-muted">{t('search', language)}:</small>
             <input
               type="text"

--- a/frontend/src/components/features/Messages.tsx
+++ b/frontend/src/components/features/Messages.tsx
@@ -108,12 +108,11 @@ export const Messages: React.FC = () => {
         <h2>{t('messages', language)}</h2>
       </div>
 
-      {/* Filters - Two row layout */}
+      {/* Filters - CSS Grid for column alignment */}
       <Card className="mb-3">
-        {/* Row 1: Date Range, Host, Tool, Sender */}
-        <div className="d-flex flex-wrap align-items-center gap-3 mb-3">
+        <div style={{ display: 'grid', gridTemplateColumns: 'auto auto auto auto', gap: '1rem', alignItems: 'center' }}>
           {/* Date Range Filter */}
-          <div className="d-flex align-items-center gap-1" style={{ minWidth: '395px' }}>
+          <div className="d-flex align-items-center gap-1">
             <small className="text-muted">{t('startDate', language)}:</small>
             <input
               type="date"
@@ -171,11 +170,8 @@ export const Messages: React.FC = () => {
               style={{ width: '150px' } as React.CSSProperties}
             />
           </div>
-        </div>
-        {/* Row 2: Role, Search */}
-        <div className="d-flex flex-wrap align-items-center gap-3">
           {/* Role Filter */}
-          <div className="d-flex align-items-center gap-1" style={{ minWidth: '395px' }}>
+          <div className="d-flex align-items-center gap-1">
             <small className="text-muted">{t('role', language)}:</small>
             <div className="form-check form-check-inline mb-0">
               <input

--- a/frontend/src/components/features/Messages.tsx
+++ b/frontend/src/components/features/Messages.tsx
@@ -210,14 +210,14 @@ export const Messages: React.FC = () => {
               </label>
             </div>
           </div>
-          {/* Search Filter */}
-          <div className="d-flex align-items-center gap-1">
+          {/* Search Filter - spans columns 2-4 to align with Sender end */}
+          <div className="d-flex align-items-center gap-1" style={{ gridColumn: '2 / -1' }}>
             <small className="text-muted">{t('search', language)}:</small>
             <input
               type="text"
               className="form-control form-control-sm"
               placeholder={t('searchMessages', language) ?? 'Search messages...'}
-              style={{ width: '250px' }}
+              style={{ flex: 1 }}
               value={filters.search ?? ''}
               onChange={(e) => handleFilterChange('search', e.target.value)}
             />

--- a/frontend/src/components/features/Messages.tsx
+++ b/frontend/src/components/features/Messages.tsx
@@ -113,7 +113,7 @@ export const Messages: React.FC = () => {
         {/* Row 1: Date Range, Host, Tool, Sender */}
         <div className="d-flex flex-wrap align-items-center gap-3 mb-3">
           {/* Date Range Filter */}
-          <div className="d-flex align-items-center gap-1">
+          <div className="d-flex align-items-center gap-1" style={{ minWidth: '382px' }}>
             <small className="text-muted">{t('startDate', language)}:</small>
             <input
               type="date"
@@ -123,7 +123,6 @@ export const Messages: React.FC = () => {
               aria-label={t('startDate', language)}
               onChange={(e) => handleFilterChange('startDate', e.target.value)}
             />
-            <span className="text-muted">-</span>
             <small className="text-muted">{t('endDate', language)}:</small>
             <input
               type="date"
@@ -176,7 +175,7 @@ export const Messages: React.FC = () => {
         {/* Row 2: Role, Search */}
         <div className="d-flex flex-wrap align-items-center gap-2">
           {/* Role Filter */}
-          <div className="d-flex align-items-center gap-1">
+          <div className="d-flex align-items-center gap-1" style={{ minWidth: '382px' }}>
             <small className="text-muted">{t('role', language)}:</small>
             <div className="form-check form-check-inline mb-0">
               <input

--- a/frontend/src/components/features/Messages.tsx
+++ b/frontend/src/components/features/Messages.tsx
@@ -110,7 +110,7 @@ export const Messages: React.FC = () => {
 
       {/* Filters - CSS Grid for column alignment */}
       <Card className="mb-3">
-        <div style={{ display: 'grid', gridTemplateColumns: 'auto auto auto auto', gap: '1rem', alignItems: 'center' }}>
+        <div style={{ display: 'grid', gridTemplateColumns: 'auto auto auto auto', gap: '0.5rem', alignItems: 'center' }}>
           {/* Date Range Filter */}
           <div className="d-flex align-items-center gap-1">
             <small className="text-muted">{t('startDate', language)}:</small>
@@ -211,13 +211,13 @@ export const Messages: React.FC = () => {
             </div>
           </div>
           {/* Search Filter - spans columns 2-4 to align with Sender end */}
-          <div className="d-flex align-items-center gap-1" style={{ gridColumn: '2 / -1' }}>
-            <small className="text-muted">{t('search', language)}:</small>
+          <div className="d-flex align-items-center gap-1" style={{ gridColumn: '2 / -1', width: '100%' }}>
+            <small className="text-muted" style={{ whiteSpace: 'nowrap' }}>{t('search', language)}:</small>
             <input
               type="text"
               className="form-control form-control-sm"
               placeholder={t('searchMessages', language) ?? 'Search messages...'}
-              style={{ flex: 1 }}
+              style={{ flex: 1, minWidth: 0 }}
               value={filters.search ?? ''}
               onChange={(e) => handleFilterChange('search', e.target.value)}
             />

--- a/frontend/src/components/features/Messages.tsx
+++ b/frontend/src/components/features/Messages.tsx
@@ -108,11 +108,11 @@ export const Messages: React.FC = () => {
         <h2>{t('messages', language)}</h2>
       </div>
 
-      {/* Filters - CSS Grid for column alignment */}
+      {/* Filters - Nested flex for column alignment */}
       <Card className="mb-3">
-        <div style={{ display: 'grid', gridTemplateColumns: 'auto auto auto auto', gap: '0.5rem', alignItems: 'center' }}>
-          {/* Date Range Filter */}
-          <div className="d-flex align-items-center gap-1">
+        {/* Row 1: Date Range + Filters */}
+        <div className="d-flex align-items-center gap-2 mb-2">
+          <div className="d-flex align-items-center gap-1" style={{ minWidth: '440px' }}>
             <small className="text-muted">{t('startDate', language)}:</small>
             <input
               type="date"
@@ -132,46 +132,44 @@ export const Messages: React.FC = () => {
               onChange={(e) => handleFilterChange('endDate', e.target.value)}
             />
           </div>
-          {/* Host Filter */}
-          <div className="d-flex align-items-center gap-1">
-            <small className="text-muted">{t('tableHost', language)}:</small>
-            <Select
-              options={hostOptions}
-              value={filters.host ?? ''}
-              onChange={(value) => handleFilterChange('host', value)}
-              size="sm"
-              className="flex-grow-0"
-              style={{ width: '150px' } as React.CSSProperties}
-            />
+          <div className="d-flex align-items-center gap-2 flex-grow-1">
+            <div className="d-flex align-items-center gap-1">
+              <small className="text-muted">{t('tableHost', language)}:</small>
+              <Select
+                options={hostOptions}
+                value={filters.host ?? ''}
+                onChange={(value) => handleFilterChange('host', value)}
+                size="sm"
+                style={{ width: '150px' } as React.CSSProperties}
+              />
+            </div>
+            <div className="d-flex align-items-center gap-1">
+              <small className="text-muted">{t('tableTool', language)}:</small>
+              <Select
+                options={toolOptions}
+                value={filters.tool ?? ''}
+                onChange={(value) => handleFilterChange('tool', value)}
+                size="sm"
+                style={{ width: '150px' } as React.CSSProperties}
+              />
+            </div>
+            <div className="d-flex align-items-center gap-1 flex-grow-1">
+              <small className="text-muted">{t('tableSender', language)}:</small>
+              <SearchableSelect
+                options={senderOptions}
+                value={filters.sender ?? ''}
+                onChange={(value) => handleFilterChange('sender', value)}
+                placeholder={t('dashboardFilterAllSenders', language) || 'All Senders'}
+                searchPlaceholder={t('searchSender', language)}
+                size="sm"
+                className="flex-grow-1"
+              />
+            </div>
           </div>
-          {/* Tool Filter */}
-          <div className="d-flex align-items-center gap-1">
-            <small className="text-muted">{t('tableTool', language)}:</small>
-            <Select
-              options={toolOptions}
-              value={filters.tool ?? ''}
-              onChange={(value) => handleFilterChange('tool', value)}
-              size="sm"
-              className="flex-grow-0"
-              style={{ width: '150px' } as React.CSSProperties}
-            />
-          </div>
-          {/* Sender Filter */}
-          <div className="d-flex align-items-center gap-1">
-            <small className="text-muted">{t('tableSender', language)}:</small>
-            <SearchableSelect
-              options={senderOptions}
-              value={filters.sender ?? ''}
-              onChange={(value) => handleFilterChange('sender', value)}
-              placeholder={t('dashboardFilterAllSenders', language) || 'All Senders'}
-              searchPlaceholder={t('searchSender', language)}
-              size="sm"
-              className="flex-grow-0"
-              style={{ width: '150px' } as React.CSSProperties}
-            />
-          </div>
-          {/* Role Filter */}
-          <div className="d-flex align-items-center gap-1">
+        </div>
+        {/* Row 2: Role + Search */}
+        <div className="d-flex align-items-center gap-2">
+          <div className="d-flex align-items-center gap-1" style={{ minWidth: '440px' }}>
             <small className="text-muted">{t('role', language)}:</small>
             <div className="form-check form-check-inline mb-0">
               <input
@@ -210,17 +208,18 @@ export const Messages: React.FC = () => {
               </label>
             </div>
           </div>
-          {/* Search Filter - spans columns 2-4 to align with Sender end */}
-          <div className="d-flex align-items-center gap-1" style={{ gridColumn: '2 / -1', width: '100%' }}>
-            <small className="text-muted" style={{ whiteSpace: 'nowrap' }}>{t('search', language)}:</small>
-            <input
-              type="text"
-              className="form-control form-control-sm"
-              placeholder={t('searchMessages', language) ?? 'Search messages...'}
-              style={{ flex: 1, minWidth: 0 }}
-              value={filters.search ?? ''}
-              onChange={(e) => handleFilterChange('search', e.target.value)}
-            />
+          <div className="d-flex align-items-center gap-2 flex-grow-1">
+            <div className="d-flex align-items-center gap-1 flex-grow-1">
+              <small className="text-muted">{t('search', language)}:</small>
+              <input
+                type="text"
+                className="form-control form-control-sm"
+                placeholder={t('searchMessages', language) ?? 'Search messages...'}
+                style={{ flex: 1, minWidth: 0 }}
+                value={filters.search ?? ''}
+                onChange={(e) => handleFilterChange('search', e.target.value)}
+              />
+            </div>
           </div>
         </div>
       </Card>


### PR DESCRIPTION
## Summary
- 去掉 startDate 和 endDate 之间的 `-` 分隔符
- 给日期区域和角色区域设置相同 minWidth，使第二行的"搜索"标签与第一行的"主机"标签对齐

## Test plan
- [ ] 确认两个日期输入框之间无 `-` 分隔符
- [ ] 确认搜索框标签与主机标签水平对齐
- [ ] 确认窗口缩小时布局正常换行

🤖 Generated with [Claude Code](https://claude.com/claude-code)