### PR TITLE
build(deps): update sqlalchemy and websocket-client

### DIFF
--- a/remote-agent/requirements.txt
+++ b/remote-agent/requirements.txt
@@ -1,3 +1,3 @@
-websocket-client>=1.6.0
+websocket-client>=1.9.0
 requests>=2.32.5
 websockets>=12.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ gunicorn>=23.0.0
 gevent>=23.0.0
 
 # Database
-sqlalchemy>=2.0.0
+sqlalchemy>=2.0.49
 alembic>=1.16.5
 
 # PostgreSQL driver


### PR DESCRIPTION
## Summary
- Update sqlalchemy>=2.0.49 (resolves #409 merge conflict)
- Update websocket-client>=1.9.0 (resolves #412 merge conflict)

Closes #409, Closes #412

🤖 Generated with [Claude Code](https://claude.com/claude-code)