### PR TITLE
fix: terminal disconnected + API credentials in settings.json

### DIFF
--- a/app/modules/workspace/api_key_proxy.py
+++ b/app/modules/workspace/api_key_proxy.py
@@ -20,6 +20,19 @@ from app.repositories.database import DB_PATH, get_database_url, is_postgresql
 
 logger = logging.getLogger(__name__)
 
+# Environment variable keys that contain API credentials.
+# These must NEVER be written to settings.json — they are injected
+# via environment variables by the remote agent at process launch time.
+# Keep in sync with remote-agent/constants.py.
+_SENSITIVE_ENV_KEYS = frozenset(
+    {
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_BASE_URL",
+        "OPENAI_API_KEY",
+        "OPENAI_BASE_URL",
+    }
+)
+
 
 def _param() -> str:
     """Get the correct parameter placeholder for the current database."""
@@ -459,15 +472,9 @@ class APIKeyProxyService:
 
         # Strip any API credential fields that the user may have
         # accidentally included in the UI.
-        _sensitive_env_keys = {
-            "ANTHROPIC_API_KEY",
-            "ANTHROPIC_BASE_URL",
-            "OPENAI_API_KEY",
-            "OPENAI_BASE_URL",
-        }
         env = settings.get("env", {})
         if env:
-            env = {k: v for k, v in env.items() if k not in _sensitive_env_keys}
+            env = {k: v for k, v in env.items() if k not in _SENSITIVE_ENV_KEYS}
             settings["env"] = env
 
         # Strip baseUrl from modelProviders entries (qwen-code)

--- a/app/modules/workspace/api_key_proxy.py
+++ b/app/modules/workspace/api_key_proxy.py
@@ -429,15 +429,11 @@ class APIKeyProxyService:
             # Get tool-specific settings from cli_settings
             tool_settings = cli_settings.get(tool_name, {})
 
-            # Decrypt the API key
-            api_key = self._decrypt_key(row["encrypted_key"])
-            base_url = row["base_url"] or ""
-
-            # Build complete settings using CLI adapter logic
-            # Import adapters to build settings
-            return self._build_cli_settings_for_tool(
-                tool_name, tool_settings, api_key, base_url, row["provider"]
-            )
+            # Return non-sensitive settings only.
+            # API credentials (key + base_url) are NOT injected here —
+            # they are set via environment variables by the agent
+            # (terminal_server.py for web terminal, executor for sessions).
+            return self._build_cli_settings_for_tool(tool_name, tool_settings)
 
         return None
 
@@ -445,49 +441,41 @@ class APIKeyProxyService:
         self,
         tool_name: str,
         base_settings: dict,
-        api_key: str,
-        base_url: str,
-        provider: str,
     ) -> dict[str, Any]:
         """
-        Build complete CLI settings by merging user settings with API credentials.
+        Build CLI settings containing only non-sensitive configuration.
+
+        API keys and base URLs are intentionally NOT included — they are
+        injected via environment variables at process launch time.
 
         Args:
             tool_name: CLI tool name.
             base_settings: User-configured settings (from cli_settings column).
-            api_key: Decrypted API key.
-            base_url: Base URL for API requests.
-            provider: Provider name (anthropic, openai, etc.).
 
         Returns:
-            Complete settings dict ready for settings.json.
+            Settings dict with non-sensitive config only.
         """
         settings = base_settings.copy()
-        settings.setdefault("env", {})
 
-        if tool_name == "claude-code":
-            # Claude Code settings format
-            settings["env"]["ANTHROPIC_API_KEY"] = api_key
-            if base_url:
-                settings["env"]["ANTHROPIC_BASE_URL"] = base_url.rstrip("/")
-        elif tool_name == "qwen-code":
-            # Qwen Code settings (bailian format)
-            settings.setdefault("modelProviders", {})
-            settings.setdefault("security", {"auth": {"selectedType": "openai"}})
-            settings["$version"] = 3
+        # Strip any API credential fields that the user may have
+        # accidentally included in the UI.
+        _sensitive_env_keys = {
+            "ANTHROPIC_API_KEY",
+            "ANTHROPIC_BASE_URL",
+            "OPENAI_API_KEY",
+            "OPENAI_BASE_URL",
+        }
+        env = settings.get("env", {})
+        if env:
+            env = {k: v for k, v in env.items() if k not in _sensitive_env_keys}
+            settings["env"] = env
 
-            provider_name = "openai"
-            settings["modelProviders"].setdefault(provider_name, [])
-
-            # Determine env key name
-            env_key_name = f"{provider_name.upper()}_API_KEY"
-            for model_config in settings["modelProviders"].get(provider_name, []):
-                if "envKey" in model_config:
-                    env_key_name = model_config["envKey"]
-                if "baseUrl" not in model_config:
-                    model_config["baseUrl"] = base_url.rstrip("/") if base_url else ""
-
-            settings["env"][env_key_name] = api_key
+        # Strip baseUrl from modelProviders entries (qwen-code)
+        for provider_models in settings.get("modelProviders", {}).values():
+            if isinstance(provider_models, list):
+                for model in provider_models:
+                    if isinstance(model, dict):
+                        model.pop("baseUrl", None)
 
         return settings
 

--- a/app/modules/workspace/ws_proxy_manager.py
+++ b/app/modules/workspace/ws_proxy_manager.py
@@ -18,12 +18,9 @@ import logging
 import os
 import subprocess as stdlib_subprocess
 import threading
-import time
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import TYPE_CHECKING
-
-import gevent
 
 if TYPE_CHECKING:
     import subprocess
@@ -186,12 +183,13 @@ class WebSocketProxyManager:
             env["OPEN_ACE_PROXY_TOKEN"] = auth_token
 
             try:
-                # Redirect proxy output to log file for debugging
+                # Use PIPE for stdout so _wait_for_ready can read the READY signal
+                # stderr goes to log file for debugging
                 proxy_log_path = f"/tmp/ws_proxy_{terminal_id[:8]}.log"
                 log_file = open(proxy_log_path, "a")
                 process = stdlib_subprocess.Popen(
                     cmd,
-                    stdout=log_file,
+                    stdout=stdlib_subprocess.PIPE,
                     stderr=log_file,
                     env=env,
                 )
@@ -237,52 +235,55 @@ class WebSocketProxyManager:
 
     def _wait_for_ready(self, process, terminal_id: str) -> bool:
         """Wait for proxy to signal it's ready (gevent-compatible)."""
+        import threading
+
         timeout = 10  # seconds
-        start = time.time()
-        ready_line = ""
+        ready_event = threading.Event()
+        ready_line_holder = [""]
+        stdout_holder = [""]
 
-        while time.time() - start < timeout:
-            poll_result = process.poll()
-            if poll_result is not None:
-                # Process exited
-                try:
-                    stderr = process.stderr.read().decode() if process.stderr else ""
-                    stdout = process.stdout.read().decode() if process.stdout else ""
-                    logger.error(
-                        "Proxy process exited early (code=%s): stderr=%s stdout=%s",
-                        poll_result,
-                        stderr[:500],
-                        stdout[:200],
-                    )
-                except Exception as read_err:
-                    logger.error("Proxy process exited, read error: %s", read_err)
-                return False
-
-            # Check stdout for READY signal (non-blocking read)
+        def _read_stdout():
+            """Read stdout in a thread to avoid gevent select issues with pipes."""
             try:
                 if process.stdout:
-                    # Use select to check if data is available (avoid blocking readline)
-                    import select as _select
-
-                    readable, _, _ = _select.select([process.stdout], [], [], 0.5)
-                    if readable:
-                        line = process.stdout.readline()
-                        if line:
-                            line_str = line.decode().strip()
-                            logger.debug("Read from stdout: %s", line_str)
-                            if line_str.startswith("READY:"):
-                                logger.info("Proxy READY signal received: %s", line_str)
-                                return True
-                            ready_line += line_str + "\n"
+                    for line in iter(process.stdout.readline, b""):
+                        line_str = line.decode().strip()
+                        logger.debug("Read from stdout: %s", line_str)
+                        if line_str.startswith("READY:"):
+                            ready_line_holder[0] = line_str
+                            ready_event.set()
+                            return
+                        stdout_holder[0] += line_str + "\n"
             except Exception as e:
-                logger.debug("Read error: %s", e)
+                logger.debug("Stdout read error: %s", e)
 
-            gevent.sleep(0.1)  # Use gevent sleep instead of blocking time.sleep
+        reader_thread = threading.Thread(target=_read_stdout, daemon=True)
+        reader_thread.start()
+
+        # Wait for READY signal or timeout
+        if ready_event.wait(timeout):
+            logger.info("Proxy READY signal received: %s", ready_line_holder[0])
+            return True
+
+        # Check if process exited
+        poll_result = process.poll()
+        if poll_result is not None:
+            try:
+                stderr = process.stderr.read().decode() if process.stderr else ""
+                logger.error(
+                    "Proxy process exited early (code=%s): stderr=%s stdout=%s",
+                    poll_result,
+                    stderr[:500],
+                    stdout_holder[0][:200],
+                )
+            except Exception as read_err:
+                logger.error("Proxy process exited, read error: %s", read_err)
+            return False
 
         logger.warning(
             "Timeout waiting for proxy READY signal (terminal %s). Accumulated output: %s",
             terminal_id[:8],
-            ready_line[:200],
+            stdout_holder[0][:200],
         )
         return False
 

--- a/app/modules/workspace/ws_proxy_manager.py
+++ b/app/modules/workspace/ws_proxy_manager.py
@@ -243,17 +243,22 @@ class WebSocketProxyManager:
         stdout_holder = [""]
 
         def _read_stdout():
-            """Read stdout in a thread to avoid gevent select issues with pipes."""
+            """Read stdout in a thread to avoid gevent select issues with pipes.
+
+            Keeps draining stdout even after READY to prevent the proxy process
+            from blocking on a full PIPE buffer (daemon thread exits with process).
+            """
             try:
                 if process.stdout:
                     for line in iter(process.stdout.readline, b""):
                         line_str = line.decode().strip()
                         logger.debug("Read from stdout: %s", line_str)
-                        if line_str.startswith("READY:"):
+                        if line_str.startswith("READY:") and not ready_event.is_set():
                             ready_line_holder[0] = line_str
                             ready_event.set()
-                            return
-                        stdout_holder[0] += line_str + "\n"
+                        # Cap accumulation to avoid unbounded memory growth
+                        if len(stdout_holder[0]) < 4096:
+                            stdout_holder[0] += line_str + "\n"
             except Exception as e:
                 logger.debug("Stdout read error: %s", e)
 

--- a/frontend/src/components/features/management/APIKeyManagement.tsx
+++ b/frontend/src/components/features/management/APIKeyManagement.tsx
@@ -207,18 +207,56 @@ export const APIKeyManagement: React.FC = () => {
     }
   };
 
+  // Fields that should never be stored in cli_settings —
+  // API credentials are injected via environment variables.
+  const SENSITIVE_ENV_KEYS = new Set([
+    'ANTHROPIC_API_KEY',
+    'ANTHROPIC_BASE_URL',
+    'OPENAI_API_KEY',
+    'OPENAI_BASE_URL',
+  ]);
+
+  const stripSensitiveFields = (toolSettings: Record<string, unknown>): Record<string, unknown> => {
+    const cleaned = { ...toolSettings };
+    // Strip sensitive env keys
+    const env = cleaned.env as Record<string, unknown> | undefined;
+    if (env && typeof env === 'object') {
+      const cleanEnv = { ...env };
+      for (const key of Object.keys(cleanEnv)) {
+        if (SENSITIVE_ENV_KEYS.has(key)) {
+          delete cleanEnv[key];
+        }
+      }
+      cleaned.env = cleanEnv;
+    }
+    // Strip baseUrl from modelProviders (qwen-code)
+    const modelProviders = cleaned.modelProviders as Record<string, unknown[]> | undefined;
+    if (modelProviders && typeof modelProviders === 'object') {
+      for (const models of Object.values(modelProviders)) {
+        if (Array.isArray(models)) {
+          for (const model of models) {
+            if (model && typeof model === 'object' && 'baseUrl' in model) {
+              delete (model as Record<string, unknown>).baseUrl;
+            }
+          }
+        }
+      }
+    }
+    return cleaned;
+  };
+
   const buildCliSettingsJson = (): string => {
     const settings: Record<string, unknown> = {};
     if (formData.cli_tools.includes('claude-code') && formData.claude_settings) {
       try {
-        settings['claude-code'] = JSON.parse(formData.claude_settings);
+        settings['claude-code'] = stripSensitiveFields(JSON.parse(formData.claude_settings));
       } catch {
         // Skip invalid JSON
       }
     }
     if (formData.cli_tools.includes('qwen-code') && formData.qwen_settings) {
       try {
-        settings['qwen-code'] = JSON.parse(formData.qwen_settings);
+        settings['qwen-code'] = stripSensitiveFields(JSON.parse(formData.qwen_settings));
       } catch {
         // Skip invalid JSON
       }

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -781,10 +781,10 @@ const translations: Record<Language, Translations> = {
     cliToolsDescription: 'Select which CLI tools this API key should configure settings for.',
     claudeCodeSettings: 'Claude Code Settings (JSON)',
     claudeCodeSettingsHint:
-      'Paste ~/.claude/settings.json content (without sensitive AUTH_TOKEN). System will inject API key automatically.',
+      'Configure non-sensitive settings only (model mappings, theme, etc.). Do NOT include API keys or base URLs — they are injected via environment variables automatically.',
     qwenCodeSettings: 'Qwen Code Settings (JSON)',
     qwenCodeSettingsHint:
-      'Paste ~/.qwen/settings.json content (without env API keys). System will inject API key automatically.',
+      'Configure non-sensitive settings only (modelProviders, model, etc.). Do NOT include API keys or base URLs — they are injected via environment variables automatically.',
     claudeSettingsInvalid: 'Claude Code settings JSON is invalid',
     qwenSettingsInvalid: 'Qwen Code settings JSON is invalid',
     providerCannotChange: 'Provider cannot be changed',
@@ -1586,10 +1586,10 @@ const translations: Record<Language, Translations> = {
     cliToolsDescription: '选择此 API 密钥应为其配置设置的 CLI 工具。',
     claudeCodeSettings: 'Claude Code 设置 (JSON)',
     claudeCodeSettingsHint:
-      '粘贴 ~/.claude/settings.json 内容（不含敏感 AUTH_TOKEN），系统将自动注入 API 密钥。',
+      '仅配置非敏感设置（模型映射、主题等）。请勿填写 API Key 或 Base URL — 系统会通过环境变量自动注入。',
     qwenCodeSettings: 'Qwen Code 设置 (JSON)',
     qwenCodeSettingsHint:
-      '粘贴 ~/.qwen/settings.json 内容（不含环境变量 API 密钥），系统将自动注入 API 密钥。',
+      '仅配置非敏感设置（modelProviders、model 等）。请勿填写 API Key 或 Base URL — 系统会通过环境变量自动注入。',
     claudeSettingsInvalid: 'Claude Code 设置 JSON 无效',
     qwenSettingsInvalid: 'Qwen Code 设置 JSON 无效',
     providerCannotChange: '提供商不可更改',

--- a/remote-agent/agent.py
+++ b/remote-agent/agent.py
@@ -616,6 +616,7 @@ class RemoteAgent:
         logger.info("Starting terminal %s: work_dir=%s", terminal_id[:8], work_dir)
 
         # Apply CLI settings before starting terminal
+        # (non-sensitive config only; API credentials are set via env vars)
         if cli_settings:
             self._apply_cli_settings(cli_settings)
 
@@ -928,9 +929,46 @@ class RemoteAgent:
     # CLI Settings Application
     # ----------------------------------------------------------------
 
+    # Fields that should never appear in settings.json — API credentials
+    # are injected via environment variables instead.
+    _SENSITIVE_ENV_KEYS = {
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_BASE_URL",
+        "OPENAI_API_KEY",
+        "OPENAI_BASE_URL",
+    }
+
+    def _strip_sensitive_fields(self, settings: dict[str, Any]) -> dict[str, Any]:
+        """Remove API key and base URL fields from settings dict.
+
+        These credentials are injected via environment variables by
+        terminal_server.py (web terminal) and executor._build_env()
+        (remote session), so they must not be written to settings.json.
+        """
+        settings = settings.copy()
+
+        # Remove sensitive keys from env block
+        env = settings.get("env", {})
+        if env:
+            env = {k: v for k, v in env.items() if k not in self._SENSITIVE_ENV_KEYS}
+            settings["env"] = env
+
+        # Remove baseUrl from modelProviders (qwen-code)
+        for provider_models in settings.get("modelProviders", {}).values():
+            if isinstance(provider_models, list):
+                for model in provider_models:
+                    if isinstance(model, dict):
+                        model.pop("baseUrl", None)
+
+        return settings
+
     def _apply_cli_settings(self, cli_settings: dict[str, Any]) -> None:
         """
         Write settings.json files for configured CLI tools.
+
+        Only non-sensitive configuration is written (model mappings, theme, etc.).
+        API keys and base URLs are NOT written — they are injected via
+        environment variables by terminal_server.py and executor.
 
         Args:
             cli_settings: Dict with tool_name -> settings mapping
@@ -941,6 +979,7 @@ class RemoteAgent:
 
         for tool_name, settings in cli_settings.items():
             try:
+                settings = self._strip_sensitive_fields(settings)
                 if tool_name == "claude-code":
                     self._write_claude_settings(settings)
                 elif tool_name == "qwen-code":

--- a/remote-agent/agent.py
+++ b/remote-agent/agent.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from typing import Any
 
 import requests
+from constants import SENSITIVE_ENV_KEYS
 from executor import ProcessExecutor
 from session_sync import SessionSyncService
 from system_info import get_capabilities
@@ -929,15 +930,6 @@ class RemoteAgent:
     # CLI Settings Application
     # ----------------------------------------------------------------
 
-    # Fields that should never appear in settings.json — API credentials
-    # are injected via environment variables instead.
-    _SENSITIVE_ENV_KEYS = {
-        "ANTHROPIC_API_KEY",
-        "ANTHROPIC_BASE_URL",
-        "OPENAI_API_KEY",
-        "OPENAI_BASE_URL",
-    }
-
     def _strip_sensitive_fields(self, settings: dict[str, Any]) -> dict[str, Any]:
         """Remove API key and base URL fields from settings dict.
 
@@ -950,7 +942,7 @@ class RemoteAgent:
         # Remove sensitive keys from env block
         env = settings.get("env", {})
         if env:
-            env = {k: v for k, v in env.items() if k not in self._SENSITIVE_ENV_KEYS}
+            env = {k: v for k, v in env.items() if k not in SENSITIVE_ENV_KEYS}
             settings["env"] = env
 
         # Remove baseUrl from modelProviders (qwen-code)

--- a/remote-agent/cli_adapters/claude_code.py
+++ b/remote-agent/cli_adapters/claude_code.py
@@ -89,34 +89,20 @@ class ClaudeCodeAdapter(BaseCLIAdapter):
     def build_settings(
         self,
         base_settings: dict,
-        api_key: str,
-        base_url: str,
     ) -> dict:
         """
-        Build complete settings.json for Claude Code.
+        Build settings.json for Claude Code (non-sensitive config only).
 
-        Merges user-configured settings with system-injected credentials.
-        User settings should not contain sensitive fields like ANTHROPIC_API_KEY.
+        API credentials (ANTHROPIC_API_KEY, ANTHROPIC_BASE_URL) are NOT
+        included — they are injected via environment variables by the agent.
 
         Args:
-            base_settings: User-configured settings (model mappings, etc.)
-            api_key: Real API key from api_key_store (or proxy token)
-            base_url: Base URL for API requests
+            base_settings: User-configured settings (model mappings, theme, etc.)
 
         Returns:
-            Complete settings dict ready to write to ~/.claude/settings.json
+            Settings dict ready to write to ~/.claude/settings.json
         """
-        settings = base_settings.copy()
-        settings.setdefault("env", {})
-
-        # Inject API credentials (from api_key_store, not user config)
-        settings["env"]["ANTHROPIC_API_KEY"] = api_key
-        settings["env"]["ANTHROPIC_BASE_URL"] = base_url.rstrip("/")
-
-        # Preserve user-configured model mappings if present:
-        # env.ANTHROPIC_MODEL, env.ANTHROPIC_DEFAULT_HAIKU_MODEL, etc.
-
-        return settings
+        return base_settings.copy()
 
     def get_settings_path(self) -> str:
         """Return the path to Claude Code settings.json."""

--- a/remote-agent/cli_adapters/qwen_code.py
+++ b/remote-agent/cli_adapters/qwen_code.py
@@ -113,52 +113,40 @@ class QwenCodeAdapter(BaseCLIAdapter):
     def build_settings(
         self,
         base_settings: dict,
-        api_key: str,
-        base_url: str,
-        provider_name: str = "openai",
     ) -> dict:
         """
-        Build complete settings.json for Qwen Code (bailian format).
+        Build settings.json for Qwen Code (non-sensitive config only).
 
-        Reference: ~/.qwen/settings.json.bailian format with:
-        - env: API key environment variables
-        - modelProviders: Provider-specific model configurations
-        - security: Auth type selection
-        - model: Default model selection
+        API credentials and baseUrl are NOT included — they are injected
+        via environment variables by the agent.
 
         Args:
             base_settings: User-configured settings (modelProviders, model, etc.)
-            api_key: Real API key from api_key_store (or proxy token)
-            base_url: Base URL for API requests
-            provider_name: Provider type (default: openai)
 
         Returns:
-            Complete settings dict ready to write to ~/.qwen/settings.json
+            Settings dict ready to write to ~/.qwen/settings.json
         """
         settings = base_settings.copy()
-        settings.setdefault("env", {})
-        settings.setdefault("modelProviders", {})
-        settings.setdefault("security", {"auth": {"selectedType": provider_name}})
-        settings["$version"] = 3
 
-        # Ensure target provider exists
-        settings["modelProviders"].setdefault(provider_name, [])
+        # Strip any API credential fields that the user may have
+        # accidentally included.
+        _sensitive_env_keys = {
+            "ANTHROPIC_API_KEY",
+            "ANTHROPIC_BASE_URL",
+            "OPENAI_API_KEY",
+            "OPENAI_BASE_URL",
+        }
+        env = settings.get("env", {})
+        if env:
+            env = {k: v for k, v in env.items() if k not in _sensitive_env_keys}
+            settings["env"] = env
 
-        # Determine env key name (default based on provider)
-        env_key_name = f"{provider_name.upper()}_API_KEY"
-
-        # Process modelProviders - inject baseUrl where needed
-        for model_config in settings["modelProviders"][provider_name]:
-            # Use the model's envKey if specified
-            if "envKey" in model_config:
-                env_key_name = model_config["envKey"]
-
-            # If baseUrl not set in model config, use api_key_store's base_url
-            if "baseUrl" not in model_config:
-                model_config["baseUrl"] = base_url.rstrip("/")
-
-        # Inject the API key into env
-        settings["env"][env_key_name] = api_key
+        # Strip baseUrl from modelProviders entries
+        for provider_models in settings.get("modelProviders", {}).values():
+            if isinstance(provider_models, list):
+                for model in provider_models:
+                    if isinstance(model, dict):
+                        model.pop("baseUrl", None)
 
         return settings
 

--- a/remote-agent/cli_adapters/qwen_code.py
+++ b/remote-agent/cli_adapters/qwen_code.py
@@ -13,6 +13,8 @@ import logging
 import shutil
 from pathlib import Path
 
+from constants import SENSITIVE_ENV_KEYS
+
 from .base import BaseCLIAdapter
 
 logger = logging.getLogger(__name__)
@@ -130,15 +132,9 @@ class QwenCodeAdapter(BaseCLIAdapter):
 
         # Strip any API credential fields that the user may have
         # accidentally included.
-        _sensitive_env_keys = {
-            "ANTHROPIC_API_KEY",
-            "ANTHROPIC_BASE_URL",
-            "OPENAI_API_KEY",
-            "OPENAI_BASE_URL",
-        }
         env = settings.get("env", {})
         if env:
-            env = {k: v for k, v in env.items() if k not in _sensitive_env_keys}
+            env = {k: v for k, v in env.items() if k not in SENSITIVE_ENV_KEYS}
             settings["env"] = env
 
         # Strip baseUrl from modelProviders entries

--- a/remote-agent/constants.py
+++ b/remote-agent/constants.py
@@ -1,0 +1,13 @@
+"""Shared constants for the Open ACE remote agent."""
+
+# Environment variable keys that contain API credentials.
+# These must NEVER be written to settings.json — they are injected
+# via environment variables at process launch time.
+SENSITIVE_ENV_KEYS = frozenset(
+    {
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_BASE_URL",
+        "OPENAI_API_KEY",
+        "OPENAI_BASE_URL",
+    }
+)


### PR DESCRIPTION
## Problems

### 1. Web terminal shows "disconnected" after creation

WebSocket proxy starts successfully but `_wait_for_ready()` times out because `select()` on a pipe fails silently under gevent monkey-patching. The proxy URL (`ws://localhost:42013`) never gets stored, so the frontend keeps polling with the original remote URL.

### 2. Direct API keys written to settings.json

`_build_cli_settings_for_tool()` injected the database API key and base URL into settings.json. Claude Code/Qwen Code should use the LLM proxy (via env vars), not connect directly.

## Changes

- **ws_proxy_manager.py**: Use PIPE for stdout + threading.Thread to read READY signal (fixes gevent select incompatibility)
- **agent.py**: Add `_strip_sensitive_fields()` that removes ANTHROPIC_API_KEY, ANTHROPIC_BASE_URL, OPENAI_API_KEY, OPENAI_BASE_URL from settings before writing to settings.json
- **api_key_proxy.py**: `_build_cli_settings_for_tool()` no longer injects API key or base_url; strips sensitive fields from user config
- **cli_adapters/claude_code.py + qwen_code.py**: `build_settings()` simplified to pass-through (no credential injection)
- **frontend**: Update i18n hints to clarify env vars are used; buildCliSettingsJson() strips sensitive fields before saving

## Verification

After deploying, create a new terminal and check:
1. Terminal connects (not "disconnected")
2. ~/.claude/settings.json on remote machine has NO ANTHROPIC_API_KEY or ANTHROPIC_BASE_URL
3. Claude Code process env vars have correct proxy token and URL
