### PR TITLE
Fix test_webui_manager: mock _ensure_system_user

### DIFF
--- a/tests/unit/test_webui_manager.py
+++ b/tests/unit/test_webui_manager.py
@@ -169,6 +169,7 @@ class TestLaunchWebuiProcessAuth:
 
         # Mock _find_webui_executable and _load_server_config
         with (
+            patch.object(manager, "_ensure_system_user", return_value=True),
             patch.object(
                 manager,
                 "_find_webui_executable",
@@ -206,6 +207,7 @@ class TestLaunchWebuiProcessAuth:
         manager._platform = "linux"
 
         with (
+            patch.object(manager, "_ensure_system_user", return_value=True),
             patch.object(
                 manager,
                 "_find_webui_executable",
@@ -241,6 +243,7 @@ class TestLaunchWebuiProcessAuth:
         manager._platform = "linux"
 
         with (
+            patch.object(manager, "_ensure_system_user", return_value=True),
             patch.object(
                 manager,
                 "_find_webui_executable",
@@ -275,6 +278,7 @@ class TestLaunchWebuiProcessAuth:
 
         try:
             with (
+                patch.object(manager, "_ensure_system_user", return_value=True),
                 patch.object(
                     manager,
                     "_find_webui_executable",
@@ -312,6 +316,7 @@ class TestLaunchWebuiProcessAuth:
 
         try:
             with (
+                patch.object(manager, "_ensure_system_user", return_value=True),
                 patch.object(
                     manager,
                     "_find_webui_executable",


### PR DESCRIPTION
## 问题描述

PR #422 合并后，CI 测试失败：
- `tests/unit/test_webui_manager.py` - 5 个测试失败

失败原因：`_launch_webui_process()` 现在调用 `_ensure_system_user()` 方法，该方法使用 `subprocess.run(["id", system_account], ...)`。测试中没有 mock 此方法，导致在 CI 环境中调用真实 subprocess 失败。

## 修复内容

在 `test_webui_manager.py` 中，为所有调用 `_launch_webui_process()` 的测试添加 `patch.object(manager, "_ensure_system_user", return_value=True)` mock。

## 受影响的测试

- `test_auth_type_injected_into_cmd`
- `test_auth_env_injected_into_subprocess`
- `test_no_auth_type_when_not_configured`
- `test_env_inherits_current_env`
- `test_auth_env_overrides_existing`

## 关联

- Related: #419
- Related: #422