### PR TITLE
Fix: Docker安装方法生成的config.json添加auth和insights字段

### DIFF
--- a/scripts/install-central/docker-method/install.sh
+++ b/scripts/install-central/docker-method/install.sh
@@ -1778,6 +1778,18 @@ $workspace_config,
   "cron": {
     "enabled": true,
     "run_time": "00:30"
+  },
+  "auth": {
+    "auth_type": "openai",
+    "env": {
+      "OPENAI_API_KEY": "<YOUR_API_KEY>",
+      "OPENAI_BASE_URL": "https://api.openai.com/v1"
+    }
+  },
+  "insights": {
+    "model": "glm-5",
+    "temperature": 0.3,
+    "max_tokens": 4096
   }
 }
 EOF


### PR DESCRIPTION
## 问题描述

Fixes #424

Docker 安装方法生成的 `config.json` 配置文件缺少必要的 `auth` 和 `insights` 字段，导致部分功能无法正常工作。

## 问题对比

| 安装方法 | 配置来源 | auth 字段 | insights 字段 |
|---------|---------|----------|---------------|
| Docker 方法 | Shell heredoc 直接生成 | ❌ 缺失 | ❌ 缺失 |
| Package 方法 | 复制 config.json.sample | ✅ 有 | ✅ 有 |

## 影响分析

- **auth 字段缺失**：`webui_manager.py` 第 224、578 行无法获取 API Key 配置；`insights_service.py` 第 57-66 行 Insights AI 分析功能无法获取 API Key
- **insights 字段缺失**：AI 分析报告的模型参数无法配置

## 修复内容

在 `scripts/install-central/docker-method/install.sh` 的配置文件生成部分添加与 `config.json.sample` 一致的字段：

```json
"auth": {
  "auth_type": "openai",
  "env": {
    "OPENAI_API_KEY": "<YOUR_API_KEY>",
    "OPENAI_BASE_URL": "https://api.openai.com/v1"
  }
},
"insights": {
  "model": "glm-5",
  "temperature": 0.3,
  "max_tokens": 4096
}
```

## 测试

- [x] Shell 脚本语法检查通过
- [x] 生成的 JSON 格式验证通过