### PR TITLE
fix: web terminal session_sync 关联 terminal_id + capabilities 动态更新

### DIFF
--- a/app/modules/workspace/remote_agent_manager.py
+++ b/app/modules/workspace/remote_agent_manager.py
@@ -730,16 +730,16 @@ class RemoteAgentManager:
                 self._connections[machine_id] = None
                 logger.info(f"Re-registered HTTP polling agent via heartbeat: {machine_id}")
 
-        # Update capabilities separately if provided
-        if capabilities:
-            self.update_capabilities(machine_id, capabilities)
-
         # Rate-limit DB writes: skip if last write was within HEARTBEAT_DB_WRITE_INTERVAL
         now_ts = time.time()
         last_write = self._last_heartbeat_db_write.get(machine_id, 0)
         if now_ts - last_write < self.HEARTBEAT_DB_WRITE_INTERVAL:
             return
         self._last_heartbeat_db_write[machine_id] = now_ts
+
+        # Update capabilities separately if provided (within rate limit)
+        if capabilities:
+            self.update_capabilities(machine_id, capabilities)
 
         with self.db.connection() as conn:
             cursor = conn.cursor()

--- a/app/modules/workspace/remote_agent_manager.py
+++ b/app/modules/workspace/remote_agent_manager.py
@@ -730,6 +730,10 @@ class RemoteAgentManager:
                 self._connections[machine_id] = None
                 logger.info(f"Re-registered HTTP polling agent via heartbeat: {machine_id}")
 
+        # Update capabilities separately if provided
+        if capabilities:
+            self.update_capabilities(machine_id, capabilities)
+
         # Rate-limit DB writes: skip if last write was within HEARTBEAT_DB_WRITE_INTERVAL
         now_ts = time.time()
         last_write = self._last_heartbeat_db_write.get(machine_id, 0)
@@ -741,25 +745,14 @@ class RemoteAgentManager:
             cursor = conn.cursor()
             now = datetime.utcnow().isoformat()
 
-            if capabilities:
-                cursor.execute(
-                    f"""
-                    UPDATE remote_machines
-                    SET last_heartbeat = {_param()}, status = {_param()}, updated_at = {_param()},
-                        capabilities = {_param()}
-                    WHERE machine_id = {_param()}
-                """,
-                    (now, status, now, json.dumps(capabilities), machine_id),
-                )
-            else:
-                cursor.execute(
-                    f"""
-                    UPDATE remote_machines
-                    SET last_heartbeat = {_param()}, status = {_param()}, updated_at = {_param()}
-                    WHERE machine_id = {_param()}
-                """,
-                    (now, status, now, machine_id),
-                )
+            cursor.execute(
+                f"""
+                UPDATE remote_machines
+                SET last_heartbeat = {_param()}, status = {_param()}, updated_at = {_param()}
+                WHERE machine_id = {_param()}
+            """,
+                (now, status, now, machine_id),
+            )
             conn.commit()
 
     def update_capabilities(self, machine_id: str, capabilities: dict[str, Any]) -> None:

--- a/app/modules/workspace/remote_agent_manager.py
+++ b/app/modules/workspace/remote_agent_manager.py
@@ -716,7 +716,11 @@ class RemoteAgentManager:
     # ==================== Heartbeat ====================
 
     def process_heartbeat(
-        self, machine_id: str, status: str = "idle", active_sessions: int = 0
+        self,
+        machine_id: str,
+        status: str = "idle",
+        active_sessions: int = 0,
+        capabilities: Optional[dict[str, Any]] = None,
     ) -> None:
         """Process a heartbeat from a remote agent."""
         # Ensure HTTP polling agents are tracked in _connections
@@ -737,15 +741,42 @@ class RemoteAgentManager:
             cursor = conn.cursor()
             now = datetime.utcnow().isoformat()
 
+            if capabilities:
+                cursor.execute(
+                    f"""
+                    UPDATE remote_machines
+                    SET last_heartbeat = {_param()}, status = {_param()}, updated_at = {_param()},
+                        capabilities = {_param()}
+                    WHERE machine_id = {_param()}
+                """,
+                    (now, status, now, json.dumps(capabilities), machine_id),
+                )
+            else:
+                cursor.execute(
+                    f"""
+                    UPDATE remote_machines
+                    SET last_heartbeat = {_param()}, status = {_param()}, updated_at = {_param()}
+                    WHERE machine_id = {_param()}
+                """,
+                    (now, status, now, machine_id),
+                )
+            conn.commit()
+
+    def update_capabilities(self, machine_id: str, capabilities: dict[str, Any]) -> None:
+        """Update capabilities for a remote machine."""
+        with self.db.connection() as conn:
+            cursor = conn.cursor()
+            now = datetime.utcnow().isoformat()
             cursor.execute(
                 f"""
                 UPDATE remote_machines
-                SET last_heartbeat = {_param()}, status = {_param()}, updated_at = {_param()}
+                SET capabilities = {_param()}, updated_at = {_param()}
                 WHERE machine_id = {_param()}
             """,
-                (now, status, now, machine_id),
+                (json.dumps(capabilities), now, machine_id),
             )
             conn.commit()
+            logger.info("Updated capabilities for machine %s", machine_id[:8])
 
     # ==================== Machine Queries ====================
 

--- a/app/modules/workspace/session_manager.py
+++ b/app/modules/workspace/session_manager.py
@@ -272,8 +272,7 @@ class SessionManager:
         id_type = "SERIAL PRIMARY KEY" if is_postgresql() else "INTEGER PRIMARY KEY AUTOINCREMENT"
 
         # Create agent_sessions table
-        cursor.execute(
-            f"""
+        cursor.execute(f"""
             CREATE TABLE IF NOT EXISTS agent_sessions (
                 id {id_type},
                 session_id TEXT NOT NULL UNIQUE,
@@ -296,12 +295,10 @@ class SessionManager:
                 completed_at TIMESTAMP,
                 expires_at TIMESTAMP
             )
-        """
-        )
+        """)
 
         # Create session_messages table
-        cursor.execute(
-            f"""
+        cursor.execute(f"""
             CREATE TABLE IF NOT EXISTS session_messages (
                 id {id_type},
                 session_id TEXT NOT NULL,
@@ -313,40 +310,29 @@ class SessionManager:
                 metadata TEXT,
                 FOREIGN KEY (session_id) REFERENCES agent_sessions(session_id)
             )
-        """
-        )
+        """)
 
         # Create indexes
-        cursor.execute(
-            """
+        cursor.execute("""
             CREATE INDEX IF NOT EXISTS idx_agent_sessions_session_id
             ON agent_sessions(session_id)
-        """
-        )
-        cursor.execute(
-            """
+        """)
+        cursor.execute("""
             CREATE INDEX IF NOT EXISTS idx_agent_sessions_user_id
             ON agent_sessions(user_id)
-        """
-        )
-        cursor.execute(
-            """
+        """)
+        cursor.execute("""
             CREATE INDEX IF NOT EXISTS idx_agent_sessions_status
             ON agent_sessions(status)
-        """
-        )
-        cursor.execute(
-            """
+        """)
+        cursor.execute("""
             CREATE INDEX IF NOT EXISTS idx_agent_sessions_tool_name
             ON agent_sessions(tool_name)
-        """
-        )
-        cursor.execute(
-            """
+        """)
+        cursor.execute("""
             CREATE INDEX IF NOT EXISTS idx_session_messages_session_id
             ON session_messages(session_id)
-        """
-        )
+        """)
 
         # Add remote workspace columns if not present
         try:
@@ -607,6 +593,7 @@ class SessionManager:
         "paused_at",
         "expires_at",
         "terminal_id",
+        "project_path",
     }
 
     def update_session_fields(self, session_id: str, fields: dict[str, Any]) -> bool:
@@ -1158,8 +1145,7 @@ class SessionManager:
                 (user_id,),
             )
         else:
-            cursor.execute(
-                """
+            cursor.execute("""
                 SELECT
                     COUNT(*) as total_sessions,
                     SUM(CASE WHEN status = 'active' THEN 1 ELSE 0 END) as active_sessions,
@@ -1167,8 +1153,7 @@ class SessionManager:
                     SUM(total_tokens) as total_tokens,
                     SUM(message_count) as total_messages
                 FROM agent_sessions
-            """
-            )
+            """)
 
         row = cursor.fetchone()
         conn.close()

--- a/app/routes/remote.py
+++ b/app/routes/remote.py
@@ -1046,6 +1046,11 @@ def agent_message():
                 session_id = terminal_id
             else:
                 session_id = claude_session_id
+                logger.warning(
+                    "session_sync: terminal_id=%s not found, " "fall back to claude_session_id=%s",
+                    terminal_id[:8],
+                    claude_session_id[:8],
+                )
         else:
             session_id = claude_session_id
 
@@ -1084,15 +1089,31 @@ def agent_message():
                 if updates:
                     sync_session_mgr.update_session_fields(session_id, updates)
 
-            # Fetch existing message uuids for dedup
+            # Fetch existing message uuids for dedup (lightweight query)
             existing_uuids: set[str] = set()
             try:
-                existing_msgs = sync_session_mgr.get_messages(session_id)
-                for em in existing_msgs:
-                    em_meta = em.metadata if isinstance(em.metadata, dict) else {}
-                    em_uuid = em_meta.get("uuid", "")
-                    if em_uuid:
-                        existing_uuids.add(em_uuid)
+                from app.repositories.database import adapt_sql, get_db_connection
+
+                with get_db_connection() as conn:
+                    cursor = conn.cursor()
+                    cursor.execute(
+                        adapt_sql("SELECT metadata FROM session_messages WHERE session_id = ?"),
+                        (session_id,),
+                    )
+                    for row in cursor.fetchall():
+                        meta_raw = row["metadata"]
+                        if isinstance(meta_raw, str):
+                            try:
+                                meta = json.loads(meta_raw)
+                            except (json.JSONDecodeError, TypeError):
+                                continue
+                        elif isinstance(meta_raw, dict):
+                            meta = meta_raw
+                        else:
+                            continue
+                        em_uuid = meta.get("uuid", "")
+                        if em_uuid:
+                            existing_uuids.add(em_uuid)
             except Exception:
                 pass
 

--- a/app/routes/remote.py
+++ b/app/routes/remote.py
@@ -1089,11 +1089,12 @@ def agent_message():
                 if updates:
                     sync_session_mgr.update_session_fields(session_id, updates)
 
-            # Fetch existing message uuids for dedup (lightweight query)
-            existing_uuids: set[str] = set()
+            # Fetch existing message uuids for dedup and mirror to daily_messages
             try:
                 from app.repositories.database import adapt_sql, get_db_connection
 
+                # Dedup: collect existing message uuids via lightweight query
+                existing_uuids: set[str] = set()
                 with get_db_connection() as conn:
                     cursor = conn.cursor()
                     cursor.execute(
@@ -1114,13 +1115,8 @@ def agent_message():
                         em_uuid = meta.get("uuid", "")
                         if em_uuid:
                             existing_uuids.add(em_uuid)
-            except Exception:
-                pass
 
-            # Mirror messages to daily_messages for ConversationHistory visibility
-            try:
-                from app.repositories.database import adapt_sql, get_db_connection
-
+                # Mirror messages to daily_messages for ConversationHistory visibility
                 for msg in messages:
                     role = msg.get("role", "")
                     content = msg.get("content", "")

--- a/app/routes/remote.py
+++ b/app/routes/remote.py
@@ -896,14 +896,17 @@ def agent_message():
     if msg_type == "register":
         # Agent re-registering on reconnect
         agent_mgr.register_connection(machine_id, None)
-        data.get("capabilities", {})
+        capabilities = data.get("capabilities", {})
+        if capabilities:
+            agent_mgr.update_capabilities(machine_id, capabilities)
         pending = agent_mgr.get_pending_commands(machine_id)
         return jsonify({"success": True, "type": "register_ack", "pending_commands": pending})
 
     elif msg_type == "heartbeat":
         status = data.get("status", "idle")
         active_sessions = data.get("active_sessions", 0)
-        agent_mgr.process_heartbeat(machine_id, status, active_sessions)
+        capabilities = data.get("capabilities", {})
+        agent_mgr.process_heartbeat(machine_id, status, active_sessions, capabilities=capabilities)
         pending = agent_mgr.get_pending_commands(machine_id)
         return jsonify({"success": True, "type": "heartbeat_ack", "pending_commands": pending})
 
@@ -1024,7 +1027,8 @@ def agent_message():
 
     elif msg_type == "session_sync":
         # Agent reports Claude Code session data from web terminal
-        session_id = data.get("session_id", "")
+        claude_session_id = data.get("session_id", "")
+        terminal_id = data.get("terminal_id", "")
         tool_name = data.get("tool_name", "claude-code")
         model = data.get("model")
         project_path = data.get("project_path")
@@ -1033,9 +1037,22 @@ def agent_message():
         total_output_tokens = data.get("total_output_tokens", 0)
         messages = data.get("messages", [])
 
+        # Resolve effective session_id: prefer terminal_id (shown in sidebar)
+        # over claude_session_id (internal Claude Code JSONL UUID).
+        sync_session_mgr = get_remote_session_manager()._session_manager
+        if terminal_id:
+            terminal_session = sync_session_mgr.get_session(terminal_id)
+            if terminal_session:
+                session_id = terminal_id
+            else:
+                session_id = claude_session_id
+        else:
+            session_id = claude_session_id
+
         logger.info(
-            "Session sync [%s]: tool=%s msgs=%d tokens=%d/%d",
-            session_id[:8],
+            "Session sync [%s] terminal=[%s]: tool=%s msgs=%d tokens=%d/%d",
+            claude_session_id[:8],
+            terminal_id[:8] if terminal_id else "none",
             tool_name,
             message_count,
             total_input_tokens,
@@ -1043,8 +1060,6 @@ def agent_message():
         )
 
         try:
-            sync_session_mgr = get_remote_session_manager()._session_manager
-
             # Upsert the session record
             existing = sync_session_mgr.get_session(session_id)
             if not existing:
@@ -1055,10 +1070,31 @@ def agent_message():
                     model=model,
                     host_name=machine_id[:8],
                     context={
-                        "workspace_type": "remote",
+                        "workspace_type": "terminal",
                         "remote_machine_id": machine_id,
                     },
                 )
+            else:
+                # Update model/project_path if missing on existing session
+                updates = {}
+                if model and not existing.model:
+                    updates["model"] = model
+                if project_path and not existing.project_path:
+                    updates["project_path"] = project_path
+                if updates:
+                    sync_session_mgr.update_session_fields(session_id, updates)
+
+            # Fetch existing message uuids for dedup
+            existing_uuids: set[str] = set()
+            try:
+                existing_msgs = sync_session_mgr.get_messages(session_id)
+                for em in existing_msgs:
+                    em_meta = em.metadata if isinstance(em.metadata, dict) else {}
+                    em_uuid = em_meta.get("uuid", "")
+                    if em_uuid:
+                        existing_uuids.add(em_uuid)
+            except Exception:
+                pass
 
             # Mirror messages to daily_messages for ConversationHistory visibility
             try:
@@ -1083,9 +1119,15 @@ def agent_message():
                     # Use uuid for dedup if available, fallback to timestamp-based id
                     message_id = msg_uuid or f"{session_id}-{timestamp}"
 
+                    # Skip if message already synced (dedup by uuid)
+                    if msg_uuid and msg_uuid in existing_uuids:
+                        continue
+
                     # 1. Write to session_messages (dual-write with daily_messages)
                     try:
                         metadata = {"message_source": "web_terminal"}
+                        if msg_uuid:
+                            metadata["uuid"] = msg_uuid
                         if content_blocks:
                             metadata["content_blocks"] = content_blocks
                         if input_tokens or output_tokens:
@@ -1119,14 +1161,12 @@ def agent_message():
                         with get_db_connection() as conn:
                             cursor = conn.cursor()
                             cursor.execute(
-                                adapt_sql(
-                                    """INSERT OR IGNORE INTO daily_messages
+                                adapt_sql("""INSERT OR IGNORE INTO daily_messages
                                     (date, tool_name, host_name, message_id, role, content,
                                      full_entry, tokens_used, input_tokens, output_tokens,
                                      model, timestamp, message_source,
                                      conversation_id, agent_session_id, project_path)
-                                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"""
-                                ),
+                                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"""),
                                 (
                                     date_str,
                                     tool_name,

--- a/frontend/src/components/common/SessionDetailContent.tsx
+++ b/frontend/src/components/common/SessionDetailContent.tsx
@@ -31,7 +31,7 @@ export const SessionDetailContent: React.FC<SessionDetailContentProps> = ({
   onRestore,
   restorePending,
 }) => {
-  // Filter state: default to show user and assistant messages
+  // Filter state: default to show user, assistant, and system messages
   const [showUser, setShowUser] = useState(true);
   const [showAssistant, setShowAssistant] = useState(true);
   const [showSystem, setShowSystem] = useState(true);

--- a/frontend/src/components/common/SessionDetailContent.tsx
+++ b/frontend/src/components/common/SessionDetailContent.tsx
@@ -34,7 +34,7 @@ export const SessionDetailContent: React.FC<SessionDetailContentProps> = ({
   // Filter state: default to show user and assistant messages
   const [showUser, setShowUser] = useState(true);
   const [showAssistant, setShowAssistant] = useState(true);
-  const [showSystem, setShowSystem] = useState(false);
+  const [showSystem, setShowSystem] = useState(true);
   const [searchText, setSearchText] = useState('');
 
   // Filter messages based on role and search text

--- a/remote-agent/agent.py
+++ b/remote-agent/agent.py
@@ -317,6 +317,7 @@ class RemoteAgent:
                 "status": "busy" if active else "idle",
                 "active_sessions": len(active),
                 "active_terminals": len(self._terminal_processes),
+                "capabilities": self._capabilities,
             }
         )
 


### PR DESCRIPTION
## Summary

- **session_sync handler 使用 terminal_id**：将 Claude Code 会话消息关联到正确的 terminal session（侧边栏显示的），而非创建以 JSONL UUID 为 key 的孤儿 session
- **session_messages 去重**：基于 msg_uuid 防止重复 sync 导致 counters 膨胀
- **capabilities 动态更新**：心跳消息携带 capabilities，服务端写入 DB，解决手动安装 CLI 工具后 capabilities 不刷新的问题
- **register handler 修复死代码**：将 capabilities 正确写入数据库
- **启用 system 消息过滤器默认值**：SessionDetailContent 中 system filter 默认开启

## 根因

PR #416 修复了 JSONL 解析和双写，但 session_sync handler 中 `terminal_id` 被 payload 携带却从未使用。消息写入了以 Claude Code JSONL UUID 为 key 的新 session，而用户在侧边栏看到的 terminal session 始终为 0。

## Test plan

- [x] `tests/415/e2e_structured_content.py` 22/22 通过
- [x] 所有 pre-commit hooks 通过（black, ruff, mypy, bandit 等）
- [ ] 在远程机器上验证 session_sync 正确关联 terminal session
- [ ] 重启 agent 后 capabilities 正确更新 `claude_installed`

Closes #415

🤖 Generated with [Claude Code](https://claude.com/claude-code)