### PR TITLE
fix: auto-focus xterm terminal on activate

### DIFF
--- a/frontend/src/components/features/TerminalTab.tsx
+++ b/frontend/src/components/features/TerminalTab.tsx
@@ -115,7 +115,7 @@ export const TerminalTab: React.FC<TerminalTabProps> = ({
           }
         }
         if (isActiveRef.current) {
-          xtermRef.current?.focus();
+          try { xtermRef.current?.focus(); } catch {}
         }
       };
 
@@ -268,7 +268,7 @@ export const TerminalTab: React.FC<TerminalTabProps> = ({
     if (isActive && fitAddonRef.current && terminalRef.current) {
       const timer = setTimeout(() => {
         fitAddonRef.current?.fit();
-        xtermRef.current?.focus();
+        try { xtermRef.current?.focus(); } catch {}
       }, 100);
       return () => clearTimeout(timer);
     }

--- a/frontend/src/components/features/TerminalTab.tsx
+++ b/frontend/src/components/features/TerminalTab.tsx
@@ -45,6 +45,8 @@ export const TerminalTab: React.FC<TerminalTabProps> = ({
   const fitAddonRef = useRef<FitAddon | null>(null);
   const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const reconnectCountRef = useRef(0);
+  const isActiveRef = useRef(isActive);
+  isActiveRef.current = isActive;
 
   // Use refs for callbacks to avoid stale closures and unnecessary reconnects
   const onReattachNeededRef = useRef(onReattachNeeded);
@@ -111,6 +113,9 @@ export const TerminalTab: React.FC<TerminalTabProps> = ({
               })
             );
           }
+        }
+        if (isActiveRef.current) {
+          xtermRef.current?.focus();
         }
       };
 
@@ -258,11 +263,12 @@ export const TerminalTab: React.FC<TerminalTabProps> = ({
     }
   }, [connect, wsUrl, token]);
 
-  // Handle resize when tab becomes active
+  // Handle resize and focus when tab becomes active
   useEffect(() => {
     if (isActive && fitAddonRef.current && terminalRef.current) {
       const timer = setTimeout(() => {
         fitAddonRef.current?.fit();
+        xtermRef.current?.focus();
       }, 100);
       return () => clearTimeout(timer);
     }


### PR DESCRIPTION
## Summary
- Web terminal 启动后 tool 选择菜单无法直接用上下键选择，需要先鼠标点击才可使用
- 原因是 `TerminalTab.tsx` 中 xterm.js 终端从未调用 `terminal.focus()`
- 在 tab 激活时和 WebSocket 连接成功后自动聚焦终端

## Changes
- 新增 `isActiveRef` 用 ref 追踪 `isActive` 状态，避免影响 `connect` 回调依赖
- `ws.onopen` 连接成功后调用 `xtermRef.current?.focus()`
- `isActive` effect 中 `fitAddon.fit()` 之后调用 `xtermRef.current?.focus()`

## Test plan
- [ ] 启动 web terminal，确认 tool 选择菜单出现后可直接用上下键选择
- [ ] 切换到其他 tab 再切回 terminal tab，确认键盘仍然可用
- [ ] WebSocket 重连后，确认键盘仍然可用
- [ ] `cd frontend && npm run build` 编译通过 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)