### PR TITLE
fix: strip dynamic envKey values from settings.json

### DIFF
--- a/app/modules/workspace/api_key_proxy.py
+++ b/app/modules/workspace/api_key_proxy.py
@@ -474,11 +474,21 @@ class APIKeyProxyService:
         """
         settings = base_settings.copy()
 
+        # Collect dynamic env key names from modelProviders (qwen-code)
+        # e.g. envKey: "ZAI_API_KEY" or "BAILIAN_CODING_PLAN_API_KEY"
+        dynamic_env_keys: set[str] = set()
+        for provider_models in settings.get("modelProviders", {}).values():
+            if isinstance(provider_models, list):
+                for model in provider_models:
+                    if isinstance(model, dict) and "envKey" in model:
+                        dynamic_env_keys.add(model["envKey"])
+
         # Strip any API credential fields that the user may have
         # accidentally included in the UI.
+        all_sensitive = _SENSITIVE_ENV_KEYS | dynamic_env_keys
         env = settings.get("env", {})
         if env:
-            env = {k: v for k, v in env.items() if k not in _SENSITIVE_ENV_KEYS}
+            env = {k: v for k, v in env.items() if k not in all_sensitive}
             settings["env"] = env
 
         # Strip baseUrl from modelProviders entries (qwen-code)

--- a/frontend/src/components/features/management/APIKeyManagement.tsx
+++ b/frontend/src/components/features/management/APIKeyManagement.tsx
@@ -218,19 +218,38 @@ export const APIKeyManagement: React.FC = () => {
 
   const stripSensitiveFields = (toolSettings: Record<string, unknown>): Record<string, unknown> => {
     const cleaned = { ...toolSettings };
+
+    // Collect dynamic env key names from modelProviders (qwen-code)
+    // e.g. envKey: "ZAI_API_KEY" or "BAILIAN_CODING_PLAN_API_KEY"
+    const dynamicEnvKeys = new Set<string>();
+    const modelProviders = cleaned.modelProviders as Record<string, unknown[]> | undefined;
+    if (modelProviders && typeof modelProviders === 'object') {
+      for (const models of Object.values(modelProviders)) {
+        if (Array.isArray(models)) {
+          for (const model of models) {
+            if (model && typeof model === 'object' && 'envKey' in model) {
+              dynamicEnvKeys.add((model as Record<string, unknown>).envKey as string);
+            }
+          }
+        }
+      }
+    }
+
+    const allSensitive = new Set([...SENSITIVE_ENV_KEYS, ...dynamicEnvKeys]);
+
     // Strip sensitive env keys
     const env = cleaned.env as Record<string, unknown> | undefined;
     if (env && typeof env === 'object') {
       const cleanEnv = { ...env };
       for (const key of Object.keys(cleanEnv)) {
-        if (SENSITIVE_ENV_KEYS.has(key)) {
+        if (allSensitive.has(key)) {
           delete cleanEnv[key];
         }
       }
       cleaned.env = cleanEnv;
     }
+
     // Strip baseUrl from modelProviders (qwen-code)
-    const modelProviders = cleaned.modelProviders as Record<string, unknown[]> | undefined;
     if (modelProviders && typeof modelProviders === 'object') {
       for (const models of Object.values(modelProviders)) {
         if (Array.isArray(models)) {

--- a/remote-agent/agent.py
+++ b/remote-agent/agent.py
@@ -940,10 +940,20 @@ class RemoteAgent:
         """
         settings = settings.copy()
 
+        # Collect dynamic env key names from modelProviders (qwen-code)
+        # e.g. envKey: "ZAI_API_KEY" or "BAILIAN_CODING_PLAN_API_KEY"
+        dynamic_env_keys: set[str] = set()
+        for provider_models in settings.get("modelProviders", {}).values():
+            if isinstance(provider_models, list):
+                for model in provider_models:
+                    if isinstance(model, dict) and "envKey" in model:
+                        dynamic_env_keys.add(model["envKey"])
+
         # Remove sensitive keys from env block
+        all_sensitive = SENSITIVE_ENV_KEYS | dynamic_env_keys
         env = settings.get("env", {})
         if env:
-            env = {k: v for k, v in env.items() if k not in SENSITIVE_ENV_KEYS}
+            env = {k: v for k, v in env.items() if k not in all_sensitive}
             settings["env"] = env
 
         # Remove baseUrl from modelProviders (qwen-code)

--- a/remote-agent/cli_adapters/qwen_code.py
+++ b/remote-agent/cli_adapters/qwen_code.py
@@ -140,11 +140,20 @@ class QwenCodeAdapter(BaseCLIAdapter):
         """
         settings = base_settings.copy()
 
+        # Collect dynamic env key names from modelProviders
+        dynamic_env_keys: set[str] = set()
+        for provider_models in settings.get("modelProviders", {}).values():
+            if isinstance(provider_models, list):
+                for model in provider_models:
+                    if isinstance(model, dict) and "envKey" in model:
+                        dynamic_env_keys.add(model["envKey"])
+
         # Strip any API credential fields that the user may have
         # accidentally included.
+        all_sensitive = SENSITIVE_ENV_KEYS | dynamic_env_keys
         env = settings.get("env", {})
         if env:
-            env = {k: v for k, v in env.items() if k not in SENSITIVE_ENV_KEYS}
+            env = {k: v for k, v in env.items() if k not in all_sensitive}
             settings["env"] = env
 
         # Strip baseUrl from modelProviders entries


### PR DESCRIPTION
## Problem

Qwen Code settings.json still contained `ZAI_API_KEY` after the terminal proxy fix (PR #423).

`modelProviders` entries can specify custom `envKey` names (e.g. `ZAI_API_KEY`, `BAILIAN_CODING_PLAN_API_KEY`). These dynamic key names were not being stripped because `_SENSITIVE_ENV_KEYS` only contained hardcoded names (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, etc.).

## Fix

Collect `envKey` values from `modelProviders` and add them to the sensitive keys set before filtering the `env` block.

Applied to:
- `api_key_proxy.py` (backend)
- `agent.py` (remote agent)
- `cli_adapters/qwen_code.py` (adapter)
- `APIKeyManagement.tsx` (frontend)
