### PR TITLE
fix: address review comments for dynamic envKey stripping

### DIFF
--- a/app/modules/workspace/api_key_proxy.py
+++ b/app/modules/workspace/api_key_proxy.py
@@ -34,6 +34,24 @@ _SENSITIVE_ENV_KEYS = frozenset(
 )
 
 
+def _collect_dynamic_env_keys(settings: dict[str, Any]) -> set[str]:
+    """Collect dynamic envKey names from modelProviders entries.
+
+    Qwen Code's modelProviders can specify custom envKey names like
+    "ZAI_API_KEY" or "BAILIAN_CODING_PLAN_API_KEY". These must also
+    be stripped from the env block to prevent API key leakage.
+
+    Keep in sync with remote-agent/constants.py:collect_dynamic_env_keys().
+    """
+    dynamic: set[str] = set()
+    for provider_models in settings.get("modelProviders", {}).values():
+        if isinstance(provider_models, list):
+            for model in provider_models:
+                if isinstance(model, dict) and isinstance(model.get("envKey"), str):
+                    dynamic.add(model["envKey"])
+    return dynamic
+
+
 def _param() -> str:
     """Get the correct parameter placeholder for the current database."""
     return "?" if not is_postgresql() else "%s"
@@ -473,19 +491,10 @@ class APIKeyProxyService:
             Settings dict with non-sensitive config only.
         """
         settings = base_settings.copy()
-
-        # Collect dynamic env key names from modelProviders (qwen-code)
-        # e.g. envKey: "ZAI_API_KEY" or "BAILIAN_CODING_PLAN_API_KEY"
-        dynamic_env_keys: set[str] = set()
-        for provider_models in settings.get("modelProviders", {}).values():
-            if isinstance(provider_models, list):
-                for model in provider_models:
-                    if isinstance(model, dict) and "envKey" in model:
-                        dynamic_env_keys.add(model["envKey"])
+        all_sensitive = _SENSITIVE_ENV_KEYS | _collect_dynamic_env_keys(settings)
 
         # Strip any API credential fields that the user may have
         # accidentally included in the UI.
-        all_sensitive = _SENSITIVE_ENV_KEYS | dynamic_env_keys
         env = settings.get("env", {})
         if env:
             env = {k: v for k, v in env.items() if k not in all_sensitive}

--- a/frontend/src/components/features/management/APIKeyManagement.tsx
+++ b/frontend/src/components/features/management/APIKeyManagement.tsx
@@ -218,16 +218,16 @@ export const APIKeyManagement: React.FC = () => {
 
   const stripSensitiveFields = (toolSettings: Record<string, unknown>): Record<string, unknown> => {
     const cleaned = { ...toolSettings };
+    const modelProviders = cleaned.modelProviders as Record<string, unknown[]> | undefined;
 
     // Collect dynamic env key names from modelProviders (qwen-code)
     // e.g. envKey: "ZAI_API_KEY" or "BAILIAN_CODING_PLAN_API_KEY"
     const dynamicEnvKeys = new Set<string>();
-    const modelProviders = cleaned.modelProviders as Record<string, unknown[]> | undefined;
     if (modelProviders && typeof modelProviders === 'object') {
       for (const models of Object.values(modelProviders)) {
         if (Array.isArray(models)) {
           for (const model of models) {
-            if (model && typeof model === 'object' && 'envKey' in model) {
+            if (model && typeof model === 'object' && typeof (model as Record<string, unknown>).envKey === 'string') {
               dynamicEnvKeys.add((model as Record<string, unknown>).envKey as string);
             }
           }

--- a/remote-agent/agent.py
+++ b/remote-agent/agent.py
@@ -23,7 +23,7 @@ from pathlib import Path
 from typing import Any
 
 import requests
-from constants import SENSITIVE_ENV_KEYS
+from constants import SENSITIVE_ENV_KEYS, collect_dynamic_env_keys
 from executor import ProcessExecutor
 from session_sync import SessionSyncService
 from system_info import get_capabilities
@@ -939,18 +939,9 @@ class RemoteAgent:
         (remote session), so they must not be written to settings.json.
         """
         settings = settings.copy()
-
-        # Collect dynamic env key names from modelProviders (qwen-code)
-        # e.g. envKey: "ZAI_API_KEY" or "BAILIAN_CODING_PLAN_API_KEY"
-        dynamic_env_keys: set[str] = set()
-        for provider_models in settings.get("modelProviders", {}).values():
-            if isinstance(provider_models, list):
-                for model in provider_models:
-                    if isinstance(model, dict) and "envKey" in model:
-                        dynamic_env_keys.add(model["envKey"])
+        all_sensitive = SENSITIVE_ENV_KEYS | collect_dynamic_env_keys(settings)
 
         # Remove sensitive keys from env block
-        all_sensitive = SENSITIVE_ENV_KEYS | dynamic_env_keys
         env = settings.get("env", {})
         if env:
             env = {k: v for k, v in env.items() if k not in all_sensitive}

--- a/remote-agent/cli_adapters/qwen_code.py
+++ b/remote-agent/cli_adapters/qwen_code.py
@@ -13,7 +13,7 @@ import logging
 import shutil
 from pathlib import Path
 
-from constants import SENSITIVE_ENV_KEYS
+from constants import SENSITIVE_ENV_KEYS, collect_dynamic_env_keys
 
 from .base import BaseCLIAdapter
 
@@ -140,17 +140,9 @@ class QwenCodeAdapter(BaseCLIAdapter):
         """
         settings = base_settings.copy()
 
-        # Collect dynamic env key names from modelProviders
-        dynamic_env_keys: set[str] = set()
-        for provider_models in settings.get("modelProviders", {}).values():
-            if isinstance(provider_models, list):
-                for model in provider_models:
-                    if isinstance(model, dict) and "envKey" in model:
-                        dynamic_env_keys.add(model["envKey"])
-
         # Strip any API credential fields that the user may have
         # accidentally included.
-        all_sensitive = SENSITIVE_ENV_KEYS | dynamic_env_keys
+        all_sensitive = SENSITIVE_ENV_KEYS | collect_dynamic_env_keys(settings)
         env = settings.get("env", {})
         if env:
             env = {k: v for k, v in env.items() if k not in all_sensitive}

--- a/remote-agent/constants.py
+++ b/remote-agent/constants.py
@@ -1,5 +1,9 @@
 """Shared constants for the Open ACE remote agent."""
 
+from __future__ import annotations
+
+from typing import Any
+
 # Environment variable keys that contain API credentials.
 # These must NEVER be written to settings.json — they are injected
 # via environment variables at process launch time.
@@ -11,3 +15,25 @@ SENSITIVE_ENV_KEYS = frozenset(
         "OPENAI_BASE_URL",
     }
 )
+
+
+def collect_dynamic_env_keys(settings: dict[str, Any]) -> set[str]:
+    """Collect dynamic envKey names from modelProviders entries.
+
+    Qwen Code's modelProviders can specify custom envKey names like
+    "ZAI_API_KEY" or "BAILIAN_CODING_PLAN_API_KEY". These must also
+    be stripped from the env block to prevent API key leakage.
+
+    Args:
+        settings: CLI settings dict that may contain modelProviders.
+
+    Returns:
+        Set of envKey name strings found in modelProviders.
+    """
+    dynamic: set[str] = set()
+    for provider_models in settings.get("modelProviders", {}).values():
+        if isinstance(provider_models, list):
+            for model in provider_models:
+                if isinstance(model, dict) and isinstance(model.get("envKey"), str):
+                    dynamic.add(model["envKey"])
+    return dynamic

--- a/tests/unit/test_cli_settings_strip.py
+++ b/tests/unit/test_cli_settings_strip.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""
+Unit tests for sensitive field stripping in CLI settings.
+
+Verifies that API keys and base URLs are properly stripped from
+settings.json, including dynamic envKey names from modelProviders.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+project_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+
+
+class TestCollectDynamicEnvKeys:
+    """Test _collect_dynamic_env_keys / collect_dynamic_env_keys."""
+
+    def test_empty_settings(self):
+        from app.modules.workspace.api_key_proxy import _collect_dynamic_env_keys
+
+        assert _collect_dynamic_env_keys({}) == set()
+
+    def test_no_model_providers(self):
+        from app.modules.workspace.api_key_proxy import _collect_dynamic_env_keys
+
+        settings = {"env": {"FOO": "bar"}, "model": {"name": "test"}}
+        assert _collect_dynamic_env_keys(settings) == set()
+
+    def test_collects_env_key_from_providers(self):
+        from app.modules.workspace.api_key_proxy import _collect_dynamic_env_keys
+
+        settings = {
+            "modelProviders": {
+                "openai": [
+                    {"id": "glm-5", "name": "glm-5", "envKey": "ZAI_API_KEY"},
+                    {"id": "gpt-4", "name": "gpt-4", "envKey": "CUSTOM_KEY"},
+                ]
+            }
+        }
+        result = _collect_dynamic_env_keys(settings)
+        assert result == {"ZAI_API_KEY", "CUSTOM_KEY"}
+
+    def test_ignores_non_string_env_key(self):
+        from app.modules.workspace.api_key_proxy import _collect_dynamic_env_keys
+
+        settings = {
+            "modelProviders": {
+                "openai": [
+                    {"id": "m1", "envKey": 123},  # not a string
+                    {"id": "m2", "envKey": "VALID_KEY"},
+                ]
+            }
+        }
+        result = _collect_dynamic_env_keys(settings)
+        assert result == {"VALID_KEY"}
+
+    def test_ignores_missing_env_key(self):
+        from app.modules.workspace.api_key_proxy import _collect_dynamic_env_keys
+
+        settings = {
+            "modelProviders": {
+                "openai": [
+                    {"id": "m1", "name": "model-1"},  # no envKey
+                ]
+            }
+        }
+        assert _collect_dynamic_env_keys(settings) == set()
+
+
+class TestBuildCliSettingsStripsSensitive:
+    """Test that _build_cli_settings_for_tool strips sensitive fields."""
+
+    def test_strips_hardcoded_keys(self):
+        from app.modules.workspace.api_key_proxy import APIKeyProxyService
+
+        svc = APIKeyProxyService.__new__(APIKeyProxyService)
+        settings = {
+            "env": {
+                "ANTHROPIC_API_KEY": "secret-key",
+                "ANTHROPIC_BASE_URL": "https://api.example.com",
+                "ANTHROPIC_MODEL": "claude-3",  # should be kept
+            },
+            "model": "haiku",
+        }
+        result = svc._build_cli_settings_for_tool("claude-code", settings)
+        assert "ANTHROPIC_API_KEY" not in result.get("env", {})
+        assert "ANTHROPIC_BASE_URL" not in result.get("env", {})
+        assert result["env"]["ANTHROPIC_MODEL"] == "claude-3"
+        assert result["model"] == "haiku"
+
+    def test_strips_dynamic_env_key(self):
+        from app.modules.workspace.api_key_proxy import APIKeyProxyService
+
+        svc = APIKeyProxyService.__new__(APIKeyProxyService)
+        settings = {
+            "env": {
+                "ZAI_API_KEY": "secret-key",  # dynamic envKey
+                "SOME_OTHER_VAR": "keep-me",
+            },
+            "modelProviders": {
+                "openai": [
+                    {"id": "glm-5", "name": "glm-5", "envKey": "ZAI_API_KEY"},
+                ]
+            },
+        }
+        result = svc._build_cli_settings_for_tool("qwen-code", settings)
+        assert "ZAI_API_KEY" not in result.get("env", {})
+        assert result["env"]["SOME_OTHER_VAR"] == "keep-me"
+
+    def test_strips_base_url_from_model_providers(self):
+        from app.modules.workspace.api_key_proxy import APIKeyProxyService
+
+        svc = APIKeyProxyService.__new__(APIKeyProxyService)
+        settings = {
+            "modelProviders": {
+                "openai": [
+                    {"id": "m1", "name": "model-1", "baseUrl": "https://api.example.com"},
+                ]
+            },
+        }
+        result = svc._build_cli_settings_for_tool("qwen-code", settings)
+        assert "baseUrl" not in result["modelProviders"]["openai"][0]
+
+    def test_preserves_non_sensitive_config(self):
+        from app.modules.workspace.api_key_proxy import APIKeyProxyService
+
+        svc = APIKeyProxyService.__new__(APIKeyProxyService)
+        settings = {
+            "env": {"ANTHROPIC_MODEL": "glm-5"},
+            "model": "haiku",
+            "theme": "dark",
+        }
+        result = svc._build_cli_settings_for_tool("claude-code", settings)
+        assert result["env"]["ANTHROPIC_MODEL"] == "glm-5"
+        assert result["model"] == "haiku"
+        assert result["theme"] == "dark"


### PR DESCRIPTION
Addresses review comments on PR #438:

1. **Extract shared function**: `collect_dynamic_env_keys()` in `remote-agent/constants.py`; `api_key_proxy.py` has local copy with sync comment
2. **Type safety**: Add `isinstance(model.get("envKey"), str)` guard
3. **Tests**: Add 9 unit tests for envKey filtering in `tests/unit/test_cli_settings_strip.py`
4. **Frontend readability**: Move `modelProviders` variable declaration earlier, add `typeof` guard
