### PR TITLE
fix: remove unused useCallback import in RemoteMachineSelector

### DIFF
--- a/frontend/src/components/work/RemoteMachineSelector.tsx
+++ b/frontend/src/components/work/RemoteMachineSelector.tsx
@@ -10,7 +10,7 @@
  * Issue #317: Remote workspace lacks project creation functionality
  */
 
-import React, { useState, useEffect, useMemo, useCallback, useRef } from 'react';
+import React, { useState, useEffect, useMemo, useRef } from 'react';
 import { useLanguage } from '@/store';
 import { t } from '@/i18n';
 import { remoteApi, type RemoteMachine } from '@/api/remote';


### PR DESCRIPTION
## Summary
- Remove unused `useCallback` import from `RemoteMachineSelector.tsx` that causes TypeScript build failure

## Test plan
- [x] `npm run build` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)