### PR TITLE
fix: request-dashboard 用户请求数柱状图显示问题 (Issue #446)

### DIFF
--- a/frontend/src/components/common/Charts.tsx
+++ b/frontend/src/components/common/Charts.tsx
@@ -287,6 +287,8 @@ interface BarChartProps {
   className?: string;
   /** Format large numbers (e.g., 'M' for millions) */
   unit?: 'none' | 'K' | 'M' | 'B';
+  /** User names for tooltip display (used when labels are ranking numbers) */
+  usernames?: string[];
 }
 
 export const BarChart: React.FC<BarChartProps> = ({
@@ -299,6 +301,7 @@ export const BarChart: React.FC<BarChartProps> = ({
   stacked = false,
   className,
   unit = 'none',
+  usernames,
 }) => {
   // Helper function to format values based on unit
   const formatValue = (value: number): number => {
@@ -347,7 +350,23 @@ export const BarChart: React.FC<BarChartProps> = ({
       tooltip: {
         callbacks: {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          title: (context: any[]) => {
+            // For horizontal bar charts with usernames, show username as title
+            if (horizontal && usernames && context[0]) {
+              const dataIndex = context[0].dataIndex ?? 0;
+              return usernames[dataIndex] ?? '';
+            }
+            // Default: use label (ranking number or category)
+            return context[0]?.label ?? '';
+          },
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
           label: (context: any) => {
+            // For horizontal bar charts with usernames, show "请求数: value"
+            if (horizontal && usernames) {
+              const value = context.parsed?.x;
+              return `请求数: ${value?.toLocaleString() ?? 0}`;
+            }
+            // Default format
             const label = context.dataset?.label ?? '';
             const value = context.parsed?.y;
             if (unit !== 'none') {
@@ -359,28 +378,36 @@ export const BarChart: React.FC<BarChartProps> = ({
       },
     },
     scales: {
-      x: {
-        stacked,
-      },
-      y: {
-        stacked,
-        beginAtZero: true,
-        max: yMax,
-        ticks:
-          unit !== 'none'
-            ? {
-                stepSize: 1,
-                callback: (value: string | number) => `${value}${unit}`,
-              }
-            : undefined,
-        title:
-          unit !== 'none'
-            ? {
-                display: true,
-                text: `Tokens (${unit})`,
-              }
-            : undefined,
-      },
+      // For horizontal bar charts: X is value axis, Y is category axis
+      // For vertical bar charts: X is category axis, Y is value axis
+      x: horizontal
+        ? {
+            stacked,
+            beginAtZero: true,
+            max: yMax,
+          }
+        : { stacked },
+      y: horizontal
+        ? { stacked }
+        : {
+            stacked,
+            beginAtZero: true,
+            max: yMax,
+            ticks:
+              unit !== 'none'
+                ? {
+                    stepSize: 1,
+                    callback: (value: string | number) => `${value}${unit}`,
+                  }
+                : undefined,
+            title:
+              unit !== 'none'
+                ? {
+                    display: true,
+                    text: `Tokens (${unit})`,
+                  }
+                : undefined,
+          },
     },
   };
 

--- a/frontend/src/components/common/LazyCharts.tsx
+++ b/frontend/src/components/common/LazyCharts.tsx
@@ -56,6 +56,7 @@ export interface BarChartProps {
   stacked?: boolean;
   className?: string;
   unit?: 'none' | 'K' | 'M' | 'B';
+  usernames?: string[];
 }
 
 export interface PieChartProps {

--- a/frontend/src/components/features/management/RequestDashboard.tsx
+++ b/frontend/src/components/features/management/RequestDashboard.tsx
@@ -141,10 +141,13 @@ export const RequestDashboard: React.FC = () => {
   }, [trendData]);
 
   // Prepare user bar chart data
+  // Y-axis shows ranking (1, 2, 3...), X-axis shows request count
+  // Tooltip shows username + request count
   const userChartData = useMemo(() => {
     const topUsers = aggregatedUserStats.slice(0, 10);
     return {
-      labels: topUsers.map((u) => u.user),
+      labels: topUsers.map((_, index) => String(index + 1)), // 排序号从1开始
+      usernames: topUsers.map((u) => u.user), // 保存用户名用于 tooltip
       datasets: [
         {
           label: t('requests', language),
@@ -340,6 +343,7 @@ export const RequestDashboard: React.FC = () => {
                 datasets={userChartData.datasets}
                 height={300}
                 horizontal
+                usernames={userChartData.usernames}
               />
             ) : (
               <EmptyState icon="bi-people" title={t('noData', language)} />


### PR DESCRIPTION
## 问题

在 `/manage/analysis/request-dashboard` 页面的"用户请求数"横向条形图中存在以下问题：

1. **Y轴显示错误**：纵坐标显示用户名，但应显示排序号（从1开始计数）
2. **Tooltip格式错误**：鼠标悬停时 tooltip 显示的值不正确

## 修复内容

1. **RequestDashboard.tsx**：将 labels 改为排序号（1-10），新增 usernames 数组保存用户名
2. **Charts.tsx**：支持 usernames 属性，tooltip 中显示用户名作为标题，请求数作为内容
3. **LazyCharts.tsx**：扩展 BarChartProps 类型定义

## 修复后效果

- **Y轴（纵坐标）**：排序号（1, 2, 3...），从上到下按请求数降序排列
- **X轴（横坐标）**：请求数（从 0 开始）
- **Tooltip格式**：
  ```
  dwu-ai-lab.dev.ivyent-qwen
  请求数: 332
  ```

## 关联

Closes #446

🤖 Generated with Qwen Code (13-shotted by Qwen-Coder)