### PR TITLE
fix: resolve remote session fetch failed caused by custom envKey in qwen settings

### DIFF
--- a/remote-agent/agent.py
+++ b/remote-agent/agent.py
@@ -1035,6 +1035,22 @@ class RemoteAgent:
         if "$version" not in merged:
             merged["$version"] = 3
 
+        # Normalize modelProviders: unify all envKeys to OPENAI_API_KEY
+        # and remove baseUrl entries so the CLI uses the proxy via env vars.
+        # This prevents user-configured custom envKeys (e.g. BAILIAN_CODING_PLAN_API_KEY)
+        # or external baseUrls from bypassing the LLM proxy.
+        providers = merged.get("modelProviders", {})
+        if isinstance(providers, dict):
+            for _auth_type, models in providers.items():
+                if not isinstance(models, list):
+                    continue
+                for model in models:
+                    if not isinstance(model, dict):
+                        continue
+                    if "envKey" in model:
+                        model["envKey"] = "OPENAI_API_KEY"
+                    model.pop("baseUrl", None)
+
         # Atomic write via temp file + rename
         self._atomic_write_json(str(settings_path), merged)
         logger.info("Wrote Qwen Code settings to %s", settings_path)

--- a/remote-agent/agent.py
+++ b/remote-agent/agent.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from typing import Any
 
 import requests
+from cli_adapters.base import normalize_model_providers
 from constants import SENSITIVE_ENV_KEYS, collect_dynamic_env_keys
 from executor import ProcessExecutor
 from session_sync import SessionSyncService
@@ -1037,19 +1038,7 @@ class RemoteAgent:
 
         # Normalize modelProviders: unify all envKeys to OPENAI_API_KEY
         # and remove baseUrl entries so the CLI uses the proxy via env vars.
-        # This prevents user-configured custom envKeys (e.g. BAILIAN_CODING_PLAN_API_KEY)
-        # or external baseUrls from bypassing the LLM proxy.
-        providers = merged.get("modelProviders", {})
-        if isinstance(providers, dict):
-            for _auth_type, models in providers.items():
-                if not isinstance(models, list):
-                    continue
-                for model in models:
-                    if not isinstance(model, dict):
-                        continue
-                    if "envKey" in model:
-                        model["envKey"] = "OPENAI_API_KEY"
-                    model.pop("baseUrl", None)
+        normalize_model_providers(merged)
 
         # Atomic write via temp file + rename
         self._atomic_write_json(str(settings_path), merged)

--- a/remote-agent/cli_adapters/base.py
+++ b/remote-agent/cli_adapters/base.py
@@ -136,6 +136,10 @@ class BaseCLIAdapter(abc.ABC):
         """Return the executable name (e.g., 'qwen', 'claude')."""
         pass
 
+    def get_settings_path(self) -> str | None:
+        """Return the path to the CLI tool's settings.json, or None if not applicable."""
+        return None
+
     def supports_stdin_input(self) -> bool:
         """Whether this CLI tool supports sending messages via stdin pipe."""
         return True

--- a/remote-agent/cli_adapters/base.py
+++ b/remote-agent/cli_adapters/base.py
@@ -9,6 +9,90 @@ CLI coding tool (e.g., qwen-code, claude-code, openclaw).
 from __future__ import annotations
 
 import abc
+import json
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def collect_custom_envkeys(
+    settings_path: str | Path,
+    token_value: str,
+) -> dict[str, str]:
+    """
+    Read a qwen-code settings file and return env vars for any custom
+    envKeys found in modelProviders.
+
+    The CLI may reference non-standard env var names (e.g.
+    BAILIAN_CODING_PLAN_API_KEY) in modelProviders entries.  This
+    function collects those keys and maps them all to *token_value* so
+    the proxy token is available regardless of which envKey the CLI
+    reads at runtime.
+
+    Args:
+        settings_path: Path to the settings.json file.
+        token_value: Value to assign (typically the proxy token).
+
+    Returns:
+        Dict of env var name -> token_value for every custom envKey
+        found.  Standard ``OPENAI_API_KEY`` is excluded (already set by
+        the adapter).
+    """
+    env_overrides: dict[str, str] = {}
+    try:
+        p = Path(settings_path)
+        if not p.is_file():
+            return env_overrides
+        with open(p, encoding="utf-8") as f:
+            settings_data = json.load(f)
+        providers = settings_data.get("modelProviders", {})
+        if isinstance(providers, dict):
+            for _provider_name, models_list in providers.items():
+                if not isinstance(models_list, list):
+                    continue
+                for entry in models_list:
+                    if isinstance(entry, dict):
+                        custom_key = entry.get("envKey")
+                        if custom_key and custom_key != "OPENAI_API_KEY":
+                            env_overrides[custom_key] = token_value
+    except Exception:
+        logger.debug(
+            "Failed to read custom envKeys from %s",
+            settings_path,
+            exc_info=True,
+        )
+    return env_overrides
+
+
+def normalize_model_providers(settings: dict) -> None:
+    """
+    Normalize modelProviders in-place: unify all envKeys to
+    OPENAI_API_KEY and remove baseUrl entries.
+
+    This ensures the CLI reads credentials from the standard
+    OPENAI_API_KEY / OPENAI_BASE_URL env vars injected by the agent,
+    rather than user-configured custom keys or external baseUrls that
+    would bypass the LLM proxy.
+
+    Only ``envKey`` and ``baseUrl`` fields are touched; all other
+    model configuration (id, name, generationConfig, etc.) and
+    top-level settings keys (mcpServers, statusLine, etc.) are
+    preserved.
+    """
+    providers = settings.get("modelProviders", {})
+    if not isinstance(providers, dict):
+        return
+    for _provider_name, models in providers.items():
+        if not isinstance(models, list):
+            continue
+        for model in models:
+            if not isinstance(model, dict):
+                continue
+            if "envKey" in model:
+                model["envKey"] = "OPENAI_API_KEY"
+            # Intentionally modify dict values (not keys) during iteration.
+            model.pop("baseUrl", None)
 
 
 class BaseCLIAdapter(abc.ABC):

--- a/remote-agent/cli_adapters/qwen_code.py
+++ b/remote-agent/cli_adapters/qwen_code.py
@@ -148,12 +148,9 @@ class QwenCodeAdapter(BaseCLIAdapter):
             env = {k: v for k, v in env.items() if k not in all_sensitive}
             settings["env"] = env
 
-        # Strip baseUrl from modelProviders entries
-        for provider_models in settings.get("modelProviders", {}).values():
-            if isinstance(provider_models, list):
-                for model in provider_models:
-                    if isinstance(model, dict):
-                        model.pop("baseUrl", None)
+        # Note: baseUrl stripping from modelProviders is handled by
+        # normalize_model_providers() in cli_adapters/base.py, called
+        # by the agent after merging settings.
 
         return settings
 

--- a/remote-agent/executor.py
+++ b/remote-agent/executor.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable
 
 from cli_adapters import get_adapter
+from cli_adapters.base import collect_custom_envkeys
 
 if TYPE_CHECKING:
     from cli_adapters.base import BaseCLIAdapter
@@ -626,19 +627,8 @@ class ProcessExecutor:
         # but this catches cases where settings were edited after that step.
         try:
             settings_path = adapter.get_settings_path()
-            if settings_path and os.path.isfile(settings_path):
-                with open(settings_path, encoding="utf-8") as f:
-                    settings_data = json.load(f)
-                providers = settings_data.get("modelProviders", {})
-                if isinstance(providers, dict):
-                    for _auth_type, models_list in providers.items():
-                        if not isinstance(models_list, list):
-                            continue
-                        for entry in models_list:
-                            if isinstance(entry, dict):
-                                custom_key = entry.get("envKey")
-                                if custom_key and custom_key != "OPENAI_API_KEY":
-                                    env[custom_key] = proxy_token
+            if settings_path:
+                env.update(collect_custom_envkeys(settings_path, proxy_token))
         except Exception:
             pass  # Non-critical fallback; proxy token is already set via adapter
 

--- a/remote-agent/executor.py
+++ b/remote-agent/executor.py
@@ -620,6 +620,28 @@ class ProcessExecutor:
         if model:
             env["OPENACE_MODEL"] = model
 
+        # Fallback: read settings to inject any custom envKeys that
+        # modelProviders may reference (e.g. BAILIAN_CODING_PLAN_API_KEY).
+        # Normally _write_qwen_settings normalizes envKey → OPENAI_API_KEY,
+        # but this catches cases where settings were edited after that step.
+        try:
+            settings_path = adapter.get_settings_path()
+            if settings_path and os.path.isfile(settings_path):
+                with open(settings_path, encoding="utf-8") as f:
+                    settings_data = json.load(f)
+                providers = settings_data.get("modelProviders", {})
+                if isinstance(providers, dict):
+                    for _auth_type, models_list in providers.items():
+                        if not isinstance(models_list, list):
+                            continue
+                        for entry in models_list:
+                            if isinstance(entry, dict):
+                                custom_key = entry.get("envKey")
+                                if custom_key and custom_key != "OPENAI_API_KEY":
+                                    env[custom_key] = proxy_token
+        except Exception:
+            pass  # Non-critical fallback; proxy token is already set via adapter
+
         return env
 
     def _find_executable(self, cli_tool: str) -> str | None:

--- a/remote-agent/terminal_server.py
+++ b/remote-agent/terminal_server.py
@@ -24,6 +24,9 @@ import struct
 import sys
 import termios
 import urllib.parse
+from pathlib import Path
+
+from cli_adapters.base import collect_custom_envkeys
 
 try:
     import websockets
@@ -323,22 +326,8 @@ def _build_env() -> dict[str, str]:
             # (e.g. BAILIAN_CODING_PLAN_API_KEY) so the proxy token
             # is available regardless of which envKey the CLI reads.
             try:
-                import pathlib
-
-                settings_path = pathlib.Path.home() / ".qwen" / "settings.json"
-                if settings_path.is_file():
-                    with open(settings_path, encoding="utf-8") as f:
-                        settings_data = json.load(f)
-                    providers = settings_data.get("modelProviders", {})
-                    if isinstance(providers, dict):
-                        for _auth_type, models_list in providers.items():
-                            if not isinstance(models_list, list):
-                                continue
-                            for entry in models_list:
-                                if isinstance(entry, dict):
-                                    custom_key = entry.get("envKey")
-                                    if custom_key and custom_key != "OPENAI_API_KEY":
-                                        env[custom_key] = OPENAI_TOKEN
+                settings_path = Path.home() / ".qwen" / "settings.json"
+                env.update(collect_custom_envkeys(settings_path, OPENAI_TOKEN))
             except Exception:
                 pass  # Non-critical fallback
     env["TERM"] = "xterm-256color"

--- a/remote-agent/terminal_server.py
+++ b/remote-agent/terminal_server.py
@@ -318,6 +318,29 @@ def _build_env() -> dict[str, str]:
         if OPENAI_TOKEN:
             env["OPENAI_API_KEY"] = OPENAI_TOKEN
             env["OPENAI_BASE_URL"] = PROXY_URL
+
+            # Fallback: inject custom envKeys from qwen settings
+            # (e.g. BAILIAN_CODING_PLAN_API_KEY) so the proxy token
+            # is available regardless of which envKey the CLI reads.
+            try:
+                import pathlib
+
+                settings_path = pathlib.Path.home() / ".qwen" / "settings.json"
+                if settings_path.is_file():
+                    with open(settings_path, encoding="utf-8") as f:
+                        settings_data = json.load(f)
+                    providers = settings_data.get("modelProviders", {})
+                    if isinstance(providers, dict):
+                        for _auth_type, models_list in providers.items():
+                            if not isinstance(models_list, list):
+                                continue
+                            for entry in models_list:
+                                if isinstance(entry, dict):
+                                    custom_key = entry.get("envKey")
+                                    if custom_key and custom_key != "OPENAI_API_KEY":
+                                        env[custom_key] = OPENAI_TOKEN
+            except Exception:
+                pass  # Non-critical fallback
     env["TERM"] = "xterm-256color"
     # Pass terminal ID to child processes for accurate session-terminal association
     if TERMINAL_ID:

--- a/tests/issues/456/test_envkey_normalization.py
+++ b/tests/issues/456/test_envkey_normalization.py
@@ -1,0 +1,224 @@
+"""
+Tests for custom envKey normalization and fallback injection.
+
+Covers:
+- normalize_model_providers: envKey unification + baseUrl removal
+- collect_custom_envkeys: reading settings and returning env overrides
+- Edge cases: malformed entries, missing fields, nested structures
+"""
+
+import json
+import os
+
+# Add remote-agent to sys.path so we can import cli_adapters
+import sys
+import tempfile
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "..", "remote-agent"))
+
+from cli_adapters.base import collect_custom_envkeys, normalize_model_providers
+
+# ---------------------------------------------------------------------------
+# normalize_model_providers tests
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeModelProviders:
+    """Tests for normalize_model_providers()."""
+
+    def test_unifies_custom_envkey_to_openai(self):
+        settings = {
+            "modelProviders": {
+                "openai": [
+                    {"envKey": "BAILIAN_CODING_PLAN_API_KEY", "id": "glm-5", "name": "glm-5"}
+                ]
+            }
+        }
+        normalize_model_providers(settings)
+        assert settings["modelProviders"]["openai"][0]["envKey"] == "OPENAI_API_KEY"
+
+    def test_removes_base_url(self):
+        settings = {
+            "modelProviders": {
+                "openai": [
+                    {
+                        "envKey": "OPENAI_API_KEY",
+                        "id": "gpt-4o",
+                        "baseUrl": "https://api.openai.com/v1",
+                    }
+                ]
+            }
+        }
+        normalize_model_providers(settings)
+        assert "baseUrl" not in settings["modelProviders"]["openai"][0]
+
+    def test_preserves_other_fields(self):
+        settings = {
+            "modelProviders": {
+                "openai": [
+                    {
+                        "envKey": "CUSTOM_KEY",
+                        "id": "gpt-4o",
+                        "name": "GPT-4o",
+                        "generationConfig": {"timeout": 60000},
+                    }
+                ]
+            }
+        }
+        normalize_model_providers(settings)
+        entry = settings["modelProviders"]["openai"][0]
+        assert entry["envKey"] == "OPENAI_API_KEY"
+        assert entry["id"] == "gpt-4o"
+        assert entry["name"] == "GPT-4o"
+        assert entry["generationConfig"] == {"timeout": 60000}
+
+    def test_preserves_top_level_settings(self):
+        settings = {
+            "model": {"name": "glm-5"},
+            "mcpServers": {"my-server": {"command": "node"}},
+            "statusLine": "custom",
+            "modelProviders": {"openai": [{"envKey": "CUSTOM_KEY", "id": "glm-5"}]},
+        }
+        normalize_model_providers(settings)
+        assert settings["model"] == {"name": "glm-5"}
+        assert settings["mcpServers"] == {"my-server": {"command": "node"}}
+        assert settings["statusLine"] == "custom"
+
+    def test_multiple_providers(self):
+        settings = {
+            "modelProviders": {
+                "openai": [{"envKey": "KEY_A", "id": "model-a"}],
+                "anthropic": [
+                    {"envKey": "KEY_B", "id": "model-b", "baseUrl": "https://api.anthropic.com"}
+                ],
+            }
+        }
+        normalize_model_providers(settings)
+        assert settings["modelProviders"]["openai"][0]["envKey"] == "OPENAI_API_KEY"
+        assert settings["modelProviders"]["anthropic"][0]["envKey"] == "OPENAI_API_KEY"
+        assert "baseUrl" not in settings["modelProviders"]["anthropic"][0]
+
+    def test_multiple_models_per_provider(self):
+        settings = {
+            "modelProviders": {
+                "openai": [
+                    {"envKey": "KEY_A", "id": "model-a", "baseUrl": "https://a.com"},
+                    {"envKey": "KEY_B", "id": "model-b", "baseUrl": "https://b.com"},
+                ]
+            }
+        }
+        normalize_model_providers(settings)
+        for model in settings["modelProviders"]["openai"]:
+            assert model["envKey"] == "OPENAI_API_KEY"
+            assert "baseUrl" not in model
+
+    def test_missing_envKey_field(self):
+        """Models without envKey should not crash."""
+        settings = {"modelProviders": {"openai": [{"id": "model-no-envkey"}]}}
+        normalize_model_providers(settings)
+        assert "envKey" not in settings["modelProviders"]["openai"][0]
+
+    def test_empty_model_providers(self):
+        settings = {"modelProviders": {}}
+        normalize_model_providers(settings)
+        assert settings == {"modelProviders": {}}
+
+    def test_no_model_providers_key(self):
+        settings = {"model": {"name": "glm-5"}}
+        normalize_model_providers(settings)
+        assert settings == {"model": {"name": "glm-5"}}
+
+    def test_malformed_model_providers_not_dict(self):
+        settings = {"modelProviders": "invalid"}
+        normalize_model_providers(settings)
+        assert settings["modelProviders"] == "invalid"
+
+    def test_malformed_models_list_not_list(self):
+        settings = {"modelProviders": {"openai": "not-a-list"}}
+        normalize_model_providers(settings)
+        assert settings["modelProviders"]["openai"] == "not-a-list"
+
+    def test_malformed_model_entry_not_dict(self):
+        settings = {"modelProviders": {"openai": ["not-a-dict"]}}
+        normalize_model_providers(settings)
+        assert settings["modelProviders"]["openai"] == ["not-a-dict"]
+
+
+# ---------------------------------------------------------------------------
+# collect_custom_envkeys tests
+# ---------------------------------------------------------------------------
+
+
+class TestCollectCustomEnvkeys:
+    """Tests for collect_custom_envkeys()."""
+
+    def test_extracts_custom_envkey(self, tmp_path):
+        settings = {
+            "modelProviders": {"openai": [{"envKey": "BAILIAN_CODING_PLAN_API_KEY", "id": "glm-5"}]}
+        }
+        settings_file = tmp_path / "settings.json"
+        settings_file.write_text(json.dumps(settings))
+
+        result = collect_custom_envkeys(str(settings_file), "my-token")
+        assert result == {"BAILIAN_CODING_PLAN_API_KEY": "my-token"}
+
+    def test_skips_openai_api_key(self, tmp_path):
+        settings = {"modelProviders": {"openai": [{"envKey": "OPENAI_API_KEY", "id": "gpt-4o"}]}}
+        settings_file = tmp_path / "settings.json"
+        settings_file.write_text(json.dumps(settings))
+
+        result = collect_custom_envkeys(str(settings_file), "my-token")
+        assert result == {}
+
+    def test_multiple_custom_keys(self, tmp_path):
+        settings = {
+            "modelProviders": {
+                "openai": [
+                    {"envKey": "KEY_A", "id": "model-a"},
+                    {"envKey": "KEY_B", "id": "model-b"},
+                ],
+                "anthropic": [
+                    {"envKey": "KEY_C", "id": "model-c"},
+                ],
+            }
+        }
+        settings_file = tmp_path / "settings.json"
+        settings_file.write_text(json.dumps(settings))
+
+        result = collect_custom_envkeys(str(settings_file), "token")
+        assert result == {"KEY_A": "token", "KEY_B": "token", "KEY_C": "token"}
+
+    def test_nonexistent_file(self, tmp_path):
+        result = collect_custom_envkeys(str(tmp_path / "nonexistent.json"), "token")
+        assert result == {}
+
+    def test_malformed_json(self, tmp_path):
+        settings_file = tmp_path / "settings.json"
+        settings_file.write_text("{invalid json")
+
+        result = collect_custom_envkeys(str(settings_file), "token")
+        assert result == {}
+
+    def test_missing_model_providers(self, tmp_path):
+        settings_file = tmp_path / "settings.json"
+        settings_file.write_text(json.dumps({"model": {"name": "glm-5"}}))
+
+        result = collect_custom_envkeys(str(settings_file), "token")
+        assert result == {}
+
+    def test_model_without_envkey(self, tmp_path):
+        settings = {"modelProviders": {"openai": [{"id": "model-no-envkey"}]}}
+        settings_file = tmp_path / "settings.json"
+        settings_file.write_text(json.dumps(settings))
+
+        result = collect_custom_envkeys(str(settings_file), "token")
+        assert result == {}
+
+    def test_malformed_providers_not_dict(self, tmp_path):
+        settings_file = tmp_path / "settings.json"
+        settings_file.write_text(json.dumps({"modelProviders": "invalid"}))
+
+        result = collect_custom_envkeys(str(settings_file), "token")
+        assert result == {}


### PR DESCRIPTION
## Problem

When users configure custom `envKey` (e.g. `BAILIAN_CODING_PLAN_API_KEY`) or external `baseUrl` in `~/.qwen/settings.json`, the qwen-code CLI reads those instead of the standard `OPENAI_API_KEY`/`OPENAI_BASE_URL` environment variables injected by the agent. This causes all LLM API calls to fail with:

```
[API Error: Connection error. (cause: fetch failed)]
```

## Root Cause

The agent writes `OPENAI_API_KEY` and `OPENAI_BASE_URL` to the subprocess environment, but the CLI prioritizes `modelProviders[].envKey` and `modelProviders[].baseUrl` from `settings.json` over standard env vars. User-configured custom envKeys are not set in the environment, and external baseUrls bypass the LLM proxy.

## Fix

Two-layer defense:

### Layer 1 (Primary): `_write_qwen_settings` in `agent.py`
- On every settings write, normalize all `modelProviders` entries:
  - Unify `envKey` → `OPENAI_API_KEY`
  - Remove all `baseUrl` entries
- Only these two fields are touched; user settings (`mcpServers`, `statusLine`, `model`, etc.) are preserved

### Layer 2 (Fallback): `_build_env` in `executor.py` + `terminal_server.py`
- Read current settings at subprocess launch time
- Extract all custom envKeys from `modelProviders`
- Inject them with the proxy token value
- Catches cases where settings are edited after the primary normalization

## Files Changed

| File | Change |
|---|---|
| `remote-agent/agent.py` | Normalize envKey/baseUrl in `_write_qwen_settings` |
| `remote-agent/executor.py` | Fallback envKey injection in `_build_env` |
| `remote-agent/terminal_server.py` | Fallback envKey injection in `_build_env` |

## Testing

Both remote sessions and web terminals are covered by the same fix logic.