### PR TITLE
fix: set proxy baseUrl in modelProviders instead of removing it

### DIFF
--- a/remote-agent/agent.py
+++ b/remote-agent/agent.py
@@ -1037,8 +1037,10 @@ class RemoteAgent:
             merged["$version"] = 3
 
         # Normalize modelProviders: unify all envKeys to OPENAI_API_KEY
-        # and remove baseUrl entries so the CLI uses the proxy via env vars.
-        normalize_model_providers(merged)
+        # and set baseUrl to the LLM proxy so the CLI routes all
+        # requests through the proxy.
+        proxy_base_url = f"{self.config.server_url.rstrip('/')}/api/remote/llm-proxy/v1"
+        normalize_model_providers(merged, proxy_base_url=proxy_base_url)
 
         # Atomic write via temp file + rename
         self._atomic_write_json(str(settings_path), merged)

--- a/remote-agent/cli_adapters/base.py
+++ b/remote-agent/cli_adapters/base.py
@@ -65,15 +65,15 @@ def collect_custom_envkeys(
     return env_overrides
 
 
-def normalize_model_providers(settings: dict) -> None:
+def normalize_model_providers(settings: dict, proxy_base_url: str = "") -> None:
     """
     Normalize modelProviders in-place: unify all envKeys to
-    OPENAI_API_KEY and remove baseUrl entries.
+    OPENAI_API_KEY and set baseUrl to the LLM proxy endpoint.
 
-    This ensures the CLI reads credentials from the standard
-    OPENAI_API_KEY / OPENAI_BASE_URL env vars injected by the agent,
-    rather than user-configured custom keys or external baseUrls that
-    would bypass the LLM proxy.
+    When *proxy_base_url* is provided, every model entry's ``baseUrl``
+    is set to that value so the CLI connects through the proxy
+    regardless of any user-configured external URL.  When empty, any
+    existing ``baseUrl`` is removed as a fallback.
 
     Only ``envKey`` and ``baseUrl`` fields are touched; all other
     model configuration (id, name, generationConfig, etc.) and
@@ -92,7 +92,10 @@ def normalize_model_providers(settings: dict) -> None:
             if "envKey" in model:
                 model["envKey"] = "OPENAI_API_KEY"
             # Intentionally modify dict values (not keys) during iteration.
-            model.pop("baseUrl", None)
+            if proxy_base_url:
+                model["baseUrl"] = proxy_base_url
+            else:
+                model.pop("baseUrl", None)
 
 
 class BaseCLIAdapter(abc.ABC):

--- a/tests/issues/456/test_envkey_normalization.py
+++ b/tests/issues/456/test_envkey_normalization.py
@@ -39,7 +39,8 @@ class TestNormalizeModelProviders:
         normalize_model_providers(settings)
         assert settings["modelProviders"]["openai"][0]["envKey"] == "OPENAI_API_KEY"
 
-    def test_removes_base_url(self):
+    def test_removes_base_url_when_no_proxy(self):
+        """Without proxy_base_url, baseUrl is removed."""
         settings = {
             "modelProviders": {
                 "openai": [
@@ -53,6 +54,32 @@ class TestNormalizeModelProviders:
         }
         normalize_model_providers(settings)
         assert "baseUrl" not in settings["modelProviders"]["openai"][0]
+
+    def test_sets_base_url_to_proxy(self):
+        """With proxy_base_url, baseUrl is set to the proxy URL."""
+        settings = {
+            "modelProviders": {
+                "openai": [
+                    {
+                        "envKey": "OPENAI_API_KEY",
+                        "id": "gpt-4o",
+                        "baseUrl": "https://api.openai.com/v1",
+                    }
+                ]
+            }
+        }
+        proxy_url = "http://192.168.64.1:5001/api/remote/llm-proxy/v1"
+        normalize_model_providers(settings, proxy_base_url=proxy_url)
+        assert settings["modelProviders"]["openai"][0]["baseUrl"] == proxy_url
+
+    def test_adds_base_url_when_missing_with_proxy(self):
+        """Model entries without baseUrl get it added when proxy_base_url is set."""
+        settings = {
+            "modelProviders": {"openai": [{"envKey": "CUSTOM_KEY", "id": "glm-5", "name": "glm-5"}]}
+        }
+        proxy_url = "http://192.168.64.1:5001/api/remote/llm-proxy/v1"
+        normalize_model_providers(settings, proxy_base_url=proxy_url)
+        assert settings["modelProviders"]["openai"][0]["baseUrl"] == proxy_url
 
     def test_preserves_other_fields(self):
         settings = {
@@ -99,6 +126,20 @@ class TestNormalizeModelProviders:
         assert settings["modelProviders"]["openai"][0]["envKey"] == "OPENAI_API_KEY"
         assert settings["modelProviders"]["anthropic"][0]["envKey"] == "OPENAI_API_KEY"
         assert "baseUrl" not in settings["modelProviders"]["anthropic"][0]
+
+    def test_multiple_providers_with_proxy(self):
+        settings = {
+            "modelProviders": {
+                "openai": [{"envKey": "KEY_A", "id": "model-a"}],
+                "anthropic": [
+                    {"envKey": "KEY_B", "id": "model-b", "baseUrl": "https://api.anthropic.com"}
+                ],
+            }
+        }
+        proxy_url = "http://proxy/v1"
+        normalize_model_providers(settings, proxy_base_url=proxy_url)
+        assert settings["modelProviders"]["openai"][0]["baseUrl"] == proxy_url
+        assert settings["modelProviders"]["anthropic"][0]["baseUrl"] == proxy_url
 
     def test_multiple_models_per_provider(self):
         settings = {


### PR DESCRIPTION
## Problem

After commit ed2c233 removed baseUrl from settings.json for security, remote workspace sessions fail with Connection error (cause: fetch failed).

## Root Cause

qwen-code CLI modelRegistry.resolveModelConfig() fills missing baseUrl with the default https://api.openai.com/v1. This default has higher priority than the OPENAI_BASE_URL environment variable in modelConfigResolver.ts (priority: modelProvider > cli > env > settings > default).

## Fix

Changed normalize_model_providers() to accept a proxy_base_url parameter. When provided, it sets every modelProvider entry baseUrl to the LLM proxy URL instead of removing it.

## Files Changed

- remote-agent/cli_adapters/base.py - Add proxy_base_url param
- remote-agent/agent.py - Compute and pass proxy URL
- tests/issues/456/test_envkey_normalization.py - 3 new tests