### PR TITLE
fix: clipboard copy fails in HTTP environment (Issue #432)

### DIFF
--- a/frontend/src/components/features/Prompts.tsx
+++ b/frontend/src/components/features/Prompts.tsx
@@ -3,7 +3,7 @@
  */
 
 import React, { useState, useEffect, useMemo } from 'react';
-import { cn } from '@/utils';
+import { cn, copyToClipboard } from '@/utils';
 import { promptsApi } from '@/api';
 import type { PromptTemplate, PromptVariable } from '@/api';
 import {
@@ -26,6 +26,7 @@ import {
   Modal,
   TextInput,
   Textarea,
+  useToast,
 } from '@/components/common';
 import type { BadgeVariant } from '@/components/common';
 
@@ -700,6 +701,7 @@ const RenderModal: React.FC<RenderModalProps> = ({
 }) => {
   const [variables, setVariables] = useState<Record<string, string>>({});
   const [isLoading, setIsLoading] = useState(false);
+  const toast = useToast();
 
   // Reset variables when modal opens
   useEffect(() => {
@@ -721,9 +723,14 @@ const RenderModal: React.FC<RenderModalProps> = ({
     }
   };
 
-  const handleCopy = () => {
+  const handleCopy = async () => {
     if (result) {
-      navigator.clipboard.writeText(result);
+      const success = await copyToClipboard(result);
+      if (success) {
+        toast.success(t('copied', language));
+      } else {
+        toast.error(t('copyFailed', language) || 'Copy failed');
+      }
     }
   };
 

--- a/frontend/src/components/features/management/RemoteMachineManagement.tsx
+++ b/frontend/src/components/features/management/RemoteMachineManagement.tsx
@@ -22,11 +22,21 @@ import {
 import { useLanguage } from '@/store';
 import type { Language } from '@/i18n';
 import { t } from '@/i18n';
-import { Button, Modal, Select, Loading, Error, EmptyState, Badge } from '@/components/common';
+import {
+  Button,
+  Modal,
+  Select,
+  Loading,
+  Error,
+  EmptyState,
+  Badge,
+  useToast,
+} from '@/components/common';
 import type { RemoteMachine } from '@/api';
 
 export const RemoteMachineManagement: React.FC = () => {
   const language = useLanguage();
+  const toast = useToast();
   const { data: machinesData, isLoading, isError, error, refetch } = useMachines();
   const generateToken = useGenerateToken();
   const deregisterMachine = useDeregisterMachine();
@@ -109,6 +119,8 @@ export const RemoteMachineManagement: React.FC = () => {
     if (success) {
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
+    } else {
+      toast.error(t('copyFailed', language) || 'Copy failed');
     }
   };
 
@@ -130,6 +142,8 @@ export const RemoteMachineManagement: React.FC = () => {
     if (success) {
       setCopiedInstall(true);
       setTimeout(() => setCopiedInstall(false), 2000);
+    } else {
+      toast.error(t('copyFailed', language) || 'Copy failed');
     }
   };
 
@@ -216,6 +230,8 @@ export const RemoteMachineManagement: React.FC = () => {
     if (success) {
       setCopiedUninstall(true);
       setTimeout(() => setCopiedUninstall(false), 2000);
+    } else {
+      toast.error(t('copyFailed', language) || 'Copy failed');
     }
   };
 

--- a/frontend/src/utils/clipboard.ts
+++ b/frontend/src/utils/clipboard.ts
@@ -1,0 +1,58 @@
+/**
+ * Clipboard Utility - Cross-environment copy to clipboard
+ */
+
+export async function copyToClipboard(text: string): Promise<boolean> {
+  if (!text || typeof text !== 'string') {
+    return false;
+  }
+
+  try {
+    if (navigator.clipboard && window.isSecureContext) {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+  } catch {
+    // Clipboard API failed, proceed to fallback
+  }
+
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  textarea.style.position = 'fixed';
+  textarea.style.left = '-9999px';
+  textarea.style.top = '0';
+  textarea.style.width = '2em';
+  textarea.style.height = '2em';
+  textarea.style.padding = '0';
+  textarea.style.border = 'none';
+  textarea.style.outline = 'none';
+  textarea.style.boxShadow = 'none';
+  textarea.style.background = 'transparent';
+  textarea.setAttribute('readonly', '');
+
+  document.body.appendChild(textarea);
+
+  let success = false;
+  try {
+    const isIOS = navigator.userAgent.match(/ipad|iphone/i);
+    if (isIOS) {
+      const range = document.createRange();
+      range.selectNodeContents(textarea);
+      const selection = window.getSelection();
+      if (selection) {
+        selection.removeAllRanges();
+        selection.addRange(range);
+      }
+      textarea.setSelectionRange(0, text.length);
+    } else {
+      textarea.focus();
+      textarea.select();
+    }
+    success = document.execCommand('copy');
+  } catch {
+    success = false;
+  }
+
+  document.body.removeChild(textarea);
+  return success;
+}

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -3,6 +3,7 @@
  */
 
 export { cn } from './cn';
+export { copyToClipboard } from './clipboard';
 export {
   formatTokens,
   formatNumber,

--- a/scripts/fetch_claude.py
+++ b/scripts/fetch_claude.py
@@ -232,12 +232,17 @@ def extract_content_blocks_from_entry(entry: dict) -> list[dict]:
                         tool_use_id = part.get("tool_use_id", "")
                         tool_content = part.get("content", "")
                         if tool_use_id:
-                            content_blocks.append({
-                                "type": "tool_result",
-                                "tool_use_id": tool_use_id,
-                                "content": tool_content if isinstance(tool_content, str)
-                                           else json.dumps(tool_content, ensure_ascii=False)
-                            })
+                            content_blocks.append(
+                                {
+                                    "type": "tool_result",
+                                    "tool_use_id": tool_use_id,
+                                    "content": (
+                                        tool_content
+                                        if isinstance(tool_content, str)
+                                        else json.dumps(tool_content, ensure_ascii=False)
+                                    ),
+                                }
+                            )
 
     elif entry_type == "assistant":
         msg = entry.get("message", {})
@@ -271,15 +276,16 @@ def extract_content_blocks_from_entry(entry: dict) -> list[dict]:
                     tool_name = tool_use.get("name", "unknown")
                     tool_input = tool_use.get("input", {})
                     if tool_id:
-                        content_blocks.append({
-                            "type": "tool_use",
-                            "id": tool_id,
-                            "name": tool_name,
-                            "input": tool_input
-                        })
+                        content_blocks.append(
+                            {
+                                "type": "tool_use",
+                                "id": tool_id,
+                                "name": tool_name,
+                                "input": tool_input,
+                            }
+                        )
 
     return content_blocks
-
 
 
 def process_jsonl_file(
@@ -459,7 +465,9 @@ def process_jsonl_file(
                                     "parent_id": entry.get("parent_id") or entry.get("parentUuid"),
                                     "role": role,
                                     "content": content or "",
-                                    "content_blocks": extract_content_blocks_from_entry(entry),  # Issue #357: structured content
+                                    "content_blocks": extract_content_blocks_from_entry(
+                                        entry
+                                    ),  # Issue #357: structured content
                                     "full_entry": full_entry_json,
                                     "tokens_used": total_tokens,
                                     "input_tokens": input_tokens,
@@ -855,7 +863,9 @@ def update_agent_sessions_stats(messages: list) -> int:
                             metadata = {
                                 "message_id": msg_id,
                                 "project_path": msg.get("project_path"),
-                                "content_blocks": msg.get("content_blocks"),  # Issue #357: structured content for session detail view
+                                "content_blocks": msg.get(
+                                    "content_blocks"
+                                ),  # Issue #357: structured content for session detail view
                             }
                             _execute(
                                 cursor,

--- a/scripts/fetch_qwen.py
+++ b/scripts/fetch_qwen.py
@@ -290,8 +290,7 @@ def extract_content_from_entry(entry: dict) -> Optional[str]:
 
 
 def extract_content_blocks_from_entry(
-    entry: dict,
-    function_call_indices: Optional[dict[str, int]] = None
+    entry: dict, function_call_indices: Optional[dict[str, int]] = None
 ) -> list[dict]:
     """Extract structured content_blocks from a Qwen log entry.
 
@@ -349,12 +348,14 @@ def extract_content_blocks_from_entry(
             fc = part.get("functionCall", {})
             # Generate a tool_use_id using entry uuid + idx
             tool_id = f"{entry.get('uuid', 'unknown')}-{idx}"
-            content_blocks.append({
-                "type": "tool_use",
-                "id": tool_id,
-                "name": fc.get("name", "unknown"),
-                "input": fc.get("args", {})
-            })
+            content_blocks.append(
+                {
+                    "type": "tool_use",
+                    "id": tool_id,
+                    "name": fc.get("name", "unknown"),
+                    "input": fc.get("args", {}),
+                }
+            )
 
         # 4. Tool result
         elif part.get("type") == "tool":
@@ -372,12 +373,17 @@ def extract_content_blocks_from_entry(
             else:
                 # Fallback: use idx from tool_result parts (may not match)
                 tool_use_id = f"{parent_uuid}-{idx}"
-            content_blocks.append({
-                "type": "tool_result",
-                "tool_use_id": tool_use_id,
-                "content": tool_content if isinstance(tool_content, str)
-                           else json.dumps(tool_content, ensure_ascii=False)
-            })
+            content_blocks.append(
+                {
+                    "type": "tool_result",
+                    "tool_use_id": tool_use_id,
+                    "content": (
+                        tool_content
+                        if isinstance(tool_content, str)
+                        else json.dumps(tool_content, ensure_ascii=False)
+                    ),
+                }
+            )
 
         # 5. Image/Document (as text placeholder)
         elif part.get("type") == "image":
@@ -583,7 +589,9 @@ def process_jsonl_file(
                                     "parent_id": entry.get("parent_id"),
                                     "role": role,
                                     "content": content or "",
-                                    "content_blocks": extract_content_blocks_from_entry(entry, function_call_indices),  # Issue #357: structured content
+                                    "content_blocks": extract_content_blocks_from_entry(
+                                        entry, function_call_indices
+                                    ),  # Issue #357: structured content
                                     "full_entry": full_entry_json,
                                     "tokens_used": total_tokens,
                                     "input_tokens": input_tokens,
@@ -978,7 +986,9 @@ def update_agent_sessions_stats(messages: list) -> int:
                             metadata = {
                                 "message_id": msg_id,
                                 "project_path": msg.get("project_path"),
-                                "content_blocks": msg.get("content_blocks"),  # Issue #357: structured content for session detail view
+                                "content_blocks": msg.get(
+                                    "content_blocks"
+                                ),  # Issue #357: structured content for session detail view
                             }
                             _execute(
                                 cursor,

--- a/tests/issues/357/test_content_blocks.py
+++ b/tests/issues/357/test_content_blocks.py
@@ -36,11 +36,7 @@ def test_user_message_text():
     entry = {
         "type": "user",
         "uuid": "user-uuid-001",
-        "message": {
-            "parts": [
-                {"text": "Hello, how are you?"}
-            ]
-        }
+        "message": {"parts": [{"text": "Hello, how are you?"}]},
     }
     result = extract_content_blocks_from_entry(entry)
     assert len(result) == 1, f"Expected 1 block, got {len(result)}"
@@ -58,9 +54,9 @@ def test_user_message_multiple_parts():
         "message": {
             "parts": [
                 {"text": "Check this image:"},
-                {"type": "image", "url": "http://example.com/img.png"}
+                {"type": "image", "url": "http://example.com/img.png"},
             ]
-        }
+        },
     }
     result = extract_content_blocks_from_entry(entry)
     assert len(result) == 2, f"Expected 2 blocks, got {len(result)}"
@@ -77,11 +73,7 @@ def test_assistant_message_text_only():
     entry = {
         "type": "assistant",
         "uuid": "assistant-uuid-001",
-        "message": {
-            "parts": [
-                {"text": "I can help you with that."}
-            ]
-        }
+        "message": {"parts": [{"text": "I can help you with that."}]},
     }
     result = extract_content_blocks_from_entry(entry)
     assert len(result) == 1
@@ -99,9 +91,9 @@ def test_assistant_message_with_thinking():
         "message": {
             "parts": [
                 {"thought": True, "text": "Let me think about this..."},
-                {"text": "Here's my answer."}
+                {"text": "Here's my answer."},
             ]
-        }
+        },
     }
     result = extract_content_blocks_from_entry(entry)
     assert len(result) == 2, f"Expected 2 blocks, got {len(result)}"
@@ -121,9 +113,9 @@ def test_assistant_message_with_function_call():
         "message": {
             "parts": [
                 {"text": "Let me check the file."},
-                {"functionCall": {"name": "read_file", "args": {"path": "/tmp/test.py"}}}
+                {"functionCall": {"name": "read_file", "args": {"path": "/tmp/test.py"}}},
             ]
-        }
+        },
     }
     result = extract_content_blocks_from_entry(entry)
     assert len(result) == 2, f"Expected 2 blocks, got {len(result)}"
@@ -144,9 +136,14 @@ def test_assistant_message_multiple_function_calls():
         "message": {
             "parts": [
                 {"functionCall": {"name": "read_file", "args": {"path": "a.py"}}},
-                {"functionCall": {"name": "write_file", "args": {"path": "b.py", "content": "test"}}}
+                {
+                    "functionCall": {
+                        "name": "write_file",
+                        "args": {"path": "b.py", "content": "test"},
+                    }
+                },
             ]
-        }
+        },
     }
     result = extract_content_blocks_from_entry(entry)
     assert len(result) == 2
@@ -169,10 +166,8 @@ def test_tool_result_message_with_correct_id_linking():
         "uuid": "tool-result-001",
         "parentUuid": "assistant-uuid-003",  # Links to the assistant message
         "message": {
-            "parts": [
-                {"type": "tool", "name": "read_file", "content": "File contents here..."}
-            ]
-        }
+            "parts": [{"type": "tool", "name": "read_file", "content": "File contents here..."}]
+        },
     }
     # function_call_indices tells us that functionCall is at idx=1 in parent assistant
     function_call_indices = {"tool-result-001": 1}
@@ -193,10 +188,8 @@ def test_tool_result_message_without_function_call_indices():
         "uuid": "tool-result-001",
         "parentUuid": "assistant-uuid-003",
         "message": {
-            "parts": [
-                {"type": "tool", "name": "read_file", "content": "File contents here..."}
-            ]
-        }
+            "parts": [{"type": "tool", "name": "read_file", "content": "File contents here..."}]
+        },
     }
     # Without function_call_indices, uses fallback (may not match exactly)
     result = extract_content_blocks_from_entry(entry)
@@ -217,7 +210,7 @@ def test_tool_result_with_dict_content():
             "parts": [
                 {"type": "tool", "name": "list_files", "content": {"files": ["a.py", "b.py"]}}
             ]
-        }
+        },
     }
     # functionCall is at idx=0 in parent (simplified scenario)
     function_call_indices = {"tool-result-002": 0}
@@ -236,11 +229,8 @@ def test_empty_text_skipped():
         "type": "assistant",
         "uuid": "assistant-uuid-006",
         "message": {
-            "parts": [
-                {"text": ""},  # Empty text - should be skipped
-                {"text": "Valid text"}
-            ]
-        }
+            "parts": [{"text": ""}, {"text": "Valid text"}]  # Empty text - should be skipped
+        },
     }
     result = extract_content_blocks_from_entry(entry)
     assert len(result) == 1, f"Expected 1 block (empty skipped), got {len(result)}"
@@ -257,9 +247,9 @@ def test_empty_thinking_skipped():
         "message": {
             "parts": [
                 {"thought": True, "text": ""},  # Empty thinking - should be skipped
-                {"text": "Result"}
+                {"text": "Result"},
             ]
-        }
+        },
     }
     result = extract_content_blocks_from_entry(entry)
     assert len(result) == 1
@@ -270,10 +260,7 @@ def test_empty_thinking_skipped():
 
 def test_no_message_field():
     """Test entry without message field."""
-    entry = {
-        "type": "assistant",
-        "uuid": "assistant-uuid-008"
-    }
+    entry = {"type": "assistant", "uuid": "assistant-uuid-008"}
     result = extract_content_blocks_from_entry(entry)
     assert result == []
 
@@ -282,11 +269,7 @@ def test_no_message_field():
 
 def test_no_parts_field():
     """Test message without parts field."""
-    entry = {
-        "type": "assistant",
-        "uuid": "assistant-uuid-009",
-        "message": {}
-    }
+    entry = {"type": "assistant", "uuid": "assistant-uuid-009", "message": {}}
     result = extract_content_blocks_from_entry(entry)
     assert result == []
 
@@ -298,9 +281,7 @@ def test_non_dict_parts():
     entry = {
         "type": "assistant",
         "uuid": "assistant-uuid-010",
-        "message": {
-            "parts": ["string part", 123, None]  # Non-dict elements
-        }
+        "message": {"parts": ["string part", 123, None]},  # Non-dict elements
     }
     result = extract_content_blocks_from_entry(entry)
     assert result == [], f"Expected empty list for non-dict parts, got {result}"
@@ -313,11 +294,7 @@ def test_document_placeholder():
     entry = {
         "type": "user",
         "uuid": "user-uuid-003",
-        "message": {
-            "parts": [
-                {"type": "document", "name": "report.pdf"}
-            ]
-        }
+        "message": {"parts": [{"type": "document", "name": "report.pdf"}]},
     }
     result = extract_content_blocks_from_entry(entry)
     assert len(result) == 1
@@ -331,11 +308,7 @@ def test_missing_uuid_fallback():
     """Test fallback when uuid is missing."""
     entry = {
         "type": "assistant",
-        "message": {
-            "parts": [
-                {"functionCall": {"name": "test_tool", "args": {}}}
-            ]
-        }
+        "message": {"parts": [{"functionCall": {"name": "test_tool", "args": {}}}]},
     }
     result = extract_content_blocks_from_entry(entry)
     assert len(result) == 1
@@ -350,11 +323,7 @@ def test_missing_parent_uuid_fallback():
     entry = {
         "type": "tool_result",
         "uuid": "tool-result-003",
-        "message": {
-            "parts": [
-                {"type": "tool", "name": "test", "content": "result"}
-            ]
-        }
+        "message": {"parts": [{"type": "tool", "name": "test", "content": "result"}]},
     }
     result = extract_content_blocks_from_entry(entry)
     assert len(result) == 1


### PR DESCRIPTION
## 问题描述

Issue #432: 点击 work 页面右侧【提示词】中的复制按钮无法复制提示词内容

**根本原因**：在非安全上下文（HTTP + 非本地 IP）环境下，`navigator.clipboard` API 不可用，导致复制功能失败。

## 修复方案

使用 `copyToClipboard` 工具函数（位于 `frontend/src/utils/clipboard.ts`），它内置了完善的降级机制：
1. 优先尝试现代 Clipboard API（需要 HTTPS 或 localhost）
2. 如果失败或不可用，降级使用 `execCommand('copy')` + 临时 textarea 元素
3. 支持 iOS 设备的特殊处理

## 修改的文件

| 文件 | 修改内容 |
|------|----------|
| `frontend/src/utils/clipboard.ts` | 新增剪贴板工具函数 |
| `frontend/src/utils/index.ts` | 导出 `copyToClipboard` |
| `frontend/src/components/features/Prompts.tsx` | RenderModal `handleCopy` 添加成功/失败 toast 提示 |
| `frontend/src/components/features/management/RemoteMachineManagement.tsx` | 三个复制函数添加失败 toast 提示 |

## 审核结论

已通过代码审核，详见 issue 评论：https://github.com/open-ace/open-ace/issues/432#issuecomment-4487354005

## 测试验证

- 前端构建验证通过
- HTTP 环境下复制功能正常工作

🤖 Generated with Qwen Code (6-shotted by Qwen-Coder)