### PR TITLE
fix: Docker部署配置文件覆盖保护 (Issue #429)

### DIFF
--- a/app/modules/workspace/api_key_proxy.py
+++ b/app/modules/workspace/api_key_proxy.py
@@ -117,7 +117,8 @@ class APIKeyProxyService:
 
         # api_key_store table is created by migration, but ensure it exists for
         # environments that don't run migrations
-        cursor.execute(f"""
+        cursor.execute(
+            f"""
             CREATE TABLE IF NOT EXISTS api_key_store (
                 id {id_type},
                 tenant_id INTEGER,
@@ -132,7 +133,8 @@ class APIKeyProxyService:
                 updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                 UNIQUE(tenant_id, provider, key_name)
             )
-        """)
+        """
+        )
 
         conn.commit()
         conn.close()

--- a/app/modules/workspace/session_manager.py
+++ b/app/modules/workspace/session_manager.py
@@ -272,7 +272,8 @@ class SessionManager:
         id_type = "SERIAL PRIMARY KEY" if is_postgresql() else "INTEGER PRIMARY KEY AUTOINCREMENT"
 
         # Create agent_sessions table
-        cursor.execute(f"""
+        cursor.execute(
+            f"""
             CREATE TABLE IF NOT EXISTS agent_sessions (
                 id {id_type},
                 session_id TEXT NOT NULL UNIQUE,
@@ -295,10 +296,12 @@ class SessionManager:
                 completed_at TIMESTAMP,
                 expires_at TIMESTAMP
             )
-        """)
+        """
+        )
 
         # Create session_messages table
-        cursor.execute(f"""
+        cursor.execute(
+            f"""
             CREATE TABLE IF NOT EXISTS session_messages (
                 id {id_type},
                 session_id TEXT NOT NULL,
@@ -310,29 +313,40 @@ class SessionManager:
                 metadata TEXT,
                 FOREIGN KEY (session_id) REFERENCES agent_sessions(session_id)
             )
-        """)
+        """
+        )
 
         # Create indexes
-        cursor.execute("""
+        cursor.execute(
+            """
             CREATE INDEX IF NOT EXISTS idx_agent_sessions_session_id
             ON agent_sessions(session_id)
-        """)
-        cursor.execute("""
+        """
+        )
+        cursor.execute(
+            """
             CREATE INDEX IF NOT EXISTS idx_agent_sessions_user_id
             ON agent_sessions(user_id)
-        """)
-        cursor.execute("""
+        """
+        )
+        cursor.execute(
+            """
             CREATE INDEX IF NOT EXISTS idx_agent_sessions_status
             ON agent_sessions(status)
-        """)
-        cursor.execute("""
+        """
+        )
+        cursor.execute(
+            """
             CREATE INDEX IF NOT EXISTS idx_agent_sessions_tool_name
             ON agent_sessions(tool_name)
-        """)
-        cursor.execute("""
+        """
+        )
+        cursor.execute(
+            """
             CREATE INDEX IF NOT EXISTS idx_session_messages_session_id
             ON session_messages(session_id)
-        """)
+        """
+        )
 
         # Add remote workspace columns if not present
         try:
@@ -1145,7 +1159,8 @@ class SessionManager:
                 (user_id,),
             )
         else:
-            cursor.execute("""
+            cursor.execute(
+                """
                 SELECT
                     COUNT(*) as total_sessions,
                     SUM(CASE WHEN status = 'active' THEN 1 ELSE 0 END) as active_sessions,
@@ -1153,7 +1168,8 @@ class SessionManager:
                     SUM(total_tokens) as total_tokens,
                     SUM(message_count) as total_messages
                 FROM agent_sessions
-            """)
+            """
+            )
 
         row = cursor.fetchone()
         conn.close()

--- a/app/routes/remote.py
+++ b/app/routes/remote.py
@@ -1182,12 +1182,14 @@ def agent_message():
                         with get_db_connection() as conn:
                             cursor = conn.cursor()
                             cursor.execute(
-                                adapt_sql("""INSERT OR IGNORE INTO daily_messages
+                                adapt_sql(
+                                    """INSERT OR IGNORE INTO daily_messages
                                     (date, tool_name, host_name, message_id, role, content,
                                      full_entry, tokens_used, input_tokens, output_tokens,
                                      model, timestamp, message_source,
                                      conversation_id, agent_session_id, project_path)
-                                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"""),
+                                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"""
+                                ),
                                 (
                                     date_str,
                                     tool_name,

--- a/frontend/src/components/features/Prompts.tsx
+++ b/frontend/src/components/features/Prompts.tsx
@@ -3,7 +3,7 @@
  */
 
 import React, { useState, useEffect, useMemo } from 'react';
-import { cn } from '@/utils';
+import { cn, copyToClipboard } from '@/utils';
 import { promptsApi } from '@/api';
 import type { PromptTemplate, PromptVariable } from '@/api';
 import {
@@ -26,6 +26,7 @@ import {
   Modal,
   TextInput,
   Textarea,
+  useToast,
 } from '@/components/common';
 import type { BadgeVariant } from '@/components/common';
 
@@ -700,6 +701,7 @@ const RenderModal: React.FC<RenderModalProps> = ({
 }) => {
   const [variables, setVariables] = useState<Record<string, string>>({});
   const [isLoading, setIsLoading] = useState(false);
+  const toast = useToast();
 
   // Reset variables when modal opens
   useEffect(() => {
@@ -721,9 +723,14 @@ const RenderModal: React.FC<RenderModalProps> = ({
     }
   };
 
-  const handleCopy = () => {
+  const handleCopy = async () => {
     if (result) {
-      navigator.clipboard.writeText(result);
+      const success = await copyToClipboard(result);
+      if (success) {
+        toast.success(t('copied', language));
+      } else {
+        toast.error(t('copyFailed', language) || 'Copy failed');
+      }
     }
   };
 

--- a/frontend/src/components/features/management/RemoteMachineManagement.tsx
+++ b/frontend/src/components/features/management/RemoteMachineManagement.tsx
@@ -22,11 +22,21 @@ import {
 import { useLanguage } from '@/store';
 import type { Language } from '@/i18n';
 import { t } from '@/i18n';
-import { Button, Modal, Select, Loading, Error, EmptyState, Badge } from '@/components/common';
+import {
+  Button,
+  Modal,
+  Select,
+  Loading,
+  Error,
+  EmptyState,
+  Badge,
+  useToast,
+} from '@/components/common';
 import type { RemoteMachine } from '@/api';
 
 export const RemoteMachineManagement: React.FC = () => {
   const language = useLanguage();
+  const toast = useToast();
   const { data: machinesData, isLoading, isError, error, refetch } = useMachines();
   const generateToken = useGenerateToken();
   const deregisterMachine = useDeregisterMachine();
@@ -109,6 +119,8 @@ export const RemoteMachineManagement: React.FC = () => {
     if (success) {
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
+    } else {
+      toast.error(t('copyFailed', language) || 'Copy failed');
     }
   };
 
@@ -130,6 +142,8 @@ export const RemoteMachineManagement: React.FC = () => {
     if (success) {
       setCopiedInstall(true);
       setTimeout(() => setCopiedInstall(false), 2000);
+    } else {
+      toast.error(t('copyFailed', language) || 'Copy failed');
     }
   };
 
@@ -216,6 +230,8 @@ export const RemoteMachineManagement: React.FC = () => {
     if (success) {
       setCopiedUninstall(true);
       setTimeout(() => setCopiedUninstall(false), 2000);
+    } else {
+      toast.error(t('copyFailed', language) || 'Copy failed');
     }
   };
 

--- a/frontend/src/utils/clipboard.ts
+++ b/frontend/src/utils/clipboard.ts
@@ -1,0 +1,58 @@
+/**
+ * Clipboard Utility - Cross-environment copy to clipboard
+ */
+
+export async function copyToClipboard(text: string): Promise<boolean> {
+  if (!text || typeof text !== 'string') {
+    return false;
+  }
+
+  try {
+    if (navigator.clipboard && window.isSecureContext) {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+  } catch {
+    // Clipboard API failed, proceed to fallback
+  }
+
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  textarea.style.position = 'fixed';
+  textarea.style.left = '-9999px';
+  textarea.style.top = '0';
+  textarea.style.width = '2em';
+  textarea.style.height = '2em';
+  textarea.style.padding = '0';
+  textarea.style.border = 'none';
+  textarea.style.outline = 'none';
+  textarea.style.boxShadow = 'none';
+  textarea.style.background = 'transparent';
+  textarea.setAttribute('readonly', '');
+
+  document.body.appendChild(textarea);
+
+  let success = false;
+  try {
+    const isIOS = navigator.userAgent.match(/ipad|iphone/i);
+    if (isIOS) {
+      const range = document.createRange();
+      range.selectNodeContents(textarea);
+      const selection = window.getSelection();
+      if (selection) {
+        selection.removeAllRanges();
+        selection.addRange(range);
+      }
+      textarea.setSelectionRange(0, text.length);
+    } else {
+      textarea.focus();
+      textarea.select();
+    }
+    success = document.execCommand('copy');
+  } catch {
+    success = false;
+  }
+
+  document.body.removeChild(textarea);
+  return success;
+}

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -3,6 +3,7 @@
  */
 
 export { cn } from './cn';
+export { copyToClipboard } from './clipboard';
 export {
   formatTokens,
   formatNumber,

--- a/scripts/fetch_claude.py
+++ b/scripts/fetch_claude.py
@@ -232,12 +232,17 @@ def extract_content_blocks_from_entry(entry: dict) -> list[dict]:
                         tool_use_id = part.get("tool_use_id", "")
                         tool_content = part.get("content", "")
                         if tool_use_id:
-                            content_blocks.append({
-                                "type": "tool_result",
-                                "tool_use_id": tool_use_id,
-                                "content": tool_content if isinstance(tool_content, str)
-                                           else json.dumps(tool_content, ensure_ascii=False)
-                            })
+                            content_blocks.append(
+                                {
+                                    "type": "tool_result",
+                                    "tool_use_id": tool_use_id,
+                                    "content": (
+                                        tool_content
+                                        if isinstance(tool_content, str)
+                                        else json.dumps(tool_content, ensure_ascii=False)
+                                    ),
+                                }
+                            )
 
     elif entry_type == "assistant":
         msg = entry.get("message", {})
@@ -271,15 +276,16 @@ def extract_content_blocks_from_entry(entry: dict) -> list[dict]:
                     tool_name = tool_use.get("name", "unknown")
                     tool_input = tool_use.get("input", {})
                     if tool_id:
-                        content_blocks.append({
-                            "type": "tool_use",
-                            "id": tool_id,
-                            "name": tool_name,
-                            "input": tool_input
-                        })
+                        content_blocks.append(
+                            {
+                                "type": "tool_use",
+                                "id": tool_id,
+                                "name": tool_name,
+                                "input": tool_input,
+                            }
+                        )
 
     return content_blocks
-
 
 
 def process_jsonl_file(
@@ -459,7 +465,9 @@ def process_jsonl_file(
                                     "parent_id": entry.get("parent_id") or entry.get("parentUuid"),
                                     "role": role,
                                     "content": content or "",
-                                    "content_blocks": extract_content_blocks_from_entry(entry),  # Issue #357: structured content
+                                    "content_blocks": extract_content_blocks_from_entry(
+                                        entry
+                                    ),  # Issue #357: structured content
                                     "full_entry": full_entry_json,
                                     "tokens_used": total_tokens,
                                     "input_tokens": input_tokens,
@@ -855,7 +863,9 @@ def update_agent_sessions_stats(messages: list) -> int:
                             metadata = {
                                 "message_id": msg_id,
                                 "project_path": msg.get("project_path"),
-                                "content_blocks": msg.get("content_blocks"),  # Issue #357: structured content for session detail view
+                                "content_blocks": msg.get(
+                                    "content_blocks"
+                                ),  # Issue #357: structured content for session detail view
                             }
                             _execute(
                                 cursor,

--- a/scripts/fetch_qwen.py
+++ b/scripts/fetch_qwen.py
@@ -359,7 +359,7 @@ def extract_content_blocks_from_entry(
 
         # 4. Tool result
         elif part.get("type") == "tool":
-            tool_name = part.get("name", "")
+            _tool_name = part.get("name", "")  # noqa: F841
             tool_content = part.get("content", "")
             parent_uuid = entry.get("parentUuid", "unknown")
             entry_uuid = entry.get("uuid", "")

--- a/scripts/fetch_qwen.py
+++ b/scripts/fetch_qwen.py
@@ -290,8 +290,7 @@ def extract_content_from_entry(entry: dict) -> Optional[str]:
 
 
 def extract_content_blocks_from_entry(
-    entry: dict,
-    function_call_indices: Optional[dict[str, int]] = None
+    entry: dict, function_call_indices: Optional[dict[str, int]] = None
 ) -> list[dict]:
     """Extract structured content_blocks from a Qwen log entry.
 
@@ -349,12 +348,14 @@ def extract_content_blocks_from_entry(
             fc = part.get("functionCall", {})
             # Generate a tool_use_id using entry uuid + idx
             tool_id = f"{entry.get('uuid', 'unknown')}-{idx}"
-            content_blocks.append({
-                "type": "tool_use",
-                "id": tool_id,
-                "name": fc.get("name", "unknown"),
-                "input": fc.get("args", {})
-            })
+            content_blocks.append(
+                {
+                    "type": "tool_use",
+                    "id": tool_id,
+                    "name": fc.get("name", "unknown"),
+                    "input": fc.get("args", {}),
+                }
+            )
 
         # 4. Tool result
         elif part.get("type") == "tool":
@@ -372,12 +373,17 @@ def extract_content_blocks_from_entry(
             else:
                 # Fallback: use idx from tool_result parts (may not match)
                 tool_use_id = f"{parent_uuid}-{idx}"
-            content_blocks.append({
-                "type": "tool_result",
-                "tool_use_id": tool_use_id,
-                "content": tool_content if isinstance(tool_content, str)
-                           else json.dumps(tool_content, ensure_ascii=False)
-            })
+            content_blocks.append(
+                {
+                    "type": "tool_result",
+                    "tool_use_id": tool_use_id,
+                    "content": (
+                        tool_content
+                        if isinstance(tool_content, str)
+                        else json.dumps(tool_content, ensure_ascii=False)
+                    ),
+                }
+            )
 
         # 5. Image/Document (as text placeholder)
         elif part.get("type") == "image":
@@ -583,7 +589,9 @@ def process_jsonl_file(
                                     "parent_id": entry.get("parent_id"),
                                     "role": role,
                                     "content": content or "",
-                                    "content_blocks": extract_content_blocks_from_entry(entry, function_call_indices),  # Issue #357: structured content
+                                    "content_blocks": extract_content_blocks_from_entry(
+                                        entry, function_call_indices
+                                    ),  # Issue #357: structured content
                                     "full_entry": full_entry_json,
                                     "tokens_used": total_tokens,
                                     "input_tokens": input_tokens,
@@ -978,7 +986,9 @@ def update_agent_sessions_stats(messages: list) -> int:
                             metadata = {
                                 "message_id": msg_id,
                                 "project_path": msg.get("project_path"),
-                                "content_blocks": msg.get("content_blocks"),  # Issue #357: structured content for session detail view
+                                "content_blocks": msg.get(
+                                    "content_blocks"
+                                ),  # Issue #357: structured content for session detail view
                             }
                             _execute(
                                 cursor,

--- a/scripts/install-central/docker-method/install.sh
+++ b/scripts/install-central/docker-method/install.sh
@@ -1631,18 +1631,34 @@ create_directories() {
     print_info "  - $user_home/workspace"
 
     # Create tool directories based on configuration
+    # Warn if directories already exist (may contain user settings)
     if [ "$QWEN_ENABLED" = "true" ]; then
-        mkdir -p "$user_home/.qwen"
+        if [ -d "$user_home/.qwen" ]; then
+            print_warning ".qwen 目录已存在: $user_home/.qwen"
+            print_info "  该目录可能包含 settings.json 等用户配置，请注意保护"
+        else
+            mkdir -p "$user_home/.qwen"
+        fi
         print_info "  - $user_home/.qwen"
     fi
 
     if [ "$CLAUDE_ENABLED" = "true" ]; then
-        mkdir -p "$user_home/.claude"
+        if [ -d "$user_home/.claude" ]; then
+            print_warning ".claude 目录已存在: $user_home/.claude"
+            print_info "  该目录可能包含 settings.json 等用户配置，请注意保护"
+        else
+            mkdir -p "$user_home/.claude"
+        fi
         print_info "  - $user_home/.claude"
     fi
 
     if [ "$OPENCLAW_ENABLED" = "true" ]; then
-        mkdir -p "$user_home/.openclaw"
+        if [ -d "$user_home/.openclaw" ]; then
+            print_warning ".openclaw 目录已存在: $user_home/.openclaw"
+            print_info "  该目录可能包含 openclaw.json 等用户配置，请注意保护"
+        else
+            mkdir -p "$user_home/.openclaw"
+        fi
         print_info "  - $user_home/.openclaw"
     fi
 
@@ -1667,10 +1683,22 @@ create_config() {
 
     if [ -f "$config_file" ]; then
         print_warning "配置文件已存在: $config_file"
-        prompt_yesno "是否覆盖?" "y" overwrite_config
+        # 默认不覆盖，保护已有配置（非交互模式下也会保留）
+        prompt_yesno "是否覆盖?" "n" overwrite_config
         if [ "$overwrite_config" = "no" ]; then
             print_info "保留现有配置文件"
             return
+        fi
+
+        # 备份现有配置文件
+        local backup_timestamp=$(date +"%Y%m%d_%H%M%S")
+        local backup_file="${config_file}.bak.${backup_timestamp}"
+        print_info "备份现有配置文件到: $backup_file"
+        if cp "$config_file" "$backup_file"; then
+            print_success "配置文件备份成功"
+        else
+            print_error "配置文件备份失败，停止覆盖操作"
+            return 1
         fi
     fi
 
@@ -2229,6 +2257,44 @@ show_deployment_info() {
     print_warning "请妥善保管 $DEPLOY_DIR/.env 文件中的敏感信息！"
 }
 
+# Check for existing config files and warn user before deployment
+check_existing_config() {
+    local config_file="$DEPLOY_DIR/config/config.json"
+    local user_home="/home/$RUN_USER"
+    local qwen_settings="$user_home/.qwen/settings.json"
+    local claude_settings="$user_home/.claude/settings.json"
+    local openclaw_settings="$user_home/.openclaw/openclaw.json"
+    local has_existing_config=false
+
+    if [ -f "$config_file" ]; then
+        print_warning "检测到已存在的配置文件: $config_file"
+        print_info "  重新运行安装脚本时，默认不会覆盖已有配置"
+        has_existing_config=true
+    fi
+
+    if [ "$QWEN_ENABLED" = "true" ] && [ -f "$qwen_settings" ]; then
+        print_warning "检测到已存在的 Qwen 配置: $qwen_settings"
+        print_info "  该文件包含 API key 等敏感信息，请注意保护"
+        has_existing_config=true
+    fi
+
+    if [ "$CLAUDE_ENABLED" = "true" ] && [ -f "$claude_settings" ]; then
+        print_warning "检测到已存在的 Claude 配置: $claude_settings"
+        has_existing_config=true
+    fi
+
+    if [ "$OPENCLAW_ENABLED" = "true" ] && [ -f "$openclaw_settings" ]; then
+        print_warning "检测到已存在的 OpenClaw 配置: $openclaw_settings"
+        has_existing_config=true
+    fi
+
+    if [ "$has_existing_config" = true ]; then
+        echo ""
+        print_info "提示: 如需覆盖配置，请在后续步骤中明确选择覆盖选项"
+        echo ""
+    fi
+}
+
 # ============================================================================
 # Main
 # ============================================================================
@@ -2400,6 +2466,8 @@ if [ "$WORKSPACE_MULTI_USER_MODE" = "true" ]; then
 fi
 
 # Execute deployment
+# Check for existing config files and warn user before deployment
+check_existing_config
 create_directories
 
 # Check for existing PostgreSQL data volume BEFORE creating config files

--- a/scripts/install-central/docker-method/install.sh
+++ b/scripts/install-central/docker-method/install.sh
@@ -1695,7 +1695,11 @@ create_config() {
         local backup_file="${config_file}.bak.${backup_timestamp}"
         print_info "备份现有配置文件到: $backup_file"
         if cp "$config_file" "$backup_file"; then
+            # 设置备份文件权限为 600（仅 owner 可读写），保护敏感信息
+            chmod 600 "$backup_file"
             print_success "配置文件备份成功"
+            # 清理超过 7 天的旧备份文件
+            find "$DEPLOY_DIR/config" -name "config.json.bak.*" -mtime +7 -delete 2>/dev/null || true
         else
             print_error "配置文件备份失败，停止覆盖操作"
             return 1

--- a/tests/issues/357/test_content_blocks.py
+++ b/tests/issues/357/test_content_blocks.py
@@ -36,11 +36,7 @@ def test_user_message_text():
     entry = {
         "type": "user",
         "uuid": "user-uuid-001",
-        "message": {
-            "parts": [
-                {"text": "Hello, how are you?"}
-            ]
-        }
+        "message": {"parts": [{"text": "Hello, how are you?"}]},
     }
     result = extract_content_blocks_from_entry(entry)
     assert len(result) == 1, f"Expected 1 block, got {len(result)}"
@@ -58,9 +54,9 @@ def test_user_message_multiple_parts():
         "message": {
             "parts": [
                 {"text": "Check this image:"},
-                {"type": "image", "url": "http://example.com/img.png"}
+                {"type": "image", "url": "http://example.com/img.png"},
             ]
-        }
+        },
     }
     result = extract_content_blocks_from_entry(entry)
     assert len(result) == 2, f"Expected 2 blocks, got {len(result)}"
@@ -77,11 +73,7 @@ def test_assistant_message_text_only():
     entry = {
         "type": "assistant",
         "uuid": "assistant-uuid-001",
-        "message": {
-            "parts": [
-                {"text": "I can help you with that."}
-            ]
-        }
+        "message": {"parts": [{"text": "I can help you with that."}]},
     }
     result = extract_content_blocks_from_entry(entry)
     assert len(result) == 1
@@ -99,9 +91,9 @@ def test_assistant_message_with_thinking():
         "message": {
             "parts": [
                 {"thought": True, "text": "Let me think about this..."},
-                {"text": "Here's my answer."}
+                {"text": "Here's my answer."},
             ]
-        }
+        },
     }
     result = extract_content_blocks_from_entry(entry)
     assert len(result) == 2, f"Expected 2 blocks, got {len(result)}"
@@ -121,9 +113,9 @@ def test_assistant_message_with_function_call():
         "message": {
             "parts": [
                 {"text": "Let me check the file."},
-                {"functionCall": {"name": "read_file", "args": {"path": "/tmp/test.py"}}}
+                {"functionCall": {"name": "read_file", "args": {"path": "/tmp/test.py"}}},
             ]
-        }
+        },
     }
     result = extract_content_blocks_from_entry(entry)
     assert len(result) == 2, f"Expected 2 blocks, got {len(result)}"
@@ -144,9 +136,14 @@ def test_assistant_message_multiple_function_calls():
         "message": {
             "parts": [
                 {"functionCall": {"name": "read_file", "args": {"path": "a.py"}}},
-                {"functionCall": {"name": "write_file", "args": {"path": "b.py", "content": "test"}}}
+                {
+                    "functionCall": {
+                        "name": "write_file",
+                        "args": {"path": "b.py", "content": "test"},
+                    }
+                },
             ]
-        }
+        },
     }
     result = extract_content_blocks_from_entry(entry)
     assert len(result) == 2
@@ -169,10 +166,8 @@ def test_tool_result_message_with_correct_id_linking():
         "uuid": "tool-result-001",
         "parentUuid": "assistant-uuid-003",  # Links to the assistant message
         "message": {
-            "parts": [
-                {"type": "tool", "name": "read_file", "content": "File contents here..."}
-            ]
-        }
+            "parts": [{"type": "tool", "name": "read_file", "content": "File contents here..."}]
+        },
     }
     # function_call_indices tells us that functionCall is at idx=1 in parent assistant
     function_call_indices = {"tool-result-001": 1}
@@ -193,10 +188,8 @@ def test_tool_result_message_without_function_call_indices():
         "uuid": "tool-result-001",
         "parentUuid": "assistant-uuid-003",
         "message": {
-            "parts": [
-                {"type": "tool", "name": "read_file", "content": "File contents here..."}
-            ]
-        }
+            "parts": [{"type": "tool", "name": "read_file", "content": "File contents here..."}]
+        },
     }
     # Without function_call_indices, uses fallback (may not match exactly)
     result = extract_content_blocks_from_entry(entry)
@@ -217,7 +210,7 @@ def test_tool_result_with_dict_content():
             "parts": [
                 {"type": "tool", "name": "list_files", "content": {"files": ["a.py", "b.py"]}}
             ]
-        }
+        },
     }
     # functionCall is at idx=0 in parent (simplified scenario)
     function_call_indices = {"tool-result-002": 0}
@@ -236,11 +229,8 @@ def test_empty_text_skipped():
         "type": "assistant",
         "uuid": "assistant-uuid-006",
         "message": {
-            "parts": [
-                {"text": ""},  # Empty text - should be skipped
-                {"text": "Valid text"}
-            ]
-        }
+            "parts": [{"text": ""}, {"text": "Valid text"}]  # Empty text - should be skipped
+        },
     }
     result = extract_content_blocks_from_entry(entry)
     assert len(result) == 1, f"Expected 1 block (empty skipped), got {len(result)}"
@@ -257,9 +247,9 @@ def test_empty_thinking_skipped():
         "message": {
             "parts": [
                 {"thought": True, "text": ""},  # Empty thinking - should be skipped
-                {"text": "Result"}
+                {"text": "Result"},
             ]
-        }
+        },
     }
     result = extract_content_blocks_from_entry(entry)
     assert len(result) == 1
@@ -270,10 +260,7 @@ def test_empty_thinking_skipped():
 
 def test_no_message_field():
     """Test entry without message field."""
-    entry = {
-        "type": "assistant",
-        "uuid": "assistant-uuid-008"
-    }
+    entry = {"type": "assistant", "uuid": "assistant-uuid-008"}
     result = extract_content_blocks_from_entry(entry)
     assert result == []
 
@@ -282,11 +269,7 @@ def test_no_message_field():
 
 def test_no_parts_field():
     """Test message without parts field."""
-    entry = {
-        "type": "assistant",
-        "uuid": "assistant-uuid-009",
-        "message": {}
-    }
+    entry = {"type": "assistant", "uuid": "assistant-uuid-009", "message": {}}
     result = extract_content_blocks_from_entry(entry)
     assert result == []
 
@@ -298,9 +281,7 @@ def test_non_dict_parts():
     entry = {
         "type": "assistant",
         "uuid": "assistant-uuid-010",
-        "message": {
-            "parts": ["string part", 123, None]  # Non-dict elements
-        }
+        "message": {"parts": ["string part", 123, None]},  # Non-dict elements
     }
     result = extract_content_blocks_from_entry(entry)
     assert result == [], f"Expected empty list for non-dict parts, got {result}"
@@ -313,11 +294,7 @@ def test_document_placeholder():
     entry = {
         "type": "user",
         "uuid": "user-uuid-003",
-        "message": {
-            "parts": [
-                {"type": "document", "name": "report.pdf"}
-            ]
-        }
+        "message": {"parts": [{"type": "document", "name": "report.pdf"}]},
     }
     result = extract_content_blocks_from_entry(entry)
     assert len(result) == 1
@@ -331,11 +308,7 @@ def test_missing_uuid_fallback():
     """Test fallback when uuid is missing."""
     entry = {
         "type": "assistant",
-        "message": {
-            "parts": [
-                {"functionCall": {"name": "test_tool", "args": {}}}
-            ]
-        }
+        "message": {"parts": [{"functionCall": {"name": "test_tool", "args": {}}}]},
     }
     result = extract_content_blocks_from_entry(entry)
     assert len(result) == 1
@@ -350,11 +323,7 @@ def test_missing_parent_uuid_fallback():
     entry = {
         "type": "tool_result",
         "uuid": "tool-result-003",
-        "message": {
-            "parts": [
-                {"type": "tool", "name": "test", "content": "result"}
-            ]
-        }
+        "message": {"parts": [{"type": "tool", "name": "test", "content": "result"}]},
     }
     result = extract_content_blocks_from_entry(entry)
     assert len(result) == 1


### PR DESCRIPTION
## 问题描述

在 Docker 部署的 Open ACE 环境中，重新执行 `scripts/install-central/docker-method/install.sh` 脚本会覆盖原有的配置文件，导致用户配置丢失。

Fixes #429

## 修复内容

### 1. 更改默认值为不覆盖
- 将 `prompt_yesno "是否覆盖?" "y"` 改为 `"n"`
- 非交互模式下也会保留已有配置

### 2. 添加备份机制
- 覆盖前自动备份配置文件
- 备份文件名格式：`config.json.bak.YYYYMMDD_HHMMSS`
- 设置备份文件权限为 600（仅 owner 可读写）
- 自动清理超过 7 天的旧备份文件

### 3. 添加 `check_existing_config` 函数
- 在部署开始前检查已有配置文件
- 提前警告用户注意保护配置

### 4. 工具目录存在检查
- 检测已存在的 `.qwen/.claude/.openclaw` 目录
- 输出警告提示用户注意保护配置文件

## 测试建议

1. **交互模式测试**：重新运行脚本，验证默认不覆盖配置
2. **非交互模式测试**：使用 `--non-interactive` 运行，验证不会自动覆盖
3. **备份功能测试**：选择覆盖时，验证备份文件正确创建
4. **权限测试**：验证备份文件权限为 600

## 变更文件

- `scripts/install-central/docker-method/install.sh` (+76 lines)