### PR TITLE
Add terminal tool launch progress prompt

### DIFF
--- a/remote-agent/terminal_menu.py
+++ b/remote-agent/terminal_menu.py
@@ -48,6 +48,11 @@ GREEN = "\x1b[32m"
 YELLOW = "\x1b[33m"
 
 
+def get_progress_bar(percent: int) -> str:
+    filled = max(0, min(20, round(percent / 5)))
+    return f"[{'=' * filled}{' ' * (20 - filled)}]"
+
+
 def check_installed(cli_name: str) -> bool:
     try:
         result = subprocess.run(["which", cli_name], capture_output=True, timeout=5)
@@ -106,6 +111,35 @@ def show_message(message: str) -> None:
     sys.stdout.flush()
 
 
+def render_launch_progress(item: dict) -> None:
+    installing = not item.get("installed")
+    action = "Installing" if installing else "Starting"
+    detail = (
+        "Installer output will appear below when it starts."
+        if installing
+        else "Waiting for the CLI interface to take over the terminal."
+    )
+    progress = 35 if installing else 55
+    lines = [
+        "",
+        f"  {BOLD_CYAN}========================================{RESET}",
+        f"  {BOLD_CYAN}  Open ACE Remote Terminal{RESET}",
+        f"  {BOLD_CYAN}========================================{RESET}",
+        "",
+        f"  {action} {BOLD_YELLOW}{item['name']}{RESET}",
+        "",
+        f"  {GREEN}{get_progress_bar(progress)}{RESET}  {progress}%",
+        "",
+        f"  {detail}",
+        "  First launch can take 5-15 seconds while the remote CLI initializes.",
+        "",
+        f"  {DIM}If this takes longer than 30 seconds, press Ctrl+C to interrupt.{RESET}",
+        "",
+    ]
+    sys.stdout.write(CLEAR + "\r\n".join(lines))
+    sys.stdout.flush()
+
+
 def read_key(fd: int) -> str:
     key = os.read(fd, 1).decode("utf-8", errors="replace")
     if key == "\x1b":
@@ -143,6 +177,7 @@ def handle_select(item: dict) -> None:
         cmd = f'{item["install_cmd"]} && {item["cmd"]}; exec {sys.executable} {MENU_PATH}'
     else:
         cmd = f'{item["cmd"]}; exec {sys.executable} {MENU_PATH}'
+    render_launch_progress(item)
     exec_command(cmd)
 
 

--- a/tests/unit/test_terminal_menu.py
+++ b/tests/unit/test_terminal_menu.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Unit tests for the remote terminal menu."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+def load_terminal_menu():
+    module_path = Path(__file__).resolve().parents[2] / "remote-agent" / "terminal_menu.py"
+    spec = importlib.util.spec_from_file_location("terminal_menu", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_render_launch_progress_for_installed_tool(capsys):
+    terminal_menu = load_terminal_menu()
+
+    terminal_menu.render_launch_progress({"name": "Claude Code", "installed": True})
+
+    output = capsys.readouterr().out
+    assert "Starting" in output
+    assert "Claude Code" in output
+    assert "[===========         ]" in output
+    assert "55%" in output
+    assert "Waiting for the CLI interface" in output
+    assert "Ctrl+C" in output
+
+
+def test_render_launch_progress_for_installing_tool(capsys):
+    terminal_menu = load_terminal_menu()
+
+    terminal_menu.render_launch_progress({"name": "Qwen Code", "installed": False})
+
+    output = capsys.readouterr().out
+    assert "Installing" in output
+    assert "Qwen Code" in output
+    assert "[=======             ]" in output
+    assert "35%" in output
+    assert "Installer output will appear below" in output
+
+
+def test_handle_select_renders_progress_before_exec(monkeypatch, capsys):
+    terminal_menu = load_terminal_menu()
+    executed_commands = []
+
+    def fake_exec_command(command):
+        executed_commands.append(command)
+
+    monkeypatch.setattr(terminal_menu, "exec_command", fake_exec_command)
+
+    terminal_menu.handle_select(
+        {
+            "name": "Claude Code",
+            "installed": True,
+            "configured": True,
+            "cmd": "claude --bare",
+        }
+    )
+
+    output = capsys.readouterr().out
+    assert "Starting" in output
+    assert "Claude Code" in output
+    assert executed_commands == [
+        f"claude --bare; exec {terminal_menu.sys.executable} {terminal_menu.MENU_PATH}"
+    ]


### PR DESCRIPTION
## Summary
- show a launch progress screen after selecting a terminal tool before the CLI takes over
- differentiate installed tool startup from install-and-launch startup
- add unit tests for the terminal menu launch prompt and command flow

## Tests
- python3 -m pytest tests/unit/test_terminal_menu.py
- python3 -m ruff check remote-agent/terminal_menu.py tests/unit/test_terminal_menu.py
- python3 -m black --check remote-agent/terminal_menu.py tests/unit/test_terminal_menu.py