### PR TITLE
fix: fs_bp 路由支持 WebUI token 认证

### DIFF
--- a/app/routes/fs.py
+++ b/app/routes/fs.py
@@ -25,6 +25,45 @@ fs_bp = Blueprint("fs", __name__)
 user_repo = UserRepository()
 
 
+@fs_bp.before_request
+def _authenticate_user():
+    """Authenticate via session token or WebUI token (for iframe integration)."""
+    # Skip auth for OPTIONS preflight requests
+    if request.method == "OPTIONS":
+        return None
+
+    # Try session token first
+    from app.auth.decorators import _extract_token, _load_user_from_token
+
+    token = _extract_token()
+    if token:
+        user_data = _load_user_from_token(token)
+        if user_data:
+            user = user_repo.get_user_by_id(int(user_data.get("id", 0)))
+            if user:
+                g.user = user
+                g.user_id = user.get("id")
+                return None
+
+    # Fallback: try WebUI token from query param (for iframe integration)
+    url_token = request.args.get("token")
+    if url_token:
+        from app.services.webui_manager import get_webui_manager
+
+        manager = get_webui_manager()
+        if manager:
+            valid, user_id, error = manager.validate_token(url_token)
+            if valid and user_id:
+                user = user_repo.get_user_by_id(user_id)
+                if user:
+                    g.user = user
+                    g.user_id = user_id
+                    g.user_role = user.get("role")
+                    return None
+
+    return jsonify({"error": "Authentication required"}), 401
+
+
 def run_as_user(system_account: str, command: list) -> subprocess.CompletedProcess:
     """Run a command as a specific user using sudo."""
     sudo_cmd = ["sudo", "-u", system_account] + command
@@ -201,7 +240,6 @@ def get_directory_info(path: str, system_account: str | None = None):
 
 
 @fs_bp.route("/fs/browse", methods=["GET"])
-@auth_required
 def api_browse_directory():
     """Browse a directory and list subdirectories."""
     user = g.user
@@ -344,7 +382,6 @@ def list_subdirectories(path: str, system_account: str | None = None) -> list:
 
 
 @fs_bp.route("/fs/check-path", methods=["POST"])
-@auth_required
 def api_check_path():
     """Check if a path is valid and can be used for a project."""
     user = g.user
@@ -425,7 +462,6 @@ def api_check_path():
 
 
 @fs_bp.route("/fs/home", methods=["GET"])
-@auth_required
 def api_get_home():
     """Get user's home directory."""
     user = g.user

--- a/app/routes/fs.py
+++ b/app/routes/fs.py
@@ -16,7 +16,6 @@ from typing import Any
 
 from flask import Blueprint, g, jsonify, request
 
-from app.auth.decorators import auth_required
 from app.repositories.user_repo import UserRepository
 
 logger = logging.getLogger(__name__)
@@ -43,6 +42,7 @@ def _authenticate_user():
             if user:
                 g.user = user
                 g.user_id = user.get("id")
+                g.user_role = user.get("role")
                 return None
 
     # Fallback: try WebUI token from query param (for iframe integration)


### PR DESCRIPTION
## 问题

在 `/work` 页面 iframe 中调用 `/fs/browse`、`/fs/check-path`、`/fs/home` API 时返回 UNAUTHORIZED。

**根本原因**：`@auth_required` 装饰器只验证 session cookie/header 中的 token，不支持 iframe 通过 URL 参数传递的 WebUI token。

对比其他路由（`projects_bp`、`workspace_bp`）都有 `before_request` 处理器，先尝试 session token，失败后 fallback 到 WebUI token 验证。`fs_bp` 缺少此 fallback 机制。

## 解决方案

为 `fs_bp` 添加 `before_request` 处理器，实现与 `projects_bp`/`workspace_bp` 一致的认证逻辑：

1. 先尝试 session token（通过 `_extract_token()` 和 `_load_user_from_token()`）
2. 失败后 fallback 到 WebUI token（通过 `request.args.get("token")` 和 `manager.validate_token()`）
3. 认证成功后设置 `g.user`、`g.user_id`、`g.user_role`

同时移除 `/fs/browse`、`/fs/check-path`、`/fs/home` 三个路由上的 `@auth_required` 装饰器，使用统一的 `before_request` 认证。

## 测试

已在 node237 验证：
- 访问 http://192.168.1.237:5000/work
- 创建会话后添加项目，选择 [local] 选项
- 输入路径正常验证，不再报 UNAUTHORIZED

Fixes #421