### PR TITLE
fix(issue #352): Add tool limit hints to inform assistant about platform constraints

### DIFF
--- a/remote-agent/executor.py
+++ b/remote-agent/executor.py
@@ -570,6 +570,71 @@ class ProcessExecutor:
         if is_complete:
             logger.info("Session %s output stream complete", session_id[:8])
 
+    def _send_tool_limit_hints(self, session_id: str) -> bool:
+        """
+        Send tool limit hints to the CLI after SDK initialization (Issue #352).
+
+        This informs the assistant about platform tool limitations so it can
+        proactively handle long-running tasks instead of silently switching
+        strategies when limits are hit.
+
+        Args:
+            session_id: Session identifier.
+
+        Returns:
+            True if hints were sent successfully.
+        """
+        with self._lock:
+            session = self._sessions.get(session_id)
+        if not session or not session.is_running:
+            logger.warning("Cannot send tool limit hints to stopped session %s", session_id[:8])
+            return False
+
+        # Tool limit hints message
+        # These limits are platform-specific and should be communicated clearly
+        hints_msg = {
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": (
+                            "[Platform Tool Limits]\n"
+                            "The following tool limitations apply on this platform:\n"
+                            "- run_shell_command: Maximum timeout is 600 seconds (10 minutes)\n"
+                            "- For tasks that may exceed this limit, consider:\n"
+                            "  1. Using is_background=true for long-running processes\n"
+                            "  2. Breaking down into smaller steps\n"
+                            "  3. Using polling/checkpointing for progress tracking\n"
+                            "- When a tool call approaches or exceeds limits, the system will\n"
+                            "  provide explicit error messages - please handle accordingly\n"
+                            "- Do not silently switch execution strategies without user confirmation\n"
+                            "\n"
+                            "Please plan your approach accordingly when executing long-running commands."
+                        ),
+                    }
+                ],
+            },
+        }
+
+        try:
+            payload = json.dumps(hints_msg) + "\n"
+            session.process.stdin.write(payload.encode("utf-8"))
+            session.process.stdin.flush()
+            logger.info(
+                "Sent tool limit hints for session %s",
+                session_id[:8],
+            )
+            return True
+        except (OSError, BrokenPipeError, AttributeError) as e:
+            logger.error(
+                "Failed to send tool limit hints for session %s: %s",
+                session_id[:8],
+                e,
+            )
+            return False
+
     def _build_env(
         self,
         cli_tool: str,
@@ -893,6 +958,9 @@ class ProcessExecutor:
                     session_id[:8],
                 )
 
+            else:
+                # SDK init successful - send tool limit hints (Issue #352)
+                self._send_tool_limit_hints(session_id)
         logger.info(
             "Session %s started (pid %d): %s",
             session_id[:8],

--- a/remote-agent/executor.py
+++ b/remote-agent/executor.py
@@ -521,6 +521,7 @@ class ProcessExecutor:
         output_callback: Callable | None = None,
         permission_callback: Callable | None = None,
         usage_callback: Callable | None = None,
+        tool_timeout: int = 600,
     ):
         """
         Args:
@@ -533,8 +534,11 @@ class ProcessExecutor:
                 prompt).  If None, control_requests are forwarded as regular output.
             usage_callback: Called with (session_id, tokens_dict) when a result
                 message contains token usage data.
+            tool_timeout: Maximum timeout for run_shell_command in seconds.
+                Defaults to 600 (10 minutes). Used in tool limit hints message.
         """
         self.server_url = server_url
+        self._tool_timeout = tool_timeout
         self._output_callback = output_callback or self._default_output_callback
         self._permission_callback = permission_callback
         self._usage_callback = usage_callback
@@ -592,6 +596,7 @@ class ProcessExecutor:
 
         # Tool limit hints message
         # These limits are platform-specific and should be communicated clearly
+        timeout_minutes = self._tool_timeout // 60
         hints_msg = {
             "type": "user",
             "message": {
@@ -602,7 +607,7 @@ class ProcessExecutor:
                         "text": (
                             "[Platform Tool Limits]\n"
                             "The following tool limitations apply on this platform:\n"
-                            "- run_shell_command: Maximum timeout is 600 seconds (10 minutes)\n"
+                            f"- run_shell_command: Maximum timeout is {self._tool_timeout} seconds ({timeout_minutes} minutes)\n"
                             "- For tasks that may exceed this limit, consider:\n"
                             "  1. Using is_background=true for long-running processes\n"
                             "  2. Breaking down into smaller steps\n"

--- a/tests/issues/352/test_tool_limit_hints.py
+++ b/tests/issues/352/test_tool_limit_hints.py
@@ -128,20 +128,36 @@ class TestSendToolLimitHints(unittest.TestCase):
         # Verify message structure
         self.assertEqual(parsed_msg["type"], "user", "Message type should be 'user'")
         self.assertEqual(parsed_msg["message"]["role"], "user", "Role should be 'user'")
-        self.assertIsInstance(parsed_msg["message"]["content"], list, "Content should be a list")
-        self.assertEqual(len(parsed_msg["message"]["content"]), 1, "Should have one content block")
+        self.assertIsInstance(
+            parsed_msg["message"]["content"], list, "Content should be a list"
+        )
+        self.assertEqual(
+            len(parsed_msg["message"]["content"]), 1, "Should have one content block"
+        )
 
         # Verify content block
         content_block = parsed_msg["message"]["content"][0]
-        self.assertEqual(content_block["type"], "text", "Content block type should be 'text'")
+        self.assertEqual(
+            content_block["type"], "text", "Content block type should be 'text'"
+        )
 
         # Verify key information is present in the text
         text_content = content_block["text"]
-        self.assertIn("Platform Tool Limits", text_content, "Should mention Platform Tool Limits")
-        self.assertIn("run_shell_command", text_content, "Should mention run_shell_command")
+        self.assertIn(
+            "Platform Tool Limits", text_content, "Should mention Platform Tool Limits"
+        )
+        self.assertIn(
+            "run_shell_command", text_content, "Should mention run_shell_command"
+        )
         self.assertIn("600 seconds", text_content, "Should mention 600 seconds timeout")
-        self.assertIn("is_background=true", text_content, "Should mention background mode")
-        self.assertIn("Breaking down into smaller steps", text_content, "Should suggest task breakdown")
+        self.assertIn(
+            "is_background=true", text_content, "Should mention background mode"
+        )
+        self.assertIn(
+            "Breaking down into smaller steps",
+            text_content,
+            "Should suggest task breakdown",
+        )
 
     def test_hints_content_comprehensive(self):
         """Test that hints content covers all required aspects."""
@@ -198,13 +214,13 @@ class TestToolLimitHintsIntegration(unittest.TestCase):
         # Verify method exists
         self.assertTrue(
             hasattr(executor, "_send_tool_limit_hints"),
-            "ProcessExecutor should have _send_tool_limit_hints method"
+            "ProcessExecutor should have _send_tool_limit_hints method",
         )
 
         # Verify method is callable
         self.assertTrue(
             callable(executor._send_tool_limit_hints),
-            "_send_tool_limit_hints should be callable"
+            "_send_tool_limit_hints should be callable",
         )
 
 
@@ -294,7 +310,9 @@ class TestToolTimeoutConfiguration(unittest.TestCase):
         )
 
         # Verify default timeout
-        self.assertEqual(executor._tool_timeout, 600, "Default timeout should be 600 seconds")
+        self.assertEqual(
+            executor._tool_timeout, 600, "Default timeout should be 600 seconds"
+        )
 
     def test_custom_timeout_value(self):
         """Test that custom timeout value is properly set."""
@@ -306,7 +324,9 @@ class TestToolTimeoutConfiguration(unittest.TestCase):
         )
 
         # Verify custom timeout
-        self.assertEqual(executor._tool_timeout, 300, "Custom timeout should be 300 seconds")
+        self.assertEqual(
+            executor._tool_timeout, 300, "Custom timeout should be 300 seconds"
+        )
 
     def test_timeout_in_hints_message(self):
         """Test that custom timeout appears in hints message."""
@@ -342,8 +362,12 @@ class TestToolTimeoutConfiguration(unittest.TestCase):
         text_content = parsed_msg["message"]["content"][0]["text"]
 
         # Verify custom timeout appears in message
-        self.assertIn("300 seconds", text_content, "Custom timeout should appear in message")
-        self.assertIn("5 minutes", text_content, "Timeout in minutes should appear in message")
+        self.assertIn(
+            "300 seconds", text_content, "Custom timeout should appear in message"
+        )
+        self.assertIn(
+            "5 minutes", text_content, "Timeout in minutes should appear in message"
+        )
 
 
 if __name__ == "__main__":

--- a/tests/issues/352/test_tool_limit_hints.py
+++ b/tests/issues/352/test_tool_limit_hints.py
@@ -208,5 +208,143 @@ class TestToolLimitHintsIntegration(unittest.TestCase):
         )
 
 
+class TestToolLimitHintsExceptionHandling(unittest.TestCase):
+    """Test exception handling in _send_tool_limit_hints method."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        from executor import ProcessExecutor
+
+        self.executor = ProcessExecutor(
+            server_url="http://localhost:5000",
+        )
+
+    def test_os_error_handling(self):
+        """Test handling of OSError when writing to stdin."""
+        session_id = "test-session-os-error"
+        mock_session = MockSessionProcess(session_id, is_running=True)
+
+        # Mock stdin.write to raise OSError
+        def raise_os_error(data):
+            raise OSError("Mock OS error")
+
+        mock_session.process.stdin.write = raise_os_error
+        mock_session.process.stdin.flush = Mock()
+
+        # Add mock session to executor's sessions dict
+        with self.executor._lock:
+            self.executor._sessions[session_id] = mock_session
+
+        # Send tool limit hints - should handle exception gracefully
+        result = self.executor._send_tool_limit_hints(session_id)
+
+        # Verify result - should return False on error
+        self.assertFalse(result, "Should return False on OSError")
+
+    def test_broken_pipe_error_handling(self):
+        """Test handling of BrokenPipeError when writing to stdin."""
+        session_id = "test-session-broken-pipe"
+        mock_session = MockSessionProcess(session_id, is_running=True)
+
+        # Mock stdin.write to raise BrokenPipeError
+        def raise_broken_pipe(data):
+            raise BrokenPipeError("Mock broken pipe")
+
+        mock_session.process.stdin.write = raise_broken_pipe
+        mock_session.process.stdin.flush = Mock()
+
+        # Add mock session to executor's sessions dict
+        with self.executor._lock:
+            self.executor._sessions[session_id] = mock_session
+
+        # Send tool limit hints - should handle exception gracefully
+        result = self.executor._send_tool_limit_hints(session_id)
+
+        # Verify result - should return False on error
+        self.assertFalse(result, "Should return False on BrokenPipeError")
+
+    def test_attribute_error_handling(self):
+        """Test handling of AttributeError when stdin is None."""
+        session_id = "test-session-attr-error"
+        mock_session = MockSessionProcess(session_id, is_running=True)
+
+        # Set stdin to None to trigger AttributeError
+        mock_session.process.stdin = None
+
+        # Add mock session to executor's sessions dict
+        with self.executor._lock:
+            self.executor._sessions[session_id] = mock_session
+
+        # Send tool limit hints - should handle exception gracefully
+        result = self.executor._send_tool_limit_hints(session_id)
+
+        # Verify result - should return False on error
+        self.assertFalse(result, "Should return False on AttributeError")
+
+
+class TestToolTimeoutConfiguration(unittest.TestCase):
+    """Test configurable tool timeout feature."""
+
+    def test_default_timeout_value(self):
+        """Test that default timeout is 600 seconds."""
+        from executor import ProcessExecutor
+
+        executor = ProcessExecutor(
+            server_url="http://localhost:5000",
+        )
+
+        # Verify default timeout
+        self.assertEqual(executor._tool_timeout, 600, "Default timeout should be 600 seconds")
+
+    def test_custom_timeout_value(self):
+        """Test that custom timeout value is properly set."""
+        from executor import ProcessExecutor
+
+        executor = ProcessExecutor(
+            server_url="http://localhost:5000",
+            tool_timeout=300,
+        )
+
+        # Verify custom timeout
+        self.assertEqual(executor._tool_timeout, 300, "Custom timeout should be 300 seconds")
+
+    def test_timeout_in_hints_message(self):
+        """Test that custom timeout appears in hints message."""
+        from executor import ProcessExecutor
+
+        executor = ProcessExecutor(
+            server_url="http://localhost:5000",
+            tool_timeout=300,  # 5 minutes
+        )
+
+        session_id = "test-session-custom-timeout"
+        mock_session = MockSessionProcess(session_id, is_running=True)
+
+        # Create a mock stdin that captures writes
+        written_content = []
+
+        def capture_write(data):
+            written_content.append(data)
+
+        mock_session.process.stdin.write = capture_write
+        mock_session.process.stdin.flush = Mock()
+
+        # Add mock session to executor's sessions dict
+        with executor._lock:
+            executor._sessions[session_id] = mock_session
+
+        # Send tool limit hints
+        executor._send_tool_limit_hints(session_id)
+
+        # Parse the written content
+        written_data = written_content[0].decode("utf-8").strip()
+        parsed_msg = json.loads(written_data)
+        text_content = parsed_msg["message"]["content"][0]["text"]
+
+        # Verify custom timeout appears in message
+        self.assertIn("300 seconds", text_content, "Custom timeout should appear in message")
+        self.assertIn("5 minutes", text_content, "Timeout in minutes should appear in message")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/issues/352/test_tool_limit_hints.py
+++ b/tests/issues/352/test_tool_limit_hints.py
@@ -128,31 +128,19 @@ class TestSendToolLimitHints(unittest.TestCase):
         # Verify message structure
         self.assertEqual(parsed_msg["type"], "user", "Message type should be 'user'")
         self.assertEqual(parsed_msg["message"]["role"], "user", "Role should be 'user'")
-        self.assertIsInstance(
-            parsed_msg["message"]["content"], list, "Content should be a list"
-        )
-        self.assertEqual(
-            len(parsed_msg["message"]["content"]), 1, "Should have one content block"
-        )
+        self.assertIsInstance(parsed_msg["message"]["content"], list, "Content should be a list")
+        self.assertEqual(len(parsed_msg["message"]["content"]), 1, "Should have one content block")
 
         # Verify content block
         content_block = parsed_msg["message"]["content"][0]
-        self.assertEqual(
-            content_block["type"], "text", "Content block type should be 'text'"
-        )
+        self.assertEqual(content_block["type"], "text", "Content block type should be 'text'")
 
         # Verify key information is present in the text
         text_content = content_block["text"]
-        self.assertIn(
-            "Platform Tool Limits", text_content, "Should mention Platform Tool Limits"
-        )
-        self.assertIn(
-            "run_shell_command", text_content, "Should mention run_shell_command"
-        )
+        self.assertIn("Platform Tool Limits", text_content, "Should mention Platform Tool Limits")
+        self.assertIn("run_shell_command", text_content, "Should mention run_shell_command")
         self.assertIn("600 seconds", text_content, "Should mention 600 seconds timeout")
-        self.assertIn(
-            "is_background=true", text_content, "Should mention background mode"
-        )
+        self.assertIn("is_background=true", text_content, "Should mention background mode")
         self.assertIn(
             "Breaking down into smaller steps",
             text_content,
@@ -310,9 +298,7 @@ class TestToolTimeoutConfiguration(unittest.TestCase):
         )
 
         # Verify default timeout
-        self.assertEqual(
-            executor._tool_timeout, 600, "Default timeout should be 600 seconds"
-        )
+        self.assertEqual(executor._tool_timeout, 600, "Default timeout should be 600 seconds")
 
     def test_custom_timeout_value(self):
         """Test that custom timeout value is properly set."""
@@ -324,9 +310,7 @@ class TestToolTimeoutConfiguration(unittest.TestCase):
         )
 
         # Verify custom timeout
-        self.assertEqual(
-            executor._tool_timeout, 300, "Custom timeout should be 300 seconds"
-        )
+        self.assertEqual(executor._tool_timeout, 300, "Custom timeout should be 300 seconds")
 
     def test_timeout_in_hints_message(self):
         """Test that custom timeout appears in hints message."""
@@ -362,12 +346,8 @@ class TestToolTimeoutConfiguration(unittest.TestCase):
         text_content = parsed_msg["message"]["content"][0]["text"]
 
         # Verify custom timeout appears in message
-        self.assertIn(
-            "300 seconds", text_content, "Custom timeout should appear in message"
-        )
-        self.assertIn(
-            "5 minutes", text_content, "Timeout in minutes should appear in message"
-        )
+        self.assertIn("300 seconds", text_content, "Custom timeout should appear in message")
+        self.assertIn("5 minutes", text_content, "Timeout in minutes should appear in message")
 
 
 if __name__ == "__main__":

--- a/tests/issues/352/test_tool_limit_hints.py
+++ b/tests/issues/352/test_tool_limit_hints.py
@@ -1,0 +1,212 @@
+"""
+Test for Issue #352: Tool limit hints communication
+
+Tests the _send_tool_limit_hints method in ProcessExecutor that informs
+the assistant about platform tool limitations (e.g., run_shell_command timeout).
+"""
+
+import json
+import subprocess
+import sys
+import threading
+import unittest
+from io import BytesIO
+from pathlib import Path
+from unittest.mock import MagicMock, Mock, patch, PropertyMock
+
+# Add remote-agent directory to path
+remote_agent_dir = Path(__file__).parent.parent.parent.parent / "remote-agent"
+sys.path.insert(0, str(remote_agent_dir))
+
+
+class MockSessionProcess:
+    """Mock SessionProcess for testing."""
+
+    def __init__(self, session_id, is_running=True):
+        self.session_id = session_id
+        self._is_running = is_running
+        self.stdin = BytesIO()
+        self.process = Mock()
+        self.process.stdin = self.stdin
+        self.process.pid = 12345
+
+    @property
+    def is_running(self):
+        return self._is_running
+
+
+class TestSendToolLimitHints(unittest.TestCase):
+    """Test cases for _send_tool_limit_hints method."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        # Import ProcessExecutor after path is set
+        from executor import ProcessExecutor
+
+        self.executor = ProcessExecutor(
+            server_url="http://localhost:5000",
+            output_callback=None,
+            permission_callback=None,
+            usage_callback=None,
+        )
+
+    def test_send_hints_to_running_session(self):
+        """Test sending tool limit hints to a running session."""
+        session_id = "test-session-001"
+        mock_session = MockSessionProcess(session_id, is_running=True)
+
+        # Add mock session to executor's sessions dict
+        with self.executor._lock:
+            self.executor._sessions[session_id] = mock_session
+
+        # Send tool limit hints
+        result = self.executor._send_tool_limit_hints(session_id)
+
+        # Verify result
+        self.assertTrue(result, "Should return True for successful send")
+
+        # Verify stdin has content written
+        # Note: BytesIO doesn't track writes like a real pipe, but we can check
+        # that the method executed without errors
+
+    def test_send_hints_to_stopped_session(self):
+        """Test sending tool limit hints to a stopped session."""
+        session_id = "test-session-002"
+        mock_session = MockSessionProcess(session_id, is_running=False)
+
+        # Add mock session to executor's sessions dict
+        with self.executor._lock:
+            self.executor._sessions[session_id] = mock_session
+
+        # Send tool limit hints
+        result = self.executor._send_tool_limit_hints(session_id)
+
+        # Verify result - should be False for stopped session
+        self.assertFalse(result, "Should return False for stopped session")
+
+    def test_send_hints_to_nonexistent_session(self):
+        """Test sending tool limit hints to a nonexistent session."""
+        session_id = "test-session-nonexistent"
+
+        # Don't add any session to executor
+
+        # Send tool limit hints
+        result = self.executor._send_tool_limit_hints(session_id)
+
+        # Verify result - should be False for nonexistent session
+        self.assertFalse(result, "Should return False for nonexistent session")
+
+    def test_hints_message_format(self):
+        """Test that the hints message is properly formatted."""
+        session_id = "test-session-003"
+        mock_session = MockSessionProcess(session_id, is_running=True)
+
+        # Create a mock stdin that captures writes
+        written_content = []
+
+        def capture_write(data):
+            written_content.append(data)
+
+        mock_session.process.stdin.write = capture_write
+        mock_session.process.stdin.flush = Mock()
+
+        # Add mock session to executor's sessions dict
+        with self.executor._lock:
+            self.executor._sessions[session_id] = mock_session
+
+        # Send tool limit hints
+        result = self.executor._send_tool_limit_hints(session_id)
+
+        # Verify message format
+        self.assertTrue(result, "Should return True for successful send")
+        self.assertEqual(len(written_content), 1, "Should write exactly one message")
+
+        # Parse the written content
+        written_data = written_content[0].decode("utf-8").strip()
+        parsed_msg = json.loads(written_data)
+
+        # Verify message structure
+        self.assertEqual(parsed_msg["type"], "user", "Message type should be 'user'")
+        self.assertEqual(parsed_msg["message"]["role"], "user", "Role should be 'user'")
+        self.assertIsInstance(parsed_msg["message"]["content"], list, "Content should be a list")
+        self.assertEqual(len(parsed_msg["message"]["content"]), 1, "Should have one content block")
+
+        # Verify content block
+        content_block = parsed_msg["message"]["content"][0]
+        self.assertEqual(content_block["type"], "text", "Content block type should be 'text'")
+
+        # Verify key information is present in the text
+        text_content = content_block["text"]
+        self.assertIn("Platform Tool Limits", text_content, "Should mention Platform Tool Limits")
+        self.assertIn("run_shell_command", text_content, "Should mention run_shell_command")
+        self.assertIn("600 seconds", text_content, "Should mention 600 seconds timeout")
+        self.assertIn("is_background=true", text_content, "Should mention background mode")
+        self.assertIn("Breaking down into smaller steps", text_content, "Should suggest task breakdown")
+
+    def test_hints_content_comprehensive(self):
+        """Test that hints content covers all required aspects."""
+        session_id = "test-session-004"
+        mock_session = MockSessionProcess(session_id, is_running=True)
+
+        # Create a mock stdin that captures writes
+        written_content = []
+
+        def capture_write(data):
+            written_content.append(data)
+
+        mock_session.process.stdin.write = capture_write
+        mock_session.process.stdin.flush = Mock()
+
+        # Add mock session to executor's sessions dict
+        with self.executor._lock:
+            self.executor._sessions[session_id] = mock_session
+
+        # Send tool limit hints
+        self.executor._send_tool_limit_hints(session_id)
+
+        # Parse the written content
+        written_data = written_content[0].decode("utf-8").strip()
+        parsed_msg = json.loads(written_data)
+        text_content = parsed_msg["message"]["content"][0]["text"]
+
+        # Check all required information
+        required_elements = [
+            "Maximum timeout is 600 seconds",
+            "is_background=true for long-running processes",
+            "Breaking down into smaller steps",
+            "polling/checkpointing for progress tracking",
+            "explicit error messages",
+            "Do not silently switch execution strategies",
+            "without user confirmation",
+        ]
+
+        for element in required_elements:
+            self.assertIn(element, text_content, f"Should contain '{element}'")
+
+
+class TestToolLimitHintsIntegration(unittest.TestCase):
+    """Integration tests for tool limit hints feature."""
+
+    def test_executor_has_send_tool_limit_hints_method(self):
+        """Test that ProcessExecutor has the _send_tool_limit_hints method."""
+        from executor import ProcessExecutor
+
+        executor = ProcessExecutor(
+            server_url="http://localhost:5000",
+        )
+
+        # Verify method exists
+        self.assertTrue(
+            hasattr(executor, "_send_tool_limit_hints"),
+            "ProcessExecutor should have _send_tool_limit_hints method"
+        )
+
+        # Verify method is callable
+        self.assertTrue(
+            callable(executor._send_tool_limit_hints),
+            "_send_tool_limit_hints should be callable"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/issues/352/test_tool_limit_hints.py
+++ b/tests/issues/352/test_tool_limit_hints.py
@@ -12,7 +12,7 @@ import threading
 import unittest
 from io import BytesIO
 from pathlib import Path
-from unittest.mock import MagicMock, Mock, patch, PropertyMock
+from unittest.mock import MagicMock, Mock, PropertyMock, patch
 
 # Add remote-agent directory to path
 remote_agent_dir = Path(__file__).parent.parent.parent.parent / "remote-agent"


### PR DESCRIPTION
## 问题描述

Issue #352: run_shell_command 工具硬限制导致任务意外中断

平台对 run_shell_command 工具存在硬限制（如 600 秒最大超时），当任务可能超出限制时，系统没有明确报错，但 assistant 会感知到限制后尝试其他替代方案，这种隐式行为导致任务意外中断。

## 解决方案

本 PR 在远程 Agent 的 SessionProcess 初始化成功后，主动发送工具限制提示消息，让 assistant 明确了解平台的工具限制：

1. **新增  方法**：在 ProcessExecutor 中添加该方法，用于发送工具限制信息

2. **SDK 初始化后发送提示**：在 SDK 初始化成功后，自动发送包含以下内容的提示消息：
   - run_shell_command 最大超时（600 秒）
   - 建议使用  处理长时间任务
   - 建议拆分任务为更小的步骤
   - 建议使用轮询/检查点跟踪进度
   - 明确要求不要在没有用户确认的情况下切换执行策略

3. **添加单元测试**：验证新功能的正确性

## 修改文件

- : 添加  方法
- : 新增测试文件

## 测试结果

```
tests/issues/352/test_tool_limit_hints.py::TestSendToolLimitHints::test_hints_content_comprehensive PASSED
tests/issues/352/test_tool_limit_hints.py::TestSendToolLimitHints::test_hints_message_format PASSED
tests/issues/352/test_tool_limit_hints.py::TestSendToolLimitHints::test_send_hints_to_nonexistent_session PASSED
tests/issues/352/test_tool_limit_hints.py::TestSendToolLimitHints::test_send_hints_to_running_session PASSED
tests/issues/352/test_tool_limit_hints.py::TestSendToolLimitHints::test_send_hints_to_stopped_session PASSED
tests/issues/352/test_tool_limit_hints.py::TestToolLimitHintsIntegration::test_executor_has_send_tool_limit_hints_method PASSED
============================== 6 passed in 0.05s
```

## 影响范围

- 仅影响远程工作区的 Session 初始化流程
- 不影响现有功能，仅添加额外的提示信息
- 向后兼容，不会破坏现有行为

Fixes #352

🤖 Generated with Qwen Code