### PR TITLE
fix: 分类计数与提示词列表显示数量不一致

### DIFF
--- a/app/modules/workspace/prompt_library.py
+++ b/app/modules/workspace/prompt_library.py
@@ -534,9 +534,12 @@ class PromptLibrary:
 
         return [self._row_to_template(row) for row in rows]
 
-    def get_categories(self) -> list[dict[str, Any]]:
+    def get_categories(self, user_id: Optional[int] = None) -> list[dict[str, Any]]:
         """
         Get all categories with template counts.
+
+        Args:
+            user_id: Optional user ID to include their private templates in counts.
 
         Returns:
             List of category info dictionaries.
@@ -544,15 +547,29 @@ class PromptLibrary:
         conn = self._get_connection()
         cursor = conn.cursor()
 
-        cursor.execute(
-            f"""
-            SELECT category, COUNT(*) as count
-            FROM prompt_templates
-            WHERE {adapt_boolean_condition('is_public', True)}
-            GROUP BY category
-            ORDER BY count DESC
-        """
-        )
+        if user_id is not None:
+            # Include user's private templates + all public templates
+            cursor.execute(
+                f"""
+                SELECT category, COUNT(*) as count
+                FROM prompt_templates
+                WHERE (author_id = ? OR {adapt_boolean_condition('is_public', True)})
+                GROUP BY category
+                ORDER BY count DESC
+            """,
+                (user_id,),
+            )
+        else:
+            # Only count public templates
+            cursor.execute(
+                f"""
+                SELECT category, COUNT(*) as count
+                FROM prompt_templates
+                WHERE {adapt_boolean_condition('is_public', True)}
+                GROUP BY category
+                ORDER BY count DESC
+            """
+            )
 
         rows = cursor.fetchall()
         conn.close()

--- a/app/routes/workspace.py
+++ b/app/routes/workspace.py
@@ -371,7 +371,9 @@ def get_prompt_categories():
     """Get prompt categories with counts."""
     try:
         library = get_prompt_library()
-        categories = library.get_categories()
+        # Get current user ID to include their private templates in counts
+        current_user_id = g.user.get("id") if hasattr(g, "user") and g.user else None
+        categories = library.get_categories(user_id=current_user_id)
 
         return jsonify({"success": True, "data": categories})
     except Exception as e:


### PR DESCRIPTION
## 问题描述

修复 Issue #459：Work 页面提示词分类计数与列表显示数量不一致的问题。

## 根因分析

两个查询逻辑不一致：

| 查询 | 条件 | 影响 |
|------|------|------|
| 提示词列表 | (author_id = user_id OR is_public = True) | 显示用户私有提示词 + 公开提示词 |
| 分类计数 | is_public = True | 只统计公开提示词 |

导致用户私有提示词在列表中显示，但分类按钮计数不包含。

## 修复内容

1. PromptLibrary.get_categories() 方法新增可选的 user_id 参数
2. 当传入 user_id 时，使用与列表查询相同的条件
3. get_prompt_categories API 层传入当前用户 ID

## 测试

PromptLibrary 相关测试全部通过 (10 passed)

Closes #459