### PR TITLE
Support username/password login in openace CLI

### DIFF
--- a/remote-agent/openace_cli.py
+++ b/remote-agent/openace_cli.py
@@ -90,9 +90,11 @@ def _session_token() -> str:
 
 
 def _login_with_password(server_url: str, username: str, password: str) -> str:
+    if not server_url.startswith("https://"):
+        print("Warning: Sending credentials over insecure connection.", file=sys.stderr)
     body = json.dumps({"username": username, "password": password}).encode("utf-8")
     req = urllib.request.Request(
-        f"{server_url}/auth/login",
+        f"{server_url}/api/auth/login",
         data=body,
         method="POST",
         headers={

--- a/remote-agent/openace_cli.py
+++ b/remote-agent/openace_cli.py
@@ -85,8 +85,43 @@ def _machine_id() -> str:
 def _session_token() -> str:
     token = str(_load_cli_config().get("session_token") or "")
     if not token:
-        raise CliError("Not logged in. Run: openace login --token <session-token>")
+        raise CliError("Not logged in. Run: openace login")
     return token
+
+
+def _login_with_password(server_url: str, username: str, password: str) -> str:
+    body = json.dumps({"username": username, "password": password}).encode("utf-8")
+    req = urllib.request.Request(
+        f"{server_url}/auth/login",
+        data=body,
+        method="POST",
+        headers={
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+            if not data.get("success"):
+                raise CliError(str(data.get("error") or "Login failed"))
+            cookies = resp.headers.get_all("Set-Cookie") or []
+            for cookie in cookies:
+                for part in cookie.split(";"):
+                    part = part.strip()
+                    if part.startswith("session_token="):
+                        return part.split("=", 1)[1]
+            raise CliError("Login succeeded but no session token received")
+    except urllib.error.HTTPError as exc:
+        raw = exc.read().decode("utf-8", errors="replace")
+        try:
+            err_data = json.loads(raw)
+            message = err_data.get("error") or err_data.get("message") or raw
+        except json.JSONDecodeError:
+            message = raw or exc.reason
+        raise CliError(f"Login failed ({exc.code}): {message}") from exc
+    except urllib.error.URLError as exc:
+        raise CliError(f"Cannot reach Open ACE server: {exc.reason}") from exc
 
 
 def _request_json(method: str, url: str, token: str, payload: dict[str, Any]) -> dict[str, Any]:
@@ -183,15 +218,24 @@ def _clear_active_terminal() -> None:
 
 
 def cmd_login(args: argparse.Namespace) -> int:
-    token = args.token or getpass.getpass("Open ACE session token: ").strip()
-    if not token:
-        raise CliError("Token is required")
+    server_url = _server_url()
+    machine_id = _machine_id()
+
+    if args.token:
+        token = args.token
+    else:
+        username = input("Username: ").strip()
+        password = getpass.getpass("Password: ")
+        if not username or not password:
+            raise CliError("Username and password are required")
+        token = _login_with_password(server_url, username, password)
+
     config = _load_cli_config()
     config["session_token"] = token
-    config["server_url"] = _server_url()
-    config["machine_id"] = _machine_id()
+    config["server_url"] = server_url
+    config["machine_id"] = machine_id
     _write_cli_config(config)
-    print(f"Logged in for server {_server_url()} on machine {_machine_id()}.")
+    print(f"Logged in for server {server_url} on machine {machine_id}.")
     return 0
 
 
@@ -237,8 +281,8 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="openace", description="Open ACE remote CLI")
     sub = parser.add_subparsers(dest="command")
 
-    login = sub.add_parser("login", help="Store an Open ACE session token")
-    login.add_argument("--token", help="Open ACE session token")
+    login = sub.add_parser("login", help="Log in with username/password or a session token")
+    login.add_argument("--token", help="Open ACE session token (skip username/password prompt)")
     login.set_defaults(func=cmd_login)
 
     logout = sub.add_parser("logout", help="Remove stored Open ACE credentials")

--- a/tests/unit/test_openace_cli.py
+++ b/tests/unit/test_openace_cli.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 from pathlib import Path
 
 
@@ -109,6 +110,10 @@ def test_login_with_password_extracts_session_token(monkeypatch, tmp_path):
             pass
 
     def fake_urlopen(req, timeout=30):
+        assert "/api/auth/login" in req.full_url, f"Unexpected URL: {req.full_url}"
+        body = json.loads(req.data)
+        assert body["username"] == "testuser"
+        assert body["password"] == "testpass"
         return FakeResp()
 
     monkeypatch.setattr(openace_cli.urllib.request, "urlopen", fake_urlopen)

--- a/tests/unit/test_openace_cli.py
+++ b/tests/unit/test_openace_cli.py
@@ -82,6 +82,42 @@ def test_login_writes_session_token(monkeypatch, tmp_path):
     assert '"session_token": "session-token"' in config_path.read_text(encoding="utf-8")
 
 
+def test_login_with_password_extracts_session_token(monkeypatch, tmp_path):
+    import builtins
+
+    openace_cli = load_openace_cli()
+    config_path = tmp_path / "config.json"
+
+    monkeypatch.setattr(openace_cli, "CLI_CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(openace_cli, "CLI_CONFIG_PATH", config_path)
+    monkeypatch.setattr(openace_cli, "_server_url", lambda: "https://openace.example")
+    monkeypatch.setattr(openace_cli, "_machine_id", lambda: "machine-123")
+
+    monkeypatch.setattr(builtins, "input", lambda _: "testuser")
+    monkeypatch.setattr(openace_cli.getpass, "getpass", lambda _: "testpass")
+
+    class FakeResp:
+        headers = type("H", (), {"get_all": lambda s, k=None: ["session_token=abc123; Path=/"]})()
+
+        def read(self):
+            return b'{"success": true, "user": {"username": "testuser"}}'
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+    def fake_urlopen(req, timeout=30):
+        return FakeResp()
+
+    monkeypatch.setattr(openace_cli.urllib.request, "urlopen", fake_urlopen)
+
+    args = type("Args", (), {"token": None})()
+    assert openace_cli.cmd_login(args) == 0
+    assert '"session_token": "abc123"' in config_path.read_text(encoding="utf-8")
+
+
 def test_write_active_terminal_metadata(monkeypatch, tmp_path):
     openace_cli = load_openace_cli()
     active_path = tmp_path / "active_terminal.json"


### PR DESCRIPTION
## Summary
- `openace login` 现在直接提示输入用户名和密码，调用 `/auth/login` API 并从 `Set-Cookie` header 中提取 session token
- 保留 `openace login --token <token>` 供需要 token 方式的用户使用
- 修复 issue #494 中提到的"用户设置中没有 session token"的问题

## Test plan
- [x] `python3 -m pytest tests/unit/test_openace_cli.py` — 6 tests passed
- [ ] 手动测试：`openace login` 输入用户名密码，验证登录成功
- [ ] 手动测试：`openace login --token <token>` 仍然正常工作

🤖 Generated with [Claude Code](https://claude.com/claude-code)