### PR TITLE
Fix web terminal disconnect: websocket.path attribute error

### DIFF
--- a/remote-agent/websocket_proxy.py
+++ b/remote-agent/websocket_proxy.py
@@ -128,8 +128,8 @@ async def proxy_connection(browser_ws, remote_ws_url: str, remote_token: str):
 async def handle_browser_connection(browser_ws):
     """Handle a browser WebSocket connection."""
     # Validate auth token from query params
-    # websockets 10.0+ uses websocket.request.path instead of websocket.path
-    raw_path = browser_ws.request.path
+    # websockets provides the request path via websocket.path
+    raw_path = getattr(browser_ws, "path", "/")
     logger.info("Browser connection received, path: %s", raw_path)
     params = urllib.parse.parse_qs(urllib.parse.urlparse(raw_path).query)
     token = params.get("token", [None])[0]


### PR DESCRIPTION
## Summary
- `websocket_proxy.py:132` 使用了 `browser_ws.request.path`，但 websockets 16.0 中 `WebSocketServerProtocol` 没有 `request` 属性
- 改为 `getattr(browser_ws, "path", "/")`，与 `terminal_server.py:361` 的写法一致
- 修复后浏览器 WebSocket 连接不再因 `AttributeError` 立即断开

## Root cause
浏览器连接 websocket proxy 时，`handle_browser_connection` 抛出 `AttributeError`，websockets 库捕获后关闭连接（code 1011），前端显示"连接断开"。

CLI 不受影响因为它不经过 `websocket_proxy.py`，直接在远程机器上运行。

## Test plan
- [ ] 启动 Open ACE 服务，通过 Web 界面新建 terminal，验证连接正常
- [ ] SSH 到远程机器运行 `openace menu`，验证 CLI 仍正常工作

🤖 Generated with [Claude Code](https://claude.com/claude-code)