### PR TITLE
Fix remote agent startup failure and web terminal auth loop

### DIFF
--- a/remote-agent/install.ps1
+++ b/remote-agent/install.ps1
@@ -76,6 +76,7 @@ $agentUrl = "$ServerUrl/api/remote/agent/files"
 $files = @(
     "agent.py",
     "config.py",
+    "constants.py",
     "executor.py",
     "system_info.py",
     "requirements.txt",

--- a/remote-agent/install.sh
+++ b/remote-agent/install.sh
@@ -143,6 +143,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 AGENT_FILES=(
     agent.py
     config.py
+    constants.py
     executor.py
     system_info.py
     requirements.txt

--- a/remote-agent/terminal_server.py
+++ b/remote-agent/terminal_server.py
@@ -357,7 +357,12 @@ async def _handle_connection(websocket) -> None:
         return
 
     # Authenticate
-    raw_path = getattr(websocket, "path", "")
+    # websockets >= 13 stores path in request.path; older versions used websocket.path
+    raw_path = ""
+    if hasattr(websocket, "request") and websocket.request is not None:
+        raw_path = websocket.request.path
+    elif hasattr(websocket, "path"):
+        raw_path = websocket.path
     params = urllib.parse.parse_qs(urllib.parse.urlparse(raw_path).query)
     token = params.get("token", [None])[0]
     if not token or not hmac.compare_digest(token, AUTH_TOKEN):

--- a/remote-agent/websocket_proxy.py
+++ b/remote-agent/websocket_proxy.py
@@ -129,7 +129,7 @@ async def handle_browser_connection(browser_ws):
     """Handle a browser WebSocket connection."""
     # Validate auth token from query params
     # websockets >= 13 stores path in request.path; older versions used websocket.path
-    raw_path = "/"
+    raw_path = ""
     if hasattr(browser_ws, "request") and browser_ws.request is not None:
         raw_path = browser_ws.request.path
     elif hasattr(browser_ws, "path"):

--- a/remote-agent/websocket_proxy.py
+++ b/remote-agent/websocket_proxy.py
@@ -128,8 +128,12 @@ async def proxy_connection(browser_ws, remote_ws_url: str, remote_token: str):
 async def handle_browser_connection(browser_ws):
     """Handle a browser WebSocket connection."""
     # Validate auth token from query params
-    # websockets provides the request path via websocket.path
-    raw_path = getattr(browser_ws, "path", "/")
+    # websockets >= 13 stores path in request.path; older versions used websocket.path
+    raw_path = "/"
+    if hasattr(browser_ws, "request") and browser_ws.request is not None:
+        raw_path = browser_ws.request.path
+    elif hasattr(browser_ws, "path"):
+        raw_path = browser_ws.path
     logger.info("Browser connection received, path: %s", raw_path)
     params = urllib.parse.parse_qs(urllib.parse.urlparse(raw_path).query)
     token = params.get("token", [None])[0]


### PR DESCRIPTION
## Summary

- Add missing `constants.py` to `install.sh` and `install.ps1` file lists, fixing `ModuleNotFoundError` on agent startup
- Update WebSocket path access in `websocket_proxy.py` and `terminal_server.py` for `websockets` >= 13 compatibility (`ws.path` → `ws.request.path` with fallback)

## Test plan

- [x] Verified fix on local environment with remote machine 192.168.64.3
- [x] Confirmed agent starts successfully after adding `constants.py`
- [x] Pre-commit hooks pass (black, isort, ruff, mypy, bandit)

Closes #501

🤖 Generated with [Claude Code](https://claude.com/claude-code)