### PR TITLE
fix: 添加缺失的agent文件到install.sh (#469)

### DIFF
--- a/remote-agent/install.sh
+++ b/remote-agent/install.sh
@@ -143,6 +143,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 AGENT_FILES=(
     agent.py
     config.py
+    constants.py
     executor.py
     system_info.py
     requirements.txt
@@ -151,6 +152,7 @@ AGENT_FILES=(
     websocket_proxy.py
     session_sync.py
     openace_cli.py
+    __init__.py
 )
 
 # If running from curl, download files; if running from source, copy

--- a/scripts/install-central/package-method/install.sh
+++ b/scripts/install-central/package-method/install.sh
@@ -3418,6 +3418,14 @@ do_upgrade_remote() {
     # Set permissions
     ssh "$remote" "chmod +x '$target_path/scripts/'*.py '$target_path/scripts/'*.sh 2>/dev/null || true"
 
+    # Sync remote-agent directory to ~/.open-ace-agent (for agent service)
+    print_info "Syncing remote-agent files to ~/.open-ace-agent..."
+    ssh "$remote" "mkdir -p ~/.open-ace-agent ~/.open-ace-agent/cli_adapters"
+    scp -r "$SOURCE_DIR/remote-agent/*.py" "$remote:~/.open-ace-agent/"
+    scp -r "$SOURCE_DIR/remote-agent/cli_adapters/*.py" "$remote:~/.open-ace-agent/cli_adapters/"
+    ssh "$remote" "chmod +x ~/.open-ace-agent/*.py ~/.open-ace-agent/cli_adapters/*.py 2>/dev/null || true"
+    ssh "$remote" "systemctl restart open-ace-agent 2>/dev/null || echo 'Note: open-ace-agent service not found or not installed'"
+
     # Install Python dependencies
     print_info "Installing Python dependencies on remote..."
     ssh "$remote" "


### PR DESCRIPTION
## 问题描述

Issue: #469

新建会话终端直接显示"已断开node237"状态，根因是`remote-agent/install.sh`脚本缺少新增文件。

### 缺失文件

- `constants.py` (于2026-05-18新增，提交22c21f7)
- `__init__.py`

用户通过curl执行安装脚本时，这些文件不会被下载，导致：
```
ModuleNotFoundError: No module named 'constants'
```

### 部署架构说明

当前部署架构存在两个目录：
- 主服务目录：`/home/ivyent/open-ace`（通过 install.sh 升级）
- Agent运行目录：`~/.open-ace-agent`（独立部署，通过remote-agent/install.sh安装）

升级主服务时不会自动同步agent运行目录，导致新增文件缺失。

## 修复内容

### 1. remote-agent/install.sh

添加缺失文件到`AGENT_FILES`数组：
```bash
AGENT_FILES=(
    agent.py
    config.py
    constants.py      # ✅ 新增
    executor.py
    system_info.py
    requirements.txt
    terminal_menu.py
    terminal_server.py
    websocket_proxy.py
    session_sync.py
    openace_cli.py
    __init__.py       # ✅ 新增
)
```

### 2. scripts/install-central/package-method/install.sh

在`do_upgrade_remote()`函数中添加同步agent运行目录的逻辑，确保升级主服务时同步agent文件。

## 测试

已在node237验证：
- 同步缺失文件后，agent服务正常启动
- 终端功能恢复正常