### PR TITLE
Fix remote agent websockets constraint

### DIFF
--- a/remote-agent/requirements.txt
+++ b/remote-agent/requirements.txt
@@ -1,3 +1,3 @@
 websocket-client>=1.9.0
 requests>=2.32.5
-websockets>=12.0
+websockets>=13.0,<17.0

--- a/remote-agent/terminal_server.py
+++ b/remote-agent/terminal_server.py
@@ -33,7 +33,7 @@ try:
     from websockets.server import serve
 except ImportError:
     print("Error: 'websockets' package is required.", file=sys.stderr)
-    print("Install with: pip install websockets>=12.0", file=sys.stderr)
+    print("Install with: pip install 'websockets>=13.0,<17.0'", file=sys.stderr)
     sys.exit(1)
 
 logger = logging.getLogger("openace-terminal-server")

--- a/remote-agent/websocket_proxy.py
+++ b/remote-agent/websocket_proxy.py
@@ -29,7 +29,7 @@ try:
     import websockets
 except ImportError:
     print("Error: 'websockets' package is required.", file=sys.stderr)
-    print("Install with: pip install websockets>=15.0", file=sys.stderr)
+    print("Install with: pip install 'websockets>=13.0,<17.0'", file=sys.stderr)
     sys.exit(1)
 
 logger = logging.getLogger("openace-ws-proxy")

--- a/tests/issues/506/test_remote_agent_websockets_constraint.py
+++ b/tests/issues/506/test_remote_agent_websockets_constraint.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+EXPECTED_CONSTRAINT = "websockets>=13.0,<17.0"
+
+
+def test_remote_agent_websockets_constraint_is_bounded():
+    requirements = (PROJECT_ROOT / "remote-agent" / "requirements.txt").read_text()
+
+    assert EXPECTED_CONSTRAINT in requirements.splitlines()
+    assert "websockets>=12.0" not in requirements
+
+
+def test_remote_agent_install_hints_match_constraint():
+    for script_name in ("terminal_server.py", "websocket_proxy.py"):
+        script = (PROJECT_ROOT / "remote-agent" / script_name).read_text()
+
+        assert f"pip install '{EXPECTED_CONSTRAINT}'" in script


### PR DESCRIPTION
## Summary
- tighten remote-agent websockets dependency to >=13.0,<17.0
- align remote-agent install hints with the bounded constraint
- add regression coverage for issue #506

## Tests
- python3 -m pytest tests/issues/506/test_remote_agent_websockets_constraint.py
- env PYTHONPYCACHEPREFIX=/private/tmp/openace-pycache python3 -m py_compile remote-agent/terminal_server.py remote-agent/websocket_proxy.py

Closes #506