### PR TITLE
fix: 添加 update_agent_sessions_stats 函数到 fetch_openclaw.py

### DIFF
--- a/scripts/fetch_openclaw.py
+++ b/scripts/fetch_openclaw.py
@@ -1465,9 +1465,6 @@ def update_agent_sessions_stats(messages: list, tool_name: str = "openclaw") -> 
                         # Deduplicate by (session_id, role, timestamp) + message_id if available
                         # Note: metadata is TEXT type, use LIKE pattern matching instead of JSONB ->>
                         if msg_id:
-                            # Pattern match for message_id in JSON-like metadata string
-                            # Use escape_like to prevent wildcard injection
-                            escaped_msg_id = escape_like(msg_id)
                             check_sql = f"""
                                 SELECT id FROM session_messages
                                 WHERE session_id = {placeholder}
@@ -1475,6 +1472,8 @@ def update_agent_sessions_stats(messages: list, tool_name: str = "openclaw") -> 
                                 AND timestamp = {placeholder}
                                 AND metadata LIKE {placeholder}
                             """
+                            # Use escape_like to prevent wildcard injection
+                            escaped_msg_id = escape_like(msg_id)
                             _execute(
                                 cursor,
                                 check_sql,
@@ -1508,7 +1507,9 @@ def update_agent_sessions_stats(messages: list, tool_name: str = "openclaw") -> 
                             metadata = {
                                 "message_id": msg_id,
                                 "project_path": msg.get("project_path"),
-                                "content_blocks": msg.get("content_blocks"),  # Issue #357: structured content
+                                "content_blocks": msg.get(
+                                    "content_blocks"
+                                ),  # Issue #357: structured content
                             }
                             _execute(
                                 cursor,

--- a/scripts/fetch_openclaw.py
+++ b/scripts/fetch_openclaw.py
@@ -1300,6 +1300,253 @@ def process_jsonl_file(
     return dict(daily), messages
 
 
+def update_agent_sessions_stats(messages: list, tool_name: str = "openclaw") -> int:
+    """
+    Update agent_sessions table statistics from collected messages.
+    Also inserts messages into session_messages table for session detail view.
+
+    Groups messages by agent_session_id and creates/updates agent_sessions records.
+
+    Args:
+        messages: List of message dicts with agent_session_id and tokens_used
+        tool_name: Tool name for new session records (default: openclaw)
+
+    Returns:
+        Number of sessions updated
+    """
+    from shared.db import _execute, _placeholder, get_connection
+
+    # Group messages by agent_session_id
+    session_stats: dict[str, dict[str, Any]] = defaultdict(
+        lambda: {
+            "message_count": 0,
+            "total_tokens": 0,
+            "request_count": 0,
+            "models": [],
+            "messages": [],
+            "last_timestamp": None,
+        }
+    )
+
+    for msg in messages:
+        session_id = msg.get("agent_session_id")
+        if not session_id:
+            continue
+
+        role = msg.get("role", "")
+        tokens = msg.get("tokens_used", 0) or 0
+        model = msg.get("model")
+
+        session_stats[session_id]["message_count"] += 1
+        session_stats[session_id]["total_tokens"] += tokens
+
+        # Count assistant messages as requests (one assistant response = one request)
+        if role == "assistant":
+            session_stats[session_id]["request_count"] += 1
+
+        if model:
+            session_stats[session_id]["models"].append(model)
+
+        session_stats[session_id]["messages"].append(msg)
+
+        timestamp = msg.get("timestamp")
+        if timestamp:
+            current_last = session_stats[session_id]["last_timestamp"]
+            if current_last is None or timestamp > current_last:
+                session_stats[session_id]["last_timestamp"] = timestamp
+
+    if not session_stats:
+        return 0
+
+    updated = 0
+    messages_inserted = 0
+    now = datetime.utcnow().isoformat()
+    placeholder = _placeholder()
+
+    conn = get_connection()
+    cursor = conn.cursor()
+
+    try:
+        for session_id, stats in session_stats.items():
+            try:
+                # Check if session exists in agent_sessions table
+                check_session_sql = (
+                    f"SELECT id, user_id FROM agent_sessions WHERE session_id = {placeholder}"
+                )
+                _execute(cursor, check_session_sql, (session_id,))
+                session_row = cursor.fetchone()
+
+                if not session_row:
+                    # Session doesn't exist - create a new record
+                    first_msg = stats["messages"][0] if stats["messages"] else {}
+
+                    project_path = first_msg.get("project_path", "")
+                    host_name = first_msg.get("host_name", "localhost")
+                    sender_name = first_msg.get("sender_name", "")
+
+                    # Extract system_account from sender_name (format: {system_account}-{hostname}-{tool})
+                    system_account = sender_name.split("-")[0] if sender_name else "unknown"
+
+                    # Find user_id by system_account
+                    user_sql = f"SELECT id FROM users WHERE system_account = {placeholder} OR username = {placeholder}"
+                    _execute(cursor, user_sql, (system_account, system_account))
+                    user_row = cursor.fetchone()
+                    user_id = user_row["id"] if user_row else None
+
+                    title = f"{tool_name} - {session_id[:8]}"
+
+                    insert_sql = f"""
+                        INSERT INTO agent_sessions
+                        (session_id, session_type, title, tool_name, host_name, user_id, status, project_path,
+                         message_count, total_tokens, request_count, model, created_at, updated_at)
+                        VALUES ({placeholder}, {placeholder}, {placeholder}, {placeholder}, {placeholder},
+                                {placeholder}, {placeholder}, {placeholder}, {placeholder}, {placeholder},
+                                {placeholder}, {placeholder}, {placeholder}, {placeholder})
+                    """
+                    # Use the most recently seen model (last in list)
+                    model = stats["models"][-1] if stats["models"] else None
+                    _execute(
+                        cursor,
+                        insert_sql,
+                        (
+                            session_id,
+                            "chat",
+                            title,
+                            tool_name,
+                            host_name,
+                            user_id,
+                            "completed",
+                            project_path,
+                            stats["message_count"],
+                            stats["total_tokens"],
+                            stats["request_count"],
+                            model,
+                            now,
+                            now,
+                        ),
+                    )
+                    updated += 1
+                else:
+                    # Update existing session
+                    model = stats["models"][-1] if stats["models"] else None
+                    session_updated_at = stats["last_timestamp"] or now
+                    sql = f"""
+                        UPDATE agent_sessions
+                        SET message_count = GREATEST(COALESCE(message_count, 0), {placeholder}),
+                            total_tokens = GREATEST(COALESCE(total_tokens, 0), {placeholder}),
+                            request_count = GREATEST(COALESCE(request_count, 0), {placeholder}),
+                            model = COALESCE(model, {placeholder}),
+                            updated_at = {placeholder}
+                        WHERE session_id = {placeholder}
+                    """
+                    _execute(
+                        cursor,
+                        sql,
+                        (
+                            stats["message_count"],
+                            stats["total_tokens"],
+                            stats["request_count"],
+                            model,
+                            session_updated_at,
+                            session_id,
+                        ),
+                    )
+                    if cursor.rowcount > 0:
+                        updated += 1
+
+                # Insert messages into session_messages table
+                for msg in stats["messages"]:
+                    try:
+                        msg_id = msg.get("message_id")
+                        timestamp = msg.get("timestamp")
+                        if not timestamp:
+                            timestamp = now
+
+                        # Deduplicate by (session_id, role, timestamp) + message_id if available
+                        # Note: metadata is TEXT type, use LIKE pattern matching instead of JSONB ->>
+                        if msg_id:
+                            # Pattern match for message_id in JSON-like metadata string
+                            check_sql = f"""
+                                SELECT id FROM session_messages
+                                WHERE session_id = {placeholder}
+                                AND role = {placeholder}
+                                AND timestamp = {placeholder}
+                                AND metadata LIKE {placeholder}
+                            """
+                            _execute(
+                                cursor,
+                                check_sql,
+                                (
+                                    session_id,
+                                    msg.get("role"),
+                                    timestamp,
+                                    f'%"message_id": "{msg_id}"%',
+                                ),
+                            )
+                        else:
+                            check_sql = f"""
+                                SELECT id FROM session_messages
+                                WHERE session_id = {placeholder}
+                                AND role = {placeholder}
+                                AND timestamp = {placeholder}
+                            """
+                            _execute(
+                                cursor,
+                                check_sql,
+                                (session_id, msg.get("role"), timestamp),
+                            )
+                        existing = cursor.fetchone()
+
+                        if not existing:
+                            insert_sql = f"""
+                                INSERT INTO session_messages
+                                (session_id, role, content, tokens_used, model, timestamp, metadata)
+                                VALUES ({placeholder}, {placeholder}, {placeholder}, {placeholder}, {placeholder}, {placeholder}, {placeholder})
+                            """
+                            metadata = {
+                                "message_id": msg_id,
+                                "project_path": msg.get("project_path"),
+                            }
+                            _execute(
+                                cursor,
+                                insert_sql,
+                                (
+                                    session_id,
+                                    msg.get("role"),
+                                    msg.get("content"),
+                                    msg.get("tokens_used", 0),
+                                    msg.get("model"),
+                                    timestamp,
+                                    json.dumps(metadata) if metadata else None,
+                                ),
+                            )
+                            messages_inserted += 1
+
+                    except Exception as e:
+                        if (
+                            "duplicate" not in str(e).lower()
+                            and "foreign key" not in str(e).lower()
+                            and "not present" not in str(e).lower()
+                        ):
+                            logger.warning("Failed to insert message: %s", e)
+
+            except Exception as e:
+                logger.warning("Failed to update session %s: %s", session_id, e)
+
+        conn.commit()
+
+        if updated > 0:
+            print(f"Updated {updated} agent sessions")
+        if messages_inserted > 0:
+            print(f"Inserted {messages_inserted} session messages")
+
+    finally:
+        cursor.close()
+        conn.close()
+
+    return updated
+
+
 def fetch_and_save_messages(
     days: int = 7,
     sessions_dir: Optional[Path] = None,
@@ -1446,6 +1693,10 @@ def fetch_and_save_messages(
         print("Saving messages to database...")
         saved_count = db.save_messages_batch(all_messages, batch_size=500)
         print(f"Saved {saved_count} messages")
+
+        # Update agent_sessions and session_messages from collected messages
+        print("\nUpdating agent sessions...")
+        update_agent_sessions_stats(all_messages, tool_name)
 
     # Filter by date range
     today = datetime.now().strftime("%Y-%m-%d")

--- a/scripts/fetch_openclaw.py
+++ b/scripts/fetch_openclaw.py
@@ -1314,7 +1314,7 @@ def update_agent_sessions_stats(messages: list, tool_name: str = "openclaw") -> 
     Returns:
         Number of sessions updated
     """
-    from shared.db import _execute, _placeholder, get_connection
+    from shared.db import _execute, _placeholder, escape_like, get_connection
 
     # Group messages by agent_session_id
     session_stats: dict[str, dict[str, Any]] = defaultdict(
@@ -1466,6 +1466,8 @@ def update_agent_sessions_stats(messages: list, tool_name: str = "openclaw") -> 
                         # Note: metadata is TEXT type, use LIKE pattern matching instead of JSONB ->>
                         if msg_id:
                             # Pattern match for message_id in JSON-like metadata string
+                            # Use escape_like to prevent wildcard injection
+                            escaped_msg_id = escape_like(msg_id)
                             check_sql = f"""
                                 SELECT id FROM session_messages
                                 WHERE session_id = {placeholder}
@@ -1480,7 +1482,7 @@ def update_agent_sessions_stats(messages: list, tool_name: str = "openclaw") -> 
                                     session_id,
                                     msg.get("role"),
                                     timestamp,
-                                    f'%"message_id": "{msg_id}"%',
+                                    f'%"message_id": "{escaped_msg_id}"%',
                                 ),
                             )
                         else:
@@ -1506,6 +1508,7 @@ def update_agent_sessions_stats(messages: list, tool_name: str = "openclaw") -> 
                             metadata = {
                                 "message_id": msg_id,
                                 "project_path": msg.get("project_path"),
+                                "content_blocks": msg.get("content_blocks"),  # Issue #357: structured content
                             }
                             _execute(
                                 cursor,
@@ -1528,10 +1531,10 @@ def update_agent_sessions_stats(messages: list, tool_name: str = "openclaw") -> 
                             and "foreign key" not in str(e).lower()
                             and "not present" not in str(e).lower()
                         ):
-                            logger.warning("Failed to insert message: %s", e)
+                            print(f"Warning: Failed to insert message: {e}")
 
             except Exception as e:
-                logger.warning("Failed to update session %s: %s", session_id, e)
+                print(f"Warning: Failed to update session {session_id}: {e}")
 
         conn.commit()
 


### PR DESCRIPTION
## 问题描述

Closes #512

在 /work 页面，OpenClaw 渠道导入的数据存在以下问题：
- 底部状态栏显示正常的请求数（如 "请求:54 / 1,500"）
- 但左侧会话列表中每个会话的请求数显示为0
- 会话详情中没有消息记录

## 问题原因

fetch_openclaw.py 脚本缺少 update_agent_sessions_stats 函数，导致 session_messages 表无数据。

## 修复内容

添加 update_agent_sessions_stats 函数，写入 session_messages 表和更新 agent_sessions.request_count。

## 修改的文件

scripts/fetch_openclaw.py - 添加函数和调用

## 修复后效果

会话列表请求数正确显示，会话详情包含消息记录。