### PR TITLE
fix: remove misleading launch progress bar from terminal menu

### DIFF
--- a/remote-agent/terminal_menu.py
+++ b/remote-agent/terminal_menu.py
@@ -51,11 +51,6 @@ GREEN = "\x1b[32m"
 YELLOW = "\x1b[33m"
 
 
-def get_progress_bar(percent: int) -> str:
-    filled = max(0, min(20, round(percent / 5)))
-    return f"[{'=' * filled}{' ' * (20 - filled)}]"
-
-
 def check_installed(cli_name: str) -> bool:
     try:
         result = subprocess.run(["which", cli_name], capture_output=True, timeout=5)
@@ -112,35 +107,6 @@ def render_menu(items: list[dict], selected: int) -> None:
 
 def show_message(message: str) -> None:
     sys.stdout.write(f"\r\n  {message}\r\n\r\n  {DIM}Press any key to continue...{RESET}")
-    sys.stdout.flush()
-
-
-def render_launch_progress(item: dict) -> None:
-    installing = not item.get("installed")
-    action = "Installing" if installing else "Starting"
-    detail = (
-        "Installer output will appear below when it starts."
-        if installing
-        else "Waiting for the CLI interface to take over the terminal."
-    )
-    progress = 35 if installing else 55
-    lines = [
-        "",
-        f"  {BOLD_CYAN}========================================{RESET}",
-        f"  {BOLD_CYAN}  Open ACE Remote Terminal{RESET}",
-        f"  {BOLD_CYAN}========================================{RESET}",
-        "",
-        f"  {action} {BOLD_YELLOW}{item['name']}{RESET}",
-        "",
-        f"  {GREEN}{get_progress_bar(progress)}{RESET}  {progress}%",
-        "",
-        f"  {detail}",
-        "  First launch can take 5-15 seconds while the remote CLI initializes.",
-        "",
-        f"  {DIM}If this takes longer than 30 seconds, press Ctrl+C to interrupt.{RESET}",
-        "",
-    ]
-    sys.stdout.write(CLEAR + "\r\n".join(lines))
     sys.stdout.flush()
 
 
@@ -218,7 +184,6 @@ def handle_select(item: dict) -> None:
         cmd = f'{item["install_cmd"]} && {item["cmd"]}; exec {sys.executable} {MENU_PATH}'
     else:
         cmd = f'{item["cmd"]}; exec {sys.executable} {MENU_PATH}'
-    render_launch_progress(item)
     exec_command(cmd)
 
 

--- a/tests/unit/test_terminal_menu.py
+++ b/tests/unit/test_terminal_menu.py
@@ -16,34 +16,7 @@ def load_terminal_menu():
     return module
 
 
-def test_render_launch_progress_for_installed_tool(capsys):
-    terminal_menu = load_terminal_menu()
-
-    terminal_menu.render_launch_progress({"name": "Claude Code", "installed": True})
-
-    output = capsys.readouterr().out
-    assert "Starting" in output
-    assert "Claude Code" in output
-    assert "[===========         ]" in output
-    assert "55%" in output
-    assert "Waiting for the CLI interface" in output
-    assert "Ctrl+C" in output
-
-
-def test_render_launch_progress_for_installing_tool(capsys):
-    terminal_menu = load_terminal_menu()
-
-    terminal_menu.render_launch_progress({"name": "Qwen Code", "installed": False})
-
-    output = capsys.readouterr().out
-    assert "Installing" in output
-    assert "Qwen Code" in output
-    assert "[=======             ]" in output
-    assert "35%" in output
-    assert "Installer output will appear below" in output
-
-
-def test_handle_select_renders_progress_before_exec(monkeypatch, capsys):
+def test_handle_select_execs_command(monkeypatch):
     terminal_menu = load_terminal_menu()
     executed_commands = []
 
@@ -61,9 +34,6 @@ def test_handle_select_renders_progress_before_exec(monkeypatch, capsys):
         }
     )
 
-    output = capsys.readouterr().out
-    assert "Starting" in output
-    assert "Claude Code" in output
     assert executed_commands == [
         f"claude --bare; exec {terminal_menu.sys.executable} {terminal_menu.MENU_PATH}"
     ]


### PR DESCRIPTION
## Summary

- Remove the static progress bar (`render_launch_progress` / `get_progress_bar`) shown when launching a tool from the terminal menu
- The progress bar was static (showing a fake percentage) and provided a poor user experience
- Tools now launch immediately after selection, no intermediate screen

## Test plan

- [x] Unit tests updated and passing (`tests/unit/test_terminal_menu.py`)
- [x] All pre-commit hooks pass (lint, type check, security scan)