### PR TITLE
fix: resolve build warnings

### DIFF
--- a/frontend/src/components/common/Charts.tsx
+++ b/frontend/src/components/common/Charts.tsx
@@ -3,6 +3,7 @@
  */
 
 import React, { useMemo } from 'react';
+import { COLORS, TOOL_COLORS, getToolColor } from './chartColors';
 import {
   Chart as ChartJS,
   CategoryScale,
@@ -45,75 +46,8 @@ const defaultOptions = {
 };
 
 // Color palette
-const COLORS = {
-  primary: 'rgba(37, 99, 235, 1)',
-  primaryLight: 'rgba(37, 99, 235, 0.2)',
-  success: 'rgba(34, 197, 94, 1)',
-  successLight: 'rgba(34, 197, 94, 0.2)',
-  warning: 'rgba(245, 158, 11, 1)',
-  warningLight: 'rgba(245, 158, 11, 0.2)',
-  danger: 'rgba(239, 68, 68, 1)',
-  dangerLight: 'rgba(239, 68, 68, 0.2)',
-  info: 'rgba(59, 130, 246, 1)',
-  infoLight: 'rgba(59, 130, 246, 0.2)',
-  purple: 'rgba(139, 92, 246, 1)',
-  purpleLight: 'rgba(139, 92, 246, 0.2)',
-  cyan: 'rgba(6, 182, 212, 1)',
-  cyanLight: 'rgba(6, 182, 212, 0.2)',
-};
-
-// Unified tool colors - used across all charts
-export const TOOL_COLORS: Record<string, { border: string; background: string; solid: string }> = {
-  openclaw: {
-    border: 'rgba(255, 99, 132, 1)',
-    background: 'rgba(255, 99, 132, 0.2)',
-    solid: 'rgba(255, 99, 132, 0.8)',
-  },
-  claude: {
-    border: 'rgba(75, 192, 192, 1)',
-    background: 'rgba(75, 192, 192, 0.2)',
-    solid: 'rgba(75, 192, 192, 0.8)',
-  },
-  qwen: {
-    border: 'rgba(54, 162, 235, 1)',
-    background: 'rgba(54, 162, 235, 0.2)',
-    solid: 'rgba(54, 162, 235, 0.8)',
-  },
-};
-
-// Get tool color, fallback to default colors
-export const getToolColor = (tool: string, index: number) => {
-  const toolColors = TOOL_COLORS[tool.toLowerCase()];
-  if (toolColors) return toolColors;
-
-  const solidColors = [
-    'rgba(37, 99, 235, 0.8)',
-    'rgba(34, 197, 94, 0.8)',
-    'rgba(245, 158, 11, 0.8)',
-    'rgba(239, 68, 68, 0.8)',
-    'rgba(139, 92, 246, 0.8)',
-    'rgba(6, 182, 212, 0.8)',
-  ];
-  return {
-    border: [
-      COLORS.primary,
-      COLORS.success,
-      COLORS.warning,
-      COLORS.danger,
-      COLORS.purple,
-      COLORS.cyan,
-    ][index % 6],
-    background: [
-      COLORS.primaryLight,
-      COLORS.successLight,
-      COLORS.warningLight,
-      COLORS.dangerLight,
-      COLORS.purpleLight,
-      COLORS.cyanLight,
-    ][index % 6],
-    solid: solidColors[index % 6],
-  };
-};
+// Re-export for backward compatibility
+export { COLORS, TOOL_COLORS, getToolColor };
 
 const COLOR_ARRAY = [
   COLORS.primary,

--- a/frontend/src/components/common/chartColors.ts
+++ b/frontend/src/components/common/chartColors.ts
@@ -1,0 +1,69 @@
+const COLORS = {
+  primary: 'rgba(37, 99, 235, 1)',
+  primaryLight: 'rgba(37, 99, 235, 0.2)',
+  success: 'rgba(34, 197, 94, 1)',
+  successLight: 'rgba(34, 197, 94, 0.2)',
+  warning: 'rgba(245, 158, 11, 1)',
+  warningLight: 'rgba(245, 158, 11, 0.2)',
+  danger: 'rgba(239, 68, 68, 1)',
+  dangerLight: 'rgba(239, 68, 68, 0.2)',
+  info: 'rgba(59, 130, 246, 1)',
+  infoLight: 'rgba(59, 130, 246, 0.2)',
+  purple: 'rgba(139, 92, 246, 1)',
+  purpleLight: 'rgba(139, 92, 246, 0.2)',
+  cyan: 'rgba(6, 182, 212, 1)',
+  cyanLight: 'rgba(6, 182, 212, 0.2)',
+};
+
+export { COLORS };
+
+export const TOOL_COLORS: Record<string, { border: string; background: string; solid: string }> = {
+  openclaw: {
+    border: 'rgba(255, 99, 132, 1)',
+    background: 'rgba(255, 99, 132, 0.2)',
+    solid: 'rgba(255, 99, 132, 0.8)',
+  },
+  claude: {
+    border: 'rgba(75, 192, 192, 1)',
+    background: 'rgba(75, 192, 192, 0.2)',
+    solid: 'rgba(75, 192, 192, 0.8)',
+  },
+  qwen: {
+    border: 'rgba(54, 162, 235, 1)',
+    background: 'rgba(54, 162, 235, 0.2)',
+    solid: 'rgba(54, 162, 235, 0.8)',
+  },
+};
+
+export const getToolColor = (tool: string, index: number) => {
+  const toolColors = TOOL_COLORS[tool.toLowerCase()];
+  if (toolColors) return toolColors;
+
+  const solidColors = [
+    'rgba(37, 99, 235, 0.8)',
+    'rgba(34, 197, 94, 0.8)',
+    'rgba(245, 158, 11, 0.8)',
+    'rgba(239, 68, 68, 0.8)',
+    'rgba(139, 92, 246, 0.8)',
+    'rgba(6, 182, 212, 0.8)',
+  ];
+  return {
+    border: [
+      COLORS.primary,
+      COLORS.success,
+      COLORS.warning,
+      COLORS.danger,
+      COLORS.purple,
+      COLORS.cyan,
+    ][index % 6],
+    background: [
+      COLORS.primaryLight,
+      COLORS.successLight,
+      COLORS.warningLight,
+      COLORS.dangerLight,
+      COLORS.purpleLight,
+      COLORS.cyanLight,
+    ][index % 6],
+    solid: solidColors[index % 6],
+  };
+};

--- a/frontend/src/components/features/management/RequestDashboard.tsx
+++ b/frontend/src/components/features/management/RequestDashboard.tsx
@@ -22,7 +22,7 @@ import {
   TextInput,
 } from '@/components/common';
 import { LazyLineChart, LazyBarChart } from '@/components/common/LazyCharts';
-import { getToolColor } from '@/components/common/Charts';
+import { getToolColor } from '@/components/common/chartColors';
 import {
   requestApi,
   type RequestTodayStats,


### PR DESCRIPTION
## Summary
- Extract `COLORS`, `TOOL_COLORS`, `getToolColor` from `Charts.tsx` to `chartColors.ts` so `RequestDashboard` can import colors without pulling in Chart.js, eliminating the dynamic/static import conflict warning

## Test plan
- [x] `cd frontend && npm run build` — no Charts warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)