### PR TITLE
fix: prevent global cache pollution across test suites

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,10 +25,17 @@ pytest_plugins = ("pytest_asyncio",)
 
 @pytest.fixture(autouse=True)
 def _clear_cache():
-    """Clear global cache before each test to prevent cross-test pollution."""
+    """Clear global caches before each test to prevent cross-test pollution."""
     from app.utils.cache import get_cache
 
     get_cache().clear()
+
+    try:
+        from app.services.auth_service import _security_settings_cache
+
+        _security_settings_cache.clear()
+    except ImportError:
+        pass
 
 
 class TestConfig:

--- a/tests/integration/test_auth_service_pg.py
+++ b/tests/integration/test_auth_service_pg.py
@@ -69,7 +69,7 @@ class TestLoginLockout:
 
     def test_no_lockout_initially(self, pg_db):
         self._setup_login_attempts(pg_db)
-        auth_service._security_settings_cache = {}
+        auth_service._security_settings_cache.clear()
 
         with self._patch_db(pg_db):
             is_locked, msg = _check_login_lockout("newuser")
@@ -78,7 +78,7 @@ class TestLoginLockout:
 
     def test_record_failed_login_increments(self, pg_db):
         self._setup_login_attempts(pg_db)
-        auth_service._security_settings_cache = {}
+        auth_service._security_settings_cache.clear()
 
         with self._patch_db(pg_db):
             _record_failed_login("testuser")
@@ -92,7 +92,7 @@ class TestLoginLockout:
 
     def test_lockout_after_max_attempts(self, pg_db):
         self._setup_login_attempts(pg_db)
-        auth_service._security_settings_cache = {}
+        auth_service._security_settings_cache.clear()
 
         with self._patch_db(pg_db):
             max_attempts = auth_service._get_max_login_attempts()
@@ -107,7 +107,7 @@ class TestLoginLockout:
 
     def test_clear_failed_logins(self, pg_db):
         self._setup_login_attempts(pg_db)
-        auth_service._security_settings_cache = {}
+        auth_service._security_settings_cache.clear()
 
         with self._patch_db(pg_db):
             _record_failed_login("cleareduser")

--- a/tests/integration/test_auth_service_sqlite.py
+++ b/tests/integration/test_auth_service_sqlite.py
@@ -86,7 +86,7 @@ class TestLoginLockout:
     def test_no_lockout_initially(self, tmp_db):
         """New username has no lockout."""
         self._setup_login_attempts(tmp_db)
-        auth_service._security_settings_cache = {}
+        auth_service._security_settings_cache.clear()
 
         with self._patch_db(tmp_db):
             is_locked, msg = _check_login_lockout("newuser")
@@ -96,7 +96,7 @@ class TestLoginLockout:
     def test_record_failed_login_increments(self, tmp_db):
         """Recording failed login creates/increments attempt_count."""
         self._setup_login_attempts(tmp_db)
-        auth_service._security_settings_cache = {}
+        auth_service._security_settings_cache.clear()
 
         with self._patch_db(tmp_db):
             _record_failed_login("testuser")
@@ -117,7 +117,7 @@ class TestLoginLockout:
         effective threshold to make the test environment-agnostic.
         """
         self._setup_login_attempts(tmp_db)
-        auth_service._security_settings_cache = {}
+        auth_service._security_settings_cache.clear()
 
         with self._patch_db(tmp_db):
             # Read the effective max_login_attempts from settings
@@ -136,7 +136,7 @@ class TestLoginLockout:
     def test_no_lockout_before_threshold(self, tmp_db):
         """Account is NOT locked before reaching max attempts."""
         self._setup_login_attempts(tmp_db)
-        auth_service._security_settings_cache = {}
+        auth_service._security_settings_cache.clear()
 
         with self._patch_db(tmp_db):
             # Record only 1 attempt (always below any reasonable threshold)
@@ -149,7 +149,7 @@ class TestLoginLockout:
     def test_clear_failed_logins(self, tmp_db):
         """Clearing failed logins removes the record."""
         self._setup_login_attempts(tmp_db)
-        auth_service._security_settings_cache = {}
+        auth_service._security_settings_cache.clear()
 
         with self._patch_db(tmp_db):
             _record_failed_login("cleareduser")
@@ -173,7 +173,7 @@ class TestLoginLockout:
     def test_expired_lockout_allows_login(self, tmp_db):
         """Expired lockout is auto-cleaned and allows login."""
         self._setup_login_attempts(tmp_db)
-        auth_service._security_settings_cache = {}
+        auth_service._security_settings_cache.clear()
 
         # Manually insert an expired lockout
         expired_time = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(minutes=30)


### PR DESCRIPTION
## Summary
- Replace `_security_settings_cache = {}` with `.clear()` in auth integration tests to preserve dict identity
- Add `_security_settings_cache.clear()` to global autouse fixture to prevent cross-suite pollution

## Problem
Integration tests were using `_security_settings_cache = {}` which replaces the module-level dict object. Unit tests that import via `from app.services.auth_service import _security_settings_cache` hold a reference to the OLD dict, so their cache writes go to a different object than what `_get_security_settings()` reads from.

## Test plan
- [x] `pytest tests/integration/ tests/unit/ -q` → 1400 passed, 0 failed