### PR TITLE
fix: add style prop support to Badge component

### DIFF
--- a/frontend/src/components/common/Badge.tsx
+++ b/frontend/src/components/common/Badge.tsx
@@ -20,6 +20,7 @@ interface BadgeProps {
   pill?: boolean;
   children: React.ReactNode;
   className?: string;
+  style?: React.CSSProperties;
   onClick?: () => void;
   dismissible?: boolean;
   onDismiss?: () => void;
@@ -41,6 +42,7 @@ export const Badge: React.FC<BadgeProps> = ({
   pill = false,
   children,
   className,
+  style,
   onClick,
   dismissible = false,
   onDismiss,
@@ -57,7 +59,7 @@ export const Badge: React.FC<BadgeProps> = ({
         className
       )}
       onClick={onClick}
-      style={onClick ? { border: 'none', cursor: 'pointer' } : undefined}
+      style={onClick ? { border: 'none', cursor: 'pointer', ...style } : style}
     >
       {children}
       {dismissible && onDismiss && (


### PR DESCRIPTION
修复前端构建错误：Badge组件缺少style属性支持

## 问题
`SessionDetailContent.tsx` 中使用了 `<Badge style={{ fontSize: '0.65rem' }}>` 但 Badge 组件的接口没有定义 `style` 属性，导致 TypeScript 编译失败。

## 解决方案
- 在 `BadgeProps` 接口中添加 `style?: React.CSSProperties` 属性
- 在组件实现中正确传递 style 属性到 DOM 元素

## 测试
- [x] 前端构建成功 (`npm run build`)
