### PR TITLE
fix: handle missing user_permissions table in migration 045

### DIFF
--- a/migrations/versions/20260523_045_fix_granted_at_type.py
+++ b/migrations/versions/20260523_045_fix_granted_at_type.py
@@ -6,6 +6,9 @@ Create Date: 2026-05-23
 
 user_permissions.granted_at was text, inconsistent with
 machine_assignments.granted_at which is timestamp.
+
+This migration also handles fresh databases where user_permissions
+table doesn't exist yet (was only in schema-postgres.sql, no migration).
 """
 
 from typing import Union
@@ -19,22 +22,71 @@ branch_labels: Union[str, None] = None
 depends_on: Union[str, None] = None
 
 
+def _table_exists(conn, table_name: str) -> bool:
+    """Check if a table exists in the database."""
+    if conn.dialect.name == "postgresql":
+        result = conn.execute(
+            sa.text(
+                "SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_name = :table_name)"
+            ),
+            {"table_name": table_name},
+        )
+        return result.fetchone()[0]
+    else:
+        result = conn.execute(
+            sa.text("SELECT name FROM sqlite_master WHERE type='table' AND name = :table_name"),
+            {"table_name": table_name},
+        )
+        return result.fetchone() is not None
+
+
 def upgrade() -> None:
-    """Change granted_at from text to timestamp."""
-    op.alter_column(
-        "user_permissions",
-        "granted_at",
-        type_=sa.TIMESTAMP(),
-        existing_type=sa.TEXT(),
-        postgresql_using="granted_at::timestamp without time zone",
-    )
+    """Create user_permissions table if not exists, ensure granted_at is timestamp."""
+    conn = op.get_bind()
+
+    if not _table_exists(conn, "user_permissions"):
+        # Table doesn't exist - create it with correct schema
+        op.create_table(
+            "user_permissions",
+            sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
+            sa.Column("user_id", sa.Integer, nullable=False),
+            sa.Column("permission", sa.Text, nullable=False),
+            sa.Column("granted_by", sa.Integer, nullable=True),
+            sa.Column("granted_at", sa.TIMESTAMP, nullable=True),
+        )
+        op.create_unique_constraint(
+            "user_permissions_user_id_permission_key",
+            "user_permissions",
+            ["user_id", "permission"],
+        )
+    else:
+        # Table exists - check if granted_at column is text type
+        if conn.dialect.name == "postgresql":
+            result = conn.execute(
+                sa.text(
+                    "SELECT data_type FROM information_schema.columns "
+                    "WHERE table_name = 'user_permissions' AND column_name = 'granted_at'"
+                )
+            )
+            row = result.fetchone()
+            if row and row[0] in ("text", "character varying"):
+                op.alter_column(
+                    "user_permissions",
+                    "granted_at",
+                    type_=sa.TIMESTAMP(),
+                    existing_type=sa.TEXT(),
+                    postgresql_using="granted_at::timestamp without time zone",
+                )
 
 
 def downgrade() -> None:
     """Revert granted_at back to text."""
-    op.alter_column(
-        "user_permissions",
-        "granted_at",
-        type_=sa.TEXT(),
-        existing_type=sa.TIMESTAMP(),
-    )
+    conn = op.get_bind()
+
+    if _table_exists(conn, "user_permissions"):
+        op.alter_column(
+            "user_permissions",
+            "granted_at",
+            type_=sa.TEXT(),
+            existing_type=sa.TIMESTAMP(),
+        )


### PR DESCRIPTION
修复迁移 045 处理 user_permissions 表不存在的情况

## 问题
在另一台机器上执行安装脚本时，alembic 迁移失败：
```
psycopg2.errors.UndefinedTable: relation "user_permissions" does not exist
```

原因：`user_permissions` 表只在 `schema-postgres.sql` 中定义，没有对应的迁移脚本。迁移 045 直接尝试修改该表，导致失败。

## 解决方案
参考迁移 017 的模式，修改迁移 045：
1. 添加 `_table_exists()` 函数检查表是否存在
2. 表不存在时创建表（使用正确的 schema）
3. 表存在时检查列类型，仅在需要时转换

## 测试
- [x] 所有 pre-commit 检查通过
