### PR TITLE
fix: handle hyphens in hostname when parsing codex sender_name

### DIFF
--- a/scripts/fetch_codex.py
+++ b/scripts/fetch_codex.py
@@ -659,6 +659,51 @@ def _process_sessions_dir(
     return total_files
 
 
+def _resolve_user_id_from_sender(cursor, sender_name: str, all_users_cache: list) -> Optional[int]:
+    """Resolve user_id from sender_name (format: {user}-{hostname}-{tool}).
+
+    Hostname may contain hyphens, so rsplit alone is unreliable.
+    Strategy: rsplit for a quick match, then fallback to longest-prefix match.
+
+    Args:
+        cursor: Database cursor.
+        sender_name: Sender name string, e.g. 'rhuang-RichdeMacBook-Pro.local-codex'.
+        all_users_cache: Cached list of all user rows (lazy-loaded externally).
+
+    Returns:
+        user_id or None.
+    """
+    if not sender_name:
+        return None
+
+    from shared.db import _execute, _placeholder
+
+    placeholder = _placeholder()
+
+    # Try rsplit first (works when hostname has no hyphens)
+    candidate = sender_name.rsplit("-", 2)[0]
+    user_sql = (
+        f"SELECT id FROM users WHERE system_account = {placeholder} OR username = {placeholder}"
+    )
+    _execute(cursor, user_sql, (candidate, candidate))
+    user_row = cursor.fetchone()
+    if user_row:
+        return user_row["id"]
+
+    # Fallback: longest-prefix match against all users
+    # Sort by field length descending so e.g. 'alice-admin' matches before 'alice'
+    candidates = sorted(
+        ((u["id"], f) for u in all_users_cache for f in (u["system_account"], u["username"]) if f),
+        key=lambda x: len(x[1]),
+        reverse=True,
+    )
+    for uid, field in candidates:
+        if sender_name.startswith(field + "-"):
+            return uid
+
+    return None
+
+
 def update_agent_sessions_stats(messages: list) -> int:
     """
     Update agent_sessions table statistics from collected Codex messages.
@@ -732,6 +777,15 @@ def update_agent_sessions_stats(messages: list) -> int:
     conn = get_connection()
     cursor = conn.cursor()
 
+    # Lazy-loaded cache for all users (avoids N+1 query inside session loop)
+    _all_users_cache: list = []
+
+    def _get_all_users():
+        if not _all_users_cache:
+            _execute(cursor, "SELECT id, system_account, username FROM users")
+            _all_users_cache.extend(cursor.fetchall())
+        return _all_users_cache
+
     try:
         for session_id, stats in session_stats.items():
             try:
@@ -752,31 +806,8 @@ def update_agent_sessions_stats(messages: list) -> int:
                     sender_name = first_msg.get("sender_name", "")
                     project_path = stats["project_path"] or first_msg.get("project_path", "")
 
-                    # Extract system_account from sender_name (format: {system_account}-{hostname}-{tool})
-                    # Hostname may contain hyphens, so rsplit alone is unreliable.
-                    # Strategy: rsplit for a quick match, then fallback to scanning all users.
-                    user_id = None
-                    if sender_name:
-                        # Try rsplit first (works when hostname has no hyphens)
-                        candidate = sender_name.rsplit("-", 2)[0]
-                        user_sql = f"SELECT id FROM users WHERE system_account = {placeholder} OR username = {placeholder}"
-                        _execute(cursor, user_sql, (candidate, candidate))
-                        user_row = cursor.fetchone()
-                        if user_row:
-                            user_id = user_row["id"]
-                        else:
-                            # Fallback: try matching each user's system_account/username
-                            # as a prefix of sender_name (handles hyphens in hostname)
-                            all_users_sql = "SELECT id, system_account, username FROM users"
-                            _execute(cursor, all_users_sql)
-                            all_users = cursor.fetchall()
-                            for u in all_users:
-                                for field in (u["system_account"], u["username"]):
-                                    if field and sender_name.startswith(field + "-"):
-                                        user_id = u["id"]
-                                        break
-                                if user_id:
-                                    break
+                    # Resolve user_id from sender_name (format: {user}-{hostname}-{tool})
+                    user_id = _resolve_user_id_from_sender(cursor, sender_name, _get_all_users())
 
                     title = f"codex - {session_id[:8]}"
 

--- a/scripts/fetch_codex.py
+++ b/scripts/fetch_codex.py
@@ -753,13 +753,30 @@ def update_agent_sessions_stats(messages: list) -> int:
                     project_path = stats["project_path"] or first_msg.get("project_path", "")
 
                     # Extract system_account from sender_name (format: {system_account}-{hostname}-{tool})
-                    system_account = sender_name.rsplit("-", 2)[0] if sender_name else "unknown"
-
-                    # Find user_id by system_account
-                    user_sql = f"SELECT id FROM users WHERE system_account = {placeholder} OR username = {placeholder}"
-                    _execute(cursor, user_sql, (system_account, system_account))
-                    user_row = cursor.fetchone()
-                    user_id = user_row["id"] if user_row else None
+                    # Hostname may contain hyphens, so rsplit alone is unreliable.
+                    # Strategy: rsplit for a quick match, then fallback to scanning all users.
+                    user_id = None
+                    if sender_name:
+                        # Try rsplit first (works when hostname has no hyphens)
+                        candidate = sender_name.rsplit("-", 2)[0]
+                        user_sql = f"SELECT id FROM users WHERE system_account = {placeholder} OR username = {placeholder}"
+                        _execute(cursor, user_sql, (candidate, candidate))
+                        user_row = cursor.fetchone()
+                        if user_row:
+                            user_id = user_row["id"]
+                        else:
+                            # Fallback: try matching each user's system_account/username
+                            # as a prefix of sender_name (handles hyphens in hostname)
+                            all_users_sql = "SELECT id, system_account, username FROM users"
+                            _execute(cursor, all_users_sql)
+                            all_users = cursor.fetchall()
+                            for u in all_users:
+                                for field in (u["system_account"], u["username"]):
+                                    if field and sender_name.startswith(field + "-"):
+                                        user_id = u["id"]
+                                        break
+                                if user_id:
+                                    break
 
                     title = f"codex - {session_id[:8]}"
 

--- a/tests/issues/517/test_sender_name_parsing.py
+++ b/tests/issues/517/test_sender_name_parsing.py
@@ -11,31 +11,6 @@ Covers _resolve_user_id_from_sender logic:
 import pytest
 
 
-@pytest.fixture
-def mock_cursor(mocker):
-    """Create a mock cursor that simulates DB queries."""
-
-    class MockCursor:
-        def __init__(self):
-            self._query_results = {}
-            self._last_params = None
-
-        def fetchone(self):
-            key = str(self._last_params)
-            return self._query_results.get(("fetchone", key))
-
-        def fetchall(self):
-            return self._query_results.get("fetchall_all_users", [])
-
-        def set_execute_result(self, sql, params, result):
-            if "fetchall" in str(result):
-                self._query_results["fetchall_all_users"] = result
-            else:
-                self._query_results[("fetchone", str(params))] = result
-
-    return MockCursor()
-
-
 def _make_cursor_with_users(users, rsplit_match=None):
     """Build a mock cursor that returns given users.
 
@@ -79,10 +54,6 @@ def _run_resolve(cursor, sender_name):
     """Run _resolve_user_id_from_sender with mocked _execute/_placeholder."""
     import unittest.mock as mock
 
-    # The function uses shared.db._execute and _placeholder internally,
-    # but since cursor methods match, we pass the cursor directly.
-    # We need to mock the imports inside the function.
-    import scripts.fetch_codex as mod
     from scripts.fetch_codex import _resolve_user_id_from_sender
 
     def mock_execute(cur, sql, params=None):

--- a/tests/issues/517/test_sender_name_parsing.py
+++ b/tests/issues/517/test_sender_name_parsing.py
@@ -1,0 +1,169 @@
+"""
+Test sender_name parsing for Codex sessions.
+
+Covers _resolve_user_id_from_sender logic:
+- hostname without hyphens: rsplit quick match
+- hostname with hyphens: longest-prefix fallback
+- no matching user: returns None
+- prefix conflict: longer name wins over shorter one
+"""
+
+import pytest
+
+
+@pytest.fixture
+def mock_cursor(mocker):
+    """Create a mock cursor that simulates DB queries."""
+
+    class MockCursor:
+        def __init__(self):
+            self._query_results = {}
+            self._last_params = None
+
+        def fetchone(self):
+            key = str(self._last_params)
+            return self._query_results.get(("fetchone", key))
+
+        def fetchall(self):
+            return self._query_results.get("fetchall_all_users", [])
+
+        def set_execute_result(self, sql, params, result):
+            if "fetchall" in str(result):
+                self._query_results["fetchall_all_users"] = result
+            else:
+                self._query_results[("fetchone", str(params))] = result
+
+    return MockCursor()
+
+
+def _make_cursor_with_users(users, rsplit_match=None):
+    """Build a mock cursor that returns given users.
+
+    Args:
+        users: list of dicts with id, system_account, username
+        rsplit_match: if set, the rsplit candidate will "match" this user_id
+    """
+
+    class Cursor:
+        def __init__(self):
+            self._rsplit_match = rsplit_match
+            self._users = users
+
+        def fetchone(self):
+            return self._one
+
+        def fetchall(self):
+            return self._all
+
+        def execute(self, sql, params=None):
+            # Detect which query is being run
+            if "system_account" in sql and "username" in sql and "SELECT id " in sql:
+                # rsplit lookup query (single user match)
+                candidate = params[0] if params else None
+                if self._rsplit_match is not None and candidate:
+                    for u in self._users:
+                        if u["system_account"] == candidate or u["username"] == candidate:
+                            self._one = {"id": u["id"]}
+                            return
+                self._one = None
+            elif "SELECT id, system_account, username FROM users" in sql:
+                self._all = self._users
+            else:
+                self._one = None
+                self._all = []
+
+    return Cursor()
+
+
+def _run_resolve(cursor, sender_name):
+    """Run _resolve_user_id_from_sender with mocked _execute/_placeholder."""
+    import unittest.mock as mock
+
+    # The function uses shared.db._execute and _placeholder internally,
+    # but since cursor methods match, we pass the cursor directly.
+    # We need to mock the imports inside the function.
+    import scripts.fetch_codex as mod
+    from scripts.fetch_codex import _resolve_user_id_from_sender
+
+    def mock_execute(cur, sql, params=None):
+        cur.execute(sql, params)
+
+    with (
+        mock.patch("shared.db._execute", side_effect=mock_execute),
+        mock.patch("shared.db._placeholder", return_value="%s"),
+    ):
+        return _resolve_user_id_from_sender(cursor, sender_name, cursor._users)
+
+
+class TestResolveUserId:
+    """Test _resolve_user_id_from_sender with various sender_name patterns."""
+
+    def test_hostname_without_hyphens(self):
+        """rsplit quick match: rhuang-MacBookPro-codex → user_id=89"""
+        cursor = _make_cursor_with_users(
+            [{"id": 89, "system_account": "rhuang", "username": "黄迎春"}],
+            rsplit_match=True,
+        )
+        result = _run_resolve(cursor, "rhuang-MacBookPro-codex")
+        assert result == 89
+
+    def test_hostname_with_hyphens(self):
+        """Fallback: rhuang-RichdeMacBook-Pro.local-codex → user_id=89"""
+        cursor = _make_cursor_with_users(
+            [{"id": 89, "system_account": "rhuang", "username": "黄迎春"}],
+            rsplit_match=False,
+        )
+        result = _run_resolve(cursor, "rhuang-RichdeMacBook-Pro.local-codex")
+        assert result == 89
+
+    def test_no_matching_user(self):
+        """No match: unknown-host-codex → None"""
+        cursor = _make_cursor_with_users(
+            [{"id": 89, "system_account": "rhuang", "username": "黄迎春"}],
+            rsplit_match=False,
+        )
+        result = _run_resolve(cursor, "unknown-host-codex")
+        assert result is None
+
+    def test_empty_sender_name(self):
+        """Empty sender_name → None"""
+        cursor = _make_cursor_with_users([], rsplit_match=False)
+        result = _run_resolve(cursor, "")
+        assert result is None
+
+    def test_prefix_conflict_longer_wins(self):
+        """alice-admin-host-tool should match alice-admin (id=2), not alice (id=1)."""
+        cursor = _make_cursor_with_users(
+            [
+                {"id": 1, "system_account": "alice", "username": "alice"},
+                {"id": 2, "system_account": "alice-admin", "username": "alice-admin"},
+            ],
+            rsplit_match=False,
+        )
+        result = _run_resolve(cursor, "alice-admin-host-codex")
+        assert result == 2, "Longer prefix (alice-admin) should win over shorter (alice)"
+
+    def test_username_match(self):
+        """Match by username field when system_account doesn't match."""
+        cursor = _make_cursor_with_users(
+            [{"id": 42, "system_account": "svc_account", "username": "testuser"}],
+            rsplit_match=False,
+        )
+        result = _run_resolve(cursor, "testuser-host-codex")
+        assert result == 42
+
+    def test_null_fields_skipped(self):
+        """Users with NULL system_account/username are safely skipped."""
+        cursor = _make_cursor_with_users(
+            [
+                {"id": 1, "system_account": None, "username": None},
+                {"id": 2, "system_account": "rhuang", "username": "黄迎春"},
+            ],
+            rsplit_match=False,
+        )
+        result = _run_resolve(cursor, "rhuang-host-codex")
+        assert result == 2
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Problem

Codex sessions imported by `fetch_codex.py` had `user_id = NULL`, making them invisible in the session list when filtered by logged-in user.

## Root Cause

`sender_name` format is `{user}-{hostname}-{tool}` (e.g., `rhuang-RichdeMacBook-Pro.local-codex`). When the hostname contains hyphens, `rsplit("-", 2)` extracts the wrong `system_account`:

- `rsplit("-", 2)` → `["rhuang-RichdeMacBook", "Pro.local", "codex"]`
- Extracted: `rhuang-RichdeMacBook` ≠ DB value `rhuang`
- Result: `user_id = NULL`, sessions invisible to users

## Fix

Improve `sender_name` parsing in `update_agent_sessions_stats()`:
1. Try `rsplit("-", 2)` for quick match (works when hostname has no hyphens)
2. Fallback: scan all users and match `system_account`/`username` as a prefix of `sender_name`

## Testing

- Verified 4 codex sessions from today now appear correctly in the session list
- All pre-commit hooks pass (black, ruff, mypy, bandit, etc.)