### PR TITLE
fix: align frontend Recommendation interface with backend API fields

### DIFF
--- a/frontend/src/api/analysis.ts
+++ b/frontend/src/api/analysis.ts
@@ -58,9 +58,9 @@ export interface ToolComparison {
 
 export interface Recommendation {
   type: string;
-  title: string;
-  description: string;
-  impact: string;
+  message: string;
+  details: string;
+  impact?: string;
 }
 
 export interface UserSegmentation {

--- a/frontend/src/api/sessions.ts
+++ b/frontend/src/api/sessions.ts
@@ -65,7 +65,11 @@ export type ContentBlock =
   | { type: 'tool_use'; id: string; name: string; input: Record<string, unknown> }
   | { type: 'tool_result'; tool_use_id: string; content: string | ContentBlock[] }
   | { type: 'reasoning'; summary: string }
-  | { type: 'file_change'; changes: FileChangeDetail[]; status: 'accepted' | 'declined' | 'modified' }
+  | {
+      type: 'file_change';
+      changes: FileChangeDetail[];
+      status: 'accepted' | 'declined' | 'modified';
+    }
   | { type: 'task_summary'; text: string; duration_ms: number; time_to_first_token_ms?: number };
 
 export interface SessionFilters {

--- a/frontend/src/components/common/SessionDetailContent.tsx
+++ b/frontend/src/components/common/SessionDetailContent.tsx
@@ -843,17 +843,31 @@ const ContentBlockRenderer: React.FC<{
 
     case 'file_change':
       return (
-        <details className={`border-start border-3 ps-2 mb-1 ${block.status === 'accepted' ? 'border-success' : 'border-danger'}`}>
+        <details
+          className={`border-start border-3 ps-2 mb-1 ${block.status === 'accepted' ? 'border-success' : 'border-danger'}`}
+        >
           <summary className="small" style={{ cursor: 'pointer' }}>
             <Badge variant={block.status === 'accepted' ? 'success' : 'danger'} className="me-1">
               {block.status === 'accepted' ? 'Accepted' : 'Declined'}
             </Badge>
-            <span className="fw-medium">{block.changes.length} file change{block.changes.length !== 1 ? 's' : ''}</span>
+            <span className="fw-medium">
+              {block.changes.length} file change{block.changes.length !== 1 ? 's' : ''}
+            </span>
           </summary>
           <div className="mt-1 small">
             {block.changes.map((change, i) => (
               <div key={i} className="d-flex align-items-center mb-1">
-                <Badge variant={change.change_type === 'add' ? 'success' : change.change_type === 'delete' ? 'danger' : 'warning'} className="me-1" pill>
+                <Badge
+                  variant={
+                    change.change_type === 'add'
+                      ? 'success'
+                      : change.change_type === 'delete'
+                        ? 'danger'
+                        : 'warning'
+                  }
+                  className="me-1"
+                  pill
+                >
                   {change.change_type.toUpperCase()}
                 </Badge>
                 <code className="small">{change.path}</code>
@@ -875,10 +889,7 @@ const ContentBlockRenderer: React.FC<{
               </span>
             )}
           </div>
-          <div
-            className="small"
-            style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}
-          >
+          <div className="small" style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
             {block.text}
           </div>
         </div>

--- a/frontend/src/components/features/Analysis.tsx
+++ b/frontend/src/components/features/Analysis.tsx
@@ -435,13 +435,15 @@ export const Analysis: React.FC = () => {
                           <div>
                             <h6 className="mb-1">
                               <i className={cn('bi me-2', getRecommendationIcon(rec.type))} />
-                              {rec.title}
+                              {rec.message}
                             </h6>
-                            <p className="mb-1 text-muted small">{rec.description}</p>
+                            <p className="mb-1 text-muted small">{rec.details}</p>
                           </div>
-                          <span className={cn('badge', getImpactBadge(rec.impact))}>
-                            {rec.impact}
-                          </span>
+                          {rec.impact && (
+                            <span className={cn('badge', getImpactBadge(rec.impact))}>
+                              {rec.impact}
+                            </span>
+                          )}
                         </div>
                       </li>
                     ))}

--- a/frontend/src/components/features/analysis/AnomalyDetection.tsx
+++ b/frontend/src/components/features/analysis/AnomalyDetection.tsx
@@ -400,13 +400,15 @@ export const AnomalyDetection: React.FC = () => {
                           <div>
                             <h6 className="mb-1">
                               <i className={cn('bi me-2', getRecommendationIcon(rec.type))} />
-                              {rec.title}
+                              {rec.message}
                             </h6>
-                            <p className="mb-1 text-muted small">{rec.description}</p>
+                            <p className="mb-1 text-muted small">{rec.details}</p>
                           </div>
-                          <span className={cn('badge', getImpactBadge(rec.impact))}>
-                            {rec.impact}
-                          </span>
+                          {rec.impact && (
+                            <span className={cn('badge', getImpactBadge(rec.impact))}>
+                              {rec.impact}
+                            </span>
+                          )}
                         </div>
                       </li>
                     ))}


### PR DESCRIPTION
## Summary

Fixes #447 - Recommendation display was broken due to field name mismatch between frontend and backend.

## Problem

The recommendation card on anomaly detection page showed empty state because:
- Frontend expected fields: title, description, impact
- Backend returned fields: message, details

## Solution

Modified frontend to match backend API response.

## Files Changed

- frontend/src/api/analysis.ts - Updated Recommendation interface
- frontend/src/components/features/analysis/AnomalyDetection.tsx - Updated component rendering
- frontend/src/components/features/Analysis.tsx - Updated component rendering

## Test Plan

- Frontend build succeeds
- Deployed to node237 for verification
- JS files use correct field names (message, details)