### PR TITLE
fix: tokens=0 不应被标记为异常 (#451)

### DIFF
--- a/app/services/analysis_service.py
+++ b/app/services/analysis_service.py
@@ -813,7 +813,10 @@ class AnalysisService:
 
         Anomaly types:
         1. usage_spike: Daily usage exceeds 2 standard deviations above mean
-        2. usage_drop: Daily usage below 50% of average
+        2. usage_drop: Daily usage has some activity but below 50% of average
+
+        Note: Days with zero tokens (no activity) are not considered anomalies.
+        They indicate inactivity (e.g., maintenance, downtime, holidays).
 
         Args:
             start_date: Optional start date filter.
@@ -854,6 +857,10 @@ class AnalysisService:
             token = d.get("total_tokens", 0)
             date = d.get("date")
 
+            # No activity - not an anomaly, just inactive
+            if token == 0:
+                continue
+
             if std_dev > 0:
                 deviation = (token - avg_tokens) / std_dev
 
@@ -876,7 +883,7 @@ class AnalysisService:
 
                     anomalies.append(anomaly)
 
-                # Usage drop: below 50% of average
+                # Usage drop: has some activity but significantly below average
                 elif token < avg_tokens * 0.5 and avg_tokens > 0:
                     anomaly = {
                         "date": date,

--- a/tests/unit/test_analysis_service.py
+++ b/tests/unit/test_analysis_service.py
@@ -166,6 +166,30 @@ class TestAnalysisService:
         assert result["anomalies"] == []
         assert result["summary"]["total"] == 0
 
+    def test_detect_anomalies_zero_tokens_not_flagged(self):
+        """Test that days with zero tokens are not flagged as anomalies."""
+        svc, _, mock_msg, _ = self._make_service()
+        # Mix of normal days and zero-token days
+        daily_data = [
+            {"date": "2026-05-01", "total_tokens": 100},
+            {"date": "2026-05-02", "total_tokens": 100},
+            {"date": "2026-05-03", "total_tokens": 100},
+            {"date": "2026-05-04", "total_tokens": 0},  # Zero tokens - should NOT be anomaly
+            {"date": "2026-05-05", "total_tokens": 0},  # Zero tokens - should NOT be anomaly
+            {"date": "2026-05-06", "total_tokens": 100},
+            {"date": "2026-05-07", "total_tokens": 5000},  # Spike - should be anomaly
+        ]
+        mock_msg.get_daily_token_totals.return_value = daily_data
+        result = svc.detect_anomalies("2026-05-01", "2026-05-07")
+
+        # Zero token days should not appear in anomalies
+        anomaly_dates = [a["date"] for a in result["anomalies"]]
+        assert "2026-05-04" not in anomaly_dates, "Zero token day should not be flagged as anomaly"
+        assert "2026-05-05" not in anomaly_dates, "Zero token day should not be flagged as anomaly"
+
+        # Spike should still be detected
+        assert any(a["type"] == "spike" for a in result["anomalies"]), "Spike anomaly should be detected"
+
     def test_get_recommendations_with_data(self):
         svc, mock_usage, _, _ = self._make_service()
         mock_usage.get_daily_range.return_value = [

--- a/tests/unit/test_analysis_service.py
+++ b/tests/unit/test_analysis_service.py
@@ -188,7 +188,9 @@ class TestAnalysisService:
         assert "2026-05-05" not in anomaly_dates, "Zero token day should not be flagged as anomaly"
 
         # Spike should still be detected
-        assert any(a["type"] == "spike" for a in result["anomalies"]), "Spike anomaly should be detected"
+        assert any(
+            a["type"] == "spike" for a in result["anomalies"]
+        ), "Spike anomaly should be detected"
 
     def test_get_recommendations_with_data(self):
         svc, mock_usage, _, _ = self._make_service()


### PR DESCRIPTION
## 问题描述

Issue #451 指出异常检测算法将 tokens=0 的日期标记为 "Usage Drop" 异常，但这在语义上不准确。零 token 表示"无活动"（如系统维护、停机、节假日），与"用量异常下降"是不同的概念。

## 问题根因

当 token == 0 时，必然满足 token < avg_tokens * 0.5 条件，因此被算法错误标记为异常。

## 修复方案

在异常检测循环中添加 token == 0 的判断，跳过零 token 日期：

```python
# No activity - not an anomaly, just inactive
if token == 0:
    continue
```

## 修改文件

- app/services/analysis_service.py - detect_anomalies() 方法
- tests/unit/test_analysis_service.py - 新增测试用例

## 验证结果

1. 本地单元测试：14/14 通过 ✅
2. node237 部署验证：零 token 日期正确跳过 ✅

Closes #451