### PR TITLE
fix: 项目管理页面 token 统计显示为 0 (#476)

### DIFF
--- a/app/repositories/project_repo.py
+++ b/app/repositories/project_repo.py
@@ -468,18 +468,10 @@ class ProjectRepository:
                 COALESCE(SUM(up.total_duration_seconds), 0) as total_duration_seconds,
                 MIN(up.first_access_at) as first_access,
                 MAX(up.last_access_at) as last_access,
-                COALESCE(dm_stats.total_tokens, 0) as total_tokens,
-                COALESCE(dm_stats.total_requests, 0) as total_requests
+                COALESCE(SUM(up.total_tokens), 0) as total_tokens,
+                COALESCE(SUM(up.total_requests), 0) as total_requests
             FROM projects p
             LEFT JOIN user_projects up ON p.id = up.project_id
-            LEFT JOIN (
-                SELECT project_path,
-                       SUM(tokens_used) as total_tokens,
-                       COUNT(*) as total_requests
-                FROM daily_messages
-                WHERE project_path IS NOT NULL
-                GROUP BY project_path
-            ) dm_stats ON p.path = dm_stats.project_path
             WHERE p.is_active IS TRUE
             GROUP BY p.id
             ORDER BY total_tokens DESC


### PR DESCRIPTION
## 问题描述

访问 /manage/projects 页面时，所有项目的 total_tokens 和 total_requests 显示为 0。

## 问题根因

get_all_project_stats() 方法从 daily_messages.project_path 获取 token 数据，但该字段未被正确填充（所有 tokens 值为 0），导致显示为 0。

真实数据实际存储在 user_projects.total_tokens 表中，但未被查询使用。

## 修复方案

修改 SQL 查询，将 token 和 request 统计数据源从 daily_messages 子查询改为直接从 user_projects 表聚合：

- 移除对 daily_messages 表的 JOIN
- 使用 SUM(up.total_tokens) 和 SUM(up.total_requests) 获取统计数据

## 修改文件

- app/repositories/project_repo.py - get_all_project_stats() 方法

## 验证结果

在 node237 环境验证修复效果：
- API /api/projects/stats 返回正确的 token 数据（96181）
- 项目管理页面统计数据不再显示为 0

Closes #476