### PR TITLE
fix: PostgreSQL 序列未同步导致添加租户失败 (#475)

### DIFF
--- a/app/repositories/tenant_repo.py
+++ b/app/repositories/tenant_repo.py
@@ -16,6 +16,21 @@ from app.repositories.database import Database
 logger = logging.getLogger(__name__)
 
 
+def _parse_datetime(value: Any) -> Optional[datetime]:
+    """Parse datetime value from database.
+
+    PostgreSQL returns datetime objects directly, while SQLite returns strings.
+    This helper handles both cases.
+    """
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        return datetime.fromisoformat(value)
+    return None
+
+
 class TenantRepository:
     """Repository for tenant data access."""
 
@@ -630,16 +645,10 @@ class TenantRepository:
             contact_name=row.get("contact_name"),
             quota=quota,
             settings=settings,
-            created_at=datetime.fromisoformat(row["created_at"]) if row.get("created_at") else None,
-            updated_at=datetime.fromisoformat(row["updated_at"]) if row.get("updated_at") else None,
-            trial_ends_at=(
-                datetime.fromisoformat(row["trial_ends_at"]) if row.get("trial_ends_at") else None
-            ),
-            subscription_ends_at=(
-                datetime.fromisoformat(row["subscription_ends_at"])
-                if row.get("subscription_ends_at")
-                else None
-            ),
+            created_at=_parse_datetime(row.get("created_at")),
+            updated_at=_parse_datetime(row.get("updated_at")),
+            trial_ends_at=_parse_datetime(row.get("trial_ends_at")),
+            subscription_ends_at=_parse_datetime(row.get("subscription_ends_at")),
             user_count=row.get("user_count", 0),
             total_tokens_used=row.get("total_tokens_used", 0),
             total_requests_made=row.get("total_requests_made", 0),

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -225,10 +225,12 @@ describe('ApiClient', () => {
 
       await client.get('/api/test', undefined, controller.signal);
 
+      // Note: client combines user signal with timeout signal via combineSignals()
+      // The signal passed to fetch is a combined signal, not the original user signal
       expect(fetch).toHaveBeenCalledWith(
         '/api/test',
         expect.objectContaining({
-          signal: controller.signal,
+          signal: expect.any(AbortSignal),
         })
       );
     });

--- a/frontend/src/api/sessions.ts
+++ b/frontend/src/api/sessions.ts
@@ -65,7 +65,11 @@ export type ContentBlock =
   | { type: 'tool_use'; id: string; name: string; input: Record<string, unknown> }
   | { type: 'tool_result'; tool_use_id: string; content: string | ContentBlock[] }
   | { type: 'reasoning'; summary: string }
-  | { type: 'file_change'; changes: FileChangeDetail[]; status: 'accepted' | 'declined' | 'modified' }
+  | {
+      type: 'file_change';
+      changes: FileChangeDetail[];
+      status: 'accepted' | 'declined' | 'modified';
+    }
   | { type: 'task_summary'; text: string; duration_ms: number; time_to_first_token_ms?: number };
 
 export interface SessionFilters {

--- a/frontend/src/components/common/SessionDetailContent.tsx
+++ b/frontend/src/components/common/SessionDetailContent.tsx
@@ -843,17 +843,31 @@ const ContentBlockRenderer: React.FC<{
 
     case 'file_change':
       return (
-        <details className={`border-start border-3 ps-2 mb-1 ${block.status === 'accepted' ? 'border-success' : 'border-danger'}`}>
+        <details
+          className={`border-start border-3 ps-2 mb-1 ${block.status === 'accepted' ? 'border-success' : 'border-danger'}`}
+        >
           <summary className="small" style={{ cursor: 'pointer' }}>
             <Badge variant={block.status === 'accepted' ? 'success' : 'danger'} className="me-1">
               {block.status === 'accepted' ? 'Accepted' : 'Declined'}
             </Badge>
-            <span className="fw-medium">{block.changes.length} file change{block.changes.length !== 1 ? 's' : ''}</span>
+            <span className="fw-medium">
+              {block.changes.length} file change{block.changes.length !== 1 ? 's' : ''}
+            </span>
           </summary>
           <div className="mt-1 small">
             {block.changes.map((change, i) => (
               <div key={i} className="d-flex align-items-center mb-1">
-                <Badge variant={change.change_type === 'add' ? 'success' : change.change_type === 'delete' ? 'danger' : 'warning'} className="me-1" pill>
+                <Badge
+                  variant={
+                    change.change_type === 'add'
+                      ? 'success'
+                      : change.change_type === 'delete'
+                        ? 'danger'
+                        : 'warning'
+                  }
+                  className="me-1"
+                  pill
+                >
                   {change.change_type.toUpperCase()}
                 </Badge>
                 <code className="small">{change.path}</code>
@@ -875,10 +889,7 @@ const ContentBlockRenderer: React.FC<{
               </span>
             )}
           </div>
-          <div
-            className="small"
-            style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}
-          >
+          <div className="small" style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
             {block.text}
           </div>
         </div>

--- a/frontend/src/components/features/management/TenantManagement.tsx
+++ b/frontend/src/components/features/management/TenantManagement.tsx
@@ -83,9 +83,17 @@ export const TenantManagement: React.FC = () => {
         plan: planFilter || undefined,
       });
       setTenants(result.tenants);
-    } catch (err) {
-      const errorMessage =
-        err instanceof Error ? (err as Error).message : 'Failed to fetch tenants';
+    } catch (err: unknown) {
+      // API client throws ApiError objects (plain objects with message property)
+      // not Error instances. Check for message property first.
+      let errorMessage: string;
+      if (err && typeof err === 'object' && 'message' in err) {
+        errorMessage = String((err as { message: string }).message);
+      } else if (err instanceof Error) {
+        errorMessage = (err as Error).message;
+      } else {
+        errorMessage = 'Failed to fetch tenants';
+      }
       setError(errorMessage);
     } finally {
       setIsLoading(false);
@@ -169,8 +177,17 @@ export const TenantManagement: React.FC = () => {
       }
       handleCloseModal();
       fetchTenants();
-    } catch (err) {
-      const errorMessage = err instanceof Error ? (err as Error).message : 'Failed to save tenant';
+    } catch (err: unknown) {
+      // API client throws ApiError objects (plain objects with message property),
+      // not Error instances. Check for message property first.
+      let errorMessage: string;
+      if (err && typeof err === 'object' && 'message' in err) {
+        errorMessage = String((err as { message: string }).message);
+      } else if (err instanceof Error) {
+        errorMessage = (err as Error).message;
+      } else {
+        errorMessage = 'Failed to save tenant';
+      }
       setFormError(errorMessage);
     }
   };

--- a/scripts/init_db.py
+++ b/scripts/init_db.py
@@ -88,9 +88,7 @@ def create_default_tenant(
         # This prevents "duplicate key violates unique constraint" errors
         # when subsequent inserts use the sequence's default value
         if db.is_postgresql():
-            cursor.execute(
-                "SELECT setval('tenants_id_seq', (SELECT MAX(id) FROM tenants))"
-            )
+            cursor.execute("SELECT setval('tenants_id_seq', (SELECT MAX(id) FROM tenants))")
             conn.commit()
             print("Synced PostgreSQL sequence tenants_id_seq")
 

--- a/scripts/init_db.py
+++ b/scripts/init_db.py
@@ -83,6 +83,17 @@ def create_default_tenant(
         )
 
         conn.commit()
+
+        # Sync PostgreSQL sequence after inserting with explicit id
+        # This prevents "duplicate key violates unique constraint" errors
+        # when subsequent inserts use the sequence's default value
+        if db.is_postgresql():
+            cursor.execute(
+                "SELECT setval('tenants_id_seq', (SELECT MAX(id) FROM tenants))"
+            )
+            conn.commit()
+            print("Synced PostgreSQL sequence tenants_id_seq")
+
         print(f"Created default tenant: {name} (id={tenant_id})")
         conn.close()
         return True


### PR DESCRIPTION
## 问题描述

Fixes #475

在 `/manage/tenants` 页面添加租户时：
- 无法保存租户
- 页面无任何错误提示

## 问题根因

**问题1（后端）**：`scripts/init_db.py` 中 `create_default_tenant` 函数在插入 `id=1` 的默认租户时，未同步 PostgreSQL 序列 `tenants_id_seq`。导致后续创建租户时，序列仍返回 `id=1`，与已存在记录产生主键冲突。

**问题2（前端）**：`TenantManagement.tsx` 中的错误处理使用 `err instanceof Error` 检查，但 API client 抛出的 `ApiError` 是普通对象而非 Error 实例，导致无法正确显示后端返回的错误消息。

## 修复内容

- `scripts/init_db.py`: 插入默认租户后执行 `SELECT setval('tenants_id_seq', (SELECT MAX(id) FROM tenants))` 同步序列值
- `TenantManagement.tsx`: 改进错误处理逻辑，优先检查错误对象是否包含 `message` 属性，正确提取 API 返回的错误消息

## 验证结果

在 node237 上验证通过：
1. 同步 PostgreSQL 序列后重启服务
2. 成功创建新租户，主键从序列正确生成
3. 前端正确显示错误提示