### PR TITLE
Fix remote agent installer Python check

### DIFF
--- a/remote-agent/install.sh
+++ b/remote-agent/install.sh
@@ -111,14 +111,13 @@ find_python() {
     return 1
 }
 
-PYTHON_PATH=$(find_python)
-if [[ -z "$PYTHON_PATH" ]]; then
+if ! PYTHON_PATH=$(find_python); then
     log_error "Python 3.8+ is not installed. Please install Python 3.8+ first."
     exit 1
 fi
 
 PYTHON_VERSION=$("$PYTHON_PATH" -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
-log_success "Python $PYTHON_PATH found at $PYTHON_PATH"
+log_success "Python ${PYTHON_VERSION} found at $PYTHON_PATH"
 
 # Check pip
 if ! "$PYTHON_PATH" -m pip --version &>/dev/null; then

--- a/tests/unit/test_remote_agent_installer.py
+++ b/tests/unit/test_remote_agent_installer.py
@@ -1,0 +1,40 @@
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+
+def test_install_script_reports_missing_python(tmp_path):
+    """The installer should not silently exit when Python is unavailable."""
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+
+    hostname = fake_bin / "hostname"
+    hostname.write_text("#!/bin/sh\necho test-host\n", encoding="utf-8")
+    hostname.chmod(hostname.stat().st_mode | stat.S_IXUSR)
+
+    repo_root = Path(__file__).resolve().parents[2]
+    script = repo_root / "remote-agent" / "install.sh"
+    env = {
+        "HOME": str(tmp_path),
+        "PATH": str(fake_bin),
+    }
+
+    result = subprocess.run(
+        [
+            "/bin/bash",
+            str(script),
+            "--server",
+            "http://127.0.0.1:5000",
+            "--token",
+            "test-token",
+        ],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert "Checking prerequisites" in result.stdout
+    assert "Python 3.8+ is not installed" in result.stdout


### PR DESCRIPTION
## Summary
- prevent the remote agent installer from silently exiting when no Python 3.8+ interpreter is available
- log the detected Python version correctly
- add a unit regression test for the missing-Python path

## Tests
- bash -n remote-agent/install.sh
- python3 -m pytest -q tests/unit/test_remote_agent_installer.py