### PR TITLE
Include Codex adapters in agent installer

### DIFF
--- a/remote-agent/install.ps1
+++ b/remote-agent/install.ps1
@@ -86,7 +86,7 @@ $files = @(
     "session_sync.py",
     "openace_cli.py"
 )
-$adapterFiles = @("__init__.py", "base.py", "qwen_code.py", "claude_code.py", "openclaw.py")
+$adapterFiles = @("__init__.py", "base.py", "qwen_code.py", "claude_code.py", "codex_cli.py", "codex_jsonl_parser.py", "openclaw.py")
 
 foreach ($file in $files) {
     $downloaded = $false

--- a/remote-agent/install.sh
+++ b/remote-agent/install.sh
@@ -180,7 +180,7 @@ else
         done
         # Download CLI adapters
         mkdir -p "${INSTALL_DIR}/cli_adapters"
-        for file in __init__.py base.py qwen_code.py claude_code.py openclaw.py; do
+        for file in __init__.py base.py qwen_code.py claude_code.py codex_cli.py codex_jsonl_parser.py openclaw.py; do
             curl -fsSL "${AGENT_URL}/cli_adapters/${file}" -o "${INSTALL_DIR}/cli_adapters/${file}" 2>/dev/null || {
                 log_warn "Could not download cli_adapters/${file}"
             }

--- a/tests/unit/test_remote_agent_installer.py
+++ b/tests/unit/test_remote_agent_installer.py
@@ -1,7 +1,10 @@
 import os
+import re
 import stat
 import subprocess
 from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 def test_install_script_reports_missing_python(tmp_path):
@@ -13,8 +16,7 @@ def test_install_script_reports_missing_python(tmp_path):
     hostname.write_text("#!/bin/sh\necho test-host\n", encoding="utf-8")
     hostname.chmod(hostname.stat().st_mode | stat.S_IXUSR)
 
-    repo_root = Path(__file__).resolve().parents[2]
-    script = repo_root / "remote-agent" / "install.sh"
+    script = REPO_ROOT / "remote-agent" / "install.sh"
     env = {
         "HOME": str(tmp_path),
         "PATH": str(fake_bin),
@@ -38,3 +40,25 @@ def test_install_script_reports_missing_python(tmp_path):
     assert result.returncode == 1
     assert "Checking prerequisites" in result.stdout
     assert "Python 3.8+ is not installed" in result.stdout
+
+
+def test_shell_installer_downloads_all_cli_adapters():
+    adapter_dir = REPO_ROOT / "remote-agent" / "cli_adapters"
+    expected = sorted(path.name for path in adapter_dir.glob("*.py"))
+
+    script = (REPO_ROOT / "remote-agent" / "install.sh").read_text(encoding="utf-8")
+    match = re.search(r"for file in (__init__\.py [^;\n]+); do", script)
+
+    assert match is not None
+    assert sorted(match.group(1).split()) == expected
+
+
+def test_powershell_installer_downloads_all_cli_adapters():
+    adapter_dir = REPO_ROOT / "remote-agent" / "cli_adapters"
+    expected = sorted(path.name for path in adapter_dir.glob("*.py"))
+
+    script = (REPO_ROOT / "remote-agent" / "install.ps1").read_text(encoding="utf-8")
+    match = re.search(r"\$adapterFiles = @\(([^)]+)\)", script)
+
+    assert match is not None
+    assert sorted(re.findall(r'"([^"]+)"', match.group(1))) == expected


### PR DESCRIPTION
## Summary
- include codex_cli.py and codex_jsonl_parser.py in Linux and Windows remote agent installer downloads
- add installer regression tests that compare adapter download lists against remote-agent/cli_adapters/*.py

## Tests
- bash -n remote-agent/install.sh
- python3 -m pytest -q tests/unit/test_remote_agent_installer.py
- python3 -c 'import sys; sys.path.insert(0, "remote-agent"); import cli_adapters; print(sorted(cli_adapters.ADAPTERS))'