### PR TITLE
fix: handle terminal WebSocket via WSGI middleware

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -36,6 +36,13 @@ def create_app(config=None):
     # This is needed for HTTPS iframe URL generation in multi-user mode
     app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_proto=1)
 
+    # Terminal WebSocket must be handled at the WSGI layer because
+    # Flask/Werkzeug cannot reliably route upgraded connections.
+    # See issue #147 and #557 for context.
+    from app.terminal_ws_middleware import TerminalWebSocketMiddleware
+
+    app.wsgi_app = TerminalWebSocketMiddleware(app.wsgi_app)
+
     # Load configuration
     app.config["TEMPLATES_AUTO_RELOAD"] = True
 

--- a/app/routes/remote.py
+++ b/app/routes/remote.py
@@ -1618,49 +1618,13 @@ def get_terminal_status(terminal_id):
 
 @remote_bp.route("/terminal/<terminal_id>/ws")
 def terminal_websocket(terminal_id):
-    """Main-origin WebSocket bridge for remote web terminals."""
-    browser_ws = request.environ.get("wsgi.websocket")
-    if browser_ws is None:
-        return jsonify({"error": "WebSocket upgrade required"}), 400
+    """Fallback for non-WebSocket requests to the terminal WS endpoint.
 
-    token = request.args.get("token", "")
-    found = terminal_info_store.find_by_terminal_id(terminal_id)
-    if not found:
-        logger.warning("Terminal WS requested for unknown terminal %s", terminal_id[:8])
-        browser_ws.close(1011, "Terminal not available")
-        return ""
-
-    machine_id, info = found
-    stored_token = info.get("token", "")
-    if not token or not stored_token or not hmac.compare_digest(token, stored_token):
-        logger.warning("Terminal WS rejected invalid token for terminal %s", terminal_id[:8])
-        browser_ws.close(4001, "Authentication failed")
-        return ""
-
-    remote_ws_url = info.get("original_ws_url") or info.get("ws_url", "")
-    remote_token = info.get("original_token", "")
-    if not remote_ws_url or remote_ws_url.startswith("/"):
-        logger.error("Terminal WS missing remote URL for terminal %s", terminal_id[:8])
-        browser_ws.close(1011, "Remote terminal not available")
-        return ""
-
-    try:
-        from app.modules.workspace.terminal_ws_bridge import bridge_terminal_websocket
-
-        logger.info(
-            "Bridging terminal %s for machine %s through main backend",
-            terminal_id[:8],
-            machine_id[:8],
-        )
-        bridge_terminal_websocket(terminal_id, browser_ws, remote_ws_url, remote_token)
-    except Exception as e:
-        logger.error("Terminal WS bridge failed for terminal %s: %s", terminal_id[:8], e)
-        try:
-            browser_ws.close(1011, "Remote terminal connection failed")
-        except Exception:
-            pass
-
-    return ""
+    Real WebSocket connections are intercepted by TerminalWebSocketMiddleware
+    at the WSGI layer (see app/terminal_ws_middleware.py).  This route only
+    fires when the request is a plain HTTP GET (no WebSocket upgrade).
+    """
+    return jsonify({"error": "WebSocket upgrade required"}), 400
 
 
 # ==================== LLM Proxy ====================

--- a/app/terminal_ws_middleware.py
+++ b/app/terminal_ws_middleware.py
@@ -1,0 +1,117 @@
+"""WSGI middleware that handles terminal WebSocket upgrades.
+
+Flask/Werkzeug cannot reliably route WebSocket requests to view functions
+because Werkzeug intercepts or mishandles the upgraded connection.
+Issue #147 first discovered this; PR #556 re-introduced the Flask-route
+approach which fails in the same way.  This middleware intercepts terminal
+WebSocket requests at the WSGI layer, before Flask sees them.
+"""
+
+import hmac
+import logging
+import re
+
+logger = logging.getLogger(__name__)
+
+# Pre-compiled pattern: /api/remote/terminal/<uuid>/ws
+_WS_PATH_RE = re.compile(
+    r"^/api/remote/terminal/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/ws$",
+    re.IGNORECASE,
+)
+
+
+class TerminalWebSocketMiddleware:
+    """WSGI middleware that bridges browser WebSocket connections to remote
+    terminal servers, bypassing Flask routing entirely.
+    """
+
+    def __init__(self, app):
+        self.app = app
+
+    def __call__(self, environ, start_response):
+        ws = environ.get("wsgi.websocket")
+        if ws is None:
+            return self.app(environ, start_response)
+
+        path = environ.get("PATH_INFO", "")
+        m = _WS_PATH_RE.match(path)
+        if m is None:
+            return self.app(environ, start_response)
+
+        terminal_id = m.group(1)
+
+        # Parse query string to extract token
+        query = environ.get("QUERY_STRING", "")
+        token = ""
+        for part in query.split("&"):
+            if part.startswith("token="):
+                token = part[6:]
+                break
+
+        self._handle_bridge(terminal_id, token, ws)
+        # The bridge consumed the connection; return empty response body
+        start_response("200 OK", [("Content-Type", "text/plain")])
+        return [b""]
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _handle_bridge(terminal_id: str, token: str, browser_ws) -> None:
+        from app.modules.workspace.terminal_store import terminal_info_store
+
+        found = terminal_info_store.find_by_terminal_id(terminal_id)
+        if not found:
+            logger.warning(
+                "Terminal WS (middleware) requested for unknown terminal %s",
+                terminal_id[:8],
+            )
+            try:
+                browser_ws.close(1011, "Terminal not available")
+            except Exception:
+                pass
+            return
+
+        machine_id, info = found
+        stored_token = info.get("token", "")
+        if not token or not stored_token or not hmac.compare_digest(token, stored_token):
+            logger.warning(
+                "Terminal WS (middleware) rejected invalid token for terminal %s",
+                terminal_id[:8],
+            )
+            try:
+                browser_ws.close(4001, "Authentication failed")
+            except Exception:
+                pass
+            return
+
+        remote_ws_url = info.get("original_ws_url") or info.get("ws_url", "")
+        remote_token = info.get("original_token", "")
+        if not remote_ws_url or remote_ws_url.startswith("/"):
+            logger.error(
+                "Terminal WS (middleware) missing remote URL for terminal %s",
+                terminal_id[:8],
+            )
+            try:
+                browser_ws.close(1011, "Remote terminal not available")
+            except Exception:
+                pass
+            return
+
+        try:
+            from app.modules.workspace.terminal_ws_bridge import bridge_terminal_websocket
+
+            logger.info(
+                "Bridging terminal %s for machine %s (middleware)",
+                terminal_id[:8],
+                machine_id[:8],
+            )
+            bridge_terminal_websocket(terminal_id, browser_ws, remote_ws_url, remote_token)
+        except Exception as e:
+            logger.error(
+                "Terminal WS (middleware) bridge failed for terminal %s: %s",
+                terminal_id[:8],
+                e,
+            )
+            try:
+                browser_ws.close(1011, "Remote terminal connection failed")
+            except Exception:
+                pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ gunicorn>=23.0.0,<24.0.0
 # WebSocket support
 gevent>=23.0.0,<24.0.0
 gevent-websocket>=0.10.1,<1.0.0
+werkzeug>=2.3,<3.0  # gevent-websocket 0.10.1 is incompatible with Werkzeug 3.x
 
 # Database
 sqlalchemy>=2.0.49,<3.0.0

--- a/tests/issues/557/test_terminal_ws_middleware.py
+++ b/tests/issues/557/test_terminal_ws_middleware.py
@@ -1,0 +1,230 @@
+"""Tests for TerminalWebSocketMiddleware (issue #557).
+
+The middleware intercepts WebSocket requests to
+/api/remote/terminal/<uuid>/ws at the WSGI layer, bypassing Flask routing.
+"""
+
+import uuid
+
+from app.modules.workspace.terminal_store import terminal_info_store
+from app.terminal_ws_middleware import _WS_PATH_RE, TerminalWebSocketMiddleware
+
+# ---------------------------------------------------------------------------
+# Path matching
+# ---------------------------------------------------------------------------
+
+
+class TestPathRegex:
+    def test_matches_valid_terminal_ws_path(self):
+        tid = str(uuid.uuid4())
+        m = _WS_PATH_RE.match(f"/api/remote/terminal/{tid}/ws")
+        assert m is not None
+        assert m.group(1) == tid
+
+    def test_rejects_non_terminal_path(self):
+        assert _WS_PATH_RE.match("/api/remote/agent/ws") is None
+
+    def test_rejects_missing_ws_suffix(self):
+        tid = str(uuid.uuid4())
+        assert _WS_PATH_RE.match(f"/api/remote/terminal/{tid}/status") is None
+
+    def test_rejects_invalid_uuid(self):
+        assert _WS_PATH_RE.match("/api/remote/terminal/not-a-uuid/ws") is None
+
+
+# ---------------------------------------------------------------------------
+# Middleware pass-through
+# ---------------------------------------------------------------------------
+
+
+class TestPassthrough:
+    def test_non_ws_environ_passes_through(self):
+        """Requests without wsgi.websocket are forwarded to the inner app."""
+        called = []
+
+        def inner_app(environ, start_response):
+            called.append(True)
+            start_response("200 OK", [("Content-Type", "text/plain")])
+            return [b"ok"]
+
+        mw = TerminalWebSocketMiddleware(inner_app)
+        environ = {"PATH_INFO": "/api/remote/terminal/irrelevant/ws", "QUERY_STRING": ""}
+        result = mw(environ, lambda s, h, e=None: [])
+        assert called == [True]
+        assert result == [b"ok"]
+
+    def test_non_terminal_ws_path_passes_through(self):
+        """WebSocket requests to other paths are forwarded to the inner app."""
+        called = []
+
+        def inner_app(environ, start_response):
+            called.append(True)
+            start_response("200 OK", [("Content-Type", "text/plain")])
+            return [b"ok"]
+
+        class FakeWS:
+            pass
+
+        mw = TerminalWebSocketMiddleware(inner_app)
+        environ = {
+            "PATH_INFO": "/api/remote/agent/ws",
+            "QUERY_STRING": "",
+            "wsgi.websocket": FakeWS(),
+        }
+        mw(environ, lambda s, h, e=None: [])
+        assert called == [True]
+
+    def test_ws_terminal_path_intercepted(self):
+        """WebSocket requests to terminal/<uuid>/ws are NOT forwarded to Flask."""
+        called = []
+
+        def inner_app(environ, start_response):
+            called.append(True)
+            return [b"should not be called"]
+
+        tid = str(uuid.uuid4())
+        machine_id = "mw-test-machine"
+
+        closed_with = {}
+
+        class FakeWS:
+            def close(self, code=1000, reason=""):
+                closed_with["code"] = code
+                closed_with["reason"] = reason
+
+        # Store terminal info so the middleware can find it
+        terminal_info_store.put(
+            machine_id,
+            tid,
+            {
+                "status": "running",
+                "token": "test-browser-token",
+                "original_ws_url": "ws://1.2.3.4:9999",
+                "original_token": "remote-token",
+            },
+        )
+
+        try:
+            mw = TerminalWebSocketMiddleware(inner_app)
+            environ = {
+                "PATH_INFO": f"/api/remote/terminal/{tid}/ws",
+                "QUERY_STRING": "token=test-browser-token",
+                "wsgi.websocket": FakeWS(),
+            }
+
+            status_holder = {}
+
+            def start_response(status, headers, exc_info=None):
+                status_holder["status"] = status
+
+            # The middleware will try to bridge, which will fail to connect
+            # to ws://1.2.3.4:9999.  We just verify it does NOT call inner_app.
+            mw(environ, start_response)
+            # inner_app should not have been called (middleware handled it)
+            assert called == []
+        finally:
+            terminal_info_store.pop(machine_id, tid)
+
+    def test_ws_terminal_unknown_terminal_closes_1011(self):
+        """Unknown terminal_id results in close code 1011."""
+        called = []
+
+        def inner_app(environ, start_response):
+            called.append(True)
+            return [b"nope"]
+
+        tid = str(uuid.uuid4())
+
+        closed_with = {}
+
+        class FakeWS:
+            def close(self, code=1000, reason=""):
+                closed_with["code"] = code
+                closed_with["reason"] = reason
+
+        mw = TerminalWebSocketMiddleware(inner_app)
+        environ = {
+            "PATH_INFO": f"/api/remote/terminal/{tid}/ws",
+            "QUERY_STRING": "token=whatever",
+            "wsgi.websocket": FakeWS(),
+        }
+
+        status_holder = {}
+
+        def start_response(status, headers, exc_info=None):
+            status_holder["status"] = status
+
+        mw(environ, start_response)
+        assert called == []
+        assert closed_with.get("code") == 1011
+
+    def test_ws_terminal_bad_token_closes_4001(self):
+        """Invalid token results in close code 4001."""
+        tid = str(uuid.uuid4())
+        machine_id = "mw-bad-token"
+
+        closed_with = {}
+
+        class FakeWS:
+            def close(self, code=1000, reason=""):
+                closed_with["code"] = code
+                closed_with["reason"] = reason
+
+        terminal_info_store.put(
+            machine_id,
+            tid,
+            {
+                "status": "running",
+                "token": "correct-token",
+                "original_ws_url": "ws://1.2.3.4:9999",
+                "original_token": "remote-token",
+            },
+        )
+
+        try:
+            mw = TerminalWebSocketMiddleware(lambda e, sr: [b"nope"])
+            environ = {
+                "PATH_INFO": f"/api/remote/terminal/{tid}/ws",
+                "QUERY_STRING": "token=wrong-token",
+                "wsgi.websocket": FakeWS(),
+            }
+
+            mw(environ, lambda s, h, e=None: [])
+            assert closed_with.get("code") == 4001
+        finally:
+            terminal_info_store.pop(machine_id, tid)
+
+    def test_ws_terminal_relative_url_closes_1011(self):
+        """Relative remote URL results in close code 1011."""
+        tid = str(uuid.uuid4())
+        machine_id = "mw-rel-url"
+
+        closed_with = {}
+
+        class FakeWS:
+            def close(self, code=1000, reason=""):
+                closed_with["code"] = code
+
+        terminal_info_store.put(
+            machine_id,
+            tid,
+            {
+                "status": "running",
+                "token": "tok",
+                "original_ws_url": "/relative/path",
+                "original_token": "remote-token",
+            },
+        )
+
+        try:
+            mw = TerminalWebSocketMiddleware(lambda e, sr: [b"nope"])
+            environ = {
+                "PATH_INFO": f"/api/remote/terminal/{tid}/ws",
+                "QUERY_STRING": "token=tok",
+                "wsgi.websocket": FakeWS(),
+            }
+
+            mw(environ, lambda s, h, e=None: [])
+            assert closed_with.get("code") == 1011
+        finally:
+            terminal_info_store.pop(machine_id, tid)


### PR DESCRIPTION
## Summary

- Route terminal WebSocket connections through a WSGI middleware instead of a Flask route, fixing persistent "Connection error" in web terminals
- Flask/Werkzeug cannot reliably route WebSocket-upgraded connections to view functions (first discovered in #147, re-introduced in #556)
- The new `TerminalWebSocketMiddleware` intercepts `/api/remote/terminal/<id>/ws` at the WSGI layer before Flask sees the request

## Root Cause

PR #556 used `@remote_bp.route("/terminal/<terminal_id>/ws")` to handle terminal WebSocket connections. However, gevent-websocket's `run_websocket()` calls Flask's WSGI app, but the `terminal_websocket` route handler **never fires**. Flask returns a `ClosingIterator` that is consumed immediately (should block during bridge), suggesting Werkzeug intercepts or mishandles the upgraded connection before routing completes.

Issue #147 first discovered this pattern: "直接在 Flask 路由中处理 WebSocket 会被 Werkzeug 拦截，必须在 WSGI 层面拦截"

## Changes

| File | Change |
|------|--------|
| `app/terminal_ws_middleware.py` | New WSGI middleware that intercepts terminal WebSocket requests |
| `app/__init__.py` | Wrap Flask app with `TerminalWebSocketMiddleware` |
| `app/routes/remote.py` | Simplify `terminal_websocket` route to HTTP-only fallback |
| `requirements.txt` | Add `werkzeug>=2.3,<3.0` constraint |
| `tests/issues/557/` | 10 tests for middleware path matching, passthrough, auth, and error handling |

## Test plan

- [x] `python3 -m pytest tests/issues/557/` — 10 tests pass
- [x] `python3 -m pytest tests/issues/555/` — 5 existing tests pass (no regression)
- [ ] Deploy to server and verify web terminal connects successfully
- [ ] Clean up debug logging from geventwebsocket handler.py on server

Closes #557

🤖 Generated with [Claude Code](https://claude.com/claude-code)