### PR TITLE
fix: resolve gevent subprocess.run crash when executing sudo commands (#487)

### DIFF
--- a/app/routes/fetch.py
+++ b/app/routes/fetch.py
@@ -49,11 +49,15 @@ def _run_subprocess(cmd, timeout=600, cwd=None):
     )
     try:
         stdout, stderr = proc.communicate(timeout=timeout)
-        return type('Result', (), {
-            'returncode': proc.returncode,
-            'stdout': stdout.decode('utf-8', errors='replace') if stdout else '',
-            'stderr': stderr.decode('utf-8', errors='replace') if stderr else ''
-        })()
+        return type(
+            "Result",
+            (),
+            {
+                "returncode": proc.returncode,
+                "stdout": stdout.decode("utf-8", errors="replace") if stdout else "",
+                "stderr": stderr.decode("utf-8", errors="replace") if stderr else "",
+            },
+        )()
     except subprocess.TimeoutExpired:
         proc.kill()
         proc.communicate()

--- a/app/routes/fetch.py
+++ b/app/routes/fetch.py
@@ -35,6 +35,31 @@ _fetch_status: dict[str, Any] = {
 _fetch_lock = threading.Lock()
 
 
+def _run_subprocess(cmd, timeout=600, cwd=None):
+    """Run subprocess using Popen to avoid gevent monkey-patch issues.
+
+    gevent monkey.patch_all() causes subprocess.run to crash (SIGSEGV)
+    when executing sudo commands. Using Popen + communicate() works correctly.
+    """
+    proc = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        cwd=cwd,
+    )
+    try:
+        stdout, stderr = proc.communicate(timeout=timeout)
+        return type('Result', (), {
+            'returncode': proc.returncode,
+            'stdout': stdout.decode('utf-8', errors='replace') if stdout else '',
+            'stderr': stderr.decode('utf-8', errors='replace') if stderr else ''
+        })()
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.communicate()
+        raise
+
+
 def run_fetch_scripts():
     """Run data fetch scripts in background."""
     global _fetch_status
@@ -73,13 +98,11 @@ def run_fetch_scripts():
             try:
                 config_path = os.path.expanduser("~/.open-ace/config.json")
 
-                result = subprocess.run(
+                result = _run_subprocess(
                     _build_cmd(
                         qwen_script,
                         ["--days", "1", "--multi-user", "--recent", "--config", config_path],
                     ),
-                    capture_output=True,
-                    text=True,
                     timeout=600,
                     cwd=project_root,
                 )
@@ -98,13 +121,11 @@ def run_fetch_scripts():
         claude_script = os.path.join(project_root, "scripts", "fetch_claude.py")
         if os.path.exists(claude_script):
             try:
-                result = subprocess.run(
+                result = _run_subprocess(
                     _build_cmd(
                         claude_script,
                         ["--days", "1", "--multi-user", "--recent", "--config", config_path],
                     ),
-                    capture_output=True,
-                    text=True,
                     timeout=600,
                     cwd=project_root,
                 )
@@ -123,7 +144,7 @@ def run_fetch_scripts():
         openclaw_script = os.path.join(project_root, "scripts", "fetch_openclaw.py")
         if os.path.exists(openclaw_script):
             try:
-                result = subprocess.run(
+                result = _run_subprocess(
                     _build_cmd(
                         openclaw_script,
                         [
@@ -137,8 +158,6 @@ def run_fetch_scripts():
                             config_path,
                         ],
                     ),
-                    capture_output=True,
-                    text=True,
                     timeout=600,
                     cwd=project_root,
                 )
@@ -157,13 +176,11 @@ def run_fetch_scripts():
         codex_script = os.path.join(project_root, "scripts", "fetch_codex.py")
         if os.path.exists(codex_script):
             try:
-                result = subprocess.run(
+                result = _run_subprocess(
                     _build_cmd(
                         codex_script,
                         ["--days", "1", "--multi-user", "--recent", "--config", config_path],
                     ),
-                    capture_output=True,
-                    text=True,
                     timeout=600,
                     cwd=project_root,
                 )


### PR DESCRIPTION
## 问题描述

Issue #487: Work 模式今日 Token/请求统计显示为 0，但实际有消耗。

## 问题根因

服务使用 gevent monkey.patch_all()，导致 subprocess.run 在调用 sudo 命令时崩溃（SIGSEGV）。fetch 脚本无法正常执行，数据无法写入数据库，页面显示 0。

## 修复方案

将 subprocess.run 改为 subprocess.Popen + communicate()，避免 gevent monkey-patch 导致的崩溃问题。

### 修改内容

1. 添加 _run_subprocess() 辅助函数，使用 Popen + communicate()
2. 替换所有 4 处 subprocess.run 调用

### 验证结果

在 node237 上验证成功：fetch 脚本正常执行，数据库连接正确。

Closes #487