### PR TITLE
Remove gevent-websocket dependency

### DIFF
--- a/app/modules/workspace/terminal_ws_bridge.py
+++ b/app/modules/workspace/terminal_ws_bridge.py
@@ -13,11 +13,6 @@ import gevent
 from websockets.exceptions import ConnectionClosed
 from websockets.sync.client import connect
 
-try:
-    from geventwebsocket.exceptions import WebSocketError
-except ImportError:
-    WebSocketError = Exception
-
 import app.ws_frame as ws_frame
 
 logger = logging.getLogger(__name__)
@@ -110,7 +105,7 @@ def bridge_terminal_websocket(
                                 "Ignoring unsupported browser terminal message type: %s",
                                 type(message).__name__,
                             )
-                except (ConnectionClosed, WebSocketError) as e:
+                except ConnectionClosed as e:
                     logger.info("Bridge B→R: connection error: %s", e)
                 except Exception as e:
                     logger.info("Browser to remote terminal bridge error: %s", e)
@@ -123,7 +118,7 @@ def bridge_terminal_websocket(
                     while True:
                         message = remote_ws.recv()
                         browser_ws.send(message)
-                except (ConnectionClosed, WebSocketError) as e:
+                except ConnectionClosed as e:
                     logger.info("Bridge R→B: connection error: %s", e)
                 except Exception as e:
                     logger.debug("Remote terminal to browser bridge error: %s", e)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ dependencies = [
     "filetype>=1.2.0,<2.0.0",
     "gunicorn>=23.0.0,<24.0.0",
     "gevent>=23.0.0,<24.0.0",
-    "gevent-websocket>=0.10.1,<1.0.0",
     "werkzeug>=2.3,<3.0.0",
     "sqlalchemy>=2.0.49,<3.0.0",
     "alembic>=1.16.5,<2.0.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,6 @@ gunicorn>=23.0.0,<24.0.0
 
 # WebSocket support
 gevent>=23.0.0,<24.0.0
-gevent-websocket>=0.10.1,<1.0.0
 werkzeug>=2.3,<3.0.0
 
 # Database

--- a/web.py
+++ b/web.py
@@ -98,14 +98,8 @@ if __name__ == "__main__":
 
         server_kwargs["handler_class"] = TerminalWSHandler
     except ImportError:
-        print("WARNING: terminal_ws_handler unavailable; " "falling back to geventwebsocket")
-        try:
-            from geventwebsocket.handler import WebSocketHandler
-
-            server_kwargs["handler_class"] = WebSocketHandler
-        except ImportError:
-            server_kwargs["handler_class"] = WSGIHandler
-            print("WARNING: gevent-websocket is not installed; " "web terminal WS is disabled")
+        server_kwargs["handler_class"] = WSGIHandler
+        print("WARNING: terminal_ws_handler unavailable; web terminal WS is disabled")
 
     server = WSGIServer((WEB_HOST, WEB_PORT), app, **server_kwargs)
 


### PR DESCRIPTION
## Summary
- Remove gevent-websocket from code, requirements.txt, and pyproject.toml
- PR #560 bypasses geventwebsocket entirely with raw socket I/O, so this dependency is no longer needed
- Cleanup: remove fallback import in web.py, remove WebSocketError catch in terminal_ws_bridge.py

## Test plan
- [x] 78 related tests pass (559, 557, 555)
- [x] No remaining code imports of geventwebsocket

🤖 Generated with [Claude Code](https://claude.com/claude-code)