### PR TITLE
Fix WS handshake: echo Sec-WebSocket-Protocol in 101 response

### DIFF
--- a/app/ws_frame.py
+++ b/app/ws_frame.py
@@ -45,14 +45,17 @@ def perform_handshake(environ: dict, sock) -> None:
         raise ValueError("Missing Sec-WebSocket-Key")
 
     accept = _compute_accept_key(key)
-    response = (
+    headers = (
         "HTTP/1.1 101 Switching Protocols\r\n"
         "Upgrade: websocket\r\n"
         "Connection: Upgrade\r\n"
         f"Sec-WebSocket-Accept: {accept}\r\n"
-        "\r\n"
     )
-    sock.sendall(response.encode())
+    protocol = environ.get("HTTP_SEC_WEBSOCKET_PROTOCOL", "")
+    if protocol:
+        headers += f"Sec-WebSocket-Protocol: {protocol}\r\n"
+    headers += "\r\n"
+    sock.sendall(headers.encode())
 
 
 def _recv_exactly(sock, n: int) -> bytes:

--- a/tests/issues/559/test_ws_frame.py
+++ b/tests/issues/559/test_ws_frame.py
@@ -119,6 +119,27 @@ class TestPerformHandshake:
         assert f"Sec-WebSocket-Accept: {accept}\r\n" in response
         assert response.endswith("\r\n\r\n")
 
+    def test_includes_protocol_header(self):
+        sock = FakeSocket()
+        key = "dGhlIHNhbXBsZSBub25jZQ=="
+        environ = {
+            "HTTP_SEC_WEBSOCKET_KEY": key,
+            "HTTP_SEC_WEBSOCKET_PROTOCOL": "binary",
+        }
+        ws_frame.perform_handshake(environ, sock)
+
+        response = sock.all_sent.decode()
+        assert "Sec-WebSocket-Protocol: binary\r\n" in response
+
+    def test_no_protocol_header_when_not_requested(self):
+        sock = FakeSocket()
+        key = "dGhlIHNhbXBsZSBub25jZQ=="
+        environ = {"HTTP_SEC_WEBSOCKET_KEY": key}
+        ws_frame.perform_handshake(environ, sock)
+
+        response = sock.all_sent.decode()
+        assert "Sec-WebSocket-Protocol" not in response
+
     def test_missing_key_raises(self):
         sock = FakeSocket()
         with pytest.raises(ValueError, match="Missing Sec-WebSocket-Key"):


### PR DESCRIPTION
## Summary
- The browser xterm.js client requests subprotocol `"binary"` via `Sec-WebSocket-Protocol` header
- RFC 6455 requires the server to include the selected protocol in the 101 response
- Without this header, the browser immediately closes the WebSocket connection
- This was the root cause of web terminal disconnects after deploying PR #560

## Test plan
- [x] 47 ws_frame unit tests pass (2 new: protocol header present/absent)
- [x] E2E test passes (browser → TerminalWSHandler → upstream terminal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)