### PR TITLE
fix: 配额管理页面进度条颜色计算错误及显示格式不一致 (#471)

### DIFF
--- a/frontend/src/components/features/management/QuotaAlerts.tsx
+++ b/frontend/src/components/features/management/QuotaAlerts.tsx
@@ -329,7 +329,9 @@ export const QuotaAlerts: React.FC = () => {
               );
               const monthlyTokenPercentage = getUsagePercentage(
                 user.tokens_used_month,
-                user.monthly_token_quota ? user.monthly_token_quota * TOKEN_QUOTA_MULTIPLIER : undefined
+                user.monthly_token_quota
+                  ? user.monthly_token_quota * TOKEN_QUOTA_MULTIPLIER
+                  : undefined
               );
               const dailyRequestPercentage = getUsagePercentage(
                 user.requests_today,

--- a/frontend/src/components/features/management/QuotaAlerts.tsx
+++ b/frontend/src/components/features/management/QuotaAlerts.tsx
@@ -32,9 +32,10 @@ import { formatTokens, formatDateTime, formatNumber } from '@/utils';
 const TOKEN_QUOTA_MULTIPLIER = 1_000_000;
 
 // Format quota value (stored in M units) to display string
+// Keep M unit format for consistency with edit modal
 const formatQuotaTokens = (quota: number | undefined | null): string => {
   if (!quota) return '∞';
-  return formatTokens(quota * TOKEN_QUOTA_MULTIPLIER);
+  return `${quota.toFixed(2)}M`;
 };
 import { alertsApi, type Alert, type NotificationPreferences } from '@/api';
 import type { QuotaUsage, UpdateQuotaRequest } from '@/api';
@@ -324,11 +325,11 @@ export const QuotaAlerts: React.FC = () => {
             {quotaData.map((user) => {
               const dailyTokenPercentage = getUsagePercentage(
                 user.tokens_used_today,
-                user.daily_token_quota
+                user.daily_token_quota ? user.daily_token_quota * TOKEN_QUOTA_MULTIPLIER : undefined
               );
               const monthlyTokenPercentage = getUsagePercentage(
                 user.tokens_used_month,
-                user.monthly_token_quota
+                user.monthly_token_quota ? user.monthly_token_quota * TOKEN_QUOTA_MULTIPLIER : undefined
               );
               const dailyRequestPercentage = getUsagePercentage(
                 user.requests_today,

--- a/frontend/src/components/features/management/QuotaManagement.tsx
+++ b/frontend/src/components/features/management/QuotaManagement.tsx
@@ -123,7 +123,9 @@ export const QuotaManagement: React.FC = () => {
             );
             const monthlyTokenPercentage = getUsagePercentage(
               user.tokens_used_month,
-              user.monthly_token_quota ? user.monthly_token_quota * TOKEN_QUOTA_MULTIPLIER : undefined
+              user.monthly_token_quota
+                ? user.monthly_token_quota * TOKEN_QUOTA_MULTIPLIER
+                : undefined
             );
 
             return (

--- a/frontend/src/components/features/management/QuotaManagement.tsx
+++ b/frontend/src/components/features/management/QuotaManagement.tsx
@@ -24,9 +24,10 @@ import type { QuotaUsage, UpdateQuotaRequest } from '@/api';
 const TOKEN_QUOTA_MULTIPLIER = 1_000_000;
 
 // Format quota value (stored in M units) to display string
+// Keep M unit format for consistency with edit modal
 const formatQuotaTokens = (quota: number | undefined | null): string => {
   if (!quota) return '∞';
-  return formatTokens(quota * TOKEN_QUOTA_MULTIPLIER);
+  return `${quota.toFixed(2)}M`;
 };
 
 export const QuotaManagement: React.FC = () => {
@@ -118,11 +119,11 @@ export const QuotaManagement: React.FC = () => {
           {quotaData.map((user) => {
             const dailyTokenPercentage = getUsagePercentage(
               user.tokens_used_today,
-              user.daily_token_quota
+              user.daily_token_quota ? user.daily_token_quota * TOKEN_QUOTA_MULTIPLIER : undefined
             );
             const monthlyTokenPercentage = getUsagePercentage(
               user.tokens_used_month,
-              user.monthly_token_quota
+              user.monthly_token_quota ? user.monthly_token_quota * TOKEN_QUOTA_MULTIPLIER : undefined
             );
 
             return (


### PR DESCRIPTION
## 问题描述

Fixes #471

### 问题1：进度条颜色计算错误

配额以百万单位（M）存储，但前端计算百分比时直接使用原始值相除，导致计算结果错误：

- 数据库值 `daily_token_quota = 500` 表示 500M tokens
- 使用量 `tokens_used_today = 76,552`
- 错误计算：`76,552 / 500 = 153%` → 显示红色
- 正确计算：`76,552 / (500 × 1,000,000) = 0.015%` → 显示绿色

### 问题2：配额显示格式不一致

- 每日配额显示：`500.00M`（与编辑框一致）
- 每月配额显示：`15.00B`（编辑框显示 `15000M`，不一致）

根因：`formatTokens` 函数自动选择单位，导致较大配额值被转换为更大单位。

## 修复内容

### 1. 百分比计算修复

```javascript
const dailyTokenPercentage = getUsagePercentage(
  user.tokens_used_today,
  user.daily_token_quota ? user.daily_token_quota * TOKEN_QUOTA_MULTIPLIER : undefined
);
```

### 2. 显示格式修复

```javascript
const formatQuotaTokens = (quota) => {
  if (!quota) return '∞';
  return `${quota.toFixed(2)}M`;
};
```

## 修改文件

- `frontend/src/components/features/management/QuotaAlerts.tsx`
- `frontend/src/components/features/management/QuotaManagement.tsx`

## 验证结果

✅ 进度条颜色：显示绿色（正确）
✅ 配额显示格式：与编辑框一致（500.00M / 15000.00M）
✅ 在 node237 测试环境验证通过