### PR TITLE
fix: 审计中心登录模式图表时区显示和统计数据不准确问题 (#470)

### DIFF
--- a/app/modules/compliance/audit.py
+++ b/app/modules/compliance/audit.py
@@ -97,6 +97,13 @@ class AuditAnalyzer:
                 hour = log.timestamp.hour
                 hourly_activity[hour] += 1
 
+        # Analyze login by hour of day (for "Login Pattern" chart)
+        login_hourly_activity: defaultdict[int, int] = defaultdict(int)
+        for log in logs:
+            if log.timestamp and log.action == "login":
+                hour = log.timestamp.hour
+                login_hourly_activity[hour] += 1
+
         # Analyze by day of week
         daily_activity: defaultdict[int, int] = defaultdict(int)
         for log in logs:
@@ -122,6 +129,7 @@ class AuditAnalyzer:
             },
             "total_events": len(logs),
             "hourly_distribution": dict(sorted(hourly_activity.items())),
+            "login_hourly_distribution": dict(sorted(login_hourly_activity.items())),
             "daily_distribution": dict(sorted(daily_activity.items())),
             "action_distribution": dict(sorted(action_distribution.items(), key=lambda x: -x[1])),
             "unique_users": len(user_activity),

--- a/frontend/src/api/compliance.ts
+++ b/frontend/src/api/compliance.ts
@@ -37,6 +37,7 @@ export interface AuditPattern {
   period: { start: string; end: string };
   total_events: number;
   hourly_distribution: Record<string, number>;
+  login_hourly_distribution: Record<string, number>;
   daily_distribution: Record<string, number>;
   action_distribution: Record<string, number>;
   unique_users: number;

--- a/frontend/src/components/features/compliance/AuditAnalysis.tsx
+++ b/frontend/src/components/features/compliance/AuditAnalysis.tsx
@@ -86,12 +86,22 @@ export const AuditAnalysis: React.FC = () => {
   }, [selectedUserId, days]);
 
   // Prepare chart data
+  // Helper function to convert UTC hour to local hour
+  const utcToLocalHour = (utcHour: number): number => {
+    const offset = -new Date().getTimezoneOffset() / 60; // getTimezoneOffset returns minutes, negative for ahead of UTC
+    return (utcHour + offset + 24) % 24;
+  };
+
   const loginPatternData = useMemo(() => {
-    if (!patterns?.hourly_distribution) return { labels: [], data: [] };
-    const entries = Object.entries(patterns.hourly_distribution);
+    if (!patterns?.login_hourly_distribution) return { labels: [], data: [] };
+    const entries = Object.entries(patterns.login_hourly_distribution);
+    // Convert UTC hours to local hours for display
+    const localEntries = entries.map(([hour, count]) => [utcToLocalHour(parseInt(hour)), count]);
+    // Sort by local hour
+    const sortedEntries = localEntries.sort((a, b) => a[0] - b[0]);
     return {
-      labels: entries.map(([hour]) => `${hour}:00`),
-      data: entries.map(([, count]) => count),
+      labels: sortedEntries.map(([hour]) => `${hour}:00`),
+      data: sortedEntries.map(([, count]) => count),
     };
   }, [patterns]);
 

--- a/frontend/src/components/features/management/AuditCenter.tsx
+++ b/frontend/src/components/features/management/AuditCenter.tsx
@@ -197,12 +197,22 @@ export const AuditCenter: React.FC = () => {
   };
 
   // --- Analysis Chart Data ---
+  // Helper function to convert UTC hour to local hour
+  const utcToLocalHour = (utcHour: number): number => {
+    const offset = -new Date().getTimezoneOffset() / 60; // getTimezoneOffset returns minutes, negative for ahead of UTC
+    return (utcHour + offset + 24) % 24;
+  };
+
   const loginPatternData = useMemo(() => {
-    if (!patterns?.hourly_distribution) return { labels: [], data: [] };
-    const entries = Object.entries(patterns.hourly_distribution);
+    if (!patterns?.login_hourly_distribution) return { labels: [], data: [] };
+    const entries = Object.entries(patterns.login_hourly_distribution);
+    // Convert UTC hours to local hours for display
+    const localEntries = entries.map(([hour, count]) => [utcToLocalHour(parseInt(hour)), count]);
+    // Sort by local hour
+    const sortedEntries = localEntries.sort((a, b) => a[0] - b[0]);
     return {
-      labels: entries.map(([hour]) => `${hour}:00`),
-      data: entries.map(([, count]) => count),
+      labels: sortedEntries.map(([hour]) => `${hour}:00`),
+      data: sortedEntries.map(([, count]) => count),
     };
   }, [patterns]);
 


### PR DESCRIPTION
## 问题描述

Issue #470 描述了审计中心「登录模式」图表的两个问题：

### 问题 1：时区显示问题
图表显示的时间为 UTC 时间（如 0:00、22:00），而非用户本地时间。对于中国用户（UTC+8），显示 `0:00` 实际是北京时间早上 `8:00`。

### 问题 2：统计数据不准确
图表标题为「登录模式」，数据标签为「登录次数」，但实际统计的是所有审计操作的总次数，包含 login、logout、create、update、delete、view 等所有操作类型。

---

## 修复方案

### 问题 1 修复：时区转换
- 前端新增 `utcToLocalHour()` 辅助函数，将 UTC 小时转换为本地小时显示
- 使用 `new Date().getTimezoneOffset() / -60` 获取本地时区偏移

### 问题 2 修复：数据准确性
- 后端新增 `login_hourly_distribution` 字段，仅统计 `action='login'` 的审计日志
- 前端改用 `login_hourly_distribution` 数据源显示"登录模式"图表

---

## 修改文件清单

| 文件 | 修改内容 |
|------|---------|
| `app/modules/compliance/audit.py` | 新增 `login_hourly_distribution` 字段统计逻辑 |
| `frontend/src/api/compliance.ts` | API 类型定义新增 `login_hourly_distribution` 字段 |
| `frontend/src/components/features/management/AuditCenter.tsx` | 使用新字段 + UTC 时区转换 |
| `frontend/src/components/features/compliance/AuditAnalysis.tsx` | 使用新字段 + UTC 时区转换 |

---

## 验证结果

在 node237 上完成验证：
- 代码部署成功，前端构建无错误
- 服务正常运行
- API 返回数据包含新字段 `login_hourly_distribution`

Closes #470