### PR TITLE
Unify Claude Code install command to use npm

### DIFF
--- a/remote-agent/terminal_menu.py
+++ b/remote-agent/terminal_menu.py
@@ -24,7 +24,7 @@ TOOLS = [
         "name": "Claude Code",
         "cli": "claude",
         "cmd": "claude --bare",
-        "install_cmd": "curl -fsSL https://claude.ai/install.sh | bash",
+        "install_cmd": "npm install -g @anthropic-ai/claude-code@latest",
         "env_key": "ANTHROPIC_API_KEY",
     },
     {


### PR DESCRIPTION
## Summary
- Change Claude Code install command in terminal menu from `curl -fsSL https://claude.ai/install.sh | bash` to `npm install -g @anthropic-ai/claude-code@latest`
- Unifies with other install paths (install.sh, cli_adapters) that already use npm

## Test plan
- [ ] Verify terminal menu shows "Install Claude Code" and runs `npm install -g @anthropic-ai/claude-code@latest` when selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)