### PR TITLE
Wire menu CLI settings through Codex, Qwen, and Claude

### DIFF
--- a/app/modules/workspace/api_key_proxy.py
+++ b/app/modules/workspace/api_key_proxy.py
@@ -19,6 +19,11 @@ from typing import Any, Optional, Union, cast
 from app.repositories.database import DB_PATH, get_database_url, is_postgresql
 from app.utils.tool_names import normalize_tool_name
 
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python < 3.11
+    import tomli as tomllib
+
 logger = logging.getLogger(__name__)
 
 # Environment variable keys that contain API credentials.
@@ -51,6 +56,21 @@ def _collect_dynamic_env_keys(settings: dict[str, Any]) -> set[str]:
                 if isinstance(model, dict) and isinstance(model.get("envKey"), str):
                     dynamic.add(model["envKey"])
     return dynamic
+
+
+def _parse_codex_settings(raw_settings: Any) -> dict[str, Any]:
+    """Parse stored Codex settings from TOML string or dict form."""
+    if isinstance(raw_settings, dict):
+        return raw_settings.copy()
+    if isinstance(raw_settings, str):
+        try:
+            parsed = tomllib.loads(raw_settings)
+        except tomllib.TOMLDecodeError as exc:
+            logger.warning("Invalid Codex settings TOML in api_key_store: %s", exc)
+            return {}
+        if isinstance(parsed, dict):
+            return parsed
+    return {}
 
 
 def _param() -> str:
@@ -486,7 +506,7 @@ class APIKeyProxyService:
     def _build_cli_settings_for_tool(
         self,
         tool_name: str,
-        base_settings: dict,
+        base_settings: Any,
     ) -> dict[str, Any]:
         """
         Build CLI settings containing only non-sensitive configuration.
@@ -501,7 +521,13 @@ class APIKeyProxyService:
         Returns:
             Settings dict with non-sensitive config only.
         """
-        settings = base_settings.copy()
+        canonical_tool = normalize_tool_name(tool_name)
+        if canonical_tool == "codex":
+            settings = _parse_codex_settings(base_settings)
+        elif isinstance(base_settings, dict):
+            settings = base_settings.copy()
+        else:
+            settings = {}
         all_sensitive = _SENSITIVE_ENV_KEYS | _collect_dynamic_env_keys(settings)
 
         # Strip any API credential fields that the user may have

--- a/app/modules/workspace/api_key_proxy.py
+++ b/app/modules/workspace/api_key_proxy.py
@@ -58,7 +58,7 @@ def _collect_dynamic_env_keys(settings: dict[str, Any]) -> set[str]:
     return dynamic
 
 
-def _parse_codex_settings(raw_settings: Any) -> dict[str, Any]:
+def _parse_codex_settings(raw_settings: Any, *, raise_on_error: bool = False) -> dict[str, Any]:
     """Parse stored Codex settings from TOML string or dict form."""
     if isinstance(raw_settings, dict):
         return raw_settings.copy()
@@ -66,11 +66,38 @@ def _parse_codex_settings(raw_settings: Any) -> dict[str, Any]:
         try:
             parsed = tomllib.loads(raw_settings)
         except tomllib.TOMLDecodeError as exc:
+            if raise_on_error:
+                raise ValueError(f"Invalid Codex settings TOML: {exc}") from exc
             logger.warning("Invalid Codex settings TOML in api_key_store: %s", exc)
             return {}
         if isinstance(parsed, dict):
             return parsed
     return {}
+
+
+def validate_cli_settings_payload(raw_cli_settings: Optional[str]) -> Optional[str]:
+    """Validate CLI settings payload before storing it."""
+    if not raw_cli_settings:
+        return None
+
+    try:
+        parsed = json.loads(raw_cli_settings)
+    except json.JSONDecodeError as exc:
+        return f"cli_settings must be valid JSON: {exc}"
+
+    if not isinstance(parsed, dict):
+        return "cli_settings must be a JSON object"
+
+    codex_settings = parsed.get("codex-cli")
+    if codex_settings is not None:
+        if not isinstance(codex_settings, (str, dict)):
+            return "codex-cli settings must be a TOML string or object"
+        try:
+            _parse_codex_settings(codex_settings, raise_on_error=True)
+        except ValueError as exc:
+            return str(exc)
+
+    return None
 
 
 def _param() -> str:

--- a/app/modules/workspace/terminal_ws_bridge.py
+++ b/app/modules/workspace/terminal_ws_bridge.py
@@ -87,7 +87,12 @@ def bridge_terminal_websocket(
     _register_bridge(state)
 
     try:
-        with connect(upstream_url, subprotocols=["binary"], close_timeout=5) as remote_ws:
+        with connect(
+            upstream_url,
+            subprotocols=["binary"],
+            close_timeout=5,
+            proxy=None,
+        ) as remote_ws:
             state.remote_ws = remote_ws
             logger.info("Connected backend bridge to remote terminal: %s", remote_ws_url)
 
@@ -149,7 +154,12 @@ def bridge_terminal_websocket_raw(
     _register_bridge(state)
 
     try:
-        with connect(upstream_url, subprotocols=["binary"], close_timeout=5) as remote_ws:
+        with connect(
+            upstream_url,
+            subprotocols=["binary"],
+            close_timeout=5,
+            proxy=None,
+        ) as remote_ws:
             state.remote_ws = remote_ws
             logger.info("Connected raw bridge to remote terminal: %s", remote_ws_url)
 

--- a/app/routes/remote.py
+++ b/app/routes/remote.py
@@ -1332,9 +1332,9 @@ def start_terminal():
     proxy_url = f"{backend_url}/api/remote/llm-proxy"
     logger.info("start_terminal: backend_url=%s, proxy_url=%s", backend_url, proxy_url)
 
-    # Get CLI settings for both Claude Code and Qwen Code
+    # Get CLI settings for supported menu tools
     cli_settings = {}
-    for tool_name in ["claude-code", "qwen-code"]:
+    for tool_name in ["claude-code", "qwen-code", "codex-cli"]:
         tool_settings = api_proxy.get_cli_settings_for_tool(tenant_id, tool_name)
         if tool_settings:
             cli_settings[tool_name] = tool_settings
@@ -1438,6 +1438,12 @@ def start_cli_terminal():
     backend_url = agent_mgr.get_backend_url(request.host_url)
     proxy_url = f"{backend_url}/api/remote/llm-proxy"
 
+    cli_settings = {}
+    for tool_name in ["claude-code", "qwen-code", "codex-cli"]:
+        tool_settings = api_proxy.get_cli_settings_for_tool(tenant_id, tool_name)
+        if tool_settings:
+            cli_settings[tool_name] = tool_settings
+
     logger.info(
         "Created CLI terminal session %s for user %s on machine %s",
         terminal_id[:8],
@@ -1455,6 +1461,7 @@ def start_cli_terminal():
                 "status": "running",
                 "source": source,
                 "proxy_url": proxy_url,
+                "cli_settings": cli_settings,
                 "tokens": {
                     "anthropic": anthropic_token,
                     "openai": openai_token,

--- a/app/routes/remote.py
+++ b/app/routes/remote.py
@@ -32,6 +32,8 @@ logger = logging.getLogger(__name__)
 MAX_RAW_CONTENT_LENGTH = 100000
 MAX_MESSAGE_LENGTH = 50000
 
+_CLI_SETTINGS_TOOLS = ["claude-code", "qwen-code", "codex-cli"]
+
 remote_bp = Blueprint("remote", __name__)
 
 
@@ -1345,7 +1347,7 @@ def start_terminal():
 
     # Get CLI settings for supported menu tools
     cli_settings = {}
-    for tool_name in ["claude-code", "qwen-code", "codex-cli"]:
+    for tool_name in _CLI_SETTINGS_TOOLS:
         tool_settings = api_proxy.get_cli_settings_for_tool(tenant_id, tool_name)
         if tool_settings:
             cli_settings[tool_name] = tool_settings
@@ -1450,7 +1452,7 @@ def start_cli_terminal():
     proxy_url = f"{backend_url}/api/remote/llm-proxy"
 
     cli_settings = {}
-    for tool_name in ["claude-code", "qwen-code", "codex-cli"]:
+    for tool_name in _CLI_SETTINGS_TOOLS:
         tool_settings = api_proxy.get_cli_settings_for_tool(tenant_id, tool_name)
         if tool_settings:
             cli_settings[tool_name] = tool_settings

--- a/app/routes/remote.py
+++ b/app/routes/remote.py
@@ -19,7 +19,10 @@ import uuid
 from flask import Blueprint, Response, g, jsonify, request, stream_with_context
 
 from app.auth.decorators import _extract_token, _load_user_from_token, admin_required
-from app.modules.workspace.api_key_proxy import get_api_key_proxy_service
+from app.modules.workspace.api_key_proxy import (
+    get_api_key_proxy_service,
+    validate_cli_settings_payload,
+)
 from app.modules.workspace.remote_agent_manager import get_remote_agent_manager
 from app.modules.workspace.remote_session_manager import get_remote_session_manager
 from app.modules.workspace.terminal_store import terminal_info_store
@@ -342,6 +345,10 @@ def store_api_key():
     if not provider or not key_name or not api_key:
         return jsonify({"error": "provider, key_name, and api_key are required"}), 400
 
+    validation_error = validate_cli_settings_payload(cli_settings)
+    if validation_error:
+        return jsonify({"error": validation_error}), 400
+
     api_proxy = get_api_key_proxy_service()
     result = api_proxy.store_api_key(
         tenant_id=tenant_id,
@@ -373,6 +380,10 @@ def update_api_key(key_id):
     if is_active is not None and not isinstance(is_active, bool):
         return jsonify({"error": "is_active must be a boolean"}), 400
     tenant_id = int(data.get("tenant_id", 1))
+
+    validation_error = validate_cli_settings_payload(cli_settings)
+    if validation_error:
+        return jsonify({"error": validation_error}), 400
 
     api_proxy = get_api_key_proxy_service()
     success = api_proxy.update_api_key_by_id(

--- a/frontend/src/components/features/management/APIKeyManagement.tsx
+++ b/frontend/src/components/features/management/APIKeyManagement.tsx
@@ -68,6 +68,13 @@ const defaultQwenSettings = `{
   }
 }`;
 
+const defaultCodexSettings = `model_provider = "openace"
+model = "qwen3.7-max"
+
+[model_providers.openace]
+name = "Open ACE Proxy"
+wire_api = "responses"`;
+
 export const APIKeyManagement: React.FC = () => {
   const language = useLanguage();
   const { data: keysData, isLoading, isError, error, refetch } = useApiKeys();
@@ -111,7 +118,45 @@ export const APIKeyManagement: React.FC = () => {
     cli_tools: [] as string[],
     claude_settings: '',
     qwen_settings: '',
+    codex_settings: '',
   });
+
+  const stringifyCodexSettings = (value: unknown): string => {
+    if (typeof value === 'string') return value;
+    if (!value || typeof value !== 'object' || Array.isArray(value)) return '';
+
+    const formatKey = (key: string) =>
+      /^[A-Za-z0-9_-]+$/.test(key) ? key : `"${key.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+
+    const formatValue = (input: unknown): string => {
+      if (typeof input === 'string') return `"${input.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+      if (typeof input === 'boolean') return input ? 'true' : 'false';
+      if (typeof input === 'number') return String(input);
+      if (Array.isArray(input)) return `[${input.map((item) => formatValue(item)).join(', ')}]`;
+      return `"${String(input)}"`;
+    };
+
+    const emitTable = (obj: Record<string, unknown>, path: string[] = []): string[] => {
+      const lines: string[] = [];
+      const scalarEntries = Object.entries(obj).filter(([, val]) => !(val && typeof val === 'object' && !Array.isArray(val)));
+      const tableEntries = Object.entries(obj).filter(([, val]) => val && typeof val === 'object' && !Array.isArray(val));
+
+      if (path.length) {
+        lines.push(`[${path.map(formatKey).join('.')}]`);
+      }
+      for (const [key, val] of scalarEntries) {
+        lines.push(`${formatKey(key)} = ${formatValue(val)}`);
+      }
+      if (scalarEntries.length && tableEntries.length) lines.push('');
+      tableEntries.forEach(([key, val], index) => {
+        lines.push(...emitTable(val as Record<string, unknown>, [...path, key]));
+        if (index !== tableEntries.length - 1) lines.push('');
+      });
+      return lines;
+    };
+
+    return emitTable(value as Record<string, unknown>).join('\n');
+  };
 
   const handleOpenAdd = () => {
     setFormError(null);
@@ -123,6 +168,7 @@ export const APIKeyManagement: React.FC = () => {
       cli_tools: [],
       claude_settings: '',
       qwen_settings: '',
+      codex_settings: '',
     });
     setShowAddDialog(true);
   };
@@ -135,6 +181,7 @@ export const APIKeyManagement: React.FC = () => {
     let cliTools: string[] = [];
     let claudeSettings = '';
     let qwenSettings = '';
+    let codexSettings = '';
 
     if (key.cli_tools) {
       try {
@@ -153,6 +200,9 @@ export const APIKeyManagement: React.FC = () => {
         if (settings['qwen-code']) {
           qwenSettings = JSON.stringify(settings['qwen-code'], null, 2);
         }
+        if (settings['codex-cli']) {
+          codexSettings = stringifyCodexSettings(settings['codex-cli']);
+        }
       } catch {
         // Ignore parse errors
       }
@@ -166,6 +216,7 @@ export const APIKeyManagement: React.FC = () => {
       cli_tools: cliTools,
       claude_settings: claudeSettings,
       qwen_settings: qwenSettings,
+      codex_settings: codexSettings,
     });
     setShowEditDialog(true);
   };
@@ -181,6 +232,7 @@ export const APIKeyManagement: React.FC = () => {
       // Add tool and set default settings if empty
       let newClaudeSettings = formData.claude_settings;
       let newQwenSettings = formData.qwen_settings;
+      let newCodexSettings = formData.codex_settings;
 
       if (tool === 'claude-code' && !formData.claude_settings) {
         newClaudeSettings = defaultClaudeSettings;
@@ -188,12 +240,16 @@ export const APIKeyManagement: React.FC = () => {
       if (tool === 'qwen-code' && !formData.qwen_settings) {
         newQwenSettings = defaultQwenSettings;
       }
+      if (tool === 'codex-cli' && !formData.codex_settings) {
+        newCodexSettings = defaultCodexSettings;
+      }
 
       setFormData({
         ...formData,
         cli_tools: [...currentTools, tool],
         claude_settings: newClaudeSettings,
         qwen_settings: newQwenSettings,
+        codex_settings: newCodexSettings,
       });
     }
   };
@@ -284,6 +340,9 @@ export const APIKeyManagement: React.FC = () => {
       } catch {
         // Skip invalid JSON
       }
+    }
+    if (formData.cli_tools.includes('codex-cli') && formData.codex_settings.trim()) {
+      settings['codex-cli'] = formData.codex_settings;
     }
     return JSON.stringify(settings);
   };
@@ -606,6 +665,20 @@ export const APIKeyManagement: React.FC = () => {
             <small className="text-muted">{t('qwenCodeSettingsHint', language)}</small>
           </div>
         )}
+
+        {formData.cli_tools.includes('codex-cli') && (
+          <div className="mb-3">
+            <label className="form-label">{t('codexSettings', language)}</label>
+            <textarea
+              className="form-control"
+              rows={8}
+              value={formData.codex_settings}
+              onChange={(e) => setFormData({ ...formData, codex_settings: e.target.value })}
+              placeholder={defaultCodexSettings}
+            />
+            <small className="text-muted">{t('codexSettingsHint', language)}</small>
+          </div>
+        )}
       </Modal>
 
       {/* Edit API Key Dialog */}
@@ -699,6 +772,19 @@ export const APIKeyManagement: React.FC = () => {
               onChange={(e) => setFormData({ ...formData, qwen_settings: e.target.value })}
             />
             <small className="text-muted">{t('qwenCodeSettingsHint', language)}</small>
+          </div>
+        )}
+
+        {formData.cli_tools.includes('codex-cli') && (
+          <div className="mb-3">
+            <label className="form-label">{t('codexSettings', language)}</label>
+            <textarea
+              className="form-control"
+              rows={8}
+              value={formData.codex_settings}
+              onChange={(e) => setFormData({ ...formData, codex_settings: e.target.value })}
+            />
+            <small className="text-muted">{t('codexSettingsHint', language)}</small>
           </div>
         )}
       </Modal>

--- a/frontend/src/components/features/management/APIKeyManagement.tsx
+++ b/frontend/src/components/features/management/APIKeyManagement.tsx
@@ -342,6 +342,8 @@ export const APIKeyManagement: React.FC = () => {
       }
     }
     if (formData.cli_tools.includes('codex-cli') && formData.codex_settings.trim()) {
+      // Codex uses TOML as its native config format, so we preserve the
+      // raw editor text here and let the backend validate/parse it.
       settings['codex-cli'] = formData.codex_settings;
     }
     return JSON.stringify(settings);

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -792,7 +792,6 @@ const translations: Record<Language, Translations> = {
       'Configure non-sensitive Codex settings only (model, sandbox, etc.). Do NOT include API keys — they are injected via environment variables automatically.',
     claudeSettingsInvalid: 'Claude Code settings JSON is invalid',
     qwenSettingsInvalid: 'Qwen Code settings JSON is invalid',
-    codexSettingsInvalid: 'Codex settings are invalid',
     providerCannotChange: 'Provider cannot be changed',
 
     // Help Documents
@@ -1610,7 +1609,6 @@ const translations: Record<Language, Translations> = {
       '仅配置非敏感 Codex 设置（model、sandbox 等）。请勿填写 API Key — 系统会通过环境变量自动注入。',
     claudeSettingsInvalid: 'Claude Code 设置 JSON 无效',
     qwenSettingsInvalid: 'Qwen Code 设置 JSON 无效',
-    codexSettingsInvalid: 'Codex 设置无效',
     providerCannotChange: '提供商不可更改',
 
     // 帮助文档
@@ -2177,7 +2175,6 @@ const translations: Record<Language, Translations> = {
     codexSettings: 'Codex 設定 (TOML)',
     codexSettingsHint:
       '機密情報以外の Codex 設定のみを構成してください（model、sandbox など）。API キーは含めないでください — 環境変数経由で自動的に挿入されます。',
-    codexSettingsInvalid: 'Codex 設定が無効です',
     providerCannotChange: 'プロバイダーは変更できません',
   },
   ko: {
@@ -2697,7 +2694,6 @@ const translations: Record<Language, Translations> = {
     codexSettings: 'Codex 설정 (TOML)',
     codexSettingsHint:
       '민감하지 않은 Codex 설정만 구성하세요 (model, sandbox 등). API 키는 포함하지 마세요 — 환경 변수를 통해 자동으로 주입됩니다.',
-    codexSettingsInvalid: 'Codex 설정이 유효하지 않습니다',
     providerCannotChange: '공급자를 변경할 수 없습니다',
   },
 };

--- a/remote-agent/agent.py
+++ b/remote-agent/agent.py
@@ -19,12 +19,10 @@ import sys
 import tempfile
 import time
 from datetime import datetime
-from pathlib import Path
 from typing import Any
 
 import requests
-from cli_adapters.base import normalize_model_providers
-from constants import SENSITIVE_ENV_KEYS, collect_dynamic_env_keys
+from cli_settings import apply_cli_settings
 from executor import ProcessExecutor
 from session_sync import SessionSyncService
 from system_info import get_capabilities
@@ -928,42 +926,13 @@ class RemoteAgent:
             return hostname
         return "127.0.0.1"
 
-    # ----------------------------------------------------------------
-    # CLI Settings Application
-    # ----------------------------------------------------------------
-
-    def _strip_sensitive_fields(self, settings: dict[str, Any]) -> dict[str, Any]:
-        """Remove API key and base URL fields from settings dict.
-
-        These credentials are injected via environment variables by
-        terminal_server.py (web terminal) and executor._build_env()
-        (remote session), so they must not be written to settings.json.
-        """
-        settings = settings.copy()
-        all_sensitive = SENSITIVE_ENV_KEYS | collect_dynamic_env_keys(settings)
-
-        # Remove sensitive keys from env block
-        env = settings.get("env", {})
-        if env:
-            env = {k: v for k, v in env.items() if k not in all_sensitive}
-            settings["env"] = env
-
-        # Remove baseUrl from modelProviders (qwen-code)
-        for provider_models in settings.get("modelProviders", {}).values():
-            if isinstance(provider_models, list):
-                for model in provider_models:
-                    if isinstance(model, dict):
-                        model.pop("baseUrl", None)
-
-        return settings
-
     def _apply_cli_settings(self, cli_settings: dict[str, Any]) -> None:
         """
-        Write settings.json files for configured CLI tools.
+        Write config files for configured CLI tools.
 
-        Only non-sensitive configuration is written (model mappings, theme, etc.).
-        API keys and base URLs are NOT written — they are injected via
-        environment variables by terminal_server.py and executor.
+        API keys are not persisted. The shared writer injects the Open ACE
+        proxy routing for Qwen and Codex while preserving non-sensitive user
+        preferences.
 
         Args:
             cli_settings: Dict with tool_name -> settings mapping
@@ -972,79 +941,8 @@ class RemoteAgent:
         if not cli_settings:
             return
 
-        for tool_name, settings in cli_settings.items():
-            try:
-                settings = self._strip_sensitive_fields(settings)
-                if tool_name == "claude-code":
-                    self._write_claude_settings(settings)
-                elif tool_name == "qwen-code":
-                    self._write_qwen_settings(settings)
-                else:
-                    logger.warning("Unknown tool name for settings: %s", tool_name)
-            except Exception as e:
-                logger.error("Failed to write settings for %s: %s", tool_name, e)
-
-    def _write_claude_settings(self, settings: dict[str, Any]) -> None:
-        """
-        Write ~/.claude/settings.json for Claude Code.
-
-        Settings should already contain injected API credentials
-        (ANTHROPIC_API_KEY, ANTHROPIC_BASE_URL) from build_settings().
-        """
-        claude_dir = Path.home() / ".claude"
-        claude_dir.mkdir(parents=True, exist_ok=True)
-
-        settings_path = claude_dir / "settings.json"
-
-        # Preserve existing settings, merge new ones
-        existing = {}
-        if settings_path.exists():
-            try:
-                existing = json.loads(settings_path.read_text(encoding="utf-8"))
-            except (json.JSONDecodeError, OSError):
-                existing = {}
-
-        merged = {**existing, **settings}
-
-        # Atomic write via temp file + rename
-        self._atomic_write_json(str(settings_path), merged)
-        logger.info("Wrote Claude Code settings to %s", settings_path)
-
-    def _write_qwen_settings(self, settings: dict[str, Any]) -> None:
-        """
-        Write ~/.qwen/settings.json for Qwen Code (bailian format).
-
-        Settings should already contain injected API credentials
-        (env.ZAI_API_KEY etc.) from build_settings().
-        """
-        qwen_dir = Path.home() / ".qwen"
-        qwen_dir.mkdir(parents=True, exist_ok=True)
-
-        settings_path = qwen_dir / "settings.json"
-
-        # Preserve existing settings, merge new ones
-        existing = {}
-        if settings_path.exists():
-            try:
-                existing = json.loads(settings_path.read_text(encoding="utf-8"))
-            except (json.JSONDecodeError, OSError):
-                existing = {}
-
-        merged = {**existing, **settings}
-
-        # Ensure $version is set for Qwen settings format
-        if "$version" not in merged:
-            merged["$version"] = 3
-
-        # Normalize modelProviders: unify all envKeys to OPENAI_API_KEY
-        # and set baseUrl to the LLM proxy so the CLI routes all
-        # requests through the proxy.
         proxy_base_url = f"{self.config.server_url.rstrip('/')}/api/remote/llm-proxy/v1"
-        normalize_model_providers(merged, proxy_base_url=proxy_base_url)
-
-        # Atomic write via temp file + rename
-        self._atomic_write_json(str(settings_path), merged)
-        logger.info("Wrote Qwen Code settings to %s", settings_path)
+        apply_cli_settings(cli_settings, proxy_base_url=proxy_base_url)
 
     # ----------------------------------------------------------------
     # Shutdown

--- a/remote-agent/cli_settings.py
+++ b/remote-agent/cli_settings.py
@@ -1,0 +1,270 @@
+"""Helpers for applying CLI settings to local tool config files."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from cli_adapters.base import normalize_model_providers
+from constants import SENSITIVE_ENV_KEYS, collect_dynamic_env_keys
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python < 3.11
+    import tomli as tomllib
+
+logger = logging.getLogger(__name__)
+
+_BARE_TOML_KEY_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+
+
+def _atomic_write_json(filepath: Path, data: dict | list) -> None:
+    """Atomically write JSON data to disk."""
+    filepath.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        encoding="utf-8",
+        delete=False,
+        dir=filepath.parent,
+        suffix=".tmp",
+    ) as tmp:
+        json.dump(data, tmp, indent=2, ensure_ascii=False)
+        tmp.write("\n")
+        tmp_path = Path(tmp.name)
+    os.replace(tmp_path, filepath)
+
+
+def _atomic_write_text(filepath: Path, content: str) -> None:
+    """Atomically write text content to disk."""
+    filepath.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        encoding="utf-8",
+        delete=False,
+        dir=filepath.parent,
+        suffix=".tmp",
+    ) as tmp:
+        tmp.write(content)
+        tmp_path = Path(tmp.name)
+    os.replace(tmp_path, filepath)
+
+
+def _deep_merge_dicts(base: dict[str, Any], updates: dict[str, Any]) -> dict[str, Any]:
+    """Merge dicts recursively while preserving unrelated existing keys."""
+    merged = dict(base)
+    for key, value in updates.items():
+        if isinstance(value, dict) and isinstance(merged.get(key), dict):
+            merged[key] = _deep_merge_dicts(merged[key], value)
+        else:
+            merged[key] = value
+    return merged
+
+
+def _strip_sensitive_env(settings: dict[str, Any]) -> dict[str, Any]:
+    """Remove API keys and base URLs from a CLI settings mapping."""
+    cleaned = settings.copy()
+    all_sensitive = SENSITIVE_ENV_KEYS | collect_dynamic_env_keys(cleaned)
+
+    env = cleaned.get("env", {})
+    if env:
+        env = {k: v for k, v in env.items() if k not in all_sensitive}
+        cleaned["env"] = env
+
+    return cleaned
+
+
+def _load_json_file(filepath: Path) -> dict[str, Any]:
+    if not filepath.exists():
+        return {}
+    try:
+        return json.loads(filepath.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def _load_toml_file(filepath: Path) -> dict[str, Any]:
+    if not filepath.exists():
+        return {}
+    try:
+        return tomllib.loads(filepath.read_text(encoding="utf-8"))
+    except (tomllib.TOMLDecodeError, OSError):
+        return {}
+
+
+def _toml_key(key: str) -> str:
+    if _BARE_TOML_KEY_RE.match(key):
+        return key
+    escaped = key.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
+def _toml_value(value: Any) -> str:
+    if isinstance(value, str):
+        escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+        return f'"{escaped}"'
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, float):
+        return repr(value)
+    if isinstance(value, list):
+        return "[" + ", ".join(_toml_value(item) for item in value) + "]"
+    if isinstance(value, dict):
+        parts = [f"{_toml_key(k)} = {_toml_value(v)}" for k, v in value.items()]
+        return "{ " + ", ".join(parts) + " }"
+    raise TypeError(f"Unsupported TOML value type: {type(value)!r}")
+
+
+def _dump_toml_table(lines: list[str], data: dict[str, Any], path: list[str]) -> None:
+    scalar_items: list[tuple[str, Any]] = []
+    table_items: list[tuple[str, dict[str, Any]]] = []
+
+    for key, value in data.items():
+        if isinstance(value, dict):
+            table_items.append((key, value))
+        else:
+            scalar_items.append((key, value))
+
+    if path:
+        lines.append("[" + ".".join(_toml_key(part) for part in path) + "]")
+
+    for key, value in scalar_items:
+        lines.append(f"{_toml_key(key)} = {_toml_value(value)}")
+
+    if scalar_items and table_items:
+        lines.append("")
+
+    for index, (key, value) in enumerate(table_items):
+        _dump_toml_table(lines, value, path + [key])
+        if index != len(table_items) - 1:
+            lines.append("")
+
+
+def dump_toml(data: dict[str, Any]) -> str:
+    """Serialize a nested dict to TOML."""
+    lines: list[str] = []
+    _dump_toml_table(lines, data, [])
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _normalize_qwen_settings(settings: dict[str, Any], proxy_base_url: str) -> dict[str, Any]:
+    cleaned = _strip_sensitive_env(settings)
+    for provider_models in cleaned.get("modelProviders", {}).values():
+        if isinstance(provider_models, list):
+            for model in provider_models:
+                if isinstance(model, dict):
+                    model.pop("baseUrl", None)
+    normalize_model_providers(cleaned, proxy_base_url=proxy_base_url)
+    if "$version" not in cleaned:
+        cleaned["$version"] = 3
+    return cleaned
+
+
+def parse_codex_settings(raw_settings: dict[str, Any] | str | None) -> dict[str, Any]:
+    """Parse stored Codex settings from dict or TOML string form."""
+    if raw_settings is None:
+        return {}
+    if isinstance(raw_settings, dict):
+        return raw_settings.copy()
+    if isinstance(raw_settings, str):
+        try:
+            parsed = tomllib.loads(raw_settings)
+        except tomllib.TOMLDecodeError as exc:
+            logger.warning("Failed to parse Codex settings TOML: %s", exc)
+            return {}
+        if isinstance(parsed, dict):
+            return parsed
+    logger.warning("Unsupported Codex settings type: %s", type(raw_settings).__name__)
+    return {}
+
+
+def _normalize_codex_settings(settings: dict[str, Any], proxy_base_url: str) -> dict[str, Any]:
+    cleaned = _strip_sensitive_env(settings)
+    if "model_reasoning_summary" not in cleaned:
+        cleaned["model_reasoning_summary"] = "auto"
+    if "model_provider" not in cleaned:
+        cleaned["model_provider"] = "openace"
+
+    providers = cleaned.get("model_providers")
+    if not isinstance(providers, dict):
+        providers = {}
+        cleaned["model_providers"] = providers
+
+    openace_provider = providers.get("openace")
+    if not isinstance(openace_provider, dict):
+        openace_provider = {}
+    openace_provider = {
+        **openace_provider,
+        "name": openace_provider.get("name", "Open ACE Proxy"),
+        "wire_api": openace_provider.get("wire_api", "responses"),
+        "base_url": proxy_base_url,
+        "env_key": "OPENAI_API_KEY",
+    }
+    providers["openace"] = openace_provider
+    return cleaned
+
+
+def write_claude_settings(settings: dict[str, Any], home_dir: Path | None = None) -> Path:
+    """Merge and write ~/.claude/settings.json."""
+    base_dir = home_dir or Path.home()
+    settings_path = base_dir / ".claude" / "settings.json"
+    merged = {**_load_json_file(settings_path), **_strip_sensitive_env(settings)}
+    _atomic_write_json(settings_path, merged)
+    return settings_path
+
+
+def write_qwen_settings(
+    settings: dict[str, Any],
+    proxy_base_url: str,
+    home_dir: Path | None = None,
+) -> Path:
+    """Merge and write ~/.qwen/settings.json."""
+    base_dir = home_dir or Path.home()
+    settings_path = base_dir / ".qwen" / "settings.json"
+    normalized = _normalize_qwen_settings(settings, proxy_base_url=proxy_base_url)
+    merged = {**_load_json_file(settings_path), **normalized}
+    _atomic_write_json(settings_path, merged)
+    return settings_path
+
+
+def write_codex_settings(
+    settings: dict[str, Any] | str,
+    proxy_base_url: str,
+    home_dir: Path | None = None,
+) -> Path:
+    """Merge and write ~/.codex/config.toml."""
+    base_dir = home_dir or Path.home()
+    config_path = base_dir / ".codex" / "config.toml"
+    normalized = _normalize_codex_settings(parse_codex_settings(settings), proxy_base_url)
+    merged = _deep_merge_dicts(_load_toml_file(config_path), normalized)
+    _atomic_write_text(config_path, dump_toml(merged))
+    return config_path
+
+
+def apply_cli_settings(
+    cli_settings: dict[str, Any],
+    proxy_base_url: str,
+    home_dir: Path | None = None,
+) -> None:
+    """Apply CLI settings for supported tools to local config files."""
+    if not cli_settings:
+        return
+
+    for tool_name, settings in cli_settings.items():
+        try:
+            if tool_name == "claude-code" and isinstance(settings, dict):
+                write_claude_settings(settings, home_dir=home_dir)
+            elif tool_name == "qwen-code" and isinstance(settings, dict):
+                write_qwen_settings(settings, proxy_base_url=proxy_base_url, home_dir=home_dir)
+            elif tool_name in {"codex", "codex-cli"}:
+                write_codex_settings(settings, proxy_base_url=proxy_base_url, home_dir=home_dir)
+            else:
+                logger.warning("Unknown tool name for settings: %s", tool_name)
+        except Exception as exc:
+            logger.error("Failed to write settings for %s: %s", tool_name, exc)

--- a/remote-agent/cli_settings.py
+++ b/remote-agent/cli_settings.py
@@ -105,7 +105,13 @@ def _toml_key(key: str) -> str:
 
 def _toml_value(value: Any) -> str:
     if isinstance(value, str):
-        escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+        escaped = (
+            value.replace("\\", "\\\\")
+            .replace('"', '\\"')
+            .replace("\n", "\\n")
+            .replace("\t", "\\t")
+            .replace("\r", "\\r")
+        )
         return f'"{escaped}"'
     if isinstance(value, bool):
         return "true" if value else "false"

--- a/remote-agent/openace_cli.py
+++ b/remote-agent/openace_cli.py
@@ -23,6 +23,11 @@ from pathlib import Path
 from typing import Any
 
 AGENT_DIR = Path(__file__).resolve().parent
+if str(AGENT_DIR) not in sys.path:
+    sys.path.insert(0, str(AGENT_DIR))
+
+from cli_settings import apply_cli_settings
+
 AGENT_CONFIG_PATH = AGENT_DIR / "config.json"
 CLI_CONFIG_DIR = Path.home() / ".open-ace-cli"
 CLI_CONFIG_PATH = CLI_CONFIG_DIR / "config.json"
@@ -202,6 +207,15 @@ def _session_env(terminal: dict[str, Any]) -> dict[str, str]:
     return env
 
 
+def _apply_local_cli_settings(terminal: dict[str, Any]) -> None:
+    """Apply CLI settings returned by /terminal/cli/start before launching tools."""
+    cli_settings = terminal.get("cli_settings") or {}
+    proxy_url = str(terminal.get("proxy_url") or "").rstrip("/")
+    if not cli_settings or not proxy_url:
+        return
+    apply_cli_settings(cli_settings, proxy_base_url=f"{proxy_url}/v1")
+
+
 def _write_active_terminal(terminal: dict[str, Any]) -> None:
     payload = {
         "terminal_id": terminal["session_id"],
@@ -261,6 +275,7 @@ def cmd_status(_: argparse.Namespace) -> int:
 def cmd_menu(args: argparse.Namespace) -> int:
     work_dir = os.path.abspath(args.work_dir or os.getcwd())
     terminal = _start_cli_terminal(work_dir)
+    _apply_local_cli_settings(terminal)
     _write_active_terminal(terminal)
     env = _session_env(terminal)
     os.execvpe(sys.executable, [sys.executable, str(MENU_PATH)], env)
@@ -269,6 +284,7 @@ def cmd_menu(args: argparse.Namespace) -> int:
 def cmd_shell(args: argparse.Namespace) -> int:
     work_dir = os.path.abspath(args.work_dir or os.getcwd())
     terminal = _start_cli_terminal(work_dir)
+    _apply_local_cli_settings(terminal)
     _write_active_terminal(terminal)
     env = _session_env(terminal)
     shell = os.environ.get("SHELL") or "/bin/sh"

--- a/remote-agent/requirements.txt
+++ b/remote-agent/requirements.txt
@@ -1,3 +1,4 @@
 websocket-client>=1.9.0,<2.0.0
 requests>=2.32.5,<3.0.0
 websockets>=13.0,<17.0
+tomli>=2.0.1,<3.0.0; python_version < "3.11"

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ bcrypt>=4.0.0,<6.0.0
 PyJWT>=2.12.1,<3.0.0
 cryptography>=38.0.0,<44.0.0
 filetype>=1.2.0,<2.0.0
+tomli>=2.0.1,<3.0.0; python_version < "3.11"
 
 # Production server
 gunicorn>=23.0.0,<24.0.0

--- a/tests/unit/test_cli_settings_apply.py
+++ b/tests/unit/test_cli_settings_apply.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Unit tests for shared CLI settings writers."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def load_cli_settings():
+    module_path = Path(__file__).resolve().parents[2] / "remote-agent" / "cli_settings.py"
+    agent_dir = str(module_path.parent)
+    if agent_dir not in sys.path:
+        sys.path.insert(0, agent_dir)
+    spec = importlib.util.spec_from_file_location("cli_settings", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_write_codex_settings_merges_existing_and_injects_proxy(tmp_path):
+    cli_settings = load_cli_settings()
+    config_path = tmp_path / ".codex" / "config.toml"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(
+        'personality = "pragmatic"\n\n[desktop]\nappearanceTheme = "system"\n',
+        encoding="utf-8",
+    )
+
+    cli_settings.write_codex_settings(
+        """model_provider = "openace"
+model = "qwen3.7-max"
+
+[model_providers.openace]
+name = "Open ACE Proxy"
+wire_api = "responses"
+""",
+        proxy_base_url="https://openace.example/api/remote/llm-proxy/v1",
+        home_dir=tmp_path,
+    )
+
+    parsed = cli_settings.tomllib.loads(config_path.read_text(encoding="utf-8"))
+    assert parsed["personality"] == "pragmatic"
+    assert parsed["desktop"]["appearanceTheme"] == "system"
+    assert parsed["model_provider"] == "openace"
+    assert parsed["model"] == "qwen3.7-max"
+    assert parsed["model_reasoning_summary"] == "auto"
+    assert parsed["model_providers"]["openace"]["name"] == "Open ACE Proxy"
+    assert parsed["model_providers"]["openace"]["wire_api"] == "responses"
+    assert (
+        parsed["model_providers"]["openace"]["base_url"]
+        == "https://openace.example/api/remote/llm-proxy/v1"
+    )
+    assert parsed["model_providers"]["openace"]["env_key"] == "OPENAI_API_KEY"

--- a/tests/unit/test_cli_settings_strip.py
+++ b/tests/unit/test_cli_settings_strip.py
@@ -161,3 +161,24 @@ wire_api = "responses"
         assert result["model"] == "qwen3.7-max"
         assert result["model_providers"]["openace"]["name"] == "Open ACE Proxy"
         assert result["model_providers"]["openace"]["wire_api"] == "responses"
+
+
+class TestValidateCliSettingsPayload:
+    """Test server-side validation of stored CLI settings payloads."""
+
+    def test_accepts_valid_codex_toml_string(self):
+        from app.modules.workspace.api_key_proxy import validate_cli_settings_payload
+
+        error = validate_cli_settings_payload(
+            """
+            {"codex-cli":"model_provider = \\"openace\\"\\nmodel = \\"qwen3.7-max\\""}
+            """
+        )
+        assert error is None
+
+    def test_rejects_invalid_codex_toml_string(self):
+        from app.modules.workspace.api_key_proxy import validate_cli_settings_payload
+
+        error = validate_cli_settings_payload('{"codex-cli":"[broken"}')
+        assert error is not None
+        assert "Invalid Codex settings TOML" in error

--- a/tests/unit/test_cli_settings_strip.py
+++ b/tests/unit/test_cli_settings_strip.py
@@ -140,3 +140,24 @@ class TestBuildCliSettingsStripsSensitive:
         assert result["env"]["ANTHROPIC_MODEL"] == "glm-5"
         assert result["model"] == "haiku"
         assert result["theme"] == "dark"
+
+    def test_parses_codex_toml_settings(self):
+        from app.modules.workspace.api_key_proxy import APIKeyProxyService
+
+        svc = APIKeyProxyService.__new__(APIKeyProxyService)
+        result = svc._build_cli_settings_for_tool(
+            "codex-cli",
+            """
+model_provider = "openace"
+model = "qwen3.7-max"
+
+[model_providers.openace]
+name = "Open ACE Proxy"
+wire_api = "responses"
+""",
+        )
+
+        assert result["model_provider"] == "openace"
+        assert result["model"] == "qwen3.7-max"
+        assert result["model_providers"]["openace"]["name"] == "Open ACE Proxy"
+        assert result["model_providers"]["openace"]["wire_api"] == "responses"

--- a/tests/unit/test_openace_cli.py
+++ b/tests/unit/test_openace_cli.py
@@ -68,6 +68,30 @@ def test_start_cli_terminal_posts_machine_and_work_dir(monkeypatch):
     ]
 
 
+def test_apply_local_cli_settings_uses_proxy_v1(monkeypatch):
+    openace_cli = load_openace_cli()
+    applied = []
+
+    def fake_apply(cli_settings, proxy_base_url):
+        applied.append((cli_settings, proxy_base_url))
+
+    monkeypatch.setattr(openace_cli, "apply_cli_settings", fake_apply)
+
+    openace_cli._apply_local_cli_settings(
+        {
+            "proxy_url": "https://openace.example/api/remote/llm-proxy",
+            "cli_settings": {"codex-cli": {"model_provider": "openace"}},
+        }
+    )
+
+    assert applied == [
+        (
+            {"codex-cli": {"model_provider": "openace"}},
+            "https://openace.example/api/remote/llm-proxy/v1",
+        )
+    ]
+
+
 def test_login_writes_session_token(monkeypatch, tmp_path):
     openace_cli = load_openace_cli()
     config_path = tmp_path / "config.json"


### PR DESCRIPTION
## Summary
- make `openace menu` apply CLI settings for Claude, Qwen, and Codex before launching tools
- add a shared CLI settings writer and complete the Codex config.toml path, including API key proxy injection
- expose Codex settings in API key management, return cli_settings from the SSH/CLI terminal endpoint, and add tests for the new flow

## Testing
- python3 -m pytest -q tests/unit/test_openace_cli.py tests/unit/test_cli_settings_apply.py tests/unit/test_cli_settings_strip.py
- npm run typecheck