### PR TITLE
Add cli_settings.py to install scripts

### DIFF
--- a/remote-agent/install.ps1
+++ b/remote-agent/install.ps1
@@ -85,7 +85,8 @@ $files = @(
     "websocket_proxy.py",
     "session_isolation.py",
     "session_sync.py",
-    "openace_cli.py"
+    "openace_cli.py",
+    "cli_settings.py"
 )
 $adapterFiles = @("__init__.py", "base.py", "qwen_code.py", "claude_code.py", "codex_cli.py", "codex_jsonl_parser.py", "openclaw.py")
 

--- a/remote-agent/install.sh
+++ b/remote-agent/install.sh
@@ -152,6 +152,7 @@ AGENT_FILES=(
     session_isolation.py
     session_sync.py
     openace_cli.py
+    cli_settings.py
     __init__.py
 )
 


### PR DESCRIPTION
## Summary
- Add `cli_settings.py` to `AGENT_FILES` in both `install.sh` and `install.ps1`
- Fixes `ModuleNotFoundError: No module named 'cli_settings'` on remote machines after PR #573

🤖 Generated with [Claude Code](https://claude.com/claude-code)