### PR TITLE
Fix Codex default model to glm-5

### DIFF
--- a/frontend/src/components/features/management/APIKeyManagement.tsx
+++ b/frontend/src/components/features/management/APIKeyManagement.tsx
@@ -69,7 +69,7 @@ const defaultQwenSettings = `{
 }`;
 
 const defaultCodexSettings = `model_provider = "openace"
-model = "qwen3.7-max"
+model = "glm-5"
 
 [model_providers.openace]
 name = "Open ACE Proxy"


### PR DESCRIPTION
## Summary
- Change Codex default model from `qwen3.7-max` to `glm-5`
- `qwen3.7-max` is not supported by DashScope Coding Plan endpoint (`coding.dashscope.aliyuncs.com`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)