### PR TITLE
Fix 3 PostgreSQL compatibility bugs

### DIFF
--- a/app/modules/workspace/prompt_library.py
+++ b/app/modules/workspace/prompt_library.py
@@ -550,25 +550,29 @@ class PromptLibrary:
         if user_id is not None:
             # Include user's private templates + all public templates
             cursor.execute(
-                f"""
-                SELECT category, COUNT(*) as count
-                FROM prompt_templates
-                WHERE (author_id = ? OR {adapt_boolean_condition('is_public', True)})
-                GROUP BY category
-                ORDER BY count DESC
-            """,
+                adapt_sql(
+                    f"""
+                    SELECT category, COUNT(*) as count
+                    FROM prompt_templates
+                    WHERE (author_id = ? OR {adapt_boolean_condition('is_public', True)})
+                    GROUP BY category
+                    ORDER BY count DESC
+                """
+                ),
                 (user_id,),
             )
         else:
             # Only count public templates
             cursor.execute(
-                f"""
-                SELECT category, COUNT(*) as count
-                FROM prompt_templates
-                WHERE {adapt_boolean_condition('is_public', True)}
-                GROUP BY category
-                ORDER BY count DESC
-            """
+                adapt_sql(
+                    f"""
+                    SELECT category, COUNT(*) as count
+                    FROM prompt_templates
+                    WHERE {adapt_boolean_condition('is_public', True)}
+                    GROUP BY category
+                    ORDER BY count DESC
+                """
+                )
             )
 
         rows = cursor.fetchall()

--- a/app/services/data_fetch_scheduler.py
+++ b/app/services/data_fetch_scheduler.py
@@ -197,8 +197,14 @@ class DataFetchScheduler:
         from datetime import datetime as dt
         from datetime import timezone as tz
 
-        from app.repositories.database import Database, adapt_boolean_condition, adapt_sql
+        from app.repositories.database import (
+            Database,
+            adapt_boolean_condition,
+            adapt_sql,
+            is_postgresql,
+        )
 
+        bigint_cast = "::bigint" if is_postgresql() else ""
         today = dt.now(tz.utc).replace(tzinfo=None).strftime("%Y-%m-%d")
         month_start = dt.now(tz.utc).replace(tzinfo=None).replace(day=1).strftime("%Y-%m-%d")
         db = Database()
@@ -219,7 +225,7 @@ class DataFetchScheduler:
                       AND {adapt_boolean_condition("u.is_active", True)}
                       AND (
                         uds.requests >= COALESCE(u.daily_request_quota, 999999)
-                        OR uds.tokens >= COALESCE(u.daily_token_quota, 999999) * 1000000
+                        OR uds.tokens >= COALESCE(u.daily_token_quota, 999999){bigint_cast} * 1000000
                       )
                 """
                 ),
@@ -244,7 +250,7 @@ class DataFetchScheduler:
                       AND u.monthly_token_quota IS NOT NULL
                     GROUP BY u.id, u.username, u.monthly_request_quota, u.monthly_token_quota
                     HAVING SUM(uds.requests) >= COALESCE(u.monthly_request_quota, 999999)
-                        OR SUM(uds.tokens) >= COALESCE(u.monthly_token_quota, 999999) * 1000000
+                        OR SUM(uds.tokens) >= COALESCE(u.monthly_token_quota, 999999){bigint_cast} * 1000000
                 """
                 ),
                 (month_start, today),

--- a/app/services/quota_enforcement_scheduler.py
+++ b/app/services/quota_enforcement_scheduler.py
@@ -108,8 +108,14 @@ class QuotaEnforcementScheduler:
 
     def _run_enforcement(self):
         """Run quota enforcement check for all users."""
-        from app.repositories.database import Database, adapt_boolean_condition, adapt_sql
+        from app.repositories.database import (
+            Database,
+            adapt_boolean_condition,
+            adapt_sql,
+            is_postgresql,
+        )
 
+        bigint_cast = "::bigint" if is_postgresql() else ""
         today = datetime.now(timezone.utc).replace(tzinfo=None).strftime("%Y-%m-%d")
         month_start = (
             datetime.now(timezone.utc).replace(tzinfo=None).replace(day=1).strftime("%Y-%m-%d")
@@ -134,7 +140,7 @@ class QuotaEnforcementScheduler:
                       AND {adapt_boolean_condition("u.is_active", True)}
                       AND (
                         uds.requests >= COALESCE(u.daily_request_quota, 999999)
-                        OR uds.tokens >= COALESCE(u.daily_token_quota, 999999) * 1000000
+                        OR uds.tokens >= COALESCE(u.daily_token_quota, 999999){bigint_cast} * 1000000
                       )
                 """
                 ),
@@ -158,7 +164,7 @@ class QuotaEnforcementScheduler:
                       AND {adapt_boolean_condition("u.is_active", True)}
                     GROUP BY u.id, u.username, u.monthly_request_quota, u.monthly_token_quota
                     HAVING SUM(uds.requests) >= COALESCE(u.monthly_request_quota, 999999)
-                        OR SUM(uds.tokens) >= COALESCE(u.monthly_token_quota, 999999) * 1000000
+                        OR SUM(uds.tokens) >= COALESCE(u.monthly_token_quota, 999999){bigint_cast} * 1000000
                 """
                 ),
                 (month_start, today),

--- a/migrations/versions/20260527_046_add_login_attempts_table.py
+++ b/migrations/versions/20260527_046_add_login_attempts_table.py
@@ -39,6 +39,7 @@ def _table_exists(conn, table_name: str) -> bool:
 
 
 def upgrade() -> None:
+    """Create login_attempts table if it does not already exist."""
     conn = op.get_bind()
 
     if _table_exists(conn, "login_attempts"):
@@ -58,8 +59,8 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    conn = op.get_bind()
-
-    if _table_exists(conn, "login_attempts"):
-        op.drop_index("idx_login_attempts_locked_until", table_name="login_attempts")
-        op.drop_table("login_attempts")
+    """No-op: the login_attempts table may have been created by runtime DDL
+    before this migration ran, so dropping it on downgrade would risk
+    deleting pre-existing production data.  Symmetric with the upgrade()
+    early-return when the table already exists.
+    """

--- a/migrations/versions/20260527_046_add_login_attempts_table.py
+++ b/migrations/versions/20260527_046_add_login_attempts_table.py
@@ -1,0 +1,65 @@
+"""Add login_attempts table for login lockout tracking
+
+Revision ID: 046_login_attempts
+Revises: 045_granted_at_type
+Create Date: 2026-05-27
+
+The login_attempts table was only created via runtime DDL (get_ddl_statements)
+or in schema-postgres.sql (fresh installs). It had no Alembic migration,
+so databases set up via `alembic upgrade head` would miss it when the
+runtime DDL failed silently.
+"""
+
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "046_login_attempts"
+down_revision: Union[str, None] = "045_granted_at_type"
+branch_labels: Union[str, None] = None
+depends_on: Union[str, None] = None
+
+
+def _table_exists(conn, table_name: str) -> bool:
+    if conn.dialect.name == "postgresql":
+        result = conn.execute(
+            sa.text(
+                "SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_name = :table_name)"
+            ),
+            {"table_name": table_name},
+        )
+        return result.fetchone()[0]
+    else:
+        result = conn.execute(
+            sa.text("SELECT name FROM sqlite_master WHERE type='table' AND name = :table_name"),
+            {"table_name": table_name},
+        )
+        return result.fetchone() is not None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    if _table_exists(conn, "login_attempts"):
+        return
+
+    op.create_table(
+        "login_attempts",
+        sa.Column("username", sa.String(255), primary_key=True),
+        sa.Column("attempt_count", sa.Integer, nullable=False, server_default="0"),
+        sa.Column("locked_until", sa.TIMESTAMP, nullable=True),
+    )
+    op.create_index(
+        "idx_login_attempts_locked_until",
+        "login_attempts",
+        ["locked_until"],
+    )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+
+    if _table_exists(conn, "login_attempts"):
+        op.drop_index("idx_login_attempts_locked_until", table_name="login_attempts")
+        op.drop_table("login_attempts")


### PR DESCRIPTION
## Summary
- Fix `get_categories()` SQL placeholder: wrap queries with `adapt_sql()` to convert `?` → `%s` for PostgreSQL, resolving "syntax error at or near OR" on every prompt categories API call
- Fix quota enforcement integer overflow: add `::bigint` cast to `COALESCE` expressions before `* 1000000` multiplication, preventing 32-bit integer overflow (`999999 * 1000000 ≈ 1 trillion > INT max ~2.1B`)
- Add Alembic migration 046 for `login_attempts` table, which was only created via runtime DDL or `schema-postgres.sql` but missing from the migration chain

## Test plan
- [ ] Verify `GET /api/workspace/prompts/categories` no longer returns 500 on PostgreSQL
- [ ] Verify `Quota enforcement check failed: integer out of range` no longer appears in logs
- [ ] Run `alembic upgrade head` on a PostgreSQL database missing `login_attempts` and confirm the table is created
- [ ] Verify existing functionality is not affected on SQLite (bigint cast is conditionally applied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)