### PR TITLE
fix(init_db): update system_account when admin user exists (Issue #361)

### DIFF
--- a/scripts/init_db.py
+++ b/scripts/init_db.py
@@ -115,6 +115,19 @@ def create_default_admin(
     # Check if admin already exists
     existing = db.get_user_by_username(username)
     if existing:
+        # Update system_account if provided and current value is NULL or different
+        # Note: Only system_account is updated; other fields (email, tenant_id) are not modified
+        # as they are typically set during initial creation and should not be changed by reinstall
+        if system_account and existing.get("system_account") != system_account:
+            # Validate system_account parameter
+            if not system_account.strip():
+                print(f"Warning: system_account is empty string, skipping update")
+                return True
+            try:
+                db.update_user(existing["id"], system_account=system_account)
+                print(f"Updated system_account for '{username}' to '{system_account}'")
+            except Exception as e:
+                print(f"Warning: Failed to update system_account for '{username}': {e}")
         print(f"Admin user '{username}' already exists")
         return True
 

--- a/scripts/init_db.py
+++ b/scripts/init_db.py
@@ -121,7 +121,7 @@ def create_default_admin(
         if system_account and existing.get("system_account") != system_account:
             # Validate system_account parameter
             if not system_account.strip():
-                print(f"Warning: system_account is empty string, skipping update")
+                print("Warning: system_account is empty string, skipping update")
                 return True
             try:
                 db.update_user(existing["id"], system_account=system_account)

--- a/scripts/shared/db.py
+++ b/scripts/shared/db.py
@@ -1767,7 +1767,7 @@ def update_user(user_id: int, **kwargs) -> bool:
     _execute(
         cursor,
         f"""
-        UPDATE users SET {', '.join(updates)}, updated_at = CURRENT_TIMESTAMP WHERE id = ?
+        UPDATE users SET {', '.join(updates)} WHERE id = ?
     """,
         params,
     )
@@ -1784,7 +1784,7 @@ def update_user_password(user_id: int, password_hash: str) -> bool:
     _execute(
         cursor,
         """
-        UPDATE users SET password_hash = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?
+        UPDATE users SET password_hash = ? WHERE id = ?
     """,
         (password_hash, user_id),
     )


### PR DESCRIPTION
## Issue #361: admin用户已存在时未更新system_account导致Workspace启动失败

### 问题描述

在多用户模式下，当访问 `/work` 页面时出现错误：`Failed to get user webui URL`

**根本原因**：
- `scripts/init_db.py` 的 `create_default_admin()` 函数当 admin 用户已存在时直接返回，不更新 `system_account` 字段
- 导致 WebUIManager 无法找到正确的系统账户来启动 Workspace

**附加问题**：
- `scripts/shared/db.py` 的 `update_user()` 和 `update_user_password()` 函数尝试更新 `users` 表的 `updated_at` 字段
- 但数据库架构中该表没有此字段，导致 SQL 执行失败

### 修复方案

**修复 1：init_db.py**
- 当用户已存在时，检查并更新 `system_account` 字段
- 添加参数验证（拒绝空字符串）
- 添加异常处理（更新失败不中断流程）
- 添加设计意图注释

**修复 2：db.py**
- 移除 `update_user()` 函数中的 `updated_at = CURRENT_TIMESTAMP`
- 移除 `update_user_password()` 函数中的 `updated_at = CURRENT_TIMESTAMP`

### 修改文件

- `scripts/init_db.py`: 添加 system_account 更新逻辑 (+13行)
- `scripts/shared/db.py`: 移除 users 表的 updated_at 字段更新 (-2行)

### 验证结果

- ✅ node237 测试环境验证通过
- ✅ init_db.py 成功更新 system_account
- ✅ /work 页面无错误提示
- ✅ Workspace 功能正常

Fixes #361