### PR TITLE
fix: SESSION过期问题 - 添加滑动过期和心跳保活机制 (#325)

### DIFF
--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -159,9 +159,55 @@ def api_profile():
     return jsonify({"error": "User not found"}), 404
 
 
+# Session refresh threshold (only refresh when less than 10 minutes remaining)
+_AUTH_SESSION_REFRESH_THRESHOLD_MINUTES = 10
+
+
+def _refresh_auth_session(token: str) -> Optional[int]:
+    """Extend session expiry when close to expiration.
+
+    Returns new timeout seconds if session was refreshed, None otherwise.
+    """
+    from datetime import datetime, timedelta, timezone
+
+    from app.services.auth_service import _get_session_timeout_hours
+
+    try:
+        # Get current expires_at
+        row = user_repo.db.fetch_one("SELECT expires_at FROM sessions WHERE token = ?", (token,))
+        if not row or not row.get("expires_at"):
+            logger.debug(f"No session row found for token: {token[:16]}...")
+            return None
+
+        expires_at = row["expires_at"]
+        if isinstance(expires_at, str):
+            expires_at = datetime.fromisoformat(expires_at).replace(tzinfo=None)
+
+        remaining = (expires_at - datetime.now(timezone.utc).replace(tzinfo=None)).total_seconds()
+        threshold = timedelta(minutes=_AUTH_SESSION_REFRESH_THRESHOLD_MINUTES).total_seconds()
+        logger.debug(f"Session refresh check: remaining={remaining/60:.1f}min, threshold={threshold/60:.1f}min")
+        if remaining > threshold:
+            logger.debug(f"Session not refreshed: remaining ({remaining/60:.1f}min) > threshold ({threshold/60:.1f}min)")
+            return None
+
+        # Refresh session
+        timeout_hours = _get_session_timeout_hours()
+        new_expires_at = datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(
+            hours=timeout_hours
+        )
+        user_repo.extend_session_expiry(token, new_expires_at)
+        logger.info(f"Session refreshed in auth check, new expiry: {new_expires_at}")
+        return int(timeout_hours * 3600)
+    except Exception as e:
+        logger.warning(f"Failed to refresh session in auth check: {e}")
+        return None
+
+
 @auth_bp.route("/auth/check", methods=["GET"])
 def api_auth_check():
-    """Check if user is authenticated."""
+    """Check if user is authenticated and extend session if needed."""
+    from flask import make_response
+
     token = request.cookies.get("session_token") or request.headers.get(
         "Authorization", ""
     ).replace("Bearer ", "")
@@ -173,24 +219,40 @@ def api_auth_check():
     if not session:
         return jsonify({"authenticated": False})
 
+    # Check if session needs refresh (sliding expiration)
+    new_timeout_seconds = _refresh_auth_session(token)
+
     user_id = int(session.get("user_id", 0))
     user_data = user_repo.get_user_by_id(user_id)
 
     avatar_url = user_data.get("avatar_url") if user_data else None
     avatar_url = _validate_avatar_url(user_id, avatar_url)
 
-    return jsonify(
-        {
-            "authenticated": True,
-            "user": {
-                "id": session.get("user_id"),
-                "username": session.get("username"),
-                "email": session.get("email"),
-                "role": session.get("role"),
-                "avatar_url": avatar_url,
-            },
-        }
-    )
+    response_data = {
+        "authenticated": True,
+        "user": {
+            "id": session.get("user_id"),
+            "username": session.get("username"),
+            "email": session.get("email"),
+            "role": session.get("role"),
+            "avatar_url": avatar_url,
+        },
+    }
+
+    response = make_response(jsonify(response_data))
+
+    # Update cookie max_age if session was refreshed
+    if new_timeout_seconds and request.cookies.get("session_token"):
+        response.set_cookie(
+            "session_token",
+            request.cookies["session_token"],
+            httponly=True,
+            secure=request.is_secure,
+            samesite="Lax",
+            max_age=new_timeout_seconds,
+        )
+
+    return response
 
 
 @auth_bp.route("/auth/me", methods=["GET"])

--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -185,9 +185,13 @@ def _refresh_auth_session(token: str) -> Optional[int]:
 
         remaining = (expires_at - datetime.now(timezone.utc).replace(tzinfo=None)).total_seconds()
         threshold = timedelta(minutes=_AUTH_SESSION_REFRESH_THRESHOLD_MINUTES).total_seconds()
-        logger.debug(f"Session refresh check: remaining={remaining/60:.1f}min, threshold={threshold/60:.1f}min")
+        logger.debug(
+            f"Session refresh check: remaining={remaining/60:.1f}min, threshold={threshold/60:.1f}min"
+        )
         if remaining > threshold:
-            logger.debug(f"Session not refreshed: remaining ({remaining/60:.1f}min) > threshold ({threshold/60:.1f}min)")
+            logger.debug(
+                f"Session not refreshed: remaining ({remaining/60:.1f}min) > threshold ({threshold/60:.1f}min)"
+            )
             return None
 
         # Refresh session

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -2,11 +2,16 @@
  * useAuth Hook - Authentication hook
  */
 
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { authApi } from '@/api';
 import { useAppStore } from '@/store';
 import type { LoginRequest } from '@/api';
+
+// Session keepalive interval (5 minutes)
+// Backend refreshes session when remaining time < 10 minutes
+// So 5-minute interval ensures session is always refreshed before expiry
+const SESSION_KEEPALIVE_INTERVAL_MS = 5 * 60 * 1000;
 
 export function useAuth() {
   const queryClient = useQueryClient();
@@ -20,6 +25,9 @@ export function useAuth() {
     logout: logoutStore,
   } = useAppStore();
 
+  // Ref for keepalive interval
+  const keepaliveIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
   // Check auth status on mount
   const {
     isLoading: isCheckingAuth,
@@ -31,6 +39,33 @@ export function useAuth() {
     staleTime: 0, // Always refetch
     refetchOnWindowFocus: true,
   });
+
+  // Session keepalive - periodically refresh auth to extend session
+  useEffect(() => {
+    // Clear existing interval
+    if (keepaliveIntervalRef.current) {
+      clearInterval(keepaliveIntervalRef.current);
+      keepaliveIntervalRef.current = null;
+    }
+
+    // Only start keepalive when authenticated
+    if (isAuthenticated) {
+      keepaliveIntervalRef.current = setInterval(() => {
+        // Silently refetch auth to trigger session refresh on backend
+        refetchAuth().catch(() => {
+          // Ignore errors - session may have expired, will be handled by auth check
+        });
+      }, SESSION_KEEPALIVE_INTERVAL_MS);
+    }
+
+    // Cleanup on unmount or when auth status changes
+    return () => {
+      if (keepaliveIntervalRef.current) {
+        clearInterval(keepaliveIntervalRef.current);
+        keepaliveIntervalRef.current = null;
+      }
+    };
+  }, [isAuthenticated, refetchAuth]);
 
   // Update store when auth check completes
   useEffect(() => {


### PR DESCRIPTION
## 问题描述

Issue #325: 用户报告两个相关问题：
1. Ctrl+F5 强制刷新页面会导致退出登录
2. 页面静止2-5分钟后自动退出登录

## 问题根因

1. **后端 Session 续期缺失**：`/api/auth/check` 端点在 `auth.py` 中，不在 `workspace_bp` 路由下，因此不触发 `workspace.py` 中已有的 `_refresh_session` 续期逻辑。

2. **前端心跳机制不完整**：前端心跳保活只在 Workspace 页面的多用户模式下启动。

## 修复方案

### 后端修改 (app/routes/auth.py)
- 新增 `_refresh_auth_session` 函数，实现滑动过期机制
- 当 session 剩余时间少于 10 分钟时自动续期

### 前端修改 (frontend/src/hooks/useAuth.ts)
- 添加全局心跳保活机制（5 分钟间隔）
- 定期调用 `/api/auth/check` 触发后端续期

## 验证结果

在 node237 验证通过：Playwright 测试确认 session 在刷新后持久化。

Fixes #325
