### PR TITLE
fix: 切换项目创建新Tab而非中断会话 (#229)

### DIFF
--- a/frontend/src/components/features/Workspace.tsx
+++ b/frontend/src/components/features/Workspace.tsx
@@ -93,6 +93,12 @@ export const Workspace: React.FC = () => {
   // Remote projects list (Issue #417: Populate "Your Projects" for remote workspace)
   const [remoteProjects, setRemoteProjects] = useState<RemoteProject[]>([]);
 
+  // State for switch project request from iframe (Issue #229)
+  const [switchProjectRequest, setSwitchProjectRequest] = useState<{
+    workspaceType: 'local' | 'remote';
+    machineId?: string;
+  } | null>(null);
+
   // Tab notifications setting
   const enableTabNotifications = useEnableTabNotifications();
 
@@ -403,6 +409,18 @@ export const Workspace: React.FC = () => {
       // Listen for ESC key forwarded from qwen-code-webui iframe (Issue #103)
       if (event.data?.type === 'qwen-code-esc-pressed' && workspaceFullscreen) {
         exitWorkspaceFullscreen();
+      }
+
+      // Listen for switch project request from qwen-code-webui iframe (Issue #229)
+      // When user clicks "Switch project" button inside iframe while thinking,
+      // create a new tab for project selection instead of interrupting current session
+      if (event.data?.type === 'qwen-code-switch-project-request') {
+        const { workspaceType, machineId } = event.data;
+        // Set state to trigger tab creation in separate useEffect
+        setSwitchProjectRequest({
+          workspaceType: workspaceType ?? 'local',
+          machineId: machineId ?? undefined,
+        });
       }
     };
 
@@ -1204,6 +1222,20 @@ export const Workspace: React.FC = () => {
     },
     [getEffectiveUrl, userWebUI, language, addStoredTab, setStoredActiveTabId, clearTabNotification]
   );
+
+  // Handle switch project request from iframe (Issue #229)
+  // Create a new tab for project selection without interrupting current session
+  useEffect(() => {
+    if (switchProjectRequest) {
+      createNewTab(undefined, {
+        workspaceType: switchProjectRequest.workspaceType,
+        machineId: switchProjectRequest.machineId,
+        machineName: undefined, // machineName will be set after project selection
+      });
+      // Clear the request after handling
+      setSwitchProjectRequest(null);
+    }
+  }, [switchProjectRequest, createNewTab]);
 
   // Actually remove a tab (shared by closeTab and remote close confirmation)
   const doCloseTab = useCallback(


### PR DESCRIPTION
## 问题描述

Issue #229: 远程工作区中，当会话正在 thinking 执行任务时，点击【切换项目】按钮会直接中断当前会话，无任何提醒。

## 问题根因

iframe 内切换项目直接调用 `navigate("/")` 重新加载 URL，导致 WebSocket/SSE 连接断开，当前正在 thinking 的会话被中断。

## 修复方案

采用**方案B（推荐）**：创建新 Tab 隔离机制。

- 监听来自 iframe 的 `qwen-code-switch-project-request` 消息
- 收到消息后创建新 Tab（不带项目参数，显示项目选择页面）
- 原 Tab 会话保持运行，不被中断

## 修改内容

- `frontend/src/components/features/Workspace.tsx`
  - 添加 `switchProjectRequest` state 用于存储切换项目请求
  - 添加消息监听器处理 `qwen-code-switch-project-request` 消息
  - 添加 useEffect 处理请求并调用 `createNewTab` 创建新 Tab
  - 使用 `??` 操作符修复 lint 错误

## 配合修改

此 PR 需配合 qwen-code-webui 的修改：
- qwen-code-webui 仓库: ivycomputing/qwen-code-webui
- 本地分支: `fix/issue-229-switch-project-new-tab`
- qwen-code-webui 端修改 `handleBackToProjects` 函数发送消息

## 关联 Issue

Fixes #229