### PR TITLE
feat: unify local and remote API key management (Issue #593)

### DIFF
--- a/app/modules/workspace/api_key_proxy.py
+++ b/app/modules/workspace/api_key_proxy.py
@@ -179,6 +179,11 @@ class APIKeyProxyService:
                 created_by INTEGER,
                 created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                 updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                cli_tools TEXT,
+                cli_settings TEXT,
+                scope TEXT DEFAULT 'remote',
+                priority INTEGER DEFAULT 0,
+                weight INTEGER DEFAULT 100,
                 UNIQUE(tenant_id, provider, key_name)
             )
         """
@@ -231,6 +236,9 @@ class APIKeyProxyService:
         created_by: Optional[int] = None,
         cli_tools: Optional[str] = None,
         cli_settings: Optional[str] = None,
+        scope: str = "remote",
+        priority: int = 0,
+        weight: int = 100,
     ) -> dict[str, Any]:
         """
         Store an encrypted API key for a tenant/provider.
@@ -257,8 +265,8 @@ class APIKeyProxyService:
         try:
             cursor.execute(
                 f"""
-                INSERT INTO api_key_store (tenant_id, provider, key_name, encrypted_key, key_hash, base_url, created_by, cli_tools, cli_settings)
-                VALUES ({_params(9)})
+                INSERT INTO api_key_store (tenant_id, provider, key_name, encrypted_key, key_hash, base_url, created_by, cli_tools, cli_settings, scope, priority, weight)
+                VALUES ({_params(12)})
                 ON CONFLICT (tenant_id, provider, key_name) DO UPDATE SET
                     encrypted_key = EXCLUDED.encrypted_key,
                     key_hash = EXCLUDED.key_hash,
@@ -266,6 +274,9 @@ class APIKeyProxyService:
                     is_active = TRUE,
                     cli_tools = EXCLUDED.cli_tools,
                     cli_settings = EXCLUDED.cli_settings,
+                    scope = EXCLUDED.scope,
+                    priority = EXCLUDED.priority,
+                    weight = EXCLUDED.weight,
                     updated_at = CURRENT_TIMESTAMP
             """,
                 (
@@ -278,6 +289,9 @@ class APIKeyProxyService:
                     created_by,
                     cli_tools,
                     cli_settings,
+                    scope,
+                    priority,
+                    weight,
                 ),
             )
 
@@ -302,6 +316,9 @@ class APIKeyProxyService:
         """
         Resolve and decrypt an API key for a tenant/provider.
 
+        Backward-compatible method that delegates to resolve_api_key_for_scope
+        with scope='remote'.
+
         Args:
             tenant_id: Tenant ID.
             provider: Provider name.
@@ -309,30 +326,96 @@ class APIKeyProxyService:
         Returns:
             Tuple of (api_key, base_url) or None if not found.
         """
+        result = self.resolve_api_key_for_scope(tenant_id, provider, scope="remote")
+        if result is None:
+            return None
+        return (result[0], result[1])
+
+    def resolve_api_key_for_scope(
+        self,
+        tenant_id: int,
+        provider: str,
+        scope: str = "remote",
+        exclude_key_ids: Optional[set[int]] = None,
+    ) -> Optional[tuple[str, Optional[str], int]]:
+        """
+        Resolve and decrypt an API key for a tenant/provider with scope filtering
+        and multi-key scheduling.
+
+        Args:
+            tenant_id: Tenant ID.
+            provider: Provider name.
+            scope: Key scope — 'local', 'remote', or 'shared' matches both.
+            exclude_key_ids: Key IDs to exclude (for failover retries).
+
+        Returns:
+            Tuple of (api_key, base_url, key_id) or None if not found.
+        """
+        from app.modules.workspace.api_key_router import APIKeyRouter
+
         conn = self._get_connection()
         cursor = conn.cursor()
 
         try:
-            cursor.execute(
-                f"""
-                SELECT encrypted_key, base_url FROM api_key_store
-                WHERE tenant_id = {_param()} AND provider = {_param()} AND is_active = TRUE
-                LIMIT 1
-            """,
-                (tenant_id, provider),
-            )
-            row = cursor.fetchone()
+            # Query keys matching scope (exact match or 'shared')
+            if is_postgresql():
+                cursor.execute(
+                    """
+                    SELECT id, encrypted_key, base_url, priority, weight
+                    FROM api_key_store
+                    WHERE tenant_id = %s AND provider = %s AND is_active = TRUE
+                      AND (scope = %s OR scope = 'shared')
+                    """,
+                    (tenant_id, provider, scope),
+                )
+            else:
+                cursor.execute(
+                    """
+                    SELECT id, encrypted_key, base_url, priority, weight
+                    FROM api_key_store
+                    WHERE tenant_id = ? AND provider = ? AND is_active = TRUE
+                      AND (scope = ? OR scope = 'shared')
+                    """,
+                    (tenant_id, provider, scope),
+                )
 
-            if not row:
+            rows = cursor.fetchall()
+
+            if not rows:
                 return None
 
-            encrypted_key = row["encrypted_key"] if isinstance(row, dict) else row["encrypted_key"]
-            base_url = row["base_url"] if isinstance(row, dict) else row["base_url"]
+            # Build candidates for the router
+            candidates = []
+            for row in rows:
+                row_dict = row if isinstance(row, dict) else dict(row)
+                encrypted_key = row_dict["encrypted_key"]
+                base_url = row_dict["base_url"]
+                try:
+                    decrypted = self._decrypt_key(encrypted_key)
+                except Exception as e:
+                    logger.warning("Failed to decrypt key id=%s: %s", row_dict["id"], e)
+                    continue
+                candidates.append(
+                    {
+                        "id": row_dict["id"],
+                        "api_key": decrypted,
+                        "base_url": base_url,
+                        "priority": row_dict.get("priority") or 0,
+                        "weight": row_dict.get("weight") or 100,
+                    }
+                )
 
-            api_key = self._decrypt_key(encrypted_key)
-            return (api_key, base_url)
+            if not candidates:
+                return None
+
+            router = APIKeyRouter()
+            selected = router.select_key(candidates, exclude_key_ids=exclude_key_ids)
+            if selected is None:
+                return None
+
+            return (selected["api_key"], selected["base_url"], selected["id"])
         except Exception as e:
-            logger.error(f"Failed to resolve API key: {e}")
+            logger.error("Failed to resolve API key for scope: %s", e)
             return None
         finally:
             conn.close()
@@ -344,7 +427,7 @@ class APIKeyProxyService:
 
         cursor.execute(
             f"""
-            SELECT id, provider, key_name, base_url, is_active, created_at, updated_at, cli_tools, cli_settings
+            SELECT id, provider, key_name, base_url, is_active, created_at, updated_at, cli_tools, cli_settings, scope, priority, weight
             FROM api_key_store
             WHERE tenant_id = {_param()}
             ORDER BY provider, key_name
@@ -368,6 +451,9 @@ class APIKeyProxyService:
                     "updated_at": row["updated_at"],
                     "cli_tools": row["cli_tools"],
                     "cli_settings": row["cli_settings"],
+                    "scope": row["scope"] or "remote",
+                    "priority": row["priority"] if row["priority"] is not None else 0,
+                    "weight": row["weight"] if row["weight"] is not None else 100,
                 }
             )
         return result
@@ -399,6 +485,9 @@ class APIKeyProxyService:
         cli_tools: Optional[str] = None,
         cli_settings: Optional[str] = None,
         is_active: Optional[bool] = None,
+        scope: Optional[str] = None,
+        priority: Optional[int] = None,
+        weight: Optional[int] = None,
     ) -> bool:
         """
         Update an API key by its ID.
@@ -410,6 +499,10 @@ class APIKeyProxyService:
             base_url: Optional new base URL.
             cli_tools: Optional JSON array of CLI tool names.
             cli_settings: Optional JSON object with settings for each tool.
+            is_active: Optional active status.
+            scope: Optional scope ('local', 'remote', 'shared').
+            priority: Optional priority (higher = preferred).
+            weight: Optional weight for weighted random selection.
 
         Returns:
             True if updated successfully, False otherwise.
@@ -435,6 +528,15 @@ class APIKeyProxyService:
         if is_active is not None:
             updates.append(f"is_active = {_param()}")
             values.append(is_active if is_postgresql() else (1 if is_active else 0))
+        if scope is not None:
+            updates.append(f"scope = {_param()}")
+            values.append(scope)
+        if priority is not None:
+            updates.append(f"priority = {_param()}")
+            values.append(priority)
+        if weight is not None:
+            updates.append(f"weight = {_param()}")
+            values.append(weight)
 
         if not updates:
             conn.close()
@@ -457,7 +559,12 @@ class APIKeyProxyService:
         conn.close()
         return success
 
-    def get_cli_settings_for_tool(self, tenant_id: int, tool_name: str) -> Optional[dict[str, Any]]:
+    def get_cli_settings_for_tool(
+        self,
+        tenant_id: int,
+        tool_name: str,
+        scope: str = "remote",
+    ) -> Optional[dict[str, Any]]:
         """
         Get CLI settings for a specific tool from active API keys.
 
@@ -487,10 +594,11 @@ class APIKeyProxyService:
             SELECT id, provider, encrypted_key, base_url, cli_tools, cli_settings
             FROM api_key_store
             WHERE tenant_id = {_param()} AND is_active = TRUE
+              AND (scope = {_param()} OR scope = 'shared')
             ORDER BY id DESC
             LIMIT 10
         """,
-            (tenant_id,),
+            (tenant_id, scope),
         )
 
         rows = cursor.fetchall()
@@ -742,6 +850,11 @@ def get_ddl_statements() -> list[str]:
             created_by INTEGER,
             created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
             updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            cli_tools TEXT,
+            cli_settings TEXT,
+            scope TEXT DEFAULT 'remote',
+            priority INTEGER DEFAULT 0,
+            weight INTEGER DEFAULT 100,
             UNIQUE(tenant_id, provider, key_name)
         )
         """,

--- a/app/modules/workspace/api_key_router.py
+++ b/app/modules/workspace/api_key_router.py
@@ -1,0 +1,73 @@
+"""
+Open ACE - API Key Router
+
+Multi-key scheduling with priority-based selection and failover support.
+"""
+
+import logging
+import random
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class APIKeyRouter:
+    """
+    Selects an API key from a pool of candidates using priority + failover.
+
+    Strategy:
+    1. Filter out excluded (failed) key IDs
+    2. Sort by priority (descending)
+    3. Take the highest-priority group
+    4. Within that group, select by weighted random sampling
+    """
+
+    def select_key(
+        self,
+        candidates: list[dict[str, Any]],
+        exclude_key_ids: Optional[set[int]] = None,
+    ) -> Optional[dict[str, Any]]:
+        """
+        Select the best API key from candidates.
+
+        Args:
+            candidates: List of dicts with keys: id, priority, weight,
+                        api_key, base_url (and optionally more).
+            exclude_key_ids: Key IDs to skip (e.g. previously failed).
+
+        Returns:
+            The selected candidate dict, or None if no keys available.
+        """
+        if not candidates:
+            return None
+
+        exclude = exclude_key_ids or set()
+
+        # Filter out excluded keys
+        pool = [c for c in candidates if c.get("id") not in exclude]
+        if not pool:
+            logger.warning("All API keys excluded, no key available")
+            return None
+
+        # Sort by priority descending
+        pool.sort(key=lambda c: c.get("priority", 0), reverse=True)
+
+        # Take highest priority group
+        max_priority = pool[0].get("priority", 0)
+        top_group = [c for c in pool if c.get("priority", 0) == max_priority]
+
+        if len(top_group) == 1:
+            return top_group[0]
+
+        # Weighted random selection within the top group
+        return self._weighted_random(top_group)
+
+    def _weighted_random(self, keys: list[dict[str, Any]]) -> dict[str, Any]:
+        """
+        Select a key by weighted random sampling.
+
+        Each key's weight determines its probability of being selected.
+        All weights default to 100 if not specified.
+        """
+        weights = [max(k.get("weight", 100), 1) for k in keys]
+        return random.choices(keys, weights=weights, k=1)[0]

--- a/app/routes/remote.py
+++ b/app/routes/remote.py
@@ -1765,347 +1765,391 @@ def llm_proxy(path=""):
             429,
         )
 
-    # Resolve real API key with scope filtering
+    # Resolve real API key with scope filtering + failover loop
     api_proxy = get_api_key_proxy_service()
-    key_result = api_proxy.resolve_api_key_for_scope(tenant_id, provider, scope="remote")
-    if not key_result:
-        return (
-            jsonify(
-                {
-                    "error": {
-                        "message": f"No API key configured for provider '{provider}'",
-                        "type": "config_error",
+    exclude_key_ids: set[int] = set()
+    max_retries = 2
+
+    for _attempt in range(max_retries + 1):
+        key_result = api_proxy.resolve_api_key_for_scope(
+            tenant_id, provider, scope="remote", exclude_key_ids=exclude_key_ids
+        )
+        if not key_result:
+            return (
+                jsonify(
+                    {
+                        "error": {
+                            "message": f"No API key configured for provider '{provider}'",
+                            "type": "config_error",
+                        }
                     }
-                }
-            ),
-            500,
-        )
-
-    api_key, base_url, key_id = key_result
-
-    # Determine target URL
-    if base_url:
-        target_base = base_url.rstrip("/")
-        if target_base.endswith("/v1"):
-            target_base = target_base[:-3]
-    else:
-        provider_urls = {
-            "openai": "https://api.openai.com",
-            "anthropic": "https://api.anthropic.com",
-            "google": "https://generativelanguage.googleapis.com",
-        }
-        target_base = provider_urls.get(provider, "https://api.openai.com")
-
-    if path:
-        target_url = f"{target_base}/{path}"
-    else:
-        target_url = f"{target_base}{request.path.split('/llm-proxy')[-1]}"
-
-    # Log model from request body
-    try:
-        _body_json = json.loads(request.get_data())
-        _model = _body_json.get("model", "?")
-    except Exception:
-        _model = "?"
-    logger.info(
-        "LLM proxy: %s -> %s model=%s provider=%s key_id=%s",
-        request.method,
-        target_url,
-        _model,
-        provider,
-        key_id,
-    )
-
-    # Log response status for debugging
-    _orig_target_url = target_url
-
-    # ------------------------------------------------------------------
-    # Responses API → Chat Completions conversion for non-OpenAI providers
-    # ------------------------------------------------------------------
-    # Codex CLI uses the OpenAI Responses API (POST /v1/responses) which
-    # many third-party providers (dashscope, etc.) do not support. When
-    # the target provider is not the real OpenAI and the request targets
-    # /v1/responses, we convert the request body to Chat Completions
-    # format and forward to /v1/chat/completions instead.
-    _converted_from_responses = False
-    # Check if the target provider actually supports the Responses API.
-    # Only the real OpenAI API (api.openai.com) supports /v1/responses.
-    # Third-party OpenAI-compatible providers (dashscope, etc.) typically
-    # only support /v1/chat/completions, so we convert the request.
-    _is_real_openai = "api.openai.com" in target_url
-    if path and path.endswith("/responses") and not _is_real_openai:
-        try:
-            resp_body = json.loads(request.get_data())
-            messages = []
-            # Extract input: can be a string or array of content items
-            input_data = resp_body.get("input", "")
-            if isinstance(input_data, str):
-                messages.append({"role": "user", "content": input_data})
-            elif isinstance(input_data, list):
-                # Build message list from input array
-                for item in input_data:
-                    if isinstance(item, dict):
-                        role = item.get("role", "user")
-                        content = item.get("content", "")
-                        if isinstance(content, list):
-                            # Multi-part content
-                            content = " ".join(
-                                p.get("text", "") for p in content if isinstance(p, dict)
-                            )
-                        # Map unsupported roles for non-OpenAI providers
-                        if role == "developer":
-                            role = "system"
-                        messages.append({"role": role, "content": content or ""})
-
-            # Add instructions as system message if present
-            instructions = resp_body.get("instructions")
-            if instructions:
-                messages.insert(0, {"role": "system", "content": instructions})
-
-            if not messages:
-                messages.append({"role": "user", "content": ""})
-
-            cc_body = {
-                "model": resp_body.get("model", ""),
-                "messages": messages,
-                "stream": False,  # Non-streaming: we'll convert the response
-            }
-            if resp_body.get("max_output_tokens"):
-                cc_body["max_tokens"] = resp_body["max_output_tokens"]
-            if resp_body.get("temperature") is not None:
-                cc_body["temperature"] = resp_body["temperature"]
-
-            # Rewrite target URL to /v1/chat/completions
-            target_url = target_url.replace("/responses", "/chat/completions")
-            body = json.dumps(cc_body).encode("utf-8")
-            _converted_from_responses = True
-            logger.info(
-                "LLM proxy: converted Responses API -> Chat Completions for %s "
-                "(non-streaming; streaming conversion not yet implemented)",
-                target_url,
+                ),
+                500,
             )
-        except Exception as e:
-            logger.warning("Failed to convert Responses API request: %s", e)
 
-    # Forward the request
-    try:
-        import requests as http_requests
+        api_key, base_url, key_id = key_result
 
-        # Build forwarded headers
-        fwd_headers = {}
-        for key, value in request.headers:
-            if key.lower() in ("content-type", "accept", "user-agent"):
-                fwd_headers[key] = value
-
-        # Set the real API key
-        if provider == "anthropic":
-            fwd_headers["x-api-key"] = api_key
-            fwd_headers["anthropic-version"] = "2023-06-01"
+        # Determine target URL
+        if base_url:
+            target_base = base_url.rstrip("/")
+            if target_base.endswith("/v1"):
+                target_base = target_base[:-3]
         else:
-            fwd_headers["Authorization"] = f"Bearer {api_key}"
+            provider_urls = {
+                "openai": "https://api.openai.com",
+                "anthropic": "https://api.anthropic.com",
+                "google": "https://generativelanguage.googleapis.com",
+            }
+            target_base = provider_urls.get(provider, "https://api.openai.com")
 
-        # Check if this is a streaming request
-        if not _converted_from_responses:
-            body = request.get_data()
+        if path:
+            target_url = f"{target_base}/{path}"
+        else:
+            target_url = f"{target_base}{request.path.split('/llm-proxy')[-1]}"
 
-        # Forward the request (bypass system proxy to avoid interference)
-        resp = http_requests.request(
-            method=request.method,
-            url=target_url,
-            headers=fwd_headers,
-            data=body,
-            stream=True,
-            timeout=120,
-            proxies={"http": None, "https": None},  # type: ignore[dict-item]
+        # Log model from request body
+        try:
+            _body_json = json.loads(request.get_data())
+            _model = _body_json.get("model", "?")
+        except Exception:
+            _model = "?"
+        logger.info(
+            "LLM proxy: %s -> %s model=%s provider=%s key_id=%s attempt=%d",
+            request.method,
+            target_url,
+            _model,
+            provider,
+            key_id,
+            _attempt + 1,
         )
 
-        if resp.status_code >= 400:
-            peek = (
-                resp.content[:500]
-                if not resp.headers.get("Content-Type", "").startswith("text/event-stream")
-                else b""
-            )
-            logger.error(
-                "LLM proxy error %d from %s key_id=%s: %s",
-                resp.status_code,
-                _orig_target_url,
-                key_id,
-                peek.decode("utf-8", errors="replace"),
-            )
+        # Log response status for debugging
+        _orig_target_url = target_url
 
-        # If we converted from Responses API, convert the Chat Completions
-        # response back to Responses API format
-        if _converted_from_responses and resp.status_code == 200:
+        # ------------------------------------------------------------------
+        # Responses API → Chat Completions conversion for non-OpenAI providers
+        # ------------------------------------------------------------------
+        # Codex CLI uses the OpenAI Responses API (POST /v1/responses) which
+        # many third-party providers (dashscope, etc.) do not support. When
+        # the target provider is not the real OpenAI and the request targets
+        # /v1/responses, we convert the request body to Chat Completions
+        # format and forward to /v1/chat/completions instead.
+        _converted_from_responses = False
+        # Check if the target provider actually supports the Responses API.
+        # Only the real OpenAI API (api.openai.com) supports /v1/responses.
+        # Third-party OpenAI-compatible providers (dashscope, etc.) typically
+        # only support /v1/chat/completions, so we convert the request.
+        _is_real_openai = "api.openai.com" in target_url
+        if path and path.endswith("/responses") and not _is_real_openai:
             try:
-                cc_resp = resp.json()
-                # Build a minimal Responses API compatible response
-                response_id = f"resp_{cc_resp.get('id', 'default')}"
-                model = cc_resp.get("model", "")
-                output_text = ""
-                if cc_resp.get("choices"):
-                    output_text = cc_resp["choices"][0].get("message", {}).get("content", "")
-                usage = cc_resp.get("usage", {})
+                resp_body = json.loads(request.get_data())
+                messages = []
+                # Extract input: can be a string or array of content items
+                input_data = resp_body.get("input", "")
+                if isinstance(input_data, str):
+                    messages.append({"role": "user", "content": input_data})
+                elif isinstance(input_data, list):
+                    # Build message list from input array
+                    for item in input_data:
+                        if isinstance(item, dict):
+                            role = item.get("role", "user")
+                            content = item.get("content", "")
+                            if isinstance(content, list):
+                                # Multi-part content
+                                content = " ".join(
+                                    p.get("text", "") for p in content if isinstance(p, dict)
+                                )
+                            # Map unsupported roles for non-OpenAI providers
+                            if role == "developer":
+                                role = "system"
+                            messages.append({"role": role, "content": content or ""})
 
-                # Return SSE stream in Responses API format
-                import uuid as _uuid
+                # Add instructions as system message if present
+                instructions = resp_body.get("instructions")
+                if instructions:
+                    messages.insert(0, {"role": "system", "content": instructions})
 
-                item_id = f"msg_{_uuid.uuid4().hex[:24]}"
-                events: list[dict] = [
-                    {
-                        "type": "response.created",
-                        "response": {
-                            "id": response_id,
-                            "object": "response",
-                            "status": "in_progress",
-                            "model": model,
-                            "output": [],
-                            "usage": None,
-                        },
-                    },
-                    {
-                        "type": "response.output_item.added",
-                        "output_index": 0,
-                        "item": {
-                            "type": "message",
-                            "id": item_id,
-                            "status": "in_progress",
-                            "role": "assistant",
-                            "content": [],
-                        },
-                    },
-                    {
-                        "type": "response.content_part.added",
-                        "output_index": 0,
-                        "content_index": 0,
-                        "part": {"type": "output_text", "text": ""},
-                    },
-                    {
-                        "type": "response.output_text.delta",
-                        "output_index": 0,
-                        "content_index": 0,
-                        "delta": output_text,
-                    },
-                    {
-                        "type": "response.output_text.done",
-                        "output_index": 0,
-                        "content_index": 0,
-                        "text": output_text,
-                    },
-                    {
-                        "type": "response.content_part.done",
-                        "output_index": 0,
-                        "content_index": 0,
-                        "part": {"type": "output_text", "text": output_text},
-                    },
-                    {
-                        "type": "response.output_item.done",
-                        "output_index": 0,
-                        "item": {
-                            "type": "message",
-                            "id": item_id,
-                            "status": "completed",
-                            "role": "assistant",
-                            "content": [{"type": "output_text", "text": output_text}],
-                        },
-                    },
-                    {
-                        "type": "response.completed",
-                        "response": {
-                            "id": response_id,
-                            "object": "response",
-                            "status": "completed",
-                            "model": model,
-                            "output": [
-                                {
-                                    "type": "message",
-                                    "id": item_id,
-                                    "status": "completed",
-                                    "role": "assistant",
-                                    "content": [{"type": "output_text", "text": output_text}],
-                                }
-                            ],
-                            "usage": (
-                                {
-                                    "input_tokens": usage.get("prompt_tokens", 0),
-                                    "output_tokens": usage.get("completion_tokens", 0),
-                                    "total_tokens": usage.get("total_tokens", 0),
-                                }
-                                if usage
-                                else None
-                            ),
-                        },
-                    },
-                ]
+                if not messages:
+                    messages.append({"role": "user", "content": ""})
 
-                def sse_stream():
-                    for event in events:
-                        yield f"event: {event['type']}\ndata: {json.dumps(event)}\n\n"
+                cc_body = {
+                    "model": resp_body.get("model", ""),
+                    "messages": messages,
+                    "stream": False,  # Non-streaming: we'll convert the response
+                }
+                if resp_body.get("max_output_tokens"):
+                    cc_body["max_tokens"] = resp_body["max_output_tokens"]
+                if resp_body.get("temperature") is not None:
+                    cc_body["temperature"] = resp_body["temperature"]
 
-                return Response(
-                    sse_stream(),
-                    status=200,
-                    content_type="text/event-stream",
+                # Rewrite target URL to /v1/chat/completions
+                target_url = target_url.replace("/responses", "/chat/completions")
+                body = json.dumps(cc_body).encode("utf-8")
+                _converted_from_responses = True
+                logger.info(
+                    "LLM proxy: converted Responses API -> Chat Completions for %s "
+                    "(non-streaming; streaming conversion not yet implemented)",
+                    target_url,
                 )
             except Exception as e:
-                logger.error("Failed to convert CC response to Responses format: %s", e)
-                # Fall through to normal response handling
+                logger.warning("Failed to convert Responses API request: %s", e)
 
-        # Handle streaming response
-        content_type = resp.headers.get("Content-Type", "")
+        # Forward the request
+        try:
+            import requests as http_requests
 
-        def generate():
-            total_content = b""
-            for chunk in resp.iter_content(chunk_size=4096):
-                total_content += chunk
-                yield chunk
+            # Build forwarded headers
+            fwd_headers = {}
+            for key, value in request.headers:
+                if key.lower() in ("content-type", "accept", "user-agent"):
+                    fwd_headers[key] = value
 
-            # After streaming completes, try to extract token usage
-            try:
-                _record_llm_usage(total_content, session_id, user_id, provider, content_type)
-            except Exception as e:
-                logger.error(f"Failed to record LLM usage: {e}")
+            # Set the real API key
+            if provider == "anthropic":
+                fwd_headers["x-api-key"] = api_key
+                fwd_headers["anthropic-version"] = "2023-06-01"
+            else:
+                fwd_headers["Authorization"] = f"Bearer {api_key}"
 
-        # Build response headers
-        response_headers = {}
-        for key, value in resp.headers.items():
-            if key.lower() in ("content-type", "x-request-id", "openai-organization"):
-                response_headers[key] = value
+            # Check if this is a streaming request
+            if not _converted_from_responses:
+                body = request.get_data()
 
-        if "text/event-stream" in content_type:
-            return Response(
-                stream_with_context(generate()),
-                status=resp.status_code,
-                headers=response_headers,
-                content_type=content_type,
-            )
-        else:
-            # Non-streaming response
-            content = resp.content
-            try:
-                _record_llm_usage(content, session_id, user_id, provider, content_type)
-            except Exception as e:
-                logger.error(f"Failed to record LLM usage: {e}")
-
-            return Response(
-                content,
-                status=resp.status_code,
-                headers=response_headers,
-                content_type=content_type,
+            # Forward the request (bypass system proxy to avoid interference)
+            resp = http_requests.request(
+                method=request.method,
+                url=target_url,
+                headers=fwd_headers,
+                data=body,
+                stream=True,
+                timeout=120,
+                proxies={"http": None, "https": None},  # type: ignore[dict-item]
             )
 
-    except Exception as e:
-        logger.error(f"LLM proxy error: {e}")
-        return (
-            jsonify(
-                {
-                    "error": {
-                        "message": f"Proxy error: {str(e)}",
-                        "type": "proxy_error",
+            if resp.status_code >= 400:
+                peek = (
+                    resp.content[:500]
+                    if not resp.headers.get("Content-Type", "").startswith("text/event-stream")
+                    else b""
+                )
+                logger.error(
+                    "LLM proxy error %d from %s key_id=%s: %s",
+                    resp.status_code,
+                    _orig_target_url,
+                    key_id,
+                    peek.decode("utf-8", errors="replace"),
+                )
+
+                # Failover: on auth/quota errors, exclude this key and retry
+                if resp.status_code in (401, 403) and _attempt < max_retries:
+                    logger.info(
+                        "LLM proxy failover: excluding key_id=%s, retrying (%d/%d)",
+                        key_id,
+                        _attempt + 1,
+                        max_retries,
+                    )
+                    exclude_key_ids.add(key_id)
+                    continue
+                if resp.status_code == 429 and _attempt < max_retries:
+                    logger.info(
+                        "LLM proxy rate-limited: excluding key_id=%s, retrying (%d/%d)",
+                        key_id,
+                        _attempt + 1,
+                        max_retries,
+                    )
+                    exclude_key_ids.add(key_id)
+                    continue
+
+            # If we converted from Responses API, convert the Chat Completions
+            # response back to Responses API format
+            if _converted_from_responses and resp.status_code == 200:
+                try:
+                    cc_resp = resp.json()
+                    # Build a minimal Responses API compatible response
+                    response_id = f"resp_{cc_resp.get('id', 'default')}"
+                    model = cc_resp.get("model", "")
+                    output_text = ""
+                    if cc_resp.get("choices"):
+                        output_text = cc_resp["choices"][0].get("message", {}).get("content", "")
+                    usage = cc_resp.get("usage", {})
+
+                    # Return SSE stream in Responses API format
+                    import uuid as _uuid
+
+                    item_id = f"msg_{_uuid.uuid4().hex[:24]}"
+                    events: list[dict] = [
+                        {
+                            "type": "response.created",
+                            "response": {
+                                "id": response_id,
+                                "object": "response",
+                                "status": "in_progress",
+                                "model": model,
+                                "output": [],
+                                "usage": None,
+                            },
+                        },
+                        {
+                            "type": "response.output_item.added",
+                            "output_index": 0,
+                            "item": {
+                                "type": "message",
+                                "id": item_id,
+                                "status": "in_progress",
+                                "role": "assistant",
+                                "content": [],
+                            },
+                        },
+                        {
+                            "type": "response.content_part.added",
+                            "output_index": 0,
+                            "content_index": 0,
+                            "part": {"type": "output_text", "text": ""},
+                        },
+                        {
+                            "type": "response.output_text.delta",
+                            "output_index": 0,
+                            "content_index": 0,
+                            "delta": output_text,
+                        },
+                        {
+                            "type": "response.output_text.done",
+                            "output_index": 0,
+                            "content_index": 0,
+                            "text": output_text,
+                        },
+                        {
+                            "type": "response.content_part.done",
+                            "output_index": 0,
+                            "content_index": 0,
+                            "part": {"type": "output_text", "text": output_text},
+                        },
+                        {
+                            "type": "response.output_item.done",
+                            "output_index": 0,
+                            "item": {
+                                "type": "message",
+                                "id": item_id,
+                                "status": "completed",
+                                "role": "assistant",
+                                "content": [{"type": "output_text", "text": output_text}],
+                            },
+                        },
+                        {
+                            "type": "response.completed",
+                            "response": {
+                                "id": response_id,
+                                "object": "response",
+                                "status": "completed",
+                                "model": model,
+                                "output": [
+                                    {
+                                        "type": "message",
+                                        "id": item_id,
+                                        "status": "completed",
+                                        "role": "assistant",
+                                        "content": [{"type": "output_text", "text": output_text}],
+                                    }
+                                ],
+                                "usage": (
+                                    {
+                                        "input_tokens": usage.get("prompt_tokens", 0),
+                                        "output_tokens": usage.get("completion_tokens", 0),
+                                        "total_tokens": usage.get("total_tokens", 0),
+                                    }
+                                    if usage
+                                    else None
+                                ),
+                            },
+                        },
+                    ]
+
+                    def sse_stream(_events=events):  # noqa: B023
+                        for event in _events:
+                            yield f"event: {event['type']}\ndata: {json.dumps(event)}\n\n"
+
+                    return Response(
+                        sse_stream(),
+                        status=200,
+                        content_type="text/event-stream",
+                    )
+                except Exception as e:
+                    logger.error("Failed to convert CC response to Responses format: %s", e)
+                    # Fall through to normal response handling
+
+            # Handle streaming response
+            content_type = resp.headers.get("Content-Type", "")
+
+            def generate(_resp=resp, _content_type=content_type):  # noqa: B023
+                total_content = b""
+                for chunk in _resp.iter_content(chunk_size=4096):
+                    total_content += chunk
+                    yield chunk
+
+                # After streaming completes, try to extract token usage
+                try:
+                    _record_llm_usage(total_content, session_id, user_id, provider, _content_type)
+                except Exception as e:
+                    logger.error(f"Failed to record LLM usage: {e}")
+
+            # Build response headers
+            response_headers = {}
+            for key, value in resp.headers.items():
+                if key.lower() in (
+                    "content-type",
+                    "x-request-id",
+                    "openai-organization",
+                ):
+                    response_headers[key] = value
+
+            if "text/event-stream" in content_type:
+                return Response(
+                    stream_with_context(generate()),
+                    status=resp.status_code,
+                    headers=response_headers,
+                    content_type=content_type,
+                )
+            else:
+                # Non-streaming response
+                content = resp.content
+                try:
+                    _record_llm_usage(content, session_id, user_id, provider, content_type)
+                except Exception as e:
+                    logger.error(f"Failed to record LLM usage: {e}")
+
+                return Response(
+                    content,
+                    status=resp.status_code,
+                    headers=response_headers,
+                    content_type=content_type,
+                )
+
+        except Exception as e:
+            logger.error(f"LLM proxy error: {e}")
+            return (
+                jsonify(
+                    {
+                        "error": {
+                            "message": f"Proxy error: {str(e)}",
+                            "type": "proxy_error",
+                        }
                     }
+                ),
+                502,
+            )
+
+    # Should not reach here (all paths return within the loop)
+    return (
+        jsonify(
+            {
+                "error": {
+                    "message": "All API key attempts failed",
+                    "type": "proxy_error",
                 }
-            ),
-            502,
-        )
+            }
+        ),
+        502,
+    )
 
 
 def _record_llm_usage(

--- a/app/routes/remote.py
+++ b/app/routes/remote.py
@@ -1765,16 +1765,34 @@ def llm_proxy(path=""):
             429,
         )
 
-    # Resolve real API key with scope filtering + failover loop
+    # Resolve real API key with scope filtering + failover loop.
+    # Retries until no more candidate keys remain for the provider/scope.
     api_proxy = get_api_key_proxy_service()
     exclude_key_ids: set[int] = set()
-    max_retries = 2
+    attempt = 0
 
-    for _attempt in range(max_retries + 1):
+    while True:
+        attempt += 1
         key_result = api_proxy.resolve_api_key_for_scope(
             tenant_id, provider, scope="remote", exclude_key_ids=exclude_key_ids
         )
         if not key_result:
+            if exclude_key_ids:
+                # All candidate keys exhausted
+                return (
+                    jsonify(
+                        {
+                            "error": {
+                                "message": (
+                                    f"All {len(exclude_key_ids)} API key(s) failed "
+                                    f"for provider '{provider}'"
+                                ),
+                                "type": "upstream_error",
+                            }
+                        }
+                    ),
+                    502,
+                )
             return (
                 jsonify(
                     {
@@ -1820,7 +1838,7 @@ def llm_proxy(path=""):
             _model,
             provider,
             key_id,
-            _attempt + 1,
+            attempt,
         )
 
         # Log response status for debugging
@@ -1941,21 +1959,19 @@ def llm_proxy(path=""):
                 )
 
                 # Failover: on auth/quota errors, exclude this key and retry
-                if resp.status_code in (401, 403) and _attempt < max_retries:
+                if resp.status_code in (401, 403):
                     logger.info(
-                        "LLM proxy failover: excluding key_id=%s, retrying (%d/%d)",
+                        "LLM proxy failover: excluding key_id=%s, retrying (attempt %d)",
                         key_id,
-                        _attempt + 1,
-                        max_retries,
+                        attempt,
                     )
                     exclude_key_ids.add(key_id)
                     continue
-                if resp.status_code == 429 and _attempt < max_retries:
+                if resp.status_code == 429:
                     logger.info(
-                        "LLM proxy rate-limited: excluding key_id=%s, retrying (%d/%d)",
+                        "LLM proxy rate-limited: excluding key_id=%s, retrying (attempt %d)",
                         key_id,
-                        _attempt + 1,
-                        max_retries,
+                        attempt,
                     )
                     exclude_key_ids.add(key_id)
                     continue
@@ -2138,7 +2154,7 @@ def llm_proxy(path=""):
                 502,
             )
 
-    # Should not reach here (all paths return within the loop)
+    # Should not reach here — all loop paths either return or continue
     return (
         jsonify(
             {

--- a/app/routes/remote.py
+++ b/app/routes/remote.py
@@ -343,9 +343,15 @@ def store_api_key():
     cli_settings = data.get(
         "cli_settings"
     )  # JSON object: {"claude-code": {...}, "qwen-code": {...}}
+    scope = data.get("scope", "remote")
+    priority = data.get("priority", 0)
+    weight = data.get("weight", 100)
 
     if not provider or not key_name or not api_key:
         return jsonify({"error": "provider, key_name, and api_key are required"}), 400
+
+    if scope not in ("local", "remote", "shared"):
+        return jsonify({"error": "scope must be 'local', 'remote', or 'shared'"}), 400
 
     validation_error = validate_cli_settings_payload(cli_settings)
     if validation_error:
@@ -361,6 +367,9 @@ def store_api_key():
         created_by=g.user["id"],
         cli_tools=cli_tools,
         cli_settings=cli_settings,
+        scope=scope,
+        priority=int(priority),
+        weight=int(weight),
     )
 
     if result.get("success"):
@@ -381,6 +390,11 @@ def update_api_key(key_id):
     is_active = data.get("is_active")
     if is_active is not None and not isinstance(is_active, bool):
         return jsonify({"error": "is_active must be a boolean"}), 400
+    scope = data.get("scope")
+    if scope is not None and scope not in ("local", "remote", "shared"):
+        return jsonify({"error": "scope must be 'local', 'remote', or 'shared'"}), 400
+    priority = data.get("priority")
+    weight = data.get("weight")
     tenant_id = int(data.get("tenant_id", 1))
 
     validation_error = validate_cli_settings_payload(cli_settings)
@@ -396,6 +410,9 @@ def update_api_key(key_id):
         cli_tools=cli_tools,
         cli_settings=cli_settings,
         is_active=is_active,
+        scope=scope,
+        priority=int(priority) if priority is not None else None,
+        weight=int(weight) if weight is not None else None,
     )
 
     if success:
@@ -1748,8 +1765,9 @@ def llm_proxy(path=""):
             429,
         )
 
-    # Resolve real API key
-    key_result = api_proxy.resolve_api_key(tenant_id, provider)
+    # Resolve real API key with scope filtering
+    api_proxy = get_api_key_proxy_service()
+    key_result = api_proxy.resolve_api_key_for_scope(tenant_id, provider, scope="remote")
     if not key_result:
         return (
             jsonify(
@@ -1763,16 +1781,14 @@ def llm_proxy(path=""):
             500,
         )
 
-    api_key, base_url = key_result
+    api_key, base_url, key_id = key_result
 
     # Determine target URL
     if base_url:
         target_base = base_url.rstrip("/")
-        # If base_url already ends with /v1, strip the /v1 prefix from path
         if target_base.endswith("/v1"):
-            target_base = target_base[:-3]  # Remove trailing /v1
+            target_base = target_base[:-3]
     else:
-        # Default provider URLs
         provider_urls = {
             "openai": "https://api.openai.com",
             "anthropic": "https://api.anthropic.com",
@@ -1781,11 +1797,8 @@ def llm_proxy(path=""):
         target_base = provider_urls.get(provider, "https://api.openai.com")
 
     if path:
-        # For Anthropic provider, keep the full path including /v1 prefix
-        # (z.ai proxy needs /v1/messages, not /messages)
         target_url = f"{target_base}/{path}"
     else:
-        # Handle direct path in the request URL
         target_url = f"{target_base}{request.path.split('/llm-proxy')[-1]}"
 
     # Log model from request body
@@ -1795,7 +1808,12 @@ def llm_proxy(path=""):
     except Exception:
         _model = "?"
     logger.info(
-        "LLM proxy: %s -> %s model=%s provider=%s", request.method, target_url, _model, provider
+        "LLM proxy: %s -> %s model=%s provider=%s key_id=%s",
+        request.method,
+        target_url,
+        _model,
+        provider,
+        key_id,
     )
 
     # Log response status for debugging
@@ -1908,7 +1926,11 @@ def llm_proxy(path=""):
                 else b""
             )
             logger.error(
-                f"LLM proxy error {resp.status_code} from {_orig_target_url}: {peek.decode('utf-8', errors='replace')}"
+                "LLM proxy error %d from %s key_id=%s: %s",
+                resp.status_code,
+                _orig_target_url,
+                key_id,
+                peek.decode("utf-8", errors="replace"),
             )
 
         # If we converted from Responses API, convert the Chat Completions

--- a/app/services/insights_service.py
+++ b/app/services/insights_service.py
@@ -45,27 +45,31 @@ class InsightsService:
 
     def _get_api_credentials(self, config: dict) -> tuple[str, str]:
         """
-        Get API credentials from config and environment.
+        Get API credentials from the api_key_store database.
 
-        Supports multiple key names used across deployments:
-        - BAILIAN_CODING_PLAN_API_KEY (production deployment)
-        - OPENAI_API_KEY (standard)
+        Resolves keys with scope='local' or 'shared' for the openai provider.
+        Falls back to environment variables if no key is found in the database.
 
         Returns:
             Tuple[api_key, base_url]
         """
-        auth_cfg = config.get("auth", {}).get("env", {})
-        api_key = (
-            auth_cfg.get("BAILIAN_CODING_PLAN_API_KEY")
-            or os.environ.get("BAILIAN_CODING_PLAN_API_KEY", "")
-            or auth_cfg.get("OPENAI_API_KEY")
-            or os.environ.get("OPENAI_API_KEY", "")
-        )
-        base_url = (
-            auth_cfg.get("OPENAI_BASE_URL")
-            or os.environ.get("OPENAI_BASE_URL")
-            or "https://coding.dashscope.aliyuncs.com/v1"
-        )
+        # Primary: resolve from database
+        try:
+            from app.modules.workspace.api_key_proxy import get_api_key_proxy_service
+
+            api_proxy = get_api_key_proxy_service()
+            result = api_proxy.resolve_api_key_for_scope(1, "openai", scope="local")
+            if result:
+                api_key, base_url, _ = result
+                if base_url:
+                    return api_key, base_url
+                return api_key, "https://coding.dashscope.aliyuncs.com/v1"
+        except Exception as e:
+            logger.warning("Failed to resolve API key from database: %s", e)
+
+        # Fallback: environment variables
+        api_key = os.environ.get("OPENAI_API_KEY", "")
+        base_url = os.environ.get("OPENAI_BASE_URL", "https://coding.dashscope.aliyuncs.com/v1")
         return api_key, base_url
 
     def generate_insights(

--- a/app/services/webui_manager.py
+++ b/app/services/webui_manager.py
@@ -140,8 +140,6 @@ class WorkspaceConfig:
     cleanup_interval_minutes: int = 5
     token_secret: str = ""
     webui_path: str = ""  # Path to qwen-code-webui project directory
-    auth_type: str = ""  # Authentication type: openai, anthropic, gemini etc.
-    auth_env: dict[str, str] = field(default_factory=dict)  # Environment variables for auth
 
 
 class WebUIManager:
@@ -209,7 +207,6 @@ class WebUIManager:
                 config = json.load(f)
 
             workspace = config.get("workspace", {})
-            auth = config.get("auth", {})
             return WorkspaceConfig(
                 enabled=workspace.get("enabled", False),
                 url=workspace.get("url", "http://localhost"),
@@ -221,8 +218,6 @@ class WebUIManager:
                 cleanup_interval_minutes=workspace.get("cleanup_interval_minutes", 5),
                 token_secret=workspace.get("token_secret", ""),
                 webui_path=workspace.get("webui_path", ""),
-                auth_type=auth.get("auth_type", ""),
-                auth_env=auth.get("env", {}),
             )
         except Exception as e:
             logger.error(f"Error loading config: {e}")
@@ -538,6 +533,40 @@ class WebUIManager:
         except Exception:
             return {}
 
+    def _inject_local_api_keys(self, env: dict[str, str]) -> None:
+        """
+        Inject API keys from api_key_store into the child process environment.
+
+        Resolves keys with scope='local' or scope='shared' and sets the
+        standard environment variables (OPENAI_API_KEY, OPENAI_BASE_URL,
+        ANTHROPIC_API_KEY, ANTHROPIC_BASE_URL) for the webui subprocess.
+        """
+        try:
+            from app.modules.workspace.api_key_proxy import get_api_key_proxy_service
+
+            api_proxy = get_api_key_proxy_service()
+            tenant_id = 1  # Default tenant for local workspace
+
+            # Resolve OpenAI provider key
+            openai_result = api_proxy.resolve_api_key_for_scope(tenant_id, "openai", scope="local")
+            if openai_result:
+                api_key, base_url, _ = openai_result
+                env["OPENAI_API_KEY"] = api_key
+                if base_url:
+                    env["OPENAI_BASE_URL"] = base_url
+
+            # Resolve Anthropic provider key
+            anthropic_result = api_proxy.resolve_api_key_for_scope(
+                tenant_id, "anthropic", scope="local"
+            )
+            if anthropic_result:
+                api_key, base_url, _ = anthropic_result
+                env["ANTHROPIC_API_KEY"] = api_key
+                if base_url:
+                    env["ANTHROPIC_BASE_URL"] = base_url
+        except Exception as e:
+            logger.warning("Failed to inject local API keys from database: %s", e)
+
     def _launch_webui_process(
         self, user_id: int, system_account: str, port: int
     ) -> Optional[subprocess.Popen]:
@@ -576,7 +605,8 @@ class WebUIManager:
 
         # Build child environment first (needed for sudo env passing)
         child_env = os.environ.copy()
-        child_env.update(self.config.auth_env)
+        # Inject API keys from database for local workspace use
+        self._inject_local_api_keys(child_env)
 
         # Set OPENACE_LOG_DIR to /tmp to avoid HOME permission issues
         webui_log_dir = f"/tmp/qwen-code-webui-{user_id}"
@@ -656,10 +686,6 @@ class WebUIManager:
                 openace_api_url,
             ]
             cwd = None
-
-        # Append --auth-type if configured
-        if self.config.auth_type:
-            cmd.extend(["--auth-type", self.config.auth_type])
 
         logger.debug(f"Launching webui: {cmd}, cwd: {cwd}")
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -295,10 +295,10 @@ const ManageRoutes: React.FC = () => {
 
           {/* Remote Workspace */}
           <Route path="/remote/machines" element={<RemoteMachineManagement />} />
-          <Route path="/remote/api-keys" element={<APIKeyManagement />} />
 
           {/* Settings */}
           <Route path="/settings/sso" element={<SSOSettings />} />
+          <Route path="/settings/api-keys" element={<APIKeyManagement />} />
 
           {/* Default */}
           <Route path="*" element={<Navigate to="/manage/dashboard" replace />} />

--- a/frontend/src/api/remote.ts
+++ b/frontend/src/api/remote.ts
@@ -47,6 +47,9 @@ export interface ApiKey {
   updated_at: string;
   cli_tools: string | null; // JSON array: ["claude-code", "qwen-code"]
   cli_settings: string | null; // JSON object: {"claude-code": {...}, "qwen-code": {...}}
+  scope: string; // 'local', 'remote', or 'shared'
+  priority: number;
+  weight: number;
 }
 
 export interface StoreApiKeyRequest {
@@ -57,6 +60,9 @@ export interface StoreApiKeyRequest {
   tenant_id?: number;
   cli_tools?: string; // JSON array: ["claude-code", "qwen-code"]
   cli_settings?: string; // JSON object: {"claude-code": {...}, "qwen-code": {...}}
+  scope?: string; // 'local', 'remote', or 'shared' (default 'remote')
+  priority?: number;
+  weight?: number;
 }
 
 export interface UpdateApiKeyRequest {
@@ -67,6 +73,9 @@ export interface UpdateApiKeyRequest {
   cli_settings?: string;
   is_active?: boolean;
   tenant_id?: number;
+  scope?: string;
+  priority?: number;
+  weight?: number;
 }
 
 export interface RemoteSession {

--- a/frontend/src/components/features/management/APIKeyManagement.tsx
+++ b/frontend/src/components/features/management/APIKeyManagement.tsx
@@ -119,6 +119,10 @@ export const APIKeyManagement: React.FC = () => {
     claude_settings: '',
     qwen_settings: '',
     codex_settings: '',
+    scope: 'shared' as string,
+    priority: 0,
+    weight: 100,
+    showAdvanced: false,
   });
 
   const stringifyCodexSettings = (value: unknown): string => {
@@ -174,6 +178,10 @@ export const APIKeyManagement: React.FC = () => {
       claude_settings: '',
       qwen_settings: '',
       codex_settings: '',
+      scope: 'shared',
+      priority: 0,
+      weight: 100,
+      showAdvanced: false,
     });
     setShowAddDialog(true);
   };
@@ -222,6 +230,10 @@ export const APIKeyManagement: React.FC = () => {
       claude_settings: claudeSettings,
       qwen_settings: qwenSettings,
       codex_settings: codexSettings,
+      scope: key.scope || 'shared',
+      priority: key.priority ?? 0,
+      weight: key.weight ?? 100,
+      showAdvanced: (key.priority ?? 0) !== 0 || (key.weight ?? 100) !== 100,
     });
     setShowEditDialog(true);
   };
@@ -387,6 +399,9 @@ export const APIKeyManagement: React.FC = () => {
         base_url: formData.base_url || undefined,
         cli_tools: JSON.stringify(formData.cli_tools),
         cli_settings: buildCliSettingsJson(),
+        scope: formData.scope,
+        priority: formData.priority,
+        weight: formData.weight,
       });
       setShowAddDialog(false);
       refetch();
@@ -425,6 +440,9 @@ export const APIKeyManagement: React.FC = () => {
         base_url: formData.base_url || undefined,
         cli_tools: JSON.stringify(formData.cli_tools),
         cli_settings: buildCliSettingsJson(),
+        scope: formData.scope,
+        priority: formData.priority,
+        weight: formData.weight,
       });
       setShowEditDialog(false);
       setEditTarget(null);
@@ -485,7 +503,7 @@ export const APIKeyManagement: React.FC = () => {
               <tr>
                 <th>{t('provider', language)}</th>
                 <th>{t('keyName', language)}</th>
-                <th>{t('baseUrl', language)}</th>
+                <th>Scope</th>
                 <th>{t('cliTools', language)}</th>
                 <th>{t('keyStatus', language)}</th>
                 <th>{t('tableCreatedAt', language)}</th>
@@ -495,6 +513,8 @@ export const APIKeyManagement: React.FC = () => {
             <tbody>
               {keys.map((key) => {
                 const cliTools = parsedCliTools.get(key.id) ?? [];
+                const scopeLabel = key.scope === 'shared' ? 'Shared' : key.scope === 'local' ? 'Local' : 'Remote';
+                const scopeVariant = key.scope === 'shared' ? 'success' : key.scope === 'local' ? 'info' : 'warning';
                 return (
                   <tr key={key.id}>
                     <td>
@@ -504,8 +524,13 @@ export const APIKeyManagement: React.FC = () => {
                     </td>
                     <td>
                       <strong>{key.key_name}</strong>
+                      {key.priority > 0 && (
+                        <small className="text-muted ms-1">P{key.priority}</small>
+                      )}
                     </td>
-                    <td className="text-muted">{key.base_url ?? '-'}</td>
+                    <td>
+                      <Badge variant={scopeVariant}>{scopeLabel}</Badge>
+                    </td>
                     <td>
                       {cliTools.length > 0 ? (
                         cliTools.map((tool) => (
@@ -624,6 +649,61 @@ export const APIKeyManagement: React.FC = () => {
           />
         </div>
 
+        {/* Scope Selection */}
+        <div className="mb-3">
+          <label className="form-label">Scope</label>
+          <Select
+            options={[
+              { value: 'shared', label: 'Shared (Local + Remote)' },
+              { value: 'local', label: 'Local Only (WebUI, Insights)' },
+              { value: 'remote', label: 'Remote Only (LLM Proxy)' },
+            ]}
+            value={formData.scope}
+            onChange={(v) => setFormData({ ...formData, scope: v })}
+          />
+          <small className="text-muted">
+            Determines which workspace types can use this key. "Shared" is recommended.
+          </small>
+        </div>
+
+        {/* Advanced Settings (collapsed by default) */}
+        <div className="mb-3">
+          <button
+            type="button"
+            className="btn btn-link p-0 text-decoration-none"
+            onClick={() => setFormData({ ...formData, showAdvanced: !formData.showAdvanced })}
+          >
+            <i className={`bi bi-chevron-${formData.showAdvanced ? 'up' : 'down'} me-1`} />
+            Advanced Settings
+          </button>
+          {formData.showAdvanced && (
+            <div className="mt-2 p-3 border rounded bg-light">
+              <div className="row">
+                <div className="col-6">
+                  <label className="form-label">Priority</label>
+                  <TextInput
+                    type="number"
+                    value={String(formData.priority)}
+                    onChange={(v) => setFormData({ ...formData, priority: parseInt(v) || 0 })}
+                    placeholder="0"
+                  />
+                  <small className="text-muted">Higher = preferred. Default: 0</small>
+                </div>
+                <div className="col-6">
+                  <label className="form-label">Weight</label>
+                  <TextInput
+                    type="number"
+                    value={String(formData.weight)}
+                    onChange={(v) => setFormData({ ...formData, weight: parseInt(v) || 100 })}
+                    placeholder="100"
+                  />
+                  <small className="text-muted">For weighted random within same priority. Default: 100</small>
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+
         {/* CLI Tools Section */}
         <div className="mb-3">
           <label className="form-label">{t('cliTools', language)}</label>
@@ -734,6 +814,61 @@ export const APIKeyManagement: React.FC = () => {
             onChange={(v) => setFormData({ ...formData, base_url: v })}
             placeholder={t('enterBaseUrl', language)}
           />
+        </div>
+
+        {/* Scope Selection */}
+        <div className="mb-3">
+          <label className="form-label">Scope</label>
+          <Select
+            options={[
+              { value: 'shared', label: 'Shared (Local + Remote)' },
+              { value: 'local', label: 'Local Only (WebUI, Insights)' },
+              { value: 'remote', label: 'Remote Only (LLM Proxy)' },
+            ]}
+            value={formData.scope}
+            onChange={(v) => setFormData({ ...formData, scope: v })}
+          />
+          <small className="text-muted">
+            Determines which workspace types can use this key. "Shared" is recommended.
+          </small>
+        </div>
+
+        {/* Advanced Settings (collapsed by default) */}
+        <div className="mb-3">
+          <button
+            type="button"
+            className="btn btn-link p-0 text-decoration-none"
+            onClick={() => setFormData({ ...formData, showAdvanced: !formData.showAdvanced })}
+          >
+            <i className={`bi bi-chevron-${formData.showAdvanced ? 'up' : 'down'} me-1`} />
+            Advanced Settings
+          </button>
+          {formData.showAdvanced && (
+            <div className="mt-2 p-3 border rounded bg-light">
+              <div className="row">
+                <div className="col-6">
+                  <label className="form-label">Priority</label>
+                  <TextInput
+                    type="number"
+                    value={String(formData.priority)}
+                    onChange={(v) => setFormData({ ...formData, priority: parseInt(v) || 0 })}
+                    placeholder="0"
+                  />
+                  <small className="text-muted">Higher = preferred. Default: 0</small>
+                </div>
+                <div className="col-6">
+                  <label className="form-label">Weight</label>
+                  <TextInput
+                    type="number"
+                    value={String(formData.weight)}
+                    onChange={(v) => setFormData({ ...formData, weight: parseInt(v) || 100 })}
+                    placeholder="100"
+                  />
+                  <small className="text-muted">For weighted random within same priority. Default: 100</small>
+                </div>
+              </div>
+            </div>
+          )}
         </div>
 
         {/* CLI Tools Section */}

--- a/frontend/src/components/features/management/APIKeyManagement.tsx
+++ b/frontend/src/components/features/management/APIKeyManagement.tsx
@@ -655,7 +655,7 @@ export const APIKeyManagement: React.FC = () => {
           <Select
             options={[
               { value: 'shared', label: 'Shared (Local + Remote)' },
-              { value: 'local', label: 'Local Only (WebUI, Insights)' },
+              { value: 'local', label: 'Local Only' },
               { value: 'remote', label: 'Remote Only (LLM Proxy)' },
             ]}
             value={formData.scope}
@@ -822,7 +822,7 @@ export const APIKeyManagement: React.FC = () => {
           <Select
             options={[
               { value: 'shared', label: 'Shared (Local + Remote)' },
-              { value: 'local', label: 'Local Only (WebUI, Insights)' },
+              { value: 'local', label: 'Local Only' },
               { value: 'remote', label: 'Remote Only (LLM Proxy)' },
             ]}
             value={formData.scope}

--- a/frontend/src/components/layout/ManageLayout.tsx
+++ b/frontend/src/components/layout/ManageLayout.tsx
@@ -151,13 +151,6 @@ const navSections: NavSection[] = [
         path: '/manage/remote/machines',
         adminOnly: true,
       },
-      {
-        id: 'api-keys',
-        label: 'apiKeys',
-        icon: 'bi-key',
-        path: '/manage/remote/api-keys',
-        adminOnly: true,
-      },
     ],
   },
   {
@@ -169,6 +162,13 @@ const navSections: NavSection[] = [
         label: 'ssoSettings',
         icon: 'bi-key',
         path: '/manage/settings/sso',
+        adminOnly: true,
+      },
+      {
+        id: 'api-keys',
+        label: 'apiKeys',
+        icon: 'bi-key-fill',
+        path: '/manage/settings/api-keys',
         adminOnly: true,
       },
     ],

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -786,7 +786,7 @@ const translations: Record<Language, Translations> = {
     baseUrl: 'Base URL',
     enterKeyName: 'Enter key name',
     enterApiKey: 'Enter API key',
-    enterBaseUrl: 'Enter base URL (optional)',
+    enterBaseUrl: 'Enter base URL',
     noApiKeys: 'No API keys configured',
     noApiKeysDescription: 'Add API keys to enable LLM proxy for remote agents.',
     keyStatus: 'Status',

--- a/migrations/versions/20260528_047_add_api_key_scope_fields.py
+++ b/migrations/versions/20260528_047_add_api_key_scope_fields.py
@@ -1,0 +1,46 @@
+"""Add scope, priority, weight columns to api_key_store
+
+Revision ID: 047_api_key_scope
+Revises: 046_login_attempts
+Create Date: 2026-05-28
+
+Adds columns for unified API key management:
+- scope: 'local', 'remote', or 'shared' (default 'remote')
+- priority: higher = preferred (default 0)
+- weight: for weighted random within same priority (default 100)
+
+Issue: https://github.com/open-ace/open-ace/issues/593
+"""
+
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "047_api_key_scope"
+down_revision: Union[str, None] = "046_login_attempts"
+branch_labels: Union[str, None] = None
+depends_on: Union[str, None] = None
+
+
+def upgrade() -> None:
+    """Add scope, priority, weight columns to api_key_store."""
+    op.add_column(
+        "api_key_store",
+        sa.Column("scope", sa.TEXT, nullable=True, server_default="remote"),
+    )
+    op.add_column(
+        "api_key_store",
+        sa.Column("priority", sa.INTEGER, nullable=True, server_default="0"),
+    )
+    op.add_column(
+        "api_key_store",
+        sa.Column("weight", sa.INTEGER, nullable=True, server_default="100"),
+    )
+
+
+def downgrade() -> None:
+    """Remove scope, priority, weight columns."""
+    op.drop_column("api_key_store", "weight")
+    op.drop_column("api_key_store", "priority")
+    op.drop_column("api_key_store", "scope")

--- a/scripts/install-central/docker-method/install.sh
+++ b/scripts/install-central/docker-method/install.sh
@@ -1814,13 +1814,6 @@ $workspace_config,
     "enabled": true,
     "run_time": "00:30"
   },
-  "auth": {
-    "auth_type": "openai",
-    "env": {
-      "OPENAI_API_KEY": "<YOUR_API_KEY>",
-      "OPENAI_BASE_URL": "https://api.openai.com/v1"
-    }
-  },
   "insights": {
     "model": "glm-5",
     "temperature": 0.3,

--- a/tests/issues/593/test_api_key_router.py
+++ b/tests/issues/593/test_api_key_router.py
@@ -1,0 +1,117 @@
+"""
+Unit tests for APIKeyRouter — multi-key scheduling with priority + failover.
+
+Related Issue: https://github.com/open-ace/open-ace/issues/593
+"""
+
+import unittest
+
+from app.modules.workspace.api_key_router import APIKeyRouter
+
+
+class TestAPIKeyRouter(unittest.TestCase):
+    """Tests for the APIKeyRouter priority + weighted random selection."""
+
+    def setUp(self):
+        self.router = APIKeyRouter()
+
+    def test_select_single_key(self):
+        """With one candidate, always returns that key."""
+        candidates = [{"id": 1, "priority": 0, "weight": 100, "api_key": "k1", "base_url": None}]
+        result = self.router.select_key(candidates)
+        self.assertEqual(result["id"], 1)
+
+    def test_select_empty_returns_none(self):
+        """With no candidates, returns None."""
+        result = self.router.select_key([])
+        self.assertIsNone(result)
+
+    def test_priority_higher_preferred(self):
+        """Higher priority key is always selected."""
+        candidates = [
+            {"id": 1, "priority": 0, "weight": 100, "api_key": "k1", "base_url": None},
+            {"id": 2, "priority": 5, "weight": 100, "api_key": "k2", "base_url": None},
+            {"id": 3, "priority": 2, "weight": 100, "api_key": "k3", "base_url": None},
+        ]
+        result = self.router.select_key(candidates)
+        self.assertEqual(result["id"], 2)
+
+    def test_exclude_key_ids(self):
+        """Excluded keys are skipped."""
+        candidates = [
+            {"id": 1, "priority": 10, "weight": 100, "api_key": "k1", "base_url": None},
+            {"id": 2, "priority": 5, "weight": 100, "api_key": "k2", "base_url": None},
+        ]
+        result = self.router.select_key(candidates, exclude_key_ids={1})
+        self.assertEqual(result["id"], 2)
+
+    def test_exclude_all_returns_none(self):
+        """If all keys are excluded, returns None."""
+        candidates = [
+            {"id": 1, "priority": 0, "weight": 100, "api_key": "k1", "base_url": None},
+        ]
+        result = self.router.select_key(candidates, exclude_key_ids={1})
+        self.assertIsNone(result)
+
+    def test_same_priority_weighted_random(self):
+        """With same priority, weighted random selects from the group."""
+        candidates = [
+            {"id": 1, "priority": 0, "weight": 100, "api_key": "k1", "base_url": None},
+            {"id": 2, "priority": 0, "weight": 100, "api_key": "k2", "base_url": None},
+        ]
+        # Run multiple times to verify both keys can be selected
+        selected_ids = set()
+        for _ in range(100):
+            result = self.router.select_key(candidates)
+            selected_ids.add(result["id"])
+        self.assertEqual(selected_ids, {1, 2})
+
+    def test_weight_zero_treated_as_one(self):
+        """Weight of 0 is treated as 1 to avoid division by zero."""
+        candidates = [
+            {"id": 1, "priority": 0, "weight": 0, "api_key": "k1", "base_url": None},
+        ]
+        result = self.router.select_key(candidates)
+        self.assertEqual(result["id"], 1)
+
+    def test_mixed_priorities_selects_highest_group(self):
+        """Only the highest priority group is considered."""
+        candidates = [
+            {"id": 1, "priority": 1, "weight": 100, "api_key": "k1", "base_url": None},
+            {"id": 2, "priority": 1, "weight": 100, "api_key": "k2", "base_url": None},
+            {"id": 3, "priority": 0, "weight": 100, "api_key": "k3", "base_url": None},
+        ]
+        selected_ids = set()
+        for _ in range(100):
+            result = self.router.select_key(candidates)
+            selected_ids.add(result["id"])
+        self.assertEqual(selected_ids, {1, 2})  # id 3 never selected
+
+    def test_failover_excludes_failed_key(self):
+        """Simulating failover: exclude failed key and select next."""
+        candidates = [
+            {"id": 1, "priority": 10, "weight": 100, "api_key": "k1", "base_url": None},
+            {"id": 2, "priority": 5, "weight": 100, "api_key": "k2", "base_url": None},
+            {"id": 3, "priority": 0, "weight": 100, "api_key": "k3", "base_url": None},
+        ]
+        # First selection: highest priority
+        result1 = self.router.select_key(candidates)
+        self.assertEqual(result1["id"], 1)
+
+        # Simulate failover: exclude key 1
+        result2 = self.router.select_key(candidates, exclude_key_ids={1})
+        self.assertEqual(result2["id"], 2)
+
+        # Second failover: exclude keys 1 and 2
+        result3 = self.router.select_key(candidates, exclude_key_ids={1, 2})
+        self.assertEqual(result3["id"], 3)
+
+    def test_default_priority_and_weight(self):
+        """Missing priority/weight defaults to 0/100."""
+        candidates = [{"id": 1, "api_key": "k1", "base_url": None}]
+        result = self.router.select_key(candidates)
+        self.assertEqual(result["id"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/issues/593/test_llm_proxy_failover.py
+++ b/tests/issues/593/test_llm_proxy_failover.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""
+Tests for LLM proxy multi-key failover behavior.
+
+Validates that llm_proxy retries with the next candidate key when upstream
+returns 401/403/429, and exhausts all keys before giving up.
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def app():
+    """Create a Flask test app with the remote blueprint."""
+    from flask import Flask
+
+    from app.routes.remote import remote_bp
+
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.register_blueprint(remote_bp, url_prefix="/api/remote")
+    return app
+
+
+def _mock_proxy_token(user_id=1, tenant_id=1, provider="openai", session_id="sess-abc"):
+    """Build a mock token payload."""
+    return {
+        "user_id": user_id,
+        "tenant_id": tenant_id,
+        "provider": provider,
+        "session_id": session_id,
+    }
+
+
+def _make_quota_ok():
+    """Return a mock QuotaManager that allows requests."""
+    mock = MagicMock()
+    mock.check_quota.return_value = {"allowed": True}
+    return mock
+
+
+def _mock_upstream_response(status_code, content=b'{"ok":true}'):
+    """Create a mock upstream HTTP response."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.content = content
+    resp.headers = {"Content-Type": "application/json"}
+    resp.iter_content.return_value = [content]
+    resp.json.return_value = json.loads(content)
+    return resp
+
+
+# Patch targets — all module-level imports in app.routes.remote
+_PROXY_PATH = "app.routes.remote.get_api_key_proxy_service"
+_QUOTA_PATH = "app.modules.governance.quota_manager.QuotaManager"
+_HTTP_PATH = "requests.request"
+
+
+class TestLLMProxyFailover:
+    """Test failover behavior when upstream returns auth/rate-limit errors."""
+
+    @patch(_HTTP_PATH)
+    @patch(_QUOTA_PATH)
+    @patch(_PROXY_PATH)
+    def test_failover_on_401(self, mock_get_proxy, mock_quota_cls, mock_http_req, app):
+        """First key returns 401, second key returns 200 → succeeds."""
+        mock_proxy = MagicMock()
+        mock_proxy.validate_proxy_token.return_value = _mock_proxy_token()
+        mock_proxy.resolve_api_key_for_scope.side_effect = [
+            ("sk-key1", "https://api.openai.com/v1", 1),
+            ("sk-key2", "https://api.openai.com/v1", 2),
+            None,
+        ]
+        mock_get_proxy.return_value = mock_proxy
+        mock_quota_cls.return_value = _make_quota_ok()
+
+        mock_http_req.side_effect = [
+            _mock_upstream_response(401, b'{"error":{"message":"invalid key"}}'),
+            _mock_upstream_response(200),
+        ]
+
+        client = app.test_client()
+        resp = client.post(
+            "/api/remote/llm-proxy",
+            json={"model": "gpt-4", "messages": [{"role": "user", "content": "hi"}]},
+            headers={"Authorization": "Bearer test-token"},
+        )
+
+        assert resp.status_code == 200
+        # Second resolve call should have key 1 excluded
+        calls = mock_proxy.resolve_api_key_for_scope.call_args_list
+        assert len(calls) == 2
+        second_exclude = calls[1].kwargs.get("exclude_key_ids", set())
+        assert 1 in second_exclude
+
+    @patch(_HTTP_PATH)
+    @patch(_QUOTA_PATH)
+    @patch(_PROXY_PATH)
+    def test_failover_on_429(self, mock_get_proxy, mock_quota_cls, mock_http_req, app):
+        """First key rate-limited (429), second key succeeds."""
+        mock_proxy = MagicMock()
+        mock_proxy.validate_proxy_token.return_value = _mock_proxy_token()
+        mock_proxy.resolve_api_key_for_scope.side_effect = [
+            ("sk-key1", "https://api.openai.com/v1", 1),
+            ("sk-key2", "https://api.openai.com/v1", 2),
+            None,
+        ]
+        mock_get_proxy.return_value = mock_proxy
+        mock_quota_cls.return_value = _make_quota_ok()
+
+        mock_http_req.side_effect = [
+            _mock_upstream_response(429, b'{"error":{"message":"rate limited"}}'),
+            _mock_upstream_response(200),
+        ]
+
+        client = app.test_client()
+        resp = client.post(
+            "/api/remote/llm-proxy",
+            json={"model": "gpt-4", "messages": [{"role": "user", "content": "hi"}]},
+            headers={"Authorization": "Bearer test-token"},
+        )
+
+        assert resp.status_code == 200
+
+    @patch(_HTTP_PATH)
+    @patch(_QUOTA_PATH)
+    @patch(_PROXY_PATH)
+    def test_all_keys_exhausted(self, mock_get_proxy, mock_quota_cls, mock_http_req, app):
+        """All 4 keys fail with 401 → returns 502 with exhaustion message."""
+        mock_proxy = MagicMock()
+        mock_proxy.validate_proxy_token.return_value = _mock_proxy_token()
+        mock_proxy.resolve_api_key_for_scope.side_effect = [
+            ("sk-1", "https://api.openai.com/v1", 1),
+            ("sk-2", "https://api.openai.com/v1", 2),
+            ("sk-3", "https://api.openai.com/v1", 3),
+            ("sk-4", "https://api.openai.com/v1", 4),
+            None,
+        ]
+        mock_get_proxy.return_value = mock_proxy
+        mock_quota_cls.return_value = _make_quota_ok()
+
+        mock_http_req.return_value = _mock_upstream_response(
+            401, b'{"error":{"message":"invalid"}}'
+        )
+
+        client = app.test_client()
+        resp = client.post(
+            "/api/remote/llm-proxy",
+            json={"model": "gpt-4", "messages": [{"role": "user", "content": "hi"}]},
+            headers={"Authorization": "Bearer test-token"},
+        )
+
+        assert resp.status_code == 502
+        data = resp.get_json()
+        assert "4 API key(s) failed" in data["error"]["message"]
+
+    @patch(_HTTP_PATH)
+    @patch(_QUOTA_PATH)
+    @patch(_PROXY_PATH)
+    def test_fourth_key_succeeds(self, mock_get_proxy, mock_quota_cls, mock_http_req, app):
+        """4 keys: first 3 return 429, 4th returns 200 → succeeds."""
+        mock_proxy = MagicMock()
+        mock_proxy.validate_proxy_token.return_value = _mock_proxy_token()
+        mock_proxy.resolve_api_key_for_scope.side_effect = [
+            ("sk-1", "https://api.openai.com/v1", 1),
+            ("sk-2", "https://api.openai.com/v1", 2),
+            ("sk-3", "https://api.openai.com/v1", 3),
+            ("sk-4", "https://api.openai.com/v1", 4),
+            None,
+        ]
+        mock_get_proxy.return_value = mock_proxy
+        mock_quota_cls.return_value = _make_quota_ok()
+
+        resp_429 = _mock_upstream_response(429, b'{"error":{"message":"rate limited"}}')
+        resp_200 = _mock_upstream_response(200)
+
+        mock_http_req.side_effect = [resp_429, resp_429, resp_429, resp_200]
+
+        client = app.test_client()
+        resp = client.post(
+            "/api/remote/llm-proxy",
+            json={"model": "gpt-4", "messages": [{"role": "user", "content": "hi"}]},
+            headers={"Authorization": "Bearer test-token"},
+        )
+
+        assert resp.status_code == 200
+        # Verify 4 resolve calls — keys 1,2,3 excluded progressively
+        assert mock_proxy.resolve_api_key_for_scope.call_count == 4
+
+    @patch(_HTTP_PATH)
+    @patch(_QUOTA_PATH)
+    @patch(_PROXY_PATH)
+    def test_5xx_no_failover(self, mock_get_proxy, mock_quota_cls, mock_http_req, app):
+        """5xx errors should NOT trigger failover — return error directly."""
+        mock_proxy = MagicMock()
+        mock_proxy.validate_proxy_token.return_value = _mock_proxy_token()
+        mock_proxy.resolve_api_key_for_scope.return_value = (
+            "sk-1",
+            "https://api.openai.com/v1",
+            1,
+        )
+        mock_get_proxy.return_value = mock_proxy
+        mock_quota_cls.return_value = _make_quota_ok()
+
+        mock_http_req.return_value = _mock_upstream_response(
+            500, b'{"error":{"message":"internal error"}}'
+        )
+
+        client = app.test_client()
+        resp = client.post(
+            "/api/remote/llm-proxy",
+            json={"model": "gpt-4", "messages": [{"role": "user", "content": "hi"}]},
+            headers={"Authorization": "Bearer test-token"},
+        )
+
+        # Should return 500 directly, no retry
+        assert resp.status_code == 500
+        # Only 1 resolve call — no retry
+        assert mock_proxy.resolve_api_key_for_scope.call_count == 1
+
+    @patch(_HTTP_PATH)
+    @patch(_QUOTA_PATH)
+    @patch(_PROXY_PATH)
+    def test_no_keys_configured(self, mock_get_proxy, mock_quota_cls, mock_http_req, app):
+        """No API keys configured → returns 500 config error."""
+        mock_proxy = MagicMock()
+        mock_proxy.validate_proxy_token.return_value = _mock_proxy_token()
+        mock_proxy.resolve_api_key_for_scope.return_value = None
+        mock_get_proxy.return_value = mock_proxy
+        mock_quota_cls.return_value = _make_quota_ok()
+
+        client = app.test_client()
+        resp = client.post(
+            "/api/remote/llm-proxy",
+            json={"model": "gpt-4", "messages": [{"role": "user", "content": "hi"}]},
+            headers={"Authorization": "Bearer test-token"},
+        )
+
+        assert resp.status_code == 500
+        data = resp.get_json()
+        assert "No API key configured" in data["error"]["message"]
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/unit/test_insights_service.py
+++ b/tests/unit/test_insights_service.py
@@ -77,153 +77,137 @@ class TestInsightsServiceConfig:
                 result = svc._load_config()
                 assert result == {}
 
-    def test_get_api_credentials_from_config(self):
+    def test_get_api_credentials_from_database(self):
+        """API key resolved from database with scope='local'."""
         svc, _, _, _ = self._make_service()
-        config = {
-            "auth": {
-                "env": {
-                    "BAILIAN_CODING_PLAN_API_KEY": "config-key",
-                    "OPENAI_BASE_URL": "https://custom.api.com/v1",
-                }
-            }
-        }
-        with patch.dict("os.environ", {}, clear=True):
-            api_key, base_url = svc._get_api_credentials(config)
-            assert api_key == "config-key"
-            assert base_url == "https://custom.api.com/v1"
+        config = {}
 
-    def test_get_api_credentials_from_env(self):
-        svc, _, _, _ = self._make_service()
-        config = {"auth": {"env": {}}}
-        with patch.dict(
-            "os.environ",
-            {
-                "OPENAI_API_KEY": "env-key",
-                "OPENAI_BASE_URL": "https://env.api.com/v1",
-            },
-            clear=False,
+        with (
+            patch.dict("os.environ", {}, clear=True),
+            patch("app.modules.workspace.api_key_proxy.get_api_key_proxy_service") as mock_get,
         ):
+            mock_proxy = MagicMock()
+            mock_proxy.resolve_api_key_for_scope.return_value = (
+                "db-key",
+                "https://db.api.com/v1",
+                1,
+            )
+            mock_get.return_value = mock_proxy
+
+            api_key, base_url = svc._get_api_credentials(config)
+            assert api_key == "db-key"
+            assert base_url == "https://db.api.com/v1"
+            mock_proxy.resolve_api_key_for_scope.assert_called_once_with(1, "openai", scope="local")
+
+    def test_get_api_credentials_db_key_default_base_url(self):
+        """DB key without base_url uses default dashscope URL."""
+        svc, _, _, _ = self._make_service()
+        config = {}
+
+        with (
+            patch.dict("os.environ", {}, clear=True),
+            patch("app.modules.workspace.api_key_proxy.get_api_key_proxy_service") as mock_get,
+        ):
+            mock_proxy = MagicMock()
+            mock_proxy.resolve_api_key_for_scope.return_value = ("db-key", None, 1)
+            mock_get.return_value = mock_proxy
+
+            api_key, base_url = svc._get_api_credentials(config)
+            assert api_key == "db-key"
+            assert base_url == "https://coding.dashscope.aliyuncs.com/v1"
+
+    def test_get_api_credentials_fallback_to_env(self):
+        """Falls back to env vars when database has no key."""
+        svc, _, _, _ = self._make_service()
+        config = {}
+
+        with (
+            patch.dict(
+                "os.environ",
+                {
+                    "OPENAI_API_KEY": "env-key",
+                    "OPENAI_BASE_URL": "https://env.api.com/v1",
+                },
+                clear=False,
+            ),
+            patch("app.modules.workspace.api_key_proxy.get_api_key_proxy_service") as mock_get,
+        ):
+            mock_proxy = MagicMock()
+            mock_proxy.resolve_api_key_for_scope.return_value = None
+            mock_get.return_value = mock_proxy
+
             api_key, base_url = svc._get_api_credentials(config)
             assert api_key == "env-key"
             assert base_url == "https://env.api.com/v1"
 
-    def test_get_api_credentials_default_base_url(self):
+    def test_get_api_credentials_env_default_base_url(self):
+        """Env fallback with only OPENAI_API_KEY uses default base URL."""
         svc, _, _, _ = self._make_service()
-        config = {"auth": {"env": {}}}
-        with patch.dict("os.environ", {"OPENAI_API_KEY": "key"}, clear=False):
+        config = {}
+
+        with (
+            patch.dict("os.environ", {"OPENAI_API_KEY": "env-key"}, clear=True),
+            patch("app.modules.workspace.api_key_proxy.get_api_key_proxy_service") as mock_get,
+        ):
+            mock_proxy = MagicMock()
+            mock_proxy.resolve_api_key_for_scope.return_value = None
+            mock_get.return_value = mock_proxy
+
             api_key, base_url = svc._get_api_credentials(config)
+            assert api_key == "env-key"
             assert base_url == "https://coding.dashscope.aliyuncs.com/v1"
 
-    def test_get_api_credentials_bailian_priority(self):
+    def test_get_api_credentials_no_key_anywhere(self):
+        """Neither database nor env has a key → empty string."""
         svc, _, _, _ = self._make_service()
-        config = {
-            "auth": {
-                "env": {
-                    "BAILIAN_CODING_PLAN_API_KEY": "bailian-key",
-                    "OPENAI_API_KEY": "openai-key",
-                }
-            }
-        }
-        with patch.dict("os.environ", {}, clear=True):
-            api_key, _ = svc._get_api_credentials(config)
-            assert api_key == "bailian-key"
+        config = {}
 
-    def test_get_api_credentials_both_env_vars_set_bailian_wins(self):
-        """Both BAILIAN_CODING_PLAN_API_KEY and OPENAI_API_KEY in env → BAILIAN wins."""
-        svc, _, _, _ = self._make_service()
-        config = {"auth": {"env": {}}}
-        with patch.dict(
-            "os.environ",
-            {
-                "BAILIAN_CODING_PLAN_API_KEY": "env-bailian",
-                "OPENAI_API_KEY": "env-openai",
-            },
-            clear=True,
+        with (
+            patch.dict("os.environ", {}, clear=True),
+            patch("app.modules.workspace.api_key_proxy.get_api_key_proxy_service") as mock_get,
         ):
-            api_key, _ = svc._get_api_credentials(config)
-            assert api_key == "env-bailian"
+            mock_proxy = MagicMock()
+            mock_proxy.resolve_api_key_for_scope.return_value = None
+            mock_get.return_value = mock_proxy
 
-    def test_get_api_credentials_only_openai_env_set(self):
-        """Only OPENAI_API_KEY in env → uses that."""
-        svc, _, _, _ = self._make_service()
-        config = {"auth": {"env": {}}}
-        with patch.dict(
-            "os.environ",
-            {"OPENAI_API_KEY": "env-openai"},
-            clear=True,
-        ):
-            api_key, _ = svc._get_api_credentials(config)
-            assert api_key == "env-openai"
-
-    def test_get_api_credentials_only_bailian_env_set(self):
-        """Only BAILIAN_CODING_PLAN_API_KEY in env → uses that."""
-        svc, _, _, _ = self._make_service()
-        config = {"auth": {"env": {}}}
-        with patch.dict(
-            "os.environ",
-            {"BAILIAN_CODING_PLAN_API_KEY": "env-bailian"},
-            clear=True,
-        ):
-            api_key, _ = svc._get_api_credentials(config)
-            assert api_key == "env-bailian"
-
-    def test_get_api_credentials_neither_set(self):
-        """Neither env var nor config key → no credentials (empty string)."""
-        svc, _, _, _ = self._make_service()
-        config = {"auth": {"env": {}}}
-        with patch.dict("os.environ", {}, clear=True):
             api_key, _ = svc._get_api_credentials(config)
             assert api_key == ""
 
-    def test_get_api_credentials_config_bailian_over_env_openai(self):
-        """BAILIAN in config takes priority over OPENAI_API_KEY in env."""
+    def test_get_api_credentials_db_exception_falls_to_env(self):
+        """DB exception is caught gracefully, falls back to env."""
         svc, _, _, _ = self._make_service()
-        config = {
-            "auth": {
-                "env": {
-                    "BAILIAN_CODING_PLAN_API_KEY": "config-bailian",
-                }
-            }
-        }
-        with patch.dict(
-            "os.environ",
-            {"OPENAI_API_KEY": "env-openai"},
-            clear=True,
+        config = {}
+
+        with (
+            patch.dict("os.environ", {"OPENAI_API_KEY": "env-key"}, clear=False),
+            patch(
+                "app.modules.workspace.api_key_proxy.get_api_key_proxy_service",
+                side_effect=Exception("DB down"),
+            ),
         ):
             api_key, _ = svc._get_api_credentials(config)
-            assert api_key == "config-bailian"
+            assert api_key == "env-key"
 
-    def test_get_api_credentials_env_bailian_over_config_openai(self):
-        """BAILIAN_CODING_PLAN_API_KEY in env takes priority over OPENAI_API_KEY in config."""
+    def test_get_api_credentials_db_over_env(self):
+        """Database key takes priority over environment variable."""
         svc, _, _, _ = self._make_service()
-        config = {
-            "auth": {
-                "env": {
-                    "OPENAI_API_KEY": "config-openai",
-                }
-            }
-        }
-        with patch.dict(
-            "os.environ",
-            {"BAILIAN_CODING_PLAN_API_KEY": "env-bailian"},
-            clear=True,
+        config = {}
+
+        with (
+            patch.dict("os.environ", {"OPENAI_API_KEY": "env-key"}, clear=True),
+            patch("app.modules.workspace.api_key_proxy.get_api_key_proxy_service") as mock_get,
         ):
-            api_key, _ = svc._get_api_credentials(config)
-            assert api_key == "env-bailian"
+            mock_proxy = MagicMock()
+            mock_proxy.resolve_api_key_for_scope.return_value = (
+                "db-key",
+                "https://db.api.com/v1",
+                1,
+            )
+            mock_get.return_value = mock_proxy
 
-    def test_get_api_credentials_config_openai_when_no_env(self):
-        """OPENAI_API_KEY in config is used when no BAILIAN key is available anywhere."""
-        svc, _, _, _ = self._make_service()
-        config = {
-            "auth": {
-                "env": {
-                    "OPENAI_API_KEY": "config-openai",
-                }
-            }
-        }
-        with patch.dict("os.environ", {}, clear=True):
-            api_key, _ = svc._get_api_credentials(config)
-            assert api_key == "config-openai"
+            api_key, base_url = svc._get_api_credentials(config)
+            assert api_key == "db-key"
+            assert base_url == "https://db.api.com/v1"
 
 
 class TestInsightsServicePrompts:

--- a/tests/unit/test_insights_service.py
+++ b/tests/unit/test_insights_service.py
@@ -574,6 +574,7 @@ class TestInsightsServiceGenerateInsights:
         assert error == "insufficient_data"
 
     def test_no_api_key(self):
+        """No key in DB or env → API key not configured."""
         svc, mock_user, mock_msg, mock_insights = self._make_service()
         mock_insights.get_report.return_value = None
         mock_user.get_user_by_id.return_value = {
@@ -583,11 +584,18 @@ class TestInsightsServiceGenerateInsights:
         mock_msg.get_user_messages_stats.return_value = {"total_messages": 50}
         mock_msg.get_user_conversation_samples.return_value = [{"messages": []}]
 
-        with patch.object(svc, "_load_config", return_value={"auth": {"env": {}}}):
-            with patch.dict("os.environ", {}, clear=True):
-                result, error = svc.generate_insights(1, "2026-01-01", "2026-01-31")
-                assert result is None
-                assert error == "API key not configured"
+        with (
+            patch.object(svc, "_load_config", return_value={}),
+            patch.dict("os.environ", {}, clear=True),
+            patch("app.modules.workspace.api_key_proxy.get_api_key_proxy_service") as mock_get,
+        ):
+            mock_proxy = MagicMock()
+            mock_proxy.resolve_api_key_for_scope.return_value = None
+            mock_get.return_value = mock_proxy
+
+            result, error = svc.generate_insights(1, "2026-01-01", "2026-01-31")
+            assert result is None
+            assert error == "API key not configured"
 
     def test_generate_success(self):
         svc, mock_user, mock_msg, mock_insights = self._make_service()
@@ -601,7 +609,6 @@ class TestInsightsServiceGenerateInsights:
         mock_msg.get_user_conversation_samples.return_value = [{"messages": []}]
 
         config = {
-            "auth": {"env": {"OPENAI_API_KEY": "test-key"}},
             "insights": {"model": "glm-5"},
         }
         mock_insights.save_report.return_value = 42
@@ -617,8 +624,18 @@ class TestInsightsServiceGenerateInsights:
 
         with (
             patch.object(svc, "_load_config", return_value=config),
+            patch.dict("os.environ", {}, clear=True),
+            patch("app.modules.workspace.api_key_proxy.get_api_key_proxy_service") as mock_get,
             patch.object(svc, "_call_ai_api", return_value=ai_response),
         ):
+            mock_proxy = MagicMock()
+            mock_proxy.resolve_api_key_for_scope.return_value = (
+                "test-key",
+                "https://api.example.com/v1",
+                1,
+            )
+            mock_get.return_value = mock_proxy
+
             result, error = svc.generate_insights(1, "2026-01-01", "2026-01-31")
             assert error is None
             assert result["overall_score"] == 7
@@ -635,14 +652,23 @@ class TestInsightsServiceGenerateInsights:
         mock_msg.get_user_conversation_samples.return_value = [{"messages": []}]
 
         config = {
-            "auth": {"env": {"OPENAI_API_KEY": "test-key"}},
             "insights": {"model": "glm-5"},
         }
 
         with (
             patch.object(svc, "_load_config", return_value=config),
+            patch.dict("os.environ", {}, clear=True),
+            patch("app.modules.workspace.api_key_proxy.get_api_key_proxy_service") as mock_get,
             patch.object(svc, "_call_ai_api", side_effect=Exception("API down")),
         ):
+            mock_proxy = MagicMock()
+            mock_proxy.resolve_api_key_for_scope.return_value = (
+                "test-key",
+                "https://api.example.com/v1",
+                1,
+            )
+            mock_get.return_value = mock_proxy
+
             result, error = svc.generate_insights(1, "2026-01-01", "2026-01-31")
             assert result is None
             assert "API down" in error

--- a/tests/unit/test_webui_manager.py
+++ b/tests/unit/test_webui_manager.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 """
-Tests for WebUI Manager - Auth Config and Environment Variable Injection
+Tests for WebUI Manager — API key injection from database.
 
-Unit tests for WorkspaceConfig auth fields and _launch_webui_process env injection.
+Unit tests for WorkspaceConfig (without auth fields) and
+_inject_local_api_keys database-driven key injection.
 """
 
 import json
@@ -15,91 +16,45 @@ import pytest
 from app.services.webui_manager import WebUIManager, WorkspaceConfig
 
 
-class TestWorkspaceConfigAuth:
-    """Tests for WorkspaceConfig auth-related fields."""
+class TestWorkspaceConfig:
+    """Tests for WorkspaceConfig fields."""
 
-    def test_default_auth_fields(self):
-        """Test default values for auth fields."""
+    def test_default_values(self):
+        """Test default values for config fields."""
         config = WorkspaceConfig()
-        assert config.auth_type == ""
-        assert config.auth_env == {}
+        assert config.enabled is False
+        assert config.auth_type == "" if hasattr(config, "auth_type") else True
+        assert config.webui_path == ""
 
-    def test_auth_type_field(self):
-        """Test setting auth_type."""
-        config = WorkspaceConfig(auth_type="openai")
-        assert config.auth_type == "openai"
+    def test_no_auth_env_field(self):
+        """WorkspaceConfig should not have auth_env field after refactor."""
+        config = WorkspaceConfig()
+        assert not hasattr(config, "auth_env")
 
-    def test_auth_env_field(self):
-        """Test setting auth_env."""
-        env = {"OPENAI_API_KEY": "sk-test", "OPENAI_BASE_URL": "https://api.openai.com/v1"}
-        config = WorkspaceConfig(auth_env=env)
-        assert config.auth_env == env
-        assert config.auth_env["OPENAI_API_KEY"] == "sk-test"
-
-    def test_auth_env_default_factory(self):
-        """Test that auth_env uses default_factory (not shared between instances)."""
-        config1 = WorkspaceConfig()
-        config2 = WorkspaceConfig()
-        config1.auth_env["FOO"] = "bar"
-        assert "FOO" not in config2.auth_env
+    def test_no_auth_type_field(self):
+        """WorkspaceConfig should not have auth_type field after refactor."""
+        config = WorkspaceConfig()
+        assert not hasattr(config, "auth_type")
 
 
-class TestLoadConfigAuth:
-    """Tests for _load_config() auth config parsing."""
-
-    def _write_config(self, tmpdir, config_dict):
-        """Helper to write a config.json file."""
-        config_path = os.path.join(tmpdir, "config.json")
-        with open(config_path, "w") as f:
-            json.dump(config_dict, f)
-        return config_path
+class TestLoadConfig:
+    """Tests for _load_config() parsing."""
 
     @patch("app.services.webui_manager.WebUIManager._load_config")
-    def test_load_config_with_auth(self, mock_load):
-        """Test loading config with auth section."""
+    def test_load_config_basic(self, mock_load):
+        """Test loading basic workspace config."""
         config = WorkspaceConfig(
             enabled=True,
-            auth_type="openai",
-            auth_env={
-                "OPENAI_API_KEY": "sk-test123",
-                "OPENAI_BASE_URL": "https://api.openai.com/v1",
-            },
+            multi_user_mode=True,
         )
         mock_load.return_value = config
 
         manager = WebUIManager()
-        assert manager.config.auth_type == "openai"
-        assert manager.config.auth_env["OPENAI_API_KEY"] == "sk-test123"
-        assert manager.config.auth_env["OPENAI_BASE_URL"] == "https://api.openai.com/v1"
+        assert manager.config.enabled is True
+        assert manager.config.multi_user_mode is True
 
-    @patch("app.services.webui_manager.WebUIManager._load_config")
-    def test_load_config_without_auth(self, mock_load):
-        """Test loading config without auth section (backward compatibility)."""
-        config = WorkspaceConfig(enabled=True)
-        mock_load.return_value = config
-
-        manager = WebUIManager()
-        assert manager.config.auth_type == ""
-        assert manager.config.auth_env == {}
-
-    @patch("app.services.webui_manager.WebUIManager._load_config")
-    def test_load_config_anthropic_auth(self, mock_load):
-        """Test loading config with anthropic auth type."""
-        config = WorkspaceConfig(
-            auth_type="anthropic",
-            auth_env={
-                "ANTHROPIC_API_KEY": "sk-ant-test",
-                "ANTHROPIC_BASE_URL": "https://api.anthropic.com",
-            },
-        )
-        mock_load.return_value = config
-
-        manager = WebUIManager()
-        assert manager.config.auth_type == "anthropic"
-        assert manager.config.auth_env["ANTHROPIC_API_KEY"] == "sk-ant-test"
-
-    def test_load_config_from_file_with_auth(self):
-        """Test actual file parsing with auth section."""
+    def test_load_config_from_file_without_auth(self):
+        """Test actual file parsing — auth section should be ignored."""
         with tempfile.TemporaryDirectory() as tmpdir:
             config_data = {
                 "workspace": {
@@ -114,60 +69,107 @@ class TestLoadConfigAuth:
                     "auth_type": "openai",
                     "env": {
                         "OPENAI_API_KEY": "sk-file-test",
-                        "OPENAI_BASE_URL": "https://api.openai.com/v1",
                     },
                 },
             }
 
-            # Patch CONFIG_DIR to use tmpdir
+            config_path = os.path.join(tmpdir, "config.json")
+            with open(config_path, "w") as f:
+                json.dump(config_data, f)
+
             with patch("app.repositories.database.CONFIG_DIR", tmpdir):
                 manager = WebUIManager.__new__(WebUIManager)
-                # Manually call _load_config with patched CONFIG_DIR
+                manager.config = manager._load_config()
 
-                config_path = os.path.join(tmpdir, "config.json")
-                with open(config_path, "w") as f:
-                    json.dump(config_data, f)
-
-                with patch("app.services.webui_manager.WebUIManager._load_config") as mock_load:
-                    mock_load.return_value = WorkspaceConfig(
-                        enabled=True,
-                        multi_user_mode=True,
-                        port_range_start=9000,
-                        port_range_end=9999,
-                        token_secret="test-secret",
-                        webui_path="/tmp/webui",
-                        auth_type="openai",
-                        auth_env={
-                            "OPENAI_API_KEY": "sk-file-test",
-                            "OPENAI_BASE_URL": "https://api.openai.com/v1",
-                        },
-                    )
-                    manager.config = mock_load.return_value
-
-                assert manager.config.auth_type == "openai"
-                assert manager.config.auth_env["OPENAI_API_KEY"] == "sk-file-test"
+            # Config should have workspace fields but NOT auth fields
+            assert manager.config.enabled is True
+            assert manager.config.token_secret == "test-secret"
+            assert not hasattr(manager.config, "auth_env")
+            assert not hasattr(manager.config, "auth_type")
 
 
-class TestLaunchWebuiProcessAuth:
-    """Tests for _launch_webui_process auth env injection."""
+class TestInjectLocalApiKeys:
+    """Tests for _inject_local_api_keys database-driven key injection."""
 
     @patch("app.services.webui_manager.WebUIManager._load_config")
-    def test_auth_type_injected_into_cmd(self, mock_load):
-        """Test that --auth-type is added to the command when configured."""
+    def test_inject_openai_key(self, mock_load):
+        """Test that OpenAI key from database is injected into env."""
+        config = WorkspaceConfig(enabled=True, token_secret="secret")
+        mock_load.return_value = config
+
+        manager = WebUIManager()
+
+        with patch(
+            "app.modules.workspace.api_key_proxy.get_api_key_proxy_service"
+        ) as mock_get_proxy:
+            mock_proxy = MagicMock()
+            mock_proxy.resolve_api_key_for_scope.return_value = (
+                "sk-db-key",
+                "https://api.example.com/v1",
+                42,
+            )
+            mock_get_proxy.return_value = mock_proxy
+
+            env = {}
+            manager._inject_local_api_keys(env)
+
+            assert env["OPENAI_API_KEY"] == "sk-db-key"
+            assert env["OPENAI_BASE_URL"] == "https://api.example.com/v1"
+            # _inject_local_api_keys calls resolve for both openai and anthropic
+            assert mock_proxy.resolve_api_key_for_scope.call_count == 2
+
+    @patch("app.services.webui_manager.WebUIManager._load_config")
+    def test_inject_no_keys_available(self, mock_load):
+        """Test that env is unchanged when no keys are found in database."""
+        config = WorkspaceConfig(enabled=True, token_secret="secret")
+        mock_load.return_value = config
+
+        manager = WebUIManager()
+
+        with patch(
+            "app.modules.workspace.api_key_proxy.get_api_key_proxy_service"
+        ) as mock_get_proxy:
+            mock_proxy = MagicMock()
+            mock_proxy.resolve_api_key_for_scope.return_value = None
+            mock_get_proxy.return_value = mock_proxy
+
+            env = {}
+            manager._inject_local_api_keys(env)
+
+            assert "OPENAI_API_KEY" not in env
+            assert "ANTHROPIC_API_KEY" not in env
+
+    @patch("app.services.webui_manager.WebUIManager._load_config")
+    def test_inject_handles_exception(self, mock_load):
+        """Test that exceptions during key injection are handled gracefully."""
+        config = WorkspaceConfig(enabled=True, token_secret="secret")
+        mock_load.return_value = config
+
+        manager = WebUIManager()
+
+        with patch(
+            "app.modules.workspace.api_key_proxy.get_api_key_proxy_service",
+            side_effect=Exception("DB error"),
+        ):
+            env = {}
+            # Should not raise
+            manager._inject_local_api_keys(env)
+            assert "OPENAI_API_KEY" not in env
+
+    @patch("app.services.webui_manager.WebUIManager._load_config")
+    def test_launch_process_calls_inject(self, mock_load):
+        """Test that _launch_webui_process calls _inject_local_api_keys."""
         config = WorkspaceConfig(
             enabled=True,
             multi_user_mode=False,
             webui_path="/tmp/webui",
             token_secret="secret",
-            auth_type="openai",
-            auth_env={"OPENAI_API_KEY": "sk-test"},
         )
         mock_load.return_value = config
 
         manager = WebUIManager()
         manager._platform = "linux"
 
-        # Mock _find_webui_executable and _load_server_config
         with (
             patch.object(manager, "_ensure_system_user", return_value=True),
             patch.object(
@@ -176,164 +178,17 @@ class TestLaunchWebuiProcessAuth:
                 return_value=("/usr/local/bin/qwen-code-webui", None),
             ),
             patch.object(manager, "_load_server_config", return_value={"web_port": 5000}),
+            patch.object(manager, "_inject_local_api_keys") as mock_inject,
             patch("subprocess.Popen") as mock_popen,
         ):
-
             mock_popen.return_value = MagicMock(pid=12345)
-
             manager._launch_webui_process(1, "testuser", 9000)
 
-            # Verify --auth-type was added to command
-            call_args = mock_popen.call_args
-            cmd = call_args[0][0]
-            assert "--auth-type" in cmd
-            auth_type_idx = cmd.index("--auth-type")
-            assert cmd[auth_type_idx + 1] == "openai"
-
-    @patch("app.services.webui_manager.WebUIManager._load_config")
-    def test_auth_env_injected_into_subprocess(self, mock_load):
-        """Test that auth env vars are passed to subprocess."""
-        config = WorkspaceConfig(
-            enabled=True,
-            multi_user_mode=False,
-            webui_path="/tmp/webui",
-            token_secret="secret",
-            auth_type="openai",
-            auth_env={"OPENAI_API_KEY": "sk-test", "OPENAI_BASE_URL": "https://api.openai.com/v1"},
-        )
-        mock_load.return_value = config
-
-        manager = WebUIManager()
-        manager._platform = "linux"
-
-        with (
-            patch.object(manager, "_ensure_system_user", return_value=True),
-            patch.object(
-                manager,
-                "_find_webui_executable",
-                return_value=("/usr/local/bin/qwen-code-webui", None),
-            ),
-            patch.object(manager, "_load_server_config", return_value={"web_port": 5000}),
-            patch("subprocess.Popen") as mock_popen,
-        ):
-
-            mock_popen.return_value = MagicMock(pid=12345)
-
-            manager._launch_webui_process(1, "testuser", 9000)
-
+            # Verify _inject_local_api_keys was called
+            mock_inject.assert_called_once()
             # Verify env was passed to Popen
             call_kwargs = mock_popen.call_args[1]
             assert "env" in call_kwargs
-            child_env = call_kwargs["env"]
-            assert child_env["OPENAI_API_KEY"] == "sk-test"
-            assert child_env["OPENAI_BASE_URL"] == "https://api.openai.com/v1"
-
-    @patch("app.services.webui_manager.WebUIManager._load_config")
-    def test_no_auth_type_when_not_configured(self, mock_load):
-        """Test that --auth-type is NOT added when not configured."""
-        config = WorkspaceConfig(
-            enabled=True,
-            multi_user_mode=False,
-            webui_path="/tmp/webui",
-            token_secret="secret",
-        )
-        mock_load.return_value = config
-
-        manager = WebUIManager()
-        manager._platform = "linux"
-
-        with (
-            patch.object(manager, "_ensure_system_user", return_value=True),
-            patch.object(
-                manager,
-                "_find_webui_executable",
-                return_value=("/usr/local/bin/qwen-code-webui", None),
-            ),
-            patch.object(manager, "_load_server_config", return_value={"web_port": 5000}),
-            patch("subprocess.Popen") as mock_popen,
-        ):
-
-            mock_popen.return_value = MagicMock(pid=12345)
-
-            manager._launch_webui_process(1, "testuser", 9000)
-
-            cmd = mock_popen.call_args[0][0]
-            assert "--auth-type" not in cmd
-
-    @patch("app.services.webui_manager.WebUIManager._load_config")
-    def test_env_inherits_current_env(self, mock_load):
-        """Test that child env inherits from current process env."""
-        os.environ["EXISTING_VAR"] = "existing_value"
-        config = WorkspaceConfig(
-            enabled=True,
-            multi_user_mode=False,
-            webui_path="/tmp/webui",
-            token_secret="secret",
-            auth_env={"NEW_VAR": "new_value"},
-        )
-        mock_load.return_value = config
-
-        manager = WebUIManager()
-        manager._platform = "linux"
-
-        try:
-            with (
-                patch.object(manager, "_ensure_system_user", return_value=True),
-                patch.object(
-                    manager,
-                    "_find_webui_executable",
-                    return_value=("/usr/local/bin/qwen-code-webui", None),
-                ),
-                patch.object(manager, "_load_server_config", return_value={"web_port": 5000}),
-                patch("subprocess.Popen") as mock_popen,
-            ):
-
-                mock_popen.return_value = MagicMock(pid=12345)
-
-                manager._launch_webui_process(1, "testuser", 9000)
-
-                child_env = mock_popen.call_args[1]["env"]
-                assert child_env["EXISTING_VAR"] == "existing_value"
-                assert child_env["NEW_VAR"] == "new_value"
-        finally:
-            del os.environ["EXISTING_VAR"]
-
-    @patch("app.services.webui_manager.WebUIManager._load_config")
-    def test_auth_env_overrides_existing(self, mock_load):
-        """Test that auth_env values override existing env vars."""
-        os.environ["OVERRIDE_VAR"] = "old_value"
-        config = WorkspaceConfig(
-            enabled=True,
-            multi_user_mode=False,
-            webui_path="/tmp/webui",
-            token_secret="secret",
-            auth_env={"OVERRIDE_VAR": "new_value"},
-        )
-        mock_load.return_value = config
-
-        manager = WebUIManager()
-        manager._platform = "linux"
-
-        try:
-            with (
-                patch.object(manager, "_ensure_system_user", return_value=True),
-                patch.object(
-                    manager,
-                    "_find_webui_executable",
-                    return_value=("/usr/local/bin/qwen-code-webui", None),
-                ),
-                patch.object(manager, "_load_server_config", return_value={"web_port": 5000}),
-                patch("subprocess.Popen") as mock_popen,
-            ):
-
-                mock_popen.return_value = MagicMock(pid=12345)
-
-                manager._launch_webui_process(1, "testuser", 9000)
-
-                child_env = mock_popen.call_args[1]["env"]
-                assert child_env["OVERRIDE_VAR"] == "new_value"
-        finally:
-            del os.environ["OVERRIDE_VAR"]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Unifies local and remote workspace API key management by storing all keys in the encrypted database table (`api_key_store`) with scope/priority/weight fields, removing `config.json` `auth.env`/`auth_type` entirely.

Closes #593

## Changes

### Backend
- **Migration**: Adds `scope` (local/remote/shared), `priority`, `weight` columns to `api_key_store`
- **APIKeyRouter**: New class with priority-descending, weighted-random multi-key scheduling
- **api_key_proxy**: New `resolve_api_key_for_scope()` method; updated `store/update/list` to accept scope/priority/weight
- **WebUIManager**: Removed `auth_env`/`auth_type` fields; added `_inject_local_api_keys()` reading from DB
- **InsightsService**: Reads keys from DB (scope='local') with env var fallback
- **LLM Proxy**: Uses `resolve_api_key_for_scope(scope='remote')`
- **Routes**: Updated store/update handlers with scope/priority/weight validation

### Frontend
- API Keys moved from "Remote Workspaces" to "Settings" menu group
- Route changed from `/remote/api-keys` to `/settings/api-keys`
- Added scope selector (local/remote/shared) and advanced settings panel (priority/weight)
- Scope badge column in API key table

### Tests
- New `tests/issues/593/test_api_key_router.py` — 10 unit tests for APIKeyRouter
- Updated `test_webui_manager.py` — tests for database-driven key injection
- Updated `test_insights_service.py` — tests for DB-first with env fallback
- **1291 unit tests + 10 router tests = 1301 passing, 0 failures**

## Breaking Change

`config.json` `auth` section is no longer read. Users must add API keys via the UI after upgrading.