### PR TITLE
feat: 支持远程工作区新建文件夹功能 (#584 Phase 2)

### DIFF
--- a/app/routes/remote.py
+++ b/app/routes/remote.py
@@ -2305,3 +2305,81 @@ def browse_remote_directory(machine_id):
             "machine": machine,
         }
     )
+
+
+@remote_bp.route("/machines/<machine_id>/create-directory", methods=["POST"])
+def create_remote_directory(machine_id):
+    """Create a directory on a remote machine.
+
+    Expects JSON body with 'path' (full path of the directory to create).
+    """
+    if not hasattr(g, "user") or g.user is None:
+        return jsonify({"error": "Unauthorized"}), 401
+
+    agent_mgr = get_remote_agent_manager()
+
+    if g.user.get("role") != "admin":
+        if not agent_mgr.check_user_access(machine_id, g.user["id"]):
+            return jsonify({"error": "Access denied"}), 403
+
+    data = request.get_json() or {}
+    dir_path = data.get("path", "")
+
+    if not dir_path:
+        return jsonify({"success": False, "error": "Path is required"}), 400
+
+    machine = agent_mgr.get_machine(machine_id)
+    if not machine:
+        return jsonify({"error": "Machine not found"}), 404
+
+    if machine.get("status") not in ("online", "idle"):
+        return (
+            jsonify(
+                {
+                    "success": False,
+                    "error": "Machine is offline. Directory creation requires an active connection.",
+                }
+            ),
+            503,
+        )
+
+    request_id = str(uuid.uuid4())
+
+    command = {
+        "type": "command",
+        "command": "create_directory",
+        "request_id": request_id,
+        "path": dir_path,
+    }
+
+    if not agent_mgr.send_command(machine_id, command):
+        return (
+            jsonify(
+                {
+                    "success": False,
+                    "error": "Failed to send command to agent",
+                }
+            ),
+            500,
+        )
+
+    result = agent_mgr.get_browse_result(request_id, timeout=15.0)
+
+    if result is None:
+        return (
+            jsonify(
+                {
+                    "success": False,
+                    "error": "Timeout waiting for agent response. Please try again.",
+                }
+            ),
+            504,
+        )
+
+    return jsonify(
+        {
+            "success": result.get("success", False),
+            "result": result.get("result"),
+            "error": result.get("error"),
+        }
+    )

--- a/app/routes/remote.py
+++ b/app/routes/remote.py
@@ -2328,6 +2328,9 @@ def create_remote_directory(machine_id):
     if not dir_path:
         return jsonify({"success": False, "error": "Path is required"}), 400
 
+    if len(dir_path) > 4096:
+        return jsonify({"success": False, "error": "Path too long"}), 400
+
     machine = agent_mgr.get_machine(machine_id)
     if not machine:
         return jsonify({"error": "Machine not found"}), 404

--- a/app/routes/remote.py
+++ b/app/routes/remote.py
@@ -2259,8 +2259,6 @@ def browse_remote_directory(machine_id):
         )
 
     # Generate unique request ID for this browse request
-    import uuid
-
     request_id = str(uuid.uuid4())
 
     # Send browse_directory command to agent

--- a/frontend/src/api/fs.ts
+++ b/frontend/src/api/fs.ts
@@ -74,4 +74,12 @@ export const fsApi = {
     if (path) params.path = path;
     return apiClient.get(`/api/remote/machines/${machineId}/browse`, params);
   },
+
+  // Create directory on remote machine (via HTTP proxy)
+  createRemoteDirectory(
+    machineId: string,
+    path: string
+  ): Promise<{ success: boolean; result?: { path: string; message?: string }; error?: string }> {
+    return apiClient.post(`/api/remote/machines/${machineId}/create-directory`, { path });
+  },
 };

--- a/frontend/src/api/fs.ts
+++ b/frontend/src/api/fs.ts
@@ -45,6 +45,12 @@ export interface CreateDirectoryResult {
   error?: string;
 }
 
+export interface RemoteOperationResult<T = unknown> {
+  success: boolean;
+  result?: T;
+  error?: string;
+}
+
 // ==================== API Methods ====================
 
 export const fsApi = {
@@ -69,7 +75,7 @@ export const fsApi = {
   browseRemoteDirectory(
     machineId: string,
     path?: string
-  ): Promise<{ success: boolean; result?: BrowseResult; error?: string }> {
+  ): Promise<RemoteOperationResult<BrowseResult>> {
     const params: Record<string, string> = {};
     if (path) params.path = path;
     return apiClient.get(`/api/remote/machines/${machineId}/browse`, params);
@@ -79,7 +85,7 @@ export const fsApi = {
   createRemoteDirectory(
     machineId: string,
     path: string
-  ): Promise<{ success: boolean; result?: { path: string; message?: string }; error?: string }> {
+  ): Promise<RemoteOperationResult<{ path: string; message?: string }>> {
     return apiClient.post(`/api/remote/machines/${machineId}/create-directory`, { path });
   },
 };

--- a/frontend/src/components/work/RemoteDirectoryBrowser.tsx
+++ b/frontend/src/components/work/RemoteDirectoryBrowser.tsx
@@ -160,18 +160,31 @@ export const RemoteDirectoryBrowser: React.FC<RemoteDirectoryBrowserProps> = ({
   };
 
   // Create new directory
-  // Note: This feature requires remote agent support which is not yet implemented
-  // Users can manually create directories on the remote machine
   const handleCreateDirectory = async () => {
     if (!newDirName.trim() || !isWritable) return;
+
+    const separator = getPathSeparator();
+    const fullPath = currentPath
+      ? currentPath + (currentPath.endsWith(separator) ? '' : separator) + newDirName.trim()
+      : newDirName.trim();
+
+    setIsLoading(true);
+    setError(null);
     setShowCreateInput(false);
-    setNewDirName('');
-    // Show info message instead of error - feature not yet available
-    setError(
-      t('createDirNotAvailable', language) ||
-        'Create directory on remote machine is not yet available. ' +
-          'Please create the directory on the remote machine first, then enter the path here.'
-    );
+
+    try {
+      const result = await fsApi.createRemoteDirectory(machineId, fullPath);
+      if (result.success) {
+        setNewDirName('');
+        await fetchDirectories(currentPath);
+      } else {
+        setError(result.error || t('createDirError', language) || 'Failed to create directory');
+      }
+    } catch (err) {
+      setError((err as Error)?.message || t('createDirError', language) || 'Failed to create directory');
+    } finally {
+      setIsLoading(false);
+    }
   };
 
   // Select path from history

--- a/frontend/src/components/work/RemoteDirectoryBrowser.tsx
+++ b/frontend/src/components/work/RemoteDirectoryBrowser.tsx
@@ -178,10 +178,12 @@ export const RemoteDirectoryBrowser: React.FC<RemoteDirectoryBrowserProps> = ({
         setNewDirName('');
         await fetchDirectories(currentPath);
       } else {
-        setError(result.error || t('createDirError', language) || 'Failed to create directory');
+        const fallback = t('createDirError', language) ?? 'Failed to create directory';
+        setError(result.error ?? fallback);
       }
     } catch (err) {
-      setError((err as Error)?.message || t('createDirError', language) || 'Failed to create directory');
+      const fallback = t('createDirError', language) ?? 'Failed to create directory';
+      setError((err as Error)?.message ?? fallback);
     } finally {
       setIsLoading(false);
     }

--- a/frontend/src/components/work/RemoteDirectoryBrowser.tsx
+++ b/frontend/src/components/work/RemoteDirectoryBrowser.tsx
@@ -51,6 +51,7 @@ export const RemoteDirectoryBrowser: React.FC<RemoteDirectoryBrowserProps> = ({
   const [isWritable, setIsWritable] = useState(false);
   const [showCreateInput, setShowCreateInput] = useState(false);
   const [newDirName, setNewDirName] = useState('');
+  const [isCreating, setIsCreating] = useState(false);
   const [pathHistory, setPathHistory] = useState<string[]>([]);
   const [fallbackNote, setFallbackNote] = useState<string | null>(null);
 
@@ -161,14 +162,14 @@ export const RemoteDirectoryBrowser: React.FC<RemoteDirectoryBrowserProps> = ({
 
   // Create new directory
   const handleCreateDirectory = async () => {
-    if (!newDirName.trim() || !isWritable) return;
+    if (!newDirName.trim() || !isWritable || isCreating) return;
 
     const separator = getPathSeparator();
     const fullPath = currentPath
       ? currentPath + (currentPath.endsWith(separator) ? '' : separator) + newDirName.trim()
       : newDirName.trim();
 
-    setIsLoading(true);
+    setIsCreating(true);
     setError(null);
     setShowCreateInput(false);
 
@@ -185,7 +186,7 @@ export const RemoteDirectoryBrowser: React.FC<RemoteDirectoryBrowserProps> = ({
       const fallback = t('createDirError', language) ?? 'Failed to create directory';
       setError((err as Error)?.message ?? fallback);
     } finally {
-      setIsLoading(false);
+      setIsCreating(false);
     }
   };
 
@@ -311,9 +312,17 @@ export const RemoteDirectoryBrowser: React.FC<RemoteDirectoryBrowserProps> = ({
               className="form-control"
               value={newDirName}
               onChange={(e) => setNewDirName(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') handleCreateDirectory();
+              }}
               placeholder={t('folderName', language) || 'Folder name'}
             />
-            <Button variant="primary" size="sm" onClick={handleCreateDirectory}>
+            <Button
+              variant="primary"
+              size="sm"
+              onClick={handleCreateDirectory}
+              disabled={isCreating}
+            >
               {t('create', language)}
             </Button>
             <Button

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -866,7 +866,8 @@ const translations: Record<Language, Translations> = {
     noSubdirectories: 'No subdirectories found',
     folderName: 'Folder name',
     createDirNotAvailable:
-      'Create directory on remote machine is not yet available. Please create the directory on the remote machine first.',
+      'Unable to create directory. Please check the folder name and try again.',
+    createDirError: 'Failed to create directory.',
   },
   zh: {
     // Common
@@ -1707,7 +1708,8 @@ const translations: Record<Language, Translations> = {
     emptyDirectory: '空目录',
     noSubdirectories: '没有子目录',
     folderName: '文件夹名称',
-    createDirNotAvailable: '暂不支持在远程机器上创建目录，请先在远程机器上手动创建。',
+    createDirNotAvailable: '无法创建目录，请检查文件夹名称后重试。',
+    createDirError: '创建目录失败。',
   },
   ja: {
     // Common
@@ -2255,7 +2257,8 @@ const translations: Record<Language, Translations> = {
     noSubdirectories: 'サブディレクトリがありません',
     folderName: 'フォルダ名',
     createDirNotAvailable:
-      'リモートマシンでのディレクトリ作成はまだサポートされていません。先にリモートマシンで手動作成してください。',
+      'ディレクトリを作成できません。フォルダ名を確認して再試行してください。',
+    createDirError: 'ディレクトリの作成に失敗しました。',
   },
   ko: {
     // Common
@@ -2801,7 +2804,8 @@ const translations: Record<Language, Translations> = {
     noSubdirectories: '하위 디렉토리 없음',
     folderName: '폴더 이름',
     createDirNotAvailable:
-      '원격 머신에서 디렉토리 생성은 아직 지원되지 않습니다. 원격 머신에서 먼저 수동으로 생성해 주세요.',
+      '디렉토리를 생성할 수 없습니다. 폴더 이름을 확인하고 다시 시도해 주세요.',
+    createDirError: '디렉토리 생성에 실패했습니다.',
   },
 };
 

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -865,7 +865,6 @@ const translations: Record<Language, Translations> = {
     emptyDirectory: 'Empty Directory',
     noSubdirectories: 'No subdirectories found',
     folderName: 'Folder name',
-    createDirFailed: 'Unable to create directory. Please check the folder name and try again.',
     createDirError: 'Failed to create directory.',
   },
   zh: {
@@ -1707,7 +1706,6 @@ const translations: Record<Language, Translations> = {
     emptyDirectory: '空目录',
     noSubdirectories: '没有子目录',
     folderName: '文件夹名称',
-    createDirFailed: '无法创建目录，请检查文件夹名称后重试。',
     createDirError: '创建目录失败。',
   },
   ja: {
@@ -2255,7 +2253,6 @@ const translations: Record<Language, Translations> = {
     emptyDirectory: '空のディレクトリ',
     noSubdirectories: 'サブディレクトリがありません',
     folderName: 'フォルダ名',
-    createDirFailed: 'ディレクトリを作成できません。フォルダ名を確認して再試行してください。',
     createDirError: 'ディレクトリの作成に失敗しました。',
   },
   ko: {
@@ -2801,7 +2798,6 @@ const translations: Record<Language, Translations> = {
     emptyDirectory: '빈 디렉토리',
     noSubdirectories: '하위 디렉토리 없음',
     folderName: '폴더 이름',
-    createDirFailed: '디렉토리를 생성할 수 없습니다. 폴더 이름을 확인하고 다시 시도해 주세요.',
     createDirError: '디렉토리 생성에 실패했습니다.',
   },
 };

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -865,8 +865,7 @@ const translations: Record<Language, Translations> = {
     emptyDirectory: 'Empty Directory',
     noSubdirectories: 'No subdirectories found',
     folderName: 'Folder name',
-    createDirNotAvailable:
-      'Unable to create directory. Please check the folder name and try again.',
+    createDirFailed: 'Unable to create directory. Please check the folder name and try again.',
     createDirError: 'Failed to create directory.',
   },
   zh: {
@@ -1708,7 +1707,7 @@ const translations: Record<Language, Translations> = {
     emptyDirectory: '空目录',
     noSubdirectories: '没有子目录',
     folderName: '文件夹名称',
-    createDirNotAvailable: '无法创建目录，请检查文件夹名称后重试。',
+    createDirFailed: '无法创建目录，请检查文件夹名称后重试。',
     createDirError: '创建目录失败。',
   },
   ja: {
@@ -2256,8 +2255,7 @@ const translations: Record<Language, Translations> = {
     emptyDirectory: '空のディレクトリ',
     noSubdirectories: 'サブディレクトリがありません',
     folderName: 'フォルダ名',
-    createDirNotAvailable:
-      'ディレクトリを作成できません。フォルダ名を確認して再試行してください。',
+    createDirFailed: 'ディレクトリを作成できません。フォルダ名を確認して再試行してください。',
     createDirError: 'ディレクトリの作成に失敗しました。',
   },
   ko: {
@@ -2803,8 +2801,7 @@ const translations: Record<Language, Translations> = {
     emptyDirectory: '빈 디렉토리',
     noSubdirectories: '하위 디렉토리 없음',
     folderName: '폴더 이름',
-    createDirNotAvailable:
-      '디렉토리를 생성할 수 없습니다. 폴더 이름을 확인하고 다시 시도해 주세요.',
+    createDirFailed: '디렉토리를 생성할 수 없습니다. 폴더 이름을 확인하고 다시 시도해 주세요.',
     createDirError: '디렉토리 생성에 실패했습니다.',
   },
 };

--- a/remote-agent/agent.py
+++ b/remote-agent/agent.py
@@ -1033,9 +1033,9 @@ class RemoteAgent:
             "request_id": request_id,
             "success": success,
         }
-        if error:
+        if error is not None:
             response["error"] = error
-        if result:
+        if result is not None:
             response["result"] = result
         self._http_send(response)
 

--- a/remote-agent/agent.py
+++ b/remote-agent/agent.py
@@ -1019,141 +1019,92 @@ class RemoteAgent:
                 }
             )
 
+    def _send_create_result(
+        self,
+        request_id: str,
+        success: bool,
+        error: str | None = None,
+        result: dict | None = None,
+    ) -> None:
+        """Send a create_directory result back to the server."""
+        response: dict[str, Any] = {
+            "type": "browse_result",
+            "machine_id": self.config.machine_id,
+            "request_id": request_id,
+            "success": success,
+        }
+        if error:
+            response["error"] = error
+        if result:
+            response["result"] = result
+        self._http_send(response)
+
     def _cmd_create_directory(self, data: dict[str, Any]) -> None:
         """Handle a create_directory command."""
         request_id = data.get("request_id", "")
         dir_path = data.get("path", "")
 
-        if dir_path:
-            dir_path = os.path.expanduser(dir_path)
-        else:
-            self._http_send(
-                {
-                    "type": "browse_result",
-                    "machine_id": self.config.machine_id,
-                    "request_id": request_id,
-                    "success": False,
-                    "error": "No path specified",
-                }
-            )
+        if not dir_path:
+            self._send_create_result(request_id, False, error="No path specified")
             return
 
+        dir_path = os.path.expanduser(dir_path)
+        name = os.path.basename(dir_path)
+
+        # Validate name before realpath (realpath fails on null bytes)
+        invalid_chars = set("/\0")
+        if os.name == "nt":
+            invalid_chars.update('\\:*?"<>|')
+        if any(c in name for c in invalid_chars) or not name:
+            self._send_create_result(request_id, False, error=f"Invalid directory name: {name}")
+            return
+
+        dir_path = os.path.realpath(dir_path)
         logger.info("Creating directory: %s", dir_path)
 
         try:
             parent = os.path.dirname(dir_path)
-            name = os.path.basename(dir_path)
 
             if not os.path.exists(parent):
-                self._http_send(
-                    {
-                        "type": "browse_result",
-                        "machine_id": self.config.machine_id,
-                        "request_id": request_id,
-                        "success": False,
-                        "error": f"Parent directory does not exist: {parent}",
-                    }
+                self._send_create_result(
+                    request_id, False, error=f"Parent directory does not exist: {parent}"
                 )
                 return
 
             if not os.path.isdir(parent):
-                self._http_send(
-                    {
-                        "type": "browse_result",
-                        "machine_id": self.config.machine_id,
-                        "request_id": request_id,
-                        "success": False,
-                        "error": f"Parent path is not a directory: {parent}",
-                    }
+                self._send_create_result(
+                    request_id, False, error=f"Parent path is not a directory: {parent}"
                 )
                 return
 
             if not os.access(parent, os.W_OK):
-                self._http_send(
-                    {
-                        "type": "browse_result",
-                        "machine_id": self.config.machine_id,
-                        "request_id": request_id,
-                        "success": False,
-                        "error": f"Permission denied: cannot write to {parent}",
-                    }
-                )
-                return
-
-            invalid_chars = set("/\0")
-            if os.name == "nt":
-                invalid_chars.update('\\:*?"<>|')
-            if any(c in name for c in invalid_chars) or not name:
-                self._http_send(
-                    {
-                        "type": "browse_result",
-                        "machine_id": self.config.machine_id,
-                        "request_id": request_id,
-                        "success": False,
-                        "error": f"Invalid directory name: {name}",
-                    }
+                self._send_create_result(
+                    request_id, False, error=f"Permission denied: cannot write to {parent}"
                 )
                 return
 
             if os.path.exists(dir_path):
-                self._http_send(
-                    {
-                        "type": "browse_result",
-                        "machine_id": self.config.machine_id,
-                        "request_id": request_id,
-                        "success": False,
-                        "error": f"Directory already exists: {dir_path}",
-                    }
+                self._send_create_result(
+                    request_id, False, error=f"Directory already exists: {dir_path}"
                 )
                 return
 
-            os.makedirs(dir_path, exist_ok=False)
+            os.mkdir(dir_path)
 
-            self._http_send(
-                {
-                    "type": "browse_result",
-                    "machine_id": self.config.machine_id,
-                    "request_id": request_id,
-                    "success": True,
-                    "result": {
-                        "path": dir_path,
-                        "message": "Directory created successfully",
-                    },
-                }
+            self._send_create_result(
+                request_id,
+                True,
+                result={"path": dir_path, "message": "Directory created successfully"},
             )
             logger.info("Created directory: %s", dir_path)
 
         except PermissionError:
-            self._http_send(
-                {
-                    "type": "browse_result",
-                    "machine_id": self.config.machine_id,
-                    "request_id": request_id,
-                    "success": False,
-                    "error": f"Permission denied: {dir_path}",
-                }
-            )
+            self._send_create_result(request_id, False, error=f"Permission denied: {dir_path}")
         except OSError as e:
-            self._http_send(
-                {
-                    "type": "browse_result",
-                    "machine_id": self.config.machine_id,
-                    "request_id": request_id,
-                    "success": False,
-                    "error": f"Failed to create directory: {e}",
-                }
-            )
+            self._send_create_result(request_id, False, error=f"Failed to create directory: {e}")
         except Exception as e:
             logger.error("Failed to create directory %s: %s", dir_path, e)
-            self._http_send(
-                {
-                    "type": "browse_result",
-                    "machine_id": self.config.machine_id,
-                    "request_id": request_id,
-                    "success": False,
-                    "error": str(e),
-                }
-            )
+            self._send_create_result(request_id, False, error=str(e))
 
     def _stop_terminal_process(self, terminal_id: str) -> None:
         """Stop a terminal server process."""

--- a/remote-agent/agent.py
+++ b/remote-agent/agent.py
@@ -460,6 +460,8 @@ class RemoteAgent:
             self._cmd_attach_terminal(data)
         elif command == "browse_directory":
             self._cmd_browse_directory(data)
+        elif command == "create_directory":
+            self._cmd_create_directory(data)
         else:
             logger.warning("Unknown command: %s", command)
 
@@ -1007,6 +1009,142 @@ class RemoteAgent:
 
         except Exception as e:
             logger.error("Failed to browse directory %s: %s", path, e)
+            self._http_send(
+                {
+                    "type": "browse_result",
+                    "machine_id": self.config.machine_id,
+                    "request_id": request_id,
+                    "success": False,
+                    "error": str(e),
+                }
+            )
+
+    def _cmd_create_directory(self, data: dict[str, Any]) -> None:
+        """Handle a create_directory command."""
+        request_id = data.get("request_id", "")
+        dir_path = data.get("path", "")
+
+        if dir_path:
+            dir_path = os.path.expanduser(dir_path)
+        else:
+            self._http_send(
+                {
+                    "type": "browse_result",
+                    "machine_id": self.config.machine_id,
+                    "request_id": request_id,
+                    "success": False,
+                    "error": "No path specified",
+                }
+            )
+            return
+
+        logger.info("Creating directory: %s", dir_path)
+
+        try:
+            parent = os.path.dirname(dir_path)
+            name = os.path.basename(dir_path)
+
+            if not os.path.exists(parent):
+                self._http_send(
+                    {
+                        "type": "browse_result",
+                        "machine_id": self.config.machine_id,
+                        "request_id": request_id,
+                        "success": False,
+                        "error": f"Parent directory does not exist: {parent}",
+                    }
+                )
+                return
+
+            if not os.path.isdir(parent):
+                self._http_send(
+                    {
+                        "type": "browse_result",
+                        "machine_id": self.config.machine_id,
+                        "request_id": request_id,
+                        "success": False,
+                        "error": f"Parent path is not a directory: {parent}",
+                    }
+                )
+                return
+
+            if not os.access(parent, os.W_OK):
+                self._http_send(
+                    {
+                        "type": "browse_result",
+                        "machine_id": self.config.machine_id,
+                        "request_id": request_id,
+                        "success": False,
+                        "error": f"Permission denied: cannot write to {parent}",
+                    }
+                )
+                return
+
+            invalid_chars = set("/\0")
+            if os.name == "nt":
+                invalid_chars.update('\\:*?"<>|')
+            if any(c in name for c in invalid_chars) or not name:
+                self._http_send(
+                    {
+                        "type": "browse_result",
+                        "machine_id": self.config.machine_id,
+                        "request_id": request_id,
+                        "success": False,
+                        "error": f"Invalid directory name: {name}",
+                    }
+                )
+                return
+
+            if os.path.exists(dir_path):
+                self._http_send(
+                    {
+                        "type": "browse_result",
+                        "machine_id": self.config.machine_id,
+                        "request_id": request_id,
+                        "success": False,
+                        "error": f"Directory already exists: {dir_path}",
+                    }
+                )
+                return
+
+            os.makedirs(dir_path, exist_ok=False)
+
+            self._http_send(
+                {
+                    "type": "browse_result",
+                    "machine_id": self.config.machine_id,
+                    "request_id": request_id,
+                    "success": True,
+                    "result": {
+                        "path": dir_path,
+                        "message": "Directory created successfully",
+                    },
+                }
+            )
+            logger.info("Created directory: %s", dir_path)
+
+        except PermissionError:
+            self._http_send(
+                {
+                    "type": "browse_result",
+                    "machine_id": self.config.machine_id,
+                    "request_id": request_id,
+                    "success": False,
+                    "error": f"Permission denied: {dir_path}",
+                }
+            )
+        except OSError as e:
+            self._http_send(
+                {
+                    "type": "browse_result",
+                    "machine_id": self.config.machine_id,
+                    "request_id": request_id,
+                    "success": False,
+                    "error": f"Failed to create directory: {e}",
+                }
+            )
+        except Exception as e:
+            logger.error("Failed to create directory %s: %s", dir_path, e)
             self._http_send(
                 {
                     "type": "browse_result",

--- a/remote-agent/agent.py
+++ b/remote-agent/agent.py
@@ -1083,12 +1083,6 @@ class RemoteAgent:
                 )
                 return
 
-            if os.path.exists(dir_path):
-                self._send_create_result(
-                    request_id, False, error=f"Directory already exists: {dir_path}"
-                )
-                return
-
             os.mkdir(dir_path)
 
             self._send_create_result(
@@ -1098,6 +1092,10 @@ class RemoteAgent:
             )
             logger.info("Created directory: %s", dir_path)
 
+        except FileExistsError:
+            self._send_create_result(
+                request_id, False, error=f"Directory already exists: {dir_path}"
+            )
         except PermissionError:
             self._send_create_result(request_id, False, error=f"Permission denied: {dir_path}")
         except OSError as e:

--- a/tests/issues/584/test_create_remote_directory.py
+++ b/tests/issues/584/test_create_remote_directory.py
@@ -262,8 +262,6 @@ class TestAgentCreateDirectory(unittest.TestCase):
         if agent_dir not in sys.path:
             sys.path.insert(0, agent_dir)
 
-        import importlib
-
         if "agent" in sys.modules:
             del sys.modules["agent"]
 
@@ -387,6 +385,17 @@ class TestAgentCreateDirectory(unittest.TestCase):
             agent._cmd_create_directory({"request_id": "test-req-123", "path": dir_path})
             result = self._get_last_send(agent)
             self.assertEqual(result["request_id"], "test-req-123")
+
+    def test_windows_invalid_chars_rejected(self):
+        """Test that Windows-specific invalid characters are rejected when os.name is 'nt'."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dir_path = os.path.join(tmpdir, "bad*name")
+            agent = self._make_agent()
+            with patch("os.name", "nt"):
+                agent._cmd_create_directory({"request_id": "r1", "path": dir_path})
+            result = self._get_last_send(agent)
+            self.assertFalse(result["success"])
+            self.assertIn("Invalid directory name", result["error"])
 
 
 if __name__ == "__main__":

--- a/tests/issues/584/test_create_remote_directory.py
+++ b/tests/issues/584/test_create_remote_directory.py
@@ -1,0 +1,393 @@
+"""
+Tests for remote directory creation feature (Issue #584 Phase 2).
+
+Covers:
+- Route endpoint: POST /api/remote/machines/<machine_id>/create-directory
+- Agent command handler: _cmd_create_directory
+"""
+
+import importlib
+import json
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
+
+# Add project root to path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+
+
+# ==================== Route Tests ====================
+
+
+class TestCreateRemoteDirectoryRoute(unittest.TestCase):
+    """Test the create_remote_directory route endpoint."""
+
+    def _make_app(self, mgr):
+        """Create a minimal Flask app with remote_bp for route testing."""
+        from flask import Flask
+
+        import app.modules.workspace.remote_agent_manager as ram_mod
+        from app.routes import remote as remote_mod
+
+        ram_mod._agent_manager = mgr
+
+        app = Flask(__name__)
+        app.config["TESTING"] = True
+        app.config["SECRET_KEY"] = "test-secret"
+        app.register_blueprint(remote_mod.remote_bp, url_prefix="/api/remote")
+
+        def _mock_load_user(token):
+            if not token:
+                return None
+            if token.startswith("test-token-"):
+                parts = token.split("-")
+                if len(parts) >= 4:
+                    return {
+                        "id": int(parts[2]),
+                        "username": f"user{parts[2]}",
+                        "email": f"user{parts[2]}@test.com",
+                        "role": parts[3],
+                    }
+            return None
+
+        from app.auth import decorators as auth_dec
+
+        auth_dec._load_user_from_token = _mock_load_user
+        remote_mod._load_user_from_token = _mock_load_user
+        self._auth_dec = auth_dec
+        return app
+
+    def _auth_post(self, client, url, token, **kwargs):
+        client.set_cookie("session_token", token)
+        return client.post(url, **kwargs)
+
+    def test_unauthenticated_returns_401(self):
+        mgr = MagicMock()
+        app = self._make_app(mgr)
+        with app.test_client() as client:
+            resp = client.post(
+                "/api/remote/machines/m1/create-directory",
+                json={"path": "/tmp/test"},
+            )
+            self.assertEqual(resp.status_code, 401)
+
+    def test_no_path_returns_400(self):
+        mgr = MagicMock()
+        app = self._make_app(mgr)
+        with app.test_client() as client:
+            resp = self._auth_post(
+                client,
+                "/api/remote/machines/m1/create-directory",
+                "test-token-1-admin",
+                json={},
+            )
+            self.assertEqual(resp.status_code, 400)
+            data = resp.get_json()
+            self.assertFalse(data["success"])
+            self.assertIn("Path is required", data["error"])
+
+    def test_path_too_long_returns_400(self):
+        mgr = MagicMock()
+        app = self._make_app(mgr)
+        with app.test_client() as client:
+            resp = self._auth_post(
+                client,
+                "/api/remote/machines/m1/create-directory",
+                "test-token-1-admin",
+                json={"path": "a" * 4097},
+            )
+            self.assertEqual(resp.status_code, 400)
+            data = resp.get_json()
+            self.assertIn("too long", data["error"])
+
+    def test_machine_not_found_returns_404(self):
+        mgr = MagicMock()
+        mgr.get_machine.return_value = None
+        app = self._make_app(mgr)
+        with app.test_client() as client:
+            resp = self._auth_post(
+                client,
+                "/api/remote/machines/m1/create-directory",
+                "test-token-1-admin",
+                json={"path": "/tmp/test"},
+            )
+            self.assertEqual(resp.status_code, 404)
+
+    def test_machine_offline_returns_503(self):
+        mgr = MagicMock()
+        mgr.get_machine.return_value = {"status": "offline"}
+        app = self._make_app(mgr)
+        with app.test_client() as client:
+            resp = self._auth_post(
+                client,
+                "/api/remote/machines/m1/create-directory",
+                "test-token-1-admin",
+                json={"path": "/tmp/test"},
+            )
+            self.assertEqual(resp.status_code, 503)
+
+    def test_non_admin_no_access_returns_403(self):
+        mgr = MagicMock()
+        mgr.check_user_access.return_value = False
+        mgr.get_machine.return_value = {"status": "online"}
+        app = self._make_app(mgr)
+        with app.test_client() as client:
+            resp = self._auth_post(
+                client,
+                "/api/remote/machines/m1/create-directory",
+                "test-token-2-user",
+                json={"path": "/tmp/test"},
+            )
+            self.assertEqual(resp.status_code, 403)
+
+    def test_successful_creation(self):
+        mgr = MagicMock()
+        mgr.check_user_access.return_value = True
+        mgr.get_machine.return_value = {"status": "online"}
+        mgr.send_command.return_value = True
+        mgr.get_browse_result.return_value = {
+            "success": True,
+            "result": {"path": "/tmp/test", "message": "Directory created successfully"},
+        }
+        app = self._make_app(mgr)
+        with app.test_client() as client:
+            resp = self._auth_post(
+                client,
+                "/api/remote/machines/m1/create-directory",
+                "test-token-1-admin",
+                json={"path": "/tmp/test"},
+            )
+            self.assertEqual(resp.status_code, 200)
+            data = resp.get_json()
+            self.assertTrue(data["success"])
+            self.assertEqual(data["result"]["path"], "/tmp/test")
+
+    def test_agent_creation_failure(self):
+        mgr = MagicMock()
+        mgr.get_machine.return_value = {"status": "online"}
+        mgr.send_command.return_value = True
+        mgr.get_browse_result.return_value = {
+            "success": False,
+            "error": "Permission denied: /tmp/test",
+        }
+        app = self._make_app(mgr)
+        with app.test_client() as client:
+            resp = self._auth_post(
+                client,
+                "/api/remote/machines/m1/create-directory",
+                "test-token-1-admin",
+                json={"path": "/tmp/test"},
+            )
+            self.assertEqual(resp.status_code, 200)
+            data = resp.get_json()
+            self.assertFalse(data["success"])
+            self.assertIn("Permission denied", data["error"])
+
+    def test_send_command_failure_returns_500(self):
+        mgr = MagicMock()
+        mgr.get_machine.return_value = {"status": "online"}
+        mgr.send_command.return_value = False
+        app = self._make_app(mgr)
+        with app.test_client() as client:
+            resp = self._auth_post(
+                client,
+                "/api/remote/machines/m1/create-directory",
+                "test-token-1-admin",
+                json={"path": "/tmp/test"},
+            )
+            self.assertEqual(resp.status_code, 500)
+
+    def test_agent_timeout_returns_504(self):
+        mgr = MagicMock()
+        mgr.get_machine.return_value = {"status": "online"}
+        mgr.send_command.return_value = True
+        mgr.get_browse_result.return_value = None
+        app = self._make_app(mgr)
+        with app.test_client() as client:
+            resp = self._auth_post(
+                client,
+                "/api/remote/machines/m1/create-directory",
+                "test-token-1-admin",
+                json={"path": "/tmp/test"},
+            )
+            self.assertEqual(resp.status_code, 504)
+
+
+# ==================== Agent Command Tests ====================
+
+
+class TestAgentCreateDirectory(unittest.TestCase):
+    """Test the _cmd_create_directory agent command handler."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Import RemoteAgent with mocked dependencies."""
+        agent_dir = os.path.join(os.path.dirname(__file__), "..", "..", "..", "remote-agent")
+        agent_dir = os.path.abspath(agent_dir)
+
+        # Mock all remote-agent dependencies before importing
+        mock_modules = [
+            "config",
+            "executor",
+            "session_sync",
+            "system_info",
+            "cli_settings",
+        ]
+        for mod_name in mock_modules:
+            if mod_name not in sys.modules:
+                sys.modules[mod_name] = MagicMock()
+
+        # Provide AgentConfig
+        mock_config = sys.modules["config"]
+        mock_config.AgentConfig = type("AgentConfig", (), {"__init__": lambda self: None})
+
+        # Provide ProcessExecutor
+        mock_executor = sys.modules["executor"]
+        mock_executor.ProcessExecutor = MagicMock
+
+        # Provide SessionSyncService
+        mock_session_sync = sys.modules["session_sync"]
+        mock_session_sync.SessionSyncService = MagicMock
+
+        # Provide get_capabilities
+        mock_system_info = sys.modules["system_info"]
+        mock_system_info.get_capabilities = MagicMock(return_value={})
+
+        # Provide apply_cli_settings
+        mock_cli = sys.modules["cli_settings"]
+        mock_cli.apply_cli_settings = MagicMock()
+
+        if agent_dir not in sys.path:
+            sys.path.insert(0, agent_dir)
+
+        import importlib
+
+        if "agent" in sys.modules:
+            del sys.modules["agent"]
+
+        import agent as agent_mod
+
+        cls.AgentClass = agent_mod.RemoteAgent
+
+    def _make_agent(self):
+        """Create a RemoteAgent with mocked _http_send."""
+        agent = self.AgentClass.__new__(self.AgentClass)
+        agent.config = MagicMock()
+        agent.config.machine_id = "test-machine"
+        agent._http_send = MagicMock()
+        return agent
+
+    def _get_last_send(self, agent):
+        """Get the last _http_send call arguments."""
+        agent._http_send.assert_called()
+        return agent._http_send.call_args[0][0]
+
+    def test_empty_path_returns_error(self):
+        agent = self._make_agent()
+        agent._cmd_create_directory({"request_id": "r1", "path": ""})
+        result = self._get_last_send(agent)
+        self.assertFalse(result["success"])
+        self.assertIn("No path specified", result["error"])
+
+    def test_missing_path_returns_error(self):
+        agent = self._make_agent()
+        agent._cmd_create_directory({"request_id": "r1"})
+        result = self._get_last_send(agent)
+        self.assertFalse(result["success"])
+        self.assertIn("No path specified", result["error"])
+
+    def test_parent_not_exists_returns_error(self):
+        agent = self._make_agent()
+        agent._cmd_create_directory({"request_id": "r1", "path": "/nonexistent/path/test"})
+        result = self._get_last_send(agent)
+        self.assertFalse(result["success"])
+        self.assertIn("Parent directory does not exist", result["error"])
+
+    def test_parent_not_directory_returns_error(self):
+        with tempfile.NamedTemporaryFile() as f:
+            dir_path = os.path.join(f.name, "subdir")
+            agent = self._make_agent()
+            agent._cmd_create_directory({"request_id": "r1", "path": dir_path})
+            result = self._get_last_send(agent)
+            self.assertFalse(result["success"])
+            self.assertIn("not a directory", result["error"])
+
+    def test_parent_not_writable_returns_error(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            subdir = os.path.join(tmpdir, "readonly")
+            os.makedirs(subdir)
+            os.chmod(subdir, 0o444)
+            dir_path = os.path.join(subdir, "newdir")
+            try:
+                agent = self._make_agent()
+                agent._cmd_create_directory({"request_id": "r1", "path": dir_path})
+                result = self._get_last_send(agent)
+                self.assertFalse(result["success"])
+                self.assertIn("Permission denied", result["error"])
+            finally:
+                os.chmod(subdir, 0o755)
+
+    def test_invalid_name_with_null_returns_error(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dir_path = os.path.join(tmpdir, "bad\x00name")
+            agent = self._make_agent()
+            agent._cmd_create_directory({"request_id": "r1", "path": dir_path})
+            result = self._get_last_send(agent)
+            self.assertFalse(result["success"])
+            self.assertIn("Invalid directory name", result["error"])
+
+    def test_already_exists_returns_error(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            existing = os.path.join(tmpdir, "existing")
+            os.makedirs(existing)
+            agent = self._make_agent()
+            agent._cmd_create_directory({"request_id": "r1", "path": existing})
+            result = self._get_last_send(agent)
+            self.assertFalse(result["success"])
+            self.assertIn("already exists", result["error"])
+
+    def test_successful_creation(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dir_path = os.path.join(tmpdir, "newdir")
+            agent = self._make_agent()
+            agent._cmd_create_directory({"request_id": "r1", "path": dir_path})
+            result = self._get_last_send(agent)
+            self.assertTrue(result["success"])
+            self.assertEqual(result["result"]["path"], os.path.realpath(dir_path))
+            self.assertTrue(os.path.isdir(dir_path))
+
+    def test_expanduser_works(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dir_path = os.path.join(tmpdir, "expanded")
+            # Use realpath since expanduser on ~ may resolve differently
+            agent = self._make_agent()
+            agent._cmd_create_directory({"request_id": "r1", "path": dir_path})
+            result = self._get_last_send(agent)
+            self.assertTrue(result["success"])
+
+    def test_path_with_dotdot_normalized(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            subdir = os.path.join(tmpdir, "sub")
+            os.makedirs(subdir)
+            dir_path = os.path.join(subdir, "..", "sub", "newdir")
+            agent = self._make_agent()
+            agent._cmd_create_directory({"request_id": "r1", "path": dir_path})
+            result = self._get_last_send(agent)
+            self.assertTrue(result["success"])
+            # realpath should normalize .. components
+            normalized = os.path.realpath(dir_path)
+            self.assertEqual(result["result"]["path"], normalized)
+
+    def test_response_includes_request_id(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dir_path = os.path.join(tmpdir, "reqtest")
+            agent = self._make_agent()
+            agent._cmd_create_directory({"request_id": "test-req-123", "path": dir_path})
+            result = self._get_last_send(agent)
+            self.assertEqual(result["request_id"], "test-req-123")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- 实现远程工作区目录浏览器的"新建文件夹"功能（Issue #584 Phase 2）
- 添加完整的创建目录管道：Remote Agent → Server Route → Frontend API → UI
- 复用 `browse_result` 存储基础设施，无需新增 manager 代码

## Changes
| 文件 | 改动 |
|------|------|
| `remote-agent/agent.py` | 添加 `_cmd_create_directory` 命令处理（验证+创建目录） |
| `app/routes/remote.py` | 添加 `POST /machines/<machine_id>/create-directory` 端点 |
| `frontend/src/api/fs.ts` | 添加 `createRemoteDirectory` API 方法 |
| `frontend/src/components/work/RemoteDirectoryBrowser.tsx` | 替换 stub 为真实实现 |
| `frontend/src/i18n/index.ts` | 更新 4 种语言的翻译文案 |

## Test plan
- [ ] 在远程工作区目录浏览器中点击"新建文件夹"
- [ ] 输入名称并创建，验证新文件夹出现在列表中
- [ ] 验证错误场景：已存在的目录、无权限目录、非法字符名称
- [ ] TypeScript 编译通过
- [ ] Pre-commit hooks 全部通过（black, ruff, mypy, bandit 等）

🤖 Generated with [Claude Code](https://claude.com/claude-code)