### PR TITLE
fix: 不持久化 tab 通知状态，避免刷新后误报通知

### DIFF
--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -20,8 +20,8 @@ export interface WorkspaceTab {
   encodedProjectName?: string; // Encoded project path for session restoration
   toolName?: string; // Tool name for session restoration
   createdAt: number;
-  waitingForUser: boolean;
-  waitingType: 'permission' | 'plan' | 'input' | null;
+  waitingForUser?: boolean;
+  waitingType?: 'permission' | 'plan' | 'input' | null;
   // Settings for tab restoration (Issue #70)
   settings?: {
     model?: string; // Selected model ID

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -250,7 +250,7 @@ export const useAppStore = create<AppState>()(
         // Issue #65: Persist workspace tabs state (exclude sensitive fields)
         workspaceTabs: state.workspaceTabs.map(
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          ({ terminalToken, terminalWsUrl, ...rest }) => rest
+          ({ terminalToken, terminalWsUrl, waitingForUser, waitingType, ...rest }) => rest
         ),
         workspaceActiveTabId: state.workspaceActiveTabId,
       }),


### PR DESCRIPTION
## Summary
- 剥离 `waitingForUser` 和 `waitingType` 的 localStorage 持久化，修复服务重启/页面刷新后远程会话 tab 误报通知的问题

## Test plan
- [ ] 打开远程会话 tab，刷新页面 → 确认无旧通知徽章残留
- [ ] 在远程会话中触发真实通知 → 确认徽章正常显示和清除
- [ ] 本地会话 tab 通知功能不受影响

Ref: #596

🤖 Generated with [Claude Code](https://claude.com/claude-code)