### PR TITLE
fix: API key scope 默认值改为 shared，API 路径重命名为 /api/api-keys

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -191,6 +191,7 @@ def register_blueprints(app):
     from app.routes.alerts import alerts_bp
     from app.routes.analysis import analysis_bp
     from app.routes.analytics import analytics_bp
+    from app.routes.api_keys import api_keys_bp
     from app.routes.auth import auth_bp
     from app.routes.compliance import compliance_bp
     from app.routes.fetch import fetch_bp
@@ -233,6 +234,7 @@ def register_blueprints(app):
     app.register_blueprint(projects_bp, url_prefix="/api")
     app.register_blueprint(insights_bp, url_prefix="/api")
     app.register_blueprint(remote_bp, url_prefix="/api/remote")
+    app.register_blueprint(api_keys_bp, url_prefix="/api")
     app.register_blueprint(pages_bp)
 
     logger.info("All blueprints registered")

--- a/app/routes/api_keys.py
+++ b/app/routes/api_keys.py
@@ -1,0 +1,144 @@
+"""Open ACE - API Key Management Routes
+
+API endpoints for managing encrypted API keys stored in the database.
+Used by both local and remote workspaces (governed by the scope field).
+"""
+
+import logging
+
+from flask import Blueprint, g, jsonify, request
+
+from app.auth.decorators import admin_required
+from app.modules.workspace.api_key_proxy import (
+    get_api_key_proxy_service,
+    validate_cli_settings_payload,
+)
+
+logger = logging.getLogger(__name__)
+
+api_keys_bp = Blueprint("api_keys", __name__)
+
+
+@api_keys_bp.route("/api-keys", methods=["GET"])
+@admin_required
+def list_api_keys():
+    """List all encrypted API keys (without revealing actual keys). Admin only."""
+
+    data = request.args
+    tenant_id = int(data.get("tenant_id", 1))
+
+    api_proxy = get_api_key_proxy_service()
+    keys = api_proxy.list_api_keys(tenant_id)
+
+    return jsonify(
+        {
+            "success": True,
+            "keys": keys,
+        }
+    )
+
+
+@api_keys_bp.route("/api-keys", methods=["POST"])
+@admin_required
+def store_api_key():
+    """Store a new encrypted API key. Admin only."""
+
+    data = request.get_json() or {}
+    provider = data.get("provider")
+    key_name = data.get("key_name")
+    api_key = data.get("api_key")
+    base_url = data.get("base_url")
+    tenant_id = int(data.get("tenant_id", 1))
+    cli_tools = data.get("cli_tools")
+    cli_settings = data.get("cli_settings")
+    scope = data.get("scope", "shared")
+    priority = data.get("priority", 0)
+    weight = data.get("weight", 100)
+
+    if not provider or not key_name or not api_key:
+        return jsonify({"error": "provider, key_name, and api_key are required"}), 400
+
+    if scope not in ("local", "remote", "shared"):
+        return jsonify({"error": "scope must be 'local', 'remote', or 'shared'"}), 400
+
+    validation_error = validate_cli_settings_payload(cli_settings)
+    if validation_error:
+        return jsonify({"error": validation_error}), 400
+
+    api_proxy = get_api_key_proxy_service()
+    result = api_proxy.store_api_key(
+        tenant_id=tenant_id,
+        provider=provider,
+        key_name=key_name,
+        api_key=api_key,
+        base_url=base_url,
+        created_by=g.user["id"],
+        cli_tools=cli_tools,
+        cli_settings=cli_settings,
+        scope=scope,
+        priority=int(priority),
+        weight=int(weight),
+    )
+
+    if result.get("success"):
+        return jsonify({"success": True, "key": result})
+    return jsonify({"error": result.get("error", "Failed to store API key")}), 400
+
+
+@api_keys_bp.route("/api-keys/<int:key_id>", methods=["PUT"])
+@admin_required
+def update_api_key(key_id):
+    """Update an API key by ID. Admin only."""
+
+    data = request.get_json() or {}
+    key_name = data.get("key_name")
+    base_url = data.get("base_url")
+    cli_tools = data.get("cli_tools")
+    cli_settings = data.get("cli_settings")
+    is_active = data.get("is_active")
+    if is_active is not None and not isinstance(is_active, bool):
+        return jsonify({"error": "is_active must be a boolean"}), 400
+    scope = data.get("scope")
+    if scope is not None and scope not in ("local", "remote", "shared"):
+        return jsonify({"error": "scope must be 'local', 'remote', or 'shared'"}), 400
+    priority = data.get("priority")
+    weight = data.get("weight")
+    tenant_id = int(data.get("tenant_id", 1))
+
+    validation_error = validate_cli_settings_payload(cli_settings)
+    if validation_error:
+        return jsonify({"error": validation_error}), 400
+
+    api_proxy = get_api_key_proxy_service()
+    success = api_proxy.update_api_key_by_id(
+        key_id=key_id,
+        tenant_id=tenant_id,
+        key_name=key_name,
+        base_url=base_url,
+        cli_tools=cli_tools,
+        cli_settings=cli_settings,
+        is_active=is_active,
+        scope=scope,
+        priority=int(priority) if priority is not None else None,
+        weight=int(weight) if weight is not None else None,
+    )
+
+    if success:
+        return jsonify({"success": True, "message": "API key updated"})
+    return jsonify({"error": "API key not found or update failed"}), 404
+
+
+@api_keys_bp.route("/api-keys/<int:key_id>", methods=["DELETE"])
+@admin_required
+def delete_api_key(key_id):
+    """Delete an API key by ID. Admin only."""
+
+    data = request.get_json() or {}
+    tenant_id = int(data.get("tenant_id", 1))
+
+    api_proxy = get_api_key_proxy_service()
+    success = api_proxy.delete_api_key_by_id(key_id, tenant_id)
+
+    if success:
+        return jsonify({"success": True, "message": "API key deleted"})
+    return jsonify({"error": "API key not found"}), 404

--- a/app/routes/remote.py
+++ b/app/routes/remote.py
@@ -19,10 +19,7 @@ import uuid
 from flask import Blueprint, Response, g, jsonify, request, stream_with_context
 
 from app.auth.decorators import _extract_token, _load_user_from_token, admin_required
-from app.modules.workspace.api_key_proxy import (
-    get_api_key_proxy_service,
-    validate_cli_settings_payload,
-)
+from app.modules.workspace.api_key_proxy import get_api_key_proxy_service
 from app.modules.workspace.remote_agent_manager import get_remote_agent_manager
 from app.modules.workspace.remote_session_manager import get_remote_session_manager
 from app.modules.workspace.terminal_store import terminal_info_store
@@ -304,136 +301,6 @@ def revoke_user(machine_id, user_id):
     if success:
         return jsonify({"success": True, "message": "User access revoked"})
     return jsonify({"error": "Assignment not found"}), 404
-
-
-# ==================== API Key Management (Admin) ====================
-
-
-@remote_bp.route("/api-keys", methods=["GET"])
-@admin_required
-def list_api_keys():
-    """List all encrypted API keys (without revealing actual keys). Admin only."""
-
-    data = request.args
-    tenant_id = int(data.get("tenant_id", 1))
-
-    api_proxy = get_api_key_proxy_service()
-    keys = api_proxy.list_api_keys(tenant_id)
-
-    return jsonify(
-        {
-            "success": True,
-            "keys": keys,
-        }
-    )
-
-
-@remote_bp.route("/api-keys", methods=["POST"])
-@admin_required
-def store_api_key():
-    """Store a new encrypted API key. Admin only."""
-
-    data = request.get_json() or {}
-    provider = data.get("provider")
-    key_name = data.get("key_name")
-    api_key = data.get("api_key")
-    base_url = data.get("base_url")
-    tenant_id = int(data.get("tenant_id", 1))
-    cli_tools = data.get("cli_tools")  # JSON array: ["claude-code", "qwen-code"]
-    cli_settings = data.get(
-        "cli_settings"
-    )  # JSON object: {"claude-code": {...}, "qwen-code": {...}}
-    scope = data.get("scope", "remote")
-    priority = data.get("priority", 0)
-    weight = data.get("weight", 100)
-
-    if not provider or not key_name or not api_key:
-        return jsonify({"error": "provider, key_name, and api_key are required"}), 400
-
-    if scope not in ("local", "remote", "shared"):
-        return jsonify({"error": "scope must be 'local', 'remote', or 'shared'"}), 400
-
-    validation_error = validate_cli_settings_payload(cli_settings)
-    if validation_error:
-        return jsonify({"error": validation_error}), 400
-
-    api_proxy = get_api_key_proxy_service()
-    result = api_proxy.store_api_key(
-        tenant_id=tenant_id,
-        provider=provider,
-        key_name=key_name,
-        api_key=api_key,
-        base_url=base_url,
-        created_by=g.user["id"],
-        cli_tools=cli_tools,
-        cli_settings=cli_settings,
-        scope=scope,
-        priority=int(priority),
-        weight=int(weight),
-    )
-
-    if result.get("success"):
-        return jsonify({"success": True, "key": result})
-    return jsonify({"error": result.get("error", "Failed to store API key")}), 400
-
-
-@remote_bp.route("/api-keys/<int:key_id>", methods=["PUT"])
-@admin_required
-def update_api_key(key_id):
-    """Update an API key by ID. Admin only."""
-
-    data = request.get_json() or {}
-    key_name = data.get("key_name")
-    base_url = data.get("base_url")
-    cli_tools = data.get("cli_tools")
-    cli_settings = data.get("cli_settings")
-    is_active = data.get("is_active")
-    if is_active is not None and not isinstance(is_active, bool):
-        return jsonify({"error": "is_active must be a boolean"}), 400
-    scope = data.get("scope")
-    if scope is not None and scope not in ("local", "remote", "shared"):
-        return jsonify({"error": "scope must be 'local', 'remote', or 'shared'"}), 400
-    priority = data.get("priority")
-    weight = data.get("weight")
-    tenant_id = int(data.get("tenant_id", 1))
-
-    validation_error = validate_cli_settings_payload(cli_settings)
-    if validation_error:
-        return jsonify({"error": validation_error}), 400
-
-    api_proxy = get_api_key_proxy_service()
-    success = api_proxy.update_api_key_by_id(
-        key_id=key_id,
-        tenant_id=tenant_id,
-        key_name=key_name,
-        base_url=base_url,
-        cli_tools=cli_tools,
-        cli_settings=cli_settings,
-        is_active=is_active,
-        scope=scope,
-        priority=int(priority) if priority is not None else None,
-        weight=int(weight) if weight is not None else None,
-    )
-
-    if success:
-        return jsonify({"success": True, "message": "API key updated"})
-    return jsonify({"error": "API key not found or update failed"}), 404
-
-
-@remote_bp.route("/api-keys/<int:key_id>", methods=["DELETE"])
-@admin_required
-def delete_api_key(key_id):
-    """Delete an API key by ID. Admin only."""
-
-    data = request.get_json() or {}
-    tenant_id = int(data.get("tenant_id", 1))
-
-    api_proxy = get_api_key_proxy_service()
-    success = api_proxy.delete_api_key_by_id(key_id, tenant_id)
-
-    if success:
-        return jsonify({"success": True, "message": "API key deleted"})
-    return jsonify({"error": "API key not found"}), 404
 
 
 # ==================== Machine User Assignments ====================

--- a/frontend/src/api/remote.ts
+++ b/frontend/src/api/remote.ts
@@ -152,22 +152,22 @@ export const remoteApi = {
   listApiKeys(tenantId?: number): Promise<{ success: boolean; keys: ApiKey[] }> {
     const params: Record<string, string> = {};
     if (tenantId) params.tenant_id = String(tenantId);
-    return apiClient.get('/api/remote/api-keys', params);
+    return apiClient.get('/api/api-keys', params);
   },
 
   storeApiKey(
     data: StoreApiKeyRequest
   ): Promise<{ success: boolean; key: { provider: string; key_name: string } }> {
-    return apiClient.post('/api/remote/api-keys', data);
+    return apiClient.post('/api/api-keys', data);
   },
 
   deleteApiKey(keyId: number, tenantId?: number): Promise<{ success: boolean; message: string }> {
-    return apiClient.delete(`/api/remote/api-keys/${keyId}`, { tenant_id: tenantId ?? 1 });
+    return apiClient.delete(`/api/api-keys/${keyId}`, { tenant_id: tenantId ?? 1 });
   },
 
   updateApiKey(data: UpdateApiKeyRequest): Promise<{ success: boolean; message: string }> {
     const { keyId, ...body } = data;
-    return apiClient.put(`/api/remote/api-keys/${keyId}`, body);
+    return apiClient.put(`/api/api-keys/${keyId}`, body);
   },
 
   // Available machines (for session creation)

--- a/frontend/src/hooks/useRemote.ts
+++ b/frontend/src/hooks/useRemote.ts
@@ -89,7 +89,7 @@ export function useRevokeUser() {
 
 export function useApiKeys(tenantId?: number) {
   return useQuery({
-    queryKey: ['remote', 'api-keys', tenantId],
+    queryKey: ['api-keys', tenantId],
     queryFn: () => remoteApi.listApiKeys(tenantId),
   });
 }
@@ -100,7 +100,7 @@ export function useStoreApiKey() {
   return useMutation({
     mutationFn: (data: StoreApiKeyRequest) => remoteApi.storeApiKey(data),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['remote', 'api-keys'] });
+      queryClient.invalidateQueries({ queryKey: ['api-keys'] });
     },
   });
 }
@@ -112,7 +112,7 @@ export function useDeleteApiKey() {
     mutationFn: ({ keyId, tenantId }: { keyId: number; tenantId?: number }) =>
       remoteApi.deleteApiKey(keyId, tenantId),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['remote', 'api-keys'] });
+      queryClient.invalidateQueries({ queryKey: ['api-keys'] });
     },
   });
 }
@@ -123,7 +123,7 @@ export function useUpdateApiKey() {
   return useMutation({
     mutationFn: (data: UpdateApiKeyRequest) => remoteApi.updateApiKey(data),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['remote', 'api-keys'] });
+      queryClient.invalidateQueries({ queryKey: ['api-keys'] });
     },
   });
 }

--- a/migrations/versions/20260528_047_add_api_key_scope_fields.py
+++ b/migrations/versions/20260528_047_add_api_key_scope_fields.py
@@ -5,7 +5,7 @@ Revises: 046_login_attempts
 Create Date: 2026-05-28
 
 Adds columns for unified API key management:
-- scope: 'local', 'remote', or 'shared' (default 'remote')
+- scope: 'local', 'remote', or 'shared' (default 'shared')
 - priority: higher = preferred (default 0)
 - weight: for weighted random within same priority (default 100)
 
@@ -37,9 +37,6 @@ def upgrade() -> None:
         "api_key_store",
         sa.Column("weight", sa.INTEGER, nullable=True, server_default="100"),
     )
-    # Fix existing keys that were created before the scope field existed;
-    # they were used by local sessions, so 'shared' is the correct default.
-    op.execute("UPDATE api_key_store SET scope = 'shared' WHERE scope IS NULL OR scope = 'remote'")
 
 
 def downgrade() -> None:

--- a/migrations/versions/20260528_047_add_api_key_scope_fields.py
+++ b/migrations/versions/20260528_047_add_api_key_scope_fields.py
@@ -27,7 +27,7 @@ def upgrade() -> None:
     """Add scope, priority, weight columns to api_key_store."""
     op.add_column(
         "api_key_store",
-        sa.Column("scope", sa.TEXT, nullable=True, server_default="remote"),
+        sa.Column("scope", sa.TEXT, nullable=True, server_default="shared"),
     )
     op.add_column(
         "api_key_store",
@@ -37,6 +37,9 @@ def upgrade() -> None:
         "api_key_store",
         sa.Column("weight", sa.INTEGER, nullable=True, server_default="100"),
     )
+    # Fix existing keys that were created before the scope field existed;
+    # they were used by local sessions, so 'shared' is the correct default.
+    op.execute("UPDATE api_key_store SET scope = 'shared' WHERE scope IS NULL OR scope = 'remote'")
 
 
 def downgrade() -> None:

--- a/migrations/versions/20260529_048_fix_api_key_scope_default.py
+++ b/migrations/versions/20260529_048_fix_api_key_scope_default.py
@@ -1,0 +1,44 @@
+"""Fix api_key_store scope default and existing data
+
+Revision ID: 048_fix_api_key_scope
+Revises: 047_api_key_scope
+Create Date: 2026-05-29
+
+Migration 047 set scope server_default to 'remote' which was incorrect —
+keys created before the scope field were used by local sessions, so 'shared'
+is the correct default. This migration fixes:
+1. Existing rows with scope='remote' or NULL → 'shared'
+2. Column server_default → 'shared' (PostgreSQL)
+"""
+
+from typing import Union
+
+from alembic import op
+
+revision: str = "048_fix_api_key_scope"
+down_revision: Union[str, None] = "047_api_key_scope"
+branch_labels: Union[str, None] = None
+depends_on: Union[str, None] = None
+
+
+def upgrade() -> None:
+    """Fix scope default and existing data."""
+    # Fix existing keys that got the wrong default from migration 047
+    op.execute(
+        "UPDATE api_key_store SET scope = 'shared' " "WHERE scope IS NULL OR scope = 'remote'"
+    )
+    # Fix column default (PostgreSQL uses ALTER COLUMN for server_default)
+    # SQLite doesn't support ALTER COLUMN, but schema.sql has the correct default
+    # for new installations, so this is a no-op for SQLite.
+    try:
+        op.alter_column("api_key_store", "scope", server_default="shared")
+    except Exception:
+        pass  # SQLite — handled by schema.sql
+
+
+def downgrade() -> None:
+    """Revert scope default to 'remote'."""
+    try:
+        op.alter_column("api_key_store", "scope", server_default="remote")
+    except Exception:
+        pass

--- a/schema/schema-postgres.sql
+++ b/schema/schema-postgres.sql
@@ -136,7 +136,10 @@ CREATE TABLE api_key_store (
     created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
     updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
     cli_tools text,
-    cli_settings text
+    cli_settings text,
+    scope text DEFAULT 'shared',
+    priority integer DEFAULT 0,
+    weight integer DEFAULT 100
 );
 
 CREATE SEQUENCE api_key_store_id_seq

--- a/schema/schema-sqlite.sql
+++ b/schema/schema-sqlite.sql
@@ -88,7 +88,10 @@ CREATE TABLE api_key_store (
  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
  cli_tools text,
- cli_settings text
+ cli_settings text,
+ scope text DEFAULT 'shared',
+ priority integer DEFAULT 0,
+ weight integer DEFAULT 100
 );
 
 CREATE TABLE audit_logs (

--- a/tests/e2e/manage/e2e_api_key_cli_settings.py
+++ b/tests/e2e/manage/e2e_api_key_cli_settings.py
@@ -4,7 +4,7 @@ Open ACE - API Key CLI Settings Configuration Playwright E2E Test
 
 Test the API Key management with CLI Settings configuration:
 1. Login as admin
-2. Navigate to API Key management page (/manage/remote/api-keys)
+2. Navigate to API Key management page (/manage/settings/api-keys)
 3. Add a new API key with CLI settings (claude-code, qwen-code)
 4. Verify the key appears in table with CLI tools badges
 5. Edit the API key to update CLI settings
@@ -78,7 +78,7 @@ def api_login():
 
 def api_list_keys(token):
     r = requests.get(
-        f"{BASE_URL}/api/remote/api-keys",
+        f"{BASE_URL}/api/api-keys",
         cookies={"session_token": token},
     )
     assert r.status_code == 200
@@ -87,7 +87,7 @@ def api_list_keys(token):
 
 def api_delete_key(token, key_id):
     r = requests.delete(
-        f"{BASE_URL}/api/remote/api-keys/{key_id}",
+        f"{BASE_URL}/api/api-keys/{key_id}",
         json={"tenant_id": 1},
         cookies={"session_token": token},
     )
@@ -143,7 +143,7 @@ def test_api_key_cli_settings():
 
             # ── Step 2: Navigate to API Key management ───────────
             log_step("Step 2", "Navigate to API Key management")
-            page.goto(f"{BASE_URL}/manage/remote/api-keys")
+            page.goto(f"{BASE_URL}/manage/settings/api-keys")
             pause(2)
             shot(page, "02_api_keys_page")
             log_step("Nav", "✓ API Key management page loaded")

--- a/tests/e2e/manage/test_manage_comprehensive.py
+++ b/tests/e2e/manage/test_manage_comprehensive.py
@@ -366,7 +366,7 @@ def run_all_tests():
             ("Tenant Management", "/manage/tenants", [".card", "table"]),
             ("Project Management", "/manage/projects", [".card", "table"]),
             ("Remote Machines", "/manage/remote/machines", [".card", "table"]),
-            ("API Keys", "/manage/remote/api-keys", [".card", "table"]),
+            ("API Keys", "/manage/settings/api-keys", [".card", "table"]),
             ("SSO Settings", "/manage/settings/sso", [".card", "form", ".sso"]),
         ]
 

--- a/tests/e2e/remote/e2e_remote_workspace_full.py
+++ b/tests/e2e/remote/e2e_remote_workspace_full.py
@@ -209,7 +209,7 @@ def api_get_machine_users(admin_token, machine_id):
 
 def api_store_key(admin_token, provider, key_name, api_key="sk-test-e2e-xxx"):
     r = requests.post(
-        f"{BASE_URL}/api/remote/api-keys",
+        f"{BASE_URL}/api/api-keys",
         json={"provider": provider, "key_name": key_name, "api_key": api_key, "tenant_id": 1},
         cookies={"session_token": admin_token},
     )
@@ -217,15 +217,13 @@ def api_store_key(admin_token, provider, key_name, api_key="sk-test-e2e-xxx"):
 
 
 def api_list_keys(admin_token):
-    r = requests.get(
-        f"{BASE_URL}/api/remote/api-keys?tenant_id=1", cookies={"session_token": admin_token}
-    )
+    r = requests.get(f"{BASE_URL}/api/api-keys?tenant_id=1", cookies={"session_token": admin_token})
     return r.json().get("keys", [])
 
 
 def api_delete_key(admin_token, key_id):
     r = requests.delete(
-        f"{BASE_URL}/api/remote/api-keys/{key_id}",
+        f"{BASE_URL}/api/api-keys/{key_id}",
         json={"tenant_id": 1},
         cookies={"session_token": admin_token},
     )
@@ -353,7 +351,7 @@ def run_tests():
         # 也检查 HTML 中是否包含远程菜单项的路径
         sidebar_html = sidebar.first.inner_html() if sidebar.count() > 0 else ""
         has_remote_path = (
-            "/manage/remote/machines" in sidebar_html or "/manage/remote/api-keys" in sidebar_html
+            "/manage/remote/machines" in sidebar_html or "/manage/settings/api-keys" in sidebar_html
         )
         shot(page, "A2_sidebar")
         assert has_remote or has_remote_path, f"侧边栏无远程工作区: {sidebar_text[:200]}"
@@ -566,7 +564,7 @@ def run_tests():
 
         # A11: API Key 管理页面 — 初始状态
         print("\n── A11: API Key 管理页面（空状态）──")
-        page.goto(f"{BASE_URL}/manage/remote/api-keys", wait_until="domcontentloaded")
+        page.goto(f"{BASE_URL}/manage/settings/api-keys", wait_until="domcontentloaded")
         page.wait_for_selector("main, .api-key-management", timeout=10000)
         pause(1)
         shot(page, "A11_apikeys_page_empty")

--- a/tests/e2e/remote/e2e_remote_workspace_ui.py
+++ b/tests/e2e/remote/e2e_remote_workspace_ui.py
@@ -443,7 +443,7 @@ def _run_all_steps(page):
 
     # ── A8. Navigate to API Keys ──
     print("\n══════ A8. Navigate to API Keys ══════")
-    page.goto(f"{BASE_URL}/manage/remote/api-keys", wait_until="domcontentloaded")
+    page.goto(f"{BASE_URL}/manage/settings/api-keys", wait_until="domcontentloaded")
     page.wait_for_selector("h2, .api-key-management, table, .empty-state", timeout=10000)
     pause(2)
     shot(page, "A8_api_keys_page")
@@ -867,7 +867,7 @@ def _run_all_steps(page):
     pause(1)
     do_login(page, ADMIN_USER, ADMIN_PASS)
 
-    page.goto(f"{BASE_URL}/manage/remote/api-keys", wait_until="domcontentloaded")
+    page.goto(f"{BASE_URL}/manage/settings/api-keys", wait_until="domcontentloaded")
     page.wait_for_selector("table, .empty-state", timeout=10000)
     pause(2)
     shot(page, "D1_api_keys_list")

--- a/tests/e2e/remote/e2e_test_remote_workspace.py
+++ b/tests/e2e/remote/e2e_test_remote_workspace.py
@@ -331,7 +331,7 @@ def store_api_key(auth_token):
     try:
         # Store a test key via REST endpoint
         r = requests.post(
-            f"{BASE_URL}/api/remote/api-keys",
+            f"{BASE_URL}/api/api-keys",
             json={
                 "provider": "openai",
                 "key_name": "e2e-test-key",
@@ -347,7 +347,7 @@ def store_api_key(auth_token):
 
         # List keys via REST endpoint
         r2 = requests.get(
-            f"{BASE_URL}/api/remote/api-keys?tenant_id=1",
+            f"{BASE_URL}/api/api-keys?tenant_id=1",
             cookies={"session_token": auth_token},
             timeout=10,
         )
@@ -376,7 +376,7 @@ def store_api_key(auth_token):
         # Cleanup via REST endpoint
         key_id = keys[0]["id"]
         r3 = requests.delete(
-            f"{BASE_URL}/api/remote/api-keys/{key_id}",
+            f"{BASE_URL}/api/api-keys/{key_id}",
             json={"tenant_id": 1},
             cookies={"session_token": auth_token},
             timeout=10,

--- a/tests/issues/435/e2e_api_key_toggle.py
+++ b/tests/issues/435/e2e_api_key_toggle.py
@@ -4,7 +4,7 @@ Open Ace - API Key Activate/Deactivate Toggle Playwright E2E Test
 
 Test the API Key activation toggle feature:
 1. Login as admin
-2. Navigate to API Key management page (/manage/remote/api-keys)
+2. Navigate to API Key management page (/manage/settings/api-keys)
 3. Create a test API key via API
 4. Verify toggle switch is present and active
 5. Deactivate the key via toggle switch
@@ -79,7 +79,7 @@ def api_login():
 
 def api_list_keys(token):
     r = requests.get(
-        f"{BASE_URL}/api/remote/api-keys",
+        f"{BASE_URL}/api/api-keys",
         cookies={"session_token": token},
     )
     assert r.status_code == 200
@@ -88,7 +88,7 @@ def api_list_keys(token):
 
 def api_store_key(token, key_name, provider="anthropic"):
     r = requests.post(
-        f"{BASE_URL}/api/remote/api-keys",
+        f"{BASE_URL}/api/api-keys",
         json={
             "provider": provider,
             "key_name": key_name,
@@ -106,7 +106,7 @@ def api_update_key(token, key_id, **fields):
     body = {"keyId": key_id, "tenant_id": 1}
     body.update(fields)
     r = requests.put(
-        f"{BASE_URL}/api/remote/api-keys/{key_id}",
+        f"{BASE_URL}/api/api-keys/{key_id}",
         json=body,
         cookies={"session_token": token},
     )
@@ -116,7 +116,7 @@ def api_update_key(token, key_id, **fields):
 
 def api_delete_key(token, key_id):
     r = requests.delete(
-        f"{BASE_URL}/api/remote/api-keys/{key_id}",
+        f"{BASE_URL}/api/api-keys/{key_id}",
         json={"tenant_id": 1},
         cookies={"session_token": token},
     )
@@ -174,7 +174,7 @@ def test_api_key_toggle():
 
             # ── Step 2: Navigate to API Key page ───────────
             log_step("Step 2", "Navigate to API Key management")
-            page.goto(f"{BASE_URL}/manage/remote/api-keys")
+            page.goto(f"{BASE_URL}/manage/settings/api-keys")
             pause(2)
             shot(page, "02_api_keys_page")
 

--- a/tests/issues/517/e2e_codex_integration.py
+++ b/tests/issues/517/e2e_codex_integration.py
@@ -530,7 +530,7 @@ def test_frontend_api_key_codex_option():
         browser, page = create_browser_page(p)
         try:
             playwright_login(page, WEBUI_URL, username="admin")
-            page.goto(f"{WEBUI_URL}/manage/api-keys")
+            page.goto(f"{WEBUI_URL}/manage/settings/api-keys")
             page.wait_for_load_state("networkidle")
             poll_until(
                 lambda: len(page.inner_text("body")) > 50,


### PR DESCRIPTION
## Summary

- Migration 047 中 `scope` 默认值从 `'remote'` 改为 `'shared'`，并在 `upgrade()` 中修复已有 key 的 scope
- Schema 文件补充缺失的 `scope`/`priority`/`weight` 列（默认值 `shared`）
- API key 路由从 `remote_bp` 提取到独立 `api_keys_bp`，路径从 `/api/remote/api-keys` 改为 `/api/api-keys`
- 后端 `store_api_key` fallback 默认值从 `'remote'` 改为 `'shared'`
- 前端 API 路径和 React Query key 同步更新
- 测试文件中的 API 路径和前端页面路径同步修复

### Background

Migration 047 设置 `scope` 默认值为 `'remote'`，导致之前用于本地 session 的 key 全部变成 remote scope。本地 session 的 `_inject_local_api_keys()` 只查 `scope='local' OR scope='shared'`，因此这些 key 突然对本地 session 不可用。由于 qwen-code CLI 自身的 `~/.qwen/settings.json` 中有 key 兜底，用户未感知到此问题。

## Test plan

- [ ] 运行 `flask db upgrade`，确认 migration 执行成功
- [ ] 查询 `SELECT id, key_name, scope FROM api_key_store` 确认所有 key scope 为 `shared`
- [ ] 管理页面创建新 API Key，确认默认 scope 为 "Shared (Local + Remote)"
- [ ] 前端 `npm run build` 无报错

🤖 Generated with [Claude Code](https://claude.com/claude-code)