### PR TITLE
fix: 新建会话时机器选择键盘导航功能 (Issue #101)

### DIFF
--- a/frontend/src/components/features/Workspace.tsx
+++ b/frontend/src/components/features/Workspace.tsx
@@ -106,6 +106,16 @@ export const Workspace: React.FC = () => {
   // Refs for iframe elements (to send focus messages)
   const iframeRefs = useRef<Map<string, HTMLIFrameElement>>(new Map());
 
+  // Workspace tabs state from store (Issue #65) - moved before pollTerminalProxy to fix TS2448
+  const storedTabs = useWorkspaceTabs();
+  const storedActiveTabId = useWorkspaceActiveTabId();
+
+  // Use stable action selectors (fixes infinite loop)
+  const setStoredActiveTabId = useSetWorkspaceActiveTabId();
+  const addStoredTab = useAddWorkspaceTab();
+  const updateStoredTab = useUpdateWorkspaceTab();
+  const removeStoredTab = useRemoveWorkspaceTab();
+
   // Shared terminal proxy polling helper
   const pollTerminalProxy = useCallback(
     async (tabId: string, terminalId: string, machineId: string, maxAttempts: number = 30) => {
@@ -166,16 +176,6 @@ export const Workspace: React.FC = () => {
   // Fullscreen state from global store
   const workspaceFullscreen = useWorkspaceFullscreen();
   const { toggleWorkspaceFullscreen, exitWorkspaceFullscreen } = useAppStore();
-
-  // Workspace tabs state from store (Issue #65)
-  const storedTabs = useWorkspaceTabs();
-  const storedActiveTabId = useWorkspaceActiveTabId();
-
-  // Use stable action selectors (fixes infinite loop)
-  const setStoredActiveTabId = useSetWorkspaceActiveTabId();
-  const addStoredTab = useAddWorkspaceTab();
-  const updateStoredTab = useUpdateWorkspaceTab();
-  const removeStoredTab = useRemoveWorkspaceTab();
 
   // Load workspace config and user webui URL
   useEffect(() => {

--- a/frontend/src/components/work/RemoteMachineSelector.tsx
+++ b/frontend/src/components/work/RemoteMachineSelector.tsx
@@ -191,6 +191,16 @@ export const RemoteMachineSelector: React.FC<RemoteMachineSelectorProps> = ({
     setFocusedIndex(-1);
   }, [searchFilter]);
 
+  // Auto-focus list container when machines are loaded (Issue #101)
+  useEffect(() => {
+    if (!loading && filteredMachines.length > 0 && listContainerRef.current) {
+      // Use requestAnimationFrame to ensure DOM is ready
+      requestAnimationFrame(() => {
+        listContainerRef.current?.focus();
+      });
+    }
+  }, [loading, filteredMachines.length]);
+
   // Get status badge variant
   const getStatusBadge = (machine: RemoteMachine) => {
     if (machine.connected) {
@@ -302,7 +312,7 @@ export const RemoteMachineSelector: React.FC<RemoteMachineSelectorProps> = ({
               key={machine.machine_id}
               className={`list-group-item list-group-item-action ${
                 selectedMachineId === machine.machine_id ? 'active' : ''
-              } ${focusedIndex === index ? 'focus' : ''}`}
+              } ${focusedIndex === index && selectedMachineId !== machine.machine_id ? 'border-primary bg-light' : ''}`}
               onClick={() => handleSelect(machine)}
               onMouseEnter={() => setFocusedIndex(index)}
               role="option"

--- a/frontend/src/components/work/RemoteMachineSelector.tsx
+++ b/frontend/src/components/work/RemoteMachineSelector.tsx
@@ -6,11 +6,12 @@
  * - Machine status indicator
  * - Quick filter/search
  * - Save selected machine preference
+ * - Keyboard navigation (ArrowUp/ArrowDown/Enter) - Issue #101
  *
  * Issue #317: Remote workspace lacks project creation functionality
  */
 
-import React, { useState, useEffect, useMemo, useRef } from 'react';
+import React, { useState, useEffect, useMemo, useRef, useCallback } from 'react';
 import { useLanguage } from '@/store';
 import { t } from '@/i18n';
 import { remoteApi, type RemoteMachine } from '@/api/remote';
@@ -38,10 +39,14 @@ export const RemoteMachineSelector: React.FC<RemoteMachineSelectorProps> = ({
   const [error, setError] = useState<string | null>(null);
   const [searchFilter, setSearchFilter] = useState('');
   const [sortBy, setSortBy] = useState<'name' | 'status' | 'lastHeartbeat'>('name');
+  const [focusedIndex, setFocusedIndex] = useState<number>(-1); // Keyboard navigation state
 
   // Use ref to avoid onSelectMachine dependency causing re-renders
   const onSelectMachineRef = useRef(onSelectMachine);
   onSelectMachineRef.current = onSelectMachine;
+
+  // Ref for the list container to handle keyboard events
+  const listContainerRef = useRef<HTMLDivElement>(null);
 
   // Track if we've already auto-selected (to prevent re-selection on re-render)
   const hasAutoSelectedRef = useRef(false);
@@ -122,10 +127,69 @@ export const RemoteMachineSelector: React.FC<RemoteMachineSelectorProps> = ({
   }, [machines, searchFilter, sortBy]);
 
   // Handle machine selection
-  const handleSelect = (machine: RemoteMachine) => {
-    localStorage.setItem(LAST_MACHINE_KEY, machine.machine_id);
-    onSelectMachine(machine.machine_id, machine);
-  };
+  const handleSelect = useCallback(
+    (machine: RemoteMachine) => {
+      localStorage.setItem(LAST_MACHINE_KEY, machine.machine_id);
+      onSelectMachine(machine.machine_id, machine);
+      setFocusedIndex(-1); // Reset focus after selection
+    },
+    [onSelectMachine]
+  );
+
+  // Scroll to the focused item in the list
+  const scrollToItem = useCallback((index: number) => {
+    if (listContainerRef.current) {
+      const items = listContainerRef.current.querySelectorAll('.list-group-item');
+      if (items[index]) {
+        items[index].scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+      }
+    }
+  }, []);
+
+  // Keyboard navigation handlers (Issue #101)
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (filteredMachines.length === 0) return;
+
+      switch (e.key) {
+        case 'ArrowDown':
+          e.preventDefault();
+          setFocusedIndex((prev) => {
+            const next = prev < filteredMachines.length - 1 ? prev + 1 : 0;
+            scrollToItem(next);
+            return next;
+          });
+          break;
+        case 'ArrowUp':
+          e.preventDefault();
+          setFocusedIndex((prev) => {
+            const next = prev > 0 ? prev - 1 : filteredMachines.length - 1;
+            scrollToItem(next);
+            return next;
+          });
+          break;
+        case 'Enter':
+          e.preventDefault();
+          if (focusedIndex >= 0 && focusedIndex < filteredMachines.length) {
+            handleSelect(filteredMachines[focusedIndex]);
+          } else if (filteredMachines.length > 0) {
+            // If no item is focused, select the first one
+            handleSelect(filteredMachines[0]);
+          }
+          break;
+        case 'Escape':
+          // Clear focus
+          setFocusedIndex(-1);
+          break;
+      }
+    },
+    [filteredMachines, focusedIndex, handleSelect, scrollToItem]
+  );
+
+  // Reset focus when search filter changes
+  useEffect(() => {
+    setFocusedIndex(-1);
+  }, [searchFilter]);
 
   // Get status badge variant
   const getStatusBadge = (machine: RemoteMachine) => {
@@ -224,14 +288,25 @@ export const RemoteMachineSelector: React.FC<RemoteMachineSelectorProps> = ({
           />
         )
       ) : (
-        <div className="list-group" style={{ maxHeight: '300px', overflow: 'auto' }}>
-          {filteredMachines.map((machine) => (
+        <div
+          ref={listContainerRef}
+          className="list-group"
+          style={{ maxHeight: '300px', overflow: 'auto' }}
+          onKeyDown={handleKeyDown}
+          tabIndex={0}
+          role="listbox"
+          aria-label={t('selectMachine', language) || 'Select machine'}
+        >
+          {filteredMachines.map((machine, index) => (
             <button
               key={machine.machine_id}
               className={`list-group-item list-group-item-action ${
                 selectedMachineId === machine.machine_id ? 'active' : ''
-              }`}
+              } ${focusedIndex === index ? 'focus' : ''}`}
               onClick={() => handleSelect(machine)}
+              onMouseEnter={() => setFocusedIndex(index)}
+              role="option"
+              aria-selected={selectedMachineId === machine.machine_id}
             >
               <div className="d-flex justify-content-between align-items-start">
                 <div>

--- a/frontend/src/components/work/RemoteMachineSelector.tsx
+++ b/frontend/src/components/work/RemoteMachineSelector.tsx
@@ -191,11 +191,14 @@ export const RemoteMachineSelector: React.FC<RemoteMachineSelectorProps> = ({
     setFocusedIndex(-1);
   }, [searchFilter]);
 
+  // Compute loading state early (fixes TS2448 - variable used before declaration)
+  const loading = externalLoading ?? isLoading;
+
   // Auto-focus list container when machines are loaded (Issue #101)
   useEffect(() => {
     if (!loading && filteredMachines.length > 0 && listContainerRef.current) {
-      // Use requestAnimationFrame to ensure DOM is ready
-      requestAnimationFrame(() => {
+      // Use window.requestAnimationFrame to ensure DOM is ready (fixes no-undef)
+      window.requestAnimationFrame(() => {
         listContainerRef.current?.focus();
       });
     }
@@ -239,8 +242,6 @@ export const RemoteMachineSelector: React.FC<RemoteMachineSelectorProps> = ({
       return `${Math.floor(diffMins / 60)} ${t('hoursAgo', language) || 'h ago'}`;
     return date.toLocaleDateString();
   };
-
-  const loading = externalLoading ?? isLoading;
 
   return (
     <div className="remote-machine-selector">


### PR DESCRIPTION
## 问题描述

新建会话时需要选择远程机器，但无法通过键盘上下键在机器列表中导航选择。

Issue: #101

## 修复内容

为 `RemoteMachineSelector` 组件添加键盘导航支持：

- **ArrowDown**: 向下移动焦点，循环到第一项
- **ArrowUp**: 向上移动焦点，循环到最后一项
- **Enter**: 选择当前聚焦的机器
- **Escape**: 清除焦点状态
- **鼠标悬停**: 同步更新键盘焦点状态

同时添加了 ARIA 属性增强可访问性：
- `role="listbox"` 和 `role="option"`
- `aria-label` 和 `aria-selected`

## 测试验证

- TypeScript 类型检查通过
- 键盘导航功能可正常使用

Fixes #101