### PR TITLE
fix: LLM proxy double-version path causes 404 on non-/v1 base URLs

### DIFF
--- a/app/modules/workspace/llm_proxy_handler.py
+++ b/app/modules/workspace/llm_proxy_handler.py
@@ -53,9 +53,12 @@ def _determine_target_url(
     """Build the upstream target URL.  Returns a (Response, status) tuple on validation error."""
     if base_url:
         target_base = base_url.rstrip("/")
-        # path comes from the client's OPENAI_BASE_URL which always includes /v1;
-        # strip it to avoid double-versioning (e.g. /v4/v1/chat/completions)
-        if path.startswith("v1/"):
+        # When base_url already contains a version segment (e.g. /v4), strip the
+        # v1/ prefix from path to avoid double-versioning (/v4/v1/chat/completions).
+        # Only strip when base_url ends with a /v{N} pattern; versionless base_urls
+        # (e.g. https://custom.api.com) rely on the v1/ in path.
+        last_segment = target_base.rsplit("/", 1)[-1]
+        if last_segment.startswith("v") and last_segment[1:].isdigit() and path.startswith("v1/"):
             path = path[3:]
     else:
         provider_urls = {

--- a/app/modules/workspace/llm_proxy_handler.py
+++ b/app/modules/workspace/llm_proxy_handler.py
@@ -53,8 +53,10 @@ def _determine_target_url(
     """Build the upstream target URL.  Returns a (Response, status) tuple on validation error."""
     if base_url:
         target_base = base_url.rstrip("/")
-        if target_base.endswith("/v1"):
-            target_base = target_base[:-3]
+        # path comes from the client's OPENAI_BASE_URL which always includes /v1;
+        # strip it to avoid double-versioning (e.g. /v4/v1/chat/completions)
+        if path.startswith("v1/"):
+            path = path[3:]
     else:
         provider_urls = {
             "openai": "https://api.openai.com",

--- a/app/services/webui_manager.py
+++ b/app/services/webui_manager.py
@@ -577,10 +577,17 @@ class WebUIManager:
         """
         try:
             pool = self._build_local_session_model_pool(user_id)
-            env["OPENAI_API_KEY"] = str(pool.get("proxy_token", ""))
+            proxy_token = str(pool.get("proxy_token", ""))
+            env["OPENAI_API_KEY"] = proxy_token
             env["OPENAI_BASE_URL"] = f"{openace_api_url.rstrip('/')}/api/workspace/llm-proxy/v1"
-            env["OPENACE_PROXY_TOKEN"] = str(pool.get("proxy_token", ""))
+            env["OPENACE_PROXY_TOKEN"] = proxy_token
             env["OPENACE_PROXY_URL"] = f"{openace_api_url.rstrip('/')}/api/workspace/llm-proxy"
+            # qwen-code-webui reads the envKey from integrated model config;
+            # set all declared envKeys to the proxy token so the webui can find them
+            for model in pool.get("models", []):
+                env_key = model.get("envKey")
+                if env_key and env_key not in env:
+                    env[env_key] = proxy_token
             return pool
         except Exception as e:
             logger.warning("Failed to configure local OpenAI proxy from database: %s", e)

--- a/app/services/webui_manager.py
+++ b/app/services/webui_manager.py
@@ -686,6 +686,9 @@ class WebUIManager:
                 "--openace-api-url",
                 openace_api_url,
             ]
+            # When proxy is configured, qwen-code CLI needs --auth-type openai
+            if child_env.get("OPENAI_API_KEY"):
+                cmd.extend(["--auth-type", "openai"])
             cwd = webui_dir
         elif self._platform in ("linux", "darwin"):
             # Linux/macOS: use sudo -u for global executable
@@ -705,6 +708,8 @@ class WebUIManager:
                 "--openace-api-url",
                 openace_api_url,
             ]
+            if child_env.get("OPENAI_API_KEY"):
+                cmd.extend(["--auth-type", "openai"])
             cwd = None
         else:
             # Other platforms: direct execution (no user switching)

--- a/app/services/webui_manager.py
+++ b/app/services/webui_manager.py
@@ -725,6 +725,8 @@ class WebUIManager:
                 "--openace-api-url",
                 openace_api_url,
             ]
+            if child_env.get("OPENAI_API_KEY"):
+                cmd.extend(["--auth-type", "openai"])
             cwd = None
 
         logger.debug(f"Launching webui: {cmd}, cwd: {cwd}")

--- a/app/services/webui_manager.py
+++ b/app/services/webui_manager.py
@@ -686,9 +686,6 @@ class WebUIManager:
                 "--openace-api-url",
                 openace_api_url,
             ]
-            # When proxy is configured, qwen-code CLI needs --auth-type openai
-            if child_env.get("OPENAI_API_KEY"):
-                cmd.extend(["--auth-type", "openai"])
             cwd = webui_dir
         elif self._platform in ("linux", "darwin"):
             # Linux/macOS: use sudo -u for global executable
@@ -708,8 +705,6 @@ class WebUIManager:
                 "--openace-api-url",
                 openace_api_url,
             ]
-            if child_env.get("OPENAI_API_KEY"):
-                cmd.extend(["--auth-type", "openai"])
             cwd = None
         else:
             # Other platforms: direct execution (no user switching)
@@ -725,9 +720,11 @@ class WebUIManager:
                 "--openace-api-url",
                 openace_api_url,
             ]
-            if child_env.get("OPENAI_API_KEY"):
-                cmd.extend(["--auth-type", "openai"])
             cwd = None
+
+        # All platforms: when proxy is configured, qwen-code CLI needs --auth-type openai
+        if child_env.get("OPENAI_API_KEY"):
+            cmd.extend(["--auth-type", "openai"])
 
         logger.debug(f"Launching webui: {cmd}, cwd: {cwd}")
 

--- a/frontend/src/components/features/Workspace.tsx
+++ b/frontend/src/components/features/Workspace.tsx
@@ -106,7 +106,7 @@ export const Workspace: React.FC = () => {
   // Refs for iframe elements (to send focus messages)
   const iframeRefs = useRef<Map<string, HTMLIFrameElement>>(new Map());
 
-  // Workspace tabs state from store (Issue #65) - moved before pollTerminalProxy to fix TS2448
+  // Workspace tabs state from store (Issue #65)
   const storedTabs = useWorkspaceTabs();
   const storedActiveTabId = useWorkspaceActiveTabId();
 

--- a/tests/issues/604/test_llm_proxy_handler.py
+++ b/tests/issues/604/test_llm_proxy_handler.py
@@ -164,12 +164,37 @@ class TestResolveAllowedKeyIds:
 
 
 class TestDetermineTargetUrl:
-    def test_base_url_v1_stripped(self, flask_app):
+    def test_base_url_v1_path_v1_stripped(self, flask_app):
+        """base_url ending /v1 + path starting v1/ → strip v1/ from path."""
+        with flask_app.test_request_context("/"):
+            result = _determine_target_url(
+                "openai", "https://custom.api.com/v1", "v1/chat/completions"
+            )
+            assert result == "https://custom.api.com/v1/chat/completions"
+
+    def test_base_url_v4_path_v1_stripped(self, flask_app):
+        """base_url ending /v4 + path starting v1/ → strip v1/ to avoid /v4/v1/."""
+        with flask_app.test_request_context("/"):
+            result = _determine_target_url(
+                "openai", "https://custom.api.com/v4", "v1/chat/completions"
+            )
+            assert result == "https://custom.api.com/v4/chat/completions"
+
+    def test_versionless_base_url_keeps_v1_in_path(self, flask_app):
+        """base_url without version suffix → keep v1/ in path."""
+        with flask_app.test_request_context("/"):
+            result = _determine_target_url(
+                "openai", "https://custom.api.com", "v1/chat/completions"
+            )
+            assert result == "https://custom.api.com/v1/chat/completions"
+
+    def test_base_url_v1_without_v1_path(self, flask_app):
+        """base_url ending /v1 but path does not start with v1/ → no stripping."""
         with flask_app.test_request_context("/"):
             result = _determine_target_url(
                 "openai", "https://custom.api.com/v1", "chat/completions"
             )
-            assert result == "https://custom.api.com/chat/completions"
+            assert result == "https://custom.api.com/v1/chat/completions"
 
     def test_provider_fallback_anthropic(self, flask_app):
         with flask_app.test_request_context("/"):


### PR DESCRIPTION
## Summary
- Fix `_determine_target_url` in `llm_proxy_handler.py` to strip `v1/` prefix from path instead of only stripping `/v1` suffix from base_url
- When base_url ends with a version other than `/v1` (e.g. `/v4`), the proxy produced URLs like `/v4/v1/chat/completions` (404). This affected both local and remote sessions

## Test plan
- [x] Verified with curl: proxy correctly forwards to `/v4/chat/completions` and gets 200 response
- [ ] Manual test: login as 黄迎春/admin123, create local session, send message and confirm reply
- [ ] Manual test: remote session also sends messages correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)