### PR TITLE
fix: fetch ha_pool_token before creating remote session

### DIFF
--- a/frontend/src/api/remote.ts
+++ b/frontend/src/api/remote.ts
@@ -105,6 +105,14 @@ export interface CreateRemoteSessionRequest {
   cli_tool?: string;
   model?: string;
   title?: string;
+  ha_pool_token?: string;
+}
+
+export interface SessionModelsResponse {
+  success: boolean;
+  models: string[];
+  empty_reason?: string;
+  ha_pool_token?: string;
 }
 
 // ==================== API Methods ====================
@@ -176,6 +184,13 @@ export const remoteApi = {
   },
 
   // Session management
+  getSessionModels(params: {
+    workspace_type: 'local' | 'remote';
+    machine_id?: string;
+  }): Promise<SessionModelsResponse> {
+    return apiClient.get('/api/workspace/session-models', params);
+  },
+
   createSession(
     data: CreateRemoteSessionRequest
   ): Promise<{ success: boolean; session: RemoteSession }> {

--- a/frontend/src/components/work/NewSessionModal.tsx
+++ b/frontend/src/components/work/NewSessionModal.tsx
@@ -170,8 +170,8 @@ export const NewSessionModal: React.FC<NewSessionModalProps> = ({
           machine_id: selectedMachineId,
         });
         haPoolToken = modelsResp.ha_pool_token;
-      } catch {
-        // Non-fatal: proceed without token; backend will return a descriptive error if needed
+      } catch (err) {
+        console.warn('Failed to fetch ha_pool_token:', err);
       }
 
       const result = await createRemoteSession.mutateAsync({

--- a/frontend/src/components/work/NewSessionModal.tsx
+++ b/frontend/src/components/work/NewSessionModal.tsx
@@ -22,6 +22,7 @@ import { Modal, Button } from '@/components/common';
 import { RemoteMachineSelector } from './RemoteMachineSelector';
 import { DirectoryBrowserModal } from './DirectoryBrowserModal';
 import type { RemoteMachine } from '@/api/remote';
+import { remoteApi } from '@/api/remote';
 
 interface NewSessionModalProps {
   isOpen?: boolean;
@@ -161,9 +162,22 @@ export const NewSessionModal: React.FC<NewSessionModalProps> = ({
     if (!selectedMachineId || !projectPath) return;
 
     try {
+      // Fetch ha_pool_token required by the backend for qwen-code sessions
+      let haPoolToken: string | undefined;
+      try {
+        const modelsResp = await remoteApi.getSessionModels({
+          workspace_type: 'remote',
+          machine_id: selectedMachineId,
+        });
+        haPoolToken = modelsResp.ha_pool_token;
+      } catch {
+        // Non-fatal: proceed without token; backend will return a descriptive error if needed
+      }
+
       const result = await createRemoteSession.mutateAsync({
         machine_id: selectedMachineId,
         project_path: projectPath,
+        ha_pool_token: haPoolToken,
       });
 
       onClose();


### PR DESCRIPTION
## Summary
- Remote session creation for qwen-code was always failing because the frontend never sent `ha_pool_token`
- Added `getSessionModels` API call to fetch `ha_pool_token` before creating remote sessions
- Added `ha_pool_token` field to `CreateRemoteSessionRequest` type

## Root Cause
The backend requires `ha_pool_token` (which encodes available API keys, models, and CLI settings) to create qwen-code remote sessions (`remote_session_manager.py:104-107`). The frontend was not calling `GET /api/workspace/session-models` to obtain this token, so the backend returned `None` and the user saw a generic "Failed to create remote session" error.

## Test plan
- [ ] Open browser, create a new remote session on a connected machine
- [ ] Verify session is created successfully
- [ ] Verify model list loads correctly in the remote workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)