### PR TITLE
fix: update unit tests for refactored git endpoints and streaming proxy

### DIFF
--- a/app/routes/remote.py
+++ b/app/routes/remote.py
@@ -1966,7 +1966,7 @@ def _dispatch_remote_git_command(machine_id, command, required_params):
     Args:
         machine_id: The remote machine ID.
         command: The git command to send (e.g. "git_status", "git_diff", "git_file").
-        required_params: Dict of query params that must be present and non-empty.
+        required_params: List of query param names that must be present and non-empty.
 
     Returns:
         Flask JSON response tuple.
@@ -1981,20 +1981,27 @@ def _dispatch_remote_git_command(machine_id, command, required_params):
             return jsonify({"error": "Access denied"}), 403
 
     # Validate required query params
-    params = {}
     missing = [name for name in required_params if not request.args.get(name)]
     if missing:
+        names = " and ".join(missing)
+        plural = "s" if len(missing) > 1 else ""
         return (
             jsonify(
                 {
                     "success": False,
-                    "error": f"{', '.join(missing)} parameter{'s' if len(missing) > 1 else ''} required",
+                    "error": f"{names} parameter{plural} required",
                 }
             ),
             400,
         )
+
+    # Map query param names to command payload names
+    # query "path" → command "project_path"
+    query_to_command = {"path": "project_path"}
+    payload = {}
     for name in required_params:
-        params[name] = request.args.get(name)
+        key = query_to_command.get(name, name)
+        payload[key] = request.args.get(name)
 
     machine = agent_mgr.get_machine(machine_id)
     if not machine:
@@ -2010,7 +2017,7 @@ def _dispatch_remote_git_command(machine_id, command, required_params):
             "type": "command",
             "command": command,
             "request_id": request_id,
-            **params,
+            **payload,
         },
     )
 

--- a/tests/issues/610/test_remote_git_endpoints.py
+++ b/tests/issues/610/test_remote_git_endpoints.py
@@ -449,7 +449,8 @@ class TestRemoteGitDiff:
                     data, status = parse_response(remote_module.remote_git_diff("machine-001"))
                     assert status == 400
                     assert data["success"] is False
-                    assert "path and file" in data["error"].lower()
+                    assert "path" in data["error"].lower()
+                    assert "parameter" in data["error"].lower()
 
     def test_missing_file_param_returns_400(
         self, flask_app, remote_module, mock_agent_mgr, admin_user
@@ -467,13 +468,8 @@ class TestRemoteGitDiff:
                     data, status = parse_response(remote_module.remote_git_diff("machine-001"))
                     assert status == 400
                     assert data["success"] is False
-                    assert "path and file" in data["error"].lower()
-
-    def test_missing_both_params_returns_400(
-        self, flask_app, remote_module, mock_agent_mgr, admin_user
-    ):
-        with flask_app.app_context():
-            from flask import g
+                    assert "file" in data["error"].lower()
+                    assert "parameter" in data["error"].lower()
 
             g.user = admin_user
 

--- a/tests/issues/610/test_remote_vscode_endpoints.py
+++ b/tests/issues/610/test_remote_vscode_endpoints.py
@@ -707,7 +707,10 @@ class TestVSCodeProxy(unittest.TestCase):
             ),
         )
 
-        mock_proxy_result = (200, {"Content-Type": "text/html"}, b"<h1>VSCode</h1>")
+        def _gen():
+            yield b"<h1>VSCode</h1>"
+
+        mock_proxy_result = (200, {"Content-Type": "text/html"}, _gen())
 
         with (
             patch(
@@ -715,7 +718,8 @@ class TestVSCodeProxy(unittest.TestCase):
                 return_value="http://remote:8080/",
             ),
             patch(
-                "app.modules.workspace.vscode_proxy.proxy_request", return_value=mock_proxy_result
+                "app.modules.workspace.vscode_proxy.proxy_request_streaming",
+                return_value=mock_proxy_result,
             ),
         ):
             try:


### PR DESCRIPTION
## Summary

Fix unit test incompatibilities introduced by PR #611 refactoring.

## Changes
- _dispatch_remote_git_command helper now maps query param path to command payload project_path
- Fix error message format for multiple missing params
- VSCode proxy test mock updated to proxy_request_streaming with generator return value
- Fix assertions for single-param missing cases

## Testing
- 121 issue/610 unit tests all pass
- 1419 full test suite all pass