### PR TITLE
feat: 添加 JSON 实时验证状态指示器

### DIFF
--- a/frontend/src/components/features/management/APIKeyManagement.tsx
+++ b/frontend/src/components/features/management/APIKeyManagement.tsx
@@ -12,6 +12,7 @@ import React, { useMemo, useState } from 'react';
 import { useApiKeys, useStoreApiKey, useUpdateApiKey, useDeleteApiKey } from '@/hooks';
 import { useLanguage } from '@/store';
 import { t } from '@/i18n';
+import type { Language } from '@/types';
 import {
   Button,
   Modal,
@@ -24,6 +25,39 @@ import {
 } from '@/components/common';
 import type { BadgeVariant } from '@/components/common';
 import type { ApiKey } from '@/api';
+
+/**
+ * JSON Validation Status Indicator Component
+ * Shows real-time validation feedback below JSON textarea
+ */
+interface JsonValidationIndicatorProps {
+  jsonStr: string;
+  validation: { valid: boolean; error: string | null };
+  language: Language;
+}
+
+const JsonValidationIndicator: React.FC<JsonValidationIndicatorProps> = ({
+  jsonStr,
+  validation,
+  language,
+}) => {
+  if (!jsonStr.trim()) return null;
+
+  return (
+    <div
+      className={`mt-1 d-flex align-items-center ${validation.valid ? 'text-success' : 'text-danger'}`}
+    >
+      <i
+        className={`bi ${validation.valid ? 'bi-check-circle-fill' : 'bi-x-circle-fill'} me-1`}
+      />
+      <small>
+        {validation.valid
+          ? t('jsonValid', language)
+          : `${t('jsonInvalid', language)}: ${validation.error}`}
+      </small>
+    </div>
+  );
+};
 
 const providerOptions = [
   { value: 'openai', label: 'OpenAI' },
@@ -124,6 +158,17 @@ export const APIKeyManagement: React.FC = () => {
     weight: 100,
     showAdvanced: false,
   });
+
+  // Cached JSON validation results (avoid repeated parsing on each render)
+  const claudeValidation = useMemo(
+    () => getJsonValidationResult(formData.claude_settings),
+    [formData.claude_settings]
+  );
+
+  const qwenValidation = useMemo(
+    () => getJsonValidationResult(formData.qwen_settings),
+    [formData.qwen_settings]
+  );
 
   const stringifyCodexSettings = (value: unknown): string => {
     if (typeof value === 'string') return value;
@@ -748,34 +793,18 @@ export const APIKeyManagement: React.FC = () => {
             <label className="form-label">{t('claudeCodeSettings', language)}</label>
             <textarea
               className={`form-control ${
-                formData.claude_settings.trim() && !getJsonValidationResult(formData.claude_settings).valid
-                  ? 'is-invalid'
-                  : ''
+                formData.claude_settings.trim() && !claudeValidation.valid ? 'is-invalid' : ''
               }`}
               rows={8}
               value={formData.claude_settings}
               onChange={(e) => setFormData({ ...formData, claude_settings: e.target.value })}
               placeholder={defaultClaudeSettings}
             />
-            {/* JSON Validation Status Indicator */}
-            {formData.claude_settings.trim() && (
-              <div
-                className={`mt-1 d-flex align-items-center ${
-                  getJsonValidationResult(formData.claude_settings).valid ? 'text-success' : 'text-danger'
-                }`}
-              >
-                <i
-                  className={`bi ${
-                    getJsonValidationResult(formData.claude_settings).valid ? 'bi-check-circle-fill' : 'bi-x-circle-fill'
-                  } me-1`}
-                />
-                <small>
-                  {getJsonValidationResult(formData.claude_settings).valid
-                    ? t('jsonValid', language)
-                    : `${t('jsonInvalid', language)}: ${getJsonValidationResult(formData.claude_settings).error}`}
-                </small>
-              </div>
-            )}
+            <JsonValidationIndicator
+              jsonStr={formData.claude_settings}
+              validation={claudeValidation}
+              language={language}
+            />
             <small className="text-muted">{t('claudeCodeSettingsHint', language)}</small>
           </div>
         )}
@@ -786,34 +815,18 @@ export const APIKeyManagement: React.FC = () => {
             <label className="form-label">{t('qwenCodeSettings', language)}</label>
             <textarea
               className={`form-control ${
-                formData.qwen_settings.trim() && !getJsonValidationResult(formData.qwen_settings).valid
-                  ? 'is-invalid'
-                  : ''
+                formData.qwen_settings.trim() && !qwenValidation.valid ? 'is-invalid' : ''
               }`}
               rows={10}
               value={formData.qwen_settings}
               onChange={(e) => setFormData({ ...formData, qwen_settings: e.target.value })}
               placeholder={defaultQwenSettings}
             />
-            {/* JSON Validation Status Indicator */}
-            {formData.qwen_settings.trim() && (
-              <div
-                className={`mt-1 d-flex align-items-center ${
-                  getJsonValidationResult(formData.qwen_settings).valid ? 'text-success' : 'text-danger'
-                }`}
-              >
-                <i
-                  className={`bi ${
-                    getJsonValidationResult(formData.qwen_settings).valid ? 'bi-check-circle-fill' : 'bi-x-circle-fill'
-                  } me-1`}
-                />
-                <small>
-                  {getJsonValidationResult(formData.qwen_settings).valid
-                    ? t('jsonValid', language)
-                    : `${t('jsonInvalid', language)}: ${getJsonValidationResult(formData.qwen_settings).error}`}
-                </small>
-              </div>
-            )}
+            <JsonValidationIndicator
+              jsonStr={formData.qwen_settings}
+              validation={qwenValidation}
+              language={language}
+            />
             <small className="text-muted">{t('qwenCodeSettingsHint', language)}</small>
           </div>
         )}
@@ -962,33 +975,17 @@ export const APIKeyManagement: React.FC = () => {
             <label className="form-label">{t('claudeCodeSettings', language)}</label>
             <textarea
               className={`form-control ${
-                formData.claude_settings.trim() && !getJsonValidationResult(formData.claude_settings).valid
-                  ? 'is-invalid'
-                  : ''
+                formData.claude_settings.trim() && !claudeValidation.valid ? 'is-invalid' : ''
               }`}
               rows={8}
               value={formData.claude_settings}
               onChange={(e) => setFormData({ ...formData, claude_settings: e.target.value })}
             />
-            {/* JSON Validation Status Indicator */}
-            {formData.claude_settings.trim() && (
-              <div
-                className={`mt-1 d-flex align-items-center ${
-                  getJsonValidationResult(formData.claude_settings).valid ? 'text-success' : 'text-danger'
-                }`}
-              >
-                <i
-                  className={`bi ${
-                    getJsonValidationResult(formData.claude_settings).valid ? 'bi-check-circle-fill' : 'bi-x-circle-fill'
-                  } me-1`}
-                />
-                <small>
-                  {getJsonValidationResult(formData.claude_settings).valid
-                    ? t('jsonValid', language)
-                    : `${t('jsonInvalid', language)}: ${getJsonValidationResult(formData.claude_settings).error}`}
-                </small>
-              </div>
-            )}
+            <JsonValidationIndicator
+              jsonStr={formData.claude_settings}
+              validation={claudeValidation}
+              language={language}
+            />
             <small className="text-muted">{t('claudeCodeSettingsHint', language)}</small>
           </div>
         )}
@@ -999,33 +996,17 @@ export const APIKeyManagement: React.FC = () => {
             <label className="form-label">{t('qwenCodeSettings', language)}</label>
             <textarea
               className={`form-control ${
-                formData.qwen_settings.trim() && !getJsonValidationResult(formData.qwen_settings).valid
-                  ? 'is-invalid'
-                  : ''
+                formData.qwen_settings.trim() && !qwenValidation.valid ? 'is-invalid' : ''
               }`}
               rows={10}
               value={formData.qwen_settings}
               onChange={(e) => setFormData({ ...formData, qwen_settings: e.target.value })}
             />
-            {/* JSON Validation Status Indicator */}
-            {formData.qwen_settings.trim() && (
-              <div
-                className={`mt-1 d-flex align-items-center ${
-                  getJsonValidationResult(formData.qwen_settings).valid ? 'text-success' : 'text-danger'
-                }`}
-              >
-                <i
-                  className={`bi ${
-                    getJsonValidationResult(formData.qwen_settings).valid ? 'bi-check-circle-fill' : 'bi-x-circle-fill'
-                  } me-1`}
-                />
-                <small>
-                  {getJsonValidationResult(formData.qwen_settings).valid
-                    ? t('jsonValid', language)
-                    : `${t('jsonInvalid', language)}: ${getJsonValidationResult(formData.qwen_settings).error}`}
-                </small>
-              </div>
-            )}
+            <JsonValidationIndicator
+              jsonStr={formData.qwen_settings}
+              validation={qwenValidation}
+              language={language}
+            />
             <small className="text-muted">{t('qwenCodeSettingsHint', language)}</small>
           </div>
         )}

--- a/frontend/src/components/features/management/APIKeyManagement.tsx
+++ b/frontend/src/components/features/management/APIKeyManagement.tsx
@@ -281,6 +281,21 @@ export const APIKeyManagement: React.FC = () => {
     }
   };
 
+  /**
+   * Get JSON validation result with error message
+   * Returns: { valid: boolean, error: string | null }
+   */
+  const getJsonValidationResult = (jsonStr: string): { valid: boolean; error: string | null } => {
+    if (!jsonStr.trim()) return { valid: true, error: null };
+    try {
+      JSON.parse(jsonStr);
+      return { valid: true, error: null };
+    } catch (e) {
+      const errorMessage = e instanceof SyntaxError ? e.message : 'Invalid JSON';
+      return { valid: false, error: errorMessage };
+    }
+  };
+
   // Fields that should never be stored in cli_settings —
   // API credentials are injected via environment variables.
   const SENSITIVE_ENV_KEYS = new Set([
@@ -732,12 +747,35 @@ export const APIKeyManagement: React.FC = () => {
           <div className="mb-3">
             <label className="form-label">{t('claudeCodeSettings', language)}</label>
             <textarea
-              className="form-control"
+              className={`form-control ${
+                formData.claude_settings.trim() && !getJsonValidationResult(formData.claude_settings).valid
+                  ? 'is-invalid'
+                  : ''
+              }`}
               rows={8}
               value={formData.claude_settings}
               onChange={(e) => setFormData({ ...formData, claude_settings: e.target.value })}
               placeholder={defaultClaudeSettings}
             />
+            {/* JSON Validation Status Indicator */}
+            {formData.claude_settings.trim() && (
+              <div
+                className={`mt-1 d-flex align-items-center ${
+                  getJsonValidationResult(formData.claude_settings).valid ? 'text-success' : 'text-danger'
+                }`}
+              >
+                <i
+                  className={`bi ${
+                    getJsonValidationResult(formData.claude_settings).valid ? 'bi-check-circle-fill' : 'bi-x-circle-fill'
+                  } me-1`}
+                />
+                <small>
+                  {getJsonValidationResult(formData.claude_settings).valid
+                    ? t('jsonValid', language)
+                    : `${t('jsonInvalid', language)}: ${getJsonValidationResult(formData.claude_settings).error}`}
+                </small>
+              </div>
+            )}
             <small className="text-muted">{t('claudeCodeSettingsHint', language)}</small>
           </div>
         )}
@@ -747,12 +785,35 @@ export const APIKeyManagement: React.FC = () => {
           <div className="mb-3">
             <label className="form-label">{t('qwenCodeSettings', language)}</label>
             <textarea
-              className="form-control"
+              className={`form-control ${
+                formData.qwen_settings.trim() && !getJsonValidationResult(formData.qwen_settings).valid
+                  ? 'is-invalid'
+                  : ''
+              }`}
               rows={10}
               value={formData.qwen_settings}
               onChange={(e) => setFormData({ ...formData, qwen_settings: e.target.value })}
               placeholder={defaultQwenSettings}
             />
+            {/* JSON Validation Status Indicator */}
+            {formData.qwen_settings.trim() && (
+              <div
+                className={`mt-1 d-flex align-items-center ${
+                  getJsonValidationResult(formData.qwen_settings).valid ? 'text-success' : 'text-danger'
+                }`}
+              >
+                <i
+                  className={`bi ${
+                    getJsonValidationResult(formData.qwen_settings).valid ? 'bi-check-circle-fill' : 'bi-x-circle-fill'
+                  } me-1`}
+                />
+                <small>
+                  {getJsonValidationResult(formData.qwen_settings).valid
+                    ? t('jsonValid', language)
+                    : `${t('jsonInvalid', language)}: ${getJsonValidationResult(formData.qwen_settings).error}`}
+                </small>
+              </div>
+            )}
             <small className="text-muted">{t('qwenCodeSettingsHint', language)}</small>
           </div>
         )}
@@ -900,11 +961,34 @@ export const APIKeyManagement: React.FC = () => {
           <div className="mb-3">
             <label className="form-label">{t('claudeCodeSettings', language)}</label>
             <textarea
-              className="form-control"
+              className={`form-control ${
+                formData.claude_settings.trim() && !getJsonValidationResult(formData.claude_settings).valid
+                  ? 'is-invalid'
+                  : ''
+              }`}
               rows={8}
               value={formData.claude_settings}
               onChange={(e) => setFormData({ ...formData, claude_settings: e.target.value })}
             />
+            {/* JSON Validation Status Indicator */}
+            {formData.claude_settings.trim() && (
+              <div
+                className={`mt-1 d-flex align-items-center ${
+                  getJsonValidationResult(formData.claude_settings).valid ? 'text-success' : 'text-danger'
+                }`}
+              >
+                <i
+                  className={`bi ${
+                    getJsonValidationResult(formData.claude_settings).valid ? 'bi-check-circle-fill' : 'bi-x-circle-fill'
+                  } me-1`}
+                />
+                <small>
+                  {getJsonValidationResult(formData.claude_settings).valid
+                    ? t('jsonValid', language)
+                    : `${t('jsonInvalid', language)}: ${getJsonValidationResult(formData.claude_settings).error}`}
+                </small>
+              </div>
+            )}
             <small className="text-muted">{t('claudeCodeSettingsHint', language)}</small>
           </div>
         )}
@@ -914,11 +998,34 @@ export const APIKeyManagement: React.FC = () => {
           <div className="mb-3">
             <label className="form-label">{t('qwenCodeSettings', language)}</label>
             <textarea
-              className="form-control"
+              className={`form-control ${
+                formData.qwen_settings.trim() && !getJsonValidationResult(formData.qwen_settings).valid
+                  ? 'is-invalid'
+                  : ''
+              }`}
               rows={10}
               value={formData.qwen_settings}
               onChange={(e) => setFormData({ ...formData, qwen_settings: e.target.value })}
             />
+            {/* JSON Validation Status Indicator */}
+            {formData.qwen_settings.trim() && (
+              <div
+                className={`mt-1 d-flex align-items-center ${
+                  getJsonValidationResult(formData.qwen_settings).valid ? 'text-success' : 'text-danger'
+                }`}
+              >
+                <i
+                  className={`bi ${
+                    getJsonValidationResult(formData.qwen_settings).valid ? 'bi-check-circle-fill' : 'bi-x-circle-fill'
+                  } me-1`}
+                />
+                <small>
+                  {getJsonValidationResult(formData.qwen_settings).valid
+                    ? t('jsonValid', language)
+                    : `${t('jsonInvalid', language)}: ${getJsonValidationResult(formData.qwen_settings).error}`}
+                </small>
+              </div>
+            )}
             <small className="text-muted">{t('qwenCodeSettingsHint', language)}</small>
           </div>
         )}

--- a/frontend/src/components/features/management/APIKeyManagement.tsx
+++ b/frontend/src/components/features/management/APIKeyManagement.tsx
@@ -159,6 +159,18 @@ export const APIKeyManagement: React.FC = () => {
     showAdvanced: false,
   });
 
+  // JSON validation function (defined before useMemo to avoid ReferenceError)
+  const getJsonValidationResult = (jsonStr: string): { valid: boolean; error: string | null } => {
+    if (!jsonStr.trim()) return { valid: true, error: null };
+    try {
+      JSON.parse(jsonStr);
+      return { valid: true, error: null };
+    } catch (e) {
+      const errorMessage = e instanceof SyntaxError ? e.message : 'Invalid JSON';
+      return { valid: false, error: errorMessage };
+    }
+  };
+
   // Cached JSON validation results (avoid repeated parsing on each render)
   const claudeValidation = useMemo(
     () => getJsonValidationResult(formData.claude_settings),
@@ -323,21 +335,6 @@ export const APIKeyManagement: React.FC = () => {
       return true;
     } catch {
       return false;
-    }
-  };
-
-  /**
-   * Get JSON validation result with error message
-   * Returns: { valid: boolean, error: string | null }
-   */
-  const getJsonValidationResult = (jsonStr: string): { valid: boolean; error: string | null } => {
-    if (!jsonStr.trim()) return { valid: true, error: null };
-    try {
-      JSON.parse(jsonStr);
-      return { valid: true, error: null };
-    } catch (e) {
-      const errorMessage = e instanceof SyntaxError ? e.message : 'Invalid JSON';
-      return { valid: false, error: errorMessage };
     }
   };
 

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -808,6 +808,8 @@ const translations: Record<Language, Translations> = {
       'Configure non-sensitive Codex settings only (model, sandbox, etc.). Do NOT include API keys — they are injected via environment variables automatically.',
     claudeSettingsInvalid: 'Claude Code settings JSON is invalid',
     qwenSettingsInvalid: 'Qwen Code settings JSON is invalid',
+    jsonValid: 'JSON is valid',
+    jsonInvalid: 'JSON is invalid',
     providerCannotChange: 'Provider cannot be changed',
 
     // Help Documents
@@ -1656,6 +1658,8 @@ const translations: Record<Language, Translations> = {
       '仅配置非敏感 Codex 设置（model、sandbox 等）。请勿填写 API Key — 系统会通过环境变量自动注入。',
     claudeSettingsInvalid: 'Claude Code 设置 JSON 无效',
     qwenSettingsInvalid: 'Qwen Code 设置 JSON 无效',
+    jsonValid: 'JSON 格式正确',
+    jsonInvalid: 'JSON 格式错误',
     providerCannotChange: '提供商不可更改',
 
     // 帮助文档


### PR DESCRIPTION
## 问题描述

用户在编辑 API Key 时，给 qwen code settings 输入有语法错误的 JSON，点击保存后对话框不消失，但没有显示错误信息。

**根本原因**：错误信息显示在对话框顶部，用户正在编辑底部的 textarea，看不到错误提示。

## 解决方案

在 JSON textarea 下方添加实时验证状态指示器：

### 无效 JSON
- textarea 显示红色边框 (`is-invalid` class)
- 显示红色 ❌ 图标和具体错误信息
- 例如：`JSON is invalid: Expected double-quoted property name in JSON at position 144`

### 有效 JSON
- 显示绿色 ✓ 图标和成功提示
- 例如：`JSON is valid`

## 修改文件

- `frontend/src/components/features/management/APIKeyManagement.tsx` - 添加验证状态显示逻辑
- `frontend/src/i18n/index.ts` - 添加翻译键

## 测试验证

✅ 自动化测试通过
✅ 手动演示测试通过

## 效果截图

用户输入无效 JSON 时，可以立即看到错误提示，不需要等到点击保存才能发现问题。

Closes #614

🤖 Generated with [Claude Code](https://claude.com/claude-code)