### PR TITLE
fix: optimize code-server install experience with timeout and skip option

### DIFF
--- a/remote-agent/install.ps1
+++ b/remote-agent/install.ps1
@@ -22,7 +22,8 @@ param(
 
     [string]$MachineName = $env:COMPUTERNAME,
     [string]$InstallCli = "qwen-code-cli",
-    [string]$InstallDir = "$env:USERPROFILE\.open-ace-agent"
+    [string]$InstallDir = "$env:USERPROFILE\.open-ace-agent",
+    [switch]$SkipCodeServer
 )
 
 $ErrorActionPreference = "Stop"
@@ -224,32 +225,46 @@ if ($gitCmd) {
 }
 
 # Install code-server if not present
-$csCmd = Get-Command code-server -ErrorAction SilentlyContinue
-if ($csCmd) {
-    $csVer = code-server --version 2>&1 | Select-Object -First 1
-    Write-Host "[OK] code-server already installed: $csVer" -ForegroundColor Green
+if ($SkipCodeServer) {
+    Write-Host "[INFO] Skipping code-server installation (-SkipCodeServer)" -ForegroundColor Cyan
 } else {
-    Write-Host "[INFO] code-server not found, attempting to install..." -ForegroundColor Cyan
-    $csInstalled = $false
-    $npmCmd = Get-Command npm -ErrorAction SilentlyContinue
-    if ($npmCmd) {
-        try {
-            $prevErrorAction = $ErrorActionPreference
-            $ErrorActionPreference = "Continue"
-            npm install -g code-server 2>&1 | Out-Null
-            if ($LASTEXITCODE -eq 0) {
-                $csInstalled = $true
-            }
-            $ErrorActionPreference = $prevErrorAction
-        } catch {
-            # npm install failed
-        }
-    }
-    if ($csInstalled -and (Get-Command code-server -ErrorAction SilentlyContinue)) {
-        Write-Host "[OK] code-server installed: $(code-server --version 2>&1 | Select-Object -First 1)" -ForegroundColor Green
+    $csCmd = Get-Command code-server -ErrorAction SilentlyContinue
+    if ($csCmd) {
+        $csVer = code-server --version 2>&1 | Select-Object -First 1
+        Write-Host "[OK] code-server already installed: $csVer" -ForegroundColor Green
     } else {
-        Write-Host "[WARN] Failed to install code-server. Remote workspace will be missing VSCode editor." -ForegroundColor Yellow
-        Write-Host "       Please install manually: https://coder.com/docs/code-server/latest/install" -ForegroundColor Yellow
+        Write-Host "[INFO] code-server not found, attempting to install..." -ForegroundColor Cyan
+        Write-Host "[INFO] This may take a few minutes, please wait..." -ForegroundColor Cyan
+        $csInstalled = $false
+        $npmCmd = Get-Command npm -ErrorAction SilentlyContinue
+        if ($npmCmd) {
+            try {
+                $prevErrorAction = $ErrorActionPreference
+                $ErrorActionPreference = "Continue"
+                # Run npm install with timeout (300s)
+                $job = Start-Job -ScriptBlock { npm install -g code-server 2>&1 }
+                $completed = Wait-Job $job -Timeout 300
+                if ($completed) {
+                    $output = Receive-Job $job
+                    if ($job.State -eq 'Completed') {
+                        $csInstalled = $true
+                    }
+                } else {
+                    Stop-Job $job
+                    Write-Host "[WARN] code-server install timed out after 300s" -ForegroundColor Yellow
+                }
+                Remove-Job $job -Force -ErrorAction SilentlyContinue
+                $ErrorActionPreference = $prevErrorAction
+            } catch {
+                # npm install failed
+            }
+        }
+        if ($csInstalled -and (Get-Command code-server -ErrorAction SilentlyContinue)) {
+            Write-Host "[OK] code-server installed: $(code-server --version 2>&1 | Select-Object -First 1)" -ForegroundColor Green
+        } else {
+            Write-Host "[WARN] Failed to install code-server. Remote workspace will be missing VSCode editor." -ForegroundColor Yellow
+            Write-Host "       You can install it manually later: https://coder.com/docs/code-server/latest/install" -ForegroundColor Yellow
+        }
     }
 }
 

--- a/remote-agent/install.ps1
+++ b/remote-agent/install.ps1
@@ -242,11 +242,16 @@ if ($SkipCodeServer) {
                 $prevErrorAction = $ErrorActionPreference
                 $ErrorActionPreference = "Continue"
                 # Run npm install with timeout (300s)
-                $job = Start-Job -ScriptBlock { npm install -g code-server 2>&1 }
+                # Pass full npm path since Start-Job doesn't inherit current session env
+                $npmPath = (Get-Command npm).Source
+                $job = Start-Job -ScriptBlock {
+                    param($p) & $p install -g code-server 2>&1; $LASTEXITCODE
+                } -ArgumentList $npmPath
                 $completed = Wait-Job $job -Timeout 300
                 if ($completed) {
                     $output = Receive-Job $job
-                    if ($job.State -eq 'Completed') {
+                    $exitCode = ($output | Select-Object -Last 1)
+                    if ($job.State -eq 'Completed' -and "$exitCode" -eq '0') {
                         $csInstalled = $true
                     }
                 } else {

--- a/remote-agent/install.sh
+++ b/remote-agent/install.sh
@@ -424,11 +424,7 @@ else
             # Run install with timeout (300s) and progress dots
             log_info "Running code-server installer..."
             _cs_killed=false
-            if command -v timeout &>/dev/null; then
-                timeout 300 sh "$CS_INSTALL_SCRIPT" &
-            else
-                sh "$CS_INSTALL_SCRIPT" &
-            fi
+            sh "$CS_INSTALL_SCRIPT" &
             CS_PID=$!
             _CS_START=$SECONDS
             while kill -0 "$CS_PID" 2>/dev/null; do

--- a/remote-agent/install.sh
+++ b/remote-agent/install.sh
@@ -423,27 +423,27 @@ else
         if [[ "$CS_DOWNLOAD_OK" == "true" ]]; then
             # Run install with timeout (300s) and progress dots
             log_info "Running code-server installer..."
+            _cs_killed=false
             if command -v timeout &>/dev/null; then
-                timeout 300 sh "$CS_INSTALL_SCRIPT" && CS_INSTALLED=true
+                timeout 300 sh "$CS_INSTALL_SCRIPT" &
             else
-                # macOS fallback: background process with manual timeout
                 sh "$CS_INSTALL_SCRIPT" &
-                CS_PID=$!
-                _CS_START=$SECONDS
-                while kill -0 "$CS_PID" 2>/dev/null; do
-                    if [[ $(( SECONDS - _CS_START )) -gt 300 ]]; then
-                        kill "$CS_PID" 2>/dev/null
-                        log_warn "code-server install timed out after 300s"
-                        break
-                    fi
-                    sleep 5
-                    echo -n "."
-                done
-                echo ""
-                # Check if process exited 0 (only if not killed)
-                if wait "$CS_PID" 2>/dev/null; then
-                    CS_INSTALLED=true
+            fi
+            CS_PID=$!
+            _CS_START=$SECONDS
+            while kill -0 "$CS_PID" 2>/dev/null; do
+                if [[ $(( SECONDS - _CS_START )) -gt 300 ]]; then
+                    kill "$CS_PID" 2>/dev/null
+                    _cs_killed=true
+                    log_warn "code-server install timed out after 300s"
+                    break
                 fi
+                sleep 5
+                echo -n "."
+            done
+            echo ""
+            if [[ "$_cs_killed" == "false" ]] && wait "$CS_PID" 2>/dev/null; then
+                CS_INSTALLED=true
             fi
         else
             log_warn "Failed to download code-server install script (network timeout or unavailable)"

--- a/remote-agent/install.sh
+++ b/remote-agent/install.sh
@@ -11,6 +11,7 @@
 #   --name NAME          Machine display name (default: hostname)
 #   --install-cli TOOL   Install a CLI tool: qwen-code-cli, claude-code (default: qwen-code-cli)
 #   --dir DIR            Installation directory (default: ~/.open-ace-agent)
+#   --skip-code-server   Skip code-server installation
 #   --help               Show this help
 #
 
@@ -35,6 +36,7 @@ MACHINE_NAME=$(hostname)
 INSTALL_CLI="qwen-code-cli"
 INSTALL_DIR="$HOME/.open-ace-agent"
 AGENT_VERSION="1.0.0"
+SKIP_CODE_SERVER=false
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do
@@ -58,6 +60,10 @@ while [[ $# -gt 0 ]]; do
         --dir)
             INSTALL_DIR="$2"
             shift 2
+            ;;
+        --skip-code-server)
+            SKIP_CODE_SERVER=true
+            shift
             ;;
         --help)
             head -20 "$0" | grep '^#' | sed 's/^# \?//'
@@ -395,18 +401,52 @@ else
 fi
 
 # Install code-server if not present
-if command -v code-server &>/dev/null; then
+if [[ "$SKIP_CODE_SERVER" == "true" ]]; then
+    log_info "Skipping code-server installation (--skip-code-server)"
+elif command -v code-server &>/dev/null; then
     log_success "code-server already installed: $(code-server --version 2>/dev/null | head -1)"
 else
     log_info "code-server not found, attempting to install..."
+    log_info "This may take a few minutes, please wait..."
     CS_INSTALLED=false
     if [[ "$(uname)" == "Darwin" ]] || [[ "$(uname)" == "Linux" ]]; then
-        # Download install script to a temp file first (safer than piping to sh)
         CS_INSTALL_SCRIPT=$(mktemp)
+        CS_DOWNLOAD_OK=false
+
+        # Download install script with timeout
         if command -v curl &>/dev/null; then
-            curl -fsSL https://code-server.dev/install.sh -o "$CS_INSTALL_SCRIPT" && sh "$CS_INSTALL_SCRIPT" && CS_INSTALLED=true
+            curl -fsSL --connect-timeout 10 --max-time 120 https://code-server.dev/install.sh -o "$CS_INSTALL_SCRIPT" && CS_DOWNLOAD_OK=true
         elif command -v wget &>/dev/null; then
-            wget -qO "$CS_INSTALL_SCRIPT" https://code-server.dev/install.sh && sh "$CS_INSTALL_SCRIPT" && CS_INSTALLED=true
+            wget --timeout=120 -qO "$CS_INSTALL_SCRIPT" https://code-server.dev/install.sh && CS_DOWNLOAD_OK=true
+        fi
+
+        if [[ "$CS_DOWNLOAD_OK" == "true" ]]; then
+            # Run install with timeout (300s) and progress dots
+            log_info "Running code-server installer..."
+            if command -v timeout &>/dev/null; then
+                timeout 300 sh "$CS_INSTALL_SCRIPT" && CS_INSTALLED=true
+            else
+                # macOS fallback: background process with manual timeout
+                sh "$CS_INSTALL_SCRIPT" &
+                CS_PID=$!
+                _CS_START=$SECONDS
+                while kill -0 "$CS_PID" 2>/dev/null; do
+                    if [[ $(( SECONDS - _CS_START )) -gt 300 ]]; then
+                        kill "$CS_PID" 2>/dev/null
+                        log_warn "code-server install timed out after 300s"
+                        break
+                    fi
+                    sleep 5
+                    echo -n "."
+                done
+                echo ""
+                # Check if process exited 0 (only if not killed)
+                if wait "$CS_PID" 2>/dev/null; then
+                    CS_INSTALLED=true
+                fi
+            fi
+        else
+            log_warn "Failed to download code-server install script (network timeout or unavailable)"
         fi
         rm -f "$CS_INSTALL_SCRIPT"
     fi
@@ -414,7 +454,7 @@ else
         log_success "code-server installed: $(code-server --version 2>/dev/null | head -1)"
     else
         log_warn "Failed to install code-server. Remote workspace will be missing VSCode editor."
-        log_warn "Please install manually: https://coder.com/docs/code-server/latest/install"
+        log_warn "You can install it manually later: https://coder.com/docs/code-server/latest/install"
     fi
 fi
 


### PR DESCRIPTION
## 问题

`install.sh` 和 `install.ps1` 安装 code-server 时存在两个问题：
1. **无进度提示** — 安装可能长达数分钟，用户只能静默等待
2. **无超时控制** — 网络不通时 curl/npm 会一直阻塞，脚本卡死

## 改动

### install.sh
- 新增 `--skip-code-server` 参数，允许跳过 code-server 安装
- 下载超时：curl 加 `--connect-timeout 10 --max-time 120`
- 安装超时：Linux 用 `timeout 300`，macOS 用后台进程 + kill 模拟 300 秒超时
- 进度提示：安装前打印等待信息，安装中每 5 秒打印 `.`

### install.ps1
- 新增 `-SkipCodeServer` switch 参数
- 安装超时：用 `Start-Job` + `Wait-Job -Timeout 300`
- 进度提示：安装前打印等待信息

## 使用示例

```bash
# 跳过 code-server 安装
curl -fsSL http://server:5000/api/remote/agent/install.sh | bash -s -- \
  --server http://server:5000 --token xxx --skip-code-server

# 后续手动安装 code-server
curl -fsSL https://code-server.dev/install.sh | sh
```

## 测试

已在 192.168.1.56 (Rocky Linux 8) 上用 `--skip-code-server` 成功安装 remote agent。

🤖 Generated with [Claude Code](https://claude.com/claude-code)