### PR TITLE
fix: 活跃用户统计按 user_id 合并，解决同一用户重复显示问题 (#184)

### DIFF
--- a/app/repositories/message_repo.py
+++ b/app/repositories/message_repo.py
@@ -646,42 +646,53 @@ class MessageRepository:
         """
         Get total tokens per user for segmentation analysis.
 
+        Merges users by user_id when available, falling back to sender_name for unmapped accounts.
+        This solves the issue where the same user appears multiple times with different
+        sender_name formats (e.g., user1-host1-qwen, user1-host2-qwen).
+
         Args:
             start_date: Optional start date filter.
             end_date: Optional end date filter.
             host_name: Optional host name filter.
 
         Returns:
-            List[Dict]: List of user token totals.
+            List[Dict]: List of user token totals with unified_username field.
         """
-        conditions = []
+        conditions = ["dm.date IS NOT NULL"]
         params = []
 
         if start_date:
-            conditions.append("date >= ?")
+            conditions.append("dm.date >= ?")
             params.append(start_date)
 
         if end_date:
-            conditions.append("date <= ?")
+            conditions.append("dm.date <= ?")
             params.append(end_date)
 
         if host_name:
-            conditions.append("host_name = ?")
+            conditions.append("dm.host_name = ?")
             params.append(host_name)
 
-        where_clause = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+        where_clause = f"WHERE {' AND '.join(conditions)}"
 
+        # Use LEFT JOIN to get unified username from users table
+        # Group by user_id when available, fallback to sender_name for unmapped accounts
+        # Use MAX/MIN for sender_name and sender_id as PostgreSQL requires all non-grouped
+        # columns to be in GROUP BY or aggregated
         query = f"""
             SELECT
-                sender_name,
-                sender_id,
-                SUM(tokens_used) as total_tokens,
-                SUM(input_tokens) as total_input_tokens,
-                SUM(output_tokens) as total_output_tokens,
+                COALESCE(dm.user_id, -1) as user_id,
+                COALESCE(u.username, dm.sender_name) as unified_username,
+                MAX(dm.sender_name) as sender_name,
+                MAX(dm.sender_id) as sender_id,
+                SUM(dm.tokens_used) as total_tokens,
+                SUM(dm.input_tokens) as total_input_tokens,
+                SUM(dm.output_tokens) as total_output_tokens,
                 COUNT(*) as message_count
-            FROM daily_messages
+            FROM daily_messages dm
+            LEFT JOIN users u ON dm.user_id = u.id
             {where_clause}
-            GROUP BY sender_name, sender_id
+            GROUP BY COALESCE(dm.user_id, -1), COALESCE(u.username, dm.sender_name)
             ORDER BY total_tokens DESC
         """
 

--- a/app/services/analysis_service.py
+++ b/app/services/analysis_service.py
@@ -562,6 +562,9 @@ class AnalysisService:
         """
         Get user ranking by token usage.
 
+        Uses unified_username from get_user_token_totals which merges users by user_id.
+        This ensures users with multiple sender_name aliases appear as a single entry.
+
         Returns:
             Dict: User rankings with users array.
         """
@@ -570,24 +573,19 @@ class AnalysisService:
         if not end_date:
             end_date = get_today()
 
-        # Get user token usage from messages
+        # Get user token usage from messages (already merged by user_id)
         user_tokens = self.message_repo.get_user_token_totals(
             start_date=start_date, end_date=end_date, host_name=host_name
         )
 
-        # Sort by tokens and limit
+        # Build user ranking using unified_username
         users = []
         for i, user_data in enumerate(user_tokens[:limit]):
-            # Clean up username - remove machine-generated suffixes
-            username = user_data.get("sender_name", "Unknown")
-            if username and ".local" in username:
-                # Remove machine suffix like "rhuang-RichdeMacBook-Pro.local-openclaw"
-                # Just use the first part before any hyphen
-                username = username.split("-")[0]
+            username = user_data.get("unified_username", "Unknown")
 
             users.append(
                 {
-                    "user_id": i + 1,
+                    "user_id": user_data.get("user_id", i + 1),
                     "username": username,
                     "tokens": user_data.get("total_tokens", 0),
                     "requests": user_data.get("message_count", 0),

--- a/tests/unit/test_analysis_service.py
+++ b/tests/unit/test_analysis_service.py
@@ -86,17 +86,32 @@ class TestAnalysisService:
     def test_get_user_ranking(self):
         svc, _, mock_msg, _ = self._make_service()
         mock_msg.get_user_token_totals.return_value = [
-            {"sender_name": "user1", "total_tokens": 5000, "message_count": 50},
-            {"sender_name": "user2", "total_tokens": 3000, "message_count": 30},
+            {
+                "user_id": 1,
+                "unified_username": "user1",
+                "sender_name": "user1",
+                "total_tokens": 5000,
+                "message_count": 50,
+            },
+            {
+                "user_id": 2,
+                "unified_username": "user2",
+                "sender_name": "user2",
+                "total_tokens": 3000,
+                "message_count": 30,
+            },
         ]
         result = svc.get_user_ranking("2026-05-01", "2026-05-23")
         assert len(result["users"]) == 2
         assert result["users"][0]["tokens"] == 5000
 
-    def test_get_user_ranking_cleans_machine_suffix(self):
+    def test_get_user_ranking_uses_unified_username(self):
+        """Test that get_user_ranking uses unified_username from get_user_token_totals."""
         svc, _, mock_msg, _ = self._make_service()
         mock_msg.get_user_token_totals.return_value = [
             {
+                "user_id": 1,
+                "unified_username": "testuser",  # unified username from users table
                 "sender_name": "testuser-MacBook-Pro.local",
                 "total_tokens": 1000,
                 "message_count": 10,
@@ -104,6 +119,32 @@ class TestAnalysisService:
         ]
         result = svc.get_user_ranking("2026-05-01", "2026-05-23")
         assert result["users"][0]["username"] == "testuser"
+        assert result["users"][0]["user_id"] == 1
+
+    def test_get_user_ranking_merges_duplicate_users(self):
+        """Test that multiple sender_names with same user_id are merged."""
+        svc, _, mock_msg, _ = self._make_service()
+        # Simulate merged result: same user_id appears only once
+        mock_msg.get_user_token_totals.return_value = [
+            {
+                "user_id": 1,
+                "unified_username": "alice",
+                "sender_name": "alice-host1-qwen",
+                "total_tokens": 3000,
+                "message_count": 30,
+            },
+            {
+                "user_id": -1,
+                "unified_username": "bob-host2-qwen",
+                "sender_name": "bob-host2-qwen",
+                "total_tokens": 2000,
+                "message_count": 20,
+            },
+        ]
+        result = svc.get_user_ranking("2026-05-01", "2026-05-23")
+        # Only 2 users, not 3 (alice merged)
+        assert len(result["users"]) == 2
+        assert result["users"][0]["username"] == "alice"
 
     def test_get_conversation_stats(self):
         svc, _, mock_msg, _ = self._make_service()


### PR DESCRIPTION
## 问题描述

Issue #184: 在趋势分析页面的「活跃用户 Top 10」统计中，同一用户在不同机器/环境下使用时，会显示为多个不同的用户名，导致：
- 用户排名不准确（实际人数少于显示人数）
- 同一用户的 tokens 和消息数分散在多条记录中

## 问题根因

`get_user_token_totals` 方法按 `sender_name, sender_id` 分组统计，未使用 `daily_messages.user_id` 字段进行合并。同一用户在不同环境下使用时，系统生成不同的 `sender_name` 格式（如 `user1-host1-qwen`, `user1-host2-qwen`），导致被当作不同用户统计。

## 修复方案

1. **修改 `get_user_token_totals` 方法**：
   - LEFT JOIN `users` 表获取用户真实姓名
   - 按 `user_id` 分组（使用 `COALESCE(dm.user_id, -1)`）
   - 使用 `COALESCE(u.username, dm.sender_name)` 作为统一用户名

2. **修改 `get_user_ranking` 方法**：
   - 使用新的 `unified_username` 字段
   - 不再手动截取用户名（删除 `.local` 后缀处理逻辑）

## 合并逻辑

- **有 user_id 的记录**：按 user_id 分组，使用 `users.username` 作为 unified_username
- **无 user_id 的记录**：user_id=-1，使用 sender_name 作为 unified_username

配置工具账户别名映射后，同一用户的多个 sender_name 会自动合并为单一用户记录。

## 修改文件

- `app/repositories/message_repo.py` - `get_user_token_totals` SQL 查询
- `app/services/analysis_service.py` - `get_user_ranking` 方法
- `tests/unit/test_analysis_service.py` - 更新测试用例

## 测试结果

- 单元测试：15 个测试全部通过
- node237 环境验证：配置别名映射后，用户成功合并显示真实用户名

Closes #184