### PR TITLE
fix: 项目工作时长统计修复 (#624)

### DIFF
--- a/app/modules/workspace/session_manager.py
+++ b/app/modules/workspace/session_manager.py
@@ -837,7 +837,11 @@ class SessionManager:
                     duration_seconds = 0
                     if created_at_str:
                         try:
-                            created_at = datetime.fromisoformat(created_at_str)
+                            # PostgreSQL returns datetime objects, SQLite returns strings
+                            if isinstance(created_at_str, datetime):
+                                created_at = created_at_str
+                            else:
+                                created_at = datetime.fromisoformat(created_at_str)
                             duration_seconds = int((now - created_at).total_seconds())
                             # Cap at reasonable maximum (24 hours)
                             duration_seconds = min(duration_seconds, 24 * 3600)


### PR DESCRIPTION
## 问题描述

 始终为 0，即使会话已完成。

## 问题根因

 中  无法处理 PostgreSQL 返回的  对象：
- PostgreSQL + psycopg2 自动将  类型转换为 Python  对象
-  期望字符串参数，收到  对象后抛出 TypeError
- 异常被捕获， 保持为 0

## 修复方案

在计算时长前检测  类型：
- 若已是  对象（PostgreSQL），直接使用
- 若是字符串（SQLite），调用  解析

## 修改文件

| 文件 | 修改内容 |
|------|---------|
|  | 添加  类型检测 |

## 验证结果

已在 node237 环境验证：
- 日志显示 （之前是 ）
-  正常累加
- 不再出现  错误

Closes #624

🤖 Generated with Qwen Code