### PR TITLE
fix: merge duplicate users in trend analysis by user_id (#626)

### DIFF
--- a/app/repositories/daily_stats_repo.py
+++ b/app/repositories/daily_stats_repo.py
@@ -142,9 +142,7 @@ class DailyStatsRepository:
             else:
                 merged[tool] = {**row, "tool_name": tool}
 
-        return sorted(
-            merged.values(), key=lambda x: x.get("total_tokens", 0), reverse=True
-        )
+        return sorted(merged.values(), key=lambda x: x.get("total_tokens", 0), reverse=True)
 
     def get_user_totals(
         self,
@@ -373,19 +371,13 @@ class DailyStatsRepository:
             "total_messages": total_messages,
             "total_tokens": total_tokens,
             "average_messages_per_conversation": (
-                total_messages / estimated_conversations
-                if estimated_conversations > 0
-                else 0
+                total_messages / estimated_conversations if estimated_conversations > 0 else 0
             ),
             "average_tokens_per_conversation": (
-                total_tokens / estimated_conversations
-                if estimated_conversations > 0
-                else 0
+                total_tokens / estimated_conversations if estimated_conversations > 0 else 0
             ),
             "avg_conversation_length": (
-                total_messages / estimated_conversations
-                if estimated_conversations > 0
-                else 0
+                total_messages / estimated_conversations if estimated_conversations > 0 else 0
             ),
         }
 
@@ -428,6 +420,7 @@ class DailyStatsRepository:
 
         if is_postgresql():
             # PostgreSQL: use subquery for user_id resolution
+            # Fallback to sender_name when user_id cannot be resolved
             query = f"""
                 SELECT
                     SUM(message_count) as total_messages,
@@ -440,13 +433,15 @@ class DailyStatsRepository:
                         (SELECT u.id FROM users u
                          WHERE sender_name LIKE (u.system_account || '-%%')
                             OR sender_name = u.username
-                         LIMIT 1))) as unique_users,
+                         LIMIT 1),
+                        sender_name)) as unique_users,
                     COUNT(DISTINCT date) as unique_days
                 FROM daily_stats
                 {where_clause}
             """
         else:
             # SQLite: use subquery for user_id resolution
+            # Fallback to sender_name when user_id cannot be resolved
             query = f"""
                 SELECT
                     SUM(message_count) as total_messages,
@@ -459,7 +454,8 @@ class DailyStatsRepository:
                         (SELECT u.id FROM users u
                          WHERE sender_name LIKE (u.system_account || '-%%')
                             OR sender_name = u.username
-                         LIMIT 1))) as unique_users,
+                         LIMIT 1),
+                        sender_name)) as unique_users,
                     COUNT(DISTINCT date) as unique_days
                 FROM daily_stats
                 {where_clause}

--- a/app/repositories/daily_stats_repo.py
+++ b/app/repositories/daily_stats_repo.py
@@ -142,7 +142,9 @@ class DailyStatsRepository:
             else:
                 merged[tool] = {**row, "tool_name": tool}
 
-        return sorted(merged.values(), key=lambda x: x.get("total_tokens", 0), reverse=True)
+        return sorted(
+            merged.values(), key=lambda x: x.get("total_tokens", 0), reverse=True
+        )
 
     def get_user_totals(
         self,
@@ -153,44 +155,86 @@ class DailyStatsRepository:
         """
         Get user token totals from pre-aggregated data.
 
+        This method merges users by user_id when available, falling back to
+        sender_name matching for unmapped accounts. This fixes Issue #626
+        where the same user appears multiple times with different sender_name
+        formats (e.g., WebUI format and Feishu format).
+
         Args:
             start_date: Optional start date filter.
             end_date: Optional end date filter.
             host_name: Optional host name filter.
 
         Returns:
-            List[Dict]: List of user totals.
+            List[Dict]: List of user totals with unified_username field.
         """
-        conditions = ["sender_name IS NOT NULL"]  # Only include rows with sender
+        conditions = ["ds.sender_name IS NOT NULL"]  # Only include rows with sender
         params = []
 
         if start_date:
-            conditions.append("date >= ?")
+            conditions.append("ds.date >= ?")
             params.append(start_date)
 
         if end_date:
-            conditions.append("date <= ?")
+            conditions.append("ds.date <= ?")
             params.append(end_date)
 
         if host_name:
-            conditions.append("host_name = ?")
+            conditions.append("ds.host_name = ?")
             params.append(host_name)
 
-        # Aggregate by sender_name (sum across all dates/tools)
         where_clause = f"WHERE {' AND '.join(conditions)}"
 
-        query = f"""
-            SELECT
-                sender_name,
-                SUM(total_tokens) as total_tokens,
-                SUM(total_input_tokens) as total_input_tokens,
-                SUM(total_output_tokens) as total_output_tokens,
-                SUM(message_count) as message_count
-            FROM daily_stats
-            {where_clause}
-            GROUP BY sender_name
-            ORDER BY total_tokens DESC
-        """
+        if is_postgresql():
+            # PostgreSQL: use subquery for user_id resolution
+            query = f"""
+                SELECT
+                    COALESCE(ds.user_id,
+                        (SELECT u.id FROM users u
+                         WHERE ds.sender_name LIKE (u.system_account || '-%%')
+                            OR ds.sender_name = u.username
+                         LIMIT 1), -1) as resolved_user_id,
+                    COALESCE(u.username,
+                        CASE WHEN ds.sender_name LIKE '%%-%%-%%'
+                             THEN SUBSTRING(ds.sender_name FROM '^[^-]+')
+                             ELSE ds.sender_name END) as unified_username,
+                    SUM(ds.total_tokens) as total_tokens,
+                    SUM(ds.total_input_tokens) as total_input_tokens,
+                    SUM(ds.total_output_tokens) as total_output_tokens,
+                    SUM(ds.message_count) as message_count
+                FROM daily_stats ds
+                LEFT JOIN users u ON ds.user_id = u.id
+                    OR ds.sender_name LIKE (u.system_account || '-%%')
+                    OR ds.sender_name = u.username
+                {where_clause}
+                GROUP BY resolved_user_id, unified_username
+                ORDER BY total_tokens DESC
+            """
+        else:
+            # SQLite: use subquery for user_id resolution
+            query = f"""
+                SELECT
+                    COALESCE(ds.user_id,
+                        (SELECT u.id FROM users u
+                         WHERE ds.sender_name LIKE (u.system_account || '-%%')
+                            OR ds.sender_name = u.username
+                         LIMIT 1), -1) as resolved_user_id,
+                    COALESCE(u.username,
+                        CASE WHEN ds.sender_name LIKE '%%-%%-%%'
+                             THEN SUBSTR(ds.sender_name, 1, INSTR(ds.sender_name, '-') - 1)
+                             ELSE ds.sender_name END) as unified_username,
+                    SUM(ds.total_tokens) as total_tokens,
+                    SUM(ds.total_input_tokens) as total_input_tokens,
+                    SUM(ds.total_output_tokens) as total_output_tokens,
+                    SUM(ds.message_count) as message_count
+                FROM daily_stats ds
+                LEFT JOIN users u ON ds.user_id = u.id
+                    OR ds.sender_name LIKE (u.system_account || '-%%')
+                    OR ds.sender_name = u.username
+                {where_clause}
+                GROUP BY resolved_user_id, unified_username
+                ORDER BY total_tokens DESC
+            """
 
         return self.db.fetch_all(query, tuple(params))
 
@@ -329,13 +373,19 @@ class DailyStatsRepository:
             "total_messages": total_messages,
             "total_tokens": total_tokens,
             "average_messages_per_conversation": (
-                total_messages / estimated_conversations if estimated_conversations > 0 else 0
+                total_messages / estimated_conversations
+                if estimated_conversations > 0
+                else 0
             ),
             "average_tokens_per_conversation": (
-                total_tokens / estimated_conversations if estimated_conversations > 0 else 0
+                total_tokens / estimated_conversations
+                if estimated_conversations > 0
+                else 0
             ),
             "avg_conversation_length": (
-                total_messages / estimated_conversations if estimated_conversations > 0 else 0
+                total_messages / estimated_conversations
+                if estimated_conversations > 0
+                else 0
             ),
         }
 
@@ -347,6 +397,9 @@ class DailyStatsRepository:
     ) -> dict:
         """
         Get all aggregates in a single query from pre-aggregated data.
+
+        This method counts unique_users by user_id instead of sender_name,
+        fixing Issue #626 where users were counted multiple times.
 
         Args:
             start_date: Optional start date filter.
@@ -373,19 +426,44 @@ class DailyStatsRepository:
 
         where_clause = f"WHERE {' AND '.join(conditions)}" if conditions else ""
 
-        query = f"""
-            SELECT
-                SUM(message_count) as total_messages,
-                SUM(total_tokens) as total_tokens,
-                SUM(total_input_tokens) as total_input_tokens,
-                SUM(total_output_tokens) as total_output_tokens,
-                COUNT(DISTINCT tool_name) as unique_tools,
-                COUNT(DISTINCT host_name) as unique_hosts,
-                COUNT(DISTINCT sender_name) as unique_users,
-                COUNT(DISTINCT date) as unique_days
-            FROM daily_stats
-            {where_clause}
-        """
+        if is_postgresql():
+            # PostgreSQL: use subquery for user_id resolution
+            query = f"""
+                SELECT
+                    SUM(message_count) as total_messages,
+                    SUM(total_tokens) as total_tokens,
+                    SUM(total_input_tokens) as total_input_tokens,
+                    SUM(total_output_tokens) as total_output_tokens,
+                    COUNT(DISTINCT tool_name) as unique_tools,
+                    COUNT(DISTINCT host_name) as unique_hosts,
+                    COUNT(DISTINCT COALESCE(user_id,
+                        (SELECT u.id FROM users u
+                         WHERE sender_name LIKE (u.system_account || '-%%')
+                            OR sender_name = u.username
+                         LIMIT 1))) as unique_users,
+                    COUNT(DISTINCT date) as unique_days
+                FROM daily_stats
+                {where_clause}
+            """
+        else:
+            # SQLite: use subquery for user_id resolution
+            query = f"""
+                SELECT
+                    SUM(message_count) as total_messages,
+                    SUM(total_tokens) as total_tokens,
+                    SUM(total_input_tokens) as total_input_tokens,
+                    SUM(total_output_tokens) as total_output_tokens,
+                    COUNT(DISTINCT tool_name) as unique_tools,
+                    COUNT(DISTINCT host_name) as unique_hosts,
+                    COUNT(DISTINCT COALESCE(user_id,
+                        (SELECT u.id FROM users u
+                         WHERE sender_name LIKE (u.system_account || '-%%')
+                            OR sender_name = u.username
+                         LIMIT 1))) as unique_users,
+                    COUNT(DISTINCT date) as unique_days
+                FROM daily_stats
+                {where_clause}
+            """
 
         result = self.db.fetch_one(query, tuple(params))
 
@@ -416,6 +494,10 @@ class DailyStatsRepository:
         """
         Refresh daily_stats from daily_messages.
 
+        This method aggregates daily_messages into daily_stats, populating user_id
+        by matching sender_name to users table. This fixes Issue #626 where users
+        were counted multiple times due to different sender_name formats.
+
         Args:
             date: Optional specific date to refresh. If None, refreshes all.
 
@@ -441,48 +523,71 @@ class DailyStatsRepository:
                     params,
                 )
 
-                # Insert new stats
+                # Insert new stats with user_id populated from users table
+                # sender_name formats:
+                # 1. WebUI: {system_account}-{hostname}-{tool} -> match users.system_account
+                # 2. Feishu: username (real name) -> match users.username
                 self.db.execute(
                     f"""
                     INSERT INTO daily_stats
-                    (date, tool_name, host_name, sender_name, total_tokens, total_input_tokens,
-                     total_output_tokens, message_count, updated_at)
+                    (date, tool_name, host_name, sender_name, user_id, total_tokens,
+                     total_input_tokens, total_output_tokens, message_count, updated_at)
                     SELECT
-                        date,
-                        tool_name,
-                        host_name,
-                        sender_name,
-                        SUM(tokens_used) as total_tokens,
-                        SUM(input_tokens) as total_input_tokens,
-                        SUM(output_tokens) as total_output_tokens,
+                        dm.date,
+                        dm.tool_name,
+                        dm.host_name,
+                        dm.sender_name,
+                        COALESCE(dm.user_id,
+                            (SELECT u.id FROM users u
+                             WHERE dm.sender_name LIKE (u.system_account || '-%%')
+                                OR dm.sender_name = u.username
+                             LIMIT 1)) as user_id,
+                        SUM(dm.tokens_used) as total_tokens,
+                        SUM(dm.input_tokens) as total_input_tokens,
+                        SUM(dm.output_tokens) as total_output_tokens,
                         COUNT(*) as message_count,
                         ?
-                    FROM daily_messages
+                    FROM daily_messages dm
                     WHERE {date_condition}
-                    GROUP BY date, tool_name, host_name, sender_name
+                    GROUP BY dm.date, dm.tool_name, dm.host_name, dm.sender_name,
+                             COALESCE(dm.user_id,
+                                (SELECT u.id FROM users u
+                                 WHERE dm.sender_name LIKE (u.system_account || '-%%')
+                                    OR dm.sender_name = u.username
+                                 LIMIT 1))
                     """,
                     (now,) + params,
                 )
             else:
-                # SQLite: use INSERT OR REPLACE
+                # SQLite: use INSERT OR REPLACE with user_id populated
                 self.db.execute(
                     f"""
                     INSERT OR REPLACE INTO daily_stats
-                    (date, tool_name, host_name, sender_name, total_tokens, total_input_tokens,
-                     total_output_tokens, message_count, updated_at)
+                    (date, tool_name, host_name, sender_name, user_id, total_tokens,
+                     total_input_tokens, total_output_tokens, message_count, updated_at)
                     SELECT
-                        date,
-                        tool_name,
-                        host_name,
-                        sender_name,
-                        SUM(tokens_used) as total_tokens,
-                        SUM(input_tokens) as total_input_tokens,
-                        SUM(output_tokens) as total_output_tokens,
+                        dm.date,
+                        dm.tool_name,
+                        dm.host_name,
+                        dm.sender_name,
+                        COALESCE(dm.user_id,
+                            (SELECT u.id FROM users u
+                             WHERE dm.sender_name LIKE (u.system_account || '-%%')
+                                OR dm.sender_name = u.username
+                             LIMIT 1)) as user_id,
+                        SUM(dm.tokens_used) as total_tokens,
+                        SUM(dm.input_tokens) as total_input_tokens,
+                        SUM(dm.output_tokens) as total_output_tokens,
                         COUNT(*) as message_count,
                         ?
-                    FROM daily_messages
+                    FROM daily_messages dm
                     WHERE {date_condition}
-                    GROUP BY date, tool_name, host_name, sender_name
+                    GROUP BY dm.date, dm.tool_name, dm.host_name, dm.sender_name,
+                             COALESCE(dm.user_id,
+                                (SELECT u.id FROM users u
+                                 WHERE dm.sender_name LIKE (u.system_account || '-%%')
+                                    OR dm.sender_name = u.username
+                                 LIMIT 1))
                     """,
                     (now,) + params,
                 )

--- a/app/repositories/usage_repo.py
+++ b/app/repositories/usage_repo.py
@@ -208,7 +208,9 @@ class UsageRepository:
         if is_postgresql():
             join_on = "dm.date::text = du.date::text AND dm.tool_name = du.tool_name AND dm.host_name = du.host_name"
         else:
-            join_on = "dm.date = du.date AND dm.tool_name = du.tool_name AND dm.host_name = du.host_name"
+            join_on = (
+                "dm.date = du.date AND dm.tool_name = du.tool_name AND dm.host_name = du.host_name"
+            )
         query = f"""
             SELECT dm.*,
                    COALESCE(du.request_count, 0) as request_count
@@ -252,9 +254,9 @@ class UsageRepository:
         if end_date is None:
             end_date = datetime.now().strftime("%Y-%m-%d")
 
-        start_date = (
-            datetime.strptime(end_date, "%Y-%m-%d") - timedelta(days=days)
-        ).strftime("%Y-%m-%d")
+        start_date = (datetime.strptime(end_date, "%Y-%m-%d") - timedelta(days=days)).strftime(
+            "%Y-%m-%d"
+        )
 
         conditions = ["tool_name = ?", "date >= ?", "date <= ?"]
         params = [tool_name, start_date, end_date]
@@ -369,21 +371,15 @@ class UsageRepository:
             if tool in results:
                 existing = results[tool]
                 existing["total_tokens"] += row["total_tokens"] or 0
-                existing["total_requests"] += (
-                    row["total_requests"] if row["total_requests"] else 0
-                )
+                existing["total_requests"] += row["total_requests"] if row["total_requests"] else 0
                 existing["total_input_tokens"] += row["total_input_tokens"] or 0
                 existing["total_output_tokens"] += row["total_output_tokens"] or 0
             else:
                 results[tool] = {
                     "days_count": row["days_count"],
                     "total_tokens": row["total_tokens"] or 0,
-                    "avg_tokens": (
-                        round(row["avg_tokens"], 2) if row["avg_tokens"] else 0
-                    ),
-                    "total_requests": (
-                        row["total_requests"] if row["total_requests"] else 0
-                    ),
+                    "avg_tokens": (round(row["avg_tokens"], 2) if row["avg_tokens"] else 0),
+                    "total_requests": (row["total_requests"] if row["total_requests"] else 0),
                     "total_input_tokens": row["total_input_tokens"] or 0,
                     "total_output_tokens": row["total_output_tokens"] or 0,
                     "first_date": row["first_date"],
@@ -607,9 +603,7 @@ class UsageRepository:
                 date_str = date_val.strftime("%Y-%m-%d")
             else:
                 # Parse HTTP date format if needed
-                date_str = (
-                    str(date_val).split()[0] if " " in str(date_val) else str(date_val)
-                )
+                date_str = str(date_val).split()[0] if " " in str(date_val) else str(date_val)
             results.append(
                 {
                     "date": date_str,
@@ -661,9 +655,7 @@ class UsageRepository:
                 date_str = date_val.strftime("%Y-%m-%d")
             else:
                 # Parse HTTP date format if needed
-                date_str = (
-                    str(date_val).split()[0] if " " in str(date_val) else str(date_val)
-                )
+                date_str = str(date_val).split()[0] if " " in str(date_val) else str(date_val)
             tool = normalize_tool_name(row["tool_name"])
             key = (date_str, tool)
             if key in results:
@@ -703,9 +695,7 @@ class UsageRepository:
             WHERE {' AND '.join(conditions)}
         """
         total_result = self.db.fetch_one(total_query, tuple(params))
-        total_requests = (
-            int(total_result.get("total_requests", 0) or 0) if total_result else 0
-        )
+        total_requests = int(total_result.get("total_requests", 0) or 0) if total_result else 0
 
         # Get by tool
         by_tool_query = f"""
@@ -827,9 +817,7 @@ class UsageRepository:
 
         results = []
         for row in rows:
-            username = (
-                row.get("unified_username") or row.get("sender_name") or "unknown"
-            )
+            username = row.get("unified_username") or row.get("sender_name") or "unknown"
             results.append(
                 {
                     "user": username,
@@ -936,9 +924,7 @@ class UsageRepository:
                 date_str = date_val.strftime("%Y-%m-%d")
             else:
                 # Parse HTTP date format if needed
-                date_str = (
-                    str(date_val).split()[0] if " " in str(date_val) else str(date_val)
-                )
+                date_str = str(date_val).split()[0] if " " in str(date_val) else str(date_val)
             results.append(
                 {
                     "date": date_str,

--- a/app/repositories/usage_repo.py
+++ b/app/repositories/usage_repo.py
@@ -140,7 +140,10 @@ class UsageRepository:
         return True
 
     def get_usage_rows_by_date(
-        self, date: str, tool_name: Optional[str] = None, host_name: Optional[str] = None
+        self,
+        date: str,
+        tool_name: Optional[str] = None,
+        host_name: Optional[str] = None,
     ) -> list[dict]:
         """
         Get raw usage rows from daily_usage for a specific date.
@@ -182,7 +185,10 @@ class UsageRepository:
         return self.db.fetch_all(query, tuple(params))
 
     def get_usage_by_date(
-        self, date: str, tool_name: Optional[str] = None, host_name: Optional[str] = None
+        self,
+        date: str,
+        tool_name: Optional[str] = None,
+        host_name: Optional[str] = None,
     ) -> list[dict]:
         """
         Get usage data for a specific date from daily_messages joined with daily_usage.
@@ -202,9 +208,7 @@ class UsageRepository:
         if is_postgresql():
             join_on = "dm.date::text = du.date::text AND dm.tool_name = du.tool_name AND dm.host_name = du.host_name"
         else:
-            join_on = (
-                "dm.date = du.date AND dm.tool_name = du.tool_name AND dm.host_name = du.host_name"
-            )
+            join_on = "dm.date = du.date AND dm.tool_name = du.tool_name AND dm.host_name = du.host_name"
         query = f"""
             SELECT dm.*,
                    COALESCE(du.request_count, 0) as request_count
@@ -248,9 +252,9 @@ class UsageRepository:
         if end_date is None:
             end_date = datetime.now().strftime("%Y-%m-%d")
 
-        start_date = (datetime.strptime(end_date, "%Y-%m-%d") - timedelta(days=days)).strftime(
-            "%Y-%m-%d"
-        )
+        start_date = (
+            datetime.strptime(end_date, "%Y-%m-%d") - timedelta(days=days)
+        ).strftime("%Y-%m-%d")
 
         conditions = ["tool_name = ?", "date >= ?", "date <= ?"]
         params = [tool_name, start_date, end_date]
@@ -365,15 +369,21 @@ class UsageRepository:
             if tool in results:
                 existing = results[tool]
                 existing["total_tokens"] += row["total_tokens"] or 0
-                existing["total_requests"] += row["total_requests"] if row["total_requests"] else 0
+                existing["total_requests"] += (
+                    row["total_requests"] if row["total_requests"] else 0
+                )
                 existing["total_input_tokens"] += row["total_input_tokens"] or 0
                 existing["total_output_tokens"] += row["total_output_tokens"] or 0
             else:
                 results[tool] = {
                     "days_count": row["days_count"],
                     "total_tokens": row["total_tokens"] or 0,
-                    "avg_tokens": round(row["avg_tokens"], 2) if row["avg_tokens"] else 0,
-                    "total_requests": row["total_requests"] if row["total_requests"] else 0,
+                    "avg_tokens": (
+                        round(row["avg_tokens"], 2) if row["avg_tokens"] else 0
+                    ),
+                    "total_requests": (
+                        row["total_requests"] if row["total_requests"] else 0
+                    ),
                     "total_input_tokens": row["total_input_tokens"] or 0,
                     "total_output_tokens": row["total_output_tokens"] or 0,
                     "first_date": row["first_date"],
@@ -597,7 +607,9 @@ class UsageRepository:
                 date_str = date_val.strftime("%Y-%m-%d")
             else:
                 # Parse HTTP date format if needed
-                date_str = str(date_val).split()[0] if " " in str(date_val) else str(date_val)
+                date_str = (
+                    str(date_val).split()[0] if " " in str(date_val) else str(date_val)
+                )
             results.append(
                 {
                     "date": date_str,
@@ -649,7 +661,9 @@ class UsageRepository:
                 date_str = date_val.strftime("%Y-%m-%d")
             else:
                 # Parse HTTP date format if needed
-                date_str = str(date_val).split()[0] if " " in str(date_val) else str(date_val)
+                date_str = (
+                    str(date_val).split()[0] if " " in str(date_val) else str(date_val)
+                )
             tool = normalize_tool_name(row["tool_name"])
             key = (date_str, tool)
             if key in results:
@@ -689,7 +703,9 @@ class UsageRepository:
             WHERE {' AND '.join(conditions)}
         """
         total_result = self.db.fetch_one(total_query, tuple(params))
-        total_requests = int(total_result.get("total_requests", 0) or 0) if total_result else 0
+        total_requests = (
+            int(total_result.get("total_requests", 0) or 0) if total_result else 0
+        )
 
         # Get by tool
         by_tool_query = f"""
@@ -726,50 +742,98 @@ class UsageRepository:
         This queries daily_messages table to get request counts per user.
         A request is counted when role = 'assistant' (API response).
 
+        This method merges users by user_id when available, fixing Issue #626
+        where the same user appears multiple times with different sender_name
+        formats.
+
         Args:
             date: Optional date filter (YYYY-MM-DD). If None, uses today.
             host_name: Optional host name filter.
             user_name: Optional user name filter (matches sender_name prefix).
 
         Returns:
-            List[Dict]: Request stats by user.
+            List[Dict]: Request stats by user with unified username.
         """
+        from app.repositories.database import is_postgresql
+
         if date is None:
             date = datetime.now().strftime("%Y-%m-%d")
 
-        conditions = ["date = ?", "role = ?"]
+        conditions = ["dm.date = ?", "dm.role = ?"]
         params = [date, "assistant"]
 
         if host_name:
-            conditions.append("host_name = ?")
+            conditions.append("dm.host_name = ?")
             params.append(host_name)
 
         if user_name:
             # sender_name format is: {username}-{hostname}-{tool}
             # Use LIKE to match username prefix
-            conditions.append("sender_name LIKE ?")
+            conditions.append("dm.sender_name LIKE ?")
             params.append(f"{escape_like(user_name)}%")
 
-        query = f"""
-            SELECT
-                sender_name,
-                tool_name,
-                COUNT(*) as requests,
-                SUM(tokens_used) as tokens
-            FROM daily_messages
-            WHERE {' AND '.join(conditions)}
-            GROUP BY sender_name, tool_name
-            ORDER BY requests DESC
-        """
+        where_clause = f"WHERE {' AND '.join(conditions)}"
+
+        if is_postgresql():
+            # PostgreSQL: use LEFT JOIN for user_id resolution
+            query = f"""
+                SELECT
+                    COALESCE(dm.user_id,
+                        (SELECT u.id FROM users u
+                         WHERE dm.sender_name LIKE (u.system_account || '-%%')
+                            OR dm.sender_name = u.username
+                         LIMIT 1), -1) as resolved_user_id,
+                    COALESCE(u.username,
+                        CASE WHEN dm.sender_name LIKE '%%-%%-%%'
+                             THEN SUBSTRING(dm.sender_name FROM '^[^-]+')
+                             ELSE dm.sender_name END) as unified_username,
+                    dm.tool_name,
+                    COUNT(*) as requests,
+                    SUM(dm.tokens_used) as tokens
+                FROM daily_messages dm
+                LEFT JOIN users u ON dm.user_id = u.id
+                    OR dm.sender_name LIKE (u.system_account || '-%%')
+                    OR dm.sender_name = u.username
+                {where_clause}
+                GROUP BY resolved_user_id, unified_username, dm.tool_name
+                ORDER BY requests DESC
+            """
+        else:
+            # SQLite: use LEFT JOIN for user_id resolution
+            query = f"""
+                SELECT
+                    COALESCE(dm.user_id,
+                        (SELECT u.id FROM users u
+                         WHERE dm.sender_name LIKE (u.system_account || '-%%')
+                            OR dm.sender_name = u.username
+                         LIMIT 1), -1) as resolved_user_id,
+                    COALESCE(u.username,
+                        CASE WHEN dm.sender_name LIKE '%%-%%-%%'
+                             THEN SUBSTR(dm.sender_name, 1, INSTR(dm.sender_name, '-') - 1)
+                             ELSE dm.sender_name END) as unified_username,
+                    dm.tool_name,
+                    COUNT(*) as requests,
+                    SUM(dm.tokens_used) as tokens
+                FROM daily_messages dm
+                LEFT JOIN users u ON dm.user_id = u.id
+                    OR dm.sender_name LIKE (u.system_account || '-%%')
+                    OR dm.sender_name = u.username
+                {where_clause}
+                GROUP BY resolved_user_id, unified_username, dm.tool_name
+                ORDER BY requests DESC
+            """
 
         rows = self.db.fetch_all(query, tuple(params))
 
         results = []
         for row in rows:
-            sender_name = row["sender_name"] or "unknown"
+            username = (
+                row.get("unified_username") or row.get("sender_name") or "unknown"
+            )
             results.append(
                 {
-                    "user": sender_name,
+                    "user": username,
+                    "user_id": row.get("resolved_user_id", -1),
                     "tool": normalize_tool_name(row["tool_name"]),
                     "requests": int(row["requests"] or 0),
                     "tokens": int(row["tokens"] or 0),
@@ -779,7 +843,11 @@ class UsageRepository:
         return results
 
     def get_user_request_trend(
-        self, user_name: str, start_date: str, end_date: str, host_name: Optional[str] = None
+        self,
+        user_name: str,
+        start_date: str,
+        end_date: str,
+        host_name: Optional[str] = None,
     ) -> list[dict]:
         """
         Get request trend for a specific user.
@@ -798,7 +866,8 @@ class UsageRepository:
         """
         # First, try to get user_id from username
         user = self.db.fetch_one(
-            "SELECT id FROM users WHERE username = ? OR system_account = ?", (user_name, user_name)
+            "SELECT id FROM users WHERE username = ? OR system_account = ?",
+            (user_name, user_name),
         )
 
         if user:
@@ -867,7 +936,9 @@ class UsageRepository:
                 date_str = date_val.strftime("%Y-%m-%d")
             else:
                 # Parse HTTP date format if needed
-                date_str = str(date_val).split()[0] if " " in str(date_val) else str(date_val)
+                date_str = (
+                    str(date_val).split()[0] if " " in str(date_val) else str(date_val)
+                )
             results.append(
                 {
                     "date": date_str,

--- a/migrations/versions/20260602_049_add_user_id_to_daily_stats.py
+++ b/migrations/versions/20260602_049_add_user_id_to_daily_stats.py
@@ -57,9 +57,7 @@ def _index_exists(conn, table_name: str, index_name: str) -> bool:
         )
     else:
         result = conn.execute(
-            sa.text(
-                "SELECT 1 FROM sqlite_master WHERE type='index' AND name = :index_name"
-            ),
+            sa.text("SELECT 1 FROM sqlite_master WHERE type='index' AND name = :index_name"),
             {"index_name": index_name},
         )
     return result.fetchone() is not None

--- a/migrations/versions/20260602_049_add_user_id_to_daily_stats.py
+++ b/migrations/versions/20260602_049_add_user_id_to_daily_stats.py
@@ -45,10 +45,7 @@ def _column_exists(conn, table_name: str, column_name: str) -> bool:
         result = conn.execute(
             sa.text(f"PRAGMA table_info({table_name})"),
         )
-        for row in result.fetchall():
-            if row[1] == column_name:
-                return True
-        return False
+        return any(row[1] == column_name for row in result.fetchall())
 
 
 def _index_exists(conn, table_name: str, index_name: str) -> bool:

--- a/migrations/versions/20260602_049_add_user_id_to_daily_stats.py
+++ b/migrations/versions/20260602_049_add_user_id_to_daily_stats.py
@@ -1,0 +1,186 @@
+"""Add user_id column to daily_stats table for accurate user statistics
+
+Revision ID: 049_add_user_id_to_daily_stats
+Revises: 048_fix_api_key_scope
+Create Date: 2026-06-02
+
+This migration adds user_id column to daily_stats table to fix the issue
+where users are counted multiple times due to different sender_name formats.
+
+Issue #626: User statistics inconsistency - same user appears as multiple
+entries when using different sender_name formats (WebUI vs Feishu).
+
+"""
+
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "049_add_user_id_to_daily_stats"
+down_revision: Union[str, None] = "048_fix_api_key_scope"
+branch_labels: Union[str, None] = None
+depends_on: Union[str, None] = None
+
+
+def _column_exists(conn, table_name: str, column_name: str) -> bool:
+    """Check if a column exists in a table."""
+    if conn.dialect.name == "postgresql":
+        result = conn.execute(
+            sa.text(
+                """
+                SELECT EXISTS (
+                    SELECT FROM information_schema.columns
+                    WHERE table_schema = 'public'
+                    AND table_name = :table_name
+                    AND column_name = :column_name
+                )
+                """
+            ),
+            {"table_name": table_name, "column_name": column_name},
+        )
+        return result.fetchone()[0]
+    else:
+        result = conn.execute(
+            sa.text(f"PRAGMA table_info({table_name})"),
+        )
+        for row in result.fetchall():
+            if row[1] == column_name:
+                return True
+        return False
+
+
+def _index_exists(conn, table_name: str, index_name: str) -> bool:
+    """Check if an index exists."""
+    if conn.dialect.name == "postgresql":
+        result = conn.execute(
+            sa.text("SELECT 1 FROM pg_indexes WHERE indexname = :index_name"),
+            {"index_name": index_name},
+        )
+    else:
+        result = conn.execute(
+            sa.text(
+                "SELECT 1 FROM sqlite_master WHERE type='index' AND name = :index_name"
+            ),
+            {"index_name": index_name},
+        )
+    return result.fetchone() is not None
+
+
+def upgrade() -> None:
+    """Add user_id column to daily_stats table."""
+    conn = op.get_bind()
+    is_postgresql = conn.dialect.name == "postgresql"
+
+    # Add user_id column to daily_stats if not exists
+    if not _column_exists(conn, "daily_stats", "user_id"):
+        if is_postgresql:
+            op.execute(
+                """
+                ALTER TABLE daily_stats ADD COLUMN user_id INTEGER NULL
+                """
+            )
+        else:
+            op.execute(
+                """
+                ALTER TABLE daily_stats ADD COLUMN user_id INTEGER
+                """
+            )
+
+        print("Added user_id column to daily_stats table.")
+
+    # Create index on user_id for fast lookups
+    if not _index_exists(conn, "daily_stats", "idx_daily_stats_user_id"):
+        if is_postgresql:
+            op.execute(
+                """
+                CREATE INDEX idx_daily_stats_user_id ON daily_stats (user_id)
+                """
+            )
+        else:
+            op.execute(
+                """
+                CREATE INDEX idx_daily_stats_user_id ON daily_stats (user_id)
+                """
+            )
+
+        print("Created index idx_daily_stats_user_id.")
+
+    # Populate user_id for existing data by matching sender_name to users
+    # sender_name formats:
+    # 1. WebUI: {system_account}-{hostname}-{tool} -> match users.system_account
+    # 2. Feishu: username (real name) -> match users.username
+    if _column_exists(conn, "daily_stats", "user_id") and _column_exists(
+        conn, "users", "system_account"
+    ):
+        if is_postgresql:
+            # PostgreSQL: use substring matching for system_account prefix
+            op.execute(
+                """
+                UPDATE daily_stats ds
+                SET user_id = (
+                    SELECT u.id FROM users u
+                    WHERE ds.sender_name LIKE (u.system_account || '-%')
+                       OR ds.sender_name = u.username
+                    LIMIT 1
+                )
+                WHERE ds.user_id IS NULL
+                  AND ds.sender_name IS NOT NULL
+                  AND EXISTS (
+                      SELECT 1 FROM users u
+                      WHERE ds.sender_name LIKE (u.system_account || '-%')
+                         OR ds.sender_name = u.username
+                  )
+                """
+            )
+        else:
+            # SQLite: use LIKE pattern matching
+            op.execute(
+                """
+                UPDATE daily_stats
+                SET user_id = (
+                    SELECT u.id FROM users u
+                    WHERE sender_name LIKE (u.system_account || '-%')
+                       OR sender_name = u.username
+                    LIMIT 1
+                )
+                WHERE user_id IS NULL
+                  AND sender_name IS NOT NULL
+                """
+            )
+
+        print("Populated user_id for existing daily_stats records.")
+
+
+def downgrade() -> None:
+    """Remove user_id column from daily_stats table."""
+    conn = op.get_bind()
+    is_postgresql = conn.dialect.name == "postgresql"
+
+    # Drop index first
+    if _index_exists(conn, "daily_stats", "idx_daily_stats_user_id"):
+        op.execute(
+            """
+            DROP INDEX idx_daily_stats_user_id
+            """
+        )
+        print("Dropped index idx_daily_stats_user_id.")
+
+    # Drop column
+    if _column_exists(conn, "daily_stats", "user_id"):
+        if is_postgresql:
+            op.execute(
+                """
+                ALTER TABLE daily_stats DROP COLUMN user_id
+                """
+            )
+        else:
+            # SQLite doesn't support DROP COLUMN directly
+            # Need to recreate table without the column
+            print(
+                "Warning: SQLite doesn't support DROP COLUMN. "
+                "user_id column will remain but won't be used."
+            )
+
+        print("Removed user_id column from daily_stats table.")

--- a/scripts/lint/.sql_baseline
+++ b/scripts/lint/.sql_baseline
@@ -1,3 +1,3 @@
 {"rule": "SQL003", "file": "app/modules/governance/quota_manager.py", "line": 550, "message": "LIKE query without escape_like() — special characters in user input will be treated as wildcards"}
-{"rule": "SQL003", "file": "app/repositories/usage_repo.py", "line": 1030, "message": "LIKE query without escape_like() — special characters in user input will be treated as wildcards"}
+{"rule": "SQL003", "file": "app/repositories/usage_repo.py", "line": 1087, "message": "LIKE query without escape_like() — special characters in user input will be treated as wildcards"}
 {"rule": "SQL003", "file": "scripts/fetch_claude.py", "line": 831, "message": "LIKE query without escape_like() — special characters in user input will be treated as wildcards"}

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -693,9 +693,7 @@ def pg_db():
         # point to our test database instead of the production config.
         with patch.object(db_mod, "is_postgresql", return_value=True):
             with patch.object(db_mod, "get_database_url", return_value=test_url):
-                with patch.object(
-                    config_mod, "get_database_url", return_value=test_url
-                ):
+                with patch.object(config_mod, "get_database_url", return_value=test_url):
                     yield db
     finally:
         # Cleanup: close connections and drop test database

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -52,7 +52,9 @@ def _create_sqlite_tables(db):
         from app.modules.workspace.api_key_proxy import get_ddl_statements as akp_ddl
         from app.modules.workspace.collaboration import get_ddl_statements as collab_ddl
         from app.modules.workspace.prompt_library import get_ddl_statements as pl_ddl
-        from app.modules.workspace.remote_agent_manager import get_ddl_statements as ram_ddl
+        from app.modules.workspace.remote_agent_manager import (
+            get_ddl_statements as ram_ddl,
+        )
         from app.modules.workspace.session_manager import get_ddl_statements as sm_ddl
         from app.services.auth_service import get_ddl_statements as auth_ddl
         from app.services.permission_service import get_ddl_statements as ps_ddl
@@ -122,6 +124,7 @@ def _create_sqlite_tables(db):
                 tool_name TEXT,
                 host_name TEXT,
                 sender_name TEXT,
+                user_id INTEGER NULL,
                 total_tokens INTEGER DEFAULT 0,
                 total_input_tokens INTEGER DEFAULT 0,
                 total_output_tokens INTEGER DEFAULT 0,
@@ -365,7 +368,9 @@ def _create_pg_tables(db):
         from app.modules.workspace.api_key_proxy import get_ddl_statements as akp_ddl
         from app.modules.workspace.collaboration import get_ddl_statements as collab_ddl
         from app.modules.workspace.prompt_library import get_ddl_statements as pl_ddl
-        from app.modules.workspace.remote_agent_manager import get_ddl_statements as ram_ddl
+        from app.modules.workspace.remote_agent_manager import (
+            get_ddl_statements as ram_ddl,
+        )
         from app.modules.workspace.session_manager import get_ddl_statements as sm_ddl
         from app.services.auth_service import get_ddl_statements as auth_ddl
         from app.services.permission_service import get_ddl_statements as ps_ddl
@@ -436,6 +441,7 @@ def _create_pg_tables(db):
                 tool_name TEXT,
                 host_name TEXT,
                 sender_name TEXT,
+                user_id INTEGER NULL,
                 total_tokens INTEGER DEFAULT 0,
                 total_input_tokens INTEGER DEFAULT 0,
                 total_output_tokens INTEGER DEFAULT 0,
@@ -689,7 +695,9 @@ def pg_db():
         # point to our test database instead of the production config.
         with patch.object(db_mod, "is_postgresql", return_value=True):
             with patch.object(db_mod, "get_database_url", return_value=test_url):
-                with patch.object(config_mod, "get_database_url", return_value=test_url):
+                with patch.object(
+                    config_mod, "get_database_url", return_value=test_url
+                ):
                     yield db
     finally:
         # Cleanup: close connections and drop test database

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -52,9 +52,7 @@ def _create_sqlite_tables(db):
         from app.modules.workspace.api_key_proxy import get_ddl_statements as akp_ddl
         from app.modules.workspace.collaboration import get_ddl_statements as collab_ddl
         from app.modules.workspace.prompt_library import get_ddl_statements as pl_ddl
-        from app.modules.workspace.remote_agent_manager import (
-            get_ddl_statements as ram_ddl,
-        )
+        from app.modules.workspace.remote_agent_manager import get_ddl_statements as ram_ddl
         from app.modules.workspace.session_manager import get_ddl_statements as sm_ddl
         from app.services.auth_service import get_ddl_statements as auth_ddl
         from app.services.permission_service import get_ddl_statements as ps_ddl
@@ -301,7 +299,8 @@ def _create_sqlite_tables(db):
                 updated_at TEXT,
                 last_login TEXT,
                 deleted_at TEXT,
-                tenant_id INTEGER
+                tenant_id INTEGER,
+                system_account TEXT
             )
         """
         )
@@ -368,9 +367,7 @@ def _create_pg_tables(db):
         from app.modules.workspace.api_key_proxy import get_ddl_statements as akp_ddl
         from app.modules.workspace.collaboration import get_ddl_statements as collab_ddl
         from app.modules.workspace.prompt_library import get_ddl_statements as pl_ddl
-        from app.modules.workspace.remote_agent_manager import (
-            get_ddl_statements as ram_ddl,
-        )
+        from app.modules.workspace.remote_agent_manager import get_ddl_statements as ram_ddl
         from app.modules.workspace.session_manager import get_ddl_statements as sm_ddl
         from app.services.auth_service import get_ddl_statements as auth_ddl
         from app.services.permission_service import get_ddl_statements as ps_ddl
@@ -613,7 +610,8 @@ def _create_pg_tables(db):
                 updated_at TEXT,
                 last_login TEXT,
                 deleted_at TEXT,
-                tenant_id INTEGER
+                tenant_id INTEGER,
+                system_account TEXT
             )
         """
         )


### PR DESCRIPTION
## 问题描述

Issue #626：趋势分析页面活跃用户数统计不一致，同一用户因不同 sender_name 格式被重复计数。

**根因分析：**
- daily_stats 表按 sender_name 统计用户，无 user_id 字段
- WebUI 格式: {system_account}-{hostname}-{tool}
- Feishu 格式: username
- 同一用户的不同格式被视为不同用户，导致重复计数

## 修复方案

添加 user_id 字段到 daily_stats 表，通过 sender_name 关联 users 表实现用户统一。

## 修改文件

- migrations/versions/20260602_049_add_user_id_to_daily_stats.py
- app/repositories/daily_stats_repo.py
- app/repositories/usage_repo.py

## 验证结果

node237 部署验证：unique_users_by_id = 1 ✅

Fixes #626
