### PR TITLE
Improve open source onboarding and trust signals

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,28 +1,7 @@
-# CODEOWNERS - Define code owners for pull request reviews
+# CODEOWNERS
 #
-# For more information, see:
-# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
-
-# Default owners for everything
-* @your-username
-
-# Core scripts
-/scripts/ @your-username
-
-# Shared modules
-/scripts/shared/ @your-username
-
-# Web interface
-/web.py @your-username
-/templates/ @your-username
-/static/ @your-username
-
-# Documentation
-/docs/ @your-username
-/README.md @your-username
-
-# Tests
-/tests/ @your-username
-
-# CI/CD
-/.github/ @your-username
+# Add active ownership rules once the Open ACE GitHub organization has
+# maintainer teams or users ready for required review assignment.
+#
+# Example:
+# * @open-ace/maintainers

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: 📖 Documentation
-    url: https://github.com/your-org/open-ace/tree/main/docs
+    url: https://github.com/open-ace/open-ace/tree/main/docs
     about: Check the documentation for usage guides and API reference
   - name: 💬 Discussions
-    url: https://github.com/your-org/open-ace/discussions
+    url: https://github.com/open-ace/open-ace/discussions
     about: Ask questions and discuss with the community

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -17,7 +17,7 @@ We take the security of Open ACE seriously. If you have discovered a security vu
 Instead, please report them via:
 
 1. **GitHub Security Advisories** (Preferred)
-   - Go to the [Security Advisories](https://github.com/your-org/open-ace/security/advisories) page
+   - Go to the [Security Advisories](https://github.com/open-ace/open-ace/security/advisories) page
    - Click "Report a vulnerability"
    - Fill in the details
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,6 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
-    reviewers:
-      - "your-username"
     labels:
       - "dependencies"
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,14 @@
   <img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg" alt="License">
   <img src="https://img.shields.io/badge/Python-3.9%2B-green.svg" alt="Python">
   <img src="https://img.shields.io/badge/React-18.3-61DAFB.svg" alt="React">
-  <img src="https://img.shields.io/badge/Flask-3.x-orange.svg" alt="Flask">
+  <img src="https://img.shields.io/badge/Flask-2.x-orange.svg" alt="Flask">
+</p>
+
+<p align="center">
+  <a href="https://www.open-ace.com">Website</a> ·
+  <a href="docs/README.md">Docs</a> ·
+  <a href="ROADMAP.md">Roadmap</a> ·
+  <a href="https://github.com/open-ace/open-ace/discussions">Discussions</a>
 </p>
 
 ---
@@ -26,12 +33,20 @@
 
 ## 🎯 这是什么？
 
-**Open ACE** 是一个开源的**企业级 AI 工作平台**，解决企业在 AI 应用中的两大核心问题：
+**Open ACE** 是一个开源的**企业级 AI 工作平台**：一边给团队成员提供统一的 AI 工作入口，一边给管理员提供用量、成本、权限、合规和审计视图。
+
+它适合正在把 Claude Code、Qwen Code、Codex、OpenClaw 等 AI 工具引入团队的组织，尤其适合需要私有化部署、统一治理和可量化 ROI 的研发团队、IT 团队和 AI 平台团队。
 
 | 问题 | 解决方案 |
 |------|----------|
 | 🤔 **AI 用得好不好？** | Work 模式让员工高效使用 AI，提升生产力 |
 | 😰 **AI 管得住管不住？** | Manage 模式让管理者全面掌控 AI 使用情况 |
+
+**你可以用 Open ACE 做什么：**
+
+- 给员工一个统一入口，管理 AI 会话、提示词、历史记录和远程工作区
+- 给管理者一套治理面板，查看 Token、成本、异常、配额、审计和 ROI
+- 在自己的网络里部署，保留企业数据边界，并逐步接入 SSO、飞书/钉钉和 Kubernetes
 
 ## ✨ 两种模式，双重价值
 
@@ -127,7 +142,7 @@ python3 web.py
 |------|--------|------|
 | 管理员 | admin | admin123 |
 
-> ⚠️ 生产环境请务必修改默认密码！
+> ⚠️ 默认账号仅用于本地首次启动。生产环境请务必设置 `SECRET_KEY`、修改默认密码，并参考 [部署指南](docs/cn/DEPLOYMENT.md) 完成安全配置。
 
 ---
 
@@ -227,11 +242,11 @@ open-ace/
 
 | 文档 | 说明 |
 |------|------|
-| [架构说明](docs/ARCHITECTURE.md) | 系统架构与核心概念 |
-| [部署指南](docs/DEPLOYMENT.md) | 本地与生产环境部署 |
-| [开发指南](docs/DEVELOPMENT.md) | 参与开发 |
-| [飞书配置](docs/FEISHU_CONFIG.md) | 飞书集成配置 |
-| [API 文档](docs/API.md) | API 接口说明 |
+| [架构说明](docs/cn/ARCHITECTURE.md) | 系统架构与核心概念 |
+| [部署指南](docs/cn/DEPLOYMENT.md) | 本地与生产环境部署 |
+| [开发指南](docs/cn/DEVELOPMENT.md) | 参与开发 |
+| [飞书配置](docs/cn/FEISHU_CONFIG.md) | 飞书集成配置 |
+| [API 文档](docs/cn/API.md) | API 接口说明 |
 
 ---
 
@@ -241,6 +256,7 @@ open-ace/
 
 - 🐛 发现 Bug？[提交 Issue](https://github.com/open-ace/open-ace/issues)
 - 💡 有想法？[参与讨论](https://github.com/open-ace/open-ace/discussions)
+- 🗺️ 想了解计划？查看 [Roadmap](ROADMAP.md)
 - 🔧 想贡献代码？阅读 [贡献指南](CONTRIBUTING.md)
 
 ---
@@ -262,12 +278,20 @@ open-ace/
 
 ## 🎯 What is This?
 
-**Open ACE** is an open-source **Enterprise AI Work Platform** that solves two core challenges in enterprise AI adoption:
+**Open ACE** is an open-source **Enterprise AI Work Platform**: it gives employees a unified AI work entry point and gives administrators visibility into usage, cost, access control, compliance, and audit trails.
+
+It is built for teams adopting tools such as Claude Code, Qwen Code, Codex, and OpenClaw, especially organizations that need self-hosted deployment, centralized governance, and measurable AI ROI.
 
 | Challenge | Solution |
 |-----------|----------|
 | 🤔 **Are we using AI effectively?** | Work Mode empowers employees to use AI efficiently and boost productivity |
 | 😰 **Is AI under control?** | Manage Mode gives administrators full visibility and control over AI usage |
+
+**What you can do with Open ACE:**
+
+- Give employees one workspace for AI sessions, prompts, history, and remote workspaces
+- Give administrators dashboards for tokens, cost, anomalies, quotas, audits, and ROI
+- Deploy inside your own network while integrating SSO, Feishu/DingTalk, and Kubernetes over time
 
 ## ✨ Two Modes, Double Value
 
@@ -363,7 +387,7 @@ python3 web.py
 |------|----------|----------|
 | Admin | admin | admin123 |
 
-> ⚠️ Please change the default password in production!
+> ⚠️ The default account is only for the first local startup. For production, set `SECRET_KEY`, change the default password, and follow the [Deployment Guide](docs/en/DEPLOYMENT.md).
 
 ---
 
@@ -463,11 +487,11 @@ open-ace/
 
 | Document | Description |
 |----------|-------------|
-| [Architecture](docs/ARCHITECTURE.md) | System architecture and concepts |
-| [Deployment](docs/DEPLOYMENT.md) | Local and production deployment |
-| [Development](docs/DEVELOPMENT.md) | Contributing guide |
-| [Feishu Config](docs/FEISHU_CONFIG.md) | Feishu integration |
-| [API Reference](docs/API.md) | API documentation |
+| [Architecture](docs/en/ARCHITECTURE.md) | System architecture and concepts |
+| [Deployment](docs/en/DEPLOYMENT.md) | Local and production deployment |
+| [Development](docs/en/DEVELOPMENT.md) | Contributing guide |
+| [Feishu Config](docs/en/FEISHU_CONFIG.md) | Feishu integration |
+| [API Reference](docs/en/API.md) | API documentation |
 
 ---
 
@@ -477,6 +501,7 @@ We welcome all forms of contribution!
 
 - 🐛 Found a bug? [Submit an Issue](https://github.com/open-ace/open-ace/issues)
 - 💡 Have an idea? [Join the discussion](https://github.com/open-ace/open-ace/discussions)
+- 🗺️ Want to see what's next? Read the [Roadmap](ROADMAP.md)
 - 🔧 Want to contribute code? Read the [Contributing Guide](CONTRIBUTING.md)
 
 ---

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,31 @@
+# Open ACE Roadmap
+
+This roadmap describes the near-term work that will make Open ACE easier to try, trust, deploy, and contribute to. It is intentionally practical: each item should improve adoption or reduce friction for real users.
+
+## Now
+
+- Make the first-run experience reliable with Docker Compose, SQLite/PostgreSQL setup, and clear default credential handling.
+- Keep README, website, and documentation links in sync across Chinese and English.
+- Publish focused starter issues for documentation, first-run bugs, UI polish, and connector examples.
+- Add GitHub repository topics: `ai-governance`, `ai-workspace`, `enterprise-ai`, `llmops`, `flask`, `react`, `self-hosted`, `claude-code`, `qwen-code`, `codex`.
+
+## Next
+
+- Publish GitHub releases with changelog notes, Docker image tags, and upgrade instructions.
+- Add a safe public demo path that does not expose shared admin credentials.
+- Improve production deployment docs for TLS, secrets, backups, SSO, and Kubernetes.
+- Add example dashboards and sample datasets so evaluators can understand the product before connecting real logs.
+
+## Later
+
+- Create connector guides for additional AI tools and model gateways.
+- Add richer audit reports for security, compliance, and cost allocation.
+- Provide Helm chart packaging and versioned migration playbooks.
+- Publish user stories and screenshots from real adoption scenarios.
+
+## Success Signals
+
+- New users can run Open ACE locally in under 10 minutes.
+- The project has tagged releases, working docs links, and a visible maintainer workflow.
+- External contributors can find good first issues and understand what kind of help is wanted.
+- Teams can evaluate Open ACE without sharing production data or credentials.

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@ Documentation files are in the [en/](en/) directory.
 | [**DEVELOPMENT**](en/DEVELOPMENT.md) | Development environment setup, project structure, and testing |
 | [**FEISHU-CONFIG**](en/FEISHU_CONFIG.md) | Feishu/Lark integration configuration guide |
 | [**CONCEPTS**](en/CONCEPTS.md) | Core concept definitions — Request, Message, Session, Conversation |
+| [**REPOSITORY-SETUP**](REPOSITORY_SETUP.md) | GitHub repository topics, labels, releases, and demo checklist |
 
 ### Reading Guide by Role
 
@@ -63,6 +64,7 @@ Documentation files are in the [en/](en/) directory.
 | [**DEVELOPMENT**](cn/DEVELOPMENT.md) | 开发环境搭建、项目结构和测试 |
 | [**FEISHU-CONFIG**](cn/FEISHU_CONFIG.md) | 飞书集成配置指南 |
 | [**CONCEPTS**](cn/CONCEPTS.md) | 核心概念定义 — Request、Message、Session、Conversation |
+| [**REPOSITORY-SETUP**](REPOSITORY_SETUP.md) | GitHub 仓库 topics、labels、releases 和 Demo 检查清单 |
 
 ### 按角色阅读指南
 

--- a/docs/REPOSITORY_SETUP.md
+++ b/docs/REPOSITORY_SETUP.md
@@ -1,0 +1,27 @@
+# Repository Setup Checklist
+
+Use this checklist for GitHub settings that cannot be fully configured from files in the repository.
+
+## About Section
+
+- Description: `Self-hosted enterprise AI workspace and governance platform`
+- Website: `https://www.open-ace.com`
+- Topics: `ai-governance`, `ai-workspace`, `enterprise-ai`, `llmops`, `flask`, `react`, `self-hosted`, `claude-code`, `qwen-code`, `codex`
+
+## Community
+
+- Enable Discussions.
+- Pin a "Show and tell" or "Adoption stories" discussion.
+- Create labels: `good first issue`, `help wanted`, `documentation`, `first-run`, `deployment`, `security`, `frontend`, `backend`.
+- Keep 5-10 small issues labeled `good first issue`.
+
+## Releases
+
+- Publish releases from Git tags such as `v1.0.1`.
+- Attach Docker/deployment notes and a short upgrade guide to each release.
+- Keep `CHANGELOG.md` aligned with the latest release.
+
+## Demo
+
+- Avoid shared public administrator credentials.
+- Prefer a resettable sandbox account, read-only sample data, or a short guided video until the sandbox is hardened.


### PR DESCRIPTION
## Summary

- tighten the README positioning and first-run security guidance
- fix public documentation links and template placeholders
- add a public roadmap and GitHub repository setup checklist
- clean CODEOWNERS/dependabot defaults that pointed to placeholder users

## Verification

- Checked that the touched files on `main` matched the downloaded baseline before creating this branch.
- Verified repository documentation links now point to `docs/cn` and `docs/en`.

Website updates were applied separately on `www.open-ace.com`.