### PR TITLE
fix: 提示词搜索支持匹配内容字段

### DIFF
--- a/app/modules/workspace/prompt_library.py
+++ b/app/modules/workspace/prompt_library.py
@@ -429,8 +429,12 @@ class PromptLibrary:
             params.append(category)
 
         if search:
-            conditions.append("(name LIKE ? OR description LIKE ?)")
-            params.extend([f"%{escape_like(search)}%", f"%{escape_like(search)}%"])
+            conditions.append("(name LIKE ? OR description LIKE ? OR content LIKE ?)")
+            params.extend([
+                f"%{escape_like(search)}%",
+                f"%{escape_like(search)}%",
+                f"%{escape_like(search)}%",
+            ])
 
         if tags:
             for tag in tags:

--- a/app/modules/workspace/prompt_library.py
+++ b/app/modules/workspace/prompt_library.py
@@ -430,11 +430,13 @@ class PromptLibrary:
 
         if search:
             conditions.append("(name LIKE ? OR description LIKE ? OR content LIKE ?)")
-            params.extend([
-                f"%{escape_like(search)}%",
-                f"%{escape_like(search)}%",
-                f"%{escape_like(search)}%",
-            ])
+            params.extend(
+                [
+                    f"%{escape_like(search)}%",
+                    f"%{escape_like(search)}%",
+                    f"%{escape_like(search)}%",
+                ]
+            )
 
         if tags:
             for tag in tags:


### PR DESCRIPTION
## 问题背景

Issue: #634

当前提示词搜索功能只匹配 `name`（标题）和 `description`（描述）字段，不匹配 `content`（内容）字段。

## 问题描述

- `description` 是非必填项，很多提示词可能没有描述
- `content` 是必填项，包含提示词的主要内容
- 用户搜索关键词（如"严格校验"）出现在内容中时无法找到

## 修复方案

扩展搜索范围，同时匹配 `name`、`description` 和 `content` 三个字段。

## 代码改动

```python
if search:
    conditions.append("(name LIKE ? OR description LIKE ? OR content LIKE ?)")
    params.extend([
        f"%{escape_like(search)}%",
        f"%{escape_like(search)}%",
        f"%{escape_like(search)}%",
    ])
```

## 测试验证

搜索关键词将能匹配：
- 提示词标题
- 提示词描述
- 提示词内容

🤖 Generated with Qwen Code (6-shotted by Qwen-Coder)