### PR TITLE
Prepare v1.0.0 release publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,8 @@ jobs:
           pytest tests/ -v --cov=scripts/shared --cov-report=xml --cov-report=html --ignore=tests/ui --ignore=tests/issues --ignore=tests/regression --ignore=tests/performance --ignore=tests/integration/test_auth_service_pg.py --ignore=tests/integration/test_daily_stats_repo_pg.py --ignore=tests/integration/test_governance_repo_pg.py --ignore=tests/integration/test_project_repo_pg.py --ignore=tests/integration/test_tenant_repo_pg.py --ignore=tests/integration/test_user_tool_account_repo_pg.py
 
       - name: Upload coverage to Codecov
+        timeout-minutes: 2
+        continue-on-error: true
         uses: codecov/codecov-action@v6
         with:
           file: ./coverage.xml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,14 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: write
+
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
+    env:
+      PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
 
     steps:
     - uses: actions/checkout@v6
@@ -23,9 +28,14 @@ jobs:
         python -m build --sdist --wheel --outdir dist/
 
     - name: Publish to PyPI
+      if: env.PYPI_API_TOKEN != ''
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        password: ${{ secrets.PYPI_API_TOKEN }}
+        password: ${{ env.PYPI_API_TOKEN }}
+
+    - name: Skip PyPI publish
+      if: env.PYPI_API_TOKEN == ''
+      run: echo "PYPI_API_TOKEN is not configured; skipping PyPI publish."
 
     - name: Upload release assets
       uses: softprops/action-gh-release@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,46 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-- Initial open source release preparation
-- Apache 2.0 License
-- Contributing guidelines
-- Comprehensive documentation
+No changes yet.
 
-## [1.0.0] - 2026-03-21
+## [1.0.0] - 2026-06-02
 
 ### Added
-- **Multi-tool Support**: Track token usage for Claude, Qwen, and OpenClaw
-- **Web Dashboard**: Interactive visualization with Chart.js
-  - Summary page with usage statistics
-  - Messages page with filtering and search
-  - Analysis page with trends and heatmaps
-  - Conversation history viewer
-- **CLI Tool**: Command-line interface for quick queries
-  - `today` - View today's usage
-  - `top` - View last 7 days usage
-  - `summary` - View total summary
-  - `report` - Generate email report
-- **Data Collection**: Automated scripts for log parsing
-  - `fetch_claude.py` - Claude log collector
-  - `fetch_qwen.py` - Qwen log collector
-  - `fetch_openclaw.py` - OpenClaw log collector
-- **Email Reports**: Automated daily usage reports
-- **Feishu Integration**: User and group name resolution
-- **Authentication**: User management with role-based access
-- **Internationalization**: English and Chinese language support
+- **Self-hosted AI workspace**: Work Mode for AI sessions, prompt reuse, conversation history, and project context.
+- **Remote Workspace and Remote Agent**: Run AI CLIs on development, staging, or GPU machines through a browser-managed remote agent.
+- **Multi-CLI support**: Claude Code, Qwen Code, Codex, and OpenClaw adapters with session recovery, permission modes, and history sync.
+- **API Key proxy**: Encrypt LLM API keys on the server and issue short-lived proxy tokens to local and remote sessions.
+- **Browser development loop**: Remote terminal, directory browsing, and VSCode/code-server proxy support.
+- **AI governance dashboards**: Token usage, cost analysis, quotas, alerts, anomaly detection, audit trails, and ROI visibility.
+- **Compliance reporting**: Governance reports with JSON/CSV export paths and practical risk recommendations.
+- **Enterprise administration**: Multi-tenant access control, roles, SSO-ready permission model, and Feishu/DingTalk integration paths.
+- **Deployment options**: Docker Compose quick start, production deployment docs, Kubernetes reference, and reverse proxy guidance.
+- **Open source readiness**: Apache 2.0 license, contributing guide, code of conduct, security policy, public roadmap, issue templates, CODEOWNERS, Dependabot, and beginner-friendly issue labels.
+- **Bilingual documentation**: Chinese and English docs for architecture, deployment, development, API usage, integrations, Remote Workspace, Remote Agent, Kubernetes, and repository setup.
 
 ### Architecture
-- SQLite database for data storage
-- Flask web framework
-- Bootstrap-based responsive UI
-- RESTful API design
+- Flask backend with SQLAlchemy repositories and Alembic migrations.
+- React 18, TypeScript, Vite, Bootstrap 5, and Chart.js frontend.
+- PostgreSQL and SQLite support for development and deployment workflows.
+- Remote agent package with CLI adapters, WebSocket terminal support, and session synchronization.
 
 ### Deployment
-- Support for local and remote deployment
-- systemd service configuration for Linux
-- launchd configuration for macOS
-- Docker support (planned)
+- Docker Compose quick start with PostgreSQL.
+- Source installation path for local development.
+- Kubernetes deployment reference.
+- Linux systemd and macOS launchd support for remote agents.
 
 ---
 
@@ -54,7 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 | Version | Date | Description |
 |---------|------|-------------|
-| 1.0.0 | 2026-03-21 | Initial open source release |
+| 1.0.0 | 2026-06-02 | Initial public release of the self-hosted AI workspace and governance platform |
 
 ---
 

--- a/docs/REPOSITORY_SETUP.md
+++ b/docs/REPOSITORY_SETUP.md
@@ -20,6 +20,8 @@ Use this checklist for GitHub settings that cannot be fully configured from file
 - Publish releases from Git tags such as `v1.0.1`.
 - Attach Docker/deployment notes and a short upgrade guide to each release.
 - Keep `CHANGELOG.md` aligned with the latest release.
+- Configure `PYPI_API_TOKEN` only after confirming the intended PyPI project and package ownership.
+- If `PYPI_API_TOKEN` is not configured, the release workflow skips PyPI publishing and still uploads GitHub release assets.
 
 ## Demo
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,18 +1,28 @@
 [project]
 name = "open-ace"
 version = "1.0.0"
-description = "Open ACE (AI Computing Explorer) - Track, analyze, and optimize AI usage"
+description = "Self-hosted enterprise AI workspace and governance platform"
 readme = "README.md"
-license = {text = "Apache-2.0"}
+license = "Apache-2.0"
 requires-python = ">=3.9"
 authors = [
     {name = "Open ACE Team"}
+]
+keywords = [
+    "ai",
+    "ai-governance",
+    "ai-workspace",
+    "codex",
+    "claude-code",
+    "enterprise-ai",
+    "llmops",
+    "qwen-code",
+    "self-hosted",
 ]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "Intended Audience :: System Administrators",
-    "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -61,10 +71,11 @@ openace = "cli:main"
 include = ["app*", "scripts*"]
 
 [project.urls]
-Homepage = "https://github.com/open-ace/open-ace"
+Homepage = "https://www.open-ace.com"
 Documentation = "https://github.com/open-ace/open-ace#readme"
 Repository = "https://github.com/open-ace/open-ace.git"
 Issues = "https://github.com/open-ace/open-ace/issues"
+Roadmap = "https://github.com/open-ace/open-ace/blob/main/ROADMAP.md"
 
 # =============================================================================
 # Black Configuration


### PR DESCRIPTION
Prepares the repository for publishing v1.0.0 safely.\n\nChanges:\n- Update release workflow so PyPI publishing runs only when PYPI_API_TOKEN is configured; GitHub release assets are still uploaded.\n- Refresh CHANGELOG.md for the current self-hosted AI workspace/governance release.\n- Update package metadata to match current positioning and modern SPDX license syntax.\n- Document PyPI token behavior in repository setup checklist.\n\nVerification:\n- Parsed pyproject.toml with tomllib.\n- Parsed release.yml with Ruby Psych.\n- Built sdist and wheel locally with python -m build: open_ace-1.0.0.tar.gz and open_ace-1.0.0-py3-none-any.whl.