### PR TITLE
fix: Pass theme parameter to iframe for Settings Modal dark mode

### DIFF
--- a/frontend/src/components/features/Workspace.tsx
+++ b/frontend/src/components/features/Workspace.tsx
@@ -24,6 +24,7 @@ import { requestApi, type QuotaStatusResponse } from '@/api/request';
 import { sessionsApi } from '@/api/sessions';
 import {
   useLanguage,
+  useTheme,
   useAppStore,
   useWorkspaceFullscreen,
   useEnableTabNotifications,
@@ -63,6 +64,7 @@ const ACTIVITY_HEARTBEAT_INTERVAL = 2 * 60 * 1000;
 
 export const Workspace: React.FC = () => {
   const language = useLanguage();
+  const theme = useTheme();
   const toast = useToast();
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
@@ -529,7 +531,7 @@ export const Workspace: React.FC = () => {
           url = `${url}&openace_url=${encodeURIComponent(openaceUrl)}`;
         }
         // Add lang parameter for language sync
-        url = `${url}&lang=${encodeURIComponent(language)}`;
+        url = `${url}&lang=${encodeURIComponent(language)}&theme=${theme}`;
         // Add sessionId, encodedProjectName, and toolName if restoring a session
         if (restoreSessionId) {
           url = `${url}&sessionId=${encodeURIComponent(restoreSessionId)}`;
@@ -564,7 +566,7 @@ export const Workspace: React.FC = () => {
       let url = config.url;
       // Add lang parameter for language sync
       const langSeparator = url.includes('?') ? '&' : '?';
-      url = `${url}${langSeparator}lang=${encodeURIComponent(language)}`;
+      url = `${url}${langSeparator}lang=${encodeURIComponent(language)}&theme=${theme}`;
       if (restoreSessionId) {
         url = appendParam(url, 'sessionId', restoreSessionId);
       }
@@ -593,7 +595,7 @@ export const Workspace: React.FC = () => {
       url = appendRecentProjects(url);
       return url;
     },
-    [config, userWebUI, language, remoteProjects]
+    [config, userWebUI, language, theme, remoteProjects]
   );
 
   // Initialize tabs when config is loaded (Issue #65: Restore from store if available)

--- a/frontend/src/components/features/Workspace.tsx
+++ b/frontend/src/components/features/Workspace.tsx
@@ -251,6 +251,22 @@ export const Workspace: React.FC = () => {
     return () => clearInterval(interval);
   }, [config?.multi_user_mode, userWebUI?.success]);
 
+  // Theme sync: Send postMessage to all iframes when theme changes (Issue #104)
+  useEffect(() => {
+    if (!tabsInitialized || tabs.length === 0) return;
+
+    // Send theme change message to all iframe tabs
+    tabs.forEach((tab) => {
+      const iframe = iframeRefs.current.get(tab.id);
+      if (iframe?.contentWindow) {
+        iframe.contentWindow.postMessage(
+          { type: 'openace-theme-change', theme },
+          '*'
+        );
+      }
+    });
+  }, [theme, tabs, tabsInitialized]);
+
   // Clear notification state for a tab (used when leaving/switching away from a tab)
   // Declared early so effects below can reference it
   const clearTabNotification = useCallback((tabId: string) => {

--- a/frontend/src/components/features/Workspace.tsx
+++ b/frontend/src/components/features/Workspace.tsx
@@ -258,11 +258,10 @@ export const Workspace: React.FC = () => {
     // Send theme change message to all iframe tabs
     tabs.forEach((tab) => {
       const iframe = iframeRefs.current.get(tab.id);
-      if (iframe?.contentWindow) {
-        iframe.contentWindow.postMessage(
-          { type: 'openace-theme-change', theme },
-          '*'
-        );
+      if (iframe?.contentWindow && iframe.src) {
+        // Use iframe's actual origin for security (instead of '*')
+        const targetOrigin = new URL(iframe.src).origin;
+        iframe.contentWindow.postMessage({ type: 'openace-theme-change', theme }, targetOrigin);
       }
     });
   }, [theme, tabs, tabsInitialized]);


### PR DESCRIPTION
## Summary

Fixes #104: Settings Modal in iframe (qwen-code-webui) displays with incorrect theme styling when Open ACE is in dark mode.

## Root Cause

When qwen-code-webui is embedded in an iframe, it has its own localStorage and cannot inherit Open ACE's theme setting. This causes the Settings Modal and other UI components inside the iframe to display with light theme styling even when Open ACE is in dark mode.

## Fix

Pass theme parameter to iframe URL similar to existing language sync mechanism:

- Added `useTheme` hook import and usage in Workspace.tsx
- Added `&theme=${theme}` parameter to iframe URL in `getEffectiveUrl` function (both multi-user and single-user mode)
- Updated `useCallback` dependency array to include `theme`

## Companion PR

This fix requires a companion change in qwen-code-webui to read the URL theme parameter:
- https://github.com/ivycomputing/qwen-code-webui/pull/165

## Testing

Verified that:
1. Theme toggle works correctly in Open ACE (light → dark)
2. iframe URL contains `&theme=dark` parameter when Open ACE is in dark mode

## Screenshots

See verification report in project screenshots directory.