### PR TITLE
fix: ensure audit_logs table auto-created at startup (Issue #197)

### DIFF
--- a/app/modules/governance/audit_logger.py
+++ b/app/modules/governance/audit_logger.py
@@ -514,9 +514,12 @@ def get_ddl_statements() -> list[str]:
     to ensure the audit_logs table exists, regardless of whether Alembic
     migrations have been run.
     """
+    from app.repositories.database import is_postgresql
+
+    id_type = "SERIAL PRIMARY KEY" if is_postgresql() else "INTEGER PRIMARY KEY AUTOINCREMENT"
     return [
-        """CREATE TABLE IF NOT EXISTS audit_logs (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
+        f"""CREATE TABLE IF NOT EXISTS audit_logs (
+            id {id_type},
             timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
             user_id INTEGER,
             username TEXT,

--- a/app/modules/governance/audit_logger.py
+++ b/app/modules/governance/audit_logger.py
@@ -329,7 +329,11 @@ class AuditLogger:
             LIMIT ? OFFSET ?
         """
 
-        rows = self.db.fetch_all(query, tuple(params + [limit, offset]))
+        try:
+            rows = self.db.fetch_all(query, tuple(params + [limit, offset]))
+        except Exception as e:
+            logger.error(f"Failed to query audit logs: {e}")
+            return []
 
         return [AuditLog.from_dict(row) for row in rows]
 
@@ -374,9 +378,12 @@ class AuditLogger:
         where_clause = " AND ".join(conditions) if conditions else "1=1"
 
         query = f"SELECT COUNT(*) as count FROM audit_logs WHERE {where_clause}"
-        result = self.db.fetch_one(query, tuple(params))
-
-        return int(result["count"]) if result else 0
+        try:
+            result = self.db.fetch_one(query, tuple(params))
+            return int(result["count"]) if result else 0
+        except Exception as e:
+            logger.error(f"Failed to count audit logs: {e}")
+            return 0
 
     def get_user_activity(self, user_id: int, days: int = 30) -> dict[str, Any]:
         """
@@ -498,3 +505,35 @@ class AuditLogger:
             return output.getvalue()
         else:
             raise ValueError(f"Unsupported format: {format}")
+
+
+def get_ddl_statements() -> list[str]:
+    """Return DDL statements for audit_logs table.
+
+    This function is called by schema_init.ensure_all_tables() at app startup
+    to ensure the audit_logs table exists, regardless of whether Alembic
+    migrations have been run.
+    """
+    return [
+        """CREATE TABLE IF NOT EXISTS audit_logs (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            user_id INTEGER,
+            username TEXT,
+            action TEXT NOT NULL,
+            severity TEXT DEFAULT 'info',
+            resource_type TEXT,
+            resource_id TEXT,
+            details TEXT,
+            ip_address TEXT,
+            user_agent TEXT,
+            session_id TEXT,
+            success INTEGER DEFAULT 1,
+            error_message TEXT
+        )""",
+        "CREATE INDEX IF NOT EXISTS idx_audit_timestamp ON audit_logs (timestamp)",
+        "CREATE INDEX IF NOT EXISTS idx_audit_user_id ON audit_logs (user_id)",
+        "CREATE INDEX IF NOT EXISTS idx_audit_action ON audit_logs (action)",
+        "CREATE INDEX IF NOT EXISTS idx_audit_resource ON audit_logs (resource_type, resource_id)",
+        "CREATE INDEX IF NOT EXISTS idx_audit_severity ON audit_logs (severity)",
+    ]

--- a/app/repositories/schema_init.py
+++ b/app/repositories/schema_init.py
@@ -20,6 +20,7 @@ def ensure_all_tables() -> None:
     """
     from app.modules.compliance.report import get_ddl_statements as report_ddl
     from app.modules.compliance.retention import get_ddl_statements as ret_ddl
+    from app.modules.governance.audit_logger import get_ddl_statements as audit_ddl
     from app.modules.sso.manager import get_ddl_statements as sso_ddl
     from app.modules.workspace.api_key_proxy import get_ddl_statements as akp_ddl
     from app.modules.workspace.collaboration import get_ddl_statements as collab_ddl
@@ -37,6 +38,7 @@ def ensure_all_tables() -> None:
         pl_ddl,
         akp_ddl,
         ram_ddl,
+        audit_ddl,
         sso_ddl,
         ret_ddl,
         ps_ddl,


### PR DESCRIPTION
## Summary

Fixes #197

### Root Cause Analysis

Issue #197 原始描述的根因分析不完全准确。真正的根因是：

1. **`audit_logs` 表的 DDL 未包含在 `ensure_all_tables()` 中** - 应用启动时不会自动创建该表
2. **`query()` 和 `count()` 方法缺少异常处理** - 表不存在时 API 返回 500 错误

### Changes

1. 在 `audit_logger.py` 中添加 `get_ddl_statements()` 函数
2. 在 `schema_init.py` 中导入并调用 `audit_ddl`
3. 在 `query()` 和 `count()` 方法中添加 try-except 异常处理（防御性编程）

### Benefits

现在 `audit_logs` 表会在应用启动时自动创建，无论：
- 是否运行了 Alembic 迁移
- 使用 SQLite 还是 PostgreSQL

### Test Plan

- 1292 unit tests passed
- audit_logger 相关测试全部通过