### PR TITLE
fix(workspace): workspace.url 端口处理逻辑不一致导致 URL 格式错误

### DIFF
--- a/app/services/webui_manager.py
+++ b/app/services/webui_manager.py
@@ -224,6 +224,33 @@ class WebUIManager:
             logger.error(f"Error loading config: {e}")
             return WorkspaceConfig()
 
+    def _remove_port_from_url(self, url: str) -> str:
+        """Remove any existing port from URL, keeping only scheme and host.
+
+        This ensures consistent URL handling when workspace.url is configured
+        with a port (e.g., user mistakenly includes webui port).
+
+        Examples:
+            http://localhost:3100 -> http://localhost
+            http://192.168.1.169:3100 -> http://192.168.1.169
+            http://[::1]:5000 -> http://[::1] (IPv6)
+            http://localhost -> http://localhost (no change)
+
+        Args:
+            url: URL string that may contain a port.
+
+        Returns:
+            URL string without port, preserving scheme and host.
+        """
+        from urllib.parse import urlparse
+
+        parsed = urlparse(url)
+        # Return scheme://hostname (no port)
+        if parsed.scheme and parsed.hostname:
+            return f"{parsed.scheme}://{parsed.hostname}"
+        # Fallback: if URL lacks scheme, return original
+        return url
+
     def start_cleanup_thread(self):
         """Start the background cleanup greenlet."""
         if self._cleanup_greenlet is not None:
@@ -420,8 +447,9 @@ class WebUIManager:
         if not self.config.multi_user_mode:
             # Single-user mode: return configured URL with a generated token
             # The token is needed for iframe auth when making cross-origin API calls
+            # Remove port from URL to ensure correct iframe address
             token = self.generate_token(user_id, 0)
-            return self.config.url, token
+            return self._remove_port_from_url(self.config.url), token
 
         with self._lock:
             # Check if user already has an instance
@@ -468,11 +496,8 @@ class WebUIManager:
         # Generate token
         token = self.generate_token(user_id, port)
 
-        # Build URL
-        base_url = self.config.url
-        # Remove any existing port from base_url
-        if ":" in base_url.split("//")[-1]:
-            base_url = base_url.split(":")[0] + ":" + base_url.split(":")[1]
+        # Build URL (remove any existing port from config.url)
+        base_url = self._remove_port_from_url(self.config.url)
         url = f"{base_url}:{port}"
 
         # Start process
@@ -633,8 +658,8 @@ class WebUIManager:
             logger.error("qwen-code-webui executable not found")
             return None, {}
 
-        # Build openace_api_url from config
-        openace_api_url = self.config.url  # e.g. "http://localhost"
+        # Build openace_api_url from config (remove any existing port first)
+        openace_api_url = self._remove_port_from_url(self.config.url)
         server_config = self._load_server_config()
         server_port = server_config.get("web_port", 5000)
         openace_api_url = f"{openace_api_url}:{server_port}"

--- a/frontend/src/components/features/Workspace.tsx
+++ b/frontend/src/components/features/Workspace.tsx
@@ -578,7 +578,15 @@ export const Workspace: React.FC = () => {
       }
 
       // Single-user mode: use configured URL
+      // Remove any existing port from URL (keep only scheme://hostname)
       let url = config.url;
+      try {
+        const parsedUrl = new URL(url);
+        url = `${parsedUrl.protocol}//${parsedUrl.hostname}`;
+      } catch {
+        // Fallback: if URL parsing fails, use original
+        console.warn('Failed to parse workspace URL:', url);
+      }
       // Add lang parameter for language sync
       const langSeparator = url.includes('?') ? '&' : '?';
       url = `${url}${langSeparator}lang=${encodeURIComponent(language)}&theme=${theme}`;


### PR DESCRIPTION
## 问题

`workspace.url` 配置字段在多处使用，但端口处理逻辑不一致：

| 位置 | 原有处理 |
|------|----------|
| iframe URL 构建（第 472-476 行） | ✅ 有端口移除逻辑（字符串分割） |
| 单用户模式返回 URL（第 424 行） | ❌ 无端口移除逻辑 |
| openace_api_url 构建（第 637 行） | ❌ 无端口移除逻辑 |
| 前端单用户模式（Workspace.tsx） | ❌ 无端口移除逻辑 |

**后果**：
- 当 `url` 带端口时，`openace_api_url` 变成错误格式（如 `http://host:3100:5000`）
- 单用户模式下 iframe 访问错误的端口
- 字符串分割方式不健壮，无法处理 IPv6 地址

## 修复方案

1. 添加 `_remove_port_from_url` 辅助方法，使用 `urllib.parse.urlparse`
2. 在后端三处使用该方法（单用户模式、iframe URL、openace_api_url）
3. 在前端使用 JavaScript `new URL()` API 处理端口移除

## 修改文件

- `app/services/webui_manager.py` - 添加辅助方法并修复三处使用
- `frontend/src/components/features/Workspace.tsx` - 前端端口移除

## 评审意见处理

根据 PR #660 评审意见，改进了代码健壮性：
- 后端使用 `urllib.parse.urlparse` 替代字符串分割
- 前端使用 `new URL()` API 替代字符串分割

Fixes #655