### PR TITLE
fix: prevent modal from closing on backdrop click

### DIFF
--- a/frontend/src/components/common/Modal.tsx
+++ b/frontend/src/components/common/Modal.tsx
@@ -96,7 +96,6 @@ export const Modal: React.FC<ModalProps> = ({
           backgroundColor: 'rgba(0, 0, 0, 0.5)',
           zIndex: 10040,
         }}
-        onClick={onClose}
       />
       {/* Modal */}
       <div
@@ -110,9 +109,6 @@ export const Modal: React.FC<ModalProps> = ({
           width: '100%',
           height: '100%',
           zIndex: 10050,
-        }}
-        onClick={(e) => {
-          if (e.target === e.currentTarget) onClose();
         }}
       >
         <div


### PR DESCRIPTION
## 修复内容

移除 Modal 组件中 Backdrop 和 Modal 容器的点击关闭逻辑。

## 问题描述

点击弹窗外阴影区域会导致弹窗关闭，这违背了 UX 最佳实践：用户在弹窗中编辑内容时，误点阴影会导致内容丢失。

## 修改内容

- 移除 Backdrop 的 `onClick={onClose}`
- 移除 Modal 容器的 `onClick` 外部点击关闭逻辑

## 保留的关闭方式

| 方式 | 状态 |
|------|------|
| 关闭按钮（X） | ✅ 保留 |
| Escape 键 | ✅ 保留 |
| 取消按钮 | ✅ 保留 |

## 影响范围

所有使用 Modal 组件的弹窗：
- 提示词详情弹窗
- 会话详情弹窗
- 用户管理弹窗
- 租户管理弹窗
- API Key 弹窗
- Remote Machine 弹窗
- ConfirmModal

Fixes #500