### PR TITLE
fix: Sessions页面远程会话按钮loading状态隔离 (#180)

### DIFF
--- a/frontend/src/components/features/Sessions.tsx
+++ b/frontend/src/components/features/Sessions.tsx
@@ -403,11 +403,9 @@ export const Sessions: React.FC = () => {
                 isDeleting={deleteMutation.isPending}
                 isCompleting={completeMutation.isPending}
                 isRestoring={restoreMutation.isPending}
-                isRemoteControlPending={
-                  stopRemoteMutation.isPending ||
-                  pauseRemoteMutation.isPending ||
-                  resumeRemoteMutation.isPending
-                }
+                stopRemoteMutation={stopRemoteMutation}
+                pauseRemoteMutation={pauseRemoteMutation}
+                resumeRemoteMutation={resumeRemoteMutation}
               />
             ))}
           </div>
@@ -511,7 +509,9 @@ interface SessionCardProps {
   isDeleting: boolean;
   isCompleting: boolean;
   isRestoring: boolean;
-  isRemoteControlPending: boolean;
+  stopRemoteMutation: ReturnType<typeof useStopRemoteSession>;
+  pauseRemoteMutation: ReturnType<typeof usePauseRemoteSession>;
+  resumeRemoteMutation: ReturnType<typeof useResumeRemoteSession>;
 }
 
 const SessionCard: React.FC<SessionCardProps> = ({
@@ -528,7 +528,9 @@ const SessionCard: React.FC<SessionCardProps> = ({
   isDeleting,
   isCompleting,
   isRestoring,
-  isRemoteControlPending,
+  stopRemoteMutation,
+  pauseRemoteMutation,
+  resumeRemoteMutation,
 }) => {
   const isRemote = session.workspace_type === 'remote';
   return (
@@ -588,7 +590,10 @@ const SessionCard: React.FC<SessionCardProps> = ({
                     variant="outline-warning"
                     size="sm"
                     onClick={() => onPauseRemote(session.session_id)}
-                    loading={isRemoteControlPending}
+                    loading={
+                      pauseRemoteMutation.isPending &&
+                      pauseRemoteMutation.variables === session.session_id
+                    }
                   >
                     <i className="bi bi-pause-fill" />
                   </Button>
@@ -598,7 +603,10 @@ const SessionCard: React.FC<SessionCardProps> = ({
                     variant="outline-danger"
                     size="sm"
                     onClick={() => onStopRemote(session.session_id)}
-                    loading={isRemoteControlPending}
+                    loading={
+                      stopRemoteMutation.isPending &&
+                      stopRemoteMutation.variables === session.session_id
+                    }
                   >
                     <i className="bi bi-stop-fill" />
                   </Button>
@@ -611,7 +619,10 @@ const SessionCard: React.FC<SessionCardProps> = ({
                   variant="outline-success"
                   size="sm"
                   onClick={() => onResumeRemote(session.session_id)}
-                  loading={isRemoteControlPending}
+                  loading={
+                    resumeRemoteMutation.isPending &&
+                    resumeRemoteMutation.variables === session.session_id
+                  }
                 >
                   <i className="bi bi-play-fill" />
                 </Button>


### PR DESCRIPTION
## 问题描述
在 Sessions 页面中，点击一个远程会话的【停止会话】按钮后，同一页面其他远程主机的【停止会话】按钮也会转圈显示 loading 状态。

## 问题根因
SessionCard 组件接收的 isRemoteControlPending 是全局布尔值状态。当任意一个远程会话正在被操作时，所有 SessionCard 都会收到 isRemoteControlPending=true，导致所有远程会话的停止/暂停/恢复按钮同时显示 loading 状态。

## 修复方案
将 mutation 对象传递给 SessionCard，在组件内部通过 mutation.isPending && mutation.variables === session.session_id 判断当前会话是否正在被操作，实现 loading 状态的会话级隔离。

## 修改内容
- 修改 SessionCardProps 接口，移除 isRemoteControlPending 属性，添加 stopRemoteMutation、pauseRemoteMutation、resumeRemoteMutation 属性
- 修改 SessionCard 内部按钮的 loading 逻辑，通过 mutation.variables 判断当前会话是否是操作目标

## 关联 Issue
Fixes #180