### PR TITLE
fix: Agent IP address not updated on register (Issue #486 v2)

### DIFF
--- a/app/modules/workspace/remote_agent_manager.py
+++ b/app/modules/workspace/remote_agent_manager.py
@@ -804,6 +804,22 @@ class RemoteAgentManager:
             conn.commit()
             logger.info("Updated capabilities for machine %s", machine_id[:8])
 
+    def update_machine_ip(self, machine_id: str, ip_address: str) -> None:
+        """Update IP address for a remote machine."""
+        with self.db.connection() as conn:
+            cursor = conn.cursor()
+            now = datetime.now(timezone.utc).replace(tzinfo=None).isoformat()
+            cursor.execute(
+                f"""
+                UPDATE remote_machines
+                SET ip_address = {_param()}, updated_at = {_param()}
+                WHERE machine_id = {_param()}
+            """,
+                (ip_address, now, machine_id),
+            )
+            conn.commit()
+            logger.info("Updated IP address for machine %s to %s", machine_id[:8], ip_address)
+
     # ==================== Machine Queries ====================
 
     def get_machine(self, machine_id: str) -> dict[str, Any] | None:

--- a/app/routes/remote.py
+++ b/app/routes/remote.py
@@ -865,6 +865,10 @@ def agent_message():
         capabilities = data.get("capabilities", {})
         if capabilities:
             agent_mgr.update_capabilities(machine_id, capabilities)
+        # Update IP address if agent reports a valid one (not 127.0.0.1)
+        agent_reported_ip = data.get("ip_address")
+        if agent_reported_ip and agent_reported_ip != "127.0.0.1" and validate_ip(agent_reported_ip):
+            agent_mgr.update_machine_ip(machine_id, agent_reported_ip)
         pending = agent_mgr.get_pending_commands(machine_id)
         return jsonify({"success": True, "type": "register_ack", "pending_commands": pending})
 

--- a/app/routes/remote.py
+++ b/app/routes/remote.py
@@ -867,7 +867,11 @@ def agent_message():
             agent_mgr.update_capabilities(machine_id, capabilities)
         # Update IP address if agent reports a valid one (not 127.0.0.1)
         agent_reported_ip = data.get("ip_address")
-        if agent_reported_ip and agent_reported_ip != "127.0.0.1" and validate_ip(agent_reported_ip):
+        if (
+            agent_reported_ip
+            and agent_reported_ip != "127.0.0.1"
+            and validate_ip(agent_reported_ip)
+        ):
             agent_mgr.update_machine_ip(machine_id, agent_reported_ip)
         pending = agent_mgr.get_pending_commands(machine_id)
         return jsonify({"success": True, "type": "register_ack", "pending_commands": pending})

--- a/remote-agent/install.ps1
+++ b/remote-agent/install.ps1
@@ -298,6 +298,17 @@ $osType = "Windows"
 $osVersion = [System.Environment]::OSVersion.Version.ToString()
 $hostname = $env:COMPUTERNAME
 
+# Get local IP address (prefer non-loopback)
+$localIp = "127.0.0.1"
+try {
+    $ipAddresses = [System.Net.Dns]::GetHostAddresses($hostname) | Where-Object { $_.AddressFamily -eq "InterNetwork" -and $_.ToString() -ne "127.0.0.1" }
+    if ($ipAddresses.Count -gt 0) {
+        $localIp = $ipAddresses[0].ToString()
+    }
+} catch {
+    # Fallback: use loopback
+}
+
 $capabilities = @{
     os = "windows"
     os_version = $osVersion
@@ -322,6 +333,7 @@ $body = @{
     os_version = $osVersion
     capabilities = $capabilities
     agent_version = "1.0.0"
+    ip_address = $localIp
 } | ConvertTo-Json
 
 try {

--- a/remote-agent/install.sh
+++ b/remote-agent/install.sh
@@ -480,6 +480,24 @@ log_info "Registering with Open ACE server..."
 OS_TYPE=$(uname -s 2>/dev/null || echo "unknown")
 OS_VERSION=$(uname -r 2>/dev/null || echo "unknown")
 
+# Get local IP address (prefer non-loopback)
+LOCAL_IP=$("$PYTHON_PATH" -c "
+import socket
+try:
+    hostname = socket.gethostname()
+    ip = socket.gethostbyname(hostname)
+    if ip != '127.0.0.1':
+        print(ip)
+    else:
+        # Fallback: try to get IP from a socket connection
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        s.connect(('8.8.8.8', 80))
+        print(s.getsockname()[0])
+        s.close()
+except:
+    print('127.0.0.1')
+" 2>/dev/null || echo "127.0.0.1")
+
 CAPABILITIES=$("$PYTHON_PATH" -c "
 import json, os, platform, shutil
 caps = {
@@ -517,7 +535,8 @@ REGISTER_RESPONSE=$(curl -s -X POST "${SERVER_URL}/api/remote/agent/register" \
         \"os_type\": \"${OS_TYPE}\",
         \"os_version\": \"${OS_VERSION}\",
         \"capabilities\": ${CAPABILITIES},
-        \"agent_version\": \"${AGENT_VERSION}\"
+        \"agent_version\": \"${AGENT_VERSION}\",
+        \"ip_address\": \"${LOCAL_IP}\"
     }" 2>/dev/null || echo '{"success": false}')
 
 if echo "$REGISTER_RESPONSE" | "$PYTHON_PATH" -c "import sys,json; d=json.load(sys.stdin); sys.exit(0 if d.get('success') else 1)" 2>/dev/null; then

--- a/tests/issues/486/test_ip_address_validation.py
+++ b/tests/issues/486/test_ip_address_validation.py
@@ -482,7 +482,11 @@ class TestAgentMessageRegisterLogic(unittest.TestCase):
 
         # Simulate the logic from agent_message register handler
         agent_reported_ip = "192.168.1.200"
-        if agent_reported_ip and agent_reported_ip != "127.0.0.1" and validate_ip(agent_reported_ip):
+        if (
+            agent_reported_ip
+            and agent_reported_ip != "127.0.0.1"
+            and validate_ip(agent_reported_ip)
+        ):
             self.mgr.update_machine_ip("test-register-logic-machine", agent_reported_ip)
 
         machine = self.mgr.get_machine("test-register-logic-machine")
@@ -497,7 +501,11 @@ class TestAgentMessageRegisterLogic(unittest.TestCase):
 
         # Simulate register with loopback IP
         agent_reported_ip = "127.0.0.1"
-        if agent_reported_ip and agent_reported_ip != "127.0.0.1" and validate_ip(agent_reported_ip):
+        if (
+            agent_reported_ip
+            and agent_reported_ip != "127.0.0.1"
+            and validate_ip(agent_reported_ip)
+        ):
             self.mgr.update_machine_ip("test-register-logic-machine", agent_reported_ip)
 
         # IP should remain unchanged
@@ -513,7 +521,11 @@ class TestAgentMessageRegisterLogic(unittest.TestCase):
 
         # Simulate register with invalid IP format
         agent_reported_ip = "invalid-ip-format"
-        if agent_reported_ip and agent_reported_ip != "127.0.0.1" and validate_ip(agent_reported_ip):
+        if (
+            agent_reported_ip
+            and agent_reported_ip != "127.0.0.1"
+            and validate_ip(agent_reported_ip)
+        ):
             self.mgr.update_machine_ip("test-register-logic-machine", agent_reported_ip)
 
         # IP should remain unchanged
@@ -525,7 +537,11 @@ class TestAgentMessageRegisterLogic(unittest.TestCase):
         from app.routes.remote import validate_ip
 
         agent_reported_ip = "2001:db8::1"
-        if agent_reported_ip and agent_reported_ip != "127.0.0.1" and validate_ip(agent_reported_ip):
+        if (
+            agent_reported_ip
+            and agent_reported_ip != "127.0.0.1"
+            and validate_ip(agent_reported_ip)
+        ):
             self.mgr.update_machine_ip("test-register-logic-machine", agent_reported_ip)
 
         machine = self.mgr.get_machine("test-register-logic-machine")

--- a/tests/issues/486/test_ip_address_validation.py
+++ b/tests/issues/486/test_ip_address_validation.py
@@ -364,3 +364,169 @@ class TestIPRegistrationIntegration(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+# ==================== Unit Tests: update_machine_ip() ====================
+
+
+class TestUpdateMachineIP(unittest.TestCase):
+    """Test the update_machine_ip method in RemoteAgentManager."""
+
+    def setUp(self):
+        """Set up test database and manager."""
+        import sqlite3
+        import tempfile
+
+        from app.modules.workspace.remote_agent_manager import (
+            RemoteAgentManager,
+            get_ddl_statements,
+        )
+
+        self.db_file = tempfile.mktemp(suffix=".db")
+        conn = sqlite3.connect(self.db_file)
+        for sql in get_ddl_statements():
+            conn.execute(sql)
+        conn.commit()
+        conn.close()
+
+        self.mgr = RemoteAgentManager(db_path=self.db_file)
+        # Register a test machine first
+        token = self.mgr.create_registration_token(tenant_id=1, created_by=1)
+        self.mgr.register_machine(
+            registration_token=token,
+            machine_id="test-ip-update-machine",
+            machine_name="Test IP Update",
+            hostname="testipupdate",
+            os_type="linux",
+            ip_address="127.0.0.1",  # Initial IP is loopback
+        )
+
+    def tearDown(self):
+        """Clean up test database."""
+        if os.path.exists(self.db_file):
+            os.remove(self.db_file)
+
+    def test_update_machine_ip_basic(self):
+        """update_machine_ip should update IP address correctly."""
+        self.mgr.update_machine_ip("test-ip-update-machine", "192.168.1.100")
+
+        machine = self.mgr.get_machine("test-ip-update-machine")
+        self.assertIsNotNone(machine)
+        self.assertEqual(machine.get("ip_address"), "192.168.1.100")
+
+    def test_update_machine_ip_ipv6(self):
+        """update_machine_ip should handle IPv6 addresses."""
+        self.mgr.update_machine_ip("test-ip-update-machine", "2001:db8::1")
+
+        machine = self.mgr.get_machine("test-ip-update-machine")
+        self.assertIsNotNone(machine)
+        self.assertEqual(machine.get("ip_address"), "2001:db8::1")
+
+    def test_update_machine_ip_nonexistent_machine(self):
+        """update_machine_ip should not fail for nonexistent machine."""
+        # Should silently do nothing (no exception raised)
+        self.mgr.update_machine_ip("nonexistent-machine-id", "10.0.0.1")
+
+    def test_update_machine_ip_overwrites_previous(self):
+        """update_machine_ip should overwrite previous IP."""
+        self.mgr.update_machine_ip("test-ip-update-machine", "10.0.0.1")
+        self.mgr.update_machine_ip("test-ip-update-machine", "172.16.0.1")
+
+        machine = self.mgr.get_machine("test-ip-update-machine")
+        self.assertEqual(machine.get("ip_address"), "172.16.0.1")
+
+
+# ==================== Route Tests: agent_message IP update ====================
+
+
+class TestAgentMessageRegisterLogic(unittest.TestCase):
+    """Test the IP update logic used in agent_message register handler."""
+
+    def setUp(self):
+        """Set up test database and manager."""
+        import sqlite3
+        import tempfile
+
+        from app.modules.workspace.remote_agent_manager import (
+            RemoteAgentManager,
+            get_ddl_statements,
+        )
+
+        self.db_file = tempfile.mktemp(suffix=".db")
+        conn = sqlite3.connect(self.db_file)
+        for sql in get_ddl_statements():
+            conn.execute(sql)
+        conn.commit()
+        conn.close()
+
+        self.mgr = RemoteAgentManager(db_path=self.db_file)
+        # Register a test machine
+        token = self.mgr.create_registration_token(tenant_id=1, created_by=1)
+        self.mgr.register_machine(
+            registration_token=token,
+            machine_id="test-register-logic-machine",
+            machine_name="Test Register Logic",
+            hostname="testreglogic",
+            os_type="linux",
+            ip_address="127.0.0.1",
+        )
+
+    def tearDown(self):
+        """Clean up test database."""
+        if os.path.exists(self.db_file):
+            os.remove(self.db_file)
+
+    def test_register_logic_updates_valid_ip(self):
+        """Valid non-loopback IP should be updated via register logic."""
+        from app.routes.remote import validate_ip
+
+        # Simulate the logic from agent_message register handler
+        agent_reported_ip = "192.168.1.200"
+        if agent_reported_ip and agent_reported_ip != "127.0.0.1" and validate_ip(agent_reported_ip):
+            self.mgr.update_machine_ip("test-register-logic-machine", agent_reported_ip)
+
+        machine = self.mgr.get_machine("test-register-logic-machine")
+        self.assertEqual(machine.get("ip_address"), "192.168.1.200")
+
+    def test_register_logic_skips_loopback(self):
+        """Loopback IP (127.0.0.1) should not trigger update."""
+        from app.routes.remote import validate_ip
+
+        # First set a valid IP
+        self.mgr.update_machine_ip("test-register-logic-machine", "10.0.0.1")
+
+        # Simulate register with loopback IP
+        agent_reported_ip = "127.0.0.1"
+        if agent_reported_ip and agent_reported_ip != "127.0.0.1" and validate_ip(agent_reported_ip):
+            self.mgr.update_machine_ip("test-register-logic-machine", agent_reported_ip)
+
+        # IP should remain unchanged
+        machine = self.mgr.get_machine("test-register-logic-machine")
+        self.assertEqual(machine.get("ip_address"), "10.0.0.1")
+
+    def test_register_logic_skips_invalid_format(self):
+        """Invalid IP format should not trigger update."""
+        from app.routes.remote import validate_ip
+
+        # First set a valid IP
+        self.mgr.update_machine_ip("test-register-logic-machine", "172.16.0.1")
+
+        # Simulate register with invalid IP format
+        agent_reported_ip = "invalid-ip-format"
+        if agent_reported_ip and agent_reported_ip != "127.0.0.1" and validate_ip(agent_reported_ip):
+            self.mgr.update_machine_ip("test-register-logic-machine", agent_reported_ip)
+
+        # IP should remain unchanged
+        machine = self.mgr.get_machine("test-register-logic-machine")
+        self.assertEqual(machine.get("ip_address"), "172.16.0.1")
+
+    def test_register_logic_handles_ipv6(self):
+        """Valid IPv6 should be updated."""
+        from app.routes.remote import validate_ip
+
+        agent_reported_ip = "2001:db8::1"
+        if agent_reported_ip and agent_reported_ip != "127.0.0.1" and validate_ip(agent_reported_ip):
+            self.mgr.update_machine_ip("test-register-logic-machine", agent_reported_ip)
+
+        machine = self.mgr.get_machine("test-register-logic-machine")
+        self.assertEqual(machine.get("ip_address"), "2001:db8::1")


### PR DESCRIPTION
## Summary

PR #632 fixed the `agent_register` endpoint IP handling, but two issues remained:

1. **Install scripts did not send IP**: `install.sh`/`install.ps1` did not send `ip_address` on first registration, relying on `request.remote_addr` (which becomes 127.0.0.1 if server has reverse proxy)

2. **agent_message ignored IP**: Agent reconnects via `agent_message` endpoint (`type: register`), but PR #632 only fixed `agent_register` endpoint

## Changes

- `app/routes/remote.py`: Add IP address update in `agent_message` register handler
- `app/modules/workspace/remote_agent_manager.py`: Add `update_machine_ip()` method
- `remote-agent/install.sh`: Get local IP and send `ip_address` on registration
- `remote-agent/install.ps1`: Same fix for Windows

## Root Cause Analysis

| Scenario | Endpoint | IP Source | PR #632 Fixed? |
|----------|----------|-----------|----------------|
| First registration (install script) | `/api/remote/agent/register` | `request.remote_addr` | ✅ But script didn't send `ip_address` |
| Agent reconnect | `/api/remote/agent/message` | Ignored | ❌ Not fixed |

Fixes #486