### PR TITLE
Add remote abort request state events

### DIFF
--- a/app/modules/workspace/remote_session_manager.py
+++ b/app/modules/workspace/remote_session_manager.py
@@ -411,7 +411,7 @@ class RemoteSessionManager:
         }
         return self._agent_manager.send_command(machine_id, command)
 
-    def abort_request(self, session_id: str) -> bool:
+    def abort_request(self, session_id: str, reason: str = "user") -> bool:
         """Abort the current in-progress request without stopping the session.
 
         Sends an interrupt signal (SIGINT/Ctrl+C) to the remote CLI process
@@ -425,10 +425,11 @@ class RemoteSessionManager:
             "type": "command",
             "command": "abort_request",
             "session_id": session_id,
+            "reason": reason,
         }
 
         self._agent_manager.send_command(machine_id, command)
-        logger.info(f"Sent abort_request for session {session_id[:8]}")
+        logger.info("Sent abort_request for session %s (reason=%s)", session_id[:8], reason)
         return True
 
     def stop_session(self, session_id: str) -> bool:
@@ -806,6 +807,37 @@ class RemoteSessionManager:
             "Buffered permission request for session %s: %s",
             session_id[:8],
             control_request.get("request", {}).get("subtype"),
+        )
+
+    def process_request_state(
+        self,
+        session_id: str,
+        state: str,
+        reason: str = "user",
+        message: Optional[str] = None,
+    ) -> None:
+        """Buffer a request lifecycle event for SSE delivery to the frontend."""
+        payload: dict[str, Any] = {
+            "type": state,
+            "reason": reason,
+        }
+        if message:
+            payload["message"] = message
+
+        output_entry = {
+            "session_id": session_id,
+            "data": json.dumps(payload, ensure_ascii=False),
+            "stream": "request_state",
+            "is_complete": state == "abort_failed",
+            "timestamp": datetime.now(timezone.utc).replace(tzinfo=None).isoformat(),
+        }
+
+        self._agent_manager.buffer_output(session_id, output_entry)
+        logger.info(
+            "Buffered request_state for session %s: %s (reason=%s)",
+            session_id[:8],
+            state,
+            reason,
         )
 
     def process_session_status_update(

--- a/app/modules/workspace/remote_session_manager.py
+++ b/app/modules/workspace/remote_session_manager.py
@@ -41,6 +41,7 @@ class RemoteSessionManager:
     _assistant_text_buffer: dict[str, str] = {}
     _content_blocks_buffer: dict[str, list[dict]] = {}
     _buffer_lock = threading.Lock()
+    _allowed_request_states = frozenset({"aborted", "abort_failed", "done"})
 
     def __init__(self):
         self._session_manager = SessionManager()
@@ -817,6 +818,14 @@ class RemoteSessionManager:
         message: Optional[str] = None,
     ) -> None:
         """Buffer a request lifecycle event for SSE delivery to the frontend."""
+        if state not in self._allowed_request_states:
+            logger.warning(
+                "Ignoring unsupported request_state for session %s: %s",
+                session_id[:8],
+                state,
+            )
+            return
+
         payload: dict[str, Any] = {
             "type": state,
             "reason": reason,

--- a/app/routes/remote.py
+++ b/app/routes/remote.py
@@ -486,8 +486,11 @@ def abort_remote_request(session_id):
     if access_error:
         return access_error
 
+    payload = request.get_json(silent=True) or {}
+    reason = payload.get("reason", "user")
+
     session_mgr = get_remote_session_manager()
-    success = session_mgr.abort_request(session_id)
+    success = session_mgr.abort_request(session_id, reason=reason)
 
     if success:
         return jsonify({"success": True})
@@ -629,6 +632,14 @@ def stream_session_output(session_id):
                             yield f"data: {json.dumps({'type': 'error', 'data': data})}\n\n"
                             last_index += 1
                             continue
+                        if stream == "request_state":
+                            try:
+                                parsed = json.loads(data)
+                                yield f"data: {json.dumps({'type': 'request_state', 'data': parsed})}\n\n"
+                            except (json.JSONDecodeError, TypeError):
+                                pass
+                            last_index += 1
+                            continue
                         try:
                             parsed = json.loads(data)
                             if stream == "permission":
@@ -659,7 +670,7 @@ def stream_session_output(session_id):
             )
             try:
                 session_mgr = get_remote_session_manager()
-                session_mgr.abort_request(session_id)
+                session_mgr.abort_request(session_id, reason="disconnect")
             except Exception:
                 pass
 
@@ -943,6 +954,24 @@ def agent_message():
             session_mgr.process_permission_request(
                 session_id=session_id,
                 control_request=control_request,
+            )
+
+        pending = agent_mgr.get_pending_commands(machine_id)
+        return jsonify({"success": True, "pending_commands": pending})
+
+    elif msg_type == "request_state":
+        session_id = data.get("session_id")
+        state = data.get("state")
+        reason = data.get("reason", "user")
+        message = data.get("message")
+
+        if session_id and state:
+            session_mgr = get_remote_session_manager()
+            session_mgr.process_request_state(
+                session_id=session_id,
+                state=state,
+                reason=reason,
+                message=message,
             )
 
         pending = agent_mgr.get_pending_commands(machine_id)

--- a/app/routes/remote.py
+++ b/app/routes/remote.py
@@ -637,7 +637,11 @@ def stream_session_output(session_id):
                                 parsed = json.loads(data)
                                 yield f"data: {json.dumps({'type': 'request_state', 'data': parsed})}\n\n"
                             except (json.JSONDecodeError, TypeError):
-                                pass
+                                logger.warning(
+                                    "Failed to parse request_state payload for session %s: %r",
+                                    session_id[:8],
+                                    data,
+                                )
                             last_index += 1
                             continue
                         try:

--- a/remote-agent/agent.py
+++ b/remote-agent/agent.py
@@ -432,6 +432,25 @@ class RemoteAgent:
             }
         )
 
+    def _send_request_state(
+        self,
+        session_id: str,
+        state: str,
+        reason: str = "user",
+        message: str | None = None,
+    ) -> None:
+        """Send request lifecycle state to the server for SSE delivery."""
+        payload: dict[str, Any] = {
+            "type": "request_state",
+            "session_id": session_id,
+            "state": state,
+            "reason": reason,
+            "machine_id": self.config.machine_id,
+        }
+        if message:
+            payload["message"] = message
+        self._http_send(payload)
+
     def _handle_command(self, data: dict[str, Any]) -> None:
         """Dispatch a command from the server."""
         command = data.get("command")
@@ -466,6 +485,7 @@ class RemoteAgent:
                     session_id, f"Resume failed: {result.get('error')}", "stderr", True
                 )
         elif command == "abort_request":
+            reason = data.get("reason", "user")
             result = self._executor.interrupt_session(session_id)
             if not result["success"]:
                 logger.warning(
@@ -473,6 +493,15 @@ class RemoteAgent:
                     session_id[:8] if session_id else "N/A",
                     result.get("error"),
                 )
+                if session_id:
+                    self._send_request_state(
+                        session_id,
+                        "abort_failed",
+                        reason=reason,
+                        message=result.get("error", "interrupt failed"),
+                    )
+            elif session_id:
+                self._send_request_state(session_id, "aborted", reason=reason)
         elif command == "start_terminal":
             self._cmd_start_terminal(data)
         elif command == "stop_terminal":

--- a/tests/issues/189/test_workspace_navigation.py
+++ b/tests/issues/189/test_workspace_navigation.py
@@ -128,12 +128,14 @@ class TestAgentAbortRequest(unittest.TestCase):
 
         agent = RemoteAgent.__new__(RemoteAgent)
         agent._executor = mock_executor
+        agent._send_request_state = MagicMock()
         agent._running = True
 
-        data = {"command": "abort_request", "session_id": "test-12345678"}
+        data = {"command": "abort_request", "session_id": "test-12345678", "reason": "user"}
         agent._handle_command(data)
 
         mock_executor.interrupt_session.assert_called_once_with("test-12345678")
+        agent._send_request_state.assert_called_once_with("test-12345678", "aborted", reason="user")
 
     @patch("executor.ProcessExecutor")
     def test_abort_request_logs_warning_on_failure(self, MockExecutor):
@@ -144,11 +146,18 @@ class TestAgentAbortRequest(unittest.TestCase):
 
         agent = RemoteAgent.__new__(RemoteAgent)
         agent._executor = mock_executor
+        agent._send_request_state = MagicMock()
         agent._running = True
 
-        data = {"command": "abort_request", "session_id": "test-12345678"}
+        data = {"command": "abort_request", "session_id": "test-12345678", "reason": "disconnect"}
         # Should not raise
         agent._handle_command(data)
+        agent._send_request_state.assert_called_once_with(
+            "test-12345678",
+            "abort_failed",
+            reason="disconnect",
+            message="Not found",
+        )
 
 
 class TestSSEDisconnectDetection(unittest.TestCase):

--- a/tests/unit/test_remote_request_state.py
+++ b/tests/unit/test_remote_request_state.py
@@ -1,0 +1,92 @@
+import json
+import unittest
+from unittest.mock import MagicMock, patch
+
+
+class TestRemoteRequestState(unittest.TestCase):
+    def setUp(self):
+        self.mock_session_mgr = MagicMock()
+        self.mock_agent_mgr = MagicMock()
+
+        self.patcher_sm = patch(
+            "app.modules.workspace.remote_session_manager.SessionManager",
+            return_value=self.mock_session_mgr,
+        )
+        self.patcher_am = patch(
+            "app.modules.workspace.remote_session_manager.get_remote_agent_manager",
+            return_value=self.mock_agent_mgr,
+        )
+        self.patcher_proxy = patch(
+            "app.modules.workspace.remote_session_manager.APIKeyProxyService",
+        )
+        self.patcher_sm.start()
+        self.patcher_am.start()
+        self.patcher_proxy.start()
+
+        from app.modules.workspace.remote_session_manager import RemoteSessionManager
+
+        self.manager = RemoteSessionManager()
+
+    def tearDown(self):
+        self.patcher_sm.stop()
+        self.patcher_am.stop()
+        self.patcher_proxy.stop()
+
+    def test_abort_request_includes_reason_in_command(self):
+        self.manager._get_machine_id = MagicMock(return_value="machine-123")
+
+        ok = self.manager.abort_request("session-123", reason="disconnect")
+
+        self.assertTrue(ok)
+        self.mock_agent_mgr.send_command.assert_called_once_with(
+            "machine-123",
+            {
+                "type": "command",
+                "command": "abort_request",
+                "session_id": "session-123",
+                "reason": "disconnect",
+            },
+        )
+
+    def test_process_request_state_buffers_control_event(self):
+        self.manager.process_request_state(
+            "session-123",
+            "aborted",
+            reason="user",
+            message="Stopped by user",
+        )
+
+        self.mock_agent_mgr.buffer_output.assert_called_once()
+        _, output_entry = self.mock_agent_mgr.buffer_output.call_args.args
+        self.assertEqual(output_entry["stream"], "request_state")
+        self.assertFalse(output_entry["is_complete"])
+        self.assertEqual(
+            json.loads(output_entry["data"]),
+            {
+                "type": "aborted",
+                "reason": "user",
+                "message": "Stopped by user",
+            },
+        )
+
+    def test_process_request_state_marks_abort_failed_complete(self):
+        self.manager.process_request_state(
+            "session-123",
+            "abort_failed",
+            reason="system",
+        )
+
+        _, output_entry = self.mock_agent_mgr.buffer_output.call_args.args
+        self.assertEqual(output_entry["stream"], "request_state")
+        self.assertTrue(output_entry["is_complete"])
+        self.assertEqual(
+            json.loads(output_entry["data"]),
+            {
+                "type": "abort_failed",
+                "reason": "system",
+            },
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_remote_request_state.py
+++ b/tests/unit/test_remote_request_state.py
@@ -87,6 +87,15 @@ class TestRemoteRequestState(unittest.TestCase):
             },
         )
 
+    def test_process_request_state_ignores_unsupported_state(self):
+        self.manager.process_request_state(
+            "session-123",
+            "unexpected_state",
+            reason="user",
+        )
+
+        self.mock_agent_mgr.buffer_output.assert_not_called()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- carry abort reasons through the remote abort API and agent command path
- emit dedicated `request_state` events for `aborted` and `abort_failed`
- buffer and stream those control events without mixing them into chat content

## Testing
- python3 -m pytest tests/issues/189/test_workspace_navigation.py tests/unit/test_remote_request_state.py
- python3 -m pytest tests/unit/test_remote_assistant_message.py

Closes #665

Paired with ivycomputing/qwen-code-webui#169.