### PR TITLE
fix: 提示词面板列表超出容器高度时显示滚动条 (Issue #630)

### DIFF
--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -1532,6 +1532,13 @@ link[rel='dns-prefetch'] {
   flex-direction: column;
 }
 
+.assist-panel .tab-pane {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
 /* Assist Panel Tabs - Equal width tabs for right panel */
 .assist-panel .nav-tabs {
   display: flex;


### PR DESCRIPTION
## 问题描述

会话页面右侧抽屉面板的"提示词"Tab，当提示词列表条目数量较多、内容高度超过面板可视高度后，容器未生成纵向滚动条，底部提示词被截断隐藏，无法向下滚动查看完整列表。

## 问题原因

CSS 布局链断裂：`.tab-pane` 缺少 flex 布局样式，导致子元素 `.assist-prompts` 的 `flex: 1` 无法生效，进而使 `.prompt-list` 的 `overflow-y: auto` 无法触发滚动。

**布局链分析：**
```
.assist-panel          → flex column, flex: 1, overflow: hidden ✓
  .tabs-container      → flex column, flex: 1, overflow: hidden ✓
    .tab-content       → flex: 1, overflow: hidden, display: flex ✓
      .tab-pane        → 只有 transition，缺少 flex 布局 ✗
        .assist-prompts → flex: 1（因父元素无 flex 而失效）
          .prompt-list → flex: 1, overflow-y: auto（本应有滚动条）
```

## 修复方案

在 `frontend/src/styles/main.css` 中添加 `.assist-panel .tab-pane` 的 flex 布局样式：

```css
.assist-panel .tab-pane {
  flex: 1;
  display: flex;
  flex-direction: column;
  overflow: hidden;
}
```

## 修复后效果

整个布局链完整，`.prompt-list` 的 `overflow-y: auto` 正常生效，内容超出时显示滚动条。

## 相关 Issue

Closes #630