### PR TITLE
fix: restore_session API 检查远程进程状态 (Issue #669)

### DIFF
--- a/app/modules/workspace/remote_agent_manager.py
+++ b/app/modules/workspace/remote_agent_manager.py
@@ -72,6 +72,8 @@ class RemoteAgentManager:
         self._last_heartbeat_db_write: dict[str, float] = {}
         # Browse results: {request_id: result} for directory browsing
         self._browse_results: dict[str, dict] = {}
+        # Session info results: {request_id: info} for get_session_info command responses
+        self._session_info_results: dict[str, dict] = {}
         # Lock for gevent coroutine safety
         self._lock = Semaphore(1)
         self._restore_in_memory_state()
@@ -627,6 +629,28 @@ class RemoteAgentManager:
             # Sleep briefly before checking again
             gevent.sleep(0.1)
         logger.warning("Timeout waiting for browse result %s", request_id[:8])
+        return None
+
+    def store_session_info_result(self, request_id: str, info: dict | None) -> None:
+        """Store session info result from agent for later retrieval."""
+        with self._lock:
+            self._session_info_results[request_id] = {"info": info}
+        logger.info("Stored session info result for request %s", request_id[:8])
+
+    def get_session_info_result(self, request_id: str, timeout: float = 5.0) -> dict | None:
+        """Wait for and retrieve session info result.
+
+        Polls for the result with a timeout. Returns None if timeout expires.
+        """
+        start_time = time.time()
+        while time.time() - start_time < timeout:
+            with self._lock:
+                if request_id in self._session_info_results:
+                    result = self._session_info_results.pop(request_id)
+                    return result.get("info")
+            # Sleep briefly before checking again
+            gevent.sleep(0.1)
+        logger.warning("Timeout waiting for session info result %s", request_id[:8])
         return None
 
     def store_terminal_info(self, machine_id: str, terminal_id: str, info: dict) -> None:

--- a/app/modules/workspace/remote_session_manager.py
+++ b/app/modules/workspace/remote_session_manager.py
@@ -525,6 +525,49 @@ class RemoteSessionManager:
             "paused_at": session.paused_at.isoformat() if session.paused_at else None,
         }
 
+    def check_session_process(self, session_id: str, timeout: float = 5.0) -> Optional[dict[str, Any]]:
+        """
+        Check if a session's process is actually running on the remote agent.
+
+        Sends a get_session_info command to the agent and waits for response.
+        This is used by restore_session to verify the process hasn't terminated.
+
+        Returns:
+            dict with session info if found, containing 'is_running' key.
+            None if session not found or agent timeout.
+        """
+        machine_id = self._get_machine_id(session_id)
+        if not machine_id:
+            logger.warning("check_session_process: no machine_id for session %s", session_id[:8])
+            return None
+
+        request_id = str(uuid.uuid4())
+        command = {
+            "type": "command",
+            "command": "get_session_info",
+            "session_id": session_id,
+            "request_id": request_id,
+        }
+
+        # Send command to agent
+        self._agent_manager.send_command(machine_id, command)
+
+        # Wait for response
+        result = self._agent_manager.get_session_info_result(request_id, timeout)
+
+        if result is None:
+            logger.warning("check_session_process: timeout for session %s", session_id[:8])
+            return None
+
+        logger.info(
+            "check_session_process: session %s is_running=%s pid=%s",
+            session_id[:8],
+            result.get("is_running"),
+            result.get("pid"),
+        )
+
+        return result
+
     def process_session_output(
         self, session_id: str, data: str, stream: str = "stdout", is_complete: bool = False
     ) -> None:

--- a/app/routes/remote.py
+++ b/app/routes/remote.py
@@ -927,6 +927,18 @@ def agent_message():
 
         return jsonify({"success": True})
 
+    elif msg_type == "session_info_response":
+        # Agent responds to get_session_info command
+        request_id = data.get("request_id")
+        info = data.get("info")
+
+        logger.info("Agent session_info_response: request_id=%s info=%s", request_id[:8] if request_id else "N/A", info)
+
+        if request_id:
+            agent_mgr.store_session_info_result(request_id, info)
+
+        return jsonify({"success": True})
+
     elif msg_type == "usage_report":
         session_id = data.get("session_id")
         tokens = data.get("tokens", {})

--- a/app/routes/workspace.py
+++ b/app/routes/workspace.py
@@ -1372,6 +1372,66 @@ def restore_session(session_id):
                 }
             )
 
+        # For remote CLI sessions, check if the process is actually running
+        # before returning the URL. If process has terminated, return error
+        # to prompt user to create a new session.
+        if workspace_type == "remote" and remote_machine_id:
+            try:
+                from app.modules.workspace.remote_session_manager import get_remote_session_manager
+
+                session_mgr = get_remote_session_manager()
+                process_info = session_mgr.check_session_process(session_id, timeout=3.0)
+
+                if process_info is None:
+                    # Agent not responding or session not found on agent
+                    logger.warning(
+                        "restore_session: session %s not found on remote agent %s",
+                        session_id[:8],
+                        remote_machine_id[:8],
+                    )
+                    return jsonify(
+                        {
+                            "success": False,
+                            "error": "Session process not found on remote agent. Please create a new session.",
+                            "error_code": "SESSION_PROCESS_NOT_FOUND",
+                        }
+                    ), 400
+
+                if not process_info.get("is_running"):
+                    # Process has terminated (e.g., received SIGINT)
+                    logger.warning(
+                        "restore_session: session %s process terminated (pid=%s)",
+                        session_id[:8],
+                        process_info.get("pid"),
+                    )
+                    return jsonify(
+                        {
+                            "success": False,
+                            "error": "Session process has terminated. Please create a new session.",
+                            "error_code": "SESSION_PROCESS_TERMINATED",
+                            "terminated_session": {
+                                "project_path": process_info.get("project_path"),
+                                "cli_tool": process_info.get("cli_tool"),
+                            },
+                        }
+                    ), 400
+
+                logger.info(
+                    "restore_session: session %s process verified (pid=%s is_running=%s)",
+                    session_id[:8],
+                    process_info.get("pid"),
+                    process_info.get("is_running"),
+                )
+
+            except Exception as e:
+                logger.warning(
+                    "restore_session: failed to check process status for %s: %s",
+                    session_id[:8],
+                    e,
+                )
+                # Continue without check if verification fails - agent may be offline
+                # Frontend will handle reconnect error when actually connecting
+
         # Generate encodedProjectName based on tool
         if normalize_tool_name(tool_name) in ["qwen", "claude"]:
             # project_path may be actual path or encoded name

--- a/remote-agent/agent.py
+++ b/remote-agent/agent.py
@@ -495,6 +495,8 @@ class RemoteAgent:
             self._cmd_stop_vscode(data)
         elif command == "attach_vscode":
             self._cmd_attach_vscode(data)
+        elif command == "get_session_info":
+            self._cmd_get_session_info(data)
         else:
             logger.warning("Unknown command: %s", command)
 
@@ -600,6 +602,23 @@ class RemoteAgent:
                 "Failed to handle permission response: %s",
                 result.get("error"),
             )
+
+    def _cmd_get_session_info(self, data: dict[str, Any]) -> None:
+        """Handle a get_session_info command to check if a session's process is running."""
+        session_id = data.get("session_id", "")
+        request_id = data.get("request_id", "")
+
+        logger.info("Getting session info for %s (request_id=%s)", session_id[:8], request_id[:8] if request_id else "N/A")
+
+        info = self._executor.get_session_info(session_id)
+
+        # Send response back to server
+        self._send_message_to_server({
+            "type": "session_info_response",
+            "session_id": session_id,
+            "request_id": request_id,
+            "info": info,  # None if session not found
+        })
 
     def _cmd_update_permission_mode(self, data: dict[str, Any]) -> None:
         """Handle update_permission_mode command from the frontend."""


### PR DESCRIPTION
## 问题描述

远程 CLI 会话进程被 SIGINT 终止后，restore_session API 不检查远程进程状态，直接返回成功 URL，导致"重新连接"无法实际恢复。

## 修复方案

参考 Terminal 的 `attachTerminal` + `not_found` 处理模式：

1. **remote-agent**: 添加 `get_session_info` 命令，返回进程运行状态（`is_running`, `pid` 等）
2. **remote_agent_manager**: 添加 session_info 结果存储和获取机制
3. **remote_session_manager**: 添加 `check_session_process` 方法
4. **restore_session API**: 检查进程状态，终止时返回明确错误

## 修改文件

| 文件 | 修改内容 |
|------|---------|
| `remote-agent/agent.py` | 新增 `_cmd_get_session_info` 处理 |
| `app/modules/workspace/remote_agent_manager.py` | `store_session_info_result`/`get_session_info_result` |
| `app/modules/workspace/remote_session_manager.py` | `check_session_process` 方法 |
| `app/routes/remote.py` | 处理 `session_info_response` 消息 |
| `app/routes/workspace.py` | restore_session 添加进程状态检查 |

## 测试验证

- 创建远程会话
- 使用 SIGINT 终止进程
- 调用 restore_session API
- 验证返回 `SESSION_PROCESS_TERMINATED` 错误码

Closes #669