### PR TITLE
fix: 趋势分析页面活跃用户显示 Unknown 问题 (#676)

### DIFF
--- a/app/services/analysis_service.py
+++ b/app/services/analysis_service.py
@@ -211,9 +211,8 @@ class AnalysisService:
         # User ranking
         users = []
         for i, user_data in enumerate(user_tokens[:10]):
-            username = user_data.get("sender_name", "Unknown")
-            if username and ".local" in username:
-                username = username.split("-")[0]
+            # Use unified_username which is resolved via LEFT JOIN users table
+            username = user_data.get("unified_username", "Unknown")
             users.append(
                 {
                     "user_id": i + 1,


### PR DESCRIPTION
## Summary

- 修复趋势分析页面"活跃用户 Top 10"显示用户名均为 "Unknown" 的问题
- 修复 COALESCE 类型不匹配问题

## Root Cause

`analysis_service.py` 使用 `sender_name` 字段获取用户名，但 `get_user_totals()` 返回的数据中只有 `unified_username` 字段，导致 `user_data.get("sender_name", "Unknown")` 始终返回默认值 "Unknown"。

## Changes

| File | Change |
|------|--------|
| `app/services/analysis_service.py` | 使用 `unified_username` 替代 `sender_name` |
| `app/repositories/daily_stats_repo.py` | COALESCE fallback 从 `sender_name` 改为 `-1` (整数哨兵值) |

## Test Plan

- [x] 本地数据库验证：API 返回正确用户名（樊青磊、韩成凤、吴丹、open、黄迎春）
- [ ] CI 通过

Fixes #676