### PR TITLE
fix: codex session discovery and missing user_id in session_sync

### DIFF
--- a/app/modules/workspace/session_manager.py
+++ b/app/modules/workspace/session_manager.py
@@ -613,6 +613,7 @@ class SessionManager:
         "expires_at",
         "terminal_id",
         "project_path",
+        "user_id",
     }
 
     def update_session_fields(self, session_id: str, fields: dict[str, Any]) -> bool:

--- a/app/routes/remote.py
+++ b/app/routes/remote.py
@@ -1176,7 +1176,7 @@ def agent_message():
         if not sync_user_id:
             # Verify machine has an active agent connection before trusting
             # machine_id from the unauthenticated POST body.
-            agent_mgr = get_remote_agent_manager()
+            # agent_mgr is already available from L871 (top of agent_message).
             if not agent_mgr.is_connected(machine_id):
                 logger.warning(
                     "session_sync: machine %s is not connected, skipping user_id resolution",

--- a/app/routes/remote.py
+++ b/app/routes/remote.py
@@ -1141,7 +1141,10 @@ def agent_message():
 
         # Resolve effective session_id: prefer terminal_id (shown in sidebar)
         # over claude_session_id (internal Claude Code JSONL UUID).
+        # Also capture user_id from the terminal session (authenticated web UI)
+        # to avoid a redundant get_session() call below.
         sync_session_mgr = get_remote_session_manager()._session_manager
+        terminal_session = None
         if terminal_id:
             terminal_session = sync_session_mgr.get_session(terminal_id)
             if terminal_session:
@@ -1166,31 +1169,42 @@ def agent_message():
             total_output_tokens,
         )
 
-        # Resolve user_id from terminal session or machine assignment
+        # Resolve user_id: terminal session (authenticated) > machine assignment
         sync_user_id = None
-        if terminal_id:
-            terminal_session = sync_session_mgr.get_session(terminal_id)
-            if terminal_session and terminal_session.user_id:
-                sync_user_id = terminal_session.user_id
+        if terminal_session and terminal_session.user_id:
+            sync_user_id = terminal_session.user_id
         if not sync_user_id:
-            try:
-                from app.repositories.database import adapt_sql, get_db_connection
+            # Verify machine has an active agent connection before trusting
+            # machine_id from the unauthenticated POST body.
+            agent_mgr = get_remote_agent_manager()
+            if not agent_mgr.is_connected(machine_id):
+                logger.warning(
+                    "session_sync: machine %s is not connected, skipping user_id resolution",
+                    machine_id[:8],
+                )
+            else:
+                try:
+                    from app.repositories.database import adapt_sql, get_db_connection
 
-                with get_db_connection() as conn:
-                    cursor = conn.cursor()
-                    cursor.execute(
-                        adapt_sql(
-                            "SELECT user_id FROM machine_assignments "
-                            "WHERE machine_id = ? AND user_id IS NOT NULL "
-                            "ORDER BY granted_at DESC LIMIT 1"
-                        ),
-                        (machine_id,),
+                    with get_db_connection() as conn:
+                        cursor = conn.cursor()
+                        cursor.execute(
+                            adapt_sql(
+                                "SELECT user_id FROM machine_assignments "
+                                "WHERE machine_id = ? AND user_id IS NOT NULL "
+                                "ORDER BY granted_at DESC LIMIT 1"
+                            ),
+                            (machine_id,),
+                        )
+                        row = cursor.fetchone()
+                        if row:
+                            sync_user_id = row["user_id"]
+                except Exception as e:
+                    logger.warning(
+                        "Failed to resolve user_id from machine_assignments for machine=%s: %s",
+                        machine_id[:8],
+                        e,
                     )
-                    row = cursor.fetchone()
-                    if row:
-                        sync_user_id = row["user_id"]
-            except Exception as e:
-                logger.debug("Failed to resolve user_id from machine_assignments: %s", e)
 
         try:
             # Upsert the session record
@@ -1209,12 +1223,14 @@ def agent_message():
                     },
                 )
             else:
-                # Update model/project_path if missing on existing session
+                # Update model/project_path/user_id if missing on existing session
                 updates = {}
                 if model and not existing.model:
                     updates["model"] = model
                 if project_path and not existing.project_path:
                     updates["project_path"] = project_path
+                if sync_user_id and not existing.user_id:
+                    updates["user_id"] = sync_user_id
                 if updates:
                     sync_session_mgr.update_session_fields(session_id, updates)
 

--- a/app/routes/remote.py
+++ b/app/routes/remote.py
@@ -1166,6 +1166,32 @@ def agent_message():
             total_output_tokens,
         )
 
+        # Resolve user_id from terminal session or machine assignment
+        sync_user_id = None
+        if terminal_id:
+            terminal_session = sync_session_mgr.get_session(terminal_id)
+            if terminal_session and terminal_session.user_id:
+                sync_user_id = terminal_session.user_id
+        if not sync_user_id:
+            try:
+                from app.repositories.database import adapt_sql, get_db_connection
+
+                with get_db_connection() as conn:
+                    cursor = conn.cursor()
+                    cursor.execute(
+                        adapt_sql(
+                            "SELECT user_id FROM machine_assignments "
+                            "WHERE machine_id = ? AND user_id IS NOT NULL "
+                            "ORDER BY granted_at DESC LIMIT 1"
+                        ),
+                        (machine_id,),
+                    )
+                    row = cursor.fetchone()
+                    if row:
+                        sync_user_id = row["user_id"]
+            except Exception as e:
+                logger.debug("Failed to resolve user_id from machine_assignments: %s", e)
+
         try:
             # Upsert the session record
             existing = sync_session_mgr.get_session(session_id)
@@ -1176,6 +1202,7 @@ def agent_message():
                     project_path=project_path or "",
                     model=model,
                     host_name=machine_id[:8],
+                    user_id=sync_user_id,
                     context={
                         "workspace_type": "terminal",
                         "remote_machine_id": machine_id,

--- a/scripts/fetch_codex.py
+++ b/scripts/fetch_codex.py
@@ -88,7 +88,7 @@ def find_all_codex_session_dirs() -> list:
 
         try:
             if codex_sessions.is_dir():
-                has_jsonl = any(codex_sessions.glob("*/*/*.jsonl"))
+                has_jsonl = any(codex_sessions.glob("*/*/*/*.jsonl"))
 
                 if has_jsonl:
                     results.append((system_account, codex_sessions))


### PR DESCRIPTION
## Problem

Codex sessions were not appearing in the Work Mode session list for logged-in users. Two root causes identified.

### 1. Glob pattern mismatch in fetch_codex.py
`find_all_codex_session_dirs()` used glob `*/*/*.jsonl` (3 levels) but Codex stores files at `sessions/YYYY/MM/DD/file.jsonl` (4 levels). The DataFetchScheduler ran every 60s but always returned "No codex session directories found" because no files matched.

### 2. Missing user_id in remote session_sync handler
When remote agent syncs terminal sessions via WebSocket `session_sync` message, the `agent_sessions` record was created without `user_id`. The session list API filters by `user_id`, so these sessions were invisible to all logged-in users.

## Changes
- `scripts/fetch_codex.py`: Fix glob from `*/*/*.jsonl` to `*/*/*/*.jsonl`
- `app/routes/remote.py`: Add user_id resolution from terminal session or machine_assignments table

## Verification
- Codex fetch now succeeds: Found 2 session files, 1522 messages
- Today codex session (019e8cdc) appears in API with user_id=89
- 305 orphaned sessions with user_id=NULL were backfilled

🤖 Generated with Qwen Code