### PR TITLE
fix: 远程终端多 API Key 场景下合并 qwen settings.json model 配置

### DIFF
--- a/app/modules/workspace/api_key_proxy.py
+++ b/app/modules/workspace/api_key_proxy.py
@@ -654,6 +654,66 @@ class APIKeyProxyService:
         # Multiple keys — merge modelProviders from all keys
         return self._merge_multi_key_settings(ranked_settings)
 
+    @staticmethod
+    def _collect_model_entries(
+        ranked_settings: list[tuple[tuple[int, int, int], dict[str, Any]]],
+    ) -> dict[str, dict[str, list[tuple[tuple[int, int, int], dict[str, Any]]]]]:
+        """Collect per-provider model entries from ranked settings.
+
+        Iterates over all ranked settings and extracts models from
+        ``modelProviders.*``, grouping them by (provider_name, model_id).
+        Duplicate model IDs within the same key are ignored.
+
+        Args:
+            ranked_settings: List of ``(rank_tuple, settings_dict)`` pairs.
+
+        Returns:
+            Nested dict: ``{provider_name: {model_id: [(rank, model_dict), ...]}}``
+        """
+        provider_model_entries: dict[
+            str, dict[str, list[tuple[tuple[int, int, int], dict[str, Any]]]]
+        ] = {}
+        for rank, settings in ranked_settings:
+            for provider_name, provider_models in settings.get("modelProviders", {}).items():
+                if not isinstance(provider_models, list):
+                    continue
+                model_map = provider_model_entries.setdefault(provider_name, {})
+                seen_in_key: set[str] = set()
+                for raw_model in provider_models:
+                    if not isinstance(raw_model, dict):
+                        continue
+                    model_id = raw_model.get("id")
+                    if not isinstance(model_id, str) or not model_id:
+                        continue
+                    # Skip duplicate model IDs within the same key
+                    if model_id in seen_in_key:
+                        continue
+                    seen_in_key.add(model_id)
+                    model_map.setdefault(model_id, []).append((rank, deepcopy(raw_model)))
+        return provider_model_entries
+
+    @staticmethod
+    def _dedup_and_sort_models(
+        model_entries: dict[str, list[tuple[tuple[int, int, int], dict[str, Any]]]],
+    ) -> list[dict[str, Any]]:
+        """Deduplicate models by ID and sort by rank for deterministic output.
+
+        For each model ID, the config from the highest-priority entry (lowest
+        rank tuple) is used as the canonical version.
+
+        Args:
+            model_entries: ``{model_id: [(rank, model_dict), ...]}``
+
+        Returns:
+            Sorted list of deduplicated model dicts.
+        """
+        ranked: list[tuple[tuple[int, int, int], str, dict[str, Any]]] = []
+        for model_id, entries in model_entries.items():
+            canonical_rank, canonical_model = sorted(entries, key=lambda x: x[0])[0]
+            ranked.append((canonical_rank, model_id, canonical_model))
+        ranked.sort(key=lambda x: (x[0], x[1]))
+        return [model for _, _, model in ranked]
+
     def _merge_multi_key_settings(
         self,
         ranked_settings: list[tuple[tuple[int, int, int], dict[str, Any]]],
@@ -677,22 +737,8 @@ class APIKeyProxyService:
         sorted_settings = sorted(ranked_settings, key=lambda item: item[0])
         base_settings = deepcopy(sorted_settings[0][1])
 
-        # Collect per-provider model entries, deduplicated by model ID
-        provider_model_entries: dict[
-            str, dict[str, list[tuple[tuple[int, int, int], dict[str, Any]]]]
-        ] = {}
-        for rank, settings in sorted_settings:
-            for provider_name, provider_models in settings.get("modelProviders", {}).items():
-                if not isinstance(provider_models, list):
-                    continue
-                model_map = provider_model_entries.setdefault(provider_name, {})
-                for raw_model in provider_models:
-                    if not isinstance(raw_model, dict):
-                        continue
-                    model_id = raw_model.get("id")
-                    if not isinstance(model_id, str) or not model_id:
-                        continue
-                    model_map.setdefault(model_id, []).append((rank, deepcopy(raw_model)))
+        # Collect per-provider model entries (with per-key dedup)
+        provider_model_entries = self._collect_model_entries(sorted_settings)
 
         # If no modelProviders found, return base settings as-is
         if not provider_model_entries:
@@ -701,14 +747,7 @@ class APIKeyProxyService:
         # Rebuild each provider's model list with deduplication
         merged_providers: dict[str, list[dict[str, Any]]] = {}
         for provider_name, pm_map in provider_model_entries.items():
-            ranked: list[tuple[tuple[int, int, int], str, dict[str, Any]]] = []
-            for mid, model_entries in pm_map.items():
-                # Pick the config from the highest-priority key
-                canonical_rank, canonical_model = sorted(model_entries, key=lambda x: x[0])[0]
-                ranked.append((canonical_rank, mid, canonical_model))
-            # Sort by rank then model ID for deterministic ordering
-            ranked.sort(key=lambda x: (x[0], x[1]))
-            merged_providers[provider_name] = [model for _, _, model in ranked]
+            merged_providers[provider_name] = self._dedup_and_sort_models(pm_map)
 
         base_settings["modelProviders"] = merged_providers
         if merged_providers and "$version" not in base_settings:
@@ -801,6 +840,7 @@ class APIKeyProxyService:
             provider_models = settings.get("modelProviders", {}).get("openai", [])
             supported_model_ids: list[str] = []
             if isinstance(provider_models, list):
+                seen_in_key: set[str] = set()
                 for raw_model in provider_models:
                     if not isinstance(raw_model, dict):
                         continue
@@ -808,6 +848,10 @@ class APIKeyProxyService:
                     if not isinstance(model_id, str) or not model_id:
                         continue
                     supported_model_ids.append(model_id)
+                    # Skip duplicate model IDs within the same key
+                    if model_id in seen_in_key:
+                        continue
+                    seen_in_key.add(model_id)
                     rank = (-priority, -weight, key_id)
                     model_entries.setdefault(model_id, []).append((rank, deepcopy(raw_model)))
                     model_key_ids.setdefault(model_id, []).append(key_id)
@@ -822,15 +866,7 @@ class APIKeyProxyService:
                 }
             )
 
-        models: list[dict[str, Any]] = []
-        ranked_model_meta: list[tuple[tuple[int, int, int], str, dict[str, Any]]] = []
-        for model_id, entries in model_entries.items():
-            canonical_rank, canonical_model = sorted(entries, key=lambda item: item[0])[0]
-            ranked_model_meta.append((canonical_rank, model_id, canonical_model))
-
-        ranked_model_meta.sort(key=lambda item: (item[0], item[1]))
-        for _, _, model in ranked_model_meta:
-            models.append(model)
+        models = self._dedup_and_sort_models(model_entries)
 
         base_settings = (
             deepcopy(sorted(ranked_settings, key=lambda item: item[0])[0][1])

--- a/app/modules/workspace/api_key_proxy.py
+++ b/app/modules/workspace/api_key_proxy.py
@@ -572,8 +572,8 @@ class APIKeyProxyService:
         Get CLI settings for a specific tool from active API keys.
 
         Searches api_key_store where cli_tools contains the tool_name.
-        Returns the tool-specific settings from cli_settings, merged with
-        the actual API key and base_url.
+        When multiple matching keys exist, merges modelProviders from all
+        keys so the resulting settings contain the union of available models.
 
         Tool name normalization is applied so that aliases like "codex-cli"
         and "codex" match each other, and "claude-code" matches "claude".
@@ -581,6 +581,7 @@ class APIKeyProxyService:
         Args:
             tenant_id: Tenant ID.
             tool_name: CLI tool name (e.g., "claude-code", "qwen-code", "codex", "codex-cli").
+            scope: Key scope filter (default "remote").
 
         Returns:
             Dict with complete settings ready for agent to write to settings.json,
@@ -591,15 +592,16 @@ class APIKeyProxyService:
         conn = self._get_connection()
         cursor = conn.cursor()
 
-        # Find API key where cli_tools contains the tool_name
+        # Find API keys where cli_tools contains the tool_name
         cursor.execute(
             f"""
-            SELECT id, provider, encrypted_key, base_url, cli_tools, cli_settings
+            SELECT id, provider, encrypted_key, base_url, cli_tools, cli_settings,
+                   priority, weight
             FROM api_key_store
             WHERE tenant_id = {_param()} AND is_active = TRUE
               AND (scope = {_param()} OR scope = 'shared')
-            ORDER BY id DESC
-            LIMIT 10
+            ORDER BY priority DESC, weight DESC, id ASC
+            LIMIT 50
         """,
             (tenant_id, scope),
         )
@@ -607,7 +609,8 @@ class APIKeyProxyService:
         rows = cursor.fetchall()
         conn.close()
 
-        # Find matching row
+        # Collect ALL matching keys with their ranked settings
+        ranked_settings: list[tuple[tuple[int, int, int], dict[str, Any]]] = []
         for row in rows:
             cli_tools_str = row["cli_tools"] or ""
             cli_settings_str = row["cli_settings"] or "{}"
@@ -622,7 +625,11 @@ class APIKeyProxyService:
             if canonical_tool not in {normalize_tool_name(t) for t in cli_tools}:
                 continue
 
-            # Found matching key - build settings
+            key_id = int(row["id"])
+            priority = int(row.get("priority") or 0)
+            weight = int(row.get("weight") or 100)
+
+            # Build settings for this key
             try:
                 cli_settings = json.loads(cli_settings_str) if cli_settings_str else {}
             except json.JSONDecodeError:
@@ -633,13 +640,81 @@ class APIKeyProxyService:
             # so that cli_settings keyed by either "codex" or "codex-cli" are found.
             tool_settings = cli_settings.get(tool_name, cli_settings.get(canonical_tool, {}))
 
-            # Return non-sensitive settings only.
-            # API credentials (key + base_url) are NOT injected here —
-            # they are set via environment variables by the agent
-            # (terminal_server.py for web terminal, executor for sessions).
-            return self._build_cli_settings_for_tool(tool_name, tool_settings)
+            settings = self._build_cli_settings_for_tool(tool_name, tool_settings)
+            rank = (-priority, -weight, key_id)
+            ranked_settings.append((rank, settings))
 
-        return None
+        if not ranked_settings:
+            return None
+
+        # Single key fast path — backward compatible
+        if len(ranked_settings) == 1:
+            return ranked_settings[0][1]
+
+        # Multiple keys — merge modelProviders from all keys
+        return self._merge_multi_key_settings(ranked_settings)
+
+    def _merge_multi_key_settings(
+        self,
+        ranked_settings: list[tuple[tuple[int, int, int], dict[str, Any]]],
+    ) -> dict[str, Any]:
+        """Merge settings from multiple API keys, unioning modelProviders.
+
+        Base settings (theme, permissions, etc.) come from the highest-priority
+        key.  ``modelProviders`` is merged: models from all keys are collected,
+        deduplicated by model ID (using the highest-priority key's config), and
+        sorted by rank for deterministic output.
+
+        Args:
+            ranked_settings: List of ``(rank_tuple, settings_dict)`` pairs.
+                ``rank_tuple`` is ``(-priority, -weight, key_id)`` so that
+                sorting ascending puts the best key first.
+
+        Returns:
+            Merged settings dict with the union of all models.
+        """
+        # Sort so the highest-priority key comes first
+        ranked_settings.sort(key=lambda item: item[0])
+        base_settings = deepcopy(ranked_settings[0][1])
+
+        # Collect per-provider model entries, deduplicated by model ID
+        provider_model_entries: dict[
+            str, dict[str, list[tuple[tuple[int, int, int], dict[str, Any]]]]
+        ] = {}
+        for rank, settings in ranked_settings:
+            for provider_name, provider_models in settings.get("modelProviders", {}).items():
+                if not isinstance(provider_models, list):
+                    continue
+                model_map = provider_model_entries.setdefault(provider_name, {})
+                for raw_model in provider_models:
+                    if not isinstance(raw_model, dict):
+                        continue
+                    model_id = raw_model.get("id")
+                    if not isinstance(model_id, str) or not model_id:
+                        continue
+                    model_map.setdefault(model_id, []).append((rank, deepcopy(raw_model)))
+
+        # If no modelProviders found, return base settings as-is
+        if not provider_model_entries:
+            return base_settings
+
+        # Rebuild each provider's model list with deduplication
+        merged_providers: dict[str, list[dict[str, Any]]] = {}
+        for provider_name, pm_map in provider_model_entries.items():
+            ranked: list[tuple[tuple[int, int, int], str, dict[str, Any]]] = []
+            for mid, model_entries in pm_map.items():
+                # Pick the config from the highest-priority key
+                canonical_rank, canonical_model = sorted(model_entries, key=lambda x: x[0])[0]
+                ranked.append((canonical_rank, mid, canonical_model))
+            # Sort by rank then model ID for deterministic ordering
+            ranked.sort(key=lambda x: (x[0], x[1]))
+            merged_providers[provider_name] = [model for _, _, model in ranked]
+
+        base_settings["modelProviders"] = merged_providers
+        if merged_providers and "$version" not in base_settings:
+            base_settings["$version"] = 3
+
+        return base_settings
 
     def _list_tool_key_rows(
         self,

--- a/app/modules/workspace/api_key_proxy.py
+++ b/app/modules/workspace/api_key_proxy.py
@@ -674,14 +674,14 @@ class APIKeyProxyService:
             Merged settings dict with the union of all models.
         """
         # Sort so the highest-priority key comes first
-        ranked_settings.sort(key=lambda item: item[0])
-        base_settings = deepcopy(ranked_settings[0][1])
+        sorted_settings = sorted(ranked_settings, key=lambda item: item[0])
+        base_settings = deepcopy(sorted_settings[0][1])
 
         # Collect per-provider model entries, deduplicated by model ID
         provider_model_entries: dict[
             str, dict[str, list[tuple[tuple[int, int, int], dict[str, Any]]]]
         ] = {}
-        for rank, settings in ranked_settings:
+        for rank, settings in sorted_settings:
             for provider_name, provider_models in settings.get("modelProviders", {}).items():
                 if not isinstance(provider_models, list):
                     continue

--- a/tests/unit/test_cli_settings_strip.py
+++ b/tests/unit/test_cli_settings_strip.py
@@ -405,3 +405,29 @@ class TestMergeMultiKeySettings:
 
         assert result["model_provider"] == "openace"
         assert result["model_providers"]["openace"]["name"] == "Proxy A"
+
+    def test_dedup_within_single_key(self):
+        """Duplicate model IDs within the same key are ignored."""
+        svc = self._make_svc()
+        ranked = [
+            (
+                (-10, -100, 1),
+                {
+                    "modelProviders": {
+                        "openai": [
+                            {"id": "qwen-max", "name": "First"},
+                            {"id": "qwen-max", "name": "Duplicate"},
+                            {"id": "qwen-plus", "name": "Plus"},
+                        ]
+                    },
+                },
+            ),
+        ]
+
+        result = svc._merge_multi_key_settings(ranked)
+
+        models = result["modelProviders"]["openai"]
+        model_ids = [m["id"] for m in models]
+        assert model_ids == ["qwen-max", "qwen-plus"]
+        # First occurrence wins within the same key
+        assert next(m for m in models if m["id"] == "qwen-max")["name"] == "First"

--- a/tests/unit/test_cli_settings_strip.py
+++ b/tests/unit/test_cli_settings_strip.py
@@ -231,3 +231,177 @@ class TestToolModelPool:
             "shared-model",
             "low-only",
         ]
+
+
+class TestMergeMultiKeySettings:
+    """Test _merge_multi_key_settings for multi-API-key model merging."""
+
+    def _make_svc(self):
+        from app.modules.workspace.api_key_proxy import APIKeyProxyService
+
+        return APIKeyProxyService.__new__(APIKeyProxyService)
+
+    def test_single_key_returns_unchanged(self):
+        """Single key fast path — returned directly, not merged."""
+        svc = self._make_svc()
+        settings = {"modelProviders": {"openai": [{"id": "qwen-max"}]}, "theme": "dark"}
+
+        result = svc._merge_multi_key_settings([((0, -100, 1), settings)])
+
+        assert result["theme"] == "dark"
+        assert result["modelProviders"]["openai"] == [{"id": "qwen-max"}]
+
+    def test_disjoint_models_are_unioned(self):
+        """Two keys with non-overlapping models — all models appear."""
+        svc = self._make_svc()
+        ranked = [
+            ((-10, -100, 1), {"modelProviders": {"openai": [{"id": "qwen-max"}]}}),
+            ((-5, -100, 2), {"modelProviders": {"openai": [{"id": "qwen-turbo"}]}}),
+        ]
+
+        result = svc._merge_multi_key_settings(ranked)
+
+        model_ids = [m["id"] for m in result["modelProviders"]["openai"]]
+        assert sorted(model_ids) == ["qwen-max", "qwen-turbo"]
+
+    def test_overlapping_model_id_uses_highest_priority(self):
+        """Same model ID in two keys — highest-priority config wins."""
+        svc = self._make_svc()
+        ranked = [
+            (
+                (-10, -100, 1),
+                {
+                    "modelProviders": {
+                        "openai": [
+                            {
+                                "id": "qwen-max",
+                                "name": "Key A qwen-max",
+                                "generationConfig": {"temperature": 0.5},
+                            },
+                        ]
+                    },
+                },
+            ),
+            (
+                (-5, -100, 2),
+                {
+                    "modelProviders": {
+                        "openai": [
+                            {"id": "qwen-max", "name": "Key B qwen-max"},
+                        ]
+                    },
+                },
+            ),
+        ]
+
+        result = svc._merge_multi_key_settings(ranked)
+
+        models = result["modelProviders"]["openai"]
+        assert len(models) == 1
+        assert models[0]["name"] == "Key A qwen-max"
+        assert models[0]["generationConfig"]["temperature"] == 0.5
+
+    def test_base_settings_from_highest_priority(self):
+        """Non-model settings come from the highest-priority key."""
+        svc = self._make_svc()
+        ranked = [
+            (
+                (-10, -100, 1),
+                {
+                    "modelProviders": {"openai": [{"id": "m1"}]},
+                    "theme": "dark",
+                    "customField": "from-high-priority",
+                },
+            ),
+            (
+                (-5, -100, 2),
+                {
+                    "modelProviders": {"openai": [{"id": "m2"}]},
+                    "theme": "light",
+                    "customField": "from-low-priority",
+                },
+            ),
+        ]
+
+        result = svc._merge_multi_key_settings(ranked)
+
+        assert result["theme"] == "dark"
+        assert result["customField"] == "from-high-priority"
+
+    def test_no_model_providers_returns_base_settings(self):
+        """Keys without modelProviders — base settings returned as-is."""
+        svc = self._make_svc()
+        ranked = [
+            ((-10, -100, 1), {"theme": "dark", "model": "haiku"}),
+            ((-5, -100, 2), {"theme": "light"}),
+        ]
+
+        result = svc._merge_multi_key_settings(ranked)
+
+        assert result["theme"] == "dark"
+        assert result["model"] == "haiku"
+        # No modelProviders key injected
+        assert "modelProviders" not in result
+
+    def test_same_priority_lower_key_id_wins(self):
+        """Same priority — lower key_id (earlier insertion) wins as canonical."""
+        svc = self._make_svc()
+        ranked = [
+            (
+                (-10, -100, 5),
+                {
+                    "modelProviders": {"openai": [{"id": "m1", "name": "Key 5"}]},
+                },
+            ),
+            (
+                (-10, -100, 2),
+                {
+                    "modelProviders": {"openai": [{"id": "m1", "name": "Key 2"}]},
+                },
+            ),
+        ]
+
+        result = svc._merge_multi_key_settings(ranked)
+
+        models = result["modelProviders"]["openai"]
+        assert len(models) == 1
+        # Key 2 has lower key_id, so after sorting (-10, -100, 2) comes before (-10, -100, 5)
+        assert models[0]["name"] == "Key 2"
+
+    def test_does_not_affect_claude_code_settings(self):
+        """Claude Code has no modelProviders — merge returns base settings."""
+        svc = self._make_svc()
+        ranked = [
+            ((-10, -100, 1), {"env": {"ANTHROPIC_MODEL": "claude-3"}, "model": "haiku"}),
+            ((-5, -100, 2), {"env": {"ANTHROPIC_MODEL": "claude-4"}, "model": "sonnet"}),
+        ]
+
+        result = svc._merge_multi_key_settings(ranked)
+
+        assert result["env"]["ANTHROPIC_MODEL"] == "claude-3"
+        assert result["model"] == "haiku"
+
+    def test_does_not_affect_codex_settings(self):
+        """Codex uses model_providers (snake_case), not modelProviders — merge is a no-op."""
+        svc = self._make_svc()
+        ranked = [
+            (
+                (-10, -100, 1),
+                {
+                    "model_provider": "openace",
+                    "model_providers": {"openace": {"name": "Proxy A"}},
+                },
+            ),
+            (
+                (-5, -100, 2),
+                {
+                    "model_provider": "openace",
+                    "model_providers": {"openace": {"name": "Proxy B"}},
+                },
+            ),
+        ]
+
+        result = svc._merge_multi_key_settings(ranked)
+
+        assert result["model_provider"] == "openace"
+        assert result["model_providers"]["openace"]["name"] == "Proxy A"


### PR DESCRIPTION

## Summary

当系统中有多个 API key 可用于同一工具（如 qwen-code），每个 key 有各自的 model 列表时，远程终端创建 `~/.qwen/settings.json` 只会取**第一个匹配 key 的 settings**，导致其他 key 的 model 被丢失。

## Changes

- **重构 `get_cli_settings_for_tool()`**：收集所有匹配 key 的 settings，多 key 时合并 `modelProviders`（按 model ID 去重，高 priority key 的配置优先）
- **新增 `_merge_multi_key_settings()`**：复用 `get_tool_model_pool()` 的去重排序逻辑，按 provider 分组合并 model 列表
- **修复排序**：SQL `ORDER BY` 从 `id DESC` 改为 `priority DESC, weight DESC, id ASC`，正确反映 priority/weight
- **单 key 快速路径**：只有 1 个匹配 key 时直接返回，完全向后兼容
- **新增 8 个测试用例**：覆盖单 key、model 不重叠、重叠去重、base settings、无 modelProviders、同 priority、Claude/Codex 不受影响等场景

## Impact

- **qwen-code**：✅ 多 key 的 model 列表正确合并到 settings.json
- **claude-code**：❌ 不受影响（settings 中没有 `modelProviders`）
- **codex**：❌ 不受影响（使用 `model_providers` snake_case）

Closes #680

🤖 Generated with [Claude Code](https://claude.com/claude-code)