### PR TITLE
Refine AI coding agent control plane positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <strong>AI Computing Explorer</strong><br>
-  <em>自托管 AI 工作台 · 统一接入 Claude Code、Qwen Code、Codex 与 OpenClaw</em>
+  <em>自托管 AI Coding Agent 工作台与治理控制面</em>
 </p>
 
 <p align="center">
@@ -33,27 +33,30 @@
 
 ## 🎯 这是什么？
 
-**Open ACE** 是一个开源的**企业级 AI 工作平台**：一边给团队成员提供统一的 AI 工作入口，一边给管理员提供用量、成本、权限、合规和审计视图。
+**Open ACE** 是一个开源的**自托管 AI Coding Agent 工作台与治理控制面**：开发者可以在浏览器里统一使用 Claude Code、Qwen Code、Codex、OpenClaw 等 AI 编码工具，并把它们运行在团队自己的远程机器上；管理员可以集中管理 API Key、权限、成本、配额、审计和合规。
 
-它适合正在把 Claude Code、Qwen Code、Codex、OpenClaw 等 AI 工具引入团队的组织，尤其适合需要私有化部署、统一治理和可量化 ROI 的研发团队、IT 团队和 AI 平台团队。
+它适合已经把 AI Coding Agent 引入真实研发流程的组织，尤其适合需要私有化部署、内网远程机器、统一密钥代理、团队配额和可追溯审计的研发团队、IT 团队和 AI 平台团队。
 
 | 问题 | 解决方案 |
 |------|----------|
-| 🤔 **AI 用得好不好？** | Work 模式让员工高效使用 AI，提升生产力 |
-| 😰 **AI 管得住管不住？** | Manage 模式让管理者全面掌控 AI 使用情况 |
+| 🤖 **团队同时使用多个 AI Coding Agent** | 多 CLI 工作台统一 Claude Code、Qwen Code、Codex、OpenClaw 等工具 |
+| 🖥️ **Agent 需要跑在内网、测试机或 GPU 机器上** | Remote Agent 让 AI CLI 直接在目标机器执行 |
+| 🔑 **API Key 不该散落在个人电脑和远程机器上** | API Key Proxy 把真实密钥留在服务端，只下发短期代理令牌 |
+| 📊 **成本、配额、风险和审计需要可见** | Manage 模式提供用量、成本、配额、异常、审计和合规视图 |
 
 **你可以用 Open ACE 做什么：**
 
-- 给员工一个统一入口，管理本地/远程 AI 会话、提示词、历史记录和项目上下文
-- 通过 Remote Agent 把 AI CLI 跑在团队自己的开发机、测试机或 GPU 机器上
-- 给管理者一套治理面板，查看 Token、成本、异常、配额、审计、合规报告和 ROI
+- 给团队一个统一入口，管理本地/远程 AI coding 会话、提示词、历史记录和项目上下文
+- 通过 Remote Agent 把 Claude Code、Qwen Code、Codex、OpenClaw 等 CLI 跑在团队自己的开发机、测试机或 GPU 机器上
 - 加密保存 LLM API Key，通过短期代理令牌给本地和远程会话安全调用模型
+- 给管理者一套控制面板，查看 Token、成本、异常、配额、审计、合规报告和 ROI
 - 在自己的网络里部署，保留企业数据边界，并逐步接入 SSO、飞书/钉钉和 Kubernetes
 
 ## 🔥 近期功能亮点
 
 | 功能 | 为什么重要 |
 |------|------------|
+| AI Coding Agent 控制面 | 把团队已在使用的多个 AI CLI 纳入统一入口、权限、成本和审计体系 |
 | 远程工作区与 Remote Agent | 用户在浏览器里选择远程机器，AI CLI 直接在目标机器运行，无需反复传 SSH 凭据 |
 | 多 CLI 适配器 | Claude Code、Qwen Code、Codex、OpenClaw 统一接入，包含会话恢复、权限模式和历史同步 |
 | API Key 代理 | API Key 加密存储在服务器，远程 Agent 只拿短期代理令牌，统一配额和用量统计 |
@@ -103,6 +106,7 @@
 | 特性 | 说明 |
 |------|------|
 | 🔒 **默认自托管** | 私有化部署，数据和 API Key 留在自己的网络与数据库里 |
+| 🎛️ **Agent 控制面** | 统一管理工具、用户、机器、密钥、配额、成本和审计，而不是替代每个 AI CLI |
 | 🌐 **多工具工作台** | Claude Code、Qwen Code、Codex、OpenClaw 统一入口、统一历史、统一治理 |
 | 🖥️ **远程执行** | Remote Agent 让 AI CLI 在目标机器运行，适合研发服务器、测试环境和 GPU 机器 |
 | 📊 **治理可观测** | Token、成本、配额、异常、审计、合规和 ROI 统一分析 |
@@ -316,8 +320,8 @@ open-ace/
 ---
 
 <p align="center">
-  <strong>把 AI 工具接进来，把成本和风险管起来</strong><br>
-  <em>Open ACE — self-hosted workspace and governance for real AI adoption</em>
+  <strong>把 AI Coding Agent 接进来，把密钥、成本和风险管起来</strong><br>
+  <em>Open ACE — self-hosted workspace and control plane for AI coding agents</em>
 </p>
 
 ---
@@ -326,27 +330,30 @@ open-ace/
 
 ## 🎯 What is This?
 
-**Open ACE** is an open-source **Enterprise AI Work Platform**: it gives employees a unified AI work entry point and gives administrators visibility into usage, cost, access control, compliance, and audit trails.
+**Open ACE** is an open-source **self-hosted workspace and control plane for AI coding agents**: developers can use Claude Code, Qwen Code, Codex, OpenClaw, and similar tools from one browser workspace while running them on the team's own remote machines; administrators can centralize API keys, access control, quotas, cost visibility, audit trails, and compliance.
 
-It is built for teams adopting tools such as Claude Code, Qwen Code, Codex, and OpenClaw, especially organizations that need self-hosted deployment, centralized governance, and measurable AI ROI.
+It is built for teams moving AI coding agents into real engineering workflows, especially organizations that need self-hosted deployment, private-network machines, centralized key proxying, team quotas, and traceable audit records.
 
 | Challenge | Solution |
 |-----------|----------|
-| 🤔 **Are we using AI effectively?** | Work Mode empowers employees to use AI efficiently and boost productivity |
-| 😰 **Is AI under control?** | Manage Mode gives administrators full visibility and control over AI usage |
+| 🤖 **Teams use multiple AI coding agents** | Multi-CLI workspace for Claude Code, Qwen Code, Codex, OpenClaw, and more |
+| 🖥️ **Agents need to run on internal, staging, or GPU machines** | Remote Agent runs AI CLIs directly on target machines |
+| 🔑 **API keys should not spread across laptops and remote boxes** | API Key Proxy keeps real keys on the server and issues short-lived proxy tokens |
+| 📊 **Cost, quotas, risk, and audit need visibility** | Manage Mode tracks usage, cost, quotas, anomalies, audit trails, and compliance |
 
 **What you can do with Open ACE:**
 
-- Give employees one place for local/remote AI sessions, prompts, history, and project context
-- Run AI CLIs on your own development, staging, or GPU machines through the Remote Agent
-- Give administrators dashboards for tokens, cost, anomalies, quotas, audits, compliance reports, and ROI
+- Give teams one place for local/remote AI coding sessions, prompts, history, and project context
+- Run Claude Code, Qwen Code, Codex, OpenClaw, and similar CLIs on your own development, staging, or GPU machines through the Remote Agent
 - Store LLM API keys centrally and issue short-lived proxy tokens to local and remote sessions
+- Give administrators a control plane for tokens, cost, anomalies, quotas, audits, compliance reports, and ROI
 - Deploy inside your own network while integrating SSO, Feishu/DingTalk, and Kubernetes over time
 
 ## 🔥 Recent Highlights
 
 | Capability | Why it matters |
 |------------|----------------|
+| AI coding agent control plane | Bring the team's existing AI CLIs under one access, key, quota, cost, and audit model |
 | Remote Workspace and Remote Agent | Users choose a remote machine in the browser and run AI CLIs there without repeatedly sharing SSH credentials |
 | Multi-CLI adapters | Claude Code, Qwen Code, Codex, and OpenClaw share one workspace with session recovery, permission modes, and history sync |
 | API Key proxy | Keys are encrypted on the server; remote agents only receive short-lived proxy tokens with unified quota and usage tracking |
@@ -396,6 +403,7 @@ It is built for teams adopting tools such as Claude Code, Qwen Code, Codex, and 
 | Feature | Description |
 |---------|-------------|
 | 🔒 **Self-hosted by default** | Keep data and API keys inside your own network and database |
+| 🎛️ **Agent control plane** | Manage tools, users, machines, keys, quotas, cost, and audit trails without replacing every AI CLI |
 | 🌐 **Multi-tool workspace** | Claude Code, Qwen Code, Codex, and OpenClaw with unified access, history, and governance |
 | 🖥️ **Remote execution** | Remote Agent runs AI CLIs on development servers, staging boxes, or GPU machines |
 | 📊 **Governance observability** | Analyze tokens, cost, quotas, anomalies, audits, compliance, and ROI together |
@@ -609,6 +617,6 @@ This project is licensed under the [Apache 2.0 License](LICENSE).
 ---
 
 <p align="center">
-  <strong>Bring AI tools in. Keep cost and risk under control.</strong><br>
-  <em>Open ACE — self-hosted workspace and governance for real AI adoption</em>
+  <strong>Bring AI coding agents in. Keep keys, cost, and risk under control.</strong><br>
+  <em>Open ACE — self-hosted workspace and control plane for AI coding agents</em>
 </p>

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,6 +29,7 @@ Documentation files are in the [en/](en/) directory.
 | [**CONCEPTS**](en/CONCEPTS.md) | Core concept definitions — Request, Message, Session, Conversation |
 | [**REPOSITORY-SETUP**](REPOSITORY_SETUP.md) | GitHub repository topics, labels, releases, and demo checklist |
 | [**MARKETING**](marketing/README.md) | Launch kit, early adopter discussion, and technical article drafts |
+| [**STRATEGY**](strategy/COMPETITIVE_POSITIONING.md) | Competitive positioning, market landscape, and product strategy |
 
 ### Reading Guide by Role
 
@@ -40,6 +41,7 @@ Documentation files are in the [en/](en/) directory.
 | API integrator | API → PERMISSION-MODEL → CONCEPTS |
 | Managing remote machines | REMOTE-WORKSPACE → REMOTE-AGENT |
 | Growing the project | MARKETING → REPOSITORY-SETUP |
+| Product strategy | STRATEGY → ROADMAP |
 
 ---
 
@@ -68,6 +70,7 @@ Documentation files are in the [en/](en/) directory.
 | [**CONCEPTS**](cn/CONCEPTS.md) | 核心概念定义 — Request、Message、Session、Conversation |
 | [**REPOSITORY-SETUP**](REPOSITORY_SETUP.md) | GitHub 仓库 topics、labels、releases 和 Demo 检查清单 |
 | [**MARKETING**](marketing/README.md) | 发布传播材料、早期用户讨论帖和技术文章草稿 |
+| [**STRATEGY**](strategy/COMPETITIVE_POSITIONING.md) | 竞争定位、市场格局和产品发展策略 |
 
 ### 按角色阅读指南
 
@@ -79,6 +82,7 @@ Documentation files are in the [en/](en/) directory.
 | API 集成 | API → PERMISSION-MODEL → CONCEPTS |
 | 管理远程机器 | REMOTE-WORKSPACE → REMOTE-AGENT |
 | 推广项目 | MARKETING → REPOSITORY-SETUP |
+| 产品策略 | STRATEGY → ROADMAP |
 
 ---
 
@@ -90,5 +94,6 @@ docs/
 ├── en/                # English documentation (15 files)
 ├── cn/                # 中文文档（15 个文件）
 ├── marketing/         # Launch and outreach materials / 发布传播材料
+├── strategy/          # Competitive positioning / 竞争定位
 └── images/            # Documentation images / 文档图片
 ```

--- a/docs/strategy/COMPETITIVE_POSITIONING.md
+++ b/docs/strategy/COMPETITIVE_POSITIONING.md
@@ -1,0 +1,475 @@
+# OpenAce 竞争定位与发展策略
+
+> 最后更新：2026-06-03
+>
+> 这份文档用于内部讨论、产品路线判断和对外定位统一。它不是一次性的市场宣传稿，而是一份可以持续维护的战略参考。
+
+## 一句话结论
+
+OpenAce 不应该把自己定位成“另一个 AI 编程助手”或“另一个 IDE”，而应该定位成：
+
+> 面向团队 AI Coding Agent 落地的自托管工作平台和治理控制面。
+
+英文表达可以是：
+
+> OpenAce is a self-hosted workspace and control plane for teams running AI coding agents.
+
+更锐利的战略表达：
+
+> OpenAce is the self-hosted control plane for teams running AI coding agents across remote machines, model providers, and governance policies.
+
+## 为什么是控制面
+
+“工作平台”强调用户在哪里干活，中心是开发者体验：
+
+- AI 会话
+- 提示词库
+- 历史记录
+- 浏览器终端
+- 远程目录
+- code-server / VSCode 入口
+
+“控制面”强调团队如何管理这些工作流，中心是编排、治理、安全和可观测：
+
+- 谁能用
+- 能在哪台机器上运行
+- 能用哪个模型和工具
+- API Key 如何保存和代理
+- 成本、配额和速率如何控制
+- 会话、命令、文件和模型调用如何审计
+- 出现风险时如何告警、阻断和追溯
+
+| 概念 | 负责什么 | OpenAce 对应能力 |
+|------|----------|------------------|
+| 工作平台 | 人机交互入口 | Work Mode、会话、提示词、终端、code-server |
+| 控制面 | 策略、权限、调度、治理 | Remote Agent 管理、API Key Proxy、配额、审计、成本、合规 |
+| 执行面 / 数据面 | 真正执行任务和调用模型 | Claude Code、Codex、Qwen Code、OpenClaw、远程机器 |
+
+建议对外不要完全放弃“工作平台”，因为它更容易被普通用户理解。但在差异化表达、投资判断、竞品分析和路线规划里，要突出“控制面”。
+
+推荐主定位：
+
+> OpenAce 是面向团队 AI Coding Agent 落地的自托管工作平台和治理控制面，统一远程执行、密钥代理、成本配额、审计合规和多工具工作流。
+
+## 市场背景
+
+AI Coding 正在从个人助手阶段进入团队生产阶段。这个阶段的主要问题会从“哪个模型更强”转向：
+
+- 团队里同时使用多个 AI coding agent，入口和历史如何统一？
+- API Key 是否要下发到每台开发机？
+- Agent 是否能安全地跑在内网开发机、测试机、GPU 机器上？
+- 谁能使用哪些机器、模型、工具和权限模式？
+- 成本、token、配额、异常调用如何可见？
+- 会话、命令、文件修改和模型调用如何审计？
+- 如何把 issue、agent session、branch、PR 和审计记录连起来？
+
+这正是 OpenAce 的机会。OpenAce 不必替代 Claude Code、Codex、Qwen Code、Gemini CLI、Aider 或 OpenHands，而应该成为团队管理这些工具的控制层。
+
+## 竞品地图
+
+### 1. AI Coding Agent 控制面
+
+这一类最接近 OpenAce 的未来方向。
+
+| 产品 / 项目 | 主要特点 | 对 OpenAce 的启发 |
+|-------------|----------|------------------|
+| Coder / Coder Agents | 自托管开发环境控制面，强调云开发环境、AI agent、集中权限、环境治理 | 最值得认真对标。Coder 强在 CDE 和企业基础设施，OpenAce 应避开完整 CDE 正面竞争 |
+| Gitpod / Ona | 云开发环境和 background agent 方向，强调从 issue/task 到远程环境执行 | 可借鉴 issue 到 agent 执行的闭环 |
+| Continue / Mission Control | 面向 AI agent / workflow / IDE 的团队化管理方向 | 可借鉴团队 agent workflow 和配置分发 |
+| 新兴多 agent dashboard | 例如 amux、Nova Code、ClauBoard 等 | 会抢早期开发者注意力，但多数较轻，企业治理深度有限 |
+
+判断：
+
+Coder 是最接近的战略竞品。它的强项是企业级开发环境、Terraform/Kubernetes、workspace 生命周期和大企业部署。OpenAce 不应该试图在这些方面短期超越 Coder，而应聚焦“接管已有机器 + 多 AI CLI + API Key proxy + 审计治理”的轻量场景。
+
+### 2. AI 编程助手和 Agent
+
+这一类拥有最强用户入口，但不应该被视为必须正面替代的对象。
+
+| 产品 / 项目 | 主要特点 | 和 OpenAce 的关系 |
+|-------------|----------|------------------|
+| GitHub Copilot / coding agent | 深度绑定 GitHub、IDE 和 PR 工作流 | 强入口。OpenAce 可做补充治理，尤其在多工具、自托管和内网执行场景 |
+| OpenAI Codex | 云端/CLI coding agent，适合任务执行和 PR 工作流 | OpenAce 应作为 Codex CLI 的团队控制面之一 |
+| Claude Code | 强 CLI agent，开发者采用快 | OpenAce 应支持其远程执行、密钥代理、审计和权限策略 |
+| Cursor / Windsurf | AI IDE 和个人开发者体验强 | 不正面竞争 IDE 体验，强调团队治理和远程执行 |
+| Devin | 更完整的 AI software engineer 产品 | 对标任务闭环，但不拼 SaaS agent 产品体验 |
+| Qwen Code / Gemini CLI / Aider / OpenHands / Cline / Roo Code / SWE-agent | 开源或半开源 coding agent 生态 | OpenAce 应通过适配器接入，成为多工具控制面 |
+
+判断：
+
+这些工具是 OpenAce 的“执行面”和“生态对象”，不是主要替代对象。OpenAce 的文案要避免让人误以为它要做另一个 AI IDE，而要强调：
+
+> Bring your own coding agents. OpenAce manages where they run, which keys they use, and how teams audit them.
+
+### 3. 自托管开发环境控制面
+
+| 产品 / 项目 | 主要特点 | 和 OpenAce 的关系 |
+|-------------|----------|------------------|
+| Coder | 企业级 self-hosted CDE，workspace 模板、权限、审计、agent 支持 | 最强近邻，尤其在远程开发环境和 AI agent 运维上 |
+| DevPod | 开源开发环境客户端，轻量连接 Kubernetes、Docker、云环境 | 可作为未来开发环境后端或集成对象 |
+| Daytona | 开源开发环境管理，强调标准化开发环境 | 可借鉴 workspace 生命周期和环境模板 |
+| Gitpod / Ona | 云开发环境和后台任务执行 | 可借鉴 task/issue 到环境的执行链路 |
+| code-server | 浏览器里的 VS Code | OpenAce 可以继续作为远程开发入口组件接入 |
+
+判断：
+
+OpenAce 不应该在 6-12 个月内追求“完整开发环境平台”。正确策略是：
+
+- 接管已有开发机、测试机、GPU 机器和内网服务器
+- 通过 Remote Agent 注册机器
+- 提供 AI CLI、终端、目录和 code-server 入口
+- 对机器、用户、API Key、会话和成本做治理
+
+也就是说，OpenAce 做“AI agent 控制层”，不是做“完整 CDE 替代品”。
+
+### 4. LLM 网关、可观测和治理
+
+| 产品 / 项目 | 主要特点 | 和 OpenAce 的关系 |
+|-------------|----------|------------------|
+| LiteLLM | OpenAI-compatible proxy、virtual keys、budget、rate limit、spend tracking | 应优先集成，而不是完全重做 |
+| Langfuse | LLM observability、trace、prompt、eval、自托管 | 可作为 trace/eval 后端或集成对象 |
+| Portkey | AI gateway、routing、observability、governance | 可借鉴企业网关能力 |
+| Helicone | LLM logging、observability、cache、cost | 可借鉴轻量观测体验 |
+| Kong AI Gateway | 企业 API 网关切入 AI 流量治理 | 大企业网关层竞争者 |
+
+判断：
+
+OpenAce 不应该把自己做成通用 LLM Gateway。更好的做法：
+
+- OpenAce 管用户、机器、会话、任务、CLI、文件和审计上下文
+- LiteLLM / Langfuse 管 provider 兼容、virtual key、模型路由、trace 和 eval
+- OpenAce 把模型调用和 coding agent 执行链路关联起来
+
+这样可以避免重复造轮子，同时保留 OpenAce 在 AI coding 场景中的上层价值。
+
+### 5. 企业代码助手
+
+| 产品 / 项目 | 主要特点 | 和 OpenAce 的关系 |
+|-------------|----------|------------------|
+| Sourcegraph Cody | 代码搜索、上下文理解、企业代码助手 | 强在代码库上下文，不是多 agent 控制面 |
+| Tabnine Enterprise | 私有化代码补全和企业部署 | 强在补全和企业私有化 |
+| Tabby | 自托管 AI coding assistant | 开源自托管代码助手，偏模型/补全/聊天 |
+| JetBrains AI / Amazon Q Developer / Gemini Code Assist | 企业 IDE 和云生态集成 | 会争夺企业 AI coding 预算 |
+
+判断：
+
+这些产品会影响预算和心智，但定位不同。OpenAce 应避免“代码补全助手”叙事，重点讲：
+
+- 多 agent
+- 远程执行
+- 密钥不下发
+- 成本和配额
+- 审计和合规
+- 团队级控制
+
+### 6. 通用 Agent / Workflow 平台
+
+| 产品 / 项目 | 主要特点 | 和 OpenAce 的关系 |
+|-------------|----------|------------------|
+| Dify | 开源 LLM 应用和 agent workflow 平台 | 通用 AI 应用平台，不专注软件研发执行链路 |
+| Flowise | 可视化 LLM workflow / agent builder | 可借鉴 workflow UX |
+| n8n | 自动化 workflow，AI 节点增强 | 可借鉴审批和自动化 |
+| LangGraph Platform | agent deployment、control plane、stateful workflow | 可借鉴 agent control plane 概念 |
+
+判断：
+
+这些平台会教育市场理解“agent workflow”和“control plane”，但 OpenAce 应保持软件研发垂直场景，不要变成通用 AI workflow 平台。
+
+## OpenAce 的优势
+
+1. 定位有差异化
+
+OpenAce 不是单纯聊天 UI，而是 Work Mode + Manage Mode。这天然适合团队场景。
+
+2. Remote Agent + API Key Proxy 是核心卖点
+
+AI CLI 跑在远程机器，真实 API Key 加密保存在 OpenAce 服务端，远程机器只拿短期代理令牌。这是安全、治理和企业采用的关键叙事。
+
+3. 多 CLI 统一入口有机会
+
+团队不太可能只使用一个 agent。OpenAce 支持 Claude Code、Qwen Code、Codex、OpenClaw，并可以继续扩展 Gemini CLI、Aider、OpenHands、Cline 等。
+
+4. 自托管和 Apache 2.0 有吸引力
+
+对私有化、内网、合规敏感、中国团队、多模型团队来说，自托管控制面比纯 SaaS 更容易进入试用。
+
+5. 已有治理基础
+
+OpenAce 已经具备成本、token、配额、审计、合规报表、多租户、SSO、远程机器、API Key 管理等模块雏形。
+
+## OpenAce 的劣势
+
+1. 社区信号仍弱
+
+截至 2026-06-03，仓库公开指标仍处于早期阶段：stars、forks、watchers、外部贡献都很少。需要真实用户和案例支撑。
+
+2. 开发者体验难以正面挑战成熟 IDE
+
+Cursor、Windsurf、Copilot、Claude Code 的个人体验和分发渠道非常强。OpenAce 不应正面拼 IDE 体验。
+
+3. 开发环境基础设施难以正面挑战 Coder
+
+Coder 在 workspace 模板、企业部署、权限、环境生命周期和 CDE 心智上领先。OpenAce 不应短期追求完整 CDE。
+
+4. LLM Gateway 能力不如专业产品
+
+LiteLLM、Portkey、Langfuse 在 provider 兼容、virtual key、routing、trace、eval 上更成熟。OpenAce 应集成它们。
+
+5. 治理能力需要更多可信证据
+
+“合规、审计、安全”不能只停留在功能列表，需要补充威胁模型、审计样例、数据流、密钥生命周期、权限边界和部署加固说明。
+
+6. 定位过宽会稀释认知
+
+如果同时讲 AI 工作平台、LLMOps、CDE、审计、ROI、SSO、Kubernetes、报表，很容易让用户不知道第一使用场景是什么。
+
+## 推荐竞争策略
+
+### 总策略
+
+> 不跟 IDE 拼体验，不跟 Coder 拼完整开发环境，不跟 LiteLLM 拼模型网关。OpenAce 要赢的点是：让团队把已经在用的 AI Coding Agents 安全接入自己的机器、密钥、权限、成本和审计体系。
+
+### 1. 避开 Coder 的强项
+
+Coder 强在：
+
+- 标准化开发环境
+- workspace templates
+- Terraform / Kubernetes
+- 大企业 CDE 部署
+- 完整环境生命周期
+
+OpenAce 应避免短期正面竞争这些能力，改打：
+
+- 已有远程机器
+- 轻量 Agent 注册
+- 多 AI CLI 接入
+- API Key 不下发
+- 会话级审计
+- 成本和配额可见
+
+### 2. 把 Remote Agent 做成招牌功能
+
+需要让用户在 10 分钟内看到：
+
+1. 启动 OpenAce
+2. 添加 API Key
+3. 注册一台远程机器
+4. 授权用户访问机器
+5. 在浏览器里启动 Claude Code / Codex / Qwen Code
+6. 查看会话输出、token、成本和审计记录
+
+如果这个 demo 顺滑，OpenAce 的差异化就能成立。
+
+### 3. 做多工具控制面
+
+OpenAce 应明确支持 “Bring your own coding agent”：
+
+- Claude Code
+- OpenAI Codex CLI
+- Qwen Code
+- Gemini CLI
+- Aider
+- OpenHands
+- Cline / Roo Code
+- 其他 OpenAI-compatible coding agents
+
+每个适配器不必一开始都做到非常深，但至少应有统一的：
+
+- 安装检查
+- 启动
+- 会话恢复
+- 输出采集
+- 权限模式
+- token / cost 统计
+- 审计事件
+
+### 4. 集成 LiteLLM / Langfuse
+
+建议路线：
+
+- 短期：OpenAce 保留内置 API Key Proxy，满足最小闭环
+- 中期：支持把 LiteLLM 作为模型网关后端
+- 中期：支持把 Langfuse 作为 trace/eval 后端
+- 长期：OpenAce 专注 coding-agent 场景层，把模型层能力交给专业组件
+
+### 5. 优先打私有化和内网团队
+
+早期 ICP：
+
+- 5-100 人研发团队
+- 已经有人在用 Claude Code / Codex / Qwen Code / Gemini CLI
+- 有内网开发机、测试机或 GPU 机器
+- 不希望 API Key 散落在每个人电脑和远程机器上
+- 需要成本、配额、审计、权限和团队可见性
+- 暂时不想引入重型 CDE 或纯 SaaS 平台
+
+更容易切入的用户：
+
+- 中国研发团队
+- 私有化部署团队
+- AI 平台团队
+- DevOps / 内部工具团队
+- 有合规或内网限制的企业研发部门
+
+## 产品路线建议
+
+### 0-3 个月：Remote AI Coding Agent 控制面
+
+目标：把“注册远程机器并安全运行 AI CLI”做成最强 demo。
+
+优先级：
+
+1. Remote Agent 注册、心跳、在线状态稳定化
+2. 用户到机器的授权关系清晰化
+3. API Key Proxy 支持 TTL、scope、quota、审计事件
+4. 每个 session 有事件时间线
+5. 终端、目录、code-server 入口稳定
+6. 支持 Claude Code、Codex、Qwen Code 的最小一致体验
+7. GitHub / GitLab issue 到 agent session 的最小闭环
+8. 输出一份 10 分钟 demo 文档和视频脚本
+
+关键验收：
+
+- 新用户能在 10 分钟内本地启动 OpenAce
+- 管理员能在 5 分钟内注册远程机器
+- 普通用户能创建一次远程 AI coding session
+- 管理员能看到这次 session 的模型调用、成本、命令和审计记录
+
+### 3-6 个月：团队治理和安全策略
+
+目标：让 OpenAce 从“能跑”变成“团队敢用”。
+
+优先级：
+
+1. 命令 allow / deny policy
+2. 敏感文件保护，例如 `.env`、SSH key、生产配置
+3. 高风险操作审批，例如 `git push`、删除、部署命令
+4. 预算、配额、速率限制的统一策略
+5. SSO / RBAC / SCIM 或企业身份同步增强
+6. 审计导出和合规报表样例
+7. LiteLLM 集成
+8. Langfuse 集成调研或 PoC
+
+关键验收：
+
+- 管理员能配置策略
+- 用户触发高风险行为时能被拦截或要求审批
+- 审计记录能解释“谁在什么机器上让哪个 agent 做了什么”
+- 团队能按用户、项目、机器、工具、模型维度看成本
+
+### 6-12 个月：Agent Governance for Engineering Teams
+
+目标：形成更完整的软件研发 agent 治理闭环。
+
+优先级：
+
+1. Issue / ticket 到 session / branch / PR 的闭环
+2. 多 agent 任务队列和并行执行
+3. 任务模板和项目级策略
+4. 审计证据链：issue、prompt、命令、文件变更、模型调用、PR
+5. 企业集成：GitHub、GitLab、Jira、飞书、钉钉
+6. 部署形态：Docker Compose 稳定、Helm Chart、升级迁移手册
+7. 真实案例和 benchmark
+
+关键验收：
+
+- 用户可以从 issue 一键创建 agent session
+- session 可以生成 branch / PR
+- 管理员能回看整个任务过程
+- 团队能复盘成本、成功率、人工节省和风险事件
+
+## 对外文案建议
+
+### 中文
+
+短版：
+
+> OpenAce 是面向团队 AI Coding Agent 落地的自托管工作平台和治理控制面。
+
+长版：
+
+> OpenAce 帮助团队统一管理 Claude Code、Codex、Qwen Code、Gemini CLI 等 AI Coding Agent。开发者可以在浏览器里把 agent 跑在自己的远程机器上；管理员可以集中管理 API Key、权限、配额、成本、审计和合规记录。
+
+### English
+
+Short:
+
+> OpenAce is a self-hosted workspace and control plane for teams running AI coding agents.
+
+Long:
+
+> OpenAce helps engineering teams run Claude Code, Codex, Qwen Code, Gemini CLI, and other AI coding agents on their own machines while centralizing API key proxying, access control, quotas, cost visibility, audit trails, and compliance reporting.
+
+### 不推荐的表达
+
+- “企业 AI 平台”：太宽，容易和 Dify、企业门户、知识库混淆
+- “AI IDE”：会和 Cursor、Windsurf、JetBrains 正面竞争
+- “LLMOps 平台”：会和 Langfuse、LiteLLM、Helicone、Portkey 正面竞争
+- “远程开发环境平台”：会和 Coder、Gitpod、Daytona 正面竞争
+
+## 风险和应对
+
+| 风险 | 表现 | 应对 |
+|------|------|------|
+| 定位过宽 | 用户不知道第一场景是什么 | 聚焦 Remote Agent + API Key Proxy + 审计 |
+| 和 Coder 过度重叠 | 被理解为弱版 CDE | 强调接管已有机器和多 AI CLI 控制 |
+| 治理可信度不足 | 企业用户不敢用 | 补 threat model、安全设计、审计样例 |
+| 开发者体验不够顺滑 | demo 跑不起来，留存低 | 优先打磨 10 分钟远程 agent demo |
+| 模型网关重复造轮子 | 投入大但不领先 | 集成 LiteLLM / Langfuse |
+| 社区信号弱 | 外部用户缺少信任 | 持续发布案例、good first issues、早期用户反馈 |
+
+## 内部讨论问题
+
+产品方向：
+
+- OpenAce 是否明确接受“控制面优先，工作平台辅助”的定位？
+- Remote Agent 是否应成为未来 3 个月最高优先级？
+- 是否把 LiteLLM 集成列为中期路线，而不是继续扩大自研 API Key Proxy？
+- 是否把 GitHub / GitLab issue 到 PR 的闭环作为下一个强 demo？
+
+市场方向：
+
+- 第一批目标用户到底是中国私有化团队，还是全球开源 AI coding 用户？
+- 对外传播应优先英文社区，还是中文技术社区？
+- 是否需要公开对比 Coder、LiteLLM、Continue、OpenHands？
+
+商业方向：
+
+- 未来如果商业化，哪些能力适合开源，哪些适合企业版？
+- 企业真正愿意付费的是远程执行、安全审计、SSO、策略审批，还是成本可视化？
+- OpenAce 是否应该提供托管版，还是坚持 self-hosted first？
+
+## 近期行动清单
+
+建议按这个顺序推进：
+
+1. 补一份 Remote Agent + API Key Proxy 的安全设计文档
+2. 做一个“10 分钟远程 AI coding session”演示脚本
+3. 把 README 和官网定位收窄为“workspace and control plane for AI coding agents”
+4. 新增 LiteLLM 集成调研 issue
+5. 新增 GitHub issue 到 agent session 的产品设计 issue
+6. 准备 Coder / LiteLLM / OpenHands / Continue 的公开竞品矩阵
+7. 找 3-5 个真实团队试用，重点问 API Key、远程机器、成本、审计是否命中痛点
+
+## 参考链接
+
+以下链接用于持续跟踪竞品和市场变化。建议每月复查一次。
+
+- Coder: https://coder.com/
+- Coder GitHub: https://github.com/coder/coder
+- Coder AI agents docs: https://coder.com/docs/ai-coder/agents
+- Gitpod docs: https://www.gitpod.io/docs
+- Continue docs: https://docs.continue.dev/
+- DevPod docs: https://devpod.sh/docs/what-is-devpod
+- Daytona: https://www.daytona.io/
+- LiteLLM OSS: https://www.litellm.ai/oss
+- LiteLLM proxy docs: https://docs.litellm.ai/docs/proxy
+- Langfuse self-hosting: https://langfuse.com/docs/deployment/self-host
+- Sourcegraph Cody docs: https://sourcegraph.com/docs/cody
+- Tabnine deployment options: https://docs.tabnine.com/main/welcome/readme/architecture/deployment-options
+- Tabby docs: https://tabby.tabbyml.com/docs/welcome/
+- Dify docs: https://docs.dify.ai/
+- Flowise docs: https://docs.flowiseai.com/
+- LangGraph Platform control plane: https://docs.langchain.com/langgraph-platform/control-plane
+- GitHub Agent HQ announcement: https://github.blog/ai-and-ml/github-copilot/introducing-agent-hq-any-agent-any-way-you-work/


### PR DESCRIPTION
## Summary
- refine README positioning around OpenAce as a self-hosted workspace and control plane for AI coding agents
- add a competitive positioning and product strategy document for internal sharing and future reference
- link the strategy document from the docs index

## Website
- updated https://www.open-ace.com copy separately to match this positioning
- deployed CTA and docs link updates to the live static site

## Checks
- git diff --check