### PR TITLE
fix(ui): 将'+ New Session'按钮移至搜索框上方

### DIFF
--- a/frontend/src/components/work/SessionList.tsx
+++ b/frontend/src/components/work/SessionList.tsx
@@ -239,8 +239,18 @@ export const SessionList: React.FC<SessionListProps> = ({ collapsed = false, onS
 
   return (
     <div className="session-list" ref={sessionListRef}>
+      {/* New Session Button */}
+      <button
+        className="btn btn-primary btn-sm w-100 mb-2"
+        onClick={handleNewSession}
+        data-testid="new-session-btn"
+      >
+        <i className="bi bi-plus-lg me-1" />
+        {t('newSession', language)}
+      </button>
+
       {/* Search */}
-      <div className="session-search mb-2">
+      <div className="session-search mb-3">
         <div className="input-group input-group-sm">
           <span className="input-group-text">
             <i className="bi bi-search" />
@@ -254,16 +264,6 @@ export const SessionList: React.FC<SessionListProps> = ({ collapsed = false, onS
           />
         </div>
       </div>
-
-      {/* New Session Button */}
-      <button
-        className="btn btn-primary btn-sm w-100 mb-3"
-        onClick={handleNewSession}
-        data-testid="new-session-btn"
-      >
-        <i className="bi bi-plus-lg me-1" />
-        {t('newSession', language)}
-      </button>
 
       {/* Session Groups */}
       {isLoading ? (


### PR DESCRIPTION
## 问题描述

当前左侧会话列表（SessionList）的布局顺序为：
1. Search 搜索框（顶部）
2. + New Session 按钮
3. Session 列表

建议将布局调整为：
1. + New Session 按钮（顶部）
2. Search 搜索框
3. Session 列表

## 修改内容

- 交换 SessionList 中 New Session Button 和 Search 的渲染顺序
- 调整 margin 间距保持视觉平衡（按钮 mb-2，搜索框 mb-3）

## 修改原因

| 方面 | New Session 在上（建议） | Search 在上（当前） |
|------|-------------------------|-------------------|
| **操作频率** | 创建新会话是高频主操作 | 搜索是过滤/辅助操作 |
| **用户认知** | 主操作优先，符合 Fitts 定律 | 先过滤再操作的流程 |
| **视觉层次** | 按钮更显眼，引导用户行动 | 输入框较被动 |

## 涉及文件

| 文件 | 修改内容 |
|------|----------|
| `frontend/src/components/work/SessionList.tsx` | 交换 New Session Button 和 Search 的渲染顺序 |

## 修复后效果

- 主操作按钮更显眼，符合用户习惯
- 视觉层次更清晰
- 与主流应用交互模式保持一致

Closes #689