### PR TITLE
fix(prompts): 搜索框添加 debounce 防止光标跳出 (#684)

### DIFF
--- a/frontend/src/components/features/Prompts.tsx
+++ b/frontend/src/components/features/Prompts.tsx
@@ -47,7 +47,7 @@ const categoryColors: Record<string, BadgeVariant> = {
 export const Prompts: React.FC = () => {
   const language = useLanguage() as Language;
   const [page, setPage] = useState(1);
-  const [filters, setFilters] = useState<{ category?: string; search?: string }>({});
+  const [filters, setFilters] = useState<{ category?: string }>({});
   // Debounce search input - separate UI state from query state
   const [searchInput, setSearchInput] = useState('');
   const [debouncedSearch, setDebouncedSearch] = useState('');
@@ -68,7 +68,8 @@ export const Prompts: React.FC = () => {
     refetch,
     error: queryError,
   } = usePrompts({
-    ...filters,
+    category: filters.category,
+    search: debouncedSearch || undefined,
     page,
     limit: ITEMS_PER_PAGE,
   });
@@ -78,11 +79,11 @@ export const Prompts: React.FC = () => {
   const total = promptsData?.total ?? 0;
   const error = actionError ?? queryError?.message ?? null;
 
-  // Reset page when filters change
+  // Reset page when filters or search change
   useEffect(() => {
     setPage(1);
     setSelectedTemplate(null);
-  }, [filters.category, filters.search]);
+  }, [filters.category, debouncedSearch]);
 
   // Debounce search input
   useEffect(() => {
@@ -98,11 +99,6 @@ export const Prompts: React.FC = () => {
       }
     };
   }, [searchInput]);
-
-  // Update filters when debouncedSearch changes
-  useEffect(() => {
-    setFilters((prev) => ({ ...prev, search: debouncedSearch || undefined }));
-  }, [debouncedSearch]);
 
   // Category options
   const categoryOptions = useMemo(
@@ -122,6 +118,11 @@ export const Prompts: React.FC = () => {
   };
 
   const handleReset = () => {
+    // Clear debounce timer first to prevent race condition
+    if (debounceTimerRef.current) {
+      clearTimeout(debounceTimerRef.current);
+      debounceTimerRef.current = null;
+    }
     setSearchInput('');
     setDebouncedSearch('');
     setFilters({});

--- a/frontend/src/components/features/Prompts.tsx
+++ b/frontend/src/components/features/Prompts.tsx
@@ -2,7 +2,7 @@
  * Prompts Component - Prompt template management with CRUD operations
  */
 
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState, useEffect, useMemo, useRef } from 'react';
 import { cn, copyToClipboard } from '@/utils';
 import { promptsApi } from '@/api';
 import type { PromptTemplate, PromptVariable } from '@/api';
@@ -31,6 +31,7 @@ import {
 import type { BadgeVariant } from '@/components/common';
 
 const ITEMS_PER_PAGE = 20;
+const DEBOUNCE_DELAY = 300;
 
 // Category colors
 const categoryColors: Record<string, BadgeVariant> = {
@@ -47,6 +48,10 @@ export const Prompts: React.FC = () => {
   const language = useLanguage() as Language;
   const [page, setPage] = useState(1);
   const [filters, setFilters] = useState<{ category?: string; search?: string }>({});
+  // Debounce search input - separate UI state from query state
+  const [searchInput, setSearchInput] = useState('');
+  const [debouncedSearch, setDebouncedSearch] = useState('');
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [selectedTemplate, setSelectedTemplate] = useState<PromptTemplate | null>(null);
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [showEditModal, setShowEditModal] = useState(false);
@@ -79,6 +84,26 @@ export const Prompts: React.FC = () => {
     setSelectedTemplate(null);
   }, [filters.category, filters.search]);
 
+  // Debounce search input
+  useEffect(() => {
+    if (debounceTimerRef.current) {
+      clearTimeout(debounceTimerRef.current);
+    }
+    debounceTimerRef.current = setTimeout(() => {
+      setDebouncedSearch(searchInput);
+    }, DEBOUNCE_DELAY);
+    return () => {
+      if (debounceTimerRef.current) {
+        clearTimeout(debounceTimerRef.current);
+      }
+    };
+  }, [searchInput]);
+
+  // Update filters when debouncedSearch changes
+  useEffect(() => {
+    setFilters((prev) => ({ ...prev, search: debouncedSearch || undefined }));
+  }, [debouncedSearch]);
+
   // Category options
   const categoryOptions = useMemo(
     () => [
@@ -96,11 +121,9 @@ export const Prompts: React.FC = () => {
     setFilters((prev) => ({ ...prev, [key]: value || undefined }));
   };
 
-  const handleSearch = (value: string) => {
-    setFilters((prev) => ({ ...prev, search: value || undefined }));
-  };
-
   const handleReset = () => {
+    setSearchInput('');
+    setDebouncedSearch('');
     setFilters({});
     setPage(1);
     setSelectedTemplate(null);
@@ -202,8 +225,8 @@ export const Prompts: React.FC = () => {
             className="form-control"
             style={{ maxWidth: '300px', height: '31px' }}
             placeholder={t('searchPrompts', language) || 'Search prompts...'}
-            value={filters.search ?? ''}
-            onChange={(e) => handleSearch(e.target.value)}
+            value={searchInput}
+            onChange={(e) => setSearchInput(e.target.value)}
           />
           {/* Category Filter */}
           <Select


### PR DESCRIPTION
## 问题描述

Fix #684: 提示词页面搜索框每输入一个字符光标就跳出，无法连续输入

## 问题原因

搜索输入缺少防抖（debounce），每次输入都触发 API 请求：
1. 用户输入字符 → `filters.search` 更新
2. queryKey 变化 → React Query 发起新请求
3. `isLoading = true` → 组件渲染 `<Loading />`
4. 搜索框被卸载再挂载 → 焦点丢失

## 修复方案

参考项目中 `SessionList.tsx` 和 `AssistPanel.tsx` 的 debounce 模式：
- 添加 `searchInput` 状态用于输入框绑定（UI 状态）
- 添加 `debouncedSearch` 状态，300ms 后同步到 `filters`（查询状态）
- 使用 `useRef` 存储 debounce timer
- 重置时清空 `searchInput`

## 修改文件

- `frontend/src/components/features/Prompts.tsx`

## 测试

- TypeScript 类型检查通过 (`npm run typecheck`)