### PR TITLE
fix(ui): 会话列表卡片元数据字段横向对齐

### DIFF
--- a/frontend/src/components/features/Sessions.tsx
+++ b/frontend/src/components/features/Sessions.tsx
@@ -683,12 +683,11 @@ const SessionCard: React.FC<SessionCardProps> = ({
             <i className="bi bi-clock me-1" />
             {session.created_at ? formatDateTime(session.created_at) : '-'}
           </span>
-          {session.completed_at && (
-            <span>
-              <i className="bi bi-check-circle me-1" />
-              {formatDateTime(session.completed_at)}
-            </span>
-          )}
+          {/* 完成时间列始终渲染，确保 Grid 列数一致 (Issue #700) */}
+          <span style={{ visibility: session.completed_at ? 'visible' : 'hidden' }}>
+            <i className="bi bi-check-circle me-1" />
+            {session.completed_at ? formatDateTime(session.completed_at) : '-'}
+          </span>
         </div>
       </div>
     </div>

--- a/frontend/src/components/features/Sessions.tsx
+++ b/frontend/src/components/features/Sessions.tsx
@@ -685,8 +685,12 @@ const SessionCard: React.FC<SessionCardProps> = ({
           </span>
           {/* 完成时间列始终渲染，确保 Grid 列数一致 (Issue #700) */}
           <span style={{ visibility: session.completed_at ? 'visible' : 'hidden' }}>
-            <i className="bi bi-check-circle me-1" />
-            {session.completed_at ? formatDateTime(session.completed_at) : '-'}
+            {session.completed_at && (
+              <>
+                <i className="bi bi-check-circle me-1" />
+                {formatDateTime(session.completed_at)}
+              </>
+            )}
           </span>
         </div>
       </div>

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -2683,14 +2683,13 @@ link[rel='dns-prefetch'] {
 .session-card-meta {
   display: grid;
   grid-template-columns:
-    minmax(70px, 90px)   /* 工具名称 */
-    minmax(80px, 100px)  /* 主机名称 */
-    minmax(80px, 1fr)    /* 模型名称 */
-    minmax(70px, 90px)   /* 消息数 */
-    minmax(80px, 100px)  /* Token数 */
+    minmax(70px, 90px) /* 工具名称 */
+    minmax(80px, 100px) /* 主机名称 */
+    minmax(80px, 1fr) /* 模型名称 */
+    minmax(70px, 90px) /* 消息数 */
+    minmax(80px, 100px) /* Token数 */
     minmax(100px, 130px) /* 创建时间 */
-    minmax(100px, 130px) /* 完成时间 */
-  ;
+    minmax(100px, 130px) /* 完成时间 */;
   align-items: center;
   gap: 0.35rem 1rem;
   font-size: 0.8rem;

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -2679,16 +2679,31 @@ link[rel='dns-prefetch'] {
   flex-shrink: 0;
 }
 
-/* Row 2: meta info — grid aligned columns with fixed widths */
+/* Row 2: meta info — grid aligned columns with minmax for responsive */
 .session-card-meta {
   display: grid;
-  grid-template-columns: 90px 100px minmax(80px, 1fr) 90px 100px 130px auto;
+  grid-template-columns:
+    minmax(70px, 90px)   /* 工具名称 */
+    minmax(80px, 100px)  /* 主机名称 */
+    minmax(80px, 1fr)    /* 模型名称 */
+    minmax(70px, 90px)   /* 消息数 */
+    minmax(80px, 100px)  /* Token数 */
+    minmax(100px, 130px) /* 创建时间 */
+    minmax(100px, 130px) /* 完成时间 */
+  ;
   align-items: center;
   gap: 0.35rem 1rem;
   font-size: 0.8rem;
   color: var(--text-muted);
   white-space: nowrap;
   overflow: hidden;
+}
+
+/* 为所有列添加溢出处理 (Issue #700 评审意见) */
+.session-card-meta span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
 }
 
 .meta-model {

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -2679,10 +2679,10 @@ link[rel='dns-prefetch'] {
   flex-shrink: 0;
 }
 
-/* Row 2: meta info — grid aligned columns */
+/* Row 2: meta info — grid aligned columns with fixed widths */
 .session-card-meta {
   display: grid;
-  grid-template-columns: auto auto 1fr auto auto auto auto;
+  grid-template-columns: 90px 100px minmax(80px, 1fr) 90px 100px 130px auto;
   align-items: center;
   gap: 0.35rem 1rem;
   font-size: 0.8rem;


### PR DESCRIPTION
## 问题

左侧菜单栏点击会话历史进入会话页面，会话列表每条会话里的标签、消息、token、时间字段横向没有对齐，各行错落。

**Issue**: #700

## 根因分析

 使用 ，auto 列宽会根据内容自适应，导致各行相同位置的列宽度不一致。

另外，第 7 列（完成时间）是条件渲染，有完成时间的卡片是 7 列，无完成时间的是 6 列，导致 Grid 布局错位。

## 修复内容

### 1. CSS 固定列宽 (main.css)



列宽对应:
- 90px: 工具名称
- 100px: 主机名称
- minmax(80px, 1fr): 模型名称（弹性收缩）
- 90px: 消息数
- 100px: Token 数
- 130px: 创建时间
- auto: 完成时间

### 2. 完成时间列始终渲染 (Sessions.tsx)

使用  隐藏无值的完成时间列，保留 Grid 位置，确保所有卡片列数一致。

## 验证

截图已保存至 `screenshots/screenshot_20260604_233830_01_full.png`

Closes #700

🤖 Generated with Qwen Code (4-shotted by Qwen-Coder)