### PR TITLE
fix: 修复删除过的Project再创建报错问题 (Issue #119)

### DIFF
--- a/app/repositories/project_repo.py
+++ b/app/repositories/project_repo.py
@@ -35,7 +35,11 @@ class ProjectRepository:
         is_shared: bool = False,
     ) -> Optional[int]:
         """
-        Create a new project.
+        Create a new project or restore a soft-deleted one.
+
+        If a soft-deleted project with the same path exists, it will be restored
+        instead of creating a new one. This fixes Issue #119 where soft-deleted
+        projects blocked creating new projects with the same path.
 
         Args:
             path: Project absolute path.
@@ -50,6 +54,41 @@ class ProjectRepository:
         try:
             now = datetime.now(timezone.utc).replace(tzinfo=None)
 
+            # Check if a soft-deleted project with the same path exists
+            soft_deleted = self.db.fetch_one(
+                "SELECT id FROM projects WHERE path = ? AND is_active IS FALSE",
+                (path,),
+            )
+
+            if soft_deleted:
+                # Restore the soft-deleted project
+                project_id = soft_deleted["id"]
+                if self.db.is_postgresql:
+                    self.db.execute(
+                        """
+                        UPDATE projects SET
+                            name = ?, description = ?, created_by = ?, is_shared = ?,
+                            is_active = TRUE, updated_at = ?
+                        WHERE id = ?
+                        """,
+                        (name, description, created_by, is_shared, now, project_id),
+                    )
+                else:
+                    is_shared_int = adapt_boolean_value(is_shared)
+                    is_active_int = adapt_boolean_value(True)
+                    self.db.execute(
+                        """
+                        UPDATE projects SET
+                            name = ?, description = ?, created_by = ?, is_shared = ?,
+                            is_active = ?, updated_at = ?
+                        WHERE id = ?
+                        """,
+                        (name, description, created_by, is_shared_int, is_active_int, now, project_id),
+                    )
+                logger.info(f"Restored soft-deleted project {project_id} with path {path}")
+                return project_id
+
+            # No soft-deleted project found, create a new one
             if self.db.is_postgresql:
                 # PostgreSQL uses TRUE/FALSE for boolean columns
                 result = self.db.fetch_one(

--- a/app/repositories/project_repo.py
+++ b/app/repositories/project_repo.py
@@ -62,7 +62,7 @@ class ProjectRepository:
 
             if soft_deleted:
                 # Restore the soft-deleted project
-                project_id = int(soft_deleted["id"])
+                restored_id = int(soft_deleted["id"])
                 if self.db.is_postgresql:
                     self.db.execute(
                         """
@@ -71,7 +71,7 @@ class ProjectRepository:
                             is_active = TRUE, updated_at = ?
                         WHERE id = ?
                         """,
-                        (name, description, created_by, is_shared, now, project_id),
+                        (name, description, created_by, is_shared, now, restored_id),
                     )
                 else:
                     is_shared_int = adapt_boolean_value(is_shared)
@@ -90,16 +90,16 @@ class ProjectRepository:
                             is_shared_int,
                             is_active_int,
                             now,
-                            project_id,
+                            restored_id,
                         ),
                     )
-                logger.info(f"Restored soft-deleted project {project_id} with path {path}")
+                logger.info(f"Restored soft-deleted project {restored_id} with path {path}")
 
                 # Add user-project relationship if creator is specified
                 if created_by:
-                    self.add_user_project(created_by, project_id)
+                    self.add_user_project(created_by, restored_id)
 
-                return project_id
+                return restored_id
 
             # No soft-deleted project found, create a new one
             if self.db.is_postgresql:

--- a/migrations/versions/20260605_051_fix_project_path_unique_constraint.py
+++ b/migrations/versions/20260605_051_fix_project_path_unique_constraint.py
@@ -1,0 +1,168 @@
+"""Fix project path unique constraint for soft-delete support
+
+Revision ID: 051_fix_project_path_unique
+Revises: 050_session_type_index
+Create Date: 2026-06-05
+
+This migration fixes Issue #119: soft-deleted projects block creating new projects
+with the same path due to unconditional unique constraint.
+
+Problem:
+- projects table has unconditional UNIQUE constraint on path
+- Soft delete sets is_active=FALSE but record remains
+- Cannot create new project with same path as soft-deleted project
+
+Solution:
+- Replace unconditional unique constraint with conditional unique index
+- PostgreSQL: CREATE UNIQUE INDEX ... WHERE is_active IS TRUE
+- SQLite: Use triggers to enforce conditional uniqueness
+
+Impact:
+- Allows re-creating projects with same path after soft delete
+- Maintains uniqueness for active projects
+- Preserves soft-deleted records for history
+
+"""
+
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "051_fix_project_path_unique"
+down_revision: Union[str, None] = "050_session_type_index"
+branch_labels: Union[str, None] = None
+depends_on: Union[str, None] = None
+
+
+def _index_exists(conn, index_name: str, table_name: str) -> bool:
+    """Check if an index exists."""
+    if conn.dialect.name == "postgresql":
+        result = conn.execute(
+            sa.text(
+                "SELECT EXISTS (SELECT FROM pg_indexes WHERE indexname = :index_name)"
+            ),
+            {"index_name": index_name},
+        )
+        return result.fetchone()[0]
+    else:
+        result = conn.execute(
+            sa.text(
+                "SELECT name FROM sqlite_master WHERE type='index' AND name = :index_name"
+            ),
+            {"index_name": index_name},
+        )
+        return result.fetchone() is not None
+
+
+def _trigger_exists(conn, trigger_name: str) -> bool:
+    """Check if a trigger exists (SQLite only)."""
+    result = conn.execute(
+        sa.text(
+            "SELECT name FROM sqlite_master WHERE type='trigger' AND name = :trigger_name"
+        ),
+        {"trigger_name": trigger_name},
+    )
+    return result.fetchone() is not None
+
+
+def upgrade() -> None:
+    """Upgrade database schema."""
+    conn = op.get_bind()
+
+    if conn.dialect.name == "postgresql":
+        # PostgreSQL: Use conditional unique index (partial index)
+        # Drop the old unconditional unique constraint
+        if _index_exists(conn, "uq_projects_path", "projects"):
+            op.drop_constraint("uq_projects_path", "projects", type_="unique")
+
+        # Create new conditional unique index
+        # Only enforce uniqueness for active projects (is_active = TRUE)
+        op.execute(
+            sa.text(
+                "CREATE UNIQUE INDEX uq_projects_path ON projects (path) WHERE is_active IS TRUE"
+            )
+        )
+
+    else:
+        # SQLite: Does not support conditional indexes
+        # Solution: Drop unique constraint and use triggers to enforce conditional uniqueness
+
+        # Step 1: Drop the old unique index
+        if _index_exists(conn, "uq_projects_path", "projects"):
+            op.drop_index("uq_projects_path", "projects")
+
+        # Step 2: Create a regular (non-unique) index for query performance
+        if not _index_exists(conn, "idx_projects_path", "projects"):
+            op.create_index("idx_projects_path", "projects", ["path"])
+
+        # Step 3: Create triggers to enforce conditional uniqueness
+        # Trigger for INSERT: Check if path already exists in active projects
+        if not _trigger_exists(conn, "trg_projects_path_unique_insert"):
+            op.execute(
+                sa.text(
+                    """
+                    CREATE TRIGGER trg_projects_path_unique_insert
+                    BEFORE INSERT ON projects
+                    FOR EACH ROW
+                    WHEN NEW.is_active = 1
+                    BEGIN
+                        SELECT RAISE(ABORT, 'Path already exists for an active project')
+                        WHERE EXISTS (
+                            SELECT 1 FROM projects
+                            WHERE path = NEW.path AND is_active = 1
+                        );
+                    END;
+                    """
+                )
+            )
+
+        # Trigger for UPDATE: Check if new path conflicts with existing active projects
+        # Also handles re-activating a soft-deleted project
+        if not _trigger_exists(conn, "trg_projects_path_unique_update"):
+            op.execute(
+                sa.text(
+                    """
+                    CREATE TRIGGER trg_projects_path_unique_update
+                    BEFORE UPDATE ON projects
+                    FOR EACH ROW
+                    WHEN (NEW.is_active = 1 AND (OLD.is_active = 0 OR NEW.path != OLD.path))
+                    BEGIN
+                        SELECT RAISE(ABORT, 'Path already exists for an active project')
+                        WHERE EXISTS (
+                            SELECT 1 FROM projects
+                            WHERE path = NEW.path AND is_active = 1 AND id != NEW.id
+                        );
+                    END;
+                    """
+                )
+            )
+
+
+def downgrade() -> None:
+    """Downgrade database schema."""
+    conn = op.get_bind()
+
+    if conn.dialect.name == "postgresql":
+        # Drop conditional unique index
+        if _index_exists(conn, "uq_projects_path", "projects"):
+            op.drop_index("uq_projects_path", "projects")
+
+        # Restore unconditional unique constraint
+        op.create_unique_constraint("uq_projects_path", "projects", ["path"])
+
+    else:
+        # SQLite: Drop triggers
+        if _trigger_exists(conn, "trg_projects_path_unique_insert"):
+            op.execute(sa.text("DROP TRIGGER trg_projects_path_unique_insert"))
+
+        if _trigger_exists(conn, "trg_projects_path_unique_update"):
+            op.execute(sa.text("DROP TRIGGER trg_projects_path_unique_update"))
+
+        # Drop regular index
+        if _index_exists(conn, "idx_projects_path", "projects"):
+            op.drop_index("idx_projects_path", "projects")
+
+        # Restore unconditional unique index
+        op.create_index("uq_projects_path", "projects", ["path"], unique=True)

--- a/tests/integration/test_project_repo_pg.py
+++ b/tests/integration/test_project_repo_pg.py
@@ -99,6 +99,54 @@ class TestProjectCRUD:
         assert repo.delete_project(project_id, soft_delete=False) is True
         assert repo.get_project_by_id(project_id) is None
 
+    def test_recreate_soft_deleted_project(self, pg_db):
+        """Test recreating a project after soft delete (Issue #119 fix)."""
+        repo = ProjectRepository(db=pg_db)
+        user_id = _insert_user(pg_db)
+
+        # Create a project
+        original_path = "/projects/recreate-test-pg"
+        project_id = repo.create_project(
+            path=original_path,
+            name="Original Project",
+            description="Original description",
+            created_by=user_id,
+            is_shared=True,
+        )
+        assert project_id is not None
+
+        # Soft delete the project
+        result = repo.delete_project(project_id, soft_delete=True)
+        assert result is True
+
+        # Verify project is no longer visible
+        assert repo.get_project_by_path(original_path) is None
+
+        # Recreate project with same path - should restore soft-deleted project
+        new_project_id = repo.create_project(
+            path=original_path,
+            name="New Project",
+            description="New description",
+            created_by=user_id,
+            is_shared=False,
+        )
+
+        # Should return the same project ID (restored)
+        assert new_project_id == project_id
+
+        # Project should now be visible again
+        restored_project = repo.get_project_by_id(new_project_id)
+        assert restored_project is not None
+        assert restored_project.path == original_path
+        assert restored_project.name == "New Project"
+        assert restored_project.description == "New description"
+        assert restored_project.is_active is True
+        assert restored_project.is_shared is False
+
+        # Verify there's only one record in database for this path
+        all_rows = pg_db.fetch_all("SELECT * FROM projects WHERE path = ?", (original_path,))
+        assert len(all_rows) == 1
+
 
 class TestUserProject:
     """Tests for user-project via PostgreSQL ON CONFLICT path."""

--- a/tests/integration/test_project_repo_sqlite.py
+++ b/tests/integration/test_project_repo_sqlite.py
@@ -166,6 +166,55 @@ class TestProjectCRUD:
         up = tmp_db.fetch_one("SELECT * FROM user_projects WHERE project_id = ?", (project_id,))
         assert up is None
 
+    def test_recreate_soft_deleted_project(self, tmp_db):
+        """Test recreating a project after soft delete (Issue #119 fix)."""
+        repo = ProjectRepository(db=tmp_db)
+        user_id = _insert_user(tmp_db)
+
+        # Create a project
+        original_path = "/projects/recreate-test"
+        project_id = repo.create_project(
+            path=original_path,
+            name="Original Project",
+            description="Original description",
+            created_by=user_id,
+            is_shared=True,
+        )
+        assert project_id is not None
+
+        # Soft delete the project
+        result = repo.delete_project(project_id, soft_delete=True)
+        assert result is True
+
+        # Verify project is no longer visible
+        assert repo.get_project_by_path(original_path) is None
+
+        # Recreate project with same path - should restore soft-deleted project
+        new_project_id = repo.create_project(
+            path=original_path,
+            name="New Project",
+            description="New description",
+            created_by=user_id,
+            is_shared=False,
+        )
+
+        # Should return the same project ID (restored)
+        assert new_project_id == project_id
+
+        # Project should now be visible again
+        restored_project = repo.get_project_by_id(new_project_id)
+        assert restored_project is not None
+        assert restored_project.path == original_path
+        assert restored_project.name == "New Project"
+        assert restored_project.description == "New description"
+        # SQLite uses 1/0 for boolean, PostgreSQL uses True/False
+        assert restored_project.is_active in (True, 1)
+        assert restored_project.is_shared in (False, 0)
+
+        # Verify there's only one record in database for this path
+        all_rows = tmp_db.fetch_all("SELECT * FROM projects WHERE path = ?", (original_path,))
+        assert len(all_rows) == 1
+
 
 class TestUserProject:
     """Tests for user-project relationship operations."""

--- a/tests/unit/test_project_repo.py
+++ b/tests/unit/test_project_repo.py
@@ -25,6 +25,8 @@ class TestProjectRepository:
     # -------------------------------------------------------------------------
 
     def test_create_project_sqlite(self):
+        # First fetch_one checks for soft-deleted project (returns None)
+        self.db.fetch_one.return_value = None
         mock_cursor = MagicMock()
         mock_cursor.lastrowid = 1
         self.db.execute.return_value = mock_cursor
@@ -42,6 +44,8 @@ class TestProjectRepository:
 
     def test_create_project_sqlite_auto_adds_user_project(self):
         """When created_by is specified, add_user_project should be called."""
+        # First fetch_one checks for soft-deleted project (returns None)
+        self.db.fetch_one.return_value = None
         mock_cursor = MagicMock()
         mock_cursor.lastrowid = 10
         self.db.execute.return_value = mock_cursor
@@ -53,6 +57,8 @@ class TestProjectRepository:
 
     def test_create_project_no_creator(self):
         """Without created_by, add_user_project should NOT be called."""
+        # First fetch_one checks for soft-deleted project (returns None)
+        self.db.fetch_one.return_value = None
         mock_cursor = MagicMock()
         mock_cursor.lastrowid = 2
         self.db.execute.return_value = mock_cursor
@@ -64,14 +70,18 @@ class TestProjectRepository:
 
     def test_create_project_postgresql(self):
         self.db.is_postgresql = True
-        self.db.fetch_one.return_value = {"id": 3}
+        # First fetch_one checks for soft-deleted project (returns None)
+        # Second fetch_one returns the new project ID
+        self.db.fetch_one.side_effect = [None, {"id": 3}]
 
         with patch.object(self.repo, "add_user_project", return_value=1):
             result = self.repo.create_project(path="/test/pg", name="PG", created_by=1)
         assert result == 3
-        self.db.fetch_one.assert_called_once()
-        call_query = self.db.fetch_one.call_args[0][0]
-        assert "RETURNING id" in call_query
+        # fetch_one called twice: check soft-deleted, then insert with RETURNING
+        assert self.db.fetch_one.call_count == 2
+        # Check that second call has RETURNING id
+        second_call_query = self.db.fetch_one.call_args_list[1][0][0]
+        assert "RETURNING id" in second_call_query
 
     def test_create_project_exception(self):
         self.db.execute.side_effect = Exception("DB error")


### PR DESCRIPTION
## 问题

删除过的 Project 再次创建时会报错：Failed to create project。

## 根因分析

软删除机制与唯一性约束冲突：
- projects 表的 path 字段有唯一性约束
- 软删除只设置 is_active=FALSE，记录仍保留在数据库
- 尝试创建同名项目时，唯一性约束阻止插入新记录

## 解决方案

1. **修改数据库唯一约束为条件唯一**
   - PostgreSQL: 使用条件唯一索引 WHERE is_active IS TRUE
   - SQLite: 使用触发器模拟条件唯一性

2. **修改 create_project 方法**
   - 创建前检查是否有软删除的同路径项目
   - 如有则恢复软删除的项目而非创建新记录

## 修改内容

### 新增迁移脚本
- migrations/versions/20260605_051_fix_project_path_unique_constraint.py

### 修改代码
- app/repositories/project_repo.py 的 create_project 方法

### 测试
- tests/unit/test_project_repo.py: 修复 mock 测试
- tests/integration/test_project_repo_sqlite.py: 新增测试
- tests/integration/test_project_repo_pg.py: 新增测试

## 测试结果

- ✅ 36 个单元测试通过
- ✅ 16 个 SQLite 集成测试通过

Fixes #119