### PR TITLE
fix: 修复提示词页面搜索框光标跳出问题 (Issue #684)

### DIFF
--- a/frontend/src/components/features/Prompts.tsx
+++ b/frontend/src/components/features/Prompts.tsx
@@ -170,7 +170,12 @@ export const Prompts: React.FC = () => {
     }
   };
 
-  if (isLoading) {
+  // Don't block UI with Loading on initial load - only show loading indicator
+  // when there's no data yet. This prevents focus loss when search changes.
+  // Note: isLoading is true only on initial fetch; isFetching is true on any fetch.
+  // Using (isLoading && templates.length === 0) allows us to keep the UI stable
+  // during search/filter changes while still showing loading for initial page load.
+  if (isLoading && templates.length === 0) {
     return <Loading size="lg" text={t('loading', language)} />;
   }
 


### PR DESCRIPTION
## 问题描述

Issue #684：在 Prompts 页面搜索框输入字符后，光标会跳出搜索框，焦点丢失到 BODY。

## 根本原因

当用户在搜索框输入字符后，debounce (300ms) 触发 `setDebouncedSearch`，导致 React Query 的 queryKey 变化（`['prompts', ..., search, ...]`）。由于这是一个新的查询，`isLoading` 变为 `true`，组件中的条件判断 `if (isLoading)` 触发，返回 `<Loading />` 组件替换整个 UI，导致搜索框被卸载，焦点丢失。

Playwright 测试结果显示：
- 焦点在约 200-300ms 时丢失
- `blur` 事件的 `relatedTarget` 为 `none`，`activeElement` 变为 `BODY`
- 这是因为组件被卸载而非焦点被其他元素抢走

## 修复方案

将 `if (isLoading)` 改为 `if (isLoading && templates.length === 0)`：

- 只在首次加载且无数据时显示 Loading 组件
- 后续搜索/filter 变化时保持 UI 稳定，保留搜索框焦点
- 使用 `templates.length === 0` 条件确保已有数据时不会触发 Loading 阻塞 UI

## 测试验证

由于测试环境限制，无法在运行的后端服务器上实时验证。但已确认：
1. 修复代码已正确应用到 `Prompts.tsx`
2. 前端重新构建后，修复逻辑已包含在 `Prompts.D6eN2WRD.js` 中
3. 构建后代码显示：`return B&&w.length===0?e.jsx(le,{size:"lg",text:t("loading",s)})` 即 `isLoading && templates.length === 0`

## 关联 Issue

Fixes #684