### PR TITLE
fix(i18n): 统三套国际化系统同步，解决语言显示不一致问题

### DIFF
--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -6,7 +6,7 @@ import React, { useState } from 'react';
 import { cn } from '@/utils';
 import { useAuth, useTheme, useLanguage, useGlobalFetch, useAppMode } from '@/hooks';
 import { useAppStore } from '@/store';
-import { t } from '@/i18n';
+import { t, setLanguage as setI18nLanguage } from '@/i18n';
 import { Button, UserSettingsModal, Avatar } from '@/components/common';
 
 interface HeaderProps {
@@ -27,7 +27,13 @@ export const Header: React.FC<HeaderProps> = ({ compact = false }) => {
   };
 
   const handleLanguageChange = (newLanguage: string) => {
-    useAppStore.getState().setLanguage(newLanguage as 'en' | 'zh' | 'ja' | 'ko');
+    const lang = newLanguage as 'en' | 'zh' | 'ja' | 'ko';
+    // 1. Update Zustand store
+    useAppStore.getState().setLanguage(lang);
+    // 2. Sync i18n module
+    setI18nLanguage(lang);
+    // 3. Sync i18next for Workspace iframe WebUI
+    localStorage.setItem('i18nextLng', lang);
   };
 
   const handleRefresh = async () => {

--- a/frontend/src/i18n/index.test.ts
+++ b/frontend/src/i18n/index.test.ts
@@ -67,17 +67,9 @@ describe('i18n', () => {
       expect(getLanguage()).toBe('zh');
     });
 
-    it('should use browser language if no saved language', () => {
+    it('should default to English if no saved language (browser language not auto-detected)', () => {
+      // PR #710: Removed browser language auto-detection to avoid conflict with user settings
       vi.stubGlobal('navigator', { language: 'ja-JP' });
-      vi.mocked(localStorage.getItem).mockReturnValue(null);
-
-      initLanguage();
-
-      expect(getLanguage()).toBe('ja');
-    });
-
-    it('should fallback to English for unsupported languages', () => {
-      vi.stubGlobal('navigator', { language: 'fr-FR' });
       vi.mocked(localStorage.getItem).mockReturnValue(null);
 
       initLanguage();

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -2853,12 +2853,11 @@ export function t(key: string, language?: Language): string {
 
 export function initLanguage(): void {
   const savedLanguage = localStorage.getItem('language') as Language | null;
-  const browserLanguage = navigator.language.split('-')[0] as Language;
 
+  // Priority: saved language > default English
+  // Do NOT auto-detect browser language to avoid conflict with user settings
   if (savedLanguage && translations[savedLanguage]) {
     currentLanguage = savedLanguage;
-  } else if (translations[browserLanguage]) {
-    currentLanguage = browserLanguage;
   } else {
     currentLanguage = 'en';
   }

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -148,7 +148,12 @@ export const useAppStore = create<AppState>()(
         document.documentElement.setAttribute('data-theme', theme);
         document.body.classList.toggle('dark-theme', theme === 'dark');
       },
-      setLanguage: (language) => set({ language }),
+      setLanguage: (language) => {
+        set({ language });
+        // Sync i18n module and i18next library
+        localStorage.setItem('language', language);
+        localStorage.setItem('i18nextLng', language);
+      },
       toggleSidebar: () => set((state) => ({ sidebarCollapsed: !state.sidebarCollapsed })),
       setSidebarCollapsed: (sidebarCollapsed) => set({ sidebarCollapsed }),
       toggleMobileSidebar: () => set((state) => ({ sidebarMobileOpen: !state.sidebarMobileOpen })),


### PR DESCRIPTION
Fixes #710

## 根因分析

前端存在三套独立的国际化系统，语言切换时未同步。

## 修复方案

1. i18n/index.ts: 移除浏览器语言自动检测
2. Header.tsx: 语言切换时同步更新三套系统
3. store/index.ts: setLanguage action 同步更新 localStorage

## 测试验证

node236 Docker 版已验证通过

🤖 Generated with Qwen Code (11-shotted by Qwen-Coder)