### PR TITLE
fix: Token Trend 数据缺失问题 (#683)

### DIFF
--- a/app/services/user_stats_aggregator.py
+++ b/app/services/user_stats_aggregator.py
@@ -69,6 +69,10 @@ class UserDailyStatsAggregator:
         """
         Aggregate usage data for a specific user.
 
+        Combines data from two sources:
+        1. daily_messages (non-Session data, filtered by agent_session_id)
+        2. agent_sessions (Session data)
+
         Args:
             user_id: User ID.
             username: Username (for logging).
@@ -93,21 +97,59 @@ class UserDailyStatsAggregator:
             with self.db.connection() as conn:
                 cursor = conn.cursor()
                 if is_postgresql():
+                    # Combine data from daily_messages (non-Session) and agent_sessions (Session)
+                    # This replaces the previous filter that excluded all agent_session_id data
                     cursor.execute(
                         """
-                        INSERT INTO user_daily_stats (user_id, date, requests, tokens, input_tokens, output_tokens, updated_at)
-                        SELECT %s, dm.date::date, COUNT(*), COALESCE(SUM(dm.tokens_used), 0),
-                               COALESCE(SUM(dm.input_tokens), 0), COALESCE(SUM(dm.output_tokens), 0), CURRENT_TIMESTAMP
-                        FROM daily_messages dm
-                        WHERE dm.date >= %s AND dm.date <= %s AND dm.sender_name LIKE %s AND dm.role = 'assistant'
+                        WITH daily_stats AS (
+                            -- Non-Session data from daily_messages (filtered)
+                            SELECT dm.date::date as date,
+                                   COUNT(*) as requests,
+                                   COALESCE(SUM(dm.tokens_used), 0) as tokens,
+                                   COALESCE(SUM(dm.input_tokens), 0) as input_tokens,
+                                   COALESCE(SUM(dm.output_tokens), 0) as output_tokens
+                            FROM daily_messages dm
+                            WHERE dm.date >= %s AND dm.date <= %s
+                              AND dm.sender_name LIKE %s
+                              AND dm.role = 'assistant'
                               AND (agent_session_id IS NULL OR agent_session_id = '')
-                        GROUP BY dm.date::date
-                        ON CONFLICT (user_id, date) DO UPDATE SET requests = EXCLUDED.requests, tokens = EXCLUDED.tokens,
-                            input_tokens = EXCLUDED.input_tokens, output_tokens = EXCLUDED.output_tokens, updated_at = CURRENT_TIMESTAMP""",
-                        (user_id, start_str, end_str, f"{escape_like(sender_prefix)}%"),
+                            GROUP BY dm.date::date
+                        ),
+                        session_stats AS (
+                            -- Session data from agent_sessions
+                            SELECT DATE(as2.created_at) as date,
+                                   COALESCE(as2.request_count, 0) as requests,
+                                   COALESCE(as2.total_tokens, 0) as tokens,
+                                   COALESCE(as2.total_input_tokens, 0) as input_tokens,
+                                   COALESCE(as2.total_output_tokens, 0) as output_tokens
+                            FROM agent_sessions as2
+                            WHERE as2.user_id = %s
+                              AND as2.created_at >= %s AND as2.created_at <= %s
+                        ),
+                        combined_stats AS (
+                            SELECT date, SUM(requests) as requests, SUM(tokens) as tokens,
+                                   SUM(input_tokens) as input_tokens, SUM(output_tokens) as output_tokens
+                            FROM (
+                                SELECT date, requests, tokens, input_tokens, output_tokens FROM daily_stats
+                                UNION ALL
+                                SELECT date, requests, tokens, input_tokens, output_tokens FROM session_stats
+                            ) all_stats
+                            GROUP BY date
+                        )
+                        INSERT INTO user_daily_stats (user_id, date, requests, tokens, input_tokens, output_tokens, updated_at)
+                        SELECT %s, cs.date, cs.requests, cs.tokens, cs.input_tokens, cs.output_tokens, CURRENT_TIMESTAMP
+                        FROM combined_stats cs
+                        ON CONFLICT (user_id, date) DO UPDATE SET
+                            requests = EXCLUDED.requests,
+                            tokens = EXCLUDED.tokens,
+                            input_tokens = EXCLUDED.input_tokens,
+                            output_tokens = EXCLUDED.output_tokens,
+                            updated_at = CURRENT_TIMESTAMP""",
+                        (start_str, end_str, f"{escape_like(sender_prefix)}%", user_id, start_str, end_str + " 23:59:59", user_id),
                     )
                 else:
                     now = datetime.now(timezone.utc).replace(tzinfo=None).isoformat()
+                    # SQLite: simpler approach without CTEs
                     cursor.execute(
                         """
                         INSERT OR REPLACE INTO user_daily_stats

--- a/app/services/user_stats_aggregator.py
+++ b/app/services/user_stats_aggregator.py
@@ -145,7 +145,15 @@ class UserDailyStatsAggregator:
                             input_tokens = EXCLUDED.input_tokens,
                             output_tokens = EXCLUDED.output_tokens,
                             updated_at = CURRENT_TIMESTAMP""",
-                        (start_str, end_str, f"{escape_like(sender_prefix)}%", user_id, start_str, end_str, user_id),
+                        (
+                            start_str,
+                            end_str,
+                            f"{escape_like(sender_prefix)}%",
+                            user_id,
+                            start_str,
+                            end_str,
+                            user_id,
+                        ),
                     )
                 else:
                     now = datetime.now(timezone.utc).replace(tzinfo=None).isoformat()
@@ -189,7 +197,16 @@ class UserDailyStatsAggregator:
                         ) combined
                         GROUP BY combined.date
                     """,
-                        (user_id, now, start_str, end_str, f"{escape_like(sender_prefix)}%", user_id, start_str, end_str),
+                        (
+                            user_id,
+                            now,
+                            start_str,
+                            end_str,
+                            f"{escape_like(sender_prefix)}%",
+                            user_id,
+                            start_str,
+                            end_str,
+                        ),
                     )
 
                 conn.commit()

--- a/app/services/user_stats_aggregator.py
+++ b/app/services/user_stats_aggregator.py
@@ -124,7 +124,7 @@ class UserDailyStatsAggregator:
                                    COALESCE(as2.total_output_tokens, 0) as output_tokens
                             FROM agent_sessions as2
                             WHERE as2.user_id = %s
-                              AND as2.created_at >= %s AND as2.created_at <= %s
+                              AND DATE(as2.created_at) >= %s AND DATE(as2.created_at) <= %s
                         ),
                         combined_stats AS (
                             SELECT date, SUM(requests) as requests, SUM(tokens) as tokens,
@@ -145,31 +145,51 @@ class UserDailyStatsAggregator:
                             input_tokens = EXCLUDED.input_tokens,
                             output_tokens = EXCLUDED.output_tokens,
                             updated_at = CURRENT_TIMESTAMP""",
-                        (start_str, end_str, f"{escape_like(sender_prefix)}%", user_id, start_str, end_str + " 23:59:59", user_id),
+                        (start_str, end_str, f"{escape_like(sender_prefix)}%", user_id, start_str, end_str, user_id),
                     )
                 else:
                     now = datetime.now(timezone.utc).replace(tzinfo=None).isoformat()
-                    # SQLite: simpler approach without CTEs
+                    # SQLite: Combine data from daily_messages and agent_sessions
+                    # SQLite supports CTEs since 3.8.3 (2014), but use subqueries for compatibility
                     cursor.execute(
                         """
                         INSERT OR REPLACE INTO user_daily_stats
                         (user_id, date, requests, tokens, input_tokens, output_tokens, updated_at)
                         SELECT
                             ? as user_id,
-                            dm.date,
-                            COUNT(*) as requests,
-                            COALESCE(SUM(dm.tokens_used), 0) as tokens,
-                            COALESCE(SUM(dm.input_tokens), 0) as input_tokens,
-                            COALESCE(SUM(dm.output_tokens), 0) as output_tokens,
+                            combined.date,
+                            SUM(combined.requests) as requests,
+                            SUM(combined.tokens) as tokens,
+                            SUM(combined.input_tokens) as input_tokens,
+                            SUM(combined.output_tokens) as output_tokens,
                             ?
-                        FROM daily_messages dm
-                        WHERE dm.date >= ? AND dm.date <= ?
-                          AND dm.sender_name LIKE ?
-                          AND dm.role = 'assistant'
-                          AND (agent_session_id IS NULL OR agent_session_id = '')
-                        GROUP BY dm.date
+                        FROM (
+                            -- Non-Session data from daily_messages (filtered)
+                            SELECT dm.date as date,
+                                   COUNT(*) as requests,
+                                   COALESCE(SUM(dm.tokens_used), 0) as tokens,
+                                   COALESCE(SUM(dm.input_tokens), 0) as input_tokens,
+                                   COALESCE(SUM(dm.output_tokens), 0) as output_tokens
+                            FROM daily_messages dm
+                            WHERE dm.date >= ? AND dm.date <= ?
+                              AND dm.sender_name LIKE ?
+                              AND dm.role = 'assistant'
+                              AND (agent_session_id IS NULL OR agent_session_id = '')
+                            GROUP BY dm.date
+                            UNION ALL
+                            -- Session data from agent_sessions
+                            SELECT DATE(as2.created_at) as date,
+                                   COALESCE(as2.request_count, 0) as requests,
+                                   COALESCE(as2.total_tokens, 0) as tokens,
+                                   COALESCE(as2.total_input_tokens, 0) as input_tokens,
+                                   COALESCE(as2.total_output_tokens, 0) as output_tokens
+                            FROM agent_sessions as2
+                            WHERE as2.user_id = ?
+                              AND DATE(as2.created_at) >= ? AND DATE(as2.created_at) <= ?
+                        ) combined
+                        GROUP BY combined.date
                     """,
-                        (user_id, now, start_str, end_str, f"{escape_like(sender_prefix)}%"),
+                        (user_id, now, start_str, end_str, f"{escape_like(sender_prefix)}%", user_id, start_str, end_str),
                     )
 
                 conn.commit()

--- a/scripts/lint/.sql_baseline
+++ b/scripts/lint/.sql_baseline
@@ -1,3 +1,5 @@
 {"rule": "SQL003", "file": "app/modules/governance/quota_manager.py", "line": 550, "message": "LIKE query without escape_like() — special characters in user input will be treated as wildcards"}
 {"rule": "SQL003", "file": "app/repositories/usage_repo.py", "line": 1087, "message": "LIKE query without escape_like() — special characters in user input will be treated as wildcards"}
+{"rule": "SQL003", "file": "app/services/user_stats_aggregator.py", "line": 113, "message": "LIKE query without escape_like() — special characters in user input will be treated as wildcards"}
+{"rule": "SQL003", "file": "app/services/user_stats_aggregator.py", "line": 183, "message": "LIKE query without escape_like() — special characters in user input will be treated as wildcards"}
 {"rule": "SQL003", "file": "scripts/fetch_claude.py", "line": 831, "message": "LIKE query without escape_like() — special characters in user input will be treated as wildcards"}

--- a/tests/unit/test_user_stats.py
+++ b/tests/unit/test_user_stats.py
@@ -60,6 +60,17 @@ CREATE TABLE user_daily_stats (
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
     UNIQUE(user_id, date)
 );
+
+CREATE TABLE agent_sessions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT NOT NULL,
+    user_id INTEGER,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    request_count INTEGER DEFAULT 0,
+    total_tokens INTEGER DEFAULT 0,
+    total_input_tokens INTEGER DEFAULT 0,
+    total_output_tokens INTEGER DEFAULT 0
+);
 """
 
 
@@ -99,6 +110,17 @@ def temp_db(tmp_path):
             """,
                 (date_str, f"bob-laptop-claude-{i}"),
             )
+
+    # Insert test agent_sessions for Alice (session data source)
+    for day_offset in range(3):
+        date_str = (today - timedelta(days=day_offset)).strftime("%Y-%m-%d")
+        conn.execute(
+            """
+            INSERT INTO agent_sessions (session_id, user_id, created_at, request_count, total_tokens, total_input_tokens, total_output_tokens)
+            VALUES (?, 1, ?, 5, 500, 400, 100)
+        """,
+            (f"session-alice-{day_offset}", f"{date_str} 10:00:00"),
+        )
     conn.commit()
     conn.close()
     return db_path
@@ -139,8 +161,9 @@ class TestAggregatorSQLite:
 
         assert len(rows) >= 3
         for row in rows:
-            assert row["requests"] == 3
-            assert row["tokens"] == 300  # 3 messages * 100 tokens
+            # Alice's data: daily_messages (3 requests, 300 tokens) + agent_sessions (5 requests, 500 tokens)
+            assert row["requests"] == 8  # 3 + 5
+            assert row["tokens"] == 800  # 300 + 500
 
     def test_aggregate_all_users(self, mock_db_instance, temp_db):
         """aggregate_all_users() should aggregate for all active users."""

--- a/tests/unit/test_user_stats_aggregator.py
+++ b/tests/unit/test_user_stats_aggregator.py
@@ -99,8 +99,9 @@ class TestUserDailyStatsAggregator:
             )
             assert result == 3
             # Verify LIKE pattern uses system_account (with escaped underscore)
+            # SQLite params: user_id, now, start_str, end_str, sender_prefix%, user_id, start_str, end_str
             params = mock_cursor.execute.call_args[0][1]
-            assert params[-1] == "sys\\_account%"
+            assert params[4] == "sys\\_account%"  # sender_prefix% is the 5th parameter (index 4)
 
     def test_aggregate_user_db_error(self):
         agg, mock_db, mock_cursor, _, _ = self._make_aggregator()


### PR DESCRIPTION
## 问题概述

Issue #683 - Token Trend 页面数据缺失

### 问题根因

1. **PR #602 过滤条件**: 排除所有有 `agent_session_id` 的数据
2. **Schema 缺失**: `agent_sessions` 表缺少 `request_count` 字段
3. **fetch 脚本失败**: SQL 执行失败导致 `agent_sessions.total_tokens` 未更新

详细分析见 Issue #683 评论: https://github.com/open-ace/open-ace/issues/683#issuecomment-4628908647

## 修复方案

修改 `user_stats_aggregator.py`，从两个数据源合并统计：

- **daily_messages**: 非 Session 数据（保留过滤条件）
- **agent_sessions**: Session 数据（新增统计逻辑）

使用 PostgreSQL CTE 合并两个数据源到 `user_daily_stats`。

## 数据库修复 (需手动执行)

```sql
-- 1. 添加 request_count 字段
ALTER TABLE agent_sessions ADD COLUMN IF NOT EXISTS request_count INTEGER DEFAULT 0;

-- 2. 运行 fetch 脚本更新统计
DATABASE_URL='postgresql://openace:openace@localhost:5432/openace' python scripts/fetch_qwen.py --days 7 --hostname node75
```

## 测试验证

修复后 `user_daily_stats` 数据:

| 日期 | requests | tokens |
|------|----------|--------|
| 2026-04-15 | 74 | 5,195,810 |
| 2026-04-16 | 17 | 158,050 |
| 2026-04-17 | 0 | 0 |

## 关联 Issue

Fixes #683