### PR TITLE
fix: autonomous workflow 7 bugs — comments, branch, merge, permissions, prompts

### DIFF
--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -190,6 +190,18 @@ class AutonomousOrchestrator:
             except (ValueError, IndexError):
                 pass
 
+            # Persist parsed issue number to workflow and record milestone
+            if issue_number:
+                self._update_workflow({"github_issue_number": issue_number})
+                self._create_milestone(
+                    phase="preparation",
+                    milestone_type="issue_linked",
+                    status="completed",
+                    title=f"Linked to issue #{issue_number}",
+                    github_issue_number=issue_number,
+                    result_summary=issue_url,
+                )
+
         if not issue_number and requirements_text:
             # Create issue from text
             try:
@@ -633,6 +645,45 @@ class AutonomousOrchestrator:
         dev_round = wf.get("dev_round", 1)
         branch_name = wf.get("branch_name", "")
         gh = self._get_gh()
+
+        # Check if branch has any changes vs main
+        has_changes = False
+        try:
+            diff_stats = gh.get_diff_stats("main", branch_name)
+            has_changes = diff_stats.get("commits", 0) > 0
+        except Exception:
+            pass
+
+        if not has_changes:
+            # No code changes produced — skip PR, post to issue, and mark completed
+            issue_number = wf.get("github_issue_number")
+            no_change_msg = (
+                f"## ℹ️ No Changes Detected\n\n"
+                f"Agent completed dev round {dev_round} without producing code changes. "
+                f"Skipping PR creation."
+            )
+            if issue_number:
+                try:
+                    gh.add_issue_comment(issue_number, no_change_msg)
+                except GitHubOpsError:
+                    pass
+            self._create_milestone(
+                phase="pr_review",
+                dev_round=dev_round,
+                milestone_type="no_changes",
+                status="completed",
+                title="No code changes produced",
+                result_summary="Agent did not produce any code changes. Skipping PR creation.",
+            )
+            self._update_workflow(
+                {
+                    "status": "completed",
+                    "current_phase": "completed",
+                    "error_message": "",
+                }
+            )
+            self._emit("phase_change", {"phase": "completed"})
+            return
 
         # Ensure branch is pushed to remote before PR creation
         try:

--- a/tests/issues/716/test_orchestrator.py
+++ b/tests/issues/716/test_orchestrator.py
@@ -262,6 +262,66 @@ class TestOrchestratorPreparation:
         phases = [c[0][1].get("current_phase") for c in update_calls if "current_phase" in c[0][1]]
         assert "planning" in phases
 
+    @patch("app.modules.workspace.autonomous.orchestrator.GitHubOps")
+    def test_preparation_persists_issue_number_from_url(self, mock_gh_cls):
+        """When requirements_issue_url is set with non-empty requirements_text,
+        the parsed issue number is persisted to the workflow."""
+        wf = _make_workflow(
+            current_phase="preparation",
+            requirements_text="请处理该issue：https://github.com/user/repo/issues/718",
+            requirements_issue_url="https://github.com/user/repo/issues/728",
+        )
+        orch, mock_repo = self._make_orchestrator(wf)
+
+        mock_gh = MagicMock()
+        mock_gh.create_branch.return_value = {"branch": "auto-dev/test-wf"}
+        mock_gh_cls.return_value = mock_gh
+
+        orch._do_preparation(wf)
+
+        # github_issue_number should be persisted via _update_workflow
+        update_calls = mock_repo.update_workflow.call_args_list
+        issue_updates = [c for c in update_calls if "github_issue_number" in c[0][1]]
+        assert len(issue_updates) == 1
+        assert issue_updates[0][0][1]["github_issue_number"] == 728
+
+        # Should also create a milestone for traceability
+        # _create_milestone passes a single dict positional arg to repo.create_milestone
+        milestone_calls = mock_repo.create_milestone.call_args_list
+        linked_milestones = [
+            c for c in milestone_calls if c[0][0].get("milestone_type") == "issue_linked"
+        ]
+        assert len(linked_milestones) == 1
+
+    @patch("app.modules.workspace.autonomous.orchestrator.GitHubOps")
+    def test_preparation_issue_url_no_text_reads_issue(self, mock_gh_cls):
+        """When requirements_issue_url is set with empty requirements_text,
+        the issue body is read and issue number is persisted."""
+        wf = _make_workflow(
+            current_phase="preparation",
+            requirements_text="",
+            requirements_issue_url="https://github.com/user/repo/issues/99",
+        )
+        orch, mock_repo = self._make_orchestrator(wf)
+
+        mock_gh = MagicMock()
+        mock_gh.get_issue.return_value = {
+            "number": 99,
+            "title": "Test Issue",
+            "body": "Issue body content",
+        }
+        mock_gh.create_branch.return_value = {"branch": "auto-dev/test-wf"}
+        mock_gh_cls.return_value = mock_gh
+
+        orch._do_preparation(wf)
+
+        # Should persist issue number from URL
+        update_calls = mock_repo.update_workflow.call_args_list
+        issue_updates = [c for c in update_calls if "github_issue_number" in c[0][1]]
+        # Both the URL parse persist and the elif block should set it
+        issue_numbers = [c[0][1]["github_issue_number"] for c in issue_updates]
+        assert 99 in issue_numbers
+
 
 class TestOrchestratorPlanning:
     """Tests for the planning phase."""
@@ -793,8 +853,14 @@ class TestOrchestratorPrReview:
             orch._gh = MagicMock()
             # Default safe return values for GitHub ops
             orch._gh.get_current_commit.return_value = ""
-            orch._gh.get_diff_stats.return_value = {}
-            orch._gh.get_diff.return_value = ""
+            # Default: branch has changes (most tests expect PR creation to proceed)
+            orch._gh.get_diff_stats.return_value = {
+                "additions": 10,
+                "deletions": 2,
+                "files": 3,
+                "commits": 1,
+            }
+            orch._gh.get_diff.return_value = "diff content"
             orch._gh.git_push.return_value = None
             orch._gh.create_pr.return_value = {"number": 99, "url": "https://github.com/pull/99"}
 
@@ -940,6 +1006,107 @@ class TestOrchestratorPrReview:
         orch._do_pr_review(wf)
 
         orch._gh.git_push.assert_called()
+
+    def test_pr_review_no_changes_marks_completed(self):
+        """When branch has no commits vs main, workflow completes gracefully."""
+        wf = _make_workflow(
+            current_phase="pr_review",
+            status="pr_review",
+            current_round=0,
+            branch_name="auto-dev/test",
+            github_issue_number=42,
+        )
+        orch, mock_repo = self._make_orchestrator(wf)
+
+        # No commits on branch vs main
+        orch._gh.get_diff_stats.return_value = {
+            "additions": 0,
+            "deletions": 0,
+            "files": 0,
+            "commits": 0,
+        }
+
+        orch._do_pr_review(wf)
+
+        # Should NOT create a PR
+        orch._gh.create_pr.assert_not_called()
+        # Should NOT push
+        orch._gh.git_push.assert_not_called()
+        # Should post comment to issue
+        orch._gh.add_issue_comment.assert_called_once()
+        comment = orch._gh.add_issue_comment.call_args[0]
+        assert comment[0] == 42
+        assert "No Changes Detected" in comment[1]
+        # Should mark workflow as completed (not failed)
+        update_calls = mock_repo.update_workflow.call_args_list
+        final_update = update_calls[-1][0][1]
+        assert final_update["status"] == "completed"
+        assert final_update["current_phase"] == "completed"
+
+    def test_pr_review_no_changes_creates_milestone(self):
+        """A 'no_changes' milestone is created when branch is empty."""
+        wf = _make_workflow(
+            current_phase="pr_review",
+            status="pr_review",
+            current_round=0,
+            branch_name="auto-dev/test",
+        )
+        orch, mock_repo = self._make_orchestrator(wf)
+        orch._gh.get_diff_stats.return_value = {
+            "additions": 0,
+            "deletions": 0,
+            "files": 0,
+            "commits": 0,
+        }
+
+        orch._do_pr_review(wf)
+
+        # _create_milestone passes a single dict positional arg to repo.create_milestone
+        milestone_calls = mock_repo.create_milestone.call_args_list
+        no_change_ms = [c for c in milestone_calls if c[0][0].get("milestone_type") == "no_changes"]
+        assert len(no_change_ms) == 1
+        assert no_change_ms[0][0][0]["status"] == "completed"
+
+    def test_pr_review_no_changes_no_issue_no_comment(self):
+        """When no issue_number and no changes, skip issue comment gracefully."""
+        wf = _make_workflow(
+            current_phase="pr_review",
+            status="pr_review",
+            current_round=0,
+            branch_name="auto-dev/test",
+            github_issue_number=None,
+        )
+        orch, _ = self._make_orchestrator(wf)
+        orch._gh.get_diff_stats.return_value = {
+            "additions": 0,
+            "deletions": 0,
+            "files": 0,
+            "commits": 0,
+        }
+
+        # Should not raise
+        orch._do_pr_review(wf)
+
+        orch._gh.add_issue_comment.assert_not_called()
+
+    def test_pr_review_diff_stats_error_treats_as_no_changes(self):
+        """When get_diff_stats raises, treat as no changes and complete gracefully."""
+        wf = _make_workflow(
+            current_phase="pr_review",
+            status="pr_review",
+            current_round=0,
+            branch_name="auto-dev/test",
+            github_issue_number=10,
+        )
+        orch, mock_repo = self._make_orchestrator(wf)
+        orch._gh.get_diff_stats.side_effect = Exception("git error")
+
+        orch._do_pr_review(wf)
+
+        # Should still complete gracefully
+        update_calls = mock_repo.update_workflow.call_args_list
+        final_update = update_calls[-1][0][1]
+        assert final_update["status"] == "completed"
 
 
 # ── _do_report Tests ──────────────────────────────────────────────────


### PR DESCRIPTION
## 修复内容

Closes #730

### Bug 1: Planning 阶段未在 GitHub Issue 上发评论
**根因**: `_do_preparation()` 中 `requirements_issue_url` 解析出的 `issue_number` 未保存到 workflow。
**修复**: 解析后立即 `_update_workflow()` 持久化并创建 milestone。

### Bug 2: 空分支导致 workflow 致命失败
**根因**: `_do_pr_review()` 不检查分支是否有 commit。
**修复**: PR 创建前检查 `get_diff_stats()`，无变更时优雅完成。

### Bug 3: claude_code adapter 未传递 permission_mode
**根因**: `build_start_args()` 忽略 `permission_mode` 参数。
**修复**: 映射为 `--permission-mode` CLI 参数。

### Bug 4: Agent 不知道自己在 autonomous 模式
**根因**: 所有 prompt 缺少 autonomous 上下文。
**修复**: 所有 prompt 添加 `AUTONOMOUS_CONTEXT` 前缀。

### Bug 5: 分支从 local HEAD 创建（非 origin/main）
**根因**: `create_branch()` 默认从 HEAD 创建，导致 PR 包含不相关 commit。
**修复**: `_do_preparation()` 先 `git fetch origin main`，再 `create_branch(name, base="origin/main")`。

### Bug 6: Wait 阶段时间戳过滤失效
**根因**: `created_at` vs `createdAt` 字段名不匹配，`last_comment_time` 始终为空。
**修复**: 使用正确的 `createdAt` 字段名；report 阶段创建 `wait_started` milestone 记录时间基准。

### Bug 7: Orchestrator 自己的评论误触发合并
**根因**: `"completed"` 在 COMPLETION_KEYWORDS 中，agent 发的 Progress Report 包含该词；简单子串匹配导致误触发。
**修复**: 移除 `"completed"`；改用 regex whole-word 匹配，支持中英文标点。

### 新增测试 (14个)
- Preparation: `persists_issue_number_from_url`, `issue_url_no_text_reads_issue`, `branches_from_origin_main`
- PR Review: `no_changes_marks_completed`, `no_changes_creates_milestone`, `no_changes_no_issue_no_comment`, `diff_stats_error_treats_as_no_changes`
- Wait: `ignores_report_with_completed_word`, `triggers_merge_on_explicit_keyword`, `uses_wait_started_timestamp`, `uses_correct_createdAt_field`, `all_done_keyword_triggers_merge`

### 修改文件
- `app/modules/workspace/autonomous/orchestrator.py` — Bug 1,2,4,5,6,7 修复
- `remote-agent/cli_adapters/claude_code.py` — Bug 3 修复
- `tests/issues/716/test_orchestrator.py` — 14 个新测试

🤖 Generated with [Claude Code](https://claude.com/claude-code)