### PR TITLE
fix: resolve autonomous workflow chain failure (Issue #733)

### DIFF
--- a/app/modules/workspace/autonomous/github_ops.py
+++ b/app/modules/workspace/autonomous/github_ops.py
@@ -192,9 +192,9 @@ class GitHubOps:
 
     # ── Worktree Operations ─────────────────────────────────────────
 
-    def create_worktree(self, path: str, branch: str) -> dict:
+    def create_worktree(self, path: str, branch: str, base: str = "HEAD") -> dict:
         """Create a git worktree with a new branch."""
-        self._run_git(["worktree", "add", "-b", branch, path, "HEAD"])
+        self._run_git(["worktree", "add", "-b", branch, path, base])
         logger.info("Created worktree at %s on branch %s", path, branch)
         return {"worktree_path": path, "branch": branch}
 

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -42,8 +42,8 @@ AUTONOMOUS_CONTEXT = (
     "你正在无人值守的自动化工作流中运行。请遵守以下规则：\n"
     "1. 不要请求人类确认或等待权限批准，如果操作被阻止请跳过并继续\n"
     "2. 不要使用需要交互式确认的 gh CLI 命令（如 gh pr create）\n"
-    "3. 直接输出你的分析和方案，不要尝试执行需要权限的操作\n"
-    "4. 如果需要修改文件，直接输出修改方案即可\n\n"
+    "3. 直接执行文件修改、git 操作等，不要仅输出方案文本\n"
+    "4. 遇到权限问题时跳过该步骤继续执行其他任务\n\n"
 )
 
 
@@ -338,7 +338,9 @@ class AutonomousOrchestrator:
                 f"## 原始需求\n{requirements}\n\n"
                 f"## 审查意见\n{review_text}\n\n"
                 f"## 原方案\n{existing_plan}\n\n"
-                f"请输出完善后的完整实现方案。"
+                f"请输出完善后的完整实现方案。\n\n"
+                f"重要约束：只输出高层设计方案和实现步骤描述，"
+                f"不要输出完整的代码实现。具体代码将在后续开发阶段编写。"
             )
             milestone_type = "plan_refined"
         else:
@@ -351,7 +353,9 @@ class AutonomousOrchestrator:
                 f"2. 技术方案和架构设计\n"
                 f"3. 实现步骤（按优先级排序）\n"
                 f"4. 测试策略\n"
-                f"5. 潜在风险和缓解措施"
+                f"5. 潜在风险和缓解措施\n\n"
+                f"重要约束：只输出高层设计方案和实现步骤描述，"
+                f"不要输出完整的代码实现。具体代码将在后续开发阶段编写。"
             )
             milestone_type = "plan_created"
 
@@ -372,6 +376,7 @@ class AutonomousOrchestrator:
             prompt=prompt,
             workspace_type=wf.get("workspace_type", "local"),
             remote_machine_id=wf.get("remote_machine_id"),
+            permission_mode=wf.get("permission_mode", "auto-edit"),
         )
 
         self._accumulate_tokens(result)
@@ -433,6 +438,7 @@ class AutonomousOrchestrator:
             prompt=review_prompt,
             workspace_type=wf.get("workspace_type", "local"),
             remote_machine_id=wf.get("remote_machine_id"),
+            permission_mode=wf.get("permission_mode", "auto-edit"),
         )
 
         self._accumulate_tokens(review_result)
@@ -463,10 +469,18 @@ class AutonomousOrchestrator:
         if round_num >= max_rounds:
             # All plan review rounds completed — post final plan to issue
             final_plan = ""
+            last_review = ""
             all_milestones = self.repo.list_milestones(self._workflow_id, phase="planning")
             for ms in reversed(all_milestones):
-                if ms.get("plan_content"):
+                if ms.get("plan_content") and not final_plan:
                     final_plan = ms["plan_content"]
+                if (
+                    ms.get("milestone_type") == "plan_reviewed"
+                    and ms.get("review_content")
+                    and not last_review
+                ):
+                    last_review = ms["review_content"]
+                if final_plan and last_review:
                     break
 
             issue_number = wf.get("github_issue_number")
@@ -477,6 +491,12 @@ class AutonomousOrchestrator:
                         f"Plan review completed after {max_rounds} round(s).\n\n"
                         f"{final_plan}"
                     )
+                    if last_review:
+                        final_comment += (
+                            f"\n\n---\n\n"
+                            f"## ⚠️ Note: Last review had feedback not yet addressed\n\n"
+                            f"{last_review[:2000]}"
+                        )
                     gh.add_issue_comment(issue_number, final_comment)
                 except Exception:
                     pass
@@ -520,6 +540,13 @@ class AutonomousOrchestrator:
             title=f"Development round {dev_round}",
         )
 
+        # Capture commit SHA before agent runs to verify code changes later
+        commit_before = ""
+        try:
+            commit_before = gh.get_current_commit()
+        except Exception:
+            pass
+
         dev_prompt = (
             AUTONOMOUS_CONTEXT + f"根据以下已审定的实现方案进行完整开发。\n\n"
             f"## 实现方案\n{final_plan}\n\n"
@@ -540,6 +567,7 @@ class AutonomousOrchestrator:
             prompt=dev_prompt,
             workspace_type=wf.get("workspace_type", "local"),
             remote_machine_id=wf.get("remote_machine_id"),
+            permission_mode=wf.get("permission_mode", "auto-edit"),
         )
 
         self._accumulate_tokens(result)
@@ -552,6 +580,26 @@ class AutonomousOrchestrator:
             diff_stats = gh.get_diff_stats("HEAD~1", "HEAD")
         except Exception:
             pass
+
+        # Verify agent actually produced code changes
+        if result.success and commit_before and commit_sha and commit_before == commit_sha:
+            logger.warning("Agent reported success but no new commits detected (SHA unchanged)")
+            self.repo.update_milestone(
+                ms.get("milestone_id", ""),
+                {
+                    "status": "failed",
+                    "session_id": result.session_id,
+                    "result_summary": result.response_text[:300] if result.response_text else "",
+                    "error_message": "Agent produced no code changes (commit SHA unchanged)",
+                },
+            )
+            self._update_workflow(
+                {
+                    "status": "failed",
+                    "error_message": "Development failed: agent produced no code changes",
+                }
+            )
+            return
 
         self.repo.update_milestone(
             ms.get("milestone_id", ""),
@@ -594,6 +642,7 @@ class AutonomousOrchestrator:
             prompt=test_prompt,
             workspace_type=wf.get("workspace_type", "local"),
             remote_machine_id=wf.get("remote_machine_id"),
+            permission_mode=wf.get("permission_mode", "auto-edit"),
         )
 
         self._accumulate_tokens(test_result)
@@ -790,6 +839,7 @@ class AutonomousOrchestrator:
             prompt=review_prompt,
             workspace_type=wf.get("workspace_type", "local"),
             remote_machine_id=wf.get("remote_machine_id"),
+            permission_mode=wf.get("permission_mode", "auto-edit"),
         )
 
         self._accumulate_tokens(review_result)
@@ -849,6 +899,7 @@ class AutonomousOrchestrator:
                 prompt=fix_prompt,
                 workspace_type=wf.get("workspace_type", "local"),
                 remote_machine_id=wf.get("remote_machine_id"),
+                permission_mode=wf.get("permission_mode", "auto-edit"),
             )
 
             self._accumulate_tokens(fix_result)
@@ -1167,6 +1218,7 @@ class AutonomousOrchestrator:
                 prompt=conflict_prompt,
                 workspace_type=wf.get("workspace_type", "local"),
                 remote_machine_id=wf.get("remote_machine_id"),
+                permission_mode=wf.get("permission_mode", "auto-edit"),
             )
 
             if not result.success:

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -36,6 +36,15 @@ COMPLETION_KEYWORDS = [
     "workflow complete",
 ]
 
+# Pre-compiled patterns for completion keyword matching (avoids recompilation in loop)
+_COMPLETION_PATTERNS = [
+    re.compile(
+        rf"(?:^|\s){re.escape(kw)}(?:[\s,，。.!！?？、;；:：\n]|$)",
+        re.IGNORECASE,
+    )
+    for kw in COMPLETION_KEYWORDS
+]
+
 # Prefix added to all prompts to inform the agent it is running autonomously
 AUTONOMOUS_CONTEXT = (
     "## 重要提示\n"
@@ -270,6 +279,7 @@ class AutonomousOrchestrator:
                     wt_data = gh.create_worktree(
                         path=f"{project_path}/../{branch_name.replace('/', '-')}",
                         branch=branch_name,
+                        base="origin/main",
                     )
                     self._update_workflow({"worktree_path": wt_data.get("worktree_path", "")})
                 else:
@@ -572,11 +582,15 @@ class AutonomousOrchestrator:
 
         self._accumulate_tokens(result)
 
-        # Get diff stats
+        # Get diff stats and commit SHA independently so one failure
+        # does not discard the other
         diff_stats = {}
         commit_sha = ""
         try:
             commit_sha = gh.get_current_commit()
+        except Exception:
+            pass
+        try:
             diff_stats = gh.get_diff_stats("HEAD~1", "HEAD")
         except Exception:
             pass
@@ -1055,13 +1069,7 @@ class AutonomousOrchestrator:
         # Check for completion signals — match whole words/lines only
         for comment in reversed(user_comments):
             body = comment.get("body", "")
-            for keyword in COMPLETION_KEYWORDS:
-                # Match as standalone phrase: at line start or preceded by whitespace,
-                # followed by whitespace, punctuation, or end of string
-                pattern = re.compile(
-                    rf"(?:^|\s){re.escape(keyword)}(?:[\s,，。.!！?？、;；:：\n]|$)",
-                    re.IGNORECASE,
-                )
+            for pattern in _COMPLETION_PATTERNS:
                 if pattern.search(body):
                     self._update_workflow(
                         {

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -35,6 +35,16 @@ COMPLETION_KEYWORDS = [
     "全部完成",
 ]
 
+# Prefix added to all prompts to inform the agent it is running autonomously
+AUTONOMOUS_CONTEXT = (
+    "## 重要提示\n"
+    "你正在无人值守的自动化工作流中运行。请遵守以下规则：\n"
+    "1. 不要请求人类确认或等待权限批准，如果操作被阻止请跳过并继续\n"
+    "2. 不要使用需要交互式确认的 gh CLI 命令（如 gh pr create）\n"
+    "3. 直接输出你的分析和方案，不要尝试执行需要权限的操作\n"
+    "4. 如果需要修改文件，直接输出修改方案即可\n\n"
+)
+
 
 class AutonomousOrchestrator:
     """Drives a single autonomous workflow through its phases."""
@@ -320,7 +330,7 @@ class AutonomousOrchestrator:
                     break
 
             prompt = (
-                f"你是一个高级开发工程师。请根据以下审查意见完善实现方案。\n\n"
+                AUTONOMOUS_CONTEXT + f"你是一个高级开发工程师。请根据以下审查意见完善实现方案。\n\n"
                 f"## 原始需求\n{requirements}\n\n"
                 f"## 审查意见\n{review_text}\n\n"
                 f"## 原方案\n{existing_plan}\n\n"
@@ -329,7 +339,7 @@ class AutonomousOrchestrator:
             milestone_type = "plan_refined"
         else:
             prompt = (
-                f"你是一个高级开发工程师。请为以下需求制定详细的实现方案。\n\n"
+                AUTONOMOUS_CONTEXT + f"你是一个高级开发工程师。请为以下需求制定详细的实现方案。\n\n"
                 f"## 需求\n{requirements}\n\n"
                 f"## 项目路径\n{wf.get('project_path', '')}\n\n"
                 f"请用 plan mode 创建方案，包含：\n"
@@ -392,7 +402,7 @@ class AutonomousOrchestrator:
 
         # Step 2: Review plan
         review_prompt = (
-            f"你是一位资深技术评审专家。请严格审查以下实现方案，指出：\n"
+            AUTONOMOUS_CONTEXT + f"你是一位资深技术评审专家。请严格审查以下实现方案，指出：\n"
             f"1. 遗漏的需求\n"
             f"2. 架构风险\n"
             f"3. 实现难度估计\n"
@@ -507,7 +517,7 @@ class AutonomousOrchestrator:
         )
 
         dev_prompt = (
-            f"根据以下已审定的实现方案进行完整开发。\n\n"
+            AUTONOMOUS_CONTEXT + f"根据以下已审定的实现方案进行完整开发。\n\n"
             f"## 实现方案\n{final_plan}\n\n"
             f"## 要求\n"
             f"1. 严格按照方案实现所有功能\n"
@@ -567,7 +577,8 @@ class AutonomousOrchestrator:
         )
 
         test_prompt = (
-            "运行项目的完整测试套件并报告结果。如果有失败，修复问题并重新测试。"
+            AUTONOMOUS_CONTEXT
+            + "运行项目的完整测试套件并报告结果。如果有失败，修复问题并重新测试。"
             "确保所有测试通过后再结束。"
         )
 
@@ -755,7 +766,7 @@ class AutonomousOrchestrator:
             pass
 
         review_prompt = (
-            f"你是一位资深代码审查专家。请审查以下 PR 的代码变更。\n\n"
+            AUTONOMOUS_CONTEXT + f"你是一位资深代码审查专家。请审查以下 PR 的代码变更。\n\n"
             f"## 需求\n{wf.get('requirements_text', '')[:500]}\n\n"
             f"## 代码变更\n{diff_text[:8000]}\n\n"
             f"请检查：\n"
@@ -822,7 +833,7 @@ class AutonomousOrchestrator:
             )
 
             fix_prompt = (
-                f"根据以下代码审查意见修改代码：\n\n{review_text}\n\n"
+                AUTONOMOUS_CONTEXT + f"根据以下代码审查意见修改代码：\n\n{review_text}\n\n"
                 f"修改后提交 git commit 并推送。"
             )
 
@@ -1114,7 +1125,8 @@ class AutonomousOrchestrator:
 
             # Ask AI agent to resolve conflicts
             conflict_prompt = (
-                "当前分支与 main 存在合并冲突。请解决所有冲突文件中的冲突标记，"
+                AUTONOMOUS_CONTEXT
+                + "当前分支与 main 存在合并冲突。请解决所有冲突文件中的冲突标记，"
                 "保留两边的有效修改。解决完成后执行 git add 并 git commit。\n\n"
                 "步骤：\n"
                 "1. 查看所有冲突文件：git diff --name-only --diff-filter=U\n"

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -9,6 +9,7 @@ pr_review -> report -> wait -> (loop or merge).
 
 import json
 import logging
+import re
 import uuid
 from datetime import datetime, timezone
 from typing import Optional
@@ -28,11 +29,11 @@ COMPLETION_KEYWORDS = [
     "无新需求",
     "项目结束",
     "all done",
-    "completed",
     "no more requirements",
     "project finished",
     "开发完毕",
     "全部完成",
+    "workflow complete",
 ]
 
 # Prefix added to all prompts to inform the agent it is running autonomously
@@ -262,6 +263,9 @@ class AutonomousOrchestrator:
             if not branch_name:
                 branch_name = f"auto-dev/{self._workflow_id[:8]}"
             try:
+                # Ensure we branch from latest origin/main
+                gh._run_git(["fetch", "origin", "main"])
+
                 if strategy == "worktree":
                     wt_data = gh.create_worktree(
                         path=f"{project_path}/../{branch_name.replace('/', '-')}",
@@ -269,7 +273,7 @@ class AutonomousOrchestrator:
                     )
                     self._update_workflow({"worktree_path": wt_data.get("worktree_path", "")})
                 else:
-                    gh.create_branch(branch_name)
+                    gh.create_branch(branch_name, base="origin/main")
                 self._create_milestone(
                     phase="preparation",
                     milestone_type="branch_created",
@@ -934,6 +938,16 @@ class AutonomousOrchestrator:
             title=f"Dev round {dev_round} completed",
         )
 
+        # Record wait phase start time for comment filtering
+        self._create_milestone(
+            phase="report",
+            dev_round=dev_round,
+            milestone_type="wait_started",
+            status="completed",
+            title="Wait phase starting",
+            metadata=json.dumps({"wait_started_at": datetime.now(timezone.utc).isoformat()}),
+        )
+
         # Move to wait phase
         self._update_workflow(
             {
@@ -953,20 +967,22 @@ class AutonomousOrchestrator:
         if not issue_number:
             return  # No issue to check
 
-        # Get last known comment timestamp from milestones
-        last_comment_time = ""
+        # Get the time when wait phase started (set by _do_report)
+        # This ensures only user comments AFTER the report are considered
+        wait_start = ""
         milestones = self.repo.list_milestones(self._workflow_id)
         for ms in reversed(milestones):
-            if ms.get("milestone_type") == "requirement_received" and ms.get("metadata"):
+            if ms.get("milestone_type") == "wait_started" and ms.get("metadata"):
                 try:
                     meta = json.loads(ms["metadata"])
-                    last_comment_time = meta.get("last_comment_time", "")
+                    wait_start = meta.get("wait_started_at", "")
                 except (json.JSONDecodeError, TypeError):
                     pass
+                break
 
         try:
             comments = gh.list_issue_comments(
-                issue_number, since=last_comment_time if last_comment_time else None
+                issue_number, since=wait_start if wait_start else None
             )
         except GitHubOpsError:
             return
@@ -985,11 +1001,17 @@ class AutonomousOrchestrator:
             )
         ]
 
-        # Check for completion signals
+        # Check for completion signals — match whole words/lines only
         for comment in reversed(user_comments):
-            body = comment.get("body", "").lower()
+            body = comment.get("body", "")
             for keyword in COMPLETION_KEYWORDS:
-                if keyword.lower() in body:
+                # Match as standalone phrase: at line start or preceded by whitespace,
+                # followed by whitespace, punctuation, or end of string
+                pattern = re.compile(
+                    rf"(?:^|\s){re.escape(keyword)}(?:[\s,，。.!！?？、;；:：\n]|$)",
+                    re.IGNORECASE,
+                )
+                if pattern.search(body):
                     self._update_workflow(
                         {
                             "current_phase": "merge",
@@ -1006,7 +1028,8 @@ class AutonomousOrchestrator:
         # New requirements detected
         new_req_comment = user_comments[-1]  # Latest user comment
         new_requirements = new_req_comment.get("body", "")
-        comment_time = new_req_comment.get("created_at", "")
+        # Use correct field name from gh CLI (camelCase)
+        comment_time = new_req_comment.get("createdAt", "")
 
         self._create_milestone(
             phase="wait",

--- a/remote-agent/cli_adapters/claude_code.py
+++ b/remote-agent/cli_adapters/claude_code.py
@@ -76,6 +76,19 @@ class ClaudeCodeAdapter(BaseCLIAdapter):
         if model:
             args.extend(["--model", model])
 
+        # Map internal permission_mode to Claude CLI --permission-mode flag
+        # Choices: "acceptEdits", "auto", "bypassPermissions", "default"
+        if permission_mode:
+            mode_map = {
+                "auto-edit": "acceptEdits",
+                "auto": "auto",
+                "bypass": "bypassPermissions",
+                "full-auto": "bypassPermissions",
+            }
+            cli_mode = mode_map.get(permission_mode)
+            if cli_mode:
+                args.extend(["--permission-mode", cli_mode])
+
         return args
 
     def get_display_name(self) -> str:

--- a/tests/issues/716/test_github_ops.py
+++ b/tests/issues/716/test_github_ops.py
@@ -330,6 +330,19 @@ class TestGitHubOpsWorktree:
         result = self.gh.create_worktree("/tmp/test-repo-wt", "feature/wt")
         assert result["worktree_path"] == "/tmp/test-repo-wt"
         assert result["branch"] == "feature/wt"
+        # Default base is HEAD
+        cmd = mock_run.call_args[0][0]
+        assert cmd[-1] == "HEAD"
+
+    @patch("app.modules.workspace.autonomous.github_ops.subprocess.run")
+    def test_create_worktree_with_base(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0, stdout="")
+        result = self.gh.create_worktree("/tmp/test-repo-wt", "feature/wt", base="origin/main")
+        assert result["worktree_path"] == "/tmp/test-repo-wt"
+        assert result["branch"] == "feature/wt"
+        # Should use the provided base ref instead of HEAD
+        cmd = mock_run.call_args[0][0]
+        assert cmd[-1] == "origin/main"
 
     @patch("app.modules.workspace.autonomous.github_ops.subprocess.run")
     def test_remove_worktree(self, mock_run):

--- a/tests/issues/716/test_orchestrator.py
+++ b/tests/issues/716/test_orchestrator.py
@@ -566,7 +566,15 @@ class TestOrchestratorWait:
         mock_repo.update_workflow.assert_not_called()
 
     def test_wait_ignores_report_with_completed_word(self):
-        """Progress Report comment containing 'completed' should NOT trigger merge."""
+        """Progress Report comment containing 'completed' should NOT trigger merge.
+
+        This is a regression guard: 'completed' was previously in
+        COMPLETION_KEYWORDS and caused false triggers on milestone reports.
+        Even if someone re-adds 'completed' to the keyword list, this test
+        ensures report-like comments don't accidentally trigger a merge.
+        The regex-based matching (whole-word/phrase) already protects against
+        this, but the test documents the design intent explicitly.
+        """
         wf = _make_workflow(current_phase="wait", github_issue_number=42)
         orch, mock_repo = self._make_orchestrator(wf)
 

--- a/tests/issues/716/test_orchestrator.py
+++ b/tests/issues/716/test_orchestrator.py
@@ -517,7 +517,7 @@ class TestOrchestratorWait:
 
         mock_gh = MagicMock()
         mock_gh.list_issue_comments.return_value = [
-            {"body": "开发完成", "created_at": "2026-06-05T14:00:00Z"},
+            {"body": "开发完成", "createdAt": "2026-06-05T14:00:00Z"},
         ]
         mock_gh_cls.return_value = mock_gh
         orch._gh = mock_gh
@@ -536,7 +536,7 @@ class TestOrchestratorWait:
 
         mock_gh = MagicMock()
         mock_gh.list_issue_comments.return_value = [
-            {"body": "Please also add a dark mode feature", "created_at": "2026-06-05T14:00:00Z"},
+            {"body": "Please also add a dark mode feature", "createdAt": "2026-06-05T14:00:00Z"},
         ]
         mock_gh_cls.return_value = mock_gh
         orch._gh = mock_gh
@@ -829,7 +829,7 @@ class TestOrchestratorDevelopment:
         orch._runner.run_agent_task.return_value = _make_agent_result(
             success=True, text="Development complete"
         )
-        orch._gh.get_current_commit.return_value = "abc1234"
+        orch._gh.get_current_commit.side_effect = ["abc1234", "def5678"]
         orch._gh.get_diff_stats.return_value = {"additions": 50, "deletions": 10, "files": 3}
 
         orch._do_development(wf)
@@ -857,7 +857,7 @@ class TestOrchestratorDevelopment:
         orch, _ = self._make_orchestrator(wf, milestones=[plan_ms])
         orch._runner = MagicMock()
         orch._runner.run_agent_task.return_value = _make_agent_result()
-        orch._gh.get_current_commit.return_value = "abc1234"
+        orch._gh.get_current_commit.side_effect = ["abc1234", "def5678"]
         orch._gh.get_diff_stats.return_value = {}
 
         orch._do_development(wf)
@@ -894,9 +894,8 @@ class TestOrchestratorDevelopment:
             _make_agent_result(success=True, text="Dev done"),
             _make_agent_result(success=False, error="Tests failed"),
         ]
-        orch._gh.get_current_commit.return_value = "abc1234"
-        orch._gh.get_diff_stats.return_value = {}
-        orch._gh.get_current_commit.return_value = "abc1234"
+        # commit_before="abc1234" -> commit_after dev="def5678" (dev changed code)
+        orch._gh.get_current_commit.side_effect = ["abc1234", "def5678", "def5678"]
         orch._gh.get_diff_stats.return_value = {}
 
         orch._do_development(wf)
@@ -916,7 +915,7 @@ class TestOrchestratorDevelopment:
         orch, _ = self._make_orchestrator(wf)
         orch._runner = MagicMock()
         orch._runner.run_agent_task.return_value = _make_agent_result()
-        orch._gh.get_current_commit.return_value = "abc1234"
+        orch._gh.get_current_commit.side_effect = ["abc1234", "def5678"]
         orch._gh.get_diff_stats.return_value = {}
 
         orch._do_development(wf)
@@ -936,7 +935,7 @@ class TestOrchestratorDevelopment:
         orch, _ = self._make_orchestrator(wf)
         orch._runner = MagicMock()
         orch._runner.run_agent_task.return_value = _make_agent_result()
-        orch._gh.get_current_commit.return_value = "abc1234"
+        orch._gh.get_current_commit.side_effect = ["abc1234", "def5678"]
         orch._gh.get_diff_stats.return_value = {}
 
         orch._do_development(wf)
@@ -953,7 +952,7 @@ class TestOrchestratorDevelopment:
         orch, _ = self._make_orchestrator(wf, milestones=[])  # No plan milestones
         orch._runner = MagicMock()
         orch._runner.run_agent_task.return_value = _make_agent_result()
-        orch._gh.get_current_commit.return_value = "abc1234"
+        orch._gh.get_current_commit.side_effect = ["abc1234", "def5678"]
         orch._gh.get_diff_stats.return_value = {}
 
         orch._do_development(wf)

--- a/tests/issues/716/test_orchestrator.py
+++ b/tests/issues/716/test_orchestrator.py
@@ -322,6 +322,32 @@ class TestOrchestratorPreparation:
         issue_numbers = [c[0][1]["github_issue_number"] for c in issue_updates]
         assert 99 in issue_numbers
 
+    @patch("app.modules.workspace.autonomous.orchestrator.GitHubOps")
+    def test_preparation_branches_from_origin_main(self, mock_gh_cls):
+        """Branch should be created from origin/main, not local HEAD."""
+        wf = _make_workflow(current_phase="preparation")
+        orch, mock_repo = self._make_orchestrator(wf)
+
+        mock_gh = MagicMock()
+        mock_gh.create_issue.return_value = {"number": 1, "url": ""}
+        mock_gh.create_branch.return_value = {"branch": "auto-dev/test-wf"}
+        mock_gh_cls.return_value = mock_gh
+
+        orch._do_preparation(wf)
+
+        # Should fetch origin/main before creating branch
+        fetch_calls = [c for c in mock_gh._run_git.call_args_list if "fetch" in str(c)]
+        assert len(fetch_calls) >= 1
+        assert "origin" in str(fetch_calls[0])
+        assert "main" in str(fetch_calls[0])
+
+        # Should create branch with base="origin/main"
+        mock_gh.create_branch.assert_called_once()
+        create_call = mock_gh.create_branch.call_args
+        assert create_call[1].get("base") == "origin/main" or (
+            len(create_call[0]) > 1 and create_call[0][1] == "origin/main"
+        )
+
 
 class TestOrchestratorPlanning:
     """Tests for the planning phase."""
@@ -538,6 +564,124 @@ class TestOrchestratorWait:
 
         # Should NOT update workflow
         mock_repo.update_workflow.assert_not_called()
+
+    def test_wait_ignores_report_with_completed_word(self):
+        """Progress Report comment containing 'completed' should NOT trigger merge."""
+        wf = _make_workflow(current_phase="wait", github_issue_number=42)
+        orch, mock_repo = self._make_orchestrator(wf)
+
+        # Simulate a report comment that contains "completed" in milestone text
+        orch._gh = MagicMock()
+        orch._gh.list_issue_comments.return_value = [
+            {
+                "body": "## 📊 Dev Round 1 Progress Report\n\n### Completed\n"
+                "- Plan round 1: status completed\n- Dev round 1 completed\n",
+                "createdAt": "2026-06-05T14:00:00Z",
+                "author": {"login": "richardhuang"},
+            },
+        ]
+
+        orch._do_wait(wf)
+
+        # Should NOT transition to merge
+        update_calls = mock_repo.update_workflow.call_args_list
+        merge_phases = [c for c in update_calls if c[0][1].get("current_phase") == "merge"]
+        assert len(merge_phases) == 0
+
+    def test_wait_triggers_merge_on_explicit_keyword(self):
+        """User comment with explicit completion keyword triggers merge."""
+        wf = _make_workflow(current_phase="wait", github_issue_number=42)
+        orch, mock_repo = self._make_orchestrator(wf)
+
+        orch._gh = MagicMock()
+        orch._gh.list_issue_comments.return_value = [
+            {
+                "body": "开发完成，没有更多需求了",
+                "createdAt": "2026-06-05T15:00:00Z",
+                "author": {"login": "richardhuang"},
+            },
+        ]
+
+        orch._do_wait(wf)
+
+        # Should transition to merge
+        update_calls = mock_repo.update_workflow.call_args_list
+        phases = [c[0][1].get("current_phase") for c in update_calls if "current_phase" in c[0][1]]
+        assert "merge" in phases
+
+    def test_wait_uses_wait_started_timestamp(self):
+        """Wait phase uses wait_started milestone timestamp for filtering."""
+        wf = _make_workflow(current_phase="wait", github_issue_number=42)
+        orch, mock_repo = self._make_orchestrator(wf)
+
+        # Set up a wait_started milestone
+        import json
+
+        mock_repo.list_milestones.return_value = [
+            {
+                "milestone_type": "wait_started",
+                "metadata": json.dumps({"wait_started_at": "2026-06-05T14:00:00Z"}),
+            },
+        ]
+
+        orch._gh = MagicMock()
+        # Comments before wait_start should be filtered out
+        orch._gh.list_issue_comments.return_value = [
+            {
+                "body": "开发完毕",
+                "createdAt": "2026-06-05T13:00:00Z",  # Before wait_started
+                "author": {"login": "richardhuang"},
+            },
+        ]
+
+        orch._do_wait(wf)
+
+        # Should NOT merge — comment is before wait_start
+        # (list_issue_comments receives since=wait_start, so comment is filtered server-side)
+        orch._gh.list_issue_comments.assert_called_once_with(42, since="2026-06-05T14:00:00Z")
+
+    def test_wait_uses_correct_createdAt_field(self):
+        """Requirement_received milestone stores createdAt (camelCase), not created_at."""
+        wf = _make_workflow(current_phase="wait", github_issue_number=42)
+        orch, mock_repo = self._make_orchestrator(wf)
+
+        orch._gh = MagicMock()
+        orch._gh.list_issue_comments.return_value = [
+            {
+                "body": "Please add dark mode support",
+                "createdAt": "2026-06-05T15:00:00Z",
+                "author": {"login": "richardhuang"},
+            },
+        ]
+
+        orch._do_wait(wf)
+
+        # Check the requirement_received milestone stores createdAt
+        ms_calls = mock_repo.create_milestone.call_args_list
+        req_ms = [c for c in ms_calls if c[0][0].get("milestone_type") == "requirement_received"]
+        assert len(req_ms) == 1
+        metadata = json.loads(req_ms[0][0][0]["metadata"])
+        assert metadata["last_comment_time"] == "2026-06-05T15:00:00Z"
+
+    def test_wait_all_done_keyword_triggers_merge(self):
+        """Comment 'all done' triggers merge (whole-word match)."""
+        wf = _make_workflow(current_phase="wait", github_issue_number=42)
+        orch, mock_repo = self._make_orchestrator(wf)
+
+        orch._gh = MagicMock()
+        orch._gh.list_issue_comments.return_value = [
+            {
+                "body": "Looks all done to me",
+                "createdAt": "2026-06-05T15:00:00Z",
+                "author": {"login": "richardhuang"},
+            },
+        ]
+
+        orch._do_wait(wf)
+
+        update_calls = mock_repo.update_workflow.call_args_list
+        phases = [c[0][1].get("current_phase") for c in update_calls if "current_phase" in c[0][1]]
+        assert "merge" in phases
 
 
 class TestOrchestratorMerge:
@@ -1169,8 +1313,8 @@ class TestOrchestratorReport:
 
         orch._do_report(wf)
 
-        # Two milestones: progress_reported + round_completed
-        assert mock_repo.create_milestone.call_count == 2
+        # Three milestones: progress_reported + round_completed + wait_started
+        assert mock_repo.create_milestone.call_count == 3
         # _create_milestone calls repo.create_milestone(kwargs_dict) as positional arg
         report_ms_dict = mock_repo.create_milestone.call_args_list[0][0][0]
         assert report_ms_dict["milestone_type"] == "progress_reported"
@@ -1251,4 +1395,4 @@ class TestOrchestratorReport:
         orch._do_report(wf)
 
         # Should still create milestones and move to wait
-        assert mock_repo.create_milestone.call_count == 2
+        assert mock_repo.create_milestone.call_count == 3

--- a/tests/issues/733/test_orchestrator_733.py
+++ b/tests/issues/733/test_orchestrator_733.py
@@ -1,0 +1,470 @@
+"""Tests for Issue #733 — chain failure fixes.
+
+Covers:
+- AUTONOMOUS_CONTEXT encourages execution (not just outputting text)
+- permission_mode passed to run_agent_task
+- commit verification in _do_development
+- planning prompt forbids full code output
+- Final Plan annotates unaddressed review feedback
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.modules.workspace.autonomous.models import AgentTaskResult
+
+
+def _make_workflow(**overrides):
+    """Create a minimal workflow dict for testing."""
+    base = {
+        "workflow_id": "test-wf-uuid",
+        "user_id": 1,
+        "title": "Test Workflow",
+        "status": "pending",
+        "requirements_text": "Build a simple feature",
+        "requirements_issue_url": "",
+        "project_path": "/tmp/test-project",
+        "project_repo_url": "",
+        "is_new_project": False,
+        "cli_tool": "claude-code",
+        "model": "claude-sonnet-4-6",
+        "permission_mode": "auto-edit",
+        "branch_name": "auto-dev/test",
+        "branch_strategy": "new-branch",
+        "workspace_type": "local",
+        "remote_machine_id": "",
+        "worktree_path": "",
+        "github_issue_number": None,
+        "github_pr_number": None,
+        "github_pr_url": "",
+        "current_phase": "development",
+        "current_round": 0,
+        "dev_round": 1,
+        "max_plan_rounds": 3,
+        "max_pr_review_rounds": 5,
+        "total_tokens": 0,
+        "total_input_tokens": 0,
+        "total_output_tokens": 0,
+        "total_requests": 0,
+        "error_message": "",
+    }
+    base.update(overrides)
+    return base
+
+
+def _make_agent_result(success=True, text="Done", tokens=100, error=None):
+    return AgentTaskResult(
+        session_id="sess-1",
+        response_text=text,
+        total_tokens=tokens,
+        total_input_tokens=tokens // 2,
+        total_output_tokens=tokens // 2,
+        success=success,
+        error=error,
+    )
+
+
+def _make_orchestrator(wf_data):
+    """Create orchestrator with mocked dependencies."""
+    from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+    with (
+        patch("app.modules.workspace.autonomous.orchestrator.Database"),
+        patch(
+            "app.modules.workspace.autonomous.orchestrator.AutonomousWorkflowRepository"
+        ) as mock_repo_cls,
+    ):
+        mock_repo = MagicMock()
+        mock_repo.get_workflow.return_value = wf_data
+        mock_repo.list_milestones.return_value = []
+        mock_repo.create_milestone.return_value = {
+            "milestone_id": "ms-1",
+            "workflow_id": wf_data["workflow_id"],
+        }
+        mock_repo.create_event.return_value = {"id": 1}
+        mock_repo.update_workflow.return_value = wf_data
+        mock_repo_cls.return_value = mock_repo
+
+        orch = AutonomousOrchestrator(wf_data["workflow_id"])
+        orch.repo = mock_repo
+
+    # Mock emitter and runner
+    orch.emitter = MagicMock()
+    orch._runner = MagicMock()
+
+    # Mock GitHubOps
+    with patch("app.modules.workspace.autonomous.orchestrator.GitHubOps") as mock_gh_cls:
+        mock_gh = MagicMock()
+        mock_gh.get_current_commit.return_value = "abc123"
+        mock_gh.get_diff_stats.return_value = {
+            "additions": 10,
+            "deletions": 2,
+            "files": 3,
+            "commits": 1,
+        }
+        mock_gh.get_diff.return_value = "diff content"
+        mock_gh.git_push.return_value = None
+        mock_gh.create_pr.return_value = {"number": 99, "url": "https://github.com/pull/99"}
+        mock_gh_cls.return_value = mock_gh
+        orch._gh = mock_gh
+
+    return orch, mock_repo
+
+
+class TestAutonomousContext:
+    """Verify AUTONOMOUS_CONTEXT encourages execution, not just text output."""
+
+    def test_context_encourages_execution(self):
+        from app.modules.workspace.autonomous.orchestrator import AUTONOMOUS_CONTEXT
+
+        # The OLD problematic full phrases should NOT appear
+        assert "不要尝试执行需要权限的操作" not in AUTONOMOUS_CONTEXT
+        assert "直接输出修改方案即可" not in AUTONOMOUS_CONTEXT
+
+        # NEW encouraging phrases SHOULD appear
+        assert "直接执行" in AUTONOMOUS_CONTEXT
+        assert "文件修改" in AUTONOMOUS_CONTEXT
+        assert "跳过该步骤继续执行" in AUTONOMOUS_CONTEXT
+
+    def test_context_no_longer_says_do_not_execute(self):
+        from app.modules.workspace.autonomous.orchestrator import AUTONOMOUS_CONTEXT
+
+        # The old problematic rules should be gone
+        lines = AUTONOMOUS_CONTEXT.strip().split("\n")
+        rule3 = [l for l in lines if l.startswith("3.")]
+        rule4 = [l for l in lines if l.startswith("4.")]
+
+        assert len(rule3) == 1
+        assert len(rule4) == 1
+        # Rule 3 should now say "execute" not "just output"
+        assert "直接执行文件修改" in rule3[0]
+        assert "仅输出方案文本" in rule3[0]  # "不要仅输出方案文本"
+        # Rule 4 should mention skipping on permission issues
+        assert "跳过" in rule4[0]
+
+
+class TestPermissionModePassthrough:
+    """Verify permission_mode is passed from workflow to run_agent_task."""
+
+    def test_planning_passes_permission_mode(self):
+        wf = _make_workflow(
+            current_phase="planning",
+            status="planning",
+            current_round=1,
+            dev_round=1,
+            permission_mode="bypass",
+        )
+        orch, mock_repo = _make_orchestrator(wf)
+        orch._runner.run_agent_task.return_value = _make_agent_result(text="# Plan\nStep 1")
+
+        mock_repo.list_milestones.return_value = []
+
+        orch._do_planning(wf)
+
+        # Check that ALL run_agent_task calls received permission_mode="bypass"
+        for call in orch._runner.run_agent_task.call_args_list:
+            pm = call.kwargs.get("permission_mode") or call[1].get("permission_mode")
+            assert pm == "bypass"
+
+    def test_development_passes_permission_mode(self):
+        wf = _make_workflow(
+            current_phase="development",
+            status="developing",
+            dev_round=1,
+            permission_mode="auto",
+        )
+        orch, mock_repo = _make_orchestrator(wf)
+        orch._runner.run_agent_task.return_value = _make_agent_result(text="Done")
+        orch._gh.get_current_commit.side_effect = ["abc123", "def456"]
+
+        mock_repo.list_milestones.return_value = [
+            {"milestone_type": "plan_created", "plan_content": "Build feature X"},
+        ]
+
+        orch._do_development(wf)
+
+        call_args = orch._runner.run_agent_task.call_args
+        pm = call_args.kwargs.get("permission_mode") or call_args[1].get("permission_mode")
+        assert pm == "auto"
+
+    def test_default_permission_mode_is_auto_edit(self):
+        wf = _make_workflow(
+            current_phase="development",
+            status="developing",
+            dev_round=1,
+        )
+        # Remove permission_mode to test default
+        wf.pop("permission_mode", None)
+        orch, mock_repo = _make_orchestrator(wf)
+        orch._runner.run_agent_task.return_value = _make_agent_result(text="Done")
+        orch._gh.get_current_commit.side_effect = ["abc123", "def456"]
+
+        mock_repo.list_milestones.return_value = [
+            {"milestone_type": "plan_created", "plan_content": "Build feature X"},
+        ]
+
+        orch._do_development(wf)
+
+        call_args = orch._runner.run_agent_task.call_args
+        pm = call_args.kwargs.get("permission_mode") or call_args[1].get("permission_mode")
+        assert pm == "auto-edit"
+
+
+class TestDevelopmentCommitVerification:
+    """Verify _do_development detects when agent produces no code changes."""
+
+    def _get_failed_updates(self, mock_repo):
+        """Extract update_workflow calls where status=failed."""
+        # repo.update_workflow is called as (workflow_id, updates_dict)
+        return [
+            c for c in mock_repo.update_workflow.call_args_list if c[0][1].get("status") == "failed"
+        ]
+
+    def test_detects_no_code_changes(self):
+        """When commit SHA is unchanged after agent run, workflow should fail."""
+        wf = _make_workflow(
+            current_phase="development",
+            status="developing",
+            dev_round=1,
+        )
+        orch, mock_repo = _make_orchestrator(wf)
+        orch._runner.run_agent_task.return_value = _make_agent_result(
+            success=True, text="I have completed the implementation"
+        )
+        # Same commit before and after = no changes
+        orch._gh.get_current_commit.return_value = "abc123"
+
+        mock_repo.list_milestones.return_value = [
+            {"milestone_type": "plan_created", "plan_content": "Build feature X"},
+        ]
+
+        orch._do_development(wf)
+
+        failed_updates = self._get_failed_updates(mock_repo)
+        assert len(failed_updates) >= 1
+        assert "no code changes" in failed_updates[-1][0][1]["error_message"].lower()
+
+    def test_allows_different_commits(self):
+        """When commit SHA changes, workflow should proceed normally."""
+        wf = _make_workflow(
+            current_phase="development",
+            status="developing",
+            dev_round=1,
+        )
+        orch, mock_repo = _make_orchestrator(wf)
+        orch._runner.run_agent_task.return_value = _make_agent_result(
+            success=True, text="Implementation done"
+        )
+        # Different commits before and after
+        orch._gh.get_current_commit.side_effect = ["abc123", "def456"]
+
+        mock_repo.list_milestones.return_value = [
+            {"milestone_type": "plan_created", "plan_content": "Build feature X"},
+        ]
+
+        orch._do_development(wf)
+
+        failed_updates = self._get_failed_updates(mock_repo)
+        assert len(failed_updates) == 0
+
+    def test_skip_check_when_commit_unavailable(self):
+        """When commit SHA is empty, skip the verification gracefully."""
+        wf = _make_workflow(
+            current_phase="development",
+            status="developing",
+            dev_round=1,
+        )
+        orch, mock_repo = _make_orchestrator(wf)
+        orch._runner.run_agent_task.return_value = _make_agent_result(success=True, text="Done")
+        # Empty commit SHA
+        orch._gh.get_current_commit.return_value = ""
+
+        mock_repo.list_milestones.return_value = [
+            {"milestone_type": "plan_created", "plan_content": "Build feature X"},
+        ]
+
+        orch._do_development(wf)
+
+        failed_updates = self._get_failed_updates(mock_repo)
+        assert len(failed_updates) == 0
+
+    def test_skip_check_when_agent_fails(self):
+        """When agent itself fails, no need for commit verification."""
+        wf = _make_workflow(
+            current_phase="development",
+            status="developing",
+            dev_round=1,
+        )
+        orch, mock_repo = _make_orchestrator(wf)
+        orch._runner.run_agent_task.return_value = _make_agent_result(
+            success=False, text="", error="Timeout"
+        )
+        orch._gh.get_current_commit.return_value = "abc123"
+
+        mock_repo.list_milestones.return_value = [
+            {"milestone_type": "plan_created", "plan_content": "Build feature X"},
+        ]
+
+        orch._do_development(wf)
+
+        failed_updates = self._get_failed_updates(mock_repo)
+        assert len(failed_updates) >= 1
+        assert "timeout" in failed_updates[-1][0][1]["error_message"].lower()
+
+
+class TestPlanningPromptConstraints:
+    """Verify planning prompts forbid full code output."""
+
+    def test_initial_plan_prompt_forbids_full_code(self):
+        """Initial plan prompt should contain constraint against full code."""
+        wf = _make_workflow(
+            current_phase="planning",
+            status="planning",
+            current_round=0,
+            dev_round=1,
+        )
+        orch, mock_repo = _make_orchestrator(wf)
+        orch._runner.run_agent_task.return_value = _make_agent_result(text="# Plan\nStep 1")
+        mock_repo.list_milestones.return_value = []
+
+        orch._do_planning(wf)
+
+        # _do_planning calls run_agent_task twice: plan agent then review agent.
+        # The constraint should be in the FIRST call (plan agent).
+        calls = orch._runner.run_agent_task.call_args_list
+        assert len(calls) >= 1
+        plan_prompt = calls[0].kwargs.get("prompt") or calls[0][1].get("prompt")
+        assert plan_prompt is not None
+        assert "不要输出完整的代码实现" in plan_prompt
+        assert "具体代码将在后续开发阶段编写" in plan_prompt
+
+    def test_refined_plan_prompt_forbids_full_code(self):
+        """Refined plan prompt should also contain constraint."""
+        wf = _make_workflow(
+            current_phase="planning",
+            status="planning",
+            current_round=1,
+            dev_round=1,
+        )
+        orch, mock_repo = _make_orchestrator(wf)
+        orch._runner.run_agent_task.return_value = _make_agent_result(text="# Refined Plan\nStep 1")
+
+        # Return existing plan + review for round 2+ (round_num=2)
+        mock_repo.list_milestones.return_value = [
+            {
+                "milestone_type": "plan_created",
+                "plan_content": "Original plan",
+                "round_number": 1,
+            },
+            {
+                "milestone_type": "plan_reviewed",
+                "review_content": "Fix the architecture",
+                "round_number": 1,
+            },
+        ]
+
+        orch._do_planning(wf)
+
+        # First call is the refine-plan agent
+        calls = orch._runner.run_agent_task.call_args_list
+        plan_prompt = calls[0].kwargs.get("prompt") or calls[0][1].get("prompt")
+        assert plan_prompt is not None
+        assert "不要输出完整的代码实现" in plan_prompt
+
+
+class TestFinalPlanAnnotation:
+    """Verify Final Plan includes unaddressed review feedback."""
+
+    def _get_last_comment(self, mock_gh):
+        """Get the last add_issue_comment call's comment text."""
+        assert mock_gh.add_issue_comment.called
+        return mock_gh.add_issue_comment.call_args_list[-1][0][1]
+
+    def test_final_plan_includes_last_review(self):
+        """When max_rounds reached, Final Plan should annotate last review."""
+        wf = _make_workflow(
+            current_phase="planning",
+            status="planning",
+            current_round=3,
+            dev_round=1,
+            max_plan_rounds=3,
+            github_issue_number=42,
+        )
+        orch, mock_repo = _make_orchestrator(wf)
+        orch._runner.run_agent_task.return_value = _make_agent_result(
+            text="# Refined Plan\nStep 1\nStep 2"
+        )
+
+        # Simulate milestones with plan + review from last round
+        mock_repo.list_milestones.return_value = [
+            {
+                "milestone_type": "plan_created",
+                "plan_content": "Build feature X with approach Y",
+                "round_number": 1,
+            },
+            {
+                "milestone_type": "plan_reviewed",
+                "review_content": "Consider error handling for edge cases",
+                "round_number": 1,
+            },
+            {
+                "milestone_type": "plan_refined",
+                "plan_content": "Build feature X with approach Y (refined)",
+                "round_number": 2,
+            },
+            {
+                "milestone_type": "plan_reviewed",
+                "review_content": "Fix data race condition in step 3",
+                "round_number": 2,
+            },
+            {
+                "milestone_type": "plan_refined",
+                "plan_content": "Final refined plan content",
+                "round_number": 3,
+            },
+            {
+                "milestone_type": "plan_reviewed",
+                "review_content": "Still need to handle timeout edge case",
+                "round_number": 3,
+            },
+        ]
+
+        orch._do_planning(wf)
+
+        # add_issue_comment is called 3 times: plan, review, final
+        # Check the last call (Final Plan)
+        comment = self._get_last_comment(orch._gh)
+        assert "Final Implementation Plan" in comment
+        assert "not yet addressed" in comment
+        assert "Still need to handle timeout edge case" in comment
+
+    def test_final_plan_without_review(self):
+        """When no review content exists, Final Plan is posted without annotation."""
+        wf = _make_workflow(
+            current_phase="planning",
+            status="planning",
+            current_round=3,
+            dev_round=1,
+            max_plan_rounds=3,
+            github_issue_number=42,
+        )
+        orch, mock_repo = _make_orchestrator(wf)
+        orch._runner.run_agent_task.return_value = _make_agent_result(text="# Refined Plan\nStep 1")
+
+        # Only plan, no reviews
+        mock_repo.list_milestones.return_value = [
+            {
+                "milestone_type": "plan_created",
+                "plan_content": "Build feature X",
+                "round_number": 1,
+            },
+        ]
+
+        orch._do_planning(wf)
+
+        comment = self._get_last_comment(orch._gh)
+        assert "Final Implementation Plan" in comment
+        # Should NOT contain review annotation
+        assert "not yet addressed" not in comment


### PR DESCRIPTION
## 概述

修复 Issue #733 中发现的 autonomous workflow 连锁故障。

## 根因链

1. PR #731 的 2 个 commit 丢失（Bug 3-7 修复不在 main 中）
2. `AUTONOMOUS_CONTEXT` 告诉 agent "仅输出方案，不要执行" → agent 不写代码 → 空 branch
3. `_do_development` 不验证 agent 是否真正写了代码
4. Planning prompt 无约束，agent 在 plan 阶段输出完整代码
5. `permission_mode` 未从 orchestrator 传递到 agent_runner
6. 当 `max_rounds` 达到上限时，最后一轮 review 的修复建议被直接忽略

## 修复内容

| 修复项 | 文件 | 说明 |
|--------|------|------|
| AUTONOMOUS_CONTEXT | `orchestrator.py` | 规则 3-4 从"不要执行"改为"直接执行" |
| permission_mode 传递 | `orchestrator.py` | 所有 7 处 `run_agent_task()` 添加 `permission_mode` 参数 |
| Commit 验证 | `orchestrator.py` | `_do_development` 中对比 agent 运行前后 commit SHA |
| Planning prompt 约束 | `orchestrator.py` | 禁止 plan agent 输出完整代码实现 |
| Final Plan 标注 | `orchestrator.py` | max_rounds 达到时附加最后一轮 review 的未处理意见 |
| 已有测试修复 | `test_orchestrator.py` | development 测试适配 commit 验证 + `created_at` → `createdAt` |
| 新增测试 | `test_orchestrator_733.py` | 13 个测试覆盖所有修复点 |

## 测试结果

- 232 passed（orchestrator 测试 + 新增测试全部通过）
- 5 failed（`test_github_ops.py` 既有问题，与本 PR 无关）

Closes #733

🤖 Generated with [Claude Code](https://claude.com/claude-code)