### PR TITLE
fix: auto-commit uncommitted changes when agent forgets to commit

### DIFF
--- a/app/modules/workspace/autonomous/github_ops.py
+++ b/app/modules/workspace/autonomous/github_ops.py
@@ -386,6 +386,11 @@ class GitHubOps:
 
     # ── Git Operations ──────────────────────────────────────────────
 
+    def has_uncommitted_changes(self) -> bool:
+        """Check if there are uncommitted changes (staged or unstaged)."""
+        result = self._run_git(["status", "--porcelain"])
+        return bool(result.stdout.strip())
+
     def git_add_all(self) -> None:
         """Stage all changes."""
         self._run_git(["add", "-A"])

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -597,23 +597,51 @@ class AutonomousOrchestrator:
 
         # Verify agent actually produced code changes
         if result.success and commit_before and commit_sha and commit_before == commit_sha:
-            logger.warning("Agent reported success but no new commits detected (SHA unchanged)")
-            self.repo.update_milestone(
-                ms.get("milestone_id", ""),
-                {
-                    "status": "failed",
-                    "session_id": result.session_id,
-                    "result_summary": result.response_text[:300] if result.response_text else "",
-                    "error_message": "Agent produced no code changes (commit SHA unchanged)",
-                },
-            )
-            self._update_workflow(
-                {
-                    "status": "failed",
-                    "error_message": "Development failed: agent produced no code changes",
-                }
-            )
-            return
+            # Commit SHA unchanged — check if agent left uncommitted changes
+            has_uncommitted = False
+            try:
+                has_uncommitted = gh.has_uncommitted_changes()
+            except Exception:
+                pass
+
+            if has_uncommitted:
+                # Agent modified files but didn't commit — auto-commit
+                logger.info("Agent left uncommitted changes, auto-committing")
+                try:
+                    gh.git_add_all()
+                    gh.git_commit(f"auto: development changes (round {dev_round})")
+                    commit_sha = gh.get_current_commit()
+                    # Re-calculate diff_stats now that auto-commit is done
+                    try:
+                        diff_stats = gh.get_diff_stats("HEAD~1", "HEAD")
+                    except Exception:
+                        pass
+                except Exception as e:
+                    logger.warning("Auto-commit failed: %s", e)
+                    # Fall through to failure path below
+                    has_uncommitted = False
+
+            if not has_uncommitted:
+                # Truly no changes or auto-commit failed
+                logger.warning("Agent reported success but no new commits detected (SHA unchanged)")
+                self.repo.update_milestone(
+                    ms.get("milestone_id", ""),
+                    {
+                        "status": "failed",
+                        "session_id": result.session_id,
+                        "result_summary": (
+                            result.response_text[:300] if result.response_text else ""
+                        ),
+                        "error_message": "Agent produced no code changes (commit SHA unchanged)",
+                    },
+                )
+                self._update_workflow(
+                    {
+                        "status": "failed",
+                        "error_message": "Development failed: agent produced no code changes",
+                    }
+                )
+                return
 
         self.repo.update_milestone(
             ms.get("milestone_id", ""),

--- a/tests/issues/733/test_orchestrator_733.py
+++ b/tests/issues/733/test_orchestrator_733.py
@@ -106,6 +106,9 @@ def _make_orchestrator(wf_data):
         }
         mock_gh.get_diff.return_value = "diff content"
         mock_gh.git_push.return_value = None
+        mock_gh.has_uncommitted_changes.return_value = False
+        mock_gh.git_add_all.return_value = None
+        mock_gh.git_commit.return_value = {"sha": "auto-sha", "message": "auto-commit"}
         mock_gh.create_pr.return_value = {"number": 99, "url": "https://github.com/pull/99"}
         mock_gh_cls.return_value = mock_gh
         orch._gh = mock_gh
@@ -223,7 +226,7 @@ class TestDevelopmentCommitVerification:
         ]
 
     def test_detects_no_code_changes(self):
-        """When commit SHA is unchanged after agent run, workflow should fail."""
+        """When commit SHA unchanged and no uncommitted files, workflow should fail."""
         wf = _make_workflow(
             current_phase="development",
             status="developing",
@@ -233,8 +236,10 @@ class TestDevelopmentCommitVerification:
         orch._runner.run_agent_task.return_value = _make_agent_result(
             success=True, text="I have completed the implementation"
         )
-        # Same commit before and after = no changes
+        # Same commit before and after = no new commits
         orch._gh.get_current_commit.return_value = "abc123"
+        # No uncommitted changes either
+        orch._gh.has_uncommitted_changes.return_value = False
 
         mock_repo.list_milestones.return_value = [
             {"milestone_type": "plan_created", "plan_content": "Build feature X"},
@@ -268,6 +273,63 @@ class TestDevelopmentCommitVerification:
 
         failed_updates = self._get_failed_updates(mock_repo)
         assert len(failed_updates) == 0
+
+    def test_auto_commits_uncommitted_changes(self):
+        """When commit SHA unchanged but files were modified, auto-commit and continue."""
+        wf = _make_workflow(
+            current_phase="development",
+            status="developing",
+            dev_round=1,
+        )
+        orch, mock_repo = _make_orchestrator(wf)
+        orch._runner.run_agent_task.return_value = _make_agent_result(
+            success=True, text="Implementation done"
+        )
+        # Same commit before and after agent runs, then changes after auto-commit
+        orch._gh.get_current_commit.side_effect = ["abc123", "abc123", "def456"]
+        orch._gh.has_uncommitted_changes.return_value = True
+
+        mock_repo.list_milestones.return_value = [
+            {"milestone_type": "plan_created", "plan_content": "Build feature X"},
+        ]
+
+        orch._do_development(wf)
+
+        # Should have auto-committed
+        orch._gh.git_add_all.assert_called_once()
+        orch._gh.git_commit.assert_called_once()
+        assert "auto: development changes" in orch._gh.git_commit.call_args[0][0]
+        # Should NOT have failed
+        failed_updates = self._get_failed_updates(mock_repo)
+        assert len(failed_updates) == 0
+
+    def test_auto_commit_failure_falls_back_to_fail(self):
+        """When auto-commit fails, workflow should still be marked as failed."""
+        wf = _make_workflow(
+            current_phase="development",
+            status="developing",
+            dev_round=1,
+        )
+        orch, mock_repo = _make_orchestrator(wf)
+        orch._runner.run_agent_task.return_value = _make_agent_result(
+            success=True, text="Implementation done"
+        )
+        orch._gh.get_current_commit.return_value = "abc123"
+        orch._gh.has_uncommitted_changes.return_value = True
+        orch._gh.git_commit.side_effect = Exception("pre-commit hook rejected")
+
+        mock_repo.list_milestones.return_value = [
+            {"milestone_type": "plan_created", "plan_content": "Build feature X"},
+        ]
+
+        orch._do_development(wf)
+
+        # Should have attempted auto-commit
+        orch._gh.git_commit.assert_called_once()
+        # Should have fallen back to failure
+        failed_updates = self._get_failed_updates(mock_repo)
+        assert len(failed_updates) >= 1
+        assert "no code changes" in failed_updates[-1][0][1]["error_message"].lower()
 
     def test_skip_check_when_commit_unavailable(self):
         """When commit SHA is empty, skip the verification gracefully."""


### PR DESCRIPTION
## 问题

Autonomous workflow 报错 `Development failed: agent produced no code changes`，但 `git status` 显示 agent 确实修改了文件。

## 根因

Commit 验证只对比 `get_current_commit()` 返回的 SHA（HEAD commit）。如果 agent 修改了文件但没有 commit，SHA 不变，被误判为"没有代码变更"。

## 修复

1. **`GitHubOps.has_uncommitted_changes()`** — 新增方法，通过 `git status --porcelain` 检查是否有未提交的变更
2. **验证逻辑改进** — SHA 不变时先检查是否有未提交变更：
   - 有 → 自动 `git add -A` + `git commit`，继续流程
   - 无 → 才判定为真正没有代码变更，标记失败

## 测试

- 新增 `test_auto_commits_uncommitted_changes` — 验证自动 commit 路径
- 更新 `test_detects_no_code_changes` — mock `has_uncommitted_changes` 返回 False
- 全部 64 个测试通过（50 + 14）

🤖 Generated with [Claude Code](https://claude.com/claude-code)