### PR TITLE
Add project status pages to website

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,11 @@ config.json
 
 # Node
 node_modules/
+website/.docusaurus/
+website/build/
+website/docs/reference/
+website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/
+website/static/img/
 
 # Release
 dist/

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -65,6 +65,7 @@ const config = {
         items: [
           {to: '/', label: 'Home', position: 'left'},
           {to: '/docs/intro', label: 'Docs', position: 'left'},
+          {to: '/project', label: 'Project', position: 'left'},
           {to: '/docs/reference/INTRO', label: 'Product Guide', position: 'left'},
           {to: '/docs/reference/REMOTE-AGENT', label: 'Remote Agent', position: 'left'},
           {
@@ -99,15 +100,15 @@ const config = {
             items: [
               {
                 label: 'Roadmap',
-                href: 'https://github.com/open-ace/open-ace/blob/main/ROADMAP.md',
+                to: '/project/roadmap',
               },
               {
-                label: 'Changelog',
-                href: 'https://github.com/open-ace/open-ace/blob/main/CHANGELOG.md',
+                label: 'Releases',
+                to: '/project/releases',
               },
               {
-                label: 'Security',
-                href: 'https://github.com/open-ace/open-ace/security/policy',
+                label: 'Community',
+                to: '/project/community',
               },
             ],
           },

--- a/website/package.json
+++ b/website/package.json
@@ -3,9 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "sync-docs": "node scripts/sync-docs.js",
-    "start": "npm run sync-docs && docusaurus start --host 0.0.0.0",
-    "build": "npm run sync-docs && docusaurus build",
+    "prepare-content": "node scripts/sync-docs.js && node scripts/generate-project-data.js",
+    "start": "npm run prepare-content && docusaurus start --host 0.0.0.0",
+    "build": "npm run prepare-content && docusaurus build",
     "serve": "docusaurus serve",
     "clear": "docusaurus clear"
   },

--- a/website/scripts/generate-project-data.js
+++ b/website/scripts/generate-project-data.js
@@ -1,0 +1,251 @@
+const fs = require('fs');
+const path = require('path');
+const https = require('https');
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+const websiteRoot = path.resolve(__dirname, '..');
+const outputDir = path.join(websiteRoot, 'src', 'data', 'generated');
+const outputFile = path.join(outputDir, 'project-data.json');
+
+const repoMeta = {
+  owner: 'open-ace',
+  repo: 'open-ace',
+  url: 'https://github.com/open-ace/open-ace',
+  docsUrl: 'https://open-ace.github.io/open-ace/docs/intro',
+  discussionsUrl: 'https://github.com/open-ace/open-ace/discussions',
+  issuesUrl: 'https://github.com/open-ace/open-ace/issues',
+  pullsUrl: 'https://github.com/open-ace/open-ace/pulls',
+  releasesUrl: 'https://github.com/open-ace/open-ace/releases',
+  roadmapUrl: 'https://github.com/open-ace/open-ace/blob/main/ROADMAP.md',
+  changelogUrl: 'https://github.com/open-ace/open-ace/blob/main/CHANGELOG.md',
+  contributingUrl: 'https://github.com/open-ace/open-ace/blob/main/CONTRIBUTING.md',
+  codeOfConductUrl: 'https://github.com/open-ace/open-ace/blob/main/CODE_OF_CONDUCT.md',
+  securityUrl: 'https://github.com/open-ace/open-ace/security/policy',
+};
+
+function ensureDir(dirPath) {
+  fs.mkdirSync(dirPath, {recursive: true});
+}
+
+function readFile(relativePath) {
+  return fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
+}
+
+function slugify(value) {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+function parseRoadmap(markdown) {
+  const lines = markdown.split(/\r?\n/);
+  const sections = [];
+  let currentSection = null;
+
+  for (const line of lines) {
+    const headingMatch = line.match(/^##\s+(.+)$/);
+    if (headingMatch) {
+      currentSection = {
+        id: slugify(headingMatch[1]),
+        title: headingMatch[1],
+        items: [],
+      };
+      sections.push(currentSection);
+      continue;
+    }
+
+    const bulletMatch = line.match(/^- (.+)$/);
+    if (bulletMatch && currentSection) {
+      currentSection.items.push(bulletMatch[1].trim());
+    }
+  }
+
+  return sections;
+}
+
+function parseChangelog(markdown) {
+  const lines = markdown.split(/\r?\n/);
+  const releases = [];
+  let currentRelease = null;
+  let currentSection = null;
+
+  for (const line of lines) {
+    const releaseMatch = line.match(/^## \[(.+?)\](?: - (\d{4}-\d{2}-\d{2}))?$/);
+    if (releaseMatch) {
+      currentRelease = {
+        version: releaseMatch[1],
+        date: releaseMatch[2] || null,
+        sections: [],
+      };
+      releases.push(currentRelease);
+      currentSection = null;
+      continue;
+    }
+
+    const sectionMatch = line.match(/^###\s+(.+)$/);
+    if (sectionMatch && currentRelease) {
+      currentSection = {
+        title: sectionMatch[1],
+        items: [],
+      };
+      currentRelease.sections.push(currentSection);
+      continue;
+    }
+
+    const bulletMatch = line.match(/^- (.+)$/);
+    if (bulletMatch && currentSection) {
+      currentSection.items.push(bulletMatch[1].trim());
+    }
+  }
+
+  return releases;
+}
+
+function requestJson(url) {
+  const token = process.env.OPEN_ACE_GITHUB_TOKEN || process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+
+  return new Promise((resolve) => {
+    const request = https.get(
+      url,
+      {
+        headers: {
+          Accept: 'application/vnd.github+json',
+          'User-Agent': 'open-ace-website-build',
+          ...(token ? {Authorization: `Bearer ${token}`} : {}),
+        },
+        timeout: 8000,
+      },
+      (response) => {
+        let data = '';
+
+        response.on('data', (chunk) => {
+          data += chunk;
+        });
+
+        response.on('end', () => {
+          if (response.statusCode && response.statusCode >= 400) {
+            resolve(null);
+            return;
+          }
+
+          try {
+            resolve(JSON.parse(data));
+          } catch (_error) {
+            resolve(null);
+          }
+        });
+      }
+    );
+
+    request.on('error', () => resolve(null));
+    request.on('timeout', () => {
+      request.destroy();
+      resolve(null);
+    });
+  });
+}
+
+async function fetchGithubData() {
+  const {owner, repo} = repoMeta;
+  const base = `https://api.github.com/repos/${owner}/${repo}`;
+
+  const [repository, releases, openGoodFirstIssues, openPullRequests] = await Promise.all([
+    requestJson(base),
+    requestJson(`${base}/releases?per_page=5`),
+    requestJson(
+      `https://api.github.com/search/issues?q=${encodeURIComponent(
+        `repo:${owner}/${repo} is:issue is:open label:"good first issue"`
+      )}`
+    ),
+    requestJson(
+      `https://api.github.com/search/issues?q=${encodeURIComponent(`repo:${owner}/${repo} is:pr is:open`)}`
+    ),
+  ]);
+
+  return {
+    repository,
+    releases,
+    openGoodFirstIssues,
+    openPullRequests,
+  };
+}
+
+async function main() {
+  const roadmapSections = parseRoadmap(readFile('ROADMAP.md'));
+  const changelogReleases = parseChangelog(readFile('CHANGELOG.md'));
+  const githubData = await fetchGithubData();
+
+  const releaseEntries = changelogReleases
+    .filter((entry) => entry.version !== 'Unreleased')
+    .slice(0, 4);
+
+  const latestRelease = githubData.releases?.[0]
+    ? {
+        tagName: githubData.releases[0].tag_name,
+        name: githubData.releases[0].name || githubData.releases[0].tag_name,
+        publishedAt: githubData.releases[0].published_at,
+        url: githubData.releases[0].html_url,
+      }
+    : releaseEntries[0]
+      ? {
+          tagName: releaseEntries[0].version,
+          name: releaseEntries[0].version,
+          publishedAt: releaseEntries[0].date,
+          url: repoMeta.releasesUrl,
+        }
+      : null;
+
+  const output = {
+    generatedAt: new Date().toISOString(),
+    repository: {
+      ...repoMeta,
+      stars: githubData.repository?.stargazers_count ?? null,
+      forks: githubData.repository?.forks_count ?? null,
+      openIssues: githubData.repository?.open_issues_count ?? null,
+      watchers: githubData.repository?.subscribers_count ?? null,
+      defaultBranch: githubData.repository?.default_branch ?? 'main',
+      license: githubData.repository?.license?.spdx_id ?? 'Apache-2.0',
+    },
+    roadmap: {
+      sections: roadmapSections,
+    },
+    releases: {
+      latest: latestRelease,
+      entries: changelogReleases,
+      githubRecent:
+        githubData.releases?.map((release) => ({
+          tagName: release.tag_name,
+          name: release.name || release.tag_name,
+          publishedAt: release.published_at,
+          url: release.html_url,
+          draft: release.draft,
+          prerelease: release.prerelease,
+        })) ?? [],
+    },
+    community: {
+      contributingUrl: repoMeta.contributingUrl,
+      codeOfConductUrl: repoMeta.codeOfConductUrl,
+      securityUrl: repoMeta.securityUrl,
+      discussionsUrl: repoMeta.discussionsUrl,
+      issuesUrl: repoMeta.issuesUrl,
+      pullsUrl: repoMeta.pullsUrl,
+      goodFirstIssueCount: githubData.openGoodFirstIssues?.total_count ?? null,
+      openPullRequestCount: githubData.openPullRequests?.total_count ?? null,
+      starterFocus: [
+        'First-run setup and deployment fixes',
+        'Docs parity between Chinese and English',
+        'Remote Agent hardening and observability',
+        'Governance dashboards and connector examples',
+      ],
+    },
+  };
+
+  ensureDir(outputDir);
+  fs.writeFileSync(outputFile, `${JSON.stringify(output, null, 2)}\n`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/website/src/components/project/ProjectLayout.js
+++ b/website/src/components/project/ProjectLayout.js
@@ -1,0 +1,131 @@
+import React from 'react';
+import Layout from '@theme/Layout';
+import Link from '@docusaurus/Link';
+import Translate from '@docusaurus/Translate';
+import projectData from '../../data/generated/project-data.json';
+import styles from './project.module.css';
+
+export function formatNumber(value) {
+  if (typeof value !== 'number') {
+    return 'Live in GitHub';
+  }
+
+  return new Intl.NumberFormat('en-US').format(value);
+}
+
+export function formatDate(value) {
+  if (!value) {
+    return 'In progress';
+  }
+
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return value;
+  }
+
+  return parsed.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+export function ProjectChrome({
+  title,
+  description,
+  eyebrow,
+  active,
+  children,
+}) {
+  const navItems = [
+    {
+      key: 'overview',
+      to: '/project',
+      eyebrow: 'Project',
+      title: 'Overview and metrics',
+      active: active === 'overview',
+    },
+    {
+      key: 'roadmap',
+      to: '/project/roadmap',
+      eyebrow: 'Roadmap',
+      title: 'Now, next, and success signals',
+      active: active === 'roadmap',
+    },
+    {
+      key: 'releases',
+      to: '/project/releases',
+      eyebrow: 'Releases',
+      title: 'Latest release and changelog view',
+      active: active === 'releases',
+    },
+    {
+      key: 'community',
+      to: '/project/community',
+      eyebrow: 'Community',
+      title: 'Contribution entry points and governance',
+      active: active === 'community',
+    },
+  ];
+
+  const heroMetrics = [
+    {
+      label: 'Latest release',
+      value: projectData.releases.latest?.tagName || 'Unreleased',
+    },
+    {
+      label: 'Roadmap lanes',
+      value: `${projectData.roadmap.sections.length} tracked sections`,
+    },
+    {
+      label: 'Project links',
+      value: 'Docs, issues, PRs, discussions, security',
+    },
+  ];
+
+  return (
+    <Layout title={title} description={description}>
+      <main className={styles.page}>
+        <section className={styles.hero}>
+          <p className={styles.eyebrow}>{eyebrow}</p>
+          <div className={styles.heroGrid}>
+            <div className={styles.heroCopy}>
+              <h1>{title}</h1>
+              <p>{description}</p>
+            </div>
+            <aside className={styles.heroPanel}>
+              <p className={styles.heroPanelTitle}>
+                <Translate id="project.hero.panelTitle">Build-time generated project view</Translate>
+              </p>
+              {heroMetrics.map((metric) => (
+                <div key={metric.label} className={styles.heroMetric}>
+                  <span>{metric.label}</span>
+                  <strong>{metric.value}</strong>
+                </div>
+              ))}
+            </aside>
+          </div>
+        </section>
+
+        <div className={styles.body}>
+          <div className={styles.navGrid}>
+            {navItems.map((item) => (
+              <Link
+                key={item.key}
+                className={styles.navCard}
+                style={item.active ? {borderColor: 'rgba(181, 107, 46, 0.34)'} : undefined}
+                to={item.to}
+              >
+                <span>{item.eyebrow}</span>
+                <strong>{item.title}</strong>
+              </Link>
+            ))}
+          </div>
+          {children}
+        </div>
+      </main>
+    </Layout>
+  );
+}
+
+export {projectData, styles};

--- a/website/src/components/project/project.module.css
+++ b/website/src/components/project/project.module.css
@@ -1,0 +1,320 @@
+.page {
+  min-height: 100%;
+  background:
+    radial-gradient(circle at top left, rgba(240, 186, 121, 0.14), transparent 24%),
+    linear-gradient(180deg, #f4efe2 0%, #f8f5ee 28%, #f3ede0 100%);
+}
+
+.hero {
+  width: min(1160px, calc(100% - 2rem));
+  margin: 0 auto;
+  padding: 4.8rem 0 2.2rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.9rem;
+  font-size: 0.82rem;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: #b56b2e;
+}
+
+.heroGrid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(280px, 0.85fr);
+  gap: 1.25rem;
+  align-items: start;
+}
+
+.heroCopy h1 {
+  margin: 0;
+  max-width: 11ch;
+  font-size: clamp(2.7rem, 5.6vw, 4.8rem);
+  line-height: 0.96;
+  letter-spacing: -0.06em;
+  color: #18262b;
+}
+
+.heroCopy p {
+  max-width: 42rem;
+  margin: 1.2rem 0 0;
+  font-size: 1.05rem;
+  line-height: 1.8;
+  color: #4c5a63;
+}
+
+.heroPanel {
+  display: grid;
+  gap: 0.8rem;
+  padding: 1.2rem;
+  border: 1px solid rgba(24, 38, 43, 0.1);
+  border-radius: 1.35rem;
+  background: rgba(255, 255, 255, 0.78);
+  box-shadow: 0 18px 42px rgba(17, 33, 44, 0.08);
+}
+
+.heroPanelTitle {
+  margin: 0;
+  font-size: 0.82rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: #8b633d;
+}
+
+.heroMetric {
+  display: grid;
+  gap: 0.25rem;
+  padding-top: 0.9rem;
+  border-top: 1px solid rgba(24, 38, 43, 0.08);
+}
+
+.heroMetric span {
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: #7f8d95;
+}
+
+.heroMetric strong {
+  font-size: 1.12rem;
+  line-height: 1.35;
+  color: #18262b;
+}
+
+.body {
+  width: min(1160px, calc(100% - 2rem));
+  margin: 0 auto;
+  padding: 0 0 4.8rem;
+}
+
+.navGrid,
+.cardGrid,
+.timelineGrid,
+.linkGrid {
+  display: grid;
+  gap: 1rem;
+}
+
+.navGrid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin-bottom: 2rem;
+}
+
+.navCard,
+.metricCard,
+.sectionCard,
+.releaseCard,
+.linkCard,
+.communityCard {
+  border: 1px solid rgba(24, 38, 43, 0.1);
+  border-radius: 1.3rem;
+  background: rgba(255, 255, 255, 0.8);
+  box-shadow: 0 16px 36px rgba(17, 33, 44, 0.08);
+}
+
+.navCard,
+.linkCard {
+  display: grid;
+  gap: 0.35rem;
+  padding: 1.2rem;
+  color: inherit;
+  text-decoration: none;
+  transition:
+    transform 180ms ease,
+    box-shadow 180ms ease,
+    border-color 180ms ease;
+}
+
+.navCard:hover,
+.linkCard:hover {
+  transform: translateY(-3px);
+  border-color: rgba(181, 107, 46, 0.28);
+  box-shadow: 0 22px 48px rgba(181, 107, 46, 0.14);
+  text-decoration: none;
+}
+
+.navCard span,
+.linkCard span {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: #8b633d;
+}
+
+.navCard strong,
+.linkCard strong {
+  font-size: 1.03rem;
+  color: #18262b;
+}
+
+.section {
+  margin-top: 2.6rem;
+}
+
+.sectionHeader {
+  max-width: 42rem;
+  margin-bottom: 1.3rem;
+}
+
+.sectionHeader h2 {
+  margin: 0;
+  font-size: clamp(1.9rem, 4vw, 2.8rem);
+  line-height: 1.02;
+  letter-spacing: -0.05em;
+  color: #18262b;
+}
+
+.sectionHeader p {
+  margin: 0.75rem 0 0;
+  line-height: 1.75;
+  color: #4c5a63;
+}
+
+.cardGrid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.metricCard,
+.sectionCard,
+.releaseCard,
+.communityCard {
+  padding: 1.25rem;
+}
+
+.metricLabel {
+  margin: 0;
+  font-size: 0.78rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: #8b633d;
+}
+
+.metricValue {
+  margin: 0.55rem 0 0;
+  font-size: clamp(1.7rem, 3vw, 2.3rem);
+  line-height: 1;
+  color: #18262b;
+}
+
+.metricHint {
+  margin: 0.7rem 0 0;
+  color: #55636b;
+  line-height: 1.65;
+}
+
+.sectionCard h3,
+.releaseCard h3,
+.communityCard h3 {
+  margin: 0 0 0.8rem;
+  font-size: 1.1rem;
+  color: #18262b;
+}
+
+.bulletList,
+.linkList,
+.metaList {
+  display: grid;
+  gap: 0.8rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.bulletList li,
+.metaList li {
+  position: relative;
+  padding-left: 1rem;
+  line-height: 1.7;
+  color: #4f5d65;
+}
+
+.bulletList li::before,
+.metaList li::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0.72rem;
+  width: 0.38rem;
+  height: 0.38rem;
+  border-radius: 999px;
+  background: #c7864a;
+}
+
+.timelineGrid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.releaseVersion {
+  margin: 0;
+  font-size: 0.82rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: #8b633d;
+}
+
+.releaseDate {
+  margin: 0.4rem 0 0.9rem;
+  color: #6e7b83;
+}
+
+.sectionTag {
+  display: inline-flex;
+  margin: 0 0 0.65rem;
+  padding: 0.28rem 0.55rem;
+  border-radius: 999px;
+  background: rgba(181, 107, 46, 0.12);
+  color: #8b633d;
+  font-size: 0.76rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.metaGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.metaBlock {
+  padding: 1rem;
+  border-radius: 1rem;
+  background: rgba(24, 38, 43, 0.04);
+}
+
+.metaBlock h3 {
+  margin: 0 0 0.8rem;
+  font-size: 0.98rem;
+}
+
+.linkGrid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.linkList a {
+  color: #1f5260;
+  text-decoration: none;
+}
+
+.linkList a:hover {
+  text-decoration: underline;
+}
+
+.stack {
+  display: grid;
+  gap: 1rem;
+}
+
+@media (max-width: 996px) {
+  .heroGrid,
+  .navGrid,
+  .cardGrid,
+  .timelineGrid,
+  .metaGrid,
+  .linkGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .heroCopy h1 {
+    max-width: none;
+  }
+}

--- a/website/src/data/generated/project-data.json
+++ b/website/src/data/generated/project-data.json
@@ -1,0 +1,149 @@
+{
+  "generatedAt": "2026-06-06T10:09:13.017Z",
+  "repository": {
+    "owner": "open-ace",
+    "repo": "open-ace",
+    "url": "https://github.com/open-ace/open-ace",
+    "docsUrl": "https://open-ace.github.io/open-ace/docs/intro",
+    "discussionsUrl": "https://github.com/open-ace/open-ace/discussions",
+    "issuesUrl": "https://github.com/open-ace/open-ace/issues",
+    "pullsUrl": "https://github.com/open-ace/open-ace/pulls",
+    "releasesUrl": "https://github.com/open-ace/open-ace/releases",
+    "roadmapUrl": "https://github.com/open-ace/open-ace/blob/main/ROADMAP.md",
+    "changelogUrl": "https://github.com/open-ace/open-ace/blob/main/CHANGELOG.md",
+    "contributingUrl": "https://github.com/open-ace/open-ace/blob/main/CONTRIBUTING.md",
+    "codeOfConductUrl": "https://github.com/open-ace/open-ace/blob/main/CODE_OF_CONDUCT.md",
+    "securityUrl": "https://github.com/open-ace/open-ace/security/policy",
+    "stars": 4,
+    "forks": 2,
+    "openIssues": 58,
+    "watchers": 0,
+    "defaultBranch": "main",
+    "license": "Apache-2.0"
+  },
+  "roadmap": {
+    "sections": [
+      {
+        "id": "now",
+        "title": "Now",
+        "items": [
+          "Make the first-run experience reliable with Docker Compose, SQLite/PostgreSQL setup, and clear default credential handling.",
+          "Keep README, website, and documentation links in sync across Chinese and English.",
+          "Publish focused starter issues for documentation, first-run bugs, UI polish, and connector examples.",
+          "Add GitHub repository topics: `ai-governance`, `ai-workspace`, `enterprise-ai`, `llmops`, `flask`, `react`, `self-hosted`, `claude-code`, `qwen-code`, `codex`."
+        ]
+      },
+      {
+        "id": "next",
+        "title": "Next",
+        "items": [
+          "Publish GitHub releases with changelog notes, Docker image tags, and upgrade instructions.",
+          "Add a safe public demo path that does not expose shared admin credentials.",
+          "Improve production deployment docs for TLS, secrets, backups, SSO, and Kubernetes.",
+          "Add example dashboards and sample datasets so evaluators can understand the product before connecting real logs."
+        ]
+      },
+      {
+        "id": "later",
+        "title": "Later",
+        "items": [
+          "Create connector guides for additional AI tools and model gateways.",
+          "Add richer audit reports for security, compliance, and cost allocation.",
+          "Provide Helm chart packaging and versioned migration playbooks.",
+          "Publish user stories and screenshots from real adoption scenarios."
+        ]
+      },
+      {
+        "id": "success-signals",
+        "title": "Success Signals",
+        "items": [
+          "New users can run Open ACE locally in under 10 minutes.",
+          "The project has tagged releases, working docs links, and a visible maintainer workflow.",
+          "External contributors can find good first issues and understand what kind of help is wanted.",
+          "Teams can evaluate Open ACE without sharing production data or credentials."
+        ]
+      }
+    ]
+  },
+  "releases": {
+    "latest": {
+      "tagName": "v1.0.0",
+      "name": "Open ACE v1.0.0",
+      "publishedAt": "2026-06-02T11:06:01Z",
+      "url": "https://github.com/open-ace/open-ace/releases/tag/v1.0.0"
+    },
+    "entries": [
+      {
+        "version": "Unreleased",
+        "date": null,
+        "sections": []
+      },
+      {
+        "version": "1.0.0",
+        "date": "2026-06-02",
+        "sections": [
+          {
+            "title": "Added",
+            "items": [
+              "**Self-hosted AI workspace**: Work Mode for AI sessions, prompt reuse, conversation history, and project context.",
+              "**Remote Workspace and Remote Agent**: Run AI CLIs on development, staging, or GPU machines through a browser-managed remote agent.",
+              "**Multi-CLI support**: Claude Code, Qwen Code, Codex, and OpenClaw adapters with session recovery, permission modes, and history sync.",
+              "**API Key proxy**: Encrypt LLM API keys on the server and issue short-lived proxy tokens to local and remote sessions.",
+              "**Browser development loop**: Remote terminal, directory browsing, and VSCode/code-server proxy support.",
+              "**AI governance dashboards**: Token usage, cost analysis, quotas, alerts, anomaly detection, audit trails, and ROI visibility.",
+              "**Compliance reporting**: Governance reports with JSON/CSV export paths and practical risk recommendations.",
+              "**Enterprise administration**: Multi-tenant access control, roles, SSO-ready permission model, and Feishu/DingTalk integration paths.",
+              "**Deployment options**: Docker Compose quick start, production deployment docs, Kubernetes reference, and reverse proxy guidance.",
+              "**Open source readiness**: Apache 2.0 license, contributing guide, code of conduct, security policy, public roadmap, issue templates, CODEOWNERS, Dependabot, and beginner-friendly issue labels.",
+              "**Bilingual documentation**: Chinese and English docs for architecture, deployment, development, API usage, integrations, Remote Workspace, Remote Agent, Kubernetes, and repository setup."
+            ]
+          },
+          {
+            "title": "Architecture",
+            "items": [
+              "Flask backend with SQLAlchemy repositories and Alembic migrations.",
+              "React 18, TypeScript, Vite, Bootstrap 5, and Chart.js frontend.",
+              "PostgreSQL and SQLite support for development and deployment workflows.",
+              "Remote agent package with CLI adapters, WebSocket terminal support, and session synchronization."
+            ]
+          },
+          {
+            "title": "Deployment",
+            "items": [
+              "Docker Compose quick start with PostgreSQL.",
+              "Source installation path for local development.",
+              "Kubernetes deployment reference.",
+              "Linux systemd and macOS launchd support for remote agents."
+            ]
+          }
+        ]
+      }
+    ],
+    "githubRecent": [
+      {
+        "tagName": "v1.0.0",
+        "name": "Open ACE v1.0.0",
+        "publishedAt": "2026-06-02T11:06:01Z",
+        "url": "https://github.com/open-ace/open-ace/releases/tag/v1.0.0",
+        "draft": false,
+        "prerelease": false
+      }
+    ]
+  },
+  "community": {
+    "contributingUrl": "https://github.com/open-ace/open-ace/blob/main/CONTRIBUTING.md",
+    "codeOfConductUrl": "https://github.com/open-ace/open-ace/blob/main/CODE_OF_CONDUCT.md",
+    "securityUrl": "https://github.com/open-ace/open-ace/security/policy",
+    "discussionsUrl": "https://github.com/open-ace/open-ace/discussions",
+    "issuesUrl": "https://github.com/open-ace/open-ace/issues",
+    "pullsUrl": "https://github.com/open-ace/open-ace/pulls",
+    "goodFirstIssueCount": 3,
+    "openPullRequestCount": 0,
+    "starterFocus": [
+      "First-run setup and deployment fixes",
+      "Docs parity between Chinese and English",
+      "Remote Agent hardening and observability",
+      "Governance dashboards and connector examples"
+    ]
+  }
+}

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -150,6 +150,10 @@ export default function Home() {
               <span>Remote Agent</span>
               <strong>Learn how CLI agents are executed on controlled remote machines</strong>
             </Link>
+            <Link className={styles.linkCard} to="/project">
+              <span>Project Status</span>
+              <strong>View roadmap, release history, and contribution entry points from the site</strong>
+            </Link>
           </div>
         </section>
       </main>

--- a/website/src/pages/project/community.js
+++ b/website/src/pages/project/community.js
@@ -1,0 +1,106 @@
+import React from 'react';
+import Link from '@docusaurus/Link';
+import {ProjectChrome, formatNumber, projectData, styles} from '../../components/project/ProjectLayout';
+
+export default function CommunityPage() {
+  const linkGroups = [
+    {
+      title: 'Contribute',
+      links: [
+        ['Contributing guide', projectData.community.contributingUrl],
+        ['Good first issues', `${projectData.repository.issuesUrl}?q=is%3Aissue%20state%3Aopen%20label%3A%22good%20first%20issue%22`],
+        ['Open pull requests', projectData.community.pullsUrl],
+      ],
+    },
+    {
+      title: 'Discuss',
+      links: [
+        ['GitHub Discussions', projectData.community.discussionsUrl],
+        ['Issue tracker', projectData.community.issuesUrl],
+        ['Project docs', projectData.repository.docsUrl],
+      ],
+    },
+    {
+      title: 'Governance',
+      links: [
+        ['Security policy', projectData.community.securityUrl],
+        ['Code of conduct', projectData.community.codeOfConductUrl],
+        ['Repository home', projectData.repository.url],
+      ],
+    },
+  ];
+
+  return (
+    <ProjectChrome
+      title="Clear entry points for contributors and evaluators."
+      description="Community pages should do more than dump repository links. This surface explains where to start, what kinds of help are wanted, and which governance documents matter before contributing or deploying."
+      eyebrow="Community"
+      active="community"
+    >
+      <section className={styles.section}>
+        <div className={styles.sectionHeader}>
+          <h2>Contribution snapshot</h2>
+          <p>
+            These counters are fetched during the site build when GitHub API access is available. They stay
+            optional so local and CI builds remain reliable even without network metadata.
+          </p>
+        </div>
+        <div className={styles.cardGrid}>
+          <article className={styles.metricCard}>
+            <p className={styles.metricLabel}>Good first issues</p>
+            <p className={styles.metricValue}>{formatNumber(projectData.community.goodFirstIssueCount)}</p>
+            <p className={styles.metricHint}>Starter issues that help new contributors find bounded work quickly.</p>
+          </article>
+          <article className={styles.metricCard}>
+            <p className={styles.metricLabel}>Open pull requests</p>
+            <p className={styles.metricValue}>{formatNumber(projectData.community.openPullRequestCount)}</p>
+            <p className={styles.metricHint}>Current review load visible to contributors and maintainers.</p>
+          </article>
+          <article className={styles.metricCard}>
+            <p className={styles.metricLabel}>Starter focus</p>
+            <p className={styles.metricValue}>{projectData.community.starterFocus.length}</p>
+            <p className={styles.metricHint}>Contribution themes maintained as part of the generated project data.</p>
+          </article>
+        </div>
+      </section>
+
+      <section className={styles.section}>
+        <div className={styles.sectionHeader}>
+          <h2>Where help is most useful</h2>
+          <p>
+            These focus areas come from the generated project data file and are meant to keep public
+            contribution expectations visible from the documentation site.
+          </p>
+        </div>
+        <article className={styles.communityCard}>
+          <ul className={styles.bulletList}>
+            {projectData.community.starterFocus.map((item) => (
+              <li key={item}>{item}</li>
+            ))}
+          </ul>
+        </article>
+      </section>
+
+      <section className={styles.section}>
+        <div className={styles.sectionHeader}>
+          <h2>Primary project links</h2>
+          <p>Keep the contribution, discussion, and governance paths visible without making users search the repo sidebar.</p>
+        </div>
+        <div className={styles.metaGrid}>
+          {linkGroups.map((group) => (
+            <article key={group.title} className={styles.metaBlock}>
+              <h3>{group.title}</h3>
+              <ul className={styles.linkList}>
+                {group.links.map(([label, href]) => (
+                  <li key={label}>
+                    <Link to={href}>{label}</Link>
+                  </li>
+                ))}
+              </ul>
+            </article>
+          ))}
+        </div>
+      </section>
+    </ProjectChrome>
+  );
+}

--- a/website/src/pages/project/index.js
+++ b/website/src/pages/project/index.js
@@ -1,0 +1,116 @@
+import React from 'react';
+import Link from '@docusaurus/Link';
+import Translate from '@docusaurus/Translate';
+import {ProjectChrome, formatNumber, projectData, styles} from '../../components/project/ProjectLayout';
+
+export default function ProjectOverviewPage() {
+  const metrics = [
+    {
+      label: 'Stars',
+      value: formatNumber(projectData.repository.stars),
+      hint: 'Public adoption signal pulled from repository metadata when available.',
+    },
+    {
+      label: 'Open issues',
+      value: formatNumber(projectData.repository.openIssues),
+      hint: 'Current backlog volume for public product and engineering work.',
+    },
+    {
+      label: 'Good first issues',
+      value: formatNumber(projectData.community.goodFirstIssueCount),
+      hint: 'Visible starter work for new external contributors.',
+    },
+  ];
+
+  return (
+    <ProjectChrome
+      title="Project visibility without leaving the docs site."
+      description="This section turns repository state, roadmap planning, changelog history, and community entry points into a single public surface. The content is generated during the site build, so the docs site stays synchronized with the repository instead of hand-maintained screenshots."
+      eyebrow="Project"
+      active="overview"
+    >
+      <section className={styles.section}>
+        <div className={styles.sectionHeader}>
+          <h2>Live repository signals</h2>
+          <p>
+            The site reads repository metadata at build time when GitHub API access is available, then
+            falls back to committed project files so Pages builds remain deterministic.
+          </p>
+        </div>
+        <div className={styles.cardGrid}>
+          {metrics.map((metric) => (
+            <article key={metric.label} className={styles.metricCard}>
+              <p className={styles.metricLabel}>{metric.label}</p>
+              <p className={styles.metricValue}>{metric.value}</p>
+              <p className={styles.metricHint}>{metric.hint}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className={styles.section}>
+        <div className={styles.sectionHeader}>
+          <h2>What this phase adds</h2>
+          <p>
+            Phase 1 established the product homepage and bilingual docs shell. This phase adds project
+            transparency pages so visitors can inspect momentum, release maturity, and contribution paths
+            from the same domain.
+          </p>
+        </div>
+        <div className={styles.cardGrid}>
+          <article className={styles.sectionCard}>
+            <h3>Roadmap page</h3>
+            <ul className={styles.bulletList}>
+              <li>Structured rendering of roadmap lanes from the repository source file</li>
+              <li>Clear separation between current work, upcoming work, and success criteria</li>
+              <li>Internal links from the landing site instead of raw GitHub Markdown links</li>
+            </ul>
+          </article>
+          <article className={styles.sectionCard}>
+            <h3>Release page</h3>
+            <ul className={styles.bulletList}>
+              <li>Latest release summary plus changelog sections extracted during build</li>
+              <li>Fallback to committed changelog data when live release API data is unavailable</li>
+              <li>Better signal for evaluators deciding whether the project is actively maintained</li>
+            </ul>
+          </article>
+          <article className={styles.sectionCard}>
+            <h3>Community page</h3>
+            <ul className={styles.bulletList}>
+              <li>Contribution, security, issues, PRs, and discussions in one place</li>
+              <li>Starter focus areas for new contributors</li>
+              <li>Build-time counters for open PRs and good-first-issue inventory when possible</li>
+            </ul>
+          </article>
+        </div>
+      </section>
+
+      <section className={styles.section}>
+        <div className={styles.sectionHeader}>
+          <h2>Where to go next</h2>
+          <p>Use these pages as the default project surface for roadmap, release, and contribution status.</p>
+        </div>
+        <div className={styles.linkGrid}>
+          <Link className={styles.linkCard} to="/project/roadmap">
+            <span>Roadmap</span>
+            <strong>Read current priorities, next-stage work, and success signals.</strong>
+          </Link>
+          <Link className={styles.linkCard} to="/project/releases">
+            <span>Releases</span>
+            <strong>Inspect shipped capabilities, latest release metadata, and changelog structure.</strong>
+          </Link>
+          <Link className={styles.linkCard} to="/project/community">
+            <span>Community</span>
+            <strong>Find contribution links, public issue paths, and security reporting entry points.</strong>
+          </Link>
+          <Link className={styles.linkCard} to={projectData.repository.issuesUrl}>
+            <span>
+              <Translate id="project.overview.issueLinkLabel">GitHub issues</Translate>
+            </span>
+            <strong>Jump into the live backlog when you need the canonical queue.</strong>
+          </Link>
+        </div>
+      </section>
+    </ProjectChrome>
+  );
+}

--- a/website/src/pages/project/releases.js
+++ b/website/src/pages/project/releases.js
@@ -1,0 +1,66 @@
+import React from 'react';
+import Link from '@docusaurus/Link';
+import {ProjectChrome, formatDate, projectData, styles} from '../../components/project/ProjectLayout';
+
+export default function ReleasesPage() {
+  const releasedEntries = projectData.releases.entries.filter((entry) => entry.version !== 'Unreleased');
+
+  return (
+    <ProjectChrome
+      title="Release history that reads like product progress."
+      description="This page combines committed changelog data with live release metadata when the GitHub API is available during the build. It gives evaluators one place to inspect shipping cadence and scope."
+      eyebrow="Releases"
+      active="releases"
+    >
+      <section className={styles.section}>
+        <div className={styles.sectionHeader}>
+          <h2>Latest published release</h2>
+          <p>
+            The hero release card is sourced from GitHub releases when available and falls back to the
+            committed changelog if the API cannot be reached during the build.
+          </p>
+        </div>
+        <article className={styles.releaseCard}>
+          <p className={styles.releaseVersion}>{projectData.releases.latest?.tagName || 'Unreleased'}</p>
+          <h3>{projectData.releases.latest?.name || 'Pending first tagged release'}</h3>
+          <p className={styles.releaseDate}>
+            {projectData.releases.latest?.publishedAt
+              ? `Published ${formatDate(projectData.releases.latest.publishedAt)}`
+              : 'No published release metadata available yet'}
+          </p>
+          <Link className="button button--primary" to={projectData.releases.latest?.url || projectData.repository.releasesUrl}>
+            View release on GitHub
+          </Link>
+        </article>
+      </section>
+
+      <section className={styles.section}>
+        <div className={styles.sectionHeader}>
+          <h2>Changelog highlights</h2>
+          <p>
+            The content below is parsed from <code>CHANGELOG.md</code>. Each release section stays close to
+            the repository source while becoming easier to scan on the public site.
+          </p>
+        </div>
+        <div className={styles.timelineGrid}>
+          {releasedEntries.map((entry) => (
+            <article key={`${entry.version}-${entry.date}`} className={styles.releaseCard}>
+              <p className={styles.releaseVersion}>v{entry.version}</p>
+              <p className={styles.releaseDate}>{formatDate(entry.date)}</p>
+              {entry.sections.map((section) => (
+                <div key={section.title}>
+                  <p className={styles.sectionTag}>{section.title}</p>
+                  <ul className={styles.bulletList}>
+                    {section.items.slice(0, 5).map((item) => (
+                      <li key={item}>{item}</li>
+                    ))}
+                  </ul>
+                </div>
+              ))}
+            </article>
+          ))}
+        </div>
+      </section>
+    </ProjectChrome>
+  );
+}

--- a/website/src/pages/project/roadmap.js
+++ b/website/src/pages/project/roadmap.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import {ProjectChrome, projectData, styles} from '../../components/project/ProjectLayout';
+
+export default function RoadmapPage() {
+  return (
+    <ProjectChrome
+      title="A practical roadmap, not a vague wishlist."
+      description="This view is generated from the repository roadmap file. It keeps the public roadmap inside the docs site while still preserving Git-based review and editing workflows for maintainers."
+      eyebrow="Roadmap"
+      active="roadmap"
+    >
+      <section className={styles.section}>
+        <div className={styles.sectionHeader}>
+          <h2>Tracked roadmap lanes</h2>
+          <p>
+            The source of truth remains <code>ROADMAP.md</code> in the repository. During each site build,
+            the content is parsed into stable sections that can be rendered with stronger visual structure.
+          </p>
+        </div>
+        <div className={styles.timelineGrid}>
+          {projectData.roadmap.sections.map((section) => (
+            <article key={section.id} className={styles.sectionCard}>
+              <h3>{section.title}</h3>
+              <ul className={styles.bulletList}>
+                {section.items.map((item) => (
+                  <li key={item}>{item}</li>
+                ))}
+              </ul>
+            </article>
+          ))}
+        </div>
+      </section>
+    </ProjectChrome>
+  );
+}


### PR DESCRIPTION
## Summary
- add build-time project data generation for roadmap, release, and community metadata
- add Project overview, roadmap, releases, and community pages to the Docusaurus site
- wire Project navigation into the navbar, footer, homepage, and clean up generated website artifacts via gitignore

## Verification
- npm ci --registry=https://registry.npmmirror.com --cache /tmp/open-ace-website-npm-cache --prefer-online --no-audit --no-fund
- npm run build in website/
