### PR TITLE
fix: remove unnecessary scrollbar in session detail dialog

### DIFF
--- a/frontend/src/components/common/Modal.tsx
+++ b/frontend/src/components/common/Modal.tsx
@@ -22,6 +22,7 @@ export const Modal: React.FC<ModalProps> = ({
   children,
   footer,
   className,
+  scrollable = true,
 }) => {
   const modalRef = useRef<HTMLDivElement>(null);
 
@@ -113,7 +114,8 @@ export const Modal: React.FC<ModalProps> = ({
       >
         <div
           className={cn(
-            'modal-dialog modal-dialog-centered modal-dialog-scrollable',
+            'modal-dialog modal-dialog-centered',
+            scrollable && 'modal-dialog-scrollable',
             sizeClasses[size],
             className
           )}

--- a/frontend/src/components/features/Sessions.tsx
+++ b/frontend/src/components/features/Sessions.tsx
@@ -474,6 +474,7 @@ export const Sessions: React.FC = () => {
           return sessionIdShort || (t('sessionDetails', language) ?? 'Session Details');
         })()}
         size="lg"
+        scrollable={false}
       >
         {isLoadingDetail ? (
           <Loading size="sm" text={t('loading', language)} />

--- a/frontend/src/components/work/SessionList.tsx
+++ b/frontend/src/components/work/SessionList.tsx
@@ -338,6 +338,7 @@ export const SessionList: React.FC<SessionListProps> = ({ collapsed = false, onS
           return sessionIdShort || 'Session';
         })()}
         size="lg"
+        scrollable={false}
       >
         {isLoadingDetail ? (
           <Loading size="sm" text={t('loading', language)} />

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -277,6 +277,7 @@ export interface ModalProps extends BaseComponentProps {
   size?: 'sm' | 'md' | 'lg' | 'xl';
   children: React.ReactNode;
   footer?: React.ReactNode;
+  scrollable?: boolean;
 }
 
 // Card types


### PR DESCRIPTION
## 问题

Session 详情对话框右侧总是出现一个不必要的滚动条。

**原因：** `Modal` 组件默认使用 Bootstrap 的 `modal-dialog-scrollable` 类，使 `.modal-body` 变成可滚动容器。同时 `SessionDetailContent` 内部已有自己的滚动区域（消息列表 400px、远程输出 300px），形成了双重滚动条。

## 改动

- 给 `Modal` 组件添加 `scrollable` 可选 prop（默认 `true`，向后兼容）
- Session 详情 Modal 传入 `scrollable={false}`，去掉外层滚动条
- 对话框高度改为自适应（内容少时更紧凑，内容多时内部滚动）

## 影响范围

- 仅影响 Session 详情对话框（Sessions 页面 + Work 模式左侧 SessionList）
- 其他使用 Modal 的地方不受影响（`scrollable` 默认 `true`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)