### PR TITLE
feat: distributed lock and remote machine admin validation (#740 batch 6)

### DIFF
--- a/app/auth/decorators.py
+++ b/app/auth/decorators.py
@@ -96,6 +96,27 @@ def _check_machine_admin(user_id: int, machine_id: str) -> bool:
         return False
 
 
+# ── Public API for cross-module use ──────────────────────────────────
+
+
+def validate_session_token(token: str) -> dict | None:
+    """Validate a session token and return the user dict, or None if invalid.
+
+    Public wrapper for _load_user_from_token — use this instead of
+    importing the private function directly.
+    """
+    return _load_user_from_token(token)
+
+
+def check_machine_admin_permission(user_id: int, machine_id: str) -> bool:
+    """Check if a user has admin permission on a remote machine.
+
+    Public wrapper for _check_machine_admin — use this instead of
+    importing the private function directly.
+    """
+    return _check_machine_admin(user_id, machine_id)
+
+
 def auth_required(f=None, *, ownership=None):
     """
     Decorator: require authentication, optionally with ownership check.

--- a/app/modules/workspace/autonomous/__init__.py
+++ b/app/modules/workspace/autonomous/__init__.py
@@ -66,7 +66,11 @@ def get_ddl_statements():
             created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
             updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
             completed_at TIMESTAMP,
-            paused_at TIMESTAMP
+            paused_at TIMESTAMP,
+            locked_at TIMESTAMP,
+            locked_by TEXT DEFAULT '',
+            retry_count INTEGER DEFAULT 0,
+            task_timeout INTEGER
         )
         """,
         """

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -10,6 +10,7 @@ pr_review -> report -> wait -> (loop or merge).
 import json
 import logging
 import re
+import threading
 import uuid
 from datetime import datetime, timezone
 from typing import Optional
@@ -65,6 +66,7 @@ class AutonomousOrchestrator:
         self.emitter = AutonomousEventEmitter.instance()
         self._workflow_id = workflow_id
         self._current_session_id: Optional[str] = None
+        self._session_lock = threading.Lock()
 
         # Wire session_manager so agent sessions are persisted to DB
         from app.modules.workspace.session_manager import SessionManager
@@ -128,7 +130,7 @@ class AutonomousOrchestrator:
                 # Add truncation note and stop
                 result_parts.append(
                     f"\n... [Truncated: {len(chunks)} files total, "
-                    f"showing {len(result_parts) + 1} with {per_file_lines} lines each]\n"
+                    f"showing {len(result_parts)} with {per_file_lines} lines each]\n"
                 )
                 break
             result_parts.append(part)
@@ -186,30 +188,50 @@ class AutonomousOrchestrator:
             },
         )
 
-    def _run_agent(self, **kwargs) -> AgentTaskResult:
-        """Run an agent task with session tracking for cancellation support."""
+    def _run_agent(self, wf: dict = None, **kwargs) -> AgentTaskResult:
+        """Run an agent task with session tracking for cancellation support.
+
+        Args:
+            wf: Optional pre-fetched workflow dict to avoid extra DB queries.
+                If not provided, falls back to self.workflow (DB query).
+        """
+        # Pre-generate session_id so cancel_current_task() can access it
+        # before run_agent_task() returns
+        if "session_id" not in kwargs:
+            kwargs["session_id"] = str(uuid.uuid4())
+        session_id = kwargs["session_id"]
+
+        with self._session_lock:
+            self._current_session_id = session_id
+
         # Inject per-workflow timeout if specified
         if "timeout" not in kwargs:
-            wf = self.workflow
-            task_timeout = (wf or {}).get("task_timeout")
+            workflow_data = wf or self.workflow
+            task_timeout = (workflow_data or {}).get("task_timeout")
             if task_timeout:
                 kwargs["timeout"] = int(task_timeout)
+
         result = self._runner.run_agent_task(**kwargs)
-        self._current_session_id = result.session_id
+
+        with self._session_lock:
+            self._current_session_id = result.session_id
         return result
 
     def cancel_current_task(self):
         """Cancel the currently running agent task (e.g. on pause/stop)."""
-        if self._current_session_id:
+        with self._session_lock:
+            session_id = self._current_session_id
+        if session_id:
             logger.info(
                 "Cancelling current agent task session=%s",
-                self._current_session_id[:8],
+                session_id[:8],
             )
             try:
-                self._runner.stop_session(self._current_session_id)
+                self._runner.stop_session(session_id)
             except Exception as e:
-                logger.warning("Failed to stop session %s: %s", self._current_session_id[:8], e)
-            self._current_session_id = None
+                logger.warning("Failed to stop session %s: %s", session_id[:8], e)
+            with self._session_lock:
+                self._current_session_id = None
 
     def advance(self):
         """Advance the workflow one step. Called by the scheduler."""

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -96,6 +96,46 @@ class AutonomousOrchestrator:
             }
         )
 
+    @staticmethod
+    def _smart_truncate_diff(
+        diff_text: str, max_chars: int = 32000, per_file_lines: int = 200
+    ) -> str:
+        """Smart diff truncation that preserves all file headers.
+
+        Keeps ``diff --git a/...`` lines intact and truncates each file's
+        content to *per_file_lines* lines.  If the total still exceeds
+        *max_chars* an explanatory note is appended.
+        """
+        if not diff_text or len(diff_text) <= max_chars:
+            return diff_text
+
+        import re
+
+        # Split into per-file chunks (each starts with a diff --git line)
+        chunks = re.split(r"(?=^diff --git )", diff_text, flags=re.MULTILINE)
+        result_parts: list[str] = []
+        total = 0
+
+        for chunk in chunks:
+            if not chunk:
+                continue
+            lines = chunk.split("\n")
+            header = lines[0] if lines else ""
+            body = "\n".join(lines[1 : per_file_lines + 1])
+
+            part = header + "\n" + body
+            if total + len(part) > max_chars:
+                # Add truncation note and stop
+                result_parts.append(
+                    f"\n... [Truncated: {len(chunks)} files total, "
+                    f"showing {len(result_parts) + 1} with {per_file_lines} lines each]\n"
+                )
+                break
+            result_parts.append(part)
+            total += len(part)
+
+        return "\n".join(result_parts)
+
     def _find_existing_milestone(
         self, phase: str, milestone_type: str, dev_round: int = None, round_number: int = None
     ) -> Optional[dict]:
@@ -913,7 +953,7 @@ class AutonomousOrchestrator:
         review_prompt = (
             AUTONOMOUS_CONTEXT + f"你是一位资深代码审查专家。请审查以下 PR 的代码变更。\n\n"
             f"## 需求\n{wf.get('requirements_text', '')[:500]}\n\n"
-            f"## 代码变更\n{diff_text[:8000]}\n\n"
+            f"## 代码变更\n{self._smart_truncate_diff(diff_text)}\n\n"
             f"请检查：\n"
             f"1. 代码质量和可读性\n"
             f"2. 潜在 bug 和安全问题\n"

--- a/app/repositories/autonomous_repo.py
+++ b/app/repositories/autonomous_repo.py
@@ -7,7 +7,7 @@ Database operations for the AI autonomous development feature.
 
 import logging
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Optional
 
 from app.repositories.database import Database, is_postgresql
@@ -561,8 +561,7 @@ class AutonomousWorkflowRepository:
         now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
 
         cutoff = (
-            datetime.now(timezone.utc)
-            - __import__("datetime").timedelta(seconds=self.LOCK_TIMEOUT_SECONDS)
+            datetime.now(timezone.utc) - timedelta(seconds=self.LOCK_TIMEOUT_SECONDS)
         ).strftime("%Y-%m-%d %H:%M:%S")
 
         conn = self.db.get_connection()

--- a/app/repositories/autonomous_repo.py
+++ b/app/repositories/autonomous_repo.py
@@ -51,6 +51,8 @@ class AutonomousWorkflowRepository:
         "error_message",
         "retry_count",
         "task_timeout",
+        "locked_at",
+        "locked_by",
         "updated_at",
         "completed_at",
         "paused_at",
@@ -542,3 +544,64 @@ class AutonomousWorkflowRepository:
             "SELECT * FROM workflow_events WHERE workflow_id = ? ORDER BY created_at ASC LIMIT ? OFFSET ?",
             (workflow_id, limit, offset),
         )
+
+    # ── Distributed Lock ──────────────────────────────────────────────
+
+    # Lock timeout in seconds — stale locks are automatically cleared
+    LOCK_TIMEOUT_SECONDS = 1800  # 30 minutes
+
+    def acquire_lock(self, workflow_id: str, owner: str) -> bool:
+        """Atomically acquire a processing lock for a workflow.
+
+        Returns True if the lock was acquired, False if already locked.
+        Stale locks (older than LOCK_TIMEOUT_SECONDS) are broken automatically.
+        """
+        import app.repositories.database as _db_mod
+
+        now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+
+        cutoff = (
+            datetime.now(timezone.utc)
+            - __import__("datetime").timedelta(seconds=self.LOCK_TIMEOUT_SECONDS)
+        ).strftime("%Y-%m-%d %H:%M:%S")
+
+        conn = self.db.get_connection()
+        try:
+            cursor = conn.cursor()
+            cursor.execute(
+                _db_mod.adapt_sql(
+                    """
+                    UPDATE autonomous_workflows
+                    SET locked_at = ?, locked_by = ?
+                    WHERE workflow_id = ?
+                      AND (locked_at IS NULL OR locked_at < ?)
+                    """
+                ),
+                (now, owner, workflow_id, cutoff),
+            )
+            rowcount = cursor.rowcount
+            conn.commit()
+            return rowcount > 0
+        finally:
+            conn.close()
+
+    def release_lock(self, workflow_id: str, owner: str) -> None:
+        """Release the lock, but only if we are the owner."""
+        import app.repositories.database as _db_mod
+
+        conn = self.db.get_connection()
+        try:
+            cursor = conn.cursor()
+            cursor.execute(
+                _db_mod.adapt_sql(
+                    """
+                    UPDATE autonomous_workflows
+                    SET locked_at = NULL, locked_by = NULL
+                    WHERE workflow_id = ? AND locked_by = ?
+                    """
+                ),
+                (workflow_id, owner),
+            )
+            conn.commit()
+        finally:
+            conn.close()

--- a/app/routes/autonomous.py
+++ b/app/routes/autonomous.py
@@ -20,6 +20,9 @@ logger = logging.getLogger(__name__)
 # Maximum retry count for failed workflows
 MAX_RETRY_COUNT = 5
 
+# Lazy repo — avoids creating DB connection at import time
+auto_repo = AutonomousWorkflowRepository()
+
 autonomous_bp = Blueprint("autonomous", __name__)
 
 auto_repo = AutonomousWorkflowRepository()
@@ -453,6 +456,58 @@ def get_milestone_session(workflow_id, milestone_id):
     session_data = sm.get_session(session_id, include_messages=True)
 
     return jsonify({"success": True, "session": session_data})
+
+
+@autonomous_bp.route("/workflows/<workflow_id>/milestones/<milestone_id>/diff", methods=["GET"])
+@auth_required
+def get_milestone_diff(workflow_id, milestone_id):
+    """Get the code diff for a milestone's commits."""
+    workflow = auto_repo.get_workflow(workflow_id)
+    if not workflow:
+        return jsonify({"error": "Workflow not found"}), 404
+    if g.user_role != "admin" and workflow.get("user_id") != g.user_id:
+        return jsonify({"error": "Access denied"}), 403
+
+    milestone = auto_repo.get_milestone(milestone_id)
+    if not milestone or milestone.get("workflow_id") != workflow_id:
+        return jsonify({"error": "Milestone not found"}), 404
+
+    commit_shas_raw = milestone.get("commit_shas", "")
+    if not commit_shas_raw:
+        return jsonify({"success": True, "diff": ""})
+
+    # Parse commit SHAs (may be JSON array or comma-separated)
+    import json as _json
+
+    try:
+        shas = (
+            _json.loads(commit_shas_raw)
+            if commit_shas_raw.startswith("[")
+            else commit_shas_raw.split(",")
+        )
+    except (ValueError, TypeError):
+        shas = [commit_shas_raw]
+
+    shas = [s.strip().strip('"').strip("'") for s in shas if s.strip()]
+
+    if not shas:
+        return jsonify({"success": True, "diff": ""})
+
+    # Get diff for each commit
+    from app.modules.workspace.autonomous.github_ops import GitHubOps
+
+    project_path = workflow.get("worktree_path") or workflow.get("project_path", "")
+    gh = GitHubOps(project_path)
+    diff_parts = []
+    for sha in shas:
+        try:
+            diff_text = gh.get_commit_diff(sha)
+            if diff_text:
+                diff_parts.append(f"--- Commit: {sha[:8]} ---\n{diff_text}")
+        except Exception as e:
+            logger.warning("Failed to get diff for %s: %s", sha[:8], e)
+
+    return jsonify({"success": True, "diff": "\n\n".join(diff_parts)})
 
 
 # ── Real-Time Events (SSE) ─────────────────────────────────────────

--- a/app/routes/autonomous.py
+++ b/app/routes/autonomous.py
@@ -100,6 +100,19 @@ def create_workflow():
     if not _workflow_rate_limiter.is_allowed(user_id):
         return jsonify({"error": "Rate limit exceeded: max 10 workflows per hour"}), 429
 
+    # Validate remote machine admin permission
+    workspace_type = data.get("workspace_type", "local")
+    remote_machine_id = data.get("remote_machine_id", "")
+    if workspace_type == "remote" and remote_machine_id:
+        if g.user_role != "admin":
+            from app.auth.decorators import _check_machine_admin
+
+            if not _check_machine_admin(user_id, remote_machine_id):
+                return (
+                    jsonify({"error": "Machine admin permission required for remote workflows"}),
+                    403,
+                )
+
     # Validate required fields
     if not data.get("requirements_text") and not data.get("requirements_issue_url"):
         return jsonify({"error": "requirements_text or requirements_issue_url is required"}), 400

--- a/app/routes/autonomous.py
+++ b/app/routes/autonomous.py
@@ -602,7 +602,7 @@ def stream_workflow_events(workflow_id):
                     emitter.mark_read(workflow_id, q)
                     yield ": keepalive\n\n"
         except GeneratorExit:
-            emitter.unsubscribe(workflow_id, q)
+            pass  # cleanup handled by finally
         finally:
             emitter.unsubscribe(workflow_id, q)
 

--- a/app/routes/autonomous.py
+++ b/app/routes/autonomous.py
@@ -16,7 +16,11 @@ import time
 
 from flask import Blueprint, Response, g, jsonify, request, stream_with_context
 
-from app.auth.decorators import _load_user_from_token, auth_required
+from app.auth.decorators import (
+    auth_required,
+    check_machine_admin_permission,
+    validate_session_token,
+)
 from app.repositories.autonomous_repo import AutonomousWorkflowRepository
 
 logger = logging.getLogger(__name__)
@@ -105,9 +109,7 @@ def create_workflow():
     remote_machine_id = data.get("remote_machine_id", "")
     if workspace_type == "remote" and remote_machine_id:
         if g.user_role != "admin":
-            from app.auth.decorators import _check_machine_admin
-
-            if not _check_machine_admin(user_id, remote_machine_id):
+            if not check_machine_admin_permission(user_id, remote_machine_id):
                 return (
                     jsonify({"error": "Machine admin permission required for remote workflows"}),
                     403,
@@ -595,7 +597,7 @@ def stream_workflow_events(workflow_id):
                     token = request.cookies.get("session_token") or request.headers.get(
                         "Authorization", ""
                     ).replace("Bearer ", "")
-                    if not token or not _load_user_from_token(token):
+                    if not token or not validate_session_token(token):
                         break  # Token invalid or revoked — close stream
                     emitter.mark_read(workflow_id, q)
                     yield ": keepalive\n\n"

--- a/app/routes/autonomous.py
+++ b/app/routes/autonomous.py
@@ -5,14 +5,18 @@ Open ACE - Autonomous Development Routes
 API routes for AI autonomous development workflow management.
 """
 
+from __future__ import annotations
+
 import json
 import logging
 import os
 import queue
+import threading
+import time
 
 from flask import Blueprint, Response, g, jsonify, request, stream_with_context
 
-from app.auth.decorators import auth_required
+from app.auth.decorators import _load_user_from_token, auth_required
 from app.repositories.autonomous_repo import AutonomousWorkflowRepository
 
 logger = logging.getLogger(__name__)
@@ -21,11 +25,47 @@ logger = logging.getLogger(__name__)
 MAX_RETRY_COUNT = 5
 
 # Lazy repo — avoids creating DB connection at import time
-auto_repo = AutonomousWorkflowRepository()
+auto_repo: AutonomousWorkflowRepository | None = None
+
+
+def _get_repo() -> AutonomousWorkflowRepository:
+    """Lazy-initialize the repository to avoid DB connection at import time."""
+    global auto_repo
+    if auto_repo is None:
+        auto_repo = AutonomousWorkflowRepository()
+    return auto_repo
+
 
 autonomous_bp = Blueprint("autonomous", __name__)
 
-auto_repo = AutonomousWorkflowRepository()
+# ── Rate Limiter ─────────────────────────────────────────────────────
+
+
+class _RateLimiter:
+    """Simple in-memory rate limiter: max *max_count* actions per user per *window* seconds."""
+
+    def __init__(self, max_count: int = 10, window: int = 3600) -> None:
+        self._max_count = max_count
+        self._window = window
+        self._hits: dict[int, list[float]] = {}
+        self._lock = threading.Lock()
+
+    def is_allowed(self, user_id: int) -> bool:
+        """Return True if the user is within the rate limit."""
+        now = time.time()
+        with self._lock:
+            timestamps = self._hits.get(user_id, [])
+            # Prune expired entries
+            timestamps = [ts for ts in timestamps if now - ts < self._window]
+            if len(timestamps) >= self._max_count:
+                self._hits[user_id] = timestamps
+                return False
+            timestamps.append(now)
+            self._hits[user_id] = timestamps
+            return True
+
+
+_workflow_rate_limiter = _RateLimiter(max_count=10, window=3600)
 
 # Shared mapping from workflow phase to active status
 PHASE_TO_STATUS = {
@@ -55,6 +95,10 @@ def create_workflow():
     """Create a new autonomous development workflow."""
     data = request.get_json(silent=True) or {}
     user_id = g.user_id
+
+    # Rate limit: max 10 workflows per user per hour
+    if not _workflow_rate_limiter.is_allowed(user_id):
+        return jsonify({"error": "Rate limit exceeded: max 10 workflows per hour"}), 429
 
     # Validate required fields
     if not data.get("requirements_text") and not data.get("requirements_issue_url"):
@@ -96,7 +140,7 @@ def create_workflow():
     }
 
     try:
-        workflow = auto_repo.create_workflow(workflow_data)
+        workflow = _get_repo().create_workflow(workflow_data)
         if not workflow:
             return jsonify({"error": "Failed to create workflow"}), 500
 
@@ -130,7 +174,7 @@ def list_workflows():
     offset = int(request.args.get("offset", 0))
 
     try:
-        workflows = auto_repo.list_workflows(
+        workflows = _get_repo().list_workflows(
             user_id=filter_user_id,
             status=status,
             limit=limit,
@@ -146,7 +190,7 @@ def list_workflows():
 @auth_required
 def get_workflow(workflow_id):
     """Get a workflow by ID."""
-    workflow = auto_repo.get_workflow(workflow_id)
+    workflow = _get_repo().get_workflow(workflow_id)
     if not workflow:
         return jsonify({"error": "Workflow not found"}), 404
 
@@ -161,7 +205,7 @@ def get_workflow(workflow_id):
 @auth_required
 def delete_workflow(workflow_id):
     """Cancel and delete a workflow."""
-    workflow = auto_repo.get_workflow(workflow_id)
+    workflow = _get_repo().get_workflow(workflow_id)
     if not workflow:
         return jsonify({"error": "Workflow not found"}), 404
 
@@ -169,7 +213,7 @@ def delete_workflow(workflow_id):
         return jsonify({"error": "Access denied"}), 403
 
     try:
-        auto_repo.delete_workflow(workflow_id)
+        _get_repo().delete_workflow(workflow_id)
         return jsonify({"success": True})
     except Exception as e:
         logger.error("Failed to delete workflow: %s", e)
@@ -183,7 +227,7 @@ def delete_workflow(workflow_id):
 @auth_required
 def pause_workflow(workflow_id):
     """Pause a running workflow."""
-    workflow = auto_repo.get_workflow(workflow_id)
+    workflow = _get_repo().get_workflow(workflow_id)
     if not workflow:
         return jsonify({"error": "Workflow not found"}), 404
     if g.user_role != "admin" and workflow.get("user_id") != g.user_id:
@@ -197,7 +241,7 @@ def pause_workflow(workflow_id):
 
     from datetime import datetime, timezone
 
-    auto_repo.update_workflow(
+    _get_repo().update_workflow(
         workflow_id,
         {
             "status": "paused",
@@ -213,7 +257,7 @@ def pause_workflow(workflow_id):
 @auth_required
 def resume_workflow(workflow_id):
     """Resume a paused workflow."""
-    workflow = auto_repo.get_workflow(workflow_id)
+    workflow = _get_repo().get_workflow(workflow_id)
     if not workflow:
         return jsonify({"error": "Workflow not found"}), 404
     if g.user_role != "admin" and workflow.get("user_id") != g.user_id:
@@ -225,7 +269,7 @@ def resume_workflow(workflow_id):
     phase = workflow.get("current_phase", "preparation")
     status = PHASE_TO_STATUS.get(phase, "pending")
 
-    auto_repo.update_workflow(
+    _get_repo().update_workflow(
         workflow_id,
         {
             "status": status,
@@ -241,7 +285,7 @@ def resume_workflow(workflow_id):
 @auth_required
 def stop_workflow(workflow_id):
     """Gracefully stop a workflow."""
-    workflow = auto_repo.get_workflow(workflow_id)
+    workflow = _get_repo().get_workflow(workflow_id)
     if not workflow:
         return jsonify({"error": "Workflow not found"}), 404
     if g.user_role != "admin" and workflow.get("user_id") != g.user_id:
@@ -252,7 +296,7 @@ def stop_workflow(workflow_id):
 
     from datetime import datetime, timezone
 
-    auto_repo.update_workflow(
+    _get_repo().update_workflow(
         workflow_id,
         {
             "status": "cancelled",
@@ -268,7 +312,7 @@ def stop_workflow(workflow_id):
 @auth_required
 def retry_workflow(workflow_id):
     """Retry a failed workflow from its current phase."""
-    workflow = auto_repo.get_workflow(workflow_id)
+    workflow = _get_repo().get_workflow(workflow_id)
     if not workflow:
         return jsonify({"error": "Workflow not found"}), 404
     if g.user_role != "admin" and workflow.get("user_id") != g.user_id:
@@ -285,7 +329,7 @@ def retry_workflow(workflow_id):
     phase = workflow.get("current_phase", "preparation")
     status = PHASE_TO_STATUS.get(phase, "pending")
 
-    auto_repo.update_workflow(
+    _get_repo().update_workflow(
         workflow_id,
         {
             "status": status,
@@ -302,7 +346,7 @@ def retry_workflow(workflow_id):
 @auth_required
 def mark_done(workflow_id):
     """Mark workflow as complete, triggering merge phase."""
-    workflow = auto_repo.get_workflow(workflow_id)
+    workflow = _get_repo().get_workflow(workflow_id)
     if not workflow:
         return jsonify({"error": "Workflow not found"}), 404
     if g.user_role != "admin" and workflow.get("user_id") != g.user_id:
@@ -316,7 +360,7 @@ def mark_done(workflow_id):
     if data.get("selected_branch"):
         updates["branch_name"] = data["selected_branch"]
 
-    auto_repo.update_workflow(workflow_id, updates)
+    _get_repo().update_workflow(workflow_id, updates)
 
     _emit_event_safe(workflow_id, "status_change", {"status": "merging", "phase": "merge"})
     return jsonify({"success": True})
@@ -329,13 +373,13 @@ def mark_done(workflow_id):
 @auth_required
 def get_timeline(workflow_id):
     """Get all milestones for a workflow (timeline)."""
-    workflow = auto_repo.get_workflow(workflow_id)
+    workflow = _get_repo().get_workflow(workflow_id)
     if not workflow:
         return jsonify({"error": "Workflow not found"}), 404
     if g.user_role != "admin" and workflow.get("user_id") != g.user_id:
         return jsonify({"error": "Access denied"}), 403
 
-    milestones = auto_repo.list_milestones(workflow_id)
+    milestones = _get_repo().list_milestones(workflow_id)
     return jsonify({"success": True, "milestones": milestones})
 
 
@@ -343,20 +387,20 @@ def get_timeline(workflow_id):
 @auth_required
 def cancel_milestone(workflow_id, milestone_id):
     """Cancel a milestone and all subsequent milestones."""
-    workflow = auto_repo.get_workflow(workflow_id)
+    workflow = _get_repo().get_workflow(workflow_id)
     if not workflow:
         return jsonify({"error": "Workflow not found"}), 404
     if g.user_role != "admin" and workflow.get("user_id") != g.user_id:
         return jsonify({"error": "Access denied"}), 403
 
-    milestone = auto_repo.get_milestone(milestone_id)
+    milestone = _get_repo().get_milestone(milestone_id)
     if not milestone or milestone.get("workflow_id") != workflow_id:
         return jsonify({"error": "Milestone not found"}), 404
 
-    cancelled = auto_repo.cancel_milestones_after(workflow_id, milestone_id)
+    cancelled = _get_repo().cancel_milestones_after(workflow_id, milestone_id)
 
     # Set workflow to waiting state for user to provide new requirements
-    auto_repo.update_workflow(
+    _get_repo().update_workflow(
         workflow_id,
         {
             "current_phase": "wait",
@@ -380,13 +424,13 @@ def cancel_milestone(workflow_id, milestone_id):
 @auth_required
 def fork_milestone(workflow_id, milestone_id):
     """Fork from a milestone, creating a new branch."""
-    workflow = auto_repo.get_workflow(workflow_id)
+    workflow = _get_repo().get_workflow(workflow_id)
     if not workflow:
         return jsonify({"error": "Workflow not found"}), 404
     if g.user_role != "admin" and workflow.get("user_id") != g.user_id:
         return jsonify({"error": "Access denied"}), 403
 
-    milestone = auto_repo.get_milestone(milestone_id)
+    milestone = _get_repo().get_milestone(milestone_id)
     if not milestone or milestone.get("workflow_id") != workflow_id:
         return jsonify({"error": "Milestone not found"}), 404
 
@@ -404,13 +448,13 @@ def fork_milestone(workflow_id, milestone_id):
         "parent_milestone_id": milestone_id,
         "fork_branch": fork_branch,
     }
-    fork_milestone = auto_repo.create_milestone(fork_data)
+    fork_milestone = _get_repo().create_milestone(fork_data)
 
     # Cancel milestones after the fork point
-    auto_repo.cancel_milestones_after(workflow_id, milestone_id)
+    _get_repo().cancel_milestones_after(workflow_id, milestone_id)
 
     # Update workflow with new branch and reset to planning
-    auto_repo.update_workflow(
+    _get_repo().update_workflow(
         workflow_id,
         {
             "branch_name": fork_branch,
@@ -435,13 +479,13 @@ def fork_milestone(workflow_id, milestone_id):
 @auth_required
 def get_milestone_session(workflow_id, milestone_id):
     """Get the agent session associated with a milestone."""
-    workflow = auto_repo.get_workflow(workflow_id)
+    workflow = _get_repo().get_workflow(workflow_id)
     if not workflow:
         return jsonify({"error": "Workflow not found"}), 404
     if g.user_role != "admin" and workflow.get("user_id") != g.user_id:
         return jsonify({"error": "Access denied"}), 403
 
-    milestone = auto_repo.get_milestone(milestone_id)
+    milestone = _get_repo().get_milestone(milestone_id)
     if not milestone or milestone.get("workflow_id") != workflow_id:
         return jsonify({"error": "Milestone not found"}), 404
 
@@ -462,13 +506,13 @@ def get_milestone_session(workflow_id, milestone_id):
 @auth_required
 def get_milestone_diff(workflow_id, milestone_id):
     """Get the code diff for a milestone's commits."""
-    workflow = auto_repo.get_workflow(workflow_id)
+    workflow = _get_repo().get_workflow(workflow_id)
     if not workflow:
         return jsonify({"error": "Workflow not found"}), 404
     if g.user_role != "admin" and workflow.get("user_id") != g.user_id:
         return jsonify({"error": "Access denied"}), 403
 
-    milestone = auto_repo.get_milestone(milestone_id)
+    milestone = _get_repo().get_milestone(milestone_id)
     if not milestone or milestone.get("workflow_id") != workflow_id:
         return jsonify({"error": "Milestone not found"}), 404
 
@@ -517,7 +561,7 @@ def get_milestone_diff(workflow_id, milestone_id):
 @auth_required
 def stream_workflow_events(workflow_id):
     """SSE stream for real-time workflow events."""
-    workflow = auto_repo.get_workflow(workflow_id)
+    workflow = _get_repo().get_workflow(workflow_id)
     if not workflow:
         return jsonify({"error": "Workflow not found"}), 404
     if g.user_role != "admin" and workflow.get("user_id") != g.user_id:
@@ -534,10 +578,17 @@ def stream_workflow_events(workflow_id):
                     emitter.mark_read(workflow_id, q)
                     yield f"data: {json.dumps(event_data)}\n\n"
                 except queue.Empty:
-                    # Send keepalive and refresh TTL
+                    # Re-validate auth on keepalive to detect revoked tokens
+                    token = request.cookies.get("session_token") or request.headers.get(
+                        "Authorization", ""
+                    ).replace("Bearer ", "")
+                    if not token or not _load_user_from_token(token):
+                        break  # Token invalid or revoked — close stream
                     emitter.mark_read(workflow_id, q)
                     yield ": keepalive\n\n"
         except GeneratorExit:
+            emitter.unsubscribe(workflow_id, q)
+        finally:
             emitter.unsubscribe(workflow_id, q)
 
     return Response(

--- a/app/services/autonomous_scheduler.py
+++ b/app/services/autonomous_scheduler.py
@@ -85,11 +85,11 @@ class AutonomousScheduler:
     def _advance_single(self, workflow_id: str) -> str:
         """Advance a single workflow. Returns workflow_id for tracking."""
         from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
-        from app.repositories.autonomous_repo import AutonomousWorkflowRepository
+        from app.routes.autonomous import _get_repo
 
         # Unique lock owner: hostname + thread name
         lock_owner = f"{socket.gethostname()}/{threading.current_thread().name}"
-        repo = AutonomousWorkflowRepository()
+        repo = _get_repo()
 
         # Acquire DB-level distributed lock
         if not repo.acquire_lock(workflow_id, lock_owner):
@@ -125,9 +125,9 @@ class AutonomousScheduler:
 
     def _process_workflows(self):
         """Find and process active workflows using thread pool for concurrency."""
-        from app.repositories.autonomous_repo import AutonomousWorkflowRepository
+        from app.routes.autonomous import _get_repo
 
-        repo = AutonomousWorkflowRepository()
+        repo = _get_repo()
 
         try:
             workflows = repo.get_active_workflows()

--- a/app/services/autonomous_scheduler.py
+++ b/app/services/autonomous_scheduler.py
@@ -9,6 +9,7 @@ Follows the same singleton pattern as DataFetchScheduler.
 from __future__ import annotations
 
 import logging
+import socket
 import threading
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import TYPE_CHECKING
@@ -84,6 +85,18 @@ class AutonomousScheduler:
     def _advance_single(self, workflow_id: str) -> str:
         """Advance a single workflow. Returns workflow_id for tracking."""
         from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+        from app.repositories.autonomous_repo import AutonomousWorkflowRepository
+
+        # Unique lock owner: hostname + thread name
+        lock_owner = f"{socket.gethostname()}/{threading.current_thread().name}"
+        repo = AutonomousWorkflowRepository()
+
+        # Acquire DB-level distributed lock
+        if not repo.acquire_lock(workflow_id, lock_owner):
+            logger.debug("Workflow %s is locked by another instance, skipping", workflow_id[:8])
+            with self._in_progress_lock:
+                self._in_progress_ids.discard(workflow_id)
+            return workflow_id
 
         orchestrator = None
         try:
@@ -101,6 +114,11 @@ class AutonomousScheduler:
         finally:
             with self._orchestrator_lock:
                 self._running_orchestrators.pop(workflow_id, None)
+            # Release DB lock
+            try:
+                repo.release_lock(workflow_id, lock_owner)
+            except Exception:
+                logger.warning("Failed to release lock for workflow %s", workflow_id[:8])
             with self._in_progress_lock:
                 self._in_progress_ids.discard(workflow_id)
         return workflow_id

--- a/frontend/src/api/autonomous.ts
+++ b/frontend/src/api/autonomous.ts
@@ -178,6 +178,13 @@ export const autonomousApi = {
     return apiClient.get(`/api/autonomous/workflows/${workflowId}/milestones/${milestoneId}/session`);
   },
 
+  async getMilestoneDiff(
+    workflowId: string,
+    milestoneId: string
+  ): Promise<{ success: boolean; diff: string }> {
+    return apiClient.get(`/api/autonomous/workflows/${workflowId}/milestones/${milestoneId}/diff`);
+  },
+
   // SSE Event Stream URL
   getEventStreamUrl(workflowId: string): string {
     return `/api/autonomous/workflows/${workflowId}/events/stream`;

--- a/frontend/src/components/features/AutonomousDev.tsx
+++ b/frontend/src/components/features/AutonomousDev.tsx
@@ -2,7 +2,7 @@
  * AutonomousDev Component - AI Autonomous Development page
  */
 
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useEffect } from 'react';
 import { useLanguage } from '@/store';
 import { t } from '@/i18n';
 import { Button, Loading, EmptyState } from '@/components/common';
@@ -17,6 +17,26 @@ export const AutonomousDev: React.FC = () => {
   const [selectedWorkflowId, setSelectedWorkflowId] = useState<string | null>(null);
   const [showNewModal, setShowNewModal] = useState(false);
 
+  // Deep linking: read workflow ID from URL query param on mount
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const wfId = params.get('workflow');
+    if (wfId) {
+      setSelectedWorkflowId(wfId);
+    }
+  }, []);
+
+  // Update URL when selection changes
+  const updateUrl = useCallback((workflowId: string | null) => {
+    const url = new URL(window.location.href);
+    if (workflowId) {
+      url.searchParams.set('workflow', workflowId);
+    } else {
+      url.searchParams.delete('workflow');
+    }
+    window.history.replaceState({}, '', url.toString());
+  }, []);
+
   const { data: workflowData, isLoading: workflowLoading } = useWorkflow(
     selectedWorkflowId || '',
     !!selectedWorkflowId
@@ -28,12 +48,14 @@ export const AutonomousDev: React.FC = () => {
 
   const handleSelectWorkflow = useCallback((workflow: AutonomousWorkflow) => {
     setSelectedWorkflowId(workflow.workflow_id);
-  }, []);
+    updateUrl(workflow.workflow_id);
+  }, [updateUrl]);
 
   const handleWorkflowCreated = useCallback((workflow: AutonomousWorkflow) => {
     setSelectedWorkflowId(workflow.workflow_id);
+    updateUrl(workflow.workflow_id);
     setShowNewModal(false);
-  }, []);
+  }, [updateUrl]);
 
   return (
     <div className="d-flex h-100">

--- a/frontend/src/components/work/AutonomousWorkflowList.tsx
+++ b/frontend/src/components/work/AutonomousWorkflowList.tsx
@@ -1,14 +1,14 @@
 /**
  * AutonomousWorkflowList Component - List of autonomous development workflows
  *
- * Displays workflows grouped by status with filtering.
+ * Displays workflows with status filter tabs and delete capability.
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import { useLanguage } from '@/store';
 import { t } from '@/i18n';
 import { Badge, Loading } from '@/components/common';
-import { useWorkflows } from '@/hooks/useAutonomous';
+import { useWorkflows, useDeleteWorkflow } from '@/hooks/useAutonomous';
 import type { AutonomousWorkflow } from '@/api/autonomous';
 
 interface AutonomousWorkflowListProps {
@@ -37,12 +37,21 @@ export const ACTIVE_WORKFLOW_STATUSES = [
   'pr_review', 'reporting', 'waiting', 'merging',
 ];
 
+const STATUS_FILTER_TABS = [
+  { key: '', label: 'All' },
+  { key: 'pending,preparing,planning,developing,pr_review,reporting,waiting,merging,paused', label: 'Active' },
+  { key: 'completed', label: 'Completed' },
+  { key: 'failed', label: 'Failed' },
+];
+
 export const AutonomousWorkflowList: React.FC<AutonomousWorkflowListProps> = ({
   selectedId,
   onSelect,
 }) => {
   const language = useLanguage();
-  const { data, isLoading } = useWorkflows();
+  const [statusFilter, setStatusFilter] = useState('');
+  const { data, isLoading } = useWorkflows(statusFilter ? { status: statusFilter } : undefined);
+  const deleteMutation = useDeleteWorkflow();
 
   const workflows = data?.workflows ?? [];
 
@@ -54,64 +63,88 @@ export const AutonomousWorkflowList: React.FC<AutonomousWorkflowListProps> = ({
     );
   }
 
-  if (workflows.length === 0) {
-    return (
-      <div className="text-center text-muted p-4">
-        <i className="bi bi-inbox fs-1 d-block mb-2"></i>
-        <small>{t('autoNoWorkflows', language)}</small>
-      </div>
-    );
-  }
-
   return (
-    <div className="list-group list-group-flush">
-      {workflows.map((workflow) => {
-        const statusCfg = STATUS_CONFIG[workflow.status] || STATUS_CONFIG.pending;
-        const isSelected = selectedId === workflow.workflow_id;
-        const isActive = ACTIVE_WORKFLOW_STATUSES.includes(workflow.status);
-
-        return (
+    <>
+      {/* Status Filter Tabs */}
+      <div className="d-flex border-bottom px-2 pt-1" style={{ fontSize: '0.75rem' }}>
+        {STATUS_FILTER_TABS.map((tab) => (
           <button
-            key={workflow.workflow_id}
-            className={`list-group-item list-group-item-action border-0 px-3 py-2 ${isSelected ? 'active' : ''}`}
-            onClick={() => onSelect(workflow)}
-            style={{ cursor: 'pointer' }}
+            key={tab.key}
+            className={`btn btn-sm px-2 py-1 border-0 rounded-0 ${statusFilter === tab.key ? 'fw-bold text-primary border-bottom border-2 border-primary' : 'text-muted'}`}
+            style={{ borderBottomWidth: '2px' }}
+            onClick={() => setStatusFilter(tab.key)}
           >
-            <div className="d-flex align-items-start justify-content-between">
-              <div className="flex-grow-1 min-width-0">
-                <div className="fw-semibold text-truncate" style={{ fontSize: '0.875rem' }}>
-                  {workflow.title || workflow.requirements_text?.slice(0, 50) || `Workflow ${workflow.workflow_id.slice(0, 8)}`}
-                </div>
-                <div className="d-flex align-items-center gap-1 mt-1">
-                  <Badge variant={statusCfg.variant as 'secondary' | 'info' | 'primary' | 'warning' | 'success' | 'danger'}>
-                    <i className={`bi ${statusCfg.icon} me-1`}></i>
-                    {t(statusCfg.labelKey, language)}
-                  </Badge>
-                  {workflow.dev_round > 1 && (
-                    <Badge variant="light">
-                      R{workflow.dev_round}
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      {workflows.length === 0 ? (
+        <div className="text-center text-muted p-4">
+          <i className="bi bi-inbox fs-1 d-block mb-2"></i>
+          <small>{t('autoNoWorkflows', language)}</small>
+        </div>
+      ) : (
+        <div className="list-group list-group-flush">
+          {workflows.map((workflow) => {
+            const statusCfg = STATUS_CONFIG[workflow.status] || STATUS_CONFIG.pending;
+            const isSelected = selectedId === workflow.workflow_id;
+            const isActive = ACTIVE_WORKFLOW_STATUSES.includes(workflow.status);
+
+            return (
+              <div
+                key={workflow.workflow_id}
+                className={`list-group-item border-0 px-3 py-2 d-flex align-items-start ${isSelected ? 'active' : ''}`}
+                style={{ cursor: 'pointer' }}
+                onClick={() => onSelect(workflow)}
+              >
+                <div className="flex-grow-1 min-width-0">
+                  <div className="fw-semibold text-truncate" style={{ fontSize: '0.875rem' }}>
+                    {workflow.title || workflow.requirements_text?.slice(0, 50) || `Workflow ${workflow.workflow_id.slice(0, 8)}`}
+                  </div>
+                  <div className="d-flex align-items-center gap-1 mt-1">
+                    <Badge variant={statusCfg.variant as 'secondary' | 'info' | 'primary' | 'warning' | 'success' | 'danger'}>
+                      <i className={`bi ${statusCfg.icon} me-1`}></i>
+                      {t(statusCfg.labelKey, language)}
                     </Badge>
-                  )}
+                    {workflow.dev_round > 1 && (
+                      <Badge variant="light">R{workflow.dev_round}</Badge>
+                    )}
+                  </div>
+                  <div className="text-muted mt-1" style={{ fontSize: '0.75rem' }}>
+                    <i className={`bi ${workflow.workspace_type === 'remote' ? 'bi-cloud' : 'bi-laptop'} me-1`}></i>
+                    {workflow.cli_tool}
+                    {workflow.created_at && (
+                      <span className="ms-2">{new Date(workflow.created_at).toLocaleDateString()}</span>
+                    )}
+                  </div>
                 </div>
-                <div className="text-muted mt-1" style={{ fontSize: '0.75rem' }}>
-                  <i className={`bi ${workflow.workspace_type === 'remote' ? 'bi-cloud' : 'bi-laptop'} me-1`}></i>
-                  {workflow.cli_tool}
-                  {workflow.created_at && (
-                    <span className="ms-2">
-                      {new Date(workflow.created_at).toLocaleDateString()}
+                <div className="d-flex align-items-center gap-1 ms-1">
+                  {isActive && (
+                    <span className="spinner-border spinner-border-sm text-primary" role="status">
+                      <span className="visually-hidden">...</span>
                     </span>
+                  )}
+                  {!isActive && (
+                    <button
+                      className="btn btn-sm btn-outline-secondary border-0 p-0"
+                      title="Delete"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        if (confirm('Delete this workflow?')) {
+                          deleteMutation.mutate(workflow.workflow_id);
+                        }
+                      }}
+                    >
+                      <i className="bi bi-trash" style={{ fontSize: '0.75rem' }}></i>
+                    </button>
                   )}
                 </div>
               </div>
-              {isActive && (
-                <span className="spinner-border spinner-border-sm text-primary ms-2" role="status">
-                  <span className="visually-hidden">...</span>
-                </span>
-              )}
-            </div>
-          </button>
-        );
-      })}
-    </div>
+            );
+          })}
+        </div>
+      )}
+    </>
   );
 };

--- a/frontend/src/components/work/WorkflowTimeline.tsx
+++ b/frontend/src/components/work/WorkflowTimeline.tsx
@@ -23,6 +23,7 @@ import {
   useCancelMilestone,
   useForkMilestone,
   useMilestoneSession,
+  useMilestoneDiff,
 } from '@/hooks/useAutonomous';
 import { ACTIVE_WORKFLOW_STATUSES } from './AutonomousWorkflowList';
 import { formatTokens } from '@/utils';
@@ -70,6 +71,7 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({ workflow }) 
   const [viewingSession, setViewingSession] = useState<{ milestoneId: string; sessionId: string } | null>(null);
   const [showBranchSelector, setShowBranchSelector] = useState(false);
   const [forkBranchName] = useState('');
+  const [viewingDiff, setViewingDiff] = useState<string | null>(null); // milestoneId
 
   const { data: timelineData, isLoading } = useWorkflowTimeline(workflow.workflow_id);
   const pauseMutation = usePauseWorkflow();
@@ -85,6 +87,13 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({ workflow }) 
     workflow.workflow_id,
     viewingSession?.milestoneId ?? '',
     !!viewingSession,
+  );
+
+  // Diff query (only fetches when viewingDiff is set)
+  const { data: diffData, isLoading: diffLoading } = useMilestoneDiff(
+    workflow.workflow_id,
+    viewingDiff ?? '',
+    !!viewingDiff,
   );
 
   const milestones = timelineData?.milestones ?? [];
@@ -176,6 +185,16 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({ workflow }) 
               <Badge variant={isActive ? 'primary' : isPaused ? 'warning' : 'secondary'}>
                 {workflow.status}
               </Badge>
+              {workflow.github_pr_url && (
+                <a href={workflow.github_pr_url} target="_blank" rel="noopener noreferrer" className="text-decoration-none">
+                  <Badge variant="success"><i className="bi bi-git-pull-request me-1"></i>PR #{workflow.github_pr_number}</Badge>
+                </a>
+              )}
+              {workflow.requirements_issue_url && (
+                <a href={workflow.requirements_issue_url} target="_blank" rel="noopener noreferrer" className="text-decoration-none">
+                  <Badge variant="light"><i className="bi bi-card-text me-1"></i>Issue</Badge>
+                </a>
+              )}
               {workflow.cli_tool && (
                 <small className="text-muted">
                   <i className="bi bi-tools me-1"></i>
@@ -376,6 +395,17 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({ workflow }) 
                               <code className="d-block mt-1" style={{ fontSize: '0.75rem' }}>
                                 {milestone.commit_shas}
                               </code>
+                              <div onClick={(e) => e.stopPropagation()}>
+                              <Button
+                                size="sm"
+                                variant="outline-dark"
+                                className="mt-1"
+                                onClick={() => setViewingDiff(milestone.milestone_id)}
+                              >
+                                <i className="bi bi-file-diff me-1"></i>
+                                View Changes
+                              </Button>
+                              </div>
                             </div>
                           )}
 
@@ -521,6 +551,36 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({ workflow }) 
                 <Button variant="secondary" onClick={() => setShowBranchSelector(false)}>
                   {t('cancel', language)}
                 </Button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Diff Viewer Modal */}
+      {viewingDiff && (
+        <div className="modal d-block" style={{ backgroundColor: 'rgba(0,0,0,0.5)' }} onClick={() => setViewingDiff(null)}>
+          <div className="modal-dialog modal-xl" onClick={(e) => e.stopPropagation()}>
+            <div className="modal-content">
+              <div className="modal-header">
+                <h5 className="modal-title">
+                  <i className="bi bi-file-diff me-2"></i>
+                  Code Changes
+                </h5>
+                <button type="button" className="btn-close" onClick={() => setViewingDiff(null)} />
+              </div>
+              <div className="modal-body" style={{ maxHeight: '80vh', overflow: 'auto' }}>
+                {diffLoading ? (
+                  <Loading />
+                ) : diffData?.diff ? (
+                  <pre className="bg-dark text-light p-3 rounded" style={{ fontSize: '0.75rem', maxHeight: '70vh', overflow: 'auto', whiteSpace: 'pre-wrap' }}>
+                    {diffData.diff.length > 50000
+                      ? diffData.diff.slice(0, 50000) + '\n\n--- Diff truncated at 50K characters ---'
+                      : diffData.diff}
+                  </pre>
+                ) : (
+                  <p className="text-muted">No diff available</p>
+                )}
               </div>
             </div>
           </div>

--- a/frontend/src/hooks/useAutonomous.ts
+++ b/frontend/src/hooks/useAutonomous.ts
@@ -212,6 +212,15 @@ export function useDeleteWorkflow() {
   });
 }
 
+export function useMilestoneDiff(workflowId: string, milestoneId: string, enabled = true) {
+  return useQuery({
+    queryKey: ['autonomous', 'diff', workflowId, milestoneId],
+    queryFn: () => autonomousApi.getMilestoneDiff(workflowId, milestoneId),
+    enabled: enabled && !!workflowId && !!milestoneId,
+    staleTime: 5 * 60 * 1000,
+  });
+}
+
 // ── Auxiliary Queries ──────────────────────────────────────────────
 
 export function useAvailableTools() {

--- a/tests/issues/740/test_batch1_session_wiring.py
+++ b/tests/issues/740/test_batch1_session_wiring.py
@@ -404,9 +404,18 @@ class TestSchedulerOrchestratorRegistry:
         scheduler = AutonomousScheduler()
         wf_id = "wf-reg-test"
 
-        with patch(
-            "app.modules.workspace.autonomous.orchestrator.AutonomousOrchestrator"
-        ) as mock_orch_cls:
+        mock_repo = MagicMock()
+        mock_repo.acquire_lock.return_value = True
+
+        with (
+            patch(
+                "app.modules.workspace.autonomous.orchestrator.AutonomousOrchestrator"
+            ) as mock_orch_cls,
+            patch(
+                "app.repositories.autonomous_repo.AutonomousWorkflowRepository",
+                return_value=mock_repo,
+            ),
+        ):
             mock_orch = MagicMock()
             mock_orch_cls.return_value = mock_orch
 
@@ -422,9 +431,18 @@ class TestSchedulerOrchestratorRegistry:
         scheduler = AutonomousScheduler()
         wf_id = "wf-error-test"
 
-        with patch(
-            "app.modules.workspace.autonomous.orchestrator.AutonomousOrchestrator"
-        ) as mock_orch_cls:
+        mock_repo = MagicMock()
+        mock_repo.acquire_lock.return_value = True
+
+        with (
+            patch(
+                "app.modules.workspace.autonomous.orchestrator.AutonomousOrchestrator"
+            ) as mock_orch_cls,
+            patch(
+                "app.repositories.autonomous_repo.AutonomousWorkflowRepository",
+                return_value=mock_repo,
+            ),
+        ):
             mock_orch = MagicMock()
             mock_orch.advance.side_effect = RuntimeError("boom")
             mock_orch_cls.return_value = mock_orch
@@ -442,9 +460,18 @@ class TestSchedulerOrchestratorRegistry:
         wf_id = "wf-cleanup-test"
         scheduler._in_progress_ids.add(wf_id)
 
-        with patch(
-            "app.modules.workspace.autonomous.orchestrator.AutonomousOrchestrator"
-        ) as mock_orch_cls:
+        mock_repo = MagicMock()
+        mock_repo.acquire_lock.return_value = True
+
+        with (
+            patch(
+                "app.modules.workspace.autonomous.orchestrator.AutonomousOrchestrator"
+            ) as mock_orch_cls,
+            patch(
+                "app.repositories.autonomous_repo.AutonomousWorkflowRepository",
+                return_value=mock_repo,
+            ),
+        ):
             mock_orch_cls.return_value = MagicMock()
             scheduler._advance_single(wf_id)
 
@@ -458,9 +485,18 @@ class TestSchedulerOrchestratorRegistry:
         wf_id = "wf-error-cleanup"
         scheduler._in_progress_ids.add(wf_id)
 
-        with patch(
-            "app.modules.workspace.autonomous.orchestrator.AutonomousOrchestrator"
-        ) as mock_orch_cls:
+        mock_repo = MagicMock()
+        mock_repo.acquire_lock.return_value = True
+
+        with (
+            patch(
+                "app.modules.workspace.autonomous.orchestrator.AutonomousOrchestrator"
+            ) as mock_orch_cls,
+            patch(
+                "app.repositories.autonomous_repo.AutonomousWorkflowRepository",
+                return_value=mock_repo,
+            ),
+        ):
             mock_orch = MagicMock()
             mock_orch.advance.side_effect = Exception("fail")
             mock_orch_cls.return_value = mock_orch

--- a/tests/issues/740/test_batch1_session_wiring.py
+++ b/tests/issues/740/test_batch1_session_wiring.py
@@ -411,10 +411,7 @@ class TestSchedulerOrchestratorRegistry:
             patch(
                 "app.modules.workspace.autonomous.orchestrator.AutonomousOrchestrator"
             ) as mock_orch_cls,
-            patch(
-                "app.repositories.autonomous_repo.AutonomousWorkflowRepository",
-                return_value=mock_repo,
-            ),
+            patch("app.routes.autonomous._get_repo", return_value=mock_repo),
         ):
             mock_orch = MagicMock()
             mock_orch_cls.return_value = mock_orch
@@ -438,10 +435,7 @@ class TestSchedulerOrchestratorRegistry:
             patch(
                 "app.modules.workspace.autonomous.orchestrator.AutonomousOrchestrator"
             ) as mock_orch_cls,
-            patch(
-                "app.repositories.autonomous_repo.AutonomousWorkflowRepository",
-                return_value=mock_repo,
-            ),
+            patch("app.routes.autonomous._get_repo", return_value=mock_repo),
         ):
             mock_orch = MagicMock()
             mock_orch.advance.side_effect = RuntimeError("boom")
@@ -467,10 +461,7 @@ class TestSchedulerOrchestratorRegistry:
             patch(
                 "app.modules.workspace.autonomous.orchestrator.AutonomousOrchestrator"
             ) as mock_orch_cls,
-            patch(
-                "app.repositories.autonomous_repo.AutonomousWorkflowRepository",
-                return_value=mock_repo,
-            ),
+            patch("app.routes.autonomous._get_repo", return_value=mock_repo),
         ):
             mock_orch_cls.return_value = MagicMock()
             scheduler._advance_single(wf_id)
@@ -492,10 +483,7 @@ class TestSchedulerOrchestratorRegistry:
             patch(
                 "app.modules.workspace.autonomous.orchestrator.AutonomousOrchestrator"
             ) as mock_orch_cls,
-            patch(
-                "app.repositories.autonomous_repo.AutonomousWorkflowRepository",
-                return_value=mock_repo,
-            ),
+            patch("app.routes.autonomous._get_repo", return_value=mock_repo),
         ):
             mock_orch = MagicMock()
             mock_orch.advance.side_effect = Exception("fail")

--- a/tests/issues/740/test_batch4_diff_api.py
+++ b/tests/issues/740/test_batch4_diff_api.py
@@ -1,0 +1,363 @@
+"""
+Batch 4 tests — Diff API endpoint, status filter.
+
+Tests for:
+- GET /api/autonomous/workflows/<id>/milestones/<mid>/diff
+- Workflow list status filter query parameter
+"""
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
+
+# Ensure project root on path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+
+
+def _make_workflow(**overrides):
+    """Create a minimal workflow dict for testing."""
+    base = {
+        "workflow_id": "wf-1",
+        "user_id": 1,
+        "title": "Test",
+        "status": "completed",
+        "requirements_text": "",
+        "requirements_issue_url": "",
+        "project_path": "/tmp/project",
+        "project_repo_url": "",
+        "is_new_project": False,
+        "cli_tool": "claude-code",
+        "model": "claude-sonnet-4-6",
+        "permission_mode": "auto-edit",
+        "branch_name": "main",
+        "branch_strategy": "new-branch",
+        "workspace_type": "local",
+        "remote_machine_id": "",
+        "worktree_path": "",
+        "github_issue_number": None,
+        "github_pr_number": None,
+        "github_pr_url": "",
+        "current_phase": "completed",
+        "current_round": 1,
+        "dev_round": 1,
+        "max_plan_rounds": 3,
+        "max_pr_review_rounds": 2,
+        "total_tokens": 0,
+        "total_input_tokens": 0,
+        "total_output_tokens": 0,
+        "total_requests": 0,
+        "error_message": "",
+        "created_at": "2026-01-01T00:00:00",
+        "updated_at": "2026-01-01T00:00:00",
+        "completed_at": "2026-01-01T00:00:00",
+        "paused_at": None,
+    }
+    base.update(overrides)
+    return base
+
+
+def _make_milestone(**overrides):
+    """Create a minimal milestone dict for testing."""
+    base = {
+        "milestone_id": "ms-1",
+        "workflow_id": "wf-1",
+        "phase": "development",
+        "dev_round": 1,
+        "round_number": 1,
+        "milestone_type": "development",
+        "status": "completed",
+        "title": "Dev Round 1",
+        "description": "",
+        "session_id": "sess-1",
+        "review_session_id": "",
+        "github_issue_number": None,
+        "github_pr_number": None,
+        "github_comment_id": "",
+        "commit_shas": "",
+        "diff_stats": "",
+        "result_summary": "Done",
+        "plan_content": "",
+        "review_content": "",
+        "error_message": "",
+        "parent_milestone_id": "",
+        "fork_branch": "",
+        "metadata": "",
+        "started_at": "2026-01-01T00:00:00",
+        "completed_at": "2026-01-01T00:00:00",
+        "created_at": "2026-01-01T00:00:00",
+        "updated_at": "2026-01-01T00:00:00",
+    }
+    base.update(overrides)
+    return base
+
+
+def _make_client():
+    """Create Flask test client with test DB and mock auth."""
+    import app.repositories.database as db_mod
+
+    db_path = tempfile.mktemp(suffix=".db")
+    orig = db_mod.adapt_sql
+    db_mod.adapt_sql = lambda sql: sql
+
+    db = db_mod.Database(db_path)
+    try:
+        with db.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT UNIQUE NOT NULL, email TEXT UNIQUE NOT NULL, password_hash TEXT NOT NULL, role TEXT DEFAULT 'user', is_active INTEGER DEFAULT 1, created_at TEXT, updated_at TEXT)"
+            )
+            cursor.execute(
+                "INSERT OR IGNORE INTO users (username, email, password_hash, role) VALUES (?, ?, ?, ?)",
+                ("admin", "admin@test.com", "hash123", "admin"),
+            )
+            from app.modules.workspace.autonomous import get_ddl_statements
+
+            for sql in get_ddl_statements():
+                cursor.execute(sql)
+            conn.commit()
+    finally:
+        pass
+
+    from app import create_app
+
+    app = create_app({"TESTING": True})
+    c = app.test_client()
+    c.set_cookie("session_token", "test-token")
+    return c, db_path, orig, db_mod
+
+
+def _mock_auth(user_id=1, role="admin"):
+    return patch(
+        "app.auth.decorators._load_user_from_token",
+        return_value={
+            "id": user_id,
+            "username": "admin" if role == "admin" else "testuser",
+            "email": f"{role}@test.com",
+            "role": role,
+        },
+    )
+
+
+class TestGetMilestoneDiff(unittest.TestCase):
+    """Tests for GET /api/autonomous/workflows/<id>/milestones/<mid>/diff."""
+
+    def setUp(self):
+        self.client, self.db_path, self.orig, self.db_mod = _make_client()
+
+    def tearDown(self):
+        self.db_mod.adapt_sql = self.orig
+        try:
+            os.unlink(self.db_path)
+        except OSError:
+            pass
+
+    @patch("app.routes.autonomous.auto_repo")
+    def test_diff_workflow_not_found(self, mock_repo):
+        """Return 404 if workflow does not exist."""
+        mock_repo.get_workflow.return_value = None
+        with _mock_auth():
+            resp = self.client.get("/api/autonomous/workflows/wf-1/milestones/ms-1/diff")
+        self.assertEqual(resp.status_code, 404)
+        data = resp.get_json()
+        self.assertIn("not found", data["error"].lower())
+
+    @patch("app.routes.autonomous.auto_repo")
+    def test_diff_access_denied_non_admin(self, mock_repo):
+        """Return 403 if non-admin tries to access another user's workflow."""
+        mock_repo.get_workflow.return_value = _make_workflow(user_id=99)
+        with _mock_auth(user_id=1, role="user"):
+            resp = self.client.get("/api/autonomous/workflows/wf-1/milestones/ms-1/diff")
+        self.assertEqual(resp.status_code, 403)
+
+    @patch("app.routes.autonomous.auto_repo")
+    def test_diff_milestone_not_found(self, mock_repo):
+        """Return 404 if milestone does not exist."""
+        mock_repo.get_workflow.return_value = _make_workflow()
+        mock_repo.get_milestone.return_value = None
+        with _mock_auth():
+            resp = self.client.get("/api/autonomous/workflows/wf-1/milestones/ms-missing/diff")
+        self.assertEqual(resp.status_code, 404)
+
+    @patch("app.routes.autonomous.auto_repo")
+    def test_diff_milestone_wrong_workflow(self, mock_repo):
+        """Return 404 if milestone belongs to different workflow."""
+        mock_repo.get_workflow.return_value = _make_workflow()
+        mock_repo.get_milestone.return_value = _make_milestone(workflow_id="other-wf")
+        with _mock_auth():
+            resp = self.client.get("/api/autonomous/workflows/wf-1/milestones/ms-1/diff")
+        self.assertEqual(resp.status_code, 404)
+
+    @patch("app.routes.autonomous.auto_repo")
+    def test_diff_empty_commit_shas(self, mock_repo):
+        """Return empty diff when milestone has no commits."""
+        mock_repo.get_workflow.return_value = _make_workflow()
+        mock_repo.get_milestone.return_value = _make_milestone(commit_shas="")
+        with _mock_auth():
+            resp = self.client.get("/api/autonomous/workflows/wf-1/milestones/ms-1/diff")
+        self.assertEqual(resp.status_code, 200)
+        data = resp.get_json()
+        self.assertTrue(data["success"])
+        self.assertEqual(data["diff"], "")
+
+    @patch("app.modules.workspace.autonomous.github_ops.GitHubOps")
+    @patch("app.routes.autonomous.auto_repo")
+    def test_diff_with_json_array_shas(self, mock_repo, mock_gh_class):
+        """Return concatenated diffs for commits in JSON array format."""
+        mock_repo.get_workflow.return_value = _make_workflow()
+        mock_repo.get_milestone.return_value = _make_milestone(
+            commit_shas='["abc123def", "456789ghi"]'
+        )
+
+        mock_gh = MagicMock()
+        mock_gh.get_commit_diff.side_effect = [
+            "diff --git a/file1.py b/file1.py\n+added line",
+            "diff --git a/file2.py b/file2.py\n-removed line",
+        ]
+        mock_gh_class.return_value = mock_gh
+
+        with _mock_auth():
+            resp = self.client.get("/api/autonomous/workflows/wf-1/milestones/ms-1/diff")
+
+        self.assertEqual(resp.status_code, 200)
+        data = resp.get_json()
+        self.assertTrue(data["success"])
+        self.assertIn("abc123de", data["diff"])
+        self.assertIn("456789gh", data["diff"])
+        self.assertIn("file1.py", data["diff"])
+        self.assertIn("file2.py", data["diff"])
+
+    @patch("app.modules.workspace.autonomous.github_ops.GitHubOps")
+    @patch("app.routes.autonomous.auto_repo")
+    def test_diff_comma_separated_shas(self, mock_repo, mock_gh_class):
+        """Handle comma-separated commit SHAs (not JSON array)."""
+        mock_repo.get_workflow.return_value = _make_workflow()
+        mock_repo.get_milestone.return_value = _make_milestone(commit_shas="abc123,def456")
+
+        mock_gh = MagicMock()
+        mock_gh.get_commit_diff.return_value = "some diff"
+        mock_gh_class.return_value = mock_gh
+
+        with _mock_auth():
+            resp = self.client.get("/api/autonomous/workflows/wf-1/milestones/ms-1/diff")
+
+        self.assertEqual(resp.status_code, 200)
+        data = resp.get_json()
+        self.assertTrue(data["success"])
+        self.assertEqual(mock_gh.get_commit_diff.call_count, 2)
+
+    @patch("app.modules.workspace.autonomous.github_ops.GitHubOps")
+    @patch("app.routes.autonomous.auto_repo")
+    def test_diff_github_ops_error_graceful(self, mock_repo, mock_gh_class):
+        """Gracefully handle GitHubOps errors — return empty diff for failed commits."""
+        mock_repo.get_workflow.return_value = _make_workflow()
+        mock_repo.get_milestone.return_value = _make_milestone(commit_shas="abc123")
+
+        mock_gh = MagicMock()
+        mock_gh.get_commit_diff.side_effect = Exception("git error")
+        mock_gh_class.return_value = mock_gh
+
+        with _mock_auth():
+            resp = self.client.get("/api/autonomous/workflows/wf-1/milestones/ms-1/diff")
+
+        self.assertEqual(resp.status_code, 200)
+        data = resp.get_json()
+        self.assertTrue(data["success"])
+        self.assertEqual(data["diff"], "")
+
+    @patch("app.modules.workspace.autonomous.github_ops.GitHubOps")
+    @patch("app.routes.autonomous.auto_repo")
+    def test_diff_uses_worktree_path_preferred(self, mock_repo, mock_gh_class):
+        """Use worktree_path over project_path when both exist."""
+        mock_repo.get_workflow.return_value = _make_workflow(
+            project_path="/tmp/project",
+            worktree_path="/tmp/worktree",
+        )
+        mock_repo.get_milestone.return_value = _make_milestone(commit_shas="abc123")
+
+        mock_gh = MagicMock()
+        mock_gh.get_commit_diff.return_value = "diff content"
+        mock_gh_class.return_value = mock_gh
+
+        with _mock_auth():
+            resp = self.client.get("/api/autonomous/workflows/wf-1/milestones/ms-1/diff")
+
+        self.assertEqual(resp.status_code, 200)
+        mock_gh_class.assert_called_once_with("/tmp/worktree")
+
+    @patch("app.modules.workspace.autonomous.github_ops.GitHubOps")
+    @patch("app.routes.autonomous.auto_repo")
+    def test_diff_falls_back_to_project_path(self, mock_repo, mock_gh_class):
+        """Use project_path when worktree_path is empty."""
+        mock_repo.get_workflow.return_value = _make_workflow(
+            project_path="/tmp/project",
+            worktree_path="",
+        )
+        mock_repo.get_milestone.return_value = _make_milestone(commit_shas="abc123")
+
+        mock_gh = MagicMock()
+        mock_gh.get_commit_diff.return_value = "diff content"
+        mock_gh_class.return_value = mock_gh
+
+        with _mock_auth():
+            resp = self.client.get("/api/autonomous/workflows/wf-1/milestones/ms-1/diff")
+
+        self.assertEqual(resp.status_code, 200)
+        mock_gh_class.assert_called_once_with("/tmp/project")
+
+    @patch("app.routes.autonomous.auto_repo")
+    def test_diff_single_sha_string(self, mock_repo):
+        """Handle a single commit SHA string (not array or comma-separated)."""
+        mock_repo.get_workflow.return_value = _make_workflow()
+        mock_repo.get_milestone.return_value = _make_milestone(commit_shas="abc123def456")
+
+        with _mock_auth():
+            with patch("app.modules.workspace.autonomous.github_ops.GitHubOps") as mock_gh_class:
+                mock_gh = MagicMock()
+                mock_gh.get_commit_diff.return_value = "diff content"
+                mock_gh_class.return_value = mock_gh
+
+                resp = self.client.get("/api/autonomous/workflows/wf-1/milestones/ms-1/diff")
+
+        self.assertEqual(resp.status_code, 200)
+        data = resp.get_json()
+        self.assertTrue(data["success"])
+        self.assertEqual(mock_gh.get_commit_diff.call_count, 1)
+
+
+class TestWorkflowListStatusFilter(unittest.TestCase):
+    """Tests for workflow list status filter query parameter."""
+
+    def setUp(self):
+        self.client, self.db_path, self.orig, self.db_mod = _make_client()
+
+    def tearDown(self):
+        self.db_mod.adapt_sql = self.orig
+        try:
+            os.unlink(self.db_path)
+        except OSError:
+            pass
+
+    @patch("app.routes.autonomous.auto_repo")
+    def test_list_with_status_filter(self, mock_repo):
+        """Status filter is passed through to repo."""
+        mock_repo.list_workflows.return_value = []
+        with _mock_auth():
+            resp = self.client.get("/api/autonomous/workflows?status=completed")
+        self.assertEqual(resp.status_code, 200)
+        mock_repo.list_workflows.assert_called_once()
+
+    @patch("app.routes.autonomous.auto_repo")
+    def test_list_without_status_filter(self, mock_repo):
+        """List all workflows when no status filter provided."""
+        mock_repo.list_workflows.return_value = []
+        with _mock_auth():
+            resp = self.client.get("/api/autonomous/workflows")
+        self.assertEqual(resp.status_code, 200)
+        mock_repo.list_workflows.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/issues/740/test_batch5_medium_backend.py
+++ b/tests/issues/740/test_batch5_medium_backend.py
@@ -1,0 +1,253 @@
+"""
+Batch 5 tests — Smart diff truncation, SSE auth re-validation, rate limiter, lazy repo.
+
+Tests for:
+- _smart_truncate_diff preserves file headers and truncates large diffs
+- _RateLimiter enforces per-user rate limits
+- SSE generate() closes stream on invalid token
+- _get_repo() lazy initialization
+"""
+
+import os
+import sys
+import tempfile
+import time
+import unittest
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+
+from app.routes.autonomous import _get_repo, _RateLimiter
+
+# ── Smart Diff Truncation ────────────────────────────────────────────
+
+
+class TestSmartDiffTruncation(unittest.TestCase):
+    """Tests for AutonomousOrchestrator._smart_truncate_diff."""
+
+    def _get_method(self):
+        from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+        return AutonomousOrchestrator._smart_truncate_diff
+
+    def test_short_diff_unchanged(self):
+        """Short diffs should pass through unchanged."""
+        truncate = self._get_method()
+        diff = "diff --git a/file.py b/file.py\n+hello\n"
+        result = truncate(diff)
+        self.assertEqual(result, diff)
+
+    def test_empty_diff_unchanged(self):
+        """Empty or None diffs should pass through."""
+        truncate = self._get_method()
+        self.assertEqual(truncate(""), "")
+        self.assertEqual(truncate(None), None)
+
+    def test_preserves_file_headers(self):
+        """All file headers should be preserved even when truncating."""
+        truncate = self._get_method()
+        # Create a large multi-file diff
+        files = []
+        for i in range(10):
+            files.append(f"diff --git a/file{i}.py b/file{i}.py\n" + f"+{'line ' * 100}\n" * 50)
+        big_diff = "\n".join(files)
+
+        result = truncate(big_diff, max_chars=500, per_file_lines=10)
+        # All file headers should be present in output
+        for i in range(min(10, len(result.split("diff --git")) - 1)):
+            self.assertIn(f"file{i}.py", result)
+
+    def test_truncation_note_appended(self):
+        """When truncated, an explanatory note should be in the output."""
+        truncate = self._get_method()
+        files = []
+        for i in range(20):
+            files.append(f"diff --git a/bigfile{i}.py b/bigfile{i}.py\n" + "+line\n" * 500)
+        big_diff = "\n".join(files)
+
+        result = truncate(big_diff, max_chars=1000, per_file_lines=10)
+        self.assertIn("Truncated", result)
+
+    def test_per_file_lines_limit(self):
+        """Each file should be limited to per_file_lines lines."""
+        truncate = self._get_method()
+        # Use multiple files with enough content to trigger truncation
+        diff = (
+            "diff --git a/file1.py b/file1.py\n"
+            + "+line\n" * 500
+            + "diff --git a/file2.py b/file2.py\n"
+            + "+line\n" * 500
+        )
+        # max_chars must be < total diff length to trigger truncation
+        result = truncate(diff, max_chars=200, per_file_lines=5)
+        lines = result.strip().split("\n")
+        # header + 5 body lines each for 2 files = ~12 lines, plus possible truncation note
+        self.assertLessEqual(len(lines), 16)
+
+
+# ── Rate Limiter ──────────────────────────────────────────────────────
+
+
+class TestRateLimiter(unittest.TestCase):
+    """Tests for _RateLimiter."""
+
+    def test_allows_under_limit(self):
+        """Requests under the limit should be allowed."""
+        limiter = _RateLimiter(max_count=3, window=60)
+        self.assertTrue(limiter.is_allowed(1))
+        self.assertTrue(limiter.is_allowed(1))
+        self.assertTrue(limiter.is_allowed(1))
+
+    def test_blocks_over_limit(self):
+        """Requests over the limit should be blocked."""
+        limiter = _RateLimiter(max_count=2, window=60)
+        limiter.is_allowed(1)
+        limiter.is_allowed(1)
+        self.assertFalse(limiter.is_allowed(1))
+
+    def test_different_users_independent(self):
+        """Different users have independent rate limits."""
+        limiter = _RateLimiter(max_count=1, window=60)
+        self.assertTrue(limiter.is_allowed(1))
+        self.assertFalse(limiter.is_allowed(1))
+        self.assertTrue(limiter.is_allowed(2))
+
+    def test_window_expiry(self):
+        """After the window expires, the limit should reset."""
+        limiter = _RateLimiter(max_count=1, window=0)  # 0 second window = immediate expiry
+        limiter.is_allowed(1)
+        # With 0-second window, next call should prune old entries
+        time.sleep(0.01)
+        self.assertTrue(limiter.is_allowed(1))
+
+
+# ── Lazy Repo ────────────────────────────────────────────────────────
+
+
+class TestLazyRepo(unittest.TestCase):
+    """Tests for _get_repo() lazy initialization."""
+
+    def test_returns_repo_instance(self):
+        """_get_repo() returns an AutonomousWorkflowRepository."""
+        # Reset global state
+        import app.routes.autonomous as mod
+        from app.repositories.autonomous_repo import AutonomousWorkflowRepository
+
+        mod.auto_repo = None
+        repo = _get_repo()
+        self.assertIsInstance(repo, AutonomousWorkflowRepository)
+
+    def test_returns_same_instance(self):
+        """_get_repo() returns the same instance on repeated calls."""
+        import app.routes.autonomous as mod
+
+        mod.auto_repo = None
+        repo1 = _get_repo()
+        repo2 = _get_repo()
+        self.assertIs(repo1, repo2)
+
+    def tearDown(self):
+        import app.routes.autonomous as mod
+
+        mod.auto_repo = None
+
+
+# ── SSE Auth Re-validation ──────────────────────────────────────────
+
+
+class TestSSEAuthRevalidation(unittest.TestCase):
+    """Tests that SSE stream closes on revoked token during keepalive."""
+
+    def _make_client(self):
+        import app.repositories.database as db_mod
+
+        db_path = tempfile.mktemp(suffix=".db")
+        orig = db_mod.adapt_sql
+        db_mod.adapt_sql = lambda sql: sql
+
+        db = db_mod.Database(db_path)
+        try:
+            with db.get_connection() as conn:
+                cursor = conn.cursor()
+                cursor.execute(
+                    "CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT UNIQUE NOT NULL, email TEXT UNIQUE NOT NULL, password_hash TEXT NOT NULL, role TEXT DEFAULT 'user', is_active INTEGER DEFAULT 1, created_at TEXT, updated_at TEXT)"
+                )
+                cursor.execute(
+                    "INSERT OR IGNORE INTO users (username, email, password_hash, role) VALUES (?, ?, ?, ?)",
+                    ("admin", "admin@test.com", "hash123", "admin"),
+                )
+                from app.modules.workspace.autonomous import get_ddl_statements
+
+                for sql in get_ddl_statements():
+                    cursor.execute(sql)
+                conn.commit()
+        finally:
+            pass
+
+        from app import create_app
+
+        app = create_app({"TESTING": True})
+        c = app.test_client()
+        c.set_cookie("session_token", "test-token")
+        return c, db_path, orig, db_mod
+
+    def test_sse_closes_on_revoked_token(self):
+        """SSE stream should terminate when token becomes invalid during keepalive."""
+        c, db_path, orig, db_mod = self._make_client()
+        try:
+            mock_repo = MagicMock()
+            mock_repo.get_workflow.return_value = {
+                "workflow_id": "wf-1",
+                "user_id": 1,
+                "status": "developing",
+            }
+
+            # Mock event emitter — queue always raises Empty (trigger keepalive)
+            import queue as queue_mod
+
+            mock_emitter = MagicMock()
+            mock_q = MagicMock()
+            mock_q.get.side_effect = queue_mod.Empty
+            mock_emitter.subscribe.return_value = mock_q
+            mock_emitter.mark_read.return_value = None
+            mock_emitter.unsubscribe.return_value = None
+
+            call_count = 0
+
+            def mock_load_token(token):
+                nonlocal call_count
+                call_count += 1
+                if call_count > 1:
+                    return None  # Token revoked after first check
+                return {
+                    "id": 1,
+                    "username": "admin",
+                    "email": "admin@test.com",
+                    "role": "admin",
+                }
+
+            # Patch auth_required decorator (bypasses initial auth) AND
+            # _load_user_from_token in autonomous routes (for keepalive re-check)
+            with patch(
+                "app.auth.decorators._load_user_from_token",
+                side_effect=mock_load_token,
+            ):
+                with patch("app.routes.autonomous._get_repo", return_value=mock_repo):
+                    with patch(
+                        "app.routes.autonomous._get_event_emitter",
+                        return_value=mock_emitter,
+                    ):
+                        resp = c.get("/api/autonomous/workflows/wf-1/events/stream")
+                        # Stream should end cleanly (not hang)
+                        self.assertEqual(resp.status_code, 200)
+                        self.assertIn("text/event-stream", resp.content_type)
+        finally:
+            db_mod.adapt_sql = orig
+            try:
+                os.unlink(db_path)
+            except OSError:
+                pass
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/issues/740/test_batch6_distributed_lock.py
+++ b/tests/issues/740/test_batch6_distributed_lock.py
@@ -1,0 +1,379 @@
+"""
+Batch 6 tests — Distributed lock, remote machine admin validation.
+
+Tests for:
+- acquire_lock / release_lock logic
+- Scheduler _advance_single uses distributed lock
+- Remote machine admin permission check in create_workflow
+"""
+
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+
+
+# ── Distributed Lock (unit tests with mocked DB) ────────────────────
+
+
+class TestDistributedLock(unittest.TestCase):
+    """Tests for acquire_lock / release_lock with real SQLite DB."""
+
+    def _make_repo(self, wf_id="wf-lock-test"):
+        """Create a repo backed by a fresh in-memory SQLite DB."""
+        import sqlite3
+
+        import app.repositories.database as db_mod
+
+        orig = db_mod.adapt_sql
+        db_mod.adapt_sql = lambda sql: sql
+
+        # Use in-memory SQLite to avoid file conflicts
+        mem_conn = sqlite3.connect(":memory:")
+        mem_conn.row_factory = sqlite3.Row
+
+        cursor = mem_conn.cursor()
+        cursor.execute(
+            "CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT UNIQUE NOT NULL, email TEXT UNIQUE NOT NULL, password_hash TEXT NOT NULL, role TEXT DEFAULT 'user', is_active INTEGER DEFAULT 1, created_at TEXT, updated_at TEXT)"
+        )
+        cursor.execute(
+            "INSERT OR IGNORE INTO users (username, email, password_hash, role) VALUES (?, ?, ?, ?)",
+            ("admin", "admin@test.com", "hash123", "admin"),
+        )
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS autonomous_workflows (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                workflow_id TEXT NOT NULL UNIQUE,
+                user_id INTEGER,
+                status TEXT DEFAULT 'pending',
+                cli_tool TEXT DEFAULT '',
+                locked_at TEXT,
+                locked_by TEXT DEFAULT ''
+            )
+            """
+        )
+        cursor.execute(
+            "INSERT INTO autonomous_workflows (workflow_id, user_id, status, cli_tool) VALUES (?, ?, ?, ?)",
+            (wf_id, 1, "pending", "claude-code"),
+        )
+        mem_conn.commit()
+
+        # Wrap in Database-like object with close() as no-op
+        mock_db = MagicMock()
+        mock_db._is_postgresql = False
+        # Return a connection that doesn't actually close (in-memory shared)
+        mock_conn = MagicMock(wraps=mem_conn)
+        mock_conn.close = MagicMock()  # no-op close
+        mock_db.get_connection.return_value = mock_conn
+
+        from app.repositories.autonomous_repo import AutonomousWorkflowRepository
+
+        repo = AutonomousWorkflowRepository(mock_db)
+        return repo, mem_conn, orig, db_mod
+
+    def tearDown(self):
+        if hasattr(self, "_conn"):
+            self._conn.close()
+        if hasattr(self, "_db_mod"):
+            self._db_mod.adapt_sql = self._orig
+
+    def test_acquire_lock_success(self):
+        """Should acquire lock when not held."""
+        repo, conn, orig, db_mod = self._make_repo("wf-ok")
+        self._conn, self._orig, self._db_mod = conn, orig, db_mod
+        result = repo.acquire_lock("wf-ok", "owner-1")
+        self.assertTrue(result)
+
+    def test_acquire_lock_fails_when_held(self):
+        """Should fail to acquire lock when already held by another owner."""
+        repo, conn, orig, db_mod = self._make_repo("wf-held")
+        self._conn, self._orig, self._db_mod = conn, orig, db_mod
+        repo.acquire_lock("wf-held", "owner-1")
+        result = repo.acquire_lock("wf-held", "owner-2")
+        self.assertFalse(result)
+
+    def test_release_lock_by_owner(self):
+        """Owner can release their own lock."""
+        repo, conn, orig, db_mod = self._make_repo("wf-release")
+        self._conn, self._orig, self._db_mod = conn, orig, db_mod
+        repo.acquire_lock("wf-release", "owner-1")
+        repo.release_lock("wf-release", "owner-1")
+        result = repo.acquire_lock("wf-release", "owner-2")
+        self.assertTrue(result)
+
+    def test_release_lock_wrong_owner_noop(self):
+        """Releasing with wrong owner should not clear the lock."""
+        repo, conn, orig, db_mod = self._make_repo("wf-wrong")
+        self._conn, self._orig, self._db_mod = conn, orig, db_mod
+        repo.acquire_lock("wf-wrong", "owner-1")
+        repo.release_lock("wf-wrong", "wrong-owner")
+        result = repo.acquire_lock("wf-wrong", "owner-2")
+        self.assertFalse(result)
+
+    def test_reentrant_lock_by_same_owner(self):
+        """Same owner can re-acquire after release."""
+        repo, conn, orig, db_mod = self._make_repo("wf-reentrant")
+        self._conn, self._orig, self._db_mod = conn, orig, db_mod
+        repo.acquire_lock("wf-reentrant", "owner-1")
+        repo.release_lock("wf-reentrant", "owner-1")
+        result = repo.acquire_lock("wf-reentrant", "owner-1")
+        self.assertTrue(result)
+
+
+class TestSchedulerLockIntegration(unittest.TestCase):
+    """Tests for scheduler _advance_single using distributed lock."""
+
+    def test_skips_locked_workflow(self):
+        """_advance_single should skip if lock cannot be acquired."""
+        from app.services.autonomous_scheduler import AutonomousScheduler
+
+        scheduler = AutonomousScheduler()
+        wf_id = "wf-locked"
+
+        mock_repo = MagicMock()
+        mock_repo.acquire_lock.return_value = False
+
+        with patch(
+            "app.repositories.autonomous_repo.AutonomousWorkflowRepository", return_value=mock_repo
+        ):
+            scheduler._advance_single(wf_id)
+
+        mock_repo.release_lock.assert_not_called()
+
+    def test_acquires_and_releases_lock(self):
+        """_advance_single should acquire and release lock in normal flow."""
+        from app.services.autonomous_scheduler import AutonomousScheduler
+
+        scheduler = AutonomousScheduler()
+        wf_id = "wf-normal"
+
+        mock_repo = MagicMock()
+        mock_repo.acquire_lock.return_value = True
+
+        with (
+            patch(
+                "app.modules.workspace.autonomous.orchestrator.AutonomousOrchestrator"
+            ) as mock_orch_cls,
+            patch(
+                "app.repositories.autonomous_repo.AutonomousWorkflowRepository",
+                return_value=mock_repo,
+            ),
+        ):
+            mock_orch_cls.return_value = MagicMock()
+            scheduler._advance_single(wf_id)
+
+        mock_repo.acquire_lock.assert_called_once()
+        mock_repo.release_lock.assert_called_once()
+
+    def test_releases_lock_on_error(self):
+        """_advance_single should release lock even on orchestrator error."""
+        from app.services.autonomous_scheduler import AutonomousScheduler
+
+        scheduler = AutonomousScheduler()
+        wf_id = "wf-error"
+
+        mock_repo = MagicMock()
+        mock_repo.acquire_lock.return_value = True
+
+        with (
+            patch(
+                "app.modules.workspace.autonomous.orchestrator.AutonomousOrchestrator"
+            ) as mock_orch_cls,
+            patch(
+                "app.repositories.autonomous_repo.AutonomousWorkflowRepository",
+                return_value=mock_repo,
+            ),
+        ):
+            mock_orch = MagicMock()
+            mock_orch.advance.side_effect = RuntimeError("boom")
+            mock_orch_cls.return_value = mock_orch
+            scheduler._advance_single(wf_id)
+
+        mock_repo.release_lock.assert_called_once()
+
+
+# ── Remote Machine Admin Validation ─────────────────────────────────
+
+
+class TestRemoteMachineAdminValidation(unittest.TestCase):
+    """Tests for remote machine admin permission check in create_workflow."""
+
+    def _make_client(self):
+        import app.repositories.database as db_mod
+
+        db_path = tempfile.mktemp(suffix=".db")
+        orig = db_mod.adapt_sql
+        db_mod.adapt_sql = lambda sql: sql
+
+        db = db_mod.Database(db_path)
+        with db.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT UNIQUE NOT NULL, email TEXT UNIQUE NOT NULL, password_hash TEXT NOT NULL, role TEXT DEFAULT 'user', is_active INTEGER DEFAULT 1, created_at TEXT, updated_at TEXT)"
+            )
+            cursor.execute(
+                "INSERT OR IGNORE INTO users (username, email, password_hash, role) VALUES (?, ?, ?, ?)",
+                ("admin", "admin@test.com", "hash123", "admin"),
+            )
+            cursor.execute(
+                "INSERT OR IGNORE INTO users (username, email, password_hash, role) VALUES (?, ?, ?, ?)",
+                ("testuser", "user@test.com", "hash123", "user"),
+            )
+            from app.modules.workspace.autonomous import get_ddl_statements
+
+            for sql in get_ddl_statements():
+                cursor.execute(sql)
+            conn.commit()
+
+        from app import create_app
+
+        app = create_app({"TESTING": True})
+        c = app.test_client()
+        c.set_cookie("session_token", "test-token")
+        return c, db_path, orig, db_mod
+
+    def _mock_auth(self, user_id=1, role="admin"):
+        return patch(
+            "app.auth.decorators._load_user_from_token",
+            return_value={
+                "id": user_id,
+                "username": "admin" if role == "admin" else "testuser",
+                "email": f"{role}@test.com",
+                "role": role,
+            },
+        )
+
+    def test_rejects_non_admin_remote_workflow(self):
+        """Non-admin user without machine admin permission should be rejected."""
+        c, db_path, orig, db_mod = self._make_client()
+        try:
+            mock_repo = MagicMock()
+            mock_repo.create_workflow.return_value = {"workflow_id": "wf-1"}
+
+            with self._mock_auth(user_id=2, role="user"):
+                with patch("app.routes.autonomous._get_repo", return_value=mock_repo):
+                    with patch("app.auth.decorators._check_machine_admin", return_value=False):
+                        resp = c.post(
+                            "/api/autonomous/workflows",
+                            json={
+                                "requirements_text": "test",
+                                "cli_tool": "claude-code",
+                                "project_path": "/tmp/project",
+                                "workspace_type": "remote",
+                                "remote_machine_id": "machine-123",
+                            },
+                        )
+
+            self.assertEqual(resp.status_code, 403)
+            data = resp.get_json()
+            self.assertIn("machine admin", data["error"].lower())
+        finally:
+            db_mod.adapt_sql = orig
+            try:
+                os.unlink(db_path)
+            except OSError:
+                pass
+
+    def test_allows_admin_remote_workflow(self):
+        """System admin should be able to create remote workflows."""
+        c, db_path, orig, db_mod = self._make_client()
+        try:
+            mock_repo = MagicMock()
+            mock_repo.create_workflow.return_value = {
+                "workflow_id": "wf-1",
+                "title": "",
+            }
+
+            with self._mock_auth(user_id=1, role="admin"):
+                with patch("app.routes.autonomous._get_repo", return_value=mock_repo):
+                    with patch("app.routes.autonomous._get_event_emitter"):
+                        resp = c.post(
+                            "/api/autonomous/workflows",
+                            json={
+                                "requirements_text": "test",
+                                "cli_tool": "claude-code",
+                                "project_path": "/tmp/project",
+                                "workspace_type": "remote",
+                                "remote_machine_id": "machine-123",
+                            },
+                        )
+
+            self.assertEqual(resp.status_code, 201)
+        finally:
+            db_mod.adapt_sql = orig
+            try:
+                os.unlink(db_path)
+            except OSError:
+                pass
+
+    def test_allows_local_workflow_without_check(self):
+        """Local workflows should not require machine admin check."""
+        c, db_path, orig, db_mod = self._make_client()
+        try:
+            mock_repo = MagicMock()
+            mock_repo.create_workflow.return_value = {
+                "workflow_id": "wf-1",
+                "title": "",
+            }
+
+            with self._mock_auth(user_id=2, role="user"):
+                with patch("app.routes.autonomous._get_repo", return_value=mock_repo):
+                    with patch("app.routes.autonomous._get_event_emitter"):
+                        resp = c.post(
+                            "/api/autonomous/workflows",
+                            json={
+                                "requirements_text": "test",
+                                "cli_tool": "claude-code",
+                                "project_path": "/tmp/project",
+                                "workspace_type": "local",
+                            },
+                        )
+
+            self.assertEqual(resp.status_code, 201)
+        finally:
+            db_mod.adapt_sql = orig
+            try:
+                os.unlink(db_path)
+            except OSError:
+                pass
+
+    def test_allows_machine_admin_remote_workflow(self):
+        """Machine admin (non-system admin) should be able to create remote workflows."""
+        c, db_path, orig, db_mod = self._make_client()
+        try:
+            mock_repo = MagicMock()
+            mock_repo.create_workflow.return_value = {
+                "workflow_id": "wf-1",
+                "title": "",
+            }
+
+            with self._mock_auth(user_id=2, role="user"):
+                with patch("app.routes.autonomous._get_repo", return_value=mock_repo):
+                    with patch("app.auth.decorators._check_machine_admin", return_value=True):
+                        with patch("app.routes.autonomous._get_event_emitter"):
+                            resp = c.post(
+                                "/api/autonomous/workflows",
+                                json={
+                                    "requirements_text": "test",
+                                    "cli_tool": "claude-code",
+                                    "project_path": "/tmp/project",
+                                    "workspace_type": "remote",
+                                    "remote_machine_id": "machine-123",
+                                },
+                            )
+
+            self.assertEqual(resp.status_code, 201)
+        finally:
+            db_mod.adapt_sql = orig
+            try:
+                os.unlink(db_path)
+            except OSError:
+                pass
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/issues/740/test_batch6_distributed_lock.py
+++ b/tests/issues/740/test_batch6_distributed_lock.py
@@ -137,9 +137,7 @@ class TestSchedulerLockIntegration(unittest.TestCase):
         mock_repo = MagicMock()
         mock_repo.acquire_lock.return_value = False
 
-        with patch(
-            "app.repositories.autonomous_repo.AutonomousWorkflowRepository", return_value=mock_repo
-        ):
+        with patch("app.routes.autonomous._get_repo", return_value=mock_repo):
             scheduler._advance_single(wf_id)
 
         mock_repo.release_lock.assert_not_called()
@@ -158,10 +156,7 @@ class TestSchedulerLockIntegration(unittest.TestCase):
             patch(
                 "app.modules.workspace.autonomous.orchestrator.AutonomousOrchestrator"
             ) as mock_orch_cls,
-            patch(
-                "app.repositories.autonomous_repo.AutonomousWorkflowRepository",
-                return_value=mock_repo,
-            ),
+            patch("app.routes.autonomous._get_repo", return_value=mock_repo),
         ):
             mock_orch_cls.return_value = MagicMock()
             scheduler._advance_single(wf_id)
@@ -183,10 +178,7 @@ class TestSchedulerLockIntegration(unittest.TestCase):
             patch(
                 "app.modules.workspace.autonomous.orchestrator.AutonomousOrchestrator"
             ) as mock_orch_cls,
-            patch(
-                "app.repositories.autonomous_repo.AutonomousWorkflowRepository",
-                return_value=mock_repo,
-            ),
+            patch("app.routes.autonomous._get_repo", return_value=mock_repo),
         ):
             mock_orch = MagicMock()
             mock_orch.advance.side_effect = RuntimeError("boom")


### PR DESCRIPTION
## Batch 6: Backend High — Distributed Lock & Remote Machine Permission

Fixes gaps #9 and #11 from issue #740.

### Changes

**Distributed lock (Gap #9)**
- Add `locked_at` / `locked_by` columns to `autonomous_workflows` DDL
- `acquire_lock(workflow_id, owner)`: atomic lock with 30-minute stale lock auto-break
- `release_lock(workflow_id, owner)`: only owner can release
- Scheduler `_advance_single` acquires lock before processing, releases after (even on error)
- Lock owner = `hostname/thread-name` for multi-instance coordination

**Remote machine admin validation (Gap #11)**
- `create_workflow` checks `_check_machine_admin()` for remote workflows
- Non-admin users must be machine admin to create remote workflows
- System admins bypass the check
- Local workflows are not affected

### Tests (12 new, 80 total for issue #740)
- 5 tests for distributed lock (acquire, fail, release, wrong owner, reentrant)
- 3 tests for scheduler lock integration (skip locked, normal flow, error flow)
- 4 tests for remote machine admin (reject, allow admin, local ok, machine admin ok)

### Dependencies
- Based on Batch 5 PR (#745)

🤖 Generated with [Claude Code](https://claude.com/claude-code)