### PR TITLE
feat: distributed lock and remote machine admin validation (#740 batch 6)

### DIFF
--- a/app/auth/decorators.py
+++ b/app/auth/decorators.py
@@ -96,6 +96,27 @@ def _check_machine_admin(user_id: int, machine_id: str) -> bool:
         return False
 
 
+# ── Public API for cross-module use ──────────────────────────────────
+
+
+def validate_session_token(token: str) -> dict | None:
+    """Validate a session token and return the user dict, or None if invalid.
+
+    Public wrapper for _load_user_from_token — use this instead of
+    importing the private function directly.
+    """
+    return _load_user_from_token(token)
+
+
+def check_machine_admin_permission(user_id: int, machine_id: str) -> bool:
+    """Check if a user has admin permission on a remote machine.
+
+    Public wrapper for _check_machine_admin — use this instead of
+    importing the private function directly.
+    """
+    return _check_machine_admin(user_id, machine_id)
+
+
 def auth_required(f=None, *, ownership=None):
     """
     Decorator: require authentication, optionally with ownership check.

--- a/app/modules/workspace/autonomous/__init__.py
+++ b/app/modules/workspace/autonomous/__init__.py
@@ -66,7 +66,11 @@ def get_ddl_statements():
             created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
             updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
             completed_at TIMESTAMP,
-            paused_at TIMESTAMP
+            paused_at TIMESTAMP,
+            locked_at TIMESTAMP,
+            locked_by TEXT DEFAULT '',
+            retry_count INTEGER DEFAULT 0,
+            task_timeout INTEGER
         )
         """,
         """

--- a/app/repositories/autonomous_repo.py
+++ b/app/repositories/autonomous_repo.py
@@ -7,7 +7,7 @@ Database operations for the AI autonomous development feature.
 
 import logging
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Optional
 
 from app.repositories.database import Database, is_postgresql
@@ -561,8 +561,7 @@ class AutonomousWorkflowRepository:
         now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
 
         cutoff = (
-            datetime.now(timezone.utc)
-            - __import__("datetime").timedelta(seconds=self.LOCK_TIMEOUT_SECONDS)
+            datetime.now(timezone.utc) - timedelta(seconds=self.LOCK_TIMEOUT_SECONDS)
         ).strftime("%Y-%m-%d %H:%M:%S")
 
         conn = self.db.get_connection()

--- a/app/repositories/autonomous_repo.py
+++ b/app/repositories/autonomous_repo.py
@@ -51,6 +51,8 @@ class AutonomousWorkflowRepository:
         "error_message",
         "retry_count",
         "task_timeout",
+        "locked_at",
+        "locked_by",
         "updated_at",
         "completed_at",
         "paused_at",
@@ -542,3 +544,64 @@ class AutonomousWorkflowRepository:
             "SELECT * FROM workflow_events WHERE workflow_id = ? ORDER BY created_at ASC LIMIT ? OFFSET ?",
             (workflow_id, limit, offset),
         )
+
+    # ── Distributed Lock ──────────────────────────────────────────────
+
+    # Lock timeout in seconds — stale locks are automatically cleared
+    LOCK_TIMEOUT_SECONDS = 1800  # 30 minutes
+
+    def acquire_lock(self, workflow_id: str, owner: str) -> bool:
+        """Atomically acquire a processing lock for a workflow.
+
+        Returns True if the lock was acquired, False if already locked.
+        Stale locks (older than LOCK_TIMEOUT_SECONDS) are broken automatically.
+        """
+        import app.repositories.database as _db_mod
+
+        now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+
+        cutoff = (
+            datetime.now(timezone.utc)
+            - __import__("datetime").timedelta(seconds=self.LOCK_TIMEOUT_SECONDS)
+        ).strftime("%Y-%m-%d %H:%M:%S")
+
+        conn = self.db.get_connection()
+        try:
+            cursor = conn.cursor()
+            cursor.execute(
+                _db_mod.adapt_sql(
+                    """
+                    UPDATE autonomous_workflows
+                    SET locked_at = ?, locked_by = ?
+                    WHERE workflow_id = ?
+                      AND (locked_at IS NULL OR locked_at < ?)
+                    """
+                ),
+                (now, owner, workflow_id, cutoff),
+            )
+            rowcount = cursor.rowcount
+            conn.commit()
+            return rowcount > 0
+        finally:
+            conn.close()
+
+    def release_lock(self, workflow_id: str, owner: str) -> None:
+        """Release the lock, but only if we are the owner."""
+        import app.repositories.database as _db_mod
+
+        conn = self.db.get_connection()
+        try:
+            cursor = conn.cursor()
+            cursor.execute(
+                _db_mod.adapt_sql(
+                    """
+                    UPDATE autonomous_workflows
+                    SET locked_at = NULL, locked_by = NULL
+                    WHERE workflow_id = ? AND locked_by = ?
+                    """
+                ),
+                (workflow_id, owner),
+            )
+            conn.commit()
+        finally:
+            conn.close()

--- a/app/routes/autonomous.py
+++ b/app/routes/autonomous.py
@@ -100,6 +100,19 @@ def create_workflow():
     if not _workflow_rate_limiter.is_allowed(user_id):
         return jsonify({"error": "Rate limit exceeded: max 10 workflows per hour"}), 429
 
+    # Validate remote machine admin permission
+    workspace_type = data.get("workspace_type", "local")
+    remote_machine_id = data.get("remote_machine_id", "")
+    if workspace_type == "remote" and remote_machine_id:
+        if g.user_role != "admin":
+            from app.auth.decorators import _check_machine_admin
+
+            if not _check_machine_admin(user_id, remote_machine_id):
+                return (
+                    jsonify({"error": "Machine admin permission required for remote workflows"}),
+                    403,
+                )
+
     # Validate required fields
     if not data.get("requirements_text") and not data.get("requirements_issue_url"):
         return jsonify({"error": "requirements_text or requirements_issue_url is required"}), 400

--- a/app/routes/autonomous.py
+++ b/app/routes/autonomous.py
@@ -16,7 +16,11 @@ import time
 
 from flask import Blueprint, Response, g, jsonify, request, stream_with_context
 
-from app.auth.decorators import _load_user_from_token, auth_required
+from app.auth.decorators import (
+    auth_required,
+    check_machine_admin_permission,
+    validate_session_token,
+)
 from app.repositories.autonomous_repo import AutonomousWorkflowRepository
 
 logger = logging.getLogger(__name__)
@@ -105,9 +109,7 @@ def create_workflow():
     remote_machine_id = data.get("remote_machine_id", "")
     if workspace_type == "remote" and remote_machine_id:
         if g.user_role != "admin":
-            from app.auth.decorators import _check_machine_admin
-
-            if not _check_machine_admin(user_id, remote_machine_id):
+            if not check_machine_admin_permission(user_id, remote_machine_id):
                 return (
                     jsonify({"error": "Machine admin permission required for remote workflows"}),
                     403,
@@ -595,7 +597,7 @@ def stream_workflow_events(workflow_id):
                     token = request.cookies.get("session_token") or request.headers.get(
                         "Authorization", ""
                     ).replace("Bearer ", "")
-                    if not token or not _load_user_from_token(token):
+                    if not token or not validate_session_token(token):
                         break  # Token invalid or revoked — close stream
                     emitter.mark_read(workflow_id, q)
                     yield ": keepalive\n\n"

--- a/app/services/autonomous_scheduler.py
+++ b/app/services/autonomous_scheduler.py
@@ -85,11 +85,11 @@ class AutonomousScheduler:
     def _advance_single(self, workflow_id: str) -> str:
         """Advance a single workflow. Returns workflow_id for tracking."""
         from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
-        from app.repositories.autonomous_repo import AutonomousWorkflowRepository
+        from app.routes.autonomous import _get_repo
 
         # Unique lock owner: hostname + thread name
         lock_owner = f"{socket.gethostname()}/{threading.current_thread().name}"
-        repo = AutonomousWorkflowRepository()
+        repo = _get_repo()
 
         # Acquire DB-level distributed lock
         if not repo.acquire_lock(workflow_id, lock_owner):
@@ -125,9 +125,9 @@ class AutonomousScheduler:
 
     def _process_workflows(self):
         """Find and process active workflows using thread pool for concurrency."""
-        from app.repositories.autonomous_repo import AutonomousWorkflowRepository
+        from app.routes.autonomous import _get_repo
 
-        repo = AutonomousWorkflowRepository()
+        repo = _get_repo()
 
         try:
             workflows = repo.get_active_workflows()

--- a/app/services/autonomous_scheduler.py
+++ b/app/services/autonomous_scheduler.py
@@ -9,6 +9,7 @@ Follows the same singleton pattern as DataFetchScheduler.
 from __future__ import annotations
 
 import logging
+import socket
 import threading
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import TYPE_CHECKING
@@ -84,6 +85,18 @@ class AutonomousScheduler:
     def _advance_single(self, workflow_id: str) -> str:
         """Advance a single workflow. Returns workflow_id for tracking."""
         from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+        from app.repositories.autonomous_repo import AutonomousWorkflowRepository
+
+        # Unique lock owner: hostname + thread name
+        lock_owner = f"{socket.gethostname()}/{threading.current_thread().name}"
+        repo = AutonomousWorkflowRepository()
+
+        # Acquire DB-level distributed lock
+        if not repo.acquire_lock(workflow_id, lock_owner):
+            logger.debug("Workflow %s is locked by another instance, skipping", workflow_id[:8])
+            with self._in_progress_lock:
+                self._in_progress_ids.discard(workflow_id)
+            return workflow_id
 
         orchestrator = None
         try:
@@ -101,6 +114,11 @@ class AutonomousScheduler:
         finally:
             with self._orchestrator_lock:
                 self._running_orchestrators.pop(workflow_id, None)
+            # Release DB lock
+            try:
+                repo.release_lock(workflow_id, lock_owner)
+            except Exception:
+                logger.warning("Failed to release lock for workflow %s", workflow_id[:8])
             with self._in_progress_lock:
                 self._in_progress_ids.discard(workflow_id)
         return workflow_id

--- a/tests/issues/740/test_batch1_session_wiring.py
+++ b/tests/issues/740/test_batch1_session_wiring.py
@@ -502,10 +502,7 @@ class TestSchedulerOrchestratorRegistry:
             patch(
                 "app.modules.workspace.autonomous.orchestrator.AutonomousOrchestrator"
             ) as mock_orch_cls,
-            patch(
-                "app.repositories.autonomous_repo.AutonomousWorkflowRepository",
-                return_value=mock_repo,
-            ),
+            patch("app.routes.autonomous._get_repo", return_value=mock_repo),
         ):
             mock_orch = MagicMock()
             mock_orch_cls.return_value = mock_orch
@@ -529,10 +526,7 @@ class TestSchedulerOrchestratorRegistry:
             patch(
                 "app.modules.workspace.autonomous.orchestrator.AutonomousOrchestrator"
             ) as mock_orch_cls,
-            patch(
-                "app.repositories.autonomous_repo.AutonomousWorkflowRepository",
-                return_value=mock_repo,
-            ),
+            patch("app.routes.autonomous._get_repo", return_value=mock_repo),
         ):
             mock_orch = MagicMock()
             mock_orch.advance.side_effect = RuntimeError("boom")
@@ -558,10 +552,7 @@ class TestSchedulerOrchestratorRegistry:
             patch(
                 "app.modules.workspace.autonomous.orchestrator.AutonomousOrchestrator"
             ) as mock_orch_cls,
-            patch(
-                "app.repositories.autonomous_repo.AutonomousWorkflowRepository",
-                return_value=mock_repo,
-            ),
+            patch("app.routes.autonomous._get_repo", return_value=mock_repo),
         ):
             mock_orch_cls.return_value = MagicMock()
             scheduler._advance_single(wf_id)
@@ -583,10 +574,7 @@ class TestSchedulerOrchestratorRegistry:
             patch(
                 "app.modules.workspace.autonomous.orchestrator.AutonomousOrchestrator"
             ) as mock_orch_cls,
-            patch(
-                "app.repositories.autonomous_repo.AutonomousWorkflowRepository",
-                return_value=mock_repo,
-            ),
+            patch("app.routes.autonomous._get_repo", return_value=mock_repo),
         ):
             mock_orch = MagicMock()
             mock_orch.advance.side_effect = Exception("fail")

--- a/tests/issues/740/test_batch1_session_wiring.py
+++ b/tests/issues/740/test_batch1_session_wiring.py
@@ -495,9 +495,18 @@ class TestSchedulerOrchestratorRegistry:
         scheduler = AutonomousScheduler()
         wf_id = "wf-reg-test"
 
-        with patch(
-            "app.modules.workspace.autonomous.orchestrator.AutonomousOrchestrator"
-        ) as mock_orch_cls:
+        mock_repo = MagicMock()
+        mock_repo.acquire_lock.return_value = True
+
+        with (
+            patch(
+                "app.modules.workspace.autonomous.orchestrator.AutonomousOrchestrator"
+            ) as mock_orch_cls,
+            patch(
+                "app.repositories.autonomous_repo.AutonomousWorkflowRepository",
+                return_value=mock_repo,
+            ),
+        ):
             mock_orch = MagicMock()
             mock_orch_cls.return_value = mock_orch
 
@@ -513,9 +522,18 @@ class TestSchedulerOrchestratorRegistry:
         scheduler = AutonomousScheduler()
         wf_id = "wf-error-test"
 
-        with patch(
-            "app.modules.workspace.autonomous.orchestrator.AutonomousOrchestrator"
-        ) as mock_orch_cls:
+        mock_repo = MagicMock()
+        mock_repo.acquire_lock.return_value = True
+
+        with (
+            patch(
+                "app.modules.workspace.autonomous.orchestrator.AutonomousOrchestrator"
+            ) as mock_orch_cls,
+            patch(
+                "app.repositories.autonomous_repo.AutonomousWorkflowRepository",
+                return_value=mock_repo,
+            ),
+        ):
             mock_orch = MagicMock()
             mock_orch.advance.side_effect = RuntimeError("boom")
             mock_orch_cls.return_value = mock_orch
@@ -533,9 +551,18 @@ class TestSchedulerOrchestratorRegistry:
         wf_id = "wf-cleanup-test"
         scheduler._in_progress_ids.add(wf_id)
 
-        with patch(
-            "app.modules.workspace.autonomous.orchestrator.AutonomousOrchestrator"
-        ) as mock_orch_cls:
+        mock_repo = MagicMock()
+        mock_repo.acquire_lock.return_value = True
+
+        with (
+            patch(
+                "app.modules.workspace.autonomous.orchestrator.AutonomousOrchestrator"
+            ) as mock_orch_cls,
+            patch(
+                "app.repositories.autonomous_repo.AutonomousWorkflowRepository",
+                return_value=mock_repo,
+            ),
+        ):
             mock_orch_cls.return_value = MagicMock()
             scheduler._advance_single(wf_id)
 
@@ -549,9 +576,18 @@ class TestSchedulerOrchestratorRegistry:
         wf_id = "wf-error-cleanup"
         scheduler._in_progress_ids.add(wf_id)
 
-        with patch(
-            "app.modules.workspace.autonomous.orchestrator.AutonomousOrchestrator"
-        ) as mock_orch_cls:
+        mock_repo = MagicMock()
+        mock_repo.acquire_lock.return_value = True
+
+        with (
+            patch(
+                "app.modules.workspace.autonomous.orchestrator.AutonomousOrchestrator"
+            ) as mock_orch_cls,
+            patch(
+                "app.repositories.autonomous_repo.AutonomousWorkflowRepository",
+                return_value=mock_repo,
+            ),
+        ):
             mock_orch = MagicMock()
             mock_orch.advance.side_effect = Exception("fail")
             mock_orch_cls.return_value = mock_orch

--- a/tests/issues/740/test_batch6_distributed_lock.py
+++ b/tests/issues/740/test_batch6_distributed_lock.py
@@ -1,0 +1,379 @@
+"""
+Batch 6 tests — Distributed lock, remote machine admin validation.
+
+Tests for:
+- acquire_lock / release_lock logic
+- Scheduler _advance_single uses distributed lock
+- Remote machine admin permission check in create_workflow
+"""
+
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+
+
+# ── Distributed Lock (unit tests with mocked DB) ────────────────────
+
+
+class TestDistributedLock(unittest.TestCase):
+    """Tests for acquire_lock / release_lock with real SQLite DB."""
+
+    def _make_repo(self, wf_id="wf-lock-test"):
+        """Create a repo backed by a fresh in-memory SQLite DB."""
+        import sqlite3
+
+        import app.repositories.database as db_mod
+
+        orig = db_mod.adapt_sql
+        db_mod.adapt_sql = lambda sql: sql
+
+        # Use in-memory SQLite to avoid file conflicts
+        mem_conn = sqlite3.connect(":memory:")
+        mem_conn.row_factory = sqlite3.Row
+
+        cursor = mem_conn.cursor()
+        cursor.execute(
+            "CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT UNIQUE NOT NULL, email TEXT UNIQUE NOT NULL, password_hash TEXT NOT NULL, role TEXT DEFAULT 'user', is_active INTEGER DEFAULT 1, created_at TEXT, updated_at TEXT)"
+        )
+        cursor.execute(
+            "INSERT OR IGNORE INTO users (username, email, password_hash, role) VALUES (?, ?, ?, ?)",
+            ("admin", "admin@test.com", "hash123", "admin"),
+        )
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS autonomous_workflows (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                workflow_id TEXT NOT NULL UNIQUE,
+                user_id INTEGER,
+                status TEXT DEFAULT 'pending',
+                cli_tool TEXT DEFAULT '',
+                locked_at TEXT,
+                locked_by TEXT DEFAULT ''
+            )
+            """
+        )
+        cursor.execute(
+            "INSERT INTO autonomous_workflows (workflow_id, user_id, status, cli_tool) VALUES (?, ?, ?, ?)",
+            (wf_id, 1, "pending", "claude-code"),
+        )
+        mem_conn.commit()
+
+        # Wrap in Database-like object with close() as no-op
+        mock_db = MagicMock()
+        mock_db._is_postgresql = False
+        # Return a connection that doesn't actually close (in-memory shared)
+        mock_conn = MagicMock(wraps=mem_conn)
+        mock_conn.close = MagicMock()  # no-op close
+        mock_db.get_connection.return_value = mock_conn
+
+        from app.repositories.autonomous_repo import AutonomousWorkflowRepository
+
+        repo = AutonomousWorkflowRepository(mock_db)
+        return repo, mem_conn, orig, db_mod
+
+    def tearDown(self):
+        if hasattr(self, "_conn"):
+            self._conn.close()
+        if hasattr(self, "_db_mod"):
+            self._db_mod.adapt_sql = self._orig
+
+    def test_acquire_lock_success(self):
+        """Should acquire lock when not held."""
+        repo, conn, orig, db_mod = self._make_repo("wf-ok")
+        self._conn, self._orig, self._db_mod = conn, orig, db_mod
+        result = repo.acquire_lock("wf-ok", "owner-1")
+        self.assertTrue(result)
+
+    def test_acquire_lock_fails_when_held(self):
+        """Should fail to acquire lock when already held by another owner."""
+        repo, conn, orig, db_mod = self._make_repo("wf-held")
+        self._conn, self._orig, self._db_mod = conn, orig, db_mod
+        repo.acquire_lock("wf-held", "owner-1")
+        result = repo.acquire_lock("wf-held", "owner-2")
+        self.assertFalse(result)
+
+    def test_release_lock_by_owner(self):
+        """Owner can release their own lock."""
+        repo, conn, orig, db_mod = self._make_repo("wf-release")
+        self._conn, self._orig, self._db_mod = conn, orig, db_mod
+        repo.acquire_lock("wf-release", "owner-1")
+        repo.release_lock("wf-release", "owner-1")
+        result = repo.acquire_lock("wf-release", "owner-2")
+        self.assertTrue(result)
+
+    def test_release_lock_wrong_owner_noop(self):
+        """Releasing with wrong owner should not clear the lock."""
+        repo, conn, orig, db_mod = self._make_repo("wf-wrong")
+        self._conn, self._orig, self._db_mod = conn, orig, db_mod
+        repo.acquire_lock("wf-wrong", "owner-1")
+        repo.release_lock("wf-wrong", "wrong-owner")
+        result = repo.acquire_lock("wf-wrong", "owner-2")
+        self.assertFalse(result)
+
+    def test_reentrant_lock_by_same_owner(self):
+        """Same owner can re-acquire after release."""
+        repo, conn, orig, db_mod = self._make_repo("wf-reentrant")
+        self._conn, self._orig, self._db_mod = conn, orig, db_mod
+        repo.acquire_lock("wf-reentrant", "owner-1")
+        repo.release_lock("wf-reentrant", "owner-1")
+        result = repo.acquire_lock("wf-reentrant", "owner-1")
+        self.assertTrue(result)
+
+
+class TestSchedulerLockIntegration(unittest.TestCase):
+    """Tests for scheduler _advance_single using distributed lock."""
+
+    def test_skips_locked_workflow(self):
+        """_advance_single should skip if lock cannot be acquired."""
+        from app.services.autonomous_scheduler import AutonomousScheduler
+
+        scheduler = AutonomousScheduler()
+        wf_id = "wf-locked"
+
+        mock_repo = MagicMock()
+        mock_repo.acquire_lock.return_value = False
+
+        with patch(
+            "app.repositories.autonomous_repo.AutonomousWorkflowRepository", return_value=mock_repo
+        ):
+            scheduler._advance_single(wf_id)
+
+        mock_repo.release_lock.assert_not_called()
+
+    def test_acquires_and_releases_lock(self):
+        """_advance_single should acquire and release lock in normal flow."""
+        from app.services.autonomous_scheduler import AutonomousScheduler
+
+        scheduler = AutonomousScheduler()
+        wf_id = "wf-normal"
+
+        mock_repo = MagicMock()
+        mock_repo.acquire_lock.return_value = True
+
+        with (
+            patch(
+                "app.modules.workspace.autonomous.orchestrator.AutonomousOrchestrator"
+            ) as mock_orch_cls,
+            patch(
+                "app.repositories.autonomous_repo.AutonomousWorkflowRepository",
+                return_value=mock_repo,
+            ),
+        ):
+            mock_orch_cls.return_value = MagicMock()
+            scheduler._advance_single(wf_id)
+
+        mock_repo.acquire_lock.assert_called_once()
+        mock_repo.release_lock.assert_called_once()
+
+    def test_releases_lock_on_error(self):
+        """_advance_single should release lock even on orchestrator error."""
+        from app.services.autonomous_scheduler import AutonomousScheduler
+
+        scheduler = AutonomousScheduler()
+        wf_id = "wf-error"
+
+        mock_repo = MagicMock()
+        mock_repo.acquire_lock.return_value = True
+
+        with (
+            patch(
+                "app.modules.workspace.autonomous.orchestrator.AutonomousOrchestrator"
+            ) as mock_orch_cls,
+            patch(
+                "app.repositories.autonomous_repo.AutonomousWorkflowRepository",
+                return_value=mock_repo,
+            ),
+        ):
+            mock_orch = MagicMock()
+            mock_orch.advance.side_effect = RuntimeError("boom")
+            mock_orch_cls.return_value = mock_orch
+            scheduler._advance_single(wf_id)
+
+        mock_repo.release_lock.assert_called_once()
+
+
+# ── Remote Machine Admin Validation ─────────────────────────────────
+
+
+class TestRemoteMachineAdminValidation(unittest.TestCase):
+    """Tests for remote machine admin permission check in create_workflow."""
+
+    def _make_client(self):
+        import app.repositories.database as db_mod
+
+        db_path = tempfile.mktemp(suffix=".db")
+        orig = db_mod.adapt_sql
+        db_mod.adapt_sql = lambda sql: sql
+
+        db = db_mod.Database(db_path)
+        with db.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT UNIQUE NOT NULL, email TEXT UNIQUE NOT NULL, password_hash TEXT NOT NULL, role TEXT DEFAULT 'user', is_active INTEGER DEFAULT 1, created_at TEXT, updated_at TEXT)"
+            )
+            cursor.execute(
+                "INSERT OR IGNORE INTO users (username, email, password_hash, role) VALUES (?, ?, ?, ?)",
+                ("admin", "admin@test.com", "hash123", "admin"),
+            )
+            cursor.execute(
+                "INSERT OR IGNORE INTO users (username, email, password_hash, role) VALUES (?, ?, ?, ?)",
+                ("testuser", "user@test.com", "hash123", "user"),
+            )
+            from app.modules.workspace.autonomous import get_ddl_statements
+
+            for sql in get_ddl_statements():
+                cursor.execute(sql)
+            conn.commit()
+
+        from app import create_app
+
+        app = create_app({"TESTING": True})
+        c = app.test_client()
+        c.set_cookie("session_token", "test-token")
+        return c, db_path, orig, db_mod
+
+    def _mock_auth(self, user_id=1, role="admin"):
+        return patch(
+            "app.auth.decorators._load_user_from_token",
+            return_value={
+                "id": user_id,
+                "username": "admin" if role == "admin" else "testuser",
+                "email": f"{role}@test.com",
+                "role": role,
+            },
+        )
+
+    def test_rejects_non_admin_remote_workflow(self):
+        """Non-admin user without machine admin permission should be rejected."""
+        c, db_path, orig, db_mod = self._make_client()
+        try:
+            mock_repo = MagicMock()
+            mock_repo.create_workflow.return_value = {"workflow_id": "wf-1"}
+
+            with self._mock_auth(user_id=2, role="user"):
+                with patch("app.routes.autonomous._get_repo", return_value=mock_repo):
+                    with patch("app.auth.decorators._check_machine_admin", return_value=False):
+                        resp = c.post(
+                            "/api/autonomous/workflows",
+                            json={
+                                "requirements_text": "test",
+                                "cli_tool": "claude-code",
+                                "project_path": "/tmp/project",
+                                "workspace_type": "remote",
+                                "remote_machine_id": "machine-123",
+                            },
+                        )
+
+            self.assertEqual(resp.status_code, 403)
+            data = resp.get_json()
+            self.assertIn("machine admin", data["error"].lower())
+        finally:
+            db_mod.adapt_sql = orig
+            try:
+                os.unlink(db_path)
+            except OSError:
+                pass
+
+    def test_allows_admin_remote_workflow(self):
+        """System admin should be able to create remote workflows."""
+        c, db_path, orig, db_mod = self._make_client()
+        try:
+            mock_repo = MagicMock()
+            mock_repo.create_workflow.return_value = {
+                "workflow_id": "wf-1",
+                "title": "",
+            }
+
+            with self._mock_auth(user_id=1, role="admin"):
+                with patch("app.routes.autonomous._get_repo", return_value=mock_repo):
+                    with patch("app.routes.autonomous._get_event_emitter"):
+                        resp = c.post(
+                            "/api/autonomous/workflows",
+                            json={
+                                "requirements_text": "test",
+                                "cli_tool": "claude-code",
+                                "project_path": "/tmp/project",
+                                "workspace_type": "remote",
+                                "remote_machine_id": "machine-123",
+                            },
+                        )
+
+            self.assertEqual(resp.status_code, 201)
+        finally:
+            db_mod.adapt_sql = orig
+            try:
+                os.unlink(db_path)
+            except OSError:
+                pass
+
+    def test_allows_local_workflow_without_check(self):
+        """Local workflows should not require machine admin check."""
+        c, db_path, orig, db_mod = self._make_client()
+        try:
+            mock_repo = MagicMock()
+            mock_repo.create_workflow.return_value = {
+                "workflow_id": "wf-1",
+                "title": "",
+            }
+
+            with self._mock_auth(user_id=2, role="user"):
+                with patch("app.routes.autonomous._get_repo", return_value=mock_repo):
+                    with patch("app.routes.autonomous._get_event_emitter"):
+                        resp = c.post(
+                            "/api/autonomous/workflows",
+                            json={
+                                "requirements_text": "test",
+                                "cli_tool": "claude-code",
+                                "project_path": "/tmp/project",
+                                "workspace_type": "local",
+                            },
+                        )
+
+            self.assertEqual(resp.status_code, 201)
+        finally:
+            db_mod.adapt_sql = orig
+            try:
+                os.unlink(db_path)
+            except OSError:
+                pass
+
+    def test_allows_machine_admin_remote_workflow(self):
+        """Machine admin (non-system admin) should be able to create remote workflows."""
+        c, db_path, orig, db_mod = self._make_client()
+        try:
+            mock_repo = MagicMock()
+            mock_repo.create_workflow.return_value = {
+                "workflow_id": "wf-1",
+                "title": "",
+            }
+
+            with self._mock_auth(user_id=2, role="user"):
+                with patch("app.routes.autonomous._get_repo", return_value=mock_repo):
+                    with patch("app.auth.decorators._check_machine_admin", return_value=True):
+                        with patch("app.routes.autonomous._get_event_emitter"):
+                            resp = c.post(
+                                "/api/autonomous/workflows",
+                                json={
+                                    "requirements_text": "test",
+                                    "cli_tool": "claude-code",
+                                    "project_path": "/tmp/project",
+                                    "workspace_type": "remote",
+                                    "remote_machine_id": "machine-123",
+                                },
+                            )
+
+            self.assertEqual(resp.status_code, 201)
+        finally:
+            db_mod.adapt_sql = orig
+            try:
+                os.unlink(db_path)
+            except OSError:
+                pass
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/issues/740/test_batch6_distributed_lock.py
+++ b/tests/issues/740/test_batch6_distributed_lock.py
@@ -137,9 +137,7 @@ class TestSchedulerLockIntegration(unittest.TestCase):
         mock_repo = MagicMock()
         mock_repo.acquire_lock.return_value = False
 
-        with patch(
-            "app.repositories.autonomous_repo.AutonomousWorkflowRepository", return_value=mock_repo
-        ):
+        with patch("app.routes.autonomous._get_repo", return_value=mock_repo):
             scheduler._advance_single(wf_id)
 
         mock_repo.release_lock.assert_not_called()
@@ -158,10 +156,7 @@ class TestSchedulerLockIntegration(unittest.TestCase):
             patch(
                 "app.modules.workspace.autonomous.orchestrator.AutonomousOrchestrator"
             ) as mock_orch_cls,
-            patch(
-                "app.repositories.autonomous_repo.AutonomousWorkflowRepository",
-                return_value=mock_repo,
-            ),
+            patch("app.routes.autonomous._get_repo", return_value=mock_repo),
         ):
             mock_orch_cls.return_value = MagicMock()
             scheduler._advance_single(wf_id)
@@ -183,10 +178,7 @@ class TestSchedulerLockIntegration(unittest.TestCase):
             patch(
                 "app.modules.workspace.autonomous.orchestrator.AutonomousOrchestrator"
             ) as mock_orch_cls,
-            patch(
-                "app.repositories.autonomous_repo.AutonomousWorkflowRepository",
-                return_value=mock_repo,
-            ),
+            patch("app.routes.autonomous._get_repo", return_value=mock_repo),
         ):
             mock_orch = MagicMock()
             mock_orch.advance.side_effect = RuntimeError("boom")


### PR DESCRIPTION
## Batch 6: 分布式锁与远程机器权限校验

Fixes gaps #9, #11 from issue #740.

### Changes
- DB-level distributed lock (acquire_lock/release_lock) with stale lock timeout
- Remote machine admin permission check on workflow creation
- Public API in decorators.py (validate_session_token, check_machine_admin_permission)
- Scheduler uses lazy _get_repo() singleton
- `from datetime import timedelta` replaces `__import__`
- Scheduler tests updated to mock _get_repo()

### Tests
88 tests passing (all batches combined).