### PR TITLE
fix: harden agent connection trust boundary — stale _connections and unvalidated register

### DIFF
--- a/app/modules/workspace/remote_agent_manager.py
+++ b/app/modules/workspace/remote_agent_manager.py
@@ -170,6 +170,20 @@ class RemoteAgentManager:
             if updated > 0:
                 logger.info(f"Marked {updated} machines offline due to heartbeat timeout")
 
+            # Remove stale entries from _connections for machines offline
+            # beyond heartbeat timeout, so is_connected() stays accurate
+            cursor.execute(
+                "SELECT machine_id FROM remote_machines "
+                f"WHERE status = 'offline' AND last_heartbeat < {_param()}",
+                (heartbeat_cutoff.isoformat(),),
+            )
+            stale_machines = [r["machine_id"] for r in cursor.fetchall()]
+            if stale_machines:
+                with self._lock:
+                    for mid in stale_machines:
+                        self._connections.pop(mid, None)
+                logger.info(f"Pruned {len(stale_machines)} stale connections from _connections")
+
             # Clean up sessions on offline machines that exceed recovery window
             cursor.execute(
                 "SELECT s.session_id FROM agent_sessions s "

--- a/app/routes/remote.py
+++ b/app/routes/remote.py
@@ -875,6 +875,10 @@ def agent_message():
         return jsonify({"error": "machine_id is required"}), 400
 
     if msg_type == "register":
+        # Validate machine exists in DB before allowing registration
+        machine = agent_mgr.get_machine(machine_id)
+        if not machine:
+            return jsonify({"error": "Unknown machine_id"}), 404
         # Agent re-registering on reconnect
         agent_mgr.register_connection(machine_id, None)
         capabilities = data.get("capabilities", {})


### PR DESCRIPTION
## Summary

Fixes #679 — hardens the agent connection trust boundary with two targeted fixes.

### Fix 1: `_check_heartbeats` prunes stale `_connections` entries
- After marking machines offline in DB, now also removes them from the in-memory `_connections` dict
- Prevents `is_connected()` / `is_agent_connected()` from returning `True` for offline machines

### Fix 2: `register` message validates `machine_id` against DB
- The `register` branch in `agent_message` now calls `get_machine(machine_id)` first
- Returns `404` for unknown `machine_id`, preventing arbitrary registration

## Testing
- All 1439 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)