### PR TITLE
feat: add config toggle for autonomous development feature (#762)

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -259,9 +259,14 @@ def start_background_services():
         logger.warning(f"Failed to start quota enforcement scheduler: {e}")
 
     try:
-        from app.services.autonomous_scheduler import init_autonomous_scheduler
+        from app.utils.config import is_autonomous_enabled
 
-        init_autonomous_scheduler()
+        if is_autonomous_enabled():
+            from app.services.autonomous_scheduler import init_autonomous_scheduler
+
+            init_autonomous_scheduler()
+        else:
+            logger.info("Autonomous scheduler disabled by configuration")
     except Exception as e:
         logger.warning(f"Failed to start autonomous scheduler: {e}")
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -267,6 +267,9 @@ def start_background_services():
             init_autonomous_scheduler()
         else:
             logger.info("Autonomous scheduler disabled by configuration")
+            logger.info(
+                "To enable: set autonomous.enabled=true in config.json and restart the server"
+            )
     except Exception as e:
         logger.warning(f"Failed to start autonomous scheduler: {e}")
 

--- a/app/routes/autonomous.py
+++ b/app/routes/autonomous.py
@@ -42,6 +42,22 @@ def _get_repo() -> AutonomousWorkflowRepository:
 
 autonomous_bp = Blueprint("autonomous", __name__)
 
+
+# ── Feature Toggle Guard ─────────────────────────────────────────────
+
+
+@autonomous_bp.before_request
+def check_autonomous_enabled():
+    """Reject all requests if autonomous development feature is disabled."""
+    from app.utils.config import is_autonomous_enabled
+
+    if not is_autonomous_enabled():
+        return (
+            jsonify({"error": "Autonomous development feature is disabled", "disabled": True}),
+            403,
+        )
+
+
 # ── Rate Limiter ─────────────────────────────────────────────────────
 
 

--- a/app/routes/workspace.py
+++ b/app/routes/workspace.py
@@ -1950,6 +1950,7 @@ def get_workspace_config():
             "max_instances": 30,
             "idle_timeout_minutes": 30,
             "base_dir": base_dir,  # For path validation in frontend
+            "autonomous_enabled": False,
         }
 
         if os.path.exists(config_path):
@@ -1964,10 +1965,22 @@ def get_workspace_config():
                 workspace_config["max_instances"] = workspace.get("max_instances", 30)
                 workspace_config["idle_timeout_minutes"] = workspace.get("idle_timeout_minutes", 30)
 
+            # Expose autonomous feature status
+            autonomous_config = config.get("autonomous", {})
+            workspace_config["autonomous_enabled"] = autonomous_config.get("enabled", False)
+
         return jsonify(workspace_config)
     except Exception as e:
         logger.error(f"Error getting workspace config: {e}")
-        return jsonify({"enabled": False, "url": "", "multi_user_mode": False, "base_dir": "/home"})
+        return jsonify(
+            {
+                "enabled": False,
+                "url": "",
+                "multi_user_mode": False,
+                "base_dir": "/home",
+                "autonomous_enabled": False,
+            }
+        )
 
 
 # ==================== Multi-User WebUI ====================

--- a/app/utils/config.py
+++ b/app/utils/config.py
@@ -1,0 +1,42 @@
+"""
+Configuration utility for reading values from ~/.open-ace/config.json.
+"""
+
+import json
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+
+def get_config_value(section: str, key: str, default=None):
+    """Read a value from ~/.open-ace/config.json.
+
+    Returns the value at config[section][key], or `default` if the
+    file, section, or key does not exist.
+
+    Args:
+        section: Top-level config section (e.g. "workspace", "autonomous").
+        key: Key within the section (e.g. "enabled").
+        default: Fallback value if the file, section, or key is missing.
+
+    Returns:
+        The config value, or `default`.
+    """
+    from app.repositories.database import CONFIG_DIR
+
+    config_path = os.path.join(CONFIG_DIR, "config.json")
+    if not os.path.exists(config_path):
+        return default
+    try:
+        with open(config_path) as f:
+            config = json.load(f)
+        return config.get(section, {}).get(key, default)
+    except Exception as e:
+        logger.warning(f"Error reading config [{section}][{key}]: {e}")
+        return default
+
+
+def is_autonomous_enabled() -> bool:
+    """Check whether the autonomous development feature is enabled."""
+    return bool(get_config_value("autonomous", "enabled", False))

--- a/app/utils/config.py
+++ b/app/utils/config.py
@@ -1,19 +1,63 @@
 """
 Configuration utility for reading values from ~/.open-ace/config.json.
+
+Configuration changes require a server restart to take full effect:
+the autonomous scheduler is started once at boot and cannot be toggled
+at runtime. The API guard reads the cached value (refreshed every 60 s)
+to allow near-immediate enforcement of a disable toggle without restart.
 """
+
+from __future__ import annotations
 
 import json
 import logging
 import os
+import threading
+import time
+from typing import Any
 
 logger = logging.getLogger(__name__)
+
+# ── Simple TTL cache ──────────────────────────────────────────────────
+# Avoids reading config.json from disk on every HTTP request while still
+# allowing runtime config changes to propagate within ~60 seconds.
+
+_cache_lock = threading.Lock()
+_cache: dict[str, tuple[float, dict[str, Any]]] = {}
+_cache_ttl: float = 60.0  # seconds
+
+
+def _read_config() -> dict[str, Any]:
+    """Return the parsed config.json, with a 60-second TTL in-memory cache."""
+    now = time.time()
+    with _cache_lock:
+        entry = _cache.get("_root")
+        if entry is not None:
+            ts, data = entry
+            if now - ts < _cache_ttl:
+                return data
+    # Cache miss — read from disk
+    from app.repositories.database import CONFIG_DIR
+
+    config_path = os.path.join(CONFIG_DIR, "config.json")
+    result: dict[str, Any] = {}
+    if os.path.exists(config_path):
+        try:
+            with open(config_path) as f:
+                result = json.load(f)
+        except Exception as e:
+            logger.warning("Error reading config.json: %s", e)
+    with _cache_lock:
+        _cache["_root"] = (now, result)
+    return result
 
 
 def get_config_value(section: str, key: str, default=None):
     """Read a value from ~/.open-ace/config.json.
 
-    Returns the value at config[section][key], or `default` if the
-    file, section, or key does not exist.
+    Returns the value at config[section][key], or ``default`` if the
+    file, section, or key does not exist.  Results are cached for up
+    to 60 seconds.
 
     Args:
         section: Top-level config section (e.g. "workspace", "autonomous").
@@ -21,20 +65,10 @@ def get_config_value(section: str, key: str, default=None):
         default: Fallback value if the file, section, or key is missing.
 
     Returns:
-        The config value, or `default`.
+        The config value, or ``default``.
     """
-    from app.repositories.database import CONFIG_DIR
-
-    config_path = os.path.join(CONFIG_DIR, "config.json")
-    if not os.path.exists(config_path):
-        return default
-    try:
-        with open(config_path) as f:
-            config = json.load(f)
-        return config.get(section, {}).get(key, default)
-    except Exception as e:
-        logger.warning(f"Error reading config [{section}][{key}]: {e}")
-        return default
+    config = _read_config()
+    return config.get(section, {}).get(key, default)
 
 
 def is_autonomous_enabled() -> bool:

--- a/config/CONFIG_GUIDE.md
+++ b/config/CONFIG_GUIDE.md
@@ -54,6 +54,14 @@
 | `workspace.idle_timeout_minutes` | 空闲实例自动关闭时间（分钟） | `30` |
 | `workspace.token_secret` | Token 签名密钥（建议使用强随机字符串） | `your-secret-key` |
 
+### Autonomous（AI 自主开发）
+
+> ⚠️ 修改此配置后需要重启服务器才能生效。
+
+| 参数 | 说明 | 默认值 |
+|------|------|--------|
+| `autonomous.enabled` | 是否启用 AI 自主开发功能 | `false` |
+
 **多用户模式说明：**
 
 多用户模式下，Open ACE 会为每个用户启动独立的 `qwen-code-webui` 进程，以该用户的 `system_account` 身份运行。这确保了：

--- a/config/config.json.sample
+++ b/config/config.json.sample
@@ -22,6 +22,9 @@
     "token_secret": "",
     "webui_path": ""
   },
+  "autonomous": {
+    "enabled": false
+  },
   "tools": {
     "openclaw": {
       "enabled": true,

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -232,6 +232,7 @@ const LegacyAppContent: React.FC = () => {
 // Work Mode Routes
 const WorkRoutes: React.FC = () => {
   const location = useLocation();
+  const autonomousEnabled = useAppStore((state) => state.autonomousEnabled);
   const isWorkspaceRoute =
     location.pathname === '/work' ||
     location.pathname === '/work/' ||
@@ -261,7 +262,7 @@ const WorkRoutes: React.FC = () => {
           <Route path="prompts" element={<Prompts />} />
           <Route path="usage" element={<UsageOverview />} />
           <Route path="insights" element={<InsightsReport />} />
-          <Route path="autonomous" element={<AutonomousDev />} />
+          {autonomousEnabled && <Route path="autonomous" element={<AutonomousDev />} />}
           {/* Explicit /workspace route for session restore */}
           <Route path="workspace" element={null} />
           <Route path="*" element={<Navigate to="/work" replace />} />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,7 +17,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Layout, WorkLayout, ManageLayout } from '@/components/layout';
 import { Login } from '@/components/features/Login';
 import { LogoutSuccess } from '@/components/features/LogoutSuccess';
-import { LoadingOverlay, PageSkeleton } from '@/components/common';
+import { LoadingOverlay, PageSkeleton, useToast } from '@/components/common';
 import {
   ContextMenuProvider,
   useContextMenu,
@@ -229,6 +229,20 @@ const LegacyAppContent: React.FC = () => {
   );
 };
 
+// Redirect component shown when autonomous feature is disabled
+const AutonomousDisabledRedirect: React.FC = () => {
+  const navigate = useNavigate();
+  const language = useAppStore((state) => state.language);
+  const toast = useToast();
+
+  useEffect(() => {
+    toast.error(t('autoFeatureDisabled', language));
+    navigate('/work', { replace: true });
+  }, [navigate, language, toast]);
+
+  return null;
+};
+
 // Work Mode Routes
 const WorkRoutes: React.FC = () => {
   const location = useLocation();
@@ -262,7 +276,11 @@ const WorkRoutes: React.FC = () => {
           <Route path="prompts" element={<Prompts />} />
           <Route path="usage" element={<UsageOverview />} />
           <Route path="insights" element={<InsightsReport />} />
-          {autonomousEnabled && <Route path="autonomous" element={<AutonomousDev />} />}
+          {autonomousEnabled ? (
+            <Route path="autonomous" element={<AutonomousDev />} />
+          ) : (
+            <Route path="autonomous" element={<AutonomousDisabledRedirect />} />
+          )}
           {/* Explicit /workspace route for session restore */}
           <Route path="workspace" element={null} />
           <Route path="*" element={<Navigate to="/work" replace />} />

--- a/frontend/src/api/workspace.ts
+++ b/frontend/src/api/workspace.ts
@@ -13,6 +13,7 @@ export interface WorkspaceConfig {
   port_range_end: number;
   max_instances: number;
   idle_timeout_minutes: number;
+  autonomous_enabled: boolean;
 }
 
 export interface UserWebUIResponse {
@@ -76,6 +77,7 @@ export const workspaceApi = {
         port_range_end: 3200,
         max_instances: 30,
         idle_timeout_minutes: 30,
+        autonomous_enabled: false,
       };
     }
   },

--- a/frontend/src/components/layout/WorkLayout.tsx
+++ b/frontend/src/components/layout/WorkLayout.tsx
@@ -18,7 +18,7 @@ import { useNavigate, useLocation } from 'react-router-dom';
 import { cn } from '@/utils';
 import { useLanguage, useAppStore, useWorkspaceFullscreen } from '@/store';
 import { t } from '@/i18n';
-import { ModeSwitcher, useToast } from '@/components/common';
+import { ModeSwitcher } from '@/components/common';
 import { Header } from './Header';
 import { SessionList, AssistPanel, StatusBar } from '@/components/work';
 import { workspaceApi } from '@/api/workspace';
@@ -59,7 +59,6 @@ export const WorkLayout: React.FC<WorkLayoutProps> = ({ children }) => {
     autonomousEnabled,
     setAutonomousEnabled,
   } = useAppStore();
-  const toast = useToast();
 
   // Load workspace config on mount to determine feature flags
   useEffect(() => {
@@ -73,17 +72,6 @@ export const WorkLayout: React.FC<WorkLayoutProps> = ({ children }) => {
     };
     loadConfig();
   }, [setAutonomousEnabled]);
-
-  // Redirect away from /work/autonomous when feature is disabled
-  useEffect(() => {
-    if (
-      !autonomousEnabled &&
-      location.pathname.startsWith('/work/autonomous')
-    ) {
-      toast.error(t('autoFeatureDisabled', language));
-      navigate('/work', { replace: true });
-    }
-  }, [autonomousEnabled, location.pathname, navigate, language, toast]);
 
   // Filter nav items based on feature flags
   const visibleNavItems = autonomousEnabled

--- a/frontend/src/components/layout/WorkLayout.tsx
+++ b/frontend/src/components/layout/WorkLayout.tsx
@@ -21,6 +21,7 @@ import { t } from '@/i18n';
 import { ModeSwitcher } from '@/components/common';
 import { Header } from './Header';
 import { SessionList, AssistPanel, StatusBar } from '@/components/work';
+import { workspaceApi } from '@/api/workspace';
 
 interface NavItem {
   id: string;
@@ -51,8 +52,31 @@ export const WorkLayout: React.FC<WorkLayoutProps> = ({ children }) => {
 
   // Fullscreen state from global store
   const workspaceFullscreen = useWorkspaceFullscreen();
-  const { exitWorkspaceFullscreen, previousLeftPanelCollapsed, previousRightPanelCollapsed } =
-    useAppStore();
+  const {
+    exitWorkspaceFullscreen,
+    previousLeftPanelCollapsed,
+    previousRightPanelCollapsed,
+    autonomousEnabled,
+    setAutonomousEnabled,
+  } = useAppStore();
+
+  // Load workspace config on mount to determine feature flags
+  useEffect(() => {
+    const loadConfig = async () => {
+      try {
+        const config = await workspaceApi.getConfig();
+        setAutonomousEnabled(config.autonomous_enabled);
+      } catch {
+        // Config fetch failed, keep defaults (autonomousEnabled = false)
+      }
+    };
+    loadConfig();
+  }, [setAutonomousEnabled]);
+
+  // Filter nav items based on feature flags
+  const visibleNavItems = autonomousEnabled
+    ? workNavItems
+    : workNavItems.filter((item) => item.id !== 'autonomous');
 
   // Get active nav item from path
   const getActiveNavItem = () => {
@@ -62,7 +86,7 @@ export const WorkLayout: React.FC<WorkLayoutProps> = ({ children }) => {
     if (path.startsWith('/work/prompts')) return 'prompts';
     if (path.startsWith('/work/usage')) return 'usage';
     if (path.startsWith('/work/insights')) return 'insights';
-    if (path.startsWith('/work/autonomous')) return 'autonomous';
+    if (path.startsWith('/work/autonomous')) return autonomousEnabled ? 'autonomous' : 'workspace';
     return 'workspace';
   };
 
@@ -133,7 +157,7 @@ export const WorkLayout: React.FC<WorkLayoutProps> = ({ children }) => {
 
           {/* Work Navigation */}
           <nav className="work-nav">
-            {workNavItems.map((item) => (
+            {visibleNavItems.map((item) => (
               <button
                 key={item.id}
                 className={cn('work-nav-item', activeNavItem === item.id && 'active')}

--- a/frontend/src/components/layout/WorkLayout.tsx
+++ b/frontend/src/components/layout/WorkLayout.tsx
@@ -18,7 +18,7 @@ import { useNavigate, useLocation } from 'react-router-dom';
 import { cn } from '@/utils';
 import { useLanguage, useAppStore, useWorkspaceFullscreen } from '@/store';
 import { t } from '@/i18n';
-import { ModeSwitcher } from '@/components/common';
+import { ModeSwitcher, useToast } from '@/components/common';
 import { Header } from './Header';
 import { SessionList, AssistPanel, StatusBar } from '@/components/work';
 import { workspaceApi } from '@/api/workspace';
@@ -59,6 +59,7 @@ export const WorkLayout: React.FC<WorkLayoutProps> = ({ children }) => {
     autonomousEnabled,
     setAutonomousEnabled,
   } = useAppStore();
+  const toast = useToast();
 
   // Load workspace config on mount to determine feature flags
   useEffect(() => {
@@ -72,6 +73,17 @@ export const WorkLayout: React.FC<WorkLayoutProps> = ({ children }) => {
     };
     loadConfig();
   }, [setAutonomousEnabled]);
+
+  // Redirect away from /work/autonomous when feature is disabled
+  useEffect(() => {
+    if (
+      !autonomousEnabled &&
+      location.pathname.startsWith('/work/autonomous')
+    ) {
+      toast.error(t('autoFeatureDisabled', language));
+      navigate('/work', { replace: true });
+    }
+  }, [autonomousEnabled, location.pathname, navigate, language, toast]);
 
   // Filter nav items based on feature flags
   const visibleNavItems = autonomousEnabled

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -885,6 +885,7 @@ const translations: Record<Language, Translations> = {
     // AI Autonomous Development
     autonomousDev: 'AI Autonomous Dev',
     autonomousDevEmpty: 'Create an autonomous development task to let AI develop independently.',
+    autoFeatureDisabled: 'Autonomous development feature is not enabled',
     autoNewTask: 'New Task',
     autoCreateFirstTask: 'Create First Task',
     autoNoWorkflows: 'No autonomous tasks yet',
@@ -1829,6 +1830,7 @@ const translations: Record<Language, Translations> = {
     // AI自主开发
     autonomousDev: 'AI自主开发',
     autonomousDevEmpty: '创建自主开发任务，让 AI 独立完成开发工作。',
+    autoFeatureDisabled: '自主开发功能未启用',
     autoNewTask: '新建任务',
     autoCreateFirstTask: '创建首个任务',
     autoNoWorkflows: '暂无自主开发任务',
@@ -2477,6 +2479,7 @@ const translations: Record<Language, Translations> = {
     // AI自律開発
     autonomousDev: 'AI自律開発',
     autonomousDevEmpty: '自律開発タスクを作成して、AIが独立して開発します。',
+    autoFeatureDisabled: '自律開発機能が有効ではありません',
     autoNewTask: '新規タスク',
     autoCreateFirstTask: '最初のタスクを作成',
     autoNoWorkflows: '自律開発タスクはまだありません',
@@ -3123,6 +3126,7 @@ const translations: Record<Language, Translations> = {
     // AI 자율 개발
     autonomousDev: 'AI 자율 개발',
     autonomousDevEmpty: '자율 개발 작업을 생성하여 AI가 독립적으로 개발합니다.',
+    autoFeatureDisabled: '자율 개발 기능이 활성화되지 않았습니다',
     autoNewTask: '새 작업',
     autoCreateFirstTask: '첫 작업 생성',
     autoNoWorkflows: '자율 개발 작업이 없습니다',

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -68,6 +68,9 @@ interface AppState {
   // File changes panel visibility setting (Issue #144)
   showFileChangesPanel: boolean;
 
+  // Feature flags
+  autonomousEnabled: boolean;
+
   // Actions
   setUser: (user: User | null) => void;
   setAuthenticated: (isAuthenticated: boolean) => void;
@@ -105,6 +108,9 @@ interface AppState {
   // File changes panel actions (Issue #144)
   setShowFileChangesPanel: (enabled: boolean) => void;
   toggleFileChangesPanel: () => void;
+
+  // Feature flag actions
+  setAutonomousEnabled: (enabled: boolean) => void;
 }
 
 export const useAppStore = create<AppState>()(
@@ -137,6 +143,9 @@ export const useAppStore = create<AppState>()(
 
       // File changes panel visibility (Issue #144)
       showFileChangesPanel: true,
+
+      // Feature flags
+      autonomousEnabled: false,
 
       // Actions
       setUser: (user) => set({ user }),
@@ -241,6 +250,9 @@ export const useAppStore = create<AppState>()(
       setShowFileChangesPanel: (enabled) => set({ showFileChangesPanel: enabled }),
       toggleFileChangesPanel: () =>
         set((state) => ({ showFileChangesPanel: !state.showFileChangesPanel })),
+
+      // Feature flag actions
+      setAutonomousEnabled: (enabled) => set({ autonomousEnabled: enabled }),
     }),
     {
       name: 'open-ace-store',

--- a/tests/issues/762/test_autonomous_config.py
+++ b/tests/issues/762/test_autonomous_config.py
@@ -1,0 +1,217 @@
+"""
+Tests for autonomous development feature toggle (Issue #762).
+
+Covers:
+- app/utils/config.py: get_config_value, is_autonomous_enabled, TTL cache
+- app/routes/autonomous.py: before_request guard (403 / pass-through)
+- app/routes/workspace.py: /api/workspace/config includes autonomous_enabled
+"""
+
+import json
+import os
+from unittest.mock import patch
+
+import pytest
+
+import app.repositories.database as db_mod
+import app.utils.config as cfg_mod
+
+# ── Fixtures ──────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def config_dir(tmp_path):
+    """Create a temporary config directory for config.json."""
+    d = tmp_path / "open-ace"
+    d.mkdir()
+    return d
+
+
+@pytest.fixture
+def config_file(config_dir):
+    """Return the config.json path inside the temp config directory."""
+    return config_dir / "config.json"
+
+
+@pytest.fixture(autouse=True)
+def _clear_config_cache():
+    """Clear the TTL cache between tests so each test starts fresh."""
+    with cfg_mod._cache_lock:
+        cfg_mod._cache.clear()
+    yield
+    with cfg_mod._cache_lock:
+        cfg_mod._cache.clear()
+
+
+def _patch_config_dir(config_dir):
+    """Patch CONFIG_DIR in both the database module and the config module."""
+    return patch.object(db_mod, "CONFIG_DIR", str(config_dir))
+
+
+# ── get_config_value tests ───────────────────────────────────────────────
+
+
+class TestGetConfigValue:
+    def test_reads_existing_value(self, config_file, config_dir):
+        config_file.write_text(json.dumps({"workspace": {"enabled": True}}))
+        with _patch_config_dir(config_dir):
+            assert cfg_mod.get_config_value("workspace", "enabled", False) is True
+
+    def test_returns_default_when_file_missing(self, tmp_path):
+        missing_dir = tmp_path / "nonexistent"
+        with _patch_config_dir(missing_dir):
+            assert cfg_mod.get_config_value("workspace", "enabled", False) is False
+
+    def test_returns_default_when_section_missing(self, config_file, config_dir):
+        config_file.write_text(json.dumps({"workspace": {"enabled": True}}))
+        with _patch_config_dir(config_dir):
+            assert cfg_mod.get_config_value("autonomous", "enabled", False) is False
+
+    def test_returns_default_when_key_missing(self, config_file, config_dir):
+        config_file.write_text(json.dumps({"autonomous": {}}))
+        with _patch_config_dir(config_dir):
+            assert cfg_mod.get_config_value("autonomous", "enabled", False) is False
+
+    def test_returns_default_on_invalid_json(self, config_file, config_dir):
+        config_file.write_text("not valid json {{{")
+        with _patch_config_dir(config_dir):
+            assert cfg_mod.get_config_value("autonomous", "enabled", False) is False
+
+
+# ── is_autonomous_enabled tests ──────────────────────────────────────────
+
+
+class TestIsAutonomousEnabled:
+    def test_default_false(self, config_file, config_dir):
+        config_file.write_text(json.dumps({}))
+        with _patch_config_dir(config_dir):
+            assert cfg_mod.is_autonomous_enabled() is False
+
+    def test_explicit_true(self, config_file, config_dir):
+        config_file.write_text(json.dumps({"autonomous": {"enabled": True}}))
+        with _patch_config_dir(config_dir):
+            assert cfg_mod.is_autonomous_enabled() is True
+
+    def test_explicit_false(self, config_file, config_dir):
+        config_file.write_text(json.dumps({"autonomous": {"enabled": False}}))
+        with _patch_config_dir(config_dir):
+            assert cfg_mod.is_autonomous_enabled() is False
+
+
+# ── TTL cache tests ──────────────────────────────────────────────────────
+
+
+class TestConfigCache:
+    def test_cache_avoids_repeated_disk_reads(self, config_file, config_dir):
+        config_file.write_text(json.dumps({"autonomous": {"enabled": True}}))
+        with _patch_config_dir(config_dir):
+            assert cfg_mod.is_autonomous_enabled() is True
+            # Change file on disk — cache should still return True
+            config_file.write_text(json.dumps({"autonomous": {"enabled": False}}))
+            assert cfg_mod.is_autonomous_enabled() is True
+
+    def test_cache_expires_after_ttl(self, config_file, config_dir):
+        config_file.write_text(json.dumps({"autonomous": {"enabled": True}}))
+        with _patch_config_dir(config_dir), patch.object(cfg_mod, "_cache_ttl", 0.0):
+            assert cfg_mod.is_autonomous_enabled() is True
+            # TTL=0 means cache always expires — next read hits disk
+            config_file.write_text(json.dumps({"autonomous": {"enabled": False}}))
+            assert cfg_mod.is_autonomous_enabled() is False
+
+
+# ── before_request guard tests ───────────────────────────────────────────
+
+
+class TestAutonomousBeforeRequest:
+    @pytest.fixture
+    def app(self):
+        """Create a minimal Flask app with autonomous blueprint."""
+        from flask import Flask, jsonify
+
+        app = Flask(__name__)
+        app.config["TESTING"] = True
+
+        # Create a fresh blueprint to avoid "already registered" errors
+        from flask import Blueprint
+
+        bp = Blueprint("autonomous_test", __name__)
+
+        @bp.before_request
+        def check_autonomous_enabled():
+            from app.utils.config import is_autonomous_enabled
+
+            if not is_autonomous_enabled():
+                return (
+                    jsonify(
+                        {"error": "Autonomous development feature is disabled", "disabled": True}
+                    ),
+                    403,
+                )
+
+        @bp.route("/test-ping")
+        def test_ping():
+            return jsonify({"ok": True})
+
+        app.register_blueprint(bp, url_prefix="/api/autonomous")
+        return app
+
+    def test_disabled_returns_403(self, app, config_file, config_dir):
+        config_file.write_text(json.dumps({"autonomous": {"enabled": False}}))
+        with _patch_config_dir(config_dir):
+            with cfg_mod._cache_lock:
+                cfg_mod._cache.clear()
+            with app.test_client() as client:
+                resp = client.get("/api/autonomous/test-ping")
+                assert resp.status_code == 403
+                data = resp.get_json()
+                assert data["disabled"] is True
+
+    def test_enabled_passes_through(self, app, config_file, config_dir):
+        config_file.write_text(json.dumps({"autonomous": {"enabled": True}}))
+        with _patch_config_dir(config_dir):
+            with cfg_mod._cache_lock:
+                cfg_mod._cache.clear()
+            with app.test_client() as client:
+                resp = client.get("/api/autonomous/test-ping")
+                assert resp.status_code == 200
+                assert resp.get_json()["ok"] is True
+
+
+# ── workspace config endpoint tests ──────────────────────────────────────
+
+
+class TestWorkspaceConfigAutonomousField:
+    def test_autonomous_enabled_true_in_config(self, config_file, config_dir):
+        config_file.write_text(
+            json.dumps({"workspace": {"enabled": False}, "autonomous": {"enabled": True}})
+        )
+        with _patch_config_dir(config_dir):
+            # Simulate the logic from get_workspace_config()
+            config_path = os.path.join(str(config_dir), "config.json")
+            with open(config_path) as f:
+                config = json.load(f)
+            autonomous_config = config.get("autonomous", {})
+            result = autonomous_config.get("enabled", False)
+            assert result is True
+
+    def test_autonomous_enabled_false_when_missing(self, config_file, config_dir):
+        config_file.write_text(json.dumps({"workspace": {"enabled": False}}))
+        with _patch_config_dir(config_dir):
+            config_path = os.path.join(str(config_dir), "config.json")
+            with open(config_path) as f:
+                config = json.load(f)
+            autonomous_config = config.get("autonomous", {})
+            result = autonomous_config.get("enabled", False)
+            assert result is False
+
+    def test_autonomous_enabled_false_when_explicit(self, config_file, config_dir):
+        config_file.write_text(
+            json.dumps({"workspace": {"enabled": True}, "autonomous": {"enabled": False}})
+        )
+        with _patch_config_dir(config_dir):
+            config_path = os.path.join(str(config_dir), "config.json")
+            with open(config_path) as f:
+                config = json.load(f)
+            autonomous_config = config.get("autonomous", {})
+            result = autonomous_config.get("enabled", False)
+            assert result is False


### PR DESCRIPTION
## Summary

Add `autonomous.enabled` boolean toggle to `config.json` to control whether the AI autonomous development feature is available.

Closes #762

## Changes

### Backend
- **`config/config.json.sample`** — 新增 `autonomous` 配置段（默认 `false`）
- **`app/utils/config.py`** — 新建配置读取工具（`get_config_value()` + `is_autonomous_enabled()`）
- **`app/__init__.py`** — 调度器启动守卫，禁用时不启动 scheduler
- **`app/routes/autonomous.py`** — `before_request` 守卫，禁用时所有端点返回 403
- **`app/routes/workspace.py`** — `/api/workspace/config` 响应暴露 `autonomous_enabled` 字段

### Frontend
- **`frontend/src/api/workspace.ts`** — `WorkspaceConfig` 接口新增 `autonomous_enabled`
- **`frontend/src/store/index.ts`** — Zustand Store 新增 `autonomousEnabled` 状态
- **`frontend/src/components/layout/WorkLayout.tsx`** — mount 时加载配置，条件过滤导航项
- **`frontend/src/App.tsx`** — 条件渲染 autonomous 路由
- **`frontend/src/i18n/index.ts`** — 新增 `autoFeatureDisabled` 翻译（en/zh/ja/ko）

## Behavior

When `autonomous.enabled = false` (default):
- ✅ Autonomous scheduler does NOT start
- ✅ All `/api/autonomous/*` endpoints return `403 {"error": "...", "disabled": true}`
- ✅ Frontend hides the "自主开发" nav item
- ✅ Direct URL `/work/autonomous` redirects to `/work`

When `autonomous.enabled = true`:
- ✅ Feature works normally as before

## Configuration

Add to `~/.open-ace/config.json`:
```json
{
  "autonomous": {
    "enabled": true
  }
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)