### PR TITLE
fix: autonomous workflow token=0, session not created, multi-tool usage parsing (#764)

### DIFF
--- a/app/modules/workspace/autonomous/agent_runner.py
+++ b/app/modules/workspace/autonomous/agent_runner.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 # mypy: disable-error-code="assignment,arg-type,union-attr,var-annotated"
 """
 Open ACE - Autonomous Agent Runner
@@ -17,11 +19,22 @@ import threading
 import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Optional
 
 from app.modules.workspace.autonomous.models import AgentTaskResult
 
 logger = logging.getLogger(__name__)
+
+
+def _extract_usage(cli_tool: str, parsed: dict) -> dict[str, int] | None:
+    """Dispatch to the correct usage extractor based on cli_tool."""
+    from cli_adapters.usage_parser import extract_claude_stream_usage, extract_qwen_stream_usage
+
+    if cli_tool == "qwen-code-cli":
+        result: dict[str, int] | None = extract_qwen_stream_usage(parsed)  # type: ignore[no-any-return]
+        return result
+    result2: dict[str, int] | None = extract_claude_stream_usage(parsed)  # type: ignore[no-any-return]
+    return result2
+
 
 # Default timeout for agent tasks — configurable via env var (default 1 hour)
 try:
@@ -37,6 +50,7 @@ class _LocalSession:
 
     session_id: str
     process: subprocess.Popen
+    cli_tool: str = "claude-code"
     output_lines: list[str] = field(default_factory=list)
     assistant_text: str = ""
     tool_calls: list[dict] = field(default_factory=list)
@@ -44,10 +58,10 @@ class _LocalSession:
     total_input_tokens: int = 0
     total_output_tokens: int = 0
     completed: threading.Event = field(default_factory=threading.Event)
-    error: Optional[str] = None
+    error: str | None = None
     _stopped: threading.Event = field(default_factory=threading.Event)
-    _stdout_thread: Optional[threading.Thread] = None
-    _stderr_thread: Optional[threading.Thread] = None
+    _stdout_thread: threading.Thread | None = None
+    _stderr_thread: threading.Thread | None = None
 
 
 class AutonomousAgentRunner:
@@ -240,7 +254,7 @@ class AutonomousAgentRunner:
                 error=f"Failed to start process: {e}",
             )
 
-        session = _LocalSession(session_id=session_id, process=process)
+        session = _LocalSession(session_id=session_id, process=process, cli_tool=cli_tool)
         self._local_sessions[session_id] = session
 
         # Start output reader threads
@@ -482,16 +496,11 @@ class AutonomousAgentRunner:
                         session.tool_calls.append(parsed)
 
                     elif msg_type == "result":
-                        # End of turn - extract usage
-                        data = parsed.get("data", {})
-                        usage = data.get("usage") or data.get("message", {}).get("usage", {})
-                        if isinstance(usage, dict):
-                            session.total_input_tokens += usage.get(
-                                "input_tokens", usage.get("input", 0)
-                            )
-                            session.total_output_tokens += usage.get(
-                                "output_tokens", usage.get("output", 0)
-                            )
+                        # End of turn - extract usage via shared parser
+                        usage = _extract_usage(session.cli_tool, parsed)
+                        if usage:
+                            session.total_input_tokens += usage["input"]
+                            session.total_output_tokens += usage["output"]
                         session.total_tokens = (
                             session.total_input_tokens + session.total_output_tokens
                         )

--- a/app/modules/workspace/autonomous/agent_runner.py
+++ b/app/modules/workspace/autonomous/agent_runner.py
@@ -19,21 +19,24 @@ import threading
 import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any
 
 from app.modules.workspace.autonomous.models import AgentTaskResult
 
 logger = logging.getLogger(__name__)
 
 
-def _extract_usage(cli_tool: str, parsed: dict) -> dict[str, int] | None:
-    """Dispatch to the correct usage extractor based on cli_tool."""
-    from cli_adapters.usage_parser import extract_claude_stream_usage, extract_qwen_stream_usage
+# Cached import — populated on first call to _run_local() which adds remote-agent to sys.path
+_extract_stream_usage: Any = None
 
-    if cli_tool == "qwen-code-cli":
-        result: dict[str, int] | None = extract_qwen_stream_usage(parsed)  # type: ignore[no-any-return]
-        return result
-    result2: dict[str, int] | None = extract_claude_stream_usage(parsed)  # type: ignore[no-any-return]
-    return result2
+
+def _ensure_usage_parser():
+    """Import extract_stream_usage once remote-agent is on sys.path."""
+    global _extract_stream_usage
+    if _extract_stream_usage is None:
+        from cli_adapters.usage_parser import extract_stream_usage
+
+        _extract_stream_usage = extract_stream_usage
 
 
 # Default timeout for agent tasks — configurable via env var (default 1 hour)
@@ -207,6 +210,9 @@ class AutonomousAgentRunner:
         if _remote_agent_dir not in sys.path:
             sys.path.insert(0, _remote_agent_dir)
         from cli_adapters import get_adapter
+
+        # Cache the usage parser now that remote-agent is on sys.path
+        _ensure_usage_parser()
 
         # Find executable
         adapter = get_adapter(cli_tool)
@@ -497,7 +503,7 @@ class AutonomousAgentRunner:
 
                     elif msg_type == "result":
                         # End of turn - extract usage via shared parser
-                        usage = _extract_usage(session.cli_tool, parsed)
+                        usage = _extract_stream_usage(session.cli_tool, parsed)
                         if usage:
                             session.total_input_tokens += usage["input"]
                             session.total_output_tokens += usage["output"]

--- a/app/modules/workspace/remote_session_manager.py
+++ b/app/modules/workspace/remote_session_manager.py
@@ -157,6 +157,8 @@ class RemoteSessionManager:
             model=model,
             project_path=project_path,
             session_id=session_id,
+            workspace_type="remote",
+            remote_machine_id=machine_id,
         )
 
         # Generate proxy token for this session

--- a/app/modules/workspace/session_manager.py
+++ b/app/modules/workspace/session_manager.py
@@ -393,6 +393,8 @@ class SessionManager:
         project_id: Optional[int] = None,
         project_path: Optional[str] = None,
         session_id: Optional[str] = None,
+        workspace_type: str = "local",
+        remote_machine_id: Optional[str] = None,
     ) -> AgentSession:
         """
         Create a new agent session.
@@ -450,6 +452,8 @@ class SessionManager:
             expires_at=expires_at,
             created_at=now,
             updated_at=now,
+            workspace_type=workspace_type,
+            remote_machine_id=remote_machine_id,
         )
 
         conn = self._get_connection()
@@ -460,8 +464,9 @@ class SessionManager:
             INSERT INTO agent_sessions
             (session_id, session_type, title, tool_name, host_name, user_id, project_id,
              project_path, status, context, settings, model, expires_at, created_at, updated_at,
-             request_count, total_tokens, total_input_tokens, total_output_tokens, message_count)
-            VALUES ({_params(20)})
+             request_count, total_tokens, total_input_tokens, total_output_tokens, message_count,
+             workspace_type, remote_machine_id)
+            VALUES ({_params(22)})
         """,
             (
                 session.session_id,
@@ -484,6 +489,8 @@ class SessionManager:
                 session.total_input_tokens or 0,
                 session.total_output_tokens or 0,
                 session.message_count or 0,
+                session.workspace_type or "local",
+                session.remote_machine_id,
             ),
         )
 

--- a/remote-agent/cli_adapters/usage_parser.py
+++ b/remote-agent/cli_adapters/usage_parser.py
@@ -53,3 +53,18 @@ def extract_qwen_stream_usage(parsed: dict[str, Any]) -> dict[str, int] | None:
         input_t = max(0, input_t - cached)
         return {"input": input_t, "output": output_t}
     return None
+
+
+# Known tools that use the Qwen usage format
+_QWEN_TOOLS = {"qwen-code-cli"}
+
+
+def extract_stream_usage(cli_tool: str, parsed: dict[str, Any]) -> dict[str, int] | None:
+    """Dispatch to the correct usage extractor based on *cli_tool*.
+
+    This is the single entry-point that both ``executor.py`` and
+    ``agent_runner.py`` should use.
+    """
+    if cli_tool in _QWEN_TOOLS:
+        return extract_qwen_stream_usage(parsed)
+    return extract_claude_stream_usage(parsed)

--- a/remote-agent/cli_adapters/usage_parser.py
+++ b/remote-agent/cli_adapters/usage_parser.py
@@ -1,0 +1,55 @@
+"""
+Shared stream-json usage extraction for CLI tool output.
+
+Each CLI tool (Claude Code, Qwen Code, etc.) emits a different JSON format
+for token usage in its ``type: "result"`` message.  This module centralises
+the extraction logic so that both the remote-agent executor and the
+autonomous agent_runner can reuse it.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def extract_claude_stream_usage(parsed: dict[str, Any]) -> dict[str, int] | None:
+    """Extract token usage from a Claude Code stream-json result message.
+
+    Claude Code ``--print --output-format stream-json --verbose`` emits:
+
+    .. code-block:: json
+
+        {"type": "result", "usage": {"input_tokens": N, "output_tokens": M}}
+
+    Older builds may nest under ``data.usage`` or ``data.message.usage``.
+    """
+    usage = parsed.get("usage")
+    if not isinstance(usage, dict):
+        data = parsed.get("data", {})
+        usage = data.get("usage") or (data.get("message", {}) or {}).get("usage")
+    if isinstance(usage, dict):
+        return {
+            "input": usage.get("input_tokens", usage.get("input", 0)),
+            "output": usage.get("output_tokens", usage.get("output", 0)),
+        }
+    return None
+
+
+def extract_qwen_stream_usage(parsed: dict[str, Any]) -> dict[str, int] | None:
+    """Extract token usage from a Qwen Code stream-json result message.
+
+    Qwen Code may use either the Claude-compatible ``usage`` dict or its own
+    ``usageMetadata`` with ``promptTokenCount`` / ``candidatesTokenCount``.
+    """
+    usage = parsed.get("usage") or parsed.get("usageMetadata")
+    if not isinstance(usage, dict):
+        data = parsed.get("data", {})
+        usage = data.get("usage") or data.get("usageMetadata")
+    if isinstance(usage, dict):
+        input_t: int = usage.get("input_tokens", usage.get("promptTokenCount", 0))
+        output_t: int = usage.get("output_tokens", usage.get("candidatesTokenCount", 0))
+        # Deduct cached tokens if present (Qwen-specific)
+        cached: int = usage.get("cachedContentTokenCount", 0)
+        input_t = max(0, input_t - cached)
+        return {"input": input_t, "output": output_t}
+    return None

--- a/remote-agent/executor.py
+++ b/remote-agent/executor.py
@@ -74,7 +74,6 @@ class SessionProcess:
         from cli_adapters.usage_parser import extract_stream_usage
 
         self._extract_stream_usage = extract_stream_usage
-        self._restart_lock = threading.Lock()  # Prevents concurrent restarts
         self._paused = False
         self._pause_lock = threading.Lock()
 

--- a/remote-agent/executor.py
+++ b/remote-agent/executor.py
@@ -169,18 +169,11 @@ class SessionProcess:
 
                         # Handle result messages — extract token usage
                         if msg_type == "result" and self.usage_callback:
-                            data = parsed.get("data", {})
-                            usage = data.get("usage")
-                            if not usage:
-                                msg = data.get("message", {})
-                                usage = msg.get("usage")
-                            if usage and isinstance(usage, dict):
-                                tokens = {
-                                    "input": usage.get("input_tokens", usage.get("input", 0)),
-                                    "output": usage.get("output_tokens", usage.get("output", 0)),
-                                }
-                                if tokens["input"] or tokens["output"]:
-                                    self.usage_callback(self.session_id, tokens)
+                            from cli_adapters.usage_parser import extract_claude_stream_usage
+
+                            tokens = extract_claude_stream_usage(parsed)
+                            if tokens and (tokens["input"] or tokens["output"]):
+                                self.usage_callback(self.session_id, tokens)
                     except (json.JSONDecodeError, ValueError):
                         pass
 

--- a/remote-agent/executor.py
+++ b/remote-agent/executor.py
@@ -169,9 +169,9 @@ class SessionProcess:
 
                         # Handle result messages — extract token usage
                         if msg_type == "result" and self.usage_callback:
-                            from cli_adapters.usage_parser import extract_claude_stream_usage
+                            from cli_adapters.usage_parser import extract_stream_usage
 
-                            tokens = extract_claude_stream_usage(parsed)
+                            tokens = extract_stream_usage(self.cli_tool, parsed)
                             if tokens and (tokens["input"] or tokens["output"]):
                                 self.usage_callback(self.session_id, tokens)
                     except (json.JSONDecodeError, ValueError):

--- a/remote-agent/executor.py
+++ b/remote-agent/executor.py
@@ -69,6 +69,12 @@ class SessionProcess:
         self._stderr_thread: threading.Thread | None = None
         self._stopped = threading.Event()
         self._restart_lock = threading.Lock()  # Prevents concurrent restarts
+
+        # Cache the usage parser at init time (avoids per-message import)
+        from cli_adapters.usage_parser import extract_stream_usage
+
+        self._extract_stream_usage = extract_stream_usage
+        self._restart_lock = threading.Lock()  # Prevents concurrent restarts
         self._paused = False
         self._pause_lock = threading.Lock()
 
@@ -169,9 +175,7 @@ class SessionProcess:
 
                         # Handle result messages — extract token usage
                         if msg_type == "result" and self.usage_callback:
-                            from cli_adapters.usage_parser import extract_stream_usage
-
-                            tokens = extract_stream_usage(self.cli_tool, parsed)
+                            tokens = self._extract_stream_usage(self.cli_tool, parsed)
                             if tokens and (tokens["input"] or tokens["output"]):
                                 self.usage_callback(self.session_id, tokens)
                     except (json.JSONDecodeError, ValueError):

--- a/remote-agent/install.ps1
+++ b/remote-agent/install.ps1
@@ -89,7 +89,7 @@ $files = @(
     "openace_cli.py",
     "cli_settings.py"
 )
-$adapterFiles = @("__init__.py", "base.py", "qwen_code.py", "claude_code.py", "codex_cli.py", "codex_jsonl_parser.py", "openclaw.py")
+$adapterFiles = @("__init__.py", "base.py", "qwen_code.py", "claude_code.py", "codex_cli.py", "codex_jsonl_parser.py", "openclaw.py", "usage_parser.py")
 
 foreach ($file in $files) {
     $downloaded = $false

--- a/remote-agent/install.sh
+++ b/remote-agent/install.sh
@@ -188,7 +188,7 @@ else
         done
         # Download CLI adapters
         mkdir -p "${INSTALL_DIR}/cli_adapters"
-        for file in __init__.py base.py qwen_code.py claude_code.py codex_cli.py codex_jsonl_parser.py openclaw.py; do
+        for file in __init__.py base.py qwen_code.py claude_code.py codex_cli.py codex_jsonl_parser.py openclaw.py usage_parser.py; do
             curl -fsSL "${AGENT_URL}/cli_adapters/${file}" -o "${INSTALL_DIR}/cli_adapters/${file}" 2>/dev/null || {
                 log_warn "Could not download cli_adapters/${file}"
             }

--- a/tests/issues/764/test_session_create_params.py
+++ b/tests/issues/764/test_session_create_params.py
@@ -1,0 +1,76 @@
+"""Tests for session_manager.create_session() workspace_type/remote_machine_id (Issue #764)."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+class TestCreateSessionAcceptsWorkspaceParams:
+    """Verify create_session() accepts workspace_type and remote_machine_id."""
+
+    def _make_session_manager(self):
+        from app.modules.workspace.session_manager import SessionManager
+
+        sm = SessionManager.__new__(SessionManager)
+        sm.get_session = MagicMock(return_value=None)
+
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_cursor.lastrowid = 1
+        mock_conn.cursor.return_value = mock_cursor
+        mock_conn.commit.return_value = None
+        mock_conn.close.return_value = None
+        sm._get_connection = MagicMock(return_value=mock_conn)
+        return sm
+
+    def test_create_session_with_workspace_type(self):
+        sm = self._make_session_manager()
+        session = sm.create_session(
+            tool_name="claude-code",
+            title="Autonomous: test",
+            project_path="/tmp/test",
+            workspace_type="remote",
+            remote_machine_id="machine-123",
+        )
+        assert session is not None
+        assert session.workspace_type == "remote"
+        assert session.remote_machine_id == "machine-123"
+
+    def test_create_session_defaults_to_local(self):
+        sm = self._make_session_manager()
+        session = sm.create_session(tool_name="claude-code", title="Test session")
+        assert session.workspace_type == "local"
+        assert session.remote_machine_id is None
+
+    def test_create_session_includes_workspace_in_insert(self):
+        sm = self._make_session_manager()
+        sm.create_session(
+            tool_name="qwen-code-cli",
+            workspace_type="remote",
+            remote_machine_id="abc-def",
+        )
+        mock_cursor = sm._get_connection.return_value.cursor.return_value
+        mock_cursor.execute.assert_called_once()
+        call_args = mock_cursor.execute.call_args
+        sql = call_args[0][0]
+        params = list(call_args[0][1])
+        assert "workspace_type" in sql
+        assert "remote_machine_id" in sql
+        assert "remote" in params
+        assert "abc-def" in params
+
+    def test_create_session_type_error_fixed(self):
+        sm = self._make_session_manager()
+        try:
+            sm.create_session(
+                session_id="test-session-id",
+                session_type="chat",
+                title="Autonomous: abc12345",
+                tool_name="claude-code",
+                project_path="/tmp/project",
+                workspace_type="local",
+                remote_machine_id=None,
+                context={"workflow_id": "test-wf"},
+            )
+        except TypeError as e:
+            pytest.fail(f"create_session raised TypeError (bug not fixed): {e}")

--- a/tests/issues/764/test_usage_parser.py
+++ b/tests/issues/764/test_usage_parser.py
@@ -1,0 +1,137 @@
+"""Tests for shared stream-json usage extraction (Issue #764)."""
+
+import os
+import sys
+
+import pytest
+
+# Add remote-agent to path so we can import cli_adapters
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "..", "remote-agent"))
+
+from cli_adapters.usage_parser import extract_claude_stream_usage, extract_qwen_stream_usage
+
+
+class TestExtractClaudeStreamUsage:
+    """Test Claude Code stream-json result message parsing."""
+
+    def test_usage_at_top_level(self):
+        parsed = {
+            "type": "result",
+            "subtype": "success",
+            "usage": {"input_tokens": 8112, "output_tokens": 5},
+        }
+        result = extract_claude_stream_usage(parsed)
+        assert result is not None
+        assert result["input"] == 8112
+        assert result["output"] == 5
+
+    def test_usage_nested_in_data(self):
+        parsed = {
+            "type": "result",
+            "data": {"usage": {"input_tokens": 3000, "output_tokens": 100}},
+        }
+        result = extract_claude_stream_usage(parsed)
+        assert result is not None
+        assert result["input"] == 3000
+        assert result["output"] == 100
+
+    def test_usage_nested_in_data_message(self):
+        parsed = {
+            "type": "result",
+            "data": {"message": {"usage": {"input_tokens": 500, "output_tokens": 50}}},
+        }
+        result = extract_claude_stream_usage(parsed)
+        assert result is not None
+        assert result["input"] == 500
+        assert result["output"] == 50
+
+    def test_no_usage(self):
+        parsed = {"type": "result", "subtype": "success"}
+        result = extract_claude_stream_usage(parsed)
+        assert result is None
+
+    def test_usage_with_legacy_keys(self):
+        parsed = {"type": "result", "usage": {"input": 1000, "output": 200}}
+        result = extract_claude_stream_usage(parsed)
+        assert result is not None
+        assert result["input"] == 1000
+        assert result["output"] == 200
+
+    def test_top_level_takes_priority_over_data(self):
+        parsed = {
+            "type": "result",
+            "usage": {"input_tokens": 100, "output_tokens": 10},
+            "data": {"usage": {"input_tokens": 999, "output_tokens": 99}},
+        }
+        result = extract_claude_stream_usage(parsed)
+        assert result is not None
+        assert result["input"] == 100
+        assert result["output"] == 10
+
+    def test_empty_usage_dict(self):
+        parsed = {"type": "result", "usage": {}}
+        result = extract_claude_stream_usage(parsed)
+        assert result is not None
+        assert result["input"] == 0
+        assert result["output"] == 0
+
+
+class TestExtractQwenStreamUsage:
+    """Test Qwen Code stream-json result message parsing."""
+
+    def test_claude_compatible_format(self):
+        parsed = {"type": "result", "usage": {"input_tokens": 5000, "output_tokens": 300}}
+        result = extract_qwen_stream_usage(parsed)
+        assert result is not None
+        assert result["input"] == 5000
+        assert result["output"] == 300
+
+    def test_qwen_usage_metadata_format(self):
+        parsed = {
+            "type": "result",
+            "usageMetadata": {"promptTokenCount": 4000, "candidatesTokenCount": 200},
+        }
+        result = extract_qwen_stream_usage(parsed)
+        assert result is not None
+        assert result["input"] == 4000
+        assert result["output"] == 200
+
+    def test_qwen_with_cached_tokens(self):
+        parsed = {
+            "type": "result",
+            "usageMetadata": {
+                "promptTokenCount": 5000,
+                "candidatesTokenCount": 200,
+                "cachedContentTokenCount": 3000,
+            },
+        }
+        result = extract_qwen_stream_usage(parsed)
+        assert result is not None
+        assert result["input"] == 2000
+        assert result["output"] == 200
+
+    def test_qwen_nested_in_data(self):
+        parsed = {
+            "type": "result",
+            "data": {"usageMetadata": {"promptTokenCount": 1000, "candidatesTokenCount": 100}},
+        }
+        result = extract_qwen_stream_usage(parsed)
+        assert result is not None
+        assert result["input"] == 1000
+        assert result["output"] == 100
+
+    def test_qwen_no_usage(self):
+        parsed = {"type": "result", "subtype": "success"}
+        result = extract_qwen_stream_usage(parsed)
+        assert result is None
+
+    def test_top_level_takes_priority(self):
+        parsed = {
+            "type": "result",
+            "usage": {"input_tokens": 100, "output_tokens": 10},
+            "data": {"usage": {"input_tokens": 999, "output_tokens": 99}},
+        }
+        result = extract_qwen_stream_usage(parsed)
+        assert result is not None
+        assert result["input"] == 100
+        assert result["output"] == 10

--- a/tests/issues/764/test_usage_parser.py
+++ b/tests/issues/764/test_usage_parser.py
@@ -8,7 +8,11 @@ import pytest
 # Add remote-agent to path so we can import cli_adapters
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "..", "remote-agent"))
 
-from cli_adapters.usage_parser import extract_claude_stream_usage, extract_qwen_stream_usage
+from cli_adapters.usage_parser import (
+    extract_claude_stream_usage,
+    extract_qwen_stream_usage,
+    extract_stream_usage,
+)
 
 
 class TestExtractClaudeStreamUsage:
@@ -135,3 +139,28 @@ class TestExtractQwenStreamUsage:
         assert result is not None
         assert result["input"] == 100
         assert result["output"] == 10
+
+
+class TestExtractStreamUsageDispatch:
+    """Test the dispatch function that routes by cli_tool."""
+
+    def test_dispatches_to_claude_by_default(self):
+        parsed = {"type": "result", "usage": {"input_tokens": 100, "output_tokens": 10}}
+        result = extract_stream_usage("claude-code", parsed)
+        assert result is not None
+        assert result["input"] == 100
+
+    def test_dispatches_to_qwen_for_qwen_tool(self):
+        parsed = {
+            "type": "result",
+            "usageMetadata": {"promptTokenCount": 4000, "candidatesTokenCount": 200},
+        }
+        result = extract_stream_usage("qwen-code-cli", parsed)
+        assert result is not None
+        assert result["input"] == 4000
+
+    def test_dispatches_to_claude_for_unknown_tool(self):
+        parsed = {"type": "result", "usage": {"input_tokens": 50, "output_tokens": 5}}
+        result = extract_stream_usage("some-unknown-tool", parsed)
+        assert result is not None
+        assert result["input"] == 50


### PR DESCRIPTION
## 问题描述

AI 自主开发工作流的 Token 用量始终为 0，Session 从未写入 DB。详见 Issue #764。

## 根因分析

### Bug 1: Session 创建 TypeError
`agent_runner.py` 调用 `create_session(workspace_type=..., remote_machine_id=...)`，但方法签名无这两个参数。每次抛 TypeError 被静默吞掉。

### Bug 2: Token 解析路径错误
Claude Code 实测确认 `usage` 在 result 消息**顶层**，代码查 `data.usage`（嵌套）→ 永远 None。
`executor.py` 有相同 bug，导致远程 web 终端实时 token 也为 0。

### Bug 3: Qwen Code 格式不同
Qwen 使用 `promptTokenCount`/`candidatesTokenCount`，代码查 `input_tokens`/`output_tokens`。

## 修复

| 文件 | 修改 |
|------|------|
| `session_manager.py` | `create_session()` 添加 `workspace_type`/`remote_machine_id` 参数和 INSERT 列 |
| `agent_runner.py` | `_LocalSession` 添加 `cli_tool`；`_read_stdout()` 按工具分支解析 |
| `executor.py` | `_read_stream()` 使用共享 parser |
| `usage_parser.py` | **新建**：共享 `extract_claude_stream_usage()` + `extract_qwen_stream_usage()` |

17 个单元测试全部通过。

Closes #764
Related #761