### PR TITLE
fix: Docker 安装脚本 yum install 包名参数解析错误

### DIFF
--- a/scripts/install-central/docker-method/install.sh
+++ b/scripts/install-central/docker-method/install.sh
@@ -914,7 +914,7 @@ install_docker_debian() {
     local install_output=""
     local install_success=false
 
-    install_output=$(sudo apt-get install -y "$packages" 2>&1) && install_success=true || install_success=false
+    install_output=$(sudo apt-get install -y $packages 2>&1) && install_success=true || install_success=false
 
     if [ "$install_success" = false ]; then
         # Check if it's SSL/network error
@@ -931,7 +931,7 @@ install_docker_debian() {
 
             print_info "重新尝试安装..."
             sudo apt-get update
-            if sudo apt-get install -y "$packages"; then
+            if sudo apt-get install -y $packages; then
                 install_success=true
             fi
         fi
@@ -1118,7 +1118,7 @@ install_docker_fedora() {
     local install_output=""
     local install_success=false
 
-    install_output=$(sudo dnf install -y "$packages" 2>&1) && install_success=true || install_success=false
+    install_output=$(sudo dnf install -y $packages 2>&1) && install_success=true || install_success=false
 
     if [ "$install_success" = false ]; then
         # Check if it's SSL/network error
@@ -1133,13 +1133,13 @@ install_docker_fedora() {
             sudo dnf config-manager --add-repo "$aliyun_repo"
 
             print_info "重新尝试安装..."
-            if sudo dnf install -y --nogpgcheck "$packages"; then
+            if sudo dnf install -y --nogpgcheck $packages; then
                 install_success=true
             fi
         else
             # Non-SSL error, try --nogpgcheck
             print_warning "安装失败，尝试跳过 GPG 检查..."
-            if sudo dnf install -y --nogpgcheck "$packages"; then
+            if sudo dnf install -y --nogpgcheck $packages; then
                 install_success=true
             fi
         fi

--- a/scripts/install-central/docker-method/install.sh
+++ b/scripts/install-central/docker-method/install.sh
@@ -1014,7 +1014,7 @@ install_docker_redhat() {
     local install_output=""
     local install_success=false
 
-    install_output=$(sudo yum install -y "$packages" 2>&1) && install_success=true || install_success=false
+    install_output=$(sudo yum install -y $packages 2>&1) && install_success=true || install_success=false
 
     if [ "$install_success" = false ]; then
         # Check if it's SSL/network error
@@ -1029,13 +1029,13 @@ install_docker_redhat() {
             sudo yum-config-manager --add-repo "$aliyun_repo"
 
             print_info "重新尝试安装..."
-            if sudo yum install -y --nogpgcheck "$packages"; then
+            if sudo yum install -y --nogpgcheck $packages; then
                 install_success=true
             fi
         else
             # Non-SSL error, try --nogpgcheck
             print_warning "安装失败，尝试跳过 GPG 检查..."
-            if sudo yum install -y --nogpgcheck "$packages"; then
+            if sudo yum install -y --nogpgcheck $packages; then
                 install_success=true
             fi
         fi


### PR DESCRIPTION
## 问题描述

Fixes #766

在 Rocky Linux 9 系统上执行 Docker 安装脚本时，`yum install` 命令无法找到 Docker 包。

## 根因

脚本中使用了双引号包裹包名变量 `$packages`：

```bash
local packages="docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin"
install_output=$(sudo yum install -y "$packages" 2>&1)  # ❌ 双引号导致问题
```

**问题**：`"$packages"` 双引号导致整个字符串被当作一个参数传递给 yum，而不是 5 个单独的包名。

## 修复内容

移除 `$packages` 的双引号：
- 第 1013 行
- 第 1025 行
- 第 1032 行

## 测试结果

已在 node236 (Rocky Linux 9.6) 上验证，Docker 安装成功。