### PR TITLE
feat: remote agent identity hardening with token-based auth (Issue #754)

### DIFF
--- a/app/modules/governance/audit_logger.py
+++ b/app/modules/governance/audit_logger.py
@@ -58,6 +58,13 @@ class AuditAction(Enum):
     CONTENT_BLOCKED = "content_blocked"
     CONTENT_FLAGGED = "content_flagged"
 
+    # Remote agent actions
+    AGENT_REGISTER = "agent_register"
+    AGENT_TOKEN_ROTATE = "agent_token_rotate"
+    AGENT_TOKEN_REVOKE = "agent_token_revoke"
+    AGENT_AUTH_FAILURE = "agent_auth_failure"
+    AGENT_RECONNECT = "agent_reconnect"
+
 
 class AuditSeverity(Enum):
     """Severity levels for audit events."""

--- a/app/modules/workspace/agent_token.py
+++ b/app/modules/workspace/agent_token.py
@@ -1,0 +1,48 @@
+"""
+Open ACE - Agent Token Module
+
+Provides secure token generation, hashing, and validation for remote agent
+authentication. Registration tokens are one-time-use tokens for enrolling new
+machines. Agent tokens (Bearer tokens) are long-lived credentials used by
+agents to authenticate heartbeat and message endpoints.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import secrets
+
+# Length of the token hash prefix used for audit logging and rate-limiting.
+HASH_PREFIX_LENGTH = 8
+
+
+def generate_agent_token() -> str:
+    """Generate a cryptographically random agent token (64-char hex).
+
+    The token is the secret presented by the agent in the Authorization
+    header. The server stores only the SHA-256 hash of this token.
+    """
+    return secrets.token_hex(32)
+
+
+def generate_registration_token() -> str:
+    """Generate a cryptographically random one-time registration token (64-char hex).
+
+    Used by admins to authorize the enrollment of a new remote machine.
+    The server stores only the SHA-256 hash of this token.
+    """
+    return secrets.token_hex(32)
+
+
+def hash_token(token: str) -> str:
+    """Compute SHA-256 hash of a token for secure storage."""
+    return hashlib.sha256(token.encode()).hexdigest()
+
+
+def token_hash_prefix(token: str) -> str:
+    """Return the first 8 characters of a token's SHA-256 hash.
+
+    Used for audit log deduplication and rate-limiting so that the raw
+    token is never logged.
+    """
+    return hash_token(token)[:HASH_PREFIX_LENGTH]

--- a/app/modules/workspace/remote_agent_manager.py
+++ b/app/modules/workspace/remote_agent_manager.py
@@ -88,8 +88,7 @@ class RemoteAgentManager:
         self._lock = Semaphore(1)
         # Token cleanup lazy-start flag
         self._token_cleanup_started: bool = False
-        # Flag indicating last rotate unrevoked a token (for audit logging)
-        self._last_rotate_unrevoked: bool = False
+        # (removed _last_rotate_unrevoked — rotate_agent_token now returns the info)
         self._restore_in_memory_state()
         # Defer session cleanup to heartbeat monitor instead of running on startup.
         # This gives agents time to re-register after a server restart before their
@@ -762,13 +761,16 @@ class RemoteAgentManager:
 
             conn.commit()
 
-        # Track if any previously-revoked tokens were present (audit detail)
-        self._last_rotate_unrevoked = len(existing) > 0 and not any_unrevoked
+        # Track if rotate also lifted a prior revocation (audit detail)
+        had_revoked_tokens = len(existing) > 0 and not any_unrevoked
 
         # Issue a new token
         new_token = self._create_agent_token(machine_id)
         logger.info("Rotated agent token for machine %s", machine_id[:8])
-        return new_token
+        return {
+            "new_token": new_token,
+            "unrevoked": had_revoked_tokens,
+        }
 
     def revoke_agent_token(self, machine_id: str, revoked_by: int | None = None) -> bool:
         """Revoke all active agent tokens for a machine.
@@ -857,7 +859,10 @@ class RemoteAgentManager:
         return legacy_mode
 
     def cleanup_expired_registration_tokens(self) -> int:
-        """Remove expired and already-consumed registration tokens.
+        """Remove expired registration tokens that have NOT been consumed.
+
+        Consumed tokens are retained for audit trail (who authorized which
+        machine, when it was consumed, etc.).
 
         Returns:
             Number of tokens removed.
@@ -867,21 +872,21 @@ class RemoteAgentManager:
         with self.db.connection() as conn:
             cursor = conn.cursor()
 
-            # Delete tokens that are consumed OR expired
-            # P0-2 fix: use parameterized boolean instead of `= 1`
+            # Only delete tokens that are expired AND not yet consumed.
+            # Consumed tokens are kept for audit purposes.
             cursor.execute(
                 f"""
                 DELETE FROM registration_tokens
                 WHERE is_consumed = {_param()}
-                   OR expires_at < {_param()}
+                   AND expires_at < {_param()}
             """,
-                (adapt_boolean_value(True), now.isoformat()),
+                (adapt_boolean_value(False), now.isoformat()),
             )
             removed = cursor.rowcount
             conn.commit()
 
         if removed:
-            logger.info("Cleaned up %d expired/consumed registration tokens", removed)
+            logger.info("Cleaned up %d expired unconsumed registration tokens", removed)
         return removed
 
     def _start_token_cleanup(self) -> None:

--- a/app/modules/workspace/remote_agent_manager.py
+++ b/app/modules/workspace/remote_agent_manager.py
@@ -9,8 +9,8 @@ command dispatching, and message routing for remote workspace sessions.
 
 import json
 import logging
+import threading
 import time
-import uuid
 from contextlib import suppress
 from datetime import datetime, timedelta, timezone
 from typing import Any, cast
@@ -18,7 +18,12 @@ from typing import Any, cast
 import gevent
 from gevent.lock import Semaphore
 
-from app.repositories.database import DB_PATH, Database, is_postgresql
+from app.modules.workspace.agent_token import (
+    generate_agent_token,
+    generate_registration_token,
+    hash_token,
+)
+from app.repositories.database import DB_PATH, Database, adapt_boolean_value, is_postgresql
 
 logger = logging.getLogger(__name__)
 
@@ -50,6 +55,15 @@ class RemoteAgentManager:
     # Sessions are only cleaned up if they've been inactive longer than this window
     SESSION_RECOVERY_WINDOW_SECONDS = 300  # 5 minutes recovery window
 
+    # Registration token cleanup interval (seconds)
+    REGISTRATION_TOKEN_CLEANUP_INTERVAL = 3600  # 1 hour
+
+    # Registration token default TTL (seconds)
+    REGISTRATION_TOKEN_TTL = 3600  # 1 hour
+
+    # Legacy mode deadline in days — machines older than this must re-register
+    LEGACY_MODE_DEADLINE_DAYS = 90
+
     def __init__(self, db_path: str | None = None):
         self.db_path = db_path or str(DB_PATH)
         if db_path:
@@ -62,8 +76,6 @@ class RemoteAgentManager:
         self._session_machines: dict[str, str] = {}
         # Output buffers: {session_id: [output_lines]}
         self._output_buffers: dict[str, list[dict]] = {}
-        # Registration tokens: {token: {tenant_id, created_by, created_at}}
-        self._registration_tokens: dict[str, dict] = {}
         # Command queues for HTTP-mode agents: {machine_id: [commands]}
         self._command_queues: dict[str, list[dict]] = {}
         # Session end flags: {session_id: True} — set when session completes/stops/errors
@@ -74,6 +86,10 @@ class RemoteAgentManager:
         self._browse_results: dict[str, dict] = {}
         # Lock for gevent coroutine safety
         self._lock = Semaphore(1)
+        # Token cleanup lazy-start flag
+        self._token_cleanup_started: bool = False
+        # Flag indicating last rotate unrevoked a token (for audit logging)
+        self._last_rotate_unrevoked: bool = False
         self._restore_in_memory_state()
         # Defer session cleanup to heartbeat monitor instead of running on startup.
         # This gives agents time to re-register after a server restart before their
@@ -266,21 +282,38 @@ class RemoteAgentManager:
         """
         Generate a one-time registration token for a new machine.
 
+        The token is stored as a SHA-256 hash in the database. The plaintext
+        token is returned once and cannot be retrieved again.
+
         Args:
             tenant_id: Tenant ID to associate the machine with.
             created_by: User ID who initiated registration.
 
         Returns:
-            Registration token string.
+            Registration token string (plaintext).
         """
-        token = str(uuid.uuid4()).replace("-", "") + str(uuid.uuid4()).replace("-", "")
-        with self._lock:
-            self._registration_tokens[token] = {
-                "tenant_id": tenant_id,
-                "created_by": created_by,
-                "created_at": datetime.now(timezone.utc).replace(tzinfo=None).isoformat(),
-            }
-        logger.info(f"Created registration token for tenant {tenant_id}")
+        # Lazy-start token cleanup on first use
+        if not self._token_cleanup_started:
+            self._token_cleanup_started = True
+            self._start_token_cleanup()
+
+        token = generate_registration_token()
+        token_hash = hash_token(token)
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
+        expires_at = (now + timedelta(seconds=self.REGISTRATION_TOKEN_TTL)).isoformat()
+
+        with self.db.connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                f"""
+                INSERT INTO registration_tokens (token_hash, tenant_id, created_by, created_at, expires_at)
+                VALUES ({_param()}, {_param()}, {_param()}, {_param()}, {_param()})
+            """,
+                (token_hash, tenant_id, created_by, now.isoformat(), expires_at),
+            )
+            conn.commit()
+
+        logger.info("Created registration token for tenant %d", tenant_id)
         return token
 
     def register_machine(
@@ -312,8 +345,8 @@ class RemoteAgentManager:
         Returns:
             Dict with machine info or None if token invalid.
         """
-        with self._lock:
-            token_info = self._registration_tokens.pop(registration_token, None)
+        # Consume the one-time registration token (DB-based)
+        token_info = self._consume_registration_token(registration_token)
 
         if not token_info:
             logger.warning("Invalid or expired registration token")
@@ -490,11 +523,15 @@ class RemoteAgentManager:
                     )
                 conn.commit()
 
+                # Issue an agent token for the newly registered machine
+                agent_token = self._create_agent_token(machine_id)
+
                 return {
                     "machine_id": machine_id,
                     "machine_name": machine_name,
                     "status": "online",
                     "tenant_id": token_info["tenant_id"],
+                    "agent_token": agent_token,
                 }
             except Exception as e:
                 logger.error(f"Failed to register machine: {e}")
@@ -509,6 +546,7 @@ class RemoteAgentManager:
             cursor.execute(
                 f"DELETE FROM machine_assignments WHERE machine_id = {_param()}", (machine_id,)
             )
+            cursor.execute(f"DELETE FROM agent_tokens WHERE machine_id = {_param()}", (machine_id,))
             cursor.execute(
                 f"DELETE FROM remote_machines WHERE machine_id = {_param()}", (machine_id,)
             )
@@ -522,6 +560,350 @@ class RemoteAgentManager:
         self._last_heartbeat_db_write.pop(machine_id, None)
 
         return cast("bool", success)
+
+    # ==================== Token Management ====================
+
+    def _consume_registration_token(self, token: str) -> dict[str, Any] | None:
+        """Consume a one-time registration token.
+
+        Validates that the token exists, has not expired, and has not been
+        consumed. Atomically marks it as consumed.
+
+        Returns:
+            Dict with tenant_id and created_by if valid, None otherwise.
+        """
+        token_hash_val = hash_token(token)
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
+
+        with self._lock, self.db.connection() as conn:
+            cursor = conn.cursor()
+
+            # Look up the token
+            cursor.execute(
+                f"""
+                SELECT id, token_hash, tenant_id, created_by, expires_at, is_consumed
+                FROM registration_tokens
+                WHERE token_hash = {_param()}
+            """,
+                (token_hash_val,),
+            )
+            row = cursor.fetchone()
+
+            if not row:
+                logger.warning("Registration token not found in DB")
+                return None
+
+            # Check consumed
+            is_consumed = row["is_consumed"]
+            if is_postgresql():
+                is_consumed = bool(is_consumed) if is_consumed is not None else False
+            else:
+                is_consumed = bool(is_consumed)
+
+            if is_consumed:
+                logger.warning("Registration token already consumed (id=%s)", row["id"])
+                return None
+
+            # Check expiry
+            expires_at = row["expires_at"]
+            if expires_at:
+                if isinstance(expires_at, str):
+                    expires_at = datetime.fromisoformat(expires_at)
+                if expires_at.tzinfo is not None:
+                    expires_at = expires_at.replace(tzinfo=None)
+                if now > expires_at:
+                    logger.warning("Registration token expired (id=%s)", row["id"])
+                    return None
+
+            # Mark as consumed (P0-1 fix: 3 placeholders / 3 params)
+            cursor.execute(
+                f"""
+                UPDATE registration_tokens
+                SET is_consumed = {_param()}, consumed_at = {_param()}
+                WHERE id = {_param()}
+            """,
+                (adapt_boolean_value(True), now.isoformat(), row["id"]),
+            )
+            conn.commit()
+
+        return {
+            "tenant_id": row["tenant_id"],
+            "created_by": row["created_by"],
+        }
+
+    def _create_agent_token(self, machine_id: str) -> str:
+        """Generate and store a new agent token for a machine.
+
+        Returns:
+            The plaintext agent token (shown once to the caller).
+        """
+        token = generate_agent_token()
+        token_hash_val = hash_token(token)
+        now = datetime.now(timezone.utc).replace(tzinfo=None).isoformat()
+
+        with self.db.connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                f"""
+                INSERT INTO agent_tokens (token_hash, machine_id, created_at)
+                VALUES ({_param()}, {_param()}, {_param()})
+            """,
+                (token_hash_val, machine_id, now),
+            )
+            conn.commit()
+
+        logger.info("Issued agent token for machine %s", machine_id[:8])
+        return token
+
+    def validate_agent_token(self, token: str, machine_id: str) -> bool:
+        """Validate an agent Bearer token against a machine_id.
+
+        Checks that the token hash exists, belongs to the given machine,
+        and has not been revoked.
+
+        Returns:
+            True if valid, False otherwise.
+        """
+        token_hash_val = hash_token(token)
+
+        with self.db.connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                f"""
+                SELECT id, machine_id, is_revoked
+                FROM agent_tokens
+                WHERE token_hash = {_param()}
+            """,
+                (token_hash_val,),
+            )
+            row = cursor.fetchone()
+
+        if not row:
+            return False
+
+        # Check revoked
+        is_revoked = row["is_revoked"]
+        if is_postgresql():
+            is_revoked = bool(is_revoked) if is_revoked is not None else False
+        else:
+            is_revoked = bool(is_revoked)
+
+        if is_revoked:
+            return False
+
+        # Check machine_id binding
+        if row["machine_id"] != machine_id:
+            return False
+
+        return True
+
+    def rotate_agent_token(self, machine_id: str, rotated_by: int | None = None) -> str | None:
+        """Rotate the agent token for a machine.
+
+        Revokes all existing tokens for the machine and issues a new one.
+        If existing tokens were already revoked (e.g., the machine was
+        previously revoked), the revocation is silently lifted — this is
+        an intentional admin action tracked via audit logging.
+
+        Args:
+            machine_id: The machine whose token to rotate.
+            rotated_by: User ID who initiated the rotation.
+
+        Returns:
+            New plaintext agent token, or None if machine not found.
+        """
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
+
+        with self._lock, self.db.connection() as conn:
+            cursor = conn.cursor()
+
+            # Verify machine exists
+            cursor.execute(
+                f"SELECT machine_id FROM remote_machines WHERE machine_id = {_param()}",
+                (machine_id,),
+            )
+            if not cursor.fetchone():
+                return None
+
+            # Revoke all existing active tokens for this machine
+            cursor.execute(
+                f"""
+                SELECT id, is_revoked FROM agent_tokens
+                WHERE machine_id = {_param()}
+            """,
+                (machine_id,),
+            )
+            existing = cursor.fetchall()
+            any_unrevoked = False
+            for row in existing:
+                is_revoked = row["is_revoked"]
+                if is_postgresql():
+                    is_revoked = bool(is_revoked) if is_revoked is not None else False
+                else:
+                    is_revoked = bool(is_revoked)
+                if not is_revoked:
+                    any_unrevoked = True
+
+            # Mark all existing tokens as revoked
+            cursor.execute(
+                f"""
+                UPDATE agent_tokens
+                SET is_revoked = {_param()}, revoked_at = {_param()}, revoked_by = {_param()}
+                WHERE machine_id = {_param()} AND is_revoked = {_param()}
+            """,
+                (
+                    adapt_boolean_value(True),
+                    now.isoformat(),
+                    rotated_by,
+                    machine_id,
+                    adapt_boolean_value(False),
+                ),
+            )
+
+            conn.commit()
+
+        # Track if any previously-revoked tokens were present (audit detail)
+        self._last_rotate_unrevoked = len(existing) > 0 and not any_unrevoked
+
+        # Issue a new token
+        new_token = self._create_agent_token(machine_id)
+        logger.info("Rotated agent token for machine %s", machine_id[:8])
+        return new_token
+
+    def revoke_agent_token(self, machine_id: str, revoked_by: int | None = None) -> bool:
+        """Revoke all active agent tokens for a machine.
+
+        Args:
+            machine_id: The machine whose tokens to revoke.
+            revoked_by: User ID who initiated the revocation.
+
+        Returns:
+            True if any tokens were revoked, False otherwise.
+        """
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
+
+        with self._lock, self.db.connection() as conn:
+            cursor = conn.cursor()
+
+            # P0-3 fix: 4 placeholders / 4 params
+            cursor.execute(
+                f"""
+                UPDATE agent_tokens
+                SET is_revoked = {_param()}, revoked_at = {_param()}, revoked_by = {_param()}
+                WHERE machine_id = {_param()} AND is_revoked = {_param()}
+            """,
+                (
+                    adapt_boolean_value(True),
+                    now.isoformat(),
+                    revoked_by,
+                    machine_id,
+                    adapt_boolean_value(False),
+                ),
+            )
+            affected = cursor.rowcount
+            conn.commit()
+
+        if affected > 0:
+            logger.info("Revoked %d agent token(s) for machine %s", affected, machine_id[:8])
+            return True
+
+        return False
+
+    def clear_legacy_mode(self, machine_id: str) -> None:
+        """Clear the legacy_mode flag for a machine after it authenticates
+        with a valid Bearer token.
+
+        Uses parameterized boolean values for cross-DB compatibility.
+        """
+        with self.db.connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                f"""
+                UPDATE remote_machines
+                SET legacy_mode = {_param()}, updated_at = {_param()}
+                WHERE machine_id = {_param()} AND legacy_mode = {_param()}
+            """,
+                (
+                    adapt_boolean_value(False),
+                    datetime.now(timezone.utc).replace(tzinfo=None).isoformat(),
+                    machine_id,
+                    adapt_boolean_value(True),
+                ),
+            )
+            conn.commit()
+
+    def is_legacy_machine(self, machine_id: str) -> bool:
+        """Check if a machine is in legacy mode (no Bearer token auth)."""
+        with self.db.connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                f"""
+                SELECT legacy_mode, created_at FROM remote_machines
+                WHERE machine_id = {_param()}
+            """,
+                (machine_id,),
+            )
+            row = cursor.fetchone()
+
+        if not row:
+            return False
+
+        legacy_mode = row["legacy_mode"]
+        if is_postgresql():
+            legacy_mode = bool(legacy_mode) if legacy_mode is not None else False
+        else:
+            legacy_mode = bool(legacy_mode)
+
+        return legacy_mode
+
+    def cleanup_expired_registration_tokens(self) -> int:
+        """Remove expired and already-consumed registration tokens.
+
+        Returns:
+            Number of tokens removed.
+        """
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
+
+        with self.db.connection() as conn:
+            cursor = conn.cursor()
+
+            # Delete tokens that are consumed OR expired
+            # P0-2 fix: use parameterized boolean instead of `= 1`
+            cursor.execute(
+                f"""
+                DELETE FROM registration_tokens
+                WHERE is_consumed = {_param()}
+                   OR expires_at < {_param()}
+            """,
+                (adapt_boolean_value(True), now.isoformat()),
+            )
+            removed = cursor.rowcount
+            conn.commit()
+
+        if removed:
+            logger.info("Cleaned up %d expired/consumed registration tokens", removed)
+        return removed
+
+    def _start_token_cleanup(self) -> None:
+        """Start the registration token cleanup timer (lazy, daemon thread)."""
+
+        def _tick():
+            try:
+                self.cleanup_expired_registration_tokens()
+            except Exception as e:
+                logger.error("Token cleanup error: %s", e)
+            # Reschedule
+            timer = threading.Timer(self.REGISTRATION_TOKEN_CLEANUP_INTERVAL, _tick)
+            timer.daemon = True
+            timer.start()
+
+        timer = threading.Timer(self.REGISTRATION_TOKEN_CLEANUP_INTERVAL, _tick)
+        timer.daemon = True
+        timer.start()
+        logger.info(
+            "Registration token cleanup timer started (interval=%ds)",
+            self.REGISTRATION_TOKEN_CLEANUP_INTERVAL,
+        )
 
     # ==================== Connection Management ====================
 
@@ -1079,7 +1461,8 @@ def get_ddl_statements() -> list[str]:
             created_by INTEGER,
             created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
             updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-            last_heartbeat TIMESTAMP
+            last_heartbeat TIMESTAMP,
+            legacy_mode INTEGER DEFAULT 0
         )
         """,
         f"""
@@ -1093,10 +1476,40 @@ def get_ddl_statements() -> list[str]:
             UNIQUE(machine_id, user_id)
         )
         """,
+        f"""
+        CREATE TABLE IF NOT EXISTS registration_tokens (
+            id {id_type},
+            token_hash TEXT NOT NULL UNIQUE,
+            tenant_id INTEGER NOT NULL,
+            created_by INTEGER NOT NULL,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            expires_at TIMESTAMP,
+            is_consumed INTEGER DEFAULT 0,
+            consumed_at TIMESTAMP
+        )
+        """,
+        f"""
+        CREATE TABLE IF NOT EXISTS agent_tokens (
+            id {id_type},
+            token_hash TEXT NOT NULL UNIQUE,
+            machine_id TEXT NOT NULL,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            is_revoked INTEGER DEFAULT 0,
+            revoked_at TIMESTAMP,
+            revoked_by INTEGER,
+            rotated_at TIMESTAMP
+        )
+        """,
+        # --- Indexes ---
         "CREATE INDEX IF NOT EXISTS idx_remote_machines_machine_id ON remote_machines(machine_id)",
         "CREATE INDEX IF NOT EXISTS idx_remote_machines_status ON remote_machines(status)",
         "CREATE INDEX IF NOT EXISTS idx_remote_machines_hostname_tenant ON remote_machines(hostname, tenant_id)",
         "CREATE INDEX IF NOT EXISTS idx_machine_assignments_user_id ON machine_assignments(user_id)",
+        "CREATE INDEX IF NOT EXISTS idx_registration_tokens_hash ON registration_tokens(token_hash)",
+        "CREATE INDEX IF NOT EXISTS idx_agent_tokens_hash ON agent_tokens(token_hash)",
+        "CREATE INDEX IF NOT EXISTS idx_agent_tokens_machine ON agent_tokens(machine_id)",
+        # --- ALTER TABLE for legacy_mode column (idempotent) ---
+        "ALTER TABLE remote_machines ADD COLUMN legacy_mode INTEGER DEFAULT 0",
     ]
 
 

--- a/app/routes/remote.py
+++ b/app/routes/remote.py
@@ -210,9 +210,8 @@ def _check_legacy_fallback(machine_id: str) -> tuple[bool, tuple | None]:
                 created_at = datetime.fromisoformat(created_at)
             if created_at.tzinfo is not None:
                 created_at = created_at.replace(tzinfo=None)
-            from datetime import datetime as _dt
 
-            age_days = (_dt.now(timezone.utc).replace(tzinfo=None) - created_at).days
+            age_days = (datetime.now(timezone.utc).replace(tzinfo=None) - created_at).days
             deadline = agent_mgr.LEGACY_MODE_DEADLINE_DAYS
             if age_days > deadline:
                 return False, (
@@ -440,22 +439,23 @@ def rotate_machine_token(machine_id):
     """
     agent_mgr = get_remote_agent_manager()
 
-    new_token = agent_mgr.rotate_agent_token(
+    result = agent_mgr.rotate_agent_token(
         machine_id=machine_id,
         rotated_by=g.user["id"],
     )
 
-    if new_token is None:
+    if result is None:
         return jsonify({"error": "Machine not found"}), 404
+
+    new_token = result["new_token"]
 
     # AGENT_TOKEN_ROTATE audit event
     details = {
         "machine_id": machine_id,
         "rotated_by": g.user["id"],
     }
-    if agent_mgr._last_rotate_unrevoked:
+    if result.get("unrevoked"):
         details["unrevoke"] = True
-    agent_mgr._last_rotate_unrevoked = False
 
     audit_logger.log_action(
         AuditAction.AGENT_TOKEN_ROTATE,

--- a/app/routes/remote.py
+++ b/app/routes/remote.py
@@ -14,6 +14,7 @@ import ipaddress
 import json
 import logging
 import os
+import threading
 import time
 import urllib.parse
 import uuid
@@ -21,6 +22,8 @@ import uuid
 from flask import Blueprint, Response, g, jsonify, request, stream_with_context
 
 from app.auth.decorators import _extract_token, _load_user_from_token, admin_required
+from app.modules.governance.audit_logger import AuditAction, AuditLogger
+from app.modules.workspace.agent_token import token_hash_prefix
 from app.modules.workspace.api_key_proxy import get_api_key_proxy_service
 from app.modules.workspace.llm_proxy_handler import handle_llm_proxy_request
 from app.modules.workspace.remote_agent_manager import get_remote_agent_manager
@@ -31,6 +34,14 @@ logger = logging.getLogger(__name__)
 
 MAX_RAW_CONTENT_LENGTH = 100000
 MAX_MESSAGE_LENGTH = 50000
+
+# Module-level audit logger instance
+audit_logger = AuditLogger()
+
+# AUTH_FAILURE rate-limiting state: {token_hash_prefix: last_audit_timestamp}
+_auth_failure_lock = threading.Lock()
+_auth_failure_last_audit: dict[str, float] = {}
+_AUTH_FAILURE_RATE_LIMIT_SECONDS = 300  # 5 minutes
 
 _CLI_SETTINGS_TOOLS = ["claude-code", "qwen-code", "codex-cli"]
 
@@ -137,6 +148,112 @@ def load_user():
             logger.warning("Failed to validate URL token: %s", e)
 
     return jsonify({"error": "Authentication required"}), 401
+
+
+def _validate_agent_bearer(machine_id: str) -> tuple[str | None, tuple | None]:
+    """Validate the Bearer token in the Authorization header.
+
+    Returns:
+        (token_value, None) on success.
+        (None, error_response) on failure.
+    """
+    auth_header = request.headers.get("Authorization", "")
+    if not auth_header.startswith("Bearer "):
+        return None, (jsonify({"error": "Missing Bearer token"}), 401)
+
+    token = auth_header[7:]  # Strip "Bearer " prefix
+    if not token:
+        return None, (jsonify({"error": "Empty Bearer token"}), 401)
+
+    agent_mgr = get_remote_agent_manager()
+    if not agent_mgr.validate_agent_token(token, machine_id):
+        return None, (jsonify({"error": "Invalid or revoked Bearer token"}), 401)
+
+    return token, None
+
+
+def _check_legacy_fallback(machine_id: str) -> tuple[bool, tuple | None]:
+    """Check if a machine qualifies for legacy (no-Bearer) auth.
+
+    Legacy machines that were registered before Bearer token enforcement
+    can still authenticate without a Bearer token, but with an expiry
+    deadline and a clear_legacy_mode transition on first Bearer use.
+
+    Returns:
+        (is_legacy, None) if legacy mode applies.
+        (False, error_response) if not legacy and no Bearer provided.
+        (False, None) if Bearer is present (caller should validate normally).
+    """
+    agent_mgr = get_remote_agent_manager()
+
+    # If an Authorization header is present, clear legacy mode and use Bearer
+    auth_header = request.headers.get("Authorization", "")
+    if auth_header.startswith("Bearer "):
+        # If this was a legacy machine, clear the flag
+        if agent_mgr.is_legacy_machine(machine_id):
+            agent_mgr.clear_legacy_mode(machine_id)
+            logger.info("Legacy mode cleared for machine %s after Bearer auth", machine_id[:8])
+        return False, None
+
+    # No Bearer header — check if legacy mode is allowed
+    if not agent_mgr.is_legacy_machine(machine_id):
+        return False, (jsonify({"error": "Missing Bearer token"}), 401)
+
+    # Legacy machine — check deadline (P2-1: 90-day expiry)
+    machine = agent_mgr.get_machine(machine_id)
+    if machine and machine.get("created_at"):
+        try:
+            from datetime import datetime, timezone
+
+            created_at = machine["created_at"]
+            if isinstance(created_at, str):
+                created_at = datetime.fromisoformat(created_at)
+            if created_at.tzinfo is not None:
+                created_at = created_at.replace(tzinfo=None)
+            from datetime import datetime as _dt
+
+            age_days = (_dt.now(timezone.utc).replace(tzinfo=None) - created_at).days
+            deadline = agent_mgr.LEGACY_MODE_DEADLINE_DAYS
+            if age_days > deadline:
+                return False, (
+                    jsonify({"error": "Legacy mode expired. Please re-register the agent."}),
+                    401,
+                )
+        except Exception:
+            pass  # If date parsing fails, allow legacy
+
+    logger.warning(
+        "Legacy auth (no Bearer) accepted for machine %s — deadline approaching",
+        machine_id[:8],
+    )
+    return True, None
+
+
+def _audit_auth_failure(token_or_prefix: str, reason: str, client_ip: str) -> None:
+    """Record an AGENT_AUTH_FAILURE audit event with rate limiting.
+
+    Only writes one audit log per token_hash_prefix per 5-minute window.
+    """
+    prefix = token_hash_prefix(token_or_prefix) if len(token_or_prefix) > 16 else token_or_prefix
+
+    now = time.time()
+    with _auth_failure_lock:
+        last = _auth_failure_last_audit.get(prefix, 0)
+        if now - last < _AUTH_FAILURE_RATE_LIMIT_SECONDS:
+            return  # Rate-limited — skip audit write
+        _auth_failure_last_audit[prefix] = now
+
+    audit_logger.log(
+        action=AuditAction.AGENT_AUTH_FAILURE.value,
+        severity="warning",
+        resource_type="agent_token",
+        details={
+            "token_hash_prefix": prefix,
+            "reason": reason,
+            "client_ip": client_ip,
+        },
+        success=False,
+    )
 
 
 def _require_machine_admin(machine_id):
@@ -310,6 +427,82 @@ def revoke_user(machine_id, user_id):
     if success:
         return jsonify({"success": True, "message": "User access revoked"})
     return jsonify({"error": "Assignment not found"}), 404
+
+
+@remote_bp.route("/machines/<machine_id>/token/rotate", methods=["POST"])
+@admin_required
+def rotate_machine_token(machine_id):
+    """Rotate the agent token for a machine. System admin only.
+
+    Revokes all existing tokens and issues a new one. If the existing
+    tokens were already revoked (i.e., the machine was previously
+    revoked and is being re-activated), this is logged as an unrevoke.
+    """
+    agent_mgr = get_remote_agent_manager()
+
+    new_token = agent_mgr.rotate_agent_token(
+        machine_id=machine_id,
+        rotated_by=g.user["id"],
+    )
+
+    if new_token is None:
+        return jsonify({"error": "Machine not found"}), 404
+
+    # AGENT_TOKEN_ROTATE audit event
+    details = {
+        "machine_id": machine_id,
+        "rotated_by": g.user["id"],
+    }
+    if agent_mgr._last_rotate_unrevoked:
+        details["unrevoke"] = True
+    agent_mgr._last_rotate_unrevoked = False
+
+    audit_logger.log_action(
+        AuditAction.AGENT_TOKEN_ROTATE,
+        user_id=g.user["id"],
+        username=g.user.get("username"),
+        severity="info",
+        resource_type="remote_machine",
+        resource_id=machine_id,
+        details=details,
+    )
+
+    return jsonify(
+        {
+            "success": True,
+            "agent_token": new_token,
+            "message": "Agent token rotated. Update the agent configuration with the new token.",
+        }
+    )
+
+
+@remote_bp.route("/machines/<machine_id>/token/revoke", methods=["POST"])
+@admin_required
+def revoke_machine_token(machine_id):
+    """Revoke all agent tokens for a machine. System admin only."""
+    agent_mgr = get_remote_agent_manager()
+
+    success = agent_mgr.revoke_agent_token(
+        machine_id=machine_id,
+        revoked_by=g.user["id"],
+    )
+
+    if success:
+        # AGENT_TOKEN_REVOKE audit event
+        audit_logger.log_action(
+            AuditAction.AGENT_TOKEN_REVOKE,
+            user_id=g.user["id"],
+            username=g.user.get("username"),
+            severity="warning",
+            resource_type="remote_machine",
+            resource_id=machine_id,
+            details={
+                "machine_id": machine_id,
+                "revoked_by": g.user["id"],
+            },
+        )
+        return jsonify({"success": True, "message": "Agent token revoked"})
+    return jsonify({"error": "No active tokens found for this machine"}), 404
 
 
 # ==================== Machine User Assignments ====================
@@ -818,6 +1011,20 @@ def agent_register():
     if result:
         if result.get("error") == "hostname_conflict":
             return jsonify({"error": result["message"]}), 409
+        # AGENT_REGISTER audit event
+        audit_logger.log_action(
+            AuditAction.AGENT_REGISTER,
+            severity="info",
+            resource_type="remote_machine",
+            resource_id=machine_id,
+            details={
+                "machine_id": machine_id,
+                "machine_name": machine_name,
+                "hostname": hostname,
+                "tenant_id": result.get("tenant_id"),
+            },
+            ip_address=ip_address,
+        )
         return jsonify({"success": True, "machine": result})
     return jsonify({"error": "Invalid or expired registration token"}), 401
 
@@ -874,6 +1081,49 @@ def agent_message():
     if not machine_id:
         return jsonify({"error": "machine_id is required"}), 400
 
+    # ===== Bearer token authentication =====
+    # All message types except "register" require a valid Bearer token
+    # (or legacy mode fallback for pre-existing machines).
+    if msg_type != "register":
+        # First, check if the machine exists
+        machine = agent_mgr.get_machine(machine_id)
+        if not machine:
+            return jsonify({"error": "Unknown machine_id"}), 404
+
+        # Check for legacy fallback (no Bearer header, machine in legacy_mode)
+        is_legacy, legacy_error = _check_legacy_fallback(machine_id)
+        if legacy_error:
+            # Not legacy and no Bearer → try extracting for audit
+            auth_header = request.headers.get("Authorization", "")
+            client_ip = get_client_ip_from_request()
+            if auth_header.startswith("Bearer "):
+                failed_token = auth_header[7:]
+                _audit_auth_failure(failed_token, "invalid_or_revoked", client_ip)
+            return legacy_error
+
+        if not is_legacy:
+            # Normal Bearer token validation
+            bearer_token, bearer_error = _validate_agent_bearer(machine_id)
+            if bearer_error:
+                client_ip = get_client_ip_from_request()
+                auth_header = request.headers.get("Authorization", "")
+                if auth_header.startswith("Bearer "):
+                    _audit_auth_failure(
+                        auth_header[7:],
+                        bearer_error[0].get_json().get("error", "unknown"),
+                        client_ip,
+                    )
+                return bearer_error
+
+        # Check for offline→online reconnect (AGENT_RECONNECT audit)
+        if machine.get("status") == "offline":
+            g._did_reconnect = True
+            g._previous_status = "offline"
+        else:
+            g._did_reconnect = False
+    else:
+        g._did_reconnect = False
+
     if msg_type == "register":
         # Validate machine exists in DB before allowing registration
         machine = agent_mgr.get_machine(machine_id)
@@ -900,6 +1150,18 @@ def agent_message():
         active_sessions = data.get("active_sessions", 0)
         capabilities = data.get("capabilities", {})
         agent_mgr.process_heartbeat(machine_id, status, active_sessions, capabilities=capabilities)
+        # AGENT_RECONNECT audit: if machine was offline, log the reconnection
+        if getattr(g, "_did_reconnect", False):
+            audit_logger.log_action(
+                AuditAction.AGENT_RECONNECT,
+                severity="info",
+                resource_type="remote_machine",
+                resource_id=machine_id,
+                details={
+                    "machine_id": machine_id,
+                    "previous_status": getattr(g, "_previous_status", "unknown"),
+                },
+            )
         pending = agent_mgr.get_pending_commands(machine_id)
         return jsonify({"success": True, "type": "heartbeat_ack", "pending_commands": pending})
 

--- a/migrations/versions/20260608_053_add_agent_identity_tables.py
+++ b/migrations/versions/20260608_053_add_agent_identity_tables.py
@@ -1,0 +1,117 @@
+"""Add registration_tokens, agent_tokens tables and legacy_mode column
+
+Revision ID: 053_agent_identity_tables
+Revises: 052_planning_timeout_extension
+Create Date: 2026-06-08
+
+Creates tables needed for remote agent identity hardening (Issue #754):
+- registration_tokens: one-time-use tokens for enrolling new machines
+- agent_tokens: long-lived Bearer tokens for agent authentication
+- legacy_mode column on remote_machines: tracks pre-token-registered machines
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "053_agent_identity_tables"
+down_revision: str = "052_planning_timeout_extension"
+branch_labels = None
+depends_on = None
+
+
+def _table_exists(conn, table: str) -> bool:
+    """Check if a table already exists."""
+    result = conn.execute(
+        sa.text(
+            "SELECT COUNT(*) FROM information_schema.tables "
+            "WHERE table_name = :table"
+        ),
+        {"table": table},
+    )
+    return result.scalar() > 0
+
+
+def _column_exists(conn, table: str, column: str) -> bool:
+    """Check if a column already exists."""
+    result = conn.execute(
+        sa.text(
+            "SELECT COUNT(*) FROM information_schema.columns "
+            "WHERE table_name = :table AND column_name = :column"
+        ),
+        {"table": table, "column": column},
+    )
+    return result.scalar() > 0
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    # registration_tokens table
+    if not _table_exists(conn, "registration_tokens"):
+        op.create_table(
+            "registration_tokens",
+            sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
+            sa.Column("token_hash", sa.String, nullable=False, unique=True),
+            sa.Column("tenant_id", sa.Integer, nullable=False),
+            sa.Column("created_by", sa.Integer, nullable=False),
+            sa.Column("created_at", sa.DateTime, server_default=sa.func.now()),
+            sa.Column("expires_at", sa.DateTime, nullable=True),
+            sa.Column("is_consumed", sa.Integer, server_default="0"),
+            sa.Column("consumed_at", sa.DateTime, nullable=True),
+        )
+        op.create_index(
+            "idx_registration_tokens_hash",
+            "registration_tokens",
+            ["token_hash"],
+        )
+
+    # agent_tokens table
+    if not _table_exists(conn, "agent_tokens"):
+        op.create_table(
+            "agent_tokens",
+            sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
+            sa.Column("token_hash", sa.String, nullable=False, unique=True),
+            sa.Column("machine_id", sa.String, nullable=False),
+            sa.Column("created_at", sa.DateTime, server_default=sa.func.now()),
+            sa.Column("is_revoked", sa.Integer, server_default="0"),
+            sa.Column("revoked_at", sa.DateTime, nullable=True),
+            sa.Column("revoked_by", sa.Integer, nullable=True),
+            sa.Column("rotated_at", sa.DateTime, nullable=True),
+        )
+        op.create_index(
+            "idx_agent_tokens_hash", "agent_tokens", ["token_hash"]
+        )
+        op.create_index(
+            "idx_agent_tokens_machine", "agent_tokens", ["machine_id"]
+        )
+
+    # legacy_mode column on remote_machines
+    if not _column_exists(conn, "remote_machines", "legacy_mode"):
+        op.add_column(
+            "remote_machines",
+            sa.Column(
+                "legacy_mode",
+                sa.Integer,
+                server_default="0",
+                nullable=True,
+            ),
+        )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+
+    if _column_exists(conn, "remote_machines", "legacy_mode"):
+        op.drop_column("remote_machines", "legacy_mode")
+
+    if _table_exists(conn, "agent_tokens"):
+        op.drop_index("idx_agent_tokens_machine", table_name="agent_tokens")
+        op.drop_index("idx_agent_tokens_hash", table_name="agent_tokens")
+        op.drop_table("agent_tokens")
+
+    if _table_exists(conn, "registration_tokens"):
+        op.drop_index(
+            "idx_registration_tokens_hash", table_name="registration_tokens"
+        )
+        op.drop_table("registration_tokens")

--- a/tests/issues/754/test_remote_agent_identity_e2e.py
+++ b/tests/issues/754/test_remote_agent_identity_e2e.py
@@ -1,0 +1,368 @@
+"""
+E2E tests for Remote Agent Identity Hardening (PR #760).
+
+Tests cover 11 scenarios for the new DB-based registration tokens,
+agent Bearer token authentication, token rotation/revocation,
+legacy mode handling.
+
+Uses RemoteAgentManager directly with a temporary SQLite database.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+import pytest
+
+import app.repositories.database as db_mod
+from app.repositories.database import Database
+
+# ── Fixtures ──────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _patch_db_compat():
+    """Patch is_postgresql and adapt_sql for all tests (SQLite mode)."""
+    with patch.object(db_mod, "is_postgresql", return_value=False):
+        orig = db_mod.adapt_sql
+        db_mod.adapt_sql = lambda q: q
+        try:
+            yield
+        finally:
+            db_mod.adapt_sql = orig
+
+
+@pytest.fixture
+def manager(tmp_path):
+    """Create a RemoteAgentManager backed by a temp SQLite database."""
+    # Import after patching is_postgresql so _param() returns '?'
+    from app.modules.workspace.remote_agent_manager import RemoteAgentManager
+
+    db_path = str(tmp_path / "test_agent.db")
+    mgr = RemoteAgentManager(db_path=db_path)
+
+    # Ensure tables exist (including new ones)
+    from app.modules.workspace.remote_agent_manager import get_ddl_statements
+
+    with mgr.db.connection() as conn:
+        cursor = conn.cursor()
+        for sql in get_ddl_statements():
+            try:
+                cursor.execute(sql)
+            except Exception:
+                pass  # ALTER TABLE may fail if column exists
+        conn.commit()
+
+    return mgr
+
+
+# ── Test Scenarios ───────────────────────────────────────────────────────
+
+
+class TestScenario01_MissingBearerToken:
+    """Scenario 1: Non-legacy machine without Bearer token → validate fails."""
+
+    def test_non_legacy_requires_token(self, manager):
+        machine_id = "machine-001"
+        agent_token = "fake-token"
+
+        # Register a machine via token flow
+        reg_token = manager.create_registration_token(tenant_id=1, created_by=1)
+        result = manager.register_machine(
+            registration_token=reg_token,
+            machine_id=machine_id,
+            machine_name="test-machine",
+            hostname="testhost",
+        )
+        assert result is not None
+        agent_token = result["agent_token"]
+
+        # Validate with no token → should fail (simulated: empty string)
+        assert manager.validate_agent_token("", machine_id) is False
+
+        # Validate with wrong token → should fail
+        assert manager.validate_agent_token("wrong-token", machine_id) is False
+
+
+class TestScenario02_InvalidBearerToken:
+    """Scenario 2: Invalid Bearer token → validate fails."""
+
+    def test_invalid_token_rejected(self, manager):
+        reg_token = manager.create_registration_token(tenant_id=1, created_by=1)
+        result = manager.register_machine(
+            registration_token=reg_token,
+            machine_id="machine-002",
+            machine_name="test-002",
+        )
+        assert result is not None
+
+        # Wrong token
+        assert manager.validate_agent_token("totally-wrong-token", "machine-002") is False
+
+
+class TestScenario03_TokenBoundToWrongMachine:
+    """Scenario 3: Token bound to wrong machine_id → validate fails."""
+
+    def test_cross_machine_token_rejected(self, manager):
+        # Register machine A
+        reg_a = manager.create_registration_token(tenant_id=1, created_by=1)
+        result_a = manager.register_machine(
+            registration_token=reg_a,
+            machine_id="machine-a",
+            machine_name="Machine A",
+        )
+        token_a = result_a["agent_token"]
+
+        # Register machine B
+        reg_b = manager.create_registration_token(tenant_id=1, created_by=1)
+        result_b = manager.register_machine(
+            registration_token=reg_b,
+            machine_id="machine-b",
+            machine_name="Machine B",
+        )
+
+        # A's token should NOT validate against B's machine_id
+        assert manager.validate_agent_token(token_a, "machine-b") is False
+
+        # A's token should validate against A's machine_id
+        assert manager.validate_agent_token(token_a, "machine-a") is True
+
+
+class TestScenario04_SuccessfulRegistration:
+    """Scenario 4: Successful registration flow."""
+
+    def test_full_registration_flow(self, manager):
+        # Create registration token
+        reg_token = manager.create_registration_token(tenant_id=1, created_by=1)
+        assert reg_token is not None
+        assert len(reg_token) == 64  # secrets.token_hex(32) = 64 chars
+
+        # Register machine
+        result = manager.register_machine(
+            registration_token=reg_token,
+            machine_id="machine-004",
+            machine_name="test-machine-4",
+            hostname="host4",
+            os_type="linux",
+        )
+        assert result is not None
+        assert result["machine_id"] == "machine-004"
+        assert result["status"] == "online"
+        assert "agent_token" in result
+
+        # Agent token should be valid
+        agent_token = result["agent_token"]
+        assert manager.validate_agent_token(agent_token, "machine-004") is True
+
+        # Machine should be queryable
+        machine = manager.get_machine("machine-004")
+        assert machine is not None
+        assert machine["machine_name"] == "test-machine-4"
+
+
+class TestScenario05_TokenRotation:
+    """Scenario 5: Token rotation — old token invalidated, new token works."""
+
+    def test_rotate_invalidates_old_token(self, manager):
+        # Register
+        reg_token = manager.create_registration_token(tenant_id=1, created_by=1)
+        result = manager.register_machine(
+            registration_token=reg_token,
+            machine_id="machine-005",
+            machine_name="test-005",
+        )
+        old_token = result["agent_token"]
+
+        # Old token works
+        assert manager.validate_agent_token(old_token, "machine-005") is True
+
+        # Rotate
+        new_token = manager.rotate_agent_token("machine-005", rotated_by=1)
+        assert new_token is not None
+
+        # Old token no longer works
+        assert manager.validate_agent_token(old_token, "machine-005") is False
+
+        # New token works
+        assert manager.validate_agent_token(new_token, "machine-005") is True
+
+
+class TestScenario06_TokenRevocation:
+    """Scenario 6: Token revoked → validate fails."""
+
+    def test_revoke_blocks_token(self, manager):
+        # Register
+        reg_token = manager.create_registration_token(tenant_id=1, created_by=1)
+        result = manager.register_machine(
+            registration_token=reg_token,
+            machine_id="machine-006",
+            machine_name="test-006",
+        )
+        agent_token = result["agent_token"]
+
+        # Token works before revocation
+        assert manager.validate_agent_token(agent_token, "machine-006") is True
+
+        # Revoke
+        success = manager.revoke_agent_token("machine-006", revoked_by=1)
+        assert success is True
+
+        # Token no longer works
+        assert manager.validate_agent_token(agent_token, "machine-006") is False
+
+
+class TestScenario07_LegacyCompat:
+    """Scenario 7: Legacy machine (legacy_mode=TRUE) accepted without Bearer."""
+
+    def test_legacy_machine_accepted(self, manager):
+        # Register a machine normally
+        reg_token = manager.create_registration_token(tenant_id=1, created_by=1)
+        result = manager.register_machine(
+            registration_token=reg_token,
+            machine_id="machine-007",
+            machine_name="legacy-machine",
+        )
+
+        # Set legacy_mode = True
+        with manager.db.connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "UPDATE remote_machines SET legacy_mode = 1 WHERE machine_id = ?",
+                ("machine-007",),
+            )
+            conn.commit()
+
+        # is_legacy_machine should return True
+        assert manager.is_legacy_machine("machine-007") is True
+
+        # clear_legacy_mode should work
+        manager.clear_legacy_mode("machine-007")
+        assert manager.is_legacy_machine("machine-007") is False
+
+
+class TestScenario08_ExpiredRegistrationToken:
+    """Scenario 8: Expired registration token → registration fails."""
+
+    def test_expired_token_rejected(self, manager):
+        # Create registration token
+        reg_token = manager.create_registration_token(tenant_id=1, created_by=1)
+
+        # Manually expire it in DB
+        from app.modules.workspace.agent_token import hash_token
+
+        token_hash = hash_token(reg_token)
+        past_time = (datetime.now(timezone.utc) - timedelta(hours=2)).isoformat()
+        with manager.db.connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "UPDATE registration_tokens SET expires_at = ? WHERE token_hash = ?",
+                (past_time, token_hash),
+            )
+            conn.commit()
+
+        # Try to register with expired token
+        result = manager.register_machine(
+            registration_token=reg_token,
+            machine_id="machine-008",
+            machine_name="expired-test",
+        )
+        assert result is None
+
+
+class TestScenario09_ClearLegacyMode:
+    """Scenario 9: Legacy machine uses Bearer → legacy_mode cleared."""
+
+    def test_legacy_cleared_on_bearer_auth(self, manager):
+        # Register a machine
+        reg_token = manager.create_registration_token(tenant_id=1, created_by=1)
+        result = manager.register_machine(
+            registration_token=reg_token,
+            machine_id="machine-009",
+            machine_name="legacy-clear-test",
+        )
+        agent_token = result["agent_token"]
+
+        # Set legacy_mode = True
+        with manager.db.connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "UPDATE remote_machines SET legacy_mode = 1 WHERE machine_id = ?",
+                ("machine-009",),
+            )
+            conn.commit()
+
+        assert manager.is_legacy_machine("machine-009") is True
+
+        # Validate token (simulates Bearer auth) — should NOT auto-clear,
+        # but clear_legacy_mode should work when called
+        assert manager.validate_agent_token(agent_token, "machine-009") is True
+
+        # Clear legacy mode (as the route layer does on Bearer auth)
+        manager.clear_legacy_mode("machine-009")
+
+        # Verify cleared
+        assert manager.is_legacy_machine("machine-009") is False
+
+        # Verify in DB directly
+        with manager.db.connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT legacy_mode FROM remote_machines WHERE machine_id = ?",
+                ("machine-009",),
+            )
+            row = cursor.fetchone()
+            assert row["legacy_mode"] == 0
+
+
+class TestScenario10_ReRegisterAfterRevocation:
+    """Scenario 10: Revoked machine gets new token via rotation."""
+
+    def test_reregister_after_revoke(self, manager):
+        # Register
+        reg_token = manager.create_registration_token(tenant_id=1, created_by=1)
+        result = manager.register_machine(
+            registration_token=reg_token,
+            machine_id="machine-010",
+            machine_name="test-010",
+        )
+        old_token = result["agent_token"]
+
+        # Revoke
+        manager.revoke_agent_token("machine-010", revoked_by=1)
+        assert manager.validate_agent_token(old_token, "machine-010") is False
+
+        # Rotate to re-issue (simulates admin re-enabling)
+        new_token = manager.rotate_agent_token("machine-010", rotated_by=1)
+        assert new_token is not None
+
+        # New token works
+        assert manager.validate_agent_token(new_token, "machine-010") is True
+
+        # _last_rotate_unrevoked should be True (was revoked before rotate)
+        assert manager._last_rotate_unrevoked is True
+
+
+class TestScenario11_DuplicateConsumeRegistrationToken:
+    """Scenario 11: Same registration token used twice → fails."""
+
+    def test_duplicate_consume_rejected(self, manager):
+        # Create registration token
+        reg_token = manager.create_registration_token(tenant_id=1, created_by=1)
+
+        # First use — should succeed
+        result1 = manager.register_machine(
+            registration_token=reg_token,
+            machine_id="dup-machine-1",
+            machine_name="Dup Machine 1",
+        )
+        assert result1 is not None
+
+        # Second use — should fail (already consumed)
+        result2 = manager.register_machine(
+            registration_token=reg_token,
+            machine_id="dup-machine-2",
+            machine_name="Dup Machine 2",
+        )
+        assert result2 is None

--- a/tests/issues/754/test_remote_agent_identity_e2e.py
+++ b/tests/issues/754/test_remote_agent_identity_e2e.py
@@ -179,14 +179,14 @@ class TestScenario05_TokenRotation:
         assert manager.validate_agent_token(old_token, "machine-005") is True
 
         # Rotate
-        new_token = manager.rotate_agent_token("machine-005", rotated_by=1)
-        assert new_token is not None
+        new_result = manager.rotate_agent_token("machine-005", rotated_by=1)
+        assert new_result is not None
 
         # Old token no longer works
         assert manager.validate_agent_token(old_token, "machine-005") is False
 
         # New token works
-        assert manager.validate_agent_token(new_token, "machine-005") is True
+        assert manager.validate_agent_token(new_result["new_token"], "machine-005") is True
 
 
 class TestScenario06_TokenRevocation:
@@ -338,10 +338,10 @@ class TestScenario10_ReRegisterAfterRevocation:
         assert new_token is not None
 
         # New token works
-        assert manager.validate_agent_token(new_token, "machine-010") is True
+        assert manager.validate_agent_token(new_token["new_token"], "machine-010") is True
 
-        # _last_rotate_unrevoked should be True (was revoked before rotate)
-        assert manager._last_rotate_unrevoked is True
+        # Rotate returns unrevoked=True (was revoked before rotate)
+        assert new_token["unrevoked"] is True
 
 
 class TestScenario11_DuplicateConsumeRegistrationToken:


### PR DESCRIPTION
## Summary

从 PR #772 中拆分出的独立 PR，仅包含 Issue #754（远程 Agent 身份加固）的改动。

### 变更内容
- **agent_token.py** (新模块): 安全 token 生成、SHA-256 哈希、前缀提取
- **remote_agent_manager.py** (+429 行): Bearer 认证、token rotation/revocation、registration token 生命周期管理
- **remote.py** (+262 行): 认证中间件、audit 日志、legacy 兼容
- **audit_logger.py** (+7 行): 新增 AGENT_TOKEN_* 审计动作
- **Alembic migration**: registration_tokens、agent_tokens 表和 legacy_mode 列

### 审查反馈已修复
- ~~Critical 2~~: `_last_rotate_unrevoked` 竞态条件 → `rotate_agent_token()` 改为返回 dict
- ~~Medium 1~~: 添加 Alembic migration
- ~~Medium 2~~: 移除冗余 datetime import
- ~~Medium 3~~: cleanup 只删除过期未消费 token，保留审计记录

### 测试
- 11 个 E2E 场景测试全部通过

Closes #754