### PR TITLE
fix: migration 051 drop_constraint bug and AI settings UX

### DIFF
--- a/frontend/src/components/features/settings/AiAgentSettings.tsx
+++ b/frontend/src/components/features/settings/AiAgentSettings.tsx
@@ -96,7 +96,9 @@ export const AiAgentSettings: React.FC = () => {
       toast.success(t('settingsSaved', language));
       setNewToken('');
       setValidationResult(null);
-      refetch();
+      // Await refetch so useEffect updates authorName/authorEmail immediately,
+      // ensuring isDirty becomes false before the next render.
+      await refetch();
     } catch (err) {
       console.error('Failed to save AI agent settings:', err);
       toast.error(t('error', language));
@@ -165,8 +167,8 @@ export const AiAgentSettings: React.FC = () => {
 
       {/* Status Banner */}
       {hasMaskedToken && !hasNewToken && (
-        <div className="alert alert-info d-flex align-items-center mb-3" role="alert">
-          <i className="bi bi-info-circle-fill me-2" />
+        <div className="alert alert-success d-flex align-items-center mb-3" role="status">
+          <i className="bi bi-check-circle-fill me-2" />
           <span>
             <i className="bi bi-github me-1" />
             {t('aiGithubAccountConfigured', language)}

--- a/migrations/versions/20260605_051_fix_project_path_unique_constraint.py
+++ b/migrations/versions/20260605_051_fix_project_path_unique_constraint.py
@@ -67,9 +67,20 @@ def upgrade() -> None:
 
     if conn.dialect.name == "postgresql":
         # PostgreSQL: Use conditional unique index (partial index)
-        # Drop the old unconditional unique constraint
+        # Drop the old unconditional unique constraint/index.
+        # uq_projects_path may be a CONSTRAINT (created via create_unique_constraint)
+        # or a plain UNIQUE INDEX (created via schema_init or create_index).
+        # Use the appropriate drop method based on what actually exists.
         if _index_exists(conn, "uq_projects_path", "projects"):
-            op.drop_constraint("uq_projects_path", "projects", type_="unique")
+            result = conn.execute(
+                sa.text(
+                    "SELECT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'uq_projects_path')"
+                )
+            )
+            if result.fetchone()[0]:
+                op.drop_constraint("uq_projects_path", "projects", type_="unique")
+            else:
+                op.drop_index("uq_projects_path", "projects")
 
         # Create new conditional unique index
         # Only enforce uniqueness for active projects (is_active = TRUE)


### PR DESCRIPTION
## Summary

PR #787 合并后发现的问题修复。

## Changes

### 1. Migration 051 Bug Fix
`migrations/versions/20260605_051_fix_project_path_unique_constraint.py`

**问题**：`uq_projects_path` 在某些环境中是 UNIQUE INDEX（非 CONSTRAINT），但 migration 只用 `op.drop_constraint()` 删除，导致：
```
constraint "uq_projects_path" of relation "projects" does not exist
```

**根因**：通过 `schema_init` 创建的数据库中 `uq_projects_path` 是纯 INDEX；通过 migration 026 创建的才是 CONSTRAINT。Migration 051 的检测方法（查 `pg_indexes`）和删除方法（操作 `pg_constraint`）不匹配。

**修复**：检测存在后，通过 `pg_constraint` 判断对象类型：
- CONSTRAINT → `op.drop_constraint()`
- INDEX → `op.drop_index()`

### 2. AI Agent Settings UX 改进
`frontend/src/components/features/settings/AiAgentSettings.tsx`

- **`await refetch()`**：保存后等待数据刷新完成，确保 `isDirty` 立即变为 `false`，Save 按钮即时置灰
- **状态横幅**：`alert-info`（蓝色 ℹ️）→ `alert-success`（绿色 ✅），明确传达"配置已生效"

## Testing
- `python3 -m alembic upgrade head` 从 050 升级到 054 全部通过
- 本地数据库 `ai_agent_settings` 表已正确创建
- TypeScript 编译通过
- 所有 pre-commit hooks 通过（black, ruff, mypy, bandit 等）

🤖 Generated with [Claude Code](https://claude.com/claude-code)