### PR TITLE
fix: realtime activity stream not showing in UI (Issue #771)

### DIFF
--- a/frontend/src/hooks/useAutonomous.ts
+++ b/frontend/src/hooks/useAutonomous.ts
@@ -85,7 +85,7 @@ export function useWorkflowActivity(workflowId: string, enabled = true) {
       try {
         const data = JSON.parse(event.data);
         if (data.event_type === 'agent_activity') {
-          setActivities((prev) => [...prev.slice(-49), data]);
+          setActivities((prev) => [...prev.slice(-49), data.data]);
         }
       } catch {
         // Ignore parse errors


### PR DESCRIPTION
## Problem

Issue #771 的实时活动流功能（PR #772）合并后前端活动面板始终为空，用户看不到 AI 执行过程。

## Root Cause

`useAutonomous.ts` 第 88 行存在数据解包错误。

SSE 事件负载是三层嵌套结构：
```json
{ "workflow_id": "...", "event_type": "agent_activity", "data": { "session_id": "...", "type": "tool_use", ... } }
```

但前端存储了外层包装对象而非内层 `data` 字段，导致 `act.type`、`act.session_id` 等全部为 `undefined`，渲染条件永远不匹配。

## Fix

一行改动：`data` → `data.data`

```diff
- setActivities((prev) => [...prev.slice(-49), data]);
+ setActivities((prev) => [...prev.slice(-49), data.data]);
```

## Verification

- ✅ 后端测试全部通过（10/10）
- ✅ 数据库验证后端管道正常（session_id、total_tokens 均已正确更新）

Closes #771

🤖 Generated with [Claude Code](https://claude.com/claude-code)