### PR TITLE
fix: add codex to tool filter options

### DIFF
--- a/frontend/src/components/features/Sessions.tsx
+++ b/frontend/src/components/features/Sessions.tsx
@@ -141,6 +141,7 @@ export const Sessions: React.FC = () => {
       { value: 'openclaw', label: 'OpenClaw' },
       { value: 'claude', label: 'Claude' },
       { value: 'qwen', label: 'Qwen' },
+      { value: 'codex', label: 'Codex' },
     ],
     [language]
   );


### PR DESCRIPTION
## 问题描述
Issue: #708

Session 页面的 Tool 过滤框缺少 codex 选项，与后端支持不一致。

## 问题分析
- **前端支持**: openclaw, claude, qwen（3个工具）
- **后端支持**: openclaw, claude, qwen, codex（4个工具）

后端在以下位置已完整支持 codex：
- app/utils/tool_names.py: TOOL_NAME_ALIASES 和 CANONICAL_TOOL_NAMES
- remote-agent/cli_adapters/__init__.py: ADAPTERS 包含 CodexCLIAdapter

## 修改内容
在 frontend/src/components/features/Sessions.tsx 的 toolOptions 中添加 codex 选项。

## 测试建议
1. 访问 Sessions 页面
2. 检查 Tool 过滤下拉框是否显示 Codex 选项
3. 选择 Codex 过滤器，验证是否能正确过滤 codex 类型的会话

Closes #708