### PR TITLE
fix: SSE stream headers delayed causing EventSource stuck in CONNECTING (Issue #771)

### DIFF
--- a/app/routes/autonomous.py
+++ b/app/routes/autonomous.py
@@ -644,6 +644,10 @@ def stream_workflow_events(workflow_id):
     q = emitter.subscribe(workflow_id)
 
     def generate():
+        # Yield immediately so Flask sends response headers — otherwise
+        # the browser's EventSource stays in CONNECTING (readyState 0)
+        # until the first q.get() returns (up to 30 s).
+        yield ": connected\n\n"
         try:
             while True:
                 try:


### PR DESCRIPTION
## Problem

Issue #771 的实时活动流在浏览器中完全不工作：EventSource 停留在 CONNECTING (readyState=0) 状态，永远不转为 OPEN。

## Root Cause

Flask SSE 端点的 `generate()` 函数在第一次 yield 之前阻塞在 `q.get(timeout=30)` 上（最长 30 秒），导致 Flask 延迟发送 HTTP 响应头。浏览器的 EventSource 必须收到 `200 OK` + `Content-Type: text/event-stream` 头部才会从 readyState=0 转为 readyState=1。

## Fix

在 `generate()` 开头立即 yield 一条 SSE 注释（`: connected\n\n`），让 Flask 马上发送响应头：

```python
def generate():
    # Yield immediately so Flask sends response headers
    yield ": connected\n\n"
    try:
        while True:
            ...
```

## Verification

- ✅ EventSource 成功触发 OPEN 事件，readyState=1
- ✅ SSE 事件流正常推送 agent_activity 事件
- ✅ 前端 `data.data` 修复（PR #789）+ 本修复 = 完整方案

Related: #771, PR #789

🤖 Generated with [Claude Code](https://claude.com/claude-code)