### PR TITLE
feat: add date range filter to Dashboard summary

### DIFF
--- a/app/repositories/daily_stats_repo.py
+++ b/app/repositories/daily_stats_repo.py
@@ -144,6 +144,92 @@ class DailyStatsRepository:
 
         return sorted(merged.values(), key=lambda x: x.get("total_tokens", 0), reverse=True)
 
+    def get_tool_totals_with_range(
+        self,
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+        host_name: Optional[str] = None,
+    ) -> dict[str, dict]:
+        """
+        Get tool totals with all required fields for summary API.
+
+        This method returns a dict format (keyed by tool_name) with all fields
+        required by the frontend ToolSummary type, including days_count, avg_tokens,
+        first_date, and last_date.
+
+        Args:
+            start_date: Optional start date filter.
+            end_date: Optional end date filter.
+            host_name: Optional host name filter.
+
+        Returns:
+            Dict[str, Dict]: Summary data keyed by normalized tool name.
+        """
+        conditions = []
+        params = []
+
+        if start_date:
+            conditions.append("date >= ?")
+            params.append(start_date)
+        if end_date:
+            conditions.append("date <= ?")
+            params.append(end_date)
+        if host_name:
+            conditions.append("host_name = ?")
+            params.append(host_name)
+
+        where_clause = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+
+        query = f"""
+            SELECT
+                tool_name,
+                SUM(total_tokens) as total_tokens,
+                SUM(total_input_tokens) as total_input_tokens,
+                SUM(total_output_tokens) as total_output_tokens,
+                SUM(message_count) as message_count,
+                COUNT(DISTINCT date) as days_count,
+                MIN(date) as first_date,
+                MAX(date) as last_date
+            FROM daily_stats
+            {where_clause}
+            GROUP BY tool_name
+        """
+
+        rows = self.db.fetch_all(query, tuple(params))
+
+        # Convert to dict format and merge normalized tool names
+        merged: dict[str, dict] = {}
+        for row in rows:
+            tool = normalize_tool_name(row["tool_name"])
+            if tool in merged:
+                existing = merged[tool]
+                existing["total_tokens"] += row["total_tokens"] or 0
+                existing["total_input_tokens"] += row["total_input_tokens"] or 0
+                existing["total_output_tokens"] += row["total_output_tokens"] or 0
+                existing["total_requests"] += row["message_count"] or 0
+                # days_count: use max() as conservative approach (dates may overlap)
+                existing["days_count"] = max(existing["days_count"], row["days_count"] or 0)
+                # first_date: take earliest
+                existing["first_date"] = min(existing["first_date"], row["first_date"] or "")
+                # last_date: take latest
+                existing["last_date"] = max(existing["last_date"], row["last_date"] or "")
+            else:
+                merged[tool] = {
+                    "total_tokens": row["total_tokens"] or 0,
+                    "total_requests": row["message_count"] or 0,
+                    "total_input_tokens": row["total_input_tokens"] or 0,
+                    "total_output_tokens": row["total_output_tokens"] or 0,
+                    "days_count": row["days_count"] or 1,
+                    "first_date": row["first_date"] or start_date or "",
+                    "last_date": row["last_date"] or end_date or "",
+                }
+
+        # Calculate avg_tokens after merging
+        for tool, data in merged.items():
+            data["avg_tokens"] = (data["total_tokens"] or 0) // max(data["days_count"] or 1, 1)
+
+        return merged
+
     def get_user_totals(
         self,
         start_date: Optional[str] = None,

--- a/app/routes/usage.py
+++ b/app/routes/usage.py
@@ -26,12 +26,25 @@ def _require_auth():
 def api_summary():
     """Get summary statistics for all tools from pre-aggregated summary table."""
     host = request.args.get("host")
+    start_date = request.args.get("start")
+    end_date = request.args.get("end")
 
-    # Check if summary needs refresh and refresh if stale
-    if summary_service.needs_refresh():
-        summary_service.refresh_summary()
+    # No date parameters -> use pre-aggregated usage_summary table (fast)
+    if not start_date and not end_date:
+        # Check if summary needs refresh and refresh if stale
+        if summary_service.needs_refresh():
+            summary_service.refresh_summary()
 
-    summary = summary_service.get_summary(host_name=host)
+        summary = summary_service.get_summary(host_name=host)
+    else:
+        # With date parameters -> query from daily_stats table
+        from app.repositories.daily_stats_repo import DailyStatsRepository
+
+        daily_stats_repo = DailyStatsRepository()
+        summary = daily_stats_repo.get_tool_totals_with_range(
+            start_date=start_date, end_date=end_date, host_name=host
+        )
+
     return jsonify(summary)
 
 

--- a/frontend/src/api/dashboard.ts
+++ b/frontend/src/api/dashboard.ts
@@ -43,9 +43,11 @@ export const dashboardApi = {
   /**
    * Get summary data
    */
-  async getSummary(host?: string): Promise<SummaryData> {
+  async getSummary(host?: string, startDate?: string, endDate?: string): Promise<SummaryData> {
     const params: Record<string, string> = {};
     if (host) params.host = host;
+    if (startDate) params.start = startDate;
+    if (endDate) params.end = endDate;
 
     const response = await apiClient.get<SummaryData>('/api/summary', params);
     return response;

--- a/frontend/src/components/features/Dashboard.tsx
+++ b/frontend/src/components/features/Dashboard.tsx
@@ -15,8 +15,9 @@ import {
   TokenTrendChart,
   TokenDistributionChart,
   DashboardSkeleton,
+  TextInput,
 } from '@/components/common';
-import { formatTokens, formatDate, TOOL_DISPLAY_NAMES } from '@/utils';
+import { formatTokens, TOOL_DISPLAY_NAMES } from '@/utils';
 import type { ToolUsage, ToolSummary } from '@/types';
 
 // Color palette for each tool
@@ -32,6 +33,44 @@ const TOOL_COLORS: Record<string, { border: string; background: string; card: st
     card: 'bg-success',
   },
   qwen: { border: 'rgba(54, 162, 235, 1)', background: 'rgba(54, 162, 235, 0.2)', card: 'bg-info' },
+};
+
+// Date range presets
+const DATE_RANGE_PRESETS = [
+  { value: '7', label: 'Last 7 Days' },
+  { value: '30', label: 'Last 30 Days' },
+  { value: 'month', label: 'This Month' },
+  { value: 'last_month', label: 'Last Month' },
+  { value: 'custom', label: 'Custom' },
+];
+
+// Helper to get date string N days ago
+const getDaysAgo = (days: number): string => {
+  const date = new Date();
+  date.setDate(date.getDate() - days);
+  return date.toISOString().split('T')[0];
+};
+
+// Helper to get first day of current month
+const getFirstDayOfMonth = (): string => {
+  const date = new Date();
+  return new Date(date.getFullYear(), date.getMonth(), 1).toISOString().split('T')[0];
+};
+
+// Helper to get first day of last month
+const getFirstDayOfLastMonth = (): string => {
+  const date = new Date();
+  return new Date(date.getFullYear(), date.getMonth() - 1, 1).toISOString().split('T')[0];
+};
+
+// Helper to get last day of last month
+const getLastDayOfLastMonth = (): string => {
+  const date = new Date();
+  return new Date(date.getFullYear(), date.getMonth(), 0).toISOString().split('T')[0];
+};
+
+const getToday = (): string => {
+  return new Date().toISOString().split('T')[0];
 };
 
 // Sort configuration type
@@ -51,15 +90,40 @@ export const Dashboard: React.FC = () => {
   const [sortKey, setSortKey] = useState<SortKey | null>(null);
   const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
 
-  // Get date range for trend data (last 30 days)
+  // Date range state
+  const [dateRangePreset, setDateRangePreset] = useState('30');
+  const [customStartDate, setCustomStartDate] = useState(getDaysAgo(30));
+  const [customEndDate, setCustomEndDate] = useState(getToday());
+  const [useCustomRange, setUseCustomRange] = useState(false);
+
+  // Compute actual date range based on preset or custom
   const { startDate, endDate } = useMemo(() => {
-    const end = new Date();
-    const start = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
-    return {
-      startDate: formatDate(start, 'iso'),
-      endDate: formatDate(end, 'iso'),
-    };
-  }, []);
+    if (useCustomRange) {
+      return { startDate: customStartDate, endDate: customEndDate };
+    }
+    switch (dateRangePreset) {
+      case '7':
+        return { startDate: getDaysAgo(7), endDate: getToday() };
+      case '30':
+        return { startDate: getDaysAgo(30), endDate: getToday() };
+      case 'month':
+        return { startDate: getFirstDayOfMonth(), endDate: getToday() };
+      case 'last_month':
+        return { startDate: getFirstDayOfLastMonth(), endDate: getLastDayOfLastMonth() };
+      default:
+        return { startDate: getDaysAgo(30), endDate: getToday() };
+    }
+  }, [dateRangePreset, useCustomRange, customStartDate, customEndDate]);
+
+  // Handle preset change
+  const handlePresetChange = (value: string) => {
+    if (value === 'custom') {
+      setUseCustomRange(true);
+    } else {
+      setUseCustomRange(false);
+      setDateRangePreset(value);
+    }
+  };
 
   // Use combined dashboard hook with trend data for parallel fetching
   const { todayData, summaryData, hosts, trendData, isLoading, isError, error, refetch } =
@@ -114,6 +178,12 @@ export const Dashboard: React.FC = () => {
     [language]
   );
 
+  // Date range preset options
+  const dateRangeOptions = useMemo(
+    () => DATE_RANGE_PRESETS.map((preset) => ({ value: preset.value, label: preset.label })),
+    []
+  );
+
   if (isLoading) {
     return <DashboardSkeleton />;
   }
@@ -127,7 +197,31 @@ export const Dashboard: React.FC = () => {
       {/* Header */}
       <div className="dashboard-header d-flex justify-content-between align-items-center mb-4">
         <h2>{t('dashboardTitle', language)}</h2>
-        <div className="page-header-controls">
+        <div className="page-header-controls d-flex gap-2 align-items-center">
+          {/* Date Range Selector */}
+          <Select
+            options={dateRangeOptions}
+            value={useCustomRange ? 'custom' : dateRangePreset}
+            onChange={handlePresetChange}
+            size="sm"
+            className="select-narrow"
+          />
+          {useCustomRange && (
+            <>
+              <TextInput
+                type="date"
+                value={customStartDate}
+                onChange={setCustomStartDate}
+                className="date-input-narrow"
+              />
+              <TextInput
+                type="date"
+                value={customEndDate}
+                onChange={setCustomEndDate}
+                className="date-input-narrow"
+              />
+            </>
+          )}
           <Select
             options={hostOptions}
             value={selectedHost}

--- a/frontend/src/hooks/useDashboard.ts
+++ b/frontend/src/hooks/useDashboard.ts
@@ -32,10 +32,10 @@ export function useTodayUsage(options: UseDashboardOptions = {}) {
   });
 }
 
-export function useSummary(host?: string) {
+export function useSummary(host?: string, startDate?: string, endDate?: string) {
   return useQuery<SummaryData>({
-    queryKey: ['dashboard', 'summary', { host }],
-    queryFn: () => dashboardApi.getSummary(host),
+    queryKey: ['dashboard', 'summary', { host, startDate, endDate }],
+    queryFn: () => dashboardApi.getSummary(host, startDate, endDate),
     staleTime: 5 * 60 * 1000, // 5 minutes
     refetchOnWindowFocus: true,
   });
@@ -73,8 +73,8 @@ export function useDashboard(options: UseDashboardOptions = {}) {
         refetchOnWindowFocus: true,
       },
       {
-        queryKey: ['dashboard', 'summary', { host }],
-        queryFn: () => dashboardApi.getSummary(host),
+        queryKey: ['dashboard', 'summary', { host, startDate, endDate }],
+        queryFn: () => dashboardApi.getSummary(host, startDate, endDate),
         staleTime: 5 * 60 * 1000, // 5 minutes
         refetchOnWindowFocus: true,
       },


### PR DESCRIPTION
## Summary

Add date range filtering capability to Dashboard page, allowing users to filter summary data (overview cards and tools table) by date range.

## Changes

### Backend
- Add `get_tool_totals_with_range()` method in `daily_stats_repo.py` that:
  - Returns dict format keyed by normalized tool name
  - Includes all required fields: `days_count`, `avg_tokens`, `first_date`, `last_date`
  - Properly merges normalized tool names with correct field aggregation

- Extend `/api/summary` endpoint to support `start` and `end` date params:
  - No date params → uses pre-aggregated `usage_summary` table (fast)
  - With date params → queries from `daily_stats` table dynamically

### Frontend
- Extend `dashboardApi.getSummary()` to accept `startDate` and `endDate` params
- Update `useDashboard` and `useSummary` hooks to pass date params
- Add date range selector UI in Dashboard.tsx with presets:
  - Last 7 Days
  - Last 30 Days
  - This Month
  - Last Month
  - Custom (with date picker inputs)

## Implementation Details

The new `get_tool_totals_with_range()` method follows the refined fix proposal from Issue #215 comments:

1. **Format conversion**: Returns `dict[str, dict]` format (keyed by tool name) matching frontend `SummaryData` type
2. **Complete field merging**: Merges all fields including `total_input_tokens`, `total_output_tokens`, `first_date`, `last_date`
3. **days_count handling**: Uses `max()` as conservative approach (dates may overlap across merged tools)
4. **first_date/last_date**: Takes min/max across merged rows for correct date range
5. **avg_tokens**: Calculated after merging completes
6. **Null handling**: Empty values use parameter values or empty string

## Testing

- Frontend typecheck passes ✓
- Frontend build succeeds ✓

## Screenshots

(Manual testing recommended to verify date selector UI and data filtering behavior)

## Related Issue

Fixes #215