### PR TITLE
fix: workflow total_requests should match session request counts

### DIFF
--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -247,9 +247,10 @@ class AutonomousOrchestrator:
                 "total_tokens": result.total_tokens,
                 "total_input_tokens": result.total_input_tokens,
                 "total_output_tokens": result.total_output_tokens,
-                "total_requests": 1,
             },
         )
+        # Recalculate request count from actual session_messages
+        self.repo.recalculate_workflow_requests(self._workflow_id)
 
     def _on_agent_activity(self, session_id: str, activity: dict):
         """Forward agent activity to the SSE event stream and update tokens."""
@@ -270,7 +271,6 @@ class AutonomousOrchestrator:
                         "total_tokens": activity.get("total_tokens", 0),
                         "total_input_tokens": activity.get("total_input_tokens", 0),
                         "total_output_tokens": activity.get("total_output_tokens", 0),
-                        "total_requests": 1,
                     },
                 )
             except Exception:

--- a/app/repositories/autonomous_repo.py
+++ b/app/repositories/autonomous_repo.py
@@ -288,7 +288,6 @@ class AutonomousWorkflowRepository:
                 total_tokens = total_tokens + ?,
                 total_input_tokens = total_input_tokens + ?,
                 total_output_tokens = total_output_tokens + ?,
-                total_requests = total_requests + ?,
                 updated_at = ?
             WHERE workflow_id = ?
             """,
@@ -296,7 +295,37 @@ class AutonomousWorkflowRepository:
                 tokens.get("total_tokens", 0),
                 tokens.get("total_input_tokens", 0),
                 tokens.get("total_output_tokens", 0),
-                tokens.get("total_requests", 1),
+                datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S"),
+                workflow_id,
+            ),
+        )
+
+    def recalculate_workflow_requests(self, workflow_id: str) -> None:
+        """Recalculate workflow total_requests from actual session message counts.
+
+        Counts assistant messages across all sessions linked to this workflow's
+        milestones, matching the request count shown in the session list sidebar.
+        """
+
+        ph = "?" if not is_postgresql() else "%s"
+        self.db.execute(
+            f"""
+            UPDATE autonomous_workflows SET
+                total_requests = (
+                    SELECT COALESCE(SUM(cnt), 0) FROM (
+                        SELECT COUNT(*) as cnt
+                        FROM session_messages sm
+                        JOIN workflow_milestones wm ON wm.session_id = sm.session_id
+                        WHERE wm.workflow_id = {ph}
+                        AND wm.session_id IS NOT NULL AND wm.session_id != ''
+                        AND sm.role = 'assistant'
+                    ) sub
+                ),
+                updated_at = ?
+            WHERE workflow_id = {ph}
+            """,
+            (
+                workflow_id,
                 datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S"),
                 workflow_id,
             ),

--- a/tests/issues/771/test_realtime_activity.py
+++ b/tests/issues/771/test_realtime_activity.py
@@ -179,7 +179,6 @@ class TestOrchestratorActivityForwarding:
                 "total_tokens": 10000,
                 "total_input_tokens": 8000,
                 "total_output_tokens": 2000,
-                "total_requests": 1,
             },
         )
 


### PR DESCRIPTION
## Problem

`autonomous_workflows.total_requests` 的计算方式不正确：每次 usage event 和 task completion 都 +1 累加，导致：
1. 双重计数（usage event + task completion 各加一次）
2. 与 session list 左侧栏显示的请求数不一致

例如 `cb7bf4a1` 工作流：实际 assistant 消息 = 9，但 `total_requests` = 4。

## Fix

- 移除 +1 累加方式
- 新增 `recalculate_workflow_requests()` 方法，从 `session_messages` 表计算 COUNT WHERE role = assistant
- 在每次 milestone 完成后重新计算
- 计算方式与 session list sidebar 的 request count 完全一致

## Verification

- ✅ 10 个测试全部通过

Related: #771

🤖 Generated with [Claude Code](https://claude.com/claude-code)