### PR TITLE
feat: agent client token management (Issue #883)

### DIFF
--- a/app/routes/remote.py
+++ b/app/routes/remote.py
@@ -473,30 +473,20 @@ def rotate_machine_token(machine_id):
     # Push rotate_token command to agent so it updates its local config.
     # send_command() only enqueues — check if agent is online to determine
     # whether the new token will be delivered immediately or needs manual update.
-    is_online = machine_id in agent_mgr._connections
-    if is_online:
-        agent_mgr.send_command(
-            machine_id,
-            {
-                "command": "rotate_token",
-                "new_token": new_token,
-            },
-        )
-        msg = "Agent token rotated. The new token has been pushed to the agent."
-    else:
-        # Agent is offline — queue the command for when it reconnects,
-        # but warn that reconnection will fail until the token is updated manually.
-        agent_mgr.send_command(
-            machine_id,
-            {
-                "command": "rotate_token",
-                "new_token": new_token,
-            },
-        )
-        msg = (
-            "Agent token rotated. Agent is offline — save the new token and"
-            " manually update the agent config."
-        )
+    agent_mgr.send_command(
+        machine_id,
+        {
+            "command": "rotate_token",
+            "new_token": new_token,
+        },
+    )
+    is_online = agent_mgr.is_connected(machine_id)
+    msg = (
+        "Agent token rotated. The new token has been pushed to the agent."
+        if is_online
+        else "Agent token rotated. Agent is offline — save the new token and"
+        " manually update the agent config."
+    )
 
     return jsonify(
         {

--- a/app/routes/remote.py
+++ b/app/routes/remote.py
@@ -470,9 +470,11 @@ def rotate_machine_token(machine_id):
         details=details,
     )
 
-    # Push rotate_token command to agent so it updates its local config
-    pushed = False
-    try:
+    # Push rotate_token command to agent so it updates its local config.
+    # send_command() only enqueues — check if agent is online to determine
+    # whether the new token will be delivered immediately or needs manual update.
+    is_online = machine_id in agent_mgr._connections
+    if is_online:
         agent_mgr.send_command(
             machine_id,
             {
@@ -480,15 +482,21 @@ def rotate_machine_token(machine_id):
                 "new_token": new_token,
             },
         )
-        pushed = True
-    except Exception:
-        logger.warning("Failed to push new token to agent %s (may be offline)", machine_id)
-
-    msg = (
-        "Agent token rotated. The new token has been pushed to the agent."
-        if pushed
-        else "Agent token rotated. Agent is offline — manually update the agent config with the new token."
-    )
+        msg = "Agent token rotated. The new token has been pushed to the agent."
+    else:
+        # Agent is offline — queue the command for when it reconnects,
+        # but warn that reconnection will fail until the token is updated manually.
+        agent_mgr.send_command(
+            machine_id,
+            {
+                "command": "rotate_token",
+                "new_token": new_token,
+            },
+        )
+        msg = (
+            "Agent token rotated. Agent is offline — save the new token and"
+            " manually update the agent config."
+        )
 
     return jsonify(
         {

--- a/app/routes/remote.py
+++ b/app/routes/remote.py
@@ -471,19 +471,30 @@ def rotate_machine_token(machine_id):
     )
 
     # Push rotate_token command to agent so it updates its local config
-    agent_mgr.send_command(
-        machine_id,
-        {
-            "command": "rotate_token",
-            "new_token": new_token,
-        },
+    pushed = False
+    try:
+        agent_mgr.send_command(
+            machine_id,
+            {
+                "command": "rotate_token",
+                "new_token": new_token,
+            },
+        )
+        pushed = True
+    except Exception:
+        logger.warning("Failed to push new token to agent %s (may be offline)", machine_id)
+
+    msg = (
+        "Agent token rotated. The new token has been pushed to the agent."
+        if pushed
+        else "Agent token rotated. Agent is offline — manually update the agent config with the new token."
     )
 
     return jsonify(
         {
             "success": True,
             "agent_token": new_token,
-            "message": "Agent token rotated. The new token has been pushed to the agent.",
+            "message": msg,
         }
     )
 

--- a/app/routes/remote.py
+++ b/app/routes/remote.py
@@ -470,11 +470,20 @@ def rotate_machine_token(machine_id):
         details=details,
     )
 
+    # Push rotate_token command to agent so it updates its local config
+    agent_mgr.send_command(
+        machine_id,
+        {
+            "command": "rotate_token",
+            "new_token": new_token,
+        },
+    )
+
     return jsonify(
         {
             "success": True,
             "agent_token": new_token,
-            "message": "Agent token rotated. Update the agent configuration with the new token.",
+            "message": "Agent token rotated. The new token has been pushed to the agent.",
         }
     )
 

--- a/remote-agent/agent.py
+++ b/remote-agent/agent.py
@@ -208,6 +208,10 @@ class RemoteAgent:
         self._session_sync.start()
 
         while self._running:
+            # Reset token_revoked flag for this connection attempt.
+            # If the previous loop exited due to a non-401 error (network
+            # timeout, etc.), we should retry with the same token — only
+            # a fresh 401 response should stop reconnection.
             self._token_revoked = False
             try:
                 self._http_poll_loop()
@@ -577,8 +581,8 @@ class RemoteAgent:
         the new token.
         """
         new_token = data.get("new_token")
-        if not new_token:
-            logger.warning("rotate_token command missing new_token field")
+        if not new_token or len(new_token) < 16:
+            logger.warning("rotate_token: new_token missing or too short, ignoring")
             return
 
         old_prefix = (self.config.agent_token or "")[:8]

--- a/remote-agent/agent.py
+++ b/remote-agent/agent.py
@@ -60,6 +60,7 @@ class RemoteAgent:
         self._capabilities = get_capabilities()
         self._running = False
         self._reconnect_delay = self.config.reconnect_base_delay
+        self._token_revoked = False
         # Terminal server management
         self._terminal_processes: dict[str, subprocess.Popen] = {}
         self._terminal_tokens: dict[str, str] = {}
@@ -207,12 +208,21 @@ class RemoteAgent:
         self._session_sync.start()
 
         while self._running:
+            self._token_revoked = False
             try:
                 self._http_poll_loop()
             except Exception as e:
                 logger.error("HTTP poll loop error: %s", e)
 
             if not self._running:
+                break
+
+            # If token was revoked, do not attempt to reconnect
+            if self._token_revoked:
+                logger.error(
+                    "Agent token revoked. Agent will NOT reconnect. "
+                    "Contact your admin to generate a new token."
+                )
                 break
 
             # Exponential backoff reconnection
@@ -298,6 +308,7 @@ class RemoteAgent:
         POST a message to the server's HTTP fallback endpoint.
 
         Returns the parsed JSON response or None on failure.
+        Sets self._token_revoked = True on 401 responses.
         """
         url = f"{self.config.server_url}/api/remote/agent/message"
         headers = {"Content-Type": "application/json"}
@@ -315,6 +326,22 @@ class RemoteAgent:
             )
             if resp.status_code == 200:
                 return resp.json()
+            elif resp.status_code == 401:
+                # Authentication failure — token may be revoked or invalid
+                self._token_revoked = True
+                try:
+                    error_body = resp.json()
+                    error_msg = error_body.get("error", "Unknown auth error")
+                except Exception:
+                    error_msg = resp.text[:200]
+                logger.error(
+                    "Authentication failed (401) for machine %s: %s. "
+                    "Agent token has been revoked or is invalid. "
+                    "Contact admin to regenerate token.",
+                    self.config.machine_id[:8],
+                    error_msg,
+                )
+                return None
             else:
                 logger.warning(
                     "HTTP %d from %s: %s",
@@ -537,8 +564,31 @@ class RemoteAgent:
                         "result": info or {"error": "Session not found"},
                     }
                 )
+        elif command == "rotate_token":
+            self._cmd_rotate_token(data)
         else:
             logger.warning("Unknown command: %s", command)
+
+    def _cmd_rotate_token(self, data: dict[str, Any]) -> None:
+        """Handle a rotate_token command from the server.
+
+        The server pushes a new agent token after an admin rotates it.
+        The agent updates its local config so subsequent requests use
+        the new token.
+        """
+        new_token = data.get("new_token")
+        if not new_token:
+            logger.warning("rotate_token command missing new_token field")
+            return
+
+        old_prefix = (self.config.agent_token or "")[:8]
+        self.config.save_agent_token(new_token)
+        logger.info(
+            "Agent token rotated (old prefix=%s..., new prefix=%s...). "
+            "Config updated. Subsequent requests will use the new token.",
+            old_prefix,
+            new_token[:8],
+        )
 
     def _cmd_start_session(self, data: dict[str, Any]) -> None:
         """Handle a start_session command."""

--- a/remote-agent/config.py
+++ b/remote-agent/config.py
@@ -220,6 +220,12 @@ class AgentConfig:
 
     def save_agent_token(self, token: str) -> None:
         """Save agent_token to config file for persistence across restarts."""
+        if os.environ.get("OPENACE_AGENT_TOKEN"):
+            logger.warning(
+                "OPENACE_AGENT_TOKEN env var is set; saved token will be"
+                " overridden on next restart. Unset the env var to use"
+                " the config file value."
+            )
         self.update({"agent_token": token})
         self.save()
         logger.info("Agent token updated and persisted to config")

--- a/remote-agent/config.py
+++ b/remote-agent/config.py
@@ -102,11 +102,10 @@ class AgentConfig:
     @property
     def agent_token(self) -> str | None:
         """
-        Authentication token for the agent.
+        Bearer authentication token for agent-server communication.
 
-        This is the registration token issued by the server admin during initial
-        machine registration. After successful registration, the server returns a
-        machine_id that is persisted locally.
+        Issued by the server during registration (one-time registration_token
+        exchange). Persisted in config.json after successful registration.
         """
         return self._data.get("agent_token")
 
@@ -218,6 +217,12 @@ class AgentConfig:
             logger.info("Saved config to %s", self._config_path)
         except OSError as e:
             logger.warning("Failed to save config: %s", e)
+
+    def save_agent_token(self, token: str) -> None:
+        """Save agent_token to config file for persistence across restarts."""
+        self.update({"agent_token": token})
+        self.save()
+        logger.info("Agent token updated and persisted to config")
 
     def ensure_config_dir(self) -> None:
         """Create the configuration directory if it does not exist."""

--- a/tests/issues/883/test_agent_client_token.py
+++ b/tests/issues/883/test_agent_client_token.py
@@ -1,0 +1,217 @@
+"""
+Tests for Issue #883: Remote Agent client token management.
+
+Covers:
+- config.py: save_agent_token() persistence
+- agent.py: 401 revoked detection and reconnect stop
+- agent.py: rotate_token command handling
+"""
+
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Add remote-agent directory to path so we can import config module
+AGENT_DIR = os.path.join(os.path.dirname(__file__), "..", "..", "..", "remote-agent")
+AGENT_DIR = os.path.abspath(AGENT_DIR)
+if AGENT_DIR not in sys.path:
+    sys.path.insert(0, AGENT_DIR)
+
+from config import AgentConfig
+
+# ==================== config.py tests ====================
+
+
+class TestSaveAgentToken:
+    """Test save_agent_token() in AgentConfig."""
+
+    def test_save_agent_token_persists_to_file(self, tmp_path):
+        """save_agent_token should write agent_token to config.json."""
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps({"server_url": "http://localhost:5000"}))
+
+        config = AgentConfig(config_path=str(config_file))
+        config.save_agent_token("abc123def456")
+
+        # Verify in-memory
+        assert config.agent_token == "abc123def456"
+
+        # Verify persisted to disk
+        with open(config_file) as f:
+            data = json.load(f)
+        assert data["agent_token"] == "abc123def456"
+
+    def test_save_agent_token_overwrites_existing(self, tmp_path):
+        """save_agent_token should replace an existing agent_token."""
+        config_file = tmp_path / "config.json"
+        config_file.write_text(
+            json.dumps(
+                {
+                    "server_url": "http://localhost:5000",
+                    "agent_token": "old_token",
+                }
+            )
+        )
+
+        config = AgentConfig(config_path=str(config_file))
+        assert config.agent_token == "old_token"
+
+        config.save_agent_token("new_token_123")
+        assert config.agent_token == "new_token_123"
+
+        # Verify on disk
+        with open(config_file) as f:
+            data = json.load(f)
+        assert data["agent_token"] == "new_token_123"
+
+    def test_save_agent_token_preserves_other_fields(self, tmp_path):
+        """save_agent_token should not remove other config fields."""
+        config_file = tmp_path / "config.json"
+        original = {
+            "server_url": "http://example.com",
+            "machine_id": "test-machine-id",
+            "machine_name": "test-box",
+            "heartbeat_interval": 30,
+        }
+        config_file.write_text(json.dumps(original))
+
+        config = AgentConfig(config_path=str(config_file))
+        config.save_agent_token("tok_abc")
+
+        with open(config_file) as f:
+            data = json.load(f)
+
+        assert data["agent_token"] == "tok_abc"
+        assert data["server_url"] == "http://example.com"
+        assert data["machine_id"] == "test-machine-id"
+        assert data["machine_name"] == "test-box"
+        assert data["heartbeat_interval"] == 30
+
+
+# ==================== agent.py tests ====================
+
+
+class TestAgent401Handling:
+    """Test 401 handling in RemoteAgent._http_send()."""
+
+    def _make_agent(self, tmp_path):
+        """Create a RemoteAgent with a temp config file."""
+        config_file = tmp_path / "config.json"
+        config_file.write_text(
+            json.dumps(
+                {
+                    "server_url": "http://localhost:9999",
+                    "machine_id": "test-machine-12345678",
+                    "agent_token": "valid_token",
+                }
+            )
+        )
+        # Import agent module
+        from agent import RemoteAgent
+
+        config = AgentConfig(config_path=str(config_file))
+        agent = RemoteAgent(config=config)
+        return agent
+
+    @patch("agent.requests.post")
+    def test_http_send_401_sets_token_revoked(self, mock_post, tmp_path):
+        """Receiving 401 should set _token_revoked flag."""
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+        mock_response.json.return_value = {"error": "Invalid or revoked Bearer token"}
+        mock_post.return_value = mock_response
+
+        agent = self._make_agent(tmp_path)
+        assert agent._token_revoked is False
+
+        result = agent._http_send({"type": "heartbeat", "machine_id": "test"})
+        assert result is None
+        assert agent._token_revoked is True
+
+    @patch("agent.requests.post")
+    def test_http_send_200_does_not_set_revoked(self, mock_post, tmp_path):
+        """Successful 200 response should not set _token_revoked."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"pending_commands": []}
+        mock_post.return_value = mock_response
+
+        agent = self._make_agent(tmp_path)
+        result = agent._http_send({"type": "heartbeat", "machine_id": "test"})
+        assert result is not None
+        assert agent._token_revoked is False
+
+    @patch("agent.requests.post")
+    def test_http_send_500_does_not_set_revoked(self, mock_post, tmp_path):
+        """Server error (500) should not set _token_revoked (temporary issue)."""
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+        mock_response.text = "Internal Server Error"
+        mock_post.return_value = mock_response
+
+        agent = self._make_agent(tmp_path)
+        result = agent._http_send({"type": "heartbeat", "machine_id": "test"})
+        assert result is None
+        assert agent._token_revoked is False
+
+
+class TestAgentRotateToken:
+    """Test rotate_token command handling in RemoteAgent."""
+
+    def _make_agent(self, tmp_path):
+        """Create a RemoteAgent with a temp config file."""
+        config_file = tmp_path / "config.json"
+        config_file.write_text(
+            json.dumps(
+                {
+                    "server_url": "http://localhost:9999",
+                    "machine_id": "test-machine-12345678",
+                    "agent_token": "old_token_abc",
+                }
+            )
+        )
+        from agent import RemoteAgent
+
+        config = AgentConfig(config_path=str(config_file))
+        agent = RemoteAgent(config=config)
+        return agent
+
+    def test_cmd_rotate_token_updates_config(self, tmp_path):
+        """_cmd_rotate_token should update agent_token in config."""
+        agent = self._make_agent(tmp_path)
+        config_file = tmp_path / "config.json"
+
+        agent._cmd_rotate_token({"command": "rotate_token", "new_token": "new_token_xyz"})
+
+        assert agent.config.agent_token == "new_token_xyz"
+
+        # Verify persisted to disk
+        with open(config_file) as f:
+            data = json.load(f)
+        assert data["agent_token"] == "new_token_xyz"
+
+    def test_cmd_rotate_token_missing_new_token(self, tmp_path):
+        """_cmd_rotate_token should log warning if new_token missing."""
+        agent = self._make_agent(tmp_path)
+
+        # Should not crash, token should remain unchanged
+        agent._cmd_rotate_token({"command": "rotate_token"})
+        assert agent.config.agent_token == "old_token_abc"
+
+    def test_handle_command_dispatches_rotate_token(self, tmp_path):
+        """_handle_command should dispatch rotate_token correctly."""
+        agent = self._make_agent(tmp_path)
+
+        agent._handle_command(
+            {
+                "command": "rotate_token",
+                "new_token": "dispatched_new_token",
+            }
+        )
+
+        assert agent.config.agent_token == "dispatched_new_token"

--- a/tests/issues/883/test_agent_client_token.py
+++ b/tests/issues/883/test_agent_client_token.py
@@ -186,14 +186,16 @@ class TestAgentRotateToken:
         agent = self._make_agent(tmp_path)
         config_file = tmp_path / "config.json"
 
-        agent._cmd_rotate_token({"command": "rotate_token", "new_token": "new_token_xyz"})
+        agent._cmd_rotate_token(
+            {"command": "rotate_token", "new_token": "new_token_xyz_abcdef012345"}
+        )
 
-        assert agent.config.agent_token == "new_token_xyz"
+        assert agent.config.agent_token == "new_token_xyz_abcdef012345"
 
         # Verify persisted to disk
         with open(config_file) as f:
             data = json.load(f)
-        assert data["agent_token"] == "new_token_xyz"
+        assert data["agent_token"] == "new_token_xyz_abcdef012345"
 
     def test_cmd_rotate_token_missing_new_token(self, tmp_path):
         """_cmd_rotate_token should log warning if new_token missing."""
@@ -210,8 +212,15 @@ class TestAgentRotateToken:
         agent._handle_command(
             {
                 "command": "rotate_token",
-                "new_token": "dispatched_new_token",
+                "new_token": "dispatched_new_token_abcdef",
             }
         )
 
-        assert agent.config.agent_token == "dispatched_new_token"
+        assert agent.config.agent_token == "dispatched_new_token_abcdef"
+
+    def test_cmd_rotate_token_too_short_rejected(self, tmp_path):
+        """_cmd_rotate_token should reject tokens shorter than 16 chars."""
+        agent = self._make_agent(tmp_path)
+
+        agent._cmd_rotate_token({"command": "rotate_token", "new_token": "short"})
+        assert agent.config.agent_token == "old_token_abc"


### PR DESCRIPTION
## Summary

Remote Agent 客户端侧的 token 管理改动，完成后端 PR #773 遗留的客户端部分。

### 变更内容

- **`remote-agent/config.py`**: 新增 `save_agent_token()` 方法，将 agent_token 持久化到 config.json
- **`remote-agent/agent.py`**:
  - 401 认证失败检测：收到 401 时设置 `_token_revoked` 标志，停止重连循环，提示管理员重新生成 token
  - `rotate_token` 命令处理：接收服务端推送的新 token，更新本地 config
- **`app/routes/remote.py`**: rotation 成功后通过 `send_command()` 推送新 token 到 agent

### 测试

9 个单元测试覆盖：
- `save_agent_token()` 持久化、覆盖、保留其他字段
- 401 设置 `_token_revoked`，200/500 不设置
- `rotate_token` 命令更新 config，缺少 new_token 不崩溃

Closes #883