### PR TITLE
feat: install scripts persist agent_token after registration (Issue #884)

### DIFF
--- a/remote-agent/install.ps1
+++ b/remote-agent/install.ps1
@@ -359,9 +359,13 @@ try {
 
         # Extract agent_token from registration response and save to config
         if ($response.machine -and $response.machine.agent_token) {
-            $config.agent_token = $response.machine.agent_token
-            $config | ConvertTo-Json | Set-Content -Path "$InstallDir\config.json"
-            Write-Host "[OK] Agent token saved to configuration" -ForegroundColor Green
+            try {
+                $config.agent_token = $response.machine.agent_token
+                $config | ConvertTo-Json | Set-Content -Path "$InstallDir\config.json"
+                Write-Host "[OK] Agent token saved to configuration" -ForegroundColor Green
+            } catch {
+                Write-Host "[WARNING] Failed to save agent_token: $_" -ForegroundColor Yellow
+            }
         } else {
             Write-Host "[INFO] No agent_token in response (server may not support token auth yet)" -ForegroundColor Cyan
         }

--- a/remote-agent/install.ps1
+++ b/remote-agent/install.ps1
@@ -356,6 +356,15 @@ try {
 
     if ($response.success) {
         Write-Host "[OK] Machine registered successfully!" -ForegroundColor Green
+
+        # Extract agent_token from registration response and save to config
+        if ($response.machine -and $response.machine.agent_token) {
+            $config.agent_token = $response.machine.agent_token
+            $config | ConvertTo-Json | Set-Content -Path "$InstallDir\config.json"
+            Write-Host "[OK] Agent token saved to configuration" -ForegroundColor Green
+        } else {
+            Write-Host "[INFO] No agent_token in response (server may not support token auth yet)" -ForegroundColor Cyan
+        }
     } elseif ($response.error) {
         Write-Host "[ERROR] Registration failed: $($response.error)" -ForegroundColor Red
         Write-Host "       This may happen if the machine is already registered. Delete it from the server first to re-register." -ForegroundColor Yellow

--- a/remote-agent/install.sh
+++ b/remote-agent/install.sh
@@ -541,6 +541,33 @@ REGISTER_RESPONSE=$(curl -s -X POST "${SERVER_URL}/api/remote/agent/register" \
 
 if echo "$REGISTER_RESPONSE" | "$PYTHON_PATH" -c "import sys,json; d=json.load(sys.stdin); sys.exit(0 if d.get('success') else 1)" 2>/dev/null; then
     log_success "Machine registered successfully!"
+
+    # Extract agent_token from registration response and save to config
+    AGENT_TOKEN=$(echo "$REGISTER_RESPONSE" | "$PYTHON_PATH" -c "
+import sys, json
+d = json.load(sys.stdin)
+m = d.get('machine', {})
+token = m.get('agent_token', '')
+print(token)
+" 2>/dev/null)
+
+    if [ -n "$AGENT_TOKEN" ]; then
+        "$PYTHON_PATH" -c "
+import json, sys
+config_path = '${INSTALL_DIR}/config.json'
+try:
+    with open(config_path) as f:
+        cfg = json.load(f)
+    cfg['agent_token'] = sys.argv[1]
+    with open(config_path, 'w') as f:
+        json.dump(cfg, f, indent=2)
+except Exception as e:
+    print(f'Warning: Failed to save agent_token: {e}', file=sys.stderr)
+" "$AGENT_TOKEN" 2>/dev/null
+        log_success "Agent token saved to configuration"
+    else
+        log_info "No agent_token in response (server may not support token auth yet)"
+    fi
 else
     log_error "Registration failed. Response: $REGISTER_RESPONSE"
     log_error "Please check your registration token and server URL."

--- a/remote-agent/install.sh
+++ b/remote-agent/install.sh
@@ -545,11 +545,18 @@ if echo "$REGISTER_RESPONSE" | "$PYTHON_PATH" -c "import sys,json; d=json.load(s
     # Extract agent_token from registration response and save to config
     AGENT_TOKEN=$(echo "$REGISTER_RESPONSE" | "$PYTHON_PATH" -c "
 import sys, json
-d = json.load(sys.stdin)
-m = d.get('machine', {})
-token = m.get('agent_token', '')
-print(token)
-" 2>/dev/null)
+try:
+    d = json.load(sys.stdin)
+    m = d.get('machine', {})
+    token = m.get('agent_token', '')
+    print(token)
+except Exception as e:
+    print(f'Warning: Failed to parse agent_token from response: {e}', file=sys.stderr)
+    print('')
+" 2>&1)
+
+    # Trim whitespace from extraction result
+    AGENT_TOKEN=$(echo "$AGENT_TOKEN" | head -1 | tr -d '[:space:]')
 
     if [ -n "$AGENT_TOKEN" ]; then
         if "$PYTHON_PATH" -c "

--- a/remote-agent/install.sh
+++ b/remote-agent/install.sh
@@ -552,19 +552,20 @@ print(token)
 " 2>/dev/null)
 
     if [ -n "$AGENT_TOKEN" ]; then
-        "$PYTHON_PATH" -c "
+        if "$PYTHON_PATH" -c "
 import json, sys
-config_path = '${INSTALL_DIR}/config.json'
-try:
-    with open(config_path) as f:
-        cfg = json.load(f)
-    cfg['agent_token'] = sys.argv[1]
-    with open(config_path, 'w') as f:
-        json.dump(cfg, f, indent=2)
-except Exception as e:
-    print(f'Warning: Failed to save agent_token: {e}', file=sys.stderr)
-" "$AGENT_TOKEN" 2>/dev/null
-        log_success "Agent token saved to configuration"
+config_path = sys.argv[1]
+token = sys.argv[2]
+with open(config_path) as f:
+    cfg = json.load(f)
+cfg['agent_token'] = token
+with open(config_path, 'w') as f:
+    json.dump(cfg, f, indent=2)
+" "${INSTALL_DIR}/config.json" "$AGENT_TOKEN"; then
+            log_success "Agent token saved to configuration"
+        else
+            log_error "Failed to save agent_token to config (check permissions)"
+        fi
     else
         log_info "No agent_token in response (server may not support token auth yet)"
     fi

--- a/remote-agent/install.sh
+++ b/remote-agent/install.sh
@@ -553,10 +553,7 @@ try:
 except Exception as e:
     print(f'Warning: Failed to parse agent_token from response: {e}', file=sys.stderr)
     print('')
-" 2>&1)
-
-    # Trim whitespace from extraction result
-    AGENT_TOKEN=$(echo "$AGENT_TOKEN" | head -1 | tr -d '[:space:]')
+")
 
     if [ -n "$AGENT_TOKEN" ]; then
         if "$PYTHON_PATH" -c "

--- a/tests/issues/884/test_install_agent_token.py
+++ b/tests/issues/884/test_install_agent_token.py
@@ -95,3 +95,53 @@ class TestInstallScriptsRegistrationResponse:
         with open(INSTALL_PS1) as f:
             content = f.read()
         assert "machine_id" in content
+
+
+class TestInstallScriptStructure:
+    """Verify token logic is inside the registration success branch."""
+
+    def test_sh_agent_token_inside_success_branch(self):
+        """install.sh agent_token extraction should be inside the success block."""
+        with open(INSTALL_SH) as f:
+            content = f.read()
+        # Find the registration success block and verify AGENT_TOKEN logic is within it
+        success_match = re.search(
+            r"registered successfully.*?(?=\n\s*else\b|\n\s*fi\b)",
+            content,
+            re.DOTALL,
+        )
+        assert success_match is not None, "Registration success block not found"
+        assert "AGENT_TOKEN" in success_match.group(
+            0
+        ), "AGENT_TOKEN extraction not inside registration success block"
+
+    def test_ps1_agent_token_inside_success_branch(self):
+        """install.ps1 agent_token extraction should be inside the success block."""
+        with open(INSTALL_PS1) as f:
+            content = f.read()
+        # Find the success block and verify agent_token logic is within it
+        success_match = re.search(
+            r"\$response\.success.*?(?=\} elseif|\} catch|\}$)",
+            content,
+            re.DOTALL,
+        )
+        assert success_match is not None, "Registration success block not found"
+        assert "agent_token" in success_match.group(
+            0
+        ), "agent_token extraction not inside registration success block"
+
+    def test_sh_uses_sys_argv_for_path(self):
+        """install.sh should pass config path via sys.argv, not string interpolation."""
+        with open(INSTALL_SH) as f:
+            content = f.read()
+        # The save script should use sys.argv[1] for config_path
+        assert "sys.argv[1]" in content
+        assert "sys.argv[2]" in content
+
+    def test_ps1_has_try_catch_for_token_save(self):
+        """install.ps1 should have try/catch around token save."""
+        with open(INSTALL_PS1) as f:
+            content = f.read()
+        # Verify there's a try block around the token save
+        assert "try {" in content
+        assert "Set-Content" in content

--- a/tests/issues/884/test_install_agent_token.py
+++ b/tests/issues/884/test_install_agent_token.py
@@ -1,0 +1,97 @@
+"""
+Tests for Issue #884: Install scripts persist agent_token after registration.
+
+Validates that install.sh and install.ps1 extract agent_token from the
+registration response and write it to config.json.
+"""
+
+import os
+import re
+
+import pytest
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+INSTALL_SH = os.path.join(REPO_ROOT, "remote-agent", "install.sh")
+INSTALL_PS1 = os.path.join(REPO_ROOT, "remote-agent", "install.ps1")
+
+
+class TestInstallShellAgentToken:
+    """Validate install.sh extracts and saves agent_token."""
+
+    @pytest.fixture
+    def script_content(self):
+        with open(INSTALL_SH) as f:
+            return f.read()
+
+    def test_install_sh_extracts_agent_token(self, script_content):
+        """install.sh should extract agent_token from registration response."""
+        # Should parse response.machine.agent_token
+        assert "machine" in script_content
+        assert "agent_token" in script_content
+
+    def test_install_sh_saves_agent_token_to_config(self, script_content):
+        """install.sh should update config.json with agent_token."""
+        # Should write agent_token into the config file
+        assert "agent_token" in script_content
+        # Should use Python to update config.json
+        assert "config.json" in script_content
+        # Should have the extraction logic near registration success
+        assert "AGENT_TOKEN" in script_content
+
+    def test_install_sh_handles_missing_agent_token(self, script_content):
+        """install.sh should handle case where server does not return agent_token."""
+        # Should have a fallback or check for empty token
+        assert "-n" in script_content  # [ -n "$AGENT_TOKEN" ] check
+
+
+class TestInstallPs1AgentToken:
+    """Validate install.ps1 extracts and saves agent_token."""
+
+    @pytest.fixture
+    def script_content(self):
+        with open(INSTALL_PS1) as f:
+            return f.read()
+
+    def test_install_ps1_extracts_agent_token(self, script_content):
+        """install.ps1 should extract agent_token from registration response."""
+        assert "$response.machine" in script_content
+        assert "agent_token" in script_content
+
+    def test_install_ps1_saves_agent_token_to_config(self, script_content):
+        """install.ps1 should update config.json with agent_token."""
+        assert "$config.agent_token" in script_content
+        assert "ConvertTo-Json" in script_content
+        assert "config.json" in script_content
+
+    def test_install_ps1_handles_missing_agent_token(self, script_content):
+        """install.ps1 should handle case where response.machine is absent."""
+        # Should check $response.machine exists before accessing agent_token
+        assert "$response.machine" in script_content
+
+
+class TestInstallScriptsRegistrationResponse:
+    """Validate both scripts handle the registration response correctly."""
+
+    def test_shell_checks_success_field(self):
+        """install.sh checks d.get('success') from registration response."""
+        with open(INSTALL_SH) as f:
+            content = f.read()
+        assert "success" in content
+
+    def test_ps1_checks_success_field(self):
+        """install.ps1 checks $response.success from registration response."""
+        with open(INSTALL_PS1) as f:
+            content = f.read()
+        assert "$response.success" in content
+
+    def test_shell_config_has_machine_id(self):
+        """install.sh writes machine_id to config.json."""
+        with open(INSTALL_SH) as f:
+            content = f.read()
+        assert "machine_id" in content
+
+    def test_ps1_config_has_machine_id(self):
+        """install.ps1 writes machine_id to config.json."""
+        with open(INSTALL_PS1) as f:
+            content = f.read()
+        assert "machine_id" in content


### PR DESCRIPTION
## Summary

修改安装脚本，注册成功后从服务端响应中提取 `agent_token` 并写入 `config.json`。

### 变更内容

- **`remote-agent/install.sh`**: 注册成功后用 Python 解析 `response.machine.agent_token`，更新 config.json
- **`remote-agent/install.ps1`**: 注册成功后从 `$response.machine.agent_token` 提取 token，更新 config.json
- 两个脚本都兼容不返回 `agent_token` 的旧服务端

### 测试

10 个测试覆盖：
- install.sh 提取、保存、处理缺失 agent_token
- install.ps1 提取、保存、处理缺失 agent_token
- 注册响应处理和 config 字段验证

Closes #884