### PR TITLE
fix(migration): resolve SQLite index name conflicts in 013_add_check_constraints

### DIFF
--- a/migrations/versions/20260328_013_add_check_constraints.py
+++ b/migrations/versions/20260328_013_add_check_constraints.py
@@ -128,6 +128,11 @@ def upgrade() -> None:
     else:
         # SQLite doesn't support ALTER TABLE ADD CONSTRAINT
         # We need to recreate the table
+        # Drop indexes first to avoid name conflicts (SQLite indexes are globally unique)
+        op.execute("DROP INDEX IF EXISTS idx_users_role")
+        op.execute("DROP INDEX IF EXISTS idx_users_email")
+        op.execute("DROP INDEX IF EXISTS idx_users_active")
+        op.execute("DROP INDEX IF EXISTS idx_users_tenant")
         op.execute(
             """
             CREATE TABLE users_new (
@@ -184,6 +189,9 @@ def upgrade() -> None:
         )
     else:
         # SQLite: recreate table with CHECK constraints
+        # Drop indexes first to avoid name conflicts (SQLite indexes are globally unique)
+        op.execute("DROP INDEX IF EXISTS idx_tenants_slug")
+        op.execute("DROP INDEX IF EXISTS idx_tenants_status")
         op.execute(
             """
             CREATE TABLE tenants_new (
@@ -241,6 +249,9 @@ def upgrade() -> None:
         )
     else:
         # SQLite: recreate table with CHECK constraints
+        # Drop indexes first to avoid name conflicts (SQLite indexes are globally unique)
+        op.execute("DROP INDEX IF EXISTS idx_quota_usage_user")
+        op.execute("DROP INDEX IF EXISTS idx_quota_usage_date")
         op.execute(
             """
             CREATE TABLE quota_usage_new (


### PR DESCRIPTION
## 问题描述

Fixes #635

运行 `alembic upgrade head` 初始化数据库时，迁移在版本 `013_add_check_constraints` 失败：

```
sqlite3.OperationalError: index idx_users_role already exists
[SQL: CREATE INDEX idx_users_role ON users_new(role)]
```

### 根本原因

SQLite 索引名**全局唯一**（跨所有表），当版本 013 重建表时：
- 创建临时表（如 `users_new`）
- 在临时表上创建索引（如 `idx_users_role`）
- 但原表（`users`）上已存在同名索引（由版本 003/011 创建）
- 导致索引名冲突

### 修复方案

在 SQLite 重建表之前，先删除旧表上的索引：

| 表 | 删除的索引 |
|----|----------|
| users | `idx_users_role`, `idx_users_email`, `idx_users_active`, `idx_users_tenant` |
| tenants | `idx_tenants_slug`, `idx_tenants_status` |
| quota_usage | `idx_quota_usage_user`, `idx_quota_usage_date` |

### 影响范围

- 仅影响 SQLite 数据库
- PostgreSQL 使用 `ALTER TABLE ADD CONSTRAINT`，不受影响
- 修复后新安装用户可正常完成迁移

### 验证步骤

```bash
# 删除数据库
rm ~/.open-ace/ace.db

# 运行迁移
alembic upgrade head

# 验证版本
alembic current  # 应显示最新版本
```