### PR TITLE
fix(migration): resolve SQLite index conflicts for daily_messages table

### DIFF
--- a/migrations/versions/20260328_013_add_check_constraints.py
+++ b/migrations/versions/20260328_013_add_check_constraints.py
@@ -307,6 +307,14 @@ def upgrade() -> None:
     else:
         # SQLite: recreate table with CHECK constraints
         # Note: This is complex due to many columns, but we need to add constraints
+        # Drop indexes first to avoid name conflicts (SQLite indexes are globally unique)
+        op.execute("DROP INDEX IF EXISTS idx_messages_date_tool_host")
+        op.execute("DROP INDEX IF EXISTS idx_messages_sender_id")
+        op.execute("DROP INDEX IF EXISTS idx_messages_date_role_timestamp")
+        op.execute("DROP INDEX IF EXISTS idx_messages_feishu_conv")
+        op.execute("DROP INDEX IF EXISTS idx_messages_conv_id")
+        op.execute("DROP INDEX IF EXISTS idx_messages_date_conv")
+        op.execute("DROP INDEX IF EXISTS idx_messages_query_optimized")
         op.execute(
             """
             CREATE TABLE daily_messages_new (


### PR DESCRIPTION
## 问题描述

Related to #635

在修复 #891 后验证时发现 `daily_messages` 表仍有索引冲突：

```
sqlite3.OperationalError: index idx_messages_date_tool_host already exists
[SQL: CREATE INDEX idx_messages_date_tool_host ON daily_messages_new(date, tool_name, host_name)]
```

### 根本原因

SQLite 索引名**全局唯一**，版本 013 重建 `daily_messages` 表时：
- 创建临时表 `daily_messages_new`
- 在临时表上创建索引（版本 001/005 已创建同名索引）
- 导致索引名冲突

### 冲突索引列表

| 索引名 | 创建版本 |
|-------|---------|
| `idx_messages_date_tool_host` | 001 |
| `idx_messages_sender_id` | 001 |
| `idx_messages_date_role_timestamp` | 001 |
| `idx_messages_feishu_conv` | 005 |
| `idx_messages_conv_id` | 005 |
| `idx_messages_date_conv` | 005 |
| `idx_messages_query_optimized` | 005 |

### 修复方案

在创建临时表之前，先删除所有冲突索引。

### 验证步骤

```bash
rm ~/.open-ace/ace.db
alembic upgrade head
alembic current  # 应显示最新版本
```