### PR TITLE
fix: 修复 PR #903 合并后的 pre-commit CI 失败

### DIFF
--- a/tests/issues/886/test_cancel_fork_redesign.py
+++ b/tests/issues/886/test_cancel_fork_redesign.py
@@ -48,15 +48,19 @@ def _patch_is_postgresql():
     return patchers
 
 
+def _passthrough_sql(q):
+    """Return SQL query unchanged for SQLite compatibility."""
+    return q
+
+
 def _replace_adapt_sql():
     """Replace adapt_sql with passthrough in all target modules; return originals."""
     originals = {}
-    passthrough = lambda q: q
     for mod_path in _ADAPT_SQL_TARGETS:
         mod = sys.modules.get(mod_path)
         if mod is not None and hasattr(mod, "adapt_sql"):
             originals[mod_path] = mod.adapt_sql
-            mod.adapt_sql = passthrough
+            mod.adapt_sql = _passthrough_sql
     return originals
 
 
@@ -103,8 +107,7 @@ def auto_db(tmp_path):
                 """
             )
             cursor.execute(
-                "INSERT INTO users (username, email, password_hash, role) "
-                "VALUES (?, ?, ?, ?)",
+                "INSERT INTO users (username, email, password_hash, role) " "VALUES (?, ?, ?, ?)",
                 ("admin", "admin@test.com", "hash123", "admin"),
             )
             conn.commit()


### PR DESCRIPTION
## 问题描述

PR #903 合并到 main 后，pre-commit CI 失败：
1. **black**: tests/issues/886/test_cancel_fork_redesign.py 需要格式化
2. **ruff E731**: 第54行使用 lambda 赋值违反规则

## 修复内容

1. 将 lambda q: q 替换为 def _passthrough_sql(q): 函数定义
2. 运行 black 格式化修复字符串拼接格式

## 测试

- python -m black --check ✅
- python -m ruff check ✅

Fixes CI failure after #903 merge.