### PR TITLE
fix: PR #907 代码审查反馈的 5 个改进项

### DIFF
--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -107,6 +107,13 @@ PLANNING_TIMEOUT = 600
 # triggers a refinement round.
 REVIEW_FEEDBACK_MIN_LENGTH = 50
 
+# Minimum review text length (chars) for an approved review to be considered
+# as having substantive improvement suggestions.  A brief approval like
+# "审查结论：方案通过审查。" is ~12 chars — well below this threshold.
+# Reviews exceeding this length after approval likely contain actionable
+# suggestions worth incorporating via the refinement step.
+REVIEW_SUGGESTIONS_MIN_LENGTH = 200
+
 # Phase ordering — used by fork to determine the next phase after the fork point.
 PHASE_ORDER = ["preparation", "planning", "development", "pr_review", "report", "merge"]
 
@@ -201,10 +208,32 @@ class AutonomousOrchestrator:
         """
         if not text:
             return text
-        match = re.search(r"^#\s", text, re.MULTILINE)
+        match = re.search(r"^#{1,6}\s", text, re.MULTILINE)
         if match:
             return text[match.start() :]
         return text
+
+    @staticmethod
+    def _should_show_review_warning(round_num: int, max_rounds: int, last_review: str) -> bool:
+        """Whether to append a "feedback not yet addressed" warning.
+
+        True when the planning loop exhausted all rounds without the
+        reviewer approving the plan (no "方案通过审查" in the last review).
+        """
+        return bool(last_review and round_num >= max_rounds and "方案通过审查" not in last_review)
+
+    @staticmethod
+    def _should_refine_plan(last_review: str) -> bool:
+        """Whether the approved review contains substantive suggestions.
+
+        True when the review approved the plan ("方案通过审查" present)
+        *and* the review text is long enough to contain actionable
+        improvement suggestions (exceeds REVIEW_SUGGESTIONS_MIN_LENGTH).
+        """
+        if not last_review:
+            return False
+        review_approved = "方案通过审查" in last_review
+        return review_approved and len(last_review.strip()) > REVIEW_SUGGESTIONS_MIN_LENGTH
 
     @staticmethod
     def _smart_truncate_diff(
@@ -910,9 +939,7 @@ class AutonomousOrchestrator:
             # If the review approved the plan but contained improvement
             # suggestions, run a one-time refinement step to incorporate
             # them into the final plan.
-            review_approved = last_review and "方案通过审查" in last_review
-            review_has_suggestions = review_approved and len(last_review.strip()) > 200
-            if review_has_suggestions and final_plan:
+            if self._should_refine_plan(last_review) and final_plan:
                 refine_prompt = (
                     PLANNING_CONTEXT + "以下实现方案已通过审查，但审查专家给出了一些改进建议。\n"
                     "请根据建议优化方案。直接输出优化后的完整方案，"
@@ -939,6 +966,14 @@ class AutonomousOrchestrator:
                 self._accumulate_tokens(refine_result)
                 if refine_result.success and refine_result.response_text:
                     final_plan = refine_result.response_text
+                    # Record refinement as a milestone for crash recovery.
+                    self._create_milestone(
+                        phase="planning",
+                        milestone_type="plan_refined",
+                        title="Plan Refined (Review Suggestions Incorporated)",
+                        plan_content=final_plan,
+                        round_number=round_num,
+                    )
 
             # Clean up agent intro text (e.g. "我来分析代码库...")
             final_plan = self._clean_plan_output(final_plan)
@@ -951,11 +986,7 @@ class AutonomousOrchestrator:
                         f"Plan review completed after {round_num} round(s).\n\n"
                         f"{final_plan}"
                     )
-                    if (
-                        last_review
-                        and round_num >= max_rounds
-                        and "方案通过审查" not in last_review
-                    ):
+                    if self._should_show_review_warning(round_num, max_rounds, last_review):
                         final_comment += (
                             f"\n\n---\n\n"
                             f"## ⚠️ Note: Last review had feedback not yet addressed\n\n"

--- a/tests/issues/886/test_cancel_fork_redesign.py
+++ b/tests/issues/886/test_cancel_fork_redesign.py
@@ -51,7 +51,10 @@ def _patch_is_postgresql():
 def _replace_adapt_sql():
     """Replace adapt_sql with passthrough in all target modules; return originals."""
     originals = {}
-    passthrough = lambda q: q
+
+    def passthrough(q):
+        return q
+
     for mod_path in _ADAPT_SQL_TARGETS:
         mod = sys.modules.get(mod_path)
         if mod is not None and hasattr(mod, "adapt_sql"):
@@ -103,8 +106,7 @@ def auto_db(tmp_path):
                 """
             )
             cursor.execute(
-                "INSERT INTO users (username, email, password_hash, role) "
-                "VALUES (?, ?, ?, ?)",
+                "INSERT INTO users (username, email, password_hash, role) " "VALUES (?, ?, ?, ?)",
                 ("admin", "admin@test.com", "hash123", "admin"),
             )
             conn.commit()

--- a/tests/issues/910/test_pr907_review_feedback.py
+++ b/tests/issues/910/test_pr907_review_feedback.py
@@ -1,0 +1,178 @@
+"""
+Tests for PR #907 code review feedback fixes (Issue #910).
+
+Covers:
+1. _clean_plan_output strips agent intro text (including H2+ headings)
+2. _should_show_review_warning — correct warning trigger logic
+3. _should_refine_plan — refinement trigger logic
+"""
+
+import pytest
+
+from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+# ── Test _clean_plan_output ──────────────────────────────────────────────
+
+
+class TestCleanPlanOutput:
+    """Test the _clean_plan_output static method."""
+
+    def test_strips_intro_text_before_h1_heading(self):
+        """Intro text like '我来分析代码库...' should be removed."""
+        text = (
+            "我来分析代码库，制定详细的实现方案。先探索相关文件。分析完成。\n\n"
+            "---\n\n"
+            "# Token 趋势工具下拉列表动态化 — 实现方案\n\n"
+            "## 一、需求分析\n内容..."
+        )
+        result = AutonomousOrchestrator._clean_plan_output(text)
+        assert result.startswith("# Token 趋势工具下拉列表动态化")
+        assert "我来分析" not in result
+        assert "需求分析" in result
+
+    def test_strips_intro_text_before_h2_heading(self):
+        """H2 headings (## Section) should also be detected as start of plan."""
+        text = "好的，让我来分析这个问题。\n\n" "## 实现方案\n\n" "### 步骤一\n内容..."
+        result = AutonomousOrchestrator._clean_plan_output(text)
+        assert result.startswith("## 实现方案")
+        assert "让我来分析" not in result
+        assert "步骤一" in result
+
+    def test_strips_intro_text_before_h3_heading(self):
+        """H3 headings (### Subsection) should also be detected."""
+        text = "Intro text\n\n### Sub-section Plan\n\nContent here."
+        result = AutonomousOrchestrator._clean_plan_output(text)
+        assert result.startswith("### Sub-section Plan")
+        assert "Intro text" not in result
+
+    def test_keeps_text_starting_with_heading(self):
+        """Text that already starts with # should be unchanged."""
+        text = "# Implementation Plan\n\n## Step 1\nDo something."
+        result = AutonomousOrchestrator._clean_plan_output(text)
+        assert result == text
+
+    def test_empty_string(self):
+        assert AutonomousOrchestrator._clean_plan_output("") == ""
+
+    def test_none_input(self):
+        assert AutonomousOrchestrator._clean_plan_output(None) is None
+
+    def test_no_heading_found(self):
+        """Text without any markdown heading is returned as-is."""
+        text = "This is a plan without any headings."
+        result = AutonomousOrchestrator._clean_plan_output(text)
+        assert result == text
+
+    def test_heading_in_middle(self):
+        """Heading not at the start should still be found."""
+        text = "Some intro text\nMore intro\n\n# Real Plan\n\nContent here."
+        result = AutonomousOrchestrator._clean_plan_output(text)
+        assert result.startswith("# Real Plan")
+        assert "Some intro" not in result
+        assert "Content here" in result
+
+    def test_preserves_content_after_heading(self):
+        """All content after the first heading should be preserved."""
+        text = (
+            "Intro text\n\n"
+            "# Plan Title\n\n"
+            "## Section 1\nContent 1\n\n"
+            "## Section 2\nContent 2\n\n"
+            "```\ncode block\n```\n"
+        )
+        result = AutonomousOrchestrator._clean_plan_output(text)
+        assert "## Section 1" in result
+        assert "## Section 2" in result
+        assert "code block" in result
+
+    def test_h4_heading_detected(self):
+        """H4 headings should also trigger cleanup."""
+        text = "Preamble\n\n#### Deep Section\n\nBody"
+        result = AutonomousOrchestrator._clean_plan_output(text)
+        assert result.startswith("#### Deep Section")
+        assert "Preamble" not in result
+
+
+# ── Test _should_show_review_warning ─────────────────────────────────────
+
+
+class TestShouldShowReviewWarning:
+    """Test the extracted _should_show_review_warning static method."""
+
+    def test_warning_not_shown_when_review_approved(self):
+        """When review contains '方案通过审查', no warning should be shown."""
+        last_review = "审查结论：方案通过审查。建议：可以使用 formatToolName。"
+        result = AutonomousOrchestrator._should_show_review_warning(3, 3, last_review)
+        assert result is False
+
+    def test_warning_shown_when_max_rounds_reached_and_not_approved(self):
+        """Warning should show when max rounds reached and review didn't approve."""
+        last_review = "方案有以下问题需要修复：遗漏了文件。"
+        result = AutonomousOrchestrator._should_show_review_warning(3, 3, last_review)
+        assert result is True
+
+    def test_warning_not_shown_when_no_review(self):
+        """No warning when there's no review."""
+        result = AutonomousOrchestrator._should_show_review_warning(1, 3, "")
+        assert result is False
+
+    def test_warning_not_shown_before_max_rounds(self):
+        """Warning should not show when we haven't reached max rounds yet."""
+        last_review = "方案有问题"
+        result = AutonomousOrchestrator._should_show_review_warning(1, 3, last_review)
+        assert result is False
+
+    def test_warning_shown_with_none_review(self):
+        """None review should not trigger warning."""
+        result = AutonomousOrchestrator._should_show_review_warning(3, 3, None)
+        assert result is False
+
+
+# ── Test _should_refine_plan ─────────────────────────────────────────────
+
+
+class TestShouldRefinePlan:
+    """Test the extracted _should_refine_plan static method."""
+
+    def test_refinement_triggered_when_approved_with_suggestions(self):
+        """When review approves but is long (>200 chars), refinement runs."""
+        last_review = (
+            "审查结论：方案通过审查。\n\n"
+            "不过有以下改进建议：\n"
+            "1. 使用 formatToolName 替代手动索引，"
+            "formatToolName 已包含 fallback 逻辑（首字母大写），更健壮。\n"
+            "2. 对动态工具列表排序，确保下拉列表顺序稳定：\n"
+            "   const sortedTools = useMemo(() => [...tools].sort(), [tools]);\n"
+            "3. 明确排除 ToolAccountsEditor.tsx 不纳入改造范围及理由："
+            "其 TOOL_TYPES 是工具类型（用于工具账号分类配置），"
+            "语义不同于可用工具筛选，应从后端 TOOL_TYPES 常量获取。\n"
+            "4. 统一 i18n 处理：Dashboard.tsx 的硬编码使用了 i18n key，"
+            "改造后统一使用 formatToolName，多余的 i18n key 可以清理。\n"
+            "5. 考虑 enabled 条件：由于这些组件只在管理模式下渲染，"
+            "useTools() 不涉及权限判断，所以不需要额外处理。\n"
+            "以上建议属于锦上添花，不构成方案阻塞。"
+        )
+        result = AutonomousOrchestrator._should_refine_plan(last_review)
+        assert result is True
+
+    def test_no_refinement_when_approved_briefly(self):
+        """Short approved review (<200 chars) should not trigger refinement."""
+        last_review = "审查结论：方案通过审查。方案整体分析准确，无重大问题。"
+        result = AutonomousOrchestrator._should_refine_plan(last_review)
+        assert result is False
+
+    def test_no_refinement_when_no_review(self):
+        """No review at all means no refinement."""
+        result = AutonomousOrchestrator._should_refine_plan("")
+        assert result is False
+
+    def test_no_refinement_when_none_review(self):
+        """None review means no refinement."""
+        result = AutonomousOrchestrator._should_refine_plan(None)
+        assert result is False
+
+    def test_no_refinement_when_not_approved(self):
+        """Review without approval should not trigger refinement."""
+        last_review = "方案有以下问题需要修复：遗漏了文件，需要补充更多测试覆盖。"
+        result = AutonomousOrchestrator._should_refine_plan(last_review)
+        assert result is False


### PR DESCRIPTION
## 来源

PR #907 代码审查反馈：[#issuecomment-4666911782](https://github.com/open-ace/open-ace/pull/907#issuecomment-4666911782)

Closes #910

## 改进项

### 1. `_clean_plan_output` regex 支持所有级别标题 — 中风险 ✅

**问题**：正则 `^#\s` 只匹配 H1，不匹配 H2/H3 等标题。

**修复**：改为 `^#{1,6}\s`，支持 H1-H6 所有 markdown 标题。新增 3 个测试覆盖 H2、H3、H4 场景。

### 2. 精炼步骤添加 milestone 记录 — 低风险 ✅

**问题**：精炼步骤的 `_run_agent` 结果没有调用 `_create_milestone()` 记录，崩溃后无法恢复。

**修复**：精炼成功后调用 `self._create_milestone(phase="planning", milestone_type="plan_refined", ...)`。

### 3. 提取魔术数字 200 为常量 — 低风险 ✅

**问题**：`len(last_review.strip()) > 200` 硬编码阈值。

**修复**：提取为 `REVIEW_SUGGESTIONS_MIN_LENGTH = 200` 常量，与已有 `REVIEW_FEEDBACK_MIN_LENGTH` 并列。

### 4. 提取可测试的静态方法 — 低风险 ✅

**问题**：测试中复制了 orchestrator 的条件逻辑，存在假阳性风险。

**修复**：
- 提取 `_should_show_review_warning(round_num, max_rounds, last_review)` 静态方法
- 提取 `_should_refine_plan(last_review)` 静态方法
- 新增 20 个测试直接调用这些方法（`tests/issues/910/`），原有 `tests/issues/906/` 的测试保留兼容

### 5. Lint 修复 ✅

所有 pre-commit hooks 通过（black、isort、ruff、mypy、bandit 等）。

## 修改文件

| 文件 | 修改内容 |
|------|----------|
| `app/modules/workspace/autonomous/orchestrator.py` | 修复 regex、添加 milestone、提取常量、提取 2 个静态方法 |
| `tests/issues/910/test_pr907_review_feedback.py` | 新增 20 个测试 |