### PR TITLE
fix: 添加 React Query placeholderData 配置修复搜索框焦点丢失问题 (Issue #917)

### DIFF
--- a/frontend/src/hooks/usePrompts.ts
+++ b/frontend/src/hooks/usePrompts.ts
@@ -11,6 +11,10 @@ export function usePrompts(filters?: PromptFilters) {
     queryKey: ['prompts', filters?.category, filters?.search, filters?.page, filters?.limit],
     queryFn: () => promptsApi.list(filters),
     staleTime: 30 * 1000,
+    // Keep previous data when queryKey changes (e.g., search/filter changes)
+    // This prevents UI from showing empty state during data transition,
+    // which would cause focus loss on search input (Issue #684)
+    placeholderData: (previousData) => previousData,
   });
 }
 


### PR DESCRIPTION
## 问题描述

Issue #684（提示词页面搜索框输入一个字符后光标跳出）的修复（PR #770）不完整。

**验证测试结果：**
```
初始 prompts 卡片数: 4
输入 't' 后:
  0-150ms: 焦点=True, 卡片=4
  200ms:   焦点=False, 卡片=0 ← 问题仍然存在！
```

## 问题原因

PR #770 只修改了 `Prompts.tsx` 的 useEffect 分离逻辑，**遗漏了 React Query placeholderData 问题**：

1. 当 `debouncedSearch` 更新时，React Query 的 `queryKey` 变化
2. React Query v5 在 queryKey 变化时会**清空 data**（没有 placeholderData 配置）
3. `templates` 变成空数组，触发 `EmptyState` 渲染
4. DOM 结构变化导致搜索框焦点丢失

## 修复方案

在 `usePrompts.ts` 添加 React Query v5 的 `placeholderData` 配置：

- 当 queryKey 变化时（搜索词变化），保持之前数据作为占位符
- 避免 UI 显示空状态，保持焦点稳定

## 修改的文件

| 文件 | 修改内容 |
|------|----------|
| frontend/src/hooks/usePrompts.ts | 添加 placeholderData: (previousData) => previousData |

## 测试验证

修复后，搜索框输入时：
- 卡片数保持不变（不会变成 0）
- 焦点不会丢失
- 用户可以连续输入

Fixes #917