### PR TITLE
fix: 修复 autonomous workflow 评论质量和重试机制 (Issue #921)

### DIFF
--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -67,7 +67,9 @@ PLANNING_CONTEXT = (
     "2. 不要使用需要交互式确认的 gh CLI 命令（如 gh pr create）\n"
     "3. 只进行分析、阅读代码、输出方案文本，不要修改任何文件或执行写操作\n"
     "4. 如果需要查看项目代码以制定方案，可以使用文件读取和搜索工具\n"
-    "5. 不要执行 git commit、git push、文件写入、文件编辑等操作\n\n"
+    "5. 不要执行 git commit、git push、文件写入、文件编辑等操作\n"
+    "6. 直接输出结构化方案内容，不要添加引导文字(如'我来...'、'让我...'、"
+    "'首先...'等)或结尾引导(如'下一步是否...'、'建议...'等)\n\n"
 )
 
 # Read-only tool sets for planning phase, keyed by CLI tool name.
@@ -138,6 +140,37 @@ CI_POLL_MAX_WAIT = 300  # maximum seconds to wait (5 minutes)
 # the review prompt.  Reviews longer than this are truncated with a
 # notice so the reviewer knows content was omitted.
 PREV_REVIEW_MAX_LENGTH = 3000
+
+# Agent intro/closing text patterns for _clean_agent_text().
+# These match common Chinese agent narration phrases that should not
+# appear in GitHub comments.
+_AGENT_INTRO_PATTERNS = [
+    re.compile(r"^我来[^\n]{0,30}[。！]"),
+    re.compile(r"^让我[^\n]{0,30}[。！]"),
+    re.compile(r"^首先[让我]*[^\n]{0,30}[。！]"),
+    re.compile(r"^现在[我来让]*[^\n]{0,30}[。！]"),
+    re.compile(r"^好的[，,][^\n]{0,30}[。！]"),
+    re.compile(r"^方案[已完]*[^\n]{0,20}[。，！]"),
+    re.compile(r"^探索完成[^\n]*"),
+    re.compile(r"^分析完成[^\n]*"),
+]
+_AGENT_CLOSING_PATTERNS = [
+    re.compile(r"下一步是否需要"),
+    re.compile(r"是否需要开始"),
+    re.compile(r"按照[^\n]*流程"),
+    re.compile(r"按照[^\n]*工作流"),
+    re.compile(r"建议[：:]\s*$"),
+]
+
+# 429 rate limit retry configuration.
+# Rate limit typically resolves within 30 minutes.
+API_RETRY_TOTAL_TIMEOUT = 1800  # max total retry duration (seconds)
+API_RETRY_INITIAL_DELAY = 30  # first retry delay (seconds)
+API_RETRY_MAX_DELAY = 300  # max single retry delay (seconds)
+
+# Test failure retry configuration.
+MAX_TEST_RETRIES = 2  # max retries when test agent itself fails
+MAX_DEV_RETRIES_ON_TEST_FAIL = 2  # max dev round retries for unfixable test failures
 
 
 def _next_phase(current_phase: str) -> str:
@@ -211,19 +244,61 @@ class AutonomousOrchestrator:
         )
 
     @staticmethod
-    def _clean_plan_output(text: str) -> str:
-        """Strip introductory agent output, keep only the structured plan.
+    def _clean_agent_text(text: str) -> str:
+        """Strip agent narration/intro/closing text, keep only structured content.
 
-        Agent responses often begin with thinking/intro text like
-        "我来分析代码库..." before the actual plan content.  This method
-        removes everything before the first markdown heading (# Title).
+        Performs three cleaning passes:
+        1. Strip everything before the first markdown heading (# Title).
+        2. Strip leading lines matching common agent intro patterns
+           (e.g. "我来为这个需求制定详细的实现方案。").
+        3. Strip trailing lines matching common agent closing patterns
+           (e.g. "下一步是否需要开始实施...").
         """
         if not text:
             return text
+
+        # Pass 1: strip before first markdown heading
         match = re.search(r"^#{1,6}\s", text, re.MULTILINE)
         if match:
-            return text[match.start() :]
-        return text
+            text = text[match.start() :]
+
+        # Pass 2: strip leading agent intro lines
+        lines = text.split("\n")
+        start = 0
+        for i, line in enumerate(lines):
+            stripped = line.strip()
+            if not stripped:
+                continue
+            is_heading = bool(re.match(r"^#{1,6}\s", stripped))
+            is_intro = any(p.search(stripped) for p in _AGENT_INTRO_PATTERNS)
+            if is_intro and not is_heading:
+                start = i + 1
+            else:
+                break
+        if start > 0:
+            lines = lines[start:]
+            text = "\n".join(lines)
+
+        # Pass 3: strip trailing agent closing text.
+        # Walk forward to find the first closing pattern match, then strip
+        # everything from that line to the end (including subsequent non-matching
+        # lines like numbered lists that are part of the closing block).
+        lines = text.split("\n")
+        for i, line in enumerate(lines):
+            stripped = line.strip()
+            if stripped and any(p.search(stripped) for p in _AGENT_CLOSING_PATTERNS):
+                # Strip empty lines before the closing text as well
+                while i > 0 and not lines[i - 1].strip():
+                    i -= 1
+                text = "\n".join(lines[:i])
+                break
+
+        return text.strip()
+
+    # Backward-compatible alias for existing tests (Issue #906, #910)
+    @staticmethod
+    def _clean_plan_output(text: str) -> str:
+        return AutonomousOrchestrator._clean_agent_text(text)
 
     @staticmethod
     def _should_show_review_warning(round_num: int, max_rounds: int, last_review: str) -> bool:
@@ -448,8 +523,19 @@ class AutonomousOrchestrator:
         except Exception:
             logger.warning("Failed to link session to milestone", exc_info=True)
 
+    @staticmethod
+    def _is_rate_limited(response: str) -> bool:
+        """Detect 429 rate limit errors in agent response or error text."""
+        if not response:
+            return False
+        response_lower = response.lower()
+        return any(
+            p in response_lower
+            for p in ["429", "quota exceeded", "rate limit", "too many requests"]
+        )
+
     def _run_agent(self, wf: dict = None, **kwargs) -> AgentTaskResult:
-        """Run an agent task with session tracking for cancellation support.
+        """Run an agent task with session tracking and 429 retry support.
 
         Args:
             wf: Optional pre-fetched workflow dict to avoid extra DB queries.
@@ -459,14 +545,13 @@ class AutonomousOrchestrator:
         # before run_agent_task() returns
         if "session_id" not in kwargs:
             kwargs["session_id"] = str(uuid.uuid4())
-        session_id = kwargs["session_id"]
 
         with self._session_lock:
-            self._current_session_id = session_id
+            self._current_session_id = kwargs["session_id"]
 
         # Immediately link session to in_progress milestone so frontend
         # can show session details while the agent is still running
-        self._link_session_to_current_milestone(session_id)
+        self._link_session_to_current_milestone(kwargs["session_id"])
 
         # Inject per-workflow timeout if specified
         if "timeout" not in kwargs:
@@ -476,6 +561,40 @@ class AutonomousOrchestrator:
                 kwargs["timeout"] = int(task_timeout)
 
         result = self._runner.run_agent_task(**kwargs)
+
+        # 429 rate limit retry — exponential backoff, max 30 minutes total
+        retry_start = time.monotonic()
+        delay = API_RETRY_INITIAL_DELAY
+        while (time.monotonic() - retry_start) < API_RETRY_TOTAL_TIMEOUT:
+            response_text = result.response_text or ""
+            error_text = result.error or ""
+            if not (self._is_rate_limited(response_text) or self._is_rate_limited(error_text)):
+                break  # Not a 429 error, no retry needed
+
+            elapsed = int(time.monotonic() - retry_start)
+            logger.warning(
+                "API rate limit (429) detected, retrying in %ds (elapsed: %ds / %ds)",
+                delay,
+                elapsed,
+                API_RETRY_TOTAL_TIMEOUT,
+            )
+            self._emit(
+                "rate_limit_retry",
+                {
+                    "delay": delay,
+                    "elapsed": elapsed,
+                    "total_timeout": API_RETRY_TOTAL_TIMEOUT,
+                },
+            )
+            time.sleep(delay)
+            delay = min(delay * 2, API_RETRY_MAX_DELAY)
+
+            # Generate new session_id for retry
+            kwargs["session_id"] = str(uuid.uuid4())
+            with self._session_lock:
+                self._current_session_id = kwargs["session_id"]
+            self._link_session_to_current_milestone(kwargs["session_id"])
+            result = self._runner.run_agent_task(**kwargs)
 
         with self._session_lock:
             self._current_session_id = result.session_id
@@ -896,7 +1015,7 @@ class AutonomousOrchestrator:
             try:
                 gh.add_issue_comment(
                     issue_number,
-                    f"## 📋 Implementation Plan (Round {round_num})\n\n{self._clean_plan_output(plan_text)}",
+                    f"## 📋 Implementation Plan (Round {round_num})\n\n{self._clean_agent_text(plan_text)}",
                 )
             except GitHubOpsError:
                 pass
@@ -910,7 +1029,9 @@ class AutonomousOrchestrator:
             f"4. 改进建议\n\n"
             f"## 方案\n{plan_text}\n\n"
             f"## 需求\n{requirements}\n\n"
-            f"如果方案没有重大问题，请明确说明'方案通过审查'。"
+            f"如果方案没有重大问题，请明确说明'方案通过审查'。\n\n"
+            f"重要：直接输出审查结果，不要添加引导文字(如'我来审查...'、'让我...'等)"
+            f"或结尾引导(如'下一步是否...'等)。"
         )
 
         review_ms = self._create_milestone(
@@ -966,7 +1087,8 @@ class AutonomousOrchestrator:
         if issue_number:
             try:
                 gh.add_issue_comment(
-                    issue_number, f"## 🔍 Plan Review (Round {round_num})\n\n{review_text}"
+                    issue_number,
+                    f"## 🔍 Plan Review (Round {round_num})\n\n{self._clean_agent_text(review_text)}",
                 )
             except GitHubOpsError:
                 pass
@@ -1043,7 +1165,7 @@ class AutonomousOrchestrator:
                     )
 
             # Clean up agent intro text (e.g. "我来分析代码库...")
-            final_plan = self._clean_plan_output(final_plan)
+            final_plan = self._clean_agent_text(final_plan)
 
             issue_number = wf.get("github_issue_number")
             if issue_number and final_plan:
@@ -1295,11 +1417,88 @@ class AutonomousOrchestrator:
             },
         )
 
+        # Post test results to issue
+        issue_number = wf.get("github_issue_number")
+        if issue_number:
+            try:
+                test_summary = self._clean_agent_text(test_result.response_text or "")[:800]
+                test_comment = (
+                    f"## 🧪 Test Results (Dev Round {dev_round})\n\n"
+                    f"{'✅ All tests passed' if test_result.success else '❌ Tests failed'}\n\n"
+                    f"{test_summary}"
+                )
+                gh.add_issue_comment(issue_number, test_comment)
+            except Exception:
+                pass
+
+        # Handle test failure with retry logic
         if not test_result.success:
-            self._update_workflow(
-                {"status": "failed", "error_message": f"Tests failed: {test_result.error}"}
-            )
-            return
+            # Situation A: test agent itself failed (timeout, API error, etc.)
+            test_retries = wf.get("test_retries", 0) + 1
+            if test_retries <= MAX_TEST_RETRIES:
+                logger.warning(
+                    "Test agent failed (round %d), retry %d/%d: %s",
+                    dev_round,
+                    test_retries,
+                    MAX_TEST_RETRIES,
+                    test_result.error,
+                )
+                self._update_workflow({"test_retries": test_retries})
+                return  # Scheduler will re-call _do_development
+            else:
+                self._update_workflow(
+                    {
+                        "status": "failed",
+                        "error_message": (
+                            f"Test agent failed after {MAX_TEST_RETRIES} retries: "
+                            f"{test_result.error}"
+                        ),
+                    }
+                )
+                return
+
+        # Situation B: test agent succeeded but reported unfixable failures
+        test_response = test_result.response_text or ""
+        _unfixable_keywords = [
+            "无法修复",
+            "不可修复",
+            "无法解决",
+            "unfixable",
+            "cannot fix",
+            "cannot resolve",
+            "unable to fix",
+        ]
+        has_unfixable = any(kw in test_response.lower() for kw in _unfixable_keywords)
+        if has_unfixable:
+            dev_retries = wf.get("dev_retries_on_test_fail", 0) + 1
+            if dev_retries <= MAX_DEV_RETRIES_ON_TEST_FAIL:
+                logger.warning(
+                    "Tests have unfixable failures, starting dev round %d (retry %d/%d)",
+                    dev_round + 1,
+                    dev_retries,
+                    MAX_DEV_RETRIES_ON_TEST_FAIL,
+                )
+                self._update_workflow(
+                    {
+                        "dev_round": dev_round + 1,
+                        "dev_retries_on_test_fail": dev_retries,
+                    }
+                )
+                return  # Scheduler will re-call _do_development with new dev_round
+            else:
+                self._update_workflow(
+                    {
+                        "status": "failed",
+                        "error_message": (
+                            f"Tests have unfixable failures after "
+                            f"{MAX_DEV_RETRIES_ON_TEST_FAIL} dev retries"
+                        ),
+                    }
+                )
+                return
+
+        # Tests passed — clear retry counters
+        self._update_workflow({"test_retries": 0, "dev_retries_on_test_fail": 0})
 
         # Dev completed milestone
         self._create_milestone(
@@ -1498,7 +1697,7 @@ class AutonomousOrchestrator:
                     last_review_text = ms["review_content"]
                     break
             if last_review_text:
-                cleaned_review = self._clean_plan_output(last_review_text)
+                cleaned_review = self._clean_agent_text(last_review_text)
                 truncated = cleaned_review[:PREV_REVIEW_MAX_LENGTH]
                 truncation_notice = (
                     "\n> ⚠️ 以上审查意见已截断至 3000 字符，部分内容可能被省略。\n"
@@ -1522,8 +1721,10 @@ class AutonomousOrchestrator:
             "3. 测试覆盖率\n"
             "4. 性能影响\n"
             "5. 与需求的对齐程度\n"
-            "6. 上一轮审查意见的落实情况（如有）\n\n"
-            "如果没有重大问题，请明确说明'代码审查通过'。"
+            "6. 上一轮审查意见的落实情况(如有)\n\n"
+            "如果没有重大问题，请明确说明'代码审查通过'。\n\n"
+            "重要：直接输出审查结果，不要添加引导文字(如'我来审查...'、'让我...'等)"
+            "或结尾引导(如'下一步是否...'等)。"
         )
 
         # Include CI failures in review prompt if any
@@ -1566,7 +1767,7 @@ class AutonomousOrchestrator:
             try:
                 gh.add_pr_comment(
                     pr_number,
-                    f"## 🔍 Code Review (Round {round_num})\n\n{self._clean_plan_output(review_text)}",
+                    f"## 🔍 Code Review (Round {round_num})\n\n{self._clean_agent_text(review_text)}",
                 )
             except GitHubOpsError:
                 pass
@@ -1596,7 +1797,7 @@ class AutonomousOrchestrator:
 
             fix_prompt = (
                 AUTONOMOUS_CONTEXT
-                + f"根据以下代码审查意见修改代码：\n\n{self._clean_plan_output(review_text)}\n\n"
+                + f"根据以下代码审查意见修改代码：\n\n{self._clean_agent_text(review_text)}\n\n"
                 "重要要求：\n"
                 "1. 修改完成后，运行项目测试确保所有测试通过\n"
                 "2. 如果测试失败，分析失败原因：\n"
@@ -1651,11 +1852,18 @@ class AutonomousOrchestrator:
 
             if pr_number:
                 try:
-                    comment = f"✅ Addressed review feedback (round {round_num})"
+                    # Extract fix summary from agent response
+                    fix_summary = self._clean_agent_text(fix_result.response_text or "")[:600]
+                    comment = (
+                        f"## ✅ Addressed Review Feedback (Round {round_num})\n\n"
+                        f"### Changes Made\n{fix_summary}\n\n"
+                    )
+                    if commit_sha:
+                        comment += f"- Commit: `{commit_sha[:8]}`\n"
                     # Note pre-existing CI failures if fix agent identified them.
                     if self._is_pre_existing_ci_failure(fix_result.response_text or ""):
                         comment += (
-                            "\n\n> ⚠️ 部分 CI 检查失败，" "但经分析为预先存在的问题，非本 PR 引入。"
+                            "\n> ⚠️ 部分 CI 检查失败，" "但经分析为预先存在的问题，非本 PR 引入。\n"
                         )
                     gh.add_pr_comment(pr_number, comment)
                 except GitHubOpsError:
@@ -1669,15 +1877,16 @@ class AutonomousOrchestrator:
         gh = self._get_gh()
         issue_number = wf.get("github_issue_number")
         pr_number = wf.get("github_pr_number")
+        all_milestones = self.repo.list_milestones(self._workflow_id, dev_round=dev_round)
 
-        # Collect milestone summaries
-        milestones = self.repo.list_milestones(self._workflow_id, dev_round=dev_round)
-        summary_parts = []
-        for ms in milestones:
-            if ms.get("status") == "completed" and ms.get("result_summary"):
-                summary_parts.append(f"- {ms.get('title', '')}: {ms['result_summary'][:100]}")
+        # 1. Plan summary (from finalized plan)
+        plan_summary = ""
+        for ms in reversed(all_milestones):
+            if ms.get("plan_content") and ms.get("phase") == "planning":
+                plan_summary = self._clean_agent_text(ms["plan_content"])[:300]
+                break
 
-        # Get diff stats
+        # 2. Diff stats
         diff_stats = {}
         try:
             branch = wf.get("branch_name", "")
@@ -1685,17 +1894,59 @@ class AutonomousOrchestrator:
         except Exception:
             pass
 
-        report = (
-            f"## 📊 Dev Round {dev_round} Progress Report\n\n"
-            f"### Completed\n" + "\n".join(summary_parts[:20]) + "\n\n"
-            f"### Stats\n"
-            f"- Tokens: {wf.get('total_tokens', 0):,}\n"
-            f"- Requests: {wf.get('total_requests', 0)}\n"
+        # 3. Test result summary (from test milestone)
+        test_summary = ""
+        for ms in all_milestones:
+            if ms.get("milestone_type") == "tests_run" and ms.get("result_summary"):
+                test_summary = self._clean_agent_text(ms["result_summary"])[:200]
+                break
+
+        # 4. Code review rounds
+        review_rounds = sum(
+            1
+            for ms in all_milestones
+            if ms.get("milestone_type") == "pr_reviewed" and ms.get("phase") == "pr_review"
         )
+        review_passed = any(
+            "代码审查通过" in (ms.get("review_content") or "")
+            for ms in all_milestones
+            if ms.get("milestone_type") == "pr_reviewed"
+        )
+
+        # Build report
+        report = f"## 📊 Dev Round {dev_round} Summary\n\n"
+
+        if plan_summary:
+            report += f"### 📋 Plan\n{plan_summary}\n\n"
+
+        # Changes section
+        report += "### 📝 Changes\n"
+        branch = wf.get("branch_name", "")
         if diff_stats:
-            report += f"- Changes: +{diff_stats.get('additions', 0)}/-{diff_stats.get('deletions', 0)} ({diff_stats.get('files', 0)} files)\n"
+            report += (
+                f"- Files: {diff_stats.get('files', 0)} changed "
+                f"(+{diff_stats.get('additions', 0)}/-{diff_stats.get('deletions', 0)})\n"
+            )
+        if branch:
+            report += f"- Branch: `{branch}`\n"
+        report += "\n"
+
+        if test_summary:
+            report += f"### 🧪 Tests\n{test_summary}\n\n"
+
+        if review_rounds > 0:
+            report += "### 🔍 Code Review\n"
+            report += f"- Rounds: {review_rounds}\n"
+            report += f"- Final status: {'✅ Passed' if review_passed else '⚠️ Issues found'}\n\n"
+
         if pr_number:
-            report += f"- PR: #{pr_number}\n"
+            report += f"### 🔗 PR\n- PR #{pr_number}\n\n"
+
+        report += (
+            "### 📈 Resources\n"
+            f"- Tokens: {wf.get('total_tokens', 0):,}\n"
+            f"- API Requests: {wf.get('total_requests', 0)}\n"
+        )
 
         self._create_milestone(
             phase="report",

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -194,6 +194,7 @@ class AutonomousOrchestrator:
         self._workflow_id = workflow_id
         self._current_session_id: Optional[str] = None
         self._session_lock = threading.Lock()
+        self._cancel_requested = threading.Event()  # in-memory cancel signal
 
         # Wire session_manager so agent sessions are persisted to DB
         from app.modules.workspace.session_manager import SessionManager
@@ -264,23 +265,30 @@ class AutonomousOrchestrator:
 
         # Pass 2: strip leading agent intro lines, skipping headings/empty lines.
         # Scan up to the first _INTRO_SCAN_LIMIT non-empty, non-heading lines.
+        # Only strip the FIRST contiguous intro block — once we see a heading
+        # after intro lines, stop so that legitimate sub-headings between
+        # intro lines are not deleted.
         _INTRO_SCAN_LIMIT = 5
         lines = text.split("\n")
-        intro_end = 0  # line index after the last consecutive intro line
+        intro_end = 0  # line index after the last contiguous intro line
         non_heading_count = 0
+        seen_intro = False
         for i, line in enumerate(lines):
             stripped = line.strip()
             if not stripped:
                 continue
             is_heading = bool(re.match(r"^#{1,6}\s", stripped))
             if is_heading:
-                continue  # skip headings, don't count toward limit
+                if seen_intro:
+                    break  # stop — don't strip across sub-headings
+                continue  # skip initial headings before any intro
             non_heading_count += 1
             if non_heading_count > _INTRO_SCAN_LIMIT:
                 break  # past scan limit, stop
             is_intro = any(p.search(stripped) for p in _AGENT_INTRO_PATTERNS)
             if is_intro:
                 intro_end = i + 1
+                seen_intro = True
             else:
                 break  # non-intro content found, stop
         if intro_end > 0:
@@ -598,15 +606,15 @@ class AutonomousOrchestrator:
                 },
             )
 
-            # Interruptible sleep: check for cancellation every 5s
+            # Interruptible sleep: check for cancellation every 5s.
+            # Use in-memory flag instead of DB query to avoid overhead.
             slept = 0
+            self._cancel_requested.clear()
             while slept < delay:
                 time.sleep(min(_CANCEL_POLL_INTERVAL, delay - slept))
                 slept += _CANCEL_POLL_INTERVAL
-                # Check if workflow was paused/stopped externally
-                wf_check = self.workflow
-                if wf_check and wf_check.get("status") in ("paused", "stopped"):
-                    logger.info("429 retry cancelled (workflow %s)", wf_check["status"])
+                if self._cancel_requested.is_set():
+                    logger.info("429 retry cancelled (cancel requested)")
                     with self._session_lock:
                         self._current_session_id = result.session_id
                     return result
@@ -626,6 +634,7 @@ class AutonomousOrchestrator:
 
     def cancel_current_task(self):
         """Cancel the currently running agent task (e.g. on pause/stop)."""
+        self._cancel_requested.set()  # signal 429 retry loop to stop
         with self._session_lock:
             session_id = self._current_session_id
         if session_id:

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -262,21 +262,29 @@ class AutonomousOrchestrator:
         if match:
             text = text[match.start() :]
 
-        # Pass 2: strip leading agent intro lines
+        # Pass 2: strip leading agent intro lines, skipping headings/empty lines.
+        # Scan up to the first _INTRO_SCAN_LIMIT non-empty, non-heading lines.
+        _INTRO_SCAN_LIMIT = 5
         lines = text.split("\n")
-        start = 0
+        intro_end = 0  # line index after the last consecutive intro line
+        non_heading_count = 0
         for i, line in enumerate(lines):
             stripped = line.strip()
             if not stripped:
                 continue
             is_heading = bool(re.match(r"^#{1,6}\s", stripped))
+            if is_heading:
+                continue  # skip headings, don't count toward limit
+            non_heading_count += 1
+            if non_heading_count > _INTRO_SCAN_LIMIT:
+                break  # past scan limit, stop
             is_intro = any(p.search(stripped) for p in _AGENT_INTRO_PATTERNS)
-            if is_intro and not is_heading:
-                start = i + 1
+            if is_intro:
+                intro_end = i + 1
             else:
-                break
-        if start > 0:
-            lines = lines[start:]
+                break  # non-intro content found, stop
+        if intro_end > 0:
+            lines = lines[intro_end:]
             text = "\n".join(lines)
 
         # Pass 3: strip trailing agent closing text.
@@ -562,7 +570,10 @@ class AutonomousOrchestrator:
 
         result = self._runner.run_agent_task(**kwargs)
 
-        # 429 rate limit retry — exponential backoff, max 30 minutes total
+        # 429 rate limit retry — exponential backoff, max 30 minutes total.
+        # Use interruptible sleep (check cancel signal every 5s) so the
+        # orchestrator can be paused/stopped during a retry wait.
+        _CANCEL_POLL_INTERVAL = 5  # seconds between cancel checks
         retry_start = time.monotonic()
         delay = API_RETRY_INITIAL_DELAY
         while (time.monotonic() - retry_start) < API_RETRY_TOTAL_TIMEOUT:
@@ -586,7 +597,20 @@ class AutonomousOrchestrator:
                     "total_timeout": API_RETRY_TOTAL_TIMEOUT,
                 },
             )
-            time.sleep(delay)
+
+            # Interruptible sleep: check for cancellation every 5s
+            slept = 0
+            while slept < delay:
+                time.sleep(min(_CANCEL_POLL_INTERVAL, delay - slept))
+                slept += _CANCEL_POLL_INTERVAL
+                # Check if workflow was paused/stopped externally
+                wf_check = self.workflow
+                if wf_check and wf_check.get("status") in ("paused", "stopped"):
+                    logger.info("429 retry cancelled (workflow %s)", wf_check["status"])
+                    with self._session_lock:
+                        self._current_session_id = result.session_id
+                    return result
+
             delay = min(delay * 2, API_RETRY_MAX_DELAY)
 
             # Generate new session_id for retry
@@ -1200,10 +1224,35 @@ class AutonomousOrchestrator:
     # ── Phase: Development ────────────────────────────────────────
 
     def _do_development(self, wf: dict):
-        """Execute development based on finalized plan."""
+        """Execute development based on finalized plan.
+
+        When ``test_retries > 0``, the dev phase was already completed and
+        only the test step needs to be re-run (e.g. the test agent itself
+        timed out or hit an API error on the previous attempt).
+        """
         dev_round = wf.get("dev_round", 1)
         gh = self._get_gh()
+        test_retries = wf.get("test_retries", 0)
 
+        # ── Development phase (skipped on test-only retry) ──
+        if test_retries > 0:
+            logger.info(
+                "Test-only retry %d for dev round %d, skipping development phase",
+                test_retries,
+                dev_round,
+            )
+        else:
+            self._run_development_agent(wf, dev_round, gh)
+
+        # ── Test phase (always runs) ──
+        self._run_test_phase(wf, dev_round, gh)
+
+    def _run_development_agent(self, wf: dict, dev_round: int, gh: GitHubOps):
+        """Run the development agent, verify code changes, and return.
+
+        On failure, updates workflow status to 'failed' and returns.
+        Caller should check workflow status if needed.
+        """
         # Get the finalized plan
         milestones = self.repo.list_milestones(self._workflow_id, phase="planning")
         final_plan = ""
@@ -1281,8 +1330,6 @@ class AutonomousOrchestrator:
 
         if not sha_changed:
             # SHA unchanged (or unavailable) — check for uncommitted changes
-            # regardless of result.success, because the agent may have edited
-            # files but failed for a secondary reason (e.g. couldn't git commit)
             has_uncommitted = False
             try:
                 has_uncommitted = gh.has_uncommitted_changes()
@@ -1290,7 +1337,6 @@ class AutonomousOrchestrator:
                 pass
 
             if has_uncommitted:
-                # Agent modified files but didn't commit — auto-commit
                 logger.info(
                     "Agent left uncommitted changes, auto-committing (success=%s)",
                     result.success,
@@ -1312,8 +1358,6 @@ class AutonomousOrchestrator:
                     has_uncommitted = False
 
         if not sha_changed and not has_uncommitted:
-            # No new commit from this session. Check if the branch already
-            # has commits relative to origin/main (from previous sessions).
             branch_has_changes_vs_base = False
             branch_name = wf.get("branch_name", "")
             base_diff_stats = {}
@@ -1325,7 +1369,6 @@ class AutonomousOrchestrator:
                 pass
 
             if branch_has_changes_vs_base:
-                # Branch has existing changes from prior sessions — treat as success
                 logger.info(
                     "No new commit this session, but branch '%s' has %d commits vs origin/main",
                     branch_name,
@@ -1338,7 +1381,6 @@ class AutonomousOrchestrator:
                     except Exception:
                         pass
             else:
-                # Truly no changes at all
                 logger.warning("Agent reported success but no new commits detected (SHA unchanged)")
                 self.repo.update_milestone(
                     ms.get("milestone_id", ""),
@@ -1377,7 +1419,12 @@ class AutonomousOrchestrator:
             )
             return
 
-        # Run tests
+    def _run_test_phase(self, wf: dict, dev_round: int, gh: GitHubOps):
+        """Run tests, post results to issue, handle retries.
+
+        On unrecoverable failure, updates workflow status to 'failed' and returns.
+        On success, transitions workflow to pr_review phase.
+        """
         test_ms = self._create_milestone(
             phase="development",
             dev_round=dev_round,
@@ -1444,7 +1491,7 @@ class AutonomousOrchestrator:
                     test_result.error,
                 )
                 self._update_workflow({"test_retries": test_retries})
-                return  # Scheduler will re-call _do_development
+                return  # Scheduler will re-call _do_development (skips dev)
             else:
                 self._update_workflow(
                     {
@@ -1459,16 +1506,18 @@ class AutonomousOrchestrator:
 
         # Situation B: test agent succeeded but reported unfixable failures
         test_response = test_result.response_text or ""
-        _unfixable_keywords = [
-            "无法修复",
-            "不可修复",
-            "无法解决",
-            "unfixable",
-            "cannot fix",
-            "cannot resolve",
-            "unable to fix",
-        ]
-        has_unfixable = any(kw in test_response.lower() for kw in _unfixable_keywords)
+        _unfixable_marker = "[UNFIXABLE]"
+        has_unfixable = _unfixable_marker in test_response
+        if not has_unfixable:
+            # Fallback: check legacy keywords for backward compatibility
+            _legacy_unfixable = [
+                "无法修复",
+                "不可修复",
+                "cannot fix",
+                "unable to fix",
+            ]
+            has_unfixable = any(kw in test_response.lower() for kw in _legacy_unfixable)
+
         if has_unfixable:
             dev_retries = wf.get("dev_retries_on_test_fail", 0) + 1
             if dev_retries <= MAX_DEV_RETRIES_ON_TEST_FAIL:
@@ -1484,7 +1533,7 @@ class AutonomousOrchestrator:
                         "dev_retries_on_test_fail": dev_retries,
                     }
                 )
-                return  # Scheduler will re-call _do_development with new dev_round
+                return
             else:
                 self._update_workflow(
                     {
@@ -1510,7 +1559,6 @@ class AutonomousOrchestrator:
         )
 
         # Post development status to issue
-        issue_number = wf.get("github_issue_number")
         if issue_number:
             try:
                 branch = wf.get("branch_name", "")

--- a/tests/issues/921/test_workflow_comment_retry.py
+++ b/tests/issues/921/test_workflow_comment_retry.py
@@ -68,6 +68,28 @@ class TestCleanAgentTextPass2:
         assert "分析完成" not in result
         assert "### Design" in result
 
+    def test_does_not_strip_across_sub_headings(self):
+        """Intro lines separated by sub-headings should not cause heading deletion.
+
+        See PR #922 Review Round 2 Issue #1: the sub-heading between two
+        intro blocks should be preserved — only the first contiguous intro
+        block (before the first sub-heading) should be stripped.
+        """
+        text = (
+            "## 实现方案\n\n"
+            "我来为这个方案做补充。\n\n"
+            "### 子标题\n\n"
+            "让我再检查一下这个细节。\n\n"
+            "### 核心内容\n实际内容..."
+        )
+        result = AutonomousOrchestrator._clean_agent_text(text)
+        # First intro block should be stripped
+        assert "我来为这个方案做补充" not in result
+        # Sub-heading and second intro should be preserved
+        assert "### 子标题" in result
+        assert "让我再检查" in result
+        assert "### 核心内容" in result
+
 
 class TestCleanAgentTextPass3:
     """Pass 3: strip trailing closing lines."""

--- a/tests/issues/921/test_workflow_comment_retry.py
+++ b/tests/issues/921/test_workflow_comment_retry.py
@@ -1,0 +1,184 @@
+"""
+Tests for PR #922 autonomous workflow comment quality and retry fixes (Issue #921).
+
+Covers:
+1. _clean_agent_text — Pass 1 (heading strip), Pass 2 (intro strip), Pass 3 (closing strip)
+2. _is_rate_limited — 429 error detection
+"""
+
+import pytest
+
+from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+# ── Test _clean_agent_text ──────────────────────────────────────────────
+
+
+class TestCleanAgentTextPass1:
+    """Pass 1: strip text before first markdown heading."""
+
+    def test_strips_intro_before_heading(self):
+        text = "我来为这个需求制定详细的实现方案。首先进入计划模式。\n\n## 方案总结\n内容..."
+        result = AutonomousOrchestrator._clean_agent_text(text)
+        assert result.startswith("## 方案总结")
+        assert "我来为" not in result
+
+    def test_empty_input(self):
+        assert AutonomousOrchestrator._clean_agent_text("") == ""
+        assert AutonomousOrchestrator._clean_agent_text(None) is None
+
+    def test_no_heading_returns_as_is(self):
+        text = "Just some text without headings."
+        result = AutonomousOrchestrator._clean_agent_text(text)
+        assert result == text
+
+
+class TestCleanAgentTextPass2:
+    """Pass 2: strip leading intro lines after first heading."""
+
+    def test_strips_intro_after_heading(self):
+        """Intro lines appearing right after a heading should be cleaned."""
+        text = "## 实现方案\n\n" "我来为这个方案做最后的补充说明。\n\n" "### 步骤一\n实际内容..."
+        result = AutonomousOrchestrator._clean_agent_text(text)
+        assert "我来为" not in result
+        assert "### 步骤一" in result
+
+    def test_strips_multiple_intro_lines_after_heading(self):
+        text = (
+            "## 方案\n\n"
+            "让我先检查一下代码结构。\n"
+            "好的，现在开始编写方案。\n\n"
+            "### 核心设计\n内容..."
+        )
+        result = AutonomousOrchestrator._clean_agent_text(text)
+        assert "让我先检查" not in result
+        assert "好的，现在开始" not in result
+        assert "### 核心设计" in result
+
+    def test_preserves_content_after_non_intro(self):
+        """Non-intro lines after heading should be preserved."""
+        text = "## 方案\n\n这是一个完整的实现方案。\n\n### 步骤\n内容..."
+        result = AutonomousOrchestrator._clean_agent_text(text)
+        assert "这是一个完整的实现方案" in result
+
+    def test_strips_explore_and_analysis_complete(self):
+        """'探索完成' and '分析完成' should be stripped."""
+        text = "## Plan\n\n探索完成，现在编写方案。\n分析完成。\n\n### Design\ncontent..."
+        result = AutonomousOrchestrator._clean_agent_text(text)
+        assert "探索完成" not in result
+        assert "分析完成" not in result
+        assert "### Design" in result
+
+
+class TestCleanAgentTextPass3:
+    """Pass 3: strip trailing closing lines."""
+
+    def test_strips_closing_next_step(self):
+        text = "## 方案\n\n核心内容。\n\n下一步是否需要开始实施？\n按照项目工作流程，我建议：\n1. 创建 Issue\n2. 开始实施"
+        result = AutonomousOrchestrator._clean_agent_text(text)
+        assert "下一步是否" not in result
+        assert "按照项目工作流程" not in result
+        assert "核心内容" in result
+
+    def test_strips_closing_with_suggestion(self):
+        text = "## Review\n\n审查结果。\n\n是否需要开始实施？"
+        result = AutonomousOrchestrator._clean_agent_text(text)
+        assert "是否需要开始" not in result
+        assert "审查结果" in result
+
+    def test_preserves_normal_ending(self):
+        text = "## 方案\n\n核心内容。\n\n### 总结\n方案可行。"
+        result = AutonomousOrchestrator._clean_agent_text(text)
+        assert "方案可行" in result
+
+
+class TestCleanAgentTextRealWorld:
+    """Test with real-world examples from Issue #829."""
+
+    def test_issue829_implementation_plan(self):
+        """Simulates the actual Implementation Plan comment from Issue #829."""
+        text = (
+            "我来为这个需求制定详细的实现方案。首先进入计划模式进行代码分析和方案设计。"
+            "现在开始分析代码库，探索对话历史页面的结构和数据流。"
+            "探索完成，现在启动 Plan agent 设计实现方案。"
+            "方案已完成，现在提交计划请求用户批准。\n\n"
+            "## 方案总结\n\n"
+            "### 核心要点\n\n需求：添加 Session ID 列。\n\n"
+            "下一步是否需要开始实施？按照项目工作流程，我建议：\n"
+            "1. 首先创建 GitHub Issue 记录完整方案\n"
+            "2. 然后进行代码实现"
+        )
+        result = AutonomousOrchestrator._clean_agent_text(text)
+        assert "我来为" not in result
+        assert "探索完成" not in result
+        assert "方案已完成" not in result
+        assert "下一步是否" not in result
+        assert "## 方案总结" in result
+        assert "### 核心要点" in result
+
+    def test_issue829_plan_review_intro(self):
+        """Simulates the actual Plan Review comment from Issue #829."""
+        text = (
+            "我来严格审查这个实现方案。首先让我验证一些关键假设。"
+            "让我继续检查 toast 的使用方式和其他细节："
+            "现在我有足够的信息来提供完整的审查报告。\n\n"
+            "## 方案审查报告\n\n"
+            "### 1. 遗漏的需求\n\n字段名混淆问题。\n\n"
+            "### 总结\n方案整体可行。"
+        )
+        result = AutonomousOrchestrator._clean_agent_text(text)
+        assert "我来严格审查" not in result
+        assert "让我继续检查" not in result
+        assert "## 方案审查报告" in result
+
+    def test_issue829_code_review_intro(self):
+        """Simulates the actual Code Review comment from Issue #829."""
+        text = (
+            "我来审查这个 PR 的代码变更，检查上一轮审查意见的落实情况。\n\n"
+            "## 审查结果\n\n"
+            "代码质量良好。\n\n"
+            "代码审查通过。"
+        )
+        result = AutonomousOrchestrator._clean_agent_text(text)
+        assert "我来审查" not in result
+        assert "## 审查结果" in result
+        assert "代码审查通过" in result
+
+
+# ── Test _is_rate_limited ──────────────────────────────────────────────
+
+
+class TestIsRateLimited:
+    """Test 429 rate limit detection."""
+
+    def test_detects_429_code(self):
+        assert AutonomousOrchestrator._is_rate_limited("API Error: Request rejected (429)")
+
+    def test_detects_quota_exceeded(self):
+        assert AutonomousOrchestrator._is_rate_limited(
+            "usage allocated quota exceeded. please try again later."
+        )
+
+    def test_detects_rate_limit(self):
+        assert AutonomousOrchestrator._is_rate_limited("Rate limit reached for default model")
+
+    def test_detects_too_many_requests(self):
+        assert AutonomousOrchestrator._is_rate_limited("Too Many Requests - try again later")
+
+    def test_case_insensitive(self):
+        assert AutonomousOrchestrator._is_rate_limited("QUOTA EXCEEDED for this request")
+
+    def test_normal_error_not_detected(self):
+        assert not AutonomousOrchestrator._is_rate_limited("File not found: config.json")
+
+    def test_empty_string(self):
+        assert not AutonomousOrchestrator._is_rate_limited("")
+
+    def test_none(self):
+        assert not AutonomousOrchestrator._is_rate_limited(None)
+
+    def test_issue829_actual_error(self):
+        """Test with the actual error from PR #915 Code Review (Round 2)."""
+        assert AutonomousOrchestrator._is_rate_limited(
+            "API Error: Request rejected (429) · usage allocated quota exceeded. "
+            "please try again later."
+        )


### PR DESCRIPTION
## 问题描述

Issue #829 和 PR #915 的自动化工作流运行暴露了以下问题（详见 Issue #921）：

1. **评论包含 Agent 引导文字** — "我来..."、"让我..."、"下一步是否..."等不应出现
2. **Progress Report 无有价值信息** — 使用原始 agent 输出拼接
3. **测试结果未发布到 Issue** — 测试失败无重试机制
4. **"Addressed review feedback" 评论过于简单** — 无具体修复说明
5. **API 429 错误无自动重试** — 遇到 rate limit 直接放弃

## 修改方案

仅修改一个文件：`app/modules/workspace/autonomous/orchestrator.py` (+294/-43)

### Fix A: 清理 Agent 引导文字
- 新增 `_clean_agent_text()` 方法，三轮清理：
  - Pass 1: 标题前内容清理（原有逻辑）
  - Pass 2: 开头引导行清理（匹配"我来..."、"让我..."等模式）
  - Pass 3: 结尾引导行清理（匹配"下一步是否..."、"按照...流程"等模式）
- 在 Planning / Plan Review / Code Review prompt 中添加禁止引导文字指令
- **Plan Review 评论原先完全未做清理**，现已修复

### Fix B: 重新设计 Progress Report
- 新格式：方案摘要 / 文件变更 / 测试结果 / 代码审查轮次 / PR 链接 / 资源使用
- 不再使用 milestone `result_summary`（原始 agent 输出）拼接

### Fix C: 发布测试结果 + 测试失败自动重试
- 测试完成后发布结果到 issue
- 区分两种情况：
  - 情况 A：测试 agent 自身执行失败 → 重跑测试（最多 2 次）
  - 情况 B：不可修复的失败 → 增加 dev_round 回到开发阶段（最多 2 次）

### Fix D: 丰富 "Addressed review feedback" 评论
- 包含修复摘要 + commit SHA + pre-existing CI 标记

### Fix E: API 429 错误自动重试
- 指数退避：30s → 60s → 120s → 240s → 300s → ...
- 总时长上限 30 分钟（1800 秒）

Closes #921

🤖 Generated with [Claude Code](https://claude.com/claude-code)