### PR TITLE
fix: 添加 title 属性支持到 Button 组件

### DIFF
--- a/frontend/src/components/common/Button.tsx
+++ b/frontend/src/components/common/Button.tsx
@@ -45,12 +45,14 @@ export const Button: React.FC<ButtonProps> = ({
   className,
   id,
   'data-testid': testId,
+  title,
 }) => {
   return (
     <button
       type={type}
       id={id}
       data-testid={testId}
+      title={title}
       className={cn(
         'btn',
         variantClasses[variant],

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -229,6 +229,7 @@ export interface BaseComponentProps {
   id?: string;
   style?: React.CSSProperties;
   'data-testid'?: string;
+  title?: string;
 }
 
 export interface LoadingProps extends BaseComponentProps {


### PR DESCRIPTION
修复构建错误，为 Button 组件添加 title 属性支持。

## 变更内容
- 在 BaseComponentProps 类型中添加 title 属性
- 在 Button 组件中传递 title 属性到 button 元素

## 修复问题
解决 ConversationHistory.tsx 中使用 Button 组件时的 TypeScript 错误。

🤖 Generated with [Claude Code](https://claude.com/claude-code)