### PR TITLE
fix: unify autonomous workflow and sidebar Claude sessions

### DIFF
--- a/app/modules/workspace/autonomous/agent_runner.py
+++ b/app/modules/workspace/autonomous/agent_runner.py
@@ -67,6 +67,10 @@ except (ValueError, TypeError):
     logger.warning("Invalid AUTONOMOUS_TASK_TIMEOUT value, using default 3600")
     DEFAULT_TASK_TIMEOUT = 3600
 
+SESSION_DETECTION_GRACE_SECONDS = 5.0
+SESSION_DETECTION_WAIT_SECONDS = 5.0
+SESSION_DETECTION_POLL_INTERVAL = 0.25
+
 
 @dataclass
 class _LocalSession:
@@ -161,14 +165,17 @@ class AutonomousAgentRunner:
             return ""
 
         latest_file = None
-        latest_mtime = min_mtime_epoch - 1
+        latest_mtime = min_mtime_epoch - SESSION_DETECTION_GRACE_SECONDS
         try:
             for candidate in project_dir.glob("*.jsonl"):
                 try:
                     stat = candidate.stat()
                 except OSError:
                     continue
-                if stat.st_mtime >= min_mtime_epoch - 1 and stat.st_mtime >= latest_mtime:
+                if (
+                    stat.st_mtime >= min_mtime_epoch - SESSION_DETECTION_GRACE_SECONDS
+                    and stat.st_mtime >= latest_mtime
+                ):
                     latest_file = candidate
                     latest_mtime = stat.st_mtime
         except OSError:
@@ -190,8 +197,6 @@ class AutonomousAgentRunner:
         if not persisted_id:
             return ""
 
-        session.persisted_session_id = persisted_id
-
         if self.session_manager:
             try:
                 self.session_manager.create_session(
@@ -207,7 +212,9 @@ class AutonomousAgentRunner:
                 )
             except Exception as e:
                 logger.warning("Failed to create resolved sidebar session: %s", e)
+                return ""
 
+        session.persisted_session_id = persisted_id
         if self._activity_callback:
             self._activity_callback(
                 persisted_id,
@@ -219,13 +226,33 @@ class AutonomousAgentRunner:
 
         return persisted_id
 
+    def _resolve_sidebar_session(
+        self,
+        session: _LocalSession,
+        wait_timeout: float = 0.0,
+    ) -> str:
+        """Resolve the persisted sidebar session, optionally waiting for late JSONL flushes."""
+        if not self._uses_sidebar_session_source(session.cli_tool, session.workspace_type):
+            return session.session_id
+        if session.persisted_session_id:
+            return session.persisted_session_id
+
+        deadline = time.monotonic() + max(wait_timeout, 0.0)
+        while True:
+            persisted_id = self._ensure_sidebar_session(session)
+            if persisted_id:
+                return persisted_id
+            if time.monotonic() >= deadline:
+                return ""
+            time.sleep(SESSION_DETECTION_POLL_INTERVAL)
+
     def _sync_sidebar_session_totals(
         self, session: _LocalSession, status: str | None = None
     ) -> None:
         """Write the current local Claude usage into the persisted sidebar session."""
         if not self._uses_sidebar_session_source(session.cli_tool, session.workspace_type):
             return
-        persisted_id = session.persisted_session_id or self._ensure_sidebar_session(session)
+        persisted_id = session.persisted_session_id or self._resolve_sidebar_session(session)
         if not persisted_id or not self.session_manager:
             return
 
@@ -509,6 +536,16 @@ class AutonomousAgentRunner:
                     pass
 
         self._local_sessions.pop(session_id, None)
+
+        if (
+            completed
+            and self._uses_sidebar_session_source(cli_tool, workspace_type)
+            and not session.persisted_session_id
+        ):
+            self._resolve_sidebar_session(
+                session,
+                wait_timeout=min(SESSION_DETECTION_WAIT_SECONDS, max(timeout, 0)),
+            )
 
         resolved_session_id = (
             session.persisted_session_id
@@ -806,7 +843,7 @@ class AutonomousAgentRunner:
 
                 try:
                     if not session.persisted_session_id:
-                        self._ensure_sidebar_session(session)
+                        self._resolve_sidebar_session(session)
                     parsed = json.loads(line)
                     msg_type = parsed.get("type", "")
 

--- a/app/modules/workspace/autonomous/agent_runner.py
+++ b/app/modules/workspace/autonomous/agent_runner.py
@@ -99,7 +99,6 @@ class _LocalSession:
     remote_machine_id: str | None = None
     started_at_epoch: float = 0.0
     persisted_session_id: str = ""
-    persisted_session_ready: threading.Event = field(default_factory=threading.Event)
 
 
 class AutonomousAgentRunner:
@@ -136,7 +135,11 @@ class AutonomousAgentRunner:
 
     @staticmethod
     def _encode_project_path(project_path: str) -> str:
-        """Match the encoded project path used by sidebar session history."""
+        """Best-effort match for the encoded project path used by Claude session history.
+
+        Today Claude stores absolute paths by replacing "/" with "-". Keep this logic
+        isolated here because it is an implementation detail outside our control.
+        """
         return project_path.replace("/", "-") if project_path.startswith("/") else project_path
 
     def _find_latest_claude_session_id(
@@ -144,7 +147,12 @@ class AutonomousAgentRunner:
         encoded_project_path: str,
         min_mtime_epoch: float,
     ) -> str:
-        """Find the latest Claude JSONL session created for the active worktree."""
+        """Find the latest Claude JSONL session created for the active worktree.
+
+        This is best-effort discovery based on the encoded worktree path and file mtime.
+        It assumes only one local autonomous Claude task is creating a new session for a
+        given worktree at a time; concurrent tasks on the same worktree can still race.
+        """
         if not encoded_project_path:
             return ""
 
@@ -183,7 +191,6 @@ class AutonomousAgentRunner:
             return ""
 
         session.persisted_session_id = persisted_id
-        session.persisted_session_ready.set()
 
         if self.session_manager:
             try:
@@ -798,7 +805,8 @@ class AutonomousAgentRunner:
                 session.output_lines.append(line)
 
                 try:
-                    self._ensure_sidebar_session(session)
+                    if not session.persisted_session_id:
+                        self._ensure_sidebar_session(session)
                     parsed = json.loads(line)
                     msg_type = parsed.get("type", "")
 

--- a/app/modules/workspace/autonomous/agent_runner.py
+++ b/app/modules/workspace/autonomous/agent_runner.py
@@ -16,6 +16,7 @@ import shutil
 import signal
 import subprocess
 import threading
+import time
 import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -34,7 +35,27 @@ def _ensure_usage_parser():
     """Import extract_stream_usage once remote-agent is on sys.path."""
     global _extract_stream_usage
     if _extract_stream_usage is None:
-        from cli_adapters.usage_parser import extract_stream_usage
+        try:
+            from cli_adapters.usage_parser import extract_stream_usage
+        except (ImportError, ModuleNotFoundError):
+            logger.warning("Falling back to built-in stream usage parser")
+
+            def extract_stream_usage(_cli_tool: str, parsed: dict) -> dict | None:
+                usage = parsed.get("usage")
+                if not isinstance(usage, dict):
+                    message = parsed.get("message", {})
+                    if isinstance(message, dict):
+                        usage = message.get("usage")
+                if not isinstance(usage, dict):
+                    data = parsed.get("data", {})
+                    if isinstance(data, dict):
+                        usage = data.get("usage")
+                if not isinstance(usage, dict):
+                    return None
+                return {
+                    "input": int(usage.get("input_tokens", 0) or 0),
+                    "output": int(usage.get("output_tokens", 0) or 0),
+                }
 
         _extract_stream_usage = extract_stream_usage
 
@@ -52,7 +73,7 @@ class _LocalSession:
     """Tracks a local CLI subprocess session."""
 
     session_id: str
-    process: subprocess.Popen
+    process: subprocess.Popen | None
     cli_tool: str = "claude-code"
     allowed_tools: list[str] | None = None
     output_lines: list[str] = field(default_factory=list)
@@ -61,6 +82,7 @@ class _LocalSession:
     total_tokens: int = 0
     total_input_tokens: int = 0
     total_output_tokens: int = 0
+    request_count: int = 0
     completed: threading.Event = field(default_factory=threading.Event)
     error: str | None = None
     _stopped: threading.Event = field(default_factory=threading.Event)
@@ -69,6 +91,15 @@ class _LocalSession:
     # Ordered event log for preserving actual message interleaving
     # Each entry: {"type": "assistant"|"tool_use"|"usage", ...}
     event_log: list[dict] = field(default_factory=list)
+    project_path: str = ""
+    encoded_project_path: str = ""
+    workflow_id: str = ""
+    user_id: int | None = None
+    workspace_type: str = "local"
+    remote_machine_id: str | None = None
+    started_at_epoch: float = 0.0
+    persisted_session_id: str = ""
+    persisted_session_ready: threading.Event = field(default_factory=threading.Event)
 
 
 class AutonomousAgentRunner:
@@ -98,6 +129,116 @@ class AutonomousAgentRunner:
         self._activity_callback = activity_callback
         self._local_sessions: dict[str, _LocalSession] = {}
 
+    @staticmethod
+    def _uses_sidebar_session_source(cli_tool: str, workspace_type: str) -> bool:
+        """Whether this task should resolve to the real sidebar Claude session."""
+        return workspace_type == "local" and cli_tool == "claude-code"
+
+    @staticmethod
+    def _encode_project_path(project_path: str) -> str:
+        """Match the encoded project path used by sidebar session history."""
+        return project_path.replace("/", "-") if project_path.startswith("/") else project_path
+
+    def _find_latest_claude_session_id(
+        self,
+        encoded_project_path: str,
+        min_mtime_epoch: float,
+    ) -> str:
+        """Find the latest Claude JSONL session created for the active worktree."""
+        if not encoded_project_path:
+            return ""
+
+        project_dir = Path.home() / ".claude" / "projects" / encoded_project_path
+        if not project_dir.is_dir():
+            return ""
+
+        latest_file = None
+        latest_mtime = min_mtime_epoch - 1
+        try:
+            for candidate in project_dir.glob("*.jsonl"):
+                try:
+                    stat = candidate.stat()
+                except OSError:
+                    continue
+                if stat.st_mtime >= min_mtime_epoch - 1 and stat.st_mtime >= latest_mtime:
+                    latest_file = candidate
+                    latest_mtime = stat.st_mtime
+        except OSError:
+            return ""
+
+        return latest_file.stem if latest_file else ""
+
+    def _ensure_sidebar_session(self, session: _LocalSession) -> str:
+        """Resolve and create the single persisted sidebar session for local Claude."""
+        if not self._uses_sidebar_session_source(session.cli_tool, session.workspace_type):
+            return session.session_id
+        if session.persisted_session_id:
+            return session.persisted_session_id
+
+        persisted_id = self._find_latest_claude_session_id(
+            session.encoded_project_path,
+            session.started_at_epoch,
+        )
+        if not persisted_id:
+            return ""
+
+        session.persisted_session_id = persisted_id
+        session.persisted_session_ready.set()
+
+        if self.session_manager:
+            try:
+                self.session_manager.create_session(
+                    session_id=persisted_id,
+                    session_type="chat",
+                    title=f"claude - {persisted_id[:8]}",
+                    tool_name="claude",
+                    user_id=session.user_id,
+                    project_path=session.encoded_project_path,
+                    workspace_type=session.workspace_type,
+                    remote_machine_id=session.remote_machine_id,
+                    context={"workflow_id": session.workflow_id},
+                )
+            except Exception as e:
+                logger.warning("Failed to create resolved sidebar session: %s", e)
+
+        if self._activity_callback:
+            self._activity_callback(
+                persisted_id,
+                {
+                    "type": "session_resolved",
+                    "session_id": persisted_id,
+                },
+            )
+
+        return persisted_id
+
+    def _sync_sidebar_session_totals(
+        self, session: _LocalSession, status: str | None = None
+    ) -> None:
+        """Write the current local Claude usage into the persisted sidebar session."""
+        if not self._uses_sidebar_session_source(session.cli_tool, session.workspace_type):
+            return
+        persisted_id = session.persisted_session_id or self._ensure_sidebar_session(session)
+        if not persisted_id or not self.session_manager:
+            return
+
+        updates = {
+            "request_count": session.request_count,
+            "total_tokens": session.total_tokens,
+            "total_input_tokens": session.total_input_tokens,
+            "total_output_tokens": session.total_output_tokens,
+            "project_path": session.encoded_project_path,
+        }
+        if session.user_id:
+            updates["user_id"] = session.user_id
+        if status:
+            updates["status"] = status
+
+        try:
+            self.session_manager.update_session_fields(persisted_id, updates)
+        except Exception as e:
+            logger.warning("Failed to sync sidebar session totals: %s", e)
+
     def run_agent_task(
         self,
         workflow_id: str,
@@ -111,6 +252,7 @@ class AutonomousAgentRunner:
         session_type: str = "workflow",
         timeout: int = DEFAULT_TASK_TIMEOUT,
         session_id: str = None,
+        user_id: int | None = None,
         allowed_tools: list[str] | None = None,
     ) -> AgentTaskResult:
         """
@@ -133,15 +275,17 @@ class AutonomousAgentRunner:
             AgentTaskResult with response text, messages, tokens, etc.
         """
         session_id = session_id or str(uuid.uuid4())
+        uses_sidebar_session = self._uses_sidebar_session_source(cli_tool, workspace_type)
 
-        # Create session record
-        if self.session_manager:
+        # Create wrapper sessions only for tools without a native sidebar session source.
+        if self.session_manager and not uses_sidebar_session:
             try:
                 self.session_manager.create_session(
                     session_id=session_id,
                     session_type=session_type,
                     title=f"Autonomous: {workflow_id[:8]}",
                     tool_name=cli_tool,
+                    user_id=user_id,
                     project_path=project_path,
                     workspace_type=workspace_type,
                     remote_machine_id=remote_machine_id,
@@ -180,20 +324,28 @@ class AutonomousAgentRunner:
                     prompt=prompt,
                     permission_mode=permission_mode,
                     timeout=timeout,
+                    workflow_id=workflow_id,
+                    user_id=user_id,
+                    workspace_type=workspace_type,
                     allowed_tools=allowed_tools,
                 )
 
+            persisted_session_id = (
+                result.session_id if uses_sidebar_session else (result.session_id or session_id)
+            )
+
             # Persist session messages to database (Issue #776 Bug 1)
-            if self.session_manager and session_id:
+            if self.session_manager and persisted_session_id and workspace_type == "local":
                 try:
-                    self._persist_local_session_messages(session_id, result)
+                    self._persist_local_session_messages(persisted_session_id, result)
                 except Exception as e:
                     logger.warning("Failed to persist session messages: %s", e)
 
             # Update session record
-            if self.session_manager:
+            if self.session_manager and persisted_session_id:
                 try:
                     update_fields = {
+                        "request_count": result.request_count,
                         "total_tokens": result.total_tokens,
                         "total_input_tokens": result.total_input_tokens,
                         "total_output_tokens": result.total_output_tokens,
@@ -202,10 +354,7 @@ class AutonomousAgentRunner:
                         update_fields["status"] = "completed"
                     else:
                         update_fields["status"] = "error"
-                    self.session_manager.update_session_fields(
-                        session_id,
-                        update_fields,
-                    )
+                    self.session_manager.update_session_fields(persisted_session_id, update_fields)
                 except Exception as e:
                     logger.warning("Failed to update session record: %s", e)
 
@@ -214,7 +363,8 @@ class AutonomousAgentRunner:
         except Exception as e:
             logger.error("Agent task failed: %s", e)
             return AgentTaskResult(
-                session_id=session_id,
+                session_id="" if uses_sidebar_session else session_id,
+                tracking_session_id=session_id,
                 success=False,
                 error=str(e),
             )
@@ -228,6 +378,9 @@ class AutonomousAgentRunner:
         prompt: str,
         permission_mode: str,
         timeout: int,
+        workflow_id: str,
+        user_id: int | None,
+        workspace_type: str,
         allowed_tools: list[str] | None = None,
     ) -> AgentTaskResult:
         """Run an agent task locally using a CLI subprocess."""
@@ -249,7 +402,12 @@ class AutonomousAgentRunner:
         executable = shutil.which(exe_name)
         if not executable:
             return AgentTaskResult(
-                session_id=session_id,
+                session_id=(
+                    ""
+                    if self._uses_sidebar_session_source(cli_tool, workspace_type)
+                    else session_id
+                ),
+                tracking_session_id=session_id,
                 success=False,
                 error=f"CLI tool '{exe_name}' not found",
             )
@@ -285,7 +443,12 @@ class AutonomousAgentRunner:
             )
         except (OSError, subprocess.SubprocessError) as e:
             return AgentTaskResult(
-                session_id=session_id,
+                session_id=(
+                    ""
+                    if self._uses_sidebar_session_source(cli_tool, workspace_type)
+                    else session_id
+                ),
+                tracking_session_id=session_id,
                 success=False,
                 error=f"Failed to start process: {e}",
             )
@@ -295,6 +458,12 @@ class AutonomousAgentRunner:
             process=process,
             cli_tool=cli_tool,
             allowed_tools=allowed_tools,
+            project_path=project_path,
+            encoded_project_path=self._encode_project_path(project_path),
+            workflow_id=workflow_id,
+            user_id=user_id,
+            workspace_type=workspace_type,
+            started_at_epoch=time.time(),
         )
         self._local_sessions[session_id] = session
 
@@ -334,13 +503,35 @@ class AutonomousAgentRunner:
 
         self._local_sessions.pop(session_id, None)
 
-        if not completed:
+        resolved_session_id = (
+            session.persisted_session_id
+            if self._uses_sidebar_session_source(cli_tool, workspace_type)
+            else session_id
+        )
+        if self._uses_sidebar_session_source(cli_tool, workspace_type) and not resolved_session_id:
             return AgentTaskResult(
-                session_id=session_id,
+                session_id="",
+                tracking_session_id=session_id,
                 response_text=session.assistant_text,
                 total_tokens=session.total_tokens,
                 total_input_tokens=session.total_input_tokens,
                 total_output_tokens=session.total_output_tokens,
+                request_count=session.request_count,
+                tool_calls=session.tool_calls,
+                success=False,
+                error="Failed to detect Claude sidebar session JSONL for autonomous task",
+                event_log=session.event_log,
+            )
+
+        if not completed:
+            return AgentTaskResult(
+                session_id=resolved_session_id,
+                tracking_session_id=session_id,
+                response_text=session.assistant_text,
+                total_tokens=session.total_tokens,
+                total_input_tokens=session.total_input_tokens,
+                total_output_tokens=session.total_output_tokens,
+                request_count=session.request_count,
                 tool_calls=session.tool_calls,
                 success=False,
                 error=f"Agent task timed out after {timeout}s",
@@ -348,11 +539,13 @@ class AutonomousAgentRunner:
             )
 
         return AgentTaskResult(
-            session_id=session_id,
+            session_id=resolved_session_id,
+            tracking_session_id=session_id,
             response_text=session.assistant_text,
             total_tokens=session.total_tokens,
             total_input_tokens=session.total_input_tokens,
             total_output_tokens=session.total_output_tokens,
+            request_count=session.request_count,
             tool_calls=session.tool_calls,
             success=session.error is None,
             error=session.error,
@@ -375,6 +568,7 @@ class AutonomousAgentRunner:
         if not self.remote_session_manager:
             return AgentTaskResult(
                 session_id=session_id,
+                tracking_session_id=session_id,
                 success=False,
                 error="Remote session manager not available",
             )
@@ -399,6 +593,7 @@ class AutonomousAgentRunner:
             if not result.get("success"):
                 return AgentTaskResult(
                     session_id=session_id,
+                    tracking_session_id=session_id,
                     success=False,
                     error=result.get("error", "Failed to create remote session"),
                 )
@@ -415,6 +610,7 @@ class AutonomousAgentRunner:
             if not self.session_manager:
                 return AgentTaskResult(
                     session_id=session_id,
+                    tracking_session_id=session_id,
                     success=False,
                     error="Session manager not available for remote session polling",
                 )
@@ -426,6 +622,7 @@ class AutonomousAgentRunner:
                 if local_session and local_session._stopped.is_set():
                     return AgentTaskResult(
                         session_id=session_id,
+                        tracking_session_id=session_id,
                         success=False,
                         error="Remote session cancelled by orchestrator",
                     )
@@ -447,11 +644,13 @@ class AutonomousAgentRunner:
 
                         return AgentTaskResult(
                             session_id=session_id,
+                            tracking_session_id=session_id,
                             response_text=assistant_text,
                             messages=messages,
                             total_tokens=session_data.get("total_tokens", 0),
                             total_input_tokens=session_data.get("total_input_tokens", 0),
                             total_output_tokens=session_data.get("total_output_tokens", 0),
+                            request_count=session_data.get("request_count", 0),
                             success=status == "completed",
                             error=(
                                 session_data.get("error_message") if status != "completed" else None
@@ -461,6 +660,7 @@ class AutonomousAgentRunner:
 
             return AgentTaskResult(
                 session_id=session_id,
+                tracking_session_id=session_id,
                 success=False,
                 error=f"Remote agent task timed out after {timeout}s",
             )
@@ -468,6 +668,7 @@ class AutonomousAgentRunner:
         except Exception as e:
             return AgentTaskResult(
                 session_id=session_id,
+                tracking_session_id=session_id,
                 success=False,
                 error=f"Remote execution error: {e}",
             )
@@ -497,6 +698,12 @@ class AutonomousAgentRunner:
                         session_id=session_id,
                         role="assistant",
                         content=event.get("text", ""),
+                        model=event.get("model"),
+                        metadata=(
+                            {"message_id": event.get("message_id")}
+                            if event.get("message_id")
+                            else None
+                        ),
                     )
                 elif event.get("type") == "tool_use":
                     tool_input = event.get("tool_input", {})
@@ -508,7 +715,14 @@ class AutonomousAgentRunner:
                             if isinstance(tool_input, (dict, list))
                             else str(tool_input)
                         ),
-                        metadata={"tool_name": event.get("tool_name", "unknown")},
+                        metadata={
+                            "tool_name": event.get("tool_name", "unknown"),
+                            **(
+                                {"tool_use_id": event.get("tool_use_id")}
+                                if event.get("tool_use_id")
+                                else {}
+                            ),
+                        },
                     )
                 # usage events are metadata-only, not persisted as messages
         else:
@@ -557,6 +771,8 @@ class AutonomousAgentRunner:
     def _write_stdin(self, session: _LocalSession, payload: str) -> bool:
         """Write a JSON message to the subprocess stdin."""
         try:
+            if session.process is None:
+                return False
             session.process.stdin.write((payload + "\n").encode("utf-8"))
             session.process.stdin.flush()
             return True
@@ -568,6 +784,8 @@ class AutonomousAgentRunner:
         """Read stdout lines from the subprocess."""
         try:
             while not session._stopped.is_set():
+                if session.process is None:
+                    break
                 line = session.process.stdout.readline()
                 if not line:
                     break
@@ -580,6 +798,7 @@ class AutonomousAgentRunner:
                 session.output_lines.append(line)
 
                 try:
+                    self._ensure_sidebar_session(session)
                     parsed = json.loads(line)
                     msg_type = parsed.get("type", "")
 
@@ -587,6 +806,7 @@ class AutonomousAgentRunner:
                         # Accumulate assistant text
                         msg = parsed.get("message", {})
                         content = msg.get("content", "")
+                        message_id = msg.get("id")
                         text_delta = ""
                         if isinstance(content, list):
                             for block in content:
@@ -602,12 +822,14 @@ class AutonomousAgentRunner:
                                 {
                                     "type": "assistant",
                                     "text": text_delta,  # full text for DB persistence
+                                    "message_id": message_id,
+                                    "model": msg.get("model"),
                                 }
                             )
                         # Emit activity for real-time frontend display
                         if self._activity_callback and text_delta:
                             self._activity_callback(
-                                session.session_id,
+                                session.persisted_session_id or session.session_id,
                                 {
                                     "type": "assistant",
                                     "text": text_delta[:500],  # truncate for SSE
@@ -623,12 +845,13 @@ class AutonomousAgentRunner:
                                 "type": "tool_use",
                                 "tool_name": tool_info.get("name", "unknown"),
                                 "tool_input": tool_info.get("input", {}),
+                                "tool_use_id": tool_info.get("id"),
                             }
                         )
                         # Emit tool call activity
                         if self._activity_callback:
                             self._activity_callback(
-                                session.session_id,
+                                session.persisted_session_id or session.session_id,
                                 {
                                     "type": "tool_use",
                                     "tool_name": tool_info.get("name", "unknown"),
@@ -645,11 +868,13 @@ class AutonomousAgentRunner:
                         session.total_tokens = (
                             session.total_input_tokens + session.total_output_tokens
                         )
+                        session.request_count += 1
+                        self._sync_sidebar_session_totals(session, status="active")
                         session.completed.set()
                         # Emit usage activity for real-time token display
                         if self._activity_callback:
                             self._activity_callback(
-                                session.session_id,
+                                session.persisted_session_id or session.session_id,
                                 {
                                     "type": "usage",
                                     "total_tokens": session.total_tokens,
@@ -688,7 +913,7 @@ class AutonomousAgentRunner:
                                 logger.warning(
                                     "Denied tool '%s' for session %s " "(not in allowed list)",
                                     tool_name,
-                                    session.session_id[:8],
+                                    (session.persisted_session_id or session.session_id)[:8],
                                 )
                             else:
                                 # Approve (no restriction, or tool is allowed)
@@ -711,13 +936,15 @@ class AutonomousAgentRunner:
             # If process exited without sending result, mark completed
             if not session.completed.is_set():
                 session._stopped.wait(2.0)
-                if session.process.returncode is not None:
+                if session.process and session.process.returncode is not None:
                     session.completed.set()
 
     def _read_stderr(self, session: _LocalSession) -> None:
         """Read stderr from the subprocess."""
         try:
             while not session._stopped.is_set():
+                if session.process is None:
+                    break
                 line = session.process.stderr.readline()
                 if not line:
                     break
@@ -730,7 +957,7 @@ class AutonomousAgentRunner:
     def stop_session(self, session_id: str) -> None:
         """Stop a running local session."""
         session = self._local_sessions.get(session_id)
-        if session and session.process.returncode is None:
+        if session and session.process and session.process.returncode is None:
             try:
                 os.killpg(os.getpgid(session.process.pid), signal.SIGTERM)
             except (ProcessLookupError, OSError):

--- a/app/modules/workspace/autonomous/models.py
+++ b/app/modules/workspace/autonomous/models.py
@@ -321,11 +321,13 @@ class AgentTaskResult:
     """Result from running an agent task."""
 
     session_id: str = ""
+    tracking_session_id: str = ""
     response_text: str = ""
     messages: list = field(default_factory=list)
     total_tokens: int = 0
     total_input_tokens: int = 0
     total_output_tokens: int = 0
+    request_count: int = 0
     tool_calls: list = field(default_factory=list)
     success: bool = False
     error: Optional[str] = None

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -131,6 +131,7 @@ CI_POLL_MAX_WAIT = 300  # maximum seconds to wait (5 minutes)
 # the review prompt.  Reviews longer than this are truncated with a
 # notice so the reviewer knows content was omitted.
 PREV_REVIEW_MAX_LENGTH = 3000
+REVIEW_SESSION_MILESTONE_TYPES = {"plan_reviewed", "pr_reviewed"}
 
 
 def _next_phase(current_phase: str) -> str:
@@ -367,9 +368,8 @@ class AutonomousOrchestrator:
         self.repo.update_workflow(self._workflow_id, updates)
         self._emit("workflow_updated", updates)
 
-    def _accumulate_tokens(self, result: AgentTaskResult):
+    def _accumulate_tokens(self, _result: AgentTaskResult):
         """Refresh workflow totals from the sessions linked to milestones."""
-        del result
         self.repo.refresh_workflow_usage_from_sessions(self._workflow_id)
 
     def _on_agent_activity(self, session_id: str, activity: dict):
@@ -403,7 +403,7 @@ class AutonomousOrchestrator:
                 ms = milestones[-1]  # most recent
                 field_name = (
                     "review_session_id"
-                    if "review" in (ms.get("milestone_type", "") or "")
+                    if ms.get("milestone_type") in REVIEW_SESSION_MILESTONE_TYPES
                     else "session_id"
                 )
                 self.repo.update_milestone(

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -368,20 +368,12 @@ class AutonomousOrchestrator:
         self._emit("workflow_updated", updates)
 
     def _accumulate_tokens(self, result: AgentTaskResult):
-        """Add agent task tokens to workflow totals."""
-        self.repo.update_workflow_tokens(
-            self._workflow_id,
-            {
-                "total_tokens": result.total_tokens,
-                "total_input_tokens": result.total_input_tokens,
-                "total_output_tokens": result.total_output_tokens,
-            },
-        )
-        # Recalculate request count from actual session_messages
-        self.repo.recalculate_workflow_requests(self._workflow_id)
+        """Refresh workflow totals from the sessions linked to milestones."""
+        del result
+        self.repo.refresh_workflow_usage_from_sessions(self._workflow_id)
 
     def _on_agent_activity(self, session_id: str, activity: dict):
-        """Forward agent activity to the SSE event stream and update tokens."""
+        """Forward agent activity to the SSE event stream and refresh usage."""
         self.emitter.emit(
             self._workflow_id,
             "agent_activity",
@@ -390,19 +382,18 @@ class AutonomousOrchestrator:
                 **activity,
             },
         )
-        # Real-time token update (only on usage events to avoid DB thrashing)
-        if activity.get("type") == "usage":
+        activity_type = activity.get("type")
+        if activity_type == "session_resolved":
             try:
-                self.repo.update_workflow_tokens(
-                    self._workflow_id,
-                    {
-                        "total_tokens": activity.get("total_tokens", 0),
-                        "total_input_tokens": activity.get("total_input_tokens", 0),
-                        "total_output_tokens": activity.get("total_output_tokens", 0),
-                    },
-                )
+                self._link_session_to_current_milestone(session_id)
+                self.repo.refresh_workflow_usage_from_sessions(self._workflow_id)
             except Exception:
-                logger.warning("Failed to update workflow tokens in real-time", exc_info=True)
+                logger.warning("Failed to resolve workflow session in real-time", exc_info=True)
+        elif activity_type == "usage":
+            try:
+                self.repo.refresh_workflow_usage_from_sessions(self._workflow_id)
+            except Exception:
+                logger.warning("Failed to refresh workflow tokens in real-time", exc_info=True)
 
     def _link_session_to_current_milestone(self, session_id: str):
         """Write session_id to the latest in_progress milestone immediately."""
@@ -410,10 +401,15 @@ class AutonomousOrchestrator:
             milestones = self.repo.list_milestones(self._workflow_id, status="in_progress")
             if milestones:
                 ms = milestones[-1]  # most recent
+                field_name = (
+                    "review_session_id"
+                    if "review" in (ms.get("milestone_type", "") or "")
+                    else "session_id"
+                )
                 self.repo.update_milestone(
                     ms.get("milestone_id", ""),
                     {
-                        "session_id": session_id,
+                        field_name: session_id,
                     },
                 )
         except Exception:
@@ -430,26 +426,33 @@ class AutonomousOrchestrator:
         # before run_agent_task() returns
         if "session_id" not in kwargs:
             kwargs["session_id"] = str(uuid.uuid4())
-        session_id = kwargs["session_id"]
+        tracking_session_id = kwargs["session_id"]
+        workflow_data = wf or self.workflow
+        if "user_id" not in kwargs and workflow_data:
+            kwargs["user_id"] = workflow_data.get("user_id")
 
         with self._session_lock:
-            self._current_session_id = session_id
+            self._current_session_id = tracking_session_id
 
-        # Immediately link session to in_progress milestone so frontend
-        # can show session details while the agent is still running
-        self._link_session_to_current_milestone(session_id)
+        should_prelink_tracking_session = not self._runner._uses_sidebar_session_source(
+            kwargs.get("cli_tool", ""),
+            kwargs.get("workspace_type", "local"),
+        )
+        if should_prelink_tracking_session:
+            self._link_session_to_current_milestone(tracking_session_id)
 
         # Inject per-workflow timeout if specified
         if "timeout" not in kwargs:
-            workflow_data = wf or self.workflow
             task_timeout = (workflow_data or {}).get("task_timeout")
             if task_timeout:
                 kwargs["timeout"] = int(task_timeout)
 
         result = self._runner.run_agent_task(**kwargs)
+        if result.session_id:
+            self._link_session_to_current_milestone(result.session_id)
 
         with self._session_lock:
-            self._current_session_id = result.session_id
+            self._current_session_id = result.tracking_session_id or result.session_id
         return result
 
     def cancel_current_task(self):

--- a/app/repositories/autonomous_repo.py
+++ b/app/repositories/autonomous_repo.py
@@ -348,6 +348,95 @@ class AutonomousWorkflowRepository:
             ),
         )
 
+    def refresh_workflow_usage_from_sessions(self, workflow_id: str) -> None:
+        """Refresh workflow token/request totals from linked agent_sessions."""
+        now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+        self.db.execute(
+            adapt_sql(
+                """
+                UPDATE autonomous_workflows SET
+                    total_tokens = COALESCE((
+                        SELECT SUM(COALESCE(s.total_tokens, 0))
+                        FROM agent_sessions s
+                        WHERE s.session_id IN (
+                            SELECT DISTINCT sid FROM (
+                                SELECT NULLIF(session_id, '') AS sid
+                                FROM workflow_milestones
+                                WHERE workflow_id = ?
+                                UNION
+                                SELECT NULLIF(review_session_id, '') AS sid
+                                FROM workflow_milestones
+                                WHERE workflow_id = ?
+                            ) linked
+                            WHERE sid IS NOT NULL
+                        )
+                    ), 0),
+                    total_input_tokens = COALESCE((
+                        SELECT SUM(COALESCE(s.total_input_tokens, 0))
+                        FROM agent_sessions s
+                        WHERE s.session_id IN (
+                            SELECT DISTINCT sid FROM (
+                                SELECT NULLIF(session_id, '') AS sid
+                                FROM workflow_milestones
+                                WHERE workflow_id = ?
+                                UNION
+                                SELECT NULLIF(review_session_id, '') AS sid
+                                FROM workflow_milestones
+                                WHERE workflow_id = ?
+                            ) linked
+                            WHERE sid IS NOT NULL
+                        )
+                    ), 0),
+                    total_output_tokens = COALESCE((
+                        SELECT SUM(COALESCE(s.total_output_tokens, 0))
+                        FROM agent_sessions s
+                        WHERE s.session_id IN (
+                            SELECT DISTINCT sid FROM (
+                                SELECT NULLIF(session_id, '') AS sid
+                                FROM workflow_milestones
+                                WHERE workflow_id = ?
+                                UNION
+                                SELECT NULLIF(review_session_id, '') AS sid
+                                FROM workflow_milestones
+                                WHERE workflow_id = ?
+                            ) linked
+                            WHERE sid IS NOT NULL
+                        )
+                    ), 0),
+                    total_requests = COALESCE((
+                        SELECT SUM(COALESCE(s.request_count, 0))
+                        FROM agent_sessions s
+                        WHERE s.session_id IN (
+                            SELECT DISTINCT sid FROM (
+                                SELECT NULLIF(session_id, '') AS sid
+                                FROM workflow_milestones
+                                WHERE workflow_id = ?
+                                UNION
+                                SELECT NULLIF(review_session_id, '') AS sid
+                                FROM workflow_milestones
+                                WHERE workflow_id = ?
+                            ) linked
+                            WHERE sid IS NOT NULL
+                        )
+                    ), 0),
+                    updated_at = ?
+                WHERE workflow_id = ?
+                """
+            ),
+            (
+                workflow_id,
+                workflow_id,
+                workflow_id,
+                workflow_id,
+                workflow_id,
+                workflow_id,
+                workflow_id,
+                workflow_id,
+                now,
+                workflow_id,
+            ),
+        )
+
     def list_forks(self, workflow_id: str) -> list:
         """List all child workflows forked from the given parent."""
         return self.db.fetch_all(

--- a/app/repositories/autonomous_repo.py
+++ b/app/repositories/autonomous_repo.py
@@ -354,82 +354,44 @@ class AutonomousWorkflowRepository:
         self.db.execute(
             adapt_sql(
                 """
+                WITH linked_sessions AS (
+                    SELECT DISTINCT sid FROM (
+                        SELECT NULLIF(session_id, '') AS sid
+                        FROM workflow_milestones
+                        WHERE workflow_id = ?
+                        UNION
+                        SELECT NULLIF(review_session_id, '') AS sid
+                        FROM workflow_milestones
+                        WHERE workflow_id = ?
+                    ) linked
+                    WHERE sid IS NOT NULL
+                )
                 UPDATE autonomous_workflows SET
                     total_tokens = COALESCE((
                         SELECT SUM(COALESCE(s.total_tokens, 0))
                         FROM agent_sessions s
-                        WHERE s.session_id IN (
-                            SELECT DISTINCT sid FROM (
-                                SELECT NULLIF(session_id, '') AS sid
-                                FROM workflow_milestones
-                                WHERE workflow_id = ?
-                                UNION
-                                SELECT NULLIF(review_session_id, '') AS sid
-                                FROM workflow_milestones
-                                WHERE workflow_id = ?
-                            ) linked
-                            WHERE sid IS NOT NULL
-                        )
+                        WHERE s.session_id IN (SELECT sid FROM linked_sessions)
                     ), 0),
                     total_input_tokens = COALESCE((
                         SELECT SUM(COALESCE(s.total_input_tokens, 0))
                         FROM agent_sessions s
-                        WHERE s.session_id IN (
-                            SELECT DISTINCT sid FROM (
-                                SELECT NULLIF(session_id, '') AS sid
-                                FROM workflow_milestones
-                                WHERE workflow_id = ?
-                                UNION
-                                SELECT NULLIF(review_session_id, '') AS sid
-                                FROM workflow_milestones
-                                WHERE workflow_id = ?
-                            ) linked
-                            WHERE sid IS NOT NULL
-                        )
+                        WHERE s.session_id IN (SELECT sid FROM linked_sessions)
                     ), 0),
                     total_output_tokens = COALESCE((
                         SELECT SUM(COALESCE(s.total_output_tokens, 0))
                         FROM agent_sessions s
-                        WHERE s.session_id IN (
-                            SELECT DISTINCT sid FROM (
-                                SELECT NULLIF(session_id, '') AS sid
-                                FROM workflow_milestones
-                                WHERE workflow_id = ?
-                                UNION
-                                SELECT NULLIF(review_session_id, '') AS sid
-                                FROM workflow_milestones
-                                WHERE workflow_id = ?
-                            ) linked
-                            WHERE sid IS NOT NULL
-                        )
+                        WHERE s.session_id IN (SELECT sid FROM linked_sessions)
                     ), 0),
                     total_requests = COALESCE((
                         SELECT SUM(COALESCE(s.request_count, 0))
                         FROM agent_sessions s
-                        WHERE s.session_id IN (
-                            SELECT DISTINCT sid FROM (
-                                SELECT NULLIF(session_id, '') AS sid
-                                FROM workflow_milestones
-                                WHERE workflow_id = ?
-                                UNION
-                                SELECT NULLIF(review_session_id, '') AS sid
-                                FROM workflow_milestones
-                                WHERE workflow_id = ?
-                            ) linked
-                            WHERE sid IS NOT NULL
-                        )
+                        WHERE s.session_id IN (SELECT sid FROM linked_sessions)
                     ), 0),
                     updated_at = ?
                 WHERE workflow_id = ?
                 """
             ),
             (
-                workflow_id,
-                workflow_id,
-                workflow_id,
-                workflow_id,
-                workflow_id,
-                workflow_id,
                 workflow_id,
                 workflow_id,
                 now,

--- a/app/services/analysis_service.py
+++ b/app/services/analysis_service.py
@@ -96,9 +96,7 @@ class AnalysisService:
             _executor.submit(
                 self.usage_repo.get_request_count_total, start_date, end_date, host_name
             ): "total_requests",
-            _executor.submit(
-                self.daily_stats_repo.get_data_range
-            ): "data_range",
+            _executor.submit(self.daily_stats_repo.get_data_range): "data_range",
         }
 
         # Collect results

--- a/frontend/src/components/common/Pagination.test.tsx
+++ b/frontend/src/components/common/Pagination.test.tsx
@@ -95,6 +95,7 @@ describe('getVisiblePages', () => {
   });
 });
 
+
 describe('Pagination Component', () => {
   const mockOnPageChange = jest.fn();
 

--- a/frontend/src/components/common/Pagination.tsx
+++ b/frontend/src/components/common/Pagination.tsx
@@ -395,6 +395,7 @@ export const Pagination: React.FC<PaginationProps> = ({
   );
 };
 
+
 /**
  * Button Component (inline for Pagination use)
  * Minimal Button component for pagination jump submit

--- a/scripts/fetch_claude.py
+++ b/scripts/fetch_claude.py
@@ -670,7 +670,7 @@ def update_agent_sessions_stats(messages: list) -> int:
     Returns:
         Number of sessions updated
     """
-    from shared.db import _execute, _placeholder, get_connection
+    from shared.db import _execute, _placeholder, escape_like, get_connection
 
     # Group messages by agent_session_id
     session_stats: dict[str, dict[str, Any]] = defaultdict(
@@ -819,16 +819,19 @@ def update_agent_sessions_stats(messages: list) -> int:
                         if not timestamp:
                             timestamp = now
 
-                        # Deduplicate by (session_id, role, timestamp) + message_id if available
+                        # Deduplicate by (session_id, role, message_id) when available.
+                        # Runner-persisted autonomous messages may have different timestamps
+                        # from the JSONL source, so timestamp must not be part of the match.
                         # Note: metadata is TEXT type, use LIKE pattern matching instead of JSONB ->>
                         if msg_id:
                             # Pattern match for message_id in JSON-like metadata string
+                            escaped_msg_id = escape_like(str(msg_id))
                             check_sql = f"""
                                 SELECT id FROM session_messages
                                 WHERE session_id = {placeholder}
                                 AND role = {placeholder}
-                                AND timestamp = {placeholder}
                                 AND metadata LIKE {placeholder}
+                                ESCAPE '\\'
                             """
                             _execute(
                                 cursor,
@@ -836,8 +839,7 @@ def update_agent_sessions_stats(messages: list) -> int:
                                 (
                                     session_id,
                                     msg.get("role"),
-                                    timestamp,
-                                    f'%"message_id": "{msg_id}"%',
+                                    f'%"message_id": "{escaped_msg_id}"%',
                                 ),
                             )
                         else:

--- a/tests/api_test_audit_filter.py
+++ b/tests/api_test_audit_filter.py
@@ -1,40 +1,44 @@
 #!/usr/bin/env python3
 """API-level test for audit log filter consistency."""
 
-import requests
 import sys
 
-BASE_URL = 'http://localhost:5001'
+import requests
+
+BASE_URL = "http://localhost:5001"
+
 
 def main():
-    print('Testing API...')
+    print("Testing API...")
     session = requests.Session()
 
     # Test login
-    r = session.post(f'{BASE_URL}/api/auth/login', json={'username': 'admin', 'password': 'admin123'}, timeout=10)
-    print(f'Login: {r.status_code}')
+    r = session.post(
+        f"{BASE_URL}/api/auth/login", json={"username": "admin", "password": "admin123"}, timeout=10
+    )
+    print(f"Login: {r.status_code}")
 
     if r.status_code != 200:
-        print('Server not available, skipping API tests')
+        print("Server not available, skipping API tests")
         return
 
     # Get audit logs without filter
-    r = session.get(f'{BASE_URL}/api/governance/audit-logs', params={'limit': 100})
+    r = session.get(f"{BASE_URL}/api/governance/audit-logs", params={"limit": 100})
     data = r.json()
-    baseline_total = data.get('total', 0)
-    baseline_logs = data.get('logs', [])
-    print(f'Baseline: total={baseline_total}, logs={len(baseline_logs)}')
+    baseline_total = data.get("total", 0)
+    baseline_logs = data.get("logs", [])
+    print(f"Baseline: total={baseline_total}, logs={len(baseline_logs)}")
 
     if not baseline_logs:
-        print('No audit logs found, tests skipped')
+        print("No audit logs found, tests skipped")
         return
 
     # Get unique values
-    actions = set(log.get('action') for log in baseline_logs if log.get('action'))
-    resource_types = set(log.get('resource_type') for log in baseline_logs if log.get('resource_type'))
+    actions = {log.get("action") for log in baseline_logs if log.get("action")}
+    resource_types = {log.get("resource_type") for log in baseline_logs if log.get("resource_type")}
 
-    print(f'Actions found: {list(actions)[:5]}')
-    print(f'Resource types found: {list(resource_types)[:5]}')
+    print(f"Actions found: {list(actions)[:5]}")
+    print(f"Resource types found: {list(resource_types)[:5]}")
 
     passed = 0
     failed = 0
@@ -42,36 +46,44 @@ def main():
     # Test action filter
     if actions:
         test_action = list(actions)[0]
-        r = session.get(f'{BASE_URL}/api/governance/audit-logs', params={'action': test_action, 'limit': 100})
+        r = session.get(
+            f"{BASE_URL}/api/governance/audit-logs", params={"action": test_action, "limit": 100}
+        )
         data = r.json()
-        filtered_logs = data.get('logs', [])
-        filtered_total = data.get('total', 0)
+        filtered_logs = data.get("logs", [])
+        filtered_total = data.get("total", 0)
 
-        all_match = all(log.get('action') == test_action for log in filtered_logs)
+        all_match = all(log.get("action") == test_action for log in filtered_logs)
         if all_match:
             passed += 1
-            print(f'PASS: Action filter ({test_action}): total={filtered_total}, logs={len(filtered_logs)}')
+            print(
+                f"PASS: Action filter ({test_action}): total={filtered_total}, logs={len(filtered_logs)}"
+            )
         else:
             failed += 1
-            print(f'FAIL: Action filter returned logs with different actions!')
+            print("FAIL: Action filter returned logs with different actions!")
             for log in filtered_logs[:3]:
                 print(f'  - log action: {log.get("action")} (expected: {test_action})')
 
     # Test resource_type filter
     if resource_types:
         test_rt = list(resource_types)[0]
-        r = session.get(f'{BASE_URL}/api/governance/audit-logs', params={'resource_type': test_rt, 'limit': 100})
+        r = session.get(
+            f"{BASE_URL}/api/governance/audit-logs", params={"resource_type": test_rt, "limit": 100}
+        )
         data = r.json()
-        filtered_logs = data.get('logs', [])
-        filtered_total = data.get('total', 0)
+        filtered_logs = data.get("logs", [])
+        filtered_total = data.get("total", 0)
 
-        all_match = all(log.get('resource_type') == test_rt for log in filtered_logs)
+        all_match = all(log.get("resource_type") == test_rt for log in filtered_logs)
         if all_match:
             passed += 1
-            print(f'PASS: Resource_type filter ({test_rt}): total={filtered_total}, logs={len(filtered_logs)}')
+            print(
+                f"PASS: Resource_type filter ({test_rt}): total={filtered_total}, logs={len(filtered_logs)}"
+            )
         else:
             failed += 1
-            print(f'FAIL: Resource_type filter returned logs with different resource_types!')
+            print("FAIL: Resource_type filter returned logs with different resource_types!")
             for log in filtered_logs[:3]:
                 print(f'  - log resource_type: {log.get("resource_type")} (expected: {test_rt})')
 
@@ -79,23 +91,27 @@ def main():
     if actions and resource_types:
         test_action = list(actions)[0]
         test_rt = list(resource_types)[0]
-        r = session.get(f'{BASE_URL}/api/governance/audit-logs', params={'action': test_action, 'resource_type': test_rt, 'limit': 100})
+        r = session.get(
+            f"{BASE_URL}/api/governance/audit-logs",
+            params={"action": test_action, "resource_type": test_rt, "limit": 100},
+        )
         data = r.json()
-        filtered_logs = data.get('logs', [])
-        filtered_total = data.get('total', 0)
+        filtered_logs = data.get("logs", [])
+        filtered_total = data.get("total", 0)
 
         all_match = all(
-            log.get('action') == test_action and log.get('resource_type') == test_rt
+            log.get("action") == test_action and log.get("resource_type") == test_rt
             for log in filtered_logs
         )
         if all_match:
             passed += 1
-            print(f'PASS: Combined filter: total={filtered_total}, logs={len(filtered_logs)}')
+            print(f"PASS: Combined filter: total={filtered_total}, logs={len(filtered_logs)}")
         else:
             failed += 1
-            print(f'FAIL: Combined filter returned inconsistent results!')
+            print("FAIL: Combined filter returned inconsistent results!")
 
-    print(f'\nResults: {passed} passed, {failed} failed')
+    print(f"\nResults: {passed} passed, {failed} failed")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/tests/e2e/e2e_dashboard_date_range_playwright.py
+++ b/tests/e2e/e2e_dashboard_date_range_playwright.py
@@ -28,7 +28,7 @@ from datetime import datetime, timedelta
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 sys.path.insert(0, PROJECT_ROOT)
 
-from playwright.sync_api import sync_playwright, expect
+from playwright.sync_api import expect, sync_playwright
 
 BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
@@ -119,14 +119,20 @@ def test_preset_selection(page):
     # Select "Last 7 Days"
     page.click(".dropdown-menu .dropdown-item:text('Last 7 Days')")
     pause(0.5)
-    check(date_select.locator(".dropdown-toggle").text_content() == "Last 7 Days", "Selected 'Last 7 Days'")
+    check(
+        date_select.locator(".dropdown-toggle").text_content() == "Last 7 Days",
+        "Selected 'Last 7 Days'",
+    )
 
     # Select "Last 30 Days"
     date_select.click()
     pause(0.5)
     page.click(".dropdown-menu .dropdown-item:text('Last 30 Days')")
     pause(0.5)
-    check(date_select.locator(".dropdown-toggle").text_content() == "Last 30 Days", "Selected 'Last 30 Days'")
+    check(
+        date_select.locator(".dropdown-toggle").text_content() == "Last 30 Days",
+        "Selected 'Last 30 Days'",
+    )
 
     shot(page, "04-preset-selection")
 
@@ -182,7 +188,10 @@ def test_date_validation_invalid_range(page):
     # Check error message is visible
     error_msg = page.locator("#date-range-error")
     check(error_msg.is_visible(), "Error message is visible for invalid range")
-    check(error_msg.text_content() == "Start date cannot be after end date", "Error message text is correct")
+    check(
+        error_msg.text_content() == "Start date cannot be after end date",
+        "Error message text is correct",
+    )
 
     # Check aria-live attribute
     check(error_msg.get_attribute("aria-live") == "polite", "Error message has aria-live='polite'")
@@ -215,7 +224,10 @@ def test_date_validation_future_date(page):
 
     error_msg = page.locator("#date-range-error")
     check(error_msg.is_visible(), "Error message is visible for future dates")
-    check(error_msg.text_content() == "Cannot select future dates", "Future date error message is correct")
+    check(
+        error_msg.text_content() == "Cannot select future dates",
+        "Future date error message is correct",
+    )
 
     shot(page, "07-future-date-error")
 
@@ -239,11 +251,18 @@ def test_accessibility_labels(page):
     check(end_label.count() == 1, "End Date label exists")
 
     # Check labels are visually hidden (class 'visually-hidden')
-    check(start_label.get_attribute("class") == "visually-hidden", "Start Date label is visually hidden")
-    check(end_label.get_attribute("class") == "visually-hidden", "End Date label is visually hidden")
+    check(
+        start_label.get_attribute("class") == "visually-hidden",
+        "Start Date label is visually hidden",
+    )
+    check(
+        end_label.get_attribute("class") == "visually-hidden", "End Date label is visually hidden"
+    )
 
     # Check label for attribute matches input id
-    check(start_label.get_attribute("for") == "date-start-input", "Start label for matches input id")
+    check(
+        start_label.get_attribute("for") == "date-start-input", "Start label for matches input id"
+    )
     check(end_label.get_attribute("for") == "date-end-input", "End label for matches input id")
 
     shot(page, "08-accessibility-labels")
@@ -298,7 +317,9 @@ def test_css_styling(page):
 
     # Check width is within expected range
     width = date_input_narrow.evaluate("el => el.getBoundingClientRect().width")
-    check(width >= 120 and width <= 150, f"Date input width is in range 120-150px (actual: {width}px)")
+    check(
+        width >= 120 and width <= 150, f"Date input width is in range 120-150px (actual: {width}px)"
+    )
 
     shot(page, "10-css-styling")
 

--- a/tests/e2e/e2e_token_trend_all_button_playwright.py
+++ b/tests/e2e/e2e_token_trend_all_button_playwright.py
@@ -25,7 +25,7 @@ from datetime import datetime, timedelta
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 sys.path.insert(0, PROJECT_ROOT)
 
-from playwright.sync_api import sync_playwright, expect
+from playwright.sync_api import expect, sync_playwright
 
 BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
@@ -114,7 +114,10 @@ def test_default_date_range(page):
     # Start date should be about 30 days ago
     start_value = start_input.input_value()
     expected_start = (datetime.now() - timedelta(days=30)).strftime("%Y-%m-%d")
-    check(start_value == expected_start, f"Start date shows 30 days ago ({start_value} vs {expected_start})")
+    check(
+        start_value == expected_start,
+        f"Start date shows 30 days ago ({start_value} vs {expected_start})",
+    )
 
     shot(page, "03-default-30-days")
 
@@ -135,7 +138,10 @@ def test_all_button_click(page):
     # Check that "All" button is now active (primary)
     active_button = page.locator(".btn-group .btn-primary")
     button_text = active_button.text_content()
-    check("All" in button_text or "全部" in button_text, f"'All' button is now active (text: '{button_text}')")
+    check(
+        "All" in button_text or "全部" in button_text,
+        f"'All' button is now active (text: '{button_text}')",
+    )
 
     shot(page, "04-all-button-active")
 
@@ -165,7 +171,9 @@ def test_all_button_date_range(page):
         check(True, f"Start date is NOT hardcoded 30 days ago (actual: {start_value})")
     else:
         # This could happen if database only has 30 days of data
-        print(f"    [INFO] Start date happens to equal 30 days ago - may be correct if data is limited")
+        print(
+            "    [INFO] Start date happens to equal 30 days ago - may be correct if data is limited"
+        )
 
     # Verify start date is NOT in the future
     start_date_obj = datetime.strptime(start_value, "%Y-%m-%d")
@@ -193,9 +201,6 @@ def test_chart_data_displayed(page):
 def test_api_response_data_range(page):
     """Test that API response includes data_range field."""
     print("\n[TEST] API response data_range...")
-
-    # Capture network response
-    api_response = None
 
     def handle_response(response):
         if "/api/analysis/batch" in response.url:
@@ -250,8 +255,10 @@ def test_date_inputs_manual_change(page):
     # Based on current implementation, manual change sets quickRange to 'all'
     active_button = page.locator(".btn-group .btn-primary")
     button_text = active_button.text_content()
-    check("All" in button_text or "全部" in button_text,
-          f"After manual change, 'All' button is active (text: '{button_text}')")
+    check(
+        "All" in button_text or "全部" in button_text,
+        f"After manual change, 'All' button is active (text: '{button_text}')",
+    )
 
     shot(page, "08-manual-date-change")
 

--- a/tests/e2e/manage/test_audit_log_filter.py
+++ b/tests/e2e/manage/test_audit_log_filter.py
@@ -102,10 +102,10 @@ def test_audit_log_filter():
     )
 
     # Analyze baseline data for available filter values
-    action_set = set(log.get("action") for log in baseline_logs if log.get("action"))
-    resource_type_set = set(
+    action_set = {log.get("action") for log in baseline_logs if log.get("action")}
+    resource_type_set = {
         log.get("resource_type") for log in baseline_logs if log.get("resource_type")
-    )
+    }
     print(f"  Available actions: {list(action_set)[:10]}")
     print(f"  Available resource_types: {list(resource_type_set)[:10]}")
 
@@ -183,7 +183,9 @@ def test_audit_log_filter():
     if baseline_logs:
         first_user_id = baseline_logs[0].get("user_id")
         if first_user_id:
-            r = session.get(f"{BASE_URL}/api/audit/user/{first_user_id}/activity", params={"days": 30})
+            r = session.get(
+                f"{BASE_URL}/api/audit/user/{first_user_id}/activity", params={"days": 30}
+            )
             check(
                 "User activity API still works",
                 r.status_code == 200,
@@ -197,7 +199,7 @@ def test_audit_log_filter():
     check(
         "Audit export API still works",
         r.status_code == 200,
-        f"(format=json)",
+        "(format=json)",
     )
 
     # Playwright UI test
@@ -235,10 +237,13 @@ def test_audit_log_filter():
             print(f"  Total display text: '{total_display}'")
             # Extract number from text
             import re
-            numbers = re.findall(r'\d+', total_display)
+
+            numbers = re.findall(r"\d+", total_display)
             if numbers:
                 displayed_total = int(numbers[0])
-                check("Total count displayed", displayed_total > 0, f"(displayed: {displayed_total})")
+                check(
+                    "Total count displayed", displayed_total > 0, f"(displayed: {displayed_total})"
+                )
         else:
             check("Total count displayed", False, "- no total text found")
 
@@ -262,10 +267,13 @@ def test_audit_log_filter():
                     # Verify all table rows have the selected action
                     rows = page.locator("table tbody tr")
                     if rows.count() > 0:
-                        first_row_action = rows.first.locator("td").nth(2).inner_text()  # Action column is 3rd
+                        first_row_action = (
+                            rows.first.locator("td").nth(2).inner_text()
+                        )  # Action column is 3rd
                         check(
                             "Action filter applied to table",
-                            second_option_value in first_row_action.lower() or first_row_action.lower() in second_option_value,
+                            second_option_value in first_row_action.lower()
+                            or first_row_action.lower() in second_option_value,
                             f"(selected={second_option_value}, row_action={first_row_action})",
                         )
                     else:
@@ -281,7 +289,11 @@ def test_audit_log_filter():
             resource_select = selects.nth(1)
             options = resource_select.locator("option")
             option_count = options.count()
-            check("Resource type select has options", option_count > 1, f"(found {option_count} options)")
+            check(
+                "Resource type select has options",
+                option_count > 1,
+                f"(found {option_count} options)",
+            )
 
             if option_count > 1:
                 second_option_value = options.nth(1).get_attribute("value")
@@ -297,7 +309,8 @@ def test_audit_log_filter():
                         first_row_rt = rows.first.locator("td").nth(3).inner_text()
                         check(
                             "Resource type filter applied to table",
-                            second_option_value in first_row_rt.lower() or first_row_rt.lower() in second_option_value,
+                            second_option_value in first_row_rt.lower()
+                            or first_row_rt.lower() in second_option_value,
                             f"(selected={second_option_value}, row_rt={first_row_rt})",
                         )
                     else:
@@ -318,7 +331,10 @@ def test_audit_log_filter():
                 action_value = selects.first.input_value()
                 resource_value = selects.nth(1).input_value()
                 check("Action filter reset to empty", action_value == "" or action_value == "All")
-                check("Resource type filter reset to empty", resource_value == "" or resource_value == "All")
+                check(
+                    "Resource type filter reset to empty",
+                    resource_value == "" or resource_value == "All",
+                )
         else:
             check("Reset button found", False)
 

--- a/tests/issues/716/test_agent_runner.py
+++ b/tests/issues/716/test_agent_runner.py
@@ -58,6 +58,7 @@ class TestAgentRunnerRunTask:
 
         assert result.success is False
         assert "not found" in result.error
+        assert result.tracking_session_id
 
     def test_run_local_success(self):
         """Test successful local agent execution — verify return value fields."""
@@ -208,6 +209,88 @@ class TestAgentRunnerRunTask:
                 )
 
         self.sm.create_session.assert_called_once()
+
+    def test_local_claude_uses_single_sidebar_session(self):
+        """Local Claude should persist only the resolved sidebar session."""
+        mock_adapter = MagicMock()
+        mock_adapter.get_executable_name.return_value = "claude"
+        mock_adapter.build_start_args.return_value = ["claude", "--model", "m1"]
+        mock_cli_adapters = MagicMock()
+        mock_cli_adapters.get_adapter.return_value = mock_adapter
+
+        stdout_lines = [
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "message": {
+                        "id": "msg-1",
+                        "model": "claude-sonnet",
+                        "content": "Hello from Claude",
+                    },
+                }
+            ).encode(),
+            json.dumps(
+                {
+                    "type": "result",
+                    "data": {
+                        "usage": {"input_tokens": 120, "output_tokens": 30},
+                    },
+                }
+            ).encode(),
+            b"",
+        ]
+
+        mock_stdout = MagicMock()
+        mock_stdout.readline = MagicMock(side_effect=stdout_lines)
+        mock_stderr = MagicMock()
+        mock_stderr.readline = MagicMock(return_value=b"")
+
+        with (
+            patch.dict("sys.modules", {"cli_adapters": mock_cli_adapters}),
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch("subprocess.Popen") as mock_popen,
+            patch.object(
+                self.runner,
+                "_find_latest_claude_session_id",
+                return_value="real-claude-session",
+            ),
+        ):
+            proc = MagicMock()
+            proc.returncode = 0
+            proc.pid = 12345
+            proc.stdin = MagicMock()
+            proc.stdout = mock_stdout
+            proc.stderr = mock_stderr
+            mock_popen.return_value = proc
+
+            result = self.runner.run_agent_task(
+                workflow_id="wf-1",
+                cli_tool="claude-code",
+                model="m1",
+                project_path="/tmp/test",
+                prompt="Do something",
+                workspace_type="local",
+                user_id=42,
+                timeout=5,
+            )
+
+        assert result.success is True
+        assert result.session_id == "real-claude-session"
+        assert result.tracking_session_id
+
+        create_calls = self.sm.create_session.call_args_list
+        assert len(create_calls) == 1
+        assert create_calls[0].kwargs["session_id"] == "real-claude-session"
+        assert create_calls[0].kwargs["tool_name"] == "claude"
+        assert create_calls[0].kwargs["title"] == "claude - real-cla"
+        assert create_calls[0].kwargs["project_path"] == "-tmp-test"
+        assert create_calls[0].kwargs["user_id"] == 42
+
+        persisted_updates = [
+            call.args[0] for call in self.sm.update_session_fields.call_args_list if call.args
+        ]
+        assert "real-claude-session" in persisted_updates
+        assert "" not in persisted_updates
 
 
 class TestLocalSession:

--- a/tests/issues/716/test_agent_runner.py
+++ b/tests/issues/716/test_agent_runner.py
@@ -292,6 +292,100 @@ class TestAgentRunnerRunTask:
         assert "real-claude-session" in persisted_updates
         assert "" not in persisted_updates
 
+    def test_local_claude_waits_for_late_session_detection(self):
+        """Late JSONL detection after process completion should still resolve the real session."""
+        mock_adapter = MagicMock()
+        mock_adapter.get_executable_name.return_value = "claude"
+        mock_adapter.build_start_args.return_value = ["claude", "--model", "m1"]
+        mock_cli_adapters = MagicMock()
+        mock_cli_adapters.get_adapter.return_value = mock_adapter
+
+        stdout_lines = [
+            json.dumps({"type": "assistant", "message": {"content": "Hello from Claude"}}).encode(),
+            json.dumps(
+                {
+                    "type": "result",
+                    "data": {
+                        "usage": {"input_tokens": 120, "output_tokens": 30},
+                    },
+                }
+            ).encode(),
+            b"",
+        ]
+
+        mock_stdout = MagicMock()
+        mock_stdout.readline = MagicMock(side_effect=stdout_lines)
+        mock_stderr = MagicMock()
+        mock_stderr.readline = MagicMock(return_value=b"")
+
+        with (
+            patch.dict("sys.modules", {"cli_adapters": mock_cli_adapters}),
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch("subprocess.Popen") as mock_popen,
+            patch.object(
+                self.runner,
+                "_find_latest_claude_session_id",
+                side_effect=["", "", "late-claude-session"],
+            ),
+            patch("time.sleep"),
+        ):
+            proc = MagicMock()
+            proc.returncode = 0
+            proc.pid = 12345
+            proc.stdin = MagicMock()
+            proc.stdout = mock_stdout
+            proc.stderr = mock_stderr
+            mock_popen.return_value = proc
+
+            result = self.runner.run_agent_task(
+                workflow_id="wf-1",
+                cli_tool="claude-code",
+                model="m1",
+                project_path="/tmp/test",
+                prompt="Do something",
+                workspace_type="local",
+                user_id=42,
+                timeout=5,
+            )
+
+        assert result.success is True
+        assert result.session_id == "late-claude-session"
+        self.sm.create_session.assert_called_with(
+            session_id="late-claude-session",
+            session_type="chat",
+            title="claude - late-cla",
+            tool_name="claude",
+            user_id=42,
+            project_path="-tmp-test",
+            workspace_type="local",
+            remote_machine_id=None,
+            context={"workflow_id": "wf-1"},
+        )
+
+    def test_sidebar_session_not_marked_resolved_when_create_fails(self):
+        """A failed DB create should not leave a ghost persisted session id."""
+        self.sm.create_session.side_effect = RuntimeError("db down")
+        session = _LocalSession(
+            session_id="tracking-1",
+            process=MagicMock(),
+            cli_tool="claude-code",
+            project_path="/tmp/test",
+            encoded_project_path="-tmp-test",
+            workflow_id="wf-1",
+            user_id=42,
+        )
+
+        with patch.object(
+            self.runner,
+            "_find_latest_claude_session_id",
+            return_value="real-claude-session",
+        ):
+            resolved = self.runner._ensure_sidebar_session(session)
+
+        assert resolved == ""
+        assert session.persisted_session_id == ""
+        self.sm.update_session_fields.assert_not_called()
+
 
 class TestLocalSession:
     """Tests for _LocalSession dataclass."""
@@ -475,3 +569,47 @@ class TestStopSession:
         runner = AutonomousAgentRunner()
         # Should not raise
         runner.stop_session("nonexistent")
+
+
+class TestPersistLocalSessionMessages:
+    """Tests for local message persistence metadata."""
+
+    def test_event_log_persists_message_and_tool_metadata(self):
+        sm = MagicMock()
+        runner = AutonomousAgentRunner(session_manager=sm)
+
+        from app.modules.workspace.autonomous.models import AgentTaskResult
+
+        result = AgentTaskResult(
+            event_log=[
+                {
+                    "type": "assistant",
+                    "text": "hello",
+                    "message_id": "msg-123",
+                    "model": "claude-sonnet",
+                },
+                {
+                    "type": "tool_use",
+                    "tool_name": "Read",
+                    "tool_input": {"file_path": "app.py"},
+                    "tool_use_id": "tool-456",
+                },
+            ]
+        )
+
+        runner._persist_local_session_messages("sess-1", result)
+
+        assert sm.add_message.call_count == 2
+        first_call = sm.add_message.call_args_list[0].kwargs
+        assert first_call["session_id"] == "sess-1"
+        assert first_call["role"] == "assistant"
+        assert first_call["model"] == "claude-sonnet"
+        assert first_call["metadata"] == {"message_id": "msg-123"}
+
+        second_call = sm.add_message.call_args_list[1].kwargs
+        assert second_call["session_id"] == "sess-1"
+        assert second_call["role"] == "tool"
+        assert second_call["metadata"] == {
+            "tool_name": "Read",
+            "tool_use_id": "tool-456",
+        }

--- a/tests/issues/716/test_autonomous_repo.py
+++ b/tests/issues/716/test_autonomous_repo.py
@@ -260,7 +260,7 @@ class TestWorkflowCRUD:
         assert fetched["total_tokens"] == 500
         assert fetched["total_input_tokens"] == 300
         assert fetched["total_output_tokens"] == 200
-        assert fetched["total_requests"] == 1
+        assert fetched["total_requests"] == 0
 
         # Accumulate more
         repo.update_workflow_tokens(
@@ -275,7 +275,7 @@ class TestWorkflowCRUD:
 
         fetched = repo.get_workflow(wf["workflow_id"])
         assert fetched["total_tokens"] == 600
-        assert fetched["total_requests"] == 2
+        assert fetched["total_requests"] == 0
 
     def test_get_active_workflows(self, auto_db):
         repo = AutonomousWorkflowRepository(auto_db)

--- a/tests/issues/716/test_models.py
+++ b/tests/issues/716/test_models.py
@@ -240,24 +240,30 @@ class TestAgentTaskResult:
     def test_default_values(self):
         r = AgentTaskResult()
         assert r.session_id == ""
+        assert r.tracking_session_id == ""
         assert r.response_text == ""
         assert r.success is False
         assert r.error is None
         assert r.total_tokens == 0
+        assert r.request_count == 0
         assert r.messages == []
         assert r.tool_calls == []
 
     def test_success_result(self):
         r = AgentTaskResult(
             session_id="sess-1",
+            tracking_session_id="track-1",
             response_text="Done",
             total_tokens=500,
             total_input_tokens=300,
             total_output_tokens=200,
+            request_count=3,
             success=True,
         )
         assert r.success is True
+        assert r.tracking_session_id == "track-1"
         assert r.total_tokens == 500
+        assert r.request_count == 3
 
     def test_error_result(self):
         r = AgentTaskResult(

--- a/tests/issues/716/test_orchestrator.py
+++ b/tests/issues/716/test_orchestrator.py
@@ -415,7 +415,13 @@ class TestOrchestratorPlanning:
 
         # Review says not approved
         plan_result = _make_agent_result(text="Plan v1")
-        review_result = _make_agent_result(text="There are issues with this plan. Needs work.")
+        review_result = _make_agent_result(
+            text=(
+                "There are issues with this plan. It is missing rollback handling, "
+                "test coverage details, and concrete implementation sequencing. "
+                "Needs another refinement pass."
+            )
+        )
         orch._runner = MagicMock()
         orch._runner.run_agent_task.side_effect = [plan_result, review_result]
         orch._gh = mock_gh
@@ -1136,9 +1142,7 @@ class TestOrchestratorPrReview:
 
         orch._do_pr_review(wf)
 
-        mock_repo.update_workflow_tokens.assert_called()
-        token_call = mock_repo.update_workflow_tokens.call_args
-        assert token_call[0][1]["total_tokens"] == 300
+        mock_repo.refresh_workflow_usage_from_sessions.assert_called_with(wf["workflow_id"])
 
     def test_pr_review_pushes_branch_before_pr(self):
         """Branch is pushed to remote before PR creation."""

--- a/tests/issues/740/test_batch1_session_wiring.py
+++ b/tests/issues/740/test_batch1_session_wiring.py
@@ -58,13 +58,23 @@ def _make_workflow(**overrides):
     return base
 
 
-def _make_agent_result(session_id="sess-abc123", success=True, text="Done", tokens=100, error=None):
+def _make_agent_result(
+    session_id="sess-abc123",
+    tracking_session_id=None,
+    success=True,
+    text="Done",
+    tokens=100,
+    error=None,
+    request_count=1,
+):
     return AgentTaskResult(
         session_id=session_id,
+        tracking_session_id=tracking_session_id or session_id,
         response_text=text,
         total_tokens=tokens,
         total_input_tokens=tokens // 2,
         total_output_tokens=tokens // 2,
+        request_count=request_count,
         success=success,
         error=error,
     )
@@ -91,6 +101,7 @@ def _make_orchestrator(wf_data):
         mock_repo.create_event.return_value = {"id": 1}
         mock_repo.update_workflow.return_value = wf_data
         mock_repo.update_workflow_tokens.return_value = None
+        mock_repo.refresh_workflow_usage_from_sessions.return_value = None
         mock_repo_cls.return_value = mock_repo
         mock_sm_cls.return_value = MagicMock()
 
@@ -102,6 +113,9 @@ def _make_orchestrator(wf_data):
     orch._runner = MagicMock()
     orch._runner.run_agent_task.return_value = _make_agent_result()
     orch._runner.stop_session = MagicMock()
+    orch._runner._uses_sidebar_session_source.side_effect = (
+        lambda cli_tool, workspace_type: cli_tool == "claude-code" and workspace_type == "local"
+    )
 
     # Mock GitHubOps
     with patch("app.modules.workspace.autonomous.orchestrator.GitHubOps") as mock_gh_cls:
@@ -148,7 +162,9 @@ class TestSessionManagerWiring:
 
             AutonomousOrchestrator("test-wf-id")
 
-            mock_runner_cls.assert_called_once_with(session_manager=mock_sm)
+            call_kwargs = mock_runner_cls.call_args[1]
+            assert call_kwargs["session_manager"] is mock_sm
+            assert "activity_callback" in call_kwargs
 
     def test_session_manager_none_triggers_default(self):
         """Without our fix, runner would get session_manager=None (regression guard)."""
@@ -191,8 +207,11 @@ class TestRunAgentWrapper:
         wf = _make_workflow()
         orch, mock_repo = _make_orchestrator(wf)
 
-        expected_session = "sess-tracked-123"
-        orch._runner.run_agent_task.return_value = _make_agent_result(session_id=expected_session)
+        expected_tracking_session = "sess-tracked-123"
+        orch._runner.run_agent_task.return_value = _make_agent_result(
+            session_id="sess-real-123",
+            tracking_session_id=expected_tracking_session,
+        )
 
         mock_repo.list_milestones.return_value = [
             {"milestone_type": "plan_created", "plan_content": "Build X"},
@@ -201,7 +220,7 @@ class TestRunAgentWrapper:
         # Call _do_development which uses _run_agent
         orch._do_development(wf)
 
-        assert orch._current_session_id == expected_session
+        assert orch._current_session_id == expected_tracking_session
 
     def test_run_agent_updates_on_each_call(self):
         """_current_session_id should update with each _run_agent call."""
@@ -210,15 +229,18 @@ class TestRunAgentWrapper:
 
         # Planning calls _run_agent twice (plan + review)
         orch._runner.run_agent_task.side_effect = [
-            _make_agent_result(session_id="sess-plan-1"),
-            _make_agent_result(session_id="sess-review-1"),
+            _make_agent_result(session_id="sess-plan-1", tracking_session_id="track-plan-1"),
+            _make_agent_result(
+                session_id="sess-review-1",
+                tracking_session_id="track-review-1",
+            ),
         ]
         mock_repo.list_milestones.return_value = []
 
         orch._do_planning(wf)
 
         # Should track the last session_id
-        assert orch._current_session_id == "sess-review-1"
+        assert orch._current_session_id == "track-review-1"
 
     def test_session_id_available_before_run_agent_task_returns(self):
         """session_id must be set BEFORE run_agent_task returns (Critical fix).
@@ -235,7 +257,10 @@ class TestRunAgentWrapper:
             nonlocal captured_session_id
             # Simulate: during execution, the session_id should already be set
             captured_session_id = orch._current_session_id
-            return _make_agent_result(session_id=kwargs.get("session_id", "default"))
+            return _make_agent_result(
+                session_id="real-sidebar-session",
+                tracking_session_id=kwargs.get("session_id", "default"),
+            )
 
         orch._runner.run_agent_task.side_effect = fake_run_agent_task
         mock_repo.list_milestones.return_value = [
@@ -603,7 +628,7 @@ class TestStopPauseCancelsTask:
         orig = db_mod.adapt_sql
         db_mod.adapt_sql = lambda sql: sql
 
-        db = db_mod.Database(db_path)
+        db = db_mod.Database(f"sqlite:///{db_path}")
         try:
             with db.get_connection() as conn:
                 cursor = conn.cursor()

--- a/tests/issues/771/test_realtime_activity.py
+++ b/tests/issues/771/test_realtime_activity.py
@@ -4,7 +4,7 @@ Covers:
   - activity_callback invocation in agent_runner
   - _on_agent_activity forwarding to emitter
   - _link_session_to_current_milestone immediate session_id write
-  - Token real-time update via usage events
+  - Workflow usage refresh via linked real sessions
 """
 
 from __future__ import annotations
@@ -129,7 +129,7 @@ class TestActivityCallback:
 
 
 class TestOrchestratorActivityForwarding:
-    """Verify orchestrator _on_agent_activity forwards to emitter and updates tokens."""
+    """Verify orchestrator _on_agent_activity forwards to emitter and refreshes usage."""
 
     def test_emits_agent_activity_event(self):
         from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
@@ -155,7 +155,7 @@ class TestOrchestratorActivityForwarding:
         assert args[2]["session_id"] == "sess-456"
         assert args[2]["type"] == "tool_use"
 
-    def test_updates_tokens_on_usage_event(self):
+    def test_refreshes_usage_on_usage_event(self):
         from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
 
         orch = AutonomousOrchestrator.__new__(AutonomousOrchestrator)
@@ -173,16 +173,29 @@ class TestOrchestratorActivityForwarding:
             },
         )
 
-        orch.repo.update_workflow_tokens.assert_called_once_with(
-            "wf-123",
+        orch.repo.refresh_workflow_usage_from_sessions.assert_called_once_with("wf-123")
+
+    def test_resolves_session_on_session_resolved_event(self):
+        from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+        orch = AutonomousOrchestrator.__new__(AutonomousOrchestrator)
+        orch._workflow_id = "wf-123"
+        orch.emitter = MagicMock()
+        orch.repo = MagicMock()
+        orch._link_session_to_current_milestone = MagicMock()
+
+        orch._on_agent_activity(
+            "sess-real-456",
             {
-                "total_tokens": 10000,
-                "total_input_tokens": 8000,
-                "total_output_tokens": 2000,
+                "type": "session_resolved",
+                "session_id": "sess-real-456",
             },
         )
 
-    def test_no_token_update_on_non_usage_event(self):
+        orch._link_session_to_current_milestone.assert_called_once_with("sess-real-456")
+        orch.repo.refresh_workflow_usage_from_sessions.assert_called_once_with("wf-123")
+
+    def test_no_usage_refresh_on_non_usage_event(self):
         from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
 
         orch = AutonomousOrchestrator.__new__(AutonomousOrchestrator)
@@ -198,7 +211,7 @@ class TestOrchestratorActivityForwarding:
             },
         )
 
-        orch.repo.update_workflow_tokens.assert_not_called()
+        orch.repo.refresh_workflow_usage_from_sessions.assert_not_called()
 
 
 class TestLinkSessionToMilestone:
@@ -220,6 +233,27 @@ class TestLinkSessionToMilestone:
         orch.repo.update_milestone.assert_called_once_with(
             "ms-789",
             {"session_id": "sess-456"},
+        )
+
+    def test_links_review_session_to_review_field(self):
+        from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+        orch = AutonomousOrchestrator.__new__(AutonomousOrchestrator)
+        orch._workflow_id = "wf-123"
+        orch.repo = MagicMock()
+
+        ms = {
+            "milestone_id": "ms-review",
+            "status": "in_progress",
+            "milestone_type": "plan_reviewed",
+        }
+        orch.repo.list_milestones.return_value = [ms]
+
+        orch._link_session_to_current_milestone("sess-review-456")
+
+        orch.repo.update_milestone.assert_called_once_with(
+            "ms-review",
+            {"review_session_id": "sess-review-456"},
         )
 
     def test_no_error_when_no_in_progress_milestones(self):

--- a/tests/unit/test_analysis_batch.py
+++ b/tests/unit/test_analysis_batch.py
@@ -4,7 +4,7 @@ Tests that batch analysis API response includes data_range field.
 """
 
 from concurrent.futures import Future
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 
@@ -182,17 +182,21 @@ class TestBatchAnalysisDataRange:
         # Create 12 valid users + 2 ou_ users
         user_data = []
         for i in range(12):
-            user_data.append({
-                "unified_username": f"user_{i}",
-                "total_tokens": 1000 - i * 50,
-                "message_count": 10,
-            })
+            user_data.append(
+                {
+                    "unified_username": f"user_{i}",
+                    "total_tokens": 1000 - i * 50,
+                    "message_count": 10,
+                }
+            )
         # Add ou_ users that should be filtered
-        user_data.append({
-            "unified_username": "ou_1234567890abcdef",
-            "total_tokens": 99999,
-            "message_count": 100,
-        })
+        user_data.append(
+            {
+                "unified_username": "ou_1234567890abcdef",
+                "total_tokens": 99999,
+                "message_count": 100,
+            }
+        )
 
         self.daily_stats_repo.get_batch_aggregates.return_value = {
             "total_messages": 1000,


### PR DESCRIPTION
## Summary
- remove the extra persisted autonomous wrapper session for future local Claude autonomous runs
- resolve and persist the real sidebar Claude session id from the active JSONL file, then link workflow milestones and usage to that session
- refresh workflow token and request totals from linked real sessions only, and make Claude fetch backfill idempotent by message_id

## Testing
- python3 -m pytest tests/issues/716/test_models.py tests/issues/716/test_agent_runner.py tests/issues/771/test_realtime_activity.py tests/issues/740/test_batch1_session_wiring.py tests/issues/716/test_orchestrator.py -q