### PR TITLE
fix: improve dark mode contrast and theme sync (Issue #637)

### DIFF
--- a/frontend/src/components/features/TerminalTab.tsx
+++ b/frontend/src/components/features/TerminalTab.tsx
@@ -49,6 +49,10 @@ export const TerminalTab: React.FC<TerminalTabProps> = ({
   const isActiveRef = useRef(isActive);
   isActiveRef.current = isActive;
 
+  // Use ref for theme to avoid stale closure in async initTerminal (Issue #637)
+  const themeRef = useRef(theme);
+  themeRef.current = theme;
+
   // Use refs for callbacks to avoid stale closures and unnecessary reconnects
   const onReattachNeededRef = useRef(onReattachNeeded);
   onReattachNeededRef.current = onReattachNeeded;
@@ -207,9 +211,10 @@ export const TerminalTab: React.FC<TerminalTabProps> = ({
       const { FitAddon } = await import('@xterm/addon-fit');
       const { WebLinksAddon } = await import('@xterm/addon-web-links');
 
-      // Dynamic theme based on application theme mode (Issue #637)
-      const terminalTheme =
-        theme === 'dark'
+      // Use current theme for initial setup via ref (Issue #637)
+      const currentTheme = themeRef.current;
+      const initialTheme =
+        currentTheme === 'dark'
           ? {
               background: '#1e1e2e',
               foreground: '#cdd6f4',
@@ -227,7 +232,7 @@ export const TerminalTab: React.FC<TerminalTabProps> = ({
         cursorBlink: true,
         fontSize: 14,
         fontFamily: 'Menlo, Monaco, "Courier New", monospace',
-        theme: terminalTheme,
+        theme: initialTheme,
         allowProposedApi: true,
       });
 
@@ -273,7 +278,28 @@ export const TerminalTab: React.FC<TerminalTabProps> = ({
         terminal.dispose();
       }
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Dynamic theme update without restarting terminal (Issue #637)
+  useEffect(() => {
+    if (!xtermRef.current) return;
+
+    const terminalTheme =
+      theme === 'dark'
+        ? {
+            background: '#1e1e2e',
+            foreground: '#cdd6f4',
+            cursor: '#f5e0dc',
+            selectionBackground: '#585b7066',
+          }
+        : {
+            background: '#ffffff',
+            foreground: '#1e1e2e',
+            cursor: '#1e1e2e',
+            selectionBackground: '#add8e666',
+          };
+
+    xtermRef.current.options.theme = terminalTheme;
   }, [theme]);
 
   // Connect when xterm is ready or wsUrl/token change

--- a/frontend/src/components/features/TerminalTab.tsx
+++ b/frontend/src/components/features/TerminalTab.tsx
@@ -10,7 +10,7 @@ import React, { useEffect, useRef, useCallback, useState } from 'react';
 import '@xterm/xterm/css/xterm.css';
 import type { Terminal } from '@xterm/xterm';
 import type { FitAddon } from '@xterm/addon-fit';
-import { useLanguage } from '@/store';
+import { useLanguage, useTheme } from '@/store';
 import { t } from '@/i18n';
 
 type ConnectionState = 'connecting' | 'connected' | 'disconnected' | 'error';
@@ -39,6 +39,7 @@ export const TerminalTab: React.FC<TerminalTabProps> = ({
   onReattachNeeded,
 }) => {
   const language = useLanguage();
+  const theme = useTheme();
   const terminalRef = useRef<HTMLDivElement>(null);
   const xtermRef = useRef<Terminal | null>(null);
   const wsRef = useRef<WebSocket | null>(null);
@@ -206,16 +207,27 @@ export const TerminalTab: React.FC<TerminalTabProps> = ({
       const { FitAddon } = await import('@xterm/addon-fit');
       const { WebLinksAddon } = await import('@xterm/addon-web-links');
 
+      // Dynamic theme based on application theme mode (Issue #637)
+      const terminalTheme =
+        theme === 'dark'
+          ? {
+              background: '#1e1e2e',
+              foreground: '#cdd6f4',
+              cursor: '#f5e0dc',
+              selectionBackground: '#585b7066',
+            }
+          : {
+              background: '#ffffff',
+              foreground: '#1e1e2e',
+              cursor: '#1e1e2e',
+              selectionBackground: '#add8e666',
+            };
+
       terminal = new Terminal({
         cursorBlink: true,
         fontSize: 14,
         fontFamily: 'Menlo, Monaco, "Courier New", monospace',
-        theme: {
-          background: '#1e1e2e',
-          foreground: '#cdd6f4',
-          cursor: '#f5e0dc',
-          selectionBackground: '#585b7066',
-        },
+        theme: terminalTheme,
         allowProposedApi: true,
       });
 
@@ -261,7 +273,8 @@ export const TerminalTab: React.FC<TerminalTabProps> = ({
         terminal.dispose();
       }
     };
-  }, []);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [theme]);
 
   // Connect when xterm is ready or wsUrl/token change
   useEffect(() => {
@@ -320,6 +333,12 @@ export const TerminalTab: React.FC<TerminalTabProps> = ({
   // Always render terminal div to allow xterm.js initialization
   // The terminal will show "waiting for connection" state if wsUrl is empty
 
+  // Dynamic styles based on theme (Issue #637)
+  const terminalBgColor = theme === 'dark' ? '#1e1e2e' : '#ffffff';
+  const statusBarBgColor = theme === 'dark' ? '#181825' : '#f8fafc';
+  const statusBarBorderColor = theme === 'dark' ? '#313244' : '#e2e8f0';
+  const statusBarTextColor = theme === 'dark' ? '#a6adc8' : '#475569';
+
   return (
     <div className="d-flex flex-column h-100">
       {/* Terminal area */}
@@ -327,7 +346,7 @@ export const TerminalTab: React.FC<TerminalTabProps> = ({
         ref={terminalRef}
         className="flex-grow-1"
         style={{
-          backgroundColor: '#1e1e2e',
+          backgroundColor: terminalBgColor,
           padding: '4px',
           minHeight: 0,
         }}
@@ -337,10 +356,10 @@ export const TerminalTab: React.FC<TerminalTabProps> = ({
       <div
         className="d-flex align-items-center px-2 py-1"
         style={{
-          backgroundColor: '#181825',
-          borderTop: '1px solid #313244',
+          backgroundColor: statusBarBgColor,
+          borderTop: `1px solid ${statusBarBorderColor}`,
           fontSize: '0.75rem',
-          color: '#a6adc8',
+          color: statusBarTextColor,
           flexShrink: 0,
         }}
       >

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -222,7 +222,7 @@
   --text-primary: #f8fafc;
   --text-secondary: #cbd5e1;
   --text-tertiary: #94a3b8;
-  --text-muted: #64748b;
+  --text-muted: #a1a1aa; /* Issue #637: Improved contrast from #64748b (~3.5:1) to #a1a1aa (~4.7:1) */
 
   --border-color: #334155;
   --border-color-light: #1e293b;

--- a/static/index.html
+++ b/static/index.html
@@ -7,7 +7,25 @@
     <title>Qwen Code Web UI</title>
     <script>
       // Prevent flash of unstyled content by setting theme class early
+      // Issue #637: Support theme parameter from URL for iframe embedding
       (function () {
+        // First check URL parameter (for iframe embedding)
+        const urlParams = new URLSearchParams(window.location.search);
+        const urlTheme = urlParams.get("theme");
+
+        if (urlTheme === "dark" || urlTheme === "light") {
+          // Use URL parameter theme
+          if (urlTheme === "dark") {
+            document.documentElement.classList.add("dark");
+          } else {
+            document.documentElement.classList.remove("dark");
+          }
+          // Also save to localStorage for persistence
+          localStorage.setItem("qwen-code-webui-theme", JSON.stringify(urlTheme));
+          return;
+        }
+
+        // Fallback to stored theme or system preference
         const storedTheme = localStorage.getItem("qwen-code-webui-theme");
         let theme = null;
         try {
@@ -16,7 +34,7 @@
           // If parsing fails, fall back to null
           theme = null;
         }
-        
+
         if (
           theme === "dark" ||
           (!theme && window.matchMedia("(prefers-color-scheme: dark)").matches)


### PR DESCRIPTION
## Summary

修复 Dark mode 下多处样式对比度不足的问题，以及 iframe 主题同步问题。

## Changes

### 1. TerminalTab.tsx - Terminal 主题动态切换
- 添加 `useTheme` hook 获取当前主题
- 根据主题动态设置 Terminal 配色方案（深色/浅色）
- Terminal 背景色和状态栏颜色随主题变化

### 2. static/index.html - iframe 主题同步
- 支持 URL 参数 `theme` 传递主题设置
- 优先使用 URL 参数主题（用于 iframe 嵌入场景）
- 同步保存到 localStorage 以持久化

### 3. main.css - text-muted 对比度提升
- Dark mode 下 `--text-muted` 从 `#64748b` 改为 `#a1a1aa`
- 对比度从 ~3.5:1 提升到 ~4.7:1，满足 WCAG AA 标准（≥4.5:1）

## Test Plan

1. 切换应用主题（dark/light），验证 Terminal 配色正确切换
2. 在 Workspace 中打开 iframe tab，验证主题与外层应用一致
3. 检查 Settings 页面在 dark mode 下文字是否清晰可见
4. 使用对比度工具验证 text-muted 颜色符合 WCAG 标准

Fixes #637