### PR TITLE
fix(windows): add Windows compatibility check for menu command (#686)

### DIFF
--- a/remote-agent/openace_cli.py
+++ b/remote-agent/openace_cli.py
@@ -275,7 +275,7 @@ def cmd_status(_: argparse.Namespace) -> int:
 def cmd_menu(args: argparse.Namespace) -> int:
     # Windows does not support termios module used by terminal_menu.py
     # Fall back to shell mode on Windows
-    if sys.platform == "win32":
+    if os.name == "nt":
         print("Note: Interactive menu is not supported on Windows.")
         print("Starting shell instead. You can run AI tools directly from the shell.\n")
         return cmd_shell(args)
@@ -294,11 +294,17 @@ def cmd_shell(args: argparse.Namespace) -> int:
     _apply_local_cli_settings(terminal)
     _write_active_terminal(terminal)
     env = _session_env(terminal)
-    shell = os.environ.get("SHELL") or "/bin/sh"
-    try:
+
+    # Windows: use COMSPEC (cmd.exe)
+    if os.name == "nt":
+        shell = os.environ.get("COMSPEC") or "cmd.exe"
+        subprocess.run([shell], env=env, cwd=work_dir, check=False)
+    else:
+        # Unix/Linux: login shell
+        shell = os.environ.get("SHELL") or "/bin/sh"
         subprocess.run([shell, "-l"], env=env, cwd=work_dir, check=False)
-    finally:
-        _clear_active_terminal()
+
+    _clear_active_terminal()
     return 0
 
 

--- a/remote-agent/openace_cli.py
+++ b/remote-agent/openace_cli.py
@@ -273,6 +273,13 @@ def cmd_status(_: argparse.Namespace) -> int:
 
 
 def cmd_menu(args: argparse.Namespace) -> int:
+    # Windows does not support termios module used by terminal_menu.py
+    # Fall back to shell mode on Windows
+    if sys.platform == "win32":
+        print("Note: Interactive menu is not supported on Windows.")
+        print("Starting shell instead. You can run AI tools directly from the shell.\n")
+        return cmd_shell(args)
+
     work_dir = os.path.abspath(args.work_dir or os.getcwd())
     terminal = _start_cli_terminal(work_dir)
     _apply_local_cli_settings(terminal)

--- a/remote-agent/openace_cli.py
+++ b/remote-agent/openace_cli.py
@@ -295,16 +295,17 @@ def cmd_shell(args: argparse.Namespace) -> int:
     _write_active_terminal(terminal)
     env = _session_env(terminal)
 
-    # Windows: use COMSPEC (cmd.exe)
-    if os.name == "nt":
-        shell = os.environ.get("COMSPEC") or "cmd.exe"
-        subprocess.run([shell], env=env, cwd=work_dir, check=False)
-    else:
-        # Unix/Linux: login shell
-        shell = os.environ.get("SHELL") or "/bin/sh"
-        subprocess.run([shell, "-l"], env=env, cwd=work_dir, check=False)
-
-    _clear_active_terminal()
+    try:
+        # Windows: use COMSPEC (cmd.exe)
+        if os.name == "nt":
+            shell = os.environ.get("COMSPEC") or "cmd.exe"
+            subprocess.run([shell], env=env, cwd=work_dir, check=False)
+        else:
+            # Unix/Linux: login shell
+            shell = os.environ.get("SHELL") or "/bin/sh"
+            subprocess.run([shell, "-l"], env=env, cwd=work_dir, check=False)
+    finally:
+        _clear_active_terminal()
     return 0
 
 


### PR DESCRIPTION
## Summary
Fix Windows compatibility issue with `openace menu` command by adding platform detection and graceful fallback.

## Problem
On Windows, running `openace menu` fails with:
```
ModuleNotFoundError: No module named 'termios'
```

The `termios` module is Unix/Linux specific and not available on Windows.

## Solution
- Add platform detection in `cmd_menu()` function
- On Windows (`sys.platform == "win32"`), fall back to shell mode
- Provide user-friendly message explaining the limitation
- No impact on Unix/Linux users

## Changes
- Modified `remote-agent/openace_cli.py`:
  - Added Windows platform check at the beginning of `cmd_menu()`
  - Falls back to `cmd_shell()` on Windows
  - Prints informative message for Windows users

## Testing
- ✅ Code compiles without syntax errors
- ✅ No changes to Unix/Linux behavior
- ⚠️ Windows testing needed (requires Windows environment)

## Related
Fixes #686

🤖 Generated with Qwen Code