### PR TITLE
fix: adjust Today's By Tool layout position in RequestDashboard

### DIFF
--- a/frontend/src/components/features/management/RequestDashboard.tsx
+++ b/frontend/src/components/features/management/RequestDashboard.tsx
@@ -228,6 +228,48 @@ export const RequestDashboard: React.FC = () => {
         </div>
       </div>
 
+      {/* Today's By Tool */}
+      <div className="row g-4 mb-4">
+        <div className="col-12">
+          <Card title={t('todayByTool', language)}>
+            {todayStats?.by_tool && Object.keys(todayStats.by_tool).length > 0 ? (
+              <div className="table-responsive">
+                <table className="table table-sm">
+                  <thead>
+                    <tr>
+                      <th>{t('tool', language)}</th>
+                      <th className="text-end">{t('requests', language)}</th>
+                      <th className="text-end">{t('percentage', language)}</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {Object.entries(todayStats.by_tool)
+                      .sort((a, b) => b[1] - a[1])
+                      .map(([tool, count]) => {
+                        const percentage =
+                          todayStats.total_requests > 0
+                            ? ((count / todayStats.total_requests) * 100).toFixed(1)
+                            : '0';
+                        return (
+                          <tr key={tool}>
+                            <td>
+                              <Badge variant="info">{tool.toUpperCase()}</Badge>
+                            </td>
+                            <td className="text-end">{formatNumber(count)}</td>
+                            <td className="text-end">{percentage}%</td>
+                          </tr>
+                        );
+                      })}
+                  </tbody>
+                </table>
+              </div>
+            ) : (
+              <EmptyState icon="bi-pie-chart" title={t('noData', language)} />
+            )}
+          </Card>
+        </div>
+      </div>
+
       {/* Date Range Selector */}
       <Card className="mb-4">
         <div className="d-flex flex-wrap gap-2 align-items-center">
@@ -274,10 +316,9 @@ export const RequestDashboard: React.FC = () => {
         </div>
       </Card>
 
-      {/* Charts Row */}
+      {/* Request Trend Chart */}
       <div className="row g-4 mb-4">
-        {/* Request Trend Chart */}
-        <div className="col-lg-8">
+        <div className="col-12">
           <Card title={t('requestTrend', language)}>
             {trendData.length > 0 ? (
               <LazyLineChart
@@ -287,46 +328,6 @@ export const RequestDashboard: React.FC = () => {
               />
             ) : (
               <EmptyState icon="bi-graph-up" title={t('noData', language)} />
-            )}
-          </Card>
-        </div>
-
-        {/* Today's By Tool */}
-        <div className="col-lg-4">
-          <Card title={t('todayByTool', language)}>
-            {todayStats?.by_tool && Object.keys(todayStats.by_tool).length > 0 ? (
-              <div className="table-responsive">
-                <table className="table table-sm">
-                  <thead>
-                    <tr>
-                      <th>{t('tool', language)}</th>
-                      <th className="text-end">{t('requests', language)}</th>
-                      <th className="text-end">{t('percentage', language)}</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {Object.entries(todayStats.by_tool)
-                      .sort((a, b) => b[1] - a[1])
-                      .map(([tool, count]) => {
-                        const percentage =
-                          todayStats.total_requests > 0
-                            ? ((count / todayStats.total_requests) * 100).toFixed(1)
-                            : '0';
-                        return (
-                          <tr key={tool}>
-                            <td>
-                              <Badge variant="info">{tool.toUpperCase()}</Badge>
-                            </td>
-                            <td className="text-end">{formatNumber(count)}</td>
-                            <td className="text-end">{percentage}%</td>
-                          </tr>
-                        );
-                      })}
-                  </tbody>
-                </table>
-              </div>
-            ) : (
-              <EmptyState icon="bi-pie-chart" title={t('noData', language)} />
             )}
           </Card>
         </div>


### PR DESCRIPTION
## 问题描述

Fixes #810

在管理模式 -> 请求统计页面，"今日按工具"的显示位置布局不合理，应调整到更合适的位置。

### 问题位置
- 页面：管理模式 -> 概览 -> 请求统计
- 元素：今日按工具

### 当前布局
"今日按工具"显示在日期范围选择下面。

### 预期布局
"今日按工具"应该放在"今日请求数"下面，而非日期范围选择下面。

### 原因分析
- "今日按工具"与"今日请求数"都是针对"今日"的数据，逻辑上应相邻显示
- 放在日期范围选择下面会导致用户困惑，因为日期范围是全局筛选条件，而"今日按工具"是特定日期的数据

## 修改内容

- 将"今日按工具"模块从 Charts Row 中移出
- 放置在"今日统计卡片"和"日期范围选择器"之间
- "请求趋势图"改为全宽显示（col-12）

## 测试

请访问管理模式 -> 概览 -> 请求统计页面，验证布局调整后的效果。