### PR TITLE
fix: 仪表盘所有工具下拉列表添加 codex 工具

### DIFF
--- a/app/repositories/usage_repo.py
+++ b/app/repositories/usage_repo.py
@@ -387,19 +387,27 @@ class UsageRepository:
 
     def get_all_tools(self) -> list[str]:
         """
-        Get list of all tools.
+        Get list of all tools, including system-supported tools.
 
         Returns:
-            List[str]: List of tool names.
+            List[str]: List of tool names (static + dynamic).
         """
+        from app.utils.tool_names import TOOL_NAME_ALIASES
+
+        # Get tools from database (dynamic tools with usage records)
         query = """
             SELECT DISTINCT tool_name
             FROM daily_messages
             ORDER BY tool_name
         """
-
         rows = self.db.fetch_all(query)
-        return sorted({normalize_tool_name(row["tool_name"]) for row in rows})
+        db_tools = {normalize_tool_name(row["tool_name"]) for row in rows}
+
+        # Get system-supported tools (static tools)
+        system_tools = set(TOOL_NAME_ALIASES.keys())
+
+        # Combine and return sorted list
+        return sorted(db_tools | system_tools)
 
     def get_all_hosts(self) -> list[str]:
         """


### PR DESCRIPTION
## 问题描述

Fixes #799

管理模式仪表盘页面的"所有工具"下拉列表显示不完整，缺少 codex 工具。

## 问题根因

`/api/tools` 端点通过 `get_all_tools()` 只返回数据库中有使用记录的工具，导致未使用过的工具（如 codex）不会出现在下拉列表中。

## 解决方案

修改 `app/repositories/usage_repo.py` 的 `get_all_tools()` 方法：
- 返回系统支持的静态工具列表（基于 `TOOL_NAME_ALIASES`)
- 加上数据库中已有的动态工具
- 确保所有可用工具都能显示在下拉列表

## 修改内容

- 修改 `get_all_tools()` 方法，合并静态工具和动态工具列表
- 现返回包含 `claude`, `codex`, `openclaw`, `qwen` 的完整工具列表

## 测试验证

本地测试验证修改后的代码正确返回包含 codex 的工具列表。