### PR TITLE
Fix additional TypeScript errors in CleanupPreviewContent and ComplianceMgmt

### DIFF
--- a/frontend/src/components/features/compliance/CleanupPreviewContent.tsx
+++ b/frontend/src/components/features/compliance/CleanupPreviewContent.tsx
@@ -11,12 +11,12 @@
 import React from 'react';
 import { useLanguage } from '@/store';
 import { t } from '@/i18n';
+import type { Language } from '@/types';
 import { Card, Badge, EmptyState } from '@/components/common';
 import { type RetentionReport, type AppliedRule } from '@/api';
 import { formatDateTime } from '@/utils';
 import { cn } from '@/utils';
 import {
-  DATA_TYPE_META,
   getDataTypeLabel,
   getDataTypeIcon,
 } from './DataRetention';
@@ -38,7 +38,7 @@ function getActionBadgeVariant(action: 'delete' | 'archive' | 'anonymize'): 'dan
 /**
  * Get action label
  */
-function getActionLabel(action: 'delete' | 'archive' | 'anonymize', language: string): string {
+function getActionLabel(action: 'delete' | 'archive' | 'anonymize', language: Language): string {
   switch (action) {
     case 'delete':
       return t('actionDelete', language);

--- a/frontend/src/components/features/management/ComplianceMgmt.tsx
+++ b/frontend/src/components/features/management/ComplianceMgmt.tsx
@@ -34,6 +34,7 @@ import {
   type RetentionRule,
   type RetentionHistory,
   type StorageEstimate,
+  type RetentionReport,
 } from '@/api';
 import { usePageRefresh } from '@/hooks';
 
@@ -205,7 +206,7 @@ export const ComplianceMgmt: React.FC = () => {
   const [editingRule, setEditingRule] = useState<string | null>(null);
   const [editDays, setEditDays] = useState(90);
   const [editAction, setEditAction] = useState<'delete' | 'archive' | 'anonymize'>('delete');
-  const [previewResult, setPreviewResult] = useState<Record<string, unknown> | null>(null);
+  const [previewResult, setPreviewResult] = useState<RetentionReport | null>(null);
   const [isRunning, setIsRunning] = useState(false);
 
   // Report preview state


### PR DESCRIPTION
Fixes remaining TypeScript compilation errors introduced by recent auto-dev merges.

- Remove unused DATA_TYPE_META import in CleanupPreviewContent
- Add Language type import and fix getActionLabel parameter type
- Fix previewResult state type (RetentionReport instead of Record<string, unknown>)

Related to #969

🤖 Generated with Qwen Code (9-shotted by Qwen-Coder)