### PR TITLE
fix: add tenant_id to /auth/check API response (Issue #874)

### DIFF
--- a/app/repositories/user_repo.py
+++ b/app/repositories/user_repo.py
@@ -460,7 +460,7 @@ class UserRepository:
             Optional[Dict]: Session data with user info or None.
         """
         query = """
-            SELECT s.*, u.username, u.email, u.role
+            SELECT s.*, u.username, u.email, u.role, u.tenant_id
             FROM sessions s
             JOIN users u ON s.user_id = u.id
             WHERE s.token = ? AND s.expires_at > ?

--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -239,6 +239,7 @@ def api_auth_check():
             "username": session.get("username"),
             "email": session.get("email"),
             "role": session.get("role"),
+            "tenant_id": session.get("tenant_id"),
             "avatar_url": avatar_url,
         },
     }


### PR DESCRIPTION
## Summary

补充修复 Issue #874 的遗漏问题：`/auth/check` API 返回的 user 对象缺少 `tenant_id` 字段。

## Changes

- `user_repo.py`: `get_session_by_token` 查询添加 `u.tenant_id`
- `auth.py`: 返回对象添加 `tenant_id: session.get("tenant_id")`

## Root Cause

PR #880 修复了 tenant_settings 表更新逻辑和前端实现，但遗漏了后端 API 返回 tenant_id 字段。导致前端 `user?.tenant_id` 为 undefined，SSOSettings 组件无法渲染。

## Test

1. 登录后检查 `/auth/check` API 返回包含 `tenant_id`
2. 进入管理模式 → 设置 → SSO 设置，页面正常渲染

Fixes #874