### PR TITLE
fix: add __future__ annotations for Python 3.9 compatibility

### DIFF
--- a/app/schemas/quota.py
+++ b/app/schemas/quota.py
@@ -7,6 +7,8 @@ Provides validation and limits for quota values to ensure:
 - Values are valid numbers (not NaN)
 """
 
+from __future__ import annotations
+
 import logging
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary

修复 `app/schemas/quota.py` 的 Python 3.9 兼容性问题。

## Problem

该文件使用了 `int | None` union type 语法，这是 Python 3.10+ 才支持的特性。CI 测试矩阵包含 Python 3.9，导致导入失败：

```
TypeError: unsupported operand type(s) for |: "type" and "NoneType"
```

## Solution

添加 `from __future__ import annotations`，使 Python 3.9 支持延迟注解解析。

## Test

- `pytest tests/unit/test_quota_validation.py` ✅ 通过