### PR TITLE
fix: session update messages assigned to wrong tab after page refresh (Issue #916)

### DIFF
--- a/frontend/src/components/features/Workspace.tsx
+++ b/frontend/src/components/features/Workspace.tsx
@@ -301,50 +301,61 @@ export const Workspace: React.FC = () => {
       // This allows the iframe to inform the workspace about its current session
       if (event.data?.type === 'qwen-code-session-update') {
         const { sessionId, encodedProjectName, toolName, title, settings } = event.data;
-        // Update the current active tab with session info
-        if (sessionId) {
-          const currentActiveTabId = useAppStore.getState().workspaceActiveTabId;
-          if (currentActiveTabId) {
-            // Filter out generic "Conversation(xxx...)" titles from iframe
-            const isGenericTitle = title && /^Conversation\([a-f0-9]+\.\.\.\)$/i.test(title);
-            // Only update title if it's explicitly provided (not undefined) and not generic
-            // Otherwise keep the existing title (e.g., "New Session")
-            const updateData: Partial<StoreWorkspaceTab> = {
-              sessionId,
-              encodedProjectName,
-              toolName,
-              settings, // Save settings for tab restoration (Issue #70)
-            };
-            if (title && !isGenericTitle) {
-              updateData.title = title;
+
+        // Find the tab that sent this message by matching event.source to iframe contentWindow
+        // This prevents session info from being incorrectly assigned to the wrong tab
+        // when multiple iframes send updates simultaneously (Issue #916)
+        let sourceTabId: string | null = null;
+        if (event.source) {
+          for (const [tabId, iframe] of iframeRefs.current.entries()) {
+            if (iframe.contentWindow === event.source) {
+              sourceTabId = tabId;
+              break;
             }
-            // Fallback: use decoded project name if title is generic Conversation(xxx...)
-            if (isGenericTitle && encodedProjectName) {
-              updateData.title = decodeURIComponent(encodedProjectName);
-            }
-            useAppStore.getState().updateWorkspaceTab(currentActiveTabId, updateData);
-            // Also update local tabs state
-            const effectiveTitle =
-              title && !isGenericTitle
-                ? title
-                : isGenericTitle && encodedProjectName
-                  ? decodeURIComponent(encodedProjectName)
-                  : undefined;
-            setTabs((prev) =>
-              prev.map((tab) =>
-                tab.id === currentActiveTabId
-                  ? {
-                      ...tab,
-                      sessionId,
-                      encodedProjectName,
-                      toolName,
-                      title: effectiveTitle ?? tab.title,
-                      settings,
-                    }
-                  : tab
-              )
-            );
           }
+        }
+
+        // Only process session update if we can identify the source tab
+        if (sessionId && sourceTabId) {
+          // Filter out generic "Conversation(xxx...)" titles from iframe
+          const isGenericTitle = title && /^Conversation\([a-f0-9]+\.\.\.\)$/i.test(title);
+          // Only update title if it's explicitly provided (not undefined) and not generic
+          // Otherwise keep the existing title (e.g., "New Session")
+          const updateData: Partial<StoreWorkspaceTab> = {
+            sessionId,
+            encodedProjectName,
+            toolName,
+            settings, // Save settings for tab restoration (Issue #70)
+          };
+          if (title && !isGenericTitle) {
+            updateData.title = title;
+          }
+          // Fallback: use decoded project name if title is generic Conversation(xxx...)
+          if (isGenericTitle && encodedProjectName) {
+            updateData.title = decodeURIComponent(encodedProjectName);
+          }
+          useAppStore.getState().updateWorkspaceTab(sourceTabId, updateData);
+          // Also update local tabs state
+          const effectiveTitle =
+            title && !isGenericTitle
+              ? title
+              : isGenericTitle && encodedProjectName
+                ? decodeURIComponent(encodedProjectName)
+                : undefined;
+          setTabs((prev) =>
+            prev.map((tab) =>
+              tab.id === sourceTabId
+                ? {
+                    ...tab,
+                    sessionId,
+                    encodedProjectName,
+                    toolName,
+                    title: effectiveTitle ?? tab.title,
+                    settings,
+                  }
+                : tab
+            )
+          );
         }
       }
 


### PR DESCRIPTION
## Problem

When multiple session tabs are open in Work mode and the page is refreshed, the session tabs' positions and content become scrambled. For example:
- Tab 2 might display content that originally belonged to Tab 4
- After renaming a tab, its content changes to another tab's content

## Root Cause

The `qwen-code-session-update` message handler in `Workspace.tsx` used `workspaceActiveTabId` (the current active tab) instead of matching the message source via `event.source`. When multiple iframes load simultaneously after a page refresh, all session update messages are incorrectly assigned to the same active tab, causing session IDs to overwrite each other.

## Solution

Changed the `qwen-code-session-update` handler to use the same approach as `qwen-code-tab-notification`:
- Use `event.source` to match against `iframeRefs.current` to identify the source tab
- Only update the tab that actually sent the message
- If the source tab cannot be identified, ignore the message

## Changes

- Modified `frontend/src/components/features/Workspace.tsx` (lines 300-362)
- Replaced `workspaceActiveTabId` with `sourceTabId` obtained from `event.source` matching

## Testing

- TypeScript compilation: ✅ Passed
- ESLint check: ✅ Passed

## Related Issues

Fixes #916

Related to:
- #65 - Feature: Work mode should restore full workspace state
- #70 - Tab pages show 404 Not Found errors during auto-restore
- #490 - Chat history lost after refreshing during long thinking state