### PR TITLE
fix: 改进工作流取消/暂停时的子进程控制机制

### DIFF
--- a/app/modules/workspace/autonomous/agent_runner.py
+++ b/app/modules/workspace/autonomous/agent_runner.py
@@ -103,6 +103,7 @@ class _LocalSession:
     remote_machine_id: str | None = None
     started_at_epoch: float = 0.0
     persisted_session_id: str = ""
+    _paused: bool = False  # True when process is suspended via SIGSTOP
 
 
 class AutonomousAgentRunner:
@@ -114,6 +115,8 @@ class AutonomousAgentRunner:
         remote_session_manager=None,
         server_url: str = "",
         activity_callback=None,
+        on_pid_registered=None,
+        on_pid_cleared=None,
     ):
         """
         Args:
@@ -123,6 +126,10 @@ class AutonomousAgentRunner:
             activity_callback: Optional callback ``(session_id, activity_dict)``
                 invoked for each assistant/tool_use/usage event, enabling
                 real-time streaming of agent activity to the frontend.
+            on_pid_registered: Optional callback ``(session_id, pid)`` called
+                when a local subprocess is created, for PID persistence.
+            on_pid_cleared: Optional callback ``(session_id)`` called when a
+                local subprocess exits, for PID cleanup.
         """
         self.session_manager = session_manager
         self.remote_session_manager = remote_session_manager
@@ -130,6 +137,8 @@ class AutonomousAgentRunner:
             "OPENACE_SERVER_URL", "http://localhost:5000"
         )
         self._activity_callback = activity_callback
+        self._on_pid_registered = on_pid_registered
+        self._on_pid_cleared = on_pid_cleared
         self._local_sessions: dict[str, _LocalSession] = {}
 
     @staticmethod
@@ -501,6 +510,13 @@ class AutonomousAgentRunner:
         )
         self._local_sessions[session_id] = session
 
+        # Persist PID to database for reliable cancel/pause
+        if self._on_pid_registered:
+            try:
+                self._on_pid_registered(session_id, process.pid)
+            except Exception as e:
+                logger.warning("on_pid_registered callback failed: %s", e)
+
         # Start output reader threads
         session._stdout_thread = threading.Thread(
             target=self._read_stdout,
@@ -536,6 +552,13 @@ class AutonomousAgentRunner:
                     pass
 
         self._local_sessions.pop(session_id, None)
+
+        # Clear PID from database
+        if self._on_pid_cleared:
+            try:
+                self._on_pid_cleared(session_id)
+            except Exception as e:
+                logger.warning("on_pid_cleared callback failed: %s", e)
 
         if (
             completed
@@ -1000,12 +1023,90 @@ class AutonomousAgentRunner:
             pass
 
     def stop_session(self, session_id: str) -> None:
-        """Stop a running local session."""
+        """Stop a running local session with SIGTERM + SIGKILL escalation.
+
+        If the process is currently paused (SIGSTOP), it will be resumed
+        first with SIGCONT so it can handle SIGTERM.
+        """
         session = self._local_sessions.get(session_id)
-        if session and session.process and session.process.returncode is None:
-            try:
-                os.killpg(os.getpgid(session.process.pid), signal.SIGTERM)
-            except (ProcessLookupError, OSError):
-                pass
+        if not session or not session.process or session.process.returncode is not None:
+            return
+
+        try:
+            pgid = os.getpgid(session.process.pid)
+        except (ProcessLookupError, OSError):
             session._stopped.set()
             session.completed.set()
+            return
+
+        # If paused, resume first so it can handle SIGTERM
+        if session._paused:
+            try:
+                os.killpg(pgid, signal.SIGCONT)
+                session._paused = False
+            except (ProcessLookupError, OSError):
+                pass
+
+        # Stage 1: SIGTERM
+        try:
+            os.killpg(pgid, signal.SIGTERM)
+        except (ProcessLookupError, OSError):
+            session._stopped.set()
+            session.completed.set()
+            return
+
+        # Stage 2: wait up to 5 seconds for graceful exit
+        try:
+            session.process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            # Stage 3: SIGKILL
+            logger.warning(
+                "Process %d did not exit after SIGTERM, sending SIGKILL",
+                session.process.pid,
+            )
+            try:
+                os.killpg(pgid, signal.SIGKILL)
+                session.process.wait(timeout=3)
+            except (ProcessLookupError, OSError, subprocess.TimeoutExpired):
+                pass
+
+        session._stopped.set()
+        session.completed.set()
+
+    def pause_session(self, session_id: str) -> bool:
+        """Suspend a running local session using SIGSTOP.
+
+        The process is frozen in place and can be resumed with
+        :meth:`resume_session` using SIGCONT.
+        """
+        session = self._local_sessions.get(session_id)
+        if not session or not session.process or session.process.returncode is not None:
+            return False
+        if session._paused:
+            return True
+        try:
+            pgid = os.getpgid(session.process.pid)
+            os.killpg(pgid, signal.SIGSTOP)
+            session._paused = True
+            logger.info("Paused session %s (pid %d)", session_id[:8], session.process.pid)
+            return True
+        except (ProcessLookupError, OSError) as e:
+            logger.error("Failed to pause session %s: %s", session_id[:8], e)
+            return False
+
+    def resume_session(self, session_id: str) -> bool:
+        """Resume a paused local session using SIGCONT."""
+        session = self._local_sessions.get(session_id)
+        if not session or not session.process or session.process.returncode is not None:
+            return False
+        if not session._paused:
+            return True
+        try:
+            pgid = os.getpgid(session.process.pid)
+            os.killpg(pgid, signal.SIGCONT)
+            session._paused = False
+            logger.info("Resumed session %s (pid %d)", session_id[:8], session.process.pid)
+            return True
+        except (ProcessLookupError, OSError) as e:
+            logger.error("Failed to resume session %s: %s", session_id[:8], e)
+            return False

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -204,6 +204,8 @@ class AutonomousOrchestrator:
         self._runner = AutonomousAgentRunner(
             session_manager=session_manager,
             activity_callback=self._on_agent_activity,
+            on_pid_registered=self._on_pid_registered,
+            on_pid_cleared=self._on_pid_cleared,
         )
         self._gh: Optional[GitHubOps] = None
 
@@ -492,6 +494,44 @@ class AutonomousOrchestrator:
         """Refresh workflow totals from the sessions linked to milestones."""
         self.repo.refresh_workflow_usage_from_sessions(self._workflow_id)
 
+    def _on_pid_registered(self, session_id: str, pid: int):
+        """Persist agent subprocess PID to database for reliable cancel/pause."""
+        try:
+            self.repo.update_workflow(
+                self._workflow_id,
+                {
+                    "agent_pid": pid,
+                    "agent_session_id": session_id,
+                },
+            )
+            logger.info(
+                "Registered agent PID %d for workflow %s (session %s)",
+                pid,
+                self._workflow_id[:8],
+                session_id[:8],
+            )
+        except Exception as e:
+            logger.warning("Failed to persist agent PID: %s", e)
+
+    def _on_pid_cleared(self, session_id: str):
+        """Clear agent subprocess PID from database after process exits."""
+        try:
+            with self._session_lock:
+                if self._current_session_id == session_id:
+                    self.repo.update_workflow(
+                        self._workflow_id,
+                        {
+                            "agent_pid": None,
+                            "agent_session_id": "",
+                        },
+                    )
+                    logger.debug(
+                        "Cleared agent PID for workflow %s",
+                        self._workflow_id[:8],
+                    )
+        except Exception as e:
+            logger.warning("Failed to clear agent PID: %s", e)
+
     def _on_agent_activity(self, session_id: str, activity: dict):
         """Forward agent activity to the SSE event stream and refresh usage."""
         self.emitter.emit(
@@ -636,8 +676,51 @@ class AutonomousOrchestrator:
             self._current_session_id = result.tracking_session_id or result.session_id
         return result
 
+    def pause_current_task(self):
+        """Pause the currently running agent task using SIGSTOP.
+
+        The process is frozen in place and can be resumed later.
+        Unlike cancel, this does NOT clear _current_session_id so
+        resume can find the session again.
+
+        Note: we intentionally do NOT set _cancel_requested here.
+        Since SIGSTOP freezes the process, _run_local's
+        session.completed.wait() will block until SIGCONT resumes
+        the process and it finishes. The scheduler won't re-poll
+        this workflow because its status is set to "paused" in the
+        database, which advance() checks at entry.
+        """
+        with self._session_lock:
+            session_id = self._current_session_id
+        if session_id:
+            logger.info(
+                "Pausing current agent task session=%s",
+                session_id[:8],
+            )
+            try:
+                self._runner.pause_session(session_id)
+            except Exception as e:
+                logger.warning("Failed to pause session %s: %s", session_id[:8], e)
+
+    def resume_current_task(self):
+        """Resume a paused agent task using SIGCONT."""
+        with self._session_lock:
+            session_id = self._current_session_id
+        if session_id:
+            logger.info(
+                "Resuming paused agent task session=%s",
+                session_id[:8],
+            )
+            try:
+                self._runner.resume_session(session_id)
+            except Exception as e:
+                logger.warning("Failed to resume session %s: %s", session_id[:8], e)
+
     def cancel_current_task(self):
-        """Cancel the currently running agent task (e.g. on pause/stop)."""
+        """Cancel the currently running agent task (e.g. on stop).
+
+        Terminates the subprocess with SIGTERM/SIGKILL.
+        """
         self._cancel_requested.set()  # signal 429 retry loop to stop
         with self._session_lock:
             session_id = self._current_session_id

--- a/app/repositories/autonomous_repo.py
+++ b/app/repositories/autonomous_repo.py
@@ -66,6 +66,8 @@ class AutonomousWorkflowRepository:
         "updated_at",
         "completed_at",
         "paused_at",
+        "agent_pid",
+        "agent_session_id",
     }
     ALLOWED_MILESTONE_FIELDS = {
         "phase",
@@ -97,6 +99,44 @@ class AutonomousWorkflowRepository:
 
     def __init__(self, db: Optional[Database] = None):
         self.db = db or Database()
+
+    # ── Agent PID helpers ──────────────────────────────────────────
+
+    def get_workflows_with_active_pid(self) -> list[dict]:
+        """Find workflows that have an agent PID set and are in an active status.
+
+        Used by the orphan process cleanup at server startup.
+        """
+        active_statuses = (
+            "pending",
+            "preparing",
+            "planning",
+            "developing",
+            "pr_review",
+            "reporting",
+            "waiting",
+            "merging",
+        )
+        placeholders = ", ".join(["?"] * len(active_statuses))
+        conn = self.db.get_connection()
+        try:
+            cursor = conn.cursor()
+            cursor.execute(
+                adapt_sql(
+                    f"""
+                    SELECT workflow_id, agent_pid, status
+                    FROM autonomous_workflows
+                    WHERE agent_pid IS NOT NULL
+                      AND agent_pid > 0
+                      AND status IN ({placeholders})
+                    """
+                ),
+                list(active_statuses),
+            )
+            cols = [d[0] for d in cursor.description]
+            return [dict(zip(cols, row)) for row in cursor.fetchall()]
+        finally:
+            conn.close()
 
     # ── Workflow CRUD ──────────────────────────────────────────────
 

--- a/app/routes/autonomous.py
+++ b/app/routes/autonomous.py
@@ -12,6 +12,7 @@ import logging
 import os
 import queue
 import re
+import signal
 import threading
 import time
 import uuid
@@ -529,8 +530,8 @@ def pause_workflow(workflow_id):
     if workflow.get("status") == "paused":
         return jsonify({"error": "Workflow already paused"}), 400
 
-    # Signal running orchestrator to cancel its active agent task
-    _cancel_running_task(workflow_id)
+    # Suspend the running agent subprocess (SIGSTOP)
+    _pause_running_task(workflow_id)
 
     from datetime import datetime, timezone
 
@@ -559,6 +560,9 @@ def resume_workflow(workflow_id):
     if workflow.get("status") != "paused":
         return jsonify({"error": "Workflow is not paused"}), 400
 
+    # Resume the paused agent subprocess (SIGCONT)
+    _resume_running_task(workflow_id)
+
     phase = workflow.get("current_phase", "preparation")
     status = PHASE_TO_STATUS.get(phase, "pending")
 
@@ -584,8 +588,8 @@ def stop_workflow(workflow_id):
     if g.user_role != "admin" and workflow.get("user_id") != g.user_id:
         return jsonify({"error": "Access denied"}), 403
 
-    # Signal running orchestrator to cancel its active agent task
-    _cancel_running_task(workflow_id)
+    # Kill the running agent subprocess (SIGTERM → SIGKILL)
+    _stop_running_task(workflow_id)
 
     from datetime import datetime, timezone
 
@@ -1150,7 +1154,188 @@ def _emit_event_safe(workflow_id: str, event_type: str, data: dict):
 
 
 def _cancel_running_task(workflow_id: str):
-    """Signal a running orchestrator to cancel its current agent task."""
+    """Legacy: cancel a running task. Delegates to _stop_running_task."""
+    _stop_running_task(workflow_id)
+
+
+def _pid_matches_expected(pid: int) -> bool:
+    """Best-effort check that PID likely belongs to a CLI agent process.
+
+    Helps guard against PID recycling on long-running servers by verifying
+    the process command line contains known agent binary names.
+    """
+    try:
+        import subprocess as _sp
+
+        result = _sp.run(
+            ["ps", "-p", str(pid), "-o", "comm="],
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+        if result.returncode != 0:
+            return False  # process doesn't exist
+        comm = result.stdout.strip().lower()
+        return any(name in comm for name in ("claude", "qwen", "codex", "openclaw", "node"))
+    except Exception:
+        # If we can't check, assume it matches (conservative: try to stop it)
+        return True
+
+
+def _kill_pid(pid: int) -> bool:
+    """Kill a process by PID with SIGTERM -> SIGKILL escalation.
+
+    Works with process groups created via ``start_new_session=True``.
+    Returns True if the process was killed or was already gone.
+    """
+    try:
+        pgid = os.getpgid(pid)
+    except (ProcessLookupError, OSError):
+        return True  # already gone
+
+    # Stage 1: SIGTERM
+    try:
+        os.killpg(pgid, signal.SIGTERM)
+    except (ProcessLookupError, OSError):
+        return True
+
+    # Stage 2: poll for exit, up to 5 seconds
+    for _ in range(10):
+        time.sleep(0.5)
+        try:
+            os.killpg(pgid, 0)  # existence check
+        except (ProcessLookupError, OSError):
+            return True  # died after SIGTERM
+
+    # Stage 3: SIGKILL
+    logger.warning("PID %d still alive after SIGTERM, sending SIGKILL", pid)
+    try:
+        os.killpg(pgid, signal.SIGKILL)
+    except (ProcessLookupError, OSError):
+        return True
+
+    # Final check
+    time.sleep(1)
+    try:
+        os.killpg(pgid, 0)
+        return False  # still alive even after SIGKILL
+    except (ProcessLookupError, OSError):
+        return True
+
+
+def _suspend_pid(pid: int) -> bool:
+    """Suspend a process by PID using SIGSTOP."""
+    try:
+        pgid = os.getpgid(pid)
+    except (ProcessLookupError, OSError):
+        return True
+
+    try:
+        os.killpg(pgid, signal.SIGSTOP)
+        return True
+    except (ProcessLookupError, OSError):
+        return True
+
+
+def _resume_pid(pid: int) -> bool:
+    """Resume a suspended process by PID using SIGCONT."""
+    try:
+        pgid = os.getpgid(pid)
+    except (ProcessLookupError, OSError):
+        return True
+
+    try:
+        os.killpg(pgid, signal.SIGCONT)
+        return True
+    except (ProcessLookupError, OSError):
+        return True
+
+
+def _pause_running_task(workflow_id: str):
+    """Pause the running agent task using multiple strategies.
+
+    Strategy 1: In-memory orchestrator → orchestrator.pause_current_task()
+    Strategy 2: PID from database → direct SIGSTOP
+    Strategy 3: Scan runner's in-memory sessions → SIGSTOP matching sessions
+    """
+    affected_pids: set[int] = set()
+
+    # Strategy 1: in-memory orchestrator (fast path)
+    try:
+        from app.services.autonomous_scheduler import AutonomousScheduler
+
+        scheduler = AutonomousScheduler.instance()
+        orchestrator = scheduler.get_running_orchestrator(workflow_id)
+        if orchestrator:
+            orchestrator.pause_current_task()
+            try:
+                with orchestrator._session_lock:
+                    sid = orchestrator._current_session_id
+                if sid:
+                    session = orchestrator._runner._local_sessions.get(sid)
+                    if session and session.process and session.process.returncode is None:
+                        affected_pids.add(session.process.pid)
+            except Exception:
+                pass
+    except Exception as e:
+        logger.warning("Pause strategy 1 (in-memory) failed for %s: %s", workflow_id[:8], e)
+
+    # Strategy 2: PID from database (covers scheduler poll gap)
+    try:
+        repo = _get_repo()
+        workflow = repo.get_workflow(workflow_id)
+        if workflow:
+            pid = workflow.get("agent_pid")
+            if (
+                pid
+                and isinstance(pid, int)
+                and pid > 0
+                and pid not in affected_pids
+                and _pid_matches_expected(pid)
+            ):
+                logger.info(
+                    "Pause strategy 2: suspending DB-tracked PID %d for workflow %s",
+                    pid,
+                    workflow_id[:8],
+                )
+                _suspend_pid(pid)
+                affected_pids.add(pid)
+            # Keep agent_pid in DB (needed for resume)
+    except Exception as e:
+        logger.warning("Pause strategy 2 (DB PID) failed for %s: %s", workflow_id[:8], e)
+
+    # Strategy 3: scan runner sessions (last resort)
+    try:
+        from app.services.autonomous_scheduler import AutonomousScheduler
+
+        scheduler = AutonomousScheduler.instance()
+        orchestrator = scheduler.get_running_orchestrator(workflow_id)
+        if orchestrator:
+            runner = orchestrator._runner
+            for _sid, session in list(runner._local_sessions.items()):
+                if session.workflow_id == workflow_id:
+                    if session.process and session.process.returncode is None:
+                        pid = session.process.pid
+                        if pid not in affected_pids:
+                            try:
+                                os.killpg(os.getpgid(pid), signal.SIGSTOP)
+                                affected_pids.add(pid)
+                            except (ProcessLookupError, OSError):
+                                pass
+    except Exception as e:
+        logger.warning("Pause strategy 3 (session scan) failed for %s: %s", workflow_id[:8], e)
+
+
+def _stop_running_task(workflow_id: str):
+    """Stop (kill) the running agent task using multiple strategies.
+
+    Strategy 1: In-memory orchestrator → orchestrator.cancel_current_task()
+    Strategy 2: PID from database → direct SIGTERM/SIGKILL
+    Strategy 3: Scan runner's in-memory sessions → kill matching sessions
+    """
+    killed_pids: set[int] = set()
+
+    # Strategy 1: in-memory orchestrator (fast path)
     try:
         from app.services.autonomous_scheduler import AutonomousScheduler
 
@@ -1158,5 +1343,113 @@ def _cancel_running_task(workflow_id: str):
         orchestrator = scheduler.get_running_orchestrator(workflow_id)
         if orchestrator:
             orchestrator.cancel_current_task()
+            try:
+                with orchestrator._session_lock:
+                    sid = orchestrator._current_session_id
+                if sid:
+                    session = orchestrator._runner._local_sessions.get(sid)
+                    if session and session.process and session.process.returncode is None:
+                        killed_pids.add(session.process.pid)
+            except Exception:
+                pass
     except Exception as e:
-        logger.warning("Failed to cancel running task for %s: %s", workflow_id[:8], e)
+        logger.warning("Stop strategy 1 (in-memory) failed for %s: %s", workflow_id[:8], e)
+
+    # Strategy 2: PID from database (covers scheduler poll gap / server restart)
+    try:
+        repo = _get_repo()
+        workflow = repo.get_workflow(workflow_id)
+        if workflow:
+            pid = workflow.get("agent_pid")
+            if (
+                pid
+                and isinstance(pid, int)
+                and pid > 0
+                and pid not in killed_pids
+                and _pid_matches_expected(pid)
+            ):
+                logger.info(
+                    "Stop strategy 2: killing DB-tracked PID %d for workflow %s",
+                    pid,
+                    workflow_id[:8],
+                )
+                _kill_pid(pid)
+                killed_pids.add(pid)
+            # Clear PID from DB
+            repo.update_workflow(workflow_id, {"agent_pid": None, "agent_session_id": ""})
+    except Exception as e:
+        logger.warning("Stop strategy 2 (DB PID) failed for %s: %s", workflow_id[:8], e)
+
+    # Strategy 3: scan runner sessions (last resort)
+    try:
+        from app.services.autonomous_scheduler import AutonomousScheduler
+
+        scheduler = AutonomousScheduler.instance()
+        orchestrator = scheduler.get_running_orchestrator(workflow_id)
+        if orchestrator:
+            runner = orchestrator._runner
+            for _sid, session in list(runner._local_sessions.items()):
+                if session.workflow_id == workflow_id:
+                    if session.process and session.process.returncode is None:
+                        pid = session.process.pid
+                        if pid not in killed_pids:
+                            try:
+                                os.killpg(os.getpgid(pid), signal.SIGTERM)
+                                killed_pids.add(pid)
+                            except (ProcessLookupError, OSError):
+                                pass
+                    runner.stop_session(_sid)
+    except Exception as e:
+        logger.warning("Stop strategy 3 (session scan) failed for %s: %s", workflow_id[:8], e)
+
+
+def _resume_running_task(workflow_id: str):
+    """Resume a paused agent task using multiple strategies.
+
+    Strategy 1: In-memory orchestrator → orchestrator.resume_current_task()
+    Strategy 2: PID from database → direct SIGCONT
+    """
+    resumed_pids: set[int] = set()
+
+    # Strategy 1: in-memory orchestrator
+    try:
+        from app.services.autonomous_scheduler import AutonomousScheduler
+
+        scheduler = AutonomousScheduler.instance()
+        orchestrator = scheduler.get_running_orchestrator(workflow_id)
+        if orchestrator:
+            orchestrator.resume_current_task()
+            try:
+                with orchestrator._session_lock:
+                    sid = orchestrator._current_session_id
+                if sid:
+                    session = orchestrator._runner._local_sessions.get(sid)
+                    if session and session.process and session.process.returncode is None:
+                        resumed_pids.add(session.process.pid)
+            except Exception:
+                pass
+    except Exception as e:
+        logger.warning("Resume strategy 1 (in-memory) failed for %s: %s", workflow_id[:8], e)
+
+    # Strategy 2: PID from database
+    try:
+        repo = _get_repo()
+        workflow = repo.get_workflow(workflow_id)
+        if workflow:
+            pid = workflow.get("agent_pid")
+            if (
+                pid
+                and isinstance(pid, int)
+                and pid > 0
+                and pid not in resumed_pids
+                and _pid_matches_expected(pid)
+            ):
+                logger.info(
+                    "Resume strategy 2: resuming DB-tracked PID %d for workflow %s",
+                    pid,
+                    workflow_id[:8],
+                )
+                _resume_pid(pid)
+                resumed_pids.add(pid)
+    except Exception as e:
+        logger.warning("Resume strategy 2 (DB PID) failed for %s: %s", workflow_id[:8], e)

--- a/app/services/autonomous_scheduler.py
+++ b/app/services/autonomous_scheduler.py
@@ -136,6 +136,19 @@ class AutonomousScheduler:
         finally:
             with self._orchestrator_lock:
                 self._running_orchestrators.pop(workflow_id, None)
+            # Safety net: clear stale agent_pid if orchestrator failed to clean up
+            try:
+                wf_check = repo.get_workflow(workflow_id)
+                if wf_check and wf_check.get("agent_pid"):
+                    repo.update_workflow(
+                        workflow_id,
+                        {
+                            "agent_pid": None,
+                            "agent_session_id": "",
+                        },
+                    )
+            except Exception:
+                pass
             # Release DB lock
             try:
                 repo.release_lock(workflow_id, lock_owner)
@@ -287,7 +300,97 @@ class AutonomousScheduler:
                     )
 
 
+def _cleanup_orphan_processes():
+    """Kill orphaned agent processes from previous server runs.
+
+    Scans DB for workflows with a non-null agent_pid and active status,
+    kills those processes, and resets the workflow status to paused.
+    """
+    import os
+    import signal
+    import time
+    from datetime import datetime, timezone
+
+    logger.info("Checking for orphaned agent processes...")
+
+    try:
+        from app.repositories.autonomous_repo import AutonomousWorkflowRepository
+        from app.repositories.database import Database
+
+        repo = AutonomousWorkflowRepository(Database())
+        workflows = repo.get_workflows_with_active_pid()
+
+        if not workflows:
+            logger.info("No orphaned processes found")
+            return
+
+        now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+        cleaned = 0
+        for wf in workflows:
+            pid = wf.get("agent_pid")
+            if not pid or not isinstance(pid, int):
+                continue
+
+            # Check if process still exists
+            try:
+                os.kill(pid, 0)  # signal 0 = existence check
+            except (ProcessLookupError, OSError):
+                # Process already dead, just clean up DB
+                repo.update_workflow(
+                    wf["workflow_id"],
+                    {
+                        "agent_pid": None,
+                        "agent_session_id": "",
+                    },
+                )
+                logger.info(
+                    "Cleaned up stale PID %d for workflow %s (process already dead)",
+                    pid,
+                    wf["workflow_id"][:8],
+                )
+                continue
+
+            # Process is still alive — kill it
+            try:
+                pgid = os.getpgid(pid)
+                os.killpg(pgid, signal.SIGTERM)
+                time.sleep(1)
+                try:
+                    os.killpg(pgid, 0)
+                    os.killpg(pgid, signal.SIGKILL)
+                except (ProcessLookupError, OSError):
+                    pass
+                cleaned += 1
+                logger.warning(
+                    "Killed orphan process PID=%d for workflow %s (status=%s)",
+                    pid,
+                    wf["workflow_id"][:8],
+                    wf.get("status"),
+                )
+            except (ProcessLookupError, OSError) as e:
+                logger.info("Orphan PID %d already gone: %s", pid, e)
+
+            # Reset workflow to paused (safe default, user can resume)
+            repo.update_workflow(
+                wf["workflow_id"],
+                {
+                    "agent_pid": None,
+                    "agent_session_id": "",
+                    "status": "paused",
+                    "paused_at": now,
+                },
+            )
+
+        if cleaned:
+            logger.info("Cleaned up %d orphaned agent processes", cleaned)
+    except Exception as e:
+        logger.error("Orphan process cleanup failed: %s", e, exc_info=True)
+
+
 def init_autonomous_scheduler():
     """Initialize and start the autonomous scheduler."""
+    # Clean up orphaned processes from previous server run
+    _cleanup_orphan_processes()
+
     scheduler = AutonomousScheduler.instance()
     scheduler.start()

--- a/app/services/autonomous_scheduler.py
+++ b/app/services/autonomous_scheduler.py
@@ -9,9 +9,13 @@ Follows the same singleton pattern as DataFetchScheduler.
 from __future__ import annotations
 
 import logging
+import os
+import signal
 import socket
 import threading
+import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -306,11 +310,6 @@ def _cleanup_orphan_processes():
     Scans DB for workflows with a non-null agent_pid and active status,
     kills those processes, and resets the workflow status to paused.
     """
-    import os
-    import signal
-    import time
-    from datetime import datetime, timezone
-
     logger.info("Checking for orphaned agent processes...")
 
     try:

--- a/migrations/versions/20260613_060_add_agent_pid_tracking.py
+++ b/migrations/versions/20260613_060_add_agent_pid_tracking.py
@@ -1,0 +1,59 @@
+"""Add agent PID tracking to autonomous workflows
+
+Revision ID: 060_agent_pid_tracking
+Revises: 058_workflow_definition_snapshot
+Create Date: 2026-06-13
+"""
+
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260613_060_agent_pid_tracking"
+down_revision: Union[str, None] = "20260612_060"
+branch_labels = None
+depends_on = None
+
+TABLE_NAME = "autonomous_workflows"
+TABLE_INFO_SQL = sa.text("PRAGMA table_info(autonomous_workflows)")
+
+
+def _column_exists(conn, column: str) -> bool:
+    """Check if a column already exists."""
+    if conn.dialect.name == "postgresql":
+        result = conn.execute(
+            sa.text(
+                "SELECT COUNT(*) FROM information_schema.columns "
+                "WHERE table_name = :table AND column_name = :column"
+            ),
+            {"table": TABLE_NAME, "column": column},
+        )
+        return result.scalar() > 0
+
+    result = conn.execute(TABLE_INFO_SQL)
+    return any(row[1] == column for row in result.fetchall())
+
+
+def upgrade() -> None:
+    """Add agent_pid and agent_session_id columns."""
+    conn = op.get_bind()
+    if not _column_exists(conn, "agent_pid"):
+        op.add_column(
+            TABLE_NAME,
+            sa.Column("agent_pid", sa.Integer, nullable=True),
+        )
+    if not _column_exists(conn, "agent_session_id"):
+        op.add_column(
+            TABLE_NAME,
+            sa.Column("agent_session_id", sa.Text, server_default="", nullable=False),
+        )
+
+
+def downgrade() -> None:
+    """Remove agent_pid and agent_session_id columns."""
+    conn = op.get_bind()
+    if _column_exists(conn, "agent_session_id"):
+        op.drop_column(TABLE_NAME, "agent_session_id")
+    if _column_exists(conn, "agent_pid"):
+        op.drop_column(TABLE_NAME, "agent_pid")

--- a/migrations/versions/20260613_060_add_agent_pid_tracking.py
+++ b/migrations/versions/20260613_060_add_agent_pid_tracking.py
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision: str = "20260613_060_agent_pid_tracking"
-down_revision: Union[str, None] = "20260612_060"
+down_revision: Union[str, None] = "059_add_smtp_tables"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## 问题

工作流取消（stop）和暂停（pause）操作依赖内存中的 `scheduler._running_orchestrators` 字典来查找 orchestrator 并控制子进程。但 orchestrator 只在 `_advance_single()` 的阻塞调用期间存在于该字典中，导致大量场景下操作**静默跳过**，子进程继续运行成为孤儿进程。

此外 `stop_session()` 只发 SIGTERM 没有 SIGKILL 备选；暂停语义不正确——暂停应该是 SIGSTOP 挂起而非终止子进程。

## 改动

### pause vs stop 语义区分

| 操作 | 语义 | 子进程动作 | 恢复方式 |
|------|------|-----------|---------|
| **pause** | 暂停，保留现场 | SIGSTOP（挂起） | SIGCONT 恢复继续 |
| **stop** | 取消，不再继续 | SIGTERM → SIGKILL | 不可恢复 |

### 具体改动

1. **数据库迁移** (`migrations/versions/20260613_060_add_agent_pid_tracking.py`)
   - 添加 `agent_pid` (Integer) 和 `agent_session_id` (Text) 列，用于 PID 持久化

2. **agent_runner.py** — 子进程控制核心
   - `_LocalSession` 添加 `_paused` 标志
   - `stop_session()` 强化：先 SIGCONT（如果 paused）→ SIGTERM → wait(5s) → SIGKILL
   - 新增 `pause_session()`：SIGSTOP 挂起子进程
   - 新增 `resume_session()`：SIGCONT 恢复子进程
   - `__init__` 添加 `on_pid_registered`/`on_pid_cleared` 回调
   - `_run_local()` 中子进程创建/退出时调用 PID 回调

3. **orchestrator.py** — 编排器
   - 新增 `pause_current_task()` — SIGSTOP 暂停，不清除 session_id
   - 新增 `resume_current_task()` — SIGCONT 恢复
   - `cancel_current_task()` 保持不变（终止进程）
   - PID 回调持久化到数据库

4. **autonomous.py** — 路由层多策略控制
   - `_pause_running_task()` — 三策略暂停（内存 orchestrator → DB PID → session 扫描）
   - `_stop_running_task()` — 三策略终止（同上，用 SIGTERM/SIGKILL）
   - `_resume_running_task()` — 两策略恢复（内存 orchestrator → DB PID）
   - 辅助函数 `_kill_pid()`/`_suspend_pid()`/`_resume_pid()`
   - `pause_workflow` 改用 `_pause_running_task`
   - `stop_workflow` 改用 `_stop_running_task`
   - `resume_workflow` 添加 `_resume_running_task`

5. **autonomous_scheduler.py** — 调度器
   - `_cleanup_orphan_processes()` — 服务器启动时清理残留子进程
   - `_advance_single()` finally 块安全清除残留 `agent_pid`

🤖 Generated with [Claude Code](https://claude.com/claude-code)