### PR TITLE
chore(frontend): fix eslint errors (unblock Lint CI)

### DIFF
--- a/frontend/src/components/features/AutonomousDev.tsx
+++ b/frontend/src/components/features/AutonomousDev.tsx
@@ -39,7 +39,7 @@ export const AutonomousDev: React.FC = () => {
     if (typeof window === 'undefined') {
       return DEFAULT_LEFT_PANEL_WIDTH;
     }
-    const saved = Number(window.localStorage.getItem(LEFT_PANEL_WIDTH_KEY) || '');
+    const saved = Number(window.localStorage.getItem(LEFT_PANEL_WIDTH_KEY) ?? '');
     return Number.isFinite(saved) && saved >= MIN_LEFT_PANEL_WIDTH && saved <= MAX_LEFT_PANEL_WIDTH
       ? saved
       : DEFAULT_LEFT_PANEL_WIDTH;
@@ -51,7 +51,10 @@ export const AutonomousDev: React.FC = () => {
 
   const clampLeftPanelWidth = useCallback((nextWidth: number) => {
     const viewportLimit = Math.max(MIN_LEFT_PANEL_WIDTH, Math.floor(window.innerWidth * 0.55));
-    return Math.min(Math.max(nextWidth, MIN_LEFT_PANEL_WIDTH), Math.min(MAX_LEFT_PANEL_WIDTH, viewportLimit));
+    return Math.min(
+      Math.max(nextWidth, MIN_LEFT_PANEL_WIDTH),
+      Math.min(MAX_LEFT_PANEL_WIDTH, viewportLimit)
+    );
   }, []);
 
   const handleResizeStart = useCallback(
@@ -178,10 +181,7 @@ export const AutonomousDev: React.FC = () => {
               }
             >
               <i
-                className={cn(
-                  'bi',
-                  workspaceFullscreen ? 'bi-fullscreen-exit' : 'bi-fullscreen'
-                )}
+                className={cn('bi', workspaceFullscreen ? 'bi-fullscreen-exit' : 'bi-fullscreen')}
               />
             </button>
             <Button size="sm" onClick={() => setShowNewModal(true)}>

--- a/frontend/src/components/work/AutonomousWorkflowList.test.tsx
+++ b/frontend/src/components/work/AutonomousWorkflowList.test.tsx
@@ -252,11 +252,7 @@ describe('AutonomousWorkflowList', () => {
     ]);
 
     render(
-      <AutonomousWorkflowList
-        selectedId={null}
-        onSelect={vi.fn()}
-        onClearSelection={vi.fn()}
-      />
+      <AutonomousWorkflowList selectedId={null} onSelect={vi.fn()} onClearSelection={vi.fn()} />
     );
 
     expect(screen.queryByText('1/3')).not.toBeInTheDocument();
@@ -292,11 +288,7 @@ describe('AutonomousWorkflowList', () => {
     ]);
 
     render(
-      <AutonomousWorkflowList
-        selectedId={null}
-        onSelect={vi.fn()}
-        onClearSelection={vi.fn()}
-      />
+      <AutonomousWorkflowList selectedId={null} onSelect={vi.fn()} onClearSelection={vi.fn()} />
     );
 
     const deleteButton = screen.getByTitle('Delete');

--- a/frontend/src/components/work/AutonomousWorkflowList.tsx
+++ b/frontend/src/components/work/AutonomousWorkflowList.tsx
@@ -111,7 +111,9 @@ function getIssueLabel(workflow: AutonomousWorkflow): string {
 
   const title = workflow.title?.trim();
   if (!title) {
-    return workflow.batch_order ? `#${workflow.batch_order}` : `#${workflow.workflow_id.slice(0, 8)}`;
+    return workflow.batch_order
+      ? `#${workflow.batch_order}`
+      : `#${workflow.workflow_id.slice(0, 8)}`;
   }
 
   const issueMatch = title.match(/\(#?(\d+)\)\s*$/);
@@ -329,7 +331,9 @@ export const AutonomousWorkflowList: React.FC<AutonomousWorkflowListProps> = ({
   };
 
   const buildBatchToolSummary = (batchWorkflows: AutonomousWorkflow[]): string => {
-    const tools = Array.from(new Set(batchWorkflows.map((workflow) => workflow.cli_tool).filter(Boolean)));
+    const tools = Array.from(
+      new Set(batchWorkflows.map((workflow) => workflow.cli_tool).filter(Boolean))
+    );
     if (tools.length <= 2) {
       return tools.join(', ');
     }
@@ -471,11 +475,7 @@ export const AutonomousWorkflowList: React.FC<AutonomousWorkflowListProps> = ({
       .join(' ');
 
     return (
-      <div
-        key={workflow.workflow_id}
-        className={itemClasses}
-        onClick={() => onSelect(workflow)}
-      >
+      <div key={workflow.workflow_id} className={itemClasses} onClick={() => onSelect(workflow)}>
         <div className="flex-grow-1 min-width-0">
           {compact ? (
             <div className="d-flex align-items-start justify-content-between gap-2">
@@ -587,7 +587,9 @@ export const AutonomousWorkflowList: React.FC<AutonomousWorkflowListProps> = ({
   const renderWorkflowBranch = (workflow: AutonomousWorkflow, compact = false) => (
     <React.Fragment key={workflow.workflow_id}>
       {renderWorkflowItem(workflow, false, compact)}
-      {(childrenMap[workflow.workflow_id] || []).map((child) => renderWorkflowItem(child, true, compact))}
+      {(childrenMap[workflow.workflow_id] || []).map((child) =>
+        renderWorkflowItem(child, true, compact)
+      )}
     </React.Fragment>
   );
 
@@ -604,7 +606,9 @@ export const AutonomousWorkflowList: React.FC<AutonomousWorkflowListProps> = ({
       if (workflow.workflow_id === selectedId) {
         return true;
       }
-      return (childrenMap[workflow.workflow_id] || []).some((child) => child.workflow_id === selectedId);
+      return (childrenMap[workflow.workflow_id] || []).some(
+        (child) => child.workflow_id === selectedId
+      );
     });
     const hasActiveWorkflow = entry.workflows.some((workflow) => {
       if (ACTIVE_WORKFLOW_STATUSES.includes(workflow.status)) {
@@ -763,7 +767,9 @@ export const AutonomousWorkflowList: React.FC<AutonomousWorkflowListProps> = ({
         <>
           <div className="list-group list-group-flush">
             {displayEntries.map((entry) =>
-              entry.type === 'batch' ? renderBatchGroup(entry) : renderWorkflowBranch(entry.workflow)
+              entry.type === 'batch'
+                ? renderBatchGroup(entry)
+                : renderWorkflowBranch(entry.workflow)
             )}
           </div>
           {totalPages > 1 && (

--- a/frontend/src/components/work/WorkflowTimeline.css
+++ b/frontend/src/components/work/WorkflowTimeline.css
@@ -196,7 +196,13 @@
   flex-shrink: 0;
   min-width: 3.9rem;
   color: #7b8ba2;
-  font-family: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, monospace;
+  font-family:
+    ui-monospace,
+    SFMono-Regular,
+    SF Mono,
+    Menlo,
+    Consolas,
+    monospace;
 }
 
 .workflow-timeline-live-activity-text {
@@ -302,7 +308,13 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   font-size: 0.78rem;
-  font-family: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, monospace;
+  font-family:
+    ui-monospace,
+    SFMono-Regular,
+    SF Mono,
+    Menlo,
+    Consolas,
+    monospace;
 }
 
 .workflow-timeline-diff-file-stats {
@@ -310,7 +322,13 @@
   gap: 0.4rem;
   flex-shrink: 0;
   font-size: 0.75rem;
-  font-family: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, monospace;
+  font-family:
+    ui-monospace,
+    SFMono-Regular,
+    SF Mono,
+    Menlo,
+    Consolas,
+    monospace;
 }
 
 .workflow-timeline-diff-viewer {
@@ -343,7 +361,13 @@
   margin-top: 0.2rem;
   color: #64748b;
   font-size: 0.74rem;
-  font-family: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, monospace;
+  font-family:
+    ui-monospace,
+    SFMono-Regular,
+    SF Mono,
+    Menlo,
+    Consolas,
+    monospace;
 }
 
 .workflow-timeline-diff-viewer-summary {
@@ -352,7 +376,13 @@
   gap: 0.55rem;
   flex-shrink: 0;
   font-size: 0.8rem;
-  font-family: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, monospace;
+  font-family:
+    ui-monospace,
+    SFMono-Regular,
+    SF Mono,
+    Menlo,
+    Consolas,
+    monospace;
 }
 
 .workflow-timeline-diff-fullscreen-btn {
@@ -365,7 +395,13 @@
   padding: 0.8rem 0;
   background: #ffffff;
   font-size: 0.76rem;
-  font-family: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, monospace;
+  font-family:
+    ui-monospace,
+    SFMono-Regular,
+    SF Mono,
+    Menlo,
+    Consolas,
+    monospace;
 }
 
 .workflow-timeline-diff-line {

--- a/frontend/src/components/work/WorkflowTimeline.tsx
+++ b/frontend/src/components/work/WorkflowTimeline.tsx
@@ -163,10 +163,11 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
   }, []);
   const resolvedIssueUrl = useMemo(() => {
     const directUrl =
-      workflow.requirements_issue_url ||
-      definitionSnapshot?.resolved_issue_url ||
-      definitionSnapshot?.parsed_issue_selectors?.find((selector) => selector.requirements_issue_url)
-        ?.requirements_issue_url ||
+      workflow.requirements_issue_url ??
+      definitionSnapshot?.resolved_issue_url ??
+      definitionSnapshot?.parsed_issue_selectors?.find(
+        (selector) => selector.requirements_issue_url
+      )?.requirements_issue_url ??
       '';
 
     if (directUrl) {
@@ -175,8 +176,8 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
 
     const issueNumber = workflow.github_issue_number;
     const repoUrl = normalizeGithubRepoUrl(
-      workflow.project_repo_url ||
-        definitionSnapshot?.project_repo_url ||
+      workflow.project_repo_url ??
+        definitionSnapshot?.project_repo_url ??
         (workflow.github_pr_url
           ? workflow.github_pr_url.replace(/\/pull\/\d+(?:[/?#].*)?$/i, '')
           : '')
@@ -199,7 +200,8 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
   const isActive = ACTIVE_WORKFLOW_STATUSES.includes(workflow.status);
   const isPaused = workflow.status === 'paused';
   const isWaiting = workflow.current_phase === 'wait';
-  const allowMilestoneActions = isActive || isPaused || isWaiting || workflow.status === 'planning_timeout';
+  const allowMilestoneActions =
+    isActive || isPaused || isWaiting || workflow.status === 'planning_timeout';
 
   // Modal state for cancel/fork
   const [showCancelModal, setShowCancelModal] = useState<string | null>(null);
@@ -493,7 +495,7 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
         timestamp,
         content: (
           <>
-            <strong>{activity.tool_name || 'tool'}</strong>
+            <strong>{activity.tool_name ?? 'tool'}</strong>
             {snippet && (
               <span className="ms-1 opacity-75">
                 {snippet.length > 96 ? `${snippet.slice(0, 96)}...` : snippet}
@@ -512,7 +514,7 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
       };
     }
 
-    const text = activity.text?.trim() || '';
+    const text = activity.text?.trim() ?? '';
     return {
       icon: 'bi-chat-text text-info',
       timestamp,
@@ -527,7 +529,7 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
     const extractFromBlock = (block: unknown): string[] => {
       if (!block || typeof block !== 'object') return [];
       const item = block as Record<string, unknown>;
-      const type = String(item.type || '');
+      const type = String(item.type ?? '');
       if (type === 'thinking') {
         const thinking = item.thinking;
         return typeof thinking === 'string' && thinking.trim() ? [thinking.trim()] : [];
@@ -566,8 +568,8 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
     (milestone: WorkflowMilestone) => {
       const title = milestone.title?.trim() || '';
       const round = milestone.round_number || milestone.dev_round || 0;
-      const issueNumber = milestone.github_issue_number || workflow.github_issue_number || null;
-      const prNumber = milestone.github_pr_number || workflow.github_pr_number || null;
+      const issueNumber = milestone.github_issue_number ?? workflow.github_issue_number ?? null;
+      const prNumber = milestone.github_pr_number ?? workflow.github_pr_number ?? null;
 
       switch (milestone.milestone_type) {
         case 'issue_linked':
@@ -580,7 +582,7 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
             : t('autoMsIssueCreated', language);
         case 'branch_created': {
           const branchMatch = title.match(/Branch ['"]?(.+?)['"]? created/i);
-          const branchName = branchMatch?.[1] || workflow.branch_name || '';
+          const branchName = branchMatch?.[1] ?? workflow.branch_name ?? '';
           return branchName
             ? t('autoMsBranchCreated', language).replace('{branch}', branchName)
             : t('autoMsBranchCreatedGeneric', language);
@@ -669,7 +671,7 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
   };
 
   const getMilestoneAnchorTime = (milestone: WorkflowMilestone) =>
-    milestone.completed_at || milestone.started_at || milestone.created_at;
+    milestone.completed_at ?? milestone.started_at ?? milestone.created_at;
 
   const workflowStartTime =
     milestones.length > 0 ? getMilestoneAnchorTime(milestones[0]) : workflow.created_at;
@@ -692,7 +694,8 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
   }, [viewingDiff, parsedDiffFiles]);
 
   const selectedDiffFile = useMemo(
-    () => parsedDiffFiles.find((file) => file.id === selectedDiffFileId) ?? parsedDiffFiles[0] ?? null,
+    () =>
+      parsedDiffFiles.find((file) => file.id === selectedDiffFileId) ?? parsedDiffFiles[0] ?? null,
     [parsedDiffFiles, selectedDiffFileId]
   );
 
@@ -733,7 +736,7 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
     const counts = new Map<string, number>();
     for (const milestone of allKnownMilestones) {
       const sessionId =
-        milestone.llm_session_id || milestone.review_session_id || milestone.session_id || '';
+        milestone.llm_session_id ?? milestone.review_session_id ?? milestone.session_id ?? '';
       if (!sessionId) continue;
       counts.set(sessionId, (counts.get(sessionId) ?? 0) + 1);
     }
@@ -782,7 +785,7 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
     const diffStats = parseDiffStats(milestone.diff_stats);
     const milestoneTime = formatMilestoneTime(getMilestoneAnchorTime(milestone));
     const llmSessionId =
-      milestone.llm_session_id || milestone.review_session_id || milestone.session_id;
+      milestone.llm_session_id ?? milestone.review_session_id ?? milestone.session_id;
     const llmTotalTokens = milestone.llm_total_tokens ?? 0;
     const llmRequestCount = milestone.llm_request_count ?? 0;
     const showUsageMetrics = !!llmSessionId || llmTotalTokens > 0 || llmRequestCount > 0;
@@ -805,16 +808,10 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
       showForkCancel &&
       (milestone.status === 'completed' || milestone.status === 'in_progress');
     const canCancel =
-      !compact &&
-      allowMilestoneActions &&
-      showForkCancel &&
-      milestone.status !== 'cancelled';
+      !compact && allowMilestoneActions && showForkCancel && milestone.status !== 'cancelled';
     const canInlineAction = !!llmSessionId || canViewChanges;
     const showActionRow =
-      !compact &&
-      (!!llmSessionId ||
-        canViewChanges ||
-        (canInlineAction && (canFork || canCancel)));
+      !compact && (!!llmSessionId || canViewChanges || (canInlineAction && (canFork || canCancel)));
     const showExpandedDetail = milestone.status === 'in_progress' && hasLiveActivity;
 
     return (
@@ -833,10 +830,7 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
           <div className="flex-grow-1 min-width-0">
             <div className="d-flex align-items-center gap-2 flex-wrap">
               <i className={`bi ${display.icon} text-${display.color}`}></i>
-              <span
-                className="fw-semibold"
-                style={{ fontSize: compact ? '0.8rem' : '0.925rem' }}
-              >
+              <span className="fw-semibold" style={{ fontSize: compact ? '0.8rem' : '0.925rem' }}>
                 {formatMilestoneTitle(milestone)}
               </span>
               {milestone.round_number > 0 && (
@@ -963,9 +957,7 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
                       key={`${milestone.milestone_id}-live-${index}`}
                       className="workflow-timeline-live-activity-line"
                     >
-                      <span className="workflow-timeline-live-activity-time">
-                        {line.timestamp}
-                      </span>
+                      <span className="workflow-timeline-live-activity-time">{line.timestamp}</span>
                       <i className={`bi ${line.icon}`}></i>
                       <span className="workflow-timeline-live-activity-text">{line.content}</span>
                     </div>
@@ -1178,8 +1170,8 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
           <span className="workflow-timeline-header-pill workflow-timeline-header-pill-status">
             {workflow.status}
           </span>
-          {workflow.github_issue_number && (
-            resolvedIssueUrl ? (
+          {workflow.github_issue_number &&
+            (resolvedIssueUrl ? (
               <a
                 href={resolvedIssueUrl}
                 target="_blank"
@@ -1194,10 +1186,9 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
                 <i className="bi bi-card-text me-1"></i>
                 {t('autoIssueBadge', language)} #{workflow.github_issue_number}
               </span>
-            )
-          )}
-          {workflow.github_pr_number && (
-            workflow.github_pr_url ? (
+            ))}
+          {workflow.github_pr_number &&
+            (workflow.github_pr_url ? (
               <a
                 href={workflow.github_pr_url}
                 target="_blank"
@@ -1214,8 +1205,7 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
                 {t('autoPrBadge', language)}
                 {workflow.github_pr_number}
               </span>
-            )
-          )}
+            ))}
           {isForkChild && parentWorkflow && (
             <Badge variant="info">
               <i className="bi bi-diagram-3 me-1"></i>
@@ -1261,7 +1251,7 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
           <small className="text-muted">
             <i className="bi bi-hourglass-split me-1"></i>
             {t('autoDuration', language)}:{' '}
-            {formatDuration(workflowStartTime, workflow.completed_at || workflow.updated_at)}
+            {formatDuration(workflowStartTime, workflow.completed_at ?? workflow.updated_at)}
           </small>
           <small className="text-muted">
             <i className="bi bi-bar-chart-line me-1"></i>
@@ -1631,17 +1621,17 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
                           variant={getDiffStatusClass(file.status)}
                           className="workflow-timeline-diff-file-badge"
                         >
-                          {file.status === 'added'
-                            ? 'A'
-                            : file.status === 'deleted'
-                              ? 'D'
-                              : 'M'}
+                          {file.status === 'added' ? 'A' : file.status === 'deleted' ? 'D' : 'M'}
                         </Badge>
                         <span className="workflow-timeline-diff-file-path">{file.path}</span>
                       </div>
                       <span className="workflow-timeline-diff-file-stats">
-                        {file.additions > 0 && <span className="text-success">+{file.additions}</span>}
-                        {file.deletions > 0 && <span className="text-danger">-{file.deletions}</span>}
+                        {file.additions > 0 && (
+                          <span className="text-success">+{file.additions}</span>
+                        )}
+                        {file.deletions > 0 && (
+                          <span className="text-danger">-{file.deletions}</span>
+                        )}
                       </span>
                     </button>
                   ))}
@@ -1656,7 +1646,9 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
                 <div className="workflow-timeline-diff-viewer">
                   <div className="workflow-timeline-diff-viewer-header">
                     <div className="min-width-0">
-                      <div className="workflow-timeline-diff-viewer-path">{selectedDiffFile.path}</div>
+                      <div className="workflow-timeline-diff-viewer-path">
+                        {selectedDiffFile.path}
+                      </div>
                       {selectedDiffFile.commitLabel && (
                         <div className="workflow-timeline-diff-viewer-commit">
                           {t('autoCommits', language)} {selectedDiffFile.commitLabel}
@@ -1681,27 +1673,30 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
                           diffFullscreen ? 'bi-fullscreen-exit' : 'bi-fullscreen'
                         } me-1`}
                       />
-                      {diffFullscreen ? t('exitFullscreen', language) : t('enterFullscreen', language)}
+                      {diffFullscreen
+                        ? t('exitFullscreen', language)
+                        : t('enterFullscreen', language)}
                     </button>
                   </div>
                   <div className="workflow-timeline-diff-code">
                     {selectedDiffFile.patch.split('\n').map((line, index) => {
-                      const lineClass = line.startsWith('+') && !line.startsWith('+++')
-                        ? 'workflow-timeline-diff-line-add'
-                        : line.startsWith('-') && !line.startsWith('---')
-                          ? 'workflow-timeline-diff-line-del'
-                          : line.startsWith('@@')
-                            ? 'workflow-timeline-diff-line-hunk'
-                            : line.startsWith('diff --git') ||
-                                line.startsWith('index ') ||
-                                line.startsWith('--- ') ||
-                                line.startsWith('+++ ') ||
-                                line.startsWith('new file mode ') ||
-                                line.startsWith('deleted file mode ') ||
-                                line.startsWith('rename from ') ||
-                                line.startsWith('rename to ')
-                              ? 'workflow-timeline-diff-line-meta'
-                              : '';
+                      const lineClass =
+                        line.startsWith('+') && !line.startsWith('+++')
+                          ? 'workflow-timeline-diff-line-add'
+                          : line.startsWith('-') && !line.startsWith('---')
+                            ? 'workflow-timeline-diff-line-del'
+                            : line.startsWith('@@')
+                              ? 'workflow-timeline-diff-line-hunk'
+                              : line.startsWith('diff --git') ||
+                                  line.startsWith('index ') ||
+                                  line.startsWith('--- ') ||
+                                  line.startsWith('+++ ') ||
+                                  line.startsWith('new file mode ') ||
+                                  line.startsWith('deleted file mode ') ||
+                                  line.startsWith('rename from ') ||
+                                  line.startsWith('rename to ')
+                                ? 'workflow-timeline-diff-line-meta'
+                                : '';
 
                       return (
                         <div

--- a/frontend/src/components/work/WorkflowTimeline.utils.test.ts
+++ b/frontend/src/components/work/WorkflowTimeline.utils.test.ts
@@ -4,9 +4,7 @@ import { parseDiffFiles, parseDiffStats } from './WorkflowTimeline.utils';
 
 describe('WorkflowTimeline.utils', () => {
   it('parses diff stats json', () => {
-    expect(
-      parseDiffStats('{"additions":100,"deletions":25,"files":3,"commits":2}')
-    ).toEqual({
+    expect(parseDiffStats('{"additions":100,"deletions":25,"files":3,"commits":2}')).toEqual({
       additions: 100,
       deletions: 25,
       files: 3,

--- a/frontend/src/components/work/WorkflowTimeline.utils.ts
+++ b/frontend/src/components/work/WorkflowTimeline.utils.ts
@@ -54,14 +54,17 @@ export function parseDiffFiles(diffText: string): ParsedDiffFile[] {
   for (const line of lines) {
     if (line.startsWith('--- Commit: ')) {
       pushCurrent();
-      commitLabel = line.replace(/^--- Commit:\s*/, '').replace(/\s*---$/, '').trim();
+      commitLabel = line
+        .replace(/^--- Commit:\s*/, '')
+        .replace(/\s*---$/, '')
+        .trim();
       continue;
     }
 
     if (line.startsWith('diff --git ')) {
       pushCurrent();
       const match = line.match(/^diff --git a\/(.+?) b\/(.+)$/);
-      const nextPath = match?.[2] || match?.[1] || line.replace('diff --git ', '').trim();
+      const nextPath = match?.[2] ?? match?.[1] ?? line.replace('diff --git ', '').trim();
       current = {
         path: nextPath,
         status: 'modified',


### PR DESCRIPTION
## 背景

Frontend CI 的 **Lint** job 在 `main` 上一直失败（66 errors），主要集中在自主工作流相关组件。PR #984 的 review 里也提到这个 Lint 失败是 main 既有的、与本 PR 无关。

本 PR 单独修掉这些 lint 错误，让 CI 变绿，不混入功能 PR。

## 改动

`npm run lint:fix` + 手动把剩余 `||` → `??`（共 6 个文件，91+/97-，纯格式化 + 操作符）：

| 文件 | 内容 |
|---|---|
| `WorkflowTimeline.tsx` | prettier 格式化 + 多处 `||`→`??`（URL/id/时间戳等 `T \| undefined` 字段） |
| `WorkflowTimeline.utils.ts` | diff 路径回退链 `||`→`??` |
| `AutonomousDev.tsx` | localStorage 读取 `||`→`??` |
| `AutonomousWorkflowList.tsx` / `.test.tsx` / `utils.test.ts` | prettier 格式化 |

### 行为说明
- `WorkflowTimeline.tsx` 里两条多行 URL 回退链改成统一的 `??` 链；下游 `if (directUrl)` / `if (repoUrl)` 仍把 `''` 当空处理，**空串行为保持不变**。
- 所有转换的 `||` 左操作数都是 `T | undefined`（URL/id/时间戳/名称），`||` 与 `??` 在实际数据上等价。

## 验证
- ✅ `npm run lint` exit 0（0 errors）
- ✅ `npx tsc --noEmit` 通过
- 剩余 16 个 warnings（test 文件的 `no-explicit-any` / `no-non-null-assertion`、`react-hooks/exhaustive-deps`）为既有，不在本次范围；lint 脚本无 `--max-warnings`，warnings 不影响 CI。

> 注：基于 `main`，与 #984 独立。#984 改动区域（WorkflowTimeline.tsx 的 68-86 / 565-665）与本次格式化区域基本不重叠，合并时若有小冲突可轻松解决。

🤖 Generated with [Claude Code](https://claude.com/claude-code)