### PR TITLE
ci: E2E 只在 main 跑，PR 跳过

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -87,6 +87,10 @@ jobs:
 
   e2e:
     name: E2E Tests
+    # E2E takes ~27min and is too slow to block every PR. Run only on pushes
+    # to the default branch; PRs skip this job. Regression coverage is still
+    # preserved on merge. Local `npm run test:e2e` is unaffected.
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## 背景

`frontend-ci.yml` 的 E2E job 要 **~27 分钟**，每个 frontend PR 都会跑，严重拖慢 PR 反馈周期。

## 改动

给 `e2e` job 加 `if: github.event_name == 'push'`：

- **PR**：E2E 跳过（显示 skipped，不阻塞合并），其余 job（lint / typecheck / test / build / bundle-analysis）照常
- **push 到 main**：E2E 照跑，保留合并后的回归保护
- **本地 `npm run test:e2e`**：不受影响

用 `if` 而非改 trigger，是因为 trigger 是 workflow 级别、所有 job 共享；只想关掉 e2e 这一个 job，其余 job 仍需在 PR 上跑。

## 影响权衡

- 失去 PR 阶段的 E2E 拦截 —— 若 PR 引入 E2E 回归，会到 main 上才暴露。但 frontend 单元测试（test job）仍在 PR 上跑，能挡住大部分；本地 E2E 工作流不变。
- 否决的替代方案：彻底删除（丢失所有 CI 回归）/ 手动+nightly（按需跑，回归延迟更大）。保留 main 跑是兼顾速度与回归保护的折中。

🤖 Generated with [Claude Code](https://claude.com/claude-code)