### PR TITLE
fix(autonomous): drop redundant prompt truncation, untruncate display side

### DIFF
--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -136,6 +136,11 @@ PHASE_STATUS_MAP = {
 CI_POLL_INTERVAL = 30  # seconds between polls
 CI_POLL_MAX_WAIT = 300  # maximum seconds to wait (5 minutes)
 
+# GitHub rejects comment bodies longer than 65536 chars. Agent output (plan /
+# review / fix / test) can exceed that, so very long comments are capped with
+# a notice pointing to the timeline full-text view (#988).
+GITHUB_COMMENT_MAX_CHARS = 65000
+
 REVIEW_SESSION_MILESTONE_TYPES = {"plan_reviewed", "pr_reviewed"}
 
 # Session lines that span multiple milestones via --resume. Each maps to a
@@ -405,6 +410,49 @@ class AutonomousOrchestrator:
             or "预先存在" in response
             or re.search(r"pre[\s-]?existing", response, re.IGNORECASE)
         )
+
+    def _post_github_comment(
+        self,
+        gh: GitHubOps,
+        number: int,
+        body: str,
+        *,
+        is_pr: bool = False,
+        context: str = "",
+    ) -> None:
+        """Post a comment to a GitHub issue or PR.
+
+        Guards two failure modes the raw ``gh.add_*_comment`` calls used to
+        swallow silently:
+
+        - **Length**: GitHub rejects comment bodies longer than 65536 chars.
+          Verbose agent output (plan / review / fix / test) can exceed that, so
+          bodies over ``GITHUB_COMMENT_MAX_CHARS`` are capped with a notice
+          pointing readers to the timeline full-text view (#988) for the rest.
+        - **Errors**: a failed post is logged at WARNING (with ``context``) and
+          swallowed, so a missing comment is diagnosable without aborting the
+          workflow phase. The body survives in the DB / timeline regardless.
+        """
+        if len(body) > GITHUB_COMMENT_MAX_CHARS:
+            notice = (
+                "\n\n---\n\n"
+                "> ⚠️ 内容超出 GitHub 评论长度上限，已截断显示。"
+                "完整内容请查看 workflow timeline 的里程碑卡片（方案/评审/报告全文）。\n"
+            )
+            body = body[: GITHUB_COMMENT_MAX_CHARS - len(notice)] + notice
+        try:
+            if is_pr:
+                gh.add_pr_comment(number, body)
+            else:
+                gh.add_issue_comment(number, body)
+        except Exception as e:  # log + continue; never abort the phase over a comment
+            logger.warning(
+                "Failed to post GitHub %s comment #%s%s: %s",
+                "PR" if is_pr else "issue",
+                number,
+                f" ({context})" if context else "",
+                e,
+            )
 
     def _find_existing_milestone(
         self, phase: str, milestone_type: str, dev_round: int = None, round_number: int = None
@@ -1231,13 +1279,12 @@ class AutonomousOrchestrator:
 
         # Post plan as issue comment
         if issue_number:
-            try:
-                gh.add_issue_comment(
-                    issue_number,
-                    f"## 📋 Implementation Plan (Round {round_num})\n\n{self._clean_agent_text(plan_text)}",
-                )
-            except GitHubOpsError:
-                pass
+            self._post_github_comment(
+                gh,
+                issue_number,
+                f"## 📋 Implementation Plan (Round {round_num})\n\n{self._clean_agent_text(plan_text)}",
+                context="plan",
+            )
 
         # Step 2: Review plan
         review_prompt = (
@@ -1306,13 +1353,12 @@ class AutonomousOrchestrator:
 
         # Post review as issue comment
         if issue_number:
-            try:
-                gh.add_issue_comment(
-                    issue_number,
-                    f"## 🔍 Plan Review (Round {round_num})\n\n{self._clean_agent_text(review_text)}",
-                )
-            except GitHubOpsError:
-                pass
+            self._post_github_comment(
+                gh,
+                issue_number,
+                f"## 🔍 Plan Review (Round {round_num})\n\n{self._clean_agent_text(review_text)}",
+                context="plan-review",
+            )
 
         # Step 3: Check if all rounds are done
         # max_plan_rounds means the max number of Plan→Review→Refine cycles.
@@ -1406,21 +1452,18 @@ class AutonomousOrchestrator:
 
             issue_number = wf.get("github_issue_number")
             if issue_number and final_plan:
-                try:
-                    final_comment = (
-                        f"## 📋 Final Implementation Plan\n\n"
-                        f"Plan review completed after {round_num} round(s).\n\n"
-                        f"{final_plan}"
+                final_comment = (
+                    f"## 📋 Final Implementation Plan\n\n"
+                    f"Plan review completed after {round_num} round(s).\n\n"
+                    f"{final_plan}"
+                )
+                if self._should_show_review_warning(round_num, max_rounds, last_review):
+                    final_comment += (
+                        f"\n\n---\n\n"
+                        f"## ⚠️ Note: Last review had feedback not yet addressed\n\n"
+                        f"{last_review}"
                     )
-                    if self._should_show_review_warning(round_num, max_rounds, last_review):
-                        final_comment += (
-                            f"\n\n---\n\n"
-                            f"## ⚠️ Note: Last review had feedback not yet addressed\n\n"
-                            f"{last_review}"
-                        )
-                    gh.add_issue_comment(issue_number, final_comment)
-                except Exception:
-                    pass
+                self._post_github_comment(gh, issue_number, final_comment, context="final-plan")
 
             # Plan finalized, move to development
             self._update_workflow(
@@ -1690,10 +1733,7 @@ class AutonomousOrchestrator:
             )
         msg += "\nProgressing to test phase..."
 
-        try:
-            gh.add_issue_comment(issue_number, msg)
-        except Exception:
-            pass
+        self._post_github_comment(gh, issue_number, msg, context="dev-progress")
 
     def _run_test_phase(self, wf: dict, dev_round: int, gh: GitHubOps):
         """Run tests, post results to issue, handle retries.
@@ -1791,22 +1831,19 @@ class AutonomousOrchestrator:
         # Post test results to issue
         issue_number = wf.get("github_issue_number")
         if issue_number:
-            try:
-                test_summary = self._clean_agent_text(test_response_text)
-                if tests_actually_skipped:
-                    status_line = "⚠️ Tests were not actually run — see details below"
-                elif test_result.success:
-                    status_line = "✅ All tests passed"
-                else:
-                    status_line = "❌ Tests failed"
-                test_comment = (
-                    f"## 🧪 Test Results (Dev Round {dev_round})\n\n"
-                    f"{status_line}\n\n"
-                    f"{test_summary}"
-                )
-                gh.add_issue_comment(issue_number, test_comment)
-            except Exception:
-                pass
+            test_summary = self._clean_agent_text(test_response_text)
+            if tests_actually_skipped:
+                status_line = "⚠️ Tests were not actually run — see details below"
+            elif test_result.success:
+                status_line = "✅ All tests passed"
+            else:
+                status_line = "❌ Tests failed"
+            test_comment = (
+                f"## 🧪 Test Results (Dev Round {dev_round})\n\n"
+                f"{status_line}\n\n"
+                f"{test_summary}"
+            )
+            self._post_github_comment(gh, issue_number, test_comment, context="test-results")
 
         # Treat skipped tests as failure — tests must actually run.
         # Allow 1 retry in case of transient environment issues.
@@ -1915,17 +1952,14 @@ class AutonomousOrchestrator:
 
         # Post test-passed status to issue
         if issue_number:
-            try:
-                branch = wf.get("branch_name", "")
-                status_msg = (
-                    f"## 🎯 All Checks Passed (Dev Round {dev_round})\n\n"
-                    f"- **Status**: Development + tests completed successfully\n"
-                    f"- **Branch**: `{branch}`\n"
-                    f"- **Next**: Creating PR and running code review\n"
-                )
-                gh.add_issue_comment(issue_number, status_msg)
-            except Exception:
-                pass
+            branch = wf.get("branch_name", "")
+            status_msg = (
+                f"## 🎯 All Checks Passed (Dev Round {dev_round})\n\n"
+                f"- **Status**: Development + tests completed successfully\n"
+                f"- **Branch**: `{branch}`\n"
+                f"- **Next**: Creating PR and running code review\n"
+            )
+            self._post_github_comment(gh, issue_number, status_msg, context="dev-complete")
 
         # Move to PR review
         self._update_workflow(
@@ -1965,10 +1999,7 @@ class AutonomousOrchestrator:
                 f"Skipping PR creation."
             )
             if issue_number:
-                try:
-                    gh.add_issue_comment(issue_number, no_change_msg)
-                except GitHubOpsError:
-                    pass
+                self._post_github_comment(gh, issue_number, no_change_msg, context="no-changes")
             self._create_milestone(
                 phase="pr_review",
                 dev_round=dev_round,
@@ -2039,19 +2070,22 @@ class AutonomousOrchestrator:
             if pr_number:
                 try:
                     ci_checks_post = self._poll_ci_status(gh, pr_number)
-                    ci_fails_post = [c for c in ci_checks_post if c.get("bucket") == "fail"]
-                    if ci_fails_post:
-                        ci_summary = "\n".join(
-                            f"- **{c['name']}**: {c.get('state', 'unknown')}" for c in ci_fails_post
-                        )
-                        gh.add_pr_comment(
-                            pr_number,
-                            "## ⚠️ CI 检查状态\n\n"
-                            f"以下 CI 检查未通过：\n{ci_summary}\n\n"
-                            "将在后续代码审查轮次中分析这些失败是否由本 PR 引入。",
-                        )
                 except Exception:
-                    pass
+                    ci_checks_post = []
+                ci_fails_post = [c for c in ci_checks_post if c.get("bucket") == "fail"]
+                if ci_fails_post:
+                    ci_summary = "\n".join(
+                        f"- **{c['name']}**: {c.get('state', 'unknown')}" for c in ci_fails_post
+                    )
+                    self._post_github_comment(
+                        gh,
+                        pr_number,
+                        "## ⚠️ CI 检查状态\n\n"
+                        f"以下 CI 检查未通过：\n{ci_summary}\n\n"
+                        "将在后续代码审查轮次中分析这些失败是否由本 PR 引入。",
+                        is_pr=True,
+                        context="ci-fails",
+                    )
 
         pr_number = wf.get("github_pr_number")
         if not pr_number:
@@ -2151,13 +2185,13 @@ class AutonomousOrchestrator:
 
         # Post review as PR comment
         if pr_number:
-            try:
-                gh.add_pr_comment(
-                    pr_number,
-                    f"## 🔍 Code Review (Round {round_num})\n\n{self._clean_agent_text(review_text)}",
-                )
-            except GitHubOpsError:
-                pass
+            self._post_github_comment(
+                gh,
+                pr_number,
+                f"## 🔍 Code Review (Round {round_num})\n\n{self._clean_agent_text(review_text)}",
+                is_pr=True,
+                context="code-review",
+            )
 
         # Check if all rounds done
         self._update_workflow({"current_round": round_num})
@@ -2220,13 +2254,13 @@ class AutonomousOrchestrator:
             )
 
             if pr_number and summary_text:
-                try:
-                    gh.add_pr_comment(
-                        pr_number,
-                        f"## ✅ PR Review Summary\n\n{summary_text}",
-                    )
-                except GitHubOpsError:
-                    pass
+                self._post_github_comment(
+                    gh,
+                    pr_number,
+                    f"## ✅ PR Review Summary\n\n{summary_text}",
+                    is_pr=True,
+                    context="review-summary",
+                )
 
             # Move to report
             self._update_workflow(
@@ -2308,24 +2342,21 @@ class AutonomousOrchestrator:
             )
 
             if pr_number:
-                try:
-                    # Extract fix summary from agent response in full; GitHub
-                    # comments render long content fine.
-                    fix_summary = self._clean_agent_text(fix_result.response_text or "")
-                    comment = (
-                        f"## ✅ Addressed Review Feedback (Round {round_num})\n\n"
-                        f"### Changes Made\n{fix_summary}\n\n"
+                # Extract fix summary from agent response in full; GitHub comments
+                # render long content fine (capped by _post_github_comment if huge).
+                fix_summary = self._clean_agent_text(fix_result.response_text or "")
+                comment = (
+                    f"## ✅ Addressed Review Feedback (Round {round_num})\n\n"
+                    f"### Changes Made\n{fix_summary}\n\n"
+                )
+                if commit_sha:
+                    comment += f"- Commit: `{commit_sha[:8]}`\n"
+                # Note pre-existing CI failures if fix agent identified them.
+                if self._is_pre_existing_ci_failure(fix_result.response_text or ""):
+                    comment += (
+                        "\n> ⚠️ 部分 CI 检查失败，" "但经分析为预先存在的问题，非本 PR 引入。\n"
                     )
-                    if commit_sha:
-                        comment += f"- Commit: `{commit_sha[:8]}`\n"
-                    # Note pre-existing CI failures if fix agent identified them.
-                    if self._is_pre_existing_ci_failure(fix_result.response_text or ""):
-                        comment += (
-                            "\n> ⚠️ 部分 CI 检查失败，" "但经分析为预先存在的问题，非本 PR 引入。\n"
-                        )
-                    gh.add_pr_comment(pr_number, comment)
-                except GitHubOpsError:
-                    pass
+                self._post_github_comment(gh, pr_number, comment, is_pr=True, context="fix")
 
     # ── Phase: Report ───────────────────────────────────────────────
 
@@ -2426,10 +2457,7 @@ class AutonomousOrchestrator:
 
         # Post report to issue
         if issue_number:
-            try:
-                gh.add_issue_comment(issue_number, report)
-            except GitHubOpsError:
-                pass
+            self._post_github_comment(gh, issue_number, report, context="progress-report")
 
         # Mark round completed
         self._create_milestone(

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -136,10 +136,6 @@ PHASE_STATUS_MAP = {
 CI_POLL_INTERVAL = 30  # seconds between polls
 CI_POLL_MAX_WAIT = 300  # maximum seconds to wait (5 minutes)
 
-# Maximum character length for previous review feedback included in
-# the review prompt.  Reviews longer than this are truncated with a
-# notice so the reviewer knows content was omitted.
-PREV_REVIEW_MAX_LENGTH = 3000
 REVIEW_SESSION_MILESTONE_TYPES = {"plan_reviewed", "pr_reviewed"}
 
 # Session lines that span multiple milestones via --resume. Each maps to a
@@ -1420,7 +1416,7 @@ class AutonomousOrchestrator:
                         final_comment += (
                             f"\n\n---\n\n"
                             f"## ⚠️ Note: Last review had feedback not yet addressed\n\n"
-                            f"{last_review[:2000]}"
+                            f"{last_review}"
                         )
                     gh.add_issue_comment(issue_number, final_comment)
                 except Exception:
@@ -1750,9 +1746,7 @@ class AutonomousOrchestrator:
             {
                 "status": "completed" if test_result.success else "failed",
                 "session_id": test_result.session_id,
-                "result_summary": (
-                    test_result.response_text[:300] if test_result.response_text else ""
-                ),
+                "result_summary": (test_result.response_text if test_result.response_text else ""),
             },
         )
 
@@ -1798,7 +1792,7 @@ class AutonomousOrchestrator:
         issue_number = wf.get("github_issue_number")
         if issue_number:
             try:
-                test_summary = self._clean_agent_text(test_response_text)[:800]
+                test_summary = self._clean_agent_text(test_response_text)
                 if tests_actually_skipped:
                     status_line = "⚠️ Tests were not actually run — see details below"
                 elif test_result.success:
@@ -2003,7 +1997,7 @@ class AutonomousOrchestrator:
         if round_num == 1:
             try:
                 # Build PR body with issue linkage
-                pr_body = f"Autonomous development for dev round {dev_round}.\n\nRequirements: {wf.get('requirements_text', '')[:500]}"
+                pr_body = f"Autonomous development for dev round {dev_round}.\n\nRequirements: {wf.get('requirements_text', '')}"
                 issue_number = wf.get("github_issue_number")
                 if issue_number:
                     pr_body += f"\n\nCloses #{issue_number}"
@@ -2092,35 +2086,18 @@ class AutonomousOrchestrator:
 
         review_prompt = (
             AUTONOMOUS_CONTEXT + f"你是一位资深代码审查专家。请审查以下 PR 的代码变更。\n\n"
-            f"## 需求\n{wf.get('requirements_text', '')[:500]}\n\n"
             f"## 代码变更\n{self._smart_truncate_diff(diff_text)}\n\n"
         )
 
-        # Include previous review feedback for rounds > 1
+        # For rounds > 1, the previous round's review is already in this review
+        # session's resumed history (--resume). Ask the reviewer to revisit it
+        # and confirm whether each point was addressed.
         if round_num > 1:
-            prev_review_milestones = self.repo.list_milestones(self._workflow_id, phase="pr_review")
-            last_review_text = ""
-            for ms in reversed(prev_review_milestones):
-                if ms.get("milestone_type") == "pr_reviewed" and ms.get("review_content"):
-                    last_review_text = ms["review_content"]
-                    break
-            if last_review_text:
-                cleaned_review = self._clean_agent_text(last_review_text)
-                truncated = cleaned_review[:PREV_REVIEW_MAX_LENGTH]
-                truncation_notice = (
-                    "\n> ⚠️ 以上审查意见已截断至 3000 字符，部分内容可能被省略。\n"
-                    if len(cleaned_review) > PREV_REVIEW_MAX_LENGTH
-                    else ""
-                )
-                review_prompt += (
-                    f"## 上一轮审查意见（Round {round_num - 1}）\n\n"
-                    f"{truncated}\n"
-                    f"{truncation_notice}\n"
-                    "**请逐条确认上一轮审查意见是否已被落实：**\n"
-                    "- 已落实：说明如何修改\n"
-                    "- 未落实：说明原因\n"
-                    "- 不适用：说明理由\n\n"
-                )
+            review_prompt += (
+                "## 上一轮审查\n"
+                "请回顾你上一轮的审查意见（在本会话历史中），逐条确认是否已落实："
+                "已落实（说明如何修改）/ 未落实（说明原因）/ 不适用（说明理由）。\n\n"
+            )
 
         review_prompt += (
             "请检查：\n"
@@ -2187,26 +2164,15 @@ class AutonomousOrchestrator:
 
         if round_num >= max_rounds:
             # All PR review rounds completed — summarize via the main session,
-            # then move to report. The main session resumes and is given the
-            # last review round's feedback plus the last fix record, then asked
-            # whether all review points were addressed and the PR is ready.
+            # then move to report. The main session resumes with the development
+            # history (incl. fixes) and is given the last review round's feedback
+            # (review runs on the review session, so it must be injected), then
+            # asked whether all review points were addressed and the PR is ready.
             last_pr_review = ""
-            last_fix_summary = ""
             pr_milestones = self.repo.list_milestones(self._workflow_id, phase="pr_review")
             for ms in reversed(pr_milestones):
-                if (
-                    ms.get("milestone_type") == "pr_reviewed"
-                    and ms.get("review_content")
-                    and not last_pr_review
-                ):
+                if ms.get("milestone_type") == "pr_reviewed" and ms.get("review_content"):
                     last_pr_review = ms["review_content"]
-                if (
-                    ms.get("milestone_type") == "pr_updated"
-                    and ms.get("result_summary")
-                    and not last_fix_summary
-                ):
-                    last_fix_summary = ms["result_summary"]
-                if last_pr_review and last_fix_summary:
                     break
 
             summary_ms = self._create_milestone(
@@ -2219,14 +2185,13 @@ class AutonomousOrchestrator:
             )
 
             summary_prompt = (
-                AUTONOMOUS_CONTEXT
-                + "代码审查已全部完成。请根据最后一轮审查意见和最后一次修复记录，"
+                AUTONOMOUS_CONTEXT + "代码审查已全部完成。请根据最后一轮审查意见，"
+                "并结合本会话历史中开发环节的修复记录，"
                 "输出一份 PR 评审总结，明确：\n"
                 "1. 最后一轮审查意见是否已全部落实\n"
                 "2. 是否还有遗留问题需要处理\n"
                 "3. 当前 PR 是否可以合并\n\n"
                 f"## 最后一轮审查意见\n{self._clean_agent_text(last_pr_review)}\n\n"
-                f"## 最后一次修复记录\n{self._clean_agent_text(last_fix_summary)}\n\n"
                 "如果审查意见已全部落实、无遗留问题，请明确说明'可以合并'。"
                 "直接输出总结，不要添加引导文字。"
             )
@@ -2344,18 +2309,9 @@ class AutonomousOrchestrator:
 
             if pr_number:
                 try:
-                    # Extract fix summary from agent response (no hard truncation —
-                    # _clean_agent_text already strips noise; only cap at 5000 chars
-                    # to avoid excessively long comments, breaking at paragraph boundary).
+                    # Extract fix summary from agent response in full; GitHub
+                    # comments render long content fine.
                     fix_summary = self._clean_agent_text(fix_result.response_text or "")
-                    if len(fix_summary) > 5000:
-                        # Truncate at last paragraph break within limit
-                        truncated = fix_summary[:5000]
-                        last_break = max(truncated.rfind("\n\n"), truncated.rfind("\n##"), 0)
-                        if last_break > 1000:
-                            fix_summary = truncated[:last_break].rstrip() + "\n\n..."
-                        else:
-                            fix_summary = truncated.rstrip() + "..."
                     comment = (
                         f"## ✅ Addressed Review Feedback (Round {round_num})\n\n"
                         f"### Changes Made\n{fix_summary}\n\n"
@@ -2389,12 +2345,12 @@ class AutonomousOrchestrator:
                 and ms.get("phase") == "planning"
                 and ms.get("milestone_type") == "plan_finalized"
             ):
-                plan_summary = self._clean_agent_text(ms["plan_content"])[:300]
+                plan_summary = self._clean_agent_text(ms["plan_content"])
                 break
         if not plan_summary:
             for ms in reversed(all_milestones):
                 if ms.get("plan_content") and ms.get("phase") == "planning":
-                    plan_summary = self._clean_agent_text(ms["plan_content"])[:300]
+                    plan_summary = self._clean_agent_text(ms["plan_content"])
                     break
 
         # 2. Diff stats
@@ -2409,7 +2365,7 @@ class AutonomousOrchestrator:
         test_summary = ""
         for ms in all_milestones:
             if ms.get("milestone_type") == "tests_run" and ms.get("result_summary"):
-                test_summary = self._clean_agent_text(ms["result_summary"])[:200]
+                test_summary = self._clean_agent_text(ms["result_summary"])
                 break
 
         # 4. Code review rounds

--- a/tests/issues/913/test_pr909_review_feedback.py
+++ b/tests/issues/913/test_pr909_review_feedback.py
@@ -4,9 +4,11 @@ Tests for PR #909 code review feedback fixes (Issue #913).
 Covers:
 1. _poll_ci_status polling mechanism
 2. get_pr_checks warning log on parse failure
-3. Previous review feedback truncation notice
-4. Pre-existing CI detection via structured output
-5. Worktree cleanup logic verification
+3. Pre-existing CI detection via structured output
+4. Worktree cleanup logic verification
+
+Note: previous-round review truncation notice tests were removed — that
+truncation was dropped in #987 (previous review is carried by --resume).
 """
 
 import json
@@ -190,47 +192,3 @@ class TestIsPreExistingCIFailure:
         """Empty string returns False."""
         result = AutonomousOrchestrator._is_pre_existing_ci_failure("")
         assert result is False
-
-
-# ── Test truncation logic with constant ───────────────────────────────────
-
-
-class TestTruncationNotice:
-    """Test the truncation notice for previous review feedback."""
-
-    def test_notice_shown_when_truncated(self):
-        from app.modules.workspace.autonomous.orchestrator import PREV_REVIEW_MAX_LENGTH
-
-        cleaned = "x" * (PREV_REVIEW_MAX_LENGTH + 100)
-        truncated = cleaned[:PREV_REVIEW_MAX_LENGTH]
-        notice = (
-            "\n> ⚠️ 以上审查意见已截断至 3000 字符，部分内容可能被省略。\n"
-            if len(cleaned) > PREV_REVIEW_MAX_LENGTH
-            else ""
-        )
-        assert "⚠️" in notice
-        assert len(truncated) == PREV_REVIEW_MAX_LENGTH
-
-    def test_no_notice_when_not_truncated(self):
-        from app.modules.workspace.autonomous.orchestrator import PREV_REVIEW_MAX_LENGTH
-
-        cleaned = "Short review content"
-        truncated = cleaned[:PREV_REVIEW_MAX_LENGTH]
-        notice = (
-            "\n> ⚠️ 以上审查意见已截断至 3000 字符，部分内容可能被省略。\n"
-            if len(cleaned) > PREV_REVIEW_MAX_LENGTH
-            else ""
-        )
-        assert notice == ""
-        assert truncated == "Short review content"
-
-    def test_no_notice_at_exact_boundary(self):
-        from app.modules.workspace.autonomous.orchestrator import PREV_REVIEW_MAX_LENGTH
-
-        cleaned = "x" * PREV_REVIEW_MAX_LENGTH
-        notice = (
-            "\n> ⚠️ 以上审查意见已截断至 3000 字符，部分内容可能被省略。\n"
-            if len(cleaned) > PREV_REVIEW_MAX_LENGTH
-            else ""
-        )
-        assert notice == ""

--- a/tests/issues/987/test_prompt_truncation.py
+++ b/tests/issues/987/test_prompt_truncation.py
@@ -1,0 +1,220 @@
+"""
+Regression tests for prompt/display truncation redesign (Issue #987).
+
+Verifies that:
+  - pr_review round-2 ``review_prompt`` no longer re-injects content already
+    carried by the review session's ``--resume`` history (requirements_text
+    and the previous round's review content), while keeping the per-point
+    confirmation instruction.
+  - ``summary_prompt`` keeps the ``last_pr_review`` cross-session bridge
+    (review runs on the review session, summary on the main session) but
+    drops the dead ``last_fix_summary`` injection.
+  - the progress report posted to the GitHub issue keeps full plan/test
+    content (no [:300] / [:200] truncation).
+"""
+
+from unittest.mock import MagicMock, patch
+
+from app.modules.workspace.autonomous.models import AgentTaskResult
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+
+def _make_workflow(**overrides):
+    """Minimal workflow dict; round=2/max=2 by default so summary runs."""
+    base = {
+        "workflow_id": "test-wf-987",
+        "title": "Test 987",
+        "requirements_text": "REQ_MARKER 需要完整保留的需求描述 " * 8,
+        "branch_name": "feature-x",
+        "github_issue_number": 100,
+        "github_pr_number": 42,
+        "current_round": 1,  # round_num = current_round + 1 = 2
+        "max_pr_review_rounds": 2,  # round(2) >= max(2) -> summary runs
+        "dev_round": 1,
+        "cli_tool": "claude-code",
+        "model": "",
+        "worktree_path": "/tmp/wf987",
+        "project_path": "/tmp/wf987",
+        "workspace_type": "local",
+        "remote_machine_id": "",
+        "permission_mode": "auto-edit",
+    }
+    base.update(overrides)
+    return base
+
+
+def _make_agent_result(text="代码审查通过"):
+    return AgentTaskResult(
+        session_id="sess-1",
+        response_text=text,
+        total_tokens=10,
+        total_input_tokens=5,
+        total_output_tokens=5,
+        success=True,
+        error=None,
+    )
+
+
+def _make_gh():
+    gh = MagicMock()
+    gh.get_diff_stats.return_value = {
+        "commits": 1,
+        "additions": 5,
+        "deletions": 1,
+        "files": 1,
+    }
+    gh.git_push.return_value = None
+    gh.get_pr_diff.return_value = "FAKE_DIFF"
+    gh.add_pr_comment.return_value = {}
+    gh.add_issue_comment.return_value = {}
+    return gh
+
+
+def _make_orchestrator(wf):
+    """AutonomousOrchestrator with all external deps mocked."""
+    from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+    with (
+        patch("app.modules.workspace.autonomous.orchestrator.Database"),
+        patch(
+            "app.modules.workspace.autonomous.orchestrator.AutonomousWorkflowRepository"
+        ) as mock_repo_cls,
+    ):
+        mock_repo = MagicMock()
+        mock_repo.get_workflow.return_value = wf
+        mock_repo_cls.return_value = mock_repo
+        orch = AutonomousOrchestrator(wf["workflow_id"])
+        orch.repo = mock_repo
+
+    orch.emitter = MagicMock()
+    orch._get_gh = MagicMock()
+    orch._poll_ci_status = MagicMock(return_value=[])
+    orch._smart_truncate_diff = MagicMock(return_value="DIFF_TEXT")
+    orch._clean_agent_text = MagicMock(side_effect=lambda x: x or "")
+    orch._create_milestone = MagicMock(return_value={"milestone_id": "ms-x"})
+    orch._update_workflow = MagicMock()
+    orch._accumulate_tokens = MagicMock()
+    orch._emit = MagicMock()
+    return orch
+
+
+def _capture_prompts(orch):
+    """Patch _run_agent to record each prompt; returns the capture list."""
+    captured = []
+
+    def fake_run_agent(**kwargs):
+        captured.append(kwargs.get("prompt", ""))
+        return _make_agent_result()
+
+    orch._run_agent = MagicMock(side_effect=fake_run_agent)
+    return captured
+
+
+# ── pr_review review_prompt ──────────────────────────────────────────────
+
+
+class TestPrReviewPrompt:
+    """Round-2 review_prompt must rely on resume, not truncated re-injection."""
+
+    def test_requirements_not_injected(self):
+        wf = _make_workflow()
+        orch = _make_orchestrator(wf)
+        orch._get_gh.return_value = _make_gh()
+        orch.repo.list_milestones.return_value = []
+        captured = _capture_prompts(orch)
+
+        orch._do_pr_review(wf)
+
+        # requirements_text was injected as [:500] before; now removed — the
+        # review session already has full requirements from the plan_review round.
+        assert "REQ_MARKER" not in captured[0]
+
+    def test_previous_review_content_not_reinjected_but_instruction_kept(self):
+        wf = _make_workflow()
+        orch = _make_orchestrator(wf)
+        orch._get_gh.return_value = _make_gh()
+        prev_review = "PREV_REVIEW_MARKER 上一轮审查意见详细内容 " * 20
+        orch.repo.list_milestones.return_value = [
+            {"milestone_type": "pr_reviewed", "review_content": prev_review},
+        ]
+        captured = _capture_prompts(orch)
+
+        orch._do_pr_review(wf)
+
+        review_prompt = captured[0]
+        # previous review was re-injected as [:3000] before; now removed (resume carries it)
+        assert "PREV_REVIEW_MARKER" not in review_prompt
+        # the per-point confirmation instruction is retained
+        assert "逐条确认" in review_prompt
+
+
+# ── summary_prompt ───────────────────────────────────────────────────────
+
+
+class TestSummaryPrompt:
+    """summary_prompt keeps last_pr_review (cross-session bridge) but drops
+    the dead last_fix_summary injection."""
+
+    def test_last_pr_review_kept_last_fix_summary_removed(self):
+        wf = _make_workflow()  # round=2 >= max=2 -> summary runs
+        orch = _make_orchestrator(wf)
+        orch._get_gh.return_value = _make_gh()
+        last_review = "LAST_REVIEW_MARKER 最后一轮审查意见 " * 10
+        orch.repo.list_milestones.return_value = [
+            {"milestone_type": "pr_reviewed", "review_content": last_review},
+        ]
+        captured = _capture_prompts(orch)
+
+        orch._do_pr_review(wf)
+
+        # captured[0] = review prompt, captured[1] = summary prompt
+        assert len(captured) >= 2
+        summary_prompt = captured[1]
+        # dead last_fix_summary section removed (pr_updated never writes
+        # result_summary, so it was always empty; and fix runs on main session)
+        assert "最后一次修复记录" not in summary_prompt
+        # last_pr_review cross-session bridge retained (review session != main)
+        assert "LAST_REVIEW_MARKER" in summary_prompt
+
+
+# ── report (GitHub issue comment) ────────────────────────────────────────
+
+
+class TestReportNotTruncated:
+    """Progress report posted to the GitHub issue keeps full plan/test content."""
+
+    def test_plan_and_test_sections_full(self):
+        wf = _make_workflow(current_round=0, max_pr_review_rounds=1)
+        orch = _make_orchestrator(wf)
+        gh = _make_gh()
+        orch._get_gh.return_value = gh
+
+        long_plan = "# PLAN_MARKER\n" + "方案详细内容行内容\n" * 60
+        long_test = "TEST_MARKER 测试输出详情\n" + "passed case line\n" * 60
+        orch.repo.list_milestones.return_value = [
+            {
+                "phase": "planning",
+                "milestone_type": "plan_finalized",
+                "plan_content": long_plan,
+            },
+            {"milestone_type": "tests_run", "result_summary": long_test},
+        ]
+
+        captured = {}
+
+        def fake_comment(num, body):
+            captured["comment"] = body
+            return {}
+
+        gh.add_issue_comment.side_effect = fake_comment
+
+        orch._do_report(wf)
+
+        comment = captured["comment"]
+        # plan section not truncated at [:300]
+        assert "PLAN_MARKER" in comment
+        assert "方案详细内容行内容" in comment
+        # test section not truncated at [:200] (nor the writer-side [:300])
+        assert "TEST_MARKER" in comment
+        assert "passed case line" in comment

--- a/tests/issues/987/test_prompt_truncation.py
+++ b/tests/issues/987/test_prompt_truncation.py
@@ -13,9 +13,11 @@ Verifies that:
     content (no [:300] / [:200] truncation).
 """
 
+import logging
 from unittest.mock import MagicMock, patch
 
 from app.modules.workspace.autonomous.models import AgentTaskResult
+from app.modules.workspace.autonomous.orchestrator import GITHUB_COMMENT_MAX_CHARS
 
 # ── Helpers ──────────────────────────────────────────────────────────────
 
@@ -218,3 +220,49 @@ class TestReportNotTruncated:
         # test section not truncated at [:200] (nor the writer-side [:300])
         assert "TEST_MARKER" in comment
         assert "passed case line" in comment
+
+
+# ── _post_github_comment (finding 1: GitHub hard-limit + silent failure) ──
+
+
+class TestPostGithubComment:
+    """``_post_github_comment`` caps over-long bodies and logs failures instead
+    of swallowing them — GitHub rejects comment bodies > 65536 chars, and the
+    old ``try/except: pass`` around every post made a rejected comment vanish
+    with no trace."""
+
+    def test_short_body_posted_verbatim(self):
+        orch = _make_orchestrator(_make_workflow())
+        gh = MagicMock()
+        orch._post_github_comment(gh, 42, "short body", context="t")
+        gh.add_issue_comment.assert_called_once_with(42, "short body")
+        gh.add_pr_comment.assert_not_called()
+
+    def test_is_pr_routes_to_pr_comment(self):
+        orch = _make_orchestrator(_make_workflow())
+        gh = MagicMock()
+        orch._post_github_comment(gh, 7, "x", is_pr=True)
+        gh.add_pr_comment.assert_called_once_with(7, "x")
+        gh.add_issue_comment.assert_not_called()
+
+    def test_long_body_capped_with_notice(self):
+        orch = _make_orchestrator(_make_workflow())
+        gh = MagicMock()
+        long_body = "B" * (GITHUB_COMMENT_MAX_CHARS + 5000)
+        orch._post_github_comment(gh, 42, long_body, context="report")
+        posted = gh.add_issue_comment.call_args[0][1]
+        # capped body respects the GitHub limit
+        assert len(posted) <= GITHUB_COMMENT_MAX_CHARS
+        # truncation notice points readers to the timeline full-text view
+        assert "截断" in posted
+        # head of the content is preserved
+        assert posted.startswith("B")
+
+    def test_failure_is_logged_not_raised(self, caplog):
+        orch = _make_orchestrator(_make_workflow())
+        gh = MagicMock()
+        gh.add_issue_comment.side_effect = RuntimeError("boom")
+        with caplog.at_level(logging.WARNING):
+            orch._post_github_comment(gh, 42, "body", context="report")  # must not raise
+        # failure logged with the context + issue number so it's diagnosable
+        assert any("report" in rec.message and "#42" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## What

Removes redundant prompt truncations in the autonomous orchestrator and untruncates the user-visible display side (PR body / GitHub comments / report). Closes #987.

## Why

#987 traces back to #957 (PR body `requirements_text[:500]` truncation). On digging, the only prompt injections that were *actually* truncated were the pr_review `review_prompt` (two spots) and a dead-code `last_fix_summary` injection in `summary_prompt` — all redundant after #984's three-session topology, where the review/main sessions `--resume` and carry the full prior-round content themselves.

The display-side truncations land on surfaces the user actually sees: PR body, GitHub issue comments, GitHub PR comments. The progress report is posted to a **GitHub issue comment** (`add_issue_comment`), not the timeline UI — `result_summary` / report fields aren't rendered by the timeline at all (frontend grep confirms `result_summary` is type-only, no component consumes it; cards show `formatMilestoneTitle()` + meta pills; full text is viewed via #988's modal).

## Changes (all in `orchestrator.py`)

**Agent prompts — drop redundant injections (rely on resume):**
- pr_review `review_prompt`: remove `requirements_text[:500]` and the previous-round `review[:3000]` re-injection. The review session `--resume` already carries both (requirements from the plan_review round; prev pr_review from its own history). Keep the per-point confirmation instruction, now pointing the reviewer at the resumed history. Drop unused `PREV_REVIEW_MAX_LENGTH`.
- `summary_prompt`: remove the dead "last fix record" injection (`pr_updated` never writes `result_summary`, so `last_fix_summary` was always empty; and fix runs on the same main session that summary resumes). Keep `last_pr_review` — the necessary cross-session bridge (review session ≠ main session).

**Display side — untruncate user-visible surfaces:**
- PR body: `requirements_text[:500]` → full (root cause of #957)
- plan-finalized comment: `last_review[:2000]` → full
- fix PR comment: `fix_summary[:5000]` + paragraph truncation → full
- test-results comment: `response_text[:800]` → full
- report (GitHub issue comment): `plan_summary[:300]` / `test_summary[:200]` (+ writer-side `tests_run` `result_summary[:300]`) → full

`result_summary` DB summary copies (no UI consumer) left as-is.

## Tests

- `tests/issues/987/test_prompt_truncation.py`: assert review_prompt no longer injects requirements/prev-review but keeps the confirmation instruction; summary_prompt drops last-fix-record but keeps last_pr_review; report comment carries full plan/test content.
- `tests/issues/913`: remove `TestTruncationNotice` (tested the removed `PREV_REVIEW_MAX_LENGTH` truncation notice).

All pre-commit hooks pass (black/ruff/mypy/bandit/isort/pydocstyle); pytest 20 passed.



## 边界 / 假设

- **requirements 在 review 历史中的假设**：pr_review 的 `review_prompt` 不再注入 requirements，依赖 review session（由 plan_review 建立 `review_session_id`）在 `--resume` 时已携带完整需求。仅当 plan_review 被跳过或未持久化 session id 时，round-1 pr_review 会开新 review session、历史里没有 requirements —— 此时 reviewer 仍有 diff + CI + 逐条确认指令，降级温和。正常流程 plan_review 总在 pr_review 前跑，此假设成立。
- **GitHub 评论长度上限**：去截断后，verbose agent 产出可能超过 GitHub 的 65536 字符硬限而被 API 拒绝。所有 comment 调用已收敛到 `_post_github_comment` —— 超过 `GITHUB_COMMENT_MAX_CHARS`（65000）自动截断并附「完整内容见 timeline」提示，post 失败时 `logger.warning`（不再 `try/except: pass` 静默吞错）。完整内容始终保留在 DB / timeline 全文 modal (#988)，无数据丢失。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
