### PR TITLE
feat(autonomous): timeline milestone card one-line TL;DR summary (#993)

### DIFF
--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -141,6 +141,17 @@ CI_POLL_MAX_WAIT = 300  # maximum seconds to wait (5 minutes)
 # a notice pointing to the timeline full-text view (#988).
 GITHUB_COMMENT_MAX_CHARS = 65000
 
+# Each phase agent appends a one-line `TL;DR: ...` summary to its output for the
+# timeline milestone card (#993). TLDR_INSTRUCTION is appended to every agent
+# prompt; _extract_tldr pulls the line back out for storage in the tldr column.
+TLDR_INSTRUCTION = (
+    "\n\n## 输出格式要求\n"
+    "请在输出的最后单独一行，用以下格式给出本次输出的一句话总结"
+    "（将显示在 timeline 卡片上，务必简洁、纯文本、不要 markdown）：\n"
+    "TL;DR: <不超过 80 字的总结>\n"
+)
+_TLDR_RE = re.compile(r"TL;DR:\s*(.+?)\s*$", re.MULTILINE | re.IGNORECASE)
+
 REVIEW_SESSION_MILESTONE_TYPES = {"plan_reviewed", "pr_reviewed"}
 
 # Session lines that span multiple milestones via --resume. Each maps to a
@@ -410,6 +421,17 @@ class AutonomousOrchestrator:
             or "预先存在" in response
             or re.search(r"pre[\s-]?existing", response, re.IGNORECASE)
         )
+
+    @staticmethod
+    def _extract_tldr(response: str) -> str:
+        """Extract the ``TL;DR: ...`` one-liner the agent was asked to append.
+
+        Returns "" when absent so callers can fall back to ``result_summary``.
+        """
+        if not response:
+            return ""
+        match = _TLDR_RE.search(response)
+        return match.group(1).strip()[:200] if match else ""
 
     def _post_github_comment(
         self,
@@ -705,6 +727,11 @@ class AutonomousOrchestrator:
             task_timeout = (workflow_data or {}).get("task_timeout")
             if task_timeout:
                 kwargs["timeout"] = int(task_timeout)
+
+        # Append the TL;DR instruction so every phase agent outputs a one-line
+        # summary for the timeline milestone card (#993).
+        if kwargs.get("prompt"):
+            kwargs["prompt"] = kwargs["prompt"] + TLDR_INSTRUCTION
 
         result = self._runner.run_agent_task(**kwargs)
         if result.session_id:
@@ -1246,6 +1273,7 @@ class AutonomousOrchestrator:
                 "status": "completed" if result.success else "failed",
                 "plan_content": plan_text,
                 "result_summary": plan_text[:200],
+                "tldr": self._extract_tldr(plan_text),
                 "session_id": result.session_id,
                 "error_message": result.error or "",
             },
@@ -1347,6 +1375,7 @@ class AutonomousOrchestrator:
                 "status": "completed" if review_result.success else "failed",
                 "review_content": review_text,
                 "result_summary": review_text[:200],
+                "tldr": self._extract_tldr(review_text),
                 "review_session_id": review_result.session_id,
             },
         )
@@ -1447,6 +1476,7 @@ class AutonomousOrchestrator:
                     "status": "completed",
                     "plan_content": final_plan,
                     "result_summary": final_plan[:200],
+                    "tldr": self._extract_tldr(final_plan),
                 },
             )
 
@@ -1667,6 +1697,7 @@ class AutonomousOrchestrator:
                         "result_summary": (
                             result.response_text[:300] if result.response_text else ""
                         ),
+                        "tldr": self._extract_tldr(result.response_text),
                         "error_message": "Agent produced no code changes (commit SHA unchanged)",
                     },
                 )
@@ -1684,6 +1715,7 @@ class AutonomousOrchestrator:
                 "status": "completed" if result.success else "failed",
                 "session_id": result.session_id,
                 "result_summary": result.response_text[:300] if result.response_text else "",
+                "tldr": self._extract_tldr(result.response_text),
                 "commit_shas": json.dumps([commit_sha] if commit_sha else []),
                 "diff_stats": json.dumps(diff_stats),
                 "error_message": result.error or "",
@@ -1787,6 +1819,7 @@ class AutonomousOrchestrator:
                 "status": "completed" if test_result.success else "failed",
                 "session_id": test_result.session_id,
                 "result_summary": (test_result.response_text if test_result.response_text else ""),
+                "tldr": self._extract_tldr(test_result.response_text),
             },
         )
 
@@ -2180,6 +2213,7 @@ class AutonomousOrchestrator:
                 "status": "completed" if review_result.success else "failed",
                 "review_content": review_text,
                 "review_session_id": review_result.session_id,
+                "tldr": self._extract_tldr(review_text),
             },
         )
 
@@ -2250,6 +2284,7 @@ class AutonomousOrchestrator:
                     "status": "completed" if summary_result.success else "failed",
                     "review_content": summary_text,
                     "result_summary": summary_text[:200],
+                    "tldr": self._extract_tldr(summary_text),
                 },
             )
 
@@ -2338,6 +2373,7 @@ class AutonomousOrchestrator:
                     "session_id": fix_result.session_id,
                     "commit_shas": json.dumps([commit_sha] if commit_sha else []),
                     "diff_stats": json.dumps(diff_stats),
+                    "tldr": self._extract_tldr(fix_result.response_text or ""),
                 },
             )
 

--- a/app/repositories/autonomous_repo.py
+++ b/app/repositories/autonomous_repo.py
@@ -90,6 +90,7 @@ class AutonomousWorkflowRepository:
         "result_summary",
         "plan_content",
         "review_content",
+        "tldr",
         "phase_total_tokens",
         "phase_input_tokens",
         "phase_output_tokens",
@@ -742,13 +743,13 @@ class AutonomousWorkflowRepository:
                      session_id, review_session_id,
                      github_issue_number, github_pr_number, github_comment_id,
                      commit_shas, diff_stats, result_summary,
-                     plan_content, review_content,
+                     plan_content, review_content, tldr,
                      parent_milestone_id, fork_branch, metadata,
                      error_message,
                      phase_total_tokens, phase_input_tokens,
                      phase_output_tokens, phase_request_count,
                      started_at, created_at, updated_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 RETURNING *
                 """,
                 (
@@ -771,6 +772,7 @@ class AutonomousWorkflowRepository:
                     data.get("result_summary", ""),
                     data.get("plan_content", ""),
                     data.get("review_content", ""),
+                    data.get("tldr", ""),
                     data.get("parent_milestone_id", ""),
                     data.get("fork_branch", ""),
                     data.get("metadata", ""),
@@ -795,13 +797,13 @@ class AutonomousWorkflowRepository:
                      session_id, review_session_id,
                      github_issue_number, github_pr_number, github_comment_id,
                      commit_shas, diff_stats, result_summary,
-                     plan_content, review_content,
+                     plan_content, review_content, tldr,
                      parent_milestone_id, fork_branch, metadata,
                      error_message,
                      phase_total_tokens, phase_input_tokens,
                      phase_output_tokens, phase_request_count,
                      started_at, created_at, updated_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     data.get("workflow_id", ""),
@@ -823,6 +825,7 @@ class AutonomousWorkflowRepository:
                     data.get("result_summary", ""),
                     data.get("plan_content", ""),
                     data.get("review_content", ""),
+                    data.get("tldr", ""),
                     data.get("parent_milestone_id", ""),
                     data.get("fork_branch", ""),
                     data.get("metadata", ""),

--- a/frontend/src/api/autonomous.ts
+++ b/frontend/src/api/autonomous.ts
@@ -104,6 +104,7 @@ export interface WorkflowMilestone {
   commit_shas: string;
   diff_stats: string;
   result_summary: string;
+  tldr: string;
   plan_content: string;
   review_content: string;
   error_message: string;

--- a/frontend/src/components/work/WorkflowTimeline.css
+++ b/frontend/src/components/work/WorkflowTimeline.css
@@ -48,7 +48,7 @@
   -webkit-box-orient: vertical;
   overflow: hidden;
   font-size: 0.78rem;
-  color: #64748b;
+  color: var(--text-tertiary);
   line-height: 1.4;
 }
 

--- a/frontend/src/components/work/WorkflowTimeline.css
+++ b/frontend/src/components/work/WorkflowTimeline.css
@@ -40,6 +40,18 @@
   font-size: 0.75rem;
 }
 
+/* One-line per-round summary on the milestone card (agent TL;DR, falling back
+   to result_summary). Plain text — no markdown — clamped to 2 lines. */
+.workflow-timeline-card-summary {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  font-size: 0.78rem;
+  color: #64748b;
+  line-height: 1.4;
+}
+
 .workflow-timeline-meta-pill {
   display: inline-flex;
   align-items: center;

--- a/frontend/src/components/work/WorkflowTimeline.tsx
+++ b/frontend/src/components/work/WorkflowTimeline.tsx
@@ -977,6 +977,15 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
                 </span>
               )}
             </div>
+            {(() => {
+              const summary = (milestone.tldr || milestone.result_summary || '').trim();
+              if (!summary || compact) return null;
+              return (
+                <div className="workflow-timeline-card-summary mt-1" title={summary}>
+                  {summary}
+                </div>
+              );
+            })()}
             {showActionRow && (
               <div
                 className="workflow-timeline-action-row mt-2 d-flex align-items-center gap-2 flex-wrap"

--- a/frontend/src/components/work/WorkflowTimeline.tsx
+++ b/frontend/src/components/work/WorkflowTimeline.tsx
@@ -928,6 +928,19 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
         canViewReviewContent ||
         (canInlineAction && (canFork || canCancel)));
     const showExpandedDetail = milestone.status === 'in_progress' && hasLiveActivity;
+    // One-line per-round summary (agent TL;DR, falling back to result_summary).
+    // Plain text, clamped to 2 lines via CSS; the title is capped so a verbose
+    // result_summary (e.g. tests_run full output) can't flood the hover tooltip.
+    const rawSummary = (milestone.tldr || milestone.result_summary || '').trim();
+    const cardSummaryEl =
+      !rawSummary || compact ? null : (
+        <div
+          className="workflow-timeline-card-summary mt-1"
+          title={rawSummary.length > 200 ? rawSummary.slice(0, 200) + '…' : rawSummary}
+        >
+          {rawSummary}
+        </div>
+      );
 
     return (
       <div key={milestone.milestone_id} className="mb-2">
@@ -977,15 +990,7 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
                 </span>
               )}
             </div>
-            {(() => {
-              const summary = (milestone.tldr || milestone.result_summary || '').trim();
-              if (!summary || compact) return null;
-              return (
-                <div className="workflow-timeline-card-summary mt-1" title={summary}>
-                  {summary}
-                </div>
-              );
-            })()}
+            {cardSummaryEl}
             {showActionRow && (
               <div
                 className="workflow-timeline-action-row mt-2 d-flex align-items-center gap-2 flex-wrap"

--- a/migrations/versions/20260614_062_add_tldr_to_milestones.py
+++ b/migrations/versions/20260614_062_add_tldr_to_milestones.py
@@ -1,0 +1,54 @@
+"""Add tldr column to workflow_milestones
+
+Each phase agent now appends a one-line ``TL;DR: ...`` summary to its output
+(see orchestrator ``TLDR_INSTRUCTION``). This column stores it so the timeline
+milestone card can show a concise per-round summary, falling back to
+``result_summary`` when the agent didn't produce one. See #993.
+
+Revision ID: 20260614_062_milestone_tldr
+Revises: 20260613_061_session_topology
+Create Date: 2026-06-14
+"""
+
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260614_062_milestone_tldr"
+down_revision: Union[str, None] = "20260613_061_session_topology"
+branch_labels = None
+depends_on = None
+
+
+def _column_exists(conn, table: str, column: str) -> bool:
+    """Check if a column already exists on the given table."""
+    if conn.dialect.name == "postgresql":
+        result = conn.execute(
+            sa.text(
+                "SELECT COUNT(*) FROM information_schema.columns "
+                "WHERE table_name = :table AND column_name = :column"
+            ),
+            {"table": table, "column": column},
+        )
+        return result.scalar() > 0
+
+    result = conn.execute(sa.text(f"PRAGMA table_info({table})"))
+    return any(row[1] == column for row in result.fetchall())
+
+
+def upgrade() -> None:
+    """Add tldr column to workflow_milestones."""
+    conn = op.get_bind()
+    if not _column_exists(conn, "workflow_milestones", "tldr"):
+        op.add_column(
+            "workflow_milestones",
+            sa.Column("tldr", sa.Text, server_default="", nullable=False),
+        )
+
+
+def downgrade() -> None:
+    """Remove tldr column from workflow_milestones."""
+    conn = op.get_bind()
+    if _column_exists(conn, "workflow_milestones", "tldr"):
+        op.drop_column("workflow_milestones", "tldr")

--- a/tests/issues/993/e2e_card_summary_playwright.py
+++ b/tests/issues/993/e2e_card_summary_playwright.py
@@ -1,0 +1,380 @@
+#!/usr/bin/env python3
+"""
+Open ACE — E2E Test: Timeline Milestone Card One-Line Summary (Issue #993)
+
+Verifies the per-round summary line on milestone cards:
+  1. A milestone with a `tldr` shows the TL;DR text on the card.
+  2. A milestone with only `result_summary` (no tldr) falls back to it.
+  3. A milestone with neither shows no summary line (no placeholder).
+
+Data is seeded directly via AutonomousWorkflowRepository (no real agent / gh runs).
+
+Run:
+  HEADLESS=true  python tests/issues/993/e2e_card_summary_playwright.py   # CI
+  HEADLESS=false python tests/issues/993/e2e_card_summary_playwright.py   # Demo
+"""
+
+import os
+import sys
+import time
+import uuid
+
+# tests/issues/993/file.py → tests/issues/993 → tests/issues → tests → PROJECT_ROOT
+PROJECT_ROOT = os.path.dirname(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
+sys.path.insert(0, PROJECT_ROOT)
+
+import requests
+
+os.environ["NO_PROXY"] = "localhost,127.0.0.1"
+_session = requests.Session()
+_session.trust_env = False
+
+# ── Config ──────────────────────────────────────────────
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
+SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "tests", "screenshots", "e2e-card-summary-993")
+TEST_USER = os.environ.get("TEST_REAL_USER", "admin")
+TEST_PASS = "admin123"
+
+auth_token = None
+created_workflow_ids = []
+
+
+# ── Helpers ─────────────────────────────────────────────
+def ensure_dir():
+    os.makedirs(SCREENSHOT_DIR, exist_ok=True)
+
+
+def shot(page, name):
+    ensure_dir()
+    path = os.path.join(SCREENSHOT_DIR, f"{name}.png")
+    page.screenshot(path=path, full_page=True)
+    print(f"  📸 {name}.png", flush=True)
+
+
+def log(tag, msg):
+    print(f"  [{tag}] {msg}", flush=True)
+
+
+def api(method, path, token=None, **kwargs):
+    url = f"{BASE_URL}{path}"
+    headers = {}
+    t = token or auth_token
+    if t:
+        headers["Cookie"] = f"session_token={t}"
+    if method == "get":
+        return _session.get(url, headers=headers, **kwargs)
+    if method == "post":
+        return _session.post(url, headers=headers, **kwargs)
+    if method == "delete":
+        return _session.delete(url, headers=headers, **kwargs)
+
+
+def get_repo():
+    from app.repositories.autonomous_repo import AutonomousWorkflowRepository
+
+    return AutonomousWorkflowRepository()
+
+
+def create_workflow_via_api(overrides=None):
+    base = {
+        "title": f"CardSummary {uuid.uuid4().hex[:8]}",
+        "requirements_text": "Build a hello world feature with tests",
+        "cli_tool": "claude-code",
+        "model": "",
+        "workspace_type": "local",
+        "project_path": "/tmp/e2e-card-summary",
+        "branch_strategy": "new-branch",
+        "max_plan_rounds": 1,
+        "max_pr_review_rounds": 1,
+    }
+    if overrides:
+        base.update(overrides)
+    return api("post", "/api/autonomous/workflows", json=base)
+
+
+def cleanup_workflows():
+    for wf_id in created_workflow_ids:
+        try:
+            api("post", f"/api/autonomous/workflows/{wf_id}/stop")
+        except Exception:
+            pass
+        try:
+            api("delete", f"/api/autonomous/workflows/{wf_id}")
+        except Exception:
+            pass
+
+
+def step_login():
+    global auth_token
+    log("LOGIN", f"Logging in as {TEST_USER}")
+    r = _session.post(
+        f"{BASE_URL}/api/auth/login",
+        json={"username": TEST_USER, "password": TEST_PASS},
+    )
+    assert r.status_code == 200, f"Login failed: {r.status_code} {r.text}"
+    auth_token = r.cookies.get("session_token")
+    assert auth_token, "No session_token cookie"
+    log("LOGIN", "✅ Login successful")
+
+
+# ── Seeders ─────────────────────────────────────────────
+def _seed_milestone(
+    repo,
+    wf_id,
+    milestone_type,
+    phase,
+    round_number=1,
+    dev_round=1,
+    status="completed",
+    plan_content="",
+    review_content="",
+    result_summary="",
+    tldr="",
+):
+    now = time.strftime("%Y-%m-%dT%H:%M:%SZ")
+    data = {
+        "workflow_id": wf_id,
+        "milestone_id": str(uuid.uuid4()),
+        "phase": phase,
+        "dev_round": dev_round,
+        "round_number": round_number,
+        "milestone_type": milestone_type,
+        "status": status,
+        "title": f"{milestone_type} dev{dev_round} r{round_number}",
+        "result_summary": result_summary,
+        "tldr": tldr,
+        "started_at": now,
+        "completed_at": now,
+    }
+    if plan_content:
+        data["plan_content"] = plan_content
+    if review_content:
+        data["review_content"] = review_content
+    repo.create_milestone(data)
+    return data["milestone_id"]
+
+
+def seed_tldr_workflow(repo, title):
+    """plan_finalized with a tldr — card must show the TL;DR text."""
+    r = create_workflow_via_api({"title": title})
+    assert r.status_code == 201, r.text
+    wf_id = r.json()["workflow"]["workflow_id"]
+    created_workflow_ids.append(wf_id)
+    repo.update_workflow(wf_id, {"status": "completed", "current_phase": "done"})
+    _seed_milestone(
+        repo,
+        wf_id,
+        "plan_finalized",
+        "planning",
+        1,
+        1,
+        plan_content="## Plan\nFull plan body here.",
+        result_summary="方案：实现登录模块",  # present but tldr wins
+        tldr="TLDR-LOGIN-MARKER 实现了用户登录与登出",
+    )
+    repo.refresh_workflow_usage_from_sessions(wf_id)
+    return wf_id
+
+
+def seed_summary_only_workflow(repo, title):
+    """plan_finalized with result_summary but empty tldr — card falls back."""
+    r = create_workflow_via_api({"title": title})
+    assert r.status_code == 201, r.text
+    wf_id = r.json()["workflow"]["workflow_id"]
+    created_workflow_ids.append(wf_id)
+    repo.update_workflow(wf_id, {"status": "completed", "current_phase": "done"})
+    _seed_milestone(
+        repo,
+        wf_id,
+        "plan_finalized",
+        "planning",
+        1,
+        1,
+        plan_content="## Plan\nBody.",
+        result_summary="SUMMARY-ONLY-MARKER 方案概述：分三步实现",
+        tldr="",  # no tldr → card uses result_summary
+    )
+    repo.refresh_workflow_usage_from_sessions(wf_id)
+    return wf_id
+
+
+def seed_empty_workflow(repo, title):
+    """repo_setup milestone with no tldr / result_summary — no summary line."""
+    r = create_workflow_via_api({"title": title})
+    assert r.status_code == 201, r.text
+    wf_id = r.json()["workflow"]["workflow_id"]
+    created_workflow_ids.append(wf_id)
+    repo.update_workflow(wf_id, {"status": "completed", "current_phase": "done"})
+    _seed_milestone(
+        repo,
+        wf_id,
+        "repo_setup",
+        "setup",
+        1,
+        1,
+        result_summary="",
+        tldr="",
+    )
+    repo.refresh_workflow_usage_from_sessions(wf_id)
+    return wf_id
+
+
+# ── Browser assertions ──────────────────────────────────
+def open_timeline_english(context, page, workflow_title, shot_name=None):
+    """Auth + English + client-side nav to a seeded workflow's timeline."""
+    context.add_cookies([{"name": "session_token", "value": auth_token, "url": BASE_URL}])
+    page.goto(f"{BASE_URL}/work")
+    page.wait_for_timeout(2000)
+    page.evaluate(
+        "() => { localStorage.setItem('language','en'); localStorage.setItem('i18nextLng','en'); }"
+    )
+    nav = page.locator(".work-nav-item:has(.bi-robot)")
+    if nav.count() == 0:
+        raise AssertionError("Autonomous nav item missing — feature flag not enabled")
+    nav.first.click()
+    page.wait_for_timeout(1500)
+    if "/work/autonomous" not in page.url:
+        raise AssertionError(f"Client-side nav failed; url={page.url}")
+    item = page.locator(f".auto-workflow-item:has-text('{workflow_title}')")
+    page.wait_for_timeout(1500)
+    if item.count() == 0:
+        raise AssertionError(f"Workflow '{workflow_title}' not found in list")
+    item.first.click()
+    page.wait_for_timeout(2500)
+    log("BROWSER", f"  url={page.url}")
+    if shot_name:
+        shot(page, shot_name)
+
+
+def step_browser_tldr(context, page, wf_id):
+    log("BROWSER", "Verifying card shows TL;DR text")
+    open_timeline_english(context, page, "TLDR Card 993", "01-tldr")
+    summary = page.locator(".workflow-timeline-card-summary")
+    assert summary.count() >= 1, "summary line missing on tldr milestone card"
+    assert (
+        "TLDR-LOGIN-MARKER" in summary.first.inner_text()
+    ), "card should show the tldr text, not result_summary"
+    log("BROWSER", "  ✅ card shows TL;DR text (tldr preferred over result_summary)")
+
+
+def step_browser_summary_fallback(context, page, wf_id):
+    log("BROWSER", "Verifying card falls back to result_summary when tldr empty")
+    open_timeline_english(context, page, "SummaryOnly Card 993", "02-summary-only")
+    summary = page.locator(".workflow-timeline-card-summary")
+    assert summary.count() >= 1, "summary line missing on summary-only card"
+    assert (
+        "SUMMARY-ONLY-MARKER" in summary.first.inner_text()
+    ), "card should fall back to result_summary when tldr is empty"
+    log("BROWSER", "  ✅ card falls back to result_summary (tldr empty)")
+
+
+def step_browser_empty(context, page, wf_id):
+    log("BROWSER", "Verifying no summary line when both tldr and result_summary empty")
+    open_timeline_english(context, page, "Empty Card 993", "03-empty")
+    summary = page.locator(".workflow-timeline-card-summary")
+    assert (
+        summary.count() == 0
+    ), "no summary line should render when tldr and result_summary are both empty"
+    log("BROWSER", "  ✅ no summary line on empty milestone (no placeholder)")
+
+
+# ── Runner ──────────────────────────────────────────────
+def run_tests():
+    global auth_token
+    ensure_dir()
+    print("\n" + "=" * 60, flush=True)
+    print("  Milestone Card One-Line Summary (#993)", flush=True)
+    print("=" * 60 + "\n", flush=True)
+
+    passed = failed = skipped = 0
+
+    try:
+        step_login()
+        passed += 1
+    except Exception as e:
+        print(f"  ❌ LOGIN FAILED: {e}", flush=True)
+        failed += 1
+        print("\nCannot continue without login — aborting.\n")
+        cleanup_workflows()
+        sys.exit(1)
+
+    repo = None
+    try:
+        repo = get_repo()
+    except Exception as e:
+        print(f"  ⚠️  Cannot import AutonomousWorkflowRepository: {e}", flush=True)
+
+    tldr_wf = summary_wf = empty_wf = None
+    if repo is not None:
+        for label, fn, arg in [
+            ("tldr", seed_tldr_workflow, "TLDR Card 993"),
+            ("summary", seed_summary_only_workflow, "SummaryOnly Card 993"),
+            ("empty", seed_empty_workflow, "Empty Card 993"),
+        ]:
+            try:
+                wid = fn(repo, arg)
+                if label == "tldr":
+                    tldr_wf = wid
+                elif label == "summary":
+                    summary_wf = wid
+                else:
+                    empty_wf = wid
+                passed += 1
+            except Exception as e:
+                print(f"  ❌ SEED {label.upper()} FAILED: {e}", flush=True)
+                failed += 1
+
+    # Browser tests
+    try:
+        from playwright.sync_api import sync_playwright
+    except ImportError:
+        print("  ⚠️  playwright not installed — skipping browser tests", flush=True)
+        skipped += 3
+        sync_playwright = None
+
+    if sync_playwright:
+        with sync_playwright() as p:
+            browser = p.chromium.launch(headless=HEADLESS)
+            context = browser.new_context(viewport={"width": 1280, "height": 900})
+            page = context.new_page()
+            page.set_default_timeout(15000)
+
+            browser_tests = [
+                ("TL;DR on card", tldr_wf, step_browser_tldr),
+                ("Summary fallback", summary_wf, step_browser_summary_fallback),
+                ("Empty → no line", empty_wf, step_browser_empty),
+            ]
+            for name, wf, fn in browser_tests:
+                if not wf:
+                    skipped += 1
+                    continue
+                try:
+                    fn(context, page, wf)
+                    passed += 1
+                except Exception as e:
+                    print(f"  ❌ {name.upper()} FAILED: {e}", flush=True)
+                    failed += 1
+                    try:
+                        shot(page, f"error-{name.lower().replace(' ', '-')}")
+                    except Exception:
+                        pass
+
+            browser.close()
+
+    # Cleanup
+    log("CLEANUP", "Removing seeded workflows")
+    cleanup_workflows()
+
+    print("\n" + "=" * 60, flush=True)
+    print(f"  Results: {passed} passed, {failed} failed, {skipped} skipped", flush=True)
+    print("=" * 60 + "\n", flush=True)
+
+    if failed > 0:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/tests/issues/993/test_tldr.py
+++ b/tests/issues/993/test_tldr.py
@@ -1,0 +1,188 @@
+"""Tests for the per-round TL;DR milestone summary (Issue #993).
+
+Verifies:
+  - ``_extract_tldr`` pulls the ``TL;DR: ...`` line (case-insensitive, first
+    match, capped at 200 chars, empty when absent / whitespace-stripped).
+  - ``TLDR_INSTRUCTION`` is appended to every ``_run_agent`` prompt.
+  - phase milestones persist the extracted ``tldr`` alongside ``result_summary``.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from app.modules.workspace.autonomous.models import AgentTaskResult
+from app.modules.workspace.autonomous.orchestrator import TLDR_INSTRUCTION, AutonomousOrchestrator
+
+# ── helpers (mirror tests/issues/987/) ───────────────────────────────────
+
+
+def _make_workflow(**overrides):
+    base = {
+        "workflow_id": "test-wf-993",
+        "title": "Test 993",
+        "requirements_text": "REQ",
+        "branch_name": "feature-x",
+        "github_issue_number": 100,
+        "github_pr_number": 42,
+        "current_round": 1,
+        "max_pr_review_rounds": 2,
+        "dev_round": 1,
+        "cli_tool": "claude-code",
+        "model": "",
+        "worktree_path": "/tmp/wf993",
+        "project_path": "/tmp/wf993",
+        "workspace_type": "local",
+        "remote_machine_id": "",
+        "permission_mode": "auto-edit",
+    }
+    base.update(overrides)
+    return base
+
+
+def _make_agent_result(text="代码审查通过\nTL;DR: 修复了登录 bug"):
+    return AgentTaskResult(
+        session_id="sess-1",
+        response_text=text,
+        total_tokens=10,
+        total_input_tokens=5,
+        total_output_tokens=5,
+        success=True,
+        error=None,
+    )
+
+
+def _make_gh():
+    gh = MagicMock()
+    gh.get_diff_stats.return_value = {
+        "commits": 1,
+        "additions": 5,
+        "deletions": 1,
+        "files": 1,
+    }
+    gh.git_push.return_value = None
+    gh.get_pr_diff.return_value = "FAKE_DIFF"
+    gh.add_pr_comment.return_value = {}
+    gh.add_issue_comment.return_value = {}
+    return gh
+
+
+def _make_orchestrator(wf):
+    with (
+        patch("app.modules.workspace.autonomous.orchestrator.Database"),
+        patch(
+            "app.modules.workspace.autonomous.orchestrator.AutonomousWorkflowRepository"
+        ) as mock_repo_cls,
+    ):
+        mock_repo = MagicMock()
+        mock_repo.get_workflow.return_value = wf
+        mock_repo_cls.return_value = mock_repo
+        orch = AutonomousOrchestrator(wf["workflow_id"])
+        orch.repo = mock_repo
+    orch.emitter = MagicMock()
+    orch._get_gh = MagicMock()
+    orch._poll_ci_status = MagicMock(return_value=[])
+    orch._smart_truncate_diff = MagicMock(return_value="DIFF_TEXT")
+    orch._clean_agent_text = MagicMock(side_effect=lambda x: x or "")
+    orch._create_milestone = MagicMock(return_value={"milestone_id": "ms-x"})
+    orch._update_workflow = MagicMock()
+    orch._accumulate_tokens = MagicMock()
+    orch._emit = MagicMock()
+    return orch
+
+
+# ── _extract_tldr ────────────────────────────────────────────────────────
+
+
+class TestExtractTldr:
+    """_extract_tldr pulls the agent's appended TL;DR one-liner."""
+
+    def test_extracts_tldr_line(self):
+        r = AutonomousOrchestrator._extract_tldr("工作完成\nTL;DR: 实现了登录功能\n")
+        assert r == "实现了登录功能"
+
+    def test_case_insensitive(self):
+        assert AutonomousOrchestrator._extract_tldr("tl;dr: lower") == "lower"
+        assert AutonomousOrchestrator._extract_tldr("TL;DR: upper") == "upper"
+        assert AutonomousOrchestrator._extract_tldr("Tl;Dr: mixed") == "mixed"
+
+    def test_empty_when_absent(self):
+        assert AutonomousOrchestrator._extract_tldr("no summary here") == ""
+
+    def test_empty_on_empty_input(self):
+        assert AutonomousOrchestrator._extract_tldr("") == ""
+
+    def test_takes_first_when_multiple(self):
+        r = AutonomousOrchestrator._extract_tldr("TL;DR: first\nbody\nTL;DR: second")
+        assert r == "first"
+
+    def test_truncates_over_200(self):
+        r = AutonomousOrchestrator._extract_tldr("TL;DR: " + "x" * 300)
+        assert len(r) == 200
+        assert r == "x" * 200
+
+    def test_strips_surrounding_whitespace(self):
+        r = AutonomousOrchestrator._extract_tldr("TL;DR:   padded summary   ")
+        assert r == "padded summary"
+
+
+# ── TLDR_INSTRUCTION + _run_agent appending ──────────────────────────────
+
+
+class TestTldrInstruction:
+    """TLDR_INSTRUCTION is appended to every _run_agent prompt so each phase
+    agent emits a one-line summary."""
+
+    def test_instruction_contains_tldr_format(self):
+        assert "TL;DR:" in TLDR_INSTRUCTION
+
+    def test_run_agent_appends_instruction(self):
+        orch = _make_orchestrator(_make_workflow())
+        captured = {}
+
+        def fake_run(**kwargs):
+            captured["prompt"] = kwargs.get("prompt", "")
+            return _make_agent_result("ok")
+
+        orch._runner = MagicMock()
+        orch._runner.run_agent_task = MagicMock(side_effect=fake_run)
+        orch._runner._uses_sidebar_session_source = MagicMock(return_value=False)
+        orch._resolve_session_line = MagicMock(return_value=("sess", None, False))
+        orch._link_session_to_current_milestone = MagicMock()
+        orch._is_rate_limited = MagicMock(return_value=False)
+        orch._write_phase_usage = MagicMock()
+
+        orch._run_agent(prompt="基础 prompt")
+
+        # the instruction is appended to the original prompt before it reaches
+        # the runner
+        assert captured["prompt"].startswith("基础 prompt")
+        assert TLDR_INSTRUCTION in captured["prompt"]
+
+
+# ── milestone write carries tldr ──────────────────────────────────────────
+
+
+class TestMilestoneTldrWrite:
+    """Phase milestones persist the extracted tldr alongside result_summary."""
+
+    def test_pr_reviewed_milestone_carries_tldr(self):
+        wf = _make_workflow(current_round=0, max_pr_review_rounds=1)  # review-only round
+        orch = _make_orchestrator(wf)
+        orch._get_gh.return_value = _make_gh()
+        orch.repo.list_milestones.return_value = []
+        review_text = "代码审查完成，发现 2 个小问题但非阻塞\nTL;DR: 审查通过，可合并"
+        orch._run_agent = MagicMock(return_value=_make_agent_result(review_text))
+
+        orch._do_pr_review(wf)
+
+        # find the pr_reviewed update_milestone call (the one carrying review_content)
+        review_updates = [
+            call.args[1]
+            for call in orch.repo.update_milestone.call_args_list
+            if len(call.args) > 1
+            and isinstance(call.args[1], dict)
+            and "review_content" in call.args[1]
+        ]
+        assert review_updates, "pr_reviewed milestone update not captured"
+        # tldr extracted from the agent response, result_summary still the [:200] slice
+        assert review_updates[0]["tldr"] == "审查通过，可合并"
+        assert review_updates[0]["review_content"] == review_text


### PR DESCRIPTION
Closes #993

## 背景

timeline 里程碑卡片信息密度低：只显示标题 + meta pill + 按钮，要了解每轮实质内容必须逐个点开 #989 的全文 modal。`result_summary` 字段已存在且 API 已返回，但前端无组件消费；且它是粗暴 `[:200]` 截断（`tests_run` 是完整测试输出、`pr_updated` 干脆不写），不适合直接贴卡片。

## 方案

每阶段 agent 在输出结尾产一行 `TL;DR: <一句话>`，存独立 `tldr` 字段作为干净的卡片摘要源。卡片优先用 `tldr`、回退 `result_summary`、都空则不占位（line-clamp 2 行纯文本，不渲染 markdown）。

## 改动

**schema + repo**：Alembic 062 加 `workflow_milestones.tldr`（TEXT NOT NULL DEFAULT ''，PG+SQLite 兼容）；repo `ALLOWED_MILESTONE_FIELDS` + `create_milestone` INSERT（双分支 31 列）。

**orchestrator**：
- `TLDR_INSTRUCTION` 在 `_run_agent` 内统一追加（DRY，一处覆盖全部 9 个 phase prompt）；
- `_extract_tldr` 解析（大小写不敏感、取首个、截 200、缺失返回 `""` → 回退 `result_summary`）；
- 9 个 phase milestone 写入 `tldr`（plan_created/refined、plan_reviewed、plan_finalized、dev×2、tests_run、pr_reviewed、pr_review_summary、pr_updated）；
- `result_summary` 写入不动（DB 副本 + 回退源）。

**前端**：`WorkflowMilestone.tldr`；`renderMilestoneCard` 标题下显示 `tldr || result_summary`（compact 卡片跳过）；`.workflow-timeline-card-summary` line-clamp 2 行纯文本，`title` 属性 hover 看完整。

## 验证

- pytest 34 passed（#993 新增 10 + #987 8 + #913 16）
- pre-commit 全 Passed（schema sync / black / ruff / mypy / bandit）
- migration 062 本地 `alembic upgrade head` 成功
- 前端 `npm run lint` 0 errors + `npm run build` 成功
- E2E headless=true 7 passed + headless=false demo 7 passed（tldr 优先 / 回退 result_summary / 都空不占位）

## 边界

- agent 没产 TL;DR → `tldr` 空 → 卡片回退 `result_summary`，降级温和。
- 旧 milestone 无 `tldr` → 回退 `result_summary`；都空则不占位。
- `result_summary` 的 `[:200]` 截断策略不动（保留作 DB 副本 + 回退源）。
- 卡片摘要纯展示不可点击；看全文走 #989 的 View Plan/Review modal。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
