### PR TITLE
fix(autonomous): allow bash in non-plan phases + fix commit fallback (#996)

### DIFF
--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -101,8 +101,10 @@ PLANNING_ALLOWED_TOOLS: dict[str, list[str]] = {
 
 # Development-phase tools: planning read-only set + Write/Edit/Bash so the agent
 # can implement, run tests, and commit. Bash is allowed wholesale (test / git /
-# build commands vary by language and can't be enumerated) — the worktree +
-# feature branch is the security boundary. plan phases stay read-only via
+# build commands vary by language and can't be enumerated). This bounds where
+# commits land (worktree + feature branch); bash itself is NOT sandboxed —
+# cd /, rm -rf, sudo, network egress are all reachable from the worktree cwd,
+# same trust model as any dev agent. plan phases stay read-only via
 # PLANNING_ALLOWED_TOOLS above. See #996.
 AUTONOMOUS_DEV_ALLOWED_TOOLS: dict[str, list[str]] = {
     "claude-code": [
@@ -2409,7 +2411,9 @@ class AutonomousOrchestrator:
 
             # Agent may fail to commit (bash blocked / forgot) — salvage
             # uncommitted changes the way dev does, else the fix never reaches
-            # the PR (#960 symptom). Mirrors _run_development_phase.
+            # the PR (#960 symptom). Adapted from _run_development_phase (no
+            # branch-vs-base check — a no-op fix is genuinely empty, not a
+            # failed dev round).
             commit_sha = ""
             diff_stats = {}
             try:
@@ -2429,9 +2433,14 @@ class AutonomousOrchestrator:
                         sha_changed = True
                 except Exception as e:
                     logger.warning("Fix auto-commit failed: %s", e)
-            try:
-                if sha_changed:
+            if sha_changed:
+                try:
                     gh.git_push()
+                except Exception as e:
+                    # push failure leaves the fix local; the next pr_review
+                    # re-reads the old PR state — log so it's diagnosable.
+                    logger.warning("Fix git_push failed (round %d): %s", round_num, e)
+            try:
                 diff_stats = gh.get_commit_diff_stats(commit_sha) if commit_sha else {}
             except Exception:
                 pass

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -99,6 +99,41 @@ PLANNING_ALLOWED_TOOLS: dict[str, list[str]] = {
     "openclaw": [],
 }
 
+# Development-phase tools: planning read-only set + Write/Edit/Bash so the agent
+# can implement, run tests, and commit. Bash is allowed wholesale (test / git /
+# build commands vary by language and can't be enumerated) — the worktree +
+# feature branch is the security boundary. plan phases stay read-only via
+# PLANNING_ALLOWED_TOOLS above. See #996.
+AUTONOMOUS_DEV_ALLOWED_TOOLS: dict[str, list[str]] = {
+    "claude-code": [
+        "Read",
+        "Glob",
+        "Grep",
+        "WebSearch",
+        "WebFetch",
+        "Agent",
+        "TaskRead",
+        "TaskGet",
+        "TaskList",
+        "Write",
+        "Edit",
+        "Bash",
+    ],
+    "qwen-code-cli": [
+        "read_file",
+        "list_files",
+        "search_files",
+        "code_search",
+        "web_search",
+        "web_fetch",
+        "write_file",
+        "edit_file",
+        "execute_command",
+    ],
+    "codex": [],
+    "openclaw": [],
+}
+
 # Maximum time (seconds) for a single planning agent call.
 # Normal planning should complete in a few minutes; this caps runaway agents.
 PLANNING_TIMEOUT = 600
@@ -1600,6 +1635,7 @@ class AutonomousOrchestrator:
             workspace_type=wf.get("workspace_type", "local"),
             remote_machine_id=wf.get("remote_machine_id"),
             permission_mode=wf.get("permission_mode", "auto-edit"),
+            allowed_tools=AUTONOMOUS_DEV_ALLOWED_TOOLS.get(wf.get("cli_tool", "claude-code"), []),
             session_line="main",
             milestone_id=ms.get("milestone_id", ""),
         )
@@ -1807,6 +1843,7 @@ class AutonomousOrchestrator:
             workspace_type=wf.get("workspace_type", "local"),
             remote_machine_id=wf.get("remote_machine_id"),
             permission_mode=wf.get("permission_mode", "auto-edit"),
+            allowed_tools=AUTONOMOUS_DEV_ALLOWED_TOOLS.get(wf.get("cli_tool", "claude-code"), []),
             session_line="test",
             milestone_id=test_ms.get("milestone_id", ""),
         )
@@ -2200,6 +2237,7 @@ class AutonomousOrchestrator:
             workspace_type=wf.get("workspace_type", "local"),
             remote_machine_id=wf.get("remote_machine_id"),
             permission_mode=wf.get("permission_mode", "auto-edit"),
+            allowed_tools=AUTONOMOUS_DEV_ALLOWED_TOOLS.get(wf.get("cli_tool", "claude-code"), []),
             session_line="review",
             milestone_id=review_ms.get("milestone_id", ""),
         )
@@ -2273,6 +2311,9 @@ class AutonomousOrchestrator:
                 workspace_type=wf.get("workspace_type", "local"),
                 remote_machine_id=wf.get("remote_machine_id"),
                 permission_mode=wf.get("permission_mode", "auto-edit"),
+                allowed_tools=AUTONOMOUS_DEV_ALLOWED_TOOLS.get(
+                    wf.get("cli_tool", "claude-code"), []
+                ),
                 session_line="main",
                 milestone_id=summary_ms.get("milestone_id", ""),
             )
@@ -2337,6 +2378,12 @@ class AutonomousOrchestrator:
                     "如果确认是预先存在的问题，在回复末尾单独一行输出 `CI_STATUS: pre-existing`。"
                 )
 
+            commit_before = ""
+            try:
+                commit_before = gh.get_current_commit()
+            except Exception:
+                pass
+
             fix_result = self._run_agent(
                 wf=wf,
                 workflow_id=self._workflow_id,
@@ -2347,6 +2394,9 @@ class AutonomousOrchestrator:
                 workspace_type=wf.get("workspace_type", "local"),
                 remote_machine_id=wf.get("remote_machine_id"),
                 permission_mode=wf.get("permission_mode", "auto-edit"),
+                allowed_tools=AUTONOMOUS_DEV_ALLOWED_TOOLS.get(
+                    wf.get("cli_tool", "claude-code"), []
+                ),
                 session_line="main",
                 milestone_id=fix_ms.get("milestone_id", ""),
             )
@@ -2357,11 +2407,31 @@ class AutonomousOrchestrator:
             if wf.get("user_feedback", "").strip():
                 self._update_workflow({"user_feedback": ""})
 
+            # Agent may fail to commit (bash blocked / forgot) — salvage
+            # uncommitted changes the way dev does, else the fix never reaches
+            # the PR (#960 symptom). Mirrors _run_development_phase.
             commit_sha = ""
             diff_stats = {}
             try:
-                gh.git_push()
                 commit_sha = gh.get_current_commit()
+            except Exception:
+                pass
+            sha_changed = commit_before and commit_sha and commit_before != commit_sha
+            if not sha_changed:
+                try:
+                    if gh.has_uncommitted_changes():
+                        gh.git_add_all()
+                        gh.git_commit(
+                            f"auto: review fixes (round {round_num})",
+                            no_verify=True,
+                        )
+                        commit_sha = gh.get_current_commit()
+                        sha_changed = True
+                except Exception as e:
+                    logger.warning("Fix auto-commit failed: %s", e)
+            try:
+                if sha_changed:
+                    gh.git_push()
                 diff_stats = gh.get_commit_diff_stats(commit_sha) if commit_sha else {}
             except Exception:
                 pass
@@ -2809,6 +2879,9 @@ class AutonomousOrchestrator:
                 workspace_type=wf.get("workspace_type", "local"),
                 remote_machine_id=wf.get("remote_machine_id"),
                 permission_mode=wf.get("permission_mode", "auto-edit"),
+                allowed_tools=AUTONOMOUS_DEV_ALLOWED_TOOLS.get(
+                    wf.get("cli_tool", "claude-code"), []
+                ),
                 session_line="main",
                 milestone_id=conflict_ms.get("milestone_id", ""),
             )

--- a/tests/issues/996/test_agent_permissions.py
+++ b/tests/issues/996/test_agent_permissions.py
@@ -1,0 +1,169 @@
+"""Tests for autonomous agent bash permission + fix commit fallback (Issue #996).
+
+Verifies:
+  - Non-plan phases pass `AUTONOMOUS_DEV_ALLOWED_TOOLS` (incl. ``Bash``) so the
+    agent can run tests / git / build; plan phases stay read-only.
+  - The fix phase salvages uncommitted changes (mirroring dev) when the agent
+    didn't commit, so review fixes actually reach the PR.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from app.modules.workspace.autonomous.models import AgentTaskResult
+from app.modules.workspace.autonomous.orchestrator import (
+    AUTONOMOUS_DEV_ALLOWED_TOOLS,
+    PLANNING_ALLOWED_TOOLS,
+    AutonomousOrchestrator,
+)
+
+# ── helpers (mirror tests/issues/987/) ───────────────────────────────────
+
+
+def _make_workflow(**overrides):
+    base = {
+        "workflow_id": "test-wf-996",
+        "title": "Test 996",
+        "requirements_text": "REQ",
+        "branch_name": "feature-x",
+        "github_issue_number": 100,
+        "github_pr_number": 42,
+        "current_round": 0,  # round_num = 1
+        "max_pr_review_rounds": 2,  # round(1) < max(2) -> fix branch
+        "dev_round": 1,
+        "cli_tool": "claude-code",
+        "model": "",
+        "worktree_path": "/tmp/wf996",
+        "project_path": "/tmp/wf996",
+        "workspace_type": "local",
+        "remote_machine_id": "",
+        "permission_mode": "auto-edit",
+    }
+    base.update(overrides)
+    return base
+
+
+def _make_agent_result(text="done\nTL;DR: fixed the bug"):
+    return AgentTaskResult(
+        session_id="sess-1",
+        response_text=text,
+        total_tokens=10,
+        total_input_tokens=5,
+        total_output_tokens=5,
+        success=True,
+        error=None,
+    )
+
+
+def _make_gh(commit_sha="abc1234", uncommitted=True):
+    gh = MagicMock()
+    gh.get_diff_stats.return_value = {"commits": 1, "additions": 5, "deletions": 1, "files": 1}
+    gh.get_commit_diff_stats.return_value = {
+        "commits": 1,
+        "additions": 5,
+        "deletions": 1,
+        "files": 1,
+    }
+    gh.git_push.return_value = None
+    gh.get_pr_diff.return_value = "FAKE_DIFF"
+    gh.add_pr_comment.return_value = {}
+    gh.add_issue_comment.return_value = {}
+    gh.get_current_commit.return_value = commit_sha  # same SHA before/after -> triggers fallback
+    gh.has_uncommitted_changes.return_value = uncommitted
+    gh.git_add_all.return_value = None
+    gh.git_commit.return_value = {"sha": commit_sha}
+    return gh
+
+
+def _make_orchestrator(wf):
+    with (
+        patch("app.modules.workspace.autonomous.orchestrator.Database"),
+        patch(
+            "app.modules.workspace.autonomous.orchestrator.AutonomousWorkflowRepository"
+        ) as mock_repo_cls,
+    ):
+        mock_repo = MagicMock()
+        mock_repo.get_workflow.return_value = wf
+        mock_repo_cls.return_value = mock_repo
+        orch = AutonomousOrchestrator(wf["workflow_id"])
+        orch.repo = mock_repo
+    orch.emitter = MagicMock()
+    orch._get_gh = MagicMock()
+    orch._poll_ci_status = MagicMock(return_value=[])
+    orch._smart_truncate_diff = MagicMock(return_value="DIFF_TEXT")
+    orch._clean_agent_text = MagicMock(side_effect=lambda x: x or "")
+    orch._create_milestone = MagicMock(return_value={"milestone_id": "ms-x"})
+    orch._update_workflow = MagicMock()
+    orch._accumulate_tokens = MagicMock()
+    orch._emit = MagicMock()
+    return orch
+
+
+# ── allowed_tools constants ──────────────────────────────────────────────
+
+
+class TestAllowedToolSets:
+    def test_dev_set_includes_bash_write_edit(self):
+        tools = AUTONOMOUS_DEV_ALLOWED_TOOLS["claude-code"]
+        assert "Bash" in tools
+        assert "Write" in tools
+        assert "Edit" in tools
+        # still has the read-only planning tools
+        assert "Read" in tools and "Grep" in tools
+
+    def test_plan_set_excludes_bash_and_writes(self):
+        tools = PLANNING_ALLOWED_TOOLS["claude-code"]
+        assert "Bash" not in tools
+        assert "Write" not in tools
+        assert "Edit" not in tools
+
+
+# ── fix phase: passes Bash + salvages uncommitted changes ────────────────
+
+
+class TestFixPhasePermissionsAndFallback:
+    def test_fix_run_agent_passes_bash_allowed_tools(self):
+        wf = _make_workflow()  # round 1 < max 2 -> fix branch
+        orch = _make_orchestrator(wf)
+        orch._get_gh.return_value = _make_gh()
+        orch.repo.list_milestones.return_value = []
+        orch._run_agent = MagicMock(return_value=_make_agent_result())
+
+        orch._do_pr_review(wf)
+
+        # every _run_agent call in the fix branch carries the dev tool set
+        for call in orch._run_agent.call_args_list:
+            allowed = call.kwargs.get("allowed_tools")
+            assert allowed is not None, "fix/review _run_agent must pass allowed_tools"
+            assert "Bash" in allowed
+
+    def test_fix_salvages_uncommitted_when_agent_did_not_commit(self):
+        wf = _make_workflow()
+        orch = _make_orchestrator(wf)
+        gh = _make_gh(commit_sha="same123", uncommitted=True)
+        orch._get_gh.return_value = gh
+        orch.repo.list_milestones.return_value = []
+        orch._run_agent = MagicMock(return_value=_make_agent_result())
+
+        orch._do_pr_review(wf)
+
+        # agent didn't commit (SHA unchanged) but left uncommitted changes ->
+        # orchestrator salvages via git_add_all + git_commit, then pushes
+        gh.has_uncommitted_changes.assert_called()
+        gh.git_add_all.assert_called_once()
+        gh.git_commit.assert_called_once()
+        assert gh.git_commit.call_args.kwargs.get("no_verify") is True
+        gh.git_push.assert_called()  # pushed after salvage
+
+    def test_fix_no_salvage_when_no_uncommitted_changes(self):
+        wf = _make_workflow()
+        orch = _make_orchestrator(wf)
+        gh = _make_gh(commit_sha="same123", uncommitted=False)
+        orch._get_gh.return_value = gh
+        orch.repo.list_milestones.return_value = []
+        orch._run_agent = MagicMock(return_value=_make_agent_result())
+
+        orch._do_pr_review(wf)
+
+        # SHA unchanged + nothing uncommitted -> no auto-commit, no push
+        gh.git_add_all.assert_not_called()
+        gh.git_commit.assert_not_called()


### PR DESCRIPTION
Closes #996

## 背景

`acceptEdits` 模式下 bash 命令需交互批准，autonomous 工作流非交互 → test/git/conflict 步骤的 bash 全被挡。两个症状：
- **test**：pytest/npm 被阻 → agent 输出 `TEST_STATUS: skipped`（[#851 评论](https://github.com/open-ace/open-ace/issues/851#issuecomment-4682289531)）
- **fix**：git commit/push 被阻 → 改动停留 worktree 未提交。dev 阶段有 orchestrator 兜底，**fix 阶段没有** → fix 改动从未进 PR（[#960 评论](https://github.com/open-ace/open-ace/pull/960#issuecomment-4683068919) 的 `Commit: 0aa5d03d` 实为 dev 遗留 HEAD）

根因不是 open-ace 的 control_request 处理（`agent_runner.py:1023` 在 `allowed_tools=None` 时本就批准所有），而是 **claude-code `acceptEdits` 对 bash 不发 control_request、直接跳过** —— 所以必须用 `--allowedTools Bash` 让 claude-code 免批 bash。

## 改动

**A. 权限**（`orchestrator.py`）
- 新增 `AUTONOMOUS_DEV_ALLOWED_TOOLS`（planning 只读集 + Write/Edit/Bash），传给 6 个非 plan 阶段的 `_run_agent`：dev / test / pr_review / summary / fix / conflict。
- **Bash 全免批**（不遗漏任何语言/工具 —— 测试/git/构建命令跨语言无法穷举，靠 worktree + feature 分支作安全边界）。
- plan 阶段仍 `PLANNING_ALLOWED_TOOLS`（只读，不变）。

**B. fix commit 兜底**（`orchestrator.py`）
- fix 阶段补 dev 的 commit 补救逻辑：`commit_before` + SHA 不变检测 + `has_uncommitted_changes` → `git_add_all` + `git_commit(no_verify=True)` → push。
- 防止 agent git commit 被阻时 fix 改动丢失（#960 bug）。

## 回答两个关键问题

1. **其它阶段有没有类似问题**：test/dev/fix/conflict 都需 bash，都被阻（dev 有 git 兜底、test 有 skip 降级，**fix/conflict 缺兜底**）；plan 类用 `PLANNING_ALLOWED_TOOLS`（只读，不需 bash，不受影响）；pr_review/summary 非强制 bash 但一并放宽（统一）。
2. **allowedTools 如何不遗漏**：穷举 `Bash(pytest:*)`/`Bash(npm:*)`... 不可行（语言/工具多样）；用 `Bash`（无参数，全 bash 免批）一条覆盖，把问题转成"接受所有 bash 免批"的安全决策。

## 验证

- pytest **39 passed**（#996 新增 5 + #993 10 + #987 8 + #913 16）
- pre-commit 全 Passed
- 测试覆盖：dev 集含 Bash（plan 不含）、fix 传 Bash、fix 兜底补救、无改动不补救
- 手动验证（真实环境，待跑）：test 阶段真跑 pytest、fix 改动进 PR、plan 仍只读

## 边界

- **Bash 全免批安全**：agent 能跑任意 bash。缓解：worktree 隔离 + feature 分支 + agent 信任模型。后续可加黑名单（`rm -rf`/`sudo`）或语言检测预设（#996 备选方案）。
- codex/openclaw 给空列表（不限制），bash 由各自 adapter 管；claude-code/qwen 先覆盖。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
