### PR TITLE
fix: Package 版安装脚本添加 SECRET_KEY 环境变量

### DIFF
--- a/scripts/install-central/package-method/install.sh
+++ b/scripts/install-central/package-method/install.sh
@@ -2612,6 +2612,16 @@ install_local() {
     # This ensures new code takes effect after upgrade
     if [ "$DO_UPGRADE" = "yes" ] && command -v systemctl &>/dev/null; then
         if systemctl is-enabled --quiet open-ace.service 2>/dev/null; then
+            # Check if systemd service is missing SECRET_KEY (upgrade from older version)
+            local service_file="/etc/systemd/system/open-ace.service"
+            local current_secret=$(grep "^Environment=SECRET_KEY=" "$service_file" 2>/dev/null | cut -d'=' -f3)
+            if [ -z "$current_secret" ]; then
+                print_warning "Adding missing SECRET_KEY to systemd service..."
+                local secret_key="${SECRET_KEY:-$(openssl rand -hex 32)}"
+                sed -i "/^Environment=HOME=/a Environment=SECRET_KEY=$secret_key" "$service_file"
+                print_info "Generated SECRET_KEY for Flask encryption"
+            fi
+
             print_info "Restarting existing open-ace service..."
             systemctl daemon-reload
             systemctl restart open-ace.service
@@ -3673,6 +3683,22 @@ do_upgrade_remote() {
 
     print_success "Remote upgrade completed"
     print_info "Backup saved to: $backup_dir on $DEPLOY_HOST"
+
+    # Check if systemd service exists on remote and update SECRET_KEY if missing
+    if ssh "$remote" "command -v systemctl &>/dev/null && systemctl is-enabled --quiet open-ace.service 2>/dev/null"; then
+        print_info "Checking systemd service on remote..."
+        local service_file="/etc/systemd/system/open-ace.service"
+        local current_secret=$(ssh "$remote" "grep '^Environment=SECRET_KEY=' $service_file 2>/dev/null | cut -d'=' -f3")
+        if [ -z "$current_secret" ]; then
+            print_warning "Adding missing SECRET_KEY to systemd service on remote..."
+            local secret_key="${SECRET_KEY:-$(openssl rand -hex 32)}"
+            ssh "$remote" "sudo sed -i '/^Environment=HOME=/a Environment=SECRET_KEY=$secret_key' $service_file && sudo systemctl daemon-reload && sudo systemctl restart open-ace.service"
+            print_info "Generated SECRET_KEY for Flask encryption"
+        else
+            print_info "Restarting systemd service on remote..."
+            ssh "$remote" "sudo systemctl restart open-ace.service"
+        fi
+    fi
 }
 
 # ============================================================================

--- a/scripts/install-central/package-method/install.sh
+++ b/scripts/install-central/package-method/install.sh
@@ -1872,6 +1872,10 @@ install_systemd_service() {
     fi
     print_info "Using Python: $python_path"
 
+    # Generate SECRET_KEY for Flask session and API key encryption
+    local secret_key="${SECRET_KEY:-$(openssl rand -hex 32)}"
+    print_info "Generated SECRET_KEY for Flask encryption"
+
     # Create service file from template
     print_info "Creating systemd service file..."
     sed -e "s|__USER__|$user|g" \
@@ -1881,6 +1885,7 @@ install_systemd_service() {
         -e "s|__HOST__|$host|g" \
         -e "s|__PYTHON__|$python_path|g" \
         -e "s|__HOME__|$home_dir|g" \
+        -e "s|__SECRET_KEY__|$secret_key|g" \
         "$service_template" > "$service_file"
 
     if [ $? -ne 0 ]; then
@@ -1975,6 +1980,10 @@ install_systemd_service_remote() {
     fi
     print_info "Using Python on remote: $python_path"
 
+    # Generate SECRET_KEY for Flask session and API key encryption
+    local secret_key="${SECRET_KEY:-$(openssl rand -hex 32)}"
+    print_info "Generated SECRET_KEY for Flask encryption"
+
     # Generate service file content locally using sed
     local service_content=$(sed -e "s|__USER__|$user|g" \
         -e "s|__GROUP__|$group|g" \
@@ -1983,6 +1992,7 @@ install_systemd_service_remote() {
         -e "s|__HOST__|$host|g" \
         -e "s|__PYTHON__|$python_path|g" \
         -e "s|__HOME__|$home_dir|g" \
+        -e "s|__SECRET_KEY__|$secret_key|g" \
         "$service_template")
 
     # If multi-user workspace mode is enabled, allow sudo (set NoNewPrivileges=false)

--- a/scripts/open-ace.service
+++ b/scripts/open-ace.service
@@ -18,6 +18,7 @@ StandardError=journal
 Environment=AI_TOKEN_WEB_PORT=__PORT__
 Environment=AI_TOKEN_WEB_HOST=__HOST__
 Environment=HOME=__HOME__
+Environment=SECRET_KEY=__SECRET_KEY__
 
 # Security settings
 NoNewPrivileges=true


### PR DESCRIPTION
## 问题

Package 版部署后，访问 `/manage/settings/api-keys` 页面返回 Internal Server Error (500)。

**Issue**: #998

## 根因

Package 版 systemd 服务缺少 `SECRET_KEY` 环境变量：
- `APIKeyProxyService` 初始化需要加密密钥来解密存储的 API keys
- Docker 版安装脚本正确配置了 `SECRET_KEY`
- Package 版安装脚本遗漏了此配置

## 修复

| 文件 | 修改 |
|------|------|
| `scripts/open-ace.service` | 添加 `Environment=SECRET_KEY=__SECRET_KEY__` |
| `scripts/install-central/package-method/install.sh` | `install_systemd_service()` 和 `install_systemd_service_remote()` 生成密钥并替换占位符 |

## 验证

node237 (Package 版部署) 验证通过：
- ✅ 服务启动成功，无错误日志
- ✅ `/manage/settings/api-keys` 页面正常显示
- ✅ API Keys 功能恢复正常