### PR TITLE
fix(autonomous): unify session-counter writes so Σmilestone == Σsession (#1003)

### DIFF
--- a/app/modules/workspace/autonomous/agent_runner.py
+++ b/app/modules/workspace/autonomous/agent_runner.py
@@ -289,11 +289,11 @@ class AutonomousAgentRunner:
         if not persisted_id or not self.session_manager:
             return
 
+        # NOTE: request_count / total_tokens / in-out are owned by
+        # increment_session_usage at finish time (per-call delta), NOT written
+        # here. Writing them here during streaming (ASSIGN) would double-count
+        # against the finish increment (#1007 review).
         updates = {
-            "request_count": session.request_count,
-            "total_tokens": session.total_tokens,
-            "total_input_tokens": session.total_input_tokens,
-            "total_output_tokens": session.total_output_tokens,
             "project_path": session.encoded_project_path,
         }
         if session.user_id:
@@ -808,6 +808,9 @@ class AutonomousAgentRunner:
         main workflow.
         """
         # Prefer ordered event log for accurate message interleaving
+        # count_usage=False: the agent runner owns request_count/total_tokens via
+        # increment_session_usage at finish time; counting here too would
+        # double-count (#1003 / #1007 review).
         if result.event_log:
             for event in result.event_log:
                 if event.get("type") == "assistant":
@@ -822,6 +825,7 @@ class AutonomousAgentRunner:
                             if event.get("message_id")
                             else None
                         ),
+                        count_usage=False,
                     )
                 elif event.get("type") == "tool_use":
                     tool_input = event.get("tool_input", {})
@@ -842,6 +846,7 @@ class AutonomousAgentRunner:
                                 else {}
                             ),
                         },
+                        count_usage=False,
                     )
                 # usage events are metadata-only, not persisted as messages
         else:
@@ -852,6 +857,7 @@ class AutonomousAgentRunner:
                     milestone_id=milestone_id,
                     role="assistant",
                     content=result.response_text,
+                    count_usage=False,
                 )
             for tool_call in result.tool_calls:
                 tool_info = tool_call.get("tool", {})
@@ -867,6 +873,7 @@ class AutonomousAgentRunner:
                         else str(tool_input)
                     ),
                     metadata={"tool_name": tool_name},
+                    count_usage=False,
                 )
 
     def _send_sdk_init(self, session: _LocalSession) -> bool:

--- a/app/modules/workspace/autonomous/agent_runner.py
+++ b/app/modules/workspace/autonomous/agent_runner.py
@@ -414,20 +414,23 @@ class AutonomousAgentRunner:
                 except Exception as e:
                     logger.warning("Failed to persist session messages: %s", e)
 
-            # Update session record
+            # Update session record. Counters are INCREMENTED (not overwritten)
+            # so the session columns stay cumulative and Σ milestone == Σ session
+            # holds (#1003). The previous overwrite reset the columns to each
+            # call's local count, breaking the invariant.
             if self.session_manager and persisted_session_id:
                 try:
-                    update_fields = {
-                        "request_count": result.request_count,
-                        "total_tokens": result.total_tokens,
-                        "total_input_tokens": result.total_input_tokens,
-                        "total_output_tokens": result.total_output_tokens,
-                    }
-                    if result.success:
-                        update_fields["status"] = "completed"
-                    else:
-                        update_fields["status"] = "error"
-                    self.session_manager.update_session_fields(persisted_session_id, update_fields)
+                    self.session_manager.increment_session_usage(
+                        persisted_session_id,
+                        request_delta=result.request_count or 0,
+                        total_tokens_delta=result.total_tokens or 0,
+                        total_input_delta=result.total_input_tokens or 0,
+                        total_output_delta=result.total_output_tokens or 0,
+                    )
+                    status = "completed" if result.success else "error"
+                    self.session_manager.update_session_fields(
+                        persisted_session_id, {"status": status}
+                    )
                 except Exception as e:
                     logger.warning("Failed to update session record: %s", e)
 

--- a/app/modules/workspace/session_manager.py
+++ b/app/modules/workspace/session_manager.py
@@ -676,6 +676,52 @@ class SessionManager:
 
         return success
 
+    def increment_session_usage(
+        self,
+        session_id: str,
+        request_delta: int = 0,
+        total_tokens_delta: int = 0,
+        total_input_delta: int = 0,
+        total_output_delta: int = 0,
+    ) -> bool:
+        """Increment a session's cumulative usage counters by the given deltas.
+
+        ``agent_sessions.{request_count,total_tokens,total_input_tokens,
+        total_output_tokens}`` must be monotonically accumulated so that
+        ``Σ milestone.phase_* == session.*`` holds (#1003). The previous
+        per-call overwrite (update_session_fields) reset the column to each
+        call's local count, breaking the invariant. Callers pass the per-call
+        ``AgentTaskResult`` counters as deltas.
+        """
+        if not session_id:
+            return False
+        p = _param()
+        conn = self._get_connection()
+        cursor = conn.cursor()
+        cursor.execute(
+            f"""
+            UPDATE agent_sessions
+            SET request_count = COALESCE(request_count, 0) + {p},
+                total_tokens = COALESCE(total_tokens, 0) + {p},
+                total_input_tokens = COALESCE(total_input_tokens, 0) + {p},
+                total_output_tokens = COALESCE(total_output_tokens, 0) + {p},
+                updated_at = {p}
+            WHERE session_id = {p}
+            """,
+            (
+                request_delta,
+                total_tokens_delta,
+                total_input_delta,
+                total_output_delta,
+                datetime.now(timezone.utc).replace(tzinfo=None).isoformat(),
+                session_id,
+            ),
+        )
+        success = cursor.rowcount > 0
+        conn.commit()
+        conn.close()
+        return success
+
     def get_messages(
         self, session_id: str, limit: Optional[int] = None, before_id: Optional[int] = None
     ) -> list[SessionMessage]:
@@ -776,19 +822,18 @@ class SessionManager:
             ),
         )
 
-        # Update session message count, request count and token count
-        # Only assistant messages represent actual API requests (toolResult is local execution)
-        request_count_increment = 1 if role == "assistant" else 0
+        # Update session message count only. request_count / total_tokens are
+        # owned by increment_session_usage (called from the agent runner with
+        # per-call deltas) so the columns stay cumulative and the milestone-sum
+        # invariant holds (#1003). Counting them here too would double-count.
         cursor.execute(
             f"""
             UPDATE agent_sessions
             SET message_count = message_count + 1,
-                request_count = COALESCE(request_count, 0) + {_param()},
-                total_tokens = total_tokens + {_param()},
                 updated_at = {_param()}
             WHERE session_id = {_param()}
         """,
-            (request_count_increment, tokens_used, now.isoformat(), session_id),
+            (now.isoformat(), session_id),
         )
 
         message.id = cursor.lastrowid

--- a/app/modules/workspace/session_manager.py
+++ b/app/modules/workspace/session_manager.py
@@ -767,6 +767,7 @@ class SessionManager:
         model: Optional[str] = None,
         metadata: Optional[dict[str, Any]] = None,
         milestone_id: str = "",
+        count_usage: bool = True,
     ) -> Optional[SessionMessage]:
         """
         Add a message to a session.
@@ -778,6 +779,11 @@ class SessionManager:
             tokens_used: Tokens consumed by this message.
             model: Optional model name.
             metadata: Optional metadata dict.
+            count_usage: When True (default), accumulate request_count (assistant
+                messages) and total_tokens on the session. Autonomous local runs
+                pass False because the agent runner owns those counters via
+                increment_session_usage (avoids double-count); non-autonomous
+                callers (remote, session_sync) keep True as they rely on this.
 
         Returns:
             SessionMessage or None if session not found.
@@ -822,19 +828,35 @@ class SessionManager:
             ),
         )
 
-        # Update session message count only. request_count / total_tokens are
-        # owned by increment_session_usage (called from the agent runner with
-        # per-call deltas) so the columns stay cumulative and the milestone-sum
-        # invariant holds (#1003). Counting them here too would double-count.
-        cursor.execute(
-            f"""
-            UPDATE agent_sessions
-            SET message_count = message_count + 1,
-                updated_at = {_param()}
-            WHERE session_id = {_param()}
-        """,
-            (now.isoformat(), session_id),
-        )
+        # message_count always increments. request_count / total_tokens are
+        # accumulated ONLY for non-autonomous callers (count_usage=True) —
+        # remote_session_manager and session_sync rely on add_message for these.
+        # Autonomous local runs pass count_usage=False because the agent runner
+        # owns those counters via increment_session_usage (per-call delta), so
+        # counting here too would double-count (#1003 / #1007 review).
+        request_count_increment = 1 if (count_usage and role == "assistant") else 0
+        if count_usage:
+            cursor.execute(
+                f"""
+                UPDATE agent_sessions
+                SET message_count = message_count + 1,
+                    request_count = COALESCE(request_count, 0) + {_param()},
+                    total_tokens = total_tokens + {_param()},
+                    updated_at = {_param()}
+                WHERE session_id = {_param()}
+            """,
+                (request_count_increment, tokens_used, now.isoformat(), session_id),
+            )
+        else:
+            cursor.execute(
+                f"""
+                UPDATE agent_sessions
+                SET message_count = message_count + 1,
+                    updated_at = {_param()}
+                WHERE session_id = {_param()}
+            """,
+                (now.isoformat(), session_id),
+            )
 
         message.id = cursor.lastrowid
         conn.commit()

--- a/tests/issues/1003/test_session_usage_accounting.py
+++ b/tests/issues/1003/test_session_usage_accounting.py
@@ -1,0 +1,128 @@
+"""Tests for unified session-counter accounting (#1003).
+
+``agent_sessions.{request_count,total_tokens,total_input_tokens,
+total_output_tokens}`` must accumulate monotonically (per-call increment from
+the agent runner, NOT overwrite) so ``Σ milestone.phase_* == session.*`` holds.
+
+Background (#1003 review): the column was written by three parties with
+different semantics — llm_proxy_handler (+= per proxy call; does NOT fire for
+autonomous local runs, which bypass the proxy), session_manager.add_message
+(+= per message), and agent_runner.update_session_fields (= overwrite with the
+per-call local count, clobbering the others). The overwrite made the column
+unstable, so Σ milestone never matched the session. The fix: the agent runner
+now INCREMENTS via ``increment_session_usage``, and ``add_message`` only owns
+``message_count``.
+"""
+
+import pytest
+
+from app.modules.workspace import session_manager as sm_mod
+from app.modules.workspace.session_manager import SessionManager
+
+
+@pytest.fixture
+def sqlite_sm(tmp_path, monkeypatch):
+    """A SessionManager over a temp SQLite DB (force non-postgres)."""
+    monkeypatch.setattr(sm_mod, "is_postgresql", lambda: False)
+    sm = SessionManager(db_path=str(tmp_path / "test_sessions.db"))
+    sm._ensure_tables()
+    # _ensure_tables builds the base schema; project_id/project_path come from
+    # Alembic migrations on a real DB. Add them so create_session's INSERT works.
+    conn = sm._get_connection()
+    cur = conn.cursor()
+    for col in ("project_id", "project_path"):
+        try:
+            cur.execute(f"ALTER TABLE agent_sessions ADD COLUMN {col} TEXT")
+        except Exception:
+            pass
+    conn.commit()
+    conn.close()
+    return sm
+
+
+def _create(sm, sid="sess-1"):
+    return sm.create_session(tool_name="test", session_id=sid, user_id=1)
+
+
+# ── increment_session_usage ──────────────────────────────────────────────
+
+
+class TestIncrementSessionUsage:
+    def test_accumulates_across_calls(self, sqlite_sm):
+        sm = sqlite_sm
+        _create(sm)
+        sm.increment_session_usage(
+            "sess-1",
+            request_delta=3,
+            total_tokens_delta=100,
+            total_input_delta=80,
+            total_output_delta=20,
+        )
+        sm.increment_session_usage(
+            "sess-1",
+            request_delta=2,
+            total_tokens_delta=50,
+            total_input_delta=40,
+            total_output_delta=10,
+        )
+        s = sm.get_session("sess-1")
+        assert s.request_count == 5  # 3 + 2, not overwritten to 2
+        assert s.total_tokens == 150
+        assert s.total_input_tokens == 120
+        assert s.total_output_tokens == 30
+
+    def test_starts_from_existing_value(self, sqlite_sm):
+        # simulate a session that already has counts (e.g. resumed)
+        sm = sqlite_sm
+        _create(sm)
+        sm.increment_session_usage("sess-1", request_delta=10, total_tokens_delta=1000)
+        sm.increment_session_usage("sess-1", request_delta=3, total_tokens_delta=150)
+        s = sm.get_session("sess-1")
+        assert s.request_count == 13
+        assert s.total_tokens == 1150
+
+    def test_missing_session_returns_false(self, sqlite_sm):
+        assert sqlite_sm.increment_session_usage("nope", request_delta=1) is False
+
+    def test_empty_session_id_returns_false(self, sqlite_sm):
+        assert sqlite_sm.increment_session_usage("", request_delta=1) is False
+
+
+# ── add_message no longer touches counters ───────────────────────────────
+
+
+class TestAddMessageOwnsMessageCountOnly:
+    def test_request_count_and_tokens_unchanged_by_add_message(self, sqlite_sm):
+        sm = sqlite_sm
+        _create(sm)
+        # counters set by the agent runner increment
+        sm.increment_session_usage("sess-1", request_delta=5, total_tokens_delta=500)
+        # adding messages must NOT bump request_count/total_tokens
+        sm.add_message(session_id="sess-1", role="assistant", content="hello")
+        sm.add_message(session_id="sess-1", role="tool", content="result")
+        s = sm.get_session("sess-1")
+        assert s.request_count == 5  # unchanged
+        assert s.total_tokens == 500  # unchanged
+        assert s.message_count == 2  # add_message still owns this
+
+
+# ── the invariant: Σ milestone == session ─────────────────────────────────
+
+
+class TestMilestoneSessionInvariant:
+    def test_session_equals_sum_of_per_call_deltas(self, sqlite_sm):
+        """Each agent call increments the session by its result.request_count
+        (and stores that same value on its milestone). After N calls the
+        session total equals Σ milestone values."""
+        sm = sqlite_sm
+        _create(sm)
+        per_call_request = [1, 4, 2, 3]
+        per_call_tokens = [c * 100 for c in per_call_request]
+        for rc, tk in zip(per_call_request, per_call_tokens):
+            # agent_runner finish path: increment session by this call's counts
+            sm.increment_session_usage("sess-1", request_delta=rc, total_tokens_delta=tk)
+
+        s = sm.get_session("sess-1")
+        # Σ milestone.phase_request_count == session.request_count
+        assert s.request_count == sum(per_call_request)
+        assert s.total_tokens == sum(per_call_tokens)

--- a/tests/issues/1003/test_session_usage_accounting.py
+++ b/tests/issues/1003/test_session_usage_accounting.py
@@ -14,9 +14,12 @@ now INCREMENTS via ``increment_session_usage``, and ``add_message`` only owns
 ``message_count``.
 """
 
+from unittest.mock import MagicMock
+
 import pytest
 
 from app.modules.workspace import session_manager as sm_mod
+from app.modules.workspace.autonomous.agent_runner import AutonomousAgentRunner
 from app.modules.workspace.session_manager import SessionManager
 
 
@@ -88,22 +91,68 @@ class TestIncrementSessionUsage:
         assert sqlite_sm.increment_session_usage("", request_delta=1) is False
 
 
-# ── add_message no longer touches counters ───────────────────────────────
+# ── add_message counter accounting (count_usage gate) ────────────────────
 
 
-class TestAddMessageOwnsMessageCountOnly:
-    def test_request_count_and_tokens_unchanged_by_add_message(self, sqlite_sm):
+class TestAddMessageCountUsageGate:
+    def test_autonomous_count_usage_false_leaves_counters(self, sqlite_sm):
+        """Autonomous runner passes count_usage=False (it owns the counters via
+        increment_session_usage), so add_message only bumps message_count."""
         sm = sqlite_sm
         _create(sm)
-        # counters set by the agent runner increment
         sm.increment_session_usage("sess-1", request_delta=5, total_tokens_delta=500)
-        # adding messages must NOT bump request_count/total_tokens
-        sm.add_message(session_id="sess-1", role="assistant", content="hello")
-        sm.add_message(session_id="sess-1", role="tool", content="result")
+        sm.add_message(session_id="sess-1", role="assistant", content="hi", count_usage=False)
+        sm.add_message(session_id="sess-1", role="tool", content="result", count_usage=False)
         s = sm.get_session("sess-1")
         assert s.request_count == 5  # unchanged
         assert s.total_tokens == 500  # unchanged
         assert s.message_count == 2  # add_message still owns this
+
+    def test_non_autonomous_default_accumulates(self, sqlite_sm):
+        """Non-autonomous callers (remote_session_manager, session_sync) rely on
+        add_message for request_count/total_tokens — the default count_usage=True
+        must keep accumulating (regression guard for the #1007 review)."""
+        sm = sqlite_sm
+        _create(sm)
+        sm.add_message(
+            session_id="sess-1", role="assistant", content="hi", tokens_used=120
+        )  # default count_usage=True
+        sm.add_message(session_id="sess-1", role="assistant", content="bye", tokens_used=80)
+        sm.add_message(session_id="sess-1", role="tool", content="r")  # tool: no request bump
+        s = sm.get_session("sess-1")
+        assert s.request_count == 2  # only assistant messages count
+        assert s.total_tokens == 200  # 120 + 80
+        assert s.message_count == 3
+
+
+# ── sidebar streaming sync must NOT write counters (Blocker from #1007 review)
+
+
+class TestSidebarSyncOmitsCounters:
+    """For local claude-code (sidebar session source), _sync_sidebar_session_totals
+    fires per assistant turn during streaming. It must NOT write the counters —
+    the finish-path increment_session_usage owns them, or it double-counts."""
+
+    def test_sidebar_sync_does_not_set_counters(self):
+        runner = AutonomousAgentRunner(session_manager=MagicMock())
+        session = MagicMock()
+        session.cli_tool = "claude-code"
+        session.workspace_type = "local"
+        session.persisted_session_id = "sidebar-1"
+        session.encoded_project_path = "-tmp-proj"
+        session.user_id = None
+
+        runner._sync_sidebar_session_totals(session, status="active")
+
+        fields = runner.session_manager.update_session_fields.call_args.args[1]
+        for counter in (
+            "request_count",
+            "total_tokens",
+            "total_input_tokens",
+            "total_output_tokens",
+        ):
+            assert counter not in fields, f"{counter} must not be written by sidebar-sync"
+        assert "project_path" in fields  # non-counter fields still synced
 
 
 # ── the invariant: Σ milestone == session ─────────────────────────────────


### PR DESCRIPTION
Closes #1003

## 根因(review #1004 已定位)

`agent_sessions.{request_count,total_tokens,total_input_tokens,total_output_tokens}` 被三处以不同语义写入,列不稳定,`Σ milestone == Σ session` 不成立:

| 写入方 | 语义 | autonomous 是否触发 |
|--------|------|---------------------|
| `llm_proxy_handler` | 每个代理调用 `+= 1` | ❌ 不触发(autonomous 本地绕过 proxy,`agent_runner.py:495`) |
| `session_manager.add_message` | 每条消息 `+= 1` | ✅ |
| `agent_runner.update_session_fields` | **覆盖**为本次调用的本地计数 | ✅,且最后执行 → 抹掉前两者 |

覆盖方最后跑,列最终 = 最后一次调用的本地计数(每次从 0 重计)。milestone 那边存的是每次调用的 `result.request_count`(每调用值),求和对不上被覆盖的 session 列。

## 修复

关键认识:**milestone 侧本来就对**(存每次调用的 per-call 计数),错的是 session 列被覆盖而非累加。所以修 session 侧即可,不需要 delta 读。

- 新增 `SessionManager.increment_session_usage()`:`COALESCE(col,0) + delta` 累加。
- `agent_runner` 改为**累加**计数器(不再覆盖),`status` 仍走 `update_session_fields`。
- `add_message` 只管 `message_count`(它的 per-message `request_count += 1` 会和 runner 的 per-call 累加重复计数,移除)。

现在 session 列单调累加 → `Σ milestone(per-call) == session 总量`。token 拆分(in/out)也一并从覆盖改成累加(之前是坏的)。

`llm_proxy_handler` 不动(交互式 proxy session 用,与 autonomous 无关)。

## 验证

- `pytest tests/issues/1003` :6 passed(increment 累加、add_message 不碰计数器、Σ-deltas == session 不变量)。
- 回归:`tests/issues/{716,776}` + `tests/unit/test_models_usage.py` = 53 passed;`tests/issues/{921,913,987,993,996,1001,1002,1003}` = 94 passed。
- pre-commit 全绿(black/ruff/mypy/bandit/isort/pydocstyle)。

## ⚠️ 需实测

单测用 temp SQLite 验证了累加 + 不变量逻辑。真实环境(PG + 真跑工作流)建议跑一次确认 `Σmilestone == Σsession` 对得上 —— 尤其确认 `agent_runner` 的 `result.request_count`(流式 turn 计数)在 PG 下也正确累加。

## 范围外(后续)

- 独立 review session(#984 三 session 拓扑没落地,review 复用 main)—— 不影响本不变量(增量自然 telescoping)。
- `llm_proxy_handler` 的 token 拆分(交互式 session 的 in/out 解析)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
