### PR TITLE
fix: add Node.js installation and startup verification (Issue #1006)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,8 +54,17 @@ RUN echo "deb http://mirrors.aliyun.com/debian/ trixie main" > /etc/apt/sources.
     gnupg \
     && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
+    # === Node.js Installation Verification (Issue #1006) ===
+    && test -x /usr/bin/node \
+    && node --version | grep -q '^v20\.' \
+    # Create symlink backup for node (prevent accidental removal, skip if already same file)
+    && sh -c 'test -e /bin/node || ln -sf /usr/bin/node /bin/node' \
+    # === npm and CLI Setup ===
     && npm config set registry https://registry.npmmirror.com/ \
     && npm install -g qwen-code-webui @qwen-code/qwen-code \
+    # === CLI Verification ===
+    && test -f /usr/lib/node_modules/@qwen-code/qwen-code/cli.js \
+    && test -x /usr/bin/qwen-code-webui \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /root/.npm
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -4,10 +4,62 @@
 
 set -e
 
-# If a custom command is passed, execute it directly
+# ============================================================================
+# 0. Pre-flight Validation (Issue #1006)
+# ============================================================================
+validate_node_environment() {
+    echo "Validating Node.js environment..."
+    
+    # Check node executable exists in PATH
+    if ! command -v node &>/dev/null; then
+        echo "ERROR: Node.js not found in PATH. Cannot start container."
+        echo "       This indicates a Docker image build failure."
+        echo "       Please rebuild the image with proper Node.js installation."
+        exit 1
+    fi
+    
+    NODE_PATH=$(which node)
+    
+    # Verify node is executable
+    if [ ! -x "$NODE_PATH" ]; then
+        echo "ERROR: Node.js at $NODE_PATH is not executable."
+        echo "       Please check file permissions or rebuild the image."
+        exit 1
+    fi
+    
+    # Get and display node version
+    NODE_VERSION=$(node --version 2>/dev/null || echo "unknown")
+    echo "  Node.js: $NODE_PATH ($NODE_VERSION)"
+    
+    # Verify CLI file exists
+    CLI_PATH="/usr/lib/node_modules/@qwen-code/qwen-code/cli.js"
+    if [ ! -f "$CLI_PATH" ]; then
+        echo "ERROR: qwen-code CLI not found at $CLI_PATH."
+        echo "       This indicates npm install failed during image build."
+        echo "       Please rebuild the image with proper npm installation."
+        exit 1
+    fi
+    echo "  CLI: $CLI_PATH"
+    
+    # Verify WebUI executable exists
+    WEBUI_PATH=$(which qwen-code-webui 2>/dev/null || echo "/usr/bin/qwen-code-webui")
+    if [ ! -x "$WEBUI_PATH" ]; then
+        echo "ERROR: qwen-code-webui not executable at $WEBUI_PATH."
+        echo "       Please check installation or rebuild the image."
+        exit 1
+    fi
+    echo "  WebUI: $WEBUI_PATH"
+    
+    echo "Node.js environment validated successfully."
+}
+
+# If a custom command is passed, execute it directly (skip validation)
 if [ "$1" != "" ] && [ "$1" != "gunicorn" ]; then
     exec "$@"
 fi
+
+# Run validation before starting the application
+validate_node_environment
 
 echo "=========================================="
 echo "  Open ACE - Starting..."

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -9,7 +9,7 @@ set -e
 # ============================================================================
 validate_node_environment() {
     echo "Validating Node.js environment..."
-    
+
     # Check node executable exists in PATH
     if ! command -v node &>/dev/null; then
         echo "ERROR: Node.js not found in PATH. Cannot start container."
@@ -17,20 +17,20 @@ validate_node_environment() {
         echo "       Please rebuild the image with proper Node.js installation."
         exit 1
     fi
-    
+
     NODE_PATH=$(which node)
-    
+
     # Verify node is executable
     if [ ! -x "$NODE_PATH" ]; then
         echo "ERROR: Node.js at $NODE_PATH is not executable."
         echo "       Please check file permissions or rebuild the image."
         exit 1
     fi
-    
+
     # Get and display node version
     NODE_VERSION=$(node --version 2>/dev/null || echo "unknown")
     echo "  Node.js: $NODE_PATH ($NODE_VERSION)"
-    
+
     # Verify CLI file exists
     CLI_PATH="/usr/lib/node_modules/@qwen-code/qwen-code/cli.js"
     if [ ! -f "$CLI_PATH" ]; then
@@ -40,7 +40,7 @@ validate_node_environment() {
         exit 1
     fi
     echo "  CLI: $CLI_PATH"
-    
+
     # Verify WebUI executable exists
     WEBUI_PATH=$(which qwen-code-webui 2>/dev/null || echo "/usr/bin/qwen-code-webui")
     if [ ! -x "$WEBUI_PATH" ]; then
@@ -49,7 +49,7 @@ validate_node_environment() {
         exit 1
     fi
     echo "  WebUI: $WEBUI_PATH"
-    
+
     echo "Node.js environment validated successfully."
 }
 


### PR DESCRIPTION
## Problem

工作区会话在 "thinking" 后闪退，错误日志显示：
```
CLI process error: spawn /usr/bin/node ENOENT
```

## Root Cause

Docker 镜像构建时 Node.js 安装可能因网络问题失败，导致 `/usr/bin/node` 不存在。Dockerfile 缺少安装验证步骤。

## Solution

### 1. Dockerfile - 构建时验证
- 验证 `/usr/bin/node` 存在且可执行
- 验证 node 版本为 v20.x
- 创建 `/bin/node` 符号链接备份（跳过已存在的同文件情况）
- 验证 CLI 文件和 WebUI 可执行文件存在

### 2. docker-entrypoint.sh - 启动时验证
- 添加 `validate_node_environment()` 函数
- 容器启动前检查 node、CLI、WebUI 是否正常
- 提供清晰的错误信息便于排查

## Verification

在 node236 上验证通过：
```
Validating Node.js environment...
  Node.js: /usr/bin/node (v20.20.2)
  CLI: /usr/lib/node_modules/@qwen-code/qwen-code/cli.js
  WebUI: /usr/bin/qwen-code-webui
Node.js environment validated successfully.
```

Closes #1006