### PR TITLE
fix: LLM Proxy 自动创建 session 并记录消息内容 (Issue #1011)

### DIFF
--- a/app/modules/workspace/llm_proxy_handler.py
+++ b/app/modules/workspace/llm_proxy_handler.py
@@ -147,7 +147,8 @@ def _record_messages(
                                     model=model or resp_data.get("model"),
                                 )
             except (json.JSONDecodeError, ValueError):
-                # Handle SSE streaming response
+                # Handle SSE streaming response - accumulate delta content
+                assistant_content_parts = []
                 for line in response_body.split(b"\n"):
                     line = line.strip()
                     if not line or not line.startswith(b"data:"):
@@ -160,12 +161,23 @@ def _record_messages(
                         choices = chunk.get("choices", [])
                         if choices:
                             delta = choices[0].get("delta", {})
-                            if delta.get("content"):
-                                # For streaming, we only log final usage stats
-                                # Message content would need accumulation
-                                pass
+                            content_part = delta.get("content")
+                            if content_part:
+                                assistant_content_parts.append(content_part)
                     except (json.JSONDecodeError, ValueError):
                         continue
+
+                # Record accumulated assistant message for streaming response
+                if assistant_content_parts:
+                    full_content = "".join(assistant_content_parts)
+                    if full_content:
+                        sm.add_message(
+                            session_id=session_id,
+                            role="assistant",
+                            content=full_content[:10000],
+                            tokens_used=output_tokens,
+                            model=model,
+                        )
     except Exception:
         logger.debug("Failed to record messages", exc_info=True)
 
@@ -240,7 +252,11 @@ def _record_llm_usage(
                 logger.info("Auto-created session %s for user %d", session_id, user_id)
             except Exception as exc:
                 logger.warning("Failed to auto-create session %s: %s", session_id, exc)
-                return
+                # Retry get_session - another concurrent request may have created it
+                session = sm.get_session(session_id)
+                if not session:
+                    logger.error("Session %s still not found after retry", session_id)
+                    return
 
         # Update session token counts
         session.total_input_tokens = (session.total_input_tokens or 0) + input_tokens
@@ -667,7 +683,12 @@ def handle_llm_proxy_request(
                     yield chunk
                 try:
                     _record_llm_usage(
-                        total_content, session_id, user_id, provider, _content_type, request_body=_body
+                        total_content,
+                        session_id,
+                        user_id,
+                        provider,
+                        _content_type,
+                        request_body=_body,
                     )
                 except Exception as exc:
                     logger.error("Failed to record LLM usage: %s", exc)
@@ -687,7 +708,9 @@ def handle_llm_proxy_request(
 
             content = resp.content
             try:
-                _record_llm_usage(content, session_id, user_id, provider, content_type, request_body=body)
+                _record_llm_usage(
+                    content, session_id, user_id, provider, content_type, request_body=body
+                )
             except Exception as exc:
                 logger.error("Failed to record LLM usage: %s", exc)
             return Response(

--- a/app/modules/workspace/llm_proxy_handler.py
+++ b/app/modules/workspace/llm_proxy_handler.py
@@ -83,18 +83,112 @@ def _determine_target_url(
     return f"{target_base}{suffix}"
 
 
-def _record_llm_usage(
-    content: bytes, session_id: str, user_id: int, provider: str, content_type: str
+def _record_messages(
+    sm: Any,
+    session_id: str,
+    request_body: bytes | None,
+    response_body: bytes,
+    output_tokens: int,
+    model: str | None = None,
 ) -> None:
-    """Extract and record token usage from LLM responses."""
+    """Parse request/response and record messages to session_messages."""
+    try:
+        # Parse user messages from request body
+        if request_body:
+            try:
+                req_data = json.loads(request_body)
+                messages = req_data.get("messages", [])
+                if isinstance(messages, list) and messages:
+                    # Record the last user message (avoid duplicates)
+                    user_content = None
+                    for msg in reversed(messages):
+                        if not isinstance(msg, dict):
+                            continue
+                        if msg.get("role") == "user":
+                            content = msg.get("content", "")
+                            if isinstance(content, list):
+                                # Handle multi-part content
+                                text_parts = []
+                                for part in content:
+                                    if isinstance(part, dict) and part.get("type") == "text":
+                                        text_parts.append(part.get("text", ""))
+                                user_content = " ".join(text_parts)
+                            elif isinstance(content, str):
+                                user_content = content
+                            if user_content:
+                                break
+
+                    if user_content:
+                        sm.add_message(
+                            session_id=session_id,
+                            role="user",
+                            content=user_content[:10000],  # Truncate to prevent overflow
+                        )
+            except (json.JSONDecodeError, ValueError):
+                pass
+
+        # Parse assistant message from response body
+        if response_body:
+            try:
+                resp_data = json.loads(response_body)
+                choices = resp_data.get("choices", [])
+                if isinstance(choices, list) and choices:
+                    choice = choices[0]
+                    if isinstance(choice, dict):
+                        msg = choice.get("message", {})
+                        if isinstance(msg, dict) and msg.get("role") == "assistant":
+                            content = msg.get("content", "")
+                            if isinstance(content, str) and content:
+                                sm.add_message(
+                                    session_id=session_id,
+                                    role="assistant",
+                                    content=content[:10000],
+                                    tokens_used=output_tokens,
+                                    model=model or resp_data.get("model"),
+                                )
+            except (json.JSONDecodeError, ValueError):
+                # Handle SSE streaming response
+                for line in response_body.split(b"\n"):
+                    line = line.strip()
+                    if not line or not line.startswith(b"data:"):
+                        continue
+                    payload = line[len(b"data:") :].strip()
+                    if payload == b"[DONE]":
+                        continue
+                    try:
+                        chunk = json.loads(payload)
+                        choices = chunk.get("choices", [])
+                        if choices:
+                            delta = choices[0].get("delta", {})
+                            if delta.get("content"):
+                                # For streaming, we only log final usage stats
+                                # Message content would need accumulation
+                                pass
+                    except (json.JSONDecodeError, ValueError):
+                        continue
+    except Exception:
+        logger.debug("Failed to record messages", exc_info=True)
+
+
+def _record_llm_usage(
+    content: bytes,
+    session_id: str,
+    user_id: int,
+    provider: str,
+    content_type: str,
+    request_body: bytes | None = None,
+) -> None:
+    """Extract and record token usage and messages from LLM responses."""
     try:
         if b"usage" not in content:
             return
 
         usage = None
+        response_model = None
         try:
             data = json.loads(content)
             usage = data.get("usage", {})
+            response_model = data.get("model")
         except json.JSONDecodeError:
             for line in content.split(b"\n"):
                 line = line.strip()
@@ -109,6 +203,7 @@ def _record_llm_usage(
                     continue
                 if "usage" in chunk:
                     usage = chunk["usage"]
+                    response_model = chunk.get("model")
                     break
 
         if not usage or not isinstance(usage, dict):
@@ -131,12 +226,38 @@ def _record_llm_usage(
 
         sm = get_session_manager()
         session = sm.get_session(session_id)
-        if session:
-            session.total_input_tokens = (session.total_input_tokens or 0) + input_tokens
-            session.total_output_tokens = (session.total_output_tokens or 0) + output_tokens
-            session.total_tokens = (session.total_tokens or 0) + input_tokens + output_tokens
-            session.request_count = (session.request_count or 0) + 1
-            sm.update_session(session)
+
+        # Auto-create session if not exists (for WebUI sessions like "webui:1")
+        if not session:
+            try:
+                session = sm.create_session(
+                    session_id=session_id,
+                    session_type="webui",
+                    tool_name="qwen-code",
+                    user_id=user_id,
+                    title="WebUI Session",
+                )
+                logger.info("Auto-created session %s for user %d", session_id, user_id)
+            except Exception as exc:
+                logger.warning("Failed to auto-create session %s: %s", session_id, exc)
+                return
+
+        # Update session token counts
+        session.total_input_tokens = (session.total_input_tokens or 0) + input_tokens
+        session.total_output_tokens = (session.total_output_tokens or 0) + output_tokens
+        session.total_tokens = (session.total_tokens or 0) + input_tokens + output_tokens
+        session.request_count = (session.request_count or 0) + 1
+        sm.update_session(session)
+
+        # Record messages to session_messages table
+        _record_messages(
+            sm=sm,
+            session_id=session_id,
+            request_body=request_body,
+            response_body=content,
+            output_tokens=output_tokens,
+            model=response_model,
+        )
 
         try:
             from app.repositories.daily_stats_repo import DailyStatsRepository
@@ -539,13 +660,15 @@ def handle_llm_proxy_request(
 
             content_type = resp.headers.get("Content-Type", "")
 
-            def generate(_resp=resp, _content_type=content_type):
+            def generate(_resp=resp, _content_type=content_type, _body=body):
                 total_content = b""
                 for chunk in _resp.iter_content(chunk_size=4096):
                     total_content += chunk
                     yield chunk
                 try:
-                    _record_llm_usage(total_content, session_id, user_id, provider, _content_type)
+                    _record_llm_usage(
+                        total_content, session_id, user_id, provider, _content_type, request_body=_body
+                    )
                 except Exception as exc:
                     logger.error("Failed to record LLM usage: %s", exc)
 
@@ -564,7 +687,7 @@ def handle_llm_proxy_request(
 
             content = resp.content
             try:
-                _record_llm_usage(content, session_id, user_id, provider, content_type)
+                _record_llm_usage(content, session_id, user_id, provider, content_type, request_body=body)
             except Exception as exc:
                 logger.error("Failed to record LLM usage: %s", exc)
             return Response(


### PR DESCRIPTION
## 问题背景

Issue #1011: Docker 版 WebUI 会话消息缺失，前端显示无请求数和消息内容

## 根因分析

1. **LLM Proxy 不自动创建 session**: WebUI 使用 `session_id="webui:{user_id}""` 格式，但 `_record_llm_usage` 中 `sm.get_session()` 返回 None

2. **LLM Proxy 不解析消息内容**: `_record_llm_usage` 只提取 token 统计，不解析请求/响应中的消息内容写入 `session_messages` 表

## 修复内容

修改 `app/modules/workspace/llm_proxy_handler.py`：

### 1. 新增 `_record_messages` 函数
- 解析请求体中的用户消息（支持多部分内容）
- 解析响应体中的助手消息（支持完整响应和 SSE 流式响应）
- 写入 `session_messages` 表

### 2. 修改 `_record_llm_usage` 函数
- 自动创建 session（如果不存在）
- 新增 `request_body` 参数用于消息解析
- 调用 `_record_messages` 记录消息

### 3. 修改 `handle_llm_proxy_request` 函数
- 在 `generate` 函数和完整响应处理中传递 `body` 参数

## 测试验证

- ✅ Python 语法检查通过
- ✅ Ruff lint 检查通过
- ✅ 33 个 LLM Proxy handler 测试全部通过
- ✅ 7 个 LLM Proxy failover 测试全部通过

## 关联 Issue

Fixes #1011

🤖 Generated with Qwen Code (9-shotted by Qwen-Coder)