### PR TITLE
fix(audit): 修复用户行为画像datetime timezone处理不一致导致TypeError

### DIFF
--- a/app/modules/compliance/audit.py
+++ b/app/modules/compliance/audit.py
@@ -489,7 +489,10 @@ class AuditAnalyzer:
         all_timestamps = []
         for log in logs:
             if log.timestamp:
-                all_timestamps.append(log.timestamp)
+                ts = log.timestamp
+                if ts.tzinfo is None:
+                    ts = ts.replace(tzinfo=timezone.utc)
+                all_timestamps.append(ts.astimezone())
         for session in sessions_data:
             # Handle both dict and tuple formats
             if isinstance(session, dict):


### PR DESCRIPTION
## 问题

Issue #1015: 审计中心用户行为画像部分用户返回空数据

## 根因

当用户同时有audit_logs和agent_sessions数据时，`all_timestamps`列表混合了：
- offset-naive datetime（来自audit_logs，直接添加未处理）
- offset-aware datetime（来自agent_sessions，经过timezone处理）

调用`min(all_timestamps)`比较时触发TypeError。

## 修复

对audit_logs的时间戳也进行timezone处理，与agent_sessions保持一致。

```python
# 修改前
for log in logs:
    if log.timestamp:
        all_timestamps.append(log.timestamp)

# 修改后
for log in logs:
    if log.timestamp:
        ts = log.timestamp
        if ts.tzinfo is None:
            ts = ts.replace(tzinfo=timezone.utc)
        all_timestamps.append(ts.astimezone())
```

## 验证

修复后所有5个用户都能正常返回数据：
| user_id | 修复前 | 修复后 |
|---------|--------|--------|
| 1 | ❌ 空数据 | ✅ total_actions=13 |
| 2 | ❌ 空数据 | ✅ total_actions=457 |
| 3 | ✅ 412 | ✅ 414 |
| 4 | ✅ 225 | ✅ 225 |
| 5 | ✅ 89 | ✅ 89 |