### PR TITLE
fix: Docker 版配置文件挂载路径修正 (#1014)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,9 @@ services:
       # Workspace base directory (users' projects stored under /workspace/<username>/)
       - WORKSPACE_BASE_DIR=/workspace
     volumes:
-      - ./config:/home/open-ace/.open-ace:ro
+      # CONFIG_DIR: Container runs as root (required for multi-user workspace mode)
+      # ~/.open-ace expands to /root/.open-ace when running as root
+      - ./config:/root/.open-ace:ro
       - ./logs:/app/logs
       # Workspace data: per-user project directories, persisted across restarts
       - workspace-data:/workspace


### PR DESCRIPTION
## 问题描述

Issue #1014：Docker 版配置文件挂载路径不一致导致工作区未配置。

执行 `docker compose down` 后重启服务，访问 `/work` 页面提示"工作区未配置"。

## 根因分析

配置文件挂载路径与应用读取路径不一致：

| 位置 | 路径 | 说明 |
|------|------|------|
| docker-compose.yml | `/home/open-ace/.open-ace` | 挂载目标 |
| 应用代码 (`~/.open-ace`) | `/root/.open-ace` | 容器以 root 运行 |

**原因**：容器以 root 用户运行（多用户 workspace 模式需要 root 权限），`~/.open-ace` 展开为 `/root/.open-ace`。

## 修复方案

修改 docker-compose.yml 挂载路径：
- `/home/open-ace/.open-ace` → `/root/.open-ace`
- 添加注释说明为何使用此路径

## 验证结果

node236 Docker 版部署验证通过：
- 日志显示 `Configuring multi-user workspace mode (env=true, config=true)`
- 之前是 `config=false`，修复后变为 `config=true`