### PR TITLE
fix: Mac 部署脚本和文档中的配置路径问题 (#1019)

### DIFF
--- a/scripts/install-central/docker-method/README-MAC-DEPLOY.md
+++ b/scripts/install-central/docker-method/README-MAC-DEPLOY.md
@@ -120,7 +120,7 @@ cd ~/open-ace
   "host_name": "my-mac",
   "database": {
     "type": "sqlite",
-    "path": "/home/open-ace/.open-ace/ace.db"
+    "path": "/root/.open-ace/ace.db"
   },
   "server": {
     "upload_auth_key": "your-random-key",
@@ -155,7 +155,7 @@ services:
       - SECRET_KEY=your-secret-key
       - UPLOAD_AUTH_KEY=your-upload-key
     volumes:
-      - ./config:/home/open-ace/.open-ace:ro
+      - ./config:/root/.open-ace:ro
       - ./logs:/app/logs
 ```
 

--- a/scripts/install-central/docker-method/README.md
+++ b/scripts/install-central/docker-method/README.md
@@ -169,7 +169,7 @@ chmod 440 /etc/sudoers.d/open-ace-webui
 
 ### 数据持久化
 
-- **配置文件**: `./config/` → `/home/open-ace/.open-ace/`
+- **配置文件**: `./config/` → `/root/.open-ace/`
 - **日志**: `./logs/` → `/app/logs/`
 - **数据库**: Docker volume `postgres-data`
 - **Workspace**: Docker volume `workspace-data` → `/workspace/`

--- a/scripts/install-central/docker-method/quick-install-mac.sh
+++ b/scripts/install-central/docker-method/quick-install-mac.sh
@@ -185,7 +185,7 @@ cat > "$DEPLOY_DIR/config/config.json" << EOF
   "host_name": "$(hostname)",
   "database": {
     "type": "sqlite",
-    "path": "/home/open-ace/.open-ace/ace.db"
+    "path": "/root/.open-ace/ace.db"
   },
   "server": {
     "upload_auth_key": "$UPLOAD_AUTH_KEY",
@@ -233,7 +233,7 @@ services:
       - SECRET_KEY=${SECRET_KEY}
       - UPLOAD_AUTH_KEY=${UPLOAD_AUTH_KEY}
     volumes:
-      - ./config:/home/open-ace/.open-ace:ro
+      - ./config:/root/.open-ace:ro
       - ./logs:/app/logs
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:5000/health')"]


### PR DESCRIPTION
## 问题描述

Issue #1014 修复了 docker-compose.yml 中的配置挂载路径，但 Mac 部署脚本和文档仍使用错误路径 `/home/open-ace/.open-ace`。

## 根因

容器以 root 用户运行（Dockerfile 无 `USER open-ace` 指令），`~/.open-ace` 展开为 `/root/.open-ace`。

## 修改内容

| 文件 | 修改 |
|------|------|
| `quick-install-mac.sh` | 数据库路径和卷挂载路径 |
| `README-MAC-DEPLOY.md` | 文档示例路径 |
| `README.md` | 数据持久化说明路径 |

全部路径从 `/home/open-ace/.open-ace` 修正为 `/root/.open-ace`。

## 关联 Issue

Fixes #1019 (衍生自 #1014)

🤖 Generated with Qwen Code (6-shotted by Qwen-Coder)