### PR TITLE
fix: 仪表盘筛选栏日期控件垂直对齐问题

### DIFF
--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -1088,6 +1088,11 @@ link[rel='dns-prefetch'] {
   outline: 0;
 }
 
+/* Remove margin from form-group in header controls for alignment */
+.page-header-controls .date-input-narrow.form-group {
+  margin-bottom: 0;
+}
+
 /* Dark theme date input calendar icon */
 [data-theme='dark']
   .page-header-controls


### PR DESCRIPTION
## 问题描述

管理模式 → 仪表盘 → 日期选择下拉列表选择 Custom 后，出现 2 个日期选择框，与相邻下拉框高度不一致。

## 根因分析

TextInput 组件外层 `.form-group` 有 `margin-bottom: var(--spacing-md)`，导致与 Select 控件垂直对齐不一致。

## 修复内容

在 `main.css` 中添加样式覆盖，移除 `.page-header-controls` 内 `.date-input-narrow.form-group` 的 margin-bottom。

## 修复效果

所有筛选栏控件垂直居中对齐。

Fixes #899