### PR TITLE
fix: Docker版会话消息无法保存到session_messages表 (#1021)

### DIFF
--- a/app/modules/workspace/session_manager.py
+++ b/app/modules/workspace/session_manager.py
@@ -379,6 +379,12 @@ class SessionManager:
         except Exception:
             pass  # Column already exists
 
+        # Add milestone_id column to session_messages if not present (migration 061)
+        try:
+            cursor.execute("ALTER TABLE session_messages ADD COLUMN milestone_id TEXT DEFAULT ''")
+        except Exception:
+            pass  # Column already exists
+
         conn.commit()
         conn.close()
 

--- a/app/utils/hostname_validator.py
+++ b/app/utils/hostname_validator.py
@@ -175,9 +175,11 @@ def get_hostname_filter_sql() -> str:
     # 2. Not placeholder format (<...>)
     # 3. Length between 1 and 253
     # 4. Not pure hexadecimal (simple check: not all lowercase hex chars)
+    # Note: In PostgreSQL, % must be escaped as %% in LIKE patterns when used with psycopg2
+    # to avoid being interpreted as a parameter placeholder.
     return """
         host_name IS NOT NULL
         AND host_name != ''
-        AND host_name NOT LIKE '<%>'
+        AND host_name NOT LIKE '<%%>'
         AND LENGTH(host_name) BETWEEN 1 AND 253
     """.strip()

--- a/migrations/versions/20260615_182506_merge_063_064.py
+++ b/migrations/versions/20260615_182506_merge_063_064.py
@@ -5,6 +5,7 @@ Revises: 060_fix_agent_identity_boolean, 20260615_063_fix_boolean_retroactive
 Create Date: 2026-06-15 18:25:06.849906
 
 """
+
 from typing import Sequence, Union
 
 from alembic import op
@@ -12,8 +13,11 @@ import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.
-revision: str = '23a7a564f5d8'
-down_revision: Union[str, None] = ('060_fix_agent_identity_boolean', '20260615_063_fix_boolean_retroactive')
+revision: str = "23a7a564f5d8"
+down_revision: Union[str, None] = (
+    "060_fix_agent_identity_boolean",
+    "20260615_063_fix_boolean_retroactive",
+)
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/migrations/versions/20260615_182506_merge_063_064.py
+++ b/migrations/versions/20260615_182506_merge_063_064.py
@@ -8,10 +8,6 @@ Create Date: 2026-06-15 18:25:06.849906
 
 from typing import Sequence, Union
 
-from alembic import op
-import sqlalchemy as sa
-
-
 # revision identifiers, used by Alembic.
 revision: str = "23a7a564f5d8"
 down_revision: Union[str, None] = (

--- a/migrations/versions/20260615_182506_merge_063_064.py
+++ b/migrations/versions/20260615_182506_merge_063_064.py
@@ -1,0 +1,28 @@
+"""merge_063_064
+
+Revision ID: 23a7a564f5d8
+Revises: 060_fix_agent_identity_boolean, 20260615_063_fix_boolean_retroactive
+Create Date: 2026-06-15 18:25:06.849906
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '23a7a564f5d8'
+down_revision: Union[str, None] = ('060_fix_agent_identity_boolean', '20260615_063_fix_boolean_retroactive')
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade database schema."""
+    pass
+
+
+def downgrade() -> None:
+    """Downgrade database schema."""
+    pass


### PR DESCRIPTION
## 关联 Issue

Fixes #1021

## 问题根因

### 核心问题
session_messages 表缺少 milestone_id 列：
- Docker 版数据库未执行 Alembic 迁移（alembic_version 表不存在）
- 表由 session_manager._ensure_tables() 创建，缺少迁移 061 添加的列
- add_message 函数尝试插入 milestone_id 列导致 PostgreSQL 报错：UndefinedColumn

### 次要问题
hostname_validator.py 中 % 字符被 psycopg2 误解析为参数占位符，导致 /api/hosts 返回 500 错误

## 修复内容

| 文件 | 修改内容 |
|------|----------|
| session_manager.py | 在 _ensure_tables() 中添加 milestone_id 列检查和自动添加逻辑 |
| hostname_validator.py | 将 <%> 改为 <%%> 以正确转义 PostgreSQL LIKE 模式 |
| 新增迁移文件 | 20260615_182506_merge_063_064.py - 合并 Alembic 头版本冲突 |

## 验证结果

在 node236 Docker 环境验证通过：
- session_messages 表已正确添加 milestone_id 列
- /api/hosts API 正常返回（空数组）
- 消息保存功能正常：sm.add_message() 成功返回 SessionMessage 对象
- 数据库验证：session_messages 表有新消息记录

## 数据影响

不影响现有数据：
- 仅添加新列，不修改已有记录
- 仅修改 SQL 查询语法