### PR TITLE
fix: i18n issues #878, #873, #852, #845, #820, #819

### DIFF
--- a/frontend/src/components/common/Charts.tsx
+++ b/frontend/src/components/common/Charts.tsx
@@ -20,6 +20,7 @@ import {
 } from 'chart.js';
 import { Line, Bar, Pie, Doughnut } from 'react-chartjs-2';
 import { cn } from '@/utils';
+import { t, type Language } from '@/i18n';
 
 // Register Chart.js components
 ChartJS.register(
@@ -223,6 +224,8 @@ interface BarChartProps {
   unit?: 'none' | 'K' | 'M' | 'B';
   /** User names for tooltip display (used when labels are ranking numbers) */
   usernames?: string[];
+  /** Language for tooltip translation */
+  language?: Language;
 }
 
 export const BarChart: React.FC<BarChartProps> = ({
@@ -236,6 +239,7 @@ export const BarChart: React.FC<BarChartProps> = ({
   className,
   unit = 'none',
   usernames,
+  language,
 }) => {
   // Helper function to format values based on unit
   const formatValue = (value: number): number => {
@@ -293,10 +297,10 @@ export const BarChart: React.FC<BarChartProps> = ({
             return context[0]?.label ?? '';
           },
           label: (context: TooltipItem<'bar'>) => {
-            // For horizontal bar charts with usernames, show "请求数: value"
+            // For horizontal bar charts with usernames, show translated "Requests: value"
             if (horizontal && usernames) {
               const value = context.parsed?.x;
-              return `请求数: ${value?.toLocaleString() ?? 0}`;
+              return `${t('requests', language)}: ${value?.toLocaleString() ?? 0}`;
             }
             // Default format
             const label = context.dataset?.label ?? '';

--- a/frontend/src/components/common/LazyCharts.tsx
+++ b/frontend/src/components/common/LazyCharts.tsx
@@ -12,6 +12,7 @@
 
 import React, { Suspense } from 'react';
 import { Skeleton } from './Loading';
+import type { Language } from '@/i18n';
 
 // Loading fallback component
 const ChartSkeleton: React.FC<{ height?: number }> = ({ height = 300 }) => (
@@ -57,6 +58,8 @@ export interface BarChartProps {
   className?: string;
   unit?: 'none' | 'K' | 'M' | 'B';
   usernames?: string[];
+  /** Language for tooltip translation */
+  language?: Language;
 }
 
 export interface PieChartProps {

--- a/frontend/src/components/features/analysis/ROIAnalysis.tsx
+++ b/frontend/src/components/features/analysis/ROIAnalysis.tsx
@@ -123,6 +123,49 @@ export const ROIAnalysis: React.FC = () => {
     setStartDate(start.toISOString().split('T')[0]);
   }, []);
 
+  // Translate suggestion based on suggestion_type
+  const translateSuggestion = useCallback(
+    (s: OptimizationSuggestion) => {
+      const typeKeyMap: Record<string, { title: string; desc: string }> = {
+        model_switch: {
+          title: 'suggestionModelSwitchTitle',
+          desc: 'suggestionModelSwitchDesc',
+        },
+        usage_pattern: {
+          title: 'suggestionUsagePatternTitle',
+          desc: 'suggestionUsagePatternDesc',
+        },
+        quota_adjustment: {
+          title: 'suggestionQuotaAdjustmentTitle',
+          desc: 'suggestionQuotaAdjustmentDesc',
+        },
+        tool_consolidation: {
+          title: 'suggestionToolConsolidationTitle',
+          desc: 'suggestionToolConsolidationDesc',
+        },
+        time_optimization: {
+          title: 'suggestionTimeOptimizationTitle',
+          desc: 'suggestionTimeOptimizationDesc',
+        },
+        token_optimization: {
+          title: 'suggestionTokenOptimizationTitle',
+          desc: 'suggestionTokenOptimizationDesc',
+        },
+      };
+
+      const keys = typeKeyMap[s.suggestion_type];
+      if (keys) {
+        return {
+          ...s,
+          title: t(keys.title, language),
+          description: t(keys.desc, language),
+        };
+      }
+      return s; // Fallback to original if no mapping found
+    },
+    [language]
+  );
+
   // Fetch data with caching
   const fetchData = useCallback(
     async (forceRefresh = false) => {
@@ -507,25 +550,28 @@ export const ROIAnalysis: React.FC = () => {
                 </tr>
               </thead>
               <tbody>
-                {suggestions.map((s, index) => (
-                  <tr key={index}>
-                    <td>
-                      <strong>{s.title}</strong>
-                    </td>
-                    <td>{s.description}</td>
-                    <td>
-                      <span
-                        className={cn(
-                          'badge',
-                          `bg-${getImpactVariant(s.impact ?? s.priority ?? 'low')}`
-                        )}
-                      >
-                        {s.impact ?? s.priority ?? 'low'}
-                      </span>
-                    </td>
-                    <td>${(s.potential_savings ?? 0).toFixed(2)}</td>
-                  </tr>
-                ))}
+                {suggestions.map((s, index) => {
+                  const translated = translateSuggestion(s);
+                  return (
+                    <tr key={index}>
+                      <td>
+                        <strong>{translated.title}</strong>
+                      </td>
+                      <td>{translated.description}</td>
+                      <td>
+                        <span
+                          className={cn(
+                            'badge',
+                            `bg-${getImpactVariant(translated.impact ?? translated.priority ?? 'low')}`
+                          )}
+                        >
+                          {translated.impact ?? translated.priority ?? 'low'}
+                        </span>
+                      </td>
+                      <td>${(translated.potential_savings ?? 0).toFixed(2)}</td>
+                    </tr>
+                  );
+                })}
               </tbody>
             </table>
           </div>

--- a/frontend/src/components/features/management/RequestDashboard.tsx
+++ b/frontend/src/components/features/management/RequestDashboard.tsx
@@ -357,6 +357,7 @@ export const RequestDashboard: React.FC = () => {
                 height={300}
                 horizontal
                 usernames={userChartData.usernames}
+                language={language}
               />
             ) : (
               <EmptyState icon="bi-people" title={t('noData', language)} />

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -659,6 +659,7 @@ const translations: Record<Language, Translations> = {
 
     // Alert Management
     totalAlerts: 'Total Alerts',
+    alertRules: 'Alert Rules',
     unreadAlerts: 'Unread Alerts',
     criticalAlerts: 'Critical Alerts',
     unreadCount: 'Unread Count',
@@ -804,11 +805,26 @@ const translations: Record<Language, Translations> = {
     efficiencyReport: 'Efficiency Report',
     overallEfficiency: 'Overall Efficiency',
     avgCostPerRequest: 'Avg Cost/Request',
+    avgTokensPerRequest: 'Avg Tokens/Request',
     wastePercentage: 'Waste %',
     optimizationSuggestions: 'Optimization Suggestions',
     potentialSavings: 'Potential Savings',
     noSuggestions: 'No optimization suggestions available',
     impact: 'Impact',
+
+    // ROI Optimization Suggestions
+    suggestionModelSwitchTitle: 'Switch to cheaper model for simple tasks',
+    suggestionModelSwitchDesc: 'Consider using a more cost-effective model for shorter requests',
+    suggestionUsagePatternTitle: 'Optimize usage patterns',
+    suggestionUsagePatternDesc: 'Adjust usage patterns for better efficiency',
+    suggestionQuotaAdjustmentTitle: 'Adjust quota allocation',
+    suggestionQuotaAdjustmentDesc: 'Review and optimize quota limits for better resource utilization',
+    suggestionToolConsolidationTitle: 'Consolidate tool usage',
+    suggestionToolConsolidationDesc: 'Reduce redundant tool usage to improve efficiency',
+    suggestionTimeOptimizationTitle: 'Optimize timing',
+    suggestionTimeOptimizationDesc: 'Schedule tasks during off-peak hours for better performance',
+    suggestionTokenOptimizationTitle: 'Reduce token waste',
+    suggestionTokenOptimizationDesc: 'Minimize unnecessary token consumption',
 
     // Tenant Management
     totalTenants: 'Total Tenants',
@@ -1834,6 +1850,7 @@ const translations: Record<Language, Translations> = {
 
     // Alert Management
     totalAlerts: '总告警数',
+    alertRules: '告警规则',
     unreadAlerts: '未读告警',
     criticalAlerts: '严重告警',
     unreadCount: '未读数量',
@@ -1976,11 +1993,26 @@ const translations: Record<Language, Translations> = {
     efficiencyReport: '效率报告',
     overallEfficiency: '整体效率',
     avgCostPerRequest: '平均成本/请求',
+    avgTokensPerRequest: '平均 Tokens/请求',
     wastePercentage: '浪费百分比',
     optimizationSuggestions: '优化建议',
     potentialSavings: '潜在节省',
     noSuggestions: '暂无优化建议',
     impact: '影响',
+
+    // ROI Optimization Suggestions
+    suggestionModelSwitchTitle: '切换到更便宜的模型处理简单任务',
+    suggestionModelSwitchDesc: '考虑使用更经济的模型处理较短的请求',
+    suggestionUsagePatternTitle: '优化使用模式',
+    suggestionUsagePatternDesc: '调整使用模式以提高效率',
+    suggestionQuotaAdjustmentTitle: '调整配额分配',
+    suggestionQuotaAdjustmentDesc: '审查并优化配额限制以提高资源利用率',
+    suggestionToolConsolidationTitle: '整合工具使用',
+    suggestionToolConsolidationDesc: '减少冗余的工具使用以提高效率',
+    suggestionTimeOptimizationTitle: '优化时间安排',
+    suggestionTimeOptimizationDesc: '将任务安排在非高峰时段以获得更好的性能',
+    suggestionTokenOptimizationTitle: '减少 Token 浪费',
+    suggestionTokenOptimizationDesc: '最小化不必要的 Token 消耗',
 
     // Tenant Management
     totalTenants: '总租户数',

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -818,7 +818,8 @@ const translations: Record<Language, Translations> = {
     suggestionUsagePatternTitle: 'Optimize usage patterns',
     suggestionUsagePatternDesc: 'Adjust usage patterns for better efficiency',
     suggestionQuotaAdjustmentTitle: 'Adjust quota allocation',
-    suggestionQuotaAdjustmentDesc: 'Review and optimize quota limits for better resource utilization',
+    suggestionQuotaAdjustmentDesc:
+      'Review and optimize quota limits for better resource utilization',
     suggestionToolConsolidationTitle: 'Consolidate tool usage',
     suggestionToolConsolidationDesc: 'Reduce redundant tool usage to improve efficiency',
     suggestionTimeOptimizationTitle: 'Optimize timing',


### PR DESCRIPTION
## 修复内容

本 PR 修复了 6 个国际化（i18n）相关问题：

### 需修复的 Issue

| Issue | 问题描述 | 修复方案 |
|-------|----------|----------|
| #878 | Charts.tsx tooltip 硬编码中文"请求数" | 添加 `language` 参数，使用 `t('requests', language)` |
| #845 | 缺少 `alertRules` 翻译键 | 添加翻译键（中英文） |
| #820 | 缺少 `avgTokensPerRequest` 翻译键 | 添加翻译键（中英文） |
| #819 | ROI 优化建议 title/description 显示英文 | 添加翻译键 + 前端映射函数 |

### 验证无需修复的 Issue

| Issue | 原因 |
|-------|------|
| #873 | 翻译键已存在，代码正确使用 `t()` 函数 |
| #852 | 翻译键已存在，前端已实现 `getReportTypeName/getReportTypeDesc` 翻译函数 |

## 修改文件

- `frontend/src/i18n/index.ts` - 添加翻译键
- `frontend/src/components/common/Charts.tsx` - tooltip 国际化
- `frontend/src/components/features/analysis/ROIAnalysis.tsx` - 优化建议翻译

## 测试验证

- ✅ 前端构建通过 (`npm run build`)