### PR TITLE
fix: AutonomousWorkflowList batch delete flaky test

### DIFF
--- a/frontend/src/components/work/AutonomousWorkflowList.test.tsx
+++ b/frontend/src/components/work/AutonomousWorkflowList.test.tsx
@@ -291,8 +291,19 @@ describe('AutonomousWorkflowList', () => {
       <AutonomousWorkflowList selectedId={null} onSelect={vi.fn()} onClearSelection={vi.fn()} />
     );
 
+    // Let component state updates complete (debounce, useEffect, etc.)
+    act(() => {
+      vi.runAllTimers();
+    });
+
     const deleteButton = screen.getByTitle('Delete');
     fireEvent.click(deleteButton);
+
+    // Let confirmation state update complete
+    act(() => {
+      vi.runAllTimers();
+    });
+
     fireEvent.click(screen.getByText('Delete this workflow?'));
 
     expect(mockDeleteBatchMutate).toHaveBeenCalledWith('batch-33');


### PR DESCRIPTION
## Summary

Fix test deletes an entire batch from the batch header action that fails in CI due to timing issues when using vi.useFakeTimers().

## Root Cause

- Test uses getByTitle which does not wait for async rendering
- vi.useFakeTimers() blocks the findBy* wait mechanism
- CI environment timing differs from local

## Solution

Use act() + vi.runAllTimers() to ensure state updates complete before querying elements, keeping the synchronous getBy* approach.

## Testing

Local: npm test -- --run AutonomousWorkflowList.test.tsx (8 tests passed)

Fixes #1026