### PR TITLE
fix: 为认证操作添加审计日志记录 (Issues #844, #843)

### DIFF
--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -14,6 +14,7 @@ import filetype
 from flask import Blueprint, jsonify, make_response, request
 
 from app.auth.decorators import public_endpoint
+from app.modules.governance.audit_logger import AuditAction, AuditLogger
 from app.repositories.user_repo import UserRepository
 from app.services.auth_service import AuthService
 
@@ -26,6 +27,7 @@ logger = logging.getLogger(__name__)
 auth_bp = Blueprint("auth", __name__)
 auth_service = AuthService()
 user_repo = UserRepository()
+audit_logger = AuditLogger()
 
 
 def _validate_avatar_url(user_id: int, avatar_url: Optional[str]) -> Optional[str]:
@@ -114,7 +116,29 @@ def api_login():
         except Exception as e:
             logger.warning(f"Failed to pre-start webui on login: {e}")
 
+        # Log successful login
+        audit_logger.log_action(
+            action=AuditAction.LOGIN,
+            user_id=user["id"],
+            username=user["username"],
+            resource_type="session",
+            resource_id=token_or_error[:16],
+            ip_address=request.remote_addr,
+            user_agent=request.headers.get("User-Agent", ""),
+        )
+
         return response
+
+    # Log failed login attempt
+    audit_logger.log_action(
+        action=AuditAction.LOGIN_FAILED,
+        username=username,
+        resource_type="session",
+        ip_address=request.remote_addr,
+        user_agent=request.headers.get("User-Agent", ""),
+        success=False,
+        error_message=token_or_error,
+    )
 
     return jsonify({"error": token_or_error}), 401
 
@@ -127,8 +151,23 @@ def api_logout():
         "Authorization", ""
     ).replace("Bearer ", "")
 
+    # Get session info before logout for audit logging
+    session = auth_service.get_session(token) if token else None
+
     if token:
         auth_service.logout(token)
+
+    # Log logout action
+    if session:
+        audit_logger.log_action(
+            action=AuditAction.LOGOUT,
+            user_id=session.get("user_id"),
+            username=session.get("username"),
+            resource_type="session",
+            resource_id=token[:16] if token else None,
+            ip_address=request.remote_addr,
+            user_agent=request.headers.get("User-Agent", ""),
+        )
 
     response = make_response(jsonify({"success": True}))
     response.delete_cookie("session_token")
@@ -306,12 +345,23 @@ def api_change_password():
         return jsonify({"error": "Current password and new password required"}), 400
 
     user_id = int(session_or_error.get("user_id", 0))
+    username = session_or_error.get("username")
 
     success, error = auth_service.change_password(
         user_id, current_password, new_password, verify_password, hash_password
     )
 
     if success:
+        # Log password change
+        audit_logger.log_action(
+            action=AuditAction.USER_PASSWORD_CHANGE,
+            user_id=user_id,
+            username=username,
+            resource_type="user",
+            resource_id=str(user_id),
+            ip_address=request.remote_addr,
+            user_agent=request.headers.get("User-Agent", ""),
+        )
         return jsonify({"success": True, "message": "Password changed successfully"})
 
     return jsonify({"error": error}), 400

--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -122,7 +122,6 @@ def api_login():
             user_id=user["id"],
             username=user["username"],
             resource_type="session",
-            resource_id=token_or_error[:16],
             ip_address=request.remote_addr,
             user_agent=request.headers.get("User-Agent", ""),
         )
@@ -164,7 +163,6 @@ def api_logout():
             user_id=session.get("user_id"),
             username=session.get("username"),
             resource_type="session",
-            resource_id=token[:16] if token else None,
             ip_address=request.remote_addr,
             user_agent=request.headers.get("User-Agent", ""),
         )


### PR DESCRIPTION
## 问题描述

Issues #844 和 #843 都涉及审计分析页面数据缺失问题：
- #844: 操作分布图表无数据显示
- #843: 登录模式无数据显示

## 问题原因

`app/routes/auth.py` 中缺少审计日志记录，导致：
- 登录成功/失败操作未记录
- 注销操作未记录
- 修改密码操作未记录

## 修复内容

在 `auth.py` 中添加以下审计日志记录：

| 操作 | 位置 | AuditAction |
|------|------|-------------|
| 登录成功 | `api_login()` | `LOGIN` |
| 登录失败 | `api_login()` | `LOGIN_FAILED` |
| 注销 | `api_logout()` | `LOGOUT` |
| 修改密码 | `api_change_password()` | `USER_PASSWORD_CHANGE` |

## 测试结果

- 单元测试：85 passed
- 语法检查：通过

## 预期效果

修复后：
- 操作分布图表将显示 `login`、`logout`、`login_failed`、`user_password_change` 等操作类型
- 登录模式图表将显示登录时段分布数据

Fixes #844
Fixes #843