### PR TITLE
fix: 统一 Docker 容器命名并添加升级向后兼容检测 (#1032)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,13 +13,13 @@ services:
   # ===========================================================================
   # Main Application
   # ===========================================================================
-  open-ace-web:
+  open-ace:
     build:
       context: .
       dockerfile: Dockerfile
       target: production
     image: ${IMAGE_NAME:-open-ace:latest}
-    container_name: open-ace-web
+    container_name: open-ace
     restart: unless-stopped
     ports:
       - "${PORT:-5000}:5000"
@@ -74,7 +74,7 @@ services:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro
       - ./ssl:/etc/nginx/ssl:ro
     depends_on:
-      - open-ace-web
+      - open-ace
     networks:
       - open-ace-network
     profiles:

--- a/scripts/install-central/docker-method/install.sh
+++ b/scripts/install-central/docker-method/install.sh
@@ -2062,19 +2062,29 @@ build_docker_image() {
 # ============================================================================
 
 # Detect existing Open ACE deployment
+# Supports two container names:
+#   - open-ace: current version (install.sh generated deployment)
+#   - open-ace-web: legacy version (source directory docker-compose.yml)
 # Returns: 0 if deployment exists, 1 if not
 detect_existing_deployment() {
-    local container_name="open-ace"
-
-    # Check if open-ace container exists
-    if ! docker ps -a --format '{{.Names}}' 2>/dev/null | grep -q "^${container_name}$"; then
+    local found_container=""
+    
+    # Check for existing containers with either name
+    for container_name in "open-ace" "open-ace-web"; do
+        if docker ps -a --format '{{.Names}}' 2>/dev/null | grep -q "^${container_name}$"; then
+            found_container="$container_name"
+            break
+        fi
+    done
+    
+    if [ -z "$found_container" ]; then
         return 1
     fi
 
     # Get deployment directory from container mount info
     # The container mounts config directory at /root/.open-ace (read-only)
     # We need to find the mount where Destination is /root/.open-ace
-    local deploy_config_dir=$(docker inspect ${container_name} --format \
+    local deploy_config_dir=$(docker inspect ${found_container} --format \
         '{{ range .Mounts }}{{ if eq .Destination "/root/.open-ace" }}{{ .Source }}{{ end }}{{ end }}' 2>/dev/null)
 
     if [ -z "$deploy_config_dir" ]; then
@@ -2211,6 +2221,20 @@ show_upgrade_summary() {
 # Execute upgrade deployment
 upgrade_deployment() {
     print_header "执行升级"
+
+    # Stop and remove old containers before upgrade
+    # This handles both current (open-ace) and legacy (open-ace-web) container names
+    # to avoid port conflicts during upgrade
+    print_info "清理旧容器..."
+    for old_container in "open-ace" "open-ace-web"; do
+        if docker ps -a --format '{{.Names}}' 2>/dev/null | grep -q "^${old_container}$"; then
+            print_info "停止容器: $old_container"
+            docker stop "$old_container" 2>/dev/null || true
+            print_info "删除容器: $old_container"
+            docker rm "$old_container" 2>/dev/null || true
+        fi
+    done
+    print_success "旧容器清理完成"
 
     # Get source directory from script location
     # Script is at scripts/install-central/docker-method/install.sh

--- a/scripts/install-central/docker-method/install.sh
+++ b/scripts/install-central/docker-method/install.sh
@@ -2068,7 +2068,7 @@ build_docker_image() {
 # Returns: 0 if deployment exists, 1 if not
 detect_existing_deployment() {
     local found_container=""
-    
+
     # Check for existing containers with either name
     for container_name in "open-ace" "open-ace-web"; do
         if docker ps -a --format '{{.Names}}' 2>/dev/null | grep -q "^${container_name}$"; then
@@ -2076,7 +2076,7 @@ detect_existing_deployment() {
             break
         fi
     done
-    
+
     if [ -z "$found_container" ]; then
         return 1
     fi


### PR DESCRIPTION
修复 Issue #1032：Docker 升级容器名不一致导致升级检测失败和端口冲突

问题：
- 源码目录 docker-compose.yml 使用容器名 open-ace-web
- install.sh 生成的部署使用容器名 open-ace
- 升级检测逻辑只检测 open-ace，无法识别旧版本部署

修复：
- docker-compose.yml: 容器名改为 open-ace
- install.sh: 支持检测两种容器名，前置清理旧容器

node236 验证通过

Closes #1032