### PR TITLE
fix: stop 529 retry loop after workflow is marked failed/cancelled

### DIFF
--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -806,6 +806,7 @@ class AutonomousOrchestrator:
             _status = (self.workflow or {}).get("status")
             if _status in ("failed", "cancelled"):
                 logger.info("API error retry aborted (workflow status=%s)", _status)
+                self._synthesize_transient_failure(result)
                 self._write_phase_usage(milestone_id, result)
                 with self._session_lock:
                     self._current_session_id = result.session_id
@@ -845,6 +846,7 @@ class AutonomousOrchestrator:
                 slept += _CANCEL_POLL_INTERVAL
                 if self._cancel_requested.is_set():
                     logger.info("API error retry cancelled (cancel requested)")
+                    self._synthesize_transient_failure(result)
                     self._write_phase_usage(milestone_id, result)
                     with self._session_lock:
                         self._current_session_id = result.session_id
@@ -861,24 +863,13 @@ class AutonomousOrchestrator:
             if result.session_id:
                 self._link_session_to_current_milestone(result.session_id)
 
-        # If the runner reported success but the body is a transient API error
-        # that didn't resolve (e.g. a 529 "overloaded" body returned as
-        # assistant_text with no tokens generated), synthesize a failure so
-        # callers mark the milestone failed and don't store the error body as
-        # plan/review content. The tokens==0 gate avoids flagging a legitimate
-        # plan that merely mentions these phrases. #1001.
-        if result.success and self._is_transient_api_error(result.response_text or ""):
-            if (result.total_tokens or 0) == 0:
-                err_snippet = (result.response_text or "")[:200]
-                logger.warning(
-                    "API error response unresolved after retries, marking failed: %s",
-                    err_snippet,
-                )
-                result.success = False
-                result.error = (
-                    result.error or f"Transient API error not resolved after retries: {err_snippet}"
-                )
-                result.response_text = ""  # don't let callers store the error body
+        # A transient-error body (e.g. a 529 "overloaded" returned as
+        # assistant_text with no tokens generated) must not be handed back as a
+        # success — callers would store it as plan/review content. The tokens==0
+        # gate avoids flagging a legitimate plan that merely mentions these
+        # phrases. #1001. Centralized in a helper so the retry loop's early-exit
+        # paths (status failed/cancelled, cancel-requested) apply it too. #1036.
+        self._synthesize_transient_failure(result)
 
         # Attribute this call's own usage to its milestone (increment, not cumulative).
         self._write_phase_usage(milestone_id, result)
@@ -886,6 +877,32 @@ class AutonomousOrchestrator:
         with self._session_lock:
             self._current_session_id = result.tracking_session_id or result.session_id
         return result
+
+    def _synthesize_transient_failure(self, result: AgentTaskResult) -> None:
+        """Synthesize a failure if the result body is an unresolved transient
+        API error (e.g. a 529 "overloaded" body returned as assistant_text with
+        no tokens generated).
+
+        Prevents callers from storing the error body as plan/review content.
+        The ``tokens==0`` gate avoids flagging a legitimate plan that merely
+        mentions these phrases. Centralized here so the retry loop's post-loop
+        path AND its early-exit paths (status failed/cancelled, cancel-requested)
+        all apply it consistently. #1001, #1036.
+        """
+        if not (result.success and self._is_transient_api_error(result.response_text or "")):
+            return
+        if (result.total_tokens or 0) != 0:
+            return
+        err_snippet = (result.response_text or "")[:200]
+        logger.warning(
+            "API error response unresolved after retries, marking failed: %s",
+            err_snippet,
+        )
+        result.success = False
+        result.error = (
+            result.error or f"Transient API error not resolved after retries: {err_snippet}"
+        )
+        result.response_text = ""  # don't let callers store the error body
 
     def _write_phase_usage(self, milestone_id: str, result: AgentTaskResult) -> None:
         """Write this call's token/request increment to its milestone."""

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -799,6 +799,18 @@ class AutonomousOrchestrator:
         retry_start = time.monotonic()
         delay = API_RETRY_INITIAL_DELAY
         while (time.monotonic() - retry_start) < API_RETRY_TOTAL_TIMEOUT:
+            # Re-check workflow status each iteration: a failure/cancellation
+            # set on the row (by a concurrent path or a prior failure in this
+            # advance()) must abort retries, otherwise we keep spawning agent
+            # subprocesses on a dead workflow for the full 30-min window. #1029
+            _status = (self.workflow or {}).get("status")
+            if _status in ("failed", "cancelled"):
+                logger.info("API error retry aborted (workflow status=%s)", _status)
+                self._write_phase_usage(milestone_id, result)
+                with self._session_lock:
+                    self._current_session_id = result.session_id
+                return result
+
             response_text = result.response_text or ""
             error_text = result.error or ""
             if not (
@@ -989,7 +1001,7 @@ class AutonomousOrchestrator:
             logger.error("Workflow %s not found", self._workflow_id)
             return
 
-        if wf.get("status") == "paused":
+        if wf.get("status") in ("paused", "failed", "cancelled"):
             return
 
         phase = wf.get("current_phase", "preparation")

--- a/tests/issues/1001/test_api_error_retry.py
+++ b/tests/issues/1001/test_api_error_retry.py
@@ -180,3 +180,57 @@ class TestRunAgentApiErrorRetry:
 
         assert result.success is True  # not synthesized away
         assert "## Plan" in result.response_text
+
+
+class TestRunAgentAbortOnFailedStatus:
+    """Regression: a workflow marked failed/cancelled mid-retry must abort
+    instead of spawning agents for the full 30-min window (#1036)."""
+
+    def test_aborts_retry_when_workflow_marked_failed(self, monkeypatch):
+        # time.sleep is a no-op so backoff is instant; retry window is large so
+        # the loop WOULD keep going if not for the status check.
+        monkeypatch.setattr("time.sleep", lambda *a, **k: None)
+        monkeypatch.setattr(orch_module, "API_RETRY_TOTAL_TIMEOUT", 1800)
+        wf_failed = _make_workflow(status="failed")
+        o = _make_orchestrator(wf_failed)
+        # First (and only) agent call returns a 529 transient-error body.
+        err = AgentTaskResult(
+            session_id="s1",
+            response_text="API Error: 529 [1305][The service may be temporarily overloaded]",
+            total_tokens=0,
+            success=True,
+        )
+        o._runner.run_agent_task = MagicMock(return_value=err)
+
+        result = o._run_agent(wf=wf_failed, prompt="x")
+
+        # No re-spawn: run_agent_task called exactly once (the initial call).
+        assert o._runner.run_agent_task.call_count == 1
+        # Usage was still attributed to the milestone.
+        o._write_phase_usage.assert_called_once()
+        # No api_error_retry event emitted (status check bails before that).
+        emitted_types = [c.args[0] for c in o._emit.call_args_list]
+        assert "api_error_retry" not in emitted_types
+        # The 529 body was synthesized to a failure even on early exit (#1036).
+        assert result.success is False
+        assert result.response_text == ""
+        assert result.error and "529" in result.error
+
+    def test_aborts_retry_when_workflow_marked_cancelled(self, monkeypatch):
+        monkeypatch.setattr("time.sleep", lambda *a, **k: None)
+        monkeypatch.setattr(orch_module, "API_RETRY_TOTAL_TIMEOUT", 1800)
+        wf_cancelled = _make_workflow(status="cancelled")
+        o = _make_orchestrator(wf_cancelled)
+        err = AgentTaskResult(
+            session_id="s1",
+            response_text="API Error: 503 Service Unavailable",
+            total_tokens=0,
+            success=True,
+        )
+        o._runner.run_agent_task = MagicMock(return_value=err)
+
+        result = o._run_agent(wf=wf_cancelled, prompt="x")
+
+        assert o._runner.run_agent_task.call_count == 1  # no re-spawn
+        assert result.success is False  # synthesized on early exit
+        assert result.response_text == ""


### PR DESCRIPTION
## Problem

The `_run_agent` 529/overload retry loop (up to 30 min via `API_RETRY_TOTAL_TIMEOUT=1800`) only checked two exit conditions:
1. The error no longer being transient (no longer a 529/5xx/overload)
2. `_cancel_requested` being set

**It never re-read the workflow status.** So once a workflow was marked `failed` (e.g. `Development failed: agent produced no code changes`) during or before an in-flight `advance()`, the loop kept spawning fresh `claude` subprocesses and retrying 529 errors until the full 30-min window elapsed — burning tokens on a dead workflow.

### Observed
Workflow #863 was marked `failed` at **11:58 CST** (`completed_at=2026-06-16 03:58:42 UTC`), but:
- A new agent (**PID 38422**) was still spawned at **12:13 CST**
- `api_error_retry` events continued at 04:02, 04:06, 04:11 UTC (≈12:02–12:11 CST)
- A final `workflow_updated` at 04:24 UTC (12:24 CST)
- Only ~25 min after the failure did retries finally stop.

## Root cause
`app/modules/workspace/autonomous/orchestrator.py`, `_run_agent` retry loop (lines ~801-850). No `status` check anywhere in the loop.

## Fix (two changes, same file)

**1. `_run_agent` retry loop** — re-check `self.workflow` status each iteration; on `failed`/`cancelled`, run the same cleanup as the cancel path (`_write_phase_usage` + set `_current_session_id`) and `return`. This lets the in-flight `advance()` stop immediately when the workflow is marked failed.

**2. `advance()` entry guard** — short-circuit on `failed`/`cancelled` in addition to `paused`. Belt-and-suspenders: the scheduler already excludes `failed` via `get_active_workflows`, this only guards the single in-flight call.

`self.workflow` is a `@property` that re-queries the DB on each access, so the status read inside the loop is live.

## What this does NOT change
- Retry backoff strategy (30→60→120s, max 300s, 1800s total window) — unchanged.
- Success path — unchanged.
- No new dependencies, no DB schema change, no API change.
- `get_active_workflows` query (already excludes `failed`) — untouched.

## Verification
- `py_compile` passes.
- All pre-commit hooks pass (black, isort, ruff, mypy, bandit, pydocstyle).

## Note
This fix prevents **new** retry storms on failed workflows. It does not reclaim an agent subprocess already running under the old code — a running server must be restarted for the fix to take effect. The currently-observed #863 case has already stopped on its own (retries exhausted, agent PID dead).

🤖 Generated with ZCode