### PR TITLE
fix: SSO注册提供者添加验证提示和错误反馈 (Issue #875)

### DIFF
--- a/frontend/src/components/features/settings/SSOSettings.tsx
+++ b/frontend/src/components/features/settings/SSOSettings.tsx
@@ -60,6 +60,8 @@ export const SSOSettings: React.FC = () => {
   const [isSaving, setIsSaving] = useState(false);
 
   const [showModal, setShowModal] = useState(false);
+  const [registerError, setRegisterError] = useState<string | null>(null);
+  const [isRegistering, setIsRegistering] = useState(false);
   const [formData, setFormData] = useState<RegisterProviderRequest>({
     name: '',
     provider_type: 'oauth2',
@@ -171,12 +173,36 @@ export const SSOSettings: React.FC = () => {
   };
 
   const handleSubmit = async () => {
+    setRegisterError(null);
+
+    // Validate required fields
+    if (!formData.client_id.trim()) {
+      setRegisterError(t('clientIdRequired', language));
+      return;
+    }
+
+    if (!formData.client_secret.trim()) {
+      setRegisterError(t('clientSecretRequired', language));
+      return;
+    }
+
+    // Custom provider requires name
+    if (!formData.predefined && !formData.name.trim()) {
+      setRegisterError(t('providerNameRequired', language));
+      return;
+    }
+
+    setIsRegistering(true);
     try {
       await ssoApi.registerProvider(formData);
       handleCloseModal();
       fetchProviders();
+      success(t('providerRegistered', language));
     } catch (err) {
-      console.error('Failed to register provider:', err);
+      const errorMsg = err instanceof Error ? err.message : t('registerFailed', language);
+      setRegisterError(errorMsg);
+    } finally {
+      setIsRegistering(false);
     }
   };
 
@@ -346,12 +372,19 @@ export const SSOSettings: React.FC = () => {
             <Button variant="secondary" onClick={handleCloseModal}>
               {t('cancel', language)}
             </Button>
-            <Button variant="primary" onClick={handleSubmit}>
+            <Button variant="primary" onClick={handleSubmit} loading={isRegistering}>
               {t('register', language)}
             </Button>
           </>
         }
       >
+        {/* Error message */}
+        {registerError && (
+          <div className="alert alert-danger mb-3">
+            <i className="bi bi-exclamation-circle me-2" />
+            {registerError}
+          </div>
+        )}
         <div className="row g-3">
           {/* Predefined Provider Selection */}
           <div className="col-12">

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -974,6 +974,11 @@ const translations: Record<Language, Translations> = {
     issuerUrl: 'Issuer URL',
     registerProvider: 'Register Provider',
     register: 'Register',
+    clientIdRequired: 'Client ID is required',
+    clientSecretRequired: 'Client secret is required',
+    providerNameRequired: 'Provider name is required',
+    registerFailed: 'Failed to register provider',
+    providerRegistered: 'Provider registered successfully',
     confirmDisableProvider: 'Are you sure you want to disable this provider?',
 
     // Insights
@@ -2331,6 +2336,11 @@ const translations: Record<Language, Translations> = {
     issuerUrl: 'Issuer URL',
     registerProvider: '注册提供者',
     register: '注册',
+    clientIdRequired: '客户端 ID 为必填项',
+    clientSecretRequired: '客户端密钥为必填项',
+    providerNameRequired: '提供者名称为必填项',
+    registerFailed: '注册提供者失败',
+    providerRegistered: '提供者注册成功',
     confirmDisableProvider: '确定要禁用此提供者吗？',
 
     // Insights


### PR DESCRIPTION
## 问题描述

修复 Issue #875: SSO注册提供者点击注册无反应，缺少验证提示和错误反馈

## 问题原因

1. 前端缺少必填字段验证（client_id、client_secret）
2. API 错误只打印到 console，用户界面无提示
3. 注册按钮缺少 loading 状态

## 修复内容

### 1. 前端 SSOSettings.tsx

- 添加 `registerError` 和 `isRegistering` 状态变量
- `handleSubmit` 函数添加必填字段验证：
  - client_id 必填
  - client_secret 必填
  - 自定义提供者需要填写 name
- API 错误显示到用户界面（红色 alert 提示）
- 注册按钮添加 loading 状态
- 成功注册后显示 Toast 提示

### 2. i18n 翻译键

添加以下翻译键（英文 + 中文）：
- `clientIdRequired`: Client ID is required / 客户端 ID 为必填项
- `clientSecretRequired`: Client secret is required / 客户端密钥为必填项
- `providerNameRequired`: Provider name is required / 提供者名称为必填项
- `registerFailed`: Failed to register provider / 注册提供者失败
- `providerRegistered`: Provider registered successfully / 提供者注册成功

## 预期效果

修复后：
- 客户端 ID 或密钥为空时显示验证错误提示
- API 调用失败时显示具体错误信息
- 注册按钮有 loading 状态
- 成功注册后关闭弹窗并刷新列表
- 用户清楚知道操作结果

## 测试验证

- ✅ 前端构建成功（npm run build）
- ⏳ 待人工测试验证

🤖 Generated with Qwen Code