### PR TITLE
fix: 仪表盘筛选栏日期控件垂直对齐问题

### DIFF
--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -1088,6 +1088,11 @@ link[rel='dns-prefetch'] {
   outline: 0;
 }
 
+/* Remove margin from form-group in header controls for alignment */
+.page-header-controls .date-input-narrow.form-group {
+  margin-bottom: 0;
+}
+
 /* Dark theme date input calendar icon */
 [data-theme='dark']
   .page-header-controls


### PR DESCRIPTION
## 问题

选择 Custom 日期范围后，日期输入框与相邻下拉框（主机/工具选择）高度不一致，视觉上高低错落。

## 根因

- `TextInput` 组件使用 `.form-group` 外层容器，有 `margin-bottom: var(--spacing-md)`
- `Select` 组件直接渲染 `<select>` 元素，无外层包裹
- `.page-header-controls` 已有 `align-items: center`，但 TextInput 的 margin 影响整体对齐

## 修复

添加 CSS 规则移除 `.page-header-controls` 内 `.date-input-narrow.form-group` 的 margin-bottom。

```css
.page-header-controls .date-input-narrow.form-group {
  margin-bottom: 0;
}
```

## 测试

- 本地验证视觉效果正常
- CI 已包含 flaky test fix (PR #1030)

Fixes #899