### PR TITLE
fix: Docker版升级时自动授予序列权限 (#1042)

### DIFF
--- a/scripts/install-central/docker-method/install.sh
+++ b/scripts/install-central/docker-method/install.sh
@@ -2288,29 +2288,42 @@ upgrade_deployment() {
 
     # 5. config.json is preserved (not overwritten)
 
-    # 5.5. Grant sequence permissions if database owner differs from current DB_USER
-    # This handles the case where database was created with a different user (e.g., ace)
-    # and later upgraded with a new DB_USER (e.g., ivyent)
+    # 5.5. Grant sequence permissions to DB_USER if needed
+    # PostgreSQL sequences have independent owners (pg_class.relowner).
+    # When DB_USER is not a superuser, permissions must be granted by a superuser.
+    # We query for actual superuser rather than assuming 'postgres' exists.
     print_info "检查数据库序列权限..."
-    local db_owner=""
-    db_owner=$(docker compose exec -T postgres psql -U "$DB_USER" -d "$DB_NAME" -t -c \
-        "SELECT pg_catalog.pg_get_userbyid(datdba) FROM pg_database WHERE datname = '$DB_NAME';" 2>/dev/null | tr -d '[:space:]')
 
-    if [ -n "$db_owner" ] && [ "$db_owner" != "$DB_USER" ]; then
-        print_info "数据库所有者为 $db_owner，授予序列权限给 $DB_USER"
-        # Try to grant using database owner first, then fallback to postgres superuser
-        if docker compose exec -T postgres psql -U "$db_owner" -d "$DB_NAME" -c \
-            "GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO \"$DB_USER\";" 2>/dev/null; then
-            print_success "序列权限授予成功"
-        elif docker compose exec -T postgres psql -U "$DB_USER" -d "$DB_NAME" -c \
-            "GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO \"$DB_USER\";" 2>/dev/null; then
-            print_success "序列权限授予成功（使用超级用户）"
-        else
-            print_warning "序列权限授予失败，如登录失败请手动执行:"
-            print_info "  docker compose exec postgres psql -U $db_owner -d $DB_NAME -c 'GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO $DB_USER;'"
-        fi
+    # Check if DB_USER is a superuser
+    local is_superuser=""
+    is_superuser=$(docker compose exec -T postgres psql -U "$DB_USER" -d "$DB_NAME" -t -c \
+        "SELECT rolsuper FROM pg_roles WHERE rolname = '$DB_USER';" 2>/dev/null | tr -d '[:space:]')
+
+    if [ "$is_superuser" = "t" ]; then
+        print_info "$DB_USER 是超级用户，无需额外授权"
     else
-        print_info "数据库所有者与 DB_USER 一致，无需额外授权"
+        # Find a superuser to grant permissions
+        local superuser=""
+        superuser=$(docker compose exec -T postgres psql -U "$DB_USER" -d "$DB_NAME" -t -c \
+            "SELECT rolname FROM pg_roles WHERE rolsuper = 't' LIMIT 1;" 2>/dev/null | tr -d '[:space:]')
+
+        if [ -n "$superuser" ]; then
+            print_info "授予序列权限给 $DB_USER（使用超级用户 $superuser）..."
+            local grant_output=""
+            grant_output=$(docker compose exec -T postgres psql -U "$superuser" -d "$DB_NAME" -c \
+                "GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO \"$DB_USER\";" 2>&1)
+
+            if echo "$grant_output" | grep -q "GRANT"; then
+                print_success "序列权限授予成功"
+            else
+                print_warning "序列权限授予失败: $grant_output"
+                print_info "如登录失败请手动执行:"
+                print_info "  docker compose exec postgres psql -U $superuser -d $DB_NAME -c 'GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO $DB_USER;'"
+            fi
+        else
+            print_warning "无法找到超级用户，跳过序列权限授权"
+            print_info "如登录失败请手动检查数据库权限配置"
+        fi
     fi
 
     # 6. Recreate only open-ace container (PostgreSQL not restarted)

--- a/scripts/install-central/docker-method/install.sh
+++ b/scripts/install-central/docker-method/install.sh
@@ -2288,6 +2288,31 @@ upgrade_deployment() {
 
     # 5. config.json is preserved (not overwritten)
 
+    # 5.5. Grant sequence permissions if database owner differs from current DB_USER
+    # This handles the case where database was created with a different user (e.g., ace)
+    # and later upgraded with a new DB_USER (e.g., ivyent)
+    print_info "检查数据库序列权限..."
+    local db_owner=""
+    db_owner=$(docker compose exec -T postgres psql -U "$DB_USER" -d "$DB_NAME" -t -c \
+        "SELECT pg_catalog.pg_get_userbyid(datdba) FROM pg_database WHERE datname = '$DB_NAME';" 2>/dev/null | tr -d '[:space:]')
+
+    if [ -n "$db_owner" ] && [ "$db_owner" != "$DB_USER" ]; then
+        print_info "数据库所有者为 $db_owner，授予序列权限给 $DB_USER"
+        # Try to grant using database owner first, then fallback to postgres superuser
+        if docker compose exec -T postgres psql -U "$db_owner" -d "$DB_NAME" -c \
+            "GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO \"$DB_USER\";" 2>/dev/null; then
+            print_success "序列权限授予成功"
+        elif docker compose exec -T postgres psql -U "$DB_USER" -d "$DB_NAME" -c \
+            "GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO \"$DB_USER\";" 2>/dev/null; then
+            print_success "序列权限授予成功（使用超级用户）"
+        else
+            print_warning "序列权限授予失败，如登录失败请手动执行:"
+            print_info "  docker compose exec postgres psql -U $db_owner -d $DB_NAME -c 'GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO $DB_USER;'"
+        fi
+    else
+        print_info "数据库所有者与 DB_USER 一致，无需额外授权"
+    fi
+
     # 6. Recreate only open-ace container (PostgreSQL not restarted)
     print_info "重建 open-ace 容器..."
     docker compose up -d --force-recreate open-ace


### PR DESCRIPTION
## 问题描述

Docker 版升级后登录失败，提示 "Failed to create session"。

错误日志：
```
Error creating session: permission denied for sequence sessions_new_id_seq1
Failed to save audit log: permission denied for sequence audit_logs_id_seq
```

## 根因分析

数据库最初由 `ace` 用户创建，后来升级时 `DB_USER` 改为 `ivyent`。表权限已授予，但序列权限未授予。

## 修复内容

在 `scripts/install-central/docker-method/install.sh` 的 `upgrade_deployment()` 函数中添加序列权限授予逻辑：

1. 检查数据库所有者是否与当前 `DB_USER` 不同
2. 使用数据库所有者授予序列权限
3. 如果失败，尝试使用超级用户授予

## 验证结果

node236 Docker 环境验证通过：

| 测试项 | 结果 |
|--------|------|
| 升级前序列权限 | \`has_sequence_privilege = f\` |
| 升级脚本执行 | \`✓ 序列权限授予成功\` |
| 升级后序列权限 | \`has_sequence_privilege = t\` |
| 登录 API | \`{"success":true}\` |

Fixes #1042