### PR TITLE
fix: 扩展 alembic_version.version_num 列长度以支持长格式版本号

### DIFF
--- a/migrations/versions/20260615_063_fix_boolean_retroactive.py
+++ b/migrations/versions/20260615_063_fix_boolean_retroactive.py
@@ -72,6 +72,10 @@ def upgrade() -> None:
 
     conn = op.get_bind()
 
+    # 先扩展 alembic_version 列长度，避免版本号太长导致迁移失败
+    # 长格式版本号如 "20260615_063_fix_boolean_retroactive" 有 36 字符，超过默认 varchar(32)
+    op.execute("ALTER TABLE alembic_version ALTER COLUMN version_num TYPE varchar(64)")
+
     # ============================================
     # registration_tokens: is_consumed -> BOOLEAN
     # ============================================


### PR DESCRIPTION
## 问题描述

迁移 `063_fix_boolean_retroactive` 在 PostgreSQL 环境执行失败，导致布尔列类型转换被回滚。

Fixes #881

## 问题原因

**版本号格式变更导致 alembic_version 列长度不足**

- 早期版本号：短格式如 `059_add_smtp_tables`（19字符）
- 新版本号：长格式如 `20260615_063_fix_boolean_retroactive`（36字符）

Alembic 默认创建的 `alembic_version.version_num` 列是 `varchar(32)`，无法存储 36 字符的版本号。

### 失败链路
```
迁移执行 ALTER COLUMN (成功) → Alembic 更新版本号 (失败: varchar(32) 太短) → 整个事务回滚 → ALTER COLUMN 被撤销
```

## 修复方案

在迁移文件开头添加扩展 `alembic_version.version_num` 列长度为 `varchar(64)` 的 SQL。

## 修改的文件

- `migrations/versions/20260615_063_fix_boolean_retroactive.py` (+4 行)

## 测试

已在生产环境验证，迁移可以正常执行。