### PR TITLE
fix: add procps package and ps command validation (Issue #1050)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,7 @@ RUN echo "deb http://mirrors.aliyun.com/debian/ trixie main" > /etc/apt/sources.
     sudo \
     ca-certificates \
     gnupg \
+    procps \
     && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
     # === Node.js Installation Verification (Issue #1006) ===
@@ -59,6 +60,9 @@ RUN echo "deb http://mirrors.aliyun.com/debian/ trixie main" > /etc/apt/sources.
     && node --version | grep -q '^v20\.' \
     # Create symlink backup for node (prevent accidental removal, skip if already same file)
     && sh -c 'test -e /bin/node || ln -sf /usr/bin/node /bin/node' \
+    # === Process Tools Verification (Issue #1050) ===
+    && test -x /usr/bin/ps \
+    && ps --version >/dev/null \
     # === npm and CLI Setup ===
     && npm config set registry https://registry.npmmirror.com/ \
     && npm install -g qwen-code-webui @qwen-code/qwen-code \

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -50,6 +50,25 @@ validate_node_environment() {
     fi
     echo "  WebUI: $WEBUI_PATH"
 
+    # === Process Tools Verification (Issue #1050) ===
+    echo "Validating process tools..."
+
+    if ! command -v ps &>/dev/null; then
+        echo "ERROR: ps command not found in PATH."
+        echo "       This indicates procps package was not installed during Docker build."
+        echo "       WebUI requires ps to find and abort CLI processes."
+        echo "       Please rebuild the image with procps package."
+        exit 1
+    fi
+
+    PS_PATH=$(which ps)
+    if [ ! -x "$PS_PATH" ]; then
+        echo "ERROR: ps at $PS_PATH is not executable."
+        echo "       Please check file permissions or rebuild the image."
+        exit 1
+    fi
+    echo "  ps: $PS_PATH"
+
     echo "Node.js environment validated successfully."
 }
 


### PR DESCRIPTION
## 问题

Docker 容器缺少 `procps` 包，导致 WebUI 执行 `ps` 命令时出现 `spawnSync ps ENOENT` 错误，会话闪退。

## 根因

Dockerfile 未安装 `procps` 包，容器中缺少 `ps` 命令。WebUI 在 abort CLI 进程时执行 `ps -Ao pid=,command=` 查找 CLI 进程 PID，因 `ps` 不存在而失败。

## 修复方案

采用与 PR #1008 相同的双重验证机制：

| 文件 | 修改内容 |
|------|----------|
| `Dockerfile` | 1. 在 apt-get install 中添加 `procps` 包<br>2. 添加构建时验证：`test -x /usr/bin/ps` 和 `ps --version >/dev/null` |
| `docker-entrypoint.sh` | 在 `validate_node_environment()` 函数中添加 ps 命令验证 |

**双重验证确保**：
- **构建时验证**：如果 `procps` 包安装失败，镜像构建失败（不会生成错误镜像）
- **启动时验证**：如果镜像缺少 `ps` 命令，容器启动失败（不会进入运行状态）

## 验证结果

在 node236 上使用官方 Debian 源进行测试构建：

| 验证项 | 结果 |
|--------|------|
| `procps` 包安装 | ✅ 成功 |
| `test -x /usr/bin/ps` | ✅ 验证通过 |
| `ps --version >/dev/null` | ✅ 验证通过 |

修复方案验证成功。

## 修改文件

- `Dockerfile` (+3 行)
- `docker-entrypoint.sh` (+19 行)

Fixes #1050

🤖 Generated with Qwen Code