### PR TITLE
feat: streamline autonomous timeline summaries

### DIFF
--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -485,6 +485,40 @@ class AutonomousOrchestrator:
         match = _TLDR_RE.search(response)
         return match.group(1).strip()[:200] if match else ""
 
+    @staticmethod
+    def _build_progress_report_tldr(
+        dev_round: int,
+        diff_stats: dict,
+        test_summary: str,
+        review_rounds: int,
+        review_passed: bool,
+        pr_number: Optional[int],
+    ) -> str:
+        """Build a compact one-line summary for synthetic progress reports."""
+        parts = [f"Round {dev_round} summary"]
+
+        if diff_stats:
+            parts.append(
+                (
+                    f"{diff_stats.get('files', 0)} files changed "
+                    f"(+{diff_stats.get('additions', 0)}/-{diff_stats.get('deletions', 0)})"
+                )
+            )
+
+        cleaned_test_summary = re.sub(r"\s+", " ", test_summary or "").strip()
+        if cleaned_test_summary:
+            parts.append(f"Tests: {cleaned_test_summary[:60].rstrip(' ,.;:')}")
+
+        if review_rounds > 0:
+            parts.append(
+                f"Review: {'passed' if review_passed else 'issues found'} ({review_rounds} rounds)"
+            )
+
+        if pr_number:
+            parts.append(f"PR #{pr_number}")
+
+        return "; ".join(parts)[:200]
+
     def _post_github_comment(
         self,
         gh: GitHubOps,
@@ -2597,6 +2631,14 @@ class AutonomousOrchestrator:
             f"- Tokens: {wf.get('total_tokens', 0):,}\n"
             f"- API Requests: {wf.get('total_requests', 0)}\n"
         )
+        report_tldr = self._build_progress_report_tldr(
+            dev_round=dev_round,
+            diff_stats=diff_stats,
+            test_summary=test_summary,
+            review_rounds=review_rounds,
+            review_passed=review_passed,
+            pr_number=pr_number,
+        )
 
         self._create_milestone(
             phase="report",
@@ -2605,6 +2647,7 @@ class AutonomousOrchestrator:
             status="completed",
             title=f"Progress report for round {dev_round}",
             result_summary=report[:500],
+            tldr=report_tldr,
         )
 
         # Post report to issue

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -499,10 +499,8 @@ class AutonomousOrchestrator:
 
         if diff_stats:
             parts.append(
-                (
-                    f"{diff_stats.get('files', 0)} files changed "
-                    f"(+{diff_stats.get('additions', 0)}/-{diff_stats.get('deletions', 0)})"
-                )
+                f"{diff_stats.get('files', 0)} files changed "
+                f"(+{diff_stats.get('additions', 0)}/-{diff_stats.get('deletions', 0)})"
             )
 
         cleaned_test_summary = re.sub(r"\s+", " ", test_summary or "").strip()

--- a/frontend/src/components/work/WorkflowTimeline.css
+++ b/frontend/src/components/work/WorkflowTimeline.css
@@ -608,7 +608,7 @@
 .timeline-milestone-preview {
   margin: 8px 0 0;
   color: var(--text-secondary);
-  font-size: var(--font-size-sm);
+  font-size: 0.82rem;
   line-height: 1.55;
 }
 

--- a/frontend/src/components/work/WorkflowTimeline.tsx
+++ b/frontend/src/components/work/WorkflowTimeline.tsx
@@ -126,11 +126,47 @@ const MILESTONE_ICON_COLORS: Record<string, string> = {
 };
 
 const TIMELINE_AUTO_SCROLL_THRESHOLD = 24;
+const MAX_DIFF_VIEW_CHARS = 50000;
 
 function truncateInlineText(text: string, max = 220): string {
   const normalized = text.replace(/\s+/g, ' ').trim();
   if (normalized.length <= max) return normalized;
   return `${normalized.slice(0, max).trimEnd()}...`;
+}
+
+function truncateDiffText(text: string, max = MAX_DIFF_VIEW_CHARS): {
+  content: string;
+  isTruncated: boolean;
+} {
+  if (text.length <= max) {
+    return { content: text, isTruncated: false };
+  }
+  return { content: text.slice(0, max), isTruncated: true };
+}
+
+function getDiffLineClass(line: string): string {
+  if (line.startsWith('+') && !line.startsWith('+++')) {
+    return 'workflow-timeline-diff-line-add';
+  }
+  if (line.startsWith('-') && !line.startsWith('---')) {
+    return 'workflow-timeline-diff-line-del';
+  }
+  if (line.startsWith('@@')) {
+    return 'workflow-timeline-diff-line-hunk';
+  }
+  if (
+    line.startsWith('diff --git') ||
+    line.startsWith('index ') ||
+    line.startsWith('--- ') ||
+    line.startsWith('+++ ') ||
+    line.startsWith('new file mode ') ||
+    line.startsWith('deleted file mode ') ||
+    line.startsWith('rename from ') ||
+    line.startsWith('rename to ')
+  ) {
+    return 'workflow-timeline-diff-line-meta';
+  }
+  return '';
 }
 
 function getActivityStableKey(activity: {
@@ -915,10 +951,18 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
     [isTimelineAtBottom]
   );
 
-  const parsedDiffFiles = useMemo(() => parseDiffFiles(diffData?.diff ?? ''), [diffData?.diff]);
-  const parsedPrDiffFiles = useMemo(
-    () => parseDiffFiles(prDiffData?.diff ?? ''),
+  const truncatedDiff = useMemo(() => truncateDiffText(diffData?.diff ?? ''), [diffData?.diff]);
+  const truncatedPrDiff = useMemo(
+    () => truncateDiffText(prDiffData?.diff ?? ''),
     [prDiffData?.diff]
+  );
+  const parsedDiffFiles = useMemo(
+    () => parseDiffFiles(truncatedDiff.content),
+    [truncatedDiff.content]
+  );
+  const parsedPrDiffFiles = useMemo(
+    () => parseDiffFiles(truncatedPrDiff.content),
+    [truncatedPrDiff.content]
   );
   const latestMilestoneSignature =
     milestones.length > 0
@@ -1001,6 +1045,32 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
       parsedPrDiffFiles[0] ??
       null,
     [parsedPrDiffFiles, selectedPrDiffFileId]
+  );
+  const renderDiffLines = useCallback(
+    (content: string, keyPrefix: string, isTruncated = false) => {
+      const lines = content.split('\n');
+      return (
+        <>
+          {lines.map((line, index) => (
+            <div
+              key={`${keyPrefix}-line-${index}`}
+              className={`workflow-timeline-diff-line ${getDiffLineClass(line)}`}
+            >
+              {line || ' '}
+            </div>
+          ))}
+          {isTruncated && (
+            <div
+              key={`${keyPrefix}-truncated`}
+              className="workflow-timeline-diff-line workflow-timeline-diff-line-meta"
+            >
+              {t('autoDiffTruncated', language)}
+            </div>
+          )}
+        </>
+      );
+    },
+    [language]
   );
 
   const handleDiffResizeStart = useCallback(
@@ -1179,6 +1249,14 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
     const showDetailSections = isExpanded && canExpand;
     const showLiveActivitySection = milestone.status === 'in_progress' && hasLiveActivity;
     const showInlinePreview = !compact && milestoneSummary;
+    const actionSectionLabelKey =
+      canFork || canCancel
+        ? 'autoActionsSection'
+        : canViewPlanContent && !canViewReviewContent
+          ? 'autoOutputSection'
+          : canViewReviewContent && !canViewPlanContent
+            ? 'autoReviewSection'
+            : 'autoActionsSection';
 
     return (
       <article
@@ -1369,7 +1447,7 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
             {(canFork || canCancel || canViewPlanContent || canViewReviewContent) && (
               <section className="timeline-milestone-section">
                 <div className="timeline-milestone-section-label">
-                  {t('autoActionsSection', language)}
+                  {t(actionSectionLabelKey, language)}
                 </div>
                 <div className="timeline-milestone-section-body">
                   <div className="timeline-milestone-inline-actions">
@@ -2228,34 +2306,11 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
                   </button>
                 </div>
                 <div className="workflow-timeline-diff-code">
-                  {selectedPrDiffFile.patch.split('\n').map((line, index) => {
-                    const lineClass =
-                      line.startsWith('+') && !line.startsWith('+++')
-                        ? 'workflow-timeline-diff-line-add'
-                        : line.startsWith('-') && !line.startsWith('---')
-                          ? 'workflow-timeline-diff-line-del'
-                          : line.startsWith('@@')
-                            ? 'workflow-timeline-diff-line-hunk'
-                            : line.startsWith('diff --git') ||
-                                line.startsWith('index ') ||
-                                line.startsWith('--- ') ||
-                                line.startsWith('+++ ') ||
-                                line.startsWith('new file mode ') ||
-                                line.startsWith('deleted file mode ') ||
-                                line.startsWith('rename from ') ||
-                                line.startsWith('rename to ')
-                              ? 'workflow-timeline-diff-line-meta'
-                              : '';
-
-                    return (
-                      <div
-                        key={`${selectedPrDiffFile.id}-line-${index}`}
-                        className={`workflow-timeline-diff-line ${lineClass}`}
-                      >
-                        {line || ' '}
-                      </div>
-                    );
-                  })}
+                  {renderDiffLines(
+                    selectedPrDiffFile.patch,
+                    selectedPrDiffFile.id,
+                    truncatedPrDiff.isTruncated
+                  )}
                 </div>
               </div>
             </div>
@@ -2263,34 +2318,11 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
             <div className="workflow-timeline-diff-shell">
               <div className="workflow-timeline-diff-viewer">
                 <div className="workflow-timeline-diff-code">
-                  {prDiffData.diff.split('\n').map((line, index) => {
-                    const lineClass =
-                      line.startsWith('+') && !line.startsWith('+++')
-                        ? 'workflow-timeline-diff-line-add'
-                        : line.startsWith('-') && !line.startsWith('---')
-                          ? 'workflow-timeline-diff-line-del'
-                          : line.startsWith('@@')
-                            ? 'workflow-timeline-diff-line-hunk'
-                            : line.startsWith('diff --git') ||
-                                line.startsWith('index ') ||
-                                line.startsWith('--- ') ||
-                                line.startsWith('+++ ') ||
-                                line.startsWith('new file mode ') ||
-                                line.startsWith('deleted file mode ') ||
-                                line.startsWith('rename from ') ||
-                                line.startsWith('rename to ')
-                              ? 'workflow-timeline-diff-line-meta'
-                              : '';
-
-                    return (
-                      <div
-                        key={`pr-diff-line-${index}`}
-                        className={`workflow-timeline-diff-line ${lineClass}`}
-                      >
-                        {line || ' '}
-                      </div>
-                    );
-                  })}
+                  {renderDiffLines(
+                    truncatedPrDiff.content,
+                    'pr-diff-fallback',
+                    truncatedPrDiff.isTruncated
+                  )}
                 </div>
               </div>
             </div>
@@ -2525,34 +2557,11 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
                     </button>
                   </div>
                   <div className="workflow-timeline-diff-code">
-                    {selectedDiffFile.patch.split('\n').map((line, index) => {
-                      const lineClass =
-                        line.startsWith('+') && !line.startsWith('+++')
-                          ? 'workflow-timeline-diff-line-add'
-                          : line.startsWith('-') && !line.startsWith('---')
-                            ? 'workflow-timeline-diff-line-del'
-                            : line.startsWith('@@')
-                              ? 'workflow-timeline-diff-line-hunk'
-                              : line.startsWith('diff --git') ||
-                                  line.startsWith('index ') ||
-                                  line.startsWith('--- ') ||
-                                  line.startsWith('+++ ') ||
-                                  line.startsWith('new file mode ') ||
-                                  line.startsWith('deleted file mode ') ||
-                                  line.startsWith('rename from ') ||
-                                  line.startsWith('rename to ')
-                                ? 'workflow-timeline-diff-line-meta'
-                                : '';
-
-                      return (
-                        <div
-                          key={`${selectedDiffFile.id}-line-${index}`}
-                          className={`workflow-timeline-diff-line ${lineClass}`}
-                        >
-                          {line || ' '}
-                        </div>
-                      );
-                    })}
+                    {renderDiffLines(
+                      selectedDiffFile.patch,
+                      selectedDiffFile.id,
+                      truncatedDiff.isTruncated
+                    )}
                   </div>
                 </div>
               </>
@@ -2566,9 +2575,9 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
                   whiteSpace: 'pre-wrap',
                 }}
               >
-                {diffData.diff.length > 50000
-                  ? diffData.diff.slice(0, 50000) + '\n\n' + t('autoDiffTruncated', language)
-                  : diffData.diff}
+                {truncatedDiff.isTruncated
+                  ? truncatedDiff.content + '\n\n' + t('autoDiffTruncated', language)
+                  : truncatedDiff.content}
               </pre>
             ) : (
               <p className="text-muted mb-0">{t('autoNoDiff', language)}</p>

--- a/frontend/src/components/work/WorkflowTimeline.tsx
+++ b/frontend/src/components/work/WorkflowTimeline.tsx
@@ -134,7 +134,10 @@ function truncateInlineText(text: string, max = 220): string {
   return `${normalized.slice(0, max).trimEnd()}...`;
 }
 
-function truncateDiffText(text: string, max = MAX_DIFF_VIEW_CHARS): {
+function truncateDiffText(
+  text: string,
+  max = MAX_DIFF_VIEW_CHARS
+): {
   content: string;
   isTruncated: boolean;
 } {
@@ -2245,9 +2248,7 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
                     key={file.id}
                     type="button"
                     className={`workflow-timeline-diff-file ${
-                      selectedPrDiffFile.id === file.id
-                        ? 'workflow-timeline-diff-file-active'
-                        : ''
+                      selectedPrDiffFile.id === file.id ? 'workflow-timeline-diff-file-active' : ''
                     }`}
                     onClick={() => setSelectedPrDiffFileId(file.id)}
                   >
@@ -2261,7 +2262,9 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
                       <span className="workflow-timeline-diff-file-path">{file.path}</span>
                     </div>
                     <span className="workflow-timeline-diff-file-stats">
-                      {file.additions > 0 && <span className="text-success">+{file.additions}</span>}
+                      {file.additions > 0 && (
+                        <span className="text-success">+{file.additions}</span>
+                      )}
                       {file.deletions > 0 && <span className="text-danger">-{file.deletions}</span>}
                     </span>
                   </button>
@@ -2302,7 +2305,9 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
                     <i
                       className={`bi ${diffFullscreen ? 'bi-fullscreen-exit' : 'bi-fullscreen'} me-1`}
                     />
-                    {diffFullscreen ? t('exitFullscreen', language) : t('enterFullscreen', language)}
+                    {diffFullscreen
+                      ? t('exitFullscreen', language)
+                      : t('enterFullscreen', language)}
                   </button>
                 </div>
                 <div className="workflow-timeline-diff-code">

--- a/frontend/src/components/work/WorkflowTimeline.tsx
+++ b/frontend/src/components/work/WorkflowTimeline.tsx
@@ -179,6 +179,7 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
   const [showBranchSelector, setShowBranchSelector] = useState(false);
   const [viewingDiff, setViewingDiff] = useState<string | null>(null);
   const [selectedDiffFileId, setSelectedDiffFileId] = useState<string | null>(null);
+  const [selectedPrDiffFileId, setSelectedPrDiffFileId] = useState<string | null>(null);
   const [diffSidebarWidth, setDiffSidebarWidth] = useState(320);
   const [diffFullscreen, setDiffFullscreen] = useState(false);
   const [showDefinitionSnapshot, setShowDefinitionSnapshot] = useState(false);
@@ -915,6 +916,10 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
   );
 
   const parsedDiffFiles = useMemo(() => parseDiffFiles(diffData?.diff ?? ''), [diffData?.diff]);
+  const parsedPrDiffFiles = useMemo(
+    () => parseDiffFiles(prDiffData?.diff ?? ''),
+    [prDiffData?.diff]
+  );
   const latestMilestoneSignature =
     milestones.length > 0
       ? [
@@ -970,10 +975,32 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
     );
   }, [viewingDiff, parsedDiffFiles]);
 
+  useEffect(() => {
+    if (!viewingPrDiff) {
+      setSelectedPrDiffFileId(null);
+      setDiffFullscreen(false);
+      return;
+    }
+    if (parsedPrDiffFiles.length === 0) {
+      setSelectedPrDiffFileId(null);
+      return;
+    }
+    setSelectedPrDiffFileId((prev) =>
+      prev && parsedPrDiffFiles.some((file) => file.id === prev) ? prev : parsedPrDiffFiles[0].id
+    );
+  }, [viewingPrDiff, parsedPrDiffFiles]);
+
   const selectedDiffFile = useMemo(
     () =>
       parsedDiffFiles.find((file) => file.id === selectedDiffFileId) ?? parsedDiffFiles[0] ?? null,
     [parsedDiffFiles, selectedDiffFileId]
+  );
+  const selectedPrDiffFile = useMemo(
+    () =>
+      parsedPrDiffFiles.find((file) => file.id === selectedPrDiffFileId) ??
+      parsedPrDiffFiles[0] ??
+      null,
+    [parsedPrDiffFiles, selectedPrDiffFileId]
   );
 
   const handleDiffResizeStart = useCallback(
@@ -1149,10 +1176,9 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
       milestone.started_at && (milestone.completed_at || milestone.status === 'in_progress')
         ? formatDuration(milestone.started_at, milestone.completed_at ?? milestone.updated_at)
         : '';
-    const previewPlan = canViewPlanContent ? milestone.plan_content.trim() : '';
-    const previewReview = canViewReviewContent ? milestone.review_content.trim() : '';
     const showDetailSections = isExpanded && canExpand;
     const showLiveActivitySection = milestone.status === 'in_progress' && hasLiveActivity;
+    const showInlinePreview = !compact && milestoneSummary;
 
     return (
       <article
@@ -1188,7 +1214,7 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
                   {milestoneDuration && <span>{milestoneDuration}</span>}
                 </div>
               </div>
-              {!compact && milestoneSummary && (
+              {showInlinePreview && (
                 <p
                   className="timeline-milestone-preview"
                   title={rawSummary.length > 220 ? rawSummary : undefined}
@@ -1230,84 +1256,6 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
 
         {showDetailSections && (
           <div className="timeline-milestone-details">
-            {(milestone.tldr || milestone.result_summary || milestone.description) && (
-              <section className="timeline-milestone-section">
-                <div className="timeline-milestone-section-label">
-                  {t('autoSummarySection', language)}
-                </div>
-                <div className="timeline-milestone-section-body">
-                  {milestone.tldr?.trim() && (
-                    <p className="timeline-milestone-detail-text timeline-milestone-detail-text--primary">
-                      {milestone.tldr.trim()}
-                    </p>
-                  )}
-                  {milestone.result_summary?.trim() &&
-                    milestone.result_summary.trim() !== milestone.tldr?.trim() && (
-                      <p className="timeline-milestone-detail-text">
-                        {milestone.result_summary.trim()}
-                      </p>
-                    )}
-                  {milestone.description?.trim() && (
-                    <p className="timeline-milestone-detail-note">{milestone.description.trim()}</p>
-                  )}
-                </div>
-              </section>
-            )}
-
-            {canViewPlanContent && (
-              <section className="timeline-milestone-section">
-                <div className="timeline-milestone-section-label">
-                  {t('autoOutputSection', language)}
-                </div>
-                <div className="timeline-milestone-section-body">
-                  <div className="timeline-milestone-detail-text">{previewPlan}</div>
-                  <div className="timeline-milestone-inline-actions">
-                    <Button
-                      size="sm"
-                      variant="outline-secondary"
-                      className="timeline-inline-btn timeline-inline-btn--success"
-                      onClick={() =>
-                        setViewingContent({
-                          title: t('autoViewPlanTitle', language),
-                          content: milestone.plan_content,
-                        })
-                      }
-                    >
-                      <i className="bi bi-file-text me-1"></i>
-                      {t('autoViewPlan', language)}
-                    </Button>
-                  </div>
-                </div>
-              </section>
-            )}
-
-            {canViewReviewContent && (
-              <section className="timeline-milestone-section">
-                <div className="timeline-milestone-section-label">
-                  {t('autoReviewSection', language)}
-                </div>
-                <div className="timeline-milestone-section-body">
-                  <div className="timeline-milestone-detail-text">{previewReview}</div>
-                  <div className="timeline-milestone-inline-actions">
-                    <Button
-                      size="sm"
-                      variant="outline-secondary"
-                      className="timeline-inline-btn timeline-inline-btn--info"
-                      onClick={() =>
-                        setViewingContent({
-                          title: t('autoViewReviewTitle', language),
-                          content: milestone.review_content,
-                        })
-                      }
-                    >
-                      <i className="bi bi-chat-text me-1"></i>
-                      {t('autoViewReview', language)}
-                    </Button>
-                  </div>
-                </div>
-              </section>
-            )}
-
             {canViewChanges && (
               <section className="timeline-milestone-section">
                 <div className="timeline-milestone-section-label">
@@ -1418,13 +1366,45 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
               </section>
             )}
 
-            {(canFork || canCancel) && (
+            {(canFork || canCancel || canViewPlanContent || canViewReviewContent) && (
               <section className="timeline-milestone-section">
                 <div className="timeline-milestone-section-label">
                   {t('autoActionsSection', language)}
                 </div>
                 <div className="timeline-milestone-section-body">
                   <div className="timeline-milestone-inline-actions">
+                    {canViewPlanContent && (
+                      <Button
+                        size="sm"
+                        variant="outline-secondary"
+                        className="timeline-inline-btn timeline-inline-btn--success"
+                        onClick={() =>
+                          setViewingContent({
+                            title: t('autoViewPlanTitle', language),
+                            content: milestone.plan_content,
+                          })
+                        }
+                      >
+                        <i className="bi bi-file-text me-1"></i>
+                        {t('autoViewPlan', language)}
+                      </Button>
+                    )}
+                    {canViewReviewContent && (
+                      <Button
+                        size="sm"
+                        variant="outline-secondary"
+                        className="timeline-inline-btn timeline-inline-btn--info"
+                        onClick={() =>
+                          setViewingContent({
+                            title: t('autoViewReviewTitle', language),
+                            content: milestone.review_content,
+                          })
+                        }
+                      >
+                        <i className="bi bi-chat-text me-1"></i>
+                        {t('autoViewReview', language)}
+                      </Button>
+                    )}
                     {canFork && (
                       <Button
                         size="sm"
@@ -1808,7 +1788,7 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
             >
               <i className="bi bi-clipboard-check me-1"></i>
               {t('autoFinalPlan', language)}
-              {latestPlanFinalized && (
+              {latestPlanFinalized && (latestPlanFinalized.dev_round || 1) > 1 && (
                 <Badge variant="light" className="ms-1" style={{ fontSize: '0.65rem' }}>
                   {t('autoRoundBadge', language).replace(
                     '{n}',
@@ -1832,7 +1812,7 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
             >
               <i className="bi bi-check2-circle me-1"></i>
               {t('autoPrReviewSummary', language)}
-              {latestPrReviewSummary && (
+              {latestPrReviewSummary && (latestPrReviewSummary.dev_round || 1) > 1 && (
                 <Badge variant="light" className="ms-1" style={{ fontSize: '0.65rem' }}>
                   {t('autoRoundBadge', language).replace(
                     '{n}',
@@ -2167,25 +2147,153 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
               : t('autoFinalCodeChanges', language)
           }
           size="xl"
+          className={`workflow-timeline-diff-modal ${
+            diffFullscreen ? 'workflow-timeline-diff-modal-fullscreen' : ''
+          }`}
+          scrollable={false}
         >
           {prDiffLoading ? (
             <div className="py-4">
               <Loading />
             </div>
+          ) : parsedPrDiffFiles.length > 0 && selectedPrDiffFile ? (
+            <div className="workflow-timeline-diff-shell">
+              <div
+                className="workflow-timeline-diff-sidebar"
+                style={{ width: `${diffSidebarWidth}px`, minWidth: `${diffSidebarWidth}px` }}
+              >
+                {parsedPrDiffFiles.map((file) => (
+                  <button
+                    key={file.id}
+                    type="button"
+                    className={`workflow-timeline-diff-file ${
+                      selectedPrDiffFile.id === file.id
+                        ? 'workflow-timeline-diff-file-active'
+                        : ''
+                    }`}
+                    onClick={() => setSelectedPrDiffFileId(file.id)}
+                  >
+                    <div className="d-flex align-items-center gap-2 min-width-0">
+                      <Badge
+                        variant={getDiffStatusClass(file.status)}
+                        className="workflow-timeline-diff-file-badge"
+                      >
+                        {file.status === 'added' ? 'A' : file.status === 'deleted' ? 'D' : 'M'}
+                      </Badge>
+                      <span className="workflow-timeline-diff-file-path">{file.path}</span>
+                    </div>
+                    <span className="workflow-timeline-diff-file-stats">
+                      {file.additions > 0 && <span className="text-success">+{file.additions}</span>}
+                      {file.deletions > 0 && <span className="text-danger">-{file.deletions}</span>}
+                    </span>
+                  </button>
+                ))}
+              </div>
+              <div
+                className="workflow-timeline-diff-resizer"
+                role="separator"
+                aria-orientation="vertical"
+                aria-label="Resize diff panels"
+                onPointerDown={handleDiffResizeStart}
+              />
+              <div className="workflow-timeline-diff-viewer">
+                <div className="workflow-timeline-diff-viewer-header">
+                  <div className="min-width-0">
+                    <div className="workflow-timeline-diff-viewer-path">
+                      {selectedPrDiffFile.path}
+                    </div>
+                    {selectedPrDiffFile.commitLabel && (
+                      <div className="workflow-timeline-diff-viewer-commit">
+                        {t('autoCommits', language)} {selectedPrDiffFile.commitLabel}
+                      </div>
+                    )}
+                  </div>
+                  <div className="workflow-timeline-diff-viewer-summary">
+                    {selectedPrDiffFile.additions > 0 && (
+                      <span className="text-success">+{selectedPrDiffFile.additions}</span>
+                    )}
+                    {selectedPrDiffFile.deletions > 0 && (
+                      <span className="text-danger">-{selectedPrDiffFile.deletions}</span>
+                    )}
+                  </div>
+                  <button
+                    type="button"
+                    className="btn btn-sm btn-outline-secondary workflow-timeline-diff-fullscreen-btn"
+                    onClick={() => setDiffFullscreen((prev) => !prev)}
+                  >
+                    <i
+                      className={`bi ${diffFullscreen ? 'bi-fullscreen-exit' : 'bi-fullscreen'} me-1`}
+                    />
+                    {diffFullscreen ? t('exitFullscreen', language) : t('enterFullscreen', language)}
+                  </button>
+                </div>
+                <div className="workflow-timeline-diff-code">
+                  {selectedPrDiffFile.patch.split('\n').map((line, index) => {
+                    const lineClass =
+                      line.startsWith('+') && !line.startsWith('+++')
+                        ? 'workflow-timeline-diff-line-add'
+                        : line.startsWith('-') && !line.startsWith('---')
+                          ? 'workflow-timeline-diff-line-del'
+                          : line.startsWith('@@')
+                            ? 'workflow-timeline-diff-line-hunk'
+                            : line.startsWith('diff --git') ||
+                                line.startsWith('index ') ||
+                                line.startsWith('--- ') ||
+                                line.startsWith('+++ ') ||
+                                line.startsWith('new file mode ') ||
+                                line.startsWith('deleted file mode ') ||
+                                line.startsWith('rename from ') ||
+                                line.startsWith('rename to ')
+                              ? 'workflow-timeline-diff-line-meta'
+                              : '';
+
+                    return (
+                      <div
+                        key={`${selectedPrDiffFile.id}-line-${index}`}
+                        className={`workflow-timeline-diff-line ${lineClass}`}
+                      >
+                        {line || ' '}
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            </div>
           ) : prDiffData?.diff ? (
-            <pre
-              className="bg-dark text-light p-3 rounded mb-0"
-              style={{
-                fontSize: '0.75rem',
-                maxHeight: '70vh',
-                overflow: 'auto',
-                whiteSpace: 'pre-wrap',
-              }}
-            >
-              {prDiffData.diff.length > 50000
-                ? prDiffData.diff.slice(0, 50000) + '\n\n' + t('autoDiffTruncated', language)
-                : prDiffData.diff}
-            </pre>
+            <div className="workflow-timeline-diff-shell">
+              <div className="workflow-timeline-diff-viewer">
+                <div className="workflow-timeline-diff-code">
+                  {prDiffData.diff.split('\n').map((line, index) => {
+                    const lineClass =
+                      line.startsWith('+') && !line.startsWith('+++')
+                        ? 'workflow-timeline-diff-line-add'
+                        : line.startsWith('-') && !line.startsWith('---')
+                          ? 'workflow-timeline-diff-line-del'
+                          : line.startsWith('@@')
+                            ? 'workflow-timeline-diff-line-hunk'
+                            : line.startsWith('diff --git') ||
+                                line.startsWith('index ') ||
+                                line.startsWith('--- ') ||
+                                line.startsWith('+++ ') ||
+                                line.startsWith('new file mode ') ||
+                                line.startsWith('deleted file mode ') ||
+                                line.startsWith('rename from ') ||
+                                line.startsWith('rename to ')
+                              ? 'workflow-timeline-diff-line-meta'
+                              : '';
+
+                    return (
+                      <div
+                        key={`pr-diff-line-${index}`}
+                        className={`workflow-timeline-diff-line ${lineClass}`}
+                      >
+                        {line || ' '}
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            </div>
           ) : (
             <p className="text-muted mb-0">{t('autoNoDiff', language)}</p>
           )}

--- a/tests/issues/716/test_orchestrator.py
+++ b/tests/issues/716/test_orchestrator.py
@@ -1343,11 +1343,13 @@ class TestOrchestratorReport:
         )
         completed_milestones = [
             {
+                "milestone_type": "dev_completed",
                 "status": "completed",
                 "title": "Development round 1",
                 "result_summary": "Built hello world feature",
             },
             {
+                "milestone_type": "tests_run",
                 "status": "completed",
                 "title": "Tests run",
                 "result_summary": "All 5 tests passed",

--- a/tests/issues/716/test_orchestrator.py
+++ b/tests/issues/716/test_orchestrator.py
@@ -1367,8 +1367,7 @@ class TestOrchestratorReport:
         assert report_ms_dict["milestone_type"] == "progress_reported"
         assert "Progress report" in report_ms_dict["title"]
         assert report_ms_dict["tldr"] == (
-            "Round 1 summary; 5 files changed (+100/-20); "
-            "Tests: All 5 tests passed; PR #99"
+            "Round 1 summary; 5 files changed (+100/-20); " "Tests: All 5 tests passed; PR #99"
         )
 
     def test_report_posts_to_issue(self):

--- a/tests/issues/716/test_orchestrator.py
+++ b/tests/issues/716/test_orchestrator.py
@@ -1364,6 +1364,10 @@ class TestOrchestratorReport:
         report_ms_dict = mock_repo.create_milestone.call_args_list[0][0][0]
         assert report_ms_dict["milestone_type"] == "progress_reported"
         assert "Progress report" in report_ms_dict["title"]
+        assert report_ms_dict["tldr"] == (
+            "Round 1 summary; 5 files changed (+100/-20); "
+            "Tests: All 5 tests passed; PR #99"
+        )
 
     def test_report_posts_to_issue(self):
         """Report is posted as a GitHub issue comment."""


### PR DESCRIPTION
## Summary
- streamline milestone cards by keeping the inline preview and removing duplicated expanded summary/output text for plan and review milestones
- reuse the structured diff viewer for final PR code changes and hide round badges on header outputs when only round 1 exists
- generate a compact structured tldr for progress_reported milestones so timeline previews stay readable

## Testing
- npm run typecheck
- python3 -m pytest tests/issues/716/test_orchestrator.py *(not runnable in this environment: pytest module is unavailable)*