### PR TITLE
fix(autonomous): pause no longer consumes task timeout budget

### DIFF
--- a/app/modules/workspace/autonomous/agent_runner.py
+++ b/app/modules/workspace/autonomous/agent_runner.py
@@ -115,7 +115,7 @@ class _LocalSession:
     sdk_initialized: threading.Event = field(default_factory=threading.Event)
     # Milestone this task belongs to — tags session_messages for per-phase detail views.
     milestone_id: str = ""
-    _paused: bool = False  # True when process is suspended via SIGSTOP
+    _paused: threading.Event = field(default_factory=threading.Event)  # set when SIGSTOPed
 
 
 class AutonomousAgentRunner:
@@ -320,11 +320,12 @@ class AutonomousAgentRunner:
         pausing a task for longer than the timeout (default 1h) would reap the
         in-flight agent even though no real work was being done (#1005).
 
-        This loop instead accounts for pause/resume: while ``session._paused`` is
-        set we do not consume the timeout budget, extending the deadline by the
-        duration of each pause. The budget resumes counting down only once the
-        process is unfrozen. Returns ``True`` if the session completed (or was
-        stopped) within the budget, ``False`` if the *active* time budget ran out.
+        This loop instead accounts for pause/resume: while ``session._paused``
+        is set we do not consume the timeout budget, extending the deadline by
+        the duration of each pause. The budget resumes counting down only once
+        the process is unfrozen. Returns ``True`` if the session completed (or
+        was stopped) within the budget, ``False`` if the *active* time budget
+        ran out.
         """
         deadline = time.monotonic() + max(timeout, 0.0)
         poll = COMPLETION_POLL_INTERVAL
@@ -335,9 +336,12 @@ class AutonomousAgentRunner:
             # While paused, freeze the deadline so the remaining budget is
             # preserved across the suspension. Resume stretches the deadline by
             # the full paused duration.
-            if session._paused:
+            if session._paused.is_set():
                 pause_started = now
-                while session._paused and not session.completed.is_set():
+                # Fixed `poll` here (not min(poll, remaining)) is deliberate:
+                # paused time is not budgeted, so there's no deadline to bound
+                # the wait against — we just need to notice resume/completion.
+                while session._paused.is_set() and not session.completed.is_set():
                     session.completed.wait(timeout=poll)
                 now = time.monotonic()
                 deadline += now - pause_started
@@ -1158,10 +1162,10 @@ class AutonomousAgentRunner:
             return
 
         # If paused, resume first so it can handle SIGTERM
-        if session._paused:
+        if session._paused.is_set():
             try:
                 os.killpg(pgid, signal.SIGCONT)
-                session._paused = False
+                session._paused.clear()
             except (ProcessLookupError, OSError):
                 pass
 
@@ -1200,12 +1204,12 @@ class AutonomousAgentRunner:
         session = self._local_sessions.get(session_id)
         if not session or not session.process or session.process.returncode is not None:
             return False
-        if session._paused:
+        if session._paused.is_set():
             return True
         try:
             pgid = os.getpgid(session.process.pid)
             os.killpg(pgid, signal.SIGSTOP)
-            session._paused = True
+            session._paused.set()
             logger.info("Paused session %s (pid %d)", session_id[:8], session.process.pid)
             return True
         except (ProcessLookupError, OSError) as e:
@@ -1217,12 +1221,12 @@ class AutonomousAgentRunner:
         session = self._local_sessions.get(session_id)
         if not session or not session.process or session.process.returncode is not None:
             return False
-        if not session._paused:
+        if not session._paused.is_set():
             return True
         try:
             pgid = os.getpgid(session.process.pid)
             os.killpg(pgid, signal.SIGCONT)
-            session._paused = False
+            session._paused.clear()
             logger.info("Resumed session %s (pid %d)", session_id[:8], session.process.pid)
             return True
         except (ProcessLookupError, OSError) as e:

--- a/app/modules/workspace/autonomous/agent_runner.py
+++ b/app/modules/workspace/autonomous/agent_runner.py
@@ -71,6 +71,11 @@ SESSION_DETECTION_GRACE_SECONDS = 5.0
 SESSION_DETECTION_WAIT_SECONDS = 5.0
 SESSION_DETECTION_POLL_INTERVAL = 0.25
 
+# How often the pause-aware completion loop re-checks the session state. The
+# underlying ``Event.wait`` returns immediately when ``completed`` is set, so
+# this only bounds how quickly we notice a pause/resume/stop transition.
+COMPLETION_POLL_INTERVAL = 5.0
+
 
 @dataclass
 class _LocalSession:
@@ -305,6 +310,39 @@ class AutonomousAgentRunner:
             self.session_manager.update_session_fields(persisted_id, updates)
         except Exception as e:
             logger.warning("Failed to sync sidebar session totals: %s", e)
+
+    @staticmethod
+    def _wait_for_completion(session: _LocalSession, timeout: float) -> bool:
+        """Wait for ``session.completed`` while excluding paused time from the budget.
+
+        ``threading.Event.wait(timeout=...)`` is a wall-clock countdown — it keeps
+        ticking even while the underlying process is frozen with SIGSTOP. That means
+        pausing a task for longer than the timeout (default 1h) would reap the
+        in-flight agent even though no real work was being done (#1005).
+
+        This loop instead accounts for pause/resume: while ``session._paused`` is
+        set we do not consume the timeout budget, extending the deadline by the
+        duration of each pause. The budget resumes counting down only once the
+        process is unfrozen. Returns ``True`` if the session completed (or was
+        stopped) within the budget, ``False`` if the *active* time budget ran out.
+        """
+        deadline = time.monotonic() + max(timeout, 0.0)
+        poll = COMPLETION_POLL_INTERVAL
+        while True:
+            if session.completed.wait(timeout=min(poll, max(deadline - time.monotonic(), 0.0))):
+                return True
+            now = time.monotonic()
+            # While paused, freeze the deadline so the remaining budget is
+            # preserved across the suspension. Resume stretches the deadline by
+            # the full paused duration.
+            if session._paused:
+                pause_started = now
+                while session._paused and not session.completed.is_set():
+                    session.completed.wait(timeout=poll)
+                now = time.monotonic()
+                deadline += now - pause_started
+            if now >= deadline:
+                return False
 
     def run_agent_task(
         self,
@@ -585,8 +623,9 @@ class AutonomousAgentRunner:
         # Send the prompt
         self._send_message(session, prompt)
 
-        # Wait for completion or timeout
-        completed = session.completed.wait(timeout=timeout)
+        # Wait for completion or timeout. Use the pause-aware wait so that
+        # time spent frozen via SIGSTOP does not consume the timeout budget (#1005).
+        completed = self._wait_for_completion(session, timeout)
 
         # Cleanup
         if process.returncode is None:

--- a/tests/issues/1005/test_pause_aware_timeout.py
+++ b/tests/issues/1005/test_pause_aware_timeout.py
@@ -15,6 +15,7 @@ These tests exercise ``_wait_for_completion`` directly (driving real
 spawning real subprocesses while still validating the pause/resume timing.
 """
 
+import signal
 import threading
 import time
 from unittest.mock import MagicMock, patch
@@ -89,10 +90,10 @@ class TestWaitForCompletionPauseFreezesBudget:
         # Let a little active time pass so the loop reaches the pause check,
         # then suspend.
         time.sleep(0.1)
-        session._paused = True
+        session._paused.set()
         # Hold the pause longer than the entire budget.
         time.sleep(0.5)
-        session._paused = False
+        session._paused.clear()
         # Now complete before the remaining active budget (~0.2s) runs out.
         session.completed.set()
         t.join(timeout=2.0)
@@ -106,9 +107,9 @@ class TestWaitForCompletionPauseFreezesBudget:
         t, holder = _run_waiter(session, timeout=0.3)
 
         time.sleep(0.05)
-        session._paused = True
+        session._paused.set()
         time.sleep(0.4)  # longer than the whole budget
-        session._paused = False
+        session._paused.clear()
         # Do NOT complete: the remaining active budget (~0.25s) should still
         # expire and return False, proving pause time was excluded.
         t.join(timeout=2.0)
@@ -125,9 +126,9 @@ class TestWaitForCompletionPauseFreezesBudget:
         t, holder = _run_waiter(session, timeout=budget)
 
         time.sleep(0.05)
-        session._paused = True
+        session._paused.set()
         time.sleep(pause)
-        session._paused = False
+        session._paused.clear()
         t.join(timeout=2.0)
         elapsed = time.monotonic() - start
 
@@ -145,10 +146,10 @@ class TestWaitForCompletionResumeTransition:
         """If the session is stopped (completed set) mid-pause, return True."""
         session = _make_session()
         t, holder = _run_waiter(session, timeout=10.0)
-        session._paused = True
+        session._paused.set()
         time.sleep(0.1)
-        # stop_session sets completed and (later) clears _paused; here just set
-        # completed — the inner pause loop checks completed too.
+        # stop_session clears the paused event and sets completed; here just
+        # set completed — the inner pause loop checks completed too.
         session.completed.set()
         t.join(timeout=2.0)
 
@@ -163,15 +164,75 @@ class TestWaitForCompletionResumeTransition:
 
         # Two short pauses with active gaps between them.
         for _ in range(2):
-            session._paused = True
+            session._paused.set()
             time.sleep(0.25)  # each pause alone is < budget but 2x approaches it
-            session._paused = False
+            session._paused.clear()
             time.sleep(0.02)
         session.completed.set()
         t.join(timeout=2.0)
 
         assert not t.is_alive()
         assert holder["result"] is True, "Pauses (not active time) must not consume the budget"
+
+
+class TestPausedEventToggleSession:
+    """pause/resume/stop mutate the _paused Event (was a bare bool, #1005 review).
+
+    These guard the cross-thread transitions the reviewer walked through: the
+    Event is written by request-handler threads (pause/resume/stop) and read by
+    the runner thread (_wait_for_completion). Using an Event keeps this consistent
+    with the existing ``_stopped`` Event.
+    """
+
+    def test_pause_sets_and_resume_clears_paused_event(self):
+        runner = AutonomousAgentRunner()
+        mock_process = MagicMock()
+        mock_process.pid = 12345
+        mock_process.returncode = None
+        session = _LocalSession(session_id="s-1", process=mock_process)
+        runner._local_sessions["s-1"] = session
+        assert session._paused.is_set() is False  # default unset
+
+        with patch("os.getpgid", return_value=12345), patch("os.killpg"):
+            assert runner.pause_session("s-1") is True
+        assert session._paused.is_set() is True
+
+        with patch("os.getpgid", return_value=12345), patch("os.killpg"):
+            assert runner.resume_session("s-1") is True
+        assert session._paused.is_set() is False
+
+    def test_stop_session_resumes_then_completes_while_paused(self):
+        """Stopping a paused session clears the paused event (SIGCONT) and completes."""
+        runner = AutonomousAgentRunner()
+        mock_process = MagicMock()
+        mock_process.pid = 12345
+        mock_process.returncode = None
+        session = _LocalSession(session_id="s-1", process=mock_process)
+        session._paused.set()  # currently paused
+        runner._local_sessions["s-1"] = session
+
+        with patch("os.getpgid", return_value=12345), patch("os.killpg"):
+            runner.stop_session("s-1")
+
+        assert session._paused.is_set() is False, "stop must resume (clear paused)"
+        assert session.completed.is_set()
+
+    def test_pause_then_pause_is_idempotent(self):
+        runner = AutonomousAgentRunner()
+        mock_process = MagicMock()
+        mock_process.pid = 12345
+        mock_process.returncode = None
+        session = _LocalSession(session_id="s-1", process=mock_process)
+        runner._local_sessions["s-1"] = session
+
+        with patch("os.getpgid", return_value=12345), patch("os.killpg") as mock_killpg:
+            assert runner.pause_session("s-1") is True
+            # Second pause: no-op, returns True without re-SIGSTOP.
+            assert runner.pause_session("s-1") is True
+        assert session._paused.is_set()
+        # SIGSTOP sent exactly once (resume does not run here).
+        sigs = [c.args[-1] for c in mock_killpg.call_args_list]
+        assert sigs.count(signal.SIGSTOP) == 1
 
 
 class TestRunLocalUsesPauseAwareWait:

--- a/tests/issues/1005/test_pause_aware_timeout.py
+++ b/tests/issues/1005/test_pause_aware_timeout.py
@@ -1,0 +1,234 @@
+"""Tests for pause-aware task timeout (#1005).
+
+Background: ``_run_local`` waited on ``session.completed.wait(timeout=timeout)``,
+a *wall-clock* countdown. Pausing a task (SIGSTOP) froze the agent process but
+NOT this clock, so pausing longer than the task timeout (default 1h) reaped the
+in-flight agent and marked the phase failed — pause did not "freeze time".
+
+Fix: ``_wait_for_completion`` waits in short increments and, while
+``session._paused`` is set, does not consume the timeout budget. The deadline is
+extended by the full paused duration so the remaining budget resumes from where
+it left off after resume.
+
+These tests exercise ``_wait_for_completion`` directly (driving real
+``threading.Event`` objects from background threads) so we avoid the cost of
+spawning real subprocesses while still validating the pause/resume timing.
+"""
+
+import threading
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.modules.workspace.autonomous import agent_runner as ar_mod
+from app.modules.workspace.autonomous.agent_runner import AutonomousAgentRunner, _LocalSession
+
+
+def _make_session() -> _LocalSession:
+    """A session with a never-started mock process (no subprocess needed)."""
+    proc = MagicMock()
+    proc.pid = 99999
+    proc.returncode = None
+    return _LocalSession(session_id="s-1", process=proc)
+
+
+def _run_waiter(session: _LocalSession, timeout: float):
+    """Run _wait_for_completion in a thread; return (thread, result holder)."""
+    runner = AutonomousAgentRunner()
+    holder = {}
+
+    def target():
+        holder["result"] = runner._wait_for_completion(session, timeout)
+
+    t = threading.Thread(target=target, daemon=True)
+    t.start()
+    return t, holder
+
+
+@pytest.fixture(autouse=True)
+def _fast_poll(monkeypatch):
+    """Speed up the loop so pauses/timeouts resolve in <1s of real time."""
+    monkeypatch.setattr(ar_mod, "COMPLETION_POLL_INTERVAL", 0.05)
+    yield
+
+
+class TestWaitForCompletionNoPause:
+    """Baseline: without pausing, the timeout behaves like a wall-clock budget."""
+
+    def test_completes_returns_true(self):
+        session = _make_session()
+        t, holder = _run_waiter(session, timeout=10.0)
+        session.completed.set()
+        t.join(timeout=2.0)
+        assert not t.is_alive()
+        assert holder["result"] is True
+
+    def test_times_out_when_not_paused(self):
+        session = _make_session()
+        start = time.monotonic()
+        t, holder = _run_waiter(session, timeout=0.3)
+        t.join(timeout=2.0)
+        elapsed = time.monotonic() - start
+        assert not t.is_alive()
+        assert holder["result"] is False
+        # Did not run for the full "would-be" deadline extension: roughly the
+        # budget, definitely well under a second.
+        assert elapsed < 1.0
+
+
+class TestWaitForCompletionPauseFreezesBudget:
+    """The core #1005 fix: paused time does not consume the timeout budget."""
+
+    def test_pause_longer_than_timeout_does_not_expire(self):
+        """A pause lasting longer than the budget must NOT cause a timeout."""
+        session = _make_session()
+        # Budget of 0.3s. We'll pause for 0.5s (> budget) then complete.
+        t, holder = _run_waiter(session, timeout=0.3)
+
+        # Let a little active time pass so the loop reaches the pause check,
+        # then suspend.
+        time.sleep(0.1)
+        session._paused = True
+        # Hold the pause longer than the entire budget.
+        time.sleep(0.5)
+        session._paused = False
+        # Now complete before the remaining active budget (~0.2s) runs out.
+        session.completed.set()
+        t.join(timeout=2.0)
+
+        assert not t.is_alive()
+        assert holder["result"] is True, "Pause longer than the timeout must not expire the budget"
+
+    def test_completes_after_resume_within_remaining_budget(self):
+        """After a long pause, the remaining active budget still applies."""
+        session = _make_session()
+        t, holder = _run_waiter(session, timeout=0.3)
+
+        time.sleep(0.05)
+        session._paused = True
+        time.sleep(0.4)  # longer than the whole budget
+        session._paused = False
+        # Do NOT complete: the remaining active budget (~0.25s) should still
+        # expire and return False, proving pause time was excluded.
+        t.join(timeout=2.0)
+
+        assert not t.is_alive()
+        assert holder["result"] is False, "Remaining active budget must still expire after resume"
+
+    def test_total_active_time_exceeds_pause_duration(self):
+        """Wall-clock elapsed is pause + active-budget, not just the budget."""
+        session = _make_session()
+        budget = 0.3
+        pause = 0.4
+        start = time.monotonic()
+        t, holder = _run_waiter(session, timeout=budget)
+
+        time.sleep(0.05)
+        session._paused = True
+        time.sleep(pause)
+        session._paused = False
+        t.join(timeout=2.0)
+        elapsed = time.monotonic() - start
+
+        assert not t.is_alive()
+        assert holder["result"] is False
+        # Elapsed wall-clock must reflect BOTH the pause and the active budget,
+        # i.e. substantially more than the budget alone.
+        assert elapsed >= pause, "Pause duration must be excluded from the budget"
+
+
+class TestWaitForCompletionResumeTransition:
+    """Completing while paused returns promptly."""
+
+    def test_completing_while_paused_returns_true(self):
+        """If the session is stopped (completed set) mid-pause, return True."""
+        session = _make_session()
+        t, holder = _run_waiter(session, timeout=10.0)
+        session._paused = True
+        time.sleep(0.1)
+        # stop_session sets completed and (later) clears _paused; here just set
+        # completed — the inner pause loop checks completed too.
+        session.completed.set()
+        t.join(timeout=2.0)
+
+        assert not t.is_alive()
+        assert holder["result"] is True
+
+    def test_multiple_pause_resume_cycles(self):
+        """Repeated pause/resume each exclude their time from the budget."""
+        session = _make_session()
+        budget = 0.3
+        t, holder = _run_waiter(session, timeout=budget)
+
+        # Two short pauses with active gaps between them.
+        for _ in range(2):
+            session._paused = True
+            time.sleep(0.25)  # each pause alone is < budget but 2x approaches it
+            session._paused = False
+            time.sleep(0.02)
+        session.completed.set()
+        t.join(timeout=2.0)
+
+        assert not t.is_alive()
+        assert holder["result"] is True, "Pauses (not active time) must not consume the budget"
+
+
+class TestRunLocalUsesPauseAwareWait:
+    """_run_local forwards the wait through _wait_for_completion (not raw wait)."""
+
+    def test_run_local_calls_wait_for_completion(self):
+        """The blocking wait in _run_local must go through _wait_for_completion."""
+        runner = AutonomousAgentRunner()
+        calls = {}
+
+        def fake_wait(session, timeout):
+            calls["timeout"] = timeout
+            calls["session"] = session
+            return True
+
+        runner._wait_for_completion = fake_wait  # type: ignore[assignment]
+
+        # Minimal mock process + adapter so _run_local reaches the wait.
+        proc = MagicMock()
+        proc.pid = 123
+        proc.returncode = None
+        mock_adapter = MagicMock()
+        mock_adapter.get_executable_name.return_value = "codex"
+        mock_adapter.build_start_args.return_value = ["codex"]
+        mock_cli_adapters = MagicMock()
+        mock_cli_adapters.get_adapter.return_value = mock_adapter
+
+        with (
+            patch.dict("sys.modules", {"cli_adapters": mock_cli_adapters}),
+            patch("shutil.which", return_value="/usr/bin/codex"),
+            patch("subprocess.Popen", return_value=proc),
+            patch.object(AutonomousAgentRunner, "_send_sdk_init"),
+            patch.object(AutonomousAgentRunner, "_send_message"),
+            patch.object(AutonomousAgentRunner, "_read_stdout"),
+            patch.object(AutonomousAgentRunner, "_read_stderr"),
+            patch("os.getpgid", return_value=123),
+            patch("os.killpg"),
+        ):
+            result = runner._run_local(
+                session_id="s-1",
+                cli_tool="codex",
+                model="m",
+                project_path="/tmp/x",
+                prompt="hi",
+                permission_mode="auto-edit",
+                timeout=42,
+                workflow_id="wf-1",
+                user_id=1,
+                workspace_type="local",
+                allowed_tools=None,
+                resume=False,
+                resume_session_id=None,
+                milestone_id="m1",
+            )
+
+        assert calls.get("timeout") == 42
+        assert calls.get("session") is not None
+        # fake_wait returned True (completed) and codex is not a sidebar tool,
+        # so the result follows the success path.
+        assert result.success is True


### PR DESCRIPTION
## Problem (#1005)

Pausing a workflow SIGSTOPs the agent process, but `_run_local` waited on:

```python
completed = session.completed.wait(timeout=timeout)   # wall-clock countdown
```

`threading.Event.wait(timeout=...)` is a wall-clock timer — it keeps ticking while the process is frozen. So pausing a task longer than the timeout (default **1h**) reaped the in-flight agent and marked the phase `failed`. Pause did not "freeze time":

> 10:14:25 dev agent starts → 10:14:38 pause (SIGSTOP) → **11:14:30** `dev_started` milestone fails — exactly 3600s later, killed by the timeout.

## Fix

Replace the single wall-clock wait with a **pause-aware** `_wait_for_completion` loop in `agent_runner.py`:

- Waits `session.completed` in short increments (`COMPLETION_POLL_INTERVAL`, default 5s); returns immediately when `completed` is set, so no idle overhead.
- While `session._paused` is set, **freezes the deadline** — blocks until resume (or completion), then extends the deadline by the full paused duration so the remaining active budget resumes from where it left off.
- Reuses the existing `_paused` flag toggled by `pause_session` / `resume_session` / `stop_session` — no DB polling needed.

Result: the timeout now means **"agent actually ran for N seconds"**, not wall-clock. Pausing for >1h no longer kills the in-flight agent.

## Configuration

Task timeout (1h default) is configurable via the `AUTONOMOUS_TASK_TIMEOUT` env var (seconds); invalid values fall back to 3600. (Documented in the issue thread.)

## Tests

New: `tests/issues/1005/test_pause_aware_timeout.py` (8 tests)
- pause longer than timeout does **not** expire (the core regression)
- remaining active budget still expires after resume
- wall-clock elapsed reflects pause + active (not just budget)
- completing while paused / multiple pause-resume cycles
- `_run_local` routes the wait through `_wait_for_completion`

Existing `tests/issues/716` (agent_runner) and `tests/issues/1003` (session-usage) still pass — no regressions. ruff / black / isort / mypy / bandit all clean.

Closes #1005.