### PR TITLE
fix: ROI成本分解饼图重复显示相同工具名称 (#822)

### DIFF
--- a/app/modules/analytics/roi_calculator.py
+++ b/app/modules/analytics/roi_calculator.py
@@ -5,6 +5,7 @@ Calculates Return on Investment for AI usage.
 Provides cost analysis, savings estimation, and productivity metrics.
 """
 
+import json
 import logging
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
@@ -802,6 +803,27 @@ class ROICalculator:
 
         return result
 
+    @staticmethod
+    def _merge_models(model1: str, model2: str) -> str:
+        """
+        Merge two model JSON array strings, deduplicate and sort.
+
+        Args:
+            model1: First model JSON string (e.g., '["glm-5"]').
+            model2: Second model JSON string.
+
+        Returns:
+            Merged and sorted JSON array string.
+        """
+        try:
+            m1 = json.loads(model1) if model1 and model1 != "unknown" else []
+            m2 = json.loads(model2) if model2 and model2 != "unknown" else []
+            merged = sorted(set(m1 + m2))
+            return json.dumps(merged, ensure_ascii=False) if merged else "unknown"
+        except (json.JSONDecodeError, TypeError):
+            # Fallback: return non-empty value or "unknown"
+            return model1 or model2 or "unknown"
+
     @cached(ttl=60, key_prefix="roi", skip_args=[0])
     def get_cost_breakdown(
         self, start_date: str, end_date: str, user_id: Optional[int] = None
@@ -858,7 +880,24 @@ class ROICalculator:
                 )
             )
 
-        return breakdown
+        # Aggregate by tool_name (multiple rows may have same tool_name with different models)
+        aggregated: dict[str, CostBreakdown] = {}
+        for item in breakdown:
+            tool = item.tool_name
+            if tool in aggregated:
+                agg = aggregated[tool]
+                agg.requests += item.requests
+                agg.input_tokens += item.input_tokens
+                agg.output_tokens += item.output_tokens
+                agg.input_cost += item.input_cost
+                agg.output_cost += item.output_cost
+                agg.total_cost += item.total_cost
+                # Merge model lists
+                agg.model = self._merge_models(agg.model, item.model)
+            else:
+                aggregated[tool] = item
+
+        return list(aggregated.values())
 
     @cached(ttl=60, key_prefix="roi", skip_args=[0])
     def get_daily_costs(

--- a/tests/unit/test_roi_calculator.py
+++ b/tests/unit/test_roi_calculator.py
@@ -1,5 +1,6 @@
 """Unit tests for ROICalculator module."""
 
+import json
 from unittest.mock import MagicMock
 
 import pytest
@@ -124,6 +125,72 @@ class TestROICalculator:
         assert len(breakdown) == 1
         assert breakdown[0].total_cost > 0
         assert isinstance(breakdown[0], CostBreakdown)
+
+    def test_get_cost_breakdown_aggregates_same_tool(self):
+        """Same tool_name with different models_used should be aggregated."""
+        calc, mock_db = self._make_calculator()
+        mock_db.fetch_all.return_value = [
+            {
+                "tool_name": "qwen-code",
+                "model": json.dumps(["glm-5"]),
+                "requests": 50,
+                "input_tokens": 10000,
+                "output_tokens": 5000,
+            },
+            {
+                "tool_name": "qwen-code-cli",
+                "model": json.dumps(["qwen3.6-plus"]),
+                "requests": 30,
+                "input_tokens": 5000,
+                "output_tokens": 2000,
+            },
+            {
+                "tool_name": "claude-code",
+                "model": json.dumps(["claude-3-sonnet"]),
+                "requests": 10,
+                "input_tokens": 2000,
+                "output_tokens": 1000,
+            },
+        ]
+        breakdown = calc.get_cost_breakdown("2026-01-01", "2026-01-31")
+
+        # Should aggregate to 2 items: qwen and claude
+        assert len(breakdown) == 2
+
+        qwen_item = next(b for b in breakdown if b.tool_name == "qwen")
+        assert qwen_item.requests == 80
+        assert qwen_item.input_tokens == 15000
+        assert qwen_item.output_tokens == 7000
+
+        # Verify model merge
+        models = json.loads(qwen_item.model)
+        assert "glm-5" in models
+        assert "qwen3.6-plus" in models
+
+    def test_merge_models(self):
+        """Test _merge_models helper method."""
+        # Normal merge
+        result = ROICalculator._merge_models(json.dumps(["glm-5"]), json.dumps(["qwen3.6-plus"]))
+        models = json.loads(result)
+        assert "glm-5" in models
+        assert "qwen3.6-plus" in models
+        assert len(models) == 2
+
+        # Deduplication
+        result = ROICalculator._merge_models(
+            json.dumps(["glm-5", "qwen3.6-plus"]), json.dumps(["glm-5"])
+        )
+        models = json.loads(result)
+        assert len(models) == 2  # Should not duplicate glm-5
+
+        # Empty values
+        result = ROICalculator._merge_models("unknown", json.dumps(["glm-5"]))
+        models = json.loads(result)
+        assert "glm-5" in models
+
+        # Both empty
+        result = ROICalculator._merge_models("", "")
+        assert result == "unknown"
 
     def test_get_daily_costs(self):
         calc, mock_db = self._make_calculator()


### PR DESCRIPTION
## Issue #822 修复

### 问题
管理模式ROI分析页面成本分解饼图显示重复的qwen工具

### 原因
- `get_cost_breakdown` 方法按 `tool_name + models_used` 分组查询
- `normalize_tool_name` 在 Python 层处理，导致标准化后相同 tool_name 出现多条记录
- 前端饼图直接使用 tool_name 作为标签，显示重复

### 修复方案
1. 添加 `_merge_models` 辅助方法处理 JSON 数组字符串合并（去重、排序）
2. 在 `get_cost_breakdown` 返回前按 tool_name 聚合数据
3. 合并相同工具的 requests、tokens、cost 等指标

### 测试
- `test_get_cost_breakdown_aggregates_same_tool`: 验证聚合逻辑
- `test_merge_models`: 验证 model 合并方法

### 文件修改
- `app/modules/analytics/roi_calculator.py`: 添加聚合逻辑
- `tests/unit/test_roi_calculator.py`: 添加测试用例