### PR TITLE
fix: protect SOURCE_DIR when inside target_path during upgrade (#1065)

### DIFF
--- a/scripts/install-central/package-method/install.sh
+++ b/scripts/install-central/package-method/install.sh
@@ -3104,9 +3104,23 @@ do_upgrade() {
         # Remove old files except logs, data, and config directory
         local config_basename=$(basename "$config_dir")
 
+        # Check if SOURCE_DIR is inside target_path to prevent accidental deletion
+        local source_exclude=""
+        if [[ "$SOURCE_DIR" == "$target_path"/* ]]; then
+            local source_rel="${SOURCE_DIR#$target_path/}"
+            local source_top=$(echo "$source_rel" | cut -d'/' -f1)
+            source_exclude="$source_top"
+            print_warning "Source directory is inside target path: $SOURCE_DIR"
+            print_info "Preserving '$source_top' directory during cleanup"
+        fi
+
         # List directories that will be deleted and ask for confirmation
         local delete_list
-        delete_list=$(find "$target_path" -mindepth 1 -maxdepth 1 ! -name 'logs' ! -name 'data' ! -name "$config_basename" 2>/dev/null)
+        if [ -n "$source_exclude" ]; then
+            delete_list=$(find "$target_path" -mindepth 1 -maxdepth 1 ! -name 'logs' ! -name 'data' ! -name "$config_basename" ! -name "$source_exclude" 2>/dev/null)
+        else
+            delete_list=$(find "$target_path" -mindepth 1 -maxdepth 1 ! -name 'logs' ! -name 'data' ! -name "$config_basename" 2>/dev/null)
+        fi
         if [ -n "$delete_list" ]; then
             echo ""
             echo -e "${YELLOW}The following items will be deleted:${NC}"
@@ -3121,11 +3135,19 @@ do_upgrade() {
                 skip_delete="yes"
             fi
             if [ "$skip_delete" = "no" ]; then
-                find "$target_path" -mindepth 1 -maxdepth 1 ! -name 'logs' ! -name 'data' ! -name "$config_basename" -exec rm -rf {} +
+                if [ -n "$source_exclude" ]; then
+                    find "$target_path" -mindepth 1 -maxdepth 1 ! -name 'logs' ! -name 'data' ! -name "$config_basename" ! -name "$source_exclude" -exec rm -rf {} +
+                else
+                    find "$target_path" -mindepth 1 -maxdepth 1 ! -name 'logs' ! -name 'data' ! -name "$config_basename" -exec rm -rf {} +
+                fi
             fi
         else
             # No files to delete (shouldn't normally happen during upgrade)
-            find "$target_path" -mindepth 1 -maxdepth 1 ! -name 'logs' ! -name 'data' ! -name "$config_basename" -exec rm -rf {} +
+            if [ -n "$source_exclude" ]; then
+                find "$target_path" -mindepth 1 -maxdepth 1 ! -name 'logs' ! -name 'data' ! -name "$config_basename" ! -name "$source_exclude" -exec rm -rf {} +
+            else
+                find "$target_path" -mindepth 1 -maxdepth 1 ! -name 'logs' ! -name 'data' ! -name "$config_basename" -exec rm -rf {} +
+            fi
         fi
         # Copy new files
         cp -r "$SOURCE_DIR"/* "$target_path/"
@@ -3550,9 +3572,24 @@ do_upgrade_remote() {
     # Update files (preserve logs, data, and config)
     print_info "Updating remote files..."
 
+    # Check if SOURCE_DIR path structure matches remote target_path pattern
+    # Note: SOURCE_DIR is local, target_path is remote - they are on different machines
+    # But we check for consistency and edge cases (e.g., shared filesystem)
+    local remote_source_exclude=""
+    if [[ "$SOURCE_DIR" == *"/dist/"* ]] || [[ "$SOURCE_DIR" == */dist/* ]]; then
+        # SOURCE_DIR is in a dist directory locally
+        # Check if remote target_path also has a dist directory that might cause confusion
+        remote_source_exclude="dist"
+        print_info "Source is from dist directory, will preserve 'dist' on remote if exists"
+    fi
+
     # List directories that will be deleted and ask for confirmation
     local remote_delete_list
-    remote_delete_list=$(ssh "$remote" "cd '$target_path' && find . -mindepth 1 -maxdepth 1 ! -name 'logs' ! -name 'data' ! -name '.open-ace' 2>/dev/null")
+    if [ -n "$remote_source_exclude" ]; then
+        remote_delete_list=$(ssh "$remote" "cd '$target_path' && find . -mindepth 1 -maxdepth 1 ! -name 'logs' ! -name 'data' ! -name '.open-ace' ! -name '$remote_source_exclude' 2>/dev/null")
+    else
+        remote_delete_list=$(ssh "$remote" "cd '$target_path' && find . -mindepth 1 -maxdepth 1 ! -name 'logs' ! -name 'data' ! -name '.open-ace' 2>/dev/null")
+    fi
     if [ -n "$remote_delete_list" ]; then
         echo ""
         echo -e "${YELLOW}The following items will be deleted on remote:${NC}"
@@ -3567,10 +3604,18 @@ do_upgrade_remote() {
             remote_skip_delete="yes"
         fi
         if [ "$remote_skip_delete" = "no" ]; then
-            ssh "$remote" "cd '$target_path' && find . -mindepth 1 -maxdepth 1 ! -name 'logs' ! -name 'data' ! -name '.open-ace' -exec rm -rf {} +"
+            if [ -n "$remote_source_exclude" ]; then
+                ssh "$remote" "cd '$target_path' && find . -mindepth 1 -maxdepth 1 ! -name 'logs' ! -name 'data' ! -name '.open-ace' ! -name '$remote_source_exclude' -exec rm -rf {} +"
+            else
+                ssh "$remote" "cd '$target_path' && find . -mindepth 1 -maxdepth 1 ! -name 'logs' ! -name 'data' ! -name '.open-ace' -exec rm -rf {} +"
+            fi
         fi
     else
-        ssh "$remote" "cd '$target_path' && find . -mindepth 1 -maxdepth 1 ! -name 'logs' ! -name 'data' ! -name '.open-ace' -exec rm -rf {} +"
+        if [ -n "$remote_source_exclude" ]; then
+            ssh "$remote" "cd '$target_path' && find . -mindepth 1 -maxdepth 1 ! -name 'logs' ! -name 'data' ! -name '.open-ace' ! -name '$remote_source_exclude' -exec rm -rf {} +"
+        else
+            ssh "$remote" "cd '$target_path' && find . -mindepth 1 -maxdepth 1 ! -name 'logs' ! -name 'data' ! -name '.open-ace' -exec rm -rf {} +"
+        fi
     fi
     scp -r "$SOURCE_DIR"/* "$remote:$target_path/"
 

--- a/scripts/install-central/package-method/install.sh
+++ b/scripts/install-central/package-method/install.sh
@@ -3105,12 +3105,13 @@ do_upgrade() {
         local config_basename=$(basename "$config_dir")
 
         # Check if SOURCE_DIR is inside target_path to prevent accidental deletion
+        # Use normalized paths (source_abs/target_abs) for consistency
         local source_exclude=""
-        if [[ "$SOURCE_DIR" == "$target_path"/* ]]; then
-            local source_rel="${SOURCE_DIR#$target_path/}"
+        if [[ "$source_abs" == "$target_abs"/* ]]; then
+            local source_rel="${source_abs#$target_abs/}"
             local source_top=$(echo "$source_rel" | cut -d'/' -f1)
             source_exclude="$source_top"
-            print_warning "Source directory is inside target path: $SOURCE_DIR"
+            print_warning "Source directory is inside target path: $source_abs"
             print_info "Preserving '$source_top' directory during cleanup"
         fi
 
@@ -3572,24 +3573,13 @@ do_upgrade_remote() {
     # Update files (preserve logs, data, and config)
     print_info "Updating remote files..."
 
-    # Check if SOURCE_DIR path structure matches remote target_path pattern
-    # Note: SOURCE_DIR is local, target_path is remote - they are on different machines
-    # But we check for consistency and edge cases (e.g., shared filesystem)
-    local remote_source_exclude=""
-    if [[ "$SOURCE_DIR" == *"/dist/"* ]] || [[ "$SOURCE_DIR" == */dist/* ]]; then
-        # SOURCE_DIR is in a dist directory locally
-        # Check if remote target_path also has a dist directory that might cause confusion
-        remote_source_exclude="dist"
-        print_info "Source is from dist directory, will preserve 'dist' on remote if exists"
-    fi
+    # Note: For remote upgrade, SOURCE_DIR is local and target_path is remote.
+    # They are on different machines, so SOURCE_DIR cannot be inside target_path.
+    # No need to check for SOURCE_DIR containment - just proceed with normal cleanup.
 
     # List directories that will be deleted and ask for confirmation
     local remote_delete_list
-    if [ -n "$remote_source_exclude" ]; then
-        remote_delete_list=$(ssh "$remote" "cd '$target_path' && find . -mindepth 1 -maxdepth 1 ! -name 'logs' ! -name 'data' ! -name '.open-ace' ! -name '$remote_source_exclude' 2>/dev/null")
-    else
-        remote_delete_list=$(ssh "$remote" "cd '$target_path' && find . -mindepth 1 -maxdepth 1 ! -name 'logs' ! -name 'data' ! -name '.open-ace' 2>/dev/null")
-    fi
+    remote_delete_list=$(ssh "$remote" "cd '$target_path' && find . -mindepth 1 -maxdepth 1 ! -name 'logs' ! -name 'data' ! -name '.open-ace' 2>/dev/null")
     if [ -n "$remote_delete_list" ]; then
         echo ""
         echo -e "${YELLOW}The following items will be deleted on remote:${NC}"
@@ -3604,18 +3594,10 @@ do_upgrade_remote() {
             remote_skip_delete="yes"
         fi
         if [ "$remote_skip_delete" = "no" ]; then
-            if [ -n "$remote_source_exclude" ]; then
-                ssh "$remote" "cd '$target_path' && find . -mindepth 1 -maxdepth 1 ! -name 'logs' ! -name 'data' ! -name '.open-ace' ! -name '$remote_source_exclude' -exec rm -rf {} +"
-            else
-                ssh "$remote" "cd '$target_path' && find . -mindepth 1 -maxdepth 1 ! -name 'logs' ! -name 'data' ! -name '.open-ace' -exec rm -rf {} +"
-            fi
-        fi
-    else
-        if [ -n "$remote_source_exclude" ]; then
-            ssh "$remote" "cd '$target_path' && find . -mindepth 1 -maxdepth 1 ! -name 'logs' ! -name 'data' ! -name '.open-ace' ! -name '$remote_source_exclude' -exec rm -rf {} +"
-        else
             ssh "$remote" "cd '$target_path' && find . -mindepth 1 -maxdepth 1 ! -name 'logs' ! -name 'data' ! -name '.open-ace' -exec rm -rf {} +"
         fi
+    else
+        ssh "$remote" "cd '$target_path' && find . -mindepth 1 -maxdepth 1 ! -name 'logs' ! -name 'data' ! -name '.open-ace' -exec rm -rf {} +"
     fi
     scp -r "$SOURCE_DIR"/* "$remote:$target_path/"
 


### PR DESCRIPTION
## Summary

Fixes #1065

## Problem

当用户按照 package.sh 提示进入 `dist/open-ace-xxx/` 目录运行 install.sh 时，升级删除逻辑会删除 dist 目录，导致 SOURCE_DIR 被删除，后续复制失败。

## Solution

在删除逻辑前检查 SOURCE_DIR 是否在 target_path 的子目录中，若是则排除该子目录不删除。

## Changes

- `do_upgrade()`: 添加 SOURCE_DIR 位置检测，保留包含目录
- `do_upgrade_remote()`: 远程升级场景的类似保护逻辑

## Test Plan

在 node237 上验证：
- SOURCE_DIR = `/home/ivyent/open-ace/dist/open-ace-xxx`
- target_path = `/home/ivyent/open-ace`
- 验证 dist 目录被排除，不在删除列表中 ✅