### PR TITLE
fix: 管理模式页面 PageRefreshControl 与 Header 重叠问题 (Issue #1068)

### DIFF
--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -1049,8 +1049,11 @@ link[rel='dns-prefetch'] {
 /* Page Refresh Control - ensure buttons are clickable (not blocked by sticky header) */
 /* Header z-index is 310 (z-fixed + 10), need higher z-index to be above header's backdrop-filter layer */
 /* Override position-absolute and top/end offsets from positionStyles to prevent covering header */
+/* Issue #1068: Extend selector to cover PageRefreshControl in all flex containers (manage mode pages) */
 .page-header-controls .page-refresh-control,
-.page-header-controls .page-refresh-control-compact {
+.page-header-controls .page-refresh-control-compact,
+.d-flex .page-refresh-control,
+.d-flex .page-refresh-control-compact {
   position: relative;
   top: auto;
   right: auto;


### PR DESCRIPTION
## 问题描述

管理模式下，多个管理页面顶端的 `PageRefreshControl` 组件与页面顶部 `Header` 组件重叠，影响用户体验。

## 根因分析

PR #978 的 CSS 覆盖规则只针对 `.page-header-controls` 容器内的 `PageRefreshControl`，但其他管理页面使用 `.d-flex` 容器而非 `.page-header-controls`，导致组件使用默认的绝对定位 (`position-absolute`) 与顶部 Header 重叠。

## 修复方案

扩展 CSS 选择器，覆盖所有 flex 容器中的 PageRefreshControl：

```css
.page-header-controls .page-refresh-control,
.page-header-controls .page-refresh-control-compact,
.d-flex .page-refresh-control,
.d-flex .page-refresh-control-compact {
  position: relative;
  top: auto;
  right: auto;
  z-index: 320;
}
```

一处 CSS 改动解决所有管理页面问题。

## 受影响页面

修复后以下页面的 PageRefreshControl 将不再与 Header 重叠：
- APIKeyManagement.tsx
- AuditCenter.tsx
- ComplianceMgmt.tsx
- ProjectManagement.tsx
- QuotaAlerts.tsx
- QuotaManagement.tsx
- SecurityCenter.tsx
- TenantManagement.tsx
- UserManagement.tsx
- AnomalyDetection.tsx
- ROIAnalysis.tsx
- TrendAnalysis.tsx

## 测试验证

- [ ] 本地启动前端，访问管理模式各页面
- [ ] 确认 PageRefreshControl 不再与 Header 重叠
- [ ] 确认刷新按钮点击正常响应

Fixes #1068