### PR TITLE
fix: unify autonomous timeline status semantics

### DIFF
--- a/frontend/src/components/work/WorkflowTimeline.tsx
+++ b/frontend/src/components/work/WorkflowTimeline.tsx
@@ -1120,7 +1120,6 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
       icon: 'bi-circle',
       color: 'secondary',
     };
-    const statusIcon = STATUS_ICONS[milestone.status] || STATUS_ICONS.pending;
     const diffStats = parseDiffStats(milestone.diff_stats);
     const milestoneTime = formatMilestoneTime(getMilestoneAnchorTime(milestone));
     const llmSessionId =
@@ -1173,30 +1172,48 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
       ''
     ).trim();
     const milestoneSummary = rawSummary ? truncateInlineText(rawSummary, compact ? 120 : 220) : '';
-    const statusTone =
-      milestone.status === 'completed'
-        ? 'success'
-        : milestone.status === 'failed'
-          ? 'danger'
-          : isCurrentActiveMilestone
-            ? workflowStatusConfig.tone
-            : milestone.status === 'in_progress'
-              ? 'info'
-              : milestone.status === 'cancelled'
-                ? 'warning'
-                : 'muted';
-    const statusLabel =
-      milestone.status === 'completed'
-        ? t('autoStatusCompleted', language)
-        : milestone.status === 'failed'
-          ? t('autoStatusFailed', language)
-          : isCurrentActiveMilestone
-            ? workflowStatusLabel
-            : milestone.status === 'in_progress'
-              ? t('autoStatusDeveloping', language)
-              : milestone.status === 'cancelled'
-                ? t('autoStatusCancelled', language)
-                : t('autoStatusPending', language);
+    const statusDisplay = (() => {
+      if (milestone.status === 'completed') {
+        return {
+          icon: STATUS_ICONS.completed,
+          label: t('autoStatusCompleted', language),
+          tone: 'success' as const,
+        };
+      }
+      if (milestone.status === 'failed') {
+        return {
+          icon: STATUS_ICONS.failed,
+          label: t('autoStatusFailed', language),
+          tone: 'danger' as const,
+        };
+      }
+      if (isCurrentActiveMilestone) {
+        return {
+          icon: workflowStatusConfig.icon,
+          label: workflowStatusLabel,
+          tone: workflowStatusConfig.tone,
+        };
+      }
+      if (milestone.status === 'in_progress') {
+        return {
+          icon: STATUS_ICONS.in_progress,
+          label: t('autoStatusDeveloping', language),
+          tone: 'info' as const,
+        };
+      }
+      if (milestone.status === 'cancelled') {
+        return {
+          icon: STATUS_ICONS.cancelled,
+          label: t('autoStatusCancelled', language),
+          tone: 'warning' as const,
+        };
+      }
+      return {
+        icon: STATUS_ICONS.pending,
+        label: t('autoStatusPending', language),
+        tone: 'muted' as const,
+      };
+    })();
     const milestoneDuration =
       milestone.started_at && (milestone.completed_at || milestone.status === 'in_progress')
         ? formatDuration(milestone.started_at, milestone.completed_at ?? milestone.updated_at)
@@ -1218,12 +1235,14 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
         key={milestone.milestone_id}
         className={`timeline-milestone-card ${
           compact ? 'timeline-milestone-card--compact' : ''
-        } ${isExpanded ? 'timeline-milestone-card--expanded' : ''} timeline-milestone-card--${statusTone}`}
+        } ${isExpanded ? 'timeline-milestone-card--expanded' : ''} timeline-milestone-card--${statusDisplay.tone}`}
       >
         <div className="timeline-milestone-summary">
           <div className="timeline-milestone-summary-main">
-            <div className={`timeline-milestone-status timeline-milestone-status--${statusTone}`}>
-              <i className={`bi ${statusIcon}`}></i>
+            <div
+              className={`timeline-milestone-status timeline-milestone-status--${statusDisplay.tone}`}
+            >
+              <i className={`bi ${statusDisplay.icon}`}></i>
             </div>
             <div className="timeline-milestone-copy">
               <div className="timeline-milestone-title-row">
@@ -1253,8 +1272,8 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
               )}
               <div className="timeline-milestone-meta-row">
                 <div className="timeline-milestone-badges">
-                  <span className={`timeline-chip timeline-chip--${statusTone}`}>
-                    {statusLabel}
+                  <span className={`timeline-chip timeline-chip--${statusDisplay.tone}`}>
+                    {statusDisplay.label}
                   </span>
                   {milestone.round_number > 0 && (
                     <span className="timeline-chip timeline-chip--subtle">

--- a/frontend/src/components/work/WorkflowTimeline.tsx
+++ b/frontend/src/components/work/WorkflowTimeline.tsx
@@ -59,12 +59,12 @@ interface WorkflowTimelineProps {
 
 // Status icon map
 const STATUS_ICONS: Record<string, string> = {
-  completed: 'bi-check-circle-fill text-success',
-  in_progress: 'bi-arrow-repeat text-primary',
-  failed: 'bi-x-circle-fill text-danger',
-  cancelled: 'bi-slash-circle-fill text-secondary',
-  forked: 'bi-diagram-3-fill text-info',
-  pending: 'bi-circle text-muted',
+  completed: 'bi-check-circle-fill',
+  in_progress: 'bi-arrow-repeat',
+  failed: 'bi-x-circle-fill',
+  cancelled: 'bi-slash-circle-fill',
+  forked: 'bi-diagram-3-fill',
+  pending: 'bi-circle',
 };
 
 // Milestone type display config

--- a/frontend/src/components/work/WorkflowTimeline.tsx
+++ b/frontend/src/components/work/WorkflowTimeline.tsx
@@ -1162,6 +1162,8 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
     const canCancel =
       !compact && allowMilestoneActions && showForkCancel && milestone.status !== 'cancelled';
     const canExpand = hasLiveActivity || !!milestone.error_message;
+    const isCurrentActiveMilestone =
+      milestone.status === 'in_progress' && (milestone.dev_round || 1) === workflow.dev_round;
     const rawSummary = (
       milestone.tldr ||
       milestone.result_summary ||
@@ -1176,21 +1178,25 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
         ? 'success'
         : milestone.status === 'failed'
           ? 'danger'
-          : milestone.status === 'in_progress'
-            ? 'info'
-            : milestone.status === 'cancelled'
-              ? 'warning'
-              : 'muted';
+          : isCurrentActiveMilestone
+            ? workflowStatusConfig.tone
+            : milestone.status === 'in_progress'
+              ? 'info'
+              : milestone.status === 'cancelled'
+                ? 'warning'
+                : 'muted';
     const statusLabel =
       milestone.status === 'completed'
         ? t('autoStatusCompleted', language)
         : milestone.status === 'failed'
           ? t('autoStatusFailed', language)
-          : milestone.status === 'in_progress'
-            ? t('autoStatusDeveloping', language)
-            : milestone.status === 'cancelled'
-              ? t('autoStatusCancelled', language)
-              : t('autoStatusPending', language);
+          : isCurrentActiveMilestone
+            ? workflowStatusLabel
+            : milestone.status === 'in_progress'
+              ? t('autoStatusDeveloping', language)
+              : milestone.status === 'cancelled'
+                ? t('autoStatusCancelled', language)
+                : t('autoStatusPending', language);
     const milestoneDuration =
       milestone.started_at && (milestone.completed_at || milestone.status === 'in_progress')
         ? formatDuration(milestone.started_at, milestone.completed_at ?? milestone.updated_at)
@@ -1972,11 +1978,6 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
                           {t('autoDevRoundLabel', language)} {round}
                         </span>
                       </div>
-                      {round === workflow.dev_round && isActive && (
-                        <span className="timeline-chip timeline-chip--info">
-                          {t('autoStatusDeveloping', language)}
-                        </span>
-                      )}
                     </div>
 
                     <div className="timeline-stack">


### PR DESCRIPTION
## Summary
- make the current active milestone display the workflow status label/tone instead of hard-coding `开发中`
- remove the duplicate status chip on the `开发轮次 N` row so status is only shown at the workflow/header and active milestone levels
- keep historical milestone status rendering unchanged

## Testing
- npm run format:check -- src/components/work/WorkflowTimeline.tsx
- npm run typecheck