### PR TITLE
fix: alembic 使用 _get_db_url 自动处理 sudo 环境 GSSAPI 崩溃 (Issue #1067)

### DIFF
--- a/migrations/env.py
+++ b/migrations/env.py
@@ -38,11 +38,13 @@ target_metadata = None
 def get_url():
     """
     Get the database URL from environment or config.
-    Uses the centralized database configuration.
+    Uses scripts.shared.db._get_db_url which automatically handles
+    sudo environment by adding gssencmode=disable for PostgreSQL
+    to prevent GSSAPI/Kerberos crash (SIGSEGV).
     """
-    from app.repositories.database import get_database_url
+    from scripts.shared.db import _get_db_url
 
-    return get_database_url()
+    return _get_db_url()
 
 
 def run_migrations_offline() -> None:


### PR DESCRIPTION
## 问题描述

sudo 环境下执行 `python3 -m alembic upgrade head` 时，psycopg2 连接 PostgreSQL 因 GSSAPI/Kerberos 导致段错误 (SIGSEGV)。

## 根因分析

`migrations/env.py` 的 `get_url()` 函数使用了错误的函数：

| 函数 | 文件 | sudo 环境处理 |
|------|------|-------------|
| `get_database_url()` | `scripts/shared/config.py` | ❌ 不处理 sudo 环境 |
| `_get_db_url()` | `scripts/shared/db.py` | ✅ 自动添加 `gssencmode=disable` |

当存在 Kerberos 配置时，sudo 环境下的 GSSAPI 认证会导致 psycopg2 崩溃。

## 修复内容

修改 `migrations/env.py` 的 `get_url()` 函数，使用 `scripts/shared/db._get_db_url()` 替代 `app.repositories.database.get_database_url()`。

## 测试验证

在 node237 上验证：

- sudo 环境下 URL 自动添加 `?gssencmode=disable` 参数 ✅
- alembic 命令不再段错误 ✅

## 相关链接

- Issue #1067: https://github.com/open-ace/open-ace/issues/1067

🤖 Generated with Qwen Code (5-shotted by Qwen-Coder)