### PR TITLE
feat: add ZCode CLI support (single-shot + app-server persistent mode)

### DIFF
--- a/app/models/user_tool_account.py
+++ b/app/models/user_tool_account.py
@@ -41,6 +41,7 @@ TOOL_TYPES = {
     "claude": "Claude",
     "openclaw": "Openclaw",
     "codex": "Codex",
+    "zcode": "ZCode",
     "feishu": "飞书",
     "slack": "Slack",
     "other": "其他",

--- a/app/modules/workspace/remote_session_manager.py
+++ b/app/modules/workspace/remote_session_manager.py
@@ -191,6 +191,7 @@ class RemoteSessionManager:
             "qwen": "qwen-code",
             "codex": "codex-cli",
             "openclaw": "openclaw",
+            "zcode": "zcode",
         }
         settings_tool = settings_tool_map.get(tool_name, cli_tool)
         tool_settings = (
@@ -898,6 +899,8 @@ class RemoteSessionManager:
             "openclaw": "openai",
             "codex": "openai",
             "codex-cli": "openai",
+            "zcode": "anthropic",
+            "zcode-code": "anthropic",
         }
         return mapping.get(cli_tool, "openai")
 

--- a/app/routes/remote.py
+++ b/app/routes/remote.py
@@ -46,7 +46,7 @@ _auth_failure_lock = threading.Lock()
 _auth_failure_last_audit: dict[str, float] = {}
 _AUTH_FAILURE_RATE_LIMIT_SECONDS = 300  # 5 minutes
 
-_CLI_SETTINGS_TOOLS = ["claude-code", "qwen-code", "codex-cli"]
+_CLI_SETTINGS_TOOLS = ["claude-code", "qwen-code", "codex-cli", "zcode"]
 
 remote_bp = Blueprint("remote", __name__)
 

--- a/app/utils/tool_names.py
+++ b/app/utils/tool_names.py
@@ -3,6 +3,7 @@ TOOL_NAME_ALIASES = {
     "claude": ["claude", "claude-code"],
     "openclaw": ["openclaw"],
     "codex": ["codex", "codex-cli"],
+    "zcode": ["zcode", "zcode-code", "zcode-cli"],
 }
 
 CANONICAL_TOOL_NAMES = {
@@ -10,6 +11,8 @@ CANONICAL_TOOL_NAMES = {
     "qwen-code-cli": "qwen",
     "claude-code": "claude",
     "codex-cli": "codex",
+    "zcode-code": "zcode",
+    "zcode-cli": "zcode",
 }
 
 

--- a/frontend/src/components/features/management/APIKeyManagement.tsx
+++ b/frontend/src/components/features/management/APIKeyManagement.tsx
@@ -81,6 +81,7 @@ const cliToolOptions = [
   { value: 'claude-code', label: 'Claude Code (Anthropic)' },
   { value: 'qwen-code', label: 'Qwen Code (OpenAI)' },
   { value: 'codex-cli', label: 'Codex (OpenAI)' },
+  { value: 'zcode', label: 'ZCode (Anthropic)' },
 ];
 
 // Default settings templates

--- a/frontend/src/components/features/management/ToolAccountsEditor.tsx
+++ b/frontend/src/components/features/management/ToolAccountsEditor.tsx
@@ -13,6 +13,7 @@ const TOOL_TYPES = [
   { value: 'qwen', display: 'Qwen' },
   { value: 'claude', display: 'Claude' },
   { value: 'openclaw', display: 'Openclaw' },
+  { value: 'zcode', display: 'ZCode' },
   { value: 'feishu', display: '飞书' },
   { value: 'slack', display: 'Slack' },
   { value: 'other', display: '其他' },

--- a/frontend/src/components/work/AssistPanel.tsx
+++ b/frontend/src/components/work/AssistPanel.tsx
@@ -74,6 +74,7 @@ export const AssistPanel: React.FC<AssistPanelProps> = ({ collapsed = false }) =
     { id: 'claude', name: 'Claude', icon: 'bi-chat-square-text', url: '/work?tool=claude' },
     { id: 'qwen', name: 'Qwen', icon: 'bi-stars', url: '/work?tool=qwen' },
     { id: 'codex', name: 'Codex', icon: 'bi-cpu', url: '/work?tool=codex' },
+    { id: 'zcode', name: 'ZCode', icon: 'bi-terminal', url: '/work?tool=zcode' },
   ];
 
   // Help documents - titles in different languages

--- a/frontend/src/components/work/NewAutonomousModal.tsx
+++ b/frontend/src/components/work/NewAutonomousModal.tsx
@@ -251,6 +251,7 @@ export const NewAutonomousModal: React.FC<NewAutonomousModalProps> = ({
                 <option value="qwen-code-cli">Qwen Code</option>
                 <option value="codex">Codex CLI</option>
                 <option value="openclaw">OpenClaw</option>
+                <option value="zcode">ZCode</option>
               </>
             )}
           </select>

--- a/frontend/src/utils/formatToolName.test.ts
+++ b/frontend/src/utils/formatToolName.test.ts
@@ -12,6 +12,7 @@ describe('formatToolName', () => {
     expect(formatToolName('openclaw')).toBe('OpenClaw');
     expect(formatToolName('openai')).toBe('OpenAI');
     expect(formatToolName('codex')).toBe('Codex');
+    expect(formatToolName('zcode')).toBe('ZCode');
     expect(formatToolName('run_shell_command')).toBe('Shell');
   });
 
@@ -43,6 +44,7 @@ describe('TOOL_DISPLAY_NAMES', () => {
     expect(TOOL_DISPLAY_NAMES).toHaveProperty('openclaw');
     expect(TOOL_DISPLAY_NAMES).toHaveProperty('openai');
     expect(TOOL_DISPLAY_NAMES).toHaveProperty('codex');
+    expect(TOOL_DISPLAY_NAMES).toHaveProperty('zcode');
     expect(TOOL_DISPLAY_NAMES).toHaveProperty('run_shell_command');
   });
 });

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -32,6 +32,7 @@ const TOOL_DISPLAY_NAMES: Record<string, string> = {
   openclaw: 'OpenClaw',
   openai: 'OpenAI',
   codex: 'Codex',
+  zcode: 'ZCode',
   run_shell_command: 'Shell',
 };
 

--- a/remote-agent/cli_adapters/__init__.py
+++ b/remote-agent/cli_adapters/__init__.py
@@ -22,6 +22,7 @@ from .claude_code import ClaudeCodeAdapter
 from .codex_cli import CodexCLIAdapter
 from .openclaw import OpenClawAdapter
 from .qwen_code import QwenCodeAdapter
+from .zcode import ZCodeAdapter
 
 logger = logging.getLogger(__name__)
 
@@ -31,6 +32,8 @@ ADAPTERS = {
     "claude-code": ClaudeCodeAdapter,
     "codex": CodexCLIAdapter,
     "openclaw": OpenClawAdapter,
+    "zcode": ZCodeAdapter,
+    "zcode-code": ZCodeAdapter,
 }
 
 

--- a/remote-agent/cli_adapters/usage_parser.py
+++ b/remote-agent/cli_adapters/usage_parser.py
@@ -55,8 +55,48 @@ def extract_qwen_stream_usage(parsed: dict[str, Any]) -> dict[str, int] | None:
     return None
 
 
+def extract_zcode_usage(parsed: dict[str, Any]) -> dict[str, int] | None:
+    """Extract token usage from a ZCode result.
+
+    ZCode ``--json`` and the ZCode Protocol both report usage with
+    camelCase keys (verified against the running CLI):
+
+    .. code-block:: json
+
+        {"usage": {"inputTokens": N, "outputTokens": M,
+                   "cacheReadTokens": R, "reasoningTokens": T,
+                   "modelRequestCount": C}}
+
+    The persistent app-server also exposes a ``session/usage`` method with
+    the same top-level camelCase keys (no ``usage`` wrapper); we accept both.
+    Returns the common ``input``/``output`` keys plus zcode-specific extras
+    (``cache_read``, ``reasoning``, ``model_requests``) when present.
+    """
+    usage = parsed.get("usage")
+    if not isinstance(usage, dict):
+        # session/usage shape: keys live at the top level.
+        if any(k in parsed for k in ("inputTokens", "outputTokens")):
+            usage = parsed
+    if not isinstance(usage, dict):
+        return None
+    result: dict[str, int] = {
+        "input": usage.get("inputTokens", 0),
+        "output": usage.get("outputTokens", 0),
+    }
+    if "cacheReadTokens" in usage:
+        result["cache_read"] = usage.get("cacheReadTokens", 0)
+    if "reasoningTokens" in usage:
+        result["reasoning"] = usage.get("reasoningTokens", 0)
+    if "modelRequestCount" in usage:
+        result["model_requests"] = usage.get("modelRequestCount", 0)
+    return result
+
+
 # Known tools that use the Qwen usage format
 _QWEN_TOOLS = {"qwen-code-cli"}
+
+# Known tools that use the ZCode camelCase usage format
+_ZCODE_TOOLS = {"zcode", "zcode-code", "zcode-cli"}
 
 
 def extract_stream_usage(cli_tool: str, parsed: dict[str, Any]) -> dict[str, int] | None:
@@ -67,4 +107,6 @@ def extract_stream_usage(cli_tool: str, parsed: dict[str, Any]) -> dict[str, int
     """
     if cli_tool in _QWEN_TOOLS:
         return extract_qwen_stream_usage(parsed)
+    if cli_tool in _ZCODE_TOOLS:
+        return extract_zcode_usage(parsed)
     return extract_claude_stream_usage(parsed)

--- a/remote-agent/cli_adapters/zcode.py
+++ b/remote-agent/cli_adapters/zcode.py
@@ -162,6 +162,10 @@ class ZCodeAdapter(BaseCLIAdapter):
         """
         Build args to resume a ZCode session in single-shot mode.
 
+        This is the single-shot resume entry point used by the autonomous runner
+        (one process per resumed turn); the persistent app-server path resumes
+        via session/resume in ZCodeAppServerSession.start instead.
+
         ``--resume <sess_id>`` restores full conversation context; ``--prompt``
         is required (it drives the resumed turn).
         """

--- a/remote-agent/cli_adapters/zcode.py
+++ b/remote-agent/cli_adapters/zcode.py
@@ -78,12 +78,18 @@ class ZCodeAdapter(BaseCLIAdapter):
         """
         Get environment variables for ZCode.
 
-        ZCode's ``anthropic`` provider reads ``ANTHROPIC_BASE_URL`` natively
-        (verified in the zcode.cjs provider factory). Credentials live in
-        ``~/.zcode/cli/config.json`` written by ``write_zcode_settings``; the
-        proxy base URL is injected here so requests route through Open ACE.
+        ZCode's ``anthropic`` provider factory reads both ``ANTHROPIC_BASE_URL``
+        and ``ANTHROPIC_API_KEY`` from the environment (verified in zcode.cjs's
+        ``wJ``/``sMe`` factories), mirroring the Claude adapter. We set both so
+        the per-session proxy token authenticates every request through the Open
+        ACE LLM proxy, and the base URL routes to it. This takes precedence over
+        any credential in ``~/.zcode/cli/config.json``.
         """
-        return {"ANTHROPIC_BASE_URL": proxy_url.rstrip("/")}
+        base = proxy_url.rstrip("/")
+        return {
+            "ANTHROPIC_API_KEY": proxy_token,
+            "ANTHROPIC_BASE_URL": base,
+        }
 
     def _uses_bundled_engine(self) -> bool:
         """Whether the engine is the bundled app script (needs ``node`` prefix)."""

--- a/remote-agent/cli_adapters/zcode.py
+++ b/remote-agent/cli_adapters/zcode.py
@@ -1,0 +1,213 @@
+"""
+Open ACE - ZCode CLI Adapter
+
+Adapter for the ZCode CLI tool. ZCode is the CLI engine bundled with the
+ZCode desktop app on macOS and resolves to a Node.js entry script:
+
+    /Applications/ZCode.app/Contents/Resources/glm/zcode.cjs
+
+It is invoked as ``node <engine> ...``. Unlike Claude Code, ZCode does NOT
+support the ``--print --input-format stream-json`` stdin protocol or a
+``control_request`` SDK control plane. It offers two non-interactive modes:
+
+  * single-shot: ``node <engine> --prompt "<text>" --json``
+      one request per process; the response JSON carries token usage.
+  * persistent : ``node <engine> app-server``
+      a long-lived process speaking the *ZCode Protocol* (a method/params
+      dialect, not JSON-RPC) over stdio, with ``session/create|send|events|
+      resume|usage|list`` methods.
+
+For autonomous single-task runs the executor uses ``build_single_shot_args``;
+for streaming multi-turn sessions the executor talks to ``app-server``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+
+from .base import BaseCLIAdapter
+
+logger = logging.getLogger(__name__)
+
+# Path to the CLI engine bundled inside the ZCode desktop app.
+_APP_ENGINE = "/Applications/ZCode.app/Contents/Resources/glm/zcode.cjs"
+
+
+def _resolve_engine() -> str:
+    """Return the CLI engine path/invocation.
+
+    Prefer the bundled engine inside the desktop app. Otherwise fall back to
+    a ``zcode`` symlink/script on PATH (set up via ``get_install_command``).
+    """
+    if os.path.isfile(_APP_ENGINE):
+        return _APP_ENGINE
+    found = shutil.which("zcode")
+    if found:
+        return found
+    return "zcode"
+
+
+class ZCodeAdapter(BaseCLIAdapter):
+    """Adapter for the ZCode CLI tool."""
+
+    EXECUTABLE = "zcode"
+    DISPLAY_NAME = "ZCode"
+    ENGINE = _resolve_engine()
+
+    def get_install_command(self) -> str:
+        """Return the command to install ZCode.
+
+        ZCode ships with the ZCode desktop app. To expose the engine on PATH
+        as ``zcode``, symlink the bundled engine:
+
+            sudo ln -s {engine} /usr/local/bin/zcode
+        """
+        return (
+            f"sudo ln -s {_APP_ENGINE} /usr/local/bin/zcode "
+            f"|| echo 'ZCode ships with the ZCode desktop app; "
+            f"see app bundle at {_APP_ENGINE}'"
+        )
+
+    def check_installed(self) -> bool:
+        """Check if the ZCode engine is available."""
+        return os.path.isfile(_APP_ENGINE) or shutil.which("zcode") is not None
+
+    def get_env_vars(self, proxy_url: str, proxy_token: str) -> dict[str, str]:
+        """
+        Get environment variables for ZCode.
+
+        ZCode's ``anthropic`` provider reads ``ANTHROPIC_BASE_URL`` natively
+        (verified in the zcode.cjs provider factory). Credentials live in
+        ``~/.zcode/cli/config.json`` written by ``write_zcode_settings``; the
+        proxy base URL is injected here so requests route through Open ACE.
+        """
+        return {"ANTHROPIC_BASE_URL": proxy_url.rstrip("/")}
+
+    def _uses_bundled_engine(self) -> bool:
+        """Whether the engine is the bundled app script (needs ``node`` prefix)."""
+        return self.ENGINE == _APP_ENGINE or self.ENGINE.endswith(".cjs")
+
+    def _base_cmd(self) -> list[str]:
+        """Prefix with ``node`` when invoking the bundled .cjs engine."""
+        if self._uses_bundled_engine():
+            return ["node", self.ENGINE]
+        return [self.ENGINE]
+
+    def build_start_args(
+        self,
+        session_id: str,
+        project_path: str,
+        model: str | None = None,
+        permission_mode: str | None = None,
+        allowed_tools: list[str] | None = None,
+        resume: bool = False,
+    ) -> list[str]:
+        """
+        Build command-line arguments to start ZCode (persistent ``app-server``).
+
+        The persistent mode keeps a single process alive for the whole agent
+        session; the executor then drives it via the ZCode Protocol over stdio.
+        ``--cwd`` and ``--mode`` set the workspace and permission posture.
+        """
+        args = self._base_cmd() + [
+            "app-server",
+            "--cwd",
+            project_path,
+        ]
+        mode = self._map_permission_mode(permission_mode)
+        args += ["--mode", mode]
+        # NOTE: the CLI has no --model flag for headless/app-server modes (passing
+        # it makes zcode print help and exit). The active model is selected via
+        # ~/.zcode/cli/config.json (written by write_zcode_settings).
+        return args
+
+    def build_single_shot_args(
+        self, prompt: str, project_path: str, model: str | None = None
+    ) -> list[str]:
+        """
+        Build args for a single-shot prompt execution (autonomous runner).
+
+        Emits machine-readable JSON (``--json``) with a ``usage`` block and a
+        ``projection`` status. ``--mode yolo`` lets the agent run tools
+        autonomously without confirmation prompts. The model is taken from
+        ~/.zcode/cli/config.json (there is no headless --model flag).
+        """
+        args = self._base_cmd() + [
+            "--cwd",
+            project_path,
+            "--prompt",
+            prompt,
+            "--mode",
+            "yolo",
+            "--json",
+            "--no-color",
+        ]
+        return args
+
+    def build_resume_args(
+        self,
+        session_id: str,
+        project_path: str,
+        prompt: str,
+        model: str | None = None,
+    ) -> list[str]:
+        """
+        Build args to resume a ZCode session in single-shot mode.
+
+        ``--resume <sess_id>`` restores full conversation context; ``--prompt``
+        is required (it drives the resumed turn).
+        """
+        args = self._base_cmd() + [
+            "--cwd",
+            project_path,
+            "--resume",
+            session_id,
+            "--prompt",
+            prompt,
+            "--mode",
+            "yolo",
+            "--json",
+            "--no-color",
+        ]
+        return args
+
+    @staticmethod
+    def _map_permission_mode(permission_mode: str | None) -> str:
+        """Map Open ACE permission modes to ZCode modes.
+
+        ZCode modes: ``build`` (ask before edits), ``edit`` (auto-edit),
+        ``plan`` (read-only planning), ``yolo`` (fully autonomous).
+        """
+        mode_map = {
+            "bypass": "yolo",
+            "full-auto": "yolo",
+            "auto": "build",
+            "auto-edit": "edit",
+            "plan": "plan",
+        }
+        return mode_map.get(permission_mode or "", "yolo")
+
+    def supports_stdin_input(self) -> bool:
+        """
+        Return False; the tool does not use the stream-json stdin protocol.
+
+        Persistent sessions are driven through ``app-server`` (a separate
+        stdio protocol handled by ``ZCodeAppServerSession``), not the generic
+        stdin pipe used for Claude/Qwen. Single-shot runs take the prompt on
+        the command line.
+        """
+        return False
+
+    def get_display_name(self) -> str:
+        """Return the display name for this CLI tool."""
+        return self.DISPLAY_NAME
+
+    def get_executable_name(self) -> str:
+        """Return the executable name."""
+        return self.EXECUTABLE
+
+    def get_settings_path(self) -> str:
+        """Return the path to the ZCode config.json."""
+        return os.path.expanduser("~/.zcode/cli/config.json")

--- a/remote-agent/cli_settings.py
+++ b/remote-agent/cli_settings.py
@@ -253,6 +253,57 @@ def write_codex_settings(
     return config_path
 
 
+def write_zcode_settings(
+    settings: dict[str, Any],
+    proxy_base_url: str,
+    home_dir: Path | None = None,
+) -> Path:
+    """Merge and write ~/.zcode/cli/config.json.
+
+    ZCode uses a ``zcode.config.v1`` schema where each provider lives under a
+    top-level ``provider`` map with an ``options`` block (``baseURL``/``apiKey``)
+    and a ``model`` selector in ``provider/model`` format. We merge onto any
+    existing config, inject the proxy ``baseURL`` and ``apiKey`` into the
+    ``zai`` (Anthropic-compatible) provider, and default the model selector.
+    """
+    base_dir = home_dir or Path.home()
+    config_path = base_dir / ".zcode" / "cli" / "config.json"
+    merged = _load_json_file(config_path)
+
+    providers = merged.setdefault("provider", {})
+    zai = providers.setdefault(
+        "zai",
+        {
+            "id": "zai",
+            "kind": "anthropic",
+            "name": "Z.AI (Anthropic-compatible)",
+            "options": {},
+        },
+    )
+    if not isinstance(zai, dict):
+        zai = providers["zai"] = {
+            "id": "zai",
+            "kind": "anthropic",
+            "name": "Z.AI (Anthropic-compatible)",
+            "options": {},
+        }
+    options = zai.setdefault("options", {})
+    if not isinstance(options, dict):
+        options = zai["options"] = {}
+
+    # Route model traffic through the Open ACE proxy.
+    options["baseURL"] = proxy_base_url.rstrip("/")
+    api_key = settings.get("api_key") or settings.get("apiKey")
+    if api_key:
+        options["apiKey"] = api_key
+
+    # Default the model selector if the user hasn't configured one.
+    merged.setdefault("model", {"main": "zai/glm-5.2", "lite": "zai/glm-4.5-air"})
+
+    _atomic_write_json(config_path, merged)
+    return config_path
+
+
 def apply_cli_settings(
     cli_settings: dict[str, Any],
     proxy_base_url: str,
@@ -270,6 +321,8 @@ def apply_cli_settings(
                 write_qwen_settings(settings, proxy_base_url=proxy_base_url, home_dir=home_dir)
             elif tool_name in {"codex", "codex-cli"}:
                 write_codex_settings(settings, proxy_base_url=proxy_base_url, home_dir=home_dir)
+            elif tool_name in {"zcode", "zcode-code"} and isinstance(settings, dict):
+                write_zcode_settings(settings, proxy_base_url=proxy_base_url, home_dir=home_dir)
             else:
                 logger.warning("Unknown tool name for settings: %s", tool_name)
         except Exception as exc:

--- a/remote-agent/executor.py
+++ b/remote-agent/executor.py
@@ -1003,6 +1003,7 @@ class ProcessExecutor:
         model: str | None = None,
         permission_mode: str | None = None,
         allowed_tools: list[str] | None = None,
+        resume_session_id: str | None = None,
     ) -> dict[str, Any]:
         """Start a persistent ZCode app-server session.
 
@@ -1078,7 +1079,11 @@ class ProcessExecutor:
             daemon=True,
         ).start()
 
-        if not session.start(model=model, permission_mode=permission_mode):
+        if not session.start(
+            model=model,
+            permission_mode=permission_mode,
+            resume_session_id=resume_session_id,
+        ):
             session.stop()
             return {"success": False, "error": "ZCode session/create failed"}
 
@@ -1641,6 +1646,7 @@ class ProcessExecutor:
                     model=info.get("model"),
                     permission_mode=info.get("permission_mode"),
                     allowed_tools=info.get("allowed_tools"),
+                    resume_session_id=info.get("cli_session_id"),
                 )
                 if result.get("success"):
                     restored.append(sid)

--- a/remote-agent/executor.py
+++ b/remote-agent/executor.py
@@ -1140,7 +1140,10 @@ class ProcessExecutor:
         if isinstance(session, ZCodeAppServerSession):
             if session.send_message(content):
                 return {"success": True}
-            return {"success": False, "error": "ZCode turn failed"}
+            return {
+                "success": False,
+                "error": session.last_send_error or "ZCode turn failed",
+            }
 
         # Check if the CLI tool supports stdin input
         adapter = get_adapter(session.cli_tool)

--- a/remote-agent/executor.py
+++ b/remote-agent/executor.py
@@ -24,11 +24,18 @@ from typing import TYPE_CHECKING, Any, Callable
 
 from cli_adapters import get_adapter
 from cli_adapters.base import collect_custom_envkeys
+from cli_adapters.zcode import ZCodeAdapter
+from zcode_app_server import ZCodeAppServerSession
 
 if TYPE_CHECKING:
     from cli_adapters.base import BaseCLIAdapter
 
 logger = logging.getLogger(__name__)
+
+# CLI tools whose persistent session is driven through a bespoke stdio
+# protocol rather than Claude's stream-json stdin (and so bypass the generic
+# SessionProcess path).
+_APPSERVER_TOOLS = {"zcode", "zcode-code"}
 
 
 class SessionProcess:
@@ -814,6 +821,21 @@ class ProcessExecutor:
             if session_id in self._sessions and self._sessions[session_id].is_running:
                 return {"success": False, "error": "Session already running"}
 
+        # ZCode runs a persistent app-server process driven by its own stdio
+        # protocol (ZCode Protocol), not Claude's stream-json stdin. Route it
+        # through a dedicated session class that the rest of the pipeline talks
+        # to with the same callback interface.
+        if cli_tool in _APPSERVER_TOOLS:
+            return self._start_zcode_session(
+                session_id,
+                project_path,
+                cli_tool,
+                proxy_token,
+                model,
+                permission_mode,
+                allowed_tools,
+            )
+
         # Find the executable via the adapter
         executable = self._find_executable(cli_tool)
         if not executable:
@@ -972,6 +994,119 @@ class ProcessExecutor:
         self._save_sessions_meta()
         return {"success": True, "pid": process.pid}
 
+    def _start_zcode_session(
+        self,
+        session_id: str,
+        project_path: str,
+        cli_tool: str,
+        proxy_token: str,
+        model: str | None = None,
+        permission_mode: str | None = None,
+        allowed_tools: list[str] | None = None,
+    ) -> dict[str, Any]:
+        """Start a persistent ZCode app-server session.
+
+        Unlike the generic path, ZCode's engine is a Node script bundled with the
+        desktop app (or a ``zcode`` symlink). We spawn ``node <engine> app-server``
+        directly and hand the process to ``ZCodeAppServerSession``, which drives the
+        ZCode Protocol over stdio and reuses the standard output/usage callbacks.
+        """
+        adapter = ZCodeAdapter()
+        if not adapter.check_installed():
+            msg = (
+                f"CLI tool '{cli_tool}' (ZCode) not found on this machine.\n"
+                f"Please install it first by running: {adapter.get_install_command()}"
+            )
+            logger.error(msg)
+            return {"success": False, "error": msg}
+
+        project_path = os.path.expanduser(project_path)
+        try:
+            Path(project_path).mkdir(parents=True, exist_ok=True)
+        except OSError as e:
+            msg = f"Cannot create project path '{project_path}': {e}"
+            logger.error(msg)
+            return {"success": False, "error": msg}
+
+        env = self._build_env(cli_tool, proxy_token, model)
+        cmd = adapter.build_start_args(
+            session_id,
+            project_path,
+            model=model,
+            permission_mode=permission_mode or "default",
+            allowed_tools=allowed_tools,
+        )
+        logger.info(
+            "Starting ZCode app-server session %s: %s in %s",
+            session_id[:8],
+            " ".join(cmd),
+            project_path,
+        )
+
+        try:
+            process = subprocess.Popen(
+                cmd,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                cwd=project_path,
+                env=env,
+                start_new_session=os.name != "nt",
+            )
+        except (OSError, subprocess.SubprocessError) as e:
+            msg = f"Failed to start ZCode process: {e}"
+            logger.error(msg)
+            return {"success": False, "error": msg}
+
+        session = ZCodeAppServerSession(
+            session_id=session_id,
+            process=process,
+            project_path=project_path,
+            output_callback=self._output_callback,
+            permission_callback=self._permission_callback,
+            usage_callback=self._usage_callback,
+            model=model,
+            permission_mode=permission_mode,
+            env=env,
+        )
+
+        # Spin up stderr reader so app-server diagnostics surface as errors.
+        threading.Thread(
+            target=self._read_zcode_stderr,
+            args=(session_id, process),
+            name=f"zcode-err-{session_id[:8]}",
+            daemon=True,
+        ).start()
+
+        if not session.start(model=model, permission_mode=permission_mode):
+            session.stop()
+            return {"success": False, "error": "ZCode session/create failed"}
+
+        with self._lock:
+            self._sessions[session_id] = session
+
+        logger.info(
+            "ZCode session %s started (pid %d)",
+            session_id[:8],
+            process.pid,
+        )
+        self._save_sessions_meta()
+        return {"success": True, "pid": process.pid}
+
+    def _read_zcode_stderr(self, session_id: str, process: subprocess.Popen) -> None:
+        """Forward ZCode app-server stderr lines as error output."""
+        stream = process.stderr
+        if stream is None:
+            return
+        try:
+            for raw in stream:
+                line = raw.decode("utf-8", "replace") if isinstance(raw, bytes) else raw
+                text = line.strip()
+                if text:
+                    self._output_callback(session_id, text, "stderr", False)
+        except (OSError, ValueError):
+            pass
+
     def send_message(self, session_id: str, content: str) -> dict[str, Any]:
         """
         Send a message to a running session.
@@ -994,6 +1129,13 @@ class ProcessExecutor:
 
         if not session:
             return {"success": False, "error": "Session not found"}
+
+        # ZCode app-server sessions are driven through the ZCode Protocol;
+        # their send_message blocks until the agent turn completes.
+        if isinstance(session, ZCodeAppServerSession):
+            if session.send_message(content):
+                return {"success": True}
+            return {"success": False, "error": "ZCode turn failed"}
 
         # Check if the CLI tool supports stdin input
         adapter = get_adapter(session.cli_tool)
@@ -1488,6 +1630,21 @@ class ProcessExecutor:
             # Expand ~ in project path if present
             if info.get("project_path"):
                 info["project_path"] = os.path.expanduser(info["project_path"])
+
+            # ZCode sessions restore through the app-server path.
+            if info["cli_tool"] in _APPSERVER_TOOLS:
+                result = self._start_zcode_session(
+                    sid,
+                    info["project_path"],
+                    info["cli_tool"],
+                    proxy_token="",
+                    model=info.get("model"),
+                    permission_mode=info.get("permission_mode"),
+                    allowed_tools=info.get("allowed_tools"),
+                )
+                if result.get("success"):
+                    restored.append(sid)
+                continue
 
             executable = self._find_executable(info["cli_tool"])
             if not executable:

--- a/remote-agent/install.ps1
+++ b/remote-agent/install.ps1
@@ -87,9 +87,10 @@ $files = @(
     "websocket_proxy.py",
     "session_sync.py",
     "openace_cli.py",
-    "cli_settings.py"
+    "cli_settings.py",
+    "zcode_app_server.py"
 )
-$adapterFiles = @("__init__.py", "base.py", "qwen_code.py", "claude_code.py", "codex_cli.py", "codex_jsonl_parser.py", "openclaw.py", "usage_parser.py")
+$adapterFiles = @("__init__.py", "base.py", "qwen_code.py", "claude_code.py", "codex_cli.py", "codex_jsonl_parser.py", "openclaw.py", "usage_parser.py", "zcode.py")
 
 foreach ($file in $files) {
     $downloaded = $false

--- a/remote-agent/install.sh
+++ b/remote-agent/install.sh
@@ -316,6 +316,7 @@ AGENT_FILES=(
     session_sync.py
     openace_cli.py
     cli_settings.py
+    zcode_app_server.py
     __init__.py
 )
 
@@ -345,7 +346,7 @@ else
         done
         # Download CLI adapters
         mkdir -p "${INSTALL_DIR}/cli_adapters"
-        for file in __init__.py base.py qwen_code.py claude_code.py codex_cli.py codex_jsonl_parser.py openclaw.py usage_parser.py; do
+        for file in __init__.py base.py qwen_code.py claude_code.py codex_cli.py codex_jsonl_parser.py openclaw.py usage_parser.py zcode.py; do
             curl -fsSL "${AGENT_URL}/cli_adapters/${file}" -o "${INSTALL_DIR}/cli_adapters/${file}" 2>/dev/null || {
                 log_warn "Could not download cli_adapters/${file}"
             }

--- a/remote-agent/zcode_app_server.py
+++ b/remote-agent/zcode_app_server.py
@@ -1,0 +1,491 @@
+"""
+Open ACE Remote Agent - ZCode app-server persistent session.
+
+Drives the ZCode CLI in persistent ``app-server`` mode over stdio. The app-server
+speaks the *ZCode Protocol*: newline-delimited JSON where each message is either
+
+  * a *request*  with an ``id`` field  -> ``{id, method, params}``,
+  * a *response* with an ``id`` field  -> ``{id, result}`` or ``{id, error}``, or
+  * a *notification* (no ``id``)       -> ``{method, params}`` pushed asynchronously
+    (e.g. ``state.updated`` as the agent runs).
+
+A single long-lived ``node <engine> app-server`` process backs one agent session.
+On start we ``session/create`` a workspace-scoped session; each user turn is a
+``session/send`` (which returns immediately with ``accepted:true`` while the agent
+works in the background). A reader thread drains stdout, dispatching responses to
+per-request futures and forwarding notifications + assistant events to the same
+``output_callback`` / ``usage_callback`` the generic ``SessionProcess`` uses, so
+the rest of the pipeline (agent.py -> server SSE) is unchanged.
+
+Verified protocol surface (against zcode 0.14.5):
+  session/create  {workspace:{workspacePath,workspaceKey}} -> sessionId
+  session/send    {sessionId, content} -> {accepted, stateRevision}  (async)
+  session/events  {sessionId} -> {events:[...]}                      (poll)
+  session/usage   {sessionId} -> {totalTokens, inputTokens, ...}     (camelCase)
+  session/resume  {sessionId} -> {messages, projection, runtime}
+  session/list    {} -> {sessions:[...]}
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import signal
+import subprocess
+import threading
+import time
+import uuid
+from typing import Any, Callable
+
+logger = logging.getLogger(__name__)
+
+# Default interval for polling session/events while a turn is running.
+_EVENTS_POLL_INTERVAL = 0.4
+# How long to wait for a turn to finish (session/send is async).
+_TURN_TIMEOUT = 600.0
+
+
+class ZCodeAppServerSession:
+    """A persistent ZCode app-server process backing one agent session.
+
+    Mimics the subset of ``SessionProcess`` that ``ProcessExecutor`` and
+    ``agent.py`` rely on: ``send_message``, ``stop``, ``is_running``, ``pid``,
+    plus the same callback signatures so output/usage flow identically.
+    """
+
+    def __init__(
+        self,
+        session_id: str,
+        process: subprocess.Popen,
+        project_path: str,
+        output_callback: Callable[[str, str, str, bool], None],
+        usage_callback: Callable[[str, dict[str, int]], None] | None = None,
+        permission_callback: Callable[[str, dict], None] | None = None,
+        model: str | None = None,
+        permission_mode: str | None = None,
+        env: dict[str, str] | None = None,
+    ):
+        self.session_id = session_id
+        self.process = process
+        self.project_path = project_path
+        self.cli_tool = "zcode"
+        self.output_callback = output_callback
+        self.usage_callback = usage_callback
+        self.permission_callback = permission_callback
+        self.model = model
+        self.permission_mode = permission_mode
+        self.env = env
+        self.allowed_tools: list[str] = []
+        self._paused = False  # parity with SessionProcess for meta persistence
+        self._restart_lock = threading.Lock()  # parity with SessionProcess
+
+        # ZCode's internal sessionId (sess_...), captured after session/create.
+        self._cli_session_id: str | None = None
+        self._created = threading.Event()
+        self._stopped = threading.Event()
+
+        # Request/response correlation: id -> (Event, result holder).
+        self._lock = threading.Lock()
+        self._pending: dict[str | int, dict[str, Any]] = {}
+
+        # Event polling state: last consumed event seq per session.
+        self._last_event_seq = 0
+        self._turn_done = threading.Event()
+
+        self._reader_thread = threading.Thread(
+            target=self._read_loop,
+            name=f"zcode-{session_id[:8]}",
+            daemon=True,
+        )
+
+    # ------------------------------------------------------------------ #
+    # Lifecycle
+    # ------------------------------------------------------------------ #
+
+    @property
+    def pid(self) -> int | None:
+        return self.process.pid if self.process.returncode is None else None
+
+    @property
+    def is_running(self) -> bool:
+        return self.process.returncode is None
+
+    def start(self, model: str | None = None, permission_mode: str | None = None) -> bool:
+        """Start the reader thread and create the ZCode session."""
+        self._reader_thread.start()
+        workspace = os.path.abspath(os.path.expanduser(self.project_path))
+        create_params: dict[str, Any] = {
+            "workspace": {"workspacePath": workspace, "workspaceKey": workspace},
+        }
+        # Build a fallback config so app-server can reach a model provider even
+        # without a pre-existing ~/.zcode/cli/config.json on the remote machine.
+        result = self._request("session/create", create_params, timeout=20.0)
+        if not result or "session" not in result:
+            logger.error("ZCode session/create failed for %s: %s", self.session_id[:8], result)
+            return False
+        self._cli_session_id = result["session"].get("sessionId")
+        if not self._cli_session_id:
+            logger.error("ZCode session/create returned no sessionId for %s", self.session_id[:8])
+            return False
+        self._created.set()
+        logger.info(
+            "ZCode session created for %s (cli session: %s)",
+            self.session_id[:8],
+            self._cli_session_id[:8],
+        )
+        return True
+
+    def start_readers(self) -> None:  # noqa: D401 - parity with SessionProcess API
+        """No-op: the reader is started in ``start``.
+
+        Kept for API parity so ``ProcessExecutor`` can call the same method name.
+        """
+        return None
+
+    # ------------------------------------------------------------------ #
+    # Sending a user turn
+    # ------------------------------------------------------------------ #
+
+    def send_message(self, content: str) -> bool:
+        """Send a user message and block until the agent turn completes.
+
+        ``session/send`` is asynchronous (returns ``accepted`` immediately), so we
+        poll ``session/events`` until the projection flips back to ``idle`` and
+        then fetch final usage. Assistant text/tool events are forwarded to the
+        output callback as they arrive so the frontend streams in real time.
+        """
+        if not self._cli_session_id or not self.is_running:
+            logger.warning("Cannot send to inactive ZCode session %s", self.session_id[:8])
+            return False
+
+        self._turn_done.clear()
+        send_result = self._request(
+            "session/send",
+            {"sessionId": self._cli_session_id, "content": content},
+            timeout=30.0,
+        )
+        if not send_result or not send_result.get("accepted"):
+            logger.error("ZCode session/send rejected for %s: %s", self.session_id[:8], send_result)
+            return False
+
+        # Poll events until the turn finishes (status returns to idle) or timeout.
+        self._drain_events_until_idle(_TURN_TIMEOUT)
+
+        # Report final token usage for this turn.
+        self._report_usage()
+        # Signal stdout EOF so the SSE stream flushes a turn boundary.
+        self.output_callback(self.session_id, "", "stdout", True)
+        return True
+
+    def _drain_events_until_idle(self, timeout: float) -> None:
+        """Poll session/events, forwarding assistant content, until the turn ends.
+
+        The reliable completion signal is a ``turn.completed`` event (emitted once
+        the agent finishes its response). We also accept a ``state.updated``
+        notification with ``status: idle`` as a fallback.
+        """
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline and not self._stopped.is_set():
+            result = self._request(
+                "session/events",
+                {"sessionId": self._cli_session_id},
+                timeout=10.0,
+            )
+            if not result:
+                break
+            events = result.get("events", []) or []
+            completed = self._forward_events(events)
+            if completed:
+                # Drain any trailing events (e.g. final session.updated).
+                tail = self._request(
+                    "session/events", {"sessionId": self._cli_session_id}, timeout=10.0
+                )
+                if tail:
+                    self._forward_events(tail.get("events", []) or [])
+                self._turn_done.set()
+                return
+            time.sleep(_EVENTS_POLL_INTERVAL)
+        logger.warning(
+            "ZCode turn did not complete within %.0fs for %s",
+            timeout,
+            self.session_id[:8],
+        )
+        self._turn_done.set()
+
+    def _forward_events(self, events: list[dict[str, Any]]) -> bool:
+        """Forward new events to the output callback. Returns True if turn done."""
+        done = False
+        for ev in events:
+            seq = ev.get("seq", 0)
+            if seq and seq <= self._last_event_seq:
+                continue
+            if seq:
+                self._last_event_seq = seq
+            done = self._forward_one_event(ev) or done
+        return done
+
+    def _forward_one_event(self, ev: dict[str, Any]) -> bool:
+        """Translate a single ZCode event into the pipeline's stream-json shape.
+
+        Verified event types (zcode 0.14.5):
+          model.streaming    -> assistant text deltas (payload.delta)
+          turn.completed     -> turn finished (reliable completion signal)
+          turn.started       -> informational
+          session.updated    -> may carry usage/content; informational
+          session.titleUpdated -> informational
+          tool.*             -> tool call/result
+        """
+        etype = ev.get("type", "")
+        payload = ev.get("payload", {}) or {}
+
+        # Streaming assistant text delta.
+        if etype == "model.streaming":
+            delta = payload.get("delta")
+            if delta:
+                msg = {"type": "assistant", "message": {"role": "assistant", "content": delta}}
+                self.output_callback(self.session_id, json.dumps(msg), "stdout", False)
+            return False
+
+        # Turn finished — the authoritative completion signal. Carries final usage.
+        if etype == "turn.completed":
+            usage = payload.get("usage") or {}
+            if usage and self.usage_callback:
+                self.usage_callback(
+                    self.session_id,
+                    {
+                        "input": usage.get("inputTokens", 0),
+                        "output": usage.get("outputTokens", 0),
+                        "cache_read": usage.get("cacheReadTokens", 0),
+                        "reasoning": usage.get("reasoningTokens", 0),
+                        "model_requests": usage.get("modelRequestCount", 0),
+                    },
+                )
+            return True
+
+        # session.updated may carry the final content + usage block.
+        if etype == "session.updated":
+            usage = payload.get("usage")
+            if usage and self.usage_callback:
+                self.usage_callback(
+                    self.session_id,
+                    {
+                        "input": usage.get("inputTokens", 0),
+                        "output": usage.get("outputTokens", 0),
+                        "cache_read": (
+                            usage.get("cacheReadTokens", 0)
+                            if isinstance(usage.get("cacheReadTokens"), int)
+                            else 0
+                        ),
+                    },
+                )
+            return False
+
+        # state.updated (from notifications) — emit request_state; idle ends turn.
+        if etype == "state.updated":
+            patch = payload.get("patch", {}) or {}
+            status = patch.get("status")
+            if status:
+                self.output_callback(
+                    self.session_id,
+                    json.dumps({"type": "request_state", "data": {"status": status}}),
+                    "stdout",
+                    False,
+                )
+            return status == "idle"
+
+        # Tool events.
+        if etype.startswith("tool."):
+            if etype == "tool.permission_request" and self.permission_callback:
+                self.permission_callback(self.session_id, payload)
+            else:
+                self.output_callback(
+                    self.session_id,
+                    json.dumps({"type": etype, "data": payload}),
+                    "stdout",
+                    False,
+                )
+            return False
+
+        # Informational events we can ignore.
+        if etype in {"turn.started", "session.titleUpdated", "session.resumed"}:
+            return False
+
+        # Generic fallback for any future event type.
+        self.output_callback(
+            self.session_id,
+            json.dumps({"type": etype or "zcode_event", "data": payload}),
+            "stdout",
+            False,
+        )
+        return False
+
+        # Tool call events -> permission or info lines.
+        if etype in {"tool.call", "tool.result", "permission.request"}:
+            if etype == "permission.request" and self.permission_callback:
+                self.permission_callback(self.session_id, payload)
+            else:
+                self.output_callback(
+                    self.session_id,
+                    json.dumps({"type": etype, "data": payload}),
+                    "stdout",
+                    False,
+                )
+            return False
+
+        # Generic fallback: forward raw event for completeness.
+        self.output_callback(
+            self.session_id,
+            json.dumps({"type": etype or "zcode_event", "data": payload}),
+            "stdout",
+            False,
+        )
+        return False
+
+    def _report_usage(self) -> None:
+        if not self.usage_callback or not self._cli_session_id:
+            return
+        usage = self._request("session/usage", {"sessionId": self._cli_session_id}, timeout=10.0)
+        if not usage:
+            return
+        self.usage_callback(
+            self.session_id,
+            {
+                "input": usage.get("inputTokens", 0),
+                "output": usage.get("outputTokens", 0),
+                "cache_read": usage.get("cacheReadTokens", 0),
+                "reasoning": usage.get("reasoningTokens", 0),
+                "model_requests": usage.get("modelRequestCount", 0),
+            },
+        )
+
+    # ------------------------------------------------------------------ #
+    # Stdio reader + request/response correlation
+    # ------------------------------------------------------------------ #
+
+    def _read_loop(self) -> None:
+        """Read stdout lines, dispatch responses to waiters, forward notifications."""
+        stream = self.process.stdout
+        if stream is None:
+            return
+        try:
+            for raw in stream:
+                if self._stopped.is_set():
+                    break
+                line = raw.decode("utf-8", "replace") if isinstance(raw, bytes) else raw
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    msg = json.loads(line)
+                except (json.JSONDecodeError, ValueError):
+                    # Forward non-JSON lines (rare diagnostics) to the callback.
+                    self.output_callback(self.session_id, line, "stdout", False)
+                    continue
+                self._handle_message(msg)
+        except (OSError, ValueError) as e:
+            if not self._stopped.is_set():
+                logger.debug("ZCode reader ended for %s: %s", self.session_id[:8], e)
+        finally:
+            if not self._stopped.is_set():
+                self.output_callback(self.session_id, "", "stdout", True)
+
+    def _handle_message(self, msg: dict[str, Any]) -> None:
+        """Route a parsed message: response (has id) vs notification (no id)."""
+        msg_id = msg.get("id")
+        if msg_id is not None:
+            # Response to a pending request.
+            with self._lock:
+                holder = self._pending.pop(msg_id, None)
+            if holder is not None:
+                if "error" in msg:
+                    holder["error"] = msg["error"]
+                else:
+                    holder["result"] = msg.get("result")
+                holder["event"].set()
+            return
+        # Notification (no id): forward as a live event if it carries state.
+        method = msg.get("method", "")
+        params = msg.get("params", {}) or {}
+        if method == "state.updated":
+            # Inject as an event-like dict so _forward_one_event handles it.
+            self._forward_one_event({"type": "state.updated", "payload": params})
+
+    def _request(
+        self, method: str, params: dict[str, Any], timeout: float = 30.0
+    ) -> dict[str, Any] | None:
+        """Send a request and wait for its correlated response."""
+        if not self.is_running:
+            return None
+        msg_id = str(uuid.uuid4())
+        holder: dict[str, Any] = {"event": threading.Event()}
+        with self._lock:
+            self._pending[msg_id] = holder
+        payload = json.dumps({"id": msg_id, "method": method, "params": params}) + "\n"
+        try:
+            self.process.stdin.write(payload.encode("utf-8"))
+            self.process.stdin.flush()
+        except (OSError, BrokenPipeError, AttributeError) as e:
+            with self._lock:
+                self._pending.pop(msg_id, None)
+            logger.error("ZCode request %s failed for %s: %s", method, self.session_id[:8], e)
+            return None
+        if not holder["event"].wait(timeout=timeout):
+            with self._lock:
+                self._pending.pop(msg_id, None)
+            logger.warning("ZCode request %s timed out for %s", method, self.session_id[:8])
+            return None
+        if "error" in holder:
+            logger.warning(
+                "ZCode request %s errored for %s: %s", method, self.session_id[:8], holder["error"]
+            )
+            return None
+        return holder.get("result")
+
+    # ------------------------------------------------------------------ #
+    # Teardown
+    # ------------------------------------------------------------------ #
+
+    def stop(self) -> None:
+        """Terminate the app-server process."""
+        if self._stopped.is_set():
+            return
+        self._stopped.set()
+        try:
+            if self.process.returncode is None:
+                self.process.terminate()
+                try:
+                    self.process.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    self.process.kill()
+        except Exception as e:  # noqa: BLE001
+            logger.debug("Error stopping ZCode session %s: %s", self.session_id[:8], e)
+
+    def pause(self) -> None:
+        """Pause the process (SIGSTOP) for the pause/resume feature."""
+        if self.is_running and os.name != "nt" and self.process.pid:
+            try:
+                os.kill(self.process.pid, signal.SIGSTOP)
+            except OSError:
+                pass
+
+    def resume(self) -> None:
+        """Resume the process (SIGCONT)."""
+        if self.is_running and os.name != "nt" and self.process.pid:
+            try:
+                os.kill(self.process.pid, signal.SIGCONT)
+            except OSError:
+                pass
+
+    def wait_for_exit(self, timeout: float = 1.0) -> int | None:
+        try:
+            return self.process.wait(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            return None
+
+    # Parity helpers expected by the executor's restart path.
+    def send_sdk_init(self) -> bool:  # noqa: D401
+        return True  # No SDK control plane; session/create handles init.
+
+    def wait_sdk_initialized(self, timeout: float = 15.0) -> bool:  # noqa: D401
+        return self._created.wait(timeout=timeout)

--- a/remote-agent/zcode_app_server.py
+++ b/remote-agent/zcode_app_server.py
@@ -91,7 +91,10 @@ class ZCodeAppServerSession:
 
         # Event polling state: last consumed event seq per session.
         self._last_event_seq = 0
+        # Set = no turn in progress (idle); cleared while a turn runs.
         self._turn_done = threading.Event()
+        self._turn_done.set()
+        self._worker: threading.Thread | None = None
 
         self._reader_thread = threading.Thread(
             target=self._read_loop,
@@ -111,28 +114,53 @@ class ZCodeAppServerSession:
     def is_running(self) -> bool:
         return self.process.returncode is None
 
-    def start(self, model: str | None = None, permission_mode: str | None = None) -> bool:
-        """Start the reader thread and create the ZCode session."""
+    def start(
+        self,
+        model: str | None = None,
+        permission_mode: str | None = None,
+        resume_session_id: str | None = None,
+    ) -> bool:
+        """Start the reader thread and create/resume the ZCode session.
+
+        When *resume_session_id* is given (crash recovery), the prior ZCode
+        session is resumed via ``session/resume`` so conversation history is
+        preserved; otherwise a fresh session is created via ``session/create``.
+        """
         self._reader_thread.start()
         workspace = os.path.abspath(os.path.expanduser(self.project_path))
-        create_params: dict[str, Any] = {
-            "workspace": {"workspacePath": workspace, "workspaceKey": workspace},
-        }
-        # Build a fallback config so app-server can reach a model provider even
-        # without a pre-existing ~/.zcode/cli/config.json on the remote machine.
-        result = self._request("session/create", create_params, timeout=20.0)
-        if not result or "session" not in result:
-            logger.error("ZCode session/create failed for %s: %s", self.session_id[:8], result)
-            return False
-        self._cli_session_id = result["session"].get("sessionId")
+        workspace_param = {"workspacePath": workspace, "workspaceKey": workspace}
+
+        if resume_session_id:
+            result = self._request(
+                "session/resume",
+                {"sessionId": resume_session_id, "workspace": workspace_param},
+                timeout=20.0,
+            )
+            session_obj = result.get("session") if isinstance(result, dict) else None
+            if session_obj and session_obj.get("sessionId"):
+                self._cli_session_id = session_obj["sessionId"]
+            else:
+                logger.warning(
+                    "ZCode session/resume failed for %s, falling back to create",
+                    self.session_id[:8],
+                )
+
+        if not self._cli_session_id:
+            result = self._request("session/create", {"workspace": workspace_param}, timeout=20.0)
+            if not result or "session" not in result:
+                logger.error("ZCode session/create failed for %s: %s", self.session_id[:8], result)
+                return False
+            self._cli_session_id = result["session"].get("sessionId")
+
         if not self._cli_session_id:
             logger.error("ZCode session/create returned no sessionId for %s", self.session_id[:8])
             return False
         self._created.set()
         logger.info(
-            "ZCode session created for %s (cli session: %s)",
+            "ZCode session ready for %s (cli session: %s, resumed=%s)",
             self.session_id[:8],
             self._cli_session_id[:8],
+            bool(resume_session_id),
         )
         return True
 
@@ -148,44 +176,86 @@ class ZCodeAppServerSession:
     # ------------------------------------------------------------------ #
 
     def send_message(self, content: str) -> bool:
-        """Send a user message and block until the agent turn completes.
+        """Send a user message and return immediately (non-blocking).
 
-        ``session/send`` is asynchronous (returns ``accepted`` immediately), so we
-        poll ``session/events`` until the projection flips back to ``idle`` and
-        then fetch final usage. Assistant text/tool events are forwarded to the
-        output callback as they arrive so the frontend streams in real time.
+        ``session/send`` is asynchronous. We dispatch it on a dedicated worker
+        thread so the caller (the agent's single command-dispatch thread) is not
+        blocked - heartbeats and other commands (stop/pause/permission) keep
+        flowing while the turn runs. The worker streams assistant events through
+        the existing callbacks and signals completion via ``_turn_done``.
         """
         if not self._cli_session_id or not self.is_running:
             logger.warning("Cannot send to inactive ZCode session %s", self.session_id[:8])
             return False
 
-        self._turn_done.clear()
-        send_result = self._request(
-            "session/send",
-            {"sessionId": self._cli_session_id, "content": content},
-            timeout=30.0,
-        )
-        if not send_result or not send_result.get("accepted"):
-            logger.error("ZCode session/send rejected for %s: %s", self.session_id[:8], send_result)
+        if not self._turn_done.is_set():
+            logger.warning("ZCode session %s already has a turn in progress", self.session_id[:8])
             return False
 
-        # Poll events until the turn finishes (status returns to idle) or timeout.
-        self._drain_events_until_idle(_TURN_TIMEOUT)
-
-        # Report final token usage for this turn.
-        self._report_usage()
-        # Signal stdout EOF so the SSE stream flushes a turn boundary.
-        self.output_callback(self.session_id, "", "stdout", True)
+        self._turn_done.clear()
+        self._worker = threading.Thread(
+            target=self._run_turn,
+            args=(content,),
+            name=f"zcode-turn-{self.session_id[:8]}",
+            daemon=True,
+        )
+        self._worker.start()
         return True
+
+    def wait_turn(self, timeout: float = _TURN_TIMEOUT) -> bool:
+        """Block until the current turn finishes (used by tests)."""
+        return self._turn_done.wait(timeout=timeout)
+
+    def _run_turn(self, content: str) -> None:
+        """Worker-thread body: send the message and stream events until done."""
+        try:
+            send_result = self._request(
+                "session/send",
+                {"sessionId": self._cli_session_id, "content": content},
+                timeout=30.0,
+            )
+            if not send_result or not send_result.get("accepted"):
+                # Surface send failures (e.g. model unavailable) to the user via
+                # the error stream rather than failing silently.
+                err_msg = "ZCode rejected the message"
+                if isinstance(send_result, dict):
+                    err = send_result.get("error") or {}
+                    err_msg = err.get("message") or err_msg
+                logger.error(
+                    "ZCode session/send rejected for %s: %s",
+                    self.session_id[:8],
+                    send_result,
+                )
+                self.output_callback(
+                    self.session_id,
+                    json.dumps({"type": "error", "data": {"message": err_msg}}),
+                    "stderr",
+                    False,
+                )
+                return
+            self._drain_events_until_idle(_TURN_TIMEOUT)
+            self._report_usage()
+        except Exception:  # noqa: BLE001
+            logger.exception("ZCode turn failed for %s", self.session_id[:8])
+            self.output_callback(
+                self.session_id,
+                json.dumps({"type": "error", "data": {"message": "ZCode turn failed"}}),
+                "stderr",
+                False,
+            )
+        finally:
+            self.output_callback(self.session_id, "", "stdout", True)
+            self._turn_done.set()
 
     def _drain_events_until_idle(self, timeout: float) -> None:
         """Poll session/events, forwarding assistant content, until the turn ends.
 
         The reliable completion signal is a ``turn.completed`` event (emitted once
-        the agent finishes its response). We also accept a ``state.updated``
-        notification with ``status: idle`` as a fallback.
+        the agent finishes its response). Polling backs off from 0.4s up to 2s so
+        long turns don't hammer the app-server.
         """
         deadline = time.monotonic() + timeout
+        interval = _EVENTS_POLL_INTERVAL
         while time.monotonic() < deadline and not self._stopped.is_set():
             result = self._request(
                 "session/events",
@@ -197,21 +267,19 @@ class ZCodeAppServerSession:
             events = result.get("events", []) or []
             completed = self._forward_events(events)
             if completed:
-                # Drain any trailing events (e.g. final session.updated).
                 tail = self._request(
                     "session/events", {"sessionId": self._cli_session_id}, timeout=10.0
                 )
                 if tail:
                     self._forward_events(tail.get("events", []) or [])
-                self._turn_done.set()
                 return
-            time.sleep(_EVENTS_POLL_INTERVAL)
+            time.sleep(interval)
+            interval = min(interval * 1.5, 2.0)
         logger.warning(
             "ZCode turn did not complete within %.0fs for %s",
             timeout,
             self.session_id[:8],
         )
-        self._turn_done.set()
 
     def _forward_events(self, events: list[dict[str, Any]]) -> bool:
         """Forward new events to the output callback. Returns True if turn done."""
@@ -312,28 +380,6 @@ class ZCodeAppServerSession:
             return False
 
         # Generic fallback for any future event type.
-        self.output_callback(
-            self.session_id,
-            json.dumps({"type": etype or "zcode_event", "data": payload}),
-            "stdout",
-            False,
-        )
-        return False
-
-        # Tool call events -> permission or info lines.
-        if etype in {"tool.call", "tool.result", "permission.request"}:
-            if etype == "permission.request" and self.permission_callback:
-                self.permission_callback(self.session_id, payload)
-            else:
-                self.output_callback(
-                    self.session_id,
-                    json.dumps({"type": etype, "data": payload}),
-                    "stdout",
-                    False,
-                )
-            return False
-
-        # Generic fallback: forward raw event for completeness.
         self.output_callback(
             self.session_id,
             json.dumps({"type": etype or "zcode_event", "data": payload}),

--- a/remote-agent/zcode_app_server.py
+++ b/remote-agent/zcode_app_server.py
@@ -96,6 +96,7 @@ class ZCodeAppServerSession:
         self._turn_done = threading.Event()
         self._turn_done.set()
         self._worker: threading.Thread | None = None
+        self.last_send_error: str | None = None
 
         self._reader_thread = threading.Thread(
             target=self._read_loop,

--- a/remote-agent/zcode_app_server.py
+++ b/remote-agent/zcode_app_server.py
@@ -22,7 +22,8 @@ Verified protocol surface (against zcode 0.14.5):
   session/send    {sessionId, content} -> {accepted, stateRevision}  (async)
   session/events  {sessionId} -> {events:[...]}                      (poll)
   session/usage   {sessionId} -> {totalTokens, inputTokens, ...}     (camelCase)
-  session/resume  {sessionId} -> {messages, projection, runtime}
+  session/resume  {sessionId} -> {messages, projection, runtime, session, settings, ...}
+#                  (session.sessionId confirms the resumed id; same shape as create)
   session/list    {} -> {sessions:[...]}
 """
 
@@ -125,10 +126,15 @@ class ZCodeAppServerSession:
         When *resume_session_id* is given (crash recovery), the prior ZCode
         session is resumed via ``session/resume`` so conversation history is
         preserved; otherwise a fresh session is created via ``session/create``.
+        Both methods return the same envelope, including a top-level
+        ``session`` object whose ``sessionId`` confirms the active id (verified
+        against zcode 0.14.5). If resume fails or the response lacks a session
+        id, we fall back to ``session/create``.
         """
         self._reader_thread.start()
         workspace = os.path.abspath(os.path.expanduser(self.project_path))
         workspace_param = {"workspacePath": workspace, "workspaceKey": workspace}
+        resumed = False
 
         if resume_session_id:
             result = self._request(
@@ -136,9 +142,12 @@ class ZCodeAppServerSession:
                 {"sessionId": resume_session_id, "workspace": workspace_param},
                 timeout=20.0,
             )
+            # Both create and resume return a `session` envelope; the resumed id
+            # is confirmed under session.sessionId.
             session_obj = result.get("session") if isinstance(result, dict) else None
             if session_obj and session_obj.get("sessionId"):
                 self._cli_session_id = session_obj["sessionId"]
+                resumed = True
             else:
                 logger.warning(
                     "ZCode session/resume failed for %s, falling back to create",
@@ -160,7 +169,7 @@ class ZCodeAppServerSession:
             "ZCode session ready for %s (cli session: %s, resumed=%s)",
             self.session_id[:8],
             self._cli_session_id[:8],
-            bool(resume_session_id),
+            resumed,
         )
         return True
 
@@ -185,13 +194,16 @@ class ZCodeAppServerSession:
         the existing callbacks and signals completion via ``_turn_done``.
         """
         if not self._cli_session_id or not self.is_running:
+            self.last_send_error = "ZCode session is not active"
             logger.warning("Cannot send to inactive ZCode session %s", self.session_id[:8])
             return False
 
         if not self._turn_done.is_set():
+            self.last_send_error = "A turn is already in progress for this session"
             logger.warning("ZCode session %s already has a turn in progress", self.session_id[:8])
             return False
 
+        self.last_send_error = None
         self._turn_done.clear()
         self._worker = threading.Thread(
             target=self._run_turn,

--- a/tests/unit/test_models_user_tool_account.py
+++ b/tests/unit/test_models_user_tool_account.py
@@ -133,7 +133,7 @@ class TestToolTypes:
         assert "other" in TOOL_TYPES
 
     def test_total_count(self):
-        assert len(TOOL_TYPES) == 7
+        assert len(TOOL_TYPES) == 8
 
     def test_all_values_are_strings(self):
         for key, value in TOOL_TYPES.items():

--- a/tests/unit/test_zcode_adapter.py
+++ b/tests/unit/test_zcode_adapter.py
@@ -88,12 +88,15 @@ def test_zcode_get_env_vars_routes_through_anthropic_proxy(cli_adapters_pkg):
 def test_zcode_build_single_shot_args(cli_adapters_pkg):
     adapter = cli_adapters_pkg.get_adapter("zcode")
     args = adapter.build_single_shot_args("do the task", "/tmp/proj", model="glm-5.2")
-    # Engine is invoked via `node <engine>` when bundled; single-shot uses --prompt.
-    assert args[0] == "node"
+    # The leading token(s) resolve the engine (either `node <engine.cjs>` when the
+    # bundled app is present, or a bare `zcode` binary). Don't assert the prefix
+    # since it depends on the host (macOS bundle vs Linux CI). The engine is
+    # always followed by the prompt/mode/json flags below.
     assert "--prompt" in args
     assert "do the task" in args
     assert "--mode" in args and "yolo" in args
     assert "--json" in args
+    assert "--no-color" in args
     # No --model flag: zcode has no headless model flag; model comes from config.
     assert "--model" not in args
 

--- a/tests/unit/test_zcode_adapter.py
+++ b/tests/unit/test_zcode_adapter.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""Unit tests for the ZCode CLI adapter, settings writer, and usage parser."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# --------------------------------------------------------------------------- #
+# Module loading helpers (mirrors test_cli_settings_apply.py)
+# --------------------------------------------------------------------------- #
+
+_AGENT_DIR = str(Path(__file__).resolve().parents[2] / "remote-agent")
+
+
+def _load_module(name: str, rel_path: str):
+    module_path = Path(__file__).resolve().parents[2] / rel_path
+    if _AGENT_DIR not in sys.path:
+        sys.path.insert(0, _AGENT_DIR)
+    spec = importlib.util.spec_from_file_location(name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def cli_adapters_pkg():
+    # Import as a proper package (relative imports `.base`, `.zcode` require
+    # the parent dir on sys.path with the package name intact).
+    import importlib
+
+    if _AGENT_DIR not in sys.path:
+        sys.path.insert(0, _AGENT_DIR)
+    return importlib.import_module("cli_adapters")
+
+
+@pytest.fixture(scope="module")
+def cli_settings_mod():
+    return _load_module("cli_settings", "remote-agent/cli_settings.py")
+
+
+@pytest.fixture(scope="module")
+def usage_parser_mod():
+    return _load_module("usage_parser", "remote-agent/cli_adapters/usage_parser.py")
+
+
+# --------------------------------------------------------------------------- #
+# Adapter registry & basic contract
+# --------------------------------------------------------------------------- #
+
+
+def test_zcode_registered_in_adapter_registry(cli_adapters_pkg):
+    assert "zcode" in cli_adapters_pkg.ADAPTERS
+    assert "zcode-code" in cli_adapters_pkg.ADAPTERS
+
+
+def test_zcode_get_adapter_returns_zcode_instance(cli_adapters_pkg):
+    adapter = cli_adapters_pkg.get_adapter("zcode")
+    assert adapter.get_display_name() == "ZCode"
+    assert adapter.get_executable_name() == "zcode"
+
+
+def test_zcode_supports_stdin_input_is_false(cli_adapters_pkg):
+    """ZCode does NOT use Claude's stream-json stdin protocol."""
+    adapter = cli_adapters_pkg.get_adapter("zcode")
+    assert adapter.supports_stdin_input() is False
+
+
+def test_zcode_get_settings_path(cli_adapters_pkg):
+    adapter = cli_adapters_pkg.get_adapter("zcode")
+    assert adapter.get_settings_path().endswith(".zcode/cli/config.json")
+
+
+def test_zcode_get_env_vars_routes_through_anthropic_proxy(cli_adapters_pkg):
+    adapter = cli_adapters_pkg.get_adapter("zcode")
+    env = adapter.get_env_vars("https://proxy.example/api/llm-proxy/", "tok")
+    # Trailing slash stripped; ZCode's anthropic provider reads ANTHROPIC_BASE_URL.
+    assert env["ANTHROPIC_BASE_URL"] == "https://proxy.example/api/llm-proxy"
+
+
+def test_zcode_build_single_shot_args(cli_adapters_pkg):
+    adapter = cli_adapters_pkg.get_adapter("zcode")
+    args = adapter.build_single_shot_args("do the task", "/tmp/proj", model="glm-5.2")
+    # Engine is invoked via `node <engine>` when bundled; single-shot uses --prompt.
+    assert args[0] == "node"
+    assert "--prompt" in args
+    assert "do the task" in args
+    assert "--mode" in args and "yolo" in args
+    assert "--json" in args
+    # No --model flag: zcode has no headless model flag; model comes from config.
+    assert "--model" not in args
+
+
+def test_zcode_build_start_args_uses_app_server(cli_adapters_pkg):
+    adapter = cli_adapters_pkg.get_adapter("zcode")
+    args = adapter.build_start_args("sess_x", "/tmp/proj", permission_mode="bypass")
+    assert "app-server" in args
+    assert "yolo" in args  # bypass -> yolo (fully autonomous)
+
+
+def test_zcode_build_resume_args(cli_adapters_pkg):
+    adapter = cli_adapters_pkg.get_adapter("zcode")
+    args = adapter.build_resume_args("sess_resume", "/tmp/proj", "continue now")
+    assert "--resume" in args
+    assert "sess_resume" in args
+    assert "--prompt" in args and "continue now" in args
+
+
+@pytest.mark.parametrize(
+    "mode,expected",
+    [
+        ("bypass", "yolo"),
+        ("full-auto", "yolo"),
+        ("auto", "build"),
+        ("auto-edit", "edit"),
+        ("plan", "plan"),
+        (None, "yolo"),
+    ],
+)
+def test_zcode_permission_mode_mapping(cli_adapters_pkg, mode, expected):
+    adapter = cli_adapters_pkg.get_adapter("zcode")
+    assert adapter._map_permission_mode(mode) == expected
+
+
+# --------------------------------------------------------------------------- #
+# Settings writer
+# --------------------------------------------------------------------------- #
+
+
+def test_write_zcode_settings_creates_config(cli_settings_mod, tmp_path):
+    path = cli_settings_mod.write_zcode_settings(
+        {"api_key": "key-123"},
+        proxy_base_url="https://proxy.example/api/llm-proxy",
+        home_dir=tmp_path,
+    )
+    cfg = json.loads(path.read_text(encoding="utf-8"))
+    assert cfg["provider"]["zai"]["kind"] == "anthropic"
+    assert cfg["provider"]["zai"]["options"]["baseURL"] == "https://proxy.example/api/llm-proxy"
+    assert cfg["provider"]["zai"]["options"]["apiKey"] == "key-123"
+    assert cfg["model"]["main"] == "zai/glm-5.2"
+    assert cfg["model"]["lite"] == "zai/glm-4.5-air"
+
+
+def test_write_zcode_settings_merges_existing(cli_settings_mod, tmp_path):
+    config_path = tmp_path / ".zcode" / "cli" / "config.json"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(
+        json.dumps(
+            {
+                "provider": {
+                    "openai": {"id": "openai", "kind": "openai", "options": {}},
+                    "zai": {"id": "zai", "kind": "anthropic", "options": {"apiKey": "old"}},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    cli_settings_mod.write_zcode_settings(
+        {"api_key": "new-key"},
+        proxy_base_url="https://px/v1",
+        home_dir=tmp_path,
+    )
+    cfg = json.loads(config_path.read_text(encoding="utf-8"))
+    # Existing non-zcode provider preserved.
+    assert "openai" in cfg["provider"]
+    # zai merged: baseURL injected, apiKey updated.
+    assert cfg["provider"]["zai"]["options"]["baseURL"] == "https://px/v1"
+    assert cfg["provider"]["zai"]["options"]["apiKey"] == "new-key"
+
+
+def test_apply_cli_settings_dispatches_zcode(cli_settings_mod, tmp_path):
+    cli_settings_mod.apply_cli_settings(
+        {"zcode": {"api_key": "dispatch-key"}},
+        proxy_base_url="https://px/v1",
+        home_dir=tmp_path,
+    )
+    config_path = tmp_path / ".zcode" / "cli" / "config.json"
+    cfg = json.loads(config_path.read_text(encoding="utf-8"))
+    assert cfg["provider"]["zai"]["options"]["apiKey"] == "dispatch-key"
+
+
+# --------------------------------------------------------------------------- #
+# Usage parser
+# --------------------------------------------------------------------------- #
+
+
+def test_usage_parser_zcode_single_shot_shape(usage_parser_mod):
+    # Shape from `zcode --prompt ... --json` (verified against running CLI).
+    parsed = {
+        "usage": {
+            "inputTokens": 8358,
+            "outputTokens": 4,
+            "cacheReadTokens": 7040,
+            "reasoningTokens": 0,
+            "modelRequestCount": 1,
+        }
+    }
+    r = usage_parser_mod.extract_stream_usage("zcode", parsed)
+    assert r == {
+        "input": 8358,
+        "output": 4,
+        "cache_read": 7040,
+        "reasoning": 0,
+        "model_requests": 1,
+    }
+
+
+def test_usage_parser_zcode_session_usage_shape(usage_parser_mod):
+    # Shape from app-server session/usage (top-level camelCase, no wrapper).
+    parsed = {
+        "totalTokens": 8362,
+        "inputTokens": 8358,
+        "outputTokens": 4,
+        "cacheReadTokens": 0,
+        "modelRequestCount": 1,
+    }
+    r = usage_parser_mod.extract_stream_usage("zcode", parsed)
+    assert r["input"] == 8358
+    assert r["output"] == 4
+    assert r["cache_read"] == 0
+    assert r["model_requests"] == 1
+
+
+def test_usage_parser_no_regression_for_claude(usage_parser_mod):
+    parsed = {"type": "result", "usage": {"input_tokens": 100, "output_tokens": 50}}
+    assert usage_parser_mod.extract_stream_usage("claude-code", parsed) == {
+        "input": 100,
+        "output": 50,
+    }
+
+
+def test_usage_parser_no_regression_for_qwen(usage_parser_mod):
+    parsed = {"usage": {"input_tokens": 10, "output_tokens": 5, "cachedContentTokenCount": 2}}
+    assert usage_parser_mod.extract_stream_usage("qwen-code-cli", parsed) == {
+        "input": 8,
+        "output": 5,
+    }

--- a/tests/unit/test_zcode_adapter.py
+++ b/tests/unit/test_zcode_adapter.py
@@ -79,8 +79,10 @@ def test_zcode_get_settings_path(cli_adapters_pkg):
 def test_zcode_get_env_vars_routes_through_anthropic_proxy(cli_adapters_pkg):
     adapter = cli_adapters_pkg.get_adapter("zcode")
     env = adapter.get_env_vars("https://proxy.example/api/llm-proxy/", "tok")
-    # Trailing slash stripped; ZCode's anthropic provider reads ANTHROPIC_BASE_URL.
+    # Trailing slash stripped; ZCode's anthropic provider reads both env vars,
+    # mirroring Claude: ANTHROPIC_API_KEY authenticates, ANTHROPIC_BASE_URL routes.
     assert env["ANTHROPIC_BASE_URL"] == "https://proxy.example/api/llm-proxy"
+    assert env["ANTHROPIC_API_KEY"] == "tok"
 
 
 def test_zcode_build_single_shot_args(cli_adapters_pkg):

--- a/tests/unit/test_zcode_adapter.py
+++ b/tests/unit/test_zcode_adapter.py
@@ -242,3 +242,160 @@ def test_usage_parser_no_regression_for_qwen(usage_parser_mod):
         "input": 8,
         "output": 5,
     }
+
+
+# --------------------------------------------------------------------------- #
+# ZCodeAppServerSession — worker/resume/guard (mocked)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture(scope="module")
+def zcode_session_cls():
+    """Load the ZCodeAppServerSession class without spawning a real process."""
+    mod = _load_module("zcode_app_server", "remote-agent/zcode_app_server.py")
+    return mod.ZCodeAppServerSession
+
+
+class _FakeProcess:
+    """Minimal stand-in for subprocess.Popen."""
+
+    def __init__(self):
+        self.returncode = None
+        self.pid = 12345
+        self.stdin = None
+        self.stdout = None
+        self.stderr = None
+
+    def wait(self, timeout=None):  # noqa: D401
+        return 0
+
+    def terminate(self):
+        self.returncode = 0
+
+    def kill(self):
+        self.returncode = 0
+
+
+def _make_session(zcode_session_cls, requests):
+    """Build a session whose ``_request`` is replaced by *requests* lookup."""
+    import threading
+
+    sess = zcode_session_cls.__new__(zcode_session_cls)
+    sess.session_id = "sess_test"
+    sess.process = _FakeProcess()
+    sess.project_path = "/tmp"
+    sess.cli_tool = "zcode"
+    sess.output_callback = lambda *a, **k: None
+    sess.usage_callback = None
+    sess.permission_callback = None
+    sess.model = None
+    sess.permission_mode = None
+    sess.env = None
+    sess.allowed_tools = []
+    sess._paused = False
+    sess._restart_lock = threading.Lock()
+    sess._cli_session_id = None
+    sess._created = threading.Event()
+    sess._stopped = threading.Event()
+    sess._lock = threading.Lock()
+    sess._pending = {}
+    sess._last_event_seq = 0
+    sess._turn_done = threading.Event()
+    sess._turn_done.set()
+    sess._worker = None
+    sess.last_send_error = None
+    sess._reader_thread = threading.Thread(target=lambda: None, daemon=True)
+
+    def fake_request(method, params, timeout=30.0):
+        return requests.get(method, {}).get("result")
+
+    sess._request = fake_request
+    return sess
+
+
+def test_start_resumes_when_session_sessionid_present(zcode_session_cls):
+    """session/resume returns session.sessionId -> resume succeeds, no create."""
+    requests = {
+        "session/resume": {"result": {"session": {"sessionId": "sess_resumed_xyz"}}},
+    }
+    sess = _make_session(zcode_session_cls, requests)
+    ok = sess.start(resume_session_id="sess_resumed_xyz")
+    assert ok is True
+    assert sess._cli_session_id == "sess_resumed_xyz"
+
+
+def test_start_falls_back_to_create_when_resume_lacks_session(zcode_session_cls):
+    """If resume response lacks session.sessionId, fall back to session/create."""
+    requests = {
+        # Resume returns no session envelope (simulates shape mismatch).
+        "session/resume": {"result": {"messages": [], "projection": {}}},
+        "session/create": {"result": {"session": {"sessionId": "sess_fresh"}}},
+    }
+    sess = _make_session(zcode_session_cls, requests)
+    ok = sess.start(resume_session_id="sess_resumed_xyz")
+    assert ok is True
+    # Fresh id from create, not the resume id.
+    assert sess._cli_session_id == "sess_fresh"
+
+
+def test_start_creates_when_no_resume_id(zcode_session_cls):
+    requests = {"session/create": {"result": {"session": {"sessionId": "sess_new"}}}}
+    sess = _make_session(zcode_session_cls, requests)
+    ok = sess.start()
+    assert ok is True
+    assert sess._cli_session_id == "sess_new"
+
+
+def test_send_message_returns_immediately_and_runs_worker(zcode_session_cls):
+    """send_message returns True without blocking; the worker runs async."""
+    import time
+
+    # session/send accepted; events immediately report turn.completed.
+    requests = {
+        "session/send": {"result": {"accepted": True, "sessionId": "sess_x"}},
+        "session/events": {
+            "result": {
+                "events": [
+                    {"seq": 1, "type": "turn.completed", "payload": {"usage": {}}},
+                ]
+            }
+        },
+        "session/usage": {"result": {"inputTokens": 0, "outputTokens": 0}},
+    }
+    sess = _make_session(zcode_session_cls, requests)
+    sess._cli_session_id = "sess_x"
+    t0 = time.monotonic()
+    ok = sess.send_message("hello")
+    elapsed = time.monotonic() - t0
+    assert ok is True
+    assert elapsed < 1.0  # non-blocking: returns well under a second
+    # Worker completes the turn.
+    assert sess.wait_turn(timeout=5.0) is True
+
+
+def test_send_message_rejects_concurrent_send_as_busy(zcode_session_cls):
+    """A second send while a turn is in progress is rejected with a busy error."""
+    import threading
+
+    gate = threading.Event()
+
+    def slow_request(method, params, timeout=30.0):
+        if method == "session/send":
+            gate.wait(timeout=5.0)  # hold the turn open
+            return {"accepted": True, "sessionId": "sess_x"}
+        if method == "session/events":
+            gate.set()
+            return {"events": [{"seq": 1, "type": "turn.completed", "payload": {}}]}
+        return None
+
+    sess = _make_session(zcode_session_cls, {})
+    sess._cli_session_id = "sess_x"
+    sess._request = slow_request
+    assert sess.send_message("first") is True
+    # Second send while the first turn is still running.
+    second = sess.send_message("second")
+    assert second is False
+    assert sess.last_send_error is not None
+    assert "in progress" in sess.last_send_error
+    gate.set()
+    assert sess.wait_turn(timeout=5.0)


### PR DESCRIPTION
## Summary

Adds full ZCode integration to Open ACE, on par with the existing Claude Code / Qwen Code / Codex / OpenClaw support.

ZCode ships with the ZCode desktop app and runs a Node.js engine. Unlike the other CLIs it has **no stream-json stdin protocol** (and no SDK control plane), so it is driven through two modes:

- **single-shot**: `node <engine> --prompt ... --json` — one process per autonomous task
- **persistent**: `node <engine> app-server` — the *ZCode Protocol* over stdio (`session/create|send|events|resume|usage|list`) for streaming multi-turn sessions with full token/request statistics and crash recovery

### Why two modes?
The single-shot path plugs straight into the autonomous runner (`build_single_shot_args`). The persistent `app-server` mode gives real-time streaming (`model.streaming` deltas), per-turn usage (`turn.completed`), and native session resume — capabilities the existing Claude `stream-json` executor can't reach without a dedicated session class.

## Changes

**Backend**
| File | Change |
|------|--------|
| `cli_adapters/zcode.py` (new) | `ZCodeAdapter`: bundled-engine resolution, env vars, single-shot/app-server/resume arg builders, permission-mode mapping |
| `zcode_app_server.py` (new) | `ZCodeAppServerSession`: drives app-server with request/response correlation, async-event polling, usage reporting, pause/resume |
| `executor.py` | Route zcode through the app-server path (start/send/restore) |
| `cli_settings.py` | `write_zcode_settings` (`~/.zcode/cli/config.json`) + dispatch |
| `usage_parser.py` | `extract_zcode_usage` (camelCase token shapes) |
| `tool_names.py`, `remote_session_manager._cli_tool_to_provider` (→anthropic), `remote._CLI_SETTINGS_TOOLS`, `user_tool_account.TOOL_TYPES` | string registrations |

**Frontend**
- ZCode option in APIKeyManagement, NewAutonomousModal, AssistPanel, ToolAccountsEditor; `formatToolName` display name + tests

## Key findings (verified against zcode 0.14.5)
1. ZCode uses a **custom ZCode Protocol** (not JSON-RPC, not standard MCP) — `session/*` methods, id-correlated responses + id-less notifications
2. `--model` flag has no effect in headless modes (passing it prints help & exits); model is selected via `~/.zcode/cli/config.json`
3. `turn.completed` event is the reliable turn-end signal (carries final token usage), not `status: idle`

## Test plan
- [x] `tests/unit/test_zcode_adapter.py` — 21 cases (registry, args, settings merge, usage shapes, no-regression for claude/qwen)
- [x] Existing tests pass: `test_cli_settings_apply`, `test_cli_settings_strip`, `test_usage_parser` (#764) — 60 total, no regression
- [x] **Live single-shot test**: autonomously created dir + file, parsed token usage (input 25251 / output 133 / cache_read 25152)
- [x] **Live app-server test**: full `session/create` → `send` → `events` → `usage` flow, streaming deltas captured, turn completed in 4.5s, 3 usage reports
- [x] ruff / black / isort / mypy / bandit / pydocstyle all clean
- [x] Frontend `tsc --noEmit` clean; `formatToolName` vitest 6/6

Verified against zcode 0.14.5 with the z.ai Anthropic-compatible provider.

🤖 Generated with ZCode
