### PR TITLE
Fix #1069: Extend needs_refresh() to detect sender_name NULL

### DIFF
--- a/app/repositories/daily_stats_repo.py
+++ b/app/repositories/daily_stats_repo.py
@@ -725,6 +725,26 @@ class DailyStatsRepository:
                 )
                 return True
 
+        # Check if sender_name is missing (NULL values that should have data)
+        # Only check rows where sender_name should NOT be NULL (corresponding daily_messages has data)
+        null_sender_query = """
+            SELECT COUNT(*) as count FROM daily_stats ds
+            WHERE ds.sender_name IS NULL
+            AND EXISTS (
+                SELECT 1 FROM daily_messages dm
+                WHERE dm.date = ds.date
+                AND dm.tool_name = ds.tool_name
+                AND dm.host_name = ds.host_name
+                AND dm.sender_name IS NOT NULL
+            )
+        """
+        null_result = self.db.fetch_one(null_sender_query)
+        if null_result and null_result.get("count", 0) > 0:
+            logger.info(
+                f"daily_stats has {null_result['count']} rows missing sender_name"
+            )
+            return True
+
         return False
 
     def get_data_range(self) -> Optional[dict]:

--- a/app/repositories/daily_stats_repo.py
+++ b/app/repositories/daily_stats_repo.py
@@ -740,9 +740,7 @@ class DailyStatsRepository:
         """
         null_result = self.db.fetch_one(null_sender_query)
         if null_result and null_result.get("count", 0) > 0:
-            logger.info(
-                f"daily_stats has {null_result['count']} rows missing sender_name"
-            )
+            logger.info(f"daily_stats has {null_result['count']} rows missing sender_name")
             return True
 
         return False

--- a/tests/unit/test_daily_stats_repo.py
+++ b/tests/unit/test_daily_stats_repo.py
@@ -433,6 +433,7 @@ class TestDailyStatsRepository:
             {"count": 100},  # daily_stats not empty
             {"max_date": "2024-01-15"},  # stats max date
             {"max_date": "2024-01-15"},  # messages max date (same)
+            {"count": 0},  # no NULL sender_name
         ]
         result = self.repo.needs_refresh()
         assert result is False
@@ -443,9 +444,21 @@ class TestDailyStatsRepository:
             {"count": 100},  # daily_stats not empty
             {"max_date": "2024-01-15"},  # stats max date
             None,  # no messages
+            {"count": 0},  # no NULL sender_name (no messages to sync)
         ]
         result = self.repo.needs_refresh()
         assert result is False
+
+    def test_needs_refresh_null_sender_name(self):
+        """Stats have NULL sender_name that should have data."""
+        self.db.fetch_one.side_effect = [
+            {"count": 100},  # daily_stats not empty
+            {"max_date": "2024-01-15"},  # stats max date
+            {"max_date": "2024-01-15"},  # messages max date (same)
+            {"count": 5},  # 5 rows with NULL sender_name that should have data
+        ]
+        result = self.repo.needs_refresh()
+        assert result is True
 
     # -------------------------------------------------------------------------
     # refresh_hourly_stats


### PR DESCRIPTION
## Summary

Fixes #1069

Extend needs_refresh() to detect sender_name NULL values that should have data.

## Problem

活跃用户 Top 10 on Trend page shows no data because daily_stats.sender_name is NULL.

## Root Cause

needs_refresh() only checks date range mismatch, not field completeness.

## Solution

Add sender_name NULL detection that only checks rows where corresponding daily_messages has data.

## Changes

- app/repositories/daily_stats_repo.py: Add NULL sender_name check in needs_refresh()