### PR TITLE
fix: Docker 版升级检测增加配置文件检测 (Issue #1078)

### DIFF
--- a/scripts/install-central/docker-method/install.sh
+++ b/scripts/install-central/docker-method/install.sh
@@ -2077,8 +2077,41 @@ detect_existing_deployment() {
         fi
     done
 
+    # If no container found, try to detect deployment by config file
+    # This handles the case where containers were removed (docker compose down)
+    # but config files and data volumes still exist
     if [ -z "$found_container" ]; then
-        return 1
+        print_info "未检测到容器，检查是否存在配置文件..."
+
+        # Scan common deployment directories for config.json
+        local found_config=false
+        for scan_dir in \
+            "/home/open-ace/open-ace" \
+            "/home/ivyent/open-ace" \
+            "/opt/open-ace" \
+            "/root/open-ace" \
+            "/tools/open-ace" \
+            "$DEPLOY_DIR"; do
+            if [ -f "$scan_dir/config/config.json" ]; then
+                DEPLOY_DIR="$scan_dir"
+                print_success "检测到配置文件: $scan_dir/config/config.json"
+                found_config=true
+                break
+            fi
+        done
+
+        if [ "$found_config" = false ]; then
+            # No existing deployment found
+            return 1
+        fi
+
+        # Verify the deployment directory exists
+        if [ ! -d "$DEPLOY_DIR" ]; then
+            print_warning "部署目录不存在: $DEPLOY_DIR"
+            return 1
+        fi
+
+        return 0
     fi
 
     # Get deployment directory from container mount info


### PR DESCRIPTION
## 概述

修复 Issue #1078：Docker 版升级检测仅依赖容器状态，配置文件存在时也应触发升级模式。

## 问题描述

当容器被删除（`docker compose down`）但配置文件和数据卷仍存在时，升级检测失败，导致用户需要重新填写所有配置参数。

## 修复内容

扩展 `detect_existing_deployment` 函数，在容器不存在时，扫描常见部署目录检查 `config/config.json` 文件是否存在。

扫描目录列表：
- `/home/open-ace/open-ace`
- `/home/ivyent/open-ace`
- `/opt/open-ace`
- `/root/open-ace`
- `/tools/open-ace`
- `$DEPLOY_DIR`（用户指定的部署目录）

## 测试结果

在 node236 上测试三个场景：

| 场景 | 操作 | 预期结果 | 实际结果 |
|------|------|----------|----------|
| A | 容器存在 + 配置存在 | 显示升级选项 | ✓ 通过 |
| B | 容器删除 + 配置存在 | 显示升级选项 | ✓ 通过（新增功能） |
| C | 全新安装 | 进入配置参数流程 | ✓ 通过 |

场景 B 测试输出：
```
ℹ 未检测到容器，检查是否存在配置文件...
✓ 检测到配置文件: /home/ivyent/open-ace/config/config.json
  升级摘要
ℹ 检测到已存在的 Open ACE 部署
ℹ 升级操作:
请选择操作:
  1) 升级 (使用当前配置，保留数据库和配置文件)
```

## 关联 Issue

Fixes #1078