### PR TITLE
fix: apply security policy to password validation in user management (Issue #866)

### DIFF
--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -16,6 +16,7 @@ from app.auth.decorators import admin_required
 from app.repositories.usage_repo import UsageRepository
 from app.repositories.user_repo import UserRepository
 from app.schemas.quota import validate_quota_update
+from app.services.auth_service import get_security_settings_cached
 from app.utils.validators import validate_email, validate_password, validate_username
 
 logger = logging.getLogger(__name__)
@@ -134,7 +135,9 @@ def api_create_user():
     if not validate_email(email):
         return jsonify({"error": "Invalid email"}), 400
 
-    is_valid, error_msg = validate_password(password)
+    # Validate password with security policy
+    settings = get_security_settings_cached()
+    is_valid, error_msg = validate_password(password, policy_settings=settings)
     if not is_valid:
         return jsonify({"error": error_msg}), 400
 
@@ -221,7 +224,9 @@ def api_update_user_password(user_id):
     data = request.get_json() or {}
     password: str = data.get("password", "")
 
-    is_valid, error_msg = validate_password(password)
+    # Validate password with security policy
+    settings = get_security_settings_cached()
+    is_valid, error_msg = validate_password(password, policy_settings=settings)
     if not is_valid:
         return jsonify({"error": error_msg}), 400
 

--- a/app/services/auth_service.py
+++ b/app/services/auth_service.py
@@ -306,9 +306,13 @@ class AuthService:
         if not password_verify_func(current_password, user.get("password_hash", "")):
             return False, "Current password is incorrect"
 
-        # Validate new password
-        if len(new_password) < 8:
-            return False, "New password must be at least 8 characters"
+        # Validate new password with security policy
+        from app.utils.validators import validate_password
+
+        settings = _get_security_settings()
+        is_valid, error_msg = validate_password(new_password, policy_settings=settings)
+        if not is_valid:
+            return False, error_msg
 
         if new_password == current_password:
             return False, "New password must be different from current password"
@@ -428,3 +432,7 @@ class AuthService:
             return False, {"error": "Admin access required"}
 
         return True, session
+
+
+# Public export for security settings (with 60-second cache)
+get_security_settings_cached = _get_security_settings

--- a/app/utils/validators.py
+++ b/app/utils/validators.py
@@ -5,6 +5,7 @@ Input validation functions.
 """
 
 import re
+from typing import Optional
 
 
 def validate_date(date_str: str) -> bool:
@@ -102,20 +103,42 @@ def validate_email(email: str) -> bool:
     return bool(re.match(pattern, email))
 
 
-def validate_password(password: str) -> tuple:
+def validate_password(password: str, policy_settings: Optional[dict] = None) -> tuple:
     """
-    Validate a password.
+    Validate a password against security policy.
 
     Args:
         password: Password to validate.
+        policy_settings: Optional dict from security_settings for policy validation.
+                         If None, only basic length check is performed.
 
     Returns:
         tuple: (is_valid, error_message)
     """
     if not password:
         return False, "Password is required"
+
+    # Basic checks (always applied)
     if len(password) < 8:
         return False, "Password must be at least 8 characters"
     if len(password) > 128:
         return False, "Password must be less than 128 characters"
+
+    # Policy-based checks (if settings provided)
+    if policy_settings:
+        min_length = int(policy_settings.get("password_min_length", 8))
+        if len(password) < min_length:
+            return False, f"Password must be at least {min_length} characters"
+
+        if policy_settings.get("password_require_uppercase") and not re.search(r"[A-Z]", password):
+            return False, "Password must contain uppercase letters"
+        if policy_settings.get("password_require_lowercase") and not re.search(r"[a-z]", password):
+            return False, "Password must contain lowercase letters"
+        if policy_settings.get("password_require_number") and not re.search(r"[0-9]", password):
+            return False, "Password must contain numbers"
+        if policy_settings.get("password_require_special") and not re.search(
+            r"[!@#$%^&*(),.?\":{}|<>]", password
+        ):
+            return False, "Password must contain special characters"
+
     return True, None

--- a/frontend/src/components/features/management/UserManagement.tsx
+++ b/frontend/src/components/features/management/UserManagement.tsx
@@ -10,6 +10,7 @@ import {
   useDeleteUser,
   useUpdateUserPassword,
   usePageRefresh,
+  useSecuritySettings,
 } from '@/hooks';
 import { useLanguage } from '@/store';
 import { t } from '@/i18n';
@@ -31,6 +32,7 @@ import type { AdminUser, CreateUserRequest, UpdateUserRequest } from '@/api';
 export const UserManagement: React.FC = () => {
   const language = useLanguage();
   const { data: users, isLoading, isError, error, refetch } = useUsers();
+  const { data: securitySettings } = useSecuritySettings();
   const createUser = useCreateUser();
   const updateUser = useUpdateUser();
   const deleteUser = useDeleteUser();
@@ -69,6 +71,58 @@ export const UserManagement: React.FC = () => {
     { value: 'true', label: t('active', language) },
     { value: 'false', label: t('inactive', language) },
   ];
+
+  // Password policy validation
+  const validatePasswordPolicy = (password: string): string | null => {
+    if (!password) return t('passwordRequired', language) ?? 'Password is required';
+    if (password.length < 8)
+      return t('passwordTooShort', language) ?? 'Password must be at least 8 characters';
+
+    const policy = securitySettings;
+    if (policy) {
+      const minLen = policy.password_min_length || 8;
+      if (password.length < minLen) {
+        return `${t('passwordMinLength', language)}: ${minLen}`;
+      }
+      if (policy.password_require_uppercase && !/[A-Z]/.test(password)) {
+        return t('requireUppercase', language);
+      }
+      if (policy.password_require_lowercase && !/[a-z]/.test(password)) {
+        return t('requireLowercase', language);
+      }
+      if (policy.password_require_number && !/[0-9]/.test(password)) {
+        return t('requireNumber', language);
+      }
+      if (policy.password_require_special && !/[!@#$%^&*(),.?":{}|<>]/.test(password)) {
+        return t('requireSpecial', language);
+      }
+    }
+    return null;
+  };
+
+  // Password policy hint component
+  const PasswordPolicyHint = () => {
+    const policy = securitySettings;
+    if (!policy) return null;
+
+    const requirements: string[] = [];
+    requirements.push(`${t('passwordMinLength', language)}: ${policy.password_min_length || 8}`);
+    if (policy.password_require_uppercase) requirements.push(t('requireUppercase', language));
+    if (policy.password_require_lowercase) requirements.push(t('requireLowercase', language));
+    if (policy.password_require_number) requirements.push(t('requireNumber', language));
+    if (policy.password_require_special) requirements.push(t('requireSpecial', language));
+
+    return (
+      <div className="password-policy-hint text-muted small mt-1">
+        <div>{t('passwordRequirements', language)}:</div>
+        <ul className="mb-0 ps-3" style={{ fontSize: '0.85em' }}>
+          {requirements.map((req, idx) => (
+            <li key={idx}>{req}</li>
+          ))}
+        </ul>
+      </div>
+    );
+  };
 
   const handleOpenCreate = () => {
     setEditingUser(null);
@@ -130,13 +184,17 @@ export const UserManagement: React.FC = () => {
     }
 
     if (!editingUser) {
-      // Password required for new users
-      if (!formData.password || formData.password.trim() === '') {
-        setFormError(t('passwordRequired', language) ?? 'Password is required');
+      // Password required for new users - validate with policy
+      const passwordError = validatePasswordPolicy(formData.password);
+      if (passwordError) {
+        setFormError(passwordError);
         return;
       }
-      if (formData.password.length < 8) {
-        setFormError(t('passwordTooShort', language) ?? 'Password must be at least 8 characters');
+    } else if (formData.password && formData.password.trim() !== '') {
+      // Optional password update for existing user - validate with policy
+      const passwordError = validatePasswordPolicy(formData.password);
+      if (passwordError) {
+        setFormError(passwordError);
         return;
       }
     }
@@ -389,6 +447,7 @@ export const UserManagement: React.FC = () => {
                     onChange={(value: string) => setFormData({ ...formData, password: value })}
                     placeholder={t('enterPassword', language)}
                   />
+                  <PasswordPolicyHint />
                 </div>
                 <div className="col-md-6">
                   <label className="form-label">{t('confirmPassword', language)}</label>
@@ -417,6 +476,7 @@ export const UserManagement: React.FC = () => {
                     onChange={(value: string) => setFormData({ ...formData, password: value })}
                     placeholder={t('enterPassword', language)}
                   />
+                  <PasswordPolicyHint />
                 </div>
                 <div className="col-md-6">
                   <label className="form-label">{t('confirmPassword', language)}</label>

--- a/tests/unit/test_auth_service.py
+++ b/tests/unit/test_auth_service.py
@@ -432,10 +432,11 @@ class TestAuthService:
         }
         mock_repo.update_password.return_value = True
 
+        # Use password that meets policy requirements (uppercase, lowercase, number)
         success, error = svc.change_password(
             user_id=1,
-            current_password="oldpass",
-            new_password="newpass123",
+            current_password="Oldpass123",
+            new_password="Newpass123",
             password_verify_func=lambda p, h: True,
             password_hash_func=lambda p: "new_hash",
         )
@@ -497,10 +498,11 @@ class TestAuthService:
             "password_hash": "old_hash",
         }
 
+        # Use password that meets policy requirements
         success, error = svc.change_password(
             user_id=1,
-            current_password="samepass",
-            new_password="samepass",
+            current_password="Samepass123",
+            new_password="Samepass123",
             password_verify_func=lambda p, h: True,
             password_hash_func=lambda p: "hash",
         )
@@ -515,10 +517,11 @@ class TestAuthService:
         }
         mock_repo.update_password.return_value = False
 
+        # Use password that meets policy requirements
         success, error = svc.change_password(
             user_id=1,
-            current_password="oldpass",
-            new_password="newpass123",
+            current_password="Oldpass123",
+            new_password="Newpass123",
             password_verify_func=lambda p, h: True,
             password_hash_func=lambda p: "new_hash",
         )

--- a/tests/unit/test_validators.py
+++ b/tests/unit/test_validators.py
@@ -348,3 +348,81 @@ class TestValidatePassword:
         is_valid, msg = validate_password(password)
         assert is_valid is False
         assert expected_in_msg in msg.lower()
+
+    @pytest.mark.parametrize(
+        "password,policy_settings,expected_valid",
+        [
+            # No policy - basic validation only
+            ("12345678", None, True),
+            ("abcdefgh", None, True),
+            # Policy with min_length
+            ("12345678", {"password_min_length": 10}, False),
+            ("1234567890", {"password_min_length": 10}, True),
+            # Policy requiring uppercase
+            ("abcdefgh", {"password_require_uppercase": True}, False),
+            ("Abcdefgh", {"password_require_uppercase": True}, True),
+            # Policy requiring lowercase
+            ("ABCDEFGH", {"password_require_lowercase": True}, False),
+            ("ABCDefgh", {"password_require_lowercase": True}, True),
+            # Policy requiring number
+            ("abcdefgh", {"password_require_number": True}, False),
+            ("abcdefg1", {"password_require_number": True}, True),
+            # Policy requiring special character
+            ("abcdefgh", {"password_require_special": True}, False),
+            ("abcdefg!", {"password_require_special": True}, True),
+            # Combined policy requirements
+            ("Abcdefg1", {
+                "password_require_uppercase": True,
+                "password_require_lowercase": True,
+                "password_require_number": True,
+            }, True),
+            ("Abcdefg!", {
+                "password_require_uppercase": True,
+                "password_require_lowercase": True,
+                "password_require_special": True,
+            }, True),
+            ("abcdefg1", {
+                "password_require_uppercase": True,
+                "password_require_number": True,
+            }, False),  # Missing uppercase
+            # Full policy requirements
+            ("Abcdefg1!", {
+                "password_min_length": 8,
+                "password_require_uppercase": True,
+                "password_require_lowercase": True,
+                "password_require_number": True,
+                "password_require_special": True,
+            }, True),
+            ("Abcdefg1", {
+                "password_min_length": 8,
+                "password_require_uppercase": True,
+                "password_require_lowercase": True,
+                "password_require_number": True,
+                "password_require_special": True,
+            }, False),  # Missing special
+        ],
+        ids=[
+            "no_policy_basic_valid",
+            "no_policy_basic_valid_2",
+            "min_length_10_fail",
+            "min_length_10_pass",
+            "require_uppercase_fail",
+            "require_uppercase_pass",
+            "require_lowercase_fail",
+            "require_lowercase_pass",
+            "require_number_fail",
+            "require_number_pass",
+            "require_special_fail",
+            "require_special_pass",
+            "combined_upper_lower_number_pass",
+            "combined_upper_lower_special_pass",
+            "combined_missing_uppercase_fail",
+            "full_policy_pass",
+            "full_policy_missing_special_fail",
+        ],
+    )
+    def test_password_with_policy(self, password, policy_settings, expected_valid):
+        is_valid, msg = validate_password(password, policy_settings=policy_settings)
+        assert is_valid is expected_valid
+        if not expected_valid:
+            assert msg is not None

--- a/tests/unit/test_validators.py
+++ b/tests/unit/test_validators.py
@@ -371,35 +371,55 @@ class TestValidatePassword:
             ("abcdefgh", {"password_require_special": True}, False),
             ("abcdefg!", {"password_require_special": True}, True),
             # Combined policy requirements
-            ("Abcdefg1", {
-                "password_require_uppercase": True,
-                "password_require_lowercase": True,
-                "password_require_number": True,
-            }, True),
-            ("Abcdefg!", {
-                "password_require_uppercase": True,
-                "password_require_lowercase": True,
-                "password_require_special": True,
-            }, True),
-            ("abcdefg1", {
-                "password_require_uppercase": True,
-                "password_require_number": True,
-            }, False),  # Missing uppercase
+            (
+                "Abcdefg1",
+                {
+                    "password_require_uppercase": True,
+                    "password_require_lowercase": True,
+                    "password_require_number": True,
+                },
+                True,
+            ),
+            (
+                "Abcdefg!",
+                {
+                    "password_require_uppercase": True,
+                    "password_require_lowercase": True,
+                    "password_require_special": True,
+                },
+                True,
+            ),
+            (
+                "abcdefg1",
+                {
+                    "password_require_uppercase": True,
+                    "password_require_number": True,
+                },
+                False,
+            ),  # Missing uppercase
             # Full policy requirements
-            ("Abcdefg1!", {
-                "password_min_length": 8,
-                "password_require_uppercase": True,
-                "password_require_lowercase": True,
-                "password_require_number": True,
-                "password_require_special": True,
-            }, True),
-            ("Abcdefg1", {
-                "password_min_length": 8,
-                "password_require_uppercase": True,
-                "password_require_lowercase": True,
-                "password_require_number": True,
-                "password_require_special": True,
-            }, False),  # Missing special
+            (
+                "Abcdefg1!",
+                {
+                    "password_min_length": 8,
+                    "password_require_uppercase": True,
+                    "password_require_lowercase": True,
+                    "password_require_number": True,
+                    "password_require_special": True,
+                },
+                True,
+            ),
+            (
+                "Abcdefg1",
+                {
+                    "password_min_length": 8,
+                    "password_require_uppercase": True,
+                    "password_require_lowercase": True,
+                    "password_require_number": True,
+                    "password_require_special": True,
+                },
+                False,
+            ),  # Missing special
         ],
         ids=[
             "no_policy_basic_valid",


### PR DESCRIPTION
## Summary

Fixes #866 - User management password validation now enforces security center password policy.

## Problem

In management mode -> Users -> User Management, passwords could be set to simple values like `12345678` without validating against the security center password policy requirements (uppercase, lowercase, number, special characters).

## Changes

### Backend

1. **`app/utils/validators.py`**
   - Added `policy_settings` parameter to `validate_password()`
   - Validates password complexity against security settings

2. **`app/services/auth_service.py`**
   - Added `get_security_settings_cached` public export (reuses 60-second TTL cache)
   - `change_password()` method now applies policy validation

3. **`app/routes/admin.py`**
   - `api_create_user()` and `api_update_user_password()` now pass security settings to password validation

### Frontend

4. **`frontend/src/components/features/management/UserManagement.tsx`**
   - Added `useSecuritySettings` hook to fetch policy
   - Added `PasswordPolicyHint` component showing policy requirements
   - Added `validatePasswordPolicy()` for client-side validation

### Tests

5. **`tests/unit/test_validators.py`**
   - Added 17 test cases for password policy validation

6. **`tests/unit/test_auth_service.py`**
   - Updated test passwords to meet policy requirements

## Testing

- All 112 validator tests pass
- All 59 auth_service tests pass

## Screenshots

Password policy hint now displayed below password input:

```
Password Requirements:
- Minimum length: 8
- Require uppercase letter
- Require lowercase letter
- Require number
```
