### PR TITLE
fix: add zcode to all remaining tool lists/selectors

### DIFF
--- a/app/models/tenant.py
+++ b/app/models/tenant.py
@@ -58,7 +58,9 @@ class QuotaConfig:
 class TenantSettings:
     """Tenant-specific settings."""
 
-    allowed_tools: list[str] = field(default_factory=lambda: ["claude", "qwen", "openclaw"])
+    allowed_tools: list[str] = field(
+        default_factory=lambda: ["claude", "qwen", "openclaw", "codex", "zcode"]
+    )
     content_filter_enabled: bool = True
     audit_log_enabled: bool = True
     audit_log_retention_days: int = 90
@@ -90,7 +92,9 @@ class TenantSettings:
     def from_dict(cls, data: dict) -> "TenantSettings":
         """Create from dictionary."""
         return cls(
-            allowed_tools=data.get("allowed_tools", ["claude", "qwen", "openclaw"]),
+            allowed_tools=data.get(
+                "allowed_tools", ["claude", "qwen", "openclaw", "codex", "zcode"]
+            ),
             content_filter_enabled=data.get("content_filter_enabled", True),
             audit_log_enabled=data.get("audit_log_enabled", True),
             audit_log_retention_days=data.get("audit_log_retention_days", 90),

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -97,6 +97,9 @@ PLANNING_ALLOWED_TOOLS: dict[str, list[str]] = {
     ],
     "codex": [],
     "openclaw": [],
+    # zcode uses its own built-in tool set (Read/Write/Edit/Bash/WebFetch/...),
+    # exposed via the ZCode Protocol; no MCP-subtool allowlist is needed.
+    "zcode": [],
 }
 
 # Development-phase tools: planning read-only set + Write/Edit/Bash so the agent
@@ -134,6 +137,7 @@ AUTONOMOUS_DEV_ALLOWED_TOOLS: dict[str, list[str]] = {
     ],
     "codex": [],
     "openclaw": [],
+    "zcode": [],
 }
 
 # Maximum time (seconds) for a single planning agent call.

--- a/app/modules/workspace/tool_connector.py
+++ b/app/modules/workspace/tool_connector.py
@@ -257,6 +257,19 @@ class ToolConnector:
                 supports_tools=True,
                 capabilities=["chat", "agent", "coding", "analysis"],
             ),
+            ToolInfo(
+                name="zcode",
+                display_name="ZCode (Z.AI)",
+                tool_type=ToolType.AGENT.value,
+                description="Z.AI's ZCode coding agent (Anthropic-compatible)",
+                models=["glm-5.2", "glm-4.5-air"],
+                default_model="glm-5.2",
+                max_tokens=1048576,
+                supports_streaming=True,
+                supports_vision=True,
+                supports_tools=True,
+                capabilities=["chat", "agent", "coding", "analysis"],
+            ),
         ]
 
         for tool in default_tools:

--- a/app/routes/autonomous.py
+++ b/app/routes/autonomous.py
@@ -1297,6 +1297,7 @@ def get_available_tools():
         {"id": "qwen-code-cli", "name": "Qwen Code", "executable": "qwen"},
         {"id": "codex", "name": "Codex CLI", "executable": "codex"},
         {"id": "openclaw", "name": "OpenClaw", "executable": "openclaw"},
+        {"id": "zcode", "name": "ZCode", "executable": "zcode"},
     ]
     return jsonify({"success": True, "tools": tools})
 
@@ -1358,7 +1359,9 @@ def _pid_matches_expected(pid: int) -> bool:
         if result.returncode != 0:
             return False  # process doesn't exist
         comm = result.stdout.strip().lower()
-        return any(name in comm for name in ("claude", "qwen", "codex", "openclaw", "node"))
+        return any(
+            name in comm for name in ("claude", "qwen", "codex", "openclaw", "zcode", "node")
+        )
     except Exception:
         # If we can't check, assume it matches (conservative: try to stop it)
         return True

--- a/frontend/src/components/features/Dashboard.tsx
+++ b/frontend/src/components/features/Dashboard.tsx
@@ -34,6 +34,16 @@ const TOOL_COLORS: Record<string, { border: string; background: string; card: st
     card: 'bg-success',
   },
   qwen: { border: 'rgba(54, 162, 235, 1)', background: 'rgba(54, 162, 235, 0.2)', card: 'bg-info' },
+  codex: {
+    border: 'rgba(153, 102, 255, 1)',
+    background: 'rgba(153, 102, 255, 0.2)',
+    card: 'bg-primary',
+  },
+  zcode: {
+    border: 'rgba(255, 159, 64, 1)',
+    background: 'rgba(255, 159, 64, 0.2)',
+    card: 'bg-warning',
+  },
 };
 
 // Date range preset values (labels will be internationalized)

--- a/remote-agent/system_info.py
+++ b/remote-agent/system_info.py
@@ -22,6 +22,7 @@ KNOWN_CLI_TOOLS = [
     "openclaw",
     "aider",
     "cursor-cli",
+    "zcode",
 ]
 
 

--- a/remote-agent/terminal_menu.py
+++ b/remote-agent/terminal_menu.py
@@ -41,6 +41,15 @@ TOOLS = [
         "install_cmd": "npm install -g @openai/codex@latest",
         "env_key": "OPENAI_API_KEY",
     },
+    {
+        "name": "ZCode",
+        "cli": "zcode",
+        "cmd": "zcode",
+        # ZCode ships inside the macOS desktop app; symlink the bundled engine.
+        # On Linux, install/symlink the engine per ZCode's docs instead.
+        "install_cmd": "sudo ln -s /Applications/ZCode.app/Contents/Resources/glm/zcode.cjs /usr/local/bin/zcode",
+        "env_key": "ANTHROPIC_API_KEY",
+    },
 ]
 
 MENU_PATH = os.path.abspath(__file__)

--- a/tests/unit/test_models_tenant.py
+++ b/tests/unit/test_models_tenant.py
@@ -104,7 +104,7 @@ class TestTenantSettings:
 
     def test_create_with_defaults(self):
         ts = TenantSettings()
-        assert ts.allowed_tools == ["claude", "qwen", "openclaw"]
+        assert ts.allowed_tools == ["claude", "qwen", "openclaw", "codex", "zcode"]
         assert ts.content_filter_enabled is True
         assert ts.audit_log_enabled is True
         assert ts.audit_log_retention_days == 90
@@ -136,7 +136,7 @@ class TestTenantSettings:
     def test_to_dict(self):
         ts = TenantSettings(sso_enabled=True, sso_provider="azure")
         d = ts.to_dict()
-        assert d["allowed_tools"] == ["claude", "qwen", "openclaw"]
+        assert d["allowed_tools"] == ["claude", "qwen", "openclaw", "codex", "zcode"]
         assert d["content_filter_enabled"] is True
         assert d["audit_log_enabled"] is True
         assert d["audit_log_retention_days"] == 90
@@ -166,7 +166,7 @@ class TestTenantSettings:
 
     def test_from_dict_empty_uses_defaults(self):
         ts = TenantSettings.from_dict({})
-        assert ts.allowed_tools == ["claude", "qwen", "openclaw"]
+        assert ts.allowed_tools == ["claude", "qwen", "openclaw", "codex", "zcode"]
         assert ts.content_filter_enabled is True
         assert ts.audit_log_enabled is True
         assert ts.sso_enabled is False


### PR DESCRIPTION
## Summary

Follow-up to #1074. The initial ZCode integration missed several hardcoded tool lists, so zcode was invisible in the autonomous-workflow agent-tool picker and other selectors. This adds zcode everywhere claude/codex/qwen/openclaw appear.

## Root cause
The agent-tool dropdown in **NewAutonomousModal** is driven by `GET /api/autonomous/tools`, which returned a hardcoded list without zcode. Several other backend selectors/allowlists had the same gap.

## Changes

**Backend** (5 spots — all the places a tool must be explicitly listed to be selectable):
| File | Change |
|------|--------|
| `app/routes/autonomous.py` | `get_available_tools` (the dropdown source) + process-name detection for stop/kill |
| `remote-agent/system_info.py` | `KNOWN_CLI_TOOLS` (machine capability reporting) |
| `remote-agent/terminal_menu.py` | `TOOLS` interactive picker |
| `app/models/tenant.py` | default `allowed_tools` (2 spots; also added the previously-missing `codex`) |
| `app/modules/workspace/tool_connector.py` | default tool registry (`ToolInfo`) |

**Frontend**:
- `Dashboard.tsx` `TOOL_COLORS` — added zcode + codex colors (previously fell back to `bg-secondary`)

## Already dynamic (no change needed)
- Session list / filter dropdowns (`Sessions.tsx`) are backend-driven, so they pick up zcode once `/api/autonomous/tools` returns it.
- `formatToolName` and `TOOL_TYPES` were updated in #1074.

## Intentionally deferred
- `session_sync.py` (local JSONL sync) and `fetch.py` (historical import) need a `ZcodeSession` parser class / `fetch_zcode.py` — out of scope here since zcode sessions stream live via the app-server path, not local JSONL sync. Tracked for a follow-up.

## Test plan
- [x] ruff/black/isort/mypy/bandit/pydocstyle clean
- [x] `test_models_user_tool_account`, `test_remote_agent_installer`, `test_zcode_adapter`, `test_cli_settings_apply` pass
- [x] `test_workspace_modules` failures are pre-existing (PG `INSERT OR IGNORE` dialect bug on clean main), unrelated to this change
- [ ] CI

🤖 Generated with ZCode
