### PR TITLE
fix: normalize worktree path + self-heal missing worktree (#814)

### DIFF
--- a/app/modules/workspace/autonomous/agent_runner.py
+++ b/app/modules/workspace/autonomous/agent_runner.py
@@ -162,10 +162,18 @@ class AutonomousAgentRunner:
     def _encode_project_path(project_path: str) -> str:
         """Best-effort match for the encoded project path used by Claude session history.
 
-        Today Claude stores absolute paths by replacing "/" with "-". Keep this logic
-        isolated here because it is an implementation detail outside our control.
+        Claude stores session history under ``~/.claude/projects/<encoded>`` where
+        ``<encoded>`` is the *real* (symlink/``..``-resolved) absolute path with
+        ``/`` replaced by ``-``. Callers can pass any form — a worktree path
+        produced by ``f"{repo}/../branch"`` still contains ``..`` — so we must
+        normalize first or the encoded dir never matches what Claude actually
+        wrote (#814). ``realpath`` also resolves symlinks, matching Claude's
+        own ``getcwd``-based encoding.
         """
-        return project_path.replace("/", "-") if project_path.startswith("/") else project_path
+        if not project_path:
+            return ""
+        resolved = os.path.realpath(project_path)
+        return resolved.replace("/", "-")
 
     def _find_latest_claude_session_id(
         self,

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -9,6 +9,7 @@ pr_review -> report -> wait -> (loop or merge).
 
 import json
 import logging
+import os
 import re
 import threading
 import time
@@ -296,6 +297,76 @@ class AutonomousOrchestrator:
             project_path = wf.get("worktree_path") or wf.get("project_path", "")
             self._gh = GitHubOps(project_path)
         return self._gh
+
+    def _ensure_worktree(self, wf: dict) -> str:
+        """Guarantee the worktree dir + branch exist before a phase runs.
+
+        Retrying/resuming a ``worktree``-strategy workflow after its dir was
+        cleaned up (e.g. a previous failure removed it, or the machine
+        rebooted) used to silently launch the agent against an empty path and
+        fail with a JSONL-detection error (#814). Every downstream phase now
+        calls this at entry so the environment self-heals:
+
+        - normalizes a stale ``worktree_path`` still containing ``..`` so the
+          DB and the on-disk dir agree;
+        - recreates the worktree dir (reusing the branch if it still exists)
+          when it is gone.
+
+        Returns the canonical worktree path. For non-worktree strategies this
+        is a no-op that returns the configured ``project_path``.
+        """
+        strategy = wf.get("branch_strategy", "new-branch")
+        project_path = wf.get("project_path", "")
+        worktree_path = wf.get("worktree_path", "")
+
+        if strategy != "worktree" or not project_path:
+            return worktree_path or project_path
+
+        canonical = os.path.realpath(worktree_path or project_path)
+        # Valid worktree: a .git file/dir inside means git set it up. If the
+        # stored path was unnormalized (legacy ".."), persist the canonical
+        # form so JSONL session detection matches Claude's encoding.
+        if worktree_path and os.path.isfile(os.path.join(canonical, ".git")):
+            if canonical != worktree_path:
+                self._update_workflow({"worktree_path": canonical})
+            return canonical
+
+        # Worktree missing — recreate from the main repo.
+        branch_name = wf.get("branch_name") or f"auto-dev/{self._workflow_id[:8]}"
+        main_gh = GitHubOps(project_path)
+        try:
+            main_gh._run_git(["fetch", "origin", "main"])
+            # Does the branch still exist locally or on origin?
+            branch_check = main_gh._run_git(
+                ["show-ref", "--verify", "--quiet", f"refs/heads/{branch_name}"],
+                check=False,
+            )
+            remote_check = main_gh._run_git(
+                ["show-ref", "--verify", "--quiet", f"refs/remotes/origin/{branch_name}"],
+                check=False,
+            )
+            if branch_check.returncode == 0 or remote_check.returncode == 0:
+                # Branch survives (local or remote) — attach a worktree to it
+                # without recreating the branch.
+                main_gh._run_git(["worktree", "add", canonical, branch_name])
+            else:
+                # Neither worktree nor branch — start fresh from origin/main.
+                main_gh._run_git(["worktree", "add", "-b", branch_name, canonical, "origin/main"])
+        except GitHubOpsError as e:
+            logger.error("Failed to recreate worktree at %s: %s", canonical, e)
+            raise
+
+        self._update_workflow({"worktree_path": canonical, "branch_name": branch_name})
+        self._create_milestone(
+            phase=wf.get("current_phase", "preparation"),
+            milestone_type="worktree_restored",
+            status="completed",
+            title=f"Worktree restored at {os.path.basename(canonical)}",
+        )
+        logger.info("Restored worktree at %s on branch %s", canonical, branch_name)
+        # Reset cached gh so it picks up the restored worktree path.
+        self._gh = None
+        return canonical
 
     def _emit(self, event_type: str, data: dict):
         """Emit a timeline event."""
@@ -1057,6 +1128,13 @@ class AutonomousOrchestrator:
         logger.info("Advancing workflow %s phase=%s", self._workflow_id[:8], phase)
 
         try:
+            # Self-heal the worktree before any downstream phase runs. A
+            # retried/resumed workflow may find its worktree dir gone (cleaned
+            # up after a prior failure), which previously launched the agent
+            # against an empty path (#814). preparation creates it, so it's
+            # skipped here.
+            if phase != "preparation":
+                self._ensure_worktree(wf)
             if phase == "preparation":
                 self._do_preparation(wf)
             elif phase == "planning":
@@ -1117,7 +1195,10 @@ class AutonomousOrchestrator:
             # Force worktree for parallel execution
             try:
                 gh._run_git(["fetch", "origin", "main"])
-                wt_path = f"{project_path}/../{branch_name.replace('/', '-')}"
+                # normpath collapses the ".." so the stored path and the worktree
+                # dir on disk agree; an unnormalized path later breaks JSONL
+                # session detection (#814).
+                wt_path = os.path.normpath(f"{project_path}/../{branch_name.replace('/', '-')}")
                 gh.create_worktree(path=wt_path, branch=branch_name, base=base_ref)
                 self._update_workflow(
                     {
@@ -1268,8 +1349,10 @@ class AutonomousOrchestrator:
                 gh._run_git(["fetch", "origin", "main"])
 
                 if strategy == "worktree":
+                    # normpath collapses ".." so DB/JSONL encoding matches the
+                    # real worktree dir (#814).
                     wt_data = gh.create_worktree(
-                        path=f"{project_path}/../{branch_name.replace('/', '-')}",
+                        path=os.path.normpath(f"{project_path}/../{branch_name.replace('/', '-')}"),
                         branch=branch_name,
                         base="origin/main",
                     )

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -312,17 +312,25 @@ class AutonomousOrchestrator:
         - recreates the worktree dir (reusing the branch if it still exists)
           when it is gone.
 
-        Returns the canonical worktree path. For non-worktree strategies this
-        is a no-op that returns the configured ``project_path``.
+        Returns the canonical worktree path. For non-worktree strategies, or
+        when ``worktree_path`` is intentionally empty (merge cleanup / conflict
+        resolution clears it), this is a no-op returning ``project_path``.
         """
         strategy = wf.get("branch_strategy", "new-branch")
         project_path = wf.get("project_path", "")
         worktree_path = wf.get("worktree_path", "")
 
-        if strategy != "worktree" or not project_path:
+        # An empty worktree_path is NOT the "dir gone, recreate it" case — it
+        # is set deliberately by merge cleanup (_resolve_merge_conflicts /
+        # _do_merge) when the worktree is removed to free the main repo for
+        # conflict resolution. Treating it as missing would fall back to
+        # project_path as canonical and try `git worktree add <main_repo>`,
+        # which fails and turns a retried merge into a hard failure. Only a
+        # non-empty path whose dir is gone represents external loss (#814).
+        if strategy != "worktree" or not project_path or not worktree_path:
             return worktree_path or project_path
 
-        canonical = os.path.realpath(worktree_path or project_path)
+        canonical = os.path.realpath(worktree_path)
         # Valid worktree: a .git file/dir inside means git set it up. If the
         # stored path was unnormalized (legacy ".."), persist the canonical
         # form so JSONL session detection matches Claude's encoding.
@@ -347,7 +355,8 @@ class AutonomousOrchestrator:
             )
             if branch_check.returncode == 0 or remote_check.returncode == 0:
                 # Branch survives (local or remote) — attach a worktree to it
-                # without recreating the branch.
+                # without recreating the branch. For a remote-only branch, git
+                # auto-creates a local tracking branch in this step.
                 main_gh._run_git(["worktree", "add", canonical, branch_name])
             else:
                 # Neither worktree nor branch — start fresh from origin/main.
@@ -1135,6 +1144,9 @@ class AutonomousOrchestrator:
             # skipped here.
             if phase != "preparation":
                 self._ensure_worktree(wf)
+                # Re-read so downstream phases see the healed worktree_path /
+                # branch_name in wf rather than the pre-heal snapshot.
+                wf = self.workflow
             if phase == "preparation":
                 self._do_preparation(wf)
             elif phase == "planning":

--- a/tests/issues/716/test_agent_runner.py
+++ b/tests/issues/716/test_agent_runner.py
@@ -1,6 +1,7 @@
 """Unit tests for AutonomousAgentRunner."""
 
 import json
+import os
 import queue
 import threading
 from io import BytesIO
@@ -283,7 +284,10 @@ class TestAgentRunnerRunTask:
         assert create_calls[0].kwargs["session_id"] == "real-claude-session"
         assert create_calls[0].kwargs["tool_name"] == "claude"
         assert create_calls[0].kwargs["title"] == "claude - real-cla"
-        assert create_calls[0].kwargs["project_path"] == "-tmp-test"
+        # realpath-resolved: /tmp is a symlink to /private/tmp on macOS
+        assert create_calls[0].kwargs["project_path"] == os.path.realpath("/tmp/test").replace(
+            "/", "-"
+        )
         assert create_calls[0].kwargs["user_id"] == 42
 
         persisted_updates = [
@@ -356,7 +360,7 @@ class TestAgentRunnerRunTask:
             title="claude - late-cla",
             tool_name="claude",
             user_id=42,
-            project_path="-tmp-test",
+            project_path=os.path.realpath("/tmp/test").replace("/", "-"),
             workspace_type="local",
             remote_machine_id=None,
             context={"workflow_id": "wf-1"},
@@ -370,7 +374,7 @@ class TestAgentRunnerRunTask:
             process=MagicMock(),
             cli_tool="claude-code",
             project_path="/tmp/test",
-            encoded_project_path="-tmp-test",
+            encoded_project_path=os.path.realpath("/tmp/test").replace("/", "-"),
             workflow_id="wf-1",
             user_id=42,
         )

--- a/tests/issues/814/test_worktree_path_selfheal.py
+++ b/tests/issues/814/test_worktree_path_selfheal.py
@@ -208,17 +208,38 @@ class TestEnsureWorktreeSelfHeal:
         assert result == wf["project_path"]
         o._update_workflow.assert_not_called()
 
+    def test_empty_worktree_path_is_noop_not_recreate(self, monkeypatch):
+        # Regression: a merge-phase retry has worktree_path="" (cleared
+        # deliberately by merge cleanup). Self-heal must NOT treat that as
+        # "dir gone, recreate" — that would try `git worktree add <main_repo>`
+        # and turn a retried merge into a hard failure (#1088 review).
+        wf = _make_workflow(
+            worktree_path="",
+            branch_name="auto-dev/1390d553",
+            current_phase="merge",
+            status="merging",
+        )
+        o = _make_orchestrator(wf)
+
+        # GitHubOps must never be constructed (no recreation attempt).
+        with patch("app.modules.workspace.autonomous.orchestrator.GitHubOps") as mock_gh_cls:
+            result = o._ensure_worktree(wf)
+            mock_gh_cls.assert_not_called()
+
+        # Returns project_path (main repo), no DB write, no milestone.
+        assert result == wf["project_path"]
+        o._update_workflow.assert_not_called()
+        o._create_milestone.assert_not_called()
+
 
 class TestAdvanceCallsSelfHeal:
     """``advance()`` must self-heal the worktree before downstream phases."""
 
-    def test_advance_calls_ensure_worktree_before_planning(self, monkeypatch):
+    def test_advance_calls_ensure_worktree_before_planning(self):
         wf = _make_workflow(current_phase="planning", status="planning")
         o = _make_orchestrator(wf)
         o._ensure_worktree = MagicMock(return_value=os.path.realpath(wf["worktree_path"]))
         o._do_planning = MagicMock()
-        # Force preparation-skipping branch.
-        monkeypatch.setattr(os.path, "isfile", lambda p: True)
 
         o.advance()
 

--- a/tests/issues/814/test_worktree_path_selfheal.py
+++ b/tests/issues/814/test_worktree_path_selfheal.py
@@ -1,0 +1,237 @@
+"""Tests for worktree path normalization + self-heal (#814).
+
+Two bugs caused a worktree-strategy workflow to fail with
+``Failed to detect Claude sidebar session JSONL``:
+
+  1. ``_encode_project_path`` encoded the raw ``f"{repo}/../branch"`` path
+     verbatim (``..`` intact), which never matched the dir Claude CLI
+     actually wrote under ``~/.claude/projects`` (realpath-resolved).
+  2. Retrying/resuming after the worktree dir was cleaned up launched the
+     agent against an empty path because no phase checked whether the
+     worktree/branch still existed.
+
+Covers:
+  - ``_encode_project_path`` resolves ``..`` and symlinks before encoding.
+  - ``_ensure_worktree`` normalizes a stale (``..``) stored path when the
+    worktree is still valid.
+  - ``_ensure_worktree`` recreates a missing worktree, reusing the branch
+    when it survives or creating fresh from origin/main.
+  - ``_ensure_worktree`` is a no-op for non-worktree strategies.
+"""
+
+import os
+from unittest.mock import MagicMock, patch
+
+from app.modules.workspace.autonomous.agent_runner import AutonomousAgentRunner
+from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+# ── _encode_project_path ─────────────────────────────────────────────────
+
+
+class TestEncodeProjectPathNormalizes:
+    def test_collapses_dotdot(self):
+        # The exact shape that broke #814: a worktree path built as
+        # f"{repo}/../branch-name" still carries ".." when stored.
+        raw = "/Users/rhuang/workspace/open-ace/../auto-dev-1390d553"
+        encoded = AutonomousAgentRunner._encode_project_path(raw)
+        # realpath collapses the ".." — encoding must match what Claude CLI
+        # writes, not the raw input.
+        expected = os.path.realpath(raw).replace("/", "-")
+        assert encoded == expected
+        assert ".." not in encoded
+
+    def test_resolves_symlinks(self, tmp_path):
+        # /tmp on macOS is a symlink to /private/tmp — encoding must follow it
+        # so it agrees with Claude's getcwd-based encoding.
+        link_target = tmp_path / "real"
+        link_target.mkdir()
+        encoded = AutonomousAgentRunner._encode_project_path(str(link_target))
+        assert encoded == os.path.realpath(str(link_target)).replace("/", "-")
+
+    def test_already_canonical_unchanged(self):
+        path = "/Users/rhuang/workspace/open-ace"
+        assert AutonomousAgentRunner._encode_project_path(path) == os.path.realpath(path).replace(
+            "/", "-"
+        )
+
+    def test_empty_string_returns_empty(self):
+        assert AutonomousAgentRunner._encode_project_path("") == ""
+
+
+# ── _ensure_worktree ─────────────────────────────────────────────────────
+
+
+def _make_workflow(**overrides):
+    base = {
+        "workflow_id": "wf-814",
+        "title": "gh issue 814",
+        "cli_tool": "claude-code",
+        "model": "",
+        "branch_strategy": "worktree",
+        "branch_name": "auto-dev/1390d553",
+        "worktree_path": "/Users/rhuang/workspace/open-ace/../auto-dev-1390d553",
+        "project_path": "/Users/rhuang/workspace/open-ace",
+        "workspace_type": "local",
+        "current_phase": "planning",
+        "status": "planning",
+    }
+    base.update(overrides)
+    return base
+
+
+def _make_orchestrator(wf):
+    with (
+        patch("app.modules.workspace.autonomous.orchestrator.Database"),
+        patch(
+            "app.modules.workspace.autonomous.orchestrator.AutonomousWorkflowRepository"
+        ) as mock_repo_cls,
+    ):
+        mock_repo = MagicMock()
+        mock_repo.get_workflow.return_value = wf
+        mock_repo_cls.return_value = mock_repo
+        o = AutonomousOrchestrator(wf["workflow_id"])
+        o.repo = mock_repo
+    o.emitter = MagicMock()
+    o._update_workflow = MagicMock()
+    o._create_milestone = MagicMock()
+    return o
+
+
+class TestEnsureWorktreeSelfHeal:
+    def test_normalizes_stale_dotdot_path_when_valid(self, monkeypatch):
+        # Worktree dir IS valid on disk — only the stored path is dirty.
+        wf = _make_workflow()
+        canonical = os.path.realpath(wf["worktree_path"])
+
+        def fake_isfile(p):
+            # The .git marker exists inside the canonical worktree dir.
+            return p == os.path.join(canonical, ".git")
+
+        monkeypatch.setattr(os.path, "isfile", fake_isfile)
+        o = _make_orchestrator(wf)
+
+        result = o._ensure_worktree(wf)
+
+        assert result == canonical
+        # Stale path was corrected in the DB.
+        o._update_workflow.assert_called_once_with({"worktree_path": canonical})
+        # No recreation milestone (worktree was already valid).
+        o._create_milestone.assert_not_called()
+
+    def test_no_update_when_path_already_canonical(self, monkeypatch):
+        wf = _make_workflow(worktree_path=os.path.realpath("/srv/repo/../wt"))
+        canonical = wf["worktree_path"]
+
+        monkeypatch.setattr(os.path, "isfile", lambda p: p == os.path.join(canonical, ".git"))
+        o = _make_orchestrator(wf)
+
+        result = o._ensure_worktree(wf)
+
+        assert result == canonical
+        o._update_workflow.assert_not_called()
+
+    def test_recreates_missing_worktree_reusing_surviving_branch(self, monkeypatch):
+        # Worktree dir is gone, but the branch still exists locally.
+        wf = _make_workflow()
+        canonical = os.path.realpath(wf["worktree_path"])
+
+        # No .git marker → worktree is considered missing.
+        monkeypatch.setattr(os.path, "isfile", lambda p: False)
+
+        o = _make_orchestrator(wf)
+        fake_gh = MagicMock()
+        # Local branch exists.
+        local_check = MagicMock(returncode=0)
+        remote_check = MagicMock(returncode=1)
+        fake_gh._run_git.side_effect = [
+            MagicMock(),  # fetch origin main
+            local_check,  # show-ref refs/heads/<branch>
+            remote_check,  # show-ref refs/remotes/origin/<branch>
+            # worktree add <path> <existing-branch>  (NO -b)
+            MagicMock(),
+        ]
+        monkeypatch.setattr(
+            "app.modules.workspace.autonomous.orchestrator.GitHubOps",
+            lambda _path: fake_gh,
+        )
+
+        result = o._ensure_worktree(wf)
+
+        assert result == canonical
+        # Last git call reattaches the existing branch (no -b flag).
+        last_call = fake_gh._run_git.call_args_list[-1].args[0]
+        assert last_call == ["worktree", "add", canonical, wf["branch_name"]]
+        o._create_milestone.assert_called_once()
+
+    def test_recreates_missing_worktree_and_branch_from_origin(self, monkeypatch):
+        # Both worktree and branch are gone — must create fresh.
+        wf = _make_workflow()
+        canonical = os.path.realpath(wf["worktree_path"])
+
+        monkeypatch.setattr(os.path, "isfile", lambda p: False)
+
+        o = _make_orchestrator(wf)
+        fake_gh = MagicMock()
+        not_found = MagicMock(returncode=1)
+        fake_gh._run_git.side_effect = [
+            MagicMock(),  # fetch origin main
+            not_found,  # local branch missing
+            not_found,  # remote branch missing
+            # worktree add -b <branch> <path> origin/main
+            MagicMock(),
+        ]
+        monkeypatch.setattr(
+            "app.modules.workspace.autonomous.orchestrator.GitHubOps",
+            lambda _path: fake_gh,
+        )
+
+        result = o._ensure_worktree(wf)
+
+        assert result == canonical
+        last_call = fake_gh._run_git.call_args_list[-1].args[0]
+        assert last_call == [
+            "worktree",
+            "add",
+            "-b",
+            wf["branch_name"],
+            canonical,
+            "origin/main",
+        ]
+
+    def test_noop_for_new_branch_strategy(self, monkeypatch):
+        wf = _make_workflow(branch_strategy="new-branch", worktree_path="")
+        o = _make_orchestrator(wf)
+
+        # For new-branch the worktree_path is empty; returns project_path.
+        result = o._ensure_worktree(wf)
+
+        assert result == wf["project_path"]
+        o._update_workflow.assert_not_called()
+
+
+class TestAdvanceCallsSelfHeal:
+    """``advance()`` must self-heal the worktree before downstream phases."""
+
+    def test_advance_calls_ensure_worktree_before_planning(self, monkeypatch):
+        wf = _make_workflow(current_phase="planning", status="planning")
+        o = _make_orchestrator(wf)
+        o._ensure_worktree = MagicMock(return_value=os.path.realpath(wf["worktree_path"]))
+        o._do_planning = MagicMock()
+        # Force preparation-skipping branch.
+        monkeypatch.setattr(os.path, "isfile", lambda p: True)
+
+        o.advance()
+
+        o._ensure_worktree.assert_called_once()
+        o._do_planning.assert_called_once()
+
+    def test_advance_skips_selfheal_during_preparation(self):
+        wf = _make_workflow(current_phase="preparation", status="preparing")
+        o = _make_orchestrator(wf)
+        o._ensure_worktree = MagicMock()
+        o._do_preparation = MagicMock()
+
+        o.advance()
+
+        o._ensure_worktree.assert_not_called()
+        o._do_preparation.assert_called_once()


### PR DESCRIPTION
## Problem

Workflow `gh issue 814` (worktree strategy) failed with:

```
Planning failed: Failed to detect Claude sidebar session JSONL for autonomous task
```

Two independent bugs caused this.

### Bug 1 — Worktree path encoding mismatch

`_do_preparation` built the worktree path as `f"{project_path}/../{branch_name}"`, leaving `..` intact and storing it raw in the DB. `_encode_project_path` then encoded this verbatim (`/Users/.../open-ace-..-auto-dev-1390d553`), but Claude CLI writes session history under the **realpath-resolved** dir (`-Users-rhuang-workspace-auto-dev-1390d553`). The encoded dir never existed, so `_find_latest_claude_session_id` always returned `<none>`.

This was latent: `_ensure_sidebar_session` prefers the `cli_session_id` captured from control_response, and only falls back to mtime-based JSONL discovery when control_response is missed. The recent z.ai `glm-5.2` 529 storms caused control_response to be missed, exposing the bug — both session-detection paths failed simultaneously.

### Bug 2 — No worktree self-heal on retry/resume

`retry` / `resume` only flip the status; they never re-check whether the worktree dir or branch still exists. A retried workflow whose worktree was cleaned up after a prior failure silently launches the agent against an empty path. `_do_preparation` (the only place that creates the worktree) is never re-run once the phase is `planning` or later.

## Fix

### Bug 1 (path normalization, defensive at two layers)

- `agent_runner.py:_encode_project_path` — `os.path.realpath()` before encoding, so any upstream path form (including `..` and symlinks) matches Claude's own getcwd-based encoding.
- `orchestrator.py` — `os.path.normpath()` at both worktree-creation sites (main path + fork path) so the stored DB path is canonical from the start.

### Bug 2 (worktree self-heal)

- New `_ensure_worktree(wf)` method:
  - No-op for non-worktree strategies (returns `project_path`).
  - If the worktree dir is valid (`.git` marker present), normalizes a stale `..` path in the DB.
  - If missing, recreates it from the main repo: reuses the branch when it survives (local or remote), otherwise starts fresh from `origin/main`. Resets the cached `_gh` so it picks up the restored path.
- Called once at `advance()` entry for all phases except `preparation` (which creates the worktree itself).

## Tests

`tests/issues/814/test_worktree_path_selfheal.py` (11 new tests):

- `_encode_project_path`: collapses `..`, resolves symlinks (`/tmp`→`/private/tmp`), canonical path unchanged, empty input.
- `_ensure_worktree`: normalizes stale path when valid, no-op when already canonical, recreates reusing surviving branch, recreates branch+worktree from origin, no-op for new-branch strategy.
- `advance()`: calls `_ensure_worktree` before planning, skips it during preparation.

All 25 tests pass (12 existing #1001 regression + 11 new + 2 advance integration).

## Notes

- After merge, #814 can be retried and will self-heal its (currently missing) worktree + branch.
- The model-availability issue (`glm-5.2[1m]` 529 on z.ai) is separate and still needs a model-config change to unblock planning reliably.
