### PR TITLE
feat: sync ZCode sessions from SQLite DB to session history

### DIFF
--- a/app/modules/workspace/autonomous/agent_runner.py
+++ b/app/modules/workspace/autonomous/agent_runner.py
@@ -162,10 +162,18 @@ class AutonomousAgentRunner:
     def _encode_project_path(project_path: str) -> str:
         """Best-effort match for the encoded project path used by Claude session history.
 
-        Today Claude stores absolute paths by replacing "/" with "-". Keep this logic
-        isolated here because it is an implementation detail outside our control.
+        Claude stores session history under ``~/.claude/projects/<encoded>`` where
+        ``<encoded>`` is the *real* (symlink/``..``-resolved) absolute path with
+        ``/`` replaced by ``-``. Callers can pass any form — a worktree path
+        produced by ``f"{repo}/../branch"`` still contains ``..`` — so we must
+        normalize first or the encoded dir never matches what Claude actually
+        wrote (#814). ``realpath`` also resolves symlinks, matching Claude's
+        own ``getcwd``-based encoding.
         """
-        return project_path.replace("/", "-") if project_path.startswith("/") else project_path
+        if not project_path:
+            return ""
+        resolved = os.path.realpath(project_path)
+        return resolved.replace("/", "-")
 
     def _find_latest_claude_session_id(
         self,

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -9,6 +9,7 @@ pr_review -> report -> wait -> (loop or merge).
 
 import json
 import logging
+import os
 import re
 import threading
 import time
@@ -300,6 +301,85 @@ class AutonomousOrchestrator:
             project_path = wf.get("worktree_path") or wf.get("project_path", "")
             self._gh = GitHubOps(project_path)
         return self._gh
+
+    def _ensure_worktree(self, wf: dict) -> str:
+        """Guarantee the worktree dir + branch exist before a phase runs.
+
+        Retrying/resuming a ``worktree``-strategy workflow after its dir was
+        cleaned up (e.g. a previous failure removed it, or the machine
+        rebooted) used to silently launch the agent against an empty path and
+        fail with a JSONL-detection error (#814). Every downstream phase now
+        calls this at entry so the environment self-heals:
+
+        - normalizes a stale ``worktree_path`` still containing ``..`` so the
+          DB and the on-disk dir agree;
+        - recreates the worktree dir (reusing the branch if it still exists)
+          when it is gone.
+
+        Returns the canonical worktree path. For non-worktree strategies, or
+        when ``worktree_path`` is intentionally empty (merge cleanup / conflict
+        resolution clears it), this is a no-op returning ``project_path``.
+        """
+        strategy = wf.get("branch_strategy", "new-branch")
+        project_path = wf.get("project_path", "")
+        worktree_path = wf.get("worktree_path", "")
+
+        # An empty worktree_path is NOT the "dir gone, recreate it" case — it
+        # is set deliberately by merge cleanup (_resolve_merge_conflicts /
+        # _do_merge) when the worktree is removed to free the main repo for
+        # conflict resolution. Treating it as missing would fall back to
+        # project_path as canonical and try `git worktree add <main_repo>`,
+        # which fails and turns a retried merge into a hard failure. Only a
+        # non-empty path whose dir is gone represents external loss (#814).
+        if strategy != "worktree" or not project_path or not worktree_path:
+            return worktree_path or project_path
+
+        canonical = os.path.realpath(worktree_path)
+        # Valid worktree: a .git file/dir inside means git set it up. If the
+        # stored path was unnormalized (legacy ".."), persist the canonical
+        # form so JSONL session detection matches Claude's encoding.
+        if worktree_path and os.path.isfile(os.path.join(canonical, ".git")):
+            if canonical != worktree_path:
+                self._update_workflow({"worktree_path": canonical})
+            return canonical
+
+        # Worktree missing — recreate from the main repo.
+        branch_name = wf.get("branch_name") or f"auto-dev/{self._workflow_id[:8]}"
+        main_gh = GitHubOps(project_path)
+        try:
+            main_gh._run_git(["fetch", "origin", "main"])
+            # Does the branch still exist locally or on origin?
+            branch_check = main_gh._run_git(
+                ["show-ref", "--verify", "--quiet", f"refs/heads/{branch_name}"],
+                check=False,
+            )
+            remote_check = main_gh._run_git(
+                ["show-ref", "--verify", "--quiet", f"refs/remotes/origin/{branch_name}"],
+                check=False,
+            )
+            if branch_check.returncode == 0 or remote_check.returncode == 0:
+                # Branch survives (local or remote) — attach a worktree to it
+                # without recreating the branch. For a remote-only branch, git
+                # auto-creates a local tracking branch in this step.
+                main_gh._run_git(["worktree", "add", canonical, branch_name])
+            else:
+                # Neither worktree nor branch — start fresh from origin/main.
+                main_gh._run_git(["worktree", "add", "-b", branch_name, canonical, "origin/main"])
+        except GitHubOpsError as e:
+            logger.error("Failed to recreate worktree at %s: %s", canonical, e)
+            raise
+
+        self._update_workflow({"worktree_path": canonical, "branch_name": branch_name})
+        self._create_milestone(
+            phase=wf.get("current_phase", "preparation"),
+            milestone_type="worktree_restored",
+            status="completed",
+            title=f"Worktree restored at {os.path.basename(canonical)}",
+        )
+        logger.info("Restored worktree at %s on branch %s", canonical, branch_name)
+        # Reset cached gh so it picks up the restored worktree path.
+        self._gh = None
+        return canonical
 
     def _emit(self, event_type: str, data: dict):
         """Emit a timeline event."""
@@ -1061,6 +1141,16 @@ class AutonomousOrchestrator:
         logger.info("Advancing workflow %s phase=%s", self._workflow_id[:8], phase)
 
         try:
+            # Self-heal the worktree before any downstream phase runs. A
+            # retried/resumed workflow may find its worktree dir gone (cleaned
+            # up after a prior failure), which previously launched the agent
+            # against an empty path (#814). preparation creates it, so it's
+            # skipped here.
+            if phase != "preparation":
+                self._ensure_worktree(wf)
+                # Re-read so downstream phases see the healed worktree_path /
+                # branch_name in wf rather than the pre-heal snapshot.
+                wf = self.workflow
             if phase == "preparation":
                 self._do_preparation(wf)
             elif phase == "planning":
@@ -1121,7 +1211,10 @@ class AutonomousOrchestrator:
             # Force worktree for parallel execution
             try:
                 gh._run_git(["fetch", "origin", "main"])
-                wt_path = f"{project_path}/../{branch_name.replace('/', '-')}"
+                # normpath collapses the ".." so the stored path and the worktree
+                # dir on disk agree; an unnormalized path later breaks JSONL
+                # session detection (#814).
+                wt_path = os.path.normpath(f"{project_path}/../{branch_name.replace('/', '-')}")
                 gh.create_worktree(path=wt_path, branch=branch_name, base=base_ref)
                 self._update_workflow(
                     {
@@ -1272,8 +1365,10 @@ class AutonomousOrchestrator:
                 gh._run_git(["fetch", "origin", "main"])
 
                 if strategy == "worktree":
+                    # normpath collapses ".." so DB/JSONL encoding matches the
+                    # real worktree dir (#814).
                     wt_data = gh.create_worktree(
-                        path=f"{project_path}/../{branch_name.replace('/', '-')}",
+                        path=os.path.normpath(f"{project_path}/../{branch_name.replace('/', '-')}"),
                         branch=branch_name,
                         base="origin/main",
                     )

--- a/remote-agent/session_sync.py
+++ b/remote-agent/session_sync.py
@@ -13,7 +13,9 @@ from __future__ import annotations
 import json
 import logging
 import os
+import sqlite3
 import time
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -33,6 +35,11 @@ QWEN_PROJECTS_DIR = QWEN_DIR / "projects"
 
 CODEX_DIR = Path.home() / ".codex"
 CODEX_SESSIONS_DIR = CODEX_DIR / "sessions"
+
+# ZCode stores sessions in a SQLite database (not JSONL files like the other CLIs).
+ZCODE_DIR = Path.home() / ".zcode"
+ZCODE_DB_PATH = ZCODE_DIR / "cli" / "db" / "db.sqlite"
+ZCODE_SYNC_TOOL_NAME = "zcode"
 
 # File to track which sessions have already been synced
 SYNC_STATE_FILE = Path.home() / ".open-ace-agent" / "session_sync_state.json"
@@ -540,6 +547,209 @@ class CodexSession:
         }
 
 
+class ZcodeSession:
+    """Parsed ZCode session read from the ZCode SQLite database.
+
+    Unlike the Claude/Qwen/Codex parsers (which read JSONL files), ZCode stores
+    sessions relationally in ``~/.zcode/cli/db/db.sqlite``. This class queries
+    the ``session``, ``message``, ``part`` and ``turn_usage`` tables to reconstruct
+    a sync payload with the same shape the server expects.
+
+    Only ``interactive`` sessions are parsed; ``subagent_child`` rows are skipped
+    by the scanner.
+    """
+
+    def __init__(self, session_id: str, db_path: str | Path):
+        self.session_id = session_id
+        self.db_path = str(db_path)
+        self.messages: list[dict[str, Any]] = []
+        self.model: str | None = None
+        self.project_path: str | None = None
+        self.total_input_tokens = 0
+        self.total_output_tokens = 0
+        self.message_count = 0
+        self.first_timestamp: str | None = None
+        self.last_timestamp: str | None = None
+
+    def _connect(self) -> sqlite3.Connection:
+        """Open a read-only connection to avoid blocking ZCode's WAL writer."""
+        return sqlite3.connect(f"file:{self.db_path}?mode=ro", uri=True)
+
+    def parse(self) -> bool:
+        """Query the DB and populate message/token metadata. Returns True if usable."""
+        try:
+            conn = self._connect()
+        except sqlite3.Error as e:
+            logger.debug("Cannot open ZCode DB %s: %s", self.db_path, e)
+            return False
+
+        try:
+            # 1. Session metadata (directory, timestamps).
+            row = conn.execute(
+                "SELECT directory, time_created, time_updated " "FROM session WHERE id = ?",
+                (self.session_id,),
+            ).fetchone()
+            if not row:
+                return False
+            self.project_path = row[0]
+            created_ms = row[1]
+            updated_ms = row[2]
+            if created_ms:
+                self.first_timestamp = _ms_to_iso(created_ms)
+            if updated_ms:
+                self.last_timestamp = _ms_to_iso(updated_ms)
+
+            # 2. Messages ordered by time, with their text parts aggregated.
+            msg_rows = conn.execute(
+                "SELECT m.id, m.time_created, m.data, "
+                "GROUP_CONCAT(p.data) AS parts_data "
+                "FROM message m LEFT JOIN part p ON p.message_id = m.id "
+                "WHERE m.session_id = ? "
+                "GROUP BY m.id ORDER BY m.time_created",
+                (self.session_id,),
+            ).fetchall()
+
+            for msg_id, time_created, data_json, parts_json in msg_rows:
+                self._process_message(msg_id, time_created, data_json, parts_json)
+
+            # 3. Authoritative token totals from turn_usage.
+            tu = conn.execute(
+                "SELECT COALESCE(SUM(input_tokens), 0), "
+                "COALESCE(SUM(output_tokens), 0) "
+                "FROM turn_usage WHERE session_id = ?",
+                (self.session_id,),
+            ).fetchone()
+            if tu:
+                self.total_input_tokens = tu[0] or 0
+                self.total_output_tokens = tu[1] or 0
+
+            return self.message_count > 0
+        except sqlite3.DatabaseError as e:
+            logger.debug("Failed to parse ZCode session %s: %s", self.session_id[:8], e)
+            return False
+        finally:
+            conn.close()
+
+    def _process_message(
+        self,
+        msg_id: str,
+        time_created: int,
+        data_json: str | None,
+        parts_json: str | None,
+    ) -> None:
+        """Build one sync message from a message row + its aggregated parts."""
+        data: dict[str, Any] = {}
+        if data_json:
+            try:
+                data = json.loads(data_json)
+            except (json.JSONDecodeError, TypeError):
+                data = {}
+
+        role = data.get("role")
+        if role not in ("user", "assistant"):
+            return
+
+        # Concatenate text content from the message's parts.
+        text_content = ""
+        if parts_json:
+            text_content = self._extract_parts_text(parts_json)
+
+        # Fallback: some user messages carry inline text.
+        if not text_content:
+            inline = data.get("text") or data.get("content")
+            if isinstance(inline, str):
+                text_content = inline
+
+        # Skip empty messages (server drops them anyway).
+        if not text_content.strip():
+            return
+
+        model = data.get("modelID") or data.get("model", {}).get("modelId")
+        timestamp = _ms_to_iso(time_created) if time_created else None
+
+        msg: dict[str, Any] = {
+            "role": role,
+            "content": text_content,
+            "content_blocks": None,
+            "timestamp": timestamp,
+            "model": model,
+            "uuid": msg_id,
+        }
+
+        tokens = data.get("tokens")
+        if isinstance(tokens, dict) and role == "assistant":
+            input_t = tokens.get("input", 0)
+            output_t = tokens.get("output", 0)
+            msg["usage"] = {"input_tokens": input_t, "output_tokens": output_t}
+
+        self.messages.append(msg)
+        self.message_count += 1
+
+        if not self.model and model:
+            self.model = model
+
+        if timestamp:
+            if not self.first_timestamp:
+                self.first_timestamp = timestamp
+            self.last_timestamp = timestamp
+
+    @staticmethod
+    def _extract_parts_text(parts_json: str) -> str:
+        """Extract concatenated text from a GROUP_CONCAT blob of part.data rows.
+
+        Each part.data is a JSON object; GROUP_CONCAT joins them with commas.
+        We walk the blob and keep only parts where type == "text".
+        """
+        # Recover individual JSON objects from the concatenated blob. A robust
+        # approach: a comma at brace-depth 0 separates objects.
+        texts: list[str] = []
+        depth = 0
+        start = 0
+        for i, ch in enumerate(parts_json):
+            if ch == "{":
+                if depth == 0:
+                    start = i
+                depth += 1
+            elif ch == "}":
+                depth -= 1
+                if depth == 0:
+                    chunk = parts_json[start : i + 1]
+                    try:
+                        part = json.loads(chunk)
+                    except json.JSONDecodeError:
+                        continue
+                    if part.get("type") == "text":
+                        t = part.get("text")
+                        if isinstance(t, str):
+                            texts.append(t)
+        return "".join(texts)
+
+    def to_sync_payload(self, machine_id: str, terminal_id: str) -> dict[str, Any]:
+        """Convert to the payload expected by the Open-ACE session-sync endpoint."""
+        return {
+            "session_id": self.session_id,
+            "machine_id": machine_id,
+            "terminal_id": terminal_id,
+            "tool_name": ZCODE_SYNC_TOOL_NAME,
+            "project_path": self.project_path,
+            "model": self.model,
+            "message_count": self.message_count,
+            "total_input_tokens": self.total_input_tokens,
+            "total_output_tokens": self.total_output_tokens,
+            "first_timestamp": self.first_timestamp,
+            "last_timestamp": self.last_timestamp,
+            "source": os.environ.get("OPEN_ACE_TERMINAL_SOURCE", "web_terminal"),
+            "messages": self.messages,
+        }
+
+
+def _ms_to_iso(ms: int | None) -> str | None:
+    """Convert epoch milliseconds to an ISO-8601 string."""
+    if not ms:
+        return None
+    return datetime.fromtimestamp(ms / 1000, tz=timezone.utc).isoformat()
+
+
 class SessionSyncService:
     """
     Background service that scans for Claude Code session files and syncs
@@ -630,6 +840,7 @@ class SessionSyncService:
         while self._running:
             try:
                 self._scan_and_sync()
+                self._scan_and_sync_zcode_db()
                 self._cleanup_synced_files()
             except Exception as e:
                 logger.error("Session sync error: %s", e)
@@ -644,6 +855,75 @@ class SessionSyncService:
             for f in to_remove:
                 self._synced_files.discard(f)
             logger.info("Cleaned up %d stale synced file entries", excess)
+
+    def _scan_and_sync_zcode_db(self) -> None:
+        """Scan the ZCode SQLite DB for interactive sessions and sync new/changed ones.
+
+        ZCode stores sessions in a relational DB rather than JSONL files, so this
+        does not use the rglob scan. Dedup keys are ``zcode:<session_id>`` strings
+        stored in the same _synced_files / _last_sync_times state as JSONL syncs.
+        A session is re-synced when its ``time_updated`` column advances past the
+        last sync time.
+        """
+        if not ZCODE_DB_PATH.exists():
+            return
+
+        # Discover candidate sessions (interactive, not archived).
+        try:
+            conn = sqlite3.connect(f"file:{ZCODE_DB_PATH}?mode=ro", uri=True)
+        except sqlite3.Error as e:
+            logger.debug("Cannot open ZCode DB for scan: %s", e)
+            return
+
+        candidates: list[tuple[str, int]] = []
+        try:
+            rows = conn.execute(
+                "SELECT id, time_updated FROM session "
+                "WHERE task_type = 'interactive' AND time_archived IS NULL"
+            ).fetchall()
+            candidates = [(r[0], r[1] or 0) for r in rows]
+        except sqlite3.DatabaseError as e:
+            logger.debug("ZCode DB query failed: %s", e)
+            return
+        finally:
+            conn.close()
+
+        synced_count = 0
+        for session_id, time_updated_ms in candidates:
+            dedup_key = f"zcode:{session_id}"
+            last_sync = self._last_sync_times.get(dedup_key, 0)
+            # time_updated is epoch ms; compare against last sync (epoch s).
+            if dedup_key in self._synced_files and time_updated_ms / 1000 <= last_sync:
+                continue
+
+            session = ZcodeSession(session_id, ZCODE_DB_PATH)
+            if not session.parse() or session.message_count == 0:
+                continue
+
+            terminal_id, source = self._get_active_terminal_context()
+            payload = session.to_sync_payload(self._config.machine_id, terminal_id)
+            payload["source"] = source
+
+            try:
+                result = self._http_send(
+                    {
+                        "type": "session_sync",
+                        "machine_id": self._config.machine_id,
+                        **payload,
+                    }
+                )
+            except Exception as e:  # noqa: BLE001
+                logger.debug("ZCode session sync send failed for %s: %s", session_id[:8], e)
+                continue
+
+            if result:
+                self._synced_files.add(dedup_key)
+                self._last_sync_times[dedup_key] = time.time()
+                synced_count += 1
+
+        if synced_count > 0:
+            self._save_state()
+            logger.info("Synced %d ZCode sessions", synced_count)
 
     def _scan_and_sync(self) -> None:
         """Scan for session files and sync new/changed ones."""

--- a/tests/issues/716/test_agent_runner.py
+++ b/tests/issues/716/test_agent_runner.py
@@ -1,6 +1,7 @@
 """Unit tests for AutonomousAgentRunner."""
 
 import json
+import os
 import queue
 import threading
 from io import BytesIO
@@ -283,7 +284,10 @@ class TestAgentRunnerRunTask:
         assert create_calls[0].kwargs["session_id"] == "real-claude-session"
         assert create_calls[0].kwargs["tool_name"] == "claude"
         assert create_calls[0].kwargs["title"] == "claude - real-cla"
-        assert create_calls[0].kwargs["project_path"] == "-tmp-test"
+        # realpath-resolved: /tmp is a symlink to /private/tmp on macOS
+        assert create_calls[0].kwargs["project_path"] == os.path.realpath("/tmp/test").replace(
+            "/", "-"
+        )
         assert create_calls[0].kwargs["user_id"] == 42
 
         persisted_updates = [
@@ -356,7 +360,7 @@ class TestAgentRunnerRunTask:
             title="claude - late-cla",
             tool_name="claude",
             user_id=42,
-            project_path="-tmp-test",
+            project_path=os.path.realpath("/tmp/test").replace("/", "-"),
             workspace_type="local",
             remote_machine_id=None,
             context={"workflow_id": "wf-1"},
@@ -370,7 +374,7 @@ class TestAgentRunnerRunTask:
             process=MagicMock(),
             cli_tool="claude-code",
             project_path="/tmp/test",
-            encoded_project_path="-tmp-test",
+            encoded_project_path=os.path.realpath("/tmp/test").replace("/", "-"),
             workflow_id="wf-1",
             user_id=42,
         )

--- a/tests/issues/814/test_worktree_path_selfheal.py
+++ b/tests/issues/814/test_worktree_path_selfheal.py
@@ -1,0 +1,258 @@
+"""Tests for worktree path normalization + self-heal (#814).
+
+Two bugs caused a worktree-strategy workflow to fail with
+``Failed to detect Claude sidebar session JSONL``:
+
+  1. ``_encode_project_path`` encoded the raw ``f"{repo}/../branch"`` path
+     verbatim (``..`` intact), which never matched the dir Claude CLI
+     actually wrote under ``~/.claude/projects`` (realpath-resolved).
+  2. Retrying/resuming after the worktree dir was cleaned up launched the
+     agent against an empty path because no phase checked whether the
+     worktree/branch still existed.
+
+Covers:
+  - ``_encode_project_path`` resolves ``..`` and symlinks before encoding.
+  - ``_ensure_worktree`` normalizes a stale (``..``) stored path when the
+    worktree is still valid.
+  - ``_ensure_worktree`` recreates a missing worktree, reusing the branch
+    when it survives or creating fresh from origin/main.
+  - ``_ensure_worktree`` is a no-op for non-worktree strategies.
+"""
+
+import os
+from unittest.mock import MagicMock, patch
+
+from app.modules.workspace.autonomous.agent_runner import AutonomousAgentRunner
+from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+# ── _encode_project_path ─────────────────────────────────────────────────
+
+
+class TestEncodeProjectPathNormalizes:
+    def test_collapses_dotdot(self):
+        # The exact shape that broke #814: a worktree path built as
+        # f"{repo}/../branch-name" still carries ".." when stored.
+        raw = "/Users/rhuang/workspace/open-ace/../auto-dev-1390d553"
+        encoded = AutonomousAgentRunner._encode_project_path(raw)
+        # realpath collapses the ".." — encoding must match what Claude CLI
+        # writes, not the raw input.
+        expected = os.path.realpath(raw).replace("/", "-")
+        assert encoded == expected
+        assert ".." not in encoded
+
+    def test_resolves_symlinks(self, tmp_path):
+        # /tmp on macOS is a symlink to /private/tmp — encoding must follow it
+        # so it agrees with Claude's getcwd-based encoding.
+        link_target = tmp_path / "real"
+        link_target.mkdir()
+        encoded = AutonomousAgentRunner._encode_project_path(str(link_target))
+        assert encoded == os.path.realpath(str(link_target)).replace("/", "-")
+
+    def test_already_canonical_unchanged(self):
+        path = "/Users/rhuang/workspace/open-ace"
+        assert AutonomousAgentRunner._encode_project_path(path) == os.path.realpath(path).replace(
+            "/", "-"
+        )
+
+    def test_empty_string_returns_empty(self):
+        assert AutonomousAgentRunner._encode_project_path("") == ""
+
+
+# ── _ensure_worktree ─────────────────────────────────────────────────────
+
+
+def _make_workflow(**overrides):
+    base = {
+        "workflow_id": "wf-814",
+        "title": "gh issue 814",
+        "cli_tool": "claude-code",
+        "model": "",
+        "branch_strategy": "worktree",
+        "branch_name": "auto-dev/1390d553",
+        "worktree_path": "/Users/rhuang/workspace/open-ace/../auto-dev-1390d553",
+        "project_path": "/Users/rhuang/workspace/open-ace",
+        "workspace_type": "local",
+        "current_phase": "planning",
+        "status": "planning",
+    }
+    base.update(overrides)
+    return base
+
+
+def _make_orchestrator(wf):
+    with (
+        patch("app.modules.workspace.autonomous.orchestrator.Database"),
+        patch(
+            "app.modules.workspace.autonomous.orchestrator.AutonomousWorkflowRepository"
+        ) as mock_repo_cls,
+    ):
+        mock_repo = MagicMock()
+        mock_repo.get_workflow.return_value = wf
+        mock_repo_cls.return_value = mock_repo
+        o = AutonomousOrchestrator(wf["workflow_id"])
+        o.repo = mock_repo
+    o.emitter = MagicMock()
+    o._update_workflow = MagicMock()
+    o._create_milestone = MagicMock()
+    return o
+
+
+class TestEnsureWorktreeSelfHeal:
+    def test_normalizes_stale_dotdot_path_when_valid(self, monkeypatch):
+        # Worktree dir IS valid on disk — only the stored path is dirty.
+        wf = _make_workflow()
+        canonical = os.path.realpath(wf["worktree_path"])
+
+        def fake_isfile(p):
+            # The .git marker exists inside the canonical worktree dir.
+            return p == os.path.join(canonical, ".git")
+
+        monkeypatch.setattr(os.path, "isfile", fake_isfile)
+        o = _make_orchestrator(wf)
+
+        result = o._ensure_worktree(wf)
+
+        assert result == canonical
+        # Stale path was corrected in the DB.
+        o._update_workflow.assert_called_once_with({"worktree_path": canonical})
+        # No recreation milestone (worktree was already valid).
+        o._create_milestone.assert_not_called()
+
+    def test_no_update_when_path_already_canonical(self, monkeypatch):
+        wf = _make_workflow(worktree_path=os.path.realpath("/srv/repo/../wt"))
+        canonical = wf["worktree_path"]
+
+        monkeypatch.setattr(os.path, "isfile", lambda p: p == os.path.join(canonical, ".git"))
+        o = _make_orchestrator(wf)
+
+        result = o._ensure_worktree(wf)
+
+        assert result == canonical
+        o._update_workflow.assert_not_called()
+
+    def test_recreates_missing_worktree_reusing_surviving_branch(self, monkeypatch):
+        # Worktree dir is gone, but the branch still exists locally.
+        wf = _make_workflow()
+        canonical = os.path.realpath(wf["worktree_path"])
+
+        # No .git marker → worktree is considered missing.
+        monkeypatch.setattr(os.path, "isfile", lambda p: False)
+
+        o = _make_orchestrator(wf)
+        fake_gh = MagicMock()
+        # Local branch exists.
+        local_check = MagicMock(returncode=0)
+        remote_check = MagicMock(returncode=1)
+        fake_gh._run_git.side_effect = [
+            MagicMock(),  # fetch origin main
+            local_check,  # show-ref refs/heads/<branch>
+            remote_check,  # show-ref refs/remotes/origin/<branch>
+            # worktree add <path> <existing-branch>  (NO -b)
+            MagicMock(),
+        ]
+        monkeypatch.setattr(
+            "app.modules.workspace.autonomous.orchestrator.GitHubOps",
+            lambda _path: fake_gh,
+        )
+
+        result = o._ensure_worktree(wf)
+
+        assert result == canonical
+        # Last git call reattaches the existing branch (no -b flag).
+        last_call = fake_gh._run_git.call_args_list[-1].args[0]
+        assert last_call == ["worktree", "add", canonical, wf["branch_name"]]
+        o._create_milestone.assert_called_once()
+
+    def test_recreates_missing_worktree_and_branch_from_origin(self, monkeypatch):
+        # Both worktree and branch are gone — must create fresh.
+        wf = _make_workflow()
+        canonical = os.path.realpath(wf["worktree_path"])
+
+        monkeypatch.setattr(os.path, "isfile", lambda p: False)
+
+        o = _make_orchestrator(wf)
+        fake_gh = MagicMock()
+        not_found = MagicMock(returncode=1)
+        fake_gh._run_git.side_effect = [
+            MagicMock(),  # fetch origin main
+            not_found,  # local branch missing
+            not_found,  # remote branch missing
+            # worktree add -b <branch> <path> origin/main
+            MagicMock(),
+        ]
+        monkeypatch.setattr(
+            "app.modules.workspace.autonomous.orchestrator.GitHubOps",
+            lambda _path: fake_gh,
+        )
+
+        result = o._ensure_worktree(wf)
+
+        assert result == canonical
+        last_call = fake_gh._run_git.call_args_list[-1].args[0]
+        assert last_call == [
+            "worktree",
+            "add",
+            "-b",
+            wf["branch_name"],
+            canonical,
+            "origin/main",
+        ]
+
+    def test_noop_for_new_branch_strategy(self, monkeypatch):
+        wf = _make_workflow(branch_strategy="new-branch", worktree_path="")
+        o = _make_orchestrator(wf)
+
+        # For new-branch the worktree_path is empty; returns project_path.
+        result = o._ensure_worktree(wf)
+
+        assert result == wf["project_path"]
+        o._update_workflow.assert_not_called()
+
+    def test_empty_worktree_path_is_noop_not_recreate(self, monkeypatch):
+        # Regression: a merge-phase retry has worktree_path="" (cleared
+        # deliberately by merge cleanup). Self-heal must NOT treat that as
+        # "dir gone, recreate" — that would try `git worktree add <main_repo>`
+        # and turn a retried merge into a hard failure (#1088 review).
+        wf = _make_workflow(
+            worktree_path="",
+            branch_name="auto-dev/1390d553",
+            current_phase="merge",
+            status="merging",
+        )
+        o = _make_orchestrator(wf)
+
+        # GitHubOps must never be constructed (no recreation attempt).
+        with patch("app.modules.workspace.autonomous.orchestrator.GitHubOps") as mock_gh_cls:
+            result = o._ensure_worktree(wf)
+            mock_gh_cls.assert_not_called()
+
+        # Returns project_path (main repo), no DB write, no milestone.
+        assert result == wf["project_path"]
+        o._update_workflow.assert_not_called()
+        o._create_milestone.assert_not_called()
+
+
+class TestAdvanceCallsSelfHeal:
+    """``advance()`` must self-heal the worktree before downstream phases."""
+
+    def test_advance_calls_ensure_worktree_before_planning(self):
+        wf = _make_workflow(current_phase="planning", status="planning")
+        o = _make_orchestrator(wf)
+        o._ensure_worktree = MagicMock(return_value=os.path.realpath(wf["worktree_path"]))
+        o._do_planning = MagicMock()
+
+        o.advance()
+
+        o._ensure_worktree.assert_called_once()
+        o._do_planning.assert_called_once()
+
+    def test_advance_skips_selfheal_during_preparation(self):
+        wf = _make_workflow(current_phase="preparation", status="preparing")
+        o = _make_orchestrator(wf)
+        o._ensure_worktree = MagicMock()
+        o._do_preparation = MagicMock()
+
+        o.advance()
+
+        o._ensure_worktree.assert_not_called()
+        o._do_preparation.assert_called_once()

--- a/tests/unit/test_zcode_session_sync.py
+++ b/tests/unit/test_zcode_session_sync.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""Unit tests for ZCode session sync (ZcodeSession + DB scanner).
+
+Builds a temporary SQLite DB mimicking ZCode's schema and verifies that
+ZcodeSession parses sessions/messages/tokens correctly and that the scanner
+syncs only interactive, non-archived sessions.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+_AGENT_DIR = str(Path(__file__).resolve().parents[2] / "remote-agent")
+
+
+def _load_session_sync():
+    if _AGENT_DIR not in sys.path:
+        sys.path.insert(0, _AGENT_DIR)
+    spec = importlib.util.spec_from_file_location(
+        "session_sync", Path(_AGENT_DIR) / "session_sync.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def sync_mod():
+    return _load_session_sync()
+
+
+def _build_db(db_path: Path) -> None:
+    """Create a minimal ZCode-schema DB with test data."""
+    conn = sqlite3.connect(str(db_path))
+    conn.executescript(
+        """
+        CREATE TABLE session (
+            id text primary key,
+            directory text not null,
+            time_created integer not null,
+            time_updated integer not null,
+            time_archived integer,
+            task_type text not null default 'interactive',
+            title text not null default ''
+        );
+        CREATE TABLE message (
+            id text primary key,
+            session_id text not null,
+            time_created integer not null,
+            data text not null
+        );
+        CREATE TABLE part (
+            id text primary key,
+            message_id text not null,
+            session_id text not null,
+            data text not null
+        );
+        CREATE TABLE turn_usage (
+            session_id text not null,
+            turn_id text not null,
+            input_tokens integer not null default 0,
+            output_tokens integer not null default 0,
+            PRIMARY KEY (session_id, turn_id)
+        );
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+def _insert_session(
+    db_path: Path,
+    session_id: str,
+    directory: str = "/tmp/project",
+    task_type: str = "interactive",
+    time_archived: int | None = None,
+    created: int = 1700000000000,
+    updated: int = 1700000001000,
+) -> None:
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        "INSERT INTO session (id, directory, time_created, time_updated, time_archived, task_type, title) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (session_id, directory, created, updated, time_archived, task_type, "test"),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _insert_message(
+    db_path: Path,
+    msg_id: str,
+    session_id: str,
+    time_created: int,
+    data: dict,
+    parts: list[dict] | None = None,
+) -> None:
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        "INSERT INTO message (id, session_id, time_created, data) VALUES (?, ?, ?, ?)",
+        (msg_id, session_id, time_created, json.dumps(data)),
+    )
+    if parts:
+        for i, part in enumerate(parts):
+            conn.execute(
+                "INSERT INTO part (id, message_id, session_id, data) VALUES (?, ?, ?, ?)",
+                (f"{msg_id}_part{i}", msg_id, session_id, json.dumps(part)),
+            )
+    conn.commit()
+    conn.close()
+
+
+def _insert_turn_usage(
+    db_path: Path, session_id: str, turn_id: str, input_t: int, output_t: int
+) -> None:
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        "INSERT INTO turn_usage (session_id, turn_id, input_tokens, output_tokens) "
+        "VALUES (?, ?, ?, ?)",
+        (session_id, turn_id, input_t, output_t),
+    )
+    conn.commit()
+    conn.close()
+
+
+# --------------------------------------------------------------------------- #
+# ZcodeSession.parse
+# --------------------------------------------------------------------------- #
+
+
+def test_parse_extracts_messages_tokens_and_project(sync_mod, tmp_path):
+    db = tmp_path / "db.sqlite"
+    _build_db(db)
+    sid = "sess_abc123"
+    _insert_session(db, sid, directory="/Users/me/repo")
+    _insert_message(
+        db,
+        "msg_1",
+        sid,
+        1700000000100,
+        {"role": "user"},
+        parts=[{"type": "text", "text": "hello world"}],
+    )
+    _insert_message(
+        db,
+        "msg_2",
+        sid,
+        1700000000200,
+        {
+            "role": "assistant",
+            "modelID": "GLM-5.2",
+            "tokens": {"total": 110, "input": 100, "output": 10},
+        },
+        parts=[{"type": "text", "text": "hi there"}, {"type": "reasoning", "text": "(hidden)"}],
+    )
+    _insert_turn_usage(db, sid, "turn_1", 100, 10)
+
+    session = sync_mod.ZcodeSession(sid, db)
+    assert session.parse() is True
+
+    assert session.project_path == "/Users/me/repo"
+    assert session.model == "GLM-5.2"
+    assert session.message_count == 2
+    assert session.total_input_tokens == 100
+    assert session.total_output_tokens == 10
+    # user message
+    assert session.messages[0]["role"] == "user"
+    assert session.messages[0]["content"] == "hello world"
+    assert session.messages[0]["uuid"] == "msg_1"
+    # assistant message — only text parts, reasoning excluded
+    assert session.messages[1]["role"] == "assistant"
+    assert session.messages[1]["content"] == "hi there"
+    assert session.messages[1]["usage"] == {"input_tokens": 100, "output_tokens": 10}
+
+
+def test_parse_returns_false_for_unknown_session(sync_mod, tmp_path):
+    db = tmp_path / "db.sqlite"
+    _build_db(db)
+    session = sync_mod.ZcodeSession("sess_nonexistent", db)
+    assert session.parse() is False
+
+
+def test_parse_skips_empty_content_messages(sync_mod, tmp_path):
+    db = tmp_path / "db.sqlite"
+    _build_db(db)
+    sid = "sess_empty"
+    _insert_session(db, sid)
+    _insert_message(db, "msg_1", sid, 1700000000100, {"role": "user"}, parts=[])  # no text
+    _insert_message(
+        db,
+        "msg_2",
+        sid,
+        1700000000200,
+        {"role": "assistant"},
+        parts=[{"type": "text", "text": "real content"}],
+    )
+    session = sync_mod.ZcodeSession(sid, db)
+    assert session.parse() is True
+    assert session.message_count == 1  # only the non-empty assistant message
+    assert session.messages[0]["content"] == "real content"
+
+
+def test_to_sync_payload_shape(sync_mod, tmp_path):
+    db = tmp_path / "db.sqlite"
+    _build_db(db)
+    sid = "sess_payload"
+    _insert_session(db, sid, directory="/repo")
+    _insert_message(
+        db,
+        "msg_1",
+        sid,
+        1700000000100,
+        {"role": "user"},
+        parts=[{"type": "text", "text": "q"}],
+    )
+    sess = sync_mod.ZcodeSession(sid, db)
+    sess.parse()
+    out = sess.to_sync_payload("machine-1", "term-1")
+    assert out["tool_name"] == "zcode"
+    assert out["session_id"] == sid
+    assert out["machine_id"] == "machine-1"
+    assert out["terminal_id"] == "term-1"
+    assert out["project_path"] == "/repo"
+    assert isinstance(out["messages"], list)
+    assert all("uuid" in m for m in out["messages"])
+
+
+# --------------------------------------------------------------------------- #
+# _extract_parts_text (edge cases)
+# --------------------------------------------------------------------------- #
+
+
+def test_extract_parts_text_handles_nested_braces(sync_mod):
+    # A part whose text contains a brace should not break the brace-depth walker.
+    blob = '{"type":"text","text":"code { x }"}{"type":"text","text":" more"}'
+    result = sync_mod.ZcodeSession._extract_parts_text(blob)
+    assert result == "code { x } more"
+
+
+def test_extract_parts_text_ignores_non_text_parts(sync_mod):
+    blob = '{"type":"tool","text":"ignored"}{"type":"text","text":"kept"}'
+    assert sync_mod.ZcodeSession._extract_parts_text(blob) == "kept"


### PR DESCRIPTION
## Summary

Syncs ZCode sessions from its SQLite DB to the Open-ACE server, so ZCode sessions appear in the session history UI alongside Claude/Qwen/Codex sessions.

ZCode stores sessions in a relational SQLite DB (`~/.zcode/cli/db/db.sqlite`), **not** JSONL files like the other CLIs. So this adds a DB-backed parser + scanner rather than extending the existing `rglob("*.jsonl")` path.

## Design

**`ZcodeSession`** (new class in `session_sync.py`): same contract as `QwenSession`/`ClaudeSession` (`parse()` → bool, `to_sync_payload()` → dict), but queries the DB instead of reading a JSONL file:
- `session` table → `directory` (project_path), `time_created`/`time_updated` (timestamps)
- `message` + `part` tables (joined) → reconstruct messages: role from `message.data.role`, content from `part` rows where `type="text"` (a brace-depth walker extracts text parts from the `GROUP_CONCAT` blob; reasoning/tool parts excluded)
- `turn_usage` table → authoritative per-session token totals (`input_tokens`/`output_tokens`)
- Opens the DB read-only (`mode=ro`) to avoid blocking ZCode's WAL writer

**`_scan_and_sync_zcode_db`** (new method on `SessionSyncService`): discovers `task_type='interactive'` non-archived sessions; dedups via `"zcode:<id>"` keys in the shared sync-state; re-syncs when `session.time_updated` advances. Wired into `_run_loop` alongside the existing JSONL scan. Only interactive sessions are synced (subagent_child skipped).

## Server-side: no changes
`tool_name="zcode"` is already registered in `tool_names.py`; the `session_sync` handler accepts any tool_name and the `{role, content, content_blocks, timestamp, model, uuid}` message shape; dedup works by `uuid` (populated from `message.id`).

## Test plan
- [x] `tests/unit/test_zcode_session_sync.py` — 6 tests with a mock ZCode-schema DB:
  - message/tokens/project extraction (text parts only, reasoning excluded)
  - empty-content message skip
  - unknown-session returns False
  - `to_sync_payload` shape (tool_name="zcode", uuid on every message)
  - `_extract_parts_text` nested-brace handling + non-text-part filtering
- [x] ruff/black/isort/mypy/bandit/pydocstyle clean
- [x] no regression in `test_zcode_adapter` / `test_remote_agent_installer`

## Out of scope
- `fetch.py` historical import (needs separate `fetch_zcode.py`)
- Server-side session-list view filter (`workspace.py` normalizes to qwen/claude only in one spot) — separate fix

🤖 Generated with ZCode
