### PR TITLE
fix: detect merge conflicts on stdout + auto-merge on branch policy (#822)

### DIFF
--- a/app/modules/workspace/autonomous/github_ops.py
+++ b/app/modules/workspace/autonomous/github_ops.py
@@ -347,8 +347,13 @@ class GitHubOps:
                 pass
         return comments
 
-    def merge_pr(self, number: int, strategy: str = "merge") -> dict:
-        """Merge a PR."""
+    def merge_pr(self, number: int, strategy: str = "merge", auto: bool = False) -> dict:
+        """Merge a PR.
+
+        When ``auto`` is set, adds ``--auto`` so GitHub merges asynchronously
+        once branch-protection requirements (CI, reviews) pass — used when the
+        immediate merge is rejected solely because of policy, not conflicts.
+        """
         args = ["pr", "merge", str(number)]
         if strategy == "squash":
             args.append("--squash")
@@ -356,9 +361,11 @@ class GitHubOps:
             args.append("--rebase")
         else:
             args.append("--merge")
+        if auto:
+            args.append("--auto")
 
         self._run_gh(args)
-        logger.info("Merged PR #%s", number)
+        logger.info("Merged PR #%s (auto=%s)", number, auto)
         return {"number": number, "merged": True}
 
     def list_pr_commits(self, number: int) -> list:

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -2977,18 +2977,42 @@ class AutonomousOrchestrator:
                     status="completed",
                     title=f"PR #{pr_number} merged",
                 )
-            except GitHubOpsError:
-                # Merge conflict — resolve locally and retry
-                logger.info("PR #%s not mergeable, resolving conflicts", pr_number)
+            except GitHubOpsError as e:
+                err_msg = str(e)
+                if "base branch policy prohibits" in err_msg:
+                    # Not a conflict — branch protection (CI pending / review
+                    # required). Enable auto-merge so GitHub completes it once
+                    # requirements pass, instead of failing the workflow.
+                    try:
+                        gh.merge_pr(pr_number, strategy="merge", auto=True)
+                        self._create_milestone(
+                            phase="merge",
+                            milestone_type="merged",
+                            status="completed",
+                            title=f"PR #{pr_number} auto-merge enabled",
+                        )
+                        logger.info("PR #%s: enabled auto-merge (branch policy)", pr_number)
+                        return  # auto-merge pending; GitHub merges asynchronously
+                    except GitHubOpsError as auto_err:
+                        # --auto also rejected — fall through to local resolution
+                        logger.info(
+                            "PR #%s --auto rejected (%s), resolving conflicts",
+                            pr_number,
+                            auto_err,
+                        )
+                else:
+                    # Merge conflict — resolve locally and retry
+                    logger.info("PR #%s not mergeable, resolving conflicts", pr_number)
+
                 try:
                     self._resolve_merge_conflicts(gh, branch_name, pr_number)
-                except Exception as e:
+                except Exception as resolve_err:
                     self._create_milestone(
                         phase="merge",
                         milestone_type="merged",
                         status="failed",
                         title="PR merge failed",
-                        error_message=f"Merge conflict resolution failed: {e}",
+                        error_message=f"Merge conflict resolution failed: {resolve_err}",
                     )
                     raise
 
@@ -3057,7 +3081,12 @@ class AutonomousOrchestrator:
             # There are conflicts — use AI agent to resolve them
             gh._run_git(["merge", "--abort"])  # Clean state first
             merge_result = gh._run_git(["merge", "origin/main"], check=False)
-            if merge_result.returncode != 0 and "CONFLICT" not in merge_result.stderr:
+            # git writes conflict summaries to STDOUT (not stderr), so we must
+            # check both streams. Checking only stderr left stderr empty on a
+            # real conflict and the code misclassified it as a "non-conflict"
+            # failure, abandoning merge without ever invoking the AI resolver.
+            combined_output = f"{merge_result.stdout}\n{merge_result.stderr}"
+            if merge_result.returncode != 0 and "CONFLICT" not in combined_output:
                 raise GitHubOpsError(
                     f"git merge failed (non-conflict): {merge_result.stderr.strip()}"
                 )

--- a/tests/issues/822/test_merge_conflict_detection.py
+++ b/tests/issues/822/test_merge_conflict_detection.py
@@ -1,0 +1,223 @@
+"""Tests for merge conflict detection + branch-policy auto-merge (#822).
+
+Two bugs caused worktrees in the 807-845 batch to fail at the merge phase:
+
+1. ``_resolve_merge_conflicts`` checked only ``stderr`` for the ``CONFLICT``
+   marker, but ``git merge`` writes conflict summaries to **stdout** (stderr is
+   empty). A real conflict was misclassified as a "non-conflict" failure and
+   the AI conflict resolver was never invoked.
+
+2. ``_do_merge`` treated every ``GitHubOpsError`` from ``merge_pr`` as a
+   conflict and dived into local resolution. But "base branch policy
+   prohibits the merge" (CI pending / review required) is not a conflict — it
+   needs ``--auto`` so GitHub merges asynchronously once requirements pass.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from app.modules.workspace.autonomous.github_ops import GitHubOps, GitHubOpsError
+from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+
+def _make_workflow(**overrides):
+    base = {
+        "workflow_id": "wf-822",
+        "title": "gh issue 807-845 (#822)",
+        "cli_tool": "claude-code",
+        "model": "",
+        "branch_strategy": "worktree",
+        "branch_name": "auto-dev/fc82f22a",
+        "worktree_path": "",
+        "project_path": "/srv/repo",
+        "workspace_type": "local",
+        "current_phase": "merge",
+        "status": "merging",
+        "github_pr_number": 1103,
+        "github_issue_number": 822,
+        "dev_round": 1,
+    }
+    base.update(overrides)
+    return base
+
+
+def _make_orchestrator(wf):
+    with (
+        patch("app.modules.workspace.autonomous.orchestrator.Database"),
+        patch(
+            "app.modules.workspace.autonomous.orchestrator.AutonomousWorkflowRepository"
+        ) as mock_repo_cls,
+    ):
+        mock_repo = MagicMock()
+        mock_repo.get_workflow.return_value = wf
+        mock_repo.create_milestone.return_value = {
+            "milestone_id": "ms-1",
+            "workflow_id": wf["workflow_id"],
+        }
+        mock_repo.create_event.return_value = {"id": 1}
+        mock_repo.update_workflow.return_value = wf
+        mock_repo_cls.return_value = mock_repo
+        o = AutonomousOrchestrator(wf["workflow_id"])
+        o.repo = mock_repo
+    o.emitter = MagicMock()
+    o._update_workflow = MagicMock()
+    o._create_milestone = MagicMock(return_value={"milestone_id": "ms-1"})
+    o._accumulate_tokens = MagicMock()
+    o._write_phase_usage = MagicMock()
+    return o, mock_repo
+
+
+# ── Bug 1: conflict detection must check stdout ──────────────────────────
+
+
+class TestResolveMergeConflictsStdoutConflict:
+    """``git merge`` writes CONFLICT to stdout, not stderr (#822)."""
+
+    @patch("app.modules.workspace.autonomous.orchestrator.GitHubOps")
+    def test_conflict_in_stdout_invokes_resolver(self, mock_gh_cls):
+        """A conflict reported on stdout must NOT be treated as a hard failure."""
+        o, _ = _make_orchestrator(_make_workflow())
+        mock_gh = MagicMock()
+        mock_gh_cls.return_value = mock_gh
+
+        # Model _run_git so the *second* merge (check=False) returns CONFLICT
+        # on stdout with empty stderr — the exact shape that broke #822.
+        def run_git(args, check=True):
+            # Only the "merge origin/main" call matters; merge --abort and
+            # other ops are no-ops.
+            if args[:2] == ["merge", "origin/main"] and check:
+                raise GitHubOpsError("git merge origin/main failed")
+            if args[:2] == ["merge", "origin/main"] and not check:
+                return MagicMock(
+                    returncode=1,
+                    stdout=(
+                        "CONFLICT (content): Merge conflict in " "app/services/auth_service.py\n"
+                    ),
+                    stderr="",
+                )
+            return MagicMock()
+
+        mock_gh._run_git = MagicMock(side_effect=run_git)
+        o._gh = mock_gh
+
+        # Stub the AI conflict resolver so we verify it IS reached.
+        o._run_agent = MagicMock()
+        o._resolve_session_line = MagicMock(return_value=("sess", None, False))
+        o._link_session_to_current_milestone = MagicMock()
+
+        o._resolve_merge_conflicts(mock_gh, "auto-dev/fc82f22a", 1103)
+
+        # The conflict was detected on stdout → resolver was invoked, not a
+        # hard failure. _run_agent was called with the conflict prompt.
+        assert o._run_agent.call_count >= 1
+        prompt = o._run_agent.call_args.kwargs.get("prompt", "")
+        assert "冲突" in prompt or "conflict" in prompt.lower()
+
+    @patch("app.modules.workspace.autonomous.orchestrator.GitHubOps")
+    def test_non_conflict_failure_still_raises(self, mock_gh_cls):
+        """A real non-conflict error (no CONFLICT anywhere) must still raise."""
+        o, _ = _make_orchestrator(_make_workflow())
+        mock_gh = MagicMock()
+        mock_gh_cls.return_value = mock_gh
+
+        def run_git(args, check=True):
+            if args[:2] == ["merge", "origin/main"] and check:
+                raise GitHubOpsError("git merge failed")
+            if args[:2] == ["merge", "origin/main"] and not check:
+                # No CONFLICT anywhere — a genuine non-conflict failure.
+                return MagicMock(returncode=1, stdout="fatal: bad object", stderr="")
+            return MagicMock()
+
+        mock_gh._run_git = MagicMock(side_effect=run_git)
+        o._gh = mock_gh
+
+        import pytest
+
+        with pytest.raises(GitHubOpsError, match="non-conflict"):
+            o._resolve_merge_conflicts(mock_gh, "auto-dev/fc82f22a", 1103)
+
+
+# ── Bug 2: branch-policy rejection uses --auto ───────────────────────────
+
+
+class TestDoMergeBranchPolicyAuto:
+    """ "base branch policy prohibits" should retry with --auto (#820)."""
+
+    @patch("app.modules.workspace.autonomous.orchestrator.GitHubOps")
+    def test_policy_prohibition_retries_with_auto(self, mock_gh_cls):
+        o, _ = _make_orchestrator(_make_workflow())
+        mock_gh = MagicMock()
+        mock_gh_cls.return_value = mock_gh
+        # First merge_pr (no auto) → policy rejection.
+        # Second merge_pr (auto=True) → success.
+        mock_gh.merge_pr.side_effect = [
+            GitHubOpsError(
+                "gh pr merge 1103 --merge failed (exit 1): "
+                "Pull request #1103 is not mergeable: "
+                "the base branch policy prohibits the merge."
+            ),
+            {"merged": True, "number": 1103},
+        ]
+        o._gh = mock_gh
+
+        o._do_merge(_make_workflow())
+
+        assert mock_gh.merge_pr.call_count == 2
+        # Second call must include auto=True.
+        second_call = mock_gh.merge_pr.call_args_list[1]
+        assert second_call.kwargs.get("auto") is True
+
+    @patch("app.modules.workspace.autonomous.orchestrator.GitHubOps")
+    def test_policy_then_auto_fail_falls_to_resolve(self, mock_gh_cls):
+        """If --auto is also rejected, fall through to conflict resolution."""
+        o, _ = _make_orchestrator(_make_workflow())
+        mock_gh = MagicMock()
+        mock_gh_cls.return_value = mock_gh
+        mock_gh.merge_pr.side_effect = [
+            GitHubOpsError("base branch policy prohibits the merge"),
+            GitHubOpsError("--auto also rejected"),
+        ]
+        o._gh = mock_gh
+        o._resolve_merge_conflicts = MagicMock()
+
+        o._do_merge(_make_workflow())
+
+        o._resolve_merge_conflicts.assert_called_once()
+
+    @patch("app.modules.workspace.autonomous.orchestrator.GitHubOps")
+    def test_clean_conflict_goes_straight_to_resolve(self, mock_gh_cls):
+        """A conflict error (not policy) skips --auto and resolves directly."""
+        o, _ = _make_orchestrator(_make_workflow())
+        mock_gh = MagicMock()
+        mock_gh_cls.return_value = mock_gh
+        mock_gh.merge_pr.side_effect = [
+            GitHubOpsError("gh pr merge 1103 failed: the merge commit cannot be cleanly created"),
+        ]
+        o._gh = mock_gh
+        o._resolve_merge_conflicts = MagicMock()
+
+        o._do_merge(_make_workflow())
+
+        # Only one merge_pr call (no --auto attempt); went straight to resolve.
+        mock_gh.merge_pr.assert_called_once()
+        assert mock_gh.merge_pr.call_args.kwargs.get("auto") is not True
+        o._resolve_merge_conflicts.assert_called_once()
+
+
+# ── github_ops.merge_pr --auto flag ──────────────────────────────────────
+
+
+class TestMergePrAutoFlag:
+    def test_auto_flag_adds_auto_arg(self):
+        gh = GitHubOps("/tmp/repo")
+        with patch.object(gh, "_run_gh") as mock_run:
+            gh.merge_pr(10, strategy="merge", auto=True)
+            cmd = mock_run.call_args.args[0]
+            assert "--auto" in cmd
+            assert "--merge" in cmd
+
+    def test_no_auto_by_default(self):
+        gh = GitHubOps("/tmp/repo")
+        with patch.object(gh, "_run_gh") as mock_run:
+            gh.merge_pr(10, strategy="merge")
+            cmd = mock_run.call_args.args[0]
+            assert "--auto" not in cmd


### PR DESCRIPTION
## Problem

4 workflows in the 807-845 batch (#807, #813, #820, #822) failed at the **merge phase** — all had completed development + PR review but never merged. Two independent bugs caused this.

### Bug 1 — Conflict detection checks the wrong stream

`_resolve_merge_conflicts` checks `merge_result.stderr` for the `CONFLICT` marker:

```python
if merge_result.returncode != 0 and "CONFLICT" not in merge_result.stderr:
    raise GitHubOpsError(f"git merge failed (non-conflict): ...")
```

But `git merge` writes conflict summaries to **stdout**, not stderr. Reproduced on the actual `auto-dev/fc82f22a` branch:

```
$ git merge origin/main; echo "rc=$?"
CONFLICT (content): Merge conflict in app/services/auth_service.py
Automatic merge failed; fix conflicts and then commit the result.
rc=1
# stderr is EMPTY
```

So `"CONFLICT" not in merge_result.stderr` was **always True** → every real conflict was misclassified as a "non-conflict" failure → raised immediately → the AI conflict resolver was **never invoked**. The error message `git merge failed (non-conflict):` had an empty body because stderr was empty.

### Bug 2 — Branch-policy rejection treated as conflict

#820 failed with `the base branch policy prohibits the merge` (CI pending / review required). `_do_merge` treated every `merge_pr` error as a conflict and dived into local resolution — pointless when there's no conflict, just a policy gate.

## Fix

### Bug 1 (`_resolve_merge_conflicts`)

Check stdout **and** stderr combined:
```python
combined_output = f"{merge_result.stdout}\n{merge_result.stderr}"
if merge_result.returncode != 0 and "CONFLICT" not in combined_output:
    raise ...
```

### Bug 2 (`merge_pr` + `_do_merge`)

- `merge_pr` gains an `auto` flag that adds `--auto` (GitHub merges asynchronously once requirements pass).
- `_do_merge` now branches on the error: `"base branch policy prohibits"` → retry with `--auto`; only if `--auto` is also rejected does it fall through to local conflict resolution. A clean conflict (`"merge commit cannot be cleanly created"`) skips `--auto` and resolves directly.

## Tests (7 new)

- conflict-on-stdout **invokes** the AI resolver (not a hard failure)
- non-conflict error (no CONFLICT anywhere) **still raises**
- policy rejection **retries with --auto**
- `--auto` also rejected → falls through to resolve
- clean conflict → skips `--auto`, resolves directly
- `merge_pr(auto=True)` adds `--auto` arg; default has none

## Impact

After merge, retrying #807/#813/#822 will reach the AI conflict resolver (Bug 1), and #820 will auto-merge once CI passes (Bug 2). Note: AI conflict resolution still uses `glm-5.2[1m]` which is currently 529-ing on z.ai — the model-config change is a separate prerequisite.
