### PR TITLE
fix: harden SQLite Alembic migrations

### DIFF
--- a/app/utils/senders.py
+++ b/app/utils/senders.py
@@ -84,7 +84,4 @@ def is_valid_sender(name: str) -> bool:
         return False
 
     # Filter out Feishu user IDs (starts with "ou_" and longer than 10 chars)
-    if name.startswith("ou_") and len(name) > 10:
-        return False
-
-    return True
+    return not (name.startswith("ou_") and len(name) > 10)

--- a/migrations/versions/20260329_018_add_daily_stats_table.py
+++ b/migrations/versions/20260329_018_add_daily_stats_table.py
@@ -63,8 +63,23 @@ def _table_exists(conn, table_name: str) -> bool:
 def upgrade() -> None:
     """Upgrade database schema."""
     conn = op.get_bind()
+    is_postgresql = conn.dialect.name == "postgresql"
 
     if not _table_exists(conn, "daily_stats"):
+        table_args = []
+        if not is_postgresql:
+            # SQLite cannot add a unique constraint via ALTER TABLE after
+            # creation, so define it inline when the table is created.
+            table_args.append(
+                sa.UniqueConstraint(
+                    "date",
+                    "tool_name",
+                    "host_name",
+                    "sender_name",
+                    name="uq_daily_stats_date_tool_host_sender",
+                )
+            )
+
         # Create daily_stats table
         op.create_table(
             "daily_stats",
@@ -82,14 +97,16 @@ def upgrade() -> None:
                 nullable=False,
                 server_default=sa.text("CURRENT_TIMESTAMP"),
             ),
+            *table_args,
         )
 
-        # Create unique constraint for date + tool_name + host_name + sender_name
-        op.create_unique_constraint(
-            "uq_daily_stats_date_tool_host_sender",
-            "daily_stats",
-            ["date", "tool_name", "host_name", "sender_name"],
-        )
+        if is_postgresql:
+            # PostgreSQL supports adding the named constraint after table creation.
+            op.create_unique_constraint(
+                "uq_daily_stats_date_tool_host_sender",
+                "daily_stats",
+                ["date", "tool_name", "host_name", "sender_name"],
+            )
 
         # Create indexes for fast lookup
         op.create_index("idx_daily_stats_date", "daily_stats", ["date"])
@@ -152,6 +169,7 @@ def upgrade() -> None:
 def downgrade() -> None:
     """Downgrade database schema."""
     conn = op.get_bind()
+    is_postgresql = conn.dialect.name == "postgresql"
 
     if _table_exists(conn, "daily_stats"):
         op.drop_index("idx_daily_stats_date_tool_host", "daily_stats")
@@ -159,5 +177,6 @@ def downgrade() -> None:
         op.drop_index("idx_daily_stats_host", "daily_stats")
         op.drop_index("idx_daily_stats_tool", "daily_stats")
         op.drop_index("idx_daily_stats_date", "daily_stats")
-        op.drop_constraint("uq_daily_stats_date_tool_host_sender", "daily_stats")
+        if is_postgresql:
+            op.drop_constraint("uq_daily_stats_date_tool_host_sender", "daily_stats")
         op.drop_table("daily_stats")

--- a/migrations/versions/20260329_019_add_hourly_stats_table.py
+++ b/migrations/versions/20260329_019_add_hourly_stats_table.py
@@ -62,8 +62,23 @@ def _table_exists(conn, table_name: str) -> bool:
 def upgrade() -> None:
     """Upgrade database schema."""
     conn = op.get_bind()
+    is_postgresql = conn.dialect.name == "postgresql"
 
     if not _table_exists(conn, "hourly_stats"):
+        table_args = []
+        if not is_postgresql:
+            # SQLite cannot add unique constraints via ALTER TABLE after table
+            # creation, so define the constraint inline.
+            table_args.append(
+                sa.UniqueConstraint(
+                    "date",
+                    "hour",
+                    "tool_name",
+                    "host_name",
+                    name="uq_hourly_stats_date_hour_tool_host",
+                )
+            )
+
         # Create hourly_stats table
         op.create_table(
             "hourly_stats",
@@ -81,14 +96,16 @@ def upgrade() -> None:
                 nullable=False,
                 server_default=sa.text("CURRENT_TIMESTAMP"),
             ),
+            *table_args,
         )
 
-        # Create unique constraint for date + hour + tool_name + host_name
-        op.create_unique_constraint(
-            "uq_hourly_stats_date_hour_tool_host",
-            "hourly_stats",
-            ["date", "hour", "tool_name", "host_name"],
-        )
+        if is_postgresql:
+            # PostgreSQL supports adding the named constraint after creation.
+            op.create_unique_constraint(
+                "uq_hourly_stats_date_hour_tool_host",
+                "hourly_stats",
+                ["date", "hour", "tool_name", "host_name"],
+            )
 
         # Create indexes for fast lookup
         op.create_index("idx_hourly_stats_date", "hourly_stats", ["date"])
@@ -150,10 +167,12 @@ def upgrade() -> None:
 def downgrade() -> None:
     """Downgrade database schema."""
     conn = op.get_bind()
+    is_postgresql = conn.dialect.name == "postgresql"
 
     if _table_exists(conn, "hourly_stats"):
         op.drop_index("idx_hourly_stats_date_hour", "hourly_stats")
         op.drop_index("idx_hourly_stats_hour", "hourly_stats")
         op.drop_index("idx_hourly_stats_date", "hourly_stats")
-        op.drop_constraint("uq_hourly_stats_date_hour_tool_host", "hourly_stats")
+        if is_postgresql:
+            op.drop_constraint("uq_hourly_stats_date_hour_tool_host", "hourly_stats")
         op.drop_table("hourly_stats")

--- a/migrations/versions/20260403_024_add_user_id_and_tool_accounts.py
+++ b/migrations/versions/20260403_024_add_user_id_and_tool_accounts.py
@@ -27,6 +27,8 @@ depends_on = None
 
 def upgrade():
     """Add user_id and user_tool_accounts table."""
+    conn = op.get_bind()
+    is_postgresql = conn.dialect.name == "postgresql"
 
     # ===========================================
     # Step 1: Add user_id to daily_messages
@@ -35,18 +37,33 @@ def upgrade():
     op.add_column("daily_messages", sa.Column("user_id", sa.Integer(), nullable=True))
 
     # Index for user_id queries (covering index for quota queries)
-    op.execute(
+    if is_postgresql:
+        op.execute(
+            """
+            CREATE INDEX idx_messages_user_date_role_covering
+            ON daily_messages (user_id, date, role)
+            INCLUDE (tokens_used)
+            WHERE user_id IS NOT NULL AND role = 'assistant'
         """
-        CREATE INDEX idx_messages_user_date_role_covering
-        ON daily_messages (user_id, date, role)
-        INCLUDE (tokens_used)
-        WHERE user_id IS NOT NULL AND role = 'assistant'
-    """
-    )
+        )
+    else:
+        # SQLite has no INCLUDE clause; include tokens_used in the indexed
+        # columns instead so the migration remains executable locally.
+        op.execute(
+            """
+            CREATE INDEX idx_messages_user_date_role_covering
+            ON daily_messages (user_id, date, role, tokens_used)
+            WHERE user_id IS NOT NULL AND role = 'assistant'
+        """
+        )
 
     # ===========================================
     # Step 2: Create user_tool_accounts table
     # ===========================================
+
+    table_args = []
+    if not is_postgresql:
+        table_args.append(sa.UniqueConstraint("tool_account", name="uq_user_tool_account"))
 
     op.create_table(
         "user_tool_accounts",
@@ -59,10 +76,12 @@ def upgrade():
         sa.Column("description", sa.String(255), nullable=True),
         sa.Column("created_at", sa.DateTime(), server_default=sa.text("CURRENT_TIMESTAMP")),
         sa.Column("updated_at", sa.DateTime(), server_default=sa.text("CURRENT_TIMESTAMP")),
+        *table_args,
     )
 
     # Unique constraint: one user can only have one mapping per tool_account
-    op.create_unique_constraint("uq_user_tool_account", "user_tool_accounts", ["tool_account"])
+    if is_postgresql:
+        op.create_unique_constraint("uq_user_tool_account", "user_tool_accounts", ["tool_account"])
 
     # Index for user_id lookups
     op.create_index("idx_tool_accounts_user_id", "user_tool_accounts", ["user_id"])
@@ -77,101 +96,152 @@ def upgrade():
     # Detect which column exists (linux_account or system_account)
     # Note: Field name changed from linux_account to system_account in migration 025
     # But init_database() also renames it, so we need to check which one exists
-    conn = op.get_bind()
-    account_column = "system_account"  # default to new name
+    account_column = None
 
-    # Check if system_account exists
-    result = conn.execute(
-        sa.text(
-            """
-        SELECT column_name FROM information_schema.columns
-        WHERE table_name = 'users' AND column_name = 'system_account'
-    """
-        )
-    )
-    if result.fetchone() is None:
-        # Check if linux_account exists (old name)
+    if is_postgresql:
+        # Check if system_account exists
         result = conn.execute(
             sa.text(
                 """
             SELECT column_name FROM information_schema.columns
-            WHERE table_name = 'users' AND column_name = 'linux_account'
+            WHERE table_name = 'users' AND column_name = 'system_account'
         """
             )
         )
-        if result.fetchone() is not None:
+        if result.fetchone() is None:
+            # Check if linux_account exists (old name)
+            result = conn.execute(
+                sa.text(
+                    """
+                SELECT column_name FROM information_schema.columns
+                WHERE table_name = 'users' AND column_name = 'linux_account'
+            """
+                )
+            )
+            if result.fetchone() is not None:
+                account_column = "linux_account"
+            else:
+                account_column = None
+        else:
+            account_column = "system_account"
+    else:
+        result = conn.execute(sa.text("PRAGMA table_info(users)"))
+        columns = {row[1] for row in result.fetchall()}
+        if "system_account" in columns:
+            account_column = "system_account"
+        elif "linux_account" in columns:
             account_column = "linux_account"
 
     # Extract unique sender_names that match account pattern
     # Pattern: {account}-{hostname}-{tool}
-    op.execute(
-        f"""
-        INSERT INTO user_tool_accounts (user_id, tool_account, tool_type)
-        SELECT DISTINCT
-            u.id as user_id,
-            dm.sender_name as tool_account,
-            CASE
-                WHEN dm.sender_name LIKE '%-qwen' THEN 'qwen'
-                WHEN dm.sender_name LIKE '%-claude' THEN 'claude'
-                WHEN dm.sender_name LIKE '%-openclaw' THEN 'openclaw'
-                ELSE 'other'
-            END as tool_type
-        FROM daily_messages dm
-        JOIN users u ON dm.sender_name LIKE u.{account_column} || '-%'
-        WHERE dm.sender_name IS NOT NULL
-          AND dm.sender_name LIKE '%-%-%'
-          AND u.{account_column} IS NOT NULL
-          AND NOT EXISTS (
-              SELECT 1 FROM user_tool_accounts uta
-              WHERE uta.tool_account = dm.sender_name
-          )
-    """
-    )
+    if account_column:
+        op.execute(
+            f"""
+            INSERT INTO user_tool_accounts (user_id, tool_account, tool_type)
+            SELECT DISTINCT
+                u.id as user_id,
+                dm.sender_name as tool_account,
+                CASE
+                    WHEN dm.sender_name LIKE '%-qwen' THEN 'qwen'
+                    WHEN dm.sender_name LIKE '%-claude' THEN 'claude'
+                    WHEN dm.sender_name LIKE '%-openclaw' THEN 'openclaw'
+                    ELSE 'other'
+                END as tool_type
+            FROM daily_messages dm
+            JOIN users u ON dm.sender_name LIKE u.{account_column} || '-%'
+            WHERE dm.sender_name IS NOT NULL
+              AND dm.sender_name LIKE '%-%-%'
+              AND u.{account_column} IS NOT NULL
+              AND NOT EXISTS (
+                  SELECT 1 FROM user_tool_accounts uta
+                  WHERE uta.tool_account = dm.sender_name
+              )
+        """
+        )
 
     # ===========================================
     # Step 4: Populate user_id in daily_messages
     # ===========================================
 
     # Update daily_messages.user_id based on user_tool_accounts mapping
-    op.execute(
+    if is_postgresql:
+        op.execute(
+            """
+            UPDATE daily_messages dm
+            SET user_id = (
+                SELECT uta.user_id
+                FROM user_tool_accounts uta
+                WHERE uta.tool_account = dm.sender_name
+                LIMIT 1
+            )
+            WHERE dm.sender_name IS NOT NULL
+              AND EXISTS (
+                  SELECT 1 FROM user_tool_accounts uta
+                  WHERE uta.tool_account = dm.sender_name
+              )
         """
-        UPDATE daily_messages dm
-        SET user_id = (
-            SELECT uta.user_id
-            FROM user_tool_accounts uta
-            WHERE uta.tool_account = dm.sender_name
-            LIMIT 1
         )
-        WHERE dm.sender_name IS NOT NULL
-          AND EXISTS (
-              SELECT 1 FROM user_tool_accounts uta
-              WHERE uta.tool_account = dm.sender_name
-          )
-    """
-    )
+    else:
+        op.execute(
+            """
+            UPDATE daily_messages
+            SET user_id = (
+                SELECT uta.user_id
+                FROM user_tool_accounts uta
+                WHERE uta.tool_account = daily_messages.sender_name
+                LIMIT 1
+            )
+            WHERE sender_name IS NOT NULL
+              AND EXISTS (
+                  SELECT 1 FROM user_tool_accounts uta
+                  WHERE uta.tool_account = daily_messages.sender_name
+              )
+        """
+        )
 
     # Also update based on direct username match (for Feishu users)
-    op.execute(
+    if is_postgresql:
+        op.execute(
+            """
+            UPDATE daily_messages dm
+            SET user_id = (
+                SELECT u.id
+                FROM users u
+                WHERE u.username = dm.sender_name
+                LIMIT 1
+            )
+            WHERE dm.user_id IS NULL
+              AND dm.sender_name IS NOT NULL
+              AND EXISTS (
+                  SELECT 1 FROM users u
+                  WHERE u.username = dm.sender_name
+              )
         """
-        UPDATE daily_messages dm
-        SET user_id = (
-            SELECT u.id
-            FROM users u
-            WHERE u.username = dm.sender_name
-            LIMIT 1
         )
-        WHERE dm.user_id IS NULL
-          AND dm.sender_name IS NOT NULL
-          AND EXISTS (
-              SELECT 1 FROM users u
-              WHERE u.username = dm.sender_name
-          )
-    """
-    )
+    else:
+        op.execute(
+            """
+            UPDATE daily_messages
+            SET user_id = (
+                SELECT u.id
+                FROM users u
+                WHERE u.username = daily_messages.sender_name
+                LIMIT 1
+            )
+            WHERE user_id IS NULL
+              AND sender_name IS NOT NULL
+              AND EXISTS (
+                  SELECT 1 FROM users u
+                  WHERE u.username = daily_messages.sender_name
+              )
+        """
+        )
 
 
 def downgrade():
     """Remove user_id and user_tool_accounts table."""
+    conn = op.get_bind()
+    is_postgresql = conn.dialect.name == "postgresql"
 
     # Drop indexes first
     op.drop_index("idx_messages_user_date_role_covering", table_name="daily_messages")
@@ -179,7 +249,8 @@ def downgrade():
     op.drop_index("idx_tool_accounts_user_id", table_name="user_tool_accounts")
 
     # Drop unique constraint
-    op.drop_constraint("uq_user_tool_account", table_name="user_tool_accounts", type_="unique")
+    if is_postgresql:
+        op.drop_constraint("uq_user_tool_account", table_name="user_tool_accounts", type_="unique")
 
     # Drop tables and columns
     op.drop_table("user_tool_accounts")

--- a/migrations/versions/20260403_025_rename_linux_account_to_system_account.py
+++ b/migrations/versions/20260403_025_rename_linux_account_to_system_account.py
@@ -9,6 +9,7 @@ Revises: 024
 Create Date: 2026-04-03
 """
 
+import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers
@@ -18,13 +19,36 @@ branch_labels = None
 depends_on = None
 
 
+def _column_exists(bind, table_name: str, column_name: str) -> bool:
+    """Check whether a column exists in the current database."""
+    if bind.dialect.name == "postgresql":
+        result = bind.execute(
+            sa.text(
+                """
+                SELECT 1
+                FROM information_schema.columns
+                WHERE table_name = :table_name AND column_name = :column_name
+                """
+            ),
+            {"table_name": table_name, "column_name": column_name},
+        )
+        return result.fetchone() is not None
+
+    result = bind.execute(sa.text(f"PRAGMA table_info({table_name})"))
+    return any(row[1] == column_name for row in result.fetchall())
+
+
 def upgrade():
     """Rename linux_account to system_account."""
 
     # Check if we're using PostgreSQL or SQLite
     bind = op.get_bind()
+    has_linux_account = _column_exists(bind, "users", "linux_account")
+    has_system_account = _column_exists(bind, "users", "system_account")
 
     if bind.dialect.name == "postgresql":
+        if not has_linux_account or has_system_account:
+            return
         # PostgreSQL: Use ALTER COLUMN with RENAME
         op.execute(
             """
@@ -32,15 +56,8 @@ def upgrade():
         """
         )
     else:
-        # SQLite: Check if column exists first
-        # SQLite doesn't support RENAME COLUMN in older versions
-        # Use a safer approach
-        op.execute(
-            """
-            -- First check if linux_account exists and system_account doesn't
-            -- This is handled by the column detection logic
-        """
-        )
+        if not has_linux_account or has_system_account:
+            return
 
         # Try to rename (works in SQLite 3.25.0+)
         try:
@@ -70,14 +87,20 @@ def downgrade():
     """Rename system_account back to linux_account."""
 
     bind = op.get_bind()
+    has_linux_account = _column_exists(bind, "users", "linux_account")
+    has_system_account = _column_exists(bind, "users", "system_account")
 
     if bind.dialect.name == "postgresql":
+        if not has_system_account or has_linux_account:
+            return
         op.execute(
             """
             ALTER TABLE users RENAME COLUMN system_account TO linux_account
         """
         )
     else:
+        if not has_system_account or has_linux_account:
+            return
         try:
             op.execute(
                 """

--- a/migrations/versions/20260413_031_add_request_count_to_agent_sessions.py
+++ b/migrations/versions/20260413_031_add_request_count_to_agent_sessions.py
@@ -47,11 +47,28 @@ def _column_exists(conn, table_name: str, column_name: str) -> bool:
     return result.fetchone() is not None
 
 
+def _table_exists(conn, table_name: str) -> bool:
+    """Check if a table exists in the current database."""
+    if conn.dialect.name == "postgresql":
+        result = conn.execute(
+            sa.text("SELECT 1 FROM information_schema.tables WHERE table_name = :table_name"),
+            {"table_name": table_name},
+        )
+    else:
+        result = conn.execute(
+            sa.text("SELECT 1 FROM sqlite_master WHERE type='table' AND name = :table_name"),
+            {"table_name": table_name},
+        )
+    return result.fetchone() is not None
+
+
 def upgrade() -> None:
     """Upgrade database schema."""
     conn = op.get_bind()
 
-    if not _column_exists(conn, "agent_sessions", "request_count"):
+    if _table_exists(conn, "agent_sessions") and not _column_exists(
+        conn, "agent_sessions", "request_count"
+    ):
         op.add_column(
             "agent_sessions",
             sa.Column("request_count", sa.Integer(), nullable=True, default=0),
@@ -67,5 +84,7 @@ def downgrade() -> None:
     """Downgrade database schema."""
     conn = op.get_bind()
 
-    if _column_exists(conn, "agent_sessions", "request_count"):
+    if _table_exists(conn, "agent_sessions") and _column_exists(
+        conn, "agent_sessions", "request_count"
+    ):
         op.drop_column("agent_sessions", "request_count")

--- a/migrations/versions/20260417_033_add_remote_workspace_tables.py
+++ b/migrations/versions/20260417_033_add_remote_workspace_tables.py
@@ -246,13 +246,14 @@ def upgrade() -> None:
         )
 
     # Add workspace_type and remote_machine_id columns to agent_sessions
-    if not _column_exists(conn, "agent_sessions", "workspace_type"):
-        op.execute(
-            sa.text("ALTER TABLE agent_sessions ADD COLUMN workspace_type TEXT DEFAULT 'local'")
-        )
+    if _table_exists(conn, "agent_sessions"):
+        if not _column_exists(conn, "agent_sessions", "workspace_type"):
+            op.execute(
+                sa.text("ALTER TABLE agent_sessions ADD COLUMN workspace_type TEXT DEFAULT 'local'")
+            )
 
-    if not _column_exists(conn, "agent_sessions", "remote_machine_id"):
-        op.execute(sa.text("ALTER TABLE agent_sessions ADD COLUMN remote_machine_id TEXT"))
+        if not _column_exists(conn, "agent_sessions", "remote_machine_id"):
+            op.execute(sa.text("ALTER TABLE agent_sessions ADD COLUMN remote_machine_id TEXT"))
 
 
 def downgrade() -> None:
@@ -261,7 +262,7 @@ def downgrade() -> None:
 
     # Drop columns from agent_sessions (SQLite doesn't support DROP COLUMN easily,
     # so we only do this for PostgreSQL)
-    if conn.dialect.name == "postgresql":
+    if conn.dialect.name == "postgresql" and _table_exists(conn, "agent_sessions"):
         if _column_exists(conn, "agent_sessions", "remote_machine_id"):
             op.execute(sa.text("ALTER TABLE agent_sessions DROP COLUMN remote_machine_id"))
         if _column_exists(conn, "agent_sessions", "workspace_type"):

--- a/migrations/versions/20260426_034_add_paused_at_to_agent_sessions.py
+++ b/migrations/versions/20260426_034_add_paused_at_to_agent_sessions.py
@@ -25,10 +25,7 @@ def _table_exists(bind, table_name: str) -> bool:
     """Check if a table exists."""
     if bind.dialect.name == "postgresql":
         result = bind.execute(
-            sa.text(
-                "SELECT 1 FROM information_schema.tables "
-                "WHERE table_name = :table_name"
-            ),
+            sa.text("SELECT 1 FROM information_schema.tables " "WHERE table_name = :table_name"),
             {"table_name": table_name},
         )
         return result.fetchone() is not None

--- a/migrations/versions/20260426_034_add_paused_at_to_agent_sessions.py
+++ b/migrations/versions/20260426_034_add_paused_at_to_agent_sessions.py
@@ -21,9 +21,30 @@ branch_labels: Union[str, None] = None
 depends_on: Union[str, None] = None
 
 
+def _table_exists(bind, table_name: str) -> bool:
+    """Check if a table exists."""
+    if bind.dialect.name == "postgresql":
+        result = bind.execute(
+            sa.text(
+                "SELECT 1 FROM information_schema.tables "
+                "WHERE table_name = :table_name"
+            ),
+            {"table_name": table_name},
+        )
+        return result.fetchone() is not None
+
+    result = bind.execute(
+        sa.text("SELECT 1 FROM sqlite_master WHERE type='table' AND name = :table_name"),
+        {"table_name": table_name},
+    )
+    return result.fetchone() is not None
+
+
 def upgrade() -> None:
     """Add paused_at column to agent_sessions."""
     bind = op.get_bind()
+    if not _table_exists(bind, "agent_sessions"):
+        return
     if bind.dialect.name == "postgresql":
         result = bind.execute(
             sa.text(
@@ -41,4 +62,6 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     """Remove paused_at column from agent_sessions."""
-    op.drop_column("agent_sessions", "paused_at")
+    bind = op.get_bind()
+    if _table_exists(bind, "agent_sessions"):
+        op.drop_column("agent_sessions", "paused_at")

--- a/migrations/versions/20260506_037_deduplicate_remote_machines.py
+++ b/migrations/versions/20260506_037_deduplicate_remote_machines.py
@@ -22,8 +22,27 @@ branch_labels: Union[str, None] = None
 depends_on: Union[str, None] = None
 
 
+def _table_exists(conn, table_name: str) -> bool:
+    """Check whether a table exists."""
+    if conn.dialect.name == "postgresql":
+        result = conn.execute(
+            sa.text("SELECT 1 FROM information_schema.tables WHERE table_name = :table_name"),
+            {"table_name": table_name},
+        )
+        return result.fetchone() is not None
+
+    result = conn.execute(
+        sa.text("SELECT 1 FROM sqlite_master WHERE type='table' AND name = :table_name"),
+        {"table_name": table_name},
+    )
+    return result.fetchone() is not None
+
+
 def upgrade() -> None:
     conn = op.get_bind()
+
+    if not _table_exists(conn, "remote_machines"):
+        return
 
     # Add index for hostname+tenant lookups
     op.execute(
@@ -79,13 +98,14 @@ def upgrade() -> None:
             )
 
             # Migrate agent_sessions to survivor
-            conn.execute(
-                sa.text(
-                    "UPDATE agent_sessions SET remote_machine_id = :survivor "
-                    "WHERE remote_machine_id = :victim"
-                ),
-                {"survivor": survivor_id, "victim": victim_mid},
-            )
+            if _table_exists(conn, "agent_sessions"):
+                conn.execute(
+                    sa.text(
+                        "UPDATE agent_sessions SET remote_machine_id = :survivor "
+                        "WHERE remote_machine_id = :victim"
+                    ),
+                    {"survivor": survivor_id, "victim": victim_mid},
+                )
 
             # Delete the duplicate machine record
             conn.execute(

--- a/migrations/versions/20260506_038_normalize_tool_names.py
+++ b/migrations/versions/20260506_038_normalize_tool_names.py
@@ -22,14 +22,32 @@ branch_labels: Union[str, None] = None
 depends_on: Union[str, None] = None
 
 
-def upgrade() -> None:
-    for table in ("agent_sessions", "daily_messages", "daily_usage"):
-        op.execute(
-            sa.text(
-                f"UPDATE {table} SET tool_name = 'qwen' "
-                f"WHERE tool_name IN ('qwen-code', 'qwen-code-cli')"
-            )
+def _table_exists(conn, table_name: str) -> bool:
+    """Check whether a table exists."""
+    if conn.dialect.name == "postgresql":
+        result = conn.execute(
+            sa.text("SELECT 1 FROM information_schema.tables WHERE table_name = :table_name"),
+            {"table_name": table_name},
         )
+        return result.fetchone() is not None
+
+    result = conn.execute(
+        sa.text("SELECT 1 FROM sqlite_master WHERE type='table' AND name = :table_name"),
+        {"table_name": table_name},
+    )
+    return result.fetchone() is not None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    for table in ("agent_sessions", "daily_messages", "daily_usage"):
+        if _table_exists(conn, table):
+            op.execute(
+                sa.text(
+                    f"UPDATE {table} SET tool_name = 'qwen' "
+                    f"WHERE tool_name IN ('qwen-code', 'qwen-code-cli')"
+                )
+            )
 
 
 def downgrade() -> None:

--- a/migrations/versions/20260506_039_normalize_derived_tables.py
+++ b/migrations/versions/20260506_039_normalize_derived_tables.py
@@ -179,30 +179,13 @@ def _rebuild_sqlite_qwen_usage_summary() -> None:
     )
 
 
-def _normalize_sqlite_claude_usage_summary() -> None:
-    """Collapse usage_summary rows that would collide on claude normalization."""
+def _rebuild_sqlite_claude_usage_summary() -> None:
+    """Recalculate claude usage_summary rows from daily_messages."""
     op.execute(
         sa.text(
-            """
-            CREATE TEMP TABLE tmp_claude_usage_summary AS
-            SELECT
-                'claude' AS tool_name,
-                host_name,
-                MAX(days_count) AS days_count,
-                SUM(total_tokens) AS total_tokens,
-                SUM(total_requests) AS total_requests,
-                SUM(total_input_tokens) AS total_input_tokens,
-                SUM(total_output_tokens) AS total_output_tokens,
-                MIN(first_date) AS first_date,
-                MAX(last_date) AS last_date,
-                MAX(updated_at) AS updated_at
-            FROM usage_summary
-            WHERE tool_name IN ('claude', 'claude-code')
-            GROUP BY host_name
-            """
+            "DELETE FROM usage_summary WHERE tool_name IN ('claude', 'claude-code')"
         )
     )
-    op.execute(sa.text("DELETE FROM usage_summary WHERE tool_name IN ('claude', 'claude-code')"))
     op.execute(
         sa.text(
             """
@@ -210,22 +193,47 @@ def _normalize_sqlite_claude_usage_summary() -> None:
             (tool_name, host_name, days_count, total_tokens, avg_tokens, total_requests,
              total_input_tokens, total_output_tokens, first_date, last_date, updated_at)
             SELECT
-                tool_name,
+                'claude' AS tool_name,
                 host_name,
-                days_count,
-                total_tokens,
-                total_tokens / CASE WHEN days_count > 0 THEN days_count ELSE 1 END AS avg_tokens,
-                total_requests,
-                total_input_tokens,
-                total_output_tokens,
-                first_date,
-                last_date,
-                updated_at
-            FROM tmp_claude_usage_summary
+                COUNT(DISTINCT date) AS days_count,
+                SUM(tokens_used) AS total_tokens,
+                SUM(tokens_used) / COUNT(DISTINCT date) AS avg_tokens,
+                COUNT(CASE WHEN role = 'assistant' THEN 1 END) AS total_requests,
+                SUM(input_tokens) AS total_input_tokens,
+                SUM(output_tokens) AS total_output_tokens,
+                MIN(date) AS first_date,
+                MAX(date) AS last_date,
+                CURRENT_TIMESTAMP AS updated_at
+            FROM daily_messages
+            WHERE tool_name IN ('claude', 'claude-code')
+            GROUP BY host_name
             """
         )
     )
-    op.execute(sa.text("DROP TABLE tmp_claude_usage_summary"))
+    op.execute(
+        sa.text(
+            """
+            INSERT INTO usage_summary
+            (tool_name, host_name, days_count, total_tokens, avg_tokens, total_requests,
+             total_input_tokens, total_output_tokens, first_date, last_date, updated_at)
+            SELECT
+                'claude' AS tool_name,
+                '' AS host_name,
+                COUNT(DISTINCT date) AS days_count,
+                SUM(tokens_used) AS total_tokens,
+                SUM(tokens_used) / COUNT(DISTINCT date) AS avg_tokens,
+                COUNT(CASE WHEN role = 'assistant' THEN 1 END) AS total_requests,
+                SUM(input_tokens) AS total_input_tokens,
+                SUM(output_tokens) AS total_output_tokens,
+                MIN(date) AS first_date,
+                MAX(date) AS last_date,
+                CURRENT_TIMESTAMP AS updated_at
+            FROM daily_messages
+            WHERE tool_name IN ('claude', 'claude-code')
+            GROUP BY 'claude'
+            """
+        )
+    )
 
 
 def upgrade() -> None:
@@ -238,7 +246,7 @@ def upgrade() -> None:
             _normalize_sqlite_hourly_stats()
         if _table_exists(conn, "usage_summary"):
             _rebuild_sqlite_qwen_usage_summary()
-            _normalize_sqlite_claude_usage_summary()
+            _rebuild_sqlite_claude_usage_summary()
         return
 
     for table in ("daily_stats", "hourly_stats", "usage_summary"):

--- a/migrations/versions/20260506_039_normalize_derived_tables.py
+++ b/migrations/versions/20260506_039_normalize_derived_tables.py
@@ -23,15 +23,237 @@ depends_on: Union[str, None] = None
 ALIASES_IN = "'qwen-code', 'qwen-code-cli'"
 
 
-def upgrade() -> None:
-    for table in ("daily_stats", "hourly_stats", "usage_summary"):
-        op.execute(
-            sa.text(f"UPDATE {table} SET tool_name = 'qwen' " f"WHERE tool_name IN ({ALIASES_IN})")
+def _table_exists(conn, table_name: str) -> bool:
+    """Check whether a table exists."""
+    if conn.dialect.name == "postgresql":
+        result = conn.execute(
+            sa.text("SELECT 1 FROM information_schema.tables WHERE table_name = :table_name"),
+            {"table_name": table_name},
         )
-    # Also normalize claude-code in all derived tables
-    op.execute(
-        sa.text("UPDATE usage_summary SET tool_name = 'claude' " "WHERE tool_name = 'claude-code'")
+        return result.fetchone() is not None
+
+    result = conn.execute(
+        sa.text("SELECT 1 FROM sqlite_master WHERE type='table' AND name = :table_name"),
+        {"table_name": table_name},
     )
+    return result.fetchone() is not None
+
+
+def _normalize_sqlite_daily_stats() -> None:
+    """Merge alias rows into a single qwen row before constraints can collide."""
+    op.execute(
+        sa.text(
+            f"""
+            CREATE TEMP TABLE tmp_qwen_daily_stats AS
+            SELECT
+                date,
+                'qwen' AS tool_name,
+                host_name,
+                sender_name,
+                SUM(total_tokens) AS total_tokens,
+                SUM(total_input_tokens) AS total_input_tokens,
+                SUM(total_output_tokens) AS total_output_tokens,
+                SUM(message_count) AS message_count,
+                MAX(updated_at) AS updated_at,
+                MIN(project_id) AS project_id,
+                MIN(project_path) AS project_path
+            FROM daily_stats
+            WHERE tool_name = 'qwen' OR tool_name IN ({ALIASES_IN})
+            GROUP BY date, host_name, sender_name
+            """
+        )
+    )
+    op.execute(sa.text(f"DELETE FROM daily_stats WHERE tool_name = 'qwen' OR tool_name IN ({ALIASES_IN})"))
+    op.execute(
+        sa.text(
+            """
+            INSERT INTO daily_stats
+            (date, tool_name, host_name, sender_name, total_tokens, total_input_tokens,
+             total_output_tokens, message_count, updated_at, project_id, project_path)
+            SELECT
+                date, tool_name, host_name, sender_name, total_tokens, total_input_tokens,
+                total_output_tokens, message_count, updated_at, project_id, project_path
+            FROM tmp_qwen_daily_stats
+            """
+        )
+    )
+    op.execute(sa.text("DROP TABLE tmp_qwen_daily_stats"))
+
+
+def _normalize_sqlite_hourly_stats() -> None:
+    """Merge alias rows into a single qwen hourly row."""
+    op.execute(
+        sa.text(
+            f"""
+            CREATE TEMP TABLE tmp_qwen_hourly_stats AS
+            SELECT
+                date,
+                hour,
+                'qwen' AS tool_name,
+                host_name,
+                SUM(total_tokens) AS total_tokens,
+                SUM(total_input_tokens) AS total_input_tokens,
+                SUM(total_output_tokens) AS total_output_tokens,
+                SUM(message_count) AS message_count,
+                MAX(updated_at) AS updated_at
+            FROM hourly_stats
+            WHERE tool_name = 'qwen' OR tool_name IN ({ALIASES_IN})
+            GROUP BY date, hour, host_name
+            """
+        )
+    )
+    op.execute(
+        sa.text(f"DELETE FROM hourly_stats WHERE tool_name = 'qwen' OR tool_name IN ({ALIASES_IN})")
+    )
+    op.execute(
+        sa.text(
+            """
+            INSERT INTO hourly_stats
+            (date, hour, tool_name, host_name, total_tokens, total_input_tokens,
+             total_output_tokens, message_count, updated_at)
+            SELECT
+                date, hour, tool_name, host_name, total_tokens, total_input_tokens,
+                total_output_tokens, message_count, updated_at
+            FROM tmp_qwen_hourly_stats
+            """
+        )
+    )
+    op.execute(sa.text("DROP TABLE tmp_qwen_hourly_stats"))
+
+
+def _rebuild_sqlite_qwen_usage_summary() -> None:
+    """Recalculate qwen usage_summary rows from normalized daily_messages."""
+    op.execute(
+        sa.text(
+            "DELETE FROM usage_summary WHERE tool_name = 'qwen' OR tool_name IN "
+            f"({ALIASES_IN})"
+        )
+    )
+    op.execute(
+        sa.text(
+            """
+            INSERT INTO usage_summary
+            (tool_name, host_name, days_count, total_tokens, avg_tokens, total_requests,
+             total_input_tokens, total_output_tokens, first_date, last_date, updated_at)
+            SELECT
+                'qwen' AS tool_name,
+                host_name,
+                COUNT(DISTINCT date) AS days_count,
+                SUM(tokens_used) AS total_tokens,
+                SUM(tokens_used) / COUNT(DISTINCT date) AS avg_tokens,
+                COUNT(CASE WHEN role = 'assistant' THEN 1 END) AS total_requests,
+                SUM(input_tokens) AS total_input_tokens,
+                SUM(output_tokens) AS total_output_tokens,
+                MIN(date) AS first_date,
+                MAX(date) AS last_date,
+                CURRENT_TIMESTAMP AS updated_at
+            FROM daily_messages
+            WHERE tool_name = 'qwen'
+            GROUP BY host_name
+            """
+        )
+    )
+    op.execute(
+        sa.text(
+            """
+            INSERT INTO usage_summary
+            (tool_name, host_name, days_count, total_tokens, avg_tokens, total_requests,
+             total_input_tokens, total_output_tokens, first_date, last_date, updated_at)
+            SELECT
+                'qwen' AS tool_name,
+                '' AS host_name,
+                COUNT(DISTINCT date) AS days_count,
+                SUM(tokens_used) AS total_tokens,
+                SUM(tokens_used) / COUNT(DISTINCT date) AS avg_tokens,
+                COUNT(CASE WHEN role = 'assistant' THEN 1 END) AS total_requests,
+                SUM(input_tokens) AS total_input_tokens,
+                SUM(output_tokens) AS total_output_tokens,
+                MIN(date) AS first_date,
+                MAX(date) AS last_date,
+                CURRENT_TIMESTAMP AS updated_at
+            FROM daily_messages
+            WHERE tool_name = 'qwen'
+            GROUP BY tool_name
+            """
+        )
+    )
+
+
+def _normalize_sqlite_claude_usage_summary() -> None:
+    """Collapse usage_summary rows that would collide on claude normalization."""
+    op.execute(
+        sa.text(
+            """
+            CREATE TEMP TABLE tmp_claude_usage_summary AS
+            SELECT
+                'claude' AS tool_name,
+                host_name,
+                MAX(days_count) AS days_count,
+                SUM(total_tokens) AS total_tokens,
+                SUM(total_requests) AS total_requests,
+                SUM(total_input_tokens) AS total_input_tokens,
+                SUM(total_output_tokens) AS total_output_tokens,
+                MIN(first_date) AS first_date,
+                MAX(last_date) AS last_date,
+                MAX(updated_at) AS updated_at
+            FROM usage_summary
+            WHERE tool_name IN ('claude', 'claude-code')
+            GROUP BY host_name
+            """
+        )
+    )
+    op.execute(sa.text("DELETE FROM usage_summary WHERE tool_name IN ('claude', 'claude-code')"))
+    op.execute(
+        sa.text(
+            """
+            INSERT INTO usage_summary
+            (tool_name, host_name, days_count, total_tokens, avg_tokens, total_requests,
+             total_input_tokens, total_output_tokens, first_date, last_date, updated_at)
+            SELECT
+                tool_name,
+                host_name,
+                days_count,
+                total_tokens,
+                total_tokens / CASE WHEN days_count > 0 THEN days_count ELSE 1 END AS avg_tokens,
+                total_requests,
+                total_input_tokens,
+                total_output_tokens,
+                first_date,
+                last_date,
+                updated_at
+            FROM tmp_claude_usage_summary
+            """
+        )
+    )
+    op.execute(sa.text("DROP TABLE tmp_claude_usage_summary"))
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    if conn.dialect.name == "sqlite":
+        if _table_exists(conn, "daily_stats"):
+            _normalize_sqlite_daily_stats()
+        if _table_exists(conn, "hourly_stats"):
+            _normalize_sqlite_hourly_stats()
+        if _table_exists(conn, "usage_summary"):
+            _rebuild_sqlite_qwen_usage_summary()
+            _normalize_sqlite_claude_usage_summary()
+        return
+
+    for table in ("daily_stats", "hourly_stats", "usage_summary"):
+        if _table_exists(conn, table):
+            op.execute(
+                sa.text(
+                    f"UPDATE {table} SET tool_name = 'qwen' "
+                    f"WHERE tool_name IN ({ALIASES_IN})"
+                )
+            )
+    # Also normalize claude-code in all derived tables
+    if _table_exists(conn, "usage_summary"):
+        op.execute(
+            sa.text("UPDATE usage_summary SET tool_name = 'claude' " "WHERE tool_name = 'claude-code'")
+        )
 
 
 def downgrade() -> None:

--- a/migrations/versions/20260506_039_normalize_derived_tables.py
+++ b/migrations/versions/20260506_039_normalize_derived_tables.py
@@ -63,7 +63,9 @@ def _normalize_sqlite_daily_stats() -> None:
             """
         )
     )
-    op.execute(sa.text(f"DELETE FROM daily_stats WHERE tool_name = 'qwen' OR tool_name IN ({ALIASES_IN})"))
+    op.execute(
+        sa.text(f"DELETE FROM daily_stats WHERE tool_name = 'qwen' OR tool_name IN ({ALIASES_IN})")
+    )
     op.execute(
         sa.text(
             """
@@ -125,8 +127,7 @@ def _rebuild_sqlite_qwen_usage_summary() -> None:
     """Recalculate qwen usage_summary rows from normalized daily_messages."""
     op.execute(
         sa.text(
-            "DELETE FROM usage_summary WHERE tool_name = 'qwen' OR tool_name IN "
-            f"({ALIASES_IN})"
+            "DELETE FROM usage_summary WHERE tool_name = 'qwen' OR tool_name IN " f"({ALIASES_IN})"
         )
     )
     op.execute(
@@ -181,11 +182,7 @@ def _rebuild_sqlite_qwen_usage_summary() -> None:
 
 def _rebuild_sqlite_claude_usage_summary() -> None:
     """Recalculate claude usage_summary rows from daily_messages."""
-    op.execute(
-        sa.text(
-            "DELETE FROM usage_summary WHERE tool_name IN ('claude', 'claude-code')"
-        )
-    )
+    op.execute(sa.text("DELETE FROM usage_summary WHERE tool_name IN ('claude', 'claude-code')"))
     op.execute(
         sa.text(
             """
@@ -253,14 +250,15 @@ def upgrade() -> None:
         if _table_exists(conn, table):
             op.execute(
                 sa.text(
-                    f"UPDATE {table} SET tool_name = 'qwen' "
-                    f"WHERE tool_name IN ({ALIASES_IN})"
+                    f"UPDATE {table} SET tool_name = 'qwen' " f"WHERE tool_name IN ({ALIASES_IN})"
                 )
             )
     # Also normalize claude-code in all derived tables
     if _table_exists(conn, "usage_summary"):
         op.execute(
-            sa.text("UPDATE usage_summary SET tool_name = 'claude' " "WHERE tool_name = 'claude-code'")
+            sa.text(
+                "UPDATE usage_summary SET tool_name = 'claude' " "WHERE tool_name = 'claude-code'"
+            )
         )
 
 

--- a/migrations/versions/20260523_045_fix_granted_at_type.py
+++ b/migrations/versions/20260523_045_fix_granted_at_type.py
@@ -43,9 +43,19 @@ def _table_exists(conn, table_name: str) -> bool:
 def upgrade() -> None:
     """Create user_permissions table if not exists, ensure granted_at is timestamp."""
     conn = op.get_bind()
+    is_postgresql = conn.dialect.name == "postgresql"
 
     if not _table_exists(conn, "user_permissions"):
         # Table doesn't exist - create it with correct schema
+        table_args = []
+        if not is_postgresql:
+            table_args.append(
+                sa.UniqueConstraint(
+                    "user_id",
+                    "permission",
+                    name="user_permissions_user_id_permission_key",
+                )
+            )
         op.create_table(
             "user_permissions",
             sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
@@ -53,15 +63,17 @@ def upgrade() -> None:
             sa.Column("permission", sa.Text, nullable=False),
             sa.Column("granted_by", sa.Integer, nullable=True),
             sa.Column("granted_at", sa.TIMESTAMP, nullable=True),
+            *table_args,
         )
-        op.create_unique_constraint(
-            "user_permissions_user_id_permission_key",
-            "user_permissions",
-            ["user_id", "permission"],
-        )
+        if is_postgresql:
+            op.create_unique_constraint(
+                "user_permissions_user_id_permission_key",
+                "user_permissions",
+                ["user_id", "permission"],
+            )
     else:
         # Table exists - check if granted_at column is text type
-        if conn.dialect.name == "postgresql":
+        if is_postgresql:
             result = conn.execute(
                 sa.text(
                     "SELECT data_type FROM information_schema.columns "
@@ -83,7 +95,7 @@ def downgrade() -> None:
     """Revert granted_at back to text."""
     conn = op.get_bind()
 
-    if _table_exists(conn, "user_permissions"):
+    if _table_exists(conn, "user_permissions") and conn.dialect.name == "postgresql":
         op.alter_column(
             "user_permissions",
             "granted_at",

--- a/migrations/versions/20260603_050_add_session_type_index.py
+++ b/migrations/versions/20260603_050_add_session_type_index.py
@@ -49,13 +49,30 @@ def _index_exists(conn, table_name: str, index_name: str) -> bool:
     return False
 
 
+def _table_exists(conn, table_name: str) -> bool:
+    """Check if a table exists."""
+    if conn.dialect.name == "postgresql":
+        result = conn.execute(
+            sa.text("SELECT 1 FROM information_schema.tables WHERE table_name = :table_name"),
+            {"table_name": table_name},
+        )
+        return result.fetchone() is not None
+    elif conn.dialect.name == "sqlite":
+        result = conn.execute(
+            sa.text("SELECT 1 FROM sqlite_master WHERE type='table' AND name=:table_name"),
+            {"table_name": table_name},
+        )
+        return result.fetchone() is not None
+    return False
+
+
 def upgrade() -> None:
     """Upgrade database schema."""
     conn = op.get_bind()
 
     index_name = "idx_agent_sessions_session_type"
 
-    if not _index_exists(conn, "agent_sessions", index_name):
+    if _table_exists(conn, "agent_sessions") and not _index_exists(conn, "agent_sessions", index_name):
         if conn.dialect.name == "postgresql" or conn.dialect.name == "sqlite":
             op.execute(sa.text(f"CREATE INDEX {index_name} ON agent_sessions(session_type)"))
 
@@ -66,5 +83,5 @@ def downgrade() -> None:
 
     index_name = "idx_agent_sessions_session_type"
 
-    if _index_exists(conn, "agent_sessions", index_name):
+    if _table_exists(conn, "agent_sessions") and _index_exists(conn, "agent_sessions", index_name):
         op.execute(sa.text(f"DROP INDEX {index_name}"))

--- a/migrations/versions/20260603_050_add_session_type_index.py
+++ b/migrations/versions/20260603_050_add_session_type_index.py
@@ -72,7 +72,9 @@ def upgrade() -> None:
 
     index_name = "idx_agent_sessions_session_type"
 
-    if _table_exists(conn, "agent_sessions") and not _index_exists(conn, "agent_sessions", index_name):
+    if _table_exists(conn, "agent_sessions") and not _index_exists(
+        conn, "agent_sessions", index_name
+    ):
         if conn.dialect.name == "postgresql" or conn.dialect.name == "sqlite":
             op.execute(sa.text(f"CREATE INDEX {index_name} ON agent_sessions(session_type)"))
 

--- a/migrations/versions/20260608_052_add_planning_timeout_extension.py
+++ b/migrations/versions/20260608_052_add_planning_timeout_extension.py
@@ -22,14 +22,18 @@ depends_on = None
 
 def _column_exists(conn, table: str, column: str) -> bool:
     """Check if a column already exists (idempotent migration)."""
-    result = conn.execute(
-        sa.text(
-            "SELECT COUNT(*) FROM information_schema.columns "
-            "WHERE table_name = :table AND column_name = :column"
-        ),
-        {"table": table, "column": column},
-    )
-    return result.scalar() > 0
+    if conn.dialect.name == "postgresql":
+        result = conn.execute(
+            sa.text(
+                "SELECT COUNT(*) FROM information_schema.columns "
+                "WHERE table_name = :table AND column_name = :column"
+            ),
+            {"table": table, "column": column},
+        )
+        return result.scalar() > 0
+
+    result = conn.execute(sa.text(f"PRAGMA table_info({table})"))
+    return any(row[1] == column for row in result.fetchall())
 
 
 def upgrade() -> None:

--- a/migrations/versions/20260608_053_add_agent_identity_tables.py
+++ b/migrations/versions/20260608_053_add_agent_identity_tables.py
@@ -22,8 +22,15 @@ depends_on = None
 
 def _table_exists(conn, table: str) -> bool:
     """Check if a table already exists."""
+    if conn.dialect.name == "postgresql":
+        result = conn.execute(
+            sa.text("SELECT COUNT(*) FROM information_schema.tables WHERE table_name = :table"),
+            {"table": table},
+        )
+        return result.scalar() > 0
+
     result = conn.execute(
-        sa.text("SELECT COUNT(*) FROM information_schema.tables " "WHERE table_name = :table"),
+        sa.text("SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name = :table"),
         {"table": table},
     )
     return result.scalar() > 0
@@ -31,14 +38,18 @@ def _table_exists(conn, table: str) -> bool:
 
 def _column_exists(conn, table: str, column: str) -> bool:
     """Check if a column already exists."""
-    result = conn.execute(
-        sa.text(
-            "SELECT COUNT(*) FROM information_schema.columns "
-            "WHERE table_name = :table AND column_name = :column"
-        ),
-        {"table": table, "column": column},
-    )
-    return result.scalar() > 0
+    if conn.dialect.name == "postgresql":
+        result = conn.execute(
+            sa.text(
+                "SELECT COUNT(*) FROM information_schema.columns "
+                "WHERE table_name = :table AND column_name = :column"
+            ),
+            {"table": table, "column": column},
+        )
+        return result.scalar() > 0
+
+    result = conn.execute(sa.text(f"PRAGMA table_info({table})"))
+    return any(row[1] == column for row in result.fetchall())
 
 
 def upgrade() -> None:

--- a/migrations/versions/20260609_055_add_fork_and_cancel_feedback_fields.py
+++ b/migrations/versions/20260609_055_add_fork_and_cancel_feedback_fields.py
@@ -26,14 +26,18 @@ depends_on = None
 
 def _column_exists(conn, table: str, column: str) -> bool:
     """Check if a column already exists (idempotent migration)."""
-    result = conn.execute(
-        sa.text(
-            "SELECT COUNT(*) FROM information_schema.columns "
-            "WHERE table_name = :table AND column_name = :column"
-        ),
-        {"table": table, "column": column},
-    )
-    return result.scalar() > 0
+    if conn.dialect.name == "postgresql":
+        result = conn.execute(
+            sa.text(
+                "SELECT COUNT(*) FROM information_schema.columns "
+                "WHERE table_name = :table AND column_name = :column"
+            ),
+            {"table": table, "column": column},
+        )
+        return result.scalar() > 0
+
+    result = conn.execute(sa.text(f"PRAGMA table_info({table})"))
+    return any(row[1] == column for row in result.fetchall())
 
 
 def upgrade() -> None:

--- a/migrations/versions/20260613_061_add_session_topology_columns.py
+++ b/migrations/versions/20260613_061_add_session_topology_columns.py
@@ -39,8 +39,24 @@ def _column_exists(conn, table: str, column: str) -> bool:
     return any(row[1] == column for row in result.fetchall())
 
 
+def _table_exists(conn, table: str) -> bool:
+    """Check if a table exists."""
+    if conn.dialect.name == "postgresql":
+        result = conn.execute(
+            sa.text("SELECT 1 FROM information_schema.tables WHERE table_name = :table"),
+            {"table": table},
+        )
+        return result.fetchone() is not None
+
+    result = conn.execute(
+        sa.text("SELECT 1 FROM sqlite_master WHERE type='table' AND name = :table"),
+        {"table": table},
+    )
+    return result.fetchone() is not None
+
+
 def _add_text(conn, table: str, column: str) -> None:
-    if not _column_exists(conn, table, column):
+    if _table_exists(conn, table) and not _column_exists(conn, table, column):
         op.add_column(
             table,
             sa.Column(column, sa.Text, server_default="", nullable=False),
@@ -48,7 +64,7 @@ def _add_text(conn, table: str, column: str) -> None:
 
 
 def _add_int(conn, table: str, column: str) -> None:
-    if not _column_exists(conn, table, column):
+    if _table_exists(conn, table) and not _column_exists(conn, table, column):
         op.add_column(
             table,
             sa.Column(column, sa.Integer, server_default="0", nullable=False),
@@ -78,7 +94,7 @@ def downgrade() -> None:
     """Remove session topology and per-phase usage columns."""
     conn = op.get_bind()
 
-    if _column_exists(conn, "session_messages", "milestone_id"):
+    if _table_exists(conn, "session_messages") and _column_exists(conn, "session_messages", "milestone_id"):
         op.drop_column("session_messages", "milestone_id")
 
     for column in (
@@ -87,9 +103,9 @@ def downgrade() -> None:
         "phase_input_tokens",
         "phase_total_tokens",
     ):
-        if _column_exists(conn, "workflow_milestones", column):
+        if _table_exists(conn, "workflow_milestones") and _column_exists(conn, "workflow_milestones", column):
             op.drop_column("workflow_milestones", column)
 
     for column in ("test_session_id", "review_session_id", "main_session_id"):
-        if _column_exists(conn, "autonomous_workflows", column):
+        if _table_exists(conn, "autonomous_workflows") and _column_exists(conn, "autonomous_workflows", column):
             op.drop_column("autonomous_workflows", column)

--- a/migrations/versions/20260613_061_add_session_topology_columns.py
+++ b/migrations/versions/20260613_061_add_session_topology_columns.py
@@ -94,7 +94,9 @@ def downgrade() -> None:
     """Remove session topology and per-phase usage columns."""
     conn = op.get_bind()
 
-    if _table_exists(conn, "session_messages") and _column_exists(conn, "session_messages", "milestone_id"):
+    if _table_exists(conn, "session_messages") and _column_exists(
+        conn, "session_messages", "milestone_id"
+    ):
         op.drop_column("session_messages", "milestone_id")
 
     for column in (
@@ -103,9 +105,13 @@ def downgrade() -> None:
         "phase_input_tokens",
         "phase_total_tokens",
     ):
-        if _table_exists(conn, "workflow_milestones") and _column_exists(conn, "workflow_milestones", column):
+        if _table_exists(conn, "workflow_milestones") and _column_exists(
+            conn, "workflow_milestones", column
+        ):
             op.drop_column("workflow_milestones", column)
 
     for column in ("test_session_id", "review_session_id", "main_session_id"):
-        if _table_exists(conn, "autonomous_workflows") and _column_exists(conn, "autonomous_workflows", column):
+        if _table_exists(conn, "autonomous_workflows") and _column_exists(
+            conn, "autonomous_workflows", column
+        ):
             op.drop_column("autonomous_workflows", column)

--- a/tests/issues/1111/test_sqlite_normalize_derived_tables.py
+++ b/tests/issues/1111/test_sqlite_normalize_derived_tables.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Regression test for SQLite alias collisions in migration 039."""
+
+import os
+import sqlite3
+import subprocess
+import sys
+
+PROJECT_ROOT = os.path.dirname(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
+
+
+def _run_alembic(db_path, revision):
+    env = os.environ.copy()
+    env["DATABASE_URL"] = f"sqlite:///{db_path}"
+    subprocess.run(
+        [sys.executable, "-m", "alembic", "-c", "alembic.ini", "upgrade", revision],
+        cwd=PROJECT_ROOT,
+        env=env,
+        check=True,
+    )
+
+
+def test_sqlite_upgrade_merges_qwen_alias_rows_before_normalization(tmp_path):
+    """Upgrade chain should merge colliding qwen alias rows instead of failing."""
+    db_path = tmp_path / "migration_039_collision.db"
+
+    _run_alembic(db_path, "017_add_usage_summary")
+
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """
+        INSERT INTO daily_messages
+        (date, tool_name, host_name, message_id, role, content, tokens_used,
+         input_tokens, output_tokens, timestamp, sender_name)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            "2026-05-01",
+            "qwen-code",
+            "build-host",
+            "msg-qwen-code",
+            "assistant",
+            "first message",
+            100,
+            60,
+            40,
+            "2026-05-01 03:00:00",
+            "agent",
+        ),
+    )
+    conn.execute(
+        """
+        INSERT INTO daily_messages
+        (date, tool_name, host_name, message_id, role, content, tokens_used,
+         input_tokens, output_tokens, timestamp, sender_name)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            "2026-05-01",
+            "qwen-code-cli",
+            "build-host",
+            "msg-qwen-code-cli",
+            "assistant",
+            "second message",
+            150,
+            90,
+            60,
+            "2026-05-01 03:30:00",
+            "agent",
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+    _run_alembic(db_path, "head")
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+
+    daily_stats = conn.execute(
+        """
+        SELECT tool_name, total_tokens, total_input_tokens, total_output_tokens, message_count
+        FROM daily_stats
+        WHERE date = ? AND host_name = ? AND sender_name = ?
+        """,
+        ("2026-05-01", "build-host", "agent"),
+    ).fetchall()
+    assert len(daily_stats) == 1
+    assert dict(daily_stats[0]) == {
+        "tool_name": "qwen",
+        "total_tokens": 250,
+        "total_input_tokens": 150,
+        "total_output_tokens": 100,
+        "message_count": 2,
+    }
+
+    hourly_stats = conn.execute(
+        """
+        SELECT tool_name, hour, total_tokens, total_input_tokens, total_output_tokens, message_count
+        FROM hourly_stats
+        WHERE date = ? AND host_name = ?
+        """,
+        ("2026-05-01", "build-host"),
+    ).fetchall()
+    assert len(hourly_stats) == 1
+    assert dict(hourly_stats[0]) == {
+        "tool_name": "qwen",
+        "hour": 11,
+        "total_tokens": 250,
+        "total_input_tokens": 150,
+        "total_output_tokens": 100,
+        "message_count": 2,
+    }
+
+    usage_summary = conn.execute(
+        """
+        SELECT tool_name, host_name, days_count, total_tokens, avg_tokens, total_requests,
+               total_input_tokens, total_output_tokens, first_date, last_date
+        FROM usage_summary
+        WHERE tool_name = ?
+        ORDER BY host_name
+        """,
+        ("qwen",),
+    ).fetchall()
+    assert [dict(row) for row in usage_summary] == [
+        {
+            "tool_name": "qwen",
+            "host_name": "",
+            "days_count": 1,
+            "total_tokens": 250,
+            "avg_tokens": 250,
+            "total_requests": 2,
+            "total_input_tokens": 150,
+            "total_output_tokens": 100,
+            "first_date": "2026-05-01",
+            "last_date": "2026-05-01",
+        },
+        {
+            "tool_name": "qwen",
+            "host_name": "build-host",
+            "days_count": 1,
+            "total_tokens": 250,
+            "avg_tokens": 250,
+            "total_requests": 2,
+            "total_input_tokens": 150,
+            "total_output_tokens": 100,
+            "first_date": "2026-05-01",
+            "last_date": "2026-05-01",
+        },
+    ]
+
+    alias_counts = conn.execute(
+        """
+        SELECT COUNT(*)
+        FROM (
+            SELECT tool_name FROM daily_stats
+            UNION ALL
+            SELECT tool_name FROM hourly_stats
+            UNION ALL
+            SELECT tool_name FROM usage_summary
+        )
+        WHERE tool_name IN ('qwen-code', 'qwen-code-cli')
+        """
+    ).fetchone()[0]
+    assert alias_counts == 0
+    conn.close()

--- a/tests/issues/1111/test_sqlite_normalize_derived_tables.py
+++ b/tests/issues/1111/test_sqlite_normalize_derived_tables.py
@@ -166,3 +166,144 @@ def test_sqlite_upgrade_merges_qwen_alias_rows_before_normalization(tmp_path):
     ).fetchone()[0]
     assert alias_counts == 0
     conn.close()
+
+
+def test_sqlite_upgrade_rebuilds_claude_summary_with_distinct_day_count(tmp_path):
+    """Claude summary rebuild should count distinct days across alias history."""
+    db_path = tmp_path / "migration_039_claude_summary.db"
+
+    _run_alembic(db_path, "038_normalize_tool_names")
+
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """
+        INSERT INTO daily_messages
+        (date, tool_name, host_name, message_id, role, content, tokens_used,
+         input_tokens, output_tokens, timestamp, sender_name)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            "2026-05-01",
+            "claude",
+            "build-host",
+            "msg-claude",
+            "assistant",
+            "claude message",
+            100,
+            70,
+            30,
+            "2026-05-01 03:00:00",
+            "agent",
+        ),
+    )
+    conn.execute(
+        """
+        INSERT INTO daily_messages
+        (date, tool_name, host_name, message_id, role, content, tokens_used,
+         input_tokens, output_tokens, timestamp, sender_name)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            "2026-05-02",
+            "claude-code",
+            "build-host",
+            "msg-claude-code",
+            "assistant",
+            "claude-code message",
+            200,
+            120,
+            80,
+            "2026-05-02 03:00:00",
+            "agent",
+        ),
+    )
+    conn.execute(
+        """
+        INSERT INTO usage_summary
+        (tool_name, host_name, days_count, total_tokens, avg_tokens, total_requests,
+         total_input_tokens, total_output_tokens, first_date, last_date)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        ("claude", "build-host", 1, 100, 100, 1, 70, 30, "2026-05-01", "2026-05-01"),
+    )
+    conn.execute(
+        """
+        INSERT INTO usage_summary
+        (tool_name, host_name, days_count, total_tokens, avg_tokens, total_requests,
+         total_input_tokens, total_output_tokens, first_date, last_date)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        ("claude-code", "build-host", 1, 200, 200, 1, 120, 80, "2026-05-02", "2026-05-02"),
+    )
+    conn.execute(
+        """
+        INSERT INTO usage_summary
+        (tool_name, host_name, days_count, total_tokens, avg_tokens, total_requests,
+         total_input_tokens, total_output_tokens, first_date, last_date)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        ("claude", "", 1, 100, 100, 1, 70, 30, "2026-05-01", "2026-05-01"),
+    )
+    conn.execute(
+        """
+        INSERT INTO usage_summary
+        (tool_name, host_name, days_count, total_tokens, avg_tokens, total_requests,
+         total_input_tokens, total_output_tokens, first_date, last_date)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        ("claude-code", "", 1, 200, 200, 1, 120, 80, "2026-05-02", "2026-05-02"),
+    )
+    conn.commit()
+    conn.close()
+
+    _run_alembic(db_path, "039_normalize_derived_tables")
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+
+    usage_summary = conn.execute(
+        """
+        SELECT tool_name, host_name, days_count, total_tokens, avg_tokens, total_requests,
+               total_input_tokens, total_output_tokens, first_date, last_date
+        FROM usage_summary
+        WHERE tool_name = ?
+        ORDER BY host_name
+        """,
+        ("claude",),
+    ).fetchall()
+    assert [dict(row) for row in usage_summary] == [
+        {
+            "tool_name": "claude",
+            "host_name": "",
+            "days_count": 2,
+            "total_tokens": 300,
+            "avg_tokens": 150,
+            "total_requests": 2,
+            "total_input_tokens": 190,
+            "total_output_tokens": 110,
+            "first_date": "2026-05-01",
+            "last_date": "2026-05-02",
+        },
+        {
+            "tool_name": "claude",
+            "host_name": "build-host",
+            "days_count": 2,
+            "total_tokens": 300,
+            "avg_tokens": 150,
+            "total_requests": 2,
+            "total_input_tokens": 190,
+            "total_output_tokens": 110,
+            "first_date": "2026-05-01",
+            "last_date": "2026-05-02",
+        },
+    ]
+
+    alias_counts = conn.execute(
+        """
+        SELECT COUNT(*)
+        FROM usage_summary
+        WHERE tool_name = 'claude-code'
+        """
+    ).fetchone()[0]
+    assert alias_counts == 0
+    conn.close()


### PR DESCRIPTION
## Summary
- make SQLite-compatible migrations define unique constraints inline instead of via unsupported ALTER paths
- guard historical migrations that assumed optional tables/columns always existed on fresh SQLite databases
- make Postgres-only metadata/introspection SQL branch correctly so a fresh SQLite database can run the full migration history to head

## Validation
- `DATABASE_URL=sqlite:////tmp/open-ace-dev.db .venv/bin/python -m alembic upgrade head`
- `DATABASE_URL=sqlite:////Users/rhuang/.open-ace/ace.db .venv/bin/python -m alembic upgrade head`
- `curl -I http://127.0.0.1:5001/`
