### PR TITLE
fix: add Number() type guard for API numeric values

### DIFF
--- a/frontend/src/components/features/analysis/SessionStatisticsCard.tsx
+++ b/frontend/src/components/features/analysis/SessionStatisticsCard.tsx
@@ -64,11 +64,12 @@ export const SessionStatisticsCard: React.FC<SessionStatisticsCardProps> = ({
 }) => {
   const language = useLanguage();
 
-  const totalConversations = conversationStats?.total_conversations ?? 0;
-  const totalMessages = conversationStats?.total_messages ?? 0;
-  const avgMessages = conversationStats?.average_messages_per_conversation ?? 0;
-  const avgTokens = conversationStats?.average_tokens_per_conversation ?? 0;
-  const multiTurnRatio = conversationStats?.multi_turn_ratio ?? 0;
+  // Ensure numeric types - API may return strings in some cases
+  const totalConversations = Number(conversationStats?.total_conversations ?? 0) || 0;
+  const totalMessages = Number(conversationStats?.total_messages ?? 0) || 0;
+  const avgMessages = Number(conversationStats?.average_messages_per_conversation ?? 0) || 0;
+  const avgTokens = Number(conversationStats?.average_tokens_per_conversation ?? 0) || 0;
+  const multiTurnRatio = Number(conversationStats?.multi_turn_ratio ?? 0) || 0;
 
   const rows: Array<{
     testId: string;

--- a/frontend/src/components/features/analysis/TrendAnalysis.tsx
+++ b/frontend/src/components/features/analysis/TrendAnalysis.tsx
@@ -361,7 +361,7 @@ export const TrendAnalysis: React.FC = () => {
         <div className="col-md-3">
           <StatCard
             label={t('totalRequests', language)}
-            value={(keyMetrics?.total_messages ?? 0).toLocaleString()}
+            value={Number(keyMetrics?.total_messages ?? 0).toLocaleString()}
             icon={<i className="bi bi-chat-dots fs-4" />}
             variant="success"
           />

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -16,27 +16,30 @@ const MAX_CACHE_SIZE = 1000; // Limit cache size to prevent memory issues
  * Cached for performance - same values return cached results
  */
 export function formatTokens(tokens: number): string {
+  // Ensure numeric type - API may return strings in some cases
+  const numTokens = Number(tokens) || 0;
+
   // Check cache first
-  const cached = tokenFormatCache.get(tokens);
+  const cached = tokenFormatCache.get(numTokens);
   if (cached !== undefined) {
     return cached;
   }
 
   // Calculate result
   let result: string;
-  if (tokens >= 1_000_000_000) {
-    result = (tokens / 1_000_000_000).toFixed(2) + 'B';
-  } else if (tokens >= 1_000_000) {
-    result = (tokens / 1_000_000).toFixed(2) + 'M';
-  } else if (tokens >= 1_000) {
-    result = (tokens / 1_000).toFixed(2) + 'K';
+  if (numTokens >= 1_000_000_000) {
+    result = (numTokens / 1_000_000_000).toFixed(2) + 'B';
+  } else if (numTokens >= 1_000_000) {
+    result = (numTokens / 1_000_000).toFixed(2) + 'M';
+  } else if (numTokens >= 1_000) {
+    result = (numTokens / 1_000).toFixed(2) + 'K';
   } else {
-    result = tokens.toString();
+    result = numTokens.toString();
   }
 
   // Cache result with size limit
   if (tokenFormatCache.size < MAX_CACHE_SIZE) {
-    tokenFormatCache.set(tokens, result);
+    tokenFormatCache.set(numTokens, result);
   }
 
   return result;


### PR DESCRIPTION
## Summary

- Fixes #1110: TypeError: i.toFixed is not a function
- Root cause: API may return numeric values as strings in some cases
- Solution: Add `Number()` type guard before calling `.toFixed()` or `.toLocaleString()`

## Changes

1. **SessionStatisticsCard.tsx**: Protect all `conversationStats` values with `Number()`
   - `total_conversations`
   - `total_messages`
   - `average_messages_per_conversation`
   - `average_tokens_per_conversation`
   - `multi_turn_ratio`

2. **TrendAnalysis.tsx**: Protect `total_messages` with `Number()`

3. **format.ts**: Add numeric type conversion in `formatTokens()` function

## Testing

- Tested locally in development environment
- Token Trend page now loads correctly without white screen
- No console errors