### PR TITLE
fix(quota): 修复配额单位不一致问题 (Issue #1061)

### DIFF
--- a/migrations/versions/20260328_015_add_force_pwd_change.py
+++ b/migrations/versions/20260328_015_add_force_pwd_change.py
@@ -89,8 +89,8 @@ def downgrade() -> None:
                     password_hash TEXT NOT NULL,
                     email TEXT,
                     role TEXT NOT NULL DEFAULT 'user',
-                    daily_token_quota INTEGER DEFAULT 1000000,
-                    monthly_token_quota INTEGER DEFAULT 30000000,
+                    daily_token_quota INTEGER DEFAULT 1,    -- 1M tokens (stored in M units)
+                    monthly_token_quota INTEGER DEFAULT 30, -- 30M tokens (stored in M units)
                     daily_request_quota INTEGER DEFAULT 1000,
                     monthly_request_quota INTEGER DEFAULT 30000,
                     is_active BOOLEAN DEFAULT TRUE,

--- a/migrations/versions/20260618_064_fix_quota_unit_inconsistency.py
+++ b/migrations/versions/20260618_064_fix_quota_unit_inconsistency.py
@@ -1,0 +1,83 @@
+"""Fix quota unit inconsistency for Issue #1061
+
+Revision ID: 20260618_064_fix_quota_unit_inconsistency
+Revises: 20260615_063_fix_boolean_retroactive
+Create Date: 2026-06-18
+
+This migration fixes the quota unit inconsistency issue:
+- Token quotas should be stored in M (millions) units per app/routes/quota.py
+- Some data was incorrectly stored as raw counts (e.g., 10000000 instead of 10)
+- This migration converts values > 2147 (the max M unit value) to M units
+
+Issue: https://github.com/open-ace/open-ace/issues/1061
+
+"""
+
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260618_064_fix_quota_unit_inconsistency"
+down_revision: Union[str, None] = "20260615_063_fix_boolean_retroactive"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Convert quota values from raw counts to M units."""
+    conn = op.get_bind()
+
+    # Fix daily_token_quota: values > 2147 should be divided by 1,000,000
+    # MAX_TOKEN_QUOTA = 2147 (in M units), so values > 2147 are raw counts
+    op.execute(
+        sa.text(
+            """
+            UPDATE users
+            SET daily_token_quota = daily_token_quota / 1000000
+            WHERE daily_token_quota IS NOT NULL AND daily_token_quota > 2147
+            """
+        )
+    )
+
+    # Fix monthly_token_quota: values > 2147 should be divided by 1,000,000
+    op.execute(
+        sa.text(
+            """
+            UPDATE users
+            SET monthly_token_quota = monthly_token_quota / 1000000
+            WHERE monthly_token_quota IS NOT NULL AND monthly_token_quota > 2147
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    """Revert quota values back to raw counts (multiply by 1,000,000)."""
+    conn = op.get_bind()
+
+    # Note: downgrade is risky because we can't distinguish between:
+    # - Values that were originally raw counts and were converted
+    # - Values that were legitimately in M units
+    # We only multiply values that are <= 2147 (assuming they were converted)
+    # This is a best-effort rollback, may not fully restore original state
+
+    op.execute(
+        sa.text(
+            """
+            UPDATE users
+            SET daily_token_quota = daily_token_quota * 1000000
+            WHERE daily_token_quota IS NOT NULL AND daily_token_quota <= 2147
+            """
+        )
+    )
+
+    op.execute(
+        sa.text(
+            """
+            UPDATE users
+            SET monthly_token_quota = monthly_token_quota * 1000000
+            WHERE monthly_token_quota IS NOT NULL AND monthly_token_quota <= 2147
+            """
+        )
+    )

--- a/migrations/versions/20260618_064_fix_quota_unit_inconsistency.py
+++ b/migrations/versions/20260618_064_fix_quota_unit_inconsistency.py
@@ -13,10 +13,13 @@ Issue: https://github.com/open-ace/open-ace/issues/1061
 
 """
 
+import logging
 from typing import Union
 
 import sqlalchemy as sa
 from alembic import op
+
+logger = logging.getLogger(__name__)
 
 revision: str = "20260618_064_fix_quota_unit_inconsistency"
 down_revision: Union[str, None] = "20260615_063_fix_boolean_retroactive"
@@ -28,33 +31,82 @@ def upgrade() -> None:
     """Convert quota values from raw counts to M units."""
     conn = op.get_bind()
 
-    # Fix daily_token_quota: values > 2147 should be divided by 1,000,000
-    # MAX_TOKEN_QUOTA = 2147 (in M units), so values > 2147 are raw counts
-    op.execute(
+    # Check how many records need to be fixed
+    result = conn.execute(
         sa.text(
             """
-            UPDATE users
-            SET daily_token_quota = daily_token_quota / 1000000
+            SELECT COUNT(*) FROM users
             WHERE daily_token_quota IS NOT NULL AND daily_token_quota > 2147
             """
         )
     )
+    daily_count = result.fetchone()[0]
+    logger.info(f"Found {daily_count} users with daily_token_quota > 2147 (raw counts)")
 
-    # Fix monthly_token_quota: values > 2147 should be divided by 1,000,000
-    op.execute(
+    result = conn.execute(
         sa.text(
             """
-            UPDATE users
-            SET monthly_token_quota = monthly_token_quota / 1000000
+            SELECT COUNT(*) FROM users
             WHERE monthly_token_quota IS NOT NULL AND monthly_token_quota > 2147
             """
         )
     )
+    monthly_count = result.fetchone()[0]
+    logger.info(f"Found {monthly_count} users with monthly_token_quota > 2147 (raw counts)")
+
+    if daily_count > 0:
+        logger.info("Converting daily_token_quota from raw counts to M units...")
+        op.execute(
+            sa.text(
+                """
+                UPDATE users
+                SET daily_token_quota = daily_token_quota / 1000000
+                WHERE daily_token_quota IS NOT NULL AND daily_token_quota > 2147
+                """
+            )
+        )
+        logger.info(f"Converted {daily_count} daily_token_quota values")
+
+    if monthly_count > 0:
+        logger.info("Converting monthly_token_quota from raw counts to M units...")
+        op.execute(
+            sa.text(
+                """
+                UPDATE users
+                SET monthly_token_quota = monthly_token_quota / 1000000
+                WHERE monthly_token_quota IS NOT NULL AND monthly_token_quota > 2147
+                """
+            )
+        )
+        logger.info(f"Converted {monthly_count} monthly_token_quota values")
 
 
 def downgrade() -> None:
     """Revert quota values back to raw counts (multiply by 1,000,000)."""
     conn = op.get_bind()
+
+    # Check how many records would be reverted
+    result = conn.execute(
+        sa.text(
+            """
+            SELECT COUNT(*) FROM users
+            WHERE daily_token_quota IS NOT NULL AND daily_token_quota <= 2147
+            """
+        )
+    )
+    daily_count = result.fetchone()[0]
+    logger.info(f"Found {daily_count} users with daily_token_quota <= 2147 (M units)")
+
+    result = conn.execute(
+        sa.text(
+            """
+            SELECT COUNT(*) FROM users
+            WHERE monthly_token_quota IS NOT NULL AND monthly_token_quota <= 2147
+            """
+        )
+    )
+    monthly_count = result.fetchone()[0]
+    logger.info(f"Found {monthly_count} users with monthly_token_quota <= 2147 (M units)")
 
     # Note: downgrade is risky because we can't distinguish between:
     # - Values that were originally raw counts and were converted
@@ -62,22 +114,32 @@ def downgrade() -> None:
     # We only multiply values that are <= 2147 (assuming they were converted)
     # This is a best-effort rollback, may not fully restore original state
 
-    op.execute(
-        sa.text(
-            """
-            UPDATE users
-            SET daily_token_quota = daily_token_quota * 1000000
-            WHERE daily_token_quota IS NOT NULL AND daily_token_quota <= 2147
-            """
+    if daily_count > 0:
+        logger.warning(
+            "Downgrade: converting daily_token_quota back to raw counts (best-effort rollback)"
         )
-    )
+        op.execute(
+            sa.text(
+                """
+                UPDATE users
+                SET daily_token_quota = daily_token_quota * 1000000
+                WHERE daily_token_quota IS NOT NULL AND daily_token_quota <= 2147
+                """
+            )
+        )
+        logger.info(f"Reverted {daily_count} daily_token_quota values")
 
-    op.execute(
-        sa.text(
-            """
-            UPDATE users
-            SET monthly_token_quota = monthly_token_quota * 1000000
-            WHERE monthly_token_quota IS NOT NULL AND monthly_token_quota <= 2147
-            """
+    if monthly_count > 0:
+        logger.warning(
+            "Downgrade: converting monthly_token_quota back to raw counts (best-effort rollback)"
         )
-    )
+        op.execute(
+            sa.text(
+                """
+                UPDATE users
+                SET monthly_token_quota = monthly_token_quota * 1000000
+                WHERE monthly_token_quota IS NOT NULL AND monthly_token_quota <= 2147
+                """
+            )
+        )
+        logger.info(f"Reverted {monthly_count} monthly_token_quota values")

--- a/scripts/init_db.py
+++ b/scripts/init_db.py
@@ -137,7 +137,7 @@ def create_default_admin(
         password_hash=password_hash,
         email=email,
         role="admin",
-        daily_token_quota=10000000,  # 10M tokens
+        daily_token_quota=10,  # 10M tokens (stored in M units)
         daily_request_quota=10000,
         is_active=True,
         must_change_password=True,  # Force password change on first login

--- a/scripts/shared/db.py
+++ b/scripts/shared/db.py
@@ -1374,8 +1374,8 @@ def init_auth_database() -> None:
             password_hash TEXT NOT NULL,
             email TEXT,
             role TEXT NOT NULL DEFAULT 'user',
-            daily_token_quota INTEGER DEFAULT 1000000,
-            monthly_token_quota INTEGER DEFAULT 30000000,
+            daily_token_quota INTEGER DEFAULT 1,    -- 1M tokens (stored in M units)
+            monthly_token_quota INTEGER DEFAULT 30, -- 30M tokens (stored in M units)
             daily_request_quota INTEGER DEFAULT 1000,
             monthly_request_quota INTEGER DEFAULT 30000,
             is_active INTEGER DEFAULT 1,

--- a/scripts/upload-to-central/shared/db.py
+++ b/scripts/upload-to-central/shared/db.py
@@ -1332,8 +1332,8 @@ def init_auth_database() -> None:
             password_hash TEXT NOT NULL,
             email TEXT,
             role TEXT NOT NULL DEFAULT 'user',
-            daily_token_quota INTEGER DEFAULT 1000000,
-            monthly_token_quota INTEGER DEFAULT 30000000,
+            daily_token_quota INTEGER DEFAULT 1,    -- 1M tokens (stored in M units)
+            monthly_token_quota INTEGER DEFAULT 30, -- 30M tokens (stored in M units)
             daily_request_quota INTEGER DEFAULT 1000,
             monthly_request_quota INTEGER DEFAULT 30000,
             is_active INTEGER DEFAULT 1,


### PR DESCRIPTION
## 问题描述

Issue #1061: 配额编辑窗口不做修改保存时报错 "Quota value exceeds maximum limit of 2147M"

## 根因分析

用户配额 `daily_token_quota` 和 `monthly_token_quota` 应存储 **M 单位**（百万），但以下位置存储了**原始数量**：

| 文件 | 当前值 | 正确值 |
|------|--------|--------|
| `scripts/init_db.py` | 10000000 | 10 |
| `migrations/20260328_015_add_force_pwd_change.py` | 1000000/30000000 | 1/30 |
| `scripts/shared/db.py` | 1000000/30000000 | 1/30 |
| `scripts/upload-to-central/shared/db.py` | 1000000/30000000 | 1/30 |

## 修复内容

1. **scripts/init_db.py**: 默认值从 `10000000` 改为 `10` (M单位)
2. **migrations/20260328_015_add_force_pwd_change.py**: 修正 SQLite downgrade 中的默认值
3. **scripts/shared/db.py**: 修正表定义中的默认值
4. **scripts/upload-to-central/shared/db.py**: 修正表定义中的默认值
5. **新增迁移脚本**: `20260618_064_fix_quota_unit_inconsistency.py` 修复现有数据库数据

## 测试

- 新安装：admin 用户配额将正确存储为 M 单位
- 现有数据库：迁移脚本会将值 > 2147 的记录转换为 M 单位