### PR TITLE
fix(docker): Docker 安装 token 统计不工作 - 使用 venv Python (Issue #1121)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,8 @@ services:
       - WORKSPACE_MULTI_USER_MODE=${WORKSPACE_MULTI_USER_MODE:-false}
       # Workspace base directory (users' projects stored under /workspace/<username>/)
       - WORKSPACE_BASE_DIR=/workspace
+      # Data fetch: container runs as root, use venv Python (Issue #1121)
+      - FETCH_USE_SUDO=false
     volumes:
       # CONFIG_DIR: Container runs as root (required for multi-user workspace mode)
       # ~/.open-ace expands to /root/.open-ace when running as root


### PR DESCRIPTION
## 问题描述

Docker 安装的 Open ACE 系统，用户通过 WebUI 进行交互后，token 数和请求数没有变化，统计数据始终为 0。

## 根本原因

1. **定时任务机制存在且正常运行**（每 5 分钟）
2. **CLI 日志包含完整的 usageMetadata**（token 数据存在）
3. **fetch_qwen.py 运行失败**：UnicodeEncodeError
4. **Python 环境差异**：
   - `/opt/venv/bin/python3`：venv 环境，编码正常
   - `/usr/bin/python3`：系统 Python，有编码问题

## 分析过程

详见 Issue #1121 评论：
- 问题发现 → 定时任务机制、CLI 日志、fetch_qwen.py 失败
- 问题根源 → Python 环境差异、代码硬编码问题
- 分析演变 → 从初步假设到用户澄清到最终确认

## 修复方案

**最简洁方案**：只修改 docker-compose.yml，添加 `FETCH_USE_SUDO=false`

```yaml
# Data fetch: container runs as root, use venv Python (Issue #1121)
- FETCH_USE_SUDO=false
```

**核心原理**：
- Docker 容器以 root 运行 → 不需要 sudo
- `FETCH_USE_SUDO=false` → 直接使用 `sys.executable`（venv Python）
- 解决编码问题 ✓
- 向后兼容：源码安装场景保持默认行为

## 测试验证

需要在 169 机器上重新构建并验证：
1. `docker compose build`
2. `docker compose up -d`
3. 检查定时任务日志：`docker logs open-ace | grep "Data fetch"`
4. 确认不再有 Unicode 编码错误

## 关联 Issue

Fixes #1121