### PR TITLE
fix: require test verification before committing conflict resolution (#807)

### DIFF
--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -3145,11 +3145,12 @@ class AutonomousOrchestrator:
                     "     冲突文件相关的测试也需要同步更新\n"
                     "   - 重复直到所有测试通过\n"
                     "5. 测试全部通过后，git commit 完成合并\n\n"
-                    "## 测试状态报告（必须）\n"
-                    "在回复的最后一行输出测试状态：\n"
-                    "- 所有测试通过：`TEST_STATUS: passed`\n"
-                    "- 测试被跳过（无法运行）：`TEST_STATUS: skipped`\n"
-                    "缺少此标记会导致合并被拒绝。"
+                    "## 总结报告（必须）\n"
+                    "在回复末尾简要总结：\n"
+                    "- 解决了哪些文件的冲突\n"
+                    "- 是否执行了测试，测试结果如何（如 42 passed, 0 failed）\n"
+                    "- 如果跳过了测试，说明原因\n"
+                    "- 这个总结会显示在工作流的 timeline 中，供用户查看"
                 )
 
                 wf = self.workflow
@@ -3179,55 +3180,20 @@ class AutonomousOrchestrator:
                     milestone_id=conflict_ms.get("milestone_id", ""),
                 )
                 self._accumulate_tokens(result)
+                response_text = result.response_text or ""
                 self.repo.update_milestone(
                     conflict_ms.get("milestone_id", ""),
                     {
                         "status": "completed" if result.success else "failed",
                         "session_id": result.session_id,
                         "error_message": result.error or "",
+                        "result_summary": response_text,
+                        "tldr": self._extract_tldr(response_text),
                     },
                 )
 
                 if not result.success:
                     raise RuntimeError(f"Conflict resolution failed: {result.error}")
-
-                # Machine-checkable test gate: the agent MUST report that tests
-                # actually ran and passed before we push. result.success only
-                # means the process exited normally — it says nothing about
-                # whether tests were executed (#1124 review). Reuse the sentinel
-                # pattern from _run_test_phase.
-                response_text = result.response_text or ""
-                test_passed = "TEST_STATUS: passed" in response_text
-                tests_skipped = (
-                    "TEST_STATUS: skipped" in response_text
-                    or "测试被跳过" in response_text
-                    or "跳过测试" in response_text
-                )
-                # Also detect "no test evidence at all" — agent never ran tests.
-                _test_keywords = [
-                    "passed",
-                    "failed",
-                    "PASSED",
-                    "FAILED",
-                    "pytest",
-                    "assertion",
-                    "AssertionError",
-                ]
-                has_test_evidence = any(kw in response_text for kw in _test_keywords)
-                if not test_passed:
-                    if tests_skipped or not has_test_evidence:
-                        logger.warning(
-                            "Conflict resolution did not verify tests "
-                            "(skipped=%s, evidence=%s) — refusing to push",
-                            tests_skipped,
-                            has_test_evidence,
-                        )
-                        raise RuntimeError(
-                            "Conflict resolution did not run tests before "
-                            "committing — merge aborted to prevent pushing "
-                            "untested code. Agent must run pytest and report "
-                            "TEST_STATUS: passed."
-                        )
 
             # Push the resolved branch. The new merge commit triggers a fresh
             # CI run, so we do NOT merge here — _do_merge will retry on the

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -3144,7 +3144,12 @@ class AutonomousOrchestrator:
                     "   - 特别注意：main 上的改动可能修改了函数签名/SQL/接口，\n"
                     "     冲突文件相关的测试也需要同步更新\n"
                     "   - 重复直到所有测试通过\n"
-                    "5. 测试全部通过后，git commit 完成合并"
+                    "5. 测试全部通过后，git commit 完成合并\n\n"
+                    "## 测试状态报告（必须）\n"
+                    "在回复的最后一行输出测试状态：\n"
+                    "- 所有测试通过：`TEST_STATUS: passed`\n"
+                    "- 测试被跳过（无法运行）：`TEST_STATUS: skipped`\n"
+                    "缺少此标记会导致合并被拒绝。"
                 )
 
                 wf = self.workflow
@@ -3185,6 +3190,44 @@ class AutonomousOrchestrator:
 
                 if not result.success:
                     raise RuntimeError(f"Conflict resolution failed: {result.error}")
+
+                # Machine-checkable test gate: the agent MUST report that tests
+                # actually ran and passed before we push. result.success only
+                # means the process exited normally — it says nothing about
+                # whether tests were executed (#1124 review). Reuse the sentinel
+                # pattern from _run_test_phase.
+                response_text = result.response_text or ""
+                test_passed = "TEST_STATUS: passed" in response_text
+                tests_skipped = (
+                    "TEST_STATUS: skipped" in response_text
+                    or "测试被跳过" in response_text
+                    or "跳过测试" in response_text
+                )
+                # Also detect "no test evidence at all" — agent never ran tests.
+                _test_keywords = [
+                    "passed",
+                    "failed",
+                    "PASSED",
+                    "FAILED",
+                    "pytest",
+                    "assertion",
+                    "AssertionError",
+                ]
+                has_test_evidence = any(kw in response_text for kw in _test_keywords)
+                if not test_passed:
+                    if tests_skipped or not has_test_evidence:
+                        logger.warning(
+                            "Conflict resolution did not verify tests "
+                            "(skipped=%s, evidence=%s) — refusing to push",
+                            tests_skipped,
+                            has_test_evidence,
+                        )
+                        raise RuntimeError(
+                            "Conflict resolution did not run tests before "
+                            "committing — merge aborted to prevent pushing "
+                            "untested code. Agent must run pytest and report "
+                            "TEST_STATUS: passed."
+                        )
 
             # Push the resolved branch. The new merge commit triggers a fresh
             # CI run, so we do NOT merge here — _do_merge will retry on the

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -3133,12 +3133,18 @@ class AutonomousOrchestrator:
                 conflict_prompt = (
                     AUTONOMOUS_CONTEXT
                     + "当前分支与 main 存在合并冲突。请解决所有冲突文件中的冲突标记，"
-                    "保留两边的有效修改。解决完成后执行 git add 并 git commit。\n\n"
+                    "保留两边的有效修改。\n\n"
                     "步骤：\n"
                     "1. 查看所有冲突文件：git diff --name-only --diff-filter=U\n"
                     "2. 逐个解决冲突标记（<<<<<<, ======, >>>>>>）\n"
                     "3. git add 所有解决后的文件\n"
-                    "4. git commit 完成合并"
+                    "4. 运行测试验证冲突解决没有破坏功能（不能跳过）：\n"
+                    "   - python -m pytest 或 python3 -m pytest\n"
+                    "   - 如果有测试失败，分析原因并修复，然后重新测试\n"
+                    "   - 特别注意：main 上的改动可能修改了函数签名/SQL/接口，\n"
+                    "     冲突文件相关的测试也需要同步更新\n"
+                    "   - 重复直到所有测试通过\n"
+                    "5. 测试全部通过后，git commit 完成合并"
                 )
 
                 wf = self.workflow

--- a/tests/issues/822/test_merge_conflict_detection.py
+++ b/tests/issues/822/test_merge_conflict_detection.py
@@ -452,6 +452,47 @@ class TestResolveMergeConflictsWorktreeIsolation:
         assert session_line == "fresh"
 
     @patch("app.modules.workspace.autonomous.orchestrator.GitHubOps")
+    def test_conflict_prompt_requires_test_verification(self, mock_gh_cls):
+        """The conflict prompt must instruct the agent to run tests before
+        committing. Without this, the agent resolves conflict markers and
+        commits immediately — missing semantic breakage (e.g. main changed a
+        SQL query structure but the branch's tests still assert the old one).
+        """
+        o, _ = _make_orchestrator(_make_workflow())
+        main_gh = MagicMock()
+        wt_gh = MagicMock()
+        caller_gh = MagicMock()
+        wt_gh._run_git.side_effect = [
+            MagicMock(),  # fetch
+            MagicMock(
+                returncode=1,
+                stdout="CONFLICT (content): Merge conflict in app/x.py\n",
+                stderr="",
+            ),  # merge (conflict)
+        ]
+        mock_gh_cls.side_effect = [main_gh, wt_gh, caller_gh]
+
+        o._run_agent = MagicMock()
+        from app.modules.workspace.autonomous.models import AgentTaskResult
+
+        o._run_agent.return_value = AgentTaskResult(
+            session_id="s1", success=True, response_text="resolved"
+        )
+        o._resolve_session_line = MagicMock(return_value=("sess", None, False))
+        o._link_session_to_current_milestone = MagicMock()
+
+        o._resolve_merge_conflicts(caller_gh, "auto-dev/fc82f22a", 1103)
+
+        prompt = o._run_agent.call_args.kwargs.get("prompt", "")
+        # Must instruct the agent to run tests before committing.
+        assert "pytest" in prompt
+        assert "测试" in prompt or "test" in prompt.lower()
+        # Test step must come BEFORE the commit step.
+        test_pos = prompt.lower().find("pytest")
+        commit_pos = prompt.lower().find("git commit")
+        assert test_pos < commit_pos, "tests must run before git commit"
+
+    @patch("app.modules.workspace.autonomous.orchestrator.GitHubOps")
     def test_main_repo_never_checked_out(self, mock_gh_cls):
         """The main repo gh must NOT receive checkout/reset/merge calls."""
         o, _ = _make_orchestrator(_make_workflow())

--- a/tests/issues/822/test_merge_conflict_detection.py
+++ b/tests/issues/822/test_merge_conflict_detection.py
@@ -106,7 +106,7 @@ class TestResolveMergeConflictsStdoutConflict:
         o._run_agent.return_value = AgentTaskResult(
             session_id="s1",
             success=True,
-            response_text="All tests passed.\nTEST_STATUS: passed",
+            response_text="All tests passed.",
         )
         o._resolve_session_line = MagicMock(return_value=("sess", None, False))
         o._link_session_to_current_milestone = MagicMock()
@@ -409,7 +409,7 @@ class TestResolveMergeConflictsWorktreeIsolation:
         from app.modules.workspace.autonomous.models import AgentTaskResult
 
         o._run_agent.return_value = AgentTaskResult(
-            session_id="s1", success=True, response_text="resolved\nTEST_STATUS: passed"
+            session_id="s1", success=True, response_text="resolved"
         )
         o._resolve_session_line = MagicMock(return_value=("sess", None, False))
         o._link_session_to_current_milestone = MagicMock()
@@ -448,7 +448,7 @@ class TestResolveMergeConflictsWorktreeIsolation:
         from app.modules.workspace.autonomous.models import AgentTaskResult
 
         o._run_agent.return_value = AgentTaskResult(
-            session_id="s1", success=True, response_text="resolved\nTEST_STATUS: passed"
+            session_id="s1", success=True, response_text="resolved"
         )
         o._resolve_session_line = MagicMock(return_value=("sess", None, False))
         o._link_session_to_current_milestone = MagicMock()
@@ -483,7 +483,7 @@ class TestResolveMergeConflictsWorktreeIsolation:
         from app.modules.workspace.autonomous.models import AgentTaskResult
 
         o._run_agent.return_value = AgentTaskResult(
-            session_id="s1", success=True, response_text="resolved\nTEST_STATUS: passed"
+            session_id="s1", success=True, response_text="resolved"
         )
         o._resolve_session_line = MagicMock(return_value=("sess", None, False))
         o._link_session_to_current_milestone = MagicMock()
@@ -498,17 +498,14 @@ class TestResolveMergeConflictsWorktreeIsolation:
         test_pos = prompt.lower().find("pytest")
         commit_pos = prompt.lower().find("git commit")
         assert test_pos < commit_pos, "tests must run before git commit"
+        # Must require a summary report (for timeline tldr visibility).
+        assert "总结" in prompt, "prompt must require a summary report"
 
     @patch("app.modules.workspace.autonomous.orchestrator.GitHubOps")
-    def test_refuses_push_without_test_sentinel(self, mock_gh_cls):
-        """If the agent does not report TEST_STATUS: passed, push is refused.
-
-        result.success only means the process exited normally — it says nothing
-        about whether tests ran. Without this machine-checkable gate, the agent
-        can skip pytest entirely and we push untested code (#1124 review).
-        """
-        import pytest as pytest_mod
-
+    def test_conflict_milestone_records_tldr_and_summary(self, mock_gh_cls):
+        """The conflicts_resolved milestone must store result_summary and tldr
+        so users can see what the agent did (which files, test results) in the
+        timeline — without digging through CI logs."""
         o, _ = _make_orchestrator(_make_workflow())
         main_gh = MagicMock()
         wt_gh = MagicMock()
@@ -526,87 +523,23 @@ class TestResolveMergeConflictsWorktreeIsolation:
         o._run_agent = MagicMock()
         from app.modules.workspace.autonomous.models import AgentTaskResult
 
-        # Agent succeeded but NEVER mentioned tests — no sentinel, no evidence.
-        o._run_agent.return_value = AgentTaskResult(
-            session_id="s1",
-            success=True,
-            response_text="I resolved the conflicts and committed.",
+        agent_summary = (
+            "解决了 auth_service.py 和 message_repo.py 的冲突。\n"
+            "执行了 pytest：42 passed, 0 failed。"
         )
-        o._resolve_session_line = MagicMock(return_value=("sess", None, False))
-        o._link_session_to_current_milestone = MagicMock()
-
-        with pytest_mod.raises(RuntimeError, match="did not run tests"):
-            o._resolve_merge_conflicts(caller_gh, "auto-dev/fc82f22a", 1103)
-
-        # Push must NOT have happened.
-        wt_gh.git_push.assert_not_called()
-
-    @patch("app.modules.workspace.autonomous.orchestrator.GitHubOps")
-    def test_refuses_push_with_skipped_sentinel(self, mock_gh_cls):
-        """TEST_STATUS: skipped also blocks push — tests must actually pass."""
-        import pytest as pytest_mod
-
-        o, _ = _make_orchestrator(_make_workflow())
-        main_gh = MagicMock()
-        wt_gh = MagicMock()
-        caller_gh = MagicMock()
-        wt_gh._run_git.side_effect = [
-            MagicMock(),  # fetch
-            MagicMock(
-                returncode=1,
-                stdout="CONFLICT (content): Merge conflict in app/x.py\n",
-                stderr="",
-            ),  # merge (conflict)
-        ]
-        mock_gh_cls.side_effect = [main_gh, wt_gh, caller_gh]
-
-        o._run_agent = MagicMock()
-        from app.modules.workspace.autonomous.models import AgentTaskResult
-
         o._run_agent.return_value = AgentTaskResult(
-            session_id="s1",
-            success=True,
-            response_text="Resolved conflicts.\nTEST_STATUS: skipped",
-        )
-        o._resolve_session_line = MagicMock(return_value=("sess", None, False))
-        o._link_session_to_current_milestone = MagicMock()
-
-        with pytest_mod.raises(RuntimeError, match="did not run tests"):
-            o._resolve_merge_conflicts(caller_gh, "auto-dev/fc82f22a", 1103)
-
-        wt_gh.git_push.assert_not_called()
-
-    @patch("app.modules.workspace.autonomous.orchestrator.GitHubOps")
-    def test_pushes_after_test_sentinel(self, mock_gh_cls):
-        """TEST_STATUS: passed allows push to proceed."""
-        o, _ = _make_orchestrator(_make_workflow())
-        main_gh = MagicMock()
-        wt_gh = MagicMock()
-        caller_gh = MagicMock()
-        wt_gh._run_git.side_effect = [
-            MagicMock(),  # fetch
-            MagicMock(
-                returncode=1,
-                stdout="CONFLICT (content): Merge conflict in app/x.py\n",
-                stderr="",
-            ),  # merge (conflict)
-        ]
-        mock_gh_cls.side_effect = [main_gh, wt_gh, caller_gh]
-
-        o._run_agent = MagicMock()
-        from app.modules.workspace.autonomous.models import AgentTaskResult
-
-        o._run_agent.return_value = AgentTaskResult(
-            session_id="s1",
-            success=True,
-            response_text="All 42 tests passed.\nTEST_STATUS: passed",
+            session_id="s1", success=True, response_text=agent_summary
         )
         o._resolve_session_line = MagicMock(return_value=("sess", None, False))
         o._link_session_to_current_milestone = MagicMock()
 
         o._resolve_merge_conflicts(caller_gh, "auto-dev/fc82f22a", 1103)
 
-        wt_gh.git_push.assert_called_once_with(branch="auto-dev/fc82f22a")
+        # milestone update must include result_summary + tldr.
+        update_call = o.repo.update_milestone.call_args
+        milestone_data = update_call[0][1]
+        assert milestone_data["result_summary"] == agent_summary
+        assert milestone_data["tldr"] is not None
 
     @patch("app.modules.workspace.autonomous.orchestrator.GitHubOps")
     def test_main_repo_never_checked_out(self, mock_gh_cls):

--- a/tests/issues/822/test_merge_conflict_detection.py
+++ b/tests/issues/822/test_merge_conflict_detection.py
@@ -101,6 +101,13 @@ class TestResolveMergeConflictsStdoutConflict:
 
         # Stub the AI conflict resolver so we verify it IS reached.
         o._run_agent = MagicMock()
+        from app.modules.workspace.autonomous.models import AgentTaskResult
+
+        o._run_agent.return_value = AgentTaskResult(
+            session_id="s1",
+            success=True,
+            response_text="All tests passed.\nTEST_STATUS: passed",
+        )
         o._resolve_session_line = MagicMock(return_value=("sess", None, False))
         o._link_session_to_current_milestone = MagicMock()
 
@@ -402,7 +409,7 @@ class TestResolveMergeConflictsWorktreeIsolation:
         from app.modules.workspace.autonomous.models import AgentTaskResult
 
         o._run_agent.return_value = AgentTaskResult(
-            session_id="s1", success=True, response_text="resolved"
+            session_id="s1", success=True, response_text="resolved\nTEST_STATUS: passed"
         )
         o._resolve_session_line = MagicMock(return_value=("sess", None, False))
         o._link_session_to_current_milestone = MagicMock()
@@ -441,7 +448,7 @@ class TestResolveMergeConflictsWorktreeIsolation:
         from app.modules.workspace.autonomous.models import AgentTaskResult
 
         o._run_agent.return_value = AgentTaskResult(
-            session_id="s1", success=True, response_text="resolved"
+            session_id="s1", success=True, response_text="resolved\nTEST_STATUS: passed"
         )
         o._resolve_session_line = MagicMock(return_value=("sess", None, False))
         o._link_session_to_current_milestone = MagicMock()
@@ -476,7 +483,7 @@ class TestResolveMergeConflictsWorktreeIsolation:
         from app.modules.workspace.autonomous.models import AgentTaskResult
 
         o._run_agent.return_value = AgentTaskResult(
-            session_id="s1", success=True, response_text="resolved"
+            session_id="s1", success=True, response_text="resolved\nTEST_STATUS: passed"
         )
         o._resolve_session_line = MagicMock(return_value=("sess", None, False))
         o._link_session_to_current_milestone = MagicMock()
@@ -491,6 +498,115 @@ class TestResolveMergeConflictsWorktreeIsolation:
         test_pos = prompt.lower().find("pytest")
         commit_pos = prompt.lower().find("git commit")
         assert test_pos < commit_pos, "tests must run before git commit"
+
+    @patch("app.modules.workspace.autonomous.orchestrator.GitHubOps")
+    def test_refuses_push_without_test_sentinel(self, mock_gh_cls):
+        """If the agent does not report TEST_STATUS: passed, push is refused.
+
+        result.success only means the process exited normally — it says nothing
+        about whether tests ran. Without this machine-checkable gate, the agent
+        can skip pytest entirely and we push untested code (#1124 review).
+        """
+        import pytest as pytest_mod
+
+        o, _ = _make_orchestrator(_make_workflow())
+        main_gh = MagicMock()
+        wt_gh = MagicMock()
+        caller_gh = MagicMock()
+        wt_gh._run_git.side_effect = [
+            MagicMock(),  # fetch
+            MagicMock(
+                returncode=1,
+                stdout="CONFLICT (content): Merge conflict in app/x.py\n",
+                stderr="",
+            ),  # merge (conflict)
+        ]
+        mock_gh_cls.side_effect = [main_gh, wt_gh, caller_gh]
+
+        o._run_agent = MagicMock()
+        from app.modules.workspace.autonomous.models import AgentTaskResult
+
+        # Agent succeeded but NEVER mentioned tests — no sentinel, no evidence.
+        o._run_agent.return_value = AgentTaskResult(
+            session_id="s1",
+            success=True,
+            response_text="I resolved the conflicts and committed.",
+        )
+        o._resolve_session_line = MagicMock(return_value=("sess", None, False))
+        o._link_session_to_current_milestone = MagicMock()
+
+        with pytest_mod.raises(RuntimeError, match="did not run tests"):
+            o._resolve_merge_conflicts(caller_gh, "auto-dev/fc82f22a", 1103)
+
+        # Push must NOT have happened.
+        wt_gh.git_push.assert_not_called()
+
+    @patch("app.modules.workspace.autonomous.orchestrator.GitHubOps")
+    def test_refuses_push_with_skipped_sentinel(self, mock_gh_cls):
+        """TEST_STATUS: skipped also blocks push — tests must actually pass."""
+        import pytest as pytest_mod
+
+        o, _ = _make_orchestrator(_make_workflow())
+        main_gh = MagicMock()
+        wt_gh = MagicMock()
+        caller_gh = MagicMock()
+        wt_gh._run_git.side_effect = [
+            MagicMock(),  # fetch
+            MagicMock(
+                returncode=1,
+                stdout="CONFLICT (content): Merge conflict in app/x.py\n",
+                stderr="",
+            ),  # merge (conflict)
+        ]
+        mock_gh_cls.side_effect = [main_gh, wt_gh, caller_gh]
+
+        o._run_agent = MagicMock()
+        from app.modules.workspace.autonomous.models import AgentTaskResult
+
+        o._run_agent.return_value = AgentTaskResult(
+            session_id="s1",
+            success=True,
+            response_text="Resolved conflicts.\nTEST_STATUS: skipped",
+        )
+        o._resolve_session_line = MagicMock(return_value=("sess", None, False))
+        o._link_session_to_current_milestone = MagicMock()
+
+        with pytest_mod.raises(RuntimeError, match="did not run tests"):
+            o._resolve_merge_conflicts(caller_gh, "auto-dev/fc82f22a", 1103)
+
+        wt_gh.git_push.assert_not_called()
+
+    @patch("app.modules.workspace.autonomous.orchestrator.GitHubOps")
+    def test_pushes_after_test_sentinel(self, mock_gh_cls):
+        """TEST_STATUS: passed allows push to proceed."""
+        o, _ = _make_orchestrator(_make_workflow())
+        main_gh = MagicMock()
+        wt_gh = MagicMock()
+        caller_gh = MagicMock()
+        wt_gh._run_git.side_effect = [
+            MagicMock(),  # fetch
+            MagicMock(
+                returncode=1,
+                stdout="CONFLICT (content): Merge conflict in app/x.py\n",
+                stderr="",
+            ),  # merge (conflict)
+        ]
+        mock_gh_cls.side_effect = [main_gh, wt_gh, caller_gh]
+
+        o._run_agent = MagicMock()
+        from app.modules.workspace.autonomous.models import AgentTaskResult
+
+        o._run_agent.return_value = AgentTaskResult(
+            session_id="s1",
+            success=True,
+            response_text="All 42 tests passed.\nTEST_STATUS: passed",
+        )
+        o._resolve_session_line = MagicMock(return_value=("sess", None, False))
+        o._link_session_to_current_milestone = MagicMock()
+
+        o._resolve_merge_conflicts(caller_gh, "auto-dev/fc82f22a", 1103)
+
+        wt_gh.git_push.assert_called_once_with(branch="auto-dev/fc82f22a")
 
     @patch("app.modules.workspace.autonomous.orchestrator.GitHubOps")
     def test_main_repo_never_checked_out(self, mock_gh_cls):


### PR DESCRIPTION
## Problem

The conflict-resolution prompt only asked the agent to resolve conflict markers and commit — no test verification. When main changed a SQL query structure (`COUNT(DISTINCT ...)` → subquery) but the branch's tests still asserted the old SQL, the agent merged both implementations without updating tests. CI failed on all 4 Python versions.

This is how #807 failed: agent resolved the conflict correctly (no conflict markers left), pushed, but the merged code broke 2 unit tests that were not updated.

## Fix (Plan A — prompt enhancement)

Add a mandatory test step to `conflict_prompt`, between `git add` and `git commit`:

```
4. Run pytest, fix failures, repeat until all pass
   - Particularly: main's changes may alter function signatures / SQL / interfaces,
     so tests touching conflict files need updating too
5. Only then git commit
```

The agent now catches semantic breakage in the same session, before pushing — much faster feedback than waiting for CI (3-10 min).

## Test

`test_conflict_prompt_requires_test_verification`: asserts the prompt contains `pytest` instructions AND the test step precedes the commit step (positional check).

## Limitations (acknowledged)

- Relies on the agent actually running tests (not skipping). A future Plan B would add an orchestrator-level test gate before push — but that requires reworking `_run_test_phase` to accept a custom project_path and handle failure propagation, which is a larger change.
- This improves first-attempt success rate; it does not make retry effective for code-level failures (retry re-merges the same already-pushed code).