### PR TITLE
fix: sync alembic migration + lowercase RPC failed keyword (#1127 followup)

### DIFF
--- a/app/modules/workspace/autonomous/github_ops.py
+++ b/app/modules/workspace/autonomous/github_ops.py
@@ -37,7 +37,7 @@ _TRANSIENT_ERROR_KEYWORDS = [
     "temporary failure in name resolution",
     "network is unreachable",
     "unable to access",
-    "RPC failed",
+    "rpc failed",
     "early eof",
 ]
 

--- a/frontend/src/api/fs.ts
+++ b/frontend/src/api/fs.ts
@@ -33,6 +33,30 @@ export interface DirectoryEntry {
   is_writable: boolean;
 }
 
+interface LocalDirectoryEntryApi {
+  name: string;
+  path: string;
+  isWritable?: boolean;
+  isReadable?: boolean;
+}
+
+interface LocalBrowseResultApi {
+  currentPath?: string;
+  path?: string;
+  name?: string;
+  directories?: LocalDirectoryEntryApi[] | DirectoryEntry[];
+  parentPath?: string | null;
+  parent?: string | null;
+  homePath?: string;
+  canCreate?: boolean;
+  is_writable?: boolean;
+}
+
+interface LocalBrowseResponseApi extends LocalBrowseResultApi {
+  error?: string;
+  fallback?: LocalBrowseResultApi;
+}
+
 export interface CreateDirectoryRequest {
   path: string;
   system_account?: string;
@@ -51,14 +75,53 @@ export interface RemoteOperationResult<T = unknown> {
   error?: string;
 }
 
+function getPathName(path: string): string {
+  const normalized = path.replace(/[\\/]+$/, '');
+  if (!normalized) {
+    return '/';
+  }
+  const parts = normalized.split(/[/\\]/).filter(Boolean);
+  return parts[parts.length - 1] ?? normalized;
+}
+
+function normalizeDirectoryEntry(entry: LocalDirectoryEntryApi | DirectoryEntry): DirectoryEntry {
+  return {
+    name: entry.name,
+    path: entry.path,
+    is_writable:
+      'is_writable' in entry
+        ? Boolean(entry.is_writable)
+        : Boolean((entry as LocalDirectoryEntryApi).isWritable),
+  };
+}
+
+function normalizeBrowseResult(payload: LocalBrowseResponseApi): BrowseResult {
+  const source = payload.fallback ?? payload;
+  const path = source.path ?? source.currentPath ?? '';
+
+  return {
+    path,
+    name: source.name ?? getPathName(path),
+    directories: Array.isArray(source.directories)
+      ? source.directories.map(normalizeDirectoryEntry)
+      : [],
+    parent: source.parent ?? source.parentPath ?? null,
+    homePath: source.homePath ?? '',
+    canCreate: source.canCreate ?? source.is_writable ?? false,
+    is_writable: source.is_writable ?? source.canCreate ?? false,
+    fallback_note: payload.error && payload.fallback ? payload.error : undefined,
+  };
+}
+
 // ==================== API Methods ====================
 
 export const fsApi = {
   // Local file system browse
-  browseDirectory(path?: string): Promise<BrowseResult> {
+  async browseDirectory(path?: string): Promise<BrowseResult> {
     const params: Record<string, string> = {};
     if (path) params.path = path;
-    return apiClient.get('/api/fs/browse', params);
+    const response = await apiClient.get<LocalBrowseResponseApi>('/api/fs/browse', params);
+    return normalizeBrowseResult(response);
   },
 
   // Create directory (local)

--- a/frontend/src/components/work/NewAutonomousModal.tsx
+++ b/frontend/src/components/work/NewAutonomousModal.tsx
@@ -2,11 +2,13 @@
  * NewAutonomousModal Component - Modal for creating a new autonomous development workflow
  */
 
-import React, { useState, useMemo, useCallback } from 'react';
+import React, { useState, useMemo, useCallback, useEffect } from 'react';
 import { useLanguage } from '@/store';
 import { t } from '@/i18n';
 import { Modal, Button } from '@/components/common';
 import { RemoteMachineSelector } from './RemoteMachineSelector';
+import { DirectoryBrowserModal } from './DirectoryBrowserModal';
+import { LocalDirectoryBrowserModal } from './LocalDirectoryBrowserModal';
 import { useCreateWorkflow, useAvailableTools, useAvailableModels } from '@/hooks/useAutonomous';
 import type { AutonomousWorkflow, CreateWorkflowRequest } from '@/api/autonomous';
 
@@ -14,6 +16,28 @@ interface NewAutonomousModalProps {
   show: boolean;
   onClose: () => void;
   onCreated: (workflow: AutonomousWorkflow) => void;
+}
+
+const LOCAL_LAST_PROJECT_PATH_KEY = 'local-last-project-path';
+
+function getRemoteLastProjectPathKey(machineId: string): string {
+  return `remote-last-project-path-${machineId}`;
+}
+
+function getStoredPath(key: string): string {
+  try {
+    return localStorage.getItem(key) ?? '';
+  } catch {
+    return '';
+  }
+}
+
+function setStoredPath(key: string, path: string): void {
+  try {
+    localStorage.setItem(key, path);
+  } catch {
+    // Ignore localStorage write failures
+  }
 }
 
 export const NewAutonomousModal: React.FC<NewAutonomousModalProps> = ({
@@ -31,16 +55,20 @@ export const NewAutonomousModal: React.FC<NewAutonomousModalProps> = ({
   const [model, setModel] = useState('');
   const [workspaceType, setWorkspaceType] = useState<'local' | 'remote'>('local');
   const [selectedMachineId, setSelectedMachineId] = useState('');
+  const [selectedMachineOsType, setSelectedMachineOsType] = useState('');
+  const [selectedMachineWorkDir, setSelectedMachineWorkDir] = useState('');
   const [projectPath, setProjectPath] = useState('');
   const [isNewProject, setIsNewProject] = useState(false);
+  const [showLocalDirectoryBrowser, setShowLocalDirectoryBrowser] = useState(false);
+  const [showRemoteDirectoryBrowser, setShowRemoteDirectoryBrowser] = useState(false);
   const [repoName, setRepoName] = useState('');
   const [isPrivate, setIsPrivate] = useState(true);
   const [branchStrategy, setBranchStrategy] = useState<'new-branch' | 'worktree' | 'current'>(
-    'new-branch'
+    'worktree'
   );
   const [branchName, setBranchName] = useState('');
-  const [maxPlanRounds, setMaxPlanRounds] = useState(3);
-  const [maxPRReviewRounds, setMaxPRReviewRounds] = useState(5);
+  const [maxPlanRounds, setMaxPlanRounds] = useState(2);
+  const [maxPRReviewRounds, setMaxPRReviewRounds] = useState(3);
   const [title, setTitle] = useState('');
   const [autoMerge, setAutoMerge] = useState(true); // Auto merge for batch workflows
   const [errorMessage, setErrorMessage] = useState('');
@@ -56,6 +84,49 @@ export const NewAutonomousModal: React.FC<NewAutonomousModalProps> = ({
   const tools = toolsData?.tools ?? [];
   const models = modelsData?.models ?? [];
   const isCreating = createWorkflow.isPending;
+
+  const persistLastProjectPath = useCallback(
+    (path: string, type: 'local' | 'remote', machineId?: string) => {
+      const normalizedPath = path.trim();
+      if (!normalizedPath) return;
+
+      if (type === 'remote') {
+        if (!machineId) return;
+        setStoredPath(getRemoteLastProjectPathKey(machineId), normalizedPath);
+        return;
+      }
+
+      setStoredPath(LOCAL_LAST_PROJECT_PATH_KEY, normalizedPath);
+    },
+    []
+  );
+
+  useEffect(() => {
+    if (!show || isNewProject || workspaceType !== 'local' || projectPath) {
+      return;
+    }
+
+    const storedPath = getStoredPath(LOCAL_LAST_PROJECT_PATH_KEY);
+    if (storedPath) {
+      setProjectPath(storedPath);
+    }
+  }, [show, isNewProject, workspaceType, projectPath]);
+
+  useEffect(() => {
+    if (!show || isNewProject || workspaceType !== 'remote' || !selectedMachineId || projectPath) {
+      return;
+    }
+
+    const storedPath = getStoredPath(getRemoteLastProjectPathKey(selectedMachineId));
+    if (storedPath) {
+      setProjectPath(storedPath);
+      return;
+    }
+
+    if (selectedMachineWorkDir) {
+      setProjectPath(selectedMachineWorkDir);
+    }
+  }, [show, isNewProject, workspaceType, selectedMachineId, selectedMachineWorkDir, projectPath]);
 
   const canSubmit = useMemo(() => {
     const hasRequirements =
@@ -76,6 +147,7 @@ export const NewAutonomousModal: React.FC<NewAutonomousModalProps> = ({
   ]);
 
   const handleSubmit = useCallback(async () => {
+    const confirmedProjectPath = isNewProject ? '' : projectPath.trim();
     const data: CreateWorkflowRequest = {
       title: title || undefined,
       requirements_text: requirementsMode === 'text' ? requirementsText : undefined,
@@ -99,6 +171,9 @@ export const NewAutonomousModal: React.FC<NewAutonomousModalProps> = ({
     try {
       setErrorMessage('');
       const result = await createWorkflow.mutateAsync(data);
+      if (confirmedProjectPath) {
+        persistLastProjectPath(confirmedProjectPath, workspaceType, selectedMachineId);
+      }
       if (result.workflow) {
         onCreated(result.workflow);
       }
@@ -121,322 +196,370 @@ export const NewAutonomousModal: React.FC<NewAutonomousModalProps> = ({
     projectPath,
     isNewProject,
     repoName,
+    isPrivate,
     branchStrategy,
     branchName,
     maxPlanRounds,
     maxPRReviewRounds,
     autoMerge,
     createWorkflow,
+    language,
     onCreated,
+    persistLastProjectPath,
   ]);
 
   return (
-    <Modal
-      isOpen={show}
-      onClose={onClose}
-      title={t('newAutonomousTask', language)}
-      size="lg"
-      footer={
-        <>
-          <Button variant="secondary" onClick={onClose}>
-            {t('cancel', language)}
-          </Button>
-          <Button onClick={handleSubmit} disabled={!canSubmit || isCreating}>
-            {isCreating ? (
-              <>
-                <span className="spinner-border spinner-border-sm me-1" role="status"></span>
-                {t('autoCreating', language)}
-              </>
-            ) : (
-              t('autoCreateTask', language)
-            )}
-          </Button>
-        </>
-      }
-    >
-      <div className="row g-3">
-        {/* Error Alert */}
-        {errorMessage && (
-          <div className="col-12">
-            <div className="alert alert-danger d-flex align-items-center" role="alert">
-              <i className="bi bi-exclamation-triangle-fill me-2"></i>
-              {errorMessage}
-            </div>
-          </div>
-        )}
-
-        {/* Title */}
-        <div className="col-12">
-          <label className="form-label fw-semibold">{t('autoTaskTitle', language)}</label>
-          <input
-            type="text"
-            className="form-control"
-            placeholder={t('autoTaskTitlePlaceholder', language)}
-            value={title}
-            onChange={(e) => setTitle(e.target.value)}
-          />
-        </div>
-
-        {/* Requirements */}
-        <div className="col-12">
-          <label className="form-label fw-semibold">
-            {t('autoRequirements', language)} <span className="text-danger">*</span>
-          </label>
-          <div className="btn-group btn-group-sm mb-2" role="group">
-            <button
-              type="button"
-              className={`btn btn-outline-primary ${requirementsMode === 'text' ? 'active' : ''}`}
-              onClick={() => setRequirementsMode('text')}
-            >
-              {t('autoTextDescription', language)}
-            </button>
-            <button
-              type="button"
-              className={`btn btn-outline-primary ${requirementsMode === 'url' ? 'active' : ''}`}
-              onClick={() => setRequirementsMode('url')}
-            >
-              {t('autoGithubIssue', language)}
-            </button>
-          </div>
-          {requirementsMode === 'text' ? (
-            <textarea
-              className="form-control"
-              rows={4}
-              placeholder={t('autoRequirementsPlaceholder', language)}
-              value={requirementsText}
-              onChange={(e) => setRequirementsText(e.target.value)}
-            />
-          ) : (
-            <>
-              <textarea
-                className="form-control"
-                rows={3}
-                placeholder={
-                  t('autoIssueInputPlaceholder', language) ||
-                  '123 125,128-130 or https://github.com/owner/repo/issues/123'
-                }
-                value={requirementsUrl}
-                onChange={(e) => setRequirementsUrl(e.target.value)}
-              />
-              <div className="form-text">
-                {t('autoIssueInputHint', language) ||
-                  'Supports commas, spaces, new lines, ranges like 12-15, and mixed GitHub issue URLs.'}
+    <>
+      <Modal
+        isOpen={show}
+        onClose={onClose}
+        title={t('newAutonomousTask', language)}
+        size="lg"
+        footer={
+          <>
+            <Button variant="secondary" onClick={onClose}>
+              {t('cancel', language)}
+            </Button>
+            <Button onClick={handleSubmit} disabled={!canSubmit || isCreating}>
+              {isCreating ? (
+                <>
+                  <span className="spinner-border spinner-border-sm me-1" role="status"></span>
+                  {t('autoCreating', language)}
+                </>
+              ) : (
+                t('autoCreateTask', language)
+              )}
+            </Button>
+          </>
+        }
+      >
+        <div className="row g-3">
+          {/* Error Alert */}
+          {errorMessage && (
+            <div className="col-12">
+              <div className="alert alert-danger d-flex align-items-center" role="alert">
+                <i className="bi bi-exclamation-triangle-fill me-2"></i>
+                {errorMessage}
               </div>
-            </>
+            </div>
           )}
-        </div>
 
-        {/* Agent Tool & Model */}
-        <div className="col-md-6">
-          <label className="form-label fw-semibold">
-            {t('autoAgentTool', language)} <span className="text-danger">*</span>
-          </label>
-          <select
-            className="form-select"
-            value={cliTool}
-            onChange={(e) => {
-              setCliTool(e.target.value);
-              setModel('');
-            }}
-          >
-            {tools.length > 0 ? (
-              tools.map((tool) => (
-                <option key={tool.id} value={tool.id}>
-                  {tool.name}
-                </option>
-              ))
-            ) : (
-              <>
-                <option value="claude-code">Claude Code</option>
-                <option value="qwen-code-cli">Qwen Code</option>
-                <option value="codex">Codex CLI</option>
-                <option value="openclaw">OpenClaw</option>
-                <option value="zcode">ZCode</option>
-              </>
-            )}
-          </select>
-        </div>
-        <div className="col-md-6">
-          <label className="form-label fw-semibold">{t('autoModel', language)}</label>
-          <select className="form-select" value={model} onChange={(e) => setModel(e.target.value)}>
-            <option value="">{t('autoDefaultModel', language)}</option>
-            {Array.isArray(models) &&
-              models.map((m: { name: string }) => (
-                <option key={m.name} value={m.name}>
-                  {m.name}
-                </option>
-              ))}
-          </select>
-        </div>
-
-        {/* Workspace Type */}
-        <div className="col-12">
-          <label className="form-label fw-semibold">{t('autoWorkspaceType', language)}</label>
-          <div className="btn-group w-100" role="group">
-            <button
-              type="button"
-              className={`btn btn-outline-primary ${workspaceType === 'local' ? 'active' : ''}`}
-              onClick={() => setWorkspaceType('local')}
-            >
-              <i className="bi bi-laptop me-1"></i>
-              {t('autoLocalWorkspace', language)}
-            </button>
-            <button
-              type="button"
-              className={`btn btn-outline-primary ${workspaceType === 'remote' ? 'active' : ''}`}
-              onClick={() => setWorkspaceType('remote')}
-            >
-              <i className="bi bi-cloud me-1"></i>
-              {t('autoRemoteWorkspace', language)}
-            </button>
-          </div>
-        </div>
-
-        {/* Remote Machine */}
-        {workspaceType === 'remote' && (
+          {/* Title */}
           <div className="col-12">
-            <label className="form-label fw-semibold">
-              {t('autoRemoteMachine', language)} <span className="text-danger">*</span>
-            </label>
-            <RemoteMachineSelector
-              selectedMachineId={selectedMachineId}
-              onSelectMachine={(machineId, machine) => {
-                setSelectedMachineId(machineId);
-                if (machine?.work_dir && !projectPath) {
-                  setProjectPath(machine.work_dir);
-                }
-              }}
-            />
-          </div>
-        )}
-
-        {/* Project Path */}
-        <div className="col-12">
-          <div className="form-check mb-2">
-            <input
-              type="checkbox"
-              className="form-check-input"
-              id="isNewProject"
-              checked={isNewProject}
-              onChange={(e) => setIsNewProject(e.target.checked)}
-            />
-            <label className="form-check-label" htmlFor="isNewProject">
-              {t('autoNewProject', language)}
-            </label>
-          </div>
-          {isNewProject ? (
-            <div className="row g-2">
-              <div className="col-md-8">
-                <input
-                  type="text"
-                  className="form-control"
-                  placeholder={t('autoRepoNamePlaceholder', language)}
-                  value={repoName}
-                  onChange={(e) => setRepoName(e.target.value)}
-                />
-              </div>
-              <div className="col-md-4">
-                <div className="form-check">
-                  <input
-                    type="checkbox"
-                    className="form-check-input"
-                    id="isPrivate"
-                    checked={isPrivate}
-                    onChange={(e) => setIsPrivate(e.target.checked)}
-                  />
-                  <label className="form-check-label" htmlFor="isPrivate">
-                    {t('autoPrivateRepo', language)}
-                  </label>
-                </div>
-              </div>
-            </div>
-          ) : (
+            <label className="form-label fw-semibold">{t('autoTaskTitle', language)}</label>
             <input
               type="text"
               className="form-control"
-              placeholder={t('autoProjectPathPlaceholder', language)}
-              value={projectPath}
-              onChange={(e) => setProjectPath(e.target.value)}
+              placeholder={t('autoTaskTitlePlaceholder', language)}
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
             />
-          )}
-        </div>
+          </div>
 
-        {/* Branch Strategy */}
-        <div className="col-md-6">
-          <label className="form-label fw-semibold">{t('autoBranchStrategy', language)}</label>
-          <select
-            className="form-select"
-            value={branchStrategy}
-            onChange={(e) =>
-              setBranchStrategy(e.target.value as 'new-branch' | 'worktree' | 'current')
-            }
-          >
-            <option value="new-branch">{t('autoNewBranch', language)}</option>
-            <option value="worktree">{t('autoWorktree', language)}</option>
-            <option value="current">{t('autoCurrentBranch', language)}</option>
-          </select>
-        </div>
-        <div className="col-md-6">
-          <label className="form-label fw-semibold">{t('autoBranchName', language)}</label>
-          <input
-            type="text"
-            className="form-control"
-            placeholder={t('autoBranchNamePlaceholder', language)}
-            value={branchName}
-            onChange={(e) => setBranchName(e.target.value)}
-          />
-        </div>
-
-        {/* Review Rounds */}
-        <div className="col-md-6">
-          <label className="form-label fw-semibold">
-            {t('autoMaxPlanRounds', language)}: {maxPlanRounds}
-          </label>
-          <input
-            type="range"
-            className="form-range"
-            min={1}
-            max={5}
-            value={maxPlanRounds}
-            onChange={(e) => setMaxPlanRounds(parseInt(e.target.value))}
-          />
-        </div>
-        <div className="col-md-6">
-          <label className="form-label fw-semibold">
-            {t('autoMaxPRReviewRounds', language)}: {maxPRReviewRounds}
-          </label>
-          <input
-            type="range"
-            className="form-range"
-            min={1}
-            max={10}
-            value={maxPRReviewRounds}
-            onChange={(e) => setMaxPRReviewRounds(parseInt(e.target.value))}
-          />
-        </div>
-
-        {/* Auto Merge - only show for batch workflows (URL mode with multiple issues) */}
-        {requirementsMode === 'url' && requirementsUrl.trim() && (
+          {/* Requirements */}
           <div className="col-12">
-            <div className="form-check">
+            <label className="form-label fw-semibold">
+              {t('autoRequirements', language)} <span className="text-danger">*</span>
+            </label>
+            <div className="btn-group btn-group-sm mb-2" role="group">
+              <button
+                type="button"
+                className={`btn btn-outline-primary ${requirementsMode === 'text' ? 'active' : ''}`}
+                onClick={() => setRequirementsMode('text')}
+              >
+                {t('autoTextDescription', language)}
+              </button>
+              <button
+                type="button"
+                className={`btn btn-outline-primary ${requirementsMode === 'url' ? 'active' : ''}`}
+                onClick={() => setRequirementsMode('url')}
+              >
+                {t('autoGithubIssue', language)}
+              </button>
+            </div>
+            {requirementsMode === 'text' ? (
+              <textarea
+                className="form-control"
+                rows={4}
+                placeholder={t('autoRequirementsPlaceholder', language)}
+                value={requirementsText}
+                onChange={(e) => setRequirementsText(e.target.value)}
+              />
+            ) : (
+              <>
+                <textarea
+                  className="form-control"
+                  rows={3}
+                  placeholder={
+                    t('autoIssueInputPlaceholder', language) ||
+                    '123 125,128-130 or https://github.com/owner/repo/issues/123'
+                  }
+                  value={requirementsUrl}
+                  onChange={(e) => setRequirementsUrl(e.target.value)}
+                />
+                <div className="form-text">
+                  {t('autoIssueInputHint', language) ||
+                    'Supports commas, spaces, new lines, ranges like 12-15, and mixed GitHub issue URLs.'}
+                </div>
+              </>
+            )}
+          </div>
+
+          {/* Agent Tool & Model */}
+          <div className="col-md-6">
+            <label className="form-label fw-semibold">
+              {t('autoAgentTool', language)} <span className="text-danger">*</span>
+            </label>
+            <select
+              className="form-select"
+              value={cliTool}
+              onChange={(e) => {
+                setCliTool(e.target.value);
+                setModel('');
+              }}
+            >
+              {tools.length > 0 ? (
+                tools.map((tool) => (
+                  <option key={tool.id} value={tool.id}>
+                    {tool.name}
+                  </option>
+                ))
+              ) : (
+                <>
+                  <option value="claude-code">Claude Code</option>
+                  <option value="qwen-code-cli">Qwen Code</option>
+                  <option value="codex">Codex CLI</option>
+                  <option value="openclaw">OpenClaw</option>
+                  <option value="zcode">ZCode</option>
+                </>
+              )}
+            </select>
+          </div>
+          <div className="col-md-6">
+            <label className="form-label fw-semibold">{t('autoModel', language)}</label>
+            <select
+              className="form-select"
+              value={model}
+              onChange={(e) => setModel(e.target.value)}
+            >
+              <option value="">{t('autoDefaultModel', language)}</option>
+              {Array.isArray(models) &&
+                models.map((m: { name: string }) => (
+                  <option key={m.name} value={m.name}>
+                    {m.name}
+                  </option>
+                ))}
+            </select>
+          </div>
+
+          {/* Workspace Type */}
+          <div className="col-12">
+            <label className="form-label fw-semibold">{t('autoWorkspaceType', language)}</label>
+            <div className="btn-group w-100" role="group">
+              <button
+                type="button"
+                className={`btn btn-outline-primary ${workspaceType === 'local' ? 'active' : ''}`}
+                onClick={() => setWorkspaceType('local')}
+              >
+                <i className="bi bi-laptop me-1"></i>
+                {t('autoLocalWorkspace', language)}
+              </button>
+              <button
+                type="button"
+                className={`btn btn-outline-primary ${workspaceType === 'remote' ? 'active' : ''}`}
+                onClick={() => setWorkspaceType('remote')}
+              >
+                <i className="bi bi-cloud me-1"></i>
+                {t('autoRemoteWorkspace', language)}
+              </button>
+            </div>
+          </div>
+
+          {/* Remote Machine */}
+          {workspaceType === 'remote' && (
+            <div className="col-12">
+              <label className="form-label fw-semibold">
+                {t('autoRemoteMachine', language)} <span className="text-danger">*</span>
+              </label>
+              <RemoteMachineSelector
+                selectedMachineId={selectedMachineId}
+                onSelectMachine={(machineId, machine) => {
+                  setSelectedMachineId(machineId);
+                  setSelectedMachineOsType(machine?.os_type ?? '');
+                  setSelectedMachineWorkDir(machine?.work_dir ?? '');
+                }}
+              />
+            </div>
+          )}
+
+          {/* Project Path */}
+          <div className="col-12">
+            <div className="form-check mb-2">
               <input
                 type="checkbox"
                 className="form-check-input"
-                id="autoMerge"
-                checked={autoMerge}
-                onChange={(e) => setAutoMerge(e.target.checked)}
+                id="isNewProject"
+                checked={isNewProject}
+                onChange={(e) => setIsNewProject(e.target.checked)}
               />
-              <label className="form-check-label" htmlFor="autoMerge">
-                {t('autoMergeAfterPR', language) || 'Auto merge after PR created'}
+              <label className="form-check-label" htmlFor="isNewProject">
+                {t('autoNewProject', language)}
               </label>
-              <div className="form-text">
-                {t('autoMergeHint', language) ||
-                  'Automatically merge PR and proceed to next workflow in batch'}
+            </div>
+            {isNewProject ? (
+              <div className="row g-2">
+                <div className="col-md-8">
+                  <input
+                    type="text"
+                    className="form-control"
+                    placeholder={t('autoRepoNamePlaceholder', language)}
+                    value={repoName}
+                    onChange={(e) => setRepoName(e.target.value)}
+                  />
+                </div>
+                <div className="col-md-4">
+                  <div className="form-check">
+                    <input
+                      type="checkbox"
+                      className="form-check-input"
+                      id="isPrivate"
+                      checked={isPrivate}
+                      onChange={(e) => setIsPrivate(e.target.checked)}
+                    />
+                    <label className="form-check-label" htmlFor="isPrivate">
+                      {t('autoPrivateRepo', language)}
+                    </label>
+                  </div>
+                </div>
+              </div>
+            ) : (
+              <div className="input-group">
+                <input
+                  type="text"
+                  className="form-control"
+                  placeholder={t('autoProjectPathPlaceholder', language)}
+                  value={projectPath}
+                  onChange={(e) => setProjectPath(e.target.value)}
+                />
+                <Button
+                  variant="outline-secondary"
+                  onClick={() => {
+                    if (workspaceType === 'remote') {
+                      setShowRemoteDirectoryBrowser(true);
+                    } else {
+                      setShowLocalDirectoryBrowser(true);
+                    }
+                  }}
+                  disabled={workspaceType === 'remote' && !selectedMachineId}
+                >
+                  <i className="bi bi-folder2-open me-1" />
+                  {t('browse', language) || 'Browse'}
+                </Button>
+              </div>
+            )}
+          </div>
+
+          {/* Branch Strategy */}
+          <div className="col-md-6">
+            <label className="form-label fw-semibold">{t('autoBranchStrategy', language)}</label>
+            <select
+              className="form-select"
+              value={branchStrategy}
+              onChange={(e) =>
+                setBranchStrategy(e.target.value as 'new-branch' | 'worktree' | 'current')
+              }
+            >
+              <option value="new-branch">{t('autoNewBranch', language)}</option>
+              <option value="worktree">{t('autoWorktree', language)}</option>
+              <option value="current">{t('autoCurrentBranch', language)}</option>
+            </select>
+          </div>
+          <div className="col-md-6">
+            <label className="form-label fw-semibold">{t('autoBranchName', language)}</label>
+            <input
+              type="text"
+              className="form-control"
+              placeholder={t('autoBranchNamePlaceholder', language)}
+              value={branchName}
+              onChange={(e) => setBranchName(e.target.value)}
+            />
+          </div>
+
+          {/* Review Rounds */}
+          <div className="col-md-6">
+            <label className="form-label fw-semibold">
+              {t('autoMaxPlanRounds', language)}: {maxPlanRounds}
+            </label>
+            <input
+              type="range"
+              className="form-range"
+              min={1}
+              max={5}
+              value={maxPlanRounds}
+              onChange={(e) => setMaxPlanRounds(parseInt(e.target.value))}
+            />
+          </div>
+          <div className="col-md-6">
+            <label className="form-label fw-semibold">
+              {t('autoMaxPRReviewRounds', language)}: {maxPRReviewRounds}
+            </label>
+            <input
+              type="range"
+              className="form-range"
+              min={1}
+              max={10}
+              value={maxPRReviewRounds}
+              onChange={(e) => setMaxPRReviewRounds(parseInt(e.target.value))}
+            />
+          </div>
+
+          {/* Auto Merge - only show for batch workflows (URL mode with multiple issues) */}
+          {requirementsMode === 'url' && requirementsUrl.trim() && (
+            <div className="col-12">
+              <div className="form-check">
+                <input
+                  type="checkbox"
+                  className="form-check-input"
+                  id="autoMerge"
+                  checked={autoMerge}
+                  onChange={(e) => setAutoMerge(e.target.checked)}
+                />
+                <label className="form-check-label" htmlFor="autoMerge">
+                  {t('autoMergeAfterPR', language) || 'Auto merge after PR created'}
+                </label>
+                <div className="form-text">
+                  {t('autoMergeHint', language) ||
+                    'Automatically merge PR and proceed to next workflow in batch'}
+                </div>
               </div>
             </div>
-          </div>
-        )}
-      </div>
-    </Modal>
+          )}
+        </div>
+      </Modal>
+
+      <LocalDirectoryBrowserModal
+        isOpen={showLocalDirectoryBrowser}
+        onClose={() => setShowLocalDirectoryBrowser(false)}
+        initialPath={projectPath}
+        onSelectPath={(path) => {
+          setProjectPath(path);
+          persistLastProjectPath(path, 'local');
+        }}
+      />
+
+      {selectedMachineId && (
+        <DirectoryBrowserModal
+          isOpen={showRemoteDirectoryBrowser}
+          onClose={() => setShowRemoteDirectoryBrowser(false)}
+          machineId={selectedMachineId}
+          initialPath={projectPath}
+          osType={selectedMachineOsType || undefined}
+          onSelectPath={(path) => {
+            setProjectPath(path);
+            persistLastProjectPath(path, 'remote', selectedMachineId);
+          }}
+        />
+      )}
+    </>
   );
 };

--- a/migrations/versions/20260605_050_add_autonomous_workflow_tables.py
+++ b/migrations/versions/20260605_050_add_autonomous_workflow_tables.py
@@ -83,6 +83,7 @@ def upgrade() -> None:
         sa.Column("updated_at", sa.TIMESTAMP),
         sa.Column("completed_at", sa.TIMESTAMP, nullable=True),
         sa.Column("paused_at", sa.TIMESTAMP, nullable=True),
+        sa.Column("transient_retry_count", sa.Integer, server_default="0"),
     )
     op.create_index(
         "idx_workflows_user_status",

--- a/tests/issues/1002/test_git_network_retry.py
+++ b/tests/issues/1002/test_git_network_retry.py
@@ -60,6 +60,11 @@ class TestIsTransientError:
         """Exit 0 (success) is never transient."""
         assert not _is_transient_error("LibreSSL", 0)
 
+    def test_rpc_failed_uppercase_is_transient(self):
+        """git outputs 'RPC failed' (uppercase) — _is_transient_error lowercases
+        stderr before matching, so the keyword must also be lowercase."""
+        assert _is_transient_error("fatal: the remote end hung up unexpectedly\nRPC failed", 128)
+
 
 # ── Layer 1: _run_git retry loop ─────────────────────────────────────────
 


### PR DESCRIPTION
## Two issues in #1127 found post-merge

### P1: Alembic migration missing transient_retry_count

`get_ddl_statements()` CREATE TABLE was updated with the new column, but the Alembic migration (`20260605_050_add_autonomous_workflow_tables.py`) was not. Environments that initialize via Alembic only would be missing the column — the first transient retry persistence would crash.

**Fix**: add `sa.Column("transient_retry_count", sa.Integer, server_default="0")` to the migration's `create_table`.

### P2: "RPC failed" keyword case mismatch

`_is_transient_error()` lowercases stderr before matching keywords, but the keyword list had `"RPC failed"` (uppercase). After lowercasing, `"rpc failed"` never matched `"RPC failed"` — git transport errors (RPC failed / early EOF, the most common large-clone failure) were silently not retried.

**Fix**: lowercase the keyword to `"rpc failed"`.

**New test**: `test_rpc_failed_uppercase_is_transient` — verifies the original uppercase git output ("RPC failed") matches after lowercasing.

18 tests pass.