### PR TITLE
feat(autonomous): improve project path selection

### DIFF
--- a/frontend/src/api/fs.ts
+++ b/frontend/src/api/fs.ts
@@ -33,6 +33,30 @@ export interface DirectoryEntry {
   is_writable: boolean;
 }
 
+interface LocalDirectoryEntryApi {
+  name: string;
+  path: string;
+  isWritable?: boolean;
+  isReadable?: boolean;
+}
+
+interface LocalBrowseResultApi {
+  currentPath?: string;
+  path?: string;
+  name?: string;
+  directories?: LocalDirectoryEntryApi[] | DirectoryEntry[];
+  parentPath?: string | null;
+  parent?: string | null;
+  homePath?: string;
+  canCreate?: boolean;
+  is_writable?: boolean;
+}
+
+interface LocalBrowseResponseApi extends LocalBrowseResultApi {
+  error?: string;
+  fallback?: LocalBrowseResultApi;
+}
+
 export interface CreateDirectoryRequest {
   path: string;
   system_account?: string;
@@ -51,14 +75,53 @@ export interface RemoteOperationResult<T = unknown> {
   error?: string;
 }
 
+function getPathName(path: string): string {
+  const normalized = path.replace(/[\\/]+$/, '');
+  if (!normalized) {
+    return '/';
+  }
+  const parts = normalized.split(/[/\\]/).filter(Boolean);
+  return parts[parts.length - 1] ?? normalized;
+}
+
+function normalizeDirectoryEntry(entry: LocalDirectoryEntryApi | DirectoryEntry): DirectoryEntry {
+  return {
+    name: entry.name,
+    path: entry.path,
+    is_writable:
+      'is_writable' in entry
+        ? Boolean(entry.is_writable)
+        : Boolean((entry as LocalDirectoryEntryApi).isWritable),
+  };
+}
+
+function normalizeBrowseResult(payload: LocalBrowseResponseApi): BrowseResult {
+  const source = payload.fallback ?? payload;
+  const path = source.path ?? source.currentPath ?? '';
+
+  return {
+    path,
+    name: source.name ?? getPathName(path),
+    directories: Array.isArray(source.directories)
+      ? source.directories.map(normalizeDirectoryEntry)
+      : [],
+    parent: source.parent ?? source.parentPath ?? null,
+    homePath: source.homePath ?? '',
+    canCreate: source.canCreate ?? source.is_writable ?? false,
+    is_writable: source.is_writable ?? source.canCreate ?? false,
+    fallback_note: payload.error && payload.fallback ? payload.error : undefined,
+  };
+}
+
 // ==================== API Methods ====================
 
 export const fsApi = {
   // Local file system browse
-  browseDirectory(path?: string): Promise<BrowseResult> {
+  async browseDirectory(path?: string): Promise<BrowseResult> {
     const params: Record<string, string> = {};
     if (path) params.path = path;
-    return apiClient.get('/api/fs/browse', params);
+    const response = await apiClient.get<LocalBrowseResponseApi>('/api/fs/browse', params);
+    return normalizeBrowseResult(response);
   },
 
   // Create directory (local)

--- a/frontend/src/components/work/LocalDirectoryBrowser.tsx
+++ b/frontend/src/components/work/LocalDirectoryBrowser.tsx
@@ -1,0 +1,368 @@
+/**
+ * LocalDirectoryBrowser Component - Browse directories on the local server
+ *
+ * Features:
+ * - Navigate local directory structure
+ * - Create new directories
+ * - Select directory as project path
+ * - Path history (saves recent paths to localStorage)
+ */
+
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import { useLanguage } from '@/store';
+import { t } from '@/i18n';
+import { fsApi, type DirectoryEntry } from '@/api/fs';
+import { Loading, Button, EmptyState } from '@/components/common';
+
+interface LocalDirectoryBrowserProps {
+  initialPath?: string;
+  onSelectPath: (path: string) => void;
+  onClose?: () => void;
+}
+
+const MAX_PATH_HISTORY = 5;
+const PATH_HISTORY_KEY = 'local-path-history';
+
+function isWindowsPath(path: string): boolean {
+  return /^[A-Za-z]:([\\/]|$)/.test(path);
+}
+
+export const LocalDirectoryBrowser: React.FC<LocalDirectoryBrowserProps> = ({
+  initialPath,
+  onSelectPath,
+  onClose,
+}) => {
+  const language = useLanguage();
+
+  const [currentPath, setCurrentPath] = useState(initialPath ?? '');
+  const [directories, setDirectories] = useState<DirectoryEntry[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [parentPath, setParentPath] = useState<string | null>(null);
+  const [isWritable, setIsWritable] = useState(false);
+  const [showCreateInput, setShowCreateInput] = useState(false);
+  const [newDirName, setNewDirName] = useState('');
+  const [isCreating, setIsCreating] = useState(false);
+  const [pathHistory, setPathHistory] = useState<string[]>([]);
+  const [fallbackNote, setFallbackNote] = useState<string | null>(null);
+
+  const isWindows = useMemo(() => {
+    const pathForDetection = currentPath !== '' ? currentPath : (initialPath ?? '');
+    return isWindowsPath(pathForDetection);
+  }, [currentPath, initialPath]);
+
+  const getPathSeparator = useCallback(() => (isWindows ? '\\' : '/'), [isWindows]);
+
+  const splitPath = useCallback((path: string): string[] => {
+    if (!path) return [];
+    const parts = path.split(/[\\/]/).filter(Boolean);
+    return parts;
+  }, []);
+
+  useEffect(() => {
+    const savedHistory = localStorage.getItem(PATH_HISTORY_KEY);
+    if (savedHistory) {
+      try {
+        const parsed = JSON.parse(savedHistory);
+        if (Array.isArray(parsed)) {
+          setPathHistory(parsed.slice(0, MAX_PATH_HISTORY));
+        }
+      } catch {
+        // Ignore parse errors
+      }
+    }
+  }, []);
+
+  const savePathToHistory = useCallback(
+    (path: string) => {
+      if (!path) return;
+      const newHistory = [path, ...pathHistory.filter((p) => p !== path)].slice(
+        0,
+        MAX_PATH_HISTORY
+      );
+      setPathHistory(newHistory);
+      localStorage.setItem(PATH_HISTORY_KEY, JSON.stringify(newHistory));
+    },
+    [pathHistory]
+  );
+
+  const fetchDirectories = useCallback(async (path?: string) => {
+    setIsLoading(true);
+    setError(null);
+    setFallbackNote(null);
+    try {
+      const result = await fsApi.browseDirectory(path);
+      setDirectories(result.directories);
+      setCurrentPath(result.path);
+      setParentPath(result.parent);
+      setIsWritable(result.is_writable);
+      if (result.fallback_note) {
+        setFallbackNote(result.fallback_note);
+      }
+    } catch (err) {
+      setError((err as Error)?.message || 'Failed to browse directory');
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void fetchDirectories(initialPath);
+  }, [initialPath, fetchDirectories]);
+
+  const handleNavigate = (dir: DirectoryEntry) => {
+    void fetchDirectories(dir.path);
+  };
+
+  const handleNavigateUp = () => {
+    if (parentPath) {
+      void fetchDirectories(parentPath);
+    }
+  };
+
+  const handleSelect = () => {
+    savePathToHistory(currentPath);
+    onSelectPath(currentPath);
+    if (onClose) onClose();
+  };
+
+  const handleCreateDirectory = async () => {
+    if (!newDirName.trim() || !isWritable || isCreating) return;
+
+    const separator = getPathSeparator();
+    const fullPath = currentPath
+      ? currentPath + (currentPath.endsWith(separator) ? '' : separator) + newDirName.trim()
+      : newDirName.trim();
+
+    setIsCreating(true);
+    setError(null);
+    setShowCreateInput(false);
+
+    try {
+      const result = await fsApi.createDirectory({ path: fullPath });
+      if (result.success) {
+        setNewDirName('');
+        await fetchDirectories(currentPath);
+      } else {
+        const fallback = t('createDirError', language) ?? 'Failed to create directory';
+        setError(result.error ?? fallback);
+      }
+    } catch (err) {
+      const fallback = t('createDirError', language) ?? 'Failed to create directory';
+      setError((err as Error)?.message ?? fallback);
+    } finally {
+      setIsCreating(false);
+    }
+  };
+
+  const handleSelectFromHistory = (path: string) => {
+    void fetchDirectories(path);
+  };
+
+  const getDisplayPath = useCallback(
+    (path: string) => {
+      if (!path) return isWindows ? 'C:\\' : '/';
+      const parts = splitPath(path);
+      if (parts.length === 0) return isWindows ? 'C:\\' : '/';
+      if (parts.length === 1 && parts[0].match(/^[A-Za-z]:$/)) {
+        return parts[0];
+      }
+      return parts[parts.length - 1];
+    },
+    [isWindows, splitPath]
+  );
+
+  const breadcrumbs = useMemo(() => {
+    if (!currentPath) return [];
+    const parts = splitPath(currentPath);
+    const crumbs: { name: string; path: string }[] = [];
+
+    if (isWindows) {
+      let accumulatedPath = '';
+      for (let i = 0; i < parts.length; i++) {
+        const part = parts[i];
+        if (i === 0 && part.match(/^[A-Za-z]:$/)) {
+          accumulatedPath = part + '\\';
+        } else {
+          accumulatedPath = accumulatedPath + (accumulatedPath.endsWith('\\') ? '' : '\\') + part;
+          crumbs.push({ name: part, path: accumulatedPath });
+        }
+      }
+    } else {
+      let accumulatedPath = '';
+      for (const part of parts) {
+        accumulatedPath += '/' + part;
+        crumbs.push({ name: part, path: accumulatedPath });
+      }
+    }
+
+    return crumbs;
+  }, [currentPath, isWindows, splitPath]);
+
+  return (
+    <div className="local-directory-browser">
+      {pathHistory.length > 0 && (
+        <div className="mb-2">
+          <label className="form-label small text-muted">
+            {t('recentPaths', language) || 'Recent Paths'}
+          </label>
+          <div className="d-flex gap-1 flex-wrap">
+            {pathHistory.map((path) => (
+              <button
+                key={path}
+                className="btn btn-sm btn-outline-secondary"
+                onClick={() => handleSelectFromHistory(path)}
+              >
+                {getDisplayPath(path)}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <div className="mb-2">
+        <div className="d-flex align-items-center gap-1 small">
+          {!isWindows && (
+            <button className="btn btn-link btn-sm p-0" onClick={() => void fetchDirectories('/')}>
+              /
+            </button>
+          )}
+          {breadcrumbs.map((crumb, index) => (
+            <React.Fragment key={crumb.path}>
+              {index > 0 && <span className="text-muted">{getPathSeparator()}</span>}
+              <button
+                className={`btn btn-link btn-sm p-0 ${
+                  index === breadcrumbs.length - 1 ? 'fw-bold' : ''
+                }`}
+                onClick={() => void fetchDirectories(crumb.path)}
+              >
+                {crumb.name}
+              </button>
+            </React.Fragment>
+          ))}
+        </div>
+      </div>
+
+      <div className="mb-2 d-flex gap-2">
+        {parentPath && (
+          <Button variant="outline-secondary" size="sm" onClick={handleNavigateUp}>
+            <i className="bi bi-arrow-up-circle me-1" />
+            {t('up', language) || 'Up'}
+          </Button>
+        )}
+        {isWritable && (
+          <Button
+            variant="outline-primary"
+            size="sm"
+            onClick={() => setShowCreateInput(!showCreateInput)}
+          >
+            <i className="bi bi-folder-plus me-1" />
+            {t('newFolder', language) || 'New Folder'}
+          </Button>
+        )}
+      </div>
+
+      {showCreateInput && (
+        <div className="mb-2">
+          <div className="input-group input-group-sm">
+            <input
+              type="text"
+              className="form-control"
+              value={newDirName}
+              onChange={(e) => setNewDirName(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') void handleCreateDirectory();
+              }}
+              placeholder={t('folderName', language) || 'Folder name'}
+            />
+            <Button
+              variant="primary"
+              size="sm"
+              onClick={() => void handleCreateDirectory()}
+              disabled={isCreating}
+            >
+              {t('create', language)}
+            </Button>
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => {
+                setShowCreateInput(false);
+                setNewDirName('');
+              }}
+            >
+              {t('cancel', language)}
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {error && (
+        <div className="alert alert-danger small mb-2">
+          <i className="bi bi-exclamation-triangle me-1" />
+          {error}
+        </div>
+      )}
+
+      {fallbackNote && (
+        <div className="alert alert-info small mb-2">
+          <i className="bi bi-info-circle me-1" />
+          {fallbackNote}
+        </div>
+      )}
+
+      <div className="directory-list" style={{ maxHeight: '300px', overflow: 'auto' }}>
+        {isLoading ? (
+          <Loading size="sm" text={t('loading', language)} />
+        ) : directories.length === 0 ? (
+          <EmptyState
+            icon="bi-folder"
+            title={t('emptyDirectory', language) || 'Empty Directory'}
+            description={t('noSubdirectories', language) || 'No subdirectories found'}
+          />
+        ) : (
+          <ul className="list-group">
+            {directories.map((dir) => (
+              <li
+                key={dir.path}
+                className="list-group-item list-group-item-action d-flex justify-content-between align-items-center"
+                onClick={() => handleNavigate(dir)}
+                style={{ cursor: 'pointer' }}
+              >
+                <div>
+                  <i className="bi bi-folder me-2" />
+                  <span>{dir.name}</span>
+                </div>
+                {dir.is_writable && (
+                  <span className="badge bg-success-subtle text-success small">
+                    <i className="bi bi-pencil me-1" />
+                    {t('writable', language) || 'Writable'}
+                  </span>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <div className="mt-3">
+        <label className="form-label small text-muted">
+          {t('currentPath', language) || 'Current Path'}
+        </label>
+        <div className="input-group">
+          <input
+            type="text"
+            className="form-control"
+            value={currentPath}
+            onChange={(e) => setCurrentPath(e.target.value)}
+            placeholder="/path/to/project"
+          />
+          <Button variant="primary" onClick={handleSelect}>
+            <i className="bi bi-check-lg me-1" />
+            {t('select', language) || 'Select'}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/work/LocalDirectoryBrowserModal.tsx
+++ b/frontend/src/components/work/LocalDirectoryBrowserModal.tsx
@@ -1,0 +1,43 @@
+/**
+ * LocalDirectoryBrowserModal Component - Modal wrapper for LocalDirectoryBrowser
+ */
+
+import React from 'react';
+import { Modal } from '@/components/common';
+import { useLanguage } from '@/store';
+import { t } from '@/i18n';
+import { LocalDirectoryBrowser } from './LocalDirectoryBrowser';
+
+interface LocalDirectoryBrowserModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  initialPath?: string;
+  onSelectPath: (path: string) => void;
+}
+
+export const LocalDirectoryBrowserModal: React.FC<LocalDirectoryBrowserModalProps> = ({
+  isOpen,
+  onClose,
+  initialPath,
+  onSelectPath,
+}) => {
+  const language = useLanguage();
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={t('browseDirectory', language) || 'Browse Directory'}
+      size="lg"
+    >
+      <LocalDirectoryBrowser
+        initialPath={initialPath}
+        onSelectPath={(path) => {
+          onSelectPath(path);
+          onClose();
+        }}
+        onClose={onClose}
+      />
+    </Modal>
+  );
+};

--- a/frontend/src/components/work/NewAutonomousModal.test.tsx
+++ b/frontend/src/components/work/NewAutonomousModal.test.tsx
@@ -1,0 +1,293 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+const mutateAsyncMock = vi.fn();
+
+vi.mock('@/store', () => ({
+  useLanguage: () => 'en',
+}));
+
+vi.mock('@/i18n', () => ({
+  t: (key: string) => key,
+}));
+
+vi.mock('@/hooks/useAutonomous', () => ({
+  useCreateWorkflow: () => ({
+    mutateAsync: mutateAsyncMock,
+    isPending: false,
+  }),
+  useAvailableTools: () => ({
+    data: {
+      tools: [
+        { id: 'claude-code', name: 'Claude Code' },
+        { id: 'zcode', name: 'ZCode' },
+      ],
+    },
+  }),
+  useAvailableModels: () => ({
+    data: {
+      models: [],
+    },
+  }),
+}));
+
+vi.mock('@/components/common', () => ({
+  Modal: ({ isOpen, title, footer, children }: any) =>
+    isOpen ? (
+      <div data-testid="modal">
+        <h5>{title}</h5>
+        {children}
+        <div>{footer}</div>
+      </div>
+    ) : null,
+  Button: ({ onClick, disabled, children, variant }: any) => (
+    <button onClick={onClick} disabled={disabled} data-testid={`btn-${variant ?? 'primary'}`}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock('./RemoteMachineSelector', () => ({
+  RemoteMachineSelector: ({ onSelectMachine, selectedMachineId }: any) => (
+    <div data-testid="remote-machine-selector" data-selected-machine={selectedMachineId}>
+      <button
+        data-testid="select-remote-machine-1"
+        onClick={() =>
+          onSelectMachine('machine-1', {
+            machine_id: 'machine-1',
+            machine_name: 'Windows Box',
+            os_type: 'windows',
+            work_dir: 'C:\\workspace',
+          })
+        }
+      >
+        Select Machine 1
+      </button>
+      <button
+        data-testid="select-remote-machine-2"
+        onClick={() =>
+          onSelectMachine('machine-2', {
+            machine_id: 'machine-2',
+            machine_name: 'Linux Box',
+            os_type: 'linux',
+            work_dir: '/srv/workspace',
+          })
+        }
+      >
+        Select Machine 2
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock('./LocalDirectoryBrowserModal', () => ({
+  LocalDirectoryBrowserModal: ({ isOpen, onSelectPath }: any) =>
+    isOpen ? (
+      <div data-testid="local-directory-browser-modal">
+        <button onClick={() => onSelectPath('/Users/test/project')}>Choose Local Path</button>
+      </div>
+    ) : null,
+}));
+
+vi.mock('./DirectoryBrowserModal', () => ({
+  DirectoryBrowserModal: ({ isOpen, osType, onSelectPath }: any) =>
+    isOpen ? (
+      <div data-testid="remote-directory-browser-modal">
+        <span data-testid="remote-os-type">{osType}</span>
+        <button onClick={() => onSelectPath('C:\\workspace\\repo')}>Choose Remote Path</button>
+      </div>
+    ) : null,
+}));
+
+import { NewAutonomousModal } from './NewAutonomousModal';
+
+describe('NewAutonomousModal', () => {
+  const defaultProps = {
+    show: true,
+    onClose: vi.fn(),
+    onCreated: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    mutateAsyncMock.mockResolvedValue({ workflow: { id: 'wf-1' } });
+  });
+
+  it('shows a browse button for local project paths', () => {
+    render(<NewAutonomousModal {...defaultProps} />);
+
+    expect(screen.getByText('browse')).toBeInTheDocument();
+  });
+
+  it('uses updated default branch and review round values', () => {
+    render(<NewAutonomousModal {...defaultProps} />);
+
+    const selects = screen.getAllByRole('combobox');
+    const sliders = screen.getAllByRole('slider');
+
+    expect(selects[2]).toHaveValue('worktree');
+    expect(sliders[0]).toHaveValue('2');
+    expect(sliders[1]).toHaveValue('3');
+    expect(screen.getByText('autoMaxPlanRounds: 2')).toBeInTheDocument();
+    expect(screen.getByText('autoMaxPRReviewRounds: 3')).toBeInTheDocument();
+  });
+
+  it('opens local directory browser and updates the project path', () => {
+    render(<NewAutonomousModal {...defaultProps} />);
+
+    fireEvent.click(screen.getByText('browse'));
+    expect(screen.getByTestId('local-directory-browser-modal')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Choose Local Path'));
+    expect(screen.getByPlaceholderText('autoProjectPathPlaceholder')).toHaveValue(
+      '/Users/test/project'
+    );
+    expect(localStorage.getItem('local-last-project-path')).toBe('/Users/test/project');
+  });
+
+  it('prefills local project path from the last confirmed selection when reopened', () => {
+    localStorage.setItem('local-last-project-path', '/Users/saved/project');
+
+    const { rerender } = render(<NewAutonomousModal {...defaultProps} show={false} />);
+    rerender(<NewAutonomousModal {...defaultProps} show={true} />);
+
+    expect(screen.getByPlaceholderText('autoProjectPathPlaceholder')).toHaveValue(
+      '/Users/saved/project'
+    );
+  });
+
+  it('does not overwrite remembered local path with an unconfirmed manual input', () => {
+    localStorage.setItem('local-last-project-path', '/Users/saved/project');
+
+    render(<NewAutonomousModal {...defaultProps} />);
+
+    const input = screen.getByPlaceholderText('autoProjectPathPlaceholder');
+    fireEvent.change(input, { target: { value: '/Users/typing/project' } });
+
+    expect(localStorage.getItem('local-last-project-path')).toBe('/Users/saved/project');
+  });
+
+  it('saves the final local path after successful task creation', async () => {
+    render(<NewAutonomousModal {...defaultProps} />);
+
+    fireEvent.change(screen.getByPlaceholderText('autoRequirementsPlaceholder'), {
+      target: { value: 'Build a feature' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('autoProjectPathPlaceholder'), {
+      target: { value: '/Users/final/project' },
+    });
+
+    fireEvent.click(screen.getByText('autoCreateTask'));
+
+    await waitFor(() => {
+      expect(mutateAsyncMock).toHaveBeenCalledTimes(1);
+    });
+    expect(localStorage.getItem('local-last-project-path')).toBe('/Users/final/project');
+  });
+
+  it('disables remote browse until a machine is selected', () => {
+    render(<NewAutonomousModal {...defaultProps} />);
+
+    fireEvent.click(screen.getByText('autoRemoteWorkspace'));
+    expect(screen.getByText('browse')).toBeDisabled();
+  });
+
+  it('opens remote directory browser after machine selection', () => {
+    render(<NewAutonomousModal {...defaultProps} />);
+
+    fireEvent.click(screen.getByText('autoRemoteWorkspace'));
+    fireEvent.click(screen.getByTestId('select-remote-machine-1'));
+
+    const browseButton = screen.getByText('browse');
+    expect(browseButton).not.toBeDisabled();
+
+    fireEvent.click(browseButton);
+    expect(screen.getByTestId('remote-directory-browser-modal')).toBeInTheDocument();
+    expect(screen.getByTestId('remote-os-type')).toHaveTextContent('windows');
+
+    fireEvent.click(screen.getByText('Choose Remote Path'));
+    expect(screen.getByPlaceholderText('autoProjectPathPlaceholder')).toHaveValue(
+      'C:\\workspace\\repo'
+    );
+    expect(localStorage.getItem('remote-last-project-path-machine-1')).toBe('C:\\workspace\\repo');
+  });
+
+  it('prefills remote project path from the last confirmed machine-specific selection', () => {
+    localStorage.setItem('remote-last-project-path-machine-1', 'C:\\saved\\repo');
+
+    render(<NewAutonomousModal {...defaultProps} />);
+
+    fireEvent.click(screen.getByText('autoRemoteWorkspace'));
+    fireEvent.click(screen.getByTestId('select-remote-machine-1'));
+
+    expect(screen.getByPlaceholderText('autoProjectPathPlaceholder')).toHaveValue(
+      'C:\\saved\\repo'
+    );
+  });
+
+  it('falls back to machine work_dir when the remote machine has no remembered path', () => {
+    render(<NewAutonomousModal {...defaultProps} />);
+
+    fireEvent.click(screen.getByText('autoRemoteWorkspace'));
+    fireEvent.click(screen.getByTestId('select-remote-machine-2'));
+
+    expect(screen.getByPlaceholderText('autoProjectPathPlaceholder')).toHaveValue('/srv/workspace');
+  });
+
+  it('does not replace a non-empty current path when switching to another remote machine', () => {
+    render(<NewAutonomousModal {...defaultProps} />);
+
+    fireEvent.click(screen.getByText('autoRemoteWorkspace'));
+    fireEvent.click(screen.getByTestId('select-remote-machine-1'));
+    fireEvent.change(screen.getByPlaceholderText('autoProjectPathPlaceholder'), {
+      target: { value: 'C:\\custom\\repo' },
+    });
+
+    fireEvent.click(screen.getByTestId('select-remote-machine-2'));
+
+    expect(screen.getByPlaceholderText('autoProjectPathPlaceholder')).toHaveValue(
+      'C:\\custom\\repo'
+    );
+  });
+
+  it('saves the final remote path after successful task creation', async () => {
+    render(<NewAutonomousModal {...defaultProps} />);
+
+    fireEvent.click(screen.getByText('autoRemoteWorkspace'));
+    fireEvent.click(screen.getByTestId('select-remote-machine-1'));
+    fireEvent.change(screen.getByPlaceholderText('autoRequirementsPlaceholder'), {
+      target: { value: 'Build a remote feature' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('autoProjectPathPlaceholder'), {
+      target: { value: 'C:\\final\\repo' },
+    });
+
+    fireEvent.click(screen.getByText('autoCreateTask'));
+
+    await waitFor(() => {
+      expect(mutateAsyncMock).toHaveBeenCalledTimes(1);
+    });
+    expect(localStorage.getItem('remote-last-project-path-machine-1')).toBe('C:\\final\\repo');
+  });
+
+  it('does not persist path memory in new project mode', async () => {
+    render(<NewAutonomousModal {...defaultProps} />);
+
+    fireEvent.click(screen.getByLabelText('autoNewProject'));
+    fireEvent.change(screen.getByPlaceholderText('autoRequirementsPlaceholder'), {
+      target: { value: 'Create a new repo' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('autoRepoNamePlaceholder'), {
+      target: { value: 'my-new-project' },
+    });
+
+    fireEvent.click(screen.getByText('autoCreateTask'));
+
+    await waitFor(() => {
+      expect(mutateAsyncMock).toHaveBeenCalledTimes(1);
+    });
+    expect(localStorage.getItem('local-last-project-path')).toBeNull();
+  });
+});

--- a/frontend/src/components/work/NewAutonomousModal.test.tsx
+++ b/frontend/src/components/work/NewAutonomousModal.test.tsx
@@ -236,7 +236,23 @@ describe('NewAutonomousModal', () => {
     expect(screen.getByPlaceholderText('autoProjectPathPlaceholder')).toHaveValue('/srv/workspace');
   });
 
-  it('does not replace a non-empty current path when switching to another remote machine', () => {
+  it('replaces the current path when switching to another remote machine', () => {
+    render(<NewAutonomousModal {...defaultProps} />);
+
+    fireEvent.click(screen.getByText('autoRemoteWorkspace'));
+    fireEvent.click(screen.getByTestId('select-remote-machine-1'));
+    fireEvent.change(screen.getByPlaceholderText('autoProjectPathPlaceholder'), {
+      target: { value: 'C:\\custom\\repo' },
+    });
+
+    fireEvent.click(screen.getByTestId('select-remote-machine-2'));
+
+    expect(screen.getByPlaceholderText('autoProjectPathPlaceholder')).toHaveValue('/srv/workspace');
+  });
+
+  it('uses the new machine remembered path when switching remote machines', () => {
+    localStorage.setItem('remote-last-project-path-machine-2', '/saved/machine-2-repo');
+
     render(<NewAutonomousModal {...defaultProps} />);
 
     fireEvent.click(screen.getByText('autoRemoteWorkspace'));
@@ -248,7 +264,7 @@ describe('NewAutonomousModal', () => {
     fireEvent.click(screen.getByTestId('select-remote-machine-2'));
 
     expect(screen.getByPlaceholderText('autoProjectPathPlaceholder')).toHaveValue(
-      'C:\\custom\\repo'
+      '/saved/machine-2-repo'
     );
   });
 

--- a/frontend/src/components/work/NewAutonomousModal.test.tsx
+++ b/frontend/src/components/work/NewAutonomousModal.test.tsx
@@ -268,6 +268,22 @@ describe('NewAutonomousModal', () => {
     );
   });
 
+  it('preserves the current path when re-selecting the same remote machine', () => {
+    render(<NewAutonomousModal {...defaultProps} />);
+
+    fireEvent.click(screen.getByText('autoRemoteWorkspace'));
+    fireEvent.click(screen.getByTestId('select-remote-machine-1'));
+    fireEvent.change(screen.getByPlaceholderText('autoProjectPathPlaceholder'), {
+      target: { value: 'C:\\custom\\repo' },
+    });
+
+    fireEvent.click(screen.getByTestId('select-remote-machine-1'));
+
+    expect(screen.getByPlaceholderText('autoProjectPathPlaceholder')).toHaveValue(
+      'C:\\custom\\repo'
+    );
+  });
+
   it('saves the final remote path after successful task creation', async () => {
     render(<NewAutonomousModal {...defaultProps} />);
 

--- a/frontend/src/components/work/NewAutonomousModal.tsx
+++ b/frontend/src/components/work/NewAutonomousModal.tsx
@@ -113,7 +113,7 @@ export const NewAutonomousModal: React.FC<NewAutonomousModalProps> = ({
   }, [show, isNewProject, workspaceType, projectPath]);
 
   useEffect(() => {
-    if (!show || isNewProject || workspaceType !== 'remote' || !selectedMachineId || projectPath) {
+    if (!show || isNewProject || workspaceType !== 'remote' || !selectedMachineId) {
       return;
     }
 
@@ -126,7 +126,7 @@ export const NewAutonomousModal: React.FC<NewAutonomousModalProps> = ({
     if (selectedMachineWorkDir) {
       setProjectPath(selectedMachineWorkDir);
     }
-  }, [show, isNewProject, workspaceType, selectedMachineId, selectedMachineWorkDir, projectPath]);
+  }, [show, isNewProject, workspaceType, selectedMachineId, selectedMachineWorkDir]);
 
   const canSubmit = useMemo(() => {
     const hasRequirements =

--- a/frontend/src/components/work/NewAutonomousModal.tsx
+++ b/frontend/src/components/work/NewAutonomousModal.tsx
@@ -384,6 +384,9 @@ export const NewAutonomousModal: React.FC<NewAutonomousModalProps> = ({
               <RemoteMachineSelector
                 selectedMachineId={selectedMachineId}
                 onSelectMachine={(machineId, machine) => {
+                  if (selectedMachineId !== machineId) {
+                    setProjectPath('');
+                  }
                   setSelectedMachineId(machineId);
                   setSelectedMachineOsType(machine?.os_type ?? '');
                   setSelectedMachineWorkDir(machine?.work_dir ?? '');

--- a/frontend/src/components/work/NewAutonomousModal.tsx
+++ b/frontend/src/components/work/NewAutonomousModal.tsx
@@ -2,11 +2,13 @@
  * NewAutonomousModal Component - Modal for creating a new autonomous development workflow
  */
 
-import React, { useState, useMemo, useCallback } from 'react';
+import React, { useState, useMemo, useCallback, useEffect } from 'react';
 import { useLanguage } from '@/store';
 import { t } from '@/i18n';
 import { Modal, Button } from '@/components/common';
 import { RemoteMachineSelector } from './RemoteMachineSelector';
+import { DirectoryBrowserModal } from './DirectoryBrowserModal';
+import { LocalDirectoryBrowserModal } from './LocalDirectoryBrowserModal';
 import { useCreateWorkflow, useAvailableTools, useAvailableModels } from '@/hooks/useAutonomous';
 import type { AutonomousWorkflow, CreateWorkflowRequest } from '@/api/autonomous';
 
@@ -14,6 +16,28 @@ interface NewAutonomousModalProps {
   show: boolean;
   onClose: () => void;
   onCreated: (workflow: AutonomousWorkflow) => void;
+}
+
+const LOCAL_LAST_PROJECT_PATH_KEY = 'local-last-project-path';
+
+function getRemoteLastProjectPathKey(machineId: string): string {
+  return `remote-last-project-path-${machineId}`;
+}
+
+function getStoredPath(key: string): string {
+  try {
+    return localStorage.getItem(key) ?? '';
+  } catch {
+    return '';
+  }
+}
+
+function setStoredPath(key: string, path: string): void {
+  try {
+    localStorage.setItem(key, path);
+  } catch {
+    // Ignore localStorage write failures
+  }
 }
 
 export const NewAutonomousModal: React.FC<NewAutonomousModalProps> = ({
@@ -31,16 +55,20 @@ export const NewAutonomousModal: React.FC<NewAutonomousModalProps> = ({
   const [model, setModel] = useState('');
   const [workspaceType, setWorkspaceType] = useState<'local' | 'remote'>('local');
   const [selectedMachineId, setSelectedMachineId] = useState('');
+  const [selectedMachineOsType, setSelectedMachineOsType] = useState('');
+  const [selectedMachineWorkDir, setSelectedMachineWorkDir] = useState('');
   const [projectPath, setProjectPath] = useState('');
   const [isNewProject, setIsNewProject] = useState(false);
+  const [showLocalDirectoryBrowser, setShowLocalDirectoryBrowser] = useState(false);
+  const [showRemoteDirectoryBrowser, setShowRemoteDirectoryBrowser] = useState(false);
   const [repoName, setRepoName] = useState('');
   const [isPrivate, setIsPrivate] = useState(true);
   const [branchStrategy, setBranchStrategy] = useState<'new-branch' | 'worktree' | 'current'>(
-    'new-branch'
+    'worktree'
   );
   const [branchName, setBranchName] = useState('');
-  const [maxPlanRounds, setMaxPlanRounds] = useState(3);
-  const [maxPRReviewRounds, setMaxPRReviewRounds] = useState(5);
+  const [maxPlanRounds, setMaxPlanRounds] = useState(2);
+  const [maxPRReviewRounds, setMaxPRReviewRounds] = useState(3);
   const [title, setTitle] = useState('');
   const [autoMerge, setAutoMerge] = useState(true); // Auto merge for batch workflows
   const [errorMessage, setErrorMessage] = useState('');
@@ -56,6 +84,49 @@ export const NewAutonomousModal: React.FC<NewAutonomousModalProps> = ({
   const tools = toolsData?.tools ?? [];
   const models = modelsData?.models ?? [];
   const isCreating = createWorkflow.isPending;
+
+  const persistLastProjectPath = useCallback(
+    (path: string, type: 'local' | 'remote', machineId?: string) => {
+      const normalizedPath = path.trim();
+      if (!normalizedPath) return;
+
+      if (type === 'remote') {
+        if (!machineId) return;
+        setStoredPath(getRemoteLastProjectPathKey(machineId), normalizedPath);
+        return;
+      }
+
+      setStoredPath(LOCAL_LAST_PROJECT_PATH_KEY, normalizedPath);
+    },
+    []
+  );
+
+  useEffect(() => {
+    if (!show || isNewProject || workspaceType !== 'local' || projectPath) {
+      return;
+    }
+
+    const storedPath = getStoredPath(LOCAL_LAST_PROJECT_PATH_KEY);
+    if (storedPath) {
+      setProjectPath(storedPath);
+    }
+  }, [show, isNewProject, workspaceType, projectPath]);
+
+  useEffect(() => {
+    if (!show || isNewProject || workspaceType !== 'remote' || !selectedMachineId || projectPath) {
+      return;
+    }
+
+    const storedPath = getStoredPath(getRemoteLastProjectPathKey(selectedMachineId));
+    if (storedPath) {
+      setProjectPath(storedPath);
+      return;
+    }
+
+    if (selectedMachineWorkDir) {
+      setProjectPath(selectedMachineWorkDir);
+    }
+  }, [show, isNewProject, workspaceType, selectedMachineId, selectedMachineWorkDir, projectPath]);
 
   const canSubmit = useMemo(() => {
     const hasRequirements =
@@ -76,6 +147,7 @@ export const NewAutonomousModal: React.FC<NewAutonomousModalProps> = ({
   ]);
 
   const handleSubmit = useCallback(async () => {
+    const confirmedProjectPath = isNewProject ? '' : projectPath.trim();
     const data: CreateWorkflowRequest = {
       title: title || undefined,
       requirements_text: requirementsMode === 'text' ? requirementsText : undefined,
@@ -99,6 +171,9 @@ export const NewAutonomousModal: React.FC<NewAutonomousModalProps> = ({
     try {
       setErrorMessage('');
       const result = await createWorkflow.mutateAsync(data);
+      if (confirmedProjectPath) {
+        persistLastProjectPath(confirmedProjectPath, workspaceType, selectedMachineId);
+      }
       if (result.workflow) {
         onCreated(result.workflow);
       }
@@ -121,322 +196,370 @@ export const NewAutonomousModal: React.FC<NewAutonomousModalProps> = ({
     projectPath,
     isNewProject,
     repoName,
+    isPrivate,
     branchStrategy,
     branchName,
     maxPlanRounds,
     maxPRReviewRounds,
     autoMerge,
     createWorkflow,
+    language,
     onCreated,
+    persistLastProjectPath,
   ]);
 
   return (
-    <Modal
-      isOpen={show}
-      onClose={onClose}
-      title={t('newAutonomousTask', language)}
-      size="lg"
-      footer={
-        <>
-          <Button variant="secondary" onClick={onClose}>
-            {t('cancel', language)}
-          </Button>
-          <Button onClick={handleSubmit} disabled={!canSubmit || isCreating}>
-            {isCreating ? (
-              <>
-                <span className="spinner-border spinner-border-sm me-1" role="status"></span>
-                {t('autoCreating', language)}
-              </>
-            ) : (
-              t('autoCreateTask', language)
-            )}
-          </Button>
-        </>
-      }
-    >
-      <div className="row g-3">
-        {/* Error Alert */}
-        {errorMessage && (
-          <div className="col-12">
-            <div className="alert alert-danger d-flex align-items-center" role="alert">
-              <i className="bi bi-exclamation-triangle-fill me-2"></i>
-              {errorMessage}
-            </div>
-          </div>
-        )}
-
-        {/* Title */}
-        <div className="col-12">
-          <label className="form-label fw-semibold">{t('autoTaskTitle', language)}</label>
-          <input
-            type="text"
-            className="form-control"
-            placeholder={t('autoTaskTitlePlaceholder', language)}
-            value={title}
-            onChange={(e) => setTitle(e.target.value)}
-          />
-        </div>
-
-        {/* Requirements */}
-        <div className="col-12">
-          <label className="form-label fw-semibold">
-            {t('autoRequirements', language)} <span className="text-danger">*</span>
-          </label>
-          <div className="btn-group btn-group-sm mb-2" role="group">
-            <button
-              type="button"
-              className={`btn btn-outline-primary ${requirementsMode === 'text' ? 'active' : ''}`}
-              onClick={() => setRequirementsMode('text')}
-            >
-              {t('autoTextDescription', language)}
-            </button>
-            <button
-              type="button"
-              className={`btn btn-outline-primary ${requirementsMode === 'url' ? 'active' : ''}`}
-              onClick={() => setRequirementsMode('url')}
-            >
-              {t('autoGithubIssue', language)}
-            </button>
-          </div>
-          {requirementsMode === 'text' ? (
-            <textarea
-              className="form-control"
-              rows={4}
-              placeholder={t('autoRequirementsPlaceholder', language)}
-              value={requirementsText}
-              onChange={(e) => setRequirementsText(e.target.value)}
-            />
-          ) : (
-            <>
-              <textarea
-                className="form-control"
-                rows={3}
-                placeholder={
-                  t('autoIssueInputPlaceholder', language) ||
-                  '123 125,128-130 or https://github.com/owner/repo/issues/123'
-                }
-                value={requirementsUrl}
-                onChange={(e) => setRequirementsUrl(e.target.value)}
-              />
-              <div className="form-text">
-                {t('autoIssueInputHint', language) ||
-                  'Supports commas, spaces, new lines, ranges like 12-15, and mixed GitHub issue URLs.'}
+    <>
+      <Modal
+        isOpen={show}
+        onClose={onClose}
+        title={t('newAutonomousTask', language)}
+        size="lg"
+        footer={
+          <>
+            <Button variant="secondary" onClick={onClose}>
+              {t('cancel', language)}
+            </Button>
+            <Button onClick={handleSubmit} disabled={!canSubmit || isCreating}>
+              {isCreating ? (
+                <>
+                  <span className="spinner-border spinner-border-sm me-1" role="status"></span>
+                  {t('autoCreating', language)}
+                </>
+              ) : (
+                t('autoCreateTask', language)
+              )}
+            </Button>
+          </>
+        }
+      >
+        <div className="row g-3">
+          {/* Error Alert */}
+          {errorMessage && (
+            <div className="col-12">
+              <div className="alert alert-danger d-flex align-items-center" role="alert">
+                <i className="bi bi-exclamation-triangle-fill me-2"></i>
+                {errorMessage}
               </div>
-            </>
+            </div>
           )}
-        </div>
 
-        {/* Agent Tool & Model */}
-        <div className="col-md-6">
-          <label className="form-label fw-semibold">
-            {t('autoAgentTool', language)} <span className="text-danger">*</span>
-          </label>
-          <select
-            className="form-select"
-            value={cliTool}
-            onChange={(e) => {
-              setCliTool(e.target.value);
-              setModel('');
-            }}
-          >
-            {tools.length > 0 ? (
-              tools.map((tool) => (
-                <option key={tool.id} value={tool.id}>
-                  {tool.name}
-                </option>
-              ))
-            ) : (
-              <>
-                <option value="claude-code">Claude Code</option>
-                <option value="qwen-code-cli">Qwen Code</option>
-                <option value="codex">Codex CLI</option>
-                <option value="openclaw">OpenClaw</option>
-                <option value="zcode">ZCode</option>
-              </>
-            )}
-          </select>
-        </div>
-        <div className="col-md-6">
-          <label className="form-label fw-semibold">{t('autoModel', language)}</label>
-          <select className="form-select" value={model} onChange={(e) => setModel(e.target.value)}>
-            <option value="">{t('autoDefaultModel', language)}</option>
-            {Array.isArray(models) &&
-              models.map((m: { name: string }) => (
-                <option key={m.name} value={m.name}>
-                  {m.name}
-                </option>
-              ))}
-          </select>
-        </div>
-
-        {/* Workspace Type */}
-        <div className="col-12">
-          <label className="form-label fw-semibold">{t('autoWorkspaceType', language)}</label>
-          <div className="btn-group w-100" role="group">
-            <button
-              type="button"
-              className={`btn btn-outline-primary ${workspaceType === 'local' ? 'active' : ''}`}
-              onClick={() => setWorkspaceType('local')}
-            >
-              <i className="bi bi-laptop me-1"></i>
-              {t('autoLocalWorkspace', language)}
-            </button>
-            <button
-              type="button"
-              className={`btn btn-outline-primary ${workspaceType === 'remote' ? 'active' : ''}`}
-              onClick={() => setWorkspaceType('remote')}
-            >
-              <i className="bi bi-cloud me-1"></i>
-              {t('autoRemoteWorkspace', language)}
-            </button>
-          </div>
-        </div>
-
-        {/* Remote Machine */}
-        {workspaceType === 'remote' && (
+          {/* Title */}
           <div className="col-12">
-            <label className="form-label fw-semibold">
-              {t('autoRemoteMachine', language)} <span className="text-danger">*</span>
-            </label>
-            <RemoteMachineSelector
-              selectedMachineId={selectedMachineId}
-              onSelectMachine={(machineId, machine) => {
-                setSelectedMachineId(machineId);
-                if (machine?.work_dir && !projectPath) {
-                  setProjectPath(machine.work_dir);
-                }
-              }}
-            />
-          </div>
-        )}
-
-        {/* Project Path */}
-        <div className="col-12">
-          <div className="form-check mb-2">
-            <input
-              type="checkbox"
-              className="form-check-input"
-              id="isNewProject"
-              checked={isNewProject}
-              onChange={(e) => setIsNewProject(e.target.checked)}
-            />
-            <label className="form-check-label" htmlFor="isNewProject">
-              {t('autoNewProject', language)}
-            </label>
-          </div>
-          {isNewProject ? (
-            <div className="row g-2">
-              <div className="col-md-8">
-                <input
-                  type="text"
-                  className="form-control"
-                  placeholder={t('autoRepoNamePlaceholder', language)}
-                  value={repoName}
-                  onChange={(e) => setRepoName(e.target.value)}
-                />
-              </div>
-              <div className="col-md-4">
-                <div className="form-check">
-                  <input
-                    type="checkbox"
-                    className="form-check-input"
-                    id="isPrivate"
-                    checked={isPrivate}
-                    onChange={(e) => setIsPrivate(e.target.checked)}
-                  />
-                  <label className="form-check-label" htmlFor="isPrivate">
-                    {t('autoPrivateRepo', language)}
-                  </label>
-                </div>
-              </div>
-            </div>
-          ) : (
+            <label className="form-label fw-semibold">{t('autoTaskTitle', language)}</label>
             <input
               type="text"
               className="form-control"
-              placeholder={t('autoProjectPathPlaceholder', language)}
-              value={projectPath}
-              onChange={(e) => setProjectPath(e.target.value)}
+              placeholder={t('autoTaskTitlePlaceholder', language)}
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
             />
-          )}
-        </div>
+          </div>
 
-        {/* Branch Strategy */}
-        <div className="col-md-6">
-          <label className="form-label fw-semibold">{t('autoBranchStrategy', language)}</label>
-          <select
-            className="form-select"
-            value={branchStrategy}
-            onChange={(e) =>
-              setBranchStrategy(e.target.value as 'new-branch' | 'worktree' | 'current')
-            }
-          >
-            <option value="new-branch">{t('autoNewBranch', language)}</option>
-            <option value="worktree">{t('autoWorktree', language)}</option>
-            <option value="current">{t('autoCurrentBranch', language)}</option>
-          </select>
-        </div>
-        <div className="col-md-6">
-          <label className="form-label fw-semibold">{t('autoBranchName', language)}</label>
-          <input
-            type="text"
-            className="form-control"
-            placeholder={t('autoBranchNamePlaceholder', language)}
-            value={branchName}
-            onChange={(e) => setBranchName(e.target.value)}
-          />
-        </div>
-
-        {/* Review Rounds */}
-        <div className="col-md-6">
-          <label className="form-label fw-semibold">
-            {t('autoMaxPlanRounds', language)}: {maxPlanRounds}
-          </label>
-          <input
-            type="range"
-            className="form-range"
-            min={1}
-            max={5}
-            value={maxPlanRounds}
-            onChange={(e) => setMaxPlanRounds(parseInt(e.target.value))}
-          />
-        </div>
-        <div className="col-md-6">
-          <label className="form-label fw-semibold">
-            {t('autoMaxPRReviewRounds', language)}: {maxPRReviewRounds}
-          </label>
-          <input
-            type="range"
-            className="form-range"
-            min={1}
-            max={10}
-            value={maxPRReviewRounds}
-            onChange={(e) => setMaxPRReviewRounds(parseInt(e.target.value))}
-          />
-        </div>
-
-        {/* Auto Merge - only show for batch workflows (URL mode with multiple issues) */}
-        {requirementsMode === 'url' && requirementsUrl.trim() && (
+          {/* Requirements */}
           <div className="col-12">
-            <div className="form-check">
+            <label className="form-label fw-semibold">
+              {t('autoRequirements', language)} <span className="text-danger">*</span>
+            </label>
+            <div className="btn-group btn-group-sm mb-2" role="group">
+              <button
+                type="button"
+                className={`btn btn-outline-primary ${requirementsMode === 'text' ? 'active' : ''}`}
+                onClick={() => setRequirementsMode('text')}
+              >
+                {t('autoTextDescription', language)}
+              </button>
+              <button
+                type="button"
+                className={`btn btn-outline-primary ${requirementsMode === 'url' ? 'active' : ''}`}
+                onClick={() => setRequirementsMode('url')}
+              >
+                {t('autoGithubIssue', language)}
+              </button>
+            </div>
+            {requirementsMode === 'text' ? (
+              <textarea
+                className="form-control"
+                rows={4}
+                placeholder={t('autoRequirementsPlaceholder', language)}
+                value={requirementsText}
+                onChange={(e) => setRequirementsText(e.target.value)}
+              />
+            ) : (
+              <>
+                <textarea
+                  className="form-control"
+                  rows={3}
+                  placeholder={
+                    t('autoIssueInputPlaceholder', language) ||
+                    '123 125,128-130 or https://github.com/owner/repo/issues/123'
+                  }
+                  value={requirementsUrl}
+                  onChange={(e) => setRequirementsUrl(e.target.value)}
+                />
+                <div className="form-text">
+                  {t('autoIssueInputHint', language) ||
+                    'Supports commas, spaces, new lines, ranges like 12-15, and mixed GitHub issue URLs.'}
+                </div>
+              </>
+            )}
+          </div>
+
+          {/* Agent Tool & Model */}
+          <div className="col-md-6">
+            <label className="form-label fw-semibold">
+              {t('autoAgentTool', language)} <span className="text-danger">*</span>
+            </label>
+            <select
+              className="form-select"
+              value={cliTool}
+              onChange={(e) => {
+                setCliTool(e.target.value);
+                setModel('');
+              }}
+            >
+              {tools.length > 0 ? (
+                tools.map((tool) => (
+                  <option key={tool.id} value={tool.id}>
+                    {tool.name}
+                  </option>
+                ))
+              ) : (
+                <>
+                  <option value="claude-code">Claude Code</option>
+                  <option value="qwen-code-cli">Qwen Code</option>
+                  <option value="codex">Codex CLI</option>
+                  <option value="openclaw">OpenClaw</option>
+                  <option value="zcode">ZCode</option>
+                </>
+              )}
+            </select>
+          </div>
+          <div className="col-md-6">
+            <label className="form-label fw-semibold">{t('autoModel', language)}</label>
+            <select
+              className="form-select"
+              value={model}
+              onChange={(e) => setModel(e.target.value)}
+            >
+              <option value="">{t('autoDefaultModel', language)}</option>
+              {Array.isArray(models) &&
+                models.map((m: { name: string }) => (
+                  <option key={m.name} value={m.name}>
+                    {m.name}
+                  </option>
+                ))}
+            </select>
+          </div>
+
+          {/* Workspace Type */}
+          <div className="col-12">
+            <label className="form-label fw-semibold">{t('autoWorkspaceType', language)}</label>
+            <div className="btn-group w-100" role="group">
+              <button
+                type="button"
+                className={`btn btn-outline-primary ${workspaceType === 'local' ? 'active' : ''}`}
+                onClick={() => setWorkspaceType('local')}
+              >
+                <i className="bi bi-laptop me-1"></i>
+                {t('autoLocalWorkspace', language)}
+              </button>
+              <button
+                type="button"
+                className={`btn btn-outline-primary ${workspaceType === 'remote' ? 'active' : ''}`}
+                onClick={() => setWorkspaceType('remote')}
+              >
+                <i className="bi bi-cloud me-1"></i>
+                {t('autoRemoteWorkspace', language)}
+              </button>
+            </div>
+          </div>
+
+          {/* Remote Machine */}
+          {workspaceType === 'remote' && (
+            <div className="col-12">
+              <label className="form-label fw-semibold">
+                {t('autoRemoteMachine', language)} <span className="text-danger">*</span>
+              </label>
+              <RemoteMachineSelector
+                selectedMachineId={selectedMachineId}
+                onSelectMachine={(machineId, machine) => {
+                  setSelectedMachineId(machineId);
+                  setSelectedMachineOsType(machine?.os_type ?? '');
+                  setSelectedMachineWorkDir(machine?.work_dir ?? '');
+                }}
+              />
+            </div>
+          )}
+
+          {/* Project Path */}
+          <div className="col-12">
+            <div className="form-check mb-2">
               <input
                 type="checkbox"
                 className="form-check-input"
-                id="autoMerge"
-                checked={autoMerge}
-                onChange={(e) => setAutoMerge(e.target.checked)}
+                id="isNewProject"
+                checked={isNewProject}
+                onChange={(e) => setIsNewProject(e.target.checked)}
               />
-              <label className="form-check-label" htmlFor="autoMerge">
-                {t('autoMergeAfterPR', language) || 'Auto merge after PR created'}
+              <label className="form-check-label" htmlFor="isNewProject">
+                {t('autoNewProject', language)}
               </label>
-              <div className="form-text">
-                {t('autoMergeHint', language) ||
-                  'Automatically merge PR and proceed to next workflow in batch'}
+            </div>
+            {isNewProject ? (
+              <div className="row g-2">
+                <div className="col-md-8">
+                  <input
+                    type="text"
+                    className="form-control"
+                    placeholder={t('autoRepoNamePlaceholder', language)}
+                    value={repoName}
+                    onChange={(e) => setRepoName(e.target.value)}
+                  />
+                </div>
+                <div className="col-md-4">
+                  <div className="form-check">
+                    <input
+                      type="checkbox"
+                      className="form-check-input"
+                      id="isPrivate"
+                      checked={isPrivate}
+                      onChange={(e) => setIsPrivate(e.target.checked)}
+                    />
+                    <label className="form-check-label" htmlFor="isPrivate">
+                      {t('autoPrivateRepo', language)}
+                    </label>
+                  </div>
+                </div>
+              </div>
+            ) : (
+              <div className="input-group">
+                <input
+                  type="text"
+                  className="form-control"
+                  placeholder={t('autoProjectPathPlaceholder', language)}
+                  value={projectPath}
+                  onChange={(e) => setProjectPath(e.target.value)}
+                />
+                <Button
+                  variant="outline-secondary"
+                  onClick={() => {
+                    if (workspaceType === 'remote') {
+                      setShowRemoteDirectoryBrowser(true);
+                    } else {
+                      setShowLocalDirectoryBrowser(true);
+                    }
+                  }}
+                  disabled={workspaceType === 'remote' && !selectedMachineId}
+                >
+                  <i className="bi bi-folder2-open me-1" />
+                  {t('browse', language) || 'Browse'}
+                </Button>
+              </div>
+            )}
+          </div>
+
+          {/* Branch Strategy */}
+          <div className="col-md-6">
+            <label className="form-label fw-semibold">{t('autoBranchStrategy', language)}</label>
+            <select
+              className="form-select"
+              value={branchStrategy}
+              onChange={(e) =>
+                setBranchStrategy(e.target.value as 'new-branch' | 'worktree' | 'current')
+              }
+            >
+              <option value="new-branch">{t('autoNewBranch', language)}</option>
+              <option value="worktree">{t('autoWorktree', language)}</option>
+              <option value="current">{t('autoCurrentBranch', language)}</option>
+            </select>
+          </div>
+          <div className="col-md-6">
+            <label className="form-label fw-semibold">{t('autoBranchName', language)}</label>
+            <input
+              type="text"
+              className="form-control"
+              placeholder={t('autoBranchNamePlaceholder', language)}
+              value={branchName}
+              onChange={(e) => setBranchName(e.target.value)}
+            />
+          </div>
+
+          {/* Review Rounds */}
+          <div className="col-md-6">
+            <label className="form-label fw-semibold">
+              {t('autoMaxPlanRounds', language)}: {maxPlanRounds}
+            </label>
+            <input
+              type="range"
+              className="form-range"
+              min={1}
+              max={5}
+              value={maxPlanRounds}
+              onChange={(e) => setMaxPlanRounds(parseInt(e.target.value))}
+            />
+          </div>
+          <div className="col-md-6">
+            <label className="form-label fw-semibold">
+              {t('autoMaxPRReviewRounds', language)}: {maxPRReviewRounds}
+            </label>
+            <input
+              type="range"
+              className="form-range"
+              min={1}
+              max={10}
+              value={maxPRReviewRounds}
+              onChange={(e) => setMaxPRReviewRounds(parseInt(e.target.value))}
+            />
+          </div>
+
+          {/* Auto Merge - only show for batch workflows (URL mode with multiple issues) */}
+          {requirementsMode === 'url' && requirementsUrl.trim() && (
+            <div className="col-12">
+              <div className="form-check">
+                <input
+                  type="checkbox"
+                  className="form-check-input"
+                  id="autoMerge"
+                  checked={autoMerge}
+                  onChange={(e) => setAutoMerge(e.target.checked)}
+                />
+                <label className="form-check-label" htmlFor="autoMerge">
+                  {t('autoMergeAfterPR', language) || 'Auto merge after PR created'}
+                </label>
+                <div className="form-text">
+                  {t('autoMergeHint', language) ||
+                    'Automatically merge PR and proceed to next workflow in batch'}
+                </div>
               </div>
             </div>
-          </div>
-        )}
-      </div>
-    </Modal>
+          )}
+        </div>
+      </Modal>
+
+      <LocalDirectoryBrowserModal
+        isOpen={showLocalDirectoryBrowser}
+        onClose={() => setShowLocalDirectoryBrowser(false)}
+        initialPath={projectPath}
+        onSelectPath={(path) => {
+          setProjectPath(path);
+          persistLastProjectPath(path, 'local');
+        }}
+      />
+
+      {selectedMachineId && (
+        <DirectoryBrowserModal
+          isOpen={showRemoteDirectoryBrowser}
+          onClose={() => setShowRemoteDirectoryBrowser(false)}
+          machineId={selectedMachineId}
+          initialPath={projectPath}
+          osType={selectedMachineOsType || undefined}
+          onSelectPath={(path) => {
+            setProjectPath(path);
+            persistLastProjectPath(path, 'remote', selectedMachineId);
+          }}
+        />
+      )}
+    </>
   );
 };


### PR DESCRIPTION
## Summary
- add a local directory browser for autonomous task creation
- remember the last confirmed project path for local and remote workspaces
- change autonomous task defaults to worktree / 2 plan rounds / 3 PR review rounds

## Testing
- npm test -- --run src/components/work/NewAutonomousModal.test.tsx src/components/work/DirectoryBrowserModal.test.tsx src/components/work/NewSessionModal.directory.test.tsx
- npm run typecheck
- npx eslint src/api/fs.ts src/components/work/NewAutonomousModal.tsx src/components/work/LocalDirectoryBrowser.tsx src/components/work/LocalDirectoryBrowserModal.tsx src/components/work/NewAutonomousModal.test.tsx