### PR TITLE
fix(autonomous): model dropdown always empty in New Task dialog

### DIFF
--- a/app/routes/autonomous.py
+++ b/app/routes/autonomous.py
@@ -1310,30 +1310,32 @@ def get_available_models():
     workspace_type = request.args.get("workspace_type", "local")
     machine_id = request.args.get("machine_id", "")
 
+    # Resolve tenant. Local is single-tenant (default 1); remote derives it from
+    # the machine. ``g.tenant_id`` is never set in the app, so the previous
+    # ``getattr`` here always returned None and short-circuited to []. The
+    # remote lookup is outside the try below on purpose: an infrastructure
+    # failure here should surface (mirrors workspace.py:241-251), not be masked
+    # as a "success, no models" response or silently fall back to tenant 1
+    # (which could surface another tenant's local-scope keys).
+    tenant_id = 1
+    if workspace_type == "remote" and machine_id:
+        from app.modules.workspace.remote_agent_manager import get_remote_agent_manager
+
+        agent_mgr = get_remote_agent_manager()
+        # Guard the machine before reading it — a caller must not read an
+        # arbitrary machine's tenant/model list. Mirrors workspace.py:244.
+        if not agent_mgr.check_user_access(machine_id, g.user["id"]):
+            return (
+                jsonify({"success": False, "error": "Machine not found or access denied"}),
+                404,
+            )
+        machine = agent_mgr.get_machine(machine_id) or {}
+        tenant_id = machine.get("tenant_id", 1)
+
     try:
         from app.modules.workspace.api_key_proxy import APIKeyProxyService
 
         api_proxy = APIKeyProxyService()
-
-        # Resolve tenant: local is single-tenant (default 1); remote derives it
-        # from the machine (falling back to 1). ``g.tenant_id`` is never set in
-        # the app, so the previous ``getattr`` here always returned None and the
-        # endpoint short-circuited to an empty list. Mirrors workspace.py:199-251.
-        tenant_id = 1
-        if workspace_type == "remote" and machine_id:
-            from app.modules.workspace.remote_agent_manager import get_remote_agent_manager
-
-            agent_mgr = get_remote_agent_manager()
-            # Guard the machine before reading it — a caller must not read an
-            # arbitrary machine's tenant/model list. Mirrors workspace.py:244.
-            if not agent_mgr.check_user_access(machine_id, g.user["id"]):
-                return (
-                    jsonify({"success": False, "error": "Machine not found or access denied"}),
-                    404,
-                )
-            machine = agent_mgr.get_machine(machine_id) or {}
-            tenant_id = machine.get("tenant_id", 1)
-
         # ``scope`` is a query value: 'local'/'remote' match keys tagged with
         # that scope *or* 'shared'; 'shared' itself would match only shared keys
         # and silently miss every remote key. See _list_tool_key_rows

--- a/app/routes/autonomous.py
+++ b/app/routes/autonomous.py
@@ -1308,18 +1308,46 @@ def get_available_models():
     """Get available models for a given tool and workspace type."""
     tool = request.args.get("tool", "")
     workspace_type = request.args.get("workspace_type", "local")
-    request.args.get("machine_id", "")
+    machine_id = request.args.get("machine_id", "")
 
     try:
         from app.modules.workspace.api_key_proxy import APIKeyProxyService
 
         api_proxy = APIKeyProxyService()
-        tenant_id = getattr(g, "tenant_id", None)
+
+        # Resolve tenant: local is single-tenant (default 1); remote derives it
+        # from the machine (falling back to 1). ``g.tenant_id`` is never set in
+        # the app, so the previous ``getattr`` here always returned None and the
+        # endpoint short-circuited to an empty list. Mirrors workspace.py:199-251.
+        tenant_id = 1
+        if workspace_type == "remote" and machine_id:
+            try:
+                from app.modules.workspace.remote_agent_manager import get_remote_agent_manager
+
+                machine = get_remote_agent_manager().get_machine(machine_id) or {}
+                tenant_id = machine.get("tenant_id", 1)
+            except Exception:
+                tenant_id = 1
+
         scope = "shared" if workspace_type == "remote" else "local"
-        if tenant_id is None:
-            return jsonify({"success": True, "models": []})
-        models = api_proxy.get_tool_model_pool(tenant_id, tool, scope)
-        return jsonify({"success": True, "models": models})
+        pool = api_proxy.get_tool_model_pool(
+            tenant_id=tenant_id, tool_name=tool, scope=scope, provider="openai"
+        )
+        # The frontend model dropdown renders ``model.name``; pool entries are the
+        # raw config dicts keyed by ``id``. Normalize so a display name is always
+        # present (fall back to id), and surface ``empty_reason`` for future UX.
+        models = [
+            {"name": m.get("name") or m.get("id") or str(m), **m}
+            for m in pool.get("models", [])
+            if isinstance(m, dict)
+        ]
+        return jsonify(
+            {
+                "success": True,
+                "models": models,
+                "empty_reason": pool.get("empty_reason"),
+            }
+        )
     except Exception as e:
         logger.error("Failed to get models: %s", e)
         return jsonify({"success": True, "models": []})

--- a/app/routes/autonomous.py
+++ b/app/routes/autonomous.py
@@ -1321,15 +1321,24 @@ def get_available_models():
         # endpoint short-circuited to an empty list. Mirrors workspace.py:199-251.
         tenant_id = 1
         if workspace_type == "remote" and machine_id:
-            try:
-                from app.modules.workspace.remote_agent_manager import get_remote_agent_manager
+            from app.modules.workspace.remote_agent_manager import get_remote_agent_manager
 
-                machine = get_remote_agent_manager().get_machine(machine_id) or {}
-                tenant_id = machine.get("tenant_id", 1)
-            except Exception:
-                tenant_id = 1
+            agent_mgr = get_remote_agent_manager()
+            # Guard the machine before reading it — a caller must not read an
+            # arbitrary machine's tenant/model list. Mirrors workspace.py:244.
+            if not agent_mgr.check_user_access(machine_id, g.user["id"]):
+                return (
+                    jsonify({"success": False, "error": "Machine not found or access denied"}),
+                    404,
+                )
+            machine = agent_mgr.get_machine(machine_id) or {}
+            tenant_id = machine.get("tenant_id", 1)
 
-        scope = "shared" if workspace_type == "remote" else "local"
+        # ``scope`` is a query value: 'local'/'remote' match keys tagged with
+        # that scope *or* 'shared'; 'shared' itself would match only shared keys
+        # and silently miss every remote key. See _list_tool_key_rows
+        # (api_key_proxy.py:770-776) and migration 048.
+        scope = "remote" if workspace_type == "remote" else "local"
         pool = api_proxy.get_tool_model_pool(
             tenant_id=tenant_id, tool_name=tool, scope=scope, provider="openai"
         )

--- a/tests/issues/716/test_autonomous_api.py
+++ b/tests/issues/716/test_autonomous_api.py
@@ -832,10 +832,15 @@ class TestGetModels:
         assert "No active" in data["empty_reason"]
 
     def test_get_models_remote_derives_tenant_from_machine(self, client):
-        """Remote workspace derives tenant_id from the machine record."""
+        """Remote workspace derives tenant_id from the machine record.
+
+        ``scope`` must be 'remote' (matching keys tagged remote *or* shared);
+        querying with 'shared' would silently miss every remote-only key.
+        """
         mock_proxy = MagicMock()
         mock_proxy.get_tool_model_pool.return_value = {"models": [], "empty_reason": None}
         mock_mgr = MagicMock()
+        mock_mgr.check_user_access.return_value = "admin"
         mock_mgr.get_machine.return_value = {"tenant_id": 7}
         with _mock_auth():
             with (
@@ -853,10 +858,34 @@ class TestGetModels:
                     "&workspace_type=remote&machine_id=m-42"
                 )
         assert resp.status_code == 200
+        mock_mgr.check_user_access.assert_called_once()
         mock_mgr.get_machine.assert_called_once_with("m-42")
         mock_proxy.get_tool_model_pool.assert_called_once_with(
-            tenant_id=7, tool_name="claude-code", scope="shared", provider="openai"
+            tenant_id=7, tool_name="claude-code", scope="remote", provider="openai"
         )
+
+    def test_get_models_remote_denies_without_access(self, client):
+        """A user without access to the machine gets 404, never the model list."""
+        mock_proxy = MagicMock()
+        mock_mgr = MagicMock()
+        mock_mgr.check_user_access.return_value = None  # no access
+        with _mock_auth():
+            with (
+                patch(
+                    "app.modules.workspace.api_key_proxy.APIKeyProxyService",
+                    return_value=mock_proxy,
+                ),
+                patch(
+                    "app.modules.workspace.remote_agent_manager.get_remote_agent_manager",
+                    return_value=mock_mgr,
+                ),
+            ):
+                resp = client.get(
+                    "/api/autonomous/models?tool=claude-code"
+                    "&workspace_type=remote&machine_id=m-42"
+                )
+        assert resp.status_code == 404
+        mock_proxy.get_tool_model_pool.assert_not_called()
 
     def test_get_models_exception_returns_empty(self, client):
         """Any unexpected error is swallowed and returns an empty model list."""

--- a/tests/issues/716/test_autonomous_api.py
+++ b/tests/issues/716/test_autonomous_api.py
@@ -778,21 +778,23 @@ class TestGetTools:
 class TestGetModels:
     """Tests for GET /api/autonomous/models."""
 
-    def test_get_models_with_tenant(self, client):
-        """Models endpoint returns models when tenant_id is set on g."""
+    def test_get_models_returns_normalized_models(self, client):
+        """Endpoint extracts pool['models'] and normalizes display names.
+
+        Regression: previously the route read ``g.tenant_id`` (never set, so it
+        always returned []) and passed args positionally into
+        ``get_tool_model_pool`` (misaligning scope/tool_name) and returned the
+        entire pool dict instead of the models list.
+        """
         mock_proxy = MagicMock()
-        mock_proxy.get_tool_model_pool.return_value = [
-            {"name": "claude-sonnet-4-6"},
-            {"name": "claude-opus-4-8"},
-        ]
-        # Set g.tenant_id via a before_request hook on the test app
-        from flask import g as flask_g
-
-        def _set_tenant():
-            flask_g.tenant_id = 1
-
-        # Access the app from the client and register the hook
-        client.application.before_request(_set_tenant)
+        mock_proxy.get_tool_model_pool.return_value = {
+            "models": [
+                {"name": "claude-sonnet-4-6", "id": "claude-sonnet-4-6"},
+                # entry with only an id -> name should fall back to id
+                {"id": "claude-opus-4-8"},
+            ],
+            "empty_reason": None,
+        }
 
         with _mock_auth():
             with patch(
@@ -802,13 +804,73 @@ class TestGetModels:
                 resp = client.get("/api/autonomous/models?tool=claude-code")
         assert resp.status_code == 200
         data = resp.get_json()
-        assert len(data["models"]) == 2
+        assert data["success"] is True
+        names = [m["name"] for m in data["models"]]
+        assert names == ["claude-sonnet-4-6", "claude-opus-4-8"]
+        # Local workspace resolves to the default single tenant (1) and local scope.
+        mock_proxy.get_tool_model_pool.assert_called_once_with(
+            tenant_id=1, tool_name="claude-code", scope="local", provider="openai"
+        )
 
-    def test_get_models_no_tenant_returns_empty(self, client):
+    def test_get_models_no_keys_returns_empty(self, client):
+        """No configured keys -> empty list (not because tenant is missing)."""
+        mock_proxy = MagicMock()
+        mock_proxy.get_tool_model_pool.return_value = {
+            "models": [],
+            "empty_reason": "No active claude-code API keys configured for scope 'local'",
+        }
         with _mock_auth():
-            resp = client.get("/api/autonomous/models?tool=claude-code")
+            with patch(
+                "app.modules.workspace.api_key_proxy.APIKeyProxyService",
+                return_value=mock_proxy,
+            ):
+                resp = client.get("/api/autonomous/models?tool=claude-code")
         assert resp.status_code == 200
         data = resp.get_json()
+        assert data["success"] is True
+        assert data["models"] == []
+        assert "No active" in data["empty_reason"]
+
+    def test_get_models_remote_derives_tenant_from_machine(self, client):
+        """Remote workspace derives tenant_id from the machine record."""
+        mock_proxy = MagicMock()
+        mock_proxy.get_tool_model_pool.return_value = {"models": [], "empty_reason": None}
+        mock_mgr = MagicMock()
+        mock_mgr.get_machine.return_value = {"tenant_id": 7}
+        with _mock_auth():
+            with (
+                patch(
+                    "app.modules.workspace.api_key_proxy.APIKeyProxyService",
+                    return_value=mock_proxy,
+                ),
+                patch(
+                    "app.modules.workspace.remote_agent_manager.get_remote_agent_manager",
+                    return_value=mock_mgr,
+                ),
+            ):
+                resp = client.get(
+                    "/api/autonomous/models?tool=claude-code"
+                    "&workspace_type=remote&machine_id=m-42"
+                )
+        assert resp.status_code == 200
+        mock_mgr.get_machine.assert_called_once_with("m-42")
+        mock_proxy.get_tool_model_pool.assert_called_once_with(
+            tenant_id=7, tool_name="claude-code", scope="shared", provider="openai"
+        )
+
+    def test_get_models_exception_returns_empty(self, client):
+        """Any unexpected error is swallowed and returns an empty model list."""
+        mock_proxy = MagicMock()
+        mock_proxy.get_tool_model_pool.side_effect = RuntimeError("boom")
+        with _mock_auth():
+            with patch(
+                "app.modules.workspace.api_key_proxy.APIKeyProxyService",
+                return_value=mock_proxy,
+            ):
+                resp = client.get("/api/autonomous/models?tool=claude-code")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is True
         assert data["models"] == []
 
 

--- a/tests/issues/716/test_autonomous_api.py
+++ b/tests/issues/716/test_autonomous_api.py
@@ -888,7 +888,11 @@ class TestGetModels:
         mock_proxy.get_tool_model_pool.assert_not_called()
 
     def test_get_models_exception_returns_empty(self, client):
-        """Any unexpected error is swallowed and returns an empty model list."""
+        """Any unexpected error in the model pool query is swallowed.
+
+        Only the pool query/formatting is wrapped — a failure there reasonably
+        degrades to an empty list (the dropdown shows "Default").
+        """
         mock_proxy = MagicMock()
         mock_proxy.get_tool_model_pool.side_effect = RuntimeError("boom")
         with _mock_auth():
@@ -901,6 +905,37 @@ class TestGetModels:
         data = resp.get_json()
         assert data["success"] is True
         assert data["models"] == []
+
+    def test_get_models_remote_lookup_failure_not_masked_as_success(self, client):
+        """Remote machine-lookup failure must not be masked as success+empty.
+
+        The remote resolution (get_remote_agent_manager / check_user_access /
+        get_machine) runs outside the try that swallows pool-query errors, so an
+        infrastructure failure there surfaces as an error rather than a
+        misleading {"success": True, "models": []}. Regression guard for the
+        behavior change flagged in review.
+        """
+        mock_proxy = MagicMock()
+        mock_mgr = MagicMock()
+        mock_mgr.check_user_access.side_effect = RuntimeError("db down")
+        with _mock_auth():
+            with (
+                patch(
+                    "app.modules.workspace.api_key_proxy.APIKeyProxyService",
+                    return_value=mock_proxy,
+                ),
+                patch(
+                    "app.modules.workspace.remote_agent_manager.get_remote_agent_manager",
+                    return_value=mock_mgr,
+                ),
+            ):
+                resp = client.get(
+                    "/api/autonomous/models?tool=claude-code"
+                    "&workspace_type=remote&machine_id=m-42"
+                )
+        # Must not be a misleading "success, no models" — surface the failure.
+        assert resp.status_code != 200
+        mock_proxy.get_tool_model_pool.assert_not_called()
 
 
 # ── Auth Tests ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem
The **Model** dropdown in the "New Autonomous Task" dialog only ever showed the "Default" option — no models listed regardless of tool/workspace selection.

## Root cause
`GET /api/autonomous/models` (`app/routes/autonomous.py`) **always returned an empty list** due to four compounding bugs in the handler:

1. **`g.tenant_id` is never set** — `getattr(g, "tenant_id", None)` is always `None`, so the route short-circuited to `{"models": []}` on every request. (`g.tenant_id` is set nowhere in the app; `auth_required` only sets `g.user/user_id/user_role`.)
2. **Positional-arg misalignment** — `get_tool_model_pool(tenant_id, tool, scope)` passed `tool` into the `scope` parameter (signature: `tenant_id, tool_name, scope, provider`) and omitted `provider`.
3. **Returned the whole pool dict** as `"models"` (includes `candidate_keys`, `settings`, …) instead of the models list, so the frontend's `models.map(m => m.name)` found nothing.
4. **Field-name mismatch** — pool entries are keyed by `id`, but the dropdown renders `name`, so even valid data showed blank options.

The frontend chain (`useAvailableModels` → `autonomousApi.getAvailableModels`) was correct and fired the request; only the backend response was broken.

## Fix
Rewrote the handler to mirror the working implementation in `app/routes/workspace.py:199-251`:
- Resolve `tenant_id` = `1` for local (single-tenant default), or the machine's `tenant_id` for remote (fallback `1`).
- Call `get_tool_model_pool` with **keyword args** (`tool_name`, `scope`, `provider`).
- Return `pool.get("models", [])` and normalize each entry to include a `name` (falling back to `id`).
- Surface `empty_reason` for future empty-state UX.

> Note: the list is still empty until an admin configures an API key with `cli_settings.modelProviders` for the tool — that's expected (data comes from `api_key_store`, no seed). This PR fixes the route so it no longer returns empty *because of a bug*.

## Testing
- `python3 -m pytest tests/issues/716/test_autonomous_api.py` — 52 passed
- Updated `TestGetModels` with 4 cases: normalized output (incl. `id`-only fallback), no-keys empty, remote tenant derivation, exception handling.
- `black --check` clean.

## Out of scope (follow-ups)
- Real multi-tenant `g.tenant_id` injection (needs a `before_request` hook).
- Provider generalization (claude/zcode models under `modelProviders.anthropic` still empty).
- Frontend empty-state text via `empty_reason`.