### PR TITLE
fix(autonomous): model dropdown shows claude-code/zcode, not just qwen-code

### DIFF
--- a/app/modules/workspace/api_key_proxy.py
+++ b/app/modules/workspace/api_key_proxy.py
@@ -926,6 +926,13 @@ class APIKeyProxyService:
 
         Returns a dict shaped like ``get_tool_model_pool``'s:
         ``{"models": [{...}, ...], "empty_reason": str | None}``.
+
+        Multi-key tenancy: for tenants with several matching keys,
+        ``get_cli_settings_for_tool`` unions ``modelProviders`` across keys but
+        carries ``env``/top-level ``model`` from only the highest-priority key.
+        So qwen/codex models are fully unioned, while claude/zcode reflect the
+        highest-priority key only. Single-key tenants (the common case) are
+        unaffected.
         """
         settings = self.get_cli_settings_for_tool(tenant_id, tool_name, scope)
         if not settings:

--- a/app/modules/workspace/api_key_proxy.py
+++ b/app/modules/workspace/api_key_proxy.py
@@ -587,6 +587,32 @@ class APIKeyProxyService:
             Dict with complete settings ready for agent to write to settings.json,
             or None if no matching API key found.
         """
+        ranked_settings = self._collect_tool_key_settings(tenant_id, tool_name, scope)
+        if not ranked_settings:
+            return None
+
+        # Single key fast path — backward compatible
+        if len(ranked_settings) == 1:
+            return ranked_settings[0][1]
+
+        # Multiple keys — merge modelProviders from all keys
+        return self._merge_multi_key_settings(ranked_settings)
+
+    def _collect_tool_key_settings(
+        self,
+        tenant_id: int,
+        tool_name: str,
+        scope: str = "remote",
+    ) -> list[tuple[tuple[int, int, int], dict[str, Any]]]:
+        """Return per-key settings for every active key matching a tool.
+
+        Shared backing store for :meth:`get_cli_settings_for_tool` (which merges
+        the results for agent settings.json) and :meth:`get_tool_models` (which
+        unions models across keys). Returns settings ranked by
+        ``(-priority, -weight, key_id)`` ascending (highest-priority key first),
+        or an empty list when no key matches. Tool-name normalization is applied
+        so aliases ("codex"/"codex-cli", "claude"/"claude-code") match.
+        """
         canonical_tool = normalize_tool_name(tool_name)
 
         conn = self._get_connection()
@@ -609,7 +635,6 @@ class APIKeyProxyService:
         rows = cursor.fetchall()
         conn.close()
 
-        # Collect ALL matching keys with their ranked settings
         ranked_settings: list[tuple[tuple[int, int, int], dict[str, Any]]] = []
         for row in rows:
             cli_tools_str = row["cli_tools"] or ""
@@ -644,15 +669,7 @@ class APIKeyProxyService:
             rank = (-priority, -weight, key_id)
             ranked_settings.append((rank, settings))
 
-        if not ranked_settings:
-            return None
-
-        # Single key fast path — backward compatible
-        if len(ranked_settings) == 1:
-            return ranked_settings[0][1]
-
-        # Multiple keys — merge modelProviders from all keys
-        return self._merge_multi_key_settings(ranked_settings)
+        return ranked_settings
 
     @staticmethod
     def _collect_model_entries(
@@ -924,18 +941,15 @@ class APIKeyProxyService:
           bare string), with values like ``"zai/glm-5.2"`` — strip the
           ``provider/`` prefix.
 
+        Models are extracted from **every** matching key and unioned (deduped
+        by id), so a tenant with several claude-code/zcode keys sees the union
+        of all their models — not just the highest-priority key's.
+
         Returns a dict shaped like ``get_tool_model_pool``'s:
         ``{"models": [{...}, ...], "empty_reason": str | None}``.
-
-        Multi-key tenancy: for tenants with several matching keys,
-        ``get_cli_settings_for_tool`` unions ``modelProviders`` across keys but
-        carries ``env``/top-level ``model`` from only the highest-priority key.
-        So qwen/codex models are fully unioned, while claude/zcode reflect the
-        highest-priority key only. Single-key tenants (the common case) are
-        unaffected.
         """
-        settings = self.get_cli_settings_for_tool(tenant_id, tool_name, scope)
-        if not settings:
+        ranked_settings = self._collect_tool_key_settings(tenant_id, tool_name, scope)
+        if not ranked_settings:
             return {
                 "models": [],
                 "empty_reason": (f"No active {tool_name} API keys configured for scope '{scope}'"),
@@ -944,42 +958,11 @@ class APIKeyProxyService:
         canonical = normalize_tool_name(tool_name)
         models: list[dict[str, Any]] = []
 
-        if canonical == "claude":
-            # claude-code configures models via env vars, not modelProviders.
-            env = settings.get("env") or {}
-            for key in (
-                "ANTHROPIC_MODEL",
-                "ANTHROPIC_DEFAULT_SONNET_MODEL",
-                "ANTHROPIC_DEFAULT_HAIKU_MODEL",
-            ):
-                value = env.get(key)
-                if isinstance(value, str) and value.strip():
-                    models.append({"id": value.strip(), "name": value.strip()})
-        elif canonical == "zcode":
-            # zcode stores the active model(s) under a top-level `model` field.
-            raw_model = settings.get("model")
-            candidates: list[str] = []
-            if isinstance(raw_model, dict):
-                candidates = [v for v in raw_model.values() if isinstance(v, str)]
-            elif isinstance(raw_model, str):
-                candidates = [raw_model]
-            for value in candidates:
-                # Values look like "zai/glm-5.2"; drop the provider/ prefix.
-                name = value.split("/", 1)[1] if "/" in value else value
-                name = name.strip()
-                if name:
-                    models.append({"id": name, "name": name})
-        else:
-            # qwen / codex / future tools: flatten every modelProviders subkey.
-            providers = settings.get("modelProviders") or {}
-            for provider_models in providers.values():
-                if not isinstance(provider_models, list):
-                    continue
-                for entry in provider_models:
-                    if isinstance(entry, dict) and entry.get("id"):
-                        models.append({"id": entry["id"], "name": entry.get("name") or entry["id"]})
+        # Walk every matching key (highest priority first) and union its models.
+        for _rank, settings in ranked_settings:
+            models.extend(self._extract_models_for_tool(canonical, settings))
 
-        # Dedup by id while preserving discovery order.
+        # Dedup by id while preserving discovery order (highest-priority key wins).
         seen: set[str] = set()
         unique: list[dict[str, Any]] = []
         for model in models:
@@ -995,6 +978,50 @@ class APIKeyProxyService:
                 None if unique else f"Current {tool_name} API keys do not configure any models"
             ),
         }
+
+    @staticmethod
+    def _extract_models_for_tool(canonical: str, settings: dict[str, Any]) -> list[dict[str, Any]]:
+        """Extract model entries from one key's settings for a canonical tool."""
+        if canonical == "claude":
+            # claude-code configures models via env vars, not modelProviders.
+            env = settings.get("env") or {}
+            models: list[dict[str, Any]] = []
+            for key in (
+                "ANTHROPIC_MODEL",
+                "ANTHROPIC_DEFAULT_SONNET_MODEL",
+                "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+            ):
+                value = env.get(key)
+                if isinstance(value, str) and value.strip():
+                    models.append({"id": value.strip(), "name": value.strip()})
+            return models
+
+        if canonical == "zcode":
+            # zcode stores the active model(s) under a top-level `model` field.
+            raw_model = settings.get("model")
+            candidates: list[str] = []
+            if isinstance(raw_model, dict):
+                candidates = [v for v in raw_model.values() if isinstance(v, str)]
+            elif isinstance(raw_model, str):
+                candidates = [raw_model]
+            models = []
+            for value in candidates:
+                # Values look like "zai/glm-5.2"; drop the provider/ prefix.
+                name = value.split("/", 1)[1] if "/" in value else value
+                name = name.strip()
+                if name:
+                    models.append({"id": name, "name": name})
+            return models
+
+        # qwen / codex / future tools: flatten every modelProviders subkey.
+        models = []
+        for provider_models in (settings.get("modelProviders") or {}).values():
+            if not isinstance(provider_models, list):
+                continue
+            for entry in provider_models:
+                if isinstance(entry, dict) and entry.get("id"):
+                    models.append({"id": entry["id"], "name": entry.get("name") or entry["id"]})
+        return models
 
     def _build_cli_settings_for_tool(
         self,

--- a/app/modules/workspace/api_key_proxy.py
+++ b/app/modules/workspace/api_key_proxy.py
@@ -898,6 +898,97 @@ class APIKeyProxyService:
             "empty_reason": empty_reason,
         }
 
+    def get_tool_models(
+        self,
+        tenant_id: int,
+        tool_name: str,
+        scope: str = "remote",
+    ) -> dict[str, Any]:
+        """Return the available models for a tool, provider-agnostic.
+
+        Unlike :meth:`get_tool_model_pool` (which filters ``WHERE provider =
+        'openai'`` and reads only ``modelProviders.openai``), this queries keys
+        by ``cli_tools`` membership and extracts models from wherever the tool
+        stores them. This is what the model *dropdown* should use; the pool
+        method remains the source of truth for functional HA routing.
+
+        Each tool stores models differently (see frontend templates in
+        ``APIKeyManagement.tsx`` and remote-agent ``cli_settings.py``):
+
+        - **qwen / codex**: ``settings["modelProviders"]``, possibly under
+          several provider subkeys (openai, anthropic, ...) — flatten all.
+        - **claude**: ``settings["env"]["ANTHROPIC_MODEL"]`` and the
+          ``ANTHROPIC_DEFAULT_(SONNET|HAIKU)_MODEL`` variants — claude-code has
+          no ``modelProviders`` block.
+        - **zcode**: top-level ``settings["model"]`` (``{main, lite}`` or a
+          bare string), with values like ``"zai/glm-5.2"`` — strip the
+          ``provider/`` prefix.
+
+        Returns a dict shaped like ``get_tool_model_pool``'s:
+        ``{"models": [{...}, ...], "empty_reason": str | None}``.
+        """
+        settings = self.get_cli_settings_for_tool(tenant_id, tool_name, scope)
+        if not settings:
+            return {
+                "models": [],
+                "empty_reason": (f"No active {tool_name} API keys configured for scope '{scope}'"),
+            }
+
+        canonical = normalize_tool_name(tool_name)
+        models: list[dict[str, Any]] = []
+
+        if canonical == "claude":
+            # claude-code configures models via env vars, not modelProviders.
+            env = settings.get("env") or {}
+            for key in (
+                "ANTHROPIC_MODEL",
+                "ANTHROPIC_DEFAULT_SONNET_MODEL",
+                "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+            ):
+                value = env.get(key)
+                if isinstance(value, str) and value.strip():
+                    models.append({"id": value.strip(), "name": value.strip()})
+        elif canonical == "zcode":
+            # zcode stores the active model(s) under a top-level `model` field.
+            raw_model = settings.get("model")
+            candidates: list[str] = []
+            if isinstance(raw_model, dict):
+                candidates = [v for v in raw_model.values() if isinstance(v, str)]
+            elif isinstance(raw_model, str):
+                candidates = [raw_model]
+            for value in candidates:
+                # Values look like "zai/glm-5.2"; drop the provider/ prefix.
+                name = value.split("/", 1)[1] if "/" in value else value
+                name = name.strip()
+                if name:
+                    models.append({"id": name, "name": name})
+        else:
+            # qwen / codex / future tools: flatten every modelProviders subkey.
+            providers = settings.get("modelProviders") or {}
+            for provider_models in providers.values():
+                if not isinstance(provider_models, list):
+                    continue
+                for entry in provider_models:
+                    if isinstance(entry, dict) and entry.get("id"):
+                        models.append({"id": entry["id"], "name": entry.get("name") or entry["id"]})
+
+        # Dedup by id while preserving discovery order.
+        seen: set[str] = set()
+        unique: list[dict[str, Any]] = []
+        for model in models:
+            mid = str(model.get("id"))
+            if mid in seen:
+                continue
+            seen.add(mid)
+            unique.append(model)
+
+        return {
+            "models": unique,
+            "empty_reason": (
+                None if unique else f"Current {tool_name} API keys do not configure any models"
+            ),
+        }
+
     def _build_cli_settings_for_tool(
         self,
         tool_name: str,

--- a/app/routes/autonomous.py
+++ b/app/routes/autonomous.py
@@ -1341,12 +1341,14 @@ def get_available_models():
         # and silently miss every remote key. See _list_tool_key_rows
         # (api_key_proxy.py:770-776) and migration 048.
         scope = "remote" if workspace_type == "remote" else "local"
-        pool = api_proxy.get_tool_model_pool(
-            tenant_id=tenant_id, tool_name=tool, scope=scope, provider="openai"
-        )
-        # The frontend model dropdown renders ``model.name``; pool entries are the
-        # raw config dicts keyed by ``id``. Normalize so a display name is always
-        # present (fall back to id), and surface ``empty_reason`` for future UX.
+        # Provider-agnostic: keys are matched by cli_tools membership and models
+        # are extracted from wherever the tool stores them (modelProviders for
+        # qwen/codex, env for claude, top-level `model` for zcode). The openai-only
+        # get_tool_model_pool is reserved for functional HA routing.
+        pool = api_proxy.get_tool_models(tenant_id=tenant_id, tool_name=tool, scope=scope)
+        # The frontend model dropdown renders ``model.name``; entries are keyed by
+        # ``id``. Normalize so a display name is always present (fall back to id),
+        # and surface ``empty_reason`` for future UX.
         models = [
             {"name": m.get("name") or m.get("id") or str(m), **m}
             for m in pool.get("models", [])

--- a/tests/issues/716/test_autonomous_api.py
+++ b/tests/issues/716/test_autonomous_api.py
@@ -1008,6 +1008,22 @@ class TestGetToolModelsExtractor:
         assert result["models"] == []
         assert "do not configure" in result["empty_reason"]
 
+    def test_multi_key_claude_reflects_merged_settings_only(self):
+        """Pin multi-key merge behavior for claude/zcode.
+
+        get_cli_settings_for_tool unions modelProviders across keys but carries
+        env/top-level model from only the highest-priority key. So for a merged
+        claude-code config, get_tool_models reflects whatever env the merge
+        produced (here: the top-priority key's models). This test pins that
+        inherited contract so a future change to the merge is caught.
+        """
+        proxy = self._proxy()
+        # Simulate the merged output: env from top-priority key only.
+        merged = {"env": {"ANTHROPIC_MODEL": "glm-5", "ANTHROPIC_DEFAULT_SONNET_MODEL": "glm-5.1"}}
+        with patch.object(proxy, "get_cli_settings_for_tool", return_value=merged):
+            result = proxy.get_tool_models(1, "claude-code", "local")
+        assert [m["id"] for m in result["models"]] == ["glm-5", "glm-5.1"]
+
 
 # ── Auth Tests ───────────────────────────────────────────────────────────
 

--- a/tests/issues/716/test_autonomous_api.py
+++ b/tests/issues/716/test_autonomous_api.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 import app.repositories.database as db_mod
+from app.modules.workspace.api_key_proxy import APIKeyProxyService
 from app.repositories.database import Database
 
 # ── Fixtures ──────────────────────────────────────────────────────────────
@@ -779,15 +780,14 @@ class TestGetModels:
     """Tests for GET /api/autonomous/models."""
 
     def test_get_models_returns_normalized_models(self, client):
-        """Endpoint extracts pool['models'] and normalizes display names.
+        """Endpoint extracts models and normalizes display names.
 
-        Regression: previously the route read ``g.tenant_id`` (never set, so it
-        always returned []) and passed args positionally into
-        ``get_tool_model_pool`` (misaligning scope/tool_name) and returned the
-        entire pool dict instead of the models list.
+        The route now uses the provider-agnostic ``get_tool_models`` (matched by
+        cli_tools, not provider). Regression: previously it read ``g.tenant_id``
+        (never set → always []) and returned the whole pool dict.
         """
         mock_proxy = MagicMock()
-        mock_proxy.get_tool_model_pool.return_value = {
+        mock_proxy.get_tool_models.return_value = {
             "models": [
                 {"name": "claude-sonnet-4-6", "id": "claude-sonnet-4-6"},
                 # entry with only an id -> name should fall back to id
@@ -807,15 +807,16 @@ class TestGetModels:
         assert data["success"] is True
         names = [m["name"] for m in data["models"]]
         assert names == ["claude-sonnet-4-6", "claude-opus-4-8"]
-        # Local workspace resolves to the default single tenant (1) and local scope.
-        mock_proxy.get_tool_model_pool.assert_called_once_with(
-            tenant_id=1, tool_name="claude-code", scope="local", provider="openai"
+        # Local workspace resolves to the default single tenant (1) and local scope;
+        # provider is NOT passed (provider-agnostic).
+        mock_proxy.get_tool_models.assert_called_once_with(
+            tenant_id=1, tool_name="claude-code", scope="local"
         )
 
     def test_get_models_no_keys_returns_empty(self, client):
         """No configured keys -> empty list (not because tenant is missing)."""
         mock_proxy = MagicMock()
-        mock_proxy.get_tool_model_pool.return_value = {
+        mock_proxy.get_tool_models.return_value = {
             "models": [],
             "empty_reason": "No active claude-code API keys configured for scope 'local'",
         }
@@ -838,7 +839,7 @@ class TestGetModels:
         querying with 'shared' would silently miss every remote-only key.
         """
         mock_proxy = MagicMock()
-        mock_proxy.get_tool_model_pool.return_value = {"models": [], "empty_reason": None}
+        mock_proxy.get_tool_models.return_value = {"models": [], "empty_reason": None}
         mock_mgr = MagicMock()
         mock_mgr.check_user_access.return_value = "admin"
         mock_mgr.get_machine.return_value = {"tenant_id": 7}
@@ -860,8 +861,8 @@ class TestGetModels:
         assert resp.status_code == 200
         mock_mgr.check_user_access.assert_called_once()
         mock_mgr.get_machine.assert_called_once_with("m-42")
-        mock_proxy.get_tool_model_pool.assert_called_once_with(
-            tenant_id=7, tool_name="claude-code", scope="remote", provider="openai"
+        mock_proxy.get_tool_models.assert_called_once_with(
+            tenant_id=7, tool_name="claude-code", scope="remote"
         )
 
     def test_get_models_remote_denies_without_access(self, client):
@@ -885,16 +886,16 @@ class TestGetModels:
                     "&workspace_type=remote&machine_id=m-42"
                 )
         assert resp.status_code == 404
-        mock_proxy.get_tool_model_pool.assert_not_called()
+        mock_proxy.get_tool_models.assert_not_called()
 
     def test_get_models_exception_returns_empty(self, client):
-        """Any unexpected error in the model pool query is swallowed.
+        """Any unexpected error in the model query is swallowed.
 
-        Only the pool query/formatting is wrapped — a failure there reasonably
+        Only the query/formatting is wrapped — a failure there reasonably
         degrades to an empty list (the dropdown shows "Default").
         """
         mock_proxy = MagicMock()
-        mock_proxy.get_tool_model_pool.side_effect = RuntimeError("boom")
+        mock_proxy.get_tool_models.side_effect = RuntimeError("boom")
         with _mock_auth():
             with patch(
                 "app.modules.workspace.api_key_proxy.APIKeyProxyService",
@@ -910,7 +911,7 @@ class TestGetModels:
         """Remote machine-lookup failure must not be masked as success+empty.
 
         The remote resolution (get_remote_agent_manager / check_user_access /
-        get_machine) runs outside the try that swallows pool-query errors, so an
+        get_machine) runs outside the try that swallows query errors, so an
         infrastructure failure there surfaces as an error rather than a
         misleading {"success": True, "models": []}. Regression guard for the
         behavior change flagged in review.
@@ -935,7 +936,77 @@ class TestGetModels:
                 )
         # Must not be a misleading "success, no models" — surface the failure.
         assert resp.status_code != 200
-        mock_proxy.get_tool_model_pool.assert_not_called()
+        mock_proxy.get_tool_models.assert_not_called()
+
+
+class TestGetToolModelsExtractor:
+    """Unit tests for APIKeyProxyService.get_tool_models (provider-agnostic).
+
+    The extractor branches on the canonical tool name because each tool stores
+    its models in a different location (see APIKeyManagement.tsx templates and
+    remote-agent cli_settings.py). These tests stub get_cli_settings_for_tool
+    so no DB is needed.
+    """
+
+    def _proxy(self):
+        # Bypass __init__ — it needs an encryption key/DB only for key
+        # management, which get_tool_models (pure extraction over the stubbed
+        # get_cli_settings_for_tool return value) does not touch.
+        return object.__new__(APIKeyProxyService)
+
+    def test_no_settings_returns_empty_with_reason(self):
+        proxy = self._proxy()
+        with patch.object(proxy, "get_cli_settings_for_tool", return_value=None):
+            result = proxy.get_tool_models(1, "claude-code", "local")
+        assert result["models"] == []
+        assert "No active" in result["empty_reason"]
+
+    def test_claude_extracts_from_env(self):
+        """claude-code stores models in env vars, not modelProviders."""
+        proxy = self._proxy()
+        settings = {
+            "env": {
+                "ANTHROPIC_MODEL": "glm-5",
+                "ANTHROPIC_DEFAULT_SONNET_MODEL": "glm-5.1",
+                "ANTHROPIC_DEFAULT_HAIKU_MODEL": "glm-5",  # dup of ANTHROPIC_MODEL
+            }
+        }
+        with patch.object(proxy, "get_cli_settings_for_tool", return_value=settings):
+            result = proxy.get_tool_models(1, "claude-code", "local")
+        ids = [m["id"] for m in result["models"]]
+        assert ids == ["glm-5", "glm-5.1"]  # deduped, order preserved
+        assert all(m["name"] == m["id"] for m in result["models"])
+
+    def test_zcode_extracts_from_model_field(self):
+        """zcode stores models under a top-level `model` dict; strip provider/."""
+        proxy = self._proxy()
+        settings = {"model": {"main": "zai/glm-5.2", "lite": "zai/glm-4.5-air"}}
+        with patch.object(proxy, "get_cli_settings_for_tool", return_value=settings):
+            result = proxy.get_tool_models(1, "zcode", "remote")
+        names = sorted(m["name"] for m in result["models"])
+        assert names == ["glm-4.5-air", "glm-5.2"]  # prefix stripped
+
+    def test_qwen_flattens_all_model_providers(self):
+        """qwen/codex: union models across every modelProviders subkey."""
+        proxy = self._proxy()
+        settings = {
+            "modelProviders": {
+                "openai": [{"id": "glm-5", "name": "glm-5"}],
+                "anthropic": [{"id": "claude-sonnet", "name": "Claude Sonnet"}],
+            }
+        }
+        with patch.object(proxy, "get_cli_settings_for_tool", return_value=settings):
+            result = proxy.get_tool_models(1, "qwen-code", "local")
+        ids = sorted(m["id"] for m in result["models"])
+        assert ids == ["claude-sonnet", "glm-5"]
+
+    def test_models_present_with_no_matching_models(self):
+        """Keys exist but none configure models -> empty with reason."""
+        proxy = self._proxy()
+        with patch.object(proxy, "get_cli_settings_for_tool", return_value={"env": {}}):
+            result = proxy.get_tool_models(1, "claude-code", "local")
+        assert result["models"] == []
+        assert "do not configure" in result["empty_reason"]
 
 
 # ── Auth Tests ───────────────────────────────────────────────────────────

--- a/tests/issues/716/test_autonomous_api.py
+++ b/tests/issues/716/test_autonomous_api.py
@@ -944,19 +944,24 @@ class TestGetToolModelsExtractor:
 
     The extractor branches on the canonical tool name because each tool stores
     its models in a different location (see APIKeyManagement.tsx templates and
-    remote-agent cli_settings.py). These tests stub get_cli_settings_for_tool
-    so no DB is needed.
+    remote-agent cli_settings.py). These tests stub _collect_tool_key_settings
+    (which returns the per-key settings list) so no DB is needed.
     """
 
     def _proxy(self):
         # Bypass __init__ — it needs an encryption key/DB only for key
         # management, which get_tool_models (pure extraction over the stubbed
-        # get_cli_settings_for_tool return value) does not touch.
+        # per-key settings) does not touch.
         return object.__new__(APIKeyProxyService)
 
-    def test_no_settings_returns_empty_with_reason(self):
+    @staticmethod
+    def _keys(*settings):
+        """Wrap per-key settings dicts as ranked entries (rank irrelevant here)."""
+        return [((-priority, -100, i), s) for i, (priority, s) in enumerate(settings)]
+
+    def test_no_keys_returns_empty_with_reason(self):
         proxy = self._proxy()
-        with patch.object(proxy, "get_cli_settings_for_tool", return_value=None):
+        with patch.object(proxy, "_collect_tool_key_settings", return_value=[]):
             result = proxy.get_tool_models(1, "claude-code", "local")
         assert result["models"] == []
         assert "No active" in result["empty_reason"]
@@ -971,7 +976,9 @@ class TestGetToolModelsExtractor:
                 "ANTHROPIC_DEFAULT_HAIKU_MODEL": "glm-5",  # dup of ANTHROPIC_MODEL
             }
         }
-        with patch.object(proxy, "get_cli_settings_for_tool", return_value=settings):
+        with patch.object(
+            proxy, "_collect_tool_key_settings", return_value=self._keys((1, settings))
+        ):
             result = proxy.get_tool_models(1, "claude-code", "local")
         ids = [m["id"] for m in result["models"]]
         assert ids == ["glm-5", "glm-5.1"]  # deduped, order preserved
@@ -981,7 +988,9 @@ class TestGetToolModelsExtractor:
         """zcode stores models under a top-level `model` dict; strip provider/."""
         proxy = self._proxy()
         settings = {"model": {"main": "zai/glm-5.2", "lite": "zai/glm-4.5-air"}}
-        with patch.object(proxy, "get_cli_settings_for_tool", return_value=settings):
+        with patch.object(
+            proxy, "_collect_tool_key_settings", return_value=self._keys((1, settings))
+        ):
             result = proxy.get_tool_models(1, "zcode", "remote")
         names = sorted(m["name"] for m in result["models"])
         assert names == ["glm-4.5-air", "glm-5.2"]  # prefix stripped
@@ -995,34 +1004,64 @@ class TestGetToolModelsExtractor:
                 "anthropic": [{"id": "claude-sonnet", "name": "Claude Sonnet"}],
             }
         }
-        with patch.object(proxy, "get_cli_settings_for_tool", return_value=settings):
+        with patch.object(
+            proxy, "_collect_tool_key_settings", return_value=self._keys((1, settings))
+        ):
             result = proxy.get_tool_models(1, "qwen-code", "local")
         ids = sorted(m["id"] for m in result["models"])
         assert ids == ["claude-sonnet", "glm-5"]
 
-    def test_models_present_with_no_matching_models(self):
+    def test_keys_present_with_no_matching_models(self):
         """Keys exist but none configure models -> empty with reason."""
         proxy = self._proxy()
-        with patch.object(proxy, "get_cli_settings_for_tool", return_value={"env": {}}):
+        with patch.object(
+            proxy, "_collect_tool_key_settings", return_value=self._keys((1, {"env": {}}))
+        ):
             result = proxy.get_tool_models(1, "claude-code", "local")
         assert result["models"] == []
         assert "do not configure" in result["empty_reason"]
 
-    def test_multi_key_claude_reflects_merged_settings_only(self):
-        """Pin multi-key merge behavior for claude/zcode.
+    def test_multi_key_claude_unions_models_across_keys(self):
+        """Multi-key claude-code: union env models from ALL keys, not just top.
 
-        get_cli_settings_for_tool unions modelProviders across keys but carries
-        env/top-level model from only the highest-priority key. So for a merged
-        claude-code config, get_tool_models reflects whatever env the merge
-        produced (here: the top-priority key's models). This test pins that
-        inherited contract so a future change to the merge is caught.
+        Regression: an earlier version delegated to get_cli_settings_for_tool,
+        whose merge carries env from only the highest-priority key — so a
+        tenant with two claude-code keys saw only the top key's models. The
+        extractor now walks every key and unions.
         """
         proxy = self._proxy()
-        # Simulate the merged output: env from top-priority key only.
-        merged = {"env": {"ANTHROPIC_MODEL": "glm-5", "ANTHROPIC_DEFAULT_SONNET_MODEL": "glm-5.1"}}
-        with patch.object(proxy, "get_cli_settings_for_tool", return_value=merged):
+        # Two keys, each configuring a different model. Priority: key A (10) > B (5).
+        key_a = (10, {"env": {"ANTHROPIC_MODEL": "glm-5"}})
+        key_b = (5, {"env": {"ANTHROPIC_MODEL": "glm-5.1"}})
+        with patch.object(
+            proxy, "_collect_tool_key_settings", return_value=self._keys(key_a, key_b)
+        ):
             result = proxy.get_tool_models(1, "claude-code", "local")
-        assert [m["id"] for m in result["models"]] == ["glm-5", "glm-5.1"]
+        assert sorted(m["id"] for m in result["models"]) == ["glm-5", "glm-5.1"]
+        # Highest-priority key's model discovered first.
+        assert result["models"][0]["id"] == "glm-5"
+
+    def test_multi_key_zcode_unions_models_across_keys(self):
+        """Multi-key zcode: union top-level model entries from all keys."""
+        proxy = self._proxy()
+        key_a = (10, {"model": {"main": "zai/glm-5.2"}})
+        key_b = (5, {"model": {"main": "zai/glm-4.5-air"}})
+        with patch.object(
+            proxy, "_collect_tool_key_settings", return_value=self._keys(key_a, key_b)
+        ):
+            result = proxy.get_tool_models(1, "zcode", "remote")
+        assert sorted(m["id"] for m in result["models"]) == ["glm-4.5-air", "glm-5.2"]
+
+    def test_multi_key_qwen_unions_model_providers_across_keys(self):
+        """Multi-key qwen: union modelProviders across keys (already correct)."""
+        proxy = self._proxy()
+        key_a = (10, {"modelProviders": {"openai": [{"id": "glm-5"}]}})
+        key_b = (5, {"modelProviders": {"openai": [{"id": "glm-5.1"}]}})
+        with patch.object(
+            proxy, "_collect_tool_key_settings", return_value=self._keys(key_a, key_b)
+        ):
+            result = proxy.get_tool_models(1, "qwen-code", "local")
+        assert sorted(m["id"] for m in result["models"]) == ["glm-5", "glm-5.1"]
 
 
 # ── Auth Tests ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem
The **Model** dropdown in the New Autonomous Task dialog only showed models for **qwen-code**. For claude-code and zcode it was empty (only "Default" appeared) even when an API key was configured.

## Root cause
`/autonomous/models` called `get_tool_model_pool(provider="openai")`, which has two openai-specific gates:
1. **SQL** `WHERE provider = 'openai'` — but claude-code/zcode keys are stored with `provider="anthropic"` (the API key form's default), so they're filtered out entirely.
2. **Model extraction** reads only `modelProviders.openai` — but claude-code stores models in `env.ANTHROPIC_MODEL*`, and zcode stores them under a top-level `model: {main, lite}` field. Neither populates `modelProviders`.

This is a codebase-wide hardcoding (all callers pass `"openai"`), but only the autonomous dropdown is purely display-oriented and safe to change; the functional HA-routing callers (`webui_manager`, `llm_proxy_handler`) genuinely need the openai-keyed pool.

## Fix
- **New** `APIKeyProxyService.get_tool_models(tenant_id, tool_name, scope)` — a provider-agnostic **display** helper. It queries keys by `cli_tools` membership (no provider filter, via the existing `get_cli_settings_for_tool`) and extracts models from wherever the tool stores them:
  - qwen / codex → flatten all `modelProviders` subkeys
  - claude → `env.ANTHROPIC_MODEL` / `ANTHROPIC_DEFAULT_(SONNET|HAIKU)_MODEL`
  - zcode → `model.{main,lite}`, stripping the `provider/` prefix (e.g. `zai/glm-5.2` → `glm-5.2`)
  - dedup by id, preserve order; returns `{models, empty_reason}` shaped like the pool.
- **Switch** `autonomous.py` to call `get_tool_models` instead of `get_tool_model_pool`.
- `get_tool_model_pool` is **unchanged** — still the source of truth for functional HA routing.

> ℹ️ **Stacked on #1132.** This branch is based on `fix/autonomous-models-empty-dropdown` (PR #1132 fixes the same route's tenant_id/scope/access bugs). Merge #1132 first; this PR then rebases cleanly onto main. If reviewed standalone, note the tenant/scope logic comes from #1132.

## Testing
- `pytest tests/issues/716/test_autonomous_api.py` → **59 passed**
- New `TestGetToolModelsExtractor`: claude env extraction, zcode prefix stripping, qwen cross-provider union, dedup, empty-with-reason, keys-but-no-models.
- Updated `TestGetModels`: asserts the provider-agnostic call (no `provider=` arg).
- `black --check` clean.

## Out of scope
- `workspace.py` session-model dropdown (qwen-code-specific, HA-token-intertwined).
- Functional callers (`webui_manager`, `llm_proxy_handler`).
- Multi-tenant `g.tenant_id`, frontend empty-state text.