### PR TITLE
feat(api-keys): add zcode default settings to API key config form

### DIFF
--- a/frontend/src/components/features/management/APIKeyManagement.tsx
+++ b/frontend/src/components/features/management/APIKeyManagement.tsx
@@ -116,6 +116,21 @@ model = "glm-5"
 name = "Open ACE Proxy"
 wire_api = "responses"`;
 
+const defaultZcodeSettings = `{
+  "provider": {
+    "zai": {
+      "id": "zai",
+      "kind": "anthropic",
+      "name": "Z.AI (Anthropic-compatible)",
+      "options": {}
+    }
+  },
+  "model": {
+    "main": "zai/glm-5.2",
+    "lite": "zai/glm-4.5-air"
+  }
+}`;
+
 export const APIKeyManagement: React.FC = () => {
   const language = useLanguage();
   const { data: keysData, isLoading, isError, error, refetch } = useApiKeys();
@@ -168,6 +183,7 @@ export const APIKeyManagement: React.FC = () => {
     claude_settings: '',
     qwen_settings: '',
     codex_settings: '',
+    zcode_settings: '',
     scope: 'shared' as string,
     priority: 0,
     weight: 100,
@@ -195,6 +211,11 @@ export const APIKeyManagement: React.FC = () => {
   const qwenValidation = useMemo(
     () => getJsonValidationResult(formData.qwen_settings),
     [formData.qwen_settings]
+  );
+
+  const zcodeValidation = useMemo(
+    () => getJsonValidationResult(formData.zcode_settings),
+    [formData.zcode_settings]
   );
 
   const stringifyCodexSettings = (value: unknown): string => {
@@ -250,6 +271,7 @@ export const APIKeyManagement: React.FC = () => {
       claude_settings: '',
       qwen_settings: '',
       codex_settings: '',
+      zcode_settings: '',
       scope: 'shared',
       priority: 0,
       weight: 100,
@@ -267,6 +289,7 @@ export const APIKeyManagement: React.FC = () => {
     let claudeSettings = '';
     let qwenSettings = '';
     let codexSettings = '';
+    let zcodeSettings = '';
 
     if (key.cli_tools) {
       try {
@@ -288,6 +311,9 @@ export const APIKeyManagement: React.FC = () => {
         if (settings['codex-cli']) {
           codexSettings = stringifyCodexSettings(settings['codex-cli']);
         }
+        if (settings['zcode']) {
+          zcodeSettings = JSON.stringify(settings['zcode'], null, 2);
+        }
       } catch {
         // Ignore parse errors
       }
@@ -302,6 +328,7 @@ export const APIKeyManagement: React.FC = () => {
       claude_settings: claudeSettings,
       qwen_settings: qwenSettings,
       codex_settings: codexSettings,
+      zcode_settings: zcodeSettings,
       scope: key.scope || 'shared',
       priority: key.priority ?? 0,
       weight: key.weight ?? 100,
@@ -322,6 +349,7 @@ export const APIKeyManagement: React.FC = () => {
       let newClaudeSettings = formData.claude_settings;
       let newQwenSettings = formData.qwen_settings;
       let newCodexSettings = formData.codex_settings;
+      let newZcodeSettings = formData.zcode_settings;
 
       if (tool === 'claude-code' && !formData.claude_settings) {
         newClaudeSettings = defaultClaudeSettings;
@@ -332,6 +360,9 @@ export const APIKeyManagement: React.FC = () => {
       if (tool === 'codex-cli' && !formData.codex_settings) {
         newCodexSettings = defaultCodexSettings;
       }
+      if (tool === 'zcode' && !formData.zcode_settings) {
+        newZcodeSettings = defaultZcodeSettings;
+      }
 
       setFormData({
         ...formData,
@@ -339,6 +370,7 @@ export const APIKeyManagement: React.FC = () => {
         claude_settings: newClaudeSettings,
         qwen_settings: newQwenSettings,
         codex_settings: newCodexSettings,
+        zcode_settings: newZcodeSettings,
       });
     }
   };
@@ -435,6 +467,13 @@ export const APIKeyManagement: React.FC = () => {
       // raw editor text here and let the backend validate/parse it.
       settings['codex-cli'] = formData.codex_settings;
     }
+    if (formData.cli_tools.includes('zcode') && formData.zcode_settings) {
+      try {
+        settings['zcode'] = stripSensitiveFields(JSON.parse(formData.zcode_settings));
+      } catch {
+        // Skip invalid JSON
+      }
+    }
     return JSON.stringify(settings);
   };
 
@@ -460,6 +499,10 @@ export const APIKeyManagement: React.FC = () => {
     }
     if (formData.cli_tools.includes('qwen-code') && !validateJsonSettings(formData.qwen_settings)) {
       setFormError(t('qwenSettingsInvalid', language));
+      return;
+    }
+    if (formData.cli_tools.includes('zcode') && !validateJsonSettings(formData.zcode_settings)) {
+      setFormError(t('zcodeSettingsInvalid', language));
       return;
     }
 
@@ -502,6 +545,10 @@ export const APIKeyManagement: React.FC = () => {
     }
     if (formData.cli_tools.includes('qwen-code') && !validateJsonSettings(formData.qwen_settings)) {
       setFormError(t('qwenSettingsInvalid', language));
+      return;
+    }
+    if (formData.cli_tools.includes('zcode') && !validateJsonSettings(formData.zcode_settings)) {
+      setFormError(t('zcodeSettingsInvalid', language));
       return;
     }
 
@@ -865,6 +912,28 @@ export const APIKeyManagement: React.FC = () => {
             <small className="text-muted">{t('codexSettingsHint', language)}</small>
           </div>
         )}
+
+        {/* ZCode Settings */}
+        {formData.cli_tools.includes('zcode') && (
+          <div className="mb-3">
+            <label className="form-label">{t('zcodeSettings', language)}</label>
+            <textarea
+              className={`form-control ${
+                formData.zcode_settings.trim() && !zcodeValidation.valid ? 'is-invalid' : ''
+              }`}
+              rows={10}
+              value={formData.zcode_settings}
+              onChange={(e) => setFormData({ ...formData, zcode_settings: e.target.value })}
+              placeholder={defaultZcodeSettings}
+            />
+            <JsonValidationIndicator
+              jsonStr={formData.zcode_settings}
+              validation={zcodeValidation}
+              language={language}
+            />
+            <small className="text-muted">{t('zcodeSettingsHint', language)}</small>
+          </div>
+        )}
       </Modal>
 
       {/* Edit API Key Dialog */}
@@ -1042,6 +1111,27 @@ export const APIKeyManagement: React.FC = () => {
               onChange={(e) => setFormData({ ...formData, codex_settings: e.target.value })}
             />
             <small className="text-muted">{t('codexSettingsHint', language)}</small>
+          </div>
+        )}
+
+        {formData.cli_tools.includes('zcode') && (
+          <div className="mb-3">
+            <label className="form-label">{t('zcodeSettings', language)}</label>
+            <textarea
+              className={`form-control ${
+                formData.zcode_settings.trim() && !zcodeValidation.valid ? 'is-invalid' : ''
+              }`}
+              rows={10}
+              value={formData.zcode_settings}
+              onChange={(e) => setFormData({ ...formData, zcode_settings: e.target.value })}
+              placeholder={defaultZcodeSettings}
+            />
+            <JsonValidationIndicator
+              jsonStr={formData.zcode_settings}
+              validation={zcodeValidation}
+              language={language}
+            />
+            <small className="text-muted">{t('zcodeSettingsHint', language)}</small>
           </div>
         )}
       </Modal>

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -1172,6 +1172,10 @@ export const translations: Record<Language, Translations> = {
       'Configure non-sensitive Codex settings only (model, sandbox, etc.). Do NOT include API keys — they are injected via environment variables automatically.',
     claudeSettingsInvalid: 'Claude Code settings JSON is invalid',
     qwenSettingsInvalid: 'Qwen Code settings JSON is invalid',
+    zcodeSettings: 'ZCode Settings (JSON)',
+    zcodeSettingsHint:
+      'Configure non-sensitive settings only (provider, model, etc.). Do NOT include API keys or base URLs — they are injected via the proxy automatically.',
+    zcodeSettingsInvalid: 'ZCode settings JSON is invalid',
     jsonValid: 'JSON is valid',
     jsonInvalid: 'JSON is invalid',
     providerCannotChange: 'Provider cannot be changed',
@@ -2578,6 +2582,10 @@ export const translations: Record<Language, Translations> = {
       '仅配置非敏感 Codex 设置（model、sandbox 等）。请勿填写 API Key — 系统会通过环境变量自动注入。',
     claudeSettingsInvalid: 'Claude Code 设置 JSON 无效',
     qwenSettingsInvalid: 'Qwen Code 设置 JSON 无效',
+    zcodeSettings: 'ZCode 设置 (JSON)',
+    zcodeSettingsHint:
+      '仅配置非敏感设置（provider、model 等）。请勿填写 API Key 或 Base URL — 系统会通过代理自动注入。',
+    zcodeSettingsInvalid: 'ZCode 设置 JSON 无效',
     jsonValid: 'JSON 格式正确',
     jsonInvalid: 'JSON 格式错误',
     providerCannotChange: '提供商不可更改',
@@ -3726,6 +3734,10 @@ export const translations: Record<Language, Translations> = {
     codexSettings: 'Codex 設定 (TOML)',
     codexSettingsHint:
       '機密情報以外の Codex 設定のみを構成してください（model、sandbox など）。API キーは含めないでください — 環境変数経由で自動的に挿入されます。',
+    zcodeSettings: 'ZCode 設定 (JSON)',
+    zcodeSettingsHint:
+      '機密情報以外の設定のみを構成してください（provider、model など）。API キーや Base URL は含めないでください — プロキシ経由で自動的に注入されます。',
+    zcodeSettingsInvalid: 'ZCode 設定の JSON が無効です',
     providerCannotChange: 'プロバイダーは変更できません',
 
     // Fullscreen
@@ -4841,6 +4853,10 @@ export const translations: Record<Language, Translations> = {
     codexSettings: 'Codex 설정 (TOML)',
     codexSettingsHint:
       '민감하지 않은 Codex 설정만 구성하세요 (model, sandbox 등). API 키는 포함하지 마세요 — 환경 변수를 통해 자동으로 주입됩니다.',
+    zcodeSettings: 'ZCode 설정 (JSON)',
+    zcodeSettingsHint:
+      '민감하지 않은 설정만 구성하세요 (provider, model 등). API 키나 Base URL은 포함하지 마세요 — 프록시를 통해 자동으로 주입됩니다.',
+    zcodeSettingsInvalid: 'ZCode 설정 JSON이 잘못되었습니다',
     providerCannotChange: '공급자를 변경할 수 없습니다',
 
     // Fullscreen


### PR DESCRIPTION
## Problem
Creating an API key for **zcode** at `/manage/settings/api-keys` produced a key with `cli_tools=["zcode"]` but an empty `cli_settings` — no default template, no settings textarea. Consequences:
- The agent's `~/.zcode/cli/config.json` was never written on launch (the write path, `write_zcode_settings`, is keyed off `cli_settings["zcode"]`, which was always absent).
- The model dropdown stayed empty for zcode even after #1133 made the *read* path provider-agnostic (it looks for `settings["model"]`, which was never stored).

So zcode was selectable in the tool list but had no working configuration flow.

## Fix
Mirror the claude/qwen/codex pattern for zcode:
- **`defaultZcodeSettings`** template matching the `zcode.config.v1` schema (`provider.zai` + `model.{main,lite}` = `zai/glm-5.2`, `zai/glm-4.5-air`) — exactly what `remote-agent/cli_settings.py:write_zcode_settings` consumes.
- **Form wiring**: `zcode_settings` state + JSON validation, auto-filled on tool toggle, loaded on edit, serialized under the `"zcode"` key in `buildCliSettingsJson`, and validated in both add/update handlers.
- **Textarea + validation indicator** in both the Add and Edit dialogs.
- **i18n** (`zcodeSettings` / `zcodeSettingsHint` / `zcodeSettingsInvalid`) in all 4 languages — preserves en/zh symmetry and the ja/ko key-gap ratchet.

After this, a zcode key stores real config → the agent gets a written `~/.zcode/cli/config.json`, and #1133's provider-agnostic read surfaces `glm-5.2` / `glm-4.5-air` in the dropdown.

## Testing
- `npm run typecheck` — clean
- `eslint` on changed files — clean
- `vitest run` — 400 passed (incl. the i18n en/zh symmetry + ja/ko gap-ratchet tests)

## Scope
Frontend-only. The backend already supported zcode end-to-end (`_CLI_SETTINGS_TOOLS` includes it, `get_cli_settings_for_tool` normalizes it, `apply_cli_settings` writes it); only the creation form was missing.