### PR TITLE
fix(autonomous): nudge to GitHub Issue mode when text input looks like issue selectors

### DIFF
--- a/frontend/src/components/work/NewAutonomousModal.test.tsx
+++ b/frontend/src/components/work/NewAutonomousModal.test.tsx
@@ -322,4 +322,58 @@ describe('NewAutonomousModal', () => {
     });
     expect(localStorage.getItem('local-last-project-path')).toBeNull();
   });
+
+  describe('issue-mode suggestion in text mode', () => {
+    it('suggests switching when the text input is a bare issue number', () => {
+      render(<NewAutonomousModal {...defaultProps} />);
+
+      const textarea = screen.getByPlaceholderText('autoRequirementsPlaceholder');
+      fireEvent.change(textarea, { target: { value: '830' } });
+
+      expect(screen.getByText('autoIssueSuggestionSwitch')).toBeInTheDocument();
+    });
+
+    it('suggests switching for comma/space/range/URL selectors', () => {
+      render(<NewAutonomousModal {...defaultProps} />);
+
+      const textarea = screen.getByPlaceholderText('autoRequirementsPlaceholder');
+      fireEvent.change(textarea, {
+        target: { value: '807, 820-824 https://github.com/open-ace/open-ace/issues/830' },
+      });
+
+      expect(screen.getByText('autoIssueSuggestionSwitch')).toBeInTheDocument();
+    });
+
+    it('does not suggest for prose that merely contains a number', () => {
+      render(<NewAutonomousModal {...defaultProps} />);
+
+      const textarea = screen.getByPlaceholderText('autoRequirementsPlaceholder');
+      fireEvent.change(textarea, { target: { value: 'Fix the bug described in issue 830' } });
+
+      expect(screen.queryByText('autoIssueSuggestionSwitch')).not.toBeInTheDocument();
+    });
+
+    it('does not suggest for a normal feature description', () => {
+      render(<NewAutonomousModal {...defaultProps} />);
+
+      const textarea = screen.getByPlaceholderText('autoRequirementsPlaceholder');
+      fireEvent.change(textarea, { target: { value: 'Add a login page with OAuth' } });
+
+      expect(screen.queryByText('autoIssueSuggestionSwitch')).not.toBeInTheDocument();
+    });
+
+    it('migrates the text and switches to url mode on click', () => {
+      render(<NewAutonomousModal {...defaultProps} />);
+
+      fireEvent.change(screen.getByPlaceholderText('autoRequirementsPlaceholder'), {
+        target: { value: '830' },
+      });
+      fireEvent.click(screen.getByText('autoIssueSuggestionSwitch'));
+
+      // url-mode textarea is revealed with the migrated value
+      expect(screen.getByDisplayValue('830')).toBeInTheDocument();
+      // text-mode textarea is gone (its value cleared and mode switched)
+      expect(screen.queryByPlaceholderText('autoRequirementsPlaceholder')).not.toBeInTheDocument();
+    });
+  });
 });

--- a/frontend/src/components/work/NewAutonomousModal.test.tsx
+++ b/frontend/src/components/work/NewAutonomousModal.test.tsx
@@ -362,6 +362,16 @@ describe('NewAutonomousModal', () => {
       expect(screen.queryByText('autoIssueSuggestionSwitch')).not.toBeInTheDocument();
     });
 
+    it('does not suggest for non-positive or inverted ranges the backend rejects', () => {
+      render(<NewAutonomousModal {...defaultProps} />);
+
+      const textarea = screen.getByPlaceholderText('autoRequirementsPlaceholder');
+      for (const bad of ['0', '0-5', '100-50', '830 0']) {
+        fireEvent.change(textarea, { target: { value: bad } });
+        expect(screen.queryByText('autoIssueSuggestionSwitch')).not.toBeInTheDocument();
+      }
+    });
+
     it('migrates the text and switches to url mode on click', () => {
       render(<NewAutonomousModal {...defaultProps} />);
 

--- a/frontend/src/components/work/NewAutonomousModal.tsx
+++ b/frontend/src/components/work/NewAutonomousModal.tsx
@@ -40,6 +40,26 @@ function setStoredPath(key: string, path: string): void {
   }
 }
 
+// Regexes mirror the backend `_parse_issue_selectors` contract
+// (ISSUE_URL_RE / ISSUE_RANGE_RE in app/routes/autonomous.py). Hoisted to
+// module scope so they are allocated once, not per render.
+const ISSUE_URL_RE = /^https:\/\/github\.com\/[^/\s]+\/[^/\s]+\/issues\/\d+(?:[/?#].*)?$/i;
+const ISSUE_RANGE_RE = /^(\d+)-(\d+)$/;
+
+// Returns true only for tokens the backend would actually accept (rejecting
+// non-positive numbers and inverted ranges), so the suggestion never nudges the
+// user toward a mode where every token would be silently dropped.
+function isAcceptableIssueToken(tok: string): boolean {
+  if (/^\d+$/.test(tok)) return Number(tok) > 0;
+  const rangeMatch = ISSUE_RANGE_RE.exec(tok);
+  if (rangeMatch) {
+    const start = Number(rangeMatch[1]);
+    const end = Number(rangeMatch[2]);
+    return start > 0 && end > 0 && start <= end;
+  }
+  return ISSUE_URL_RE.test(tok);
+}
+
 export const NewAutonomousModal: React.FC<NewAutonomousModalProps> = ({
   show,
   onClose,
@@ -138,16 +158,10 @@ export const NewAutonomousModal: React.FC<NewAutonomousModalProps> = ({
     if (!trimmed) return null;
     const tokens = trimmed.split(/[\s,]+/).filter(Boolean);
     if (tokens.length === 0) return null;
-    const issueUrlRe = /^https:\/\/github\.com\/[^/\s]+\/[^/\s]+\/issues\/\d+(?:[/?#].*)?$/i;
-    const rangeRe = /^\d+-\d+$/;
-    const isIssueToken = (tok: string) =>
-      /^\d+$/.test(tok) || rangeRe.test(tok) || issueUrlRe.test(tok);
     // Only suggest when the ENTIRE input parses as issue selectors. A prose
     // description that merely contains a number ("see issue 830 for details")
     // must not trigger the nudge.
-    const allMatch = tokens.every(isIssueToken);
-    if (!allMatch) return null;
-    return trimmed;
+    return tokens.every(isAcceptableIssueToken) ? trimmed : null;
   }, [requirementsMode, requirementsText]);
 
   const switchToIssueMode = useCallback(() => {

--- a/frontend/src/components/work/NewAutonomousModal.tsx
+++ b/frontend/src/components/work/NewAutonomousModal.tsx
@@ -128,6 +128,34 @@ export const NewAutonomousModal: React.FC<NewAutonomousModalProps> = ({
     }
   }, [show, isNewProject, workspaceType, selectedMachineId, selectedMachineWorkDir]);
 
+  // Detect when a "Text Description" input actually looks like a GitHub issue
+  // selector (bare numbers, ranges, or issue URLs). Mirrors the backend's
+  // _parse_issue_selectors so we can nudge the user toward the correct mode
+  // instead of silently storing e.g. "830" as a literal requirement body.
+  const issueLikeSuggestion = useMemo(() => {
+    if (requirementsMode !== 'text') return null;
+    const trimmed = requirementsText.trim();
+    if (!trimmed) return null;
+    const tokens = trimmed.split(/[\s,]+/).filter(Boolean);
+    if (tokens.length === 0) return null;
+    const issueUrlRe = /^https:\/\/github\.com\/[^/\s]+\/[^/\s]+\/issues\/\d+(?:[/?#].*)?$/i;
+    const rangeRe = /^\d+-\d+$/;
+    const isIssueToken = (tok: string) =>
+      /^\d+$/.test(tok) || rangeRe.test(tok) || issueUrlRe.test(tok);
+    // Only suggest when the ENTIRE input parses as issue selectors. A prose
+    // description that merely contains a number ("see issue 830 for details")
+    // must not trigger the nudge.
+    const allMatch = tokens.every(isIssueToken);
+    if (!allMatch) return null;
+    return trimmed;
+  }, [requirementsMode, requirementsText]);
+
+  const switchToIssueMode = useCallback(() => {
+    setRequirementsUrl(requirementsText);
+    setRequirementsText('');
+    setRequirementsMode('url');
+  }, [requirementsText]);
+
   const canSubmit = useMemo(() => {
     const hasRequirements =
       requirementsMode === 'text' ? !!requirementsText.trim() : !!requirementsUrl.trim();
@@ -278,13 +306,27 @@ export const NewAutonomousModal: React.FC<NewAutonomousModalProps> = ({
               </button>
             </div>
             {requirementsMode === 'text' ? (
-              <textarea
-                className="form-control"
-                rows={4}
-                placeholder={t('autoRequirementsPlaceholder', language)}
-                value={requirementsText}
-                onChange={(e) => setRequirementsText(e.target.value)}
-              />
+              <>
+                <textarea
+                  className="form-control"
+                  rows={4}
+                  placeholder={t('autoRequirementsPlaceholder', language)}
+                  value={requirementsText}
+                  onChange={(e) => setRequirementsText(e.target.value)}
+                />
+                {issueLikeSuggestion && (
+                  <div className="alert alert-warning py-2 mt-2 d-flex align-items-center gap-2 flex-wrap" role="alert">
+                    <span>{t('autoIssueSuggestionHint', language)}</span>
+                    <button
+                      type="button"
+                      className="btn btn-sm btn-outline-primary ms-auto"
+                      onClick={switchToIssueMode}
+                    >
+                      {t('autoIssueSuggestionSwitch', language)}
+                    </button>
+                  </div>
+                )}
+              </>
             ) : (
               <>
                 <textarea

--- a/frontend/src/components/work/NewAutonomousModal.tsx
+++ b/frontend/src/components/work/NewAutonomousModal.tsx
@@ -329,7 +329,10 @@ export const NewAutonomousModal: React.FC<NewAutonomousModalProps> = ({
                   onChange={(e) => setRequirementsText(e.target.value)}
                 />
                 {issueLikeSuggestion && (
-                  <div className="alert alert-warning py-2 mt-2 d-flex align-items-center gap-2 flex-wrap" role="alert">
+                  <div
+                    className="alert alert-warning py-2 mt-2 d-flex align-items-center gap-2 flex-wrap"
+                    role="alert"
+                  >
                     <span>{t('autoIssueSuggestionHint', language)}</span>
                     <button
                       type="button"

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -2671,7 +2671,8 @@ export const translations: Record<Language, Translations> = {
     autoRequirementsPlaceholder: '描述你希望 AI 开发的功能或变更...',
     autoIssueInputPlaceholder: '123 125,128-130 或 https://github.com/owner/repo/issues/123',
     autoIssueInputHint: '支持逗号、空格、换行、12-15 这样的范围，以及混合 GitHub issue URL。',
-    autoIssueSuggestionHint: '这看起来像是 GitHub issue 编号或链接。切换到 GitHub Issue 模式可以正确解析。',
+    autoIssueSuggestionHint:
+      '这看起来像是 GitHub issue 编号或链接。切换到 GitHub Issue 模式可以正确解析。',
     autoIssueSuggestionSwitch: '切换到 GitHub Issue',
     autoTextDescription: '文字描述',
     autoAgentTool: 'Agent 工具',

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -1261,6 +1261,9 @@ export const translations: Record<Language, Translations> = {
     autoIssueInputPlaceholder: '123 125,128-130 or https://github.com/owner/repo/issues/123',
     autoIssueInputHint:
       'Supports commas, spaces, new lines, ranges like 12-15, and mixed GitHub issue URLs.',
+    autoIssueSuggestionHint:
+      'This looks like a GitHub issue number or URL. Switch to GitHub Issue mode to parse it correctly.',
+    autoIssueSuggestionSwitch: 'Switch to GitHub Issue',
     autoTextDescription: 'Text Description',
     autoAgentTool: 'Agent Tool',
     autoModel: 'Model',
@@ -2668,6 +2671,8 @@ export const translations: Record<Language, Translations> = {
     autoRequirementsPlaceholder: '描述你希望 AI 开发的功能或变更...',
     autoIssueInputPlaceholder: '123 125,128-130 或 https://github.com/owner/repo/issues/123',
     autoIssueInputHint: '支持逗号、空格、换行、12-15 这样的范围，以及混合 GitHub issue URL。',
+    autoIssueSuggestionHint: '这看起来像是 GitHub issue 编号或链接。切换到 GitHub Issue 模式可以正确解析。',
+    autoIssueSuggestionSwitch: '切换到 GitHub Issue',
     autoTextDescription: '文字描述',
     autoAgentTool: 'Agent 工具',
     autoModel: '模型',
@@ -3778,6 +3783,9 @@ export const translations: Record<Language, Translations> = {
     autoIssueInputPlaceholder: '123 125,128-130 または https://github.com/owner/repo/issues/123',
     autoIssueInputHint:
       'カンマ、空白、改行、12-15 のような範囲、GitHub issue URL の混在入力に対応します。',
+    autoIssueSuggestionHint:
+      'これは GitHub issue 番号または URL のようです。正しく解析するために GitHub Issue モードに切り替えてください。',
+    autoIssueSuggestionSwitch: 'GitHub Issue に切り替え',
     autoTextDescription: 'テキスト説明',
     autoAgentTool: 'エージェントツール',
     autoModel: 'モデル',
@@ -4897,6 +4905,9 @@ export const translations: Record<Language, Translations> = {
     autoIssueInputPlaceholder: '123 125,128-130 또는 https://github.com/owner/repo/issues/123',
     autoIssueInputHint:
       '쉼표, 공백, 줄바꿈, 12-15 같은 범위, GitHub 이슈 URL 혼합 입력을 지원합니다.',
+    autoIssueSuggestionHint:
+      'GitHub 이슈 번호 또는 URL로 보입니다. 올바르게 파싱하려면 GitHub Issue 모드로 전환하세요.',
+    autoIssueSuggestionSwitch: 'GitHub Issue로 전환',
     autoTextDescription: '텍스트 설명',
     autoAgentTool: '에이전트 도구',
     autoModel: '모델',


### PR DESCRIPTION
## Problem

When creating an autonomous workflow, the requirements area has two mutually exclusive modes — **Text Description** (`requirements_text`) and **GitHub Issue** (`requirements_issue_input`). Only the GitHub Issue mode parses bare numbers like `830` as issue selectors via `_parse_issue_selectors`.

If a user selects Text mode and types a bare issue number (e.g. `830`), the backend stores it verbatim as the requirement body. The workflow then:
- Runs with an empty requirement (`"830"` as the only content)
- Auto-creates a spurious GitHub issue (#1135) instead of linking to the real #830
- Stalls in planning — the agent has no real content to work on, times out after 600s

This happened in practice this week (workflow id=524, planning_timeout).

## Fix

Detect the mistake at the source — in `NewAutonomousModal`, while the user is typing in Text mode, check whether the **entire** input parses as issue selectors (mirrors the backend `_parse_issue_selectors` regex: bare numbers, `N-M` ranges, or issue URLs). When it does, show a warning with a one-click **"Switch to GitHub Issue"** button that migrates the text into the issue-input field and switches modes.

### Why "entire input" not "contains"
A prose requirement like `"fix the bug described in issue 830"` is legitimate Text-mode input. Only when **every** whitespace/comma-separated token is a number/range/URL do we suggest switching — so normal descriptions never trigger the nudge.

## Changes
- `frontend/src/components/work/NewAutonomousModal.tsx` — `issueLikeSuggestion` memo + `switchToIssueMode` handler + warning alert UI
- `frontend/src/i18n/index.ts` — 2 new keys (`autoIssueSuggestionHint`, `autoIssueSuggestionSwitch`) for en/zh/ja/ko
- `frontend/src/components/work/NewAutonomousModal.test.tsx` — 5 new tests

## Test plan
- [x] `vitest run NewAutonomousModal.test.tsx` — 20 passed (15 existing + 5 new)
- [x] `tsc --noEmit` — no errors
- [ ] Manual: type `830` in Text mode → warning appears → click switch → value migrates to Issue mode
- [ ] Manual: type `807, 820-824 https://github.com/open-ace/open-ace/issues/830` → warning appears
- [ ] Manual: type `"fix the bug in issue 830"` → no warning
- [ ] Manual: type `"Add a login page"` → no warning