### PR TITLE
fix(fs): directory browser rejected all paths on macOS

### DIFF
--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -7,6 +7,7 @@ API routes for admin operations.
 import logging
 import os
 import subprocess
+from pathlib import Path
 from typing import Optional, cast
 
 import bcrypt
@@ -32,8 +33,12 @@ def hash_password(password: str) -> str:
 
 
 def get_workspace_base_dir() -> str:
-    """Get the workspace base directory. Configurable via WORKSPACE_BASE_DIR env var."""
-    return os.environ.get("WORKSPACE_BASE_DIR", "/home")
+    """Get the workspace base directory. Configurable via WORKSPACE_BASE_DIR env var.
+
+    Falls back to the user's home directory when unset — see fs.py's
+    ``get_workspace_base_dir`` for rationale.
+    """
+    return os.environ.get("WORKSPACE_BASE_DIR") or str(Path.home())
 
 
 def ensure_system_user(system_account: str, uid: Optional[int] = None) -> bool:

--- a/app/routes/fs.py
+++ b/app/routes/fs.py
@@ -134,8 +134,14 @@ def get_webui_user():
 
 
 def get_workspace_base_dir() -> str:
-    """Get the workspace base directory. Configurable via WORKSPACE_BASE_DIR env var."""
-    return os.environ.get("WORKSPACE_BASE_DIR", "/home")
+    """Get the workspace base directory. Configurable via WORKSPACE_BASE_DIR env var.
+
+    When the env var is unset, falls back to the current user's home directory
+    (e.g. ``/Users/<user>`` on macOS, ``/home/<user>`` on Linux) so the
+    directory browser works out of the box on any platform. Docker/server
+    deployments set ``WORKSPACE_BASE_DIR`` explicitly (e.g. ``/workspace``).
+    """
+    return os.environ.get("WORKSPACE_BASE_DIR") or str(Path.home())
 
 
 def get_workspace_base_dirs() -> list[str]:
@@ -143,8 +149,11 @@ def get_workspace_base_dirs() -> list[str]:
 
     Example: WORKSPACE_BASE_DIR=/workspace,/tools,/projects
     Returns: ['/workspace', '/tools', '/projects']
+
+    When unset, defaults to ``[str(Path.home())]`` — see
+    :func:`get_workspace_base_dir`.
     """
-    base_dir = os.environ.get("WORKSPACE_BASE_DIR", "/home")
+    base_dir = os.environ.get("WORKSPACE_BASE_DIR") or str(Path.home())
     return [d.strip() for d in base_dir.split(",") if d.strip()]
 
 

--- a/app/routes/workspace.py
+++ b/app/routes/workspace.py
@@ -11,6 +11,7 @@ API endpoints for workspace functionality including:
 
 import logging
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 
 from flask import Blueprint, g, jsonify, request
 
@@ -1981,7 +1982,7 @@ def get_workspace_config():
         config_path = os.path.join(CONFIG_DIR, "config.json")
 
         # Get workspace base directory for path validation
-        base_dir = os.environ.get("WORKSPACE_BASE_DIR", "/home")
+        base_dir = os.environ.get("WORKSPACE_BASE_DIR") or str(Path.home())
 
         workspace_config = {
             "enabled": False,
@@ -2019,7 +2020,7 @@ def get_workspace_config():
                 "enabled": False,
                 "url": "",
                 "multi_user_mode": False,
-                "base_dir": "/home",
+                "base_dir": str(Path.home()),
                 "autonomous_enabled": False,
             }
         )

--- a/tests/unit/test_fs_path_validation.py
+++ b/tests/unit/test_fs_path_validation.py
@@ -41,47 +41,51 @@ class TestWorkspaceBaseDirDefault:
 
 
 class TestIsValidPath:
-    """is_valid_path prefix + blacklist + traversal behavior."""
+    """is_valid_path prefix + blacklist + traversal behavior.
 
-    def test_home_prefix_allowed_when_default(self, monkeypatch, tmp_path):
+    NOTE: tests deliberately avoid pytest's ``tmp_path`` — on Linux it lives
+    under /tmp, which is in BLACKLISTED_PATHS, so any tmp_path-based assertion
+    would be rejected by the blacklist regardless of the prefix check. We also
+    avoid hard-coding /home/... because macOS autofs rewrites /home under
+    realpath. Instead we pick a prefix that realpath leaves untouched on both
+    platforms by using a workspace env override with a non-blacklisted root.
+    """
+
+    def test_home_prefix_allowed_when_default(self, monkeypatch):
         monkeypatch.delenv("WORKSPACE_BASE_DIR", raising=False)
         # A path under the real home dir passes the prefix check (path need not exist).
         candidate = str(Path.home() / "some_project")
         assert is_valid_path(candidate, allowed_prefixes=get_workspace_base_dirs())
 
-    def test_blacklisted_dir_rejected(self, monkeypatch, tmp_path):
-        # Blacklist fires independent of allowed_prefixes. Use a real tmp dir as
-        # the allowed prefix, and a blacklisted path that resolves identically on
-        # both Linux (/usr/bin) — note macOS symlinks /etc → /private/etc so /etc
-        # is NOT caught there (a pre-existing platform quirk, out of scope here).
-        home = str(tmp_path)
-        assert not is_valid_path("/usr/bin", allowed_prefixes=[home])
+    def test_blacklisted_dir_rejected(self):
+        # Blacklist fires independent of allowed_prefixes. /usr/bin resolves to
+        # itself on both Linux and macOS and is blacklisted on both.
+        assert not is_valid_path("/usr/bin", allowed_prefixes=[str(Path.home())])
 
-    def test_outside_prefix_rejected(self, tmp_path):
-        # A path outside the allowed prefix is rejected even if not blacklisted.
-        # Use tmp_path (which exists) so realpath doesn't traverse symlinks.
-        inside = tmp_path / "repo"
-        outside = tmp_path.parent / "other_user"
-        assert is_valid_path(str(inside), allowed_prefixes=[str(tmp_path)])
-        assert not is_valid_path(str(outside), allowed_prefixes=[str(tmp_path)])
+    def test_inside_prefix_accepted_outside_rejected(self, monkeypatch):
+        # Use a synthetic, non-blacklisted prefix that realpath leaves alone.
+        # /workspace is not in BLACKLISTED_PATHS and resolves to itself on both
+        # Linux and macOS (no autofs/symlink interference).
+        prefix = "/workspace"
+        assert is_valid_path("/workspace/repo", allowed_prefixes=[prefix])
+        # Outside the prefix:
+        assert not is_valid_path("/srv/repo", allowed_prefixes=[prefix])
 
-    def test_prefix_boundary_not_prefix_match(self, tmp_path):
-        # tmp_path must not match as a prefix of a sibling whose name extends it,
-        # and vice-versa (prevents /home/alice matching /home/alice_evil).
-        sibling = tmp_path.parent / (tmp_path.name + "_evil")
-        assert not is_valid_path(str(sibling), allowed_prefixes=[str(tmp_path)])
+    def test_prefix_boundary_not_prefix_match(self):
+        # A sibling whose name extends the prefix must NOT match it.
+        prefix = "/workspace"
+        assert not is_valid_path("/workspace_evil/repo", allowed_prefixes=[prefix])
 
-    def test_parent_traversal_rejected(self, tmp_path):
-        # ".." anywhere in the input is rejected outright.
-        assert not is_valid_path(str(tmp_path / ".." / "etc"), allowed_prefixes=[str(tmp_path)])
+    def test_parent_traversal_rejected(self):
+        # ".." anywhere in the input is rejected outright (before prefix check).
+        assert not is_valid_path("/workspace/repo/../etc", allowed_prefixes=["/workspace"])
 
     def test_empty_rejected(self):
         assert not is_valid_path("", allowed_prefixes=None)
 
-    def test_no_prefix_restriction_allows_non_blacklisted(self, tmp_path):
-        # allowed_prefixes=None → only the blacklist applies. A real tmp path
-        # is not blacklisted and resolves to itself.
-        assert is_valid_path(str(tmp_path), allowed_prefixes=None)
+    def test_no_prefix_restriction_allows_non_blacklisted(self):
+        # allowed_prefixes=None → only the blacklist applies.
+        assert is_valid_path("/workspace/repo", allowed_prefixes=None)
         assert not is_valid_path("/usr/bin", allowed_prefixes=None)
 
 

--- a/tests/unit/test_fs_path_validation.py
+++ b/tests/unit/test_fs_path_validation.py
@@ -1,0 +1,101 @@
+"""Unit tests for workspace base-dir resolution and path validation (app/routes/fs.py).
+
+Guards the macOS directory-browser bug: when ``WORKSPACE_BASE_DIR`` is unset,
+the allowed-prefix default must be the user's actual home directory (e.g.
+``/Users/<user>`` on macOS), not the Linux-only ``/home`` — otherwise every
+explicit path is rejected with "Path must be under one of: /home".
+"""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from app.routes.fs import get_workspace_base_dir, get_workspace_base_dirs, is_valid_path
+
+
+class TestWorkspaceBaseDirDefault:
+    """WORKSPACE_BASE_DIR unset → default to the user's home directory."""
+
+    def test_unset_env_falls_back_to_home(self, monkeypatch):
+        monkeypatch.delenv("WORKSPACE_BASE_DIR", raising=False)
+        assert get_workspace_base_dir() == str(Path.home())
+
+    def test_unset_env_dirs_contain_home(self, monkeypatch):
+        monkeypatch.delenv("WORKSPACE_BASE_DIR", raising=False)
+        assert str(Path.home()) in get_workspace_base_dirs()
+
+    def test_explicit_env_overrides_home(self, monkeypatch):
+        monkeypatch.setenv("WORKSPACE_BASE_DIR", "/workspace")
+        assert get_workspace_base_dir() == "/workspace"
+        assert get_workspace_base_dirs() == ["/workspace"]
+
+    def test_comma_separated_multiple_dirs(self, monkeypatch):
+        monkeypatch.setenv("WORKSPACE_BASE_DIR", "/workspace,/opt/projects")
+        assert get_workspace_base_dirs() == ["/workspace", "/opt/projects"]
+
+    def test_empty_env_falls_back_to_home(self, monkeypatch):
+        # An empty string env value should also fall back (the `or` guard).
+        monkeypatch.setenv("WORKSPACE_BASE_DIR", "")
+        assert get_workspace_base_dir() == str(Path.home())
+
+
+class TestIsValidPath:
+    """is_valid_path prefix + blacklist + traversal behavior."""
+
+    def test_home_prefix_allowed_when_default(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("WORKSPACE_BASE_DIR", raising=False)
+        # A path under the real home dir passes the prefix check (path need not exist).
+        candidate = str(Path.home() / "some_project")
+        assert is_valid_path(candidate, allowed_prefixes=get_workspace_base_dirs())
+
+    def test_blacklisted_dir_rejected(self, monkeypatch, tmp_path):
+        # Blacklist fires independent of allowed_prefixes. Use a real tmp dir as
+        # the allowed prefix, and a blacklisted path that resolves identically on
+        # both Linux (/usr/bin) — note macOS symlinks /etc → /private/etc so /etc
+        # is NOT caught there (a pre-existing platform quirk, out of scope here).
+        home = str(tmp_path)
+        assert not is_valid_path("/usr/bin", allowed_prefixes=[home])
+
+    def test_outside_prefix_rejected(self, tmp_path):
+        # A path outside the allowed prefix is rejected even if not blacklisted.
+        # Use tmp_path (which exists) so realpath doesn't traverse symlinks.
+        inside = tmp_path / "repo"
+        outside = tmp_path.parent / "other_user"
+        assert is_valid_path(str(inside), allowed_prefixes=[str(tmp_path)])
+        assert not is_valid_path(str(outside), allowed_prefixes=[str(tmp_path)])
+
+    def test_prefix_boundary_not_prefix_match(self, tmp_path):
+        # tmp_path must not match as a prefix of a sibling whose name extends it,
+        # and vice-versa (prevents /home/alice matching /home/alice_evil).
+        sibling = tmp_path.parent / (tmp_path.name + "_evil")
+        assert not is_valid_path(str(sibling), allowed_prefixes=[str(tmp_path)])
+
+    def test_parent_traversal_rejected(self, tmp_path):
+        # ".." anywhere in the input is rejected outright.
+        assert not is_valid_path(str(tmp_path / ".." / "etc"), allowed_prefixes=[str(tmp_path)])
+
+    def test_empty_rejected(self):
+        assert not is_valid_path("", allowed_prefixes=None)
+
+    def test_no_prefix_restriction_allows_non_blacklisted(self, tmp_path):
+        # allowed_prefixes=None → only the blacklist applies. A real tmp path
+        # is not blacklisted and resolves to itself.
+        assert is_valid_path(str(tmp_path), allowed_prefixes=None)
+        assert not is_valid_path("/usr/bin", allowed_prefixes=None)
+
+
+class TestAdminWorkspaceBaseDirDefault:
+    """The duplicate get_workspace_base_dir in admin.py shares the default."""
+
+    def test_admin_unset_env_falls_back_to_home(self, monkeypatch):
+        monkeypatch.delenv("WORKSPACE_BASE_DIR", raising=False)
+        from app.routes.admin import get_workspace_base_dir as admin_get
+
+        assert admin_get() == str(Path.home())
+
+    def test_admin_explicit_env_overrides(self, monkeypatch):
+        monkeypatch.setenv("WORKSPACE_BASE_DIR", "/workspace")
+        from app.routes.admin import get_workspace_base_dir as admin_get
+
+        assert admin_get() == "/workspace"


### PR DESCRIPTION
## Problem
Creating an autonomous workflow and selecting a project directory failed on macOS with `Path must be under one of: /home` for **every** path.

## Root cause
`/api/fs/browse` validates the chosen path against `WORKSPACE_BASE_DIR`. When that env var is unset, it defaulted to the Linux convention **`/home`**, so on macOS real paths like `/Users/<user>/workspace/...` never matched the allowed prefix and were all rejected.

The "home" navigation worked only because it goes through `get_home_directory()` (which already falls back to `Path.home()`) and bypasses `is_valid_path`; any explicit path was forced through the prefix check and failed.

## Fix
Change the unset-default from `/home` to `str(Path.home())` in all four places that read the env, using `or` so explicit values still win:
- `app/routes/fs.py` — `get_workspace_base_dir()` + `get_workspace_base_dirs()`
- `app/routes/admin.py` — duplicate `get_workspace_base_dir()` (+ `from pathlib import Path`)
- `app/routes/workspace.py` — frontend-facing `base_dir` and its error fallback (+ import)

Effect:
- **macOS local dev**: unset env → default `/Users/<user>` → browsing/selecting home paths works out of the box.
- **Docker/server**: env is explicitly set (`/workspace`), zero change.
- **Want a path outside home?** Set `WORKSPACE_BASE_DIR=/Users/me,/opt/projects` (comma-separated).

The blacklist (`/etc`, `/bin`, `/usr`, `/var`, `/tmp`, …) is evaluated independently and before the prefix check, so this only widens browsing to the user's own home tree — strictly safer than `/home` (which covers every user's home on Linux).

## Testing
New `tests/unit/test_fs_path_validation.py` (fs.py previously had zero unit tests): home fallback when unset, explicit-env override, comma-separated multi-dir, empty-env fallback, prefix-boundary (no `/home/alice` matching `/home/alice_evil`), blacklist rejection, parent-traversal rejection, and the admin.py duplicate. → 14 passed.

## Notes / out of scope
- ⚠️ **Behavior change**: the default is now the user's home dir, not `/home`. Documented in `.env.example` (local-only; that file is gitignored so not in this PR). Linux servers running as root without the env set would land on `/root` (blacklisted) — operators should set the env, as before.
- A pre-existing macOS quirk: `/etc` → `/private/etc` symlink means the blacklist doesn't catch `/etc` on macOS. Not addressed here (predates this change, separate concern).