### PR TITLE
refactor(fs): shared workspace base-dir helper + macOS blacklist symlink fix

### DIFF
--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -7,7 +7,6 @@ API routes for admin operations.
 import logging
 import os
 import subprocess
-from pathlib import Path
 from typing import Optional, cast
 
 import bcrypt
@@ -19,6 +18,7 @@ from app.repositories.user_repo import UserRepository
 from app.schemas.quota import validate_quota_update
 from app.services.auth_service import get_security_settings_cached
 from app.utils.validators import validate_email, validate_password, validate_username
+from app.utils.workspace import get_workspace_base_dir
 
 logger = logging.getLogger(__name__)
 
@@ -30,15 +30,6 @@ usage_repo = UsageRepository()
 def hash_password(password: str) -> str:
     """Hash a password using bcrypt."""
     return cast("str", bcrypt.hashpw(password.encode(), bcrypt.gensalt(rounds=12)).decode())
-
-
-def get_workspace_base_dir() -> str:
-    """Get the workspace base directory. Configurable via WORKSPACE_BASE_DIR env var.
-
-    Falls back to the user's home directory when unset — see fs.py's
-    ``get_workspace_base_dir`` for rationale.
-    """
-    return os.environ.get("WORKSPACE_BASE_DIR") or str(Path.home())
 
 
 def ensure_system_user(system_account: str, uid: Optional[int] = None) -> bool:

--- a/app/routes/fs.py
+++ b/app/routes/fs.py
@@ -17,6 +17,7 @@ from typing import Any
 from flask import Blueprint, g, jsonify, request
 
 from app.repositories.user_repo import UserRepository
+from app.utils.workspace import get_workspace_base_dir, get_workspace_base_dirs
 
 logger = logging.getLogger(__name__)
 
@@ -43,6 +44,16 @@ BLACKLISTED_PATHS = [
     "/lib",  # Shared libraries
     "/lib64",  # 64-bit libraries
 ]
+
+# Resolved blacklist used for matching: each literal is canonicalized through
+# realpath so symlinked entries still match. On macOS /etc → /private/etc,
+# /var → /private/var, /tmp → /private/tmp; without this, a path like /etc
+# (realpath /private/etc) would slip past the literal /etc check. Keep both the
+# literal (for readability/docs above) and its realpath here.
+_BLACKLISTED_RESOLVED = {
+    *BLACKLISTED_PATHS,
+    *(os.path.realpath(p) for p in BLACKLISTED_PATHS),
+}
 
 
 @fs_bp.before_request
@@ -133,30 +144,6 @@ def get_webui_user():
     return user, None, 200
 
 
-def get_workspace_base_dir() -> str:
-    """Get the workspace base directory. Configurable via WORKSPACE_BASE_DIR env var.
-
-    When the env var is unset, falls back to the current user's home directory
-    (e.g. ``/Users/<user>`` on macOS, ``/home/<user>`` on Linux) so the
-    directory browser works out of the box on any platform. Docker/server
-    deployments set ``WORKSPACE_BASE_DIR`` explicitly (e.g. ``/workspace``).
-    """
-    return os.environ.get("WORKSPACE_BASE_DIR") or str(Path.home())
-
-
-def get_workspace_base_dirs() -> list[str]:
-    """Get list of workspace base directories. Supports comma-separated WORKSPACE_BASE_DIR.
-
-    Example: WORKSPACE_BASE_DIR=/workspace,/tools,/projects
-    Returns: ['/workspace', '/tools', '/projects']
-
-    When unset, defaults to ``[str(Path.home())]`` — see
-    :func:`get_workspace_base_dir`.
-    """
-    base_dir = os.environ.get("WORKSPACE_BASE_DIR") or str(Path.home())
-    return [d.strip() for d in base_dir.split(",") if d.strip()]
-
-
 def get_home_directory(user=None):
     """Get user's home directory based on system_account."""
     base_dir = get_workspace_base_dir()
@@ -208,7 +195,7 @@ def is_valid_path(path: str, allowed_prefixes: list[str] | None = None) -> bool:
             return False
 
         # Blacklist check for Linux/Mac - protect system directories
-        for blocked in BLACKLISTED_PATHS:
+        for blocked in _BLACKLISTED_RESOLVED:
             if abs_path == blocked or abs_path.startswith(blocked + os.sep):
                 return False
 

--- a/app/routes/workspace.py
+++ b/app/routes/workspace.py
@@ -11,7 +11,6 @@ API endpoints for workspace functionality including:
 
 import logging
 from datetime import datetime, timedelta, timezone
-from pathlib import Path
 
 from flask import Blueprint, g, jsonify, request
 
@@ -24,6 +23,7 @@ from app.modules.workspace.session_manager import SessionType, _param, get_sessi
 from app.modules.workspace.state_sync import get_state_sync_manager
 from app.modules.workspace.tool_connector import get_tool_connector
 from app.utils.tool_names import TOOL_NAME_ALIASES, normalize_tool_name
+from app.utils.workspace import get_workspace_base_dir
 
 logger = logging.getLogger(__name__)
 
@@ -1982,7 +1982,7 @@ def get_workspace_config():
         config_path = os.path.join(CONFIG_DIR, "config.json")
 
         # Get workspace base directory for path validation
-        base_dir = os.environ.get("WORKSPACE_BASE_DIR") or str(Path.home())
+        base_dir = get_workspace_base_dir()
 
         workspace_config = {
             "enabled": False,
@@ -2020,7 +2020,7 @@ def get_workspace_config():
                 "enabled": False,
                 "url": "",
                 "multi_user_mode": False,
-                "base_dir": str(Path.home()),
+                "base_dir": get_workspace_base_dir(),
                 "autonomous_enabled": False,
             }
         )

--- a/app/utils/workspace.py
+++ b/app/utils/workspace.py
@@ -1,0 +1,38 @@
+"""Workspace base-directory resolution.
+
+Single source of truth for the ``WORKSPACE_BASE_DIR`` env var so the directory
+browser's allowed-prefix logic is consistent across routes (fs / admin /
+workspace). When the env var is unset, the default is the current user's home
+directory (e.g. ``/Users/<user>`` on macOS, ``/home/<user>`` on Linux) so the
+browser works out of the box on any platform; Docker/server deployments set
+the env explicitly (e.g. ``/workspace``).
+"""
+
+import os
+from pathlib import Path
+
+__all__ = ["get_workspace_base_dir", "get_workspace_base_dirs"]
+
+
+def get_workspace_base_dir() -> str:
+    """Get the workspace base directory. Configurable via WORKSPACE_BASE_DIR env var.
+
+    Falls back to ``str(Path.home())`` when the env var is unset or empty, so
+    the directory browser works on macOS (``/Users/<user>``) and Linux
+    (``/home/<user>``) alike. Explicit env values — e.g. Docker's ``/workspace``
+    — always win.
+    """
+    return os.environ.get("WORKSPACE_BASE_DIR") or str(Path.home())
+
+
+def get_workspace_base_dirs() -> list[str]:
+    """Get list of workspace base directories. Supports comma-separated WORKSPACE_BASE_DIR.
+
+    Example: ``WORKSPACE_BASE_DIR=/workspace,/tools,/projects``
+    Returns: ``['/workspace', '/tools', '/projects']``
+
+    When unset, defaults to ``[str(Path.home())]`` — see
+    :func:`get_workspace_base_dir`.
+    """
+    base_dir = get_workspace_base_dir()
+    return [d.strip() for d in base_dir.split(",") if d.strip()]

--- a/scripts/install-central/docker-method/README.md
+++ b/scripts/install-central/docker-method/README.md
@@ -101,11 +101,13 @@ docker compose up -d --build
 | 变量 | 说明 | 默认值 |
 |------|------|--------|
 | `WORKSPACE_MULTI_USER_MODE` | 启用多用户模式 | false |
-| `WORKSPACE_BASE_DIR` | 用户项目存储根目录 | /workspace（Docker）/home（二进制） |
+| `WORKSPACE_BASE_DIR` | 用户项目存储根目录，支持逗号分隔多个目录（如 `/workspace,/opt/projects`） | /workspace（Docker）/ 用户家目录（二进制，未设时） |
 | `WORKSPACE_PORT_RANGE_START` | 端口池起始端口 | 3100 |
 | `WORKSPACE_PORT_RANGE_END` | 端口池结束端口 | 3200 |
 | `WORKSPACE_MAX_INSTANCES` | 最大实例数 | 30 |
 | `WORKSPACE_IDLE_TIMEOUT` | 空闲超时(分钟) | 30 |
+
+> ⚠️ **二进制部署以 root 运行时**：未设 `WORKSPACE_BASE_DIR` 会回退到 `/root`（root 家目录），而 `/root` 在黑名单中会被拒绝，导致目录浏览不可用。以 root 运行的部署请显式设置 `WORKSPACE_BASE_DIR`（如 `/workspace` 或 `/home`）。
 
 **启动方式：**
 

--- a/tests/unit/test_fs_path_validation.py
+++ b/tests/unit/test_fs_path_validation.py
@@ -62,6 +62,18 @@ class TestIsValidPath:
         # itself on both Linux and macOS and is blacklisted on both.
         assert not is_valid_path("/usr/bin", allowed_prefixes=[str(Path.home())])
 
+    def test_blacklist_catches_symlinked_path(self):
+        # Regression: macOS symlinks /etc -> /private/etc, so a realpath of /etc
+        # yields /private/etc and the literal-blacklist check used to miss it.
+        # The blacklist now resolves each entry through realpath, so both the
+        # literal and its symlink target are rejected on any platform.
+        import os
+
+        resolved = os.path.realpath("/etc")
+        assert not is_valid_path("/etc", allowed_prefixes=None)
+        if resolved != "/etc":  # e.g. /private/etc on macOS — also blocked
+            assert not is_valid_path(resolved, allowed_prefixes=None)
+
     def test_inside_prefix_accepted_outside_rejected(self, monkeypatch):
         # Use a synthetic, non-blacklisted prefix that realpath leaves alone.
         # /workspace is not in BLACKLISTED_PATHS and resolves to itself on both


### PR DESCRIPTION
## Summary
Three follow-ups from the #1137 review, bundled here:

### 1. Dedup the workspace-base-dir default
`get_workspace_base_dir` / `get_workspace_base_dirs` existed in 3 places: `fs.py`, a duplicate in `admin.py`, and two inline reads in `workspace.py`. Extracted to a single `app/utils/workspace.py` module; all three routes now import it. Removes the triplicated home-fallback logic.

### 2. Fix macOS blacklist bypass
`BLACKLISTED_PATHS` stored literal paths (`/etc`, `/var`, `/tmp`, …) but `is_valid_path` compares against the **realpath'd** input. On macOS `/etc` → `/private/etc`, so a realpath of `/etc` slipped past the literal `/etc` check. Pre-resolve each blacklist entry through `realpath` into `_BLACKLISTED_RESOLVED` and match against that — both the literal and its symlink target are now blocked on any platform. (Pre-existing bug, flagged in #1137 review.)

### 3. Docs
Updated `README.md`: `WORKSPACE_BASE_DIR` default → "user home (binary, unset)"; added a note that **root deployments must set it explicitly** (since `/root` is blacklisted, the home fallback would break browsing when running as root).

## Testing
- `black` clean; imports clean.
- `pytest tests/unit/test_fs_path_validation.py` → **15 passed** (added `test_blacklist_catches_symlinked_path` covering the `/etc` → `/private/etc` regression).