### PR TITLE
fix(autonomous): multi-protocol CLI dispatch for zcode/codex/openclaw

### DIFF
--- a/app/modules/workspace/autonomous/agent_runner.py
+++ b/app/modules/workspace/autonomous/agent_runner.py
@@ -143,6 +143,11 @@ class _ZcodeResultCollector:
         self.input_tokens: int = 0
         self.output_tokens: int = 0
         self.request_count: int = 0
+        # When the usage_callback provides an authoritative model_requests
+        # count, we use that instead of counting done=True callbacks. This
+        # avoids double-counting: ZCode calls on_usage (with modelRequestCount)
+        # BEFORE the final on_output(done=True), so both would increment.
+        self._request_count_from_usage: bool = False
         self.event_log: list = []
         self.error: str | None = None
 
@@ -154,7 +159,9 @@ class _ZcodeResultCollector:
         identically regardless of CLI tool. See agent_runner.py:1443-1472.
         """
         if not data:
-            if done:
+            if done and not self._request_count_from_usage:
+                # Fallback: no authoritative model_requests from usage_callback,
+                # so count this turn as 1 request.
                 self.request_count += 1
             return
         try:
@@ -224,9 +231,12 @@ class _ZcodeResultCollector:
         self.input_tokens = usage.get("input", self.input_tokens)
         self.output_tokens = usage.get("output", self.output_tokens)
         self.total_tokens = self.input_tokens + self.output_tokens
-        # model_requests maps to request_count for parity with Claude SDK path
+        # model_requests is the authoritative request count from the model
+        # gateway. When present, it takes precedence over the done=True
+        # fallback counting in on_output to avoid double-counting.
         if "model_requests" in usage:
             self.request_count = usage["model_requests"]
+            self._request_count_from_usage = True
 
     def on_permission(self, session_id: str, control_request: dict) -> None:
         """Auto-approve all permission requests in autonomous mode.

--- a/app/modules/workspace/autonomous/agent_runner.py
+++ b/app/modules/workspace/autonomous/agent_runner.py
@@ -83,6 +83,10 @@ COMPLETION_POLL_INTERVAL = 5.0
 _APPSERVER_TOOLS = frozenset({"zcode", "zcode-code"})
 
 
+class ZCodeSessionError(Exception):
+    """Raised when a ZCode app-server session fails to start or send."""
+
+
 @dataclass
 class _LocalSession:
     """Tracks a local CLI subprocess session."""
@@ -178,10 +182,18 @@ class _ZcodeResultCollector:
                     self.error = msg
 
     def on_usage(self, session_id: str, usage: dict) -> None:
-        """Receive ZCode usage_callback invocations."""
-        self.total_tokens = usage.get("totalTokens", self.total_tokens)
-        self.input_tokens = usage.get("inputTokens", self.input_tokens)
-        self.output_tokens = usage.get("outputTokens", self.output_tokens)
+        """Receive ZCode usage_callback invocations.
+
+        ZCodeAppServerSession emits a normalized dict with snake_case keys
+        (input, output, cache_read, reasoning, model_requests), NOT the
+        camelCase session/usage response. See zcode_app_server.py:335-417.
+        """
+        self.input_tokens = usage.get("input", self.input_tokens)
+        self.output_tokens = usage.get("output", self.output_tokens)
+        self.total_tokens = self.input_tokens + self.output_tokens
+        # model_requests maps to request_count for parity with Claude SDK path
+        if "model_requests" in usage:
+            self.request_count = usage["model_requests"]
 
     def on_permission(self, session_id: str, control_request: dict) -> None:
         """Auto-approve all permission requests in autonomous mode.
@@ -949,36 +961,32 @@ class AutonomousAgentRunner:
                 permission_mode=permission_mode,
                 resume_session_id=resume_session_id if resume else None,
             ):
-                return AgentTaskResult(
-                    session_id=session_id,
-                    tracking_session_id=session_id,
-                    success=False,
-                    error="ZCode session/create failed",
-                )
+                raise ZCodeSessionError("ZCode session/create failed")
 
             tracker.cli_session_id = zc_session._cli_session_id
             tracker.persisted_session_id = zc_session._cli_session_id
             tracker.sdk_initialized.set()
 
             if not zc_session.send_message(prompt):
-                return AgentTaskResult(
-                    session_id=zc_session._cli_session_id or session_id,
-                    tracking_session_id=session_id,
-                    success=False,
-                    error=zc_session.last_send_error or "ZCode session/send failed",
-                )
+                raise ZCodeSessionError(zc_session.last_send_error or "ZCode session/send failed")
 
             completed = zc_session.wait_turn(timeout=timeout)
+        except ZCodeSessionError as e:
+            return AgentTaskResult(
+                session_id=zc_session._cli_session_id or session_id,
+                tracking_session_id=session_id,
+                success=False,
+                error=str(e),
+            )
         finally:
-            # Ensure the app-server process is terminated.
+            # Always clean up: stop the process, remove the tracker, clear PID.
             zc_session.stop()
-
-        self._local_sessions.pop(session_id, None)
-        if self._on_pid_cleared:
-            try:
-                self._on_pid_cleared(session_id)
-            except Exception as e:
-                logger.warning("on_pid_cleared callback failed: %s", e)
+            self._local_sessions.pop(session_id, None)
+            if self._on_pid_cleared:
+                try:
+                    self._on_pid_cleared(session_id)
+                except Exception as e:
+                    logger.warning("on_pid_cleared callback failed: %s", e)
 
         cli_sid = zc_session._cli_session_id or session_id
         if not completed:

--- a/app/modules/workspace/autonomous/agent_runner.py
+++ b/app/modules/workspace/autonomous/agent_runner.py
@@ -147,12 +147,16 @@ class _ZcodeResultCollector:
         self.error: str | None = None
 
     def on_output(self, session_id: str, data: str, stream: str, done: bool) -> None:
-        """Receive ZCode output_callback invocations."""
+        """Receive ZCode output_callback invocations.
+
+        Builds ``event_log`` dicts in the same shape ``_LocalSession._read_stdout``
+        produces, so ``_persist_local_session_messages`` can consume them
+        identically regardless of CLI tool. See agent_runner.py:1443-1472.
+        """
         if not data:
             if done:
                 self.request_count += 1
             return
-        self.event_log.append(data)
         try:
             parsed = json.loads(data)
         except (json.JSONDecodeError, ValueError):
@@ -162,18 +166,47 @@ class _ZcodeResultCollector:
             return
 
         msg_type = parsed.get("type", "")
+
+        # Assistant text delta (from model.streaming → {"type":"assistant",...})
         if msg_type == "assistant":
             content = parsed.get("message", {}).get("content", "")
+            text = ""
             if isinstance(content, list):
                 for block in content:
                     if isinstance(block, dict) and block.get("type") == "text":
-                        self.assistant_text += block.get("text", "")
+                        text += block.get("text", "")
             elif isinstance(content, str):
-                self.assistant_text += content
-        elif msg_type == "tool_use":
+                text = content
+            if text:
+                self.assistant_text += text
+                self.event_log.append(
+                    {
+                        "type": "assistant",
+                        "text": text,
+                        "message_id": parsed.get("message", {}).get("id"),
+                        "model": parsed.get("message", {}).get("model"),
+                    }
+                )
+
+        # Tool events: ZCode emits tool.<name> with data payload.
+        # Normalize to the Claude SDK tool_use shape for persistence.
+        elif msg_type.startswith("tool."):
+            tool_name = msg_type.split(".", 1)[1]
+            payload = parsed.get("data", {}) or {}
+            tool_input = payload.get("input", payload)
+            tool_id = payload.get("id", "")
             self.tool_calls.append(
-                {"name": parsed.get("name", ""), "input": parsed.get("input", {})}
+                {"tool": {"name": tool_name, "input": tool_input, "id": tool_id}}
             )
+            self.event_log.append(
+                {
+                    "type": "tool_use",
+                    "tool_name": tool_name,
+                    "tool_input": tool_input,
+                    "tool_use_id": tool_id,
+                }
+            )
+
         elif msg_type == "error":
             err_data = parsed.get("data", {})
             if isinstance(err_data, dict):

--- a/app/modules/workspace/autonomous/agent_runner.py
+++ b/app/modules/workspace/autonomous/agent_runner.py
@@ -76,6 +76,12 @@ SESSION_DETECTION_POLL_INTERVAL = 0.25
 # this only bounds how quickly we notice a pause/resume/stop transition.
 COMPLETION_POLL_INTERVAL = 5.0
 
+# CLI tools that run a persistent app-server process with their own stdio
+# protocol (not Claude's stream-json). These must be driven through a dedicated
+# session class instead of the generic _LocalSession path. Mirrors
+# remote-agent/executor.py::_APPSERVER_TOOLS.
+_APPSERVER_TOOLS = frozenset({"zcode", "zcode-code"})
+
 
 @dataclass
 class _LocalSession:
@@ -116,6 +122,74 @@ class _LocalSession:
     # Milestone this task belongs to — tags session_messages for per-phase detail views.
     milestone_id: str = ""
     _paused: threading.Event = field(default_factory=threading.Event)  # set when SIGSTOPed
+
+
+class _ZcodeResultCollector:
+    """Collects assistant text, tool calls, and token usage from ZCode app-server.
+
+    Acts as the ``output_callback`` / ``usage_callback`` for
+    ``ZCodeAppServerSession``, translating ZCode Protocol notifications into
+    the same data ``_LocalSession`` accumulates for Claude SDK sessions.
+    """
+
+    def __init__(self) -> None:
+        self.assistant_text: str = ""
+        self.tool_calls: list[dict] = []
+        self.total_tokens: int = 0
+        self.input_tokens: int = 0
+        self.output_tokens: int = 0
+        self.request_count: int = 0
+        self.event_log: list = []
+        self.error: str | None = None
+
+    def on_output(self, session_id: str, data: str, stream: str, done: bool) -> None:
+        """Receive ZCode output_callback invocations."""
+        if not data:
+            if done:
+                self.request_count += 1
+            return
+        self.event_log.append(data)
+        try:
+            parsed = json.loads(data)
+        except (json.JSONDecodeError, ValueError):
+            return
+
+        if not isinstance(parsed, dict):
+            return
+
+        msg_type = parsed.get("type", "")
+        if msg_type == "assistant":
+            content = parsed.get("message", {}).get("content", "")
+            if isinstance(content, list):
+                for block in content:
+                    if isinstance(block, dict) and block.get("type") == "text":
+                        self.assistant_text += block.get("text", "")
+            elif isinstance(content, str):
+                self.assistant_text += content
+        elif msg_type == "tool_use":
+            self.tool_calls.append(
+                {"name": parsed.get("name", ""), "input": parsed.get("input", {})}
+            )
+        elif msg_type == "error":
+            err_data = parsed.get("data", {})
+            if isinstance(err_data, dict):
+                msg = err_data.get("message", "")
+                if msg and self.error is None:
+                    self.error = msg
+
+    def on_usage(self, session_id: str, usage: dict) -> None:
+        """Receive ZCode usage_callback invocations."""
+        self.total_tokens = usage.get("totalTokens", self.total_tokens)
+        self.input_tokens = usage.get("inputTokens", self.input_tokens)
+        self.output_tokens = usage.get("outputTokens", self.output_tokens)
+
+    def on_permission(self, session_id: str, control_request: dict) -> None:
+        """Auto-approve all permission requests in autonomous mode.
+
+        ZCode app-server in edit/yolo mode auto-approves tool calls, so this
+        callback is rarely invoked. Left as a no-op notification hook.
+        """
+        pass
 
 
 class AutonomousAgentRunner:
@@ -532,6 +606,40 @@ class AutonomousAgentRunner:
         project_path = os.path.expanduser(project_path)
         Path(project_path).mkdir(parents=True, exist_ok=True)
 
+        # Protocol dispatch: different CLI tools speak different stdin protocols.
+        # The generic _LocalSession path below assumes Claude SDK stream-json,
+        # which only claude-code and qwen-code-cli support. Route tools with
+        # their own app-server protocol (ZCode) or no stdin protocol at all
+        # (codex, openclaw) through dedicated paths. Mirrors the dispatch in
+        # remote-agent/executor.py (_APPSERVER_TOOLS + supports_stdin_input).
+        if cli_tool in _APPSERVER_TOOLS:
+            return self._run_zcode_appserver(
+                session_id=session_id,
+                cli_tool=cli_tool,
+                model=model,
+                project_path=project_path,
+                prompt=prompt,
+                permission_mode=permission_mode,
+                timeout=timeout,
+                workflow_id=workflow_id,
+                user_id=user_id,
+                workspace_type=workspace_type,
+                resume=resume,
+                resume_session_id=resume_session_id,
+                milestone_id=milestone_id,
+            )
+        if not adapter.supports_stdin_input():
+            return self._run_single_shot(
+                session_id=session_id,
+                cli_tool=cli_tool,
+                model=model,
+                project_path=project_path,
+                prompt=prompt,
+                timeout=timeout,
+                workflow_id=workflow_id,
+                milestone_id=milestone_id,
+            )
+
         # Build env vars (use direct env vars, no proxy for local autonomous)
         env = dict(os.environ)
 
@@ -725,6 +833,322 @@ class AutonomousAgentRunner:
             error=session.error,
             event_log=session.event_log,
         )
+
+    def _run_zcode_appserver(
+        self,
+        session_id: str,
+        cli_tool: str,
+        model: str,
+        project_path: str,
+        prompt: str,
+        permission_mode: str,
+        timeout: int,
+        workflow_id: str,
+        user_id: int | None,
+        workspace_type: str,
+        resume: bool = False,
+        resume_session_id: str = None,
+        milestone_id: str = "",
+    ) -> AgentTaskResult:
+        """Run a ZCode agent task via the persistent app-server protocol.
+
+        ZCode speaks the *ZCode Protocol* (``{id, method, params}``), not
+        Claude's stream-json. We reuse ``ZCodeAppServerSession`` — the same
+        class the interactive executor uses — to drive ``session/create`` →
+        ``session/send`` → ``session/events`` and collect results.
+        """
+        import sys
+
+        _remote_agent_dir = os.path.normpath(
+            os.path.join(os.path.dirname(__file__), "..", "..", "..", "..", "remote-agent")
+        )
+        if _remote_agent_dir not in sys.path:
+            sys.path.insert(0, _remote_agent_dir)
+        from cli_adapters import get_adapter
+        from zcode_app_server import ZCodeAppServerSession
+
+        _ensure_usage_parser()
+        adapter = get_adapter(cli_tool)
+
+        env = dict(os.environ)
+        cmd = adapter.build_start_args(
+            resume_session_id if (resume and resume_session_id) else session_id,
+            project_path,
+            model,
+            permission_mode=permission_mode,
+            resume=resume,
+        )
+        logger.info("Launching ZCode app-server: %s", " ".join(cmd))
+
+        try:
+            process = subprocess.Popen(
+                cmd,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                cwd=project_path,
+                env=env,
+                start_new_session=True,
+            )
+        except (OSError, subprocess.SubprocessError) as e:
+            return AgentTaskResult(
+                session_id=session_id,
+                tracking_session_id=session_id,
+                success=False,
+                error=f"Failed to start ZCode process: {e}",
+            )
+
+        collector = _ZcodeResultCollector()
+
+        zc_session = ZCodeAppServerSession(
+            session_id=session_id,
+            process=process,
+            project_path=project_path,
+            output_callback=collector.on_output,
+            usage_callback=collector.on_usage,
+            permission_callback=lambda sid, req: collector.on_permission(sid, req),
+            model=model,
+            permission_mode=permission_mode,
+            env=env,
+        )
+        zc_session.allowed_tools = []  # planning restriction handled by --mode
+
+        # Register PID + wrap into a _LocalSession-compatible tracker so the
+        # orchestrator's stop/pause/cancel can reach the process.
+        tracker = _LocalSession(
+            session_id=session_id,
+            process=process,
+            cli_tool=cli_tool,
+            project_path=project_path,
+            encoded_project_path=self._encode_project_path(project_path),
+            workflow_id=workflow_id,
+            user_id=user_id,
+            workspace_type=workspace_type,
+            started_at_epoch=time.time(),
+            milestone_id=milestone_id,
+        )
+        self._local_sessions[session_id] = tracker
+        if self._on_pid_registered:
+            try:
+                self._on_pid_registered(session_id, process.pid)
+            except Exception as e:
+                logger.warning("on_pid_registered callback failed: %s", e)
+
+        # Start stderr reader so app-server diagnostics surface as errors.
+        stderr_thread = threading.Thread(
+            target=self._read_zcode_stderr_local,
+            args=(session_id, process, collector),
+            name=f"zcode-err-{session_id[:8]}",
+            daemon=True,
+        )
+        stderr_thread.start()
+
+        try:
+            if not zc_session.start(
+                model=model,
+                permission_mode=permission_mode,
+                resume_session_id=resume_session_id if resume else None,
+            ):
+                return AgentTaskResult(
+                    session_id=session_id,
+                    tracking_session_id=session_id,
+                    success=False,
+                    error="ZCode session/create failed",
+                )
+
+            tracker.cli_session_id = zc_session._cli_session_id
+            tracker.persisted_session_id = zc_session._cli_session_id
+            tracker.sdk_initialized.set()
+
+            if not zc_session.send_message(prompt):
+                return AgentTaskResult(
+                    session_id=zc_session._cli_session_id or session_id,
+                    tracking_session_id=session_id,
+                    success=False,
+                    error=zc_session.last_send_error or "ZCode session/send failed",
+                )
+
+            completed = zc_session.wait_turn(timeout=timeout)
+        finally:
+            # Ensure the app-server process is terminated.
+            zc_session.stop()
+
+        self._local_sessions.pop(session_id, None)
+        if self._on_pid_cleared:
+            try:
+                self._on_pid_cleared(session_id)
+            except Exception as e:
+                logger.warning("on_pid_cleared callback failed: %s", e)
+
+        cli_sid = zc_session._cli_session_id or session_id
+        if not completed:
+            return AgentTaskResult(
+                session_id=cli_sid,
+                tracking_session_id=session_id,
+                response_text=collector.assistant_text,
+                total_tokens=collector.total_tokens,
+                total_input_tokens=collector.input_tokens,
+                total_output_tokens=collector.output_tokens,
+                request_count=collector.request_count,
+                tool_calls=collector.tool_calls,
+                success=False,
+                error=f"Agent task timed out after {timeout}s",
+                event_log=collector.event_log,
+            )
+
+        return AgentTaskResult(
+            session_id=cli_sid,
+            tracking_session_id=session_id,
+            response_text=collector.assistant_text,
+            total_tokens=collector.total_tokens,
+            total_input_tokens=collector.input_tokens,
+            total_output_tokens=collector.output_tokens,
+            request_count=collector.request_count,
+            tool_calls=collector.tool_calls,
+            success=collector.error is None,
+            error=collector.error,
+            event_log=collector.event_log,
+        )
+
+    def _run_single_shot(
+        self,
+        session_id: str,
+        cli_tool: str,
+        model: str,
+        project_path: str,
+        prompt: str,
+        timeout: int,
+        workflow_id: str,
+        milestone_id: str = "",
+    ) -> AgentTaskResult:
+        """Run a CLI tool in single-shot mode for tools without stdin protocol.
+
+        Uses ``adapter.build_single_shot_args`` to produce a self-contained
+        command (e.g. ``codex exec --json "<prompt>"``) and captures output.
+        """
+        import sys
+
+        _remote_agent_dir = os.path.normpath(
+            os.path.join(os.path.dirname(__file__), "..", "..", "..", "..", "remote-agent")
+        )
+        if _remote_agent_dir not in sys.path:
+            sys.path.insert(0, _remote_agent_dir)
+        from cli_adapters import get_adapter
+
+        _ensure_usage_parser()
+        adapter = get_adapter(cli_tool)
+
+        exe_name = adapter.get_executable_name()
+        executable = shutil.which(exe_name)
+        if not executable:
+            return AgentTaskResult(
+                session_id=session_id,
+                tracking_session_id=session_id,
+                success=False,
+                error=f"CLI tool '{exe_name}' not found",
+            )
+
+        args = adapter.build_single_shot_args(prompt, project_path, model)
+        cmd = [executable] + (args[1:] if len(args) > 1 and args[0] == exe_name else args)
+        env = dict(os.environ)
+
+        logger.info("Launching single-shot agent (%s): %s", cli_tool, " ".join(cmd))
+
+        try:
+            proc = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                cwd=project_path,
+                env=env,
+                timeout=timeout,
+            )
+        except subprocess.TimeoutExpired:
+            return AgentTaskResult(
+                session_id=session_id,
+                tracking_session_id=session_id,
+                success=False,
+                error=f"Agent task timed out after {timeout}s",
+            )
+        except (OSError, subprocess.SubprocessError) as e:
+            return AgentTaskResult(
+                session_id=session_id,
+                tracking_session_id=session_id,
+                success=False,
+                error=f"Failed to run command: {e}",
+            )
+
+        response_text = ""
+        total_tokens = 0
+        input_tokens = 0
+        output_tokens = 0
+        event_log = []
+
+        for line in (proc.stdout or "").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            event_log.append(line)
+            try:
+                parsed = json.loads(line)
+            except (json.JSONDecodeError, ValueError):
+                response_text += line + "\n"
+                continue
+
+            # Extract text content from common JSON shapes
+            if isinstance(parsed, dict):
+                text = (
+                    parsed.get("response")
+                    or parsed.get("text")
+                    or parsed.get("content")
+                    or parsed.get("output")
+                )
+                if isinstance(text, str):
+                    response_text += text + "\n"
+                usage = _extract_stream_usage(cli_tool, parsed)
+                if usage:
+                    input_tokens += usage["input"]
+                    output_tokens += usage["output"]
+
+        total_tokens = input_tokens + output_tokens
+
+        stderr_text = (proc.stderr or "").strip()
+        success = proc.returncode == 0
+        error = None
+        if not success:
+            error = stderr_text or f"Command exited with code {proc.returncode}"
+
+        return AgentTaskResult(
+            session_id=session_id,
+            tracking_session_id=session_id,
+            response_text=response_text.strip(),
+            total_tokens=total_tokens,
+            total_input_tokens=input_tokens,
+            total_output_tokens=output_tokens,
+            request_count=1,
+            success=success,
+            error=error,
+            event_log=event_log,
+        )
+
+    @staticmethod
+    def _read_zcode_stderr_local(
+        session_id: str, process: subprocess.Popen, collector: _ZcodeResultCollector
+    ) -> None:
+        """Forward ZCode app-server stderr lines as errors (autonomous variant)."""
+        stream = process.stderr
+        if stream is None:
+            return
+        try:
+            for raw in stream:
+                line = raw.decode("utf-8", "replace") if isinstance(raw, bytes) else raw
+                text = line.strip()
+                if text:
+                    logger.warning("[zcode %s stderr] %s", session_id[:8], text)
+                    if collector.error is None:
+                        collector.error = text
+        except (OSError, ValueError):
+            pass
 
     def _run_remote(
         self,

--- a/remote-agent/cli_adapters/codex_cli.py
+++ b/remote-agent/cli_adapters/codex_cli.py
@@ -146,8 +146,16 @@ class CodexCLIAdapter(BaseCLIAdapter):
         return args
 
     def supports_stdin_input(self) -> bool:
-        """Codex CLI supports stdin input via JSONRPC 2.0 (app-server mode)."""
-        return True
+        """Codex does NOT use the Claude stream-json stdin protocol.
+
+        Although Codex has a JSONRPC 2.0 ``serve`` mode, ``build_start_args``
+        launches a bare interactive ``codex`` TTY process, not an app-server.
+        Sending Claude SDK ``control_request`` / ``user`` messages to that
+        process is silently ignored, causing the autonomous runner to hang
+        until timeout. Return False so the runner uses ``codex exec --json``
+        single-shot mode instead.
+        """
+        return False
 
     # ------------------------------------------------------------------
     # Display helpers

--- a/remote-agent/cli_adapters/openclaw.py
+++ b/remote-agent/cli_adapters/openclaw.py
@@ -83,6 +83,14 @@ class OpenClawAdapter(BaseCLIAdapter):
 
         return args
 
+    def supports_stdin_input(self) -> bool:
+        """Return False — self-contained agent run with no stdin protocol.
+
+        Sending Claude SDK stream-json messages to its stdin is unsupported;
+        the autonomous runner should use single-shot mode instead.
+        """
+        return False
+
     def get_display_name(self) -> str:
         """Return the display name for this CLI tool."""
         return self.DISPLAY_NAME

--- a/remote-agent/cli_adapters/openclaw.py
+++ b/remote-agent/cli_adapters/openclaw.py
@@ -83,6 +83,24 @@ class OpenClawAdapter(BaseCLIAdapter):
 
         return args
 
+    def build_single_shot_args(
+        self, prompt: str, project_path: str, model: str | None = None
+    ) -> list[str]:
+        """Build args for a single-shot OpenClaw execution.
+
+        Mirrors build_start_args but appends the prompt as the final
+        positional argument, matching OpenClaw's agent-mode CLI contract.
+        """
+        args = [
+            self.EXECUTABLE,
+            "--agent",
+            "--json",
+        ]
+        if model:
+            args.extend(["--model", model])
+        args.append(prompt)
+        return args
+
     def supports_stdin_input(self) -> bool:
         """Return False — self-contained agent run with no stdin protocol.
 

--- a/tests/issues/1138/test_multi_protocol_runner.py
+++ b/tests/issues/1138/test_multi_protocol_runner.py
@@ -228,6 +228,9 @@ def test_claude_code_still_uses_local_session(runner):
 
 
 def test_collector_accumulates_assistant_text():
+    """on_output must build event_log dicts matching _LocalSession._read_stdout
+    shape: {"type":"assistant","text":...,"message_id":...,"model":...}.
+    _persist_local_session_messages reads event.get("type")/event.get("text")."""
     from app.modules.workspace.autonomous.agent_runner import _ZcodeResultCollector
 
     c = _ZcodeResultCollector()
@@ -246,15 +249,34 @@ def test_collector_accumulates_assistant_text():
     c.on_output("sid", "", "stdout", True)
     assert c.assistant_text == "Hello world"
     assert c.request_count == 1
+    # event_log entries must be dicts (not raw strings) for persistence
+    assert len(c.event_log) == 2
+    assert c.event_log[0]["type"] == "assistant"
+    assert c.event_log[0]["text"] == "Hello "
 
 
 def test_collector_accumulates_tool_calls():
+    """Tool events arrive as tool.<name> from ZCode, normalized to
+    {"tool":{"name","input","id"}} in tool_calls and {"type":"tool_use",...}
+    in event_log — matching what _persist_local_session_messages expects."""
     from app.modules.workspace.autonomous.agent_runner import _ZcodeResultCollector
 
     c = _ZcodeResultCollector()
-    c.on_output("sid", '{"type":"tool_use","name":"Read","input":{"file":"a.py"}}', "stdout", False)
+    c.on_output(
+        "sid",
+        '{"type":"tool.Read","data":{"input":{"file":"a.py"},"id":"tu_123"}}',
+        "stdout",
+        False,
+    )
     assert len(c.tool_calls) == 1
-    assert c.tool_calls[0]["name"] == "Read"
+    # Fallback path reads tool_call.get("tool", {}).get("name"/"input")
+    assert c.tool_calls[0]["tool"]["name"] == "Read"
+    assert c.tool_calls[0]["tool"]["input"] == {"file": "a.py"}
+    # event_log path reads event.get("tool_name"/"tool_input"/"tool_use_id")
+    assert c.event_log[0]["type"] == "tool_use"
+    assert c.event_log[0]["tool_name"] == "Read"
+    assert c.event_log[0]["tool_input"] == {"file": "a.py"}
+    assert c.event_log[0]["tool_use_id"] == "tu_123"
 
 
 def test_collector_captures_usage():
@@ -284,7 +306,7 @@ def test_collector_ignores_non_json():
     c = _ZcodeResultCollector()
     c.on_output("sid", "not json at all", "stdout", False)
     assert c.assistant_text == ""
-    assert len(c.event_log) == 1  # still logged
+    assert len(c.event_log) == 0  # non-JSON is silently dropped
 
 
 # ── ZCode session failure cleanup ─────────────────────────────────────────

--- a/tests/issues/1138/test_multi_protocol_runner.py
+++ b/tests/issues/1138/test_multi_protocol_runner.py
@@ -10,6 +10,8 @@ codex/openclaw to hang until timeout because they don't understand the
 stream-json protocol.
 """
 
+import os
+import sys
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -256,13 +258,16 @@ def test_collector_accumulates_tool_calls():
 
 
 def test_collector_captures_usage():
+    """on_usage must read snake_case keys (input/output/model_requests),
+    matching what ZCodeAppServerSession actually emits (zcode_app_server.py:335-417)."""
     from app.modules.workspace.autonomous.agent_runner import _ZcodeResultCollector
 
     c = _ZcodeResultCollector()
-    c.on_usage("sid", {"totalTokens": 500, "inputTokens": 300, "outputTokens": 200})
+    c.on_usage("sid", {"input": 300, "output": 200, "model_requests": 3})
     assert c.total_tokens == 500
     assert c.input_tokens == 300
     assert c.output_tokens == 200
+    assert c.request_count == 3
 
 
 def test_collector_captures_error():
@@ -280,3 +285,69 @@ def test_collector_ignores_non_json():
     c.on_output("sid", "not json at all", "stdout", False)
     assert c.assistant_text == ""
     assert len(c.event_log) == 1  # still logged
+
+
+# ── ZCode session failure cleanup ─────────────────────────────────────────
+
+
+def test_zcode_session_start_failure_cleans_up(runner):
+    """When ZCode session/create fails, _local_sessions and PID must be cleared."""
+    with patch("app.modules.workspace.autonomous.agent_runner.subprocess.Popen") as mock_popen:
+        mock_proc = MagicMock(returncode=None, pid=12345)
+        mock_proc.stdin = MagicMock()
+        mock_proc.stdout = MagicMock()
+        mock_proc.stderr = MagicMock()
+        mock_popen.return_value = mock_proc
+
+        # Patch ZCodeAppServerSession where _run_zcode_appserver imports it
+        _ra = os.path.normpath(
+            os.path.join(os.path.dirname(__file__), "..", "..", "..", "remote-agent")
+        )
+        if _ra not in sys.path:
+            sys.path.insert(0, _ra)
+        import zcode_app_server
+
+        mock_zc_instance = MagicMock()
+        mock_zc_instance.start.return_value = False  # session/create fails
+        mock_zc_instance._cli_session_id = None
+        mock_zc_instance.stop = MagicMock()
+
+        with patch.object(zcode_app_server, "ZCodeAppServerSession", return_value=mock_zc_instance):
+            result = runner._run_zcode_appserver(
+                session_id="test-fail",
+                cli_tool="zcode",
+                model="glm-5.2",
+                project_path="/tmp/test",
+                prompt="hello",
+                permission_mode="edit",
+                timeout=10,
+                workflow_id="wf-1",
+                user_id=1,
+                workspace_type="local",
+            )
+        assert result.success is False
+        assert "session/create failed" in result.error
+        # Tracker must be removed even on failure (issue #2 fix)
+        assert "test-fail" not in runner._local_sessions
+        runner._on_pid_cleared.assert_called_once_with("test-fail")
+
+
+# ── OpenClaw single-shot args ─────────────────────────────────────────────
+
+
+def test_openclaw_single_shot_includes_agent_json_flags():
+    """build_single_shot_args must include --agent --json, not just [exe, prompt]."""
+    import os
+    import sys
+
+    _ra = os.path.normpath(
+        os.path.join(os.path.dirname(__file__), "..", "..", "..", "remote-agent")
+    )
+    if _ra not in sys.path:
+        sys.path.insert(0, _ra)
+    from cli_adapters.openclaw import OpenClawAdapter
+
+    args = OpenClawAdapter().build_single_shot_args("do something", "/tmp/proj")
+    assert "--agent" in args
+    assert "--json" in args
+    assert "do something" in args

--- a/tests/issues/1138/test_multi_protocol_runner.py
+++ b/tests/issues/1138/test_multi_protocol_runner.py
@@ -292,6 +292,30 @@ def test_collector_captures_usage():
     assert c.request_count == 3
 
 
+def test_collector_no_double_count_request():
+    """Real ZCode callback order: on_usage(model_requests=N) THEN
+    on_output(done=True). The done=True must NOT increment again — otherwise
+    request_count becomes N+1. See zcode_app_server.py:249-260."""
+    from app.modules.workspace.autonomous.agent_runner import _ZcodeResultCollector
+
+    c = _ZcodeResultCollector()
+    # Simulate the real callback sequence from _run_turn → _report_usage → output_callback(done=True)
+    c.on_usage("sid", {"input": 300, "output": 200, "model_requests": 3})
+    assert c.request_count == 3
+    c.on_output("sid", "", "stdout", True)
+    assert c.request_count == 3  # NOT 4
+
+
+def test_collector_done_fallback_without_usage():
+    """When no usage_callback fires (e.g. error before turn completes),
+    done=True should count as 1 request as a fallback."""
+    from app.modules.workspace.autonomous.agent_runner import _ZcodeResultCollector
+
+    c = _ZcodeResultCollector()
+    c.on_output("sid", "", "stdout", True)
+    assert c.request_count == 1
+
+
 def test_collector_captures_error():
     from app.modules.workspace.autonomous.agent_runner import _ZcodeResultCollector
 

--- a/tests/issues/1138/test_multi_protocol_runner.py
+++ b/tests/issues/1138/test_multi_protocol_runner.py
@@ -1,0 +1,282 @@
+"""Tests for multi-protocol CLI dispatch in the autonomous agent runner.
+
+The autonomous runner must route CLI tools by their stdin protocol:
+  - ZCode (zcode/zcode-code): ZCode Protocol app-server → _run_zcode_appserver
+  - Claude SDK stream-json (claude-code, qwen-code-cli): _LocalSession path
+  - No stdin protocol (codex, openclaw): single-shot mode → _run_single_shot
+
+Previously the runner sent Claude SDK messages to ALL tools, causing zcode/
+codex/openclaw to hang until timeout because they don't understand the
+stream-json protocol.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ── Adapter protocol declarations ─────────────────────────────────────────
+
+
+def test_codex_does_not_claim_stdin_input():
+    """Codex must return False — it uses single-shot exec, not stream-json."""
+    import os
+    import sys
+
+    _ra = os.path.normpath(
+        os.path.join(os.path.dirname(__file__), "..", "..", "..", "remote-agent")
+    )
+    if _ra not in sys.path:
+        sys.path.insert(0, _ra)
+    from cli_adapters.codex_cli import CodexCLIAdapter
+
+    assert CodexCLIAdapter().supports_stdin_input() is False
+
+
+def test_openclaw_does_not_claim_stdin_input():
+    """OpenClaw must return False — it has no stdin protocol at all."""
+    import os
+    import sys
+
+    _ra = os.path.normpath(
+        os.path.join(os.path.dirname(__file__), "..", "..", "..", "remote-agent")
+    )
+    if _ra not in sys.path:
+        sys.path.insert(0, _ra)
+    from cli_adapters.openclaw import OpenClawAdapter
+
+    assert OpenClawAdapter().supports_stdin_input() is False
+
+
+def test_zcode_provides_full_command():
+    """ZCode provides a self-contained node command (not a PATH executable)."""
+    import os
+    import sys
+
+    _ra = os.path.normpath(
+        os.path.join(os.path.dirname(__file__), "..", "..", "..", "remote-agent")
+    )
+    if _ra not in sys.path:
+        sys.path.insert(0, _ra)
+    from cli_adapters.zcode import ZCodeAdapter
+
+    assert ZCodeAdapter().provides_full_command() is True
+
+
+def test_claude_code_still_supports_stdin():
+    """claude-code is the native stream-json target — must remain True."""
+    import os
+    import sys
+
+    _ra = os.path.normpath(
+        os.path.join(os.path.dirname(__file__), "..", "..", "..", "remote-agent")
+    )
+    if _ra not in sys.path:
+        sys.path.insert(0, _ra)
+    from cli_adapters.claude_code import ClaudeCodeAdapter
+
+    assert ClaudeCodeAdapter().supports_stdin_input() is True
+
+
+def test_qwen_code_still_supports_stdin():
+    """qwen-code-cli uses the same stream-json family — must remain True."""
+    import os
+    import sys
+
+    _ra = os.path.normpath(
+        os.path.join(os.path.dirname(__file__), "..", "..", "..", "remote-agent")
+    )
+    if _ra not in sys.path:
+        sys.path.insert(0, _ra)
+    from cli_adapters.qwen_code import QwenCodeAdapter
+
+    assert QwenCodeAdapter().supports_stdin_input() is True
+
+
+# ── _APPSERVER_TOOLS constant ─────────────────────────────────────────────
+
+
+def test_appserver_tools_includes_zcode():
+    from app.modules.workspace.autonomous.agent_runner import _APPSERVER_TOOLS
+
+    assert "zcode" in _APPSERVER_TOOLS
+    assert "zcode-code" in _APPSERVER_TOOLS
+
+
+# ── Dispatch routing ──────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def runner():
+    """Create an AutonomousAgentRunner with mocked dependencies."""
+    from app.modules.workspace.autonomous.agent_runner import AutonomousAgentRunner
+
+    return AutonomousAgentRunner(
+        session_manager=MagicMock(),
+        on_pid_registered=MagicMock(),
+        on_pid_cleared=MagicMock(),
+    )
+
+
+def test_zcode_routes_to_appserver_path(runner):
+    """zcode must go through _run_zcode_appserver, not _run_local's _LocalSession."""
+    with patch.object(
+        runner, "_run_zcode_appserver", return_value=MagicMock(success=True)
+    ) as mock_zc:
+        with patch.object(runner, "_run_single_shot") as mock_ss:
+            runner._run_local(
+                session_id="test-zcode",
+                cli_tool="zcode",
+                model="glm-5.2",
+                project_path="/tmp/test",
+                prompt="hello",
+                permission_mode="auto-edit",
+                timeout=60,
+                workflow_id="wf-test",
+                user_id=1,
+                workspace_type="local",
+            )
+            mock_zc.assert_called_once()
+            mock_ss.assert_not_called()
+
+
+def test_zcode_code_also_routes_to_appserver(runner):
+    """zcode-code alias must also use the app-server path."""
+    with patch.object(
+        runner, "_run_zcode_appserver", return_value=MagicMock(success=True)
+    ) as mock_zc:
+        runner._run_local(
+            session_id="test-zcode2",
+            cli_tool="zcode-code",
+            model="glm-5.2",
+            project_path="/tmp/test",
+            prompt="hello",
+            permission_mode="auto-edit",
+            timeout=60,
+            workflow_id="wf-test",
+            user_id=1,
+            workspace_type="local",
+        )
+        mock_zc.assert_called_once()
+
+
+def test_codex_routes_to_single_shot(runner):
+    """codex must go through _run_single_shot since supports_stdin_input is False."""
+    with patch.object(runner, "_run_single_shot", return_value=MagicMock(success=True)) as mock_ss:
+        with patch.object(runner, "_run_zcode_appserver") as mock_zc:
+            runner._run_local(
+                session_id="test-codex",
+                cli_tool="codex",
+                model="o4-mini",
+                project_path="/tmp/test",
+                prompt="hello",
+                permission_mode="auto-edit",
+                timeout=60,
+                workflow_id="wf-test",
+                user_id=1,
+                workspace_type="local",
+            )
+            mock_ss.assert_called_once()
+            mock_zc.assert_not_called()
+
+
+def test_openclaw_routes_to_single_shot(runner):
+    """openclaw must go through _run_single_shot."""
+    with patch.object(runner, "_run_single_shot", return_value=MagicMock(success=True)) as mock_ss:
+        runner._run_local(
+            session_id="test-openclaw",
+            cli_tool="openclaw",
+            model="",
+            project_path="/tmp/test",
+            prompt="hello",
+            permission_mode="auto-edit",
+            timeout=60,
+            workflow_id="wf-test",
+            user_id=1,
+            workspace_type="local",
+        )
+        mock_ss.assert_called_once()
+
+
+def test_claude_code_still_uses_local_session(runner):
+    """claude-code must NOT use zcode or single-shot paths."""
+    with patch.object(runner, "_run_zcode_appserver") as mock_zc:
+        with patch.object(runner, "_run_single_shot") as mock_ss:
+            # Will fail trying to spawn claude, but we just need to verify
+            # it doesn't route to zcode/single-shot
+            try:
+                runner._run_local(
+                    session_id="test-claude",
+                    cli_tool="claude-code",
+                    model="sonnet",
+                    project_path="/tmp/test",
+                    prompt="hello",
+                    permission_mode="auto-edit",
+                    timeout=5,
+                    workflow_id="wf-test",
+                    user_id=1,
+                    workspace_type="local",
+                )
+            except Exception:
+                pass  # Expected — claude not installed or fails to start
+            mock_zc.assert_not_called()
+            mock_ss.assert_not_called()
+
+
+# ── _ZcodeResultCollector ─────────────────────────────────────────────────
+
+
+def test_collector_accumulates_assistant_text():
+    from app.modules.workspace.autonomous.agent_runner import _ZcodeResultCollector
+
+    c = _ZcodeResultCollector()
+    c.on_output(
+        "sid",
+        '{"type":"assistant","message":{"content":[{"type":"text","text":"Hello "}]}}',
+        "stdout",
+        False,
+    )
+    c.on_output(
+        "sid",
+        '{"type":"assistant","message":{"content":[{"type":"text","text":"world"}]}}',
+        "stdout",
+        False,
+    )
+    c.on_output("sid", "", "stdout", True)
+    assert c.assistant_text == "Hello world"
+    assert c.request_count == 1
+
+
+def test_collector_accumulates_tool_calls():
+    from app.modules.workspace.autonomous.agent_runner import _ZcodeResultCollector
+
+    c = _ZcodeResultCollector()
+    c.on_output("sid", '{"type":"tool_use","name":"Read","input":{"file":"a.py"}}', "stdout", False)
+    assert len(c.tool_calls) == 1
+    assert c.tool_calls[0]["name"] == "Read"
+
+
+def test_collector_captures_usage():
+    from app.modules.workspace.autonomous.agent_runner import _ZcodeResultCollector
+
+    c = _ZcodeResultCollector()
+    c.on_usage("sid", {"totalTokens": 500, "inputTokens": 300, "outputTokens": 200})
+    assert c.total_tokens == 500
+    assert c.input_tokens == 300
+    assert c.output_tokens == 200
+
+
+def test_collector_captures_error():
+    from app.modules.workspace.autonomous.agent_runner import _ZcodeResultCollector
+
+    c = _ZcodeResultCollector()
+    c.on_output("sid", '{"type":"error","data":{"message":"model unavailable"}}', "stderr", False)
+    assert c.error == "model unavailable"
+
+
+def test_collector_ignores_non_json():
+    from app.modules.workspace.autonomous.agent_runner import _ZcodeResultCollector
+
+    c = _ZcodeResultCollector()
+    c.on_output("sid", "not json at all", "stdout", False)
+    assert c.assistant_text == ""
+    assert len(c.event_log) == 1  # still logged

--- a/tests/issues/716/test_agent_runner.py
+++ b/tests/issues/716/test_agent_runner.py
@@ -44,6 +44,10 @@ class TestAgentRunnerRunTask:
         """Should fail gracefully when CLI tool not found."""
         mock_adapter = MagicMock()
         mock_adapter.get_executable_name.return_value = "nonexistent-tool"
+        # Must explicitly return bool — MagicMock truthiness causes dispatch confusion
+        mock_adapter.supports_stdin_input.return_value = True
+        mock_adapter.provides_full_command.return_value = False
+        mock_adapter.build_start_args.return_value = ["nonexistent-tool"]
         mock_cli_adapters = MagicMock()
         mock_cli_adapters.get_adapter.return_value = mock_adapter
 


### PR DESCRIPTION
## Problem

Every `cli_tool='zcode'` autonomous workflow **100% failed** with `planning_timeout` after 600s. Root cause: the agent runner sent Claude SDK stream-json protocol (`{"type":"control_request","request":{"subtype":"initialize"}}`) to **all** CLI tools, but zcode's app-server speaks the **ZCode Protocol** (`{id, method, params}`). The app-server immediately rejected the messages (`"Invalid ZCode Protocol message"`), but the runner's stdout reader didn't recognize the error response (no `type` field), so it waited silently for a `result` event that never came — hanging until timeout.

**Verified by cold-start test**: sending Claude SDK format to `zcode app-server` produces instant rejection:
```
"Unrecognized keys: \"type\", \"request_id\", \"request\""
```

The same issue affects **codex** (claims JSONRPC 2.0 but `build_start_args` produces a bare TTY process) and **openclaw** (no stdin protocol at all). Only `claude-code` and `qwen-code-cli` actually use the Claude SDK stream-json protocol.

The interactive executor (`executor.py`) **already handles this correctly** via `_APPSERVER_TOOLS` + `supports_stdin_input()` dispatch — but the autonomous runner (`agent_runner.py`) never replicated that logic.

## Fix

Route CLI tools by their actual protocol in `_run_local`, mirroring the executor's dispatch:

| Protocol | Tools | Path |
|----------|-------|------|
| ZCode Protocol | zcode, zcode-code | `_run_zcode_appserver()` → reuses existing `ZCodeAppServerSession` |
| Claude SDK stream-json | claude-code, qwen-code-cli | `_LocalSession` (unchanged) |
| No stdin | codex, openclaw | `_run_single_shot()` → `adapter.build_single_shot_args` |

### Changes
- **`agent_runner.py`**: Added `_APPSERVER_TOOLS` constant, `_ZcodeResultCollector` (translates ZCode notifications to `AgentTaskResult` fields), `_run_zcode_appserver()` (spawns app-server, drives `session/create`→`send`→`wait_turn`, collects results), `_run_single_shot()` (subprocess.run with JSON parsing)
- **`codex_cli.py`**: `supports_stdin_input()` → `False` (codex exec --json is the correct single-shot path)
- **`openclaw.py`**: `supports_stdin_input()` → `False` (self-contained --agent run)
- **`test_agent_runner.py`**: Fixed pre-existing test whose mock adapter returned truthy MagicMock for protocol checks

### Not changed
- `executor.py` — interactive path was already correct
- `zcode_app_server.py` — reused as-is
- claude-code / qwen-code-cli — protocol-compatible, path unchanged

## Test plan
- [x] 16 new tests: adapter protocol declarations, dispatch routing, `_ZcodeResultCollector` — all pass
- [x] 22 existing `test_agent_runner.py` tests pass (including the pre-existing failure, now fixed)
- [x] `ruff` + `black` clean
- [ ] Manual: retry workflow #830 (id=525) with zcode → should reach planning/development instead of timeout