### PR TITLE
fix(workspace): webui 子进程 PATH 硬覆盖导致 macOS 找不到 node (#1083 回归)

### DIFF
--- a/app/services/webui_manager.py
+++ b/app/services/webui_manager.py
@@ -691,14 +691,20 @@ class WebUIManager:
             except OSError as e:
                 logger.warning(f"Failed to chown log dir: {e}")
 
-        # Ensure PATH is complete and includes all necessary directories.
-        # This fixes spawn ENOENT issues where the node executable cannot be
-        # found (Issue #1083). PATH is the correct mechanism for resolving the
-        # `node` binary. NODE_PATH is intentionally NOT set: it controls Node
-        # *module* resolution (a list of directories, not a binary path), so
-        # pointing it at an executable was semantically wrong and could only
-        # interfere with module lookup.
-        child_env["PATH"] = "/usr/local/bin:/usr/bin:/bin"
+        # Ensure PATH can resolve the `node` binary while preserving the host's
+        # inherited PATH. Prepend the standard system directories so Docker
+        # (node in /usr/bin) keeps resolving (Issue #1083), then append the
+        # inherited PATH so host-installed binaries are still found — e.g.
+        # /opt/homebrew/bin on Apple Silicon macOS, where Homebrew installs
+        # node. NODE_PATH is intentionally NOT set: it controls Node *module*
+        # resolution (a list of directories, not a binary path), so pointing it
+        # at an executable was semantically wrong and could only interfere with
+        # module lookup.
+        _system_dirs = "/usr/local/bin:/usr/bin:/bin"
+        _inherited_path = child_env.get("PATH", "")
+        child_env["PATH"] = (
+            _system_dirs + ":" + _inherited_path if _inherited_path else _system_dirs
+        )
 
         # Build command based on platform
         if webui_dir:


### PR DESCRIPTION
## 问题
用任意账号（如黄迎春/admin123）登录本机环境，工作区显示"不可用"，浏览器控制台 `GET /api/workspace/user-url` 返回 **503**。

## 根因（已用日志确证）
主进程日志（`/private/tmp/server_log.txt`）真实报错：
```
ERROR - Failed to launch webui process: [Errno 2] No such file or directory: 'node'
```
与用户名/密码/中文无关。45b193a1（Issue #1083，修 Docker spawn ENOENT）把 webui 子进程 PATH 硬编码为：
```python
child_env["PATH"] = "/usr/local/bin:/usr/bin:/bin"
```
覆盖掉了宿主 PATH。Apple Silicon macOS 上 node 装在 `/opt/homebrew/bin`，不在此 PATH，导致 `subprocess.Popen(["node",...])` 抛 `FileNotFoundError` → `_launch_webui_process` 返回 None → `ValueError` → 接口 503 → 前端"工作区不可用"。

这也是"前两天没问题、最近坏了"的直接原因。

## 修复
`app/services/webui_manager.py`：把"硬覆盖 PATH"改为"系统目录前置 + 追加继承的 PATH"。
- 系统目录 `/usr/local/bin:/usr/bin:/bin` 置前 → Docker（node 在 `/usr/bin`）仍优先命中
- 追加继承的 `PATH` → 保留 macOS 的 `/opt/homebrew/bin`、volta/nvm 等
- 维持不设 NODE_PATH（45b193a1 的正确决定）

## 测试
- `tests/unit/test_webui_manager.py` 9/9 通过，无回归
- `tests/issues/42/test_webui_manager.py` 的 2 个失败为改动前已存在（pre-existing，测试 mock 过时），与本次无关（已用 `git stash` 验证）