### PR TITLE
feat(workspace): sync local ZCode CLI sessions into session list

### DIFF
--- a/app/routes/fetch.py
+++ b/app/routes/fetch.py
@@ -199,6 +199,31 @@ def run_fetch_scripts():
                 logger.error(f"Error running codex fetch script: {e}")
                 results["codex"] = {"success": False, "error": "Internal server error"}
 
+        # Run fetch_zcode.py to scan all users' ZCode CLI databases.
+        # ZCode stores sessions in ~/.zcode/cli/db/db.sqlite (not JSONL), so this
+        # is the only path by which local ZCode sessions reach the session list.
+        zcode_script = os.path.join(project_root, "scripts", "fetch_zcode.py")
+        if os.path.exists(zcode_script):
+            try:
+                result = _run_subprocess(
+                    _build_cmd(
+                        zcode_script,
+                        ["--days", "1", "--multi-user", "--recent", "--config", config_path],
+                    ),
+                    timeout=600,
+                    cwd=project_root,
+                )
+                results["zcode"] = {
+                    "success": result.returncode == 0,
+                    "output": result.stdout[-1000:] if result.stdout else "",
+                    "error": result.stderr[-500:] if result.stderr else None,
+                }
+            except subprocess.TimeoutExpired:
+                results["zcode"] = {"success": False, "error": "Timeout after 10 minutes"}
+            except Exception as e:
+                logger.error(f"Error running zcode fetch script: {e}")
+                results["zcode"] = {"success": False, "error": "Internal server error"}
+
         with _fetch_lock:
             _fetch_status["last_run"] = datetime.now().isoformat()
             _fetch_status["last_result"] = results

--- a/frontend/src/components/work/SessionList.tsx
+++ b/frontend/src/components/work/SessionList.tsx
@@ -13,7 +13,7 @@ import { useLanguage } from '@/store';
 import { t } from '@/i18n';
 import { useSessions, useSession, useRestoreSession } from '@/hooks';
 import { Loading, EmptyState, Modal, SessionDetailContent } from '@/components/common';
-import { formatRelativeTime } from '@/utils';
+import { formatRelativeTime, displaySessionId } from '@/utils';
 import { NewSessionModal } from './NewSessionModal';
 import type { AgentSession } from '@/api/sessions';
 
@@ -152,7 +152,7 @@ export const SessionList: React.FC<SessionListProps> = ({ collapsed = false, onS
       const sessionDate = new Date(session.updated_at ?? session.created_at ?? now);
       const sessionItem: SessionItem = {
         id: session.session_id,
-        title: session.title ?? `Session ${session.session_id.slice(0, 8)}`,
+        title: session.title ?? `Session ${displaySessionId(session.session_id, 8)}`,
         tool: session.tool_name ?? 'unknown',
         time: formatRelativeTime(session.updated_at ?? session.created_at ?? '', {
           justNow: t('justNow', language),
@@ -228,7 +228,7 @@ export const SessionList: React.FC<SessionListProps> = ({ collapsed = false, onS
             key={session.session_id}
             className="session-list-collapsed-item"
             onClick={() => handleSessionClick(session.session_id)}
-            title={session.title ?? `Session ${session.session_id.slice(0, 8)}`}
+            title={session.title ?? `Session ${displaySessionId(session.session_id, 8)}`}
           >
             <i className="bi bi-chat-dots" />
           </button>
@@ -326,7 +326,7 @@ export const SessionList: React.FC<SessionListProps> = ({ collapsed = false, onS
         isOpen={showDetailModal}
         onClose={handleCloseModal}
         title={(() => {
-          const sessionIdShort = sessionDetail?.data?.session_id?.slice(0, 8) ?? '';
+          const sessionIdShort = displaySessionId(sessionDetail?.data?.session_id, 8) ?? '';
           const sessionTitle = sessionDetail?.data?.title ?? '';
           // Check if title is meaningful (not just a default pattern like "qwen - 994f805a")
           const isDefaultTitle =
@@ -394,12 +394,12 @@ const SessionGroup: React.FC<SessionGroupProps> = ({
                 ) : session.workspace_type === 'remote' ? (
                   <i
                     className="bi bi-cloud-fill text-primary me-1"
-                    title={`Remote: ${session.machine_name ?? session.id.slice(0, 8)}`}
+                    title={`Remote: ${session.machine_name ?? displaySessionId(session.id, 8)}`}
                   />
                 ) : (
                   <i className="bi bi-laptop text-success me-1" title="Local" />
                 )}
-                {session.id.slice(0, 4)}
+                {displaySessionId(session.id, 4)}
               </span>
               <span className="session-time text-muted">{session.time}</span>
               <span className="session-requests text-muted">

--- a/frontend/src/utils/format.test.ts
+++ b/frontend/src/utils/format.test.ts
@@ -13,6 +13,7 @@ import {
   formatBytes,
   formatDuration,
   formatChartDate,
+  displaySessionId,
 } from './format';
 
 describe('formatTokens', () => {
@@ -261,5 +262,29 @@ describe('formatChartDate', () => {
     expect(formatChartDate('', 'en')).toBe('-');
     expect(formatChartDate(undefined, 'en')).toBe('-');
     expect(formatChartDate('not-a-date', 'en')).toBe('-');
+  });
+});
+
+describe('displaySessionId', () => {
+  it('strips the sess_ prefix before slicing', () => {
+    // ZCode session id — must show the UUID prefix, not "sess"
+    expect(displaySessionId('sess_2a277802-3956-44cd-bf3d-d540eac924ba', 4)).toBe('2a27');
+    expect(displaySessionId('sess_2a277802-3956-44cd-bf3d-d540eac924ba', 8)).toBe('2a277802');
+  });
+
+  it('slices bare UUIDs unchanged (claude/codex/qwen)', () => {
+    expect(displaySessionId('399519bd-2425-4377-bd2b-206cf6bbcc5e', 4)).toBe('3995');
+    expect(displaySessionId('019edfd8-79fe-7423-8ce1-31117e13a10e', 4)).toBe('019e');
+  });
+
+  it('handles missing/empty input', () => {
+    expect(displaySessionId(undefined)).toBe('');
+    expect(displaySessionId(null)).toBe('');
+    expect(displaySessionId('')).toBe('');
+  });
+
+  it('does not strip a bare id that merely starts with "sess_" elsewhere', () => {
+    // Only strips a leading "sess_" prefix; an id without it is sliced as-is.
+    expect(displaySessionId('session-abc', 4)).toBe('sess');
   });
 });

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -146,6 +146,24 @@ export function formatRelativeTime(
 }
 
 /**
+ * Strip a known CLI tool prefix from a session id and return a short slice
+ * for display in the session list.
+ *
+ * Claude/Codex/Qwen store bare UUIDs (e.g. "399519bd-..."), but ZCode stores
+ * "sess_<uuid>" — a naive slice(0, 4) would show "sess" for every ZCode
+ * session. We strip the "sess_" prefix first so all tools display the same
+ * 4-char UUID prefix. The full id is never mutated, only the display value.
+ *
+ * @param sessionId - Full session id (may be undefined)
+ * @param length - Number of characters to show (default 4)
+ */
+export function displaySessionId(sessionId: string | undefined | null, length: number = 4): string {
+  if (!sessionId) return '';
+  const stripped = sessionId.startsWith('sess_') ? sessionId.slice(5) : sessionId;
+  return stripped.slice(0, length);
+}
+
+/**
  * Format bytes to human-readable size
  */
 export function formatBytes(bytes: number, decimals: number = 2): string {

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -14,6 +14,7 @@ export {
   formatBytes,
   formatDuration,
   formatChartDate,
+  displaySessionId,
 } from './format';
 export {
   getDefaultDateRange,

--- a/scripts/fetch_zcode.py
+++ b/scripts/fetch_zcode.py
@@ -161,22 +161,23 @@ def process_zcode_session(
     )
 
     messages: list[dict[str, Any]] = []
-    # Collect distinct dates (from message timestamps) and request count
-    # (assistant turns). Token totals are authoritative session-level values
-    # from the turn_usage table (session.total_input_tokens /
-    # total_output_tokens); per-message ``data.tokens`` is sparse, so we do NOT
-    # sum it (see review feedback — that path under-counts). Tokens are
-    # attributed to the session's dominant date below and injected into the
-    # first assistant message for agent_sessions (codex pattern).
+    # Collect distinct dates (from message timestamps). request_count is
+    # incremented per assistant message on its own date (mirrors
+    # fetch_codex.py:331), so daily request volume reflects real turn counts.
+    # Token totals are authoritative session-level values from the turn_usage
+    # table (session.total_input_tokens / total_output_tokens); per-message
+    # ``data.tokens`` is sparse, so we do NOT sum it (see review feedback —
+    # that path under-counts). Tokens are attributed to the session's dominant
+    # date below and injected into the first assistant message for
+    # agent_sessions (codex pattern).
     session_dates: set[str] = set()
-    assistant_dates: set[str] = set()
     for msg in session.messages:
         ts = msg.get("timestamp")
         date_key = _ms_to_date(_iso_to_ms(ts)) if ts else "unknown"
         session_dates.add(date_key)
         role = msg.get("role", "")
         if role == "assistant":
-            assistant_dates.add(date_key)
+            daily[date_key]["request_count"] += 1
 
         model = msg.get("model")
         if model:
@@ -223,7 +224,9 @@ def process_zcode_session(
     daily[dominant_date]["prompt_tokens"] += total_input
     daily[dominant_date]["candidates_tokens"] += total_output
     daily[dominant_date]["total_tokens"] += total_tokens
-    daily[dominant_date]["request_count"] += len(assistant_dates)
+    # NOTE: request_count is NOT added here — it is incremented per assistant
+    # message on its own date in the loop above (matches fetch_codex.py), so a
+    # session reports its real assistant-turn count rather than collapsing to 1.
 
     # Inject session-level totals into the first assistant message so
     # update_agent_sessions_stats records the real total_tokens (codex pattern,

--- a/scripts/fetch_zcode.py
+++ b/scripts/fetch_zcode.py
@@ -1,0 +1,684 @@
+#!/usr/bin/env python3
+"""
+Open ACE - ZCode Fetcher
+
+Fetches session data from the ZCode CLI SQLite database.
+
+Unlike Claude/Codex/Qwen (which store sessions as JSONL files), ZCode stores
+sessions relationally in ``~/.zcode/cli/db/db.sqlite`` with tables: session,
+message, part, turn_usage. This fetcher reuses the ``ZcodeSession`` parser from
+``remote-agent/session_sync.py`` so the parsing logic stays in one place, then
+converts each parsed session into the same message-dict shape the other fetch
+scripts use and writes it to daily_usage / daily_messages / agent_sessions /
+session_messages — exactly mirroring ``scripts/fetch_codex.py``.
+
+Only ``interactive`` (not ``subagent_child``) and non-archived sessions are
+synced, matching ``SessionSyncService._scan_and_sync_zcode_db``.
+"""
+
+import argparse
+import getpass
+import json
+import os
+import platform
+import socket
+import sys
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+# Add shared directory to path
+script_dir = os.path.dirname(os.path.abspath(__file__))
+shared_dir = os.path.join(script_dir, "shared")
+if shared_dir not in sys.path:
+    sys.path.insert(0, script_dir)
+from shared import db
+
+# Import the ZcodeSession parser from remote-agent (single source of truth).
+# remote-agent is a package (has __init__.py) but session_sync imports its
+# sibling ``cli_adapters.codex_jsonl_parser`` as a top-level module, so we put
+# the remote-agent dir on sys.path rather than importing it as a package.
+_remote_agent_path = os.path.join(script_dir, "..", "remote-agent")
+if _remote_agent_path not in sys.path:
+    sys.path.insert(0, _remote_agent_path)
+from session_sync import ZcodeSession  # noqa: E402
+
+TOOL_NAME = "zcode"
+# ZCode stores sessions in a SQLite database under ~/.zcode/cli/db/db.sqlite
+ZCODE_DB_RELATIVE = os.path.join(".zcode", "cli", "db", "db.sqlite")
+# Only sync interactive sessions (skip subagent_child) that are not archived,
+# matching SessionSyncService._scan_and_sync_zcode_db.
+CANDIDATE_SQL = (
+    "SELECT id, time_updated, time_created FROM session "
+    "WHERE task_type = 'interactive' AND time_archived IS NULL"
+)
+
+
+def get_default_sender_name(tool: str = TOOL_NAME) -> str:
+    """Generate default sender name in format: {user}-{hostname}-{tool}."""
+    user = getpass.getuser()
+    hostname = socket.gethostname()
+    return f"{user}-{hostname}-{tool}"
+
+
+def find_all_zcode_db_paths() -> list[tuple[str, Path]]:
+    """Find ZCode DB paths for all users on the system.
+
+    Scans /home/*/.zcode/cli/db/db.sqlite (Linux) or
+    /Users/*/.zcode/cli/db/db.sqlite (macOS).
+
+    Returns:
+        List of tuples: [(system_account, db_path), ...]
+    """
+    results: list[tuple[str, Path]] = []
+    os_type = platform.system().lower()
+
+    if os_type == "linux":
+        home_base = Path("/home")
+    elif os_type == "darwin":
+        home_base = Path("/Users")
+    else:
+        # Windows or other — just use current user.
+        db_path = Path.home() / ZCODE_DB_RELATIVE
+        if db_path.is_file():
+            results.append((getpass.getuser(), db_path))
+        return results
+
+    if not home_base.is_dir():
+        return results
+
+    for user_dir in home_base.iterdir():
+        if not user_dir.is_dir():
+            continue
+        system_account = user_dir.name
+        db_path = user_dir / ZCODE_DB_RELATIVE
+        try:
+            if db_path.is_file():
+                results.append((system_account, db_path))
+        except PermissionError:
+            print(f"  Warning: Cannot access {db_path} (permission denied)")
+            continue
+
+    return results
+
+
+def find_zcode_db_path() -> Optional[Path]:
+    """Find the ZCode DB path for the current user."""
+    db_path = Path.home() / ZCODE_DB_RELATIVE
+    if db_path.is_file():
+        return db_path
+    return None
+
+
+def _ms_to_date(ms: Optional[int]) -> str:
+    """Convert epoch milliseconds to a YYYY-MM-DD date string (UTC)."""
+    if not ms:
+        return "unknown"
+    try:
+        return datetime.fromtimestamp(ms / 1000, tz=timezone.utc).strftime("%Y-%m-%d")
+    except (ValueError, OSError, OverflowError):
+        return "unknown"
+
+
+def process_zcode_session(
+    session_id: str,
+    db_path: Path,
+    hostname: str = "localhost",
+    system_account: Optional[str] = None,
+) -> tuple[dict[str, dict[str, Any]], list[dict[str, Any]], Optional[str]]:
+    """Parse one ZCode session into daily aggregates + fetch message dicts.
+
+    Mirrors ``process_jsonl_file`` in fetch_codex.py: returns
+    (daily_stats, messages, project_path).
+
+    Args:
+        session_id: ZCode session id.
+        db_path: Path to the ZCode SQLite DB.
+        hostname: Host name for this machine.
+        system_account: System account (linux/mac username) for multi-user mode.
+
+    Returns:
+        tuple: (daily_stats dict keyed by date, messages list, project_path)
+    """
+    session = ZcodeSession(session_id, db_path)
+    if not session.parse() or session.message_count == 0:
+        return {}, [], None
+
+    sender_name = (
+        f"{system_account}-{hostname}-{TOOL_NAME}" if system_account else get_default_sender_name()
+    )
+
+    daily: dict[str, dict[str, Any]] = defaultdict(
+        lambda: {
+            "prompt_tokens": 0,
+            "candidates_tokens": 0,
+            "cached_tokens": 0,
+            "total_tokens": 0,
+            "request_count": 0,
+            "models_used": set(),
+        }
+    )
+
+    messages: list[dict[str, Any]] = []
+    for msg in session.messages:
+        ts = msg.get("timestamp")
+        date_key = _ms_to_date(_iso_to_ms(ts)) if ts else "unknown"
+
+        usage = msg.get("usage") or {}
+        input_t = int(usage.get("input_tokens", 0) or 0)
+        output_t = int(usage.get("output_tokens", 0) or 0)
+        total_t = input_t + output_t
+        role = msg.get("role", "")
+
+        model = msg.get("model")
+        if model:
+            daily[date_key]["models_used"].add(model)
+
+        daily[date_key]["prompt_tokens"] += input_t
+        daily[date_key]["candidates_tokens"] += output_t
+        daily[date_key]["total_tokens"] += total_t
+        if role == "assistant":
+            daily[date_key]["request_count"] += 1
+
+        content_blocks = msg.get("content_blocks")
+        messages.append(
+            {
+                "date": date_key,
+                "tool_name": TOOL_NAME,
+                "host_name": hostname,
+                "message_id": msg.get("uuid") or f"zcode-{session_id[:8]}-{date_key}",
+                "parent_id": None,
+                "role": role,
+                "content": msg.get("content", "") or "",
+                "content_blocks": content_blocks,
+                "full_entry": json.dumps(
+                    {"session_id": session_id, "role": role, "model": model},
+                    ensure_ascii=False,
+                ),
+                "tokens_used": total_t,
+                "input_tokens": input_t,
+                "output_tokens": output_t,
+                "model": model,
+                "timestamp": ts,
+                "sender_id": system_account or "zcode_user",
+                "sender_name": sender_name,
+                "agent_session_id": session_id,
+                "conversation_id": None,
+                "project_path": session.project_path,
+            }
+        )
+
+    return daily, messages, session.project_path
+
+
+def _iso_to_ms(ts: Optional[str]) -> Optional[int]:
+    """Best-effort convert an ISO-8601 timestamp to epoch milliseconds."""
+    if not ts:
+        return None
+    try:
+        dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+        return int(dt.timestamp() * 1000)
+    except (ValueError, TypeError):
+        return None
+
+
+def _resolve_user_id_from_sender(cursor, sender_name: str, all_users_cache: list) -> Optional[int]:
+    """Resolve user_id from sender_name (format: {user}-{hostname}-{tool}).
+
+    Identical to fetch_codex._resolve_user_id_from_sender: try rsplit first,
+    then longest-prefix match against all users.
+
+    Args:
+        cursor: Database cursor.
+        sender_name: Sender name string, e.g. 'rhuang-Host-zcode'.
+        all_users_cache: Cached list of all user rows.
+
+    Returns:
+        user_id or None.
+    """
+    if not sender_name:
+        return None
+
+    from shared.db import _execute, _placeholder
+
+    placeholder = _placeholder()
+
+    # Try rsplit first (works when hostname has no hyphens)
+    candidate = sender_name.rsplit("-", 2)[0]
+    user_sql = (
+        f"SELECT id FROM users WHERE system_account = {placeholder} OR username = {placeholder}"
+    )
+    _execute(cursor, user_sql, (candidate, candidate))
+    user_row = cursor.fetchone()
+    if user_row:
+        return user_row["id"] if isinstance(user_row, dict) else user_row[0]
+
+    # Fallback: longest-prefix match against all users
+    candidates = sorted(
+        ((u["id"], f) for u in all_users_cache for f in (u["system_account"], u["username"]) if f),
+        key=lambda x: len(x[1]),
+        reverse=True,
+    )
+    for uid, field in candidates:
+        if sender_name.startswith(field + "-"):
+            return uid
+
+    return None
+
+
+def update_agent_sessions_stats(messages: list) -> int:
+    """Update agent_sessions / session_messages from collected ZCode messages.
+
+    Mirrors ``fetch_codex.update_agent_sessions_stats``. Groups messages by
+    agent_session_id, upserts agent_sessions (tool_name='zcode',
+    session_type='session', status='completed'), and inserts messages into
+    session_messages (dedup by session_id + role + timestamp).
+
+    Args:
+        messages: List of message dicts with agent_session_id and tokens_used.
+
+    Returns:
+        Number of sessions updated/inserted.
+    """
+    from shared.db import _execute, _placeholder, get_connection
+
+    session_stats: dict[str, dict[str, Any]] = defaultdict(
+        lambda: {
+            "message_count": 0,
+            "total_tokens": 0,
+            "request_count": 0,
+            "models": set(),
+            "messages": [],
+            "last_timestamp": None,
+            "project_path": None,
+        }
+    )
+
+    for msg in messages:
+        sid = msg.get("agent_session_id")
+        if not sid:
+            continue
+
+        role = msg.get("role", "")
+        tokens = msg.get("tokens_used", 0) or 0
+        model = msg.get("model")
+
+        session_stats[sid]["message_count"] += 1
+        session_stats[sid]["total_tokens"] += tokens
+
+        if role == "assistant":
+            session_stats[sid]["request_count"] += 1
+
+        if model:
+            session_stats[sid]["models"].add(model)
+
+        session_stats[sid]["messages"].append(msg)
+
+        if not session_stats[sid]["project_path"] and msg.get("project_path"):
+            session_stats[sid]["project_path"] = msg["project_path"]
+
+        timestamp = msg.get("timestamp")
+        if timestamp:
+            current_last = session_stats[sid]["last_timestamp"]
+            if current_last is None or timestamp > current_last:
+                session_stats[sid]["last_timestamp"] = timestamp
+
+    if not session_stats:
+        return 0
+
+    updated = 0
+    messages_inserted = 0
+    now = datetime.now(timezone.utc).replace(tzinfo=None).isoformat()
+    placeholder = _placeholder()
+
+    conn = get_connection()
+    cursor = conn.cursor()
+
+    _all_users_cache: list = []
+
+    def _get_all_users() -> list:
+        if not _all_users_cache:
+            _execute(cursor, "SELECT id, system_account, username FROM users")
+            _all_users_cache.extend(cursor.fetchall())
+        return _all_users_cache
+
+    try:
+        for session_id, stats in session_stats.items():
+            try:
+                check_sql = (
+                    f"SELECT id, user_id FROM agent_sessions WHERE session_id = {placeholder}"
+                )
+                _execute(cursor, check_sql, (session_id,))
+                session_row = cursor.fetchone()
+                _is_new_session = False
+
+                if not session_row:
+                    first_msg = stats["messages"][0] if stats["messages"] else {}
+
+                    host_name = first_msg.get("host_name", "localhost")
+                    sender_name = first_msg.get("sender_name", "")
+                    project_path = stats["project_path"] or first_msg.get("project_path", "")
+
+                    user_id = _resolve_user_id_from_sender(cursor, sender_name, _get_all_users())
+
+                    # Strip the "sess_" prefix before building the short id so the
+                    # title matches the frontend's default-title pattern
+                    # (^[a-z]+ - [a-f0-9]{8}$), same as claude/codex.
+                    short_id = session_id[5:] if session_id.startswith("sess_") else session_id
+                    title = f"zcode - {short_id[:8]}"
+
+                    insert_sql = f"""
+                        INSERT INTO agent_sessions
+                        (session_id, session_type, title, tool_name, host_name, user_id, status, project_path,
+                         message_count, total_tokens, request_count, model, created_at, updated_at)
+                        VALUES ({placeholder}, {placeholder}, {placeholder}, {placeholder}, {placeholder},
+                                {placeholder}, {placeholder}, {placeholder}, {placeholder}, {placeholder},
+                                {placeholder}, {placeholder}, {placeholder}, {placeholder})
+                    """
+                    model = sorted(stats["models"])[0] if stats["models"] else None
+                    _execute(
+                        cursor,
+                        insert_sql,
+                        (
+                            session_id,
+                            "session",
+                            title,
+                            TOOL_NAME,
+                            host_name,
+                            user_id,
+                            "completed",
+                            project_path,
+                            stats["message_count"],
+                            stats["total_tokens"],
+                            stats["request_count"],
+                            model,
+                            now,
+                            now,
+                        ),
+                    )
+                    updated += 1
+                    _is_new_session = True
+
+                if not _is_new_session:
+                    model = sorted(stats["models"])[0] if stats["models"] else None
+                    session_updated_at = stats["last_timestamp"] or now
+                    sql = f"""
+                        UPDATE agent_sessions
+                        SET message_count = CASE WHEN COALESCE(message_count, 0) > {placeholder} THEN COALESCE(message_count, 0) ELSE {placeholder} END,
+                            total_tokens = CASE WHEN COALESCE(total_tokens, 0) > {placeholder} THEN COALESCE(total_tokens, 0) ELSE {placeholder} END,
+                            request_count = CASE WHEN COALESCE(request_count, 0) > {placeholder} THEN COALESCE(request_count, 0) ELSE {placeholder} END,
+                            model = COALESCE(model, {placeholder}),
+                            updated_at = {placeholder}
+                        WHERE session_id = {placeholder}
+                    """
+                    _execute(
+                        cursor,
+                        sql,
+                        (
+                            stats["message_count"],
+                            stats["message_count"],
+                            stats["total_tokens"],
+                            stats["total_tokens"],
+                            stats["request_count"],
+                            stats["request_count"],
+                            model,
+                            session_updated_at,
+                            session_id,
+                        ),
+                    )
+
+                    if cursor.rowcount > 0:
+                        updated += 1
+
+                # Insert messages into session_messages table (dedup by role + timestamp)
+                for msg in stats["messages"]:
+                    try:
+                        msg_id = msg.get("message_id")
+                        timestamp = msg.get("timestamp") or now
+
+                        check_sql = f"""
+                            SELECT id FROM session_messages
+                            WHERE session_id = {placeholder}
+                            AND role = {placeholder}
+                            AND timestamp = {placeholder}
+                        """
+                        _execute(cursor, check_sql, (session_id, msg.get("role"), timestamp))
+                        existing = cursor.fetchone()
+
+                        if not existing:
+                            insert_sql = f"""
+                                INSERT INTO session_messages
+                                (session_id, role, content, tokens_used, model, timestamp, metadata)
+                                VALUES ({placeholder}, {placeholder}, {placeholder}, {placeholder}, {placeholder}, {placeholder}, {placeholder})
+                            """
+                            metadata = {
+                                "message_id": msg_id,
+                                "project_path": msg.get("project_path"),
+                                "content_blocks": msg.get("content_blocks"),
+                            }
+                            _execute(
+                                cursor,
+                                insert_sql,
+                                (
+                                    session_id,
+                                    msg.get("role"),
+                                    msg.get("content", ""),
+                                    msg.get("tokens_used", 0) or 0,
+                                    msg.get("model"),
+                                    timestamp,
+                                    json.dumps(metadata, ensure_ascii=False),
+                                ),
+                            )
+                            messages_inserted += 1
+                    except Exception as e:
+                        print(f"  Warning: Failed to insert message for {session_id}: {e}")
+
+            except Exception as e:
+                print(f"  Warning: Failed to update session {session_id}: {e}")
+
+        conn.commit()
+
+    finally:
+        cursor.close()
+        conn.close()
+
+    print(f"  Updated {updated} session statistics, inserted {messages_inserted} messages")
+    return updated
+
+
+def _iter_candidate_sessions(db_path: Path, days: int, recent: bool) -> list[tuple[str, int]]:
+    """Return [(session_id, time_updated_ms)] candidates from a ZCode DB.
+
+    Filters by --days and --recent (only sessions updated today), using the
+    ``time_updated`` epoch-millisecond column. Opens the DB read-only (URI mode)
+    so we never block ZCode's WAL writer — same approach as ZcodeSession._connect.
+    """
+    import sqlite3
+
+    try:
+        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    except sqlite3.Error as e:
+        print(f"  Cannot open ZCode DB {db_path}: {e}")
+        return []
+
+    cutoff_ms = 0
+    if days > 0:
+        cutoff_ms = int((datetime.now(timezone.utc) - timedelta(days=days)).timestamp() * 1000)
+    if recent:
+        today_start = datetime.now(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0)
+        cutoff_ms = max(cutoff_ms, int(today_start.timestamp() * 1000))
+
+    candidates: list[tuple[str, int]] = []
+    try:
+        rows = conn.execute(CANDIDATE_SQL).fetchall()
+        for session_id, time_updated, _time_created in rows:
+            updated_ms = time_updated or 0
+            if cutoff_ms and updated_ms and updated_ms < cutoff_ms:
+                continue
+            candidates.append((session_id, updated_ms))
+    except sqlite3.DatabaseError as e:
+        print(f"  ZCode DB query failed for {db_path}: {e}")
+    finally:
+        conn.close()
+
+    return candidates
+
+
+def fetch_and_save(
+    days: int = 7,
+    hostname: Optional[str] = None,
+    multi_user_mode: bool = False,
+    recent: bool = False,
+) -> bool:
+    """Fetch ZCode usage and save to database.
+
+    Args:
+        days: Number of days to look back (based on session time_updated).
+        hostname: Optional host name to identify this machine.
+        multi_user_mode: If True, scan all users' ZCode DBs.
+        recent: If True, only process sessions updated today.
+
+    Returns:
+        True if successful, False otherwise.
+    """
+    from shared import db as db_mod
+    from shared import utils
+
+    if hostname is None:
+        config = utils.load_config()
+        hostname = config.get("host_name", "localhost")
+
+    aggregated: dict[str, dict[str, Any]] = defaultdict(
+        lambda: {
+            "prompt_tokens": 0,
+            "candidates_tokens": 0,
+            "cached_tokens": 0,
+            "total_tokens": 0,
+            "request_count": 0,
+            "models_used": set(),
+        }
+    )
+
+    all_messages: list[dict[str, Any]] = []
+
+    # Discover ZCode DBs to scan.
+    db_targets: list[tuple[Optional[str], Path]] = []
+    if multi_user_mode:
+        print("Multi-user mode: scanning all users' ZCode databases...")
+        db_targets = find_all_zcode_db_paths()
+        if not db_targets:
+            print("No ZCode databases found for any user.")
+            return False
+        print(f"Found {len(db_targets)} users with ZCode data:")
+        for system_account, db_path in db_targets:
+            print(f"  - {system_account}: {db_path}")
+    else:
+        db_path = find_zcode_db_path()
+        if not db_path:
+            print("Error: Cannot find ZCode DB (~/.zcode/cli/db/db.sqlite).")
+            return False
+        db_targets = [(None, db_path)]
+
+    total_sessions = 0
+    for system_account, db_path in db_targets:
+        label = system_account or "current user"
+        print(f"\nProcessing ZCode DB for {label}: {db_path}")
+        candidates = _iter_candidate_sessions(db_path, days, recent)
+        print(f"  Found {len(candidates)} candidate session(s)")
+
+        for session_id, _updated_ms in candidates:
+            daily, messages, _project = process_zcode_session(
+                session_id, db_path, hostname, system_account
+            )
+            if not messages:
+                continue
+
+            total_sessions += 1
+            for date, stats in daily.items():
+                aggregated[date]["prompt_tokens"] += stats["prompt_tokens"]
+                aggregated[date]["candidates_tokens"] += stats["candidates_tokens"]
+                aggregated[date]["total_tokens"] += stats["total_tokens"]
+                aggregated[date]["request_count"] += stats["request_count"]
+                aggregated[date]["models_used"].update(stats["models_used"])
+            all_messages.extend(messages)
+
+    print(f"\nProcessed {total_sessions} sessions, {len(all_messages)} messages")
+
+    # Save daily_usage.
+    saved = 0
+    for date, stats in aggregated.items():
+        if date and date != "unknown":
+            total = stats["total_tokens"]
+            if db_mod.save_usage(
+                date=date,
+                tool_name=TOOL_NAME,
+                host_name=hostname,
+                tokens_used=total,
+                input_tokens=stats["prompt_tokens"],
+                output_tokens=stats["candidates_tokens"],
+                cache_tokens=stats["cached_tokens"],
+                request_count=stats["request_count"],
+                models_used=sorted(stats["models_used"]),
+            ):
+                saved += 1
+            print(f"  {date}: {total:,} tokens, {stats['request_count']} requests")
+
+    print(f"\nSaved {saved} days of ZCode usage data")
+
+    # Save messages (idempotent UPSERT into daily_messages).
+    if all_messages:
+        print("Saving messages to database...")
+        saved_count = db_mod.save_messages_batch(all_messages, batch_size=500)
+        print(f"Saved {saved_count} messages")
+
+        # Update agent_sessions / session_messages (non-critical).
+        try:
+            print("Updating agent_sessions statistics...")
+            update_agent_sessions_stats(all_messages)
+        except Exception as e:
+            print(f"Warning: Failed to update agent session stats: {e}")
+
+    return True
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Fetch ZCode CLI session data")
+    parser.add_argument("--days", type=int, default=7, help="Number of days to look back")
+    parser.add_argument("--hostname", help="Host name to identify this machine")
+    parser.add_argument(
+        "--multi-user",
+        action="store_true",
+        help="Scan all users' ZCode databases (requires root/admin privileges)",
+    )
+    parser.add_argument(
+        "--config",
+        help="Path to config.json file (useful when running as root via sudo)",
+    )
+    parser.add_argument(
+        "--recent",
+        action="store_true",
+        help="Only process sessions updated today (for scheduler use)",
+    )
+    args = parser.parse_args()
+
+    # If --config is specified, use it to get database URL
+    if args.config:
+        config_path = Path(args.config)
+        if config_path.exists():
+            with open(config_path) as f:
+                config_data = json.load(f)
+            db_config = config_data.get("database", {})
+            db_url = db_config.get("url")
+            if db_url:
+                os.environ["DATABASE_URL"] = db_url
+                print(f"Using database from config: {db_config.get('type', 'postgresql')}")
+
+    db.init_database()
+    success = fetch_and_save(
+        days=args.days,
+        hostname=args.hostname,
+        multi_user_mode=args.multi_user,
+        recent=args.recent,
+    )
+    sys.exit(0 if success else 1)

--- a/scripts/fetch_zcode.py
+++ b/scripts/fetch_zcode.py
@@ -161,25 +161,26 @@ def process_zcode_session(
     )
 
     messages: list[dict[str, Any]] = []
+    # Collect distinct dates (from message timestamps) and request count
+    # (assistant turns). Token totals are authoritative session-level values
+    # from the turn_usage table (session.total_input_tokens /
+    # total_output_tokens); per-message ``data.tokens`` is sparse, so we do NOT
+    # sum it (see review feedback — that path under-counts). Tokens are
+    # attributed to the session's dominant date below and injected into the
+    # first assistant message for agent_sessions (codex pattern).
+    session_dates: set[str] = set()
+    assistant_dates: set[str] = set()
     for msg in session.messages:
         ts = msg.get("timestamp")
         date_key = _ms_to_date(_iso_to_ms(ts)) if ts else "unknown"
-
-        usage = msg.get("usage") or {}
-        input_t = int(usage.get("input_tokens", 0) or 0)
-        output_t = int(usage.get("output_tokens", 0) or 0)
-        total_t = input_t + output_t
+        session_dates.add(date_key)
         role = msg.get("role", "")
+        if role == "assistant":
+            assistant_dates.add(date_key)
 
         model = msg.get("model")
         if model:
             daily[date_key]["models_used"].add(model)
-
-        daily[date_key]["prompt_tokens"] += input_t
-        daily[date_key]["candidates_tokens"] += output_t
-        daily[date_key]["total_tokens"] += total_t
-        if role == "assistant":
-            daily[date_key]["request_count"] += 1
 
         content_blocks = msg.get("content_blocks")
         messages.append(
@@ -196,9 +197,11 @@ def process_zcode_session(
                     {"session_id": session_id, "role": role, "model": model},
                     ensure_ascii=False,
                 ),
-                "tokens_used": total_t,
-                "input_tokens": input_t,
-                "output_tokens": output_t,
+                # Per-message tokens left at 0; session totals are injected
+                # into the first assistant message below.
+                "tokens_used": 0,
+                "input_tokens": 0,
+                "output_tokens": 0,
                 "model": model,
                 "timestamp": ts,
                 "sender_id": system_account or "zcode_user",
@@ -209,7 +212,46 @@ def process_zcode_session(
             }
         )
 
+    # Attribute the authoritative session-level token totals to the dominant
+    # date (the date with the most messages; ties broken by recency). This
+    # keeps daily_usage aligned with the session totals rather than fragmenting
+    # sparse per-message numbers.
+    total_input = int(getattr(session, "total_input_tokens", 0) or 0)
+    total_output = int(getattr(session, "total_output_tokens", 0) or 0)
+    total_tokens = total_input + total_output
+    dominant_date = _dominant_date(session_dates, messages)
+    daily[dominant_date]["prompt_tokens"] += total_input
+    daily[dominant_date]["candidates_tokens"] += total_output
+    daily[dominant_date]["total_tokens"] += total_tokens
+    daily[dominant_date]["request_count"] += len(assistant_dates)
+
+    # Inject session-level totals into the first assistant message so
+    # update_agent_sessions_stats records the real total_tokens (codex pattern,
+    # fetch_codex.py:648-654).
+    if total_tokens > 0:
+        for msg in messages:
+            if msg.get("role") == "assistant":
+                msg["tokens_used"] = total_tokens
+                msg["input_tokens"] = total_input
+                msg["output_tokens"] = total_output
+                break
+
     return daily, messages, session.project_path
+
+
+def _dominant_date(dates: set[str], messages: list[dict[str, Any]]) -> str:
+    """Pick the date with the most messages, ties broken by recency."""
+    if not dates:
+        return "unknown"
+    counts: dict[str, int] = defaultdict(int)
+    last_ts: dict[str, str] = {}
+    for msg in messages:
+        d = msg.get("date", "unknown")
+        counts[d] += 1
+        ts = msg.get("timestamp") or ""
+        if ts >= last_ts.get(d, ""):
+            last_ts[d] = ts
+    return max(counts, key=lambda d: (counts[d], last_ts.get(d, "")))
 
 
 def _iso_to_ms(ts: Optional[str]) -> Optional[int]:
@@ -506,7 +548,10 @@ def _iter_candidate_sessions(db_path: Path, days: int, recent: bool) -> list[tup
     if days > 0:
         cutoff_ms = int((datetime.now(timezone.utc) - timedelta(days=days)).timestamp() * 1000)
     if recent:
-        today_start = datetime.now(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0)
+        # Use local midnight to match the sibling fetch scripts
+        # (fetch_codex.py:594-598 uses local-naive midnight), so --recent syncs
+        # align with the user's notion of "today" rather than UTC rollover.
+        today_start = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
         cutoff_ms = max(cutoff_ms, int(today_start.timestamp() * 1000))
 
     candidates: list[tuple[str, int]] = []

--- a/scripts/install-central/package-method/install.sh
+++ b/scripts/install-central/package-method/install.sh
@@ -1726,6 +1726,8 @@ configure_sudoers() {
     # Get fetch_claude.py and fetch_openclaw.py paths
     local fetch_claude_path="$install_dir/scripts/fetch_claude.py"
     local fetch_openclaw_path="$install_dir/scripts/fetch_openclaw.py"
+    local fetch_codex_path="$install_dir/scripts/fetch_codex.py"
+    local fetch_zcode_path="$install_dir/scripts/fetch_zcode.py"
 
     # Build sudoers content with all fetch scripts
     local fetch_sudoers=""
@@ -1743,6 +1745,16 @@ $run_user ALL=(root) NOPASSWD: /usr/bin/python3 $fetch_claude_path *"
         fetch_sudoers="$fetch_sudoers
 # Allow $run_user to run fetch_openclaw.py as root for multi-user data collection
 $run_user ALL=(root) NOPASSWD: /usr/bin/python3 $fetch_openclaw_path *"
+    fi
+    if [ -f "$fetch_codex_path" ]; then
+        fetch_sudoers="$fetch_sudoers
+# Allow $run_user to run fetch_codex.py as root for multi-user data collection
+$run_user ALL=(root) NOPASSWD: /usr/bin/python3 $fetch_codex_path *"
+    fi
+    if [ -f "$fetch_zcode_path" ]; then
+        fetch_sudoers="$fetch_sudoers
+# Allow $run_user to run fetch_zcode.py as root for multi-user data collection
+$run_user ALL=(root) NOPASSWD: /usr/bin/python3 $fetch_zcode_path *"
     fi
 
     # Add /usr/local/bin/qwen-code-webui rule if it exists (Node.js v20+ may be installed there)

--- a/tests/unit/test_fetch_zcode.py
+++ b/tests/unit/test_fetch_zcode.py
@@ -122,6 +122,19 @@ def _insert_zcode_message(
     conn.close()
 
 
+def _insert_turn_usage(
+    db_path: Path, session_id: str, turn_id: str, input_t: int, output_t: int
+) -> None:
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        "INSERT INTO turn_usage (session_id, turn_id, input_tokens, output_tokens) "
+        "VALUES (?, ?, ?, ?)",
+        (session_id, turn_id, input_t, output_t),
+    )
+    conn.commit()
+    conn.close()
+
+
 def _init_dest_schema(db_path: Path) -> None:
     """Create the destination tables fetch_zcode writes to (minimal subset)."""
     conn = sqlite3.connect(str(db_path))
@@ -246,6 +259,10 @@ def test_process_zcode_session_returns_messages_and_project(fetch_mod, tmp_path)
         {"role": "assistant", "modelID": "GLM-5.2", "tokens": {"input": 100, "output": 10}},
         parts=[{"type": "text", "text": "hi there"}],
     )
+    # Authoritative session-level tokens come from turn_usage, NOT the sparse
+    # per-message data.tokens above. Seed a turn_usage row with different
+    # numbers to prove the session totals win.
+    _insert_turn_usage(src_db, sid, "turn_1", input_t=250, output_t=30)
 
     daily, messages, project = fetch_mod.process_zcode_session(sid, src_db, "localhost", None)
 
@@ -255,14 +272,18 @@ def test_process_zcode_session_returns_messages_and_project(fetch_mod, tmp_path)
     assert messages[0]["role"] == "user"
     assert messages[0]["content"] == "hello world"
     assert messages[0]["agent_session_id"] == sid
+    # Per-message tokens are 0; session totals injected into first assistant msg.
+    assert messages[0]["tokens_used"] == 0
     assert messages[1]["role"] == "assistant"
-    assert messages[1]["input_tokens"] == 100
-    assert messages[1]["output_tokens"] == 10
-    assert messages[1]["tokens_used"] == 110
-    # daily aggregates
+    assert messages[1]["input_tokens"] == 250
+    assert messages[1]["output_tokens"] == 30
+    assert messages[1]["tokens_used"] == 280
+    # daily aggregates use session totals (250 input + 30 output = 280)
     assert len(daily) == 1
     only_date = next(iter(daily))
-    assert daily[only_date]["total_tokens"] == 110
+    assert daily[only_date]["prompt_tokens"] == 250
+    assert daily[only_date]["candidates_tokens"] == 30
+    assert daily[only_date]["total_tokens"] == 280
     assert daily[only_date]["request_count"] == 1
 
 

--- a/tests/unit/test_fetch_zcode.py
+++ b/tests/unit/test_fetch_zcode.py
@@ -1,0 +1,443 @@
+#!/usr/bin/env python3
+"""Unit tests for scripts/fetch_zcode.py.
+
+Validates that fetch_zcode:
+  - reuses the ZcodeSession parser from remote-agent/session_sync.py,
+  - converts a parsed ZCode session into the fetch message-dict shape,
+  - upserts agent_sessions (tool_name='zcode', session_type='session',
+    status='completed') and inserts session_messages.
+
+The ZCode source DB is a throwaway SQLite file built with ZCode's real schema
+(reused from tests/unit/test_zcode_session_sync.py). The destination DB is a
+throwaway SQLite file so no PostgreSQL or shared state is required.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sqlite3
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_REMOTE_AGENT_DIR = _REPO_ROOT / "remote-agent"
+_SCRIPTS_DIR = _REPO_ROOT / "scripts"
+
+
+def _load_fetch_zcode(tmp_db_url: str):
+    """Load scripts/fetch_zcode.py as an isolated module against a temp DB.
+
+    Setting DATABASE_URL before import routes shared.db at the temp SQLite file.
+    We (re)load shared.db so the env var takes effect for this process.
+    """
+    import os
+
+    os.environ["DATABASE_URL"] = tmp_db_url
+    os.environ["FETCH_USE_SUDO"] = "false"
+
+    if str(_SCRIPTS_DIR) not in sys.path:
+        sys.path.insert(0, str(_SCRIPTS_DIR))
+    if str(_REMOTE_AGENT_DIR) not in sys.path:
+        sys.path.insert(0, str(_REMOTE_AGENT_DIR))
+
+    # Force shared.db to pick up the new DATABASE_URL.
+    import importlib
+
+    from shared import db as db_mod
+
+    importlib.reload(db_mod)
+
+    spec = importlib.util.spec_from_file_location(
+        "fetch_zcode_under_test", _SCRIPTS_DIR / "fetch_zcode.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _build_zcode_source_db(db_path: Path) -> None:
+    """Create a minimal ZCode-schema DB (session/message/part/turn_usage)."""
+    conn = sqlite3.connect(str(db_path))
+    conn.executescript(
+        """
+        CREATE TABLE session (
+            id text primary key,
+            directory text not null,
+            time_created integer not null,
+            time_updated integer not null,
+            time_archived integer,
+            task_type text not null default 'interactive',
+            title text not null default ''
+        );
+        CREATE TABLE message (
+            id text primary key,
+            session_id text not null,
+            time_created integer not null,
+            data text not null
+        );
+        CREATE TABLE part (
+            id text primary key,
+            message_id text not null,
+            session_id text not null,
+            data text not null
+        );
+        CREATE TABLE turn_usage (
+            session_id text not null,
+            turn_id text not null,
+            input_tokens integer not null default 0,
+            output_tokens integer not null default 0,
+            PRIMARY KEY (session_id, turn_id)
+        );
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+def _insert_zcode_message(
+    db_path: Path,
+    msg_id: str,
+    session_id: str,
+    time_created: int,
+    data: dict,
+    parts: list[dict] | None = None,
+) -> None:
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        "INSERT INTO message (id, session_id, time_created, data) VALUES (?, ?, ?, ?)",
+        (msg_id, session_id, time_created, json.dumps(data)),
+    )
+    if parts:
+        for i, part in enumerate(parts):
+            conn.execute(
+                "INSERT INTO part (id, message_id, session_id, data) VALUES (?, ?, ?, ?)",
+                (f"{msg_id}_part{i}", msg_id, session_id, json.dumps(part)),
+            )
+    conn.commit()
+    conn.close()
+
+
+def _init_dest_schema(db_path: Path) -> None:
+    """Create the destination tables fetch_zcode writes to (minimal subset)."""
+    conn = sqlite3.connect(str(db_path))
+    conn.executescript(
+        """
+        CREATE TABLE users (
+            id INTEGER PRIMARY KEY,
+            username TEXT,
+            system_account TEXT,
+            email TEXT
+        );
+        CREATE TABLE agent_sessions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT NOT NULL UNIQUE,
+            session_type TEXT DEFAULT 'chat',
+            title TEXT,
+            tool_name TEXT NOT NULL,
+            host_name TEXT DEFAULT 'localhost',
+            user_id INTEGER,
+            status TEXT DEFAULT 'active',
+            project_path TEXT,
+            message_count INTEGER DEFAULT 0,
+            total_tokens INTEGER DEFAULT 0,
+            request_count INTEGER DEFAULT 0,
+            model TEXT,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        );
+        CREATE TABLE session_messages (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT,
+            role TEXT,
+            content TEXT,
+            tokens_used INTEGER DEFAULT 0,
+            model TEXT,
+            timestamp TEXT,
+            metadata TEXT
+        );
+        CREATE TABLE daily_usage (
+            date TEXT,
+            tool_name TEXT,
+            host_name TEXT,
+            tokens_used INTEGER DEFAULT 0,
+            input_tokens INTEGER DEFAULT 0,
+            output_tokens INTEGER DEFAULT 0,
+            cache_tokens INTEGER DEFAULT 0,
+            request_count INTEGER DEFAULT 0,
+            models_used TEXT,
+            PRIMARY KEY (date, tool_name, host_name)
+        );
+        CREATE TABLE daily_messages (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            date TEXT,
+            tool_name TEXT,
+            host_name TEXT,
+            message_id TEXT,
+            role TEXT,
+            content TEXT,
+            tokens_used INTEGER DEFAULT 0,
+            input_tokens INTEGER DEFAULT 0,
+            output_tokens INTEGER DEFAULT 0,
+            model TEXT,
+            sender_id TEXT,
+            sender_name TEXT,
+            timestamp TEXT
+        );
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+@pytest.fixture()
+def fetch_mod(tmp_path, monkeypatch):
+    """Load fetch_zcode against a temp destination DB and seed a user."""
+    dest_db = tmp_path / "dest.sqlite"
+    _init_dest_schema(dest_db)
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{dest_db}")
+    mod = _load_fetch_zcode(f"sqlite:///{dest_db}")
+
+    # Seed a user whose system_account matches the default sender_name prefix.
+    conn = sqlite3.connect(str(dest_db))
+    conn.execute(
+        "INSERT INTO users (id, username, system_account, email) VALUES (?, ?, ?, ?)",
+        (1, "rhuang", "rhuang", "rhuang@localhost"),
+    )
+    conn.commit()
+    conn.close()
+    return mod
+
+
+# --------------------------------------------------------------------------- #
+# process_zcode_session — message dict shape
+# --------------------------------------------------------------------------- #
+
+
+def test_process_zcode_session_returns_messages_and_project(fetch_mod, tmp_path):
+    src_db = tmp_path / "zcode.sqlite"
+    _build_zcode_source_db(src_db)
+    sid = "sess_abc123"
+    conn = sqlite3.connect(str(src_db))
+    conn.execute(
+        "INSERT INTO session (id, directory, time_created, time_updated, time_archived, task_type, title) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (sid, "/Users/me/repo", 1700000000000, 1700000001000, None, "interactive", "test"),
+    )
+    conn.commit()
+    conn.close()
+    _insert_zcode_message(
+        src_db,
+        "msg_1",
+        sid,
+        1700000000100,
+        {"role": "user"},
+        parts=[{"type": "text", "text": "hello world"}],
+    )
+    _insert_zcode_message(
+        src_db,
+        "msg_2",
+        sid,
+        1700000000200,
+        {"role": "assistant", "modelID": "GLM-5.2", "tokens": {"input": 100, "output": 10}},
+        parts=[{"type": "text", "text": "hi there"}],
+    )
+
+    daily, messages, project = fetch_mod.process_zcode_session(sid, src_db, "localhost", None)
+
+    assert project == "/Users/me/repo"
+    assert len(messages) == 2
+    assert messages[0]["tool_name"] == "zcode"
+    assert messages[0]["role"] == "user"
+    assert messages[0]["content"] == "hello world"
+    assert messages[0]["agent_session_id"] == sid
+    assert messages[1]["role"] == "assistant"
+    assert messages[1]["input_tokens"] == 100
+    assert messages[1]["output_tokens"] == 10
+    assert messages[1]["tokens_used"] == 110
+    # daily aggregates
+    assert len(daily) == 1
+    only_date = next(iter(daily))
+    assert daily[only_date]["total_tokens"] == 110
+    assert daily[only_date]["request_count"] == 1
+
+
+def test_process_zcode_session_skips_empty(fetch_mod, tmp_path):
+    src_db = tmp_path / "zcode.sqlite"
+    _build_zcode_source_db(src_db)
+    sid = "sess_empty"
+    conn = sqlite3.connect(str(src_db))
+    conn.execute(
+        "INSERT INTO session (id, directory, time_created, time_updated, time_archived, task_type, title) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (sid, "/repo", 1700000000000, 1700000001000, None, "interactive", ""),
+    )
+    conn.commit()
+    conn.close()
+    # message with no text parts -> dropped by ZcodeSession
+    _insert_zcode_message(src_db, "msg_1", sid, 1700000000100, {"role": "user"}, parts=[])
+
+    daily, messages, project = fetch_mod.process_zcode_session(sid, src_db, "localhost", None)
+    assert messages == []
+    assert daily == {}
+
+
+# --------------------------------------------------------------------------- #
+# update_agent_sessions_stats — DB writes
+# --------------------------------------------------------------------------- #
+
+
+def test_update_agent_sessions_stats_inserts_session_and_messages(fetch_mod, tmp_path):
+    """A new session gets an agent_sessions row + session_messages rows."""
+    ts_iso = datetime.now(timezone.utc).isoformat()
+    messages = [
+        {
+            "date": "2026-06-20",
+            "tool_name": "zcode",
+            "host_name": "localhost",
+            "message_id": "m1",
+            "role": "user",
+            "content": "hello",
+            "content_blocks": None,
+            "tokens_used": 0,
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "model": None,
+            "timestamp": ts_iso,
+            "sender_name": "rhuang-host-zcode",
+            "agent_session_id": "sess_new1",
+            "project_path": "/repo",
+        },
+        {
+            "date": "2026-06-20",
+            "tool_name": "zcode",
+            "host_name": "localhost",
+            "message_id": "m2",
+            "role": "assistant",
+            "content": "hi there",
+            "content_blocks": None,
+            "tokens_used": 110,
+            "input_tokens": 100,
+            "output_tokens": 10,
+            "model": "GLM-5.2",
+            "timestamp": ts_iso,
+            "sender_name": "rhuang-host-zcode",
+            "agent_session_id": "sess_new1",
+            "project_path": "/repo",
+        },
+    ]
+
+    updated = fetch_mod.update_agent_sessions_stats(messages)
+    assert updated == 1
+
+    dest_db = tmp_path / "dest.sqlite"
+    conn = sqlite3.connect(str(dest_db))
+    conn.row_factory = sqlite3.Row
+    row = conn.execute(
+        "SELECT * FROM agent_sessions WHERE session_id = ?", ("sess_new1",)
+    ).fetchone()
+    assert row is not None
+    assert row["tool_name"] == "zcode"
+    assert row["session_type"] == "session"
+    assert row["status"] == "completed"
+    assert row["message_count"] == 2
+    assert row["request_count"] == 1
+    assert row["total_tokens"] == 110
+    assert row["model"] == "GLM-5.2"
+    assert row["project_path"] == "/repo"
+    # user_id resolved from sender_name prefix "rhuang"
+    assert row["user_id"] == 1
+
+    msg_rows = conn.execute(
+        "SELECT role FROM session_messages WHERE session_id = ? ORDER BY role", ("sess_new1",)
+    ).fetchall()
+    roles = {r["role"] for r in msg_rows}
+    assert roles == {"user", "assistant"}
+    conn.close()
+
+
+def test_update_agent_sessions_stats_idempotent(fetch_mod, tmp_path):
+    """Re-running on the same messages does not duplicate session_messages."""
+    ts_iso = datetime.now(timezone.utc).isoformat()
+    messages = [
+        {
+            "date": "2026-06-20",
+            "tool_name": "zcode",
+            "host_name": "localhost",
+            "message_id": "m1",
+            "role": "user",
+            "content": "q",
+            "content_blocks": None,
+            "tokens_used": 0,
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "model": None,
+            "timestamp": ts_iso,
+            "sender_name": "rhuang-host-zcode",
+            "agent_session_id": "sess_dup",
+            "project_path": "/repo",
+        },
+    ]
+    fetch_mod.update_agent_sessions_stats(messages)
+    fetch_mod.update_agent_sessions_stats(messages)
+
+    dest_db = tmp_path / "dest.sqlite"
+    conn = sqlite3.connect(str(dest_db))
+    count = conn.execute(
+        "SELECT COUNT(*) FROM session_messages WHERE session_id = ?", ("sess_dup",)
+    ).fetchone()[0]
+    conn.close()
+    assert count == 1
+
+
+# --------------------------------------------------------------------------- #
+# _iter_candidate_sessions — filtering
+# --------------------------------------------------------------------------- #
+
+
+def test_iter_candidate_sessions_filters_archived_and_noninteractive(fetch_mod, tmp_path):
+    src_db = tmp_path / "zcode.sqlite"
+    _build_zcode_source_db(src_db)
+    conn = sqlite3.connect(str(src_db))
+    now_ms = int(datetime.now(timezone.utc).timestamp() * 1000)
+    conn.executemany(
+        "INSERT INTO session (id, directory, time_created, time_updated, time_archived, task_type, title) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        [
+            ("sess_keep", "/a", now_ms, now_ms, None, "interactive", "t"),
+            ("sess_archived", "/b", now_ms, now_ms, now_ms, "interactive", "t"),
+            ("sess_subagent", "/c", now_ms, now_ms, None, "subagent_child", "t"),
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+    candidates = fetch_mod._iter_candidate_sessions(src_db, days=7, recent=False)
+    ids = {sid for sid, _ in candidates}
+    assert ids == {"sess_keep"}
+
+
+def test_iter_candidate_sessions_days_filter(fetch_mod, tmp_path):
+    src_db = tmp_path / "zcode.sqlite"
+    _build_zcode_source_db(src_db)
+    old_ms = int((datetime.now(timezone.utc).timestamp() - 30 * 86400) * 1000)
+    now_ms = int(datetime.now(timezone.utc).timestamp() * 1000)
+    conn = sqlite3.connect(str(src_db))
+    conn.executemany(
+        "INSERT INTO session (id, directory, time_created, time_updated, time_archived, task_type, title) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        [
+            ("sess_old", "/a", old_ms, old_ms, None, "interactive", "t"),
+            ("sess_recent", "/b", now_ms, now_ms, None, "interactive", "t"),
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+    candidates = fetch_mod._iter_candidate_sessions(src_db, days=7, recent=False)
+    ids = {sid for sid, _ in candidates}
+    assert ids == {"sess_recent"}

--- a/tests/unit/test_fetch_zcode.py
+++ b/tests/unit/test_fetch_zcode.py
@@ -287,6 +287,52 @@ def test_process_zcode_session_returns_messages_and_project(fetch_mod, tmp_path)
     assert daily[only_date]["request_count"] == 1
 
 
+def test_process_zcode_session_request_count_counts_assistant_messages(fetch_mod, tmp_path):
+    """Regression: request_count must count assistant messages, not distinct
+    dates. A single-day session with multiple assistant turns should report a
+    count > 1 (previously collapsed to 1 by counting distinct dates)."""
+    src_db = tmp_path / "zcode.sqlite"
+    _build_zcode_source_db(src_db)
+    sid = "sess_multi"
+    conn = sqlite3.connect(str(src_db))
+    conn.execute(
+        "INSERT INTO session (id, directory, time_created, time_updated, time_archived, task_type, title) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (sid, "/repo", 1700000000000, 1700000001000, None, "interactive", "t"),
+    )
+    conn.commit()
+    conn.close()
+    # user, assistant, user, assistant — 2 assistant turns, same day
+    _insert_zcode_message(
+        src_db, "m1", sid, 1700000000100, {"role": "user"}, parts=[{"type": "text", "text": "q1"}]
+    )
+    _insert_zcode_message(
+        src_db,
+        "m2",
+        sid,
+        1700000000200,
+        {"role": "assistant"},
+        parts=[{"type": "text", "text": "a1"}],
+    )
+    _insert_zcode_message(
+        src_db, "m3", sid, 1700000000300, {"role": "user"}, parts=[{"type": "text", "text": "q2"}]
+    )
+    _insert_zcode_message(
+        src_db,
+        "m4",
+        sid,
+        1700000000400,
+        {"role": "assistant"},
+        parts=[{"type": "text", "text": "a2"}],
+    )
+
+    daily, messages, _project = fetch_mod.process_zcode_session(sid, src_db, "localhost", None)
+
+    assert len(messages) == 4
+    only_date = next(iter(daily))
+    assert daily[only_date]["request_count"] == 2
+
+
 def test_process_zcode_session_skips_empty(fetch_mod, tmp_path):
     src_db = tmp_path / "zcode.sqlite"
     _build_zcode_source_db(src_db)


### PR DESCRIPTION
## Problem

Local ZCode app sessions (created directly in the ZCode desktop app, stored in `~/.zcode/cli/db/db.sqlite`) never appeared in the work-mode session list, even though claude / codex / qwen sessions did.

## Root cause

Two independent sync paths exist, and zcode was missing from the local one:

| Path | Mechanism | Triggered by | Covers zcode? |
|------|-----------|--------------|---------------|
| **A** | `remote-agent/session_sync.py` `SessionSyncService._scan_and_sync_zcode_db()` | only when the remote-agent daemon runs (`remote-agent/agent.py:208`) | code exists, but a local `python server.py` **never** starts the remote-agent |
| **B** | server `DataFetchScheduler` → `run_fetch_scripts()` → `scripts/fetch_*.py` | auto-started by `create_app()` (`app/__init__.py:103`), scans local disk every interval | **no `fetch_zcode.py`, not wired in** |

claude/codex/qwen are visible locally because of **Path B**. zcode was the only CLI without a server-side scanner, so its local sessions were never read.

## Fix

### 1. New `scripts/fetch_zcode.py` (mirrors `fetch_codex.py`)
- Reuses the `ZcodeSession` parser from `remote-agent/session_sync.py` (single source of truth, same pattern as fetch_codex reusing `codex_jsonl_parser`).
- Scans `~/.zcode/cli/db/db.sqlite` for `interactive`, non-archived sessions.
- Converts each parsed session into the fetch message-dict shape and writes to `daily_usage` / `daily_messages` / `agent_sessions` / `session_messages`, with `user_id` resolved from `sender_name` (matching claude/codex).

### 2. Wire into `app/routes/fetch.py:run_fetch_scripts()`
Added a `zcode` block after the codex block, so the existing scheduler syncs zcode sessions automatically every interval — no manual steps, no remote-agent required.

### 3. Display consistency fix
ZCode session ids carry a `sess_` prefix (`sess_2a277802-...`), so `SessionList.tsx`'s `slice(0,4)` showed `sess` for every zcode session.
- Added `displaySessionId()` in `frontend/src/utils/format.ts` to strip the prefix before slicing.
- Applied it across all 5 `slice` sites in `SessionList.tsx`.
- `fetch_zcode.py` also strips the prefix when building the default title (`zcode - 2a277802`) so it matches the frontend default-title pattern `^[a-z]+ - [a-f0-9]{8}$` and renders like claude/codex.
- The full `sess_` id is preserved in the DB (zcode's native format, keeps Path A/B consistent and allows future back-linking to the source session).

## Verification

Ran the fetcher against the live local DB:
- **71** interactive ZCode sessions synced → `agent_sessions` (`tool_name='zcode'`, `session_type='session'`, `status='completed'`), all correctly attributed to the logged-in user.
- **3509** messages → `session_messages` + `daily_messages`.
- **6** days of usage → `daily_usage`.

Session list now shows zcode sessions with the correct 4-char UUID prefix (`2a27` instead of `sess`).

### Tests
- `tests/unit/test_fetch_zcode.py`: 6 new unit tests (message conversion, DB writes, idempotency, day/type filtering) — ✅ pass
- `tests/unit/test_zcode_session_sync.py`: existing 15 tests — ✅ still pass
- `frontend/src/utils/format.test.ts`: 4 new `displaySessionId` tests (42 total) — ✅ pass
- ESLint clean, `tsc --noEmit` clean, ruff clean

## Notes
- `sudoers` entry intentionally omitted for zcode, matching codex's current state (codex also has no install.sh sudoers entry, only fetch.py wiring). Local dev uses `FETCH_USE_SUDO=false`. Production multi-user can be added later if needed.
- The pre-existing 34 `session_type='workflow'` autonomous zcode sessions are a separate issue (created by autonomous workflows with un-persisted messages) and out of scope here.