### PR TITLE
fix(autonomous): zcode workflow sessions show 0 messages in detail view

### DIFF
--- a/app/modules/workspace/autonomous/agent_runner.py
+++ b/app/modules/workspace/autonomous/agent_runner.py
@@ -1132,10 +1132,16 @@ class AutonomousAgentRunner:
                 raise ZCodeSessionError(zc_session.last_send_error or "ZCode session/send failed")
 
             completed = zc_session.wait_turn(timeout=timeout)
-        except ZCodeSessionError as e:
-            # session/create may have failed before _cli_session_id was known,
-            # in which case no wrapper row exists yet. Create one under whatever
-            # id we have so the failed session is still visible in the list.
+        except Exception as e:
+            # Catch ALL exceptions (not just ZCodeSessionError) so that any
+            # failure after session/create — including unexpected errors in
+            # send_message/wait_turn — takes this single error path and returns
+            # from here. This prevents a non-ZCodeSessionError from escaping to
+            # run_agent_task's outer except, which would create a SECOND row
+            # under the uuid (duplicate of the CLI-id row created above). The
+            # row-creation under err_sid below is idempotent, so if the CLI-id
+            # row already exists this is a harmless no-op.
+            logger.warning("ZCode app-server task failed: %s", e)
             err_sid = zc_session._cli_session_id or session_id
             self._create_workflow_session(
                 err_sid,

--- a/app/modules/workspace/autonomous/agent_runner.py
+++ b/app/modules/workspace/autonomous/agent_runner.py
@@ -653,6 +653,22 @@ class AutonomousAgentRunner:
 
         except Exception as e:
             logger.error("Agent task failed: %s", e)
+            # For tools that defer row creation (app-server tools), a failure
+            # before _run_zcode_appserver ran (e.g. adapter/executable not
+            # found) leaves no agent_sessions row. Create one under the uuid so
+            # the failed run stays visible. Claude (uses_sidebar_session) is
+            # excluded — its row is created under the CLI id inside _run_local,
+            # and pre-create tools already have their row from the block above.
+            # App-server tools only run locally, so guard on workspace_type too.
+            if creates_session_late and not uses_sidebar_session and workspace_type == "local":
+                self._create_workflow_session(
+                    session_id,
+                    workflow_id,
+                    cli_tool,
+                    user_id,
+                    project_path,
+                    workspace_type,
+                )
             return AgentTaskResult(
                 session_id="" if uses_sidebar_session else session_id,
                 tracking_session_id=session_id,
@@ -926,6 +942,36 @@ class AutonomousAgentRunner:
             event_log=session.event_log,
         )
 
+    def _create_workflow_session(
+        self,
+        sid: str,
+        workflow_id: str,
+        cli_tool: str,
+        user_id: int | None,
+        project_path: str,
+        workspace_type: str,
+    ) -> None:
+        """Create the agent_sessions wrapper row for an autonomous workflow run.
+
+        Centralizes the kwargs so the success, error, and pre-dispatch paths
+        can't silently diverge. create_session is idempotent.
+        """
+        if not self.session_manager or not sid:
+            return
+        try:
+            self.session_manager.create_session(
+                session_id=sid,
+                session_type="workflow",
+                title=f"Autonomous: {workflow_id[:8]}",
+                tool_name=cli_tool,
+                user_id=user_id,
+                project_path=project_path,
+                workspace_type=workspace_type,
+                context={"workflow_id": workflow_id},
+            )
+        except Exception as e:
+            logger.warning("Failed to create workflow session record: %s", e)
+
     def _run_zcode_appserver(
         self,
         session_id: str,
@@ -1073,20 +1119,14 @@ class AutonomousAgentRunner:
             # session-exists check pass during _persist_local_session_messages
             # and keeps milestone/session_messages keys aligned — mirroring
             # Claude's _ensure_sidebar_session. create_session is idempotent.
-            if self.session_manager and zc_session._cli_session_id:
-                try:
-                    self.session_manager.create_session(
-                        session_id=zc_session._cli_session_id,
-                        session_type="workflow",
-                        title=f"Autonomous: {workflow_id[:8]}",
-                        tool_name=cli_tool,
-                        user_id=user_id,
-                        project_path=project_path,
-                        workspace_type=workspace_type,
-                        context={"workflow_id": workflow_id},
-                    )
-                except Exception as e:
-                    logger.warning("Failed to create zcode session record: %s", e)
+            self._create_workflow_session(
+                zc_session._cli_session_id,
+                workflow_id,
+                cli_tool,
+                user_id,
+                project_path,
+                workspace_type,
+            )
 
             if not zc_session.send_message(prompt):
                 raise ZCodeSessionError(zc_session.last_send_error or "ZCode session/send failed")
@@ -1097,20 +1137,14 @@ class AutonomousAgentRunner:
             # in which case no wrapper row exists yet. Create one under whatever
             # id we have so the failed session is still visible in the list.
             err_sid = zc_session._cli_session_id or session_id
-            if self.session_manager and err_sid:
-                try:
-                    self.session_manager.create_session(
-                        session_id=err_sid,
-                        session_type="workflow",
-                        title=f"Autonomous: {workflow_id[:8]}",
-                        tool_name=cli_tool,
-                        user_id=user_id,
-                        project_path=project_path,
-                        workspace_type=workspace_type,
-                        context={"workflow_id": workflow_id},
-                    )
-                except Exception as ce:
-                    logger.warning("Failed to create zcode error session record: %s", ce)
+            self._create_workflow_session(
+                err_sid,
+                workflow_id,
+                cli_tool,
+                user_id,
+                project_path,
+                workspace_type,
+            )
             return AgentTaskResult(
                 session_id=err_sid,
                 tracking_session_id=session_id,

--- a/app/modules/workspace/autonomous/agent_runner.py
+++ b/app/modules/workspace/autonomous/agent_runner.py
@@ -554,9 +554,16 @@ class AutonomousAgentRunner:
         """
         session_id = session_id or str(uuid.uuid4())
         uses_sidebar_session = self._uses_sidebar_session_source(cli_tool, workspace_type)
+        # App-server tools (ZCode) resolve their real CLI session id only after
+        # session/create inside _run_zcode_appserver. The wrapper row must be
+        # keyed by that CLI id (not the uuid) so add_message's session-exists
+        # check passes and milestone/messages keys line up — same invariant
+        # _ensure_sidebar_session gives Claude. So skip the uuid-keyed pre-create
+        # here; _run_zcode_appserver creates the row under the real CLI id.
+        creates_session_late = uses_sidebar_session or cli_tool in _APPSERVER_TOOLS
 
-        # Create wrapper sessions only for tools without a native sidebar session source.
-        if self.session_manager and not uses_sidebar_session:
+        # Create wrapper sessions only for tools without a deferred session id.
+        if self.session_manager and not creates_session_late:
             try:
                 self.session_manager.create_session(
                     session_id=session_id,
@@ -1059,13 +1066,53 @@ class AutonomousAgentRunner:
             tracker.persisted_session_id = zc_session._cli_session_id
             tracker.sdk_initialized.set()
 
+            # Create the wrapper agent_sessions row under the REAL CLI session
+            # id (not the uuid). run_agent_task skips the pre-create for
+            # app-server tools because the CLI id is only known after
+            # session/create. Keying the row here by cli_sid makes add_message's
+            # session-exists check pass during _persist_local_session_messages
+            # and keeps milestone/session_messages keys aligned — mirroring
+            # Claude's _ensure_sidebar_session. create_session is idempotent.
+            if self.session_manager and zc_session._cli_session_id:
+                try:
+                    self.session_manager.create_session(
+                        session_id=zc_session._cli_session_id,
+                        session_type="workflow",
+                        title=f"Autonomous: {workflow_id[:8]}",
+                        tool_name=cli_tool,
+                        user_id=user_id,
+                        project_path=project_path,
+                        workspace_type=workspace_type,
+                        context={"workflow_id": workflow_id},
+                    )
+                except Exception as e:
+                    logger.warning("Failed to create zcode session record: %s", e)
+
             if not zc_session.send_message(prompt):
                 raise ZCodeSessionError(zc_session.last_send_error or "ZCode session/send failed")
 
             completed = zc_session.wait_turn(timeout=timeout)
         except ZCodeSessionError as e:
+            # session/create may have failed before _cli_session_id was known,
+            # in which case no wrapper row exists yet. Create one under whatever
+            # id we have so the failed session is still visible in the list.
+            err_sid = zc_session._cli_session_id or session_id
+            if self.session_manager and err_sid:
+                try:
+                    self.session_manager.create_session(
+                        session_id=err_sid,
+                        session_type="workflow",
+                        title=f"Autonomous: {workflow_id[:8]}",
+                        tool_name=cli_tool,
+                        user_id=user_id,
+                        project_path=project_path,
+                        workspace_type=workspace_type,
+                        context={"workflow_id": workflow_id},
+                    )
+                except Exception as ce:
+                    logger.warning("Failed to create zcode error session record: %s", ce)
             return AgentTaskResult(
-                session_id=zc_session._cli_session_id or session_id,
+                session_id=err_sid,
                 tracking_session_id=session_id,
                 success=False,
                 error=str(e),

--- a/tests/unit/test_zcode_workflow_session_persistence.py
+++ b/tests/unit/test_zcode_workflow_session_persistence.py
@@ -287,6 +287,64 @@ def test_run_agent_task_pre_dispatch_failure_creates_session(env, monkeypatch):
     assert row is not None, "pre-dispatch failure should still create a visible session row"
 
 
+def test_run_zcode_appserver_unexpected_error_no_duplicate_row(env, monkeypatch):
+    """Edge case: a non-ZCodeSessionError raised AFTER the CLI-id row is created
+    (e.g. unexpected error in wait_turn) must not escape to run_agent_task's
+    outer except and create a SECOND row under the uuid. The broadened inner
+    except catches it, reuses the err_sid (CLI id), and create_session's
+    idempotency means no duplicate."""
+    session_manager_mod = _load_session_manager()
+    runner, agent_runner_mod = _make_runner(session_manager_mod, env)
+
+    fake_process = MagicMock()
+    monkeypatch.setattr(agent_runner_mod.subprocess, "Popen", lambda *a, **k: fake_process)
+
+    fake_adapter = MagicMock()
+    fake_adapter.build_start_args.return_value = ["zcode", "--app-server"]
+    fake_adapter.supports_stdin_input.return_value = False
+
+    remote_agent_dir = str(_REPO_ROOT / "remote-agent")
+    if remote_agent_dir not in sys.path:
+        sys.path.insert(0, remote_agent_dir)
+    cli_adapters_mod = types.ModuleType("cli_adapters")
+    cli_adapters_mod.get_adapter = lambda name: fake_adapter
+    monkeypatch.setitem(sys.modules, "cli_adapters", cli_adapters_mod)
+
+    # wait_turn raises a generic error AFTER session/create + row creation.
+    class _UnexpectedErrorSession(_StubZCodeSession):
+        def wait_turn(self, timeout=None):
+            raise RuntimeError("unexpected SDK crash")
+
+    zcode_app_mod = types.ModuleType("zcode_app_server")
+    zcode_app_mod.ZCodeAppServerSession = _UnexpectedErrorSession
+    monkeypatch.setitem(sys.modules, "zcode_app_server", zcode_app_mod)
+
+    result = runner._run_zcode_appserver(
+        session_id="uuid-wrapper-id",
+        cli_tool="zcode",
+        model="GLM-5.2",
+        project_path="/tmp/repo",
+        prompt="do the thing",
+        permission_mode="yolo",
+        timeout=60,
+        workflow_id="wf_edge",
+        user_id=1,
+        workspace_type="local",
+    )
+
+    assert result.success is False
+    # Only ONE row should exist — the CLI-id row. No empty uuid duplicate.
+    conn = sqlite3.connect(str(env))
+    conn.row_factory = sqlite3.Row
+    rows = conn.execute(
+        "SELECT session_id FROM agent_sessions WHERE session_id IN (?, ?)",
+        ("sess_cli_abc123", "uuid-wrapper-id"),
+    ).fetchall()
+    conn.close()
+    assert len(rows) == 1, f"expected 1 row, got {[r['session_id'] for r in rows]}"
+    assert rows[0]["session_id"] == "sess_cli_abc123"
+
+
 # --------------------------------------------------------------------------- #
 # add_message succeeds when the row exists under the CLI id (the core invariant)
 # --------------------------------------------------------------------------- #

--- a/tests/unit/test_zcode_workflow_session_persistence.py
+++ b/tests/unit/test_zcode_workflow_session_persistence.py
@@ -243,6 +243,50 @@ def test_run_zcode_appserver_error_path_creates_session(env, monkeypatch):
     assert row is not None, "failed session should still be visible in the list"
 
 
+def test_run_agent_task_pre_dispatch_failure_creates_session(env, monkeypatch):
+    """Regression: a failure before _run_zcode_appserver dispatches (e.g.
+    adapter/executable resolution) must still leave a visible row. Previously,
+    skipping the uuid pre-create for app-server tools made such failures
+    invisible. The run_agent_task outer-except now creates the row under uuid."""
+    session_manager_mod = _load_session_manager()
+    runner, agent_runner_mod = _make_runner(session_manager_mod, env)
+
+    # Force _run_local to fail before dispatch: get_adapter raises.
+    remote_agent_dir = str(_REPO_ROOT / "remote-agent")
+    if remote_agent_dir not in sys.path:
+        sys.path.insert(0, remote_agent_dir)
+    cli_adapters_mod = types.ModuleType("cli_adapters")
+
+    def _boom(name):
+        raise RuntimeError("adapter not found")
+
+    cli_adapters_mod.get_adapter = _boom
+    monkeypatch.setitem(sys.modules, "cli_adapters", cli_adapters_mod)
+
+    result = runner.run_agent_task(
+        workflow_id="wf_pre",
+        cli_tool="zcode",
+        model="GLM-5.2",
+        project_path="/tmp/repo",
+        prompt="do the thing",
+        workspace_type="local",
+        permission_mode="yolo",
+        session_id="uuid-pre-dispatch",
+        user_id=1,
+    )
+
+    assert result.success is False
+    # The uuid row must exist so the failed run is visible in the session list.
+    conn = sqlite3.connect(str(env))
+    conn.row_factory = sqlite3.Row
+    row = conn.execute(
+        "SELECT session_id, status FROM agent_sessions WHERE session_id = ?",
+        ("uuid-pre-dispatch",),
+    ).fetchone()
+    conn.close()
+    assert row is not None, "pre-dispatch failure should still create a visible session row"
+
+
 # --------------------------------------------------------------------------- #
 # add_message succeeds when the row exists under the CLI id (the core invariant)
 # --------------------------------------------------------------------------- #

--- a/tests/unit/test_zcode_workflow_session_persistence.py
+++ b/tests/unit/test_zcode_workflow_session_persistence.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""Unit tests for zcode autonomous workflow session persistence.
+
+Verifies the fix for the bug where zcode workflow sessions had 0 messages in
+the detail view. Root cause: _run_zcode_appserver returned the CLI session id
+(sess_xxx) as result.session_id, but run_agent_task created the wrapper
+agent_sessions row under the uuid. add_message's session-exists check
+(session_manager.py:806-812) then silently dropped every message because no
+agent_sessions row existed under the CLI id.
+
+The fix: _run_zcode_appserver now creates the wrapper row under the real CLI
+id (mirroring Claude's _ensure_sidebar_session), so milestone/messages/row all
+share one id. These tests drive _run_zcode_appserver with a stubbed SDK and a
+real SessionManager against a temp SQLite DB and assert:
+
+  1. result.session_id is the CLI id (not the uuid),
+  2. create_session was called with the CLI id (row exists),
+  3. after _persist_local_session_messages, session_messages rows exist.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_agent_runner():
+    """Load the agent_runner module fresh (it has heavy imports done lazily)."""
+    if str(_REPO_ROOT) not in sys.path:
+        sys.path.insert(0, str(_REPO_ROOT))
+    import importlib
+
+    mod_path = _REPO_ROOT / "app" / "modules" / "workspace" / "autonomous" / "agent_runner.py"
+    spec = importlib.util.spec_from_file_location("agent_runner_under_test", mod_path)
+    mod = importlib.util.module_from_spec(spec)
+    # Register before exec so the module's dataclasses can resolve their own
+    # type hints via sys.modules during class construction.
+    sys.modules["agent_runner_under_test"] = mod
+    assert spec and spec.loader
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _load_session_manager():
+    import importlib
+
+    mod_path = _REPO_ROOT / "app" / "modules" / "workspace" / "session_manager.py"
+    spec = importlib.util.spec_from_file_location("session_manager_under_test", mod_path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["session_manager_under_test"] = mod
+    assert spec and spec.loader
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture()
+def env(tmp_path, monkeypatch):
+    """Point the DB at a temp SQLite file so no PostgreSQL/shared state is used."""
+    db_file = tmp_path / "test.sqlite"
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_file}")
+    # Create the authoritative schema (the inline _ensure_tables() is stale and
+    # misses columns like project_id, so load the real DDL instead).
+    schema_path = _REPO_ROOT / "schema" / "schema-sqlite.sql"
+    conn = sqlite3.connect(str(db_file))
+    if schema_path.exists():
+        conn.executescript(schema_path.read_text())
+    # session_messages.milestone_id is written by add_message but missing from
+    # schema-sqlite.sql (pre-existing drift). Add it so the real code path works.
+    try:
+        conn.execute("ALTER TABLE session_messages ADD COLUMN milestone_id text")
+    except sqlite3.OperationalError:
+        pass  # column already exists
+    conn.commit()
+    conn.close()
+    return db_file
+
+
+class _StubZCodeSession:
+    """Minimal stand-in for ZCodeAppServerSession.
+
+    Simulates a successful session/create → send → wait_turn cycle, emitting
+    one assistant text event so _persist_local_session_messages has an
+    event_log to write.
+    """
+
+    _cli_session_id = "sess_cli_abc123"
+    last_send_error = None
+
+    def __init__(self, **kwargs):
+        self.allowed_tools = []
+
+    def start(self, **kwargs):
+        return True
+
+    def send_message(self, prompt):
+        return True
+
+    def wait_turn(self, timeout=None):
+        return True
+
+    def stop(self):
+        pass
+
+
+def _make_runner(session_manager_mod, env):
+    """Build an AgentRunner with a real SessionManager over the temp DB."""
+    agent_runner_mod = _load_agent_runner()
+    sm = session_manager_mod.SessionManager(db_path=str(env))
+    return agent_runner_mod.AutonomousAgentRunner(session_manager=sm), agent_runner_mod
+
+
+# --------------------------------------------------------------------------- #
+# create_session is called under the CLI id
+# --------------------------------------------------------------------------- #
+
+
+def test_run_zcode_appserver_creates_session_under_cli_id(env, monkeypatch):
+    session_manager_mod = _load_session_manager()
+    runner, agent_runner_mod = _make_runner(session_manager_mod, env)
+
+    # Stub the SDK + adapter + subprocess so no real process is spawned.
+    fake_process = MagicMock()
+    monkeypatch.setattr(agent_runner_mod.subprocess, "Popen", lambda *a, **k: fake_process)
+
+    fake_adapter = MagicMock()
+    fake_adapter.build_start_args.return_value = ["zcode", "--app-server"]
+    fake_adapter.supports_stdin_input.return_value = False
+    monkeypatch.setitem(
+        sys.modules, "cli_adapters", types.SimpleNamespace(get_adapter=lambda name: fake_adapter)
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "zcode_app_server",
+        types.SimpleNamespace(ZCodeAppServerSession=_StubZCodeSession),
+    )
+
+    # Patch the lazy import targets inside _run_zcode_appserver: it does
+    # `from cli_adapters import get_adapter` and
+    # `from zcode_app_server import ZCodeAppServerSession` after putting
+    # remote-agent on sys.path. Pre-seed those modules.
+    import importlib
+
+    remote_agent_dir = str(_REPO_ROOT / "remote-agent")
+    if remote_agent_dir not in sys.path:
+        sys.path.insert(0, remote_agent_dir)
+
+    cli_adapters_mod = types.ModuleType("cli_adapters")
+    cli_adapters_mod.get_adapter = lambda name: fake_adapter
+    monkeypatch.setitem(sys.modules, "cli_adapters", cli_adapters_mod)
+
+    zcode_app_mod = types.ModuleType("zcode_app_server")
+    zcode_app_mod.ZCodeAppServerSession = _StubZCodeSession
+    monkeypatch.setitem(sys.modules, "zcode_app_server", zcode_app_mod)
+
+    result = runner._run_zcode_appserver(
+        session_id="uuid-wrapper-id",
+        cli_tool="zcode",
+        model="GLM-5.2",
+        project_path="/tmp/repo",
+        prompt="do the thing",
+        permission_mode="yolo",
+        timeout=60,
+        workflow_id="wf_001",
+        user_id=1,
+        workspace_type="local",
+    )
+
+    # result.session_id must be the CLI id, not the uuid.
+    assert result.session_id == "sess_cli_abc123"
+
+    # The wrapper row must exist under the CLI id (the invariant the bug broke).
+    conn = sqlite3.connect(str(env))
+    conn.row_factory = sqlite3.Row
+    row = conn.execute(
+        "SELECT session_id, tool_name, session_type FROM agent_sessions WHERE session_id = ?",
+        ("sess_cli_abc123",),
+    ).fetchone()
+    conn.close()
+    assert row is not None, "wrapper row missing under CLI id — add_message would drop messages"
+    assert row["tool_name"] == "zcode"
+    assert row["session_type"] == "workflow"
+
+
+def test_run_zcode_appserver_error_path_creates_session(env, monkeypatch):
+    """When session/create fails (no CLI id), the error session is still visible."""
+    session_manager_mod = _load_session_manager()
+    runner, agent_runner_mod = _make_runner(session_manager_mod, env)
+
+    fake_process = MagicMock()
+    monkeypatch.setattr(agent_runner_mod.subprocess, "Popen", lambda *a, **k: fake_process)
+
+    fake_adapter = MagicMock()
+    fake_adapter.build_start_args.return_value = ["zcode", "--app-server"]
+    fake_adapter.supports_stdin_input.return_value = False
+
+    remote_agent_dir = str(_REPO_ROOT / "remote-agent")
+    if remote_agent_dir not in sys.path:
+        sys.path.insert(0, remote_agent_dir)
+    cli_adapters_mod = types.ModuleType("cli_adapters")
+    cli_adapters_mod.get_adapter = lambda name: fake_adapter
+    monkeypatch.setitem(sys.modules, "cli_adapters", cli_adapters_mod)
+
+    # A session that fails to start → no _cli_session_id → falls back to uuid.
+    class _FailingSession(_StubZCodeSession):
+        _cli_session_id = ""
+
+        def start(self, **kwargs):
+            return False
+
+    zcode_app_mod = types.ModuleType("zcode_app_server")
+    zcode_app_mod.ZCodeAppServerSession = _FailingSession
+    monkeypatch.setitem(sys.modules, "zcode_app_server", zcode_app_mod)
+
+    result = runner._run_zcode_appserver(
+        session_id="uuid-wrapper-id",
+        cli_tool="zcode",
+        model="GLM-5.2",
+        project_path="/tmp/repo",
+        prompt="do the thing",
+        permission_mode="yolo",
+        timeout=60,
+        workflow_id="wf_002",
+        user_id=1,
+        workspace_type="local",
+    )
+
+    assert result.success is False
+    # Falls back to uuid when no CLI id; a row must still exist so it's visible.
+    assert result.session_id == "uuid-wrapper-id"
+    conn = sqlite3.connect(str(env))
+    row = conn.execute(
+        "SELECT session_id FROM agent_sessions WHERE session_id = ?", ("uuid-wrapper-id",)
+    ).fetchone()
+    conn.close()
+    assert row is not None, "failed session should still be visible in the list"
+
+
+# --------------------------------------------------------------------------- #
+# add_message succeeds when the row exists under the CLI id (the core invariant)
+# --------------------------------------------------------------------------- #
+
+
+def test_add_message_succeeds_when_row_exists_under_cli_id(env):
+    """Directly proves the proximate cause is fixed: create_session(cli_id) then
+    add_message(cli_id) now inserts a row (previously a silent no-op)."""
+    session_manager_mod = _load_session_manager()
+    sm = session_manager_mod.SessionManager(db_path=str(env))
+
+    cli_id = "sess_cli_xyz"
+    sm.create_session(
+        session_id=cli_id,
+        session_type="workflow",
+        title="Autonomous: wf",
+        tool_name="zcode",
+        user_id=1,
+    )
+    msg = sm.add_message(session_id=cli_id, role="assistant", content="hello from zcode")
+
+    assert msg is not None, "add_message returned None — no agent_sessions row under the CLI id"
+    conn = sqlite3.connect(str(env))
+    count = conn.execute(
+        "SELECT COUNT(*) FROM session_messages WHERE session_id = ?", (cli_id,)
+    ).fetchone()[0]
+    conn.close()
+    assert count == 1
+
+
+def test_add_message_is_noop_without_row(env):
+    """Guard test: the silent-drop behavior still exists when no row is present,
+    confirming the fix relies on creating the row (not changing add_message)."""
+    session_manager_mod = _load_session_manager()
+    sm = session_manager_mod.SessionManager(db_path=str(env))
+
+    msg = sm.add_message(session_id="sess_never_created", role="assistant", content="dropped")
+    assert msg is None


### PR DESCRIPTION
## Problem

zcode autonomous workflow sessions (created by `agent_runner._run_zcode_appserver`) appear in the session list but **show 0 messages** when opened — the detail view is empty. All 34 existing sessions are `message_count=0` with no `session_messages` rows, and 31 are stuck in `active` (never reached the status-update step).

## Root cause

Three different identifiers were in play for a zcode workflow run, and they didn't line up:

| Identity | Value |
|----------|-------|
| wrapper `agent_sessions.session_id` (created at `run_agent_task:561`) | **uuid** |
| `result.session_id` (`_run_zcode_appserver:1099`) | **CLI id `sess_xxx`** |
| `session_messages` write key (`persisted_session_id`) | **CLI id `sess_xxx`** |

`_persist_local_session_messages` called `add_message(session_id=sess_xxx, ...)`, but `add_message` (`session_manager.py:806-812`) does a pre-check:

```python
SELECT session_id FROM agent_sessions WHERE session_id = ?   -- sess_xxx
if not cursor.fetchone():
    return None   # ← silent no-op: no row under sess_xxx → zero messages written
```

Only the **uuid**-keyed wrapper row existed, so every `add_message` returned `None`. Messages weren't written under a wrong key — they weren't written at all.

### Why Claude works (reference)
Claude local runs use `_uses_sidebar_session_source=True`, and `_ensure_sidebar_session` (`agent_runner.py:404-416`) creates the `agent_sessions` row **under the real CLI id**. So wrapper row, milestone `session_id`, and `session_messages` key all share one id. zcode's `_APPSERVER_TOOLS` path had no equivalent step.

## Fix (option 3: single row keyed by the CLI id)

1. **`_run_zcode_appserver`** now creates the wrapper row under the real CLI id right after `session/create` succeeds (`agent_runner.py`), mirroring Claude's `_ensure_sidebar_session`. Since `result.session_id` is already the CLI id, milestone/persist/messages keys all align naturally.
2. **`run_agent_task`** skips the uuid-keyed pre-create for `_APPSERVER_TOOLS` (the CLI id is only known inside `_run_zcode_appserver`), via a new `creates_session_late` predicate alongside the existing `uses_sidebar_session` check.
3. **Error path**: when `session/create` fails (no CLI id), the row is created under the uuid so failed sessions stay visible.

`create_session` is idempotent (`session_manager.py:440-441`), so re-runs/resumes are safe.

## Tests

New `tests/unit/test_zcode_workflow_session_persistence.py` (4 tests):
- `test_run_zcode_appserver_creates_session_under_cli_id` — drives `_run_zcode_appserver` with a stubbed SDK + real SessionManager; asserts `result.session_id == cli_id` **and** the wrapper row exists under that id (the broken invariant).
- `test_run_zcode_appserver_error_path_creates_session` — failed `session/create` still creates a visible row (under uuid fallback).
- `test_add_message_succeeds_when_row_exists_under_cli_id` — directly proves the proximate cause: `create_session(cli_id)` → `add_message(cli_id)` now inserts (previously silent no-op).
- `test_add_message_is_noop_without_row` — guard test confirming the silent-drop behavior is unchanged (fix relies on creating the row, not altering `add_message`).

Regression: 119 existing tests pass (`-k "agent_runner or zcode or session or workflow"`), ruff + black clean.

## Out of scope
- The 34 pre-existing empty workflow sessions can't be backfilled (their messages were never written anywhere; the CLI app-server process is long gone). Only **new** runs after this fix get messages. Backfilling would require re-running the workflows.
- Separate from #1142 (that PR synced *local CLI* sessions `session_type='session'`; this fixes *autonomous workflow* sessions `session_type='workflow'`).