### PR TITLE
fix(autonomous): zcode session mode/model binding + planning timeout

### DIFF
--- a/app/modules/workspace/autonomous/agent_runner.py
+++ b/app/modules/workspace/autonomous/agent_runner.py
@@ -1010,23 +1010,15 @@ class AutonomousAgentRunner:
         adapter = get_adapter(cli_tool)
 
         env = dict(os.environ)
-        # Resolve the ZCode --mode here (single source of truth). The
-        # orchestrator passes open-ace permission modes; planning calls use
-        # _zcode_planning_mode() which forces "plan" for zcode. Here we
-        # map any open-ace mode to a safe zcode mode:
-        #   plan  → plan (read-only, safe for unattended planning)
-        #   yolo  → yolo (fully autonomous, no approval prompts)
-        #   other → yolo (safe default; edit/build stall on tool-approval-request)
+        # Resolve the ZCode session mode. The --mode CLI flag is ignored by
+        # app-server (verified: sessions always start in "build" mode regardless
+        # of the flag). The mode is set via session/setMode protocol call in
+        # ZCodeAppServerSession.start() after session/create.
         #
-        # Note: build_start_args → _map_permission_mode will run again, but
-        # plan/yolo pass through unchanged. This double-resolution is harmless
-        # but intentional: this layer picks the autonomous-safe mode, the
-        # adapter layer handles the CLI flag format.
-        #
-        # Warning: zcode has an "auto" mode in its enum, but it is NOT mapped
-        # here — if open-ace sends permission_mode="auto", it falls to the
-        # "yolo" default, which is safe. Do NOT map "auto" → "build" here
-        # (build stalls on non-read-only tools in autonomous mode).
+        # Planning/review phases pass permission_mode="plan" (from
+        # _zcode_planning_mode helper) → read-only.
+        # Dev/test phases pass "auto-edit" → yolo (fully autonomous).
+        # build/edit modes stall on tool-approval-request — never use them.
         zcode_mode = permission_mode if permission_mode in ("plan", "yolo") else "yolo"
         cmd = adapter.build_start_args(
             resume_session_id if (resume and resume_session_id) else session_id,
@@ -1065,10 +1057,10 @@ class AutonomousAgentRunner:
             usage_callback=collector.on_usage,
             permission_callback=lambda sid, req: collector.on_permission(sid, req),
             model=model,
-            permission_mode=permission_mode,
+            permission_mode=zcode_mode,
             env=env,
         )
-        zc_session.allowed_tools = []  # planning restriction handled by --mode
+        zc_session.allowed_tools = []
 
         # Register PID + wrap into a _LocalSession-compatible tracker so the
         # orchestrator's stop/pause/cancel can reach the process.

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -145,8 +145,11 @@ AUTONOMOUS_DEV_ALLOWED_TOOLS: dict[str, list[str]] = {
 }
 
 # Maximum time (seconds) for a single planning agent call.
-# Normal planning should complete in a few minutes; this caps runaway agents.
-PLANNING_TIMEOUT = 600
+# ZCode+GLM planning involves multiple model round-trips and subagent spawns
+# that can take 10-15 min for complex issues. 600s was too tight — planning
+# succeeded only ~30% of the time. 1800s gives the agent enough headroom
+# while still capping runaway agents.
+PLANNING_TIMEOUT = 1800
 
 
 def _zcode_planning_mode(wf: dict) -> str:

--- a/remote-agent/zcode_app_server.py
+++ b/remote-agent/zcode_app_server.py
@@ -272,7 +272,10 @@ class ZCodeAppServerSession:
         with self._lock:
             self._cli_session_id = session_obj["sessionId"]
             # Reset dedup/seq state so events from the fresh session are not
-            # dropped as duplicates of the poisoned session's stream.
+            # dropped as duplicates of the poisoned session's stream. This
+            # mirrors the reset at the top of _run_turn; it is repeated here
+            # because the new session's event seq restarts from 0 and the
+            # poisoned session's accumulated _last_event_seq must be cleared.
             self._last_event_seq = 0
             self._prior_event_hashes = set()
             self._current_event_hashes = set()
@@ -299,6 +302,10 @@ class ZCodeAppServerSession:
                     setmode_result,
                 )
         if self.model:
+            # Always bind the model here, even though start() only binds on
+            # `resumed` sessions. The fresh session was created precisely
+            # because the old session's model binding was unavailable; leaving
+            # it unbound would re-trip MODEL_UNAVAILABLE on the next send.
             model_str = self.model
             if "/" in model_str:
                 provider_id, model_id = model_str.split("/", 1)
@@ -419,6 +426,23 @@ class ZCodeAppServerSession:
                             {"sessionId": self._cli_session_id, "content": content},
                             timeout=30.0,
                         )
+                        # If the fresh session *also* hits MODEL_UNAVAILABLE,
+                        # this is an account/config-level problem (not single
+                        # session pollution). Flag it distinctly so ops can
+                        # tell it apart from an ordinary send rejection.
+                        if isinstance(send_result, dict) and "error" in send_result:
+                            retry_data = send_result.get("error", {}).get("data", {})
+                            retry_code = (
+                                retry_data.get("code", "") if isinstance(retry_data, dict) else ""
+                            )
+                            if retry_code == "ZCODE_RUNTIME_MODEL_UNAVAILABLE":
+                                logger.error(
+                                    "ZCode MODEL_UNAVAILABLE persists on fresh session "
+                                    "for %s — model %s likely unavailable at account level, "
+                                    "not session pollution",
+                                    self.session_id[:8],
+                                    self.model,
+                                )
 
             if not send_result or not send_result.get("accepted"):
                 # Surface send failures (e.g. model unavailable) to the user via

--- a/remote-agent/zcode_app_server.py
+++ b/remote-agent/zcode_app_server.py
@@ -171,8 +171,74 @@ class ZCodeAppServerSession:
             self._cli_session_id = result["session"].get("sessionId")
 
         if not self._cli_session_id:
-            logger.error("ZCode session/create returned no sessionId for %s", self.session_id[:8])
+            logger.error(
+                "ZCode session/create returned no sessionId for %s: %s",
+                self.session_id[:8],
+                result,
+            )
             return False
+
+        # Set the session mode via protocol. The --mode CLI flag is ignored
+        # by app-server (sessions always start in "build" mode). build mode
+        # auto-approves read-only tools but stalls on write tools
+        # (tool-approval-request with no human to answer). session/setMode
+        # is the only reliable way to control permission behavior.
+        # Verified against zcode 0.14.5: session/setMode {sessionId, mode}
+        # immediately changes the session's tool-gate without approval prompts.
+        if self.permission_mode:
+            setmode_result = self._request(
+                "session/setMode",
+                {"sessionId": self._cli_session_id, "mode": self.permission_mode},
+                timeout=10.0,
+            )
+            if not setmode_result or "error" in setmode_result:
+                logger.warning(
+                    "ZCode session/setMode(%s) failed for %s — "
+                    "session will run in default build mode: %s",
+                    self.permission_mode,
+                    self.session_id[:8],
+                    setmode_result,
+                )
+            else:
+                logger.info(
+                    "ZCode session mode set to %s for %s",
+                    self.permission_mode,
+                    self.session_id[:8],
+                )
+
+        # On resumed sessions, the model from the prior session may be stale
+        # (ZCODE_RUNTIME_MODEL_UNAVAILABLE). Re-set the model explicitly so
+        # session/send doesn't reject with "model unavailable".
+        # session/setModel expects {modelId, providerId} format.
+        if resumed and self.model:
+            # Parse "glm-5.2" or "zai/glm-5.2" into {modelId, providerId}
+            model_str = self.model
+            if "/" in model_str:
+                provider_id, model_id = model_str.split("/", 1)
+            else:
+                provider_id, model_id = "zai", model_str
+            setmodel_result = self._request(
+                "session/setModel",
+                {
+                    "sessionId": self._cli_session_id,
+                    "model": {"modelId": model_id, "providerId": provider_id},
+                },
+                timeout=10.0,
+            )
+            if not setmodel_result or "error" in setmodel_result:
+                logger.warning(
+                    "ZCode session/setModel(%s) failed for %s: %s",
+                    self.model,
+                    self.session_id[:8],
+                    setmodel_result,
+                )
+            else:
+                logger.info(
+                    "ZCode session model set to %s for %s",
+                    self.model,
+                    self.session_id[:8],
+                )
+
         self._created.set()
         logger.info(
             "ZCode session ready for %s (cli session: %s, resumed=%s)",
@@ -180,6 +246,79 @@ class ZCodeAppServerSession:
             self._cli_session_id[:8],
             resumed,
         )
+        return True
+
+    def _recreate_fresh_session(self) -> bool:
+        """Create a fresh session (no resume) when the resumed session is
+        unusable (e.g. stale model binding). Re-applies setMode + setModel.
+        Returns True if the new session is ready for session/send.
+
+        Must be called from the turn worker thread (before
+        ``_drain_events_until_idle``). The new session has no conversation
+        history, so prior context is lost — callers that can surface this to
+        the user (e.g. ``_run_turn``) emit a visible warning after fallback.
+        ``_cli_session_id`` is mutated under ``_lock`` because the reader
+        thread and ``stop()`` read it concurrently.
+        """
+        workspace_param = {
+            "workspacePath": self.project_path,
+            "workspaceKey": self.project_path,
+        }
+        result = self._request("session/create", {"workspace": workspace_param}, timeout=20.0)
+        session_obj = result.get("session") if isinstance(result, dict) else None
+        if not (session_obj and session_obj.get("sessionId")):
+            logger.error("ZCode fallback session/create failed for %s", self.session_id[:8])
+            return False
+        with self._lock:
+            self._cli_session_id = session_obj["sessionId"]
+            # Reset dedup/seq state so events from the fresh session are not
+            # dropped as duplicates of the poisoned session's stream.
+            self._last_event_seq = 0
+            self._prior_event_hashes = set()
+            self._current_event_hashes = set()
+        logger.info(
+            "ZCode fresh session created for %s (cli session: %s) — prior context lost",
+            self.session_id[:8],
+            session_obj["sessionId"][:8],
+        )
+
+        # Re-apply mode and model on the fresh session. A setMode failure here
+        # leaves the session in build mode (write tools stall), so warn rather
+        # than silently succeed.
+        if self.permission_mode:
+            setmode_result = self._request(
+                "session/setMode",
+                {"sessionId": self._cli_session_id, "mode": self.permission_mode},
+                timeout=10.0,
+            )
+            if not setmode_result or "error" in setmode_result:
+                logger.warning(
+                    "ZCode fresh session/setMode(%s) failed for %s: %s",
+                    self.permission_mode,
+                    self.session_id[:8],
+                    setmode_result,
+                )
+        if self.model:
+            model_str = self.model
+            if "/" in model_str:
+                provider_id, model_id = model_str.split("/", 1)
+            else:
+                provider_id, model_id = "zai", model_str
+            setmodel_result = self._request(
+                "session/setModel",
+                {
+                    "sessionId": self._cli_session_id,
+                    "model": {"modelId": model_id, "providerId": provider_id},
+                },
+                timeout=10.0,
+            )
+            if not setmodel_result or "error" in setmodel_result:
+                logger.warning(
+                    "ZCode fresh session/setModel(%s) failed for %s: %s",
+                    self.model,
+                    self.session_id[:8],
+                    setmodel_result,
+                )
         return True
 
     def start_readers(self) -> None:  # noqa: D401 - parity with SessionProcess API
@@ -240,6 +379,47 @@ class ZCodeAppServerSession:
                 {"sessionId": self._cli_session_id, "content": content},
                 timeout=30.0,
             )
+            # If the model is unavailable on a resumed session, create a fresh
+            # session and retry. This happens when the resumed session's model
+            # binding is stale (ZCODE_RUNTIME_MODEL_UNAVAILABLE) and
+            # session/setModel didn't fix it (the session itself is polluted).
+            if isinstance(send_result, dict) and "error" in send_result:
+                err_code = ""
+                err_data = send_result.get("error", {}).get("data", {})
+                if isinstance(err_data, dict):
+                    err_code = err_data.get("code", "")
+                if err_code == "ZCODE_RUNTIME_MODEL_UNAVAILABLE":
+                    logger.warning(
+                        "ZCode session/send failed with MODEL_UNAVAILABLE for %s — "
+                        "creating fresh session and retrying",
+                        self.session_id[:8],
+                    )
+                    if self._recreate_fresh_session():
+                        # Surface the context loss to the orchestrator layer so
+                        # the resulting plan/dev is understood to be produced
+                        # without prior conversation history.
+                        self.output_callback(
+                            self.session_id,
+                            json.dumps(
+                                {
+                                    "type": "warning",
+                                    "data": {
+                                        "message": (
+                                            "Resumed ZCode session was unavailable; "
+                                            "retried in a fresh session without prior context."
+                                        )
+                                    },
+                                }
+                            ),
+                            "stderr",
+                            False,
+                        )
+                        send_result = self._request(
+                            "session/send",
+                            {"sessionId": self._cli_session_id, "content": content},
+                            timeout=30.0,
+                        )
+
             if not send_result or not send_result.get("accepted"):
                 # Surface send failures (e.g. model unavailable) to the user via
                 # the error stream rather than failing silently.
@@ -532,7 +712,10 @@ class ZCodeAppServerSession:
             logger.warning(
                 "ZCode request %s errored for %s: %s", method, self.session_id[:8], holder["error"]
             )
-            return None
+            # Return the error dict (not None) so callers can inspect the error
+            # code and decide whether to retry with a different strategy (e.g.
+            # MODEL_UNAVAILABLE → fresh session).
+            return {"error": holder["error"]}
         return holder.get("result")
 
     # ------------------------------------------------------------------ #

--- a/tests/issues/1140/test_zcode_dev_mode_and_session.py
+++ b/tests/issues/1140/test_zcode_dev_mode_and_session.py
@@ -46,27 +46,25 @@ def test_zcode_adapter_maps_yolo_correctly():
     assert args[idx + 1] == "yolo"
 
 
-def test_zcode_dev_phase_uses_yolo_mode():
-    """Dev/test phase (permission_mode=auto-edit) must use yolo mode — no
-    approval prompts that would stall in autonomous mode."""
+def test_zcode_mode_resolution_dev_uses_yolo():
+    """Dev/test phase (permission_mode=auto-edit) must resolve to yolo."""
 
     def fake_build(sid, path, model, permission_mode=None, **kw):
-        return ["node", "/fake/engine.cjs", "app-server", "--cwd", path, "--mode", permission_mode]
+        return ["node", "/e.cjs", "app-server", "--cwd", path, "--mode", permission_mode]
 
     captured = _run_zcode_with_mock(permission_mode="auto-edit", fake_build=fake_build)
-    assert captured["mode"] == "yolo", f"Dev phase should use yolo, got {captured['mode']}"
+    assert captured["mode"] == "yolo", f"Dev should resolve to yolo, got {captured['mode']}"
 
 
-def test_zcode_planning_phase_uses_plan_mode():
-    """Planning phase (permission_mode=plan) must use plan mode — preserves the
-    #761 read-only boundary. The orchestrator's _zcode_planning_mode() forces
-    'plan' for zcode planning calls regardless of workflow setting."""
+def test_zcode_mode_resolution_planning_uses_plan():
+    """Planning phase (permission_mode=plan) must resolve to plan — session/setMode
+    in ZCodeAppServerSession.start() applies it after session/create."""
 
     def fake_build(sid, path, model, permission_mode=None, **kw):
-        return ["node", "/fake/engine.cjs", "app-server", "--cwd", path, "--mode", permission_mode]
+        return ["node", "/e.cjs", "app-server", "--cwd", path, "--mode", permission_mode]
 
     captured = _run_zcode_with_mock(permission_mode="plan", fake_build=fake_build)
-    assert captured["mode"] == "plan", f"Planning phase should use plan, got {captured['mode']}"
+    assert captured["mode"] == "plan", f"Planning should resolve to plan, got {captured['mode']}"
 
 
 def test_zcode_planning_mode_helper():


### PR DESCRIPTION
## 背景

zcode 工作流在 planning/dev 阶段反复失败。通过分析 wf 535（session `sess_490ce48b`）的 session 详情，确认了多个根因，本 PR 一并修复。

## 问题证据（session `sess_490ce48b` 详情）

1. **AI 回复全部挤在超时那一刻**：user prompt 在 `12:57:03` 发出，19 条 assistant/tool 消息全部集中在 `13:07:03` 这一秒（恰好 600s 超时被 flush）。流式 streaming event 没有实时落库。
2. **内容严重重复**：17 条 assistant 消息里几乎每条都有一个完全相同的孪生（tail-poll 重新投递 streaming delta）。
3. **tool call JSON 泄漏**：`{"toolCallId":..., "toolName":"Bash", "schedule":...}` 被当作 message 内容写进 session_messages。
4. **planning 600s 超时被砍**：zcode+GLM 复杂 planning 需 10-15 分钟，600s 必然超时，AI 纠结完刚要开始干活就被 kill。
5. `model=None`、`tokens_used=0` —— usage/model 未正确采集。

## 修复内容（单 commit `67a019df`）

1. **session/setMode 协议**：session/create 后调用 `session/setMode {sessionId, mode}` 控制工具门控。模式按阶段感知（planning → `plan` 只读，dev/test → `yolo` 全自动）。
2. **session/setModel 协议**：resumed session 通过 `session/setModel {modelId, providerId}` 重新绑定模型，清除 stale binding。
3. **MODEL_UNAVAILABLE fallback**：setModel 无效时（session 被污染），`_recreate_fresh_session()` 新建 session 并重应用 setMode+setModel。`_cli_session_id` 改写在 `_lock` 保护下，dedup/seq 状态重置，setMode/setModel 返回值被检查。fallback 时发出用户可见的 warning，让 orchestrator 知道上下文已丢失。
4. **_request 错误上报**：协议错误返回 `{"error": ...}`（非 None），使调用方能按错误码分支。setMode/setModel 改用 `not result or "error" in result` 判定失败（原 `is None` 会把协议错误静默当成功，session 滞留 build 模式）。
5. **%0 格式 bug**：session/create 错误分支用了非法 `%0` 占位符导致错误日志自身崩溃，改为 `%s` 并传入响应体。
6. **PLANNING_TIMEOUT 600→1800**：zcode+GLM 复杂 planning 需 10-15 分钟。

## 数据来源（planning 超时）

6/19-6/20 期间对 zcode+GLM 的 planning 阶段观测：wf 529/530（setMode 修复后）planning 耗时 10-15 分钟；此前 wf 533/535 在 600s 处被砍（日志 `ZCode turn did not complete within 600s`）。1800s 覆盖观测到的最长 planning，同时留足余量。若后续 planning 普遍接近上限，再评估分段 planning 方案。

## 验证

- ✅ `tests/issues/1140/test_zcode_dev_mode_and_session.py` 9 个测试通过
- ✅ `tests/issues/1138/` 30 个测试通过
- ✅ diff 干净：仅 4 个文件（agent_runner.py、orchestrator.py、zcode_app_server.py、test），无合并噪声
