### PR TITLE
fix(zcode): filter tool.updated lifecycle events + propagate turn timeout

### DIFF
--- a/app/modules/workspace/autonomous/agent_runner.py
+++ b/app/modules/workspace/autonomous/agent_runner.py
@@ -229,6 +229,18 @@ class _ZcodeResultCollector:
         elif msg_type.startswith("tool."):
             tool_name = msg_type.split(".", 1)[1]
             payload = parsed.get("data", {}) or {}
+            # ZCode sends tool.updated lifecycle notifications (kind =
+            # scheduled/started/result/batch) that carry only scheduling
+            # metadata, not real tool input/output. These would leak as
+            # tool_name="updated" garbage messages, so skip them. Real
+            # tool_use events have no "kind" field and carry actual input.
+            if isinstance(payload, dict) and payload.get("kind") in (
+                "scheduled",
+                "started",
+                "result",
+                "batch",
+            ):
+                return
             tool_input = payload.get("input", payload)
             tool_id = payload.get("id", "")
             self.tool_calls.append(
@@ -1120,7 +1132,7 @@ class AutonomousAgentRunner:
                 workspace_type,
             )
 
-            if not zc_session.send_message(prompt):
+            if not zc_session.send_message(prompt, timeout=timeout):
                 raise ZCodeSessionError(zc_session.last_send_error or "ZCode session/send failed")
 
             completed = zc_session.wait_turn(timeout=timeout)

--- a/remote-agent/zcode_app_server.py
+++ b/remote-agent/zcode_app_server.py
@@ -103,6 +103,9 @@ class ZCodeAppServerSession:
         # Set = no turn in progress (idle); cleared while a turn runs.
         self._turn_done = threading.Event()
         self._turn_done.set()
+        # Wall-clock budget for draining events in a single turn. Set by
+        # send_message from the caller's timeout; defaults to _TURN_TIMEOUT.
+        self._turn_timeout: float = _TURN_TIMEOUT
         self._worker: threading.Thread | None = None
         self.last_send_error: str | None = None
 
@@ -339,7 +342,7 @@ class ZCodeAppServerSession:
     # Sending a user turn
     # ------------------------------------------------------------------ #
 
-    def send_message(self, content: str) -> bool:
+    def send_message(self, content: str, timeout: float = _TURN_TIMEOUT) -> bool:
         """Send a user message and return immediately (non-blocking).
 
         ``session/send`` is asynchronous. We dispatch it on a dedicated worker
@@ -347,6 +350,10 @@ class ZCodeAppServerSession:
         blocked - heartbeats and other commands (stop/pause/permission) keep
         flowing while the turn runs. The worker streams assistant events through
         the existing callbacks and signals completion via ``_turn_done``.
+
+        *timeout* is the wall-clock budget for the worker to drain events from
+        this turn (passed through to ``_run_turn``). It should match the
+        ``wait_turn`` timeout so the worker does not give up before the caller.
         """
         if not self._cli_session_id or not self.is_running:
             self.last_send_error = "ZCode session is not active"
@@ -360,6 +367,7 @@ class ZCodeAppServerSession:
 
         self.last_send_error = None
         self._turn_done.clear()
+        self._turn_timeout = timeout
         self._worker = threading.Thread(
             target=self._run_turn,
             args=(content,),
@@ -463,7 +471,7 @@ class ZCodeAppServerSession:
                     False,
                 )
                 return
-            self._drain_events_until_idle(_TURN_TIMEOUT)
+            self._drain_events_until_idle(self._turn_timeout)
             self._report_usage()
         except Exception:  # noqa: BLE001
             logger.exception("ZCode turn failed for %s", self.session_id[:8])


### PR DESCRIPTION
## 背景

工作流 536（#830）验证 PR #1145 时发现两个新问题，本 PR 修复。

## 问题 1：tool.updated 生命周期事件泄漏为垃圾消息 🔴

**证据**：session `sess_9b81c2f6`（wf 536 planning）的 77 条 tool 消息**全部是垃圾**——`tool_name="updated"`，内容是调度元数据：

```json
{"toolCallId":"call_...", "toolName":"Agent", "kind":"scheduled", "schedule":{"parallelGroups":[...]}}
```

kind 分布全是生命周期噪音：`scheduled`(21) / `started`(19) / `result`(19) / `batch`(18)。真正的 tool_use（工具名、输入、输出）全部丢失。

**根因**：ZCode 发出 `tool.updated` 事件（工具调度生命周期通知）。`on_output` 的 `msg_type.startswith("tool.")` 匹配到它，把 `"updated"` 当成工具名，整个调度 JSON 当 `tool_input` 落库。`_looks_like_tool_json()`（PR #1145）只过滤了 assistant text 路径，没覆盖 `tool.*` 分支。

**修复**：在 `on_output` 的 `tool.*` 分支，跳过 payload 里 `kind` 为 `scheduled`/`started`/`result`/`batch` 的生命周期事件。真正的 tool_use 没有 `kind` 字段、带实质 input，不受影响。

## 问题 2：_TURN_TIMEOUT 硬编码 600s 砍掉 dev/tests turn 🔴

**证据**：wf 536 dev 阶段，fork 后的 session（b420f9a3）在 22:32:17 ready 后，到 22:42 之间没有任何完成日志，agent 最终死亡。日志确认 `ZCode turn did not complete within 600s`。

**根因**：`_run_turn` 内部调用 `_drain_events_until_idle(_TURN_TIMEOUT)`，用模块级硬编码的 600s。而 `wait_turn(timeout=...)` 接收的是 dev 的 1 小时 task timeout。两者脱节——无论外部给多少时间，单个 turn 内的事件 drain 固定 600s 就砍。

PR #1145 只改了 `PLANNING_TIMEOUT`（orchestrator 层，1800s），但 zcode_app_server 内部的 `_TURN_TIMEOUT`（单 turn drain 超时）没改。

**修复**：
- `send_message(content, timeout)` 接收 timeout 参数，存到 `self._turn_timeout`
- `_run_turn` 用 `self._turn_timeout` 替代硬编码 `_TURN_TIMEOUT`
- `agent_runner.py` 的 dev 路径传 `send_message(prompt, timeout=timeout)`

## 验证

- ✅ tool 泄漏：生命周期事件被跳过（tool_calls=0），真实 tool_use 被保留（tool_calls=1, name=Bash）
- ✅ 39 个测试（1140 + 1138）全部通过
