### PR TITLE
fix(autonomous): fork pause_original must stop the running agent

### DIFF
--- a/app/routes/autonomous.py
+++ b/app/routes/autonomous.py
@@ -1031,6 +1031,12 @@ def fork_milestone(workflow_id, milestone_id):
 
     # Optionally pause the original workflow
     if pause_original:
+        # Suspend the running agent subprocess (SIGSTOP) BEFORE flipping the
+        # DB status. Without this the orchestrator thread currently inside
+        # _run_agent() keeps running — advance() only checks status at entry,
+        # not mid-phase — so the "paused" workflow would continue dev→test→PR
+        # to completion despite being forked. Mirrors pause_workflow()'s order.
+        _pause_running_task(workflow_id)
         _get_repo().update_workflow(
             workflow_id,
             {


### PR DESCRIPTION
## Bug

`fork_milestone` 的 `pause_original=True` 只更新了 DB status=`paused`，**没有调用 `_pause_running_task()` 停止正在运行的 agent 进程**。

## 影响

orchestrator 的 `advance()` 只在入口检查 `status in ("paused", ...)`，一旦进入某个 phase 就不再检查。fork 时 orchestrator 线程正阻塞在 `_run_agent()` 里，改 DB status 无法中断它。结果：

- 原始工作流（如 wf 536）被 fork 后**继续跑完** dev→test→PR，与 fork（wf 537）并行竞争
- 用户明确设置了 `pause_original`，但原工作流完全没停

## 证据

wf 536 在 22:30 被 fork（status→paused），但 22:32-22:47 继续执行了 dev→tests→pr_created→pr_review，创建了 PR #1146。fork 出的 537 同时在 planning。

## 修复

在 `fork_milestone` 的 `pause_original` 分支，改 DB status 前先调 `_pause_running_task(workflow_id)`（SIGSTOP agent），与 `pause_workflow` 的顺序一致：

```python
if pause_original:
    _pause_running_task(workflow_id)   # ← 新增
    _get_repo().update_workflow(workflow_id, {"status": "paused", ...})
```

## 验证

- ✅ 39 个测试全部通过
- ✅ 语法检查通过
