### PR TITLE
fix(zcode): auto-allow interaction/requestPermission in unattended mode

### DIFF
--- a/remote-agent/zcode_app_server.py
+++ b/remote-agent/zcode_app_server.py
@@ -804,6 +804,22 @@ class ZCodeAppServerSession:
                 },
             )
             return
+        if method == "interaction/requestPermission":
+            # A tool call needs permission approval. In unattended mode there
+            # is no human to approve/deny — auto-allow so the agent can proceed.
+            # plan mode already restricts the tool set to read-only tools; if a
+            # permission request still fires (e.g. reading outside cwd), the
+            # safest option for an autonomous workflow is to allow it rather
+            # than stall the turn indefinitely.
+            tool_name = params.get("toolName", "?")
+            logger.info(
+                "ZCode interaction/requestPermission auto-allowed for %s "
+                "(tool=%s, unattended workflow)",
+                self.session_id[:8],
+                tool_name,
+            )
+            self._send_response(msg_id, {"decision": "allow"})
+            return
         # Unknown server request: respond with a generic error so it doesn't
         # hang forever.
         logger.warning("ZCode unhandled server request %s for %s", method, self.session_id[:8])


### PR DESCRIPTION
## 问题

PR #1152 修复了 `interaction/requestUserInput`（AskUserQuestion），但漏了 `interaction/requestPermission`。

wf 540 planning 阶段：AI 调用需要权限的工具 → `requestPermission` server→client request → 无 handler → 落入 generic -32601 error → app-server 阻塞 → `session/events` poll 超时 → drain 循环 break → turn 只跑了 270s（而非 1800s budget）就报 "did not complete"。

## 修复

`_handle_server_request` 新增 `interaction/requestPermission` 分支，auto-allow（`{decision: "allow"}`）。

plan mode 已限制工具集为只读；permission request 触发是边缘情况，allow 比 stall 更安全。

39 个测试通过。
