### PR TITLE
fix(zcode): runtimeModel provider kind must match config (anthropic)

### DIFF
--- a/remote-agent/zcode_app_server.py
+++ b/remote-agent/zcode_app_server.py
@@ -160,8 +160,7 @@ class ZCodeAppServerSession:
             "model": {"providerId": provider_id, "modelId": model_id},
             "provider": {
                 "providerId": provider_id,
-                "kind": "openai-compatible",
-                "apiFormat": "anthropic-messages",
+                "kind": "anthropic",
                 "source": "builtin",
                 "baseURL": base_url,
                 "models": [{"modelId": model_id}],


### PR DESCRIPTION
## 问题

PR #1151 的 `_build_runtime_model` 用了 `kind: "openai-compatible"` + `apiFormat: "anthropic-messages"`，但 `~/.zcode/cli/config.json` 里 zai 的 kind 是 `"anthropic"`。

这个不匹配导致 zcode 对 resumed session 用 OpenAI 兼容格式发请求（而非 anthropic native），zai API 返回 `404 NOT_FOUND`。

**证据**（wf 540）：
- planning（用 config.json provider，kind=anthropic）→ 成功
- dev（用 runtimeModel provider，kind=openai-compatible）→ 第一次 model 调用就 404

## 修复

runtimeModel 的 provider kind 改为 `"anthropic"`（和 config.json 一致），去掉 `apiFormat`（anthropic kind 默认就是 anthropic-messages）。

39 个测试通过。
