### PR TITLE
fix(autonomous): sync in-memory wf dict after session line update

### DIFF
--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -958,6 +958,10 @@ class AutonomousOrchestrator:
             field = SESSION_LINE_FIELDS.get(session_line)
             if field:
                 self._update_workflow({field: result.session_id})
+                # Keep the in-memory wf dict in sync so the next _resolve_session_line
+                # call in the same phase (e.g. planning → finalize) sees the updated
+                # session id and resumes it instead of creating a new session.
+                wf[field] = result.session_id
 
         # Transient API error retry (429 / 5xx / overload) — exponential
         # backoff, max 30 minutes total. Interruptible sleep (cancel check


### PR DESCRIPTION
## 问题

`_run_agent` 更新了 DB 里的 session line（`main_session_id` 等），但**没有同步更新内存中的 `wf` 字典**。同一个 orchestrator run 里下一个阶段调 `_resolve_session_line(wf, "main")` 时，读的是旧的 `wf`——`main_session_id` 仍为空 → `resume=False` → 创建全新 session。

**证据**（wf 542）：4 个阶段全部 `resumed=False`，每个阶段都创建新 session，3-session 上下文链完全断裂：
- planning: sess_ff7 (create)
- review: sess_afa (create)  
- finalize: sess_4d3 (create，本应 resume sess_ff7)
- dev: sess_c04 (create，本应 resume sess_4d3)

## 修复

`_run_agent` 在 `self._update_workflow({field: result.session_id})` 之后，同步写入 `wf[field] = result.session_id`。这样同一 orchestrator run 里后续阶段的 `_resolve_session_line` 能看到最新的 session id，正确 resume。

39 个测试通过。
