### PR TITLE
fix(autonomous): extract final visible agent output

### DIFF
--- a/app/modules/workspace/autonomous/agent_runner.py
+++ b/app/modules/workspace/autonomous/agent_runner.py
@@ -266,6 +266,23 @@ def _extract_final_response_text(event_log: list[dict], fallback_text: str = "")
     return fallback_text.strip()
 
 
+def _extract_visible_response_text(event_log: list[dict], fallback_text: str = "") -> str:
+    """Return all visible assistant turns, excluding hidden/tool payloads.
+
+    This preserves structured tags like ``TL;DR:`` or ``CI_STATUS:`` even when
+    the agent emits them before a trailing tool call or short final ack turn.
+    """
+
+    assistant_turns: list[str] = [
+        event.get("text", "").strip()
+        for event in _coalesce_assistant_events(event_log)
+        if event.get("type") == "assistant" and event.get("text", "").strip()
+    ]
+    if assistant_turns:
+        return "\n\n".join(assistant_turns)
+    return fallback_text.strip()
+
+
 class _ZcodeResultCollector:
     """Collects assistant text, tool calls, and token usage from ZCode app-server.
 
@@ -1023,7 +1040,7 @@ class AutonomousAgentRunner:
             return AgentTaskResult(
                 session_id="",
                 tracking_session_id=session_id,
-                response_text=_extract_final_response_text(
+                response_text=_extract_visible_response_text(
                     session.event_log, session.assistant_text
                 ),
                 total_tokens=session.total_tokens,
@@ -1040,7 +1057,7 @@ class AutonomousAgentRunner:
             return AgentTaskResult(
                 session_id=resolved_session_id,
                 tracking_session_id=session_id,
-                response_text=_extract_final_response_text(
+                response_text=_extract_visible_response_text(
                     session.event_log, session.assistant_text
                 ),
                 total_tokens=session.total_tokens,
@@ -1056,7 +1073,7 @@ class AutonomousAgentRunner:
         return AgentTaskResult(
             session_id=resolved_session_id,
             tracking_session_id=session_id,
-            response_text=_extract_final_response_text(session.event_log, session.assistant_text),
+            response_text=_extract_visible_response_text(session.event_log, session.assistant_text),
             total_tokens=session.total_tokens,
             total_input_tokens=session.total_input_tokens,
             total_output_tokens=session.total_output_tokens,
@@ -1289,7 +1306,7 @@ class AutonomousAgentRunner:
             return AgentTaskResult(
                 session_id=cli_sid,
                 tracking_session_id=session_id,
-                response_text=_extract_final_response_text(
+                response_text=_extract_visible_response_text(
                     collector.event_log, collector.assistant_text
                 ),
                 total_tokens=collector.total_tokens,
@@ -1305,7 +1322,7 @@ class AutonomousAgentRunner:
         return AgentTaskResult(
             session_id=cli_sid,
             tracking_session_id=session_id,
-            response_text=_extract_final_response_text(
+            response_text=_extract_visible_response_text(
                 collector.event_log, collector.assistant_text
             ),
             total_tokens=collector.total_tokens,
@@ -1553,7 +1570,7 @@ class AutonomousAgentRunner:
                         return AgentTaskResult(
                             session_id=session_id,
                             tracking_session_id=session_id,
-                            response_text=_extract_final_response_text(assistant_events),
+                            response_text=_extract_visible_response_text(assistant_events),
                             messages=messages,
                             total_tokens=session_data.get("total_tokens", 0),
                             total_input_tokens=session_data.get("total_input_tokens", 0),

--- a/app/modules/workspace/autonomous/agent_runner.py
+++ b/app/modules/workspace/autonomous/agent_runner.py
@@ -131,7 +131,19 @@ class _LocalSession:
 # Top-level keys that indicate a JSON object is a leaked tool-call blob
 # rather than genuine assistant prose. ZCode sometimes streams tool
 # invocations as text content before emitting a structured tool.* event.
-_TOOL_JSON_KEYS = frozenset({"tool", "command", "subagent_type", "file_path"})
+_TOOL_JSON_KEYS = frozenset(
+    {
+        "tool",
+        "command",
+        "subagent_type",
+        "file_path",
+        # ZCode sometimes leaks child-agent invocation payloads as assistant
+        # text; those arrive as {"description": "...", "prompt": "..."}.
+        "description",
+        "prompt",
+    }
+)
+_NON_VISIBLE_BLOCK_TYPES = frozenset({"thinking", "tool_use", "tool_result", "reasoning"})
 
 
 def _looks_like_tool_json(text: str) -> bool:
@@ -149,6 +161,109 @@ def _looks_like_tool_json(text: str) -> bool:
     except (json.JSONDecodeError, ValueError):
         return False
     return isinstance(obj, dict) and any(k in obj for k in _TOOL_JSON_KEYS)
+
+
+def _extract_visible_text(content: Any) -> str:
+    """Extract user-visible assistant text from mixed protocol payloads.
+
+    Handles three common autonomous-runner payload shapes:
+
+    - Claude/OpenAI-style content blocks: ``[{"type":"text","text":"..."}]``
+    - Stringified JSON arrays/objects leaked through assistant content
+      (e.g. Claude ``thinking`` / ``tool_use`` blocks)
+    - ZCode leaked plan/tool objects, where ``{"plan":"..."}`` should render
+      as the final plan text while tool-call payloads should be hidden.
+    """
+
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            text = _extract_visible_text(item)
+            if text:
+                parts.append(text)
+        return "".join(parts)
+
+    if isinstance(content, dict):
+        block_type = content.get("type")
+        if block_type in _NON_VISIBLE_BLOCK_TYPES:
+            return ""
+        text_value = content.get("text")
+        if block_type == "text" and isinstance(text_value, str):
+            return text_value
+        plan_value = content.get("plan")
+        if isinstance(plan_value, str):
+            return plan_value
+        if any(k in content for k in _TOOL_JSON_KEYS):
+            return ""
+        if "content" in content:
+            return _extract_visible_text(content.get("content"))
+        if isinstance(text_value, str):
+            return text_value
+        return ""
+
+    if isinstance(content, str):
+        stripped = content.strip()
+        if stripped.startswith("{") or stripped.startswith("["):
+            try:
+                parsed = json.loads(stripped)
+            except (json.JSONDecodeError, ValueError):
+                return content
+            return _extract_visible_text(parsed)
+        return content
+
+    return ""
+
+
+def _coalesce_assistant_events(event_log: list[dict]) -> list[dict]:
+    """Merge adjacent assistant deltas into turn-sized assistant messages."""
+
+    merged: list[dict] = []
+    current_assistant: dict | None = None
+
+    for event in event_log or []:
+        if event.get("type") == "assistant":
+            text = event.get("text", "")
+            if not text:
+                continue
+            if current_assistant is None:
+                current_assistant = {
+                    "type": "assistant",
+                    "text": text,
+                    "message_id": event.get("message_id"),
+                    "model": event.get("model"),
+                }
+            else:
+                current_assistant["text"] += text
+                if event.get("message_id"):
+                    current_assistant["message_id"] = event.get("message_id")
+                if event.get("model"):
+                    current_assistant["model"] = event.get("model")
+            continue
+
+        if current_assistant is not None:
+            merged.append(current_assistant)
+            current_assistant = None
+
+        if event.get("type") == "tool_use":
+            merged.append(event)
+
+    if current_assistant is not None:
+        merged.append(current_assistant)
+
+    return merged
+
+
+def _extract_final_response_text(event_log: list[dict], fallback_text: str = "") -> str:
+    """Return the last user-visible assistant turn from an event log."""
+
+    assistant_turns: list[str] = [
+        event.get("text", "").strip()
+        for event in _coalesce_assistant_events(event_log)
+        if event.get("type") == "assistant" and event.get("text", "").strip()
+    ]
+    if assistant_turns:
+        return assistant_turns[-1]
+    return fallback_text.strip()
 
 
 class _ZcodeResultCollector:
@@ -200,13 +315,7 @@ class _ZcodeResultCollector:
         # Assistant text delta (from model.streaming → {"type":"assistant",...})
         if msg_type == "assistant":
             content = parsed.get("message", {}).get("content", "")
-            text = ""
-            if isinstance(content, list):
-                for block in content:
-                    if isinstance(block, dict) and block.get("type") == "text":
-                        text += block.get("text", "")
-            elif isinstance(content, str):
-                text = content
+            text = _extract_visible_text(content)
             # Filter out leaked tool-call JSON: ZCode sometimes streams tool
             # invocations as text content before emitting a structured tool.*
             # event. These look like raw JSON with tool/command markers and
@@ -914,7 +1023,9 @@ class AutonomousAgentRunner:
             return AgentTaskResult(
                 session_id="",
                 tracking_session_id=session_id,
-                response_text=session.assistant_text,
+                response_text=_extract_final_response_text(
+                    session.event_log, session.assistant_text
+                ),
                 total_tokens=session.total_tokens,
                 total_input_tokens=session.total_input_tokens,
                 total_output_tokens=session.total_output_tokens,
@@ -929,7 +1040,9 @@ class AutonomousAgentRunner:
             return AgentTaskResult(
                 session_id=resolved_session_id,
                 tracking_session_id=session_id,
-                response_text=session.assistant_text,
+                response_text=_extract_final_response_text(
+                    session.event_log, session.assistant_text
+                ),
                 total_tokens=session.total_tokens,
                 total_input_tokens=session.total_input_tokens,
                 total_output_tokens=session.total_output_tokens,
@@ -943,7 +1056,7 @@ class AutonomousAgentRunner:
         return AgentTaskResult(
             session_id=resolved_session_id,
             tracking_session_id=session_id,
-            response_text=session.assistant_text,
+            response_text=_extract_final_response_text(session.event_log, session.assistant_text),
             total_tokens=session.total_tokens,
             total_input_tokens=session.total_input_tokens,
             total_output_tokens=session.total_output_tokens,
@@ -1176,7 +1289,9 @@ class AutonomousAgentRunner:
             return AgentTaskResult(
                 session_id=cli_sid,
                 tracking_session_id=session_id,
-                response_text=collector.assistant_text,
+                response_text=_extract_final_response_text(
+                    collector.event_log, collector.assistant_text
+                ),
                 total_tokens=collector.total_tokens,
                 total_input_tokens=collector.input_tokens,
                 total_output_tokens=collector.output_tokens,
@@ -1190,7 +1305,9 @@ class AutonomousAgentRunner:
         return AgentTaskResult(
             session_id=cli_sid,
             tracking_session_id=session_id,
-            response_text=collector.assistant_text,
+            response_text=_extract_final_response_text(
+                collector.event_log, collector.assistant_text
+            ),
             total_tokens=collector.total_tokens,
             total_input_tokens=collector.input_tokens,
             total_output_tokens=collector.output_tokens,
@@ -1426,15 +1543,17 @@ class AutonomousAgentRunner:
                             messages = self.session_manager.get_messages(session_id) or []
 
                         # Extract assistant text
-                        assistant_text = ""
+                        assistant_events: list[dict] = []
                         for msg in messages:
                             if msg.get("role") == "assistant":
-                                assistant_text += msg.get("content", "")
+                                text = _extract_visible_text(msg.get("content", ""))
+                                if text:
+                                    assistant_events.append({"type": "assistant", "text": text})
 
                         return AgentTaskResult(
                             session_id=session_id,
                             tracking_session_id=session_id,
-                            response_text=assistant_text,
+                            response_text=_extract_final_response_text(assistant_events),
                             messages=messages,
                             total_tokens=session_data.get("total_tokens", 0),
                             total_input_tokens=session_data.get("total_input_tokens", 0),
@@ -1470,12 +1589,15 @@ class AutonomousAgentRunner:
     def _persist_local_session_messages(
         self, session_id: str, result: AgentTaskResult, milestone_id: str = ""
     ) -> None:
-        """Write agent conversation to session_messages preserving order.
+        """Write workflow-visible messages to ``session_messages``.
 
-        Uses the ordered event_log from _LocalSession to maintain the actual
-        interleaving (assistant -> tool_use -> assistant -> ...).
-        Falls back to separate assistant_text + tool_calls if event_log is empty
-        (e.g. remote sessions or legacy code path).
+        Autonomous workflow detail views should show the final assistant output
+        for a phase, not every streamed delta / hidden reasoning fragment. We
+        therefore persist all tool-use events but collapse assistant deltas down
+        to the last visible assistant turn.
+
+        Falls back to separate ``response_text`` + ``tool_calls`` if event_log
+        is empty (e.g. remote sessions or legacy code path).
 
         Called after the agent task finishes, before the session status is
         updated.  Errors are caught by the caller and do not affect the
@@ -1486,21 +1608,11 @@ class AutonomousAgentRunner:
         # increment_session_usage at finish time; counting here too would
         # double-count (#1003 / #1007 review).
         if result.event_log:
-            for event in result.event_log:
+            merged_events = _coalesce_assistant_events(result.event_log)
+            final_assistant = None
+            for event in merged_events:
                 if event.get("type") == "assistant":
-                    self.session_manager.add_message(
-                        session_id=session_id,
-                        milestone_id=milestone_id,
-                        role="assistant",
-                        content=event.get("text", ""),
-                        model=event.get("model"),
-                        metadata=(
-                            {"message_id": event.get("message_id")}
-                            if event.get("message_id")
-                            else None
-                        ),
-                        count_usage=False,
-                    )
+                    final_assistant = event
                 elif event.get("type") == "tool_use":
                     tool_input = event.get("tool_input", {})
                     self.session_manager.add_message(
@@ -1522,6 +1634,20 @@ class AutonomousAgentRunner:
                         },
                         count_usage=False,
                     )
+            if final_assistant:
+                self.session_manager.add_message(
+                    session_id=session_id,
+                    milestone_id=milestone_id,
+                    role="assistant",
+                    content=final_assistant.get("text", ""),
+                    model=final_assistant.get("model"),
+                    metadata=(
+                        {"message_id": final_assistant.get("message_id")}
+                        if final_assistant.get("message_id")
+                        else None
+                    ),
+                    count_usage=False,
+                )
                 # usage events are metadata-only, not persisted as messages
         else:
             # Fallback: write as single assistant + individual tool messages
@@ -1612,15 +1738,9 @@ class AutonomousAgentRunner:
                         msg = parsed.get("message", {})
                         content = msg.get("content", "")
                         message_id = msg.get("id")
-                        text_delta = ""
-                        if isinstance(content, list):
-                            for block in content:
-                                if isinstance(block, dict) and block.get("type") == "text":
-                                    text_delta = block.get("text", "")
-                                    session.assistant_text += text_delta
-                        elif isinstance(content, str):
-                            text_delta = content
-                            session.assistant_text += content
+                        text_delta = _extract_visible_text(content)
+                        if text_delta:
+                            session.assistant_text += text_delta
                         # Record in event log for ordered message persistence
                         if text_delta:
                             session.event_log.append(

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -860,11 +860,23 @@ class AutonomousOrchestrator:
         main/review/test: if the workflow already stores that line's real CLI
         session id, resume it (--resume); otherwise mint a fresh tracking id
         (first call on that line). fresh/unknown: brand-new session, no resume.
+
+        Reads from the wf dict first, then falls back to a fresh DB query.
+        The DB fallback is critical: _run_agent updates the session line in the
+        DB, but the in-memory wf dict may be stale if it was read before the
+        update (e.g. _do_planning reads wf once at entry, then planning's
+        _run_agent writes to DB; finalize needs the updated value).
         """
         field = SESSION_LINE_FIELDS.get(session_line)
         if not field:
             return str(uuid.uuid4()), None, False
         existing = ((wf or {}).get(field) or "").strip()
+        # Fallback to DB if the in-memory wf dict doesn't have the session id.
+        # This handles the case where a prior _run_agent in the same phase
+        # updated the DB but the in-memory wf dict wasn't refreshed.
+        if not existing:
+            fresh = self.workflow or {}
+            existing = (fresh.get(field) or "").strip()
         if existing:
             return str(uuid.uuid4()), existing, True
         return str(uuid.uuid4()), None, False

--- a/app/repositories/message_repo.py
+++ b/app/repositories/message_repo.py
@@ -9,6 +9,7 @@ from typing import Any, Optional
 
 from app.repositories.database import Database, escape_like
 from app.utils.cache import cached
+from app.utils.roles import normalize_message_role
 from app.utils.senders import is_valid_sender
 from app.utils.tool_names import normalize_tool_name
 
@@ -60,7 +61,9 @@ class MessageRepository:
             date: Date string (YYYY-MM-DD).
             tool_name: Name of the tool.
             message_id: Unique message identifier.
-            role: Message role (user, assistant, system).
+            role: Message role (user, assistant, system, tool). Variant
+                tool-result spellings (toolResult, tool_result) are normalized
+                to ``tool`` at the write boundary.
             host_name: Host name.
             parent_id: Parent message ID.
             content: Message content.
@@ -88,6 +91,13 @@ class MessageRepository:
         # QWEN, ...) can never split downstream aggregates (daily_stats,
         # hourly_stats, ROI cost-breakdown) into duplicate slices.
         tool_name = normalize_tool_name(tool_name)
+
+        # Normalize the message role at the write boundary so variant
+        # tool-result spellings (toolResult / tool_result) collapse to the
+        # canonical ``tool``. Without this, conversations produced by different
+        # write paths stored different role values and the conversation-detail
+        # role filter showed "no messages found" for one of them.
+        role = normalize_message_role(role)
 
         if is_postgresql():
             self.db.execute(

--- a/app/routes/remote.py
+++ b/app/routes/remote.py
@@ -1561,6 +1561,14 @@ def agent_message():
                     if not content or len(content) > MAX_RAW_CONTENT_LENGTH:
                         continue
 
+                    # Normalize the role so variant tool-result spellings
+                    # (toolResult / tool_result) collapse to the canonical
+                    # "tool" before being written to daily_messages. This path
+                    # writes directly and bypasses message_repo.save_message.
+                    from app.utils.roles import normalize_message_role
+
+                    role = normalize_message_role(role)
+
                     input_tokens = usage.get("input_tokens", 0) if isinstance(usage, dict) else 0
                     output_tokens = usage.get("output_tokens", 0) if isinstance(usage, dict) else 0
                     tokens_used = input_tokens + output_tokens

--- a/app/utils/roles.py
+++ b/app/utils/roles.py
@@ -1,0 +1,78 @@
+"""Canonical message-role normalization.
+
+Centralizes the mapping of variant tool-result role spellings
+(``toolResult``, ``tool_result``) to the canonical form ``tool``. The
+canonical value matches the Anthropic/OpenAI native ``tool`` role and the
+value the live agent runner already writes (``agent_runner`` ->
+``session_manager.add_message(role="tool")``).
+
+Why this matters: two parallel write paths persisted different spellings for
+tool-result messages. The Claude/OpenClaw intake path wrote ``role="toolResult"``
+while the live autonomous agent path wrote ``role="tool"``. Downstream
+consumers (the conversation-detail role filter, message statistics, latency
+curve) only compared against one spelling, so conversations produced by the
+"other" path surfaced as "no messages found" when filtered.
+
+Every write path into ``daily_messages`` funnels through
+``normalize_message_role`` at the write boundary (mirroring
+``normalize_tool_name``), so a tool-result message can never again split or
+hide based on spelling. Matching is case- and whitespace-insensitive.
+
+Decision basis (forensics on the codebase): the only observed variants were
+``tool``, ``toolResult`` and ``tool_result`` -- all three representing the same
+semantic "tool result" message. No arbitrary matching is performed; unknown
+roles are returned stripped and lower-cased so future case drift cannot
+re-introduce a split.
+"""
+
+from typing import Optional
+
+# Canonical message roles. All write paths should reference these instead of
+# bare string literals so role values can never drift.
+ROLE_USER = "user"
+ROLE_ASSISTANT = "assistant"
+ROLE_SYSTEM = "system"
+ROLE_TOOL = "tool"
+
+# Variant spellings observed across write paths, all mapping to ROLE_TOOL.
+# Matched case- and whitespace-insensitively.
+_TOOL_ROLE_ALIASES = {
+    "tool",
+    "toolresult",
+    "tool_result",
+}
+
+
+def normalize_message_role(role: Optional[str]) -> str:
+    """Normalize a message role to its canonical form.
+
+    Tool-result spellings (``toolResult``, ``tool_result``) collapse to the
+    canonical ``tool``. Other roles (``user``/``assistant``/``system``) pass
+    through. ``None``/blank input becomes ``"unknown"``. Unknown values are
+    returned stripped and lower-cased so case drift never re-splits a
+    downstream aggregate or filter.
+
+    Args:
+        role: Raw message role. May be ``None`` or contain surrounding
+            whitespace / mixed case.
+
+    Returns:
+        Canonical role string (e.g. ``"tool"``). ``None``/blank input returns
+        ``"unknown"``.
+
+    Examples:
+        >>> normalize_message_role("toolResult")
+        'tool'
+        >>> normalize_message_role(" tool_result ")
+        'tool'
+        >>> normalize_message_role("assistant")
+        'assistant'
+        >>> normalize_message_role(None)
+        'unknown'
+    """
+    if not role or not role.strip():
+        return "unknown"
+    cleaned = role.strip().lower()
+    if cleaned in _TOOL_ROLE_ALIASES:
+        return ROLE_TOOL
+    return cleaned

--- a/frontend/src/components/features/ConversationHistory.tsx
+++ b/frontend/src/components/features/ConversationHistory.tsx
@@ -38,6 +38,21 @@ import type { ConversationHistory as ConversationHistoryType } from '@/api';
 
 const ITEMS_PER_PAGE = 20;
 
+// Canonical tool-result role. The backend normalizes variant spellings
+// (toolResult / tool_result) to this value at the write boundary, and the
+// historical-data migration backfills existing rows. The helper accepts both
+// the canonical "tool" and the legacy "toolResult" so messages written before
+// the normalization landed (or before the migration runs) still match.
+const TOOL_ROLE = 'tool';
+
+/**
+ * Returns true when a message role represents a tool-result message.
+ * Accepts the canonical ``tool`` role as well as the legacy ``toolResult``
+ * spelling so the UI degrades gracefully during the normalization/migration
+ * transition window (pre-migration rows may still carry the old value).
+ */
+const isToolRole = (role: string): boolean => role === TOOL_ROLE || role === 'toolResult';
+
 // Column definitions
 interface ColumnDef {
   key: string;
@@ -648,6 +663,8 @@ const MessageItem: React.FC<MessageItemProps> = ({ msg, language }) => {
         return 'bi-robot';
       case 'system':
         return 'bi-gear-fill';
+      // Canonical tool role plus legacy "toolResult" spelling (pre-migration rows)
+      case 'tool':
       case 'toolResult':
         return 'bi-wrench';
       default:
@@ -663,6 +680,8 @@ const MessageItem: React.FC<MessageItemProps> = ({ msg, language }) => {
         return 'bg-success';
       case 'system':
         return 'bg-secondary';
+      // Canonical tool role plus legacy "toolResult" spelling (pre-migration rows)
+      case 'tool':
       case 'toolResult':
         return 'bg-info';
       default:
@@ -770,6 +789,9 @@ const ConversationDetailModal: React.FC<ConversationDetailModalProps> = ({
   const filteredMessages = useMemo(() => {
     if (!messages) return [];
     if (roleFilter === 'all') return messages;
+    // The tool filter must match both the canonical "tool" role and the legacy
+    // "toolResult" spelling so pre-migration rows are still found.
+    if (roleFilter === TOOL_ROLE) return messages.filter((msg) => isToolRole(msg.role));
     return messages.filter((msg) => msg.role === roleFilter);
   }, [messages, roleFilter]);
 
@@ -787,7 +809,7 @@ const ConversationDetailModal: React.FC<ConversationDetailModalProps> = ({
       if (msg.role === 'user') {
         lastUserTime = msgTime;
         lastUserIndex = index;
-      } else if ((msg.role === 'assistant' || msg.role === 'toolResult') && lastUserTime) {
+      } else if ((msg.role === 'assistant' || isToolRole(msg.role)) && lastUserTime) {
         const latency = (msgTime.getTime() - lastUserTime.getTime()) / 1000; // seconds
         if (latency > 0) {
           latencies.push({
@@ -846,7 +868,7 @@ const ConversationDetailModal: React.FC<ConversationDetailModalProps> = ({
       if (msg.role === 'user') stats.user++;
       else if (msg.role === 'assistant') stats.assistant++;
       else if (msg.role === 'system') stats.system++;
-      else if (msg.role === 'toolResult') stats.toolResult++;
+      else if (isToolRole(msg.role)) stats.toolResult++;
       stats.totalTokens += msg.tokens_used ?? 0;
       stats.totalInputTokens += msg.input_tokens ?? 0;
       stats.totalOutputTokens += msg.output_tokens ?? 0;
@@ -855,13 +877,15 @@ const ConversationDetailModal: React.FC<ConversationDetailModalProps> = ({
     return stats;
   }, [messages]);
 
-  // Role filter options
+  // Role filter options. The tool option value is the canonical "tool" role
+  // (what the backend now stores); the filter logic accepts both "tool" and
+  // the legacy "toolResult" spelling via isToolRole so pre-migration rows match.
   const roleFilterOptions = [
     { value: 'all', label: t('all', language) },
     { value: 'user', label: t('messageRoleUser', language) },
     { value: 'assistant', label: t('messageRoleAssistant', language) },
     { value: 'system', label: t('messageRoleSystem', language) },
-    { value: 'toolResult', label: t('messageRoleToolResult', language) },
+    { value: TOOL_ROLE, label: t('messageRoleToolResult', language) },
   ];
 
   return (

--- a/migrations/versions/20260621_041_normalize_tool_result_role.py
+++ b/migrations/versions/20260621_041_normalize_tool_result_role.py
@@ -1,0 +1,71 @@
+"""Normalize tool-result message roles to canonical ``tool``
+
+Revision ID: 041_normalize_tool_result_role
+Revises: 040_normalize_tool_names_case_insensitive
+Create Date: 2026-06-21
+
+Two parallel write paths persisted different spellings for tool-result
+messages in ``daily_messages``:
+
+- Claude/OpenClaw intake (``scripts/fetch_openclaw`` / ``fetch_claude``)
+  wrote ``role = 'toolResult'``.
+- The live autonomous agent path
+  (``agent_runner`` -> ``session_manager.add_message(role="tool")``)
+  wrote ``role = 'tool'``.
+
+Downstream consumers (the conversation-detail role filter, message
+statistics, latency curve) only compared against one spelling, so
+conversations produced by the "other" path surfaced as "no messages found"
+when filtered by ToolResult.
+
+This migration is a one-time, idempotent data cleanup that collapses every
+tool-result spelling (``toolResult``, ``tool_result``, plus case/whitespace
+drift) to the canonical ``tool`` across the tables that persist a ``role``
+column. Write-side normalization now happens at the intake boundary
+(``message_repo.save_message`` / the remote mirror path), so this migration
+only backfills historical rows. Each UPDATE only touches rows that still need
+fixing, so it is safe to re-run.
+"""
+
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "041_normalize_tool_result_role"
+down_revision: Union[str, None] = "040_normalize_tool_names_case_insensitive"
+branch_labels: Union[str, None] = None
+depends_on: Union[str, None] = None
+
+# Tables that persist a message role column.
+TABLES = (
+    "daily_messages",
+    "session_messages",
+)
+
+# Variant spellings observed across write paths. Matched case- and
+# whitespace-insensitively; all collapse to the canonical "tool".
+CANONICAL_ROLE = "tool"
+_TOOL_ROLE_ALIASES = ("toolresult", "tool_result")
+
+
+def upgrade() -> None:
+    """Collapse tool-result role spellings to the canonical ``tool``."""
+    for table in TABLES:
+        # Map the known aliases (matched case- and whitespace-insensitively)
+        # to the canonical role. Only touches rows that still need fixing.
+        for alias in _TOOL_ROLE_ALIASES:
+            op.execute(
+                sa.text(
+                    f"UPDATE {table} SET role = :canonical " f"WHERE LOWER(TRIM(role)) = :alias"
+                ).bindparams(
+                    sa.bindparam("canonical", CANONICAL_ROLE), sa.bindparam("alias", alias)
+                )
+            )
+
+
+def downgrade() -> None:
+    # Data normalization is not meaningfully reversible; original spellings
+    # are gone once collapsed. Intentionally a no-op.
+    pass

--- a/migrations/versions/20260621_193547_merge_041_064.py
+++ b/migrations/versions/20260621_193547_merge_041_064.py
@@ -1,0 +1,35 @@
+"""merge_041_064
+
+Revision ID: 7bcf07ee658e
+Revises: 041_normalize_tool_result_role, 20260618_064_fix_quota_unit_inconsistency
+Create Date: 2026-06-21 19:35:47
+
+Merge point that collapses the two heads created when the tool-result role
+normalization migration (``041_normalize_tool_result_role``) was attached to
+the ``040_normalize_tool_names_case_insensitive`` lineage while
+``20260618_064_fix_quota_unit_inconsistency`` branched independently off
+``20260615_063_fix_boolean_retroactive``. Without this merge ``alembic heads``
+reports two heads and ``alembic upgrade head`` is ambiguous. This is a
+topological merge only -- no schema changes.
+"""
+
+from typing import Sequence, Union
+
+# revision identifiers, used by Alembic.
+revision: str = "7bcf07ee658e"
+down_revision: Union[str, None] = (
+    "041_normalize_tool_result_role",
+    "20260618_064_fix_quota_unit_inconsistency",
+)
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade database schema."""
+    pass
+
+
+def downgrade() -> None:
+    """Downgrade database schema."""
+    pass

--- a/remote-agent/zcode_app_server.py
+++ b/remote-agent/zcode_app_server.py
@@ -177,7 +177,7 @@ class ZCodeAppServerSession:
             "models": [{"modelId": model_id}],
         }
         if api_key:
-            provider["apiKey"] = api_key
+            provider["apiKey"] = {"source": "inline", "value": api_key}
         return {
             "revision": "0",
             "generatedAt": int(time.time() * 1000),

--- a/tests/issues/1138/test_multi_protocol_runner.py
+++ b/tests/issues/1138/test_multi_protocol_runner.py
@@ -333,6 +333,18 @@ def test_collector_ignores_non_json():
     assert len(c.event_log) == 0  # non-JSON is silently dropped
 
 
+def test_extract_final_response_text_uses_last_visible_turn():
+    from app.modules.workspace.autonomous.agent_runner import _extract_final_response_text
+
+    event_log = [
+        {"type": "assistant", "text": "Let me inspect. "},
+        {"type": "tool_use", "tool_name": "Read", "tool_input": {"file_path": "a.py"}},
+        {"type": "assistant", "text": "## Final Review\n"},
+        {"type": "assistant", "text": "Looks good."},
+    ]
+    assert _extract_final_response_text(event_log) == "## Final Review\nLooks good."
+
+
 # ── ZCode session failure cleanup ─────────────────────────────────────────
 
 

--- a/tests/issues/1138/test_multi_protocol_runner.py
+++ b/tests/issues/1138/test_multi_protocol_runner.py
@@ -345,6 +345,19 @@ def test_extract_final_response_text_uses_last_visible_turn():
     assert _extract_final_response_text(event_log) == "## Final Review\nLooks good."
 
 
+def test_extract_visible_response_text_preserves_all_visible_turns():
+    from app.modules.workspace.autonomous.agent_runner import _extract_visible_response_text
+
+    event_log = [
+        {"type": "assistant", "text": "Applied fix\nCI_STATUS: pre-existing"},
+        {"type": "tool_use", "tool_name": "Bash", "tool_input": {"command": "git push"}},
+        {"type": "assistant", "text": "Done."},
+    ]
+    assert _extract_visible_response_text(event_log) == (
+        "Applied fix\nCI_STATUS: pre-existing\n\nDone."
+    )
+
+
 # ── ZCode session failure cleanup ─────────────────────────────────────────
 
 

--- a/tests/issues/1140/test_plan_corruption_and_reporting.py
+++ b/tests/issues/1140/test_plan_corruption_and_reporting.py
@@ -148,6 +148,36 @@ def test_collector_keeps_normal_assistant_text():
     assert "## Plan: Fix the bug" in c.assistant_text
 
 
+def test_collector_extracts_plan_from_leaked_plan_json():
+    """A leaked {"plan": "..."} blob should become the final visible plan."""
+    from app.modules.workspace.autonomous.agent_runner import _ZcodeResultCollector
+
+    c = _ZcodeResultCollector()
+    c.on_output(
+        "sid",
+        '{"type":"assistant","message":{"content":"{\\"plan\\":\\"## Final Plan\\\\n1. Fix bug\\"}"}}',
+        "stdout",
+        False,
+    )
+    assert c.assistant_text == "## Final Plan\n1. Fix bug"
+    assert c.event_log[-1]["text"] == "## Final Plan\n1. Fix bug"
+
+
+def test_collector_hides_child_agent_prompt_json():
+    """Child-agent prompt payloads must not show up as assistant prose."""
+    from app.modules.workspace.autonomous.agent_runner import _ZcodeResultCollector
+
+    c = _ZcodeResultCollector()
+    c.on_output(
+        "sid",
+        '{"type":"assistant","message":{"content":"{\\"description\\":\\"Find bug\\",\\"prompt\\":\\"inspect files\\"}"}}',
+        "stdout",
+        False,
+    )
+    assert c.assistant_text == ""
+    assert c.event_log == []
+
+
 def test_looks_like_tool_json_helper():
     """The _looks_like_tool_json helper correctly classifies text.
 
@@ -159,10 +189,12 @@ def test_looks_like_tool_json_helper():
     assert _looks_like_tool_json('{"command": "ls /tmp"}')
     assert _looks_like_tool_json('{"tool": "Read", "file_path": "/tmp/a.py"}')
     assert _looks_like_tool_json('{"subagent_type": "Explore", "prompt": "..."}')
+    assert _looks_like_tool_json('{"description": "Find role filter", "prompt": "inspect files"}')
 
     # NOT tool JSON: valid JSON but no tool keys at top level
     assert not _looks_like_tool_json('{"type": "assistant"}')
     assert not _looks_like_tool_json('{"name": "Write"}')
+    assert not _looks_like_tool_json('{"plan": "## Final Plan"}')
 
     # NOT tool JSON: prose that happens to contain JSON-like text
     assert not _looks_like_tool_json("## Implementation Plan")

--- a/tests/issues/1140/test_session_line_resume.py
+++ b/tests/issues/1140/test_session_line_resume.py
@@ -1,0 +1,94 @@
+"""Integration test: 3-session resume across planning → finalize → dev.
+
+Verifies that when planning creates a session on the "main" line, finalize
+(and subsequently dev) correctly resumes that session instead of creating
+a new one. This is the core of the 3-session design.
+
+Root cause being tested: _run_agent updates the session line in the DB, but
+the in-memory wf dict may not reflect the update when the next phase in the
+same _do_planning run calls _resolve_session_line. The fix adds a DB
+fallback in _resolve_session_line.
+"""
+
+import uuid
+from unittest.mock import MagicMock
+
+
+def _make_orchestrator(db_state):
+    """Create an orchestrator with a mock repo that returns db_state copies."""
+    from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+    workflow_id = str(uuid.uuid4())
+
+    # AutonomousOrchestrator.__init__ creates its own repo from self.db.
+    # We patch self.repo after construction to control get_workflow.
+    repo = MagicMock()
+    repo.get_workflow = MagicMock(return_value=dict(db_state))
+    repo.update_workflow = MagicMock(side_effect=lambda wid, updates: db_state.update(updates))
+
+    # Bypass __init__ to avoid real DB connection
+    orch = AutonomousOrchestrator.__new__(AutonomousOrchestrator)
+    orch._workflow_id = workflow_id
+    orch.repo = repo
+    orch._session_lock = MagicMock()
+    orch._current_session_id = None
+    return orch, repo
+
+
+def test_resolve_session_line_resumes_after_run_agent_update():
+    """_resolve_session_line must see the session id written by a prior
+    _run_agent call on the same line, even if the in-memory wf dict is stale.
+
+    Simulates the _do_planning flow:
+      1. wf = self.workflow (read once at entry, main_session_id empty)
+      2. planning _run_agent(session_line="main") → updates DB
+      3. finalize _resolve_session_line(stale_wf, "main") → must resume
+    """
+    db_state = {"main_session_id": "", "review_session_id": "", "status": "planning"}
+    orch, repo = _make_orchestrator(db_state)
+
+    # Phase 1: planning — session line is empty → create new
+    wf = orch.workflow
+    assert wf["main_session_id"] == "", "precondition: empty main_session_id"
+    sid, resume_sid, resume = orch._resolve_session_line(wf, "main")
+    assert resume is False, "first call on main line should not resume"
+
+    # Simulate _run_agent success: update DB with the real session id
+    planning_sid = "sess_planning_abc123"
+    db_state["main_session_id"] = planning_sid
+    # repo.get_workflow returns copies, so update the mock
+    repo.get_workflow = MagicMock(return_value=dict(db_state))
+
+    # Phase 2: finalize — wf dict is STALE (still has empty main_session_id)
+    stale_wf = {"main_session_id": "", "review_session_id": "", "status": "planning"}
+    sid2, resume_sid2, resume2 = orch._resolve_session_line(stale_wf, "main")
+    assert resume2 is True, (
+        "finalize must resume planning session even if wf dict is stale — "
+        "DB fallback is required"
+    )
+    assert resume_sid2 == planning_sid, "resume_session_id must match planning session"
+
+
+def test_resolve_session_line_resume_with_fresh_wf():
+    """When wf dict IS up-to-date (PR #1156 wf[field] sync), resume works
+    without needing DB fallback."""
+    db_state = {"main_session_id": "", "review_session_id": ""}
+    orch, repo = _make_orchestrator(db_state)
+
+    # Simulate wf[field] = result.session_id (PR #1156)
+    wf = {"main_session_id": "sess_planning_fresh", "review_session_id": ""}
+    sid, resume_sid, resume = orch._resolve_session_line(wf, "main")
+    assert resume is True
+    assert resume_sid == "sess_planning_fresh"
+
+
+def test_resolve_session_line_review_independent_from_main():
+    """review session line is independent — resuming main does not affect it."""
+    db_state = {"main_session_id": "sess_main", "review_session_id": ""}
+    orch, repo = _make_orchestrator(db_state)
+
+    wf = {"main_session_id": "sess_main", "review_session_id": ""}
+
+    # review line should NOT resume (empty), even though main has a session
+    sid, resume_sid, resume = orch._resolve_session_line(wf, "review")
+    assert resume is False, "review line must be independent from main"

--- a/tests/issues/716/test_agent_runner.py
+++ b/tests/issues/716/test_agent_runner.py
@@ -552,6 +552,27 @@ class TestStdoutParsing:
         assert "Real content" in session.assistant_text
         assert len(session.output_lines) == 1  # Only the non-empty JSON line
 
+    def test_parse_assistant_stringified_thinking_json_is_hidden(self):
+        """Stringified thinking/tool JSON must not pollute assistant_text."""
+        session = self._run_read_stdout(
+            [
+                json.dumps(
+                    {
+                        "type": "assistant",
+                        "message": {
+                            "content": '[{"type":"thinking","thinking":"internal scratchpad"}]'
+                        },
+                    }
+                ),
+                json.dumps({"type": "assistant", "message": {"content": "Final answer"}}),
+                "",
+            ]
+        )
+        assert session.assistant_text == "Final answer"
+        assert [e["text"] for e in session.event_log if e.get("type") == "assistant"] == [
+            "Final answer"
+        ]
+
 
 class TestStopSession:
     """Tests for stop_session."""
@@ -610,14 +631,37 @@ class TestPersistLocalSessionMessages:
         assert sm.add_message.call_count == 2
         first_call = sm.add_message.call_args_list[0].kwargs
         assert first_call["session_id"] == "sess-1"
-        assert first_call["role"] == "assistant"
-        assert first_call["model"] == "claude-sonnet"
-        assert first_call["metadata"] == {"message_id": "msg-123"}
-
-        second_call = sm.add_message.call_args_list[1].kwargs
-        assert second_call["session_id"] == "sess-1"
-        assert second_call["role"] == "tool"
-        assert second_call["metadata"] == {
+        assert first_call["role"] == "tool"
+        assert first_call["metadata"] == {
             "tool_name": "Read",
             "tool_use_id": "tool-456",
         }
+
+        second_call = sm.add_message.call_args_list[1].kwargs
+        assert second_call["session_id"] == "sess-1"
+        assert second_call["role"] == "assistant"
+        assert second_call["model"] == "claude-sonnet"
+        assert second_call["metadata"] == {"message_id": "msg-123"}
+
+    def test_event_log_persists_only_final_assistant_turn(self):
+        sm = MagicMock()
+        runner = AutonomousAgentRunner(session_manager=sm)
+        from app.modules.workspace.autonomous.models import AgentTaskResult
+
+        result = AgentTaskResult(
+            event_log=[
+                {"type": "assistant", "text": "Let me inspect the codebase. "},
+                {"type": "tool_use", "tool_name": "Read", "tool_input": {"file_path": "a.py"}},
+                {"type": "assistant", "text": "## Final Plan\n"},
+                {"type": "assistant", "text": "1. Fix the bug"},
+            ]
+        )
+
+        runner._persist_local_session_messages("sess-1", result)
+
+        assert sm.add_message.call_count == 2
+        first_call = sm.add_message.call_args_list[0].kwargs
+        assert first_call["role"] == "tool"
+        second_call = sm.add_message.call_args_list[1].kwargs
+        assert second_call["role"] == "assistant"
+        assert second_call["content"] == "## Final Plan\n1. Fix the bug"

--- a/tests/unit/test_message_role_normalization.py
+++ b/tests/unit/test_message_role_normalization.py
@@ -1,0 +1,117 @@
+"""Unit tests for message-role normalization.
+
+Guards the conversation-detail role-filter bug: tool-result messages persisted
+under different spellings (``tool`` vs ``toolResult`` / ``tool_result``) must
+all collapse to the canonical ``tool`` role at the write boundary, so the
+conversation-detail role filter, message statistics and latency curve can never
+again surface as "no messages found" for one of the write paths.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.repositories.message_repo import MessageRepository
+from app.utils.roles import (
+    ROLE_ASSISTANT,
+    ROLE_SYSTEM,
+    ROLE_TOOL,
+    ROLE_USER,
+    normalize_message_role,
+)
+
+
+class TestNormalizeMessageRole:
+    """Pure unit tests for normalize_message_role."""
+
+    @pytest.mark.parametrize(
+        "variant",
+        [
+            "tool",
+            "Tool",
+            "TOOL",
+            " tool ",
+            "\ttool\n",
+            "toolResult",
+            "ToolResult",
+            " toolResult ",
+            "tool_result",
+            "TOOL_RESULT",
+        ],
+    )
+    def test_tool_result_spellings_collapse_to_tool(self, variant):
+        assert normalize_message_role(variant) == "tool"
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("user", "user"),
+            ("assistant", "assistant"),
+            ("system", "system"),
+            ("USER", "user"),
+            (" Assistant ", "assistant"),
+        ],
+    )
+    def test_non_tool_roles_passthrough_lowercased(self, raw, expected):
+        assert normalize_message_role(raw) == expected
+
+    @pytest.mark.parametrize("raw", [None, "", "   ", "\t\n"])
+    def test_empty_returns_unknown(self, raw):
+        assert normalize_message_role(raw) == "unknown"
+
+    def test_unknown_role_lowercased_not_swallowed(self):
+        # NEGATIVE: no prefix/fuzzy matching. An unknown role is preserved
+        # (lower-cased), never force-merged into "tool".
+        assert normalize_message_role("developer") == "developer"
+        assert normalize_message_role("ToolUser") == "tooluser"
+
+    def test_idempotent(self):
+        once = normalize_message_role("toolResult")
+        twice = normalize_message_role(once)
+        assert once == twice == "tool"
+
+    def test_role_constants(self):
+        assert ROLE_USER == "user"
+        assert ROLE_ASSISTANT == "assistant"
+        assert ROLE_SYSTEM == "system"
+        assert ROLE_TOOL == "tool"
+
+
+class TestSaveMessageWriteBoundary:
+    """save_message must normalize the role before writing daily_messages."""
+
+    @patch("app.repositories.database.is_postgresql", return_value=False)
+    def test_save_message_normalizes_tool_result_alias(self, _mock_pg):
+        db = MagicMock()
+        repo = MessageRepository(db=db)
+        repo.save_message(date="2026-06-21", tool_name="claude", message_id="m1", role="toolResult")
+        params = db.execute.call_args[0][1]
+        # role is the 6th positional column (date, tool_name, host_name,
+        # message_id, parent_id, role) -> index 5.
+        assert params[5] == "tool"
+
+    @patch("app.repositories.database.is_postgresql", return_value=False)
+    def test_save_message_normalizes_tool_result_snake_case(self, _mock_pg):
+        db = MagicMock()
+        repo = MessageRepository(db=db)
+        repo.save_message(
+            date="2026-06-21", tool_name="claude", message_id="m2", role="tool_result"
+        )
+        params = db.execute.call_args[0][1]
+        assert params[5] == "tool"
+
+    @patch("app.repositories.database.is_postgresql", return_value=False)
+    def test_save_message_preserves_canonical_tool(self, _mock_pg):
+        db = MagicMock()
+        repo = MessageRepository(db=db)
+        repo.save_message(date="2026-06-21", tool_name="claude", message_id="m3", role="tool")
+        params = db.execute.call_args[0][1]
+        assert params[5] == "tool"
+
+    @patch("app.repositories.database.is_postgresql", return_value=False)
+    def test_save_message_preserves_other_roles(self, _mock_pg):
+        db = MagicMock()
+        repo = MessageRepository(db=db)
+        repo.save_message(date="2026-06-21", tool_name="claude", message_id="m4", role="assistant")
+        params = db.execute.call_args[0][1]
+        assert params[5] == "assistant"

--- a/tests/unit/test_zcode_adapter.py
+++ b/tests/unit/test_zcode_adapter.py
@@ -351,6 +351,35 @@ def test_start_resumes_when_session_sessionid_present(zcode_session_cls):
     assert sess._cli_session_id == "sess_resumed_xyz"
 
 
+def test_runtime_model_api_key_uses_protocol_credential_shape(
+    zcode_session_cls, tmp_path, monkeypatch
+):
+    """runtimeModel.provider.apiKey must be an object accepted by ZCode Protocol.
+
+    ZCode 0.14.5 rejects a bare string with:
+    runtimeModel.provider.apiKey expected object, received string. That makes
+    session/resume fail and the runner fall back to session/create, losing the
+    workflow's intended main/review/test resume context.
+    """
+    config_path = tmp_path / ".zcode" / "cli" / "config.json"
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text(
+        json.dumps({"provider": {"zai": {"options": {"apiKey": "key-123"}}}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    sess = _make_session(zcode_session_cls, {})
+    sess.model = "glm-5.2"
+
+    runtime_model = sess._build_runtime_model()
+
+    assert runtime_model["provider"]["apiKey"] == {
+        "source": "inline",
+        "value": "key-123",
+    }
+
+
 def test_start_falls_back_to_create_when_resume_lacks_session(zcode_session_cls):
     """If resume response lacks session.sessionId, fall back to session/create."""
     requests = {


### PR DESCRIPTION
## Summary
- extract only visible assistant text from workflow agent streams
- drop leaked thinking/tool JSON from Claude and ZCode assistant output
- persist only the final visible assistant turn for workflow session details
- add regression coverage for final-turn extraction and ZCode plan JSON handling

## Validation
- python3 -m pytest tests/issues/716/test_agent_runner.py -q
- python3 -m pytest tests/issues/1140/test_plan_corruption_and_reporting.py -q
- python3 -m pytest tests/issues/1138/test_multi_protocol_runner.py -q
- python3 -m py_compile app/modules/workspace/autonomous/agent_runner.py