### PR TITLE
fix(issue-830): normalize tool-result role at fetch-script write boundary

### DIFF
--- a/scripts/shared/db.py
+++ b/scripts/shared/db.py
@@ -25,6 +25,31 @@ from shared import config
 DB_DIR = config.DB_DIR
 DB_PATH = config.DB_PATH
 
+# Canonical message roles. Variant tool-result spellings (toolResult,
+# tool_result) collapse to ROLE_TOOL so conversations produced by different
+# write paths never split on role spelling downstream (e.g. the
+# conversation-detail role filter). Kept self-contained here because the
+# scripts package ships standalone and must not import from app/.
+ROLE_TOOL = "tool"
+_TOOL_ROLE_ALIASES = {"tool", "toolresult", "tool_result"}
+
+
+def normalize_message_role(role: Optional[str]) -> str:
+    """Normalize a message role to its canonical form.
+
+    Tool-result spellings (``toolResult``, ``tool_result``) collapse to the
+    canonical ``tool``. Other roles pass through stripped/lower-cased.
+    ``None``/blank input becomes ``"unknown"``. Matching is case- and
+    whitespace-insensitive.
+    """
+    if not role or not str(role).strip():
+        return "unknown"
+    cleaned = str(role).strip().lower()
+    if cleaned in _TOOL_ROLE_ALIASES:
+        return ROLE_TOOL
+    return cleaned
+
+
 # Cache for database URL
 _db_url_cache = None
 
@@ -832,6 +857,13 @@ def save_message(
     conn = get_connection()
     cursor = conn.cursor()
 
+    # Normalize the role at the write boundary so variant tool-result
+    # spellings (toolResult / tool_result) collapse to the canonical "tool".
+    # Without this, conversations produced by the fetch scripts stored the
+    # OpenClaw-native "toolResult" while other paths stored "tool", and the
+    # conversation-detail role filter showed "no messages found" for one.
+    role = normalize_message_role(role)
+
     # Check if message already exists
     _execute(
         cursor,
@@ -1003,6 +1035,11 @@ def save_messages_batch(messages: list[dict], batch_size: int = 1000) -> int:
                 sender_id = msg.get("sender_id")
                 sender_name = msg.get("sender_name")
                 model = msg.get("model")
+
+                # Normalize the role at the write boundary (toolResult /
+                # tool_result -> tool) so variant spellings never reach the
+                # daily_messages role column. See normalize_message_role.
+                msg["role"] = normalize_message_role(msg.get("role"))
 
                 # Check for existing message
                 key = (date, tool_name, host_name, message_id)

--- a/scripts/shared/db.py
+++ b/scripts/shared/db.py
@@ -1039,6 +1039,9 @@ def save_messages_batch(messages: list[dict], batch_size: int = 1000) -> int:
                 # Normalize the role at the write boundary (toolResult /
                 # tool_result -> tool) so variant spellings never reach the
                 # daily_messages role column. See normalize_message_role.
+                # In-place mutation is deliberate: both the ON-CONFLICT update
+                # branch and the insert-new branch below read msg["role"], so
+                # mutating once here covers both without a second pass.
                 msg["role"] = normalize_message_role(msg.get("role"))
 
                 # Check for existing message

--- a/scripts/upload-to-central/shared/db.py
+++ b/scripts/upload-to-central/shared/db.py
@@ -25,6 +25,31 @@ from shared import config
 DB_DIR = config.DB_DIR
 DB_PATH = config.DB_PATH
 
+# Canonical message roles. Variant tool-result spellings (toolResult,
+# tool_result) collapse to ROLE_TOOL so conversations produced by different
+# write paths never split on role spelling downstream (e.g. the
+# conversation-detail role filter). Kept self-contained here because the
+# scripts package ships standalone and must not import from app/.
+ROLE_TOOL = "tool"
+_TOOL_ROLE_ALIASES = {"tool", "toolresult", "tool_result"}
+
+
+def normalize_message_role(role: Optional[str]) -> str:
+    """Normalize a message role to its canonical form.
+
+    Tool-result spellings (``toolResult``, ``tool_result``) collapse to the
+    canonical ``tool``. Other roles pass through stripped/lower-cased.
+    ``None``/blank input becomes ``"unknown"``. Matching is case- and
+    whitespace-insensitive.
+    """
+    if not role or not str(role).strip():
+        return "unknown"
+    cleaned = str(role).strip().lower()
+    if cleaned in _TOOL_ROLE_ALIASES:
+        return ROLE_TOOL
+    return cleaned
+
+
 # Cache for database URL
 _db_url_cache = None
 
@@ -709,6 +734,13 @@ def save_message(
     conn = get_connection()
     cursor = conn.cursor()
 
+    # Normalize the role at the write boundary so variant tool-result
+    # spellings (toolResult / tool_result) collapse to the canonical "tool".
+    # Without this, conversations produced by the fetch scripts stored the
+    # OpenClaw-native "toolResult" while other paths stored "tool", and the
+    # conversation-detail role filter showed "no messages found" for one.
+    role = normalize_message_role(role)
+
     # Check if message already exists
     _execute(
         cursor,
@@ -950,6 +982,11 @@ def save_messages_batch(messages: list[dict], batch_size: int = 1000) -> int:
                 sender_id = msg.get("sender_id")
                 sender_name = msg.get("sender_name")
                 model = msg.get("model")
+
+                # Normalize the role at the write boundary (toolResult /
+                # tool_result -> tool) so variant spellings never reach the
+                # daily_messages role column. See normalize_message_role.
+                msg["role"] = normalize_message_role(msg.get("role"))
 
                 # Check for existing message
                 key = (date, tool_name, host_name, message_id)

--- a/scripts/upload-to-central/shared/db.py
+++ b/scripts/upload-to-central/shared/db.py
@@ -986,6 +986,9 @@ def save_messages_batch(messages: list[dict], batch_size: int = 1000) -> int:
                 # Normalize the role at the write boundary (toolResult /
                 # tool_result -> tool) so variant spellings never reach the
                 # daily_messages role column. See normalize_message_role.
+                # In-place mutation is deliberate: both the ON-CONFLICT update
+                # branch and the insert-new branch below read msg["role"], so
+                # mutating once here covers both without a second pass.
                 msg["role"] = normalize_message_role(msg.get("role"))
 
                 # Check for existing message

--- a/tests/unit/test_message_role_normalization.py
+++ b/tests/unit/test_message_role_normalization.py
@@ -115,3 +115,160 @@ class TestSaveMessageWriteBoundary:
         repo.save_message(date="2026-06-21", tool_name="claude", message_id="m4", role="assistant")
         params = db.execute.call_args[0][1]
         assert params[5] == "assistant"
+
+
+class TestSharedDbWriteBoundary:
+    """scripts/shared/db.py is the write path the fetch scripts (fetch_openclaw,
+    fetch_claude, ...) use via save_message / save_messages_batch. It must
+    normalize tool-result spellings to ``tool`` before they reach
+    daily_messages, otherwise OpenClaw transcripts keep writing the native
+    ``toolResult`` and the conversation-detail role filter relapses into
+    "no messages found" (issue #830).
+    """
+
+    @pytest.fixture()
+    def shared_db(self, monkeypatch, tmp_path):
+        """Load scripts/shared/db.py against a file-backed SQLite database.
+
+        Adds scripts/ to sys.path so ``from shared import db`` resolves, and
+        points get_connection at a temp file DB with the daily_messages table
+        created. A file-backed DB survives save_message's conn.close() between
+        the write and the assertion (in-memory :memory: would not).
+        """
+        import os
+        import sqlite3
+        import sys
+
+        repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+        scripts_dir = os.path.join(repo_root, "scripts")
+        if scripts_dir not in sys.path:
+            sys.path.insert(0, scripts_dir)
+
+        import importlib
+
+        db = importlib.import_module("shared.db")
+
+        db_path = str(tmp_path / "test.db")
+
+        def _connect():
+            conn = sqlite3.connect(db_path)
+            conn.row_factory = sqlite3.Row
+            return conn
+
+        # Create the daily_messages table on the file-backed DB.
+        init_conn = _connect()
+        init_conn.execute(
+            """
+            CREATE TABLE daily_messages (
+                date TEXT,
+                tool_name TEXT,
+                host_name TEXT,
+                message_id TEXT,
+                parent_id TEXT,
+                role TEXT,
+                content TEXT,
+                full_entry TEXT,
+                tokens_used INTEGER DEFAULT 0,
+                input_tokens INTEGER DEFAULT 0,
+                output_tokens INTEGER DEFAULT 0,
+                model TEXT,
+                timestamp TEXT,
+                sender_id TEXT,
+                sender_name TEXT,
+                message_source TEXT,
+                feishu_conversation_id TEXT,
+                group_subject TEXT,
+                is_group_chat INTEGER,
+                agent_session_id TEXT,
+                conversation_id TEXT,
+                PRIMARY KEY (date, tool_name, host_name, message_id)
+            )
+            """
+        )
+        init_conn.commit()
+        init_conn.close()
+
+        monkeypatch.setattr(db, "get_connection", _connect)
+        monkeypatch.setattr(db, "is_postgresql", lambda: False)
+        return db, db_path
+
+    def _fetch_role(self, db_path, message_id):
+        import sqlite3
+
+        conn = sqlite3.connect(db_path)
+        conn.row_factory = sqlite3.Row
+        row = conn.execute(
+            "SELECT role FROM daily_messages WHERE message_id = ?", (message_id,)
+        ).fetchone()
+        conn.close()
+        return row["role"] if row else None
+
+    def test_save_message_normalizes_tool_result_alias(self, shared_db):
+        db, db_path = shared_db
+        db.save_message(
+            date="2026-06-21",
+            tool_name="openclaw",
+            message_id="m1",
+            role="toolResult",
+            content="result payload",
+        )
+        assert self._fetch_role(db_path, "m1") == "tool"
+
+    def test_save_message_normalizes_tool_result_snake_case(self, shared_db):
+        db, db_path = shared_db
+        db.save_message(
+            date="2026-06-21",
+            tool_name="openclaw",
+            message_id="m2",
+            role="tool_result",
+            content="result payload",
+        )
+        assert self._fetch_role(db_path, "m2") == "tool"
+
+    def test_save_message_preserves_canonical_tool_and_other_roles(self, shared_db):
+        db, db_path = shared_db
+        db.save_message(
+            date="2026-06-21", tool_name="openclaw", message_id="m3", role="tool", content="x"
+        )
+        db.save_message(
+            date="2026-06-21", tool_name="openclaw", message_id="m4", role="assistant", content="x"
+        )
+        assert self._fetch_role(db_path, "m3") == "tool"
+        assert self._fetch_role(db_path, "m4") == "assistant"
+
+    def test_save_messages_batch_normalizes_tool_result_alias(self, shared_db):
+        db, db_path = shared_db
+        messages = [
+            {
+                "date": "2026-06-21",
+                "tool_name": "openclaw",
+                "host_name": "localhost",
+                "message_id": "b1",
+                "role": "toolResult",
+                "content": "batch result",
+                "tokens_used": 0,
+            },
+            {
+                "date": "2026-06-21",
+                "tool_name": "openclaw",
+                "host_name": "localhost",
+                "message_id": "b2",
+                "role": "TOOL_RESULT",
+                "content": "batch result 2",
+                "tokens_used": 0,
+            },
+            {
+                "date": "2026-06-21",
+                "tool_name": "openclaw",
+                "host_name": "localhost",
+                "message_id": "b3",
+                "role": "user",
+                "content": "a question",
+                "tokens_used": 0,
+            },
+        ]
+        saved = db.save_messages_batch(messages, batch_size=10)
+        assert saved == 3
+        assert self._fetch_role(db_path, "b1") == "tool"
+        assert self._fetch_role(db_path, "b2") == "tool"
+        assert self._fetch_role(db_path, "b3") == "user"

--- a/tests/unit/test_message_role_normalization.py
+++ b/tests/unit/test_message_role_normalization.py
@@ -272,3 +272,57 @@ class TestSharedDbWriteBoundary:
         assert self._fetch_role(db_path, "b1") == "tool"
         assert self._fetch_role(db_path, "b2") == "tool"
         assert self._fetch_role(db_path, "b3") == "user"
+
+
+class TestRoleNormalizationParity:
+    """There are two normalize_message_role implementations that must stay in
+    lockstep: ``app/utils/roles.py`` (app write paths) and
+    ``scripts/shared/db.py`` (fetch-script write paths). The scripts package
+    ships standalone and cannot import from app/, so the duplication is
+    intentional. This parity guard locks them together: if a future alias (or
+    the ``"unknown"`` fallback) is added to one and not the other, the
+    conversation-detail role-filter bug silently recurs for one write path.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _load_shared_db(self):
+        import importlib
+        import os
+        import sys
+
+        repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+        scripts_dir = os.path.join(repo_root, "scripts")
+        if scripts_dir not in sys.path:
+            sys.path.insert(0, scripts_dir)
+        # Cache on the instance so parametrized cases reuse the import.
+        self._shared_db = importlib.import_module("shared.db")
+        yield
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            None,
+            "",
+            "   ",
+            "tool",
+            "Tool",
+            "TOOL",
+            " tool ",
+            "toolResult",
+            "ToolResult",
+            "tool_result",
+            "TOOL_RESULT",
+            "user",
+            "USER",
+            " Assistant ",
+            "system",
+            "developer",
+            "ToolUser",
+        ],
+    )
+    def test_app_and_shared_implementations_agree(self, raw):
+        app_result = normalize_message_role(raw)
+        shared_result = self._shared_db.normalize_message_role(raw)
+        assert app_result == shared_result, (
+            f"role normalization drift for {raw!r}: " f"app={app_result!r} shared={shared_result!r}"
+        )


### PR DESCRIPTION
## Summary

Fixes #830 (conversation-detail role filter showed the empty state for ToolResult on OpenClaw conversations).

### Root cause
`daily_messages.role` stored the same semantic "tool result" message under different spellings depending on the write path:

| Write path | Stored role |
|------------|-------------|
| `fetch_openclaw.py` | `toolResult` (OpenClaw-native, written verbatim via `msg.get("role")`) |
| `fetch_claude.py` / `fetch_qwen.py` | `system` (collapsed by their `role_map`) |
| live autonomous agent (`agent_runner`) | `tool` |

The conversation-detail role filter compared against one spelling, so conversations produced by another path surfaced as "no messages found" when filtered by ToolResult.

### What PR #1158 already did
- `app/utils/roles.py` — `normalize_message_role()`
- `app/repositories/message_repo.py` + `app/routes/remote.py` — normalize at the app write boundary
- migration `041_normalize_tool_result_role` — one-time backfill of historical rows
- `ConversationHistory.tsx` — filter tolerates both `tool` and legacy `toolResult`

### The gap this PR closes
PR #1158 missed the **fetch-script write path**. All fetch scripts write through `scripts/shared/db.py` (`save_message` / `save_messages_batch`), which stored `role` raw. `fetch_openclaw.py` kept writing the native `toolResult`, so the migration backfill + app-side normalization were undone by every new OpenClaw ingest — the bug kept recurring.

### Changes
- `scripts/shared/db.py`: add self-contained `normalize_message_role()` (scripts ship standalone, must not import from `app/`) and apply it at the write boundary in both `save_message` and `save_messages_batch`.
- `scripts/upload-to-central/shared/db.py`: identical change (this is an independent copy, not a symlink).
- Migration `041` remains the one-time backfill for historical rows.

### Scope (deliberate non-changes)
This PR (option A) only stops new `toolResult` rows. It does **not** change `fetch_claude.py` / `fetch_qwen.py`, which collapse tool messages to `system` at the source — fixing that would change the `system`/`tool` statistics split and require a non-reversible historical backfill that cannot distinguish "real system" from "collapsed tool". That is a separate decision.

## Validation
- `python3 -m pytest tests/unit/test_message_role_normalization.py -q` → **30 passed** (26 existing + 4 new `TestSharedDbWriteBoundary`)
- `python3 -m pytest tests/unit/ -q -k "message or role or repo"` → **469 passed**
- `python3 -m py_compile scripts/shared/db.py scripts/upload-to-central/shared/db.py`
- alembic head unchanged (single head `7bcf07ee658e`)
- pre-commit (black/isort/ruff/mypy/bandit/shebang) all pass; executable bits on both `db.py` preserved

## User-visible result after fix
- OpenClaw conversations: filter by "Tool Result" now shows the tool-return messages (previously empty).
- Live autonomous conversations: unchanged (already worked via PR #1158).
- Claude/Qwen historical conversations: tool messages remain under `system` (see Scope).