### PR TITLE
fix(manage): default audit-log date range to last 7 days (#838)

### DIFF
--- a/frontend/src/components/features/management/AuditLog.tsx
+++ b/frontend/src/components/features/management/AuditLog.tsx
@@ -8,10 +8,20 @@ import { useLanguage } from '@/store';
 import { t } from '@/i18n';
 import { Card, Button, Select, Loading, Error, EmptyState, Badge } from '@/components/common';
 import type { BadgeVariant } from '@/components/common';
-import { formatDateTime } from '@/utils';
+import { formatDateTime, getDefaultDateRange } from '@/utils';
 import type { AuditLogFilters } from '@/api';
 
 const ITEMS_PER_PAGE = 20;
+// Default audit-log filter window: the last 7 days. Used both on initial
+// load and after Reset so the page always queries a bounded range instead
+// of an unbounded one (issue #838). 7 days balances coverage and payload
+// size for an audit trail.
+const AUDIT_LOG_DEFAULT_RANGE_DAYS = 7;
+
+const getDefaultAuditFilters = (): AuditLogFilters => {
+  const { start, end } = getDefaultDateRange(AUDIT_LOG_DEFAULT_RANGE_DAYS);
+  return { start_date: start, end_date: end };
+};
 
 const ACTION_COLORS: Record<string, BadgeVariant> = {
   // Authentication
@@ -55,7 +65,7 @@ const ACTION_COLORS: Record<string, BadgeVariant> = {
 
 export const AuditLog: React.FC = () => {
   const language = useLanguage();
-  const [filters, setFilters] = useState<AuditLogFilters>({});
+  const [filters, setFilters] = useState<AuditLogFilters>(getDefaultAuditFilters);
   const [page, setPage] = useState(1);
 
   const { data, isLoading, isFetching, isError, error, refetch } = useAuditLogs({
@@ -131,12 +141,20 @@ export const AuditLog: React.FC = () => {
   );
 
   const handleFilterChange = (key: keyof AuditLogFilters, value: string) => {
-    setFilters((prev) => ({ ...prev, [key]: value || undefined }));
+    setFilters((prev) => {
+      const next = { ...prev, [key]: value || undefined };
+      // Clear an out-of-order end date, mirroring Messages.tsx, so the
+      // range stays valid as the user edits the date inputs.
+      if (next.start_date && next.end_date && next.end_date < next.start_date) {
+        next.end_date = undefined;
+      }
+      return next;
+    });
     setPage(1);
   };
 
   const handleReset = () => {
-    setFilters({});
+    setFilters(getDefaultAuditFilters());
     setPage(1);
   };
 


### PR DESCRIPTION
## Summary

Fixes #838. The 审计日志 page initialized its date filters as an empty object, so `start_date`/`end_date` were unset on entry — the user had to pick dates manually before any data loaded.

## Changes

All in `frontend/src/components/features/management/AuditLog.tsx`:

- Default the filter window to the **last 7 days** (today inclusive) on initial load and after Reset, via a new `getDefaultAuditFilters()` helper.
- Reuse the existing locale-correct `getDefaultDateRange(days)` helper, which builds `YYYY-MM-DD` from **local** date parts — so an early-morning access in a UTC+ timezone does not roll "today" back a day (the exact pitfall called out in the issue). This is the same helper ConversationHistory uses.
- Clear an out-of-order `end_date` while editing the date inputs, mirroring `Messages.tsx`.

## Rationale (matches issue design notes)

| Decision | Choice | Reason |
|---|---|---|
| Date computation | local date | UTC would shift today back a day for UTC+ users |
| Range | last 7 days | balances audit coverage and payload size |
| Reset behavior | restore default range | page always queries a bounded range |

## Verification

- `npm run typecheck` — passes
- `eslint AuditLog.tsx` — passes

Closes #838