### PR TITLE
Fix zcode workflow artifact extraction and session isolation

### DIFF
--- a/app/modules/workspace/autonomous/agent_runner.py
+++ b/app/modules/workspace/autonomous/agent_runner.py
@@ -12,6 +12,7 @@ remote execution.
 import json
 import logging
 import os
+import re
 import shutil
 import signal
 import subprocess
@@ -144,6 +145,11 @@ _TOOL_JSON_KEYS = frozenset(
     }
 )
 _NON_VISIBLE_BLOCK_TYPES = frozenset({"thinking", "tool_use", "tool_result", "reasoning"})
+_STRUCTURED_TAG_PATTERNS = {
+    "tldr": re.compile(r"^\s*TL;DR:\s*(.+?)\s*$", re.MULTILINE | re.IGNORECASE),
+    "test_status": re.compile(r"^\s*TEST_STATUS:\s*(.+?)\s*$", re.MULTILINE | re.IGNORECASE),
+    "ci_status": re.compile(r"^\s*CI_STATUS:\s*(.+?)\s*$", re.MULTILINE | re.IGNORECASE),
+}
 
 
 def _looks_like_tool_json(text: str) -> bool:
@@ -281,6 +287,55 @@ def _extract_visible_response_text(event_log: list[dict], fallback_text: str = "
     if assistant_turns:
         return "\n\n".join(assistant_turns)
     return fallback_text.strip()
+
+
+def _extract_structured_response_tags(text: str) -> dict[str, str]:
+    """Extract structured status tags from assistant-visible text."""
+    if not text:
+        return {}
+    tags: dict[str, str] = {}
+    for key, pattern in _STRUCTURED_TAG_PATTERNS.items():
+        match = pattern.search(text)
+        if match:
+            tags[key] = match.group(1).strip()
+    return tags
+
+
+def _build_agent_task_result(
+    *,
+    session_id: str,
+    tracking_session_id: str,
+    event_log: list[dict] | None = None,
+    fallback_text: str = "",
+    total_tokens: int = 0,
+    total_input_tokens: int = 0,
+    total_output_tokens: int = 0,
+    request_count: int = 0,
+    tool_calls: list | None = None,
+    success: bool = False,
+    error: str | None = None,
+    messages: list | None = None,
+) -> AgentTaskResult:
+    """Build a task result with both final-output and visible-text views."""
+    normalized_event_log = event_log or []
+    visible_text = _extract_visible_response_text(normalized_event_log, fallback_text)
+    final_text = _extract_final_response_text(normalized_event_log, fallback_text)
+    return AgentTaskResult(
+        session_id=session_id,
+        tracking_session_id=tracking_session_id,
+        response_text=final_text,
+        visible_response_text=visible_text,
+        structured_tags=_extract_structured_response_tags(visible_text),
+        messages=messages or [],
+        total_tokens=total_tokens,
+        total_input_tokens=total_input_tokens,
+        total_output_tokens=total_output_tokens,
+        request_count=request_count,
+        tool_calls=tool_calls or [],
+        success=success,
+        error=error,
+        event_log=normalized_event_log,
+    )
 
 
 class _ZcodeResultCollector:
@@ -1037,12 +1092,11 @@ class AutonomousAgentRunner:
             else session_id
         )
         if self._uses_sidebar_session_source(cli_tool, workspace_type) and not resolved_session_id:
-            return AgentTaskResult(
+            return _build_agent_task_result(
                 session_id="",
                 tracking_session_id=session_id,
-                response_text=_extract_visible_response_text(
-                    session.event_log, session.assistant_text
-                ),
+                event_log=session.event_log,
+                fallback_text=session.assistant_text,
                 total_tokens=session.total_tokens,
                 total_input_tokens=session.total_input_tokens,
                 total_output_tokens=session.total_output_tokens,
@@ -1050,16 +1104,14 @@ class AutonomousAgentRunner:
                 tool_calls=session.tool_calls,
                 success=False,
                 error="Failed to detect Claude sidebar session JSONL for autonomous task",
-                event_log=session.event_log,
             )
 
         if not completed:
-            return AgentTaskResult(
+            return _build_agent_task_result(
                 session_id=resolved_session_id,
                 tracking_session_id=session_id,
-                response_text=_extract_visible_response_text(
-                    session.event_log, session.assistant_text
-                ),
+                event_log=session.event_log,
+                fallback_text=session.assistant_text,
                 total_tokens=session.total_tokens,
                 total_input_tokens=session.total_input_tokens,
                 total_output_tokens=session.total_output_tokens,
@@ -1067,13 +1119,13 @@ class AutonomousAgentRunner:
                 tool_calls=session.tool_calls,
                 success=False,
                 error=f"Agent task timed out after {timeout}s",
-                event_log=session.event_log,
             )
 
-        return AgentTaskResult(
+        return _build_agent_task_result(
             session_id=resolved_session_id,
             tracking_session_id=session_id,
-            response_text=_extract_visible_response_text(session.event_log, session.assistant_text),
+            event_log=session.event_log,
+            fallback_text=session.assistant_text,
             total_tokens=session.total_tokens,
             total_input_tokens=session.total_input_tokens,
             total_output_tokens=session.total_output_tokens,
@@ -1081,7 +1133,6 @@ class AutonomousAgentRunner:
             tool_calls=session.tool_calls,
             success=session.error is None,
             error=session.error,
-            event_log=session.event_log,
         )
 
     def _create_workflow_session(
@@ -1303,12 +1354,11 @@ class AutonomousAgentRunner:
 
         cli_sid = zc_session._cli_session_id or session_id
         if not completed:
-            return AgentTaskResult(
+            return _build_agent_task_result(
                 session_id=cli_sid,
                 tracking_session_id=session_id,
-                response_text=_extract_visible_response_text(
-                    collector.event_log, collector.assistant_text
-                ),
+                event_log=collector.event_log,
+                fallback_text=collector.assistant_text,
                 total_tokens=collector.total_tokens,
                 total_input_tokens=collector.input_tokens,
                 total_output_tokens=collector.output_tokens,
@@ -1316,15 +1366,13 @@ class AutonomousAgentRunner:
                 tool_calls=collector.tool_calls,
                 success=False,
                 error=f"Agent task timed out after {timeout}s",
-                event_log=collector.event_log,
             )
 
-        return AgentTaskResult(
+        return _build_agent_task_result(
             session_id=cli_sid,
             tracking_session_id=session_id,
-            response_text=_extract_visible_response_text(
-                collector.event_log, collector.assistant_text
-            ),
+            event_log=collector.event_log,
+            fallback_text=collector.assistant_text,
             total_tokens=collector.total_tokens,
             total_input_tokens=collector.input_tokens,
             total_output_tokens=collector.output_tokens,
@@ -1332,7 +1380,6 @@ class AutonomousAgentRunner:
             tool_calls=collector.tool_calls,
             success=collector.error is None,
             error=collector.error,
-            event_log=collector.event_log,
         )
 
     def _run_single_shot(
@@ -1443,17 +1490,17 @@ class AutonomousAgentRunner:
         if not success:
             error = stderr_text or f"Command exited with code {proc.returncode}"
 
-        return AgentTaskResult(
+        return _build_agent_task_result(
             session_id=session_id,
             tracking_session_id=session_id,
-            response_text=response_text.strip(),
+            event_log=event_log,
+            fallback_text=response_text.strip(),
             total_tokens=total_tokens,
             total_input_tokens=input_tokens,
             total_output_tokens=output_tokens,
             request_count=1,
             success=success,
             error=error,
-            event_log=event_log,
         )
 
     @staticmethod
@@ -1567,10 +1614,10 @@ class AutonomousAgentRunner:
                                 if text:
                                     assistant_events.append({"type": "assistant", "text": text})
 
-                        return AgentTaskResult(
+                        return _build_agent_task_result(
                             session_id=session_id,
                             tracking_session_id=session_id,
-                            response_text=_extract_visible_response_text(assistant_events),
+                            event_log=assistant_events,
                             messages=messages,
                             total_tokens=session_data.get("total_tokens", 0),
                             total_input_tokens=session_data.get("total_input_tokens", 0),
@@ -1635,6 +1682,7 @@ class AutonomousAgentRunner:
                     self.session_manager.add_message(
                         session_id=session_id,
                         milestone_id=milestone_id,
+                        source="workflow_local",
                         role="tool",
                         content=(
                             json.dumps(tool_input)
@@ -1655,6 +1703,7 @@ class AutonomousAgentRunner:
                 self.session_manager.add_message(
                     session_id=session_id,
                     milestone_id=milestone_id,
+                    source="workflow_local",
                     role="assistant",
                     content=final_assistant.get("text", ""),
                     model=final_assistant.get("model"),
@@ -1672,6 +1721,7 @@ class AutonomousAgentRunner:
                 self.session_manager.add_message(
                     session_id=session_id,
                     milestone_id=milestone_id,
+                    source="workflow_local",
                     role="assistant",
                     content=result.response_text,
                     count_usage=False,
@@ -1683,6 +1733,7 @@ class AutonomousAgentRunner:
                 self.session_manager.add_message(
                     session_id=session_id,
                     milestone_id=milestone_id,
+                    source="workflow_local",
                     role="tool",
                     content=(
                         json.dumps(tool_input)

--- a/app/modules/workspace/autonomous/agent_runner.py
+++ b/app/modules/workspace/autonomous/agent_runner.py
@@ -295,9 +295,9 @@ def _extract_structured_response_tags(text: str) -> dict[str, str]:
         return {}
     tags: dict[str, str] = {}
     for key, pattern in _STRUCTURED_TAG_PATTERNS.items():
-        match = pattern.search(text)
-        if match:
-            tags[key] = match.group(1).strip()
+        matches = list(pattern.finditer(text))
+        if matches:
+            tags[key] = matches[-1].group(1).strip()
     return tags
 
 

--- a/app/modules/workspace/autonomous/models.py
+++ b/app/modules/workspace/autonomous/models.py
@@ -339,6 +339,8 @@ class AgentTaskResult:
     session_id: str = ""
     tracking_session_id: str = ""
     response_text: str = ""
+    visible_response_text: str = ""
+    structured_tags: dict = field(default_factory=dict)
     messages: list = field(default_factory=list)
     total_tokens: int = 0
     total_input_tokens: int = 0

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -617,6 +617,69 @@ class AutonomousOrchestrator:
         return match.group(1).strip()[:200] if match else ""
 
     @staticmethod
+    def _artifact_visible_text(result: Optional[AgentTaskResult]) -> str:
+        """Return all user-visible assistant turns for a task result."""
+        if not result:
+            return ""
+        return (getattr(result, "visible_response_text", "") or result.response_text or "").strip()
+
+    @classmethod
+    def _sanitize_artifact_text(cls, text: str) -> str:
+        """Drop leaked process/JSON noise and collapse repeated adjacent blocks."""
+        if not text:
+            return ""
+        cleaned = cls._clean_agent_text(text)
+        cleaned = re.sub(
+            r"(?im)^\s*(The user wants me to|user wants me to|Let me\b|I need to:)\b.*$",
+            "",
+            cleaned,
+        )
+        cleaned = re.sub(
+            r'(?im)^\s*\{.*"(description|prompt|tool|command|subagent_type|file_path)".*\}\s*$',
+            "",
+            cleaned,
+        )
+        paragraphs = [p.strip() for p in re.split(r"\n\s*\n", cleaned) if p.strip()]
+        deduped: list[str] = []
+        last_norm = ""
+        for paragraph in paragraphs:
+            norm = re.sub(r"\s+", " ", paragraph)
+            if norm == last_norm:
+                continue
+            deduped.append(paragraph)
+            last_norm = norm
+        return "\n\n".join(deduped).strip()
+
+    @classmethod
+    def _artifact_text(cls, result: Optional[AgentTaskResult]) -> str:
+        """Return the milestone/comment artifact text for a task result."""
+        if not result:
+            return ""
+        primary = (result.response_text or "").strip()
+        if primary:
+            return cls._sanitize_artifact_text(primary)
+        return cls._sanitize_artifact_text(cls._artifact_visible_text(result))
+
+    @classmethod
+    def _artifact_tldr(cls, result: Optional[AgentTaskResult]) -> str:
+        """Prefer structured/extracted TL;DR over raw string slicing."""
+        if not result:
+            return ""
+        structured = getattr(result, "structured_tags", {}) or {}
+        if structured.get("tldr"):
+            return structured["tldr"][:200]
+        return cls._extract_tldr(cls._artifact_visible_text(result) or result.response_text or "")
+
+    @staticmethod
+    def _artifact_status_tag(result: Optional[AgentTaskResult], key: str) -> str:
+        """Read structured status tags extracted by the runner."""
+        if not result:
+            return ""
+        structured = getattr(result, "structured_tags", {}) or {}
+        value = structured.get(key, "")
+        return value.strip() if isinstance(value, str) else ""
+
+    @staticmethod
     def _build_progress_report_tldr(
         dev_round: int,
         diff_stats: dict,
@@ -1086,6 +1149,8 @@ class AutonomousOrchestrator:
             result.error or f"Transient API error not resolved after retries: {err_snippet}"
         )
         result.response_text = ""  # don't let callers store the error body
+        result.visible_response_text = ""
+        result.structured_tags = {}
 
     def _write_phase_usage(self, milestone_id: str, result: AgentTaskResult) -> None:
         """Write this call's token/request increment to its milestone."""
@@ -1605,14 +1670,14 @@ class AutonomousOrchestrator:
         self._accumulate_tokens(result)
 
         # Store plan
-        plan_text = result.response_text or ""
+        plan_text = self._artifact_text(result)
         self.repo.update_milestone(
             ms.get("milestone_id", ""),
             {
                 "status": "completed" if result.success else "failed",
                 "plan_content": plan_text,
                 "result_summary": plan_text[:200],
-                "tldr": self._extract_tldr(plan_text),
+                "tldr": self._artifact_tldr(result),
                 "session_id": result.session_id,
                 "error_message": result.error or "",
             },
@@ -1635,7 +1700,7 @@ class AutonomousOrchestrator:
                     {
                         "timeout": planning_timeout,
                         "tokens_used": result.total_tokens,
-                        "partial_plan": (result.response_text or "")[:500],
+                        "partial_plan": (self._artifact_visible_text(result) or plan_text)[:500],
                     },
                 )
             else:
@@ -1649,7 +1714,7 @@ class AutonomousOrchestrator:
             self._post_github_comment(
                 gh,
                 issue_number,
-                f"## 📋 Implementation Plan (Round {round_num})\n\n{self._clean_agent_text(plan_text)}",
+                f"## 📋 Implementation Plan (Round {round_num})\n\n{plan_text}",
                 context="plan",
             )
 
@@ -1694,7 +1759,7 @@ class AutonomousOrchestrator:
 
         self._accumulate_tokens(review_result)
 
-        review_text = review_result.response_text or ""
+        review_text = self._artifact_text(review_result)
 
         # Detect empty review output (agent produced no meaningful content)
         if not review_text.strip():
@@ -1714,7 +1779,7 @@ class AutonomousOrchestrator:
                 "status": "completed" if review_result.success else "failed",
                 "review_content": review_text,
                 "result_summary": review_text[:200],
-                "tldr": self._extract_tldr(review_text),
+                "tldr": self._artifact_tldr(review_result),
                 "review_session_id": review_result.session_id,
             },
         )
@@ -1724,7 +1789,7 @@ class AutonomousOrchestrator:
             self._post_github_comment(
                 gh,
                 issue_number,
-                f"## 🔍 Plan Review (Round {round_num})\n\n{self._clean_agent_text(review_text)}",
+                f"## 🔍 Plan Review (Round {round_num})\n\n{review_text}",
                 context="plan-review",
             )
 
@@ -1800,11 +1865,10 @@ class AutonomousOrchestrator:
                     milestone_id=plan_final_ms.get("milestone_id", ""),
                 )
                 self._accumulate_tokens(finalize_result)
-                if finalize_result.success and finalize_result.response_text:
-                    final_plan = finalize_result.response_text
+                if finalize_result.success:
+                    final_plan = self._artifact_text(finalize_result) or final_plan
 
-            # Clean up agent intro text (e.g. "我来分析代码库...")
-            final_plan = self._clean_agent_text(final_plan)
+            final_plan = self._sanitize_artifact_text(final_plan)
 
             # Record the authoritative final plan on the milestone. When the
             # review carried no suggestions, the existing plan is the final plan
@@ -2052,10 +2116,8 @@ class AutonomousOrchestrator:
                     {
                         "status": "failed",
                         "session_id": result.session_id,
-                        "result_summary": (
-                            result.response_text[:300] if result.response_text else ""
-                        ),
-                        "tldr": self._extract_tldr(result.response_text),
+                        "result_summary": self._artifact_text(result)[:300],
+                        "tldr": self._artifact_tldr(result),
                         "error_message": "Agent produced no code changes (commit SHA unchanged)",
                     },
                 )
@@ -2072,8 +2134,8 @@ class AutonomousOrchestrator:
             {
                 "status": "completed" if result.success else "failed",
                 "session_id": result.session_id,
-                "result_summary": result.response_text[:300] if result.response_text else "",
-                "tldr": self._extract_tldr(result.response_text),
+                "result_summary": self._artifact_text(result)[:300],
+                "tldr": self._artifact_tldr(result),
                 "commit_shas": json.dumps([commit_sha] if commit_sha else []),
                 "diff_stats": json.dumps(diff_stats),
                 "error_message": result.error or "",
@@ -2172,18 +2234,20 @@ class AutonomousOrchestrator:
 
         self._accumulate_tokens(test_result)
 
+        test_summary = self._artifact_text(test_result)
+        test_visible_text = self._artifact_visible_text(test_result)
         self.repo.update_milestone(
             test_ms.get("milestone_id", ""),
             {
                 "status": "completed" if test_result.success else "failed",
                 "session_id": test_result.session_id,
-                "result_summary": (test_result.response_text if test_result.response_text else ""),
-                "tldr": self._extract_tldr(test_result.response_text),
+                "result_summary": test_summary,
+                "tldr": self._artifact_tldr(test_result),
             },
         )
 
         # Detect if tests were actually skipped (agent couldn't run them)
-        test_response_text = test_result.response_text or ""
+        test_response_text = test_visible_text or test_summary
         _skipped_markers = ["TEST_STATUS: skipped", "测试被跳过", "跳过测试"]
         _skipped_keywords = [
             "pytest 未安装",
@@ -2214,8 +2278,10 @@ class AutonomousOrchestrator:
             "test",
         ]
         has_test_result = any(kw in test_response_text for kw in _test_result_keywords)
+        test_status_tag = self._artifact_status_tag(test_result, "test_status").lower()
         tests_actually_skipped = (
-            any(m in test_response_text for m in _skipped_markers)
+            test_status_tag == "skipped"
+            or any(m in test_response_text for m in _skipped_markers)
             or (test_result.success and has_skip_keyword)
             or (test_result.success and not has_test_result)
         )
@@ -2223,7 +2289,6 @@ class AutonomousOrchestrator:
         # Post test results to issue
         issue_number = wf.get("github_issue_number")
         if issue_number:
-            test_summary = self._clean_agent_text(test_response_text)
             if tests_actually_skipped:
                 status_line = "⚠️ Tests were not actually run — see details below"
             elif test_result.success:
@@ -2300,7 +2365,7 @@ class AutonomousOrchestrator:
                 return
 
         # Situation B: test agent succeeded but reported unfixable failures
-        test_response = test_result.response_text or ""
+        test_response = self._artifact_visible_text(test_result) or self._artifact_text(test_result)
         _unfixable_marker = "[UNFIXABLE]"
         has_unfixable = _unfixable_marker in test_response
         if not has_unfixable:
@@ -2577,14 +2642,14 @@ class AutonomousOrchestrator:
 
         self._accumulate_tokens(review_result)
 
-        review_text = review_result.response_text or ""
+        review_text = self._artifact_text(review_result)
         self.repo.update_milestone(
             review_ms.get("milestone_id", ""),
             {
                 "status": "completed" if review_result.success else "failed",
                 "review_content": review_text,
                 "review_session_id": review_result.session_id,
-                "tldr": self._extract_tldr(review_text),
+                "tldr": self._artifact_tldr(review_result),
             },
         )
 
@@ -2593,7 +2658,7 @@ class AutonomousOrchestrator:
             self._post_github_comment(
                 gh,
                 pr_number,
-                f"## 🔍 Code Review (Round {round_num})\n\n{self._clean_agent_text(review_text)}",
+                f"## 🔍 Code Review (Round {round_num})\n\n{review_text}",
                 is_pr=True,
                 context="code-review",
             )
@@ -2651,14 +2716,14 @@ class AutonomousOrchestrator:
                 milestone_id=summary_ms.get("milestone_id", ""),
             )
             self._accumulate_tokens(summary_result)
-            summary_text = self._clean_agent_text(summary_result.response_text or "")
+            summary_text = self._artifact_text(summary_result)
             self.repo.update_milestone(
                 summary_ms.get("milestone_id", ""),
                 {
                     "status": "completed" if summary_result.success else "failed",
                     "review_content": summary_text,
                     "result_summary": summary_text[:200],
-                    "tldr": self._extract_tldr(summary_text),
+                    "tldr": self._artifact_tldr(summary_result),
                 },
             )
 
@@ -2783,14 +2848,15 @@ class AutonomousOrchestrator:
                     "session_id": fix_result.session_id,
                     "commit_shas": json.dumps([commit_sha] if commit_sha else []),
                     "diff_stats": json.dumps(diff_stats),
-                    "tldr": self._extract_tldr(fix_result.response_text or ""),
+                    "result_summary": self._artifact_text(fix_result)[:200],
+                    "tldr": self._artifact_tldr(fix_result),
                 },
             )
 
             if pr_number:
                 # Extract fix summary from agent response in full; GitHub comments
                 # render long content fine (capped by _post_github_comment if huge).
-                fix_summary = self._clean_agent_text(fix_result.response_text or "")
+                fix_summary = self._artifact_text(fix_result)
                 comment = (
                     f"## ✅ Addressed Review Feedback (Round {round_num})\n\n"
                     f"### Changes Made\n{fix_summary}\n\n"
@@ -2798,7 +2864,11 @@ class AutonomousOrchestrator:
                 if commit_sha:
                     comment += f"- Commit: `{commit_sha[:8]}`\n"
                 # Note pre-existing CI failures if fix agent identified them.
-                if self._is_pre_existing_ci_failure(fix_result.response_text or ""):
+                if self._artifact_status_tag(
+                    fix_result, "ci_status"
+                ).lower() == "pre-existing" or self._is_pre_existing_ci_failure(
+                    self._artifact_visible_text(fix_result)
+                ):
                     comment += (
                         "\n> ⚠️ 部分 CI 检查失败，" "但经分析为预先存在的问题，非本 PR 引入。\n"
                     )
@@ -3314,7 +3384,7 @@ class AutonomousOrchestrator:
                     milestone_id=conflict_ms.get("milestone_id", ""),
                 )
                 self._accumulate_tokens(result)
-                response_text = result.response_text or ""
+                response_text = self._artifact_text(result)
                 self.repo.update_milestone(
                     conflict_ms.get("milestone_id", ""),
                     {
@@ -3322,7 +3392,7 @@ class AutonomousOrchestrator:
                         "session_id": result.session_id,
                         "error_message": result.error or "",
                         "result_summary": response_text,
-                        "tldr": self._extract_tldr(response_text),
+                        "tldr": self._artifact_tldr(result),
                     },
                 )
 

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -630,7 +630,7 @@ class AutonomousOrchestrator:
             return ""
         cleaned = cls._clean_agent_text(text)
         cleaned = re.sub(
-            r"(?im)^\s*(The user wants me to|user wants me to|Let me\b|I need to:)\b.*$",
+            r"(?im)^\s*(The user wants me to|user wants me to)\b.*$",
             "",
             cleaned,
         )

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -630,7 +630,7 @@ class AutonomousOrchestrator:
             return ""
         cleaned = cls._clean_agent_text(text)
         cleaned = re.sub(
-            r"(?im)^\s*(The user wants me to|user wants me to)\b.*$",
+            r"(?im)^\s*(The user wants me to|user wants me to|Let me\b|I need to:)\b.*$",
             "",
             cleaned,
         )

--- a/app/modules/workspace/session_manager.py
+++ b/app/modules/workspace/session_manager.py
@@ -20,6 +20,19 @@ from app.utils.tool_names import normalize_tool_name
 logger = logging.getLogger(__name__)
 
 
+def _sanitize_text_value(text: Optional[str]) -> Optional[str]:
+    """Remove NUL / invalid UTF-8 surrogate data before persistence."""
+    if text is None:
+        return None
+    if "\x00" in text:
+        text = text.replace("\x00", "")
+    try:
+        text.encode("utf-8")
+        return text
+    except UnicodeEncodeError:
+        return text.encode("utf-8", errors="surrogatepass").decode("utf-8", errors="replace")
+
+
 # Parameter placeholder for SQL queries
 def _param() -> str:
     """Get the correct parameter placeholder for the current database."""
@@ -63,6 +76,7 @@ class SessionMessage:
     timestamp: Optional[datetime] = None
     metadata: dict[str, Any] = field(default_factory=dict)
     milestone_id: str = ""
+    source: str = ""
 
     def to_dict(self) -> dict:
         """Convert to dictionary."""
@@ -76,6 +90,7 @@ class SessionMessage:
             "timestamp": _format_dt(self.timestamp),
             "metadata": self.metadata,
             "milestone_id": self.milestone_id,
+            "source": self.source,
         }
 
     @classmethod
@@ -91,6 +106,7 @@ class SessionMessage:
             timestamp=datetime.fromisoformat(data["timestamp"]) if data.get("timestamp") else None,
             metadata=data.get("metadata", {}),
             milestone_id=data.get("milestone_id", ""),
+            source=data.get("source", ""),
         )
 
 
@@ -320,6 +336,7 @@ class SessionManager:
                 timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                 metadata TEXT,
                 milestone_id TEXT DEFAULT '',
+                source TEXT DEFAULT '',
                 FOREIGN KEY (session_id) REFERENCES agent_sessions(session_id)
             )
         """
@@ -383,6 +400,11 @@ class SessionManager:
         # Add milestone_id column to session_messages if not present (migration 061)
         try:
             cursor.execute("ALTER TABLE session_messages ADD COLUMN milestone_id TEXT DEFAULT ''")
+        except Exception:
+            pass  # Column already exists
+
+        try:
+            cursor.execute("ALTER TABLE session_messages ADD COLUMN source TEXT DEFAULT ''")
         except Exception:
             pass  # Column already exists
 
@@ -516,7 +538,10 @@ class SessionManager:
         return session
 
     def get_session(
-        self, session_id: str, include_messages: bool = False
+        self,
+        session_id: str,
+        include_messages: bool = False,
+        message_milestone_id: Optional[str] = None,
     ) -> Optional[AgentSession]:
         """
         Get a session by ID.
@@ -524,6 +549,7 @@ class SessionManager:
         Args:
             session_id: Session ID to retrieve.
             include_messages: Whether to include messages.
+            message_milestone_id: Optional milestone filter for session messages.
 
         Returns:
             AgentSession or None if not found.
@@ -541,14 +567,16 @@ class SessionManager:
         session = self._row_to_session(row)
 
         if include_messages:
-            cursor.execute(
-                f"""
+            query = f"""
                 SELECT * FROM session_messages
                 WHERE session_id = {_param()}
-                ORDER BY timestamp ASC
-            """,
-                (session_id,),
-            )
+            """
+            params: list[Any] = [session_id]
+            if message_milestone_id is not None:
+                query += f" AND milestone_id = {_param()}"
+                params.append(message_milestone_id)
+            query += " ORDER BY timestamp ASC"
+            cursor.execute(query, params)
             message_rows = cursor.fetchall()
             session.messages = [self._row_to_message(msg_row) for msg_row in message_rows]
 
@@ -734,7 +762,11 @@ class SessionManager:
         return success
 
     def get_messages(
-        self, session_id: str, limit: Optional[int] = None, before_id: Optional[int] = None
+        self,
+        session_id: str,
+        limit: Optional[int] = None,
+        before_id: Optional[int] = None,
+        milestone_id: Optional[str] = None,
     ) -> list[SessionMessage]:
         """
         Get messages for a session.
@@ -743,6 +775,7 @@ class SessionManager:
             session_id: Session ID.
             limit: Optional limit on number of messages.
             before_id: Get messages before this ID.
+            milestone_id: Optional milestone filter.
 
         Returns:
             List of SessionMessage objects.
@@ -752,6 +785,10 @@ class SessionManager:
 
         query = f"SELECT * FROM session_messages WHERE session_id = {_param()}"
         params: list[Any] = [session_id]
+
+        if milestone_id is not None:
+            query += f" AND milestone_id = {_param()}"
+            params.append(milestone_id)
 
         if before_id:
             query += f" AND id < {_param()}"
@@ -778,6 +815,7 @@ class SessionManager:
         model: Optional[str] = None,
         metadata: Optional[dict[str, Any]] = None,
         milestone_id: str = "",
+        source: str = "",
         count_usage: bool = True,
     ) -> Optional[SessionMessage]:
         """
@@ -790,6 +828,7 @@ class SessionManager:
             tokens_used: Tokens consumed by this message.
             model: Optional model name.
             metadata: Optional metadata dict.
+            source: Message source tag for downstream filtering.
             count_usage: When True (default), accumulate request_count (assistant
                 messages) and total_tokens on the session. Autonomous local runs
                 pass False because the agent runner owns those counters via
@@ -815,17 +854,19 @@ class SessionManager:
         message = SessionMessage(
             session_id=session_id,
             role=role,
-            content=content,
+            content=_sanitize_text_value(content) or "",
             tokens_used=tokens_used,
             model=model,
             timestamp=now,
             metadata=metadata or {},
+            source=source,
         )
 
         cursor.execute(
             f"""
-            INSERT INTO session_messages (session_id, role, content, tokens_used, model, timestamp, metadata, milestone_id)
-            VALUES ({_params(8)})
+            INSERT INTO session_messages
+            (session_id, role, content, tokens_used, model, timestamp, metadata, milestone_id, source)
+            VALUES ({_params(9)})
         """,
             (
                 message.session_id,
@@ -834,8 +875,9 @@ class SessionManager:
                 message.tokens_used,
                 message.model,
                 message.timestamp.isoformat() if message.timestamp else None,
-                json.dumps(message.metadata),
+                _sanitize_text_value(json.dumps(message.metadata)),
                 milestone_id,
+                source,
             ),
         )
 
@@ -1321,6 +1363,7 @@ class SessionManager:
             timestamp=parse_datetime(get_value("timestamp")),
             metadata=json.loads(get_value("metadata")) if get_value("metadata") else {},
             milestone_id=get_value("milestone_id") or "",
+            source=get_value("source") or "",
         )
 
 
@@ -1362,6 +1405,8 @@ def get_ddl_statements() -> list[str]:
             model TEXT,
             timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
             metadata TEXT,
+            milestone_id TEXT DEFAULT '',
+            source TEXT DEFAULT '',
             FOREIGN KEY (session_id) REFERENCES agent_sessions(session_id)
         )
         """,

--- a/app/routes/autonomous.py
+++ b/app/routes/autonomous.py
@@ -1142,16 +1142,11 @@ def get_milestone_session(workflow_id, milestone_id):
     from app.modules.workspace.session_manager import SessionManager
 
     sm = SessionManager()
-    session_data = sm.get_session(session_id, include_messages=True)
-
-    # Multiple milestones may share a session (main/review/test lines via
-    # --resume); surface only this milestone's own messages.
-    if session_data and getattr(session_data, "messages", None):
-        session_data.messages = [
-            m
-            for m in session_data.messages
-            if (getattr(m, "milestone_id", "") or "") == milestone_id
-        ]
+    session_data = sm.get_session(
+        session_id,
+        include_messages=True,
+        message_milestone_id=milestone_id,
+    )
 
     return jsonify({"success": True, "session": session_data})
 

--- a/app/routes/remote.py
+++ b/app/routes/remote.py
@@ -1598,6 +1598,7 @@ def agent_message():
                             tokens_used=tokens_used,
                             model=msg_model,
                             metadata=metadata,
+                            source="remote_sync",
                         )
                     except Exception as e:
                         logger.debug("Failed to add session_message: %s", e)

--- a/frontend/src/components/work/WorkflowTimeline.css
+++ b/frontend/src/components/work/WorkflowTimeline.css
@@ -393,6 +393,7 @@
 .timeline-state-banner__message {
   margin-top: 4px;
   color: var(--text-secondary);
+  font-size: 0.82rem;
   line-height: 1.55;
   word-break: break-word;
 }
@@ -402,6 +403,10 @@
   flex-wrap: wrap;
   gap: 12px;
   flex-shrink: 0;
+}
+
+.timeline-state-banner__actions .timeline-inline-link {
+  font-size: 0.82rem;
 }
 
 .timeline-body {

--- a/frontend/src/components/work/WorkflowTimeline.tsx
+++ b/frontend/src/components/work/WorkflowTimeline.tsx
@@ -1560,6 +1560,12 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
                   {workflow.cli_tool}
                 </span>
               )}
+              {workflow.model && (
+                <span className="timeline-chip timeline-chip--neutral">
+                  <i className="bi bi-cpu me-1"></i>
+                  {workflow.model}
+                </span>
+              )}
               {definitionSnapshot && (
                 <button
                   type="button"
@@ -1635,6 +1641,12 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
                 <span className="timeline-chip timeline-chip--info">
                   <i className="bi bi-diagram-3 me-1"></i>
                   {t('autoForkedWorkflows', language)} ({forks.length})
+                </span>
+              )}
+              {workflow.dev_round > 1 && (
+                <span className="timeline-chip timeline-chip--neutral">
+                  <i className="bi bi-arrow-repeat me-1"></i>
+                  R{workflow.dev_round}
                 </span>
               )}
             </div>
@@ -1745,12 +1757,6 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
               {workflowPhaseLabel}
             </span>
           </div>
-          {workflow.model && (
-            <div className="timeline-meta-item">
-              <span className="timeline-meta-item__label">{t('autoModel', language)}</span>
-              <span className="timeline-meta-item__value">{workflow.model}</span>
-            </div>
-          )}
           <div className="timeline-meta-item timeline-meta-item--start">
             <span className="timeline-meta-item__label">{t('autoStartTime', language)}</span>
             <span className="timeline-meta-item__value">
@@ -1771,12 +1777,6 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
             <span className="timeline-meta-item__label">{t('totalRequests', language)}</span>
             <span className="timeline-meta-item__value">{workflow.total_requests}</span>
           </div>
-          {workflow.dev_round > 1 && (
-            <div className="timeline-meta-item">
-              <span className="timeline-meta-item__label">{t('autoDevRoundLabel', language)}</span>
-              <span className="timeline-meta-item__value">{workflow.dev_round}</span>
-            </div>
-          )}
         </div>
 
         <div className="timeline-output-rail">

--- a/frontend/src/components/work/WorkflowTimeline.tsx
+++ b/frontend/src/components/work/WorkflowTimeline.tsx
@@ -1645,8 +1645,7 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
               )}
               {workflow.dev_round > 1 && (
                 <span className="timeline-chip timeline-chip--neutral">
-                  <i className="bi bi-arrow-repeat me-1"></i>
-                  R{workflow.dev_round}
+                  <i className="bi bi-arrow-repeat me-1"></i>R{workflow.dev_round}
                 </span>
               )}
             </div>

--- a/migrations/versions/20260622_001_add_session_message_source.py
+++ b/migrations/versions/20260622_001_add_session_message_source.py
@@ -1,0 +1,49 @@
+"""Add source column to session_messages
+
+Separates workflow-local persisted messages from transcript sync/fetch rows so
+autonomous milestone/session detail views can filter raw importer data.
+
+Revision ID: 20260622_001_session_message_source
+Revises: 20260621_193547_merge_041_064
+Create Date: 2026-06-22
+"""
+
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260622_001_session_message_source"
+down_revision: Union[str, None] = "20260621_193547_merge_041_064"
+branch_labels = None
+depends_on = None
+
+
+def _column_exists(conn, table: str, column: str) -> bool:
+    if conn.dialect.name == "postgresql":
+        result = conn.execute(
+            sa.text(
+                "SELECT COUNT(*) FROM information_schema.columns "
+                "WHERE table_name = :table AND column_name = :column"
+            ),
+            {"table": table, "column": column},
+        )
+        return result.scalar() > 0
+
+    result = conn.execute(sa.text(f"PRAGMA table_info({table})"))
+    return any(row[1] == column for row in result.fetchall())
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    if not _column_exists(conn, "session_messages", "source"):
+        op.add_column(
+            "session_messages",
+            sa.Column("source", sa.Text, server_default="", nullable=False),
+        )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    if _column_exists(conn, "session_messages", "source"):
+        op.drop_column("session_messages", "source")

--- a/schema/schema-postgres.sql
+++ b/schema/schema-postgres.sql
@@ -558,7 +558,9 @@ CREATE TABLE session_messages (
     tokens_used integer DEFAULT 0,
     model text,
     "timestamp" timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
-    metadata text
+    metadata text,
+    milestone_id text DEFAULT ''::text NOT NULL,
+    source text DEFAULT ''::text NOT NULL
 );
 
 CREATE SEQUENCE session_messages_id_seq

--- a/schema/schema-sqlite.sql
+++ b/schema/schema-sqlite.sql
@@ -366,7 +366,9 @@ CREATE TABLE session_messages (
  tokens_used integer DEFAULT 0,
  model text,
  "timestamp" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
- metadata text
+ metadata text,
+ milestone_id text DEFAULT '',
+ source text DEFAULT ''
 );
 
 CREATE TABLE sessions (

--- a/scripts/fetch_zcode.py
+++ b/scripts/fetch_zcode.py
@@ -649,6 +649,10 @@ def fetch_and_save(
             try:
                 from shared.db import _execute, _placeholder, get_connection
 
+                # Pre-filter workflow-backed session_ids before any usage or
+                # transcript aggregation. This keeps imported desktop sessions
+                # from inflating per-day usage when the same workflow is already
+                # persisted by the app itself.
                 conn = get_connection()
                 cursor = conn.cursor()
                 try:
@@ -701,6 +705,10 @@ def fetch_and_save(
         try:
             from shared.db import _execute, _placeholder, get_connection
 
+            # Keep a second transcript-level filter even after candidate
+            # pre-filtering. It protects against partial/failed pre-filter
+            # queries, concurrent rows added while scanning, and any messages
+            # that arrive from helper paths not sourced from ``candidates``.
             candidate_ids = sorted(
                 {
                     str(m.get("agent_session_id", "")).strip()

--- a/scripts/fetch_zcode.py
+++ b/scripts/fetch_zcode.py
@@ -392,11 +392,22 @@ def update_agent_sessions_stats(messages: list) -> int:
         for session_id, stats in session_stats.items():
             try:
                 check_sql = (
-                    f"SELECT id, user_id FROM agent_sessions WHERE session_id = {placeholder}"
+                    f"SELECT id, user_id, session_type FROM agent_sessions "
+                    f"WHERE session_id = {placeholder}"
                 )
                 _execute(cursor, check_sql, (session_id,))
                 session_row = cursor.fetchone()
                 _is_new_session = False
+
+                session_type = ""
+                if session_row:
+                    session_type = (
+                        session_row["session_type"]
+                        if isinstance(session_row, dict) or hasattr(session_row, "keys")
+                        else session_row[2]
+                    ) or ""
+                if session_type == "workflow":
+                    continue
 
                 if not session_row:
                     first_msg = stats["messages"][0] if stats["messages"] else {}
@@ -494,8 +505,8 @@ def update_agent_sessions_stats(messages: list) -> int:
                         if not existing:
                             insert_sql = f"""
                                 INSERT INTO session_messages
-                                (session_id, role, content, tokens_used, model, timestamp, metadata)
-                                VALUES ({placeholder}, {placeholder}, {placeholder}, {placeholder}, {placeholder}, {placeholder}, {placeholder})
+                                (session_id, role, content, tokens_used, model, timestamp, metadata, source)
+                                VALUES ({placeholder}, {placeholder}, {placeholder}, {placeholder}, {placeholder}, {placeholder}, {placeholder}, {placeholder})
                             """
                             metadata = {
                                 "message_id": msg_id,
@@ -513,6 +524,7 @@ def update_agent_sessions_stats(messages: list) -> int:
                                     msg.get("model"),
                                     timestamp,
                                     json.dumps(metadata, ensure_ascii=False),
+                                    "zcode_fetch",
                                 ),
                             )
                             messages_inserted += 1
@@ -633,6 +645,37 @@ def fetch_and_save(
         label = system_account or "current user"
         print(f"\nProcessing ZCode DB for {label}: {db_path}")
         candidates = _iter_candidate_sessions(db_path, days, recent)
+        if candidates:
+            try:
+                from shared.db import _execute, _placeholder, get_connection
+
+                conn = get_connection()
+                cursor = conn.cursor()
+                try:
+                    placeholder = _placeholder()
+                    candidate_ids = [sid for sid, _ in candidates]
+                    placeholders = ",".join([placeholder] * len(candidate_ids))
+                    _execute(
+                        cursor,
+                        "SELECT session_id FROM agent_sessions "
+                        f"WHERE session_type = {placeholder} AND session_id IN ({placeholders})",
+                        ("workflow", *candidate_ids),
+                    )
+                    workflow_ids = {
+                        row["session_id"] if isinstance(row, dict) else row[0]
+                        for row in cursor.fetchall()
+                    }
+                finally:
+                    cursor.close()
+                    conn.close()
+                if workflow_ids:
+                    candidates = [(sid, ts) for sid, ts in candidates if sid not in workflow_ids]
+                    print(
+                        "  Skipping workflow-backed sessions: "
+                        f"{len(workflow_ids)} filtered before usage/message sync"
+                    )
+            except Exception as e:
+                print(f"  Warning: failed to pre-filter workflow sessions: {e}")
         print(f"  Found {len(candidates)} candidate session(s)")
 
         for session_id, _updated_ms in candidates:
@@ -652,6 +695,52 @@ def fetch_and_save(
             all_messages.extend(messages)
 
     print(f"\nProcessed {total_sessions} sessions, {len(all_messages)} messages")
+
+    if all_messages:
+        workflow_session_ids: set[str] = set()
+        try:
+            from shared.db import _execute, _placeholder, get_connection
+
+            candidate_ids = sorted(
+                {
+                    str(m.get("agent_session_id", "")).strip()
+                    for m in all_messages
+                    if m.get("agent_session_id")
+                }
+            )
+            if candidate_ids:
+                conn = get_connection()
+                cursor = conn.cursor()
+                try:
+                    placeholder = _placeholder()
+                    placeholders = ",".join([placeholder] * len(candidate_ids))
+                    _execute(
+                        cursor,
+                        "SELECT session_id FROM agent_sessions "
+                        f"WHERE session_type = {placeholder} AND session_id IN ({placeholders})",
+                        ("workflow", *candidate_ids),
+                    )
+                    workflow_session_ids = {
+                        row["session_id"] if isinstance(row, dict) else row[0]
+                        for row in cursor.fetchall()
+                    }
+                finally:
+                    cursor.close()
+                    conn.close()
+        except Exception as e:
+            print(f"Warning: Failed to detect workflow-backed ZCode sessions: {e}")
+
+        if workflow_session_ids:
+            before = len(all_messages)
+            all_messages = [
+                msg
+                for msg in all_messages
+                if msg.get("agent_session_id") not in workflow_session_ids
+            ]
+            print(
+                "Skipped workflow-backed ZCode sessions from transcript sync: "
+                f"{len(workflow_session_ids)} session(s), {before - len(all_messages)} message(s)"
+            )
 
     # Save daily_usage.
     saved = 0

--- a/tests/issues/1138/test_multi_protocol_runner.py
+++ b/tests/issues/1138/test_multi_protocol_runner.py
@@ -358,6 +358,27 @@ def test_extract_visible_response_text_preserves_all_visible_turns():
     )
 
 
+def test_build_agent_task_result_separates_final_text_from_visible_text():
+    from app.modules.workspace.autonomous.agent_runner import _build_agent_task_result
+
+    result = _build_agent_task_result(
+        session_id="sess-1",
+        tracking_session_id="track-1",
+        event_log=[
+            {"type": "assistant", "text": "Applied fix\nCI_STATUS: pre-existing"},
+            {"type": "tool_use", "tool_name": "Bash", "tool_input": {"command": "git push"}},
+            {"type": "assistant", "text": "## Final Summary\nDone."},
+        ],
+        success=True,
+    )
+
+    assert result.response_text == "## Final Summary\nDone."
+    assert result.visible_response_text == (
+        "Applied fix\nCI_STATUS: pre-existing\n\n## Final Summary\nDone."
+    )
+    assert result.structured_tags["ci_status"] == "pre-existing"
+
+
 # ── ZCode session failure cleanup ─────────────────────────────────────────
 
 

--- a/tests/issues/1138/test_multi_protocol_runner.py
+++ b/tests/issues/1138/test_multi_protocol_runner.py
@@ -379,6 +379,36 @@ def test_build_agent_task_result_separates_final_text_from_visible_text():
     assert result.structured_tags["ci_status"] == "pre-existing"
 
 
+def test_build_agent_task_result_uses_last_structured_status_tag():
+    from app.modules.workspace.autonomous.agent_runner import _build_agent_task_result
+
+    result = _build_agent_task_result(
+        session_id="sess-2",
+        tracking_session_id="track-2",
+        event_log=[
+            {"type": "assistant", "text": "Attempt 1\nTEST_STATUS: skipped"},
+            {"type": "tool_use", "tool_name": "Bash", "tool_input": {"command": "pytest"}},
+            {"type": "assistant", "text": "Retried\nTEST_STATUS: passed"},
+            {
+                "type": "tool_use",
+                "tool_name": "Bash",
+                "tool_input": {"command": "rerun ci checks"},
+            },
+            {"type": "assistant", "text": "CI_STATUS: pre-existing"},
+            {
+                "type": "tool_use",
+                "tool_name": "Bash",
+                "tool_input": {"command": "fix ci"},
+            },
+            {"type": "assistant", "text": "CI_STATUS: fixed"},
+        ],
+        success=True,
+    )
+
+    assert result.structured_tags["test_status"] == "passed"
+    assert result.structured_tags["ci_status"] == "fixed"
+
+
 # ── ZCode session failure cleanup ─────────────────────────────────────────
 
 

--- a/tests/issues/716/test_autonomous_api.py
+++ b/tests/issues/716/test_autonomous_api.py
@@ -1184,7 +1184,9 @@ class TestGetMilestoneSession:
         data = resp.get_json()
         assert data["success"] is True
         assert data["session"]["session_id"] == "sess-123"
-        mock_sm.get_session.assert_called_once_with("sess-123", include_messages=True)
+        mock_sm.get_session.assert_called_once_with(
+            "sess-123", include_messages=True, message_milestone_id="ms-1"
+        )
 
     def test_get_session_no_session_id(self, client):
         """Returns null session when milestone has no session_id."""

--- a/tests/issues/716/test_models.py
+++ b/tests/issues/716/test_models.py
@@ -242,6 +242,8 @@ class TestAgentTaskResult:
         assert r.session_id == ""
         assert r.tracking_session_id == ""
         assert r.response_text == ""
+        assert r.visible_response_text == ""
+        assert r.structured_tags == {}
         assert r.success is False
         assert r.error is None
         assert r.total_tokens == 0
@@ -254,6 +256,8 @@ class TestAgentTaskResult:
             session_id="sess-1",
             tracking_session_id="track-1",
             response_text="Done",
+            visible_response_text="Working...\n\nDone",
+            structured_tags={"tldr": "done"},
             total_tokens=500,
             total_input_tokens=300,
             total_output_tokens=200,
@@ -262,6 +266,8 @@ class TestAgentTaskResult:
         )
         assert r.success is True
         assert r.tracking_session_id == "track-1"
+        assert r.visible_response_text == "Working...\n\nDone"
+        assert r.structured_tags["tldr"] == "done"
         assert r.total_tokens == 500
         assert r.request_count == 3
 

--- a/tests/issues/716/test_orchestrator.py
+++ b/tests/issues/716/test_orchestrator.py
@@ -485,6 +485,26 @@ class TestOrchestratorPlanning:
         assert "The user wants me" not in posted_body
         assert '"description":"find tests"' not in posted_body
 
+    def test_sanitize_artifact_text_preserves_legitimate_final_output_prefixes(self):
+        from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+        sanitized = AutonomousOrchestrator._sanitize_artifact_text(
+            "Let me summarize the changes:\n1. Fix session filtering\n2. Add regression coverage"
+        )
+
+        assert sanitized == (
+            "Let me summarize the changes:\n1. Fix session filtering\n2. Add regression coverage"
+        )
+
+    def test_sanitize_artifact_text_strips_user_wants_me_leakage(self):
+        from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+        sanitized = AutonomousOrchestrator._sanitize_artifact_text(
+            "The user wants me to inspect the codebase.\n\n## Final Plan\n1. Fix the filter mapping"
+        )
+
+        assert sanitized == "## Final Plan\n1. Fix the filter mapping"
+
     @patch("app.modules.workspace.autonomous.orchestrator.GitHubOps")
     def test_planning_max_rounds_forces_transition(self, mock_gh_cls):
         wf = _make_workflow(current_phase="planning", current_round=2, max_plan_rounds=3)

--- a/tests/issues/716/test_orchestrator.py
+++ b/tests/issues/716/test_orchestrator.py
@@ -438,6 +438,54 @@ class TestOrchestratorPlanning:
         assert round_updates[0][0][1]["current_round"] == 1
 
     @patch("app.modules.workspace.autonomous.orchestrator.GitHubOps")
+    def test_planning_uses_final_artifact_not_visible_transcript(self, mock_gh_cls):
+        wf = _make_workflow(
+            current_phase="planning",
+            current_round=0,
+            max_plan_rounds=1,
+            github_issue_number=42,
+        )
+        orch, mock_repo = self._make_orchestrator(wf)
+
+        mock_gh = MagicMock()
+        mock_gh_cls.return_value = mock_gh
+
+        plan_result = AgentTaskResult(
+            session_id="sess-plan",
+            response_text="## Final Plan\n1. Fix the filter mapping\n2. Add regression tests",
+            visible_response_text=(
+                "The user wants me to inspect the codebase.\n\n"
+                '{"description":"find tests","prompt":"..."}\n\n'
+                "## Final Plan\n1. Fix the filter mapping\n2. Add regression tests"
+            ),
+            structured_tags={"tldr": "修复过滤并补测试"},
+            total_tokens=100,
+            total_input_tokens=50,
+            total_output_tokens=50,
+            success=True,
+        )
+        review_result = _make_agent_result(text="方案通过审查。")
+        orch._runner = MagicMock()
+        orch._runner.run_agent_task.side_effect = [plan_result, review_result]
+        orch._gh = mock_gh
+
+        orch._do_planning(wf)
+
+        plan_updates = [
+            call[0][1]
+            for call in mock_repo.update_milestone.call_args_list
+            if "plan_content" in call[0][1]
+        ]
+        assert plan_updates
+        assert plan_updates[0]["plan_content"] == (
+            "## Final Plan\n1. Fix the filter mapping\n2. Add regression tests"
+        )
+        assert plan_updates[0]["tldr"] == "修复过滤并补测试"
+        posted_body = mock_gh.add_issue_comment.call_args_list[0][0][1]
+        assert "The user wants me" not in posted_body
+        assert '"description":"find tests"' not in posted_body
+
+    @patch("app.modules.workspace.autonomous.orchestrator.GitHubOps")
     def test_planning_max_rounds_forces_transition(self, mock_gh_cls):
         wf = _make_workflow(current_phase="planning", current_round=2, max_plan_rounds=3)
         orch, mock_repo = self._make_orchestrator(wf)

--- a/tests/issues/716/test_orchestrator.py
+++ b/tests/issues/716/test_orchestrator.py
@@ -485,26 +485,6 @@ class TestOrchestratorPlanning:
         assert "The user wants me" not in posted_body
         assert '"description":"find tests"' not in posted_body
 
-    def test_sanitize_artifact_text_preserves_legitimate_final_output_prefixes(self):
-        from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
-
-        sanitized = AutonomousOrchestrator._sanitize_artifact_text(
-            "Let me summarize the changes:\n1. Fix session filtering\n2. Add regression coverage"
-        )
-
-        assert sanitized == (
-            "Let me summarize the changes:\n1. Fix session filtering\n2. Add regression coverage"
-        )
-
-    def test_sanitize_artifact_text_strips_user_wants_me_leakage(self):
-        from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
-
-        sanitized = AutonomousOrchestrator._sanitize_artifact_text(
-            "The user wants me to inspect the codebase.\n\n## Final Plan\n1. Fix the filter mapping"
-        )
-
-        assert sanitized == "## Final Plan\n1. Fix the filter mapping"
-
     @patch("app.modules.workspace.autonomous.orchestrator.GitHubOps")
     def test_planning_max_rounds_forces_transition(self, mock_gh_cls):
         wf = _make_workflow(current_phase="planning", current_round=2, max_plan_rounds=3)

--- a/tests/issues/776/test_session_persist_and_change_detection.py
+++ b/tests/issues/776/test_session_persist_and_change_detection.py
@@ -50,7 +50,7 @@ class TestPersistSessionMessagesWithEventLog:
         return AgentTaskResult(**defaults)
 
     def test_event_log_preserves_interleaving_order(self):
-        """Messages are written in the order they occurred in event_log."""
+        """Tool uses keep order, assistant output collapses to the final visible turn."""
         runner = self._make_runner()
         result = self._make_result(
             response_text="Reading file, then editing it.",
@@ -69,16 +69,14 @@ class TestPersistSessionMessagesWithEventLog:
         runner._persist_local_session_messages("sess-1", result)
 
         calls = runner.session_manager.add_message.call_args_list
-        assert len(calls) == 4
-        # Verify order: assistant, tool, assistant, tool
-        assert calls[0].kwargs["role"] == "assistant"
-        assert "read the file" in calls[0].kwargs["content"]
+        assert len(calls) == 3
+        assert calls[0].kwargs["role"] == "tool"
+        assert calls[0].kwargs["metadata"]["tool_name"] == "Read"
         assert calls[1].kwargs["role"] == "tool"
-        assert calls[1].kwargs["metadata"]["tool_name"] == "Read"
+        assert calls[1].kwargs["metadata"]["tool_name"] == "Edit"
         assert calls[2].kwargs["role"] == "assistant"
-        assert "edit it" in calls[2].kwargs["content"]
-        assert calls[3].kwargs["role"] == "tool"
-        assert calls[3].kwargs["metadata"]["tool_name"] == "Edit"
+        assert "Now I will edit it." in calls[2].kwargs["content"]
+        assert calls[2].kwargs["source"] == "workflow_local"
 
     def test_tool_input_serialized_as_json(self):
         """Tool input dict is serialized to JSON in content field."""
@@ -95,6 +93,7 @@ class TestPersistSessionMessagesWithEventLog:
         content = call.kwargs["content"]
         parsed = json.loads(content)
         assert parsed["command"] == "git add -A"
+        assert call.kwargs["source"] == "workflow_local"
 
     def test_fallback_without_event_log(self):
         """When event_log is empty, falls back to response_text + tool_calls."""
@@ -113,6 +112,7 @@ class TestPersistSessionMessagesWithEventLog:
         assert len(calls) == 2
         assert calls[0].kwargs["role"] == "assistant"
         assert calls[0].kwargs["content"] == "I made changes."
+        assert calls[0].kwargs["source"] == "workflow_local"
         assert calls[1].kwargs["role"] == "tool"
 
     def test_no_messages_when_empty(self):
@@ -138,8 +138,9 @@ class TestPersistSessionMessagesWithEventLog:
         runner._persist_local_session_messages("sess-1", result)
 
         calls = runner.session_manager.add_message.call_args_list
-        assert len(calls) == 2  # Only 2 assistant messages, usage skipped
-        assert all(c.kwargs["role"] == "assistant" for c in calls)
+        assert len(calls) == 1  # Only the final assistant turn survives
+        assert calls[0].kwargs["role"] == "assistant"
+        assert calls[0].kwargs["content"] == "Done."
 
 
 class TestReadStdoutPopulatesEventLog:

--- a/tests/unit/test_fetch_zcode.py
+++ b/tests/unit/test_fetch_zcode.py
@@ -171,7 +171,8 @@ def _init_dest_schema(db_path: Path) -> None:
             tokens_used INTEGER DEFAULT 0,
             model TEXT,
             timestamp TEXT,
-            metadata TEXT
+            metadata TEXT,
+            source TEXT DEFAULT ''
         );
         CREATE TABLE daily_usage (
             date TEXT,
@@ -420,10 +421,12 @@ def test_update_agent_sessions_stats_inserts_session_and_messages(fetch_mod, tmp
     assert row["user_id"] == 1
 
     msg_rows = conn.execute(
-        "SELECT role FROM session_messages WHERE session_id = ? ORDER BY role", ("sess_new1",)
+        "SELECT role, source FROM session_messages WHERE session_id = ? ORDER BY role",
+        ("sess_new1",),
     ).fetchall()
     roles = {r["role"] for r in msg_rows}
     assert roles == {"user", "assistant"}
+    assert {r["source"] for r in msg_rows} == {"zcode_fetch"}
     conn.close()
 
 
@@ -459,6 +462,53 @@ def test_update_agent_sessions_stats_idempotent(fetch_mod, tmp_path):
     ).fetchone()[0]
     conn.close()
     assert count == 1
+
+
+def test_update_agent_sessions_stats_skips_existing_workflow_session(fetch_mod, tmp_path):
+    """Fetcher must not backfill raw transcript rows into workflow-owned sessions."""
+    ts_iso = datetime.now(timezone.utc).isoformat()
+    dest_db = tmp_path / "dest.sqlite"
+    conn = sqlite3.connect(str(dest_db))
+    conn.execute(
+        """
+        INSERT INTO agent_sessions
+        (session_id, session_type, title, tool_name, host_name, user_id, status, project_path)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        ("sess_workflow", "workflow", "wf", "zcode", "localhost", 1, "completed", "/repo"),
+    )
+    conn.commit()
+    conn.close()
+
+    messages = [
+        {
+            "date": "2026-06-20",
+            "tool_name": "zcode",
+            "host_name": "localhost",
+            "message_id": "m1",
+            "role": "assistant",
+            "content": "raw sync content",
+            "content_blocks": None,
+            "tokens_used": 10,
+            "input_tokens": 6,
+            "output_tokens": 4,
+            "model": "GLM-5.2",
+            "timestamp": ts_iso,
+            "sender_name": "rhuang-host-zcode",
+            "agent_session_id": "sess_workflow",
+            "project_path": "/repo",
+        },
+    ]
+
+    updated = fetch_mod.update_agent_sessions_stats(messages)
+    assert updated == 0
+
+    conn = sqlite3.connect(str(dest_db))
+    count = conn.execute(
+        "SELECT COUNT(*) FROM session_messages WHERE session_id = ?", ("sess_workflow",)
+    ).fetchone()[0]
+    conn.close()
+    assert count == 0
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/unit/test_workspace_modules.py
+++ b/tests/unit/test_workspace_modules.py
@@ -220,6 +220,43 @@ class TestSessionManager:
         assert retrieved is not None
         assert retrieved.session_id == created.session_id
 
+    def test_get_session_filters_messages_by_milestone(self, session_manager):
+        """Milestone session detail only returns messages tagged to that milestone."""
+        created = session_manager.create_session(tool_name="qwen")
+        conn = session_manager._get_connection()
+        try:
+            conn.cursor().execute("ALTER TABLE session_messages ADD COLUMN source TEXT DEFAULT ''")
+            conn.commit()
+        except Exception:
+            conn.rollback()
+        finally:
+            conn.close()
+        session_manager.add_message(
+            created.session_id,
+            role="assistant",
+            content="message A",
+            milestone_id="ms-a",
+            source="workflow_local",
+        )
+        session_manager.add_message(
+            created.session_id,
+            role="assistant",
+            content="message B",
+            milestone_id="ms-b",
+            source="workflow_local",
+        )
+
+        retrieved = session_manager.get_session(
+            created.session_id,
+            include_messages=True,
+            message_milestone_id="ms-a",
+        )
+
+        assert retrieved is not None
+        assert len(retrieved.messages) == 1
+        assert retrieved.messages[0].content == "message A"
+        assert retrieved.messages[0].source == "workflow_local"
+
     def test_complete_session(self, session_manager):
         """Test completing a session."""
         session = session_manager.create_session(tool_name="claude")


### PR DESCRIPTION
## Summary
- split autonomous agent output into final artifact text vs visible transcript text
- store/publish milestone content from the final artifact path and keep structured tags from visible text
- isolate workflow sessions from zcode transcript fetch sync, add explicit session message source tagging, and filter milestone session detail in SQL

## Root cause addressed
- workflow milestones and GitHub comments were reading `response_text` built from all visible assistant turns, so zcode planning/review/test output could include repeated process text and leaked JSON
- `fetch_zcode.py` was writing raw zcode transcript rows back into `session_messages` for workflow-owned session ids, so milestone session detail mixed clean workflow messages with raw synced transcript rows

## Validation
- `python3 -m pytest -q tests/issues/1138/test_multi_protocol_runner.py tests/issues/776/test_session_persist_and_change_detection.py tests/issues/716/test_models.py tests/issues/716/test_autonomous_api.py tests/issues/716/test_orchestrator.py tests/unit/test_fetch_zcode.py tests/unit/test_workspace_modules.py::TestSessionManager::test_get_session_filters_messages_by_milestone`
- `python3 -m pytest -q tests/unit/test_zcode_workflow_session_persistence.py`
