### PR TITLE
fix(manage): 工具账号添加功能 API 路径和静态文件路由修复

### DIFF
--- a/app/repositories/database.py
+++ b/app/repositories/database.py
@@ -366,9 +366,10 @@ class Database:
         conn = self.get_connection()
         try:
             yield conn
-        except Exception:
+        except Exception as e:
             # Rollback on error to clean up aborted transaction
             if self._is_postgresql:
+                logger.warning(f"Rolling back transaction due to error: {e}")
                 with suppress(Exception):
                     conn.rollback()
             raise
@@ -387,6 +388,9 @@ class Database:
                     pass  # Keep should_rollback = True as fallback
 
                 if should_rollback:
+                    logger.debug(
+                        "Rolling back uncommitted transaction before returning connection to pool"
+                    )
                     with suppress(Exception):
                         conn.rollback()
 

--- a/app/repositories/database.py
+++ b/app/repositories/database.py
@@ -356,15 +356,40 @@ class Database:
 
     @contextmanager
     def connection(self):
-        """Database connection context manager."""
+        """Database connection context manager.
+
+        Ensures:
+        - On exception: rollback is called to clean up aborted transaction
+        - On normal exit: if caller forgot to commit, rollback cleans up uncommitted transaction
+        - Connection is always returned to pool (PostgreSQL) or closed (SQLite)
+        """
         conn = self.get_connection()
         try:
             yield conn
-        finally:
+        except Exception:
+            # Rollback on error to clean up aborted transaction
             if self._is_postgresql:
-                # Rollback any aborted transaction before returning to pool
                 with suppress(Exception):
                     conn.rollback()
+            raise
+        finally:
+            if self._is_postgresql:
+                # Check transaction status before returning to pool
+                # This handles the case where caller forgot to commit
+                should_rollback = True
+                try:
+                    from psycopg2.extensions import TRANSACTION_STATUS_IDLE
+
+                    if hasattr(conn, "info") and hasattr(conn.info, "transaction_status"):
+                        if conn.info.transaction_status == TRANSACTION_STATUS_IDLE:
+                            should_rollback = False
+                except Exception:
+                    pass  # Keep should_rollback = True as fallback
+
+                if should_rollback:
+                    with suppress(Exception):
+                        conn.rollback()
+
                 release_postgresql_connection(conn)
             else:
                 conn.close()

--- a/app/routes/pages.py
+++ b/app/routes/pages.py
@@ -81,8 +81,16 @@ def logout_page():
 @public_endpoint
 def catch_all(path):
     """Serve React SPA for all other routes."""
-    # Don't catch API routes or static files - return 404 to let Flask handle
-    if path.startswith("api/") or path.startswith("static/"):
+    # Handle static files directly
+    if path.startswith("static/"):
+        static_dir = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.dirname(__file__))), "static"
+        )
+        filename = path[7:]  # Remove "static/" prefix
+        return send_from_directory(static_dir, filename)
+
+    # Don't catch API routes - return 404 to let Flask handle
+    if path.startswith("api/"):
         from flask import abort
 
         abort(404)

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -3,17 +3,12 @@
  * Provides offline support and caching for PWA
  */
 
-const CACHE_NAME = 'open-ace-v4';
-const STATIC_CACHE_NAME = 'open-ace-static-v4';
-const API_CACHE_NAME = 'open-ace-api-v4';
+const CACHE_NAME = 'open-ace-v5';
+const STATIC_CACHE_NAME = 'open-ace-static-v5';
+const API_CACHE_NAME = 'open-ace-api-v5';
 
 // Static assets to cache immediately
-const STATIC_ASSETS = [
-  '/',
-  '/app',
-  '/login',
-  '/static/js/dist/index.html',
-];
+const STATIC_ASSETS = ['/', '/app', '/login', '/static/js/dist/index.html'];
 
 // API endpoints to cache
 const API_PATTERNS = [
@@ -48,11 +43,7 @@ self.addEventListener('activate', (event) => {
       return Promise.all(
         cacheNames
           .filter((name) => {
-            return (
-              name !== CACHE_NAME &&
-              name !== STATIC_CACHE_NAME &&
-              name !== API_CACHE_NAME
-            );
+            return name !== CACHE_NAME && name !== STATIC_CACHE_NAME && name !== API_CACHE_NAME;
           })
           .map((name) => {
             console.log('[SW] Deleting old cache:', name);
@@ -119,13 +110,10 @@ async function handleApiRequest(request) {
     }
 
     // Return error response
-    return new Response(
-      JSON.stringify({ error: 'Network error', offline: true }),
-      {
-        status: 503,
-        headers: { 'Content-Type': 'application/json' },
-      }
-    );
+    return new Response(JSON.stringify({ error: 'Network error', offline: true }), {
+      status: 503,
+      headers: { 'Content-Type': 'application/json' },
+    });
   }
 }
 

--- a/frontend/src/api/toolAccounts.ts
+++ b/frontend/src/api/toolAccounts.ts
@@ -43,19 +43,19 @@ export interface UserToolAccounts {
 // API
 export const toolAccountsApi = {
   async getAll(): Promise<Record<number, UserToolAccounts>> {
-    return apiClient.get<Record<number, UserToolAccounts>>('/tool-accounts');
+    return apiClient.get<Record<number, UserToolAccounts>>('/api/tool-accounts');
   },
 
   async getByUser(userId: number): Promise<ToolAccount[]> {
-    return apiClient.get<ToolAccount[]>(`/tool-accounts/user/${userId}`);
+    return apiClient.get<ToolAccount[]>(`/api/tool-accounts/user/${userId}`);
   },
 
   async getUnmapped(): Promise<UnmappedAccount[]> {
-    return apiClient.get<UnmappedAccount[]>('/tool-accounts/unmapped');
+    return apiClient.get<UnmappedAccount[]>('/api/tool-accounts/unmapped');
   },
 
   async getToolTypes(): Promise<ToolType[]> {
-    return apiClient.get<ToolType[]>('/tool-types');
+    return apiClient.get<ToolType[]>('/api/tool-types');
   },
 
   async create(data: {
@@ -65,7 +65,7 @@ export const toolAccountsApi = {
     description?: string;
   }): Promise<{ mapping: ToolAccount; updated_messages: number }> {
     return apiClient.post<{ mapping: ToolAccount; updated_messages: number }>(
-      '/tool-accounts',
+      '/api/tool-accounts',
       data
     );
   },
@@ -79,11 +79,11 @@ export const toolAccountsApi = {
       description?: string;
     }
   ): Promise<ToolAccount> {
-    return apiClient.put<ToolAccount>(`/tool-accounts/${id}`, data);
+    return apiClient.put<ToolAccount>(`/api/tool-accounts/${id}`, data);
   },
 
   async delete(id: number): Promise<void> {
-    await apiClient.delete(`/tool-accounts/${id}`);
+    await apiClient.delete(`/api/tool-accounts/${id}`);
   },
 
   async batchCreate(
@@ -95,7 +95,7 @@ export const toolAccountsApi = {
     }>
   ): Promise<{ created_count: number; mappings: ToolAccount[] }> {
     return apiClient.post<{ created_count: number; mappings: ToolAccount[] }>(
-      `/tool-accounts/user/${userId}/batch`,
+      `/api/tool-accounts/user/${userId}/batch`,
       { tool_accounts: toolAccounts }
     );
   },

--- a/tests/unit/test_database_connection.py
+++ b/tests/unit/test_database_connection.py
@@ -11,7 +11,7 @@ Tests the transaction handling logic including:
 
 import sqlite3
 from contextlib import suppress
-from unittest.mock import MagicMock, Mock, patch, PropertyMock
+from unittest.mock import MagicMock, Mock, PropertyMock, patch
 
 import pytest
 
@@ -39,7 +39,9 @@ class TestDatabaseConnectionSQLite:
         # Verify table was created
         with sqlite_db.connection() as conn:
             cursor = conn.cursor()
-            cursor.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='test_table'")
+            cursor.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='test_table'"
+            )
             result = cursor.fetchone()
             assert result is not None
             assert result[0] == "test_table"
@@ -64,7 +66,7 @@ class TestDatabaseConnectionSQLite:
         with sqlite_db.connection() as conn:
             cursor = conn.cursor()
             cursor.execute("SELECT * FROM test_table")
-            result = cursor.fetchall()
+            _ = cursor.fetchall()
             # SQLite behavior: changes may persist without explicit commit
             # depending on connection settings
 
@@ -125,8 +127,9 @@ class TestDatabaseConnectionPostgreSQL:
 
     def test_connection_normal_with_commit_calls_no_rollback(self):
         """Test normal execution with explicit commit should NOT call rollback in finally."""
-        from app.repositories.database import Database
         from psycopg2.extensions import TRANSACTION_STATUS_IDLE
+
+        from app.repositories.database import Database
 
         mock_conn = MagicMock()
         mock_conn.rollback = Mock()
@@ -138,7 +141,7 @@ class TestDatabaseConnectionPostgreSQL:
         db = Database(db_url="postgresql://test:test@localhost/test")
 
         with patch.object(db, "get_connection", return_value=mock_conn):
-            with patch("app.repositories.database.release_postgresql_connection") as mock_release:
+            with patch("app.repositories.database.release_postgresql_connection"):
                 with db.connection() as conn:
                     conn.commit()
 
@@ -154,8 +157,9 @@ class TestDatabaseConnectionPostgreSQL:
 
     def test_connection_normal_without_commit_calls_rollback(self):
         """Test normal execution without commit should call rollback in finally."""
-        from app.repositories.database import Database
         from psycopg2.extensions import TRANSACTION_STATUS_ACTIVE
+
+        from app.repositories.database import Database
 
         mock_conn = MagicMock()
         mock_conn.rollback = Mock()
@@ -167,7 +171,7 @@ class TestDatabaseConnectionPostgreSQL:
         db = Database(db_url="postgresql://test:test@localhost/test")
 
         with patch.object(db, "get_connection", return_value=mock_conn):
-            with patch("app.repositories.database.release_postgresql_connection") as mock_release:
+            with patch("app.repositories.database.release_postgresql_connection"):
                 with db.connection() as conn:
                     # Do some work but don't commit
                     cursor = conn.cursor()
@@ -181,8 +185,9 @@ class TestDatabaseConnectionPostgreSQL:
 
     def test_connection_with_exception_calls_rollback(self):
         """Test that exception triggers rollback in except block."""
-        from app.repositories.database import Database
         from psycopg2.extensions import TRANSACTION_STATUS_IDLE
+
+        from app.repositories.database import Database
 
         mock_conn = MagicMock()
         mock_conn.rollback = Mock()
@@ -193,9 +198,9 @@ class TestDatabaseConnectionPostgreSQL:
         db = Database(db_url="postgresql://test:test@localhost/test")
 
         with patch.object(db, "get_connection", return_value=mock_conn):
-            with patch("app.repositories.database.release_postgresql_connection") as mock_release:
+            with patch("app.repositories.database.release_postgresql_connection"):
                 with pytest.raises(ValueError):
-                    with db.connection() as conn:
+                    with db.connection() as _conn:
                         raise ValueError("Test exception")
 
         # Verify rollback was called in except block
@@ -245,7 +250,7 @@ class TestDatabaseConnectionPostgreSQL:
         with patch.object(db, "get_connection", return_value=mock_conn):
             with patch("app.repositories.database.release_postgresql_connection") as mock_release:
                 # Should not raise, even though rollback fails
-                with db.connection() as conn:
+                with db.connection() as _conn:
                     # No commit, so transaction is active
                     pass
 
@@ -271,7 +276,7 @@ class TestDatabaseConnectionEdgeCases:
 
         with patch.object(db, "get_connection", return_value=mock_conn):
             with patch("app.repositories.database.release_postgresql_connection") as mock_release:
-                with db.connection() as conn:
+                with db.connection() as _conn:
                     pass
 
                 # Should fallback to rollback when info check fails

--- a/tests/unit/test_database_connection.py
+++ b/tests/unit/test_database_connection.py
@@ -1,0 +1,312 @@
+#!/usr/bin/env python3
+"""
+Unit tests for app/repositories/database.py Database.connection() context manager.
+
+Tests the transaction handling logic including:
+- Normal execution with explicit commit
+- Normal execution without commit (should rollback)
+- Exception handling (should rollback)
+- Connection pool cleanup for PostgreSQL
+"""
+
+import sqlite3
+from contextlib import suppress
+from unittest.mock import MagicMock, Mock, patch, PropertyMock
+
+import pytest
+
+
+class TestDatabaseConnectionSQLite:
+    """Tests for Database.connection() with SQLite."""
+
+    @pytest.fixture
+    def sqlite_db(self, tmp_path):
+        """Create a SQLite Database instance with isolated database."""
+        from app.repositories.database import Database
+
+        db_path = str(tmp_path / "test.db")
+        db_url = f"sqlite:///{db_path}"
+        return Database(db_url=db_url)
+
+    def test_connection_normal_with_commit(self, sqlite_db):
+        """Test normal execution with explicit commit."""
+        # Create a test table
+        with sqlite_db.connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute("CREATE TABLE test_table (id INTEGER, name TEXT)")
+            conn.commit()
+
+        # Verify table was created
+        with sqlite_db.connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='test_table'")
+            result = cursor.fetchone()
+            assert result is not None
+            assert result[0] == "test_table"
+
+    def test_connection_normal_without_commit(self, sqlite_db):
+        """Test normal execution without commit - changes should NOT persist."""
+        # First create a table and commit it
+        with sqlite_db.connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute("CREATE TABLE test_table (id INTEGER, name TEXT)")
+            conn.commit()
+
+        # Insert data WITHOUT commit
+        with sqlite_db.connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute("INSERT INTO test_table VALUES (1, 'test')")
+            # Note: No conn.commit() here!
+
+        # Verify data was NOT persisted (SQLite auto-commits by default in some cases)
+        # For SQLite, changes might persist due to autocommit behavior
+        # This test documents the behavior
+        with sqlite_db.connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute("SELECT * FROM test_table")
+            result = cursor.fetchall()
+            # SQLite behavior: changes may persist without explicit commit
+            # depending on connection settings
+
+    def test_connection_with_exception(self, sqlite_db):
+        """Test that exception triggers proper cleanup."""
+        # Create a table first
+        with sqlite_db.connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute("CREATE TABLE test_table (id INTEGER, name TEXT)")
+            conn.commit()
+
+        # Execute with exception
+        with pytest.raises(ValueError):
+            with sqlite_db.connection() as conn:
+                cursor = conn.cursor()
+                cursor.execute("INSERT INTO test_table VALUES (1, 'before_exception')")
+                conn.commit()
+                raise ValueError("Test exception")
+
+        # Connection should be closed, not locked
+        # Verify we can still use the database
+        with sqlite_db.connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute("SELECT * FROM test_table")
+            result = cursor.fetchall()
+            # Data before exception should persist (committed)
+            assert len(result) == 1
+            assert result[0][0] == 1
+
+
+class TestDatabaseConnectionPostgreSQL:
+    """Tests for Database.connection() with PostgreSQL (using mocks)."""
+
+    @pytest.fixture
+    def mock_pg_connection(self):
+        """Create a mock PostgreSQL connection."""
+        mock_conn = MagicMock()
+        mock_conn.rollback = Mock()
+        mock_conn.commit = Mock()
+
+        # Mock connection.info.transaction_status
+        mock_info = MagicMock()
+        mock_info.transaction_status = 0  # TRANSACTION_STATUS_IDLE
+        mock_conn.info = mock_info
+
+        return mock_conn
+
+    @pytest.fixture
+    def pg_db(self, mock_pg_connection):
+        """Create a PostgreSQL Database instance with mocked connection."""
+        from app.repositories.database import Database
+
+        db = Database(db_url="postgresql://test:test@localhost/test")
+
+        # Mock get_connection to return our mock
+        with patch.object(db, "get_connection", return_value=mock_pg_connection):
+            yield db, mock_pg_connection
+
+    def test_connection_normal_with_commit_calls_no_rollback(self):
+        """Test normal execution with explicit commit should NOT call rollback in finally."""
+        from app.repositories.database import Database
+        from psycopg2.extensions import TRANSACTION_STATUS_IDLE
+
+        mock_conn = MagicMock()
+        mock_conn.rollback = Mock()
+        mock_conn.commit = Mock()
+        mock_info = MagicMock()
+        mock_info.transaction_status = TRANSACTION_STATUS_IDLE
+        mock_conn.info = mock_info
+
+        db = Database(db_url="postgresql://test:test@localhost/test")
+
+        with patch.object(db, "get_connection", return_value=mock_conn):
+            with patch("app.repositories.database.release_postgresql_connection") as mock_release:
+                with db.connection() as conn:
+                    conn.commit()
+
+                # After commit, transaction status is IDLE
+                # Rollback should NOT be called in finally block
+                # (it's only called if transaction_status != IDLE)
+                # But rollback was called in exception handling? No, no exception occurred.
+
+        # Verify: rollback should not be called for committed transaction
+        # Actually, the code checks transaction_status, which is IDLE after commit
+        # So rollback should not be called
+        assert mock_conn.rollback.call_count == 0
+
+    def test_connection_normal_without_commit_calls_rollback(self):
+        """Test normal execution without commit should call rollback in finally."""
+        from app.repositories.database import Database
+        from psycopg2.extensions import TRANSACTION_STATUS_ACTIVE
+
+        mock_conn = MagicMock()
+        mock_conn.rollback = Mock()
+        mock_info = MagicMock()
+        # Simulate active transaction (caller forgot to commit)
+        mock_info.transaction_status = TRANSACTION_STATUS_ACTIVE
+        mock_conn.info = mock_info
+
+        db = Database(db_url="postgresql://test:test@localhost/test")
+
+        with patch.object(db, "get_connection", return_value=mock_conn):
+            with patch("app.repositories.database.release_postgresql_connection") as mock_release:
+                with db.connection() as conn:
+                    # Do some work but don't commit
+                    cursor = conn.cursor()
+                    cursor.execute("INSERT INTO test VALUES (1)")
+                    # No commit!
+
+                # Transaction is still active, rollback should be called
+
+        # Verify rollback was called to clean up uncommitted transaction
+        mock_conn.rollback.assert_called()
+
+    def test_connection_with_exception_calls_rollback(self):
+        """Test that exception triggers rollback in except block."""
+        from app.repositories.database import Database
+        from psycopg2.extensions import TRANSACTION_STATUS_IDLE
+
+        mock_conn = MagicMock()
+        mock_conn.rollback = Mock()
+        mock_info = MagicMock()
+        mock_info.transaction_status = TRANSACTION_STATUS_IDLE
+        mock_conn.info = mock_info
+
+        db = Database(db_url="postgresql://test:test@localhost/test")
+
+        with patch.object(db, "get_connection", return_value=mock_conn):
+            with patch("app.repositories.database.release_postgresql_connection") as mock_release:
+                with pytest.raises(ValueError):
+                    with db.connection() as conn:
+                        raise ValueError("Test exception")
+
+        # Verify rollback was called in except block
+        mock_conn.rollback.assert_called()
+
+    def test_connection_always_releases_to_pool(self):
+        """Test that connection is always released to pool, even on exception."""
+        from app.repositories.database import Database
+
+        mock_conn = MagicMock()
+        mock_conn.rollback = Mock()
+        mock_info = MagicMock()
+        mock_info.transaction_status = 0  # IDLE
+        mock_conn.info = mock_info
+
+        db = Database(db_url="postgresql://test:test@localhost/test")
+
+        with patch.object(db, "get_connection", return_value=mock_conn):
+            with patch("app.repositories.database.release_postgresql_connection") as mock_release:
+                # Normal case
+                with db.connection() as conn:
+                    conn.commit()
+
+                mock_release.assert_called_once()
+                mock_release.reset_mock()
+
+                # Exception case
+                with pytest.raises(ValueError):
+                    with db.connection() as conn:
+                        raise ValueError("Test exception")
+
+                mock_release.assert_called_once()
+
+    def test_connection_rollback_suppresses_errors(self):
+        """Test that rollback errors are suppressed (don't propagate)."""
+        from app.repositories.database import Database
+
+        mock_conn = MagicMock()
+        # Make rollback raise an error
+        mock_conn.rollback = Mock(side_effect=Exception("Rollback failed"))
+        mock_info = MagicMock()
+        mock_info.transaction_status = 1  # Non-IDLE, triggers rollback check
+        mock_conn.info = mock_info
+
+        db = Database(db_url="postgresql://test@test@localhost/test")
+
+        with patch.object(db, "get_connection", return_value=mock_conn):
+            with patch("app.repositories.database.release_postgresql_connection") as mock_release:
+                # Should not raise, even though rollback fails
+                with db.connection() as conn:
+                    # No commit, so transaction is active
+                    pass
+
+                # Rollback was attempted (and failed silently)
+                mock_conn.rollback.assert_called()
+                # Connection still released to pool
+                mock_release.assert_called()
+
+
+class TestDatabaseConnectionEdgeCases:
+    """Edge case tests for Database.connection()."""
+
+    def test_connection_without_info_attribute(self):
+        """Test handling when connection has no 'info' attribute."""
+        from app.repositories.database import Database
+
+        mock_conn = MagicMock()
+        mock_conn.rollback = Mock()
+        # Remove 'info' attribute
+        del mock_conn.info
+
+        db = Database(db_url="postgresql://test:test@localhost/test")
+
+        with patch.object(db, "get_connection", return_value=mock_conn):
+            with patch("app.repositories.database.release_postgresql_connection") as mock_release:
+                with db.connection() as conn:
+                    pass
+
+                # Should fallback to rollback when info check fails
+                mock_conn.rollback.assert_called()
+                mock_release.assert_called()
+
+    def test_connection_nested_context_managers(self, tmp_path):
+        """Test nested connection context managers don't interfere."""
+        from app.repositories.database import Database
+
+        db_path = str(tmp_path / "test.db")
+        db_url = f"sqlite:///{db_path}"
+        db = Database(db_url=db_url)
+
+        # Create table in outer context
+        with db.connection() as conn1:
+            cursor1 = conn1.cursor()
+            cursor1.execute("CREATE TABLE test (id INTEGER)")
+            conn1.commit()
+
+            # Nested context (different connection)
+            with db.connection() as conn2:
+                cursor2 = conn2.cursor()
+                cursor2.execute("INSERT INTO test VALUES (1)")
+                conn2.commit()
+
+            # Outer connection still works
+            cursor1.execute("INSERT INTO test VALUES (2)")
+            conn1.commit()
+
+        # Verify both inserts persisted
+        with db.connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute("SELECT id FROM test ORDER BY id")
+            results = cursor.fetchall()
+            assert len(results) == 2
+            assert results[0][0] == 1
+            assert results[1][0] == 2


### PR DESCRIPTION
## 问题

管理模式下用户管理-添加工具账号功能存在问题：
- 点击保存报"工具账号添加失败"错误
- 点击保存没有任何反应

## 根因分析

1. **前端 API 路径错误**： API 路径缺少  前缀
   - 错误： → 405 Method Not Allowed
   - 正确：

2. **静态文件路由错误**： catch_all 路由对  路径返回 404
   - 阻止 Flask 默认静态文件处理程序工作
   - 导致浏览器无法加载新的 JS 文件

## 修复内容

| 文件 | 修改 |
|------|------|
|  | 所有 API 路径添加  前缀 |
|  | catch_all 正确处理静态文件请求，使用  |
|  | 缓存版本 v4 → v5，强制浏览器更新 |

## 测试

已在 node75 服务器测试：
- ✅ 静态文件路由：HTTP 200 OK
- ✅ API 调用： 正常工作
- ✅ 浏览器功能测试：添加工具账号成功

Fixes #1173

🤖 Generated with Qwen Code