### PR TITLE
fix(remote-agent): 优先使用配置的 hostname 解决 VPN IP 干扰问题 (Issue #672)

### DIFF
--- a/remote-agent/agent.py
+++ b/remote-agent/agent.py
@@ -1808,7 +1808,13 @@ class RemoteAgent:
 
     def _get_reachable_hostname(self) -> str:
         """Get a hostname/IP that the browser can use to reach this machine."""
-        # Prefer IP address (hostname may not be resolvable from browser)
+        # Prefer configured hostname if set and not localhost (fixes VPN IP issue)
+        # When VPN is active, socket.connect returns VPN IP which may not be
+        # reachable from the browser. User-configured hostname takes priority.
+        hostname = self.config.hostname
+        if hostname and hostname != "localhost":
+            return hostname
+        # Fall back to auto-detected IP address
         try:
             with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
                 s.connect(("8.8.8.8", 80))
@@ -1816,10 +1822,6 @@ class RemoteAgent:
                 return ip
         except Exception:
             pass
-        # Fall back to configured hostname
-        hostname = self.config.hostname
-        if hostname and hostname != "localhost":
-            return hostname
         return "127.0.0.1"
 
     def _apply_cli_settings(self, cli_settings: dict[str, Any]) -> None:

--- a/remote-agent/agent.py
+++ b/remote-agent/agent.py
@@ -1813,16 +1813,50 @@ class RemoteAgent:
         # reachable from the browser. User-configured hostname takes priority.
         hostname = self.config.hostname
         if hostname and hostname != "localhost":
-            return hostname
+            # Validate hostname format (IP address or valid hostname)
+            if self._is_valid_hostname(hostname):
+                logger.debug("Using configured hostname: %s", hostname)
+                return hostname
+            else:
+                logger.warning(
+                    "Configured hostname '%s' is not a valid IP or hostname format, "
+                    "falling back to auto-detection",
+                    hostname,
+                )
         # Fall back to auto-detected IP address
         try:
             with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
                 s.connect(("8.8.8.8", 80))
                 ip = s.getsockname()[0]
+                logger.debug("Auto-detected IP address: %s", ip)
                 return ip
-        except Exception:
-            pass
+        except Exception as e:
+            logger.warning("Failed to auto-detect IP address: %s", e)
+        logger.debug("Using fallback hostname: 127.0.0.1")
         return "127.0.0.1"
+
+    def _is_valid_hostname(self, hostname: str) -> bool:
+        """Validate hostname format (IP address or valid hostname)."""
+        # Check if it's a valid IP address (IPv4 or IPv6)
+        try:
+            socket.inet_pton(socket.AF_INET, hostname)
+            return True
+        except OSError:
+            pass
+        try:
+            socket.inet_pton(socket.AF_INET6, hostname)
+            return True
+        except OSError:
+            pass
+        # Check if it's a valid hostname (RFC 1123)
+        import re
+
+        # Hostname: 1-253 chars, alphanumeric and hyphens, no leading/trailing hyphens
+        hostname_pattern = re.compile(
+            r"^(?=.{1,253}$)(?!-)[A-Za-z0-9-]{1,63}(?<!-)"
+            r"(\.[A-Za-z0-9-]{1,63}(?<!-))*$"
+        )
+        return bool(hostname_pattern.match(hostname))
 
     def _apply_cli_settings(self, cli_settings: dict[str, Any]) -> None:
         """

--- a/remote-agent/agent.py
+++ b/remote-agent/agent.py
@@ -1853,8 +1853,7 @@ class RemoteAgent:
 
         # Hostname: 1-253 chars, alphanumeric and hyphens, no leading/trailing hyphens
         hostname_pattern = re.compile(
-            r"^(?=.{1,253}$)(?!-)[A-Za-z0-9-]{1,63}(?<!-)"
-            r"(\.[A-Za-z0-9-]{1,63}(?<!-))*$"
+            r"^(?=.{1,253}$)(?!-)[A-Za-z0-9-]{1,63}(?<!-)" r"(\.[A-Za-z0-9-]{1,63}(?<!-))*$"
         )
         return bool(hostname_pattern.match(hostname))
 

--- a/tests/issues/610/test_remote_agent_handlers.py
+++ b/tests/issues/610/test_remote_agent_handlers.py
@@ -1099,3 +1099,75 @@ class TestGetReachableHostname:
 
         assert result == "172.16.0.1"
         mock_sock.connect.assert_called_once()
+
+
+class TestIsValidHostname:
+    """Tests for RemoteAgent._is_valid_hostname.
+
+    Issue #672: Validate hostname format to prevent invalid configuration.
+    """
+
+    def test_valid_ipv4_address(self):
+        """Valid IPv4 address should pass validation."""
+        agent = _make_agent()
+        assert agent._is_valid_hostname("192.168.1.100") is True
+        assert agent._is_valid_hostname("10.0.0.1") is True
+        assert agent._is_valid_hostname("127.0.0.1") is True
+
+    def test_valid_ipv6_address(self):
+        """Valid IPv6 address should pass validation."""
+        agent = _make_agent()
+        assert agent._is_valid_hostname("::1") is True
+        assert agent._is_valid_hostname("fe80::1") is True
+        assert agent._is_valid_hostname("2001:db8::1") is True
+
+    def test_valid_hostname(self):
+        """Valid hostname should pass validation."""
+        agent = _make_agent()
+        assert agent._is_valid_hostname("example.com") is True
+        assert agent._is_valid_hostname("my-host.local") is True
+        assert agent._is_valid_hostname("server01") is True
+
+    def test_invalid_hostname_with_special_chars(self):
+        """Hostname with invalid characters should fail."""
+        agent = _make_agent()
+        assert agent._is_valid_hostname("host@name") is False
+        assert agent._is_valid_hostname("host name") is False
+        assert agent._is_valid_hostname("host!name") is False
+
+    def test_invalid_hostname_leading_hyphen(self):
+        """Hostname with leading hyphen should fail."""
+        agent = _make_agent()
+        assert agent._is_valid_hostname("-hostname") is False
+
+    def test_invalid_hostname_trailing_hyphen(self):
+        """Hostname with trailing hyphen should fail."""
+        agent = _make_agent()
+        assert agent._is_valid_hostname("hostname-") is False
+
+    def test_empty_string_fails(self):
+        """Empty string should fail validation."""
+        agent = _make_agent()
+        assert agent._is_valid_hostname("") is False
+
+
+class TestGetReachableHostnameWithValidation:
+    """Tests for _get_reachable_hostname with format validation (Issue #672 Minor fix)."""
+
+    def test_invalid_hostname_falls_back_to_ip_detection(self):
+        """Invalid hostname format should fall back to IP detection."""
+        agent = _make_agent()
+        agent.config.hostname = "invalid@hostname"  # Invalid format
+
+        with patch("agent.socket.socket") as mock_socket_class:
+            mock_sock = MagicMock()
+            mock_sock.__enter__ = MagicMock(return_value=mock_sock)
+            mock_sock.__exit__ = MagicMock(return_value=False)
+            mock_sock.getsockname.return_value = ("192.168.1.50", 0)
+            mock_socket_class.return_value = mock_sock
+
+            result = agent._get_reachable_hostname()
+
+        # Should return auto-detected IP, NOT invalid hostname
+        assert result == "192.168.1.50"
+        mock_sock.connect.assert_called_once()

--- a/tests/issues/610/test_remote_agent_handlers.py
+++ b/tests/issues/610/test_remote_agent_handlers.py
@@ -61,6 +61,7 @@ def _make_agent() -> RemoteAgent:
     agent._vscode_processes = {}
     agent._vscode_tokens = {}
     agent._vscode_ports = {}
+    agent._vscode_passwords = {}
 
     return agent
 
@@ -1003,3 +1004,98 @@ class TestRunGit:
         assert stdout == ""
         assert "oops" in stderr
         assert success is False
+
+
+class TestGetReachableHostname:
+    """Tests for RemoteAgent._get_reachable_hostname.
+
+    Issue #672: When VPN is active, socket.connect returns VPN IP which may not
+    be reachable from the browser. Configured hostname should take priority.
+    """
+
+    def test_configured_hostname_takes_priority_over_detected_ip(self):
+        """Configured hostname should be used instead of auto-detected IP."""
+        agent = _make_agent()
+        agent.config.hostname = "192.168.1.100"  # Configured LAN IP
+
+        # Even if socket.connect would return a different IP (VPN IP scenario)
+        with patch("agent.socket.socket") as mock_socket_class:
+            mock_sock = MagicMock()
+            mock_sock.__enter__ = MagicMock(return_value=mock_sock)
+            mock_sock.__exit__ = MagicMock(return_value=False)
+            mock_sock.getsockname.return_value = ("192.168.255.10", 0)  # VPN IP
+            mock_socket_class.return_value = mock_sock
+
+            result = agent._get_reachable_hostname()
+
+        # Should return configured hostname, NOT the VPN IP
+        assert result == "192.168.1.100"
+        # socket.connect should NOT be called when hostname is configured
+        mock_sock.connect.assert_not_called()
+
+    def test_localhost_is_ignored_and_ip_detected(self):
+        """'localhost' should be treated as not configured, IP detection kicks in."""
+        agent = _make_agent()
+        agent.config.hostname = "localhost"
+
+        with patch("agent.socket.socket") as mock_socket_class:
+            mock_sock = MagicMock()
+            mock_sock.__enter__ = MagicMock(return_value=mock_sock)
+            mock_sock.__exit__ = MagicMock(return_value=False)
+            mock_sock.getsockname.return_value = ("192.168.1.50", 0)
+            mock_socket_class.return_value = mock_sock
+
+            result = agent._get_reachable_hostname()
+
+        assert result == "192.168.1.50"
+        mock_sock.connect.assert_called_once()
+
+    def test_no_hostname_uses_detected_ip(self):
+        """No hostname configured -> auto-detect IP via socket.connect."""
+        agent = _make_agent()
+        agent.config.hostname = None
+
+        with patch("agent.socket.socket") as mock_socket_class:
+            mock_sock = MagicMock()
+            mock_sock.__enter__ = MagicMock(return_value=mock_sock)
+            mock_sock.__exit__ = MagicMock(return_value=False)
+            mock_sock.getsockname.return_value = ("10.0.0.5", 0)
+            mock_socket_class.return_value = mock_sock
+
+            result = agent._get_reachable_hostname()
+
+        assert result == "10.0.0.5"
+        mock_sock.connect.assert_called_once_with(("8.8.8.8", 80))
+
+    def test_socket_failure_fallback_to_localhost(self):
+        """If socket.connect fails, fallback to 127.0.0.1."""
+        agent = _make_agent()
+        agent.config.hostname = None
+
+        with patch("agent.socket.socket") as mock_socket_class:
+            mock_sock = MagicMock()
+            mock_sock.__enter__ = MagicMock(return_value=mock_sock)
+            mock_sock.__exit__ = MagicMock(return_value=False)
+            mock_sock.connect.side_effect = OSError("Network unreachable")
+            mock_socket_class.return_value = mock_sock
+
+            result = agent._get_reachable_hostname()
+
+        assert result == "127.0.0.1"
+
+    def test_empty_string_hostname_uses_detected_ip(self):
+        """Empty string hostname should be treated as not configured."""
+        agent = _make_agent()
+        agent.config.hostname = ""
+
+        with patch("agent.socket.socket") as mock_socket_class:
+            mock_sock = MagicMock()
+            mock_sock.__enter__ = MagicMock(return_value=mock_sock)
+            mock_sock.__exit__ = MagicMock(return_value=False)
+            mock_sock.getsockname.return_value = ("172.16.0.1", 0)
+            mock_socket_class.return_value = mock_sock
+
+            result = agent._get_reachable_hostname()
+
+        assert result == "172.16.0.1"
+        mock_sock.connect.assert_called_once()


### PR DESCRIPTION
## 问题描述

用户通过浏览器访问远程 Mac 终端时，WebSocket 连接反复断开重连，显示 "Connected to remote terminal" 与 "Connection closed. Reconnecting..." 交替出现。

WebSocket 日志显示 "426 Upgrade Required" 错误。

## 问题原因

远程 Mac 有多个网络接口：
- `192.168.1.238` - 局域网 IP（正确）
- `192.168.255.10` - VPN（utun4）接口 IP

`_get_reachable_hostname()` 方法使用 `socket.connect(("8.8.8.8", 80))` 获取本机 IP，当 VPN 连接时获取到 VPN IP `192.168.255.10`，导致 WebSocket URL 配置错误。

## 修复方案

修改 `_get_reachable_hostname()` 方法，**优先使用配置的 hostname**（如果配置且不是 localhost），然后再尝试自动检测 IP：

```python
def _get_reachable_hostname(self) -> str:
    # Prefer configured hostname if set and not localhost (fixes VPN IP issue)
    hostname = self.config.hostname
    if hostname and hostname != "localhost":
        return hostname
    # Fall back to auto-detected IP address
    try:
        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
            s.connect(("8.8.8.8", 80))
            ip = s.getsockname()[0]
            return ip
    except Exception:
        pass
    return "127.0.0.1"
```

## 修改的文件

| 文件 | 修改内容 |
|------|----------|
| `remote-agent/agent.py` | 修改 `_get_reachable_hostname()` 方法优先级逻辑 |

## 使用说明

用户在 VPN 环境下使用远程终端时，需要在远程 agent 配置文件 `~/.open-ace-agent/config.json` 中添加正确的局域网 IP：

```json
{
  "hostname": "192.168.1.238"
}
```

Closes #672