### PR TITLE
fix(ui): 工作区会话列表显示重命名后的会话名，tooltip 支持完整展示 (Issue #1031)

### DIFF
--- a/frontend/src/components/work/SessionList.tsx
+++ b/frontend/src/components/work/SessionList.tsx
@@ -399,7 +399,20 @@ const SessionGroup: React.FC<SessionGroupProps> = ({
                 ) : (
                   <i className="bi bi-laptop text-success me-1" title="Local" />
                 )}
-                {displaySessionId(session.id, 4)}
+                {(() => {
+                  const sessionIdShort = displaySessionId(session.id, 4);
+                  const sessionIdFull = displaySessionId(session.id, 8);
+                  const sessionTitle = session.title ?? '';
+                  // Check if title is meaningful (not a default pattern like "qwen - 2a277802" or "Session 2a277802")
+                  const isDefaultTitle =
+                    sessionTitle.includes(sessionIdFull) ||
+                    sessionTitle.match(/^[a-z]+ - [a-f0-9]{8}$/i);
+                  // Format: "2a27（会话名字）" or just "2a27"
+                  if (sessionTitle && !isDefaultTitle) {
+                    return `${sessionIdShort}（${sessionTitle}）`;
+                  }
+                  return sessionIdShort;
+                })()}
               </span>
               <span className="session-time text-muted">{session.time}</span>
               <span className="session-requests text-muted">

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -2642,9 +2642,7 @@ table .latency-row:hover td {
   color: #f8fafc;
   line-height: 1.4;
   margin-bottom: 6px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  word-break: break-word;
 }
 
 .session-tooltip-preview {


### PR DESCRIPTION
Fixes #1031

## 问题描述

工作区会话重命名后，会话列表存在以下问题：
1. **会话列表项只显示 ID 前 4 位**，不显示重命名后的会话名
2. **Tooltip 标题过长时被截断**，无法查看完整会话名

## 修改内容

### 1. 会话列表项显示改进 ()
- 判断 title 是否为默认标题（包含 session ID 或匹配默认模式）
- 如果有自定义标题，显示 `ID（标题）` 格式，如 `2d63（下拉列表#828, #834）`
- 默认标题只显示 ID 前 4 位

### 2. Tooltip 样式修复 ()
- 移除 `.session-tooltip-title` 的截断样式
- 添加 `word-break: break-word` 支持换行显示完整标题

## 测试

- ✅ Lint 检查通过
- ✅ TypeScript 类型检查通过

🤖 Generated with Qwen Code