### PR TITLE
fix(migration): use revision ID instead of filename in down_revision (Issue #1180)

### DIFF
--- a/migrations/versions/20260622_001_add_session_message_source.py
+++ b/migrations/versions/20260622_001_add_session_message_source.py
@@ -4,7 +4,7 @@ Separates workflow-local persisted messages from transcript sync/fetch rows so
 autonomous milestone/session detail views can filter raw importer data.
 
 Revision ID: 20260622_001_session_message_source
-Revises: 20260621_193547_merge_041_064
+Revises: 7bcf07ee658e
 Create Date: 2026-06-22
 """
 
@@ -14,7 +14,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision: str = "20260622_001_session_message_source"
-down_revision: Union[str, None] = "20260621_193547_merge_041_064"
+down_revision: Union[str, None] = "7bcf07ee658e"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## 问题描述

升级安装过程中，alembic 数据库迁移失败，报 `KeyError`：

```
KeyError: '20260621_193547_merge_041_064'
```

## 根因

`20260622_001_add_session_message_source.py` 的 `down_revision` 使用了**文件名** `'20260621_193547_merge_041_064'` 而非**实际 revision ID** `'7bcf07ee658e'`。

Alembic 的 revision 系统使用 revision ID 来建立依赖链，不是文件名。当 alembic 尝试查找 revision ID 为 `'20260621_193547_merge_041_064'` 的 migration 时，找不到匹配的 revision（该文件的真实 revision ID 是 `'7bcf07ee658e'`），因此报 KeyError。

## 修复内容

将 `down_revision` 从文件名改为正确的 revision ID：

```python
# 修改前
down_revision: Union[str, None] = "20260621_193547_merge_041_064"

# 修改后
down_revision: Union[str, None] = "7bcf07ee658e"
```

同步更新 docstring 中的 `Revises` 字段。

## 验证

修复后 `alembic heads` 输出唯一 head：
```
20260622_001_session_message_source (head)
```

`alembic history` 显示完整连续的 revision 链，无 KeyError。

## 影响范围

- `migrations/versions/20260622_001_add_session_message_source.py` — 仅修改 down_revision 和 docstring

Closes #1180