### PR TITLE
fix(docker): 修复 alembic migration 系统失效问题 (Issue #1192)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -116,11 +116,13 @@ RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 # - In production, use network isolation and limit container privileges
 # - Refer to docker-entrypoint.sh for sudoers configuration details
 
-# Environment variables
+# Environment variables (Issue #1192: add LANG/LC_ALL for Unicode support)
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     FLASK_APP=server.py \
-    FLASK_ENV=production
+    FLASK_ENV=production \
+    LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8
 
 # Expose port
 EXPOSE 5000

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -192,8 +192,8 @@ import os, psycopg2
 try:
     conn = psycopg2.connect(os.environ['DATABASE_URL'])
     cur = conn.cursor()
-    cur.execute(\"ALTER MATERIALIZED VIEW IF EXISTS session_stats OWNER TO current_user\")
-    cur.execute(\"ALTER MATERIALIZED VIEW IF EXISTS request_stats OWNER TO current_user\")
+    cur.execute(\"ALTER MATERIALIZED VIEW IF EXISTS session_stats OWNER TO CURRENT_USER\")
+    cur.execute(\"ALTER MATERIALIZED VIEW IF EXISTS request_stats OWNER TO CURRENT_USER\")
     conn.commit()
     conn.close()
 except Exception as e:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -113,9 +113,26 @@ if [ -n "$DATABASE_URL" ]; then
         exit 1
     fi
 
-    # Check if database is initialized (check core 'users' table, not alembic_version)
-    echo "Checking database initialization status..."
-    TABLES_EXIST=$(python3 -c "
+    # Check database migration status using alembic_version table (Issue #1192)
+    # This is more accurate than checking 'users' table for migration tracking
+    echo "Checking database migration status..."
+    ALEMBIC_EXISTS=$(python3 -c "
+import os, psycopg2
+try:
+    conn = psycopg2.connect(os.environ['DATABASE_URL'])
+    cur = conn.cursor()
+    cur.execute(\"SELECT 1 FROM information_schema.tables WHERE table_name = 'alembic_version'\")
+    result = 'yes' if cur.fetchone() else 'no'
+    conn.close()
+    print(result)
+except Exception:
+    print('error')
+" 2>/dev/null || echo "error")
+
+    if [ "$ALEMBIC_EXISTS" = "no" ]; then
+        # alembic_version not found - check if this is legacy upgrade or fresh install
+        echo "alembic_version table not found. Checking for existing tables..."
+        USERS_EXIST=$(python3 -c "
 import os, psycopg2
 try:
     conn = psycopg2.connect(os.environ['DATABASE_URL'])
@@ -125,35 +142,63 @@ try:
     conn.close()
     print(result)
 except Exception:
-    print('error')
-" 2>/dev/null || echo "error")
+    print('no')
+" 2>/dev/null || echo "no")
 
-    if [ "$TABLES_EXIST" = "no" ]; then
-        echo "Database not initialized. Creating schema from schema-postgres.sql..."
-        python3 -c "
-import os, psycopg2
-conn = psycopg2.connect(os.environ['DATABASE_URL'])
-cur = conn.cursor()
-with open('schema/schema-postgres.sql') as f:
-    cur.execute(f.read())
-conn.commit()
-conn.close()
-print('Schema created successfully.')
-"
-        echo "Stamping alembic version to head..."
-        alembic stamp head 2>/dev/null || echo "WARNING: alembic stamp failed (non-critical)"
+        if [ "$USERS_EXIST" = "yes" ]; then
+            # Legacy database: tables exist but alembic_version missing
+            # This happens when database was initialized with schema.sql but stamp failed
+            echo "Legacy database detected (tables exist, alembic_version missing)."
+            echo "Stamping alembic version to enable future migrations..."
+            alembic stamp head
+            if [ $? -ne 0 ]; then
+                echo "ERROR: alembic stamp failed, database may be corrupted"
+                exit 1
+            fi
+            echo "Alembic version stamped successfully."
 
-        echo "Creating default admin user..."
-        python3 scripts/init_db.py 2>/dev/null || echo "WARNING: admin user creation failed (may already exist)"
+            # Run any pending migrations after stamp
+            echo "Running pending migrations..."
+            alembic upgrade head || echo "No pending migrations."
+        else
+            # Fresh installation: use alembic migrations for complete initialization
+            echo "Database not initialized. Running alembic migrations..."
+            alembic upgrade head
+            if [ $? -ne 0 ]; then
+                echo "ERROR: alembic upgrade head failed"
+                exit 1
+            fi
 
-        echo "Database initialization completed."
-    elif [ "$TABLES_EXIST" = "error" ]; then
+            # Create default admin user
+            echo "Creating default admin user..."
+            python3 scripts/init_db.py || echo "WARNING: admin user creation failed (may already exist)"
+
+            echo "Database initialization completed."
+        fi
+    elif [ "$ALEMBIC_EXISTS" = "error" ]; then
         echo "WARNING: Could not check database status. Attempting migration..."
-        alembic upgrade head 2>/dev/null || echo "WARNING: Migration failed (database may not be ready)"
+        alembic upgrade head || echo "WARNING: Migration failed (database may not be ready)"
     else
+        # Database already has alembic_version: run pending migrations
         echo "Database already initialized. Running pending migrations..."
-        alembic upgrade head 2>/dev/null || echo "No pending migrations."
+        alembic upgrade head || echo "No pending migrations."
     fi
+
+    # Fix materialized view ownership for PostgreSQL (Issue #1192)
+    # Ensure current database user can refresh materialized views
+    echo "Fixing materialized view ownership..."
+    python3 -c "
+import os, psycopg2
+try:
+    conn = psycopg2.connect(os.environ['DATABASE_URL'])
+    cur = conn.cursor()
+    cur.execute(\"ALTER MATERIALIZED VIEW IF EXISTS session_stats OWNER TO current_user\")
+    cur.execute(\"ALTER MATERIALIZED VIEW IF EXISTS request_stats OWNER TO current_user\")
+    conn.commit()
+    conn.close()
+except Exception as e:
+    print(f'Warning: materialized view fix failed: {e}')
+" || echo "WARNING: materialized view ownership fix failed"
 fi
 
 # ============================================================================

--- a/migrations/versions/20260622_001_add_session_message_source.py
+++ b/migrations/versions/20260622_001_add_session_message_source.py
@@ -3,7 +3,7 @@
 Separates workflow-local persisted messages from transcript sync/fetch rows so
 autonomous milestone/session detail views can filter raw importer data.
 
-Revision ID: 20260622_001_session_message_source
+Revision ID: 064_add_session_msg_source
 Revises: 7bcf07ee658e
 Create Date: 2026-06-22
 """
@@ -13,7 +13,7 @@ from typing import Union
 import sqlalchemy as sa
 from alembic import op
 
-revision: str = "20260622_001_session_message_source"
+revision: str = "064_add_session_msg_source"
 down_revision: Union[str, None] = "7bcf07ee658e"
 branch_labels = None
 depends_on = None

--- a/scripts/install-central/docker-method/install.sh
+++ b/scripts/install-central/docker-method/install.sh
@@ -2496,6 +2496,23 @@ upgrade_deployment() {
         fi
     fi
 
+    # 5.6. Check alembic_version table before recreating container (Issue #1192)
+    # This detects legacy databases that were initialized with schema.sql but
+    # alembic stamp failed silently. We need to fix this after container restart.
+    print_info "检查数据库 migration 状态..."
+    local alembic_exists=""
+    alembic_exists=$(docker compose exec -T postgres psql -U "$DB_USER" -d "$DB_NAME" -t -c \
+        "SELECT 1 FROM information_schema.tables WHERE table_name = 'alembic_version';" 2>/dev/null | tr -d '[:space:]')
+
+    if [ "$alembic_exists" = "1" ]; then
+        print_success "alembic_version 表存在，migration 系统正常"
+        export ALEMBIC_VERSION_EXISTS="yes"
+    else
+        print_warning "alembic_version 表不存在"
+        print_info "数据库可能是旧版本升级，需要在容器重启后执行 alembic stamp head"
+        export ALEMBIC_VERSION_EXISTS="no"
+    fi
+
     # 6. Recreate only open-ace container (PostgreSQL not restarted)
     print_info "重建 open-ace 容器..."
     docker compose up -d --force-recreate open-ace
@@ -2523,6 +2540,26 @@ upgrade_deployment() {
 
     if [ $attempt -gt $max_attempts ]; then
         print_warning "应用启动中，请稍后检查状态"
+    fi
+
+    # 7. Fix alembic_version if missing (Issue #1192)
+    # For legacy databases initialized with schema.sql, alembic stamp may have failed.
+    # The docker-entrypoint.sh handles this automatically, but we verify here.
+    if [ "$ALEMBIC_VERSION_EXISTS" = "no" ]; then
+        print_info "验证 alembic stamp 是否已由 entrypoint 自动修复..."
+        local alembic_fixed=""
+        alembic_fixed=$(docker compose exec -T postgres psql -U "$DB_USER" -d "$DB_NAME" -t -c \
+            "SELECT 1 FROM information_schema.tables WHERE table_name = 'alembic_version';" 2>/dev/null | tr -d '[:space:]')
+
+        if [ "$alembic_fixed" = "1" ]; then
+            print_success "alembic_version 表已自动创建"
+        else
+            print_warning "alembic_version 表仍然缺失，尝试手动修复..."
+            docker compose exec -T open-ace alembic stamp head 2>&1 || {
+                print_error "alembic stamp head 失败，请检查日志"
+                print_info "可能需要手动执行: docker compose exec open-ace alembic stamp head"
+            }
+        fi
     fi
 
     return 0


### PR DESCRIPTION
## 问题概述

Issue #1192: Docker 版 schema.sql 不含 alembic_version 表导致 migration 系统完全失效。

**根本原因**:
1. schema.sql 由 pg_dump 生成，不包含 alembic_version 表
2. docker-entrypoint.sh 的 alembic stamp head 2>/dev/null 失败被静默吞没
3. 导致后续 alembic upgrade head 无法识别数据库版本

## 修复方案

- docker-entrypoint.sh: 重构数据库初始化逻辑，双重检测机制
- Dockerfile: 添加 LANG/LC_ALL 解决 Unicode 编码问题
- install.sh: 升级模式添加 alembic_version 检查和自动修复
- migration revision ID: 缩短到 32 字符以内

## 验证结果

node236 测试: ✅ alembic_version 创建, ✅ source 列添加, ✅ 物化视图修复

Fixes #1192
