### PR TITLE
fix: install.sh 多安装路径选择时 bash 数组语法错误

### DIFF
--- a/scripts/install-central/package-method/install.sh
+++ b/scripts/install-central/package-method/install.sh
@@ -2410,7 +2410,7 @@ detect_and_load_local_upgrade() {
             fi
             print_info "  [$i] ${valid_paths[$i]} (owner: $path_owner)"
         done
-        prompt_input "Select installation to upgrade [0-${#valid_paths[@]-1}]" "0" selection
+        prompt_input "Select installation to upgrade [0-$(( ${#valid_paths[@]} - 1 ))]" "0" selection
         if [ -n "$selection" ] && [ "$selection" -ge 0 ] && [ "$selection" -lt ${#valid_paths[@]} ]; then
             target_path="${valid_paths[$selection]}"
         else


### PR DESCRIPTION
## 问题描述

Fixes #1198

在 install.sh 脚本中，当检测到多个 Open ACE 安装路径时，脚本会因为 bash 语法错误而崩溃。

## 问题根因

`${#valid_paths[@]-1}` 不是有效的 bash 语法 - `-1` 被解释为"默认值语法"，而非算术减法。

## 修复方案

使用正确的 bash 算术表达式：`$(( ${#valid_paths[@]} - 1 ))`

## 测试验证

在 node237 上验证 bash 语法正确，模拟多安装路径场景确认选择逻辑正常。