### PR TITLE
fix: 合并 Alembic 多 head 版本解决迁移失败问题 (#1203)

### DIFF
--- a/migrations/versions/20260623_merge_heads.py
+++ b/migrations/versions/20260623_merge_heads.py
@@ -3,20 +3,28 @@
 Revision ID: 20260623_merge_heads
 Revises: 20260622_001_session_message_source, 026_add_tool_account_mapping_rules
 Create Date: 2026-06-23
+
+Merge point that collapses the two heads created when the tool_account_mapping_rules
+migration branched independently while session_message_source continued from the
+earlier merge point. This is a topological merge only -- no schema changes.
 """
 
-from alembic import op
-import sqlalchemy as sa
+from typing import Sequence, Union
 
-revision = "20260623_merge_heads"
-down_revision = ("20260622_001_session_message_source", "026_add_tool_account_mapping_rules")
-branch_labels = None
-depends_on = None
-
-
-def upgrade():
-    pass  # Topological merge only - no schema changes
+revision: str = "20260623_merge_heads"
+down_revision: Union[str, None] = (
+    "20260622_001_session_message_source",
+    "026_add_tool_account_mapping_rules",
+)
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
 
 
-def downgrade():
+def upgrade() -> None:
+    """Upgrade database schema."""
+    pass
+
+
+def downgrade() -> None:
+    """Downgrade database schema."""
     pass

--- a/migrations/versions/20260623_merge_heads.py
+++ b/migrations/versions/20260623_merge_heads.py
@@ -1,0 +1,22 @@
+"""Merge multiple heads into single revision.
+
+Revision ID: 20260623_merge_heads
+Revises: 20260622_001_session_message_source, 026_add_tool_account_mapping_rules
+Create Date: 2026-06-23
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "20260623_merge_heads"
+down_revision = ("20260622_001_session_message_source", "026_add_tool_account_mapping_rules")
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pass  # Topological merge only - no schema changes
+
+
+def downgrade():
+    pass

--- a/scripts/install-central/package-method/install.sh
+++ b/scripts/install-central/package-method/install.sh
@@ -2410,7 +2410,7 @@ detect_and_load_local_upgrade() {
             fi
             print_info "  [$i] ${valid_paths[$i]} (owner: $path_owner)"
         done
-        prompt_input "Select installation to upgrade [0-${#valid_paths[@]-1}]" "0" selection
+        prompt_input "Select installation to upgrade [0-$(( ${#valid_paths[@]} - 1 ))]" "0" selection
         if [ -n "$selection" ] && [ "$selection" -ge 0 ] && [ "$selection" -lt ${#valid_paths[@]} ]; then
             target_path="${valid_paths[$selection]}"
         else


### PR DESCRIPTION
## 问题

执行 package-method install.sh 升级安装时，Alembic 迁移失败：
```
ERROR [alembic.util.messaging] Multiple head revisions are present for argument 'head'
```

## 修复内容

创建合并迁移 `migrations/versions/20260623_merge_heads.py`，统一两个 head 分支：
- `20260622_001_session_message_source`
- `026_add_tool_account_mapping_rules`

## 验证结果

已在 node236 和 node237 上验证迁移成功：
- ✅ `alembic heads` 显示单一 head
- ✅ `session_messages.source` 字段已添加
- ✅ `tool_account_mapping_rules` 表已创建

## 关联

Fixes #1203