### PR TITLE
fix(ui): 工作区标签页添加 tooltip 显示完整会话名 (Issue #1207)

### DIFF
--- a/frontend/src/components/features/Workspace.tsx
+++ b/frontend/src/components/features/Workspace.tsx
@@ -1838,6 +1838,7 @@ export const Workspace: React.FC = () => {
                       tab.waitingForUser && 'fw-semibold'
                     )}
                     style={{ minWidth: 0 }}
+                    title={tab.title}
                   >
                     {tab.tabType === 'terminal' ? (
                       <i className="bi bi-terminal-fill text-warning me-1" title="Terminal" />


### PR DESCRIPTION
## 问题描述

Work 模式中间面板（工作区）的标签页，会话重命名后标题被截断显示省略号，无法查看完整会话名。

## 修复内容

给标签页标题的 `<span>` 添加 `title` 属性作为 tooltip，当标题被截断时，用户 hover 可查看完整会话名。

## 关联 Issue

Fixes #1207

## 测试方法

1. 在工作区打开一个会话
2. 重命名会话为较长的名称
3. 观察标签页标题是否截断
4. Hover 标签页标题，确认 tooltip 显示完整会话名