### PR TITLE
fix(docker): 添加 volume 映射解决容器重建数据丢失问题 (Issue #1205)

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -370,8 +370,16 @@ def create_system_user(username):
     # When /home is mounted as volume, useradd -m won't fix permissions on existing directory
     user_home = f'/home/{username}'
     if os.path.isdir(user_home):
-        subprocess.run(['chown', '-R', f'{username}:{username}', user_home], capture_output=True)
-        print(f'  Fixed home directory permissions: {user_home}')
+        # Check if ownership is correct before running chown (Issue #1209 review)
+        stat_result = subprocess.run(['stat', '-c', '%U:%G', user_home], capture_output=True, text=True)
+        current_owner = stat_result.stdout.strip()
+        expected_owner = f'{username}:{username}'
+
+        if current_owner != expected_owner:
+            subprocess.run(['chown', '-R', f'{username}:{username}', user_home], capture_output=True)
+            print(f'  Fixed home directory permissions: {user_home}')
+        else:
+            print(f'  Home directory ownership correct: {user_home}')
 
     # Sync SSH keys if mounted (Issue #1122)
     sync_ssh_keys(username)

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -5,7 +5,13 @@
 set -e
 
 # ============================================================================
-# 0. Pre-flight Validation (Issue #1006)
+# 0. Pre-flight Setup
+# ============================================================================
+# Create logs directory (Issue #1205)
+mkdir -p /app/logs
+
+# ============================================================================
+# 0.1. Pre-flight Validation (Issue #1006)
 # ============================================================================
 validate_node_environment() {
     echo "Validating Node.js environment..."
@@ -360,6 +366,13 @@ def create_system_user(username):
         subprocess.run(['chown', f'{username}:{username}', user_workspace], capture_output=True)
         print(f'  Created workspace directory: {user_workspace}')
 
+    # Fix home directory permissions (Issue #1205)
+    # When /home is mounted as volume, useradd -m won't fix permissions on existing directory
+    user_home = f'/home/{username}'
+    if os.path.isdir(user_home):
+        subprocess.run(['chown', '-R', f'{username}:{username}', user_home], capture_output=True)
+        print(f'  Fixed home directory permissions: {user_home}')
+
     # Sync SSH keys if mounted (Issue #1122)
     sync_ssh_keys(username)
 
@@ -453,7 +466,7 @@ try:
     print('User and project sync completed.')
 except Exception as e:
     print(f'Error syncing users and projects: {e}')
-" 2>&1 | tee /var/log/open-ace-user-sync.log || echo "WARNING: User sync failed - check /var/log/open-ace-user-sync.log for details"
+" 2>&1 | tee /app/logs/open-ace-user-sync.log || echo "WARNING: User sync failed - check /app/logs/open-ace-user-sync.log for details"
     fi
 
     # Configure sudoers for qwen-code-webui

--- a/scripts/install-central/docker-method/install.sh
+++ b/scripts/install-central/docker-method/install.sh
@@ -2385,15 +2385,23 @@ upgrade_deployment() {
                 local home_exists=$(docker exec "$old_container" test -d /home 2>/dev/null && echo "yes" || echo "no")
 
                 if [ "$home_exists" = "yes" ]; then
-                    local home_files=$(docker exec "$old_container" ls -1 /home 2>/dev/null | grep -v "open-ace" || true)
+                    # Exclude default system users (Issue #1209 review)
+                    local home_files=$(docker exec "$old_container" ls -1 /home 2>/dev/null | grep -v -E "^(open-ace|openace|root)$" || true)
 
                     if [ -n "$home_files" ]; then
                         print_info "发现容器内 home 目录数据，正在迁移..."
                         mkdir -p "$DEPLOY_DIR/data/home"
 
                         for user_dir in $home_files; do
-                            print_info "  迁移: /home/$user_dir -> ./data/home/$user_dir"
-                            docker cp "$old_container:/home/$user_dir" "$DEPLOY_DIR/data/home/" 2>/dev/null || true
+                            local target_dir="$DEPLOY_DIR/data/home/$user_dir"
+
+                            # Skip if target already exists to avoid overwriting (Issue #1209 review)
+                            if [ -d "$target_dir" ]; then
+                                print_warning "  跳过已存在目录: ./data/home/$user_dir"
+                            else
+                                print_info "  迁移: /home/$user_dir -> ./data/home/$user_dir"
+                                docker cp "$old_container:/home/$user_dir" "$DEPLOY_DIR/data/home/" 2>/dev/null || true
+                            fi
                         done
 
                         print_success "home 目录数据迁移完成: ./data/home"
@@ -2697,7 +2705,9 @@ create_directories() {
     # This ensures user home directories persist across container restarts
     if [ "$WORKSPACE_MULTI_USER_MODE" = "true" ]; then
         mkdir -p "$DEPLOY_DIR"/data/home
-        print_info "  - $DEPLOY_DIR/data/home (多用户 home 目录)"
+        # Set restrictive permissions for sensitive user data (Issue #1209 review)
+        chmod 700 "$DEPLOY_DIR"/data/home
+        print_info "  - $DEPLOY_DIR/data/home (多用户 home 目录, 权限 700)"
     fi
 
     print_success "目录创建完成"

--- a/scripts/install-central/docker-method/install.sh
+++ b/scripts/install-central/docker-method/install.sh
@@ -2376,6 +2376,33 @@ upgrade_deployment() {
         if docker ps -a --format '{{.Names}}' 2>/dev/null | grep -q "^${old_container}$"; then
             print_info "停止容器: $old_container"
             docker stop "$old_container" 2>/dev/null || true
+
+            # Data migration for multi-user mode (Issue #1205)
+            # Export container /home data to host ./data/home before container removal
+            # This is a one-time migration when upgrading from version without volume mapping
+            if [ "$WORKSPACE_MULTI_USER_MODE" = "true" ]; then
+                print_info "检查容器内 home 目录数据..."
+                local home_exists=$(docker exec "$old_container" test -d /home 2>/dev/null && echo "yes" || echo "no")
+
+                if [ "$home_exists" = "yes" ]; then
+                    local home_files=$(docker exec "$old_container" ls -1 /home 2>/dev/null | grep -v "open-ace" || true)
+
+                    if [ -n "$home_files" ]; then
+                        print_info "发现容器内 home 目录数据，正在迁移..."
+                        mkdir -p "$DEPLOY_DIR/data/home"
+
+                        for user_dir in $home_files; do
+                            print_info "  迁移: /home/$user_dir -> ./data/home/$user_dir"
+                            docker cp "$old_container:/home/$user_dir" "$DEPLOY_DIR/data/home/" 2>/dev/null || true
+                        done
+
+                        print_success "home 目录数据迁移完成: ./data/home"
+                    else
+                        print_info "容器内 /home 目录为空，无需迁移"
+                    fi
+                fi
+            fi
+
             print_info "删除容器: $old_container"
             docker rm "$old_container" 2>/dev/null || true
         fi
@@ -2445,6 +2472,14 @@ upgrade_deployment() {
     create_docker_compose
     create_env_file
     NON_INTERACTIVE="$old_non_interactive"
+
+    # 3.5. Ensure new directories exist for volume mounts (Issue #1205)
+    print_info "创建持久化目录..."
+    mkdir -p "$DEPLOY_DIR"/logs
+    if [ "$WORKSPACE_MULTI_USER_MODE" = "true" ]; then
+        mkdir -p "$DEPLOY_DIR"/data/home
+    fi
+    print_success "持久化目录创建完成"
 
     # 4. Update sudoers if multi-user mode is enabled
     if [ "$WORKSPACE_MULTI_USER_MODE" = "true" ]; then
@@ -2653,6 +2688,18 @@ create_directories() {
 
     chmod -R 755 "$DEPLOY_DIR"
 
+    # Create logs directory for Docker volume mount (Issue #1205)
+    # This ensures application logs persist across container restarts
+    mkdir -p "$DEPLOY_DIR"/logs
+    print_info "  - $DEPLOY_DIR/logs (应用日志目录)"
+
+    # Create multi-user home directory for Docker volume mount (Issue #1205)
+    # This ensures user home directories persist across container restarts
+    if [ "$WORKSPACE_MULTI_USER_MODE" = "true" ]; then
+        mkdir -p "$DEPLOY_DIR"/data/home
+        print_info "  - $DEPLOY_DIR/data/home (多用户 home 目录)"
+    fi
+
     print_success "目录创建完成"
     print_info "  - $DEPLOY_DIR/config"
     print_info "  - 所有者: $RUN_USER:$RUN_USER"
@@ -2836,27 +2883,40 @@ create_docker_compose() {
     fi
     # Build volumes section based on enabled tools
     local volumes_section="      - ./config:/root/.open-ace:ro"
-    local user_home="/home/$RUN_USER"
 
-    if [ "$QWEN_ENABLED" = "true" ]; then
-        # Issue #1192: Map to /home/$RUN_USER instead of /home/open-ace
-        # This ensures fetch scripts can find data under /home/$RUN_USER/.qwen/projects
-        # which matches the multi-user scanning logic in fetch_qwen.py
+    # Add logs directory mount (Issue #1205)
+    volumes_section="$volumes_section
+      - ./logs:/app/logs"
+
+    # Handle CLI/home mapping based on multi-user mode (Issue #1205)
+    # Multi-user mode: Use unified ./data/home:/home mount for all users
+    # Single-user mode: Use per-tool CLI directory mounts (Issue #1192: map to /home/$RUN_USER)
+    if [ "$WORKSPACE_MULTI_USER_MODE" = "true" ]; then
         volumes_section="$volumes_section
+      - ./data/home:/home"
+        print_info "  - 映射多用户 home 目录: ./data/home:/home"
+    else
+        local user_home="/home/$RUN_USER"
+
+        if [ "$QWEN_ENABLED" = "true" ]; then
+            # Issue #1192: Map to /home/$RUN_USER instead of /home/open-ace
+            # This ensures fetch scripts can find data under /home/$RUN_USER/.qwen/projects
+            volumes_section="$volumes_section
       - $user_home/.qwen:/home/$RUN_USER/.qwen"
-        print_info "  - 映射 .qwen 目录 ($RUN_USER -> $RUN_USER)"
-    fi
+            print_info "  - 映射 .qwen 目录 ($RUN_USER -> $RUN_USER)"
+        fi
 
-    if [ "$CLAUDE_ENABLED" = "true" ]; then
-        volumes_section="$volumes_section
+        if [ "$CLAUDE_ENABLED" = "true" ]; then
+            volumes_section="$volumes_section
       - $user_home/.claude:/home/$RUN_USER/.claude"
-        print_info "  - 映射 .claude 目录 ($RUN_USER -> $RUN_USER)"
-    fi
+            print_info "  - 映射 .claude 目录 ($RUN_USER -> $RUN_USER)"
+        fi
 
-    if [ "$OPENCLAW_ENABLED" = "true" ]; then
-        volumes_section="$volumes_section
+        if [ "$OPENCLAW_ENABLED" = "true" ]; then
+            volumes_section="$volumes_section
       - $user_home/.openclaw:/home/$RUN_USER/.openclaw"
-        print_info "  - 映射 .openclaw 目录 ($RUN_USER -> $RUN_USER)"
+            print_info "  - 映射 .openclaw 目录 ($RUN_USER -> $RUN_USER)"
+        fi
     fi
 
     # Add workspace volume mount (Issue #1083)


### PR DESCRIPTION
## 问题

Docker 安装脚本缺少关键路径的 volume 映射，容器重启/重建时数据丢失：
- 多用户模式：用户 home 目录 (`/home`) 无持久化
- 应用日志：写入 `/var/log` 或 `/app/logs` 但无映射

## 修复内容

### 1. install.sh `create_directories()`
- 新增 `./logs` 目录（应用日志持久化）
- 多用户模式下新增 `./data/home` 目录

### 2. install.sh `create_docker_compose()`
- 多用户模式：使用 `./data/home:/home` 统一映射，移除 CLI 单独映射
- 单用户模式：保留原有 CLI 目录映射
- 统一添加 `./logs:/app/logs` 映射

### 3. install.sh `upgrade_deployment()`
- 升级前数据迁移：`docker cp` 导出容器内 `/home` 数据
- 升级时目录创建：确保 `logs` 和 `data/home` 目录存在

### 4. docker-entrypoint.sh
- 启动时创建 `/app/logs` 目录
- `create_system_user()` 添加 home 目录权限修复（`useradd -m` 不修复已存在目录权限）
- 日志路径改写为 `/app/logs/open-ace-user-sync.log`

## 测试

- bash -n 语法检查通过

Fixes #1205