### PR TITLE
fix(insights): Insights 报告使用 API Key 的 cli_settings 配置模型 (Issue #1171)

### DIFF
--- a/app/modules/workspace/api_key_proxy.py
+++ b/app/modules/workspace/api_key_proxy.py
@@ -340,7 +340,7 @@ class APIKeyProxyService:
         provider: str,
         scope: str = "remote",
         exclude_key_ids: Optional[set[int]] = None,
-    ) -> Optional[tuple[str, Optional[str], int]]:
+    ) -> Optional[tuple[str, Optional[str], int, Optional[str]]]:
         """
         Resolve and decrypt an API key for a tenant/provider with scope filtering
         and multi-key scheduling.
@@ -352,7 +352,7 @@ class APIKeyProxyService:
             exclude_key_ids: Key IDs to exclude (for failover retries).
 
         Returns:
-            Tuple of (api_key, base_url, key_id) or None if not found.
+            Tuple of (api_key, base_url, key_id, cli_settings) or None if not found.
         """
         from app.modules.workspace.api_key_router import APIKeyRouter
 
@@ -364,7 +364,7 @@ class APIKeyProxyService:
             if is_postgresql():
                 cursor.execute(
                     """
-                    SELECT id, encrypted_key, base_url, priority, weight
+                    SELECT id, encrypted_key, base_url, priority, weight, cli_settings
                     FROM api_key_store
                     WHERE tenant_id = %s AND provider = %s AND is_active = TRUE
                       AND (scope = %s OR scope = 'shared')
@@ -374,7 +374,7 @@ class APIKeyProxyService:
             else:
                 cursor.execute(
                     """
-                    SELECT id, encrypted_key, base_url, priority, weight
+                    SELECT id, encrypted_key, base_url, priority, weight, cli_settings
                     FROM api_key_store
                     WHERE tenant_id = ? AND provider = ? AND is_active = TRUE
                       AND (scope = ? OR scope = 'shared')
@@ -393,6 +393,7 @@ class APIKeyProxyService:
                 row_dict = row if isinstance(row, dict) else dict(row)
                 encrypted_key = row_dict["encrypted_key"]
                 base_url = row_dict["base_url"]
+                cli_settings = row_dict.get("cli_settings")
                 try:
                     decrypted = self._decrypt_key(encrypted_key)
                 except Exception as e:
@@ -405,6 +406,7 @@ class APIKeyProxyService:
                         "base_url": base_url,
                         "priority": row_dict.get("priority") or 0,
                         "weight": row_dict.get("weight") or 100,
+                        "cli_settings": cli_settings,
                     }
                 )
 
@@ -416,7 +418,7 @@ class APIKeyProxyService:
             if selected is None:
                 return None
 
-            return (selected["api_key"], selected["base_url"], selected["id"])
+            return (selected["api_key"], selected["base_url"], selected["id"], selected.get("cli_settings"))
         except Exception as e:
             logger.error("Failed to resolve API key for scope: %s", e)
             return None
@@ -1072,8 +1074,12 @@ class APIKeyProxyService:
         provider: str,
         key_ids: list[int],
         exclude_key_ids: Optional[set[int]] = None,
-    ) -> Optional[tuple[str, Optional[str], int]]:
-        """Resolve a real API key from an allowed key-id subset using HA routing."""
+    ) -> Optional[tuple[str, Optional[str], int, Optional[str]]]:
+        """Resolve a real API key from an allowed key-id subset using HA routing.
+
+        Returns:
+            Tuple of (api_key, base_url, key_id, cli_settings) or None if not found.
+        """
         normalized_ids = sorted({int(key_id) for key_id in key_ids if key_id is not None})
         if not normalized_ids:
             return None
@@ -1084,7 +1090,7 @@ class APIKeyProxyService:
             cursor = conn.cursor()
             cursor.execute(
                 f"""
-                SELECT id, encrypted_key, base_url, priority, weight
+                SELECT id, encrypted_key, base_url, priority, weight, cli_settings
                 FROM api_key_store
                 WHERE tenant_id = {_param()} AND provider = {_param()} AND is_active = TRUE
                   AND id IN ({placeholders})
@@ -1109,6 +1115,7 @@ class APIKeyProxyService:
                     "weight": int(row.get("weight") or 100),
                     "api_key": api_key,
                     "base_url": row.get("base_url"),
+                    "cli_settings": row.get("cli_settings"),
                 }
             )
 
@@ -1119,6 +1126,7 @@ class APIKeyProxyService:
             cast("str", selected["api_key"]),
             cast("Optional[str]", selected.get("base_url")),
             int(selected["id"]),
+            cast("Optional[str]", selected.get("cli_settings")),
         )
 
     def delete_api_key_by_id(self, key_id: int, tenant_id: int) -> bool:

--- a/app/modules/workspace/api_key_proxy.py
+++ b/app/modules/workspace/api_key_proxy.py
@@ -418,7 +418,12 @@ class APIKeyProxyService:
             if selected is None:
                 return None
 
-            return (selected["api_key"], selected["base_url"], selected["id"], selected.get("cli_settings"))
+            return (
+                selected["api_key"],
+                selected["base_url"],
+                selected["id"],
+                selected.get("cli_settings"),
+            )
         except Exception as e:
             logger.error("Failed to resolve API key for scope: %s", e)
             return None

--- a/app/modules/workspace/llm_proxy_handler.py
+++ b/app/modules/workspace/llm_proxy_handler.py
@@ -450,7 +450,7 @@ def handle_llm_proxy_request(
                 500,
             )
 
-        api_key, base_url, key_id = key_result
+        api_key, base_url, key_id, _ = key_result
         target_result = _determine_target_url(provider, base_url, path)
         if isinstance(target_result, tuple):
             return target_result

--- a/app/services/insights_service.py
+++ b/app/services/insights_service.py
@@ -43,7 +43,7 @@ class InsightsService:
             logger.warning(f"Could not load config.json: {e}")
             return {}
 
-    def _get_api_credentials(self, config: dict) -> tuple[str, str]:
+    def _get_api_credentials(self, config: dict) -> tuple[str, str, Optional[str]]:
         """
         Get API credentials from the api_key_store database.
 
@@ -51,7 +51,7 @@ class InsightsService:
         Falls back to environment variables if no key is found in the database.
 
         Returns:
-            Tuple[api_key, base_url]
+            Tuple[api_key, base_url, default_model]
         """
         # Primary: resolve from database
         try:
@@ -60,17 +60,52 @@ class InsightsService:
             api_proxy = get_api_key_proxy_service()
             result = api_proxy.resolve_api_key_for_scope(1, "openai", scope="local")
             if result:
-                api_key, base_url, _ = result
+                api_key, base_url, _, cli_settings = result
+                default_model = self._extract_model_from_cli_settings(cli_settings)
                 if base_url:
-                    return api_key, base_url
-                return api_key, "https://coding.dashscope.aliyuncs.com/v1"
+                    return api_key, base_url, default_model
+                return api_key, "https://coding.dashscope.aliyuncs.com/v1", default_model
         except Exception as e:
             logger.warning("Failed to resolve API key from database: %s", e)
 
         # Fallback: environment variables
         api_key = os.environ.get("OPENAI_API_KEY", "")
         base_url = os.environ.get("OPENAI_BASE_URL", "https://coding.dashscope.aliyuncs.com/v1")
-        return api_key, base_url
+        return api_key, base_url, None
+
+    def _extract_model_from_cli_settings(self, cli_settings: Optional[str]) -> Optional[str]:
+        """
+        Extract default model from cli_settings JSON.
+
+        Parses cli_settings and looks for modelProviders.openai[0].id.
+        Returns None if cli_settings is empty, invalid, or missing the model.
+
+        Args:
+            cli_settings: JSON string from api_key_store.cli_settings.
+
+        Returns:
+            Model ID string or None.
+        """
+        if not cli_settings:
+            return None
+
+        try:
+            settings = json.loads(cli_settings)
+        except json.JSONDecodeError:
+            logger.warning("Invalid cli_settings JSON: %s", cli_settings[:100])
+            return None
+
+        # Try modelProviders.openai[0].id
+        model_providers = settings.get("modelProviders", {})
+        openai_models = model_providers.get("openai", [])
+        if isinstance(openai_models, list) and openai_models:
+            first_model = openai_models[0]
+            if isinstance(first_model, dict):
+                model_id = first_model.get("id")
+                if model_id:
+                    return str(model_id)
+
+        return None
 
     def generate_insights(
         self, user_id: int, start_date: str, end_date: str
@@ -120,8 +155,10 @@ class InsightsService:
         # 6. Load config and credentials
         config = self._load_config()
         insights_cfg = config.get("insights", {})
-        model = insights_cfg.get("model", "glm-5")
-        api_key, base_url = self._get_api_credentials(config)
+        api_key, base_url, cli_model = self._get_api_credentials(config)
+
+        # Model priority: config.insights.model > cli_settings model > default
+        model = insights_cfg.get("model") or cli_model or "glm-5.1"
 
         if not api_key:
             return None, "API key not configured"

--- a/tests/issues/593/test_llm_proxy_failover.py
+++ b/tests/issues/593/test_llm_proxy_failover.py
@@ -70,8 +70,8 @@ class TestLLMProxyFailover:
         mock_proxy = MagicMock()
         mock_proxy.validate_proxy_token.return_value = _mock_proxy_token()
         mock_proxy.resolve_api_key_for_scope.side_effect = [
-            ("sk-key1", "https://api.openai.com/v1", 1),
-            ("sk-key2", "https://api.openai.com/v1", 2),
+            ("sk-key1", "https://api.openai.com/v1", 1, None),
+            ("sk-key2", "https://api.openai.com/v1", 2, None),
             None,
         ]
         mock_get_proxy.return_value = mock_proxy
@@ -104,8 +104,8 @@ class TestLLMProxyFailover:
         mock_proxy = MagicMock()
         mock_proxy.validate_proxy_token.return_value = _mock_proxy_token()
         mock_proxy.resolve_api_key_for_scope.side_effect = [
-            ("sk-key1", "https://api.openai.com/v1", 1),
-            ("sk-key2", "https://api.openai.com/v1", 2),
+            ("sk-key1", "https://api.openai.com/v1", 1, None),
+            ("sk-key2", "https://api.openai.com/v1", 2, None),
             None,
         ]
         mock_get_proxy.return_value = mock_proxy
@@ -133,10 +133,10 @@ class TestLLMProxyFailover:
         mock_proxy = MagicMock()
         mock_proxy.validate_proxy_token.return_value = _mock_proxy_token()
         mock_proxy.resolve_api_key_for_scope.side_effect = [
-            ("sk-1", "https://api.openai.com/v1", 1),
-            ("sk-2", "https://api.openai.com/v1", 2),
-            ("sk-3", "https://api.openai.com/v1", 3),
-            ("sk-4", "https://api.openai.com/v1", 4),
+            ("sk-1", "https://api.openai.com/v1", 1, None),
+            ("sk-2", "https://api.openai.com/v1", 2, None),
+            ("sk-3", "https://api.openai.com/v1", 3, None),
+            ("sk-4", "https://api.openai.com/v1", 4, None),
             None,
         ]
         mock_get_proxy.return_value = mock_proxy
@@ -165,10 +165,10 @@ class TestLLMProxyFailover:
         mock_proxy = MagicMock()
         mock_proxy.validate_proxy_token.return_value = _mock_proxy_token()
         mock_proxy.resolve_api_key_for_scope.side_effect = [
-            ("sk-1", "https://api.openai.com/v1", 1),
-            ("sk-2", "https://api.openai.com/v1", 2),
-            ("sk-3", "https://api.openai.com/v1", 3),
-            ("sk-4", "https://api.openai.com/v1", 4),
+            ("sk-1", "https://api.openai.com/v1", 1, None),
+            ("sk-2", "https://api.openai.com/v1", 2, None),
+            ("sk-3", "https://api.openai.com/v1", 3, None),
+            ("sk-4", "https://api.openai.com/v1", 4, None),
             None,
         ]
         mock_get_proxy.return_value = mock_proxy
@@ -201,6 +201,7 @@ class TestLLMProxyFailover:
             "sk-1",
             "https://api.openai.com/v1",
             1,
+            None,
         )
         mock_get_proxy.return_value = mock_proxy
         mock_quota_cls.return_value = _make_quota_ok()
@@ -265,8 +266,8 @@ class TestLLMProxyFailover:
             },
         }
         mock_proxy.resolve_api_key_from_key_ids.side_effect = [
-            ("sk-key1", "https://api.openai.com/v1", 11),
-            ("sk-key3", "https://api.openai.com/v1", 33),
+            ("sk-key1", "https://api.openai.com/v1", 11, None),
+            ("sk-key3", "https://api.openai.com/v1", 33, None),
             None,
         ]
         mock_get_proxy.return_value = mock_proxy

--- a/tests/issues/604/test_llm_proxy_handler.py
+++ b/tests/issues/604/test_llm_proxy_handler.py
@@ -329,6 +329,7 @@ class TestHandleLlmProxyRequest:
             "sk-key",
             "https://api.openai.com/v1",
             42,
+            None,
         )
         mock_get_proxy.return_value = mock_proxy
         mock_quota_cls.return_value = _make_quota_ok()
@@ -372,6 +373,7 @@ class TestHandleLlmProxyRequest:
             "sk-key",
             "https://api.openai.com/v1",
             1,
+            None,
         )
         mock_get_proxy.return_value = mock_proxy
         mock_quota_cls.return_value = _make_quota_ok()
@@ -434,6 +436,7 @@ class TestHandleLlmProxyRequest:
             "sk-key",
             "https://api.openai.com/v1",
             1,
+            None,
         )
         mock_get_proxy.return_value = mock_proxy
         mock_quota_cls.return_value = _make_quota_ok()
@@ -462,6 +465,7 @@ class TestHandleLlmProxyRequest:
             "sk-key",
             "https://api.openai.com/v1",
             1,
+            None,
         )
         mock_get_proxy.return_value = mock_proxy
         mock_quota_cls.return_value = _make_quota_ok()
@@ -500,6 +504,7 @@ class TestResponsesApiConversion:
             "sk-key",
             base_url,
             1,
+            None,
         )
         return mock_proxy
 

--- a/tests/issues/604/test_remote_session_ha.py
+++ b/tests/issues/604/test_remote_session_ha.py
@@ -66,7 +66,7 @@ class TestRemoteSessionHA:
         """Critical bug regression: non-qwen tools must NOT embed empty HA fields."""
         mgr._agent_manager = _connected_machine()
         mgr._api_key_proxy.validate_proxy_token.return_value = None  # not used
-        mgr._api_key_proxy.resolve_api_key_for_scope.return_value = ("sk", None, 1)
+        mgr._api_key_proxy.resolve_api_key_for_scope.return_value = ("sk", None, 1, None)
         mgr._api_key_proxy.get_cli_settings_for_tool.return_value = None
         mgr._api_key_proxy.generate_proxy_token.return_value = "proxy-tok"
         mgr._session_manager.create_session.return_value = MagicMock(context={})

--- a/tests/unit/test_insights.py
+++ b/tests/unit/test_insights.py
@@ -423,7 +423,7 @@ class TestInsightsService:
             patch("app.modules.workspace.api_key_proxy.get_api_key_proxy_service") as mock_get,
         ):
             mock_proxy = MagicMock()
-            mock_proxy.resolve_api_key_for_scope.return_value = ("test-key", None, 1)
+            mock_proxy.resolve_api_key_for_scope.return_value = ("test-key", None, 1, None)
             mock_get.return_value = mock_proxy
             result, error = service.generate_insights(1, "2026-04-09", "2026-04-16")
 

--- a/tests/unit/test_insights_service.py
+++ b/tests/unit/test_insights_service.py
@@ -91,12 +91,14 @@ class TestInsightsServiceConfig:
                 "db-key",
                 "https://db.api.com/v1",
                 1,
+                None,
             )
             mock_get.return_value = mock_proxy
 
-            api_key, base_url = svc._get_api_credentials(config)
+            api_key, base_url, model = svc._get_api_credentials(config)
             assert api_key == "db-key"
             assert base_url == "https://db.api.com/v1"
+            assert model is None
             mock_proxy.resolve_api_key_for_scope.assert_called_once_with(1, "openai", scope="local")
 
     def test_get_api_credentials_db_key_default_base_url(self):
@@ -109,12 +111,13 @@ class TestInsightsServiceConfig:
             patch("app.modules.workspace.api_key_proxy.get_api_key_proxy_service") as mock_get,
         ):
             mock_proxy = MagicMock()
-            mock_proxy.resolve_api_key_for_scope.return_value = ("db-key", None, 1)
+            mock_proxy.resolve_api_key_for_scope.return_value = ("db-key", None, 1, None)
             mock_get.return_value = mock_proxy
 
-            api_key, base_url = svc._get_api_credentials(config)
+            api_key, base_url, model = svc._get_api_credentials(config)
             assert api_key == "db-key"
             assert base_url == "https://coding.dashscope.aliyuncs.com/v1"
+            assert model is None
 
     def test_get_api_credentials_fallback_to_env(self):
         """Falls back to env vars when database has no key."""
@@ -136,9 +139,10 @@ class TestInsightsServiceConfig:
             mock_proxy.resolve_api_key_for_scope.return_value = None
             mock_get.return_value = mock_proxy
 
-            api_key, base_url = svc._get_api_credentials(config)
+            api_key, base_url, model = svc._get_api_credentials(config)
             assert api_key == "env-key"
             assert base_url == "https://env.api.com/v1"
+            assert model is None
 
     def test_get_api_credentials_env_default_base_url(self):
         """Env fallback with only OPENAI_API_KEY uses default base URL."""
@@ -153,9 +157,10 @@ class TestInsightsServiceConfig:
             mock_proxy.resolve_api_key_for_scope.return_value = None
             mock_get.return_value = mock_proxy
 
-            api_key, base_url = svc._get_api_credentials(config)
+            api_key, base_url, model = svc._get_api_credentials(config)
             assert api_key == "env-key"
             assert base_url == "https://coding.dashscope.aliyuncs.com/v1"
+            assert model is None
 
     def test_get_api_credentials_no_key_anywhere(self):
         """Neither database nor env has a key → empty string."""
@@ -170,8 +175,9 @@ class TestInsightsServiceConfig:
             mock_proxy.resolve_api_key_for_scope.return_value = None
             mock_get.return_value = mock_proxy
 
-            api_key, _ = svc._get_api_credentials(config)
+            api_key, _, model = svc._get_api_credentials(config)
             assert api_key == ""
+            assert model is None
 
     def test_get_api_credentials_db_exception_falls_to_env(self):
         """DB exception is caught gracefully, falls back to env."""
@@ -185,8 +191,9 @@ class TestInsightsServiceConfig:
                 side_effect=Exception("DB down"),
             ),
         ):
-            api_key, _ = svc._get_api_credentials(config)
+            api_key, _, model = svc._get_api_credentials(config)
             assert api_key == "env-key"
+            assert model is None
 
     def test_get_api_credentials_db_over_env(self):
         """Database key takes priority over environment variable."""
@@ -202,12 +209,14 @@ class TestInsightsServiceConfig:
                 "db-key",
                 "https://db.api.com/v1",
                 1,
+                None,
             )
             mock_get.return_value = mock_proxy
 
-            api_key, base_url = svc._get_api_credentials(config)
+            api_key, base_url, model = svc._get_api_credentials(config)
             assert api_key == "db-key"
             assert base_url == "https://db.api.com/v1"
+            assert model is None
 
 
 class TestInsightsServicePrompts:
@@ -633,6 +642,7 @@ class TestInsightsServiceGenerateInsights:
                 "test-key",
                 "https://api.example.com/v1",
                 1,
+                None,
             )
             mock_get.return_value = mock_proxy
 
@@ -666,6 +676,7 @@ class TestInsightsServiceGenerateInsights:
                 "test-key",
                 "https://api.example.com/v1",
                 1,
+                None,
             )
             mock_get.return_value = mock_proxy
 


### PR DESCRIPTION
## 问题

Issue #1171: Insights 报告生成时使用固定的 `glm-5` 模型，无法使用 API Key 配置的模型。

## 修复方案

1. `resolve_api_key_for_scope` 和 `resolve_api_key_from_key_ids` 返回值增加 `cli_settings` 字段
2. `insights_service._get_api_credentials` 返回值增加 `default_model`
3. 新增 `_extract_model_from_cli_settings` 方法从 `cli_settings.modelProviders.openai[0].id` 提取模型

## 模型优先级

```
config.insights.model > cli_settings 模型 > 默认值 glm-5.1
```

## 测试

- 所有相关测试已更新并通过
- `test_llm_proxy_failover.py`: 7 tests passed
- `test_llm_proxy_handler.py`: 40 tests passed

## 修改文件

- `app/modules/workspace/api_key_proxy.py`
- `app/modules/workspace/llm_proxy_handler.py`
- `app/services/insights_service.py`
- `tests/issues/593/test_llm_proxy_failover.py`
- `tests/issues/604/test_llm_proxy_handler.py`

Fixes #1171