### PR TITLE
fix(auth): 登录时初始化 workspace 目录并幂等更新 system_account (Issue #1213)

### DIFF
--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -16,7 +16,7 @@ from app.repositories.user_repo import UserRepository
 from app.schemas.quota import validate_quota_update
 from app.services.auth_service import get_security_settings_cached
 from app.utils.validators import validate_email, validate_password, validate_username
-from app.utils.workspace import ensure_system_user, get_workspace_base_dir
+from app.utils.workspace import ensure_system_user
 
 logger = logging.getLogger(__name__)
 

--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -5,9 +5,7 @@ API routes for admin operations.
 """
 
 import logging
-import os
-import subprocess
-from typing import Optional, cast
+from typing import cast
 
 import bcrypt
 from flask import Blueprint, g, jsonify, request
@@ -18,7 +16,7 @@ from app.repositories.user_repo import UserRepository
 from app.schemas.quota import validate_quota_update
 from app.services.auth_service import get_security_settings_cached
 from app.utils.validators import validate_email, validate_password, validate_username
-from app.utils.workspace import get_workspace_base_dir
+from app.utils.workspace import ensure_system_user, get_workspace_base_dir
 
 logger = logging.getLogger(__name__)
 
@@ -30,75 +28,6 @@ usage_repo = UsageRepository()
 def hash_password(password: str) -> str:
     """Hash a password using bcrypt."""
     return cast("str", bcrypt.hashpw(password.encode(), bcrypt.gensalt(rounds=12)).decode())
-
-
-def ensure_system_user(system_account: str, uid: Optional[int] = None) -> bool:
-    """
-    Ensure a system user exists for workspace operations.
-    Creates the OS user, workspace directory, and .qwen directory.
-
-    Args:
-        system_account: Username for the system account.
-        uid: Optional specific UID. If None, system auto-assigns.
-
-    Returns:
-        True if user exists or was created successfully.
-    """
-    base_dir = get_workspace_base_dir()
-
-    # Check if user already exists
-    result = subprocess.run(["id", system_account], capture_output=True, text=True)
-    if result.returncode == 0:
-        logger.info(f"System user {system_account} already exists")
-        # Still ensure workspace directories exist
-        _ensure_workspace_dirs(system_account, base_dir)
-        return True
-
-    # Build useradd command
-    cmd = ["useradd", "-m", "-s", "/bin/bash"]
-    if uid is not None:
-        cmd.extend(["-u", str(uid)])
-    cmd.append(system_account)
-
-    logger.info(f"Creating system user: {system_account}" + (f" (UID: {uid})" if uid else ""))
-    result = subprocess.run(cmd, capture_output=True, text=True)
-
-    if result.returncode != 0:
-        logger.error(f"Failed to create system user {system_account}: {result.stderr}")
-        return False
-
-    logger.info(f"System user {system_account} created successfully")
-    _ensure_workspace_dirs(system_account, base_dir)
-    return True
-
-
-def _ensure_workspace_dirs(system_account: str, base_dir: str):
-    """Ensure workspace directories exist with correct ownership."""
-    workspace_dir = f"{base_dir}/{system_account}"
-    qwen_dir = f"{workspace_dir}/.qwen"
-
-    for directory in [workspace_dir, qwen_dir]:
-        if not os.path.exists(directory):
-            try:
-                os.makedirs(directory, mode=0o755, exist_ok=True)
-            except PermissionError:
-                logger.warning(f"Cannot create {directory} (permission denied)")
-                continue
-
-    # Set ownership
-    try:
-        uid_result = subprocess.run(["id", "-u", system_account], capture_output=True, text=True)
-        gid_result = subprocess.run(["id", "-g", system_account], capture_output=True, text=True)
-        if uid_result.returncode == 0 and gid_result.returncode == 0:
-            uid = int(uid_result.stdout.strip())
-            gid = int(gid_result.stdout.strip())
-            for directory in [workspace_dir, qwen_dir]:
-                try:
-                    os.chown(directory, uid, gid)
-                except PermissionError:
-                    logger.warning(f"Cannot chown {directory} to {uid}:{gid}")
-    except Exception as e:
-        logger.warning(f"Error setting ownership for {system_account}: {e}")
 
 
 @admin_bp.route("/admin/users", methods=["GET"])

--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -94,7 +94,9 @@ def api_login():
                 if not user_data.get("system_account"):
                     try:
                         user_repo.update_user(user_id=user_id, system_account=system_account)
-                        logger.info(f"Updated system_account for user {user_id} to {system_account}")
+                        logger.info(
+                            f"Updated system_account for user {user_id} to {system_account}"
+                        )
                     except Exception as e:
                         logger.warning(f"Failed to update system_account for user {user_id}: {e}")
 

--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -79,9 +79,30 @@ def api_login():
 
     if user:
         from app.services.auth_service import _get_session_timeout_hours
+        from app.utils.workspace import ensure_user_workspace
 
         # Validate avatar file exists
         user["avatar_url"] = _validate_avatar_url(user["id"], user.get("avatar_url"))
+
+        # Ensure workspace directory exists on login
+        user_id = int(user.get("id", 0))
+        user_data = user_repo.get_user_by_id(user_id)
+        if user_data:
+            system_account = user_data.get("system_account") or user_data.get("username")
+            if system_account:
+                # Idempotent update: set system_account if empty
+                if not user_data.get("system_account"):
+                    try:
+                        user_repo.update_user(user_id=user_id, system_account=system_account)
+                        logger.info(f"Updated system_account for user {user_id} to {system_account}")
+                    except Exception as e:
+                        logger.warning(f"Failed to update system_account for user {user_id}: {e}")
+
+                # Ensure workspace directory exists
+                try:
+                    ensure_user_workspace(system_account)
+                except Exception as e:
+                    logger.warning(f"Failed to ensure workspace for {system_account}: {e}")
 
         timeout_seconds = int(_get_session_timeout_hours() * 3600)
         response = make_response(jsonify({"success": True, "user": user}))

--- a/app/routes/fs.py
+++ b/app/routes/fs.py
@@ -178,14 +178,18 @@ def get_home_directory(user=None):
                 return user_home
             # Directory doesn't exist yet - return expected path
             # Frontend will show "directory doesn't exist" hint
-            logger.info(f"Workspace directory {user_home} doesn't exist yet for user {system_account}")
+            logger.info(
+                f"Workspace directory {user_home} doesn't exist yet for user {system_account}"
+            )
             return user_home
         elif system_account:
             # Already running as target user, check directly
             if os.path.exists(user_home):
                 return user_home
             # Directory doesn't exist yet - return expected path
-            logger.info(f"Workspace directory {user_home} doesn't exist yet for user {system_account}")
+            logger.info(
+                f"Workspace directory {user_home} doesn't exist yet for user {system_account}"
+            )
             return user_home
     # Fallback to process user's home
     return str(Path.home())

--- a/app/routes/fs.py
+++ b/app/routes/fs.py
@@ -169,18 +169,24 @@ def get_home_directory(user=None):
     if user:
         system_account = user.get("system_account") or user.get("username")
         effective_system_account = get_effective_system_account(system_account)
+        user_home = f"{base_dir}/{system_account}"
         if effective_system_account:
             # Return the system account's workspace directory
-            user_home = f"{base_dir}/{system_account}"
             # Use sudo to check if directory exists
             result = run_as_user(effective_system_account, ["test", "-e", user_home])
             if result.returncode == 0:
                 return user_home
+            # Directory doesn't exist yet - return expected path
+            # Frontend will show "directory doesn't exist" hint
+            logger.info(f"Workspace directory {user_home} doesn't exist yet for user {system_account}")
+            return user_home
         elif system_account:
             # Already running as target user, check directly
-            user_home = f"{base_dir}/{system_account}"
             if os.path.exists(user_home):
                 return user_home
+            # Directory doesn't exist yet - return expected path
+            logger.info(f"Workspace directory {user_home} doesn't exist yet for user {system_account}")
+            return user_home
     # Fallback to process user's home
     return str(Path.home())
 
@@ -331,10 +337,13 @@ def api_browse_directory():
     if not dir_info["exists"]:
         # Return home directory as fallback
         home = get_home_directory(user)
+        # Provide helpful note: directory will be created when project is set up
+        fallback_note = f"Directory '{path}' does not exist. It will be created automatically when you create a project here."
         return jsonify(
             {
                 "currentPath": path,
                 "error": "Directory does not exist",
+                "fallback_note": fallback_note,
                 "fallback": {
                     "currentPath": home,
                     "parentPath": str(Path(home).parent),

--- a/app/utils/workspace.py
+++ b/app/utils/workspace.py
@@ -149,8 +149,6 @@ def ensure_user_workspace(system_account: str) -> bool:
     Returns:
         True if workspace setup succeeded or was already ready.
     """
-    base_dir = get_workspace_base_dir()
-
     if _is_docker_multi_user_mode():
         # Docker multi-user mode: ensure system user and workspace
         logger.info(f"Ensuring workspace for {system_account} in Docker multi-user mode")

--- a/app/utils/workspace.py
+++ b/app/utils/workspace.py
@@ -8,10 +8,20 @@ browser works out of the box on any platform; Docker/server deployments set
 the env explicitly (e.g. ``/workspace``).
 """
 
+import logging
 import os
+import subprocess
 from pathlib import Path
+from typing import Optional
 
-__all__ = ["get_workspace_base_dir", "get_workspace_base_dirs"]
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "get_workspace_base_dir",
+    "get_workspace_base_dirs",
+    "ensure_system_user",
+    "ensure_user_workspace",
+]
 
 
 def get_workspace_base_dir() -> str:
@@ -36,3 +46,127 @@ def get_workspace_base_dirs() -> list[str]:
     """
     base_dir = get_workspace_base_dir()
     return [d.strip() for d in base_dir.split(",") if d.strip()]
+
+
+def _is_docker_multi_user_mode() -> bool:
+    """Check if running in Docker multi-user mode.
+
+    Docker multi-user mode is indicated by:
+    1. WORKSPACE_BASE_DIR is set (typically /workspace)
+    2. Process is running as root (can create system users)
+
+    Returns True if both conditions are met.
+    """
+    base_dir = os.environ.get("WORKSPACE_BASE_DIR", "")
+    # Docker sets WORKSPACE_BASE_DIR=/workspace, Package version uses default (Path.home())
+    is_docker_workspace = base_dir == "/workspace"
+    # In Docker container, typically running as root
+    is_root = os.geteuid() == 0
+    return is_docker_workspace and is_root
+
+
+def ensure_system_user(system_account: str, uid: Optional[int] = None) -> bool:
+    """
+    Ensure a system user exists for workspace operations.
+    Creates the OS user, workspace directory, and .qwen directory.
+
+    Args:
+        system_account: Username for the system account.
+        uid: Optional specific UID. If None, system auto-assigns.
+
+    Returns:
+        True if user exists or was created successfully.
+    """
+    base_dir = get_workspace_base_dir()
+
+    # Check if user already exists
+    result = subprocess.run(["id", system_account], capture_output=True, text=True)
+    if result.returncode == 0:
+        logger.info(f"System user {system_account} already exists")
+        # Still ensure workspace directories exist
+        _ensure_workspace_dirs(system_account, base_dir)
+        return True
+
+    # Build useradd command
+    cmd = ["useradd", "-m", "-s", "/bin/bash"]
+    if uid is not None:
+        cmd.extend(["-u", str(uid)])
+    cmd.append(system_account)
+
+    logger.info(f"Creating system user: {system_account}" + (f" (UID: {uid})" if uid else ""))
+    result = subprocess.run(cmd, capture_output=True, text=True)
+
+    if result.returncode != 0:
+        logger.error(f"Failed to create system user {system_account}: {result.stderr}")
+        return False
+
+    logger.info(f"System user {system_account} created successfully")
+    _ensure_workspace_dirs(system_account, base_dir)
+    return True
+
+
+def _ensure_workspace_dirs(system_account: str, base_dir: str):
+    """Ensure workspace directories exist with correct ownership."""
+    workspace_dir = f"{base_dir}/{system_account}"
+    qwen_dir = f"{workspace_dir}/.qwen"
+
+    for directory in [workspace_dir, qwen_dir]:
+        if not os.path.exists(directory):
+            try:
+                os.makedirs(directory, mode=0o755, exist_ok=True)
+            except PermissionError:
+                logger.warning(f"Cannot create {directory} (permission denied)")
+                continue
+
+    # Set ownership
+    try:
+        uid_result = subprocess.run(["id", "-u", system_account], capture_output=True, text=True)
+        gid_result = subprocess.run(["id", "-g", system_account], capture_output=True, text=True)
+        if uid_result.returncode == 0 and gid_result.returncode == 0:
+            uid = int(uid_result.stdout.strip())
+            gid = int(gid_result.stdout.strip())
+            for directory in [workspace_dir, qwen_dir]:
+                try:
+                    os.chown(directory, uid, gid)
+                except PermissionError:
+                    logger.warning(f"Cannot chown {directory} to {uid}:{gid}")
+    except Exception as e:
+        logger.warning(f"Error setting ownership for {system_account}: {e}")
+
+
+def ensure_user_workspace(system_account: str) -> bool:
+    """
+    Ensure workspace directory exists for user login.
+    Called during login to prepare workspace environment.
+
+    Behavior differs by deployment mode:
+    - Docker multi-user mode: Creates system user + workspace + .qwen dirs
+    - Package single-user mode: Only creates .qwen in user's home
+
+    Args:
+        system_account: Username for the system account.
+
+    Returns:
+        True if workspace setup succeeded or was already ready.
+    """
+    base_dir = get_workspace_base_dir()
+
+    if _is_docker_multi_user_mode():
+        # Docker multi-user mode: ensure system user and workspace
+        logger.info(f"Ensuring workspace for {system_account} in Docker multi-user mode")
+        return ensure_system_user(system_account)
+    else:
+        # Package single-user mode: only create .qwen in home directory
+        # system_account may not match actual OS user, use current user's home
+        home_dir = str(Path.home())
+        qwen_dir = f"{home_dir}/.qwen"
+
+        if not os.path.exists(qwen_dir):
+            try:
+                os.makedirs(qwen_dir, mode=0o755, exist_ok=True)
+                logger.info(f"Created .qwen directory at {qwen_dir}")
+            except PermissionError as e:
+                logger.warning(f"Cannot create .qwen directory: {e}")
+                return False
+
+        return True

--- a/tests/unit/test_fs_path_validation.py
+++ b/tests/unit/test_fs_path_validation.py
@@ -102,16 +102,16 @@ class TestIsValidPath:
 
 
 class TestAdminWorkspaceBaseDirDefault:
-    """The duplicate get_workspace_base_dir in admin.py shares the default."""
+    """Admin.py imports from workspace.py, verify the import path."""
 
     def test_admin_unset_env_falls_back_to_home(self, monkeypatch):
         monkeypatch.delenv("WORKSPACE_BASE_DIR", raising=False)
-        from app.routes.admin import get_workspace_base_dir as admin_get
+        from app.utils.workspace import get_workspace_base_dir as workspace_get
 
-        assert admin_get() == str(Path.home())
+        assert workspace_get() == str(Path.home())
 
     def test_admin_explicit_env_overrides(self, monkeypatch):
         monkeypatch.setenv("WORKSPACE_BASE_DIR", "/workspace")
-        from app.routes.admin import get_workspace_base_dir as admin_get
+        from app.utils.workspace import get_workspace_base_dir as workspace_get
 
-        assert admin_get() == "/workspace"
+        assert workspace_get() == "/workspace"


### PR DESCRIPTION
## 修复 Issue #1213

**问题**：Docker 版普通用户 wd236 登录后默认项目路径显示为 `/root`（无权限）

**根因**：wd236 用户 `system_account` 字段为空，导致 `get_home_directory()` fallback 到 `Path.home()` = `/root`

## 修复内容

| 文件 | 修改 |
|------|------|
| `app/utils/workspace.py` | 移入 `ensure_system_user`、`_ensure_workspace_dirs`，新增 `ensure_user_workspace()` |
| `app/routes/admin.py` | 删除原函数，导入 workspace.py |
| `app/routes/auth.py` | 登录时幂等更新空 `system_account` + 调用 `ensure_user_workspace()` |
| `app/routes/fs.py` | `get_home_directory()` 返回期望路径而非 `/root`；添加 `fallback_note` |

## 部署验证

node236 Docker 版验证：
- wd236 登录后默认路径从 `/root` 改为 `/workspace/wd236`
- workspace 目录自动创建

## 关联 Issue

- Fixes #1213
- #1217 - Package 版同类问题（优先级 P2）