### PR TITLE
fix(terminal): 保存 CLI 工具 session_id 用于会话恢复 (Issue #1080)

### DIFF
--- a/app/routes/remote.py
+++ b/app/routes/remote.py
@@ -1516,7 +1516,7 @@ def agent_message():
                     },
                 )
             else:
-                # Update model/project_path/user_id if missing on existing session
+                # Update model/project_path/user_id/cli_session_id if missing on existing session
                 updates = {}
                 if model and not existing.model:
                     updates["model"] = model
@@ -1524,6 +1524,10 @@ def agent_message():
                     updates["project_path"] = project_path
                 if sync_user_id and not existing.user_id:
                     updates["user_id"] = sync_user_id
+                # Issue #1080: Save CLI tool's internal session_id for terminal session restore
+                # When terminal_session exists, claude_session_id is the CLI tool's internal UUID
+                if terminal_session and claude_session_id and not existing.cli_session_id:
+                    updates["cli_session_id"] = claude_session_id
                 if updates:
                     sync_session_mgr.update_session_fields(session_id, updates)
 

--- a/app/routes/workspace.py
+++ b/app/routes/workspace.py
@@ -1323,7 +1323,8 @@ def restore_session(session_id):
                 project_path,
                 workspace_type,
                 remote_machine_id,
-                user_id
+                user_id,
+                cli_session_id
             FROM agent_sessions
             WHERE session_id = {p}
             LIMIT 1
@@ -1355,6 +1356,8 @@ def restore_session(session_id):
         remote_machine_id = session_data.get("remote_machine_id")
 
         # Terminal sessions don't need project_path - they use terminalId
+        # Issue #1080: Check if CLI tool session history exists (cli_session_id)
+        cli_session_id = session_data.get("cli_session_id") or ""
         if workspace_type == "terminal":
             # Build workspace URL for terminal session
             machine_name = None
@@ -1391,6 +1394,7 @@ def restore_session(session_id):
                         "terminal_id": session_id,
                         "remote_machine_id": remote_machine_id,
                         "machine_name": machine_name,
+                        "cli_session_id": cli_session_id,
                     },
                 }
             )

--- a/frontend/src/api/sessions.ts
+++ b/frontend/src/api/sessions.ts
@@ -201,6 +201,11 @@ export const sessionsApi = {
       encoded_project_name: string;
       tool_name: string;
       url: string;
+      workspace_type?: string;
+      terminal_id?: string;
+      remote_machine_id?: string;
+      machine_name?: string;
+      cli_session_id?: string;
     };
     error?: string;
     // Issue #669: Process terminated status
@@ -218,6 +223,11 @@ export const sessionsApi = {
         encoded_project_name: string;
         tool_name: string;
         url: string;
+        workspace_type?: string;
+        terminal_id?: string;
+        remote_machine_id?: string;
+        machine_name?: string;
+        cli_session_id?: string;
       };
       error?: string;
       can_recreate?: boolean;


### PR DESCRIPTION
## 问题描述

Issue #1080: Terminal 类型会话恢复后上下文丢失

当用户从 Sessions 页面点击"恢复会话"恢复 Terminal 类型会话时，CLI 工具（claude/qwen/codex）的历史上下文会丢失。

## 根因分析

- Terminal 会话创建时只保存 `workspace_type="terminal"` 和 `remote_machine_id`
- `session_sync` 处理时，CLI 工具内部的 session_id（JSONL 文件 UUID）被丢弃
- 恢复会话时，系统不知道 CLI 工具的历史数据在哪里

## 修改内容

1. **remote.py**: session_sync 处理时，将 `claude_session_id` 保存到 `cli_session_id` 字段
2. **workspace.py**: restore_session API 返回 `cli_session_id` 信息
3. **sessions.ts**: 更新前端 API 类型定义

## 修改效果

- Terminal 会话现在会保存 CLI 工具的内部 session_id
- 恢复 Terminal 会话时，返回 `cli_session_id` 信息，前端可以判断是否有历史数据
- 为后续完善恢复功能打下基础

## 后续改进方向（待讨论）

1. 在恢复 terminal 会话时，检查 terminal_server 进程是否还在运行
2. 如果进程已终止但有 `cli_session_id`，提示用户选择恢复或新建
3. 让 terminal_menu 支持 `--resume` 参数来恢复 CLI 工具历史

## 测试

- 后端 lint 检查通过
- 前端 lint 检查通过（无新增错误）