### PR TITLE
feat(workspace): 添加标签拖拽排序功能 (Issue #946)

### DIFF
--- a/frontend/src/components/features/Workspace.tsx
+++ b/frontend/src/components/features/Workspace.tsx
@@ -34,6 +34,7 @@ import {
   useAddWorkspaceTab,
   useUpdateWorkspaceTab,
   useRemoveWorkspaceTab,
+  useReorderWorkspaceTabs,
   type WorkspaceTab as StoreWorkspaceTab,
 } from '@/store';
 import { t } from '@/i18n';
@@ -89,6 +90,8 @@ export const Workspace: React.FC = () => {
   const [isStoppingRemote, setIsStoppingRemote] = useState(false);
   const [tabWidths, setTabWidths] = useState<Record<string, number>>({});
   const [resizingTabId, setResizingTabId] = useState<string | null>(null);
+  const [draggedTabId, setDraggedTabId] = useState<string | null>(null);
+  const [dragOverTabId, setDragOverTabId] = useState<string | null>(null);
 
   // Flag to track if tabs have been initialized (Issue #65)
   const [tabsInitialized, setTabsInitialized] = useState(false);
@@ -117,6 +120,7 @@ export const Workspace: React.FC = () => {
   const addStoredTab = useAddWorkspaceTab();
   const updateStoredTab = useUpdateWorkspaceTab();
   const removeStoredTab = useRemoveWorkspaceTab();
+  const reorderStoredTabs = useReorderWorkspaceTabs();
 
   // Shared terminal proxy polling helper
   const pollTerminalProxy = useCallback(
@@ -1417,6 +1421,57 @@ export const Workspace: React.FC = () => {
     [tabs]
   );
 
+  // Drag and drop handlers for tab reordering (Issue #946)
+  const handleDragStart = useCallback((tabId: string, e: React.DragEvent) => {
+    setDraggedTabId(tabId);
+    e.dataTransfer.effectAllowed = 'move';
+    e.dataTransfer.setData('text/plain', tabId);
+  }, []);
+
+  const handleDragOver = useCallback(
+    (tabId: string, e: React.DragEvent) => {
+      e.preventDefault();
+      e.dataTransfer.dropEffect = 'move';
+      if (draggedTabId && tabId !== draggedTabId) {
+        setDragOverTabId(tabId);
+      }
+    },
+    [draggedTabId]
+  );
+
+  const handleDragLeave = useCallback(() => {
+    setDragOverTabId(null);
+  }, []);
+
+  const handleDrop = useCallback(
+    (tabId: string) => {
+      if (!draggedTabId || draggedTabId === tabId) return;
+
+      const fromIndex = tabs.findIndex((t) => t.id === draggedTabId);
+      const toIndex = tabs.findIndex((t) => t.id === tabId);
+
+      if (fromIndex !== -1 && toIndex !== -1) {
+        // Update local state
+        const newTabs = [...tabs];
+        const [removed] = newTabs.splice(fromIndex, 1);
+        newTabs.splice(toIndex, 0, removed);
+        setTabs(newTabs);
+
+        // Update store
+        reorderStoredTabs(fromIndex, toIndex);
+      }
+
+      setDraggedTabId(null);
+      setDragOverTabId(null);
+    },
+    [draggedTabId, tabs, reorderStoredTabs]
+  );
+
+  const handleDragEnd = useCallback(() => {
+    setDraggedTabId(null);
+    setDragOverTabId(null);
+  }, []);
+
   const handleSaveRename = useCallback(async () => {
     if (!renameTabId || !renameValue.trim()) return;
 
@@ -1810,10 +1865,18 @@ export const Workspace: React.FC = () => {
                 <div
                   key={tab.id}
                   data-tab-id={tab.id}
+                  draggable
+                  onDragStart={(e) => handleDragStart(tab.id, e)}
+                  onDragOver={(e) => handleDragOver(tab.id, e)}
+                  onDragLeave={handleDragLeave}
+                  onDrop={() => handleDrop(tab.id)}
+                  onDragEnd={handleDragEnd}
                   className={cn(
                     'workspace-tab d-flex align-items-center px-2 py-2 cursor-pointer',
                     'border-end position-relative',
-                    activeTabId === tab.id && 'active bg-white'
+                    activeTabId === tab.id && 'active bg-white',
+                    draggedTabId === tab.id && 'dragging',
+                    dragOverTabId === tab.id && 'drag-over'
                   )}
                   onClick={() => switchTab(tab.id)}
                   style={{

--- a/frontend/src/store/index.test.ts
+++ b/frontend/src/store/index.test.ts
@@ -34,6 +34,15 @@ describe('App Store', () => {
       theme: 'light',
       language: 'en',
       sidebarCollapsed: false,
+      workspaceTabs: [],
+      workspaceActiveTabId: '',
+      reorderWorkspaceTabs: (fromIndex: number, toIndex: number) => {
+        const state = useAppStore.getState();
+        const tabs = [...state.workspaceTabs];
+        const [removed] = tabs.splice(fromIndex, 1);
+        tabs.splice(toIndex, 0, removed);
+        useAppStore.setState({ workspaceTabs: tabs });
+      },
     });
     vi.clearAllMocks();
   });
@@ -245,6 +254,45 @@ describe('App Store', () => {
       });
 
       expect(result.current).toBe(true);
+    });
+  });
+
+  describe('workspace tabs actions', () => {
+    it('should reorder workspace tabs', () => {
+      // Set up initial tabs
+      const tabs = [
+        { id: 'tab-1', title: 'Tab 1', sessionId: 'session-1' },
+        { id: 'tab-2', title: 'Tab 2', sessionId: 'session-2' },
+        { id: 'tab-3', title: 'Tab 3', sessionId: 'session-3' },
+      ];
+
+      act(() => {
+        useAppStore.getState().setWorkspaceTabs(tabs as any);
+      });
+
+      expect(useAppStore.getState().workspaceTabs).toHaveLength(3);
+      expect(useAppStore.getState().workspaceTabs[0].id).toBe('tab-1');
+
+      // Reorder: move tab-1 to position 2
+      act(() => {
+        useAppStore.getState().reorderWorkspaceTabs(0, 2);
+      });
+
+      const reorderedTabs = useAppStore.getState().workspaceTabs;
+      expect(reorderedTabs).toHaveLength(3);
+      expect(reorderedTabs[0].id).toBe('tab-2');
+      expect(reorderedTabs[1].id).toBe('tab-3');
+      expect(reorderedTabs[2].id).toBe('tab-1');
+
+      // Reorder back: move tab-1 from position 2 to position 0
+      act(() => {
+        useAppStore.getState().reorderWorkspaceTabs(2, 0);
+      });
+
+      const restoredTabs = useAppStore.getState().workspaceTabs;
+      expect(restoredTabs[0].id).toBe('tab-1');
+      expect(restoredTabs[1].id).toBe('tab-2');
+      expect(restoredTabs[2].id).toBe('tab-3');
     });
   });
 });

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -96,6 +96,7 @@ interface AppState {
   updateWorkspaceTab: (tabId: string, updates: Partial<WorkspaceTab>) => void;
   removeWorkspaceTab: (tabId: string) => void;
   clearWorkspaceTabs: () => void;
+  reorderWorkspaceTabs: (fromIndex: number, toIndex: number) => void;
 
   // Tab notification actions
   setEnableTabNotifications: (enabled: boolean) => void;
@@ -235,6 +236,13 @@ export const useAppStore = create<AppState>()(
           workspaceTabs: [],
           workspaceActiveTabId: '',
         }),
+      reorderWorkspaceTabs: (fromIndex, toIndex) =>
+        set((state) => {
+          const tabs = [...state.workspaceTabs];
+          const [removed] = tabs.splice(fromIndex, 1);
+          tabs.splice(toIndex, 0, removed);
+          return { workspaceTabs: tabs };
+        }),
 
       // Tab notification actions
       setEnableTabNotifications: (enabled) => set({ enableTabNotifications: enabled }),
@@ -307,6 +315,7 @@ export const useAddWorkspaceTab = () => useAppStore((state) => state.addWorkspac
 export const useUpdateWorkspaceTab = () => useAppStore((state) => state.updateWorkspaceTab);
 export const useRemoveWorkspaceTab = () => useAppStore((state) => state.removeWorkspaceTab);
 export const useClearWorkspaceTabs = () => useAppStore((state) => state.clearWorkspaceTabs);
+export const useReorderWorkspaceTabs = () => useAppStore((state) => state.reorderWorkspaceTabs);
 
 // Legacy selector - DEPRECATED: Use individual action selectors instead for stable references
 export const useWorkspaceTabsActions = () =>

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -13,6 +13,7 @@
   /* ===== Color Palette - Modern Tech Theme ===== */
   /* Primary - Deep Ocean Blue */
   --color-primary: #0ea5e9;
+  --color-primary-rgb: 14, 165, 233;
   --color-primary-hover: #0284c7;
   --color-primary-light: #e0f2fe;
   --color-primary-dark: #0c4a6e;
@@ -226,6 +227,7 @@
   --border-color-dark: #475569;
 
   --color-primary: #38bdf8;
+  --color-primary-rgb: 56, 189, 248;
   --color-primary-hover: #0ea5e9;
   --color-primary-light: rgba(14, 165, 233, 0.1);
 

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -2246,6 +2246,17 @@ table .latency-row:hover td {
   border-color: var(--color-primary);
 }
 
+/* Workspace tab drag styles (Issue #946) */
+.workspace-tab.dragging {
+  opacity: 0.5;
+  cursor: grabbing !important;
+}
+
+.workspace-tab.drag-over {
+  border-left: 2px solid var(--color-primary);
+  background: rgba(var(--color-primary-rgb), 0.1);
+}
+
 /* Work Left Panel - Session List */
 .work-left-panel {
   width: 260px;


### PR DESCRIPTION
## 概述

实现 Workspace 标签拖拽排序功能，用户可以通过拖拽调整标签顺序。

## 修改内容

1. **Store 层** (`frontend/src/store/index.ts`)
   - 添加 `reorderWorkspaceTabs` action 和 `useReorderWorkspaceTabs` hook

2. **Workspace.tsx** 
   - 添加拖拽状态：`draggedTabId`, `dragOverTabId`
   - 添加拖拽事件处理：`handleDragStart`, `handleDragOver`, `handleDragLeave`, `handleDrop`, `handleDragEnd`
   - 标签元素添加 `draggable` 属性和事件绑定

3. **CSS 样式** (`frontend/src/styles/main.css`)
   - 添加 `.workspace-tab.dragging` 样式（拖拽时透明度 50%）
   - 添加 `.workspace-tab.drag-over` 样式（目标位置高亮）

## 测试

手动测试：
- 拖拽标签可正常排序
- 拖拽时有视觉反馈（半透明 + 目标位置高亮）
- 排序后刷新页面，顺序保持不变（localStorage 持久化）

## 关联 Issue

Closes #946