### PR TITLE
fix(manage): 工具账号工具类型改为从后端 API 动态获取

### DIFF
--- a/frontend/src/components/features/management/ToolAccountsEditor.tsx
+++ b/frontend/src/components/features/management/ToolAccountsEditor.tsx
@@ -6,18 +6,12 @@ import React, { useState, useEffect, useCallback } from 'react';
 import { useLanguage } from '@/store';
 import { t } from '@/i18n';
 import { Button, TextInput, Modal, Badge, useToast } from '@/components/common';
-import { toolAccountsApi, type ToolAccount, type UnmappedAccount } from '@/api/toolAccounts';
-
-// Hardcoded tool types (matches backend TOOL_TYPES)
-const TOOL_TYPES = [
-  { value: 'qwen', display: 'Qwen' },
-  { value: 'claude', display: 'Claude' },
-  { value: 'openclaw', display: 'Openclaw' },
-  { value: 'zcode', display: 'ZCode' },
-  { value: 'feishu', display: '飞书' },
-  { value: 'slack', display: 'Slack' },
-  { value: 'other', display: '其他' },
-];
+import {
+  toolAccountsApi,
+  type ToolAccount,
+  type UnmappedAccount,
+  type ToolType,
+} from '@/api/toolAccounts';
 
 interface ToolAccountsEditorProps {
   userId: number;
@@ -28,6 +22,7 @@ export const ToolAccountsEditor: React.FC<ToolAccountsEditorProps> = ({ userId, 
   const language = useLanguage();
   const [toolAccounts, setToolAccounts] = useState<ToolAccount[]>([]);
   const [unmappedAccounts, setUnmappedAccounts] = useState<UnmappedAccount[]>([]);
+  const [toolTypes, setToolTypes] = useState<ToolType[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [showAddModal, setShowAddModal] = useState(false);
   const [newAccount, setNewAccount] = useState({
@@ -44,12 +39,14 @@ export const ToolAccountsEditor: React.FC<ToolAccountsEditorProps> = ({ userId, 
   const loadData = useCallback(async () => {
     setIsLoading(true);
     try {
-      const [accounts, unmapped] = await Promise.all([
+      const [accounts, unmapped, types] = await Promise.all([
         toolAccountsApi.getByUser(userId),
         toolAccountsApi.getUnmapped(),
+        toolAccountsApi.getToolTypes(),
       ]);
       setToolAccounts(accounts);
       setUnmappedAccounts(unmapped);
+      setToolTypes(types);
     } catch (err) {
       console.error('Failed to load tool accounts:', err);
     } finally {
@@ -236,7 +233,7 @@ export const ToolAccountsEditor: React.FC<ToolAccountsEditorProps> = ({ userId, 
               onChange={(e) => setNewAccount({ ...newAccount, tool_type: e.target.value })}
             >
               <option value="">-- Select --</option>
-              {TOOL_TYPES.map((type) => (
+              {toolTypes.map((type) => (
                 <option key={type.value} value={type.value}>
                   {type.display}
                 </option>


### PR DESCRIPTION
## 问题描述

Issue #867: 管理模式用户管理工具账号添加的工具类型下拉列表包含未使用的工具

### 问题分析
- 前端硬编码工具类型列表，未与后端 TOOL_TYPES 同步
- 前端缺少 `codex` 工具类型（后端有但前端没有）
- 存在未实现的 `slack` 工具类型

## 修复方案

将前端改为从后端 API `/api/tool-types` 动态获取工具类型列表，彻底解决前后端同步问题。

### 修改内容
1. 移除前端硬编码的 `TOOL_TYPES` 常量
2. 导入 `ToolType` 类型定义
3. 添加 `toolTypes` state 存储动态获取的数据
4. 在 `loadData` 函数中增加 `getToolTypes()` API 调用
5. 下拉列表使用动态 `toolTypes` 数据

### 修改文件
- `frontend/src/components/features/management/ToolAccountsEditor.tsx`

## 测试验证
- 前端类型检查通过 (`npm run typecheck`)

Closes #867

🤖 Generated with Qwen Code