### PR TITLE
fix(manage): 统一租户配额 Token 单位显示为 M (Issue #879)

### DIFF
--- a/frontend/src/components/features/management/TenantManagement.tsx
+++ b/frontend/src/components/features/management/TenantManagement.tsx
@@ -28,6 +28,8 @@ import {
 import { tenantApi, type Tenant, type CreateTenantRequest, type UpdateTenantRequest } from '@/api';
 import { formatDateTime } from '@/utils';
 import { usePageRefresh } from '@/hooks';
+import { TOKEN_QUOTA_MULTIPLIER } from '@/constants/quota';
+import { formatQuotaForDisplay } from '@/utils/quotaFormatter';
 
 const STATUS_OPTIONS = [
   { value: '', label: 'All Statuses' },
@@ -81,8 +83,8 @@ export const TenantManagement: React.FC = () => {
     contact_name: '',
   });
   const [quotaData, setQuotaData] = useState({
-    daily_token_limit: 1000000,
-    monthly_token_limit: 30000000,
+    daily_token_limit: 1,
+    monthly_token_limit: 30,
     daily_request_limit: 10000,
     monthly_request_limit: 300000,
     max_users: 100,
@@ -171,8 +173,12 @@ export const TenantManagement: React.FC = () => {
   const handleOpenQuota = (tenant: Tenant) => {
     setEditingTenant(tenant);
     setQuotaData({
-      daily_token_limit: tenant.quota?.daily_token_limit ?? 1000000,
-      monthly_token_limit: tenant.quota?.monthly_token_limit ?? 30000000,
+      daily_token_limit: Math.floor(
+        (tenant.quota?.daily_token_limit ?? 1000000) / TOKEN_QUOTA_MULTIPLIER
+      ),
+      monthly_token_limit: Math.floor(
+        (tenant.quota?.monthly_token_limit ?? 30000000) / TOKEN_QUOTA_MULTIPLIER
+      ),
       daily_request_limit: tenant.quota?.daily_request_limit ?? 10000,
       monthly_request_limit: tenant.quota?.monthly_request_limit ?? 300000,
       max_users: tenant.quota?.max_users ?? 100,
@@ -225,7 +231,14 @@ export const TenantManagement: React.FC = () => {
   const handleSaveQuota = async () => {
     if (!editingTenant) return;
     try {
-      await tenantApi.updateQuota(editingTenant.id, quotaData);
+      await tenantApi.updateQuota(editingTenant.id, {
+        daily_token_limit: quotaData.daily_token_limit * TOKEN_QUOTA_MULTIPLIER,
+        monthly_token_limit: quotaData.monthly_token_limit * TOKEN_QUOTA_MULTIPLIER,
+        daily_request_limit: quotaData.daily_request_limit,
+        monthly_request_limit: quotaData.monthly_request_limit,
+        max_users: quotaData.max_users,
+        max_sessions_per_user: quotaData.max_sessions_per_user,
+      });
       handleCloseQuotaModal();
       fetchTenants();
     } catch (err) {
@@ -423,8 +436,15 @@ export const TenantManagement: React.FC = () => {
                             />
                           </div>
                           <small className="text-muted">
-                            {tenant.total_tokens_used.toLocaleString()} /{' '}
-                            {tenant.quota.monthly_token_limit.toLocaleString()}
+                            {formatQuotaForDisplay(
+                              tenant.total_tokens_used / TOKEN_QUOTA_MULTIPLIER,
+                              true
+                            )}{' '}
+                            /{' '}
+                            {formatQuotaForDisplay(
+                              tenant.quota.monthly_token_limit / TOKEN_QUOTA_MULTIPLIER,
+                              true
+                            )}
                           </small>
                         </div>
                       ) : (
@@ -588,7 +608,7 @@ export const TenantManagement: React.FC = () => {
         >
           <div className="row g-3">
             <div className="col-md-6">
-              <label className="form-label">{t('dailyTokenLimit', language)}</label>
+              <label className="form-label">{t('dailyTokenLimit', language)} (M)</label>
               <input
                 type="number"
                 className="form-control"
@@ -602,7 +622,7 @@ export const TenantManagement: React.FC = () => {
               />
             </div>
             <div className="col-md-6">
-              <label className="form-label">{t('monthlyTokenLimit', language)}</label>
+              <label className="form-label">{t('monthlyTokenLimit', language)} (M)</label>
               <input
                 type="number"
                 className="form-control"


### PR DESCRIPTION
## 问题描述

Issue #879: 配额管理页面 Token 配额单位显示不一致。

TenantManagement 页面的 Token 配额输入使用原始数值（如 `1000000`），而 QuotaAlerts/QuotaManagement 页面使用 M 单位（如 `1`），导致管理员体验不一致，容易造成配置错误。

## 修复内容

### 数据流分析

| 数据模型 | 存储单位 | 示例值 |
|----------|----------|--------|
| 用户配额 (`daily_token_quota`) | M 单位 | `1` 表示 1M tokens |
| 租户配额 (`daily_token_limit`) | 原始数值 | `1000000` 表示 1M tokens |

### 修改方案

采用前端转换方案，保持后端数据不变：

- **显示时**: 原始数值 ÷ `TOKEN_QUOTA_MULTIPLIER` → M 单位
- **输入时**: M 单位 × `TOKEN_QUOTA_MULTIPLIER` → 原始数值发送到后端
- **添加 `(M)` 标签提示**

### 具体修改

1. 导入 `TOKEN_QUOTA_MULTIPLIER` 和 `formatQuotaForDisplay` 工具函数
2. `handleOpenQuota`: 将后端原始数值转换为 M 单位显示
3. `handleSaveQuota`: 将 M 单位转换回原始数值发送到后端
4. `quotaData` 默认值: `daily_token_limit=1`, `monthly_token_limit=30` (M单位)
5. 表格显示: 使用 `formatQuotaForDisplay` 格式化为 M 单位
6. 输入标签: 添加 `(M)` 单位提示

## 测试

- [x] ESLint 检查通过
- [x] 手动验证数据转换逻辑正确

Closes #879