### PR TITLE
fix(workspace): fetch source fallback + remote_sync message_count (#1221 followup)

### DIFF
--- a/app/routes/remote.py
+++ b/app/routes/remote.py
@@ -1549,6 +1549,7 @@ def agent_message():
                             existing_uuids.add(em_uuid)
 
                 # Mirror messages to daily_messages for ConversationHistory visibility
+                synced_message_delta = 0
                 for msg in messages:
                     role = msg.get("role", "")
                     content = msg.get("content", "")
@@ -1591,7 +1592,7 @@ def agent_message():
                             metadata["input_tokens"] = input_tokens
                             metadata["output_tokens"] = output_tokens
 
-                        sync_session_mgr.append_transcript_message(
+                        stored = sync_session_mgr.append_transcript_message(
                             session_id=session_id,
                             role=role,
                             content=content[:MAX_MESSAGE_LENGTH],
@@ -1602,6 +1603,8 @@ def agent_message():
                             source="remote_sync",
                             external_message_id=msg_uuid or message_id,
                         )
+                        if getattr(stored, "_was_inserted", False):
+                            synced_message_delta += 1
                     except Exception as e:
                         logger.debug("Failed to add session_message: %s", e)
 
@@ -1680,6 +1683,16 @@ def agent_message():
                             conn.commit()
                     except Exception as e:
                         logger.debug("Failed to insert daily_message: %s", e)
+
+                # Apply the net message-count delta once after the loop. The
+                # transcript writer keeps add_message side-effect-free
+                # (count_usage=False), so the session owner must advance
+                # message_count itself — otherwise remote-synced sessions
+                # never reflect their imported messages (#1128).
+                if synced_message_delta:
+                    sync_session_mgr.increment_session_usage(
+                        session_id, message_delta=synced_message_delta
+                    )
             except Exception as e:
                 logger.debug("Failed to mirror messages: %s", e)
 

--- a/scripts/fetch_claude.py
+++ b/scripts/fetch_claude.py
@@ -743,9 +743,8 @@ def update_agent_sessions_stats(messages: list) -> int:
     conn = get_connection()
     cursor = conn.cursor()
     has_external_message_id = _column_exists(cursor, "session_messages", "external_message_id")
-    has_structured_session_messages = has_external_message_id and _column_exists(
-        cursor, "session_messages", "source"
-    )
+    has_source = _column_exists(cursor, "session_messages", "source")
+    has_structured_session_messages = has_external_message_id and has_source
 
     try:
         for session_id, stats in session_stats.items():
@@ -928,6 +927,26 @@ def update_agent_sessions_stats(messages: list) -> int:
                                             if msg.get("content_blocks")
                                             else None
                                         ),
+                                    ),
+                                )
+                            elif has_source:
+                                insert_sql = f"""
+                                    INSERT INTO session_messages
+                                    (session_id, role, content, tokens_used, model, timestamp, metadata, source)
+                                    VALUES ({placeholder}, {placeholder}, {placeholder}, {placeholder}, {placeholder}, {placeholder}, {placeholder}, {placeholder})
+                                """
+                                _execute(
+                                    cursor,
+                                    insert_sql,
+                                    (
+                                        session_id,
+                                        msg.get("role"),
+                                        msg.get("content"),
+                                        msg.get("tokens_used", 0),
+                                        msg.get("model"),
+                                        timestamp,
+                                        json.dumps(metadata) if metadata else None,
+                                        "fetch_claude",
                                     ),
                                 )
                             else:

--- a/scripts/fetch_qwen.py
+++ b/scripts/fetch_qwen.py
@@ -892,9 +892,8 @@ def update_agent_sessions_stats(messages: list) -> int:
     conn = get_connection()
     cursor = conn.cursor()
     has_external_message_id = _column_exists(cursor, "session_messages", "external_message_id")
-    has_structured_session_messages = has_external_message_id and _column_exists(
-        cursor, "session_messages", "source"
-    )
+    has_source = _column_exists(cursor, "session_messages", "source")
+    has_structured_session_messages = has_external_message_id and has_source
 
     try:
         for session_id, stats in session_stats.items():
@@ -1084,6 +1083,26 @@ def update_agent_sessions_stats(messages: list) -> int:
                                             if msg.get("content_blocks")
                                             else None
                                         ),
+                                    ),
+                                )
+                            elif has_source:
+                                insert_sql = f"""
+                                    INSERT INTO session_messages
+                                    (session_id, role, content, tokens_used, model, timestamp, metadata, source)
+                                    VALUES ({placeholder}, {placeholder}, {placeholder}, {placeholder}, {placeholder}, {placeholder}, {placeholder}, {placeholder})
+                                """
+                                _execute(
+                                    cursor,
+                                    insert_sql,
+                                    (
+                                        session_id,
+                                        msg.get("role"),
+                                        msg.get("content"),
+                                        msg.get("tokens_used", 0),
+                                        msg.get("model"),
+                                        timestamp,
+                                        json.dumps(metadata) if metadata else None,
+                                        "fetch_qwen",
                                     ),
                                 )
                             else:

--- a/tests/unit/test_fetch_source_fallback.py
+++ b/tests/unit/test_fetch_source_fallback.py
@@ -1,0 +1,190 @@
+"""Source-fallback coverage for ``fetch_claude`` / ``fetch_qwen``.
+
+PR #1225 added a ``has_source``-aware fallback INSERT to all four fetch scripts
+so ``session_messages.source`` is still written when the structured transcript
+columns (``external_message_id`` etc.) are absent — mirroring the existing
+``fetch_codex`` / ``fetch_zcode`` behavior.
+
+``test_fetch_zcode`` already asserts the source value for the zcode fetcher;
+this module closes the gap for claude and qwen. The destination table is built
+WITH a ``source`` column but WITHOUT ``external_message_id``, which forces the
+``elif has_source:`` branch (the fallback under test).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sqlite3
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).resolve().parents[2]
+_SCRIPTS_DIR = project_root / "scripts"
+
+
+def _load_fetch_module(name: str, tmp_db_url: str):
+    """Load scripts/<name>.py as an isolated module against a temp DB."""
+    os.environ["DATABASE_URL"] = tmp_db_url
+    os.environ["FETCH_USE_SUDO"] = "false"
+    if str(_SCRIPTS_DIR) not in sys.path:
+        sys.path.insert(0, str(_SCRIPTS_DIR))
+
+    from shared import db as db_mod
+
+    importlib.reload(db_mod)
+
+    spec = importlib.util.spec_from_file_location(f"{name}_under_test", _SCRIPTS_DIR / f"{name}.py")
+    mod = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _init_dest_schema(db_path: Path) -> None:
+    """Destination tables — session_messages has ``source`` but NOT
+    ``external_message_id``, forcing the has_source fallback branch."""
+    conn = sqlite3.connect(str(db_path))
+    conn.executescript(
+        """
+        CREATE TABLE users (
+            id INTEGER PRIMARY KEY,
+            username TEXT,
+            system_account TEXT,
+            email TEXT
+        );
+        CREATE TABLE agent_sessions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT NOT NULL UNIQUE,
+            session_type TEXT DEFAULT 'chat',
+            title TEXT,
+            tool_name TEXT NOT NULL,
+            host_name TEXT DEFAULT 'localhost',
+            user_id INTEGER,
+            status TEXT DEFAULT 'active',
+            project_path TEXT,
+            message_count INTEGER DEFAULT 0,
+            total_tokens DEFAULT 0,
+            request_count INTEGER DEFAULT 0,
+            model TEXT,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        );
+        CREATE TABLE session_messages (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT,
+            role TEXT,
+            content TEXT,
+            tokens_used INTEGER DEFAULT 0,
+            model TEXT,
+            timestamp TEXT,
+            metadata TEXT,
+            source TEXT DEFAULT ''
+        );
+        CREATE TABLE daily_usage (
+            date TEXT,
+            tool_name TEXT,
+            host_name TEXT,
+            tokens_used INTEGER DEFAULT 0,
+            input_tokens INTEGER DEFAULT 0,
+            output_tokens INTEGER DEFAULT 0,
+            cache_tokens INTEGER DEFAULT 0,
+            request_count INTEGER DEFAULT 0,
+            models_used TEXT,
+            PRIMARY KEY (date, tool_name, host_name)
+        );
+        CREATE TABLE daily_messages (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            date TEXT,
+            tool_name TEXT,
+            host_name TEXT,
+            message_id TEXT,
+            role TEXT,
+            content TEXT,
+            tokens_used INTEGER DEFAULT 0,
+            input_tokens INTEGER DEFAULT 0,
+            output_tokens INTEGER DEFAULT 0,
+            model TEXT,
+            sender_id TEXT,
+            sender_name TEXT,
+            timestamp TEXT
+        );
+        """
+    )
+    conn.execute(
+        "INSERT INTO users (id, username, system_account, email) VALUES (1, 'rhuang', 'rhuang', 'r@x')"
+    )
+    conn.commit()
+    conn.close()
+
+
+def _messages(tool_name: str) -> list:
+    ts_iso = datetime.now(timezone.utc).isoformat()
+    return [
+        {
+            "date": "2026-06-24",
+            "tool_name": tool_name,
+            "host_name": "localhost",
+            "message_id": "m1",
+            "role": "user",
+            "content": "hello",
+            "content_blocks": None,
+            "tokens_used": 0,
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "model": None,
+            "timestamp": ts_iso,
+            "sender_name": "rhuang-host-" + tool_name,
+            "agent_session_id": "sess_src1",
+            "project_path": "/repo",
+        },
+        {
+            "date": "2026-06-24",
+            "tool_name": tool_name,
+            "host_name": "localhost",
+            "message_id": "m2",
+            "role": "assistant",
+            "content": "hi there",
+            "content_blocks": None,
+            "tokens_used": 110,
+            "input_tokens": 100,
+            "output_tokens": 10,
+            "model": "GLM-5.2",
+            "timestamp": ts_iso,
+            "sender_name": "rhuang-host-" + tool_name,
+            "agent_session_id": "sess_src1",
+            "project_path": "/repo",
+        },
+    ]
+
+
+@pytest.mark.parametrize(
+    "module_name,tool_name,expected_source",
+    [
+        ("fetch_claude", "claude", "fetch_claude"),
+        ("fetch_qwen", "qwen", "fetch_qwen"),
+    ],
+)
+def test_fetch_source_fallback_writes_source(tmp_path, module_name, tool_name, expected_source):
+    """When the dest table lacks external_message_id (has_source fallback),
+    the fetcher still writes ``source`` to session_messages."""
+    dest_db = tmp_path / "dest.sqlite"
+    _init_dest_schema(dest_db)
+    fetch_mod = _load_fetch_module(module_name, f"sqlite:///{dest_db}")
+
+    updated = fetch_mod.update_agent_sessions_stats(_messages(tool_name))
+    assert updated == 1
+
+    conn = sqlite3.connect(str(dest_db))
+    conn.row_factory = sqlite3.Row
+    rows = conn.execute(
+        "SELECT role, source FROM session_messages WHERE session_id = ? ORDER BY role",
+        ("sess_src1",),
+    ).fetchall()
+    conn.close()
+
+    assert {r["role"] for r in rows} == {"user", "assistant"}
+    assert {r["source"] for r in rows} == {expected_source}

--- a/tests/unit/test_remote_sync_message_count.py
+++ b/tests/unit/test_remote_sync_message_count.py
@@ -1,0 +1,122 @@
+"""Regression test for the remote_sync ``message_count`` contract.
+
+Background: commit 8bf44e72 (PR #1221) made ``append_transcript_message``
+side-effect-free — it calls ``add_message(count_usage=False)``, which no longer
+advances ``agent_sessions.message_count``. Responsibility for ``message_count``
+moved to the *caller*, which must accumulate ``_was_inserted`` and apply the
+delta via ``increment_session_usage(message_delta=...)``. Three callers were
+migrated (``llm_proxy_handler``, ``agent_runner``, ``remote_session_manager``);
+the ``remote.py`` ``session_sync`` import loop was missed, so remote-synced
+sessions stopped reflecting their imported messages (fixed in PR #1225).
+
+These tests encode the contract every ``append_transcript_message`` caller
+relies on, against a real isolated SQLite ``SessionManager``. They would have
+failed at the regression: without the ``increment_session_usage(message_delta=)``
+call, ``message_count`` stays 0.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.modules.workspace import session_manager as sm_mod
+from app.modules.workspace.session_manager import SessionManager
+
+
+@pytest.fixture
+def sqlite_sm(tmp_path, monkeypatch):
+    monkeypatch.setattr(sm_mod, "is_postgresql", lambda: False)
+    sm = SessionManager(db_path=str(tmp_path / "remote_sync_count.db"))
+    sm._ensure_tables()
+    # create_session writes project_id / project_path; ensure both exist.
+    conn = sm._get_connection()
+    cur = conn.cursor()
+    for col in ("project_id", "project_path"):
+        try:
+            cur.execute(f"ALTER TABLE agent_sessions ADD COLUMN {col} TEXT")
+        except Exception:
+            pass
+    conn.commit()
+    conn.close()
+    return sm
+
+
+def _create_session(sm: SessionManager, session_id: str = "sess-sync"):
+    return sm.create_session(tool_name="claude", session_id=session_id, user_id=1)
+
+
+def _import_like_remote_sync(sm: SessionManager, session_id: str, messages: list) -> int:
+    """Mirror the remote.py session_sync import loop exactly.
+
+    Append each message, accumulate the count of newly-inserted rows, then
+    apply the net delta once via ``increment_session_usage``. Returns the delta
+    that was applied.
+    """
+    synced_message_delta = 0
+    for msg in messages:
+        stored = sm.append_transcript_message(
+            session_id=session_id,
+            role=msg["role"],
+            content=msg["content"],
+            source="remote_sync",
+            external_message_id=msg["external_message_id"],
+        )
+        if getattr(stored, "_was_inserted", False):
+            synced_message_delta += 1
+    if synced_message_delta:
+        sm.increment_session_usage(session_id, message_delta=synced_message_delta)
+    return synced_message_delta
+
+
+def test_remote_sync_import_advances_message_count(sqlite_sm):
+    """A bulk import advances message_count by the number of new messages."""
+    _create_session(sqlite_sm)
+    messages = [
+        {"role": "user", "content": "what is 2+2?", "external_message_id": "m1"},
+        {"role": "assistant", "content": "4", "external_message_id": "m2"},
+        {"role": "assistant", "content": "let me elaborate", "external_message_id": "m3"},
+    ]
+
+    delta = _import_like_remote_sync(sqlite_sm, "sess-sync", messages)
+
+    assert delta == 3
+    session = sqlite_sm.get_session("sess-sync")
+    assert session.message_count == 3  # was 0 before PR #1225 (the regression)
+
+
+def test_remote_sync_reimport_does_not_double_count(sqlite_sm):
+    """Re-syncing the same history must not advance message_count again."""
+    _create_session(sqlite_sm)
+    messages = [
+        {"role": "user", "content": "again", "external_message_id": "m1"},
+        {"role": "assistant", "content": "ok", "external_message_id": "m2"},
+    ]
+
+    _import_like_remote_sync(sqlite_sm, "sess-sync", messages)
+    delta = _import_like_remote_sync(sqlite_sm, "sess-sync", messages)
+
+    assert delta == 0  # dedup: _was_inserted is False on the upsert path
+    session = sqlite_sm.get_session("sess-sync")
+    assert session.message_count == 2  # unchanged after re-sync
+
+
+def test_append_transcript_message_alone_does_not_advance_count(sqlite_sm):
+    """Guards the regression root cause.
+
+    ``append_transcript_message`` keeps ``add_message`` side-effect-free
+    (``count_usage=False``), so it must NOT touch ``message_count`` on its own.
+    This is precisely why the caller owns the delta — and why the missed
+    migration in remote.py zeroed-out the count.
+    """
+    _create_session(sqlite_sm)
+
+    sqlite_sm.append_transcript_message(
+        session_id="sess-sync",
+        role="assistant",
+        content="a message with no caller-side accounting",
+        source="remote_sync",
+        external_message_id="m1",
+    )
+
+    session = sqlite_sm.get_session("sess-sync")
+    assert session.message_count == 0


### PR DESCRIPTION
Follow-up to #1221. A line-by-line three-way review (merge-base `0bed81b6` / main `e76479a6` / pre-rebase B `8e0b6832`) of PR#1221's merged result found two issues.

## Findings from the review

- `remote.py`, `agent_runner.py`, `models.py` — **byte-identical** to pre-rebase B; rebase introduced no changes. ✓
- `session_manager.py` — all changes came from the review-fix commit `8bf44e72`; verified `_ensure_tables` preserves all 10 columns + 2 indexes (check-first refactor is clean) and `increment_session_usage`'s new `message_delta` param is coherent. ✓
- **Regression found**: `8bf44e72` removed `add_message`'s `count_usage=False` else-branch (which advanced `message_count`) and shifted that responsibility to callers. Three callers were migrated (`llm_proxy_handler`, `agent_runner`, `remote_session_manager`) — but the **`remote.py` session_sync import loop was missed**, so remote-synced sessions stopped reflecting imported messages in `message_count`. (The payload's `message_count` is log-only, never written, so there was no compensating path.)

## Changes

1. **`fetch_claude.py` / `fetch_qwen.py`** — add the `has_source`-aware fallback INSERT (already in `fetch_codex`/`fetch_zcode`), so all four fetch scripts write `source` consistently when the structured transcript columns are absent.
2. **`remote.py`** — capture `_was_inserted` from `append_transcript_message`, accumulate `synced_message_delta` across the loop, and apply it once via `increment_session_usage(message_delta=...)` after the loop (accumulate pattern — avoids N DB updates on bulk history import; matches `llm_proxy_handler`/`agent_runner`).

## Verification
- 1927 unit tests pass; black + ruff clean.
- `session_sync` / usage-accounting / session-summary-contract suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)