### PR TITLE
fix(insights): ensure deterministic score for regenerated reports (Issue #685)

### DIFF
--- a/app/repositories/message_repo.py
+++ b/app/repositories/message_repo.py
@@ -1289,6 +1289,7 @@ class MessageRepository:
             List[Dict]: List of conversations, each with session_id and messages.
         """
         # Find distinct agent_session_ids that have user messages
+        # Use ORDER BY to ensure deterministic sampling (fixes #685)
         safe_prefix = escape_like(sender_prefix)
         session_query = """
             SELECT DISTINCT COALESCE(agent_session_id, conversation_id) as session_id
@@ -1297,6 +1298,8 @@ class MessageRepository:
               AND sender_name LIKE ?
               AND role = 'user'
               AND COALESCE(agent_session_id, conversation_id) IS NOT NULL
+            GROUP BY session_id
+            ORDER BY MIN(timestamp) ASC, session_id ASC
             LIMIT ?
         """
         sessions = self.db.fetch_all(

--- a/app/repositories/message_repo.py
+++ b/app/repositories/message_repo.py
@@ -1292,7 +1292,7 @@ class MessageRepository:
         # Use ORDER BY to ensure deterministic sampling (fixes #685)
         safe_prefix = escape_like(sender_prefix)
         session_query = """
-            SELECT DISTINCT COALESCE(agent_session_id, conversation_id) as session_id
+            SELECT COALESCE(agent_session_id, conversation_id) as session_id
             FROM daily_messages
             WHERE date >= ? AND date <= ?
               AND sender_name LIKE ?

--- a/app/services/insights_service.py
+++ b/app/services/insights_service.py
@@ -138,7 +138,7 @@ class InsightsService:
                 model=model,
                 system_prompt=system_prompt,
                 user_prompt=user_prompt,
-                temperature=insights_cfg.get("temperature", 0.3),
+                temperature=insights_cfg.get("temperature", 0),
                 max_tokens=insights_cfg.get("max_tokens", 4096),
             )
         except Exception as e:


### PR DESCRIPTION
## 问题描述

用户生成 AI 对话洞察报告，删除后再次生成，两次分数不一致。

## 问题分析

1. **对话样本的随机性**：`get_user_conversation_samples` 方法的 SQL 查询没有 `ORDER BY` 子句，每次查询返回的会话样本可能不同
2. **AI 模型的随机性**：温度参数默认值为 `temperature=0.3`，导致 AI 输出有随机性

## 修改内容

| 文件 | 修改 |
|------|------|
| `app/repositories/message_repo.py` | 添加 `GROUP BY session_id ORDER BY MIN(timestamp) ASC, session_id ASC` 确保确定性抽样 |
| `app/services/insights_service.py` | 将 `temperature` 默认值从 `0.3` 改为 `0` |

## 测试结果

- ✅ 74 个单元测试全部通过

## 关联 Issue

Fixes #685