### PR TITLE
feat(workspace): scroll to bottom when switching tabs

### DIFF
--- a/frontend/src/components/features/Workspace.tsx
+++ b/frontend/src/components/features/Workspace.tsx
@@ -1401,6 +1401,8 @@ export const Workspace: React.FC = () => {
         const iframe = iframeRefs.current.get(tabId);
         if (iframe?.contentWindow) {
           iframe.contentWindow.postMessage({ type: 'openace-focus-input' }, '*');
+          // Scroll to bottom when switching tabs to show latest messages (Issue #1232)
+          iframe.contentWindow.postMessage({ type: 'openace-scroll-to-bottom' }, '*');
         }
       }, 100);
     },


### PR DESCRIPTION
## Summary

When switching between workspace tabs, send `openace-scroll-to-bottom` message to iframe so that users can see the latest messages instead of staying at the previous scroll position.

## Changes

- Modified `switchTab` function in `Workspace.tsx` to send `openace-scroll-to-bottom` postMessage when switching tabs

## Related Issue

Fixes #1232

## Note

This PR only modifies the open-ace side. For complete functionality, the WebUI (`qwen-code-webui`) project also needs to be updated to handle the `openace-scroll-to-bottom` message and call `scrollToBottom()` on the chat messages component.

## Workflow

```
用户切换标签 → Workspace.tsx 发送 postMessage → WebUI ChatPage.tsx 接收消息 → 调用 ChatMessages.scrollToBottom() → 滚动到底部
```