### PR TITLE
fix(security): hide 2FA toggle as feature not implemented (Issue #862)

### DIFF
--- a/frontend/src/components/features/management/SecurityCenter.tsx
+++ b/frontend/src/components/features/management/SecurityCenter.tsx
@@ -687,7 +687,8 @@ export const SecurityCenter: React.FC = () => {
           </div>
         </Card>
 
-        {/* Two-Factor Authentication */}
+        {/* Two-Factor Authentication - 功能未实现，暂时隐藏 (Issue #862) */}
+        {/*
         <Card title={t('twoFactorAuth', language)} className="mb-4">
           <div className="form-check form-switch">
             <input
@@ -703,6 +704,7 @@ export const SecurityCenter: React.FC = () => {
           </div>
           <small className="text-muted">{t('twoFactorHelp', language)}</small>
         </Card>
+        */}
 
         {/* IP Whitelist */}
         <Card title={t('ipWhitelist', language)} className="mb-4">


### PR DESCRIPTION
## 问题

Issue #862：安全设置页面有双因素认证开关但缺少实际 2FA 功能实现

在 **管理模式 → 治理 → 安全中心 → 安全设置** 页面：
- 有「启用双因素认证」开关选项
- 但系统中没有任何实际的 2FA 功能：
  - 用户没有个人 2FA 设置页面
  - 登录时没有 2FA 验证流程
  - 没有 TOTP/App 绑定功能

## 修复方案

采用方案 2：**暂时隐藏开关**

避免误导用户以为系统有 2FA 功能，等完整功能实现后再显示。

## 修改内容

- `frontend/src/components/features/management/SecurityCenter.tsx`：注释掉 2FA 开关卡片

## 保留不变

- i18n 翻译文件（保留供未来使用）
- API 类型定义（后端字段保留）
- 后端代码与测试（设置存储功能保留）

## 验证

- [x] 前端 lint 检查通过

Closes #862

🤖 Generated with Qwen Code