### PR TITLE
fix(install): 相对路径部署目录导致 cd 失败及输入验证缺失

### DIFF
--- a/scripts/install-central/docker-method/install.sh
+++ b/scripts/install-central/docker-method/install.sh
@@ -142,20 +142,32 @@ prompt_yesno() {
     local options="[Y/n]"
     [ "$default" = "n" ] && options="[y/N]"
 
-    echo -ne "${BLUE}$prompt ${options}: ${NC}"
-    read -r value
+    while true; do
+        echo -ne "${BLUE}$prompt ${options}: ${NC}"
+        read -r value
 
-    value=$(echo "$value" | tr '[:upper:]' '[:lower:]')
+        value=$(echo "$value" | tr '[:upper:]' '[:lower:]')
 
-    if [ -z "$value" ]; then
-        value="$default"
-    fi
+        # Empty value uses default
+        if [ -z "$value" ]; then
+            value="$default"
+        fi
 
-    if [ "$value" = "y" ] || [ "$value" = "yes" ]; then
-        eval "$var_name='yes'"
-    else
-        eval "$var_name='no'"
-    fi
+        # Validate input (Issue #1235)
+        case "$value" in
+            y|yes)
+                eval "$var_name='yes'"
+                break
+                ;;
+            n|no)
+                eval "$var_name='no'"
+                break
+                ;;
+            *)
+                print_warning "无效输入 '$value'，请输入 Y/n"
+                ;;
+        esac
+    done
 }
 
 # ============================================================================
@@ -3588,6 +3600,11 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+# Ensure DEPLOY_DIR is absolute path (Issue #1235)
+if [[ "$DEPLOY_DIR" != /* ]] && [ -n "$DEPLOY_DIR" ]; then
+    DEPLOY_DIR="$(pwd)/$DEPLOY_DIR"
+fi
+
 # Main execution
 print_header "Open ACE - 快速部署"
 
@@ -3678,6 +3695,41 @@ if [ "$NON_INTERACTIVE" = false ]; then
     DEPLOY_DIR="/home/$RUN_USER/open-ace"
     DB_USER="$RUN_USER"
     prompt_input "部署目录" "$DEPLOY_DIR" DEPLOY_DIR
+
+    # Ensure DEPLOY_DIR is absolute path (Issue #1235)
+    if [[ "$DEPLOY_DIR" != /* ]] && [ -n "$DEPLOY_DIR" ]; then
+        DEPLOY_DIR="$(pwd)/$DEPLOY_DIR"
+    fi
+
+    # Validate parent directory (Issue #1235)
+    while true; do
+        parent_dir=$(dirname "$DEPLOY_DIR")
+
+        if [ -d "$parent_dir" ]; then
+            # Parent exists, continue
+            break
+        else
+            print_warning "父目录不存在: $parent_dir"
+            prompt_yesno "是否创建父目录?" "y" create_parent
+            if [ "$create_parent" = "yes" ]; then
+                mkdir -p "$parent_dir"
+                if [ $? -eq 0 ]; then
+                    print_success "父目录创建成功: $parent_dir"
+                    break
+                else
+                    print_error "创建父目录失败，请重新输入部署目录"
+                fi
+            else
+                print_info "请重新输入部署目录"
+            fi
+            prompt_input "部署目录" "$DEPLOY_DIR" DEPLOY_DIR
+            # Re-normalize after re-input
+            if [[ "$DEPLOY_DIR" != /* ]] && [ -n "$DEPLOY_DIR" ]; then
+                DEPLOY_DIR="$(pwd)/$DEPLOY_DIR"
+            fi
+        fi
+    done
+
     prompt_input "Web 端口" "$WEB_PORT" WEB_PORT
 
     # Host name


### PR DESCRIPTION
## 关联 Issue

Closes #1235

## 问题描述

在 node238 上执行 Docker 版安装脚本时，用户输入相对路径 `y` 作为部署目录，脚本在第 3243 行报错：
```
/root/open-ace/scripts/install-central/docker-method/install.sh: 第 3243 行：cd: y: 没有那个文件或目录
```

### 根因分析

`DEPLOY_DIR` 存储用户输入的原始值（相对路径），脚本多次改变工作目录后再次 cd 相对路径导致失败。

### 附加问题

1. `prompt_yesno()` 函数将无效输入（如 `x`、`abc`）当作 `no` 处理
2. 部署目录父目录不存在时无提示

## 修复内容

| 序号 | 修改内容 |
|------|----------|
| 1 | `prompt_yesno()` 函数添加输入验证循环（第 132-165 行） |
| 2 | 非交互模式参数解析后转换相对路径为绝对路径（第 3600-3604 行） |
| 3 | 交互模式部署目录处理：路径转换 + 父目录验证/创建（第 3697-3733 行） |

## 验证结果

**相对路径转换**
```
Before: DEPLOY_DIR=y
After:  DEPLOY_DIR=/root/y  ✓
```

**父目录验证**
```
DEPLOY_DIR=/invalid/path/app
parent_dir=/invalid/path
not exists - would prompt to create  ✓
```