### PR TITLE
Fix workflow fork timeline visualization

### DIFF
--- a/app/modules/workspace/autonomous/models.py
+++ b/app/modules/workspace/autonomous/models.py
@@ -213,6 +213,7 @@ class WorkflowMilestone:
     error_message: str = ""
     parent_milestone_id: str = ""
     fork_branch: str = ""
+    fork_workflow_id: str = ""
     metadata: str = ""  # JSON
     started_at: Optional[datetime] = None
     completed_at: Optional[datetime] = None
@@ -244,6 +245,7 @@ class WorkflowMilestone:
             "error_message": self.error_message,
             "parent_milestone_id": self.parent_milestone_id,
             "fork_branch": self.fork_branch,
+            "fork_workflow_id": self.fork_workflow_id,
             "metadata": self.metadata,
             "started_at": self.started_at.isoformat() if self.started_at else None,
             "completed_at": self.completed_at.isoformat() if self.completed_at else None,
@@ -279,6 +281,7 @@ class WorkflowMilestone:
             error_message=data.get("error_message", ""),
             parent_milestone_id=data.get("parent_milestone_id", ""),
             fork_branch=data.get("fork_branch", ""),
+            fork_workflow_id=data.get("fork_workflow_id", ""),
             metadata=data.get("metadata", ""),
             started_at=(
                 datetime.fromisoformat(data["started_at"]) if data.get("started_at") else None

--- a/app/repositories/autonomous_repo.py
+++ b/app/repositories/autonomous_repo.py
@@ -624,6 +624,7 @@ class AutonomousWorkflowRepository:
             "error_message",
             "parent_milestone_id",
             "fork_branch",
+            "fork_workflow_id",
             "metadata",
         ]
         col_names = [
@@ -745,12 +746,12 @@ class AutonomousWorkflowRepository:
                      github_issue_number, github_pr_number, github_comment_id,
                      commit_shas, diff_stats, result_summary,
                      plan_content, review_content, tldr,
-                     parent_milestone_id, fork_branch, metadata,
+                     parent_milestone_id, fork_branch, fork_workflow_id, metadata,
                      error_message,
                      phase_total_tokens, phase_input_tokens,
                      phase_output_tokens, phase_request_count,
                      started_at, created_at, updated_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 RETURNING *
                 """,
                 (
@@ -776,6 +777,7 @@ class AutonomousWorkflowRepository:
                     data.get("tldr", ""),
                     data.get("parent_milestone_id", ""),
                     data.get("fork_branch", ""),
+                    data.get("fork_workflow_id", ""),
                     data.get("metadata", ""),
                     data.get("error_message", ""),
                     data.get("phase_total_tokens", 0),
@@ -799,12 +801,12 @@ class AutonomousWorkflowRepository:
                      github_issue_number, github_pr_number, github_comment_id,
                      commit_shas, diff_stats, result_summary,
                      plan_content, review_content, tldr,
-                     parent_milestone_id, fork_branch, metadata,
+                     parent_milestone_id, fork_branch, fork_workflow_id, metadata,
                      error_message,
                      phase_total_tokens, phase_input_tokens,
                      phase_output_tokens, phase_request_count,
                      started_at, created_at, updated_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     data.get("workflow_id", ""),
@@ -829,6 +831,7 @@ class AutonomousWorkflowRepository:
                     data.get("tldr", ""),
                     data.get("parent_milestone_id", ""),
                     data.get("fork_branch", ""),
+                    data.get("fork_workflow_id", ""),
                     data.get("metadata", ""),
                     data.get("error_message", ""),
                     data.get("phase_total_tokens", 0),

--- a/frontend/src/components/work/WorkflowTimeline.tsx
+++ b/frontend/src/components/work/WorkflowTimeline.tsx
@@ -45,6 +45,7 @@ import type {
   WorkflowMilestone,
 } from '@/api/autonomous';
 import {
+  findForkMilestoneIndex,
   formatTokens,
   parseDiffFiles,
   parseDiffStats,
@@ -380,44 +381,6 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
     [parentTimelineData?.milestones]
   );
 
-  const findForkMilestoneIndex = useCallback(
-    (
-      sourceMilestones: WorkflowMilestone[],
-      options?: {
-        childWorkflowId?: string | null;
-        fallbackMilestoneId?: string | null;
-      }
-    ) => {
-      if (!sourceMilestones.length) return -1;
-
-      const childWorkflowId = options?.childWorkflowId?.trim() ?? '';
-      if (childWorkflowId) {
-        const directIndex = sourceMilestones.findIndex(
-          (m) => (m.fork_workflow_id ?? '').trim() === childWorkflowId
-        );
-        if (directIndex >= 0) return directIndex;
-      }
-
-      const fallbackMilestoneId = options?.fallbackMilestoneId?.trim() ?? '';
-      if (fallbackMilestoneId) {
-        const milestoneIdIndex = sourceMilestones.findIndex(
-          (m) => m.milestone_id === fallbackMilestoneId
-        );
-        if (milestoneIdIndex >= 0) return milestoneIdIndex;
-      }
-
-      const forkMarkers = sourceMilestones
-        .map((milestone, index) => ({ milestone, index }))
-        .filter(({ milestone }) => milestone.milestone_type === 'workflow_forked');
-      if (forkMarkers.length === 1) {
-        return forkMarkers[0].index;
-      }
-
-      return -1;
-    },
-    []
-  );
-
   // ── Compute Fork Visualization Data ───────────────────────────────
 
   const forkViz = useMemo<{
@@ -427,7 +390,9 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
   } | null>(() => {
     if (isForkParent) {
       // Case 1: This workflow has forks — we are the parent
-      const forkIdx = findForkMilestoneIndex(milestones);
+      const forkIdx = findForkMilestoneIndex(milestones, {
+        preferFirstForkWorkflowId: true,
+      });
       if (forkIdx < 0) return null;
 
       const shared = milestones.slice(0, forkIdx + 1);
@@ -507,7 +472,6 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
 
     return null;
   }, [
-    findForkMilestoneIndex,
     isForkParent,
     isForkChild,
     milestones,

--- a/frontend/src/components/work/WorkflowTimeline.tsx
+++ b/frontend/src/components/work/WorkflowTimeline.tsx
@@ -380,6 +380,44 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
     [parentTimelineData?.milestones]
   );
 
+  const findForkMilestoneIndex = useCallback(
+    (
+      sourceMilestones: WorkflowMilestone[],
+      options?: {
+        childWorkflowId?: string | null;
+        fallbackMilestoneId?: string | null;
+      }
+    ) => {
+      if (!sourceMilestones.length) return -1;
+
+      const childWorkflowId = options?.childWorkflowId?.trim() ?? '';
+      if (childWorkflowId) {
+        const directIndex = sourceMilestones.findIndex(
+          (m) => (m.fork_workflow_id ?? '').trim() === childWorkflowId
+        );
+        if (directIndex >= 0) return directIndex;
+      }
+
+      const fallbackMilestoneId = options?.fallbackMilestoneId?.trim() ?? '';
+      if (fallbackMilestoneId) {
+        const milestoneIdIndex = sourceMilestones.findIndex(
+          (m) => m.milestone_id === fallbackMilestoneId
+        );
+        if (milestoneIdIndex >= 0) return milestoneIdIndex;
+      }
+
+      const forkMarkers = sourceMilestones
+        .map((milestone, index) => ({ milestone, index }))
+        .filter(({ milestone }) => milestone.milestone_type === 'workflow_forked');
+      if (forkMarkers.length === 1) {
+        return forkMarkers[0].index;
+      }
+
+      return -1;
+    },
+    []
+  );
+
   // ── Compute Fork Visualization Data ───────────────────────────────
 
   const forkViz = useMemo<{
@@ -389,9 +427,7 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
   } | null>(() => {
     if (isForkParent) {
       // Case 1: This workflow has forks — we are the parent
-      const forkIdx = milestones.findIndex(
-        (m) => m.fork_workflow_id && m.fork_workflow_id.trim() !== ''
-      );
+      const forkIdx = findForkMilestoneIndex(milestones);
       if (forkIdx < 0) return null;
 
       const shared = milestones.slice(0, forkIdx + 1);
@@ -431,9 +467,10 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
 
     if (isForkChild && parentWorkflow && parentMilestones.length > 0) {
       // Case 2: This workflow is a fork — show from child perspective
-      const forkIdx = parentMilestones.findIndex(
-        (m) => m.fork_workflow_id === workflow.workflow_id
-      );
+      const forkIdx = findForkMilestoneIndex(parentMilestones, {
+        childWorkflowId: workflow.workflow_id,
+        fallbackMilestoneId: workflow.fork_milestone_id,
+      });
       if (forkIdx < 0) return null;
 
       const shared = parentMilestones.slice(0, forkIdx + 1);
@@ -470,6 +507,7 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
 
     return null;
   }, [
+    findForkMilestoneIndex,
     isForkParent,
     isForkChild,
     milestones,

--- a/frontend/src/components/work/WorkflowTimeline.utils.test.ts
+++ b/frontend/src/components/work/WorkflowTimeline.utils.test.ts
@@ -87,9 +87,7 @@ describe('WorkflowTimeline.utils', () => {
         fork_workflow_id: 'wf-child-1',
       },
     ];
-    expect(findForkMilestoneIndex(childMatchMilestones, { childWorkflowId: 'wf-child-1' })).toBe(
-      1
-    );
+    expect(findForkMilestoneIndex(childMatchMilestones, { childWorkflowId: 'wf-child-1' })).toBe(1);
 
     const milestoneIdFallbackMilestones = [
       { milestone_id: 'ms-1', milestone_type: 'dev_started', fork_workflow_id: '' },

--- a/frontend/src/components/work/WorkflowTimeline.utils.test.ts
+++ b/frontend/src/components/work/WorkflowTimeline.utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { parseDiffFiles, parseDiffStats } from './WorkflowTimeline.utils';
+import { findForkMilestoneIndex, parseDiffFiles, parseDiffStats } from './WorkflowTimeline.utils';
 
 describe('WorkflowTimeline.utils', () => {
   it('parses diff stats json', () => {
@@ -58,5 +58,63 @@ describe('WorkflowTimeline.utils', () => {
       additions: 1,
       deletions: 1,
     });
+  });
+
+  it('finds the first persisted fork marker for parent timelines', () => {
+    const milestones = [
+      { milestone_id: 'ms-1', milestone_type: 'dev_started', fork_workflow_id: '' },
+      {
+        milestone_id: 'ms-2',
+        milestone_type: 'workflow_forked',
+        fork_workflow_id: 'wf-child-1',
+      },
+      {
+        milestone_id: 'ms-3',
+        milestone_type: 'workflow_forked',
+        fork_workflow_id: 'wf-child-2',
+      },
+    ];
+
+    expect(findForkMilestoneIndex(milestones, { preferFirstForkWorkflowId: true })).toBe(1);
+  });
+
+  it('falls back from child workflow id to fork milestone id to a single marker', () => {
+    const childMatchMilestones = [
+      { milestone_id: 'ms-1', milestone_type: 'dev_started', fork_workflow_id: '' },
+      {
+        milestone_id: 'ms-2',
+        milestone_type: 'workflow_forked',
+        fork_workflow_id: 'wf-child-1',
+      },
+    ];
+    expect(findForkMilestoneIndex(childMatchMilestones, { childWorkflowId: 'wf-child-1' })).toBe(
+      1
+    );
+
+    const milestoneIdFallbackMilestones = [
+      { milestone_id: 'ms-1', milestone_type: 'dev_started', fork_workflow_id: '' },
+      { milestone_id: 'ms-fork', milestone_type: 'workflow_forked', fork_workflow_id: '' },
+      { milestone_id: 'ms-3', milestone_type: 'tests_run', fork_workflow_id: '' },
+    ];
+    expect(
+      findForkMilestoneIndex(milestoneIdFallbackMilestones, { fallbackMilestoneId: 'ms-fork' })
+    ).toBe(1);
+
+    const singleMarkerFallbackMilestones = [
+      { milestone_id: 'ms-1', milestone_type: 'dev_started', fork_workflow_id: '' },
+      { milestone_id: 'ms-2', milestone_type: 'workflow_forked', fork_workflow_id: '' },
+      { milestone_id: 'ms-3', milestone_type: 'tests_run', fork_workflow_id: '' },
+    ];
+    expect(findForkMilestoneIndex(singleMarkerFallbackMilestones)).toBe(1);
+  });
+
+  it('returns -1 when no direct or fallback fork marker can be resolved', () => {
+    const milestones = [
+      { milestone_id: 'ms-1', milestone_type: 'dev_started', fork_workflow_id: '' },
+      { milestone_id: 'ms-2', milestone_type: 'workflow_forked', fork_workflow_id: '' },
+      { milestone_id: 'ms-3', milestone_type: 'workflow_forked', fork_workflow_id: '' },
+    ];
+
+    expect(findForkMilestoneIndex(milestones, { childWorkflowId: 'wf-missing' })).toBe(-1);
   });
 });

--- a/frontend/src/components/work/WorkflowTimeline.utils.ts
+++ b/frontend/src/components/work/WorkflowTimeline.utils.ts
@@ -2,6 +2,12 @@ import { formatTokens } from '@/utils';
 
 export type ParsedDiffFileStatus = 'added' | 'modified' | 'deleted';
 
+export interface ForkTimelineMilestoneLike {
+  milestone_id: string;
+  milestone_type: string;
+  fork_workflow_id: string;
+}
+
 export interface ParsedDiffFile {
   id: string;
   path: string;
@@ -97,6 +103,43 @@ export function parseDiffFiles(diffText: string): ParsedDiffFile[] {
 
   pushCurrent();
   return files;
+}
+
+export function findForkMilestoneIndex(
+  sourceMilestones: ForkTimelineMilestoneLike[],
+  options?: {
+    childWorkflowId?: string | null;
+    fallbackMilestoneId?: string | null;
+    preferFirstForkWorkflowId?: boolean;
+  }
+): number {
+  if (!sourceMilestones.length) return -1;
+
+  if (options?.preferFirstForkWorkflowId) {
+    const firstForkWorkflowIndex = sourceMilestones.findIndex((m) => m.fork_workflow_id.trim());
+    if (firstForkWorkflowIndex >= 0) return firstForkWorkflowIndex;
+  }
+
+  const childWorkflowId = options?.childWorkflowId?.trim() ?? '';
+  if (childWorkflowId) {
+    const directIndex = sourceMilestones.findIndex((m) => m.fork_workflow_id.trim() === childWorkflowId);
+    if (directIndex >= 0) return directIndex;
+  }
+
+  const fallbackMilestoneId = options?.fallbackMilestoneId?.trim() ?? '';
+  if (fallbackMilestoneId) {
+    const milestoneIdIndex = sourceMilestones.findIndex((m) => m.milestone_id === fallbackMilestoneId);
+    if (milestoneIdIndex >= 0) return milestoneIdIndex;
+  }
+
+  const forkMarkers = sourceMilestones
+    .map((milestone, index) => ({ milestone, index }))
+    .filter(({ milestone }) => milestone.milestone_type === 'workflow_forked');
+  if (forkMarkers.length === 1) {
+    return forkMarkers[0].index;
+  }
+
+  return -1;
 }
 
 export { formatTokens };

--- a/frontend/src/components/work/WorkflowTimeline.utils.ts
+++ b/frontend/src/components/work/WorkflowTimeline.utils.ts
@@ -122,13 +122,17 @@ export function findForkMilestoneIndex(
 
   const childWorkflowId = options?.childWorkflowId?.trim() ?? '';
   if (childWorkflowId) {
-    const directIndex = sourceMilestones.findIndex((m) => m.fork_workflow_id.trim() === childWorkflowId);
+    const directIndex = sourceMilestones.findIndex(
+      (m) => m.fork_workflow_id.trim() === childWorkflowId
+    );
     if (directIndex >= 0) return directIndex;
   }
 
   const fallbackMilestoneId = options?.fallbackMilestoneId?.trim() ?? '';
   if (fallbackMilestoneId) {
-    const milestoneIdIndex = sourceMilestones.findIndex((m) => m.milestone_id === fallbackMilestoneId);
+    const milestoneIdIndex = sourceMilestones.findIndex(
+      (m) => m.milestone_id === fallbackMilestoneId
+    );
     if (milestoneIdIndex >= 0) return milestoneIdIndex;
   }
 

--- a/tests/issues/716/test_models.py
+++ b/tests/issues/716/test_models.py
@@ -163,12 +163,14 @@ class TestWorkflowMilestone:
             "phase": "development",
             "milestone_type": "dev_started",
             "status": "in_progress",
+            "fork_workflow_id": "wf-fork-2",
             "created_at": "2026-06-05T12:00:00",
         }
         ms = WorkflowMilestone.from_dict(data)
         assert ms.milestone_id == "ms-2"
         assert ms.phase == "development"
         assert ms.status == "in_progress"
+        assert ms.fork_workflow_id == "wf-fork-2"
 
     def test_from_dict_empty(self):
         ms = WorkflowMilestone.from_dict({})
@@ -194,6 +196,15 @@ class TestWorkflowMilestone:
         assert ms2.milestone_id == ms.milestone_id
         assert ms2.phase == ms.phase
         assert ms2.dev_round == ms.dev_round
+
+    def test_to_dict_includes_fork_workflow_id(self):
+        ms = WorkflowMilestone(
+            milestone_id="ms-fork",
+            milestone_type="workflow_forked",
+            fork_workflow_id="wf-fork-001",
+        )
+        d = ms.to_dict()
+        assert d["fork_workflow_id"] == "wf-fork-001"
 
 
 class TestWorkflowEvent:

--- a/tests/issues/886/test_cancel_fork_redesign.py
+++ b/tests/issues/886/test_cancel_fork_redesign.py
@@ -696,3 +696,26 @@ class TestForkRepoIntegration:
         original_ids = {"ms-1", "ms-2"}
         copied_ids = {ms["milestone_id"] for ms in dst_milestones}
         assert copied_ids.isdisjoint(original_ids), "Copied milestones should have new IDs"
+
+    def test_create_milestone_persists_fork_workflow_id(self, auto_db):
+        """Fork marker milestones persist fork_workflow_id for timeline fork visualization."""
+        from app.repositories.autonomous_repo import AutonomousWorkflowRepository
+
+        repo = AutonomousWorkflowRepository(auto_db)
+
+        repo.create_workflow(_make_workflow())
+        created = repo.create_milestone(
+            _make_milestone(
+                milestone_id="ms-fork",
+                milestone_type="workflow_forked",
+                title="Forked to new workflow",
+                fork_branch="fork/from-ms-fork",
+                fork_workflow_id="wf-fork-001",
+            )
+        )
+
+        assert created["fork_workflow_id"] == "wf-fork-001"
+
+        fetched = repo.get_milestone("ms-fork")
+        assert fetched is not None
+        assert fetched["fork_workflow_id"] == "wf-fork-001"


### PR DESCRIPTION
## Summary
- persist `fork_workflow_id` when creating workflow milestones so fork markers can link to child workflows
- add timeline fallback logic so historical forked workflows still render shared history and branch columns when only the fork milestone id is available
- add regression coverage for milestone fork metadata persistence and model serialization

## Testing
- `python3 -m pytest tests/issues/886/test_cancel_fork_redesign.py tests/issues/716/test_models.py -q`
- `npm exec -- tsc -p tsconfig.json --noEmit` (run in `frontend/`)