### PR TITLE
feat(autonomous): include issue comments in planning phase

### DIFF
--- a/app/modules/workspace/autonomous/github_ops.py
+++ b/app/modules/workspace/autonomous/github_ops.py
@@ -245,9 +245,20 @@ class GitHubOps:
         return {"number": issue_number, "url": issue_url}
 
     def get_issue(self, number: int) -> dict:
-        """Get issue details."""
+        """Get issue details, including all comments.
+
+        Comments are fetched so downstream phases (e.g. planning) can see
+        clarifications or supplementary requirements that only appear in the
+        issue discussion, not in the issue body.
+        """
         result = self._run_gh(
-            ["issue", "view", str(number), "--json", "number,title,body,url,state,labels"]
+            [
+                "issue",
+                "view",
+                str(number),
+                "--json",
+                "number,title,body,url,state,labels,comments",
+            ]
         )
         return json.loads(result.stdout.strip())
 

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -1503,10 +1503,28 @@ class AutonomousOrchestrator:
                 )
                 raise
         elif issue_number and not requirements_text:
-            # Read issue content
+            # Read issue content (body + all comments so planning sees the
+            # full discussion, not just the top-level description)
             try:
                 issue_data = gh.get_issue(issue_number)
                 requirements_text = issue_data.get("body", "")
+                comments = issue_data.get("comments", []) or []
+                if comments:
+                    # Format comments in chronological order. The gh CLI
+                    # returns author as {"login": "..."} and timestamps in
+                    # camelCase ("createdAt"), matching list_issue_comments.
+                    formatted = []
+                    for c in comments:
+                        author = c.get("author", {}) or {}
+                        author_name = (
+                            author.get("login") if isinstance(author, dict) else author
+                        ) or "unknown"
+                        created = c.get("createdAt", "") or c.get("created_at", "")
+                        stamp = f" ({created})" if created else ""
+                        formatted.append(f"### 评论 by @{author_name}{stamp}\n{c.get('body', '')}")
+                    requirements_text += "\n\n---\n\n## Issue 评论（补充信息）\n\n" + "\n\n".join(
+                        formatted
+                    )
                 self._create_milestone(
                     phase="preparation",
                     milestone_type="issue_created",

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -56,6 +56,20 @@ _COMPLETION_PATTERNS = [
     for kw in COMPLETION_KEYWORDS
 ]
 
+# Substrings that identify a comment as authored by the automation itself.
+# Shared by preparation (issue ingestion) and wait (new-requirement polling)
+# so status reports / PR links the bot posts back to the issue are never
+# re-ingested as requirements (#1244).
+BOT_AUTHOR_KEYWORDS = ["open-ace-bot", "autonomous", "bot"]
+
+
+def _is_bot_comment(comment: dict) -> bool:
+    """Return True if a comment looks like it was authored by the automation."""
+    author = comment.get("author", {}) or {}
+    login = (author.get("login") if isinstance(author, dict) else author) or ""
+    return any(kw in login.lower() for kw in BOT_AUTHOR_KEYWORDS)
+
+
 # Prefix added to all prompts to inform the agent it is running autonomously
 AUTONOMOUS_CONTEXT = (
     "## 重要提示\n"
@@ -1509,6 +1523,11 @@ class AutonomousOrchestrator:
                 issue_data = gh.get_issue(issue_number)
                 requirements_text = issue_data.get("body", "")
                 comments = issue_data.get("comments", []) or []
+                if comments:
+                    # Skip automation-authored comments (status reports / PR
+                    # links the bot itself posts) so a rerun or fork on an
+                    # existing issue doesn't re-ingest them as requirements.
+                    comments = [c for c in comments if not _is_bot_comment(c)]
                 if comments:
                     # Format comments in chronological order. The gh CLI
                     # returns author as {"login": "..."} and timestamps in
@@ -3196,15 +3215,7 @@ class AutonomousOrchestrator:
             return  # No new comments
 
         # Filter out bot's own comments (comments authored by the automation)
-        bot_author_keywords = ["open-ace-bot", "autonomous", "bot"]
-        user_comments = [
-            c
-            for c in comments
-            if not any(
-                kw in (c.get("author", {}).get("login", "") or "").lower()
-                for kw in bot_author_keywords
-            )
-        ]
+        user_comments = [c for c in comments if not _is_bot_comment(c)]
 
         # Check for completion signals — match whole words/lines only
         for comment in reversed(user_comments):

--- a/tests/issues/716/test_github_ops.py
+++ b/tests/issues/716/test_github_ops.py
@@ -91,11 +91,16 @@ class TestGitHubOpsIssue:
     def test_get_issue(self, mock_run):
         mock_run.return_value = MagicMock(
             returncode=0,
-            stdout='{"number": 42, "title": "Bug", "body": "Fix it", "state": "open"}',
+            stdout='{"number": 42, "title": "Bug", "body": "Fix it", "state": "open", "comments": [{"body": "More detail", "createdAt": "2026-06-05T12:00:00Z"}]}',
         )
         result = self.gh.get_issue(42)
         assert result["number"] == 42
         assert result["title"] == "Bug"
+        # Comments are now included so downstream phases see the full discussion
+        args = mock_run.call_args[0][0]
+        json_fields = next(a for a in args if a.startswith("number,title"))
+        assert "comments" in json_fields
+        assert len(result["comments"]) == 1
 
     @patch("app.modules.workspace.autonomous.github_ops.subprocess.run")
     def test_add_issue_comment(self, mock_run):

--- a/tests/issues/716/test_orchestrator.py
+++ b/tests/issues/716/test_orchestrator.py
@@ -216,6 +216,53 @@ class TestOrchestratorPreparation:
         assert len(req_updates) > 0
         assert req_updates[0][0][1]["requirements_text"] == "Issue body content"
 
+    def test_preparation_reads_issue_with_comments(self):
+        """Issue comments are appended to requirements_text so planning sees
+        the full discussion, not just the issue body."""
+        wf = _make_workflow(
+            current_phase="preparation",
+            requirements_text="",
+            requirements_issue_url="https://github.com/user/repo/issues/99",
+        )
+        orch, mock_repo = self._make_orchestrator(wf)
+
+        mock_gh = MagicMock()
+        mock_gh.get_issue.return_value = {
+            "number": 99,
+            "title": "Test Issue",
+            "body": "Issue body content",
+            "state": "open",
+            "comments": [
+                {
+                    "body": "Should also handle the edge case",
+                    "author": {"login": "alice"},
+                    "createdAt": "2026-06-05T12:00:00Z",
+                },
+                {
+                    "body": "Use Postgres for this",
+                    "author": {"login": "bob"},
+                    "createdAt": "2026-06-05T13:00:00Z",
+                },
+            ],
+        }
+        mock_gh.create_branch.return_value = {"branch": "auto-dev/test-wf"}
+        orch._gh = mock_gh
+
+        with patch("app.modules.workspace.autonomous.orchestrator.GitHubOps", return_value=mock_gh):
+            orch._do_preparation(wf)
+
+        update_calls = mock_repo.update_workflow.call_args_list
+        req_updates = [c for c in update_calls if c[0][1].get("requirements_text")]
+        assert len(req_updates) > 0
+        merged = req_updates[0][0][1]["requirements_text"]
+        # Body is preserved verbatim at the top
+        assert merged.startswith("Issue body content")
+        # Both comments are included with their authors and timestamps
+        assert "@alice" in merged
+        assert "Should also handle the edge case" in merged
+        assert "@bob" in merged
+        assert "Use Postgres for this" in merged
+
     @patch("app.modules.workspace.autonomous.orchestrator.GitHubOps")
     def test_preparation_worktree_strategy(self, mock_gh_cls):
         wf = _make_workflow(

--- a/tests/issues/716/test_orchestrator.py
+++ b/tests/issues/716/test_orchestrator.py
@@ -239,6 +239,11 @@ class TestOrchestratorPreparation:
                     "createdAt": "2026-06-05T12:00:00Z",
                 },
                 {
+                    "body": "## Progress Report\nPR created: #123",
+                    "author": {"login": "open-ace-bot"},
+                    "createdAt": "2026-06-05T12:30:00Z",
+                },
+                {
                     "body": "Use Postgres for this",
                     "author": {"login": "bob"},
                     "createdAt": "2026-06-05T13:00:00Z",
@@ -257,11 +262,14 @@ class TestOrchestratorPreparation:
         merged = req_updates[0][0][1]["requirements_text"]
         # Body is preserved verbatim at the top
         assert merged.startswith("Issue body content")
-        # Both comments are included with their authors and timestamps
+        # Real user comments are included with their authors and timestamps
         assert "@alice" in merged
         assert "Should also handle the edge case" in merged
         assert "@bob" in merged
         assert "Use Postgres for this" in merged
+        # Automation-authored comments are filtered out (#1244)
+        assert "open-ace-bot" not in merged
+        assert "Progress Report" not in merged
 
     @patch("app.modules.workspace.autonomous.orchestrator.GitHubOps")
     def test_preparation_worktree_strategy(self, mock_gh_cls):


### PR DESCRIPTION
## 背景

AI 自主开发工作流在 planning 阶段读取 GitHub issue 时，只会读取 issue 的正文（body），完全忽略 issue 下的评论。如果需求澄清、补充信息、截图链接等只出现在评论里，第一轮 planning 是看不到的——这些信息直到 wait 阶段（提了 PR 之后轮询评论）才会被读取，且后续 dev round 也只消费最新一条评论而非全部历史。

## 改动

- **`github_ops.py`** — `get_issue()` 的 `gh issue view --json` 字段表里增加 `comments`，一次请求同时取回正文与全部评论，不新增网络调用。
- **`orchestrator.py`** — preparation 阶段读取 issue 后，将评论按时间顺序格式化（作者、时间戳、正文）追加到 `requirements_text` 末尾，用分隔线和「Issue 评论（补充信息）」标题与正文隔开。issue 无评论时行为完全不变。
- **测试**
  - `test_github_ops.py` — `test_get_issue` 断言 `--json` 含 `comments` 字段且返回值带评论。
  - `test_orchestrator.py` — 新增 `test_preparation_reads_issue_with_comments`，验证多条评论（含 `author`/`createdAt`）均被拼进 `requirements_text`，且正文仍位于顶部。

## 行为对照

| 场景 | 改动前 | 改动后 |
|---|---|---|
| issue 有评论 | planning 只看到 body | planning 看到 body + 全部评论 |
| issue 无评论 | 只看 body | 只看 body（不变） |

## 测试

`python3 -m pytest tests/issues/716/test_github_ops.py tests/issues/716/test_orchestrator.py` — 97 passed。