### PR TITLE
fix(autonomous): strip fork_workflow_id when copying milestones

### DIFF
--- a/app/repositories/autonomous_repo.py
+++ b/app/repositories/autonomous_repo.py
@@ -652,8 +652,16 @@ class AutonomousWorkflowRepository:
                     now,
                     now,
                 ]
+                # Copied milestones become the child workflow's own history. They
+                # are not the fork point this child originated from, so the
+                # ancestor's fork_workflow_id (which points at a *sibling*
+                # workflow, e.g. an earlier fork) must not be carried over —
+                # otherwise a later fork from this child misattributes its split
+                # to the ancestor's branch point. See PR #1243 review.
+                source_milestone = dict(ms)
+                source_milestone["fork_workflow_id"] = ""
                 for f in fields:
-                    col_values.append(ms.get(f, ""))
+                    col_values.append(source_milestone.get(f, ""))
 
                 cursor.execute(
                     adapt_sql(

--- a/tests/issues/886/test_cancel_fork_redesign.py
+++ b/tests/issues/886/test_cancel_fork_redesign.py
@@ -719,3 +719,57 @@ class TestForkRepoIntegration:
         fetched = repo.get_milestone("ms-fork")
         assert fetched is not None
         assert fetched["fork_workflow_id"] == "wf-fork-001"
+
+    def test_copy_milestones_strips_inherited_fork_workflow_id(self, auto_db):
+        """Copied milestones must not carry an ancestor's fork_workflow_id.
+
+        Regression for 2nd-generation forks (PR #1243 review): when A forks to
+        B (marker on A with fork_workflow_id=wf-B) and A later forks to C at a
+        milestone *after* the A->B marker, C's copied history would otherwise
+        inherit fork_workflow_id=wf-B. That makes C's parent-view fork split
+        resolve at A's earlier branch point instead of C's real one. Copied
+        rows are the child's own history, so fork_workflow_id must be cleared.
+        """
+        from app.repositories.autonomous_repo import AutonomousWorkflowRepository
+
+        repo = AutonomousWorkflowRepository(auto_db)
+
+        # Workflow A: M1 is the fork point for B.
+        repo.create_workflow(_make_workflow(workflow_id="wf-A"))
+        repo.create_milestone(_make_milestone(milestone_id="M1", workflow_id="wf-A"))
+
+        # Fork A -> B at M1 (per route order: copy history, then fork marker).
+        repo.create_workflow(
+            _make_workflow(workflow_id="wf-B", parent_workflow_id="wf-A", fork_milestone_id="M1")
+        )
+        repo.copy_milestones_to_workflow("wf-A", "wf-B", "M1")
+        repo.create_milestone(
+            _make_milestone(
+                milestone_id="MS-AFORK",
+                workflow_id="wf-A",
+                milestone_type="workflow_forked",
+                fork_branch="fb-AB",
+                fork_workflow_id="wf-B",
+                parent_milestone_id="M1",
+            )
+        )
+
+        # A continues to M2 (after MS-AFORK), then forks to C at M2. C's copy
+        # scope (id <= M2) *includes* the A->B fork marker MS-AFORK.
+        repo.create_milestone(_make_milestone(milestone_id="M2", workflow_id="wf-A"))
+        repo.create_workflow(
+            _make_workflow(workflow_id="wf-C", parent_workflow_id="wf-A", fork_milestone_id="M2")
+        )
+        repo.copy_milestones_to_workflow("wf-A", "wf-C", "M2")
+
+        c_history = repo.list_milestones("wf-C")
+        # The ancestor's fork marker type is preserved (still describes history)
+        # but its fork_workflow_id must be cleared so it doesn't masattribute a
+        # split to wf-B when C is later rendered as a parent.
+        inherited_markers = [ms for ms in c_history if ms["milestone_type"] == "workflow_forked"]
+        assert inherited_markers, "C should carry the inherited workflow_forked marker"
+        for ms in inherited_markers:
+            assert ms["fork_workflow_id"] == "", (
+                "Copied ancestor fork marker must not retain fork_workflow_id; "
+                f"got {ms['fork_workflow_id']!r}"
+            )


### PR DESCRIPTION
## Summary

Follow-up fix for the **2nd-generation fork** issue raised in the [#1243 review](https://github.com/open-ace/open-ace/pull/1243#issuecomment-4788986820) (PR #1243 has since merged, so the bug is on `main`).

### The bug (reproduced)
Copied milestones become the child workflow's **own** history. `copy_milestones_to_workflow` was carrying the ancestor's `fork_workflow_id` into them, which misattributes a later fork's split point.

Concretely: when **A forks to B** at `M1` (fork marker on A with `fork_workflow_id=wf-B`) and A later **forks to C** at `M2` (a milestone that comes *after* the A→B marker in row order), C's copy scope (`id <= M2`) **includes** the A→B marker. So C inherits `fork_workflow_id=wf-B`. When C is later rendered as a parent (Case 1), `findForkMilestoneIndex({ preferFirstForkWorkflowId })` picks the **first** non-empty id — the inherited `wf-B` — and renders C's fork split at **A's earlier branch point** instead of C's real one.

### The fix
Clear `fork_workflow_id` to `""` when copying milestones (`app/repositories/autonomous_repo.py`). The `milestone_type` (incl. `workflow_forked`) is preserved, so inherited fork markers still render an accurate "Workflow forked" label — only the misleading fork-target id is removed.

This is the approach the reviewer endorsed: *"We should not carry ancestor `fork_workflow_id` values into copied milestones."*

### Why no frontend change is needed
With inherited ids stripped, `preferFirstForkWorkflowId` correctly skips ancestor markers (empty id) and resolves to the child's real fork. Case 2 (child perspective) is unaffected — it matches against the marker on the **parent's own** timeline, which is created natively (never copied) and retains its real id.

## Testing
- `python3 -m pytest tests/issues/886/test_cancel_fork_redesign.py tests/issues/716/test_models.py -q` → **46 passed**
- New regression test `test_copy_milestones_strips_inherited_fork_workflow_id` verified to **fail without the fix** and **pass with it**.
- `npm exec -- tsc -p tsconfig.json --noEmit` (frontend) → clean (no FE change)