### PR TITLE
fix(security): add password reset with temporary password flow (Issue #865)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -133,6 +133,11 @@ const SmtpConfig = lazy(() =>
     default: m.SmtpConfig,
   }))
 );
+const ForceChangePasswordModal = lazy(() =>
+  import('@/components/features/ForceChangePasswordModal').then((m) => ({
+    default: m.ForceChangePasswordModal,
+  }))
+);
 
 // Page loading fallback with skeleton
 const PageLoader: React.FC = () => {
@@ -356,68 +361,75 @@ const AppContent: React.FC = () => {
   }, []);
 
   return (
-    <Routes>
-      {/* Work Mode Routes - All users */}
-      <Route path="/work/*" element={<WorkRoutes />} />
+    <>
+      {/* Force change password modal - shown when must_change_password is true */}
+      <Suspense fallback={null}>
+        <ForceChangePasswordModal />
+      </Suspense>
 
-      {/* Manage Mode Routes - Admin only */}
-      <Route
-        path="/manage/*"
-        element={isAdmin ? <ManageRoutes /> : <Navigate to="/work" replace />}
-      />
+      <Routes>
+        {/* Work Mode Routes - All users */}
+        <Route path="/work/*" element={<WorkRoutes />} />
 
-      {/* Legacy Routes - redirect based on user role */}
-      <Route
-        path="/dashboard"
-        element={
-          isAdmin ? <Navigate to="/manage/dashboard" replace /> : <Navigate to="/work" replace />
-        }
-      />
-      <Route
-        path="/messages"
-        element={
-          isAdmin ? <Navigate to="/manage/messages" replace /> : <Navigate to="/work" replace />
-        }
-      />
-      <Route
-        path="/analysis"
-        element={
-          isAdmin ? <Navigate to="/manage/analysis" replace /> : <Navigate to="/work" replace />
-        }
-      />
-      <Route
-        path="/management"
-        element={
-          isAdmin ? <Navigate to="/manage/users" replace /> : <Navigate to="/work" replace />
-        }
-      />
-      <Route
-        path="/security"
-        element={
-          isAdmin ? <Navigate to="/manage/security" replace /> : <Navigate to="/work" replace />
-        }
-      />
-      <Route path="/workspace" element={<Navigate to="/work" replace />} />
-      <Route path="/sessions" element={<Navigate to="/work/sessions" replace />} />
-      <Route path="/prompts" element={<Navigate to="/work/prompts" replace />} />
+        {/* Manage Mode Routes - Admin only */}
+        <Route
+          path="/manage/*"
+          element={isAdmin ? <ManageRoutes /> : <Navigate to="/work" replace />}
+        />
 
-      {/* Report - Keep as standalone for now */}
-      <Route path="/report" element={<LegacyAppContent />} />
+        {/* Legacy Routes - redirect based on user role */}
+        <Route
+          path="/dashboard"
+          element={
+            isAdmin ? <Navigate to="/manage/dashboard" replace /> : <Navigate to="/work" replace />
+          }
+        />
+        <Route
+          path="/messages"
+          element={
+            isAdmin ? <Navigate to="/manage/messages" replace /> : <Navigate to="/work" replace />
+          }
+        />
+        <Route
+          path="/analysis"
+          element={
+            isAdmin ? <Navigate to="/manage/analysis" replace /> : <Navigate to="/work" replace />
+          }
+        />
+        <Route
+          path="/management"
+          element={
+            isAdmin ? <Navigate to="/manage/users" replace /> : <Navigate to="/work" replace />
+          }
+        />
+        <Route
+          path="/security"
+          element={
+            isAdmin ? <Navigate to="/manage/security" replace /> : <Navigate to="/work" replace />
+          }
+        />
+        <Route path="/workspace" element={<Navigate to="/work" replace />} />
+        <Route path="/sessions" element={<Navigate to="/work/sessions" replace />} />
+        <Route path="/prompts" element={<Navigate to="/work/prompts" replace />} />
 
-      {/* Default redirect - Admin goes to manage mode, others go to work mode */}
-      <Route
-        path="/"
-        element={
-          isAdmin ? <Navigate to="/manage/dashboard" replace /> : <Navigate to="/work" replace />
-        }
-      />
-      <Route
-        path="*"
-        element={
-          isAdmin ? <Navigate to="/manage/dashboard" replace /> : <Navigate to="/work" replace />
-        }
-      />
-    </Routes>
+        {/* Report - Keep as standalone for now */}
+        <Route path="/report" element={<LegacyAppContent />} />
+
+        {/* Default redirect - Admin goes to manage mode, others go to work mode */}
+        <Route
+          path="/"
+          element={
+            isAdmin ? <Navigate to="/manage/dashboard" replace /> : <Navigate to="/work" replace />
+          }
+        />
+        <Route
+          path="*"
+          element={
+            isAdmin ? <Navigate to="/manage/dashboard" replace /> : <Navigate to="/work" replace />
+          }
+        />
+      </Routes>
+    </>
   );
 };
 

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -85,4 +85,18 @@ export const authApi = {
     const response = await apiClient.delete<{ success: boolean }>('/api/user/avatar');
     return response;
   },
+
+  /**
+   * Change password
+   */
+  async changePassword(
+    currentPassword: string,
+    newPassword: string
+  ): Promise<{ success: boolean; message?: string }> {
+    const response = await apiClient.post<{ success: boolean; message?: string }>(
+      '/api/auth/change-password',
+      { current_password: currentPassword, new_password: newPassword }
+    );
+    return response;
+  },
 };

--- a/frontend/src/components/features/ForceChangePasswordModal.tsx
+++ b/frontend/src/components/features/ForceChangePasswordModal.tsx
@@ -7,18 +7,43 @@
 
 import React, { useState } from 'react';
 import { Modal, Button, TextInput } from '@/components/common';
-import { useAuth, useLanguage, useMustChangePassword } from '@/hooks';
+import { useAuth, useLanguage, useMustChangePassword, useSecuritySettings } from '@/hooks';
 import { t } from '@/i18n';
 
 export const ForceChangePasswordModal: React.FC = () => {
   const language = useLanguage();
   const mustChangePassword = useMustChangePassword();
   const { changePassword, isChangingPassword, changePasswordError } = useAuth();
+  const { data: securitySettings } = useSecuritySettings();
 
   const [currentPassword, setCurrentPassword] = useState('');
   const [newPassword, setNewPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
   const [error, setError] = useState<string | null>(null);
+
+  // Password policy hint component
+  const PasswordPolicyHint = () => {
+    const policy = securitySettings;
+    if (!policy) return null;
+
+    const requirements: string[] = [];
+    requirements.push(`${t('passwordMinLength', language)}: ${policy.password_min_length ?? 8}`);
+    if (policy.password_require_uppercase) requirements.push(t('requireUppercase', language));
+    if (policy.password_require_lowercase) requirements.push(t('requireLowercase', language));
+    if (policy.password_require_number) requirements.push(t('requireNumber', language));
+    if (policy.password_require_special) requirements.push(t('requireSpecial', language));
+
+    return (
+      <div className="password-policy-hint text-muted small mt-1">
+        <div>{t('passwordRequirements', language)}:</div>
+        <ul className="mb-0 ps-3" style={{ fontSize: '0.85em' }}>
+          {requirements.map((req, idx) => (
+            <li key={idx}>{req}</li>
+          ))}
+        </ul>
+      </div>
+    );
+  };
 
   const handleSubmit = async () => {
     setError(null);
@@ -79,7 +104,7 @@ export const ForceChangePasswordModal: React.FC = () => {
           'Your password was reset by an administrator. You must change it before continuing.'}
       </div>
 
-      {(error || changePasswordError) && (
+      {(error ?? changePasswordError) && (
         <div className="alert alert-danger mb-3" role="alert">
           <i className="bi bi-exclamation-triangle-fill me-2" />
           {error ?? (changePasswordError as Error)?.message}
@@ -104,6 +129,7 @@ export const ForceChangePasswordModal: React.FC = () => {
           onChange={(value: string) => setNewPassword(value)}
           placeholder={t('enterNewPassword', language) ?? 'Enter new password'}
         />
+        <PasswordPolicyHint />
       </div>
 
       <div className="mb-3">

--- a/frontend/src/components/features/ForceChangePasswordModal.tsx
+++ b/frontend/src/components/features/ForceChangePasswordModal.tsx
@@ -1,0 +1,120 @@
+/**
+ * ForceChangePasswordModal - Modal for forced password change
+ *
+ * Displays when user's must_change_password flag is true,
+ * requiring them to change password before continuing.
+ */
+
+import React, { useState } from 'react';
+import { Modal, Button, TextInput } from '@/components/common';
+import { useAuth, useLanguage, useMustChangePassword } from '@/hooks';
+import { t } from '@/i18n';
+
+export const ForceChangePasswordModal: React.FC = () => {
+  const language = useLanguage();
+  const mustChangePassword = useMustChangePassword();
+  const { changePassword, isChangingPassword, changePasswordError } = useAuth();
+
+  const [currentPassword, setCurrentPassword] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async () => {
+    setError(null);
+
+    if (!currentPassword) {
+      setError(t('currentPasswordRequired', language) ?? 'Current password is required');
+      return;
+    }
+
+    if (!newPassword) {
+      setError(t('newPasswordRequired', language) ?? 'New password is required');
+      return;
+    }
+
+    if (newPassword.length < 8) {
+      setError(t('passwordTooShort', language) ?? 'Password must be at least 8 characters');
+      return;
+    }
+
+    if (newPassword !== confirmPassword) {
+      setError(t('passwordMismatch', language) ?? 'Passwords do not match');
+      return;
+    }
+
+    try {
+      await changePassword(currentPassword, newPassword);
+      // After successful change, the auth hook will refetch and update must_change_password
+    } catch (err) {
+      const errorMessage =
+        (err as Error)?.message ??
+        (err as Record<string, string>)?.error ??
+        t('failedToChangePassword', language) ??
+        'Failed to change password';
+      setError(errorMessage);
+    }
+  };
+
+  // Don't render if not required
+  if (!mustChangePassword) {
+    return null;
+  }
+
+  return (
+    <Modal
+      isOpen={true}
+      onClose={() => {}}
+      title={t('changePasswordRequired', language) ?? 'Change Password Required'}
+      size="md"
+      footer={
+        <Button variant="primary" onClick={handleSubmit} loading={isChangingPassword}>
+          {t('changePassword', language) ?? 'Change Password'}
+        </Button>
+      }
+    >
+      <div className="alert alert-warning mb-3">
+        <i className="bi bi-exclamation-triangle-fill me-2" />
+        {t('mustChangePasswordHint', language) ??
+          'Your password was reset by an administrator. You must change it before continuing.'}
+      </div>
+
+      {(error || changePasswordError) && (
+        <div className="alert alert-danger mb-3" role="alert">
+          <i className="bi bi-exclamation-triangle-fill me-2" />
+          {error ?? (changePasswordError as Error)?.message}
+        </div>
+      )}
+
+      <div className="mb-3">
+        <label className="form-label">{t('currentPassword', language) ?? 'Current Password'}</label>
+        <TextInput
+          type="password"
+          value={currentPassword}
+          onChange={(value: string) => setCurrentPassword(value)}
+          placeholder={t('enterCurrentPassword', language) ?? 'Enter current password'}
+        />
+      </div>
+
+      <div className="mb-3">
+        <label className="form-label">{t('password', language) ?? 'New Password'}</label>
+        <TextInput
+          type="password"
+          value={newPassword}
+          onChange={(value: string) => setNewPassword(value)}
+          placeholder={t('enterNewPassword', language) ?? 'Enter new password'}
+        />
+      </div>
+
+      <div className="mb-3">
+        <label className="form-label">{t('confirmPassword', language) ?? 'Confirm Password'}</label>
+        <TextInput
+          type="password"
+          value={confirmPassword}
+          onChange={(value: string) => setConfirmPassword(value)}
+          placeholder={t('confirmPassword', language) ?? 'Confirm password'}
+        />
+      </div>
+    </Modal>
+  );
+};

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -110,7 +110,6 @@ export {
   useLanguage,
   useSidebarCollapsed,
   useAppMode,
-  useMustChangePassword,
 } from '@/store';
 
 // Page refresh hooks

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -110,6 +110,7 @@ export {
   useLanguage,
   useSidebarCollapsed,
   useAppMode,
+  useMustChangePassword,
 } from '@/store';
 
 // Page refresh hooks

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -105,6 +105,21 @@ export function useAuth() {
     },
   });
 
+  // Change password mutation
+  const changePasswordMutation = useMutation({
+    mutationFn: ({
+      currentPassword,
+      newPassword,
+    }: {
+      currentPassword: string;
+      newPassword: string;
+    }) => authApi.changePassword(currentPassword, newPassword),
+    onSuccess: async () => {
+      // Refetch auth to get updated must_change_password flag
+      await refetchAuth();
+    },
+  });
+
   const login = useCallback(
     (credentials: LoginRequest) => loginMutation.mutateAsync(credentials),
     [loginMutation]
@@ -112,14 +127,23 @@ export function useAuth() {
 
   const logout = useCallback(() => logoutMutation.mutate(), [logoutMutation]);
 
+  const changePassword = useCallback(
+    (currentPassword: string, newPassword: string) =>
+      changePasswordMutation.mutateAsync({ currentPassword, newPassword }),
+    [changePasswordMutation]
+  );
+
   return {
     user,
     isAuthenticated,
     isLoading: authLoading || isCheckingAuth,
     login,
     logout,
+    changePassword,
     loginError: loginMutation.error,
     isLoggingIn: loginMutation.isPending,
     isLoggingOut: logoutMutation.isPending,
+    isChangingPassword: changePasswordMutation.isPending,
+    changePasswordError: changePasswordMutation.error,
   };
 }

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -178,23 +178,6 @@ export const translations: Record<Language, Translations> = {
     newPassword: 'New Password',
     confirmPassword: 'Confirm Password',
     passwordHint: 'Leave blank to keep current password',
-    // Password reset
-    resetPassword: 'Reset Password',
-    temporaryPassword: 'Temporary Password',
-    tempPasswordWarning:
-      'Please share this password securely with the user. They will be required to change it on first login.',
-    copyToClipboard: 'Copy to clipboard',
-    // Force password change
-    changePassword: 'Change Password',
-    changePasswordRequired: 'Change Password Required',
-    mustChangePasswordHint:
-      'Your password was reset by an administrator. You must change it before continuing.',
-    currentPassword: 'Current Password',
-    currentPasswordRequired: 'Current password is required',
-    newPasswordRequired: 'New password is required',
-    enterCurrentPassword: 'Enter current password',
-    enterNewPassword: 'Enter new password',
-    failedToChangePassword: 'Failed to change password',
     activationStatus: 'Activation Status',
     active: 'Active',
     inactive: 'Inactive',
@@ -1659,21 +1642,6 @@ export const translations: Record<Language, Translations> = {
     tableStatus: '状态',
     tableCreatedAt: '创建时间',
     tableActions: '操作',
-    // Password reset
-    resetPassword: '重置密码',
-    temporaryPassword: '临时密码',
-    tempPasswordWarning: '请安全地与用户共享此密码。首次登录时需要更改。',
-    copyToClipboard: '复制到剪贴板',
-    // Force password change
-    changePassword: '更改密码',
-    changePasswordRequired: '需要更改密码',
-    mustChangePasswordHint: '您的密码已被管理员重置。继续操作前必须更改密码。',
-    currentPassword: '当前密码',
-    currentPasswordRequired: '当前密码为必填项',
-    newPasswordRequired: '新密码为必填项',
-    enterCurrentPassword: '输入当前密码',
-    enterNewPassword: '输入新密码',
-    failedToChangePassword: '更改密码失败',
 
     linuxAccount: '系统账号',
     toolAccounts: '工具账号',
@@ -3111,23 +3079,6 @@ export const translations: Record<Language, Translations> = {
     tableStatus: 'ステータス',
     tableCreatedAt: '作成日時',
     tableActions: 'アクション',
-    // Password reset
-    resetPassword: 'パスワードリセット',
-    temporaryPassword: '一時パスワード',
-    tempPasswordWarning:
-      'このパスワードをユーザーと安全に共有してください。初回ログイン時に変更が必要です。',
-    copyToClipboard: 'クリップボードにコピー',
-    // Force password change
-    changePassword: 'パスワード変更',
-    changePasswordRequired: 'パスワード変更が必要',
-    mustChangePasswordHint:
-      'パスワードが管理者によってリセットされました。続行前にパスワードを変更してください。',
-    currentPassword: '現在のパスワード',
-    currentPasswordRequired: '現在のパスワードは必須です',
-    newPasswordRequired: '新しいパスワードは必須です',
-    enterCurrentPassword: '現在のパスワードを入力',
-    enterNewPassword: '新しいパスワードを入力',
-    failedToChangePassword: 'パスワード変更に失敗しました',
 
     linuxAccount: 'システムアカウント',
     newPassword: '新しいパスワード',
@@ -4281,23 +4232,6 @@ export const translations: Record<Language, Translations> = {
     tableStatus: '상태',
     tableCreatedAt: '생성일',
     tableActions: '작업',
-    // Password reset
-    resetPassword: '비밀번호 재설정',
-    temporaryPassword: '임시 비밀번호',
-    tempPasswordWarning:
-      '이 비밀번호를 사용자와 안전하게 공유하세요. 첫 로그인 시 변경이 필요합니다.',
-    copyToClipboard: '클립보드에 복사',
-    // Force password change
-    changePassword: '비밀번호 변경',
-    changePasswordRequired: '비밀번호 변경 필요',
-    mustChangePasswordHint:
-      '비밀번호가 관리자에 의해 재설정되었습니다. 계속하기 전에 비밀번호를 변경하세요.',
-    currentPassword: '현재 비밀번호',
-    currentPasswordRequired: '현재 비밀번호는 필수입니다',
-    newPasswordRequired: '새 비밀번호는 필수입니다',
-    enterCurrentPassword: '현재 비밀번호 입력',
-    enterNewPassword: '새 비밀번호 입력',
-    failedToChangePassword: '비밀번호 변경 실패',
 
     linuxAccount: '시스템 계정',
     newPassword: '새 비밀번호',

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -208,6 +208,23 @@ export const translations: Record<Language, Translations> = {
     passwordRequired: 'Password is required',
     passwordTooShort: 'Password must be at least 8 characters',
     passwordMismatch: 'Passwords do not match',
+    // Password reset
+    resetPassword: 'Reset Password',
+    temporaryPassword: 'Temporary Password',
+    tempPasswordWarning:
+      'Please share this password securely with the user. They will be required to change it on first login.',
+    copyToClipboard: 'Copy to clipboard',
+    // Force password change
+    changePassword: 'Change Password',
+    changePasswordRequired: 'Change Password Required',
+    mustChangePasswordHint:
+      'Your password was reset by an administrator. You must change it before continuing.',
+    currentPassword: 'Current Password',
+    currentPasswordRequired: 'Current password is required',
+    newPasswordRequired: 'New password is required',
+    enterCurrentPassword: 'Enter current password',
+    enterNewPassword: 'Enter new password',
+    failedToChangePassword: 'Failed to change password',
     failedToSaveUser: 'Failed to save user',
     enterUsername: 'Enter username',
     enterEmail: 'Enter email',
@@ -1686,6 +1703,21 @@ export const translations: Record<Language, Translations> = {
     passwordRequired: '密码不能为空',
     passwordTooShort: '密码至少需要8个字符',
     passwordMismatch: '两次输入的密码不一致',
+    // Password reset
+    resetPassword: '重置密码',
+    temporaryPassword: '临时密码',
+    tempPasswordWarning: '请将此密码安全地分享给用户。用户首次登录时必须修改此密码。',
+    copyToClipboard: '复制到剪贴板',
+    // Force password change
+    changePassword: '修改密码',
+    changePasswordRequired: '需要修改密码',
+    mustChangePasswordHint: '您的密码已被管理员重置。必须修改密码后才能继续操作。',
+    currentPassword: '当前密码',
+    currentPasswordRequired: '当前密码不能为空',
+    newPasswordRequired: '新密码不能为空',
+    enterCurrentPassword: '请输入当前密码',
+    enterNewPassword: '请输入新密码',
+    failedToChangePassword: '修改密码失败',
     failedToSaveUser: '保存用户失败',
     enterUsername: '请输入用户名',
     enterEmail: '请输入邮箱',
@@ -3114,6 +3146,23 @@ export const translations: Record<Language, Translations> = {
     passwordRequired: 'パスワードは必須です',
     passwordTooShort: 'パスワードは8文字以上必要です',
     passwordMismatch: 'パスワードが一致しません',
+    // Password reset
+    resetPassword: 'パスワードリセット',
+    temporaryPassword: '一時パスワード',
+    tempPasswordWarning:
+      'このパスワードをユーザーに安全に共有してください。ユーザーは初回ログイン時にパスワードを変更する必要があります。',
+    copyToClipboard: 'クリップボードにコピー',
+    // Force password change
+    changePassword: 'パスワード変更',
+    changePasswordRequired: 'パスワード変更が必要',
+    mustChangePasswordHint:
+      'パスワードが管理者によってリセットされました。続行する前にパスワードを変更する必要があります。',
+    currentPassword: '現在のパスワード',
+    currentPasswordRequired: '現在のパスワードは必須です',
+    newPasswordRequired: '新しいパスワードは必須です',
+    enterCurrentPassword: '現在のパスワードを入力',
+    enterNewPassword: '新しいパスワードを入力',
+    failedToChangePassword: 'パスワードの変更に失敗しました',
     failedToSaveUser: 'ユーザーの保存に失敗しました',
     enterUsername: 'ユーザー名を入力',
     enterEmail: 'メールを入力',
@@ -4267,6 +4316,23 @@ export const translations: Record<Language, Translations> = {
     passwordRequired: '비밀번호는 필수입니다',
     passwordTooShort: '비밀번호는 8자 이상이어야 합니다',
     passwordMismatch: '비밀번호가 일치하지 않습니다',
+    // Password reset
+    resetPassword: '비밀번호 재설정',
+    temporaryPassword: '임시 비밀번호',
+    tempPasswordWarning:
+      '이 비밀번호를 사용자에게 안전하게 공유하세요. 사용자는 첫 로그인 시 비밀번호를 변경해야 합니다.',
+    copyToClipboard: '클립보드에 복사',
+    // Force password change
+    changePassword: '비밀번호 변경',
+    changePasswordRequired: '비밀번호 변경 필요',
+    mustChangePasswordHint:
+      '비밀번호가 관리자에 의해 재설정되었습니다. 계속하기 전에 비밀번호를 변경해야 합니다.',
+    currentPassword: '현재 비밀번호',
+    currentPasswordRequired: '현재 비밀번호는 필수입니다',
+    newPasswordRequired: '새 비밀번호는 필수입니다',
+    enterCurrentPassword: '현재 비밀번호 입력',
+    enterNewPassword: '새 비밀번호 입력',
+    failedToChangePassword: '비밀번호 변경 실패',
     failedToSaveUser: '사용자 저장 실패',
     enterUsername: '사용자 이름 입력',
     enterEmail: '이메일 입력',


### PR DESCRIPTION
## Summary

This PR implements a secure password reset flow for user management in manage mode, following enterprise-level security best practices.

## Changes

- **Backend**: Already had reset-password API and change-password API with must_change_password support
- **Frontend**:
  - Added `resetUserPassword` API client and `useResetUserPassword` hook
  - Added `changePassword` API client and mutation in useAuth hook
  - Added `ForceChangePasswordModal` component that blocks access when `must_change_password` is true
  - Added `must_change_password` field to User type
  - Added `useMustChangePassword` selector from store
  - Added i18n translations for EN/ZH/JA/KO

## Workflow

1. Admin resets user password → generates temporary password
2. User logs in with temporary password
3. `ForceChangePasswordModal` appears, blocking all app access
4. User must change password before continuing

## Test Plan

- [x] Frontend build passes
- [ ] Manual test: Admin resets password for a user
- [ ] Manual test: User logs in with temporary password
- [ ] Manual test: User is forced to change password
- [ ] Manual test: After password change, modal disappears

Fixes #865