### PR TITLE
fix(docker): /home目录权限700导致用户无法访问home目录 (Issue #1249)

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -247,6 +247,18 @@ if [ "$WORKSPACE_MULTI_USER_MODE" = "true" ] || [ "$CONFIG_MULTI_USER" = "true" 
     WORKSPACE_DIR="${WORKSPACE_BASE_DIR:-/workspace}"
     mkdir -p "$WORKSPACE_DIR"
 
+    # Fix /home directory permissions (Issue #1249)
+    # When data/home is mounted as /home, restrictive 700 permissions prevent
+    # users from accessing their own home directories. /home should be 755
+    # (enterable by all), while /home/<user> remains 700 (private to user).
+    if [ -d "/home" ]; then
+        home_perms=$(stat -c "%a" /home 2>/dev/null || echo "unknown")
+        if [ "$home_perms" != "755" ] && [ "$home_perms" != "unknown" ]; then
+            chmod 755 /home
+            echo "  Fixed /home permissions: $home_perms -> 755"
+        fi
+    fi
+
     # Sync workspace users from database to container
     # This creates OS users for each database user with system_account
     if [ -n "$DATABASE_URL" ]; then

--- a/scripts/install-central/docker-method/install.sh
+++ b/scripts/install-central/docker-method/install.sh
@@ -2706,9 +2706,11 @@ create_directories() {
     # This ensures user home directories persist across container restarts
     if [ "$WORKSPACE_MULTI_USER_MODE" = "true" ]; then
         mkdir -p "$DEPLOY_DIR"/data/home
-        # Set restrictive permissions for sensitive user data (Issue #1209 review)
-        chmod 700 "$DEPLOY_DIR"/data/home
-        print_info "  - $DEPLOY_DIR/data/home (多用户 home 目录, 权限 700)"
+        # Set permissions for /home directory (Issue #1249)
+        # /home should be 755 (enterable by all users)
+        # Individual /home/<user> directories will be 700 (private, set by useradd -m)
+        chmod 755 "$DEPLOY_DIR"/data/home
+        print_info "  - $DEPLOY_DIR/data/home (多用户 home 目录, 权限 755)"
     fi
 
     print_success "目录创建完成"

--- a/scripts/install-central/docker-method/install.sh
+++ b/scripts/install-central/docker-method/install.sh
@@ -2391,6 +2391,8 @@ upgrade_deployment() {
                     if [ -n "$home_files" ]; then
                         print_info "发现容器内 home 目录数据，正在迁移..."
                         mkdir -p "$DEPLOY_DIR/data/home"
+                        # Set permissions for /home directory (Issue #1249)
+                        chmod 755 "$DEPLOY_DIR/data/home"
 
                         for user_dir in $home_files; do
                             local target_dir="$DEPLOY_DIR/data/home/$user_dir"
@@ -2486,6 +2488,8 @@ upgrade_deployment() {
     mkdir -p "$DEPLOY_DIR"/logs
     if [ "$WORKSPACE_MULTI_USER_MODE" = "true" ]; then
         mkdir -p "$DEPLOY_DIR"/data/home
+        # Set permissions for /home directory (Issue #1249)
+        chmod 755 "$DEPLOY_DIR"/data/home
     fi
     print_success "持久化目录创建完成"
 


### PR DESCRIPTION
## 问题

用户在 WebUI 发送消息后显示 "thinking..." 然后无响应，返回错误：
```
{"type":"error","error":"CLI process exited with code 1"}
```

## 根因

1. `install.sh` 设置 `$DEPLOY_DIR/data/home` 权限为 700
2. 挂载到容器内 `/home`，权限也是 700
3. 普通用户无法进入 `/home`
4. CLI 无法读取 `/home/<user>` 配置，启动失败

## 修复

- **docker-entrypoint.sh**: 启动时检测并修复 `/home` 权限为 755
- **install.sh**: 创建目录时设置权限为 755

## 权限说明

- `/home` 应为 **755**：允许所有用户进入
- `/home/<user>` 应为 **700**：只有用户可访问（由 useradd -m 设置）

## 关联 Issue

Fixes #1249