### PR TITLE
fix(sso): pass tenant_id when registering provider (Issue #1247)

### DIFF
--- a/frontend/src/components/features/settings/SSOSettings.tsx
+++ b/frontend/src/components/features/settings/SSOSettings.tsx
@@ -243,6 +243,7 @@ export const SSOSettings: React.FC = () => {
       fetchProviders();
       success(t('providerRegistered', language));
     } catch (err) {
+      console.error('Failed to register provider:', err);
       const errorMsg = err instanceof Error ? err.message : t('registerFailed', language);
       setRegisterError(errorMsg);
     } finally {

--- a/frontend/src/components/features/settings/SSOSettings.tsx
+++ b/frontend/src/components/features/settings/SSOSettings.tsx
@@ -235,7 +235,10 @@ export const SSOSettings: React.FC = () => {
 
     setIsRegistering(true);
     try {
-      await ssoApi.registerProvider(formData);
+      await ssoApi.registerProvider({
+        ...formData,
+        tenant_id: effectiveTenantId ?? undefined,
+      });
       handleCloseModal();
       fetchProviders();
       success(t('providerRegistered', language));


### PR DESCRIPTION
Fixes #1247

## 问题描述

SSO 设置页面注册提供者时显示"注册提供者失败"，页面卡住不退出。

## 根本原因

前端 `SSOSettings.tsx` 组件存在 bug：
- `handleSubmit` 函数提交时直接使用 `formData`，没有将 `effectiveTenantId` 传递给后端

## 修改内容

在 `handleSubmit` 中提交前将 `effectiveTenantId` 添加到请求数据：

```typescript
await ssoApi.registerProvider({
  ...formData,
  tenant_id: effectiveTenantId ?? undefined,
});
```

使用 `?? undefined` 处理类型兼容问题（`effectiveTenantId` 类型为 `number | null | undefined`）。

## 测试验证

- TypeScript 类型检查通过
- Prettier 格式检查通过

🤖 Generated with Qwen Code (3-shotted by Qwen-Coder)