### PR TITLE
fix(autonomous): salvage dev work on timeout + fix single-shot event log

### DIFF
--- a/app/modules/workspace/autonomous/agent_runner.py
+++ b/app/modules/workspace/autonomous/agent_runner.py
@@ -1475,6 +1475,127 @@ class AutonomousAgentRunner:
             error=collector.error,
         )
 
+    @staticmethod
+    def _parse_single_shot_line(parsed: dict, cli_tool: str) -> dict | None:
+        """Normalize one parsed JSON stdout line into a typed event-log dict.
+
+        Single-shot tools (codex ``exec --json``, openclaw ``--agent --json``)
+        emit line-delimited JSON with per-tool shapes. This coalesces the common
+        shapes into the same ``{"type": ...}`` dict contract used by the
+        interactive path (see ``_read_stdout``) so that
+        ``_extract_visible_response_text`` / ``_persist_local_session_messages``
+        — which assume dict entries with ``type``/``text`` keys — work correctly.
+
+        Returns ``None`` when the line is not a recognizable assistant/tool event
+        (the caller then falls back to best-effort text extraction).
+        """
+        if not isinstance(parsed, dict):
+            return None
+        msg_type = parsed.get("type", "")
+
+        # Claude stream-json shape: {"type":"assistant","message":{"content":...}}
+        if msg_type == "assistant":
+            msg = parsed.get("message", {}) or {}
+            text = _extract_visible_text(msg.get("content", ""))
+            if text:
+                return {
+                    "type": "assistant",
+                    "text": text,
+                    "message_id": msg.get("id"),
+                    "model": msg.get("model"),
+                }
+            return None
+
+        # Claude stream-json shape: {"type":"tool_use","tool":{"name":...,"input":...}}
+        if msg_type == "tool_use":
+            tool_info = parsed.get("tool", {}) or parsed
+            return {
+                "type": "tool_use",
+                "tool_name": tool_info.get("name", "unknown"),
+                "tool_input": tool_info.get("input", {}),
+                "tool_use_id": tool_info.get("id"),
+            }
+
+        # Codex/OpenAI shape: {"type":"message","role":"assistant","content":[{"type":"output_text","text":...}]}
+        if msg_type == "message" and parsed.get("role") == "assistant":
+            text = _extract_visible_text(parsed.get("content", ""))
+            if text:
+                return {"type": "assistant", "text": text, "message_id": None, "model": None}
+            return None
+
+        # Codex/OpenAI shape: {"type":"function_call","name":...,"arguments":...}
+        if msg_type in ("function_call", "custom_tool_call"):
+            name = parsed.get("name", "")
+            if name:
+                return {
+                    "type": "tool_use",
+                    "tool_name": name,
+                    "tool_input": parsed.get("arguments", parsed.get("input", {})),
+                    "tool_use_id": parsed.get("call_id"),
+                }
+            return None
+
+        return None
+
+    def _parse_single_shot_stdout(
+        self, stdout: str, cli_tool: str
+    ) -> tuple[list, str, int, int, list]:
+        """Parse single-shot stdout into typed event log + text + tokens + tools.
+
+        Returns ``(event_log, response_text, input_tokens, output_tokens,
+        tool_calls)`` where ``event_log`` contains dict entries (matching the
+        interactive-path contract) instead of raw strings, so that downstream
+        extractors and persistence behave identically for single-shot runs.
+        """
+        event_log: list[dict] = []
+        response_text = ""
+        input_tokens = 0
+        output_tokens = 0
+        tool_calls: list[dict] = []
+
+        for line in (stdout or "").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                parsed = json.loads(line)
+            except (json.JSONDecodeError, ValueError):
+                # Non-JSON line (e.g. progress noise): keep as raw text only.
+                response_text += line + "\n"
+                continue
+
+            if not isinstance(parsed, dict):
+                continue
+
+            event = self._parse_single_shot_line(parsed, cli_tool)
+            if event:
+                event_log.append(event)
+                if event["type"] == "assistant" and event.get("text"):
+                    response_text += event["text"] + "\n"
+                elif event["type"] == "tool_use":
+                    tool_calls.append(
+                        {"tool": {"name": event["tool_name"], "input": event["tool_input"]}}
+                    )
+            else:
+                # Unrecognized JSON event: best-effort text extraction, plus
+                # usage parsing (single-shot result/usage lines often land here).
+                text = (
+                    parsed.get("response")
+                    or parsed.get("text")
+                    or parsed.get("content")
+                    or parsed.get("output")
+                )
+                if isinstance(text, str):
+                    response_text += text + "\n"
+
+            if _extract_stream_usage is not None:
+                usage = _extract_stream_usage(cli_tool, parsed)
+                if usage:
+                    input_tokens += usage["input"]
+                    output_tokens += usage["output"]
+
+        return event_log, response_text.strip(), input_tokens, output_tokens, tool_calls
+
     def _run_single_shot(
         self,
         session_id: str,
@@ -1528,10 +1649,33 @@ class AutonomousAgentRunner:
                 env=env,
                 timeout=timeout,
             )
-        except subprocess.TimeoutExpired:
-            return AgentTaskResult(
+        except subprocess.TimeoutExpired as te:
+            # Salvage partial output: the agent may have emitted assistant text
+            # and tool calls before the wall-clock timeout fired. ``run`` populates
+            # ``TimeoutExpired.output`` with whatever stdout was captured. Parse
+            # it so the result carries real text/events rather than an empty
+            # shell (an empty visible_response_text would, e.g., make the
+            # orchestrator's test-skip detector false-positive).
+            partial_out = te.output if isinstance(te.output, str) else ""
+            event_log, response_text, input_tokens, output_tokens, tool_calls = (
+                self._parse_single_shot_stdout(partial_out, cli_tool)
+            )
+            logger.warning(
+                "Single-shot agent (%s) timed out after %ds; salvaged %d events",
+                cli_tool,
+                timeout,
+                len(event_log),
+            )
+            return _build_agent_task_result(
                 session_id=session_id,
                 tracking_session_id=session_id,
+                event_log=event_log,
+                fallback_text=response_text,
+                total_tokens=input_tokens + output_tokens,
+                total_input_tokens=input_tokens,
+                total_output_tokens=output_tokens,
+                request_count=1 if event_log else 0,
+                tool_calls=tool_calls,
                 success=False,
                 error=f"Agent task timed out after {timeout}s",
             )
@@ -1543,38 +1687,9 @@ class AutonomousAgentRunner:
                 error=f"Failed to run command: {e}",
             )
 
-        response_text = ""
-        total_tokens = 0
-        input_tokens = 0
-        output_tokens = 0
-        event_log = []
-
-        for line in (proc.stdout or "").splitlines():
-            line = line.strip()
-            if not line:
-                continue
-            event_log.append(line)
-            try:
-                parsed = json.loads(line)
-            except (json.JSONDecodeError, ValueError):
-                response_text += line + "\n"
-                continue
-
-            # Extract text content from common JSON shapes
-            if isinstance(parsed, dict):
-                text = (
-                    parsed.get("response")
-                    or parsed.get("text")
-                    or parsed.get("content")
-                    or parsed.get("output")
-                )
-                if isinstance(text, str):
-                    response_text += text + "\n"
-                usage = _extract_stream_usage(cli_tool, parsed)
-                if usage:
-                    input_tokens += usage["input"]
-                    output_tokens += usage["output"]
-
+        event_log, response_text, input_tokens, output_tokens, tool_calls = (
+            self._parse_single_shot_stdout(proc.stdout or "", cli_tool)
+        )
         total_tokens = input_tokens + output_tokens
 
         stderr_text = (proc.stderr or "").strip()
@@ -1587,11 +1702,12 @@ class AutonomousAgentRunner:
             session_id=session_id,
             tracking_session_id=session_id,
             event_log=event_log,
-            fallback_text=response_text.strip(),
+            fallback_text=response_text,
             total_tokens=total_tokens,
             total_input_tokens=input_tokens,
             total_output_tokens=output_tokens,
             request_count=1,
+            tool_calls=tool_calls,
             success=success,
             error=error,
         )

--- a/app/modules/workspace/autonomous/agent_runner.py
+++ b/app/modules/workspace/autonomous/agent_runner.py
@@ -1655,8 +1655,15 @@ class AutonomousAgentRunner:
             # ``TimeoutExpired.output`` with whatever stdout was captured. Parse
             # it so the result carries real text/events rather than an empty
             # shell (an empty visible_response_text would, e.g., make the
-            # orchestrator's test-skip detector false-positive).
-            partial_out = te.output if isinstance(te.output, str) else ""
+            # orchestrator's test-skip detector false-positive). NB: on POSIX
+            # the captured output is bytes even when ``text=True`` was passed
+            # (the decode step only runs on the normal return path, not when
+            # the exception is re-raised mid-read), so decode it explicitly.
+            partial_out = te.output
+            if isinstance(partial_out, bytes):
+                partial_out = partial_out.decode("utf-8", "replace")
+            elif not isinstance(partial_out, str):
+                partial_out = ""
             event_log, response_text, input_tokens, output_tokens, tool_calls = (
                 self._parse_single_shot_stdout(partial_out, cli_tool)
             )

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -2213,6 +2213,13 @@ class AutonomousOrchestrator:
         # committed code, treat the round as completed instead of discarding
         # hours of work. Only the no-commit case (handled at the ``not
         # sha_changed`` branch above) is a true failure.
+        #
+        # Note (scope): ``sha_changed`` is set both by an explicit agent commit
+        # AND by the auto-commit of uncommitted changes above. So a failed agent
+        # that left half-finished edits is also salvaged and forwarded to the
+        # test phase. This is intentional: the test phase is the gate that
+        # catches broken/half-finished code, so salvaging lets the workflow
+        # progress to that gate rather than dying on a late subprocess error.
         salvaged = (not result.success) and bool(sha_changed)
         if salvaged:
             logger.warning(

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -2205,27 +2205,50 @@ class AutonomousOrchestrator:
                 )
                 return
 
+        # Salvage logic (issue #723): the dev agent may report failure
+        # (success=False) even though it produced real work this session — most
+        # commonly a subprocess timeout where claude-code finished and committed
+        # but never emitted a closing `result` event, or an API error that
+        # landed after the commit. When ``sha_changed`` proves the agent
+        # committed code, treat the round as completed instead of discarding
+        # hours of work. Only the no-commit case (handled at the ``not
+        # sha_changed`` branch above) is a true failure.
+        salvaged = (not result.success) and bool(sha_changed)
+        if salvaged:
+            logger.warning(
+                "Dev agent reported failure (%s) but produced a new commit %s "
+                "this session — salvaging development and proceeding to tests",
+                result.error,
+                (commit_sha or "")[:8],
+            )
+
         dev_result_summary = self._build_dev_result_summary(
             self._artifact_text(result),
             diff_stats,
             commit_sha,
-            result.success,
+            result.success or salvaged,
         )
+
+        milestone_error = ""
+        if salvaged:
+            milestone_error = f"Salvaged after agent error: {result.error or ''}".strip()
+        elif result.error:
+            milestone_error = result.error
 
         self.repo.update_milestone(
             ms.get("milestone_id", ""),
             {
-                "status": "completed" if result.success else "failed",
+                "status": "completed" if (result.success or salvaged) else "failed",
                 "session_id": result.session_id,
                 "result_summary": dev_result_summary,
                 "tldr": self._artifact_tldr(result),
                 "commit_shas": json.dumps([commit_sha] if commit_sha else []),
                 "diff_stats": json.dumps(diff_stats),
-                "error_message": result.error or "",
+                "error_message": milestone_error,
             },
         )
 
-        if not result.success:
+        if not result.success and not salvaged:
             self._update_workflow(
                 {"status": "failed", "error_message": f"Development failed: {result.error}"}
             )

--- a/tests/issues/716/test_orchestrator.py
+++ b/tests/issues/716/test_orchestrator.py
@@ -994,7 +994,7 @@ class TestOrchestratorDevelopment:
         assert "Detailed implementation plan" in prompt
 
     def test_development_fails_sets_error(self):
-        """Failed development sets workflow to failed with error message."""
+        """Failed development with no code changes sets workflow to failed."""
         wf = _make_workflow(current_phase="development", status="developing")
         orch, mock_repo = self._make_orchestrator(wf)
         orch._runner = MagicMock()
@@ -1003,6 +1003,9 @@ class TestOrchestratorDevelopment:
         )
         orch._gh.get_current_commit.return_value = ""
         orch._gh.get_diff_stats.return_value = {}
+        # The agent produced nothing: no new commit AND no uncommitted changes,
+        # so the dev phase must fail rather than be salvaged (issue #723).
+        orch._gh.has_uncommitted_changes.return_value = False
 
         orch._do_development(wf)
 

--- a/tests/issues/723/test_orchestrator_dev_salvage.py
+++ b/tests/issues/723/test_orchestrator_dev_salvage.py
@@ -1,0 +1,175 @@
+"""Tests for development-phase salvage logic (issue #723).
+
+Covers Bug #1: when the dev agent reports failure (e.g. a subprocess timeout)
+but DID commit real code this session (``sha_changed``), the orchestrator must
+salvage the work and proceed to tests instead of marking the workflow failed.
+This is exactly what happened to issue #723: claude-code committed a full
+3721-line implementation, the subprocess hit the 1h timeout, and the workflow
+was discarded purely on ``not result.success``.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.modules.workspace.autonomous.models import AgentTaskResult
+
+
+def _make_workflow(**overrides):
+    base = {
+        "workflow_id": "wf-723",
+        "user_id": 1,
+        "title": "Test",
+        "status": "developing",
+        "requirements_text": "Build feature",
+        "requirements_issue_url": "",
+        "project_path": "/tmp/p",
+        "project_repo_url": "",
+        "is_new_project": False,
+        "cli_tool": "claude-code",
+        "model": "claude-sonnet-4-6",
+        "permission_mode": "auto-edit",
+        "branch_name": "auto-dev/x",
+        "branch_strategy": "new-branch",
+        "workspace_type": "local",
+        "remote_machine_id": "",
+        "worktree_path": "/tmp/p",
+        "github_issue_number": None,
+        "github_pr_number": None,
+        "github_pr_url": "",
+        "current_phase": "development",
+        "current_round": 1,
+        "dev_round": 1,
+        "max_plan_rounds": 3,
+        "max_pr_review_rounds": 5,
+        "total_tokens": 0,
+        "total_input_tokens": 0,
+        "total_output_tokens": 0,
+        "total_requests": 0,
+        "error_message": "",
+    }
+    base.update(overrides)
+    return base
+
+
+def _agent_result(success=True, error=None, text="dev output"):
+    return AgentTaskResult(
+        session_id="sess-dev",
+        response_text=text,
+        visible_response_text=text,
+        success=success,
+        error=error,
+    )
+
+
+def _make_orchestrator(wf_data, milestones=None):
+    from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+    with (
+        patch("app.modules.workspace.autonomous.orchestrator.Database"),
+        patch(
+            "app.modules.workspace.autonomous.orchestrator.AutonomousWorkflowRepository"
+        ) as mock_repo_cls,
+    ):
+        mock_repo = MagicMock()
+        mock_repo.get_workflow.return_value = wf_data
+        mock_repo.list_milestones.return_value = milestones or []
+        mock_repo.create_milestone.return_value = {
+            "milestone_id": "ms-new",
+            "workflow_id": wf_data["workflow_id"],
+        }
+        mock_repo.create_event.return_value = {"id": 1}
+        mock_repo.update_workflow.return_value = wf_data
+        mock_repo.update_milestone.return_value = {}
+        mock_repo.update_workflow_tokens.return_value = None
+        mock_repo_cls.return_value = mock_repo
+
+        orch = AutonomousOrchestrator(wf_data["workflow_id"])
+        orch.repo = mock_repo
+        orch.emitter = MagicMock()
+        orch._gh = MagicMock()
+        orch._gh.get_current_commit.return_value = "abc1234"
+        orch._gh.get_commit_diff_stats.return_value = {
+            "additions": 0,
+            "deletions": 0,
+            "files": 0,
+            "commits": 1,
+        }
+        orch._gh.get_diff_stats.return_value = {}
+        orch._gh.has_uncommitted_changes.return_value = False
+
+    return orch, mock_repo
+
+
+# ── Salvage (positive): failure + real commit -> proceeds ─────────────
+
+
+def test_dev_salvaged_on_timeout_with_commit():
+    """Bug #1: agent times out but committed code -> NOT failed, proceeds to tests."""
+    plan_ms = {
+        "milestone_id": "ms-plan",
+        "plan_content": "1. Implement",
+        "status": "completed",
+    }
+    wf = _make_workflow()
+    orch, mock_repo = _make_orchestrator(wf, milestones=[plan_ms])
+
+    orch._runner = MagicMock()
+    # First call (dev): timed out but produced a commit.
+    # Second call (tests): succeeds with real test output.
+    orch._runner.run_agent_task.side_effect = [
+        _agent_result(success=False, error="Agent task timed out after 3600s"),
+        _agent_result(success=True, text="2202 passed, 1 skipped"),
+    ]
+    # commit_before="aaa", commit_after="bbb" => sha_changed is True.
+    orch._gh.get_current_commit.side_effect = ["aaa1111", "bbb2222"]
+
+    orch._do_development(wf)
+
+    update_calls = mock_repo.update_workflow.call_args_list
+    fields_list = [c[0][1] for c in update_calls if len(c[0]) > 1 and isinstance(c[0][1], dict)]
+
+    # No "Development failed" status update was emitted.
+    assert not any(
+        f.get("status") == "failed" and "Development failed" in (f.get("error_message") or "")
+        for f in fields_list
+    ), "dev failure should have been salvaged, not marked failed"
+
+    # The dev milestone was marked completed (not failed) despite the timeout.
+    ms_updates = mock_repo.update_milestone.call_args_list
+    ms_fields = [c[0][1] for c in ms_updates if len(c[0]) > 1 and isinstance(c[0][1], dict)]
+    dev_ms_updates = [f for f in ms_fields if f.get("status") == "completed"]
+    assert dev_ms_updates, "dev milestone should be completed when salvaged"
+    salvaged_update = dev_ms_updates[0]
+    assert salvaged_update.get("error_message", "").startswith("Salvaged")
+
+
+# ── Salvage (negative): failure + no commit -> still failed ───────────
+
+
+def test_dev_not_salvaged_when_no_commit():
+    """Without a new commit, a failed agent run must still fail the workflow."""
+    plan_ms = {
+        "milestone_id": "ms-plan",
+        "plan_content": "1. Implement",
+        "status": "completed",
+    }
+    wf = _make_workflow()
+    orch, mock_repo = _make_orchestrator(wf, milestones=[plan_ms])
+
+    orch._runner = MagicMock()
+    orch._runner.run_agent_task.side_effect = [
+        _agent_result(success=False, error="Agent task timed out after 3600s"),
+        _agent_result(success=False, error="Tests failed"),
+    ]
+    # commit unchanged => sha_changed is False.
+    orch._gh.get_current_commit.side_effect = ["abc1234", "abc1234"]
+
+    orch._do_development(wf)
+
+    update_calls = mock_repo.update_workflow.call_args_list
+    fields_list = [c[0][1] for c in update_calls if len(c[0]) > 1 and isinstance(c[0][1], dict)]
+    assert any(
+        f.get("status") == "failed" and "Development failed" in (f.get("error_message") or "")
+        for f in fields_list
+    ), "dev failure with no commit should still mark the workflow failed"

--- a/tests/issues/723/test_runner_single_shot.py
+++ b/tests/issues/723/test_runner_single_shot.py
@@ -1,0 +1,219 @@
+"""Tests for single-shot agent runner stdout parsing (issue #723).
+
+Covers two bugs:
+  * Bug #2: ``_run_single_shot`` stuffed raw JSON strings into ``event_log``,
+    so the dict-based extractors (``_extract_visible_response_text`` etc.)
+    produced empty ``visible_response_text`` — which made the orchestrator's
+    test-skip detector false-positive on ``not has_test_result``.
+  * Bug #3: ``subprocess.TimeoutExpired`` discarded partial stdout entirely,
+    returning an empty result even when the agent had emitted real text.
+"""
+
+import json
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.modules.workspace.autonomous.agent_runner import AutonomousAgentRunner
+
+# ── _parse_single_shot_line ───────────────────────────────────────────
+
+
+class TestParseSingleShotLine:
+    """The per-line normalizer must emit dict events the extractors expect."""
+
+    def setup_method(self):
+        self.runner = AutonomousAgentRunner()
+
+    def test_claude_assistant_event_becomes_dict(self):
+        """Claude stream-json assistant line -> {"type":"assistant","text":...}."""
+        parsed = {
+            "type": "assistant",
+            "message": {
+                "content": [{"type": "text", "text": "Hello from agent"}],
+                "id": "msg_1",
+                "model": "claude-sonnet-4-6",
+            },
+        }
+        event = self.runner._parse_single_shot_line(parsed, "claude-code")
+        assert event == {
+            "type": "assistant",
+            "text": "Hello from agent",
+            "message_id": "msg_1",
+            "model": "claude-sonnet-4-6",
+        }
+
+    def test_claude_tool_use_event_becomes_dict(self):
+        """Claude tool_use line -> {"type":"tool_use",...}."""
+        parsed = {
+            "type": "tool_use",
+            "tool": {"name": "read_file", "input": {"path": "/tmp/x.py"}, "id": "tu_1"},
+        }
+        event = self.runner._parse_single_shot_line(parsed, "claude-code")
+        assert event == {
+            "type": "tool_use",
+            "tool_name": "read_file",
+            "tool_input": {"path": "/tmp/x.py"},
+            "tool_use_id": "tu_1",
+        }
+
+    def test_codex_message_event_becomes_assistant_dict(self):
+        """Codex/OpenAI message line -> assistant event."""
+        parsed = {
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": "All tests passed"}],
+        }
+        event = self.runner._parse_single_shot_line(parsed, "codex")
+        assert event["type"] == "assistant"
+        assert event["text"] == "All tests passed"
+
+    def test_codex_function_call_becomes_tool_use(self):
+        """Codex function_call line -> tool_use event."""
+        parsed = {"type": "function_call", "name": "shell", "arguments": "{}", "call_id": "c1"}
+        event = self.runner._parse_single_shot_line(parsed, "codex")
+        assert event["type"] == "tool_use"
+        assert event["tool_name"] == "shell"
+
+    def test_unrecognized_event_returns_none(self):
+        """Usage/result lines that aren't assistant/tool events return None."""
+        parsed = {"type": "result", "data": {"usage": {"input_tokens": 10, "output_tokens": 5}}}
+        assert self.runner._parse_single_shot_line(parsed, "codex") is None
+
+    def test_assistant_with_empty_content_returns_none(self):
+        """An assistant event whose content extracts to no text returns None."""
+        parsed = {"type": "assistant", "message": {"content": []}}
+        assert self.runner._parse_single_shot_line(parsed, "claude-code") is None
+
+
+# ── _parse_single_shot_stdout ─────────────────────────────────────────
+
+
+class TestParseSingleShotStdout:
+    """Full stdout parse: event_log must contain dict entries (not strings)."""
+
+    def setup_method(self):
+        self.runner = AutonomousAgentRunner()
+
+    def test_event_log_entries_are_dicts(self):
+        """Regression for Bug #2: event_log entries are dicts, not raw strings."""
+        stdout = json.dumps(
+            {"type": "assistant", "message": {"content": [{"type": "text", "text": "hi"}]}}
+        )
+        event_log, text, *_ = self.runner._parse_single_shot_stdout(stdout, "claude-code")
+        assert len(event_log) == 1
+        assert isinstance(event_log[0], dict)
+        assert event_log[0]["type"] == "assistant"
+        assert "hi" in text
+
+    def test_visible_text_and_tool_calls_populated(self):
+        """Both assistant text and tool calls are extracted."""
+        stdout = "\n".join(
+            [
+                json.dumps(
+                    {
+                        "type": "assistant",
+                        "message": {"content": [{"type": "text", "text": "Working"}]},
+                    }
+                ),
+                json.dumps(
+                    {"type": "tool_use", "tool": {"name": "edit", "input": {"file": "a.py"}}}
+                ),
+            ]
+        )
+        event_log, text, in_tok, out_tok, tool_calls = self.runner._parse_single_shot_stdout(
+            stdout, "claude-code"
+        )
+        assert "Working" in text
+        assert len(tool_calls) == 1
+        assert tool_calls[0]["tool"]["name"] == "edit"
+        assert len(event_log) == 2
+        assert all(isinstance(e, dict) for e in event_log)
+
+    def test_non_json_lines_become_text(self):
+        """Plain-text lines (progress noise) accumulate into response_text."""
+        stdout = "starting up...\nstill working...\n"
+        event_log, text, *_ = self.runner._parse_single_shot_stdout(stdout, "codex")
+        assert event_log == []
+        assert "starting up" in text and "still working" in text
+
+
+# ── _run_single_shot (subprocess mocking) ─────────────────────────────
+
+
+def _patch_cli_adapters(runner, exe="codex"):
+    """Patch cli_adapters.get_adapter so _run_single_shot finds an executable."""
+    mock_adapter = MagicMock()
+    mock_adapter.get_executable_name.return_value = exe
+    mock_adapter.build_single_shot_args.return_value = [exe, "exec", "--json", "prompt"]
+    mock_cli_adapters = MagicMock()
+    mock_cli_adapters.get_adapter.return_value = mock_adapter
+    return (
+        patch.dict("sys.modules", {"cli_adapters": mock_cli_adapters}),
+        patch("shutil.which", return_value=f"/usr/bin/{exe}"),
+    )
+
+
+class TestRunSingleShotResult:
+    """End-to-end single-shot result construction."""
+
+    def test_success_populates_visible_response_text(self):
+        """Bug #2 fix: a completed run carries non-empty visible_response_text."""
+        runner = AutonomousAgentRunner()
+        stdout = json.dumps(
+            {
+                "type": "assistant",
+                "message": {"content": [{"type": "text", "text": "All tests passed"}]},
+            }
+        )
+        proc = MagicMock(returncode=0, stdout=stdout, stderr="")
+
+        mod_patch, which_patch = _patch_cli_adapters(runner)
+        with mod_patch, which_patch, patch("subprocess.run", return_value=proc):
+            result = runner._run_single_shot(
+                session_id="s1",
+                cli_tool="codex",
+                model="m",
+                project_path="/tmp/p",
+                prompt="do it",
+                timeout=5,
+                workflow_id="wf1",
+            )
+
+        assert result.success is True
+        assert result.error is None
+        assert "All tests passed" in result.response_text
+        assert result.visible_response_text  # non-empty — the Bug #2 regression guard
+        assert result.event_log and isinstance(result.event_log[0], dict)
+
+    def test_timeout_salvages_partial_output(self):
+        """Bug #3 fix: TimeoutExpired keeps partial stdout in the result."""
+        runner = AutonomousAgentRunner()
+        partial = json.dumps(
+            {
+                "type": "assistant",
+                "message": {"content": [{"type": "text", "text": "partial work"}]},
+            }
+        )
+
+        def _raise(*a, **k):
+            raise subprocess.TimeoutExpired(cmd=["codex"], timeout=5, output=partial)
+
+        mod_patch, which_patch = _patch_cli_adapters(runner)
+        with mod_patch, which_patch, patch("subprocess.run", side_effect=_raise):
+            result = runner._run_single_shot(
+                session_id="s1",
+                cli_tool="codex",
+                model="m",
+                project_path="/tmp/p",
+                prompt="do it",
+                timeout=5,
+                workflow_id="wf1",
+            )
+
+        assert result.success is False
+        assert "timed out after 5s" in result.error
+        # The salvaged partial output must survive.
+        assert "partial work" in result.response_text
+        assert result.event_log and isinstance(result.event_log[0], dict)

--- a/tests/issues/723/test_runner_single_shot.py
+++ b/tests/issues/723/test_runner_single_shot.py
@@ -188,7 +188,13 @@ class TestRunSingleShotResult:
         assert result.event_log and isinstance(result.event_log[0], dict)
 
     def test_timeout_salvages_partial_output(self):
-        """Bug #3 fix: TimeoutExpired keeps partial stdout in the result."""
+        """Bug #3 fix: TimeoutExpired keeps partial stdout in the result.
+
+        On POSIX, ``subprocess.run(..., text=True)`` raises a TimeoutExpired
+        whose ``.output`` is **bytes** (the decode step only runs on the normal
+        return path, not on the re-raised exception), so the salvage path must
+        decode explicitly. The exception here mirrors that: bytes output.
+        """
         runner = AutonomousAgentRunner()
         partial = json.dumps(
             {
@@ -198,7 +204,10 @@ class TestRunSingleShotResult:
         )
 
         def _raise(*a, **k):
-            raise subprocess.TimeoutExpired(cmd=["codex"], timeout=5, output=partial)
+            # bytes — the real POSIX shape, not str.
+            raise subprocess.TimeoutExpired(
+                cmd=["codex"], timeout=5, output=partial.encode("utf-8")
+            )
 
         mod_patch, which_patch = _patch_cli_adapters(runner)
         with mod_patch, which_patch, patch("subprocess.run", side_effect=_raise):


### PR DESCRIPTION
## Summary

Fixes the failure mode that discarded issue #723's completed implementation (a full 3721-line run-timeline feature) and marked the workflow `failed` purely because the dev subprocess hit the 1h wall-clock timeout — even though the agent had finished and committed the work.

### Root cause (confirmed from the live `ace` Postgres DB)
- Workflow `ae3884d7` for #723: dev agent committed `b6b8f789` at 13:42 UTC, but the claude-code subprocess never emitted a closing `result` event, so the 3600s timeout fired at 13:45. `_run_development_agent` marked the workflow `failed` on `not result.success`, **ignoring the `sha_changed=True` it had already computed**. The 31-file implementation was stranded on `auto-dev/ae3884d7` with no PR.

### Changes

**Bug 1 — dev-phase timeout discarded committed work** (`orchestrator.py`)
- `_run_development_agent` now salvages the round when the agent reported failure **but produced a real commit this session** (`sha_changed`), treating it as completed and proceeding to tests. Only the no-commit case (already guarded upstream) is a true failure.

**Bug 2 — single-shot `event_log` held raw strings** (`agent_runner.py`)
- `_run_single_shot` appended raw JSON lines to `event_log`, but the dict-based extractors (`_extract_visible_response_text` / `_persist_local_session_messages`) expect `{"type": ...}` dicts. Result: `response_text`/`visible_response_text` came back empty, which made the orchestrator's test-skip detector false-positive on `not has_test_result` and lost `tool_calls`. Affects codex/openclaw (tools without stdin protocol).
- New `_parse_single_shot_line` / `_parse_single_shot_stdout` normalize codex/openclaw/claude stream-json shapes into the same dict contract used by the interactive `_read_stdout` path.

**Bug 3 — single-shot timeout discarded partial stdout** (`agent_runner.py`)
- `subprocess.TimeoutExpired` now parses the partial output captured before the kill (via `TimeoutExpired.output`) instead of returning an empty result.

### Tests (`tests/issues/723/`, 13 new)
- `_parse_single_shot_line`: claude assistant/tool_use, codex message/function_call, unrecognized→None, empty-content→None.
- `_parse_single_shot_stdout`: event_log entries are dicts (Bug 2 regression guard), text + tool_calls populated, non-JSON lines → text.
- `_run_single_shot`: success populates `visible_response_text`; timeout salvages partial output (Bug 3 guard).
- orchestrator salvage: dev failure **with** commit → not failed, milestone `completed`/`Salvaged`; dev failure **without** commit → still failed.
- Corrected `tests/issues/716/test_orchestrator.py::test_development_fails_sets_error` to explicitly assert `has_uncommitted_changes()=False` (it previously passed only because MagicMock's default truthy value tripped auto-commit).

### Test results
- `tests/issues/716/ tests/issues/723/`: **285 passed**
- Full backend `pytest -q`: **2160 passed, 1 skipped** (no regressions)

### Notes
- This is backend-only; frontend vitest is unaffected.
- Issue #723 was already rescued separately (DB reset to `pr_review` → **PR #1256** created from the salvaged `b6b8f789`). This PR hardens the orchestrator/runner so future workflows don't hit the same discard-on-timeout failure.