### PR TITLE
fix(install): config.json权限600保护敏感信息 (Issue #1252)

### DIFF
--- a/scripts/install-central/docker-method/install.sh
+++ b/scripts/install-central/docker-method/install.sh
@@ -3030,6 +3030,10 @@ volumes:
     driver: local
 EOF
 
+    # Set permissions for docker-compose.yml (Issue #1253)
+    # This file contains sensitive information: database password, secret key, etc.
+    chmod 600 "$compose_file"
+
     print_success "Docker Compose 配置创建完成"
 }
 

--- a/scripts/install-central/docker-method/install.sh
+++ b/scripts/install-central/docker-method/install.sh
@@ -2868,6 +2868,10 @@ $workspace_config,
 }
 EOF
 
+    # Set permissions for config.json (Issue #1252)
+    # This file contains sensitive information: database password, token secret, etc.
+    chmod 600 "$config_file"
+
     print_success "配置文件创建完成: $config_file"
     print_info "  - 主机名: $HOST_NAME"
     print_info "  - 服务地址: $server_url"


### PR DESCRIPTION
## 问题

`install.sh` 创建的敏感配置文件权限为 755，所有用户可读。

### Issue #1252 - config.json
- `database.url` → 数据库密码
- `upload_auth_key` → 认证密钥
- `workspace.token_secret` → token 密钥

### Issue #1253 - docker-compose.yml
- `POSTGRES_PASSWORD` → 数据库密码
- `DATABASE_URL` → 数据库连接字符串
- `SECRET_KEY` → Flask 密钥
- `UPLOAD_AUTH_KEY` → 认证密钥

## 修复

| 文件 | 函数 | 修复 |
|------|------|------|
| config.json | create_config() | 添加 chmod 600 |
| docker-compose.yml | create_docker_compose() | 添加 chmod 600 |

## 权限对比

| 文件 | 权限 | 状态 |
|------|------|------|
| config.json | 600 | ✅ 本次修复 |
| docker-compose.yml | 600 | ✅ 本次修复 |
| .env | 600 | ✅ 已设置 |
| config.json.bak.* | 600 | ✅ 已设置 |

## 关联 Issue

- Fixes #1252
- Fixes #1253