### PR TITLE
feat(docker): 一键部署支持 - 自动生成 config.json (Issue #1260)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,11 +3,58 @@ name: Release
 on:
   release:
     types: [published]
+  # Allow manual trigger for testing Docker build
+  workflow_dispatch:
 
 permissions:
   contents: write
 
 jobs:
+  # ===========================================================================
+  # Docker Image Build & Push to Docker Hub (Issue #1260)
+  # ===========================================================================
+  docker-build-push:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log in to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+    - name: Extract metadata
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ secrets.DOCKERHUB_USERNAME }}/open-ace
+        tags: |
+          type=ref,event=tag
+          type=raw,value=latest,enable={{is_default_branch}}
+
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: Dockerfile
+        target: production
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+        platforms: linux/amd64
+
+    - name: Output image digest
+      run: echo "Pushed to Docker Hub: ${{ steps.meta.outputs.tags }}"
+
+  # ===========================================================================
+  # PyPI Package Build & Publish
+  # ===========================================================================
   build-and-publish:
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,58 +3,11 @@ name: Release
 on:
   release:
     types: [published]
-  # Allow manual trigger for testing Docker build
-  workflow_dispatch:
 
 permissions:
   contents: write
 
 jobs:
-  # ===========================================================================
-  # Docker Image Build & Push to Docker Hub (Issue #1260)
-  # ===========================================================================
-  docker-build-push:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v6
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-
-    - name: Log in to Docker Hub
-      uses: docker/login-action@v3
-      with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-    - name: Extract metadata
-      id: meta
-      uses: docker/metadata-action@v5
-      with:
-        images: ${{ secrets.DOCKERHUB_USERNAME }}/open-ace
-        tags: |
-          type=ref,event=tag
-          type=raw,value=latest,enable={{is_default_branch}}
-
-    - name: Build and push Docker image
-      uses: docker/build-push-action@v6
-      with:
-        context: .
-        file: Dockerfile
-        target: production
-        push: true
-        tags: ${{ steps.meta.outputs.tags }}
-        labels: ${{ steps.meta.outputs.labels }}
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
-        platforms: linux/amd64
-
-    - name: Output image digest
-      run: echo "Pushed to Docker Hub: ${{ steps.meta.outputs.tags }}"
-
-  # ===========================================================================
-  # PyPI Package Build & Publish
-  # ===========================================================================
   build-and-publish:
     runs-on: ubuntu-latest
     env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,29 @@
 # Open ACE - AI Computing Explorer
 # Docker build for production deployment
 #
-# Frontend is pre-built on the host (npm run build) before docker build.
-# This avoids npm issues on certain architectures (e.g., ARM64 podman).
+# Frontend is built inside Docker (Issue #1260: one-click deploy support)
+
+# =============================================================================
+# Frontend Build Stage (Issue #1260)
+# =============================================================================
+FROM node:20-alpine AS frontend-builder
+
+WORKDIR /app/frontend
+
+# Configure npm mirror for Chinese network
+RUN npm config set registry https://registry.npmmirror.com/
+
+# Copy frontend source
+COPY frontend/package.json frontend/package-lock.json* ./
+
+# Install dependencies
+RUN npm ci --legacy-peer-deps || npm install --legacy-peer-deps
+
+# Copy frontend source files
+COPY frontend/ .
+
+# Build frontend (outputs to ../static/js/dist/)
+RUN npm run build
 
 # =============================================================================
 # Python Build Stage
@@ -99,8 +120,11 @@ WORKDIR /app
 COPY --from=builder /opt/venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 
-# Copy application code (includes pre-built frontend in static/js/dist/)
+# Copy application code
 COPY --chown=open-ace:open-ace . .
+
+# Copy frontend build output from frontend-builder stage (Issue #1260)
+COPY --from=frontend-builder --chown=open-ace:open-ace /app/static/js/dist ./static/js/dist
 
 # Copy and set up entrypoint script
 COPY --chown=open-ace:open-ace docker-entrypoint.sh /usr/local/bin/

--- a/README.md
+++ b/README.md
@@ -118,20 +118,34 @@
 
 ## 🚀 5 分钟快速开始
 
-### 方式一：Docker 部署（推荐）
+### 方式一：一键部署（推荐）
 
 ```bash
 # 克隆项目
 git clone https://github.com/open-ace/open-ace.git
 cd open-ace
 
-# 构建并启动（包含 PostgreSQL 数据库）
-docker compose up -d --build
+# 拉取预构建镜像并启动（包含 PostgreSQL 数据库）
+docker compose up -d
 
 # 访问 http://localhost:5000
 ```
 
-> 💡 生产环境部署请参考 [部署指南](scripts/install-central/docker-method/README.md)
+> 💡 预构建镜像托管在 Docker Hub (openace/open-ace)
+>
+> 生产环境部署请参考 [部署指南](scripts/install-central/docker-method/README.md)
+
+<details>
+<summary>本地构建（开发者可选）</summary>
+
+如需本地构建镜像：
+
+```bash
+docker build -t open-ace:dev --target production .
+IMAGE_NAME=open-ace:dev docker compose up -d
+```
+
+</details>
 
 ### 方式二：源码安装
 
@@ -421,20 +435,34 @@ It is built for teams moving AI coding agents into real engineering workflows, e
 
 ## 🚀 Quick Start in 5 Minutes
 
-### Option 1: Docker (Recommended)
+### Option 1: One-click Deploy (Recommended)
 
 ```bash
 # Clone the project
 git clone https://github.com/open-ace/open-ace.git
 cd open-ace
 
-# Build and start (includes PostgreSQL database)
-docker compose up -d --build
+# Pull pre-built image and start (includes PostgreSQL database)
+docker compose up -d
 
 # Visit http://localhost:5000
 ```
 
-> 💡 For production deployment, see [Deployment Guide](scripts/install-central/docker-method/README.md)
+> 💡 Pre-built image hosted on GitHub Container Registry (ghcr.io/open-ace/open-ace)
+>
+> For production deployment, see [Deployment Guide](scripts/install-central/docker-method/README.md)
+
+<details>
+<summary>Local Build (Optional for Developers)</summary>
+
+To build the image locally:
+
+```bash
+docker build -t open-ace:dev --target production .
+IMAGE_NAME=open-ace:dev docker compose up -d
+```
+
+</details>
 
 ### Option 2: From Source
 

--- a/README.md
+++ b/README.md
@@ -125,27 +125,13 @@
 git clone https://github.com/open-ace/open-ace.git
 cd open-ace
 
-# 拉取预构建镜像并启动（包含 PostgreSQL 数据库）
-docker compose up -d
+# 构建并启动
+docker compose up -d --build
 
 # 访问 http://localhost:5000
 ```
 
-> 💡 预构建镜像托管在 Docker Hub (openace/open-ace)
->
-> 生产环境部署请参考 [部署指南](scripts/install-central/docker-method/README.md)
-
-<details>
-<summary>本地构建（开发者可选）</summary>
-
-如需本地构建镜像：
-
-```bash
-docker build -t open-ace:dev --target production .
-IMAGE_NAME=open-ace:dev docker compose up -d
-```
-
-</details>
+> 💡 生产环境部署请参考 [部署指南](scripts/install-central/docker-method/README.md)
 
 ### 方式二：源码安装
 
@@ -442,27 +428,13 @@ It is built for teams moving AI coding agents into real engineering workflows, e
 git clone https://github.com/open-ace/open-ace.git
 cd open-ace
 
-# Pull pre-built image and start (includes PostgreSQL database)
-docker compose up -d
+# Build and start
+docker compose up -d --build
 
 # Visit http://localhost:5000
 ```
 
-> 💡 Pre-built image hosted on GitHub Container Registry (ghcr.io/open-ace/open-ace)
->
-> For production deployment, see [Deployment Guide](scripts/install-central/docker-method/README.md)
-
-<details>
-<summary>Local Build (Optional for Developers)</summary>
-
-To build the image locally:
-
-```bash
-docker build -t open-ace:dev --target production .
-IMAGE_NAME=open-ace:dev docker compose up -d
-```
-
-</details>
+> 💡 For production deployment, see [Deployment Guide](docs/en/DEPLOYMENT.md)
 
 ### Option 2: From Source
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,24 +1,29 @@
 # Open ACE - AI Computing Explorer - Docker Compose Configuration
 # For production deployment with PostgreSQL database
 #
-# Usage:
-#   docker compose up -d                          # Basic deployment
-#   docker compose --profile production up -d     # With nginx reverse proxy
+# One-click deploy (Issue #1260):
+#   docker compose up -d                          # Pull from Docker Hub and start
+#   # Access http://localhost:5000
+#
+# With nginx reverse proxy:
+#   docker compose --profile production up -d
 #
 # Multi-user workspace:
 #   WORKSPACE_MULTI_USER_MODE=true docker compose up -d
 #   Then create users via admin API — system users are auto-created in container
+#
+# Developer build (for local testing):
+#   docker build -t open-ace:dev --target production .
+#   IMAGE_NAME=open-ace:dev docker compose up -d
 
 services:
   # ===========================================================================
   # Main Application
   # ===========================================================================
   open-ace:
-    build:
-      context: .
-      dockerfile: Dockerfile
-      target: production
-    image: ${IMAGE_NAME:-open-ace:latest}
+    # Pull pre-built image from Docker Hub (Issue #1260)
+    # For local development: build with docker build and set IMAGE_NAME
+    image: ${IMAGE_NAME:-openace/open-ace:latest}
     container_name: open-ace
     restart: unless-stopped
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,13 @@
 # For production deployment with PostgreSQL database
 #
 # One-click deploy (Issue #1260):
-#   docker compose up -d                          # Pull from Docker Hub and start
+#   git clone https://github.com/open-ace/open-ace.git
+#   cd open-ace
+#   docker compose up -d --build
 #   # Access http://localhost:5000
+#
+# Pull pre-built image from Docker Hub:
+#   docker compose up -d
 #
 # With nginx reverse proxy:
 #   docker compose --profile production up -d
@@ -21,8 +26,12 @@ services:
   # Main Application
   # ===========================================================================
   open-ace:
-    # Pull pre-built image from Docker Hub (Issue #1260)
-    # For local development: build with docker build and set IMAGE_NAME
+    # One-click deploy: docker compose up -d --build
+    # Pull pre-built image: docker compose up -d (without --build)
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: production
     image: ${IMAGE_NAME:-openace/open-ace:latest}
     container_name: open-ace
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -120,6 +120,7 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+      start_period: 30s
     logging:
       driver: "json-file"
       options:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,9 +47,10 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
     volumes:
-      # CONFIG_DIR: Container runs as root (required for multi-user workspace mode)
-      # ~/.open-ace expands to /root/.open-ace when running as root
-      - ./config:/root/.open-ace:ro
+      # Config: Use named volume for persistence (Issue #1260)
+      # Entrypoint will auto-generate config.json if not exists
+      # Users can mount custom config: - ./my-config.json:/root/.open-ace/config.json:ro
+      - config-data:/root/.open-ace
       - ./logs:/app/logs
       # Workspace data: per-user project directories, persisted across restarts
       - workspace-data:/workspace
@@ -136,6 +137,8 @@ networks:
 # Volumes
 # =============================================================================
 volumes:
+  config-data:
+    driver: local
   postgres-data:
     driver: local
   workspace-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,14 @@ services:
       - WORKSPACE_BASE_DIR=/workspace
       # Data fetch: container runs as root, use venv Python (Issue #1121)
       - FETCH_USE_SUDO=false
+      # Server IP for URL configuration (Issue #1260)
+      # Defaults to host.docker.internal for one-click deploy
+      # Users can override via .env file for production
+      - SERVER_IP=${SERVER_IP:-host.docker.internal}
+    # Allow container to access host network (Issue #1260)
+    # Required for host.docker.internal on Linux Docker 20.10+
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     volumes:
       # CONFIG_DIR: Container runs as root (required for multi-user workspace mode)
       # ~/.open-ace expands to /root/.open-ace when running as root

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -113,18 +113,22 @@ generate_default_config() {
     SERVER_IP="${SERVER_IP:-host.docker.internal}"
     PORT="${PORT:-5000}"
 
+    # Get hostname dynamically (matches install.sh behavior)
+    HOST_NAME=$(hostname -f 2>/dev/null || hostname 2>/dev/null || echo "docker-container")
+
     # Generate random token secret and upload auth key (32 chars hex)
     TOKEN_SECRET=$(python3 -c "import secrets; print(secrets.token_hex(16))")
     UPLOAD_AUTH_KEY=$(python3 -c "import secrets; print(secrets.token_hex(16))")
 
     # Generate default config (matches install.sh defaults)
     # Note: DATABASE_URL env var takes precedence over config file for database connection
+    # Database credentials use docker-compose.yml defaults (${DB_USER:-ace}, etc.)
     cat > "$CONFIG_FILE" << CONFIG_EOF
 {
-  "host_name": "docker-container",
+  "host_name": "$HOST_NAME",
   "database": {
     "type": "postgresql",
-    "url": "postgresql://ace:ace-secret@postgres:5432/ace"
+    "url": "postgresql://\${DB_USER:-ace}:\${DB_PASSWORD:-ace-secret}@postgres:5432/\${DB_NAME:-ace}"
   },
   "server": {
     "upload_auth_key": "$UPLOAD_AUTH_KEY",
@@ -151,16 +155,16 @@ generate_default_config() {
     "openclaw": {
       "enabled": true,
       "token_env": "OPENCLAW_TOKEN",
-      "gateway_url": "http://localhost:18789",
-      "hostname": "docker-container"
+      "gateway_url": "http://${SERVER_IP}:18789",
+      "hostname": "$HOST_NAME"
     },
     "claude": {
       "enabled": true,
-      "hostname": "docker-container"
+      "hostname": "$HOST_NAME"
     },
     "qwen": {
       "enabled": true,
-      "hostname": "docker-container"
+      "hostname": "$HOST_NAME"
     }
   },
   "cron": {

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -91,6 +91,109 @@ echo "  Open ACE - Starting..."
 echo "=========================================="
 
 # ============================================================================
+# 0.2. Generate Default Config (Issue #1260)
+# ============================================================================
+# Generate default config.json if not exists (one-click deploy support)
+generate_default_config() {
+    CONFIG_FILE="/root/.open-ace/config.json"
+    CONFIG_DIR=$(dirname "$CONFIG_FILE")
+
+    # Skip if config already exists (user-mounted or previously generated)
+    if [ -f "$CONFIG_FILE" ]; then
+        echo "Config file exists at $CONFIG_FILE, skipping generation."
+        return 0
+    fi
+
+    echo "Generating default config at $CONFIG_FILE..."
+
+    # Create config directory
+    mkdir -p "$CONFIG_DIR"
+
+    # Use SERVER_IP environment variable (default: host.docker.internal)
+    SERVER_IP="${SERVER_IP:-host.docker.internal}"
+    PORT="${PORT:-5000}"
+
+    # Generate random token secret and upload auth key (32 chars hex)
+    TOKEN_SECRET=$(python3 -c "import secrets; print(secrets.token_hex(16))")
+    UPLOAD_AUTH_KEY=$(python3 -c "import secrets; print(secrets.token_hex(16))")
+
+    # Generate default config (matches install.sh defaults)
+    # Note: DATABASE_URL env var takes precedence over config file for database connection
+    cat > "$CONFIG_FILE" << CONFIG_EOF
+{
+  "host_name": "docker-container",
+  "database": {
+    "type": "postgresql",
+    "url": "postgresql://ace:ace-secret@postgres:5432/ace"
+  },
+  "server": {
+    "upload_auth_key": "$UPLOAD_AUTH_KEY",
+    "server_url": "http://${SERVER_IP}:${PORT}",
+    "web_port": ${PORT},
+    "web_host": "0.0.0.0"
+  },
+  "workspace": {
+    "enabled": true,
+    "url": "http://${SERVER_IP}",
+    "multi_user_mode": true,
+    "port_range_start": 3100,
+    "port_range_end": 3200,
+    "max_instances": 30,
+    "idle_timeout_minutes": 30,
+    "cleanup_interval_minutes": 5,
+    "token_secret": "$TOKEN_SECRET",
+    "webui_path": ""
+  },
+  "autonomous": {
+    "enabled": false
+  },
+  "tools": {
+    "openclaw": {
+      "enabled": true,
+      "token_env": "OPENCLAW_TOKEN",
+      "gateway_url": "http://localhost:18789",
+      "hostname": "docker-container"
+    },
+    "claude": {
+      "enabled": true,
+      "hostname": "docker-container"
+    },
+    "qwen": {
+      "enabled": true,
+      "hostname": "docker-container"
+    }
+  },
+  "cron": {
+    "enabled": true,
+    "run_time": "00:30"
+  },
+  "feishu": {
+    "app_id": "",
+    "app_secret": ""
+  },
+  "auth": {
+    "auth_type": "openai",
+    "env": {
+      "OPENAI_API_KEY": "",
+      "OPENAI_BASE_URL": "https://api.openai.com/v1"
+    }
+  },
+  "insights": {
+    "model": "glm-5",
+    "temperature": 0.3,
+    "max_tokens": 4096
+  }
+}
+CONFIG_EOF
+
+    # Set restrictive permissions (Issue #1252)
+    chmod 600 "$CONFIG_FILE"
+    echo "Default config generated with permissions 600."
+}
+
+generate_default_config
+
+# ============================================================================
 # 1. Database Initialization
 # ============================================================================
 if [ -n "$DATABASE_URL" ]; then

--- a/scripts/install-central/docker-method/README.md
+++ b/scripts/install-central/docker-method/README.md
@@ -4,15 +4,15 @@
 
 ## 快速部署（推荐）
 
-### 1. 拉取镜像并启动
+### 1. 构建并启动
 
 ```bash
 # 在项目根目录执行
-docker compose up -d
+docker compose up -d --build
 ```
 
 这将：
-- 从 Docker Hub 拉取预构建镜像 (openace/open-ace)
+- 本地构建 open-ace 镜像
 - 启动 open-ace 容器（端口 5000）
 - 启动 PostgreSQL 数据库（内部端口 5432）
 

--- a/scripts/install-central/docker-method/README.md
+++ b/scripts/install-central/docker-method/README.md
@@ -2,18 +2,19 @@
 
 本目录包含 Open ACE 的 Docker 部署相关脚本。
 
-## 快速部署
+## 快速部署（推荐）
 
-### 1. 构建并启动
+### 1. 拉取镜像并启动
 
 ```bash
 # 在项目根目录执行
-docker compose up -d --build
+docker compose up -d
 ```
 
-这将启动：
-- **open-ace-web**: Web 应用（端口 5000）
-- **open-ace-postgres**: PostgreSQL 数据库（内部端口 5432）
+这将：
+- 从 Docker Hub 拉取预构建镜像 (openace/open-ace)
+- 启动 open-ace 容器（端口 5000）
+- 启动 PostgreSQL 数据库（内部端口 5432）
 
 ### 2. 访问应用
 


### PR DESCRIPTION
## Summary

实现 Issue #1260 的一键部署方案：`git clone → cd → docker compose up -d --build → 访问 http://localhost:5000`

### 主要改动

1. **docker-compose.yml**
   - 添加 `SERVER_IP` 环境变量，默认 `host.docker.internal`
   - 添加 `extra_hosts` 配置，支持 Linux Docker 20.10+ 的 host.docker.internal

2. **docker-entrypoint.sh**
   - 添加 `generate_default_config()` 函数
   - 启动时检测 `/root/.open-ace/config.json` 是否存在
   - 不存在则自动生成默认配置（与 install.sh 默认值一致）
   - 自动生成随机 `token_secret` 和 `upload_auth_key`
   - 设置权限 600（遵循 Issue #1252 安全要求）

### 默认配置

生成的默认配置与 install.sh 交互式安装的默认值一致：

| 配置项 | 默认值 | 说明 |
|--------|--------|------|
| `workspace.enabled` | `true` | 启用 Workspace 功能 |
| `workspace.multi_user_mode` | `true` | 多用户模式 |
| `tools.openclaw.enabled` | `true` | 启用 OpenClaw |
| `tools.claude.enabled` | `true` | 启用 Claude |
| `tools.qwen.enabled` | `true` | 启用 Qwen |
| `autonomous.enabled` | `false` | AI 自主开发（默认关闭） |

### 使用方式

**一键部署（无需配置）：**
```bash
git clone https://github.com/open-ace/open-ace.git
cd open-ace
docker compose up -d --build
```

访问 `http://localhost:5000` 即可使用。

**生产环境部署：**
创建 `.env` 文件覆盖默认值：
```env
SERVER_IP=192.168.x.xxx
SECRET_KEY=your-production-secret-key
DB_PASSWORD=your-db-password
```

**自定义配置：**
挂载自定义配置文件：
```yaml
volumes:
  - ./my-config.json:/root/.open-ace/config.json:ro
```

### Test Plan

1. 全新部署测试
   - 删除所有 volumes 和容器
   - `docker compose up -d --build`
   - 验证 config.json 自动生成
   - 验证服务正常启动

2. 配置挂载测试
   - 挂载自定义 config.json
   - 验证不覆盖用户配置

3. 生产环境模拟
   - 设置 SERVER_IP 环境变量
   - 验证 URL 配置正确

Closes #1260