### PR TITLE
fix(quota): work-page quota reads agent_sessions only; gray-style CLI sessions (#1269 P1)

### DIFF
--- a/app/repositories/usage_repo.py
+++ b/app/repositories/usage_repo.py
@@ -1116,6 +1116,32 @@ class UsageRepository:
         # Session usage from agent_sessions (includes local, remote, and terminal sessions)
         # Note: WebUI creates 'local' sessions, CLI via remote mode creates 'remote' sessions,
         # and terminal sessions have workspace_type='terminal'
+        session_tokens, session_requests = self._session_usage(user_id, start_date, end_date)
+
+        local_tokens = int(local_row["tokens"]) if local_row else 0
+        local_requests = int(local_row["requests"]) if local_row else 0
+
+        return {
+            "tokens": local_tokens + session_tokens,
+            "requests": local_requests + session_requests,
+            "local_tokens": local_tokens,
+            "local_requests": local_requests,
+            "remote_tokens": session_tokens,  # Keep legacy field name for compatibility
+            "remote_requests": session_requests,  # Keep legacy field name for compatibility
+        }
+
+    def _session_usage(
+        self,
+        user_id: int,
+        start_date: str,
+        end_date: str,
+    ) -> tuple[int, int]:
+        """Query agent_sessions for session-backed tokens/requests in a window.
+
+        Shared by get_combined_usage (Manage page) and get_session_only_usage
+        (Work page) so the workspace_type/date/request-subquery filter lives in
+        one place — see #1272 review (avoid two copies drifting).
+        """
         session_row = self.db.fetch_one(
             """
             SELECT
@@ -1132,20 +1158,9 @@ class UsageRepository:
         """,
             (user_id, start_date, end_date),
         )
-
-        local_tokens = int(local_row["tokens"]) if local_row else 0
-        local_requests = int(local_row["requests"]) if local_row else 0
         session_tokens = int(session_row["tokens"]) if session_row else 0
         session_requests = int(session_row["requests"]) if session_row else 0
-
-        return {
-            "tokens": local_tokens + session_tokens,
-            "requests": local_requests + session_requests,
-            "local_tokens": local_tokens,
-            "local_requests": local_requests,
-            "remote_tokens": session_tokens,  # Keep legacy field name for compatibility
-            "remote_requests": session_requests,  # Keep legacy field name for compatibility
-        }
+        return session_tokens, session_requests
 
     def get_session_only_usage(
         self,
@@ -1172,26 +1187,7 @@ class UsageRepository:
             Dict with tokens, requests, and per-source breakdown (local_* are
             always 0 here since daily_messages is excluded).
         """
-        session_row = self.db.fetch_one(
-            """
-            SELECT
-                COALESCE(SUM(total_tokens), 0) as tokens,
-                COALESCE(SUM(
-                    (SELECT COUNT(*) FROM session_messages sm
-                     WHERE sm.session_id = agent_sessions.session_id
-                       AND sm.role = 'assistant')
-                ), 0) as requests
-            FROM agent_sessions
-            WHERE user_id = ?
-              AND workspace_type IN ('local', 'remote', 'terminal')
-              AND CAST(created_at AS DATE) >= ? AND CAST(created_at AS DATE) <= ?
-        """,
-            (user_id, start_date, end_date),
-        )
-
-        session_tokens = int(session_row["tokens"]) if session_row else 0
-        session_requests = int(session_row["requests"]) if session_row else 0
-
+        session_tokens, session_requests = self._session_usage(user_id, start_date, end_date)
         return {
             "tokens": session_tokens,
             "requests": session_requests,

--- a/app/repositories/usage_repo.py
+++ b/app/repositories/usage_repo.py
@@ -1147,6 +1147,60 @@ class UsageRepository:
             "remote_requests": session_requests,  # Keep legacy field name for compatibility
         }
 
+    def get_session_only_usage(
+        self,
+        user_id: int,
+        start_date: str,
+        end_date: str,
+    ) -> dict:
+        """Get usage from agent_sessions only (no daily_messages).
+
+        Used by the Work-page quota display so Workspace runtime does not read
+        the daily_messages analysis fact table (#1125: analysis tables must not
+        participate in Workspace runtime display). Counts all session-backed
+        spend across workspace_type local/remote/terminal, which covers WebUI,
+        autonomous, remote, and terminal sessions. get_combined_usage (which
+        adds a daily_messages leg) is retained for the Manage/analysis page,
+        which #1125 whitelists on the analysis tables.
+
+        Args:
+            user_id: User ID.
+            start_date: Start date (YYYY-MM-DD).
+            end_date: End date (YYYY-MM-DD).
+
+        Returns:
+            Dict with tokens, requests, and per-source breakdown (local_* are
+            always 0 here since daily_messages is excluded).
+        """
+        session_row = self.db.fetch_one(
+            """
+            SELECT
+                COALESCE(SUM(total_tokens), 0) as tokens,
+                COALESCE(SUM(
+                    (SELECT COUNT(*) FROM session_messages sm
+                     WHERE sm.session_id = agent_sessions.session_id
+                       AND sm.role = 'assistant')
+                ), 0) as requests
+            FROM agent_sessions
+            WHERE user_id = ?
+              AND workspace_type IN ('local', 'remote', 'terminal')
+              AND CAST(created_at AS DATE) >= ? AND CAST(created_at AS DATE) <= ?
+        """,
+            (user_id, start_date, end_date),
+        )
+
+        session_tokens = int(session_row["tokens"]) if session_row else 0
+        session_requests = int(session_row["requests"]) if session_row else 0
+
+        return {
+            "tokens": session_tokens,
+            "requests": session_requests,
+            "local_tokens": 0,
+            "local_requests": 0,
+            "remote_tokens": session_tokens,  # legacy field name for compatibility
+            "remote_requests": session_requests,
+        }
+
     def get_user_daily_detail(
         self,
         user_id: int,

--- a/app/routes/quota.py
+++ b/app/routes/quota.py
@@ -89,25 +89,23 @@ def check_quota():
             return jsonify({"error": "User not found"}), 404
 
         username = user.get("username", "")
-        system_account = user.get("system_account") or username
 
-        # Get today's usage combining local CLI and remote proxy
+        # Get today's usage — session-only (agent_sessions) per #1125: the Work
+        # page must not read the daily_messages analysis fact table.
         today = datetime.now().strftime("%Y-%m-%d")
-        today_combined = usage_repo.get_combined_usage(
+        today_combined = usage_repo.get_session_only_usage(
             user_id=user_id,
-            system_account=system_account,
             start_date=today,
             end_date=today,
         )
         today_requests = today_combined["requests"]
         today_tokens = today_combined["tokens"]
 
-        # Get monthly usage combining local CLI and remote proxy
+        # Get monthly usage — session-only (same #1125 rationale).
         now = datetime.now()
         month_start = now.replace(day=1).strftime("%Y-%m-%d")
-        monthly_combined = usage_repo.get_combined_usage(
+        monthly_combined = usage_repo.get_session_only_usage(
             user_id=user_id,
-            system_account=system_account,
             start_date=month_start,
             end_date=today,
         )
@@ -132,7 +130,7 @@ def check_quota():
 
         response = {
             "user_id": user_id,
-            "username": g.user.get("username"),
+            "username": username,
             "daily": {
                 "tokens": {
                     "used": today_tokens,
@@ -216,27 +214,23 @@ def get_quota_status():
             return jsonify({"error": "User not found"}), 404
 
         username = user.get("username", "")
-        # Use system_account for matching sender_name if available
-        # sender_name format: {system_account}-{hostname}-{tool}
-        system_account = user.get("system_account") or username
 
-        # Get today's usage combining local CLI and remote proxy
+        # Get today's usage — session-only (agent_sessions) per #1125: the Work
+        # page must not read the daily_messages analysis fact table.
         today = datetime.now().strftime("%Y-%m-%d")
-        today_combined = usage_repo.get_combined_usage(
+        today_combined = usage_repo.get_session_only_usage(
             user_id=user_id,
-            system_account=system_account,
             start_date=today,
             end_date=today,
         )
         today_requests = today_combined["requests"]
         today_tokens = today_combined["tokens"]
 
-        # Get monthly usage combining local CLI and remote proxy
+        # Get monthly usage — session-only (same #1125 rationale).
         now = datetime.now()
         month_start = now.replace(day=1).strftime("%Y-%m-%d")
-        monthly_combined = usage_repo.get_combined_usage(
+        monthly_combined = usage_repo.get_session_only_usage(
             user_id=user_id,
-            system_account=system_account,
             start_date=month_start,
             end_date=today,
         )
@@ -423,26 +417,22 @@ def webui_quota_check():
         if not user:
             return jsonify({"error": "User not found"}), 404
 
-        username = user.get("username", "")
-        system_account = user.get("system_account") or username
-
-        # Get today's usage combining local CLI and remote proxy
+        # Get today's usage — session-only (agent_sessions) per #1125: the Work
+        # page must not read the daily_messages analysis fact table.
         today = datetime.now().strftime("%Y-%m-%d")
-        today_combined = usage_repo.get_combined_usage(
+        today_combined = usage_repo.get_session_only_usage(
             user_id=user_id,
-            system_account=system_account,
             start_date=today,
             end_date=today,
         )
         today_requests = today_combined["requests"]
         today_tokens = today_combined["tokens"]
 
-        # Get monthly usage combining local CLI and remote proxy
+        # Get monthly usage — session-only (same #1125 rationale).
         now = datetime.now()
         month_start = now.replace(day=1).strftime("%Y-%m-%d")
-        monthly_combined = usage_repo.get_combined_usage(
+        monthly_combined = usage_repo.get_session_only_usage(
             user_id=user_id,
-            system_account=system_account,
             start_date=month_start,
             end_date=today,
         )

--- a/app/routes/workspace.py
+++ b/app/routes/workspace.py
@@ -737,6 +737,7 @@ def list_sessions():
                     "project_path": s.get("project_path"),
                     "workspace_type": s.get("workspace_type") or "local",
                     "remote_machine_id": s.get("remote_machine_id"),
+                    "cli_session_id": s.get("cli_session_id") or "",
                     "messages": [],
                 }
             )
@@ -1947,15 +1948,11 @@ def get_workspace_status():
                 tokens_limit = (user.get("daily_token_quota") or 1) * TOKEN_QUOTA_MULTIPLIER
                 requests_limit = user.get("daily_request_quota") or 1000
 
-                # Get user's system_account for filtering (sender_name format: {system_account}-{hostname}-{tool})
-                username = user.get("username", "")
-                system_account = user.get("system_account") or username
-
-                # Get today's usage combining local CLI (daily_messages) and remote proxy (quota_usage)
+                # Get today's usage — session-only (agent_sessions) per #1125:
+                # the Work page must not read the daily_messages analysis table.
                 usage_repo = UsageRepository()
-                combined = usage_repo.get_combined_usage(
+                combined = usage_repo.get_session_only_usage(
                     user_id=user_id,
-                    system_account=system_account,
                     start_date=today,
                     end_date=today,
                 )

--- a/frontend/src/api/sessions.ts
+++ b/frontend/src/api/sessions.ts
@@ -30,6 +30,7 @@ export interface AgentSession {
   project_path?: string;
   workspace_type?: 'local' | 'remote' | 'terminal';
   remote_machine_id?: string;
+  cli_session_id?: string;
   machine_name?: string;
   first_message?: string; // First user message preview (for tooltip)
   messages: SessionMessage[];

--- a/frontend/src/components/features/Sessions.tsx
+++ b/frontend/src/components/features/Sessions.tsx
@@ -594,7 +594,7 @@ const SessionCard: React.FC<SessionCardProps> = ({
       className={cn(
         'session-item card mb-2',
         isSelected && 'border-primary',
-        isImported && 'session-imported',
+        isImported && 'session-imported'
       )}
       onClick={onClick}
       style={{ cursor: 'pointer' }}

--- a/frontend/src/components/features/Sessions.tsx
+++ b/frontend/src/components/features/Sessions.tsx
@@ -580,7 +580,15 @@ const SessionCard: React.FC<SessionCardProps> = ({
   resumeRemoteMutation,
 }) => {
   const isRemote = session.workspace_type === 'remote';
-  const isImported = !session.cli_session_id && session.status === 'completed';
+  // A CLI-imported session: local + no cli_session_id + completed + no
+  // session_messages. cli_session_id is only written for local claude-code
+  // sessions at runtime, so without the workspace_type/message_count gates
+  // every completed remote/terminal session would be mis-flagged.
+  const isImported =
+    session.workspace_type === 'local' &&
+    !session.cli_session_id &&
+    session.status === 'completed' &&
+    (session.message_count ?? 0) === 0;
   return (
     <div
       className={cn(

--- a/frontend/src/components/features/Sessions.tsx
+++ b/frontend/src/components/features/Sessions.tsx
@@ -580,15 +580,15 @@ const SessionCard: React.FC<SessionCardProps> = ({
   resumeRemoteMutation,
 }) => {
   const isRemote = session.workspace_type === 'remote';
-  // A CLI-imported session: local + no cli_session_id + completed + no
-  // session_messages. cli_session_id is only written for local claude-code
-  // sessions at runtime, so without the workspace_type/message_count gates
-  // every completed remote/terminal session would be mis-flagged.
+  // A CLI-imported session: local + no cli_session_id + completed. The fetcher
+  // (scripts/fetch_*.py) never sets cli_session_id (not in its INSERT column
+  // list); the runtime runner backfills it for local claude-code sessions.
+  // workspace_type gates out remote/terminal (also empty cli_session_id).
+  // NOTE: deliberately NOT gated on message_count — the fetcher sets
+  // message_count>0 and inserts session_messages, so that gate would match
+  // nothing (false negatives). See #1272 review.
   const isImported =
-    session.workspace_type === 'local' &&
-    !session.cli_session_id &&
-    session.status === 'completed' &&
-    (session.message_count ?? 0) === 0;
+    session.workspace_type === 'local' && !session.cli_session_id && session.status === 'completed';
   return (
     <div
       className={cn(

--- a/frontend/src/components/features/Sessions.tsx
+++ b/frontend/src/components/features/Sessions.tsx
@@ -580,9 +580,14 @@ const SessionCard: React.FC<SessionCardProps> = ({
   resumeRemoteMutation,
 }) => {
   const isRemote = session.workspace_type === 'remote';
+  const isImported = !session.cli_session_id && session.status === 'completed';
   return (
     <div
-      className={cn('session-item card mb-2', isSelected && 'border-primary')}
+      className={cn(
+        'session-item card mb-2',
+        isSelected && 'border-primary',
+        isImported && 'session-imported',
+      )}
       onClick={onClick}
       style={{ cursor: 'pointer' }}
     >
@@ -614,6 +619,12 @@ const SessionCard: React.FC<SessionCardProps> = ({
               <Badge variant="info">
                 <i className="bi bi-cloud-fill me-1" />
                 {session.machine_name ?? 'Remote'}
+              </Badge>
+            )}
+            {isImported && (
+              <Badge variant="secondary">
+                <i className="bi bi-archive me-1" />
+                {t('cliImported', language)}
               </Badge>
             )}
           </div>

--- a/frontend/src/components/work/SessionList.tsx
+++ b/frontend/src/components/work/SessionList.tsx
@@ -169,8 +169,7 @@ export const SessionList: React.FC<SessionListProps> = ({ collapsed = false, onS
         isImported:
           session.workspace_type === 'local' &&
           !session.cli_session_id &&
-          session.status === 'completed' &&
-          (session.message_count ?? 0) === 0,
+          session.status === 'completed',
         firstMessage: session.first_message, // First user message preview
       };
 

--- a/frontend/src/components/work/SessionList.tsx
+++ b/frontend/src/components/work/SessionList.tsx
@@ -37,6 +37,7 @@ interface SessionItem {
   requests: number;
   workspace_type?: string;
   machine_name?: string;
+  isImported?: boolean; // CLI-imported session (no cli_session_id + completed)
   firstMessage?: string; // First user message preview (truncated to 100 chars)
 }
 
@@ -165,6 +166,7 @@ export const SessionList: React.FC<SessionListProps> = ({ collapsed = false, onS
         requests: session.request_count ?? 0,
         workspace_type: session.workspace_type,
         machine_name: session.machine_name,
+        isImported: !session.cli_session_id && session.status === 'completed',
         firstMessage: session.first_message, // First user message preview
       };
 
@@ -385,11 +387,13 @@ const SessionGroup: React.FC<SessionGroupProps> = ({
         {sessions.map((session) => (
           <li key={session.id}>
             <button
-              className={`session-item w-100 p-2 ${selectedSessionId === session.id ? 'selected' : ''}`}
+              className={`session-item w-100 p-2 ${selectedSessionId === session.id ? 'selected' : ''} ${session.isImported ? 'session-imported' : ''}`}
               onClick={() => onSessionClick(session.id)}
             >
               <span className="session-id text-truncate">
-                {session.workspace_type === 'terminal' ? (
+                {session.isImported ? (
+                  <i className="bi bi-archive text-muted me-1" title="本地 CLI 历史导入" />
+                ) : session.workspace_type === 'terminal' ? (
                   <i className="bi bi-terminal-fill text-info me-1" title="Web Terminal" />
                 ) : session.workspace_type === 'remote' ? (
                   <i

--- a/frontend/src/components/work/SessionList.tsx
+++ b/frontend/src/components/work/SessionList.tsx
@@ -166,7 +166,11 @@ export const SessionList: React.FC<SessionListProps> = ({ collapsed = false, onS
         requests: session.request_count ?? 0,
         workspace_type: session.workspace_type,
         machine_name: session.machine_name,
-        isImported: !session.cli_session_id && session.status === 'completed',
+        isImported:
+          session.workspace_type === 'local' &&
+          !session.cli_session_id &&
+          session.status === 'completed' &&
+          (session.message_count ?? 0) === 0,
         firstMessage: session.first_message, // First user message preview
       };
 
@@ -392,7 +396,7 @@ const SessionGroup: React.FC<SessionGroupProps> = ({
             >
               <span className="session-id text-truncate">
                 {session.isImported ? (
-                  <i className="bi bi-archive text-muted me-1" title="本地 CLI 历史导入" />
+                  <i className="bi bi-archive text-muted me-1" title={t('cliImported', language)} />
                 ) : session.workspace_type === 'terminal' ? (
                   <i className="bi bi-terminal-fill text-info me-1" title="Web Terminal" />
                 ) : session.workspace_type === 'remote' ? (

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -469,6 +469,7 @@ export const translations: Record<Language, Translations> = {
     restoreToWorkspace: 'Restore to Workspace',
     sessionRestored: 'Session restored to workspace',
     restoredSession: 'Restored Session',
+    cliImported: 'Local CLI History',
     // Issue #669: Session terminated recreation
     sessionTerminated: 'Session Process Terminated',
     sessionTerminatedCanResume:
@@ -1942,6 +1943,7 @@ export const translations: Record<Language, Translations> = {
     restoreToWorkspace: '恢复到工作区',
     sessionRestored: '会话已恢复到工作区',
     restoredSession: '恢复的会话',
+    cliImported: '本地 CLI 历史',
     // Issue #669: Session terminated recreation
     sessionTerminated: '会话进程已终止',
     sessionTerminatedCanResume: '检测到可恢复的对话历史，是否尝试恢复上下文？',
@@ -4083,6 +4085,7 @@ export const translations: Record<Language, Translations> = {
     toolAccountRequired: 'ツールアカウントは必須です',
     addToolAccountSuccess: 'ツールアカウントが正常に追加されました',
     addToolAccountFailed: 'ツールアカウントの追加に失敗しました',
+    cliImported: 'ローカル CLI 履歴',
   },
   ko: {
     // Common
@@ -5238,6 +5241,7 @@ export const translations: Record<Language, Translations> = {
     toolAccountRequired: '도구 계정은 필수입니다',
     addToolAccountSuccess: '도구 계정이 성공적으로 추가되었습니다',
     addToolAccountFailed: '도구 계정 추가 실패',
+    cliImported: '로컬 CLI 기록',
   },
 };
 

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -2497,6 +2497,16 @@ table .latency-row:hover td {
   border: 1px solid var(--color-primary);
 }
 
+/* CLI-imported sessions (no cli_session_id + completed) — muted to distinguish
+   from live WebUI/autonomous/remote sessions. */
+.session-item.session-imported {
+  opacity: 0.7;
+}
+.session-item.session-imported .session-id,
+.session-item.session-imported .session-title {
+  color: var(--text-secondary);
+}
+
 .session-item .session-title {
   flex: 1;
   min-width: 0;

--- a/tests/unit/test_usage_repo_session_only.py
+++ b/tests/unit/test_usage_repo_session_only.py
@@ -1,0 +1,63 @@
+"""Tests for UsageRepository.get_session_only_usage (#1269 P1).
+
+Pins that the Work-page quota display reads agent_sessions only and does NOT
+touch daily_messages, per the #1125 data-contract rule that analysis fact
+tables must not participate in Workspace runtime display.
+"""
+
+from unittest.mock import MagicMock
+
+from app.repositories.usage_repo import UsageRepository
+
+
+def _make_repo(db):
+    repo = UsageRepository()
+    repo.db = db
+    return repo
+
+
+class TestGetSessionOnlyUsage:
+    def test_does_not_query_daily_messages(self):
+        """The query must read agent_sessions and never daily_messages."""
+        db = MagicMock()
+        db.fetch_one.return_value = {"tokens": 12345, "requests": 7}
+        repo = _make_repo(db)
+
+        result = repo.get_session_only_usage(
+            user_id=1, start_date="2026-06-25", end_date="2026-06-25"
+        )
+
+        sql = db.fetch_one.call_args[0][0]
+        assert "FROM agent_sessions" in sql
+        assert "daily_messages" not in sql
+        # Must cover all workspace types (local autonomous/terminal/remote).
+        assert "workspace_type IN ('local', 'remote', 'terminal')" in sql
+        assert result["tokens"] == 12345
+        assert result["requests"] == 7
+        # local_* legs are zeroed since daily_messages is excluded.
+        assert result["local_tokens"] == 0
+        assert result["local_requests"] == 0
+
+    def test_zero_when_no_sessions(self):
+        db = MagicMock()
+        db.fetch_one.return_value = None
+        repo = _make_repo(db)
+
+        result = repo.get_session_only_usage(
+            user_id=1, start_date="2026-06-25", end_date="2026-06-25"
+        )
+
+        assert result["tokens"] == 0
+        assert result["requests"] == 0
+        assert result["local_tokens"] == 0
+
+    def test_scoped_to_user_and_date_range(self):
+        """The query must bind user_id and the date window."""
+        db = MagicMock()
+        db.fetch_one.return_value = {"tokens": 0, "requests": 0}
+        repo = _make_repo(db)
+
+        repo.get_session_only_usage(user_id=42, start_date="2026-06-01", end_date="2026-06-25")
+
+        params = db.fetch_one.call_args[0][1]
+        assert params == (42, "2026-06-01", "2026-06-25")


### PR DESCRIPTION
Closes #1269 (P1; P0-optional documented in the issue).

## Summary
Follow-up to #1125's quota-display residue and #1265. Two pre-existing issues the prior PR surfaced but left out of scope:

### P1-A: Work-page quota no longer reads `daily_messages`
Per the #1125 data contract, the analysis fact table (`daily_messages`) must not participate in Workspace runtime display — but the Work-scope quota endpoints did, via `UsageRepository.get_combined_usage` (which sums a `daily_messages` leg + an `agent_sessions` leg).

- Added `UsageRepository.get_session_only_usage` (agent_sessions only, `workspace_type IN local/remote/terminal`) — counts WebUI, autonomous, remote, and terminal sessions.
- Switched the Work-scope endpoints to it: `/api/workspace/status`, `/api/quota/status`, `/api/quota/check`, `/api/quota/webui-check`.
- **`get_combined_usage` is unchanged** — still serves the Manage page (`/api/admin/quota/usage`), which #1125 whitelists on the analysis tables.
- `/api/quota/usage/me` unchanged — it reads `user_daily_stats` (a derived stats table, #1125-allowed), not `daily_messages` directly.

### P1-B/C: CLI-imported sessions visually distinguished
- Exposed `cli_session_id` in the `/api/workspace/sessions` response (the column was read via `SELECT *` but dropped at serialization).
- `SessionList` (Work left panel) and `SessionCard` (/work/sessions) mark sessions where `cli_session_id == '' && status == 'completed'` with a muted style: `opacity: 0.7`, gray `bi-archive` icon, and a "Local CLI History" badge (`cliImported`).
- Composite-signal discriminator (per discussion) — no schema migration. Known negligible false-positive window (a WebUI session before runner backfill + completed) given the 1-min list refresh and that active sessions aren't `completed`.
- Added `cliImported` translations for en/zh/ja/ko.

### P0-optional: documented, no code change
The metering burst window is bounded by the `UserDailyStatsAggregator` interval, which is already tunable via `~/.open-ace/config.json` → `data_fetch.interval` (or env `DATA_FETCH_INTERVAL`), default 300s, min 60s. Per decision the default is unchanged. Documented in #1269.

## Tests
- `tests/unit/test_usage_repo_session_only.py` (3): pins that the Work query reads `agent_sessions` (all workspace types) and never `daily_messages`; binds user_id + date range.
- Regression: `test_quota_autonomous_metering.py`, `test_quota_stats.py`, `test_scheduler.py`, `test_autonomous_quota_gate.py` — all pass.
- Frontend: `tsc --noEmit` clean.

## Verification
\`\`\`bash
python3 -m pytest tests/unit/test_usage_repo_session_only.py tests/unit/test_quota_autonomous_metering.py tests/unit/test_quota_stats.py tests/issues/716/test_scheduler.py tests/issues/716/test_autonomous_quota_gate.py -q
# 43 passed
\`\`\`

## Risk
- **Work token/request counts drop** for pure local-CLI (non-session) historical traffic — expected per #1125 (analysis data out of Workspace runtime); still visible on the Manage page.
- No schema migration; no `daily_messages` writes.