### PR TITLE
fix(schema): single source of truth — load authoritative schema.sql (#1273)

### DIFF
--- a/app/modules/workspace/session_manager.py
+++ b/app/modules/workspace/session_manager.py
@@ -350,146 +350,22 @@ class SessionManager:
         return cursor.fetchone() is not None
 
     def _ensure_tables(self) -> None:
-        """Ensure required tables exist."""
-        conn = self._get_connection()
-        cursor = conn.cursor()
+        """Ensure required tables exist from the authoritative schema (#1273).
 
-        # Use SERIAL for PostgreSQL, AUTOINCREMENT for SQLite
-        id_type = "SERIAL PRIMARY KEY" if is_postgresql() else "INTEGER PRIMARY KEY AUTOINCREMENT"
+        Loads schema-sqlite.sql / schema-postgres.sql via the centralized
+        load_schema_from_file(), which is the single source of truth. This
+        replaces the former hand-maintained CREATE TABLE + alter_columns list
+        that had drifted from the authoritative schema (missing project_id,
+        project_path, request_count, etc.). Idempotent (CREATE IF NOT EXISTS).
+        """
+        from app.repositories.schema_init import load_schema_from_file
 
-        # Create agent_sessions table
-        cursor.execute(
-            f"""
-            CREATE TABLE IF NOT EXISTS agent_sessions (
-                id {id_type},
-                session_id TEXT NOT NULL UNIQUE,
-                session_type TEXT DEFAULT 'chat',
-                title TEXT,
-                tool_name TEXT NOT NULL,
-                host_name TEXT DEFAULT 'localhost',
-                user_id INTEGER,
-                status TEXT DEFAULT 'active',
-                context TEXT,
-                settings TEXT,
-                total_tokens INTEGER DEFAULT 0,
-                total_input_tokens INTEGER DEFAULT 0,
-                total_output_tokens INTEGER DEFAULT 0,
-                message_count INTEGER DEFAULT 0,
-                model TEXT,
-                tags TEXT,
-                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                completed_at TIMESTAMP,
-                expires_at TIMESTAMP,
-                cli_session_id TEXT DEFAULT ''
-            )
-        """
-        )
-
-        # Create session_messages table
-        cursor.execute(
-            f"""
-            CREATE TABLE IF NOT EXISTS session_messages (
-                id {id_type},
-                session_id TEXT NOT NULL,
-                role TEXT NOT NULL,
-                content TEXT,
-                tokens_used INTEGER DEFAULT 0,
-                model TEXT,
-                timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                source_timestamp TIMESTAMP,
-                metadata TEXT,
-                milestone_id TEXT DEFAULT '',
-                source TEXT DEFAULT '',
-                external_message_id TEXT DEFAULT '',
-                content_blocks TEXT,
-                FOREIGN KEY (session_id) REFERENCES agent_sessions(session_id)
-            )
-        """
-        )
-
-        # Create indexes
-        cursor.execute(
-            """
-            CREATE INDEX IF NOT EXISTS idx_agent_sessions_session_id
-            ON agent_sessions(session_id)
-        """
-        )
-        cursor.execute(
-            """
-            CREATE INDEX IF NOT EXISTS idx_agent_sessions_user_id
-            ON agent_sessions(user_id)
-        """
-        )
-        cursor.execute(
-            """
-            CREATE INDEX IF NOT EXISTS idx_agent_sessions_status
-            ON agent_sessions(status)
-        """
-        )
-        cursor.execute(
-            """
-            CREATE INDEX IF NOT EXISTS idx_agent_sessions_tool_name
-            ON agent_sessions(tool_name)
-        """
-        )
-        cursor.execute(
-            """
-            CREATE INDEX IF NOT EXISTS idx_session_messages_session_id
-            ON session_messages(session_id)
-        """
-        )
-
-        # Add remote workspace columns if not present.
-        # Use a check-first strategy so PostgreSQL never enters a failed
-        # transaction (a single "column already exists" error aborts the whole
-        # transaction in PG and breaks subsequent statements). SQLite tolerates
-        # the try/except fallback, but check-first works for both backends.
-        alter_columns = [
-            ("agent_sessions", "workspace_type", "TEXT DEFAULT 'local'"),
-            ("agent_sessions", "remote_machine_id", "TEXT"),
-            ("agent_sessions", "request_count", "INTEGER DEFAULT 0"),
-            ("agent_sessions", "paused_at", "TIMESTAMP"),
-            ("agent_sessions", "cli_session_id", "TEXT DEFAULT ''"),
-            # project_id / project_path are in the authoritative schema files
-            # (schema-sqlite.sql / schema-postgres.sql) and added by Alembic on
-            # real DBs, but were missing from this bootstrap CREATE TABLE, so a
-            # fresh SQLite-only DB (and SessionManager tests) hit "no such column"
-            # on create_session()'s INSERT. Add them here for parity (#723).
-            ("agent_sessions", "project_id", "INTEGER"),
-            ("agent_sessions", "project_path", "TEXT"),
-            ("session_messages", "milestone_id", "TEXT DEFAULT '' NOT NULL"),
-            ("session_messages", "source_timestamp", "TIMESTAMP"),
-            ("session_messages", "source", "TEXT DEFAULT '' NOT NULL"),
-            ("session_messages", "external_message_id", "TEXT DEFAULT ''"),
-            ("session_messages", "content_blocks", "TEXT"),
-        ]
-        for table, column, definition in alter_columns:
-            if not self._column_exists(cursor, table, column):
-                cursor.execute(f"ALTER TABLE {table} ADD COLUMN {column} {definition}")
-
-        # Add newer indexes only when missing (CREATE INDEX IF NOT EXISTS is
-        # also valid on both backends, but check-first keeps PG transactions
-        # healthy when a prior statement in another caller failed).
-        if not self._index_exists(
-            cursor, "session_messages", "idx_session_messages_external_message_id"
-        ):
-            cursor.execute(
-                """
-                CREATE INDEX idx_session_messages_external_message_id
-                ON session_messages(session_id, external_message_id)
-            """
-            )
-        if not self._index_exists(cursor, "session_messages", "idx_session_messages_source"):
-            cursor.execute(
-                """
-                CREATE INDEX idx_session_messages_source
-                ON session_messages(session_id, source)
-            """
-            )
-
-        conn.commit()
-        conn.close()
+        # Pin the dialect from THIS module's is_postgresql (tests monkeypatch it
+        # here, not in schema_init.database), and convert the sqlite db_path to a
+        # db_url. Postgres relies on DATABASE_URL (db_url=None).
+        dialect = "postgresql" if is_postgresql() else "sqlite"
+        db_url = f"sqlite:///{self.db_path}" if dialect == "sqlite" and self.db_path else None
+        load_schema_from_file(db_url=db_url, dialect=dialect)
 
     @staticmethod
     def _extract_external_message_id(metadata: Optional[dict[str, Any]]) -> str:

--- a/app/repositories/schema_init.py
+++ b/app/repositories/schema_init.py
@@ -5,64 +5,132 @@ replacing the per-request _ensure_tables() pattern that caused ShareLock
 contention on PostgreSQL.
 """
 
+from __future__ import annotations
+
 import logging
+import re
+from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+_SCHEMA_FILES = {
+    "sqlite": _PROJECT_ROOT / "schema" / "schema-sqlite.sql",
+    "postgresql": _PROJECT_ROOT / "schema" / "schema-postgres.sql",
+}
+
+# Match "CREATE TABLE <name>" and "CREATE [UNIQUE] INDEX <name>", case-insensitive,
+# so we can rewrite them to their IF NOT EXISTS form without editing schema.sql
+# itself (the authoritative .sql files are consumed as-is by Alembic and must not
+# gain IF NOT EXISTS there). This makes load_schema_from_file idempotent on a DB
+# that already has the tables.
+_CREATE_TABLE_RE = re.compile(r"^(\s*CREATE\s+TABLE\s+)(?!IF\s+NOT\s+EXISTS)", re.IGNORECASE)
+_CREATE_INDEX_RE = re.compile(
+    r"^(\s*CREATE\s+(?:UNIQUE\s+)?INDEX\s+)(?!IF\s+NOT\s+EXISTS)", re.IGNORECASE
+)
+
+
+def _make_idempotent(sql_text: str) -> str:
+    """Rewrite CREATE TABLE/INDEX to their IF NOT EXISTS form.
+
+    The authoritative schema files (schema-sqlite.sql / schema-postgres.sql) are
+    written for a one-shot bootstrap of an EMPTY database (Alembic baseline), so
+    their CREATE statements lack IF NOT EXISTS. Re-running them on a DB that
+    already has the tables would error. This rewrites each CREATE to be safe to
+    re-run, so load_schema_from_file is idempotent (production startup, tests).
+    """
+    out_lines = []
+    for line in sql_text.splitlines(keepends=True):
+        if _CREATE_TABLE_RE.match(line):
+            line = _CREATE_TABLE_RE.sub(r"\1IF NOT EXISTS ", line, count=1)
+        elif _CREATE_INDEX_RE.match(line):
+            line = _CREATE_INDEX_RE.sub(r"\1IF NOT EXISTS ", line, count=1)
+        out_lines.append(line)
+    return "".join(out_lines)
+
+
+def _iter_pg_statements(sql_text: str):
+    """Yield top-level statements from a SQL script (split on ';'-terminated lines).
+
+    Mirrors migrations/baseline.iter_sql_statements: the schema files only contain
+    plain DDL terminated by line-ending semicolons, so line-based splitting is safe.
+    """
+    buffer = []
+    for line in sql_text.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("--"):
+            continue
+        buffer.append(line)
+        if stripped.endswith(";"):
+            yield "\n".join(buffer)
+            buffer = []
+    if buffer:
+        yield "\n".join(buffer)
+
+
+def schema_file_for_dialect(dialect: str) -> Path:
+    """Return the authoritative schema .sql path for a dialect."""
+    path = _SCHEMA_FILES.get(dialect)
+    if not path:
+        raise ValueError(f"Unsupported dialect for schema file: {dialect}")
+    return path
+
+
+def load_schema_from_file(db_url: str | None = None, dialect: str | None = None) -> None:
+    """Load the authoritative schema .sql as the single source of truth (#1273).
+
+    Replaces both the per-module get_ddl_statements() aggregation and
+    SessionManager._ensure_tables(): both had drifted from the authoritative
+    schema files (missing columns like project_id/project_path/request_count).
+    This reads schema-{sqlite,postgres}.sql, makes the CREATE statements
+    idempotent (IF NOT EXISTS), and executes them — so every table carries the
+    full, authoritative column set with no parallel hand-maintained DDL.
+
+    ``dialect`` lets a caller (e.g. SessionManager._ensure_tables under a
+    monkeypatched is_postgresql) pin the dialect explicitly; otherwise it's
+    derived from the current DATABASE_URL.
+
+    For sqlite the whole script runs via executescript; for postgres statements
+    run one-by-one (each wrapped in try/except so a CREATE on an existing object
+    is a no-op rather than aborting the whole script).
+    """
+    from app.repositories.database import Database, is_postgresql
+
+    if dialect is None:
+        dialect = "postgresql" if is_postgresql() else "sqlite"
+    sql_text = schema_file_for_dialect(dialect).read_text(encoding="utf-8")
+    sql_text = _make_idempotent(sql_text)
+    db = Database(db_url=db_url)
+    conn = db.get_connection()
+    try:
+        if db.is_postgresql:
+            cursor = conn.cursor()
+            for stmt in _iter_pg_statements(sql_text):
+                try:
+                    cursor.execute(stmt)
+                except Exception as e:  # noqa: BLE001 - idempotent DDL tolerates "already exists"
+                    logger.debug("Schema DDL skipped: %s — %s", stmt[:80].strip(), e)
+            conn.commit()
+        else:
+            conn.executescript(sql_text)  # sqlite: whole-script, IF NOT EXISTS makes it safe
+            conn.commit()
+    finally:
+        conn.close()
+
 
 def ensure_all_tables() -> None:
-    """Ensure all application tables and indexes exist.
+    """Ensure all application tables and indexes exist (single source of truth).
 
-    Executes all DDL statements from each module's get_ddl_statements().
-    Called once at startup from create_app(). Each statement is wrapped in
-    try/except so that ALTER TABLE "column already exists" errors are silently
-    handled.
+    Loads the authoritative schema files (schema-sqlite.sql / schema-postgres.sql)
+    via load_schema_from_file(). This replaces the former per-module
+    get_ddl_statements() aggregation, which had drifted from the authoritative
+    schema (each module hand-maintained a parallel DDL that lost columns like
+    project_id/project_path/request_count — #1273).
+
+    The per-module get_ddl_statements() functions are kept for now (deprecated;
+    not called here) to avoid breaking any external references and may be
+    removed in a follow-up. Schema is now driven solely by the .sql files +
+    Alembic migrations.
     """
-    from app.modules.compliance.report import get_ddl_statements as report_ddl
-    from app.modules.compliance.retention import get_ddl_statements as ret_ddl
-    from app.modules.governance.audit_logger import get_ddl_statements as audit_ddl
-    from app.modules.sso.manager import get_ddl_statements as sso_ddl
-    from app.modules.workspace.api_key_proxy import get_ddl_statements as akp_ddl
-    from app.modules.workspace.autonomous import get_ddl_statements as auto_ddl
-    from app.modules.workspace.collaboration import get_ddl_statements as collab_ddl
-    from app.modules.workspace.prompt_library import get_ddl_statements as pl_ddl
-    from app.modules.workspace.remote_agent_manager import get_ddl_statements as ram_ddl
-    from app.modules.workspace.session_manager import get_ddl_statements as sm_ddl
-    from app.repositories.database import Database
-    from app.services.auth_service import get_ddl_statements as auth_ddl
-    from app.services.permission_service import get_ddl_statements as ps_ddl
-
-    all_ddl = []
-    for ddl_fn in [
-        sm_ddl,
-        collab_ddl,
-        pl_ddl,
-        akp_ddl,
-        ram_ddl,
-        auto_ddl,
-        audit_ddl,
-        sso_ddl,
-        ret_ddl,
-        ps_ddl,
-        report_ddl,
-        auth_ddl,
-    ]:
-        try:
-            all_ddl.extend(ddl_fn())
-        except Exception as e:
-            logger.warning("Failed to get DDL from %s: %s", ddl_fn.__module__, e)
-
-    if not all_ddl:
-        return
-
-    db = Database()
-    with db.connection() as conn:
-        cursor = conn.cursor()
-        for sql in all_ddl:
-            try:
-                cursor.execute(sql)
-            except Exception as e:
-                logger.debug("DDL skipped (expected for ALTER TABLE): %s — %s", sql[:80].strip(), e)
-        conn.commit()
-
-    logger.info("Schema initialization complete (%d DDL statements executed)", len(all_ddl))
+    load_schema_from_file()
+    logger.info("Schema initialization complete (loaded from authoritative schema.sql)")

--- a/tests/issues/1273/test_schema_single_source.py
+++ b/tests/issues/1273/test_schema_single_source.py
@@ -1,0 +1,143 @@
+"""Tests for schema single-source-of-truth (#1273).
+
+Guards against the "shadow schema" drift that plagued SessionManager and
+ensure_all_tables: both had hand-maintained CREATE TABLE statements that lost
+columns present in the authoritative schema.sql (project_id, project_path,
+request_count, ...). These tests assert the new load_schema_from_file() path
+builds the FULL authoritative schema, and that re-running it is idempotent.
+"""
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from app.repositories.schema_init import (
+    _make_idempotent,
+    load_schema_from_file,
+    schema_file_for_dialect,
+)
+
+
+def _table_columns(conn, table):
+    return {row[1] for row in conn.execute(f"PRAGMA table_info({table})").fetchall()}
+
+
+def _all_tables(conn):
+    return {
+        row[0]
+        for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
+    }
+
+
+class TestMakeIdempotent:
+    def test_create_table_gets_if_not_exists(self):
+        out = _make_idempotent("CREATE TABLE foo (id INTEGER);\n")
+        assert "CREATE TABLE IF NOT EXISTS foo" in out
+
+    def test_create_index_gets_if_not_exists(self):
+        out = _make_idempotent("CREATE INDEX idx ON foo(id);\n")
+        assert "CREATE INDEX IF NOT EXISTS idx" in out
+
+    def test_create_unique_index_gets_if_not_exists(self):
+        out = _make_idempotent("CREATE UNIQUE INDEX idx ON foo(id);\n")
+        assert "CREATE UNIQUE INDEX IF NOT EXISTS idx" in out
+
+    def test_already_idempotent_unchanged(self):
+        sql = "CREATE TABLE IF NOT EXISTS foo (id INTEGER);\n"
+        assert _make_idempotent(sql) == sql
+
+    def test_non_create_lines_untouched(self):
+        sql = "INSERT INTO foo VALUES (1);\n-- a comment\n"
+        assert _make_idempotent(sql) == sql
+
+
+class TestLoadSchemaFromFile:
+    def test_builds_all_authoritative_tables(self, tmp_path):
+        """load_schema_from_file creates all tables from schema-sqlite.sql."""
+        db_file = tmp_path / "test.db"
+        load_schema_from_file(db_url=f"sqlite:///{db_file}", dialect="sqlite")
+        conn = sqlite3.connect(str(db_file))
+        tables = _all_tables(conn)
+        conn.close()
+        # Spot-check a representative set across modules.
+        for required in (
+            "agent_sessions",
+            "session_messages",
+            "autonomous_workflows",
+            "users",
+            "workflow_milestones",
+        ):
+            assert required in tables, f"{required} table missing"
+
+    def test_agent_sessions_has_drifted_columns(self, tmp_path):
+        """The columns that were lost to shadow-schema drift are present."""
+        db_file = tmp_path / "test.db"
+        load_schema_from_file(db_url=f"sqlite:///{db_file}", dialect="sqlite")
+        conn = sqlite3.connect(str(db_file))
+        cols = _table_columns(conn, "agent_sessions")
+        conn.close()
+        for col in ("project_id", "project_path", "request_count", "cli_session_id"):
+            assert col in cols, f"agent_sessions.{col} missing (shadow-schema drift)"
+
+    def test_idempotent_re_run(self, tmp_path):
+        """Re-running on an existing DB is a no-op (CREATE IF NOT EXISTS)."""
+        db_file = tmp_path / "test.db"
+        load_schema_from_file(db_url=f"sqlite:///{db_file}", dialect="sqlite")
+        # Second run must not raise even though all tables exist.
+        load_schema_from_file(db_url=f"sqlite:///{db_file}", dialect="sqlite")
+        conn = sqlite3.connect(str(db_file))
+        assert "agent_sessions" in _all_tables(conn)
+        conn.close()
+
+
+class TestEnsureTablesMatchesSchema:
+    """SessionManager._ensure_tables() must produce the same columns as schema.sql
+    — the core anti-drift guarantee of #1273."""
+
+    def test_session_manager_columns_match_schema_sql(self, tmp_path, monkeypatch):
+        import app.modules.workspace.session_manager as sm_mod
+        from app.modules.workspace.session_manager import SessionManager
+
+        monkeypatch.setattr(sm_mod, "is_postgresql", lambda: False)
+        db_file = tmp_path / "sm.db"
+        sm = SessionManager(db_path=str(db_file))
+        sm._ensure_tables()
+
+        conn = sqlite3.connect(str(db_file))
+        sm_cols = _table_columns(conn, "agent_sessions")
+        conn.close()
+
+        # Reference: columns directly from schema-sqlite.sql.
+        schema_sql = schema_file_for_dialect("sqlite").read_text(encoding="utf-8")
+        # Parse column names from the agent_sessions CREATE TABLE block.
+        schema_cols = set()
+        in_block = False
+        for line in schema_sql.splitlines():
+            stripped = line.strip()
+            if stripped.startswith("CREATE TABLE agent_sessions"):
+                in_block = True
+                continue
+            if in_block:
+                if stripped.startswith(")"):
+                    break
+                # column line: " name type ..."
+                first = stripped.split()[0] if stripped.split() else ""
+                if first and not first.startswith("PRIMARY") and not first.startswith("FOREIGN"):
+                    schema_cols.add(first)
+
+        # _ensure_tables columns must be a superset of schema.sql columns.
+        missing = schema_cols - sm_cols
+        assert not missing, f"_ensure_tables() is missing columns vs schema.sql: {missing}"
+
+
+class TestSchemaFileForDialect:
+    def test_sqlite_path_exists(self):
+        assert schema_file_for_dialect("sqlite").exists()
+
+    def test_postgres_path_exists(self):
+        assert schema_file_for_dialect("postgresql").exists()
+
+    def test_unknown_dialect_raises(self):
+        with pytest.raises(ValueError):
+            schema_file_for_dialect("mysql")


### PR DESCRIPTION
Closes #1273.

## Summary

Eliminates the two "shadow schema" code paths that drifted from the authoritative `schema/schema-sqlite.sql` / `schema/schema-postgres.sql`:

- **`SessionManager._ensure_tables()`** — a hand-maintained `CREATE TABLE` + `alter_columns` list (test-only caller) that was missing `project_id`/`project_path`/`request_count` until a #1270 patch added them piecemeal.
- **`ensure_all_tables()` + 12 per-module `get_ddl_statements()`** — the production startup path, where each module hand-maintained parallel DDL that lost the same columns.

Both now delegate to a new **`load_schema_from_file()`** in `schema_init.py`, which reads the authoritative schema `.sql` files (already the single source Alembic consumes), rewrites `CREATE` → `CREATE IF NOT EXISTS` for idempotency, and executes them (sqlite `executescript` / postgres statement-by-statement with try/except).

### Why this is safe for production
- The authoritative `.sql` files lack `IF NOT EXISTS` (they're written for a one-shot bootstrap of an empty DB via Alembic baseline). `load_schema_from_file` rewrites them in-memory (not editing the files Alembic reads), so re-running on a DB that already has the tables is idempotent.
- **Verified on the live postgres DB**: `load_schema_from_file()` ran clean (all `CREATE IF NOT EXISTS` no-ops), no startup breakage.
- `ensure_all_tables()` still runs once at `create_app()`; behavior unchanged except it now builds the *full* authoritative schema.

### Changes
- `app/repositories/schema_init.py`: `load_schema_from_file()` (new) + `_make_idempotent`/`_iter_pg_statements`/`schema_file_for_dialect` helpers; `ensure_all_tables()` reduced to a one-liner calling it.
- `app/modules/workspace/session_manager.py`: `_ensure_tables()` reduced from ~140 lines of hardcoded DDL to ~10 lines delegating to `load_schema_from_file` (pins dialect from the module's `is_postgresql` so test monkeypatches work; converts sqlite `db_path` → `db_url`).
- `tests/issues/1273/test_schema_single_source.py` (new, 12 tests): schema builds all tables, drifted columns present, idempotent re-run, `_ensure_tables()` columns match schema.sql (anti-drift guard), idempotency of `_make_idempotent`.

### Test results
- `tests/issues/1273/`: **12 passed**
- Full backend `pytest -q`: **2163 passed, 1 skipped** — 0 failures. (Bonus: the 17 pre-existing `test_workspace_modules` integration failures on `main` now pass too, because `ensure_all_tables()` builds the full schema those tests expected.)
- `pre-commit run --all-files`: all green.

### Out of scope (follow-up)
- The 12 per-module `get_ddl_statements()` functions are kept (deprecated, no longer called by `ensure_all_tables`) to avoid a large diff; a follow-up can delete them.
- Bypass modules with their own `_ensure_tables()` (state_sync, alert_notifier, etc.) are not yet migrated — they build tables also present in schema.sql, so they're now redundant but harmless; can be收口 separately.