### PR TITLE
fix(cutover): recognize post-baseline revisions so head DBs upgrade cleanly

### DIFF
--- a/migrations/baseline.py
+++ b/migrations/baseline.py
@@ -17,6 +17,7 @@ HEAD_REVISION = "001_fix_auto_provision"
 
 _PROJECT_ROOT = Path(__file__).resolve().parents[1]
 _BASELINE_SCHEMA_DIR = _PROJECT_ROOT / "schema" / "baselines"
+ACTIVE_MIGRATIONS_DIR = _PROJECT_ROOT / "migrations" / "versions"
 LEGACY_MIGRATIONS_DIR = _PROJECT_ROOT / "migrations" / "legacy_versions"
 
 

--- a/scripts/cutover_alembic_baseline.py
+++ b/scripts/cutover_alembic_baseline.py
@@ -15,6 +15,7 @@ if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
 from migrations.baseline import (
+    ACTIVE_MIGRATIONS_DIR,
     BASELINE_REVISION,
     LEGACY_MIGRATIONS_DIR,
     read_current_revision,
@@ -54,6 +55,29 @@ def collect_legacy_revision_ids() -> set[str]:
         return revision_ids
 
     for path in LEGACY_MIGRATIONS_DIR.rglob("*.py"):
+        text = path.read_text(encoding="utf-8")
+        match = _REVISION_RE.search(text) or _REVISION_RE_FALLBACK.search(text)
+        if match:
+            revision_ids.add(match.group(1))
+
+    return revision_ids
+
+
+def collect_active_revision_ids() -> set[str]:
+    """Collect revision identifiers from the active post-baseline lineage.
+
+    Mirrors :func:`collect_legacy_revision_ids` but scans the live
+    ``migrations/versions`` directory. The baseline migration pins its
+    ``revision`` to the ``BASELINE_REVISION`` symbol rather than a literal, so
+    its identifier is not picked up here; the caller unions the baseline in
+    explicitly. This keeps the active-revision allowlist self-maintaining as
+    new post-baseline migrations ship.
+    """
+    revision_ids: set[str] = set()
+    if not ACTIVE_MIGRATIONS_DIR.exists():
+        return revision_ids
+
+    for path in ACTIVE_MIGRATIONS_DIR.glob("*.py"):
         text = path.read_text(encoding="utf-8")
         match = _REVISION_RE.search(text) or _REVISION_RE_FALLBACK.search(text)
         if match:
@@ -407,7 +431,13 @@ def ensure_compliance_reports_table(connection: sa.Connection) -> bool:
 
 def cutover_database(connection: sa.Connection, *, dry_run: bool = False) -> tuple[bool, list[str]]:
     """Cut over a legacy database to the baseline revision."""
-    active_revisions = {BASELINE_REVISION}
+    # The active lineage includes the baseline plus every post-baseline
+    # revision in migrations/versions/. A DB already migrated to head (or any
+    # post-baseline revision) is on a known-good revision, so cutover treats
+    # it as a no-op and lets `alembic upgrade head` advance it the rest of the
+    # way. This must be derived from the live migration directory, not
+    # hard-coded, so new post-baseline migrations do not trip the refusal guard.
+    active_revisions = collect_active_revision_ids() | {BASELINE_REVISION}
     legacy_revisions = collect_legacy_revision_ids()
     actions: list[str] = []
 

--- a/tests/unit/test_alembic_baseline_cutover.py
+++ b/tests/unit/test_alembic_baseline_cutover.py
@@ -13,8 +13,8 @@ from contextlib import contextmanager
 import pytest
 import sqlalchemy as sa
 
-from migrations.baseline import BASELINE_REVISION, read_current_revision
-from scripts.cutover_alembic_baseline import cutover_database
+from migrations.baseline import BASELINE_REVISION, HEAD_REVISION, read_current_revision
+from scripts.cutover_alembic_baseline import collect_active_revision_ids, cutover_database
 
 
 def _postgres_server_binaries_available() -> bool:
@@ -167,8 +167,9 @@ def test_cutover_stamps_legacy_sqlite_and_backfills_latest_baseline_artifacts(tm
     assert "source" in session_columns
 
 
-def test_cutover_skips_active_revision_when_schema_complete(tmp_path):
-    """A DB already on baseline with all current objects is a no-op."""
+@pytest.mark.parametrize("revision", [BASELINE_REVISION, HEAD_REVISION])
+def test_cutover_skips_active_revision_when_schema_complete(tmp_path, revision):
+    """A DB already on baseline or any post-baseline revision is a no-op."""
     db_path = tmp_path / "active.db"
     conn = sqlite3.connect(db_path)
     conn.executescript(
@@ -203,7 +204,7 @@ def test_cutover_skips_active_revision_when_schema_complete(tmp_path):
         CREATE TABLE tool_account_mapping_rules (id INTEGER PRIMARY KEY);
         CREATE TABLE compliance_reports (id INTEGER PRIMARY KEY);
         CREATE TABLE alembic_version (version_num TEXT PRIMARY KEY);
-        INSERT INTO alembic_version(version_num) VALUES ('{BASELINE_REVISION}');
+        INSERT INTO alembic_version(version_num) VALUES ('{revision}');
         """
     )
     conn.commit()
@@ -217,7 +218,7 @@ def test_cutover_skips_active_revision_when_schema_complete(tmp_path):
         engine.dispose()
 
     assert changed is False
-    assert actions == [f"already on active revision {BASELINE_REVISION}"]
+    assert actions == [f"already on active revision {revision}"]
 
 
 def test_cutover_active_revision_backfills_newly_absorbed_objects(tmp_path):
@@ -304,6 +305,25 @@ def test_cutover_rejects_unknown_revision(tmp_path):
                 cutover_database(connection)
     finally:
         engine.dispose()
+
+
+def test_collect_active_revision_ids_includes_post_baseline_lineage():
+    """The active-lineage allowlist must cover post-baseline revisions.
+
+    Regression guard for the failure where the cutover refusal guard hard-coded
+    only the baseline revision: DBs already migrated to head were rejected.
+    The collector scans the live migrations/versions directory, so new
+    post-baseline migrations are picked up without editing the cutover script.
+    """
+    active_ids = collect_active_revision_ids()
+
+    # The post-baseline head (added by the auto_provision_users fix) must be
+    # recognised as an active revision so a head-stamped DB is a cutover no-op.
+    assert HEAD_REVISION in active_ids
+    # The baseline pins its revision to the BASELINE_REVISION symbol rather
+    # than a literal, so the collector does not surface it; the caller unions
+    # it in explicitly. Legacy ids must never leak into the active set.
+    assert BASELINE_REVISION not in active_ids
 
 
 def test_cutover_dry_run_reports_actions_without_mutating_schema(tmp_path):


### PR DESCRIPTION
## Problem

`scripts/cutover_alembic_baseline.py` hard-coded the active-revision allowlist to `{BASELINE_REVISION}`. After #1266 shipped migration `001_fix_auto_provision` and bumped `HEAD_REVISION`, any database already migrated to head was rejected as an unknown revision:

```
RuntimeError: Refusing cutover from unknown revision '001_fix_auto_provision';
inspect the database before rewriting alembic_version.
```

This blocked `update-open-ace.sh` (and the package/Docker install paths) at the baseline-cutover step for any environment that had already run `alembic upgrade head`.

## Root cause

`cutover_database()` built the known-good revision set from only the baseline:

```python
active_revisions = {BASELINE_REVISION}   # baseline only
```

The refusal guard then raises for any revision that is neither a legacy revision nor the baseline. There was no active-lineage collector (only `collect_legacy_revision_ids()` scanning `legacy_versions/`), so the allowlist silently fell behind whenever a new post-baseline migration shipped.

## Fix

Make the allowlist self-maintaining, mirroring the existing legacy collector.

- **`migrations/baseline.py`**: add `ACTIVE_MIGRATIONS_DIR` (`migrations/versions`).
- **`scripts/cutover_alembic_baseline.py`**: add `collect_active_revision_ids()` (scans `migrations/versions`, same regexes as the legacy collector) and build the allowlist as `collect_active_revision_ids() | {BASELINE_REVISION}`. The baseline migration pins its `revision` to the `BASELINE_REVISION` symbol rather than a literal, so its id is not picked up by the collector and is unioned in explicitly — exactly as before. Also fix the file mode to executable to match its shebang and sibling scripts (caught by a pre-commit hook).
- **`tests/unit/test_alembic_baseline_cutover.py`**: parametrize the active-revision no-op test over `[baseline, head]` (covers the exact regression) and add a unit test for `collect_active_revision_ids()`.

A DB already at head now takes the no-op branch (`already on active revision 001_fix_auto_provision`), and `alembic upgrade head` is a clean no-op for it. Support for pre-baseline databases is unchanged.

## Verification

- `pytest tests/unit/test_alembic_baseline_cutover.py -q` → 9 passed
- `../update-open-ace.sh --skip-pull` end-to-end → cutover reports `already on active revision 001_fix_auto_provision`, alembic upgrade, frontend build, and service restart all succeed.

## Notes

This does **not** remove the cutover script; it preserves support for pre-baseline databases. Full cutover removal is tracked separately in #1215 (conditional on all supported environments having crossed the baseline).