### PR TITLE
Fix autonomous workflow session topology drift

### DIFF
--- a/app/modules/workspace/autonomous/agent_runner.py
+++ b/app/modules/workspace/autonomous/agent_runner.py
@@ -571,6 +571,51 @@ class AutonomousAgentRunner:
         return workspace_type == "local" and cli_tool == "claude-code"
 
     @staticmethod
+    def _extract_stream_session_id(parsed: dict[str, Any]) -> str:
+        """Best-effort extraction of Claude's real session_id from a stream event."""
+        if not isinstance(parsed, dict):
+            return ""
+
+        candidates: list[Any] = [parsed.get("session_id")]
+        response = parsed.get("response", {}) or {}
+        if isinstance(response, dict):
+            candidates.append(response.get("session_id"))
+            inner_response = response.get("response", {}) or {}
+            if isinstance(inner_response, dict):
+                candidates.append(inner_response.get("session_id"))
+
+        for candidate in candidates:
+            session_id = str(candidate or "").strip()
+            if session_id:
+                return session_id
+        return ""
+
+    def _capture_cli_session_id(
+        self,
+        session: _LocalSession,
+        parsed: dict[str, Any],
+        source: str,
+    ) -> str:
+        """Persist the authoritative Claude session_id when the stream exposes it."""
+        if not self._uses_sidebar_session_source(session.cli_tool, session.workspace_type):
+            return ""
+
+        cli_session_id = self._extract_stream_session_id(parsed)
+        if not cli_session_id:
+            return ""
+
+        if cli_session_id != session.cli_session_id:
+            session.cli_session_id = cli_session_id
+            logger.info(
+                "Captured Claude session_id from %s (workflow=%s tracking=%s cli=%s)",
+                source,
+                session.workflow_id,
+                (session.session_id or "")[:8],
+                cli_session_id[:8],
+            )
+        return cli_session_id
+
+    @staticmethod
     def _encode_project_path(project_path: str) -> str:
         """Best-effort match for the encoded project path used by Claude session history.
 
@@ -2270,6 +2315,7 @@ class AutonomousAgentRunner:
                             )
 
                     elif msg_type == "result":
+                        self._capture_cli_session_id(session, parsed, "result")
                         # End of turn - extract usage via shared parser.
                         # request_count is counted per assistant message_id above
                         # (not here), since one --print result summarizes all turns.
@@ -2303,6 +2349,10 @@ class AutonomousAgentRunner:
                                 },
                             )
 
+                    elif msg_type in {"system", "initialized"}:
+                        if msg_type == "initialized" or parsed.get("subtype") == "initialized":
+                            self._capture_cli_session_id(session, parsed, "system.initialized")
+
                     elif msg_type == "control_response":
                         # Capture the real Claude session_id from the SDK
                         # initialize response (mirrors remote executor.py).
@@ -2312,11 +2362,12 @@ class AutonomousAgentRunner:
                             and resp.get("request_id") == session.init_request_id
                         ):
                             if resp.get("subtype") == "success":
-                                inner = resp.get("response", {}) or {}
-                                cli_sid = inner.get("session_id", "")
-                                if cli_sid and not session.cli_session_id:
-                                    session.cli_session_id = cli_sid
-                                elif not cli_sid and not session.cli_session_id:
+                                cli_sid = self._capture_cli_session_id(
+                                    session,
+                                    parsed,
+                                    "control_response.initialize",
+                                )
+                                if not cli_sid and not session.cli_session_id:
                                     # Initialize succeeded but no session_id — the
                                     # SDK response shape may have changed. Log so the
                                     # mtime fallback (next resort) is traceable rather

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -1027,20 +1027,21 @@ class AutonomousOrchestrator:
                     if cli_session_id:
                         resume_target = cli_session_id
                     else:
-                        # Mapping lost: keep the 3-session design by re-probing
-                        # and rebinding the real CLI id to this line on the next
-                        # run, rather than faking a resume with the tracking id.
+                        # Mapping lost: keep this SAME session line stable and
+                        # re-probe/rebind the real CLI id onto it on the next
+                        # run, rather than creating a new wrapper line or faking
+                        # a resume with the tracking id.
                         logger.warning(
                             "Claude session line %s has no cli_session_id mapping "
-                            "(tracking=%s); starting fresh and rebinding",
+                            "(tracking=%s); starting fresh on the same line",
                             session_line,
                             existing[:8],
                         )
-                        return str(uuid.uuid4()), None, False
+                        return existing, None, False
                 except Exception:
                     logger.warning("Failed to resolve Claude resume target", exc_info=True)
-                    return str(uuid.uuid4()), None, False
-            return str(uuid.uuid4()), resume_target, True
+                    return existing, None, False
+            return existing, resume_target, True
         return str(uuid.uuid4()), None, False
 
     @staticmethod
@@ -1165,17 +1166,16 @@ class AutonomousOrchestrator:
             # Falls back to the wrapper uuid when the real id isn't resolved yet.
             link_session_id = result.source_session_id or result.session_id
             self._link_session_to_current_milestone(link_session_id)
-            # Always update the session line with the real CLI session id.
-            # Resume can fail silently (e.g. the prior session died after a
-            # crash/timeout), in which case the agent falls back to a fresh
-            # session/create and returns a new id. If we don't overwrite here,
-            # subsequent milestones resume the stale dead id forever (#525).
+            # Persist the stable tracking id for this line. Fresh lines write
+            # their first tracking id here; established lines keep reusing the
+            # same wrapper row across milestones so timeline/session identity
+            # does not drift with every resume attempt.
             field = SESSION_LINE_FIELDS.get(session_line)
             if field:
                 self._update_workflow({field: result.session_id})
                 # Keep the in-memory wf dict in sync so the next _resolve_session_line
                 # call in the same phase (e.g. planning → finalize) sees the updated
-                # session id and resumes it instead of creating a new session.
+                # line identity and resumes it instead of rotating wrappers.
                 wf[field] = result.session_id
 
         # Transient API error retry (429 / 5xx / overload) — exponential

--- a/app/routes/autonomous.py
+++ b/app/routes/autonomous.py
@@ -123,6 +123,52 @@ def _resolve_milestone_session_id(milestone: dict[str, Any]) -> str:
     return milestone.get("review_session_id") or milestone.get("session_id") or ""
 
 
+def _extract_cli_session_id(session_row: Any) -> str:
+    """Return the mapped real CLI session id for a workflow-owned session row."""
+    if not session_row:
+        return ""
+
+    cli_session_id = getattr(session_row, "cli_session_id", "")
+    if not cli_session_id and isinstance(session_row, dict):
+        cli_session_id = session_row.get("cli_session_id", "")
+    if cli_session_id:
+        return str(cli_session_id).strip()
+
+    context = getattr(session_row, "context", None)
+    if context is None and isinstance(session_row, dict):
+        context = session_row.get("context", {})
+    if isinstance(context, dict):
+        return str(context.get("cli_session_id", "") or "").strip()
+    return ""
+
+
+def _resolve_actual_session_id(
+    session_id: str, session_manager: Any | None, cache: dict[str, str] | None = None
+) -> str:
+    """Resolve a workflow-owned tracking session id to the real CLI session id."""
+    if not session_id:
+        return ""
+    if cache is not None and session_id in cache:
+        return cache[session_id]
+    if session_manager is None:
+        if cache is not None:
+            cache[session_id] = session_id
+        return session_id
+
+    actual_session_id = session_id
+    try:
+        session_row = session_manager.get_session(session_id)
+        cli_session_id = _extract_cli_session_id(session_row)
+        if cli_session_id:
+            actual_session_id = cli_session_id
+    except Exception:
+        logger.warning("Failed to resolve actual milestone session id", exc_info=True)
+
+    if cache is not None:
+        cache[session_id] = actual_session_id
+    return actual_session_id
+
+
 def _enforce_quota_gate(user_id: int) -> Response | None:
     """Fail-closed quota pre-check for workflow creation paths.
 
@@ -151,15 +197,26 @@ def _enrich_milestones_with_usage(
     """Attach per-milestone LLM usage/session metadata for the timeline UI."""
     repo = _get_repo()
     usage_by_milestone = repo.get_milestone_usage_summary(workflow_id, milestones)
+    session_manager = None
+    session_cache: dict[str, str] = {}
+    try:
+        from app.modules.workspace.session_manager import SessionManager
+
+        session_manager = SessionManager()
+    except Exception:
+        logger.warning("Failed to initialize SessionManager for milestone enrichment")
     enriched: list[dict[str, Any]] = []
     for milestone in milestones:
         milestone_id = milestone.get("milestone_id", "")
         usage = usage_by_milestone.get(milestone_id, {})
+        llm_session_id = usage.get("llm_session_id") or _resolve_milestone_session_id(milestone)
         enriched.append(
             {
                 **milestone,
-                "llm_session_id": usage.get("llm_session_id")
-                or _resolve_milestone_session_id(milestone),
+                "llm_session_id": llm_session_id,
+                "actual_llm_session_id": _resolve_actual_session_id(
+                    llm_session_id, session_manager, session_cache
+                ),
                 "llm_total_tokens": usage.get("llm_total_tokens", 0),
                 "llm_request_count": usage.get("llm_request_count", 0),
             }
@@ -1200,10 +1257,15 @@ def get_milestone_session(workflow_id, milestone_id):
     from app.modules.workspace.session_manager import SessionManager
 
     sm = SessionManager()
+    actual_session_id = _resolve_actual_session_id(session_id, sm)
+
+    if actual_session_id and actual_session_id != session_id:
+        session_data = sm.get_session(actual_session_id, include_messages=True)
+        if session_data:
+            return jsonify({"success": True, "session": session_data})
+
     session_data = sm.get_session(
-        session_id,
-        include_messages=True,
-        message_milestone_id=milestone_id,
+        session_id, include_messages=True, message_milestone_id=milestone_id
     )
 
     return jsonify({"success": True, "session": session_data})

--- a/app/routes/autonomous.py
+++ b/app/routes/autonomous.py
@@ -1260,7 +1260,11 @@ def get_milestone_session(workflow_id, milestone_id):
     actual_session_id = _resolve_actual_session_id(session_id, sm)
 
     if actual_session_id and actual_session_id != session_id:
-        session_data = sm.get_session(actual_session_id, include_messages=True)
+        session_data = sm.get_session(
+            actual_session_id,
+            include_messages=True,
+            message_milestone_id=milestone_id,
+        )
         if session_data:
             return jsonify({"success": True, "session": session_data})
 

--- a/frontend/src/api/autonomous.ts
+++ b/frontend/src/api/autonomous.ts
@@ -116,6 +116,7 @@ export interface WorkflowMilestone {
   fork_workflow_id: string;
   metadata: string;
   llm_session_id?: string;
+  actual_llm_session_id?: string;
   llm_total_tokens?: number;
   llm_request_count?: number;
   started_at: string | null;

--- a/frontend/src/components/work/WorkflowTimeline.tsx
+++ b/frontend/src/components/work/WorkflowTimeline.tsx
@@ -894,7 +894,11 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
   const latestMilestoneWithSession = [...milestones]
     .reverse()
     .find(
-      (milestone) => milestone.llm_session_id ?? milestone.review_session_id ?? milestone.session_id
+      (milestone) =>
+        milestone.actual_llm_session_id ??
+        milestone.llm_session_id ??
+        milestone.review_session_id ??
+        milestone.session_id
     );
   const latestFailedMilestone = [...milestones]
     .reverse()
@@ -1126,7 +1130,10 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
     const diffStats = parseDiffStats(milestone.diff_stats);
     const milestoneTime = formatMilestoneTime(getMilestoneAnchorTime(milestone));
     const llmSessionId =
-      milestone.llm_session_id ?? milestone.review_session_id ?? milestone.session_id;
+      milestone.actual_llm_session_id ??
+      milestone.llm_session_id ??
+      milestone.review_session_id ??
+      milestone.session_id;
     const llmTotalTokens = milestone.llm_total_tokens ?? 0;
     const llmRequestCount = milestone.llm_request_count ?? 0;
     const showUsageMetrics = !!llmSessionId || llmTotalTokens > 0 || llmRequestCount > 0;
@@ -1907,6 +1914,7 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
                     setViewingSession({
                       milestoneId: latestMilestoneWithSession.milestone_id,
                       sessionId:
+                        latestMilestoneWithSession.actual_llm_session_id ??
                         latestMilestoneWithSession.llm_session_id ??
                         latestMilestoneWithSession.review_session_id ??
                         latestMilestoneWithSession.session_id ??

--- a/remote-agent/executor.py
+++ b/remote-agent/executor.py
@@ -117,6 +117,45 @@ class SessionProcess:
         self._stdout_thread.start()
         self._stderr_thread.start()
 
+    @staticmethod
+    def _extract_stream_session_id(parsed: dict[str, Any]) -> str:
+        """Best-effort extraction of Claude's real session_id from a stream event."""
+        if not isinstance(parsed, dict):
+            return ""
+
+        candidates: list[Any] = [parsed.get("session_id")]
+        response = parsed.get("response", {}) or {}
+        if isinstance(response, dict):
+            candidates.append(response.get("session_id"))
+            inner_response = response.get("response", {}) or {}
+            if isinstance(inner_response, dict):
+                candidates.append(inner_response.get("session_id"))
+
+        for candidate in candidates:
+            session_id = str(candidate or "").strip()
+            if session_id:
+                return session_id
+        return ""
+
+    def _capture_cli_session_id(self, parsed: dict[str, Any], source: str) -> str:
+        """Store the authoritative Claude session_id when the stream exposes it."""
+        if self.cli_tool != "claude-code":
+            return ""
+
+        cli_session_id = self._extract_stream_session_id(parsed)
+        if not cli_session_id:
+            return ""
+
+        if cli_session_id != self._cli_session_id:
+            self._cli_session_id = cli_session_id
+            logger.info(
+                "Captured Claude session_id from %s for session %s -> %s",
+                source,
+                self.session_id[:8],
+                cli_session_id[:8],
+            )
+        return cli_session_id
+
     def _read_stream(self, stream: Any, stream_name: str) -> None:
         """
         Continuously read lines from a subprocess stream and forward them
@@ -149,10 +188,11 @@ class SessionProcess:
                                 subtype = resp.get("subtype")
                                 if subtype == "success":
                                     # Extract CLI's internal session_id for --resume
-                                    inner_resp = resp.get("response", {})
-                                    cli_sid = inner_resp.get("session_id")
+                                    cli_sid = self._capture_cli_session_id(
+                                        parsed,
+                                        "control_response.initialize",
+                                    )
                                     if cli_sid:
-                                        self._cli_session_id = cli_sid
                                         logger.info(
                                             "SDK initialization complete for session %s (CLI session_id: %s)",
                                             self.session_id[:8],
@@ -179,11 +219,19 @@ class SessionProcess:
                             self.permission_callback(self.session_id, parsed)
                             continue
 
-                        # Handle result messages — extract token usage
-                        if msg_type == "result" and self.usage_callback:
-                            tokens = self._extract_stream_usage(self.cli_tool, parsed)
-                            if tokens and (tokens["input"] or tokens["output"]):
-                                self.usage_callback(self.session_id, tokens)
+                        if msg_type in {"system", "initialized"} and (
+                            msg_type == "initialized" or parsed.get("subtype") == "initialized"
+                        ):
+                            self._capture_cli_session_id(parsed, "system.initialized")
+
+                        # Handle result messages — capture session_id and
+                        # extract token usage when requested.
+                        if msg_type == "result":
+                            self._capture_cli_session_id(parsed, "result")
+                            if self.usage_callback:
+                                tokens = self._extract_stream_usage(self.cli_tool, parsed)
+                                if tokens and (tokens["input"] or tokens["output"]):
+                                    self.usage_callback(self.session_id, tokens)
                     except (json.JSONDecodeError, ValueError):
                         pass
 

--- a/tests/issues/1140/test_session_line_resume.py
+++ b/tests/issues/1140/test_session_line_resume.py
@@ -82,6 +82,7 @@ def test_resolve_session_line_resume_with_fresh_wf():
     sid, resume_sid, resume = orch._resolve_session_line(wf, "main")
     assert resume is True
     assert resume_sid == "sess_planning_fresh"
+    assert sid == "sess_planning_fresh"
 
 
 def test_resolve_session_line_review_independent_from_main():
@@ -112,6 +113,7 @@ def test_resolve_session_line_uses_claude_cli_session_mapping():
     sid, resume_sid, resume = orch._resolve_session_line(dict(db_state), "main")
 
     assert resume is True
+    assert sid == "wf-main-track"
     assert resume_sid == "claude-sidebar-real"
 
 
@@ -126,16 +128,17 @@ def test_resolve_session_line_reads_authoritative_cli_session_column():
         session_id="wf-main-track", cli_session_id="claude-real-999"
     )
 
-    _, resume_sid, resume = orch._resolve_session_line(dict(db_state), "main")
+    sid, resume_sid, resume = orch._resolve_session_line(dict(db_state), "main")
     assert resume is True
+    assert sid == "wf-main-track"
     assert resume_sid == "claude-real-999"
 
 
 def test_resolve_session_line_missing_mapping_starts_fresh_not_fake():
     """A Claude line whose cli_session_id mapping is lost must NOT disguise the
     tracking id as a resume target. Return resume=False so ``_run_local``
-    re-probes the real CLI id and rebinds it to this same line — strict
-    3-session topology, no fake resume, no 4th session (#1200)."""
+    re-probes the real CLI id and rebinds it to this SAME line, instead of
+    rotating to a fresh wrapper session."""
     from app.modules.workspace.session_manager import AgentSession
 
     db_state = {"main_session_id": "wf-main-track", "cli_tool": "claude-code"}
@@ -148,5 +151,21 @@ def test_resolve_session_line_missing_mapping_starts_fresh_not_fake():
     sid, resume_sid, resume = orch._resolve_session_line(dict(db_state), "main")
     assert resume is False
     assert resume_sid is None
-    # A fresh tracking id is minted; the stale tracking id is never used to resume.
-    assert sid != "wf-main-track"
+    assert sid == "wf-main-track"
+
+
+def test_resolve_session_line_keeps_tracking_id_stable_across_resume():
+    """An established line should reuse its original tracking id on later rounds."""
+    from app.modules.workspace.session_manager import AgentSession
+
+    db_state = {"review_session_id": "wf-review-track", "cli_tool": "claude-code"}
+    orch, _ = _make_orchestrator(db_state)
+    orch._runner.session_manager.get_session.return_value = AgentSession(
+        session_id="wf-review-track", cli_session_id="claude-review-real"
+    )
+
+    sid, resume_sid, resume = orch._resolve_session_line(dict(db_state), "review")
+
+    assert resume is True
+    assert sid == "wf-review-track"
+    assert resume_sid == "claude-review-real"

--- a/tests/issues/189/test_workspace_navigation.py
+++ b/tests/issues/189/test_workspace_navigation.py
@@ -12,10 +12,12 @@ Run:
   python tests/189/test_workspace_navigation.py
 """
 
+import json
 import os
 import signal
 import sys
 import unittest
+from io import BytesIO
 from unittest.mock import MagicMock, patch
 
 PROJECT_ROOT = os.path.dirname(
@@ -114,6 +116,64 @@ class TestProcessExecutorInterruptSession(unittest.TestCase):
         ex = self._make_executor(sessions={"s1": mock_session})
         result = ex.interrupt_session("s1")
         self.assertFalse(result["success"])
+
+
+class TestSessionProcessCliSessionTracking(unittest.TestCase):
+    """Capture the real Claude session id from stdout events."""
+
+    def _make_session(self):
+        from executor import SessionProcess
+
+        mock_proc = MagicMock()
+        mock_proc.pid = 12345
+        mock_proc.returncode = None
+
+        return SessionProcess(
+            session_id="tracking-session-12345678",
+            process=mock_proc,
+            project_path="/tmp",
+            cli_tool="claude-code",
+            output_callback=MagicMock(),
+        )
+
+    def test_read_stream_captures_session_id_from_initialized_event(self):
+        sp = self._make_session()
+        stream = BytesIO(
+            (
+                json.dumps(
+                    {
+                        "type": "system",
+                        "subtype": "initialized",
+                        "session_id": "claude-init-123",
+                    }
+                )
+                + "\n"
+            ).encode()
+        )
+
+        sp._read_stream(stream, "stdout")
+
+        self.assertEqual(sp._cli_session_id, "claude-init-123")
+
+    def test_read_stream_captures_session_id_from_result_event(self):
+        sp = self._make_session()
+        stream = BytesIO(
+            (
+                json.dumps(
+                    {
+                        "type": "result",
+                        "subtype": "success",
+                        "session_id": "claude-result-456",
+                        "duration_ms": 42,
+                    }
+                )
+                + "\n"
+            ).encode()
+        )
+
+        sp._read_stream(stream, "stdout")
+
+        self.assertEqual(sp._cli_session_id, "claude-result-456")
 
 
 class TestAgentAbortRequest(unittest.TestCase):

--- a/tests/issues/716/test_agent_runner.py
+++ b/tests/issues/716/test_agent_runner.py
@@ -364,6 +364,142 @@ class TestAgentRunnerRunTask:
         self.sm.create_session.assert_called_once()
         assert self.sm.create_session.call_args.kwargs["session_id"] == result.session_id
 
+    def test_local_claude_captures_session_id_from_initialized_event(self):
+        """System initialized events should bind the real Claude session without JSONL fallback."""
+        mock_adapter = MagicMock()
+        mock_adapter.get_executable_name.return_value = "claude"
+        mock_adapter.build_start_args.return_value = ["claude", "--model", "m1"]
+        mock_cli_adapters = MagicMock()
+        mock_cli_adapters.get_adapter.return_value = mock_adapter
+
+        stdout_lines = [
+            json.dumps(
+                {
+                    "type": "system",
+                    "subtype": "initialized",
+                    "session_id": "claude-init-123",
+                }
+            ).encode(),
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "message": {
+                        "id": "msg-1",
+                        "model": "claude-sonnet",
+                        "content": "Hello from Claude",
+                    },
+                }
+            ).encode(),
+            json.dumps(
+                {
+                    "type": "result",
+                    "data": {
+                        "usage": {"input_tokens": 120, "output_tokens": 30},
+                    },
+                }
+            ).encode(),
+            b"",
+        ]
+
+        mock_stdout = MagicMock()
+        mock_stdout.readline = MagicMock(side_effect=stdout_lines)
+        mock_stderr = MagicMock()
+        mock_stderr.readline = MagicMock(return_value=b"")
+
+        with (
+            patch.dict("sys.modules", {"cli_adapters": mock_cli_adapters}),
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch("subprocess.Popen") as mock_popen,
+            patch.object(self.runner, "_find_latest_claude_session_id") as mock_find_latest,
+        ):
+            proc = MagicMock()
+            proc.returncode = 0
+            proc.pid = 12345
+            proc.stdin = MagicMock()
+            proc.stdout = mock_stdout
+            proc.stderr = mock_stderr
+            mock_popen.return_value = proc
+
+            result = self.runner.run_agent_task(
+                workflow_id="wf-1",
+                cli_tool="claude-code",
+                model="m1",
+                project_path="/tmp/test",
+                prompt="Do something",
+                workspace_type="local",
+                user_id=42,
+                timeout=5,
+            )
+
+        assert result.success is True
+        assert result.source_session_id == "claude-init-123"
+        mock_find_latest.assert_not_called()
+
+    def test_local_claude_captures_session_id_from_result_event(self):
+        """Result events should bind the real Claude session when init omits it."""
+        mock_adapter = MagicMock()
+        mock_adapter.get_executable_name.return_value = "claude"
+        mock_adapter.build_start_args.return_value = ["claude", "--model", "m1"]
+        mock_cli_adapters = MagicMock()
+        mock_cli_adapters.get_adapter.return_value = mock_adapter
+
+        stdout_lines = [
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "message": {
+                        "id": "msg-1",
+                        "model": "claude-sonnet",
+                        "content": "Hello from Claude",
+                    },
+                }
+            ).encode(),
+            json.dumps(
+                {
+                    "type": "result",
+                    "session_id": "claude-result-456",
+                    "data": {
+                        "usage": {"input_tokens": 120, "output_tokens": 30},
+                    },
+                }
+            ).encode(),
+            b"",
+        ]
+
+        mock_stdout = MagicMock()
+        mock_stdout.readline = MagicMock(side_effect=stdout_lines)
+        mock_stderr = MagicMock()
+        mock_stderr.readline = MagicMock(return_value=b"")
+
+        with (
+            patch.dict("sys.modules", {"cli_adapters": mock_cli_adapters}),
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch("subprocess.Popen") as mock_popen,
+            patch.object(self.runner, "_find_latest_claude_session_id") as mock_find_latest,
+        ):
+            proc = MagicMock()
+            proc.returncode = 0
+            proc.pid = 12345
+            proc.stdin = MagicMock()
+            proc.stdout = mock_stdout
+            proc.stderr = mock_stderr
+            mock_popen.return_value = proc
+
+            result = self.runner.run_agent_task(
+                workflow_id="wf-1",
+                cli_tool="claude-code",
+                model="m1",
+                project_path="/tmp/test",
+                prompt="Do something",
+                workspace_type="local",
+                user_id=42,
+                timeout=5,
+            )
+
+        assert result.success is True
+        assert result.source_session_id == "claude-result-456"
+        mock_find_latest.assert_not_called()
+
     def test_sidebar_session_not_marked_resolved_when_context_sync_fails(self):
         """A failed tracking-session sync should not leave a ghost persisted session id."""
         self.sm.update_session_fields.side_effect = RuntimeError("db down")

--- a/tests/issues/716/test_autonomous_api.py
+++ b/tests/issues/716/test_autonomous_api.py
@@ -26,7 +26,8 @@ def auto_db(tmp_path):
             conn = db.get_connection()
             try:
                 cursor = conn.cursor()
-                cursor.execute("""
+                cursor.execute(
+                    """
                     CREATE TABLE IF NOT EXISTS users (
                         id INTEGER PRIMARY KEY AUTOINCREMENT,
                         username TEXT UNIQUE NOT NULL,
@@ -37,7 +38,8 @@ def auto_db(tmp_path):
                         created_at TEXT,
                         updated_at TEXT
                     )
-                    """)
+                    """
+                )
                 cursor.execute(
                     "INSERT INTO users (username, email, password_hash, role) VALUES (?, ?, ?, ?)",
                     ("admin", "admin@test.com", "hash123", "admin"),

--- a/tests/issues/716/test_autonomous_api.py
+++ b/tests/issues/716/test_autonomous_api.py
@@ -1273,7 +1273,7 @@ class TestGetMilestoneSession:
         assert data["session"]["session_id"] == "actual-456"
         assert mock_sm.get_session.call_args_list == [
             (("track-123",), {}),
-            (("actual-456",), {"include_messages": True}),
+            (("actual-456",), {"include_messages": True, "message_milestone_id": "ms-1"}),
         ]
 
     def test_get_session_no_session_id(self, client):

--- a/tests/issues/716/test_autonomous_api.py
+++ b/tests/issues/716/test_autonomous_api.py
@@ -26,8 +26,7 @@ def auto_db(tmp_path):
             conn = db.get_connection()
             try:
                 cursor = conn.cursor()
-                cursor.execute(
-                    """
+                cursor.execute("""
                     CREATE TABLE IF NOT EXISTS users (
                         id INTEGER PRIMARY KEY AUTOINCREMENT,
                         username TEXT UNIQUE NOT NULL,
@@ -38,8 +37,7 @@ def auto_db(tmp_path):
                         created_at TEXT,
                         updated_at TEXT
                     )
-                    """
-                )
+                    """)
                 cursor.execute(
                     "INSERT INTO users (username, email, password_hash, role) VALUES (?, ?, ?, ?)",
                     ("admin", "admin@test.com", "hash123", "admin"),
@@ -619,9 +617,44 @@ class TestGetTimeline:
         data = resp.get_json()
         assert len(data["milestones"]) == 2
         assert data["milestones"][0]["llm_session_id"] == "sess-plan"
+        assert data["milestones"][0]["actual_llm_session_id"] == "sess-plan"
         assert data["milestones"][0]["llm_total_tokens"] == 1234
         assert data["milestones"][0]["llm_request_count"] == 7
         assert data["milestones"][1]["llm_total_tokens"] == 0
+
+    def test_get_timeline_exposes_actual_llm_session_id(self, client):
+        repo = _make_repo()
+        repo.get_workflow.return_value = {"workflow_id": "wf-1", "user_id": 1}
+        repo.list_milestones.return_value = [
+            {
+                "milestone_id": "ms-1",
+                "phase": "planning",
+                "status": "completed",
+                "session_id": "track-1",
+            }
+        ]
+        repo.get_milestone_usage_summary.return_value = {
+            "ms-1": {
+                "llm_session_id": "track-1",
+                "llm_total_tokens": 100,
+                "llm_request_count": 2,
+            }
+        }
+
+        session_row = MagicMock()
+        session_row.cli_session_id = "actual-claude-1"
+        with _mock_auth():
+            with patch("app.routes.autonomous.auto_repo", repo):
+                with patch("app.modules.workspace.session_manager.SessionManager") as mock_sm_cls:
+                    mock_sm = MagicMock()
+                    mock_sm.get_session.return_value = session_row
+                    mock_sm_cls.return_value = mock_sm
+                    resp = client.get("/api/autonomous/workflows/wf-1/timeline")
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["milestones"][0]["llm_session_id"] == "track-1"
+        assert data["milestones"][0]["actual_llm_session_id"] == "actual-claude-1"
 
     def test_get_timeline_backfills_diff_stats_per_milestone(self, client):
         repo = _make_repo()
@@ -1204,9 +1237,44 @@ class TestGetMilestoneSession:
         data = resp.get_json()
         assert data["success"] is True
         assert data["session"]["session_id"] == "sess-123"
-        mock_sm.get_session.assert_called_once_with(
-            "sess-123", include_messages=True, message_milestone_id="ms-1"
-        )
+        assert mock_sm.get_session.call_args_list == [
+            (("sess-123",), {}),
+            (("sess-123",), {"include_messages": True, "message_milestone_id": "ms-1"}),
+        ]
+
+    def test_get_session_prefers_actual_cli_session_when_mapped(self, client):
+        """Returns the real Claude session when the milestone session is a tracking row."""
+        repo = _make_repo()
+        repo.get_workflow.return_value = {"workflow_id": "wf-1", "user_id": 1}
+        repo.get_milestone.return_value = {
+            "milestone_id": "ms-1",
+            "workflow_id": "wf-1",
+            "session_id": "track-123",
+        }
+        tracking_session = MagicMock()
+        tracking_session.cli_session_id = "actual-456"
+        actual_session = {
+            "session_id": "actual-456",
+            "status": "completed",
+            "messages": [{"role": "assistant", "content": "Full transcript"}],
+        }
+        with _mock_auth():
+            with patch("app.routes.autonomous.auto_repo", repo):
+                with patch("app.modules.workspace.session_manager.SessionManager") as mock_sm_cls:
+                    mock_sm = MagicMock()
+                    mock_sm.get_session.side_effect = [tracking_session, actual_session]
+                    mock_sm_cls.return_value = mock_sm
+
+                    resp = client.get("/api/autonomous/workflows/wf-1/milestones/ms-1/session")
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is True
+        assert data["session"]["session_id"] == "actual-456"
+        assert mock_sm.get_session.call_args_list == [
+            (("track-123",), {}),
+            (("actual-456",), {"include_messages": True}),
+        ]
 
     def test_get_session_no_session_id(self, client):
         """Returns null session when milestone has no session_id."""


### PR DESCRIPTION
## Summary
- keep each autonomous session line on a stable tracking session id across resumes
- expose the actual Claude CLI session id on timeline milestones and prefer it in the UI/session viewer
- add regression coverage for session line reuse and actual-session lookup in the autonomous API

## Testing
- `.venv-test/bin/ruff check app/routes/autonomous.py app/modules/workspace/autonomous/orchestrator.py tests/issues/1140/test_session_line_resume.py tests/issues/716/test_autonomous_api.py`
- `git diff --check`
- `.venv-test/bin/pytest tests/issues/1140/test_session_line_resume.py -q` *(6 passed; 1 existing fixture import error from `scripts/shared/__init__.py` UnicodeEncodeError during global test setup)*