### PR TITLE
ci(migrations): assert single Alembic head on pre-merged tree

### DIFF
--- a/.github/workflows/migration-graph.yml
+++ b/.github/workflows/migration-graph.yml
@@ -1,0 +1,90 @@
+name: Migration Graph
+
+# Guard the single-head invariant of the Alembic migration chain.
+#
+# Two parallel PRs can each fork off the same parent migration (both declaring
+# the same down_revision) without any git text conflict — each branch is
+# single-headed in isolation, so schema-sync and pre-commit cannot see the fork.
+# It only surfaces once the branches merge. This workflow catches it BEFORE
+# merge by assembling the pre-merged `migrations/versions/` tree (base branch +
+# PR's migration changes) and asserting exactly one Alembic head.
+#
+# See scripts/check_migration_heads.py for the checker this workflow runs.
+
+on:
+  pull_request:
+    paths:
+      - 'migrations/versions/**'
+
+permissions:
+  contents: read
+
+jobs:
+  single-head:
+    name: Single migration head
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # need base-branch history + the PR merge-base
+
+      - name: Fetch base branch
+        run: git fetch origin "${{ github.base_ref }}"
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install Alembic
+        # Only alembic is needed: get_heads() parses migration modules but never
+        # opens a database or runs upgrade(). alembic pulls in sqlalchemy, which
+        # migrations/baseline.py imports at module load time.
+        run: pip install alembic
+
+      - name: Assemble pre-merged migration tree
+        env:
+          BASE_REF: origin/${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          MERGED_DIR="$RUNNER_TEMP/merged-migrations"
+          mkdir -p "$MERGED_DIR/migrations"
+
+          # Support files are identical across branches; copy from the checkout
+          # without ever mutating the checked-out working tree.
+          cp alembic.ini "$MERGED_DIR/"
+          cp migrations/baseline.py migrations/version_table.py "$MERGED_DIR/migrations/"
+
+          # 1) Start from the base branch's full versions/ directory. Read every
+          #    blob out of git ($BASE_REF) into the temp tree — never touch the
+          #    checkout itself, so later steps keep seeing the PR's files.
+          for f in $(git ls-tree -r --name-only "$BASE_REF" -- migrations/versions); do
+            mkdir -p "$MERGED_DIR/$(dirname "$f")"
+            git show "$BASE_REF:$f" > "$MERGED_DIR/$f"
+          done
+
+          # 2) Apply the PR's migration changes (added/modified/deleted since the
+          #    merge-base) on top, producing the post-merge versions/ tree.
+          MERGE_BASE="$(git merge-base "$BASE_REF" HEAD)"
+          echo "merge-base: $MERGE_BASE"
+          git diff --name-only --diff-filter=AMD "$MERGE_BASE" HEAD -- migrations/versions \
+            | while read -r f; do
+                if git cat-file -e "HEAD:$f" 2>/dev/null; then
+                  mkdir -p "$MERGED_DIR/$(dirname "$f")"
+                  git show "HEAD:$f" > "$MERGED_DIR/$f"
+                else
+                  rm -f "$MERGED_DIR/$f"
+                fi
+              done
+
+          echo "--- pre-merged versions/ contents ---"
+          ls -1 "$MERGED_DIR/migrations/versions/"
+          echo "MERGED_DIR=$MERGED_DIR" >> "$GITHUB_ENV"
+
+      - name: Assert single migration head
+        working-directory: ${{ env.MERGED_DIR }}
+        run: python "$GITHUB_WORKSPACE/scripts/check_migration_heads.py"
+
+      - name: Cleanup merged tree
+        if: always()
+        run: rm -rf "$MERGED_DIR"

--- a/.github/workflows/migration-graph.yml
+++ b/.github/workflows/migration-graph.yml
@@ -58,17 +58,22 @@ jobs:
           # 1) Start from the base branch's full versions/ directory. Read every
           #    blob out of git ($BASE_REF) into the temp tree — never touch the
           #    checkout itself, so later steps keep seeing the PR's files.
-          for f in $(git ls-tree -r --name-only "$BASE_REF" -- migrations/versions); do
-            mkdir -p "$MERGED_DIR/$(dirname "$f")"
-            git show "$BASE_REF:$f" > "$MERGED_DIR/$f"
-          done
+          git ls-tree -r --name-only "$BASE_REF" -- migrations/versions \
+            | while IFS= read -r f; do
+                mkdir -p "$MERGED_DIR/$(dirname "$f")"
+                git show "$BASE_REF:$f" > "$MERGED_DIR/$f"
+              done
 
           # 2) Apply the PR's migration changes (added/modified/deleted since the
           #    merge-base) on top, producing the post-merge versions/ tree.
+          #    --no-renames decomposes a rename into delete(old)+add(new) so
+          #    --diff-filter=AMD applies both halves; with rename detection on
+          #    (the default), a rename would surface as status R and be dropped,
+          #    silently leaving the stale old path in the merged tree.
           MERGE_BASE="$(git merge-base "$BASE_REF" HEAD)"
           echo "merge-base: $MERGE_BASE"
-          git diff --name-only --diff-filter=AMD "$MERGE_BASE" HEAD -- migrations/versions \
-            | while read -r f; do
+          git diff --no-renames --name-only --diff-filter=AMD "$MERGE_BASE" HEAD -- migrations/versions \
+            | while IFS= read -r f; do
                 if git cat-file -e "HEAD:$f" 2>/dev/null; then
                   mkdir -p "$MERGED_DIR/$(dirname "$f")"
                   git show "HEAD:$f" > "$MERGED_DIR/$f"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,19 @@ repos:
         files: ^migrations/versions/.*\.py$
         pass_filenames: false
 
+      # Assert the migration graph has exactly one head.
+      # Note: this only sees the current working tree, so it catches a single
+      # branch forking its own chain — NOT the cross-branch fork that occurs
+      # when two PRs each fork off the same parent. That cross-branch case is
+      # guarded by .github/workflows/migration-graph.yml, which runs this same
+      # script against a pre-merged migration tree.
+      - id: check-migration-heads
+        name: Check single migration head
+        entry: python3 scripts/check_migration_heads.py
+        language: system
+        files: ^migrations/versions/.*\.py$
+        pass_filenames: false
+
       # Validate PostgreSQL schema for boolean field consistency
       - id: validate-schema
         name: Validate PostgreSQL schema boolean fields

--- a/scripts/check_migration_heads.py
+++ b/scripts/check_migration_heads.py
@@ -44,14 +44,16 @@ def main() -> int:
     if len(heads) != 1:
         print(
             f"FAIL: expected exactly 1 migration head, found {len(heads)}:"
-            f" a forked migration chain."
+            f" a forked migration chain.",
+            file=sys.stderr,
         )
         for head in heads:
-            print(f"  - {head}")
+            print(f"  - {head}", file=sys.stderr)
         print(
             "Two migrations share a down_revision. Rebase one onto the other so "
             "the chain stays linear (its down_revision must point at the other's "
-            "revision, not at their common parent)."
+            "revision, not at their common parent).",
+            file=sys.stderr,
         )
         return 1
 

--- a/scripts/check_migration_heads.py
+++ b/scripts/check_migration_heads.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""
+Check that the Alembic migration graph has exactly one head.
+
+A single head is a structural invariant of the migration chain: if two
+migrations declare the same ``down_revision`` (e.g. two parallel branches each
+forking off the same parent), the chain forks and ``alembic heads`` reports
+more than one. Each branch is single-headed in isolation, so this fork only
+appears once the branches are merged — this script only catches it when run
+against the *merged* migration tree.
+
+It is therefore designed to be run from CI on a pre-merged tree (see
+``.github/workflows/migration-graph.yml``), which assembles the base branch's
+``migrations/versions/`` together with the PR's migration changes before
+invoking this check. The pre-commit hook ``check-migration-heads`` also calls
+this script, but it only sees the current working tree and so cannot detect
+cross-branch forks — it guards the (rarer) single-branch multi-head case.
+
+No database is opened and no ``upgrade()`` is executed; ``get_heads()`` only
+parses each migration module's ``revision`` / ``down_revision`` attributes.
+
+Usage:
+    python3 scripts/check_migration_heads.py
+"""
+
+import sys
+from pathlib import Path
+
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+
+
+def main() -> int:
+    # Resolve alembic.ini from the current directory so the check works inside
+    # the temporary pre-merged tree assembled by the CI workflow.
+    cfg_path = Path("alembic.ini")
+    if not cfg_path.exists():
+        print(f"FAIL: {cfg_path} not found in {Path.cwd()}", file=sys.stderr)
+        return 2
+
+    cfg = Config(str(cfg_path))
+    heads = ScriptDirectory.from_config(cfg).get_heads()
+
+    if len(heads) != 1:
+        print(
+            f"FAIL: expected exactly 1 migration head, found {len(heads)}:"
+            f" a forked migration chain."
+        )
+        for head in heads:
+            print(f"  - {head}")
+        print(
+            "Two migrations share a down_revision. Rebase one onto the other so "
+            "the chain stays linear (its down_revision must point at the other's "
+            "revision, not at their common parent)."
+        )
+        return 1
+
+    print(f"OK: single migration head -> {heads[0]}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_migration_heads.py
+++ b/scripts/check_migration_heads.py
@@ -26,11 +26,24 @@ Usage:
 import sys
 from pathlib import Path
 
-from alembic.config import Config
-from alembic.script import ScriptDirectory
-
 
 def main() -> int:
+    # alembic is an optional dependency for this check's environments (e.g. the
+    # CI lint job runs pre-commit without installing requirements). Import
+    # lazily and warn-only when absent — the authoritative check runs in the
+    # dedicated migration-graph CI job, mirroring how check-schema-sync.sh
+    # degrades when alembic isn't installed.
+    try:
+        from alembic.config import Config
+        from alembic.script import ScriptDirectory
+    except ImportError:
+        print(
+            "WARNING: alembic not installed; skipping single-head check. "
+            "The migration-graph CI job runs the authoritative check.",
+            file=sys.stderr,
+        )
+        return 0
+
     # Resolve alembic.ini from the current directory so the check works inside
     # the temporary pre-merged tree assembled by the CI workflow.
     cfg_path = Path("alembic.ini")


### PR DESCRIPTION
## What & why

Prevents a repeat of #1284's root cause: a **forked Alembic migration chain** (multiple heads) that only appears once two branches merge.

Two parallel PRs can each fork off the same parent migration (both declaring the same `down_revision`) with **no git text conflict** — each branch is single-headed in isolation, so `schema-sync` and pre-commit can't see the fork. #1284 hit exactly this: its `status-index` migration and #1287's `content_language` migration both claimed `down_revision=001`, producing a two-head fork only after merge.

## How it works

A new lightweight CI guard assembles the **pre-merged migration tree** (base branch's `migrations/versions/` + the PR's add/modify/delete overlay, in a temp dir under `$RUNNER_TEMP`) and asserts exactly one Alembic head.

- **`scripts/check_migration_heads.py`** — asserts `ScriptDirectory.get_heads()` returns exactly one head. No DB, no `upgrade()`; `get_heads()` only parses each migration's `revision`/`down_revision`.
- **`.github/workflows/migration-graph.yml`** — runs only on PRs touching `migrations/versions/**`. Assembles the merged `versions/` via `git ls-tree` + `git diff --diff-filter=AMD` overlay **without mutating the checkout** (all in `$RUNNER_TEMP`), then runs the checker. Cleanup: `if: always()` `rm -rf` + `$RUNNER_TEMP` auto-disposal.
- **`.pre-commit-config.yaml`** — local `check-migration-heads` hook for the single-branch multi-head case. Cannot see cross-branch forks (the CI workflow's job); documented in the hook comment.

## Verification
- ✅ Single-head tree (current main) → `OK: single migration head -> 20260626_003...` (exit 0)
- ✅ Injected fork (both status-index & content_language claiming `down_revision=001`) → `FAIL: ... found 2` (exit 1)
- ✅ `black` / `isort` / `ruff` clean; YAML parses; pre-commit hooks pass

## Notes
- This PR doesn't touch `migrations/versions/`, so `migration-graph` won't trigger on it (by design — `paths: migrations/versions/**`). Self-test path documented above.
- Defense-in-depth only: branch protection (`require status checks`) is what makes any CI check binding — that's a repo setting left to maintainers.

Closes nothing directly; complements #1284 (the merge-conflict fix) with prevention.