### PR TITLE
fix(workflow): show full transcript for shared milestone sessions

### DIFF
--- a/app/routes/autonomous.py
+++ b/app/routes/autonomous.py
@@ -1260,10 +1260,15 @@ def get_milestone_session(workflow_id, milestone_id):
     actual_session_id = _resolve_actual_session_id(session_id, sm)
 
     if actual_session_id and actual_session_id != session_id:
+        # The resolved actual session is the real Claude transcript, shared
+        # across multiple milestones (e.g. plan_created + plan_refined resume
+        # the same CLI session). Its messages are not tagged per-milestone
+        # (milestone_id is typically NULL), so filtering by message_milestone_id
+        # would drop them all and leave the viewer showing only "Status".
+        # Return the full transcript for the actual session.
         session_data = sm.get_session(
             actual_session_id,
             include_messages=True,
-            message_milestone_id=milestone_id,
         )
         if session_data:
             return jsonify({"success": True, "session": session_data})

--- a/tests/issues/716/test_autonomous_api.py
+++ b/tests/issues/716/test_autonomous_api.py
@@ -1245,7 +1245,13 @@ class TestGetMilestoneSession:
         ]
 
     def test_get_session_prefers_actual_cli_session_when_mapped(self, client):
-        """Returns the real Claude session when the milestone session is a tracking row."""
+        """Returns the real Claude session when the milestone session is a tracking row.
+
+        The actual session is a shared transcript across milestones, so its
+        messages are returned unfiltered (no message_milestone_id) — otherwise
+        messages with a NULL/other milestone_id would be dropped and the viewer
+        would show only "Status".
+        """
         repo = _make_repo()
         repo.get_workflow.return_value = {"workflow_id": "wf-1", "user_id": 1}
         repo.get_milestone.return_value = {
@@ -1273,9 +1279,10 @@ class TestGetMilestoneSession:
         data = resp.get_json()
         assert data["success"] is True
         assert data["session"]["session_id"] == "actual-456"
+        # actual session lookup returns the full transcript (no milestone filter)
         assert mock_sm.get_session.call_args_list == [
             (("track-123",), {}),
-            (("actual-456",), {"include_messages": True, "message_milestone_id": "ms-1"}),
+            (("actual-456",), {"include_messages": True}),
         ]
 
     def test_get_session_no_session_id(self, client):


### PR DESCRIPTION
## What

Clicking a milestone's session id in the workflow timeline showed only **"Status: completed"** with no messages — the transcript was empty.

## Root cause

`get_milestone_session` resolves the milestone's tracking session to the real CLI session (`actual`) via `_resolve_actual_session_id`, but still passed `message_milestone_id` when fetching its messages:

```python
session_data = sm.get_session(
    actual_session_id,
    include_messages=True,
    message_milestone_id=milestone_id,   # ← drops everything
)
```

The actual session is a **shared transcript across milestones** (e.g. `plan_created` + `plan_refined` resume the same CLI session). Its messages are not tagged per-milestone (`milestone_id` is NULL), so filtering by `message_milestone_id` dropped **every** message → viewer rendered only the status badge.

This regressed in #1289, which added `message_milestone_id` to the actual path to mirror the tracking path.

## Fix

Drop `message_milestone_id` on the actual-session path so the full transcript is returned. The tracking-session fallback path (when `actual == tracking`) keeps the filter, since that row's own messages may legitimately carry the milestone id.

## Verification (live data, issue 248 plan_created milestone)
```
resolved actual session: 6201826f-...
before fix (message_milestone_id filter): 0 messages
after fix  (no filter):                   88 messages
```
- `tests/issues/716/test_autonomous_api.py` — 64 passed (updated the actual-path assertion + docstring)
