### PR TITLE
fix(management): use copyToClipboard for HTTP compatibility in password reset modal

### DIFF
--- a/frontend/src/components/features/management/UserManagement.tsx
+++ b/frontend/src/components/features/management/UserManagement.tsx
@@ -15,6 +15,7 @@ import {
 } from '@/hooks';
 import { useLanguage } from '@/store';
 import { t } from '@/i18n';
+import { copyToClipboard } from '@/utils';
 import {
   Button,
   Modal,
@@ -25,7 +26,7 @@ import {
   EmptyState,
   Badge,
 } from '@/components/common';
-import { useConfirm } from '@/components/common';
+import { useConfirm, useToast } from '@/components/common';
 import { ToolAccountsEditor } from './ToolAccountsEditor';
 import { MappingRulesEditor } from './MappingRulesEditor';
 import { createMatcherConfig } from '@/utils';
@@ -242,6 +243,7 @@ export const UserManagement: React.FC = () => {
   };
 
   const confirm = useConfirm();
+  const toast = useToast();
   const handleDelete = async (userId: number) => {
     if (await confirm({ message: t('confirmDeleteUser', language), variant: 'danger' })) {
       try {
@@ -581,8 +583,11 @@ export const UserManagement: React.FC = () => {
             />
             <Button
               variant="outline-secondary"
-              onClick={() => {
-                navigator.clipboard.writeText(tempPassword);
+              onClick={async () => {
+                const success = await copyToClipboard(tempPassword);
+                if (!success) {
+                  toast.error(t('copyFailed', language) || 'Copy failed');
+                }
               }}
               title={t('copyToClipboard', language) ?? 'Copy to clipboard'}
             >


### PR DESCRIPTION
## Problem

管理员重置用户密码后，临时密码弹窗中的复制按钮在 HTTP 环境下无法复制到剪贴板。

**Root Cause**: `navigator.clipboard.writeText()` 仅在 HTTPS 或 localhost 环境下可用，在 HTTP 环境下会静默失败。

## Solution

使用项目已有的 `copyToClipboard` 工具函数，该函数：
1. 先尝试现代 clipboard API（HTTPS/localhost）
2. 失败时 fallback 到 `execCommand`（兼容 HTTP 环境）

参考 `RemoteMachineManagement.tsx` 的正确用法，添加错误处理。

## Changes

- 导入 `copyToClipboard` 工具函数
- 导入并使用 `useToast` 进行错误反馈
- 修改复制按钮的 onClick 逻辑

## Testing

- ✅ ESLint 检查通过
- ✅ TypeScript 类型检查通过

Fixes #1320