### PR TITLE
fix(fetch): convert UTC timestamps to local time for date extraction

### DIFF
--- a/scripts/fetch_claude.py
+++ b/scripts/fetch_claude.py
@@ -14,7 +14,7 @@ import re
 import socket
 import sys
 from collections import defaultdict
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Optional
 
@@ -65,7 +65,7 @@ def get_agent_session_id_from_path(project_path: str) -> Optional[str]:
 
 
 def parse_timestamp(ts_str: str) -> str:
-    """Extract date from ISO timestamp."""
+    """Extract date from ISO timestamp, converting UTC to local time."""
     if not ts_str:
         return "unknown"
     try:
@@ -77,6 +77,8 @@ def parse_timestamp(ts_str: str) -> str:
                 dt = datetime.strptime(f"{base}.{ms}Z", "%Y-%m-%dT%H:%M:%S.%fZ")
             else:
                 dt = datetime.strptime(ts_str, "%Y-%m-%dT%H:%M:%SZ")
+            # UTC time - convert to local time for date extraction
+            dt = dt.replace(tzinfo=timezone.utc).astimezone()
         else:
             dt = datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
         return dt.strftime("%Y-%m-%d")

--- a/scripts/fetch_codex.py
+++ b/scripts/fetch_codex.py
@@ -110,7 +110,7 @@ def find_codex_session_dir() -> Optional[Path]:
 
 
 def parse_timestamp(ts_str: str) -> str:
-    """Extract date (YYYY-MM-DD) from ISO timestamp string."""
+    """Extract date (YYYY-MM-DD) from ISO timestamp string, converting UTC to local time."""
     if not ts_str:
         return "unknown"
     try:
@@ -122,6 +122,8 @@ def parse_timestamp(ts_str: str) -> str:
                 dt = datetime.strptime(f"{base}.{ms}Z", "%Y-%m-%dT%H:%M:%S.%fZ")
             else:
                 dt = datetime.strptime(ts_str, "%Y-%m-%dT%H:%M:%SZ")
+            # UTC time - convert to local time for date extraction
+            dt = dt.replace(tzinfo=timezone.utc).astimezone()
         else:
             dt = datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
         return dt.strftime("%Y-%m-%d")

--- a/scripts/fetch_openclaw.py
+++ b/scripts/fetch_openclaw.py
@@ -16,7 +16,7 @@ import socket
 import sys
 import uuid
 from collections import defaultdict
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Optional
 
@@ -94,7 +94,6 @@ def parse_timestamp(ts_str: str) -> str:
         return "unknown"
     try:
         if ts_str.endswith("Z"):
-            # UTC time - convert to local time (assuming UTC+8 for China)
             if "." in ts_str:
                 base, rest = ts_str.rsplit(".", 1)
                 ms = rest.rstrip("Z")
@@ -102,14 +101,11 @@ def parse_timestamp(ts_str: str) -> str:
                 dt = datetime.strptime(f"{base}.{ms}Z", "%Y-%m-%dT%H:%M:%S.%fZ")
             else:
                 dt = datetime.strptime(ts_str, "%Y-%m-%dT%H:%M:%SZ")
-            # Convert UTC to local time (UTC+8 for China)
-            from datetime import timedelta
-
-            local_dt = dt + timedelta(hours=8)
-            return local_dt.strftime("%Y-%m-%d")
+            # UTC time - convert to local time for date extraction
+            dt = dt.replace(tzinfo=timezone.utc).astimezone()
         else:
             dt = datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
-            return dt.strftime("%Y-%m-%d")
+        return dt.strftime("%Y-%m-%d")
     except Exception:
         return "unknown"
 

--- a/scripts/fetch_qwen.py
+++ b/scripts/fetch_qwen.py
@@ -13,7 +13,7 @@ import re
 import socket
 import sys
 from collections import defaultdict
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Optional
 
@@ -181,12 +181,10 @@ def parse_timestamp(ts_str: str) -> str:
             else:
                 dt = datetime.strptime(ts_str, "%Y-%m-%dT%H:%M:%SZ")
             # Convert UTC to local time
-            from datetime import timezone
             dt = dt.replace(tzinfo=timezone.utc).astimezone()
         else:
             dt = datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
             if dt.tzinfo is None:
-                from datetime import timezone
                 dt = dt.replace(tzinfo=timezone.utc).astimezone()
         return dt.strftime("%Y-%m-%d")
     except Exception:

--- a/scripts/fetch_qwen.py
+++ b/scripts/fetch_qwen.py
@@ -162,11 +162,17 @@ def get_agent_session_id_from_path(project_path: str) -> Optional[str]:
 
 
 def parse_timestamp(ts_str: str) -> str:
-    """Extract date from ISO timestamp."""
+    """Extract date from ISO timestamp, converting UTC to local time.
+
+    This ensures consistency with get_today() which uses local time.
+    Fixes issue #1322: UTC/local time mismatch causing early morning
+    usage data to be stored under the previous day's date.
+    """
     if not ts_str:
         return "unknown"
     try:
         if ts_str.endswith("Z"):
+            # UTC time - convert to local time for date extraction
             if "." in ts_str:
                 base, rest = ts_str.rsplit(".", 1)
                 ms = rest.rstrip("Z")
@@ -174,8 +180,14 @@ def parse_timestamp(ts_str: str) -> str:
                 dt = datetime.strptime(f"{base}.{ms}Z", "%Y-%m-%dT%H:%M:%S.%fZ")
             else:
                 dt = datetime.strptime(ts_str, "%Y-%m-%dT%H:%M:%SZ")
+            # Convert UTC to local time
+            from datetime import timezone
+            dt = dt.replace(tzinfo=timezone.utc).astimezone()
         else:
             dt = datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
+            if dt.tzinfo is None:
+                from datetime import timezone
+                dt = dt.replace(tzinfo=timezone.utc).astimezone()
         return dt.strftime("%Y-%m-%d")
     except Exception:
         return "unknown"

--- a/scripts/fetch_zcode.py
+++ b/scripts/fetch_zcode.py
@@ -113,11 +113,13 @@ def find_zcode_db_path() -> Optional[Path]:
 
 
 def _ms_to_date(ms: Optional[int]) -> str:
-    """Convert epoch milliseconds to a YYYY-MM-DD date string (UTC)."""
+    """Convert epoch milliseconds to a YYYY-MM-DD date string (local time)."""
     if not ms:
         return "unknown"
     try:
-        return datetime.fromtimestamp(ms / 1000, tz=timezone.utc).strftime("%Y-%m-%d")
+        # Convert UTC timestamp to local time for date extraction
+        dt = datetime.fromtimestamp(ms / 1000, tz=timezone.utc).astimezone()
+        return dt.strftime("%Y-%m-%d")
     except (ValueError, OSError, OverflowError):
         return "unknown"
 


### PR DESCRIPTION
## 问题

Issue #1322: UTC/本地时间不一致导致凌晨时段用量数据不显示

### 根因分析
- CLI 工具日志时间戳为 UTC 格式（如 `2026-06-26T17:16:31.380Z`）
- fetch 脚本直接从 UTC 时间提取日期 → `2026-06-26`
- 但 `get_today()` 和前端查询使用本地时间 → `2026-06-27`
- 结果：凌晨时段（本地时间 00:00-08:00）的会话被存储到前一天日期，前端查询今日数据时不可见

## 解决方案

统一使用本地时间：所有 `parse_timestamp` 函数将 UTC 时间转换为本地时间后再提取日期，确保与 `get_today()` 一致。

## 修改文件

| 文件 | 修改内容 |
|------|---------|
| `scripts/fetch_qwen.py` | UTC → 本地时间转换 |
| `scripts/fetch_claude.py` | UTC → 本地时间转换 |
| `scripts/fetch_codex.py` | UTC → 本地时间转换 |
| `scripts/fetch_zcode.py` | `_ms_to_date()` UTC → 本地时间转换 |
| `scripts/fetch_openclaw.py` | 移除硬编码 UTC+8，使用系统时区 |

## 测试验证

- `ruff check` 通过
- 本地时间转换逻辑使用标准 Python `timezone.utc.astimezone()` 方法

Closes #1322