### PR TITLE
fix(migration): initialize project_categories with default data

### DIFF
--- a/migrations/versions/20260627_001_init_project_categories_data.py
+++ b/migrations/versions/20260627_001_init_project_categories_data.py
@@ -1,0 +1,74 @@
+"""Initialize project_categories with default data
+
+Revision ID: 20260627_001_init_project_categories
+Revises: 20260626_004_fix_tenant_quotas_overflow
+Create Date: 2026-06-27
+
+Issue: #1327
+Initialize project_categories table with default categories.
+This ensures projects are properly categorized instead of all showing as "uncategorized".
+
+Default categories:
+- Frontend: projects with frontend/web/ui keywords
+- Backend: projects with backend/api/server keywords
+- Testing: projects with test/tests/spec keywords
+"""
+
+import sqlalchemy as sa
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "20260627_001_init_project_categories"
+down_revision: Union[str, None] = "20260626_004_fix_tenant_quotas_overflow"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Insert default project categories."""
+    conn = op.get_bind()
+
+    # Check if data already exists to avoid duplicates
+    result = conn.execute(sa.text("SELECT COUNT(*) as count FROM project_categories"))
+    row = result.fetchone()
+    count = row[0] if row else 0
+
+    if count > 0:
+        return
+
+    # Insert default categories
+    if conn.dialect.name == "postgresql":
+        # PostgreSQL uses TRUE/FALSE for boolean
+        op.execute(
+            """
+            INSERT INTO project_categories (name, key_patterns, sort_order, is_active)
+            VALUES
+                ('Frontend', '["frontend", "web", "ui"]', 1, TRUE),
+                ('Backend', '["backend", "api", "server"]', 2, TRUE),
+                ('Testing', '["test", "tests", "spec"]', 3, TRUE)
+            """
+        )
+    else:
+        # SQLite uses 1/0 for boolean
+        op.execute(
+            """
+            INSERT INTO project_categories (name, key_patterns, sort_order, is_active)
+            VALUES
+                ('Frontend', '["frontend", "web", "ui"]', 1, 1),
+                ('Backend', '["backend", "api", "server"]', 2, 1),
+                ('Testing', '["test", "tests", "spec"]', 3, 1)
+            """
+        )
+
+
+def downgrade() -> None:
+    """Remove default project categories."""
+    # Delete the default categories we inserted
+    op.execute(
+        """
+        DELETE FROM project_categories
+        WHERE name IN ('Frontend', 'Backend', 'Testing')
+        AND key_patterns IN ('["frontend", "web", "ui"]', '["backend", "api", "server"]', '["test", "tests", "spec"]')
+        """
+    )

--- a/migrations/versions/20260627_001_init_project_categories_data.py
+++ b/migrations/versions/20260627_001_init_project_categories_data.py
@@ -65,7 +65,9 @@ def upgrade() -> None:
             """
         )
 
-    logger.info("Initialized project_categories with default categories: Frontend, Backend, Testing")
+    logger.info(
+        "Initialized project_categories with default categories: Frontend, Backend, Testing"
+    )
 
 
 def downgrade() -> None:

--- a/migrations/versions/20260627_001_init_project_categories_data.py
+++ b/migrations/versions/20260627_001_init_project_categories_data.py
@@ -14,10 +14,13 @@ Default categories:
 - Testing: projects with test/tests/spec keywords
 """
 
-import sqlalchemy as sa
+import logging
 from typing import Sequence, Union
 
+import sqlalchemy as sa
 from alembic import op
+
+logger = logging.getLogger(__name__)
 
 revision: str = "20260627_001_init_project_categories"
 down_revision: Union[str, None] = "20260626_004_fix_tenant_quotas_overflow"
@@ -35,6 +38,7 @@ def upgrade() -> None:
     count = row[0] if row else 0
 
     if count > 0:
+        logger.info(f"project_categories already has {count} records, skipping initialization")
         return
 
     # Insert default categories
@@ -61,6 +65,8 @@ def upgrade() -> None:
             """
         )
 
+    logger.info("Initialized project_categories with default categories: Frontend, Backend, Testing")
+
 
 def downgrade() -> None:
     """Remove default project categories."""
@@ -72,3 +78,5 @@ def downgrade() -> None:
         AND key_patterns IN ('["frontend", "web", "ui"]', '["backend", "api", "server"]', '["test", "tests", "spec"]')
         """
     )
+
+    logger.info("Removed default project categories: Frontend, Backend, Testing")

--- a/tests/unit/test_alembic_sqlite_upgrade.py
+++ b/tests/unit/test_alembic_sqlite_upgrade.py
@@ -85,8 +85,8 @@ def test_alembic_upgrade_head_succeeds_for_fresh_sqlite(tmp_path, monkeypatch):
 
     assert version is not None
     # Migration chain: 001_run_timeline -> 002_content_language -> 003_status_index
-    # -> 001_add_project_categories -> 004_fix_tenant_quotas_overflow
-    assert version[0] == "20260626_004_fix_tenant_quotas_overflow"
+    # -> 001_add_project_categories -> 004_fix_tenant_quotas_overflow -> 001_init_project_categories
+    assert version[0] == "20260627_001_init_project_categories"
     if has_session_messages:
         assert "source" in columns
     assert has_mapping_rules is True


### PR DESCRIPTION
## Summary

Fixes #1327

Project categorization feature was not working because `project_categories` table had no initial data. All projects showed as "uncategorized" instead of being properly grouped.

## Changes

- Add migration script `20260627_001_init_project_categories_data.py` to insert 3 default categories:
  - **Frontend**: matches `frontend/web/ui` keywords
  - **Backend**: matches `backend/api/server` keywords
  - **Testing**: matches `test/tests/spec` keywords
- Update alembic test to assert new head revision

## Migration Features

- ✅ Idempotent: checks for existing data before inserting
- ✅ PostgreSQL/SQLite compatible
- ✅ Supports downgrade (removes default categories)

## Test Plan

```bash
pytest tests/unit/test_alembic_sqlite_upgrade.py -v
```

All 3 tests passed.