### PR TITLE
fix(PageRefreshControl): 隐藏空下拉菜单避免点击无内容

### DIFF
--- a/frontend/src/components/common/PageRefreshControl.test.tsx
+++ b/frontend/src/components/common/PageRefreshControl.test.tsx
@@ -136,6 +136,58 @@ describe('PageRefreshControl', () => {
 
       expect(screen.getByTestId('refresh-error-indicator')).toBeInTheDocument();
     });
+
+    it('should render static clock icon when no dropdown content in compact mode', () => {
+      const mockRefresh = createMockRefresh();
+
+      render(
+        <PageRefreshControl
+          refresh={mockRefresh}
+          compact={true}
+          showAutoRefreshToggle={false}
+          showIntervalSelector={false}
+        />
+      );
+
+      // Should render static clock icon instead of dropdown toggle
+      expect(screen.getByTestId('refresh-clock-icon')).toBeInTheDocument();
+      expect(screen.queryByTestId('dropdown-toggle')).not.toBeInTheDocument();
+    });
+
+    it('should show tooltip on static clock icon with last refresh time', () => {
+      const mockRefresh = createMockRefresh();
+      mockRefresh.lastRefreshTime = Date.now() - 120000;
+
+      render(
+        <PageRefreshControl
+          refresh={mockRefresh}
+          compact={true}
+          showAutoRefreshToggle={false}
+          showIntervalSelector={false}
+          showLastRefreshTime={true}
+        />
+      );
+
+      const clockIcon = screen.getByTestId('refresh-clock-icon');
+      expect(clockIcon).toHaveAttribute('title');
+      expect(clockIcon.getAttribute('title')).toContain('Last Refresh');
+    });
+
+    it('should still render manual refresh button when no dropdown content', () => {
+      const mockRefresh = createMockRefresh();
+
+      render(
+        <PageRefreshControl
+          refresh={mockRefresh}
+          compact={true}
+          showAutoRefreshToggle={false}
+          showIntervalSelector={false}
+        />
+      );
+
+      // Manual refresh button should always be present
+      expect(screen.getByTestId('manual-refresh-button')).toBeInTheDocument();
+    });
   });
 
   describe('manual refresh only mode', () => {

--- a/frontend/src/components/common/PageRefreshControl.tsx
+++ b/frontend/src/components/common/PageRefreshControl.tsx
@@ -183,6 +183,9 @@ export const PageRefreshControl: React.FC<PageRefreshControlProps> = ({
   // Error indicator
   const hasError = showErrorIndicator && error && errorCount > 0;
 
+  // Check if dropdown has any content (auto refresh toggle or interval selector)
+  const hasDropdownContent = showAutoRefreshToggle || (showIntervalSelector && autoRefresh);
+
   if (compact) {
     // Compact mode: just icon buttons with dropdown
     return (
@@ -203,61 +206,70 @@ export const PageRefreshControl: React.FC<PageRefreshControlProps> = ({
           />
         )}
 
-        {/* Dropdown for settings */}
-        <div className="dropdown">
-          <button
-            className="btn btn-link btn-sm p-0"
-            type="button"
-            data-bs-toggle="dropdown"
-            aria-expanded="false"
-            title={buildTooltip()}
-            data-testid="dropdown-toggle"
-          >
-            <i className={cn('bi', autoRefresh ? 'bi-clock' : 'bi-clock-history')} />
-          </button>
-          <ul className="dropdown-menu dropdown-menu-end">
-            {showAutoRefreshToggle && (
-              <li>
-                <div className="dropdown-item-text">
-                  <div className="form-check form-switch">
-                    <input
-                      className="form-check-input"
-                      type="checkbox"
-                      id={`${position}-auto-refresh`}
-                      checked={autoRefresh}
-                      onChange={(e) => setAutoRefresh(e.target.checked)}
-                    />
-                    <label className="form-check-label" htmlFor={`${position}-auto-refresh`}>
-                      {t('autoRefresh', language)}
-                    </label>
+        {/* Dropdown for settings - only render if there's content */}
+        {hasDropdownContent ? (
+          <div className="dropdown">
+            <button
+              className="btn btn-link btn-sm p-0"
+              type="button"
+              data-bs-toggle="dropdown"
+              aria-expanded="false"
+              title={buildTooltip()}
+              data-testid="dropdown-toggle"
+            >
+              <i className={cn('bi', autoRefresh ? 'bi-clock' : 'bi-clock-history')} />
+            </button>
+            <ul className="dropdown-menu dropdown-menu-end">
+              {showAutoRefreshToggle && (
+                <li>
+                  <div className="dropdown-item-text">
+                    <div className="form-check form-switch">
+                      <input
+                        className="form-check-input"
+                        type="checkbox"
+                        id={`${position}-auto-refresh`}
+                        checked={autoRefresh}
+                        onChange={(e) => setAutoRefresh(e.target.checked)}
+                      />
+                      <label className="form-check-label" htmlFor={`${position}-auto-refresh`}>
+                        {t('autoRefresh', language)}
+                      </label>
+                    </div>
                   </div>
-                </div>
-              </li>
-            )}
-            {showIntervalSelector && autoRefresh && (
-              <>
-                <li>
-                  <hr className="dropdown-divider" />
                 </li>
-                <li>
-                  <span className="dropdown-item-text small text-muted">
-                    {t('refreshInterval', language)}
-                  </span>
-                </li>
-                {intervalOptions.map((option) => (
-                  <li key={option.value}>
-                    <button
-                      className={cn('dropdown-item', interval === option.value && 'active')}
-                      onClick={() => setInterval(option.value)}
-                    >
-                      {t(option.label, language)}
-                    </button>
+              )}
+              {showIntervalSelector && autoRefresh && (
+                <>
+                  <li>
+                    <hr className="dropdown-divider" />
                   </li>
-                ))}
-              </>
-            )}
-          </ul>
-        </div>
+                  <li>
+                    <span className="dropdown-item-text small text-muted">
+                      {t('refreshInterval', language)}
+                    </span>
+                  </li>
+                  {intervalOptions.map((option) => (
+                    <li key={option.value}>
+                      <button
+                        className={cn('dropdown-item', interval === option.value && 'active')}
+                        onClick={() => setInterval(option.value)}
+                      >
+                        {t(option.label, language)}
+                      </button>
+                    </li>
+                  ))}
+                </>
+              )}
+            </ul>
+          </div>
+        ) : (
+          /* Static clock icon when no dropdown content - shows last refresh time tooltip */
+          <i
+            className={cn('bi bi-clock-history', 'text-muted')}
+            title={buildTooltip()}
+            data-testid="refresh-clock-icon"
+          />
+        )}
 
         {/* Manual refresh button */}
         <button


### PR DESCRIPTION
## 问题描述

管理页面 PageRefreshControl 小闹钟按钮点击后显示空下拉菜单

## 原因分析

所有管理页面的 PageRefreshControl 组件配置都关闭了下拉菜单选项：
- `showAutoRefreshToggle={false}` - 不显示自动刷新开关
- `showIntervalSelector={false}` - 不显示间隔选择器

导致下拉菜单没有任何内容，用户点击后看到空白菜单。

## 修复内容

在 compact 模式下添加 `hasDropdownContent` 判断：
- 当 `showAutoRefreshToggle=false` 且 `showIntervalSelector=false` 时
- 渲染静态时钟图标而非下拉按钮
- 保留手动刷新按钮和上次刷新时间 tooltip

## 影响页面

- ProjectManagement
- TenantManagement  
- APIKeyManagement
- SecurityCenter
- AuditCenter
- QuotaAlerts
- ComplianceMgmt

Fixes #1330