### PR TITLE
fix(PageRefreshControl): 修复管理页面下拉面板被容器遮挡问题 (Issue #1331)

### DIFF
--- a/frontend/src/components/common/PageRefreshControl.tsx
+++ b/frontend/src/components/common/PageRefreshControl.tsx
@@ -269,12 +269,10 @@ export const PageRefreshControl: React.FC<PageRefreshControlProps> = ({
         {hasDropdownContent ? (
           <button
             ref={dropdownButtonRef}
-            className={cn(
-              'btn btn-link btn-sm p-0',
-              isDropdownOpen && 'active'
-            )}
+            className={cn('btn btn-link btn-sm p-0', isDropdownOpen && 'active')}
             type="button"
             onClick={handleDropdownToggle}
+            aria-haspopup="true"
             aria-expanded={isDropdownOpen}
             title={buildTooltip()}
             data-testid="dropdown-toggle"
@@ -322,6 +320,8 @@ export const PageRefreshControl: React.FC<PageRefreshControlProps> = ({
                 ref={dropdownPanelRef}
                 className="page-refresh-dropdown-panel"
                 style={getDropdownPosition()}
+                role="menu"
+                aria-label={t('settings', language)}
                 data-testid="dropdown-panel"
               >
                 {showAutoRefreshToggle && (
@@ -334,10 +334,7 @@ export const PageRefreshControl: React.FC<PageRefreshControlProps> = ({
                         checked={autoRefresh}
                         onChange={(e) => setAutoRefresh(e.target.checked)}
                       />
-                      <label
-                        className="form-check-label"
-                        htmlFor={`${position}-auto-refresh`}
-                      >
+                      <label className="form-check-label" htmlFor={`${position}-auto-refresh`}>
                         {t('autoRefresh', language)}
                       </label>
                     </div>
@@ -358,6 +355,7 @@ export const PageRefreshControl: React.FC<PageRefreshControlProps> = ({
                           'page-refresh-dropdown-option',
                           interval === option.value && 'active'
                         )}
+                        role="menuitem"
                         onClick={() => handleIntervalSelect(option.value)}
                       >
                         {t(option.label, language)}

--- a/frontend/src/components/common/PageRefreshControl.tsx
+++ b/frontend/src/components/common/PageRefreshControl.tsx
@@ -7,10 +7,11 @@
  * - Manual refresh button with debounce
  * - Refresh status indicators (last/next refresh time)
  * - Error indicator
- * - Compact mode for mobile
+ * - Compact mode for mobile with Portal-based dropdown (z-index fixed)
  */
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
+import { createPortal } from 'react-dom';
 import { cn } from '@/utils';
 import { useLanguage } from '@/hooks';
 import { t, type Language } from '@/i18n';
@@ -114,6 +115,9 @@ export const PageRefreshControl: React.FC<PageRefreshControlProps> = ({
   const language = useLanguage();
   const [isButtonDisabled, setIsButtonDisabled] = useState(false);
   const [countdown, setCountdown] = useState('');
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+  const dropdownButtonRef = useRef<HTMLButtonElement>(null);
+  const dropdownPanelRef = useRef<HTMLDivElement>(null);
 
   const {
     isRefreshing,
@@ -158,6 +162,20 @@ export const PageRefreshControl: React.FC<PageRefreshControlProps> = ({
     return () => window.clearInterval(intervalId);
   }, [showNextRefreshTime, autoRefresh, nextRefreshTime]);
 
+  // Close dropdown on Escape key
+  useEffect(() => {
+    if (!isDropdownOpen) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setIsDropdownOpen(false);
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [isDropdownOpen]);
+
   // Build tooltip content
   const buildTooltip = () => {
     const parts: string[] = [];
@@ -173,6 +191,31 @@ export const PageRefreshControl: React.FC<PageRefreshControlProps> = ({
     return parts.join('\n');
   };
 
+  // Calculate dropdown panel position
+  const getDropdownPosition = useCallback(() => {
+    if (!dropdownButtonRef.current) return { top: 0, left: 0 };
+
+    const buttonRect = dropdownButtonRef.current.getBoundingClientRect();
+    const panelWidth = 200; // Estimated panel width
+    const panelHeight = 300; // Estimated max panel height
+
+    // Default: show below the button, aligned to the right
+    let top = buttonRect.bottom + 8;
+    let left = buttonRect.right - panelWidth;
+
+    // Adjust if panel would go beyond viewport bottom
+    if (top + panelHeight > window.innerHeight) {
+      top = buttonRect.top - panelHeight - 8;
+    }
+
+    // Adjust if panel would go beyond viewport left
+    if (left < 0) {
+      left = buttonRect.left;
+    }
+
+    return { top, left };
+  }, []);
+
   // Position styles
   const positionStyles = {
     'top-right': 'position-absolute top-0 end-0',
@@ -183,8 +226,27 @@ export const PageRefreshControl: React.FC<PageRefreshControlProps> = ({
   // Error indicator
   const hasError = showErrorIndicator && error && errorCount > 0;
 
+  // Check if dropdown has any content (auto refresh toggle or interval selector)
+  const hasDropdownContent = showAutoRefreshToggle || (showIntervalSelector && autoRefresh);
+
+  // Handle dropdown toggle
+  const handleDropdownToggle = () => {
+    setIsDropdownOpen((prev) => !prev);
+  };
+
+  // Handle backdrop click
+  const handleBackdropClick = () => {
+    setIsDropdownOpen(false);
+  };
+
+  // Handle interval selection
+  const handleIntervalSelect = (value: number) => {
+    setInterval(value);
+    setIsDropdownOpen(false);
+  };
+
   if (compact) {
-    // Compact mode: just icon buttons with dropdown
+    // Compact mode: icon buttons with Portal-based dropdown
     return (
       <div
         className={cn(
@@ -203,61 +265,30 @@ export const PageRefreshControl: React.FC<PageRefreshControlProps> = ({
           />
         )}
 
-        {/* Dropdown for settings */}
-        <div className="dropdown">
+        {/* Dropdown toggle button - only render if there's content */}
+        {hasDropdownContent ? (
           <button
-            className="btn btn-link btn-sm p-0"
+            ref={dropdownButtonRef}
+            className={cn(
+              'btn btn-link btn-sm p-0',
+              isDropdownOpen && 'active'
+            )}
             type="button"
-            data-bs-toggle="dropdown"
-            aria-expanded="false"
+            onClick={handleDropdownToggle}
+            aria-expanded={isDropdownOpen}
             title={buildTooltip()}
             data-testid="dropdown-toggle"
           >
             <i className={cn('bi', autoRefresh ? 'bi-clock' : 'bi-clock-history')} />
           </button>
-          <ul className="dropdown-menu dropdown-menu-end">
-            {showAutoRefreshToggle && (
-              <li>
-                <div className="dropdown-item-text">
-                  <div className="form-check form-switch">
-                    <input
-                      className="form-check-input"
-                      type="checkbox"
-                      id={`${position}-auto-refresh`}
-                      checked={autoRefresh}
-                      onChange={(e) => setAutoRefresh(e.target.checked)}
-                    />
-                    <label className="form-check-label" htmlFor={`${position}-auto-refresh`}>
-                      {t('autoRefresh', language)}
-                    </label>
-                  </div>
-                </div>
-              </li>
-            )}
-            {showIntervalSelector && autoRefresh && (
-              <>
-                <li>
-                  <hr className="dropdown-divider" />
-                </li>
-                <li>
-                  <span className="dropdown-item-text small text-muted">
-                    {t('refreshInterval', language)}
-                  </span>
-                </li>
-                {intervalOptions.map((option) => (
-                  <li key={option.value}>
-                    <button
-                      className={cn('dropdown-item', interval === option.value && 'active')}
-                      onClick={() => setInterval(option.value)}
-                    >
-                      {t(option.label, language)}
-                    </button>
-                  </li>
-                ))}
-              </>
-            )}
-          </ul>
-        </div>
+        ) : (
+          /* Static clock icon when no dropdown content - shows last refresh time tooltip */
+          <i
+            className={cn('bi bi-clock-history', 'text-muted')}
+            title={buildTooltip()}
+            data-testid="refresh-clock-icon"
+          />
+        )}
 
         {/* Manual refresh button */}
         <button
@@ -274,6 +305,70 @@ export const PageRefreshControl: React.FC<PageRefreshControlProps> = ({
             )}
           />
         </button>
+
+        {/* Portal-rendered dropdown panel */}
+        {isDropdownOpen &&
+          createPortal(
+            <>
+              {/* Backdrop overlay */}
+              <div
+                className="page-refresh-dropdown-backdrop"
+                onClick={handleBackdropClick}
+                data-testid="dropdown-backdrop"
+              />
+
+              {/* Dropdown panel */}
+              <div
+                ref={dropdownPanelRef}
+                className="page-refresh-dropdown-panel"
+                style={getDropdownPosition()}
+                data-testid="dropdown-panel"
+              >
+                {showAutoRefreshToggle && (
+                  <div className="page-refresh-dropdown-item">
+                    <div className="form-check form-switch">
+                      <input
+                        className="form-check-input"
+                        type="checkbox"
+                        id={`${position}-auto-refresh`}
+                        checked={autoRefresh}
+                        onChange={(e) => setAutoRefresh(e.target.checked)}
+                      />
+                      <label
+                        className="form-check-label"
+                        htmlFor={`${position}-auto-refresh`}
+                      >
+                        {t('autoRefresh', language)}
+                      </label>
+                    </div>
+                  </div>
+                )}
+
+                {showIntervalSelector && autoRefresh && (
+                  <>
+                    <div className="page-refresh-dropdown-divider" />
+                    <div className="page-refresh-dropdown-header">
+                      {t('refreshInterval', language)}
+                    </div>
+                    {intervalOptions.map((option) => (
+                      <button
+                        key={option.value}
+                        className={cn(
+                          'page-refresh-dropdown-item',
+                          'page-refresh-dropdown-option',
+                          interval === option.value && 'active'
+                        )}
+                        onClick={() => handleIntervalSelect(option.value)}
+                      >
+                        {t(option.label, language)}
+                      </button>
+                    ))}
+                  </>
+                )}
+              </div>
+            </>,
+            document.body
+          )}
       </div>
     );
   }

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -1869,6 +1869,70 @@ table .latency-row:hover td {
   background: rgba(239, 68, 68, 0.1) !important;
 }
 
+/* PageRefreshControl Portal Dropdown Styles */
+.page-refresh-dropdown-backdrop {
+  position: fixed;
+  inset: 0;
+  background: var(--bg-overlay);
+  z-index: var(--z-modal-backdrop);
+}
+
+.page-refresh-dropdown-panel {
+  position: fixed;
+  min-width: 180px;
+  max-width: 280px;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--border-radius);
+  box-shadow: var(--shadow-lg);
+  padding: var(--spacing-xs) 0;
+  z-index: var(--z-popover);
+  color: var(--text-primary);
+}
+
+.page-refresh-dropdown-item {
+  padding: var(--spacing-sm) var(--spacing-md);
+  color: var(--text-primary);
+  transition: background-color var(--transition-fast);
+}
+
+.page-refresh-dropdown-item:hover {
+  background: var(--bg-tertiary);
+}
+
+.page-refresh-dropdown-item.active {
+  background: var(--color-primary);
+  color: var(--text-inverse);
+}
+
+.page-refresh-dropdown-item.active:hover {
+  background: var(--color-primary-hover);
+  color: var(--text-inverse);
+}
+
+.page-refresh-dropdown-option {
+  display: block;
+  width: 100%;
+  text-align: left;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  font-size: var(--font-size-sm);
+}
+
+.page-refresh-dropdown-divider {
+  height: 1px;
+  background: var(--border-color);
+  margin: var(--spacing-xs) 0;
+}
+
+.page-refresh-dropdown-header {
+  padding: var(--spacing-xs) var(--spacing-md);
+  font-size: var(--font-size-xs);
+  color: var(--text-muted);
+  font-weight: var(--font-weight-medium);
+}
+
 /* Fix for header dropdown button color */
 .header .dropdown-toggle {
   color: var(--text-primary) !important;


### PR DESCRIPTION
## 问题描述

Issue #1331: 管理页面 PageRefreshControl 下拉面板被容器遮挡

右上角搜索框右侧有两个图标按钮（时间筛选 / 刷新），点击后弹出的下拉悬浮面板被页面容器遮挡，完全看不到下拉内容，存在层级 (z-index)、定位偏移、溢出裁剪问题。

## 修复方案

1. **React Portal** - 将下拉面板渲染到 `document.body`，避免父容器 `overflow: hidden` 裁剪
2. **z-index 层级** - 使用 CSS 变量设置正确的层级：
   - Backdrop: `--z-modal-backdrop (400)`
   - Panel: `--z-popover (600)`
3. **轻量遮罩** - 添加半透明遮罩区分弹窗与底层页面
4. **智能定位** - 自动计算定位，避免超出可视区域边界
5. **交互优化** - 支持 Escape 键关闭、点击遮罩关闭
6. **UI 风格统一** - 使用现有 CSS 变量（圆角、阴影、配色）

## 影响范围

所有使用 PageRefreshControl compact 模式的管理页面：
- ProjectManagement
- TenantManagement
- APIKeyManagement
- SecurityCenter
- AuditCenter
- QuotaAlerts
- ComplianceMgmt
- RequestDashboard

## 测试

- TypeScript 类型检查通过
- 17 个单元测试全部通过

## 关联 Issue

Fixes #1331