### PR TITLE
fix(PageRefresh): 修正 refreshKey 配置使刷新按钮生效 (Issue #1335)

### DIFF
--- a/frontend/src/components/features/analysis/AnomalyDetection.tsx
+++ b/frontend/src/components/features/analysis/AnomalyDetection.tsx
@@ -60,7 +60,13 @@ export const AnomalyDetection: React.FC = () => {
   // Page refresh control - manual refresh for anomaly detection
   const pageRefresh = usePageRefresh({
     page: '/manage/analysis/anomaly',
-    refreshKey: createMatcherConfig([['analysis', 'anomaly-detection'], ['analysis', 'anomaly-trend']], 'prefix'),
+    refreshKey: createMatcherConfig(
+      [
+        ['analysis', 'anomaly-detection'],
+        ['analysis', 'anomaly-trend'],
+      ],
+      'prefix'
+    ),
     interval: 0, // No auto refresh - manual only
     enabled: false,
   });

--- a/frontend/src/components/features/analysis/AnomalyDetection.tsx
+++ b/frontend/src/components/features/analysis/AnomalyDetection.tsx
@@ -60,7 +60,7 @@ export const AnomalyDetection: React.FC = () => {
   // Page refresh control - manual refresh for anomaly detection
   const pageRefresh = usePageRefresh({
     page: '/manage/analysis/anomaly',
-    refreshKey: createMatcherConfig([['analysis', 'anomaly']], 'prefix'),
+    refreshKey: createMatcherConfig([['analysis', 'anomaly-detection'], ['analysis', 'anomaly-trend']], 'prefix'),
     interval: 0, // No auto refresh - manual only
     enabled: false,
   });

--- a/frontend/src/components/features/analysis/ROIAnalysis.tsx
+++ b/frontend/src/components/features/analysis/ROIAnalysis.tsx
@@ -180,6 +180,9 @@ export const ROIAnalysis: React.FC = () => {
     refreshKey: createMatcherConfig([['analysis', 'roi']], 'prefix'),
     interval: 0, // No auto refresh - manual only
     enabled: false,
+    // Note: fetchData defined below, use arrow function to avoid hoisting issues
+    // forceRefresh=true to bypass cache and fetch fresh data
+    onRefresh: () => fetchData(true),
   });
 
   // Initialize dates

--- a/frontend/src/components/features/analysis/TrendAnalysis.tsx
+++ b/frontend/src/components/features/analysis/TrendAnalysis.tsx
@@ -77,7 +77,7 @@ export const TrendAnalysis: React.FC = () => {
   // Page refresh control - manual refresh for trend analysis
   const pageRefresh = usePageRefresh({
     page: '/manage/analysis/trend',
-    refreshKey: createMatcherConfig([['analysis', 'batch'], ['analysis', 'anomaly-trend']], 'prefix'),
+    refreshKey: createMatcherConfig([['analysis', 'batch']], 'prefix'),
     interval: 0, // No auto refresh - manual only
     enabled: false,
   });

--- a/frontend/src/components/features/analysis/TrendAnalysis.tsx
+++ b/frontend/src/components/features/analysis/TrendAnalysis.tsx
@@ -77,7 +77,7 @@ export const TrendAnalysis: React.FC = () => {
   // Page refresh control - manual refresh for trend analysis
   const pageRefresh = usePageRefresh({
     page: '/manage/analysis/trend',
-    refreshKey: createMatcherConfig([['analysis', 'trend']], 'prefix'),
+    refreshKey: createMatcherConfig([['analysis', 'batch'], ['analysis', 'anomaly-trend']], 'prefix'),
     interval: 0, // No auto refresh - manual only
     enabled: false,
   });

--- a/frontend/src/components/features/management/AuditCenter.tsx
+++ b/frontend/src/components/features/management/AuditCenter.tsx
@@ -110,7 +110,13 @@ export const AuditCenter: React.FC = () => {
   // --- Page Refresh Control ---
   const pageRefresh = usePageRefresh({
     page: '/manage/audit',
-    refreshKey: createMatcherConfig([['admin', 'audit-logs'], ['admin', 'audit-thresholds']], 'prefix'),
+    refreshKey: createMatcherConfig(
+      [
+        ['admin', 'audit-logs'],
+        ['admin', 'audit-thresholds'],
+      ],
+      'prefix'
+    ),
     interval: 0, // No auto refresh - manual only for audit logs
     enabled: false,
   });

--- a/frontend/src/components/features/management/AuditCenter.tsx
+++ b/frontend/src/components/features/management/AuditCenter.tsx
@@ -110,7 +110,7 @@ export const AuditCenter: React.FC = () => {
   // --- Page Refresh Control ---
   const pageRefresh = usePageRefresh({
     page: '/manage/audit',
-    refreshKey: createMatcherConfig([['audit']], 'prefix'),
+    refreshKey: createMatcherConfig([['admin', 'audit-logs'], ['admin', 'audit-thresholds']], 'prefix'),
     interval: 0, // No auto refresh - manual only for audit logs
     enabled: false,
   });

--- a/frontend/src/components/features/management/ComplianceMgmt.tsx
+++ b/frontend/src/components/features/management/ComplianceMgmt.tsx
@@ -182,6 +182,10 @@ export const ComplianceMgmt: React.FC = () => {
     refreshKey: createMatcherConfig([['compliance']], 'prefix'),
     interval: 0, // No auto refresh - manual only for compliance data
     enabled: false,
+    onRefresh: () => {
+      fetchReportsData();
+      fetchRetentionData();
+    },
   });
 
   // --- Reports State ---

--- a/frontend/src/components/features/management/ProjectManagement.tsx
+++ b/frontend/src/components/features/management/ProjectManagement.tsx
@@ -157,6 +157,8 @@ export const ProjectManagement: React.FC = () => {
     refreshKey: createMatcherConfig([['projects']], 'prefix'),
     interval: 0,
     enabled: false,
+    // Note: fetchData defined below, use arrow function to avoid hoisting issues
+    onRefresh: () => fetchData(),
   });
 
   const fetchData = async () => {

--- a/frontend/src/components/features/management/QuotaAlerts.tsx
+++ b/frontend/src/components/features/management/QuotaAlerts.tsx
@@ -73,7 +73,13 @@ export const QuotaAlerts: React.FC = () => {
   // Page refresh control - manages manual refresh for quota and alerts data
   const pageRefresh = usePageRefresh({
     page: '/manage/quota',
-    refreshKey: createMatcherConfig([['admin', 'quota'], ['admin', 'quota-stats']], 'prefix'),
+    refreshKey: createMatcherConfig(
+      [
+        ['admin', 'quota'],
+        ['admin', 'quota-stats'],
+      ],
+      'prefix'
+    ),
     interval: 0, // Manual refresh only for configuration data
     enabled: false,
   });

--- a/frontend/src/components/features/management/QuotaAlerts.tsx
+++ b/frontend/src/components/features/management/QuotaAlerts.tsx
@@ -73,7 +73,7 @@ export const QuotaAlerts: React.FC = () => {
   // Page refresh control - manages manual refresh for quota and alerts data
   const pageRefresh = usePageRefresh({
     page: '/manage/quota',
-    refreshKey: createMatcherConfig([['quota'], ['alerts']], 'prefix'),
+    refreshKey: createMatcherConfig([['admin', 'quota'], ['admin', 'quota-stats']], 'prefix'),
     interval: 0, // Manual refresh only for configuration data
     enabled: false,
   });

--- a/frontend/src/components/features/management/SecurityCenter.tsx
+++ b/frontend/src/components/features/management/SecurityCenter.tsx
@@ -84,7 +84,13 @@ export const SecurityCenter: React.FC = () => {
   // --- Page Refresh Control ---
   const pageRefresh = usePageRefresh({
     page: '/manage/security',
-    refreshKey: createMatcherConfig([['admin', 'security-settings'], ['admin', 'audit-thresholds']], 'prefix'),
+    refreshKey: createMatcherConfig(
+      [
+        ['admin', 'security-settings'],
+        ['admin', 'audit-thresholds'],
+      ],
+      'prefix'
+    ),
     interval: 0, // Manual refresh only
     enabled: false,
   });

--- a/frontend/src/components/features/management/SecurityCenter.tsx
+++ b/frontend/src/components/features/management/SecurityCenter.tsx
@@ -84,7 +84,7 @@ export const SecurityCenter: React.FC = () => {
   // --- Page Refresh Control ---
   const pageRefresh = usePageRefresh({
     page: '/manage/security',
-    refreshKey: createMatcherConfig([['security']], 'prefix'),
+    refreshKey: createMatcherConfig([['admin', 'security-settings'], ['admin', 'audit-thresholds']], 'prefix'),
     interval: 0, // Manual refresh only
     enabled: false,
   });

--- a/frontend/src/components/features/management/TenantManagement.tsx
+++ b/frontend/src/components/features/management/TenantManagement.tsx
@@ -102,7 +102,7 @@ export const TenantManagement: React.FC = () => {
   // Page refresh control - manual refresh for tenant management
   const pageRefresh = usePageRefresh({
     page: '/manage/tenants',
-    refreshKey: createMatcherConfig([['tenants']], 'prefix'),
+    refreshKey: createMatcherConfig([['admin', 'tenants']], 'prefix'),
     interval: 0, // No auto refresh - manual only
     enabled: false,
   });

--- a/frontend/src/components/features/management/UserManagement.tsx
+++ b/frontend/src/components/features/management/UserManagement.tsx
@@ -25,6 +25,7 @@ import {
   Error,
   EmptyState,
   Badge,
+  PageRefreshControl,
 } from '@/components/common';
 import { useConfirm, useToast } from '@/components/common';
 import { ToolAccountsEditor } from './ToolAccountsEditor';
@@ -50,7 +51,7 @@ export const UserManagement: React.FC = () => {
   // Page refresh control - manual refresh for user management
   const pageRefresh = usePageRefresh({
     page: '/manage/users',
-    refreshKey: createMatcherConfig([['users']], 'prefix'),
+    refreshKey: createMatcherConfig([['admin', 'users']], 'prefix'),
     interval: 0, // No auto refresh - manual only
     enabled: false,
   });
@@ -317,25 +318,14 @@ export const UserManagement: React.FC = () => {
 
         {/* 右侧：操作按钮 */}
         <div className="d-flex align-items-center gap-2 ms-auto">
-          {/* 刷新按钮：简约图标轻按钮 */}
-          <button
-            type="button"
-            className="btn btn-sm p-1 border-0"
-            onClick={() => refetch()}
-            disabled={pageRefresh.isRefreshing}
-            title={t('refresh', language)}
-            style={{
-              color: '#6c757d',
-              backgroundColor: 'transparent',
-              borderRadius: '4px',
-              lineHeight: '1',
-            }}
-          >
-            <i
-              className={`bi bi-arrow-clockwise ${pageRefresh.isRefreshing ? 'spinner-border spinner-border-sm' : ''}`}
-              style={{ fontSize: '1rem' }}
-            />
-          </button>
+          {/* 刷新按钮 */}
+          <PageRefreshControl
+            refresh={pageRefresh}
+            compact={true}
+            showAutoRefreshToggle={false}
+            showIntervalSelector={false}
+            showLastRefreshTime={true}
+          />
 
           {/* 添加用户按钮：柔和圆角主色按钮 */}
           <Button variant="primary" size="sm" onClick={handleOpenCreate}>


### PR DESCRIPTION
## 问题描述

Issue #1335：管理页面刷新按钮点击无效。

**根因分析：** `usePageRefresh` 的 `refreshKey` 配置与实际 React Query `queryKey` 不匹配，导致 `invalidateQueries` 无法正确刷新缓存。

## 修改内容

### 1. React Query 页面 - 修正 refreshKey prefix

| 页面 | 修改前 | 修改后 |
|------|--------|--------|
| UserManagement | `['users']` | `['admin', 'users']` |
| TenantManagement | `['tenants']` | `['admin', 'tenants']` |
| AuditCenter | `['audit']` | `['admin', 'audit-logs'], ['admin', 'audit-thresholds']` |
| QuotaAlerts | `['quota'], ['alerts']` | `['admin', 'quota'], ['admin', 'quota-stats']` |
| SecurityCenter | `['security']` | `['admin', 'security-settings'], ['admin', 'audit-thresholds']` |
| AnomalyDetection | `['analysis', 'anomaly']` | `['analysis', 'anomaly-detection'], ['analysis', 'anomaly-trend']` |
| TrendAnalysis | `['analysis', 'trend']` | `['analysis', 'batch'], ['analysis', 'anomaly-trend']` |

### 2. 传统 API 页面 - 添加 onRefresh 回调

- **ProjectManagement.tsx**: 添加 `onRefresh: () => fetchData()`
- **ComplianceMgmt.tsx**: 添加 `onRefresh` 刷新 Reports 和 Retention 两个 tab 数据

### 3. UserManagement - 组件统一化

替换自定义刷新按钮为统一的 `PageRefreshControl` 组件，保持页面风格一致。

## 测试验证

- ✅ TypeScript 构建通过
- ✅ 前端打包成功

## 关联 Issue

Fixes #1335