### PR TITLE
fix(UserManagement): 为必填字段添加红色星号标识 (Issue #1340)

### DIFF
--- a/frontend/src/components/features/management/UserManagement.tsx
+++ b/frontend/src/components/features/management/UserManagement.tsx
@@ -468,7 +468,10 @@ export const UserManagement: React.FC = () => {
 
           <div className="row g-3">
             <div className="col-md-6">
-              <label className="form-label">{t('tableUsername', language)}</label>
+              <label className="form-label">
+                {t('tableUsername', language)}
+                <span className="text-danger ms-1">*</span>
+              </label>
               <TextInput
                 value={formData.username}
                 onChange={(value: string) => setFormData({ ...formData, username: value })}
@@ -476,7 +479,10 @@ export const UserManagement: React.FC = () => {
               />
             </div>
             <div className="col-md-6">
-              <label className="form-label">{t('tableEmail', language)}</label>
+              <label className="form-label">
+                {t('tableEmail', language)}
+                <span className="text-danger ms-1">*</span>
+              </label>
               <TextInput
                 type="email"
                 value={formData.email}
@@ -526,7 +532,10 @@ export const UserManagement: React.FC = () => {
             {!editingUser && (
               <>
                 <div className="col-md-6">
-                  <label className="form-label">{t('password', language)}</label>
+                  <label className="form-label">
+                    {t('password', language)}
+                    <span className="text-danger ms-1">*</span>
+                  </label>
                   <TextInput
                     type="password"
                     value={formData.password}
@@ -536,7 +545,10 @@ export const UserManagement: React.FC = () => {
                   <PasswordPolicyHint />
                 </div>
                 <div className="col-md-6">
-                  <label className="form-label">{t('confirmPassword', language)}</label>
+                  <label className="form-label">
+                    {t('confirmPassword', language)}
+                    <span className="text-danger ms-1">*</span>
+                  </label>
                   <TextInput
                     type="password"
                     value={formData.confirm_password ?? ''}


### PR DESCRIPTION
## 问题描述

管理模式下用户管理页面的添加用户表单，UI 上没有标识哪些字段是必填项，用户无法直观了解必须填写哪些字段才能提交。

## 必填字段分析

根据代码分析，添加用户时的必填字段：

| 字段 | 说明 |
|------|------|
| **用户名** | 必填，需符合用户名格式验证 |
| **邮箱** | 必填，需符合邮箱格式验证 |
| **密码** | 必填（仅新建用户），需满足密码策略 |
| **确认密码** | 必填（仅新建用户），需与密码匹配 |

## 修改内容

为必填字段的 label 添加红色星号标识：

- 用户名 label：添加 `<span className="text-danger ms-1">*</span>`
- 邮箱 label：添加 `<span className="text-danger ms-1">*</span>`
- 密码 label：添加 `<span className="text-danger ms-1">*</span>`（仅新建用户时显示）
- 确认密码 label：添加 `<span className="text-danger ms-1">*</span>`（仅新建用户时显示）

## 修改文件

- `frontend/src/components/features/management/UserManagement.tsx`

## 关联 Issue

Fixes #1340