### PR TITLE
docs: 添加端口配置指南到部署文档 (Issue #1339)

### DIFF
--- a/docs/cn/DEPLOYMENT.md
+++ b/docs/cn/DEPLOYMENT.md
@@ -256,6 +256,77 @@ cd /home/open-ace/open-ace
 | `OPENCLAW_TOKEN` | OpenClaw API token |
 | `SMTP_PASSWORD` | 邮件 SMTP 密码 |
 
+### 端口配置
+
+Open ACE 默认监听 5000 端口。如需修改端口，可根据部署方式选择以下方法。
+
+#### macOS 端口冲突
+
+macOS Monterey (12) 及以后版本默认启用 **AirPlay Receiver**，监听 5000 端口，会与 Open ACE 冲突。
+
+**解决方案**：
+1. 关闭 AirPlay Receiver：系统设置 → 通用 → AirDrop 与接力 → 关闭「AirPlay 接收器」
+2. 或修改 Open ACE 端口（见下方方法）
+
+#### 二进制方式
+
+修改配置文件 `~/.open-ace/config.json`：
+
+```json
+{
+  "server": {
+    "web_port": 5001,
+    "web_host": "0.0.0.0"
+  }
+}
+```
+
+修改后重启服务即可生效。
+
+#### Docker 方式
+
+**临时修改**（命令行）：
+
+```bash
+PORT=5001 docker compose up -d
+```
+
+**永久修改**（.env 文件）：
+
+```bash
+# 在项目根目录创建/编辑 .env 文件
+echo "PORT=5001" >> .env
+
+# 重启容器
+docker compose down
+docker compose up -d
+```
+
+**验证端口映射**：
+
+```bash
+docker ps
+# 应显示 0.0.0.0:5001->5000/tcp
+```
+
+#### 防火墙设置（如需外网访问）
+
+```bash
+# Ubuntu/Debian
+sudo ufw allow 5001/tcp
+
+# CentOS/RHEL
+sudo firewall-cmd --add-port=5001/tcp --permanent
+sudo firewall-cmd --reload
+```
+
+#### 总结
+
+| 方式 | 配置位置 | 修改方法 |
+|------|----------|----------|
+| 二进制 | `~/.open-ace/config.json` | 修改 `server.web_port` |
+| Docker | 环境变量 `PORT` | `.env` 文件或命令行传入 |
+
 ## 部署场景
 
 ### 场景一：单机部署（推荐个人使用）
@@ -427,6 +498,11 @@ python3 scripts/manage.py local start
 
 ### 端口被占用
 
+如果启动时提示端口被占用，可以选择：
+
+1. **修改 Open ACE 端口** - 参见 [端口配置](#端口配置)
+2. **终止占用进程**：
+
 ```bash
 # 查找占用 5000 端口的进程
 lsof -i :5000
@@ -434,6 +510,8 @@ lsof -i :5000
 # 终止进程
 kill -9 <PID>
 ```
+
+**macOS 用户注意**：macOS Monterey (12) 及以后版本默认启用 AirPlay Receiver，监听 5000 端口。建议关闭 AirPlay Receiver 或修改 Open ACE 端口。
 
 ### 数据库被锁定
 

--- a/docs/en/DEPLOYMENT.md
+++ b/docs/en/DEPLOYMENT.md
@@ -256,6 +256,77 @@ Configuration is stored in `~/.open-ace/config.json`:
 | `OPENCLAW_TOKEN` | OpenClaw API token |
 | `SMTP_PASSWORD` | Email SMTP password |
 
+### Port Configuration
+
+Open ACE listens on port 5000 by default. To change the port, use the appropriate method based on your deployment type.
+
+#### macOS Port Conflict
+
+macOS Monterey (12) and later versions enable **AirPlay Receiver** by default, which listens on port 5000 and conflicts with Open ACE.
+
+**Solutions**:
+1. Disable AirPlay Receiver: System Settings → General → AirDrop & Handoff → Turn off "AirPlay Receiver"
+2. Or change Open ACE port (see methods below)
+
+#### Binary Installation
+
+Modify the configuration file `~/.open-ace/config.json`:
+
+```json
+{
+  "server": {
+    "web_port": 5001,
+    "web_host": "0.0.0.0"
+  }
+}
+```
+
+Restart the service after modification.
+
+#### Docker Installation
+
+**Temporary change** (command line):
+
+```bash
+PORT=5001 docker compose up -d
+```
+
+**Permanent change** (.env file):
+
+```bash
+# Create/edit .env file in project root
+echo "PORT=5001" >> .env
+
+# Restart container
+docker compose down
+docker compose up -d
+```
+
+**Verify port mapping**:
+
+```bash
+docker ps
+# Should show 0.0.0.0:5001->5000/tcp
+```
+
+#### Firewall Settings (for external access)
+
+```bash
+# Ubuntu/Debian
+sudo ufw allow 5001/tcp
+
+# CentOS/RHEL
+sudo firewall-cmd --add-port=5001/tcp --permanent
+sudo firewall-cmd --reload
+```
+
+#### Summary
+
+| Method | Configuration Location | How to Change |
+|--------|------------------------|---------------|
+| Binary | `~/.open-ace/config.json` | Modify `server.web_port` |
+| Docker | Environment variable `PORT` | `.env` file or command line |
+
 ## Deployment Scenarios
 
 ### 1. Single Machine (Recommended for Personal Use)
@@ -427,6 +498,11 @@ python3 scripts/manage.py local start
 
 ### Port Already in Use
 
+If startup fails due to port conflict, you can:
+
+1. **Change Open ACE port** - See [Port Configuration](#port-configuration)
+2. **Kill the conflicting process**:
+
 ```bash
 # Find process using port 5000
 lsof -i :5000
@@ -434,6 +510,8 @@ lsof -i :5000
 # Kill process
 kill -9 <PID>
 ```
+
+**macOS users**: macOS Monterey (12) and later versions enable AirPlay Receiver by default, which listens on port 5000. Consider disabling AirPlay Receiver or changing Open ACE port.
 
 ### Database Locked
 


### PR DESCRIPTION
## 概述

添加端口修改指南到部署文档，覆盖二进制和 Docker 两种安装方式。

## 关联 Issue

Closes #1339

## 修改内容

### 配置章节新增「端口配置」小节
- macOS AirPlay Receiver 端口冲突说明
- 二进制方式：修改 ~/.open-ace/config.json
- Docker 方式：环境变量 PORT 或 .env 文件
- 防火墙设置指南
- 总结表格

### 故障排查章节更新
- 添加端口配置链接引用
- macOS 用户注意事项

## 文档位置

- docs/cn/DEPLOYMENT.md（中文）
- docs/en/DEPLOYMENT.md（英文）

## 测试验证

- 本地验证文档格式正确
- Markdown 链接可正常跳转