### PR TITLE
fix(docker): 修复 config.json 中数据库 URL 变量未展开问题 (Issue #1338)

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -139,13 +139,16 @@ generate_default_config() {
 
     # Generate default config (matches install.sh defaults)
     # Note: DATABASE_URL env var takes precedence over config file for database connection
-    # Database credentials use docker-compose.yml defaults (${DB_USER:-ace}, etc.)
+    # Database credentials use docker-compose.yml defaults, shell-expanded at generation time
+    # Issue #1336: Use ${VAR:-default} syntax (no \$ escape) so shell expands variables
+    # This prevents fetch scripts from reading unexpanded "${DB_USER:-ace}" literal strings
+    # which would cause psycopg2 to parse "${DB_USER" as username (colon as delimiter)
     cat > "$CONFIG_FILE" << CONFIG_EOF
 {
   "host_name": "$HOST_NAME",
   "database": {
     "type": "postgresql",
-    "url": "postgresql://\${DB_USER:-ace}:\${DB_PASSWORD:-ace-secret}@postgres:5432/\${DB_NAME:-ace}"
+    "url": "postgresql://${DB_USER:-ace}:${DB_PASSWORD:-ace-secret}@postgres:5432/${DB_NAME:-ace}"
   },
   "server": {
     "upload_auth_key": "$UPLOAD_AUTH_KEY",


### PR DESCRIPTION
## 问题

容器启动时 `docker-entrypoint.sh` 的 `generate_default_config()` 使用 heredoc 生成 config.json，其中 `database.url` 配置使用了 `\${DB_USER:-ace}` 格式（`\$` 转义）。这导致 shell 不展开变量，写入 config.json 的是字面字符串 `${DB_USER:-ace}`。

当 fetch 脚本（如 `fetch_qwen.py`）被调度执行时，会读取 config.json 的 `database.url` 并覆盖 `DATABASE_URL` 环境变量。psycopg2 解析这个 URL 时，`${DB_USER:-ace}` 中的第一个 `:` 被当作用户名和密码分隔符，导致 `${DB_USER` 作为实际用户名发送给 PostgreSQL，认证失败。

错误日志：
```
password authentication failed for user "${DB_USER"
```

## 修复

去掉 `\` 转义，让 shell 正确展开 `${VAR:-default}` 变量：
- 如果 `DB_USER` 等变量存在，使用其值
- 如果不存在，使用默认值 `ace`、`ace-secret`、`ace`

修复后生成的 URL：`postgresql://ace:ace-secret@postgres:5432/ace`

## 测试验证

```bash
# 设置变量时
$ DB_USER=testuser bash -c 'echo "${DB_USER:-ace}"'
testuser

# 未设置时使用默认值
$ bash -c 'echo "${DB_USER:-ace}"'
ace
```

## 用户应用修复的步骤

1. 拉取最新代码并重建镜像：
   ```bash
   git pull
   docker compose build
   ```
2. 删除旧的 config volume 数据：
   ```bash
   docker volume rm open-ace_config-data
   ```
3. 重启容器：
   ```bash
   docker compose up -d
   ```