### PR TITLE
docs: 添加 Docker 方式卸载说明 (Issue #1338)

### DIFF
--- a/docs/cn/DEPLOYMENT.md
+++ b/docs/cn/DEPLOYMENT.md
@@ -208,6 +208,28 @@ docker compose restart open-ace
 
 ### 卸载
 
+#### Docker 方式卸载
+
+如果使用纯 Docker 部署（无 deploy.sh 脚本），可手动卸载：
+
+```bash
+# 停止并删除容器
+docker compose down
+
+# 删除镜像
+docker rmi openace/open-ace:latest postgres:15-alpine
+
+# 删除数据卷（彻底清理）
+docker volume rm open-ace_postgres-data open-ace_config-data open-ace_workspace-data
+
+# 删除本地配置（可选）
+rm -rf ~/.open-ace ./logs
+```
+
+#### 脚本方式卸载
+
+如果使用 deploy.sh 脚本部署：
+
 ```bash
 cd /home/open-ace/open-ace
 

--- a/docs/en/DEPLOYMENT.md
+++ b/docs/en/DEPLOYMENT.md
@@ -208,6 +208,28 @@ docker compose restart open-ace
 
 ### Uninstallation
 
+#### Docker Uninstallation
+
+For pure Docker deployments (without deploy.sh script):
+
+```bash
+# Stop and remove containers
+docker compose down
+
+# Remove images
+docker rmi openace/open-ace:latest postgres:15-alpine
+
+# Remove data volumes (complete cleanup)
+docker volume rm open-ace_postgres-data open-ace_config-data open-ace_workspace-data
+
+# Remove local configuration (optional)
+rm -rf ~/.open-ace ./logs
+```
+
+#### Script Uninstallation
+
+For deployments using deploy.sh script:
+
 ```bash
 cd /home/open-ace/open-ace
 


### PR DESCRIPTION
## 问题描述

Issue #1338 问题 1：Docker 方式卸载文档缺失

部署文档的卸载部分只有脚本方式 (`./uninstall.sh`) 的说明，缺少纯 Docker 部署方式的卸载步骤。

## 修改内容

在 `docs/cn/DEPLOYMENT.md` 和 `docs/en/DEPLOYMENT.md` 的卸载部分添加：

1. **Docker 方式卸载**：适用于纯 Docker 部署（无 deploy.sh 脚本）
   - 停止并删除容器 (`docker compose down`)
   - 删除镜像 (`docker rmi ...`)
   - 删除数据卷 (`docker volume rm ...`)
   - 删除本地配置（可选）

2. **脚本方式卸载**：适用于使用 deploy.sh 脚本部署
   - 保留原有的 `./uninstall.sh` 说明

## 关联 Issue

Fixes #1338 (问题 1)