### PR TITLE
fix(PageRefresh): 统一管理页面刷新按钮样式 (Issue #1337)

### DIFF
--- a/frontend/src/components/features/ConversationHistory.tsx
+++ b/frontend/src/components/features/ConversationHistory.tsx
@@ -601,8 +601,6 @@ export const ConversationHistory: React.FC = () => {
         <PageRefreshControl
           refresh={pageRefresh}
           compact={true}
-          showAutoRefreshToggle={false}
-          showIntervalSelector={false}
           showLastRefreshTime={true}
         />
       </div>

--- a/frontend/src/components/features/ConversationHistory.tsx
+++ b/frontend/src/components/features/ConversationHistory.tsx
@@ -598,11 +598,7 @@ export const ConversationHistory: React.FC = () => {
       {/* Page Header */}
       <div className="page-header mb-4 d-flex justify-content-between align-items-center">
         <h2>{t('conversationHistory', language)}</h2>
-        <PageRefreshControl
-          refresh={pageRefresh}
-          compact={true}
-          showLastRefreshTime={true}
-        />
+        <PageRefreshControl refresh={pageRefresh} compact={true} showLastRefreshTime={true} />
       </div>
       {tableContent}
       {/* Conversation Detail Modal */}

--- a/frontend/src/components/features/analysis/AnomalyDetection.tsx
+++ b/frontend/src/components/features/analysis/AnomalyDetection.tsx
@@ -201,8 +201,6 @@ export const AnomalyDetection: React.FC = () => {
         <PageRefreshControl
           refresh={pageRefresh}
           compact={true}
-          showAutoRefreshToggle={false}
-          showIntervalSelector={false}
           showLastRefreshTime={true}
         />
       </div>

--- a/frontend/src/components/features/analysis/AnomalyDetection.tsx
+++ b/frontend/src/components/features/analysis/AnomalyDetection.tsx
@@ -198,11 +198,7 @@ export const AnomalyDetection: React.FC = () => {
       {/* Header */}
       <div className="page-header d-flex justify-content-between align-items-center mb-4">
         <h2>{t('anomalyDetection', language)}</h2>
-        <PageRefreshControl
-          refresh={pageRefresh}
-          compact={true}
-          showLastRefreshTime={true}
-        />
+        <PageRefreshControl refresh={pageRefresh} compact={true} showLastRefreshTime={true} />
       </div>
 
       {/* Filters */}

--- a/frontend/src/components/features/analysis/ROIAnalysis.tsx
+++ b/frontend/src/components/features/analysis/ROIAnalysis.tsx
@@ -469,11 +469,7 @@ export const ROIAnalysis: React.FC = () => {
       {/* Header */}
       <div className="d-flex justify-content-between align-items-center mb-4">
         <h2>{t('roiAnalysis', language)}</h2>
-        <PageRefreshControl
-          refresh={pageRefresh}
-          compact={true}
-          showLastRefreshTime={true}
-        />
+        <PageRefreshControl refresh={pageRefresh} compact={true} showLastRefreshTime={true} />
       </div>
 
       {/* Filters */}

--- a/frontend/src/components/features/analysis/ROIAnalysis.tsx
+++ b/frontend/src/components/features/analysis/ROIAnalysis.tsx
@@ -472,8 +472,6 @@ export const ROIAnalysis: React.FC = () => {
         <PageRefreshControl
           refresh={pageRefresh}
           compact={true}
-          showAutoRefreshToggle={false}
-          showIntervalSelector={false}
           showLastRefreshTime={true}
         />
       </div>

--- a/frontend/src/components/features/analysis/TrendAnalysis.tsx
+++ b/frontend/src/components/features/analysis/TrendAnalysis.tsx
@@ -264,11 +264,7 @@ export const TrendAnalysis: React.FC = () => {
       <div className="page-header d-flex justify-content-between align-items-center mb-4">
         <h2>{t('tokenTrend', language)}</h2>
         {/* Page Refresh Control - compact mode */}
-        <PageRefreshControl
-          refresh={pageRefresh}
-          compact={true}
-          showLastRefreshTime={true}
-        />
+        <PageRefreshControl refresh={pageRefresh} compact={true} showLastRefreshTime={true} />
       </div>
 
       {/* Filters */}

--- a/frontend/src/components/features/analysis/TrendAnalysis.tsx
+++ b/frontend/src/components/features/analysis/TrendAnalysis.tsx
@@ -267,8 +267,6 @@ export const TrendAnalysis: React.FC = () => {
         <PageRefreshControl
           refresh={pageRefresh}
           compact={true}
-          showAutoRefreshToggle={false}
-          showIntervalSelector={false}
           showLastRefreshTime={true}
         />
       </div>

--- a/frontend/src/components/features/management/AuditCenter.tsx
+++ b/frontend/src/components/features/management/AuditCenter.tsx
@@ -1119,11 +1119,7 @@ export const AuditCenter: React.FC = () => {
         <h2>{t('auditCenter', language)}</h2>
         <div className="d-flex gap-2">
           {/* Page Refresh Control */}
-          <PageRefreshControl
-            refresh={pageRefresh}
-            compact={true}
-            showLastRefreshTime={true}
-          />
+          <PageRefreshControl refresh={pageRefresh} compact={true} showLastRefreshTime={true} />
           {activeTab === 'analysis' && (
             <Button variant="outline-success" size="sm" onClick={handleExportReport}>
               <i className="bi bi-download me-1" />

--- a/frontend/src/components/features/management/AuditCenter.tsx
+++ b/frontend/src/components/features/management/AuditCenter.tsx
@@ -1122,8 +1122,6 @@ export const AuditCenter: React.FC = () => {
           <PageRefreshControl
             refresh={pageRefresh}
             compact={true}
-            showAutoRefreshToggle={false}
-            showIntervalSelector={false}
             showLastRefreshTime={true}
           />
           {activeTab === 'analysis' && (

--- a/frontend/src/components/features/management/QuotaAlerts.tsx
+++ b/frontend/src/components/features/management/QuotaAlerts.tsx
@@ -966,11 +966,7 @@ export const QuotaAlerts: React.FC = () => {
       <div className="d-flex justify-content-between align-items-center mb-3">
         <h2>{t('quotaAndAlerts', language)}</h2>
         <div className="d-flex gap-2">
-          <PageRefreshControl
-            refresh={pageRefresh}
-            compact={true}
-            showLastRefreshTime={true}
-          />
+          <PageRefreshControl refresh={pageRefresh} compact={true} showLastRefreshTime={true} />
           {activeTab === 'quota' && unreadCount > 0 && (
             <Button variant="outline-info" size="sm" onClick={() => setActiveTab('alerts')}>
               <i className="bi bi-bell me-1" />

--- a/frontend/src/components/features/management/QuotaAlerts.tsx
+++ b/frontend/src/components/features/management/QuotaAlerts.tsx
@@ -968,8 +968,6 @@ export const QuotaAlerts: React.FC = () => {
         <div className="d-flex gap-2">
           <PageRefreshControl
             refresh={pageRefresh}
-            showAutoRefreshToggle={false}
-            showIntervalSelector={false}
             compact={true}
             showLastRefreshTime={true}
           />

--- a/frontend/src/components/features/management/RequestDashboard.tsx
+++ b/frontend/src/components/features/management/RequestDashboard.tsx
@@ -194,6 +194,7 @@ export const RequestDashboard: React.FC = () => {
         <h2>{t('requestStatistics', language)}</h2>
         <PageRefreshControl
           refresh={pageRefresh}
+          compact={true}
           showLastRefreshTime={true}
           showNextRefreshTime={false}
         />


### PR DESCRIPTION
## 问题描述

Issue #1337：管理页面的 `PageRefreshControl` 组件配置不一致，数据查看类页面与配置管理类页面按钮样式不同。

## 修改内容（方案 B - 按页面类型区分）

### 1. 数据/分析类页面改为完整功能（显示闹钟按钮 + 间隔选择器）

| 页面 | 修改内容 |
|------|----------|
| RequestDashboard | 添加 `compact={true}` |
| ConversationHistory | 移除 `showAutoRefreshToggle={false}` 和 `showIntervalSelector={false}` |
| AnomalyDetection | 移除简化配置 |
| ROIAnalysis | 移除简化配置 |
| TrendAnalysis | 移除简化配置 |
| AuditCenter | 移除简化配置 |
| QuotaAlerts | 移除简化配置 |

### 2. 配置管理类页面保持简化版（只有手动刷新）

- UserManagement、TenantManagement、SecurityCenter
- ComplianceMgmt、APIKeyManagement、ProjectManagement

## 修改后效果

- 数据查看类页面（Messages、RequestDashboard 等）样式完全一致：图标按钮 + 闹钟 + 间隔选择器
- 配置管理类页面保持简洁样式：只有手动刷新按钮 + 上次刷新时间

## 测试验证

- ✅ TypeScript 构建通过
- ✅ 前端打包成功

## 关联 Issue

Fixes #1337