### PR TITLE
fix(Autonomous): 修复页面刷新时竞态条件导致的错误提示 (Issue #1347)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -260,6 +260,7 @@ const AutonomousDisabledRedirect: React.FC = () => {
 const WorkRoutes: React.FC = () => {
   const location = useLocation();
   const autonomousEnabled = useAppStore((state) => state.autonomousEnabled);
+  const configLoaded = useAppStore((state) => state.configLoaded);
   const isWorkspaceRoute =
     location.pathname === '/work' ||
     location.pathname === '/work/' ||
@@ -289,10 +290,15 @@ const WorkRoutes: React.FC = () => {
           <Route path="prompts" element={<Prompts />} />
           <Route path="usage" element={<UsageOverview />} />
           <Route path="insights" element={<InsightsReport />} />
-          {autonomousEnabled ? (
-            <Route path="autonomous" element={<AutonomousDev />} />
+          {/* Wait for config to load before deciding autonomous route */}
+          {configLoaded ? (
+            autonomousEnabled ? (
+              <Route path="autonomous" element={<AutonomousDev />} />
+            ) : (
+              <Route path="autonomous" element={<AutonomousDisabledRedirect />} />
+            )
           ) : (
-            <Route path="autonomous" element={<AutonomousDisabledRedirect />} />
+            <Route path="autonomous" element={<PageLoader />} />
           )}
           {/* Explicit /workspace route for session restore */}
           <Route path="workspace" element={null} />

--- a/frontend/src/components/layout/WorkLayout.tsx
+++ b/frontend/src/components/layout/WorkLayout.tsx
@@ -57,6 +57,7 @@ export const WorkLayout: React.FC<WorkLayoutProps> = ({ children }) => {
     previousRightPanelCollapsed,
     autonomousEnabled,
     setAutonomousEnabled,
+    setConfigLoaded,
   } = useAppStore();
 
   // Load workspace config on mount to determine feature flags
@@ -65,12 +66,14 @@ export const WorkLayout: React.FC<WorkLayoutProps> = ({ children }) => {
       try {
         const config = await workspaceApi.getConfig();
         setAutonomousEnabled(config.autonomous_enabled);
+        setConfigLoaded(true);
       } catch {
-        // Config fetch failed, keep defaults (autonomousEnabled = false)
+        // Config fetch failed, keep defaults but mark as loaded
+        setConfigLoaded(true);
       }
     };
     loadConfig();
-  }, [setAutonomousEnabled]);
+  }, [setAutonomousEnabled, setConfigLoaded]);
 
   // Filter nav items based on feature flags
   const visibleNavItems = autonomousEnabled

--- a/frontend/src/store/index.test.ts
+++ b/frontend/src/store/index.test.ts
@@ -36,6 +36,8 @@ describe('App Store', () => {
       sidebarCollapsed: false,
       workspaceTabs: [],
       workspaceActiveTabId: '',
+      autonomousEnabled: false,
+      configLoaded: false,
       reorderWorkspaceTabs: (fromIndex: number, toIndex: number) => {
         const state = useAppStore.getState();
         const tabs = [...state.workspaceTabs];
@@ -57,6 +59,8 @@ describe('App Store', () => {
       expect(state.theme).toBe('light');
       expect(state.language).toBe('en');
       expect(state.sidebarCollapsed).toBe(false);
+      expect(state.autonomousEnabled).toBe(false);
+      expect(state.configLoaded).toBe(false);
     });
   });
 
@@ -293,6 +297,40 @@ describe('App Store', () => {
       expect(restoredTabs[0].id).toBe('tab-1');
       expect(restoredTabs[1].id).toBe('tab-2');
       expect(restoredTabs[2].id).toBe('tab-3');
+    });
+  });
+
+  describe('feature flag actions', () => {
+    it('should set autonomousEnabled', () => {
+      expect(useAppStore.getState().autonomousEnabled).toBe(false);
+
+      act(() => {
+        useAppStore.getState().setAutonomousEnabled(true);
+      });
+
+      expect(useAppStore.getState().autonomousEnabled).toBe(true);
+
+      act(() => {
+        useAppStore.getState().setAutonomousEnabled(false);
+      });
+
+      expect(useAppStore.getState().autonomousEnabled).toBe(false);
+    });
+
+    it('should set configLoaded', () => {
+      expect(useAppStore.getState().configLoaded).toBe(false);
+
+      act(() => {
+        useAppStore.getState().setConfigLoaded(true);
+      });
+
+      expect(useAppStore.getState().configLoaded).toBe(true);
+
+      act(() => {
+        useAppStore.getState().setConfigLoaded(false);
+      });
+
+      expect(useAppStore.getState().configLoaded).toBe(false);
     });
   });
 });

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -70,6 +70,7 @@ interface AppState {
 
   // Feature flags
   autonomousEnabled: boolean;
+  configLoaded: boolean;
 
   // Actions
   setUser: (user: User | null) => void;
@@ -112,6 +113,7 @@ interface AppState {
 
   // Feature flag actions
   setAutonomousEnabled: (enabled: boolean) => void;
+  setConfigLoaded: (loaded: boolean) => void;
 }
 
 export const useAppStore = create<AppState>()(
@@ -147,6 +149,7 @@ export const useAppStore = create<AppState>()(
 
       // Feature flags
       autonomousEnabled: false,
+      configLoaded: false,
 
       // Actions
       setUser: (user) => set({ user }),
@@ -261,6 +264,7 @@ export const useAppStore = create<AppState>()(
 
       // Feature flag actions
       setAutonomousEnabled: (enabled) => set({ autonomousEnabled: enabled }),
+      setConfigLoaded: (loaded) => set({ configLoaded: loaded }),
     }),
     {
       name: 'open-ace-store',


### PR DESCRIPTION
## 问题描述

Fixes #1347

在 AI 自主开发功能页面刷新后，会短暂显示错误提示：「自主开发功能未启用」，然后被重定向到 `/work` 页面。

## 根因分析

这是一个经典的**前端竞态条件问题**：

1. Store 中 `autonomousEnabled` 初始值为 `false`
2. 页面刷新时，React 路由在 API 请求完成前就渲染 `AutonomousDisabledRedirect`
3. 该组件立即显示错误 toast 并重定向到 `/work`
4. 之后 API 返回 `autonomous_enabled: true`，但已经太晚了

## 修复方案

添加 `configLoaded` 状态，在配置加载完成前显示加载状态而非判断路由：

1. **Store**: 添加 `configLoaded` 状态和 `setConfigLoaded` action
2. **WorkLayout**: 配置加载后设置 `configLoaded(true)`
3. **App.tsx**: 路由守卫改为等待配置加载后再判断

## 测试验证

- TypeScript 类型检查通过

## 文件变更

- `frontend/src/store/index.ts` - 添加 configLoaded 状态
- `frontend/src/components/layout/WorkLayout.tsx` - 配置加载后标记完成
- `frontend/src/App.tsx` - 路由守卫等待配置加载

🤖 Generated with Qwen Code (5-shotted by Qwen-Coder)