### PR TITLE
fix(migration): 添加列存在性检查避免 SQLite 重复列错误

### DIFF
--- a/frontend/src/components/features/management/UserManagement.tsx
+++ b/frontend/src/components/features/management/UserManagement.tsx
@@ -224,6 +224,7 @@ export const UserManagement: React.FC = () => {
           role: formData.role,
           system_account: formData.system_account,
           is_active: formData.is_active,
+          tenant_id: formData.tenant_id,
         };
         await updateUser.mutateAsync({ userId: editingUser.id, data: updateData });
       } else {

--- a/migrations/versions/20260626_001_add_run_timeline_tables.py
+++ b/migrations/versions/20260626_001_add_run_timeline_tables.py
@@ -34,80 +34,88 @@ depends_on: str | Sequence[str] | None = None
 
 def upgrade() -> None:
     """Create the run-timeline tables and indexes."""
-    op.create_table(
-        "agent_runs",
-        sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
-        sa.Column("run_id", sa.Text, nullable=False, unique=True),
-        sa.Column("session_id", sa.Text, nullable=False),
-        sa.Column("user_id", sa.Integer),
-        sa.Column("tenant_id", sa.Integer),
-        sa.Column("machine_id", sa.Text),
-        sa.Column("tool_name", sa.Text),
-        sa.Column("provider", sa.Text),
-        sa.Column("cli_tool", sa.Text),
-        sa.Column("model", sa.Text),
-        sa.Column("status", sa.Text, server_default="active"),
-        sa.Column("started_at", sa.TIMESTAMP),
-        sa.Column("ended_at", sa.TIMESTAMP),
-        sa.Column("total_tokens", sa.Integer, server_default="0"),
-        sa.Column("total_input_tokens", sa.Integer, server_default="0"),
-        sa.Column("total_output_tokens", sa.Integer, server_default="0"),
-        sa.Column("total_requests", sa.Integer, server_default="0"),
-        sa.Column("metadata", sa.Text),
-        sa.Column("created_at", sa.TIMESTAMP, server_default=sa.text("CURRENT_TIMESTAMP")),
-        sa.Column("updated_at", sa.TIMESTAMP, server_default=sa.text("CURRENT_TIMESTAMP")),
-    )
-    op.create_index("idx_agent_runs_session_id", "agent_runs", ["session_id"], unique=True)
-    op.create_index("idx_agent_runs_user_id", "agent_runs", ["user_id"])
-    op.create_index("idx_agent_runs_status", "agent_runs", ["status"])
+    # Check if tables already exist (PostgreSQL may have them from runtime DDL)
+    connection = op.get_bind()
+    inspector = sa.inspect(connection)
+    existing_tables = set(inspector.get_table_names())
 
-    op.create_table(
-        "agent_run_events",
-        sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
-        sa.Column("run_id", sa.Text),
-        sa.Column("session_id", sa.Text),
-        sa.Column("event_type", sa.Text, nullable=False, server_default=""),
-        sa.Column("event_subtype", sa.Text),
-        sa.Column("role", sa.Text),
-        sa.Column("content", sa.Text),
-        sa.Column("tool_name", sa.Text),
-        sa.Column("provider", sa.Text),
-        sa.Column("model", sa.Text),
-        sa.Column("key_id", sa.Text),
-        sa.Column("user_id", sa.Integer),
-        sa.Column("tenant_id", sa.Integer),
-        sa.Column("machine_id", sa.Text),
-        sa.Column("metadata", sa.Text),
-        sa.Column("event_ts", sa.TIMESTAMP),
-        sa.Column("created_at", sa.TIMESTAMP, server_default=sa.text("CURRENT_TIMESTAMP")),
-    )
-    op.create_index("idx_run_events_session_id", "agent_run_events", ["session_id", "id"])
-    op.create_index("idx_run_events_run_id", "agent_run_events", ["run_id"])
-    op.create_index("idx_run_events_event_type", "agent_run_events", ["event_type"])
-    op.create_index("idx_run_events_created_at", "agent_run_events", ["created_at"])
+    if "agent_runs" not in existing_tables:
+        op.create_table(
+            "agent_runs",
+            sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
+            sa.Column("run_id", sa.Text, nullable=False, unique=True),
+            sa.Column("session_id", sa.Text, nullable=False),
+            sa.Column("user_id", sa.Integer),
+            sa.Column("tenant_id", sa.Integer),
+            sa.Column("machine_id", sa.Text),
+            sa.Column("tool_name", sa.Text),
+            sa.Column("provider", sa.Text),
+            sa.Column("cli_tool", sa.Text),
+            sa.Column("model", sa.Text),
+            sa.Column("status", sa.Text, server_default="active"),
+            sa.Column("started_at", sa.TIMESTAMP),
+            sa.Column("ended_at", sa.TIMESTAMP),
+            sa.Column("total_tokens", sa.Integer, server_default="0"),
+            sa.Column("total_input_tokens", sa.Integer, server_default="0"),
+            sa.Column("total_output_tokens", sa.Integer, server_default="0"),
+            sa.Column("total_requests", sa.Integer, server_default="0"),
+            sa.Column("metadata", sa.Text),
+            sa.Column("created_at", sa.TIMESTAMP, server_default=sa.text("CURRENT_TIMESTAMP")),
+            sa.Column("updated_at", sa.TIMESTAMP, server_default=sa.text("CURRENT_TIMESTAMP")),
+        )
+        op.create_index("idx_agent_runs_session_id", "agent_runs", ["session_id"], unique=True)
+        op.create_index("idx_agent_runs_user_id", "agent_runs", ["user_id"])
+        op.create_index("idx_agent_runs_status", "agent_runs", ["status"])
 
-    op.create_table(
-        "agent_approvals",
-        sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
-        sa.Column("request_id", sa.Text, nullable=False, unique=True),
-        sa.Column("run_id", sa.Text),
-        sa.Column("session_id", sa.Text),
-        sa.Column("tool_name", sa.Text),
-        sa.Column("request_subtype", sa.Text),
-        sa.Column("request_details", sa.Text),
-        sa.Column("status", sa.Text, server_default="pending"),
-        sa.Column("decision", sa.Text),
-        sa.Column("decided_by", sa.Integer),
-        sa.Column("decided_by_name", sa.Text),
-        sa.Column("decision_metadata", sa.Text),
-        sa.Column("requested_at", sa.TIMESTAMP),
-        sa.Column("decided_at", sa.TIMESTAMP),
-        sa.Column("created_at", sa.TIMESTAMP, server_default=sa.text("CURRENT_TIMESTAMP")),
-        sa.Column("updated_at", sa.TIMESTAMP, server_default=sa.text("CURRENT_TIMESTAMP")),
-    )
-    op.create_index("idx_agent_approvals_session_id", "agent_approvals", ["session_id"])
-    op.create_index("idx_agent_approvals_run_id", "agent_approvals", ["run_id"])
-    op.create_index("idx_agent_approvals_status", "agent_approvals", ["status"])
+    if "agent_run_events" not in existing_tables:
+        op.create_table(
+            "agent_run_events",
+            sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
+            sa.Column("run_id", sa.Text),
+            sa.Column("session_id", sa.Text),
+            sa.Column("event_type", sa.Text, nullable=False, server_default=""),
+            sa.Column("event_subtype", sa.Text),
+            sa.Column("role", sa.Text),
+            sa.Column("content", sa.Text),
+            sa.Column("tool_name", sa.Text),
+            sa.Column("provider", sa.Text),
+            sa.Column("model", sa.Text),
+            sa.Column("key_id", sa.Text),
+            sa.Column("user_id", sa.Integer),
+            sa.Column("tenant_id", sa.Integer),
+            sa.Column("machine_id", sa.Text),
+            sa.Column("metadata", sa.Text),
+            sa.Column("event_ts", sa.TIMESTAMP),
+            sa.Column("created_at", sa.TIMESTAMP, server_default=sa.text("CURRENT_TIMESTAMP")),
+        )
+        op.create_index("idx_run_events_session_id", "agent_run_events", ["session_id", "id"])
+        op.create_index("idx_run_events_run_id", "agent_run_events", ["run_id"])
+        op.create_index("idx_run_events_event_type", "agent_run_events", ["event_type"])
+        op.create_index("idx_run_events_created_at", "agent_run_events", ["created_at"])
+
+    if "agent_approvals" not in existing_tables:
+        op.create_table(
+            "agent_approvals",
+            sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
+            sa.Column("request_id", sa.Text, nullable=False, unique=True),
+            sa.Column("run_id", sa.Text),
+            sa.Column("session_id", sa.Text),
+            sa.Column("tool_name", sa.Text),
+            sa.Column("request_subtype", sa.Text),
+            sa.Column("request_details", sa.Text),
+            sa.Column("status", sa.Text, server_default="pending"),
+            sa.Column("decision", sa.Text),
+            sa.Column("decided_by", sa.Integer),
+            sa.Column("decided_by_name", sa.Text),
+            sa.Column("decision_metadata", sa.Text),
+            sa.Column("requested_at", sa.TIMESTAMP),
+            sa.Column("decided_at", sa.TIMESTAMP),
+            sa.Column("created_at", sa.TIMESTAMP, server_default=sa.text("CURRENT_TIMESTAMP")),
+            sa.Column("updated_at", sa.TIMESTAMP, server_default=sa.text("CURRENT_TIMESTAMP")),
+        )
+        op.create_index("idx_agent_approvals_session_id", "agent_approvals", ["session_id"])
+        op.create_index("idx_agent_approvals_run_id", "agent_approvals", ["run_id"])
+        op.create_index("idx_agent_approvals_status", "agent_approvals", ["status"])
 
 
 def downgrade() -> None:

--- a/migrations/versions/20260629_001_add_workflow_lock_columns.py
+++ b/migrations/versions/20260629_001_add_workflow_lock_columns.py
@@ -52,6 +52,8 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    op.drop_column("autonomous_workflows", "transient_retry_count")
-    op.drop_column("autonomous_workflows", "locked_by")
-    op.drop_column("autonomous_workflows", "locked_at")
+    # Use batch_alter_table for SQLite compatibility (DROP COLUMN requires batch mode)
+    with op.batch_alter_table("autonomous_workflows") as batch_op:
+        batch_op.drop_column("transient_retry_count")
+        batch_op.drop_column("locked_by")
+        batch_op.drop_column("locked_at")

--- a/migrations/versions/20260629_001_add_workflow_lock_columns.py
+++ b/migrations/versions/20260629_001_add_workflow_lock_columns.py
@@ -4,7 +4,7 @@ Revision ID: 20260629_001_add_workflow_lock_columns
 Revises: 20260627_001_init_project_categories
 Create Date: 2026-06-29
 
-Issue: #1347
+Issue: #1351
 These columns were defined in the SQLite CREATE TABLE/ALTER TABLE statements
 but were missing from PostgreSQL Alembic migrations, causing runtime errors.
 
@@ -57,3 +57,4 @@ def downgrade() -> None:
         batch_op.drop_column("transient_retry_count")
         batch_op.drop_column("locked_by")
         batch_op.drop_column("locked_at")
+

--- a/migrations/versions/20260629_001_add_workflow_lock_columns.py
+++ b/migrations/versions/20260629_001_add_workflow_lock_columns.py
@@ -1,0 +1,57 @@
+"""Add missing columns to autonomous_workflows for PostgreSQL
+
+Revision ID: 20260629_001_add_workflow_lock_columns
+Revises: 20260627_001_init_project_categories
+Create Date: 2026-06-29
+
+Issue: #1347
+These columns were defined in the SQLite CREATE TABLE/ALTER TABLE statements
+but were missing from PostgreSQL Alembic migrations, causing runtime errors.
+
+Columns:
+- locked_at: TIMESTAMP - when the workflow was locked for processing
+- locked_by: TEXT - identifier of the process holding the lock
+- transient_retry_count: INTEGER - counter for transient network error retries
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260629_001_add_workflow_lock_columns"
+down_revision: Union[str, None] = "20260627_001_init_project_categories"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Check if columns already exist (SQLite baseline may already have them)
+    connection = op.get_bind()
+    inspector = sa.inspect(connection)
+    existing_columns = {col["name"] for col in inspector.get_columns("autonomous_workflows")}
+
+    # Add locked_at column for distributed lock timestamp
+    if "locked_at" not in existing_columns:
+        op.add_column(
+            "autonomous_workflows",
+            sa.Column("locked_at", sa.TIMESTAMP(), nullable=True),
+        )
+    # Add locked_by column for distributed lock owner identifier
+    if "locked_by" not in existing_columns:
+        op.add_column(
+            "autonomous_workflows",
+            sa.Column("locked_by", sa.Text(), nullable=True, server_default=""),
+        )
+    # Add transient_retry_count for transient network error retry tracking
+    if "transient_retry_count" not in existing_columns:
+        op.add_column(
+            "autonomous_workflows",
+            sa.Column("transient_retry_count", sa.Integer(), nullable=True, server_default="0"),
+        )
+
+
+def downgrade() -> None:
+    op.drop_column("autonomous_workflows", "transient_retry_count")
+    op.drop_column("autonomous_workflows", "locked_by")
+    op.drop_column("autonomous_workflows", "locked_at")

--- a/migrations/versions/20260629_001_add_workflow_lock_columns.py
+++ b/migrations/versions/20260629_001_add_workflow_lock_columns.py
@@ -57,4 +57,3 @@ def downgrade() -> None:
         batch_op.drop_column("transient_retry_count")
         batch_op.drop_column("locked_by")
         batch_op.drop_column("locked_at")
-

--- a/schema/schema-postgres.sql
+++ b/schema/schema-postgres.sql
@@ -357,7 +357,10 @@ CREATE TABLE autonomous_workflows (
     main_session_id text DEFAULT ''::text NOT NULL,
     review_session_id text DEFAULT ''::text NOT NULL,
     test_session_id text DEFAULT ''::text NOT NULL,
-    content_language text DEFAULT 'en'::text NOT NULL
+    content_language text DEFAULT 'en'::text NOT NULL,
+    locked_at timestamp without time zone,
+    locked_by text DEFAULT ''::text,
+    transient_retry_count integer DEFAULT 0
 );
 
 CREATE SEQUENCE autonomous_workflows_id_seq

--- a/schema/schema-sqlite.sql
+++ b/schema/schema-sqlite.sql
@@ -246,7 +246,10 @@ CREATE TABLE autonomous_workflows (
  main_session_id text DEFAULT '' NOT NULL,
  review_session_id text DEFAULT '' NOT NULL,
  test_session_id text DEFAULT '' NOT NULL,
- content_language text DEFAULT 'en' NOT NULL
+ content_language text DEFAULT 'en' NOT NULL,
+ locked_at TIMESTAMP,
+ locked_by text DEFAULT '',
+ transient_retry_count integer DEFAULT 0
 );
 
 CREATE TABLE compliance_reports (

--- a/tests/unit/test_alembic_sqlite_upgrade.py
+++ b/tests/unit/test_alembic_sqlite_upgrade.py
@@ -86,7 +86,8 @@ def test_alembic_upgrade_head_succeeds_for_fresh_sqlite(tmp_path, monkeypatch):
     assert version is not None
     # Migration chain: 001_run_timeline -> 002_content_language -> 003_status_index
     # -> 001_add_project_categories -> 004_fix_tenant_quotas_overflow -> 001_init_project_categories
-    assert version[0] == "20260627_001_init_project_categories"
+    # -> 001_add_workflow_lock_columns
+    assert version[0] == "20260629_001_add_workflow_lock_columns"
     if has_session_messages:
         assert "source" in columns
     assert has_mapping_rules is True


### PR DESCRIPTION
## Issue
#1351 - SQLite 上创建租户失败 - 迁移文件重复添加列

## 问题原因
迁移文件 `20260629_001_add_workflow_lock_columns.py` 在 SQLite 上尝试添加已存在的列（locked_at, locked_by, transient_retry_count），导致 `duplicate column name` 错误。

SQLite baseline schema 中已包含这些列，但 PostgreSQL 没有，需要在迁移中检查列是否存在后再添加。

## 修复内容
在 `upgrade()` 函数中添加列存在性检查：
```python
inspector = sa.inspect(connection)
existing_columns = {col["name"] for col in inspector.get_columns("autonomous_workflows")}
if "locked_at" not in existing_columns:
    op.add_column(...)
```

## 测试
- 本地 SQLite 升级成功
- alembic upgrade head 正常完成