### PR TITLE
fix(tenant): PostgreSQL 创建租户时 boolean 类型兼容性修复

### DIFF
--- a/app/repositories/tenant_repo.py
+++ b/app/repositories/tenant_repo.py
@@ -133,10 +133,14 @@ class TenantRepository:
                 # Insert tenant_settings
                 settings_dict = tenant.settings.to_dict()
                 # Use adapt_boolean_value for PostgreSQL/SQLite compatibility
-                content_filter_val = adapt_boolean_value(settings_dict.get("content_filter_enabled", True))
+                content_filter_val = adapt_boolean_value(
+                    settings_dict.get("content_filter_enabled", True)
+                )
                 audit_log_val = adapt_boolean_value(settings_dict.get("audit_log_enabled", True))
                 sso_val = adapt_boolean_value(settings_dict.get("sso_enabled", False))
-                auto_provision_val = adapt_boolean_value(settings_dict.get("auto_provision_users", False))
+                auto_provision_val = adapt_boolean_value(
+                    settings_dict.get("auto_provision_users", False)
+                )
 
                 cursor.execute(
                     adapt_sql(

--- a/app/repositories/tenant_repo.py
+++ b/app/repositories/tenant_repo.py
@@ -11,7 +11,7 @@ from datetime import datetime, timezone
 from typing import Any, Optional, cast
 
 from app.models.tenant import QuotaConfig, Tenant, TenantSettings, TenantUsage
-from app.repositories.database import Database
+from app.repositories.database import Database, adapt_boolean_value
 from app.utils.helpers import parse_db_datetime
 
 logger = logging.getLogger(__name__)
@@ -132,11 +132,11 @@ class TenantRepository:
 
                 # Insert tenant_settings
                 settings_dict = tenant.settings.to_dict()
-                # Both PostgreSQL and SQLite use integer for boolean fields in tenant_settings
-                content_filter_val = 1 if settings_dict.get("content_filter_enabled", True) else 0
-                audit_log_val = 1 if settings_dict.get("audit_log_enabled", True) else 0
-                sso_val = 1 if settings_dict.get("sso_enabled", False) else 0
-                auto_provision_val = 1 if settings_dict.get("auto_provision_users", False) else 0
+                # Use adapt_boolean_value for PostgreSQL/SQLite compatibility
+                content_filter_val = adapt_boolean_value(settings_dict.get("content_filter_enabled", True))
+                audit_log_val = adapt_boolean_value(settings_dict.get("audit_log_enabled", True))
+                sso_val = adapt_boolean_value(settings_dict.get("sso_enabled", False))
+                auto_provision_val = adapt_boolean_value(settings_dict.get("auto_provision_users", False))
 
                 cursor.execute(
                     adapt_sql(
@@ -755,7 +755,7 @@ class TenantRepository:
                 fields.append(f"{key} = {p}")
                 value = quota_dict[key]
                 if cast_type is int and isinstance(value, bool):
-                    value = 1 if value else 0
+                    value = adapt_boolean_value(value)
                 values.append(value)
 
         if not fields:


### PR DESCRIPTION
**问题**

PostgreSQL 的 tenant_settings 表使用真正的 boolean 类型，但 tenant_repo.py 的 create 方法在插入数据时传入 integer (0/1)，导致类型不匹配错误：

```
错误:  字段 "content_filter_enabled" 的类型为 boolean, 但表达式的类型为 integer
```

**修复**

使用 `adapt_boolean_value` 函数：
- PostgreSQL: 返回真正的 boolean 类型
- SQLite: 返回 integer 类型 (0/1)

**验证**

在 node75 PostgreSQL 数据库上测试创建租户成功：
```json
{"id":129,"name":"Test Tenant 5","plan":"standard","status":"active"}
```

🤖 Generated with Qwen Code