### PR TITLE
fix(webui): WebUI进程使用请求中的IP连接主服务 (Issue #1357)

### DIFF
--- a/app/services/webui_manager.py
+++ b/app/services/webui_manager.py
@@ -569,7 +569,9 @@ class WebUIManager:
         process = None
 
         try:
-            process, model_pool = self._launch_webui_process(user_id, system_account, port)
+            process, model_pool = self._launch_webui_process(
+                user_id, system_account, port, base_url
+            )
             pid = process.pid if process else None
 
             if process is None:
@@ -693,7 +695,7 @@ class WebUIManager:
             }
 
     def _launch_webui_process(
-        self, user_id: int, system_account: str, port: int
+        self, user_id: int, system_account: str, port: int, base_url: str
     ) -> tuple[Optional[subprocess.Popen], dict[str, Any]]:
         """
         Launch a webui process as the specified user.
@@ -702,6 +704,8 @@ class WebUIManager:
             user_id: User ID for log directory naming.
             system_account: System account to run the process as.
             port: Port for the webui to listen on.
+            base_url: Base URL from request (e.g., http://192.168.1.87), used for
+                      WebUI process to connect to main service's LLM proxy API.
 
         Returns:
             subprocess.Popen object or None if launch failed.
@@ -722,8 +726,10 @@ class WebUIManager:
             logger.error("qwen-code-webui executable not found")
             return None, {}
 
-        # Build openace_api_url from config (remove any existing port first)
-        openace_api_url = self._remove_port_from_url(self.config.url)
+        # Build openace_api_url from base_url (from request host_url)
+        # WebUI process needs to connect to main service's LLM proxy API
+        # Use base_url (user's actual access IP) instead of config.url (container-detected IP)
+        openace_api_url = self._remove_port_from_url(base_url)
         server_config = self._load_server_config()
         server_port = server_config.get("web_port", 5000)
         openace_api_url = f"{openace_api_url}:{server_port}"

--- a/tests/unit/test_webui_manager.py
+++ b/tests/unit/test_webui_manager.py
@@ -209,7 +209,9 @@ class TestConfigureLocalOpenAIProxy:
         ):
             mock_popen.return_value = MagicMock(pid=12345)
             mock_run_as_root.return_value = MagicMock(returncode=0, stdout="", stderr="")
-            _, model_pool = manager._launch_webui_process(1, "testuser", 9000)
+            _, model_pool = manager._launch_webui_process(
+                1, "testuser", 9000, "http://192.168.1.87"
+            )
 
             # Verify local proxy setup was called
             mock_proxy_setup.assert_called_once()


### PR DESCRIPTION
## 问题描述

在 Docker 容器部署中，普通用户创建本地工作区会话后发送消息报错：
```
[API Error: Connection error. (cause: fetch failed)]
```

## 问题根因

1. `docker-entrypoint.sh` 中 SERVER_IP 自动检测可能返回 IPv6 地址（如 `fdc4:f303:9324::254`）
2. IPv6 地址写入 `config.json` 的 `workspace.url` 字段
3. WebUI 进程启动时从 `config.url` 获取 `openace_api_url`
4. WebUI 进程使用 IPv6/外部 IP 尝试连接主服务，但在容器内无法通过外部 IP 访问

## 修复方案

- `_launch_webui_process` 增加 `base_url` 参数
- 使用 `base_url`（来自请求的 `host_url`）构建 `openace_api_url`
- 调用处传递 `base_url`

## 测试

- [x] 单元测试通过

## Related Issue

Fixes #1357