### PR TITLE
fix: fetch脚本不覆盖已存在的DATABASE_URL环境变量 (Issue #1362)

### DIFF
--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -135,7 +135,7 @@ def api_login():
                     logger.info(
                         f"Pre-starting webui for user {user_id} ({system_account}) on login"
                     )
-                    manager.prestart_user_instance_async(user_id, system_account)
+                    manager.prestart_user_instance_async(user_id, system_account, request.host_url)
         except Exception as e:
             logger.warning(f"Failed to pre-start webui on login: {e}")
 

--- a/app/services/webui_manager.py
+++ b/app/services/webui_manager.py
@@ -1050,7 +1050,9 @@ class WebUIManager:
             if user_id in self._instances:
                 self._instances[user_id].update_activity()
 
-    def prestart_user_instance_async(self, user_id: int, system_account: str):
+    def prestart_user_instance_async(
+        self, user_id: int, system_account: str, host_url: Optional[str] = None
+    ):
         """
         Pre-start a webui instance for a user in background thread.
 
@@ -1060,6 +1062,9 @@ class WebUIManager:
         Args:
             user_id: User ID.
             system_account: User's system account name.
+            host_url: Optional host URL from Flask request (e.g., "http://192.168.1.87:5000").
+                      Used to replace container-detected IP with user's actual access IP.
+                      Required for Docker deployments where container cannot detect host's real IP.
         """
         if not self.config.multi_user_mode:
             return  # No pre-start needed in single-user mode
@@ -1076,7 +1081,7 @@ class WebUIManager:
         def start_in_background():
             try:
                 logger.info(f"Pre-starting webui instance for user {user_id} ({system_account})")
-                url, token = self.get_user_webui_url(user_id, system_account)
+                url, token = self.get_user_webui_url(user_id, system_account, host_url)
                 logger.info(f"Pre-started webui for user {user_id}: {url}")
             except Exception as e:
                 logger.error(f"Failed to pre-start webui for user {user_id}: {e}")

--- a/scripts/fetch_claude.py
+++ b/scripts/fetch_claude.py
@@ -1301,11 +1301,12 @@ if __name__ == "__main__":
         config_path = Path(args.config)
         if config_path.exists():
             # Load config and set DATABASE_URL environment variable
+            # Only set if not already configured (Docker provides DATABASE_URL)
             with open(config_path) as f:
                 config_data = json.load(f)
             db_config = config_data.get("database", {})
             db_url = db_config.get("url")
-            if db_url:
+            if db_url and not os.environ.get("DATABASE_URL"):
                 os.environ["DATABASE_URL"] = db_url
                 print(f"Using database from config: {db_config.get('type', 'postgresql')}")
 

--- a/scripts/fetch_codex.py
+++ b/scripts/fetch_codex.py
@@ -1188,7 +1188,8 @@ if __name__ == "__main__":
                 config_data = json.load(f)
             db_config = config_data.get("database", {})
             db_url = db_config.get("url")
-            if db_url:
+            # Only set if not already configured (Docker provides DATABASE_URL)
+            if db_url and not os.environ.get("DATABASE_URL"):
                 os.environ["DATABASE_URL"] = db_url
                 print(f"Using database from config: {db_config.get('type', 'postgresql')}")
 

--- a/scripts/fetch_openclaw.py
+++ b/scripts/fetch_openclaw.py
@@ -1839,11 +1839,12 @@ def main():
         config_path = Path(args.config)
         if config_path.exists():
             # Load config and set DATABASE_URL environment variable
+            # Only set if not already configured (Docker provides DATABASE_URL)
             with open(config_path) as f:
                 config_data = json.load(f)
             db_config = config_data.get("database", {})
             db_url = db_config.get("url")
-            if db_url:
+            if db_url and not os.environ.get("DATABASE_URL"):
                 os.environ["DATABASE_URL"] = db_url
                 print(f"Using database from config: {db_config.get('type', 'postgresql')}")
 

--- a/scripts/fetch_qwen.py
+++ b/scripts/fetch_qwen.py
@@ -1313,11 +1313,12 @@ if __name__ == "__main__":
         config_path = Path(args.config)
         if config_path.exists():
             # Load config and set DATABASE_URL environment variable
+            # Only set if not already configured (Docker provides DATABASE_URL)
             with open(config_path) as f:
                 config_data = json.load(f)
             db_config = config_data.get("database", {})
             db_url = db_config.get("url")
-            if db_url:
+            if db_url and not os.environ.get("DATABASE_URL"):
                 os.environ["DATABASE_URL"] = db_url
                 print(f"Using database from config: {db_config.get('type', 'postgresql')}")
 

--- a/scripts/fetch_zcode.py
+++ b/scripts/fetch_zcode.py
@@ -832,7 +832,8 @@ if __name__ == "__main__":
                 config_data = json.load(f)
             db_config = config_data.get("database", {})
             db_url = db_config.get("url")
-            if db_url:
+            # Only set if not already configured (Docker provides DATABASE_URL)
+            if db_url and not os.environ.get("DATABASE_URL"):
                 os.environ["DATABASE_URL"] = db_url
                 print(f"Using database from config: {db_config.get('type', 'postgresql')}")
 


### PR DESCRIPTION
**问题描述**

在 Docker 环境中，`fetch_*.py` 脚本从 `config.json` 读取数据库 URL 并覆盖了 Docker Compose 传入的正确 `DATABASE_URL` 环境变量。

**根因**

1. Docker Compose 通过环境变量传入正确的 DATABASE_URL
2. `docker-entrypoint.sh` 生成的 `config.json` 包含未展开的变量语法 `${DB_USER:-ace}`
3. fetch 脚本从 config.json 读取并覆盖环境变量

**修复**

如果环境变量 `DATABASE_URL` 已存在，不覆盖。

```python
# 修改前
if db_url:
    os.environ["DATABASE_URL"] = db_url

# 修改后
if db_url and not os.environ.get("DATABASE_URL"):
    os.environ["DATABASE_URL"] = db_url
```

**影响文件**
- fetch_qwen.py
- fetch_claude.py
- fetch_openclaw.py
- fetch_codex.py
- fetch_zcode.py

Closes #1362