### PR TITLE
fix(webui): 单用户模式下保留配置 URL 的端口 (Issue #1366)

### DIFF
--- a/app/services/webui_manager.py
+++ b/app/services/webui_manager.py
@@ -262,21 +262,21 @@ class WebUIManager:
         Used in Docker deployments where container cannot detect host's real IP.
 
         Examples:
-            config_url="http://172.17.0.1", request_host_url="http://192.168.1.169:5000"
-            -> "http://192.168.1.169"
+            config_url="http://172.17.0.1:3100", request_host_url="http://192.168.1.169:5000"
+            -> "http://192.168.1.169:3100" (hostname replaced, port preserved from config)
 
-            config_url="http://host.docker.internal", request_host_url="http://example.com"
-            -> "http://example.com"
+            config_url="http://host.docker.internal:3100", request_host_url="http://example.com"
+            -> "http://example.com:3100"
 
-            config_url="http://[::1]", request_host_url="http://[2001:db8::1]:5000"
-            -> "http://[2001:db8::1]" (IPv6 preserved with brackets)
+            config_url="http://[::1]:3100", request_host_url="http://[2001:db8::1]:5000"
+            -> "http://[2001:db8::1]:3100" (IPv6 preserved with brackets)
 
         Args:
             config_url: URL from config.json (may have wrong IP in Docker).
             request_host_url: Host URL from Flask request (user's actual access URL).
 
         Returns:
-            URL with hostname replaced from request, without port.
+            URL with hostname replaced from request, preserving config's port.
         """
         from urllib.parse import urlparse
 
@@ -286,15 +286,21 @@ class WebUIManager:
         # Use request's scheme and hostname, preserving config's scheme if request lacks it
         scheme = request_parsed.scheme or config_parsed.scheme or "http"
         hostname = request_parsed.hostname or config_parsed.hostname
+        # Preserve port from config_url (important for single-user mode where WebUI port is fixed)
+        port = config_parsed.port
 
         if hostname:
             # Check if hostname is IPv6 (contains colons and no dots)
             # IPv6 addresses need to be wrapped in brackets in URLs
             if ":" in hostname and "." not in hostname:
+                if port:
+                    return f"{scheme}://[{hostname}]:{port}"
                 return f"{scheme}://[{hostname}]"
+            if port:
+                return f"{scheme}://{hostname}:{port}"
             return f"{scheme}://{hostname}"
         # Fallback: return original config_url if parsing fails
-        return self._remove_port_from_url(config_url)
+        return config_url
 
     def start_cleanup_thread(self):
         """Start the background cleanup greenlet."""
@@ -495,10 +501,12 @@ class WebUIManager:
             Tuple of (url, token).
         """
         # Determine base URL: use request host if provided, otherwise use config
+        # In single-user mode, preserve the port from config.url (WebUI port is fixed)
         if host_url:
             base_url = self._replace_host_from_request(self.config.url, host_url)
         else:
-            base_url = self._remove_port_from_url(self.config.url)
+            # Single-user mode: use configured URL directly (preserve port)
+            base_url = self.config.url
 
         if not self.config.multi_user_mode:
             # Single-user mode: return configured URL with a generated token

--- a/tests/issues/1306/test_host_url_replacement.py
+++ b/tests/issues/1306/test_host_url_replacement.py
@@ -2,6 +2,7 @@
 
 Tests that iframe URL uses user's actual access IP (from Flask request)
 instead of container-detected IP (from config.json).
+Also tests that config URL's port is preserved when replacing hostname.
 """
 
 import pytest
@@ -21,33 +22,47 @@ def test_replace_host_from_request():
     manager = WebUIManager(config)
     manager.stop_cleanup_thread()
 
-    # Test case 1: Replace container IP with user's actual IP
+    # Test case 1: Replace container IP with user's actual IP (no port in config)
     config_url = "http://172.17.0.1"
     request_host_url = "http://192.168.1.169:5000"
     result = manager._replace_host_from_request(config_url, request_host_url)
     assert result == "http://192.168.1.169"
     print(f"✓ Case 1: {config_url} + {request_host_url} -> {result}")
 
-    # Test case 2: Replace host.docker.internal with domain
+    # Test case 2: Replace host.docker.internal with domain (no port in config)
     config_url = "http://host.docker.internal"
     request_host_url = "http://example.com:5000"
     result = manager._replace_host_from_request(config_url, request_host_url)
     assert result == "http://example.com"
     print(f"✓ Case 2: {config_url} + {request_host_url} -> {result}")
 
-    # Test case 3: HTTPS request
+    # Test case 3: HTTPS request (no port in config)
     config_url = "http://172.17.0.1"
     request_host_url = "https://192.168.1.169:5000"
     result = manager._replace_host_from_request(config_url, request_host_url)
     assert result == "https://192.168.1.169"
     print(f"✓ Case 3: {config_url} + {request_host_url} -> {result}")
 
-    # Test case 4: IPv6
+    # Test case 4: IPv6 (no port in config)
     config_url = "http://[::1]"
     request_host_url = "http://[2001:db8::1]:5000"
     result = manager._replace_host_from_request(config_url, request_host_url)
     assert result == "http://[2001:db8::1]"
     print(f"✓ Case 4: {config_url} + {request_host_url} -> {result}")
+
+    # Test case 5: Preserve port from config URL (single-user mode)
+    config_url = "http://172.17.0.1:3100"
+    request_host_url = "http://192.168.1.169:5000"
+    result = manager._replace_host_from_request(config_url, request_host_url)
+    assert result == "http://192.168.1.169:3100"
+    print(f"✓ Case 5 (preserve port): {config_url} + {request_host_url} -> {result}")
+
+    # Test case 6: Preserve port with IPv6
+    config_url = "http://[::1]:3100"
+    request_host_url = "http://[2001:db8::1]:5000"
+    result = manager._replace_host_from_request(config_url, request_host_url)
+    assert result == "http://[2001:db8::1]:3100"
+    print(f"✓ Case 6 (IPv6 with port): {config_url} + {request_host_url} -> {result}")
 
 
 def test_get_user_webui_url_with_host_url():
@@ -56,13 +71,13 @@ def test_get_user_webui_url_with_host_url():
 
     config = WorkspaceConfig(
         enabled=True,
-        url="http://172.17.0.1",  # Container-detected IP (wrong)
+        url="http://172.17.0.1",  # Container-detected IP (wrong), no port
         multi_user_mode=False,
     )
     manager = WebUIManager(config)
     manager.stop_cleanup_thread()
 
-    # Without host_url: uses config.url (wrong IP)
+    # Without host_url: uses config.url directly
     url1, token1 = manager.get_user_webui_url(user_id=1, system_account="testuser")
     assert url1 == "http://172.17.0.1"
     print(f"✓ Without host_url: {url1}")
@@ -78,6 +93,36 @@ def test_get_user_webui_url_with_host_url():
     assert token1.startswith("1:0:")
     assert token2.startswith("1:0:")
     print("✓ Tokens generated correctly")
+
+
+def test_get_user_webui_url_preserves_port_single_user():
+    """Test that single-user mode preserves port from config URL."""
+    print("\n=== Test: Single-user mode port preservation ===")
+
+    # Config URL with port (typical for single-user mode)
+    config = WorkspaceConfig(
+        enabled=True,
+        url="http://172.17.0.1:3100",  # WebUI port
+        multi_user_mode=False,
+    )
+    manager = WebUIManager(config)
+    manager.stop_cleanup_thread()
+
+    # Without host_url: uses config.url directly (port preserved)
+    url1, token1 = manager.get_user_webui_url(user_id=1, system_account="testuser")
+    assert url1 == "http://172.17.0.1:3100"
+    print(f"✓ Without host_url (port preserved): {url1}")
+
+    # With host_url: replaces hostname but preserves port
+    url2, token2 = manager.get_user_webui_url(
+        user_id=1, system_account="testuser", host_url="http://192.168.1.169:5000"
+    )
+    assert url2 == "http://192.168.1.169:3100"
+    print(f"✓ With host_url (hostname replaced, port preserved): {url2}")
+
+    assert token1.startswith("1:0:")
+    assert token2.startswith("1:0:")
+    print("✓ Port preservation test passed")
 
 
 def test_get_user_webui_url_preserves_port_in_multi_user():
@@ -102,4 +147,5 @@ def test_get_user_webui_url_preserves_port_in_multi_user():
 if __name__ == "__main__":
     test_replace_host_from_request()
     test_get_user_webui_url_with_host_url()
+    test_get_user_webui_url_preserves_port_single_user()
     print("\n✓ All tests passed")

--- a/tests/issues/42/test_webui_manager.py
+++ b/tests/issues/42/test_webui_manager.py
@@ -181,8 +181,8 @@ def test_manager_get_user_webui_url_single_user():
 
     url, token = manager.get_user_webui_url(user_id=1, system_account="testuser")
 
-    # URL should have port removed for correct iframe address
-    assert url == "http://localhost"
+    # URL should preserve port from config (WebUI port is fixed in single-user mode)
+    assert url == "http://localhost:8080"
     # Token is generated for iframe auth in cross-origin API calls
     assert token.startswith("1:0:")  # Format: user_id:port:random:signature
     print(f"✓ Single-user mode: url={url}, token={token[:20]}...")


### PR DESCRIPTION
## 问题描述

在单用户模式下，创建工作区时 iframe 一直显示"正在启动工作区，请稍候..."，无法正常加载 WebUI。

## 根因分析

`app/services/webui_manager.py` 中的 `_replace_host_from_request` 方法错误地移除了配置 URL 的端口：

- 配置：`http://192.168.1.75:3100`
- 实际加载：`http://192.168.1.75`（无端口 → 默认端口 80）
- iframe 加载到无服务的端口 → 卡在加载状态

## 触发条件

单用户模式 (`multi_user_mode=false`) + 配置 URL 包含端口（如 `http://xxx:3100`）

## 修复方案

1. `_replace_host_from_request` 方法：保留 config_url 的端口
2. `get_user_webui_url` 方法：单用户模式直接使用 config.url（保留端口）

## 测试覆盖

- 新增 `test_get_user_webui_url_preserves_port_single_user()` 测试
- 新增端口保留测试 case 5、6

## 相关文件

- `app/services/webui_manager.py`
- `tests/issues/1306/test_host_url_replacement.py`
- `tests/issues/42/test_webui_manager.py`

## 关联 Issue

Fixes #1366