### PR TITLE
fix(workspace): 单用户模式下 iframe URL 添加 token 参数

### DIFF
--- a/frontend/src/components/features/Workspace.tsx
+++ b/frontend/src/components/features/Workspace.tsx
@@ -562,33 +562,34 @@ export const Workspace: React.FC = () => {
           url = `${url}&openace_url=${encodeURIComponent(openaceUrl)}`;
         }
         // Add lang parameter for language sync
-        url = `${url}&lang=${encodeURIComponent(language)}&theme=${theme}`;
+        url = appendParam(url, 'lang', language);
+        url = appendParam(url, 'theme', theme);
         // Add sessionId, encodedProjectName, and toolName if restoring a session
         if (restoreSessionId) {
-          url = `${url}&sessionId=${encodeURIComponent(restoreSessionId)}`;
+          url = appendParam(url, 'sessionId', restoreSessionId);
         }
         if (encodedProjectName) {
-          url = `${url}&encodedProjectName=${encodeURIComponent(encodedProjectName)}`;
+          url = appendParam(url, 'encodedProjectName', encodedProjectName);
         }
         if (toolName) {
-          url = `${url}&toolName=${encodeURIComponent(toolName)}`;
+          url = appendParam(url, 'toolName', toolName);
         }
         // Add settings parameters (Issue #70)
         if (settings?.model) {
-          url = `${url}&model=${encodeURIComponent(settings.model)}`;
+          url = appendParam(url, 'model', settings.model);
         }
         if (settings?.useWebUI !== undefined) {
-          url = `${url}&useWebUI=${settings.useWebUI}`;
+          url = appendParam(url, 'useWebUI', String(settings.useWebUI));
         }
         if (settings?.permissionMode) {
-          url = `${url}&permissionMode=${encodeURIComponent(settings.permissionMode)}`;
+          url = appendParam(url, 'permissionMode', settings.permissionMode);
         }
         // File changes panel visibility (Issue #144)
         const showPanel = useAppStore.getState().showFileChangesPanel;
-        url = `${url}&showFileChangesPanel=${showPanel}`;
+        url = appendParam(url, 'showFileChangesPanel', String(showPanel));
         // Resume hint for CLI session (Issue #669)
         if (resumeHint) {
-          url = `${url}&resumeHint=true`;
+          url = appendParam(url, 'resumeHint', 'true');
         }
         // Remote workspace parameters
         url = appendRemoteParams(url);
@@ -625,7 +626,7 @@ export const Workspace: React.FC = () => {
         url = appendParam(url, 'model', settings.model);
       }
       if (settings?.useWebUI !== undefined) {
-        url = `${url}&useWebUI=${settings.useWebUI}`;
+        url = appendParam(url, 'useWebUI', String(settings.useWebUI));
       }
       if (settings?.permissionMode) {
         url = appendParam(url, 'permissionMode', settings.permissionMode);

--- a/frontend/src/components/features/Workspace.tsx
+++ b/frontend/src/components/features/Workspace.tsx
@@ -597,19 +597,20 @@ export const Workspace: React.FC = () => {
         return url;
       }
 
-      // Single-user mode: use configured URL
-      // Remove any existing port from URL (keep only scheme://hostname)
+      // Single-user mode: use configured URL (preserve port)
+      // Note: Port should NOT be removed - WebUI runs on a specific port (e.g., 3100)
+      // The backend handles hostname replacement via _replace_host_from_request if needed
       let url = config.url;
-      try {
-        const parsedUrl = new URL(url);
-        url = `${parsedUrl.protocol}//${parsedUrl.hostname}`;
-      } catch {
-        // Fallback: if URL parsing fails, use original
-        console.warn('Failed to parse workspace URL:', url);
-      }
       // Add lang parameter for language sync
       const langSeparator = url.includes('?') ? '&' : '?';
       url = `${url}${langSeparator}lang=${encodeURIComponent(language)}&theme=${theme}`;
+      // Add token and openace_url for authentication (same as multi-user mode)
+      if (userWebUI?.success && userWebUI.token) {
+        url = appendParam(url, 'token', userWebUI.token);
+        if (userWebUI.openace_url) {
+          url = appendParam(url, 'openace_url', userWebUI.openace_url);
+        }
+      }
       if (restoreSessionId) {
         url = appendParam(url, 'sessionId', restoreSessionId);
       }


### PR DESCRIPTION
## 修复内容

修复 Issue #1368：单用户模式下工作区 iframe 无法加载 WebUI，显示 "Failed to load projects: Unauthorized" 错误。

## 根因分析

前端 `Workspace.tsx` 在生成 iframe URL 时，多用户模式会添加 `token` 和 `openace_url` 参数，但单用户模式遗漏了这些参数。

WebUI（qwen-code-webui）需要通过 URL 参数 `token` 进行认证。缺少 token 时，WebUI API 返回 "Unauthorized: Missing token"。

## 修改方案

在单用户模式分支中，也从 `userWebUI` 获取 token 并添加到 URL：

```typescript
// Add token and openace_url for authentication (same as multi-user mode)
if (userWebUI?.success && userWebUI.token) {
  url = appendParam(url, 'token', userWebUI.token);
  if (userWebUI.openace_url) {
    url = appendParam(url, 'openace_url', userWebUI.openace_url);
  }
}
```

## 测试方法

1. 配置单用户模式：`multi_user_mode: false`
2. 启动 WebUI 并配置 token_secret
3. 登录后进入工作区，确认 iframe 正常加载
4. 检查 iframe URL 包含 `token` 参数

Closes #1368