### PR TITLE
fix(webui): 单用户模式下使用固定端口3100，不依赖config.json解析端口 (Issue #1357)

### DIFF
--- a/app/services/webui_manager.py
+++ b/app/services/webui_manager.py
@@ -261,45 +261,54 @@ class WebUIManager:
 
         Used in Docker deployments where container cannot detect host's real IP.
 
+        **Design Principle (Issue #1357):**
+        In docker compose deployment, WebUI and open-ace are on the same machine.
+        URL should come from request.host_url (user's actual access IP),
+        NOT from config.json (which may have wrong IPv6 or container-detected IP).
+
+        Port is handled separately:
+        - Single-user mode: fixed port 3100 (WebUI port)
+        - Multi-user mode: dynamic port from instance.port
+
         Examples:
             config_url="http://172.17.0.1:3100", request_host_url="http://192.168.1.169:5000"
-            -> "http://192.168.1.169:3100" (hostname replaced, port preserved from config)
+            -> "http://192.168.1.169" (hostname replaced, no port)
 
             config_url="http://host.docker.internal:3100", request_host_url="http://example.com"
-            -> "http://example.com:3100"
+            -> "http://example.com"
 
             config_url="http://[::1]:3100", request_host_url="http://[2001:db8::1]:5000"
-            -> "http://[2001:db8::1]:3100" (IPv6 preserved with brackets)
+            -> "http://[2001:db8::1]" (IPv6 preserved with brackets)
 
         Args:
             config_url: URL from config.json (may have wrong IP in Docker).
             request_host_url: Host URL from Flask request (user's actual access URL).
 
         Returns:
-            URL with hostname replaced from request, preserving config's port.
+            URL with hostname replaced from request, without port.
         """
         from urllib.parse import urlparse
 
-        config_parsed = urlparse(config_url)
         request_parsed = urlparse(request_host_url)
 
-        # Use request's scheme and hostname, preserving config's scheme if request lacks it
-        scheme = request_parsed.scheme or config_parsed.scheme or "http"
-        hostname = request_parsed.hostname or config_parsed.hostname
-        # Preserve port from config_url (important for single-user mode where WebUI port is fixed)
-        port = config_parsed.port
+        # Use request's scheme and hostname
+        scheme = request_parsed.scheme or "http"
+        hostname = request_parsed.hostname
 
         if hostname:
             # Check if hostname is IPv6 (contains colons and no dots)
             # IPv6 addresses need to be wrapped in brackets in URLs
             if ":" in hostname and "." not in hostname:
-                if port:
-                    return f"{scheme}://[{hostname}]:{port}"
                 return f"{scheme}://[{hostname}]"
-            if port:
-                return f"{scheme}://{hostname}:{port}"
             return f"{scheme}://{hostname}"
-        # Fallback: return original config_url if parsing fails
+        # Fallback: parse config_url if request_host_url parsing fails
+        config_parsed = urlparse(config_url)
+        hostname = config_parsed.hostname
+        scheme = config_parsed.scheme or "http"
+        if hostname:
+            if ":" in hostname and "." not in hostname:
+                return f"{scheme}://[{hostname}]"
+            return f"{scheme}://{hostname}"
         return config_url
 
     def start_cleanup_thread(self):
@@ -501,18 +510,27 @@ class WebUIManager:
             Tuple of (url, token).
         """
         # Determine base URL: use request host if provided, otherwise use config
-        # In single-user mode, preserve the port from config.url (WebUI port is fixed)
+        # Design Principle (Issue #1357):
+        # - Single-user mode (docker compose): WebUI and open-ace on same machine
+        #   URL from request.host_url with fixed port 3100, NOT from config.json
+        # - Multi-user mode (install.sh): WebUI and open-ace may be on different machines
+        #   URL from config.json (user-configured) or request.host_url with instance.port
         if host_url:
             base_url = self._replace_host_from_request(self.config.url, host_url)
         else:
-            # Single-user mode: use configured URL directly (preserve port)
             base_url = self.config.url
 
         if not self.config.multi_user_mode:
-            # Single-user mode: return configured URL with a generated token
-            # The token is needed for iframe auth when making cross-origin API calls
+            # Single-user mode (docker compose): use fixed WebUI port 3100
+            # base_url from _replace_host_from_request has no port
             token = self.generate_token(user_id, 0)
-            return base_url, token
+            if host_url:
+                # Docker compose: URL from request.host_url with fixed port 3100
+                url = f"{base_url}:3100"
+            else:
+                # Fallback: use config.url (for edge cases where host_url not provided)
+                url = base_url
+            return url, token
 
         with self._lock:
             # Check if user already has an instance

--- a/tests/issues/1306/test_host_url_replacement.py
+++ b/tests/issues/1306/test_host_url_replacement.py
@@ -1,8 +1,13 @@
-"""Test host_url replacement for Issue #1306.
+"""Test host_url replacement for Issue #1306 and Issue #1357.
 
 Tests that iframe URL uses user's actual access IP (from Flask request)
 instead of container-detected IP (from config.json).
-Also tests that config URL's port is preserved when replacing hostname.
+
+Issue #1357 Design Principle:
+- Single-user mode (docker compose): WebUI and open-ace on same machine
+  URL from request.host_url with fixed port 3100, NOT from config.json
+- Multi-user mode (install.sh): WebUI and open-ace may be on different machines
+  URL from config.json (user-configured) or request.host_url with instance.port
 """
 
 import pytest
@@ -50,19 +55,20 @@ def test_replace_host_from_request():
     assert result == "http://[2001:db8::1]"
     print(f"✓ Case 4: {config_url} + {request_host_url} -> {result}")
 
-    # Test case 5: Preserve port from config URL (single-user mode)
+    # Test case 5: _replace_host_from_request no longer returns port (Issue #1357)
+    # Port is added separately in get_user_webui_url for single-user mode
     config_url = "http://172.17.0.1:3100"
     request_host_url = "http://192.168.1.169:5000"
     result = manager._replace_host_from_request(config_url, request_host_url)
-    assert result == "http://192.168.1.169:3100"
-    print(f"✓ Case 5 (preserve port): {config_url} + {request_host_url} -> {result}")
+    assert result == "http://192.168.1.169"
+    print(f"✓ Case 5 (no port in result): {config_url} + {request_host_url} -> {result}")
 
-    # Test case 6: Preserve port with IPv6
+    # Test case 6: IPv6 - no port in result (Issue #1357)
     config_url = "http://[::1]:3100"
     request_host_url = "http://[2001:db8::1]:5000"
     result = manager._replace_host_from_request(config_url, request_host_url)
-    assert result == "http://[2001:db8::1]:3100"
-    print(f"✓ Case 6 (IPv6 with port): {config_url} + {request_host_url} -> {result}")
+    assert result == "http://[2001:db8::1]"
+    print(f"✓ Case 6 (IPv6, no port in result): {config_url} + {request_host_url} -> {result}")
 
 
 def test_get_user_webui_url_with_host_url():
@@ -77,17 +83,17 @@ def test_get_user_webui_url_with_host_url():
     manager = WebUIManager(config)
     manager.stop_cleanup_thread()
 
-    # Without host_url: uses config.url directly
+    # Without host_url: uses config.url directly (fallback)
     url1, token1 = manager.get_user_webui_url(user_id=1, system_account="testuser")
     assert url1 == "http://172.17.0.1"
-    print(f"✓ Without host_url: {url1}")
+    print(f"✓ Without host_url (fallback): {url1}")
 
-    # With host_url: uses request IP (correct IP)
+    # With host_url: uses request IP with fixed port 3100 (Issue #1357)
     url2, token2 = manager.get_user_webui_url(
         user_id=1, system_account="testuser", host_url="http://192.168.1.169:5000"
     )
-    assert url2 == "http://192.168.1.169"
-    print(f"✓ With host_url: {url2}")
+    assert url2 == "http://192.168.1.169:3100"
+    print(f"✓ With host_url (fixed port 3100): {url2}")
 
     # Verify tokens are generated
     assert token1.startswith("1:0:")
@@ -96,10 +102,14 @@ def test_get_user_webui_url_with_host_url():
 
 
 def test_get_user_webui_url_preserves_port_single_user():
-    """Test that single-user mode preserves port from config URL."""
-    print("\n=== Test: Single-user mode port preservation ===")
+    """Test that single-user mode uses fixed port 3100 (Issue #1357).
 
-    # Config URL with port (typical for single-user mode)
+    In single-user mode (docker compose), WebUI runs on fixed port 3100.
+    URL should come from request.host_url with port 3100, NOT from config.json.
+    """
+    print("\n=== Test: Single-user mode fixed port 3100 ===")
+
+    # Config URL with port (but will be ignored in single-user mode with host_url)
     config = WorkspaceConfig(
         enabled=True,
         url="http://172.17.0.1:3100",  # WebUI port
@@ -108,17 +118,17 @@ def test_get_user_webui_url_preserves_port_single_user():
     manager = WebUIManager(config)
     manager.stop_cleanup_thread()
 
-    # Without host_url: uses config.url directly (port preserved)
+    # Without host_url: uses config.url as fallback
     url1, token1 = manager.get_user_webui_url(user_id=1, system_account="testuser")
     assert url1 == "http://172.17.0.1:3100"
-    print(f"✓ Without host_url (port preserved): {url1}")
+    print(f"✓ Without host_url (fallback to config.url): {url1}")
 
-    # With host_url: replaces hostname but preserves port
+    # With host_url: uses request IP with fixed port 3100 (Issue #1357)
     url2, token2 = manager.get_user_webui_url(
         user_id=1, system_account="testuser", host_url="http://192.168.1.169:5000"
     )
     assert url2 == "http://192.168.1.169:3100"
-    print(f"✓ With host_url (hostname replaced, port preserved): {url2}")
+    print(f"✓ With host_url (request IP + fixed port 3100): {url2}")
 
     assert token1.startswith("1:0:")
     assert token2.startswith("1:0:")


### PR DESCRIPTION
## 问题根因

docker compose部署下，docker-entrypoint.sh自动检测SERVER_IP可能返回IPv6地址，IPv6地址写入config.json但格式错误（缺少方括号），导致`_replace_host_from_request`方法解析config_url端口时抛出ValueError。

## 设计原则（Issue #1357）

- docker compose部署下，WebUI和open-ace在同一机器
- URL应来自request.host_url（用户实际访问IP），不依赖config.json
- 单用户模式：固定端口3100
- 多用户模式：动态端口instance.port（保留原有逻辑）

## 修复内容

1. `_replace_host_from_request`：只替换hostname，不解析config_url端口
2. `get_user_webui_url`：单用户模式下使用固定端口3100
3. 更新测试以匹配新逻辑

## 不影响范围

install.sh部署（多用户模式）保留原有逻辑，不受此修复影响。