### PR TITLE
fix(manage): 项目分类按工作区路径智能提取项目名 (Issue #1371)

### DIFF
--- a/frontend/src/components/features/management/ProjectManagement.tsx
+++ b/frontend/src/components/features/management/ProjectManagement.tsx
@@ -461,14 +461,10 @@ export const ProjectManagement: React.FC = () => {
                         <td>
                           <div className="d-flex align-items-center">
                             <i
-                              className={`bi ${isUncategorized ? 'bi-folder-x text-muted' : 'bi-folder-fill text-warning'} me-2`}
+                              className={`bi ${isUncategorized ? 'bi-folder2-open text-info' : 'bi-folder-fill text-warning'} me-2`}
                             />
                             <div>
-                              <strong>
-                                {isUncategorized
-                                  ? t('uncategorized', language)
-                                  : category.category_name}
-                              </strong>
+                              <strong>{category.category_name}</strong>
                               {!isUncategorized && category.key_patterns.length > 0 && (
                                 <small className="d-block text-muted">
                                   {category.key_patterns.slice(0, 3).join(', ')}

--- a/frontend/src/components/features/management/ProjectManagement.tsx
+++ b/frontend/src/components/features/management/ProjectManagement.tsx
@@ -33,6 +33,30 @@ import { usePageRefresh } from '@/hooks';
 type CategorySortKey = 'name' | 'total_workspaces' | 'total_users' | 'total_tokens' | 'last_access';
 type SortDirection = 'asc' | 'desc';
 
+// Functional directories that should not be considered as project names
+// These are common subdirectories that indicate project structure, not project identity
+const FUNCTIONAL_DIRS = [
+  'test',
+  'tests',
+  'testing',
+  'spec',
+  'specs',
+  'src',
+  'frontend',
+  'backend',
+  'web',
+  'ui',
+  'api',
+  'server',
+  'lib',
+  'libs',
+  'utils',
+  'scripts',
+  'docs',
+  'config',
+  'data',
+];
+
 // Aggregated stats for a category
 interface CategoryAggregatedStats {
   category_id: number;
@@ -46,6 +70,20 @@ interface CategoryAggregatedStats {
   first_access: string | null;
   last_access: string | null;
   workspaces: ProjectStats[];
+}
+
+// Extract project name from path, skipping functional directories
+// Issue #1371: Auto-categorize by project name instead of generic "uncategorized"
+function extractProjectName(path: string): string {
+  const parts = path.split(/[/\\]/).filter((p) => p);
+  // Search from end, skip functional directories
+  for (let i = parts.length - 1; i >= 0; i--) {
+    const part = parts[i].toLowerCase();
+    if (!FUNCTIONAL_DIRS.includes(part)) {
+      return parts[i]; // Return original case
+    }
+  }
+  return parts[parts.length - 1] || 'unknown'; // Fallback
 }
 
 // Match project path against patterns (case-insensitive, contains match)
@@ -104,35 +142,43 @@ function categorizeProjects(
     result.push(aggregated);
   }
 
-  // Add uncategorized group
+  // Auto-categorize remaining projects by extracted project name (Issue #1371)
   const uncategorizedWorkspaces = stats.filter((s) => !matchedProjectIds.has(s.project_id));
   if (uncategorizedWorkspaces.length > 0) {
-    const uniqueUserIds = new Set(
-      uncategorizedWorkspaces.flatMap((w) => w.user_stats.map((u) => u.user_id))
-    );
+    // Group by extracted project name
+    const projectGroups: Map<string, ProjectStats[]> = new Map();
+    for (const workspace of uncategorizedWorkspaces) {
+      const projectName = extractProjectName(workspace.project_path);
+      if (!projectGroups.has(projectName)) {
+        projectGroups.set(projectName, []);
+      }
+      projectGroups.get(projectName)!.push(workspace);
+    }
 
-    result.push({
-      category_id: -1,
-      category_name: 'uncategorized', // Will be translated in render
-      key_patterns: [],
-      total_workspaces: uncategorizedWorkspaces.length,
-      total_users: uniqueUserIds.size,
-      total_tokens: uncategorizedWorkspaces.reduce((sum, w) => sum + Number(w.total_tokens), 0),
-      total_requests: uncategorizedWorkspaces.reduce((sum, w) => sum + w.total_requests, 0),
-      total_duration_seconds: uncategorizedWorkspaces.reduce(
-        (sum, w) => sum + w.total_duration_seconds,
-        0
-      ),
-      first_access: uncategorizedWorkspaces.reduce(
-        (min, w) => (w.first_access && (!min || w.first_access < min) ? w.first_access : min),
-        null as string | null
-      ),
-      last_access: uncategorizedWorkspaces.reduce(
-        (max, w) => (w.last_access && (!max || w.last_access > max) ? w.last_access : max),
-        null as string | null
-      ),
-      workspaces: uncategorizedWorkspaces,
-    });
+    // Create aggregated stats for each project group
+    for (const [projectName, workspaces] of projectGroups) {
+      const uniqueUserIds = new Set(workspaces.flatMap((w) => w.user_stats.map((u) => u.user_id)));
+
+      result.push({
+        category_id: -1, // Use -1 for auto-generated categories
+        category_name: projectName,
+        key_patterns: [],
+        total_workspaces: workspaces.length,
+        total_users: uniqueUserIds.size,
+        total_tokens: workspaces.reduce((sum, w) => sum + Number(w.total_tokens), 0),
+        total_requests: workspaces.reduce((sum, w) => sum + w.total_requests, 0),
+        total_duration_seconds: workspaces.reduce((sum, w) => sum + w.total_duration_seconds, 0),
+        first_access: workspaces.reduce(
+          (min, w) => (w.first_access && (!min || w.first_access < min) ? w.first_access : min),
+          null as string | null
+        ),
+        last_access: workspaces.reduce(
+          (max, w) => (w.last_access && (!max || w.last_access > max) ? w.last_access : max),
+          null as string | null
+        ),
+        workspaces,
+      });
+    }
   }
 
   return result;

--- a/frontend/src/components/features/management/ProjectManagement.tsx
+++ b/frontend/src/components/features/management/ProjectManagement.tsx
@@ -190,7 +190,7 @@ export const ProjectManagement: React.FC = () => {
   const [categories, setCategories] = useState<ProjectCategory[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [expandedCategories, setExpandedCategories] = useState<Set<number>>(new Set());
+  const [expandedCategories, setExpandedCategories] = useState<Set<string>>(new Set());
   const [selectedWorkspace, setSelectedWorkspace] = useState<ProjectStats | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<ProjectStats | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
@@ -291,13 +291,13 @@ export const ProjectManagement: React.FC = () => {
     });
   }, [categorizedStats, sortKey, sortDirection]);
 
-  const toggleExpand = (categoryId: number) => {
+  const toggleExpand = (categoryName: string) => {
     setExpandedCategories((prev) => {
       const next = new Set(prev);
-      if (next.has(categoryId)) {
-        next.delete(categoryId);
+      if (next.has(categoryName)) {
+        next.delete(categoryName);
       } else {
-        next.add(categoryId);
+        next.add(categoryName);
       }
       return next;
     });
@@ -442,14 +442,14 @@ export const ProjectManagement: React.FC = () => {
               </thead>
               <tbody>
                 {sortedCategorizedStats.map((category) => {
-                  const isExpanded = expandedCategories.has(category.category_id);
+                  const isExpanded = expandedCategories.has(category.category_name);
                   const isUncategorized = category.category_id === -1;
 
                   return (
-                    <React.Fragment key={category.category_id}>
+                    <React.Fragment key={category.category_name}>
                       {/* Category Row */}
                       <tr
-                        onClick={() => toggleExpand(category.category_id)}
+                        onClick={() => toggleExpand(category.category_name)}
                         style={{ cursor: 'pointer' }}
                         className={isUncategorized ? 'table-secondary' : ''}
                       >


### PR DESCRIPTION
## 相关 Issue

Closes #1371

## 问题描述

项目管理页面的分类是固定的关键词匹配系统：
- Frontend: `["frontend", "web", "ui"]`
- Backend: `["backend", "api", "server"]`  
- Testing: `["test", "tests", "spec"]`

用户的工作区如 `/home/xxx/frontend/qwen-code-webui` 会被归入 "Frontend" 分类，而不是显示实际项目名 "qwen-code-webui"。同一项目的不同子目录也无法自动归类在一起。

## 解决方案

改进分类逻辑，将未分类的项目**自动按项目名分组**：

1. 新增 `FUNCTIONAL_DIRS` 常量：过滤功能目录（test/src/frontend/backend 等）
2. 新增 `extractProjectName()` 函数：从路径智能提取项目名
3. 修改 `categorizeProjects()` 函数：按项目名自动分组

## 效果示例

| 路径 | 提取项目名 |
|------|-----------|
| `/home/xxx/frontend/qwen-code-webui` | `qwen-code-webui` |
| `/home/xxx/frontend/qwen-code-webui/test` | `qwen-code-webui` |
| `/home/xxx/projects/iplan-backend/api` | `iplan-backend` |

同一项目的子目录自动归类在一起。

## 修改文件

- `frontend/src/components/features/management/ProjectManagement.tsx`
  - 新增 `FUNCTIONAL_DIRS` 常量（19 个功能目录）
  - 新增 `extractProjectName()` 函数
  - 修改 `categorizeProjects()` 函数

## 测试验证

- ✅ TypeScript 类型检查通过
- ✅ ESLint/Prettier 格式检查通过