### PR TITLE
fix(ci): 为 Sync to Gitee workflow 添加重试机制 (Issue #1378)

### DIFF
--- a/.github/workflows/sync-to-gitee.yml
+++ b/.github/workflows/sync-to-gitee.yml
@@ -29,23 +29,34 @@ jobs:
           git fetch gitee --prune
 
       - name: Push main branch to Gitee
-        run: |
-          # Push main branch with force-with-lease (safer than force)
-          git push gitee origin/main:main --force-with-lease || \
-          git push gitee origin/main:main --force
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_wait_seconds: 30
+          command: |
+            git push gitee origin/main:main --force-with-lease || \
+            git push gitee origin/main:main --force
         env:
           GITEE_TOKEN: ${{ secrets.GITEE_TOKEN }}
 
       - name: Push other branches to Gitee
-        run: |
-          # Push all other branches
-          git push gitee --all --force || true
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_wait_seconds: 30
+          command: git push gitee --all --force
         env:
           GITEE_TOKEN: ${{ secrets.GITEE_TOKEN }}
 
       - name: Push tags to Gitee
-        run: |
-          git push gitee --tags --force
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_wait_seconds: 30
+          command: git push gitee --tags --force
         env:
           GITEE_TOKEN: ${{ secrets.GITEE_TOKEN }}
 


### PR DESCRIPTION
## Summary

为 Sync to Gitee workflow 的三个 git push 步骤添加重试机制，解决因网络波动或 Gitee 服务端临时问题导致的同步失败。

## Changes

- 使用 `nick-fields/retry@v3` 为以下步骤添加重试：
  - Push main branch to Gitee
  - Push other branches to Gitee  
  - Push tags to Gitee

- 配置参数：
  - `max_attempts: 3` - 最多重试 3 次
  - `retry_wait_seconds: 30` - 每次重试间隔 30 秒
  - `timeout_minutes: 5` - 单次超时 5 分钟

## Test Plan

- [ ] 合并后观察 Sync to Gitee workflow 执行情况
- [ ] 确认重试机制在失败时正常工作

Closes #1378