### PR TITLE
fix(work): fork 视图中「查看最近里程碑」按钮点击无响应 (Issue #1375)

### DIFF
--- a/frontend/src/components/work/WorkflowTimeline.tsx
+++ b/frontend/src/components/work/WorkflowTimeline.tsx
@@ -1346,7 +1346,7 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
     return (
       <article
         key={milestone.milestone_id}
-        ref={!compact ? registerMilestoneCard(milestone.milestone_id) : undefined}
+        ref={registerMilestoneCard(milestone.milestone_id)}
         className={`timeline-milestone-card ${
           compact ? 'timeline-milestone-card--compact' : ''
         } ${isExpanded ? 'timeline-milestone-card--expanded' : ''} timeline-milestone-card--${statusDisplay.tone}`}


### PR DESCRIPTION
## 问题描述

AI自主开发任务页面的「查看最近里程碑」按钮在 fork 视图中点击无响应，无法滚动定位到失败的 milestone。

## 问题分析

在 fork 视图中，分支内的 milestones 以 `compact: true` 模式渲染：
```tsx
// renderBranchMilestones 函数
{grouped[round].map((ms) => renderMilestoneCard(ms, { compact: true }))}
```

而 milestone 卡片的 ref 注册有条件判断：
```tsx
ref={!compact ? registerMilestoneCard(milestone.milestone_id) : undefined}
```

compact 模式下 ref 不注册，导致 `expandAndScrollToMilestone` 无法通过 `milestoneCardRefs.get()` 获取 DOM 元素进行滚动。

## 修复方案

移除 ref 注册的 `!compact` 条件判断，让所有 milestone 卡片都注册 ref：

```tsx
// 修改前
ref={!compact ? registerMilestoneCard(milestone.milestone_id) : undefined}

// 修改后
ref={registerMilestoneCard(milestone.milestone_id)}
```

## 修改范围

- `frontend/src/components/work/WorkflowTimeline.tsx`: 1 行修改

## 测试验证

- fork 视图中点击「查看最近里程碑」按钮应能正确滚动到失败的 milestone 卡片

Closes #1375