### PR TITLE
fix(migration): 添加 autonomous_workflows.retry_count 列 (Issue #1376)

### DIFF
--- a/migrations/baseline.py
+++ b/migrations/baseline.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from sqlalchemy.engine import Connection
 
 BASELINE_REVISION = "baseline_2026_06_23"
-HEAD_REVISION = "001_fix_auto_provision"
+HEAD_REVISION = "20260630_001_add_retry_count_column"
 
 _PROJECT_ROOT = Path(__file__).resolve().parents[1]
 _BASELINE_SCHEMA_DIR = _PROJECT_ROOT / "schema" / "baselines"

--- a/migrations/versions/20260630_001_add_retry_count_column.py
+++ b/migrations/versions/20260630_001_add_retry_count_column.py
@@ -1,0 +1,69 @@
+"""Add retry_count column to autonomous_workflows table
+
+Revision ID: 20260630_001
+Revises: 20260629_001
+Create Date: 2026-06-30
+
+Issue: retry API returns Internal server error because PostgreSQL lacks
+retry_count column which exists in SQLite CREATE TABLE but not in migration.
+
+Column:
+- retry_count: INTEGER - counter for manual user-triggered retries
+"""
+
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260630_001_add_retry_count_column"
+down_revision: Union[str, None] = "20260629_001_add_workflow_lock_columns"
+branch_labels: Union[str, None] = None
+depends_on: Union[str, None] = None
+
+
+def _column_exists(conn, table_name: str, column_name: str) -> bool:
+    """Check if a column exists in a table."""
+    if conn.dialect.name == "postgresql":
+        result = conn.execute(
+            sa.text(
+                "SELECT EXISTS ("
+                "  SELECT FROM information_schema.columns "
+                "  WHERE table_name = :table_name AND column_name = :column_name"
+                ")"
+            ),
+            {"table_name": table_name, "column_name": column_name},
+        )
+        return result.fetchone()[0]
+    else:
+        result = conn.execute(
+            sa.text(
+                "SELECT name FROM pragma_table_info(:table_name) WHERE name = :column_name"
+            ),
+            {"table_name": table_name, "column_name": column_name},
+        )
+        return result.fetchone() is not None
+
+
+def upgrade() -> None:
+    """Add retry_count column to autonomous_workflows."""
+    conn = op.get_bind()
+
+    if not _column_exists(conn, "autonomous_workflows", "retry_count"):
+        op.add_column(
+            "autonomous_workflows",
+            sa.Column("retry_count", sa.Integer(), nullable=True, server_default="0"),
+        )
+
+
+def downgrade() -> None:
+    """Remove retry_count column."""
+    conn = op.get_bind()
+
+    if _column_exists(conn, "autonomous_workflows", "retry_count"):
+        if conn.dialect.name == "postgresql":
+            op.drop_column("autonomous_workflows", "retry_count")
+        else:
+            # SQLite requires batch_alter_table
+            with op.batch_alter_table("autonomous_workflows") as batch_op:
+                batch_op.drop_column("retry_count")

--- a/migrations/versions/20260630_001_add_retry_count_column.py
+++ b/migrations/versions/20260630_001_add_retry_count_column.py
@@ -1,20 +1,23 @@
 """Add retry_count column to autonomous_workflows table
 
-Revision ID: 20260630_001
-Revises: 20260629_001
+Revision ID: 20260630_001_add_retry_count_column
+Revises: 20260629_001_add_workflow_lock_columns
 Create Date: 2026-06-30
 
-Issue: retry API returns Internal server error because PostgreSQL lacks
+Issue: #1376 - retry API returns Internal server error because PostgreSQL lacks
 retry_count column which exists in SQLite CREATE TABLE but not in migration.
 
 Column:
 - retry_count: INTEGER - counter for manual user-triggered retries
 """
 
+import logging
 from typing import Union
 
 import sqlalchemy as sa
 from alembic import op
+
+log = logging.getLogger(__name__)
 
 revision: str = "20260630_001_add_retry_count_column"
 down_revision: Union[str, None] = "20260629_001_add_workflow_lock_columns"
@@ -50,10 +53,13 @@ def upgrade() -> None:
     conn = op.get_bind()
 
     if not _column_exists(conn, "autonomous_workflows", "retry_count"):
+        log.info("Adding retry_count column to autonomous_workflows table")
         op.add_column(
             "autonomous_workflows",
             sa.Column("retry_count", sa.Integer(), nullable=True, server_default="0"),
         )
+    else:
+        log.info("retry_count column already exists, skipping")
 
 
 def downgrade() -> None:
@@ -61,9 +67,12 @@ def downgrade() -> None:
     conn = op.get_bind()
 
     if _column_exists(conn, "autonomous_workflows", "retry_count"):
+        log.info("Removing retry_count column from autonomous_workflows table")
         if conn.dialect.name == "postgresql":
             op.drop_column("autonomous_workflows", "retry_count")
         else:
             # SQLite requires batch_alter_table
             with op.batch_alter_table("autonomous_workflows") as batch_op:
                 batch_op.drop_column("retry_count")
+    else:
+        log.info("retry_count column does not exist, skipping")

--- a/migrations/versions/20260630_001_add_retry_count_column.py
+++ b/migrations/versions/20260630_001_add_retry_count_column.py
@@ -40,9 +40,7 @@ def _column_exists(conn, table_name: str, column_name: str) -> bool:
         return result.fetchone()[0]
     else:
         result = conn.execute(
-            sa.text(
-                "SELECT name FROM pragma_table_info(:table_name) WHERE name = :column_name"
-            ),
+            sa.text("SELECT name FROM pragma_table_info(:table_name) WHERE name = :column_name"),
             {"table_name": table_name, "column_name": column_name},
         )
         return result.fetchone() is not None

--- a/schema/schema-postgres.sql
+++ b/schema/schema-postgres.sql
@@ -360,7 +360,8 @@ CREATE TABLE autonomous_workflows (
     content_language text DEFAULT 'en'::text NOT NULL,
     locked_at timestamp without time zone,
     locked_by text DEFAULT ''::text,
-    transient_retry_count integer DEFAULT 0
+    transient_retry_count integer DEFAULT 0,
+    retry_count integer DEFAULT 0
 );
 
 CREATE SEQUENCE autonomous_workflows_id_seq

--- a/schema/schema-sqlite.sql
+++ b/schema/schema-sqlite.sql
@@ -249,7 +249,8 @@ CREATE TABLE autonomous_workflows (
  content_language text DEFAULT 'en' NOT NULL,
  locked_at TIMESTAMP,
  locked_by text DEFAULT '',
- transient_retry_count integer DEFAULT 0
+ transient_retry_count integer DEFAULT 0,
+ retry_count integer DEFAULT 0
 );
 
 CREATE TABLE compliance_reports (

--- a/tests/unit/test_alembic_sqlite_upgrade.py
+++ b/tests/unit/test_alembic_sqlite_upgrade.py
@@ -86,8 +86,8 @@ def test_alembic_upgrade_head_succeeds_for_fresh_sqlite(tmp_path, monkeypatch):
     assert version is not None
     # Migration chain: 001_run_timeline -> 002_content_language -> 003_status_index
     # -> 001_add_project_categories -> 004_fix_tenant_quotas_overflow -> 001_init_project_categories
-    # -> 001_add_workflow_lock_columns
-    assert version[0] == "20260629_001_add_workflow_lock_columns"
+    # -> 001_add_workflow_lock_columns -> 001_add_retry_count_column
+    assert version[0] == "20260630_001_add_retry_count_column"
     if has_session_messages:
         assert "source" in columns
     assert has_mapping_rules is True


### PR DESCRIPTION
## 问题

Issue #1376：管理模式下自主工作流 retry API 返回 500 Internal server error

## 根本原因

`autonomous_workflows` 表缺少 `retry_count` 列：
- SQLite CREATE TABLE 定义中有该列
- PostgreSQL Alembic 迁移文件遗漏

导致 PostgreSQL 执行 UPDATE 时报错。

## 修改内容

1. 新增迁移 `20260630_001_add_retry_count_column.py`：
   - 添加 `retry_count INTEGER DEFAULT 0` 列
   - 支持 PostgreSQL 和 SQLite
   - 包含 upgrade 和 downgrade

2. 更新 `migrations/baseline.py`：
   - HEAD_REVISION 更新为新版本

3. 更新测试 `test_alembic_sqlite_upgrade.py`：
   - 断言更新为新的 revision

## 测试

- ✅ `test_alembic_sqlite_upgrade.py` 3 passed
- ✅ lint 检查通过

## 部署说明

生产环境需执行：
```bash
alembic upgrade head
```

Closes #1376