### PR TITLE
fix(migration): 移除默认项目分类初始化，使用智能分类替代 (Issue #1382)

### DIFF
--- a/migrations/versions/20260627_001_init_project_categories_data.py
+++ b/migrations/versions/20260627_001_init_project_categories_data.py
@@ -20,8 +20,6 @@ Migration kept for alembic version chain continuity.
 import logging
 from typing import Sequence, Union
 
-from alembic import op
-
 logger = logging.getLogger(__name__)
 
 revision: str = "20260627_001_init_project_categories"

--- a/migrations/versions/20260627_001_init_project_categories_data.py
+++ b/migrations/versions/20260627_001_init_project_categories_data.py
@@ -1,23 +1,25 @@
-"""Initialize project_categories with default data
+"""Initialize project_categories table (no default data)
 
 Revision ID: 20260627_001_init_project_categories
 Revises: 20260626_004_fix_tenant_quotas_overflow
 Create Date: 2026-06-27
 
-Issue: #1327
-Initialize project_categories table with default categories.
-This ensures projects are properly categorized instead of all showing as "uncategorized".
+Issue: #1327 (original), #1382 (removal)
+Originally initialized project_categories with default categories.
+Now removed - Issue #1371's smart categorization handles project grouping.
 
-Default categories:
-- Frontend: projects with frontend/web/ui keywords
-- Backend: projects with backend/api/server keywords
-- Testing: projects with test/tests/spec keywords
+Why removed:
+- Default categories (Frontend/Backend/Testing) use functional keywords
+- These don't match actual project paths like /home/openace, /home/openace/iplan
+- Smart categorization (extractProjectName) extracts project names from paths
+- Example: /home/openace → "openace", /home/openace/iplan → "iplan"
+
+Migration kept for alembic version chain continuity.
 """
 
 import logging
 from typing import Sequence, Union
 
-import sqlalchemy as sa
 from alembic import op
 
 logger = logging.getLogger(__name__)
@@ -29,56 +31,10 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    """Insert default project categories."""
-    conn = op.get_bind()
-
-    # Check if data already exists to avoid duplicates
-    result = conn.execute(sa.text("SELECT COUNT(*) as count FROM project_categories"))
-    row = result.fetchone()
-    count = row[0] if row else 0
-
-    if count > 0:
-        logger.info(f"project_categories already has {count} records, skipping initialization")
-        return
-
-    # Insert default categories
-    if conn.dialect.name == "postgresql":
-        # PostgreSQL uses TRUE/FALSE for boolean
-        op.execute(
-            """
-            INSERT INTO project_categories (name, key_patterns, sort_order, is_active)
-            VALUES
-                ('Frontend', '["frontend", "web", "ui"]', 1, TRUE),
-                ('Backend', '["backend", "api", "server"]', 2, TRUE),
-                ('Testing', '["test", "tests", "spec"]', 3, TRUE)
-            """
-        )
-    else:
-        # SQLite uses 1/0 for boolean
-        op.execute(
-            """
-            INSERT INTO project_categories (name, key_patterns, sort_order, is_active)
-            VALUES
-                ('Frontend', '["frontend", "web", "ui"]', 1, 1),
-                ('Backend', '["backend", "api", "server"]', 2, 1),
-                ('Testing', '["test", "tests", "spec"]', 3, 1)
-            """
-        )
-
-    logger.info(
-        "Initialized project_categories with default categories: Frontend, Backend, Testing"
-    )
+    """No-op: default categories removed, smart categorization handles grouping."""
+    logger.info("Skipping default project categories initialization (Issue #1382)")
 
 
 def downgrade() -> None:
-    """Remove default project categories."""
-    # Delete the default categories we inserted
-    op.execute(
-        """
-        DELETE FROM project_categories
-        WHERE name IN ('Frontend', 'Backend', 'Testing')
-        AND key_patterns IN ('["frontend", "web", "ui"]', '["backend", "api", "server"]', '["test", "tests", "spec"]')
-        """
-    )
-
-    logger.info("Removed default project categories: Frontend, Backend, Testing")
+    """No-op: nothing to remove since upgrade does nothing."""
+    logger.info("No default project categories to remove (Issue #1382)")


### PR DESCRIPTION
## 问题描述

迁移 `20260627_001_init_project_categories_data.py` 会创建三个默认分类：
- Frontend (key_patterns: frontend, web, ui)
- Backend (key_patterns: backend, api, server)  
- Testing (key_patterns: test, tests, spec)

这些分类基于功能关键词，对实际项目路径不匹配，导致显示空分类或所有项目都在"未分类"下。

## 解决方案

移除迁移中的默认分类初始化，让 Issue #1371 的智能分类 (`extractProjectName()`) 完全接管项目分组。

智能分类示例：
- `/home/openace` → openace
- `/home/openace/iplan` → iplan
- `/opt/iplan` → iplan

## 修改内容

- 修改 `20260627_001_init_project_categories_data.py` 的 upgrade() 和 downgrade() 为空操作
- 保留迁移文件以维持 alembic 版本链完整性

## 测试

- 新安装不再有默认分类，项目自动按智能分类显示
- 已有数据库不受影响（迁移只影响新安装）

## 相关 Issue

Fixes #1382
Related: #1371, #1327

🤖 Generated with Qwen Code (1-shotted by Qwen-Coder)