### PR TITLE
fix: 项目管理页面总项目数统计应包含智能分类 (Issue #1384)

### DIFF
--- a/frontend/src/components/features/management/ProjectManagement.tsx
+++ b/frontend/src/components/features/management/ProjectManagement.tsx
@@ -253,7 +253,7 @@ export const ProjectManagement: React.FC = () => {
 
   // Summary statistics (aggregated from categories)
   const summary = useMemo(() => {
-    const totalCategories = categorizedStats.filter((c) => c.category_id !== -1).length;
+    const totalCategories = categorizedStats.length;
     const totalWorkspaces = categorizedStats.reduce((sum, c) => sum + c.total_workspaces, 0);
     const totalUsers = categorizedStats.reduce((sum, c) => sum + c.total_users, 0);
     const totalTokens = categorizedStats.reduce((sum, c) => sum + c.total_tokens, 0);


### PR DESCRIPTION
## 关联 Issue

Fixes #1384

## 问题描述

项目管理页面顶部统计卡片显示「总项目数 = 0」，但列表有数据。

## 根本原因

当所有用户定义分类未激活时，项目被归入智能分类（`category_id = -1`），原代码 `filter(category_id !== -1)` 排除智能分类导致统计为0。

## 修复方案

修改 `ProjectManagement.tsx` 第256行：
```diff
- const totalCategories = categorizedStats.filter((c) => c.category_id !== -1).length;
+ const totalCategories = categorizedStats.length;
```

统计所有分类（包括智能分类）的数量。

## 影响范围

仅影响顶部「总项目数」统计卡片显示，不影响其他统计逻辑。

## 测试验证

修复后预期显示：
- 总项目数 = 分类数量（包括智能分类）
- 总用户数 = 各分类用户数汇总（逻辑不变）