### PR TITLE
fix: E2E 测试环境跳过强制改密弹窗 (Issue #1372)

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -130,7 +130,7 @@ jobs:
       - name: Create admin user
         run: |
           cd ..
-          python3 scripts/init_db.py
+          OPENACE_E2E_TEST=true python3 scripts/init_db.py
 
       - name: Run E2E tests
         run: npm run test:e2e

--- a/scripts/init_db.py
+++ b/scripts/init_db.py
@@ -131,7 +131,11 @@ def create_default_admin(
         print(f"Admin user '{username}' already exists")
         return True
 
-    # Create admin user with must_change_password = True (force password change on first login)
+    # E2E test environment: skip forced password change to avoid modal blocking tests
+    is_e2e_test = os.environ.get("OPENACE_E2E_TEST", "").lower() in ("true", "1", "yes")
+    must_change_pwd = not is_e2e_test
+
+    # Create admin user with must_change_password based on environment
     result = db.create_user_with_is_active(
         username=username,
         password_hash=password_hash,
@@ -140,7 +144,7 @@ def create_default_admin(
         daily_token_quota=10,  # 10M tokens (stored in M units)
         daily_request_quota=10000,
         is_active=True,
-        must_change_password=True,  # Force password change on first login
+        must_change_password=must_change_pwd,
         system_account=system_account,
         tenant_id=tenant_id,
     )


### PR DESCRIPTION
## 问题

Issue #1372: PR #1386 合并后 E2E 测试失败，62 个测试被 `ForceChangePasswordModal` 阻挡。

### 根因分析

从 CI 日志发现：
```
<div class="alert alert-warning mb-3">…</div> from <div role="dialog" aria-modal="true" class="modal fade show d-block">…</div> subtree intercepts pointer events
```

1. `init_db.py` 创建 admin 用户时设置 `must_change_password=True`
2. E2E 测试登录后自动显示 `ForceChangePasswordModal`
3. 弹窗遮挡页面元素，导致测试无法点击按钮

### 修复

1. **scripts/init_db.py**: 添加 `OPENACE_E2E_TEST` 环境变量控制
   - 当 `OPENACE_E2E_TEST=true` 时，跳过强制改密设置
   - 生产环境保持安全默认行为（强制改密）

2. **.github/workflows/frontend-ci.yml**: 创建用户时设置环境变量
   ```yaml
   OPENACE_E2E_TEST=true python3 scripts/init_db.py
   ```

### 测试

- 本地 ruff 检查通过
- E2E 测试环境将跳过强制改密弹窗

### 相关 Issue

- #1372 端口统一为 19888
- #1386 端口修改 PR（已合并）