### PR TITLE
fix: 修正测试框架端口遗漏 (Issue #1372)

### DIFF
--- a/app/modules/workspace/remote_agent_manager.py
+++ b/app/modules/workspace/remote_agent_manager.py
@@ -1184,7 +1184,8 @@ class RemoteAgentManager:
 
         # Preserve the legacy no-context fallback. Runtime request paths pass
         # request.host_url so forwarded deployments use the browser-visible URL.
-        return "http://localhost:5001"
+        # Issue #1372: 统一端口为 19888
+        return "http://localhost:19888"
 
     def _get_backend_url(self) -> str:
         """Backward-compatible alias for internal callers without request context."""

--- a/docs/cn/DEPLOYMENT.md
+++ b/docs/cn/DEPLOYMENT.md
@@ -328,17 +328,17 @@ docker compose up -d
 
 ```bash
 docker ps
-# 应显示 0.0.0.0:5001->19888/tcp
+# 应显示 0.0.0.0:19888->19888/tcp
 ```
 
 #### 防火墙设置（如需外网访问）
 
 ```bash
 # Ubuntu/Debian
-sudo ufw allow 5001/tcp
+sudo ufw allow 19888/tcp
 
 # CentOS/RHEL
-sudo firewall-cmd --add-port=5001/tcp --permanent
+sudo firewall-cmd --add-port=19888/tcp --permanent
 sudo firewall-cmd --reload
 ```
 

--- a/docs/en/DEPLOYMENT.md
+++ b/docs/en/DEPLOYMENT.md
@@ -328,17 +328,17 @@ docker compose up -d
 
 ```bash
 docker ps
-# Should show 0.0.0.0:5001->19888/tcp
+# Should show 0.0.0.0:19888->19888/tcp
 ```
 
 #### Firewall Settings (for external access)
 
 ```bash
 # Ubuntu/Debian
-sudo ufw allow 5001/tcp
+sudo ufw allow 19888/tcp
 
 # CentOS/RHEL
-sudo firewall-cmd --add-port=5001/tcp --permanent
+sudo firewall-cmd --add-port=19888/tcp --permanent
 sudo firewall-cmd --reload
 ```
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -154,7 +154,7 @@ pytest tests/regression/test_login.py
 
 | 变量 | 说明 | 默认值 |
 |------|------|--------|
-| `BASE_URL` | 应用服务器地址 | `http://localhost:5001` |
+| `BASE_URL` | 应用服务器地址 | `http://localhost:19888` |
 | `TEST_USERNAME` | 测试用户名 | `admin` |
 | `TEST_PASSWORD` | 测试密码 | `admin123` |
 | `HEADLESS` | 无头模式 | `true` |

--- a/tests/api_test_audit_filter.py
+++ b/tests/api_test_audit_filter.py
@@ -5,7 +5,7 @@ import sys
 
 import requests
 
-BASE_URL = "http://localhost:5001"
+BASE_URL = "http://localhost:19888"
 
 
 def main():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -154,7 +154,8 @@ def sample_message_data():
 # =============================================================================
 
 # Test configuration for UI tests
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+# Issue #1372: 统一端口为 19888
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 TEST_USERNAME = os.environ.get("TEST_USERNAME", "admin")
 TEST_PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/e2e/e2e_anomaly_all_button_playwright.py
+++ b/tests/e2e/e2e_anomaly_all_button_playwright.py
@@ -31,7 +31,7 @@ sys.path.insert(0, PROJECT_ROOT)
 
 from playwright.sync_api import sync_playwright
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "tests", "screenshots", "e2e-anomaly-all")
 

--- a/tests/e2e/e2e_anomaly_description_playwright.py
+++ b/tests/e2e/e2e_anomaly_description_playwright.py
@@ -33,7 +33,7 @@ sys.path.insert(0, PROJECT_ROOT)
 
 from playwright.sync_api import sync_playwright
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "tests", "screenshots", "e2e-anomaly-description")
 

--- a/tests/e2e/e2e_audit_log_default_dates_playwright.py
+++ b/tests/e2e/e2e_audit_log_default_dates_playwright.py
@@ -29,7 +29,7 @@ sys.path.insert(0, PROJECT_ROOT)
 
 from playwright.sync_api import sync_playwright
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "tests", "screenshots", "e2e-audit-default-dates")
 

--- a/tests/e2e/e2e_compliance_report_playwright.py
+++ b/tests/e2e/e2e_compliance_report_playwright.py
@@ -25,7 +25,7 @@ sys.path.insert(0, PROJECT_ROOT)
 
 from playwright.sync_api import expect, sync_playwright
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "tests", "screenshots", "e2e-compliance-report")
 

--- a/tests/e2e/e2e_dashboard_date_range_playwright.py
+++ b/tests/e2e/e2e_dashboard_date_range_playwright.py
@@ -30,7 +30,7 @@ sys.path.insert(0, PROJECT_ROOT)
 
 from playwright.sync_api import expect, sync_playwright
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "tests", "screenshots", "e2e-dashboard-date-range")
 

--- a/tests/e2e/e2e_data_retention_cleanup_playwright.py
+++ b/tests/e2e/e2e_data_retention_cleanup_playwright.py
@@ -29,7 +29,7 @@ import subprocess
 
 from playwright.sync_api import sync_playwright
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "tests", "screenshots", "e2e-retention-cleanup")
 

--- a/tests/e2e/e2e_data_retention_playwright.py
+++ b/tests/e2e/e2e_data_retention_playwright.py
@@ -26,7 +26,7 @@ sys.path.insert(0, PROJECT_ROOT)
 
 from playwright.sync_api import expect, sync_playwright
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "tests", "screenshots", "e2e-data-retention")
 

--- a/tests/e2e/e2e_global_confirm_toast_playwright.py
+++ b/tests/e2e/e2e_global_confirm_toast_playwright.py
@@ -20,7 +20,7 @@ Run:
   HEADLESS=true  python tests/e2e/e2e_global_confirm_toast_playwright.py   # auto
   HEADLESS=false python tests/e2e/e2e_global_confirm_toast_playwright.py   # demo
 
-  # Point at a Vite dev server (this PR's frontend tree) proxying the API to :5001:
+  # Point at a Vite dev server (this PR's frontend tree) proxying the API to :19888:
   BASE_URL=http://localhost:5173 HEADLESS=true python tests/e2e/e2e_global_confirm_toast_playwright.py
 """
 

--- a/tests/e2e/e2e_global_confirm_toast_playwright.py
+++ b/tests/e2e/e2e_global_confirm_toast_playwright.py
@@ -36,7 +36,7 @@ import json  # noqa: E402
 
 from playwright.sync_api import sync_playwright  # noqa: E402
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "tests", "screenshots", "e2e-global-confirm-toast")
 

--- a/tests/e2e/e2e_page_refresh_playwright.py
+++ b/tests/e2e/e2e_page_refresh_playwright.py
@@ -33,7 +33,7 @@ sys.path.insert(0, PROJECT_ROOT)
 
 from playwright.sync_api import expect, sync_playwright
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "tests", "screenshots", "e2e-page-refresh")
 

--- a/tests/e2e/e2e_quota_management_playwright.py
+++ b/tests/e2e/e2e_quota_management_playwright.py
@@ -29,7 +29,7 @@ sys.path.insert(0, PROJECT_ROOT)
 
 from playwright.sync_api import expect, sync_playwright
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "tests", "screenshots", "e2e-quota-management")
 

--- a/tests/e2e/e2e_roi_daily_costs_axis_playwright.py
+++ b/tests/e2e/e2e_roi_daily_costs_axis_playwright.py
@@ -38,7 +38,7 @@ sys.path.insert(0, PROJECT_ROOT)
 
 from playwright.sync_api import sync_playwright  # noqa: E402
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "tests", "screenshots", "e2e-roi-daily-costs-axis")
 

--- a/tests/e2e/e2e_roi_i18n_playwright.py
+++ b/tests/e2e/e2e_roi_i18n_playwright.py
@@ -11,7 +11,7 @@ tokenAccumulationWarning / roiNegativeHint / avgTokensPerRequest）。
 tests/e2e/manage/test_manage_full_audit.py。
 
 按项目 E2E 规范：默认 headless 先跑通；HEADLESS=false 可演示。
-依赖：BASE_URL (默认 http://localhost:5001)、TEST_USERNAME/TEST_PASSWORD (默认 admin/admin123)。
+依赖：BASE_URL (默认 http://localhost:19888)、TEST_USERNAME/TEST_PASSWORD (默认 admin/admin123)。
 """
 
 import os
@@ -21,7 +21,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from playwright.sync_api import sync_playwright
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() != "false"

--- a/tests/e2e/e2e_token_trend_all_button_playwright.py
+++ b/tests/e2e/e2e_token_trend_all_button_playwright.py
@@ -27,7 +27,7 @@ sys.path.insert(0, PROJECT_ROOT)
 
 from playwright.sync_api import expect, sync_playwright
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "tests", "screenshots", "e2e-token-trend-all")
 

--- a/tests/e2e/e2e_user_segmentation_pie_chart_playwright.py
+++ b/tests/e2e/e2e_user_segmentation_pie_chart_playwright.py
@@ -26,7 +26,7 @@ sys.path.insert(0, PROJECT_ROOT)
 
 from playwright.sync_api import expect, sync_playwright
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "tests", "screenshots", "e2e-user-segmentation")
 

--- a/tests/e2e/manage/e2e_api_key_cli_settings.py
+++ b/tests/e2e/manage/e2e_api_key_cli_settings.py
@@ -28,7 +28,7 @@ import requests
 from playwright.sync_api import expect, sync_playwright
 
 # ── 配置 ──────────────────────────────────────────────
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "screenshots", "e2e-api-key-cli-settings")
 

--- a/tests/e2e/manage/e2e_audit_thresholds_playwright.py
+++ b/tests/e2e/manage/e2e_audit_thresholds_playwright.py
@@ -27,7 +27,7 @@ sys.path.insert(0, PROJECT_ROOT)
 import requests
 from playwright.sync_api import sync_playwright
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "screenshots", "e2e-audit-thresholds")
 

--- a/tests/e2e/manage/e2e_token_install_command.py
+++ b/tests/e2e/manage/e2e_token_install_command.py
@@ -26,7 +26,7 @@ sys.path.insert(0, PROJECT_ROOT)
 from playwright.sync_api import sync_playwright
 
 # ── 配置 ──────────────────────────────────────────────
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 TEST_USER = "admin"
 TEST_PASS = "admin123"

--- a/tests/e2e/manage/test_audit_log_filter.py
+++ b/tests/e2e/manage/test_audit_log_filter.py
@@ -28,7 +28,7 @@ sys.path.insert(0, PROJECT_ROOT)
 import requests
 from playwright.sync_api import sync_playwright
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")

--- a/tests/e2e/manage/test_manage_api_audit.py
+++ b/tests/e2e/manage/test_manage_api_audit.py
@@ -10,7 +10,7 @@ import requests
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 s = requests.Session()
 
 issues = []

--- a/tests/e2e/manage/test_manage_comprehensive.py
+++ b/tests/e2e/manage/test_manage_comprehensive.py
@@ -18,7 +18,7 @@ import requests
 from playwright.sync_api import sync_playwright
 
 # 配置
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/e2e/manage/test_manage_full_audit.py
+++ b/tests/e2e/manage/test_manage_full_audit.py
@@ -13,7 +13,7 @@ import contextlib
 
 from playwright.sync_api import sync_playwright
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 SCREENSHOT_DIR = os.path.join(

--- a/tests/e2e/manage/test_session_id_column.py
+++ b/tests/e2e/manage/test_session_id_column.py
@@ -28,7 +28,7 @@ sys.path.insert(0, PROJECT_ROOT)
 import requests
 from playwright.sync_api import sync_playwright
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")

--- a/tests/e2e/remote/e2e_directory_browser.py
+++ b/tests/e2e/remote/e2e_directory_browser.py
@@ -34,7 +34,7 @@ sys.path.insert(0, PROJECT_ROOT)
 from playwright.sync_api import sync_playwright
 
 # ── Config ──────────────────────────────────────────────
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 REMOTE_HOST = os.environ.get("REMOTE_HOST", "192.168.64.3")
 REMOTE_USER = os.environ.get("REMOTE_USER", "root")

--- a/tests/e2e/remote/e2e_permission_panel_style.py
+++ b/tests/e2e/remote/e2e_permission_panel_style.py
@@ -28,7 +28,7 @@ import requests
 from playwright.sync_api import sync_playwright
 
 # ── Config ──
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 PROXIES = {"http": None, "https": None}
 WEBUI_URL = os.environ.get("WEBUI_URL", "http://127.0.0.1:3101")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/e2e/remote/e2e_remote_chat_quality.py
+++ b/tests/e2e/remote/e2e_remote_chat_quality.py
@@ -29,7 +29,7 @@ import requests
 from playwright.sync_api import sync_playwright
 
 # ── Config ──
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 WEBUI_URL = os.environ.get("WEBUI_URL", "http://127.0.0.1:3101")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "screenshots", "e2e-remote-chat-quality")

--- a/tests/e2e/remote/e2e_remote_default_permission.py
+++ b/tests/e2e/remote/e2e_remote_default_permission.py
@@ -36,7 +36,7 @@ import requests
 from playwright.sync_api import sync_playwright
 
 # ── Config ──
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 
 # Bypass system proxy for all requests (macOS proxy can interfere)
 PROXIES = {"http": None, "https": None}

--- a/tests/e2e/remote/e2e_remote_message.py
+++ b/tests/e2e/remote/e2e_remote_message.py
@@ -38,7 +38,7 @@ import requests
 from playwright.sync_api import sync_playwright
 
 # ── Config ──
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "screenshots", "e2e-remote-message")
 

--- a/tests/e2e/remote/e2e_remote_model_hot_switch.py
+++ b/tests/e2e/remote/e2e_remote_model_hot_switch.py
@@ -28,7 +28,7 @@ import contextlib
 import requests
 
 # ── Config ──
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 TEST_USER = os.environ.get("TEST_REAL_USER", "test_user")
 TEST_PASS = "admin123"
 RESPONSE_TIMEOUT = 120

--- a/tests/e2e/remote/e2e_remote_model_switch_chat.py
+++ b/tests/e2e/remote/e2e_remote_model_switch_chat.py
@@ -28,7 +28,7 @@ import requests
 from playwright.sync_api import sync_playwright
 
 # ── Config ──
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 WEBUI_URL = os.environ.get("WEBUI_URL", "http://127.0.0.1:3101")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "screenshots", "e2e-remote-model-switch")

--- a/tests/e2e/remote/e2e_remote_permission.py
+++ b/tests/e2e/remote/e2e_remote_permission.py
@@ -31,7 +31,7 @@ import contextlib
 import requests
 from playwright.sync_api import sync_playwright
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 WEBUI_URL = os.environ.get("WEBUI_URL", "http://localhost:3000")
 TEST_USER = os.environ.get("TEST_REAL_USER", "test_user")

--- a/tests/e2e/remote/e2e_remote_reconnect.py
+++ b/tests/e2e/remote/e2e_remote_reconnect.py
@@ -31,7 +31,7 @@ sys.path.insert(0, PROJECT_ROOT)
 import requests
 
 # ── Config ──
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "screenshots", "e2e-reconnect")
 TEST_USER = os.environ.get("TEST_REAL_USER", "test_user")

--- a/tests/e2e/remote/e2e_remote_reconnect.py
+++ b/tests/e2e/remote/e2e_remote_reconnect.py
@@ -202,7 +202,7 @@ def test_2_stale_session_after_restart():
 
     # Restart open-ace server
     log("重启", "Restarting open-ace server...")
-    pid = subprocess.run(["lsof", "-ti:5001"], capture_output=True, text=True).stdout.strip()
+    pid = subprocess.run(["lsof :19888"], capture_output=True, text=True).stdout.strip()
     if pid:
         subprocess.run(["kill", "-9", pid], capture_output=True)
     time.sleep(2)

--- a/tests/e2e/remote/e2e_remote_reconnect_ui.py
+++ b/tests/e2e/remote/e2e_remote_reconnect_ui.py
@@ -27,7 +27,7 @@ import requests
 from playwright.sync_api import sync_playwright
 
 # ── Config ──
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 WEBUI_URL = os.environ.get("WEBUI_URL", "http://127.0.0.1:3101")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "screenshots", "e2e-reconnect-ui")

--- a/tests/e2e/remote/e2e_remote_reconnect_ui.py
+++ b/tests/e2e/remote/e2e_remote_reconnect_ui.py
@@ -301,7 +301,7 @@ def _run_all(page, token, webui_url, webui_token, console_errors):
 
     # Restart server
     log("Restart", "Restarting open-ace server...")
-    pid = subprocess.run(["lsof", "-ti:5001"], capture_output=True, text=True).stdout.strip()
+    pid = subprocess.run(["lsof :19888"], capture_output=True, text=True).stdout.strip()
     if pid:
         subprocess.run(["kill", "-9"] + pid.split(), capture_output=True)
     time.sleep(2)

--- a/tests/e2e/remote/e2e_remote_session_restore.py
+++ b/tests/e2e/remote/e2e_remote_session_restore.py
@@ -31,7 +31,7 @@ import requests
 from playwright.sync_api import sync_playwright
 
 # ── Config ──────────────────────────────────────────────
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 WEBUI_URL = os.environ.get("WEBUI_URL", "http://localhost:3000")
 TEST_USER = os.environ.get("TEST_REAL_USER", "test_user")

--- a/tests/e2e/remote/e2e_remote_session_ui.py
+++ b/tests/e2e/remote/e2e_remote_session_ui.py
@@ -44,7 +44,7 @@ import requests
 from playwright.sync_api import sync_playwright
 
 # ── Config ──
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "screenshots", "e2e-remote-session-ui")
 

--- a/tests/e2e/remote/e2e_remote_ui_improvements.py
+++ b/tests/e2e/remote/e2e_remote_ui_improvements.py
@@ -28,7 +28,7 @@ import requests
 from playwright.sync_api import sync_playwright
 
 # ── Config ──
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 WEBUI_URL = os.environ.get("WEBUI_URL", "http://localhost:3000")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "screenshots", "e2e-remote-ui-improvements")

--- a/tests/e2e/remote/e2e_remote_workspace_full.py
+++ b/tests/e2e/remote/e2e_remote_workspace_full.py
@@ -62,7 +62,7 @@ import requests
 from playwright.sync_api import sync_playwright
 
 # ── 配置 ───────────────────────────────────────────────
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "screenshots", "e2e-remote-full")
 

--- a/tests/e2e/remote/e2e_remote_workspace_playwright.py
+++ b/tests/e2e/remote/e2e_remote_workspace_playwright.py
@@ -27,7 +27,7 @@ import requests
 from playwright.sync_api import sync_playwright
 
 # ── 配置 ──────────────────────────────────────────────
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 WEBUI_URL = os.environ.get("WEBUI_URL", "http://localhost:3000")
 TEST_USER = os.environ.get("TEST_REAL_USER", "test_user")

--- a/tests/e2e/remote/e2e_remote_workspace_ui.py
+++ b/tests/e2e/remote/e2e_remote_workspace_ui.py
@@ -63,7 +63,7 @@ import requests
 from playwright.sync_api import sync_playwright
 
 # ── Config ──
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 RECORD_VIDEO = os.environ.get("RECORD_VIDEO", "false").lower() == "true"
 VIDEO_DIR = os.path.join(PROJECT_ROOT, "videos", "e2e-remote-ui")

--- a/tests/e2e/remote/e2e_remote_workspace_ui.py
+++ b/tests/e2e/remote/e2e_remote_workspace_ui.py
@@ -68,7 +68,7 @@ HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 RECORD_VIDEO = os.environ.get("RECORD_VIDEO", "false").lower() == "true"
 VIDEO_DIR = os.path.join(PROJECT_ROOT, "videos", "e2e-remote-ui")
 VM_HOST = os.environ.get("VM_HOST", "root@192.168.64.4")
-SERVER_URL_FOR_VM = os.environ.get("SERVER_URL_FOR_VM", "http://192.168.64.1:5001")
+SERVER_URL_FOR_VM = os.environ.get("SERVER_URL_FOR_VM", "http://192.168.64.1:19888")")
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "screenshots", "e2e-remote-ui")
 
 ADMIN_USER = "admin"

--- a/tests/e2e/remote/e2e_remote_workspace_ui.py
+++ b/tests/e2e/remote/e2e_remote_workspace_ui.py
@@ -68,7 +68,7 @@ HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 RECORD_VIDEO = os.environ.get("RECORD_VIDEO", "false").lower() == "true"
 VIDEO_DIR = os.path.join(PROJECT_ROOT, "videos", "e2e-remote-ui")
 VM_HOST = os.environ.get("VM_HOST", "root@192.168.64.4")
-SERVER_URL_FOR_VM = os.environ.get("SERVER_URL_FOR_VM", "http://192.168.64.1:19888")")
+SERVER_URL_FOR_VM = os.environ.get("SERVER_URL_FOR_VM", "http://192.168.64.1:19888")
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "screenshots", "e2e-remote-ui")
 
 ADMIN_USER = "admin"

--- a/tests/e2e/remote/e2e_run_timeline_playwright.py
+++ b/tests/e2e/remote/e2e_run_timeline_playwright.py
@@ -12,7 +12,7 @@ gevent pywsgi 服务会 502（见项目记忆 urllib→gevent 502）。fetch 复
 cookie，登录后自动携带。
 
 前置条件（与其它 remote E2E 一致）：
-  - 运行中的服务 BASE_URL（默认 http://localhost:5001），且 config 中
+  - 运行中的服务 BASE_URL（默认 http://localhost:19888），且 config 中
     ``run_timeline.enabled=true``（特性默认关闭，需显式开启）
   - 存在管理员账号（默认 admin / admin123）
   - 已安装 playwright chromium
@@ -28,7 +28,7 @@ import uuid
 
 from playwright.sync_api import sync_playwright
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 ADMIN_USER = os.environ.get("TEST_REAL_USER", "admin")
 ADMIN_PASS = os.environ.get("TEST_REAL_PASS", "admin123")

--- a/tests/e2e/remote/e2e_test_remote_workspace.py
+++ b/tests/e2e/remote/e2e_test_remote_workspace.py
@@ -20,7 +20,7 @@ sys.path.insert(0, PROJECT_ROOT)
 
 import requests
 
-BASE_URL = "http://localhost:5001"
+BASE_URL = "http://localhost:19888"
 
 # Track test results
 RESULTS = []

--- a/tests/e2e/terminal/e2e_quota_recovery.py
+++ b/tests/e2e/terminal/e2e_quota_recovery.py
@@ -11,7 +11,7 @@ from playwright.sync_api import sync_playwright
 
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 

--- a/tests/e2e/terminal/e2e_terminal_quota.py
+++ b/tests/e2e/terminal/e2e_terminal_quota.py
@@ -11,7 +11,7 @@ from playwright.sync_api import sync_playwright
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 
 
 def test_terminal_session():

--- a/tests/e2e/terminal/e2e_terminal_restore.py
+++ b/tests/e2e/terminal/e2e_terminal_restore.py
@@ -16,7 +16,7 @@ import time
 import requests
 from playwright.sync_api import sync_playwright
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 MACHINE_ID = os.environ.get("MACHINE_ID", "6f85734e-9b21-4320-a857-a67bc36b9078")

--- a/tests/e2e/terminal/e2e_terminal_restore_flow.py
+++ b/tests/e2e/terminal/e2e_terminal_restore_flow.py
@@ -18,7 +18,7 @@ import time
 import requests
 from playwright.sync_api import sync_playwright
 
-BASE_URL = "http://localhost:5001"
+BASE_URL = "http://localhost:19888"
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 MACHINE_ID = os.environ.get("MACHINE_ID", "6f85734e-9b21-4320-a857-a67bc36b9078")

--- a/tests/e2e/terminal/e2e_terminal_restore_full.py
+++ b/tests/e2e/terminal/e2e_terminal_restore_full.py
@@ -22,7 +22,7 @@ import time
 import requests
 from playwright.sync_api import expect, sync_playwright
 
-BASE_URL = "http://localhost:5001"
+BASE_URL = "http://localhost:19888"
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 MACHINE_ID = os.environ.get("MACHINE_ID", "6f85734e-9b21-4320-a857-a67bc36b9078")

--- a/tests/e2e/terminal/e2e_terminal_screen_restore.py
+++ b/tests/e2e/terminal/e2e_terminal_screen_restore.py
@@ -20,7 +20,7 @@ import time
 import requests
 from playwright.sync_api import sync_playwright
 
-BASE_URL = "http://localhost:5001"
+BASE_URL = "http://localhost:19888"
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 MACHINE_ID = os.environ.get("MACHINE_ID", "6f85734e-9b21-4320-a857-a67bc36b9078")

--- a/tests/e2e/work/e2e_context_command.py
+++ b/tests/e2e/work/e2e_context_command.py
@@ -30,7 +30,7 @@ APP_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__fil
 from playwright.sync_api import sync_playwright
 
 # ── 配置 ──────────────────────────────────────────────
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 WEBUI_URL = os.environ.get("WEBUI_URL", "http://localhost:3000")
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "screenshots", "e2e-context")

--- a/tests/e2e/work/e2e_vscode_websocket.py
+++ b/tests/e2e/work/e2e_vscode_websocket.py
@@ -17,7 +17,7 @@ import time
 import requests
 from playwright.sync_api import sync_playwright
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 

--- a/tests/issues/1006/e2e_conversation_history_default_dates.py
+++ b/tests/issues/1006/e2e_conversation_history_default_dates.py
@@ -20,7 +20,7 @@ Run:
   BASE_URL=http://localhost:5173 HEADLESS=true  python tests/issues/1006/e2e_conversation_history_default_dates.py
   BASE_URL=http://localhost:5173 HEADLESS=false python tests/issues/1006/e2e_conversation_history_default_dates.py
   # Or against a deployed instance:
-  BASE_URL=http://localhost:5001 HEADLESS=true python tests/issues/1006/e2e_conversation_history_default_dates.py
+  BASE_URL=http://localhost:19888 HEADLESS=true python tests/issues/1006/e2e_conversation_history_default_dates.py
 """
 
 import os
@@ -37,7 +37,7 @@ import tempfile
 import requests  # noqa: F401  (kept for parity with sibling E2E scripts)
 from playwright.sync_api import sync_playwright
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001").rstrip("/")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888").rstrip("/")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")

--- a/tests/issues/144/e2e_file_changes_comprehensive.py
+++ b/tests/issues/144/e2e_file_changes_comprehensive.py
@@ -25,7 +25,7 @@ import requests
 from playwright.sync_api import sync_playwright
 
 # ── 配置 ──────────────────────────────────────────────
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 WEBUI_URL = os.environ.get("WEBUI_URL", "http://localhost:3000")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 TEST_USER = os.environ.get("TEST_REAL_USER", "test_user")

--- a/tests/issues/144/e2e_file_changes_panel.py
+++ b/tests/issues/144/e2e_file_changes_panel.py
@@ -28,7 +28,7 @@ import requests
 from playwright.sync_api import sync_playwright
 
 # ── 配置 ──────────────────────────────────────────────
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 WEBUI_URL = os.environ.get("WEBUI_URL", "http://localhost:3000")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 TEST_USER = os.environ.get("TEST_REAL_USER", "test_user")

--- a/tests/issues/15/test_issue15.py
+++ b/tests/issues/15/test_issue15.py
@@ -6,7 +6,7 @@ import os
 
 from playwright.async_api import async_playwright
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 
 
 async def main():

--- a/tests/issues/15/test_issue15_rowclick.py
+++ b/tests/issues/15/test_issue15_rowclick.py
@@ -6,7 +6,7 @@ import os
 
 from playwright.async_api import async_playwright
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 
 
 async def main():

--- a/tests/issues/16/test_session_restore.py
+++ b/tests/issues/16/test_session_restore.py
@@ -15,7 +15,7 @@ import sys
 from playwright.sync_api import expect, sync_playwright
 
 # 配置
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/issues/164/test_crash_recovery.py
+++ b/tests/issues/164/test_crash_recovery.py
@@ -29,7 +29,7 @@ import requests
 from playwright.sync_api import sync_playwright
 
 # ── 配置 ──
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "screenshots", "e2e-164-crash")
 SESSIONS_META_PATH = os.path.expanduser("~/.open-ace-agent/sessions.json")

--- a/tests/issues/164/test_pause_resume.py
+++ b/tests/issues/164/test_pause_resume.py
@@ -28,7 +28,7 @@ import requests
 from playwright.sync_api import sync_playwright
 
 # ── 配置 ──
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 WEBUI_URL = os.environ.get("WEBUI_URL", "http://localhost:3000")
 TEST_USER = os.environ.get("TEST_REAL_USER", "test_user")

--- a/tests/issues/165/test_remote_session_ux.py
+++ b/tests/issues/165/test_remote_session_ux.py
@@ -37,7 +37,7 @@ import requests
 from playwright.sync_api import sync_playwright
 
 # ── 配置 ──
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 WEBUI_URL = os.environ.get("WEBUI_URL", "http://localhost:3000")
 TEST_USER = os.environ.get("TEST_REAL_USER", "test_user")

--- a/tests/issues/172/e2e_quota_enforcement.py
+++ b/tests/issues/172/e2e_quota_enforcement.py
@@ -25,7 +25,7 @@ sys.path.insert(0, PROJECT_ROOT)
 import requests
 
 # ── 配置 ──────────────────────────────────────────────
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 ADMIN_USER = os.environ.get("TEST_USERNAME", "admin")
 ADMIN_PASS = os.environ.get("TEST_PASSWORD", "admin123")
 TEST_USER = os.environ.get("TEST_USERNAME", "admin")

--- a/tests/issues/191/e2e_conversation_history.py
+++ b/tests/issues/191/e2e_conversation_history.py
@@ -16,7 +16,7 @@ sys.path.insert(0, PROJECT_ROOT)
 import requests
 from playwright.sync_api import sync_playwright
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")

--- a/tests/issues/198/e2e_audit_analysis_playwright.py
+++ b/tests/issues/198/e2e_audit_analysis_playwright.py
@@ -25,7 +25,7 @@ sys.path.insert(0, PROJECT_ROOT)
 import requests
 from playwright.sync_api import sync_playwright
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "screenshots", "e2e-audit-analysis")
 

--- a/tests/issues/20/test_issue20.py
+++ b/tests/issues/20/test_issue20.py
@@ -15,7 +15,7 @@ import pytest
 from playwright.async_api import async_playwright
 
 # Test configuration
-BASE_URL = "http://localhost:5001"
+BASE_URL = "http://localhost:19888"
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 TIMEOUT = 15000  # 15 seconds timeout

--- a/tests/issues/210/e2e_project_stats_accuracy.py
+++ b/tests/issues/210/e2e_project_stats_accuracy.py
@@ -26,7 +26,7 @@ sys.path.insert(0, PROJECT_ROOT)
 import requests
 
 # Config
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")

--- a/tests/issues/211/e2e_project_sort.py
+++ b/tests/issues/211/e2e_project_sort.py
@@ -23,7 +23,7 @@ import requests
 from playwright.sync_api import sync_playwright
 
 # Config
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")

--- a/tests/issues/221/test_tenant_form_validation.py
+++ b/tests/issues/221/test_tenant_form_validation.py
@@ -25,7 +25,7 @@ import sys
 from playwright.async_api import async_playwright
 
 # Configuration
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 SESSION_TOKEN = os.environ.get("SESSION_TOKEN", "")
 SCREENSHOT_DIR = os.environ.get("SCREENSHOT_DIR", "./screenshots/issues/221")
 

--- a/tests/issues/25/test_issue25.py
+++ b/tests/issues/25/test_issue25.py
@@ -9,7 +9,7 @@ import pytest
 from playwright.async_api import async_playwright
 
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))

--- a/tests/issues/29/test_issue29.py
+++ b/tests/issues/29/test_issue29.py
@@ -11,7 +11,7 @@ import pytest
 from playwright.async_api import async_playwright
 
 # 配置
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001/")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888/")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 SCREENSHOT_DIR = "screenshots"

--- a/tests/issues/30/test_issue30.py
+++ b/tests/issues/30/test_issue30.py
@@ -10,7 +10,7 @@ from playwright.async_api import async_playwright
 
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))

--- a/tests/issues/32/test_issue32.py
+++ b/tests/issues/32/test_issue32.py
@@ -11,7 +11,7 @@ import pytest
 from playwright.async_api import async_playwright
 
 # 配置
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001/")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888/")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 SCREENSHOT_DIR = "screenshots"

--- a/tests/issues/34/test_issue34.py
+++ b/tests/issues/34/test_issue34.py
@@ -21,7 +21,7 @@ from datetime import datetime
 import pytest
 from playwright.async_api import async_playwright
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001/")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888/")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 SCREENSHOT_DIR = "screenshots"

--- a/tests/issues/341/test_issue_341_unified_logs.py
+++ b/tests/issues/341/test_issue_341_unified_logs.py
@@ -16,7 +16,7 @@ import time
 
 from playwright.async_api import async_playwright
 
-BASE_URL = os.environ.get("OPENACE_URL", "http://127.0.0.1:5001")
+BASE_URL = os.environ.get("OPENACE_URL", "http://127.0.0.1:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 SCREENSHOT_DIR = os.path.join(os.path.dirname(__file__), "..", "..", "screenshots", "issues", "341")

--- a/tests/issues/35/test_issue35.py
+++ b/tests/issues/35/test_issue35.py
@@ -29,7 +29,7 @@ PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(SCRIPT_DIR)))
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "screenshots", "issues", "35")
 os.makedirs(SCREENSHOT_DIR, exist_ok=True)
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 

--- a/tests/issues/352/test_tool_limit_hints.py
+++ b/tests/issues/352/test_tool_limit_hints.py
@@ -15,7 +15,7 @@ from io import BytesIO
 from pathlib import Path
 from unittest.mock import MagicMock, Mock, PropertyMock, patch
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 
 # Add remote-agent directory to path
 remote_agent_dir = Path(__file__).parent.parent.parent.parent / "remote-agent"

--- a/tests/issues/36/check_custom_dropdown.py
+++ b/tests/issues/36/check_custom_dropdown.py
@@ -7,7 +7,7 @@ import time
 
 from playwright.sync_api import sync_playwright
 
-BASE_URL = "http://localhost:5001"
+BASE_URL = "http://localhost:19888"
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 

--- a/tests/issues/36/check_sender.py
+++ b/tests/issues/36/check_sender.py
@@ -7,7 +7,7 @@ import time
 
 from playwright.sync_api import sync_playwright
 
-BASE_URL = "http://localhost:5001"
+BASE_URL = "http://localhost:19888"
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 

--- a/tests/issues/36/test_issue36_simplified_display.py
+++ b/tests/issues/36/test_issue36_simplified_display.py
@@ -17,7 +17,7 @@ import pytest
 from playwright.async_api import async_playwright
 
 # Test configuration
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 TIMEOUT = 10000  # 10 seconds timeout

--- a/tests/issues/38/test_issue38.py
+++ b/tests/issues/38/test_issue38.py
@@ -17,7 +17,7 @@ import pytest
 from playwright.async_api import async_playwright
 
 # 配置
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001/")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888/")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 SCREENSHOT_DIR = "screenshots"

--- a/tests/issues/394/demo_real_chat.py
+++ b/tests/issues/394/demo_real_chat.py
@@ -22,7 +22,7 @@ sys.path.insert(0, PROJECT_ROOT)
 import requests
 from playwright.sync_api import sync_playwright
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "screenshots", "demo-real-chat")
 
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/issues/394/demo_terminal.py
+++ b/tests/issues/394/demo_terminal.py
@@ -24,7 +24,7 @@ sys.path.insert(0, PROJECT_ROOT)
 import requests
 from playwright.sync_api import sync_playwright
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 
 TEST_USER = "admin"

--- a/tests/issues/394/demo_web_terminal.py
+++ b/tests/issues/394/demo_web_terminal.py
@@ -21,7 +21,7 @@ from playwright.sync_api import sync_playwright
 
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 
 TEST_USER = "admin"
 TEST_PASS = "admin123"

--- a/tests/issues/394/e2e_real_chat.py
+++ b/tests/issues/394/e2e_real_chat.py
@@ -24,7 +24,7 @@ import requests
 from playwright.sync_api import sync_playwright
 
 # ── Config ──
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "screenshots", "e2e-real-chat")
 

--- a/tests/issues/394/e2e_terminal_tab.py
+++ b/tests/issues/394/e2e_terminal_tab.py
@@ -36,7 +36,7 @@ import requests
 from playwright.sync_api import expect, sync_playwright
 
 # ── Config ──
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "screenshots", "e2e-terminal-tab")
 

--- a/tests/issues/394/test_terminal_demo.py
+++ b/tests/issues/394/test_terminal_demo.py
@@ -15,7 +15,7 @@ HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 
 TEST_USER = os.environ.get("TEST_REAL_USER", "test_user")
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 
 
 def login(page):

--- a/tests/issues/4/test_conversation_history_icon.py
+++ b/tests/issues/4/test_conversation_history_icon.py
@@ -9,7 +9,7 @@ PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(_
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "screenshots", "issues", "4")
 
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 
 
 async def test_conversation_history_icon():

--- a/tests/issues/41/test_footer_version.py
+++ b/tests/issues/41/test_footer_version.py
@@ -13,7 +13,7 @@ import re
 
 from playwright.async_api import async_playwright
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 
 
 async def main():

--- a/tests/issues/41/test_request_quota.py
+++ b/tests/issues/41/test_request_quota.py
@@ -25,7 +25,7 @@ except ImportError:
     sys.exit(1)
 
 # Configuration
-BASE_URL = "http://localhost:5001"
+BASE_URL = "http://localhost:19888"
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 VIEWPORT_SIZE = {"width": 1400, "height": 900}

--- a/tests/issues/415/e2e_structured_content.py
+++ b/tests/issues/415/e2e_structured_content.py
@@ -21,7 +21,7 @@ import uuid
 import requests
 from playwright.sync_api import sync_playwright
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")

--- a/tests/issues/42/test_page_size_loading.py
+++ b/tests/issues/42/test_page_size_loading.py
@@ -21,7 +21,7 @@ from playwright.async_api import async_playwright
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 
 # Test configuration
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 TIMEOUT = 10000  # 10 seconds timeout

--- a/tests/issues/42/test_quota_enforcement.py
+++ b/tests/issues/42/test_quota_enforcement.py
@@ -21,7 +21,7 @@ import time
 import requests
 
 # Configuration
-OPENACE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+OPENACE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 

--- a/tests/issues/42/test_token_auth.py
+++ b/tests/issues/42/test_token_auth.py
@@ -20,7 +20,7 @@ import urllib.parse
 import requests
 
 # Configuration
-OPENACE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+OPENACE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 TOKEN_SECRET = "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6"

--- a/tests/issues/435/e2e_api_key_toggle.py
+++ b/tests/issues/435/e2e_api_key_toggle.py
@@ -30,7 +30,7 @@ import requests
 from playwright.sync_api import expect, sync_playwright
 
 # ── 配置 ──────────────────────────────────────────────
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "screenshots", "e2e-api-key-toggle")
 

--- a/tests/issues/456/test_envkey_normalization.py
+++ b/tests/issues/456/test_envkey_normalization.py
@@ -68,7 +68,7 @@ class TestNormalizeModelProviders:
                 ]
             }
         }
-        proxy_url = "http://test-server:5001/api/remote/llm-proxy/v1"
+        proxy_url = "http://test-server:19888/api/remote/llm-proxy/v1"
         normalize_model_providers(settings, proxy_base_url=proxy_url)
         assert settings["modelProviders"]["openai"][0]["baseUrl"] == proxy_url
 
@@ -77,7 +77,7 @@ class TestNormalizeModelProviders:
         settings = {
             "modelProviders": {"openai": [{"envKey": "CUSTOM_KEY", "id": "glm-5", "name": "glm-5"}]}
         }
-        proxy_url = "http://test-server:5001/api/remote/llm-proxy/v1"
+        proxy_url = "http://test-server:19888/api/remote/llm-proxy/v1"
         normalize_model_providers(settings, proxy_base_url=proxy_url)
         assert settings["modelProviders"]["openai"][0]["baseUrl"] == proxy_url
 

--- a/tests/issues/47/test_auto_refresh.py
+++ b/tests/issues/47/test_auto_refresh.py
@@ -17,7 +17,7 @@ from playwright.async_api import async_playwright
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 
 # Test configuration
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 TIMEOUT = 15000  # 15 seconds timeout

--- a/tests/issues/48/test_status_bar_usage.py
+++ b/tests/issues/48/test_status_bar_usage.py
@@ -22,7 +22,7 @@ sys.path.insert(0, project_root)
 from playwright.sync_api import expect, sync_playwright
 
 # Test configuration
-BASE_URL = "http://localhost:5001"
+BASE_URL = "http://localhost:19888"
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/issues/48/test_status_bar_usage_v2.py
+++ b/tests/issues/48/test_status_bar_usage_v2.py
@@ -25,7 +25,7 @@ sys.path.insert(0, project_root)
 from playwright.sync_api import expect, sync_playwright
 
 # Test configuration
-BASE_URL = "http://localhost:5001"
+BASE_URL = "http://localhost:19888"
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/issues/50/test_issue50.py
+++ b/tests/issues/50/test_issue50.py
@@ -14,7 +14,7 @@ from tests.conftest import login_and_navigate
 # Test user credentials (normal user, not admin)
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 
 
 async def main():

--- a/tests/issues/50/test_issue50_admin.py
+++ b/tests/issues/50/test_issue50_admin.py
@@ -14,7 +14,7 @@ from tests.conftest import login_and_navigate
 # Test admin credentials
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 
 
 async def main():

--- a/tests/issues/51/test_api_data.py
+++ b/tests/issues/51/test_api_data.py
@@ -12,7 +12,7 @@ sys.path.insert(
 
 from playwright.sync_api import sync_playwright
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/issues/51/test_issue51.py
+++ b/tests/issues/51/test_issue51.py
@@ -30,7 +30,7 @@ except ImportError:
     sys.exit(1)
 
 # Test configuration
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 ADMIN_USERNAME = os.environ.get("TEST_USERNAME", "admin")
 ADMIN_PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 TEST_USER_USERNAME = os.environ.get("TEST_USERNAME", "admin")

--- a/tests/issues/51/test_manage_trend.py
+++ b/tests/issues/51/test_manage_trend.py
@@ -12,7 +12,7 @@ sys.path.insert(
 
 from playwright.sync_api import sync_playwright
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/issues/51/test_page_structure.py
+++ b/tests/issues/51/test_page_structure.py
@@ -12,7 +12,7 @@ sys.path.insert(
 
 from playwright.sync_api import sync_playwright
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/issues/51/test_usage_trend_stats.py
+++ b/tests/issues/51/test_usage_trend_stats.py
@@ -21,7 +21,7 @@ sys.path.insert(
 from playwright.sync_api import expect, sync_playwright
 
 # Configuration
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/issues/517/e2e_codex_real_session.py
+++ b/tests/issues/517/e2e_codex_real_session.py
@@ -12,7 +12,7 @@ Actually tests the full lifecycle on a remote test machine:
 7. Verify quota tracks codex usage
 
 This test REQUIRES:
-  - open-ace server running at localhost:5001
+  - open-ace server running at localhost:19888
   - Remote test machine online with agent running
   - codex installed on remote test machine
   - LLM proxy working (proxy token configured)

--- a/tests/issues/517/e2e_codex_real_session.py
+++ b/tests/issues/517/e2e_codex_real_session.py
@@ -193,7 +193,7 @@ def test_codex_exec_conversation():
     if not existing_files:
         # No existing sessions - we need to create one
         # Use the proxy URL and token from the open-ace server
-        proxy_base = f"http://{REMOTE_HOST.replace('.3', '.1')}:5001/api/remote/llm-proxy/v1"
+        proxy_base = f"http://{REMOTE_HOST.replace('.3', '.1')}:19888/api/remote/llm-proxy/v1"
 
         # Get a fresh proxy token - use session_token as auth
         # Actually, let's try running codex exec directly with proper env

--- a/tests/issues/517/test_helpers.py
+++ b/tests/issues/517/test_helpers.py
@@ -16,7 +16,7 @@ sys.path.insert(0, os.path.join(PROJECT_ROOT, "scripts"))
 import requests
 
 # ── Configuration ──────────────────────────────────────
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 WEBUI_URL = os.environ.get("WEBUI_URL", "http://localhost:3000")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 REMOTE_TEST_HOST = os.environ.get("REMOTE_TEST_HOST", "192.168.64.3")

--- a/tests/issues/52/test_issue52_management_users.py
+++ b/tests/issues/52/test_issue52_management_users.py
@@ -29,7 +29,7 @@ except ImportError:
     sys.exit(1)
 
 # Test configuration
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 SCREENSHOT_DIR = os.path.join(

--- a/tests/issues/52/test_project_keyboard_nav.py
+++ b/tests/issues/52/test_project_keyboard_nav.py
@@ -30,7 +30,7 @@ from playwright.async_api import async_playwright
 from tests.conftest import login_and_navigate
 
 # 测试配置
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/issues/53/test-quota-fullscreen-exit.spec.ts
+++ b/tests/issues/53/test-quota-fullscreen-exit.spec.ts
@@ -13,7 +13,7 @@ import { test, expect } from '@playwright/test';
 test.describe('Issue 53: Auto exit fullscreen on quota exceeded', () => {
   test.beforeEach(async ({ page }) => {
     // Login first
-    await page.goto('http://localhost:5001/login');
+    await page.goto('http://localhost:19888/login');
     await page.fill('input[name="username"]', 'admin');
     await page.fill('input[name="password"]', 'admin123');
     await page.click('button[type="submit"]');
@@ -24,7 +24,7 @@ test.describe('Issue 53: Auto exit fullscreen on quota exceeded', () => {
 
   test('should show quota exceeded warning when quota is over limit', async ({ page }) => {
     // Navigate to workspace
-    await page.goto('http://localhost:5001/work/workspace');
+    await page.goto('http://localhost:19888/work/workspace');
 
     // Wait for workspace to load
     await page.waitForSelector('.workspace', { timeout: 15000 });
@@ -39,7 +39,7 @@ test.describe('Issue 53: Auto exit fullscreen on quota exceeded', () => {
 
   test('should display fullscreen toggle button', async ({ page }) => {
     // Navigate to workspace
-    await page.goto('http://localhost:5001/work/workspace');
+    await page.goto('http://localhost:19888/work/workspace');
 
     // Wait for workspace header to load
     await page.waitForSelector('.page-header', { timeout: 15000 });
@@ -54,7 +54,7 @@ test.describe('Issue 53: Auto exit fullscreen on quota exceeded', () => {
 
   test('should enter fullscreen mode when button clicked', async ({ page }) => {
     // Navigate to workspace
-    await page.goto('http://localhost:5001/work/workspace');
+    await page.goto('http://localhost:19888/work/workspace');
 
     // Wait for page header
     await page.waitForSelector('.page-header', { timeout: 15000 });
@@ -77,7 +77,7 @@ test.describe('Issue 53: Auto exit fullscreen on quota exceeded', () => {
   test('should show toast notification when quota exceeded', async ({ page }) => {
     // This test verifies the toast notification component is available
     // Navigate to workspace
-    await page.goto('http://localhost:5001/work/workspace');
+    await page.goto('http://localhost:19888/work/workspace');
 
     // Wait for workspace to load
     await page.waitForSelector('.workspace', { timeout: 15000 });

--- a/tests/issues/53/test_add_user_button.py
+++ b/tests/issues/53/test_add_user_button.py
@@ -30,7 +30,7 @@ except ImportError:
     sys.exit(1)
 
 # Test configuration
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 SCREENSHOT_DIR = os.path.join(

--- a/tests/issues/54/session_detail_test.py
+++ b/tests/issues/54/session_detail_test.py
@@ -28,7 +28,7 @@ except ImportError:
     from playwright.async_api import async_playwright
 
 # Configuration
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 VIEWPORT = {"width": 1400, "height": 900}

--- a/tests/issues/54/test_issue54.py
+++ b/tests/issues/54/test_issue54.py
@@ -21,7 +21,7 @@ from playwright.sync_api import expect
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__)))))
 
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 
 
 async def take_screenshot(page, name):

--- a/tests/issues/54/test_session_detail_issue54.py
+++ b/tests/issues/54/test_session_detail_issue54.py
@@ -18,7 +18,7 @@ import time
 from playwright.sync_api import sync_playwright
 
 # 配置
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/issues/55/test_debug_save_detailed.py
+++ b/tests/issues/55/test_debug_save_detailed.py
@@ -8,7 +8,7 @@ import time
 
 from playwright.sync_api import sync_playwright
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/issues/55/test_debug_save_issue.py
+++ b/tests/issues/55/test_debug_save_issue.py
@@ -8,7 +8,7 @@ import time
 
 from playwright.sync_api import sync_playwright
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/issues/55/test_issue55_messages_pagination.py
+++ b/tests/issues/55/test_issue55_messages_pagination.py
@@ -18,7 +18,7 @@ from playwright.async_api import async_playwright
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 
 # Test configuration
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 TIMEOUT = 10000  # 10 seconds timeout

--- a/tests/issues/55/test_quota_alerts_dialog_v2.py
+++ b/tests/issues/55/test_quota_alerts_dialog_v2.py
@@ -18,7 +18,7 @@ import time
 from playwright.sync_api import sync_playwright
 
 # Test configuration
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/issues/55/test_tenant_quota_dialog_v3.py
+++ b/tests/issues/55/test_tenant_quota_dialog_v3.py
@@ -9,7 +9,7 @@ import time
 
 from playwright.sync_api import sync_playwright
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/issues/55/test_user_scenario.py
+++ b/tests/issues/55/test_user_scenario.py
@@ -9,7 +9,7 @@ import time
 
 from playwright.sync_api import sync_playwright
 
-BASE_URL = "http://localhost:5001"
+BASE_URL = "http://localhost:19888"
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/issues/555/test_terminal_main_ws_bridge.py
+++ b/tests/issues/555/test_terminal_main_ws_bridge.py
@@ -69,7 +69,7 @@ def test_backend_url_preserves_legacy_fallback_when_no_context(tmp_path, monkeyp
     from app.repositories import database
 
     monkeypatch.setattr(database, "CONFIG_DIR", tmp_path)
-    assert manager.get_backend_url() == "http://localhost:5001"
+    assert manager.get_backend_url() == "http://localhost:19888"
 
 
 def test_close_terminal_bridges_closes_active_connections():

--- a/tests/issues/59/test_session_list_display.py
+++ b/tests/issues/59/test_session_list_display.py
@@ -16,7 +16,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
 
 from playwright.sync_api import sync_playwright
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 TIMEOUT = 30000

--- a/tests/issues/60/test_language_sync.py
+++ b/tests/issues/60/test_language_sync.py
@@ -11,7 +11,7 @@ import os
 
 from playwright.async_api import async_playwright
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 
 
 async def test_language_sync():

--- a/tests/issues/604/e2e_ha_model_pool.py
+++ b/tests/issues/604/e2e_ha_model_pool.py
@@ -29,7 +29,7 @@ import requests
 from playwright.sync_api import sync_playwright
 
 # ── 配置 ──────────────────────────────────────────────
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "screenshots", "e2e-ha-pool")
 

--- a/tests/issues/610/e2e_remote_file_changes_playwright.py
+++ b/tests/issues/610/e2e_remote_file_changes_playwright.py
@@ -33,7 +33,7 @@ import requests
 from playwright.sync_api import sync_playwright
 
 # ── 配置 ──────────────────────────────────────────────
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 WEBUI_URL = os.environ.get("WEBUI_URL", "http://localhost:3000")
 TEST_USER = os.environ.get("TEST_REAL_USER", "test_user")

--- a/tests/issues/65/test_workspace_state_restore.py
+++ b/tests/issues/65/test_workspace_state_restore.py
@@ -16,7 +16,7 @@ import os
 
 from playwright.async_api import async_playwright
 
-OPENACE_URL = os.environ.get("OPENACE_URL", "http://localhost:5001")
+OPENACE_URL = os.environ.get("OPENACE_URL", "http://localhost:19888")
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "screenshots", "issues", "65")
 

--- a/tests/issues/67/test_status_bar_issue67.py
+++ b/tests/issues/67/test_status_bar_issue67.py
@@ -13,7 +13,7 @@ import time
 from playwright.sync_api import sync_playwright
 
 # Test configuration
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/issues/673/test_session_filter_params.py
+++ b/tests/issues/673/test_session_filter_params.py
@@ -219,7 +219,7 @@ def test_api_endpoint_integration():
     """
     import requests
 
-    BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+    BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 
     # 测试 status 过滤
     resp = requests.get(f"{BASE_URL}/api/workspace/sessions", params={"status": "active"})

--- a/tests/issues/68/test_data_status.py
+++ b/tests/issues/68/test_data_status.py
@@ -26,7 +26,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspa
 from playwright.async_api import async_playwright
 
 # Test configuration
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 SCREENSHOT_DIR = os.path.join(

--- a/tests/issues/68/test_keyboard_in_input.py
+++ b/tests/issues/68/test_keyboard_in_input.py
@@ -35,7 +35,7 @@ os.makedirs(OUTPUT_DIR, exist_ok=True)
 
 def ensure_service_running():
     """确保服务运行"""
-    result = subprocess.run(["lsof", "-i", ":5001"], capture_output=True, text=True)
+    result = subprocess.run(["lsof :19888"], capture_output=True, text=True)
     if not result.stdout.strip():
         print("启动服务...")
         subprocess.Popen(
@@ -46,7 +46,7 @@ def ensure_service_running():
         )
         for _i in range(30):
             time.sleep(1)
-            result = subprocess.run(["lsof", "-i", ":5001"], capture_output=True, text=True)
+            result = subprocess.run(["lsof :19888"], capture_output=True, text=True)
             if result.stdout.strip():
                 break
         time.sleep(3)

--- a/tests/issues/68/test_keyboard_in_input.py
+++ b/tests/issues/68/test_keyboard_in_input.py
@@ -22,7 +22,7 @@ from playwright.sync_api import sync_playwright
 project_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 sys.path.insert(0, project_root)
 
-BASE_URL = "http://localhost:5001"
+BASE_URL = "http://localhost:19888"
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 VIEWPORT_SIZE = {"width": 1400, "height": 900}

--- a/tests/issues/68/test_keyboard_shortcut_chat.py
+++ b/tests/issues/68/test_keyboard_shortcut_chat.py
@@ -24,7 +24,7 @@ from playwright.sync_api import sync_playwright
 project_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 sys.path.insert(0, project_root)
 
-BASE_URL = "http://localhost:5001"
+BASE_URL = "http://localhost:19888"
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 VIEWPORT_SIZE = {"width": 1400, "height": 900}

--- a/tests/issues/68/test_keyboard_shortcut_chat.py
+++ b/tests/issues/68/test_keyboard_shortcut_chat.py
@@ -37,7 +37,7 @@ os.makedirs(OUTPUT_DIR, exist_ok=True)
 
 def ensure_service_running():
     """确保服务运行"""
-    result = subprocess.run(["lsof", "-i", ":5001"], capture_output=True, text=True)
+    result = subprocess.run(["lsof :19888"], capture_output=True, text=True)
     if not result.stdout.strip():
         print("启动服务...")
         subprocess.Popen(
@@ -48,7 +48,7 @@ def ensure_service_running():
         )
         for _i in range(30):
             time.sleep(1)
-            result = subprocess.run(["lsof", "-i", ":5001"], capture_output=True, text=True)
+            result = subprocess.run(["lsof :19888"], capture_output=True, text=True)
             if result.stdout.strip():
                 break
         time.sleep(3)

--- a/tests/issues/69/test_issue69_recommendations.py
+++ b/tests/issues/69/test_issue69_recommendations.py
@@ -21,7 +21,7 @@ from playwright.async_api import async_playwright
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 
 # Test configuration
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 TIMEOUT = 10000  # 10 seconds timeout

--- a/tests/issues/69/test_session_detail_ui.py
+++ b/tests/issues/69/test_session_detail_ui.py
@@ -23,7 +23,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
 
 from playwright.sync_api import sync_playwright
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 TIMEOUT = 30000

--- a/tests/issues/70/test_chat_restore.py
+++ b/tests/issues/70/test_chat_restore.py
@@ -25,7 +25,7 @@ from playwright.sync_api import sync_playwright
 project_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 sys.path.insert(0, project_root)
 
-BASE_URL = "http://localhost:5001"
+BASE_URL = "http://localhost:19888"
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 VIEWPORT_SIZE = {"width": 1400, "height": 900}

--- a/tests/issues/70/test_chat_restore.py
+++ b/tests/issues/70/test_chat_restore.py
@@ -65,7 +65,7 @@ def restart_service():
     # 等待服务就绪
     for _i in range(30):
         time.sleep(1)
-        result = subprocess.run(["lsof", "-i", ":5001"], capture_output=True, text=True)
+        result = subprocess.run(["lsof :19888"], capture_output=True, text=True)
         if result.stdout.strip():
             break
 
@@ -294,7 +294,7 @@ def test_chat_restore():
             # 等待服务就绪
             for i in range(30):
                 time.sleep(1)
-                result = subprocess.run(["lsof", "-i", ":5001"], capture_output=True, text=True)
+                result = subprocess.run(["lsof :19888"], capture_output=True, text=True)
                 if result.stdout.strip():
                     break
 

--- a/tests/issues/70/test_settings_restore.py
+++ b/tests/issues/70/test_settings_restore.py
@@ -20,7 +20,7 @@ from playwright.sync_api import sync_playwright
 project_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 sys.path.insert(0, project_root)
 
-BASE_URL = "http://localhost:5001"
+BASE_URL = "http://localhost:19888"
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 VIEWPORT_SIZE = {"width": 1400, "height": 900}

--- a/tests/issues/70/test_title_restore.py
+++ b/tests/issues/70/test_title_restore.py
@@ -13,7 +13,7 @@ from playwright.sync_api import sync_playwright
 project_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 sys.path.insert(0, project_root)
 
-BASE_URL = "http://localhost:5001"
+BASE_URL = "http://localhost:19888"
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/issues/70/test_workspace_restore_error.py
+++ b/tests/issues/70/test_workspace_restore_error.py
@@ -21,7 +21,7 @@ project_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(_
 sys.path.insert(0, project_root)
 
 # UI 测试配置
-BASE_URL = "http://localhost:5001"
+BASE_URL = "http://localhost:19888"
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 VIEWPORT_SIZE = {"width": 1400, "height": 900}

--- a/tests/issues/70/test_workspace_restore_full.py
+++ b/tests/issues/70/test_workspace_restore_full.py
@@ -23,7 +23,7 @@ project_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(_
 sys.path.insert(0, project_root)
 
 # UI 测试配置
-BASE_URL = "http://localhost:5001"
+BASE_URL = "http://localhost:19888"
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 VIEWPORT_SIZE = {"width": 1400, "height": 900}

--- a/tests/issues/71/test_all_scenarios.py
+++ b/tests/issues/71/test_all_scenarios.py
@@ -36,7 +36,7 @@ os.makedirs(OUTPUT_DIR, exist_ok=True)
 
 def ensure_service_running():
     """确保服务运行"""
-    result = subprocess.run(["lsof", "-i", ":5001"], capture_output=True, text=True)
+    result = subprocess.run(["lsof :19888"], capture_output=True, text=True)
     if not result.stdout.strip():
         print("启动服务...")
         subprocess.Popen(
@@ -47,7 +47,7 @@ def ensure_service_running():
         )
         for _i in range(30):
             time.sleep(1)
-            result = subprocess.run(["lsof", "-i", ":5001"], capture_output=True, text=True)
+            result = subprocess.run(["lsof :19888"], capture_output=True, text=True)
             if result.stdout.strip():
                 break
         time.sleep(3)

--- a/tests/issues/71/test_all_scenarios.py
+++ b/tests/issues/71/test_all_scenarios.py
@@ -23,7 +23,7 @@ from playwright.sync_api import sync_playwright
 project_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 sys.path.insert(0, project_root)
 
-BASE_URL = "http://localhost:5001"
+BASE_URL = "http://localhost:19888"
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 VIEWPORT_SIZE = {"width": 1400, "height": 900}

--- a/tests/issues/71/test_background_permission.py
+++ b/tests/issues/71/test_background_permission.py
@@ -17,7 +17,7 @@ from playwright.sync_api import sync_playwright
 project_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 sys.path.insert(0, project_root)
 
-BASE_URL = "http://localhost:5001"
+BASE_URL = "http://localhost:19888"
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/issues/71/test_console_log.py
+++ b/tests/issues/71/test_console_log.py
@@ -11,7 +11,7 @@ from playwright.sync_api import sync_playwright
 project_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 sys.path.insert(0, project_root)
 
-BASE_URL = "http://localhost:5001"
+BASE_URL = "http://localhost:19888"
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/issues/71/test_cross_tab_message.py
+++ b/tests/issues/71/test_cross_tab_message.py
@@ -35,7 +35,7 @@ os.makedirs(OUTPUT_DIR, exist_ok=True)
 
 def ensure_service_running():
     """确保服务运行"""
-    result = subprocess.run(["lsof", "-i", ":5001"], capture_output=True, text=True)
+    result = subprocess.run(["lsof :19888"], capture_output=True, text=True)
     if not result.stdout.strip():
         print("启动服务...")
         subprocess.Popen(
@@ -46,7 +46,7 @@ def ensure_service_running():
         )
         for _i in range(30):
             time.sleep(1)
-            result = subprocess.run(["lsof", "-i", ":5001"], capture_output=True, text=True)
+            result = subprocess.run(["lsof :19888"], capture_output=True, text=True)
             if result.stdout.strip():
                 break
         time.sleep(3)

--- a/tests/issues/71/test_cross_tab_message.py
+++ b/tests/issues/71/test_cross_tab_message.py
@@ -22,7 +22,7 @@ from playwright.sync_api import sync_playwright
 project_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 sys.path.insert(0, project_root)
 
-BASE_URL = "http://localhost:5001"
+BASE_URL = "http://localhost:19888"
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 VIEWPORT_SIZE = {"width": 1400, "height": 900}

--- a/tests/issues/71/test_notification_timing.py
+++ b/tests/issues/71/test_notification_timing.py
@@ -13,7 +13,7 @@ from playwright.sync_api import sync_playwright
 project_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 sys.path.insert(0, project_root)
 
-BASE_URL = "http://localhost:5001"
+BASE_URL = "http://localhost:19888"
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/issues/71/test_realtime_cross_tab.py
+++ b/tests/issues/71/test_realtime_cross_tab.py
@@ -35,7 +35,7 @@ os.makedirs(OUTPUT_DIR, exist_ok=True)
 
 def ensure_service_running():
     """确保服务运行"""
-    result = subprocess.run(["lsof", "-i", ":5001"], capture_output=True, text=True)
+    result = subprocess.run(["lsof :19888"], capture_output=True, text=True)
     if not result.stdout.strip():
         print("启动服务...")
         subprocess.Popen(
@@ -46,7 +46,7 @@ def ensure_service_running():
         )
         for _i in range(30):
             time.sleep(1)
-            result = subprocess.run(["lsof", "-i", ":5001"], capture_output=True, text=True)
+            result = subprocess.run(["lsof :19888"], capture_output=True, text=True)
             if result.stdout.strip():
                 break
         time.sleep(3)

--- a/tests/issues/71/test_realtime_cross_tab.py
+++ b/tests/issues/71/test_realtime_cross_tab.py
@@ -22,7 +22,7 @@ from playwright.sync_api import sync_playwright
 project_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 sys.path.insert(0, project_root)
 
-BASE_URL = "http://localhost:5001"
+BASE_URL = "http://localhost:19888"
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 VIEWPORT_SIZE = {"width": 1400, "height": 900}

--- a/tests/issues/71/test_tab_notification_chat.py
+++ b/tests/issues/71/test_tab_notification_chat.py
@@ -36,7 +36,7 @@ TEST_MESSAGE = "Hello, please answer: what is 1+1? Just give me a number."
 
 def ensure_service_running():
     """确保服务运行"""
-    result = subprocess.run(["lsof", "-i", ":5001"], capture_output=True, text=True)
+    result = subprocess.run(["lsof :19888"], capture_output=True, text=True)
     if not result.stdout.strip():
         print("启动服务...")
         subprocess.Popen(
@@ -47,7 +47,7 @@ def ensure_service_running():
         )
         for _i in range(30):
             time.sleep(1)
-            result = subprocess.run(["lsof", "-i", ":5001"], capture_output=True, text=True)
+            result = subprocess.run(["lsof :19888"], capture_output=True, text=True)
             if result.stdout.strip():
                 break
         time.sleep(3)

--- a/tests/issues/71/test_tab_notification_chat.py
+++ b/tests/issues/71/test_tab_notification_chat.py
@@ -20,7 +20,7 @@ from playwright.sync_api import sync_playwright
 project_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 sys.path.insert(0, project_root)
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 VIEWPORT_SIZE = {"width": 1400, "height": 900}

--- a/tests/issues/716/e2e_autonomous_playwright.py
+++ b/tests/issues/716/e2e_autonomous_playwright.py
@@ -36,7 +36,7 @@ _session.trust_env = False
 
 # ── Config ──────────────────────────────────────────────
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "tests", "screenshots", "e2e-autonomous")
 TEST_USER = os.environ.get("TEST_REAL_USER", "admin")

--- a/tests/issues/72/test_issue72.py
+++ b/tests/issues/72/test_issue72.py
@@ -21,7 +21,7 @@ from playwright.async_api import async_playwright
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 
 # Test configuration
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 TIMEOUT = 30000  # 30 seconds timeout

--- a/tests/issues/73/test_data_status_local.py
+++ b/tests/issues/73/test_data_status_local.py
@@ -23,7 +23,7 @@ sys.path.insert(0, PROJECT_ROOT)
 from playwright.async_api import async_playwright
 
 # Configuration
-BASE_URL = "http://localhost:5001"
+BASE_URL = "http://localhost:19888"
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "screenshots", "issues", "73")

--- a/tests/issues/73/test_issue73_bell_fullscreen.py
+++ b/tests/issues/73/test_issue73_bell_fullscreen.py
@@ -29,7 +29,7 @@ except ImportError:
     sys.exit(1)
 
 # Configuration
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/issues/74/test_data_status_simplified.py
+++ b/tests/issues/74/test_data_status_simplified.py
@@ -23,7 +23,7 @@ sys.path.insert(0, PROJECT_ROOT)
 from playwright.async_api import async_playwright, expect
 
 # Configuration
-BASE_URL = "http://localhost:5001"
+BASE_URL = "http://localhost:19888"
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "screenshots", "issues", "74")

--- a/tests/issues/74/test_restore_button.py
+++ b/tests/issues/74/test_restore_button.py
@@ -7,7 +7,7 @@ import os
 
 from playwright.async_api import async_playwright
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 
 
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/issues/740/e2e_autonomous_comprehensive_playwright.py
+++ b/tests/issues/740/e2e_autonomous_comprehensive_playwright.py
@@ -67,7 +67,7 @@ _session.trust_env = False
 
 # ── Config ──────────────────────────────────────────────
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "tests", "screenshots", "e2e-autonomous-740")
 TEST_USER = os.environ.get("TEST_REAL_USER", "admin")

--- a/tests/issues/740/e2e_autonomous_gap_playwright.py
+++ b/tests/issues/740/e2e_autonomous_gap_playwright.py
@@ -45,7 +45,7 @@ _session.trust_env = False
 
 # ── Config ──────────────────────────────────────────────
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "tests", "screenshots", "e2e-autonomous-740-gap")
 TEST_USER = os.environ.get("TEST_REAL_USER", "admin")

--- a/tests/issues/75/test_language_selector.py
+++ b/tests/issues/75/test_language_selector.py
@@ -22,7 +22,7 @@ sys.path.insert(0, PROJECT_ROOT)
 from playwright.async_api import async_playwright, expect
 
 # Configuration
-BASE_URL = "http://localhost:5001"
+BASE_URL = "http://localhost:19888"
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "screenshots", "issues", "75")

--- a/tests/issues/76/test_admin_menu.py
+++ b/tests/issues/76/test_admin_menu.py
@@ -22,7 +22,7 @@ sys.path.insert(0, PROJECT_ROOT)
 from playwright.async_api import async_playwright, expect
 
 # Configuration
-BASE_URL = "http://localhost:5001"
+BASE_URL = "http://localhost:19888"
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "screenshots", "issues", "76")

--- a/tests/issues/76/test_menu.py
+++ b/tests/issues/76/test_menu.py
@@ -7,7 +7,7 @@ import os
 import pytest
 from playwright.async_api import async_playwright
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "screenshots", "issues", "76")
 

--- a/tests/issues/77/test_sidebar_scrollbar.py
+++ b/tests/issues/77/test_sidebar_scrollbar.py
@@ -22,7 +22,7 @@ sys.path.insert(0, PROJECT_ROOT)
 from playwright.async_api import async_playwright
 
 # Configuration
-BASE_URL = "http://localhost:5001"
+BASE_URL = "http://localhost:19888"
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "screenshots", "issues", "77")

--- a/tests/issues/78/test_login_button.py
+++ b/tests/issues/78/test_login_button.py
@@ -22,7 +22,7 @@ sys.path.insert(0, PROJECT_ROOT)
 from playwright.async_api import async_playwright, expect
 
 # Configuration
-BASE_URL = "http://localhost:5001"
+BASE_URL = "http://localhost:19888"
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "screenshots", "issues", "78")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 

--- a/tests/issues/79/test_add_user_final.py
+++ b/tests/issues/79/test_add_user_final.py
@@ -12,7 +12,7 @@ import time
 from playwright.async_api import async_playwright
 
 # 配置
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "screenshots", "issues", "79")
 

--- a/tests/issues/79/test_add_user_save.py
+++ b/tests/issues/79/test_add_user_save.py
@@ -22,7 +22,7 @@ import sys
 from playwright.async_api import async_playwright
 
 # 配置
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 SESSION_TOKEN = os.environ.get("SESSION_TOKEN", "")
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "screenshots", "issues", "79")

--- a/tests/issues/79/test_add_user_save_v2.py
+++ b/tests/issues/79/test_add_user_save_v2.py
@@ -11,7 +11,7 @@ import sys
 from playwright.async_api import async_playwright
 
 # 配置
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "screenshots", "issues", "79")
 

--- a/tests/issues/79/test_conversation_detail_modal.py
+++ b/tests/issues/79/test_conversation_detail_modal.py
@@ -14,7 +14,7 @@ from datetime import datetime
 
 import aiohttp
 
-BASE_URL = "http://localhost:5001"
+BASE_URL = "http://localhost:19888"
 
 
 async def test_conversation_history_api():

--- a/tests/issues/79/test_issue79_conversation_detail.py
+++ b/tests/issues/79/test_issue79_conversation_detail.py
@@ -22,7 +22,7 @@ import time
 from playwright.async_api import async_playwright
 
 # Test configuration
-BASE_URL = "http://localhost:5001"
+BASE_URL = "http://localhost:19888"
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/issues/79/test_role_filter.py
+++ b/tests/issues/79/test_role_filter.py
@@ -23,7 +23,7 @@ import os
 
 from playwright.async_api import async_playwright
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 
 
 async def test_role_filter():

--- a/tests/issues/80/test_manage_language_dropdown.py
+++ b/tests/issues/80/test_manage_language_dropdown.py
@@ -8,7 +8,7 @@ import time
 
 from playwright.sync_api import expect, sync_playwright
 
-BASE_URL = "http://localhost:5001/"
+BASE_URL = "http://localhost:19888/"
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 SCREENSHOT_DIR = "screenshots/issues/80"

--- a/tests/issues/82/test_sidebar_collapse.py
+++ b/tests/issues/82/test_sidebar_collapse.py
@@ -7,7 +7,7 @@ import os
 import pytest
 from playwright.async_api import async_playwright
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "screenshots", "issues", "82")
 

--- a/tests/issues/82/test_sidebar_collapse_normal_user.py
+++ b/tests/issues/82/test_sidebar_collapse_normal_user.py
@@ -11,7 +11,7 @@ import os
 import pytest
 from playwright.async_api import async_playwright
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "screenshots", "issues", "82")
 

--- a/tests/issues/824/e2e_conversation_history_pagination.py
+++ b/tests/issues/824/e2e_conversation_history_pagination.py
@@ -19,8 +19,8 @@ stack but responds correctly to curl and to the browser. API calls in this test
 therefore use curl (see project E2E gotchas); the browser drives the UI.
 
 Environment:
-  WEB_BASE  Playwright UI origin  (default http://localhost:5001)
-  API_BASE  curl API origin       (default http://localhost:5001)
+  WEB_BASE  Playwright UI origin  (default http://localhost:19888)
+  API_BASE  curl API origin       (default http://localhost:19888)
   HEADLESS  true|false            (default true)
 
 Run (normal):
@@ -29,7 +29,7 @@ Run (normal):
 
 Run against a local Vite dev server (exercises current source rather than the
 built dist):
-  WEB_BASE=http://localhost:3000 API_BASE=http://localhost:5001 HEADLESS=true \\
+  WEB_BASE=http://localhost:3000 API_BASE=http://localhost:19888 HEADLESS=true \\
     python tests/issues/824/e2e_conversation_history_pagination.py
 """
 
@@ -45,8 +45,8 @@ sys.path.insert(0, PROJECT_ROOT)
 
 from playwright.sync_api import sync_playwright
 
-WEB_BASE = os.environ.get("WEB_BASE", os.environ.get("BASE_URL", "http://localhost:5001"))
-API_BASE = os.environ.get("API_BASE", "http://localhost:5001")
+WEB_BASE = os.environ.get("WEB_BASE", os.environ.get("BASE_URL", "http://localhost:19888"))
+API_BASE = os.environ.get("API_BASE", "http://localhost:19888")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")

--- a/tests/issues/83/test_issue83_85_workspace.py
+++ b/tests/issues/83/test_issue83_85_workspace.py
@@ -24,7 +24,7 @@ import time
 from playwright.async_api import async_playwright, expect
 
 # 测试配置
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/issues/86/test_issue86_profile_hover.py
+++ b/tests/issues/86/test_issue86_profile_hover.py
@@ -25,7 +25,7 @@ import time
 from playwright.async_api import async_playwright, expect
 
 # 测试配置
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/issues/863/e2e_ip_whitelist_input.py
+++ b/tests/issues/863/e2e_ip_whitelist_input.py
@@ -29,7 +29,7 @@ sys.path.insert(0, PROJECT_ROOT)
 import requests
 from playwright.sync_api import sync_playwright
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "screenshots", "e2e-ip-whitelist")
 

--- a/tests/issues/90/test_i18n_translations.py
+++ b/tests/issues/90/test_i18n_translations.py
@@ -20,7 +20,7 @@ sys.path.insert(0, str(project_root))
 
 from playwright.sync_api import expect, sync_playwright
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 

--- a/tests/issues/91/test_management_button.py
+++ b/tests/issues/91/test_management_button.py
@@ -12,7 +12,7 @@ import os
 
 from playwright.async_api import async_playwright
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))

--- a/tests/issues/91/test_report_charts.py
+++ b/tests/issues/91/test_report_charts.py
@@ -19,7 +19,7 @@ import time
 from playwright.sync_api import expect, sync_playwright
 
 # Test configuration
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001/")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888/")
 USERNAME = os.environ.get("USERNAME", "testuser91")
 PASSWORD = os.environ.get("PASSWORD", "test123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/issues/92/test_logout_position.py
+++ b/tests/issues/92/test_logout_position.py
@@ -18,7 +18,7 @@ import time
 from playwright.sync_api import expect, sync_playwright
 
 # Test configuration
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001/")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888/")
 USERNAME = os.environ.get("USERNAME", "testuser91")
 PASSWORD = os.environ.get("PASSWORD", "test123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/issues/94/test_issue94_conversation.py
+++ b/tests/issues/94/test_issue94_conversation.py
@@ -25,7 +25,7 @@ sys.path.insert(
 from playwright.async_api import async_playwright, expect
 
 # Test configuration
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001/")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888/")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/issues/94/test_ui_conversation_history.py
+++ b/tests/issues/94/test_ui_conversation_history.py
@@ -23,7 +23,7 @@ sys.path.insert(
 from playwright.sync_api import expect, sync_playwright
 
 # Test configuration
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001/")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888/")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/issues/95/test_messages_ui.py
+++ b/tests/issues/95/test_messages_ui.py
@@ -10,7 +10,7 @@ import time
 
 from playwright.sync_api import sync_playwright
 
-BASE_URL = "http://localhost:5001/"
+BASE_URL = "http://localhost:19888/"
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 

--- a/tests/issues/98/test_conversation_detail.py
+++ b/tests/issues/98/test_conversation_detail.py
@@ -11,7 +11,7 @@ import os
 
 from playwright.async_api import async_playwright
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "screenshots", "issues", "98")
 

--- a/tests/issues/98/test_data_update.py
+++ b/tests/issues/98/test_data_update.py
@@ -17,7 +17,7 @@ from datetime import datetime
 import psycopg2
 from playwright.async_api import async_playwright
 
-BASE_URL = "http://localhost:5001"
+BASE_URL = "http://localhost:19888"
 
 
 def get_db_connection():

--- a/tests/issues/98/test_global_refresh.py
+++ b/tests/issues/98/test_global_refresh.py
@@ -12,7 +12,7 @@ import asyncio
 
 from playwright.async_api import async_playwright
 
-BASE_URL = "http://localhost:5001"
+BASE_URL = "http://localhost:19888"
 
 
 async def test_global_refresh():

--- a/tests/issues/98/test_refresh.py
+++ b/tests/issues/98/test_refresh.py
@@ -13,7 +13,7 @@ import time
 
 from playwright.async_api import async_playwright
 
-BASE_URL = "http://localhost:5001"
+BASE_URL = "http://localhost:19888"
 
 
 async def test_messages_refresh():

--- a/tests/issues/98/test_refresh_detailed.py
+++ b/tests/issues/98/test_refresh_detailed.py
@@ -13,7 +13,7 @@ import time
 
 from playwright.async_api import async_playwright
 
-BASE_URL = "http://localhost:5001"
+BASE_URL = "http://localhost:19888"
 
 
 async def test_messages_refresh_detailed():

--- a/tests/issues/983/e2e_session_topology_playwright.py
+++ b/tests/issues/983/e2e_session_topology_playwright.py
@@ -41,7 +41,7 @@ _session = requests.Session()
 _session.trust_env = False
 
 # ── Config ──────────────────────────────────────────────
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "tests", "screenshots", "e2e-session-topology-983")
 TEST_USER = os.environ.get("TEST_REAL_USER", "admin")

--- a/tests/issues/988/e2e_milestone_fulltext_playwright.py
+++ b/tests/issues/988/e2e_milestone_fulltext_playwright.py
@@ -43,7 +43,7 @@ _session = requests.Session()
 _session.trust_env = False
 
 # ── Config ──────────────────────────────────────────────
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "tests", "screenshots", "e2e-milestone-fulltext-988")
 TEST_USER = os.environ.get("TEST_REAL_USER", "admin")

--- a/tests/issues/99/test_add_prompt.py
+++ b/tests/issues/99/test_add_prompt.py
@@ -22,7 +22,7 @@ except ImportError:
     sys.exit(1)
 
 # Configuration
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 VIEWPORT_SIZE = {"width": 1400, "height": 900}

--- a/tests/issues/993/e2e_card_summary_playwright.py
+++ b/tests/issues/993/e2e_card_summary_playwright.py
@@ -32,7 +32,7 @@ _session = requests.Session()
 _session.trust_env = False
 
 # ── Config ──────────────────────────────────────────────
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "tests", "screenshots", "e2e-card-summary-993")
 TEST_USER = os.environ.get("TEST_REAL_USER", "admin")

--- a/tests/performance/test_analytics_pages_performance.py
+++ b/tests/performance/test_analytics_pages_performance.py
@@ -20,7 +20,7 @@ import time
 
 from playwright.async_api import async_playwright
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/performance/test_anomaly_performance.py
+++ b/tests/performance/test_anomaly_performance.py
@@ -25,7 +25,7 @@ sys.path.insert(0, project_root)
 from playwright.sync_api import sync_playwright
 
 # Test configuration
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/performance/test_dashboard_load_breakdown.py
+++ b/tests/performance/test_dashboard_load_breakdown.py
@@ -19,7 +19,7 @@ sys.path.insert(0, project_root)
 from playwright.async_api import async_playwright
 
 # Configuration
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/performance/test_dashboard_load_performance.py
+++ b/tests/performance/test_dashboard_load_performance.py
@@ -21,7 +21,7 @@ sys.path.insert(0, project_root)
 from playwright.async_api import async_playwright
 
 # Configuration
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/performance/test_messages_performance.py
+++ b/tests/performance/test_messages_performance.py
@@ -12,7 +12,7 @@ import time
 
 import requests
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 

--- a/tests/performance/test_page_load_performance.py
+++ b/tests/performance/test_page_load_performance.py
@@ -15,7 +15,7 @@ import time
 from playwright.async_api import async_playwright
 
 # Configuration
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/performance/test_trend_analysis_performance.py
+++ b/tests/performance/test_trend_analysis_performance.py
@@ -13,7 +13,7 @@ import time
 from playwright.async_api import async_playwright
 
 # Configuration
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/performance/test_work_sessions_list_performance.py
+++ b/tests/performance/test_work_sessions_list_performance.py
@@ -18,7 +18,7 @@ import time
 from playwright.sync_api import sync_playwright
 
 # 配置
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/regression/test_helpers.py
+++ b/tests/regression/test_helpers.py
@@ -10,7 +10,7 @@ import os
 from playwright.sync_api import Page
 
 # 配置
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/regression/test_login.py
+++ b/tests/regression/test_login.py
@@ -27,7 +27,7 @@ from tests.regression.test_helpers import (
 MODULE_NAME = "login"
 
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 
 
 def test_login_page_loads():

--- a/tests/ui/conftest.py
+++ b/tests/ui/conftest.py
@@ -35,7 +35,8 @@ def ui_screenshot_dir(tmp_path):
 @pytest.fixture(scope="session")
 def ui_base_url():
     """Base URL for the application under test."""
-    return os.environ.get("BASE_URL", "http://localhost:5001")
+    # Issue #1372: 统一端口为 19888
+    return os.environ.get("BASE_URL", "http://localhost:19888")
 
 
 @pytest.fixture(scope="session")

--- a/tests/ui/demo_create_project.py
+++ b/tests/ui/demo_create_project.py
@@ -14,7 +14,7 @@ import time
 
 from playwright.sync_api import sync_playwright
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/ui/test_admin_default_mode.py
+++ b/tests/ui/test_admin_default_mode.py
@@ -11,7 +11,7 @@ import os
 
 from playwright.async_api import async_playwright
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))

--- a/tests/ui/test_alert_icon.py
+++ b/tests/ui/test_alert_icon.py
@@ -11,7 +11,7 @@ from datetime import datetime
 from playwright.async_api import async_playwright
 
 # Configuration
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/ui/test_analysis_charts.py
+++ b/tests/ui/test_analysis_charts.py
@@ -23,7 +23,7 @@ import time
 from playwright.sync_api import sync_playwright
 
 # Configuration
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/ui/test_analysis_conversation_history.py
+++ b/tests/ui/test_analysis_conversation_history.py
@@ -21,7 +21,7 @@ from playwright.async_api import async_playwright
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 
 # Test configuration
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 TIMEOUT = 10000  # 10 seconds timeout

--- a/tests/ui/test_anomaly_layout.py
+++ b/tests/ui/test_anomaly_layout.py
@@ -23,7 +23,7 @@ import time
 from playwright.sync_api import sync_playwright
 
 # Test configuration
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/ui/test_auto_click.py
+++ b/tests/ui/test_auto_click.py
@@ -9,7 +9,7 @@ import time
 
 from playwright.async_api import async_playwright
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 SCREENSHOT_DIR = os.path.join(
     os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))), "screenshots"
 )

--- a/tests/ui/test_auto_fullscreen_on_chat.py
+++ b/tests/ui/test_auto_fullscreen_on_chat.py
@@ -20,7 +20,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspa
 from playwright.async_api import async_playwright
 
 # Test configuration
-BASE_URL = "http://localhost:5001"
+BASE_URL = "http://localhost:19888"
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/ui/test_auto_refresh_layout.py
+++ b/tests/ui/test_auto_refresh_layout.py
@@ -9,7 +9,7 @@ import os
 
 from playwright.sync_api import sync_playwright
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 VIEWPORT_SIZE = (1400, 900)

--- a/tests/ui/test_clear_guide.py
+++ b/tests/ui/test_clear_guide.py
@@ -10,7 +10,7 @@ import time
 
 from playwright.async_api import async_playwright
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "screenshots")
 

--- a/tests/ui/test_click_debug.py
+++ b/tests/ui/test_click_debug.py
@@ -8,7 +8,7 @@ import os
 
 from playwright.async_api import async_playwright
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 WEBUI_PORT = os.environ.get("WEBUI_PORT", "3101")
 WEBUI_TOKEN = os.environ.get("WEBUI_TOKEN", "")
 SCREENSHOT_DIR = os.path.join(

--- a/tests/ui/test_conversation_history_modal.py
+++ b/tests/ui/test_conversation_history_modal.py
@@ -18,7 +18,7 @@ import time
 from playwright.async_api import async_playwright
 
 # Test configuration
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/ui/test_create_button_full.py
+++ b/tests/ui/test_create_button_full.py
@@ -9,7 +9,7 @@ import os
 
 from playwright.async_api import async_playwright
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 SCREENSHOT_DIR = os.path.join(
     os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))), "screenshots"
 )

--- a/tests/ui/test_create_debug.py
+++ b/tests/ui/test_create_debug.py
@@ -14,7 +14,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspa
 
 from playwright.sync_api import sync_playwright
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 
 SCREENSHOT_DIR = os.path.join(

--- a/tests/ui/test_create_direct.py
+++ b/tests/ui/test_create_direct.py
@@ -14,7 +14,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspa
 
 from playwright.sync_api import sync_playwright
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 WEBUI_PORT = os.environ.get("WEBUI_PORT", "3101")  # test user's webui port
 WEBUI_TOKEN = os.environ.get("WEBUI_TOKEN", "")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/ui/test_create_flow.py
+++ b/tests/ui/test_create_flow.py
@@ -9,7 +9,7 @@ import time
 
 from playwright.async_api import async_playwright
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "screenshots")
 

--- a/tests/ui/test_create_project_button.py
+++ b/tests/ui/test_create_project_button.py
@@ -17,7 +17,7 @@ import contextlib
 from playwright.sync_api import sync_playwright
 
 # Configuration
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/ui/test_dashboard_charts.py
+++ b/tests/ui/test_dashboard_charts.py
@@ -17,7 +17,7 @@ import time
 from playwright.sync_api import sync_playwright
 
 # Configuration
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/ui/test_dashboard_first_load.py
+++ b/tests/ui/test_dashboard_first_load.py
@@ -16,7 +16,7 @@ sys.path.insert(0, project_root)
 
 from playwright.async_api import async_playwright
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/ui/test_deep_debug.py
+++ b/tests/ui/test_deep_debug.py
@@ -11,7 +11,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspa
 
 from playwright.sync_api import sync_playwright
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 WEBUI_PORT = os.environ.get("WEBUI_PORT", "3101")
 WEBUI_TOKEN = os.environ.get("WEBUI_TOKEN", "")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/ui/test_fullscreen_modal.py
+++ b/tests/ui/test_fullscreen_modal.py
@@ -18,7 +18,7 @@ import time
 from playwright.async_api import async_playwright
 
 # Test configuration
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/ui/test_header_buttons.py
+++ b/tests/ui/test_header_buttons.py
@@ -11,7 +11,7 @@ import os
 
 from playwright.sync_api import sync_playwright
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 VIEWPORT_SIZE = (1400, 900)

--- a/tests/ui/test_iframe_add_project.py
+++ b/tests/ui/test_iframe_add_project.py
@@ -19,7 +19,7 @@ import time
 
 from playwright.sync_api import sync_playwright
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/ui/test_iframe_debug.py
+++ b/tests/ui/test_iframe_debug.py
@@ -8,7 +8,7 @@ import os
 
 from playwright.async_api import async_playwright
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 SCREENSHOT_DIR = os.path.join(
     os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))), "screenshots"
 )

--- a/tests/ui/test_insights_generate.py
+++ b/tests/ui/test_insights_generate.py
@@ -13,7 +13,7 @@ import time
 from playwright.sync_api import sync_playwright
 
 # Configuration
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_REAL_USER", "test_user")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/ui/test_interactive_create.py
+++ b/tests/ui/test_interactive_create.py
@@ -10,7 +10,7 @@ import time
 
 from playwright.async_api import async_playwright
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "screenshots")
 

--- a/tests/ui/test_language_dropdown.py
+++ b/tests/ui/test_language_dropdown.py
@@ -8,7 +8,7 @@ import time
 
 from playwright.sync_api import expect, sync_playwright
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 

--- a/tests/ui/test_manual_create.py
+++ b/tests/ui/test_manual_create.py
@@ -9,7 +9,7 @@ import time
 
 from playwright.async_api import async_playwright
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "screenshots")
 LOG_FILE = os.path.join(PROJECT_ROOT, "screenshots", "manual_create_log.txt")

--- a/tests/ui/test_messages_filter_layout.py
+++ b/tests/ui/test_messages_filter_layout.py
@@ -17,7 +17,7 @@ from playwright.async_api import async_playwright, expect
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 
 # Test configuration
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 TIMEOUT = 10000  # 10 seconds timeout

--- a/tests/ui/test_messages_page_loading.py
+++ b/tests/ui/test_messages_page_loading.py
@@ -17,7 +17,7 @@ from playwright.async_api import async_playwright
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 
 # Test configuration
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 TIMEOUT = 10000  # 10 seconds timeout

--- a/tests/ui/test_messages_sender_dropdown.py
+++ b/tests/ui/test_messages_sender_dropdown.py
@@ -13,7 +13,7 @@ import pytest
 from playwright.async_api import async_playwright, expect
 
 # Test configuration
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 TIMEOUT = 10000  # 10 seconds timeout

--- a/tests/ui/test_new_folder_create.py
+++ b/tests/ui/test_new_folder_create.py
@@ -9,7 +9,7 @@ import time
 
 from playwright.async_api import async_playwright
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 SCREENSHOT_DIR = os.path.join(
     os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))), "screenshots"
 )

--- a/tests/ui/test_pm_feature.py
+++ b/tests/ui/test_pm_feature.py
@@ -21,7 +21,7 @@ import time
 from playwright.sync_api import sync_playwright
 
 # Configuration
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/ui/test_project_management_duration.py
+++ b/tests/ui/test_project_management_duration.py
@@ -21,7 +21,7 @@ import requests
 from playwright.sync_api import sync_playwright
 
 # Configuration
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/ui/test_project_management_full.py
+++ b/tests/ui/test_project_management_full.py
@@ -19,7 +19,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspa
 from playwright.sync_api import sync_playwright
 
 # Configuration
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
@@ -251,7 +251,7 @@ def generate_report(screenshots):
     <h1>Project Management Feature Test Report</h1>
     <div class="meta">
         <p>Test Date: 2026-04-04</p>
-        <p>URL: http://localhost:5001/manage/projects</p>
+        <p>URL: http://localhost:19888/manage/projects</p>
     </div>
 """
 

--- a/tests/ui/test_quota_enter_save.py
+++ b/tests/ui/test_quota_enter_save.py
@@ -18,7 +18,7 @@ import time
 from playwright.sync_api import sync_playwright
 
 # Test configuration
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/ui/test_quota_token_unit.py
+++ b/tests/ui/test_quota_token_unit.py
@@ -11,7 +11,7 @@ import time
 from playwright.sync_api import sync_playwright
 
 # Test configuration
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/ui/test_refresh_functionality.py
+++ b/tests/ui/test_refresh_functionality.py
@@ -13,7 +13,7 @@ import time
 import requests
 from playwright.sync_api import sync_playwright
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 VIEWPORT_SIZE = (1400, 900)

--- a/tests/ui/test_roi_sessions.py
+++ b/tests/ui/test_roi_sessions.py
@@ -17,7 +17,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspa
 from playwright.async_api import async_playwright
 
 # Test configuration
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/ui/test_screenshot.py
+++ b/tests/ui/test_screenshot.py
@@ -6,7 +6,7 @@ import os
 
 from playwright.async_api import async_playwright
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 

--- a/tests/ui/test_security_center_tooltip.py
+++ b/tests/ui/test_security_center_tooltip.py
@@ -9,7 +9,7 @@ Dependencies:
 
 Configuration:
     Environment variables (optional):
-        BASE_URL: Target URL (default: http://localhost:5001)
+        BASE_URL: Target URL (default: http://localhost:19888)
         USERNAME: Login username (default: admin)
         PASSWORD: Login password (default: admin123)
         HEADLESS: Run in headless mode (default: true)
@@ -23,7 +23,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspa
 from playwright.sync_api import sync_playwright
 
 # Configuration - use environment variables or defaults
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/ui/test_security_page.py
+++ b/tests/ui/test_security_page.py
@@ -13,7 +13,7 @@ import time
 from playwright.sync_api import sync_playwright
 
 # Configuration
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/ui/test_session_list_scroll.py
+++ b/tests/ui/test_session_list_scroll.py
@@ -24,7 +24,7 @@ import time
 from playwright.async_api import async_playwright, expect
 
 # 测试配置
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/ui/test_session_search.py
+++ b/tests/ui/test_session_search.py
@@ -19,7 +19,7 @@ project_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(_
 sys.path.insert(0, project_root)
 
 # UI test configuration
-BASE_URL = "http://localhost:5001"
+BASE_URL = "http://localhost:19888"
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 VIEWPORT_SIZE = {"width": 1400, "height": 900}

--- a/tests/ui/test_sessions_page.py
+++ b/tests/ui/test_sessions_page.py
@@ -19,7 +19,7 @@ import time
 from playwright.sync_api import sync_playwright
 
 # 配置
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/ui/test_tab_close_last.py
+++ b/tests/ui/test_tab_close_last.py
@@ -20,7 +20,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspa
 
 from playwright.async_api import async_playwright
 
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/ui/test_tab_focus_input.py
+++ b/tests/ui/test_tab_focus_input.py
@@ -19,7 +19,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspa
 from playwright.async_api import async_playwright
 
 # Test configuration
-BASE_URL = "http://localhost:5001"
+BASE_URL = "http://localhost:19888"
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/ui/test_tab_keyboard_shortcut.py
+++ b/tests/ui/test_tab_keyboard_shortcut.py
@@ -19,7 +19,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspa
 from playwright.async_api import async_playwright
 
 # Test configuration
-BASE_URL = "http://localhost:5001"
+BASE_URL = "http://localhost:19888"
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/ui/test_tab_notification.py
+++ b/tests/ui/test_tab_notification.py
@@ -30,7 +30,7 @@ except ImportError:
     sys.exit(1)
 
 # Configuration
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/ui/test_tab_notification_chat.py
+++ b/tests/ui/test_tab_notification_chat.py
@@ -23,7 +23,7 @@ from playwright.sync_api import sync_playwright
 project_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 sys.path.insert(0, project_root)
 
-BASE_URL = "http://localhost:5001"
+BASE_URL = "http://localhost:19888"
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 VIEWPORT_SIZE = {"width": 1400, "height": 900}

--- a/tests/ui/test_tab_notification_full.py
+++ b/tests/ui/test_tab_notification_full.py
@@ -30,7 +30,7 @@ except ImportError:
     sys.exit(1)
 
 # Configuration
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/ui/test_tab_title_rename.py
+++ b/tests/ui/test_tab_title_rename.py
@@ -29,7 +29,7 @@ except ImportError:
     sys.exit(1)
 
 # Configuration
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/ui/test_tool_accounts.py
+++ b/tests/ui/test_tool_accounts.py
@@ -16,7 +16,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspa
 from playwright.sync_api import sync_playwright
 
 # Configuration
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/ui/test_user_enter_save.py
+++ b/tests/ui/test_user_enter_save.py
@@ -31,7 +31,7 @@ except ImportError:
     sys.exit(1)
 
 # Test configuration
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 SCREENSHOT_DIR = os.path.join(

--- a/tests/ui/test_user_segmentation_chart.py
+++ b/tests/ui/test_user_segmentation_chart.py
@@ -21,7 +21,7 @@ import time
 from playwright.sync_api import sync_playwright
 
 # Configuration
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/ui/test_work_assist_panel_prompts.py
+++ b/tests/ui/test_work_assist_panel_prompts.py
@@ -21,7 +21,7 @@ import time
 
 from playwright.sync_api import expect, sync_playwright
 
-BASE_URL = "http://localhost:5001"
+BASE_URL = "http://localhost:19888"
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/ui/test_work_page_loads.py
+++ b/tests/ui/test_work_page_loads.py
@@ -11,7 +11,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspa
 from playwright.sync_api import sync_playwright
 
 # Configuration
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/ui/test_work_prompts_view_all.py
+++ b/tests/ui/test_work_prompts_view_all.py
@@ -6,7 +6,7 @@ Test Objective:
 Verify that the "View All" link in the Prompts tab of the right panel is clickable and navigates to /work/prompts.
 
 Test Steps:
-1. Visit http://localhost:5001/
+1. Visit http://localhost:19888/
 2. Login to the system (using default credentials)
 3. Navigate to work mode (click /work)
 4. Check the right panel's Prompts tab
@@ -33,7 +33,7 @@ import time
 from playwright.async_api import async_playwright
 
 # Test Configuration
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/ui/test_work_right_panel_tabs.py
+++ b/tests/ui/test_work_right_panel_tabs.py
@@ -6,7 +6,7 @@ Test Objective:
 Verify that the 3 tabs (Prompts, Tools, Docs) in the right panel of work mode are displayed on the same row.
 
 Test Steps:
-1. Visit http://localhost:5001/
+1. Visit http://localhost:19888/
 2. Login to the system (using default credentials)
 3. Navigate to work mode (click /work)
 4. Check the right panel's 3 tabs layout
@@ -31,7 +31,7 @@ import time
 from playwright.async_api import async_playwright
 
 # Test Configuration
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/ui/test_work_session_list.py
+++ b/tests/ui/test_work_session_list.py
@@ -21,7 +21,7 @@ project_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(_
 sys.path.insert(0, project_root)
 
 # UI 测试配置
-BASE_URL = "http://localhost:5001"
+BASE_URL = "http://localhost:19888"
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 VIEWPORT_SIZE = {"width": 1400, "height": 900}

--- a/tests/ui/test_work_usage_page.py
+++ b/tests/ui/test_work_usage_page.py
@@ -18,7 +18,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspa
 from playwright.sync_api import expect, sync_playwright
 
 # Configuration
-BASE_URL = os.environ.get("BASE_URL", "http://localhost:5001")
+BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/ui/test_workspace_fullscreen.py
+++ b/tests/ui/test_workspace_fullscreen.py
@@ -19,7 +19,7 @@ import time
 from playwright.async_api import async_playwright
 
 # Test configuration
-BASE_URL = "http://localhost:5001"
+BASE_URL = "http://localhost:19888"
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"

--- a/tests/ui/test_workspace_remote_icon.py
+++ b/tests/ui/test_workspace_remote_icon.py
@@ -21,7 +21,7 @@ project_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(_
 sys.path.insert(0, project_root)
 
 # UI 测试配置
-BASE_URL = "http://localhost:5001"
+BASE_URL = "http://localhost:19888"
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 VIEWPORT_SIZE = {"width": 1400, "height": 900}


### PR DESCRIPTION
## 背景

PR #1386 评审报告指出 260+ 处 `localhost:5001` 引用未更新。经历史分析（已评论到 Issue #1372），这是 2026-05-23 提交 `14dad598` 引入的错误。

### 端口演变历史

| 日期 | 主服务端口 | 测试框架默认 | 状态 |
|------|-----------|-------------|------|
| 2026-03-31 前 | 5001 | 5001 | 一致 |
| 2026-03-31 后 | 5000 | 5000 | 一致 |
| 2026-05-23 后 | 5000 | 5001 ❌ | 不一致（错误） |
| 2026-07-01 后 | 19888 | 5001 ❌ | 不一致（PR #1386 遗漏） |
| 本次修复后 | 19888 | 19888 ✅ | 一致 |

## 修改范围

- `app/modules/workspace/remote_agent_manager.py`: fallback URL `localhost:5001` → `localhost:19888`
- `tests/conftest.py`: BASE_URL 默认值
- `tests/ui/conftest.py`: ui_base_url fixture
- `tests/` 目录所有 `.py/.md/.spec.ts` 文件（259 个文件）

## 验证

- `localhost:5001` 引用：0 处（全部替换完成）
- `localhost:19888` 引用：274 处（替换成功）

## 相关

- Issue #1372
- PR #1386（端口统一为 19888）
- 评审报告评论链接