### PR TITLE
fix: E2E测试登录后处理ForceChangePasswordModal弹窗 (Issue #1388)

### DIFF
--- a/frontend/e2e/helpers.ts
+++ b/frontend/e2e/helpers.ts
@@ -32,7 +32,8 @@ export async function login(page: Page, username = 'admin', password = 'admin123
 
   // Handle ForceChangePasswordModal if it appears (for users with must_change_password=true)
   const skipButton = page.locator('button:has-text("Skip"), button:has-text("跳过")');
-  const modalVisible = await skipButton.isVisible().catch(() => false);
+  // Use waitFor with short timeout to avoid race condition (isVisible is non-waiting)
+  const modalVisible = await skipButton.waitFor({ state: 'visible', timeout: 2000 }).then(() => true).catch(() => false);
   if (modalVisible) {
     // Click Skip button to dismiss the modal
     await skipButton.click();

--- a/frontend/e2e/helpers.ts
+++ b/frontend/e2e/helpers.ts
@@ -30,6 +30,16 @@ export async function login(page: Page, username = 'admin', password = 'admin123
     }
   }
 
+  // Handle ForceChangePasswordModal if it appears (for users with must_change_password=true)
+  const skipButton = page.locator('button:has-text("Skip"), button:has-text("跳过")');
+  const modalVisible = await skipButton.isVisible().catch(() => false);
+  if (modalVisible) {
+    // Click Skip button to dismiss the modal
+    await skipButton.click();
+    // Wait for modal to disappear
+    await page.locator('[role="dialog"]').waitFor({ state: 'hidden', timeout: 5000 }).catch(() => {});
+  }
+
   // Wait for page to be ready
   await page.waitForLoadState('networkidle');
 }


### PR DESCRIPTION
## 问题

Issue #1388: E2E测试登录后因`must_change_password=true`显示强制改密弹窗，遮挡页面元素导致测试超时失败。

## 根因分析

1. `scripts/init_db.py`创建admin用户时设置`must_change_password=True`
2. 登录成功后前端显示`ForceChangePasswordModal`弹窗
3. 弹窗覆盖页面，Playwright无法点击被遮挡元素
4. 测试超时失败：`TimeoutError: locator.click`

## 修复方案

**方案二**：在E2E测试中处理弹窗（不修改后端代码）

修改`frontend/e2e/helpers.ts`的`login()`函数：
- 登录成功后检测弹窗是否可见
- 点击Skip按钮关闭弹窗
- 等待弹窗消失后继续测试流程

**优点**：
- 不修改生产环境代码，保持安全行为
- E2E测试自己处理UI交互
- 简单直接

## 测试

- TypeScript编译通过
- 本地lint检查通过（e2e文件不在tsconfig范围是配置问题，不影响代码）

## 相关

- Closes #1388