### PR TITLE
docs: 移除端口谐音描述

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ cd open-ace
 # 构建并启动
 docker compose up -d --build
 
-# 访问 http://localhost:19888 (AI + ace 谐音端口)
+# 访问 http://localhost:19888
 ```
 
 > 💡 生产环境部署请参考 [部署指南](scripts/install-central/docker-method/README.md)
@@ -154,7 +154,7 @@ python3 scripts/init_db.py
 # 5. 启动服务
 python3 server.py
 
-# 访问 http://localhost:19888 (AI + ace 谐音端口)
+# 访问 http://localhost:19888
 ```
 
 ### 默认账号

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@
 #   git clone https://github.com/open-ace/open-ace.git
 #   cd open-ace
 #   docker compose up -d --build
-#   # Access http://localhost:19888 (Issue #1372: AI + ace 谐音端口)
+#   # Access http://localhost:19888
 #
 # Pull pre-built image from Docker Hub:
 #   docker compose up -d

--- a/scripts/install-central/docker-method/README.md
+++ b/scripts/install-central/docker-method/README.md
@@ -13,7 +13,7 @@ docker compose up -d --build
 
 这将：
 - 本地构建 open-ace 镜像
-- 启动 open-ace 容器（端口 19888，Issue #1372: AI + ace 谐音端口）
+- 启动 open-ace 容器（端口 19888）
 - 启动 PostgreSQL 数据库（内部端口 5432）
 
 ### 2. 访问应用

--- a/scripts/install-central/package-method/install.sh
+++ b/scripts/install-central/package-method/install.sh
@@ -2674,7 +2674,7 @@ configure_local() {
     echo ""
     prompt_yesno "Install as systemd service?" "y" install_service
     if [ "$install_service" = "yes" ]; then
-        # Get default port from config or use 19888 (Issue #1372: AI + ace 谐音端口)
+        # Get default port from config or use 19888
         local default_port=$(get_web_port_from_config)
         prompt_input "Web server port" "$default_port" SERVICE_PORT
         prompt_input "Web server host" "$SERVICE_HOST" SERVICE_HOST

--- a/scripts/shared/config.py
+++ b/scripts/shared/config.py
@@ -53,7 +53,7 @@ def _get_web_port() -> int:
         except (ValueError, TypeError):
             pass
 
-    # Priority 2: Default (Issue #1372: AI + ace 谐音端口)
+    # Priority 2: Default port
     return 19888
 
 

--- a/scripts/upload-to-central/shared/config.py
+++ b/scripts/upload-to-central/shared/config.py
@@ -60,7 +60,7 @@ def _get_web_port() -> int:
         except (ValueError, TypeError):
             pass
 
-    # Priority 3: Default (Issue #1372: AI + ace 谐音端口)
+    # Priority 3: Default port
     return 19888
 
 


### PR DESCRIPTION
移除代码和文档中的端口谐音描述，保持简洁。

影响 6 个文件，7 处修改。