### PR TITLE
fix: 改进 E2E 测试中 ForceChangePasswordModal 处理逻辑 (Issue #1388)

### DIFF
--- a/frontend/e2e/helpers.ts
+++ b/frontend/e2e/helpers.ts
@@ -31,14 +31,19 @@ export async function login(page: Page, username = 'admin', password = 'admin123
   }
 
   // Handle ForceChangePasswordModal if it appears (for users with must_change_password=true)
-  const skipButton = page.locator('button:has-text("Skip"), button:has-text("跳过")');
-  // Use waitFor with short timeout to avoid race condition (isVisible is non-waiting)
-  const modalVisible = await skipButton.waitFor({ state: 'visible', timeout: 2000 }).then(() => true).catch(() => false);
+  // The modal is loaded lazily via Suspense, so it may take time to appear in CI environments
+  const modalDialog = page.locator('[role="dialog"][aria-modal="true"]');
+  const skipButton = modalDialog.locator('button:has-text("Skip"), button:has-text("跳过")');
+
+  // Wait for modal to appear (up to 5s for CI environments), then handle it
+  const modalVisible = await modalDialog.waitFor({ state: 'visible', timeout: 5000 }).then(() => true).catch(() => false);
   if (modalVisible) {
+    // Wait for Skip button to be visible and clickable
+    await skipButton.waitFor({ state: 'visible', timeout: 3000 }).catch(() => {});
     // Click Skip button to dismiss the modal
-    await skipButton.click();
-    // Wait for modal to disappear
-    await page.locator('[role="dialog"]').waitFor({ state: 'hidden', timeout: 5000 }).catch(() => {});
+    await skipButton.click({ force: true });
+    // Wait for modal to disappear completely
+    await modalDialog.waitFor({ state: 'hidden', timeout: 5000 }).catch(() => {});
   }
 
   // Wait for page to be ready
@@ -50,6 +55,18 @@ export async function login(page: Page, username = 'admin', password = 'admin123
  */
 export async function waitForApp(page: Page) {
   await page.waitForLoadState('networkidle');
+
+  // Fallback: handle ForceChangePasswordModal if login helper missed it
+  const modalDialog = page.locator('[role="dialog"][aria-modal="true"]');
+  const isModalVisible = await modalDialog.isVisible().catch(() => false);
+  if (isModalVisible) {
+    const skipButton = modalDialog.locator('button:has-text("Skip"), button:has-text("跳过")');
+    if (await skipButton.isVisible().catch(() => false)) {
+      await skipButton.click({ force: true });
+      await modalDialog.waitFor({ state: 'hidden', timeout: 5000 }).catch(() => {});
+    }
+  }
+
   // Wait for main content to be visible
   await page.locator('main').waitFor({ state: 'visible', timeout: 10000 }).catch(() => {});
 }


### PR DESCRIPTION
## 问题

PR #1390 的修复不完整，Frontend CI 仍然失败（55 个测试）。

根本原因：modal 处理存在 race condition。

### 错误日志
```
TimeoutError: locator.click: Timeout 10000ms exceeded.
<div class="alert alert-warning mb-3">…</div> from <div role="dialog" aria-modal="true" class="modal fade show d-block">…</div> subtree intercepts pointer events
```

ForceChangePasswordModal 阻挡了元素点击，说明处理代码没有正确执行。

## 根因分析

1. Modal 通过 `Suspense` + `lazy` 异步加载
2. 原代码等待 2 秒检测 Skip 按钮
3. 在 CI 环境中，modal 加载可能需要超过 2 秒
4. 超时后 `catch(() => false)` 返回，跳过 modal 处理
5. Modal 仍然显示，阻挡后续测试操作

## 改进

1. **更精确的 locator**：先定位 modal dialog (`[role="dialog"][aria-modal="true"]`)，再在其中找 Skip 按钮
2. **增加等待时间**：从 2 秒增加到 5 秒
3. **等待按钮可见**：在点击前额外等待 Skip 按钮可见（3 秒）
4. **force: true 点击**：避免其他元素阻挡
5. **waitForApp 备用处理**：如果 login helper 漏掉，waitForApp 会再次尝试处理

## 测试验证

等待 Frontend CI 结果。

## 关联 Issue

Continues #1390, fixes #1388