### PR TITLE
fix: 修复通过 Issue 编号指定已存在 Issue 时里程碑类型错误显示为 issue_created (Issue #1407)

### DIFF
--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -1717,9 +1717,9 @@ class AutonomousOrchestrator:
                     )
                 self._create_milestone(
                     phase="preparation",
-                    milestone_type="issue_created",
+                    milestone_type="issue_linked",
                     status="completed",
-                    title=f"Read issue #{issue_number}",
+                    title=f"Linked to issue #{issue_number}",
                     github_issue_number=issue_number,
                     result_summary=issue_data.get("title", ""),
                 )


### PR DESCRIPTION
## 问题描述

当用户通过 Issue 编号（如 `1329`）指定一个**已存在**的 Issue 启动自主开发任务时，里程碑类型错误设置为 `issue_created`，导致前端显示"已创建 Issue"，而实际上系统只是读取了该 Issue，并未创建新 Issue。

## 修复内容

将 `orchestrator.py` 中读取已存在 Issue 时的里程碑类型从 `issue_created` 改为 `issue_linked`：

- `milestone_type="issue_created"` → `milestone_type="issue_linked"`
- `title="Read issue #{issue_number}"` → `title="Linked to issue #{issue_number}"`

## 修改位置

`app/modules/workspace/autonomous/orchestrator.py` 第 1719-1721 行

## 修复后效果

| 输入方式 | milestone_type | 前端显示 |
|---------|---------------|---------|
| Issue URL | `issue_linked` | "关联到 Issue #N" ✓ |
| Issue 编号 | `issue_linked` | "关联到 Issue #N" ✓ (修复) |
| 新建 Issue | `issue_created` | "已创建 Issue #N" ✓ |

## 关联 Issue

Fixes #1407

🤖 Generated with Qwen Code (7-shotted by Qwen-Coder)