### PR TITLE
fix(install): workspace.enabled 配置缺失和多用户模式 root 权限检查

### DIFF
--- a/scripts/install-central/package-method/install.sh
+++ b/scripts/install-central/package-method/install.sh
@@ -1251,7 +1251,7 @@ update_config_workspace() {
     if command -v python3 &>/dev/null; then
         # Use environment variables to pass values safely (avoids special character issues in heredoc)
         export _CONFIG_FILE="$config_file"
-        export _WS_ENABLED="$WORKSPACE_MULTI_USER_MODE"
+        export _WS_ENABLED="$WORKSPACE_ENABLED"
         export _WS_MULTI_USER="$WORKSPACE_MULTI_USER_MODE"
         export _WS_PORT_START="$WORKSPACE_PORT_RANGE_START"
         export _WS_PORT_END="$WORKSPACE_PORT_RANGE_END"
@@ -1367,6 +1367,11 @@ with open('$config_file', 'w') as f:
 # Systemd service settings
 SERVICE_PORT=""       # Web server port (will be read from config or use default)
 SERVICE_HOST="0.0.0.0" # Web server host
+
+# Workspace settings
+# WORKSPACE_ENABLED: workspace 功能是否启用（独立于 multi_user_mode）
+# multi_user_mode 只控制是否为每个用户启动独立进程，不影响 workspace 功能启用
+WORKSPACE_ENABLED="true"
 
 # Multi-user workspace mode settings
 WORKSPACE_MULTI_USER_MODE="true"
@@ -3045,6 +3050,21 @@ install_local() {
     # Configure sudoers for multi-user workspace mode
     # sudoers run_user should match the systemd service's actual running user
     if [ "$WORKSPACE_MULTI_USER_MODE" = "true" ]; then
+        # Check root privileges - required for sudoers configuration
+        if [ "$(id -u)" -ne 0 ]; then
+            print_error "Root privileges required for multi-user workspace mode"
+            print_error "Multi-user mode requires sudoers configuration to allow the service account to:"
+            print_error "  - Create system users (useradd)"
+            print_error "  - Change file ownership (chown)"
+            print_error "  - Run qwen-code-webui as other users"
+            print_info ""
+            print_info "Please run the installation script with sudo or as root:"
+            print_info "  sudo bash install.sh"
+            print_info ""
+            print_info "Or disable multi-user mode to install without root privileges."
+            exit 1
+        fi
+
         # Stop existing qwen-code-webui systemd service first
         stop_webui_systemd_service
 


### PR DESCRIPTION
## Issue #1406 修复

### 问题描述

源码部署后工作区显示"未配置"，启动工作区失败。

### 根因分析

**问题一：workspace.enabled 配置缺失**

`update_config_workspace()` 函数错误地将 `_WS_ENABLED` 设置为 `$WORKSPACE_MULTI_USER_MODE`，混淆了：
- `enabled`：workspace 功能是否启用
- `multi_user_mode`：是否为每个用户启动独立进程

**问题二：sudoers 配置缺失 root 权限检查**

安装脚本允许以非 root 用户运行，`configure_sudoers` 函数失败后只打印警告继续安装，导致：
- sudoers 文件未创建
- 多用户模式启动工作区时 `sudo useradd` 需要密码
- 服务进程无法交互输入密码，启动失败

### 修复方案

1. **引入 WORKSPACE_ENABLED 变量**
   - 添加独立的 `WORKSPACE_ENABLED="true"` 变量
   - 修改 `_WS_ENABLED="$WORKSPACE_ENABLED"`，与 `multi_user_mode` 分离

2. **添加 root 权限检查**
   - 在调用 `configure_sudoers` 前检查 root 权限
   - 无权限时报错终止，提示用户以 sudo 运行

### 影响范围

- package-method 源码部署
- 多用户模式 workspace 功能

### 测试

需要在干净环境中测试安装脚本的完整流程。