### PR TITLE
fix: 深色模式下工作区Tab Bar颜色冲突 (Issue #1410)

### DIFF
--- a/frontend/src/components/features/Workspace.tsx
+++ b/frontend/src/components/features/Workspace.tsx
@@ -1857,7 +1857,7 @@ export const Workspace: React.FC = () => {
         <div
           className={cn(
             'workspace-tabs d-flex align-items-center border-bottom',
-            workspaceFullscreen ? 'bg-white fullscreen-tabs' : 'bg-light'
+            workspaceFullscreen ? 'bg-white dark:bg-slate-800 fullscreen-tabs' : 'bg-light dark:bg-slate-900'
           )}
           style={{ minHeight: '40px' }}
         >
@@ -1878,7 +1878,7 @@ export const Workspace: React.FC = () => {
                   className={cn(
                     'workspace-tab d-flex align-items-center px-2 py-2 cursor-pointer',
                     'border-end position-relative',
-                    activeTabId === tab.id && 'active bg-white',
+                    activeTabId === tab.id && 'active bg-white dark:bg-slate-800',
                     draggedTabId === tab.id && 'dragging',
                     dragOverTabId === tab.id && 'drag-over'
                   )}
@@ -2250,6 +2250,9 @@ export const Workspace: React.FC = () => {
         }
         .workspace-tab:hover {
           background-color: rgba(0, 0, 0, 0.05);
+        }
+        [data-theme='dark'] .workspace-tab:hover {
+          background-color: rgba(255, 255, 255, 0.05);
         }
         .workspace-tab.active {
           border-bottom: 2px solid var(--primary, #0d6efd);

--- a/frontend/src/components/features/Workspace.tsx
+++ b/frontend/src/components/features/Workspace.tsx
@@ -1857,7 +1857,9 @@ export const Workspace: React.FC = () => {
         <div
           className={cn(
             'workspace-tabs d-flex align-items-center border-bottom',
-            workspaceFullscreen ? 'bg-white dark:bg-slate-800 fullscreen-tabs' : 'bg-light dark:bg-slate-900'
+            workspaceFullscreen
+              ? 'bg-white dark:bg-slate-800 fullscreen-tabs'
+              : 'bg-light dark:bg-slate-900'
           )}
           style={{ minHeight: '40px' }}
         >


### PR DESCRIPTION
## 问题描述

在全局深色模式下，工作区会话窗口的Tab Bar出现颜色冲突：
- **背景颜色**：白色（应为深色）
- **文字颜色**：白色（跟随全局深色模式）
- **结果**：白色背景叠加白色文字，导致内容不可见

## 修复方案

使用 Tailwind `dark:` 前缀为深色模式添加适配样式：

1. **Tab Bar背景**：`bg-white dark:bg-slate-800` / `bg-light dark:bg-slate-900`
2. **Active Tab背景**：`bg-white dark:bg-slate-800`
3. **hover样式**：添加 `[data-theme='dark'] .workspace-tab:hover` 样式

## 修改文件

- `frontend/src/components/features/Workspace.tsx`

## 验证

已在 node237 (Package 版) 验证修复效果。

Fixes #1410