### PR TITLE
fix(install): Python布尔值大小写导致WORKSPACE_MULTI_USER_MODE条件判断失败

### DIFF
--- a/scripts/install-central/package-method/install.sh
+++ b/scripts/install-central/package-method/install.sh
@@ -2572,7 +2572,8 @@ detect_and_load_local_upgrade() {
         EXISTING_CONFIG_PATH="$config_file"
 
         # Read WORKSPACE_MULTI_USER_MODE from existing config (upgrade should respect original setting)
-        local multi_user=$(python3 -c "import json; c=json.load(open('$config_file')); print(c.get('workspace', {}).get('multi_user_mode', 'true'))" 2>/dev/null)
+        # Python prints True/False (capitalized), but shell expects true/false (lowercase)
+        local multi_user=$(python3 -c "import json; c=json.load(open('$config_file')); print(c.get('workspace', {}).get('multi_user_mode', 'true'))" 2>/dev/null | tr '[:upper:]' '[:lower:]')
         if [ -n "$multi_user" ]; then
             WORKSPACE_MULTI_USER_MODE="$multi_user"
             print_info "Read WORKSPACE_MULTI_USER_MODE=$WORKSPACE_MULTI_USER_MODE from existing config"


### PR DESCRIPTION
## 问题描述

Issue #1415: 升级安装后，即使 config.json 中 `workspace.multi_user_mode=true`，sudoers 配置文件 `/etc/sudoers.d/open-ace-webui` 未生成。

## 根因分析

代码位置: `scripts/install-central/package-method/install.sh` 第 2575 行

Python 对布尔值 `print()` 输出 `True`/`False`（首字母大写），但 shell 脚本中的字符串比较 `[ "$WORKSPACE_MULTI_USER_MODE" = "true" ]` 期望 `true`/`false`（全小写）。

结果: 变量值为 `True`，但条件检查 `"True" = "true"` 不匹配，导致 sudoers 配置块（第 3047 行）被跳过。

## 修复方案

在读取 Python 输出时转换为小写：
```bash
local multi_user=$(python3 -c "..." | tr \"[:upper:]\" \"[:lower:]\")
```

## 测试

- Shell 语法检查通过: `bash -n scripts/install-central/package-method/install.sh`

## 相关 Issue

- Fixes #1415
- Related #1395 (AI自主开发本地工作区权限隔离问题)
- Related #1400 (已合并的 sudoers CLI 工具规则，但此问题导致规则未生效)
- Related #1409 (未合并的 root 权限检查，此问题是另一层原因)