### PR TITLE
docs: 添加发布流程和节奏规范

### DIFF
--- a/docs/REPOSITORY_SETUP.md
+++ b/docs/REPOSITORY_SETUP.md
@@ -19,7 +19,50 @@ Use this checklist for GitHub settings that cannot be fully configured from file
 
 ## Releases
 
-- Publish releases from Git tags such as `v1.0.1`.
+### Release Process
+
+Use `scripts/release.sh` to prepare and publish a new release:
+
+```bash
+# Preview changes (dry-run)
+./scripts/release.sh --version 1.2.0 --dry-run
+
+# Execute release
+./scripts/release.sh --version 1.2.0
+```
+
+The script automates:
+1. Validate version format (SemVer: X.Y.Z)
+2. Update `pyproject.toml` version
+3. Update `CHANGELOG.md` (move [Unreleased] to new version section)
+4. Create git commit and tag
+5. Push tag to origin
+
+After tag is pushed, create GitHub Release with CHANGELOG content:
+```bash
+gh release create v1.2.0 --title "Open ACE v1.2.0" --notes-file release_notes.md --latest
+```
+
+### Release Cadence
+
+| Version Type | Version Bump | Trigger Conditions | Frequency |
+|--------------|-------------|-------------------|-----------|
+| **Major** | 2.0.0 | Architecture refactor, breaking API changes | 1-2 per year |
+| **Minor** | 1.1.0 → 1.2.0 | New features, significant improvements | Monthly (1st Tuesday) |
+| **Patch** | 1.1.1 | Bug fixes, security patches | As needed (weekly or on-demand) |
+
+**Patch Release Guidelines:**
+- Accumulate ≥3 bug fixes before releasing patch
+- Security fixes can be released immediately
+- Wait ≥7 days between patch releases to avoid excessive frequency
+
+### Release Checklist
+
+- Publish releases from Git tags such as `v1.1.0`.
+- Use `scripts/generate_changelog.py` to collect commits since last release:
+  ```bash
+  python3 scripts/generate_changelog.py --since v1.1.0
+  ```
 - Attach Docker/deployment notes and a short upgrade guide to each release.
 - Keep `CHANGELOG.md` aligned with the latest release.
 - Configure `PYPI_API_TOKEN` only after confirming the intended PyPI project and package ownership.


### PR DESCRIPTION
## Changes

扩展 `docs/REPOSITORY_SETUP.md` 的 Releases 部分，添加：

- **Release Process** - 使用 `scripts/release.sh` 的完整流程
- **Release Cadence** - 版本节奏规则（Major/Minor/Patch）
- **Release Checklist** - 发布检查清单

### Release Cadence Summary

| Version Type | Frequency |
|--------------|-----------|
| Major | 1-2 per year |
| Minor | Monthly (1st Tuesday) |
| Patch | As needed |

## Related

- v1.1.0 release process (#1403)
- `scripts/release.sh` creation