### PR TITLE
fix(autonomous): prune lost worktrees before creation (Issue #1442)

### DIFF
--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -1747,6 +1747,10 @@ class AutonomousOrchestrator:
                         f"{project_path}/../{branch_name.replace('/', '-')}"
                     )
 
+                    # Clean up prunable worktrees (directory lost but registered)
+                    # This happens when worktree dir was deleted externally (Issue #1442)
+                    gh._run_git(["worktree", "prune"])
+
                     # Check and clean up residual worktree directory (Issue #1442)
                     if Path(worktree_path).exists():
                         git_file = Path(worktree_path) / ".git"


### PR DESCRIPTION
## 问题

扩展方案A，处理 "prunable worktree" 场景：
```
git worktree add failed (exit 128):
致命错误：'/home/<user>/auto-dev-eefdf3cd' 是一个丢失但已经注册的工作区
```

## 根因

worktree 目录被外部删除（如手动 rm），但 git 的 worktree 注册信息还在。

## 修复

在检查目录存在前，先执行 `git worktree prune` 清理 prunable worktrees。

Fixes #1442