### PR TITLE
fix(autonomous): use sudo wrapper for worktree cleanup in multi-user mode (Issue #1442)

### DIFF
--- a/app/modules/workspace/autonomous/agent_runner.py
+++ b/app/modules/workspace/autonomous/agent_runner.py
@@ -1182,7 +1182,16 @@ class AutonomousAgentRunner:
 
         # Expand project path
         project_path = os.path.expanduser(project_path)
-        Path(project_path).mkdir(parents=True, exist_ok=True)
+        # Create project directory with proper user permission isolation
+        # (Issue #1438: Use sudo wrapper when system_account is set)
+        if system_account:
+            subprocess.run(
+                ["sudo", "-u", system_account, "mkdir", "-p", project_path],
+                check=True,
+                capture_output=True,
+            )
+        else:
+            Path(project_path).mkdir(parents=True, exist_ok=True)
 
         # Protocol dispatch: different CLI tools speak different stdin protocols.
         # The generic _LocalSession path below assumes Claude SDK stream-json,

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -1773,8 +1773,14 @@ class AutonomousOrchestrator:
                         if system_account:
                             # Use sudo to check .git file
                             result = subprocess.run(
-                                ["sudo", "-u", system_account, "test", "-f",
-                                 os.path.join(worktree_path, ".git")],
+                                [
+                                    "sudo",
+                                    "-u",
+                                    system_account,
+                                    "test",
+                                    "-f",
+                                    os.path.join(worktree_path, ".git"),
+                                ],
                                 capture_output=True,
                             )
                             git_file_exists = result.returncode == 0

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -1747,6 +1747,10 @@ class AutonomousOrchestrator:
                         f"{project_path}/../{branch_name.replace('/', '-')}"
                     )
 
+                    # Clean up prunable worktrees (directory lost but registered)
+                    # This happens when worktree dir was deleted externally (Issue #1442)
+                    gh._run_git(["worktree", "prune"])
+
                     # Check and clean up residual worktree directory (Issue #1442)
                     if Path(worktree_path).exists():
                         git_file = Path(worktree_path) / ".git"

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -12,6 +12,7 @@ import logging
 import os
 import re
 import shutil
+import subprocess
 import threading
 import time
 import uuid
@@ -1752,23 +1753,61 @@ class AutonomousOrchestrator:
                     gh._run_git(["worktree", "prune"])
 
                     # Check and clean up residual worktree directory (Issue #1442)
-                    if Path(worktree_path).exists():
+                    # Use sudo wrapper for permission isolation - Path.exists() fails
+                    # when openace cannot access user's private directory (700 permissions)
+                    system_account = wf.get("system_account")
+                    dir_exists = False
+                    if system_account:
+                        # Use sudo to check directory existence
+                        result = subprocess.run(
+                            ["sudo", "-u", system_account, "test", "-d", worktree_path],
+                            capture_output=True,
+                        )
+                        dir_exists = result.returncode == 0
+                    else:
+                        dir_exists = Path(worktree_path).exists()
+
+                    if dir_exists:
                         git_file = Path(worktree_path) / ".git"
-                        if git_file.exists() and git_file.is_file():
-                            # Valid worktree - remove via git
+                        git_file_exists = False
+                        if system_account:
+                            # Use sudo to check .git file
+                            result = subprocess.run(
+                                ["sudo", "-u", system_account, "test", "-f",
+                                 os.path.join(worktree_path, ".git")],
+                                capture_output=True,
+                            )
+                            git_file_exists = result.returncode == 0
+                        else:
+                            git_file_exists = git_file.exists() and git_file.is_file()
+
+                        if git_file_exists:
+                            # Valid worktree - remove via git (git handles sudo internally)
                             try:
                                 gh.remove_worktree(worktree_path)
                                 logger.info("Removed residual worktree at %s", worktree_path)
                             except GitHubOpsError:
-                                # Fallback to force delete
-                                shutil.rmtree(worktree_path)
+                                # Fallback to sudo rm
+                                if system_account:
+                                    subprocess.run(
+                                        ["sudo", "-u", system_account, "rm", "-rf", worktree_path],
+                                        check=True,
+                                    )
+                                else:
+                                    shutil.rmtree(worktree_path)
                                 logger.info(
                                     "Force removed worktree directory at %s",
                                     worktree_path,
                                 )
                         else:
-                            # Not a worktree, just a directory
-                            shutil.rmtree(worktree_path)
+                            # Not a worktree, just a directory - use sudo rm
+                            if system_account:
+                                subprocess.run(
+                                    ["sudo", "-u", system_account, "rm", "-rf", worktree_path],
+                                    check=True,
+                                )
+                            else:
+                                shutil.rmtree(worktree_path)
                             logger.info("Removed residual directory at %s", worktree_path)
 
                     wt_data = gh.create_worktree(


### PR DESCRIPTION
## 问题背景

Issue #1442: worktree残留导致重试失败

之前的修复（#1444）使用了 `Path.exists()` 检查目录是否存在，但在多用户权限隔离环境下失效。

## 根因分析

<user>主目录权限为700，openace服务进程用户无法执行 `Path(worktree_path).exists()` 检查，导致修复逻辑无法检测到残留目录。

## 修复内容

### orchestrator.py
- 使用 `sudo -u system_account test -d` 检查目录存在
- 使用 `sudo -u system_account test -f` 检查.git文件
- 使用 `sudo -u system_account rm -rf` 清理残留目录

### agent_runner.py (Issue #1438)
- 创建项目目录时使用 `sudo -u system_account mkdir -p`

## 测试环境

- 服务器: 192.168.x.xxx
- 用户: <username>（<user>）
- 场景: AI自主开发重试任务

## 关联Issue

- Fixes #1442
- Related #1438