### PR TITLE
fix(tests/ui): 移除错加的 @pytest.mark.asyncio，恢复 async 测试收集 (回归 #1446)

### DIFF
--- a/tests/ui/test_create_flow.py
+++ b/tests/ui/test_create_flow.py
@@ -7,7 +7,6 @@ import asyncio
 import os
 import time
 
-import pytest
 from playwright.async_api import async_playwright
 
 BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
@@ -22,7 +21,6 @@ USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 
 
-@pytest.mark.asyncio
 async def test_create_flow(ui_screenshot_dir):
     global SCREENSHOT_DIR
     SCREENSHOT_DIR = ui_screenshot_dir

--- a/tests/ui/test_dashboard_first_load.py
+++ b/tests/ui/test_dashboard_first_load.py
@@ -14,7 +14,6 @@ import time
 project_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 sys.path.insert(0, project_root)
 
-import pytest
 from playwright.async_api import async_playwright
 
 BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
@@ -28,7 +27,6 @@ SCREENSHOT_DIR = os.path.join(
 )
 
 
-@pytest.mark.asyncio
 async def test_dashboard_first_load(ui_screenshot_dir):
     """Test dashboard first load with detailed timing."""
     global SCREENSHOT_DIR


### PR DESCRIPTION
## 修复 #1446 引入的回归

### 问题

PR #1446 给 `test_create_flow.py` 和 `test_dashboard_first_load.py` 加了 `@pytest.mark.asyncio`，声称是为了修"async 测试静默不执行"。但实测发现这个判断是错的，且 marker **引入了回归**。

### 根因（实测验证）

在本仓库环境（**pytest-asyncio 1.3.0 + pytest 9.0.3**）下，async 测试的收集行为反直觉：

| 写法 | 收集结果 | 是否执行 |
|---|---|---|
| `async def test_x()` **不加** marker | `<Function>` | ✅ 正常执行 |
| `async def test_x()` **加了** `@pytest.mark.asyncio` | `<Coroutine>` | ❌ 不执行 |

pytest-asyncio 1.3.0 会自动识别无 marker 的 async 测试为 Function 正常执行；加了 marker 反而被收集成裸 Coroutine。**#1446 把这两个原本能执行（`<Function>`）的测试变成了不执行的 `<Coroutine>`** —— 正是评论里担忧的"假绿"，但因果搞反了。

### 验证

- 当前 main（带 marker）：两者为 `<Coroutine>`
- 本 PR（移除 marker）：两者恢复为 `<Function>`
- 已用最小项目复现确认工具链行为

### 修改

每个文件 -2 行：移除 `@pytest.mark.asyncio` + 因未使用而移除的 `import pytest`。**保留** #1446 的其余正确修复（消除模块级 makedirs、注入 `ui_screenshot_dir` fixture）。

### 影响 #1448

#1448（"17 个 async 测试缺 marker 导致假绿"）前提**已证伪**：不加 marker 即为 `<Function>`，并非假绿。#1448 将更正并关闭。