### PR TITLE
fix(tests/ui): 函数级 makedirs 改用 ui_screenshot_dir fixture

### DIFF
--- a/tests/ui/test_admin_default_mode.py
+++ b/tests/ui/test_admin_default_mode.py
@@ -18,8 +18,10 @@ PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "screenshots", "ui")
 
 
-async def test_admin_default_mode():
+async def test_admin_default_mode(ui_screenshot_dir):
     """Test admin user lands on Manage mode after login."""
+    global SCREENSHOT_DIR
+    SCREENSHOT_DIR = ui_screenshot_dir
     async with async_playwright() as p:
         browser = await p.chromium.launch(headless=True)
         context = await browser.new_context(viewport={"width": 1280, "height": 900})
@@ -53,8 +55,10 @@ async def test_admin_default_mode():
         }
 
 
-async def test_normal_user_default_mode():
+async def test_normal_user_default_mode(ui_screenshot_dir):
     """Test normal user lands on Work mode after login."""
+    global SCREENSHOT_DIR
+    SCREENSHOT_DIR = ui_screenshot_dir
     async with async_playwright() as p:
         browser = await p.chromium.launch(headless=True)
         context = await browser.new_context(viewport={"width": 1280, "height": 900})

--- a/tests/ui/test_alert_icon.py
+++ b/tests/ui/test_alert_icon.py
@@ -18,8 +18,10 @@ HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 SCREENSHOT_DIR = "screenshots/issues/alert-icon"
 
 
-async def test_alert_icon():
+async def test_alert_icon(ui_screenshot_dir):
     """Test alert management page icon display"""
+    global SCREENSHOT_DIR
+    SCREENSHOT_DIR = ui_screenshot_dir
     os.makedirs(SCREENSHOT_DIR, exist_ok=True)
 
     async with async_playwright() as p:

--- a/tests/ui/test_auto_fullscreen_on_chat.py
+++ b/tests/ui/test_auto_fullscreen_on_chat.py
@@ -27,8 +27,10 @@ HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 SCREENSHOT_DIR = "screenshots/ui"
 
 
-async def test_auto_fullscreen_on_chat():
+async def test_auto_fullscreen_on_chat(ui_screenshot_dir):
     """Test auto fullscreen when entering chat page in iframe."""
+    global SCREENSHOT_DIR
+    SCREENSHOT_DIR = ui_screenshot_dir
     async with async_playwright() as p:
         browser = await p.chromium.launch(headless=HEADLESS)
         context = await browser.new_context(viewport={"width": 1400, "height": 900})

--- a/tests/ui/test_clear_guide.py
+++ b/tests/ui/test_clear_guide.py
@@ -30,7 +30,9 @@ def log_message(msg):
         f.write(log_line + "\n")
 
 
-async def test_clear_guide():
+async def test_clear_guide(ui_screenshot_dir):
+    global SCREENSHOT_DIR
+    SCREENSHOT_DIR = ui_screenshot_dir
     os.makedirs(SCREENSHOT_DIR, exist_ok=True)
 
     with open(LOG_FILE, "w") as f:

--- a/tests/ui/test_click_debug.py
+++ b/tests/ui/test_click_debug.py
@@ -16,7 +16,9 @@ SCREENSHOT_DIR = os.path.join(
 )
 
 
-async def test_click_debug():
+async def test_click_debug(ui_screenshot_dir):
+    global SCREENSHOT_DIR
+    SCREENSHOT_DIR = ui_screenshot_dir
     os.makedirs(SCREENSHOT_DIR, exist_ok=True)
 
     async with async_playwright() as p:

--- a/tests/ui/test_create_button_full.py
+++ b/tests/ui/test_create_button_full.py
@@ -22,7 +22,9 @@ USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 
 
-async def test_create_button_full():
+async def test_create_button_full(ui_screenshot_dir):
+    global SCREENSHOT_DIR
+    SCREENSHOT_DIR = ui_screenshot_dir
     os.makedirs(SCREENSHOT_DIR, exist_ok=True)
 
     async with async_playwright() as p:

--- a/tests/ui/test_create_debug.py
+++ b/tests/ui/test_create_debug.py
@@ -22,7 +22,9 @@ SCREENSHOT_DIR = os.path.join(
 )
 
 
-def test_create_debug():
+def test_create_debug(ui_screenshot_dir):
+    global SCREENSHOT_DIR
+    SCREENSHOT_DIR = ui_screenshot_dir
     print("=" * 70)
     print("Create Project Button Debug Test")
     print("=" * 70)

--- a/tests/ui/test_create_direct.py
+++ b/tests/ui/test_create_direct.py
@@ -24,7 +24,9 @@ SCREENSHOT_DIR = os.path.join(
 )
 
 
-def test_create_direct():
+def test_create_direct(ui_screenshot_dir):
+    global SCREENSHOT_DIR
+    SCREENSHOT_DIR = ui_screenshot_dir
     print("=" * 70)
     print("Create Project Button Direct Debug Test")
     print("=" * 70)

--- a/tests/ui/test_create_project_button.py
+++ b/tests/ui/test_create_project_button.py
@@ -27,7 +27,9 @@ SCREENSHOT_DIR = os.path.join(
 )
 
 
-def test_nonadmin_create_project():
+def test_nonadmin_create_project(ui_screenshot_dir):
+    global SCREENSHOT_DIR
+    SCREENSHOT_DIR = ui_screenshot_dir
     print("=" * 70)
     print("Non-admin user - Create Project Button Test")
     print("=" * 70)

--- a/tests/ui/test_deep_debug.py
+++ b/tests/ui/test_deep_debug.py
@@ -21,7 +21,9 @@ SCREENSHOT_DIR = os.path.join(
 )
 
 
-def test_deep_debug():
+def test_deep_debug(ui_screenshot_dir):
+    global SCREENSHOT_DIR
+    SCREENSHOT_DIR = ui_screenshot_dir
     print("=" * 70)
     print("Deep Debug: Create Button Analysis")
     print("=" * 70)

--- a/tests/ui/test_iframe_add_project.py
+++ b/tests/ui/test_iframe_add_project.py
@@ -29,7 +29,9 @@ SCREENSHOT_DIR = os.path.join(
 )
 
 
-def test_iframe_add_project_browse():
+def test_iframe_add_project_browse(ui_screenshot_dir):
+    global SCREENSHOT_DIR
+    SCREENSHOT_DIR = ui_screenshot_dir
     print("=" * 60)
     print("iframe Add Project - Browse Directory Test")
     print("=" * 60)

--- a/tests/ui/test_iframe_debug.py
+++ b/tests/ui/test_iframe_debug.py
@@ -21,7 +21,9 @@ USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 
 
-async def test_iframe_debug():
+async def test_iframe_debug(ui_screenshot_dir):
+    global SCREENSHOT_DIR
+    SCREENSHOT_DIR = ui_screenshot_dir
     os.makedirs(SCREENSHOT_DIR, exist_ok=True)
 
     async with async_playwright() as p:

--- a/tests/ui/test_interactive_create.py
+++ b/tests/ui/test_interactive_create.py
@@ -34,7 +34,9 @@ def log_message(msg):
         f.write(log_line + "\n")
 
 
-async def test_interactive():
+async def test_interactive(ui_screenshot_dir):
+    global SCREENSHOT_DIR
+    SCREENSHOT_DIR = ui_screenshot_dir
     os.makedirs(SCREENSHOT_DIR, exist_ok=True)
 
     # 清空日志文件

--- a/tests/ui/test_project_management_duration.py
+++ b/tests/ui/test_project_management_duration.py
@@ -49,8 +49,10 @@ def save_screenshot(page, name):
     return path
 
 
-def test_project_management_page():
+def test_project_management_page(ui_screenshot_dir):
     """Test Project Management page is accessible."""
+    global SCREENSHOT_DIR
+    SCREENSHOT_DIR = ui_screenshot_dir
     print("\n" + "=" * 60)
     print("Test: Project Management Page")
     print("=" * 60)
@@ -122,8 +124,10 @@ def test_project_management_page():
     return all_passed
 
 
-def test_session_tracking_api():
+def test_session_tracking_api(ui_screenshot_dir):
     """Test session creation and completion API."""
+    global SCREENSHOT_DIR
+    SCREENSHOT_DIR = ui_screenshot_dir
     print("\n" + "=" * 60)
     print("Test: Session Tracking API")
     print("=" * 60)

--- a/tests/ui/test_project_management_full.py
+++ b/tests/ui/test_project_management_full.py
@@ -42,8 +42,10 @@ def save_screenshot(page, name):
     return path
 
 
-def test_project_management():
+def test_project_management(ui_screenshot_dir):
     """Test Project Management page with all features."""
+    global SCREENSHOT_DIR
+    SCREENSHOT_DIR = ui_screenshot_dir
     print("\n" + "=" * 60)
     print("Test: Project Management Full Feature")
     print("=" * 60)

--- a/tests/ui/test_quota_enter_save.py
+++ b/tests/ui/test_quota_enter_save.py
@@ -33,8 +33,10 @@ def take_screenshot(page, name):
     print(f"  Saved: {path}")
 
 
-def test_quota_enter_save():
+def test_quota_enter_save(ui_screenshot_dir):
     """Test Enter key saves quota in edit quota dialog"""
+    global SCREENSHOT_DIR
+    SCREENSHOT_DIR = ui_screenshot_dir
 
     with sync_playwright() as p:
         # Launch browser

--- a/tests/ui/test_quota_token_unit.py
+++ b/tests/ui/test_quota_token_unit.py
@@ -26,8 +26,10 @@ def take_screenshot(page, name):
     print(f"  Saved: {path}")
 
 
-def test_quota_token_unit():
+def test_quota_token_unit(ui_screenshot_dir):
     """Test that token quota inputs display values in M (millions) unit"""
+    global SCREENSHOT_DIR
+    SCREENSHOT_DIR = ui_screenshot_dir
 
     with sync_playwright() as p:
         # Launch browser

--- a/tests/ui/test_security_page.py
+++ b/tests/ui/test_security_page.py
@@ -22,8 +22,10 @@ SCREENSHOT_DIR = os.path.join(
 )
 
 
-def test_security_page():
+def test_security_page(ui_screenshot_dir):
     """Test Security Settings page"""
+    global SCREENSHOT_DIR
+    SCREENSHOT_DIR = ui_screenshot_dir
     results = []
 
     with sync_playwright() as p:

--- a/tests/ui/test_session_list_scroll.py
+++ b/tests/ui/test_session_list_scroll.py
@@ -34,8 +34,10 @@ SCREENSHOT_DIR = os.path.join(
 
 
 @pytest.mark.asyncio
-async def test_session_list_scroll():
+async def test_session_list_scroll(ui_screenshot_dir):
     """测试 Session List 滚动问题"""
+    global SCREENSHOT_DIR
+    SCREENSHOT_DIR = ui_screenshot_dir
 
     # 确保截图目录存在
     os.makedirs(SCREENSHOT_DIR, exist_ok=True)

--- a/tests/ui/test_sessions_page.py
+++ b/tests/ui/test_sessions_page.py
@@ -43,8 +43,10 @@ def save_screenshot(page, name):
     return path
 
 
-def test_sessions_page():
+def test_sessions_page(ui_screenshot_dir):
     """测试 Sessions 页面"""
+    global SCREENSHOT_DIR
+    SCREENSHOT_DIR = ui_screenshot_dir
     print("\n" + "=" * 60)
     print("Sessions 页面 UI 测试")
     print("=" * 60)

--- a/tests/ui/test_tab_focus_input.py
+++ b/tests/ui/test_tab_focus_input.py
@@ -26,8 +26,10 @@ HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 SCREENSHOT_DIR = "screenshots/issues/63"
 
 
-async def test_tab_focus_input():
+async def test_tab_focus_input(ui_screenshot_dir):
     """Test tab focus input after switching tabs."""
+    global SCREENSHOT_DIR
+    SCREENSHOT_DIR = ui_screenshot_dir
     async with async_playwright() as p:
         browser = await p.chromium.launch(headless=HEADLESS)
         context = await browser.new_context(viewport={"width": 1400, "height": 900})

--- a/tests/ui/test_tab_keyboard_shortcut.py
+++ b/tests/ui/test_tab_keyboard_shortcut.py
@@ -26,8 +26,10 @@ HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 SCREENSHOT_DIR = "screenshots/issues/68"
 
 
-async def test_tab_keyboard_shortcut():
+async def test_tab_keyboard_shortcut(ui_screenshot_dir):
     """Test keyboard shortcut for switching tabs."""
+    global SCREENSHOT_DIR
+    SCREENSHOT_DIR = ui_screenshot_dir
     async with async_playwright() as p:
         browser = await p.chromium.launch(headless=HEADLESS)
         context = await browser.new_context(viewport={"width": 1400, "height": 900})

--- a/tests/ui/test_tool_accounts.py
+++ b/tests/ui/test_tool_accounts.py
@@ -26,8 +26,10 @@ SCREENSHOT_DIR = os.path.join(
 )
 
 
-def test_tool_accounts_dropdown():
+def test_tool_accounts_dropdown(ui_screenshot_dir):
     """测试工具账号下拉框功能"""
+    global SCREENSHOT_DIR
+    SCREENSHOT_DIR = ui_screenshot_dir
     os.makedirs(SCREENSHOT_DIR, exist_ok=True)
 
     with sync_playwright() as p:

--- a/tests/ui/test_work_page_loads.py
+++ b/tests/ui/test_work_page_loads.py
@@ -15,10 +15,13 @@ BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
+SCREENSHOT_DIR = "screenshots"
 
 
-def test_work_page_loads():
+def test_work_page_loads(ui_screenshot_dir):
     """Test that /work page loads without errors"""
+    global SCREENSHOT_DIR
+    SCREENSHOT_DIR = ui_screenshot_dir
     console_errors = []
     page_errors = []
 
@@ -54,8 +57,8 @@ def test_work_page_loads():
         page.wait_for_timeout(5000)  # Wait for React to render
 
         # Take screenshot to see what's on the page
-        os.makedirs("screenshots", exist_ok=True)
-        page.screenshot(path="screenshots/test_work_page_debug.png")
+        os.makedirs(SCREENSHOT_DIR, exist_ok=True)
+        page.screenshot(path=os.path.join(SCREENSHOT_DIR, "test_work_page_debug.png"))
         print(f"  Current URL: {page.url}")
 
         # Print errors
@@ -97,7 +100,7 @@ def test_work_page_loads():
         assert status_bar.is_visible(), "Status bar should be visible"
 
         # Take screenshot
-        page.screenshot(path="screenshots/test_work_page_loads.png")
+        page.screenshot(path=os.path.join(SCREENSHOT_DIR, "test_work_page_loads.png"))
 
         print("All checks passed!")
         print("Screenshot saved to: screenshots/test_work_page_loads.png")

--- a/tests/ui/test_work_prompts_view_all.py
+++ b/tests/ui/test_work_prompts_view_all.py
@@ -45,8 +45,10 @@ SCREENSHOT_DIR = os.path.join(
 
 
 @pytest.mark.asyncio
-async def test_work_prompts_view_all_button():
+async def test_work_prompts_view_all_button(ui_screenshot_dir):
     """Test Work Mode Prompts Tab View All Button"""
+    global SCREENSHOT_DIR
+    SCREENSHOT_DIR = ui_screenshot_dir
 
     # Ensure screenshot directory exists
     os.makedirs(os.path.join(SCREENSHOT_DIR, "view_all"), exist_ok=True)

--- a/tests/ui/test_work_right_panel_tabs.py
+++ b/tests/ui/test_work_right_panel_tabs.py
@@ -43,8 +43,10 @@ SCREENSHOT_DIR = os.path.join(
 
 
 @pytest.mark.asyncio
-async def test_work_right_panel_tabs_layout():
+async def test_work_right_panel_tabs_layout(ui_screenshot_dir):
     """Test Work Mode Right Panel Tabs Layout"""
+    global SCREENSHOT_DIR
+    SCREENSHOT_DIR = ui_screenshot_dir
 
     # Ensure screenshot directory exists
     os.makedirs(os.path.join(SCREENSHOT_DIR, "work_tabs"), exist_ok=True)

--- a/tests/ui/test_work_usage_page.py
+++ b/tests/ui/test_work_usage_page.py
@@ -27,8 +27,10 @@ SCREENSHOT_DIR = os.path.join(
 )
 
 
-def test_work_usage_page():
+def test_work_usage_page(ui_screenshot_dir):
     """测试 /work/usage 页面"""
+    global SCREENSHOT_DIR
+    SCREENSHOT_DIR = ui_screenshot_dir
     os.makedirs(SCREENSHOT_DIR, exist_ok=True)
 
     console_messages = []

--- a/tests/ui/test_workspace_fullscreen.py
+++ b/tests/ui/test_workspace_fullscreen.py
@@ -26,8 +26,10 @@ HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
 SCREENSHOT_DIR = "screenshots/issues/49"
 
 
-async def test_workspace_fullscreen():
+async def test_workspace_fullscreen(ui_screenshot_dir):
     """Test Workspace fullscreen mode functionality."""
+    global SCREENSHOT_DIR
+    SCREENSHOT_DIR = ui_screenshot_dir
     async with async_playwright() as p:
         browser = await p.chromium.launch(headless=HEADLESS)
         context = await browser.new_context()


### PR DESCRIPTION
## 修复 #1447

### 问题

`tests/ui/` 下 28 个测试文件在**函数体内**（或其调用的 helper 如 `ensure_screenshot_dir()` / `take_screenshot()` 内）执行 `os.makedirs(SCREENSHOT_DIR)`，而 `SCREENSHOT_DIR` 指向 checkout 内路径。pytest **运行**这些测试时，在只读 CI checkout 上会触发 `PermissionError`。

这是 #1446 修复的 collection error（模块级副作用）的姊妹问题：#1446 修的是 import 时的副作用，本 PR 修的是**运行时**的副作用。同类、同模式。

### 修复

复用 #1446 / #1451 已建立的 `ui_screenshot_dir` fixture 模式：
- 每个 test 函数注入 `conftest.py` 的 `ui_screenshot_dir` fixture（基于 `tmp_path`）
- 函数体内 `global SCREENSHOT_DIR; SCREENSHOT_DIR = ui_screenshot_dir`，让 helper 读到可写的临时目录
- `test_work_page_loads.py` 原用字面量 `'screenshots'`，引入 `SCREENSHOT_DIR` 变量并统一替换硬编码路径

### 范围说明

issue #1447 原列 30 个文件，实测后**实际修复 28 个**：
- `test_pm_feature.py`、`test_tab_close_last.py` **无 `test_` 函数**，pytest 不收集运行（其 makedirs 在 `run_tests` 等 helper 内，仅 `__main__` 手动运行时触发，不在 CI 范围）。保持不修改。

### 验证

- ✅ 28 文件 `py_compile` 全通过
- ✅ 只读环境 `--collect-only` 无 collection error
- ✅ 运行时验证：fixture 注入后，helper 内 makedirs 作用在可写 tmp 目录，不再 `PermissionError`
- ✅ pre-commit 全通过

### 与相关 PR 的关系

- #1446：修模块级（import 时）副作用 → 已合并
- #1451：修 #1446 错加的 asyncio marker 回归 → 已合并
- #1448：已证伪关闭（async 测试无需 marker）

Closes #1447