### PR TITLE
fix(db): singleton 锁、心跳竞态修复、SSO 内联 DDL 迁移到权威 schema (Issue #237)

### DIFF
--- a/app/modules/sso/manager.py
+++ b/app/modules/sso/manager.py
@@ -634,22 +634,12 @@ class SSOManager:
         self, state: str, code_verifier: str, provider_name: str, nonce: Optional[str] = None
     ) -> None:
         """Store authentication state for verification."""
-        # In production, use Redis with TTL
-        # For now, we'll use a simple in-memory cache or database
+        # The sso_auth_states table is created at startup from the authoritative
+        # schema files (schema_init.load_schema_from_file), so no inline DDL is
+        # needed here (Issue #237, item 4).
         try:
             with self.db.connection() as conn:
                 cursor = conn.cursor()
-                cursor.execute(
-                    """
-                    CREATE TABLE IF NOT EXISTS sso_auth_states (
-                        state TEXT PRIMARY KEY,
-                        code_verifier TEXT NOT NULL,
-                        provider_name TEXT NOT NULL,
-                        nonce TEXT,
-                        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-                    )
-                """
-                )
                 cursor.execute(
                     """
                     INSERT INTO sso_auth_states (state, code_verifier, provider_name, nonce)

--- a/app/modules/sso/manager.py
+++ b/app/modules/sso/manager.py
@@ -633,10 +633,17 @@ class SSOManager:
     def _store_auth_state(
         self, state: str, code_verifier: str, provider_name: str, nonce: Optional[str] = None
     ) -> None:
-        """Store authentication state for verification."""
-        # The sso_auth_states table is created at startup from the authoritative
-        # schema files (schema_init.load_schema_from_file), so no inline DDL is
-        # needed here (Issue #237, item 4).
+        """Store authentication state for verification.
+
+        Requires the ``sso_auth_states`` table to already exist. In production it
+        is created at startup from the authoritative schema files via
+        ``schema_init.load_schema_from_file()`` (and by the
+        ``20260703_002_add_sso_auth_states`` migration for pure-Alembic
+        upgrades). Tests that exercise this path must run ``ensure_all_tables()``
+        or ``get_ddl_statements()`` first — otherwise the INSERT below fails and
+        is swallowed by the broad except, surfacing as a downstream SSO failure
+        instead of a clear error (Issue #237 item 4, review note).
+        """
         try:
             with self.db.connection() as conn:
                 cursor = conn.cursor()

--- a/app/modules/workspace/api_key_proxy.py
+++ b/app/modules/workspace/api_key_proxy.py
@@ -12,6 +12,7 @@ import logging
 import os
 import secrets
 import sqlite3
+import threading
 from base64 import b64decode, b64encode
 from copy import deepcopy
 from datetime import datetime, timedelta, timezone
@@ -1376,11 +1377,14 @@ def get_ddl_statements() -> list[str]:
 
 # Module-level singleton
 _instance: Optional[APIKeyProxyService] = None
+_instance_lock = threading.Lock()
 
 
 def get_api_key_proxy_service() -> APIKeyProxyService:
     """Get the module-level APIKeyProxyService singleton."""
     global _instance
     if _instance is None:
-        _instance = APIKeyProxyService()
+        with _instance_lock:
+            if _instance is None:
+                _instance = APIKeyProxyService()
     return _instance

--- a/app/modules/workspace/collaboration.py
+++ b/app/modules/workspace/collaboration.py
@@ -8,6 +8,7 @@ Supports session sharing, team workspaces, and collaborative annotations.
 import json
 import logging
 import sqlite3
+import threading
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
@@ -1283,11 +1284,14 @@ def get_ddl_statements() -> list[str]:
 
 # Module-level singleton
 _instance: Optional[CollaborationManager] = None
+_instance_lock = threading.Lock()
 
 
 def get_collaboration_manager() -> CollaborationManager:
     """Get the module-level CollaborationManager singleton."""
     global _instance
     if _instance is None:
-        _instance = CollaborationManager()
+        with _instance_lock:
+            if _instance is None:
+                _instance = CollaborationManager()
     return _instance

--- a/app/modules/workspace/prompt_library.py
+++ b/app/modules/workspace/prompt_library.py
@@ -8,6 +8,7 @@ Users can create, organize, and share prompt templates.
 import json
 import logging
 import sqlite3
+import threading
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
@@ -835,11 +836,14 @@ def get_ddl_statements() -> list[str]:
 
 # Module-level singleton
 _instance: Optional[PromptLibrary] = None
+_instance_lock = threading.Lock()
 
 
 def get_prompt_library() -> PromptLibrary:
     """Get the module-level PromptLibrary singleton."""
     global _instance
     if _instance is None:
-        _instance = PromptLibrary()
+        with _instance_lock:
+            if _instance is None:
+                _instance = PromptLibrary()
     return _instance

--- a/app/modules/workspace/remote_agent_manager.py
+++ b/app/modules/workspace/remote_agent_manager.py
@@ -1244,19 +1244,23 @@ class RemoteAgentManager:
         capabilities: dict[str, Any] | None = None,
     ) -> None:
         """Process a heartbeat from a remote agent."""
-        # Ensure HTTP polling agents are tracked in _connections
-        # (needed after server restart, since _connections is in-memory)
+        # Ensure HTTP polling agents are tracked in _connections and rate-limit
+        # the heartbeat DB write under the same lock: the read-modify-write on
+        # _last_heartbeat_db_write must be atomic with _connections tracking to
+        # avoid two concurrent heartbeats both passing the rate-limit check and
+        # both issuing a DB write (Issue #237, item 2). The DB I/O itself stays
+        # outside the lock so the lock is never held across network/disk work.
         with self._lock:
             if machine_id not in self._connections:
                 self._connections[machine_id] = None
                 logger.info(f"Re-registered HTTP polling agent via heartbeat: {machine_id}")
 
-        # Rate-limit DB writes: skip if last write was within HEARTBEAT_DB_WRITE_INTERVAL
-        now_ts = time.time()
-        last_write = self._last_heartbeat_db_write.get(machine_id, 0)
-        if now_ts - last_write < self.HEARTBEAT_DB_WRITE_INTERVAL:
-            return
-        self._last_heartbeat_db_write[machine_id] = now_ts
+            # Rate-limit DB writes: skip if last write was within HEARTBEAT_DB_WRITE_INTERVAL
+            now_ts = time.time()
+            last_write = self._last_heartbeat_db_write.get(machine_id, 0)
+            if now_ts - last_write < self.HEARTBEAT_DB_WRITE_INTERVAL:
+                return
+            self._last_heartbeat_db_write[machine_id] = now_ts
 
         # Update capabilities separately if provided (within rate limit)
         if capabilities:
@@ -1685,11 +1689,14 @@ def get_ddl_statements() -> list[str]:
 
 # Global singleton
 _agent_manager: RemoteAgentManager | None = None
+_agent_manager_lock = threading.Lock()
 
 
 def get_remote_agent_manager() -> RemoteAgentManager:
     """Get the global RemoteAgentManager instance."""
     global _agent_manager
     if _agent_manager is None:
-        _agent_manager = RemoteAgentManager()
+        with _agent_manager_lock:
+            if _agent_manager is None:
+                _agent_manager = RemoteAgentManager()
     return _agent_manager

--- a/app/modules/workspace/session_manager.py
+++ b/app/modules/workspace/session_manager.py
@@ -8,6 +8,7 @@ Manages conversation history, state, and context across sessions.
 import json
 import logging
 import sqlite3
+import threading
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
@@ -1729,11 +1730,14 @@ def get_ddl_statements() -> list[str]:
 
 # Module-level singleton
 _instance: Optional[SessionManager] = None
+_instance_lock = threading.Lock()
 
 
 def get_session_manager() -> SessionManager:
     """Get the module-level SessionManager singleton."""
     global _instance
     if _instance is None:
-        _instance = SessionManager()
+        with _instance_lock:
+            if _instance is None:
+                _instance = SessionManager()
     return _instance

--- a/migrations/versions/20260703_002_add_sso_auth_states.py
+++ b/migrations/versions/20260703_002_add_sso_auth_states.py
@@ -1,0 +1,82 @@
+"""add sso_auth_states table
+
+Revision ID: 20260703_002_add_sso_auth_states
+Revises: 20260703_001_add_require_full_review_rounds
+Create Date: 2026-07-03
+
+Promotes the "wild" ``sso_auth_states`` table into the migration lineage. Until
+now this table only existed because ``SSOManager._store_auth_state`` ran a
+runtime ``CREATE TABLE IF NOT EXISTS`` on every OAuth/OIDC callback — it was
+never in the baseline nor any migration, so a pure-Alembic upgrade (deployments
+that don't run ``ensure_all_tables()`` at startup) never got it, and the Schema
+Sync CI treated it as drift once the runtime DDL was removed (Issue #237 item 4).
+
+Columns mirror the former runtime DDL exactly so existing rows keep working.
+"""
+
+import logging
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+
+log = logging.getLogger(__name__)
+
+revision: str = "20260703_002_add_sso_auth_states"
+down_revision: Union[str, None] = "20260703_001_add_require_full_review_rounds"
+branch_labels: Union[str, None] = None
+depends_on: Union[str, None] = None
+
+
+def _table_exists(conn, table_name: str) -> bool:
+    """Check if a table exists (PostgreSQL or SQLite)."""
+    if conn.dialect.name == "postgresql":
+        result = conn.execute(
+            sa.text(
+                "SELECT EXISTS ("
+                "  SELECT FROM information_schema.tables"
+                "  WHERE table_name = :table_name"
+                ")"
+            ),
+            {"table_name": table_name},
+        )
+        return result.fetchone()[0]
+    result = conn.execute(
+        sa.text("SELECT name FROM sqlite_master WHERE type='table' AND name = :table_name"),
+        {"table_name": table_name},
+    )
+    return result.fetchone() is not None
+
+
+def upgrade() -> None:
+    """Create the sso_auth_states table."""
+    conn = op.get_bind()
+
+    if _table_exists(conn, "sso_auth_states"):
+        log.info("sso_auth_states table already exists, skipping")
+        return
+
+    log.info("Creating sso_auth_states table")
+    # The DDL is dialect-neutral (plain TEXT columns + TIMESTAMP default), so a
+    # single statement works for both PostgreSQL and SQLite.
+    op.execute(
+        """
+        CREATE TABLE sso_auth_states (
+            state TEXT PRIMARY KEY,
+            code_verifier TEXT NOT NULL,
+            provider_name TEXT NOT NULL,
+            nonce TEXT,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+        """
+    )
+
+
+def downgrade() -> None:
+    """Drop the sso_auth_states table."""
+    conn = op.get_bind()
+    if _table_exists(conn, "sso_auth_states"):
+        log.info("Dropping sso_auth_states table")
+        op.execute("DROP TABLE IF EXISTS sso_auth_states")
+    else:
+        log.info("sso_auth_states table does not exist, skipping")

--- a/schema/schema-postgres.sql
+++ b/schema/schema-postgres.sql
@@ -1047,6 +1047,14 @@ CREATE SEQUENCE smtp_settings_id_seq
     CACHE 1;
 
 ALTER SEQUENCE smtp_settings_id_seq OWNED BY smtp_settings.id;
+CREATE TABLE sso_auth_states (
+    state text NOT NULL,
+    code_verifier text NOT NULL,
+    provider_name text NOT NULL,
+    nonce text,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
+);
+
 CREATE TABLE sso_identities (
     id integer NOT NULL,
     user_id integer NOT NULL,
@@ -1106,13 +1114,6 @@ CREATE SEQUENCE sso_sessions_id_seq
     CACHE 1;
 
 ALTER SEQUENCE sso_sessions_id_seq OWNED BY sso_sessions.id;
-CREATE TABLE sso_auth_states (
-    state text PRIMARY KEY,
-    code_verifier text NOT NULL,
-    provider_name text NOT NULL,
-    nonce text,
-    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
-);
 CREATE TABLE sync_events (
     id integer NOT NULL,
     event_id text NOT NULL,
@@ -1781,6 +1782,9 @@ ALTER TABLE ONLY shared_sessions
 
 ALTER TABLE ONLY shared_sessions
     ADD CONSTRAINT shared_sessions_share_id_key UNIQUE (share_id);
+
+ALTER TABLE ONLY sso_auth_states
+    ADD CONSTRAINT sso_auth_states_pkey PRIMARY KEY (state);
 
 ALTER TABLE ONLY sso_identities
     ADD CONSTRAINT sso_identities_pkey PRIMARY KEY (id);

--- a/schema/schema-postgres.sql
+++ b/schema/schema-postgres.sql
@@ -1106,6 +1106,13 @@ CREATE SEQUENCE sso_sessions_id_seq
     CACHE 1;
 
 ALTER SEQUENCE sso_sessions_id_seq OWNED BY sso_sessions.id;
+CREATE TABLE sso_auth_states (
+    state text PRIMARY KEY,
+    code_verifier text NOT NULL,
+    provider_name text NOT NULL,
+    nonce text,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
+);
 CREATE TABLE sync_events (
     id integer NOT NULL,
     event_id text NOT NULL,

--- a/schema/schema-sqlite.sql
+++ b/schema/schema-sqlite.sql
@@ -683,6 +683,14 @@ CREATE TABLE smtp_settings (
  created_by integer
 );
 
+CREATE TABLE sso_auth_states (
+ state text PRIMARY KEY NOT NULL,
+ code_verifier text NOT NULL,
+ provider_name text NOT NULL,
+ nonce text,
+ created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
 CREATE TABLE sso_identities (
  id INTEGER PRIMARY KEY AUTOINCREMENT,
  user_id integer NOT NULL,
@@ -712,14 +720,6 @@ CREATE TABLE sso_sessions (
  access_token text,
  refresh_token text,
  expires_at TIMESTAMP,
- created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-);
-
-CREATE TABLE sso_auth_states (
- state text PRIMARY KEY,
- code_verifier text NOT NULL,
- provider_name text NOT NULL,
- nonce text,
  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 

--- a/schema/schema-sqlite.sql
+++ b/schema/schema-sqlite.sql
@@ -715,6 +715,14 @@ CREATE TABLE sso_sessions (
  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
+CREATE TABLE sso_auth_states (
+ state text PRIMARY KEY,
+ code_verifier text NOT NULL,
+ provider_name text NOT NULL,
+ nonce text,
+ created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
 CREATE TABLE sync_events (
  id INTEGER PRIMARY KEY AUTOINCREMENT,
  event_id text NOT NULL,

--- a/tests/unit/test_alembic_sqlite_upgrade.py
+++ b/tests/unit/test_alembic_sqlite_upgrade.py
@@ -92,6 +92,12 @@ def test_alembic_upgrade_head_succeeds_for_fresh_sqlite(tmp_path, monkeypatch):
         ).fetchone()
         is not None
     )
+    has_sso_auth_states = (
+        conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='sso_auth_states'"
+        ).fetchone()
+        is not None
+    )
     columns = set()
     if has_session_messages:
         columns = {row[1] for row in conn.execute("PRAGMA table_info(session_messages)")}
@@ -104,7 +110,8 @@ def test_alembic_upgrade_head_succeeds_for_fresh_sqlite(tmp_path, monkeypatch):
     # -> 001_add_project_categories -> 004_fix_tenant_quotas_overflow
     # -> 005_add_policy_tables -> 001_add_model_gateway_config
     # -> 20260703_001_add_require_full_review_rounds
-    assert version[0] == "20260703_001_add_require_full_review_rounds"
+    # -> 20260703_002_add_sso_auth_states
+    assert version[0] == "20260703_002_add_sso_auth_states"
     if has_session_messages:
         assert "source" in columns
     assert has_mapping_rules is True
@@ -113,6 +120,7 @@ def test_alembic_upgrade_head_succeeds_for_fresh_sqlite(tmp_path, monkeypatch):
     assert has_project_categories is True
     assert has_model_gateway_config is True
     assert has_policy_tables is True
+    assert has_sso_auth_states is True
     assert "auto_mapping_enabled" in user_columns
     # content_language column added by 20260626_002 (#1287)
     assert "content_language" in aw_columns


### PR DESCRIPTION
## 背景

Closes #237（items 2/4/6）—— PR #225 PostgreSQL 性能优化后续的低风险项。

> ⚠️ **范围说明**：Issue #237 共 6 项。本次只做**零/低回归风险**的 items 2/4/6。连接池统一迁移（item 1）与 `_ensure_tables`/`_get_connection` 死代码清理（items 3/5）因大量单元/issue 测试直接依赖这些方法（`tests/issues/1273`、`1003`、`1128`、`test_workspace_modules.py` 等，把它们当测试夹具用，并非真死代码），需配套改写测试，留作后续单独 PR 评估。

## 改动

### Item 6 — 5 个 singleton accessor 加 `threading.Lock`
`get_session_manager` / `get_collaboration_manager` / `get_prompt_library` / `get_api_key_proxy_service` / `get_remote_agent_manager` 原为 bare `if _instance is None`，多线程首次并发调用可能各自创建实例。改为**双重检查锁**（fast path 无锁，仅建实例时持锁）：
```python
if _instance is None:
    with _instance_lock:
        if _instance is None:
            _instance = SessionManager()
```
4 个文件补 `import threading`（`remote_agent_manager` 已有）。

### Item 2 — `_last_heartbeat_db_write` 竞态修复
`RemoteAgentManager.process_heartbeat` 中，`_last_heartbeat_db_write` 的 read-modify-write 不在 `self._lock` 保护下，与同类 `_connections`/`_session_machines` 用锁模式不一致。多线程部署下两个心跳可能同时读到旧 `last_write` 并都通过速率限制、都写 DB。

修复：将 `_connections` 跟踪与速率限制判断合并进**同一个 `self._lock` 块**（字典更新原子化），DB 写保持在锁外（避免锁内 I/O）。

### Item 4 — `_store_auth_state` 内联 DDL 迁移
移除 `SSOManager._store_auth_state` 中的内联 `CREATE TABLE IF NOT EXISTS sso_auth_states`。

> ⚠️ 核查发现 **Issue #237 描述有误**：该表**并未**出现在权威 schema 文件中（`schema-sqlite.sql`/`schema-postgres.sql` 只有 `sso_providers`/`sso_identities`/`sso_sessions`），且 `SSOManager.__init__` 早已不调 `_ensure_tables()`，生产环境 `get_ddl_statements()` 也不被调用。若直接删内联 DDL，`sso_auth_states` 表将无处创建，SSO 登录会崩。

故先把 `sso_auth_states` 补进两个权威 schema 文件（启动时由 `schema_init.load_schema_from_file` 创建），再删内联 DDL。

## 验证
- ✅ 全部 pre-commit hooks 通过：black / isort / ruff / mypy / bandit / pydocstyle / SQL 兼容性 / PG schema boolean 校验 / 表边界检查（#1125）
- ✅ `tests/issues/1273`（schema 单一源，16 项）、`tests/unit/test_security_model`（32 项）、`test_permission_service` 等共 **115 个单元测试通过**
- ✅ 功能检查（SQLite）：心跳速率限制、SSO store/get/delete、singleton 锁行为正确
- ✅ `test_workspace_modules` 中 17 个失败在 clean `main` 上同样存在（PG 占位符 `?`/`INSERT OR IGNORE` **预存 bug**，与本次改动无关——本次只改了那些文件的 singleton accessor，没碰 SQL 查询）

## 关联
- Closes #237（items 2/4/6）
- 另开 #1453 跟踪核查中发现的 SSOManager 全模块 PG 占位符 bug（item 4 触发的发现，超出本次范围）

🤖 Generated with ZCode