### PR TITLE
fix(sso): SSOManager 改用 Database 高层 API 修复 PG 占位符报错 (Issue #1453)

### DIFF
--- a/app/modules/sso/manager.py
+++ b/app/modules/sso/manager.py
@@ -19,7 +19,12 @@ from app.modules.sso.provider import (
     SSOProviderConfig,
     get_provider_config,
 )
-from app.repositories.database import Database, is_postgresql
+from app.repositories.database import (
+    Database,
+    adapt_boolean_condition,
+    adapt_boolean_value,
+    is_postgresql,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -177,31 +182,29 @@ class SSOManager:
         )
 
         try:
-            with self.db.connection() as conn:
-                cursor = conn.cursor()
-                cursor.execute(
-                    """
-                    INSERT INTO sso_providers
-                    (name, provider_type, config, tenant_id)
-                    VALUES (?, ?, ?, ?)
-                    ON CONFLICT(name) DO UPDATE SET
-                        provider_type = ?,
-                        config = ?,
-                        tenant_id = ?,
-                        updated_at = ?
-                """,
-                    (
-                        name,
-                        provider_type,
-                        json.dumps(config.__dict__),
-                        tenant_id,
-                        provider_type,
-                        json.dumps(config.__dict__),
-                        tenant_id,
-                        datetime.now(timezone.utc).replace(tzinfo=None),
-                    ),
-                )
-                conn.commit()
+            now = datetime.now(timezone.utc).replace(tzinfo=None)
+            self.db.execute(
+                """
+                INSERT INTO sso_providers
+                (name, provider_type, config, tenant_id)
+                VALUES (?, ?, ?, ?)
+                ON CONFLICT(name) DO UPDATE SET
+                    provider_type = ?,
+                    config = ?,
+                    tenant_id = ?,
+                    updated_at = ?
+            """,
+                (
+                    name,
+                    provider_type,
+                    json.dumps(config.__dict__),
+                    tenant_id,
+                    provider_type,
+                    json.dumps(config.__dict__),
+                    tenant_id,
+                    now,
+                ),
+            )
 
             # Clear cached provider
             with self._providers_lock:
@@ -275,7 +278,8 @@ class SSOManager:
 
         # Load from database
         row = self.db.fetch_one(
-            "SELECT * FROM sso_providers WHERE name = ? AND is_active IS TRUE", (name,)
+            f"SELECT * FROM sso_providers WHERE name = ? AND {adapt_boolean_condition('is_active', True)}",
+            (name,),
         )
 
         if not row:
@@ -337,10 +341,10 @@ class SSOManager:
     def disable_provider(self, name: str) -> bool:
         """Disable an SSO provider."""
         try:
-            with self.db.connection() as conn:
-                cursor = conn.cursor()
-                cursor.execute("UPDATE sso_providers SET is_active = FALSE WHERE name = ?", (name,))
-                conn.commit()
+            self.db.execute(
+                "UPDATE sso_providers SET is_active = ? WHERE name = ?",
+                (adapt_boolean_value(False), name),
+            )
 
             with self._providers_lock:
                 if name in self._providers:
@@ -355,10 +359,10 @@ class SSOManager:
     def enable_provider(self, name: str) -> bool:
         """Enable an SSO provider."""
         try:
-            with self.db.connection() as conn:
-                cursor = conn.cursor()
-                cursor.execute("UPDATE sso_providers SET is_active = TRUE WHERE name = ?", (name,))
-                conn.commit()
+            self.db.execute(
+                "UPDATE sso_providers SET is_active = ? WHERE name = ?",
+                (adapt_boolean_value(True), name),
+            )
 
             return True
 
@@ -472,30 +476,29 @@ class SSOManager:
             bool: True if successful.
         """
         try:
-            with self.db.connection() as conn:
-                cursor = conn.cursor()
-                cursor.execute(
-                    """
-                    INSERT INTO sso_identities
-                    (user_id, provider_name, provider_user_id, provider_data, last_used_at)
-                    VALUES (?, ?, ?, ?, ?)
-                    ON CONFLICT(provider_name, provider_user_id) DO UPDATE SET
-                        user_id = ?,
-                        provider_data = ?,
-                        last_used_at = ?
-                """,
-                    (
-                        user_id,
-                        provider_name,
-                        provider_user_id,
-                        json.dumps(provider_data) if provider_data else None,
-                        datetime.now(timezone.utc).replace(tzinfo=None),
-                        user_id,
-                        json.dumps(provider_data) if provider_data else None,
-                        datetime.now(timezone.utc).replace(tzinfo=None),
-                    ),
-                )
-                conn.commit()
+            now = datetime.now(timezone.utc).replace(tzinfo=None)
+            provider_data_json = json.dumps(provider_data) if provider_data else None
+            self.db.execute(
+                """
+                INSERT INTO sso_identities
+                (user_id, provider_name, provider_user_id, provider_data, last_used_at)
+                VALUES (?, ?, ?, ?, ?)
+                ON CONFLICT(provider_name, provider_user_id) DO UPDATE SET
+                    user_id = ?,
+                    provider_data = ?,
+                    last_used_at = ?
+            """,
+                (
+                    user_id,
+                    provider_name,
+                    provider_user_id,
+                    provider_data_json,
+                    now,
+                    user_id,
+                    provider_data_json,
+                    now,
+                ),
+            )
 
             logger.info(
                 f"Linked SSO identity: {provider_name}:{provider_user_id} -> user:{user_id}"
@@ -552,24 +555,21 @@ class SSOManager:
         expires_at = datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(seconds=expires_in)
 
         try:
-            with self.db.connection() as conn:
-                cursor = conn.cursor()
-                cursor.execute(
-                    """
-                    INSERT INTO sso_sessions
-                    (session_token, user_id, provider_name, access_token, refresh_token, expires_at)
-                    VALUES (?, ?, ?, ?, ?, ?)
-                """,
-                    (
-                        session_token,
-                        user_id,
-                        provider_name,
-                        access_token,
-                        refresh_token,
-                        expires_at,
-                    ),
-                )
-                conn.commit()
+            self.db.execute(
+                """
+                INSERT INTO sso_sessions
+                (session_token, user_id, provider_name, access_token, refresh_token, expires_at)
+                VALUES (?, ?, ?, ?, ?, ?)
+            """,
+                (
+                    session_token,
+                    user_id,
+                    provider_name,
+                    access_token,
+                    refresh_token,
+                    expires_at,
+                ),
+            )
 
             return session_token
 
@@ -603,11 +603,8 @@ class SSOManager:
     def delete_sso_session(self, session_token: str) -> bool:
         """Delete an SSO session."""
         try:
-            with self.db.connection() as conn:
-                cursor = conn.cursor()
-                cursor.execute("DELETE FROM sso_sessions WHERE session_token = ?", (session_token,))
-                conn.commit()
-                return True
+            self.db.execute("DELETE FROM sso_sessions WHERE session_token = ?", (session_token,))
+            return True
 
         except Exception as e:
             logger.error(f"Failed to delete SSO session: {e}")
@@ -616,15 +613,11 @@ class SSOManager:
     def cleanup_expired_sessions(self) -> int:
         """Delete expired SSO sessions."""
         try:
-            with self.db.connection() as conn:
-                cursor = conn.cursor()
-                cursor.execute(
-                    "DELETE FROM sso_sessions WHERE expires_at < ?",
-                    (datetime.now(timezone.utc).replace(tzinfo=None),),
-                )
-                deleted = cursor.rowcount
-                conn.commit()
-                return cast("int", deleted)
+            cursor = self.db.execute(
+                "DELETE FROM sso_sessions WHERE expires_at < ?",
+                (datetime.now(timezone.utc).replace(tzinfo=None),),
+            )
+            return cast("int", cursor.rowcount)
 
         except Exception as e:
             logger.error(f"Failed to cleanup sessions: {e}")
@@ -645,16 +638,13 @@ class SSOManager:
         instead of a clear error (Issue #237 item 4, review note).
         """
         try:
-            with self.db.connection() as conn:
-                cursor = conn.cursor()
-                cursor.execute(
-                    """
-                    INSERT INTO sso_auth_states (state, code_verifier, provider_name, nonce)
-                    VALUES (?, ?, ?, ?)
-                """,
-                    (state, code_verifier, provider_name, nonce),
-                )
-                conn.commit()
+            self.db.execute(
+                """
+                INSERT INTO sso_auth_states (state, code_verifier, provider_name, nonce)
+                VALUES (?, ?, ?, ?)
+            """,
+                (state, code_verifier, provider_name, nonce),
+            )
 
         except Exception as e:
             logger.error(f"Failed to store auth state: {e}")
@@ -672,10 +662,7 @@ class SSOManager:
     def _delete_auth_state(self, state: str) -> None:
         """Delete authentication state."""
         try:
-            with self.db.connection() as conn:
-                cursor = conn.cursor()
-                cursor.execute("DELETE FROM sso_auth_states WHERE state = ?", (state,))
-                conn.commit()
+            self.db.execute("DELETE FROM sso_auth_states WHERE state = ?", (state,))
 
         except Exception as e:
             logger.error(f"Failed to delete auth state: {e}")

--- a/tests/issues/1453/test_sso_placeholder_regression.py
+++ b/tests/issues/1453/test_sso_placeholder_regression.py
@@ -1,0 +1,126 @@
+"""Regression tests for SSO placeholder adaptation (Issue #1453).
+
+The SSO write methods must run their SQL through ``Database.execute()`` so the
+``?`` placeholders get rewritten to ``%s`` on PostgreSQL. Before this fix every
+write method used a raw ``cursor.execute("... ? ...")`` and raised
+``syntax error at or near ","`` on PostgreSQL, breaking all of SSO.
+
+These tests mirror the ``test_retention.py`` pattern (issue #860): patch
+``is_postgresql()`` and spy on the SQL the underlying cursor receives, so they
+catch the regression in CI without a live PostgreSQL server. They use a *real*
+``Database`` instance with only ``connection()`` mocked out, so ``execute()``
+runs its real body — including ``adapt_sql(query)`` — and the spy captures the
+fully-adapted SQL the driver would see.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import app.repositories.database as db_mod
+from app.modules.sso.manager import SSOManager
+from app.repositories.database import Database
+
+
+def _make_manager_with_spy() -> tuple[SSOManager, list[str]]:
+    """Build an SSOManager backed by a real Database with a mocked connection.
+
+    ``Database.execute()`` runs its real body (calling ``adapt_sql(query)``),
+    but ``connection()`` returns a mock so no DB is touched. The spy captures
+    every SQL string handed to the underlying cursor — i.e. AFTER adaptation,
+    exactly what the driver would receive.
+    """
+    db = Database(db_url="sqlite:///dummy")  # real Database, dialect controlled via is_postgresql
+    captured: list[str] = []
+
+    mock_conn = MagicMock()
+    cursor = mock_conn.cursor.return_value
+    cursor.execute.side_effect = lambda query, *args, **kwargs: captured.append(query)
+    # execute() does `with self.connection() as conn:` then `conn.cursor()`.
+    # The context manager's __enter__ must yield mock_conn itself.
+    mock_connection_ctx = MagicMock()
+    mock_connection_ctx.__enter__.return_value = mock_conn
+    db.connection = MagicMock(return_value=mock_connection_ctx)  # type: ignore[method-assign]
+
+    manager = SSOManager(db=db)
+    return manager, captured
+
+
+def test_register_provider_adapts_placeholders_for_postgres(monkeypatch):
+    """INSERT ... ON CONFLICT for register_provider must use %s (not ?) on PG."""
+    monkeypatch.setattr(db_mod, "is_postgresql", lambda: True)
+
+    manager, captured = _make_manager_with_spy()
+    manager.register_provider(
+        name="google",
+        provider_type="oauth2",
+        client_id="cid",
+        client_secret="csec",
+        authorization_url="https://example.com/auth",
+        token_url="https://example.com/token",
+    )
+
+    insert_sqls = [q for q in captured if "INSERT" in q.upper()]
+    assert len(insert_sqls) == 1
+    assert "%s" in insert_sqls[0]
+    assert "?" not in insert_sqls[0]
+
+
+def test_register_provider_keeps_sqlite_placeholders(monkeypatch):
+    """Under SQLite the '?' placeholder is preserved (adapt_sql is a no-op)."""
+    monkeypatch.setattr(db_mod, "is_postgresql", lambda: False)
+
+    manager, captured = _make_manager_with_spy()
+    manager.register_provider(
+        name="google",
+        provider_type="oauth2",
+        client_id="cid",
+        client_secret="csec",
+        authorization_url="https://example.com/auth",
+        token_url="https://example.com/token",
+    )
+
+    insert_sqls = [q for q in captured if "INSERT" in q.upper()]
+    assert len(insert_sqls) == 1
+    assert "?" in insert_sqls[0]
+    assert "%s" not in insert_sqls[0]
+
+
+def test_disable_provider_adapts_placeholders_for_postgres(monkeypatch):
+    """UPDATE in disable_provider must use %s (not ?) on PostgreSQL."""
+    monkeypatch.setattr(db_mod, "is_postgresql", lambda: True)
+
+    manager, captured = _make_manager_with_spy()
+    manager.disable_provider("google")
+
+    update_sqls = [q for q in captured if "UPDATE" in q.upper()]
+    assert len(update_sqls) == 1
+    assert "%s" in update_sqls[0]
+    assert "?" not in update_sqls[0]
+
+
+def test_cleanup_expired_sessions_adapts_placeholders_for_postgres(monkeypatch):
+    """DELETE in cleanup_expired_sessions must use %s (not ?) on PostgreSQL."""
+    monkeypatch.setattr(db_mod, "is_postgresql", lambda: True)
+
+    manager, captured = _make_manager_with_spy()
+    manager.cleanup_expired_sessions()
+
+    delete_sqls = [q for q in captured if "DELETE" in q.upper()]
+    assert len(delete_sqls) == 1
+    assert "%s" in delete_sqls[0]
+    assert "?" not in delete_sqls[0]
+
+
+def test_store_auth_state_adapts_placeholders_for_postgres(monkeypatch):
+    """INSERT in _store_auth_state must use %s (not ?) on PostgreSQL."""
+    monkeypatch.setattr(db_mod, "is_postgresql", lambda: True)
+
+    manager, captured = _make_manager_with_spy()
+    manager._store_auth_state("state1", "ver1", "google", "nonce1")
+
+    insert_sqls = [q for q in captured if "INSERT" in q.upper()]
+    assert len(insert_sqls) == 1
+    assert "%s" in insert_sqls[0]
+    assert "?" not in insert_sqls[0]


### PR DESCRIPTION
Closes #1453。

## 问题
`SSOManager` 已迁移到 `self.db`（Database 连接池），但写类方法仍用原始 `cursor.execute()` 跑 SQLite 的 `?` 占位符 SQL，未走 `adapt_sql()`，导致 PostgreSQL 下全部报：
```
psycopg2.errors.SyntaxError: syntax error at or near ","
LINE 3:   VALUES (?, ?, ?, ?)
```
整个 SSO 功能在 PG 部署下不可用。

## 改法（Issue 建议的方式 2）
把 9 个写类方法的
```python
with self.db.connection() as conn:
    cursor = conn.cursor()
    cursor.execute("... ? ...", ...)
    conn.commit()
```
统一改为 `self.db.execute(...)`（内部已调 `adapt_sql`，自动 `?` → `%s`）：

| 方法 | 原 |
|------|-----|
| `register_provider` | INSERT ... ON CONFLICT |
| `disable_provider` / `enable_provider` | UPDATE（boolean 字面量）|
| `link_identity` | INSERT ... ON CONFLICT |
| `create_sso_session` | INSERT |
| `delete_sso_session` | DELETE |
| `cleanup_expired_sessions` | DELETE（用 `cursor.rowcount`）|
| `_store_auth_state` / `_delete_auth_state` | INSERT / DELETE |

读类方法（`get_provider` / `list_providers` / `get_user_by_sso_identity` / `get_sso_session` / `_get_auth_state`）本就用 `fetch_one`/`fetch_all`，无需改。

## 顺带修 boolean 双 DB 兼容
- `get_provider` 的 `is_active IS TRUE` → `adapt_boolean_condition`（SQLite 存 0/1，`IS TRUE` 行为不一致）
- `disable`/`enable_provider` 的 `is_active = FALSE/TRUE` 字面量 → `adapt_boolean_value`（PG 要 boolean、SQLite 要 0/1）

`_ensure_tables()` 的 DDL 未动（属 Issue #237 item 5，留后续）。

## 验证
- ✅ 功能测试双方言：SQLite + PostgreSQL 各跑 **11 个 SSO 方法**全过（register/upsert/get/disable/enable/link_identity/get_user/create/get/delete sso_session/auth_state store/get/delete/cleanup_expired），PG 下不再报 syntax error
- ✅ 现有测试 `test_security_model`(32) + `test_issue22`(7) 全过，无回归
- ✅ pre-commit hooks 全过（black/isort/ruff/mypy/bandit/pydocstyle/SQL 兼容性）

🤖 Generated with ZCode