### PR TITLE
fix(autonomous): gh 在 sudo wrapper 下用 -R owner/repo 替代非法 -C 标志 (Issue #1421)

### DIFF
--- a/app/modules/workspace/autonomous/github_ops.py
+++ b/app/modules/workspace/autonomous/github_ops.py
@@ -81,11 +81,16 @@ class GitHubOps:
         """
         self.repo_path = repo_path
         self.system_account = system_account
-        # Cached owner/repo (e.g. "open-ace/open-ace") resolved from the local
-        # repo's origin remote, used to target gh under a sudo wrapper where gh
-        # can no longer infer the repo from cwd. Lazily populated by
-        # _resolve_owner_repo(); None means "not resolvable / not yet tried".
+        # Cached owner/repo (e.g. "open-ace/open-ace", or "host/owner/repo" for
+        # GHES) resolved from the local repo's origin remote, used to target gh
+        # under a sudo wrapper where gh can no longer infer the repo from cwd.
+        # Lazily populated by _resolve_owner_repo(); None means "not resolvable
+        # / not yet tried".
         self._owner_repo: Optional[str] = None
+        # Pure OWNER/REPO slug (never carries the GHES host), used for REST API
+        # paths (gh api repos/<owner>/<repo>/...). Populated alongside
+        # _owner_repo by _resolve_owner_repo().
+        self._repo_slug: Optional[str] = None
         # Tracks whether _resolve_owner_repo has been attempted, so None can
         # distinguish "tried and failed" from "not yet tried".
         self._owner_repo_resolved: bool = False
@@ -186,6 +191,9 @@ class GitHubOps:
             slug = m.group(4)
         if not slug:
             return None
+        # The API-path slug is always plain OWNER/REPO (REST paths don't carry
+        # the host), regardless of host.
+        self._repo_slug = slug
         # Only github.com is the public host; any other host is a GHES instance
         # and must be passed through to gh's -R as HOST/OWNER/REPO.
         if host and host != "github.com":
@@ -397,11 +405,23 @@ class GitHubOps:
         return result.stdout.strip()
 
     def get_repo_name(self) -> str:
-        """Get the repo name in owner/repo format."""
-        # `gh repo view` also rejects -R, so disable repo-scoped binding.
-        result = self._run_gh(["repo", "view", "--json", "nameWithOwner"], repo_scoped=False)
-        data = json.loads(result.stdout.strip())
-        return data.get("nameWithOwner", "")
+        """Get the repo name in ``owner/repo`` format (no GHES host).
+
+        Resolved from the local ``origin`` remote via ``_resolve_owner_repo()``
+        (which uses ``git remote get-url``, valid under a sudo wrapper) rather
+        than ``gh repo view``: the latter rejects ``-R`` and, with ``cwd``
+        dropped under sudo, can only guess the repo from the parent process's
+        working directory — failing in non-repo dirs or returning the wrong
+        repo. Falls back to ``gh repo view`` only when the remote is absent.
+        """
+        if self._resolve_owner_repo() is None:
+            # No origin remote to parse (e.g. a freshly created repo before its
+            # remote is wired). gh repo view rejects -R, so this runs plain;
+            # under sudo it relies on cwd and is best-effort.
+            result = self._run_gh(["repo", "view", "--json", "nameWithOwner"], repo_scoped=False)
+            data = json.loads(result.stdout.strip())
+            return data.get("nameWithOwner", "")
+        return self._repo_slug or ""
 
     # ── Issue Operations ────────────────────────────────────────────
 

--- a/app/modules/workspace/autonomous/github_ops.py
+++ b/app/modules/workspace/autonomous/github_ops.py
@@ -91,6 +91,9 @@ class GitHubOps:
         # paths (gh api repos/<owner>/<repo>/...). Populated alongside
         # _owner_repo by _resolve_owner_repo().
         self._repo_slug: Optional[str] = None
+        # The remote host (e.g. "github.com" or "gh.example.com"), needed for
+        # gh api --hostname under a sudo wrapper on GHES. None until resolved.
+        self._repo_host: Optional[str] = None
         # Tracks whether _resolve_owner_repo has been attempted, so None can
         # distinguish "tried and failed" from "not yet tried".
         self._owner_repo_resolved: bool = False
@@ -194,6 +197,7 @@ class GitHubOps:
         # The API-path slug is always plain OWNER/REPO (REST paths don't carry
         # the host), regardless of host.
         self._repo_slug = slug
+        self._repo_host = host
         # Only github.com is the public host; any other host is a GHES instance
         # and must be passed through to gh's -R as HOST/OWNER/REPO.
         if host and host != "github.com":
@@ -626,16 +630,32 @@ class GitHubOps:
         logger.info("Added comment to PR #%s", number)
         return {"number": number, "body": body}
 
+    def _gh_api_args(self, extra: list[str]) -> list[str]:
+        """Build a ``gh api`` arg list with GHES hostname handling.
+
+        ``gh api`` rejects ``-R`` (unlike issue/pr subcommands) and resolves the
+        repo from the REST path; under a sudo wrapper we therefore call it with
+        ``repo_scoped=False`` (no ``-R`` injection). For a GHES host it instead
+        needs ``--hostname`` to target the right server.
+        """
+        self._resolve_owner_repo()
+        args = ["api"]
+        if self._repo_host and self._repo_host != "github.com":
+            args += ["--hostname", self._repo_host]
+        return args + extra
+
     def list_pr_comments(self, number: int) -> list:
         """List review comments on a PR."""
         repo = self.get_repo_name()
         result = self._run_gh(
-            [
-                "api",
-                f"repos/{repo}/pulls/{number}/comments",
-                "--jq",
-                ".[] | {id, path, body, line, created_at, user: .user.login}",
-            ]
+            self._gh_api_args(
+                [
+                    f"repos/{repo}/pulls/{number}/comments",
+                    "--jq",
+                    ".[] | {id, path, body, line, created_at, user: .user.login}",
+                ]
+            ),
+            repo_scoped=False,
         )
         if not result.stdout.strip():
             return []
@@ -652,12 +672,14 @@ class GitHubOps:
         """List issue-level comments on a PR."""
         repo = self.get_repo_name()
         result = self._run_gh(
-            [
-                "api",
-                f"repos/{repo}/issues/{number}/comments",
-                "--jq",
-                ".[] | {id, body, created_at, user: .user.login}",
-            ]
+            self._gh_api_args(
+                [
+                    f"repos/{repo}/issues/{number}/comments",
+                    "--jq",
+                    ".[] | {id, body, created_at, user: .user.login}",
+                ]
+            ),
+            repo_scoped=False,
         )
         if not result.stdout.strip():
             return []

--- a/app/modules/workspace/autonomous/github_ops.py
+++ b/app/modules/workspace/autonomous/github_ops.py
@@ -167,17 +167,48 @@ class GitHubOps:
             return None
         if not url:
             return None
-        # Accept https://github.com/<owner>/<repo>[.git] and
-        # git@github.com:<owner>/<repo>[.git]. Tolerate an optional trailing
-        # .git and a trailing slash.
-        m = re.match(r"(?:https?://github\.com/|git@github\.com:)([^/]+/[^/]+?)(?:\.git)?/?$", url)
-        if not m:
+        # Parse the host and owner/repo from common git remote forms:
+        #   https://github.com/<owner>/<repo>[.git]
+        #   git@github.com:<owner>/<repo>[.git]            (SCP-style)
+        #   ssh://git@github.com/<owner>/<repo>[.git]
+        #   https://gh.example.com/<owner>/<repo>[.git]    (GHES)
+        # gh's -R/--repo accepts [HOST/]OWNER/REPO, so for non-github.com hosts
+        # (GHES) we include the host so the command targets the right server.
+        host: Optional[str] = None
+        slug: Optional[str] = None
+        m = re.match(
+            r"(?:https?://([^/]+)/|ssh://[^@]+@([^/]+)/|(?:[^@]+@([^:]+):))"  # host capture
+            r"([^/]+/[^/]+?)(?:\.git)?/?$",
+            url,
+        )
+        if m:
+            host = next((g for g in (m.group(1), m.group(2), m.group(3)) if g), None)
+            slug = m.group(4)
+        if not slug:
             return None
-        self._owner_repo = m.group(1)
+        # Only github.com is the public host; any other host is a GHES instance
+        # and must be passed through to gh's -R as HOST/OWNER/REPO.
+        if host and host != "github.com":
+            self._owner_repo = f"{host}/{slug}"
+        else:
+            self._owner_repo = slug
         return self._owner_repo
 
-    def _run_gh(self, args: list[str], check: bool = True) -> subprocess.CompletedProcess:
-        """Run a gh CLI command with transient-network-error retry."""
+    def _run_gh(
+        self, args: list[str], check: bool = True, repo_scoped: bool = True
+    ) -> subprocess.CompletedProcess:
+        """Run a gh CLI command with transient-network-error retry.
+
+        Args:
+            args: gh CLI argument list (e.g. ``["issue", "view", "42", "--json", ...]``).
+            check: Raise ``GitHubOpsError`` on non-zero exit when True.
+            repo_scoped: Whether the command targets a specific repo and should
+                carry ``-R owner/repo`` under a sudo wrapper. Most gh subcommands
+                (issue/pr/view) accept ``-R``, but ``repo create`` / ``repo view``
+                do not — for those the caller passes ``repo_scoped=False`` so the
+                sudo path runs plain ``gh`` without repo context (they don't need
+                an existing-repo context anyway).
+        """
         kwargs = self._build_subprocess_kwargs()
         account = self.system_account
         if self._needs_sudo():
@@ -187,14 +218,13 @@ class GitHubOps:
             # explicitly via `-R owner/repo` resolved from the local remote.
             assert account is not None  # _needs_sudo() guarantees non-empty
             cmd: list[str] = ["sudo", "-u", account]
-            owner_repo = self._resolve_owner_repo()
+            owner_repo = self._resolve_owner_repo() if repo_scoped else None
             if owner_repo:
                 cmd += ["gh", "-R", owner_repo] + args
             else:
-                # No resolvable remote (e.g. create_repo before the remote
-                # exists). gh runs without -R; this is best-effort since such
-                # commands (e.g. `gh repo create <name>`) don't need an
-                # existing remote context anyway.
+                # No resolvable remote, or a command (repo create/view) that
+                # rejects -R. Run plain gh; commands that need repo context
+                # (issue/pr) will already have a resolvable owner_repo above.
                 cmd += ["gh"] + args
             kwargs.pop("cwd", None)  # cwd under sudo triggers Permission denied (Issue #1421)
         else:
@@ -352,7 +382,9 @@ class GitHubOps:
         if description:
             args.extend(["--description", description])
 
-        result = self._run_gh(args)
+        # `gh repo create` rejects -R (unlike issue/pr subcommands), so disable
+        # repo-scoped binding; it creates a new repo and needs no existing one.
+        result = self._run_gh(args, repo_scoped=False)
         # gh repo create doesn't support --json; parse URL from stdout
         output = result.stdout.strip()
         repo_url = output.split("\n")[-1].strip()
@@ -366,7 +398,8 @@ class GitHubOps:
 
     def get_repo_name(self) -> str:
         """Get the repo name in owner/repo format."""
-        result = self._run_gh(["repo", "view", "--json", "nameWithOwner"])
+        # `gh repo view` also rejects -R, so disable repo-scoped binding.
+        result = self._run_gh(["repo", "view", "--json", "nameWithOwner"], repo_scoped=False)
         data = json.loads(result.stdout.strip())
         return data.get("nameWithOwner", "")
 

--- a/app/modules/workspace/autonomous/github_ops.py
+++ b/app/modules/workspace/autonomous/github_ops.py
@@ -9,6 +9,8 @@ All methods invoke gh/git via subprocess and return parsed results.
 import json
 import logging
 import os
+import pwd
+import re
 import subprocess
 import time
 from typing import Optional
@@ -79,6 +81,14 @@ class GitHubOps:
         """
         self.repo_path = repo_path
         self.system_account = system_account
+        # Cached owner/repo (e.g. "open-ace/open-ace") resolved from the local
+        # repo's origin remote, used to target gh under a sudo wrapper where gh
+        # can no longer infer the repo from cwd. Lazily populated by
+        # _resolve_owner_repo(); None means "not resolvable / not yet tried".
+        self._owner_repo: Optional[str] = None
+        # Tracks whether _resolve_owner_repo has been attempted, so None can
+        # distinguish "tried and failed" from "not yet tried".
+        self._owner_repo_resolved: bool = False
 
     def _get_env(self) -> Optional[dict[str, str]]:
         """Get environment overrides for AI GitHub account.
@@ -112,17 +122,84 @@ class GitHubOps:
             kwargs["env"] = {**os.environ, **ai_env}
         return kwargs
 
+    def _needs_sudo(self) -> bool:
+        """Whether git/gh commands actually need a sudo -u wrapper.
+
+        A sudo wrapper is only required when the service process user differs
+        from ``system_account`` (Issue #1395/#1421: cross-user access to a
+        user's private workspace). When the service already runs as
+        ``system_account`` (common dev/single-user setup, and systemd
+        User=<account> deployments), sudo is a no-op that additionally breaks
+        under NoNewPrivileges — mirroring the same-user short-circuit already
+        used in webui_manager. Skipping it also sidesteps the gh ``-C`` flag
+        incompatibility (gh has no ``-C``; see _run_gh) for this common case.
+        """
+        if not self.system_account:
+            return False
+        try:
+            current_user = pwd.getpwuid(os.getuid()).pw_name
+        except (KeyError, OverflowError):
+            # Cannot determine the current user; assume cross-user to stay safe.
+            return True
+        return current_user != self.system_account
+
+    def _resolve_owner_repo(self) -> Optional[str]:
+        """Resolve the ``owner/repo`` slug for the local repo's origin remote.
+
+        gh CLI infers the target repo from the working directory's ``.git``,
+        but under a ``sudo -u`` wrapper we drop ``cwd`` (it triggers a Python
+        permission check as the service user, Issue #1421) and gh has no ``-C``
+        flag to compensate. Instead we resolve ``owner/repo`` from the local
+        remote (git ``-C`` *is* valid, so ``_run_git`` still works under sudo)
+        and pass it to gh via ``-R``.
+
+        Cached on the instance after the first call; returns None when the
+        remote is absent or unparseable (e.g. a brand-new project before its
+        GitHub repo is wired up).
+        """
+        if self._owner_repo_resolved:
+            return self._owner_repo
+        self._owner_repo_resolved = True
+        try:
+            url = self.get_repo_url().strip()
+        except GitHubOpsError:
+            # No origin remote configured (e.g. new project pre-create_repo).
+            return None
+        if not url:
+            return None
+        # Accept https://github.com/<owner>/<repo>[.git] and
+        # git@github.com:<owner>/<repo>[.git]. Tolerate an optional trailing
+        # .git and a trailing slash.
+        m = re.match(r"(?:https?://github\.com/|git@github\.com:)([^/]+/[^/]+?)(?:\.git)?/?$", url)
+        if not m:
+            return None
+        self._owner_repo = m.group(1)
+        return self._owner_repo
+
     def _run_gh(self, args: list[str], check: bool = True) -> subprocess.CompletedProcess:
         """Run a gh CLI command with transient-network-error retry."""
-        # Build subprocess kwargs - remove cwd when using system_account to avoid
-        # Python permission check on repo_path (Issue #1421: cwd causes Permission denied)
         kwargs = self._build_subprocess_kwargs()
-        # If system_account is set, use -C flag instead of cwd for multi-user permission isolation
-        # (Issue #1395 + #1421: Allow GitHubOps to access user-private directories)
-        if self.system_account:
-            cmd = ["sudo", "-u", self.system_account, "gh", "-C", self.repo_path] + args
-            kwargs.pop("cwd", None)  # Remove cwd to avoid Python permission check
+        account = self.system_account
+        if self._needs_sudo():
+            # gh has no `-C <path>` flag (that is git-only), so under a sudo
+            # wrapper — where we must drop cwd to avoid a Python permission
+            # check as the service user (Issue #1421) — target the repo
+            # explicitly via `-R owner/repo` resolved from the local remote.
+            assert account is not None  # _needs_sudo() guarantees non-empty
+            cmd: list[str] = ["sudo", "-u", account]
+            owner_repo = self._resolve_owner_repo()
+            if owner_repo:
+                cmd += ["gh", "-R", owner_repo] + args
+            else:
+                # No resolvable remote (e.g. create_repo before the remote
+                # exists). gh runs without -R; this is best-effort since such
+                # commands (e.g. `gh repo create <name>`) don't need an
+                # existing remote context anyway.
+                cmd += ["gh"] + args
+            kwargs.pop("cwd", None)  # cwd under sudo triggers Permission denied (Issue #1421)
         else:
+            # Same-user (or no system_account): run gh directly with cwd so it
+            # infers owner/repo from the working directory as before.
             cmd = ["gh"] + args
         last_error: Optional[GitHubOpsError] = None
         for attempt in range(GIT_NETWORK_RETRY_COUNT):
@@ -184,16 +261,22 @@ class GitHubOps:
 
         # Build the git config command
         # Use wildcard for Docker environments with multiple mount paths
-        safe_cmd = ["git", "config", "--global", "--add", "safe.directory", "*"]
+        safe_cmd: list[str] = ["git", "config", "--global", "--add", "safe.directory", "*"]
 
-        # Wrap with sudo if system_account is set (same logic as _run_git)
-        # This ensures the config is written to the target user's ~/.gitconfig
-        if self.system_account:
-            safe_cmd = ["sudo", "-u", self.system_account] + safe_cmd
+        # Wrap with sudo only when actually cross-user (same logic as _run_git).
+        # This ensures the config is written to the target user's ~/.gitconfig.
+        account = self.system_account
+        if self._needs_sudo():
+            assert account is not None  # _needs_sudo() guarantees non-empty
+            safe_cmd = ["sudo", "-u", account] + safe_cmd
 
-        # Execute without cwd (global config doesn't need repo context)
+        # Execute without cwd (global config doesn't need repo context) and
+        # without the default 120s timeout — pass our own shorter one. Both
+        # must be dropped from _build_subprocess_kwargs() to avoid passing
+        # `timeout` twice (a hard TypeError in Python, surfaced as a warning
+        # here and which silently prevented safe.directory from ever being set).
         base_kwargs = self._build_subprocess_kwargs()
-        safe_kwargs = {k: v for k, v in base_kwargs.items() if k != "cwd"}
+        safe_kwargs = {k: v for k, v in base_kwargs.items() if k not in ("cwd", "timeout")}
         try:
             subprocess.run(safe_cmd, **safe_kwargs, check=False, timeout=5)
             GitHubOps._safe_directory_configured.add(cache_key)
@@ -205,13 +288,14 @@ class GitHubOps:
         """Run a git command with transient-network-error retry."""
         # Ensure safe.directory is configured for Docker volume mounts
         self._ensure_safe_directory()
-        # Build subprocess kwargs - remove cwd when using system_account to avoid
-        # Python permission check on repo_path (Issue #1421: cwd causes Permission denied)
         kwargs = self._build_subprocess_kwargs()
-        # If system_account is set, use -C flag instead of cwd for multi-user permission isolation
-        # (Issue #1395 + #1421: Allow GitHubOps to access user-private directories)
-        if self.system_account:
-            cmd = ["sudo", "-u", self.system_account, "git", "-C", self.repo_path] + args
+        account = self.system_account
+        if self._needs_sudo():
+            # git supports `-C <path>` (unlike gh), so we use it to set the
+            # working directory under a sudo wrapper where cwd would trigger a
+            # Python permission check as the service user (Issue #1421).
+            assert account is not None  # _needs_sudo() guarantees non-empty
+            cmd: list[str] = ["sudo", "-u", account, "git", "-C", self.repo_path] + args
             kwargs.pop("cwd", None)  # Remove cwd to avoid Python permission check
         else:
             cmd = ["git"] + args

--- a/tests/issues/716/test_github_ops.py
+++ b/tests/issues/716/test_github_ops.py
@@ -52,8 +52,17 @@ class TestGitHubOpsRepo:
         url = self.gh.get_repo_url()
         assert url == "https://github.com/user/test-repo.git"
 
+    @patch.object(GitHubOps, "get_repo_url", return_value="https://github.com/user/test-repo.git")
+    def test_get_repo_name(self, _mock_url):
+        # get_repo_name now resolves from the origin remote (not gh repo view),
+        # so it returns the parsed owner/repo slug without a gh subprocess call.
+        name = self.gh.get_repo_name()
+        assert name == "user/test-repo"
+
+    @patch.object(GitHubOps, "get_repo_url", side_effect=GitHubOpsError("no origin"))
     @patch("app.modules.workspace.autonomous.github_ops.subprocess.run")
-    def test_get_repo_name(self, mock_run):
+    def test_get_repo_name_fallback_no_remote(self, mock_run, _mock_url):
+        # When no origin remote is resolvable, fall back to gh repo view.
         mock_run.return_value = MagicMock(
             returncode=0, stdout='{"nameWithOwner": "user/test-repo"}'
         )
@@ -229,25 +238,22 @@ class TestGitHubOpsPR:
         cmd = mock_run.call_args[0][0]
         assert "--squash" in cmd
 
+    @patch.object(GitHubOps, "get_repo_url", return_value="https://github.com/user/test.git")
     @patch("app.modules.workspace.autonomous.github_ops.subprocess.run")
-    def test_list_pr_comments(self, mock_run):
-        # First call for get_repo_name, second for list comments
-        mock_run.side_effect = [
-            MagicMock(returncode=0, stdout='{"nameWithOwner": "user/test"}'),
-            MagicMock(
-                returncode=0,
-                stdout='{"id": 1, "path": "a.py", "body": "LGTM", "line": 10}\n{"id": 2, "path": "b.py", "body": "Fix", "line": 20}',
-            ),
-        ]
+    def test_list_pr_comments(self, mock_run, _mock_url):
+        # get_repo_name now resolves from the remote (no gh subprocess call),
+        # so only the gh api subprocess.run is mocked here.
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout='{"id": 1, "path": "a.py", "body": "LGTM", "line": 10}\n{"id": 2, "path": "b.py", "body": "Fix", "line": 20}',
+        )
         comments = self.gh.list_pr_comments(10)
         assert len(comments) == 2
 
+    @patch.object(GitHubOps, "get_repo_url", return_value="https://github.com/user/test.git")
     @patch("app.modules.workspace.autonomous.github_ops.subprocess.run")
-    def test_list_pr_comments_empty(self, mock_run):
-        mock_run.side_effect = [
-            MagicMock(returncode=0, stdout='{"nameWithOwner": "user/test"}'),
-            MagicMock(returncode=0, stdout=""),
-        ]
+    def test_list_pr_comments_empty(self, mock_run, _mock_url):
+        mock_run.return_value = MagicMock(returncode=0, stdout="")
         comments = self.gh.list_pr_comments(10)
         assert comments == []
 

--- a/tests/issues/716/test_github_ops_sudo.py
+++ b/tests/issues/716/test_github_ops_sudo.py
@@ -1,0 +1,165 @@
+"""Tests for GitHubOps sudo wrapper and owner/repo resolution.
+
+These cover the system_account / cross-user code paths that the original
+test_github_ops.py never exercised — the gap that let PR #1422's invalid
+`gh -C <path>` flag ship (gh has no `-C`; only git does), breaking every
+gh operation under a sudo wrapper and causing empty-requirements plans.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from app.modules.workspace.autonomous.github_ops import GitHubOps, GitHubOpsError
+
+
+def _completed(stdout: str = "", returncode: int = 0, stderr: str = "") -> MagicMock:
+    return MagicMock(returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+class TestNeedsSudo:
+    """_needs_sudo short-circuits when the service already runs as system_account."""
+
+    @patch("app.modules.workspace.autonomous.github_ops.pwd.getpwuid")
+    def test_same_user_skips_sudo(self, mock_getpwuid):
+        mock_getpwuid.return_value.pw_name = "alice"
+        gh = GitHubOps("/tmp/repo", system_account="alice")
+        assert gh._needs_sudo() is False
+
+    @patch("app.modules.workspace.autonomous.github_ops.pwd.getpwuid")
+    def test_cross_user_needs_sudo(self, mock_getpwuid):
+        mock_getpwuid.return_value.pw_name = "openace"
+        gh = GitHubOps("/tmp/repo", system_account="alice")
+        assert gh._needs_sudo() is True
+
+    def test_no_system_account_needs_no_sudo(self):
+        assert GitHubOps("/tmp/repo")._needs_sudo() is False
+
+    @patch(
+        "app.modules.workspace.autonomous.github_ops.pwd.getpwuid",
+        side_effect=KeyError("no such uid"),
+    )
+    def test_pwd_lookup_failure_defaults_to_sudo(self, _mock):
+        gh = GitHubOps("/tmp/repo", system_account="alice")
+        # Cannot determine current user → stay safe and assume cross-user.
+        assert gh._needs_sudo() is True
+
+
+class TestResolveOwnerRepo:
+    """_resolve_owner_repo derives owner/repo from the origin remote."""
+
+    def test_https_url(self):
+        gh = GitHubOps("/tmp/repo", system_account="alice")
+        with patch.object(
+            GitHubOps, "get_repo_url", return_value="https://github.com/open-ace/open-ace.git"
+        ):
+            assert gh._resolve_owner_repo() == "open-ace/open-ace"
+
+    def test_ssh_url(self):
+        gh = GitHubOps("/tmp/repo", system_account="alice")
+        with patch.object(
+            GitHubOps, "get_repo_url", return_value="git@github.com:open-ace/open-ace.git"
+        ):
+            assert gh._resolve_owner_repo() == "open-ace/open-ace"
+
+    def test_https_url_without_git_suffix(self):
+        gh = GitHubOps("/tmp/repo", system_account="alice")
+        with patch.object(
+            GitHubOps, "get_repo_url", return_value="https://github.com/open-ace/open-ace"
+        ):
+            assert gh._resolve_owner_repo() == "open-ace/open-ace"
+
+    def test_result_is_cached(self):
+        gh = GitHubOps("/tmp/repo", system_account="alice")
+        with patch.object(
+            GitHubOps, "get_repo_url", return_value="https://github.com/open-ace/open-ace.git"
+        ) as m:
+            assert gh._resolve_owner_repo() == "open-ace/open-ace"
+            assert gh._resolve_owner_repo() == "open-ace/open-ace"
+            # get_repo_url (and thus the underlying git call) runs only once.
+            assert m.call_count == 1
+
+    def test_no_remote_returns_none(self):
+        gh = GitHubOps("/tmp/repo", system_account="alice")
+        with patch.object(GitHubOps, "get_repo_url", side_effect=GitHubOpsError("no origin")):
+            # A GitHubOpsError (e.g. missing origin remote on a new project)
+            # must not propagate; resolution yields None.
+            assert gh._resolve_owner_repo() is None
+
+    def test_unparseable_url_returns_none(self):
+        gh = GitHubOps("/tmp/repo", system_account="alice")
+        with patch.object(GitHubOps, "get_repo_url", return_value="https://gitlab.com/foo/bar"):
+            assert gh._resolve_owner_repo() is None
+
+
+class TestRunGhSudo:
+    """_run_gh under a sudo wrapper uses -R owner/repo, never -C."""
+
+    @patch.object(GitHubOps, "_resolve_owner_repo", return_value="open-ace/open-ace")
+    @patch.object(GitHubOps, "_needs_sudo", return_value=True)
+    @patch("app.modules.workspace.autonomous.github_ops.subprocess.run")
+    def test_sudo_uses_repo_flag_not_dash_c(self, mock_run, _needs, _resolve):
+        mock_run.return_value = _completed(stdout='{"number": 240}')
+        gh = GitHubOps("/tmp/repo", system_account="alice")
+
+        gh.get_issue(240)
+
+        gh_cmd = mock_run.call_args.args[0]
+        assert gh_cmd[:4] == ["sudo", "-u", "alice", "gh"]
+        assert "-R" in gh_cmd
+        assert "open-ace/open-ace" in gh_cmd
+        # gh has no -C flag — it must never appear.
+        assert "-C" not in gh_cmd
+
+    @patch.object(GitHubOps, "_resolve_owner_repo", return_value="open-ace/open-ace")
+    @patch.object(GitHubOps, "_needs_sudo", return_value=True)
+    @patch("app.modules.workspace.autonomous.github_ops.subprocess.run")
+    def test_sudo_drops_cwd_kwarg(self, mock_run, _needs, _resolve):
+        mock_run.return_value = _completed(stdout='{"number": 240}')
+        gh = GitHubOps("/tmp/repo", system_account="alice")
+
+        gh.get_issue(240)
+
+        # The gh subprocess call must not pass cwd (Issue #1421: cwd under
+        # sudo triggers a Python permission check as the service user).
+        assert "cwd" not in mock_run.call_args.kwargs
+
+    @patch.object(GitHubOps, "_needs_sudo", return_value=False)
+    @patch("app.modules.workspace.autonomous.github_ops.subprocess.run")
+    def test_same_user_no_sudo_no_dash_c(self, mock_run, _needs):
+        # Service runs as the target user → sudo skipped, gh infers the repo
+        # from cwd as it always did.
+        mock_run.return_value = _completed(stdout='{"number": 240}')
+        gh = GitHubOps("/tmp/repo", system_account="alice")
+
+        gh.get_issue(240)
+
+        gh_cmd = mock_run.call_args.args[0]
+        assert gh_cmd[0] == "gh"  # no sudo prefix
+        assert "sudo" not in gh_cmd
+        assert "-C" not in gh_cmd
+        assert "-R" not in gh_cmd  # no explicit -R needed; cwd is kept
+        # cwd is preserved so gh can resolve the repo from the working dir.
+        assert mock_run.call_args.kwargs.get("cwd") == "/tmp/repo"
+
+
+class TestEnsureSafeDirectory:
+    """_ensure_safe_directory must not crash on duplicate timeout kwarg."""
+
+    def setup_method(self):
+        # The class-level cache persists across tests; reset it so each test
+        # actually exercises the subprocess path.
+        GitHubOps._safe_directory_configured.clear()
+
+    @patch("app.modules.workspace.autonomous.github_ops.subprocess.run")
+    def test_no_duplicate_timeout(self, mock_run):
+        # Regression guard: previously this raised
+        # "got multiple values for keyword argument 'timeout'" (a hard
+        # TypeError swallowed as a warning), so safe.directory was never set.
+        mock_run.return_value = _completed(stdout="")
+        gh = GitHubOps("/tmp/repo")
+
+        gh._ensure_safe_directory()
+
+        # subprocess.run ran and completed without raising; the call was made
+        # with exactly one timeout value.
+        assert mock_run.call_count == 1
+        assert mock_run.call_args.kwargs.get("timeout") == 5

--- a/tests/issues/716/test_github_ops_sudo.py
+++ b/tests/issues/716/test_github_ops_sudo.py
@@ -235,7 +235,49 @@ class TestRunGhRepoScoped:
         assert name == "owner/repo"
 
 
-class TestEnsureSafeDirectory:
+class TestGhApiSudo:
+    """gh api rejects -R; under sudo it must use the REST path + GHES --hostname."""
+
+    @patch.object(
+        GitHubOps, "get_repo_url", return_value="https://github.com/open-ace/open-ace.git"
+    )
+    @patch.object(GitHubOps, "_needs_sudo", return_value=True)
+    @patch("app.modules.workspace.autonomous.github_ops.subprocess.run")
+    def test_list_pr_comments_no_dash_r_under_sudo(self, mock_run, _needs, _url):
+        # gh api rejects -R (review: list_pr_comments under sudo would be
+        # injected with an illegal -R). It targets the repo via the REST path
+        # repos/<owner>/<repo>/pulls/.../comments, so no -R is needed.
+        mock_run.return_value = _completed(stdout="")
+        gh = GitHubOps("/tmp/repo", system_account="alice")
+
+        gh.list_pr_comments(10)
+
+        gh_cmd = mock_run.call_args.args[0]
+        assert gh_cmd[:3] == ["sudo", "-u", "alice"]
+        assert gh_cmd[3] == "gh"
+        assert gh_cmd[4] == "api"
+        assert "-R" not in gh_cmd
+        # The REST path uses the resolved owner/repo slug.
+        assert "repos/open-ace/open-ace/pulls/10/comments" in gh_cmd
+
+    @patch.object(GitHubOps, "get_repo_url", return_value="https://gh.example.com/owner/repo.git")
+    @patch.object(GitHubOps, "_needs_sudo", return_value=True)
+    @patch("app.modules.workspace.autonomous.github_ops.subprocess.run")
+    def test_list_pr_comments_ghes_adds_hostname(self, mock_run, _needs, _url):
+        # For GHES, gh api can't use -R; it needs --hostname to target the
+        # right server (review feedback).
+        mock_run.return_value = _completed(stdout="")
+        gh = GitHubOps("/tmp/repo", system_account="alice")
+
+        gh.list_pr_issue_comments(10)
+
+        gh_cmd = mock_run.call_args.args[0]
+        assert "--hostname" in gh_cmd
+        assert "gh.example.com" in gh_cmd
+        assert "-R" not in gh_cmd
+        # REST path uses the plain owner/repo (no host prefix).
+        assert "repos/owner/repo/issues/10/comments" in gh_cmd
+
     """_ensure_safe_directory must not crash on duplicate timeout kwarg."""
 
     def setup_method(self):

--- a/tests/issues/716/test_github_ops_sudo.py
+++ b/tests/issues/716/test_github_ops_sudo.py
@@ -201,19 +201,38 @@ class TestRunGhRepoScoped:
         assert "-R" not in gh_cmd
         assert "repo" in gh_cmd and "create" in gh_cmd
 
-    @patch.object(GitHubOps, "_resolve_owner_repo", return_value="open-ace/open-ace")
+    @patch.object(
+        GitHubOps, "get_repo_url", return_value="https://github.com/open-ace/open-ace.git"
+    )
     @patch.object(GitHubOps, "_needs_sudo", return_value=True)
     @patch("app.modules.workspace.autonomous.github_ops.subprocess.run")
-    def test_get_repo_name_no_dash_r(self, mock_run, _needs, _resolve):
-        # `gh repo view` likewise rejects -R.
-        mock_run.return_value = _completed(stdout='{"nameWithOwner": "open-ace/open-ace"}')
+    def test_get_repo_name_resolves_from_remote_under_sudo(self, mock_run, _needs, _url):
+        # get_repo_name must resolve the slug from the origin remote (via
+        # _resolve_owner_repo, which uses git -C under sudo) — NOT gh repo view,
+        # which under sudo has lost cwd and would guess the wrong repo / fail.
+        # Review: the old repo_scoped=False path only asserted "no -R" without
+        # verifying the repo is actually resolved, masking this regression.
         gh = GitHubOps("/tmp/repo", system_account="alice")
 
-        gh.get_repo_name()
+        name = gh.get_repo_name()
 
-        gh_cmd = mock_run.call_args.args[0]
-        assert "-R" not in gh_cmd
-        assert "repo" in gh_cmd and "view" in gh_cmd
+        assert name == "open-ace/open-ace"
+        # No gh subprocess call at all: the slug comes purely from git remote.
+        for call in mock_run.call_args_list:
+            assert "gh" not in call.args[0]
+
+    @patch.object(GitHubOps, "get_repo_url", return_value="https://gh.example.com/owner/repo.git")
+    @patch.object(GitHubOps, "_needs_sudo", return_value=True)
+    @patch("app.modules.workspace.autonomous.github_ops.subprocess.run")
+    def test_get_repo_name_ghes_strips_host_for_api_path(self, mock_run, _needs, _url):
+        # For GHES, _resolve_owner_repo carries the host for gh -R, but
+        # get_repo_name feeds gh api repos/<owner>/<repo>/... which must be a
+        # plain OWNER/REPO (no host in the REST path).
+        gh = GitHubOps("/tmp/repo", system_account="alice")
+
+        name = gh.get_repo_name()
+
+        assert name == "owner/repo"
 
 
 class TestEnsureSafeDirectory:

--- a/tests/issues/716/test_github_ops_sudo.py
+++ b/tests/issues/716/test_github_ops_sudo.py
@@ -86,8 +86,45 @@ class TestResolveOwnerRepo:
 
     def test_unparseable_url_returns_none(self):
         gh = GitHubOps("/tmp/repo", system_account="alice")
-        with patch.object(GitHubOps, "get_repo_url", return_value="https://gitlab.com/foo/bar"):
+        # A remote that doesn't match any known host/slug form (no owner/repo
+        # path component) yields None. Note: non-github.com hosts (gitlab/GHES)
+        # are now intentionally carried through as HOST/OWNER/REPO — see
+        # test_ghes_https_url_includes_host — so this must use a truly
+        # unparseable value.
+        with patch.object(GitHubOps, "get_repo_url", return_value="/local/path/repo"):
             assert gh._resolve_owner_repo() is None
+
+    def test_ssh_scheme_url(self):
+        # ssh://git@github.com/owner/repo.git — standard git SSH remote form
+        # that the original parser missed (review feedback).
+        gh = GitHubOps("/tmp/repo", system_account="alice")
+        with patch.object(
+            GitHubOps, "get_repo_url", return_value="ssh://git@github.com/open-ace/open-ace.git"
+        ):
+            assert gh._resolve_owner_repo() == "open-ace/open-ace"
+
+    def test_ssh_scheme_url_without_git_suffix(self):
+        gh = GitHubOps("/tmp/repo", system_account="alice")
+        with patch.object(
+            GitHubOps, "get_repo_url", return_value="ssh://git@github.com/open-ace/open-ace"
+        ):
+            assert gh._resolve_owner_repo() == "open-ace/open-ace"
+
+    def test_ghes_https_url_includes_host(self):
+        # A GHES host must be carried through as HOST/OWNER/REPO so gh's -R
+        # targets the right server (review feedback).
+        gh = GitHubOps("/tmp/repo", system_account="alice")
+        with patch.object(
+            GitHubOps, "get_repo_url", return_value="https://gh.example.com/owner/repo.git"
+        ):
+            assert gh._resolve_owner_repo() == "gh.example.com/owner/repo"
+
+    def test_ghes_scp_url_includes_host(self):
+        gh = GitHubOps("/tmp/repo", system_account="alice")
+        with patch.object(
+            GitHubOps, "get_repo_url", return_value="git@gh.example.com:owner/repo.git"
+        ):
+            assert gh._resolve_owner_repo() == "gh.example.com/owner/repo"
 
 
 class TestRunGhSudo:
@@ -139,6 +176,44 @@ class TestRunGhSudo:
         assert "-R" not in gh_cmd  # no explicit -R needed; cwd is kept
         # cwd is preserved so gh can resolve the repo from the working dir.
         assert mock_run.call_args.kwargs.get("cwd") == "/tmp/repo"
+
+
+class TestRunGhRepoScoped:
+    """repo create/view reject -R; repo_scoped=False omits it (review feedback)."""
+
+    @patch.object(GitHubOps, "_resolve_owner_repo", return_value="open-ace/open-ace")
+    @patch.object(GitHubOps, "_needs_sudo", return_value=True)
+    @patch("app.modules.workspace.autonomous.github_ops.subprocess.run")
+    def test_create_repo_no_dash_r(self, mock_run, _needs, _resolve):
+        # `gh repo create` does not accept -R; even when a remote resolves, the
+        # command must run plain gh under sudo (previously the unconditional -R
+        # would regress to "unknown shorthand flag: 'R'").
+        mock_run.return_value = _completed(
+            stdout="https://github.com/open-ace/new-repo\n✓ Created repository"
+        )
+        gh = GitHubOps("/tmp/repo", system_account="alice")
+
+        gh.create_repo("new-repo", private=True)
+
+        gh_cmd = mock_run.call_args.args[0]
+        assert gh_cmd[:3] == ["sudo", "-u", "alice"]
+        assert gh_cmd[3] == "gh"
+        assert "-R" not in gh_cmd
+        assert "repo" in gh_cmd and "create" in gh_cmd
+
+    @patch.object(GitHubOps, "_resolve_owner_repo", return_value="open-ace/open-ace")
+    @patch.object(GitHubOps, "_needs_sudo", return_value=True)
+    @patch("app.modules.workspace.autonomous.github_ops.subprocess.run")
+    def test_get_repo_name_no_dash_r(self, mock_run, _needs, _resolve):
+        # `gh repo view` likewise rejects -R.
+        mock_run.return_value = _completed(stdout='{"nameWithOwner": "open-ace/open-ace"}')
+        gh = GitHubOps("/tmp/repo", system_account="alice")
+
+        gh.get_repo_name()
+
+        gh_cmd = mock_run.call_args.args[0]
+        assert "-R" not in gh_cmd
+        assert "repo" in gh_cmd and "view" in gh_cmd
 
 
 class TestEnsureSafeDirectory:


### PR DESCRIPTION
## 问题

PR #1422 为修复 Issue #1421（`sudo -u` 后 `cwd=repo_path` 触发 Python 权限检查 Permission denied），把 `_run_gh` 和 `_run_git` 都改成 `-C <path>` 并弹出 cwd。

但 **git 支持 `-C`，gh CLI 不支持**（`-C` 是 git 专属标志，gh 没有）。导致所有设置了 `system_account` 的工作流，其 gh 操作（`issue view`、`issue comment`、`pr create` 等 16 个方法）全部报错失败：

```
unknown shorthand flag: 'C' in -C
```

实际影响：0703 batch issues（#240 等 6 个 issue）在 preparation 阶段读取 issue 正文失败（异常被静默吞掉），`requirements_text` 始终为空，planning 阶段 LLM 收到空需求，按"不编造假需求"规则产出「传入需求字段为空，无法解析出具体任务」的无效方案。后续 `gh issue comment` 也因同一 bug 全部失败。

> 注：`_run_git` 用 `git -C` 是正确的（worktree/branch 创建正常），仅 `_run_gh` 错误。

## 修复（`app/modules/workspace/autonomous/github_ops.py`）

**1. `_run_gh` sudo 分支 —— 用 `-R owner/repo` 替代非法的 `-C`**

新增 `_resolve_owner_repo()`：用 `git remote get-url origin`（git 支持 `-C`，sudo 下已验证可用）解析出 `owner/repo`（支持 https / ssh 两种形态），结果缓存到实例。`_run_gh` 的 sudo 分支改用 `gh -R owner/repo` 定位仓库；无 remote 时回退（如 `create_repo` 本就不需要仓库上下文）。

**2. 同用户跳过 sudo —— `_needs_sudo()`**

新增 helper：仅当 `system_account` 非空且与当前进程用户不同时才需 sudo，复用 `webui_manager.py:834-836` 既有的同用户短路模式。本机场景（服务以 rhuang 运行、system_account=rhuang）直接走原路径（`gh` + cwd），彻底绕开问题并省去无谓的 sudo 进程。`_run_gh` / `_run_git` / `_ensure_safe_directory` 三处统一改用 `_needs_sudo()`。

**3. `_ensure_safe_directory` 重复 timeout kwarg**

`_build_subprocess_kwargs()` 含 `timeout=120`，第 273 行又传 `timeout=5` → Python `TypeError: got multiple values for keyword argument 'timeout'`，被 warning 静默吞掉，导致 safe.directory 永远配不上、每次 `_run_git` 刷 warning。修法：构建 safe_kwargs 时同时弹出 `timeout`。

## 测试（`tests/issues/716/test_github_ops_sudo.py`，新增 14 个用例）

原 `test_github_ops.py` 全部用 `GitHubOps(path)` 无 `system_account`，**完全没覆盖 sudo 分支**——这是 bug 漏网的原因。新增：
- `_needs_sudo`：同用户/跨用户/无 account/pwd 查询失败
- `_resolve_owner_repo`：https/ssh/无 .git 后缀/缓存/无 remote/不可解析
- `_run_gh` sudo 命令形态：含 `-R owner/repo`、不含 `-C`、弹 cwd
- 同用户路径：无 sudo、无 -C、保留 cwd
- safe.directory 重复 timeout 回归

全部 14 个新测试 + 132 个既有 GitHubOps 相关测试通过，所有 pre-commit hooks（含 mypy）通过。

## 影响面

- 修复所有 system_account 工作流（本机同用户 + Docker 跨用户）的 gh 操作
- 同用户场景额外获得性能提升（省去 no-op 的 sudo 进程）
- safe.directory 配置恢复正常工作（Docker volume mount 防 dubious ownership）
- 不改动 `_run_git` 的 `-C`（git 支持，已验证正常）、orchestrator.py、routes

Refs #1421