### PR TITLE
fix(autonomous): 跨用户文件系统调用走 sudo，修复 Permission denied (Issue #1395)

### DIFF
--- a/app/modules/workspace/autonomous/agent_runner.py
+++ b/app/modules/workspace/autonomous/agent_runner.py
@@ -12,6 +12,7 @@ remote execution.
 import json
 import logging
 import os
+import pwd
 import re
 import shutil
 import signal
@@ -616,6 +617,35 @@ class AutonomousAgentRunner:
         return cli_session_id
 
     @staticmethod
+    def _ensure_project_dir(project_path: str, system_account: str | None) -> None:
+        """Ensure ``project_path`` exists, cross-user safe (Issue #1395).
+
+        ``Path.mkdir`` stats/creates as the service user and raises
+        ``PermissionError`` when the path lives under a user-private parent
+        (e.g. a 0700 home). When ``system_account`` differs from the service
+        user, route through ``sudo -u <account> mkdir -p`` (``mkdir`` is
+        covered by the sudoers ``OPENACE_UTILS`` alias). Same-user skips sudo
+        to avoid failing under systemd ``NoNewPrivileges`` (mirrors
+        ``github_ops._needs_sudo``).
+        """
+        same_user = False
+        if system_account:
+            try:
+                same_user = pwd.getpwuid(os.getuid()).pw_name == system_account
+            except (KeyError, OverflowError):
+                same_user = False
+        if system_account and not same_user:
+            subprocess.run(
+                ["sudo", "-u", system_account, "mkdir", "-p", project_path],
+                capture_output=True,
+                text=True,
+                timeout=30,
+                check=False,
+            )
+        else:
+            Path(project_path).mkdir(parents=True, exist_ok=True)
+
+    @staticmethod
     def _encode_project_path(project_path: str) -> str:
         """Best-effort match for the encoded project path used by Claude session history.
 
@@ -1182,7 +1212,8 @@ class AutonomousAgentRunner:
 
         # Expand project path
         project_path = os.path.expanduser(project_path)
-        Path(project_path).mkdir(parents=True, exist_ok=True)
+        # Ensure the project dir exists (cross-user safe, Issue #1395).
+        self._ensure_project_dir(project_path, system_account)
 
         # Protocol dispatch: different CLI tools speak different stdin protocols.
         # The generic _LocalSession path below assumes Claude SDK stream-json,

--- a/app/modules/workspace/autonomous/agent_runner.py
+++ b/app/modules/workspace/autonomous/agent_runner.py
@@ -635,13 +635,22 @@ class AutonomousAgentRunner:
             except (KeyError, OverflowError):
                 same_user = False
         if system_account and not same_user:
-            subprocess.run(
+            # Mirror Path.mkdir's failure semantics: raise on error so the
+            # caller fails fast instead of chalking it up to a later, fuzzier
+            # CLI-launch failure (Issue #1395 review).
+            result = subprocess.run(
                 ["sudo", "-u", system_account, "mkdir", "-p", project_path],
                 capture_output=True,
                 text=True,
                 timeout=30,
                 check=False,
             )
+            if result.returncode != 0:
+                raise PermissionError(
+                    f"Failed to create project dir {project_path} as "
+                    f"{system_account} (exit {result.returncode}): "
+                    f"{result.stderr.strip()}"
+                )
         else:
             Path(project_path).mkdir(parents=True, exist_ok=True)
 

--- a/app/modules/workspace/autonomous/github_ops.py
+++ b/app/modules/workspace/autonomous/github_ops.py
@@ -383,7 +383,9 @@ class GitHubOps:
                 raise GitHubOpsError("git not found")
         raise last_error or GitHubOpsError(f"git {' '.join(args)} failed after retries")
 
-    def path_exists_as_user(self, path: str, *, dir_only: bool = False) -> bool:
+    def path_exists_as_user(
+        self, path: str, *, dir_only: bool = False, file_only: bool = False
+    ) -> bool:
         """Check whether ``path`` exists, executing as ``system_account``.
 
         Python's ``Path.exists()`` stats with the service process's identity
@@ -398,10 +400,21 @@ class GitHubOps:
             path: Absolute path to check.
             dir_only: When True require the path to be a directory (``test -d``);
                 otherwise any existing entry passes (``test -e``).
+            file_only: When True require the path to be a regular file
+                (``test -f``). Used to distinguish a worktree's ``.git`` file
+                from a normal repo's ``.git`` directory. Mutually exclusive
+                with ``dir_only``.
         """
         if not self._needs_sudo():
+            if file_only:
+                return Path(path).is_file()
             return Path(path).is_dir() if dir_only else Path(path).exists()
-        flag = "-d" if dir_only else "-e"
+        if file_only:
+            flag = "-f"
+        elif dir_only:
+            flag = "-d"
+        else:
+            flag = "-e"
         assert self.system_account is not None  # _needs_sudo() guarantees non-empty
         try:
             result = subprocess.run(

--- a/app/modules/workspace/autonomous/github_ops.py
+++ b/app/modules/workspace/autonomous/github_ops.py
@@ -13,6 +13,7 @@ import pwd
 import re
 import subprocess
 import time
+from pathlib import Path
 from typing import Optional
 
 logger = logging.getLogger(__name__)
@@ -381,6 +382,39 @@ class GitHubOps:
             except FileNotFoundError:
                 raise GitHubOpsError("git not found")
         raise last_error or GitHubOpsError(f"git {' '.join(args)} failed after retries")
+
+    def path_exists_as_user(self, path: str, *, dir_only: bool = False) -> bool:
+        """Check whether ``path`` exists, executing as ``system_account``.
+
+        Python's ``Path.exists()`` stats with the service process's identity
+        and raises ``PermissionError`` when the path sits under a user-private
+        parent (e.g. a 700 home dir) — the same cross-user gap that the
+        ``_run_git``/``_run_gh`` sudo wrapper closes for git/gh subprocesses
+        (Issue #1395/#1421). This routes the check through
+        ``sudo -u <system_account> test`` so it runs with the repo owner's
+        privileges; ``test`` is covered by the sudoers ``OPENACE_UTILS`` alias.
+
+        Args:
+            path: Absolute path to check.
+            dir_only: When True require the path to be a directory (``test -d``);
+                otherwise any existing entry passes (``test -e``).
+        """
+        if not self._needs_sudo():
+            return Path(path).is_dir() if dir_only else Path(path).exists()
+        flag = "-d" if dir_only else "-e"
+        assert self.system_account is not None  # _needs_sudo() guarantees non-empty
+        try:
+            result = subprocess.run(
+                ["sudo", "-u", self.system_account, "test", flag, path],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                env=self._build_subprocess_kwargs().get("env"),
+            )
+            return result.returncode == 0
+        except (subprocess.TimeoutExpired, FileNotFoundError) as e:
+            logger.warning("path_exists_as_user(%s) failed: %s", path, e)
+            return False
 
     # ── Repo Operations ────────────────────────────────────────────
 

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -11,12 +11,10 @@ import json
 import logging
 import os
 import re
-import shutil
 import threading
 import time
 import uuid
 from datetime import datetime, timezone
-from pathlib import Path
 from typing import Optional
 
 from app.modules.workspace.autonomous.agent_runner import (
@@ -545,16 +543,9 @@ class AutonomousOrchestrator:
             return worktree_path or project_path
 
         canonical = os.path.realpath(worktree_path)
-        # Valid worktree: a .git file/dir inside means git set it up. If the
-        # stored path was unnormalized (legacy ".."), persist the canonical
-        # form so JSONL session detection matches Claude's encoding.
-        if worktree_path and os.path.isfile(os.path.join(canonical, ".git")):
-            if canonical != worktree_path:
-                self._update_workflow({"worktree_path": canonical})
-            return canonical
-
-        # Worktree missing — recreate from the main repo.
-        branch_name = wf.get("branch_name") or f"auto-dev/{self._workflow_id[:8]}"
+        # Resolve system_account up front so the validity check below can use
+        # it: os.path.isfile() stats as the service user and raises
+        # PermissionError under a user-private parent (700 home, Issue #1395).
         # Get system_account for multi-user permission isolation (Issue #1395)
         system_account = None
         user_id = wf.get("user_id")
@@ -564,6 +555,16 @@ class AutonomousOrchestrator:
             if user:
                 system_account = user.get("system_account")
         main_gh = GitHubOps(project_path, system_account=system_account)
+        # Valid worktree: a .git file inside means git set it up. If the
+        # stored path was unnormalized (legacy ".."), persist the canonical
+        # form so JSONL session detection matches Claude's encoding.
+        if worktree_path and main_gh.path_exists_as_user(os.path.join(canonical, ".git")):
+            if canonical != worktree_path:
+                self._update_workflow({"worktree_path": canonical})
+            return canonical
+
+        # Worktree missing — recreate from the main repo.
+        branch_name = wf.get("branch_name") or f"auto-dev/{self._workflow_id[:8]}"
         try:
             main_gh._run_git(["fetch", "origin", "main"])
             # Does the branch still exist locally or on origin?
@@ -1759,25 +1760,34 @@ class AutonomousOrchestrator:
                     # This happens when worktree dir was deleted externally (Issue #1442)
                     gh._run_git(["worktree", "prune"])
 
-                    # Check and clean up residual worktree directory (Issue #1442)
-                    if Path(worktree_path).exists():
-                        git_file = Path(worktree_path) / ".git"
-                        if git_file.exists() and git_file.is_file():
-                            # Valid worktree - remove via git
-                            try:
-                                gh.remove_worktree(worktree_path)
-                                logger.info("Removed residual worktree at %s", worktree_path)
-                            except GitHubOpsError:
-                                # Fallback to force delete
-                                shutil.rmtree(worktree_path)
-                                logger.info(
-                                    "Force removed worktree directory at %s",
-                                    worktree_path,
-                                )
-                        else:
-                            # Not a worktree, just a directory
-                            shutil.rmtree(worktree_path)
-                            logger.info("Removed residual directory at %s", worktree_path)
+                    # Check and clean up residual worktree (Issue #1442).
+                    # Path.exists()/shutil.rmtree() run as the service user and
+                    # hit [Errno 13] under a user-private parent (700 home),
+                    # so we cross-check via git's own worktree registry (already
+                    # routed through the sudo wrapper in _run_git) instead of
+                    # Python filesystem calls. Bare residual dirs (registered
+                    # then pruned, but the directory survived) are detected via
+                    # path_exists_as_user; removal of those falls back to git
+                    # and, on failure, is left in place with a warning rather
+                    # than force-deleting as the service user.
+                    if any(wt.get("path") == worktree_path for wt in gh.list_worktrees()):
+                        try:
+                            gh.remove_worktree(worktree_path)
+                            logger.info("Removed residual worktree at %s", worktree_path)
+                        except GitHubOpsError as e:
+                            logger.warning(
+                                "Could not remove residual worktree %s: %s", worktree_path, e
+                            )
+                    elif gh.path_exists_as_user(worktree_path, dir_only=True):
+                        # Directory present but not git-registered (e.g. pruned).
+                        # git worktree remove will reject it; we cannot safely
+                        # rmtree as the service user, so leave it and let
+                        # create_worktree surface a clear error if it blocks.
+                        logger.warning(
+                            "Residual non-worktree directory at %s is not git-registered; "
+                            "leaving in place (no rm privilege as service user)",
+                            worktree_path,
+                        )
 
                     wt_data = gh.create_worktree(
                         path=worktree_path,

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -555,10 +555,14 @@ class AutonomousOrchestrator:
             if user:
                 system_account = user.get("system_account")
         main_gh = GitHubOps(project_path, system_account=system_account)
-        # Valid worktree: a .git file inside means git set it up. If the
-        # stored path was unnormalized (legacy ".."), persist the canonical
-        # form so JSONL session detection matches Claude's encoding.
-        if worktree_path and main_gh.path_exists_as_user(os.path.join(canonical, ".git")):
+        # Valid worktree: a .git FILE inside means git set it up (a plain
+        # clone has a .git directory instead). If the stored path was
+        # unnormalized (legacy ".."), persist the canonical form so JSONL
+        # session detection matches Claude's encoding. file_only keeps the
+        # original os.path.isfile() semantics (Issue #1395 review).
+        if worktree_path and main_gh.path_exists_as_user(
+            os.path.join(canonical, ".git"), file_only=True
+        ):
             if canonical != worktree_path:
                 self._update_workflow({"worktree_path": canonical})
             return canonical

--- a/tests/issues/1395/test_cross_user_permissions.py
+++ b/tests/issues/1395/test_cross_user_permissions.py
@@ -1,0 +1,321 @@
+"""Tests for cross-user filesystem permission fixes (Issue #1395).
+
+The open-ace service runs as the ``openace`` user, but autonomous-development
+workflows target a repo owned by another user (``system_account``), often
+under a 0700 home directory. The ``_run_git``/``_run_gh`` sudo wrapper already
+routes git/gh subprocesses through ``sudo -u <system_account>``, but several
+*Python-native* filesystem calls slipped through and stat'd as the service
+user, raising ``[Errno 13] Permission denied``.
+
+Covers the four fixes:
+
+  1. ``GitHubOps.path_exists_as_user`` — routes existence checks through
+     ``sudo -u <account> test`` when cross-user, else falls back to ``Path``.
+  2. ``_do_preparation`` residual-worktree cleanup uses ``list_worktrees`` +
+     ``remove_worktree`` (both already sudo-wrapped) instead of
+     ``Path.exists()`` / ``shutil.rmtree``.
+  3. ``_ensure_worktree`` validity check uses ``path_exists_as_user`` instead
+     of ``os.path.isfile``.
+  4. ``_run_local_agent_task`` mkdir uses ``sudo -u <account> mkdir -p`` when
+     cross-user.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from app.modules.workspace.autonomous.github_ops import GitHubOps
+
+# ── GitHubOps.path_exists_as_user ────────────────────────────────────────
+
+
+class TestPathExistsAsUser:
+    def test_same_user_falls_back_to_path(self, monkeypatch, tmp_path):
+        # When the service already runs as system_account (NoNewPrivileges
+        # forbids sudo), path_exists_as_user must use Path directly.
+        gh = GitHubOps(str(tmp_path), system_account="openace")
+        monkeypatch.setattr(
+            "app.modules.workspace.autonomous.github_ops.pwd.getpwuid",
+            lambda _uid: MagicMock(pw_name="openace"),
+        )
+
+        target = tmp_path / "marker"
+        target.mkdir()
+        assert gh.path_exists_as_user(str(target), dir_only=True) is True
+
+    def test_same_user_dir_only_false_for_file(self, monkeypatch, tmp_path):
+        gh = GitHubOps(str(tmp_path), system_account="openace")
+        monkeypatch.setattr(
+            "app.modules.workspace.autonomous.github_ops.pwd.getpwuid",
+            lambda _uid: MagicMock(pw_name="openace"),
+        )
+        target = tmp_path / "file.txt"
+        target.write_text("x")
+        # dir_only requires a directory; a file must return False.
+        assert gh.path_exists_as_user(str(target), dir_only=True) is False
+        # Without dir_only the file exists.
+        assert gh.path_exists_as_user(str(target)) is True
+
+    def test_cross_user_runs_sudo_test(self, monkeypatch, tmp_path):
+        # Service runs as 'openace' but repo owner is 'rhuang' → must sudo.
+        gh = GitHubOps(str(tmp_path), system_account="rhuang")
+        monkeypatch.setattr(
+            "app.modules.workspace.autonomous.github_ops.pwd.getpwuid",
+            lambda _uid: MagicMock(pw_name="openace"),
+        )
+        target_path = "/home/rhuang/auto-dev-abc12345"
+        captured = {}
+
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+            captured["kwargs"] = kwargs
+            return MagicMock(returncode=0)  # test -e → 0 means exists
+
+        monkeypatch.setattr("app.modules.workspace.autonomous.github_ops.subprocess.run", fake_run)
+        result = gh.path_exists_as_user(target_path)
+
+        assert result is True
+        assert captured["cmd"] == ["sudo", "-u", "rhuang", "test", "-e", target_path]
+
+    def test_cross_user_dir_only_uses_d_flag(self, monkeypatch, tmp_path):
+        gh = GitHubOps(str(tmp_path), system_account="rhuang")
+        monkeypatch.setattr(
+            "app.modules.workspace.autonomous.github_ops.pwd.getpwuid",
+            lambda _uid: MagicMock(pw_name="openace"),
+        )
+        captured = {}
+
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+            return MagicMock(returncode=0)
+
+        monkeypatch.setattr("app.modules.workspace.autonomous.github_ops.subprocess.run", fake_run)
+        gh.path_exists_as_user("/home/rhuang/x", dir_only=True)
+
+        assert captured["cmd"][4] == "-d"
+
+    def test_cross_user_sudo_failure_returns_false(self, monkeypatch, tmp_path):
+        # test exits non-zero → path does not exist.
+        gh = GitHubOps(str(tmp_path), system_account="rhuang")
+        monkeypatch.setattr(
+            "app.modules.workspace.autonomous.github_ops.pwd.getpwuid",
+            lambda _uid: MagicMock(pw_name="openace"),
+        )
+        monkeypatch.setattr(
+            "app.modules.workspace.autonomous.github_ops.subprocess.run",
+            lambda cmd, **_kw: MagicMock(returncode=1),
+        )
+        assert gh.path_exists_as_user("/home/rhuang/missing") is False
+
+    def test_no_system_account_uses_path(self, tmp_path):
+        # system_account=None → never sudo, always Path.
+        gh = GitHubOps(str(tmp_path), system_account=None)
+        assert gh._needs_sudo() is False
+        present = tmp_path / "there"
+        present.mkdir()
+        assert gh.path_exists_as_user(str(present)) is True
+        assert gh.path_exists_as_user(str(tmp_path / "absent")) is False
+
+    def test_subprocess_exception_returns_false(self, monkeypatch, tmp_path):
+        # TimeoutExpired / FileNotFoundError → treat as "does not exist".
+        gh = GitHubOps(str(tmp_path), system_account="rhuang")
+        monkeypatch.setattr(
+            "app.modules.workspace.autonomous.github_ops.pwd.getpwuid",
+            lambda _uid: MagicMock(pw_name="openace"),
+        )
+        import subprocess as _sp
+
+        monkeypatch.setattr(
+            "app.modules.workspace.autonomous.github_ops.subprocess.run",
+            lambda cmd, **_kw: (_ for _ in ()).throw(_sp.TimeoutExpired(cmd, 10)),
+        )
+        assert gh.path_exists_as_user("/home/rhuang/x") is False
+
+
+# ── _do_preparation residual worktree cleanup ───────────────────────────
+
+
+def _make_workflow(**overrides):
+    base = {
+        "workflow_id": "wf-1395",
+        "title": "gh issue 1395",
+        "cli_tool": "claude-code",
+        "model": "",
+        "branch_strategy": "worktree",
+        "project_path": "/home/rhuang/open-ace",
+        "user_id": 5,
+        "current_phase": "preparation",
+        "status": "preparing",
+        "github_issue_number": 1395,
+        "requirements_text": "fix cross-user permissions",
+    }
+    base.update(overrides)
+    return base
+
+
+def _make_orchestrator(wf):
+    from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+    with (
+        patch("app.modules.workspace.autonomous.orchestrator.Database"),
+        patch(
+            "app.modules.workspace.autonomous.orchestrator.AutonomousWorkflowRepository"
+        ) as mock_repo_cls,
+    ):
+        mock_repo = MagicMock()
+        mock_repo.get_workflow.return_value = wf
+        mock_repo.list_milestones.return_value = []
+        mock_repo.create_milestone.return_value = {
+            "milestone_id": "ms-new",
+            "workflow_id": wf["workflow_id"],
+        }
+        mock_repo.create_event.return_value = {"id": 1}
+        mock_repo.update_workflow.return_value = wf
+        mock_repo_cls.return_value = mock_repo
+        o = AutonomousOrchestrator(wf["workflow_id"])
+        o.repo = mock_repo
+        o.emitter = MagicMock()
+    return o, mock_repo
+
+
+class TestPreparationWorktreeCleanup:
+    """Residual-worktree cleanup must route through git (already sudo-wrapped),
+    not Python Path.exists()/shutil.rmtree() which stat as the service user."""
+
+    def _setup_gh(self, mock_gh_cls, list_worktrees):
+        mock_gh = MagicMock()
+        mock_gh.create_issue.return_value = {"number": 1395, "url": "x"}
+        mock_gh.list_worktrees.return_value = list_worktrees
+        mock_gh.create_worktree.return_value = {"worktree_path": "/home/rhuang/auto-dev-wf-1395"}
+        mock_gh_cls.return_value = mock_gh
+        return mock_gh
+
+    @patch("app.modules.workspace.autonomous.orchestrator.GitHubOps")
+    def test_registered_residual_removed_via_git(self, mock_gh_cls):
+        # Residual worktree is still git-registered → remove_worktree (sudo).
+        wt_path = "/home/rhuang/auto-dev-wf-1395"
+        mock_gh = self._setup_gh(
+            mock_gh_cls,
+            list_worktrees=[{"path": wt_path, "branch": "auto-dev/wf-1395"}],
+        )
+        wf = _make_workflow()
+        orch, _repo = _make_orchestrator(wf)
+
+        orch._do_preparation(wf)
+
+        mock_gh.remove_worktree.assert_called_once_with(wt_path)
+        # shutil.rmtree must NOT have been invoked on the orchestrator: the
+        # service user cannot delete a path under a 0700 home anyway.
+        mock_gh.create_worktree.assert_called_once()
+        mock_gh.path_exists_as_user.assert_not_called()
+
+    @patch("app.modules.workspace.autonomous.orchestrator.GitHubOps")
+    def test_non_registered_residual_dir_left_in_place(self, mock_gh_cls):
+        # Directory present but pruned (not git-registered): no rm privilege →
+        # leave it and warn, do not rmtree as the service user.
+        mock_gh = self._setup_gh(mock_gh_cls, list_worktrees=[])
+        mock_gh.path_exists_as_user.return_value = True  # dir still on disk
+        wf = _make_workflow()
+        orch, _repo = _make_orchestrator(wf)
+
+        orch._do_preparation(wf)
+
+        mock_gh.remove_worktree.assert_not_called()
+        mock_gh.path_exists_as_user.assert_called()
+        # create_worktree still attempted (surfaces a clear error if blocked).
+        mock_gh.create_worktree.assert_called_once()
+
+    @patch("app.modules.workspace.autonomous.orchestrator.GitHubOps")
+    def test_clean_path_creates_worktree_directly(self, mock_gh_cls):
+        # No residual at all → straight to create_worktree.
+        mock_gh = self._setup_gh(mock_gh_cls, list_worktrees=[])
+        mock_gh.path_exists_as_user.return_value = False
+        wf = _make_workflow()
+        orch, _repo = _make_orchestrator(wf)
+
+        orch._do_preparation(wf)
+
+        mock_gh.remove_worktree.assert_not_called()
+        mock_gh.create_worktree.assert_called_once()
+
+    @patch("app.modules.workspace.autonomous.orchestrator.GitHubOps")
+    def test_remove_failure_does_not_raise(self, mock_gh_cls):
+        # If git worktree remove fails, log a warning and continue — must
+        # NOT fall back to shutil.rmtree (would PermissionError as service user).
+        from app.modules.workspace.autonomous.github_ops import GitHubOpsError
+
+        wt_path = "/home/rhuang/auto-dev-wf-1395"
+        mock_gh = self._setup_gh(
+            mock_gh_cls,
+            list_worktrees=[{"path": wt_path, "branch": "auto-dev/wf-1395"}],
+        )
+        mock_gh.remove_worktree.side_effect = GitHubOpsError("locked")
+        wf = _make_workflow()
+        orch, _repo = _make_orchestrator(wf)
+
+        # Must not raise — preparation continues to create_worktree.
+        orch._do_preparation(wf)
+        mock_gh.create_worktree.assert_called_once()
+
+
+# ── _ensure_project_dir (agent_runner mkdir) ────────────────────────────
+
+
+class TestEnsureProjectDir:
+    def test_cross_user_mkdir_uses_sudo(self, monkeypatch, tmp_path):
+        # project_path under a user-private dir → mkdir goes through sudo.
+        from app.modules.workspace.autonomous import agent_runner
+
+        monkeypatch.setattr(agent_runner.pwd, "getpwuid", lambda _uid: MagicMock(pw_name="openace"))
+        captured = {}
+
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+            captured["kwargs"] = kwargs
+            return MagicMock(returncode=0)
+
+        monkeypatch.setattr(agent_runner.subprocess, "run", fake_run)
+        target = str(tmp_path / "deep" / "newdir")
+
+        agent_runner.AutonomousAgentRunner._ensure_project_dir(target, "rhuang")
+
+        assert captured["cmd"] == ["sudo", "-u", "rhuang", "mkdir", "-p", target]
+        assert captured["kwargs"]["timeout"] == 30
+
+    def test_same_user_mkdir_uses_path(self, monkeypatch, tmp_path):
+        # Same user → plain Path.mkdir, no sudo (NoNewPrivileges safe).
+        from app.modules.workspace.autonomous import agent_runner
+
+        monkeypatch.setattr(agent_runner.pwd, "getpwuid", lambda _uid: MagicMock(pw_name="openace"))
+        sudo_calls = []
+        monkeypatch.setattr(
+            agent_runner.subprocess,
+            "run",
+            lambda cmd, **_kw: sudo_calls.append(cmd) or MagicMock(returncode=0),
+        )
+        target = tmp_path / "plain"
+        agent_runner.AutonomousAgentRunner._ensure_project_dir(str(target), "openace")
+
+        assert sudo_calls == []  # no sudo
+        assert target.is_dir()  # Path.mkdir actually created it
+
+    def test_no_system_account_uses_path(self, tmp_path):
+        from app.modules.workspace.autonomous import agent_runner
+
+        target = tmp_path / "plain"
+        agent_runner.AutonomousAgentRunner._ensure_project_dir(str(target), None)
+        assert target.is_dir()
+
+    def test_cross_user_existing_dir_still_sudo_mkdir_p(self, monkeypatch, tmp_path):
+        # mkdir -p is idempotent; even if the dir exists, sudo mkdir is fine.
+        from app.modules.workspace.autonomous import agent_runner
+
+        monkeypatch.setattr(agent_runner.pwd, "getpwuid", lambda _uid: MagicMock(pw_name="openace"))
+        target = tmp_path / "exists"
+        target.mkdir()
+        captured = {}
+        monkeypatch.setattr(
+            agent_runner.subprocess,
+            "run",
+            lambda cmd, **_kw: captured.setdefault("cmd", cmd) or MagicMock(returncode=0),
+        )
+        agent_runner.AutonomousAgentRunner._ensure_project_dir(str(target), "rhuang")
+        assert captured["cmd"][:3] == ["sudo", "-u", "rhuang"]

--- a/tests/issues/1395/test_cross_user_permissions.py
+++ b/tests/issues/1395/test_cross_user_permissions.py
@@ -92,6 +92,41 @@ class TestPathExistsAsUser:
 
         assert captured["cmd"][4] == "-d"
 
+    def test_cross_user_file_only_uses_f_flag(self, monkeypatch, tmp_path):
+        # file_only → test -f, distinguishes a worktree's .git FILE from a
+        # normal repo's .git DIRECTORY (Issue #1395 review).
+        gh = GitHubOps(str(tmp_path), system_account="rhuang")
+        monkeypatch.setattr(
+            "app.modules.workspace.autonomous.github_ops.pwd.getpwuid",
+            lambda _uid: MagicMock(pw_name="openace"),
+        )
+        captured = {}
+
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+            return MagicMock(returncode=0)
+
+        monkeypatch.setattr("app.modules.workspace.autonomous.github_ops.subprocess.run", fake_run)
+        gh.path_exists_as_user("/home/rhuang/repo/.git", file_only=True)
+
+        assert captured["cmd"][4] == "-f"
+
+    def test_same_user_file_only_false_for_directory(self, monkeypatch, tmp_path):
+        # A directory must NOT pass the file_only check — this is the core
+        # regression guard: a plain clone's .git directory must not be mistaken
+        # for a valid worktree's .git file.
+        gh = GitHubOps(str(tmp_path), system_account="openace")
+        monkeypatch.setattr(
+            "app.modules.workspace.autonomous.github_ops.pwd.getpwuid",
+            lambda _uid: MagicMock(pw_name="openace"),
+        )
+        # tmp_path itself is a directory.
+        assert gh.path_exists_as_user(str(tmp_path), file_only=True) is False
+        # A real file passes.
+        f = tmp_path / "gitfile"
+        f.write_text("gitdir: ../.git/worktrees/x")
+        assert gh.path_exists_as_user(str(f), file_only=True) is True
+
     def test_cross_user_sudo_failure_returns_false(self, monkeypatch, tmp_path):
         # test exits non-zero → path does not exist.
         gh = GitHubOps(str(tmp_path), system_account="rhuang")
@@ -312,10 +347,30 @@ class TestEnsureProjectDir:
         target = tmp_path / "exists"
         target.mkdir()
         captured = {}
-        monkeypatch.setattr(
-            agent_runner.subprocess,
-            "run",
-            lambda cmd, **_kw: captured.setdefault("cmd", cmd) or MagicMock(returncode=0),
-        )
+
+        def fake_run(cmd, **_kw):
+            captured["cmd"] = cmd
+            return MagicMock(returncode=0)
+
+        monkeypatch.setattr(agent_runner.subprocess, "run", fake_run)
         agent_runner.AutonomousAgentRunner._ensure_project_dir(str(target), "rhuang")
         assert captured["cmd"][:3] == ["sudo", "-u", "rhuang"]
+
+    def test_cross_user_mkdir_failure_raises(self, monkeypatch, tmp_path):
+        # sudo/mkdir failure must raise (fail-fast) instead of being swallowed,
+        # mirroring Path.mkdir's semantics (Issue #1395 review).
+        from app.modules.workspace.autonomous import agent_runner
+
+        monkeypatch.setattr(agent_runner.pwd, "getpwuid", lambda _uid: MagicMock(pw_name="openace"))
+
+        def fake_run(cmd, **_kw):
+            return MagicMock(
+                returncode=1, stderr="mkdir: cannot create directory: Permission denied"
+            )
+
+        monkeypatch.setattr(agent_runner.subprocess, "run", fake_run)
+
+        import pytest
+
+        with pytest.raises(PermissionError, match="Permission denied"):
+            agent_runner.AutonomousAgentRunner._ensure_project_dir("/home/rhuang/no-perm", "rhuang")

--- a/tests/issues/814/test_worktree_path_selfheal.py
+++ b/tests/issues/814/test_worktree_path_selfheal.py
@@ -103,11 +103,14 @@ class TestEnsureWorktreeSelfHeal:
         wf = _make_workflow()
         canonical = os.path.realpath(wf["worktree_path"])
 
-        def fake_isfile(p):
-            # The .git marker exists inside the canonical worktree dir.
-            return p == os.path.join(canonical, ".git")
-
-        monkeypatch.setattr(os.path, "isfile", fake_isfile)
+        # _ensure_worktree now checks validity via main_gh.path_exists_as_user
+        # (cross-user safe; replaced the old os.path.isfile probe, Issue #1395).
+        fake_gh = MagicMock()
+        fake_gh.path_exists_as_user.return_value = True
+        monkeypatch.setattr(
+            "app.modules.workspace.autonomous.orchestrator.GitHubOps",
+            lambda _path, **_kw: fake_gh,
+        )
         o = _make_orchestrator(wf)
 
         result = o._ensure_worktree(wf)
@@ -122,7 +125,12 @@ class TestEnsureWorktreeSelfHeal:
         wf = _make_workflow(worktree_path=os.path.realpath("/srv/repo/../wt"))
         canonical = wf["worktree_path"]
 
-        monkeypatch.setattr(os.path, "isfile", lambda p: p == os.path.join(canonical, ".git"))
+        fake_gh = MagicMock()
+        fake_gh.path_exists_as_user.return_value = True
+        monkeypatch.setattr(
+            "app.modules.workspace.autonomous.orchestrator.GitHubOps",
+            lambda _path, **_kw: fake_gh,
+        )
         o = _make_orchestrator(wf)
 
         result = o._ensure_worktree(wf)
@@ -135,11 +143,10 @@ class TestEnsureWorktreeSelfHeal:
         wf = _make_workflow()
         canonical = os.path.realpath(wf["worktree_path"])
 
-        # No .git marker → worktree is considered missing.
-        monkeypatch.setattr(os.path, "isfile", lambda p: False)
-
         o = _make_orchestrator(wf)
         fake_gh = MagicMock()
+        # No .git marker → worktree is considered missing.
+        fake_gh.path_exists_as_user.return_value = False
         # Local branch exists.
         local_check = MagicMock(returncode=0)
         remote_check = MagicMock(returncode=1)
@@ -152,7 +159,7 @@ class TestEnsureWorktreeSelfHeal:
         ]
         monkeypatch.setattr(
             "app.modules.workspace.autonomous.orchestrator.GitHubOps",
-            lambda _path: fake_gh,
+            lambda _path, **_kw: fake_gh,
         )
 
         result = o._ensure_worktree(wf)
@@ -168,10 +175,9 @@ class TestEnsureWorktreeSelfHeal:
         wf = _make_workflow()
         canonical = os.path.realpath(wf["worktree_path"])
 
-        monkeypatch.setattr(os.path, "isfile", lambda p: False)
-
         o = _make_orchestrator(wf)
         fake_gh = MagicMock()
+        fake_gh.path_exists_as_user.return_value = False
         not_found = MagicMock(returncode=1)
         fake_gh._run_git.side_effect = [
             MagicMock(),  # fetch origin main
@@ -182,7 +188,7 @@ class TestEnsureWorktreeSelfHeal:
         ]
         monkeypatch.setattr(
             "app.modules.workspace.autonomous.orchestrator.GitHubOps",
-            lambda _path: fake_gh,
+            lambda _path, **_kw: fake_gh,
         )
 
         result = o._ensure_worktree(wf)


### PR DESCRIPTION
## 问题

open-ace 服务以 \`openace\` 用户运行，但 AI 自主开发工作流的 \`project_path\` 常指向用户私有目录（如 \`/home/rhuang/open-ace\`，家目录 \`drwx------\` 700）。

项目已有一套 \`system_account\` + \`sudo -u <account>\` 机制（Issue #1395/#1421）覆盖所有 **git/gh 子进程**（\`_run_git\`/\`_run_gh\`/agent 启动），但**漏了 5 处 Python 进程自身的文件系统调用**——它们始终以 \`openace\` 身份执行，遇到用户私有父目录就 \`[Errno 13] Permission denied\`。

触发场景：黄迎春（\`system_account=rhuang\`）创建 \`worktree\` 策略工作流，\`project_path=/home/rhuang/open-ace\`，\`orchestrator.py\` 把 worktree 目录拼成 \`/home/rhuang/auto-dev-0b463e77\`，随后 \`Path(worktree_path).exists()\` 以 openace 身份 stat → 崩。

```
PermissionError: [Errno 13] Permission denied: '/home/rhuang/auto-dev-0b463e77'
  File ".../orchestrator.py", line 1763, in _do_preparation
  File ".../pathlib.py", line 1352, in exists
```

## 根因

| 调用类型 | 是否走 sudo | 状态 |
|---|---|---|
| git/gh 子进程（\`_run_git\`/\`_run_gh\`/\`create_worktree\`…） | ✅ 已走 \`sudo -u\` | 正常 |
| Python \`Path.exists()\`/\`shutil.rmtree()\`/\`Path.mkdir()\` | ❌ 以服务进程身份 | **本次修复** |

\`test\`/\`mkdir\`/\`git\`/\`gh\` **已在 sudoers \`OPENACE_UTILS\` 别名授权**，无需新增 sudoers 规则。

## 修复

### 源码（\`app/modules/workspace/autonomous/\`）

1. **\`github_ops.py\`** — 新增 \`path_exists_as_user(path, *, dir_only=False)\`
   - 跨用户时走 \`sudo -u <account> test -e/-d <path>\`（\`test\` 已在 sudoers）
   - 同用户/无 \`system_account\` 时回退 \`Path.exists()\`（避免 NoNewPrivileges 下 sudo 失败）
   - 复用现有 \`_needs_sudo()\` + \`_build_subprocess_kwargs()\` env 注入

2. **\`orchestrator.py\` \`_do_preparation\`**（原报错点）
   - 残留 worktree 清理：\`gh.list_worktrees()\` 判断是否已登记 → \`gh.remove_worktree\`（均已 sudo）
   - 未登记的残留目录：\`gh.path_exists_as_user\` 探测后**保留 + 记日志**，**不再 \`shutil.rmtree\`**（不引入 \`rm\` 权限）

3. **\`orchestrator.py\` \`_ensure_worktree\`**
   - \`os.path.isfile(canonical/".git")\` → \`main_gh.path_exists_as_user(...)\`

4. **\`agent_runner.py\`** — 抽出 \`_ensure_project_dir(project_path, system_account)\` 静态方法
   - 跨用户时 \`sudo -u <account> mkdir -p\`（\`mkdir\` 已在 sudoers）
   - 同用户时 \`Path.mkdir\`

### 测试

- **新增 \`tests/issues/1395/\`**（15 个用例）：覆盖 \`path_exists_as_user\`（7）、残留 worktree 清理（4）、\`_ensure_project_dir\`（4）
- **更新 \`tests/issues/814/\`**：mock 从 \`os.path.isfile\` 迁移到 \`GitHubOps.path_exists_as_user\`（适配改动 3）
- **85 个相关测试全绿**

## 不改动

- **sudoers**：\`OPENACE_UTILS\` 已含 \`test\`/\`mkdir\`/\`git\`/\`gh\`
- **systemd unit** / 服务运行用户：维持 \`openace\`
- **git/gh 子进程调用链**：已正确走 sudo
- merge-conflict 的 \`temp_wt_path\`：由 \`add_worktree\` 创建（已 sudo），无 Python FS 调用

## 验证

- [x] 三个源文件 \`py_compile\` + black/isort/ruff/mypy 全通过
- [x] 新增 15 个测试全绿；814/716 相关测试全绿（85 passed）
- [ ] 部署到 192.168.31.159 后实测：黄迎春账号重跑 worktree 工作流，\`journalctl -u open-ace | grep -i "permission denied"\` 应为空

## 回滚

纯函数级修改，两个 \`.py\` 文件，\`git revert\` 即可；无数据迁移。

Closes #1395