### PR TITLE
fix(autonomous): 重跑时 _get_gh 回退 project_path，避免 git -C 指向已删 worktree (Issue #1395 续)

### DIFF
--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -495,11 +495,21 @@ class AutonomousOrchestrator:
         return self.repo.get_workflow(self._workflow_id)
 
     def _get_gh(self) -> GitHubOps:
-        """Lazily initialize GitHubOps."""
+        """Lazily initialize GitHubOps.
+
+        Prefers ``worktree_path`` (the agent's working repo once preparation
+        has run) but falls back to ``project_path`` when the worktree dir does
+        not yet exist. This matters on rerun: a previous failure may have
+        removed the worktree dir while the stale ``worktree_path`` is still in
+        the DB, so binding GitHubOps to it makes every ``git -C <worktree>``
+        fail with ENOENT (Issue #1395 rerun regression). Preparation creates
+        the worktree; until it does, the main repo is the only valid repo_path.
+        """
         wf = self.workflow
         if not self._gh and wf:
-            project_path = wf.get("worktree_path") or wf.get("project_path", "")
-            # Get system_account for multi-user permission isolation (Issue #1395)
+            worktree_path = wf.get("worktree_path", "")
+            project_path = wf.get("project_path", "")
+            # Resolve system_account for multi-user permission isolation (Issue #1395)
             system_account = None
             user_id = wf.get("user_id")
             if user_id:
@@ -507,7 +517,16 @@ class AutonomousOrchestrator:
                 user = user_repo.get_user_by_id(user_id)
                 if user:
                     system_account = user.get("system_account")
-            self._gh = GitHubOps(project_path, system_account=system_account)
+            # Prefer the worktree once it exists; otherwise the main repo.
+            # path_exists_as_user cross-user-checks under a 700 home (the
+            # service user can't stat it directly), so it's correct both for
+            # same-user dev runs and the multi-user deployment.
+            chosen = project_path
+            if worktree_path:
+                probe = GitHubOps(project_path, system_account=system_account)
+                if probe.path_exists_as_user(worktree_path, dir_only=True):
+                    chosen = worktree_path
+            self._gh = GitHubOps(chosen, system_account=system_account)
         return self._gh
 
     def _ensure_worktree(self, wf: dict) -> str:
@@ -1575,6 +1594,9 @@ class AutonomousOrchestrator:
                         "branch_strategy": "worktree",
                     }
                 )
+                # Worktree now exists; drop the cached gh (bound to the main
+                # repo) so the next _get_gh() rebinds to the worktree path.
+                self._gh = None
                 self._create_milestone(
                     phase="preparation",
                     milestone_type="branch_created",
@@ -1799,6 +1821,10 @@ class AutonomousOrchestrator:
                         base="origin/main",
                     )
                     self._update_workflow({"worktree_path": wt_data.get("worktree_path", "")})
+                    # The worktree now exists; drop the cached gh (bound to the
+                    # main repo during preparation) so the next _get_gh() rebinds
+                    # to the worktree path — the agent's actual working repo.
+                    self._gh = None
                 else:
                     gh.create_branch(branch_name, base="origin/main")
                 self._create_milestone(

--- a/tests/issues/1395/test_cross_user_permissions.py
+++ b/tests/issues/1395/test_cross_user_permissions.py
@@ -674,3 +674,116 @@ class TestSingleShotUserIdPropagation:
         )
 
         assert captured["user_id"] == 77  # real user, not 0
+
+
+# ── _get_gh() rerun path fallback (Issue #1395 rerun regression) ─────────
+
+
+class TestGetGhRerunFallback:
+    """On rerun, a worktree-strategy workflow may carry a stale
+    ``worktree_path`` in the DB whose dir was removed by a prior failure's
+    cleanup. ``_get_gh()`` previously bound ``GitHubOps`` to that stale path
+    unconditionally (``worktree_path or project_path``), making every
+    ``git -C <stale>`` fail with ENOENT during preparation. It must fall back
+    to ``project_path`` when the worktree dir is gone, and rebind to the
+    worktree once preparation recreates it."""
+
+    def _make_orchestrator(self, wf_data):
+        from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+        with (
+            patch("app.modules.workspace.autonomous.orchestrator.Database"),
+            patch(
+                "app.modules.workspace.autonomous.orchestrator.AutonomousWorkflowRepository"
+            ) as mock_repo_cls,
+        ):
+            mock_repo = MagicMock()
+            mock_repo.get_workflow.return_value = wf_data
+            mock_repo.update_workflow.return_value = wf_data
+            mock_repo_cls.return_value = mock_repo
+            orch = AutonomousOrchestrator(wf_data["workflow_id"])
+            orch.repo = mock_repo
+            orch.emitter = MagicMock()
+            return orch
+
+    def _wf(self, **overrides):
+        base = {
+            "workflow_id": "wf-1395",
+            "user_id": 1,
+            "project_path": "/home/rhuang/open-ace",
+            "worktree_path": "/home/rhuang/auto-dev-dead",
+            "branch_strategy": "worktree",
+            "branch_name": "auto-dev/dead",
+        }
+        base.update(overrides)
+        return base
+
+    def test_falls_back_to_project_when_worktree_dir_missing(self, monkeypatch):
+        # Stale worktree_path in DB, dir gone → _get_gh must use project_path.
+        orch = self._make_orchestrator(self._wf())
+
+        # path_exists_as_user → False (worktree dir doesn't exist)
+        monkeypatch.setattr(
+            "app.modules.workspace.autonomous.github_ops.GitHubOps.path_exists_as_user",
+            lambda self, path, **kw: False,
+        )
+
+        gh = orch._get_gh()
+        assert gh.repo_path == "/home/rhuang/open-ace"  # project_path, not stale
+
+    def test_uses_worktree_when_dir_exists(self, monkeypatch):
+        # Worktree dir present → _get_gh binds to worktree_path.
+        orch = self._make_orchestrator(self._wf())
+
+        monkeypatch.setattr(
+            "app.modules.workspace.autonomous.github_ops.GitHubOps.path_exists_as_user",
+            lambda self, path, **kw: True,
+        )
+
+        gh = orch._get_gh()
+        assert gh.repo_path == "/home/rhuang/auto-dev-dead"  # worktree_path
+
+    def test_no_worktree_path_uses_project_path(self, monkeypatch):
+        # Empty worktree_path (e.g. merge cleanup cleared it) → project_path.
+        orch = self._make_orchestrator(self._wf(worktree_path=""))
+
+        called = []
+
+        def _probe(self, path, **kw):
+            called.append(path)
+            return False
+
+        monkeypatch.setattr(
+            "app.modules.workspace.autonomous.github_ops.GitHubOps.path_exists_as_user",
+            _probe,
+        )
+
+        gh = orch._get_gh()
+        assert gh.repo_path == "/home/rhuang/open-ace"
+        # Must NOT probe an empty worktree path.
+        assert called == []
+
+    def test_cached_gh_not_rebuilt_until_reset(self, monkeypatch):
+        # After the first _get_gh() caches a gh bound to project_path, a
+        # second call returns the same instance even if the worktree later
+        # appears — unless self._gh is reset (preparation does this after
+        # creating the worktree).
+        orch = self._make_orchestrator(self._wf())
+        monkeypatch.setattr(
+            "app.modules.workspace.autonomous.github_ops.GitHubOps.path_exists_as_user",
+            lambda self, path, **kw: False,
+        )
+
+        first = orch._get_gh()
+        second = orch._get_gh()
+        assert first is second  # cached
+
+        # Simulate preparation finishing: reset cache, worktree now exists.
+        orch._gh = None
+        monkeypatch.setattr(
+            "app.modules.workspace.autonomous.github_ops.GitHubOps.path_exists_as_user",
+            lambda self, path, **kw: True,
+        )
+        third = orch._get_gh()
+        assert third.repo_path == "/home/rhuang/auto-dev-dead"  # rebound
+        assert third is not first


### PR DESCRIPTION
## 背景

issue #143 工作流在 159 部署上重跑报错：

```
git worktree add -b auto-dev/0b463e77 /home/rhuang/auto-dev-0b463e77 origin/main failed (exit 128):
致命错误：cannot change to '/home/rhuang/auto-dev-0b463e77': 没有那个文件或目录
```

注意 journal 里所有 git 命令的 `-C` 路径都是 `worktree_path`（`/home/rhuang/auto-dev-0b463e77`）而非 repo（`/home/rhuang/open-ace`）。

## 根因（与权限无关）

worktree 策略工作流首轮跑时 `_do_preparation` 成功创建了 worktree 并把 `worktree_path` 持久化进 DB（orchestrator.py:1820）。后续失败清理把 worktree 目录删了，但 DB 字段还在。重跑时：

1. `_do_preparation` 走现有项目路径（非 `is_new_project`），`self._gh` 没在 preparation 显式构造
2. line 1647 `gh = self._get_gh()` 懒加载
3. 旧版 `_get_gh()`（orchestrator.py:501）用 `wf.get("worktree_path") or wf.get("project_path")`，**优先取已不存在的 worktree_path**
4. 构造出 `GitHubOps(repo_path="/home/rhuang/auto-dev-0b463e77")` → 所有 `git -C <worktree_path> ...` ENOENT
5. preparation 阶段 `_ensure_worktree` 被故意跳过（orchestrator.py:1463 `phase != "preparation"`），没有自愈机会

手动用正确的 repo 路径重放同一命令序列（`git -C /home/rhuang/open-ace ...`）全部成功，确认是路径选错而非权限。

## 修复

### 1. `_get_gh()` 增加 worktree 存在性回退
- `worktree_path` 存在且目录在 → 用 `worktree_path`
- 否则回退 `project_path`
- 用 `path_exists_as_user` 跨用户探测（700 home 下服务用户直接 stat 会 PermissionError）

### 2. preparation 创建 worktree 后重置缓存
`create_worktree` 成功后 `self._gh = None`，让下游 `_get_gh()` 重新绑定到新 worktree（主路径 + fork 快路径都加）。否则缓存还指向 project_path，后续阶段的 git 操作会跑在主仓库而非 agent 工作目录。

## 测试

`tests/issues/1395/test_cross_user_permissions.py` 新增 `TestGetGhRerunFallback`（4 用例）：
- `test_falls_back_to_project_when_worktree_dir_missing`：worktree 目录缺失 → 用 project_path
- `test_uses_worktree_when_dir_exists`：worktree 目录在 → 用 worktree_path
- `test_no_worktree_path_uses_project_path`：空 worktree_path → 用 project_path 且不探测
- `test_cached_gh_not_rebuilt_until_reset`：缓存语义 + reset 后重新绑定

全部 36 个 1395 测试 + 100 个 723/826/996/1002 测试通过。

## 关联

- 续 #1466 / #1467（跨用户权限修复）
- 该 bug 在那两个 PR 之前就存在，但只有 worktree 策略 + 失败重跑场景才触发