### PR TITLE
fix(install/package): configure_sudoers 增量更新补 wrapper 规则探测 (Issue #1395)

### DIFF
--- a/scripts/install-central/package-method/install.sh
+++ b/scripts/install-central/package-method/install.sh
@@ -1990,9 +1990,14 @@ ${line}"
         # secure_path, so without this check the wrapper rule never gets
         # added on upgrade — stock deployments stayed broken (the agent
         # launch failed with "sudo: a password is required").
+        # Match user+path on the same line (like the webui/fetch checks above):
+        # a file-global grep would false-pass when another user already has a
+        # wrapper rule (other_user_rules are preserved), skipping the current
+        # user's authorization.
         local wrapper_path="/usr/local/bin/openace-run-as"
-        if [ -x "$wrapper_path" ] && ! grep -qF "openace-run-as" "$sudoers_file" 2>/dev/null; then
-            print_warning "Sudoers missing run-as wrapper rule (wrapper installed but not authorized)"
+        if [ -x "$wrapper_path" ] && \
+           ! grep -E "^${run_user} .*(NOPASSWD: )?${wrapper_path}( |\*|$)" "$sudoers_file" 2>/dev/null; then
+            print_warning "Sudoers missing run-as wrapper rule for user '$run_user' (wrapper installed but not authorized)"
             need_update=true
         fi
 

--- a/scripts/install-central/package-method/install.sh
+++ b/scripts/install-central/package-method/install.sh
@@ -1983,6 +1983,19 @@ ${line}"
             need_update=true
         fi
 
+        # 【修复 Issue #1395 (PR #1467 评论)】Check run-as wrapper rule.
+        # The wrapper is installed just before configure_sudoers, but the
+        # incremental update above only rewrites the file when an existing
+        # check trips. A pre-#1467 sudoers file already has webui / utils /
+        # secure_path, so without this check the wrapper rule never gets
+        # added on upgrade — stock deployments stayed broken (the agent
+        # launch failed with "sudo: a password is required").
+        local wrapper_path="/usr/local/bin/openace-run-as"
+        if [ -x "$wrapper_path" ] && ! grep -qF "openace-run-as" "$sudoers_file" 2>/dev/null; then
+            print_warning "Sudoers missing run-as wrapper rule (wrapper installed but not authorized)"
+            need_update=true
+        fi
+
         # 【新增】Warn about sudoers vs systemd service user mismatch
         if command -v systemctl &>/dev/null && systemctl is-enabled --quiet open-ace.service 2>/dev/null; then
             local svc_file=$(systemctl show open-ace.service -p FragmentPath 2>/dev/null | cut -d= -f2)


### PR DESCRIPTION
## 现象

159 重跑 `package-method/install.sh` 后，wrapper 二进制装上了（`/usr/local/bin/openace-run-as` 755），但 `/etc/sudoers.d/open-ace-webui` 仍缺 `openace ALL=(root) NOPASSWD: /usr/local/bin/openace-run-as *`。agent 启动会 `sudo: a password is required`。

## 根因

`configure_sudoers` 的增量更新逻辑 `need_update` 只查 4 项：
1. webui 规则
2. `OPENACE_UTILS` Cmnd_Alias + chown
3. `secure_path` 含 `/usr/local/bin`
4. fetch 脚本路径

pre-#1467 的 sudoers 文件这 4 项都齐备 → `need_update=false` → 直接 return 不重写文件 → `wrapper_rule` 永远写不进去。`install_run_as_wrapper` 在 `configure_sudoers` 之前跑，wrapper 装了但授权没补。

journal 证据（159 现场实测，所有 need_update 检查都 PASS）：
```
check 1 (webui rule):           PASS
check 2 (OPENACE_UTILS+chown):  PASS
check 3 (secure_path):          PASS
check 4 (wrapper rule):         FAIL ← 缺失，但 need_update 没查它
```

## 修复

`need_update` 增加 wrapper 规则探测：wrapper 已安装（`-x /usr/local/bin/openace-run-as`）但 sudoers 文件里没有 `openace-run-as` → `need_update=true`。

与 `docker-method/install.sh` 的对应修复（commit 90299a7b）保持一致。

## 验证

- `bash -n` 通过
- 三种升级场景 dry-run：
  - pre-#1467（4 项齐备、无 wrapper）→ `need_update=true`（触发重写）✓
  - 完整（含 wrapper）→ `need_update=false`（跳过）✓
  - 有 git 无 wrapper → `need_update=true` ✓

## 关联

- 续 #1467（run-as wrapper 引入，但 package-method 的增量更新漏了 wrapper 探测）
- `docker-method/install.sh` 已在 90299a7b 修复同样问题