### PR TITLE
fix(autonomous): preparation 重跑时分支已存在改用 add_worktree (Issue #1395)

### DIFF
--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -1815,11 +1815,41 @@ class AutonomousOrchestrator:
                             worktree_path,
                         )
 
-                    wt_data = gh.create_worktree(
-                        path=worktree_path,
-                        branch=branch_name,
-                        base="origin/main",
+                    # A prior run may have created the branch then failed before
+                    # (or after) registering the worktree; the cleanup above only
+                    # removes the worktree registration, not the branch. Blindly
+                    # calling create_worktree (which uses ``-b``) would then fail
+                    # with "a branch named '<branch>' already exists". If the
+                    # branch survives (local or remote), attach a worktree to it
+                    # via add_worktree (no ``-b``); otherwise create both fresh.
+                    # Mirrors the recovery logic in _ensure_worktree.
+                    branch_exists = (
+                        gh._run_git(
+                            ["show-ref", "--verify", "--quiet", f"refs/heads/{branch_name}"],
+                            check=False,
+                        ).returncode
+                        == 0
                     )
+                    remote_exists = (
+                        gh._run_git(
+                            [
+                                "show-ref",
+                                "--verify",
+                                "--quiet",
+                                f"refs/remotes/origin/{branch_name}",
+                            ],
+                            check=False,
+                        ).returncode
+                        == 0
+                    )
+                    if branch_exists or remote_exists:
+                        wt_data = gh.add_worktree(path=worktree_path, branch=branch_name)
+                    else:
+                        wt_data = gh.create_worktree(
+                            path=worktree_path,
+                            branch=branch_name,
+                            base="origin/main",
+                        )
                     self._update_workflow({"worktree_path": wt_data.get("worktree_path", "")})
                     # The worktree now exists; drop the cached gh (bound to the
                     # main repo during preparation) so the next _get_gh() rebinds

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -1586,7 +1586,30 @@ class AutonomousOrchestrator:
                 # dir on disk agree; an unnormalized path later breaks JSONL
                 # session detection (#814).
                 wt_path = os.path.normpath(f"{project_path}/../{branch_name.replace('/', '-')}")
-                gh.create_worktree(path=wt_path, branch=branch_name, base=base_ref)
+                # A prior fork attempt may have created the branch then failed
+                # before/after registering the worktree; cleanup only removes
+                # the worktree, not the branch. Probe for a surviving branch
+                # (local or remote) and attach via add_worktree (no -b) if it
+                # exists, otherwise create both fresh. Same pattern as the
+                # main prep path and _ensure_worktree (#814).
+                _fork_branch_exists = (
+                    gh._run_git(
+                        ["show-ref", "--verify", "--quiet", f"refs/heads/{branch_name}"],
+                        check=False,
+                    ).returncode
+                    == 0
+                )
+                _fork_remote_exists = (
+                    gh._run_git(
+                        ["show-ref", "--verify", "--quiet", f"refs/remotes/origin/{branch_name}"],
+                        check=False,
+                    ).returncode
+                    == 0
+                )
+                if _fork_branch_exists or _fork_remote_exists:
+                    gh.add_worktree(path=wt_path, branch=branch_name)
+                else:
+                    gh.create_worktree(path=wt_path, branch=branch_name, base=base_ref)
                 self._update_workflow(
                     {
                         "worktree_path": wt_path,

--- a/tests/issues/1395/test_cross_user_permissions.py
+++ b/tests/issues/1395/test_cross_user_permissions.py
@@ -290,6 +290,29 @@ class TestPreparationWorktreeCleanup:
         orch._do_preparation(wf)
         mock_gh.create_worktree.assert_called_once()
 
+    @patch("app.modules.workspace.autonomous.orchestrator.GitHubOps")
+    def test_existing_branch_uses_add_worktree_not_create(self, mock_gh_cls):
+        # A prior failed run left the branch behind (worktree gone, branch
+        # survives). Blindly calling create_worktree (which uses -b) would
+        # fail "a branch named '...' already exists". The prep path must
+        # detect the surviving branch and attach via add_worktree (no -b).
+        from subprocess import CompletedProcess
+
+        mock_gh = self._setup_gh(mock_gh_cls, list_worktrees=[])
+        mock_gh.path_exists_as_user.return_value = False
+        # show-ref --verify for refs/heads/<branch> → found (rc=0).
+        found = CompletedProcess(args=[], returncode=0)
+        mock_gh._run_git.side_effect = lambda *a, **k: found
+        mock_gh.add_worktree.return_value = {"worktree_path": "/home/rhuang/auto-dev-wf-1395"}
+
+        wf = _make_workflow()
+        orch, _repo = _make_orchestrator(wf)
+
+        orch._do_preparation(wf)
+
+        mock_gh.add_worktree.assert_called_once()
+        mock_gh.create_worktree.assert_not_called()
+
 
 # ── _ensure_project_dir (agent_runner mkdir) ────────────────────────────
 


### PR DESCRIPTION
## 现象

issue #143 工作流在 159 重跑报错：
```
git worktree add -b auto-dev/0b463e77 /home/rhuang/auto-dev-0b463e77 origin/main failed (exit 255):
准备工作区（新分支 'auto-dev/0b463e77'）
致命错误：一个名为 'auto-dev/0b463e77' 的分支已经存在
```

## 根因

worktree 策略工作流首轮 preparation 成功创建了分支 + worktree，后续失败清理（`worktree prune` / `remove_worktree`）**只删 worktree 注册，不删 git 分支**。重跑时 `create_worktree` 用 `git worktree add -b <branch>` 尝试新建分支 → 分支已存在 → exit 255。

159 现场实测状态：
```
branches: auto-dev/0b463e77 存在
worktree list: 只有 main（auto-dev 的 worktree 已清理）
auto-dev 目录: 不存在
workflow: status=failed, phase=preparation（重跑中）
```

这是 #1471（修 `_get_gh()` 路径回退）之后的下一层问题：#1471 让重跑能走到 `create_worktree`，但 `create_worktree` 自身不检查分支是否存在，所以暴露了这个更深的问题。

## 修复

`_do_preparation` 的 worktree 创建段（orchestrator.py），在调用 `create_worktree` 之前先 `show-ref --verify` 检查分支（本地 + origin）是否存在：

- **存在** → `add_worktree`（`git worktree add <path> <branch>`，不带 `-b`，检出现有分支；origin-only 时 git 自动建本地跟踪分支）
- **不存在** → `create_worktree`（`git worktree add -b <branch>`，新建）

与 `_ensure_worktree`（#814 的自愈逻辑）的分支探测保持一致。

## 测试

`tests/issues/1395/test_cross_user_permissions.py` 新增：
- `test_existing_branch_uses_add_worktree_not_create`：show-ref rc=0（分支存在）→ `add_worktree` 调用，`create_worktree` 不调用

37 个 1395 测试 + 2 个 orchestrator salvage 测试全过。

## 关联

- 续 #1471（`_get_gh()` 路径回退）
- 与 #1473（install.sh sudoers）是独立问题，分开 PR