### PR TITLE
fix(autonomous): 恢复已存在 session 线时重新激活为 active，修 proxy 401

### DIFF
--- a/app/modules/workspace/autonomous/agent_runner.py
+++ b/app/modules/workspace/autonomous/agent_runner.py
@@ -1217,6 +1217,29 @@ class AutonomousAgentRunner:
             except Exception as e:
                 logger.warning("Failed to create session record: %s", e)
 
+        # A resumed session line (main/review/test) may carry a completed/error
+        # status from a prior run (run_agent_task writes the terminal status at
+        # the end of every call). The LLM proxy token validator requires
+        # agent_sessions.status in (active, paused), so reactivate before any
+        # proxy-token-bearing env is built. Only touches the autonomous path —
+        # WebUI/other create_session callers are unaffected.
+        if self.session_manager and session_id:
+            try:
+                existing = self.session_manager.get_session(session_id)
+                if existing:
+                    cur_status = getattr(existing, "status", "") or (
+                        existing.get("status", "") if isinstance(existing, dict) else ""
+                    )
+                    if cur_status not in ("active", "paused"):
+                        self.session_manager.update_session_fields(session_id, {"status": "active"})
+                        logger.info(
+                            "Reactivated session %s (was %s) for agent run",
+                            session_id[:8],
+                            cur_status,
+                        )
+            except Exception as e:
+                logger.warning("Failed to reactivate session %s: %s", session_id[:8], e)
+
         logger.info(
             "Starting agent task: tool=%s model=%s workspace=%s session=%s",
             cli_tool,

--- a/app/modules/workspace/autonomous/agent_runner.py
+++ b/app/modules/workspace/autonomous/agent_runner.py
@@ -1231,7 +1231,13 @@ class AutonomousAgentRunner:
                         existing.get("status", "") if isinstance(existing, dict) else ""
                     )
                     if cur_status not in ("active", "paused"):
-                        self.session_manager.update_session_fields(session_id, {"status": "active"})
+                        # Clear stale terminal timestamps too — otherwise the
+                        # Sessions UI keeps rendering the old completed_at for a
+                        # row that is now active again (#1475 review).
+                        self.session_manager.update_session_fields(
+                            session_id,
+                            {"status": "active", "completed_at": None, "paused_at": None},
+                        )
                         logger.info(
                             "Reactivated session %s (was %s) for agent run",
                             session_id[:8],

--- a/tests/issues/1395/test_cross_user_permissions.py
+++ b/tests/issues/1395/test_cross_user_permissions.py
@@ -810,3 +810,119 @@ class TestGetGhRerunFallback:
         third = orch._get_gh()
         assert third.repo_path == "/home/rhuang/auto-dev-dead"  # rebound
         assert third is not first
+
+
+# ── run_agent_task session reactivation (proxy 401 on resumed line) ──────
+
+
+class TestRunAgentTaskSessionReactivation:
+    """A resumed session line (main/review/test) may carry a completed/error
+    status from a prior run. The LLM proxy token validator requires
+    agent_sessions.status in (active, paused), so run_agent_task must
+    reactivate the row before any proxy-token-bearing env is built. Without
+    this, the second call on a line 401s with "session not active"."""
+
+    def _make_runner(self, monkeypatch):
+        from app.modules.workspace.autonomous.agent_runner import (
+            AgentTaskResult,
+            AutonomousAgentRunner,
+        )
+
+        runner = AutonomousAgentRunner.__new__(AutonomousAgentRunner)
+        runner.session_manager = MagicMock()
+
+        # Stub _run_local so no real CLI launches; return a minimal success.
+        def fake_run_local(self, **kwargs):
+            return AgentTaskResult(session_id=kwargs.get("session_id", "s"), success=True)
+
+        monkeypatch.setattr(
+            "app.modules.workspace.autonomous.agent_runner.AutonomousAgentRunner._run_local",
+            fake_run_local,
+        )
+        return runner
+
+    def test_completed_session_reactivated_to_active(self, monkeypatch):
+        runner = self._make_runner(monkeypatch)
+        # Session exists, status=completed (prior run finished).
+        runner.session_manager.get_session.return_value = MagicMock(status="completed")
+
+        runner.run_agent_task(
+            workflow_id="wf",
+            cli_tool="claude-code",
+            model="m",
+            project_path="/tmp/p",
+            prompt="x",
+            session_id="sess-completed",
+        )
+
+        # The FIRST update_session_fields call is the reactivation (active);
+        # a later post-run call writes the terminal status. Assert the first.
+        calls = runner.session_manager.update_session_fields.call_args_list
+        assert calls[0] == (("sess-completed", {"status": "active"}),)
+
+    def test_error_session_reactivated_to_active(self, monkeypatch):
+        runner = self._make_runner(monkeypatch)
+        runner.session_manager.get_session.return_value = MagicMock(status="error")
+
+        runner.run_agent_task(
+            workflow_id="wf",
+            cli_tool="claude-code",
+            model="m",
+            project_path="/tmp/p",
+            prompt="x",
+            session_id="sess-error",
+        )
+
+        calls = runner.session_manager.update_session_fields.call_args_list
+        assert calls[0] == (("sess-error", {"status": "active"}),)
+
+    def test_active_session_no_reactivation_call(self, monkeypatch):
+        runner = self._make_runner(monkeypatch)
+        runner.session_manager.get_session.return_value = MagicMock(status="active")
+
+        runner.run_agent_task(
+            workflow_id="wf",
+            cli_tool="claude-code",
+            model="m",
+            project_path="/tmp/p",
+            prompt="x",
+            session_id="sess-active",
+        )
+
+        # No reactivation; only the post-run terminal-status write happens.
+        calls = runner.session_manager.update_session_fields.call_args_list
+        assert all(c.args[1] != {"status": "active"} for c in calls)
+
+    def test_paused_session_no_reactivation_call(self, monkeypatch):
+        runner = self._make_runner(monkeypatch)
+        runner.session_manager.get_session.return_value = MagicMock(status="paused")
+
+        runner.run_agent_task(
+            workflow_id="wf",
+            cli_tool="claude-code",
+            model="m",
+            project_path="/tmp/p",
+            prompt="x",
+            session_id="sess-paused",
+        )
+
+        calls = runner.session_manager.update_session_fields.call_args_list
+        assert all(c.args[1] != {"status": "active"} for c in calls)
+
+    def test_missing_session_no_reactivation(self, monkeypatch):
+        runner = self._make_runner(monkeypatch)
+        # Session row absent (e.g. late-creating tools) — must not crash.
+        runner.session_manager.get_session.return_value = None
+
+        runner.run_agent_task(
+            workflow_id="wf",
+            cli_tool="claude-code",
+            model="m",
+            project_path="/tmp/p",
+            prompt="x",
+            session_id="sess-missing",
+        )
+
+        # Only the post-run write (if any) happens; no reactivation.
+        calls = runner.session_manager.update_session_fields.call_args_list
+        assert all(c.args[1] != {"status": "active"} for c in calls)

--- a/tests/issues/1395/test_cross_user_permissions.py
+++ b/tests/issues/1395/test_cross_user_permissions.py
@@ -855,10 +855,14 @@ class TestRunAgentTaskSessionReactivation:
             session_id="sess-completed",
         )
 
-        # The FIRST update_session_fields call is the reactivation (active);
-        # a later post-run call writes the terminal status. Assert the first.
+        # The FIRST update_session_fields call is the reactivation (active +
+        # clear stale timestamps); a later post-run call writes the terminal
+        # status. Assert the first.
         calls = runner.session_manager.update_session_fields.call_args_list
-        assert calls[0] == (("sess-completed", {"status": "active"}),)
+        assert calls[0] == (
+            ("sess-completed", {"status": "active", "completed_at": None, "paused_at": None}),
+            {},
+        )
 
     def test_error_session_reactivated_to_active(self, monkeypatch):
         runner = self._make_runner(monkeypatch)
@@ -874,7 +878,10 @@ class TestRunAgentTaskSessionReactivation:
         )
 
         calls = runner.session_manager.update_session_fields.call_args_list
-        assert calls[0] == (("sess-error", {"status": "active"}),)
+        assert calls[0] == (
+            ("sess-error", {"status": "active", "completed_at": None, "paused_at": None}),
+            {},
+        )
 
     def test_active_session_no_reactivation_call(self, monkeypatch):
         runner = self._make_runner(monkeypatch)


### PR DESCRIPTION
## 现象

issue #143 工作流重跑进入 planning review 报：
```
Failed to authenticate. API Error: 401 Invalid or expired proxy token
```
服务日志：
```
Proxy token session not active: a547aed4 (status=completed)
```

## 根因

`run_agent_task` 每次跑完都会把 session 状态写成终态（`completed`/`error`，agent_runner.py:1289）。同一条会话线（main/review/test）被第二次调用时：

1. `_resolve_session_line` 返回已存在的 session_id（`completed`）+ `resume=True`
2. `create_session` 幂等早返回（session_manager.py:441-444），**不重新激活** — status 仍停在终态
3. `_build_agent_env` 用这个 session_id 生成 proxy token
4. `validate_proxy_token`（api_key_proxy.py:1324）要求 `agent_sessions.status in ("active","paused")`，终态被拒 → **401**

## 触发条件（不只是重跑）

任何同一条会话线被第二次调用、且该 session 已是终态的场景：
- **同一轮内多回合**：review 不通过 → 第二回合 review；dev → test 失败 → 第二回合 dev
- **重跑工作流**：首轮某阶段成功标 completed → 工作流失败 → 重跑恢复同一线（issue #143 的路径）
- **多轮 PR review**

## 修复

`run_agent_task`（agent_runner.py）在 `create_session` 之后、dispatch 之前，检测 session 存在且 status 不在 `("active","paused")` → `update_session_fields` 置为 `active`：

```python
if self.session_manager and session_id:
    existing = self.session_manager.get_session(session_id)
    if existing:
        cur_status = getattr(existing, "status", "") or ...
        if cur_status not in ("active", "paused"):
            self.session_manager.update_session_fields(session_id, {"status": "active"})
```

只动 autonomous 路径，不影响 WebUI / 其他 `create_session` 调用方。

### 不改的地方
- `create_session` 本身（会影响 WebUI/remote 等不希望被重新激活的调用方）
- `validate_proxy_token`（active/paused 门槛本身正确）
- `_resolve_session_line`（恢复语义正确，问题在 session 状态没翻转）

## 测试

`tests/issues/1395/test_cross_user_permissions.py` 新增 `TestRunAgentTaskSessionReactivation`（5 用例）：
- `test_completed_session_reactivated_to_active`：completed → 第一次 update_session_fields 是 `{"status":"active"}`
- `test_error_session_reactivated_to_active`：error → 同上
- `test_active_session_no_reactivation_call`：active → 不发 active 写
- `test_paused_session_no_reactivation_call`：paused → 不发 active 写
- `test_missing_session_no_reactivation`：session 不存在 → 不崩、不发 active 写

142 个 1395/723/826/996/1002 测试全过。

## 关联

issue #1395 重跑链路的 proxy auth 层（#1466→#1467→#1471→#1474 之后）。独立 PR。