### PR TITLE
fix(autonomous): test-skip 误判 + retry 计数持久化失效 (Issue #1277)

### DIFF
--- a/app/modules/workspace/autonomous/__init__.py
+++ b/app/modules/workspace/autonomous/__init__.py
@@ -88,7 +88,10 @@ def get_ddl_statements():
             user_feedback TEXT DEFAULT '',
             original_branch_name TEXT DEFAULT '',
             transient_retry_count INTEGER DEFAULT 0,
-            content_language TEXT DEFAULT 'en'
+            content_language TEXT DEFAULT 'en',
+            test_retries INTEGER DEFAULT 0,
+            skip_retries INTEGER DEFAULT 0,
+            dev_retries_on_test_fail INTEGER DEFAULT 0
         )
         """,
     ]
@@ -110,6 +113,14 @@ def get_ddl_statements():
     )
     statements.append(
         f"ALTER TABLE autonomous_workflows ADD COLUMN require_full_review_rounds {bool_type} DEFAULT {bool_false}"
+    )
+    # test_retries / skip_retries / dev_retries_on_test_fail: counters for the
+    # development-phase test retry logic. Mirrors Alembic migration
+    # 20260704_001_add_test_retry_columns for the SQLite dev/test path.
+    statements.append("ALTER TABLE autonomous_workflows ADD COLUMN test_retries INTEGER DEFAULT 0")
+    statements.append("ALTER TABLE autonomous_workflows ADD COLUMN skip_retries INTEGER DEFAULT 0")
+    statements.append(
+        "ALTER TABLE autonomous_workflows ADD COLUMN dev_retries_on_test_fail INTEGER DEFAULT 0"
     )
     statements.extend(
         [

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -2662,7 +2662,19 @@ class AutonomousOrchestrator:
 
         # Detect if tests were actually skipped (agent couldn't run them)
         test_response_text = test_visible_text or test_summary
-        _skipped_markers = ["TEST_STATUS: skipped", "测试被跳过", "跳过测试"]
+        # TEST_STATUS: skipped is a status tag the agent emits on its own line
+        # at the end of the reply. Match it as a standalone line, not a bare
+        # substring — otherwise an agent that *explains* "TEST_STATUS: skipped
+        # 不适用" (i.e. asserts tests DID run) is false-positive matched and
+        # the workflow needlessly retries (#1277 regression).
+        _skip_tag_re = re.compile(r"(?mi)^\s*TEST_STATUS:\s*skipped\s*$")
+        # Chinese skip markers: only count when they appear as a short
+        # standalone statement (own line, <= 30 chars), not embedded in a
+        # longer sentence like "本次跳过测试是因为..." which is an explanation.
+        _cn_skip_re = re.compile(r"(?m)^\s*(测试被跳过|跳过测试)\s*[。.]?\s*$")
+        has_skip_tag = bool(_skip_tag_re.search(test_response_text)) or bool(
+            _cn_skip_re.search(test_response_text)
+        )
         _skipped_keywords = [
             "pytest 未安装",
             "pytest was not installed",
@@ -2695,7 +2707,7 @@ class AutonomousOrchestrator:
         test_status_tag = self._artifact_status_tag(test_result, "test_status").lower()
         tests_actually_skipped = (
             test_status_tag == "skipped"
-            or any(m in test_response_text for m in _skipped_markers)
+            or has_skip_tag
             or (test_result.success and has_skip_keyword)
             or (test_result.success and not has_test_result)
         )

--- a/app/repositories/autonomous_repo.py
+++ b/app/repositories/autonomous_repo.py
@@ -80,6 +80,9 @@ class AutonomousWorkflowRepository:
         "test_session_id",
         "transient_retry_count",
         "content_language",
+        "test_retries",
+        "skip_retries",
+        "dev_retries_on_test_fail",
     }
     ALLOWED_MILESTONE_FIELDS = {
         "phase",

--- a/migrations/versions/20260704_001_add_test_retry_columns.py
+++ b/migrations/versions/20260704_001_add_test_retry_columns.py
@@ -1,0 +1,86 @@
+"""Add test retry counter columns to autonomous_workflows
+
+Revision ID: 20260704_001_add_test_retry_columns
+Revises: 20260703_002_add_sso_auth_states
+Create Date: 2026-07-04
+
+Issue: test-skip / test-fail retry counters (skip_retries, test_retries,
+dev_retries_on_test_fail) are written via _update_workflow but were never
+added to the table schema nor ALLOWED_WORKFLOW_FIELDS, so the writes were
+silently filtered out and the scheduler re-read 0 on the next advance() —
+causing the dev agent to be re-run on a test-only retry and then false-
+failing with "agent produced no code changes" (commit SHA unchanged).
+
+Columns (all INTEGER DEFAULT 0, nullable for back-compat with existing rows):
+- test_retries: count of test-agent-failure retries (timeout/API error)
+- skip_retries: count of test-skipped retries (agent didn't run tests)
+- dev_retries_on_test_fail: count of dev reruns triggered by test failure
+"""
+
+import logging
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+
+log = logging.getLogger(__name__)
+
+revision: str = "20260704_001_add_test_retry_columns"
+down_revision: Union[str, None] = "20260703_002_add_sso_auth_states"
+branch_labels: Union[str, None] = None
+depends_on: Union[str, None] = None
+
+
+def _column_exists(conn, table_name: str, column_name: str) -> bool:
+    """Check if a column exists in a table (PostgreSQL or SQLite)."""
+    if conn.dialect.name == "postgresql":
+        result = conn.execute(
+            sa.text(
+                "SELECT EXISTS ("
+                "  SELECT FROM information_schema.columns "
+                "  WHERE table_name = :table_name AND column_name = :column_name"
+                ")"
+            ),
+            {"table_name": table_name, "column_name": column_name},
+        )
+        return result.fetchone()[0]
+    result = conn.execute(
+        sa.text("SELECT name FROM pragma_table_info(:table_name) WHERE name = :column_name"),
+        {"table_name": table_name, "column_name": column_name},
+    )
+    return result.fetchone() is not None
+
+
+_NEW_COLUMNS = [
+    ("test_retries", sa.Integer()),
+    ("skip_retries", sa.Integer()),
+    ("dev_retries_on_test_fail", sa.Integer()),
+]
+
+
+def upgrade() -> None:
+    """Add test retry counter columns to autonomous_workflows."""
+    conn = op.get_bind()
+    for col_name, col_type in _NEW_COLUMNS:
+        if not _column_exists(conn, "autonomous_workflows", col_name):
+            log.info("Adding %s column to autonomous_workflows", col_name)
+            op.add_column(
+                "autonomous_workflows",
+                sa.Column(col_name, col_type, nullable=True, server_default="0"),
+            )
+        else:
+            log.info("%s column already exists, skipping", col_name)
+
+
+def downgrade() -> None:
+    """Remove test retry counter columns from autonomous_workflows."""
+    conn = op.get_bind()
+    for col_name, _ in reversed(_NEW_COLUMNS):
+        if not _column_exists(conn, "autonomous_workflows", col_name):
+            continue
+        log.info("Removing %s column from autonomous_workflows", col_name)
+        if conn.dialect.name == "postgresql":
+            op.drop_column("autonomous_workflows", col_name)
+        else:
+            with op.batch_alter_table("autonomous_workflows") as batch_op:
+                batch_op.drop_column(col_name)

--- a/schema/schema-postgres.sql
+++ b/schema/schema-postgres.sql
@@ -362,7 +362,10 @@ CREATE TABLE autonomous_workflows (
     locked_at timestamp without time zone,
     locked_by text DEFAULT ''::text,
     transient_retry_count integer DEFAULT 0,
-    retry_count integer DEFAULT 0
+    retry_count integer DEFAULT 0,
+    test_retries integer DEFAULT 0,
+    skip_retries integer DEFAULT 0,
+    dev_retries_on_test_fail integer DEFAULT 0
 );
 
 CREATE SEQUENCE autonomous_workflows_id_seq

--- a/schema/schema-sqlite.sql
+++ b/schema/schema-sqlite.sql
@@ -251,7 +251,10 @@ CREATE TABLE autonomous_workflows (
  locked_at TIMESTAMP,
  locked_by text DEFAULT '',
  transient_retry_count integer DEFAULT 0,
- retry_count integer DEFAULT 0
+ retry_count integer DEFAULT 0,
+ test_retries integer DEFAULT 0,
+ skip_retries integer DEFAULT 0,
+ dev_retries_on_test_fail integer DEFAULT 0
 );
 
 CREATE TABLE compliance_reports (

--- a/tests/issues/1277/test_test_skip_false_positive.py
+++ b/tests/issues/1277/test_test_skip_false_positive.py
@@ -241,3 +241,87 @@ class TestRetryCounterPersistence:
         assert not any(
             "skipped by agent" in (f.get("error_message") or "") for f in ms_fields
         ), "test milestone must not be marked 'skipped by agent'"
+
+
+# ── Legacy runtime DDL must include the new columns (#1476 review) ──────
+
+
+class TestLegacyDdlIncludesRetryColumns:
+    """The runtime ``get_ddl_statements()`` path (used by SQLite dev/test
+    setup) must create the three retry columns, otherwise
+    ``_update_workflow({"skip_retries": 1})`` fails with
+    ``OperationalError: no such column: skip_retries`` on fresh DBs that
+    bypass Alembic."""
+
+    def test_create_table_has_retry_columns(self):
+        from app.modules.workspace.autonomous import get_ddl_statements
+
+        ddl = "\n".join(get_ddl_statements())
+        # The CREATE TABLE block must list all three columns so fresh DBs
+        # have them without relying on the ALTER TABLE fallback.
+        for col in ("test_retries", "skip_retries", "dev_retries_on_test_fail"):
+            assert col in ddl, f"{col} missing from get_ddl_statements()"
+
+    def test_alter_table_adds_retry_columns_for_existing_dbs(self):
+        from app.modules.workspace.autonomous import get_ddl_statements
+
+        alters = [s for s in get_ddl_statements() if s.strip().upper().startswith("ALTER TABLE")]
+        for col in ("test_retries", "skip_retries", "dev_retries_on_test_fail"):
+            assert any(col in a for a in alters), f"no ALTER TABLE adds {col} for existing DBs"
+
+    def test_update_skip_retries_succeeds_on_fresh_sqlite(self, tmp_path):
+        """End-to-end: init a fresh SQLite DB via get_ddl_statements(), then
+        update_workflow with skip_retries must not raise."""
+        import sqlite3
+
+        from app.modules.workspace.autonomous import get_ddl_statements
+        from app.repositories.autonomous_repo import AutonomousWorkflowRepository
+
+        db_path = str(tmp_path / "test.db")
+        conn = sqlite3.connect(db_path)
+        try:
+            cursor = conn.cursor()
+            for sql in get_ddl_statements():
+                try:
+                    cursor.execute(sql)
+                except Exception:
+                    pass
+            conn.commit()
+        finally:
+            conn.close()
+
+        # Minimal workflow row so update_workflow has something to update.
+        conn = sqlite3.connect(db_path)
+        try:
+            conn.execute(
+                "INSERT INTO autonomous_workflows (workflow_id, title, status, cli_tool, "
+                "branch_strategy, workspace_type) VALUES (?, ?, ?, ?, ?, ?)",
+                ("wf-ddl", "t", "developing", "claude-code", "new-branch", "local"),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        db = MagicMock()
+        db._db_path = db_path
+        repo = AutonomousWorkflowRepository.__new__(AutonomousWorkflowRepository)
+        repo.db = db
+
+        # Monkeypatch a real sqlite execute for this test.
+        def _execute(query, params=()):
+            c = sqlite3.connect(db_path)
+            c.execute(query, params)
+            c.commit()
+            c.close()
+
+        def _fetch_one(query, params=()):
+            c = sqlite3.connect(db_path)
+            row = c.execute(query, params).fetchone()
+            c.close()
+            return row
+
+        db.execute = _execute
+        db.fetch_one = _fetch_one
+
+        # This must not raise OperationalError.
+        repo.update_workflow("wf-ddl", {"skip_retries": 1})

--- a/tests/issues/1277/test_test_skip_false_positive.py
+++ b/tests/issues/1277/test_test_skip_false_positive.py
@@ -1,0 +1,243 @@
+"""Tests for test-skip false-positive and retry-counter persistence (issue #1277).
+
+Two bugs chained to false-fail autonomous workflows in the development phase:
+
+Bug B (upstream trigger): ``_run_test_phase`` detected "tests skipped" via a
+bare substring match on ``"TEST_STATUS: skipped"``. An agent that *explains*
+"``TEST_STATUS: skipped`` 不适用" (asserting tests DID run) was false-positive
+matched, so the workflow entered the skip-retry path even though tests passed.
+
+Bug A (downstream amplifier): ``skip_retries`` / ``test_retries`` /
+``dev_retries_on_test_fail`` were written via ``_update_workflow`` but were
+absent from both the DB schema and ``ALLOWED_WORKFLOW_FIELDS``, so the writes
+were silently filtered. The scheduler re-read 0 on the next ``advance()``,
+re-ran the dev agent on a test-only retry, and false-failed with
+"agent produced no code changes" (SHA unchanged).
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.modules.workspace.autonomous.models import AgentTaskResult
+
+# ── helpers (mirror tests/issues/723/test_orchestrator_dev_salvage.py) ───
+
+
+def _make_workflow(**overrides):
+    base = {
+        "workflow_id": "wf-1277",
+        "user_id": 1,
+        "title": "Test",
+        "status": "developing",
+        "requirements_text": "Build feature",
+        "requirements_issue_url": "",
+        "project_path": "/tmp/p",
+        "project_repo_url": "",
+        "is_new_project": False,
+        "cli_tool": "claude-code",
+        "model": "claude-sonnet-4-6",
+        "permission_mode": "auto-edit",
+        "branch_name": "auto-dev/x",
+        "branch_strategy": "new-branch",
+        "workspace_type": "local",
+        "remote_machine_id": "",
+        "worktree_path": "/tmp/p",
+        "github_issue_number": None,
+        "github_pr_number": None,
+        "github_pr_url": "",
+        "current_phase": "development",
+        "current_round": 1,
+        "dev_round": 1,
+        "max_plan_rounds": 3,
+        "max_pr_review_rounds": 5,
+        "total_tokens": 0,
+        "total_input_tokens": 0,
+        "total_output_tokens": 0,
+        "total_requests": 0,
+        "error_message": "",
+    }
+    base.update(overrides)
+    return base
+
+
+def _agent_result(success=True, error=None, text="dev output"):
+    return AgentTaskResult(
+        session_id="sess",
+        response_text=text,
+        visible_response_text=text,
+        success=success,
+        error=error,
+    )
+
+
+def _make_orchestrator(wf_data, milestones=None):
+    from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+    with (
+        patch("app.modules.workspace.autonomous.orchestrator.Database"),
+        patch(
+            "app.modules.workspace.autonomous.orchestrator.AutonomousWorkflowRepository"
+        ) as mock_repo_cls,
+    ):
+        mock_repo = MagicMock()
+        mock_repo.get_workflow.return_value = wf_data
+        mock_repo.list_milestones.return_value = milestones or []
+        mock_repo.create_milestone.return_value = {
+            "milestone_id": "ms-new",
+            "workflow_id": wf_data["workflow_id"],
+        }
+        mock_repo.create_event.return_value = {"id": 1}
+        mock_repo.update_workflow.return_value = wf_data
+        mock_repo.update_milestone.return_value = {}
+        mock_repo.update_workflow_tokens.return_value = None
+        mock_repo_cls.return_value = mock_repo
+
+        orch = AutonomousOrchestrator(wf_data["workflow_id"])
+        orch.repo = mock_repo
+        orch.emitter = MagicMock()
+        orch._gh = MagicMock()
+        orch._gh.get_current_commit.return_value = "abc1234"
+        orch._gh.get_commit_diff_stats.return_value = {
+            "additions": 10,
+            "deletions": 0,
+            "files": 1,
+            "commits": 1,
+        }
+        orch._gh.get_diff_stats.return_value = {}
+        orch._gh.has_uncommitted_changes.return_value = False
+        return orch, mock_repo
+
+
+# ── Bug B: TEST_STATUS marker must not match explanatory text ────────────
+
+
+class TestSkipMarkerNotFalsePositive:
+    """The skip tag ``TEST_STATUS: skipped`` must only match as a standalone
+    line, not when the agent references it in an explanation. Issue #1277's
+    agent wrote ``TEST_STATUS: skipped 不适用`` (tests passed) and was
+    false-positive flagged."""
+
+    def test_explanatory_reference_not_matched(self):
+        import re
+
+        # The exact text from issue #1277 that caused the false positive.
+        text = "2423 passed, 1 skipped\n- `TEST_STATUS: skipped` 不适用，因为测试已实际执行并通过。"
+        # The fix's regex: standalone line, case-insensitive.
+        pat = re.compile(r"(?mi)^\s*TEST_STATUS:\s*skipped\s*$")
+        assert not pat.search(text), "explanatory reference to TEST_STATUS: skipped must NOT match"
+
+    def test_real_skip_tag_matched(self):
+        import re
+
+        # A genuine skip: agent emits the tag on its own line at the end.
+        text = "Could not find pytest.\n\nTEST_STATUS: skipped"
+        pat = re.compile(r"(?mi)^\s*TEST_STATUS:\s*skipped\s*$")
+        assert pat.search(text), "standalone TEST_STATUS: skipped must match"
+
+    def test_cn_marker_in_sentence_not_matched(self):
+        import re
+
+        # "跳过测试" embedded in a longer explanation sentence.
+        text = "本次跳过测试是因为环境缺少 PostgreSQL 连接，但其他测试全通过。"
+        pat = re.compile(r"(?m)^\s*(测试被跳过|跳过测试)\s*[。.]?\s*$")
+        assert not pat.search(text), "inline 跳过测试 must NOT match"
+
+    def test_cn_marker_standalone_matched(self):
+        import re
+
+        text = "所有测试框架都不可用。\n跳过测试。"
+        pat = re.compile(r"(?m)^\s*(测试被跳过|跳过测试)\s*[。.]?\s*$")
+        assert pat.search(text), "standalone 跳过测试 must match"
+
+
+# ── Bug A: retry counters must persist via ALLOWED_WORKFLOW_FIELDS ───────
+
+
+class TestRetryCounterPersistence:
+    """``skip_retries`` / ``test_retries`` / ``dev_retries_on_test_fail``
+    must be in ALLOWED_WORKFLOW_FIELDS so _update_workflow actually writes
+    them instead of silently filtering."""
+
+    def test_retry_fields_in_allowed_workflow_fields(self):
+        from app.repositories.autonomous_repo import AutonomousWorkflowRepository
+
+        fields = AutonomousWorkflowRepository.ALLOWED_WORKFLOW_FIELDS
+        for col in ("test_retries", "skip_retries", "dev_retries_on_test_fail"):
+            assert col in fields, f"{col} missing from ALLOWED_WORKFLOW_FIELDS"
+
+    def test_skip_retries_persisted_on_test_skip(self):
+        """When tests are skipped, _run_test_phase must write skip_retries=1
+        to the workflow (not have it filtered out). Verified by checking the
+        update_workflow call includes the field."""
+        plan_ms = {
+            "milestone_id": "ms-plan",
+            "plan_content": "1. Implement",
+            "status": "completed",
+        }
+        wf = _make_workflow()
+        orch, mock_repo = _make_orchestrator(wf, milestones=[plan_ms])
+
+        orch._runner = MagicMock()
+        # Dev: success with a commit (sha changes).
+        # Test: success but agent genuinely skipped (standalone tag).
+        orch._runner.run_agent_task.side_effect = [
+            _agent_result(success=True, text="Implementation done"),
+            _agent_result(
+                success=True,
+                text="No test framework found.\n\nTEST_STATUS: skipped",
+            ),
+        ]
+        orch._gh.get_current_commit.side_effect = ["aaa1111", "bbb2222"]
+
+        orch._do_development(wf)
+
+        # The skip-retry path must have written skip_retries=1.
+        update_calls = mock_repo.update_workflow.call_args_list
+        fields_list = [c[0][1] for c in update_calls if len(c[0]) > 1 and isinstance(c[0][1], dict)]
+        assert any(
+            f.get("skip_retries") == 1 for f in fields_list
+        ), "skip_retries=1 must be persisted when tests are skipped"
+
+    def test_real_tests_not_flagged_skipped(self):
+        """When the test agent runs real tests (output has 'passed') and
+        merely references the skip tag in explanation, it must NOT be flagged
+        as skipped. This is the core #1277 regression: tests passed but the
+        workflow was sent into the skip-retry loop."""
+        plan_ms = {
+            "milestone_id": "ms-plan",
+            "plan_content": "1. Implement",
+            "status": "completed",
+        }
+        wf = _make_workflow()
+        orch, mock_repo = _make_orchestrator(wf, milestones=[plan_ms])
+
+        orch._runner = MagicMock()
+        orch._runner.run_agent_task.side_effect = [
+            _agent_result(success=True, text="Implementation done"),
+            _agent_result(
+                success=True,
+                text=(
+                    "## 测试报告\n2423 passed, 1 skipped\n"
+                    "- `TEST_STATUS: skipped` 不适用，因为测试已实际执行并通过。"
+                ),
+            ),
+        ]
+        orch._gh.get_current_commit.side_effect = ["aaa1111", "bbb2222"]
+
+        orch._do_development(wf)
+
+        # Must NOT enter skip-retry path: no skip_retries=1 write (only the
+        # success-reset to 0 at line ~2834 is acceptable), no test milestone
+        # marked "skipped by agent".
+        update_calls = mock_repo.update_workflow.call_args_list
+        fields_list = [c[0][1] for c in update_calls if len(c[0]) > 1 and isinstance(c[0][1], dict)]
+        assert not any(
+            f.get("skip_retries") == 1 for f in fields_list
+        ), "must not flag skip_retries=1 when tests actually ran"
+
+        ms_updates = mock_repo.update_milestone.call_args_list
+        ms_fields = [c[0][1] for c in ms_updates if len(c[0]) > 1 and isinstance(c[0][1], dict)]
+        assert not any(
+            "skipped by agent" in (f.get("error_message") or "") for f in ms_fields
+        ), "test milestone must not be marked 'skipped by agent'"

--- a/tests/unit/test_alembic_sqlite_upgrade.py
+++ b/tests/unit/test_alembic_sqlite_upgrade.py
@@ -111,7 +111,8 @@ def test_alembic_upgrade_head_succeeds_for_fresh_sqlite(tmp_path, monkeypatch):
     # -> 005_add_policy_tables -> 001_add_model_gateway_config
     # -> 20260703_001_add_require_full_review_rounds
     # -> 20260703_002_add_sso_auth_states
-    assert version[0] == "20260703_002_add_sso_auth_states"
+    # -> 20260704_001_add_test_retry_columns
+    assert version[0] == "20260704_001_add_test_retry_columns"
     if has_session_messages:
         assert "source" in columns
     assert has_mapping_rules is True


### PR DESCRIPTION
## 背景

autonomous 工作流在 development 阶段误判失败，表现为 \`Development failed: agent produced no code changes\`。本地 DB 查到 3 个工作流命中（#1277 最典型），159 上 issue #143 也命中。

## 两个 bug 叠加

### Bug B（上游触发）：test-skipped 子串误匹配

\`_run_test_phase\`（orchestrator.py）用 \`any(m in text for m in markers)\` 检测 \`TEST_STATUS: skipped\`。#1277 的 test agent 实际跑了 2423 passed，但在解释性文本里写了：

\`\`\`
- \`TEST_STATUS: skipped\` 不适用，因为测试已实际执行并通过。
\`\`\`

子串 \`TEST_STATUS: skipped\` 命中 → 误判 skipped → 进入 skip_retries 路径。

**修复**：marker 匹配从子串改为行首独立 token 正则（\`^\s*TEST_STATUS:\s*skipped\$\`），中文 marker（跳过测试/测试被跳过）同理要求独立短句行。

### Bug A（下游放大）：retry 计数持久化失效

\`skip_retries\`/\`test_retries\`/\`dev_retries_on_test_fail\` 被 \`_update_workflow\` 写入，但：
- 不在 DB schema 里（没有列）
- 不在 \`ALLOWED_WORKFLOW_FIELDS\` 里

\`update_workflow\`（autonomous_repo.py:508）过滤未知字段 → 写操作是 no-op。调度器重入 \`advance()\` 时 \`wf = self.workflow\`（查 DB）→ \`skip_retries=0\` → 又跑了 dev agent → SHA 没变 → 误判 "no code changes"。

**修复**：
- alembic migration \`20260704_001\` 加三列（INTEGER DEFAULT 0）
- \`ALLOWED_WORKFLOW_FIELDS\` 加三个字段名
- \`schema-postgres.sql\` + \`schema-sqlite.sql\` 同步

## 触发条件

1. dev 成功提交代码
2. test agent 被判定 skipped（Bug B 误判，或 agent 真的跳过）
3. skip_retries 持久化失效（Bug A）→ 重入时又跑 dev → SHA 没变 → 失败

## 测试

\`tests/issues/1277/test_test_skip_false_positive.py\`（7 用例）：
- Bug B：解释性引用不匹配 / 真实 skip tag 匹配 / 中文 marker 句中不匹配 / 独立行匹配
- Bug A：retry 字段在 ALLOWED_WORKFLOW_FIELDS / skip 路径写 skip_retries=1 / 真跑测试不误判

161 个现有测试（1277/1140/723/776/1395/826/996）全过。

## 关联

- #1277（本地复现，test agent 跑了测试但被误判 skipped）
- issue #143（159，agent 真的跳过测试 + Bug A 放大）