### PR TITLE
fix(init_db): 区分新建和已存在用户的日志输出

### DIFF
--- a/scripts/init_db.py
+++ b/scripts/init_db.py
@@ -8,7 +8,7 @@ Database schema is created by schema.sql during installation.
 
 import os
 import sys
-from typing import Optional
+from typing import Optional, Tuple
 
 import bcrypt
 
@@ -107,8 +107,14 @@ def create_default_admin(
     email: str = "admin@localhost",
     system_account: Optional[str] = None,
     tenant_id: int = 1,
-) -> bool:
-    """Create a default admin user with forced password change on first login."""
+) -> Tuple[bool, bool]:
+    """Create a default admin user with forced password change on first login.
+
+    Returns:
+        Tuple[bool, bool]: (success, is_new_user)
+            - success: True if operation completed successfully
+            - is_new_user: True if a new user was created, False if user already existed
+    """
     # Hash password using bcrypt
     password_hash = bcrypt.hashpw(password.encode(), bcrypt.gensalt(rounds=12)).decode()
 
@@ -122,14 +128,14 @@ def create_default_admin(
             # Validate system_account parameter
             if not system_account.strip():
                 print("Warning: system_account is empty string, skipping update")
-                return True
+                return (True, False)
             try:
                 db.update_user(existing["id"], system_account=system_account)
                 print(f"Updated system_account for '{username}' to '{system_account}'")
             except Exception as e:
                 print(f"Warning: Failed to update system_account for '{username}': {e}")
         print(f"Admin user '{username}' already exists")
-        return True
+        return (True, False)
 
     # Create admin user with must_change_password = True (force password change on first login)
     result = db.create_user_with_is_active(
@@ -151,10 +157,10 @@ def create_default_admin(
         print(f"Password: {password}")
         print(f"Tenant ID: {tenant_id}")
         print("\nIMPORTANT: You MUST change the password on first login!")
-        return True
+        return (True, True)
     else:
         print(f"Failed to create admin user '{username}'")
-        return False
+        return (False, False)
 
 
 def main():
@@ -172,12 +178,17 @@ def main():
     create_default_tenant()
 
     # Create default admin user with tenant_id=1
-    create_default_admin(system_account=system_account, tenant_id=1)
+    success, is_new_user = create_default_admin(system_account=system_account, tenant_id=1)
 
-    print("\nDefault admin credentials:")
-    print("  Username: admin")
-    print("  Password: admin123")
-    print("\nPlease change the default password after first login!")
+    # Only show default password message when a new user was actually created
+    if is_new_user:
+        print("\nDefault admin credentials:")
+        print("  Username: admin")
+        print("  Password: admin123")
+        print("\nPlease change the default password after first login!")
+    else:
+        print("\nAdmin user 'admin' already exists - password unchanged.")
+        print("If you forgot the password, please use the password reset feature.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 问题

升级时 `init_db.py` 无条件显示 `Password: admin123`，即使用户已存在且密码已被修改。这导致用户误以为密码被重置，实际登录时使用 admin123 失败。

## 修复

1. `create_default_admin()` 返回类型改为 `Tuple[bool, bool]`，返回 `(success, is_new_user)` 元组
2. `main()` 函数根据 `is_new_user` 值决定输出内容：
   - 新建用户：显示默认密码提示
   - 用户已存在：显示密码未变更提示

## 测试验证

在 node237 (Package 版) 上验证：

```
$ sudo -u ivyent python3 scripts/init_db.py ivyent
Initializing default tenant and admin user...
Default tenant (id=1) already exists
Admin user 'admin' already exists

Admin user 'admin' already exists - password unchanged.
If you forgot the password, please use the password reset feature.
```

## 相关 Issue

此问题由 commit bc0aaf25 (security issues #18, #19, #20 修复) 引入，该 commit 添加了保留已有用户密码的逻辑，但日志输出未同步更新。