### PR TITLE
fix(autonomous): correct qwen-code-cli allowed_tools tool name

### DIFF
--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -161,7 +161,7 @@ AUTONOMOUS_DEV_ALLOWED_TOOLS: dict[str, list[str]] = {
         "web_fetch",
         "write_file",
         "edit_file",
-        "execute_command",
+        "run_shell_command",
     ],
     "codex": [],
     "openclaw": [],


### PR DESCRIPTION
## Summary
Fixes #1485

## Root Cause
`AUTONOMOUS_DEV_ALLOWED_TOOLS` for qwen-code-cli listed `execute_command` but the CLI actually sends `run_shell_command`.

This mismatch caused test-phase agent commands to be denied with misleading error:
```
Tool 'run_shell_command' is not allowed in planning phase.
```

## Fix
Changed `execute_command` → `run_shell_command` in `orchestrator.py:159`

## How to Verify
Run autonomous dev workflow with test phase - CLI commands should now be allowed.