### PR TITLE
fix(remote): SSE stream stability improvements for remote sessions

### DIFF
--- a/app/modules/workspace/remote_agent_manager.py
+++ b/app/modules/workspace/remote_agent_manager.py
@@ -1270,7 +1270,7 @@ class RemoteAgentManager:
             List of output entries (converted from deque slice).
         """
         with self._lock:
-            buf = self._output_buffers.get(session_id, deque())
+            buf: deque[dict] = self._output_buffers.get(session_id, deque())
             offset = self._buffer_offsets.get(session_id, 0)
             effective_index = max(0, after_index - offset)
             # Convert deque slice to list (deque doesn't support slicing directly)

--- a/app/modules/workspace/remote_agent_manager.py
+++ b/app/modules/workspace/remote_agent_manager.py
@@ -53,6 +53,10 @@ class RemoteAgentManager:
     # Heartbeat rate-limiting interval (seconds)
     HEARTBEAT_DB_WRITE_INTERVAL = 30
 
+    # Maximum output buffer size per session (Issue #1511)
+    # Prevents unbounded memory growth when SSE disconnects but CLI continues
+    MAX_BUFFER_SIZE = 1000  # ~1000 messages per session
+
     # Session recovery window (seconds) - allows reconnection after brief disconnects
     # Sessions are only cleaned up if they've been inactive longer than this window
     SESSION_RECOVERY_WINDOW_SECONDS = 300  # 5 minutes recovery window
@@ -78,6 +82,10 @@ class RemoteAgentManager:
         self._session_machines: dict[str, str] = {}
         # Output buffers: {session_id: [output_lines]}
         self._output_buffers: dict[str, list[dict]] = {}
+        # Buffer offsets: {session_id: trimmed_count} — tracks how many items were trimmed
+        # This prevents data loss when get_buffered_output(after_index) is called
+        # after the buffer was trimmed (Issue #1511)
+        self._buffer_offsets: dict[str, int] = {}
         # Command queues for HTTP-mode agents: {machine_id: [commands]}
         self._command_queues: dict[str, list[dict]] = {}
         # Session end flags: {session_id: True} — set when session completes/stops/errors
@@ -1212,17 +1220,40 @@ class RemoteAgentManager:
     # ==================== Output Buffering ====================
 
     def buffer_output(self, session_id: str, output: dict[str, Any]) -> None:
-        """Buffer output from a remote session."""
+        """Buffer output from a remote session.
+
+        If buffer exceeds MAX_BUFFER_SIZE, trim oldest entries and record
+        the offset to prevent data loss on get_buffered_output (Issue #1511).
+        """
         with self._lock:
             if session_id not in self._output_buffers:
                 self._output_buffers[session_id] = []
-            self._output_buffers[session_id].append(output)
+                self._buffer_offsets[session_id] = 0
+            buf = self._output_buffers[session_id]
+            buf.append(output)
+            # Trim if exceeds MAX_BUFFER_SIZE
+            if len(buf) > self.MAX_BUFFER_SIZE:
+                trim_count = len(buf) - self.MAX_BUFFER_SIZE
+                self._output_buffers[session_id] = buf[trim_count:]
+                self._buffer_offsets[session_id] += trim_count
 
     def get_buffered_output(self, session_id: str, after_index: int = 0) -> list[dict]:
-        """Get buffered output for a session after a given index."""
+        """Get buffered output for a session after a given index.
+
+        Takes into account _buffer_offsets to prevent data loss when
+        the buffer was trimmed (Issue #1511).
+
+        Example:
+            - Buffer grew to 13000 items, trimmed to 10000 (offset=3000)
+            - Client requests after_index=3000
+            - Without offset: buf[3000:] returns items 3000-12999 (missing 0-2999)
+            - With offset: effective_index = max(0, 3000-3000) = 0, returns all
+        """
         with self._lock:
             buf = self._output_buffers.get(session_id, [])
-            return buf[after_index:]
+            offset = self._buffer_offsets.get(session_id, 0)
+            effective_index = max(0, after_index - offset)
+            return buf[effective_index:]
 
     def mark_session_ended(self, session_id: str) -> None:
         """Mark a session as ended (completed/stopped/error)."""

--- a/app/modules/workspace/remote_agent_manager.py
+++ b/app/modules/workspace/remote_agent_manager.py
@@ -12,6 +12,7 @@ import logging
 import threading
 import time
 import uuid
+from collections import deque
 from contextlib import suppress
 from datetime import datetime, timedelta, timezone
 from typing import Any, cast
@@ -138,7 +139,7 @@ class RemoteAgentManager:
                         mid = row["remote_machine_id"]
                         if sid and mid:
                             self._session_machines[sid] = mid
-                            self._output_buffers.setdefault(sid, [])
+                            self._output_buffers.setdefault(sid, deque(maxlen=self.MAX_BUFFER_SIZE))
 
                 # Restore end flags for completed/stopped/error sessions
                 cursor.execute(
@@ -1210,14 +1211,22 @@ class RemoteAgentManager:
         """Bind a session to a machine."""
         with self._lock:
             self._session_machines[session_id] = machine_id
-            self._output_buffers[session_id] = []
+            self._output_buffers[session_id] = deque(maxlen=self.MAX_BUFFER_SIZE)
 
     def unbind_session(self, session_id: str) -> None:
-        """Remove session binding."""
+        """Remove session binding.
+
+        Cleans up all session-related state to prevent memory leaks:
+        - _session_machines: session → machine mapping
+        - _output_buffers: buffered output data
+        - _buffer_offsets: buffer trim offset tracking
+        - _last_delivered: SSE reconnect position (Issue #1511)
+        """
         with self._lock:
             self._session_machines.pop(session_id, None)
             self._output_buffers.pop(session_id, None)
-            self._buffer_offsets.pop(session_id, None)  # Issue #1511: cleanup buffer offset
+            self._buffer_offsets.pop(session_id, None)
+            self._last_delivered.pop(session_id, None)  # Issue #1511: cleanup SSE state
 
     def get_machine_for_session(self, session_id: str) -> str | None:
         """Get the machine ID for a session."""
@@ -1228,20 +1237,22 @@ class RemoteAgentManager:
     def buffer_output(self, session_id: str, output: dict[str, Any]) -> None:
         """Buffer output from a remote session.
 
-        If buffer exceeds MAX_BUFFER_SIZE, trim oldest entries and record
-        the offset to prevent data loss on get_buffered_output (Issue #1511).
+        Uses deque(maxlen=MAX_BUFFER_SIZE) for O(1) append and automatic trim.
+        When maxlen is reached, oldest entries are automatically dropped, and
+        we increment _buffer_offsets to track the dropped count (Issue #1511).
+
+        Limitation: If SSE disconnects for >3-5 minutes during high-frequency
+        output (>5000 messages), old data will be trimmed and lost on reconnect.
         """
         with self._lock:
             if session_id not in self._output_buffers:
-                self._output_buffers[session_id] = []
+                self._output_buffers[session_id] = deque(maxlen=self.MAX_BUFFER_SIZE)
                 self._buffer_offsets[session_id] = 0
             buf = self._output_buffers[session_id]
+            # Track if this append will cause a trim (deque at maxlen)
+            if len(buf) == self.MAX_BUFFER_SIZE:
+                self._buffer_offsets[session_id] += 1
             buf.append(output)
-            # Trim if exceeds MAX_BUFFER_SIZE
-            if len(buf) > self.MAX_BUFFER_SIZE:
-                trim_count = len(buf) - self.MAX_BUFFER_SIZE
-                self._output_buffers[session_id] = buf[trim_count:]
-                self._buffer_offsets[session_id] += trim_count
 
     def get_buffered_output(self, session_id: str, after_index: int = 0) -> list[dict]:
         """Get buffered output for a session after a given index.
@@ -1250,16 +1261,22 @@ class RemoteAgentManager:
         the buffer was trimmed (Issue #1511).
 
         Example:
-            - Buffer grew to 13000 items, trimmed to 10000 (offset=3000)
-            - Client requests after_index=3000
-            - Without offset: buf[3000:] returns items 3000-12999 (missing 0-2999)
-            - With offset: effective_index = max(0, 3000-3000) = 0, returns all
+            - Buffer grew to 6000 items, trimmed to 5000 (offset=1000)
+            - Client requests after_index=1000
+            - Without offset: effective_index would be 1000, but deque only has 0-4999
+            - With offset: effective_index = max(0, 1000-1000) = 0, returns all 5000 items
+
+        Returns:
+            List of output entries (converted from deque slice).
         """
         with self._lock:
-            buf = self._output_buffers.get(session_id, [])
+            buf = self._output_buffers.get(session_id, deque())
             offset = self._buffer_offsets.get(session_id, 0)
             effective_index = max(0, after_index - offset)
-            return buf[effective_index:]
+            # Convert deque slice to list (deque doesn't support slicing directly)
+            if effective_index >= len(buf):
+                return []
+            return list(buf)[effective_index:]
 
     def mark_session_ended(self, session_id: str) -> None:
         """Mark a session as ended (completed/stopped/error).

--- a/app/modules/workspace/remote_agent_manager.py
+++ b/app/modules/workspace/remote_agent_manager.py
@@ -83,7 +83,7 @@ class RemoteAgentManager:
         # Session to machine mapping: {session_id: machine_id}
         self._session_machines: dict[str, str] = {}
         # Output buffers: {session_id: [output_lines]}
-        self._output_buffers: dict[str, list[dict]] = {}
+        self._output_buffers: dict[str, deque[dict]] = {}
         # Buffer offsets: {session_id: trimmed_count} — tracks how many items were trimmed
         # This prevents data loss when get_buffered_output(after_index) is called
         # after the buffer was trimmed (Issue #1511)

--- a/app/modules/workspace/remote_agent_manager.py
+++ b/app/modules/workspace/remote_agent_manager.py
@@ -55,7 +55,8 @@ class RemoteAgentManager:
 
     # Maximum output buffer size per session (Issue #1511)
     # Prevents unbounded memory growth when SSE disconnects but CLI continues
-    MAX_BUFFER_SIZE = 1000  # ~1000 messages per session
+    # 5000 messages ≈ 3-5 minutes of AI output, covers most brief disconnect scenarios
+    MAX_BUFFER_SIZE = 5000
 
     # Session recovery window (seconds) - allows reconnection after brief disconnects
     # Sessions are only cleaned up if they've been inactive longer than this window
@@ -90,6 +91,10 @@ class RemoteAgentManager:
         self._command_queues: dict[str, list[dict]] = {}
         # Session end flags: {session_id: True} — set when session completes/stops/errors
         self._session_end_flags: dict[str, bool] = {}
+        # SSE last delivered position: {session_id: last_index} (Issue #1511)
+        # Tracks the last index delivered to SSE client, so reconnect can resume
+        # from this position instead of replaying all buffered output from index 0.
+        self._last_delivered: dict[str, int] = {}
         # Heartbeat rate limiter: {machine_id: last_db_write_timestamp}
         self._last_heartbeat_db_write: dict[str, float] = {}
         # Browse results: {request_id: result} for directory browsing
@@ -1212,6 +1217,7 @@ class RemoteAgentManager:
         with self._lock:
             self._session_machines.pop(session_id, None)
             self._output_buffers.pop(session_id, None)
+            self._buffer_offsets.pop(session_id, None)  # Issue #1511: cleanup buffer offset
 
     def get_machine_for_session(self, session_id: str) -> str | None:
         """Get the machine ID for a session."""
@@ -1256,14 +1262,35 @@ class RemoteAgentManager:
             return buf[effective_index:]
 
     def mark_session_ended(self, session_id: str) -> None:
-        """Mark a session as ended (completed/stopped/error)."""
+        """Mark a session as ended (completed/stopped/error).
+
+        Also cleans up _last_delivered to prevent memory leak (Issue #1511).
+        """
         with self._lock:
             self._session_end_flags[session_id] = True
+            self._last_delivered.pop(session_id, None)  # Cleanup SSE state
 
     def is_session_ended(self, session_id: str) -> bool:
         """Check if a session has ended (in-memory, no DB query)."""
         with self._lock:
             return self._session_end_flags.get(session_id, False)
+
+    # ==================== SSE Last Delivered ====================
+
+    def get_last_delivered(self, session_id: str) -> int:
+        """Get the last delivered index for SSE reconnect (Issue #1511)."""
+        with self._lock:
+            return self._last_delivered.get(session_id, 0)
+
+    def set_last_delivered(self, session_id: str, index: int) -> None:
+        """Set the last delivered index for SSE reconnect (Issue #1511)."""
+        with self._lock:
+            self._last_delivered[session_id] = index
+
+    def clear_last_delivered(self, session_id: str) -> None:
+        """Clear the last delivered index (called when SSE stream ends)."""
+        with self._lock:
+            self._last_delivered.pop(session_id, None)
 
     # ==================== Heartbeat ====================
 

--- a/app/routes/remote.py
+++ b/app/routes/remote.py
@@ -842,7 +842,9 @@ def stream_session_output(session_id):
                     agent_mgr.set_last_delivered(session_id, last_index)
                 else:
                     idle_count += 1
-                    if idle_count >= 50:  # ~10 seconds (50 * 0.2s), aligned with KEEPALIVE_INTERVAL_MS
+                    if (
+                        idle_count >= 50
+                    ):  # ~10 seconds (50 * 0.2s), aligned with KEEPALIVE_INTERVAL_MS
                         yield ": keepalive\n\n"
                         idle_count = 0
 

--- a/app/routes/remote.py
+++ b/app/routes/remote.py
@@ -51,6 +51,12 @@ _CLI_SETTINGS_TOOLS = ["claude-code", "qwen-code", "codex-cli", "zcode"]
 
 remote_bp = Blueprint("remote", __name__)
 
+# SSE last delivered index tracking (Issue #1511)
+# When SSE disconnects and reconnects, this allows resuming from the last
+# delivered position instead of replaying all buffered output from index 0.
+# Key: session_id, Value: last_index delivered to client
+_last_delivered: dict[str, int] = {}
+
 
 @remote_bp.before_request
 def load_user():
@@ -778,7 +784,9 @@ def stream_session_output(session_id):
     def generate():
         try:
             yield ": connected\n\n"
-            last_index = 0
+            # Resume from last delivered index (Issue #1511)
+            # This prevents replaying all buffered output on SSE reconnect
+            last_index = _last_delivered.get(session_id, 0)
             idle_count = 0
             while True:
                 new_output = agent_mgr.get_buffered_output(session_id, after_index=last_index)
@@ -807,6 +815,7 @@ def stream_session_output(session_id):
                             # can display CLI errors instead of silently hanging.
                             yield f"data: {json.dumps({'type': 'error', 'data': data})}\n\n"
                             last_index += 1
+                            _last_delivered[session_id] = last_index
                             continue
                         if stream == "request_state":
                             try:
@@ -819,6 +828,7 @@ def stream_session_output(session_id):
                                     data,
                                 )
                             last_index += 1
+                            _last_delivered[session_id] = last_index
                             continue
                         try:
                             parsed = json.loads(data)
@@ -828,12 +838,13 @@ def stream_session_output(session_id):
                             else:
                                 # Wrap as claude_json to match local streaming format
                                 yield f"data: {json.dumps({'type': 'claude_json', 'data': parsed})}\n\n"
+                            last_index += 1
+                            _last_delivered[session_id] = last_index
                         except (json.JSONDecodeError, TypeError):
-                            pass
-                        last_index += 1
+                            last_index += 1
                 else:
                     idle_count += 1
-                    if idle_count >= 150:  # ~30 seconds (150 * 0.2s)
+                    if idle_count >= 50:  # ~10 seconds (50 * 0.2s), aligned with KEEPALIVE_INTERVAL_MS
                         yield ": keepalive\n\n"
                         idle_count = 0
 
@@ -843,16 +854,15 @@ def stream_session_output(session_id):
                 time.sleep(0.2)
 
             yield "data: [DONE]\n\n"
+            # Session completed — clean up last_delivered (Issue #1511)
+            _last_delivered.pop(session_id, None)
         except GeneratorExit:
             logger.info(
-                "Client disconnected during SSE for session %s, aborting request",
+                "Client disconnected during SSE for session %s, request continues in background",
                 session_id[:8],
             )
-            try:
-                session_mgr = get_remote_session_manager()
-                session_mgr.abort_request(session_id, reason="disconnect")
-            except Exception:
-                pass
+            # Don't abort_request — CLI continues running, data accumulates in buffer
+            # User can reconnect via SSE and receive buffered output
 
     return Response(
         stream_with_context(generate()),

--- a/app/routes/remote.py
+++ b/app/routes/remote.py
@@ -53,9 +53,8 @@ remote_bp = Blueprint("remote", __name__)
 
 # SSE last delivered index tracking (Issue #1511)
 # When SSE disconnects and reconnects, this allows resuming from the last
-# delivered position instead of replaying all buffered output from index 0.
-# Key: session_id, Value: last_index delivered to client
-_last_delivered: dict[str, int] = {}
+# SSE last delivered position is now managed by RemoteAgentManager (Issue #1511)
+# See: agent_mgr.get_last_delivered(), set_last_delivered(), clear_last_delivered()
 
 
 @remote_bp.before_request
@@ -786,7 +785,7 @@ def stream_session_output(session_id):
             yield ": connected\n\n"
             # Resume from last delivered index (Issue #1511)
             # This prevents replaying all buffered output on SSE reconnect
-            last_index = _last_delivered.get(session_id, 0)
+            last_index = agent_mgr.get_last_delivered(session_id)
             idle_count = 0
             while True:
                 new_output = agent_mgr.get_buffered_output(session_id, after_index=last_index)
@@ -815,7 +814,6 @@ def stream_session_output(session_id):
                             # can display CLI errors instead of silently hanging.
                             yield f"data: {json.dumps({'type': 'error', 'data': data})}\n\n"
                             last_index += 1
-                            _last_delivered[session_id] = last_index
                             continue
                         if stream == "request_state":
                             try:
@@ -828,7 +826,6 @@ def stream_session_output(session_id):
                                     data,
                                 )
                             last_index += 1
-                            _last_delivered[session_id] = last_index
                             continue
                         try:
                             parsed = json.loads(data)
@@ -839,9 +836,10 @@ def stream_session_output(session_id):
                                 # Wrap as claude_json to match local streaming format
                                 yield f"data: {json.dumps({'type': 'claude_json', 'data': parsed})}\n\n"
                             last_index += 1
-                            _last_delivered[session_id] = last_index
                         except (json.JSONDecodeError, TypeError):
                             last_index += 1
+                    # Update last_delivered after processing all entries in this batch
+                    agent_mgr.set_last_delivered(session_id, last_index)
                 else:
                     idle_count += 1
                     if idle_count >= 50:  # ~10 seconds (50 * 0.2s), aligned with KEEPALIVE_INTERVAL_MS
@@ -855,7 +853,7 @@ def stream_session_output(session_id):
 
             yield "data: [DONE]\n\n"
             # Session completed — clean up last_delivered (Issue #1511)
-            _last_delivered.pop(session_id, None)
+            agent_mgr.clear_last_delivered(session_id)
         except GeneratorExit:
             logger.info(
                 "Client disconnected during SSE for session %s, request continues in background",

--- a/app/routes/remote.py
+++ b/app/routes/remote.py
@@ -51,11 +51,6 @@ _CLI_SETTINGS_TOOLS = ["claude-code", "qwen-code", "codex-cli", "zcode"]
 
 remote_bp = Blueprint("remote", __name__)
 
-# SSE last delivered index tracking (Issue #1511)
-# When SSE disconnects and reconnects, this allows resuming from the last
-# SSE last delivered position is now managed by RemoteAgentManager (Issue #1511)
-# See: agent_mgr.get_last_delivered(), set_last_delivered(), clear_last_delivered()
-
 
 @remote_bp.before_request
 def load_user():
@@ -857,6 +852,10 @@ def stream_session_output(session_id):
             # Session completed — clean up last_delivered (Issue #1511)
             agent_mgr.clear_last_delivered(session_id)
         except GeneratorExit:
+            # Save delivered progress before disconnect (Issue #1511)
+            # Without this, data sent during the current batch but not yet recorded
+            # would be replayed on reconnect, causing duplicate messages.
+            agent_mgr.set_last_delivered(session_id, last_index)
             logger.info(
                 "Client disconnected during SSE for session %s, request continues in background",
                 session_id[:8],

--- a/scripts/init_db.py
+++ b/scripts/init_db.py
@@ -8,7 +8,7 @@ Database schema is created by schema.sql during installation.
 
 import os
 import sys
-from typing import Optional
+from typing import Optional, Tuple
 
 import bcrypt
 
@@ -107,8 +107,14 @@ def create_default_admin(
     email: str = "admin@localhost",
     system_account: Optional[str] = None,
     tenant_id: int = 1,
-) -> bool:
-    """Create a default admin user with forced password change on first login."""
+) -> Tuple[bool, bool]:
+    """Create a default admin user with forced password change on first login.
+
+    Returns:
+        Tuple[bool, bool]: (success, is_new_user)
+            - success: True if operation completed successfully
+            - is_new_user: True if a new user was created, False if user already existed
+    """
     # Hash password using bcrypt
     password_hash = bcrypt.hashpw(password.encode(), bcrypt.gensalt(rounds=12)).decode()
 
@@ -122,14 +128,14 @@ def create_default_admin(
             # Validate system_account parameter
             if not system_account.strip():
                 print("Warning: system_account is empty string, skipping update")
-                return True
+                return (True, False)
             try:
                 db.update_user(existing["id"], system_account=system_account)
                 print(f"Updated system_account for '{username}' to '{system_account}'")
             except Exception as e:
                 print(f"Warning: Failed to update system_account for '{username}': {e}")
         print(f"Admin user '{username}' already exists")
-        return True
+        return (True, False)
 
     # Create admin user with must_change_password = True (force password change on first login)
     result = db.create_user_with_is_active(
@@ -151,10 +157,10 @@ def create_default_admin(
         print(f"Password: {password}")
         print(f"Tenant ID: {tenant_id}")
         print("\nIMPORTANT: You MUST change the password on first login!")
-        return True
+        return (True, True)
     else:
         print(f"Failed to create admin user '{username}'")
-        return False
+        return (False, False)
 
 
 def main():
@@ -172,12 +178,17 @@ def main():
     create_default_tenant()
 
     # Create default admin user with tenant_id=1
-    create_default_admin(system_account=system_account, tenant_id=1)
+    success, is_new_user = create_default_admin(system_account=system_account, tenant_id=1)
 
-    print("\nDefault admin credentials:")
-    print("  Username: admin")
-    print("  Password: admin123")
-    print("\nPlease change the default password after first login!")
+    # Only show default password message when a new user was actually created
+    if is_new_user:
+        print("\nDefault admin credentials:")
+        print("  Username: admin")
+        print("  Password: admin123")
+        print("\nPlease change the default password after first login!")
+    else:
+        print("\nAdmin user 'admin' already exists - password unchanged.")
+        print("If you forgot the password, please use the password reset feature.")
 
 
 if __name__ == "__main__":

--- a/scripts/init_db.py
+++ b/scripts/init_db.py
@@ -8,7 +8,7 @@ Database schema is created by schema.sql during installation.
 
 import os
 import sys
-from typing import Optional, Tuple
+from typing import Optional
 
 import bcrypt
 
@@ -107,14 +107,8 @@ def create_default_admin(
     email: str = "admin@localhost",
     system_account: Optional[str] = None,
     tenant_id: int = 1,
-) -> Tuple[bool, bool]:
-    """Create a default admin user with forced password change on first login.
-
-    Returns:
-        Tuple[bool, bool]: (success, is_new_user)
-            - success: True if operation completed successfully
-            - is_new_user: True if a new user was created, False if user already existed
-    """
+) -> bool:
+    """Create a default admin user with forced password change on first login."""
     # Hash password using bcrypt
     password_hash = bcrypt.hashpw(password.encode(), bcrypt.gensalt(rounds=12)).decode()
 
@@ -128,14 +122,14 @@ def create_default_admin(
             # Validate system_account parameter
             if not system_account.strip():
                 print("Warning: system_account is empty string, skipping update")
-                return (True, False)
+                return True
             try:
                 db.update_user(existing["id"], system_account=system_account)
                 print(f"Updated system_account for '{username}' to '{system_account}'")
             except Exception as e:
                 print(f"Warning: Failed to update system_account for '{username}': {e}")
         print(f"Admin user '{username}' already exists")
-        return (True, False)
+        return True
 
     # Create admin user with must_change_password = True (force password change on first login)
     result = db.create_user_with_is_active(
@@ -157,10 +151,10 @@ def create_default_admin(
         print(f"Password: {password}")
         print(f"Tenant ID: {tenant_id}")
         print("\nIMPORTANT: You MUST change the password on first login!")
-        return (True, True)
+        return True
     else:
         print(f"Failed to create admin user '{username}'")
-        return (False, False)
+        return False
 
 
 def main():
@@ -178,17 +172,12 @@ def main():
     create_default_tenant()
 
     # Create default admin user with tenant_id=1
-    success, is_new_user = create_default_admin(system_account=system_account, tenant_id=1)
+    create_default_admin(system_account=system_account, tenant_id=1)
 
-    # Only show default password message when a new user was actually created
-    if is_new_user:
-        print("\nDefault admin credentials:")
-        print("  Username: admin")
-        print("  Password: admin123")
-        print("\nPlease change the default password after first login!")
-    else:
-        print("\nAdmin user 'admin' already exists - password unchanged.")
-        print("If you forgot the password, please use the password reset feature.")
+    print("\nDefault admin credentials:")
+    print("  Username: admin")
+    print("  Password: admin123")
+    print("\nPlease change the default password after first login!")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

This PR improves SSE stream stability for remote sessions, fixing issues with permission request timeouts and AI not responding.

## Changes

### SSE Heartbeat
- Reduce heartbeat interval from 30s to 10s (aligned with KEEPALIVE_INTERVAL_MS)

### SSE Disconnect Handling
- Remove `abort_request` on SSE disconnect - CLI continues running in background
- Data accumulates in buffer for later retrieval on reconnect

### Buffer Management
- Add `MAX_BUFFER_SIZE = 1000` to prevent unbounded memory growth
- Track buffer offset (`_buffer_offsets`) for index consistency after trimming

### SSE Reconnect Recovery
- Add `_last_delivered` tracking to resume from last delivered index on reconnect
- Clean up `_last_delivered` when session ends

## Related Issues

Fixes #1511
Related to ivycomputing/qwen-code-webui#195