### PR TITLE
fix(autonomous): strip credentials from git remote URL before parsing (Issue #1524)

### DIFF
--- a/app/modules/workspace/autonomous/github_ops.py
+++ b/app/modules/workspace/autonomous/github_ops.py
@@ -176,6 +176,9 @@ class GitHubOps:
             return None
         if not url:
             return None
+        # Strip credentials from URL before parsing
+        # (handles https://user:token@host and https://user@host formats)
+        url = re.sub(r"^(https?://)([^@/:]+(?::[^@/]*)?@)", r"\1", url)
         # Parse the host and owner/repo from common git remote forms:
         #   https://github.com/<owner>/<repo>[.git]
         #   git@github.com:<owner>/<repo>[.git]            (SCP-style)

--- a/tests/issues/716/test_github_ops_sudo.py
+++ b/tests/issues/716/test_github_ops_sudo.py
@@ -126,6 +126,34 @@ class TestResolveOwnerRepo:
         ):
             assert gh._resolve_owner_repo() == "gh.example.com/owner/repo"
 
+    def test_https_url_with_credentials(self):
+        """URL containing user:token@ credentials is stripped before parsing."""
+        gh = GitHubOps("/tmp/repo", system_account="alice")
+        with patch.object(
+            GitHubOps,
+            "get_repo_url",
+            return_value="https://user:ghp_token@github.com/open-ace/open-ace.git",
+        ):
+            assert gh._resolve_owner_repo() == "open-ace/open-ace"
+
+    def test_https_url_with_credentials_only_user(self):
+        """URL containing user@ (no password) is stripped before parsing."""
+        gh = GitHubOps("/tmp/repo", system_account="alice")
+        with patch.object(
+            GitHubOps, "get_repo_url", return_value="https://user@github.com/open-ace/open-ace.git"
+        ):
+            assert gh._resolve_owner_repo() == "open-ace/open-ace"
+
+    def test_ghes_https_url_with_credentials(self):
+        """GHES URL with credentials strips credentials and includes host."""
+        gh = GitHubOps("/tmp/repo", system_account="alice")
+        with patch.object(
+            GitHubOps,
+            "get_repo_url",
+            return_value="https://user:token@gh.example.com/owner/repo.git",
+        ):
+            assert gh._resolve_owner_repo() == "gh.example.com/owner/repo"
+
 
 class TestRunGhSudo:
     """_run_gh under a sudo wrapper uses -R owner/repo, never -C."""


### PR DESCRIPTION
## Summary

Fixes #1524

Git remote URLs may contain credentials in the format:
```
https://user:token@github.com/owner/repo.git
```

The existing regex in `_resolve_owner_repo()` matched incorrectly, capturing `user:token@github.com` as the host instead of `github.com`, causing gh CLI to receive malformed `-R` argument and return HTTP 422.

## Changes

- Add preprocessing step to strip credentials before parsing
- Handles `https://user:token@host` and `https://user@host` formats
- Works for both github.com and GHES URLs

## Tests

Added 3 test cases:
- `test_https_url_with_credentials` - URL with `user:token@`
- `test_https_url_with_credentials_only_user` - URL with `user@` (no password)
- `test_ghes_https_url_with_credentials` - GHES URL with credentials

## Test plan

```bash
pytest tests/issues/716/test_github_ops_sudo.py::TestResolveOwnerRepo -v
```