### PR TITLE
fix(autonomous): detect test execution from tool_calls to prevent false skip (Issue #1532)

### DIFF
--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -225,7 +225,9 @@ def _has_test_tool_call(tool_calls: list, framework_type: str) -> bool:
     for tc in tool_calls:
         tool_name = tc.get("tool", {}).get("name", "") if isinstance(tc.get("tool"), dict) else ""
         # P0: Ensure tool_input is dict (handle None case)
-        tool_input = (tc.get("tool", {}).get("input", {}) or {}) if isinstance(tc.get("tool"), dict) else {}
+        tool_input = (
+            (tc.get("tool", {}).get("input", {}) or {}) if isinstance(tc.get("tool"), dict) else {}
+        )
 
         # P2: Check non-Bash test tools first (pytest, run_tests, test)
         if tool_name in ("pytest", "run_tests", "test"):
@@ -3000,9 +3002,7 @@ class AutonomousOrchestrator:
         has_test_tool_call = _has_test_tool_call(test_result.tool_calls or [], framework_type)
 
         tests_actually_run = (
-            test_status_tag in ("passed", "failed")
-            or has_test_tool_call
-            or has_test_result
+            test_status_tag in ("passed", "failed") or has_test_tool_call or has_test_result
         )
 
         tests_actually_skipped = (

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -198,6 +198,51 @@ def _is_bot_comment(comment: dict) -> bool:
     return any(kw in login.lower() for kw in BOT_AUTHOR_KEYWORDS)
 
 
+def _has_test_tool_call(tool_calls: list, framework_type: str) -> bool:
+    """Check if tool_calls contains a test framework execution command.
+
+    This detects actual test execution by examining tool call commands,
+    complementing pytest output detection. Used to prevent false-negative
+    "Tests were not actually run" judgments when agent runs tests but
+    output is not captured in visible text (Issue #1532).
+    """
+    if not tool_calls:
+        return False
+
+    test_commands = {
+        "python": ["pytest", "python -m pytest", "-m pytest", "unittest", "tox", "nox"],
+        "javascript": ["jest", "npm test", "npm run test", "yarn test", "vitest", "mocha"],
+        "go": ["go test", "gotestsum"],
+        "rust": ["cargo test", "cargo t"],
+        "java": ["mvn test", "gradle test", "./gradlew test"],
+    }
+    # P1: generic_patterns includes unittest for unknown frameworks
+    generic_patterns = ["pytest", "unittest", "jest", "go test", "cargo test", "npm test"]
+    patterns_to_check = test_commands.get(framework_type, generic_patterns)
+    # Note: -v (verbose) is NOT excluded, only --help/--version/-h
+    exclude_flags = ["--help", "--version", "-h"]
+
+    for tc in tool_calls:
+        tool_name = tc.get("tool", {}).get("name", "") if isinstance(tc.get("tool"), dict) else ""
+        # P0: Ensure tool_input is dict (handle None case)
+        tool_input = (tc.get("tool", {}).get("input", {}) or {}) if isinstance(tc.get("tool"), dict) else {}
+
+        # P2: Check non-Bash test tools first (pytest, run_tests, test)
+        if tool_name in ("pytest", "run_tests", "test"):
+            return True
+
+        # Then check Bash/run_shell_command for test commands
+        if tool_name in ("Bash", "run_shell_command"):
+            cmd = tool_input.get("command", "")
+            if not cmd or any(flag in cmd for flag in exclude_flags):
+                continue
+            for pattern in patterns_to_check:
+                if pattern in cmd:
+                    return True
+
+    return False
+
+
 # Prefix added to all prompts to inform the agent it is running autonomously
 AUTONOMOUS_CONTEXT = (
     "## 重要提示\n"
@@ -2950,11 +2995,21 @@ class AutonomousOrchestrator:
         # Final test result determination
         has_test_result = has_actual_pytest_output
         test_status_tag = self._artifact_status_tag(test_result, "test_status").lower()
+
+        # Issue #1532 fix: Reverse judgment logic with tool_calls check
+        has_test_tool_call = _has_test_tool_call(test_result.tool_calls or [], framework_type)
+
+        tests_actually_run = (
+            test_status_tag in ("passed", "failed")
+            or has_test_tool_call
+            or has_test_result
+        )
+
         tests_actually_skipped = (
             test_status_tag == "skipped"
             or has_skip_tag
-            or (test_result.success and has_skip_keyword)
-            or (test_result.success and not has_test_result)
+            or (test_result.success and has_skip_keyword and not tests_actually_run)
+            or (test_result.success and not tests_actually_run)
         )
 
         # Post test results to issue

--- a/tests/issues/1532/test_tool_call_detection.py
+++ b/tests/issues/1532/test_tool_call_detection.py
@@ -1,0 +1,196 @@
+"""Tests for test tool call detection (Issue #1532).
+
+Bug: Agent runs pytest but output is not captured in visible text,
+causing tests_actually_skipped=True -> infinite retry loop.
+
+Fix: Check tool_calls for test execution commands + reverse judgment logic.
+"""
+
+import pytest
+
+
+class TestHasTestToolCall:
+    """Verify _has_test_tool_call detects test commands correctly."""
+
+    @pytest.mark.parametrize(
+        "tool_calls,framework_type,expected",
+        [
+            # Empty tool_calls -> False
+            ([], "python", False),
+            # Python pytest detection
+            ([{"tool": {"name": "Bash", "input": {"command": "pytest"}}}], "python", True),
+            ([{"tool": {"name": "Bash", "input": {"command": "pytest tests/"}}}], "python", True),
+            ([{"tool": {"name": "Bash", "input": {"command": "python -m pytest"}}}], "python", True),
+            ([{"tool": {"name": "Bash", "input": {"command": "pytest -v"}}}], "python", True),
+            # Help/version queries should NOT count as test execution
+            ([{"tool": {"name": "Bash", "input": {"command": "pytest --help"}}}], "python", False),
+            ([{"tool": {"name": "Bash", "input": {"command": "pytest --version"}}}], "python", False),
+            ([{"tool": {"name": "Bash", "input": {"command": "pytest -h"}}}], "python", False),
+            # Non-test commands -> False
+            ([{"tool": {"name": "Bash", "input": {"command": "ls -la"}}}], "python", False),
+            ([{"tool": {"name": "Bash", "input": {"command": "git status"}}}], "python", False),
+            # JavaScript Jest detection
+            ([{"tool": {"name": "Bash", "input": {"command": "npm test"}}}], "javascript", True),
+            ([{"tool": {"name": "Bash", "input": {"command": "jest"}}}], "javascript", True),
+            ([{"tool": {"name": "Bash", "input": {"command": "vitest run"}}}], "javascript", True),
+            # Go test detection (including -v verbose)
+            ([{"tool": {"name": "Bash", "input": {"command": "go test ./..."}}}], "go", True),
+            ([{"tool": {"name": "Bash", "input": {"command": "go test -v ./pkg"}}}], "go", True),
+            ([{"tool": {"name": "Bash", "input": {"command": "gotestsum"}}}], "go", True),
+            # Rust cargo test detection
+            ([{"tool": {"name": "Bash", "input": {"command": "cargo test"}}}], "rust", True),
+            ([{"tool": {"name": "Bash", "input": {"command": "cargo t"}}}], "rust", True),
+            # Java gradle/maven test detection
+            ([{"tool": {"name": "Bash", "input": {"command": "mvn test"}}}], "java", True),
+            ([{"tool": {"name": "Bash", "input": {"command": "gradle test"}}}], "java", True),
+            ([{"tool": {"name": "Bash", "input": {"command": "./gradlew test"}}}], "java", True),
+            # Unknown framework -> fallback to generic_patterns (includes unittest)
+            ([{"tool": {"name": "Bash", "input": {"command": "pytest"}}}], "unknown", True),
+            ([{"tool": {"name": "Bash", "input": {"command": "unittest discover"}}}], "unknown", True),
+            ([{"tool": {"name": "Bash", "input": {"command": "jest"}}}], "unknown", True),
+            ([{"tool": {"name": "Bash", "input": {"command": "go test"}}}], "unknown", True),
+            ([{"tool": {"name": "Bash", "input": {"command": "cargo test"}}}], "unknown", True),
+            ([{"tool": {"name": "Bash", "input": {"command": "npm test"}}}], "unknown", True),
+            # Multiple tool_calls: one is test command
+            (
+                [
+                    {"tool": {"name": "Bash", "input": {"command": "git status"}}},
+                    {"tool": {"name": "Bash", "input": {"command": "pytest"}}},
+                ],
+                "python",
+                True,
+            ),
+            # Non-Bash test tools (pytest, run_tests, test)
+            ([{"tool": {"name": "pytest", "input": {}}}], "python", True),
+            ([{"tool": {"name": "run_tests", "input": {}}}], "python", True),
+            ([{"tool": {"name": "test", "input": {}}}], "python", True),
+            # Empty/malformed tool_calls
+            ([{}], "python", False),
+            ([{"tool": {}}], "python", False),
+            ([{"tool": {"name": "Bash"}}], "python", False),  # missing input
+        ],
+    )
+    def test_tool_call_detection(self, tool_calls, framework_type, expected):
+        """_has_test_tool_call should detect test execution commands."""
+        from app.modules.workspace.autonomous.orchestrator import _has_test_tool_call
+
+        result = _has_test_tool_call(tool_calls, framework_type)
+        assert result == expected
+
+    def test_multiple_tool_calls(self):
+        """When multiple tool_calls present, one test command is sufficient."""
+        from app.modules.workspace.autonomous.orchestrator import _has_test_tool_call
+
+        tool_calls = [
+            {"tool": {"name": "Bash", "input": {"command": "ls -la"}}},
+            {"tool": {"name": "Bash", "input": {"command": "pytest tests/ -v"}}},
+            {"tool": {"name": "Bash", "input": {"command": "git status"}}},
+        ]
+        assert _has_test_tool_call(tool_calls, "python") is True
+
+
+class TestToolInputNoneSafety:
+    """P0 fix: tool_input being None should not cause AttributeError."""
+
+    def test_tool_input_none_no_error(self):
+        """tool_input=None should be handled gracefully."""
+        from app.modules.workspace.autonomous.orchestrator import _has_test_tool_call
+
+        tool_calls = [{"tool": {"name": "Bash", "input": None}}]
+        # Should not raise AttributeError, should return False
+        result = _has_test_tool_call(tool_calls, "python")
+        assert result is False
+
+    def test_tool_input_none_with_other_tools(self):
+        """tool_input=None in one tool should not break other tools."""
+        from app.modules.workspace.autonomous.orchestrator import _has_test_tool_call
+
+        tool_calls = [
+            {"tool": {"name": "Bash", "input": None}},
+            {"tool": {"name": "Bash", "input": {"command": "pytest"}}},
+        ]
+        assert _has_test_tool_call(tool_calls, "python") is True
+
+
+class TestSkipDetectionLogic:
+    """Test the reverse judgment logic for tests_actually_skipped."""
+
+    def test_agent_no_text_but_has_tool_call(self):
+        """Agent has no visible pytest output but tool_call shows test ran."""
+        from app.modules.workspace.autonomous.orchestrator import _has_test_tool_call
+
+        tool_calls = [{"tool": {"name": "Bash", "input": {"command": "pytest -x"}}}]
+        has_test_tool_call = _has_test_tool_call(tool_calls, "python")
+
+        # tests_actually_run should be True due to tool_call evidence
+        tests_actually_run = has_test_tool_call
+        assert tests_actually_run is True
+
+    def test_agent_with_passed_status_tag(self):
+        """Agent outputs TEST_STATUS: passed -> tests_actually_run."""
+        test_status_tag = "passed"
+        tests_actually_run = test_status_tag in ("passed", "failed")
+        assert tests_actually_run is True
+
+    def test_agent_with_skipped_status_tag(self):
+        """Agent outputs TEST_STATUS: skipped -> tests_actually_skipped."""
+        test_status_tag = "skipped"
+        tests_actually_skipped = test_status_tag == "skipped"
+        assert tests_actually_skipped is True
+
+    def test_agent_with_no_evidence(self):
+        """Agent has no test_status, no tool_call, no pytest output -> skipped."""
+        test_status_tag = ""
+        has_test_tool_call = False
+        has_test_result = False
+        test_result_success = True
+
+        tests_actually_run = (
+            test_status_tag in ("passed", "failed")
+            or has_test_tool_call
+            or has_test_result
+        )
+        tests_actually_skipped = (
+            test_status_tag == "skipped"
+            or (test_result_success and not tests_actually_run)
+        )
+        assert tests_actually_skipped is True
+
+
+class TestFrameworkSpecificPatterns:
+    """Test detection patterns for different test frameworks."""
+
+    def test_python_unittest_detection(self):
+        """unittest is a valid Python test framework."""
+        from app.modules.workspace.autonomous.orchestrator import _has_test_tool_call
+
+        tool_calls = [{"tool": {"name": "Bash", "input": {"command": "python -m unittest"}}}]
+        assert _has_test_tool_call(tool_calls, "python") is True
+
+    def test_python_tox_detection(self):
+        """tox is a valid Python test framework."""
+        from app.modules.workspace.autonomous.orchestrator import _has_test_tool_call
+
+        tool_calls = [{"tool": {"name": "Bash", "input": {"command": "tox"}}}]
+        assert _has_test_tool_call(tool_calls, "python") is True
+
+    def test_go_verbose_test_detection(self):
+        """go test -v (verbose) is a valid test command."""
+        from app.modules.workspace.autonomous.orchestrator import _has_test_tool_call
+
+        tool_calls = [{"tool": {"name": "Bash", "input": {"command": "go test -v ./..."}}}]
+        assert _has_test_tool_call(tool_calls, "go") is True
+
+    def test_rust_cargo_test_detection(self):
+        """cargo test is a valid Rust test command."""
+        from app.modules.workspace.autonomous.orchestrator import _has_test_tool_call
+
+        tool_calls = [{"tool": {"name": "Bash", "input": {"command": "cargo test"}}}]
+        assert _has_test_tool_call(tool_calls, "rust") is True
+
+    def test_java_gradle_test_detection(self):
+        """gradle test is a valid Java test command."""
+        from app.modules.workspace.autonomous.orchestrator import _has_test_tool_call
+
+        tool_calls = [{"tool": {"name": "Bash", "input": {"command": "gradle test"}}}]
+        assert _has_test_tool_call(tool_calls, "java") is True

--- a/tests/issues/1532/test_tool_call_detection.py
+++ b/tests/issues/1532/test_tool_call_detection.py
@@ -20,11 +20,19 @@ class TestHasTestToolCall:
             # Python pytest detection
             ([{"tool": {"name": "Bash", "input": {"command": "pytest"}}}], "python", True),
             ([{"tool": {"name": "Bash", "input": {"command": "pytest tests/"}}}], "python", True),
-            ([{"tool": {"name": "Bash", "input": {"command": "python -m pytest"}}}], "python", True),
+            (
+                [{"tool": {"name": "Bash", "input": {"command": "python -m pytest"}}}],
+                "python",
+                True,
+            ),
             ([{"tool": {"name": "Bash", "input": {"command": "pytest -v"}}}], "python", True),
             # Help/version queries should NOT count as test execution
             ([{"tool": {"name": "Bash", "input": {"command": "pytest --help"}}}], "python", False),
-            ([{"tool": {"name": "Bash", "input": {"command": "pytest --version"}}}], "python", False),
+            (
+                [{"tool": {"name": "Bash", "input": {"command": "pytest --version"}}}],
+                "python",
+                False,
+            ),
             ([{"tool": {"name": "Bash", "input": {"command": "pytest -h"}}}], "python", False),
             # Non-test commands -> False
             ([{"tool": {"name": "Bash", "input": {"command": "ls -la"}}}], "python", False),
@@ -46,7 +54,11 @@ class TestHasTestToolCall:
             ([{"tool": {"name": "Bash", "input": {"command": "./gradlew test"}}}], "java", True),
             # Unknown framework -> fallback to generic_patterns (includes unittest)
             ([{"tool": {"name": "Bash", "input": {"command": "pytest"}}}], "unknown", True),
-            ([{"tool": {"name": "Bash", "input": {"command": "unittest discover"}}}], "unknown", True),
+            (
+                [{"tool": {"name": "Bash", "input": {"command": "unittest discover"}}}],
+                "unknown",
+                True,
+            ),
             ([{"tool": {"name": "Bash", "input": {"command": "jest"}}}], "unknown", True),
             ([{"tool": {"name": "Bash", "input": {"command": "go test"}}}], "unknown", True),
             ([{"tool": {"name": "Bash", "input": {"command": "cargo test"}}}], "unknown", True),
@@ -146,13 +158,10 @@ class TestSkipDetectionLogic:
         test_result_success = True
 
         tests_actually_run = (
-            test_status_tag in ("passed", "failed")
-            or has_test_tool_call
-            or has_test_result
+            test_status_tag in ("passed", "failed") or has_test_tool_call or has_test_result
         )
-        tests_actually_skipped = (
-            test_status_tag == "skipped"
-            or (test_result_success and not tests_actually_run)
+        tests_actually_skipped = test_status_tag == "skipped" or (
+            test_result_success and not tests_actually_run
         )
         assert tests_actually_skipped is True
 


### PR DESCRIPTION
## Summary

Fixes #1532

Bug: Agent runs pytest but output is not captured in visible text, causing `tests_actually_skipped=True` → infinite retry loop.

## Root Cause

`_artifact_visible_text` only extracts assistant text, pytest output is in tool_use results and invisible to skip detection.

## Fix

1. **Add `_has_test_tool_call()` function** to detect test commands in tool_calls
   - Support pytest/jest/go test/cargo test/mvn test frameworks
   - Exclude --help/--version queries (not real test execution)
   - Handle `tool_input=None` edge case (P0)

2. **Reverse judgment logic**:
   - First determine `tests_actually_run` (status_tag OR tool_call OR pytest_output)
   - Then determine `tests_actually_skipped` (based on `tests_actually_run`)

3. **Three evidence types prove test ran**:
   - status_tag (passed/failed)
   - tool_call (test command detected)
   - pytest_output (visible text detection)

## Test Coverage

- 46 test cases covering Python/JS/Go/Rust/Java frameworks
- P0: `tool_input=None` safety
- P1: `generic_patterns` includes unittest, `go test -v` allowed

## Test Plan

```bash
python -m pytest tests/issues/1532/test_tool_call_detection.py -v
```

All 46 tests passed.