### PR TITLE
fix(test): add socket directory for PostgreSQL tests (Issue #1550)

### DIFF
--- a/tests/unit/test_alembic_baseline_cutover.py
+++ b/tests/unit/test_alembic_baseline_cutover.py
@@ -42,6 +42,8 @@ def _temporary_postgres_database(tmp_path):
 
     cluster_dir = tmp_path / "pg-cluster"
     log_path = tmp_path / "postgres.log"
+    socket_dir = tmp_path / "pg-socket"
+    socket_dir.mkdir(parents=True, exist_ok=True)
     port = "55435"
     env = os.environ.copy()
     env.update({"LC_ALL": "C", "LANG": "C"})
@@ -54,7 +56,16 @@ def _temporary_postgres_database(tmp_path):
         env=env,
     )
     subprocess.run(
-        ["pg_ctl", "-D", str(cluster_dir), "-l", str(log_path), "-o", f"-p {port}", "start"],
+        [
+            "pg_ctl",
+            "-D",
+            str(cluster_dir),
+            "-l",
+            str(log_path),
+            "-o",
+            f"-p {port} -k {socket_dir}",
+            "start",
+        ],
         check=True,
         capture_output=True,
         text=True,


### PR DESCRIPTION
## 问题描述

PostgreSQL 测试 fixture 在某些环境下失败，原因是 PostgreSQL 尝试在 `/var/run/postgresql` 创建 Unix socket lock file 时遇到权限问题。

## 修复内容

为 PostgreSQL 测试 fixture 添加自定义 socket 目录（使用测试临时路径），避免依赖系统目录权限：

```python
socket_dir = tmp_path / "pg-socket"
socket_dir.mkdir(parents=True, exist_ok=True)
# pg_ctl start 添加 -k 参数
-o f"-p {port} -k {socket_dir}"
```

## 影响范围

- `tests/unit/test_alembic_baseline_cutover.py` 中所有 PostgreSQL 测试

Closes #1550