### PR TITLE
fix: tenant management page internationalization and trial days (Issue #1500, #1501)

### DIFF
--- a/app/modules/sso/manager.py
+++ b/app/modules/sso/manager.py
@@ -214,7 +214,7 @@ class SSOManager:
             logger.info(f"Registered SSO provider: {name}")
             return True
 
-        except Exception as e:
+        except Exception:
             logger.error(f"Failed to register SSO provider: {e}")
             return False
 
@@ -312,7 +312,7 @@ class SSOManager:
 
             return cast("Optional[SSOProvider]", provider)
 
-        except Exception as e:
+        except Exception:
             logger.error(f"Failed to load SSO provider {name}: {e}")
             return None
 
@@ -352,7 +352,7 @@ class SSOManager:
 
             return True
 
-        except Exception as e:
+        except Exception:
             logger.error(f"Failed to disable provider: {e}")
             return False
 
@@ -366,7 +366,7 @@ class SSOManager:
 
             return True
 
-        except Exception as e:
+        except Exception:
             logger.error(f"Failed to enable provider: {e}")
             return False
 
@@ -505,7 +505,7 @@ class SSOManager:
             )
             return True
 
-        except Exception as e:
+        except Exception:
             logger.error(f"Failed to link SSO identity: {e}")
             return False
 
@@ -573,7 +573,7 @@ class SSOManager:
 
             return session_token
 
-        except Exception as e:
+        except Exception:
             logger.error(f"Failed to create SSO session: {e}")
             return None
 
@@ -606,7 +606,7 @@ class SSOManager:
             self.db.execute("DELETE FROM sso_sessions WHERE session_token = ?", (session_token,))
             return True
 
-        except Exception as e:
+        except Exception:
             logger.error(f"Failed to delete SSO session: {e}")
             return False
 
@@ -619,7 +619,7 @@ class SSOManager:
             )
             return cast("int", cursor.rowcount)
 
-        except Exception as e:
+        except Exception:
             logger.error(f"Failed to cleanup sessions: {e}")
             return 0
 
@@ -646,7 +646,7 @@ class SSOManager:
                 (state, code_verifier, provider_name, nonce),
             )
 
-        except Exception as e:
+        except Exception:
             logger.error(f"Failed to store auth state: {e}")
 
     def _get_auth_state(self, state: str) -> Optional[dict[str, Any]]:
@@ -655,7 +655,7 @@ class SSOManager:
             row = self.db.fetch_one("SELECT * FROM sso_auth_states WHERE state = ?", (state,))
             return dict(row) if row else None
 
-        except Exception as e:
+        except Exception:
             logger.error(f"Failed to get auth state: {e}")
             return None
 
@@ -664,7 +664,7 @@ class SSOManager:
         try:
             self.db.execute("DELETE FROM sso_auth_states WHERE state = ?", (state,))
 
-        except Exception as e:
+        except Exception:
             logger.error(f"Failed to delete auth state: {e}")
 
 

--- a/app/modules/sso/manager.py
+++ b/app/modules/sso/manager.py
@@ -214,7 +214,7 @@ class SSOManager:
             logger.info(f"Registered SSO provider: {name}")
             return True
 
-        except Exception:
+        except Exception as e:
             logger.error(f"Failed to register SSO provider: {e}")
             return False
 
@@ -312,7 +312,7 @@ class SSOManager:
 
             return cast("Optional[SSOProvider]", provider)
 
-        except Exception:
+        except Exception as e:
             logger.error(f"Failed to load SSO provider {name}: {e}")
             return None
 
@@ -352,7 +352,7 @@ class SSOManager:
 
             return True
 
-        except Exception:
+        except Exception as e:
             logger.error(f"Failed to disable provider: {e}")
             return False
 
@@ -366,7 +366,7 @@ class SSOManager:
 
             return True
 
-        except Exception:
+        except Exception as e:
             logger.error(f"Failed to enable provider: {e}")
             return False
 
@@ -505,7 +505,7 @@ class SSOManager:
             )
             return True
 
-        except Exception:
+        except Exception as e:
             logger.error(f"Failed to link SSO identity: {e}")
             return False
 
@@ -573,7 +573,7 @@ class SSOManager:
 
             return session_token
 
-        except Exception:
+        except Exception as e:
             logger.error(f"Failed to create SSO session: {e}")
             return None
 
@@ -606,7 +606,7 @@ class SSOManager:
             self.db.execute("DELETE FROM sso_sessions WHERE session_token = ?", (session_token,))
             return True
 
-        except Exception:
+        except Exception as e:
             logger.error(f"Failed to delete SSO session: {e}")
             return False
 
@@ -619,7 +619,7 @@ class SSOManager:
             )
             return cast("int", cursor.rowcount)
 
-        except Exception:
+        except Exception as e:
             logger.error(f"Failed to cleanup sessions: {e}")
             return 0
 
@@ -646,7 +646,7 @@ class SSOManager:
                 (state, code_verifier, provider_name, nonce),
             )
 
-        except Exception:
+        except Exception as e:
             logger.error(f"Failed to store auth state: {e}")
 
     def _get_auth_state(self, state: str) -> Optional[dict[str, Any]]:
@@ -655,7 +655,7 @@ class SSOManager:
             row = self.db.fetch_one("SELECT * FROM sso_auth_states WHERE state = ?", (state,))
             return dict(row) if row else None
 
-        except Exception:
+        except Exception as e:
             logger.error(f"Failed to get auth state: {e}")
             return None
 
@@ -664,7 +664,7 @@ class SSOManager:
         try:
             self.db.execute("DELETE FROM sso_auth_states WHERE state = ?", (state,))
 
-        except Exception:
+        except Exception as e:
             logger.error(f"Failed to delete auth state: {e}")
 
 

--- a/frontend/src/components/features/management/TenantManagement.tsx
+++ b/frontend/src/components/features/management/TenantManagement.tsx
@@ -32,7 +32,7 @@ import { usePageRefresh } from '@/hooks';
 import { TOKEN_QUOTA_MULTIPLIER } from '@/constants/quota';
 import { formatQuotaForDisplay } from '@/utils/quotaFormatter';
 
-// Tenant i18n fixes (Issue #1547)
+// Tenant i18n fixes (Issue #1500)
 // Type-safe label mappings for plan and status
 const PLAN_LABELS: Record<string, string> = {
   standard: 'tenantPlanStandard',
@@ -148,7 +148,7 @@ export const TenantManagement: React.FC = () => {
   const [formError, setFormError] = useState<string | null>(null);
   const [trialDaysError, setTrialDaysError] = useState<string | null>(null);
 
-  // Dynamic options with useMemo for performance (Issue #1547)
+  // Dynamic options with useMemo for performance (Issue #1500)
   const statusOptions = useMemo(() => getTenantStatusOptions(language), [language]);
   const planOptions = useMemo(() => getTenantPlanOptions(language), [language]);
   const modalPlanOptions = useMemo(() => getTenantPlanOptions(language, false), [language]);
@@ -285,7 +285,7 @@ export const TenantManagement: React.FC = () => {
       return;
     }
 
-    // Validate trial days (Issue #1547)
+    // Validate trial days (Issue #1501)
     if (!editingTenant && formData.trial_days !== undefined) {
       const error = validateTrialDays(formData.trial_days, language);
       if (error) {
@@ -698,7 +698,7 @@ export const TenantManagement: React.FC = () => {
                 placeholder={t('enterContactName', language)}
               />
             </div>
-            {/* Trial Days - Only for new tenants (Issue #1547) */}
+            {/* Trial Days - Only for new tenants (Issue #1501) */}
             {!editingTenant && (
               <div className="col-md-6">
                 <label className="form-label">{t('tenantTrialDays', language)}</label>

--- a/frontend/src/components/features/management/TenantManagement.tsx
+++ b/frontend/src/components/features/management/TenantManagement.tsx
@@ -32,19 +32,65 @@ import { usePageRefresh } from '@/hooks';
 import { TOKEN_QUOTA_MULTIPLIER } from '@/constants/quota';
 import { formatQuotaForDisplay } from '@/utils/quotaFormatter';
 
-const STATUS_OPTIONS = [
-  { value: '', label: 'All Statuses' },
-  { value: 'active', label: 'Active' },
-  { value: 'suspended', label: 'Suspended' },
-  { value: 'trial', label: 'Trial' },
+// Tenant i18n fixes (Issue #1547)
+// Type-safe label mappings for plan and status
+const PLAN_LABELS: Record<string, string> = {
+  standard: 'tenantPlanStandard',
+  premium: 'tenantPlanPremium',
+  enterprise: 'tenantPlanEnterprise',
+};
+
+const STATUS_LABELS: Record<string, string> = {
+  active: 'tenantStatusActive',
+  suspended: 'tenantStatusSuspended',
+  trial: 'tenantStatusTrial',
+};
+
+// Helper functions for translation with fallback
+const getPlanLabel = (plan: string, language: Language): string => {
+  const key = PLAN_LABELS[plan];
+  return key ? t(key, language) : plan;
+};
+
+const getStatusLabel = (status: string, language: Language): string => {
+  const key = STATUS_LABELS[status];
+  return key ? t(key, language) : status;
+};
+
+// Dynamic options generators
+const getTenantStatusOptions = (language: Language) => [
+  { value: '', label: t('tenantAllStatuses', language) },
+  { value: 'active', label: t('tenantStatusActive', language) },
+  { value: 'suspended', label: t('tenantStatusSuspended', language) },
+  { value: 'trial', label: t('tenantStatusTrial', language) },
 ];
 
-const PLAN_OPTIONS = [
-  { value: '', label: 'All Plans' },
-  { value: 'standard', label: 'Standard' },
-  { value: 'premium', label: 'Premium' },
-  { value: 'enterprise', label: 'Enterprise' },
-];
+const getTenantPlanOptions = (language: Language, includeAll: boolean = true) => {
+  const options = includeAll
+    ? [{ value: '', label: t('tenantAllPlans', language) }]
+    : [];
+  return [
+    ...options,
+    { value: 'standard', label: t('tenantPlanStandard', language) },
+    { value: 'premium', label: t('tenantPlanPremium', language) },
+    { value: 'enterprise', label: t('tenantPlanEnterprise', language) },
+  ];
+};
+
+// Trial days validation
+const validateTrialDays = (value: string | number | undefined, language: Language): string | null => {
+  if (value === undefined || value === null || value === '') {
+    return null; // Optional field, empty is valid
+  }
+  const num = Number(value);
+  if (!Number.isInteger(num) || num <= 0) {
+    return t('validationTrialDaysPositive', language);
+  }
+  if (num > 365) {
+    return t('validationTrialDaysMax', language);
+  }
+  return null;
+};
 
 // Tenant API error translation map (moved outside component to avoid recreation)
 const TENANT_ERROR_MAP: Record<string, string> = {
@@ -82,6 +128,7 @@ export const TenantManagement: React.FC = () => {
     plan: 'standard',
     contact_email: '',
     contact_name: '',
+    trial_days: undefined,
   });
   const [createAdminAccount, setCreateAdminAccount] = useState(false);
   const [adminFormData, setAdminFormData] = useState({
@@ -98,6 +145,12 @@ export const TenantManagement: React.FC = () => {
     max_sessions_per_user: 5,
   });
   const [formError, setFormError] = useState<string | null>(null);
+  const [trialDaysError, setTrialDaysError] = useState<string | null>(null);
+
+  // Dynamic options with useMemo for performance (Issue #1547)
+  const statusOptions = useMemo(() => getTenantStatusOptions(language), [language]);
+  const planOptions = useMemo(() => getTenantPlanOptions(language), [language]);
+  const modalPlanOptions = useMemo(() => getTenantPlanOptions(language, false), [language]);
 
   // Page refresh control - manual refresh for tenant management
   const pageRefresh = usePageRefresh({
@@ -154,12 +207,14 @@ export const TenantManagement: React.FC = () => {
   const handleOpenCreate = () => {
     setEditingTenant(null);
     setFormError(null);
+    setTrialDaysError(null);
     setFormData({
       name: '',
       slug: '',
       plan: 'standard',
       contact_email: '',
       contact_name: '',
+      trial_days: undefined,
     });
     setCreateAdminAccount(false);
     setAdminFormData({
@@ -173,6 +228,7 @@ export const TenantManagement: React.FC = () => {
   const handleOpenEdit = (tenant: Tenant) => {
     setEditingTenant(tenant);
     setFormError(null);
+    setTrialDaysError(null);
     setFormData({
       name: tenant.name,
       slug: tenant.slug,
@@ -226,6 +282,15 @@ export const TenantManagement: React.FC = () => {
     if (!formData.name.trim()) {
       setFormError(t('tenantNameRequired', language));
       return;
+    }
+
+    // Validate trial days (Issue #1547)
+    if (!editingTenant && formData.trial_days !== undefined) {
+      const error = validateTrialDays(formData.trial_days, language);
+      if (error) {
+        setTrialDaysError(error);
+        return;
+      }
     }
 
     // Validate admin account fields if creating admin
@@ -421,11 +486,11 @@ export const TenantManagement: React.FC = () => {
         <div className="row g-3">
           <div className="col-md-3">
             <label className="form-label">{t('status', language)}</label>
-            <Select options={STATUS_OPTIONS} value={statusFilter} onChange={setStatusFilter} />
+            <Select options={statusOptions} value={statusFilter} onChange={setStatusFilter} />
           </div>
           <div className="col-md-3">
             <label className="form-label">{t('plan', language)}</label>
-            <Select options={PLAN_OPTIONS} value={planFilter} onChange={setPlanFilter} />
+            <Select options={planOptions} value={planFilter} onChange={setPlanFilter} />
           </div>
         </div>
       </Card>
@@ -461,10 +526,14 @@ export const TenantManagement: React.FC = () => {
                       <code>{tenant.slug}</code>
                     </td>
                     <td>
-                      <Badge variant={getPlanVariant(tenant.plan)}>{tenant.plan}</Badge>
+                      <Badge variant={getPlanVariant(tenant.plan)}>
+                        {getPlanLabel(tenant.plan, language)}
+                      </Badge>
                     </td>
                     <td>
-                      <Badge variant={getStatusVariant(tenant.status)}>{tenant.status}</Badge>
+                      <Badge variant={getStatusVariant(tenant.status)}>
+                        {getStatusLabel(tenant.status, language)}
+                      </Badge>
                     </td>
                     <td>
                       {tenant.quota && tenant.total_tokens_used !== undefined ? (
@@ -605,11 +674,7 @@ export const TenantManagement: React.FC = () => {
             <div className="col-md-6">
               <label className="form-label">{t('plan', language)}</label>
               <Select
-                options={[
-                  { value: 'standard', label: 'Standard' },
-                  { value: 'premium', label: 'Premium' },
-                  { value: 'enterprise', label: 'Enterprise' },
-                ]}
+                options={modalPlanOptions}
                 value={formData.plan ?? 'standard'}
                 onChange={(value) =>
                   setFormData({ ...formData, plan: value as 'standard' | 'premium' | 'enterprise' })
@@ -632,6 +697,34 @@ export const TenantManagement: React.FC = () => {
                 placeholder={t('enterContactName', language)}
               />
             </div>
+            {/* Trial Days - Only for new tenants (Issue #1547) */}
+            {!editingTenant && (
+              <div className="col-md-6">
+                <label className="form-label">{t('tenantTrialDays', language)}</label>
+                <div className="input-group">
+                  <input
+                    type="number"
+                    className={`form-control ${trialDaysError ? 'is-invalid' : ''}`}
+                    min="1"
+                    max="365"
+                    placeholder="7"
+                    value={formData.trial_days ?? ''}
+                    onChange={(e) => {
+                      const value = e.target.value ? parseInt(e.target.value) : undefined;
+                      setFormData({ ...formData, trial_days: value });
+                      // Validate on change
+                      const error = validateTrialDays(value, language);
+                      setTrialDaysError(error);
+                    }}
+                  />
+                  <span className="input-group-text">{t('days', language)}</span>
+                </div>
+                <small className="text-muted">{t('tenantTrialDaysHelp', language)}</small>
+                {trialDaysError && (
+                  <div className="invalid-feedback d-block">{trialDaysError}</div>
+                )}
+              </div>
+            )}
             {/* Admin Account Creation - Only for new tenants */}
             {!editingTenant && (
               <>

--- a/frontend/src/components/features/management/TenantManagement.tsx
+++ b/frontend/src/components/features/management/TenantManagement.tsx
@@ -66,9 +66,7 @@ const getTenantStatusOptions = (language: Language) => [
 ];
 
 const getTenantPlanOptions = (language: Language, includeAll: boolean = true) => {
-  const options = includeAll
-    ? [{ value: '', label: t('tenantAllPlans', language) }]
-    : [];
+  const options = includeAll ? [{ value: '', label: t('tenantAllPlans', language) }] : [];
   return [
     ...options,
     { value: 'standard', label: t('tenantPlanStandard', language) },
@@ -78,7 +76,10 @@ const getTenantPlanOptions = (language: Language, includeAll: boolean = true) =>
 };
 
 // Trial days validation
-const validateTrialDays = (value: string | number | undefined, language: Language): string | null => {
+const validateTrialDays = (
+  value: string | number | undefined,
+  language: Language
+): string | null => {
   if (value === undefined || value === null || value === '') {
     return null; // Optional field, empty is valid
   }
@@ -720,9 +721,7 @@ export const TenantManagement: React.FC = () => {
                   <span className="input-group-text">{t('days', language)}</span>
                 </div>
                 <small className="text-muted">{t('tenantTrialDaysHelp', language)}</small>
-                {trialDaysError && (
-                  <div className="invalid-feedback d-block">{trialDaysError}</div>
-                )}
+                {trialDaysError && <div className="invalid-feedback d-block">{trialDaysError}</div>}
               </div>
             )}
             {/* Admin Account Creation - Only for new tenants */}

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -1074,6 +1074,20 @@ export const translations: Record<Language, Translations> = {
     maxSessionsPerUser: 'Max Sessions/User',
     quota: 'Quota',
 
+    // Tenant i18n fixes (Issue #1547)
+    tenantAllStatuses: 'All Statuses',
+    tenantAllPlans: 'All Plans',
+    tenantPlanStandard: 'Standard',
+    tenantPlanPremium: 'Premium',
+    tenantPlanEnterprise: 'Enterprise',
+    tenantStatusActive: 'Active',
+    tenantStatusSuspended: 'Suspended',
+    tenantStatusTrial: 'Trial',
+    tenantTrialDays: 'Trial Days',
+    tenantTrialDaysHelp: 'Number of days for trial period. Leave empty for active tenant.',
+    validationTrialDaysPositive: 'Trial days must be a positive integer',
+    validationTrialDaysMax: 'Trial days cannot exceed 365',
+
     // SSO Settings
     registeredProviders: 'Registered Providers',
     noProvidersRegistered: 'No SSO providers registered',
@@ -2592,6 +2606,20 @@ export const translations: Record<Language, Translations> = {
     maxSessionsPerUser: '每用户最大会话数',
     quota: '配额',
 
+    // Tenant i18n fixes (Issue #1547)
+    tenantAllStatuses: '所有状态',
+    tenantAllPlans: '所有计划',
+    tenantPlanStandard: '标准',
+    tenantPlanPremium: '高级',
+    tenantPlanEnterprise: '企业',
+    tenantStatusActive: '活跃',
+    tenantStatusSuspended: '已暂停',
+    tenantStatusTrial: '试用',
+    tenantTrialDays: '试用期天数',
+    tenantTrialDaysHelp: '试用期天数。留空则创建活跃租户。',
+    validationTrialDaysPositive: '试用期天数必须为正整数',
+    validationTrialDaysMax: '试用期天数不能超过365天',
+
     // SSO Settings
     registeredProviders: '已注册提供者',
     noProvidersRegistered: '暂无已注册的 SSO 提供者',
@@ -3998,6 +4026,20 @@ export const translations: Record<Language, Translations> = {
     maxUsers: '最大ユーザー数',
     maxSessionsPerUser: 'ユーザー最大セッション数',
 
+    // Tenant i18n fixes (Issue #1547)
+    tenantAllStatuses: 'すべてのステータス',
+    tenantAllPlans: 'すべてのプラン',
+    tenantPlanStandard: 'スタンダード',
+    tenantPlanPremium: 'プレミアム',
+    tenantPlanEnterprise: 'エンタープライズ',
+    tenantStatusActive: 'アクティブ',
+    tenantStatusSuspended: '停止',
+    tenantStatusTrial: 'トライアル',
+    tenantTrialDays: 'トライアル期間(日)',
+    tenantTrialDaysHelp: 'トライアル期間の日数。空の場合はアクティブテナントになります。',
+    validationTrialDaysPositive: 'トライアル期間は正の整数で入力してください',
+    validationTrialDaysMax: 'トライアル期間は365日以内で入力してください',
+
     // Insights
     insights: 'AI インサイト',
     insightsTitle: 'AI 会話インサイトレポート',
@@ -5304,6 +5346,20 @@ export const translations: Record<Language, Translations> = {
     dailyRequestLimit: '일간 요청 제한',
     maxUsers: '최대 사용자',
     maxSessionsPerUser: '사용자 최대 세션',
+
+    // Tenant i18n fixes (Issue #1547)
+    tenantAllStatuses: '모든 상태',
+    tenantAllPlans: '모든 플랜',
+    tenantPlanStandard: '스탠다드',
+    tenantPlanPremium: '프리미엄',
+    tenantPlanEnterprise: '엔터프라이즈',
+    tenantStatusActive: '활성',
+    tenantStatusSuspended: '일시 중단',
+    tenantStatusTrial: '체험',
+    tenantTrialDays: '체험 기간(일)',
+    tenantTrialDaysHelp: '체험 기간 일수. 비워두면 활성 테넌트가 생성됩니다.',
+    validationTrialDaysPositive: '체험 기간은 양의 정수여야 합니다',
+    validationTrialDaysMax: '체험 기간은 365일 이하로 입력하세요',
 
     // Insights
     insights: 'AI 인사이트',


### PR DESCRIPTION
## Changes

- Add dynamic translation for status and plan filter dropdowns
- Translate Badge display for status and plan columns
- Add trial_days field to tenant creation form with validation
- Add i18n keys: tenantAllStatuses, tenantAllPlans, tenantPlanStandard/Premium/Enterprise, tenantStatusActive/Suspended/Trial

Fixes #1500, #1501