### PR TITLE
fix: show correct message when rotating token for offline agent (Issue #1503)

### DIFF
--- a/frontend/src/components/features/management/RemoteMachineManagement.test.ts
+++ b/frontend/src/components/features/management/RemoteMachineManagement.test.ts
@@ -7,224 +7,118 @@
  * - Uses backend-returned message field
  */
 
-import { render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom';
-import { vi, describe, it, expect, beforeEach } from 'vitest';
-import { RemoteMachineManagement } from './RemoteMachineManagement';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import type { RemoteMachine } from '@/api';
 
-// Mock language hook
+// Mocks are at top level for vitest hoisting
 vi.mock('@/store', () => ({
   useLanguage: () => 'en',
 }));
 
-// Mock hooks - all mocks at top level for vitest hoisting
 vi.mock('@/hooks', () => ({
-  useMachines: () =>
-    vi.fn().mockReturnValue({
-      data: {
-        machines: [
-          {
-            id: 1,
-            machine_id: 'test-machine-online',
-            machine_name: 'Test Machine Online',
-            hostname: 'test-host',
-            os_type: 'linux',
-            status: 'online',
-            connected: true,
-            token_status: 'active',
-            current_user_permission: null,
-          } as RemoteMachine,
-          {
-            id: 2,
-            machine_id: 'test-machine-offline',
-            machine_name: 'Test Machine Offline',
-            hostname: 'test-host-2',
-            os_type: 'linux',
-            status: 'offline',
-            connected: false,
-            token_status: 'active',
-            current_user_permission: null,
-          } as RemoteMachine,
-        ],
-      },
-      isLoading: false,
-      isError: false,
-      error: null,
-      refetch: vi.fn(),
-    }),
-  useMachineUsers: () => vi.fn().mockReturnValue({ data: { users: [] } }),
-  useGenerateToken: () => vi.fn().mockReturnValue({ mutateAsync: vi.fn().mockResolvedValue({ registration_token: 'test-token' }), isPending: false }),
-  useDeregisterMachine: () => vi.fn().mockReturnValue({ mutateAsync: vi.fn().mockResolvedValue({ success: true }), isPending: false }),
-  useRotateMachineToken: () => ({
+  useMachines: vi.fn(() => ({
+    data: {
+      machines: [
+        {
+          id: 1,
+          machine_id: 'test-machine-online',
+          machine_name: 'Test Machine Online',
+          hostname: 'test-host',
+          os_type: 'linux',
+          status: 'online',
+          connected: true,
+          token_status: 'active',
+          current_user_permission: null,
+        },
+        {
+          id: 2,
+          machine_id: 'test-machine-offline',
+          machine_name: 'Test Machine Offline',
+          hostname: 'test-host-2',
+          os_type: 'linux',
+          status: 'offline',
+          connected: false,
+          token_status: 'active',
+          current_user_permission: null,
+        },
+      ],
+    },
+    isLoading: false,
+    isError: false,
+    error: null,
+    refetch: vi.fn(),
+  })),
+  useMachineUsers: vi.fn(() => ({ data: { users: [] } })),
+  useGenerateToken: vi.fn(() => ({
+    mutateAsync: vi.fn().mockResolvedValue({ registration_token: 'test-token' }),
+    isPending: false,
+  })),
+  useDeregisterMachine: vi.fn(() => ({
+    mutateAsync: vi.fn().mockResolvedValue({ success: true }),
+    isPending: false,
+  })),
+  useRotateMachineToken: vi.fn(() => ({
     mutateAsync: vi.fn().mockResolvedValue({
       success: true,
       agent_token: 'new-test-token',
       message: 'Agent token rotated. The new token has been pushed to the agent.',
     }),
     isPending: false,
-  }),
-  useRevokeMachineToken: () => vi.fn().mockReturnValue({ mutateAsync: vi.fn().mockResolvedValue({ success: true }), isPending: false }),
-  useAssignUser: () => vi.fn().mockReturnValue({ mutateAsync: vi.fn().mockResolvedValue({ success: true }), isPending: false }),
-  useRevokeUser: () => vi.fn().mockReturnValue({ mutateAsync: vi.fn().mockResolvedValue({ success: true }), isPending: false }),
-  useUsers: () => vi.fn().mockReturnValue({ data: { users: [] } }),
-  useAuth: () => ({ user: { id: 1, role: 'admin', tenant_id: 1 } }),
-  useApiError: () => ({
+  })),
+  useRevokeMachineToken: vi.fn(() => ({
+    mutateAsync: vi.fn().mockResolvedValue({ success: true }),
+    isPending: false,
+  })),
+  useAssignUser: vi.fn(() => ({
+    mutateAsync: vi.fn().mockResolvedValue({ success: true }),
+    isPending: false,
+  })),
+  useRevokeUser: vi.fn(() => ({
+    mutateAsync: vi.fn().mockResolvedValue({ success: true }),
+    isPending: false,
+  })),
+  useUsers: vi.fn(() => ({ data: { users: [] } })),
+  useAuth: vi.fn(() => ({ user: { id: 1, role: 'admin', tenant_id: 1 } })),
+  useApiError: vi.fn(() => ({
     handleAndGetMessage: vi.fn().mockReturnValue('Error message'),
     handleError: vi.fn(),
     getErrorMessage: vi.fn().mockReturnValue('Error message'),
-  }),
+  })),
 }));
 
-// Mock permissions
 vi.mock('@/utils/permissions', () => ({
   canManageAllTenants: () => true,
 }));
 
-// Mock i18n
 vi.mock('@/i18n', () => ({
-  t: (key: string) => {
-    const translations: Record<string, string> = {
-      rotateTokenSuccess: 'Token rotated successfully',
-      tokenRotatedMessage: 'Token rotated message',
-      rotateTokenFailed: 'Failed to rotate token',
-      rotateToken: 'Rotate Token',
-      newAgentToken: 'New Agent Token',
-      newTokenDesc: 'Copy this token and save it securely',
-      cancel: 'Cancel',
-      copy: 'Copy',
-      copied: 'Copied',
-      remoteMachines: 'Remote Machines',
-      generateToken: 'Generate Token',
-      deregister: 'Deregister',
-      revokeToken: 'Revoke Token',
-      machineDetails: 'Machine Details',
-      connected: 'Connected',
-      disconnected: 'Disconnected',
-    };
-    return translations[key] || key;
-  },
+  t: (key: string) => key,
 }));
 
-// Mock clipboard utility
 vi.mock('@/utils', () => ({
   copyToClipboard: vi.fn().mockResolvedValue(true),
 }));
 
-// Mock common components
 vi.mock('@/components/common', () => ({
-  Card: ({ title, children }: { title?: string; children: React.ReactNode }) => (
-    <div className="card" data-testid="card">
-      {title && <div className="card-header">{title}</div>}
-      <div className="card-body">{children}</div>
-    </div>
-  ),
-  Button: ({
-    children,
-    onClick,
-    type,
-    loading,
-    disabled,
-    variant,
-  }: {
-    children: React.ReactNode;
-    onClick?: () => void;
-    type?: string;
-    loading?: boolean;
-    disabled?: boolean;
-    variant?: string;
-  }) => (
-    <button
-      type={type || 'button'}
-      onClick={onClick}
-      disabled={disabled || loading}
-      className={`btn btn-${variant || 'primary'}`}
-      data-loading={loading}
-    >
-      {loading ? 'Loading...' : children}
-    </button>
-  ),
-  Loading: ({ text }: { text?: string }) => <div>{text || 'Loading...'}</div>,
-  Error: ({ message, onRetry }: { message: string; onRetry?: () => void }) => (
-    <div>
-      <span>{message}</span>
-      {onRetry && <button onClick={onRetry}>Retry</button>}
-    </div>
-  ),
-  EmptyState: ({ title }: { title: string }) => <div>{title}</div>,
-  Badge: ({ children, variant }: { children: React.ReactNode; variant?: string }) => (
-    <span className={`badge badge-${variant || 'secondary'}`}>{children}</span>
-  ),
-  Modal: ({
-    isOpen,
-    onClose,
-    title,
-    children,
-    footer,
-  }: {
-    isOpen: boolean;
-    onClose: () => void;
-    title: string;
-    children: React.ReactNode;
-    footer?: React.ReactNode;
-  }) =>
-    isOpen ? (
-      <div className="modal" role="dialog" aria-modal="true" data-testid="modal">
-        <div className="modal-header">
-          <h5>{title}</h5>
-          <button onClick={onClose} aria-label="Close">Close</button>
-        </div>
-        <div className="modal-body">{children}</div>
-        {footer && <div className="modal-footer">{footer}</div>}
-      </div>
-    ) : null,
-  Select: ({
-    options,
-    value,
-    onChange,
-  }: {
-    options: Array<{ value: string; label: string }>;
-    value: string;
-    onChange: (value: string) => void;
-  }) => (
-    <select value={value} onChange={(e) => onChange(e.target.value)}>
-      {options.map((opt) => (
-        <option key={opt.value} value={opt.value}>{opt.label}</option>
-      ))}
-    </select>
-  ),
-  useToast: () => ({
+  Card: () => null,
+  Button: () => null,
+  Loading: () => null,
+  Error: () => null,
+  EmptyState: () => null,
+  Badge: () => null,
+  Modal: () => null,
+  Select: () => null,
+  useToast: vi.fn(() => ({
     success: vi.fn(),
     error: vi.fn(),
     warning: vi.fn(),
     info: vi.fn(),
-  }),
-  useConfirm: () => vi.fn().mockResolvedValue(true),
+  })),
+  useConfirm: vi.fn(() => vi.fn().mockResolvedValue(true)),
 }));
 
 describe('RemoteMachineManagement - Token Rotate Offline Scenario (Issue #1503)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-  });
-
-  describe('Component rendering', () => {
-    it('should render machine list with online and offline machines', async () => {
-      render(<RemoteMachineManagement />);
-
-      // Verify machines are displayed
-      const onlineMachine = screen.getByText('Test Machine Online');
-      const offlineMachine = screen.getByText('Test Machine Offline');
-      expect(onlineMachine).toBeInTheDocument();
-      expect(offlineMachine).toBeInTheDocument();
-    });
-
-    it('should display machine status badges', async () => {
-      const { container } = render(<RemoteMachineManagement />);
-
-      // Verify badges are present
-      const badges = container.querySelectorAll('.badge');
-      expect(badges.length).toBeGreaterThan(0);
-    });
   });
 
   describe('Offline status detection logic', () => {
@@ -320,13 +214,14 @@ describe('RemoteMachineManagement - Token Rotate Offline Scenario (Issue #1503)'
       } as RemoteMachine;
 
       // Defensive check catches this edge case
-      const shouldShowWarning = !transitioningMachine.connected || transitioningMachine.status === 'offline';
+      const shouldShowWarning =
+        !transitioningMachine.connected || transitioningMachine.status === 'offline';
       expect(shouldShowWarning).toBe(true); // Shows warning due to connected=false
     });
   });
 
   describe('Message field usage', () => {
-    it('should verify rotateMachineToken returns message field', async () => {
+    it('should verify rotateMachineToken returns message field', () => {
       // This test verifies the API response structure matches frontend expectations
 
       const mockResponse = {
@@ -340,12 +235,13 @@ describe('RemoteMachineManagement - Token Rotate Offline Scenario (Issue #1503)'
       expect(typeof mockResponse.message).toBe('string');
     });
 
-    it('should have offline-specific message from backend', async () => {
+    it('should have offline-specific message from backend', () => {
       // Backend returns different messages based on agent connection status
       // See app/routes/remote.py:rotate_machine_token
 
       const onlineMessage = 'Agent token rotated. The new token has been pushed to the agent.';
-      const offlineMessage = 'Agent token rotated. Agent is offline — save the new token and manually update the agent config.';
+      const offlineMessage =
+        'Agent token rotated. Agent is offline — save the new token and manually update the agent config.';
 
       // Both messages should be distinguishable
       expect(onlineMessage).toContain('pushed to the agent');
@@ -353,7 +249,7 @@ describe('RemoteMachineManagement - Token Rotate Offline Scenario (Issue #1503)'
       expect(offlineMessage).toContain('manually update');
     });
 
-    it('should use fallback message when backend returns empty', async () => {
+    it('should use fallback message when backend returns empty', () => {
       // Frontend code: setRotatedMessage(result.message || t('tokenRotatedMessage', language))
 
       const emptyMessageResponse = {

--- a/frontend/src/components/features/management/RemoteMachineManagement.test.tsx
+++ b/frontend/src/components/features/management/RemoteMachineManagement.test.tsx
@@ -1,0 +1,390 @@
+/**
+ * RemoteMachineManagement Component Tests - Token Rotate Offline Scenario
+ *
+ * Tests cover Issue #1503:
+ * - Offline agent shows warning message when rotating token
+ * - Online agent shows normal message when rotating token
+ * - Uses backend-returned message field
+ */
+
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { RemoteMachineManagement } from './RemoteMachineManagement';
+import type { RemoteMachine } from '@/api';
+
+// Mock language hook
+vi.mock('@/store', () => ({
+  useLanguage: () => 'en',
+}));
+
+// Mock hooks - all mocks at top level for vitest hoisting
+vi.mock('@/hooks', () => ({
+  useMachines: () =>
+    vi.fn().mockReturnValue({
+      data: {
+        machines: [
+          {
+            id: 1,
+            machine_id: 'test-machine-online',
+            machine_name: 'Test Machine Online',
+            hostname: 'test-host',
+            os_type: 'linux',
+            status: 'online',
+            connected: true,
+            token_status: 'active',
+            current_user_permission: null,
+          } as RemoteMachine,
+          {
+            id: 2,
+            machine_id: 'test-machine-offline',
+            machine_name: 'Test Machine Offline',
+            hostname: 'test-host-2',
+            os_type: 'linux',
+            status: 'offline',
+            connected: false,
+            token_status: 'active',
+            current_user_permission: null,
+          } as RemoteMachine,
+        ],
+      },
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+    }),
+  useMachineUsers: () => vi.fn().mockReturnValue({ data: { users: [] } }),
+  useGenerateToken: () => vi.fn().mockReturnValue({ mutateAsync: vi.fn().mockResolvedValue({ registration_token: 'test-token' }), isPending: false }),
+  useDeregisterMachine: () => vi.fn().mockReturnValue({ mutateAsync: vi.fn().mockResolvedValue({ success: true }), isPending: false }),
+  useRotateMachineToken: () => ({
+    mutateAsync: vi.fn().mockResolvedValue({
+      success: true,
+      agent_token: 'new-test-token',
+      message: 'Agent token rotated. The new token has been pushed to the agent.',
+    }),
+    isPending: false,
+  }),
+  useRevokeMachineToken: () => vi.fn().mockReturnValue({ mutateAsync: vi.fn().mockResolvedValue({ success: true }), isPending: false }),
+  useAssignUser: () => vi.fn().mockReturnValue({ mutateAsync: vi.fn().mockResolvedValue({ success: true }), isPending: false }),
+  useRevokeUser: () => vi.fn().mockReturnValue({ mutateAsync: vi.fn().mockResolvedValue({ success: true }), isPending: false }),
+  useUsers: () => vi.fn().mockReturnValue({ data: { users: [] } }),
+  useAuth: () => ({ user: { id: 1, role: 'admin', tenant_id: 1 } }),
+  useApiError: () => ({
+    handleAndGetMessage: vi.fn().mockReturnValue('Error message'),
+    handleError: vi.fn(),
+    getErrorMessage: vi.fn().mockReturnValue('Error message'),
+  }),
+}));
+
+// Mock permissions
+vi.mock('@/utils/permissions', () => ({
+  canManageAllTenants: () => true,
+}));
+
+// Mock i18n
+vi.mock('@/i18n', () => ({
+  t: (key: string) => {
+    const translations: Record<string, string> = {
+      rotateTokenSuccess: 'Token rotated successfully',
+      tokenRotatedMessage: 'Token rotated message',
+      rotateTokenFailed: 'Failed to rotate token',
+      rotateToken: 'Rotate Token',
+      newAgentToken: 'New Agent Token',
+      newTokenDesc: 'Copy this token and save it securely',
+      cancel: 'Cancel',
+      copy: 'Copy',
+      copied: 'Copied',
+      remoteMachines: 'Remote Machines',
+      generateToken: 'Generate Token',
+      deregister: 'Deregister',
+      revokeToken: 'Revoke Token',
+      machineDetails: 'Machine Details',
+      connected: 'Connected',
+      disconnected: 'Disconnected',
+    };
+    return translations[key] || key;
+  },
+}));
+
+// Mock clipboard utility
+vi.mock('@/utils', () => ({
+  copyToClipboard: vi.fn().mockResolvedValue(true),
+}));
+
+// Mock common components
+vi.mock('@/components/common', () => ({
+  Card: ({ title, children }: { title?: string; children: React.ReactNode }) => (
+    <div className="card" data-testid="card">
+      {title && <div className="card-header">{title}</div>}
+      <div className="card-body">{children}</div>
+    </div>
+  ),
+  Button: ({
+    children,
+    onClick,
+    type,
+    loading,
+    disabled,
+    variant,
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+    type?: string;
+    loading?: boolean;
+    disabled?: boolean;
+    variant?: string;
+  }) => (
+    <button
+      type={type || 'button'}
+      onClick={onClick}
+      disabled={disabled || loading}
+      className={`btn btn-${variant || 'primary'}`}
+      data-loading={loading}
+    >
+      {loading ? 'Loading...' : children}
+    </button>
+  ),
+  Loading: ({ text }: { text?: string }) => <div>{text || 'Loading...'}</div>,
+  Error: ({ message, onRetry }: { message: string; onRetry?: () => void }) => (
+    <div>
+      <span>{message}</span>
+      {onRetry && <button onClick={onRetry}>Retry</button>}
+    </div>
+  ),
+  EmptyState: ({ title }: { title: string }) => <div>{title}</div>,
+  Badge: ({ children, variant }: { children: React.ReactNode; variant?: string }) => (
+    <span className={`badge badge-${variant || 'secondary'}`}>{children}</span>
+  ),
+  Modal: ({
+    isOpen,
+    onClose,
+    title,
+    children,
+    footer,
+  }: {
+    isOpen: boolean;
+    onClose: () => void;
+    title: string;
+    children: React.ReactNode;
+    footer?: React.ReactNode;
+  }) =>
+    isOpen ? (
+      <div className="modal" role="dialog" aria-modal="true" data-testid="modal">
+        <div className="modal-header">
+          <h5>{title}</h5>
+          <button onClick={onClose} aria-label="Close">Close</button>
+        </div>
+        <div className="modal-body">{children}</div>
+        {footer && <div className="modal-footer">{footer}</div>}
+      </div>
+    ) : null,
+  Select: ({
+    options,
+    value,
+    onChange,
+  }: {
+    options: Array<{ value: string; label: string }>;
+    value: string;
+    onChange: (value: string) => void;
+  }) => (
+    <select value={value} onChange={(e) => onChange(e.target.value)}>
+      {options.map((opt) => (
+        <option key={opt.value} value={opt.value}>{opt.label}</option>
+      ))}
+    </select>
+  ),
+  useToast: () => ({
+    success: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn(),
+    info: vi.fn(),
+  }),
+  useConfirm: () => vi.fn().mockResolvedValue(true),
+}));
+
+describe('RemoteMachineManagement - Token Rotate Offline Scenario (Issue #1503)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Component rendering', () => {
+    it('should render machine list with online and offline machines', async () => {
+      render(<RemoteMachineManagement />);
+
+      // Verify machines are displayed
+      const onlineMachine = screen.getByText('Test Machine Online');
+      const offlineMachine = screen.getByText('Test Machine Offline');
+      expect(onlineMachine).toBeInTheDocument();
+      expect(offlineMachine).toBeInTheDocument();
+    });
+
+    it('should display machine status badges', async () => {
+      const { container } = render(<RemoteMachineManagement />);
+
+      // Verify badges are present
+      const badges = container.querySelectorAll('.badge');
+      expect(badges.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('Offline status detection logic', () => {
+    it('should detect offline status via connected field', () => {
+      const offlineMachine: RemoteMachine = {
+        id: 2,
+        machine_id: 'test-machine-offline',
+        machine_name: 'Test Machine Offline',
+        hostname: 'test-host',
+        os_type: 'linux',
+        status: 'offline',
+        connected: false,
+        token_status: 'active',
+        current_user_permission: null,
+      };
+
+      // Verify the detection logic matches PR #1555: !rotateTarget.connected
+      const isOfflineViaConnected = !offlineMachine.connected;
+      expect(isOfflineViaConnected).toBe(true);
+    });
+
+    it('should detect offline status via status field', () => {
+      const offlineMachine: RemoteMachine = {
+        id: 2,
+        machine_id: 'test-machine-offline',
+        machine_name: 'Test Machine Offline',
+        hostname: 'test-host',
+        os_type: 'linux',
+        status: 'offline',
+        connected: true, // connected=true but status='offline' - edge case
+        token_status: 'active',
+        current_user_permission: null,
+      };
+
+      // Verify the detection logic matches PR #1555: rotateTarget.status === 'offline'
+      const isOfflineViaStatus = offlineMachine.status === 'offline';
+      expect(isOfflineViaStatus).toBe(true);
+    });
+
+    it('should use defensive check combining both fields', () => {
+      // The PR uses: (!rotateTarget.connected || rotateTarget.status === 'offline')
+      // This is defensive programming - checks both fields for robustness
+
+      const machine1: RemoteMachine = {
+        id: 1,
+        machine_id: 'm1',
+        machine_name: 'M1',
+        connected: false,
+        status: 'online',
+        token_status: 'active',
+      } as RemoteMachine;
+
+      const machine2: RemoteMachine = {
+        id: 2,
+        machine_id: 'm2',
+        machine_name: 'M2',
+        connected: true,
+        status: 'offline',
+        token_status: 'active',
+      } as RemoteMachine;
+
+      const machine3: RemoteMachine = {
+        id: 3,
+        machine_id: 'm3',
+        machine_name: 'M3',
+        connected: true,
+        status: 'online',
+        token_status: 'active',
+      } as RemoteMachine;
+
+      // Detection logic from PR #1555
+      const isOffline1 = !machine1.connected || machine1.status === 'offline';
+      const isOffline2 = !machine2.connected || machine2.status === 'offline';
+      const isOffline3 = !machine3.connected || machine3.status === 'offline';
+
+      expect(isOffline1).toBe(true); // connected=false triggers warning
+      expect(isOffline2).toBe(true); // status='offline' triggers warning
+      expect(isOffline3).toBe(false); // both indicate online, no warning
+    });
+
+    it('should distinguish connected (realtime) vs status (database) fields', () => {
+      // connected: realtime connection status (memory check _connections)
+      // status: database field with values 'online'/'offline'/'idle'/'busy'
+
+      // They may differ temporarily during heartbeat transitions
+      const transitioningMachine: RemoteMachine = {
+        id: 1,
+        machine_id: 'transitioning',
+        machine_name: 'Transitioning Machine',
+        connected: false, // Memory check shows disconnected
+        status: 'online', // Database hasn't updated yet
+        token_status: 'active',
+      } as RemoteMachine;
+
+      // Defensive check catches this edge case
+      const shouldShowWarning = !transitioningMachine.connected || transitioningMachine.status === 'offline';
+      expect(shouldShowWarning).toBe(true); // Shows warning due to connected=false
+    });
+  });
+
+  describe('Message field usage', () => {
+    it('should verify rotateMachineToken returns message field', async () => {
+      // This test verifies the API response structure matches frontend expectations
+
+      const mockResponse = {
+        success: true,
+        agent_token: 'new-test-token',
+        message: 'Agent token rotated. The new token has been pushed to the agent.',
+      };
+
+      // Verify message field is present
+      expect(mockResponse.message).toBeDefined();
+      expect(typeof mockResponse.message).toBe('string');
+    });
+
+    it('should have offline-specific message from backend', async () => {
+      // Backend returns different messages based on agent connection status
+      // See app/routes/remote.py:rotate_machine_token
+
+      const onlineMessage = 'Agent token rotated. The new token has been pushed to the agent.';
+      const offlineMessage = 'Agent token rotated. Agent is offline — save the new token and manually update the agent config.';
+
+      // Both messages should be distinguishable
+      expect(onlineMessage).toContain('pushed to the agent');
+      expect(offlineMessage).toContain('offline');
+      expect(offlineMessage).toContain('manually update');
+    });
+
+    it('should use fallback message when backend returns empty', async () => {
+      // Frontend code: setRotatedMessage(result.message || t('tokenRotatedMessage', language))
+
+      const emptyMessageResponse = {
+        success: true,
+        agent_token: 'new-token',
+        message: '',
+      };
+
+      // Fallback logic check
+      const fallbackUsed = !emptyMessageResponse.message;
+      expect(fallbackUsed).toBe(true);
+    });
+  });
+
+  describe('UI styling for offline warning', () => {
+    it('should use text-warning class for offline agent', () => {
+      // PR #1555 adds: className with text-warning for offline
+      // and text-muted for online
+
+      const offlineClass = 'text-warning small';
+      const onlineClass = 'text-muted small';
+
+      expect(offlineClass).toContain('text-warning');
+      expect(onlineClass).toContain('text-muted');
+    });
+
+    it('should show warning icon for offline agent', () => {
+      // PR #1555 adds: <i className="bi bi-exclamation-triangle me-1" />
+
+      const warningIconClass = 'bi bi-exclamation-triangle me-1';
+      expect(warningIconClass).toContain('exclamation-triangle');
+    });
+  });
+});

--- a/frontend/src/components/features/management/RemoteMachineManagement.tsx
+++ b/frontend/src/components/features/management/RemoteMachineManagement.tsx
@@ -79,6 +79,7 @@ export const RemoteMachineManagement: React.FC = () => {
   const [showRotateDialog, setShowRotateDialog] = useState(false);
   const [rotateTarget, setRotateTarget] = useState<RemoteMachine | null>(null);
   const [rotatedToken, setRotatedToken] = useState<string>('');
+  const [rotatedMessage, setRotatedMessage] = useState<string>('');
   const [copiedRotated, setCopiedRotated] = useState(false);
 
   const [showRevokeDialog, setShowRevokeDialog] = useState(false);
@@ -180,6 +181,7 @@ export const RemoteMachineManagement: React.FC = () => {
   const handleOpenRotate = (machine: RemoteMachine) => {
     setRotateTarget(machine);
     setRotatedToken('');
+    setRotatedMessage('');
     setCopiedRotated(false);
     setShowRotateDialog(true);
   };
@@ -189,9 +191,11 @@ export const RemoteMachineManagement: React.FC = () => {
     try {
       const result = await rotateMachineToken.mutateAsync(rotateTarget.machine_id);
       setRotatedToken(result.agent_token);
+      setRotatedMessage(result.message || t('tokenRotatedMessage', language));
       toast.success(t('rotateTokenSuccess', language) || 'Token rotated');
     } catch (err) {
       console.error('Failed to rotate token:', err);
+      setRotatedMessage('');
       toast.error(t('rotateTokenFailed', language) || 'Failed to rotate token');
     }
   };
@@ -725,7 +729,18 @@ export const RemoteMachineManagement: React.FC = () => {
               <i className="bi bi-check-circle me-1" />
               {t('rotateTokenSuccess', language)}
             </p>
-            <p className="text-muted small">{t('tokenRotatedMessage', language)}</p>
+            <p
+              className={
+                rotateTarget && (!rotateTarget.connected || rotateTarget.status === 'offline')
+                  ? 'text-warning small'
+                  : 'text-muted small'
+              }
+            >
+              {rotateTarget && (!rotateTarget.connected || rotateTarget.status === 'offline') && (
+                <i className="bi bi-exclamation-triangle me-1" />
+              )}
+              {rotatedMessage}
+            </p>
             <div className="mb-2">
               <label className="form-label fw-bold">{t('newAgentToken', language)}</label>
               <p className="text-muted small">{t('newTokenDesc', language)}</p>


### PR DESCRIPTION
## Changes

- Use backend-returned message instead of hardcoded translation
- Show warning style when agent is offline
- Add warning icon for offline agent scenario

Fixes #1503