### PR TITLE
fix(retention): correct SQL field names in anonymize method (Issue #1491)

### DIFF
--- a/app/modules/compliance/retention.py
+++ b/app/modules/compliance/retention.py
@@ -347,8 +347,8 @@ class DataRetentionManager:
                     adapt_sql(
                         f"""
                     UPDATE daily_messages
-                    SET sender = 'ANONYMIZED',
-                        recipient = 'ANONYMIZED'
+                    SET sender_id = 'ANONYMIZED',
+                        sender_name = 'ANONYMIZED'
                     WHERE {time_col} < ?
                 """
                     ),

--- a/tests/unit/test_retention.py
+++ b/tests/unit/test_retention.py
@@ -261,6 +261,47 @@ class TestPostgresPlaceholderAdaptation:
         assert "%s" in delete_sqls[0]
         assert "?" not in delete_sqls[0]
 
+    def test_anonymize_old_data_adapts_placeholders_for_postgres(self, monkeypatch):
+        """Anonymize UPDATE must use %s (not ?) under PostgreSQL (issue #1491)."""
+        monkeypatch.setattr(db_mod, "is_postgresql", lambda: True)
+
+        manager, mock_db, captured = self._make_manager_with_spy()
+        mock_db.fetch_one.return_value = {"count": 5}  # Mock COUNT(*) result
+
+        manager._anonymize_old_data("messages", datetime(2020, 1, 1), dry_run=False)
+
+        update_sqls = [
+            q for q in captured if "UPDATE" in q.upper() and "daily_messages" in q.lower()
+        ]
+        assert len(update_sqls) == 1
+
+        # Verify WHERE clause uses %s placeholder (not ?)
+        sql = update_sqls[0]
+        assert "WHERE" in sql.upper()
+        assert "%s" in sql  # PostgreSQL placeholder
+        assert "?" not in sql  # SQLite placeholder should not appear
+
+    def test_anonymize_old_data_uses_correct_field_names(self, monkeypatch):
+        """Anonymize UPDATE must use sender_id/sender_name (not sender/recipient)."""
+        monkeypatch.setattr(db_mod, "is_postgresql", lambda: False)
+
+        manager, mock_db, captured = self._make_manager_with_spy()
+        mock_db.fetch_one.return_value = {"count": 5}
+
+        manager._anonymize_old_data("messages", datetime(2020, 1, 1), dry_run=False)
+
+        update_sqls = [
+            q for q in captured if "UPDATE" in q.upper() and "daily_messages" in q.lower()
+        ]
+        assert len(update_sqls) == 1
+
+        # Verify correct field names
+        sql = update_sqls[0]
+        assert "sender_id" in sql.lower()
+        assert "sender_name" in sql.lower()
+        assert "sender" not in sql.lower().replace("sender_id", "").replace("sender_name", "")
+        assert "recipient" not in sql.lower()
+
     def test_run_cleanup_surfaces_save_report_failure(self, monkeypatch):
         """A _save_report failure must surface into report.errors, not be silent.
 


### PR DESCRIPTION
## 修复说明

关联 Issue：#1491

## 根因

`_anonymize_old_data()` 方法使用了不存在的字段名 `sender` 和 `recipient`。
`daily_messages` 表的实际字段为 `sender_id` 和 `sender_name`。

## 修复方案

- 将 `SET sender = 'ANONYMIZED'` 改为 `SET sender_id = 'ANONYMIZED'`
- 将 `SET recipient = 'ANONYMIZED'` 改为 `SET sender_name = 'ANONYMIZED'`

## 主要变更

- `app/modules/compliance/retention.py`：修复 SQL 字段名
- `tests/unit/test_retention.py`：添加 PostgreSQL placeholder 测试和字段名测试

## 测试

- 测试执行主机：本地 + node237（PostgreSQL 环境）
- 已运行的测试：`pytest tests/unit/test_retention.py` - 14 passed
- 新增测试：
  - `test_anonymize_old_data_adapts_placeholders_for_postgres`
  - `test_anonymize_old_data_uses_correct_field_names`
- 测试结果：全部通过

## 验证

- node237 代码已同步，服务已重启
- grep 验证字段名正确：`SET sender_id = 'ANONYMIZED', sender_name = 'ANONYMIZED'`

## 风险

- 兼容性风险：无，字段名修复与 schema 一致
- 性能风险：无，仅修改字段名，不影响查询性能
- 安全风险：无，匿名化逻辑不变
- 回归风险：低，已有单元测试覆盖