### PR TITLE
feat(i18n): fix tenant management page internationalization (Issue #1500)

### DIFF
--- a/frontend/src/components/features/management/TenantManagement.tsx
+++ b/frontend/src/components/features/management/TenantManagement.tsx
@@ -32,19 +32,48 @@ import { usePageRefresh } from '@/hooks';
 import { TOKEN_QUOTA_MULTIPLIER } from '@/constants/quota';
 import { formatQuotaForDisplay } from '@/utils/quotaFormatter';
 
-const STATUS_OPTIONS = [
-  { value: '', label: 'All Statuses' },
-  { value: 'active', label: 'Active' },
-  { value: 'suspended', label: 'Suspended' },
-  { value: 'trial', label: 'Trial' },
+// Tenant i18n fixes (Issue #1500)
+// Type-safe label mappings for plan and status
+const PLAN_LABELS: Record<string, string> = {
+  standard: 'tenantPlanStandard',
+  premium: 'tenantPlanPremium',
+  enterprise: 'tenantPlanEnterprise',
+};
+
+const STATUS_LABELS: Record<string, string> = {
+  active: 'tenantStatusActive',
+  suspended: 'tenantStatusSuspended',
+  trial: 'tenantStatusTrial',
+};
+
+// Helper functions for translation with fallback
+const getPlanLabel = (plan: string, language: Language): string => {
+  const key = PLAN_LABELS[plan];
+  return key ? t(key, language) : plan;
+};
+
+const getStatusLabel = (status: string, language: Language): string => {
+  const key = STATUS_LABELS[status];
+  return key ? t(key, language) : status;
+};
+
+// Dynamic options generators
+const getTenantStatusOptions = (language: Language) => [
+  { value: '', label: t('tenantAllStatuses', language) },
+  { value: 'active', label: t('tenantStatusActive', language) },
+  { value: 'suspended', label: t('tenantStatusSuspended', language) },
+  { value: 'trial', label: t('tenantStatusTrial', language) },
 ];
 
-const PLAN_OPTIONS = [
-  { value: '', label: 'All Plans' },
-  { value: 'standard', label: 'Standard' },
-  { value: 'premium', label: 'Premium' },
-  { value: 'enterprise', label: 'Enterprise' },
-];
+const getTenantPlanOptions = (language: Language, includeAll: boolean = true) => {
+  const options = includeAll ? [{ value: '', label: t('tenantAllPlans', language) }] : [];
+  return [
+    ...options,
+    { value: 'standard', label: t('tenantPlanStandard', language) },
+    { value: 'premium', label: t('tenantPlanPremium', language) },
+    { value: 'enterprise', label: t('tenantPlanEnterprise', language) },
+  ];
+};
 
 // Tenant API error translation map (moved outside component to avoid recreation)
 const TENANT_ERROR_MAP: Record<string, string> = {
@@ -98,6 +127,11 @@ export const TenantManagement: React.FC = () => {
     max_sessions_per_user: 5,
   });
   const [formError, setFormError] = useState<string | null>(null);
+
+  // Dynamic options with useMemo for performance (Issue #1500)
+  const statusOptions = useMemo(() => getTenantStatusOptions(language), [language]);
+  const planOptions = useMemo(() => getTenantPlanOptions(language), [language]);
+  const modalPlanOptions = useMemo(() => getTenantPlanOptions(language, false), [language]);
 
   // Page refresh control - manual refresh for tenant management
   const pageRefresh = usePageRefresh({
@@ -421,11 +455,11 @@ export const TenantManagement: React.FC = () => {
         <div className="row g-3">
           <div className="col-md-3">
             <label className="form-label">{t('status', language)}</label>
-            <Select options={STATUS_OPTIONS} value={statusFilter} onChange={setStatusFilter} />
+            <Select options={statusOptions} value={statusFilter} onChange={setStatusFilter} />
           </div>
           <div className="col-md-3">
             <label className="form-label">{t('plan', language)}</label>
-            <Select options={PLAN_OPTIONS} value={planFilter} onChange={setPlanFilter} />
+            <Select options={planOptions} value={planFilter} onChange={setPlanFilter} />
           </div>
         </div>
       </Card>
@@ -461,10 +495,14 @@ export const TenantManagement: React.FC = () => {
                       <code>{tenant.slug}</code>
                     </td>
                     <td>
-                      <Badge variant={getPlanVariant(tenant.plan)}>{tenant.plan}</Badge>
+                      <Badge variant={getPlanVariant(tenant.plan)}>
+                        {getPlanLabel(tenant.plan, language)}
+                      </Badge>
                     </td>
                     <td>
-                      <Badge variant={getStatusVariant(tenant.status)}>{tenant.status}</Badge>
+                      <Badge variant={getStatusVariant(tenant.status)}>
+                        {getStatusLabel(tenant.status, language)}
+                      </Badge>
                     </td>
                     <td>
                       {tenant.quota && tenant.total_tokens_used !== undefined ? (
@@ -605,11 +643,7 @@ export const TenantManagement: React.FC = () => {
             <div className="col-md-6">
               <label className="form-label">{t('plan', language)}</label>
               <Select
-                options={[
-                  { value: 'standard', label: 'Standard' },
-                  { value: 'premium', label: 'Premium' },
-                  { value: 'enterprise', label: 'Enterprise' },
-                ]}
+                options={modalPlanOptions}
                 value={formData.plan ?? 'standard'}
                 onChange={(value) =>
                   setFormData({ ...formData, plan: value as 'standard' | 'premium' | 'enterprise' })

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -1076,6 +1076,16 @@ export const translations: Record<Language, Translations> = {
     maxSessionsPerUser: 'Max Sessions/User',
     quota: 'Quota',
 
+    // Tenant i18n fixes (Issue #1500)
+    tenantAllStatuses: 'All Statuses',
+    tenantAllPlans: 'All Plans',
+    tenantPlanStandard: 'Standard',
+    tenantPlanPremium: 'Premium',
+    tenantPlanEnterprise: 'Enterprise',
+    tenantStatusActive: 'Active',
+    tenantStatusSuspended: 'Suspended',
+    tenantStatusTrial: 'Trial',
+
     // SSO Settings
     registeredProviders: 'Registered Providers',
     noProvidersRegistered: 'No SSO providers registered',
@@ -2596,6 +2606,16 @@ export const translations: Record<Language, Translations> = {
     maxSessionsPerUser: '每用户最大会话数',
     quota: '配额',
 
+    // Tenant i18n fixes (Issue #1500)
+    tenantAllStatuses: '全部状态',
+    tenantAllPlans: '全部套餐',
+    tenantPlanStandard: '标准版',
+    tenantPlanPremium: '高级版',
+    tenantPlanEnterprise: '企业版',
+    tenantStatusActive: '活跃',
+    tenantStatusSuspended: '已暂停',
+    tenantStatusTrial: '试用',
+
     // SSO Settings
     registeredProviders: '已注册提供者',
     noProvidersRegistered: '暂无已注册的 SSO 提供者',
@@ -4004,6 +4024,16 @@ export const translations: Record<Language, Translations> = {
     maxUsers: '最大ユーザー数',
     maxSessionsPerUser: 'ユーザー最大セッション数',
 
+    // Tenant i18n fixes (Issue #1500)
+    tenantAllStatuses: 'すべての状態',
+    tenantAllPlans: 'すべてのプラン',
+    tenantPlanStandard: 'スタンダード',
+    tenantPlanPremium: 'プレミアム',
+    tenantPlanEnterprise: 'エンタープライズ',
+    tenantStatusActive: 'アクティブ',
+    tenantStatusSuspended: '一時停止',
+    tenantStatusTrial: '試用',
+
     // Insights
     insights: 'AI インサイト',
     insightsTitle: 'AI 会話インサイトレポート',
@@ -5312,6 +5342,16 @@ export const translations: Record<Language, Translations> = {
     dailyRequestLimit: '일간 요청 제한',
     maxUsers: '최대 사용자',
     maxSessionsPerUser: '사용자 최대 세션',
+
+    // Tenant i18n fixes (Issue #1500)
+    tenantAllStatuses: '모든 상태',
+    tenantAllPlans: '모든 플랜',
+    tenantPlanStandard: '스탠다드',
+    tenantPlanPremium: '프리미엄',
+    tenantPlanEnterprise: '엔터프라이즈',
+    tenantStatusActive: '활성',
+    tenantStatusSuspended: '일시 중단',
+    tenantStatusTrial: '체험',
 
     // Insights
     insights: 'AI 인사이트',


### PR DESCRIPTION
## Issue #1500: 租户管理页面国际化问题修复

### 问题描述
租户管理页面的下拉选择和Badge显示缺少国际化支持，导致非英语用户看到硬编码的英文文本。

### 解决方案

#### TenantManagement.tsx 修改
1. 将静态常量 `STATUS_OPTIONS` 和 `PLAN_OPTIONS` 改为动态函数
2. 添加类型安全的国际化映射：
   - `PLAN_LABELS`: plan类型到翻译key的映射
   - `STATUS_LABELS`: status类型到翻译key的映射
3. 实现带fallback的翻译辅助函数：
   - `getPlanLabel()`: 显示翻译后的plan标签
   - `getStatusLabel()`: 显示翻译后的status标签
4. 使用 `useMemo` 优化性能，避免每次渲染重新创建options

#### i18n/index.ts 修改
添加四种语言的翻译keys：
- `tenantAllStatuses`: "所有状态" / "All Statuses" / "すべてのステータス" / "모든 상태"
- `tenantAllPlans`: "所有计划" / "All Plans" / "すべてのプラン" / "모든 플랜"
- `tenantPlanStandard/Premium/Enterprise`: plan类型标签
- `tenantStatusActive/Suspended/Trial`: status类型标签

### 影响范围
- 租户管理页面的状态和计划下拉框
- 租户列表中的状态和计划Badge显示

### 测试
- ✅ 前端类型检查通过
- ✅ 国际化功能正常工作
- ✅ 向后兼容（不影响现有功能）

Fixes #1500