### PR TITLE
feat: add trial days field to tenant creation form (Issue #1501)

### DIFF
--- a/frontend/src/components/features/management/TenantManagement.tsx
+++ b/frontend/src/components/features/management/TenantManagement.tsx
@@ -92,6 +92,24 @@ const translateTenantError = (error: string, lang: Language): string => {
   return key ? t(key, lang) : error;
 };
 
+// Trial days validation (Issue #1501)
+const validateTrialDays = (
+  value: string | number | undefined,
+  language: Language
+): string | null => {
+  if (value === undefined || value === null || value === '') {
+    return null; // Optional field, empty is valid
+  }
+  const num = Number(value);
+  if (!Number.isInteger(num) || num <= 0) {
+    return t('validationTrialDaysPositive', language);
+  }
+  if (num > 365) {
+    return t('validationTrialDaysMax', language);
+  }
+  return null;
+};
+
 export const TenantManagement: React.FC = () => {
   const language = useLanguage();
   const [tenants, setTenants] = useState<Tenant[]>([]);
@@ -111,6 +129,7 @@ export const TenantManagement: React.FC = () => {
     plan: 'standard',
     contact_email: '',
     contact_name: '',
+    trial_days: undefined,
   });
   const [createAdminAccount, setCreateAdminAccount] = useState(false);
   const [adminFormData, setAdminFormData] = useState({
@@ -127,6 +146,7 @@ export const TenantManagement: React.FC = () => {
     max_sessions_per_user: 5,
   });
   const [formError, setFormError] = useState<string | null>(null);
+  const [trialDaysError, setTrialDaysError] = useState<string | null>(null);
 
   // Dynamic options with useMemo for performance (Issue #1500)
   const statusOptions = useMemo(() => getTenantStatusOptions(language), [language]);
@@ -188,12 +208,14 @@ export const TenantManagement: React.FC = () => {
   const handleOpenCreate = () => {
     setEditingTenant(null);
     setFormError(null);
+    setTrialDaysError(null);
     setFormData({
       name: '',
       slug: '',
       plan: 'standard',
       contact_email: '',
       contact_name: '',
+      trial_days: undefined,
     });
     setCreateAdminAccount(false);
     setAdminFormData({
@@ -207,6 +229,7 @@ export const TenantManagement: React.FC = () => {
   const handleOpenEdit = (tenant: Tenant) => {
     setEditingTenant(tenant);
     setFormError(null);
+    setTrialDaysError(null);
     setFormData({
       name: tenant.name,
       slug: tenant.slug,
@@ -260,6 +283,15 @@ export const TenantManagement: React.FC = () => {
     if (!formData.name.trim()) {
       setFormError(t('tenantNameRequired', language));
       return;
+    }
+
+    // Validate trial days (Issue #1501)
+    if (!editingTenant && formData.trial_days !== undefined) {
+      const error = validateTrialDays(formData.trial_days, language);
+      if (error) {
+        setTrialDaysError(error);
+        return;
+      }
     }
 
     // Validate admin account fields if creating admin
@@ -666,6 +698,32 @@ export const TenantManagement: React.FC = () => {
                 placeholder={t('enterContactName', language)}
               />
             </div>
+            {/* Trial Days - Only for new tenants (Issue #1501) */}
+            {!editingTenant && (
+              <div className="col-md-6">
+                <label className="form-label">{t('tenantTrialDays', language)}</label>
+                <div className="input-group">
+                  <input
+                    type="number"
+                    className={`form-control ${trialDaysError ? 'is-invalid' : ''}`}
+                    min="1"
+                    max="365"
+                    placeholder="7"
+                    value={formData.trial_days ?? ''}
+                    onChange={(e) => {
+                      const value = e.target.value ? parseInt(e.target.value) : undefined;
+                      setFormData({ ...formData, trial_days: value });
+                      // Validate on change
+                      const error = validateTrialDays(value, language);
+                      setTrialDaysError(error);
+                    }}
+                  />
+                  <span className="input-group-text">{t('days', language)}</span>
+                </div>
+                <small className="text-muted">{t('tenantTrialDaysHelp', language)}</small>
+                {trialDaysError && <div className="invalid-feedback d-block">{trialDaysError}</div>}
+              </div>
+            )}
             {/* Admin Account Creation - Only for new tenants */}
             {!editingTenant && (
               <>

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -1086,6 +1086,12 @@ export const translations: Record<Language, Translations> = {
     tenantStatusSuspended: 'Suspended',
     tenantStatusTrial: 'Trial',
 
+    // Trial days field (Issue #1501)
+    tenantTrialDays: 'Trial Days',
+    tenantTrialDaysHelp: 'Number of days for trial period. Leave empty for active tenant.',
+    validationTrialDaysPositive: 'Trial days must be a positive integer',
+    validationTrialDaysMax: 'Trial days cannot exceed 365',
+
     // SSO Settings
     registeredProviders: 'Registered Providers',
     noProvidersRegistered: 'No SSO providers registered',
@@ -2616,6 +2622,12 @@ export const translations: Record<Language, Translations> = {
     tenantStatusSuspended: '已暂停',
     tenantStatusTrial: '试用',
 
+    // Trial days field (Issue #1501)
+    tenantTrialDays: '试用期天数',
+    tenantTrialDaysHelp: '试用期天数。留空则创建活跃租户。',
+    validationTrialDaysPositive: '试用期天数必须为正整数',
+    validationTrialDaysMax: '试用期天数不能超过365天',
+
     // SSO Settings
     registeredProviders: '已注册提供者',
     noProvidersRegistered: '暂无已注册的 SSO 提供者',
@@ -4034,6 +4046,12 @@ export const translations: Record<Language, Translations> = {
     tenantStatusSuspended: '一時停止',
     tenantStatusTrial: '試用',
 
+    // Trial days field (Issue #1501)
+    tenantTrialDays: 'トライアル期間(日)',
+    tenantTrialDaysHelp: 'トライアル期間の日数。空の場合はアクティブテナントになります。',
+    validationTrialDaysPositive: 'トライアル期間は正の整数で入力してください',
+    validationTrialDaysMax: 'トライアル期間は365日以内で入力してください',
+
     // Insights
     insights: 'AI インサイト',
     insightsTitle: 'AI 会話インサイトレポート',
@@ -5352,6 +5370,12 @@ export const translations: Record<Language, Translations> = {
     tenantStatusActive: '활성',
     tenantStatusSuspended: '일시 중단',
     tenantStatusTrial: '체험',
+
+    // Trial days field (Issue #1501)
+    tenantTrialDays: '체험 기간(일)',
+    tenantTrialDaysHelp: '체험 기간 일수. 비워두면 활성 테넌트가 생성됩니다.',
+    validationTrialDaysPositive: '체험 기간은 양의 정수여야 합니다',
+    validationTrialDaysMax: '체험 기간은 365일 이하로 입력하세요',
 
     // Insights
     insights: 'AI 인사이트',


### PR DESCRIPTION
## Issue #1501: 租户创建表单添加试用期字段

### 问题描述
创建租户时缺少试用期(trial days)字段设置，无法指定新租户的试用期天数。

### 解决方案

#### TenantManagement.tsx 修改
1. 在formData中添加 `trial_days` 字段（可选）
2. 实现 `validateTrialDays()` 验证函数：
   - 验证必须是正整数
   - 验证不能超过365天
   - 空值允许（创建active租户）
3. 添加 `trialDaysError` state显示验证错误
4. 在handleSubmit中添加trial days验证逻辑（只对新建租户）
5. 在Modal中添加trial days输入框（只在新建租户时显示）

#### i18n/index.ts 修改
添加四种语言的翻译keys：
- `tenantTrialDays`: "试用期天数" / "Trial Days"
- `tenantTrialDaysHelp`: 帮助文本
- `validationTrialDaysPositive`: 验证错误消息（必须是正整数）
- `validationTrialDaysMax`: 验证错误消息（不能超过365天）

### 依赖关系
⚠️ **此PR依赖于 #1500** (租户管理页面国际化)
- 基础分支: `fix/issue-1500-tenant-i18n`
- 需要先合并 #1500，然后将base改为main

### 影响范围
- 租户创建表单新增试用期字段
- 不影响现有租户编辑功能
- 向后兼容

### 测试
- ✅ 输入验证正常工作
- ✅ 国际化支持完整
- ✅ UI只在新建租户时显示

Fixes #1501