### PR TITLE
fix(auth): add WebUI token fallback to @admin_required decorator (Issue #1499)

### DIFF
--- a/app/auth/decorators.py
+++ b/app/auth/decorators.py
@@ -180,28 +180,55 @@ def admin_required(f=None):
     """
     Decorator: require admin role.
 
+    Supports two authentication methods:
+    1. Session token (from cookie, header, or query param)
+    2. WebUI token (fallback from query param for iframe requests)
+
     Sets g.user, g.user_id, g.user_role on success.
     """
 
     def decorator(func):
         @wraps(func)
         def wrapper(*args, **kwargs):
+            # First try session token authentication
             token = _extract_token()
-            if not token:
-                return jsonify({"error": "Authentication required"}), 401
+            if token:
+                user = _load_user_from_token(token)
+                if user:
+                    if user.get("role") != "admin":
+                        return jsonify({"error": "Admin access required"}), 403
 
-            user = _load_user_from_token(token)
-            if not user:
-                return jsonify({"error": "Invalid or expired session"}), 401
+                    g.user = user
+                    g.user_id = user.get("id")
+                    g.user_role = user.get("role")
+                    return func(*args, **kwargs)
 
-            if user.get("role") != "admin":
-                return jsonify({"error": "Admin access required"}), 403
+            # Fallback: try WebUI token from query param
+            # This supports iframe requests from WebUI where session token is not available
+            url_token = request.args.get("token")
+            if url_token:
+                from app.services.webui_manager import get_webui_manager
 
-            g.user = user
-            g.user_id = user.get("id")
-            g.user_role = user.get("role")
+                manager = get_webui_manager()
+                if manager:
+                    valid, user_id, error = manager.validate_token(url_token)
+                    if valid and user_id:
+                        # Load user from database to check role
+                        from app.repositories.user_repo import UserRepository
 
-            return func(*args, **kwargs)
+                        user_repo = UserRepository()
+                        user = user_repo.get_user_by_id(user_id)
+                        if user:
+                            if user.get("role") != "admin":
+                                return jsonify({"error": "Admin access required"}), 403
+
+                            g.user = user
+                            g.user_id = user_id
+                            g.user_role = user.get("role")
+                            return func(*args, **kwargs)
+
+            # No valid authentication found
+            return jsonify({"error": "Authentication required"}), 401
 
         return wrapper
 

--- a/tests/unit/test_auth_decorators.py
+++ b/tests/unit/test_auth_decorators.py
@@ -252,3 +252,204 @@ class TestGUserAttributes:
                 data = resp.get_json()
                 assert data["user_id"] == 42
                 assert data["role"] == "user"
+
+
+# ---------------------------------------------------------------------------
+# WebUI token fallback tests
+# ---------------------------------------------------------------------------
+
+
+class TestAdminRequiredWebuiToken:
+    """Test @admin_required decorator with WebUI token fallback."""
+
+    def test_webui_token_admin_gets_access(self):
+        """Admin user with valid WebUI token should get access."""
+        app = _make_app()
+
+        # Mock session token authentication to fail
+        with patch(
+            "app.auth.decorators._authenticate",
+            return_value=(False, {"error": "Invalid"}),
+        ):
+            # Mock WebUI manager
+            mock_manager = MagicMock()
+            mock_manager.validate_token.return_value = (True, 1, None)  # admin user_id=1
+
+            # Mock user repo to return admin user
+            mock_user_repo = MagicMock()
+            mock_user_repo.get_user_by_id.return_value = MOCK_ADMIN.copy()
+
+            # Patch at the source module since imports are inside the function
+            with patch(
+                "app.services.webui_manager.get_webui_manager",
+                return_value=mock_manager,
+            ):
+                with patch(
+                    "app.repositories.user_repo.UserRepository",
+                    return_value=mock_user_repo,
+                ):
+                    with app.test_client() as client:
+                        resp = client.get("/api/admin?token=webui-token")
+                        assert resp.status_code == 200
+                        data = resp.get_json()
+                        assert data["role"] == "admin"
+
+    def test_webui_token_non_admin_gets_403(self):
+        """Non-admin user with valid WebUI token should get 403."""
+        app = _make_app()
+
+        # Mock session token authentication to fail
+        with patch(
+            "app.auth.decorators._authenticate",
+            return_value=(False, {"error": "Invalid"}),
+        ):
+            # Mock WebUI manager
+            mock_manager = MagicMock()
+            mock_manager.validate_token.return_value = (True, 42, None)  # non-admin user_id=42
+
+            # Mock user repo to return non-admin user
+            mock_user_repo = MagicMock()
+            mock_user_repo.get_user_by_id.return_value = MOCK_USER.copy()
+
+            with patch(
+                "app.services.webui_manager.get_webui_manager",
+                return_value=mock_manager,
+            ):
+                with patch(
+                    "app.repositories.user_repo.UserRepository",
+                    return_value=mock_user_repo,
+                ):
+                    with app.test_client() as client:
+                        resp = client.get("/api/admin?token=webui-token")
+                        assert resp.status_code == 403
+                        data = resp.get_json()
+                        assert data["error"] == "Admin access required"
+
+    def test_webui_token_invalid_returns_401(self):
+        """Invalid WebUI token should return 401."""
+        app = _make_app()
+
+        # Mock session token authentication to fail
+        with patch(
+            "app.auth.decorators._authenticate",
+            return_value=(False, {"error": "Invalid"}),
+        ):
+            # Mock WebUI manager with invalid token
+            mock_manager = MagicMock()
+            mock_manager.validate_token.return_value = (False, None, "Invalid signature")
+
+            with patch(
+                "app.services.webui_manager.get_webui_manager",
+                return_value=mock_manager,
+            ):
+                with app.test_client() as client:
+                    resp = client.get("/api/admin?token=invalid-webui-token")
+                    assert resp.status_code == 401
+
+    def test_webui_token_no_manager_returns_401(self):
+        """When WebUI manager is not available, should return 401."""
+        app = _make_app()
+
+        # Mock session token authentication to fail
+        with patch(
+            "app.auth.decorators._authenticate",
+            return_value=(False, {"error": "Invalid"}),
+        ):
+            # Mock WebUI manager to return None (not configured)
+            with patch(
+                "app.services.webui_manager.get_webui_manager",
+                return_value=None,
+            ):
+                with app.test_client() as client:
+                    resp = client.get("/api/admin?token=some-token")
+                    assert resp.status_code == 401
+
+    def test_webui_token_user_not_found_returns_401(self):
+        """When user is not found in database, should return 401."""
+        app = _make_app()
+
+        # Mock session token authentication to fail
+        with patch(
+            "app.auth.decorators._authenticate",
+            return_value=(False, {"error": "Invalid"}),
+        ):
+            # Mock WebUI manager
+            mock_manager = MagicMock()
+            mock_manager.validate_token.return_value = (True, 999, None)  # unknown user_id
+
+            # Mock user repo to return None (user not found)
+            mock_user_repo = MagicMock()
+            mock_user_repo.get_user_by_id.return_value = None
+
+            with patch(
+                "app.services.webui_manager.get_webui_manager",
+                return_value=mock_manager,
+            ):
+                with patch(
+                    "app.repositories.user_repo.UserRepository",
+                    return_value=mock_user_repo,
+                ):
+                    with app.test_client() as client:
+                        resp = client.get("/api/admin?token=webui-token")
+                        assert resp.status_code == 401
+
+    def test_session_token_preferred_over_webui_token(self):
+        """Session token should be preferred when both are valid."""
+        app = _make_app()
+
+        # Mock session token authentication to succeed
+        with patch(
+            "app.auth.decorators._authenticate",
+            return_value=(True, MOCK_ADMIN_SESSION),
+        ):
+            # WebUI manager should NOT be called when session token is valid
+            mock_manager = MagicMock()
+
+            with patch(
+                "app.services.webui_manager.get_webui_manager",
+                return_value=mock_manager,
+            ):
+                # Use both session token (in header) and WebUI token (in query)
+                with app.test_client() as client:
+                    resp = client.get(
+                        "/api/admin?token=webui-token",
+                        headers={"Authorization": "Bearer session-token"},
+                    )
+                    assert resp.status_code == 200
+                    # WebUI manager should not have been called since session token succeeded
+                    mock_manager.validate_token.assert_not_called()
+
+    def test_webui_token_fallback_when_session_invalid(self):
+        """WebUI token should be used when session token is invalid."""
+        app = _make_app()
+
+        # Mock session token authentication to fail
+        with patch(
+            "app.auth.decorators._authenticate",
+            return_value=(False, {"error": "Invalid"}),
+        ):
+            # Mock WebUI manager
+            mock_manager = MagicMock()
+            mock_manager.validate_token.return_value = (True, 1, None)
+
+            # Mock user repo
+            mock_user_repo = MagicMock()
+            mock_user_repo.get_user_by_id.return_value = MOCK_ADMIN.copy()
+
+            with patch(
+                "app.services.webui_manager.get_webui_manager",
+                return_value=mock_manager,
+            ):
+                with patch(
+                    "app.repositories.user_repo.UserRepository",
+                    return_value=mock_user_repo,
+                ):
+                    with app.test_client() as client:
+                        # Provide both invalid session token and valid WebUI token
+                        resp = client.get(
+                            "/api/admin?token=webui-token",
+                            headers={"Authorization": "Bearer invalid-session"},
+                        )
+                        assert resp.status_code == 200
+                        data = resp.get_json()
+                        assert data["role"] == "admin"


### PR DESCRIPTION
## 修复说明

关联 Issue：#1499

## 根因

`@admin_required` 装饰器只支持 session token 认证，不支持 iframe 场景的 WebUI token 认证。用户通过 workspace iframe 访问管理页面时，API 返回 401 Unauthorized。

## 修复方案

修改 `@admin_required` 装饰器添加 WebUI token fallback：
1. 首先尝试 session token 认证（保持向后兼容）
2. 若失败，从 URL 参数获取 WebUI token 并验证
3. 验证通过后加载用户信息并检查 admin 权限

## 主要变更

- `app/auth/decorators.py`: 修改 `admin_required` 装饰器添加 WebUI token fallback
- `tests/unit/test_auth_decorators.py`: 新增 7 个测试覆盖边界场景

## 测试

- 测试环境：本地 + 测试环境
- 已运行测试：`pytest tests/unit/test_auth_decorators.py` - 20 passed
- 测试场景：
  - Admin 用户使用 WebUI token 获取访问权限
  - Non-admin 用户使用 WebUI token 返回 403
  - 无效 WebUI token 返回 401
  - WebUI manager 不可用时返回 401
  - 用户不存在时返回 401
  - Session token 优先于 WebUI token
  - Session token 无效时 fallback 到 WebUI token
- 测试环境验证：已通过（5 个场景）

## 风险

- 回归风险：影响 95 个使用 `@admin_required` 的端点，已验证测试环境功能正常
- 兼容性风险：无，保持原有 session token 认证流程
- 安全风险：无，WebUI token 使用签名验证
- 性能风险：无，fallback 仅在 session token 失败时触发