### PR TITLE
fix(E2E): resolve empty-state class and waitForApp issues

### DIFF
--- a/frontend/e2e/remote-directory-browser.spec.ts
+++ b/frontend/e2e/remote-directory-browser.spec.ts
@@ -5,7 +5,7 @@
  */
 
 import { test, expect } from '@playwright/test';
-import { login } from './helpers';
+import { login, waitForApp } from './helpers';
 
 test.describe('Remote Directory Browser', () => {
   test.beforeEach(async ({ page }) => {
@@ -14,6 +14,7 @@ test.describe('Remote Directory Browser', () => {
 
   test('new session modal opens and displays workspace type buttons', async ({ page }) => {
     await page.goto('/work');
+    await waitForApp(page);
 
     const newSessionBtn = page.getByTestId('new-session-btn');
     await expect(newSessionBtn).toBeVisible();
@@ -33,6 +34,7 @@ test.describe('Remote Directory Browser', () => {
 
   test('selecting remote workspace shows machine list and project path', async ({ page }) => {
     await page.goto('/work');
+    await waitForApp(page);
 
     const newSessionBtn = page.getByTestId('new-session-btn');
     await expect(newSessionBtn).toBeVisible();
@@ -50,6 +52,7 @@ test.describe('Remote Directory Browser', () => {
 
   test('selecting terminal workspace shows machine list', async ({ page }) => {
     await page.goto('/work');
+    await waitForApp(page);
 
     const newSessionBtn = page.getByTestId('new-session-btn');
     await expect(newSessionBtn).toBeVisible();
@@ -66,6 +69,7 @@ test.describe('Remote Directory Browser', () => {
 
   test('browse button appears when machine is selected for remote workspace', async ({ page }) => {
     await page.goto('/work');
+    await waitForApp(page);
 
     const newSessionBtn = page.getByTestId('new-session-btn');
     await expect(newSessionBtn).toBeVisible();
@@ -88,6 +92,7 @@ test.describe('Remote Directory Browser', () => {
 
   test('project path input appears for terminal workspace when machine selected', async ({ page }) => {
     await page.goto('/work');
+    await waitForApp(page);
 
     const newSessionBtn = page.getByTestId('new-session-btn');
     await expect(newSessionBtn).toBeVisible();
@@ -109,6 +114,7 @@ test.describe('Remote Directory Browser', () => {
 
   test('create button state reflects machine selection', async ({ page }) => {
     await page.goto('/work');
+    await waitForApp(page);
 
     const newSessionBtn = page.getByTestId('new-session-btn');
     await expect(newSessionBtn).toBeVisible();
@@ -133,6 +139,7 @@ test.describe('Remote Directory Browser', () => {
 
   test('modal can be closed with cancel button', async ({ page }) => {
     await page.goto('/work');
+    await waitForApp(page);
 
     const newSessionBtn = page.getByTestId('new-session-btn');
     await expect(newSessionBtn).toBeVisible();

--- a/frontend/src/components/common/Error.tsx
+++ b/frontend/src/components/common/Error.tsx
@@ -51,7 +51,7 @@ export const EmptyState: React.FC<EmptyStateProps> = ({
   className,
 }) => {
   return (
-    <div className={cn('text-center py-5', className)}>
+    <div className={cn('empty-state text-center py-5', className)}>
       <i className={cn('bi', icon, 'fs-1 text-muted d-block mb-3')} />
       <h5 className="text-muted">{title}</h5>
       {description && <p className="text-muted">{description}</p>}


### PR DESCRIPTION
## Summary

Fixes E2E test failures in Frontend CI (run #29001331166)

### Changes

1. **EmptyState component**: Added `empty-state` class to make the component discoverable by E2E test locators
   - Test was using `.empty-state` selector but component only had `text-center py-5` classes
   - Affects: `management.spec.ts` - alerts tab test

2. **remote-directory-browser tests**: Added `waitForApp()` calls to all 6 tests
   - Tests were timing out because they did not wait for page load completion
   - Added proper import and usage following the pattern in other E2E test files

### Test Results

Before:
- `management.spec.ts`: alerts tab test failed - `expect(hasTable || hasEmpty).toBeTruthy()` 
- `remote-directory-browser.spec.ts`: All 6 tests failed with TimeoutError

After: Tests should pass with proper element discovery and page load waiting

### Related

- CI Run: https://github.com/open-ace/open-ace/actions/runs/29001331166