### PR TITLE
fix(E2E): add empty-state class to EmptyState component

### DIFF
--- a/frontend/src/components/common/Error.tsx
+++ b/frontend/src/components/common/Error.tsx
@@ -51,7 +51,7 @@ export const EmptyState: React.FC<EmptyStateProps> = ({
   className,
 }) => {
   return (
-    <div className={cn('text-center py-5', className)}>
+    <div className={cn('empty-state text-center py-5', className)}>
       <i className={cn('bi', icon, 'fs-1 text-muted d-block mb-3')} />
       <h5 className="text-muted">{title}</h5>
       {description && <p className="text-muted">{description}</p>}


### PR DESCRIPTION
## 问题

Issue #1566: E2E测试 `management.spec.ts` 在 alerts tab 测试时失败，因为 EmptyState 组件缺少 `.empty-state` CSS class。

## 根因

EmptyState 组件的根元素只有 `text-center py-5`，没有添加 `empty-state` class，导致测试的 selector `.user-management .empty-state` 无法匹配。

## 修复

在 EmptyState 组件的根元素添加 `empty-state` class。

```tsx
// Before:
<div className={cn("text-center py-5", className)}>

// After:
<div className={cn("empty-state text-center py-5", className)}>
```

## 测试验证

- E2E测试 `management.spec.ts` alerts tab 测试现在可以正确识别 empty-state 元素