### PR TITLE
fix: 内容过滤页面国际化翻译缺失 (#1494)

### DIFF
--- a/frontend/src/components/features/management/SecurityCenter.tsx
+++ b/frontend/src/components/features/management/SecurityCenter.tsx
@@ -44,23 +44,24 @@ import type {
   AuditThresholds as AuditThresholdsType,
 } from '@/api';
 
-const TYPE_OPTIONS = [
-  { value: 'keyword', label: 'Keyword' },
-  { value: 'regex', label: 'Regex' },
-  { value: 'pii', label: 'PII' },
-];
+// Translation key mappings for filter rule values
+const TYPE_LABEL_KEYS: Record<string, string> = {
+  keyword: 'typeKeyword',
+  regex: 'typeRegex',
+  pii: 'typePii',
+};
 
-const SEVERITY_OPTIONS = [
-  { value: 'low', label: 'Low' },
-  { value: 'medium', label: 'Medium' },
-  { value: 'high', label: 'High' },
-];
+const SEVERITY_LABEL_KEYS: Record<string, string> = {
+  low: 'severityLow',
+  medium: 'severityMedium',
+  high: 'severityHigh',
+};
 
-const ACTION_OPTIONS = [
-  { value: 'warn', label: 'Warn' },
-  { value: 'block', label: 'Block' },
-  { value: 'redact', label: 'Redact' },
-];
+const ACTION_LABEL_KEYS: Record<string, string> = {
+  warn: 'actionWarn',
+  block: 'actionBlock',
+  redact: 'actionRedact',
+};
 
 type TabType = 'filter' | 'settings' | 'audit';
 
@@ -80,6 +81,31 @@ export const SecurityCenter: React.FC = () => {
   const language = useLanguage();
   const toast = useToast();
   const [activeTab, setActiveTab] = useState<TabType>('filter');
+
+  // Generate translated options for Select components
+  const getTypeOptions = () => [
+    { value: 'keyword', label: t('typeKeyword', language) },
+    { value: 'regex', label: t('typeRegex', language) },
+    { value: 'pii', label: t('typePii', language) },
+  ];
+
+  const getSeverityOptions = () => [
+    { value: 'low', label: t('severityLow', language) },
+    { value: 'medium', label: t('severityMedium', language) },
+    { value: 'high', label: t('severityHigh', language) },
+  ];
+
+  const getActionOptions = () => [
+    { value: 'warn', label: t('actionWarn', language) },
+    { value: 'block', label: t('actionBlock', language) },
+    { value: 'redact', label: t('actionRedact', language) },
+  ];
+
+  // Translation helper functions for table data
+  const getFilterTypeLabel = (type: string) => t(TYPE_LABEL_KEYS[type] || type, language);
+  const getFilterSeverityLabel = (severity: string) =>
+    t(SEVERITY_LABEL_KEYS[severity] || severity, language);
+  const getFilterActionLabel = (action: string) => t(ACTION_LABEL_KEYS[action] || action, language);
 
   // --- Page Refresh Control ---
   const pageRefresh = usePageRefresh({
@@ -407,13 +433,17 @@ export const SecurityCenter: React.FC = () => {
                       )}
                     </td>
                     <td>
-                      <Badge variant="secondary">{rule.type}</Badge>
+                      <Badge variant="secondary">{getFilterTypeLabel(rule.type)}</Badge>
                     </td>
                     <td>
-                      <Badge variant={getSeverityVariant(rule.severity)}>{rule.severity}</Badge>
+                      <Badge variant={getSeverityVariant(rule.severity)}>
+                        {getFilterSeverityLabel(rule.severity)}
+                      </Badge>
                     </td>
                     <td>
-                      <Badge variant={getActionVariant(rule.action)}>{rule.action}</Badge>
+                      <Badge variant={getActionVariant(rule.action)}>
+                        {getFilterActionLabel(rule.action)}
+                      </Badge>
                     </td>
                     <td>
                       <div className="form-check form-switch">
@@ -491,7 +521,7 @@ export const SecurityCenter: React.FC = () => {
               <div className="col-md-4">
                 <label className="form-label">{t('tableType', language)}</label>
                 <Select
-                  options={TYPE_OPTIONS}
+                  options={getTypeOptions()}
                   value={ruleFormData.type}
                   onChange={(value) =>
                     setRuleFormData({
@@ -509,7 +539,7 @@ export const SecurityCenter: React.FC = () => {
               <div className="col-md-4">
                 <label className="form-label">{t('tableSeverity', language)}</label>
                 <Select
-                  options={SEVERITY_OPTIONS}
+                  options={getSeverityOptions()}
                   value={ruleFormData.severity}
                   onChange={(value) =>
                     setRuleFormData({
@@ -522,7 +552,7 @@ export const SecurityCenter: React.FC = () => {
               <div className="col-md-4">
                 <label className="form-label">{t('tableAction', language)}</label>
                 <Select
-                  options={ACTION_OPTIONS}
+                  options={getActionOptions()}
                   value={ruleFormData.action}
                   onChange={(value) =>
                     setRuleFormData({

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -349,6 +349,17 @@ export const translations: Record<Language, Translations> = {
     blockActionHelp: 'Block: Prevent the message from being sent',
     redactActionHelp: 'Redact: Replace sensitive content with placeholder',
 
+    // Filter type/severity/action values
+    typeKeyword: 'Keyword',
+    typeRegex: 'Regex',
+    typePii: 'PII',
+    severityLow: 'Low',
+    severityMedium: 'Medium',
+    severityHigh: 'High',
+    actionWarn: 'Warn',
+    actionBlock: 'Block',
+    actionRedact: 'Redact',
+
     // Security Settings
     settingsSaved: 'Settings saved successfully',
     sessionSettings: 'Session Settings',
@@ -1908,6 +1919,17 @@ export const translations: Record<Language, Translations> = {
     warnActionHelp: '警告：记录警告但允许消息发送',
     blockActionHelp: '阻止：禁止消息发送',
     redactActionHelp: '替换：将敏感内容替换为占位符',
+
+    // Filter type/severity/action values
+    typeKeyword: '关键词',
+    typeRegex: '正则表达式',
+    typePii: 'PII',
+    severityLow: '低',
+    severityMedium: '中',
+    severityHigh: '高',
+    actionWarn: '警告',
+    actionBlock: '阻止',
+    actionRedact: '替换',
 
     // Security Settings
     settingsSaved: '设置已保存',
@@ -3617,6 +3639,17 @@ export const translations: Record<Language, Translations> = {
     blockActionHelp: 'ブロック：メッセージの送信を阻止',
     redactActionHelp: '秘匿：機密内容をプレースホルダーで置換',
 
+    // Filter type/severity/action values
+    typeKeyword: 'キーワード',
+    typeRegex: '正規表現',
+    typePii: 'PII（個人識別情報）',
+    severityLow: '低',
+    severityMedium: '中',
+    severityHigh: '高',
+    actionWarn: '警告',
+    actionBlock: 'ブロック',
+    actionRedact: '秘匿',
+
     // Security Settings
     settingsSaved: '設定を保存しました',
     sessionSettings: 'セッション設定',
@@ -4941,6 +4974,17 @@ export const translations: Record<Language, Translations> = {
     warnActionHelp: '경고: 경고를 로그하고 메시지 허용',
     blockActionHelp: '차단: 메시지 전송 방지',
     redactActionHelp: '수정: 민감한 내용을 플레이스홀더로 교체',
+
+    // Filter type/severity/action values
+    typeKeyword: '키워드',
+    typeRegex: '정규식',
+    typePii: 'PII',
+    severityLow: '낮음',
+    severityMedium: '중간',
+    severityHigh: '높음',
+    actionWarn: '경고',
+    actionBlock: '차단',
+    actionRedact: '수정',
 
     // Security Settings
     settingsSaved: '설정이 저장되었습니다',


### PR DESCRIPTION
## 修复说明

关联 Issue：#1494

## 根因

安全中心内容过滤页面的表格数据单元格和下拉菜单选项直接使用硬编码英文值（`rule.type`, `rule.severity`, `rule.action`），缺少对应的 i18n 翻译 key 和翻译函数调用。

## 修复方案

1. 在 `i18n/index.ts` 中添加 9 个翻译 key（类型、严重程度、操作的值翻译），共 4 种语言（en, zh, ja, ko）
2. 在 `SecurityCenter.tsx` 中使用翻译映射常量和翻译函数，替换硬编码文本
3. Select 组件使用动态生成的选项，支持语言切换

## 主要变更

- **i18n/index.ts**：添加 `typeKeyword`, `typeRegex`, `typePii`, `severityLow`, `severityMedium`, `severityHigh`, `actionWarn`, `actionBlock`, `actionRedact` 等翻译 key
- **SecurityCenter.tsx**：
  - 移除硬编码的 `TYPE_OPTIONS`, `SEVERITY_OPTIONS`, `ACTION_OPTIONS` 常量
  - 添加翻译映射常量 `TYPE_LABEL_KEYS`, `SEVERITY_LABEL_KEYS`, `ACTION_LABEL_KEYS`
  - 添加动态生成选项的函数
  - 表格数据单元格和 Select 组件使用翻译函数

## 测试

- 本地构建验证：`npm run build` 成功，无 TypeScript 错误
- 前端开发服务器启动成功

## 风险

- 兼容性：无风险，翻译 key 是新增的
- 性能：无影响，翻译函数开销极小
- 安全：无影响，仅涉及 UI 文本
- 回归：无影响，不改变后端数据结构

🤖 Generated with Qwen Code