### PR TITLE
fix: ManageRoutes 路由配置从绝对路径改为相对路径 (Issue #1512)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -322,39 +322,39 @@ const ManageRoutes: React.FC = () => {
       <Suspense fallback={<PageLoader />}>
         <Routes>
           {/* Overview */}
-          <Route path="/dashboard" element={<Dashboard />} />
+          <Route path="dashboard" element={<Dashboard />} />
 
           {/* Analysis */}
-          <Route path="/analysis" element={<Navigate to="/manage/analysis/trend" replace />} />
-          <Route path="/analysis/trend" element={<TrendAnalysis />} />
-          <Route path="/analysis/request-dashboard" element={<RequestDashboard />} />
-          <Route path="/analysis/anomaly" element={<AnomalyDetection />} />
-          <Route path="/analysis/roi" element={<ROIAnalysis />} />
-          <Route path="/analysis/conversation-history" element={<ConversationHistory />} />
-          <Route path="/messages" element={<Messages />} />
+          <Route path="analysis" element={<Navigate to="/manage/analysis/trend" replace />} />
+          <Route path="analysis/trend" element={<TrendAnalysis />} />
+          <Route path="analysis/request-dashboard" element={<RequestDashboard />} />
+          <Route path="analysis/anomaly" element={<AnomalyDetection />} />
+          <Route path="analysis/roi" element={<ROIAnalysis />} />
+          <Route path="analysis/conversation-history" element={<ConversationHistory />} />
+          <Route path="messages" element={<Messages />} />
 
           {/* Governance - Merged Pages */}
-          <Route path="/audit" element={<AuditCenter />} />
-          <Route path="/quota" element={<QuotaAlerts />} />
-          <Route path="/compliance" element={<ComplianceMgmt />} />
-          <Route path="/security" element={<SecurityCenter />} />
+          <Route path="audit" element={<AuditCenter />} />
+          <Route path="quota" element={<QuotaAlerts />} />
+          <Route path="compliance" element={<ComplianceMgmt />} />
+          <Route path="security" element={<SecurityCenter />} />
 
           {/* Users */}
-          <Route path="/users" element={<UserManagement />} />
-          <Route path="/tenants" element={<TenantManagement />} />
+          <Route path="users" element={<UserManagement />} />
+          <Route path="tenants" element={<TenantManagement />} />
 
           {/* Projects */}
-          <Route path="/projects" element={<ProjectManagement />} />
+          <Route path="projects" element={<ProjectManagement />} />
 
           {/* Remote Workspace */}
-          <Route path="/remote/machines" element={<RemoteMachineManagement />} />
+          <Route path="remote/machines" element={<RemoteMachineManagement />} />
 
           {/* Settings */}
-          <Route path="/settings/sso" element={<SSOSettings />} />
-          <Route path="/settings/api-keys" element={<APIKeyManagement />} />
-          <Route path="/settings/ai-agent" element={<AiAgentSettings />} />
-          <Route path="/settings/smtp" element={<SmtpConfig />} />
-          <Route path="/settings/model-gateway" element={<ModelGatewayConfig />} />
+          <Route path="settings/sso" element={<SSOSettings />} />
+          <Route path="settings/api-keys" element={<APIKeyManagement />} />
+          <Route path="settings/ai-agent" element={<AiAgentSettings />} />
+          <Route path="settings/smtp" element={<SmtpConfig />} />
+          <Route path="settings/model-gateway" element={<ModelGatewayConfig />} />
 
           {/* Default */}
           <Route path="*" element={<Navigate to="/manage/dashboard" replace />} />


### PR DESCRIPTION
## Issue #1512

访问 `/manage/settings/sso` 页面显示空白，没有任何内容渲染。

### 根本原因

ManageRoutes 内 21 条路由错误使用绝对路径 (如 path="/dashboard")，React Router v6 要求嵌套 Routes 使用相对路径。

### 修复方案

将所有 Route path 从绝对路径改为相对路径，保持 Navigate to 使用完整路径。

### 影响范围

- /manage/dashboard、/manage/settings/sso、/manage/users 等 21 条路由
- 所有管理模式页面恢复正常访问