### PR TITLE
fix: storage estimate data type i18n missing (#1492)

### DIFF
--- a/frontend/src/components/features/compliance/DataRetention.tsx
+++ b/frontend/src/components/features/compliance/DataRetention.tsx
@@ -52,16 +52,19 @@ export const DATA_TYPE_META: Record<
     i18nKey: 'dataTypeAuditLogs',
     icon: 'bi-journal-text',
     fallbackLabel: 'Audit Logs',
+    storageEstimateKey: 'audit_logs',
   },
   quota_alerts: {
     i18nKey: 'dataTypeQuotaAlerts',
     icon: 'bi-bell',
     fallbackLabel: 'Quota Alerts',
+    storageEstimateKey: 'quota_alerts',
   },
   sessions: {
     i18nKey: 'dataTypeSessions',
     icon: 'bi-chat-square',
     fallbackLabel: 'Sessions',
+    storageEstimateKey: 'sessions',
   },
   sso_sessions: {
     i18nKey: 'dataTypeSsoSessions',
@@ -84,6 +87,12 @@ export const DATA_TYPE_META: Record<
     i18nKey: 'dataTypeUserActivity',
     icon: 'bi-person-activity',
     fallbackLabel: 'User Activity',
+  },
+  users: {
+    i18nKey: 'dataTypeUsers',
+    icon: 'bi-person',
+    fallbackLabel: 'Users',
+    storageEstimateKey: 'users',
   },
 };
 

--- a/frontend/src/components/features/management/ComplianceMgmt.tsx
+++ b/frontend/src/components/features/management/ComplianceMgmt.tsx
@@ -66,16 +66,19 @@ const DATA_TYPE_META: Record<
     i18nKey: 'dataTypeAuditLogs',
     icon: 'bi-journal-text',
     fallbackLabel: 'Audit Logs',
+    storageEstimateKey: 'audit_logs',
   },
   quota_alerts: {
     i18nKey: 'dataTypeQuotaAlerts',
     icon: 'bi-bell',
     fallbackLabel: 'Quota Alerts',
+    storageEstimateKey: 'quota_alerts',
   },
   sessions: {
     i18nKey: 'dataTypeSessions',
     icon: 'bi-chat-square',
     fallbackLabel: 'Sessions',
+    storageEstimateKey: 'sessions',
   },
   sso_sessions: {
     i18nKey: 'dataTypeSsoSessions',
@@ -98,6 +101,12 @@ const DATA_TYPE_META: Record<
     i18nKey: 'dataTypeUserActivity',
     icon: 'bi-person-activity',
     fallbackLabel: 'User Activity',
+  },
+  users: {
+    i18nKey: 'dataTypeUsers',
+    icon: 'bi-person',
+    fallbackLabel: 'Users',
+    storageEstimateKey: 'users',
   },
 };
 

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -933,6 +933,7 @@ export const translations: Record<Language, Translations> = {
     dataTypeSsoSessions: 'SSO Sessions',
     dataTypeUsageData: 'Usage Data',
     dataTypeUserActivity: 'User Activity',
+    dataTypeUsers: 'Users',
     dataTypeUnknown: 'Unknown Type',
 
     // Data Retention - Action Labels
@@ -2486,6 +2487,7 @@ export const translations: Record<Language, Translations> = {
     dataTypeSsoSessions: 'SSO会话',
     dataTypeUsageData: '使用数据',
     dataTypeUserActivity: '用户活动',
+    dataTypeUsers: '用户',
     dataTypeUnknown: '未知类型',
 
     // Data Retention - Action Labels
@@ -3467,6 +3469,7 @@ export const translations: Record<Language, Translations> = {
     dataTypeSsoSessions: 'SSOセッション',
     dataTypeUsageData: '使用データ',
     dataTypeUserActivity: 'ユーザー活動',
+    dataTypeUsers: 'ユーザー',
     dataTypeUnknown: '未知タイプ',
 
     // Data Retention - Action Labels
@@ -4804,6 +4807,7 @@ export const translations: Record<Language, Translations> = {
     dataTypeSsoSessions: 'SSO 세션',
     dataTypeUsageData: '사용 데이터',
     dataTypeUserActivity: '사용자 활동',
+    dataTypeUsers: '사용자',
     dataTypeUnknown: '알 수 없는 유형',
 
     // Data Retention - Action Labels


### PR DESCRIPTION
## Issue

Fixes #1492 - 数据保留页面存储估算表格数据类型在中文页面显示英文

## Root Cause

存储估算表格的数据类型显示依赖于 `DATA_TYPE_META` 中的 `storageEstimateKey` 映射到 i18n 翻译键，但部分数据类型缺少该映射，导致显示 fallback 英文标签。

具体问题：
- `audit_logs`、`quota_alerts`、`sessions` 缺少 `storageEstimateKey` 映射
- `users` 类型定义缺失
- `dataTypeUsers` 四语言翻译缺失

## Fix

1. 为 `audit_logs`、`quota_alerts`、`sessions` 补全 `storageEstimateKey` 映射
2. 新增 `users` 类型定义（`storageEstimateKey: 'users'`）
3. 添加 `dataTypeUsers` 四语言翻译：
   - en: 'Users'
   - zh: '用户'
   - ja: 'ユーザー'
   - ko: '사용자'

## Files Changed

仅前端修改（3 个文件）：
- `frontend/src/components/features/compliance/DataRetention.tsx` - DATA_TYPE_META 补全 storageEstimateKey
- `frontend/src/components/features/management/ComplianceMgmt.tsx` - DATA_TYPE_META 补全 storageEstimateKey
- `frontend/src/i18n/index.ts` - 添加 dataTypeUsers 四语言翻译

## Note

此 PR 替代 PR #1587（已关闭），仅包含 Issue #1492 相关的前端修改，不包含 Issue #1493 的后端内容过滤修改。

🤖 Generated with Qwen Code (3-shotted by Qwen-Coder)