### PR TITLE
feat(alert): add scene-specific alert functions with severity determination (Issue #1489)

### DIFF
--- a/app/modules/governance/alert_notifier.py
+++ b/app/modules/governance/alert_notifier.py
@@ -992,3 +992,328 @@ def create_security_alert(
         username=username,
         language=language,
     )
+
+
+# =============================================================================
+# Scene-Specific Alert Functions
+# =============================================================================
+# These functions provide built-in severity determination for common scenarios.
+# Developers should prefer these functions over generic create_system_alert /
+# create_security_alert for better consistency and maintainability.
+
+
+def create_service_down_alert(
+    service_name: str,
+    details: str,
+    language: str = "en",
+) -> Alert:
+    """
+    Create a service down alert (CRITICAL severity).
+
+    Used when a critical service becomes unavailable.
+
+    Severity: CRITICAL (service down is always critical)
+
+    Args:
+        service_name: Name of the affected service.
+        details: Additional details about the service failure.
+        language: Language for email notification.
+
+    Returns:
+        Created Alert.
+    """
+    return create_system_alert(
+        title=f"Service Down: {service_name}",
+        message=f"Service '{service_name}' is unavailable. Details: {details}",
+        severity=AlertSeverity.CRITICAL.value,
+        language=language,
+    )
+
+
+def create_service_startup_alert(
+    service_name: str,
+    startup_time: float,
+    threshold: float,
+    language: str = "en",
+) -> Alert:
+    """
+    Create a service startup alert (WARNING or CRITICAL based on startup time).
+
+    Used when a service takes longer than expected to start.
+
+    Severity determination:
+    - startup_time > threshold * 2: CRITICAL
+    - startup_time > threshold: WARNING
+
+    Args:
+        service_name: Name of the service.
+        startup_time: Actual startup time in seconds.
+        threshold: Expected startup time threshold in seconds.
+        language: Language for email notification.
+
+    Returns:
+        Created Alert.
+    """
+    if startup_time > threshold * 2:
+        severity = AlertSeverity.CRITICAL.value
+        title = f"Service Startup Critical: {service_name}"
+        message = (
+            f"Service '{service_name}' startup took {startup_time:.1f}s, "
+            f"which is {startup_time / threshold:.1f}x the expected threshold ({threshold}s)."
+        )
+    else:
+        severity = AlertSeverity.WARNING.value
+        title = f"Service Startup Warning: {service_name}"
+        message = (
+            f"Service '{service_name}' startup took {startup_time:.1f}s, "
+            f"exceeding the expected threshold ({threshold}s)."
+        )
+
+    return create_system_alert(
+        title=title,
+        message=message,
+        severity=severity,
+        language=language,
+    )
+
+
+def create_resource_alert(
+    resource_type: str,
+    current: float,
+    limit: float,
+    threshold_warning: float = 0.8,
+    threshold_critical: float = 0.95,
+    language: str = "en",
+) -> Alert:
+    """
+    Create a resource shortage alert (INFO, WARNING, or CRITICAL based on usage).
+
+    Used for memory, CPU, disk, or other resource shortage alerts.
+
+    Severity determination:
+    - usage >= 100%: CRITICAL (resource exhausted)
+    - usage >= threshold_critical: CRITICAL (approaching limit)
+    - usage >= threshold_warning: WARNING (moderate shortage)
+    - usage < threshold_warning: INFO (notification only)
+
+    Args:
+        resource_type: Type of resource (memory, cpu, disk, etc.).
+        current: Current resource usage.
+        limit: Resource limit.
+        threshold_warning: Warning threshold as percentage (default 80%).
+        threshold_critical: Critical threshold as percentage (default 95%).
+        language: Language for email notification.
+
+    Returns:
+        Created Alert.
+    """
+    usage_percent = (current / limit) * 100 if limit > 0 else 100
+
+    if usage_percent >= 100:
+        severity = AlertSeverity.CRITICAL.value
+        title = f"Resource Exhausted: {resource_type}"
+        message = f"{resource_type} is fully used ({current}/{limit})."
+    elif usage_percent >= threshold_critical * 100:
+        severity = AlertSeverity.CRITICAL.value
+        title = f"Resource Critical: {resource_type}"
+        message = f"{resource_type} usage at {usage_percent:.1f}% ({current}/{limit})."
+    elif usage_percent >= threshold_warning * 100:
+        severity = AlertSeverity.WARNING.value
+        title = f"Resource Warning: {resource_type}"
+        message = f"{resource_type} usage at {usage_percent:.1f}% ({current}/{limit})."
+    else:
+        severity = AlertSeverity.INFO.value
+        title = f"Resource Notice: {resource_type}"
+        message = f"{resource_type} usage at {usage_percent:.1f}% ({current}/{limit})."
+
+    return create_system_alert(
+        title=title,
+        message=message,
+        severity=severity,
+        language=language,
+    )
+
+
+def create_config_error_alert(
+    config_key: str,
+    error_details: str,
+    language: str = "en",
+) -> Alert:
+    """
+    Create a configuration error alert (WARNING severity).
+
+    Used for configuration validation errors or invalid settings.
+
+    Severity: WARNING (configuration errors need attention but are not immediately critical)
+
+    Args:
+        config_key: The configuration key that has an error.
+        error_details: Details about the configuration error.
+        language: Language for email notification.
+
+    Returns:
+        Created Alert.
+    """
+    return create_system_alert(
+        title=f"Configuration Error: {config_key}",
+        message=f"Configuration key '{config_key}' has an error: {error_details}",
+        severity=AlertSeverity.WARNING.value,
+        language=language,
+    )
+
+
+def create_api_error_alert(
+    api_name: str,
+    error_code: int,
+    error_message: str,
+    language: str = "en",
+) -> Alert:
+    """
+    Create an API error alert (WARNING severity).
+
+    Used for API call failures or unexpected responses.
+
+    Severity: WARNING (API errors typically need investigation)
+
+    Args:
+        api_name: Name of the API or endpoint.
+        error_code: Error code returned by the API.
+        error_message: Error message from the API.
+        language: Language for email notification.
+
+    Returns:
+        Created Alert.
+    """
+    return create_system_alert(
+        title=f"API Error: {api_name}",
+        message=f"API '{api_name}' returned error {error_code}: {error_message}",
+        severity=AlertSeverity.WARNING.value,
+        language=language,
+    )
+
+
+def create_auth_failure_alert(
+    username: str,
+    failure_count: int,
+    threshold: int = 5,
+    language: str = "en",
+) -> Alert:
+    """
+    Create an authentication failure alert (WARNING or CRITICAL based on count).
+
+    Used for login failures, token validation failures, etc.
+
+    Severity determination:
+    - failure_count >= threshold: CRITICAL (repeated failures indicate potential attack)
+    - failure_count < threshold: WARNING (single failure needs monitoring)
+
+    Args:
+        username: Username that failed authentication.
+        failure_count: Number of consecutive failures for this user.
+        threshold: Threshold for upgrading to CRITICAL (default 5).
+        language: Language for email notification.
+
+    Returns:
+        Created Alert.
+    """
+    if failure_count >= threshold:
+        severity = AlertSeverity.CRITICAL.value
+        title = f"Authentication Failure Alert: {username}"
+        message = (
+            f"User '{username}' has {failure_count} consecutive authentication failures. "
+            f"This may indicate a brute-force attack attempt."
+        )
+    else:
+        severity = AlertSeverity.WARNING.value
+        title = f"Authentication Failure: {username}"
+        message = (
+            f"User '{username}' authentication failed ({failure_count} failures). "
+            f"Monitoring suggested."
+        )
+
+    return create_security_alert(
+        title=title,
+        message=message,
+        username=username,
+        severity=severity,
+        language=language,
+    )
+
+
+def create_permission_violation_alert(
+    username: str,
+    resource: str,
+    action: str,
+    language: str = "en",
+) -> Alert:
+    """
+    Create a permission violation alert (CRITICAL severity).
+
+    Used when a user attempts to access a resource without proper permissions.
+
+    Severity: CRITICAL (permission violations are security incidents)
+
+    Args:
+        username: Username that attempted the unauthorized action.
+        resource: Resource that was accessed.
+        action: Action that was attempted.
+        language: Language for email notification.
+
+    Returns:
+        Created Alert.
+    """
+    return create_security_alert(
+        title=f"Permission Violation: {username}",
+        message=f"User '{username}' attempted '{action}' on '{resource}' without authorization.",
+        username=username,
+        severity=AlertSeverity.CRITICAL.value,
+        language=language,
+    )
+
+
+def create_suspicious_activity_alert(
+    username: str,
+    activity_type: str,
+    risk_score: float,
+    language: str = "en",
+) -> Alert:
+    """
+    Create a suspicious activity alert (WARNING or CRITICAL based on risk score).
+
+    Used for detecting unusual user behavior patterns.
+
+    Severity determination:
+    - risk_score >= 50: CRITICAL (high-risk activity)
+    - risk_score < 50: WARNING (moderate-risk activity)
+
+    Args:
+        username: Username showing suspicious behavior.
+        activity_type: Type of suspicious activity detected.
+        risk_score: Risk score from 0-100 (higher = more suspicious).
+        language: Language for email notification.
+
+    Returns:
+        Created Alert.
+    """
+    if risk_score >= 50:
+        severity = AlertSeverity.CRITICAL.value
+        title = f"High-Risk Activity: {username}"
+        message = (
+            f"User '{username}' detected performing '{activity_type}' with risk score {risk_score:.1f}. "
+            f"Immediate investigation recommended."
+        )
+    else:
+        severity = AlertSeverity.WARNING.value
+        title = f"Suspicious Activity: {username}"
+        message = (
+            f"User '{username}' detected performing '{activity_type}' with risk score {risk_score:.1f}. "
+            f"Monitoring recommended."
+        )
+
+    return create_security_alert(
+        title=title,
+        message=message,
+        username=username,
+        severity=severity,
+        language=language,
+    )

--- a/tests/test_scene_specific_alerts.py
+++ b/tests/test_scene_specific_alerts.py
@@ -4,22 +4,23 @@ Tests for scene-specific alert functions.
 Tests severity determination logic for system and security alert scenarios.
 """
 
-import pytest
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from app.modules.governance.alert_notifier import (
+    Alert,
     AlertSeverity,
     AlertType,
-    Alert,
-    create_service_down_alert,
-    create_service_startup_alert,
-    create_resource_alert,
-    create_config_error_alert,
     create_api_error_alert,
     create_auth_failure_alert,
+    create_config_error_alert,
     create_permission_violation_alert,
-    create_suspicious_activity_alert,
     create_quota_alert,
+    create_resource_alert,
+    create_service_down_alert,
+    create_service_startup_alert,
+    create_suspicious_activity_alert,
 )
 
 
@@ -32,7 +33,7 @@ class TestServiceDownAlert:
         mock_alert = MagicMock(spec=Alert)
         mock_create_system.return_value = mock_alert
 
-        result = create_service_down_alert(
+        create_service_down_alert(
             service_name="API Gateway",
             details="Service crashed after memory exhaustion",
         )
@@ -50,7 +51,7 @@ class TestServiceDownAlert:
         mock_alert = MagicMock(spec=Alert)
         mock_create_system.return_value = mock_alert
 
-        result = create_service_down_alert(
+        create_service_down_alert(
             service_name="Database",
             details="Connection refused",
             language="zh",
@@ -70,7 +71,7 @@ class TestServiceStartupAlert:
         mock_create_system.return_value = mock_alert
 
         # startup_time = 15s, threshold = 10s -> 1.5x threshold -> WARNING
-        result = create_service_startup_alert(
+        create_service_startup_alert(
             service_name="Web Server",
             startup_time=15.0,
             threshold=10.0,
@@ -87,7 +88,7 @@ class TestServiceStartupAlert:
         mock_create_system.return_value = mock_alert
 
         # startup_time = 25s, threshold = 10s -> 2.5x threshold -> CRITICAL
-        result = create_service_startup_alert(
+        create_service_startup_alert(
             service_name="Web Server",
             startup_time=25.0,
             threshold=10.0,
@@ -107,7 +108,7 @@ class TestResourceAlert:
         mock_alert = MagicMock(spec=Alert)
         mock_create_system.return_value = mock_alert
 
-        result = create_resource_alert(
+        create_resource_alert(
             resource_type="memory",
             current=8192,
             limit=8192,
@@ -123,7 +124,7 @@ class TestResourceAlert:
         mock_alert = MagicMock(spec=Alert)
         mock_create_system.return_value = mock_alert
 
-        result = create_resource_alert(
+        create_resource_alert(
             resource_type="cpu",
             current=95,
             limit=100,
@@ -139,7 +140,7 @@ class TestResourceAlert:
         mock_alert = MagicMock(spec=Alert)
         mock_create_system.return_value = mock_alert
 
-        result = create_resource_alert(
+        create_resource_alert(
             resource_type="disk",
             current=85,
             limit=100,
@@ -155,7 +156,7 @@ class TestResourceAlert:
         mock_alert = MagicMock(spec=Alert)
         mock_create_system.return_value = mock_alert
 
-        result = create_resource_alert(
+        create_resource_alert(
             resource_type="disk",
             current=50,
             limit=100,
@@ -175,7 +176,7 @@ class TestConfigErrorAlert:
         mock_alert = MagicMock(spec=Alert)
         mock_create_system.return_value = mock_alert
 
-        result = create_config_error_alert(
+        create_config_error_alert(
             config_key="database_url",
             error_details="Invalid connection string format",
         )
@@ -194,7 +195,7 @@ class TestApiErrorAlert:
         mock_alert = MagicMock(spec=Alert)
         mock_create_system.return_value = mock_alert
 
-        result = create_api_error_alert(
+        create_api_error_alert(
             api_name="External Service",
             error_code=500,
             error_message="Internal Server Error",
@@ -214,7 +215,7 @@ class TestAuthFailureAlert:
         mock_alert = MagicMock(spec=Alert)
         mock_create_security.return_value = mock_alert
 
-        result = create_auth_failure_alert(
+        create_auth_failure_alert(
             username="testuser",
             failure_count=1,
             threshold=5,
@@ -231,7 +232,7 @@ class TestAuthFailureAlert:
         mock_alert = MagicMock(spec=Alert)
         mock_create_security.return_value = mock_alert
 
-        result = create_auth_failure_alert(
+        create_auth_failure_alert(
             username="attacker",
             failure_count=7,
             threshold=5,
@@ -252,7 +253,7 @@ class TestPermissionViolationAlert:
         mock_alert = MagicMock(spec=Alert)
         mock_create_security.return_value = mock_alert
 
-        result = create_permission_violation_alert(
+        create_permission_violation_alert(
             username="hacker",
             resource="/admin/users",
             action="delete",
@@ -272,7 +273,7 @@ class TestSuspiciousActivityAlert:
         mock_alert = MagicMock(spec=Alert)
         mock_create_security.return_value = mock_alert
 
-        result = create_suspicious_activity_alert(
+        create_suspicious_activity_alert(
             username="normaluser",
             activity_type="unusual_login_time",
             risk_score=30.0,
@@ -288,7 +289,7 @@ class TestSuspiciousActivityAlert:
         mock_alert = MagicMock(spec=Alert)
         mock_create_security.return_value = mock_alert
 
-        result = create_suspicious_activity_alert(
+        create_suspicious_activity_alert(
             username="suspect",
             activity_type="mass_data_download",
             risk_score=75.0,
@@ -311,7 +312,7 @@ class TestRegressionQuotaAlert:
         mock_get_notifier.return_value = mock_notifier
 
         # Test quota alert at 95%
-        result = create_quota_alert(
+        create_quota_alert(
             user_id=1,
             username="testuser",
             usage_percent=95.0,

--- a/tests/test_scene_specific_alerts.py
+++ b/tests/test_scene_specific_alerts.py
@@ -1,0 +1,323 @@
+"""
+Tests for scene-specific alert functions.
+
+Tests severity determination logic for system and security alert scenarios.
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from app.modules.governance.alert_notifier import (
+    AlertSeverity,
+    AlertType,
+    Alert,
+    create_service_down_alert,
+    create_service_startup_alert,
+    create_resource_alert,
+    create_config_error_alert,
+    create_api_error_alert,
+    create_auth_failure_alert,
+    create_permission_violation_alert,
+    create_suspicious_activity_alert,
+    create_quota_alert,
+)
+
+
+class TestServiceDownAlert:
+    """Tests for create_service_down_alert."""
+
+    @patch("app.modules.governance.alert_notifier.create_system_alert")
+    def test_service_down_is_critical(self, mock_create_system):
+        """Service down should always be CRITICAL."""
+        mock_alert = MagicMock(spec=Alert)
+        mock_create_system.return_value = mock_alert
+
+        result = create_service_down_alert(
+            service_name="API Gateway",
+            details="Service crashed after memory exhaustion",
+        )
+
+        mock_create_system.assert_called_once()
+        call_kwargs = mock_create_system.call_args.kwargs
+
+        assert call_kwargs["severity"] == AlertSeverity.CRITICAL.value
+        assert "Service Down: API Gateway" in call_kwargs["title"]
+        assert "API Gateway" in call_kwargs["message"]
+
+    @patch("app.modules.governance.alert_notifier.create_system_alert")
+    def test_service_down_with_language(self, mock_create_system):
+        """Service down alert should support language parameter."""
+        mock_alert = MagicMock(spec=Alert)
+        mock_create_system.return_value = mock_alert
+
+        result = create_service_down_alert(
+            service_name="Database",
+            details="Connection refused",
+            language="zh",
+        )
+
+        call_kwargs = mock_create_system.call_args.kwargs
+        assert call_kwargs["language"] == "zh"
+
+
+class TestServiceStartupAlert:
+    """Tests for create_service_startup_alert."""
+
+    @patch("app.modules.governance.alert_notifier.create_system_alert")
+    def test_startup_time_warning(self, mock_create_system):
+        """Startup time exceeding threshold should be WARNING."""
+        mock_alert = MagicMock(spec=Alert)
+        mock_create_system.return_value = mock_alert
+
+        # startup_time = 15s, threshold = 10s -> 1.5x threshold -> WARNING
+        result = create_service_startup_alert(
+            service_name="Web Server",
+            startup_time=15.0,
+            threshold=10.0,
+        )
+
+        call_kwargs = mock_create_system.call_args.kwargs
+        assert call_kwargs["severity"] == AlertSeverity.WARNING.value
+        assert "Service Startup Warning" in call_kwargs["title"]
+
+    @patch("app.modules.governance.alert_notifier.create_system_alert")
+    def test_startup_time_critical(self, mock_create_system):
+        """Startup time exceeding 2x threshold should be CRITICAL."""
+        mock_alert = MagicMock(spec=Alert)
+        mock_create_system.return_value = mock_alert
+
+        # startup_time = 25s, threshold = 10s -> 2.5x threshold -> CRITICAL
+        result = create_service_startup_alert(
+            service_name="Web Server",
+            startup_time=25.0,
+            threshold=10.0,
+        )
+
+        call_kwargs = mock_create_system.call_args.kwargs
+        assert call_kwargs["severity"] == AlertSeverity.CRITICAL.value
+        assert "Service Startup Critical" in call_kwargs["title"]
+
+
+class TestResourceAlert:
+    """Tests for create_resource_alert."""
+
+    @patch("app.modules.governance.alert_notifier.create_system_alert")
+    def test_resource_exhausted(self, mock_create_system):
+        """Resource at 100% usage should be CRITICAL."""
+        mock_alert = MagicMock(spec=Alert)
+        mock_create_system.return_value = mock_alert
+
+        result = create_resource_alert(
+            resource_type="memory",
+            current=8192,
+            limit=8192,
+        )
+
+        call_kwargs = mock_create_system.call_args.kwargs
+        assert call_kwargs["severity"] == AlertSeverity.CRITICAL.value
+        assert "Resource Exhausted" in call_kwargs["title"]
+
+    @patch("app.modules.governance.alert_notifier.create_system_alert")
+    def test_resource_critical(self, mock_create_system):
+        """Resource at 95%+ usage should be CRITICAL."""
+        mock_alert = MagicMock(spec=Alert)
+        mock_create_system.return_value = mock_alert
+
+        result = create_resource_alert(
+            resource_type="cpu",
+            current=95,
+            limit=100,
+        )
+
+        call_kwargs = mock_create_system.call_args.kwargs
+        assert call_kwargs["severity"] == AlertSeverity.CRITICAL.value
+        assert "Resource Critical" in call_kwargs["title"]
+
+    @patch("app.modules.governance.alert_notifier.create_system_alert")
+    def test_resource_warning(self, mock_create_system):
+        """Resource at 80%+ usage should be WARNING."""
+        mock_alert = MagicMock(spec=Alert)
+        mock_create_system.return_value = mock_alert
+
+        result = create_resource_alert(
+            resource_type="disk",
+            current=85,
+            limit=100,
+        )
+
+        call_kwargs = mock_create_system.call_args.kwargs
+        assert call_kwargs["severity"] == AlertSeverity.WARNING.value
+        assert "Resource Warning" in call_kwargs["title"]
+
+    @patch("app.modules.governance.alert_notifier.create_system_alert")
+    def test_resource_info(self, mock_create_system):
+        """Resource below 80% usage should be INFO."""
+        mock_alert = MagicMock(spec=Alert)
+        mock_create_system.return_value = mock_alert
+
+        result = create_resource_alert(
+            resource_type="disk",
+            current=50,
+            limit=100,
+        )
+
+        call_kwargs = mock_create_system.call_args.kwargs
+        assert call_kwargs["severity"] == AlertSeverity.INFO.value
+        assert "Resource Notice" in call_kwargs["title"]
+
+
+class TestConfigErrorAlert:
+    """Tests for create_config_error_alert."""
+
+    @patch("app.modules.governance.alert_notifier.create_system_alert")
+    def test_config_error_is_warning(self, mock_create_system):
+        """Configuration error should be WARNING."""
+        mock_alert = MagicMock(spec=Alert)
+        mock_create_system.return_value = mock_alert
+
+        result = create_config_error_alert(
+            config_key="database_url",
+            error_details="Invalid connection string format",
+        )
+
+        call_kwargs = mock_create_system.call_args.kwargs
+        assert call_kwargs["severity"] == AlertSeverity.WARNING.value
+        assert "Configuration Error" in call_kwargs["title"]
+
+
+class TestApiErrorAlert:
+    """Tests for create_api_error_alert."""
+
+    @patch("app.modules.governance.alert_notifier.create_system_alert")
+    def test_api_error_is_warning(self, mock_create_system):
+        """API error should be WARNING."""
+        mock_alert = MagicMock(spec=Alert)
+        mock_create_system.return_value = mock_alert
+
+        result = create_api_error_alert(
+            api_name="External Service",
+            error_code=500,
+            error_message="Internal Server Error",
+        )
+
+        call_kwargs = mock_create_system.call_args.kwargs
+        assert call_kwargs["severity"] == AlertSeverity.WARNING.value
+        assert "API Error" in call_kwargs["title"]
+
+
+class TestAuthFailureAlert:
+    """Tests for create_auth_failure_alert."""
+
+    @patch("app.modules.governance.alert_notifier.create_security_alert")
+    def test_single_auth_failure_warning(self, mock_create_security):
+        """Single auth failure should be WARNING."""
+        mock_alert = MagicMock(spec=Alert)
+        mock_create_security.return_value = mock_alert
+
+        result = create_auth_failure_alert(
+            username="testuser",
+            failure_count=1,
+            threshold=5,
+        )
+
+        call_kwargs = mock_create_security.call_args.kwargs
+        assert call_kwargs["severity"] == AlertSeverity.WARNING.value
+        assert "Authentication Failure" in call_kwargs["title"]
+        assert call_kwargs["username"] == "testuser"
+
+    @patch("app.modules.governance.alert_notifier.create_security_alert")
+    def test_repeated_auth_failure_critical(self, mock_create_security):
+        """Repeated auth failures (>= threshold) should be CRITICAL."""
+        mock_alert = MagicMock(spec=Alert)
+        mock_create_security.return_value = mock_alert
+
+        result = create_auth_failure_alert(
+            username="attacker",
+            failure_count=7,
+            threshold=5,
+        )
+
+        call_kwargs = mock_create_security.call_args.kwargs
+        assert call_kwargs["severity"] == AlertSeverity.CRITICAL.value
+        assert "Authentication Failure Alert" in call_kwargs["title"]
+        assert "brute-force" in call_kwargs["message"].lower()
+
+
+class TestPermissionViolationAlert:
+    """Tests for create_permission_violation_alert."""
+
+    @patch("app.modules.governance.alert_notifier.create_security_alert")
+    def test_permission_violation_is_critical(self, mock_create_security):
+        """Permission violation should be CRITICAL."""
+        mock_alert = MagicMock(spec=Alert)
+        mock_create_security.return_value = mock_alert
+
+        result = create_permission_violation_alert(
+            username="hacker",
+            resource="/admin/users",
+            action="delete",
+        )
+
+        call_kwargs = mock_create_security.call_args.kwargs
+        assert call_kwargs["severity"] == AlertSeverity.CRITICAL.value
+        assert "Permission Violation" in call_kwargs["title"]
+
+
+class TestSuspiciousActivityAlert:
+    """Tests for create_suspicious_activity_alert."""
+
+    @patch("app.modules.governance.alert_notifier.create_security_alert")
+    def test_low_risk_warning(self, mock_create_security):
+        """Low risk score (< 50) should be WARNING."""
+        mock_alert = MagicMock(spec=Alert)
+        mock_create_security.return_value = mock_alert
+
+        result = create_suspicious_activity_alert(
+            username="normaluser",
+            activity_type="unusual_login_time",
+            risk_score=30.0,
+        )
+
+        call_kwargs = mock_create_security.call_args.kwargs
+        assert call_kwargs["severity"] == AlertSeverity.WARNING.value
+        assert "Suspicious Activity" in call_kwargs["title"]
+
+    @patch("app.modules.governance.alert_notifier.create_security_alert")
+    def test_high_risk_critical(self, mock_create_security):
+        """High risk score (>= 50) should be CRITICAL."""
+        mock_alert = MagicMock(spec=Alert)
+        mock_create_security.return_value = mock_alert
+
+        result = create_suspicious_activity_alert(
+            username="suspect",
+            activity_type="mass_data_download",
+            risk_score=75.0,
+        )
+
+        call_kwargs = mock_create_security.call_args.kwargs
+        assert call_kwargs["severity"] == AlertSeverity.CRITICAL.value
+        assert "High-Risk Activity" in call_kwargs["title"]
+
+
+class TestRegressionQuotaAlert:
+    """Regression tests to ensure create_quota_alert still works."""
+
+    @patch("app.modules.governance.alert_notifier.get_alert_notifier")
+    def test_quota_alert_still_works(self, mock_get_notifier):
+        """Existing quota alert function should continue to work."""
+        mock_notifier = MagicMock()
+        mock_alert = MagicMock(spec=Alert)
+        mock_notifier.create_alert.return_value = mock_alert
+        mock_get_notifier.return_value = mock_notifier
+
+        # Test quota alert at 95%
+        result = create_quota_alert(
+            user_id=1,
+            username="testuser",
+            usage_percent=95.0,
+            quota_type="tokens",
+        )
+
+        call_kwargs = mock_notifier.create_alert.call_args.kwargs
+        assert call_kwargs["severity"] == AlertSeverity.CRITICAL.value
+        assert call_kwargs["alert_type"] == AlertType.QUOTA.value


### PR DESCRIPTION
## 修复说明

关联 Issue：#1489

## 根因

告警系统的严重程度（severity）判定机制不一致：
- 配额告警：有明确的自动判定逻辑（基于 usage_percent）
- 系统告警：需要手动指定 severity，无判定指导
- 安全告警：需要手动指定 severity，无判定指导

## 修复方案

添加场景专用告警创建函数，内置正确的 severity 判定：

### 系统告警场景函数
- \`create_service_down_alert\`: 服务宕机告警 → CRITICAL
- \`create_service_startup_alert\`: 服务启动异常告警 → WARNING/CRITICAL（基于启动时间）
- \`create_resource_alert\`: 资源不足告警 → INFO/WARNING/CRITICAL（基于使用率）
- \`create_config_error_alert\`: 配置错误告警 → WARNING
- \`create_api_error_alert\`: API 调用异常告警 → WARNING

### 安全告警场景函数
- \`create_auth_failure_alert\`: 认证失败告警 → WARNING/CRITICAL（基于失败次数）
- \`create_permission_violation_alert\`: 权限违规告警 → CRITICAL
- \`create_suspicious_activity_alert\`: 可疑行为检测告警 → WARNING/CRITICAL（基于风险评分）

每个函数包含详细的文档注释，说明 severity 判定逻辑和使用指南。

## 主要变更

- \`app/modules/governance/alert_notifier.py\`: 添加 8 个场景专用告警函数
- \`tests/test_scene_specific_alerts.py\`: 新增单元测试（16 个测试用例）

## 测试

- 测试执行位置：本地开发环境
- 已运行测试：pytest tests/test_scene_specific_alerts.py -v
- 新增测试：16 个测试用例全部通过
- 回归测试：create_quota_alert 函数仍正常工作

## 风险

- 兼容性风险：无（新增函数不修改现有 API）
- 性能风险：无（仅做 severity 计算，无额外开销）
- 安全风险：无（不改变告警创建的安全机制）
- 回归风险：低（改动集中在 alert_notifier.py，回归测试通过）
