### PR TITLE
fix(i18n): 合规报告页面已保存报告时间段显示未国际化 (Issue #1486)

### DIFF
--- a/frontend/src/components/features/management/ComplianceMgmt.tsx
+++ b/frontend/src/components/features/management/ComplianceMgmt.tsx
@@ -28,7 +28,7 @@ import {
 import { useConfirm } from '@/components/common';
 import { ReportPreviewModal } from './ReportPreviewModal';
 import { CleanupPreviewContent } from '@/components/features/compliance/CleanupPreviewContent';
-import { formatDateTime, createMatcherConfig } from '@/utils';
+import { formatDate, formatDateTime, createMatcherConfig } from '@/utils';
 import { getReportTypeName, getReportTypeDesc } from '@/utils/compliance';
 import {
   complianceApi,
@@ -588,11 +588,12 @@ export const ComplianceMgmt: React.FC = () => {
                         </Badge>
                       </td>
                       <td>
-                        <small>{formatDateTime(report.generated_at)}</small>
+                        <small>{formatDateTime(report.generated_at, language)}</small>
                       </td>
                       <td>
                         <small>
-                          {report.period_start} - {report.period_end}
+                          {formatDate(report.period_start, 'short', language)} -{' '}
+                          {formatDate(report.period_end, 'short', language)}
                         </small>
                       </td>
                       <td>
@@ -840,7 +841,7 @@ export const ComplianceMgmt: React.FC = () => {
                 <tbody>
                   {history.map((h, index) => (
                     <tr key={index}>
-                      <td>{formatDateTime(h.executed_at)}</td>
+                      <td>{formatDateTime(h.executed_at, language)}</td>
                       <td>{h.cleanup_type}</td>
                       <td>{h.records_deleted.toLocaleString()}</td>
                       <td>

--- a/frontend/src/utils/format.test.ts
+++ b/frontend/src/utils/format.test.ts
@@ -88,6 +88,35 @@ describe('formatDate', () => {
   it('should handle string dates', () => {
     expect(formatDate('2024-03-15', 'iso')).toBe('2024-03-15');
   });
+
+  it('should localize per language when language is provided', () => {
+    const langs = ['en', 'zh', 'ja', 'ko'] as const;
+    for (const lang of langs) {
+      const result = formatDate('2024-03-15', 'short', lang);
+      // Day-of-month and year must always be present
+      expect(result).toMatch(/15/);
+      expect(result).toMatch(/2024/);
+    }
+  });
+
+  it('should render long format with the UI language locale', () => {
+    // zh-CN long format contains the CJK numeral for year, e.g. "2024年3月15日"
+    const result = formatDate('2024-03-15', 'long', 'zh');
+    expect(result).toMatch(/15/);
+    expect(result).toMatch(/2024/);
+    expect(result).toMatch(/年/);
+  });
+
+  it('should ignore language for ISO format (stable machine-readable output)', () => {
+    expect(formatDate('2024-03-15', 'iso', 'zh')).toBe('2024-03-15');
+  });
+
+  it('should fall back to browser locale when language is omitted', () => {
+    // No language argument — behaves exactly as before the i18n change.
+    const result = formatDate('2024-03-15');
+    expect(result).toMatch(/15/);
+    expect(result).toMatch(/2024/);
+  });
 });
 
 describe('formatDateTime', () => {
@@ -96,6 +125,30 @@ describe('formatDateTime', () => {
     const result = formatDateTime(date);
     expect(result).toMatch(/2024/);
     expect(result).toMatch(/15/);
+  });
+
+  it('should return "-" for null/empty values', () => {
+    expect(formatDateTime(null)).toBe('-');
+    expect(formatDateTime('')).toBe('-');
+  });
+
+  it('should return "-" for invalid dates', () => {
+    expect(formatDateTime('not-a-date')).toBe('-');
+  });
+
+  it('should localize per language when language is provided', () => {
+    const langs = ['en', 'zh', 'ja', 'ko'] as const;
+    for (const lang of langs) {
+      const result = formatDateTime('2024-03-15T14:30:00', lang);
+      expect(result).toMatch(/15/);
+      expect(result).toMatch(/2024/);
+    }
+  });
+
+  it('should fall back to browser locale when language is omitted', () => {
+    const result = formatDateTime('2024-03-15T14:30:00');
+    expect(result).toMatch(/15/);
+    expect(result).toMatch(/2024/);
   });
 });
 

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -60,37 +60,48 @@ export function formatPercentage(value: number, decimals: number = 1): string {
 }
 
 /**
- * Format a date string
+ * Format a date string.
+ *
+ * When `language` is provided, the date is rendered with the locale that
+ * matches the active UI language (e.g. zh → zh-CN). Otherwise the host
+ * browser locale is used, preserving backward compatibility.
  */
 export function formatDate(
   date: string | Date,
-  format: 'short' | 'long' | 'iso' = 'short'
+  format: 'short' | 'long' | 'iso' = 'short',
+  language?: Language
 ): string {
   const d = typeof date === 'string' ? new Date(date) : date;
+  const locale = language ? DATE_LOCALE[language] : undefined;
 
   switch (format) {
     case 'iso':
       return d.toISOString().split('T')[0];
     case 'long':
-      return d.toLocaleDateString(undefined, {
+      return d.toLocaleDateString(locale, {
         year: 'numeric',
         month: 'long',
         day: 'numeric',
       });
     case 'short':
     default:
-      return d.toLocaleDateString();
+      return d.toLocaleDateString(locale);
   }
 }
 
 /**
- * Format a datetime string
+ * Format a datetime string.
+ *
+ * When `language` is provided, the value is rendered with the locale that
+ * matches the active UI language. Otherwise the host browser locale is used,
+ * preserving backward compatibility.
  */
-export function formatDateTime(date: string | Date | null): string {
+export function formatDateTime(date: string | Date | null, language?: Language): string {
   if (!date) return '-';
   const d = typeof date === 'string' ? new Date(date) : date;
   if (isNaN(d.getTime())) return '-';
-  return d.toLocaleString();
+  const locale = language ? DATE_LOCALE[language] : undefined;
+  return d.toLocaleString(locale);
 }
 
 /**
@@ -193,8 +204,8 @@ export function formatDuration(seconds: number): string {
   }
 }
 
-// Locale tag per supported UI language, for chart date rendering.
-const CHART_DATE_LOCALE: Record<Language, string> = {
+// Locale tag per supported UI language, shared across date rendering helpers.
+const DATE_LOCALE: Record<Language, string> = {
   en: 'en-US',
   zh: 'zh-CN',
   ja: 'ja-JP',
@@ -247,7 +258,7 @@ export function formatChartDate(
   if (!parts) return '-';
   const d = new Date(parts.year, parts.month - 1, parts.day);
   if (isNaN(d.getTime())) return '-';
-  const locale = CHART_DATE_LOCALE[language] ?? 'en-US';
+  const locale = DATE_LOCALE[language] ?? 'en-US';
   return d.toLocaleDateString(locale, {
     day: 'numeric',
     ...(options.dayOnly ? {} : { month: 'short' }),


### PR DESCRIPTION
## 问题描述

Fixes #1486

合规管理页面（`/manage/compliance`）的已保存报告表格中，"时间段"列直接显示 API 返回的 ISO 日期字符串（如 `2024-01-01`），未根据用户界面语言进行本地化格式化，导致中文界面下显示英文日期格式。

## 修复内容

### 1. 扩展日期格式化工具 (`frontend/src/utils/format.ts`)

- `formatDate(date, format, language?)` — 新增可选 `language` 参数，传入时按 UI 语言选择对应 locale（zh→zh-CN、ja→ja-JP、ko→ko-KR、en→en-US）渲染日期；省略时回退到浏览器 locale，完全向后兼容。
- `formatDateTime(date, language?)` — 同样支持可选 `language` 参数。
- ISO 格式不受 `language` 影响，保持机器可读输出稳定。
- 将 `CHART_DATE_LOCALE` 重命名为共享的 `DATE_LOCALE`，供所有日期格式化函数共用同一 locale 映射，消除重复。

### 2. 更新合规管理组件 (`ComplianceMgmt.tsx`)

- **时间段列**（主要修复）：`{report.period_start} - {report.period_end}` → `{formatDate(report.period_start, 'short', language)} - {formatDate(report.period_end, 'short', language)}`
- **生成时间列**：`formatDateTime(report.generated_at)` → `formatDateTime(report.generated_at, language)`（同一表格内相同的 i18n 问题）
- **清理历史执行时间列**：`formatDateTime(h.executed_at)` → `formatDateTime(h.executed_at, language)`

### 3. 新增测试 (`frontend/src/utils/format.test.ts`)

为 `formatDate` 和 `formatDateTime` 增加了语言本地化、空值/无效输入回退、向后兼容性的测试用例。

## 验证

- ✅ 全部 50 条 format 测试通过
- ✅ TypeScript 类型检查 (`tsc --noEmit`) 通过
- ✅ ESLint 检查通过

## 预期行为

| 语言 | 修复前 | 修复后 |
|------|--------|--------|
| 中文 | `2024-01-01 - 2024-01-31` | `2024/1/1 - 2024/1/31` |
| 英文 | `2024-01-01 - 2024-01-31` | `1/1/2024 - 1/31/2024` |
| 日文 | `2024-01-01 - 2024-01-31` | `2024/01/01 - 2024/01/31` |
| 韩文 | `2024-01-01 - 2024-01-31` | `2024. 1. 1. - 2024. 1. 31.` |