### PR TITLE
fix: formatTokens 函数支持负数格式化 (Issue #1487)

### DIFF
--- a/frontend/src/utils/format.test.ts
+++ b/frontend/src/utils/format.test.ts
@@ -43,6 +43,40 @@ describe('formatTokens', () => {
     expect(formatTokens(1_000_000)).toBe('1.00M');
     expect(formatTokens(1_000_000_000)).toBe('1.00B');
   });
+
+  // Negative number tests (Issue #1487)
+  it('should format negative billions correctly', () => {
+    expect(formatTokens(-3_500_000_000)).toBe('-3.50B');
+    expect(formatTokens(-1_500_000_000)).toBe('-1.50B');
+  });
+
+  it('should format negative millions correctly', () => {
+    expect(formatTokens(-1_500_000)).toBe('-1.50M');
+    expect(formatTokens(-2_000_000)).toBe('-2.00M');
+  });
+
+  it('should format negative thousands correctly', () => {
+    expect(formatTokens(-5_000)).toBe('-5.00K');
+    expect(formatTokens(-1_000)).toBe('-1.00K');
+  });
+
+  it('should format small negative numbers without suffix', () => {
+    expect(formatTokens(-100)).toBe('-100');
+    expect(formatTokens(-999)).toBe('-999');
+    expect(formatTokens(-500)).toBe('-500');
+  });
+
+  it('should handle negative zero correctly', () => {
+    // In JavaScript, -0 === 0, so -0 < 0 is false, sign is empty
+    expect(formatTokens(-0)).toBe('0');
+  });
+
+  it('should handle negative edge cases', () => {
+    // Just below thresholds
+    expect(formatTokens(-999_999_999)).toBe('-1000.00M'); // Just below 1B
+    expect(formatTokens(-1_000)).toBe('-1.00K'); // Exact threshold
+    expect(formatTokens(-999)).toBe('-999'); // Just below 1K
+  });
 });
 
 describe('formatNumber', () => {

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -14,6 +14,7 @@ const MAX_CACHE_SIZE = 1000; // Limit cache size to prevent memory issues
 /**
  * Format a number of tokens with K/M/B suffixes
  * Cached for performance - same values return cached results
+ * Supports negative numbers by using absolute value for formatting
  */
 export function formatTokens(tokens: number): string {
   // Ensure numeric type - API may return strings in some cases
@@ -25,14 +26,18 @@ export function formatTokens(tokens: number): string {
     return cached;
   }
 
+  // Handle negative numbers by using absolute value
+  const absValue = Math.abs(numTokens);
+  const sign = numTokens < 0 ? '-' : '';
+
   // Calculate result
   let result: string;
-  if (numTokens >= 1_000_000_000) {
-    result = (numTokens / 1_000_000_000).toFixed(2) + 'B';
-  } else if (numTokens >= 1_000_000) {
-    result = (numTokens / 1_000_000).toFixed(2) + 'M';
-  } else if (numTokens >= 1_000) {
-    result = (numTokens / 1_000).toFixed(2) + 'K';
+  if (absValue >= 1_000_000_000) {
+    result = sign + (absValue / 1_000_000_000).toFixed(2) + 'B';
+  } else if (absValue >= 1_000_000) {
+    result = sign + (absValue / 1_000_000).toFixed(2) + 'M';
+  } else if (absValue >= 1_000) {
+    result = sign + (absValue / 1_000).toFixed(2) + 'K';
   } else {
     result = numTokens.toString();
   }


### PR DESCRIPTION
## 修复说明

关联 Issue：#1487

## 根因

`formatTokens` 函数使用 `>=` 条件判断数值范围，负数不满足任何条件分支（如 `-3500000000 >= 1_000_000_000` 为 false），最终返回原始字符串而非格式化值。

## 修复方案

使用 `Math.abs()` 计算绝对值进行范围判断，保留原始负号：
- `absValue = Math.abs(numTokens)`
- `sign = numTokens < 0 ? '-' : ''`
- 格式化结果拼接：`sign + (absValue / threshold).toFixed(2) + suffix`

正数逻辑完全不变，缓存机制无需调整。

## 主要变更

- `frontend/src/utils/format.ts`: 添加绝对值判断逻辑
- `frontend/src/utils/format.test.ts`: 新增 6 个负数测试用例

## 测试

- 本地 Node.js 验证通过：
  - `-3500000000` → `-3.50B` ✓
  - `-1500000` → `-1.50M` ✓
  - `-5000` → `-5.00K` ✓
  - `-500` → `-500` ✓
  - `-0` → `0` ✓
  - 正数回归：`3500000000` → `3.50B` ✓

- 新增测试覆盖：负 billions、负 millions、负 thousands、小负数、负零、边界值

## 风险

- 兼容性风险：无（正数格式化行为完全不变）
- 性能风险：无（仅增加 O(1) Math.abs 计算）
- 安全风险：无
- 回归风险：无（正数逻辑和缓存机制不变）