### PR TITLE
feat(governance): add scene-specific alert functions with automatic severity (Issue #1489)

### DIFF
--- a/app/modules/governance/__init__.py
+++ b/app/modules/governance/__init__.py
@@ -5,17 +5,57 @@ Enterprise governance features including:
 - Audit logging
 - Content filtering
 - Quota management
+- Alert notification
 """
 
 from app.modules.governance.audit_logger import AuditLog, AuditLogger
 from app.modules.governance.content_filter import ContentFilter, FilterResult
 from app.modules.governance.quota_manager import QuotaAlert, QuotaManager
+from app.modules.governance.alert_notifier import (
+    AlertNotifier,
+    Alert,
+    AlertType,
+    AlertSeverity,
+    NotificationPreference,
+    create_quota_alert,
+    create_system_alert,
+    create_security_alert,
+    # Scene-specific alert functions (Issue #1489)
+    create_service_down_alert,
+    create_resource_alert,
+    create_config_error_alert,
+    create_api_error_alert,
+    create_auth_failure_alert,
+    create_permission_violation_alert,
+    create_suspicious_activity_alert,
+)
 
 __all__ = [
+    # Audit logging
     "AuditLogger",
     "AuditLog",
+    # Content filtering
     "ContentFilter",
     "FilterResult",
+    # Quota management
     "QuotaManager",
     "QuotaAlert",
+    # Alert notification
+    "AlertNotifier",
+    "Alert",
+    "AlertType",
+    "AlertSeverity",
+    "NotificationPreference",
+    # Alert creation functions
+    "create_quota_alert",
+    "create_system_alert",
+    "create_security_alert",
+    # Scene-specific alert functions (Issue #1489)
+    "create_service_down_alert",
+    "create_resource_alert",
+    "create_config_error_alert",
+    "create_api_error_alert",
+    "create_auth_failure_alert",
+    "create_permission_violation_alert",
+    "create_suspicious_activity_alert",
 ]

--- a/app/modules/governance/alert_notifier.py
+++ b/app/modules/governance/alert_notifier.py
@@ -1061,8 +1061,8 @@ def create_resource_alert(
 
     Args:
         resource_type: Type of resource (e.g., "memory", "cpu", "disk", "connections").
-        current: Current usage value.
-        limit: Maximum limit value.
+        current: Current usage value (must be non-negative).
+        limit: Maximum limit value (must be positive).
         threshold_warning: Warning threshold as ratio (default 0.8 = 80%).
         threshold_critical: Critical threshold as ratio (default 0.95 = 95%).
         language: Language for email notification (en, zh, ja, ko).
@@ -1070,10 +1070,19 @@ def create_resource_alert(
 
     Returns:
         Alert: The created alert with automatically determined severity.
+
+    Raises:
+        ValueError: If limit is not positive or current is negative.
     """
+    # Validate parameters
+    if limit <= 0:
+        raise ValueError(f"limit must be positive, got {limit}")
+    if current < 0:
+        raise ValueError(f"current must be non-negative, got {current}")
+
     notifier = get_alert_notifier()
-    usage_percent = (current / limit) * 100 if limit > 0 else 0
-    usage_ratio = current / limit if limit > 0 else 0
+    usage_percent = (current / limit) * 100
+    usage_ratio = current / limit
 
     if usage_ratio >= threshold_critical:
         severity = AlertSeverity.CRITICAL.value
@@ -1336,7 +1345,14 @@ def create_suspicious_activity_alert(
 
     Returns:
         Alert: The created alert with automatically determined severity.
+
+    Raises:
+        ValueError: If risk_score is not in range [0, 100].
     """
+    # Validate risk_score range
+    if not (0 <= risk_score <= 100):
+        raise ValueError(f"risk_score must be between 0 and 100, got {risk_score}")
+
     notifier = get_alert_notifier()
 
     # Risk score threshold: 50

--- a/app/modules/governance/alert_notifier.py
+++ b/app/modules/governance/alert_notifier.py
@@ -992,3 +992,382 @@ def create_security_alert(
         username=username,
         language=language,
     )
+
+
+# =============================================================================
+# Scene-Specific Alert Functions (Issue #1489)
+# =============================================================================
+# These functions encapsulate severity judgment logic for common scenarios,
+# providing developers with easy-to-use APIs without needing to understand
+# severity determination details.
+
+
+def create_service_down_alert(
+    service_name: str,
+    details: str,
+    language: str = "en",
+    user_id: Optional[int] = None,
+) -> Alert:
+    """
+    Create a service down alert with critical severity.
+
+    Used when a critical service becomes unavailable or crashes.
+
+    Args:
+        service_name: Name of the service that is down.
+        details: Details about the failure (error message, cause, etc.).
+        language: Language for email notification (en, zh, ja, ko).
+        user_id: Optional target user ID for the alert.
+
+    Returns:
+        Alert: The created alert with severity=critical.
+    """
+    notifier = get_alert_notifier()
+    title = f"Service Down: {service_name}"
+    message = f"The service '{service_name}' is unavailable. Details: {details}"
+
+    return notifier.create_alert(
+        alert_type=AlertType.SYSTEM.value,
+        severity=AlertSeverity.CRITICAL.value,
+        title=title,
+        message=message,
+        user_id=user_id,
+        metadata={
+            "service_name": service_name,
+            "details": details,
+        },
+        action_url="/admin/services",
+        action_text="View Services",
+        language=language,
+    )
+
+
+def create_resource_alert(
+    resource_type: str,
+    current: float,
+    limit: float,
+    threshold_warning: float = 0.8,
+    threshold_critical: float = 0.95,
+    language: str = "en",
+    user_id: Optional[int] = None,
+) -> Alert:
+    """
+    Create a resource shortage alert with automatic severity determination.
+
+    Severity is automatically determined based on usage percentage:
+    - usage >= threshold_critical (95%): critical
+    - usage >= threshold_warning (80%): warning
+    - usage < threshold_warning: info
+
+    Args:
+        resource_type: Type of resource (e.g., "memory", "cpu", "disk", "connections").
+        current: Current usage value.
+        limit: Maximum limit value.
+        threshold_warning: Warning threshold as ratio (default 0.8 = 80%).
+        threshold_critical: Critical threshold as ratio (default 0.95 = 95%).
+        language: Language for email notification (en, zh, ja, ko).
+        user_id: Optional target user ID for the alert.
+
+    Returns:
+        Alert: The created alert with automatically determined severity.
+    """
+    notifier = get_alert_notifier()
+    usage_percent = (current / limit) * 100 if limit > 0 else 0
+    usage_ratio = current / limit if limit > 0 else 0
+
+    if usage_ratio >= threshold_critical:
+        severity = AlertSeverity.CRITICAL.value
+        title = f"Resource Critical: {resource_type.title()}"
+        message = (
+            f"Resource '{resource_type}' is critically low. "
+            f"Current usage: {usage_percent:.1f}% ({current:.2f}/{limit:.2f}). "
+            f"Immediate action required."
+        )
+    elif usage_ratio >= threshold_warning:
+        severity = AlertSeverity.WARNING.value
+        title = f"Resource Warning: {resource_type.title()}"
+        message = (
+            f"Resource '{resource_type}' is approaching limit. "
+            f"Current usage: {usage_percent:.1f}% ({current:.2f}/{limit:.2f})."
+        )
+    else:
+        severity = AlertSeverity.INFO.value
+        title = f"Resource Notice: {resource_type.title()}"
+        message = (
+            f"Resource '{resource_type}' usage is normal. "
+            f"Current usage: {usage_percent:.1f}% ({current:.2f}/{limit:.2f})."
+        )
+
+    return notifier.create_alert(
+        alert_type=AlertType.SYSTEM.value,
+        severity=severity,
+        title=title,
+        message=message,
+        user_id=user_id,
+        metadata={
+            "resource_type": resource_type,
+            "usage_percent": usage_percent,
+            "current": current,
+            "limit": limit,
+            "threshold_warning": threshold_warning,
+            "threshold_critical": threshold_critical,
+        },
+        action_url="/admin/resources",
+        action_text="View Resources",
+        language=language,
+    )
+
+
+def create_config_error_alert(
+    config_key: str,
+    error_details: str,
+    language: str = "en",
+    user_id: Optional[int] = None,
+) -> Alert:
+    """
+    Create a configuration error alert with warning severity.
+
+    Used when a configuration setting is invalid, missing, or causes issues.
+
+    Args:
+        config_key: The configuration key that has the error.
+        error_details: Details about the configuration error.
+        language: Language for email notification (en, zh, ja, ko).
+        user_id: Optional target user ID for the alert.
+
+    Returns:
+        Alert: The created alert with severity=warning.
+    """
+    notifier = get_alert_notifier()
+    title = f"Configuration Error: {config_key}"
+    message = (
+        f"Configuration '{config_key}' has an error. "
+        f"Details: {error_details}. Please review and fix the configuration."
+    )
+
+    return notifier.create_alert(
+        alert_type=AlertType.SYSTEM.value,
+        severity=AlertSeverity.WARNING.value,
+        title=title,
+        message=message,
+        user_id=user_id,
+        metadata={
+            "config_key": config_key,
+            "error_type": "config_error",
+            "error_details": error_details,
+        },
+        action_url="/admin/config",
+        action_text="View Config",
+        language=language,
+    )
+
+
+def create_api_error_alert(
+    api_name: str,
+    error_code: int,
+    error_message: str,
+    language: str = "en",
+    user_id: Optional[int] = None,
+) -> Alert:
+    """
+    Create an API error alert with warning severity.
+
+    Used when an external API call fails with an error.
+
+    Args:
+        api_name: Name of the API that failed.
+        error_code: HTTP error code or API-specific error code.
+        error_message: Error message from the API.
+        language: Language for email notification (en, zh, ja, ko).
+        user_id: Optional target user ID for the alert.
+
+    Returns:
+        Alert: The created alert with severity=warning.
+    """
+    notifier = get_alert_notifier()
+    title = f"API Error: {api_name}"
+    message = (
+        f"API '{api_name}' returned an error. "
+        f"Error code: {error_code}. Message: {error_message}."
+    )
+
+    return notifier.create_alert(
+        alert_type=AlertType.SYSTEM.value,
+        severity=AlertSeverity.WARNING.value,
+        title=title,
+        message=message,
+        user_id=user_id,
+        metadata={
+            "api_name": api_name,
+            "error_code": error_code,
+            "error_message": error_message,
+        },
+        action_url="/admin/api-status",
+        action_text="View API Status",
+        language=language,
+    )
+
+
+def create_auth_failure_alert(
+    username: str,
+    failure_count: int,
+    threshold: int = 5,
+    language: str = "en",
+    user_id: Optional[int] = None,
+) -> Alert:
+    """
+    Create an authentication failure alert with automatic severity determination.
+
+    Severity is automatically determined based on failure count:
+    - failure_count < threshold: warning (single or few failures)
+    - failure_count >= threshold: critical (repeated failures, potential attack)
+
+    Args:
+        username: Username that failed authentication.
+        failure_count: Number of consecutive failed attempts.
+        threshold: Threshold for upgrading to critical (default 5).
+        language: Language for email notification (en, zh, ja, ko).
+        user_id: Optional target user ID for the alert.
+
+    Returns:
+        Alert: The created alert with automatically determined severity.
+    """
+    notifier = get_alert_notifier()
+
+    if failure_count >= threshold:
+        severity = AlertSeverity.CRITICAL.value
+        title = f"Repeated Authentication Failures: {username}"
+        message = (
+            f"User '{username}' has {failure_count} consecutive authentication failures. "
+            f"This exceeds the threshold of {threshold} and may indicate a security threat."
+        )
+    else:
+        severity = AlertSeverity.WARNING.value
+        title = f"Authentication Failure: {username}"
+        message = (
+            f"User '{username}' failed authentication. "
+            f"Failure count: {failure_count} (threshold: {threshold})."
+        )
+
+    return notifier.create_alert(
+        alert_type=AlertType.SECURITY.value,
+        severity=severity,
+        title=title,
+        message=message,
+        user_id=user_id,
+        username=username,
+        metadata={
+            "failure_count": failure_count,
+            "threshold": threshold,
+        },
+        action_url="/settings/security",
+        action_text="View Security",
+        language=language,
+    )
+
+
+def create_permission_violation_alert(
+    username: str,
+    resource: str,
+    action: str,
+    language: str = "en",
+    user_id: Optional[int] = None,
+) -> Alert:
+    """
+    Create a permission violation alert with critical severity.
+
+    Used when a user attempts to access a resource or perform an action
+    without proper permissions.
+
+    Args:
+        username: Username that attempted the unauthorized action.
+        resource: Resource that was accessed.
+        action: Action that was attempted (e.g., "read", "write", "delete").
+        language: Language for email notification (en, zh, ja, ko).
+        user_id: Optional target user ID for the alert.
+
+    Returns:
+        Alert: The created alert with severity=critical.
+    """
+    notifier = get_alert_notifier()
+    title = f"Permission Violation: {username}"
+    message = (
+        f"User '{username}' attempted unauthorized action '{action}' "
+        f"on resource '{resource}'. This is a security violation."
+    )
+
+    return notifier.create_alert(
+        alert_type=AlertType.SECURITY.value,
+        severity=AlertSeverity.CRITICAL.value,
+        title=title,
+        message=message,
+        user_id=user_id,
+        username=username,
+        metadata={
+            "resource": resource,
+            "action": action,
+        },
+        action_url="/audit",
+        action_text="View Audit Log",
+        language=language,
+    )
+
+
+def create_suspicious_activity_alert(
+    username: str,
+    activity_type: str,
+    risk_score: float,
+    language: str = "en",
+    user_id: Optional[int] = None,
+) -> Alert:
+    """
+    Create a suspicious activity alert with automatic severity determination.
+
+    Severity is automatically determined based on risk score (0-100):
+    - risk_score < 50: warning (moderate risk)
+    - risk_score >= 50: critical (high risk)
+
+    Args:
+        username: Username associated with the suspicious activity.
+        activity_type: Type of suspicious activity detected.
+        risk_score: Risk score from 0 to 100 (higher = more risky).
+        language: Language for email notification (en, zh, ja, ko).
+        user_id: Optional target user ID for the alert.
+
+    Returns:
+        Alert: The created alert with automatically determined severity.
+    """
+    notifier = get_alert_notifier()
+
+    # Risk score threshold: 50
+    if risk_score >= 50:
+        severity = AlertSeverity.CRITICAL.value
+        title = f"High-Risk Suspicious Activity: {username}"
+        message = (
+            f"High-risk suspicious activity detected for user '{username}'. "
+            f"Activity type: {activity_type}. Risk score: {risk_score:.1f}/100. "
+            f"Immediate investigation recommended."
+        )
+    else:
+        severity = AlertSeverity.WARNING.value
+        title = f"Suspicious Activity Detected: {username}"
+        message = (
+            f"Suspicious activity detected for user '{username}'. "
+            f"Activity type: {activity_type}. Risk score: {risk_score:.1f}/100."
+        )
+
+    return notifier.create_alert(
+        alert_type=AlertType.SECURITY.value,
+        severity=severity,
+        title=title,
+        message=message,
+        user_id=user_id,
+        username=username,
+        metadata={
+            "activity_type": activity_type,
+            "risk_score": risk_score,
+        },
+        action_url="/audit",
+        action_text="View Audit Log",
+        language=language,
+    )

--- a/tests/unit/test_alert_notifier.py
+++ b/tests/unit/test_alert_notifier.py
@@ -1,0 +1,332 @@
+"""Unit tests for AlertNotifier module - Scene-specific alert functions (Issue #1489)."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.modules.governance.alert_notifier import (
+    AlertNotifier,
+    AlertSeverity,
+    AlertType,
+    create_service_down_alert,
+    create_resource_alert,
+    create_config_error_alert,
+    create_api_error_alert,
+    create_auth_failure_alert,
+    create_permission_violation_alert,
+    create_suspicious_activity_alert,
+)
+
+
+class TestCreateServiceDownAlert:
+    """Test create_service_down_alert function."""
+
+    @patch("app.modules.governance.alert_notifier.get_alert_notifier")
+    def test_creates_critical_alert(self, mock_get_notifier):
+        mock_notifier = MagicMock()
+        mock_get_notifier.return_value = mock_notifier
+
+        create_service_down_alert(
+            service_name="api-server",
+            details="Connection timeout after 30 seconds",
+        )
+
+        mock_notifier.create_alert.assert_called_once()
+        call_args = mock_notifier.create_alert.call_args
+
+        assert call_args.kwargs["alert_type"] == AlertType.SYSTEM.value
+        assert call_args.kwargs["severity"] == AlertSeverity.CRITICAL.value
+        assert "api-server" in call_args.kwargs["title"]
+        assert call_args.kwargs["metadata"]["service_name"] == "api-server"
+
+    @patch("app.modules.governance.alert_notifier.get_alert_notifier")
+    def test_with_user_id(self, mock_get_notifier):
+        mock_notifier = MagicMock()
+        mock_get_notifier.return_value = mock_notifier
+
+        create_service_down_alert(
+            service_name="database",
+            details="Connection refused",
+            user_id=123,
+        )
+
+        call_args = mock_notifier.create_alert.call_args
+        assert call_args.kwargs["user_id"] == 123
+
+
+class TestCreateResourceAlert:
+    """Test create_resource_alert function with automatic severity."""
+
+    @patch("app.modules.governance.alert_notifier.get_alert_notifier")
+    def test_critical_threshold(self, mock_get_notifier):
+        mock_notifier = MagicMock()
+        mock_get_notifier.return_value = mock_notifier
+
+        create_resource_alert(
+            resource_type="memory",
+            current=9.5,
+            limit=10.0,
+        )
+
+        call_args = mock_notifier.create_alert.call_args
+        # 95% usage >= 0.95 threshold -> critical
+        assert call_args.kwargs["severity"] == AlertSeverity.CRITICAL.value
+        assert "Critical" in call_args.kwargs["title"]
+
+    @patch("app.modules.governance.alert_notifier.get_alert_notifier")
+    def test_warning_threshold(self, mock_get_notifier):
+        mock_notifier = MagicMock()
+        mock_get_notifier.return_value = mock_notifier
+
+        create_resource_alert(
+            resource_type="cpu",
+            current=8.0,
+            limit=10.0,
+        )
+
+        call_args = mock_notifier.create_alert.call_args
+        # 80% usage >= 0.8 threshold -> warning
+        assert call_args.kwargs["severity"] == AlertSeverity.WARNING.value
+        assert "Warning" in call_args.kwargs["title"]
+
+    @patch("app.modules.governance.alert_notifier.get_alert_notifier")
+    def test_info_below_threshold(self, mock_get_notifier):
+        mock_notifier = MagicMock()
+        mock_get_notifier.return_value = mock_notifier
+
+        create_resource_alert(
+            resource_type="disk",
+            current=5.0,
+            limit=10.0,
+        )
+
+        call_args = mock_notifier.create_alert.call_args
+        # 50% usage < 0.8 threshold -> info
+        assert call_args.kwargs["severity"] == AlertSeverity.INFO.value
+        assert "Notice" in call_args.kwargs["title"]
+
+    @patch("app.modules.governance.alert_notifier.get_alert_notifier")
+    def test_custom_thresholds(self, mock_get_notifier):
+        mock_notifier = MagicMock()
+        mock_get_notifier.return_value = mock_notifier
+
+        create_resource_alert(
+            resource_type="connections",
+            current=50,
+            limit=100,
+            threshold_warning=0.4,
+            threshold_critical=0.6,
+        )
+
+        call_args = mock_notifier.create_alert.call_args
+        # 50% usage >= 0.4 (warning) but < 0.6 (critical) -> warning
+        assert call_args.kwargs["severity"] == AlertSeverity.WARNING.value
+
+    @patch("app.modules.governance.alert_notifier.get_alert_notifier")
+    def test_metadata_contains_usage_info(self, mock_get_notifier):
+        mock_notifier = MagicMock()
+        mock_get_notifier.return_value = mock_notifier
+
+        create_resource_alert(
+            resource_type="memory",
+            current=8.5,
+            limit=10.0,
+        )
+
+        call_args = mock_notifier.create_alert.call_args
+        metadata = call_args.kwargs["metadata"]
+        assert metadata["resource_type"] == "memory"
+        assert metadata["current"] == 8.5
+        assert metadata["limit"] == 10.0
+        assert "usage_percent" in metadata
+
+
+class TestCreateConfigErrorAlert:
+    """Test create_config_error_alert function."""
+
+    @patch("app.modules.governance.alert_notifier.get_alert_notifier")
+    def test_creates_warning_alert(self, mock_get_notifier):
+        mock_notifier = MagicMock()
+        mock_get_notifier.return_value = mock_notifier
+
+        create_config_error_alert(
+            config_key="database.url",
+            error_details="Invalid connection string format",
+        )
+
+        call_args = mock_notifier.create_alert.call_args
+        assert call_args.kwargs["alert_type"] == AlertType.SYSTEM.value
+        assert call_args.kwargs["severity"] == AlertSeverity.WARNING.value
+        assert "database.url" in call_args.kwargs["title"]
+        assert call_args.kwargs["metadata"]["config_key"] == "database.url"
+
+
+class TestCreateApiErrorAlert:
+    """Test create_api_error_alert function."""
+
+    @patch("app.modules.governance.alert_notifier.get_alert_notifier")
+    def test_creates_warning_alert(self, mock_get_notifier):
+        mock_notifier = MagicMock()
+        mock_get_notifier.return_value = mock_notifier
+
+        create_api_error_alert(
+            api_name="openai",
+            error_code=500,
+            error_message="Internal server error",
+        )
+
+        call_args = mock_notifier.create_alert.call_args
+        assert call_args.kwargs["alert_type"] == AlertType.SYSTEM.value
+        assert call_args.kwargs["severity"] == AlertSeverity.WARNING.value
+        assert "openai" in call_args.kwargs["title"]
+        assert call_args.kwargs["metadata"]["error_code"] == 500
+
+
+class TestCreateAuthFailureAlert:
+    """Test create_auth_failure_alert function with automatic severity."""
+
+    @patch("app.modules.governance.alert_notifier.get_alert_notifier")
+    def test_warning_below_threshold(self, mock_get_notifier):
+        mock_notifier = MagicMock()
+        mock_get_notifier.return_value = mock_notifier
+
+        create_auth_failure_alert(
+            username="testuser",
+            failure_count=2,
+            threshold=5,
+        )
+
+        call_args = mock_notifier.create_alert.call_args
+        assert call_args.kwargs["severity"] == AlertSeverity.WARNING.value
+        assert call_args.kwargs["username"] == "testuser"
+
+    @patch("app.modules.governance.alert_notifier.get_alert_notifier")
+    def test_critical_at_threshold(self, mock_get_notifier):
+        mock_notifier = MagicMock()
+        mock_get_notifier.return_value = mock_notifier
+
+        create_auth_failure_alert(
+            username="attacker",
+            failure_count=5,
+            threshold=5,
+        )
+
+        call_args = mock_notifier.create_alert.call_args
+        assert call_args.kwargs["severity"] == AlertSeverity.CRITICAL.value
+        assert "Repeated" in call_args.kwargs["title"]
+
+    @patch("app.modules.governance.alert_notifier.get_alert_notifier")
+    def test_critical_above_threshold(self, mock_get_notifier):
+        mock_notifier = MagicMock()
+        mock_get_notifier.return_value = mock_notifier
+
+        create_auth_failure_alert(
+            username="suspect",
+            failure_count=10,
+            threshold=5,
+        )
+
+        call_args = mock_notifier.create_alert.call_args
+        assert call_args.kwargs["severity"] == AlertSeverity.CRITICAL.value
+
+    @patch("app.modules.governance.alert_notifier.get_alert_notifier")
+    def test_metadata_contains_threshold_info(self, mock_get_notifier):
+        mock_notifier = MagicMock()
+        mock_get_notifier.return_value = mock_notifier
+
+        create_auth_failure_alert(
+            username="testuser",
+            failure_count=3,
+            threshold=5,
+        )
+
+        call_args = mock_notifier.create_alert.call_args
+        metadata = call_args.kwargs["metadata"]
+        assert metadata["failure_count"] == 3
+        assert metadata["threshold"] == 5
+
+
+class TestCreatePermissionViolationAlert:
+    """Test create_permission_violation_alert function."""
+
+    @patch("app.modules.governance.alert_notifier.get_alert_notifier")
+    def test_creates_critical_alert(self, mock_get_notifier):
+        mock_notifier = MagicMock()
+        mock_get_notifier.return_value = mock_notifier
+
+        create_permission_violation_alert(
+            username="unauthorized_user",
+            resource="/admin/settings",
+            action="write",
+        )
+
+        call_args = mock_notifier.create_alert.call_args
+        assert call_args.kwargs["alert_type"] == AlertType.SECURITY.value
+        assert call_args.kwargs["severity"] == AlertSeverity.CRITICAL.value
+        assert "unauthorized_user" in call_args.kwargs["title"]
+        assert call_args.kwargs["metadata"]["resource"] == "/admin/settings"
+        assert call_args.kwargs["metadata"]["action"] == "write"
+
+
+class TestCreateSuspiciousActivityAlert:
+    """Test create_suspicious_activity_alert function with automatic severity."""
+
+    @patch("app.modules.governance.alert_notifier.get_alert_notifier")
+    def test_warning_below_risk_threshold(self, mock_get_notifier):
+        mock_notifier = MagicMock()
+        mock_get_notifier.return_value = mock_notifier
+
+        create_suspicious_activity_alert(
+            username="user1",
+            activity_type="unusual_login_time",
+            risk_score=30.0,
+        )
+
+        call_args = mock_notifier.create_alert.call_args
+        assert call_args.kwargs["severity"] == AlertSeverity.WARNING.value
+        assert call_args.kwargs["username"] == "user1"
+
+    @patch("app.modules.governance.alert_notifier.get_alert_notifier")
+    def test_critical_at_risk_threshold(self, mock_get_notifier):
+        mock_notifier = MagicMock()
+        mock_get_notifier.return_value = mock_notifier
+
+        create_suspicious_activity_alert(
+            username="user2",
+            activity_type="multiple_ip_addresses",
+            risk_score=50.0,
+        )
+
+        call_args = mock_notifier.create_alert.call_args
+        assert call_args.kwargs["severity"] == AlertSeverity.CRITICAL.value
+        assert "High-Risk" in call_args.kwargs["title"]
+
+    @patch("app.modules.governance.alert_notifier.get_alert_notifier")
+    def test_critical_above_risk_threshold(self, mock_get_notifier):
+        mock_notifier = MagicMock()
+        mock_get_notifier.return_value = mock_notifier
+
+        create_suspicious_activity_alert(
+            username="user3",
+            activity_type="brute_force_attempt",
+            risk_score=85.0,
+        )
+
+        call_args = mock_notifier.create_alert.call_args
+        assert call_args.kwargs["severity"] == AlertSeverity.CRITICAL.value
+
+    @patch("app.modules.governance.alert_notifier.get_alert_notifier")
+    def test_metadata_contains_risk_info(self, mock_get_notifier):
+        mock_notifier = MagicMock()
+        mock_get_notifier.return_value = mock_notifier
+
+        create_suspicious_activity_alert(
+            username="testuser",
+            activity_type="rate_limit_exceeded",
+            risk_score=45.0,
+        )
+
+        call_args = mock_notifier.create_alert.call_args
+        metadata = call_args.kwargs["metadata"]
+        assert metadata["activity_type"] == "rate_limit_exceeded"
+        assert metadata["risk_score"] == 45.0

--- a/tests/unit/test_alert_notifier.py
+++ b/tests/unit/test_alert_notifier.py
@@ -330,3 +330,137 @@ class TestCreateSuspiciousActivityAlert:
         metadata = call_args.kwargs["metadata"]
         assert metadata["activity_type"] == "rate_limit_exceeded"
         assert metadata["risk_score"] == 45.0
+
+
+class TestBoundaryValidation:
+    """Test boundary validation for alert functions (Agent d review)."""
+
+    @patch("app.modules.governance.alert_notifier.get_alert_notifier")
+    def test_create_resource_alert_limit_zero_raises(self, mock_get_notifier):
+        """Test that limit=0 raises ValueError."""
+        mock_notifier = MagicMock()
+        mock_get_notifier.return_value = mock_notifier
+
+        with pytest.raises(ValueError, match="limit must be positive"):
+            create_resource_alert(
+                resource_type="memory",
+                current=5.0,
+                limit=0,
+            )
+
+    @patch("app.modules.governance.alert_notifier.get_alert_notifier")
+    def test_create_resource_alert_limit_negative_raises(self, mock_get_notifier):
+        """Test that negative limit raises ValueError."""
+        mock_notifier = MagicMock()
+        mock_get_notifier.return_value = mock_notifier
+
+        with pytest.raises(ValueError, match="limit must be positive"):
+            create_resource_alert(
+                resource_type="memory",
+                current=5.0,
+                limit=-10.0,
+            )
+
+    @patch("app.modules.governance.alert_notifier.get_alert_notifier")
+    def test_create_resource_alert_current_negative_raises(self, mock_get_notifier):
+        """Test that negative current raises ValueError."""
+        mock_notifier = MagicMock()
+        mock_get_notifier.return_value = mock_notifier
+
+        with pytest.raises(ValueError, match="current must be non-negative"):
+            create_resource_alert(
+                resource_type="memory",
+                current=-5.0,
+                limit=10.0,
+            )
+
+    @patch("app.modules.governance.alert_notifier.get_alert_notifier")
+    def test_create_resource_alert_current_zero_allowed(self, mock_get_notifier):
+        """Test that current=0 is allowed (valid boundary)."""
+        mock_notifier = MagicMock()
+        mock_get_notifier.return_value = mock_notifier
+
+        create_resource_alert(
+            resource_type="memory",
+            current=0.0,
+            limit=10.0,
+        )
+
+        call_args = mock_notifier.create_alert.call_args
+        # 0% usage -> info level
+        assert call_args.kwargs["severity"] == AlertSeverity.INFO.value
+        assert call_args.kwargs["metadata"]["usage_percent"] == 0
+
+    @patch("app.modules.governance.alert_notifier.get_alert_notifier")
+    def test_create_suspicious_activity_alert_risk_score_below_zero_raises(self, mock_get_notifier):
+        """Test that risk_score < 0 raises ValueError."""
+        mock_notifier = MagicMock()
+        mock_get_notifier.return_value = mock_notifier
+
+        with pytest.raises(ValueError, match="risk_score must be between 0 and 100"):
+            create_suspicious_activity_alert(
+                username="testuser",
+                activity_type="test",
+                risk_score=-1.0,
+            )
+
+    @patch("app.modules.governance.alert_notifier.get_alert_notifier")
+    def test_create_suspicious_activity_alert_risk_score_above_100_raises(self, mock_get_notifier):
+        """Test that risk_score > 100 raises ValueError."""
+        mock_notifier = MagicMock()
+        mock_get_notifier.return_value = mock_notifier
+
+        with pytest.raises(ValueError, match="risk_score must be between 0 and 100"):
+            create_suspicious_activity_alert(
+                username="testuser",
+                activity_type="test",
+                risk_score=101.0,
+            )
+
+    @patch("app.modules.governance.alert_notifier.get_alert_notifier")
+    def test_create_suspicious_activity_alert_risk_score_zero_allowed(self, mock_get_notifier):
+        """Test that risk_score=0 is allowed (valid boundary)."""
+        mock_notifier = MagicMock()
+        mock_get_notifier.return_value = mock_notifier
+
+        create_suspicious_activity_alert(
+            username="testuser",
+            activity_type="test",
+            risk_score=0.0,
+        )
+
+        call_args = mock_notifier.create_alert.call_args
+        # 0 < 50 -> warning
+        assert call_args.kwargs["severity"] == AlertSeverity.WARNING.value
+
+    @patch("app.modules.governance.alert_notifier.get_alert_notifier")
+    def test_create_suspicious_activity_alert_risk_score_100_allowed(self, mock_get_notifier):
+        """Test that risk_score=100 is allowed (valid boundary)."""
+        mock_notifier = MagicMock()
+        mock_get_notifier.return_value = mock_notifier
+
+        create_suspicious_activity_alert(
+            username="testuser",
+            activity_type="test",
+            risk_score=100.0,
+        )
+
+        call_args = mock_notifier.create_alert.call_args
+        # 100 >= 50 -> critical
+        assert call_args.kwargs["severity"] == AlertSeverity.CRITICAL.value
+
+    @patch("app.modules.governance.alert_notifier.get_alert_notifier")
+    def test_create_suspicious_activity_alert_risk_score_exactly_50(self, mock_get_notifier):
+        """Test that risk_score=50 (threshold boundary) triggers critical."""
+        mock_notifier = MagicMock()
+        mock_get_notifier.return_value = mock_notifier
+
+        create_suspicious_activity_alert(
+            username="testuser",
+            activity_type="test",
+            risk_score=50.0,
+        )
+
+        call_args = mock_notifier.create_alert.call_args
+        # 50 >= 50 -> critical (at threshold)
+        assert call_args.kwargs["severity"] == AlertSeverity.CRITICAL.value


### PR DESCRIPTION
## 修复说明

关联 Issue：#1489

## 根因

告警系统 severity 判定机制不一致：
- `create_quota_alert()` 有明确的自动化 severity 判定逻辑（基于 usage_percent 阈值）
- `create_system_alert()` 和 `create_security_alert()` 无自动判定机制，需开发者手动指定
- 两者在代码库中从未被实际调用
- 缺乏告警 severity 选择指南文档

## 修复方案

新增 7 个场景专用告警函数，内置正确的 severity 判定逻辑：

### 系统告警（4 个）
| 函数 | 自动判定规则 |
|------|-------------|
| `create_service_down_alert` | 固定 critical |
| `create_resource_alert` | 基于 usage_ratio 自动判定（≥0.95 critical, ≥0.80 warning, <0.80 info） |
| `create_config_error_alert` | 固定 warning |
| `create_api_error_alert` | 固定 warning |

### 安全告警（3 个）
| 函数 | 自动判定规则 |
|------|-------------|
| `create_auth_failure_alert` | 基于 failure_count 自动判定（≥threshold critical, <threshold warning） |
| `create_permission_violation_alert` | 固定 critical |
| `create_suspicious_activity_alert` | 基于 risk_score 自动判定（≥50 critical, <50 warning） |

## 主要变更

- `app/modules/governance/alert_notifier.py`：新增 7 个场景专用函数（约 370 行）
- `app/modules/governance/__init__.py`：导出新增函数
- `tests/unit/test_alert_notifier.py`：新增 18 个单元测试

## 测试

- 测试环境：本地开发环境
- 已运行测试：`pytest tests/unit/test_alert_notifier.py -v`
- 新增测试：18 个测试用例，覆盖所有 7 个函数的各种阈值场景
- 测试结果：**全部通过** (18 passed)

## 风险

- 兼容性风险：**低** - 新增函数，不影响现有 API 签名
- 性能风险：**无** - 仅做阈值判断，无额外开销
- 安全风险：**无** - 不改变告警创建安全机制
- 回归风险：**低** - 集中在 alert_notifier.py，现有 5 处调用不受影响