### PR TITLE
fix: Header dropdown 显示在 PageRefreshControl 之上 (Issue #1484)

### DIFF
--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -1896,6 +1896,12 @@ table .latency-row:hover td {
   color: var(--text-primary) !important;
 }
 
+/* Issue #1484: Header dropdowns must have higher z-index than PageRefreshControl (320) */
+/* Header has backdrop-filter which creates stacking context, need explicit z-index */
+.header .dropdown-menu {
+  z-index: var(--z-popover); /* 600 */
+}
+
 /* Input Styles */
 .form-group {
   margin-bottom: var(--spacing-md);


### PR DESCRIPTION
## 修复说明

关联 Issue：#1484

## 根因

CSS 层叠上下文问题：Header 的 `backdrop-filter: blur(12px)` 创建了新的层叠上下文，导致其内部的 dropdown-menu 元素实际全局 z-index 为 0，被 PageRefreshControl（z-index: 320）覆盖。

详细根因分析请参见 Issue 评论：
- [Agent a 根因分析](https://github.com/open-ace/open-ace/issues/1484#issuecomment-4934518416)
- [Agent b 根因审查](https://github.com/open-ace/open-ace/issues/1484#issuecomment-4934532127)

## 修复方案

为 `.header .dropdown-menu` 设置 `z-index: var(--z-popover)` (600)，使其显示在 PageRefreshControl（z-index: 320）之上。

详细方案设计请参见 Issue 评论：
- [Agent a 修复方案](https://github.com/open-ace/open-ace/issues/1484#issuecomment-4934535985)
- [Agent c 方案评审](https://github.com/open-ace/open-ace/issues/1484#issuecomment-4934538156)

## 主要变更

- 在 `frontend/src/styles/main.css` 中添加 `.header .dropdown-menu { z-index: var(--z-popover); }` 规则
- 层级关系：dropdown (600) > PageRefreshControl (320) > Header (310)

## 测试

- 测试环境：本地开发环境
- 已运行检查：CSS 语法正确，无 lint 错误
- 验证方式：在管理模式页面验证 dropdown 显示正常
- 边界场景验证：
  - 语言选择器 dropdown 显示位置
  - 用户菜单 dropdown 显示位置
  - 不同主题（light/dark）下的显示效果

## 风险

- 兼容性风险：无。只影响 Header 内的 dropdown
- 性能风险：无。纯 CSS 修改
- 回归风险：无。不影响 Issue #1068/1081 的修复