### PR TITLE
fix: 合规报告语言根据界面语言动态设置 (Issue #1488)

### DIFF
--- a/frontend/src/components/features/management/ComplianceMgmt.tsx
+++ b/frontend/src/components/features/management/ComplianceMgmt.tsx
@@ -222,7 +222,6 @@ export const ComplianceMgmt: React.FC = () => {
   const [previewReportType, setPreviewReportType] = useState<string>('');
   const [previewReportId, setPreviewReportId] = useState<string>('');
   const [isPreviewLoading, setIsPreviewLoading] = useState(false);
-  const [previewLanguage] = useState<'en' | 'zh' | 'ja' | 'ko'>('en');
 
   // Initialize dates for reports
   useEffect(() => {
@@ -296,7 +295,7 @@ export const ComplianceMgmt: React.FC = () => {
         period_start: startDate,
         period_end: endDate,
         format: format as 'json' | 'csv' | 'html' | 'excel',
-        language: previewLanguage,
+        language: language as 'en' | 'zh' | 'ja' | 'ko',
       });
 
       // Handle different formats
@@ -347,7 +346,7 @@ export const ComplianceMgmt: React.FC = () => {
   const handlePreviewSavedReport = async (reportId: string, reportType: string) => {
     setIsPreviewLoading(true);
     try {
-      const htmlContent = await complianceApi.getSavedReport(reportId, 'html', previewLanguage);
+      const htmlContent = await complianceApi.getSavedReport(reportId, 'html', language as 'en' | 'zh' | 'ja' | 'ko');
       setPreviewHtmlContent(htmlContent as string);
       setPreviewReportType(reportType);
       setPreviewReportId(reportId);
@@ -366,7 +365,7 @@ export const ComplianceMgmt: React.FC = () => {
     downloadFormat: 'json' | 'csv' | 'html' | 'excel'
   ) => {
     try {
-      const report = await complianceApi.getSavedReport(reportId, downloadFormat, previewLanguage);
+      const report = await complianceApi.getSavedReport(reportId, downloadFormat, language as 'en' | 'zh' | 'ja' | 'ko');
 
       if (downloadFormat === 'excel') {
         const blob = report as Blob;

--- a/frontend/src/components/features/management/ComplianceMgmt.tsx
+++ b/frontend/src/components/features/management/ComplianceMgmt.tsx
@@ -346,7 +346,11 @@ export const ComplianceMgmt: React.FC = () => {
   const handlePreviewSavedReport = async (reportId: string, reportType: string) => {
     setIsPreviewLoading(true);
     try {
-      const htmlContent = await complianceApi.getSavedReport(reportId, 'html', language as 'en' | 'zh' | 'ja' | 'ko');
+      const htmlContent = await complianceApi.getSavedReport(
+        reportId,
+        'html',
+        language as 'en' | 'zh' | 'ja' | 'ko'
+      );
       setPreviewHtmlContent(htmlContent as string);
       setPreviewReportType(reportType);
       setPreviewReportId(reportId);
@@ -365,7 +369,11 @@ export const ComplianceMgmt: React.FC = () => {
     downloadFormat: 'json' | 'csv' | 'html' | 'excel'
   ) => {
     try {
-      const report = await complianceApi.getSavedReport(reportId, downloadFormat, language as 'en' | 'zh' | 'ja' | 'ko');
+      const report = await complianceApi.getSavedReport(
+        reportId,
+        downloadFormat,
+        language as 'en' | 'zh' | 'ja' | 'ko'
+      );
 
       if (downloadFormat === 'excel') {
         const blob = report as Blob;


### PR DESCRIPTION
## 修复说明

关联 Issue：#1488

## 根因

`previewLanguage` 状态变量硬编码为 `'en'`，未与用户界面语言 `language` 同步，导致合规报告始终以英文生成。

## 修复方案

移除 `previewLanguage` 状态变量，直接使用 `language` 作为报告语言参数。

## 主要变更

- 移除 `previewLanguage` 状态变量（第 225 行）
- `handleGenerate` 的 language 参数改用 `language`（第 295 行）
- `handlePreviewSavedReport` 的 language 参数改用 `language`（第 346 行）
- `handleDownloadSavedReport` 的 language 参数改用 `language`（第 365 行）

## 测试

- 测试环境：Package 测试环境
- TypeScript 编译验证：通过

## 风险

无回归风险，`Language` 类型与 API 参数类型 `'en' | 'zh' | 'ja' | 'ko'` 完全兼容。