### PR TITLE
fix: add SMTP port 465 SSL connection support (Issue #1515)

### DIFF
--- a/app/services/email_notification_service.py
+++ b/app/services/email_notification_service.py
@@ -12,12 +12,14 @@ Provides:
 import logging
 import queue
 import smtplib
+import socket
+import ssl
 import threading
 import time
 from datetime import datetime, timedelta, timezone
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 from app.repositories.email_notification_log_repository import get_email_log_repository
 from app.repositories.smtp_config_repository import get_smtp_config_repository
@@ -336,11 +338,22 @@ class EmailQueue:
             msg.attach(MIMEText(body, "plain", "utf-8"))
 
             # Connect and send
-            if config["use_tls"]:
-                smtp = smtplib.SMTP(config["smtp_host"], config["smtp_port"], timeout=30)
+            # Port 465 uses SSL connection (SMTPS), other ports use SMTP with optional STARTTLS
+            smtp_port = config["smtp_port"]
+            use_ssl = smtp_port == 465
+            use_tls = config["use_tls"]
+            smtp: Union[smtplib.SMTP, smtplib.SMTP_SSL]
+
+            if use_ssl:
+                smtp = smtplib.SMTP_SSL(config["smtp_host"], smtp_port, timeout=30)
+                logger.info(f"SMTP_SSL connection established for port {smtp_port}")
+            elif use_tls:
+                smtp = smtplib.SMTP(config["smtp_host"], smtp_port, timeout=30)
                 smtp.starttls()
+                logger.info(f"SMTP STARTTLS connection established for port {smtp_port}")
             else:
-                smtp = smtplib.SMTP(config["smtp_host"], config["smtp_port"], timeout=30)
+                smtp = smtplib.SMTP(config["smtp_host"], smtp_port, timeout=30)
+                logger.info(f"SMTP plain connection established for port {smtp_port}")
 
             # Login if credentials provided
             if config["smtp_user"] and config["smtp_password"]:
@@ -356,6 +369,21 @@ class EmailQueue:
 
             return True
 
+        except ssl.SSLError as e:
+            logger.error(f"SMTP SSL error: {e}")
+            return False
+        except socket.timeout as e:
+            logger.error(f"SMTP timeout error: {e}")
+            return False
+        except socket.gaierror as e:
+            logger.error(f"SMTP address resolution error: {e}")
+            return False
+        except ConnectionRefusedError as e:
+            logger.error(f"SMTP connection refused: {e}")
+            return False
+        except smtplib.SMTPException as e:
+            logger.error(f"SMTP error: {e}")
+            return False
         except Exception as e:
             logger.error(f"SMTP send error: {e}")
             return False

--- a/app/services/smtp_config_service.py
+++ b/app/services/smtp_config_service.py
@@ -6,8 +6,10 @@ Provides SMTP configuration management and connection testing.
 
 import logging
 import smtplib
+import socket
+import ssl
 from email.mime.text import MIMEText
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 from app.repositories.email_notification_log_repository import get_email_log_repository
 from app.repositories.smtp_config_repository import get_smtp_config_repository
@@ -115,7 +117,12 @@ class SMTPConfigService:
 
         try:
             # Create SMTP connection
-            if use_tls:
+            # Port 465 uses SSL connection (SMTPS), other ports use SMTP with optional STARTTLS
+            smtp: Union[smtplib.SMTP, smtplib.SMTP_SSL]
+            use_ssl = smtp_port == 465
+            if use_ssl:
+                smtp = smtplib.SMTP_SSL(smtp_host, smtp_port, timeout=10)
+            elif use_tls:
                 smtp = smtplib.SMTP(smtp_host, smtp_port, timeout=10)
                 smtp.starttls()
             else:
@@ -142,9 +149,22 @@ class SMTPConfigService:
             if config_id:
                 self.config_repo.update_verified_status(config_id, True)
 
+            # Return success message with connection mode information
+            if use_ssl:
+                success_msg = (
+                    "SMTP SSL connection test successful (port 465 automatically uses SSL)"
+                )
+            elif use_tls:
+                success_msg = "SMTP STARTTLS connection test successful"
+            else:
+                success_msg = (
+                    "SMTP connection test successful (plain connection, recommend enabling TLS)"
+                )
+
             return {
                 "success": True,
-                "message": "SMTP connection test successful",
+                "message": success_msg,
+                "connection_mode": "ssl" if use_ssl else ("starttls" if use_tls else "plain"),
             }
 
         except smtplib.SMTPAuthenticationError as e:
@@ -163,6 +183,38 @@ class SMTPConfigService:
                 e.smtp_error.decode() if isinstance(e.smtp_error, bytes) else str(e.smtp_error)
             )
             error_msg = f"SMTP connection failed: {e.smtp_code} - {smtp_error_str}"
+            logger.error(error_msg)
+            return {
+                "success": False,
+                "message": error_msg,
+            }
+
+        except ssl.SSLError as e:
+            error_msg = f"SSL connection failed: certificate verification error or handshake failure - {str(e)}"
+            logger.error(error_msg)
+            return {
+                "success": False,
+                "message": error_msg,
+            }
+
+        except socket.timeout as e:
+            error_msg = f"Connection timeout: unable to connect within 10 seconds - {str(e)}"
+            logger.error(error_msg)
+            return {
+                "success": False,
+                "message": error_msg,
+            }
+
+        except socket.gaierror as e:
+            error_msg = f"Server address resolution failed: unable to find SMTP server - {str(e)}"
+            logger.error(error_msg)
+            return {
+                "success": False,
+                "message": error_msg,
+            }
+
+        except ConnectionRefusedError as e:
+            error_msg = f"Connection refused: SMTP server not responding - {str(e)}"
             logger.error(error_msg)
             return {
                 "success": False,

--- a/frontend/src/components/features/management/SmtpConfig.tsx
+++ b/frontend/src/components/features/management/SmtpConfig.tsx
@@ -45,6 +45,12 @@ export const SmtpConfig: React.FC = () => {
     use_tls: true,
   });
 
+  // Check if port is 465 (SSL port)
+  const isPort465 = parseInt(formData.smtp_port, 10) === 465;
+  // Check if port is non-standard (not 25, 587, 465)
+  const isNonStandardPort =
+    !['25', '587', '465'].includes(formData.smtp_port) && formData.smtp_port !== '';
+
   // Fetch config on mount
   useEffect(() => {
     fetchConfig();
@@ -256,6 +262,18 @@ export const SmtpConfig: React.FC = () => {
                 onChange={(value) => setFormData({ ...formData, smtp_port: value })}
                 placeholder="587"
               />
+              {isPort465 && (
+                <small className="text-info d-block mt-1">
+                  <i className="bi bi-info-circle me-1" />
+                  {t('smtpPort465AutoSSL', language)}
+                </small>
+              )}
+              {isNonStandardPort && (
+                <small className="text-warning d-block mt-1">
+                  <i className="bi bi-exclamation-triangle me-1" />
+                  {t('smtpNonStandardPortWarning', language)}
+                </small>
+              )}
             </div>
 
             <div className="col-md-6">
@@ -301,10 +319,16 @@ export const SmtpConfig: React.FC = () => {
                   id="useTLS"
                   checked={formData.use_tls}
                   onChange={(e) => setFormData({ ...formData, use_tls: e.target.checked })}
+                  disabled={isPort465}
                 />
                 <label className="form-check-label" htmlFor="useTLS">
                   {t('useTLS', language)}
                 </label>
+                {isPort465 && (
+                  <small className="text-muted d-block mt-1">
+                    {t('smtpPort465AutoSSL', language)}
+                  </small>
+                )}
               </div>
             </div>
 
@@ -386,6 +410,19 @@ export const SmtpConfig: React.FC = () => {
             <li>{t('smtpSetupGuide2', language)}</li>
             <li>{t('smtpSetupGuide3', language)}</li>
             <li>{t('smtpSetupGuide4', language)}</li>
+          </ul>
+          <hr className="my-2" />
+          <h6 className="alert-heading mb-2">{t('smtpPortGuide', language) || 'Port Guide'}</h6>
+          <ul className="mb-0">
+            <li>
+              <strong>25</strong>: {t('smtpHelpPort25', language)}
+            </li>
+            <li>
+              <strong>587</strong>: {t('smtpHelpPort587', language)}
+            </li>
+            <li>
+              <strong>465</strong>: {t('smtpHelpPort465', language)}
+            </li>
           </ul>
         </div>
       </Card>

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -898,6 +898,19 @@ export const translations: Record<Language, Translations> = {
     smtpSetupGuide3: 'Enter the sender email address',
     smtpSetupGuide4:
       'Click "Test Connection" to verify the configuration before enabling email notifications',
+    smtpPort465AutoSSL: 'Port 465 automatically uses SSL connection',
+    smtpSslConnectionSuccess: 'SMTP SSL connection test successful',
+    smtpStarttlsConnectionSuccess: 'SMTP STARTTLS connection test successful',
+    smtpPlainConnectionSuccess:
+      'SMTP connection test successful (plain connection, recommend enabling TLS)',
+    smtpSslError: 'SSL connection failed: certificate verification error or handshake failure',
+    smtpConnectionTimeout: 'Connection timeout: unable to connect within 10 seconds',
+    smtpNonStandardPortWarning: 'Non-standard port, please confirm server configuration is correct',
+    smtpHelpPort25: 'Port 25: Traditional SMTP, plain connection (not recommended)',
+    smtpHelpPort587: 'Port 587: Modern SMTP, STARTTLS encryption (recommended)',
+    smtpHelpPort465:
+      'Port 465: SMTPS, immediate SSL encryption (for Tencent Enterprise Mail, etc.)',
+    smtpPortGuide: 'Port Guide',
     help: 'Help',
 
     // Data Retention
@@ -2489,6 +2502,17 @@ export const translations: Record<Language, Translations> = {
     smtpSetupGuide2: '如果需要认证，输入 SMTP 凭证',
     smtpSetupGuide3: '输入发件人邮箱地址',
     smtpSetupGuide4: '点击"测试连接"验证配置后再启用邮件通知',
+    smtpPort465AutoSSL: '端口 465 自动使用 SSL 连接',
+    smtpSslConnectionSuccess: 'SMTP SSL 连接测试成功',
+    smtpStarttlsConnectionSuccess: 'SMTP STARTTLS 连接测试成功',
+    smtpPlainConnectionSuccess: 'SMTP 连接测试成功（明文连接，建议启用 TLS）',
+    smtpSslError: 'SSL 连接失败：证书验证错误或加密握手失败',
+    smtpConnectionTimeout: '连接超时：无法在 10 秒内建立连接',
+    smtpNonStandardPortWarning: '非标准端口，请确认服务器配置是否正确',
+    smtpHelpPort25: '端口 25：传统 SMTP，明文连接（不推荐）',
+    smtpHelpPort587: '端口 587：现代 SMTP，STARTTLS 加密（推荐）',
+    smtpHelpPort465: '端口 465：SMTPS，立即 SSL 加密（腾讯企业邮箱等）',
+    smtpPortGuide: '端口指南',
     help: '帮助',
     message: '消息',
     time: '时间',
@@ -4629,6 +4653,19 @@ export const translations: Record<Language, Translations> = {
     priorityHelp: '高いほど優先されます。デフォルト：0',
     weight: '重み',
     weightHelp: '同じ優先度内での加重ランダム用。デフォルト：100',
+
+    // SMTP Configuration (Japanese)
+    smtpPort465AutoSSL: 'ポート465は自動的にSSL接続を使用します',
+    smtpSslConnectionSuccess: 'SMTP SSL接続テスト成功',
+    smtpStarttlsConnectionSuccess: 'SMTP STARTTLS接続テスト成功',
+    smtpPlainConnectionSuccess: 'SMTP接続テスト成功（平文接続、TLSを推奨）',
+    smtpSslError: 'SSL接続失敗：証明書検証エラーまたはハンドシェイク失敗',
+    smtpConnectionTimeout: '接続タイムアウト：10秒以内に接続できません',
+    smtpNonStandardPortWarning: '非標準ポート、サーバー設定が正しいか確認してください',
+    smtpHelpPort25: 'ポート25：従来のSMTP、平文接続（非推奨）',
+    smtpHelpPort587: 'ポート587：現代SMTP、STARTTLS暗号化（推奨）',
+    smtpHelpPort465: 'ポート465：SMTPS、即時SSL暗号化（テンセント企業メール等）',
+    smtpPortGuide: 'ポートガイド',
   },
   ko: {
     // Common
@@ -6062,6 +6099,19 @@ export const translations: Record<Language, Translations> = {
     priorityHelp: '높을수록 우선합니다. 기본값: 0',
     weight: '가중치',
     weightHelp: '동일 우선순위 내에서 가중 랜덤용. 기본값: 100',
+
+    // SMTP Configuration (Korean)
+    smtpPort465AutoSSL: '포트 465는 자동으로 SSL 연결을 사용합니다',
+    smtpSslConnectionSuccess: 'SMTP SSL 연결 테스트 성공',
+    smtpStarttlsConnectionSuccess: 'SMTP STARTTLS 연결 테스트 성공',
+    smtpPlainConnectionSuccess: 'SMTP 연결 테스트 성공 (평문 연결, TLS 사용 권장)',
+    smtpSslError: 'SSL 연결 실패: 인증서 검증 오류 또는 핸드셰이크 실패',
+    smtpConnectionTimeout: '연결 시간 초과: 10초 내에 연결할 수 없습니다',
+    smtpNonStandardPortWarning: '비표준 포트, 서버 설정이 올바른지 확인하세요',
+    smtpHelpPort25: '포트 25: 기본 SMTP, 평문 연결 (비권장)',
+    smtpHelpPort587: '포트 587: 현대 SMTP, STARTTLS 암호화 (권장)',
+    smtpHelpPort465: '포트 465: SMTPS, 즉시 SSL 암호화 (텐센트 기업 메일 등)',
+    smtpPortGuide: '포트 가이드',
   },
 };
 

--- a/tests/test_smtp_connection_modes.py
+++ b/tests/test_smtp_connection_modes.py
@@ -1,0 +1,379 @@
+#!/usr/bin/env python3
+"""
+Tests for SMTP Connection Modes
+
+Tests cover:
+- Port 465 SSL connection
+- Port 587 STARTTLS connection
+- Port 25 plain connection
+- SSL exception handling
+- Timeout exception handling
+"""
+
+import smtplib
+import socket
+import ssl
+import unittest
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestSMTPConnectionModes(unittest.TestCase):
+    """Test SMTP connection modes for different ports."""
+
+    def test_port_465_uses_smtp_ssl(self):
+        """Test that port 465 uses SMTP_SSL connection."""
+        from app.services.smtp_config_service import SMTPConfigService
+
+        service = SMTPConfigService()
+
+        # Mock SMTP_SSL
+        with patch("smtplib.SMTP_SSL") as mock_smtp_ssl:
+            mock_smtp_instance = MagicMock()
+            mock_smtp_ssl.return_value = mock_smtp_instance
+
+            # Test connection with port 465
+            result = service.test_connection(
+                smtp_host="smtp.exmail.qq.com",
+                smtp_port=465,
+                smtp_user="test@example.com",
+                smtp_password="test_password",
+                from_address="test@example.com",
+                use_tls=True,
+            )
+
+            # Verify SMTP_SSL was called
+            mock_smtp_ssl.assert_called_once_with("smtp.exmail.qq.com", 465, timeout=10)
+            # Verify SMTP was NOT called
+            mock_smtp_instance.login.assert_called_once()
+            mock_smtp_instance.sendmail.assert_called_once()
+            mock_smtp_instance.quit.assert_called_once()
+
+            # Verify result contains connection_mode
+            assert result["success"] is True
+            assert result["connection_mode"] == "ssl"
+
+    def test_port_465_ignores_use_tls(self):
+        """Test that port 465 ignores use_tls setting and uses SSL."""
+        from app.services.smtp_config_service import SMTPConfigService
+
+        service = SMTPConfigService()
+
+        # Mock SMTP_SSL
+        with patch("smtplib.SMTP_SSL") as mock_smtp_ssl:
+            mock_smtp_instance = MagicMock()
+            mock_smtp_ssl.return_value = mock_smtp_instance
+
+            # Test connection with port 465 and use_tls=False
+            result = service.test_connection(
+                smtp_host="smtp.exmail.qq.com",
+                smtp_port=465,
+                smtp_user="test@example.com",
+                smtp_password="test_password",
+                from_address="test@example.com",
+                use_tls=False,
+            )
+
+            # Verify SMTP_SSL was called (ignoring use_tls)
+            mock_smtp_ssl.assert_called_once()
+            assert result["success"] is True
+            assert result["connection_mode"] == "ssl"
+
+    def test_port_587_uses_starttls(self):
+        """Test that port 587 uses SMTP with STARTTLS."""
+        from app.services.smtp_config_service import SMTPConfigService
+
+        service = SMTPConfigService()
+
+        # Mock SMTP
+        with patch("smtplib.SMTP") as mock_smtp:
+            mock_smtp_instance = MagicMock()
+            mock_smtp.return_value = mock_smtp_instance
+
+            # Test connection with port 587
+            result = service.test_connection(
+                smtp_host="smtp.gmail.com",
+                smtp_port=587,
+                smtp_user="test@gmail.com",
+                smtp_password="test_password",
+                from_address="test@gmail.com",
+                use_tls=True,
+            )
+
+            # Verify SMTP was called
+            mock_smtp.assert_called_once_with("smtp.gmail.com", 587, timeout=10)
+            # Verify STARTTLS was called
+            mock_smtp_instance.starttls.assert_called_once()
+            mock_smtp_instance.login.assert_called_once()
+            mock_smtp_instance.sendmail.assert_called_once()
+            mock_smtp_instance.quit.assert_called_once()
+
+            # Verify result contains connection_mode
+            assert result["success"] is True
+            assert result["connection_mode"] == "starttls"
+
+    def test_port_25_plain_connection(self):
+        """Test that port 25 uses plain SMTP connection."""
+        from app.services.smtp_config_service import SMTPConfigService
+
+        service = SMTPConfigService()
+
+        # Mock SMTP
+        with patch("smtplib.SMTP") as mock_smtp:
+            mock_smtp_instance = MagicMock()
+            mock_smtp.return_value = mock_smtp_instance
+
+            # Test connection with port 25 and use_tls=False
+            result = service.test_connection(
+                smtp_host="smtp.example.com",
+                smtp_port=25,
+                smtp_user="test@example.com",
+                smtp_password="test_password",
+                from_address="test@example.com",
+                use_tls=False,
+            )
+
+            # Verify SMTP was called
+            mock_smtp.assert_called_once_with("smtp.example.com", 25, timeout=10)
+            # Verify STARTTLS was NOT called
+            mock_smtp_instance.starttls.assert_not_called()
+            mock_smtp_instance.login.assert_called_once()
+            mock_smtp_instance.sendmail.assert_called_once()
+            mock_smtp_instance.quit.assert_called_once()
+
+            # Verify result contains connection_mode
+            assert result["success"] is True
+            assert result["connection_mode"] == "plain"
+
+    def test_ssl_error_handling(self):
+        """Test SSL error handling for port 465."""
+        from app.services.smtp_config_service import SMTPConfigService
+
+        service = SMTPConfigService()
+
+        # Mock SMTP_SSL to raise SSLError
+        with patch("smtplib.SMTP_SSL") as mock_smtp_ssl:
+            mock_smtp_ssl.side_effect = ssl.SSLError("SSL handshake failed")
+
+            # Test connection
+            result = service.test_connection(
+                smtp_host="smtp.exmail.qq.com",
+                smtp_port=465,
+                smtp_user="test@example.com",
+                smtp_password="test_password",
+                from_address="test@example.com",
+                use_tls=True,
+            )
+
+            # Verify error was handled
+            assert result["success"] is False
+            assert "SSL" in result["message"]
+
+    def test_timeout_error_handling(self):
+        """Test timeout error handling for all ports."""
+        from app.services.smtp_config_service import SMTPConfigService
+
+        service = SMTPConfigService()
+
+        # Mock SMTP to raise timeout
+        with patch("smtplib.SMTP") as mock_smtp:
+            mock_smtp.side_effect = socket.timeout("Connection timed out")
+
+            # Test connection with port 587
+            result = service.test_connection(
+                smtp_host="smtp.gmail.com",
+                smtp_port=587,
+                smtp_user="test@gmail.com",
+                smtp_password="test_password",
+                from_address="test@gmail.com",
+                use_tls=True,
+            )
+
+            # Verify error was handled
+            assert result["success"] is False
+            assert "timeout" in result["message"].lower()
+
+    def test_gaierror_handling(self):
+        """Test DNS resolution error handling."""
+        from app.services.smtp_config_service import SMTPConfigService
+
+        service = SMTPConfigService()
+
+        # Mock SMTP to raise gaierror
+        with patch("smtplib.SMTP") as mock_smtp:
+            mock_smtp.side_effect = socket.gaierror("DNS resolution failed")
+
+            # Test connection
+            result = service.test_connection(
+                smtp_host="invalid.hostname",
+                smtp_port=587,
+                smtp_user="test@example.com",
+                smtp_password="test_password",
+                from_address="test@example.com",
+                use_tls=True,
+            )
+
+            # Verify error was handled
+            assert result["success"] is False
+            assert "resolution" in result["message"].lower()
+
+    def test_connection_refused_handling(self):
+        """Test connection refused error handling."""
+        from app.services.smtp_config_service import SMTPConfigService
+
+        service = SMTPConfigService()
+
+        # Mock SMTP to raise ConnectionRefusedError
+        with patch("smtplib.SMTP") as mock_smtp:
+            mock_smtp.side_effect = ConnectionRefusedError("Connection refused")
+
+            # Test connection
+            result = service.test_connection(
+                smtp_host="smtp.example.com",
+                smtp_port=25,
+                smtp_user="test@example.com",
+                smtp_password="test_password",
+                from_address="test@example.com",
+                use_tls=False,
+            )
+
+            # Verify error was handled
+            assert result["success"] is False
+            assert "refused" in result["message"].lower()
+
+
+class TestEmailNotificationServiceSendEmail(unittest.TestCase):
+    """Test EmailQueue._send_email connection modes."""
+
+    def test_send_email_port_465_ssl(self):
+        """Test _send_email uses SMTP_SSL for port 465."""
+        from app.services.email_notification_service import EmailQueue
+
+        queue = EmailQueue()
+
+        config = {
+            "smtp_host": "smtp.exmail.qq.com",
+            "smtp_port": 465,
+            "smtp_user": "test@example.com",
+            "smtp_password": "test_password",
+            "from_address": "test@example.com",
+            "use_tls": True,
+        }
+
+        email_data = {
+            "recipient_email": "recipient@example.com",
+            "subject": "Test Subject",
+            "email_body": "Test Body",
+        }
+
+        with patch("smtplib.SMTP_SSL") as mock_smtp_ssl:
+            mock_smtp_instance = MagicMock()
+            mock_smtp_ssl.return_value = mock_smtp_instance
+
+            result = queue._send_email(config, email_data)
+
+            # Verify SMTP_SSL was called with timeout=30
+            mock_smtp_ssl.assert_called_once_with("smtp.exmail.qq.com", 465, timeout=30)
+            mock_smtp_instance.login.assert_called_once()
+            mock_smtp_instance.sendmail.assert_called_once()
+            mock_smtp_instance.quit.assert_called_once()
+
+            assert result is True
+
+    def test_send_email_port_587_starttls(self):
+        """Test _send_email uses SMTP with STARTTLS for port 587."""
+        from app.services.email_notification_service import EmailQueue
+
+        queue = EmailQueue()
+
+        config = {
+            "smtp_host": "smtp.gmail.com",
+            "smtp_port": 587,
+            "smtp_user": "test@gmail.com",
+            "smtp_password": "test_password",
+            "from_address": "test@gmail.com",
+            "use_tls": True,
+        }
+
+        email_data = {
+            "recipient_email": "recipient@example.com",
+            "subject": "Test Subject",
+            "email_body": "Test Body",
+        }
+
+        with patch("smtplib.SMTP") as mock_smtp:
+            mock_smtp_instance = MagicMock()
+            mock_smtp.return_value = mock_smtp_instance
+
+            result = queue._send_email(config, email_data)
+
+            # Verify SMTP was called
+            mock_smtp.assert_called_once_with("smtp.gmail.com", 587, timeout=30)
+            # Verify STARTTLS was called
+            mock_smtp_instance.starttls.assert_called_once()
+            mock_smtp_instance.login.assert_called_once()
+            mock_smtp_instance.sendmail.assert_called_once()
+            mock_smtp_instance.quit.assert_called_once()
+
+            assert result is True
+
+    def test_send_email_ssl_error_returns_false(self):
+        """Test _send_email returns False on SSL error."""
+        from app.services.email_notification_service import EmailQueue
+
+        queue = EmailQueue()
+
+        config = {
+            "smtp_host": "smtp.exmail.qq.com",
+            "smtp_port": 465,
+            "smtp_user": "test@example.com",
+            "smtp_password": "test_password",
+            "from_address": "test@example.com",
+            "use_tls": True,
+        }
+
+        email_data = {
+            "recipient_email": "recipient@example.com",
+            "subject": "Test Subject",
+            "email_body": "Test Body",
+        }
+
+        with patch("smtplib.SMTP_SSL") as mock_smtp_ssl:
+            mock_smtp_ssl.side_effect = ssl.SSLError("SSL error")
+
+            result = queue._send_email(config, email_data)
+
+            assert result is False
+
+    def test_send_email_timeout_returns_false(self):
+        """Test _send_email returns False on timeout."""
+        from app.services.email_notification_service import EmailQueue
+
+        queue = EmailQueue()
+
+        config = {
+            "smtp_host": "smtp.gmail.com",
+            "smtp_port": 587,
+            "smtp_user": "test@gmail.com",
+            "smtp_password": "test_password",
+            "from_address": "test@gmail.com",
+            "use_tls": True,
+        }
+
+        email_data = {
+            "recipient_email": "recipient@example.com",
+            "subject": "Test Subject",
+            "email_body": "Test Body",
+        }
+
+        with patch("smtplib.SMTP") as mock_smtp:
+            mock_smtp.side_effect = socket.timeout("Timeout")
+
+            result = queue._send_email(config, email_data)
+
+            assert result is False
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 问题描述

配置腾讯企业邮箱 SMTP（smtp.exmail.qq.com:465）时，保存配置成功但测试连接失败，报错 "SMTP error: Connection unexpectedly closed: timed out"。

## 解决方案

- 修复 `smtp_config_service.py` 的 `test_connection` 方法，添加 465 端口 SSL 连接支持
- 修复 `email_notification_service.py` 的 `_send_email` 方法，添加 465 端口 SSL 连接支持
- 添加单元测试覆盖三种端口连接方式
- 更新前端 UI 提示

## 端口协议对照

| 端口 | 协议 | 连接方式 |
|-----|------|---------|
| 25 | SMTP | 明文连接 |
| 587 | SMTP+STARTTLS | 先明文再升级 |
| 465 | SMTPS | 立即 SSL |

Closes #1515