### PR TITLE
fix: 修复浅色主题中文字颜色异常问题 (Issue #1623)

### DIFF
--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -3495,7 +3495,6 @@ table .latency-row:hover td {
   color: #f8fafc !important;
 }
 
-
 [data-theme='dark'] .session-list-collapsed-item {
   color: var(--text-secondary);
 }

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -48,7 +48,7 @@
   --text-primary: #0f172a;
   --text-secondary: #475569;
   --text-tertiary: #64748b;
-  --text-muted: #94a3b8;
+  --text-muted: #64748b; /* Issue #1623: Improved from #94a3b8 (~2.8:1) to #64748b (~4.6:1) for WCAG AA on light backgrounds */
   --text-inverse: #ffffff;
 
   /* ===== Border Colors ===== */
@@ -2545,12 +2545,9 @@ table .latency-row:hover td {
 
 /* CLI-imported sessions (no cli_session_id + completed) — muted to distinguish
    from live WebUI/autonomous/remote sessions. */
-.session-item.session-imported {
-  opacity: 0.7;
-}
 .session-item.session-imported .session-id,
 .session-item.session-imported .session-title {
-  color: var(--text-secondary);
+  color: var(--text-primary);
 }
 
 .session-item .session-title {
@@ -2581,7 +2578,7 @@ table .latency-row:hover td {
   white-space: nowrap;
   font-size: var(--font-size-xs);
   text-decoration: none;
-  color: var(--text-muted);
+  color: var(--text-primary);
   padding: 0 var(--spacing-sm);
   border-right: 1px solid var(--border-color);
   margin-right: var(--spacing-sm);
@@ -3498,43 +3495,6 @@ table .latency-row:hover td {
   color: #f8fafc !important;
 }
 
-/* System dark mode support (Issue #1619) */
-@media (prefers-color-scheme: dark) {
-  /* Override responsive.css CSS variables with better contrast */
-  :root {
-    --text-muted: #a1a1aa;
-    --text-secondary: #cbd5e1;
-    --text-primary: #f8fafc;
-  }
-
-  .session-item .session-time {
-    color: #f8fafc !important;
-    border-right-color: var(--border-color);
-  }
-
-  .session-item .session-requests,
-  .session-item .session-messages {
-    color: #f8fafc !important;
-  }
-
-  .session-group-title {
-    color: #f8fafc !important;
-  }
-
-  .session-group-title.small {
-    color: #f8fafc !important;
-  }
-
-  /* Force override Bootstrap .text-muted in dark mode */
-  .text-muted {
-    color: #a1a1aa !important;
-  }
-
-  .session-group-title.text-muted,
-  .session-group-title.small.text-muted {
-    color: #f8fafc !important;
-  }
-}
 
 [data-theme='dark'] .session-list-collapsed-item {
   color: var(--text-secondary);

--- a/frontend/src/styles/responsive.css
+++ b/frontend/src/styles/responsive.css
@@ -538,19 +538,6 @@ body.sidebar-mobile-open {
   }
 }
 
-/* ===== Dark Mode Responsive ===== */
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --bg-primary: #0f172a;
-    --bg-secondary: #1e293b;
-    --bg-tertiary: #334155;
-    --text-primary: #f1f5f9;
-    --text-secondary: #94a3b8;
-    --text-muted: #64748b;
-    --border-color: #334155;
-  }
-}
 
 /* ===== Landscape Orientation ===== */
 

--- a/frontend/src/styles/responsive.css
+++ b/frontend/src/styles/responsive.css
@@ -538,7 +538,6 @@ body.sidebar-mobile-open {
   }
 }
 
-
 /* ===== Landscape Orientation ===== */
 
 @media (orientation: landscape) and (max-height: 500px) {


### PR DESCRIPTION
## 问题背景

Issue #1619 修复深色主题时添加了 `@media (prefers-color-scheme: dark)` 块，将 `:root` 中的文字颜色变量覆盖为近白色（`--text-primary: #f8fafc`、`--text-secondary: #cbd5e1`、`--text-muted: #a1a1aa`）。当用户操作系统为深色模式但应用选择浅色主题时，浅色背景上出现近白色文字，页面整体发白不可读。

`responsive.css` 中同样存在旧的 `@media (prefers-color-scheme: dark)` 块覆盖 `:root` 变量。

Closes #1623

## 修复内容

### 1. 移除 `@media (prefers-color-scheme: dark)` 块
- **main.css**: 删除整个 `@media (prefers-color-scheme: dark)` 块（37 行）
- **responsive.css**: 删除 `@media (prefers-color-scheme: dark)` 块（13 行）
- 应用通过 JS 设置 `data-theme` 属性切换主题，不应依赖系统偏好媒体查询

### 2. 统一历史会话列表文字颜色
- `.session-time` 颜色从 `var(--text-muted)` 改为 `var(--text-primary)`，与 session ID 统一
- `.session-imported` 移除 `opacity: 0.7`，ID/title 颜色统一为 `var(--text-primary)`

### 3. 改善浅色主题 `--text-muted` 对比度
- `:root --text-muted` 从 `#94a3b8`（对比度 2.8:1）改为 `#64748b`（4.6:1），达到 WCAG AA 标准

## 主题隔离
- ✅ 深色主题 `[data-theme="dark"]` 块完全未修改（46 个选择器保持不变）
- ✅ `:root` 变量修改仅影响浅色主题（深色主题由更高特异性的 `[data-theme="dark"]` 覆盖）
- ✅ 未修改任何布局、尺寸、间距或组件结构

## 修改文件
| 文件 | 修改内容 |
|------|----------|
| `frontend/src/styles/main.css` | 移除 `@media (prefers-color-scheme: dark)` 块；统一 session 文字颜色；改善 `--text-muted` 对比度 |
| `frontend/src/styles/responsive.css` | 移除 `@media (prefers-color-scheme: dark)` 块 |