### PR TITLE
fix(usage): 深色主题下"关于配额限制"卡片对比度问题 (Issue #1628)

### DIFF
--- a/frontend/src/components/work/UsageOverview.tsx
+++ b/frontend/src/components/work/UsageOverview.tsx
@@ -511,7 +511,7 @@ export const UsageOverview: React.FC = () => {
       )}
 
       {/* Help Text */}
-      <Card className="bg-light">
+      <Card style={{ backgroundColor: 'var(--bg-secondary)' }}>
         <div className="d-flex align-items-start">
           <i className="bi bi-info-circle text-muted me-2" />
           <div className="small text-muted">


### PR DESCRIPTION
## 问题描述

Issue #1628：深色主题下"我的用量"页面底部的"关于配额限制"信息卡片使用了 Bootstrap 的 `bg-light` 固定浅色类，导致深色背景下卡片仍为白色，文字几乎不可读。

## 修复内容

移除 `bg-light` 类，改用项目主题感知的 CSS 变量 `var(--bg-secondary)`：
- **浅色主题**：`#f8fafc`（与原 `bg-light` 视觉几乎一致）
- **深色主题**：`#1e293b`（与深色背景协调，文字清晰可读）

卡片内的 `.text-muted` 文字已通过项目 CSS 正确适配双主题，无需额外修改。

## 修改范围
- `frontend/src/components/work/UsageOverview.tsx`（1行）

## 验收标准
- [x] 深色主题下"关于配额限制"卡片背景色与页面整体深色风格一致
- [x] 深色主题下卡片内文字清晰可读
- [x] 浅色主题下该区域显示完全不受影响
- [x] 修改范围仅限于当前文件，不涉及其他模块

## 人工验证
- [x] 已在 node237 部署并通过人工验证