### PR TITLE
fix(theme): 深色模式下全局 btn-secondary 按钮文字不可见 (Issue #1634)

### DIFF
--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -3727,7 +3727,10 @@ table .latency-row:hover td {
   --bs-btn-hover-border-color: var(--color-success-hover);
 }
 
-[data-theme='dark'] .session-detail-content .btn-secondary {
+/* Dark mode: global btn-secondary override (Issue #1634)
+   Previously scoped to .session-detail-content only, leaving portal-rendered
+   modals (NewSessionModal, ConfirmModal, etc.) with white-on-white text. */
+[data-theme='dark'] .btn-secondary {
   --bs-btn-color: #fff;
   --bs-btn-bg: #495057;
   --bs-btn-border-color: #495057;
@@ -3739,7 +3742,7 @@ table .latency-row:hover td {
   border-color: #495057 !important;
 }
 
-[data-theme='dark'] .session-detail-content .btn-secondary:hover {
+[data-theme='dark'] .btn-secondary:hover {
   color: #fff !important;
   background-color: #3d4349 !important;
   border-color: #373b3f !important;


### PR DESCRIPTION
## 问题

深色模式下，点击「+ 新建会话」按钮后弹窗中的【取消】按钮背景色（`#f1f3f5`）与字体颜色（`#f8fafc`）对比度仅约 **1.07:1**，文字几乎不可见。

## 根因

`.btn-secondary` 的深色模式覆盖规则选择器为 `[data-theme="dark"] .session-detail-content .btn-secondary`，作用域仅限于 `.session-detail-content` 内部。而 `NewSessionModal` 等弹窗通过 `createPortal` 渲染到 `document.body`，不在该作用域内，导致深色模式下背景色未被覆盖（仍为浅灰 `#f1f3f5`），文字色却因 CSS 变量 `--text-primary` 变为近白 `#f8fafc`，形成白底白字。

## 修复

将选择器从：
```css
[data-theme="dark"] .session-detail-content .btn-secondary
```
扩展为全局：
```css
[data-theme="dark"] .btn-secondary
```

修复后背景色 `#495057`（深灰）+ 文字色 `#fff`（白色），对比度约 **5.9:1**，满足 WCAG AA 标准（≥4.5:1）。

## 影响范围

此修复同时解决所有 portal 渲染弹窗中 `btn-secondary` 按钮在深色模式下的可读性问题：
- `NewSessionModal` — 新建会话【取消】
- `ConfirmModal` — 确认弹窗【取消】
- `Workspace.tsx` — 重命名弹窗、远程会话关闭确认
- `AvatarUploader` — 头像上传【取消】
- `CancelRoundModal` — 取消轮次

Closes #1634