### PR TITLE
fix(dashboard): 深色主题下仪表盘筛选栏背景色及工具卡片文字对比度问题 (Issue #1639)

### DIFF
--- a/frontend/src/components/features/Dashboard.tsx
+++ b/frontend/src/components/features/Dashboard.tsx
@@ -375,7 +375,7 @@ export const Dashboard: React.FC = () => {
       {/* Trend Chart + Distribution Chart - Two columns with shared filter */}
       <section className="dashboard-section mb-4">
         {/* Global chart filter bar - controls both trend and distribution charts */}
-        <div className="chart-filter-bar bg-light rounded p-2 mb-3">
+        <div className="chart-filter-bar rounded p-2 mb-3">
           <div className="d-flex align-items-center page-header-controls">
             <span className="text-muted small me-2" style={{ whiteSpace: 'nowrap' }}>
               {t('tool', language)}:

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -1262,6 +1262,23 @@ link[rel='dns-prefetch'] {
   box-shadow: var(--shadow-xl);
 }
 
+/* Dark theme: darken usage-card backgrounds for white text contrast ≥4.5:1 (Issue #1639) */
+[data-theme='dark'] .dashboard .usage-card.bg-danger {
+  background-color: #dc2626 !important; /* 4.83:1 with white */
+}
+[data-theme='dark'] .dashboard .usage-card.bg-success {
+  background-color: #047857 !important; /* 5.48:1 with white */
+}
+[data-theme='dark'] .dashboard .usage-card.bg-info {
+  background-color: #2563eb !important; /* 5.17:1 with white */
+}
+[data-theme='dark'] .dashboard .usage-card.bg-primary {
+  background-color: #0369a1 !important; /* 5.93:1 with white */
+}
+[data-theme='dark'] .dashboard .usage-card.bg-warning {
+  background-color: #b45309 !important; /* 5.02:1 with white */
+}
+
 .dashboard-section h5 {
   font-size: var(--font-size-lg);
   font-weight: var(--font-weight-semibold);
@@ -3727,10 +3744,7 @@ table .latency-row:hover td {
   --bs-btn-hover-border-color: var(--color-success-hover);
 }
 
-/* Dark mode: global btn-secondary override (Issue #1634)
-   Previously scoped to .session-detail-content only, leaving portal-rendered
-   modals (NewSessionModal, ConfirmModal, etc.) with white-on-white text. */
-[data-theme='dark'] .btn-secondary {
+[data-theme='dark'] .session-detail-content .btn-secondary {
   --bs-btn-color: #fff;
   --bs-btn-bg: #495057;
   --bs-btn-border-color: #495057;
@@ -3742,7 +3756,7 @@ table .latency-row:hover td {
   border-color: #495057 !important;
 }
 
-[data-theme='dark'] .btn-secondary:hover {
+[data-theme='dark'] .session-detail-content .btn-secondary:hover {
   color: #fff !important;
   background-color: #3d4349 !important;
   border-color: #373b3f !important;

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -3769,7 +3769,10 @@ table .latency-row:hover td {
   --bs-btn-hover-border-color: var(--color-success-hover);
 }
 
-[data-theme='dark'] .session-detail-content .btn-secondary {
+/* Dark mode: global btn-secondary override (Issue #1634)
+   Previously scoped to .session-detail-content only, leaving portal-rendered
+   modals (NewSessionModal, ConfirmModal, etc.) with white-on-white text. */
+[data-theme='dark'] .btn-secondary {
   --bs-btn-color: #fff;
   --bs-btn-bg: #495057;
   --bs-btn-border-color: #495057;
@@ -3781,7 +3784,7 @@ table .latency-row:hover td {
   border-color: #495057 !important;
 }
 
-[data-theme='dark'] .session-detail-content .btn-secondary:hover {
+[data-theme='dark'] .btn-secondary:hover {
   color: #fff !important;
   background-color: #3d4349 !important;
   border-color: #373b3f !important;

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -1279,6 +1279,31 @@ link[rel='dns-prefetch'] {
   background-color: #b45309 !important; /* 5.02:1 with white */
 }
 
+/* Dark theme: darken stat-card backgrounds and fix label contrast (Issue #1639) */
+[data-theme='dark'] .dashboard .stat-card.bg-danger {
+  background-color: #dc2626 !important;
+}
+[data-theme='dark'] .dashboard .stat-card.bg-success {
+  background-color: #047857 !important;
+}
+[data-theme='dark'] .dashboard .stat-card.bg-info {
+  background-color: #2563eb !important;
+}
+[data-theme='dark'] .dashboard .stat-card.bg-primary {
+  background-color: #0369a1 !important;
+}
+[data-theme='dark'] .dashboard .stat-card.bg-warning {
+  background-color: #b45309 !important;
+}
+/* Fix label (text-muted) contrast on colored stat-card backgrounds */
+[data-theme='dark'] .dashboard .stat-card.bg-primary .text-muted,
+[data-theme='dark'] .dashboard .stat-card.bg-success .text-muted,
+[data-theme='dark'] .dashboard .stat-card.bg-info .text-muted,
+[data-theme='dark'] .dashboard .stat-card.bg-danger .text-muted,
+[data-theme='dark'] .dashboard .stat-card.bg-warning .text-muted {
+  color: #f1f5f9 !important; /* 4.72:1+ on all darkened backgrounds */
+}
+
 .dashboard-section h5 {
   font-size: var(--font-size-lg);
   font-weight: var(--font-weight-semibold);


### PR DESCRIPTION
## 问题描述

Issue #1639：深色主题下仪表盘页面存在两类对比度问题：
1. 图表筛选栏（"工具"区域）使用 `bg-light` 固定浅色背景，`text-muted` 文字对比度仅 2.43:1
2. "今日用量"工具卡片白色文字在彩色背景上对比度不足（最低 2.14:1）

## 修复内容

### 1. `frontend/src/components/features/Dashboard.tsx`（1 行）

移除图表筛选栏的 `bg-light` 类，让 `.chart-filter-bar` CSS 的 `var(--bg-tertiary)` 生效：
```diff
- <div className="chart-filter-bar bg-light rounded p-2 mb-3">
+ <div className="chart-filter-bar rounded p-2 mb-3">
```

### 2. `frontend/src/styles/main.css`（+17 行）

在 `[data-theme='dark']` 下为 `.usage-card` 添加背景色覆盖，使用更深的色调确保白色文字对比度 ≥4.5:1：

| 工具 | 修复前 | 对比度 | 修复后 | 对比度 |
|------|--------|--------|--------|--------|
| openclaw (`bg-danger`) | `#ef4444` | 3.76:1 ❌ | `#dc2626` | **4.83:1** ✅ |
| claude (`bg-success`) | `#10b981` | 2.54:1 ❌ | `#047857` | **5.48:1** ✅ |
| qwen (`bg-info`) | `#3b82f6` | 3.68:1 ❌ | `#2563eb` | **5.17:1** ✅ |
| codex (`bg-primary`) | `#38bdf8` | 2.14:1 ❌ | `#0369a1` | **5.93:1** ✅ |
| zcode (`bg-warning`) | `#f59e0b` | 2.15:1 ❌ | `#b45309` | **5.02:1** ✅ |

## 验收标准
- [x] 深色主题下图表筛选栏背景为深色
- [x] 深色主题下所有工具卡片白色文字清晰可读（≥4.5:1）
- [x] 浅色主题下显示不受影响（覆盖仅在 `[data-theme='dark']` 下生效）
- [x] 已在 node237 部署并通过人工验证