### PR TITLE
fix: StatCard 深色主题覆盖选择器去掉 .dashboard 前缀，覆盖全部 14 个页面 (Issue #1644)

### DIFF
--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -1280,27 +1280,27 @@ link[rel='dns-prefetch'] {
 }
 
 /* Dark theme: darken stat-card backgrounds and fix label contrast (Issue #1639) */
-[data-theme='dark'] .dashboard .stat-card.bg-danger {
+[data-theme='dark'] .stat-card.bg-danger {
   background-color: #dc2626 !important;
 }
-[data-theme='dark'] .dashboard .stat-card.bg-success {
+[data-theme='dark'] .stat-card.bg-success {
   background-color: #047857 !important;
 }
-[data-theme='dark'] .dashboard .stat-card.bg-info {
+[data-theme='dark'] .stat-card.bg-info {
   background-color: #2563eb !important;
 }
-[data-theme='dark'] .dashboard .stat-card.bg-primary {
+[data-theme='dark'] .stat-card.bg-primary {
   background-color: #0369a1 !important;
 }
-[data-theme='dark'] .dashboard .stat-card.bg-warning {
+[data-theme='dark'] .stat-card.bg-warning {
   background-color: #b45309 !important;
 }
 /* Fix label (text-muted) contrast on colored stat-card backgrounds */
-[data-theme='dark'] .dashboard .stat-card.bg-primary .text-muted,
-[data-theme='dark'] .dashboard .stat-card.bg-success .text-muted,
-[data-theme='dark'] .dashboard .stat-card.bg-info .text-muted,
-[data-theme='dark'] .dashboard .stat-card.bg-danger .text-muted,
-[data-theme='dark'] .dashboard .stat-card.bg-warning .text-muted {
+[data-theme='dark'] .stat-card.bg-primary .text-muted,
+[data-theme='dark'] .stat-card.bg-success .text-muted,
+[data-theme='dark'] .stat-card.bg-info .text-muted,
+[data-theme='dark'] .stat-card.bg-danger .text-muted,
+[data-theme='dark'] .stat-card.bg-warning .text-muted {
   color: #f1f5f9 !important; /* 4.72:1+ on all darkened backgrounds */
 }
 


### PR DESCRIPTION
## 问题描述

Issue #1644：PR #1640 为 StatCard 添加的深色主题 CSS 覆盖使用了 `.dashboard .stat-card.bg-*` 选择器，仅在仪表盘页面生效。全项目共有 14 个文件使用 StatCard 组件，其余 13 个页面（请求统计、Token 趋势、异常检测、ROI 分析、审计中心等）的 StatCard 在深色主题下标签文字对比度极低。

## 修复内容

`frontend/src/styles/main.css`：将 10 处选择器从 `.dashboard .stat-card` 改为 `.stat-card`（去掉 `.dashboard` 前缀）

```diff
- [data-theme='dark'] .dashboard .stat-card.bg-danger {
+ [data-theme='dark'] .stat-card.bg-danger {
```

## 影响范围

| 修复前 | 修复后 |
|--------|--------|
| 仅仪表盘（1 个页面） | 全部 14 个使用 StatCard 的页面 |

## 验收标准
- [x] 所有使用 StatCard 的页面在深色主题下标签文字清晰可读
- [x] 浅色主题下显示不受影响
- [x] 仅修改 `main.css`，不修改组件代码
- [x] 已部署到测试环境并通过人工验证