### PR TITLE
fix(anomaly): 深色主题下异常检测页面 bg-light 背景及 Badge 文字对比度问题 (Issue #1648)

### DIFF
--- a/frontend/src/components/features/analysis/AnomalyDetection.tsx
+++ b/frontend/src/components/features/analysis/AnomalyDetection.tsx
@@ -16,6 +16,8 @@ import { cn, createMatcherConfig } from '@/utils';
 import { useLanguage } from '@/store';
 import { t, type Language } from '@/i18n';
 import {
+  Badge,
+  type BadgeVariant,
   Card,
   StatCard,
   Select,
@@ -376,7 +378,7 @@ export const AnomalyDetection: React.FC = () => {
               >
                 {/* Baseline banner — surfaces the detection context (currently discarded) */}
                 {anomalyData?.statistics && (
-                  <div className="mb-3 p-2 bg-light rounded">
+                  <div className="anomaly-baseline-banner mb-3 p-2 rounded">
                     <small className="fw-semibold text-muted d-block mb-1">
                       {t('anomalyMethodIntro', language)}
                     </small>
@@ -401,16 +403,11 @@ export const AnomalyDetection: React.FC = () => {
                           <div className="d-flex justify-content-between align-items-start">
                             <div className="me-2 flex-grow-1" style={{ minWidth: 0 }}>
                               <div className="d-flex align-items-center gap-2 mb-1 flex-wrap">
-                                <span
-                                  className={cn(
-                                    'badge',
-                                    anomaly.type === 'spike' ? 'bg-danger' : 'bg-info'
-                                  )}
-                                >
+                                <Badge variant={anomaly.type === 'spike' ? 'danger' : 'info'}>
                                   {anomaly.type === 'spike'
                                     ? t('usageSpike', language)
                                     : t('usageDrop', language)}
-                                </span>
+                                </Badge>
                                 <span className="text-muted small" style={{ whiteSpace: 'nowrap' }}>
                                   {anomaly.date}
                                 </span>
@@ -431,18 +428,18 @@ export const AnomalyDetection: React.FC = () => {
                                 {getAnomalySuggestion(anomaly.type, language)}
                               </p>
                             </div>
-                            <span
-                              className={cn(
-                                'badge ms-2',
+                            <Badge
+                              className="ms-2"
+                              variant={
                                 anomaly.severity === 'high'
-                                  ? 'bg-danger'
+                                  ? 'danger'
                                   : anomaly.severity === 'medium'
-                                    ? 'bg-warning'
-                                    : 'bg-info'
-                              )}
+                                    ? 'warning'
+                                    : 'info'
+                              }
                             >
                               {anomaly.severity}
-                            </span>
+                            </Badge>
                           </div>
                         </li>
                       );
@@ -479,9 +476,9 @@ export const AnomalyDetection: React.FC = () => {
                               </p>
                             )}
                           </div>
-                          <span className={cn('badge', getImpactBadge(rec.type))}>
+                          <Badge variant={getImpactBadgeVariant(rec.type)}>
                             {t(getImpactKey(rec.type), language)}
-                          </span>
+                          </Badge>
                         </div>
                       </li>
                     ))}
@@ -512,17 +509,17 @@ function getRecommendationIcon(type: string): string {
   return icons[type] ?? 'bi-lightbulb';
 }
 
-function getImpactBadge(type: string): string {
-  const badges: Record<string, string> = {
-    optimization: 'bg-warning',
-    cost: 'bg-danger',
-    performance: 'bg-warning',
-    security: 'bg-danger',
-    usage: 'bg-info',
-    info: 'bg-info',
-    success: 'bg-success',
+function getImpactBadgeVariant(type: string): BadgeVariant {
+  const variants: Record<string, BadgeVariant> = {
+    optimization: 'warning',
+    cost: 'danger',
+    performance: 'warning',
+    security: 'danger',
+    usage: 'info',
+    info: 'info',
+    success: 'success',
   };
-  return badges[type] || 'bg-secondary';
+  return variants[type] || 'secondary';
 }
 
 function getImpactKey(type: string): string {

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -1304,6 +1304,36 @@ link[rel='dns-prefetch'] {
   color: #f1f5f9 !important; /* 4.72:1+ on all darkened backgrounds */
 }
 
+/* Dark theme: darken badge backgrounds for text contrast ≥4.5:1 (Issue #1648)
+   Badge component uses text-dark for warning/info/success — override to white
+   in dark theme so white text on darkened backgrounds meets WCAG AA. */
+[data-theme='dark'] .badge.bg-danger {
+  background-color: #dc2626 !important; /* 4.83:1 with white */
+}
+[data-theme='dark'] .badge.bg-success {
+  background-color: #047857 !important; /* 5.48:1 with white */
+  color: #fff !important;
+}
+[data-theme='dark'] .badge.bg-info {
+  background-color: #1e40af !important; /* 8.72:1 with white */
+  color: #fff !important;
+}
+[data-theme='dark'] .badge.bg-warning {
+  background-color: #b45309 !important; /* 5.02:1 with white */
+  color: #fff !important;
+}
+[data-theme='dark'] .badge.bg-primary {
+  background-color: #1e40af !important; /* 8.72:1 with white */
+}
+
+/* Anomaly detection baseline banner — theme-aware subtle background (Issue #1648) */
+.anomaly-baseline-banner {
+  background-color: var(--bg-secondary);
+}
+[data-theme='dark'] .anomaly-baseline-banner {
+  background-color: rgba(255, 255, 255, 0.05);
+}
+
 .dashboard-section h5 {
   font-size: var(--font-size-lg);
   font-weight: var(--font-weight-semibold);


### PR DESCRIPTION
## 问题描述

Issue #1648：异常检测页面在深色主题下存在两类对比度问题：
1. 检测方法说明区域使用 `bg-light` 固定浅色背景，`text-muted` 文字对比度仅 2.43:1
2. 异常列表 Badge（类型/严重程度/影响程度）白色文字在亮色背景上对比度不足（2.15~3.76:1）

## 修复内容

### 1. `frontend/src/components/features/analysis/AnomalyDetection.tsx`

- 检测方法说明区域：`bg-light` → CSS 类 `.anomaly-baseline-banner`
- 异常类型 Badge：`<span className="badge bg-*">` → `<Badge variant="...">`
- 严重程度 Badge：同上
- 影响程度 Badge：`getImpactBadge()` → `getImpactBadgeVariant()` + `<Badge>`
- 新增 `Badge`、`BadgeVariant` import

### 2. `frontend/src/styles/main.css`

**Badge 深色主题背景色覆盖**（白色文字对比度 ≥4.5:1）：

| Badge | 修复前 | 对比度 | 修复后 | 对比度 |
|-------|--------|--------|--------|--------|
| `bg-danger` | `#ef4444` 白字 | 3.76:1 ❌ | `#dc2626` 白字 | **4.83:1** ✅ |
| `bg-warning` | `#f59e0b` 白字 | 2.15:1 ❌ | `#b45309` 白字 | **5.02:1** ✅ |
| `bg-info` | `#3b82f6` 白字 | 3.68:1 ❌ | `#1e40af` 白字 | **8.72:1** ✅ |
| `bg-success` | `#10b981` 白字 | 2.54:1 ❌ | `#047857` 白字 | **5.48:1** ✅ |

warning/info/success Badge 同时覆盖 `color: #fff`（原 Badge 组件使用 `text-dark`，深色背景上需改为白色）。

**Baseline banner 主题适配**：
- 浅色主题：`var(--bg-secondary)`（与原 `bg-light` 效果一致）
- 深色主题：`rgba(255, 255, 255, 0.05)`（微妙区分，不破坏深色背景）

## 验收标准
- [x] 深色主题下检测方法说明区域背景与深色主题协调
- [x] 深色主题下所有 Badge 文字清晰可读（≥4.5:1）
- [x] 浅色主题下显示不受影响
- [x] 已在 node237 部署并通过人工验证