### PR TITLE
fix(history): 深色主题下对话历史页面及对话详情弹窗多处对比度问题 (Issue #1652)

### DIFF
--- a/frontend/src/components/features/ConversationHistory.tsx
+++ b/frontend/src/components/features/ConversationHistory.tsx
@@ -19,6 +19,7 @@ import {
 import { useLanguage } from '@/store';
 import { t, type Language } from '@/i18n';
 import {
+  Badge,
   Card,
   Button,
   Select,
@@ -803,10 +804,10 @@ const MessageItem: React.FC<MessageItemProps> = ({
             </span>
           )}
           {msg.model && (
-            <span className="badge bg-dark">
+            <Badge variant="dark">
               <i className="bi bi-cpu me-1" />
               {msg.model}
-            </span>
+            </Badge>
           )}
         </div>
         <small className="text-muted">
@@ -1045,34 +1046,34 @@ export const ConversationDetailModal: React.FC<ConversationDetailModalProps> = (
               </div>
               {messageStats.user > 0 && (
                 <div className="col-auto">
-                  <span className="badge bg-primary me-1">
+                  <Badge variant="primary" className="me-1">
                     <i className="bi bi-person me-1" />
                     User: {messageStats.user}
-                  </span>
+                  </Badge>
                 </div>
               )}
               {messageStats.assistant > 0 && (
                 <div className="col-auto">
-                  <span className="badge bg-success me-1">
+                  <Badge variant="success" className="me-1">
                     <i className="bi bi-robot me-1" />
                     Assistant: {messageStats.assistant}
-                  </span>
+                  </Badge>
                 </div>
               )}
               {messageStats.toolResult > 0 && (
                 <div className="col-auto">
-                  <span className="badge bg-info me-1">
+                  <Badge variant="info" className="me-1">
                     <i className="bi bi-wrench me-1" />
                     Tool: {messageStats.toolResult}
-                  </span>
+                  </Badge>
                 </div>
               )}
               {messageStats.totalTokens > 0 && (
                 <div className="col-auto">
-                  <span className="badge bg-dark me-1">
+                  <Badge variant="dark" className="me-1">
                     <i className="bi bi-coin me-1" />
                     {formatTokens(messageStats.totalTokens)} {t('tokens', language)}
-                  </span>
+                  </Badge>
                 </div>
               )}
             </div>
@@ -1273,18 +1274,17 @@ export const ConversationDetailModal: React.FC<ConversationDetailModalProps> = (
                                 <small>{truncatePreview(d.content)}</small>
                               </td>
                               <td>
-                                <span
-                                  className={cn(
-                                    'badge',
+                                <Badge
+                                  variant={
                                     d.latency > 10
-                                      ? 'bg-danger'
+                                      ? 'danger'
                                       : d.latency > 5
-                                        ? 'bg-warning'
-                                        : 'bg-success'
-                                  )}
+                                        ? 'warning'
+                                        : 'success'
+                                  }
                                 >
                                   {d.latency}s
-                                </span>
+                                </Badge>
                               </td>
                               <td>
                                 <small>{formatDateTime(d.timestamp)}</small>

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -3793,10 +3793,11 @@ table .latency-row:hover td {
   color: #fff !important;
 }
 
-/* Fix Bootstrap .text-dark on warning/info badges in dark theme */
+/* Fix Bootstrap .text-dark on warning/info badges in dark theme —
+   use white text on darkened badge backgrounds (Issue #1652) */
 [data-theme='dark'] .session-detail-content .badge.bg-warning.text-dark,
 [data-theme='dark'] .session-detail-content .badge.bg-info.text-dark {
-  color: #000 !important;
+  color: #fff !important;
 }
 
 /* Filter buttons - improve contrast for outline buttons in dark theme */
@@ -3848,6 +3849,40 @@ table .latency-row:hover td {
   --bs-btn-hover-color: #fff;
   --bs-btn-hover-bg: var(--color-success-hover);
   --bs-btn-hover-border-color: var(--color-success-hover);
+}
+
+/* Conversation History page — dark theme overrides (Issue #1652) */
+
+/* Fullscreen mode — replace bg-white with dark background */
+[data-theme='dark'] .conversation-history-fullscreen.bg-white {
+  background-color: var(--bg-primary) !important;
+  color: var(--text-primary) !important;
+}
+
+/* Message items in conversation detail modal (rendered via portal) */
+[data-theme='dark'] .modal .message-item.bg-light,
+[data-theme='dark'] .modal .message-item.bg-white {
+  background-color: var(--bg-secondary) !important;
+  border-color: var(--border-color) !important;
+}
+
+/* Latency statistics cards inside conversation detail modal */
+[data-theme='dark'] .modal .latency-chart .card.bg-light {
+  background-color: var(--bg-secondary) !important;
+  border-color: var(--border-color) !important;
+}
+
+/* Message items on the conversation history page itself */
+[data-theme='dark'] .conversation-history .message-item.bg-light,
+[data-theme='dark'] .conversation-history .message-item.bg-white {
+  background-color: var(--bg-secondary) !important;
+  border-color: var(--border-color) !important;
+}
+
+/* Latency statistics cards on the conversation history page */
+[data-theme='dark'] .conversation-history .card.bg-light {
+  background-color: var(--bg-secondary) !important;
+  border-color: var(--border-color) !important;
 }
 
 /* Dark mode: global btn-secondary override (Issue #1634)


### PR DESCRIPTION
## 问题描述

Issue #1652：对话历史页面及对话详情弹窗在深色主题下存在 6 处对比度问题。

## 修复内容

### 1. `frontend/src/components/features/ConversationHistory.tsx`

- 新增 `Badge` 组件 import
- 将 7 处原始 `<span className="badge bg-*">` 替换为 `<Badge>` 组件：
  - 消息统计 Badge（primary/success/info）
  - 模型/Token Badge（dark）
  - 延迟严重度 Badge（danger/warning/success）

### 2. `frontend/src/styles/main.css`

**对话详情弹窗（Modal portal 渲染）**：
- `.modal .message-item.bg-light/bg-white` → `var(--bg-secondary)`（修复消息项白色背景）
- `.modal .latency-chart .card.bg-light` → `var(--bg-secondary)`（修复延迟统计卡片白色背景）
- `.badge.bg-warning.text-dark` / `.badge.bg-info.text-dark` → `color: #fff`（修复 Badge text-dark 与 Issue #1648 深色背景冲突）

**对话历史页面**：
- `.conversation-history-fullscreen.bg-white` → `var(--bg-primary)`（修复全屏模式白色背景）
- `.conversation-history .message-item.bg-light/bg-white` → `var(--bg-secondary)`
- `.conversation-history .card.bg-light` → `var(--bg-secondary)`

## 关键发现

对话详情弹窗通过 `<Modal>` 的 `createPortal` 渲染到 `document.body`，脱离了 `.conversation-history` 页面 DOM 层级。CSS 选择器需要同时覆盖 `.modal` 和 `.conversation-history` 两个作用域。

## 验收标准
- [x] 对话详情弹窗消息项背景为深色
- [x] 对话详情弹窗延迟统计卡片背景为深色
- [x] 对话详情弹窗 Badge 文字清晰可读
- [x] 对话历史页面全屏模式背景为深色
- [x] 浅色主题下显示不受影响
- [x] 已在 node237 部署并通过人工验证