### PR TITLE
fix(ui): SearchableSelect 下拉弹窗深色模式背景适配

### DIFF
--- a/frontend/src/components/common/SearchableSelect.tsx
+++ b/frontend/src/components/common/SearchableSelect.tsx
@@ -116,7 +116,7 @@ export const SearchableSelect: React.FC<SearchableSelectProps> = ({
       {/* Dropdown Menu */}
       {isOpen && (
         <div
-          className="position-absolute top-100 start-0 mt-1 bg-white border rounded shadow-sm"
+          className="searchable-select-dropdown position-absolute top-100 start-0 mt-1 border rounded shadow-sm"
           style={{ minWidth: '100%', maxHeight: '300px', overflow: 'hidden', zIndex: 1050 }}
           role="listbox"
         >
@@ -143,9 +143,8 @@ export const SearchableSelect: React.FC<SearchableSelectProps> = ({
                   key={option.value}
                   type="button"
                   className={cn(
-                    'text-start px-3 py-2 border-0 bg-transparent',
-                    'hover:bg-light cursor-pointer text-nowrap',
-                    option.value === value && 'bg-primary bg-opacity-10',
+                    'searchable-select-option text-start px-3 py-2 border-0',
+                    option.value === value && 'active',
                     option.disabled && 'text-muted'
                   )}
                   style={{ minWidth: '100%' }}

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -1591,6 +1591,50 @@ table .latency-row:hover td {
   border-top: 1px solid var(--border-color);
 }
 
+/* SearchableSelect dropdown - theme-aware styling */
+.searchable-select-dropdown {
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  border-color: var(--border-color) !important;
+}
+
+.searchable-select-dropdown .border-bottom {
+  border-color: var(--border-color) !important;
+}
+
+.searchable-select-dropdown .form-control {
+  background-color: var(--bg-secondary);
+  border-color: var(--border-color);
+  color: var(--text-primary);
+}
+
+.searchable-select-dropdown .form-control::placeholder {
+  color: var(--text-muted);
+}
+
+.searchable-select-dropdown .form-control:focus {
+  background-color: var(--bg-secondary);
+  border-color: var(--color-primary);
+  color: var(--text-primary);
+  box-shadow: 0 0 0 3px rgba(var(--color-primary-rgb), 0.15);
+}
+
+.searchable-select-option {
+  background-color: transparent;
+  color: var(--text-primary);
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background-color var(--transition-fast);
+}
+
+.searchable-select-option:hover {
+  background-color: var(--bg-tertiary);
+}
+
+.searchable-select-option.active {
+  background-color: rgba(var(--color-primary-rgb), 0.1);
+}
+
 /* Legacy message-content class for backward compatibility */
 .message-content {
   white-space: pre-wrap;


### PR DESCRIPTION
## 问题

全局设置为深色模式后，管理 → 分析 → 消息页面，点击发送者筛选器的"所有发送者"按钮，弹出的下拉搜索弹窗外围背景为白色，未适配 dark theme。

## 根因

`SearchableSelect.tsx` 中下拉菜单容器硬编码了 Bootstrap 的 `bg-white` 类，选项使用了 `hover:bg-light` 等不随主题变化的工具类。

## 修复

1. 将 `bg-white` 替换为自定义主题感知类 `.searchable-select-dropdown`
2. 将选项的 `hover:bg-light bg-transparent` 替换为 `.searchable-select-option`
3. 在 `main.css` 中使用 CSS 变量定义样式，自动适配 light/dark 主题

## 影响范围

- `Messages.tsx` 发送者筛选器
- `ConversationHistory.tsx` 中同样使用 `SearchableSelect` 的筛选器

## 排查结论（消息页面其他元素）

逐项检查消息页面所有元素，其余在深色模式下均正常（form-control、form-select、Card、message-item、message-content-expanded、message-footer、pre、EmptyState、Pagination）。

Closes #1664