### PR TITLE
fix(ui): 审计中心深色模式适配 - 详情弹窗及表格样式

### DIFF
--- a/frontend/src/components/features/compliance/AuditAnalysis.tsx
+++ b/frontend/src/components/features/compliance/AuditAnalysis.tsx
@@ -173,26 +173,13 @@ export const AuditAnalysis: React.FC = () => {
                 className={cn(
                   'security-score-circle',
                   securityScore.score >= 80
-                    ? 'text-success'
+                    ? 'security-score-good'
                     : securityScore.score >= 60
-                      ? 'text-warning'
-                      : 'text-danger'
+                      ? 'security-score-medium'
+                      : 'security-score-poor'
                 )}
               >
-                <div
-                  className="display-1 fw-bold"
-                  style={{
-                    fontSize: '4rem',
-                    color:
-                      securityScore.score >= 80
-                        ? '#198754'
-                        : securityScore.score >= 60
-                          ? '#ffc107'
-                          : '#dc3545',
-                  }}
-                >
-                  {securityScore.score}
-                </div>
+                <div className="display-1 fw-bold security-score-value">{securityScore.score}</div>
                 <div className="text-muted">
                   {t('overallScore', language)} ({securityScore.grade})
                 </div>

--- a/frontend/src/components/features/management/AuditCenter.tsx
+++ b/frontend/src/components/features/management/AuditCenter.tsx
@@ -599,7 +599,7 @@ export const AuditCenter: React.FC = () => {
                           <div className="mt-3">
                             <h6>{t('tableDetails', language)}</h6>
                             <pre
-                              className="bg-light p-3 rounded"
+                              className="audit-detail-pre p-3 rounded"
                               style={{
                                 maxHeight: '300px',
                                 overflow: 'auto',
@@ -649,24 +649,13 @@ export const AuditCenter: React.FC = () => {
                   className={cn(
                     'security-score-circle',
                     securityScore.score >= 80
-                      ? 'text-success'
+                      ? 'security-score-good'
                       : securityScore.score >= 60
-                        ? 'text-warning'
-                        : 'text-danger'
+                        ? 'security-score-medium'
+                        : 'security-score-poor'
                   )}
                 >
-                  <div
-                    className="display-1 fw-bold"
-                    style={{
-                      fontSize: '4rem',
-                      color:
-                        securityScore.score >= 80
-                          ? '#198754'
-                          : securityScore.score >= 60
-                            ? '#ffc107'
-                            : '#dc3545',
-                    }}
-                  >
+                  <div className="display-1 fw-bold security-score-value">
                     {securityScore.score}
                   </div>
                   <div className="text-muted">

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -1635,6 +1635,81 @@ table .latency-row:hover td {
   background-color: rgba(var(--color-primary-rgb), 0.1);
 }
 
+/* Audit Center - theme-aware styling */
+.audit-detail-pre {
+  background-color: var(--bg-secondary);
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
+  font-size: 0.85rem;
+}
+
+/* Security Score Circle - theme-aware colors */
+.security-score-value {
+  font-size: 4rem;
+}
+
+.security-score-good .security-score-value {
+  color: var(--color-success);
+}
+
+.security-score-medium .security-score-value {
+  color: var(--color-warning);
+}
+
+.security-score-poor .security-score-value {
+  color: var(--color-danger);
+}
+
+/* Audit Center tables - dark theme */
+[data-theme='dark'] .audit-center .table {
+  --bs-table-color: var(--text-primary);
+  --bs-table-bg: transparent;
+  --bs-table-border-color: var(--border-color);
+  --bs-table-hover-color: var(--text-primary);
+  --bs-table-hover-bg: rgba(255, 255, 255, 0.05);
+  --bs-table-striped-color: var(--text-primary);
+  --bs-table-striped-bg: rgba(255, 255, 255, 0.02);
+  color: var(--text-primary);
+}
+
+/* Audit Center modal table */
+[data-theme='dark'] .audit-center .modal .table {
+  --bs-table-color: var(--text-primary);
+  --bs-table-bg: transparent;
+  --bs-table-border-color: var(--border-color);
+  color: var(--text-primary);
+}
+
+/* Audit Center modal detail pre */
+[data-theme='dark'] .audit-center .modal pre {
+  background-color: var(--bg-secondary);
+  color: var(--text-primary);
+  border-color: var(--border-color);
+}
+
+/* Audit Center list-group - dark theme */
+[data-theme='dark'] .audit-center .list-group-item {
+  background-color: var(--bg-secondary);
+  border-color: var(--border-color);
+  color: var(--text-primary);
+}
+
+/* Audit Analysis page - same overrides (standalone page) */
+[data-theme='dark'] .audit-analysis .table {
+  --bs-table-color: var(--text-primary);
+  --bs-table-bg: transparent;
+  --bs-table-border-color: var(--border-color);
+  --bs-table-hover-color: var(--text-primary);
+  --bs-table-hover-bg: rgba(255, 255, 255, 0.05);
+  color: var(--text-primary);
+}
+
+[data-theme='dark'] .audit-analysis .list-group-item {
+  background-color: var(--bg-secondary);
+  border-color: var(--border-color);
+  color: var(--text-primary);
+}
+
 /* Legacy message-content class for backward compatibility */
 .message-content {
   white-space: pre-wrap;


### PR DESCRIPTION
## 问题

管理 → 治理 → 审计中心页面深色模式下多处不适配：
1. 审计日志详情弹窗中 `pre.bg-light` 呈现浅色主题白色背景
2. 安全分数使用硬编码内联颜色 `#198754`/`#ffc107`/`#dc3545`
3. 表格 (`table-hover`)、`list-group-item` 缺少深色模式覆盖

## 修复

1. 将 `bg-light` 替换为主题感知类 `.audit-detail-pre`，使用 `var(--bg-secondary)` / `var(--text-primary)` / `var(--border-color)`
2. 将安全分数硬编码内联颜色替换为 `.security-score-{good,medium,poor}` CSS 类，使用 `var(--color-success)` / `var(--color-warning)` / `var(--color-danger)`
3. 在 `main.css` 中为 `.audit-center` 和 `.audit-analysis` 添加表格、列表组的深色模式覆盖

## 影响范围

- `AuditCenter.tsx`（审计日志 + 审计分析 tab）
- `AuditAnalysis.tsx`（独立审计分析页面）

Closes #1666