### PR TITLE
fix(ui): 合规报告和数据保留页面深色模式背景适配 (Issue #1669)

### DIFF
--- a/frontend/src/components/features/compliance/ComplianceReport.tsx
+++ b/frontend/src/components/features/compliance/ComplianceReport.tsx
@@ -145,7 +145,7 @@ export const ComplianceReport: React.FC = () => {
               <div
                 className={cn(
                   'report-type-card p-3 border rounded cursor-pointer',
-                  selectedType === type.type && 'border-primary bg-light'
+                  selectedType === type.type && 'report-type-card-selected border-primary'
                 )}
                 onClick={() => setSelectedType(type.type)}
                 style={{ cursor: 'pointer' }}

--- a/frontend/src/components/features/management/ComplianceMgmt.tsx
+++ b/frontend/src/components/features/management/ComplianceMgmt.tsx
@@ -508,7 +508,7 @@ export const ComplianceMgmt: React.FC = () => {
                 <div
                   className={cn(
                     'report-type-card p-3 border rounded cursor-pointer',
-                    selectedType === type.type && 'border-primary bg-light'
+                    selectedType === type.type && 'report-type-card-selected border-primary'
                   )}
                   onClick={() => setSelectedType(type.type)}
                   style={{ cursor: 'pointer' }}

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -1334,6 +1334,22 @@ link[rel='dns-prefetch'] {
   background-color: rgba(255, 255, 255, 0.05);
 }
 
+/* Compliance report type card — theme-aware selected background (Issue #1660)
+   Replaces Bootstrap .bg-light which stays white (#f8f9fa) in dark mode. */
+.report-type-card-selected {
+  background-color: var(--bg-secondary);
+}
+[data-theme='dark'] .report-type-card-selected {
+  background-color: var(--bg-tertiary);
+}
+
+/* StatCard default variant (.bg-light) — darken in dark mode (Issue #1660)
+   The default StatCard uses Bootstrap .bg-light which stays #f8f9fa in dark mode. */
+[data-theme='dark'] .stat-card.bg-light {
+  background-color: var(--bg-tertiary) !important;
+  color: var(--text-primary) !important;
+}
+
 .dashboard-section h5 {
   font-size: var(--font-size-lg);
   font-weight: var(--font-weight-semibold);


### PR DESCRIPTION
## Description

Fixes #1669

管理 → 治理 → 合规管理中的深色模式背景问题修复：

1. **合规报告页面**：选中报告类型卡片背景从 `bg-light`（深色模式下为白色 `#f8f9fa`）替换为主题感知类 `report-type-card-selected`，深色模式下使用 `--bg-tertiary`。
2. **数据保留页面**：为 StatCard 默认变体（`.bg-light`）添加深色模式覆盖，"保留规则"统计卡片背景不再为白色。

## Type of Change

- [x] Bug fix (non-breaking change which fixes functionality)

## How Has This Been Tested?

- [x] Manual testing performed

## Changes

| File | Change |
|------|--------|
| `ComplianceReport.tsx` | 选中态 `bg-light` → `report-type-card-selected` |
| `ComplianceMgmt.tsx` | 同上 |
| `main.css` | 新增 `.report-type-card-selected` 和 `[data-theme=dark] .stat-card.bg-light` 样式 |

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings