### PR TITLE
fix(Messages): 消息页面 UI/UX 优化 (Issue #1434)

### DIFF
--- a/frontend/src/components/features/Messages.tsx
+++ b/frontend/src/components/features/Messages.tsx
@@ -1,8 +1,15 @@
 /**
  * Messages Component - Messages list with filters
+ *
+ * UI improvements for Issue #1434:
+ * - Responsive filter layout (no fixed widths)
+ * - Optimized role-badge design (icon + lowercase text)
+ * - Meta info for all roles (not just user)
+ * - Debounced search input
+ * - Default filter: all roles + last 7 days
  */
 
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useCallback, useRef, useEffect } from 'react';
 import { cn } from '@/utils';
 import {
   useMessages,
@@ -34,19 +41,53 @@ import {
 import type { Message, MessageFilters } from '@/types';
 
 const ITEMS_PER_PAGE = 20;
+const SEARCH_DEBOUNCE_MS = 300;
 
-// Get today's date in ISO format for default filter
-const getTodayDate = () => formatDate(new Date(), 'iso');
+// Get date N days ago in ISO format
+const getDateDaysAgo = (days: number) => {
+  const date = new Date();
+  date.setDate(date.getDate() - days);
+  return formatDate(date, 'iso');
+};
+
+// Custom hook for debounced value
+function useDebouncedValue<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedValue(value), delay);
+    return () => clearTimeout(timer);
+  }, [value, delay]);
+
+  return debouncedValue;
+}
 
 export const Messages: React.FC = () => {
   const language = useLanguage();
-  const [selectedRoles, setSelectedRoles] = useState<string[]>(['user']);
+
+  // Default: all roles selected + last 7 days
+  const defaultRoles = ['user', 'assistant', 'system'];
+  const [selectedRoles, setSelectedRoles] = useState<string[]>(defaultRoles);
+  const [searchInput, setSearchInput] = useState('');
+  const debouncedSearch = useDebouncedValue(searchInput, SEARCH_DEBOUNCE_MS);
+
   const [filters, setFilters] = useState<MessageFilters>(() => ({
-    startDate: getTodayDate(),
-    endDate: getTodayDate(),
-    role: ['user'],
+    startDate: getDateDaysAgo(7),
+    endDate: formatDate(new Date(), 'iso'),
+    role: defaultRoles,
   }));
   const [page, setPage] = useState(1);
+
+  // Ref to track if we should apply debounced search
+  const filtersRef = useRef(filters);
+
+  // Apply debounced search to filters
+  useEffect(() => {
+    if (debouncedSearch !== filtersRef.current.search) {
+      setFilters((prev) => ({ ...prev, search: debouncedSearch || undefined }));
+      setPage(1);
+    }
+  }, [debouncedSearch]);
 
   // Get hosts for filter
   const { data: hostsData } = useHosts();
@@ -71,12 +112,12 @@ export const Messages: React.FC = () => {
   const messages = data?.data ?? [];
   const pagination = data?.pagination;
 
-  // Page refresh control - manages auto refresh for messages queries
+  // Page refresh control
   const pageRefresh = usePageRefresh({
     page: '/manage/messages',
     refreshKey: createMatcherConfig([['messages']], 'prefix'),
-    interval: 60000, // 1 minute default
-    enabled: false, // Disable by default for historical messages
+    interval: 60000,
+    enabled: false,
   });
 
   // Get tools for filter
@@ -111,23 +152,35 @@ export const Messages: React.FC = () => {
   );
 
   // Handle role checkbox change
-  const handleRoleChange = (role: string, checked: boolean) => {
-    const newRoles = checked ? [...selectedRoles, role] : selectedRoles.filter((r) => r !== role);
-    setSelectedRoles(newRoles);
-    setFilters((prev) => ({ ...prev, role: newRoles.length > 0 ? newRoles : undefined }));
+  const handleRoleChange = useCallback((role: string, checked: boolean) => {
+    setSelectedRoles((prev) => {
+      const newRoles = checked ? [...prev, role] : prev.filter((r) => r !== role);
+      return newRoles;
+    });
+    setFilters((prev) => {
+      const newRoles = checked
+        ? [...(prev.role || []), role]
+        : (prev.role || []).filter((r) => r !== role);
+      return { ...prev, role: newRoles.length > 0 ? newRoles : undefined };
+    });
     setPage(1);
-  };
+  }, []);
 
-  const handleFilterChange = (key: keyof MessageFilters, value: string) => {
+  const handleFilterChange = useCallback((key: keyof MessageFilters, value: string) => {
     setFilters((prev) => {
       const next = { ...prev, [key]: value || undefined };
       if (next.startDate && next.endDate && next.endDate < next.startDate) {
         next.endDate = undefined;
       }
+      filtersRef.current = next;
       return next;
     });
     setPage(1);
-  };
+  }, []);
+
+  const handleSearchChange = useCallback((value: string) => {
+    setSearchInput(value);
+  }, []);
 
   if (isError) {
     return <Error message={error?.message || t('error', language)} onRetry={() => refetch()} />;
@@ -146,118 +199,117 @@ export const Messages: React.FC = () => {
         />
       </div>
 
-      {/* Filters - Nested flex for column alignment */}
-      <Card className="mb-3">
-        {/* Row 1: Date Range + Filters */}
-        <div className="d-flex align-items-center gap-2 mb-2">
-          <div className="d-flex align-items-center gap-1" style={{ minWidth: '440px' }}>
-            <small className="text-muted">{t('startDate', language)}:</small>
-            <input
-              type="date"
-              className="form-control form-control-sm"
-              style={{ width: '150px' }}
-              value={filters.startDate ?? ''}
-              aria-label={t('startDate', language)}
-              onChange={(e) => handleFilterChange('startDate', e.target.value)}
-            />
-            <small className="text-muted ms-2">{t('endDate', language)}:</small>
-            <input
-              type="date"
-              className="form-control form-control-sm"
-              style={{ width: '150px' }}
-              value={filters.endDate ?? ''}
-              aria-label={t('endDate', language)}
-              onChange={(e) => handleFilterChange('endDate', e.target.value)}
-            />
-          </div>
-          <div className="d-flex align-items-center gap-2 flex-grow-1">
-            <div className="d-flex align-items-center gap-1">
-              <small className="text-muted">{t('tableHost', language)}:</small>
-              <Select
-                options={hostOptions}
-                value={filters.host ?? ''}
-                onChange={(value) => handleFilterChange('host', value)}
-                size="sm"
-                style={{ width: '150px' } as React.CSSProperties}
+      {/* Filters - Responsive layout */}
+      <Card className="mb-3 messages-filter-card">
+        {/* Filter Row 1: Date Range */}
+        <div className="messages-filter-row">
+          <div className="messages-filter-group messages-filter-dates">
+            <label className="messages-filter-label">
+              <i className="bi bi-calendar-range me-1" />
+              {t('dateRange', language)}
+            </label>
+            <div className="messages-filter-dates-inputs">
+              <input
+                type="date"
+                className="form-control form-control-sm"
+                value={filters.startDate ?? ''}
+                aria-label={t('startDate', language)}
+                onChange={(e) => handleFilterChange('startDate', e.target.value)}
               />
-            </div>
-            <div className="d-flex align-items-center gap-1">
-              <small className="text-muted">{t('tableTool', language)}:</small>
-              <Select
-                options={toolOptions}
-                value={filters.tool ?? ''}
-                onChange={(value) => handleFilterChange('tool', value)}
-                size="sm"
-                style={{ width: '150px' } as React.CSSProperties}
-              />
-            </div>
-            <div className="d-flex align-items-center gap-1 flex-grow-1">
-              <small className="text-muted">{t('tableSender', language)}:</small>
-              <SearchableSelect
-                options={senderOptions}
-                value={filters.sender ?? ''}
-                onChange={(value) => handleFilterChange('sender', value)}
-                placeholder={t('dashboardFilterAllSenders', language) || 'All Senders'}
-                searchPlaceholder={t('searchSender', language)}
-                size="sm"
-                className="flex-grow-1"
+              <span className="messages-filter-dates-separator">~</span>
+              <input
+                type="date"
+                className="form-control form-control-sm"
+                value={filters.endDate ?? ''}
+                aria-label={t('endDate', language)}
+                onChange={(e) => handleFilterChange('endDate', e.target.value)}
               />
             </div>
           </div>
         </div>
-        {/* Row 2: Role + Search */}
-        <div className="d-flex align-items-center gap-2">
-          <div className="d-flex align-items-center gap-1" style={{ minWidth: '440px' }}>
-            <small className="text-muted">{t('role', language)}:</small>
-            <div className="form-check form-check-inline mb-0">
-              <input
-                className="form-check-input"
-                type="checkbox"
-                id="roleUser"
-                checked={selectedRoles.includes('user')}
-                onChange={(e) => handleRoleChange('user', e.target.checked)}
-              />
-              <label className="form-check-label" htmlFor="roleUser">
-                {t('messageRoleUser', language)}
-              </label>
-            </div>
-            <div className="form-check form-check-inline mb-0">
-              <input
-                className="form-check-input"
-                type="checkbox"
-                id="roleAssistant"
-                checked={selectedRoles.includes('assistant')}
-                onChange={(e) => handleRoleChange('assistant', e.target.checked)}
-              />
-              <label className="form-check-label" htmlFor="roleAssistant">
-                {t('messageRoleAssistant', language)}
-              </label>
-            </div>
-            <div className="form-check form-check-inline mb-0">
-              <input
-                className="form-check-input"
-                type="checkbox"
-                id="roleSystem"
-                checked={selectedRoles.includes('system')}
-                onChange={(e) => handleRoleChange('system', e.target.checked)}
-              />
-              <label className="form-check-label" htmlFor="roleSystem">
-                {t('messageRoleSystem', language)}
-              </label>
+
+        {/* Filter Row 2: Host + Tool + Sender */}
+        <div className="messages-filter-row">
+          <div className="messages-filter-group">
+            <label className="messages-filter-label">
+              <i className="bi bi-pc-display-horizontal me-1" />
+              {t('tableHost', language)}
+            </label>
+            <Select
+              options={hostOptions}
+              value={filters.host ?? ''}
+              onChange={(value) => handleFilterChange('host', value)}
+              size="sm"
+            />
+          </div>
+          <div className="messages-filter-group">
+            <label className="messages-filter-label">
+              <i className="bi bi-tools me-1" />
+              {t('tableTool', language)}
+            </label>
+            <Select
+              options={toolOptions}
+              value={filters.tool ?? ''}
+              onChange={(value) => handleFilterChange('tool', value)}
+              size="sm"
+            />
+          </div>
+          <div className="messages-filter-group messages-filter-sender">
+            <label className="messages-filter-label">
+              <i className="bi bi-person-badge me-1" />
+              {t('tableSender', language)}
+            </label>
+            <SearchableSelect
+              options={senderOptions}
+              value={filters.sender ?? ''}
+              onChange={(value) => handleFilterChange('sender', value)}
+              placeholder={t('dashboardFilterAllSenders', language) || 'All Senders'}
+              searchPlaceholder={t('searchSender', language)}
+              size="sm"
+            />
+          </div>
+        </div>
+
+        {/* Filter Row 3: Role + Search */}
+        <div className="messages-filter-row">
+          <div className="messages-filter-group messages-filter-roles">
+            <label className="messages-filter-label">
+              <i className="bi bi-person-workspace me-1" />
+              {t('role', language)}
+            </label>
+            <div className="messages-filter-roles-checkboxes">
+              {[
+                { key: 'user', icon: 'bi-person', label: t('messageRoleUser', language) },
+                { key: 'assistant', icon: 'bi-robot', label: t('messageRoleAssistant', language) },
+                { key: 'system', icon: 'bi-gear', label: t('messageRoleSystem', language) },
+              ].map(({ key, icon, label }) => (
+                <label key={key} className="form-check form-check-inline">
+                  <input
+                    className="form-check-input"
+                    type="checkbox"
+                    checked={selectedRoles.includes(key)}
+                    onChange={(e) => handleRoleChange(key, e.target.checked)}
+                  />
+                  <span className="form-check-label">
+                    <i className={`bi ${icon} me-1`} />
+                    {label}
+                  </span>
+                </label>
+              ))}
             </div>
           </div>
-          <div className="d-flex align-items-center gap-2 flex-grow-1">
-            <div className="d-flex align-items-center gap-1 flex-grow-1">
-              <small className="text-muted">{t('search', language)}:</small>
-              <input
-                type="text"
-                className="form-control form-control-sm"
-                placeholder={t('searchMessages', language) ?? 'Search messages...'}
-                style={{ flex: 1, minWidth: 0 }}
-                value={filters.search ?? ''}
-                onChange={(e) => handleFilterChange('search', e.target.value)}
-              />
-            </div>
+          <div className="messages-filter-group messages-filter-search">
+            <label className="messages-filter-label">
+              <i className="bi bi-search me-1" />
+              {t('search', language)}
+            </label>
+            <input
+              type="text"
+              className="form-control form-control-sm"
+              placeholder={t('searchMessages', language) ?? 'Search messages...'}
+              value={searchInput}
+              onChange={(e) => handleSearchChange(e.target.value)}
+            />
           </div>
         </div>
       </Card>
@@ -314,9 +366,10 @@ export const Messages: React.FC = () => {
  *
  * Features:
  * - Click entire card to expand/collapse
+ * - Role badge with icon and translated text
+ * - Meta info for all roles (not just user)
  * - Smooth shadow transition on hover and expand
  * - Chevron rotation animation
- * - Memoized for performance (rerender-memo optimization)
  */
 interface MessageCardProps {
   message: Message;
@@ -326,16 +379,38 @@ interface MessageCardProps {
 const MessageCard = React.memo<MessageCardProps>(({ message, language }) => {
   const [expanded, setExpanded] = React.useState(false);
 
-  const roleColors: Record<string, string> = {
-    user: 'border-primary',
-    assistant: 'border-success',
-    system: 'border-warning',
+  // Role display config with icons and colors
+  const roleConfig: Record<
+    string,
+    { icon: string; borderClass: string; bgClass: string; textClass: string }
+  > = {
+    user: {
+      icon: 'bi-person-fill',
+      borderClass: 'message-border-user',
+      bgClass: 'role-badge-user',
+      textClass: 'role-text-user',
+    },
+    assistant: {
+      icon: 'bi-robot',
+      borderClass: 'message-border-assistant',
+      bgClass: 'role-badge-assistant',
+      textClass: 'role-text-assistant',
+    },
+    system: {
+      icon: 'bi-gear-fill',
+      borderClass: 'message-border-system',
+      bgClass: 'role-badge-system',
+      textClass: 'role-text-system',
+    },
   };
 
-  const roleIcons: Record<string, string> = {
-    user: 'bi-person',
-    assistant: 'bi-robot',
-    system: 'bi-gear',
+  const config = roleConfig[message.role] || roleConfig.user;
+
+  // Get role display text using i18n
+  const roleDisplayText: Record<string, string> = {
+    user: t('messageRoleUser', language) || 'User',
+    assistant: t('messageRoleAssistant', language) || 'Assistant',
+    system: t('messageRoleSystem', language) || 'System',
   };
 
   // Toggle expand/collapse
@@ -348,49 +423,59 @@ const MessageCard = React.memo<MessageCardProps>(({ message, language }) => {
 
   return (
     <div
-      className={cn('message-item', roleColors[message.role] || '', expanded && 'expanded')}
+      className={cn(
+        'message-item',
+        config.borderClass,
+        expanded && 'expanded'
+      )}
       onClick={handleToggle}
       style={{ cursor: canExpand ? 'pointer' : 'default' }}
     >
-      {/* Header with tags */}
+      {/* Header */}
       <div className="message-header">
-        {/* Role Badge */}
+        {/* Role Badge - Compact design */}
         <div className="message-role">
-          <span className={cn('role-badge', message.role)}>
-            <i className={cn('bi', roleIcons[message.role] || 'bi-chat', 'me-1')} />
-            {message.role.toUpperCase()}
+          <span className={cn('role-badge', config.bgClass)}>
+            <i className={`bi ${config.icon}`} />
+            <span className="role-badge-text">{roleDisplayText[message.role] || message.role}</span>
           </span>
         </div>
 
         {/* Content area */}
         <div className="message-content">
-          {/* Meta info for user messages */}
-          {message.role === 'user' && (
-            <div className="message-meta">
-              {/* Host Name */}
-              {(message.host_name ?? message.host) && (
-                <span className="text-muted">
-                  <i className="bi bi-pc-display-horizontal me-1" />
-                  {message.host_name ?? message.host}
-                </span>
-              )}
+          {/* Meta info - Show for all roles */}
+          <div className="message-meta">
+            {/* Host Name - for all roles */}
+            {(message.host_name ?? message.host) && (
+              <span className="message-meta-item">
+                <i className="bi bi-pc-display-horizontal" />
+                {message.host_name ?? message.host}
+              </span>
+            )}
 
-              {/* Message Source */}
-              {message.message_source && (
-                <span className={cn('message-source', message.message_source)}>
-                  {message.message_source.toUpperCase()}
-                </span>
-              )}
+            {/* Message Source - for all roles */}
+            {message.message_source && (
+              <span className={cn('message-source', message.message_source)}>
+                {message.message_source}
+              </span>
+            )}
 
-              {/* Sender Name */}
-              {message.sender_name && (
-                <span className="text-primary fw-semibold">
-                  <i className="bi bi-person-circle me-1" />
-                  {message.sender_name}
-                </span>
-              )}
-            </div>
-          )}
+            {/* Sender Name - primarily for user, but show if available */}
+            {message.sender_name && (
+              <span className="message-meta-item message-meta-sender">
+                <i className="bi bi-person-circle" />
+                {message.sender_name}
+              </span>
+            )}
+
+            {/* Model info - for assistant messages */}
+            {message.role === 'assistant' && message.model && (
+              <span className="message-meta-item message-meta-model">
+                <i className="bi bi-cpu" />
+                {message.model}
+              </span>
+            )}
+          </div>
 
           {/* Truncated content */}
           <div className="message-content-truncated">
@@ -431,8 +516,16 @@ const MessageCard = React.memo<MessageCardProps>(({ message, language }) => {
 
       {/* Footer */}
       <div className="message-footer">
-        <small>{formatDateTime(message.timestamp)}</small>
-        {message.model && <small className="text-muted">Model: {message.model}</small>}
+        <small className="message-footer-time">
+          <i className="bi bi-clock me-1" />
+          {formatDateTime(message.timestamp)}
+        </small>
+        {message.model && message.role !== 'assistant' && (
+          <small className="text-muted">
+            <i className="bi bi-cpu me-1" />
+            {message.model}
+          </small>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/components/features/Messages.tsx
+++ b/frontend/src/components/features/Messages.tsx
@@ -159,8 +159,8 @@ export const Messages: React.FC = () => {
     });
     setFilters((prev) => {
       const newRoles = checked
-        ? [...(prev.role || []), role]
-        : (prev.role || []).filter((r) => r !== role);
+        ? [...(prev.role ?? []), role]
+        : (prev.role ?? []).filter((r) => r !== role);
       return { ...prev, role: newRoles.length > 0 ? newRoles : undefined };
     });
     setPage(1);
@@ -423,11 +423,7 @@ const MessageCard = React.memo<MessageCardProps>(({ message, language }) => {
 
   return (
     <div
-      className={cn(
-        'message-item',
-        config.borderClass,
-        expanded && 'expanded'
-      )}
+      className={cn('message-item', config.borderClass, expanded && 'expanded')}
       onClick={handleToggle}
       style={{ cursor: canExpand ? 'pointer' : 'default' }}
     >

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -1470,35 +1470,62 @@ table .latency-row:hover td {
   gap: 10px;
 }
 
-/* Role Badge */
+/* Role Badge - Issue #1434: Compact design with icon */
 .message-role {
-  width: 100px;
-  text-align: center;
   flex-shrink: 0;
 }
 
 .role-badge {
-  display: inline-block;
-  padding: 4px 12px;
-  border-radius: 4px;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 10px;
+  border-radius: 6px;
   font-size: 0.75rem;
-  font-weight: 600;
-  text-transform: uppercase;
+  font-weight: 500;
+  white-space: nowrap;
 }
 
+.role-badge .role-badge-text {
+  text-transform: capitalize;
+}
+
+/* Role badge variants - subtle colored backgrounds */
+.role-badge-user,
 .role-badge.user {
-  background-color: var(--color-primary);
-  color: white;
+  background-color: rgba(var(--color-primary-rgb, 13, 110, 253), 0.12);
+  color: var(--color-primary);
+  border: 1px solid rgba(var(--color-primary-rgb, 13, 110, 253), 0.25);
 }
 
+.role-badge-assistant,
 .role-badge.assistant {
-  background-color: var(--color-success);
-  color: white;
+  background-color: rgba(var(--color-success-rgb, 25, 135, 84), 0.12);
+  color: var(--color-success);
+  border: 1px solid rgba(var(--color-success-rgb, 25, 135, 84), 0.25);
 }
 
+.role-badge-system,
 .role-badge.system {
-  background-color: var(--color-secondary);
-  color: white;
+  background-color: rgba(var(--color-secondary-rgb, 108, 117, 125), 0.12);
+  color: var(--color-secondary);
+  border: 1px solid rgba(var(--color-secondary-rgb, 108, 117, 125), 0.25);
+}
+
+/* Role-based border colors - updated for new design */
+.message-border-user,
+.message-item.border-primary {
+  border-left: 3px solid var(--color-primary);
+}
+
+.message-border-assistant,
+.message-item.border-success {
+  border-left: 3px solid var(--color-success);
+}
+
+.message-border-system,
+.message-item.border-warning {
+  border-left: 3px solid var(--color-secondary);
 }
 
 /* Message Content */
@@ -4055,6 +4082,223 @@ table .latency-row:hover td {
 /* Thinking / reasoning blocks - ensure muted text is readable */
 [data-theme='dark'] .session-detail-content details .text-muted {
   color: var(--text-muted) !important;
+}
+
+/* ===== Messages Page Responsive Styles (Issue #1434) ===== */
+
+/* Filter Card - Responsive Layout */
+.messages-filter-card {
+  padding: var(--spacing-md);
+}
+
+.messages-filter-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-md);
+  margin-bottom: var(--spacing-md);
+}
+
+.messages-filter-row:last-child {
+  margin-bottom: 0;
+}
+
+.messages-filter-group {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.messages-filter-label {
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--text-muted);
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+/* Date Range Filter */
+.messages-filter-dates {
+  flex: 0 0 auto;
+}
+
+.messages-filter-dates-inputs {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.messages-filter-dates-inputs .form-control {
+  width: 140px;
+}
+
+.messages-filter-dates-separator {
+  color: var(--text-muted);
+  font-weight: 500;
+}
+
+/* Sender Filter */
+.messages-filter-sender {
+  flex: 1;
+  min-width: 180px;
+}
+
+/* Role Checkboxes */
+.messages-filter-roles {
+  flex: 0 0 auto;
+}
+
+.messages-filter-roles-checkboxes {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 16px;
+}
+
+.messages-filter-roles-checkboxes .form-check {
+  margin-bottom: 0;
+}
+
+.messages-filter-roles-checkboxes .form-check-label {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  cursor: pointer;
+}
+
+/* Search Filter */
+.messages-filter-search {
+  flex: 1;
+  min-width: 200px;
+  max-width: 300px;
+}
+
+/* Message Meta - Improved styling */
+.message-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 12px;
+  align-items: center;
+  margin-bottom: 6px;
+  font-size: 0.75rem;
+}
+
+.message-meta-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: var(--text-muted);
+}
+
+.message-meta-item i {
+  font-size: 0.7rem;
+}
+
+.message-meta-sender {
+  color: var(--color-primary);
+  font-weight: 500;
+}
+
+.message-meta-model {
+  color: var(--text-muted);
+  font-family: var(--font-family-monospace);
+}
+
+/* Message Source Badge - Compact style */
+.message-source {
+  font-size: 0.65rem;
+  padding: 2px 6px;
+  border-radius: 4px;
+  text-transform: capitalize;
+  font-weight: 500;
+}
+
+/* Message Footer Time */
+.message-footer-time {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+/* Responsive adjustments */
+@media (max-width: 991.98px) {
+  .messages-filter-row {
+    flex-direction: column;
+  }
+
+  .messages-filter-group {
+    width: 100%;
+  }
+
+  .messages-filter-dates-inputs .form-control {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .messages-filter-sender,
+  .messages-filter-search {
+    max-width: none;
+  }
+
+  .messages-filter-roles-checkboxes {
+    flex-direction: column;
+    gap: 8px;
+  }
+}
+
+@media (max-width: 575.98px) {
+  .messages-filter-card {
+    padding: var(--spacing-sm);
+  }
+
+  .messages-filter-dates-inputs {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .messages-filter-dates-separator {
+    display: none;
+  }
+
+  .messages-filter-dates-inputs .form-control {
+    width: 100%;
+  }
+
+  /* Hide message tokens on very small screens */
+  .message-tokens {
+    display: none;
+  }
+
+  /* Compact role badge on mobile */
+  .role-badge {
+    padding: 2px 6px;
+    font-size: 0.7rem;
+  }
+
+  .role-badge .role-badge-text {
+    display: none;
+  }
+
+  .role-badge i {
+    margin: 0 !important;
+  }
+}
+
+/* Dark mode adjustments for messages */
+[data-theme='dark'] .messages-filter-card {
+  background-color: var(--bg-secondary);
+}
+
+[data-theme='dark'] .messages-filter-label {
+  color: var(--text-muted);
+}
+
+[data-theme='dark'] .message-meta-item {
+  color: var(--text-muted);
+}
+
+[data-theme='dark'] .message-meta-sender {
+  color: var(--color-primary-light, #60a5fa);
 }
 
 /* Alert warning - adapt to dark theme */


### PR DESCRIPTION
## 问题概述

管理模式下"分析"菜单的"消息"页面（`/manage/messages`）存在多项 UI/UX 设计问题，影响用户浏览和检索消息的体验。

## 修复内容

### 1. 筛选区域响应式重构
- 移除固定宽度 `minWidth: 440px`
- 使用 `flex-wrap` 布局自动换行
- 992px 以下筛选条件垂直堆叠
- 576px 以下日期选择器全宽显示

### 2. role-badge 设计优化
- 图标 + 小写文本（使用 i18n 翻译）
- 柔和背景色（`rgba` 透明度设计）
- 移除僵硬的大写文本和固定宽度
- 移动端仅显示图标

### 3. 元信息展示完善
- assistant/system 消息也显示主机、模型等元信息
- 之前只有 user 角色显示，现在所有角色都显示

### 4. 搜索防抖机制
- 添加 300ms 防抖
- 避免输入时频繁发送 API 请求

### 5. 默认筛选优化
- 默认选中所有角色（user + assistant + system）
- 默认日期范围改为最近 7 天（之前只有当天）

## 响应式设计

| 屏幕宽度 | 布局调整 |
|---------|--------|
| > 992px | 筛选条件横向排列 |
| ≤ 992px | 筛选条件垂直堆叠 |
| ≤ 576px | 日期全宽、role-badge 仅图标 |

## 修复了 PR #1435 测试反馈问题

之前的 PR #1435 测试反馈：
- UI 改动不明显
- 响式布局改善有限
- 整体视觉体验提升不足

本次修复针对以上问题进行了重新设计。

## 关联 Issue

Fixes #1434