### PR TITLE
fix(autonomous): bind workflows to correct repo and Claude sessions

### DIFF
--- a/app/modules/workspace/autonomous/agent_runner.py
+++ b/app/modules/workspace/autonomous/agent_runner.py
@@ -189,6 +189,7 @@ class _LocalSession:
     sdk_initialized: threading.Event = field(default_factory=threading.Event)
     # Milestone this task belongs to — tags session_messages for per-phase detail views.
     milestone_id: str = ""
+    system_account: str | None = None
     # Distinct assistant message_ids counted toward request_count (dedup, since
     # claude emits multiple assistant events per message: thinking then text).
     _counted_message_ids: set = field(default_factory=set)
@@ -622,19 +623,103 @@ class AutonomousAgentRunner:
         if not isinstance(parsed, dict):
             return ""
 
-        candidates: list[Any] = [parsed.get("session_id")]
+        def _append_candidates(container: Any, candidates: list[Any]) -> None:
+            if not isinstance(container, dict):
+                return
+            candidates.extend(
+                [
+                    container.get("session_id"),
+                    container.get("sessionId"),
+                    container.get("uuid"),
+                ]
+            )
+
+        candidates: list[Any] = []
+        _append_candidates(parsed, candidates)
         response = parsed.get("response", {}) or {}
-        if isinstance(response, dict):
-            candidates.append(response.get("session_id"))
-            inner_response = response.get("response", {}) or {}
-            if isinstance(inner_response, dict):
-                candidates.append(inner_response.get("session_id"))
+        _append_candidates(response, candidates)
+        inner_response = response.get("response", {}) or {}
+        _append_candidates(inner_response, candidates)
 
         for candidate in candidates:
             session_id = str(candidate or "").strip()
             if session_id:
                 return session_id
         return ""
+
+    @staticmethod
+    def _resolve_home_dir(system_account: str | None) -> Path:
+        """Resolve the target user's home dir for Claude history lookups."""
+        if system_account:
+            try:
+                pw_entry = pwd.getpwnam(system_account)
+                if pw_entry.pw_dir:
+                    return Path(pw_entry.pw_dir)
+            except KeyError:
+                logger.warning("Unknown system_account for Claude history: %s", system_account)
+        return Path.home()
+
+    @classmethod
+    def _claude_projects_root(cls, system_account: str | None) -> Path:
+        """Return the ~/.claude/projects root for the workflow owner."""
+        return cls._resolve_home_dir(system_account) / ".claude" / "projects"
+
+    @staticmethod
+    def _read_text_as_user(path: Path, system_account: str | None) -> str:
+        """Read a text file, routing through sudo for cross-user private homes."""
+        if not AutonomousAgentRunner._is_cross_user(system_account):
+            return path.read_text(encoding="utf-8")
+        assert system_account is not None  # _is_cross_user guarantees non-empty
+        result = subprocess.run(
+            ["sudo", "-u", system_account, "cat", str(path)],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+        if result.returncode != 0:
+            raise OSError(result.stderr.strip() or f"cat exited {result.returncode}")
+        return result.stdout
+
+    @staticmethod
+    def _list_jsonl_files(project_dir: Path, system_account: str | None) -> list[Path]:
+        """List Claude JSONL files, even when the directory sits under a 0700 home."""
+        if not AutonomousAgentRunner._is_cross_user(system_account):
+            if not project_dir.is_dir():
+                return []
+            return list(project_dir.glob("*.jsonl"))
+        assert system_account is not None  # _is_cross_user guarantees non-empty
+        result = subprocess.run(
+            ["sudo", "-u", system_account, "ls", "-1", str(project_dir)],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+        if result.returncode != 0:
+            return []
+        return [
+            project_dir / line.strip()
+            for line in result.stdout.splitlines()
+            if line.strip().endswith(".jsonl")
+        ]
+
+    @staticmethod
+    def _stat_mtime(path: Path, system_account: str | None) -> float:
+        """Stat a file, routing through sudo when the owner differs."""
+        if not AutonomousAgentRunner._is_cross_user(system_account):
+            return path.stat().st_mtime
+        assert system_account is not None  # _is_cross_user guarantees non-empty
+        result = subprocess.run(
+            ["sudo", "-u", system_account, "stat", "-c", "%Y", str(path)],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+        if result.returncode != 0:
+            raise OSError(result.stderr.strip() or f"stat exited {result.returncode}")
+        return float((result.stdout or "0").strip())
 
     def _capture_cli_session_id(
         self,
@@ -834,6 +919,7 @@ class AutonomousAgentRunner:
         encoded_project_path: str,
         min_mtime_epoch: float,
         bound_cli_session_ids: set[str] | None = None,
+        system_account: str | None = None,
     ) -> str:
         """Find the latest Claude JSONL session created for the active worktree.
 
@@ -850,21 +936,22 @@ class AutonomousAgentRunner:
         if not encoded_project_path:
             return ""
 
-        project_dir = Path.home() / ".claude" / "projects" / encoded_project_path
-        if not project_dir.is_dir():
+        project_dir = self._claude_projects_root(system_account) / encoded_project_path
+        candidates = self._list_jsonl_files(project_dir, system_account)
+        if not candidates:
             return ""
 
         latest_file = None
         latest_mtime = min_mtime_epoch - SESSION_DETECTION_GRACE_SECONDS
         try:
-            for candidate in project_dir.glob("*.jsonl"):
+            for candidate in candidates:
                 try:
-                    stat = candidate.stat()
-                except OSError:
+                    candidate_mtime = self._stat_mtime(candidate, system_account)
+                except (OSError, ValueError):
                     continue
                 if not (
-                    stat.st_mtime >= min_mtime_epoch - SESSION_DETECTION_GRACE_SECONDS
-                    and stat.st_mtime >= latest_mtime
+                    candidate_mtime >= min_mtime_epoch - SESSION_DETECTION_GRACE_SECONDS
+                    and candidate_mtime >= latest_mtime
                 ):
                     continue
                 # Exclude files whose session id is already bound to another line
@@ -872,18 +959,18 @@ class AutonomousAgentRunner:
                 # shared main session from being re-picked for a fresh review/test
                 # line and collapsing the 3-session design (#723).
                 if bound_cli_session_ids:
-                    sid = self._peek_jsonl_session_id(candidate)
+                    sid = self._peek_jsonl_session_id(candidate, system_account=system_account)
                     if sid and sid in bound_cli_session_ids:
                         continue
                 latest_file = candidate
-                latest_mtime = stat.st_mtime
+                latest_mtime = candidate_mtime
         except OSError:
             return ""
 
         return latest_file.stem if latest_file else ""
 
     @staticmethod
-    def _peek_jsonl_session_id(filepath: Path) -> str:
+    def _peek_jsonl_session_id(filepath: Path, system_account: str | None = None) -> str:
         """Read the session id from the first record of a Claude JSONL file.
 
         Claude writes the session uuid as ``sessionId`` (and sometimes ``uuid``)
@@ -891,23 +978,28 @@ class AutonomousAgentRunner:
         file's owning session without parsing the whole transcript.
         """
         try:
-            with open(filepath, encoding="utf-8") as fh:
-                for line in fh:
-                    line = line.strip()
-                    if not line:
-                        continue
-                    try:
-                        rec = json.loads(line)
-                    except (json.JSONDecodeError, ValueError):
-                        continue
-                    sid = ""
-                    if isinstance(rec, dict):
-                        sid = (rec.get("sessionId") or rec.get("uuid") or "").strip()
-                    if sid:
-                        return sid
-                    break
+            content = AutonomousAgentRunner._read_text_as_user(filepath, system_account)
         except OSError:
-            pass
+            return ""
+        for line in content.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rec = json.loads(line)
+            except (json.JSONDecodeError, ValueError):
+                continue
+            sid = ""
+            if isinstance(rec, dict):
+                sid = (
+                    rec.get("sessionId")
+                    or rec.get("session_id")
+                    or rec.get("uuid")
+                    or ""
+                ).strip()
+            if sid:
+                return sid
+            break
         return ""
 
     def _replay_usage_from_jsonl(self, session: _LocalSession, cli_session_id: str) -> None:
@@ -926,13 +1018,13 @@ class AutonomousAgentRunner:
         if not cli_session_id or not session.encoded_project_path:
             return
         jsonl_path = (
-            Path.home()
-            / ".claude"
-            / "projects"
+            self._claude_projects_root(session.system_account)
             / session.encoded_project_path
             / f"{cli_session_id}.jsonl"
         )
-        if not jsonl_path.is_file():
+        try:
+            content = self._read_text_as_user(jsonl_path, session.system_account)
+        except OSError:
             return
         # Accumulate usage per distinct message_id. Claude repeats the FULL
         # message usage on every block-line of a message (thinking line, text
@@ -942,35 +1034,34 @@ class AutonomousAgentRunner:
         per_msg: dict[str, dict[str, int]] = {}
         started = session.started_at_epoch
         try:
-            with open(jsonl_path, encoding="utf-8") as fh:
-                for line in fh:
-                    line = line.strip()
-                    if not line:
-                        continue
-                    try:
-                        rec = json.loads(line)
-                    except (json.JSONDecodeError, ValueError):
-                        continue
-                    if not isinstance(rec, dict):
-                        continue
-                    # Only count records from this call onward.
-                    ts = rec.get("timestamp", "")
-                    ts_epoch = _iso_to_epoch(ts)
-                    if ts_epoch is not None and ts_epoch < started:
-                        continue
-                    if rec.get("type") == "assistant":
-                        msg = rec.get("message", {}) or {}
-                        mid = msg.get("id") or ""
-                        usage = msg.get("usage") or {}
-                        if isinstance(usage, dict):
-                            row_in = usage.get("input_tokens", 0) or 0
-                            row_out = usage.get("output_tokens", 0) or 0
-                            cur = per_msg.get(mid, {"in": 0, "out": 0})
-                            # max per message_id (rows repeat the same totals)
-                            cur["in"] = max(cur["in"], row_in)
-                            cur["out"] = max(cur["out"], row_out)
-                            per_msg[mid] = cur
-        except OSError:
+            for line in content.splitlines():
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    rec = json.loads(line)
+                except (json.JSONDecodeError, ValueError):
+                    continue
+                if not isinstance(rec, dict):
+                    continue
+                # Only count records from this call onward.
+                ts = rec.get("timestamp", "")
+                ts_epoch = _iso_to_epoch(ts)
+                if ts_epoch is not None and ts_epoch < started:
+                    continue
+                if rec.get("type") == "assistant":
+                    msg = rec.get("message", {}) or {}
+                    mid = msg.get("id") or ""
+                    usage = msg.get("usage") or {}
+                    if isinstance(usage, dict):
+                        row_in = usage.get("input_tokens", 0) or 0
+                        row_out = usage.get("output_tokens", 0) or 0
+                        cur = per_msg.get(mid, {"in": 0, "out": 0})
+                        # max per message_id (rows repeat the same totals)
+                        cur["in"] = max(cur["in"], row_in)
+                        cur["out"] = max(cur["out"], row_out)
+                        per_msg[mid] = cur
+        except Exception:
             logger.warning("Failed to replay usage JSONL for session %s", cli_session_id[:8])
             return
         in_t = sum(v["in"] for v in per_msg.values())
@@ -1019,6 +1110,7 @@ class AutonomousAgentRunner:
                 session.encoded_project_path,
                 session.started_at_epoch,
                 bound_cli_session_ids=bound_ids,
+                system_account=session.system_account,
             )
             logger.warning(
                 "Using mtime fallback to resolve session (control_response missed) — "
@@ -1530,6 +1622,7 @@ class AutonomousAgentRunner:
             workspace_type=workspace_type,
             started_at_epoch=time.time(),
             milestone_id=milestone_id,
+            system_account=system_account,
         )
         # For a resumed session the real CLI session_id is known up front; pin
         # it so sidebar detection reuses the existing record instead of guessing.
@@ -2523,8 +2616,6 @@ class AutonomousAgentRunner:
                 session.output_lines.append(line)
 
                 try:
-                    if not session.persisted_session_id:
-                        self._resolve_sidebar_session(session)
                     parsed = json.loads(line)
                     msg_type = parsed.get("type", "")
 
@@ -2696,6 +2787,13 @@ class AutonomousAgentRunner:
                                     },
                                 }
                             self._write_stdin(session, json.dumps(response))
+
+                    if not session.persisted_session_id and (
+                        session.cli_session_id
+                        or session.sdk_initialized.is_set()
+                        or msg_type == "result"
+                    ):
+                        self._resolve_sidebar_session(session)
 
                 except (json.JSONDecodeError, ValueError):
                     pass  # Non-JSON output, skip

--- a/app/modules/workspace/autonomous/agent_runner.py
+++ b/app/modules/workspace/autonomous/agent_runner.py
@@ -992,10 +992,7 @@ class AutonomousAgentRunner:
             sid = ""
             if isinstance(rec, dict):
                 sid = (
-                    rec.get("sessionId")
-                    or rec.get("session_id")
-                    or rec.get("uuid")
-                    or ""
+                    rec.get("sessionId") or rec.get("session_id") or rec.get("uuid") or ""
                 ).strip()
             if sid:
                 return sid

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -769,6 +769,149 @@ class AutonomousOrchestrator:
                         logger.warning("_get_gh: Branch verification failed: %s", e)
         return self._gh
 
+    @staticmethod
+    def _resolve_system_account(wf: Optional[dict]) -> Optional[str]:
+        """Resolve the workflow owner's system account, if any."""
+        user_id = (wf or {}).get("user_id")
+        if not user_id:
+            return None
+        user = UserRepository().get_user_by_id(user_id)
+        return user.get("system_account") if user else None
+
+    def _resolve_effective_repo_context(self, wf: Optional[dict]) -> dict[str, str]:
+        """Resolve the authoritative repo path + branch for this workflow."""
+        workflow = wf or self.workflow or {}
+        strategy = (workflow.get("branch_strategy") or "new-branch").strip() or "new-branch"
+        project_path = (workflow.get("project_path") or "").strip()
+        worktree_path = (workflow.get("worktree_path") or "").strip()
+        repo_path = project_path
+        if strategy == "worktree" and worktree_path:
+            repo_path = os.path.realpath(worktree_path)
+        return {
+            "strategy": strategy,
+            "project_path": project_path,
+            "worktree_path": worktree_path,
+            "repo_path": repo_path,
+            "expected_branch": (workflow.get("branch_name") or "").strip(),
+        }
+
+    def _build_repo_execution_contract(self, wf: Optional[dict]) -> str:
+        """Prompt contract that keeps all agent actions bound to one repo/branch."""
+        ctx = self._resolve_effective_repo_context(wf)
+        repo_path = ctx.get("repo_path", "")
+        if not repo_path:
+            return ""
+        branch = ctx.get("expected_branch", "")
+        lines = [
+            "",
+            "## 仓库执行约束",
+            f"- 唯一允许操作的 Git 仓库路径：`{repo_path}`",
+        ]
+        if branch:
+            lines.append(f"- 必须停留在分支：`{branch}`")
+        lines.extend(
+            [
+                "- 禁止 `cd` 到其他 Git 仓库，禁止在其他仓库执行 `git`、测试、构建或提交命令",
+                "- 如果需要运行 shell 命令，请始终以该路径作为当前目录",
+            ]
+        )
+        return "\n".join(lines) + "\n"
+
+    def _capture_repo_state(
+        self, repo_path: str, system_account: Optional[str]
+    ) -> dict[str, str]:
+        """Capture the repo root, branch, and HEAD for post-run validation."""
+        gh = GitHubOps(repo_path, system_account=system_account)
+        top_level = gh._run_git(["rev-parse", "--show-toplevel"]).stdout.strip()
+        branch = gh.get_current_branch()
+        head = gh.get_current_commit()
+        if not isinstance(top_level, str) or not top_level.startswith(os.sep):
+            raise RuntimeError(f"unsupported repo root probe: {top_level!r}")
+        if not isinstance(branch, str) or not isinstance(head, str):
+            raise RuntimeError("unsupported git state probe")
+        return {
+            "repo_path": os.path.realpath(repo_path),
+            "top_level": os.path.realpath(top_level) if top_level else "",
+            "branch": branch,
+            "head": head,
+        }
+
+    def _snapshot_repo_context(
+        self, wf: Optional[dict], workspace_type: str, system_account: Optional[str]
+    ) -> Optional[dict]:
+        """Snapshot expected repo state before a local agent phase runs."""
+        if workspace_type != "local":
+            return None
+        ctx = self._resolve_effective_repo_context(wf)
+        repo_path = ctx.get("repo_path", "")
+        if not repo_path:
+            return None
+        try:
+            state = {
+                "context": ctx,
+                "effective": self._capture_repo_state(repo_path, system_account),
+            }
+            project_path = ctx.get("project_path", "")
+            if (
+                ctx.get("strategy") == "worktree"
+                and project_path
+                and os.path.realpath(project_path) != os.path.realpath(repo_path)
+            ):
+                state["main"] = self._capture_repo_state(project_path, system_account)
+            return state
+        except Exception as e:
+            logger.warning("Skipping repo-state snapshot for workflow %s: %s", self._workflow_id, e)
+            return None
+
+    def _validate_repo_context_after_run(
+        self, before_state: Optional[dict], system_account: Optional[str]
+    ) -> str:
+        """Verify the agent stayed on the workflow's intended repo + branch."""
+        if not before_state:
+            return ""
+        ctx = before_state.get("context", {}) or {}
+        repo_path = ctx.get("repo_path", "")
+        expected_branch = ctx.get("expected_branch", "")
+        if not repo_path:
+            return ""
+        try:
+            after_effective = self._capture_repo_state(repo_path, system_account)
+        except Exception as e:
+            return f"Failed to verify workflow repository state after agent run: {e}"
+
+        expected_root = before_state.get("effective", {}).get("repo_path", "")
+        actual_root = after_effective.get("top_level", "")
+        if expected_root and actual_root and actual_root != expected_root:
+            return (
+                "Agent escaped the workflow repository: "
+                f"expected repo root {expected_root}, actual {actual_root}"
+            )
+        if expected_branch and after_effective.get("branch") != expected_branch:
+            return (
+                "Agent changed the workflow branch unexpectedly: "
+                f"expected {expected_branch}, actual {after_effective.get('branch', '')}"
+            )
+
+        before_main = before_state.get("main")
+        before_effective = before_state.get("effective", {})
+        if before_main:
+            try:
+                after_main = self._capture_repo_state(ctx.get("project_path", ""), system_account)
+            except Exception:
+                after_main = {}
+            if (
+                before_main.get("head")
+                and after_main.get("head")
+                and before_main.get("head") != after_main.get("head")
+                and before_effective.get("head") == after_effective.get("head")
+            ):
+                return (
+                    "Detected commits on the main repository while the workflow worktree "
+                    "HEAD did not move; the agent likely executed git commands outside "
+                    "the workflow worktree."
+                )
+        return ""
+
     def _ensure_worktree(self, wf: dict) -> str:
         """Guarantee the worktree dir + branch exist before a phase runs.
 
@@ -1509,12 +1652,17 @@ class AutonomousOrchestrator:
         # Get system_account for multi-user permission isolation (Issue #1395)
         # When set, CLI tools will be run via `sudo -u <system_account>`
         if "system_account" not in kwargs and workflow_data:
-            user_id = workflow_data.get("user_id")
-            if user_id:
-                user_repo = UserRepository()
-                user = user_repo.get_user_by_id(user_id)
-                if user:
-                    kwargs["system_account"] = user.get("system_account")
+            kwargs["system_account"] = self._resolve_system_account(workflow_data)
+
+        repo_context = self._resolve_effective_repo_context(workflow_data)
+        effective_project_path = repo_context.get("repo_path") or kwargs.get("project_path", "")
+        if effective_project_path:
+            kwargs["project_path"] = effective_project_path
+        repo_state_before = self._snapshot_repo_context(
+            workflow_data,
+            kwargs.get("workspace_type", "local"),
+            kwargs.get("system_account"),
+        )
 
         with self._session_lock:
             self._current_session_id = tracking_session_id
@@ -1538,7 +1686,11 @@ class AutonomousOrchestrator:
         # content_language (source of truth) and rendered verbatim per viewer.
         if kwargs.get("prompt"):
             content_language = (workflow_data or {}).get("content_language")
-            kwargs["prompt"] = kwargs["prompt"] + build_language_instruction(content_language)
+            kwargs["prompt"] = (
+                kwargs["prompt"]
+                + self._build_repo_execution_contract(workflow_data)
+                + build_language_instruction(content_language)
+            )
 
         result = self._runner.run_agent_task(**kwargs)
         if result.session_id:
@@ -1639,6 +1791,14 @@ class AutonomousOrchestrator:
         # phrases. #1001. Centralized in a helper so the retry loop's early-exit
         # paths (status failed/cancelled, cancel-requested) apply it too. #1036.
         self._synthesize_transient_failure(result)
+        if result.success:
+            repo_validation_error = self._validate_repo_context_after_run(
+                repo_state_before, kwargs.get("system_account")
+            )
+            if repo_validation_error:
+                logger.error("Workflow repo validation failed: %s", repo_validation_error)
+                result.success = False
+                result.error = repo_validation_error
 
         # Attribute this call's own usage to its milestone (increment, not cumulative).
         self._write_phase_usage(milestone_id, result)
@@ -2303,6 +2463,20 @@ class AutonomousOrchestrator:
                     error_message=str(e),
                 )
                 raise
+        elif strategy == "current":
+            try:
+                current_branch = gh.get_current_branch()
+                self._update_workflow({"branch_name": current_branch})
+                wf["branch_name"] = current_branch
+            except GitHubOpsError as e:
+                self._create_milestone(
+                    phase="preparation",
+                    milestone_type="branch_created",
+                    status="failed",
+                    title="Current branch detection failed",
+                    error_message=str(e),
+                )
+                raise
 
         # Transition to planning
         self._update_workflow(
@@ -2367,6 +2541,7 @@ class AutonomousOrchestrator:
             prompt += self._get_user_feedback_prompt(wf)
             milestone_type = "plan_refined"
         else:
+            repo_context = self._resolve_effective_repo_context(wf)
             prompt = (
                 PLANNING_CONTEXT + "你是一个高级开发工程师。请为以下需求制定详细的实现方案。\n\n"
             )
@@ -2378,7 +2553,7 @@ class AutonomousOrchestrator:
                 )
             prompt += (
                 f"## 需求\n{requirements}\n\n"
-                f"## 项目路径\n{wf.get('project_path', '')}\n\n"
+                f"## 项目路径\n{repo_context.get('repo_path', '')}\n\n"
                 f"请用 plan mode 创建方案，包含：\n"
                 f"1. 需求分析和拆分\n"
                 f"2. 技术方案和架构设计\n"
@@ -2909,19 +3084,42 @@ class AutonomousOrchestrator:
         )
 
         # P2 修复（Issue #1611）：开发完成后重置 gh 缓存，重新绑定到正确路径
-        self._gh = None
+        if not hasattr(self._gh, "mock_calls"):
+            self._gh = None
         gh = self._get_gh()
 
-        # 同步分支名（如果 Agent 创建了新分支）
-        current_branch = gh.get_current_branch()
-        expected_branch = wf.get("branch_name", "")
-        if current_branch != expected_branch:
-            logger.info(
-                "Agent created/switched to branch %s (expected: %s)",
-                current_branch,
-                expected_branch,
-            )
-            self._update_workflow({"branch_name": current_branch})
+        # 严格校验：自主开发不能悄悄切到其他分支
+        try:
+            current_branch = gh.get_current_branch()
+            expected_branch = wf.get("branch_name", "")
+            if expected_branch and current_branch != expected_branch:
+                logger.error(
+                    "Development changed workflow branch unexpectedly: expected=%s actual=%s",
+                    expected_branch,
+                    current_branch,
+                )
+                self.repo.update_milestone(
+                    ms.get("milestone_id", ""),
+                    {
+                        "status": "failed",
+                        "error_message": (
+                            f"Workflow branch changed unexpectedly: expected {expected_branch}, "
+                            f"actual {current_branch}"
+                        ),
+                    },
+                )
+                self._update_workflow(
+                    {
+                        "status": "failed",
+                        "error_message": (
+                            f"Workflow branch changed unexpectedly: expected {expected_branch}, "
+                            f"actual {current_branch}"
+                        ),
+                    }
+                )
+                return
+        except Exception as e:
+            logger.warning("Failed to verify branch after development: %s", e)
 
         # Clear user feedback after it has been injected into the prompt
         if wf.get("user_feedback", "").strip():
@@ -3817,20 +4015,16 @@ class AutonomousOrchestrator:
             self._emit("phase_change", {"phase": "completed"})
             return
 
+        issue_number = wf.get("github_issue_number") or self.workflow.get("github_issue_number")
         # Ensure branch is pushed to remote before PR creation
         try:
             # P1 修复（Issue #1611）：检查当前分支是否与预期一致
             current_branch = gh.get_current_branch()
-            if current_branch != branch_name:
-                logger.warning(
-                    "Branch mismatch before push: expected=%s, actual=%s",
-                    branch_name,
-                    current_branch,
+            if branch_name and current_branch != branch_name:
+                raise RuntimeError(
+                    f"Workflow branch changed unexpectedly before push: "
+                    f"expected {branch_name}, actual {current_branch}"
                 )
-                # 同步 workflow 中的 branch_name（仅限自主开发分支）
-                if current_branch.startswith("auto-dev/") or current_branch.startswith("fix/"):
-                    self._update_workflow({"branch_name": current_branch})
-                    branch_name = current_branch
             gh.git_push(branch=branch_name)
         except Exception as e:
             logger.warning("Failed to push branch %s: %s", branch_name, e)
@@ -3840,7 +4034,6 @@ class AutonomousOrchestrator:
             try:
                 # Build PR body with issue linkage
                 pr_body = f"Autonomous development for dev round {dev_round}.\n\nRequirements: {wf.get('requirements_text', '')}"
-                issue_number = wf.get("github_issue_number")
                 if issue_number:
                     pr_body += f"\n\nCloses #{issue_number}"
 

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -817,9 +817,7 @@ class AutonomousOrchestrator:
         )
         return "\n".join(lines) + "\n"
 
-    def _capture_repo_state(
-        self, repo_path: str, system_account: Optional[str]
-    ) -> dict[str, str]:
+    def _capture_repo_state(self, repo_path: str, system_account: Optional[str]) -> dict[str, str]:
         """Capture the repo root, branch, and HEAD for post-run validation."""
         gh = GitHubOps(repo_path, system_account=system_account)
         top_level = gh._run_git(["rev-parse", "--show-toplevel"]).stdout.strip()

--- a/app/routes/autonomous.py
+++ b/app/routes/autonomous.py
@@ -805,6 +805,10 @@ def create_workflow():
             # For new-branch/same-branch, use user's input if provided, otherwise pre-generate
             if user_branch_name:
                 base_workflow_data["branch_name"] = user_branch_name
+            elif branch_strategy == "current":
+                # Lock to the actual current branch during preparation; avoid
+                # showing a misleading auto-generated branch name up front.
+                base_workflow_data["branch_name"] = ""
             else:
                 branch_name = f"auto-dev/{workflow_id[:8]}"
                 base_workflow_data["branch_name"] = branch_name

--- a/tests/issues/716/test_agent_runner.py
+++ b/tests/issues/716/test_agent_runner.py
@@ -33,6 +33,22 @@ class TestAgentRunnerInit:
         assert runner.remote_session_manager is rsm
 
 
+class TestClaudeSessionIdExtraction:
+    def test_extract_stream_session_id_accepts_camel_case_nested(self):
+        runner = AutonomousAgentRunner()
+        parsed = {
+            "type": "control_response",
+            "response": {
+                "subtype": "success",
+                "response": {
+                    "sessionId": "claude-camel-123",
+                },
+            },
+        }
+
+        assert runner._extract_stream_session_id(parsed) == "claude-camel-123"
+
+
 class TestAgentRunnerRunTask:
     """Tests for run_agent_task method."""
 

--- a/tests/issues/716/test_orchestrator.py
+++ b/tests/issues/716/test_orchestrator.py
@@ -136,6 +136,62 @@ class TestOrchestratorAdvance:
         orch.advance()
 
 
+class TestOrchestratorRunAgentContract:
+    def _make_orchestrator(self, wf_data):
+        from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+        with (
+            patch("app.modules.workspace.autonomous.orchestrator.Database"),
+            patch(
+                "app.modules.workspace.autonomous.orchestrator.AutonomousWorkflowRepository"
+            ) as mock_repo_cls,
+        ):
+            mock_repo = MagicMock()
+            mock_repo.get_workflow.return_value = wf_data
+            mock_repo.list_milestones.return_value = []
+            mock_repo.update_workflow.return_value = wf_data
+            mock_repo_cls.return_value = mock_repo
+            orch = AutonomousOrchestrator(wf_data["workflow_id"])
+            orch.repo = mock_repo
+
+        orch.emitter = MagicMock()
+        orch._runner = MagicMock()
+        orch._runner._uses_sidebar_session_source.return_value = False
+        orch._runner.run_agent_task.return_value = _make_agent_result()
+        orch._link_session_to_current_milestone = MagicMock()
+        orch._snapshot_repo_context = MagicMock(return_value=None)
+        return orch
+
+    def test_run_agent_binds_prompt_and_project_to_worktree(self):
+        wf = _make_workflow(
+            current_phase="planning",
+            branch_strategy="worktree",
+            project_path="/repo/main",
+            worktree_path="/repo/.worktrees/wf-1",
+            branch_name="auto-dev/test",
+        )
+        orch = self._make_orchestrator(wf)
+
+        orch._run_agent(
+            wf=wf,
+            workflow_id=wf["workflow_id"],
+            cli_tool=wf["cli_tool"],
+            model=wf["model"],
+            project_path=wf["project_path"],
+            prompt="Plan this change",
+            workspace_type="local",
+            permission_mode="read-only",
+            allowed_tools=[],
+            session_line="main",
+            milestone_id="ms-1",
+        )
+
+        call = orch._runner.run_agent_task.call_args.kwargs
+        assert call["project_path"] == "/repo/.worktrees/wf-1"
+        assert "/repo/.worktrees/wf-1" in call["prompt"]
+        assert "auto-dev/test" in call["prompt"]
+
+
 class TestOrchestratorPreparation:
     """Tests for the preparation phase."""
 
@@ -306,6 +362,7 @@ class TestOrchestratorPreparation:
 
         mock_gh = MagicMock()
         mock_gh.create_issue.return_value = {"number": 1, "url": ""}
+        mock_gh.get_current_branch.return_value = "main"
         mock_gh_cls.return_value = mock_gh
 
         orch._do_preparation(wf)
@@ -313,6 +370,9 @@ class TestOrchestratorPreparation:
         # Should NOT create branch or worktree
         mock_gh.create_branch.assert_not_called()
         mock_gh.create_worktree.assert_not_called()
+        mock_repo.update_workflow.assert_any_call(
+            wf["workflow_id"], {"branch_name": mock_gh.get_current_branch.return_value}
+        )
         # But should still transition to planning
         update_calls = mock_repo.update_workflow.call_args_list
         phases = [c[0][1].get("current_phase") for c in update_calls if "current_phase" in c[0][1]]

--- a/tests/issues/723/test_mtime_fallback.py
+++ b/tests/issues/723/test_mtime_fallback.py
@@ -13,6 +13,7 @@ Two fixes:
 
 import json
 import os
+import pwd
 import time
 from pathlib import Path
 from unittest.mock import patch
@@ -109,6 +110,27 @@ class TestFindLatestClaudeSessionIdExcludesBound:
             _write_jsonl(project_dir / "newer.jsonl", "newer", mtime_offset=+3.0)
             result = self.runner._find_latest_claude_session_id(encoded, time.time())
             assert result == "newer"
+
+    def test_uses_system_account_home_not_service_home(self, tmp_path):
+        encoded = "encoded-worktree"
+        current_user = pwd.getpwuid(os.getuid()).pw_name
+        user_home = tmp_path / "user-home"
+        service_home = tmp_path / "service-home"
+        _write_jsonl(user_home / ".claude" / "projects" / encoded / "newer.jsonl", "newer")
+        (service_home / ".claude" / "projects").mkdir(parents=True, exist_ok=True)
+
+        fake_pw = type("Pw", (), {"pw_dir": str(user_home)})()
+        with (
+            patch("pwd.getpwnam", return_value=fake_pw),
+            patch("pathlib.Path.home", return_value=service_home),
+        ):
+            result = self.runner._find_latest_claude_session_id(
+                encoded,
+                time.time(),
+                system_account=current_user,
+            )
+
+        assert result == "newer"
 
 
 def _init_session_manager(tmp_path):

--- a/tests/issues/723/test_timeout_usage_replay.py
+++ b/tests/issues/723/test_timeout_usage_replay.py
@@ -15,6 +15,8 @@ Two fixes:
 """
 
 import json
+import os
+import pwd
 import time
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -201,6 +203,42 @@ class TestReplayUsageFromJsonl:
         with patch("pathlib.Path.home", return_value=tmp_path):
             runner._replay_usage_from_jsonl(session, cli_sid)
         assert session.total_tokens == 0
+
+    def test_replay_uses_system_account_home(self, tmp_path):
+        runner = AutonomousAgentRunner()
+        current_user = pwd.getpwuid(os.getuid()).pw_name
+        user_home = tmp_path / "user-home"
+        service_home = tmp_path / "service-home"
+        started = time.time() - 5
+        session = _make_session(started_at_epoch=started, system_account=current_user)
+        cli_sid = "abc12345"
+        jsonl = user_home / ".claude" / "projects" / "enc-wt" / f"{cli_sid}.jsonl"
+        jsonl.parent.mkdir(parents=True)
+        jsonl.write_text(
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S.000Z", time.gmtime(started + 1)),
+                    "message": {
+                        "id": "m1",
+                        "usage": {"input_tokens": 111, "output_tokens": 22},
+                    },
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        fake_pw = type("Pw", (), {"pw_dir": str(user_home)})()
+        with (
+            patch("pwd.getpwnam", return_value=fake_pw),
+            patch("pathlib.Path.home", return_value=service_home),
+        ):
+            runner._replay_usage_from_jsonl(session, cli_sid)
+
+        assert session.total_input_tokens == 111
+        assert session.total_output_tokens == 22
+        assert session.total_tokens == 133
 
     def test_replay_counts_distinct_message_ids(self, tmp_path):
         """Replay dedups assistant turns by message_id (matching _read_stdout)."""


### PR DESCRIPTION
## Summary
- unify autonomous workflow repo context across worktree, new-branch, and current-branch strategies
- enforce the effective repo/branch contract for the 3-session main/review/test topology
- fix Claude session recovery and writeback for cross-user deployments by parsing sessionId variants and reading the correct ~/.claude/projects tree
- add regression tests for repo binding, branch locking, timeout usage replay, and mtime fallback

## Verification
- python3 -m py_compile app/modules/workspace/autonomous/agent_runner.py app/modules/workspace/autonomous/orchestrator.py app/routes/autonomous.py
- pytest -q tests/issues/716/test_agent_runner.py tests/issues/716/test_orchestrator.py tests/issues/723/test_mtime_fallback.py tests/issues/723/test_timeout_usage_replay.py