### PR TITLE
fix(remote): emit keepalive as SSE data event for client stall detection

### DIFF
--- a/app/routes/autonomous.py
+++ b/app/routes/autonomous.py
@@ -1590,7 +1590,10 @@ def stream_workflow_events(workflow_id):
                     if not token or not validate_session_token(token):
                         break  # Token invalid or revoked — close stream
                     emitter.mark_read(workflow_id, q)
-                    yield ": keepalive\n\n"
+                    # Emit as a `data:` event (not an SSE comment line) so the
+                    # browser fires onmessage and the frontend stall detector can
+                    # reset on every keepalive. See app/routes/remote.py.
+                    yield f"data: {json.dumps({'type': 'keepalive'})}\n\n"
         except GeneratorExit:
             pass  # cleanup handled by finally
         finally:

--- a/app/routes/remote.py
+++ b/app/routes/remote.py
@@ -904,7 +904,11 @@ def stream_session_output(session_id):
                     if (
                         idle_count >= 50
                     ):  # ~10 seconds (50 * 0.2s), aligned with KEEPALIVE_INTERVAL_MS
-                        yield ": keepalive\n\n"
+                        # Emit as a `data:` event (not an SSE comment line) so the
+                        # browser fires onmessage and the frontend stall detector
+                        # can reset on every keepalive. Comment lines (`:` prefix)
+                        # are silently dropped by the browser and never reach JS.
+                        yield f"data: {json.dumps({'type': 'keepalive'})}\n\n"
                         idle_count = 0
 
                 # Check if session ended (in-memory, no DB query)

--- a/tests/routes/test_remote_stream_keepalive.py
+++ b/tests/routes/test_remote_stream_keepalive.py
@@ -1,0 +1,117 @@
+"""Tests for the remote SSE stream keepalive format.
+
+Background (Issue #1511 / frontend PR ivycomputing/qwen-code-webui#196):
+the SSE stream emits a keepalive while the session is idle. It used to be
+an SSE comment line (``: keepalive``), which browsers silently drop and
+never deliver to ``onmessage`` — so a frontend stall detector that resets
+on every message never saw the heartbeat and falsely declared the
+connection dead after its timeout. The keepalive must be a ``data:``
+event so the browser fires ``onmessage``.
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+from flask import g
+
+
+def _auth_chain():
+    """Patch the remote blueprint auth chain to a minimal authenticated user.
+
+    The blueprint's ``before_request`` calls ``_set_user_from_token`` (imported
+    into ``app.routes.remote``) which sets ``g.user``. We bypass token loading
+    and inject a minimal admin user so ``_check_session_access`` passes.
+    """
+
+    def apply_user(_user):
+        g.user = {"id": 1, "role": "system_admin"}
+        g.user_id = 1
+        g.user_role = "system_admin"
+
+    return (
+        patch("app.routes.remote._set_user_from_token", return_value=True),
+        patch("app.routes.remote._set_user_from_webui_token", return_value=False),
+        patch("app.modules.workspace.session_access._apply_user", side_effect=apply_user),
+        patch("app.routes.remote._check_session_access", return_value=(None, None)),
+    )
+
+
+def _make_minimal_app():
+    """Flask app with only the remote blueprint registered (no full create_app)."""
+    from flask import Flask
+
+    from app.routes.remote import remote_bp
+
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.register_blueprint(remote_bp, url_prefix="/api/remote")
+    return app
+
+
+def _make_agent_mgr(loop_count):
+    """Return a mock remote agent manager.
+
+    Yields no buffered output (so the idle/keepalive branch is taken) and
+    reports the session as ended after ``loop_count`` iterations, so the
+    generator terminates.
+    """
+    mgr = MagicMock()
+    mgr.get_last_delivered.return_value = 0
+    mgr.get_buffered_output.return_value = []  # always idle → keepalive path
+    mgr.is_session_ended.side_effect = [False] * loop_count + [True]
+    return mgr
+
+
+def _consume_stream(resp):
+    """Read the full SSE response body and decode to text."""
+    return b"".join(resp.iter_encoded()).decode("utf-8")
+
+
+def _stream_body(loop_count=52):
+    """Run the stream route with mocked deps and return the decoded SSE body."""
+    from contextlib import ExitStack
+
+    app = _make_minimal_app()
+    agent_mgr = _make_agent_mgr(loop_count=loop_count)
+    auth_patches = _auth_chain()
+
+    with ExitStack() as stack:
+        for p in auth_patches:
+            stack.enter_context(p)
+        stack.enter_context(
+            patch("app.routes.remote.get_remote_agent_manager", return_value=agent_mgr)
+        )
+        stack.enter_context(patch("app.routes.remote.time.sleep"))  # no real delays
+        with app.test_client() as client:
+            resp = client.get("/api/remote/sessions/test-sid/stream")
+
+    assert resp.status_code == 200, resp.get_data(as_text=True)
+    return _consume_stream(resp)
+
+
+class TestKeepaliveFormat:
+    def test_keepalive_is_data_event_not_comment(self):
+        """Idle keepalive must be a ``data:`` event, never an SSE comment line."""
+        body = _stream_body()
+
+        # The keepalive MUST be a data: event (fires onmessage) ...
+        assert 'data: {"type": "keepalive"}' in body
+        # ... and MUST NOT be a comment line (silently dropped by browsers).
+        assert ": keepalive" not in body
+
+    def test_keepalive_payload_is_valid_json(self):
+        """The keepalive data payload parses as JSON with type == keepalive."""
+        body = _stream_body()
+        # Extract the first keepalive data line and validate it.
+        keepalive_line = next(
+            line for line in body.splitlines() if line.startswith("data:") and "keepalive" in line
+        )
+        payload = json.loads(keepalive_line[len("data:") :].strip())
+        assert payload == {"type": "keepalive"}
+
+    def test_stream_emits_connected_comment_header(self):
+        """The leading ``: connected`` header (to flush response headers) is kept."""
+        body = _stream_body()
+        # The first chunk is the connected header — this is intentional and
+        # must NOT be changed (only the periodic keepalive is a data event).
+        assert body.startswith(": connected")


### PR DESCRIPTION
## Problem

The remote and autonomous SSE streams emit their idle keepalive as an SSE **comment line** (`: keepalive`). Per the SSE spec, comment lines (any line starting with `: `) are silently dropped by the browser and **never dispatch a `message` event**.

This breaks the frontend stall detector in ivycomputing/qwen-code-webui#196, which resets its stall timer inside `onmessage`. Because the 10s heartbeat never reaches `onmessage`, the detector falsely declares the connection dead after its 35s timeout → `es.close()` + reconnect, then the same thing repeats → **every ~35s of healthy idle triggers a needless reconnect**. That is the opposite of the protection it was meant to provide, and each reconnect churns the connection (and briefly flashes a reconnecting state).

Per the spec, `EventSource` has no way to observe comment-line heartbeats, so stall detection cannot distinguish "healthy idle (heartbeat in stream)" from "dead connection (no data)" while the heartbeat is a comment.

## Fix

Emit the keepalive as a `data:` event so the browser fires `onmessage` and the frontend can reset its stall timer on every heartbeat:

```python
# before
yield ": keepalive\n\n"
# after
yield f"data: {json.dumps({'type':'keepalive'})}\n\n"
```

The leading `: connected` flush header (used only to force response headers out so the browser leaves the CONNECTING state quickly) is **unchanged** — it correctly is not a message and the frontend does not rely on it.

## Changes

- `app/routes/remote.py` — `stream_session_output` keepalive → `data:` event
- `app/routes/autonomous.py` — same change for the autonomous workflow stream (same trap; keeps the two streams consistent)
- `tests/routes/test_remote_stream_keepalive.py` — new unit tests asserting the keepalive is a `data:` event with valid JSON `{"type":"keepalive"}`, not a comment line; and that the `: connected` header is preserved

## Compatibility

- Frontend `onmessage` handlers that forward `data:` payloads must **ignore** `{"type":"keepalive"}`. That frontend change is part of ivycomputing/qwen-code-webui#196 (this backend PR + that frontend PR should land together).
- Existing consumers that already parse wrapped `data:` events by `type` (claude_json / permission_request / request_state / error) are unaffected — a new `keepalive` type is simply a no-op for them.

Refs #1511
Refs ivycomputing/qwen-code-webui#196