### PR TITLE
fix(ui): 项目管理页面深色模式适配 — 分类行背景及弹窗统计卡片 (Issue #1675)

### DIFF
--- a/frontend/src/components/features/management/ProjectManagement.tsx
+++ b/frontend/src/components/features/management/ProjectManagement.tsx
@@ -326,7 +326,7 @@ export const ProjectManagement: React.FC = () => {
   }
 
   return (
-    <div className="space-y-4">
+    <div className="project-management space-y-4">
       {/* Page Header */}
       <div className="page-header d-flex justify-content-between align-items-center mb-4">
         <h2>{t('projectManagement', language)}</h2>
@@ -451,7 +451,9 @@ export const ProjectManagement: React.FC = () => {
                       <tr
                         onClick={() => toggleExpand(category.category_name)}
                         style={{ cursor: 'pointer' }}
-                        className={isUncategorized ? 'table-secondary' : ''}
+                        className={
+                          isUncategorized ? 'project-category-secondary' : 'project-category-row'
+                        }
                       >
                         <td>
                           <i
@@ -494,7 +496,7 @@ export const ProjectManagement: React.FC = () => {
 
                       {/* Expanded Workspace Rows */}
                       {isExpanded && category.workspaces.length > 0 && (
-                        <tr className="table-light">
+                        <tr className="project-workspace-expand">
                           <td colSpan={8} style={{ padding: 0 }}>
                             <div className="p-2 ps-4">
                               <table className="table table-sm mb-0">
@@ -639,8 +641,8 @@ const WorkspaceDetailContent: React.FC<{
       {/* Workspace Header */}
       <div className="d-flex align-items-start gap-3">
         <div
-          className="d-flex align-items-center justify-content-center rounded-3 flex-shrink-0"
-          style={{ width: 48, height: 48, backgroundColor: 'var(--bs-info-bg-subtle, #cff4fc)' }}
+          className="d-flex align-items-center justify-content-center rounded-3 flex-shrink-0 project-detail-icon-box"
+          style={{ width: 48, height: 48 }}
         >
           <i className="bi bi-folder2-open-fill text-info fs-4" />
         </div>
@@ -668,30 +670,21 @@ const WorkspaceDetailContent: React.FC<{
       {/* Stats Grid */}
       <div className="row g-3">
         <div className="col-6 col-md-3">
-          <div
-            className="text-center p-3 rounded-3"
-            style={{ backgroundColor: 'var(--bs-primary-bg-subtle, #cfe2ff)' }}
-          >
+          <div className="text-center p-3 rounded-3 project-detail-stat-box project-detail-stat-primary">
             <i className="bi bi-people text-primary d-block mb-1" />
             <div className="text-muted small">{t('users', language)}</div>
             <div className="fs-4 fw-bold text-primary">{workspace.total_users}</div>
           </div>
         </div>
         <div className="col-6 col-md-3">
-          <div
-            className="text-center p-3 rounded-3"
-            style={{ backgroundColor: 'var(--bs-info-bg-subtle, #cff4fc)' }}
-          >
+          <div className="text-center p-3 rounded-3 project-detail-stat-box project-detail-stat-info">
             <i className="bi bi-chat-square-text text-info d-block mb-1" />
             <div className="text-muted small">{t('sessions', language)}</div>
             <div className="fs-4 fw-bold text-info">{workspace.total_sessions}</div>
           </div>
         </div>
         <div className="col-6 col-md-3">
-          <div
-            className="text-center p-3 rounded-3"
-            style={{ backgroundColor: 'var(--bs-success-bg-subtle, #d1e7dd)' }}
-          >
+          <div className="text-center p-3 rounded-3 project-detail-stat-box project-detail-stat-success">
             <i className="bi bi-cpu text-success d-block mb-1" />
             <div className="text-muted small">{t('tokens', language)}</div>
             <div className="fs-4 fw-bold text-success">
@@ -700,10 +693,7 @@ const WorkspaceDetailContent: React.FC<{
           </div>
         </div>
         <div className="col-6 col-md-3">
-          <div
-            className="text-center p-3 rounded-3"
-            style={{ backgroundColor: 'var(--bs-warning-bg-subtle, #fff3cd)' }}
-          >
+          <div className="text-center p-3 rounded-3 project-detail-stat-box project-detail-stat-warning">
             <i className="bi bi-clock text-warning d-block mb-1" />
             <div className="text-muted small">{t('workTime', language)}</div>
             <div className="fs-4 fw-bold text-warning">

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -1726,6 +1726,98 @@ table .latency-row:hover td {
   color: var(--text-primary);
 }
 
+/* ===== Project Management Page - Dark Theme (Issue #1666) ===== */
+
+/* Base table overrides */
+[data-theme='dark'] .project-management .table {
+  --bs-table-color: var(--text-primary);
+  --bs-table-bg: transparent;
+  --bs-table-border-color: var(--border-color);
+  --bs-table-hover-color: var(--text-primary);
+  --bs-table-hover-bg: rgba(255, 255, 255, 0.05);
+  --bs-table-striped-color: var(--text-primary);
+  --bs-table-striped-bg: rgba(255, 255, 255, 0.02);
+  color: var(--text-primary);
+}
+
+/* Category row (normal) — subtle alternating background */
+.project-category-row {
+  background-color: transparent;
+}
+[data-theme='dark'] .project-category-row {
+  background-color: rgba(255, 255, 255, 0.02);
+}
+
+/* Category row (uncategorized/secondary) — slightly more prominent */
+.project-category-secondary {
+  background-color: #e2e3e5; /* Bootstrap table-secondary light */
+}
+[data-theme='dark'] .project-category-secondary {
+  background-color: rgba(255, 255, 255, 0.06);
+  color: var(--text-primary);
+}
+
+/* Expanded workspace container row */
+.project-workspace-expand {
+  background-color: #f8f9fa; /* Bootstrap table-light light */
+}
+[data-theme='dark'] .project-workspace-expand {
+  background-color: rgba(255, 255, 255, 0.03);
+}
+
+/* Inner expanded table */
+[data-theme='dark'] .project-workspace-expand .table {
+  --bs-table-color: var(--text-primary);
+  --bs-table-bg: transparent;
+  --bs-table-border-color: var(--border-color);
+  --bs-table-hover-color: var(--text-primary);
+  --bs-table-hover-bg: rgba(255, 255, 255, 0.05);
+  color: var(--text-primary);
+}
+
+/* Workspace detail modal — icon box */
+.project-detail-icon-box {
+  background-color: var(--bs-info-bg-subtle, #cff4fc);
+}
+[data-theme='dark'] .project-detail-icon-box {
+  background-color: rgba(59, 130, 246, 0.15);
+}
+
+/* Workspace detail modal — stat boxes (light mode) */
+.project-detail-stat-primary {
+  background-color: var(--bs-primary-bg-subtle, #cfe2ff);
+}
+.project-detail-stat-info {
+  background-color: var(--bs-info-bg-subtle, #cff4fc);
+}
+.project-detail-stat-success {
+  background-color: var(--bs-success-bg-subtle, #d1e7dd);
+}
+.project-detail-stat-warning {
+  background-color: var(--bs-warning-bg-subtle, #fff3cd);
+}
+
+/* Workspace detail modal — stat boxes (dark mode) */
+[data-theme='dark'] .project-detail-stat-primary {
+  background-color: rgba(56, 189, 248, 0.12);
+}
+[data-theme='dark'] .project-detail-stat-info {
+  background-color: rgba(59, 130, 246, 0.12);
+}
+[data-theme='dark'] .project-detail-stat-success {
+  background-color: rgba(16, 185, 129, 0.12);
+}
+[data-theme='dark'] .project-detail-stat-warning {
+  background-color: rgba(245, 158, 11, 0.12);
+}
+
+/* Delete confirmation alert — dark mode */
+[data-theme='dark'] .project-management .alert-danger {
+  background-color: rgba(239, 68, 68, 0.12);
+  border-color: rgba(239, 68, 68, 0.25);
+  color: var(--color-danger);
+}
+
 /* Legacy message-content class for backward compatibility */
 .message-content {
   white-space: pre-wrap;


### PR DESCRIPTION
## 问题

管理 → 项目 → 项目管理页面在深色模式下存在多处不适配：

1. **项目分类表格行**：使用 Bootstrap `table-secondary` / `table-light` 类，深色模式下仍为浅色背景
2. **工作区详情弹窗**：统计卡片使用硬编码内联 `var(--bs-*-bg-subtle, #xxx)` 样式，深色模式下不切换
3. **删除确认弹窗**：`alert-danger` 在深色模式下仍为浅色背景

## 修复方案

### `ProjectManagement.tsx`
- 添加 `project-management` 包裹类用于 CSS 作用域定位
- 替换 `table-secondary` → `project-category-secondary`
- 替换 `table-light` → `project-workspace-expand`
- 普通分类行使用 `project-category-row`
- 弹窗中硬编码内联背景色替换为 CSS 类（`project-detail-icon-box`、`project-detail-stat-{primary,info,success,warning}`）

### `main.css`
- 添加 `.project-management .table` 深色模式覆盖
- 添加分类行、展开行、弹窗统计框、删除确认 alert 的深色模式样式

## 测试

- TypeScript 编译通过 (`tsc --noEmit`)
- ESLint 通过（仅有预存 warning）
- 单元测试通过（无新增失败）

Closes #1675