### PR TITLE
fix(ui): 模型网关配置页面深色模式对比度不足 (Issue #1680)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- 管理-设置-模型网关配置页面深色模式对比度问题：状态提示框（"网关路由未启用"警告与"已启用"成功状态）文字与背景对比度不足，新增 `--color-{success,warning,danger,info}-{bg,text}` CSS 变量并在深色模式下使用低透明度语义背景 + 明亮文字色，确保 WCAG AA ≥ 4.5:1。
+
 ### Changed
 - 代码审查提醒 Issue（每 3 周自动生成）现自带体检报告：workflow 内自动执行 Bandit 安全扫描、pip-audit 依赖漏洞、迁移单 head 校验、前端构建体积，以及 DB 死索引/大表/慢查询 SQL 清单，并在模板补齐"🛡️ 安全"维度；每项体检步骤 `continue-on-error`，单项工具故障不阻断 Issue 创建。
 - `MessageRepository.get_user_conversation_samples` 由 per-session N+1 查询改为单次批量查询（`IN` 列表 + 应用层按 session 分组），保留逐 session `(agent_session_id = S OR conversation_id = S)` 语义与值域碰撞/双字段场景的等价性；批量失败时回退到原 per-session 循环。

--- a/frontend/src/components/features/management/ModelGatewayConfig.tsx
+++ b/frontend/src/components/features/management/ModelGatewayConfig.tsx
@@ -176,11 +176,28 @@ export const ModelGatewayConfig: React.FC = () => {
           {statusInfo.variant === 'success' ? (
             <Badge variant="success">{statusInfo.text}</Badge>
           ) : (
-            <span style={{ fontWeight: 500 }}>{statusInfo.text}</span>
+            <span
+              style={{
+                fontWeight: 600,
+                color: 'var(--color-warning-text, #856404)',
+              }}
+            >
+              {statusInfo.text}
+            </span>
           )}
         </div>
         {statusInfo.showInstructions && (
-          <p style={{ marginTop: '0.5rem', marginBottom: 0, fontSize: '0.9em' }}>
+          <p
+            style={{
+              marginTop: '0.5rem',
+              marginBottom: 0,
+              fontSize: '0.9em',
+              color:
+                statusInfo.variant === 'success'
+                  ? 'var(--color-success-text, #155724)'
+                  : 'var(--color-warning-text, #856404)',
+            }}
+          >
             {t('gatewayEnableInstructions', language)}
           </p>
         )}

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -26,12 +26,20 @@
   /* Accent Colors */
   --color-success: #10b981;
   --color-success-hover: #059669;
+  --color-success-bg: #d4edda;
+  --color-success-text: #155724;
   --color-warning: #f59e0b;
   --color-warning-hover: #d97706;
+  --color-warning-bg: #fff3cd;
+  --color-warning-text: #856404;
   --color-danger: #ef4444;
   --color-danger-hover: #dc2626;
+  --color-danger-bg: #f8d7da;
+  --color-danger-text: #721c24;
   --color-info: #3b82f6;
   --color-info-hover: #2563eb;
+  --color-info-bg: #d1ecf1;
+  --color-info-text: #0c5460;
 
   /* Purple Accent for special elements */
   --color-accent: #8b5cf6;
@@ -240,6 +248,18 @@
   --color-primary-rgb: 56, 189, 248;
   --color-primary-hover: #0ea5e9;
   --color-primary-light: rgba(14, 165, 233, 0.1);
+
+  /* Semantic background tints for dark mode (Issue: ModelGatewayConfig contrast)
+     Use low-opacity tints of the semantic color so that light text (--text-primary)
+     maintains WCAG AA contrast (≥4.5:1) on the dark card/page background. */
+  --color-success-bg: rgba(16, 185, 129, 0.15);
+  --color-success-text: #34d399; /* bright green — ≥4.5:1 on dark bg */
+  --color-warning-bg: rgba(245, 158, 11, 0.15);
+  --color-warning-text: #fbbf24; /* bright amber — ≥4.5:1 on dark bg */
+  --color-danger-bg: rgba(239, 68, 68, 0.15);
+  --color-danger-text: #f87171;
+  --color-info-bg: rgba(59, 130, 246, 0.15);
+  --color-info-text: #60a5fa;
 
   --shadow-sm: 0 1px 3px 0 rgb(0 0 0 / 0.3), 0 1px 2px -1px rgb(0 0 0 / 0.3);
   --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.3), 0 2px 4px -2px rgb(0 0 0 / 0.3);


### PR DESCRIPTION
## 问题

全局深色模式下，管理 → 设置 → 模型网关配置页面的状态提示框文字几乎不可见。

Closes #1680

## 原因

`ModelGatewayConfig.tsx` 使用 `var(--color-warning-bg, #fff3cd)` / `var(--color-success-bg, #d4edda)` 作为提示框背景，但这两个 CSS 变量**从未在 `main.css` 中定义**。深色模式下回退到亮色背景，搭配浅色文字 `--text-primary: #f8fafc`，对比度极差。

## 修复内容

### `frontend/src/styles/main.css`
- `:root` 新增 `--color-{success,warning,danger,info}-{bg,text}` 变量（浅色模式）
- `[data-theme='dark']` 新增对应深色模式值：
  - 背景：低透明度语义色（如 `rgba(245, 158, 11, 0.15)`）
  - 文字：明亮语义色（如 `#fbbf24`），确保 WCAG AA ≥ 4.5:1

### `frontend/src/components/features/management/ModelGatewayConfig.tsx`
- 警告标题文字使用 `var(--color-warning-text, #856404)`
- 说明段落文字使用 `var(--color-warning-text)` / `var(--color-success-text)`
- 标题字重增加到 600

## 测试
- ✅ 10 个现有单元测试全部通过
- ✅ TypeScript 编译无错误