### PR TITLE
fix: reflow autonomous workflows on merge CI failures

### DIFF
--- a/app/modules/workspace/autonomous/__init__.py
+++ b/app/modules/workspace/autonomous/__init__.py
@@ -50,6 +50,7 @@ def get_ddl_statements():
             workspace_type TEXT DEFAULT 'local',
             remote_machine_id TEXT DEFAULT '',
             worktree_path TEXT DEFAULT '',
+            preferred_worktree_path TEXT DEFAULT '',
             main_session_id TEXT DEFAULT '',
             review_session_id TEXT DEFAULT '',
             test_session_id TEXT DEFAULT '',
@@ -92,7 +93,10 @@ def get_ddl_statements():
             test_retries INTEGER DEFAULT 0,
             skip_retries INTEGER DEFAULT 0,
             dev_retries_on_test_fail INTEGER DEFAULT 0,
-            system_account TEXT DEFAULT ''
+            system_account TEXT DEFAULT '',
+            ci_repair_context TEXT DEFAULT '',
+            ci_repair_attempts INTEGER DEFAULT 0,
+            last_ci_failure_signature TEXT DEFAULT ''
         )
         """,
     ]
@@ -127,6 +131,18 @@ def get_ddl_statements():
     # private directories. Mirrors Alembic migration
     # 20260707_001_add_system_account_to_workflows for the SQLite dev/test path.
     statements.append("ALTER TABLE autonomous_workflows ADD COLUMN system_account TEXT DEFAULT ''")
+    statements.append(
+        "ALTER TABLE autonomous_workflows ADD COLUMN preferred_worktree_path TEXT DEFAULT ''"
+    )
+    statements.append(
+        "ALTER TABLE autonomous_workflows ADD COLUMN ci_repair_context TEXT DEFAULT ''"
+    )
+    statements.append(
+        "ALTER TABLE autonomous_workflows ADD COLUMN ci_repair_attempts INTEGER DEFAULT 0"
+    )
+    statements.append(
+        "ALTER TABLE autonomous_workflows ADD COLUMN last_ci_failure_signature TEXT DEFAULT ''"
+    )
     statements.extend(
         [
             """

--- a/app/modules/workspace/autonomous/github_ops.py
+++ b/app/modules/workspace/autonomous/github_ops.py
@@ -776,6 +776,88 @@ class GitHubOps:
         data = json.loads(result.stdout.strip())
         return data.get("commits", [])
 
+    @staticmethod
+    def _bucket_from_status_state(state: str) -> str:
+        state = (state or "").strip().lower()
+        if state in {"queued", "in_progress", "pending", "waiting", "requested"}:
+            return "pending"
+        if state in {"success", "passed", "pass"}:
+            return "pass"
+        if state in {"neutral", "skipped"}:
+            return "skipping"
+        if state in {"failure", "failed", "error", "cancelled", "timed_out", "action_required"}:
+            return "fail"
+        return "pending" if not state else "fail"
+
+    @classmethod
+    def _bucket_from_check_run(cls, status: str, conclusion: str) -> str:
+        normalized_status = (status or "").strip().lower()
+        if normalized_status and normalized_status != "completed":
+            return "pending"
+        return cls._bucket_from_status_state(conclusion or normalized_status)
+
+    @staticmethod
+    def _is_pr_checks_json_unsupported(output: str) -> bool:
+        lowered = (output or "").lower()
+        return "--json" in lowered and (
+            "unknown flag" in lowered
+            or "accepts 1 arg" in lowered
+            or "unknown shorthand flag" in lowered
+        )
+
+    def _get_pr_head_sha(self, pr_number: int) -> str:
+        repo = self.get_repo_name()
+        result = self._run_gh(
+            self._gh_api_args([f"repos/{repo}/pulls/{pr_number}"]),
+            repo_scoped=False,
+        )
+        data = json.loads((result.stdout or "").strip() or "{}")
+        return ((data.get("head") or {}).get("sha") or "").strip()
+
+    def _get_pr_checks_via_api(self, pr_number: int) -> list:
+        repo = self.get_repo_name()
+        head_sha = self._get_pr_head_sha(pr_number)
+        if not head_sha:
+            raise GitHubOpsError(f"Unable to resolve head SHA for PR #{pr_number}")
+
+        status_result = self._run_gh(
+            self._gh_api_args([f"repos/{repo}/commits/{head_sha}/status"]),
+            repo_scoped=False,
+        )
+        check_runs_result = self._run_gh(
+            self._gh_api_args([f"repos/{repo}/commits/{head_sha}/check-runs"]),
+            repo_scoped=False,
+        )
+
+        status_payload = json.loads((status_result.stdout or "").strip() or "{}")
+        check_runs_payload = json.loads((check_runs_result.stdout or "").strip() or "{}")
+
+        checks: list[dict] = []
+        for status in status_payload.get("statuses", []) or []:
+            state = (status.get("state") or "").strip().lower()
+            checks.append(
+                {
+                    "name": status.get("context") or "status",
+                    "state": state or "unknown",
+                    "bucket": self._bucket_from_status_state(state),
+                    "link": status.get("target_url") or "",
+                }
+            )
+
+        for check_run in check_runs_payload.get("check_runs", []) or []:
+            status = (check_run.get("status") or "").strip().lower()
+            conclusion = (check_run.get("conclusion") or "").strip().lower()
+            checks.append(
+                {
+                    "name": check_run.get("name") or "check-run",
+                    "state": conclusion or status or "unknown",
+                    "bucket": self._bucket_from_check_run(status, conclusion),
+                    "link": check_run.get("html_url") or "",
+                }
+            )
+
+        return checks
+
     def get_pr_checks(self, pr_number: int) -> list:
         """Get CI check status for a PR.
 
@@ -787,11 +869,43 @@ class GitHubOps:
             check=False,
         )
         try:
-            return json.loads(result.stdout)
+            if result.returncode == 0:
+                raw = result.stdout if result.stdout else ""
+                if not raw.strip():
+                    return []
+                return json.loads(raw)
         except (json.JSONDecodeError, AttributeError, TypeError):
             raw = result.stdout if result.stdout else ""
             logger.warning("Failed to parse CI checks for PR #%s: %s", pr_number, raw[:200])
-            return []
+
+        primary_parts = []
+        for part in (getattr(result, "stderr", ""), getattr(result, "stdout", "")):
+            if not isinstance(part, str):
+                continue
+            stripped = part.strip()
+            if stripped:
+                primary_parts.append(stripped)
+        primary_output = "\n".join(primary_parts)
+        if result.returncode != 0 and not self._is_pr_checks_json_unsupported(primary_output):
+            logger.warning(
+                "gh pr checks --json failed for PR #%s, falling back to REST API: %s",
+                pr_number,
+                primary_output[:200],
+            )
+        elif self._is_pr_checks_json_unsupported(primary_output):
+            logger.info(
+                "gh pr checks --json unsupported for PR #%s, falling back to REST API",
+                pr_number,
+            )
+
+        try:
+            return self._get_pr_checks_via_api(pr_number)
+        except Exception as api_err:
+            detail = primary_output[:200] if primary_output else "empty response"
+            raise GitHubOpsError(
+                f"Failed to query CI checks for PR #{pr_number}: {detail}; "
+                f"REST fallback error: {api_err}"
+            ) from api_err
 
     def get_pr_diff(self, number: int) -> str:
         """Get the full diff of a PR (head vs base) via `gh pr diff`.

--- a/app/modules/workspace/autonomous/models.py
+++ b/app/modules/workspace/autonomous/models.py
@@ -41,6 +41,7 @@ class AutonomousWorkflow:
     workspace_type: str = "local"  # local|remote
     remote_machine_id: str = ""
     worktree_path: str = ""
+    preferred_worktree_path: str = ""
     github_issue_number: Optional[int] = None
     github_pr_number: Optional[int] = None
     github_pr_url: str = ""
@@ -63,6 +64,9 @@ class AutonomousWorkflow:
     total_output_tokens: int = 0
     total_requests: int = 0
     error_message: str = ""
+    ci_repair_context: str = ""
+    ci_repair_attempts: int = 0
+    last_ci_failure_signature: str = ""
     # Source of truth for AI-authored content language (en/zh/ja/ko). Set once
     # at creation; persisted content is generated in this language and rendered
     # verbatim (it does NOT switch per viewer). System-authored structured
@@ -112,6 +116,7 @@ class AutonomousWorkflow:
             "workspace_type": self.workspace_type,
             "remote_machine_id": self.remote_machine_id,
             "worktree_path": self.worktree_path,
+            "preferred_worktree_path": self.preferred_worktree_path,
             "github_issue_number": self.github_issue_number,
             "github_pr_number": self.github_pr_number,
             "github_pr_url": self.github_pr_url,
@@ -132,6 +137,9 @@ class AutonomousWorkflow:
             "total_output_tokens": self.total_output_tokens,
             "total_requests": self.total_requests,
             "error_message": self.error_message,
+            "ci_repair_context": self.ci_repair_context,
+            "ci_repair_attempts": self.ci_repair_attempts,
+            "last_ci_failure_signature": self.last_ci_failure_signature,
             "content_language": self.content_language,
             "created_at": self.created_at.isoformat() if self.created_at else None,
             "updated_at": self.updated_at.isoformat() if self.updated_at else None,
@@ -163,6 +171,7 @@ class AutonomousWorkflow:
             workspace_type=data.get("workspace_type", "local"),
             remote_machine_id=data.get("remote_machine_id", ""),
             worktree_path=data.get("worktree_path", ""),
+            preferred_worktree_path=data.get("preferred_worktree_path", ""),
             github_issue_number=data.get("github_issue_number"),
             github_pr_number=data.get("github_pr_number"),
             github_pr_url=data.get("github_pr_url", ""),
@@ -183,6 +192,9 @@ class AutonomousWorkflow:
             total_output_tokens=data.get("total_output_tokens", 0),
             total_requests=data.get("total_requests", 0),
             error_message=data.get("error_message", ""),
+            ci_repair_context=data.get("ci_repair_context", ""),
+            ci_repair_attempts=data.get("ci_repair_attempts", 0),
+            last_ci_failure_signature=data.get("last_ci_failure_signature", ""),
             content_language=data.get("content_language", "en"),
             created_at=(
                 datetime.fromisoformat(data["created_at"]) if data.get("created_at") else None

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -658,6 +658,7 @@ _TRANSIENT_API_ERROR_RE = re.compile(
 # Test failure retry configuration.
 MAX_TEST_RETRIES = 2  # max retries when test agent itself fails
 MAX_DEV_RETRIES_ON_TEST_FAIL = 2  # max dev round retries for unfixable test failures
+MAX_CI_REPAIR_ATTEMPTS = 2  # max automatic dev-round retries for merge-phase CI failures
 
 
 def _next_phase(current_phase: str) -> str:
@@ -1112,6 +1113,70 @@ class AutonomousOrchestrator:
         )
 
     @staticmethod
+    def _ci_failure_signature(checks: list[dict]) -> str:
+        """Build a stable signature for the current set of failed CI checks."""
+        parts = []
+        for check in checks or []:
+            if check.get("bucket") != "fail":
+                continue
+            parts.append(
+                "|".join(
+                    [
+                        str(check.get("name") or "").strip(),
+                        str(check.get("state") or "").strip(),
+                        str(check.get("bucket") or "").strip(),
+                    ]
+                )
+            )
+        return "\n".join(sorted(parts))
+
+    def _get_preferred_worktree_path(self, wf: dict) -> str:
+        """Return the canonical worktree path the workflow should reuse."""
+        preferred = (wf.get("preferred_worktree_path") or "").strip()
+        if preferred:
+            return preferred
+        current = (wf.get("worktree_path") or "").strip()
+        if current:
+            return current
+        project_path = (wf.get("project_path") or "").strip()
+        workflow_id = (wf.get("workflow_id") or self._workflow_id or "").strip()
+        if not project_path or not workflow_id:
+            return ""
+        return os.path.join(project_path, ".worktrees", workflow_id)
+
+    @staticmethod
+    def _build_ci_repair_context(pr_number: int, failed_checks: list[dict]) -> str:
+        """Summarize failed CI checks for the next development round prompt."""
+        lines = [f"PR #{pr_number} 在合并前检测到以下 CI 失败：", ""]
+        for check in failed_checks or []:
+            if check.get("bucket") != "fail":
+                continue
+            state = check.get("state") or "unknown"
+            link = check.get("link") or ""
+            bullet = f"- {check.get('name') or 'unknown'}: {state}"
+            if link:
+                bullet += f" ({link})"
+            lines.append(bullet)
+        lines.extend(
+            [
+                "",
+                "请优先分析这些失败是否由当前分支引入，修复后重新运行相关测试，并确保修改已推送到当前工作分支。",
+            ]
+        )
+        return "\n".join(lines).strip()
+
+    def _get_ci_repair_prompt(self, wf: dict) -> str:
+        """Return merge-phase CI repair context for development, or empty."""
+        context = wf.get("ci_repair_context", "")
+        if not context or not context.strip():
+            return ""
+        return (
+            "\n\n## ⚠️ Merge 阶段 CI 修复上下文\n"
+            "当前轮次是因为 PR 在合并阶段检测到 CI 失败而回流，请优先处理以下问题：\n"
+            f"{context}\n\n"
+        )
+
+    @staticmethod
     def _clean_agent_text(text: str) -> str:
         return clean_agent_text(text)
 
@@ -1376,17 +1441,22 @@ class AutonomousOrchestrator:
         items if the timeout was reached).
         """
         deadline = time.monotonic() + CI_POLL_MAX_WAIT
+        last_error = ""
         while True:
             try:
                 checks = gh.get_pr_checks(pr_number)
-            except Exception:
+            except Exception as e:
+                last_error = str(e)
                 logger.warning("CI check query failed for PR #%s, will retry...", pr_number)
                 if time.monotonic() >= deadline:
-                    return []
+                    raise GitHubOpsError(
+                        f"Failed to query CI checks for PR #{pr_number} within "
+                        f"{CI_POLL_MAX_WAIT}s: {last_error}"
+                    ) from e
                 time.sleep(CI_POLL_INTERVAL)
                 continue
             if not checks:
-                # No checks configured or parse failure — nothing to wait for.
+                # No checks configured — nothing to wait for.
                 return checks
             pending = [c for c in checks if c.get("bucket") == "pending"]
             if not pending:
@@ -1406,6 +1476,80 @@ class AutonomousOrchestrator:
                 CI_POLL_INTERVAL,
             )
             time.sleep(CI_POLL_INTERVAL)
+
+    def _start_ci_repair_round(self, wf: dict, pr_number: int, failed_checks: list[dict]) -> None:
+        """Route merge-phase CI failures back into a new development round."""
+        dev_round = int(wf.get("dev_round", 1) or 1)
+        previous_attempts = int(wf.get("ci_repair_attempts", 0) or 0)
+        next_attempt = previous_attempts + 1
+        signature = self._ci_failure_signature(failed_checks)
+        previous_signature = (wf.get("last_ci_failure_signature") or "").strip()
+        failure_names = ", ".join(
+            check.get("name") or "unknown"
+            for check in failed_checks
+            if check.get("bucket") == "fail"
+        )
+        preferred_worktree_path = self._get_preferred_worktree_path(wf)
+
+        if previous_signature and signature and previous_signature == signature:
+            message = f"PR #{pr_number} CI 失败在自动修复后仍未变化: {failure_names or signature}"
+            self._create_milestone(
+                phase="merge",
+                dev_round=dev_round,
+                milestone_type="ci_repair_exhausted",
+                status="failed",
+                title="CI failures unchanged after automatic repair",
+                error_message=message,
+            )
+            self._update_workflow({"status": "failed", "error_message": message})
+            return
+
+        if next_attempt > MAX_CI_REPAIR_ATTEMPTS:
+            message = (
+                f"PR #{pr_number} CI failed after {MAX_CI_REPAIR_ATTEMPTS} automatic repair rounds: "
+                f"{failure_names or signature}"
+            )
+            self._create_milestone(
+                phase="merge",
+                dev_round=dev_round,
+                milestone_type="ci_repair_exhausted",
+                status="failed",
+                title="CI automatic repair limit reached",
+                error_message=message,
+            )
+            self._update_workflow({"status": "failed", "error_message": message})
+            return
+
+        next_dev_round = dev_round + 1
+        context = self._build_ci_repair_context(pr_number, failed_checks)
+        self._create_milestone(
+            phase="merge",
+            dev_round=dev_round,
+            milestone_type="ci_repair_started",
+            status="completed",
+            title=f"CI failed for PR #{pr_number}, restarting development round {next_dev_round}",
+            result_summary=context[:200],
+        )
+        updates = {
+            "current_phase": "development",
+            "status": "developing",
+            "current_round": 0,
+            "dev_round": next_dev_round,
+            "agent_pid": None,
+            "agent_session_id": "",
+            "test_retries": 0,
+            "skip_retries": 0,
+            "dev_retries_on_test_fail": 0,
+            "error_message": "",
+            "ci_repair_attempts": next_attempt,
+            "ci_repair_context": context,
+            "last_ci_failure_signature": signature,
+        }
+        if wf.get("branch_strategy") == "worktree" and preferred_worktree_path:
+            updates["preferred_worktree_path"] = preferred_worktree_path
+            updates["worktree_path"] = preferred_worktree_path
+        self._update_workflow(updates)
+        self._emit("phase_change", {"phase": "development"})
 
     def _update_workflow(self, updates: dict):
         """Update workflow and emit event."""
@@ -2431,6 +2575,7 @@ class AutonomousOrchestrator:
                     self._update_workflow(
                         {
                             "worktree_path": actual_worktree_path,
+                            "preferred_worktree_path": actual_worktree_path,
                             "branch_name": branch_name,
                         }
                     )
@@ -3063,6 +3208,7 @@ class AutonomousOrchestrator:
             f"5. 遵循项目现有的代码风格和约定\n"
             f"6. 所有修改完成后，提交 git commit"
         )
+        dev_prompt += self._get_ci_repair_prompt(wf)
         dev_prompt += self._get_user_feedback_prompt(wf)
 
         result = self._run_agent(
@@ -3886,7 +4032,14 @@ class AutonomousOrchestrator:
                 return
 
         # Tests passed — clear retry counters
-        self._update_workflow({"test_retries": 0, "dev_retries_on_test_fail": 0, "skip_retries": 0})
+        self._update_workflow(
+            {
+                "test_retries": 0,
+                "dev_retries_on_test_fail": 0,
+                "skip_retries": 0,
+                "ci_repair_context": "",
+            }
+        )
 
         # Dev completed milestone
         self._create_milestone(
@@ -4741,13 +4894,19 @@ class AutonomousOrchestrator:
         branch_name = wf.get("branch_name", "")
 
         if pr_number:
+            try:
+                checks = gh.get_pr_checks(pr_number)
+            except Exception as e:
+                raise GitHubOpsError(
+                    f"Unable to query CI checks before merging PR #{pr_number}: {e}"
+                ) from e
+            failed = [c for c in checks if c.get("bucket") == "fail"]
+            if failed:
+                self._start_ci_repair_round(wf, pr_number, failed)
+                return
             # If CI is still running, defer this merge to the next scheduler
             # cycle instead of blocking (synchronous poll) or failing. The
             # scheduler re-enters _do_merge every ~10s.
-            try:
-                checks = gh.get_pr_checks(pr_number)
-            except Exception:
-                checks = []
             pending = [c for c in checks if c.get("bucket") == "pending"]
             if pending:
                 logger.info(
@@ -4773,10 +4932,8 @@ class AutonomousOrchestrator:
                     # if so, this is a real failure, not a transient deferral.
                     failed = [c for c in checks if c.get("bucket") == "fail"]
                     if failed:
-                        failed_names = ", ".join(c.get("name", "?") for c in failed)
-                        raise GitHubOpsError(
-                            f"PR #{pr_number} CI failed ({failed_names}), cannot merge"
-                        )
+                        self._start_ci_repair_round(wf, pr_number, failed)
+                        return
                     # No failures, just policy lag — defer to next cycle.
                     logger.info(
                         "PR #%s: policy prohibits (CI not failed), deferring merge", pr_number
@@ -4994,7 +5151,7 @@ class AutonomousOrchestrator:
             # at the top and defers until checks are green).
             # P1 修复（Issue #1611）：Conflict 解决后检查分支一致性
             current_branch = wt_gh.get_current_branch()
-            if current_branch != branch_name:
+            if isinstance(current_branch, str) and current_branch and current_branch != branch_name:
                 logger.warning(
                     "Conflict resolution branch mismatch: expected=%s, actual=%s",
                     branch_name,

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -2207,6 +2207,13 @@ class AutonomousOrchestrator:
         - Jump to the next phase after the fork milestone's phase
         """
         project_path = wf.get("project_path", "")
+        system_account = None
+        user_id = wf.get("user_id")
+        if user_id:
+            user_repo = UserRepository()
+            user = user_repo.get_user_by_id(user_id)
+            if user:
+                system_account = user.get("system_account")
 
         # --- Fork workflow fast path ---
         if self._is_fork_workflow(wf):
@@ -2304,14 +2311,6 @@ class AutonomousOrchestrator:
         # New project: create GitHub repo
         if wf.get("is_new_project"):
             try:
-                # Get system_account for multi-user permission isolation (Issue #1395)
-                system_account = None
-                user_id = wf.get("user_id")
-                if user_id:
-                    user_repo = UserRepository()
-                    user = user_repo.get_user_by_id(user_id)
-                    if user:
-                        system_account = user.get("system_account")
                 gh = GitHubOps(project_path or ".", system_account=system_account)
                 repo_data = gh.create_repo(
                     name=wf.get("project_repo_url", f"auto-project-{uuid.uuid4().hex[:8]}"),
@@ -2461,7 +2460,9 @@ class AutonomousOrchestrator:
                     # Use pre-generated worktree_path if available (Issue #1573)
                     # Format: {project_path}/.worktrees/{workflow_id}
                     # Fallback to legacy format for backwards compatibility
-                    pre_generated_worktree_path = wf.get("worktree_path", "")
+                    pre_generated_worktree_path = wf.get("worktree_path", "") or wf.get(
+                        "preferred_worktree_path", ""
+                    )
                     if pre_generated_worktree_path and pre_generated_worktree_path.startswith(
                         project_path
                     ):

--- a/app/repositories/autonomous_repo.py
+++ b/app/repositories/autonomous_repo.py
@@ -208,7 +208,7 @@ class AutonomousWorkflowRepository:
                      requirements_issue_url, project_path, project_repo_url,
                      is_new_project, is_private, cli_tool, model, permission_mode,
                      branch_name, branch_strategy, workspace_type,
-                     remote_machine_id, preferred_worktree_path, github_issue_number, batch_id,
+                     remote_machine_id, worktree_path, preferred_worktree_path, github_issue_number, batch_id,
                      batch_order, batch_total, auto_merge, definition_snapshot,
                      current_phase, dev_round,
                      max_plan_rounds, max_pr_review_rounds, require_full_review_rounds,
@@ -216,7 +216,7 @@ class AutonomousWorkflowRepository:
                      original_branch_name, content_language, system_account,
                      ci_repair_context, ci_repair_attempts, last_ci_failure_signature,
                      created_at, updated_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 RETURNING *
                 """,
                 (
@@ -237,6 +237,7 @@ class AutonomousWorkflowRepository:
                     data.get("branch_strategy", "new-branch"),
                     data.get("workspace_type", "local"),
                     data.get("remote_machine_id", ""),
+                    data.get("worktree_path", ""),
                     data.get("preferred_worktree_path", ""),
                     data.get("github_issue_number"),
                     data.get("batch_id"),
@@ -272,7 +273,7 @@ class AutonomousWorkflowRepository:
                      requirements_issue_url, project_path, project_repo_url,
                      is_new_project, is_private, cli_tool, model, permission_mode,
                      branch_name, branch_strategy, workspace_type,
-                     remote_machine_id, preferred_worktree_path, github_issue_number, batch_id,
+                     remote_machine_id, worktree_path, preferred_worktree_path, github_issue_number, batch_id,
                      batch_order, batch_total, auto_merge, definition_snapshot,
                      current_phase, dev_round,
                      max_plan_rounds, max_pr_review_rounds, require_full_review_rounds,
@@ -280,7 +281,7 @@ class AutonomousWorkflowRepository:
                      original_branch_name, content_language, system_account,
                      ci_repair_context, ci_repair_attempts, last_ci_failure_signature,
                      created_at, updated_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     workflow_id,
@@ -300,6 +301,7 @@ class AutonomousWorkflowRepository:
                     data.get("branch_strategy", "new-branch"),
                     data.get("workspace_type", "local"),
                     data.get("remote_machine_id", ""),
+                    data.get("worktree_path", ""),
                     data.get("preferred_worktree_path", ""),
                     data.get("github_issue_number"),
                     data.get("batch_id"),

--- a/app/repositories/autonomous_repo.py
+++ b/app/repositories/autonomous_repo.py
@@ -42,6 +42,7 @@ class AutonomousWorkflowRepository:
         "workspace_type",
         "remote_machine_id",
         "worktree_path",
+        "preferred_worktree_path",
         "github_issue_number",
         "github_pr_number",
         "github_pr_url",
@@ -85,6 +86,9 @@ class AutonomousWorkflowRepository:
         "skip_retries",
         "dev_retries_on_test_fail",
         "system_account",
+        "ci_repair_context",
+        "ci_repair_attempts",
+        "last_ci_failure_signature",
     }
     ALLOWED_MILESTONE_FIELDS = {
         "phase",
@@ -204,14 +208,15 @@ class AutonomousWorkflowRepository:
                      requirements_issue_url, project_path, project_repo_url,
                      is_new_project, is_private, cli_tool, model, permission_mode,
                      branch_name, branch_strategy, workspace_type,
-                     remote_machine_id, github_issue_number, batch_id,
+                     remote_machine_id, preferred_worktree_path, github_issue_number, batch_id,
                      batch_order, batch_total, auto_merge, definition_snapshot,
                      current_phase, dev_round,
                      max_plan_rounds, max_pr_review_rounds, require_full_review_rounds,
                      parent_workflow_id, fork_milestone_id, user_feedback,
                      original_branch_name, content_language, system_account,
+                     ci_repair_context, ci_repair_attempts, last_ci_failure_signature,
                      created_at, updated_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 RETURNING *
                 """,
                 (
@@ -232,6 +237,7 @@ class AutonomousWorkflowRepository:
                     data.get("branch_strategy", "new-branch"),
                     data.get("workspace_type", "local"),
                     data.get("remote_machine_id", ""),
+                    data.get("preferred_worktree_path", ""),
                     data.get("github_issue_number"),
                     data.get("batch_id"),
                     data.get("batch_order"),
@@ -249,6 +255,9 @@ class AutonomousWorkflowRepository:
                     data.get("original_branch_name", ""),
                     data.get("content_language", "en"),
                     data.get("system_account", ""),
+                    data.get("ci_repair_context", ""),
+                    data.get("ci_repair_attempts", 0),
+                    data.get("last_ci_failure_signature", ""),
                     now,
                     now,
                 ),
@@ -263,14 +272,15 @@ class AutonomousWorkflowRepository:
                      requirements_issue_url, project_path, project_repo_url,
                      is_new_project, is_private, cli_tool, model, permission_mode,
                      branch_name, branch_strategy, workspace_type,
-                     remote_machine_id, github_issue_number, batch_id,
+                     remote_machine_id, preferred_worktree_path, github_issue_number, batch_id,
                      batch_order, batch_total, auto_merge, definition_snapshot,
                      current_phase, dev_round,
                      max_plan_rounds, max_pr_review_rounds, require_full_review_rounds,
                      parent_workflow_id, fork_milestone_id, user_feedback,
                      original_branch_name, content_language, system_account,
+                     ci_repair_context, ci_repair_attempts, last_ci_failure_signature,
                      created_at, updated_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     workflow_id,
@@ -290,6 +300,7 @@ class AutonomousWorkflowRepository:
                     data.get("branch_strategy", "new-branch"),
                     data.get("workspace_type", "local"),
                     data.get("remote_machine_id", ""),
+                    data.get("preferred_worktree_path", ""),
                     data.get("github_issue_number"),
                     data.get("batch_id"),
                     data.get("batch_order"),
@@ -307,6 +318,9 @@ class AutonomousWorkflowRepository:
                     data.get("original_branch_name", ""),
                     data.get("content_language", "en"),
                     data.get("system_account", ""),
+                    data.get("ci_repair_context", ""),
+                    data.get("ci_repair_attempts", 0),
+                    data.get("last_ci_failure_signature", ""),
                     now,
                     now,
                 ),

--- a/app/routes/autonomous.py
+++ b/app/routes/autonomous.py
@@ -745,6 +745,7 @@ def create_workflow():
                         # Pre-generated values for scheduler conflict checks (Issue #1573)
                         "branch_name": branch_name,
                         "worktree_path": worktree_path,
+                        "preferred_worktree_path": worktree_path,
                         "branch_strategy": "worktree",  # Force worktree for batch workflows
                         "original_branch_name": user_branch_name,  # Preserve user's original input
                     }
@@ -794,6 +795,7 @@ def create_workflow():
             )
             base_workflow_data["branch_name"] = branch_name
             base_workflow_data["worktree_path"] = worktree_path
+            base_workflow_data["preferred_worktree_path"] = worktree_path
             base_workflow_data["original_branch_name"] = user_branch_name  # Preserve user's input
             logger.info(
                 "Pre-generated branch_name=%s, worktree_path=%s for workflow %s",

--- a/migrations/baseline.py
+++ b/migrations/baseline.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from sqlalchemy.engine import Connection
 
 BASELINE_REVISION = "baseline_2026_06_23"
-HEAD_REVISION = "20260630_001_add_retry_count_column"
+HEAD_REVISION = "20260714_001_add_ci_repair_fields_to_workflows"
 
 _PROJECT_ROOT = Path(__file__).resolve().parents[1]
 _BASELINE_SCHEMA_DIR = _PROJECT_ROOT / "schema" / "baselines"

--- a/migrations/versions/20260714_001_add_ci_repair_fields_to_workflows.py
+++ b/migrations/versions/20260714_001_add_ci_repair_fields_to_workflows.py
@@ -1,0 +1,78 @@
+"""Add CI repair and preferred worktree fields to autonomous_workflows
+
+Revision ID: 20260714_001_add_ci_repair_fields_to_workflows
+Revises: 20260709_003_add_tenant_usage_aggregation
+Create Date: 2026-07-14
+
+Issue: #1647
+The merge phase needs durable state for:
+- preferred_worktree_path: recreate worktree-based workflows after merge cleanup
+- ci_repair_context: carry failed CI details back into a development round
+- ci_repair_attempts: cap automatic CI repair loops
+- last_ci_failure_signature: stop repeating the same failed-check loop forever
+"""
+
+import logging
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+
+log = logging.getLogger(__name__)
+
+revision: str = "20260714_001_add_ci_repair_fields_to_workflows"
+down_revision: Union[str, None] = "20260709_003_add_tenant_usage_aggregation"
+branch_labels: Union[str, None] = None
+depends_on: Union[str, None] = None
+
+
+def upgrade() -> None:
+    """Add CI repair state columns to autonomous_workflows."""
+    connection = op.get_bind()
+    inspector = sa.inspect(connection)
+    existing_columns = {col["name"] for col in inspector.get_columns("autonomous_workflows")}
+
+    if "preferred_worktree_path" not in existing_columns:
+        op.add_column(
+            "autonomous_workflows",
+            sa.Column("preferred_worktree_path", sa.Text(), nullable=True, server_default=""),
+        )
+    if "ci_repair_context" not in existing_columns:
+        op.add_column(
+            "autonomous_workflows",
+            sa.Column("ci_repair_context", sa.Text(), nullable=True, server_default=""),
+        )
+    if "ci_repair_attempts" not in existing_columns:
+        op.add_column(
+            "autonomous_workflows",
+            sa.Column("ci_repair_attempts", sa.Integer(), nullable=True, server_default="0"),
+        )
+    if "last_ci_failure_signature" not in existing_columns:
+        op.add_column(
+            "autonomous_workflows",
+            sa.Column("last_ci_failure_signature", sa.Text(), nullable=True, server_default=""),
+        )
+
+    op.execute(
+        """
+        UPDATE autonomous_workflows
+        SET preferred_worktree_path = CASE
+            WHEN worktree_path IS NOT NULL AND worktree_path != '' THEN worktree_path
+            WHEN branch_strategy = 'worktree'
+                 AND project_path IS NOT NULL AND project_path != ''
+                 AND workflow_id IS NOT NULL AND workflow_id != ''
+            THEN project_path || '/.worktrees/' || workflow_id
+            ELSE COALESCE(preferred_worktree_path, '')
+        END
+        WHERE preferred_worktree_path IS NULL OR preferred_worktree_path = ''
+        """
+    )
+
+
+def downgrade() -> None:
+    """Remove CI repair state columns from autonomous_workflows."""
+    with op.batch_alter_table("autonomous_workflows") as batch_op:
+        batch_op.drop_column("last_ci_failure_signature")
+        batch_op.drop_column("ci_repair_attempts")
+        batch_op.drop_column("ci_repair_context")
+        batch_op.drop_column("preferred_worktree_path")

--- a/schema/schema-postgres.sql
+++ b/schema/schema-postgres.sql
@@ -441,7 +441,11 @@ CREATE TABLE autonomous_workflows (
     skip_retries integer DEFAULT 0,
     dev_retries_on_test_fail integer DEFAULT 0,
     system_account text DEFAULT ''::text,
-    base_commit_sha character varying(40)
+    base_commit_sha character varying(40),
+    preferred_worktree_path text DEFAULT ''::text,
+    ci_repair_context text DEFAULT ''::text,
+    ci_repair_attempts integer DEFAULT 0,
+    last_ci_failure_signature text DEFAULT ''::text
 );
 
 CREATE SEQUENCE autonomous_workflows_id_seq
@@ -1070,22 +1074,22 @@ CREATE SEQUENCE session_messages_id_seq
 
 ALTER SEQUENCE session_messages_id_seq OWNED BY session_messages.id;
 CREATE MATERIALIZED VIEW session_stats AS
- SELECT daily_messages.agent_session_id AS session_id,
-    daily_messages.tool_name,
-    daily_messages.host_name,
-    daily_messages.sender_name,
-    max((daily_messages.sender_id)::text) AS sender_id,
-    max((daily_messages.date)::text) AS date,
+ SELECT agent_session_id AS session_id,
+    tool_name,
+    host_name,
+    sender_name,
+    max((sender_id)::text) AS sender_id,
+    max((date)::text) AS date,
     count(*) AS message_count,
-    sum(daily_messages.tokens_used) AS total_tokens,
-    sum(daily_messages.input_tokens) AS total_input_tokens,
-    sum(daily_messages.output_tokens) AS total_output_tokens,
-    min(daily_messages."timestamp") AS created_at,
-    max(daily_messages."timestamp") AS updated_at,
-    max(daily_messages.project_path) AS project_path
+    sum(tokens_used) AS total_tokens,
+    sum(input_tokens) AS total_input_tokens,
+    sum(output_tokens) AS total_output_tokens,
+    min("timestamp") AS created_at,
+    max("timestamp") AS updated_at,
+    max(project_path) AS project_path
    FROM daily_messages
-  WHERE (daily_messages.agent_session_id IS NOT NULL)
-  GROUP BY daily_messages.agent_session_id, daily_messages.tool_name, daily_messages.host_name, daily_messages.sender_name
+  WHERE (agent_session_id IS NOT NULL)
+  GROUP BY agent_session_id, tool_name, host_name, sender_name
   WITH NO DATA;
 
 CREATE TABLE sessions (

--- a/schema/schema-sqlite.sql
+++ b/schema/schema-sqlite.sql
@@ -290,7 +290,11 @@ CREATE TABLE autonomous_workflows (
  skip_retries integer DEFAULT 0,
  dev_retries_on_test_fail integer DEFAULT 0,
  system_account text DEFAULT '',
- base_commit_sha TEXT
+ base_commit_sha TEXT,
+ preferred_worktree_path text DEFAULT '',
+ ci_repair_context text DEFAULT '',
+ ci_repair_attempts integer DEFAULT 0,
+ last_ci_failure_signature text DEFAULT ''
 );
 
 CREATE TABLE compliance_reports (

--- a/scripts/shared/schema_sync.py
+++ b/scripts/shared/schema_sync.py
@@ -234,8 +234,34 @@ def _normalize_sqlite_type(type_name: str | None) -> str:
     return "NUMERIC"
 
 
+def _normalize_postgres_session_stats_qualification(sql: str) -> str:
+    """Normalize PG15/PG16 qualification noise in the session_stats view.
+
+    PostgreSQL 15's pg_dump may emit fully-qualified ``daily_messages.*``
+    references inside the ``session_stats`` materialized view, while newer
+    versions collapse the same expressions to unqualified column names. The
+    view semantics are identical, so snapshot generation and comparison should
+    canonicalize both forms to the same text.
+    """
+    if "CREATE MATERIALIZED VIEW session_stats AS" not in sql:
+        return sql
+
+    pattern = re.compile(
+        r"(CREATE MATERIALIZED VIEW session_stats AS\s+)(.*?)(\s+WITH NO DATA;)",
+        re.DOTALL,
+    )
+
+    def _rewrite(match: re.Match[str]) -> str:
+        body = match.group(2)
+        normalized_body = re.sub(r"\bdaily_messages\.", "", body)
+        return f"{match.group(1)}{normalized_body}{match.group(3)}"
+
+    return pattern.sub(_rewrite, sql)
+
+
 def normalize_sql_text(sql: str) -> str:
     """Normalize SQL text for stable textual diffs."""
+    sql = _normalize_postgres_session_stats_qualification(sql)
     lines = [line.rstrip() for line in sql.replace("\r\n", "\n").splitlines()]
     return "\n".join(lines).strip() + "\n"
 

--- a/tests/issues/716/test_autonomous_repo.py
+++ b/tests/issues/716/test_autonomous_repo.py
@@ -811,6 +811,10 @@ class TestAllowedFieldsFiltering:
         assert "error_message" in repo.ALLOWED_WORKFLOW_FIELDS
         assert "current_phase" in repo.ALLOWED_WORKFLOW_FIELDS
         assert "branch_name" in repo.ALLOWED_WORKFLOW_FIELDS
+        assert "preferred_worktree_path" in repo.ALLOWED_WORKFLOW_FIELDS
+        assert "ci_repair_context" in repo.ALLOWED_WORKFLOW_FIELDS
+        assert "ci_repair_attempts" in repo.ALLOWED_WORKFLOW_FIELDS
+        assert "last_ci_failure_signature" in repo.ALLOWED_WORKFLOW_FIELDS
         # These should NOT be in the whitelist
         assert "user_id" not in repo.ALLOWED_WORKFLOW_FIELDS
         assert "workflow_id" not in repo.ALLOWED_WORKFLOW_FIELDS
@@ -908,6 +912,29 @@ class TestContentLanguagePersistence:
         repo = AutonomousWorkflowRepository(auto_db)
         created = repo.create_workflow(self._data(content_language=None))
         assert created["content_language"] == "en"
+
+
+class TestCIRoundTripPersistence:
+    def test_ci_repair_fields_round_trip(self, auto_db):
+        repo = AutonomousWorkflowRepository(auto_db)
+        created = repo.create_workflow(
+            {
+                "user_id": 1,
+                "title": "CI repair",
+                "requirements_text": "Fix CI",
+                "cli_tool": "claude-code",
+                "project_path": "/tmp/test-project",
+                "preferred_worktree_path": "/tmp/test-project/.worktrees/wf-1",
+                "ci_repair_context": "lint failed",
+                "ci_repair_attempts": 1,
+                "last_ci_failure_signature": "lint|failure|fail",
+            }
+        )
+
+        assert created["preferred_worktree_path"] == "/tmp/test-project/.worktrees/wf-1"
+        assert created["ci_repair_context"] == "lint failed"
+        assert created["ci_repair_attempts"] == 1
+        assert created["last_ci_failure_signature"] == "lint|failure|fail"
 
 
 # Required import for TestAllowedFieldsFiltering

--- a/tests/issues/716/test_autonomous_repo.py
+++ b/tests/issues/716/test_autonomous_repo.py
@@ -936,6 +936,24 @@ class TestCIRoundTripPersistence:
         assert created["ci_repair_attempts"] == 1
         assert created["last_ci_failure_signature"] == "lint|failure|fail"
 
+    def test_worktree_and_preferred_paths_round_trip_together(self, auto_db):
+        repo = AutonomousWorkflowRepository(auto_db)
+        created = repo.create_workflow(
+            {
+                "user_id": 1,
+                "title": "Worktree round trip",
+                "requirements_text": "Fix CI",
+                "cli_tool": "claude-code",
+                "project_path": "/repo",
+                "branch_strategy": "worktree",
+                "worktree_path": "/repo/.worktrees/wf",
+                "preferred_worktree_path": "/repo/.worktrees/wf",
+            }
+        )
+
+        assert created["worktree_path"] == "/repo/.worktrees/wf"
+        assert created["preferred_worktree_path"] == "/repo/.worktrees/wf"
+
 
 # Required import for TestAllowedFieldsFiltering
 from unittest.mock import MagicMock

--- a/tests/issues/716/test_orchestrator.py
+++ b/tests/issues/716/test_orchestrator.py
@@ -28,6 +28,7 @@ def _make_workflow(**overrides):
         "workspace_type": "local",
         "remote_machine_id": "",
         "worktree_path": "",
+        "preferred_worktree_path": "",
         "github_issue_number": None,
         "github_pr_number": None,
         "github_pr_url": "",
@@ -342,6 +343,7 @@ class TestOrchestratorPreparation:
             "worktree_path": "/tmp/wt-path",
             "branch": "auto-dev/test-wf",
         }
+        mock_gh.get_current_branch.return_value = "auto-dev/test-wf-"
         mock_gh_cls.return_value = mock_gh
 
         orch._do_preparation(wf)
@@ -351,6 +353,35 @@ class TestOrchestratorPreparation:
         update_calls = mock_repo.update_workflow.call_args_list
         wt_updates = [c for c in update_calls if c[0][1].get("worktree_path")]
         assert len(wt_updates) > 0
+
+    @patch("app.modules.workspace.autonomous.orchestrator.GitHubOps")
+    def test_preparation_worktree_uses_preferred_path_when_live_path_empty(self, mock_gh_cls):
+        wf = _make_workflow(
+            current_phase="preparation",
+            branch_strategy="worktree",
+            branch_name="auto-dev/test-wf",
+            worktree_path="",
+            project_path="/tmp/project",
+            preferred_worktree_path="/tmp/project/.worktrees/test-wf",
+        )
+        orch, _ = self._make_orchestrator(wf)
+
+        mock_gh = MagicMock()
+        mock_gh.create_issue.return_value = {"number": 1, "url": ""}
+        mock_gh.create_worktree.return_value = {
+            "worktree_path": "/tmp/project/.worktrees/test-wf",
+            "branch": "auto-dev/test-wf",
+        }
+        mock_gh.get_current_branch.return_value = "auto-dev/test-wf"
+        mock_gh_cls.return_value = mock_gh
+
+        orch._do_preparation(wf)
+
+        mock_gh.create_worktree.assert_called_once_with(
+            path="/tmp/project/.worktrees/test-wf",
+            branch="auto-dev/test-wf",
+            base="origin/main",
+        )
 
     @patch("app.modules.workspace.autonomous.orchestrator.GitHubOps")
     def test_preparation_current_branch_strategy(self, mock_gh_cls):

--- a/tests/issues/822/test_merge_conflict_detection.py
+++ b/tests/issues/822/test_merge_conflict_detection.py
@@ -28,6 +28,7 @@ def _make_workflow(**overrides):
         "branch_strategy": "worktree",
         "branch_name": "auto-dev/fc82f22a",
         "worktree_path": "",
+        "preferred_worktree_path": "/srv/repo/.worktrees/wf-822",
         "project_path": "/srv/repo",
         "workspace_type": "local",
         "current_phase": "merge",
@@ -202,20 +203,20 @@ class TestDoMergeDeferredRetry:
 
     @patch("app.modules.workspace.autonomous.orchestrator.GitHubOps")
     def test_policy_rejection_with_ci_fail_raises(self, mock_gh_cls):
-        """Policy rejection WITH CI failures is a hard error, not a deferral."""
-        import pytest
-
+        """Failed CI at merge time should restart development instead of failing."""
         o, _ = _make_orchestrator(_make_workflow())
         mock_gh = MagicMock()
         mock_gh_cls.return_value = mock_gh
         o._gh = mock_gh
+        o._start_ci_repair_round = MagicMock()
         mock_gh.get_pr_checks.return_value = [
             {"name": "test (3.9)", "bucket": "fail"},
         ]
-        mock_gh.merge_pr.side_effect = GitHubOpsError("base branch policy prohibits the merge")
 
-        with pytest.raises(GitHubOpsError, match="CI failed"):
-            o._do_merge(_make_workflow())
+        o._do_merge(_make_workflow())
+
+        mock_gh.merge_pr.assert_not_called()
+        o._start_ci_repair_round.assert_called_once()
 
     @patch("app.modules.workspace.autonomous.orchestrator.GitHubOps")
     def test_clean_conflict_goes_straight_to_resolve(self, mock_gh_cls):
@@ -288,6 +289,43 @@ class TestDoMergeDeferredRetry:
 
         # Merge succeeded → cleanup ran → branch deleted.
         mock_gh.delete_branch.assert_called_once_with("auto-dev/fc82f22a")
+
+    def test_start_ci_repair_round_restores_preferred_worktree(self):
+        """CI repair loop should restore the preferred worktree path for worktree strategy."""
+        wf = _make_workflow(worktree_path="", preferred_worktree_path="/srv/repo/.worktrees/wf-822")
+        o, _ = _make_orchestrator(wf)
+
+        o._start_ci_repair_round(
+            wf,
+            1103,
+            [{"name": "test (3.9)", "bucket": "fail", "state": "failure"}],
+        )
+
+        update_payload = o._update_workflow.call_args.args[0]
+        assert update_payload["current_phase"] == "development"
+        assert update_payload["status"] == "developing"
+        assert update_payload["dev_round"] == 2
+        assert update_payload["ci_repair_attempts"] == 1
+        assert update_payload["worktree_path"] == "/srv/repo/.worktrees/wf-822"
+        assert update_payload["preferred_worktree_path"] == "/srv/repo/.worktrees/wf-822"
+
+    def test_start_ci_repair_round_fails_when_signature_repeats(self):
+        """A repeated failed-check signature should stop the auto-repair loop."""
+        wf = _make_workflow(
+            ci_repair_attempts=1,
+            last_ci_failure_signature="test (3.9)|failure|fail",
+        )
+        o, _ = _make_orchestrator(wf)
+
+        o._start_ci_repair_round(
+            wf,
+            1103,
+            [{"name": "test (3.9)", "bucket": "fail", "state": "failure"}],
+        )
+
+        failure_update = o._update_workflow.call_args.args[0]
+        assert failure_update["status"] == "failed"
+        assert "仍未变化" in failure_update["error_message"]
 
 
 # ── github_ops.merge_pr --auto flag ──────────────────────────────────────

--- a/tests/issues/913/test_pr909_review_feedback.py
+++ b/tests/issues/913/test_pr909_review_feedback.py
@@ -17,7 +17,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from app.modules.workspace.autonomous.github_ops import GitHubOps
+from app.modules.workspace.autonomous.github_ops import GitHubOps, GitHubOpsError
 from app.modules.workspace.autonomous.orchestrator import (
     CI_POLL_INTERVAL,
     CI_POLL_MAX_WAIT,
@@ -51,13 +51,53 @@ class TestGetPRChecks:
         result = gh.get_pr_checks(42)
         assert result == []
 
-    def test_returns_empty_on_invalid_json(self):
-        gh = self._make_gh("not json at all")
+    def test_falls_back_to_api_when_pr_checks_json_unsupported(self):
+        gh = GitHubOps("/tmp/fake")
+        gh.get_repo_name = MagicMock(return_value="open-ace/open-ace")
+        gh._gh_api_args = MagicMock(side_effect=lambda extra: extra)
+        gh._run_gh = MagicMock(
+            side_effect=[
+                MagicMock(returncode=1, stdout="", stderr="unknown flag: --json"),
+                MagicMock(returncode=0, stdout='{"head": {"sha": "abc123"}}', stderr=""),
+                MagicMock(
+                    returncode=0,
+                    stdout=(
+                        '{"statuses": [{"context": "lint", "state": "success", '
+                        '"target_url": "https://example.com/lint"}]}'
+                    ),
+                    stderr="",
+                ),
+                MagicMock(
+                    returncode=0,
+                    stdout=(
+                        '{"check_runs": [{"name": "test", "status": "completed", '
+                        '"conclusion": "failure", "html_url": "https://example.com/test"}]}'
+                    ),
+                    stderr="",
+                ),
+            ]
+        )
+
         result = gh.get_pr_checks(42)
-        assert result == []
+
+        assert result == [
+            {
+                "name": "lint",
+                "state": "success",
+                "bucket": "pass",
+                "link": "https://example.com/lint",
+            },
+            {
+                "name": "test",
+                "state": "failure",
+                "bucket": "fail",
+                "link": "https://example.com/test",
+            },
+        ]
 
     def test_logs_warning_on_parse_failure(self, caplog):
         gh = self._make_gh("bad json")
+        gh._get_pr_checks_via_api = MagicMock(return_value=[])
         with caplog.at_level(logging.WARNING):
             gh.get_pr_checks(42)
         assert "Failed to parse CI checks" in caplog.text
@@ -67,6 +107,13 @@ class TestGetPRChecks:
         gh = self._make_gh(None)
         result = gh.get_pr_checks(42)
         assert result == []
+
+    def test_raises_when_primary_and_fallback_both_fail(self):
+        gh = self._make_gh("", returncode=1)
+        gh._get_pr_checks_via_api = MagicMock(side_effect=GitHubOpsError("api failed"))
+
+        with pytest.raises(GitHubOpsError, match="Failed to query CI checks for PR #42"):
+            gh.get_pr_checks(42)
 
 
 # ── Test _poll_ci_status ────────────────────────────────────────────────
@@ -138,6 +185,18 @@ class TestPollCIStatus:
         assert result == pending_checks
         assert gh.get_pr_checks.call_count == 1  # only one call before timeout
         assert mock_time.sleep.call_count == 0  # never slept — timed out immediately
+
+    @patch("app.modules.workspace.autonomous.orchestrator.time")
+    def test_raises_after_repeated_query_failures(self, mock_time):
+        """Repeated CI query failures must surface as an error, not empty checks."""
+        gh = MagicMock()
+        gh.get_pr_checks.side_effect = GitHubOpsError("bad credentials")
+        mock_time.monotonic.side_effect = [0, CI_POLL_MAX_WAIT + 1]
+        mock_time.sleep = MagicMock()
+
+        orchestrator = MagicMock(spec=AutonomousOrchestrator)
+        with pytest.raises(GitHubOpsError, match="Failed to query CI checks for PR #42"):
+            AutonomousOrchestrator._poll_ci_status(orchestrator, gh, 42)
 
 
 # ── Test _is_pre_existing_ci_failure ──────────────────────────────────────

--- a/tests/unit/test_alembic_sqlite_upgrade.py
+++ b/tests/unit/test_alembic_sqlite_upgrade.py
@@ -117,7 +117,8 @@ def test_alembic_upgrade_head_succeeds_for_fresh_sqlite(tmp_path, monkeypatch):
     # -> 20260709_001_add_readonly_role_to_check_constraint (Issue #1497)
     # -> 20260709_001_add_base_commit_sha (Issue #1552)
     # -> 20260709_003_add_tenant_usage_aggregation (Tenant usage aggregation infrastructure)
-    assert version[0] == "20260709_003_add_tenant_usage_aggregation"
+    # -> 20260714_001_add_ci_repair_fields_to_workflows (Issue #1647)
+    assert version[0] == "20260714_001_add_ci_repair_fields_to_workflows"
     if has_session_messages:
         assert "source" in columns
     assert has_mapping_rules is True
@@ -130,6 +131,10 @@ def test_alembic_upgrade_head_succeeds_for_fresh_sqlite(tmp_path, monkeypatch):
     assert "auto_mapping_enabled" in user_columns
     # content_language column added by 20260626_002 (#1287)
     assert "content_language" in aw_columns
+    assert "preferred_worktree_path" in aw_columns
+    assert "ci_repair_context" in aw_columns
+    assert "ci_repair_attempts" in aw_columns
+    assert "last_ci_failure_signature" in aw_columns
 
 
 def test_workflow_status_index_created_after_upgrade(tmp_path, monkeypatch):

--- a/tests/unit/test_schema_sync.py
+++ b/tests/unit/test_schema_sync.py
@@ -70,6 +70,34 @@ def test_compare_postgres_schema_text_normalizes_line_endings():
     assert diff == []
 
 
+def test_compare_postgres_schema_text_ignores_session_stats_qualification_noise():
+    """PG15/PG16 pg_dump differences in session_stats should not cause drift."""
+    expected = """
+    CREATE MATERIALIZED VIEW session_stats AS
+     SELECT agent_session_id AS session_id,
+        tool_name,
+        sum(tokens_used) AS total_tokens
+       FROM daily_messages
+      WHERE (agent_session_id IS NOT NULL)
+      GROUP BY agent_session_id, tool_name
+      WITH NO DATA;
+    """
+    actual = """
+    CREATE MATERIALIZED VIEW session_stats AS
+     SELECT daily_messages.agent_session_id AS session_id,
+        daily_messages.tool_name,
+        sum(daily_messages.tokens_used) AS total_tokens
+       FROM daily_messages
+      WHERE (daily_messages.agent_session_id IS NOT NULL)
+      GROUP BY daily_messages.agent_session_id, daily_messages.tool_name
+      WITH NO DATA;
+    """
+
+    diff = schema_sync.compare_postgres_schema_text(actual, expected)
+
+    assert diff == []
+
+
 def test_compare_sqlite_snapshots_ignores_pk_notnull_and_boolean_default_noise():
     """SQLite PK/nullability quirks and boolean literals should not cause drift."""
     actual = schema_sync.sqlite_snapshot_from_sql(


### PR DESCRIPTION
## Summary
- add a compatibility fallback for `gh pr checks --json` so older gh builds can still read PR CI via `gh api`
- route merge-phase CI failures back into a new development round instead of marking the workflow failed immediately
- persist preferred worktree and CI repair state with a new Alembic migration so worktree/new-branch/current strategies can all resume correctly

## Root cause
- the merge phase treated `gh.get_pr_checks()` parse/query failures as an empty list, so an unsupported `gh pr checks --json` call looked the same as "no CI checks"
- when CI actually failed at merge time, `_do_merge()` raised a hard error instead of reusing the 3-session workflow to repair and retest the branch
- worktree workflows lost their resumable worktree path after merge-conflict cleanup removed the live worktree directory

## What changed
- `GitHubOps.get_pr_checks()` now falls back to REST API queries for PR head SHA, commit statuses, and check runs
- CI check query failures now surface as real errors instead of silently becoming `[]`
- merge now classifies failed checks before attempting merge and starts a new development round with CI failure context
- added `preferred_worktree_path`, `ci_repair_context`, `ci_repair_attempts`, and `last_ci_failure_signature`
- added Alembic migration `20260714_001_add_ci_repair_fields_to_workflows`
- expanded tests for gh fallback, merge reflow, repository persistence, and SQLite upgrade coverage

## Verification
- `python3 -m py_compile app/modules/workspace/autonomous/github_ops.py app/modules/workspace/autonomous/orchestrator.py app/modules/workspace/autonomous/__init__.py app/modules/workspace/autonomous/models.py app/repositories/autonomous_repo.py app/routes/autonomous.py migrations/versions/20260714_001_add_ci_repair_fields_to_workflows.py migrations/baseline.py`
- `pytest -q tests/issues/913/test_pr909_review_feedback.py tests/issues/716/test_autonomous_repo.py tests/unit/test_alembic_sqlite_upgrade.py`
- `pytest -q tests/issues/822/test_merge_conflict_detection.py tests/issues/716/test_orchestrator.py -k "merge or development"`

## Notes
- `tests/unit/test_alembic_baseline_cutover.py` still has three local PostgreSQL startup failures on this machine (`pg_ctl ... start` exits 1), so I did not use that suite as a merge gate for this change.
