### PR TITLE
fix(db): 补齐旧数据库缺失字段，解决 schema 初始化失败问题 (Issue #1663)

### DIFF
--- a/app/repositories/schema_init.py
+++ b/app/repositories/schema_init.py
@@ -206,10 +206,7 @@ def _column_exists(conn, table_name: str, column_name: str, dialect: str) -> boo
         return cursor.fetchone() is not None
     else:
         cursor = conn.execute(f"PRAGMA table_info({table_name})")
-        for row in cursor.fetchall():
-            if row[1] == column_name:
-                return True
-        return False
+        return any(row[1] == column_name for row in cursor.fetchall())
 
 
 def _table_exists(conn, table_name: str, dialect: str) -> bool:

--- a/app/repositories/schema_init.py
+++ b/app/repositories/schema_init.py
@@ -262,7 +262,11 @@ def _backfill_missing_columns(conn, dialect: str) -> None:
     if _table_exists(conn, "session_messages", dialect):
         session_messages_columns = [
             ("source", "TEXT", "''"),
-            ("source_timestamp", "TIMESTAMP" if not is_postgres else "timestamp without time zone", None),
+            (
+                "source_timestamp",
+                "TIMESTAMP" if not is_postgres else "timestamp without time zone",
+                None,
+            ),
             ("external_message_id", "TEXT", "''"),
             ("content_blocks", "TEXT", None),
             ("milestone_id", "INTEGER", None),

--- a/app/repositories/schema_init.py
+++ b/app/repositories/schema_init.py
@@ -118,6 +118,12 @@ def load_schema_from_file(db_url: str | None = None, dialect: str | None = None)
     db = Database(db_url=db_url)
     conn = db.get_connection()
     try:
+        # Backfill missing columns before executing schema.sql (Issue #1663).
+        # CREATE TABLE IF NOT EXISTS won't add missing columns to existing tables,
+        # but CREATE INDEX statements may reference them. This backfill ensures
+        # legacy databases have all required columns before the schema runs.
+        _backfill_missing_columns(conn, dialect)
+
         if db.is_postgresql:
             # autocommit so each statement is independent: a pre-existing
             # SEQUENCE/VIEW/CONSTRAINT (not covered by IF NOT EXISTS) raising
@@ -185,3 +191,92 @@ def ensure_all_tables() -> None:
     """
     load_schema_from_file()
     logger.info("Schema initialization complete (loaded from authoritative schema.sql)")
+
+
+def _column_exists(conn, table_name: str, column_name: str, dialect: str) -> bool:
+    """Check if a column exists in a table."""
+    if dialect == "postgresql":
+        cursor = conn.execute(
+            """
+            SELECT 1 FROM information_schema.columns
+            WHERE table_name = %s AND column_name = %s
+            """,
+            (table_name, column_name),
+        )
+        return cursor.fetchone() is not None
+    else:
+        cursor = conn.execute(f"PRAGMA table_info({table_name})")
+        for row in cursor.fetchall():
+            if row[1] == column_name:
+                return True
+        return False
+
+
+def _table_exists(conn, table_name: str, dialect: str) -> bool:
+    """Check if a table exists."""
+    if dialect == "postgresql":
+        cursor = conn.execute(
+            """
+            SELECT 1 FROM information_schema.tables
+            WHERE table_schema = 'public' AND table_name = %s
+            """,
+            (table_name,),
+        )
+        return cursor.fetchone() is not None
+    else:
+        cursor = conn.execute(
+            f"SELECT 1 FROM sqlite_master WHERE type='table' AND name='{table_name}'"
+        )
+        return cursor.fetchone() is not None
+
+
+def _backfill_missing_columns(conn, dialect: str) -> None:
+    """Backfill missing columns that were added after the initial schema.
+
+    This is needed because CREATE TABLE IF NOT EXISTS won't add missing columns
+    to existing tables, but CREATE INDEX statements in schema.sql reference them.
+
+    Issue #1663: Old SQLite databases missing these columns fail schema init.
+    """
+    is_postgres = dialect == "postgresql"
+
+    # agent_sessions columns
+    if _table_exists(conn, "agent_sessions", dialect):
+        agent_sessions_columns = [
+            ("project_id", "INTEGER", None),
+            ("project_path", "TEXT", None),
+            ("request_count", "INTEGER", "0"),
+            ("workspace_type", "TEXT", "'local'"),
+            ("remote_machine_id", "TEXT", None),
+            ("paused_at", "TIMESTAMP" if not is_postgres else "timestamp without time zone", None),
+        ]
+        for col_name, col_type, default in agent_sessions_columns:
+            if not _column_exists(conn, "agent_sessions", col_name, dialect):
+                sql = f"ALTER TABLE agent_sessions ADD COLUMN {col_name} {col_type}"
+                if default is not None:
+                    if is_postgres and col_type == "TEXT":
+                        sql += f" DEFAULT {default}::text"
+                    else:
+                        sql += f" DEFAULT {default}"
+                conn.execute(sql)
+        conn.commit()
+
+    # session_messages columns
+    if _table_exists(conn, "session_messages", dialect):
+        session_messages_columns = [
+            ("source", "TEXT", "''"),
+            ("source_timestamp", "TIMESTAMP" if not is_postgres else "timestamp without time zone", None),
+            ("external_message_id", "TEXT", "''"),
+            ("content_blocks", "TEXT", None),
+            ("milestone_id", "INTEGER", None),
+        ]
+        for col_name, col_type, default in session_messages_columns:
+            if not _column_exists(conn, "session_messages", col_name, dialect):
+                sql = f"ALTER TABLE session_messages ADD COLUMN {col_name} {col_type}"
+                if default is not None:
+                    if is_postgres and col_type == "TEXT":
+                        sql += f" DEFAULT {default}::text"
+                    else:
+                        sql += f" DEFAULT {default}"
+                conn.execute(sql)
+        conn.commit()

--- a/app/repositories/schema_init.py
+++ b/app/repositories/schema_init.py
@@ -269,7 +269,7 @@ def _backfill_missing_columns(conn, dialect: str) -> None:
             ),
             ("external_message_id", "TEXT", "''"),
             ("content_blocks", "TEXT", None),
-            ("milestone_id", "INTEGER", None),
+            ("milestone_id", "TEXT", "''"),
         ]
         for col_name, col_type, default in session_messages_columns:
             if not _column_exists(conn, "session_messages", col_name, dialect):

--- a/scripts/cutover_alembic_baseline.py
+++ b/scripts/cutover_alembic_baseline.py
@@ -203,6 +203,70 @@ def ensure_agent_sessions_cli_session_id(connection: sa.Connection) -> bool:
     return True
 
 
+def ensure_agent_sessions_project_columns(connection: sa.Connection) -> bool:
+    """Backfill agent_sessions project and workspace columns for legacy DBs.
+
+    These columns were added after the initial schema and are required by the
+    baseline snapshot. Missing them causes CREATE INDEX failures when
+    load_schema_from_file() tries to create indexes referencing these columns.
+
+    Issue #1663: Old SQLite databases missing these columns fail schema init.
+    """
+    if not table_exists(connection, "agent_sessions"):
+        return False
+
+    changed = False
+    is_postgres = connection.dialect.name == "postgresql"
+
+    # project_id - for project association
+    if not _column_exists(connection, "agent_sessions", "project_id"):
+        connection.exec_driver_sql("ALTER TABLE agent_sessions ADD COLUMN project_id INTEGER")
+        changed = True
+
+    # project_path - for quick reference
+    if not _column_exists(connection, "agent_sessions", "project_path"):
+        connection.exec_driver_sql("ALTER TABLE agent_sessions ADD COLUMN project_path TEXT")
+        changed = True
+
+    # request_count - number of API requests
+    if not _column_exists(connection, "agent_sessions", "request_count"):
+        connection.exec_driver_sql(
+            "ALTER TABLE agent_sessions ADD COLUMN request_count INTEGER DEFAULT 0"
+        )
+        changed = True
+
+    # workspace_type - local or remote
+    if not _column_exists(connection, "agent_sessions", "workspace_type"):
+        if is_postgres:
+            connection.exec_driver_sql(
+                "ALTER TABLE agent_sessions ADD COLUMN workspace_type TEXT DEFAULT 'local'::text"
+            )
+        else:
+            connection.exec_driver_sql(
+                "ALTER TABLE agent_sessions ADD COLUMN workspace_type TEXT DEFAULT 'local'"
+            )
+        changed = True
+
+    # remote_machine_id - for remote workspace sessions
+    if not _column_exists(connection, "agent_sessions", "remote_machine_id"):
+        connection.exec_driver_sql("ALTER TABLE agent_sessions ADD COLUMN remote_machine_id TEXT")
+        changed = True
+
+    # paused_at - session pause tracking
+    if not _column_exists(connection, "agent_sessions", "paused_at"):
+        if is_postgres:
+            connection.exec_driver_sql(
+                "ALTER TABLE agent_sessions ADD COLUMN paused_at timestamp without time zone"
+            )
+        else:
+            connection.exec_driver_sql(
+                "ALTER TABLE agent_sessions ADD COLUMN paused_at TIMESTAMP"
+            )
+        changed = True
+
+    return changed
+
+
 def ensure_session_messages_transcript_columns(connection: sa.Connection) -> bool:
     """Add #1125/#1128 transcript columns to session_messages for legacy DBs.
 
@@ -239,6 +303,11 @@ def ensure_session_messages_transcript_columns(connection: sa.Connection) -> boo
 
     if not _column_exists(connection, "session_messages", "content_blocks"):
         connection.exec_driver_sql("ALTER TABLE session_messages ADD COLUMN content_blocks TEXT")
+        changed = True
+
+    # milestone_id - for milestone tracking (Issue #1663)
+    if not _column_exists(connection, "session_messages", "milestone_id"):
+        connection.exec_driver_sql("ALTER TABLE session_messages ADD COLUMN milestone_id INTEGER")
         changed = True
 
     if is_postgres:
@@ -510,8 +579,28 @@ def cutover_database(connection: sa.Connection, *, dry_run: bool = False) -> tup
             actions.append("would backfill session_messages.source")
         if not _column_exists(connection, "agent_sessions", "cli_session_id"):
             actions.append("would backfill agent_sessions.cli_session_id")
+        # Check agent_sessions project/workspace columns (Issue #1663)
+        agent_sessions_columns = [
+            "project_id",
+            "project_path",
+            "request_count",
+            "workspace_type",
+            "remote_machine_id",
+            "paused_at",
+        ]
+        missing_agent_sessions_cols = [
+            col for col in agent_sessions_columns
+            if not _column_exists(connection, "agent_sessions", col)
+        ]
+        if missing_agent_sessions_cols:
+            actions.append(
+                f"would backfill agent_sessions columns: {', '.join(missing_agent_sessions_cols)}"
+            )
         if not _column_exists(connection, "session_messages", "external_message_id"):
             actions.append("would add session_messages transcript columns (#1125/#1128)")
+        # Check milestone_id column (Issue #1663)
+        if not _column_exists(connection, "session_messages", "milestone_id"):
+            actions.append("would backfill session_messages.milestone_id")
         if not _column_exists(connection, "users", "auto_mapping_enabled"):
             actions.append("would backfill users.auto_mapping_enabled")
         if not table_exists(connection, "tool_account_mapping_rules"):
@@ -538,6 +627,9 @@ def cutover_database(connection: sa.Connection, *, dry_run: bool = False) -> tup
         changed = True
     if ensure_agent_sessions_cli_session_id(connection):
         actions.append("backfilled agent_sessions.cli_session_id")
+        changed = True
+    if ensure_agent_sessions_project_columns(connection):
+        actions.append("backfilled agent_sessions project/workspace columns (#1663)")
         changed = True
     if ensure_session_messages_transcript_columns(connection):
         actions.append("added session_messages transcript columns (#1125/#1128)")

--- a/scripts/cutover_alembic_baseline.py
+++ b/scripts/cutover_alembic_baseline.py
@@ -305,7 +305,9 @@ def ensure_session_messages_transcript_columns(connection: sa.Connection) -> boo
 
     # milestone_id - for milestone tracking (Issue #1663)
     if not _column_exists(connection, "session_messages", "milestone_id"):
-        connection.exec_driver_sql("ALTER TABLE session_messages ADD COLUMN milestone_id INTEGER")
+        connection.exec_driver_sql(
+            "ALTER TABLE session_messages ADD COLUMN milestone_id TEXT DEFAULT ''"
+        )
         changed = True
 
     if is_postgres:

--- a/scripts/cutover_alembic_baseline.py
+++ b/scripts/cutover_alembic_baseline.py
@@ -259,9 +259,7 @@ def ensure_agent_sessions_project_columns(connection: sa.Connection) -> bool:
                 "ALTER TABLE agent_sessions ADD COLUMN paused_at timestamp without time zone"
             )
         else:
-            connection.exec_driver_sql(
-                "ALTER TABLE agent_sessions ADD COLUMN paused_at TIMESTAMP"
-            )
+            connection.exec_driver_sql("ALTER TABLE agent_sessions ADD COLUMN paused_at TIMESTAMP")
         changed = True
 
     return changed
@@ -589,7 +587,8 @@ def cutover_database(connection: sa.Connection, *, dry_run: bool = False) -> tup
             "paused_at",
         ]
         missing_agent_sessions_cols = [
-            col for col in agent_sessions_columns
+            col
+            for col in agent_sessions_columns
             if not _column_exists(connection, "agent_sessions", col)
         ]
         if missing_agent_sessions_cols:

--- a/tests/unit/test_alembic_baseline_cutover.py
+++ b/tests/unit/test_alembic_baseline_cutover.py
@@ -206,7 +206,13 @@ def test_cutover_skips_active_revision_when_schema_complete(tmp_path, revision):
         CREATE TABLE agent_sessions (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             session_id TEXT,
-            cli_session_id TEXT DEFAULT ''
+            cli_session_id TEXT DEFAULT '',
+            project_id INTEGER,
+            project_path TEXT,
+            request_count INTEGER DEFAULT 0,
+            workspace_type TEXT DEFAULT 'local',
+            remote_machine_id TEXT,
+            paused_at TIMESTAMP
         );
         CREATE TABLE session_messages (
             id INTEGER PRIMARY KEY AUTOINCREMENT,


### PR DESCRIPTION
## 问题

旧版 SQLite 数据库升级时，因 `agent_sessions` 和 `session_messages` 表缺少新字段，导致 `load_schema_from_file()` 执行 `CREATE INDEX` 时失败。

**错误信息**：`sqlite3.OperationalError: no such column: project_id`

## 根因

- `CREATE TABLE IF NOT EXISTS` 不会添加缺失字段到已存在的表
- 但 `schema.sql` 中的 `CREATE INDEX` 语句引用了这些字段
- 旧数据库升级时，表已存在但缺少字段，执行索引创建时失败

## 修复

### 1. `scripts/cutover_alembic_baseline.py`

- 新增 `ensure_agent_sessions_project_columns()` 补齐 `agent_sessions` 表 6 个字段：
  - `project_id`, `project_path`, `request_count`, `workspace_type`, `remote_machine_id`, `paused_at`
- 修改 `ensure_session_messages_transcript_columns()` 添加 `milestone_id`
- 更新 `dry_run` 检查和实际执行逻辑

### 2. `app/repositories/schema_init.py`

- 新增 `_backfill_missing_columns()` 在执行 `schema.sql` 前补齐缺失字段
- 确保 `load_schema_from_file()` 能安全处理旧数据库

## 测试

- ✅ `test_ensure_tables_migrates_legacy_session_messages_schema` 通过
- ✅ 所有 `tests/issues/1128/` 测试通过

## 关联 Issue

Fixes #1663