### PR TITLE
fix: SSO API 字段名与前端类型不匹配 (Issue #1689)

### DIFF
--- a/app/routes/sso.py
+++ b/app/routes/sso.py
@@ -170,6 +170,19 @@ def list_sso_providers():
 
     providers = get_sso_manager().list_providers(tenant_id=tenant_id)
 
+    # Transform provider fields to match frontend SSOProvider type:
+    # - provider_type -> type
+    # - is_active -> is_enabled
+    registered = [
+        {
+            "name": p.get("name"),
+            "type": p.get("provider_type"),
+            "is_enabled": p.get("is_active", True),
+            "tenant_id": p.get("tenant_id"),
+        }
+        for p in providers
+    ]
+
     # Also include predefined providers with full config (type, display_name, icon)
     predefined_names = list_providers()
     predefined = []
@@ -190,7 +203,7 @@ def list_sso_providers():
 
     return jsonify(
         {
-            "registered": providers,
+            "registered": registered,
             "predefined": predefined,
         }
     )


### PR DESCRIPTION
## 问题
SSO 设置页面白屏，原因是 `/api/sso/providers` API 返回的字段名与前端类型定义不匹配。

## 修复内容
- 将 `provider_type` 转换为 `type`
- 将 `is_active` 转换为 `is_enabled`

## 测试
- SSO 回归测试通过

Closes #1689