### PR TITLE
fix(i18n): 异常检测页面下拉菜单添加国际化支持 (Issue #1429)

### DIFF
--- a/frontend/src/components/features/analysis/AnomalyDetection.tsx
+++ b/frontend/src/components/features/analysis/AnomalyDetection.tsx
@@ -38,23 +38,24 @@ import {
   useDataRange,
 } from '@/hooks';
 
-// Anomaly type options
-const anomalyTypeOptions = [
-  { value: '', label: 'All Types' },
-  { value: 'spike', label: 'Usage Spike' },
-  { value: 'drop', label: 'Usage Drop' },
-];
-
-// Severity options
-const severityOptions = [
-  { value: '', label: 'All Severities' },
-  { value: 'high', label: 'High' },
-  { value: 'medium', label: 'Medium' },
-  { value: 'low', label: 'Low' },
-];
-
 export const AnomalyDetection: React.FC = () => {
   const language = useLanguage();
+
+  // Anomaly type options (i18n)
+  const anomalyTypeOptions = [
+    { value: '', label: t('allTypes', language) },
+    { value: 'spike', label: t('usageSpike', language) },
+    { value: 'drop', label: t('usageDrop', language) },
+  ];
+
+  // Severity options (i18n)
+  const severityOptions = [
+    { value: '', label: t('allSeverities', language) },
+    { value: 'high', label: t('severityHigh', language) },
+    { value: 'medium', label: t('severityMedium', language) },
+    { value: 'low', label: t('severityLow', language) },
+  ];
+
   const [selectedHost, setSelectedHost] = useState<string>('');
   const [anomalyTypeFilter, setAnomalyTypeFilter] = useState<string>('');
   const [severityFilter, setSeverityFilter] = useState<string>('');

--- a/frontend/src/components/features/analysis/AnomalyDetection.tsx
+++ b/frontend/src/components/features/analysis/AnomalyDetection.tsx
@@ -38,23 +38,23 @@ import {
   useDataRange,
 } from '@/hooks';
 
+const getAnomalyTypeOptions = (language: Language) => [
+  { value: '', label: t('allTypes', language) },
+  { value: 'spike', label: t('usageSpike', language) },
+  { value: 'drop', label: t('usageDrop', language) },
+];
+
+const getSeverityOptions = (language: Language) => [
+  { value: '', label: t('allSeverities', language) },
+  { value: 'high', label: t('severityHigh', language) },
+  { value: 'medium', label: t('severityMedium', language) },
+  { value: 'low', label: t('severityLow', language) },
+];
+
 export const AnomalyDetection: React.FC = () => {
   const language = useLanguage();
-
-  // Anomaly type options (i18n)
-  const anomalyTypeOptions = [
-    { value: '', label: t('allTypes', language) },
-    { value: 'spike', label: t('usageSpike', language) },
-    { value: 'drop', label: t('usageDrop', language) },
-  ];
-
-  // Severity options (i18n)
-  const severityOptions = [
-    { value: '', label: t('allSeverities', language) },
-    { value: 'high', label: t('severityHigh', language) },
-    { value: 'medium', label: t('severityMedium', language) },
-    { value: 'low', label: t('severityLow', language) },
-  ];
+  const anomalyTypeOptions = getAnomalyTypeOptions(language);
+  const severityOptions = getSeverityOptions(language);
 
   const [selectedHost, setSelectedHost] = useState<string>('');
   const [anomalyTypeFilter, setAnomalyTypeFilter] = useState<string>('');


### PR DESCRIPTION
## Summary

Fixes #1429

修复管理模式异常检测页面的下拉菜单缺少国际化问题。

### 问题
- 异常类型下拉菜单选项（All Types、Usage Spike、Usage Drop）硬编码英文
- 严重程度下拉菜单选项（All Severities、High、Medium、Low）硬编码英文
- 切换语言后不显示对应翻译

### 修复方案
- 将 `anomalyTypeOptions` 和 `severityOptions` 移到组件内部
- 使用 `t()` 函数调用已有的 i18n 翻译键

### 翻译键
| 键 | 中文 | 英文 |
|---|---|---|
| allTypes | 所有类型 | All Types |
| usageSpike | 用量突增 | Usage Spike |
| usageDrop | 用量骤降 | Usage Drop |
| allSeverities | 所有严重程度 | All Severities |
| severityHigh | 高 | High |
| severityMedium | 中 | Medium |
| severityLow | 低 | Low |

### 测试
- [x] TypeScript 类型检查通过
- [ ] 切换语言验证下拉菜单显示正确