### PR TITLE
fix(ui): 峰值使用时段显示时段而非日期 (Issue #1426)

### DIFF
--- a/frontend/src/components/features/Analysis.tsx
+++ b/frontend/src/components/features/Analysis.tsx
@@ -19,7 +19,7 @@ import {
   DoughnutChart,
   SimpleTabs,
 } from '@/components/common';
-import { formatTokens, formatDate, formatToolName } from '@/utils';
+import { formatTokens, formatDate, formatToolName, formatHourRange } from '@/utils';
 import {
   useKeyMetrics,
   useDailyHourlyUsage,
@@ -406,17 +406,12 @@ export const Analysis: React.FC = () => {
                         </tr>
                       </thead>
                       <tbody>
-                        {peakUsage.peak_hours.slice(0, 5).map((hour, index) => {
-                          const start = hour.hour.toString().padStart(2, '0') + ':00';
-                          const endHour = hour.hour === 23 ? 0 : hour.hour + 1;
-                          const end = endHour.toString().padStart(2, '0') + ':00';
-                          return (
-                            <tr key={index}>
-                              <td>{`${start}-${end}`}</td>
-                              <td>{formatTokens(hour.avg_tokens)}</td>
-                            </tr>
-                          );
-                        })}
+                        {peakUsage.peak_hours.slice(0, 5).map((hour, index) => (
+                          <tr key={index}>
+                            <td>{formatHourRange(hour.hour)}</td>
+                            <td>{formatTokens(hour.avg_tokens)}</td>
+                          </tr>
+                        ))}
                       </tbody>
                     </table>
                   </div>

--- a/frontend/src/components/features/Analysis.tsx
+++ b/frontend/src/components/features/Analysis.tsx
@@ -396,22 +396,27 @@ export const Analysis: React.FC = () => {
             {/* Peak Usage Periods */}
             <div className="col-md-6">
               <Card title={t('peakUsagePeriods', language)}>
-                {peakUsage?.peak_days && peakUsage.peak_days.length > 0 ? (
+                {peakUsage?.peak_hours && peakUsage.peak_hours.length > 0 ? (
                   <div className="table-responsive">
                     <table className="table table-sm table-hover">
                       <thead>
                         <tr>
-                          <th>{t('tableDate', language)}</th>
+                          <th>{t('tableTimePeriod', language)}</th>
                           <th>{t('tableTokens', language)}</th>
                         </tr>
                       </thead>
                       <tbody>
-                        {peakUsage.peak_days.slice(0, 5).map((day, index) => (
-                          <tr key={index}>
-                            <td>{day.date}</td>
-                            <td>{formatTokens(day.tokens)}</td>
-                          </tr>
-                        ))}
+                        {peakUsage.peak_hours.slice(0, 5).map((hour, index) => {
+                          const start = hour.hour.toString().padStart(2, '0') + ':00';
+                          const endHour = hour.hour === 23 ? 0 : hour.hour + 1;
+                          const end = endHour.toString().padStart(2, '0') + ':00';
+                          return (
+                            <tr key={index}>
+                              <td>{`${start}-${end}`}</td>
+                              <td>{formatTokens(hour.avg_tokens)}</td>
+                            </tr>
+                          );
+                        })}
                       </tbody>
                     </table>
                   </div>

--- a/frontend/src/components/features/analysis/TrendAnalysis.tsx
+++ b/frontend/src/components/features/analysis/TrendAnalysis.tsx
@@ -430,7 +430,7 @@ export const TrendAnalysis: React.FC = () => {
         {/* Peak Usage Periods */}
         <div className="col-md-6">
           <Card title={t('peakUsagePeriods', language)}>
-            {peakUsage?.peak_days && peakUsage.peak_days.length > 0 ? (
+            {peakUsage?.peak_hours && peakUsage.peak_hours.length > 0 ? (
               <div style={{ minHeight: 380 }}>
                 <table
                   className="table table-sm table-hover"
@@ -439,20 +439,25 @@ export const TrendAnalysis: React.FC = () => {
                   <thead>
                     <tr>
                       <th style={{ width: '10%' }}>#</th>
-                      <th style={{ width: '45%' }}>{t('tableDate', language)}</th>
+                      <th style={{ width: '45%' }}>{t('tableTimePeriod', language)}</th>
                       <th style={{ width: '45%' }} className="text-end">
                         {t('tableTokens', language)}
                       </th>
                     </tr>
                   </thead>
                   <tbody>
-                    {peakUsage.peak_days.slice(0, 10).map((day, index) => (
-                      <tr key={index}>
-                        <td>{index + 1}</td>
-                        <td>{day.date}</td>
-                        <td className="text-end">{formatTokens(day.tokens)}</td>
-                      </tr>
-                    ))}
+                    {peakUsage.peak_hours.slice(0, 10).map((hour, index) => {
+                      const start = hour.hour.toString().padStart(2, '0') + ':00';
+                      const endHour = hour.hour === 23 ? 0 : hour.hour + 1;
+                      const end = endHour.toString().padStart(2, '0') + ':00';
+                      return (
+                        <tr key={index}>
+                          <td>{index + 1}</td>
+                          <td>{`${start}-${end}`}</td>
+                          <td className="text-end">{formatTokens(hour.avg_tokens)}</td>
+                        </tr>
+                      );
+                    })}
                   </tbody>
                 </table>
               </div>

--- a/frontend/src/components/features/analysis/TrendAnalysis.tsx
+++ b/frontend/src/components/features/analysis/TrendAnalysis.tsx
@@ -32,7 +32,7 @@ import {
   Skeleton,
   PageRefreshControl,
 } from '@/components/common';
-import { formatTokens, formatToolName, createMatcherConfig } from '@/utils';
+import { formatTokens, formatToolName, createMatcherConfig, formatHourRange } from '@/utils';
 import { useBatchAnalysis, useHosts, useTools, usePageRefresh } from '@/hooks';
 import { SessionStatisticsCard, calculateHealthScore } from './SessionStatisticsCard';
 
@@ -446,18 +446,13 @@ export const TrendAnalysis: React.FC = () => {
                     </tr>
                   </thead>
                   <tbody>
-                    {peakUsage.peak_hours.slice(0, 10).map((hour, index) => {
-                      const start = hour.hour.toString().padStart(2, '0') + ':00';
-                      const endHour = hour.hour === 23 ? 0 : hour.hour + 1;
-                      const end = endHour.toString().padStart(2, '0') + ':00';
-                      return (
-                        <tr key={index}>
-                          <td>{index + 1}</td>
-                          <td>{`${start}-${end}`}</td>
-                          <td className="text-end">{formatTokens(hour.avg_tokens)}</td>
-                        </tr>
-                      );
-                    })}
+                    {peakUsage.peak_hours.slice(0, 10).map((hour, index) => (
+                      <tr key={index}>
+                        <td>{index + 1}</td>
+                        <td>{formatHourRange(hour.hour)}</td>
+                        <td className="text-end">{formatTokens(hour.avg_tokens)}</td>
+                      </tr>
+                    ))}
                   </tbody>
                 </table>
               </div>

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -145,6 +145,7 @@ export const translations: Record<Language, Translations> = {
 
     // Table
     tableDate: 'Date',
+    tableTimePeriod: 'Time Period',
     tableRequests: 'Requests',
     tableAverage: 'Average',
     tableInput: 'Input',
@@ -1791,6 +1792,7 @@ export const translations: Record<Language, Translations> = {
 
     // Table
     tableDate: '日期',
+    tableTimePeriod: '时段',
     tableRequests: '请求数',
     tableAverage: '平均值',
     tableInput: '输入',
@@ -3511,6 +3513,7 @@ export const translations: Record<Language, Translations> = {
 
     // Table
     tableDate: '日付',
+    tableTimePeriod: '時間帯',
     tableRequests: 'リクエスト数',
     tableAverage: '平均',
     tableInput: '入力',
@@ -4980,6 +4983,7 @@ export const translations: Record<Language, Translations> = {
 
     // Table
     tableDate: '날짜',
+    tableTimePeriod: '시간대',
     tableRequests: '요청 수',
     tableAverage: '평균',
     tableInput: '입력',

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -269,3 +269,14 @@ export function formatChartDate(
     ...(options.dayOnly ? {} : { month: 'short' }),
   });
 }
+
+/**
+ * Format an hour (0-23) as a time range string.
+ * Example: 14 → "14:00-15:00", 23 → "23:00-00:00"
+ */
+export function formatHourRange(hour: number): string {
+  const start = hour.toString().padStart(2, '0') + ':00';
+  const endHour = hour === 23 ? 0 : hour + 1;
+  const end = endHour.toString().padStart(2, '0') + ':00';
+  return `${start}-${end}`;
+}

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -14,6 +14,7 @@ export {
   formatBytes,
   formatDuration,
   formatChartDate,
+  formatHourRange,
   displaySessionId,
 } from './format';
 export {


### PR DESCRIPTION
## Summary

修复 Issue #1426：管理模式 Token 趋势页面中"峰值使用时段"卡片显示日期而非时段的问题。

## Changes

- 将 Analysis.tsx 和 TrendAnalysis.tsx 中的数据源从 peak_days 改为 peak_hours
- 新增 tableTimePeriod 翻译键（en/zh/ja/ko 四种语言）
- 时段显示格式为 HH:00-HH+1:00（如 14:00-15:00）

## Test

- TypeScript 类型检查通过
- ESLint 检查通过

## Related Issue

Fixes #1426