### PR TITLE
fix(pagination): 分页组件跳转按钮体验优化 (Issue #1433)

### DIFF
--- a/frontend/src/components/common/Pagination.test.tsx
+++ b/frontend/src/components/common/Pagination.test.tsx
@@ -35,6 +35,9 @@ vi.mock('@/i18n', () => ({
       invalidPageNumber: 'Please enter a valid page number (1-{total})',
       previousPage: 'Previous page',
       nextPage: 'Next page',
+      jumpButton: 'Go',
+      jumpButtonLabel: 'Go to specified page',
+      jumpInputGroupLabel: 'Page jump controls',
     };
     return translations[key] || key;
   },
@@ -307,6 +310,128 @@ describe('Pagination Component', () => {
         },
         { timeout: 3000 }
       );
+    });
+  });
+
+  describe('Jump button (Issue #1433)', () => {
+    it('should render jump button with correct aria-label', () => {
+      render(<Pagination currentPage={1} totalPages={10} onPageChange={mockOnPageChange} />);
+
+      // Desktop version jump button
+      const jumpButtons = screen.getAllByRole('button', { name: /Go to specified page/i });
+      expect(jumpButtons.length).toBeGreaterThan(0);
+    });
+
+    it('should call onPageChange when clicking jump button', () => {
+      render(<Pagination currentPage={1} totalPages={10} onPageChange={mockOnPageChange} />);
+
+      const inputs = screen.getAllByRole('spinbutton', { name: /Go to page/i });
+      const input = inputs[0]; // Desktop version input
+      fireEvent.change(input, { target: { value: '5' } });
+
+      const jumpButtons = screen.getAllByRole('button', { name: /Go to specified page/i });
+      const jumpButton = jumpButtons[0]; // Desktop version
+      fireEvent.click(jumpButton);
+
+      expect(mockOnPageChange).toHaveBeenCalledWith(5);
+    });
+
+    it('should disable jump button when input is empty', () => {
+      render(<Pagination currentPage={1} totalPages={10} onPageChange={mockOnPageChange} />);
+
+      const jumpButtons = screen.getAllByRole('button', { name: /Go to specified page/i });
+      const jumpButton = jumpButtons[0]; // Desktop version
+      expect(jumpButton).toBeDisabled();
+    });
+
+    it('should disable jump button for invalid input (non-number)', () => {
+      render(<Pagination currentPage={1} totalPages={10} onPageChange={mockOnPageChange} />);
+
+      const inputs = screen.getAllByRole('spinbutton', { name: /Go to page/i });
+      const input = inputs[0]; // Desktop version input
+      fireEvent.change(input, { target: { value: 'abc' } });
+
+      const jumpButtons = screen.getAllByRole('button', { name: /Go to specified page/i });
+      const jumpButton = jumpButtons[0];
+      expect(jumpButton).toBeDisabled();
+    });
+
+    it('should disable jump button when input exceeds max page', () => {
+      render(<Pagination currentPage={1} totalPages={10} onPageChange={mockOnPageChange} />);
+
+      const inputs = screen.getAllByRole('spinbutton', { name: /Go to page/i });
+      const input = inputs[0]; // Desktop version input
+      fireEvent.change(input, { target: { value: '15' } });
+
+      const jumpButtons = screen.getAllByRole('button', { name: /Go to specified page/i });
+      const jumpButton = jumpButtons[0];
+      expect(jumpButton).toBeDisabled();
+    });
+
+    it('should disable jump button when input equals current page', () => {
+      render(<Pagination currentPage={5} totalPages={10} onPageChange={mockOnPageChange} />);
+
+      const inputs = screen.getAllByRole('spinbutton', { name: /Go to page/i });
+      const input = inputs[0]; // Desktop version input
+      fireEvent.change(input, { target: { value: '5' } });
+
+      const jumpButtons = screen.getAllByRole('button', { name: /Go to specified page/i });
+      const jumpButton = jumpButtons[0];
+      expect(jumpButton).toBeDisabled();
+    });
+
+    it('should enable jump button for valid page number', () => {
+      render(<Pagination currentPage={1} totalPages={10} onPageChange={mockOnPageChange} />);
+
+      const inputs = screen.getAllByRole('spinbutton', { name: /Go to page/i });
+      const input = inputs[0]; // Desktop version input
+      fireEvent.change(input, { target: { value: '5' } });
+
+      const jumpButtons = screen.getAllByRole('button', { name: /Go to specified page/i });
+      const jumpButton = jumpButtons[0];
+      expect(jumpButton).not.toBeDisabled();
+    });
+
+    it('should have pagination-jump-input class on input', () => {
+      render(<Pagination currentPage={1} totalPages={10} onPageChange={mockOnPageChange} />);
+
+      const inputs = screen.getAllByRole('spinbutton', { name: /Go to page/i });
+      const input = inputs[0]; // Desktop version input
+      expect(input).toHaveClass('pagination-jump-input');
+    });
+
+    it('should have role="group" on jump input container', () => {
+      render(<Pagination currentPage={1} totalPages={10} onPageChange={mockOnPageChange} />);
+
+      // Find the group by aria-label
+      const groups = screen.getAllByRole('group', { name: /Page jump controls/i });
+      expect(groups.length).toBeGreaterThan(0);
+    });
+
+    it('should have aria-describedby on input when error exists', async () => {
+      render(<Pagination currentPage={1} totalPages={10} onPageChange={mockOnPageChange} />);
+
+      const inputs = screen.getAllByRole('spinbutton', { name: /Go to page/i });
+      const input = inputs[0]; // Desktop version input
+      fireEvent.change(input, { target: { value: '15' } });
+      fireEvent.keyDown(input, { key: 'Enter' });
+
+      await waitFor(() => {
+        expect(input).toHaveAttribute('aria-describedby', 'pagination-error');
+      });
+    });
+
+    it('should have aria-invalid on input when error exists', async () => {
+      render(<Pagination currentPage={1} totalPages={10} onPageChange={mockOnPageChange} />);
+
+      const inputs = screen.getAllByRole('spinbutton', { name: /Go to page/i });
+      const input = inputs[0]; // Desktop version input
+      fireEvent.change(input, { target: { value: '15' } });
+      fireEvent.keyDown(input, { key: 'Enter' });
+
+      await waitFor(() => {
+        expect(input).toHaveAttribute('aria-invalid', 'true');
+      });
     });
   });
 

--- a/frontend/src/components/common/Pagination.tsx
+++ b/frontend/src/components/common/Pagination.tsx
@@ -127,6 +127,16 @@ export const Pagination: React.FC<PaginationProps> = ({
     [currentPage, totalPages, maxVisiblePages]
   );
 
+  // Calculate jump button disabled state (Issue #1433)
+  const isJumpDisabled = useMemo(() => {
+    if (!inputValue.trim()) return true;
+    const page = parseInt(inputValue, 10);
+    if (isNaN(page)) return true;
+    if (page < 1 || page > totalPages) return true;
+    if (page === currentPage) return true;
+    return false;
+  }, [inputValue, currentPage, totalPages]);
+
   // Handle page change
   const handlePageChange = useCallback(
     (page: number) => {
@@ -287,25 +297,41 @@ export const Pagination: React.FC<PaginationProps> = ({
 
         {/* Jump input */}
         {showPageInput && (
-          <div className="d-flex align-items-center gap-1">
+          <div
+            className="d-flex align-items-center gap-1"
+            role="group"
+            aria-label={t('jumpInputGroupLabel', language)}
+          >
             <span className="text-muted small">{t('goToPageLabel', language)}:</span>
             <input
               type="number"
-              className="form-control form-control-sm"
-              style={{ width: '60px' }}
+              className="form-control form-control-sm pagination-jump-input"
+              style={{ width: '70px' }}
               value={inputValue}
               onChange={handleInputChange}
               onKeyDown={handleInputKeyDown}
               min={1}
               max={totalPages}
               aria-label={t('goToPageLabel', language)}
+              aria-describedby={error ? 'pagination-error' : undefined}
+              aria-invalid={!!error}
             />
+            <button
+              type="button"
+              className="btn btn-outline-secondary btn-sm"
+              onClick={handleJumpSubmit}
+              disabled={isJumpDisabled}
+              aria-label={t('jumpButtonLabel', language)}
+            >
+              {t('jumpButton', language)}
+            </button>
           </div>
         )}
 
         {/* Error message */}
         {error && (
           <span
+            id="pagination-error"
             className="text-danger small"
             role="alert"
             aria-live="polite"
@@ -356,21 +382,41 @@ export const Pagination: React.FC<PaginationProps> = ({
 
         {/* Mobile jump input */}
         {showPageInput && (
-          <div className="d-flex align-items-center gap-1">
+          <div
+            className="d-flex align-items-center gap-1"
+            role="group"
+            aria-label={t('jumpInputGroupLabel', language)}
+          >
             <small className="text-muted">{t('goToPageLabel', language)}:</small>
             <input
               type="number"
-              className="form-control form-control-sm"
-              style={{ width: '50px' }}
+              className="form-control form-control-sm pagination-jump-input"
+              style={{ width: '60px' }}
               value={inputValue}
               onChange={handleInputChange}
               onKeyDown={handleInputKeyDown}
               min={1}
               max={totalPages}
               aria-label={t('goToPageLabel', language)}
+              aria-describedby={error ? 'pagination-error-mobile' : undefined}
+              aria-invalid={!!error}
             />
+            <button
+              type="button"
+              className="btn btn-outline-secondary btn-sm"
+              onClick={handleJumpSubmit}
+              disabled={isJumpDisabled}
+              aria-label={t('jumpButtonLabel', language)}
+            >
+              <i className="bi bi-arrow-right" />
+            </button>
             {error && (
-              <span className="text-danger small" role="alert" aria-live="polite">
+              <span
+                id="pagination-error-mobile"
+                className="text-danger small"
+                role="alert"
+                aria-live="polite"
+              >
                 {error}
               </span>
             )}

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -622,6 +622,9 @@ export const translations: Record<Language, Translations> = {
     invalidPageNumber: 'Please enter a valid page number (1-{total})',
     previousPage: 'Previous page',
     nextPage: 'Next page',
+    jumpButton: 'Go',
+    jumpButtonLabel: 'Go to specified page',
+    jumpInputGroupLabel: 'Page jump controls',
 
     // Prompts
     addPrompt: 'Add Prompt',
@@ -2252,6 +2255,9 @@ export const translations: Record<Language, Translations> = {
     invalidPageNumber: '请输入有效的页码 (1-{total})',
     previousPage: '上一页',
     nextPage: '下一页',
+    jumpButton: '跳转',
+    jumpButtonLabel: '跳转到指定页',
+    jumpInputGroupLabel: '页码跳转控制',
 
     // Prompts
     addPrompt: '添加提示词',
@@ -4063,6 +4069,9 @@ export const translations: Record<Language, Translations> = {
     invalidPageNumber: '有効なページ番号を入力してください (1-{total})',
     previousPage: '前のページ',
     nextPage: '次のページ',
+    jumpButton: '移動',
+    jumpButtonLabel: '指定ページに移動',
+    jumpInputGroupLabel: 'ページ移動コントロール',
 
     // Prompts
     addPrompt: 'プロンプト追加',
@@ -5533,6 +5542,9 @@ export const translations: Record<Language, Translations> = {
     lastPage: '마지막 페이지',
     previousPage: '이전 페이지',
     nextPage: '다음 페이지',
+    jumpButton: '이동',
+    jumpButtonLabel: '지정 페이지로 이동',
+    jumpInputGroupLabel: '페이지 이동 컨트롤',
 
     // Prompts
     addPrompt: '프롬프트 추가',

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -4447,3 +4447,13 @@ table .latency-row:hover td {
 [data-theme='dark'] .security-score-circle:hover {
   box-shadow: 0 6px 16px rgba(0, 0, 0, 0.35);
 }
+
+/* Pagination jump input - hide spin buttons (Issue #1433) */
+.pagination-jump-input::-webkit-inner-spin-button,
+.pagination-jump-input::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+.pagination-jump-input[type='number'] {
+  -moz-appearance: textfield;
+}


### PR DESCRIPTION
## 关联 Issue

Fixes #1433

## 改动内容

### 核心改动
- ✅ 添加跳转按钮解决触屏设备无法确认问题
- ✅ 实现按钮禁用逻辑（空输入、无效值、超出范围、当前页）
- ✅ 隐藏 number 输入框的 spin 按钮（CSS）
- ✅ 增加输入框宽度（桌面端 70px，移动端 60px）

### 无障碍改进
- ✅ 补充完整无障碍属性（`role="group"`、`aria-describedby`、`aria-invalid`）
- ✅ 跳转按钮添加 `aria-label` 属性

### 国际化
- ✅ 新增四语言翻译：`jumpButton`、`jumpButtonLabel`、`jumpInputGroupLabel`

### 测试
- ✅ 新增 11 个测试用例覆盖新功能
- ✅ 全部 49 个测试通过

## 改动文件

| 文件 | 改动 |
|------|------|
| `frontend/src/styles/main.css` | +10 行（spin 按钮隐藏 CSS） |
| `frontend/src/i18n/index.ts` | +12 行（四语言翻译） |
| `frontend/src/components/common/Pagination.tsx` | +60/-7 行（按钮禁用逻辑、跳转按钮、无障碍属性） |
| `frontend/src/components/common/Pagination.test.tsx` | +125 行（11 个新测试用例） |

## 验证结果

- ✅ 前端构建成功
- ✅ 49 个测试全部通过

## 截图

### 桌面端
- 输入框旁显示"Go"按钮
- 无效输入时按钮禁用
- 输入框不显示 spin 箭头

### 移动端
- 输入框旁显示箭头图标按钮
- 触屏设备可点击按钮确认跳转