### PR TITLE
chore(db): remove stale HEAD_REVISION constant from baseline.py

### DIFF
--- a/migrations/baseline.py
+++ b/migrations/baseline.py
@@ -11,7 +11,6 @@ if TYPE_CHECKING:
     from sqlalchemy.engine import Connection
 
 BASELINE_REVISION = "baseline_2026_06_23"
-HEAD_REVISION = "20260714_001_add_ci_repair_fields_to_workflows"
 
 _PROJECT_ROOT = Path(__file__).resolve().parents[1]
 _BASELINE_SCHEMA_DIR = _PROJECT_ROOT / "schema" / "baselines"

--- a/tests/unit/test_check_min_revision.py
+++ b/tests/unit/test_check_min_revision.py
@@ -23,11 +23,13 @@ def post_baseline_revision() -> str:
     """A real post-baseline revision, derived at runtime from the live migrations dir.
 
     Avoids hard-coding (and then maintaining) a head revision constant that
-    drifts every time a new migration lands.
+    drifts every time a new migration lands. Returns the earliest post-baseline
+    revision (revision ids are timestamp-prefixed, so sorted() orders them) for
+    reproducibility across runs regardless of PYTHONHASHSEED.
     """
     revisions = collect_active_revision_ids()
     assert revisions, "expected at least one post-baseline migration"
-    return next(iter(revisions))
+    return sorted(revisions)[0]
 
 
 def _stamp_sqlite(db_path, revision: str | None) -> None:

--- a/tests/unit/test_check_min_revision.py
+++ b/tests/unit/test_check_min_revision.py
@@ -8,7 +8,7 @@ import sys
 
 import pytest
 
-from migrations.baseline import ACTIVE_MIGRATIONS_DIR, BASELINE_REVISION, HEAD_REVISION
+from migrations.baseline import ACTIVE_MIGRATIONS_DIR, BASELINE_REVISION
 from scripts.check_min_revision import collect_active_revision_ids, is_supported_revision
 
 
@@ -16,6 +16,18 @@ from scripts.check_min_revision import collect_active_revision_ids, is_supported
 def _clean_argv(monkeypatch):
     """main() parses sys.argv; strip pytest's args so argparse doesn't choke."""
     monkeypatch.setattr(sys, "argv", ["check_min_revision.py"])
+
+
+@pytest.fixture(scope="session")
+def post_baseline_revision() -> str:
+    """A real post-baseline revision, derived at runtime from the live migrations dir.
+
+    Avoids hard-coding (and then maintaining) a head revision constant that
+    drifts every time a new migration lands.
+    """
+    revisions = collect_active_revision_ids()
+    assert revisions, "expected at least one post-baseline migration"
+    return next(iter(revisions))
 
 
 def _stamp_sqlite(db_path, revision: str | None) -> None:
@@ -33,10 +45,10 @@ def _stamp_sqlite(db_path, revision: str | None) -> None:
     conn.close()
 
 
-def test_collect_active_revision_ids_includes_post_baseline_head():
+def test_collect_active_revision_ids_is_non_empty_and_excludes_baseline():
     """The allowlist is derived from the live migrations dir."""
     active_ids = collect_active_revision_ids()
-    assert HEAD_REVISION in active_ids
+    assert active_ids  # post-baseline lineage exists
     # The baseline pins its revision to a symbol, so it is unioned in by the
     # caller rather than surfaced by the collector.
     assert BASELINE_REVISION not in active_ids
@@ -60,10 +72,10 @@ def test_collect_covers_every_non_baseline_migration():
     assert len(collect_active_revision_ids()) == len(migration_files) - 1
 
 
-def test_is_supported_revision_accepts_baseline_and_successors():
+def test_is_supported_revision_accepts_baseline_and_successors(post_baseline_revision):
     supported = collect_active_revision_ids() | {BASELINE_REVISION}
     assert is_supported_revision(BASELINE_REVISION, supported) is True
-    assert is_supported_revision(HEAD_REVISION, supported) is True
+    assert is_supported_revision(post_baseline_revision, supported) is True
 
 
 def test_is_supported_revision_rejects_pre_baseline_hash():
@@ -90,11 +102,11 @@ def test_main_allows_baseline_revision(tmp_path, monkeypatch, capsys):
     assert "supported lineage" in out
 
 
-def test_main_allows_head_revision(tmp_path, monkeypatch, capsys):
+def test_main_allows_post_baseline_revision(tmp_path, monkeypatch, capsys, post_baseline_revision):
     import scripts.check_min_revision as mod
 
-    db_path = tmp_path / "head.db"
-    _stamp_sqlite(db_path, HEAD_REVISION)
+    db_path = tmp_path / "post_baseline.db"
+    _stamp_sqlite(db_path, post_baseline_revision)
     monkeypatch.setattr(mod, "_get_db_url", lambda: f"sqlite:///{db_path}")
 
     rc = mod.main()


### PR DESCRIPTION
## 背景

`migrations/baseline.py` 里的 `HEAD_REVISION` 是一个硬编码字面量，每次新增迁移都会过期，需要手动同步更新（容易遗忘，且没有任何检查保证它和实际 head 一致）。这正是上一个 PR（#1688）rebase 时产生冲突的根源之一。

## 问题

`HEAD_REVISION` **没有任何生产代码消费者**：

- `check_min_revision.py` 的 guard 在运行时动态扫描 `migrations/versions/` 目录得到受支持 revision 集合，不读这个常量
- 安装脚本、docker-entrypoint 等也不引用它

它唯一的使用者是测试，需要"一个已知的 post-baseline revision"作为样例值。

## 改动

- **删除** `baseline.py` 中的 `HEAD_REVISION` 常量。该文件现在只暴露 `BASELINE_REVISION` —— 迁移链唯一稳定的不动点
- **测试**新增 `post_baseline_revision` session fixture，运行时从 `collect_active_revision_ids()` 取一个真实 revision，替代原先的 `HEAD_REVISION`。测试断言改为非空 + 排除 baseline，不再绑定具体 head

## 效果

今后新增迁移时，**不再需要更新 `baseline.py`**。`BASELINE_REVISION` 只在提升 baseline 时才变（半年/年级别频率），是真正需要人工维护且语义明确的锚点。

## 验证

- `test_check_min_revision.py` 10/10 通过
- 相关 alembic/schema 测试 21/21 通过
- `baseline.py` 导入正常，不再导出 `HEAD_REVISION`
- 全仓库无 `HEAD_REVISION` 残留引用