### PR TITLE
Fix autonomous workflow session identity boundaries

### DIFF
--- a/app/modules/workspace/autonomous/models.py
+++ b/app/modules/workspace/autonomous/models.py
@@ -366,6 +366,9 @@ class AgentTaskResult:
 
     session_id: str = ""
     tracking_session_id: str = ""
+    # The real provider transcript session (Claude sidebar / app-server session).
+    # Milestones now persist tracking_session_id instead; read paths use this
+    # field to resolve the actual transcript when available.
     source_session_id: str = ""
     prompt: str = ""
     response_text: str = ""

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -1836,12 +1836,19 @@ class AutonomousOrchestrator:
 
         result = self._runner.run_agent_task(**kwargs)
         if result.session_id:
-            # Link the milestone card to the REAL claude session id (not the
-            # per-call wrapper uuid), so all milestones sharing a session line
-            # (e.g. plan_created/plan_refined/dev on the "main" line) show the
-            # SAME id and the card's "view session" points to the right transcript.
-            # Falls back to the wrapper uuid when the real id isn't resolved yet.
-            link_session_id = result.source_session_id or result.session_id
+            # Workflow milestones must keep the stable session-line tracking id
+            # (main/review/test), not the provider's real CLI id. The timeline
+            # resolves the actual transcript session at read time via
+            # agent_sessions.cli_session_id, which keeps DB identity stable
+            # while still letting the UI open the real transcript.
+            link_session_id = (
+                (result.tracking_session_id or result.session_id)
+                if self._runner._uses_sidebar_session_source(
+                    kwargs.get("cli_tool", ""),
+                    kwargs.get("workspace_type", "local"),
+                )
+                else result.session_id
+            )
             self._link_session_to_current_milestone(link_session_id)
             # Persist the stable tracking id for this line. Fresh lines write
             # their first tracking id here; established lines keep reusing the

--- a/app/modules/workspace/session_manager.py
+++ b/app/modules/workspace/session_manager.py
@@ -61,18 +61,23 @@ def _params(count: int) -> str:
     return ", ".join([p] * count)
 
 
-def _visible_session_clause(alias: str = "") -> tuple[str, list[Any]]:
+_AUTONOMOUS_WORKFLOW_CONTEXT_PATTERN = f"%{escape_like('\"workflow_id\"')}%"
+
+
+def visible_session_clause(alias: str = "") -> tuple[str, list[Any]]:
     """Hide autonomous workflow tracking wrappers from user-facing listings."""
 
     prefix = f"{alias}." if alias else ""
     p = _param()
+    # escape_like is baked into _AUTONOMOUS_WORKFLOW_CONTEXT_PATTERN so the
+    # JSON-key substring match remains SQL003/SQL004-safe on SQLite and PG.
     return (
         "NOT ("
         f"{prefix}session_type = {p} "
         f"AND COALESCE({prefix}cli_session_id, '') != '' "
         f"AND COALESCE({prefix}context, '') LIKE {p} ESCAPE '\\'"
         ")",
-        [SessionType.WORKFLOW.value, '%"workflow_id"%'],
+        [SessionType.WORKFLOW.value, _AUTONOMOUS_WORKFLOW_CONTEXT_PATTERN],
     )
 
 
@@ -1558,7 +1563,7 @@ class SessionManager:
             conditions.append(f"title LIKE {_param()} ESCAPE '\\'")
             params.append(f"%{escape_like(search)}%")
 
-        visible_clause, visible_params = _visible_session_clause()
+        visible_clause, visible_params = visible_session_clause()
         conditions.append(visible_clause)
         params.extend(visible_params)
 
@@ -1714,7 +1719,7 @@ class SessionManager:
         cursor = conn.cursor()
 
         if user_id:
-            visible_clause, visible_params = _visible_session_clause()
+            visible_clause, visible_params = visible_session_clause()
             cursor.execute(
                 f"""
                 SELECT
@@ -1729,7 +1734,7 @@ class SessionManager:
                 (user_id, *visible_params),
             )
         else:
-            visible_clause, visible_params = _visible_session_clause()
+            visible_clause, visible_params = visible_session_clause()
             cursor.execute(
                 f"""
                 SELECT

--- a/app/modules/workspace/session_manager.py
+++ b/app/modules/workspace/session_manager.py
@@ -61,7 +61,8 @@ def _params(count: int) -> str:
     return ", ".join([p] * count)
 
 
-_AUTONOMOUS_WORKFLOW_CONTEXT_PATTERN = f"%{escape_like('\"workflow_id\"')}%"
+_WORKFLOW_ID_CONTEXT_MARKER = '"workflow_id"'
+_AUTONOMOUS_WORKFLOW_CONTEXT_PATTERN = "%" + escape_like(_WORKFLOW_ID_CONTEXT_MARKER) + "%"
 
 
 def visible_session_clause(alias: str = "") -> tuple[str, list[Any]]:

--- a/app/modules/workspace/session_manager.py
+++ b/app/modules/workspace/session_manager.py
@@ -61,6 +61,21 @@ def _params(count: int) -> str:
     return ", ".join([p] * count)
 
 
+def _visible_session_clause(alias: str = "") -> tuple[str, list[Any]]:
+    """Hide autonomous workflow tracking wrappers from user-facing listings."""
+
+    prefix = f"{alias}." if alias else ""
+    p = _param()
+    return (
+        "NOT ("
+        f"{prefix}session_type = {p} "
+        f"AND COALESCE({prefix}cli_session_id, '') != '' "
+        f"AND COALESCE({prefix}context, '') LIKE {p} ESCAPE '\\'"
+        ")",
+        [SessionType.WORKFLOW.value, '%"workflow_id"%'],
+    )
+
+
 class SessionStatus(Enum):
     """Session status enumeration."""
 
@@ -1543,6 +1558,10 @@ class SessionManager:
             conditions.append(f"title LIKE {_param()} ESCAPE '\\'")
             params.append(f"%{escape_like(search)}%")
 
+        visible_clause, visible_params = _visible_session_clause()
+        conditions.append(visible_clause)
+        params.extend(visible_params)
+
         where_clause = " AND ".join(conditions) if conditions else "1=1"
 
         # Get total count
@@ -1695,6 +1714,7 @@ class SessionManager:
         cursor = conn.cursor()
 
         if user_id:
+            visible_clause, visible_params = _visible_session_clause()
             cursor.execute(
                 f"""
                 SELECT
@@ -1704,13 +1724,14 @@ class SessionManager:
                     SUM(total_tokens) as total_tokens,
                     SUM(message_count) as total_messages
                 FROM agent_sessions
-                WHERE user_id = {_param()}
+                WHERE user_id = {_param()} AND {visible_clause}
             """,
-                (user_id,),
+                (user_id, *visible_params),
             )
         else:
+            visible_clause, visible_params = _visible_session_clause()
             cursor.execute(
-                """
+                f"""
                 SELECT
                     COUNT(*) as total_sessions,
                     SUM(CASE WHEN status = 'active' THEN 1 ELSE 0 END) as active_sessions,
@@ -1718,7 +1739,9 @@ class SessionManager:
                     SUM(total_tokens) as total_tokens,
                     SUM(message_count) as total_messages
                 FROM agent_sessions
-            """
+                WHERE {visible_clause}
+            """,
+                visible_params,
             )
 
         row = cursor.fetchone()

--- a/app/routes/autonomous.py
+++ b/app/routes/autonomous.py
@@ -237,13 +237,16 @@ def _enrich_milestones_with_usage(
     for milestone in milestones:
         milestone_id = milestone.get("milestone_id", "")
         usage = usage_by_milestone.get(milestone_id, {})
-        llm_session_id = usage.get("llm_session_id") or _resolve_milestone_session_id(milestone)
+        tracking_llm_session_id = usage.get("llm_session_id") or _resolve_milestone_session_id(
+            milestone
+        )
         enriched.append(
             {
                 **milestone,
-                "llm_session_id": llm_session_id,
+                "tracking_llm_session_id": tracking_llm_session_id,
+                "llm_session_id": tracking_llm_session_id,
                 "actual_llm_session_id": _resolve_actual_session_id(
-                    llm_session_id, session_manager, session_cache
+                    tracking_llm_session_id, session_manager, session_cache
                 ),
                 "llm_total_tokens": usage.get("llm_total_tokens", 0),
                 "llm_request_count": usage.get("llm_request_count", 0),

--- a/app/routes/workspace.py
+++ b/app/routes/workspace.py
@@ -57,6 +57,25 @@ def format_datetime(dt):
     return dt
 
 
+def _exclude_autonomous_tracking_session_clause(alias: str, placeholder: str) -> tuple[str, list[str]]:
+    """Hide autonomous workflow tracking wrappers from user-facing session lists.
+
+    Autonomous workflows maintain stable main/review/test tracking rows whose
+    real CLI session is stored in ``cli_session_id``. Showing both the tracking
+    row and the provider row duplicates the same conversation in Work mode.
+    """
+
+    prefix = f"{alias}." if alias else ""
+    return (
+        "NOT ("
+        f"{prefix}session_type = {placeholder} "
+        f"AND COALESCE({prefix}cli_session_id, '') != '' "
+        f"AND COALESCE({prefix}context, '') LIKE {placeholder} ESCAPE '\\'"
+        ")",
+        ["workflow", '%"workflow_id"%'],
+    )
+
+
 workspace_bp = Blueprint("workspace", __name__)
 
 
@@ -557,6 +576,9 @@ def list_sessions():
         # escape_like not needed: hard-coded pattern, no user input
         base_conditions.append(f"session_id NOT LIKE {p}")
         base_params.append("webui:%")
+        visible_clause, visible_params = _exclude_autonomous_tracking_session_clause("", p)
+        base_conditions.append(visible_clause)
+        base_params.extend(visible_params)
 
         if user_id:
             base_conditions.append(f"user_id = {p}")

--- a/app/routes/workspace.py
+++ b/app/routes/workspace.py
@@ -20,7 +20,11 @@ from app.modules.workspace.api_key_proxy import get_api_key_proxy_service
 from app.modules.workspace.collaboration import SharePermission, get_collaboration_manager
 from app.modules.workspace.llm_proxy_handler import handle_llm_proxy_request
 from app.modules.workspace.prompt_library import PromptCategory, PromptTemplate, get_prompt_library
-from app.modules.workspace.session_manager import SessionType, get_session_manager
+from app.modules.workspace.session_manager import (
+    SessionType,
+    get_session_manager,
+    visible_session_clause,
+)
 from app.modules.workspace.state_sync import get_state_sync_manager
 from app.modules.workspace.tool_connector import get_tool_connector
 from app.utils.tool_names import TOOL_NAME_ALIASES, normalize_tool_name
@@ -55,25 +59,6 @@ def format_datetime(dt):
             iso_str += "+00:00"
         return iso_str
     return dt
-
-
-def _exclude_autonomous_tracking_session_clause(alias: str, placeholder: str) -> tuple[str, list[str]]:
-    """Hide autonomous workflow tracking wrappers from user-facing session lists.
-
-    Autonomous workflows maintain stable main/review/test tracking rows whose
-    real CLI session is stored in ``cli_session_id``. Showing both the tracking
-    row and the provider row duplicates the same conversation in Work mode.
-    """
-
-    prefix = f"{alias}." if alias else ""
-    return (
-        "NOT ("
-        f"{prefix}session_type = {placeholder} "
-        f"AND COALESCE({prefix}cli_session_id, '') != '' "
-        f"AND COALESCE({prefix}context, '') LIKE {placeholder} ESCAPE '\\'"
-        ")",
-        ["workflow", '%"workflow_id"%'],
-    )
 
 
 workspace_bp = Blueprint("workspace", __name__)
@@ -576,7 +561,7 @@ def list_sessions():
         # escape_like not needed: hard-coded pattern, no user input
         base_conditions.append(f"session_id NOT LIKE {p}")
         base_params.append("webui:%")
-        visible_clause, visible_params = _exclude_autonomous_tracking_session_clause("", p)
+        visible_clause, visible_params = visible_session_clause()
         base_conditions.append(visible_clause)
         base_params.extend(visible_params)
 

--- a/frontend/src/api/autonomous.ts
+++ b/frontend/src/api/autonomous.ts
@@ -117,6 +117,7 @@ export interface WorkflowMilestone {
   fork_branch: string;
   fork_workflow_id: string;
   metadata: string;
+  tracking_llm_session_id?: string;
   llm_session_id?: string;
   actual_llm_session_id?: string;
   llm_total_tokens?: number;

--- a/tests/issues/1125/test_workspace_session_summary_contract.py
+++ b/tests/issues/1125/test_workspace_session_summary_contract.py
@@ -10,20 +10,36 @@ from app.routes import workspace as workspace_route
 
 
 class _FakeListDatabase:
-    def __init__(self, session_row: dict):
-        self.session_row = session_row
+    def __init__(self, session_rows: list[dict]):
+        self.session_rows = session_rows
 
     def fetch_one(self, query: str, params):
         if "COUNT(*) as count FROM agent_sessions" in query:
-            return {"count": 1}
+            rows = self._visible_rows(query)
+            return {"count": len(rows)}
         raise AssertionError(f"Unexpected fetch_one query: {query}")
 
     def fetch_all(self, query: str, params):
         if "SELECT * FROM agent_sessions" in query:
-            return [self.session_row]
+            return self._visible_rows(query)
         if "FROM session_messages" in query and "role = 'user'" in query:
-            return [{"session_id": self.session_row["session_id"], "content": "first prompt"}]
+            return [
+                {"session_id": row["session_id"], "content": "first prompt"} for row in self.session_rows
+            ]
         raise AssertionError(f"Unexpected fetch_all query: {query}")
+
+    def _visible_rows(self, query: str) -> list[dict]:
+        if "COALESCE(cli_session_id, '') != ''" not in query:
+            return self.session_rows
+        return [
+            row
+            for row in self.session_rows
+            if not (
+                row.get("session_type") == "workflow"
+                and row.get("cli_session_id")
+                and '"workflow_id"' in (row.get("context") or "")
+            )
+        ]
 
 
 def _make_app() -> Flask:
@@ -56,7 +72,7 @@ def test_list_sessions_uses_agent_sessions_summary(monkeypatch):
         "workspace_type": "local",
         "remote_machine_id": None,
     }
-    fake_db = _FakeListDatabase(session_row)
+    fake_db = _FakeListDatabase([session_row])
 
     monkeypatch.setattr("app.repositories.database.Database", lambda: fake_db)
     monkeypatch.setattr("app.repositories.database.adapt_sql", lambda sql: sql)
@@ -77,6 +93,58 @@ def test_list_sessions_uses_agent_sessions_summary(monkeypatch):
     assert session["first_message"] == "first prompt"
 
 
+def test_list_sessions_hides_autonomous_tracking_wrappers(monkeypatch):
+    tracking_row = {
+        "id": 1,
+        "session_id": "track-123",
+        "session_type": "workflow",
+        "title": "Autonomous: wf-1",
+        "tool_name": "claude",
+        "host_name": "localhost",
+        "user_id": 7,
+        "status": "completed",
+        "total_tokens": 120,
+        "total_input_tokens": 80,
+        "total_output_tokens": 40,
+        "message_count": 2,
+        "request_count": 1,
+        "model": "claude-sonnet",
+        "created_at": datetime(2026, 6, 18, 0, 0, 0),
+        "updated_at": datetime(2026, 6, 18, 0, 5, 0),
+        "completed_at": None,
+        "expires_at": None,
+        "project_path": "/tmp/project",
+        "workspace_type": "local",
+        "remote_machine_id": None,
+        "cli_session_id": "actual-claude-123",
+        "context": '{"workflow_id": "wf-1"}',
+    }
+    provider_row = {
+        **tracking_row,
+        "id": 2,
+        "session_id": "actual-claude-123",
+        "session_type": "chat",
+        "title": "claude - actual",
+        "cli_session_id": "",
+    }
+    fake_db = _FakeListDatabase([tracking_row, provider_row])
+
+    monkeypatch.setattr("app.repositories.database.Database", lambda: fake_db)
+    monkeypatch.setattr("app.repositories.database.adapt_sql", lambda sql: sql)
+    monkeypatch.setattr("app.repositories.database.escape_like", lambda value: value)
+    monkeypatch.setattr("app.repositories.database.get_param_placeholder", lambda: "?")
+    monkeypatch.setattr("app.repositories.database.is_postgresql", lambda: False)
+
+    app = _make_app()
+    with app.test_request_context("/api/workspace/sessions?page=1&limit=20"):
+        g.user = {"id": 7, "role": "user"}
+        response = workspace_route.list_sessions()
+
+    payload = response.get_json()
+    sessions = payload["data"]["sessions"]
+    assert [session["session_id"] for session in sessions] == ["actual-claude-123"]
+
+
 def test_get_session_keeps_agent_sessions_request_count(monkeypatch):
     session = AgentSession(
         session_id="sess-1125-detail",
@@ -92,7 +160,14 @@ def test_get_session_keeps_agent_sessions_request_count(monkeypatch):
             SessionMessage(session_id="sess-1125-detail", role="assistant", content="turn 2"),
         ],
     )
-    manager = SimpleNamespace(get_session=lambda session_id, include_messages=False: session)
+    manager = SimpleNamespace(
+        get_session=lambda session_id, include_messages=False: session,
+        get_messages_page=lambda session_id, limit=None, milestone_id=None: {
+            "messages": session.messages,
+            "has_more": False,
+            "next_cursor": None,
+        },
+    )
 
     monkeypatch.setattr(workspace_route, "get_session_manager", lambda: manager)
     monkeypatch.setattr("app.repositories.database.Database", lambda: SimpleNamespace())

--- a/tests/issues/1125/test_workspace_session_summary_contract.py
+++ b/tests/issues/1125/test_workspace_session_summary_contract.py
@@ -24,7 +24,8 @@ class _FakeListDatabase:
             return self._visible_rows(query)
         if "FROM session_messages" in query and "role = 'user'" in query:
             return [
-                {"session_id": row["session_id"], "content": "first prompt"} for row in self.session_rows
+                {"session_id": row["session_id"], "content": "first prompt"}
+                for row in self.session_rows
             ]
         raise AssertionError(f"Unexpected fetch_all query: {query}")
 

--- a/tests/issues/716/test_agent_runner.py
+++ b/tests/issues/716/test_agent_runner.py
@@ -315,8 +315,16 @@ class TestAgentRunnerRunTask:
             for call in self.sm.update_session_fields.call_args_list
             if len(call.args) >= 2 and isinstance(call.args[1], dict) and "context" in call.args[1]
         ]
+        field_updates = [
+            call.args[1]
+            for call in self.sm.update_session_fields.call_args_list
+            if len(call.args) >= 2 and isinstance(call.args[1], dict)
+        ]
         assert any(
             (ctx or {}).get("cli_session_id") == "real-claude-session" for ctx in context_updates
+        )
+        assert any(
+            update.get("cli_session_id") == "real-claude-session" for update in field_updates
         )
 
     def test_local_claude_waits_for_late_session_detection(self):

--- a/tests/issues/716/test_autonomous_api.py
+++ b/tests/issues/716/test_autonomous_api.py
@@ -641,6 +641,7 @@ class TestGetTimeline:
         assert resp.status_code == 200
         data = resp.get_json()
         assert len(data["milestones"]) == 2
+        assert data["milestones"][0]["tracking_llm_session_id"] == "sess-plan"
         assert data["milestones"][0]["llm_session_id"] == "sess-plan"
         assert data["milestones"][0]["actual_llm_session_id"] == "sess-plan"
         assert data["milestones"][0]["llm_total_tokens"] == 1234
@@ -678,6 +679,7 @@ class TestGetTimeline:
 
         assert resp.status_code == 200
         data = resp.get_json()
+        assert data["milestones"][0]["tracking_llm_session_id"] == "track-1"
         assert data["milestones"][0]["llm_session_id"] == "track-1"
         assert data["milestones"][0]["actual_llm_session_id"] == "actual-claude-1"
 

--- a/tests/issues/723/test_milestone_session_link.py
+++ b/tests/issues/723/test_milestone_session_link.py
@@ -1,13 +1,9 @@
-"""Tests for milestone card session-id linking (issue #723, group D).
+"""Tests for milestone session identity on autonomous session lines.
 
-The milestone card's "view session" should point to the REAL claude session id,
-not the per-call wrapper uuid. Without this, all milestones sharing a session
-line (e.g. plan_created/plan_refined/dev on the "main" line) showed DIFFERENT
-ids (each call's wrapper uuid) even though they ran in the same claude session,
-and the card pointed to a session with no transcript.
-
-The fix: _run_agent links the milestone via result.source_session_id (the real
-cli session) with fallback to result.session_id (wrapper).
+Milestones should persist the stable workflow tracking session id for the
+main/review/test line. The UI resolves the real provider transcript later via
+agent_sessions.cli_session_id, so workflow_milestones never mixes tracking ids
+with provider ids.
 """
 
 from unittest.mock import MagicMock, patch
@@ -66,17 +62,17 @@ def _make_orchestrator(wf_data, milestones=None):
         return orch, mock_repo
 
 
-class TestMilestoneLinksRealCliSession:
-    def test_card_links_to_source_session_id_when_available(self):
-        """When result.source_session_id (real cli session) is set, the milestone
-        card is linked to it, not the wrapper uuid."""
+class TestMilestoneTracksWorkflowSession:
+    def test_sidebar_sessions_link_milestone_to_tracking_id(self):
+        """Claude workflow milestones keep the stable tracking session id."""
         from app.modules.workspace.autonomous.models import AgentTaskResult
 
         wf = _make_workflow()
         orch, mock_repo = _make_orchestrator(wf)
         orch._runner = MagicMock()
         orch._runner._uses_sidebar_session_source.return_value = True
-        # result carries BOTH: session_id (wrapper) and source_session_id (real cli)
+        # result carries BOTH: session_id (tracking wrapper) and
+        # source_session_id (real provider session)
         orch._runner.run_agent_task.return_value = AgentTaskResult(
             session_id="wrapper-uuid-1",
             tracking_session_id="wrapper-uuid-1",
@@ -115,13 +111,10 @@ class TestMilestoneLinksRealCliSession:
         linked_id = link_calls[0][0][1].get("session_id") or link_calls[0][0][1].get(
             "review_session_id"
         )
-        assert (
-            linked_id == "real-cli-session-4448"
-        ), "card must link to the real cli session id, not the wrapper uuid"
+        assert linked_id == "wrapper-uuid-1"
 
-    def test_card_falls_back_to_wrapper_when_no_source(self):
-        """When source_session_id is empty (e.g. session not yet resolved),
-        fall back to the wrapper uuid so the card still links somewhere."""
+    def test_sidebar_sessions_keep_tracking_id_when_provider_not_resolved(self):
+        """If provider resolution is missing, milestone still keeps tracking id."""
         from app.modules.workspace.autonomous.models import AgentTaskResult
 
         wf = _make_workflow()
@@ -163,4 +156,4 @@ class TestMilestoneLinksRealCliSession:
         linked_id = link_calls[0][0][1].get("session_id") or link_calls[0][0][1].get(
             "review_session_id"
         )
-        assert linked_id == "wrapper-uuid-2", "fallback to wrapper uuid when no real cli session"
+        assert linked_id == "wrapper-uuid-2"

--- a/tests/unit/test_autonomous_timeline_session_identity.py
+++ b/tests/unit/test_autonomous_timeline_session_identity.py
@@ -1,0 +1,64 @@
+from unittest.mock import MagicMock, patch
+
+
+def test_enrich_milestones_keeps_tracking_id_and_resolves_actual_provider():
+    from app.routes import autonomous as autonomous_route
+
+    milestone = {
+        "milestone_id": "ms-1",
+        "session_id": "track-main-1",
+        "review_session_id": "",
+        "phase_total_tokens": 321,
+        "phase_request_count": 4,
+    }
+
+    repo = MagicMock()
+    repo.get_milestone_usage_summary.return_value = {
+        "ms-1": {
+            "llm_session_id": "track-main-1",
+            "llm_total_tokens": 321,
+            "llm_request_count": 4,
+        }
+    }
+
+    session_row = MagicMock()
+    session_row.cli_session_id = "actual-claude-1"
+
+    with patch.object(autonomous_route, "auto_repo", repo):
+        with patch("app.modules.workspace.session_manager.SessionManager") as mock_sm_cls:
+            mock_sm = MagicMock()
+            mock_sm.get_session.return_value = session_row
+            mock_sm_cls.return_value = mock_sm
+
+            enriched = autonomous_route._enrich_milestones_with_usage("wf-1", [milestone])
+
+    assert enriched[0]["tracking_llm_session_id"] == "track-main-1"
+    assert enriched[0]["llm_session_id"] == "track-main-1"
+    assert enriched[0]["actual_llm_session_id"] == "actual-claude-1"
+    assert enriched[0]["llm_total_tokens"] == 321
+    assert enriched[0]["llm_request_count"] == 4
+
+
+def test_enrich_milestones_falls_back_to_tracking_id_without_mapping():
+    from app.routes import autonomous as autonomous_route
+
+    milestone = {
+        "milestone_id": "ms-2",
+        "session_id": "track-main-2",
+        "review_session_id": "",
+    }
+
+    repo = MagicMock()
+    repo.get_milestone_usage_summary.return_value = {}
+
+    with patch.object(autonomous_route, "auto_repo", repo):
+        with patch("app.modules.workspace.session_manager.SessionManager") as mock_sm_cls:
+            mock_sm = MagicMock()
+            mock_sm.get_session.return_value = None
+            mock_sm_cls.return_value = mock_sm
+
+            enriched = autonomous_route._enrich_milestones_with_usage("wf-2", [milestone])
+
+    assert enriched[0]["tracking_llm_session_id"] == "track-main-2"
+    assert enriched[0]["llm_session_id"] == "track-main-2"
+    assert enriched[0]["actual_llm_session_id"] == "track-main-2"

--- a/tests/unit/test_workspace_modules.py
+++ b/tests/unit/test_workspace_modules.py
@@ -319,6 +319,26 @@ class TestSessionManager:
         result = session_manager.list_sessions(user_id=1)
         assert len(result["sessions"]) == 3
 
+    def test_list_sessions_hides_autonomous_tracking_wrappers(self, session_manager):
+        """Workflow tracking wrappers should not appear in user-facing lists."""
+        tracking = session_manager.create_session(
+            tool_name="claude",
+            user_id=1,
+            session_type=SessionType.WORKFLOW.value,
+            title="Autonomous wrapper",
+            context={"workflow_id": "wf-1"},
+        )
+        session_manager.update_session_fields(tracking.session_id, {"cli_session_id": "actual-123"})
+        session_manager.create_session(
+            tool_name="claude",
+            user_id=1,
+            session_id="actual-123",
+            title="Provider session",
+        )
+
+        result = session_manager.list_sessions(user_id=1)
+        assert [session.session_id for session in result["sessions"]] == ["actual-123"]
+
     def test_session_expiration(self, session_manager):
         """Test session expiration."""
         session = session_manager.create_session(tool_name="claude", expires_in_hours=1)
@@ -334,6 +354,27 @@ class TestSessionManager:
         stats = session_manager.get_session_stats(user_id=1)
         assert stats["total_sessions"] == 2
         assert stats["active_sessions"] == 2
+
+    def test_session_stats_ignore_autonomous_tracking_wrappers(self, session_manager):
+        """Summary counts should match the visible sessions list."""
+        tracking = session_manager.create_session(
+            tool_name="claude",
+            user_id=1,
+            session_type=SessionType.WORKFLOW.value,
+            title="Autonomous wrapper",
+            context={"workflow_id": "wf-1"},
+        )
+        session_manager.update_session_fields(tracking.session_id, {"cli_session_id": "actual-456"})
+        session_manager.create_session(
+            tool_name="claude",
+            user_id=1,
+            session_id="actual-456",
+            title="Provider session",
+        )
+
+        stats = session_manager.get_session_stats(user_id=1)
+        assert stats["total_sessions"] == 1
+        assert stats["active_sessions"] == 1
 
 
 # ==================== Tool Connector Tests ====================


### PR DESCRIPTION
## Summary
- keep autonomous workflow milestones pinned to tracking session ids and resolve provider transcript ids at read time
- expose `tracking_llm_session_id` in timeline payloads while preserving `actual_llm_session_id` for transcript viewing
- hide autonomous workflow tracking wrapper rows from Work session lists/stats so users only see provider sessions

## Testing
- `.venv/bin/python -m pytest tests/issues/723/test_milestone_session_link.py tests/issues/1125/test_workspace_session_summary_contract.py tests/unit/test_workspace_modules.py tests/unit/test_autonomous_timeline_session_identity.py`
- `.venv/bin/python -m pytest tests/issues/771/test_realtime_activity.py tests/issues/716/test_agent_runner.py`

## Notes
- `tests/issues/716/test_autonomous_api.py` is currently blocked in local app setup by an unrelated schema init error: `sqlite3.OperationalError: no such column: billing_cycle_end`.
