### PR TITLE
fix(db): use cursor in schema_init backfill helpers for PostgreSQL (#1663)

### DIFF
--- a/app/repositories/schema_init.py
+++ b/app/repositories/schema_init.py
@@ -195,36 +195,48 @@ def ensure_all_tables() -> None:
 
 def _column_exists(conn, table_name: str, column_name: str, dialect: str) -> bool:
     """Check if a column exists in a table."""
-    if dialect == "postgresql":
-        cursor = conn.execute(
-            """
-            SELECT 1 FROM information_schema.columns
-            WHERE table_name = %s AND column_name = %s
-            """,
-            (table_name, column_name),
-        )
-        return cursor.fetchone() is not None
-    else:
-        cursor = conn.execute(f"PRAGMA table_info({table_name})")
-        return any(row[1] == column_name for row in cursor.fetchall())
+    # Use an explicit cursor: psycopg2 connections have no .execute() (only
+    # cursors do), unlike sqlite3 connections. conn.cursor() works for both.
+    cursor = conn.cursor()
+    try:
+        if dialect == "postgresql":
+            cursor.execute(
+                """
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name = %s AND column_name = %s
+                """,
+                (table_name, column_name),
+            )
+            return cursor.fetchone() is not None
+        else:
+            cursor.execute(f"PRAGMA table_info({table_name})")
+            return any(row[1] == column_name for row in cursor.fetchall())
+    finally:
+        cursor.close()
 
 
 def _table_exists(conn, table_name: str, dialect: str) -> bool:
     """Check if a table exists."""
-    if dialect == "postgresql":
-        cursor = conn.execute(
-            """
-            SELECT 1 FROM information_schema.tables
-            WHERE table_schema = 'public' AND table_name = %s
-            """,
-            (table_name,),
-        )
-        return cursor.fetchone() is not None
-    else:
-        cursor = conn.execute(
-            f"SELECT 1 FROM sqlite_master WHERE type='table' AND name='{table_name}'"
-        )
-        return cursor.fetchone() is not None
+    # Use an explicit cursor (see _column_exists): psycopg2 connections have no
+    # .execute(), so conn.execute() only works on sqlite3.
+    cursor = conn.cursor()
+    try:
+        if dialect == "postgresql":
+            cursor.execute(
+                """
+                SELECT 1 FROM information_schema.tables
+                WHERE table_schema = 'public' AND table_name = %s
+                """,
+                (table_name,),
+            )
+            return cursor.fetchone() is not None
+        else:
+            cursor.execute(
+                f"SELECT 1 FROM sqlite_master WHERE type='table' AND name='{table_name}'"
+            )
+            return cursor.fetchone() is not None
+    finally:
+        cursor.close()
 
 
 def _backfill_missing_columns(conn, dialect: str) -> None:
@@ -236,6 +248,9 @@ def _backfill_missing_columns(conn, dialect: str) -> None:
     Issue #1663: Old SQLite databases missing these columns fail schema init.
     """
     is_postgres = dialect == "postgresql"
+    # Explicit cursor: psycopg2 connections have no .execute() (only cursors
+    # do), so the ALTERs below must run via a cursor on both dialects.
+    cursor = conn.cursor()
 
     # agent_sessions columns
     if _table_exists(conn, "agent_sessions", dialect):
@@ -255,7 +270,7 @@ def _backfill_missing_columns(conn, dialect: str) -> None:
                         sql += f" DEFAULT {default}::text"
                     else:
                         sql += f" DEFAULT {default}"
-                conn.execute(sql)
+                cursor.execute(sql)
         conn.commit()
 
     # session_messages columns
@@ -279,5 +294,7 @@ def _backfill_missing_columns(conn, dialect: str) -> None:
                         sql += f" DEFAULT {default}::text"
                     else:
                         sql += f" DEFAULT {default}"
-                conn.execute(sql)
+                cursor.execute(sql)
         conn.commit()
+
+    cursor.close()

--- a/tests/issues/1663/test_backfill_postgres_cursor.py
+++ b/tests/issues/1663/test_backfill_postgres_cursor.py
@@ -1,0 +1,147 @@
+"""Regression tests for the PostgreSQL path of schema_init helpers (#1663).
+
+The column-backfill helpers added in #1663 (``_table_exists``,
+``_column_exists``, ``_backfill_missing_columns``) originally called
+``conn.execute(...)`` directly. That works for sqlite3 (its Connection exposes
+``execute``) but NOT for psycopg2: a psycopg2 connection has no ``.execute()``
+attribute — only cursors do. On PostgreSQL the dev service crashed at startup:
+
+    AttributeError: 'psycopg2.extensions.connection' object has no attribute 'execute'
+
+These tests exercise the exact object shape that triggered the bug — a
+connection with ``.cursor()`` but NO ``.execute()`` (wrapped in the real
+``PgConnectionWrapper``) — so a revert to ``conn.execute()`` fails loudly.
+"""
+
+import pytest
+
+from app.repositories.database import PgConnectionWrapper
+from app.repositories.schema_init import _backfill_missing_columns, _column_exists, _table_exists
+
+
+class _FakePsycopg2Cursor:
+    """Records executed SQL into a shared list and answers the two
+    information_schema introspection queries the helpers issue."""
+
+    def __init__(self, tables, executed):
+        # tables: {table_name: set(column_names)} present in the "database".
+        self._tables = tables
+        self._executed = executed
+        self._fetch = None
+
+    def execute(self, sql, params=None):
+        sql = sql.strip()
+        self._executed.append(sql)
+        lower = sql.lower()
+        if "information_schema.tables" in lower:
+            # _table_exists: WHERE table_name = %s
+            table = params[0] if params else None
+            self._fetch = [(1,)] if table in self._tables else None
+        elif "information_schema.columns" in lower:
+            # _column_exists: WHERE table_name = %s AND column_name = %s
+            table, column = params
+            self._fetch = [(1,)] if column in self._tables.get(table, set()) else None
+        else:
+            # ALTER TABLE ... ADD COLUMN (or anything else): no row result.
+            self._fetch = None
+
+    def fetchone(self):
+        return self._fetch
+
+    def fetchall(self):
+        return self._fetch or []
+
+    def close(self):
+        pass
+
+
+class _FakePsycopg2Conn:
+    """Minimal psycopg2 connection stand-in.
+
+    It deliberately exposes NO ``execute`` attribute — exactly like a real
+    psycopg2 connection — so going through ``PgConnectionWrapper`` (whose
+    ``__getattr__`` delegates to this object) reproduces the AttributeError if
+    a helper ever calls ``conn.execute(...)`` again.
+    """
+
+    def __init__(self, tables):
+        self._tables = tables
+        self.executed = []  # shared across every cursor created here
+
+    def cursor(self, cursor_factory=None):
+        return _FakePsycopg2Cursor(self._tables, self.executed)
+
+    def commit(self):
+        pass
+
+    def rollback(self):
+        pass
+
+    def close(self):
+        pass
+
+
+def _pg_conn(tables):
+    """A PgConnectionWrapper around a cursor-only (psycopg2-shaped) fake."""
+    return PgConnectionWrapper(_FakePsycopg2Conn(tables))
+
+
+def _altered_columns(executed_sql):
+    """Extract the column names from recorded ALTER TABLE ... ADD COLUMN stmts."""
+    cols = []
+    for stmt in executed_sql:
+        if stmt.upper().startswith("ALTER TABLE") and "ADD COLUMN" in stmt.upper():
+            # "ALTER TABLE <t> ADD COLUMN <col> <type> [DEFAULT ...]"
+            after = stmt.upper().split("ADD COLUMN", 1)[1].strip().split()
+            if after:
+                cols.append(after[0].lower())
+    return cols
+
+
+class TestTableExistsPostgres:
+    def test_present_and_absent_tables(self):
+        conn = _pg_conn({"agent_sessions": {"id"}})
+        # Must NOT raise AttributeError (the #1663 regression on psycopg2).
+        assert _table_exists(conn, "agent_sessions", "postgresql") is True
+        assert _table_exists(conn, "does_not_exist", "postgresql") is False
+
+
+class TestColumnExistsPostgres:
+    def test_present_and_absent_columns(self):
+        conn = _pg_conn({"agent_sessions": {"id", "project_id"}})
+        assert _column_exists(conn, "agent_sessions", "project_id", "postgresql") is True
+        assert _column_exists(conn, "agent_sessions", "request_count", "postgresql") is False
+
+
+class TestBackfillMissingColumnsPostgres:
+    def test_adds_only_missing_columns(self):
+        # agent_sessions exists with project_path already present; the other
+        # backfill columns are missing and must be ALTERed in.
+        conn = _pg_conn({"agent_sessions": {"id", "project_path"}})
+        _backfill_missing_columns(conn, "postgresql")
+
+        altered = _altered_columns(conn._conn.executed)
+        # Missing ones are added ...
+        assert "project_id" in altered
+        assert "request_count" in altered
+        # ... the already-present one is skipped (no duplicate ALTER).
+        assert "project_path" not in altered
+
+    def test_skips_when_table_absent(self):
+        # Neither known table present: no introspection ALTERs, no crash.
+        conn = _pg_conn({})
+        _backfill_missing_columns(conn, "postgresql")
+        assert _altered_columns(conn._conn.executed) == []
+
+    def test_does_not_call_conn_execute(self):
+        """The defining guard: a psycopg2-shaped connection (no .execute())
+        must not blow up. Reverting to conn.execute() makes this raise."""
+        conn = _pg_conn({"agent_sessions": {"id"}})
+        # If any helper used conn.execute(), this would raise AttributeError.
+        _backfill_missing_columns(conn, "postgresql")
+        # Sanity: at least the table-existence introspection ran via cursor.
+        assert any("information_schema" in s.lower() for s in conn._conn.executed)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Problem

After pulling latest `main`, the dev service crashes on startup against PostgreSQL inside `ensure_all_tables()`:

```
File ".../app/repositories/schema_init.py", line 215, in _table_exists
    cursor = conn.execute(...)
AttributeError: 'psycopg2.extensions.connection' object has no attribute 'execute'
```

## Root cause

The column-backfill helpers introduced in #1663 (`_table_exists`, `_column_exists`, `_backfill_missing_columns`) called `conn.execute(...)` directly. `sqlite3` connections expose `.execute()`, but **psycopg2 connections do not — only cursors do**. The original #1663 work was validated on SQLite, so the PostgreSQL path was never exercised and silently regressed startup.

This went unnoticed because a long-running server process keeps its already-imported (pre-bug) code in memory; only a fresh start hits the broken path.

## Fix

Route all three helpers through `conn.cursor()` — matching the existing DDL loop already in `load_schema_from_file()` — so they work on both SQLite and PostgreSQL.

## Test

Adds `tests/issues/1663/test_backfill_postgres_cursor.py`, which exercises a **psycopg2-shaped connection** (has `.cursor()`, deliberately no `.execute()`) wrapped in the real `PgConnectionWrapper` — the exact object shape that triggered the crash. A revert to `conn.execute()` makes these tests raise `AttributeError`.

Verification:
- ✅ `python3 -m pytest tests/issues/1663/ ...` — 5 new tests pass
- ✅ Existing schema/db suites still green (`tests/issues/1273/`, `tests/unit/test_database_connection.py`, `tests/unit/test_schema_sync.py` — 38 passed)
- ✅ Stashed the fix → the 5 new tests **fail** with the exact `AttributeError` (true regression guard); restored → pass
- ✅ `scripts/manage.py --dev restart` — service boots cleanly on PostgreSQL, `GET /` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)
