### PR TITLE
fix: harden autonomous CI repair investigation (Issue #1574)

### DIFF
--- a/app/modules/workspace/autonomous/github_ops.py
+++ b/app/modules/workspace/autonomous/github_ops.py
@@ -18,6 +18,11 @@ from typing import Optional
 
 logger = logging.getLogger(__name__)
 
+_GITHUB_ACTIONS_JOB_URL_RE = re.compile(
+    r"https://github\.com/[^/]+/[^/]+/actions/runs/(?P<run_id>\d+)/job/(?P<job_id>\d+)"
+)
+_ANSI_ESCAPE_RE = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
+
 # Transient git/gh error retry — network blips (TLS, DNS, connection reset)
 # are common and recover within seconds. Fixed-interval retry is sufficient
 # because git operations are lightweight and idempotent; exponential backoff
@@ -906,6 +911,61 @@ class GitHubOps:
                 f"Failed to query CI checks for PR #{pr_number}: {detail}; "
                 f"REST fallback error: {api_err}"
             ) from api_err
+
+    @staticmethod
+    def _parse_github_actions_job_url(url: str) -> Optional[tuple[str, str]]:
+        """Extract GitHub Actions run/job ids from a check details URL."""
+        if not url:
+            return None
+        match = _GITHUB_ACTIONS_JOB_URL_RE.match(url.strip())
+        if not match:
+            return None
+        return match.group("run_id"), match.group("job_id")
+
+    @staticmethod
+    def _strip_ansi(text: str) -> str:
+        """Remove ANSI escape sequences from GitHub Actions logs."""
+        return _ANSI_ESCAPE_RE.sub("", text or "")
+
+    def get_check_failure_excerpt(
+        self, check: dict, max_lines: int = 80, max_chars: int = 4000
+    ) -> str:
+        """Fetch a concise failed-log excerpt for a CI check when available.
+
+        Currently supports GitHub Actions job URLs. Non-Actions URLs return an
+        empty string so callers can degrade gracefully for other CI providers.
+        """
+        parsed = self._parse_github_actions_job_url(str(check.get("link") or ""))
+        if not parsed:
+            return ""
+
+        run_id, job_id = parsed
+        result = self._run_gh(
+            ["run", "view", run_id, "--job", job_id, "--log-failed"],
+            check=False,
+        )
+        if result.returncode != 0:
+            logger.warning(
+                "Failed to fetch failed log excerpt for check '%s' (run=%s job=%s): %s",
+                check.get("name") or "unknown",
+                run_id,
+                job_id,
+                (result.stderr or result.stdout or "").strip()[:200],
+            )
+            return ""
+
+        cleaned = self._strip_ansi(result.stdout or "").strip()
+        if not cleaned:
+            return ""
+
+        lines = [line.rstrip() for line in cleaned.splitlines() if line.strip()]
+        if not lines:
+            return ""
+
+        excerpt = "\n".join(lines[-max_lines:]).strip()
+        if len(excerpt) > max_chars:
+            excerpt = excerpt[-max_chars:].lstrip()
+        return excerpt
 
     def get_pr_diff(self, number: int) -> str:
         """Get the full diff of a PR (head vs base) via `gh pr diff`.

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -1144,23 +1144,42 @@ class AutonomousOrchestrator:
             return ""
         return os.path.join(project_path, ".worktrees", workflow_id)
 
-    @staticmethod
-    def _build_ci_repair_context(pr_number: int, failed_checks: list[dict]) -> str:
-        """Summarize failed CI checks for the next development round prompt."""
-        lines = [f"PR #{pr_number} 在合并前检测到以下 CI 失败：", ""]
+    def _build_ci_repair_context(
+        self, wf: dict, gh: GitHubOps, pr_number: int, failed_checks: list[dict]
+    ) -> str:
+        """Summarize failed CI checks and require evidence-driven local investigation."""
+        lines = [
+            f"PR #{pr_number} 在合并前检测到以下 CI 失败。",
+            "请先根据失败日志复现问题，再修复；不能只跑“相关测试”就宣布已解决。",
+            "如果本轮没有产生新的代码改动，就不能视为修复完成。",
+            "请优先自行调查仓库中的 CI 定义与脚本来源，而不是依赖人工预先配置的规则。",
+            "",
+        ]
         for check in failed_checks or []:
             if check.get("bucket") != "fail":
                 continue
             state = check.get("state") or "unknown"
             link = check.get("link") or ""
-            bullet = f"- {check.get('name') or 'unknown'}: {state}"
+            name = check.get("name") or "unknown"
+            lines.append(f"### {name}")
+            lines.append(f"- 状态: {state}")
             if link:
-                bullet += f" ({link})"
-            lines.append(bullet)
+                lines.append(f"- 链接: {link}")
+
+            excerpt = gh.get_check_failure_excerpt(check)
+            if excerpt:
+                lines.append("- 失败摘录:")
+                lines.append("```text")
+                lines.append(excerpt)
+                lines.append("```")
+            lines.append("")
         lines.extend(
             [
-                "",
-                "请优先分析这些失败是否由当前分支引入，修复后重新运行相关测试，并确保修改已推送到当前工作分支。",
+                "调查要求：",
+                "1. 先查看 `.github/workflows/`、`package.json`、`Makefile`、`tox.ini`、`pytest.ini`、`scripts/` 等，确认失败 check 在仓库中对应哪条本地命令或脚本。",
+                "2. 优先用 CI 工作流里真实执行的命令在本地复现，而不是只挑选你认为“相关”的部分测试。",
+                "3. 修复后重新运行对应命令，以及你新增/修改代码的相关测试。",
+                "4. 只有在确实产生新代码提交后，才能宣布 CI 修复完成；如果没有代码改动，必须明确说明为什么 CI 会自动恢复。",
             ]
         )
         return "\n".join(lines).strip()
@@ -1521,7 +1540,7 @@ class AutonomousOrchestrator:
             return
 
         next_dev_round = dev_round + 1
-        context = self._build_ci_repair_context(pr_number, failed_checks)
+        context = self._build_ci_repair_context(wf, self._get_gh(), pr_number, failed_checks)
         self._create_milestone(
             phase="merge",
             dev_round=dev_round,
@@ -3077,11 +3096,18 @@ class AutonomousOrchestrator:
             )
         else:
             self._run_development_agent(wf, dev_round, gh)
+            wf = self.workflow or {}
+            if wf.get("status") == "failed":
+                logger.info(
+                    "Development round %d failed, skipping test phase for workflow %s",
+                    dev_round,
+                    self._workflow_id[:8],
+                )
+                return
             # Post development completion comment — but only if dev succeeded.
             # _run_development_agent sets status="failed" on failure; without
             # this guard, a "✅ Completed" comment is posted with a stale
             # commit that isn't the agent's work (#525).
-            wf = self.workflow or {}
             if wf.get("status") != "failed":
                 self._post_dev_completion_comment(wf, dev_round, gh)
 

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -1166,7 +1166,16 @@ class AutonomousOrchestrator:
             if link:
                 lines.append(f"- 链接: {link}")
 
-            excerpt = gh.get_check_failure_excerpt(check)
+            try:
+                excerpt = gh.get_check_failure_excerpt(check)
+            except Exception as exc:
+                logger.warning(
+                    "Failed to fetch CI failure excerpt for check '%s' in PR #%s: %s",
+                    name,
+                    pr_number,
+                    exc,
+                )
+                excerpt = ""
             if excerpt:
                 lines.append("- 失败摘录:")
                 lines.append("```text")
@@ -3108,8 +3117,7 @@ class AutonomousOrchestrator:
             # _run_development_agent sets status="failed" on failure; without
             # this guard, a "✅ Completed" comment is posted with a stale
             # commit that isn't the agent's work (#525).
-            if wf.get("status") != "failed":
-                self._post_dev_completion_comment(wf, dev_round, gh)
+            self._post_dev_completion_comment(wf, dev_round, gh)
 
         # ── Test phase (always runs) ──
         self._run_test_phase(wf, dev_round, gh)

--- a/tests/issues/1574/test_ci_repair_verifiers.py
+++ b/tests/issues/1574/test_ci_repair_verifiers.py
@@ -1,0 +1,107 @@
+"""Regression tests for evidence-driven CI repair flow (Issue #1574)."""
+
+from unittest.mock import MagicMock, patch
+
+
+def _make_workflow(**overrides):
+    base = {
+        "workflow_id": "wf-1574",
+        "user_id": 1,
+        "title": "issue-1574",
+        "status": "developing",
+        "requirements_text": "Fix CI",
+        "requirements_issue_url": "",
+        "project_path": "/tmp/repo",
+        "project_repo_url": "",
+        "is_new_project": False,
+        "cli_tool": "claude-code",
+        "model": "claude-sonnet-4-6",
+        "permission_mode": "auto-edit",
+        "branch_name": "auto-dev/wf-1574",
+        "branch_strategy": "worktree",
+        "workspace_type": "local",
+        "remote_machine_id": "",
+        "worktree_path": "/tmp/repo",
+        "preferred_worktree_path": "/tmp/repo",
+        "github_issue_number": 1574,
+        "github_pr_number": 1697,
+        "github_pr_url": "",
+        "current_phase": "development",
+        "current_round": 0,
+        "dev_round": 2,
+        "max_plan_rounds": 3,
+        "max_pr_review_rounds": 5,
+        "require_full_review_rounds": False,
+        "total_tokens": 0,
+        "total_input_tokens": 0,
+        "total_output_tokens": 0,
+        "total_requests": 0,
+        "error_message": "",
+    }
+    base.update(overrides)
+    return base
+
+
+def _make_orchestrator(wf_data):
+    from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+    with (
+        patch("app.modules.workspace.autonomous.orchestrator.Database"),
+        patch(
+            "app.modules.workspace.autonomous.orchestrator.AutonomousWorkflowRepository"
+        ) as mock_repo_cls,
+    ):
+        mock_repo = MagicMock()
+        mock_repo.get_workflow.return_value = wf_data
+        mock_repo.list_milestones.return_value = []
+        mock_repo.create_milestone.return_value = {
+            "milestone_id": "ms-1",
+            "workflow_id": wf_data["workflow_id"],
+        }
+        mock_repo.create_event.return_value = {"id": 1}
+        mock_repo.update_workflow.return_value = wf_data
+        mock_repo_cls.return_value = mock_repo
+
+        orch = AutonomousOrchestrator(wf_data["workflow_id"])
+        orch.repo = mock_repo
+        orch.emitter = MagicMock()
+    return orch, mock_repo
+
+
+def test_build_ci_repair_context_includes_failure_excerpt_and_investigation_steps():
+    wf = _make_workflow(project_path="/tmp/repo", worktree_path="/tmp/repo")
+    orch, _ = _make_orchestrator(wf)
+    gh = MagicMock()
+    gh.get_check_failure_excerpt.return_value = "black failed\nfiles were modified"
+
+    context = orch._build_ci_repair_context(
+        wf,
+        gh,
+        1697,
+        [{"name": "lint", "state": "failure", "bucket": "fail", "link": "https://example.com"}],
+    )
+
+    assert "black failed" in context
+    assert ".github/workflows/" in context
+    assert "package.json" in context
+    assert "不能只跑“相关测试”就宣布已解决" in context
+
+
+def test_do_development_skips_test_phase_when_dev_failed():
+    wf = _make_workflow()
+    failed_wf = dict(wf, status="failed", error_message="Development failed")
+    orch, mock_repo = _make_orchestrator(wf)
+    mock_repo.get_workflow.return_value = wf
+
+    def fail_dev(*_args, **_kwargs):
+        mock_repo.get_workflow.return_value = failed_wf
+
+    orch._get_gh = MagicMock(return_value=MagicMock())
+    orch._run_development_agent = MagicMock(side_effect=fail_dev)
+    orch._post_dev_completion_comment = MagicMock()
+    orch._run_test_phase = MagicMock()
+
+    orch._do_development(wf)
+
+    orch._post_dev_completion_comment.assert_not_called()
+    orch._run_test_phase.assert_not_called()

--- a/tests/issues/913/test_pr909_review_feedback.py
+++ b/tests/issues/913/test_pr909_review_feedback.py
@@ -135,7 +135,7 @@ class TestGetCheckFailureExcerpt:
             return_value=MagicMock(
                 returncode=0,
                 stdout=(
-                    "lint\tSTEP\t\\x1b[31mblack....................................................................Failed\\x1b[0m\n"
+                    "lint\tSTEP\t\x1b[31mblack....................................................................Failed\x1b[0m\n"
                     "lint\tSTEP\tfiles were modified by this hook\n"
                 ),
                 stderr="",
@@ -151,6 +151,22 @@ class TestGetCheckFailureExcerpt:
 
         assert "black" in excerpt
         assert "\x1b" not in excerpt
+
+    def test_ci_repair_context_skips_excerpt_failure(self):
+        gh = MagicMock()
+        gh.get_check_failure_excerpt.side_effect = RuntimeError("timeout")
+        orch = MagicMock()
+
+        context = AutonomousOrchestrator._build_ci_repair_context(
+            orch,
+            {"project_path": "/tmp/repo", "worktree_path": "/tmp/repo"},
+            gh,
+            42,
+            [{"name": "lint", "state": "failure", "bucket": "fail", "link": "https://example.com"}],
+        )
+
+        assert "### lint" in context
+        assert "失败摘录" not in context
 
 
 # ── Test _poll_ci_status ────────────────────────────────────────────────

--- a/tests/issues/913/test_pr909_review_feedback.py
+++ b/tests/issues/913/test_pr909_review_feedback.py
@@ -116,6 +116,43 @@ class TestGetPRChecks:
             gh.get_pr_checks(42)
 
 
+class TestGetCheckFailureExcerpt:
+    """Test GitHub Actions failed-log excerpt extraction."""
+
+    def test_parses_actions_job_url(self):
+        parsed = GitHubOps._parse_github_actions_job_url(
+            "https://github.com/open-ace/open-ace/actions/runs/123/job/456"
+        )
+        assert parsed == ("123", "456")
+
+    def test_returns_empty_for_non_actions_url(self):
+        gh = GitHubOps("/tmp/fake")
+        assert gh.get_check_failure_excerpt({"link": "https://example.com/build/42"}) == ""
+
+    def test_fetches_failed_log_excerpt(self):
+        gh = GitHubOps("/tmp/fake")
+        gh._run_gh = MagicMock(
+            return_value=MagicMock(
+                returncode=0,
+                stdout=(
+                    "lint\tSTEP\t\\x1b[31mblack....................................................................Failed\\x1b[0m\n"
+                    "lint\tSTEP\tfiles were modified by this hook\n"
+                ),
+                stderr="",
+            )
+        )
+
+        excerpt = gh.get_check_failure_excerpt(
+            {
+                "name": "lint",
+                "link": "https://github.com/open-ace/open-ace/actions/runs/123/job/456",
+            }
+        )
+
+        assert "black" in excerpt
+        assert "\x1b" not in excerpt
+
+
 # ── Test _poll_ci_status ────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary
- capture GitHub Actions failed-log excerpts for CI repair rounds
- make CI repair prompts evidence-driven so agents inspect real CI workflow/scripts before claiming a fix
- stop autonomous workflows from entering the test phase after development has already failed
- add regression coverage for failed-log extraction, CI repair prompting, and dev-failure short-circuiting

## Testing
- `.venv/bin/python -m black --check app/modules/workspace/autonomous/github_ops.py app/modules/workspace/autonomous/orchestrator.py tests/issues/913/test_pr909_review_feedback.py tests/issues/1574/test_ci_repair_verifiers.py`
- `.venv/bin/python -m ruff check app/modules/workspace/autonomous/github_ops.py app/modules/workspace/autonomous/orchestrator.py tests/issues/913/test_pr909_review_feedback.py tests/issues/1574/test_ci_repair_verifiers.py`
- `.venv/bin/python -m pytest tests/issues/913/test_pr909_review_feedback.py tests/issues/1574/test_ci_repair_verifiers.py tests/issues/822/test_merge_conflict_detection.py tests/issues/1277/test_test_skip_false_positive.py -q`
