### PR TITLE
fix: keep CI repair in merge phase (Issue #1574)

### DIFF
--- a/app/modules/workspace/autonomous/__init__.py
+++ b/app/modules/workspace/autonomous/__init__.py
@@ -96,7 +96,8 @@ def get_ddl_statements():
             system_account TEXT DEFAULT '',
             ci_repair_context TEXT DEFAULT '',
             ci_repair_attempts INTEGER DEFAULT 0,
-            last_ci_failure_signature TEXT DEFAULT ''
+            last_ci_failure_signature TEXT DEFAULT '',
+            last_ci_failure_head_sha TEXT DEFAULT ''
         )
         """,
     ]
@@ -142,6 +143,9 @@ def get_ddl_statements():
     )
     statements.append(
         "ALTER TABLE autonomous_workflows ADD COLUMN last_ci_failure_signature TEXT DEFAULT ''"
+    )
+    statements.append(
+        "ALTER TABLE autonomous_workflows ADD COLUMN last_ci_failure_head_sha TEXT DEFAULT ''"
     )
     statements.extend(
         [

--- a/app/modules/workspace/autonomous/github_ops.py
+++ b/app/modules/workspace/autonomous/github_ops.py
@@ -819,6 +819,10 @@ class GitHubOps:
         data = json.loads((result.stdout or "").strip() or "{}")
         return ((data.get("head") or {}).get("sha") or "").strip()
 
+    def get_pr_head_sha(self, pr_number: int) -> str:
+        """Return the current head SHA for a PR."""
+        return self._get_pr_head_sha(pr_number)
+
     def _get_pr_checks_via_api(self, pr_number: int) -> list:
         repo = self.get_repo_name()
         head_sha = self._get_pr_head_sha(pr_number)

--- a/app/modules/workspace/autonomous/models.py
+++ b/app/modules/workspace/autonomous/models.py
@@ -67,6 +67,7 @@ class AutonomousWorkflow:
     ci_repair_context: str = ""
     ci_repair_attempts: int = 0
     last_ci_failure_signature: str = ""
+    last_ci_failure_head_sha: str = ""
     # Source of truth for AI-authored content language (en/zh/ja/ko). Set once
     # at creation; persisted content is generated in this language and rendered
     # verbatim (it does NOT switch per viewer). System-authored structured
@@ -140,6 +141,7 @@ class AutonomousWorkflow:
             "ci_repair_context": self.ci_repair_context,
             "ci_repair_attempts": self.ci_repair_attempts,
             "last_ci_failure_signature": self.last_ci_failure_signature,
+            "last_ci_failure_head_sha": self.last_ci_failure_head_sha,
             "content_language": self.content_language,
             "created_at": self.created_at.isoformat() if self.created_at else None,
             "updated_at": self.updated_at.isoformat() if self.updated_at else None,
@@ -195,6 +197,7 @@ class AutonomousWorkflow:
             ci_repair_context=data.get("ci_repair_context", ""),
             ci_repair_attempts=data.get("ci_repair_attempts", 0),
             last_ci_failure_signature=data.get("last_ci_failure_signature", ""),
+            last_ci_failure_head_sha=data.get("last_ci_failure_head_sha", ""),
             content_language=data.get("content_language", "en"),
             created_at=(
                 datetime.fromisoformat(data["created_at"]) if data.get("created_at") else None

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -1194,7 +1194,7 @@ class AutonomousOrchestrator:
         return "\n".join(lines).strip()
 
     def _get_ci_repair_prompt(self, wf: dict) -> str:
-        """Return merge-phase CI repair context for development, or empty."""
+        """Return merge-phase CI repair context, or empty."""
         context = wf.get("ci_repair_context", "")
         if not context or not context.strip():
             return ""
@@ -1203,6 +1203,194 @@ class AutonomousOrchestrator:
             "当前轮次是因为 PR 在合并阶段检测到 CI 失败而回流，请优先处理以下问题：\n"
             f"{context}\n\n"
         )
+
+    def _run_merge_ci_repair(
+        self, wf: dict, gh: GitHubOps, pr_number: int, failed_checks: list[dict]
+    ) -> None:
+        """Repair CI failures for an existing PR in-place during merge phase."""
+        dev_round = int(wf.get("dev_round", 1) or 1)
+        attempt = int(wf.get("ci_repair_attempts", 0) or 0)
+        branch_name = wf.get("branch_name", "")
+        issue_number = wf.get("github_issue_number") or self.workflow.get("github_issue_number")
+
+        repair_ms = self._create_milestone(
+            phase="merge",
+            dev_round=dev_round,
+            milestone_type="ci_repair_applied",
+            status="in_progress",
+            title=f"CI repair attempt {attempt} for PR #{pr_number}",
+        )
+
+        repair_prompt = (
+            AUTONOMOUS_CONTEXT
+            + "当前任务是在已有 PR 上修复 merge 阶段失败的 CI，不是开始新一轮完整开发。\n\n"
+        )
+        if issue_number:
+            repair_prompt += (
+                f"## 关联 Issue\n"
+                f"本任务关联 GitHub Issue #{issue_number}。\n"
+                f"修复时请确保修改继续满足 Issue #{issue_number} 的所有需求。\n\n"
+            )
+        repair_prompt += (
+            "## 重要约束\n"
+            "1. 保持在当前工作分支上修复，不要创建新的 PR，不要切换到其他分支。\n"
+            "2. 不要进入新的代码审查、进度汇报或等待流程；当前唯一目标是让现有 PR 的 CI 通过。\n"
+            "3. 必须优先根据 CI 工作流、失败日志摘录和仓库脚本定位问题，复现 CI 真实执行的命令。\n"
+            "4. 修复后重新运行对应命令，以及你改动涉及到的必要相关测试。\n"
+            "5. 只有在确实产生代码或配置修改后，才能提交 git commit 并推送到当前 PR 分支。\n"
+            "6. 结束时请明确说明：你复现了哪些命令、修复了什么、还剩什么风险。\n"
+        )
+        repair_prompt += self._get_ci_repair_prompt(wf)
+        if failed_checks:
+            failure_list = "\n".join(
+                f"- **{check.get('name') or 'unknown'}**: {check.get('state') or 'unknown'}"
+                for check in failed_checks
+                if check.get("bucket") == "fail"
+            )
+            if failure_list:
+                repair_prompt += f"## 当前失败检查\n{failure_list}\n\n"
+        repair_prompt += self._get_user_feedback_prompt(wf)
+
+        commit_before = ""
+        try:
+            commit_before = gh.get_current_commit()
+        except Exception:
+            pass
+
+        repair_result = self._run_agent(
+            wf=wf,
+            workflow_id=self._workflow_id,
+            cli_tool=wf.get("cli_tool", "claude-code"),
+            model=wf.get("model", ""),
+            project_path=wf.get("worktree_path") or wf.get("project_path", ""),
+            prompt=repair_prompt,
+            workspace_type=wf.get("workspace_type", "local"),
+            remote_machine_id=wf.get("remote_machine_id"),
+            permission_mode=wf.get("permission_mode", "auto-edit"),
+            allowed_tools=AUTONOMOUS_DEV_ALLOWED_TOOLS.get(wf.get("cli_tool", "claude-code"), []),
+            session_line="main",
+            timeout=int(wf.get("task_timeout") or DEFAULT_TASK_TIMEOUT),
+            milestone_id=repair_ms.get("milestone_id", ""),
+        )
+
+        if not hasattr(self._gh, "mock_calls"):
+            self._gh = None
+        gh = self._get_gh()
+
+        try:
+            current_branch = gh.get_current_branch()
+            if branch_name and current_branch != branch_name:
+                message = (
+                    f"CI repair changed workflow branch unexpectedly: expected {branch_name}, "
+                    f"actual {current_branch}"
+                )
+                self.repo.update_milestone(
+                    repair_ms.get("milestone_id", ""),
+                    {
+                        "status": "failed",
+                        "error_message": message,
+                    },
+                )
+                self._update_workflow({"status": "failed", "error_message": message})
+                return
+        except Exception as e:
+            logger.warning("Failed to verify branch after CI repair: %s", e)
+
+        if wf.get("user_feedback", "").strip():
+            self._update_workflow({"user_feedback": ""})
+
+        self._accumulate_tokens(repair_result)
+
+        commit_sha = ""
+        diff_stats = {}
+        push_error = ""
+        try:
+            commit_sha = gh.get_current_commit()
+        except Exception:
+            pass
+        sha_changed = bool(commit_before and commit_sha and commit_before != commit_sha)
+
+        if not sha_changed:
+            try:
+                if gh.has_uncommitted_changes():
+                    gh.git_add_all()
+                    gh.git_commit(
+                        f"auto: ci repair (attempt {attempt})",
+                        no_verify=True,
+                    )
+                    commit_sha = gh.get_current_commit()
+                    sha_changed = bool(commit_before and commit_sha and commit_before != commit_sha)
+            except Exception as e:
+                logger.warning("CI repair auto-commit failed: %s", e)
+
+        if sha_changed:
+            try:
+                gh.git_push(branch=branch_name or None)
+            except Exception as e:
+                push_error = str(e)
+                logger.warning("CI repair git_push failed for PR #%s: %s", pr_number, e)
+
+        try:
+            diff_stats = gh.get_commit_diff_stats(commit_sha) if commit_sha else {}
+        except Exception:
+            pass
+
+        salvaged = (not repair_result.success) and sha_changed and not push_error
+        summary = self._build_dev_result_summary(
+            self._artifact_text(repair_result),
+            diff_stats,
+            commit_sha,
+            repair_result.success or salvaged,
+        )
+
+        milestone_updates = {
+            "status": "completed" if (repair_result.success or salvaged) else "failed",
+            "session_id": repair_result.session_id,
+            "commit_shas": json.dumps([commit_sha] if commit_sha else []),
+            "diff_stats": json.dumps(diff_stats),
+            "result_summary": summary,
+            "tldr": self._artifact_tldr(repair_result),
+            "error_message": "",
+        }
+
+        if push_error:
+            message = f"CI repair failed to push branch '{branch_name}': {push_error}"
+            milestone_updates["status"] = "failed"
+            milestone_updates["error_message"] = message
+            self.repo.update_milestone(repair_ms.get("milestone_id", ""), milestone_updates)
+            self._update_workflow({"status": "failed", "error_message": message})
+            return
+
+        if not sha_changed:
+            message = "CI repair failed: agent produced no code changes"
+            milestone_updates["status"] = "failed"
+            milestone_updates["error_message"] = message
+            self.repo.update_milestone(repair_ms.get("milestone_id", ""), milestone_updates)
+            self._update_workflow({"status": "failed", "error_message": message})
+            return
+
+        if not repair_result.success and not salvaged:
+            message = f"CI repair failed: {repair_result.error}"
+            milestone_updates["status"] = "failed"
+            milestone_updates["error_message"] = message
+            self.repo.update_milestone(repair_ms.get("milestone_id", ""), milestone_updates)
+            self._update_workflow({"status": "failed", "error_message": message})
+            return
+
+        self.repo.update_milestone(repair_ms.get("milestone_id", ""), milestone_updates)
+        self._update_workflow({"current_phase": "merge", "status": "merging", "error_message": ""})
+
+        repair_comment = (
+            f"## 🔧 CI Repair Attempt {attempt}\n\n"
+            f"- PR: #{pr_number}\n"
+            f"- Branch: `{branch_name}`\n"
+        )
+        if commit_sha:
+            repair_comment += f"- Commit: `{commit_sha[:8]}`\n"
+        repair_comment += "\n已推送修复提交，等待 GitHub CI 重新运行。\n"
+        if summary:
+            repair_comment += f"\n### 修复摘要\n{summary}\n"
+        self._post_github_comment(gh, pr_number, repair_comment, is_pr=True, context="ci-repair")
 
     @staticmethod
     def _clean_agent_text(text: str) -> str:
@@ -1506,20 +1694,36 @@ class AutonomousOrchestrator:
             time.sleep(CI_POLL_INTERVAL)
 
     def _start_ci_repair_round(self, wf: dict, pr_number: int, failed_checks: list[dict]) -> None:
-        """Route merge-phase CI failures back into a new development round."""
+        """Repair merge-phase CI failures in-place on the existing PR branch."""
         dev_round = int(wf.get("dev_round", 1) or 1)
         previous_attempts = int(wf.get("ci_repair_attempts", 0) or 0)
         next_attempt = previous_attempts + 1
         signature = self._ci_failure_signature(failed_checks)
         previous_signature = (wf.get("last_ci_failure_signature") or "").strip()
+        previous_head_sha = (wf.get("last_ci_failure_head_sha") or "").strip()
         failure_names = ", ".join(
             check.get("name") or "unknown"
             for check in failed_checks
             if check.get("bucket") == "fail"
         )
         preferred_worktree_path = self._get_preferred_worktree_path(wf)
+        gh = self._get_gh()
+        current_head_sha = ""
+        try:
+            current_head_sha = gh.get_pr_head_sha(pr_number)
+        except Exception as e:
+            logger.warning(
+                "Failed to resolve PR head SHA for CI repair on PR #%s: %s", pr_number, e
+            )
 
-        if previous_signature and signature and previous_signature == signature:
+        if (
+            previous_signature
+            and signature
+            and previous_signature == signature
+            and previous_head_sha
+            and current_head_sha
+            and previous_head_sha != current_head_sha
+        ):
             message = f"PR #{pr_number} CI 失败在自动修复后仍未变化: {failure_names or signature}"
             self._create_milestone(
                 phase="merge",
@@ -1548,36 +1752,31 @@ class AutonomousOrchestrator:
             self._update_workflow({"status": "failed", "error_message": message})
             return
 
-        next_dev_round = dev_round + 1
-        context = self._build_ci_repair_context(wf, self._get_gh(), pr_number, failed_checks)
+        context = self._build_ci_repair_context(wf, gh, pr_number, failed_checks)
         self._create_milestone(
             phase="merge",
             dev_round=dev_round,
             milestone_type="ci_repair_started",
             status="completed",
-            title=f"CI failed for PR #{pr_number}, restarting development round {next_dev_round}",
+            title=f"CI failed for PR #{pr_number}, starting merge repair attempt {next_attempt}",
             result_summary=context[:200],
         )
         updates = {
-            "current_phase": "development",
-            "status": "developing",
-            "current_round": 0,
-            "dev_round": next_dev_round,
+            "current_phase": "merge",
+            "status": "merging",
             "agent_pid": None,
             "agent_session_id": "",
-            "test_retries": 0,
-            "skip_retries": 0,
-            "dev_retries_on_test_fail": 0,
             "error_message": "",
             "ci_repair_attempts": next_attempt,
             "ci_repair_context": context,
             "last_ci_failure_signature": signature,
+            "last_ci_failure_head_sha": current_head_sha,
         }
         if wf.get("branch_strategy") == "worktree" and preferred_worktree_path:
             updates["preferred_worktree_path"] = preferred_worktree_path
             updates["worktree_path"] = preferred_worktree_path
         self._update_workflow(updates)
-        self._emit("phase_change", {"phase": "development"})
+        self._run_merge_ci_repair(self.workflow or wf, gh, pr_number, failed_checks)
 
     def _update_workflow(self, updates: dict):
         """Update workflow and emit event."""

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -1273,8 +1273,7 @@ class AutonomousOrchestrator:
             milestone_id=repair_ms.get("milestone_id", ""),
         )
 
-        if not hasattr(self._gh, "mock_calls"):
-            self._gh = None
+        self._gh = None
         gh = self._get_gh()
 
         try:
@@ -3469,8 +3468,7 @@ class AutonomousOrchestrator:
         )
 
         # P2 修复（Issue #1611）：开发完成后重置 gh 缓存，重新绑定到正确路径
-        if not hasattr(self._gh, "mock_calls"):
-            self._gh = None
+        self._gh = None
         gh = self._get_gh()
 
         # 严格校验：自主开发不能悄悄切到其他分支
@@ -5129,6 +5127,11 @@ class AutonomousOrchestrator:
         scheduler retries in ~10s. This avoids hogging a workflow thread for
         the full CI duration (10+ min for Python 3.9) and naturally adapts
         to variable CI times without --admin bypass or long polls.
+
+        Note: an automatic CI repair attempt runs synchronously in this phase
+        on the existing PR branch. That intentionally spends one merge worker
+        for the repair task, but avoids bouncing the workflow back through the
+        full development/test/review/report loop.
         """
         gh = self._get_gh()
         pr_number = wf.get("github_pr_number")

--- a/app/repositories/autonomous_repo.py
+++ b/app/repositories/autonomous_repo.py
@@ -149,13 +149,15 @@ class AutonomousWorkflowRepository:
         try:
             cursor = conn.cursor()
             cursor.execute(
-                adapt_sql(f"""
+                adapt_sql(
+                    f"""
                     SELECT workflow_id, agent_pid, status
                     FROM autonomous_workflows
                     WHERE agent_pid IS NOT NULL
                       AND agent_pid > 0
                       AND status IN ({placeholders})
-                    """),
+                    """
+                ),
                 list(active_statuses),
             )
             cols = [d[0] for d in cursor.description]
@@ -443,12 +445,14 @@ class AutonomousWorkflowRepository:
 
     def get_active_workflows(self) -> list:
         """Get all workflows that need processing."""
-        return self.db.fetch_all("""
+        return self.db.fetch_all(
+            """
             SELECT * FROM autonomous_workflows
             WHERE status IN ('pending', 'preparing', 'planning', 'developing',
                              'pr_review', 'reporting', 'waiting', 'merging')
             ORDER BY created_at ASC
-            """)
+            """
+        )
 
     def get_paused_workflows(self, quota_prefix: str = "") -> list:
         """Get paused workflows, optionally filtered to a quota-pause reason.
@@ -466,19 +470,23 @@ class AutonomousWorkflowRepository:
                 """,
                 (f"{escape_like(quota_prefix)}%",),
             )
-        return self.db.fetch_all("""
+        return self.db.fetch_all(
+            """
             SELECT * FROM autonomous_workflows
             WHERE status = 'paused'
             ORDER BY created_at ASC
-            """)
+            """
+        )
 
     def get_queued_workflows(self) -> list:
         """Get workflows that are queued behind another workflow in the same batch."""
-        return self.db.fetch_all("""
+        return self.db.fetch_all(
+            """
             SELECT * FROM autonomous_workflows
             WHERE status = 'queued' AND batch_id IS NOT NULL AND batch_id != ''
             ORDER BY created_at ASC, batch_order ASC
-            """)
+            """
+        )
 
     def list_batch_workflows(self, batch_id: str) -> list:
         """List all workflows in a batch ordered by configured sequence."""
@@ -498,13 +506,15 @@ class AutonomousWorkflowRepository:
         try:
             cursor = conn.cursor()
             cursor.execute(
-                adapt_sql("""
+                adapt_sql(
+                    """
                     UPDATE autonomous_workflows
                     SET status = 'cancelled', completed_at = ?, updated_at = ?
                     WHERE batch_id = ?
                       AND workflow_id != ?
                       AND status = 'queued'
-                    """),
+                    """
+                ),
                 (now, now, batch_id, exclude_workflow_id),
             )
             rowcount = cursor.rowcount
@@ -616,7 +626,8 @@ class AutonomousWorkflowRepository:
         milestones, matching the request count shown in the session list sidebar.
         """
         self.db.execute(
-            adapt_sql("""
+            adapt_sql(
+                """
                 UPDATE autonomous_workflows SET
                     total_requests = (
                         SELECT COALESCE(SUM(cnt), 0) FROM (
@@ -630,7 +641,8 @@ class AutonomousWorkflowRepository:
                     ),
                     updated_at = ?
                 WHERE workflow_id = ?
-                """),
+                """
+            ),
             (
                 workflow_id,
                 datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S"),
@@ -647,7 +659,8 @@ class AutonomousWorkflowRepository:
         """
         now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
         self.db.execute(
-            adapt_sql("""
+            adapt_sql(
+                """
                 UPDATE autonomous_workflows SET
                     total_tokens = COALESCE((
                         SELECT SUM(COALESCE(phase_total_tokens, 0))
@@ -667,7 +680,8 @@ class AutonomousWorkflowRepository:
                     ), 0),
                     updated_at = ?
                 WHERE workflow_id = ?
-                """),
+                """
+            ),
             (workflow_id, workflow_id, workflow_id, workflow_id, now, workflow_id),
         )
 
@@ -1123,12 +1137,14 @@ class AutonomousWorkflowRepository:
         try:
             cursor = conn.cursor()
             cursor.execute(
-                _db_mod.adapt_sql("""
+                _db_mod.adapt_sql(
+                    """
                     UPDATE autonomous_workflows
                     SET locked_at = ?, locked_by = ?
                     WHERE workflow_id = ?
                       AND (locked_at IS NULL OR locked_at < ?)
-                    """),
+                    """
+                ),
                 (now, owner, workflow_id, cutoff),
             )
             rowcount = cursor.rowcount
@@ -1145,11 +1161,13 @@ class AutonomousWorkflowRepository:
         try:
             cursor = conn.cursor()
             cursor.execute(
-                _db_mod.adapt_sql("""
+                _db_mod.adapt_sql(
+                    """
                     UPDATE autonomous_workflows
                     SET locked_at = NULL, locked_by = NULL
                     WHERE workflow_id = ? AND locked_by = ?
-                    """),
+                    """
+                ),
                 (workflow_id, owner),
             )
             conn.commit()

--- a/app/repositories/autonomous_repo.py
+++ b/app/repositories/autonomous_repo.py
@@ -89,6 +89,7 @@ class AutonomousWorkflowRepository:
         "ci_repair_context",
         "ci_repair_attempts",
         "last_ci_failure_signature",
+        "last_ci_failure_head_sha",
     }
     ALLOWED_MILESTONE_FIELDS = {
         "phase",
@@ -148,15 +149,13 @@ class AutonomousWorkflowRepository:
         try:
             cursor = conn.cursor()
             cursor.execute(
-                adapt_sql(
-                    f"""
+                adapt_sql(f"""
                     SELECT workflow_id, agent_pid, status
                     FROM autonomous_workflows
                     WHERE agent_pid IS NOT NULL
                       AND agent_pid > 0
                       AND status IN ({placeholders})
-                    """
-                ),
+                    """),
                 list(active_statuses),
             )
             cols = [d[0] for d in cursor.description]
@@ -215,8 +214,8 @@ class AutonomousWorkflowRepository:
                      parent_workflow_id, fork_milestone_id, user_feedback,
                      original_branch_name, content_language, system_account,
                      ci_repair_context, ci_repair_attempts, last_ci_failure_signature,
-                     created_at, updated_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                     last_ci_failure_head_sha, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 RETURNING *
                 """,
                 (
@@ -259,6 +258,7 @@ class AutonomousWorkflowRepository:
                     data.get("ci_repair_context", ""),
                     data.get("ci_repair_attempts", 0),
                     data.get("last_ci_failure_signature", ""),
+                    data.get("last_ci_failure_head_sha", ""),
                     now,
                     now,
                 ),
@@ -280,8 +280,8 @@ class AutonomousWorkflowRepository:
                      parent_workflow_id, fork_milestone_id, user_feedback,
                      original_branch_name, content_language, system_account,
                      ci_repair_context, ci_repair_attempts, last_ci_failure_signature,
-                     created_at, updated_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                     last_ci_failure_head_sha, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     workflow_id,
@@ -323,6 +323,7 @@ class AutonomousWorkflowRepository:
                     data.get("ci_repair_context", ""),
                     data.get("ci_repair_attempts", 0),
                     data.get("last_ci_failure_signature", ""),
+                    data.get("last_ci_failure_head_sha", ""),
                     now,
                     now,
                 ),
@@ -442,14 +443,12 @@ class AutonomousWorkflowRepository:
 
     def get_active_workflows(self) -> list:
         """Get all workflows that need processing."""
-        return self.db.fetch_all(
-            """
+        return self.db.fetch_all("""
             SELECT * FROM autonomous_workflows
             WHERE status IN ('pending', 'preparing', 'planning', 'developing',
                              'pr_review', 'reporting', 'waiting', 'merging')
             ORDER BY created_at ASC
-            """
-        )
+            """)
 
     def get_paused_workflows(self, quota_prefix: str = "") -> list:
         """Get paused workflows, optionally filtered to a quota-pause reason.
@@ -467,23 +466,19 @@ class AutonomousWorkflowRepository:
                 """,
                 (f"{escape_like(quota_prefix)}%",),
             )
-        return self.db.fetch_all(
-            """
+        return self.db.fetch_all("""
             SELECT * FROM autonomous_workflows
             WHERE status = 'paused'
             ORDER BY created_at ASC
-            """
-        )
+            """)
 
     def get_queued_workflows(self) -> list:
         """Get workflows that are queued behind another workflow in the same batch."""
-        return self.db.fetch_all(
-            """
+        return self.db.fetch_all("""
             SELECT * FROM autonomous_workflows
             WHERE status = 'queued' AND batch_id IS NOT NULL AND batch_id != ''
             ORDER BY created_at ASC, batch_order ASC
-            """
-        )
+            """)
 
     def list_batch_workflows(self, batch_id: str) -> list:
         """List all workflows in a batch ordered by configured sequence."""
@@ -503,15 +498,13 @@ class AutonomousWorkflowRepository:
         try:
             cursor = conn.cursor()
             cursor.execute(
-                adapt_sql(
-                    """
+                adapt_sql("""
                     UPDATE autonomous_workflows
                     SET status = 'cancelled', completed_at = ?, updated_at = ?
                     WHERE batch_id = ?
                       AND workflow_id != ?
                       AND status = 'queued'
-                    """
-                ),
+                    """),
                 (now, now, batch_id, exclude_workflow_id),
             )
             rowcount = cursor.rowcount
@@ -623,8 +616,7 @@ class AutonomousWorkflowRepository:
         milestones, matching the request count shown in the session list sidebar.
         """
         self.db.execute(
-            adapt_sql(
-                """
+            adapt_sql("""
                 UPDATE autonomous_workflows SET
                     total_requests = (
                         SELECT COALESCE(SUM(cnt), 0) FROM (
@@ -638,8 +630,7 @@ class AutonomousWorkflowRepository:
                     ),
                     updated_at = ?
                 WHERE workflow_id = ?
-                """
-            ),
+                """),
             (
                 workflow_id,
                 datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S"),
@@ -656,8 +647,7 @@ class AutonomousWorkflowRepository:
         """
         now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
         self.db.execute(
-            adapt_sql(
-                """
+            adapt_sql("""
                 UPDATE autonomous_workflows SET
                     total_tokens = COALESCE((
                         SELECT SUM(COALESCE(phase_total_tokens, 0))
@@ -677,8 +667,7 @@ class AutonomousWorkflowRepository:
                     ), 0),
                     updated_at = ?
                 WHERE workflow_id = ?
-                """
-            ),
+                """),
             (workflow_id, workflow_id, workflow_id, workflow_id, now, workflow_id),
         )
 
@@ -1134,14 +1123,12 @@ class AutonomousWorkflowRepository:
         try:
             cursor = conn.cursor()
             cursor.execute(
-                _db_mod.adapt_sql(
-                    """
+                _db_mod.adapt_sql("""
                     UPDATE autonomous_workflows
                     SET locked_at = ?, locked_by = ?
                     WHERE workflow_id = ?
                       AND (locked_at IS NULL OR locked_at < ?)
-                    """
-                ),
+                    """),
                 (now, owner, workflow_id, cutoff),
             )
             rowcount = cursor.rowcount
@@ -1158,13 +1145,11 @@ class AutonomousWorkflowRepository:
         try:
             cursor = conn.cursor()
             cursor.execute(
-                _db_mod.adapt_sql(
-                    """
+                _db_mod.adapt_sql("""
                     UPDATE autonomous_workflows
                     SET locked_at = NULL, locked_by = NULL
                     WHERE workflow_id = ? AND locked_by = ?
-                    """
-                ),
+                    """),
                 (workflow_id, owner),
             )
             conn.commit()

--- a/migrations/versions/20260715_001_add_last_ci_failure_head_sha.py
+++ b/migrations/versions/20260715_001_add_last_ci_failure_head_sha.py
@@ -1,0 +1,41 @@
+"""Add last_ci_failure_head_sha to autonomous_workflows
+
+Revision ID: 20260715_001_add_last_ci_failure_head_sha
+Revises: 20260714_001_add_ci_repair_fields_to_workflows
+Create Date: 2026-07-15
+
+Issue: #1574
+CI repair now runs in merge phase on an existing PR. We need to remember the
+PR head SHA associated with the last failed-check signature so we can
+distinguish "same failure on the same commit" from "same failure after a new
+repair commit was pushed".
+"""
+
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260715_001_add_last_ci_failure_head_sha"
+down_revision: Union[str, None] = "20260714_001_add_ci_repair_fields_to_workflows"
+branch_labels: Union[str, None] = None
+depends_on: Union[str, None] = None
+
+
+def upgrade() -> None:
+    """Add last_ci_failure_head_sha to autonomous_workflows."""
+    connection = op.get_bind()
+    inspector = sa.inspect(connection)
+    existing_columns = {col["name"] for col in inspector.get_columns("autonomous_workflows")}
+
+    if "last_ci_failure_head_sha" not in existing_columns:
+        op.add_column(
+            "autonomous_workflows",
+            sa.Column("last_ci_failure_head_sha", sa.Text(), nullable=True, server_default=""),
+        )
+
+
+def downgrade() -> None:
+    """Remove last_ci_failure_head_sha from autonomous_workflows."""
+    with op.batch_alter_table("autonomous_workflows") as batch_op:
+        batch_op.drop_column("last_ci_failure_head_sha")

--- a/schema/schema-postgres.sql
+++ b/schema/schema-postgres.sql
@@ -445,7 +445,8 @@ CREATE TABLE autonomous_workflows (
     preferred_worktree_path text DEFAULT ''::text,
     ci_repair_context text DEFAULT ''::text,
     ci_repair_attempts integer DEFAULT 0,
-    last_ci_failure_signature text DEFAULT ''::text
+    last_ci_failure_signature text DEFAULT ''::text,
+    last_ci_failure_head_sha text DEFAULT ''::text
 );
 
 CREATE SEQUENCE autonomous_workflows_id_seq

--- a/schema/schema-sqlite.sql
+++ b/schema/schema-sqlite.sql
@@ -291,10 +291,11 @@ CREATE TABLE autonomous_workflows (
  dev_retries_on_test_fail integer DEFAULT 0,
  system_account text DEFAULT '',
  base_commit_sha TEXT,
- preferred_worktree_path text DEFAULT '',
- ci_repair_context text DEFAULT '',
- ci_repair_attempts integer DEFAULT 0,
- last_ci_failure_signature text DEFAULT ''
+preferred_worktree_path text DEFAULT '',
+ci_repair_context text DEFAULT '',
+ci_repair_attempts integer DEFAULT 0,
+last_ci_failure_signature text DEFAULT '',
+last_ci_failure_head_sha text DEFAULT ''
 );
 
 CREATE TABLE compliance_reports (

--- a/schema/schema-sqlite.sql
+++ b/schema/schema-sqlite.sql
@@ -291,11 +291,11 @@ CREATE TABLE autonomous_workflows (
  dev_retries_on_test_fail integer DEFAULT 0,
  system_account text DEFAULT '',
  base_commit_sha TEXT,
-preferred_worktree_path text DEFAULT '',
-ci_repair_context text DEFAULT '',
-ci_repair_attempts integer DEFAULT 0,
-last_ci_failure_signature text DEFAULT '',
-last_ci_failure_head_sha text DEFAULT ''
+    preferred_worktree_path text DEFAULT '',
+    ci_repair_context text DEFAULT '',
+    ci_repair_attempts integer DEFAULT 0,
+    last_ci_failure_signature text DEFAULT '',
+    last_ci_failure_head_sha text DEFAULT ''
 );
 
 CREATE TABLE compliance_reports (

--- a/schema/schema-sqlite.sql
+++ b/schema/schema-sqlite.sql
@@ -291,11 +291,11 @@ CREATE TABLE autonomous_workflows (
  dev_retries_on_test_fail integer DEFAULT 0,
  system_account text DEFAULT '',
  base_commit_sha TEXT,
-    preferred_worktree_path text DEFAULT '',
-    ci_repair_context text DEFAULT '',
-    ci_repair_attempts integer DEFAULT 0,
-    last_ci_failure_signature text DEFAULT '',
-    last_ci_failure_head_sha text DEFAULT ''
+ preferred_worktree_path text DEFAULT '',
+ ci_repair_context text DEFAULT '',
+ ci_repair_attempts integer DEFAULT 0,
+ last_ci_failure_signature text DEFAULT '',
+ last_ci_failure_head_sha text DEFAULT ''
 );
 
 CREATE TABLE compliance_reports (

--- a/tests/issues/1574/test_ci_repair_verifiers.py
+++ b/tests/issues/1574/test_ci_repair_verifiers.py
@@ -37,6 +37,7 @@ def _make_workflow(**overrides):
         "total_output_tokens": 0,
         "total_requests": 0,
         "error_message": "",
+        "last_ci_failure_head_sha": "",
     }
     base.update(overrides)
     return base
@@ -105,3 +106,94 @@ def test_do_development_skips_test_phase_when_dev_failed():
 
     orch._post_dev_completion_comment.assert_not_called()
     orch._run_test_phase.assert_not_called()
+
+
+def test_start_ci_repair_round_stays_in_merge_and_runs_merge_repair():
+    wf = _make_workflow(status="merging", current_phase="merge", ci_repair_attempts=0)
+    orch, mock_repo = _make_orchestrator(wf)
+    gh = MagicMock()
+    gh.get_pr_head_sha.return_value = "sha-old"
+    gh.get_check_failure_excerpt.return_value = "black failed\nfiles were modified"
+    orch._get_gh = MagicMock(return_value=gh)
+    orch._run_merge_ci_repair = MagicMock()
+
+    failed_checks = [
+        {"name": "lint", "state": "failure", "bucket": "fail", "link": "https://example.com"}
+    ]
+    orch._start_ci_repair_round(wf, 1697, failed_checks)
+
+    orch._run_merge_ci_repair.assert_called_once_with(wf, gh, 1697, failed_checks)
+    updates = mock_repo.update_workflow.call_args.args[1]
+    assert updates["current_phase"] == "merge"
+    assert updates["status"] == "merging"
+    assert updates["ci_repair_attempts"] == 1
+    assert updates["last_ci_failure_head_sha"] == "sha-old"
+    assert "dev_round" not in updates
+    assert "current_round" not in updates
+
+
+def test_start_ci_repair_round_fails_when_signature_unchanged_after_new_head():
+    failed_checks = [
+        {"name": "lint", "state": "failure", "bucket": "fail", "link": "https://example.com"}
+    ]
+    wf = _make_workflow(
+        status="merging",
+        current_phase="merge",
+        ci_repair_attempts=1,
+        last_ci_failure_signature="lint|failure|fail",
+        last_ci_failure_head_sha="sha-old",
+    )
+    orch, mock_repo = _make_orchestrator(wf)
+    gh = MagicMock()
+    gh.get_pr_head_sha.return_value = "sha-new"
+    orch._get_gh = MagicMock(return_value=gh)
+    orch._run_merge_ci_repair = MagicMock()
+
+    orch._start_ci_repair_round(wf, 1697, failed_checks)
+
+    orch._run_merge_ci_repair.assert_not_called()
+    updates = mock_repo.update_workflow.call_args.args[1]
+    assert updates["status"] == "failed"
+    assert "CI 失败在自动修复后仍未变化" in updates["error_message"]
+
+
+def test_run_merge_ci_repair_pushes_commit_and_stays_in_merge():
+    from app.modules.workspace.autonomous.models import AgentTaskResult
+
+    wf = _make_workflow(
+        status="merging",
+        current_phase="merge",
+        ci_repair_attempts=1,
+        ci_repair_context="### lint\n- 状态: failure",
+    )
+    orch, mock_repo = _make_orchestrator(wf)
+    gh = MagicMock()
+    gh.get_current_commit.side_effect = ["sha-old", "sha-new"]
+    gh.get_current_branch.return_value = wf["branch_name"]
+    gh.get_commit_diff_stats.return_value = {"files": 1, "additions": 3, "deletions": 1}
+    orch._get_gh = MagicMock(return_value=gh)
+    orch._accumulate_tokens = MagicMock()
+    orch._post_github_comment = MagicMock()
+    orch._run_agent = MagicMock(
+        return_value=AgentTaskResult(
+            success=True,
+            session_id="sess-1",
+            response_text="Reproduced lint command and fixed formatting.",
+            visible_response_text="Reproduced lint command and fixed formatting.",
+            error="",
+        )
+    )
+
+    orch._run_merge_ci_repair(
+        wf,
+        gh,
+        1697,
+        [{"name": "lint", "state": "failure", "bucket": "fail", "link": "https://example.com"}],
+    )
+
+    gh.git_push.assert_called_once_with(branch=wf["branch_name"])
+    updates = mock_repo.update_workflow.call_args.args[1]
+    assert updates["current_phase"] == "merge"
+    assert updates["status"] == "merging"
+    assert updates["error_message"] == ""
+    orch._post_github_comment.assert_called_once()

--- a/tests/issues/241/test_pagination_migration_head.py
+++ b/tests/issues/241/test_pagination_migration_head.py
@@ -33,8 +33,10 @@ _PROJECT_ROOT = Path(__file__).resolve().parents[3]
 if str(_PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(_PROJECT_ROOT))
 
-NEW_REVISION = "20260704_001_session_messages_pagination_index"
-PARENT_REVISION = "20260704_001_add_test_retry_columns"
+HEAD_REVISION = "20260715_001_add_last_ci_failure_head_sha"
+HEAD_PARENT_REVISION = "20260714_001_add_ci_repair_fields_to_workflows"
+ISSUE241_REVISION = "20260704_001_session_messages_pagination_index"
+ISSUE241_PARENT_REVISION = "20260704_001_add_test_retry_columns"
 
 
 def _alembic_config() -> Config:
@@ -58,17 +60,18 @@ def test_single_migration_head():
         "A forked/stale head usually means main advanced and a migration needs "
         "re-parenting onto the current head."
     )
-    assert heads[0] == NEW_REVISION
+    assert heads[0] == HEAD_REVISION
 
 
 def test_new_migration_parents_off_current_head():
     """The new migration must chain directly under the prior head, not branch."""
     cfg = _alembic_config()
     script_dir = ScriptDirectory.from_config(cfg)
-    revision = script_dir.get_revision(NEW_REVISION)
-    assert revision is not None, f"migration {NEW_REVISION} not found in script directory"
-    assert revision.down_revision == PARENT_REVISION, (
-        f"new migration down_revision={revision.down_revision!r}, " f"expected {PARENT_REVISION!r}"
+    revision = script_dir.get_revision(HEAD_REVISION)
+    assert revision is not None, f"migration {HEAD_REVISION} not found in script directory"
+    assert revision.down_revision == HEAD_PARENT_REVISION, (
+        f"new migration down_revision={revision.down_revision!r}, "
+        f"expected {HEAD_PARENT_REVISION!r}"
     )
 
 
@@ -103,7 +106,7 @@ def test_upgrade_makes_timestamp_not_null(tmp_path, monkeypatch):
 
     shared_db._db_url_cache = None
     cfg = _alembic_config()
-    command.upgrade(cfg, PARENT_REVISION)
+    command.upgrade(cfg, ISSUE241_PARENT_REVISION)
 
     conn = sqlite3.connect(db_path)
     # Ensure a session exists for the FK-ish insert.

--- a/tests/issues/822/test_merge_conflict_detection.py
+++ b/tests/issues/822/test_merge_conflict_detection.py
@@ -294,6 +294,11 @@ class TestDoMergeDeferredRetry:
         """CI repair loop should restore the preferred worktree path for worktree strategy."""
         wf = _make_workflow(worktree_path="", preferred_worktree_path="/srv/repo/.worktrees/wf-822")
         o, _ = _make_orchestrator(wf)
+        mock_gh = MagicMock()
+        mock_gh.get_pr_head_sha.return_value = "sha-old"
+        mock_gh.get_check_failure_excerpt.return_value = "pytest failed"
+        o._get_gh = MagicMock(return_value=mock_gh)
+        o._run_merge_ci_repair = MagicMock()
 
         o._start_ci_repair_round(
             wf,
@@ -302,20 +307,30 @@ class TestDoMergeDeferredRetry:
         )
 
         update_payload = o._update_workflow.call_args.args[0]
-        assert update_payload["current_phase"] == "development"
-        assert update_payload["status"] == "developing"
-        assert update_payload["dev_round"] == 2
+        assert update_payload["current_phase"] == "merge"
+        assert update_payload["status"] == "merging"
+        assert "dev_round" not in update_payload
         assert update_payload["ci_repair_attempts"] == 1
         assert update_payload["worktree_path"] == "/srv/repo/.worktrees/wf-822"
         assert update_payload["preferred_worktree_path"] == "/srv/repo/.worktrees/wf-822"
+        o._run_merge_ci_repair.assert_called_once_with(
+            wf,
+            mock_gh,
+            1103,
+            [{"name": "test (3.9)", "bucket": "fail", "state": "failure"}],
+        )
 
     def test_start_ci_repair_round_fails_when_signature_repeats(self):
         """A repeated failed-check signature should stop the auto-repair loop."""
         wf = _make_workflow(
             ci_repair_attempts=1,
             last_ci_failure_signature="test (3.9)|failure|fail",
+            last_ci_failure_head_sha="sha-old",
         )
         o, _ = _make_orchestrator(wf)
+        mock_gh = MagicMock()
+        mock_gh.get_pr_head_sha.return_value = "sha-new"
+        o._get_gh = MagicMock(return_value=mock_gh)
 
         o._start_ci_repair_round(
             wf,

--- a/tests/unit/test_alembic_sqlite_upgrade.py
+++ b/tests/unit/test_alembic_sqlite_upgrade.py
@@ -118,7 +118,8 @@ def test_alembic_upgrade_head_succeeds_for_fresh_sqlite(tmp_path, monkeypatch):
     # -> 20260709_001_add_base_commit_sha (Issue #1552)
     # -> 20260709_003_add_tenant_usage_aggregation (Tenant usage aggregation infrastructure)
     # -> 20260714_001_add_ci_repair_fields_to_workflows (Issue #1647)
-    assert version[0] == "20260714_001_add_ci_repair_fields_to_workflows"
+    # -> 20260715_001_add_last_ci_failure_head_sha (Issue #1574)
+    assert version[0] == "20260715_001_add_last_ci_failure_head_sha"
     if has_session_messages:
         assert "source" in columns
     assert has_mapping_rules is True
@@ -135,6 +136,7 @@ def test_alembic_upgrade_head_succeeds_for_fresh_sqlite(tmp_path, monkeypatch):
     assert "ci_repair_context" in aw_columns
     assert "ci_repair_attempts" in aw_columns
     assert "last_ci_failure_signature" in aw_columns
+    assert "last_ci_failure_head_sha" in aw_columns
 
 
 def test_workflow_status_index_created_after_upgrade(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- keep automatic CI repair inside the merge phase instead of bouncing back to a full development/test/review/report cycle
- run CI repair on the existing PR branch with the main session, require a real pushed commit, and track PR head SHA to detect no-progress repair loops
- add an Alembic migration plus schema/test updates for the new `last_ci_failure_head_sha` field

## Testing
- `.venv/bin/python -m black --check app/modules/workspace/autonomous/github_ops.py app/modules/workspace/autonomous/orchestrator.py app/modules/workspace/autonomous/models.py app/modules/workspace/autonomous/__init__.py app/repositories/autonomous_repo.py tests/issues/1574/test_ci_repair_verifiers.py tests/issues/241/test_pagination_migration_head.py tests/unit/test_alembic_sqlite_upgrade.py migrations/versions/20260715_001_add_last_ci_failure_head_sha.py`
- `.venv/bin/python -m ruff check app/modules/workspace/autonomous/github_ops.py app/modules/workspace/autonomous/orchestrator.py app/modules/workspace/autonomous/models.py app/modules/workspace/autonomous/__init__.py app/repositories/autonomous_repo.py tests/issues/1574/test_ci_repair_verifiers.py tests/issues/241/test_pagination_migration_head.py tests/unit/test_alembic_sqlite_upgrade.py migrations/versions/20260715_001_add_last_ci_failure_head_sha.py`
- `.venv/bin/python -m pytest tests/issues/1574/test_ci_repair_verifiers.py tests/issues/913/test_pr909_review_feedback.py tests/issues/241/test_pagination_migration_head.py tests/unit/test_alembic_sqlite_upgrade.py -q`
