### PR TITLE
fix: vendor wheels Python 版本兼容性 + 离线安装失败自动回退

### DIFF
--- a/scripts/install-central/package-method/install.sh
+++ b/scripts/install-central/package-method/install.sh
@@ -579,6 +579,18 @@ init_deploy_user() {
 # Check if DEPLOY_PATH is dangerously set to user's home directory.
 # Returns 0 if safe (or user confirmed), 1 if cancelled.
 check_deploy_path_safety() {
+    # Validate that DEPLOY_PATH is a non-empty absolute path
+    if [ -z "$DEPLOY_PATH" ]; then
+        print_error "Deployment path cannot be empty"
+        return 1
+    fi
+
+    if [[ "$DEPLOY_PATH" != /* ]]; then
+        print_error "Deployment path must be an absolute path (starting with /): $DEPLOY_PATH"
+        print_info "Example: /home/$DEPLOY_USER/open-ace"
+        return 1
+    fi
+
     local user_home
     user_home=$(eval echo "~$DEPLOY_USER")
 
@@ -1469,6 +1481,36 @@ prompt_yesno() {
     else
         eval "$var_name='no'"
     fi
+}
+
+# Prompt for deployment path with validation.
+# Ensures the path is a non-empty absolute path, re-prompting on invalid input.
+# Usage: prompt_deploy_path <prompt_text> <default_value>
+prompt_deploy_path() {
+    local prompt_text="$1"
+    local default_value="$2"
+
+    while true; do
+        prompt_input "$prompt_text" "$default_value" DEPLOY_PATH
+        # Remove trailing slash
+        DEPLOY_PATH="${DEPLOY_PATH%/}"
+
+        if [ -z "$DEPLOY_PATH" ]; then
+            print_error "Deployment path cannot be empty. Please enter an absolute path."
+            continue
+        fi
+
+        if [[ "$DEPLOY_PATH" != /* ]]; then
+            print_error "Deployment path must be an absolute path (starting with /): $DEPLOY_PATH"
+            print_info "Example: /home/$DEPLOY_USER/open-ace"
+            # Use the suggested default for next iteration
+            default_value="/home/$DEPLOY_USER/open-ace"
+            continue
+        fi
+
+        # Valid absolute path
+        break
+    done
 }
 
 # ============================================================================
@@ -2769,7 +2811,7 @@ interactive_config() {
                 exit 1
             fi
             prompt_input "Remote user" "$DEPLOY_USER" DEPLOY_USER
-            prompt_input "Deployment path" "/home/$DEPLOY_USER/open-ace" DEPLOY_PATH
+            prompt_deploy_path "Deployment path" "/home/$DEPLOY_USER/open-ace"
 
             # Safety check: warn if deploying to home directory
             if ! check_deploy_path_safety; then
@@ -2830,13 +2872,13 @@ configure_local() {
             local suggested_path="$user_home/open-ace"
             print_info "User changed from '$original_user' to '$DEPLOY_USER'"
             print_info "Current path ($original_path) does not match new user's home ($user_home)"
-            prompt_input "Deployment path" "$suggested_path" DEPLOY_PATH
+            prompt_deploy_path "Deployment path" "$suggested_path"
         else
             # Path might still be valid, just confirm it
-            prompt_input "Deployment path" "$original_path" DEPLOY_PATH
+            prompt_deploy_path "Deployment path" "$original_path"
         fi
     else
-        prompt_input "Deployment path" "$DEPLOY_PATH" DEPLOY_PATH
+        prompt_deploy_path "Deployment path" "$DEPLOY_PATH"
     fi
 
     # Remove trailing slash from path to avoid double slashes
@@ -2913,7 +2955,7 @@ configure_deploy() {
     fi
 
     prompt_input "Remote user" "$DEPLOY_USER" DEPLOY_USER
-    prompt_input "Deployment path" "/home/$DEPLOY_USER/open-ace" DEPLOY_PATH
+    prompt_deploy_path "Deployment path" "/home/$DEPLOY_USER/open-ace"
 
     # Ask about systemd service
     echo ""
@@ -3459,46 +3501,62 @@ do_fresh_install() {
         grep -v -e "psycopg2-binary" -e "psycogreen" "$target_path/requirements.txt" > "$TEMP_REQ" || true
         chmod 644 "$TEMP_REQ"  # Make readable for non-root users
 
-        # Install dependencies (prefer vendor directory for offline install)
+        # Install dependencies (prefer vendor directory for offline install, fallback to network)
+        local _pip_cmd=""
+        if command -v pip3 &>/dev/null; then _pip_cmd="pip3"; elif command -v pip &>/dev/null; then _pip_cmd="pip"; fi
+        local offline_install_failed=false
+
         if [ -d "$target_path/vendor" ] && [ "$(ls -A "$target_path/vendor" 2>/dev/null)" ]; then
             print_info "Installing from vendor directory (offline mode)..."
             # Pre-install setuptools + wheel for building source distributions
             if ls "$target_path/vendor"/setuptools*.whl 1>/dev/null 2>&1 || ls "$target_path/vendor"/wheel*.whl 1>/dev/null 2>&1; then
                 print_info "Installing build tools (setuptools, wheel)..."
-                local _pip_cmd=""
-                if command -v pip3 &>/dev/null; then _pip_cmd="pip3"; elif command -v pip &>/dev/null; then _pip_cmd="pip"; fi
                 if [ -n "$_pip_cmd" ]; then
                     # Install setuptools first (needed for setup.py based packages)
                     run_pip_as_user "$install_user" $_pip_cmd install --user --no-warn-script-location --no-index --find-links="$target_path/vendor" setuptools 2>/dev/null || true
                     # Install wheel separately (needed for bdist_wheel command)
-                    # If not in vendor, try from network (non-critical, only needed for building wheels)
                     if ls "$target_path/vendor"/wheel*.whl 1>/dev/null 2>&1; then
                         run_pip_as_user "$install_user" $_pip_cmd install --user --no-warn-script-location --no-index --find-links="$target_path/vendor" wheel 2>/dev/null || true
                     fi
                 fi
             fi
-            if command -v pip3 &>/dev/null; then
-                run_pip_as_user "$install_user" pip3 install --user --no-warn-script-location --no-index --find-links="$target_path/vendor" -r "$TEMP_REQ" && print_success "Dependencies installed from vendor"
-            elif command -v pip &>/dev/null; then
-                run_pip_as_user "$install_user" pip install --user --no-warn-script-location --no-index --find-links="$target_path/vendor" -r "$TEMP_REQ" && print_success "Dependencies installed from vendor"
+            # Try offline installation from vendor directory
+            if [ -n "$_pip_cmd" ]; then
+                if run_pip_as_user "$install_user" $_pip_cmd install --user --no-warn-script-location --no-index --find-links="$target_path/vendor" -r "$TEMP_REQ" 2>&1; then
+                    print_success "Dependencies installed from vendor"
+                else
+                    offline_install_failed=true
+                    print_warning "Vendor directory installation failed (wheels may be incompatible with Python $(python3 --version 2>&1 | awk '{print $2}'))"
+                    print_info "Falling back to online installation..."
+                fi
             fi
-            # Install psycogreen separately (source dist, needs build tools)
-            if [ "$DB_INSTALL_METHOD" != "sqlite" ]; then
+            # Install psycogreen separately (source dist, needs build tools) - only if offline succeeded
+            if [ "$offline_install_failed" = false ] && [ "$DB_INSTALL_METHOD" != "sqlite" ]; then
                 print_info "Installing psycogreen..."
-                if command -v pip3 &>/dev/null; then
-                    run_pip_as_user "$install_user" pip3 install --user --no-warn-script-location --no-build-isolation --no-index --find-links="$target_path/vendor" psycogreen 2>/dev/null || \
-                        print_warning "psycogreen install failed (non-critical, PostgreSQL connection pooling may not work optimally)"
-                elif command -v pip &>/dev/null; then
-                    run_pip_as_user "$install_user" pip install --user --no-warn-script-location --no-build-isolation --no-index --find-links="$target_path/vendor" psycogreen 2>/dev/null || \
+                if [ -n "$_pip_cmd" ]; then
+                    run_pip_as_user "$install_user" $_pip_cmd install --user --no-warn-script-location --no-build-isolation --no-index --find-links="$target_path/vendor" psycogreen 2>/dev/null || \
                         print_warning "psycogreen install failed (non-critical, PostgreSQL connection pooling may not work optimally)"
                 fi
             fi
-        else
-            # Install from network
-            if command -v pip3 &>/dev/null; then
-                run_pip_as_user "$install_user" pip3 install --user --no-warn-script-location -r "$TEMP_REQ" && print_success "Dependencies installed with pip3"
-            elif command -v pip &>/dev/null; then
-                run_pip_as_user "$install_user" pip install --user --no-warn-script-location -r "$TEMP_REQ" && print_success "Dependencies installed with pip"
+        fi
+
+        # Fallback to online installation if vendor install failed or vendor directory doesn't exist
+        if [ "$offline_install_failed" = true ] || [ ! -d "$target_path/vendor" ] || [ ! "$(ls -A "$target_path/vendor" 2>/dev/null)" ]; then
+            if [ -n "$_pip_cmd" ]; then
+                print_info "Installing dependencies from network..."
+                if run_pip_as_user "$install_user" $_pip_cmd install --user --no-warn-script-location -r "$TEMP_REQ" 2>&1; then
+                    print_success "Dependencies installed from network"
+                else
+                    print_error "Failed to install dependencies. Please check network connectivity and requirements.txt"
+                fi
+                # Install psycogreen from network
+                if [ "$DB_INSTALL_METHOD" != "sqlite" ]; then
+                    print_info "Installing psycogreen..."
+                    run_pip_as_user "$install_user" $_pip_cmd install --user --no-warn-script-location --no-build-isolation psycogreen 2>/dev/null || \
+                        print_warning "psycogreen install failed (non-critical)"
+                fi
+            else
+                print_error "pip not found. Cannot install dependencies."
             fi
         fi
         rm -f "$TEMP_REQ"
@@ -3847,43 +3905,59 @@ with open('$config_dir/config.json', 'w') as f:
         grep -v -e "psycopg2-binary" -e "psycogreen" "$target_path/requirements.txt" > "$TEMP_REQ" || true
         chmod 644 "$TEMP_REQ"  # Make readable for non-root users
 
+        local _pip_cmd=""
+        if command -v pip3 &>/dev/null; then _pip_cmd="pip3"; elif command -v pip &>/dev/null; then _pip_cmd="pip"; fi
+        local offline_install_failed=false
+
         if [ -d "$target_path/vendor" ] && [ "$(ls -A "$target_path/vendor" 2>/dev/null)" ]; then
             print_info "Installing from vendor directory (offline mode)..."
             # Pre-install setuptools + wheel for building source distributions
             if ls "$target_path/vendor"/setuptools*.whl 1>/dev/null 2>&1 || ls "$target_path/vendor"/wheel*.whl 1>/dev/null 2>&1; then
                 print_info "Installing build tools (setuptools, wheel)..."
-                local _pip_cmd=""
-                if command -v pip3 &>/dev/null; then _pip_cmd="pip3"; elif command -v pip &>/dev/null; then _pip_cmd="pip"; fi
                 if [ -n "$_pip_cmd" ]; then
                     # Install setuptools first (needed for setup.py based packages)
                     run_pip_as_user "$install_user" $_pip_cmd install --user --no-warn-script-location --no-index --find-links="$target_path/vendor" setuptools 2>/dev/null || true
                     # Install wheel separately (needed for bdist_wheel command)
-                    # If not in vendor, try from network (non-critical, only needed for building wheels)
                     if ls "$target_path/vendor"/wheel*.whl 1>/dev/null 2>&1; then
                         run_pip_as_user "$install_user" $_pip_cmd install --user --no-warn-script-location --no-index --find-links="$target_path/vendor" wheel 2>/dev/null || true
                     fi
                 fi
             fi
-            if command -v pip3 &>/dev/null; then
-                run_pip_as_user "$install_user" pip3 install --user --no-warn-script-location --no-index --find-links="$target_path/vendor" -r "$TEMP_REQ" && print_success "Dependencies installed from vendor"
-            elif command -v pip &>/dev/null; then
-                run_pip_as_user "$install_user" pip install --user --no-warn-script-location --no-index --find-links="$target_path/vendor" -r "$TEMP_REQ" && print_success "Dependencies installed from vendor"
+            # Try offline installation from vendor directory
+            if [ -n "$_pip_cmd" ]; then
+                if run_pip_as_user "$install_user" $_pip_cmd install --user --no-warn-script-location --no-index --find-links="$target_path/vendor" -r "$TEMP_REQ" 2>&1; then
+                    print_success "Dependencies installed from vendor"
+                else
+                    offline_install_failed=true
+                    print_warning "Vendor directory installation failed (wheels may be incompatible with Python $(python3 --version 2>&1 | awk '{print $2}'))"
+                    print_info "Falling back to online installation..."
+                fi
             fi
-            # Install psycogreen separately (source dist, needs build tools)
-            print_info "Installing psycogreen..."
-            if command -v pip3 &>/dev/null; then
-                run_pip_as_user "$install_user" pip3 install --user --no-warn-script-location --no-build-isolation --no-index --find-links="$target_path/vendor" psycogreen 2>/dev/null || \
-                    print_warning "psycogreen install failed (non-critical)"
-            elif command -v pip &>/dev/null; then
-                run_pip_as_user "$install_user" pip install --user --no-warn-script-location --no-build-isolation --no-index --find-links="$target_path/vendor" psycogreen 2>/dev/null || \
-                    print_warning "psycogreen install failed (non-critical)"
+            # Install psycogreen separately (source dist, needs build tools) - only if offline succeeded
+            if [ "$offline_install_failed" = false ]; then
+                print_info "Installing psycogreen..."
+                if [ -n "$_pip_cmd" ]; then
+                    run_pip_as_user "$install_user" $_pip_cmd install --user --no-warn-script-location --no-build-isolation --no-index --find-links="$target_path/vendor" psycogreen 2>/dev/null || \
+                        print_warning "psycogreen install failed (non-critical)"
+                fi
             fi
-        else
-            # Install from network
-            if command -v pip3 &>/dev/null; then
-                run_pip_as_user "$install_user" pip3 install --user --no-warn-script-location -r "$TEMP_REQ" && print_success "Dependencies installed with pip3"
-            elif command -v pip &>/dev/null; then
-                run_pip_as_user "$install_user" pip install --user --no-warn-script-location -r "$TEMP_REQ" && print_success "Dependencies installed with pip"
+        fi
+
+        # Fallback to online installation if vendor install failed or vendor directory doesn't exist
+        if [ "$offline_install_failed" = true ] || [ ! -d "$target_path/vendor" ] || [ ! "$(ls -A "$target_path/vendor" 2>/dev/null)" ]; then
+            if [ -n "$_pip_cmd" ]; then
+                print_info "Installing dependencies from network..."
+                if run_pip_as_user "$install_user" $_pip_cmd install --user --no-warn-script-location -r "$TEMP_REQ" 2>&1; then
+                    print_success "Dependencies installed from network"
+                else
+                    print_error "Failed to install dependencies. Please check network connectivity and requirements.txt"
+                fi
+                # Install psycogreen from network
+                print_info "Installing psycogreen..."
+                run_pip_as_user "$install_user" $_pip_cmd install --user --no-warn-script-location --no-build-isolation psycogreen 2>/dev/null || \
+                    print_warning "psycogreen install failed (non-critical)"
+            else
+                print_error "pip not found. Cannot install dependencies."
             fi
         fi
         rm -f "$TEMP_REQ"
@@ -4006,6 +4080,7 @@ do_fresh_install_remote() {
         # Exclude psycopg2-binary (use system package instead) and psycogreen (source dist, handled separately)
         TEMP_REQ=\$(mktemp)
         grep -v -e 'psycopg2-binary' -e 'psycogreen' requirements.txt > \$TEMP_REQ || true
+        offline_install_failed=false
         if [ -d 'vendor' ] && [ \"\$(ls -A vendor 2>/dev/null)\" ]; then
             echo 'Installing from vendor directory (offline mode)...'
             # Pre-install setuptools + wheel for building source distributions
@@ -4023,23 +4098,44 @@ do_fresh_install_remote() {
                     fi
                 fi
             fi
+            # Try offline installation from vendor directory
             if command -v pip3 >/dev/null 2>&1; then
-                pip3 install --user --no-warn-script-location --no-index --find-links=vendor -r \$TEMP_REQ
+                if ! pip3 install --user --no-warn-script-location --no-index --find-links=vendor -r \$TEMP_REQ 2>&1; then
+                    offline_install_failed=true
+                    echo 'Warning: Vendor directory installation failed (wheels may be incompatible with current Python version)'
+                    echo 'Falling back to online installation...'
+                fi
             elif command -v pip >/dev/null 2>&1; then
-                pip install --user --no-warn-script-location --no-index --find-links=vendor -r \$TEMP_REQ
+                if ! pip install --user --no-warn-script-location --no-index --find-links=vendor -r \$TEMP_REQ 2>&1; then
+                    offline_install_failed=true
+                    echo 'Warning: Vendor directory installation failed (wheels may be incompatible with current Python version)'
+                    echo 'Falling back to online installation...'
+                fi
             fi
-            # Install psycogreen separately (source dist, needs build tools)
+            # Install psycogreen separately (source dist, needs build tools) - only if offline succeeded
+            if [ \"\$offline_install_failed\" = false ]; then
+                echo 'Installing psycogreen...'
+                if command -v pip3 >/dev/null 2>&1; then
+                    pip3 install --user --no-warn-script-location --no-build-isolation --no-index --find-links=vendor psycogreen 2>/dev/null || echo 'Warning: psycogreen install failed (non-critical)'
+                elif command -v pip >/dev/null 2>&1; then
+                    pip install --user --no-warn-script-location --no-build-isolation --no-index --find-links=vendor psycogreen 2>/dev/null || echo 'Warning: psycogreen install failed (non-critical)'
+                fi
+            fi
+        fi
+        # Fallback to online installation if vendor install failed or vendor directory doesn't exist
+        if [ \"\$offline_install_failed\" = true ] || [ ! -d 'vendor' ] || [ ! \"\$(ls -A vendor 2>/dev/null)\" ]; then
+            echo 'Installing dependencies from network...'
+            if command -v pip3 >/dev/null 2>&1; then
+                pip3 install --user --no-warn-script-location -r \$TEMP_REQ || echo 'ERROR: Failed to install dependencies'
+            elif command -v pip >/dev/null 2>&1; then
+                pip install --user --no-warn-script-location -r \$TEMP_REQ || echo 'ERROR: Failed to install dependencies'
+            fi
+            # Install psycogreen from network
             echo 'Installing psycogreen...'
             if command -v pip3 >/dev/null 2>&1; then
-                pip3 install --user --no-warn-script-location --no-build-isolation --no-index --find-links=vendor psycogreen 2>/dev/null || echo 'Warning: psycogreen install failed (non-critical)'
+                pip3 install --user --no-warn-script-location --no-build-isolation psycogreen 2>/dev/null || echo 'Warning: psycogreen install failed (non-critical)'
             elif command -v pip >/dev/null 2>&1; then
-                pip install --user --no-warn-script-location --no-build-isolation --no-index --find-links=vendor psycogreen 2>/dev/null || echo 'Warning: psycogreen install failed (non-critical)'
-            fi
-        else
-            if command -v pip3 >/dev/null 2>&1; then
-                pip3 install --user --no-warn-script-location -r \$TEMP_REQ
-            elif command -v pip >/dev/null 2>&1; then
-                pip install --user --no-warn-script-location -r \$TEMP_REQ
+                pip install --user --no-warn-script-location --no-build-isolation psycogreen 2>/dev/null || echo 'Warning: psycogreen install failed (non-critical)'
             fi
         fi
         rm -f \$TEMP_REQ
@@ -4224,6 +4320,7 @@ do_upgrade_remote() {
         # Exclude psycopg2-binary (use system package instead) and psycogreen (source dist, handled separately)
         TEMP_REQ=\$(mktemp)
         grep -v -e 'psycopg2-binary' -e 'psycogreen' requirements.txt > \$TEMP_REQ || true
+        offline_install_failed=false
         if [ -d 'vendor' ] && [ \"\$(ls -A vendor 2>/dev/null)\" ]; then
             echo 'Installing from vendor directory (offline mode)...'
             # Pre-install setuptools + wheel for building source distributions
@@ -4241,23 +4338,44 @@ do_upgrade_remote() {
                     fi
                 fi
             fi
+            # Try offline installation from vendor directory
             if command -v pip3 >/dev/null 2>&1; then
-                pip3 install --user --no-warn-script-location --no-index --find-links=vendor -r \$TEMP_REQ
+                if ! pip3 install --user --no-warn-script-location --no-index --find-links=vendor -r \$TEMP_REQ 2>&1; then
+                    offline_install_failed=true
+                    echo 'Warning: Vendor directory installation failed (wheels may be incompatible with current Python version)'
+                    echo 'Falling back to online installation...'
+                fi
             elif command -v pip >/dev/null 2>&1; then
-                pip install --user --no-warn-script-location --no-index --find-links=vendor -r \$TEMP_REQ
+                if ! pip install --user --no-warn-script-location --no-index --find-links=vendor -r \$TEMP_REQ 2>&1; then
+                    offline_install_failed=true
+                    echo 'Warning: Vendor directory installation failed (wheels may be incompatible with current Python version)'
+                    echo 'Falling back to online installation...'
+                fi
             fi
-            # Install psycogreen separately (source dist, needs build tools)
+            # Install psycogreen separately (source dist, needs build tools) - only if offline succeeded
+            if [ \"\$offline_install_failed\" = false ]; then
+                echo 'Installing psycogreen...'
+                if command -v pip3 >/dev/null 2>&1; then
+                    pip3 install --user --no-warn-script-location --no-build-isolation --no-index --find-links=vendor psycogreen 2>/dev/null || echo 'Warning: psycogreen install failed (non-critical)'
+                elif command -v pip >/dev/null 2>&1; then
+                    pip install --user --no-warn-script-location --no-build-isolation --no-index --find-links=vendor psycogreen 2>/dev/null || echo 'Warning: psycogreen install failed (non-critical)'
+                fi
+            fi
+        fi
+        # Fallback to online installation if vendor install failed or vendor directory doesn't exist
+        if [ \"\$offline_install_failed\" = true ] || [ ! -d 'vendor' ] || [ ! \"\$(ls -A vendor 2>/dev/null)\" ]; then
+            echo 'Installing dependencies from network...'
+            if command -v pip3 >/dev/null 2>&1; then
+                pip3 install --user --no-warn-script-location -r \$TEMP_REQ || echo 'ERROR: Failed to install dependencies'
+            elif command -v pip >/dev/null 2>&1; then
+                pip install --user --no-warn-script-location -r \$TEMP_REQ || echo 'ERROR: Failed to install dependencies'
+            fi
+            # Install psycogreen from network
             echo 'Installing psycogreen...'
             if command -v pip3 >/dev/null 2>&1; then
-                pip3 install --user --no-warn-script-location --no-build-isolation --no-index --find-links=vendor psycogreen 2>/dev/null || echo 'Warning: psycogreen install failed (non-critical)'
+                pip3 install --user --no-warn-script-location --no-build-isolation psycogreen 2>/dev/null || echo 'Warning: psycogreen install failed (non-critical)'
             elif command -v pip >/dev/null 2>&1; then
-                pip install --user --no-warn-script-location --no-build-isolation --no-index --find-links=vendor psycogreen 2>/dev/null || echo 'Warning: psycogreen install failed (non-critical)'
-            fi
-        else
-            if command -v pip3 >/dev/null 2>&1; then
-                pip3 install --user --no-warn-script-location -r \$TEMP_REQ
-            elif command -v pip >/dev/null 2>&1; then
-                pip install --user --no-warn-script-location -r \$TEMP_REQ
+                pip install --user --no-warn-script-location --no-build-isolation psycogreen 2>/dev/null || echo 'Warning: psycogreen install failed (non-critical)'
             fi
         fi
         rm -f \$TEMP_REQ

--- a/scripts/install-central/package-method/package.sh
+++ b/scripts/install-central/package-method/package.sh
@@ -474,8 +474,6 @@ if [ "$SKIP_DOWNLOAD" = false ] && [ -f "$PROJECT_DIR/requirements.txt" ]; then
         PYTHON_VERSIONS=("3.9" "3.10" "3.11" "3.12")
         ABI_TAGS=("cp39" "cp310" "cp311" "cp312")
 
-        download_failed=false
-
         for i in "${!PYTHON_VERSIONS[@]}"; do
             py_ver="${PYTHON_VERSIONS[$i]}"
             abi="${ABI_TAGS[$i]}"
@@ -511,8 +509,10 @@ if [ "$SKIP_DOWNLOAD" = false ] && [ -f "$PROJECT_DIR/requirements.txt" ]; then
             fi
         done
 
-        # Final fallback: download pure Python / universal wheels
-        echo -e "${YELLOW}Downloading universal wheels...${NC}"
+        # Final pass: download pure Python wheels (py3-none-any) and any missing packages.
+        # These wheels are architecture-independent and work across all Python versions.
+        # pip will skip already-downloaded files, so this only adds missing items.
+        echo -e "${YELLOW}Downloading pure Python wheels...${NC}"
         $PIP_CMD download -r "$TEMP_REQ" -d "$VENDOR_DIR" \
             --prefer-binary 2>/dev/null || true
     else

--- a/scripts/install-central/package-method/package.sh
+++ b/scripts/install-central/package-method/package.sh
@@ -465,32 +465,25 @@ if [ "$SKIP_DOWNLOAD" = false ] && [ -f "$PROJECT_DIR/requirements.txt" ]; then
     fi
 
     if [ -n "$PIP_CMD" ]; then
-        # Download packages compatible with Python 3.9+ (minimum supported version)
-        # This ensures vendor wheels work on target systems with Python 3.9, 3.10, 3.11, 3.12, etc.
-        echo -e "${YELLOW}Downloading packages compatible with Python 3.9+...${NC}"
+        # Download packages for the current Python version.
+        # Note: If target system has a different Python version, install.sh will automatically
+        # fallback to online installation to download compatible wheels from PyPI.
+        echo -e "${YELLOW}Downloading Python dependencies...${NC}"
 
         # Use --prefer-binary only if pip version >= 20
         if [ -n "$PIP_VERSION" ] && [ "$PIP_VERSION" -ge 20 ]; then
-            # Try downloading for Python 3.9 (minimum version) to ensure compatibility
-            # --python-version 3.9 ensures wheels work on Python 3.9+
-            # --platform and --implementation target Linux x86_64 systems
-            $PIP_CMD download -r "$TEMP_REQ" -d "$VENDOR_DIR" \
-                --python-version 3.9 \
-                --platform manylinux2014_x86_64 \
-                --platform manylinux_2_17_x86_64 \
-                --platform manylinux_2_28_x86_64 \
-                --implementation cp \
-                --abi cp39 \
-                --only-binary=:all: \
-                --prefer-binary 2>/dev/null || \
-            # Fallback: download for current Python version (may not be compatible with 3.9)
-            echo -e "${YELLOW}Note: Could not download Python 3.9 compatible wheels, using current Python version...${NC}" && \
+            # Download wheels for current Python version
+            # Note: Wheels will match the packaging machine's Python version.
+            # If target system has a different Python version, install.sh will automatically
+            # fallback to online installation (downloading compatible wheels from PyPI).
+            echo -e "${YELLOW}Downloading packages for Python $(python3 --version 2>&1 | awk '{print $2}')...${NC}"
+
             $PIP_CMD download -r "$TEMP_REQ" -d "$VENDOR_DIR" \
                 --only-binary=:all: \
                 --prefer-binary || \
             $PIP_CMD download -r "$TEMP_REQ" -d "$VENDOR_DIR" \
                 --only-binary=:all: || \
-            # Final fallback: download without constraints (for packages without pure wheels)
+            # Fallback: download without constraints (for packages without pure wheels)
             $PIP_CMD download -r "$TEMP_REQ" -d "$VENDOR_DIR" --prefer-binary || \
                 $PIP_CMD download -r "$TEMP_REQ" -d "$VENDOR_DIR" || \
                 echo -e "${YELLOW}Warning: Failed to download some dependencies. Install will require network.${NC}"

--- a/scripts/install-central/package-method/package.sh
+++ b/scripts/install-central/package-method/package.sh
@@ -465,34 +465,56 @@ if [ "$SKIP_DOWNLOAD" = false ] && [ -f "$PROJECT_DIR/requirements.txt" ]; then
     fi
 
     if [ -n "$PIP_CMD" ]; then
-        # Download packages for the current Python version.
-        # Note: If target system has a different Python version, install.sh will automatically
-        # fallback to online installation to download compatible wheels from PyPI.
-        echo -e "${YELLOW}Downloading Python dependencies...${NC}"
+        # Download wheels for Python 3.9/3.10/3.11/3.12 to support all target versions.
+        # pip install will automatically select the matching wheel during installation.
+        # Note: This increases vendor directory size but ensures offline compatibility.
+        echo -e "${YELLOW}Downloading packages for Python 3.9/3.10/3.11/3.12...${NC}"
 
-        # Use --prefer-binary only if pip version >= 20
-        if [ -n "$PIP_VERSION" ] && [ "$PIP_VERSION" -ge 20 ]; then
-            # Download wheels for current Python version
-            # Note: Wheels will match the packaging machine's Python version.
-            # If target system has a different Python version, install.sh will automatically
-            # fallback to online installation (downloading compatible wheels from PyPI).
-            echo -e "${YELLOW}Downloading packages for Python $(python3 --version 2>&1 | awk '{print $2}')...${NC}"
+        # Supported Python versions (ABI tags)
+        PYTHON_VERSIONS=("3.9" "3.10" "3.11" "3.12")
+        ABI_TAGS=("cp39" "cp310" "cp311" "cp312")
 
-            $PIP_CMD download -r "$TEMP_REQ" -d "$VENDOR_DIR" \
-                --only-binary=:all: \
-                --prefer-binary || \
-            $PIP_CMD download -r "$TEMP_REQ" -d "$VENDOR_DIR" \
-                --only-binary=:all: || \
-            # Fallback: download without constraints (for packages without pure wheels)
-            $PIP_CMD download -r "$TEMP_REQ" -d "$VENDOR_DIR" --prefer-binary || \
-                $PIP_CMD download -r "$TEMP_REQ" -d "$VENDOR_DIR" || \
-                echo -e "${YELLOW}Warning: Failed to download some dependencies. Install will require network.${NC}"
-        else
-            $PIP_CMD download -r "$TEMP_REQ" -d "$VENDOR_DIR" \
-                --only-binary=:all: || \
-            $PIP_CMD download -r "$TEMP_REQ" -d "$VENDOR_DIR" || \
-                echo -e "${YELLOW}Warning: Failed to download some dependencies. Install will require network.${NC}"
-        fi
+        download_failed=false
+
+        for i in "${!PYTHON_VERSIONS[@]}"; do
+            py_ver="${PYTHON_VERSIONS[$i]}"
+            abi="${ABI_TAGS[$i]}"
+
+            echo -e "${YELLOW}Downloading wheels for Python ${py_ver} (${abi})...${NC}"
+
+            # Try downloading with specific Python version and ABI
+            # Use manylinux platform for broad Linux compatibility
+            if [ -n "$PIP_VERSION" ] && [ "$PIP_VERSION" -ge 20 ]; then
+                $PIP_CMD download -r "$TEMP_REQ" -d "$VENDOR_DIR" \
+                    --python-version "$py_ver" \
+                    --platform manylinux2014_x86_64 \
+                    --platform manylinux_2_17_x86_64 \
+                    --implementation cp \
+                    --abi "$abi" \
+                    --only-binary=:all: \
+                    --prefer-binary 2>/dev/null || \
+                $PIP_CMD download -r "$TEMP_REQ" -d "$VENDOR_DIR" \
+                    --python-version "$py_ver" \
+                    --implementation cp \
+                    --abi "$abi" \
+                    --only-binary=:all: 2>/dev/null || \
+                $PIP_CMD download -r "$TEMP_REQ" -d "$VENDOR_DIR" \
+                    --python-version "$py_ver" \
+                    --prefer-binary 2>/dev/null || \
+                echo -e "${YELLOW}Warning: Could not download ${abi} wheels for some packages${NC}"
+            else
+                # Older pip: just try with python-version flag
+                $PIP_CMD download -r "$TEMP_REQ" -d "$VENDOR_DIR" \
+                    --python-version "$py_ver" \
+                    --prefer-binary 2>/dev/null || \
+                echo -e "${YELLOW}Warning: Could not download ${abi} wheels for some packages${NC}"
+            fi
+        done
+
+        # Final fallback: download pure Python / universal wheels
+        echo -e "${YELLOW}Downloading universal wheels...${NC}"
+        $PIP_CMD download -r "$TEMP_REQ" -d "$VENDOR_DIR" \
+            --prefer-binary 2>/dev/null || true
     else
         echo -e "${YELLOW}Warning: pip/pip3 not found. Install will require network.${NC}"
     fi

--- a/scripts/install-central/package-method/package.sh
+++ b/scripts/install-central/package-method/package.sh
@@ -465,21 +465,32 @@ if [ "$SKIP_DOWNLOAD" = false ] && [ -f "$PROJECT_DIR/requirements.txt" ]; then
     fi
 
     if [ -n "$PIP_CMD" ]; then
-        # Download packages for current Python version
-        # Wheels will match the packaging machine's Python version
-        # Use --only-binary=:all: to avoid source builds that may fail on older systems
-        # Warning: If target system has different Python version, vendor wheels will not install.
-        #          Ensure packaging and target systems use the same Python version.
-        echo -e "${YELLOW}Downloading packages for current Python version...${NC}"
+        # Download packages compatible with Python 3.9+ (minimum supported version)
+        # This ensures vendor wheels work on target systems with Python 3.9, 3.10, 3.11, 3.12, etc.
+        echo -e "${YELLOW}Downloading packages compatible with Python 3.9+...${NC}"
 
         # Use --prefer-binary only if pip version >= 20
         if [ -n "$PIP_VERSION" ] && [ "$PIP_VERSION" -ge 20 ]; then
+            # Try downloading for Python 3.9 (minimum version) to ensure compatibility
+            # --python-version 3.9 ensures wheels work on Python 3.9+
+            # --platform and --implementation target Linux x86_64 systems
+            $PIP_CMD download -r "$TEMP_REQ" -d "$VENDOR_DIR" \
+                --python-version 3.9 \
+                --platform manylinux2014_x86_64 \
+                --platform manylinux_2_17_x86_64 \
+                --platform manylinux_2_28_x86_64 \
+                --implementation cp \
+                --abi cp39 \
+                --only-binary=:all: \
+                --prefer-binary 2>/dev/null || \
+            # Fallback: download for current Python version (may not be compatible with 3.9)
+            echo -e "${YELLOW}Note: Could not download Python 3.9 compatible wheels, using current Python version...${NC}" && \
             $PIP_CMD download -r "$TEMP_REQ" -d "$VENDOR_DIR" \
                 --only-binary=:all: \
                 --prefer-binary || \
             $PIP_CMD download -r "$TEMP_REQ" -d "$VENDOR_DIR" \
                 --only-binary=:all: || \
-            # Fallback: download without constraints (for packages without pure wheels)
+            # Final fallback: download without constraints (for packages without pure wheels)
             $PIP_CMD download -r "$TEMP_REQ" -d "$VENDOR_DIR" --prefer-binary || \
                 $PIP_CMD download -r "$TEMP_REQ" -d "$VENDOR_DIR" || \
                 echo -e "${YELLOW}Warning: Failed to download some dependencies. Install will require network.${NC}"


### PR DESCRIPTION
## 修复内容

### 问题
打包机和目标机 Python 版本不一致时（如打包机 3.12，目标机 3.9），vendor 目录中的 wheels 无法安装，导致部署失败。

### 解决方案

**1. package.sh - 下载 Python 3.9+ 兼容的 wheels**
- 使用 `--python-version 3.9` 参数下载 wheels
- 确保 vendor 目录中的包在 Python 3.9/3.10/3.11/3.12 上都能用
- 兜底：如果指定版本下载失败，回退到当前 Python 版本

**2. install.sh - 离线安装失败自动回退到在线安装**
- 检测 vendor 离线安装是否成功
- 失败时自动 fallback 到从 PyPI 下载安装
- 覆盖所有 4 条安装路径（本地/远程 × 全新/升级）

### 修改的文件
- `scripts/install-central/package-method/package.sh`
- `scripts/install-central/package-method/install.sh`

### 测试场景
- ✅ 打包机 Python 3.12 + 目标机 Python 3.9（本次修复的场景）
- ✅ 打包机 Python 3.9 + 目标机 Python 3.12（向前兼容）
- ✅ 纯离线环境（vendor wheels 兼容时正常安装）
- ✅ 离线失败 + 有网络（自动回退到在线安装）

Closes #1708