### PR TITLE
fix: preserve primary autonomous CLI failures

### DIFF
--- a/app/modules/workspace/autonomous/agent_runner.py
+++ b/app/modules/workspace/autonomous/agent_runner.py
@@ -168,6 +168,8 @@ class _LocalSession:
     request_count: int = 0
     completed: threading.Event = field(default_factory=threading.Event)
     error: str | None = None
+    error_code: str | None = None
+    last_stderr: str = ""
     _stopped: threading.Event = field(default_factory=threading.Event)
     _stdout_thread: threading.Thread | None = None
     _stderr_thread: threading.Thread | None = None
@@ -382,6 +384,7 @@ def _build_agent_task_result(
     tool_calls: list | None = None,
     success: bool = False,
     error: str | None = None,
+    error_code: str | None = None,
     messages: list | None = None,
 ) -> AgentTaskResult:
     """Build a task result with both final-output and visible-text views."""
@@ -403,8 +406,47 @@ def _build_agent_task_result(
         tool_calls=tool_calls or [],
         success=success,
         error=error,
+        error_code=error_code,
         event_log=normalized_event_log,
     )
+
+
+def _extract_cli_result_error(parsed: dict, stderr_hint: str = "") -> tuple[str | None, str | None]:
+    """Classify an error-bearing CLI ``result`` payload using observed failures only."""
+    if not parsed.get("is_error"):
+        return None, None
+
+    candidates: list[str] = []
+    errors = parsed.get("errors")
+    if isinstance(errors, list):
+        candidates.extend(str(item).strip() for item in errors if str(item).strip())
+
+    error_value = parsed.get("error")
+    if isinstance(error_value, str) and error_value.strip():
+        candidates.append(error_value.strip())
+
+    if stderr_hint.strip():
+        candidates.append(stderr_hint.strip())
+
+    subtype = str(parsed.get("subtype") or "").strip()
+    message = next((item for item in candidates if item), "")
+    normalized = message.lower()
+
+    if "no conversation found with session id" in normalized:
+        return "resume_session_not_found", message
+
+    if (
+        "not logged in" in normalized
+        or "/login" in normalized
+        or subtype == "authentication_failed"
+    ):
+        return "cli_auth_failed", message or "Not logged in · Please run /login"
+
+    if message:
+        return "unknown_cli_error", message
+    if subtype:
+        return "unknown_cli_error", subtype
+    return "unknown_cli_error", "CLI execution failed"
 
 
 class _ZcodeResultCollector:
@@ -1738,6 +1780,7 @@ class AutonomousAgentRunner:
                 tool_calls=session.tool_calls,
                 success=False,
                 error=f"Agent task timed out after {timeout}s",
+                error_code=session.error_code,
             )
 
         return _build_agent_task_result(
@@ -1753,6 +1796,7 @@ class AutonomousAgentRunner:
             tool_calls=session.tool_calls,
             success=session.error is None,
             error=session.error,
+            error_code=session.error_code,
         )
 
     def _create_workflow_session(
@@ -2695,7 +2739,20 @@ class AutonomousAgentRunner:
                         # bump (it summarizes the whole --print run).
                         if not session._counted_message_ids and session.request_count == 0:
                             session.request_count += 1
-                        self._sync_sidebar_session_totals(session, status="active")
+                        error_code, error_message = _extract_cli_result_error(
+                            parsed, session.last_stderr
+                        )
+                        if error_message:
+                            session.error_code = error_code
+                            session.error = error_message
+                            logger.warning(
+                                "Agent CLI result reported error (%s): %s",
+                                error_code or "unknown_cli_error",
+                                error_message,
+                            )
+                        self._sync_sidebar_session_totals(
+                            session, status="error" if session.error else "active"
+                        )
                         session.completed.set()
                         # Emit usage activity for real-time token display
                         if self._activity_callback:
@@ -2815,6 +2872,9 @@ class AutonomousAgentRunner:
                     break
                 if isinstance(line, bytes):
                     line = line.decode("utf-8", errors="replace")
+                stripped = line.strip()
+                if stripped:
+                    session.last_stderr = stripped
                 logger.debug("[%s/stderr] %s", session.session_id[:8], line.strip())
         except (OSError, ValueError):
             pass

--- a/app/modules/workspace/autonomous/agent_runner.py
+++ b/app/modules/workspace/autonomous/agent_runner.py
@@ -168,6 +168,7 @@ class _LocalSession:
     request_count: int = 0
     completed: threading.Event = field(default_factory=threading.Event)
     error: str | None = None
+    # Runtime-only classification mirroring AgentTaskResult.error_code.
     error_code: str | None = None
     last_stderr: str = ""
     _stopped: threading.Event = field(default_factory=threading.Event)
@@ -435,11 +436,7 @@ def _extract_cli_result_error(parsed: dict, stderr_hint: str = "") -> tuple[str 
     if "no conversation found with session id" in normalized:
         return "resume_session_not_found", message
 
-    if (
-        "not logged in" in normalized
-        or "/login" in normalized
-        or subtype == "authentication_failed"
-    ):
+    if "not logged in" in normalized or "/login" in normalized:
         return "cli_auth_failed", message or "Not logged in · Please run /login"
 
     if message:

--- a/app/modules/workspace/autonomous/models.py
+++ b/app/modules/workspace/autonomous/models.py
@@ -385,5 +385,6 @@ class AgentTaskResult:
     tool_calls: list = field(default_factory=list)
     success: bool = False
     error: Optional[str] = None
+    error_code: Optional[str] = None
     # Ordered event log preserving actual message interleaving
     event_log: list = field(default_factory=list)

--- a/app/modules/workspace/autonomous/models.py
+++ b/app/modules/workspace/autonomous/models.py
@@ -385,6 +385,8 @@ class AgentTaskResult:
     tool_calls: list = field(default_factory=list)
     success: bool = False
     error: Optional[str] = None
+    # Runtime-only classification for logs/tests; not persisted or used for
+    # retry/control-flow decisions yet.
     error_code: Optional[str] = None
     # Ordered event log preserving actual message interleaving
     event_log: list = field(default_factory=list)

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -1539,6 +1539,14 @@ class AutonomousOrchestrator:
         return value.strip() if isinstance(value, str) else ""
 
     @staticmethod
+    def _primary_result_error(result: Optional[AgentTaskResult]) -> str:
+        """Return the first-class runner error that should win over heuristics."""
+        if not result or result.success:
+            return ""
+        error = getattr(result, "error", None)
+        return error.strip() if isinstance(error, str) else ""
+
+    @staticmethod
     def _build_dev_result_summary(
         artifact_text: str, diff_stats: dict, commit_sha: str, success: bool
     ) -> str:
@@ -3530,6 +3538,7 @@ class AutonomousOrchestrator:
         # Verify agent actually produced code changes (Issue #776 Bug 2)
         sha_changed = commit_before and commit_sha and commit_before != commit_sha
         has_uncommitted = False
+        primary_error = self._primary_result_error(result)
 
         if not sha_changed:
             # SHA unchanged (or unavailable) — check for uncommitted changes
@@ -3600,7 +3609,25 @@ class AutonomousOrchestrator:
                     "this session (commit_sha == commit_before) — not agent work",
                     base_diff_stats.get("commits", 0),
                 )
-                logger.warning("Agent reported success but no new commits detected (SHA unchanged)")
+                if primary_error:
+                    logger.warning(
+                        "Agent failed before producing a new commit; preserving primary error: %s",
+                        primary_error,
+                    )
+                else:
+                    logger.warning(
+                        "Agent reported success but no new commits detected (SHA unchanged)"
+                    )
+                milestone_error = (
+                    primary_error
+                    if primary_error
+                    else "Agent produced no code changes (commit SHA unchanged)"
+                )
+                workflow_error = (
+                    f"Development failed: {primary_error}"
+                    if primary_error
+                    else "Development failed: agent produced no code changes"
+                )
                 self.repo.update_milestone(
                     ms.get("milestone_id", ""),
                     {
@@ -3608,13 +3635,13 @@ class AutonomousOrchestrator:
                         "session_id": result.session_id,
                         "result_summary": self._artifact_text(result)[:300],
                         "tldr": self._artifact_tldr(result),
-                        "error_message": "Agent produced no code changes (commit SHA unchanged)",
+                        "error_message": milestone_error,
                     },
                 )
                 self._update_workflow(
                     {
                         "status": "failed",
-                        "error_message": "Development failed: agent produced no code changes",
+                        "error_message": workflow_error,
                     }
                 )
                 return
@@ -4131,6 +4158,22 @@ class AutonomousOrchestrator:
         # Treat skipped tests as failure — tests must actually run.
         # Allow 1 retry in case of transient environment issues.
         if tests_actually_skipped:
+            primary_error = self._primary_result_error(test_result)
+            if primary_error:
+                self.repo.update_milestone(
+                    test_ms.get("milestone_id", ""),
+                    {
+                        "status": "failed",
+                        "error_message": primary_error,
+                    },
+                )
+                self._update_workflow(
+                    {
+                        "status": "failed",
+                        "error_message": f"Testing failed: {primary_error}",
+                    }
+                )
+                return
             # Correct the milestone status: it was optimistically set to
             # "completed" above based on session success alone, but tests
             # were not actually executed. Without this correction, the

--- a/tests/issues/716/test_agent_runner.py
+++ b/tests/issues/716/test_agent_runner.py
@@ -677,10 +677,10 @@ class TestStdoutParsing:
         )
         assert session.error_code == "resume_session_not_found"
 
-    def test_extract_cli_result_error_uses_authentication_subtype_and_stderr(self):
+    def test_extract_cli_result_error_uses_logged_out_message(self):
         """Authentication failures should be classified from observed CLI output."""
         error_code, error_message = _extract_cli_result_error(
-            {"type": "result", "is_error": True, "subtype": "authentication_failed"},
+            {"type": "result", "is_error": True},
             "Not logged in · Please run /login",
         )
         assert error_code == "cli_auth_failed"

--- a/tests/issues/716/test_agent_runner.py
+++ b/tests/issues/716/test_agent_runner.py
@@ -11,8 +11,8 @@ import pytest
 
 from app.modules.workspace.autonomous.agent_runner import (
     AutonomousAgentRunner,
-    _LocalSession,
     _extract_cli_result_error,
+    _LocalSession,
 )
 
 
@@ -672,9 +672,7 @@ class TestStdoutParsing:
             ]
         )
         assert session.completed.is_set()
-        assert (
-            session.error == "No conversation found with session ID: dead-session"
-        )
+        assert session.error == "No conversation found with session ID: dead-session"
         assert session.error_code == "resume_session_not_found"
 
     def test_extract_cli_result_error_uses_logged_out_message(self):

--- a/tests/issues/716/test_agent_runner.py
+++ b/tests/issues/716/test_agent_runner.py
@@ -9,7 +9,11 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from app.modules.workspace.autonomous.agent_runner import AutonomousAgentRunner, _LocalSession
+from app.modules.workspace.autonomous.agent_runner import (
+    AutonomousAgentRunner,
+    _LocalSession,
+    _extract_cli_result_error,
+)
 
 
 class TestAgentRunnerInit:
@@ -652,6 +656,35 @@ class TestStdoutParsing:
         assert session.total_tokens == 150
         assert session.total_input_tokens == 100
         assert session.total_output_tokens == 50
+
+    def test_parse_error_result_marks_session_failed(self):
+        """Claude ``result.is_error`` must become a failed local session."""
+        session = self._run_read_stdout(
+            [
+                json.dumps(
+                    {
+                        "type": "result",
+                        "is_error": True,
+                        "errors": ["No conversation found with session ID: dead-session"],
+                    }
+                ),
+                "",
+            ]
+        )
+        assert session.completed.is_set()
+        assert (
+            session.error == "No conversation found with session ID: dead-session"
+        )
+        assert session.error_code == "resume_session_not_found"
+
+    def test_extract_cli_result_error_uses_authentication_subtype_and_stderr(self):
+        """Authentication failures should be classified from observed CLI output."""
+        error_code, error_message = _extract_cli_result_error(
+            {"type": "result", "is_error": True, "subtype": "authentication_failed"},
+            "Not logged in · Please run /login",
+        )
+        assert error_code == "cli_auth_failed"
+        assert error_message == "Not logged in · Please run /login"
 
     def test_parse_control_request_auto_approve(self):
         """_read_stdout auto-approves control_request by writing a response to stdin."""

--- a/tests/issues/716/test_orchestrator.py
+++ b/tests/issues/716/test_orchestrator.py
@@ -1138,6 +1138,39 @@ class TestOrchestratorDevelopment:
             for f in fields_list
         )
 
+    def test_development_preserves_primary_error_before_no_code_change_fallback(self):
+        """A runner error must win over the SHA-unchanged fallback diagnosis."""
+        wf = _make_workflow(
+            current_phase="development",
+            status="developing",
+            branch_name="auto-dev/test-wf",
+        )
+        orch, mock_repo = self._make_orchestrator(wf)
+        orch._runner = MagicMock()
+        orch._runner.run_agent_task.return_value = _make_agent_result(
+            success=False,
+            error="No conversation found with session ID: dead-session",
+        )
+        orch._gh.get_current_commit.side_effect = ["abc1234", "abc1234"]
+        orch._gh.get_commit_diff_stats.return_value = {"files": 0, "additions": 0, "deletions": 0}
+        orch._gh.get_diff_stats.return_value = {"commits": 1, "files": 3}
+        orch._gh.has_uncommitted_changes.return_value = False
+
+        orch._do_development(wf)
+
+        milestone_updates = [c[0][1] for c in mock_repo.update_milestone.call_args_list]
+        assert any(
+            update.get("error_message") == "No conversation found with session ID: dead-session"
+            for update in milestone_updates
+        )
+        workflow_updates = [c[0][1] for c in mock_repo.update_workflow.call_args_list]
+        assert any(
+            update.get("status") == "failed"
+            and update.get("error_message")
+            == "Development failed: No conversation found with session ID: dead-session"
+            for update in workflow_updates
+        )
+
     def test_development_test_failure_sets_error(self):
         """When tests fail past max retries, workflow status becomes failed."""
         from app.modules.workspace.autonomous.orchestrator import MAX_TEST_RETRIES
@@ -1166,6 +1199,50 @@ class TestOrchestratorDevelopment:
             for f in fields_list
         )
 
+    def test_test_phase_preserves_primary_error_before_skipped_fallback(self):
+        """A failing test session should not be rewritten to 'tests not actually run'."""
+        wf = _make_workflow(
+            current_phase="development",
+            status="developing",
+            github_issue_number=42,
+        )
+        orch, mock_repo = self._make_orchestrator(wf)
+        orch._runner = MagicMock()
+        dev_result = _make_agent_result(
+            success=True,
+            text="Development complete",
+        )
+        test_result = AgentTaskResult(
+            session_id="sess-test",
+            response_text="TEST_STATUS: skipped",
+            structured_tags={"test_status": "skipped"},
+            total_tokens=50,
+            total_input_tokens=25,
+            total_output_tokens=25,
+            success=False,
+            error="No conversation found with session ID: dead-test-session",
+        )
+        orch._runner.run_agent_task.side_effect = [dev_result, test_result]
+        orch._gh.get_current_commit.side_effect = ["abc1234", "def5678"]
+        orch._gh.get_commit_diff_stats.return_value = {"files": 1, "additions": 10, "deletions": 0}
+        orch._gh.get_diff_stats.return_value = {"files": 1, "additions": 10, "deletions": 0}
+
+        orch._do_development(wf)
+
+        milestone_updates = [c[0][1] for c in mock_repo.update_milestone.call_args_list]
+        assert any(
+            update.get("error_message")
+            == "No conversation found with session ID: dead-test-session"
+            for update in milestone_updates
+        )
+        workflow_updates = [c[0][1] for c in mock_repo.update_workflow.call_args_list]
+        assert any(
+            update.get("status") == "failed"
+            and update.get("error_message")
+            == "Testing failed: No conversation found with session ID: dead-test-session"
+            for update in workflow_updates
+        )
+
     def test_development_posts_to_issue(self):
         """Development completion posts status to GitHub issue."""
         wf = _make_workflow(
@@ -1175,6 +1252,7 @@ class TestOrchestratorDevelopment:
         )
         orch, _ = self._make_orchestrator(wf)
         orch._runner = MagicMock()
+        orch._post_github_comment = MagicMock()
         orch._runner.run_agent_task.return_value = _make_agent_result(
             text="Dev done\nAll tests passed"
         )
@@ -1185,10 +1263,10 @@ class TestOrchestratorDevelopment:
 
         # Dev flow posts several comments (dev progress, test results, all-checks);
         # verify the development-completion comment landed on the issue.
-        calls = orch._gh.add_issue_comment.call_args_list
-        dev_comments = [c for c in calls if "Development Round 1 Completed" in c[0][1]]
+        calls = orch._post_github_comment.call_args_list
+        dev_comments = [c for c in calls if "Development Round 1 Completed" in c[0][2]]
         assert len(dev_comments) == 1
-        assert dev_comments[0][0][0] == 42
+        assert dev_comments[0][0][1] == 42
 
     def test_development_no_issue_no_comment(self):
         """No issue comment when github_issue_number is not set."""
@@ -1199,13 +1277,14 @@ class TestOrchestratorDevelopment:
         )
         orch, _ = self._make_orchestrator(wf)
         orch._runner = MagicMock()
+        orch._post_github_comment = MagicMock()
         orch._runner.run_agent_task.return_value = _make_agent_result()
         orch._gh.get_current_commit.side_effect = ["abc1234", "def5678"]
         orch._gh.get_diff_stats.return_value = {}
 
         orch._do_development(wf)
 
-        orch._gh.add_issue_comment.assert_not_called()
+        orch._post_github_comment.assert_not_called()
 
     def test_development_fallback_to_requirements(self):
         """When no plan exists, requirements_text is used as the plan."""


### PR DESCRIPTION
## Summary
- detect Claude CLI `result.is_error` responses in the autonomous runner and carry the original error plus a lightweight runtime `error_code`
- preserve primary runner failures in development/test orchestrator paths instead of rewriting them to "no code changes" or "tests were not actually run"
- add focused regression coverage for resume-session-not-found and CLI auth failures

## Testing
- pytest tests/issues/716/test_agent_runner.py tests/issues/716/test_orchestrator.py -q
