### PR TITLE
fix(messages): 优化筛选框布局、统一圆角和高度

### DIFF
--- a/frontend/src/components/common/SearchableSelect.tsx
+++ b/frontend/src/components/common/SearchableSelect.tsx
@@ -100,7 +100,7 @@ export const SearchableSelect: React.FC<SearchableSelectProps> = ({
       <button
         type="button"
         className={cn(
-          'form-control text-start d-flex justify-content-between align-items-center',
+          'form-control searchable-select-trigger text-start d-flex justify-content-between align-items-center',
           sizeClasses[size],
           disabled && 'disabled'
         )}

--- a/frontend/src/components/features/Messages.tsx
+++ b/frontend/src/components/features/Messages.tsx
@@ -202,30 +202,7 @@ export const Messages: React.FC = () => {
 
       {/* Filters - Responsive layout */}
       <Card className="mb-3 messages-filter-card">
-        {/* Filter Row 1: Date Range */}
-        <div className="messages-filter-row">
-          <div className="messages-filter-group messages-filter-dates">
-            <label className="messages-filter-label">
-              <i className="bi bi-calendar-range me-1" />
-              {t('dateRange', language)}
-            </label>
-            <div className="messages-filter-dates-inputs">
-              <DatePicker
-                value={filters.startDate ?? ''}
-                onChange={(v) => handleFilterChange('startDate', v)}
-                placeholder={t('startDate', language)}
-              />
-              <span className="messages-filter-dates-separator">~</span>
-              <DatePicker
-                value={filters.endDate ?? ''}
-                onChange={(v) => handleFilterChange('endDate', v)}
-                placeholder={t('endDate', language)}
-              />
-            </div>
-          </div>
-        </div>
-
-        {/* Filter Row 2: Host + Tool + Sender */}
+        {/* Filter Row 1: Host + Tool + Sender + Date Range */}
         <div className="messages-filter-row">
           <div className="messages-filter-group">
             <label className="messages-filter-label">
@@ -265,9 +242,28 @@ export const Messages: React.FC = () => {
               size="sm"
             />
           </div>
+          <div className="messages-filter-group messages-filter-dates">
+            <label className="messages-filter-label">
+              <i className="bi bi-calendar-range me-1" />
+              {t('dateRange', language)}
+            </label>
+            <div className="messages-filter-dates-inputs">
+              <DatePicker
+                value={filters.startDate ?? ''}
+                onChange={(v) => handleFilterChange('startDate', v)}
+                placeholder={t('startDate', language)}
+              />
+              <span className="messages-filter-dates-separator">~</span>
+              <DatePicker
+                value={filters.endDate ?? ''}
+                onChange={(v) => handleFilterChange('endDate', v)}
+                placeholder={t('endDate', language)}
+              />
+            </div>
+          </div>
         </div>
 
-        {/* Filter Row 3: Role + Search */}
+        {/* Filter Row 2: Role + Search */}
         <div className="messages-filter-row">
           <div className="messages-filter-group messages-filter-roles">
             <label className="messages-filter-label">

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -2564,16 +2564,21 @@ table .latency-row:hover td {
   padding-right: 2.5rem;
 }
 
-/* Messages page filter controls -统一高度 */
-.messages-header .form-control-sm,
-.messages-header .form-select-sm,
-.messages .card .form-control-sm,
-.messages .card .form-select-sm {
-  padding-top: 0.375rem;
-  padding-bottom: 0.375rem;
-  font-size: 0.875rem;
-  line-height: 1.5;
-  height: 2.25rem;
+/* Messages page filter controls - 统一所有筛选框高度 */
+.messages .card .messages-filter-row .form-select-sm,
+.messages .card .messages-filter-row .form-control-sm,
+.messages .card .messages-filter-row input,
+.messages .card .messages-filter-row select,
+.messages .card .messages-filter-row button.form-control {
+  height: 36px !important;
+  min-height: 36px !important;
+  max-height: 36px !important;
+  padding-top: 0.25rem !important;
+  padding-bottom: 0.25rem !important;
+  font-size: 0.875rem !important;
+  line-height: 1.5 !important;
+  border-radius: var(--border-radius-sm) !important;
+  box-sizing: border-box !important;
 }
 
 .messages-header .form-check-inline,
@@ -4433,6 +4438,7 @@ table .latency-row:hover td {
 .messages-filter-sender {
   flex: 1;
   min-width: 180px;
+  max-width: 300px;
 }
 
 /* Role Checkboxes */


### PR DESCRIPTION
## 修复内容

Closes #1711

### 问题描述
在「管理 → 消息」页面中，筛选框存在以下 UI 问题：
1. **布局不合理**：日期范围筛选框独占一行，浪费空间
2. **圆角不一致**：主机、工具筛选框（Select 组件）是直角，发送者筛选框（SearchableSelect）是圆角
3. **高度不一致**：不同筛选框的高度不同，视觉上不够美观

### 修复方案

| 问题 | 修改内容 |
|-----|----------|
| 布局 | 将日期范围移到发送者右侧，主机/工具/发送者/日期在同一行 |
| 圆角 | 统一所有筛选框圆角为 `var(--border-radius-sm)` |
| 高度 | 统一所有筛选框高度为 `36px` |

### 修改的文件

- `frontend/src/components/features/Messages.tsx` - 调整筛选框布局
- `frontend/src/components/common/SearchableSelect.tsx` - 添加 `searchable-select-trigger` 类名
- `frontend/src/styles/main.css` - 统一样式

### 新的布局结构

```
┌─────────────────────────────────────────────────────────────────┐
│ [主机]  [工具]  [发送者 ▼]  [开始日期 ~ 结束日期]              │
│ [角色 ☑user ☑assistant ☑system]  [搜索...]                    │
└─────────────────────────────────────────────────────────────────┘
```

### CSS 关键修改

```css
.messages .card .messages-filter-row .form-select-sm,
.messages .card .messages-filter-row .form-control-sm,
.messages .card .messages-filter-row input,
.messages .card .messages-filter-row select,
.messages .card .messages-filter-row button.form-control {
  height: 36px !important;
  min-height: 36px !important;
  max-height: 36px !important;
  border-radius: var(--border-radius-sm) !important;
  box-sizing: border-box !important;
}
```

### 验证

已在 node237 上部署验证，所有筛选框高度统一为 36px，圆角一致。