### PR TITLE
fix(autonomous): system 事件转发 activity callback，消除 AI activity 空窗

### DIFF
--- a/app/modules/workspace/autonomous/agent_runner.py
+++ b/app/modules/workspace/autonomous/agent_runner.py
@@ -2713,6 +2713,24 @@ class AutonomousAgentRunner:
                     elif msg_type in {"system", "initialized"}:
                         if msg_type == "initialized" or parsed.get("subtype") == "initialized":
                             self._capture_cli_session_id(session, parsed, "system.initialized")
+                        # Forward key system events to the UI so the workflow
+                        # detail shows progress during long LLM waits.
+                        # Without this, an agent stuck in api_retry (upstream
+                        # overload / transient auth) emits only `system` events
+                        # — which never triggered _activity_callback — so the
+                        # UI showed "no AI activity" for minutes until the
+                        # first `assistant` event finally arrived.
+                        subtype = parsed.get("subtype", "")
+                        if self._activity_callback and subtype:
+                            activity: dict[str, Any] = {
+                                "type": "system",
+                                "subtype": subtype,
+                            }
+                            if subtype == "thinking_tokens":
+                                activity["estimated_tokens"] = parsed.get("estimated_tokens", 0)
+                            elif subtype == "api_retry":
+                                activity["attempt"] = parsed.get("attempt", 0)
+                            self._activity_callback(session.session_id, activity)
 
                     elif msg_type == "control_response":
                         # Capture the real Claude session_id from the SDK

--- a/frontend/src/components/work/WorkflowTimeline.tsx
+++ b/frontend/src/components/work/WorkflowTimeline.tsx
@@ -645,11 +645,14 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
 
   const formatLiveActivityLine = (activity: {
     timestamp?: string;
-    type: 'assistant' | 'tool_use' | 'usage';
+    type: 'assistant' | 'tool_use' | 'usage' | 'system';
     text?: string;
     tool_name?: string;
     tool_input?: string;
     total_tokens?: number;
+    subtype?: string;
+    estimated_tokens?: number;
+    attempt?: number;
   }) => {
     const timestamp = formatMilestoneTime(activity.timestamp ?? null) || '--:--:--';
     if (activity.type === 'tool_use') {
@@ -675,6 +678,40 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
         icon: 'bi-bar-chart-line text-primary',
         timestamp,
         content: <>Token: {formatTokens(activity.total_tokens ?? 0)}</>,
+      };
+    }
+
+    if (activity.type === 'system') {
+      const sub = activity.subtype ?? '';
+      if (sub === 'thinking_tokens') {
+        return {
+          icon: 'bi-lightbulb text-secondary',
+          timestamp,
+          content: (
+            <>
+              <span className="opacity-75">thinking…</span>{' '}
+              {activity.estimated_tokens ? `~${activity.estimated_tokens} tokens` : ''}
+            </>
+          ),
+        };
+      }
+      if (sub === 'api_retry') {
+        return {
+          icon: 'bi-arrow-repeat text-warning',
+          timestamp,
+          content: (
+            <>
+              <span className="opacity-75">retrying API request</span>{' '}
+              {activity.attempt ? `(attempt ${activity.attempt})` : ''}
+            </>
+          ),
+        };
+      }
+      // init, hook_started, etc. — lightweight status
+      return {
+        icon: 'bi-info-circle text-secondary',
+        timestamp,
+        content: <span className="opacity-75">{sub || 'system'}</span>,
       };
     }
 

--- a/frontend/src/components/work/WorkflowTimeline.tsx
+++ b/frontend/src/components/work/WorkflowTimeline.tsx
@@ -176,10 +176,12 @@ function getDiffLineClass(line: string): string {
 
 function getActivityStableKey(activity: {
   session_id: string;
-  type: 'assistant' | 'tool_use' | 'usage';
+  type: 'assistant' | 'tool_use' | 'usage' | 'system';
   timestamp?: string;
   text?: string;
   tool_name?: string;
+  subtype?: string;
+  attempt?: number;
 }): string {
   return [
     activity.session_id,
@@ -187,6 +189,10 @@ function getActivityStableKey(activity: {
     activity.timestamp ?? '',
     activity.tool_name ?? '',
     (activity.text ?? '').slice(0, 40),
+    // Include subtype/attempt so same-millisecond system events (e.g.
+    // consecutive api_retry bursts) don't collide and get deduped.
+    activity.subtype ?? '',
+    activity.attempt?.toString() ?? '',
   ].join(':');
 }
 

--- a/frontend/src/hooks/useAutonomous.ts
+++ b/frontend/src/hooks/useAutonomous.ts
@@ -56,7 +56,7 @@ export function useWorkflowTimeline(workflowId: string, enabled = true) {
 /** A single agent activity event from the SSE stream */
 export interface AgentActivity {
   session_id: string;
-  type: 'assistant' | 'tool_use' | 'usage';
+  type: 'assistant' | 'tool_use' | 'usage' | 'system';
   timestamp?: string;
   text?: string;
   tool_name?: string;
@@ -64,6 +64,10 @@ export interface AgentActivity {
   total_tokens?: number;
   total_input_tokens?: number;
   total_output_tokens?: number;
+  // system-type fields
+  subtype?: string;
+  estimated_tokens?: number;
+  attempt?: number;
 }
 
 /**

--- a/tests/issues/1395/test_system_event_activity.py
+++ b/tests/issues/1395/test_system_event_activity.py
@@ -8,122 +8,132 @@ first ``assistant`` event arrived. Now key system subtypes also trigger the
 callback so the workflow detail shows live progress throughout the wait.
 """
 
+import json
+import threading
 from unittest.mock import MagicMock
 
 
+class _FakeStream:
+    """Mimic subprocess stdout: ``readline()`` returns queued lines, then ``""``."""
+
+    def __init__(self, lines):
+        self._lines = [ln if ln.endswith("\n") else ln + "\n" for ln in lines]
+
+    def readline(self):
+        return self._lines.pop(0) if self._lines else ""
+
+
+class _StubProcess:
+    """Minimal stand-in for subprocess.Popen — only stdout/returncode are read."""
+
+    returncode = None  # is_running → True (process not exited)
+
+    def __init__(self, stdout):
+        self.stdout = stdout
+
+
+def _make_session(lines):
+    """Build a real _LocalSession whose process.stdout yields the given JSON lines."""
+    from app.modules.workspace.autonomous.agent_runner import _LocalSession
+
+    session = _LocalSession(
+        session_id="sess-1",
+        process=_StubProcess(_FakeStream(lines)),
+        workflow_id="wf-1",
+    )
+    return session
+
+
+def _make_runner():
+    """Build an AutonomousAgentRunner with a mock _activity_callback."""
+    from app.modules.workspace.autonomous.agent_runner import AutonomousAgentRunner
+
+    runner = AutonomousAgentRunner.__new__(AutonomousAgentRunner)
+    runner._activity_callback = MagicMock()
+    return runner
+
+
 class TestSystemEventActivityForwarding:
-    """_read_stdout must emit _activity_callback for key system events."""
-
-    def _make_runner(self):
-        from app.modules.workspace.autonomous.agent_runner import AutonomousAgentRunner
-
-        runner = AutonomousAgentRunner.__new__(AutonomousAgentRunner)
-        runner._activity_callback = MagicMock()
-        return runner
+    """_read_stdout must emit _activity_callback for key system events.
+    These tests call the REAL _read_stdout method (not a re-implementation)
+    so removing the production change makes them fail."""
 
     def test_api_retry_triggers_activity(self):
         """api_retry system events must reach the callback so the UI shows
         'retrying' during upstream overload."""
-        import json
-
-        from app.modules.workspace.autonomous.agent_runner import (
-            AutonomousAgentRunner,
-            _LocalSession,
+        runner = _make_runner()
+        session = _make_session(
+            [
+                json.dumps(
+                    {"type": "system", "subtype": "api_retry", "attempt": 3, "session_id": "abc"}
+                ),
+            ]
         )
-
-        runner = self._make_runner()
-        session = _LocalSession.__new__(_LocalSession)
-        session.session_id = "sess-1"
-        session.workflow_id = "wf-1"
-        session.process = None
-        session._stopped = MagicMock()
-        session._stopped.is_set.return_value = False
-        session.cli_session_id = ""
-        session.persisted_session_id = ""
-        session.init_request_id = ""
-        session.sdk_initialized = MagicMock()
-        session.sdk_initialized.is_set.return_value = False
-        session.allowed_tools = None
-
-        # Simulate an api_retry system event line
-        line = json.dumps(
-            {
-                "type": "system",
-                "subtype": "api_retry",
-                "attempt": 3,
-                "session_id": "abc",
-            }
-        )
-
-        # Call _read_stdout's parsing path by feeding the line directly.
-        # We can't easily call _read_stdout (it loops on readline), so we
-        # verify the logic by checking the callback was invoked with the
-        # right shape when we simulate the parsed dispatch.
-        parsed = json.loads(line)
-        assert parsed["type"] == "system"
-        assert parsed["subtype"] == "api_retry"
-
-        # The code path we added:
-        subtype = parsed.get("subtype", "")
-        if runner._activity_callback and subtype:
-            activity = {"type": "system", "subtype": subtype}
-            if subtype == "api_retry":
-                activity["attempt"] = parsed.get("attempt", 0)
-            runner._activity_callback(session.session_id, activity)
-
+        runner._read_stdout(session)
         runner._activity_callback.assert_called_once_with(
             "sess-1",
             {"type": "system", "subtype": "api_retry", "attempt": 3},
         )
 
     def test_thinking_tokens_triggers_activity(self):
-        import json
-
-        runner = self._make_runner()
-
-        parsed = json.loads(
-            json.dumps(
-                {
-                    "type": "system",
-                    "subtype": "thinking_tokens",
-                    "estimated_tokens": 42,
-                }
-            )
+        runner = _make_runner()
+        session = _make_session(
+            [
+                json.dumps(
+                    {"type": "system", "subtype": "thinking_tokens", "estimated_tokens": 42}
+                ),
+            ]
         )
-
-        subtype = parsed.get("subtype", "")
-        if runner._activity_callback and subtype:
-            activity = {"type": "system", "subtype": subtype}
-            if subtype == "thinking_tokens":
-                activity["estimated_tokens"] = parsed.get("estimated_tokens", 0)
-            runner._activity_callback("sess-1", activity)
-
+        runner._read_stdout(session)
         runner._activity_callback.assert_called_once_with(
             "sess-1",
             {"type": "system", "subtype": "thinking_tokens", "estimated_tokens": 42},
         )
 
     def test_init_triggers_activity(self):
-        import json
-
-        runner = self._make_runner()
-
-        parsed = json.loads(
-            json.dumps(
-                {
-                    "type": "system",
-                    "subtype": "init",
-                    "session_id": "abc",
-                }
-            )
+        runner = _make_runner()
+        session = _make_session(
+            [
+                json.dumps({"type": "system", "subtype": "init", "session_id": "abc"}),
+            ]
         )
-
-        subtype = parsed.get("subtype", "")
-        if runner._activity_callback and subtype:
-            activity = {"type": "system", "subtype": subtype}
-            runner._activity_callback("sess-1", activity)
-
+        runner._read_stdout(session)
         runner._activity_callback.assert_called_once_with(
             "sess-1",
             {"type": "system", "subtype": "init"},
         )
+
+    def test_no_subtype_does_not_trigger(self):
+        """A system event without subtype (e.g. bare 'initialized') must
+        not fire the callback — avoids noise from events we don't care about."""
+        runner = _make_runner()
+        session = _make_session(
+            [
+                json.dumps({"type": "system"}),
+            ]
+        )
+        runner._read_stdout(session)
+        runner._activity_callback.assert_not_called()
+
+    def test_assistant_still_triggers_activity(self):
+        """Regression guard: assistant events must still fire the callback."""
+        runner = _make_runner()
+        session = _make_session(
+            [
+                json.dumps(
+                    {
+                        "type": "assistant",
+                        "message": {
+                            "id": "msg-1",
+                            "model": "glm-5",
+                            "content": [{"type": "text", "text": "Hello world"}],
+                        },
+                    }
+                ),
+            ]
+        )
+        runner._read_stdout(session)
+        runner._activity_callback.assert_called_once()
+        _args, activity = runner._activity_callback.call_args[0]
+        assert activity["type"] == "assistant"
+        assert "Hello world" in activity["text"]

--- a/tests/issues/1395/test_system_event_activity.py
+++ b/tests/issues/1395/test_system_event_activity.py
@@ -1,0 +1,129 @@
+"""Tests for system-event activity forwarding (Issue #1395 — AI activity gap).
+
+During long LLM waits (api_retry from upstream overload, slow first-token),
+claude --print emits only ``system`` events (api_retry, thinking_tokens, init).
+_read_stdout previously forwarded only assistant/tool_use/usage events to
+_activity_callback, so the UI showed "no AI activity" for minutes until the
+first ``assistant`` event arrived. Now key system subtypes also trigger the
+callback so the workflow detail shows live progress throughout the wait.
+"""
+
+from unittest.mock import MagicMock
+
+
+class TestSystemEventActivityForwarding:
+    """_read_stdout must emit _activity_callback for key system events."""
+
+    def _make_runner(self):
+        from app.modules.workspace.autonomous.agent_runner import AutonomousAgentRunner
+
+        runner = AutonomousAgentRunner.__new__(AutonomousAgentRunner)
+        runner._activity_callback = MagicMock()
+        return runner
+
+    def test_api_retry_triggers_activity(self):
+        """api_retry system events must reach the callback so the UI shows
+        'retrying' during upstream overload."""
+        import json
+
+        from app.modules.workspace.autonomous.agent_runner import (
+            AutonomousAgentRunner,
+            _LocalSession,
+        )
+
+        runner = self._make_runner()
+        session = _LocalSession.__new__(_LocalSession)
+        session.session_id = "sess-1"
+        session.workflow_id = "wf-1"
+        session.process = None
+        session._stopped = MagicMock()
+        session._stopped.is_set.return_value = False
+        session.cli_session_id = ""
+        session.persisted_session_id = ""
+        session.init_request_id = ""
+        session.sdk_initialized = MagicMock()
+        session.sdk_initialized.is_set.return_value = False
+        session.allowed_tools = None
+
+        # Simulate an api_retry system event line
+        line = json.dumps(
+            {
+                "type": "system",
+                "subtype": "api_retry",
+                "attempt": 3,
+                "session_id": "abc",
+            }
+        )
+
+        # Call _read_stdout's parsing path by feeding the line directly.
+        # We can't easily call _read_stdout (it loops on readline), so we
+        # verify the logic by checking the callback was invoked with the
+        # right shape when we simulate the parsed dispatch.
+        parsed = json.loads(line)
+        assert parsed["type"] == "system"
+        assert parsed["subtype"] == "api_retry"
+
+        # The code path we added:
+        subtype = parsed.get("subtype", "")
+        if runner._activity_callback and subtype:
+            activity = {"type": "system", "subtype": subtype}
+            if subtype == "api_retry":
+                activity["attempt"] = parsed.get("attempt", 0)
+            runner._activity_callback(session.session_id, activity)
+
+        runner._activity_callback.assert_called_once_with(
+            "sess-1",
+            {"type": "system", "subtype": "api_retry", "attempt": 3},
+        )
+
+    def test_thinking_tokens_triggers_activity(self):
+        import json
+
+        runner = self._make_runner()
+
+        parsed = json.loads(
+            json.dumps(
+                {
+                    "type": "system",
+                    "subtype": "thinking_tokens",
+                    "estimated_tokens": 42,
+                }
+            )
+        )
+
+        subtype = parsed.get("subtype", "")
+        if runner._activity_callback and subtype:
+            activity = {"type": "system", "subtype": subtype}
+            if subtype == "thinking_tokens":
+                activity["estimated_tokens"] = parsed.get("estimated_tokens", 0)
+            runner._activity_callback("sess-1", activity)
+
+        runner._activity_callback.assert_called_once_with(
+            "sess-1",
+            {"type": "system", "subtype": "thinking_tokens", "estimated_tokens": 42},
+        )
+
+    def test_init_triggers_activity(self):
+        import json
+
+        runner = self._make_runner()
+
+        parsed = json.loads(
+            json.dumps(
+                {
+                    "type": "system",
+                    "subtype": "init",
+                    "session_id": "abc",
+                }
+            )
+        )
+
+        subtype = parsed.get("subtype", "")
+        if runner._activity_callback and subtype:
+            activity = {"type": "system", "subtype": subtype}
+            runner._activity_callback("sess-1", activity)
+
+        runner._activity_callback.assert_called_once_with(
+            "sess-1",
+            {"type": "system", "subtype": "init"},
+        )


### PR DESCRIPTION
## 现象

autonomous 工作流 development 阶段 UI 长时间显示"无 AI activity"，但 agent 实际在正常运行（LLM proxy 持续有请求、claude 进程活着）。

## 实测根因

用 \`claude --print --output-format stream-json --verbose\` 在本地实测（timestamping 每一行 stdout）：

\`\`\`
  1.18s  system  hook_started
  2.63s  system  init
  3.32s  system  api_retry
  6.43s  system  api_retry
  ...
197.41s  assistant  (LLM 终于响应)
197.42s  result  success
\`\`\`

**claude 在等待 LLM 响应期间（本次 ~3 分钟，z.ai 端 529 过载）只输出 \`system\` 事件**（api_retry / thinking_tokens / init），不输出 assistant/tool_use。

\`_read_stdout\` 只对 \`assistant\`/\`tool_use\`/\`usage\` 触发 \`_activity_callback\`，\`system\` 事件不触发 → **UI 在整个等待期间无 activity**。一旦 LLM 响应到达，assistant 事件流式到达，activity 正常。

## 修复

### 后端（agent_runner.py）
\`_read_stdout\` 的 \`system\` 事件分支：对关键 subtype（api_retry / thinking_tokens / init 等）也触发 \`_activity_callback\`，带 subtype 和附加数据（attempt / estimated_tokens）。

### 前端（WorkflowTimeline.tsx）
\`formatLiveActivityLine\` 支持 \`system\` 类型渲染：
- \`api_retry\` → 🔄 retrying API request (attempt N)
- \`thinking_tokens\` → 💡 thinking… ~N tokens
- \`init\` 等 → ℹ️ 轻量状态

### 不改 \`--print\` 模式
实测确认 \`--print --output-format stream-json --verbose\` 是增量流式的（system/init/api_retry 逐行到达）。不需要改架构或生命周期。\`--print\` 是非 TTY 管道流式模式，web 终端的 executor 用完全相同的命令。

## 测试

\`tests/issues/1395/test_system_event_activity.py\`（3 用例）：
- \`test_api_retry_triggers_activity\`：api_retry → callback 带 attempt
- \`test_thinking_tokens_triggers_activity\`：thinking_tokens → callback 带 estimated_tokens
- \`test_init_triggers_activity\`：init → callback 带 subtype