### PR TITLE
fix: theme workflow list search in dark mode

### DIFF
--- a/frontend/src/components/work/AutonomousWorkflowList.css
+++ b/frontend/src/components/work/AutonomousWorkflowList.css
@@ -8,30 +8,30 @@
     background-color 180ms ease;
 }
 
-.auto-workflow-search .input-group {
+[data-theme='dark'] .auto-workflow-search .input-group {
   background: var(--bg-secondary);
   border: 1px solid var(--border-color);
   border-radius: var(--border-radius);
   overflow: hidden;
 }
 
-.auto-workflow-search .input-group-text {
+[data-theme='dark'] .auto-workflow-search .input-group-text {
   background: transparent;
   border: none;
   color: var(--text-muted);
 }
 
-.auto-workflow-search .form-control {
+[data-theme='dark'] .auto-workflow-search .form-control {
   background: transparent;
   border: none;
   color: var(--text-primary);
 }
 
-.auto-workflow-search .form-control:focus {
+[data-theme='dark'] .auto-workflow-search .form-control:focus {
   box-shadow: none;
 }
 
-.auto-workflow-search .form-control::placeholder {
+[data-theme='dark'] .auto-workflow-search .form-control::placeholder {
   color: var(--text-muted);
 }
 

--- a/frontend/src/components/work/AutonomousWorkflowList.css
+++ b/frontend/src/components/work/AutonomousWorkflowList.css
@@ -8,6 +8,33 @@
     background-color 180ms ease;
 }
 
+.auto-workflow-search .input-group {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--border-radius);
+  overflow: hidden;
+}
+
+.auto-workflow-search .input-group-text {
+  background: transparent;
+  border: none;
+  color: var(--text-muted);
+}
+
+.auto-workflow-search .form-control {
+  background: transparent;
+  border: none;
+  color: var(--text-primary);
+}
+
+.auto-workflow-search .form-control:focus {
+  box-shadow: none;
+}
+
+.auto-workflow-search .form-control::placeholder {
+  color: var(--text-muted);
+}
+
 .auto-workflow-item {
   cursor: pointer;
   border-bottom: 1px solid rgba(15, 23, 42, 0.06) !important;

--- a/frontend/src/components/work/AutonomousWorkflowList.tsx
+++ b/frontend/src/components/work/AutonomousWorkflowList.tsx
@@ -719,9 +719,9 @@ export const AutonomousWorkflowList: React.FC<AutonomousWorkflowListProps> = ({
   return (
     <>
       {/* Status Filter Tabs */}
-      <div className="px-2 py-2 border-bottom">
+      <div className="px-2 py-2 border-bottom auto-workflow-search">
         <div className="input-group input-group-sm">
-          <span className="input-group-text bg-white">
+          <span className="input-group-text">
             <i className="bi bi-search"></i>
           </span>
           <input


### PR DESCRIPTION
## Summary
- remove the hard-coded `bg-white` class from the autonomous workflow search icon container
- apply theme-aware search input styles so the workflow list search box matches dark mode

## Testing
- Not run (`frontend/node_modules` is missing in this worktree, so `vitest` and `tsc` are unavailable)