### PR TITLE
fix(analysis): 异常趋势图颜色区分异常类型 (Issue #1430)

### DIFF
--- a/frontend/src/components/features/analysis/AnomalyDetection.tsx
+++ b/frontend/src/components/features/analysis/AnomalyDetection.tsx
@@ -188,12 +188,13 @@ export const AnomalyDetection: React.FC = () => {
     return [spikes, drops];
   }, [anomalies]);
 
-  // Anomaly trend data from API
+  // Anomaly trend data from API - split by type for color coding
   const anomalyTrendData = useMemo(() => {
     const trend = trendData?.trend ?? [];
     return {
       labels: trend.map((t) => t.date),
-      data: trend.map((t) => t.count),
+      spikes: trend.map((t) => t.spikes),
+      drops: trend.map((t) => t.drops),
     };
   }, [trendData]);
 
@@ -336,10 +337,16 @@ export const AnomalyDetection: React.FC = () => {
                     labels={anomalyTrendData.labels}
                     datasets={[
                       {
-                        label: t('anomalies', language),
-                        data: anomalyTrendData.data,
+                        label: t('usageSpike', language),
+                        data: anomalyTrendData.spikes,
                         borderColor: 'rgba(255, 99, 132, 1)',
                         backgroundColor: 'rgba(255, 99, 132, 0.2)',
+                      },
+                      {
+                        label: t('usageDrop', language),
+                        data: anomalyTrendData.drops,
+                        borderColor: 'rgba(75, 192, 192, 1)',
+                        backgroundColor: 'rgba(75, 192, 192, 0.2)',
                       },
                     ]}
                     height={300}


### PR DESCRIPTION
## 问题描述

Fixes #1430

管理模式异常检测页面的异常趋势图未用颜色区分不同类型的异常情况（激增异常和下降异常），导致用户无法快速识别图表中不同类型的异常点。

## 修复方案

将单一数据集拆分为两个数据集，使用不同颜色区分：

- **激增异常 (spike)**: 红色 `rgba(255, 99, 132, 1)`
- **下降异常 (drop)**: 青色 `rgba(75, 192, 192, 1)`

颜色方案与异常分布饼图保持一致，确保视觉统一性。

## 技术实现

### 后端状态
API `/api/analysis/anomaly-trend` 已返回按类型分组的数据：
```json
{
  "trend": [
    {"date": "2026-07-01", "count": 5, "spikes": 3, "drops": 2}
  ]
}
```

### 前端修改
修改 `AnomalyDetection.tsx`：

1. `anomalyTrendData` useMemo 从 `count` 改为提取 `spikes` 和 `drops`
2. LineChart 配置从单一数据集改为两个数据集

## 验证要点

- [x] ESLint 检查通过
- [ ] CI 测试通过
- [ ] 趋势图显示两条不同颜色的线条
- [ ] 图例显示 "激增异常" 和 "下降异常" 两个标签
- [ ] 鼠标悬停时正确显示对应类型的数值

🤖 Generated with Qwen Code