### PR TITLE
fix(autonomous): implement max_sessions_per_user concurrent limit (Issue #1329)

### DIFF
--- a/app/repositories/autonomous_repo.py
+++ b/app/repositories/autonomous_repo.py
@@ -469,7 +469,7 @@ class AutonomousWorkflowRepository:
             """,
             (user_id,),
         )
-        return result["count"] if result else 0
+        return int(result["count"]) if result else 0
 
     def get_paused_workflows(self, quota_prefix: str = "") -> list:
         """Get paused workflows, optionally filtered to a quota-pause reason.

--- a/app/repositories/autonomous_repo.py
+++ b/app/repositories/autonomous_repo.py
@@ -454,6 +454,23 @@ class AutonomousWorkflowRepository:
             """
         )
 
+    def count_active_workflows_by_user(self, user_id: int) -> int:
+        """Count active workflows for a specific user.
+
+        Active statuses match ACTIVE_WORKFLOW_STATUSES in autonomous_scheduler.py.
+        Used for enforcing max_sessions_per_user concurrent limit.
+        """
+        result = self.db.fetch_one(
+            """
+            SELECT COUNT(*) as count FROM autonomous_workflows
+            WHERE user_id = ? AND status IN ('pending', 'preparing', 'planning',
+                                              'developing', 'pr_review', 'reporting',
+                                              'waiting', 'merging')
+            """,
+            (user_id,),
+        )
+        return result["count"] if result else 0
+
     def get_paused_workflows(self, quota_prefix: str = "") -> list:
         """Get paused workflows, optionally filtered to a quota-pause reason.
 

--- a/app/routes/autonomous.py
+++ b/app/routes/autonomous.py
@@ -219,6 +219,55 @@ def _enforce_quota_gate(user_id: int) -> Response | None:
     return None
 
 
+def _check_user_concurrent_limit(user_id: int) -> Response | None:
+    """Check if user has reached max_sessions_per_user limit.
+
+    Returns a 429 Response to short-circuit when the user has too many active
+    workflows; returns None to proceed.
+    """
+    from app.repositories.autonomous_repo import AutonomousWorkflowRepository
+    from app.repositories.tenant_repo import TenantRepository
+
+    DEFAULT_MAX_SESSIONS = 5
+
+    try:
+        # Get user's tenant quota
+        user = user_repo.get_user_by_id(user_id)
+        if not user:
+            return jsonify({"error": "User not found"}), 404
+
+        tenant_id = user.get("tenant_id")
+        max_sessions = DEFAULT_MAX_SESSIONS
+
+        if tenant_id:
+            tenant_repo = TenantRepository()
+            tenant = tenant_repo.get_tenant_by_id(tenant_id)
+            if tenant:
+                quota = tenant.get("quota", {})
+                max_sessions = quota.get("max_sessions_per_user", DEFAULT_MAX_SESSIONS)
+
+        # Count user's active workflows
+        auto_repo = _get_repo()
+        active_count = auto_repo.count_active_workflows_by_user(user_id)
+
+        if active_count >= max_sessions:
+            return (
+                jsonify(
+                    {
+                        "error": f"User has reached maximum concurrent workflows limit ({max_sessions})"
+                    }
+                ),
+                429,
+            )
+
+    except Exception as exc:
+        logger.error("Concurrent limit check failed: %s", exc)
+        # Fail-open: allow creation if check fails (less disruptive than blocking everyone)
+        return None
+
+    return None
+
+
 def _enrich_milestones_with_usage(
     workflow_id: str, milestones: list[dict[str, Any]]
 ) -> list[dict[str, Any]]:
@@ -539,6 +588,11 @@ def create_workflow():
     quota_rejection = _enforce_quota_gate(user_id)
     if quota_rejection is not None:
         return quota_rejection
+
+    # Concurrent limit: check max_sessions_per_user
+    concurrent_rejection = _check_user_concurrent_limit(user_id)
+    if concurrent_rejection is not None:
+        return concurrent_rejection
 
     # Validate remote machine admin permission
     workspace_type = data.get("workspace_type", "local")

--- a/app/routes/autonomous.py
+++ b/app/routes/autonomous.py
@@ -225,7 +225,6 @@ def _check_user_concurrent_limit(user_id: int) -> Response | None:
     Returns a 429 Response to short-circuit when the user has too many active
     workflows; returns None to proceed.
     """
-    from app.repositories.autonomous_repo import AutonomousWorkflowRepository
     from app.repositories.tenant_repo import TenantRepository
 
     DEFAULT_MAX_SESSIONS = 5
@@ -241,10 +240,9 @@ def _check_user_concurrent_limit(user_id: int) -> Response | None:
 
         if tenant_id:
             tenant_repo = TenantRepository()
-            tenant = tenant_repo.get_tenant_by_id(tenant_id)
+            tenant = tenant_repo.get_by_id(tenant_id)
             if tenant:
-                quota = tenant.get("quota", {})
-                max_sessions = quota.get("max_sessions_per_user", DEFAULT_MAX_SESSIONS)
+                max_sessions = tenant.quota.max_sessions_per_user
 
         # Count user's active workflows
         auto_repo = _get_repo()

--- a/app/services/autonomous_scheduler.py
+++ b/app/services/autonomous_scheduler.py
@@ -26,6 +26,20 @@ logger = logging.getLogger(__name__)
 
 # Maximum concurrent workflow executions
 MAX_CONCURRENT_WORKFLOWS = 3
+
+# Active workflow statuses for user concurrent limit check.
+# Includes 'waiting' because waiting workflows still occupy user's active slots.
+ACTIVE_WORKFLOW_STATUSES = {
+    "pending",
+    "preparing",
+    "planning",
+    "developing",
+    "pr_review",
+    "reporting",
+    "waiting",
+    "merging",
+}
+
 RUNNING_BATCH_STATUSES = {
     "pending",
     "preparing",

--- a/tests/issues/1329/test_concurrent_limit.py
+++ b/tests/issues/1329/test_concurrent_limit.py
@@ -1,0 +1,160 @@
+"""
+Tests for Issue #1329: max_sessions_per_user concurrent limit enforcement.
+"""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import app.repositories.database as db_mod
+from app.repositories.database import Database
+
+
+@pytest.fixture
+def auto_db(tmp_path):
+    """Create a temporary SQLite database with autonomous tables."""
+    with patch.object(db_mod, "is_postgresql", return_value=False):
+        orig = db_mod.adapt_sql
+        db_mod.adapt_sql = lambda q: q
+        try:
+            db_path = str(tmp_path / "test_concurrent.db")
+            db = Database(db_url=f"sqlite:///{db_path}")
+            conn = db.get_connection()
+            try:
+                cursor = conn.cursor()
+                cursor.execute("""
+                    CREATE TABLE IF NOT EXISTS users (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        username TEXT UNIQUE NOT NULL,
+                        email TEXT UNIQUE NOT NULL,
+                        password_hash TEXT NOT NULL,
+                        role TEXT DEFAULT 'user',
+                        tenant_id INTEGER,
+                        is_active INTEGER DEFAULT 1
+                    )
+                """)
+                cursor.execute("INSERT INTO users (username, email, password_hash, role, tenant_id) VALUES (?, ?, ?, ?, ?)", ("testuser", "test@test.com", "hash123", "user", 1))
+                cursor.execute("INSERT INTO users (username, email, password_hash, role, tenant_id) VALUES (?, ?, ?, ?, ?)", ("otheruser", "other@test.com", "hash456", "user", 1))
+                cursor.execute("""
+                    CREATE TABLE IF NOT EXISTS tenants (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        name TEXT NOT NULL,
+                        slug TEXT UNIQUE NOT NULL,
+                        quota TEXT
+                    )
+                """)
+                cursor.execute("INSERT INTO tenants (name, slug, quota) VALUES (?, ?, ?)", ("Test Tenant", "test-tenant", '{"max_sessions_per_user": 3}'))
+                from app.modules.workspace.autonomous import get_ddl_statements
+                for sql in get_ddl_statements():
+                    try:
+                        cursor.execute(sql)
+                    except Exception:
+                        pass
+                conn.commit()
+            finally:
+                conn.close()
+            yield db
+        finally:
+            db_mod.adapt_sql = orig
+            try:
+                os.unlink(db_path)
+            except OSError:
+                pass
+
+
+@pytest.fixture
+def flask_app():
+    """Create Flask app for testing jsonify responses."""
+    from app import create_app
+    app = create_app({"TESTING": True})
+    return app
+
+
+@pytest.fixture
+def repo(auto_db):
+    from app.repositories.autonomous_repo import AutonomousWorkflowRepository
+    return AutonomousWorkflowRepository(auto_db)
+
+
+class TestCountActiveWorkflowsByUser:
+    def test_count_zero_when_no_workflows(self, repo):
+        count = repo.count_active_workflows_by_user(user_id=1)
+        assert count == 0
+
+    def test_count_active_workflows_only(self, repo):
+        import uuid
+        repo.create_workflow({"workflow_id": str(uuid.uuid4()), "user_id": 1, "title": "Active", "status": "developing", "cli_tool": "claude-code"})
+        repo.create_workflow({"workflow_id": str(uuid.uuid4()), "user_id": 1, "title": "Done", "status": "completed", "cli_tool": "claude-code"})
+        count = repo.count_active_workflows_by_user(user_id=1)
+        assert count == 1
+
+    def test_count_multiple_active_statuses(self, repo):
+        import uuid
+        for i, status in enumerate(["pending", "planning", "developing", "waiting"]):
+            repo.create_workflow({"workflow_id": str(uuid.uuid4()), "user_id": 1, "title": f"T{i}", "status": status, "cli_tool": "claude-code"})
+        assert repo.count_active_workflows_by_user(user_id=1) == 4
+
+    def test_count_only_specific_user(self, repo):
+        import uuid
+        repo.create_workflow({"workflow_id": str(uuid.uuid4()), "user_id": 1, "title": "U1", "status": "developing", "cli_tool": "claude-code"})
+        repo.create_workflow({"workflow_id": str(uuid.uuid4()), "user_id": 2, "title": "U2", "status": "developing", "cli_tool": "claude-code"})
+        assert repo.count_active_workflows_by_user(user_id=1) == 1
+        assert repo.count_active_workflows_by_user(user_id=2) == 1
+
+
+class TestCheckUserConcurrentLimit:
+    def test_returns_none_when_under_limit(self, auto_db):
+        from app.routes.autonomous import _check_user_concurrent_limit
+        with patch("app.routes.autonomous._get_repo") as mock_get_repo:
+            mock_repo = MagicMock()
+            mock_repo.count_active_workflows_by_user.return_value = 1
+            mock_get_repo.return_value = mock_repo
+            with patch("app.routes.autonomous.user_repo") as mock_user_repo:
+                mock_user_repo.get_user_by_id.return_value = {"id": 1, "tenant_id": 1}
+                with patch("app.repositories.tenant_repo.TenantRepository") as mock_tenant_repo_class:
+                    mock_tenant_repo = MagicMock()
+                    mock_tenant_repo.get_tenant_by_id.return_value = {"id": 1, "quota": {"max_sessions_per_user": 3}}
+                    mock_tenant_repo_class.return_value = mock_tenant_repo
+                    result = _check_user_concurrent_limit(user_id=1)
+        assert result is None
+
+    def test_returns_429_when_at_limit(self, auto_db, flask_app):
+        """Should return 429 Response when user has reached the limit."""
+        from app.routes.autonomous import _check_user_concurrent_limit
+        with flask_app.app_context():
+            with patch("app.routes.autonomous._get_repo") as mock_get_repo:
+                mock_repo = MagicMock()
+                mock_repo.count_active_workflows_by_user.return_value = 3
+                mock_get_repo.return_value = mock_repo
+                with patch("app.routes.autonomous.user_repo") as mock_user_repo:
+                    mock_user_repo.get_user_by_id.return_value = {"id": 1, "tenant_id": 1}
+                    with patch("app.repositories.tenant_repo.TenantRepository") as mock_tenant_repo_class:
+                        mock_tenant_repo = MagicMock()
+                        mock_tenant_repo.get_tenant_by_id.return_value = {"id": 1, "quota": {"max_sessions_per_user": 3}}
+                        mock_tenant_repo_class.return_value = mock_tenant_repo
+                        result = _check_user_concurrent_limit(user_id=1)
+        assert result is not None
+        assert result[1] == 429
+
+    def test_uses_default_when_no_tenant(self, auto_db):
+        from app.routes.autonomous import _check_user_concurrent_limit
+        with patch("app.routes.autonomous._get_repo") as mock_get_repo:
+            mock_repo = MagicMock()
+            mock_repo.count_active_workflows_by_user.return_value = 3
+            mock_get_repo.return_value = mock_repo
+            with patch("app.routes.autonomous.user_repo") as mock_user_repo:
+                mock_user_repo.get_user_by_id.return_value = {"id": 1, "tenant_id": None}
+                result = _check_user_concurrent_limit(user_id=1)
+        assert result is None
+
+    def test_fail_open_on_exception(self, auto_db):
+        from app.routes.autonomous import _check_user_concurrent_limit
+        with patch("app.routes.autonomous._get_repo") as mock_get_repo:
+            mock_repo = MagicMock()
+            mock_repo.count_active_workflows_by_user.side_effect = Exception("DB error")
+            mock_get_repo.return_value = mock_repo
+            with patch("app.routes.autonomous.user_repo") as mock_user_repo:
+                mock_user_repo.get_user_by_id.return_value = {"id": 1, "tenant_id": 1}
+                result = _check_user_concurrent_limit(user_id=1)
+        assert result is None

--- a/tests/issues/1329/test_concurrent_limit.py
+++ b/tests/issues/1329/test_concurrent_limit.py
@@ -23,7 +23,8 @@ def auto_db(tmp_path):
             conn = db.get_connection()
             try:
                 cursor = conn.cursor()
-                cursor.execute("""
+                cursor.execute(
+                    """
                     CREATE TABLE IF NOT EXISTS users (
                         id INTEGER PRIMARY KEY AUTOINCREMENT,
                         username TEXT UNIQUE NOT NULL,
@@ -33,19 +34,32 @@ def auto_db(tmp_path):
                         tenant_id INTEGER,
                         is_active INTEGER DEFAULT 1
                     )
-                """)
-                cursor.execute("INSERT INTO users (username, email, password_hash, role, tenant_id) VALUES (?, ?, ?, ?, ?)", ("testuser", "test@test.com", "hash123", "user", 1))
-                cursor.execute("INSERT INTO users (username, email, password_hash, role, tenant_id) VALUES (?, ?, ?, ?, ?)", ("otheruser", "other@test.com", "hash456", "user", 1))
-                cursor.execute("""
+                """
+                )
+                cursor.execute(
+                    "INSERT INTO users (username, email, password_hash, role, tenant_id) VALUES (?, ?, ?, ?, ?)",
+                    ("testuser", "test@test.com", "hash123", "user", 1),
+                )
+                cursor.execute(
+                    "INSERT INTO users (username, email, password_hash, role, tenant_id) VALUES (?, ?, ?, ?, ?)",
+                    ("otheruser", "other@test.com", "hash456", "user", 1),
+                )
+                cursor.execute(
+                    """
                     CREATE TABLE IF NOT EXISTS tenants (
                         id INTEGER PRIMARY KEY AUTOINCREMENT,
                         name TEXT NOT NULL,
                         slug TEXT UNIQUE NOT NULL,
                         quota TEXT
                     )
-                """)
-                cursor.execute("INSERT INTO tenants (name, slug, quota) VALUES (?, ?, ?)", ("Test Tenant", "test-tenant", '{"max_sessions_per_user": 3}'))
+                """
+                )
+                cursor.execute(
+                    "INSERT INTO tenants (name, slug, quota) VALUES (?, ?, ?)",
+                    ("Test Tenant", "test-tenant", '{"max_sessions_per_user": 3}'),
+                )
                 from app.modules.workspace.autonomous import get_ddl_statements
+
                 for sql in get_ddl_statements():
                     try:
                         cursor.execute(sql)
@@ -67,6 +81,7 @@ def auto_db(tmp_path):
 def flask_app():
     """Create Flask app for testing jsonify responses."""
     from app import create_app
+
     app = create_app({"TESTING": True})
     return app
 
@@ -74,6 +89,7 @@ def flask_app():
 @pytest.fixture
 def repo(auto_db):
     from app.repositories.autonomous_repo import AutonomousWorkflowRepository
+
     return AutonomousWorkflowRepository(auto_db)
 
 
@@ -84,21 +100,64 @@ class TestCountActiveWorkflowsByUser:
 
     def test_count_active_workflows_only(self, repo):
         import uuid
-        repo.create_workflow({"workflow_id": str(uuid.uuid4()), "user_id": 1, "title": "Active", "status": "developing", "cli_tool": "claude-code"})
-        repo.create_workflow({"workflow_id": str(uuid.uuid4()), "user_id": 1, "title": "Done", "status": "completed", "cli_tool": "claude-code"})
+
+        repo.create_workflow(
+            {
+                "workflow_id": str(uuid.uuid4()),
+                "user_id": 1,
+                "title": "Active",
+                "status": "developing",
+                "cli_tool": "claude-code",
+            }
+        )
+        repo.create_workflow(
+            {
+                "workflow_id": str(uuid.uuid4()),
+                "user_id": 1,
+                "title": "Done",
+                "status": "completed",
+                "cli_tool": "claude-code",
+            }
+        )
         count = repo.count_active_workflows_by_user(user_id=1)
         assert count == 1
 
     def test_count_multiple_active_statuses(self, repo):
         import uuid
+
         for i, status in enumerate(["pending", "planning", "developing", "waiting"]):
-            repo.create_workflow({"workflow_id": str(uuid.uuid4()), "user_id": 1, "title": f"T{i}", "status": status, "cli_tool": "claude-code"})
+            repo.create_workflow(
+                {
+                    "workflow_id": str(uuid.uuid4()),
+                    "user_id": 1,
+                    "title": f"T{i}",
+                    "status": status,
+                    "cli_tool": "claude-code",
+                }
+            )
         assert repo.count_active_workflows_by_user(user_id=1) == 4
 
     def test_count_only_specific_user(self, repo):
         import uuid
-        repo.create_workflow({"workflow_id": str(uuid.uuid4()), "user_id": 1, "title": "U1", "status": "developing", "cli_tool": "claude-code"})
-        repo.create_workflow({"workflow_id": str(uuid.uuid4()), "user_id": 2, "title": "U2", "status": "developing", "cli_tool": "claude-code"})
+
+        repo.create_workflow(
+            {
+                "workflow_id": str(uuid.uuid4()),
+                "user_id": 1,
+                "title": "U1",
+                "status": "developing",
+                "cli_tool": "claude-code",
+            }
+        )
+        repo.create_workflow(
+            {
+                "workflow_id": str(uuid.uuid4()),
+                "user_id": 2,
+                "title": "U2",
+                "status": "developing",
+                "cli_tool": "claude-code",
+            }
+        )
         assert repo.count_active_workflows_by_user(user_id=1) == 1
         assert repo.count_active_workflows_by_user(user_id=2) == 1
 
@@ -106,15 +165,20 @@ class TestCountActiveWorkflowsByUser:
 class TestCheckUserConcurrentLimit:
     def test_returns_none_when_under_limit(self, auto_db):
         from app.routes.autonomous import _check_user_concurrent_limit
+
         with patch("app.routes.autonomous._get_repo") as mock_get_repo:
             mock_repo = MagicMock()
             mock_repo.count_active_workflows_by_user.return_value = 1
             mock_get_repo.return_value = mock_repo
             with patch("app.routes.autonomous.user_repo") as mock_user_repo:
                 mock_user_repo.get_user_by_id.return_value = {"id": 1, "tenant_id": 1}
-                with patch("app.repositories.tenant_repo.TenantRepository") as mock_tenant_repo_class:
+                with patch(
+                    "app.repositories.tenant_repo.TenantRepository"
+                ) as mock_tenant_repo_class:
                     mock_tenant_repo = MagicMock()
-                    mock_tenant_repo.get_tenant_by_id.return_value = {"id": 1, "quota": {"max_sessions_per_user": 3}}
+                    mock_tenant = MagicMock()
+                    mock_tenant.quota.max_sessions_per_user = 3
+                    mock_tenant_repo.get_by_id.return_value = mock_tenant
                     mock_tenant_repo_class.return_value = mock_tenant_repo
                     result = _check_user_concurrent_limit(user_id=1)
         assert result is None
@@ -122,6 +186,7 @@ class TestCheckUserConcurrentLimit:
     def test_returns_429_when_at_limit(self, auto_db, flask_app):
         """Should return 429 Response when user has reached the limit."""
         from app.routes.autonomous import _check_user_concurrent_limit
+
         with flask_app.app_context():
             with patch("app.routes.autonomous._get_repo") as mock_get_repo:
                 mock_repo = MagicMock()
@@ -129,9 +194,13 @@ class TestCheckUserConcurrentLimit:
                 mock_get_repo.return_value = mock_repo
                 with patch("app.routes.autonomous.user_repo") as mock_user_repo:
                     mock_user_repo.get_user_by_id.return_value = {"id": 1, "tenant_id": 1}
-                    with patch("app.repositories.tenant_repo.TenantRepository") as mock_tenant_repo_class:
+                    with patch(
+                        "app.repositories.tenant_repo.TenantRepository"
+                    ) as mock_tenant_repo_class:
                         mock_tenant_repo = MagicMock()
-                        mock_tenant_repo.get_tenant_by_id.return_value = {"id": 1, "quota": {"max_sessions_per_user": 3}}
+                        mock_tenant = MagicMock()
+                        mock_tenant.quota.max_sessions_per_user = 3
+                        mock_tenant_repo.get_by_id.return_value = mock_tenant
                         mock_tenant_repo_class.return_value = mock_tenant_repo
                         result = _check_user_concurrent_limit(user_id=1)
         assert result is not None
@@ -139,6 +208,7 @@ class TestCheckUserConcurrentLimit:
 
     def test_uses_default_when_no_tenant(self, auto_db):
         from app.routes.autonomous import _check_user_concurrent_limit
+
         with patch("app.routes.autonomous._get_repo") as mock_get_repo:
             mock_repo = MagicMock()
             mock_repo.count_active_workflows_by_user.return_value = 3
@@ -150,6 +220,7 @@ class TestCheckUserConcurrentLimit:
 
     def test_fail_open_on_exception(self, auto_db):
         from app.routes.autonomous import _check_user_concurrent_limit
+
         with patch("app.routes.autonomous._get_repo") as mock_get_repo:
             mock_repo = MagicMock()
             mock_repo.count_active_workflows_by_user.side_effect = Exception("DB error")


### PR DESCRIPTION
## Summary

Fixes #1329: Implements `max_sessions_per_user` concurrent limit enforcement for autonomous workflows.

## Problem

- `MAX_CONCURRENT_WORKFLOWS=3` was hardcoded, not configurable
- `max_sessions_per_user` was defined in `QuotaConfig` but never used
- Users could create unlimited concurrent workflows ignoring quota settings

## Solution

1. Add `ACTIVE_WORKFLOW_STATUSES` constant in `autonomous_scheduler.py`
2. Add `count_active_workflows_by_user()` method in `autonomous_repo.py`
3. Add `_check_user_concurrent_limit()` function in `autonomous.py`
4. Add check call in `create_workflow()`

## Test Plan

- 8 new tests covering count, limit check, and edge cases
- All tests pass