### PR TITLE
fix(e2e): 修复测试选择器与组件实现不匹配 (Issue #1720)

### DIFF
--- a/frontend/e2e/management.spec.ts
+++ b/frontend/e2e/management.spec.ts
@@ -187,6 +187,10 @@ test.describe('Audit Center', () => {
     await page.goto('/manage/audit');
     await waitForApp(page);
 
+    // Wait for loading to complete (spinner may or may not appear)
+    const loading = page.locator('.audit-center .spinner-border');
+    await loading.waitFor({ state: 'hidden', timeout: 10000 }).catch(() => {});
+
     // Log tab should show filters card and table, or error alert, or empty state
     const table = page.locator('.audit-center table.table');
     const card = page.locator('.audit-center .card');

--- a/frontend/e2e/report.spec.ts
+++ b/frontend/e2e/report.spec.ts
@@ -50,9 +50,9 @@ test.describe('Report Page', () => {
     await page.goto('/report');
     await waitForApp(page);
 
-    // Look for date inputs
-    const dateInput = page.locator('input[type="date"]').first();
-    await expect(dateInput).toBeVisible({ timeout: 5000 });
+    // Look for DatePicker components (rendered as button.form-control, not input[type="date"])
+    const datePicker = page.locator('.open-ace-datepicker button.form-control').first();
+    await expect(datePicker).toBeVisible({ timeout: 5000 });
   });
 
   test('should display usage table', async ({ page }) => {


### PR DESCRIPTION
## 问题描述

E2E 测试失败，两个测试在所有浏览器上失败：

1. **Report Page › should have date range filter**
   - 测试使用 `input[type="date"]` 选择器
   - 但 DatePicker 组件渲染为 `<button class="form-control">`

2. **Audit Center › should display audit log table or content**
   - 测试没有等待 Loading 状态完成
   - 页面在 loading 时检查元素导致失败

## 修复内容

- `frontend/e2e/report.spec.ts`: 更新选择器为 `.open-ace-datepicker button.form-control`
- `frontend/e2e/management.spec.ts`: 添加 loading 状态等待

## 测试验证

CI 将自动运行 E2E 测试验证修复效果。

Fixes #1720