### PR TITLE
fix(remote-agent): 交互式询问转发到前端处理 (Issue #122)

### DIFF
--- a/app/modules/workspace/remote_session_manager.py
+++ b/app/modules/workspace/remote_session_manager.py
@@ -679,6 +679,53 @@ class RemoteSessionManager:
         self._agent_manager.send_command(machine_id, command)
         return True
 
+    def respond_to_interaction(
+        self,
+        session_id: str,
+        msg_id: str,
+        response: dict[str, Any],
+        *,
+        decided_by: Optional[int] = None,
+        decided_by_name: Optional[str] = None,
+    ) -> bool:
+        """Send an interaction response to the remote agent.
+
+        This handles responses for interaction/requestUserInput and
+        interaction/requestPermission server requests that were forwarded
+        to the frontend for user decision.
+
+        Args:
+            session_id: Session identifier.
+            msg_id: The message ID from the original interaction request.
+            response: The user's response (action: answer/decline or decision: allow/deny).
+            decided_by: User ID who made the decision.
+            decided_by_name: Username who made the decision.
+
+        Returns:
+            True if the response was sent successfully, False otherwise.
+        """
+        machine_id = self._get_machine_id(session_id)
+        if not machine_id:
+            return False
+
+        logger.info(
+            "Sending interaction response for session %s, msg_id=%s, decided_by=%s",
+            session_id[:8],
+            msg_id[:8] if msg_id else "N/A",
+            decided_by_name or decided_by or "unknown",
+        )
+
+        command: dict[str, Any] = {
+            "type": "command",
+            "command": "interaction_response",
+            "session_id": session_id,
+            "msg_id": msg_id,
+            "response": response,
+        }
+
+        self._agent_manager.send_command(machine_id, command)
+        return True
+
     def _enforce_policy_consume(
         self,
         session_id: str,

--- a/app/routes/remote.py
+++ b/app/routes/remote.py
@@ -829,6 +829,52 @@ def send_permission_response(session_id):
     return jsonify({"success": True})
 
 
+@remote_bp.route("/sessions/<session_id>/interaction", methods=["POST"])
+def send_interaction_response(session_id):
+    """
+    Send an interaction response from the frontend to the remote agent.
+
+    This handles responses for interaction/requestUserInput and
+    interaction/requestPermission server requests that were forwarded
+    to the frontend for user decision.
+
+    Expected JSON body:
+        {
+            "msg_id": "...",
+            "response": {
+                "action": "answer" | "decline",
+                "response": "user input"  // for answer
+            }
+            // OR
+            "response": {
+                "decision": "allow" | "deny",
+                "reason": "optional deny reason"
+            }
+        }
+    """
+    session_info, access_error = _check_session_access(session_id)
+    if access_error:
+        return access_error
+
+    data = request.get_json() or {}
+    msg_id = data.get("msg_id")
+    response = data.get("response", {})
+
+    if not msg_id:
+        return jsonify({"success": False, "error": "Missing msg_id"}), 400
+
+    session_mgr = get_remote_session_manager()
+    success = session_mgr.respond_to_interaction(
+        session_id,
+        msg_id,
+        response,
+        decided_by=g.user.get("id") if g.get("user") else None,
+        decided_by_name=g.user.get("username") if g.get("user") else None,
+    )
+
+    return jsonify({"success": success})
+
+
 @remote_bp.route("/sessions/<session_id>/stream")
 def stream_session_output(session_id):
     """SSE: real-time stream of remote session output, formatted as claude_json."""

--- a/remote-agent/agent.py
+++ b/remote-agent/agent.py
@@ -495,6 +495,8 @@ class RemoteAgent:
             self._cmd_stop_session(data)
         elif command == "permission_response":
             self._cmd_permission_response(data)
+        elif command == "interaction_response":
+            self._cmd_interaction_response(data)
         elif command == "update_permission_mode":
             self._cmd_update_permission_mode(data)
         elif command == "update_model":
@@ -696,6 +698,30 @@ class RemoteAgent:
         if not result["success"]:
             logger.warning(
                 "Failed to handle permission response: %s",
+                result.get("error"),
+            )
+
+    def _cmd_interaction_response(self, data: dict[str, Any]) -> None:
+        """Handle an interaction_response command from the frontend.
+
+        Sends a user's response back to the ZCode app-server for
+        interaction/requestUserInput or interaction/requestPermission requests.
+        """
+        session_id = data.get("session_id", "")
+        msg_id = data.get("msg_id", "")
+        response = data.get("response", {})
+
+        logger.info(
+            "Interaction response for session %s: msg_id=%s",
+            session_id[:8],
+            msg_id[:8] if msg_id else "N/A",
+        )
+
+        result = self._executor.send_interaction_response(session_id, msg_id, response)
+
+        if not result["success"]:
+            logger.warning(
+                "Failed to handle interaction response: %s",
                 result.get("error"),
             )
 

--- a/remote-agent/executor.py
+++ b/remote-agent/executor.py
@@ -1591,6 +1591,35 @@ class ProcessExecutor:
             return {"success": True}
         return {"success": False, "error": "Failed to write permission response to stdin"}
 
+    def send_interaction_response(
+        self, session_id: str, msg_id: str, response: dict[str, Any]
+    ) -> dict[str, Any]:
+        """
+        Send an interaction response to a ZCode session.
+
+        Args:
+            session_id: Session identifier.
+            msg_id: The message ID from the original interaction request.
+            response: The user's response (action: answer/decline or decision: allow/deny).
+
+        Returns:
+            Dict with 'success' and optionally 'error'.
+        """
+        with self._lock:
+            session = self._sessions.get(session_id)
+
+        if not session:
+            return {"success": False, "error": f"Session {session_id[:8]} not found"}
+
+        # ZCodeAppServerSession has send_interaction_response method
+        if hasattr(session, "send_interaction_response"):
+            ok = session.send_interaction_response(msg_id, response)
+            if ok:
+                return {"success": True}
+            return {"success": False, "error": "Failed to send interaction response"}
+
+        return {"success": False, "error": "Session does not support interaction response"}
+
     def pause_session(self, session_id: str) -> dict[str, Any]:
         """Pause a session by suspending its subprocess."""
         with self._lock:

--- a/remote-agent/zcode_app_server.py
+++ b/remote-agent/zcode_app_server.py
@@ -829,12 +829,15 @@ class ZCodeAppServerSession:
             with self._lock:
                 self._pending_server_requests[msg_id] = method
             # Forward to frontend via permission_callback
-            self.permission_callback(self.session_id, {
-                "type": "interaction_request",
-                "method": method,
-                "id": msg_id,
-                "params": params,
-            })
+            self.permission_callback(
+                self.session_id,
+                {
+                    "type": "interaction_request",
+                    "method": method,
+                    "id": msg_id,
+                    "params": params,
+                },
+            )
             return
 
         if method == "interaction/requestPermission" and self.permission_callback:
@@ -848,12 +851,15 @@ class ZCodeAppServerSession:
             with self._lock:
                 self._pending_server_requests[msg_id] = method
             # Forward to frontend via permission_callback
-            self.permission_callback(self.session_id, {
-                "type": "interaction_request",
-                "method": method,
-                "id": msg_id,
-                "params": params,
-            })
+            self.permission_callback(
+                self.session_id,
+                {
+                    "type": "interaction_request",
+                    "method": method,
+                    "id": msg_id,
+                    "params": params,
+                },
+            )
             return
 
         # Unattended mode: auto-respond

--- a/remote-agent/zcode_app_server.py
+++ b/remote-agent/zcode_app_server.py
@@ -90,6 +90,8 @@ class ZCodeAppServerSession:
         # Request/response correlation: id -> (Event, result holder).
         self._lock = threading.Lock()
         self._pending: dict[str | int, dict[str, Any]] = {}
+        # Pending server requests waiting for user response (interaction/requestUserInput, interaction/requestPermission)
+        self._pending_server_requests: dict[str | int, str] = {}
 
         # Event polling state: last consumed event seq per session.
         self._last_event_seq = 0
@@ -812,7 +814,49 @@ class ZCodeAppServerSession:
             self._forward_one_event({"type": "state.updated", "payload": msg.get("params", {})})
 
     def _handle_server_request(self, msg_id: str, method: str, params: dict[str, Any]) -> None:
-        """Auto-respond to server→client requests in unattended mode."""
+        """Handle server→client requests.
+
+        In user-interactive mode (permission_callback set), forward requests
+        to the frontend for human decision. In unattended mode, auto-respond.
+        """
+        # User-interactive mode: forward to frontend for human decision
+        if method == "interaction/requestUserInput" and self.permission_callback:
+            logger.info(
+                "ZCode interaction/requestUserInput forwarded to frontend for %s",
+                self.session_id[:8],
+            )
+            # Store pending request for later response
+            with self._lock:
+                self._pending_server_requests[msg_id] = method
+            # Forward to frontend via permission_callback
+            self.permission_callback(self.session_id, {
+                "type": "interaction_request",
+                "method": method,
+                "id": msg_id,
+                "params": params,
+            })
+            return
+
+        if method == "interaction/requestPermission" and self.permission_callback:
+            tool_name = params.get("toolName", "?")
+            logger.info(
+                "ZCode interaction/requestPermission forwarded to frontend for %s (tool=%s)",
+                self.session_id[:8],
+                tool_name,
+            )
+            # Store pending request for later response
+            with self._lock:
+                self._pending_server_requests[msg_id] = method
+            # Forward to frontend via permission_callback
+            self.permission_callback(self.session_id, {
+                "type": "interaction_request",
+                "method": method,
+                "id": msg_id,
+                "params": params,
+            })
+            return
+
+        # Unattended mode: auto-respond
         if method == "interaction/requestUserInput":
             # AskUserQuestion (or similar) is waiting for a human answer.
             # Decline so the agent knows to proceed with its own judgment.
@@ -859,6 +903,34 @@ class ZCodeAppServerSession:
                 "message": f"Unhandled server request: {method}",
             },
         )
+
+    def send_interaction_response(self, msg_id: str, response: dict[str, Any]) -> bool:
+        """Send a user's response back to the ZCode app-server.
+
+        Args:
+            msg_id: The message ID from the original interaction request.
+            response: The user's response (action: answer/decline or decision: allow/deny).
+
+        Returns:
+            True if the response was sent successfully, False otherwise.
+        """
+        with self._lock:
+            if msg_id not in self._pending_server_requests:
+                logger.warning(
+                    "Unknown interaction request %s for %s",
+                    msg_id[:8] if msg_id else "N/A",
+                    self.session_id[:8],
+                )
+                return False
+            del self._pending_server_requests[msg_id]
+
+        logger.info(
+            "Sending interaction response for %s, msg_id=%s",
+            self.session_id[:8],
+            msg_id[:8] if msg_id else "N/A",
+        )
+        self._send_response(msg_id, response)
+        return True
 
     def _send_response(self, msg_id: str, result: Any, error: dict[str, Any] | None = None) -> None:
         """Write a server→client response back to the app-server stdin."""


### PR DESCRIPTION
## 问题

当 ZCode app-server 发送 `interaction/requestUserInput` 或 `interaction/requestPermission` 请求时，`_handle_server_request` 方法无条件自动响应，导致用户选择（NO/Deny）被忽略，Agent 继续运行。

## 解决方案

1. 在 `_handle_server_request` 中检查 `permission_callback` 是否存在
2. 用户交互模式下通过 `permission_callback` 转发请求到前端
3. 前端用户做出选择后，通过新增的 API 发送响应回 ZCode

## 修改文件

| 文件 | 修改内容 |
|------|----------|
| `remote-agent/zcode_app_server.py` | 添加 `_pending_server_requests` 字典、修改 `_handle_server_request`、新增 `send_interaction_response` 方法 |
| `remote-agent/agent.py` | 新增 `_cmd_interaction_response` 处理器和路由 |
| `remote-agent/executor.py` | 新增 `send_interaction_response` 方法 |
| `app/routes/remote.py` | 新增 `/sessions/<session_id>/interaction` API 端点 |
| `app/modules/workspace/remote_session_manager.py` | 新增 `respond_to_interaction` 方法 |

## 响应格式

**`interaction/requestUserInput` 响应：**
```python
# 用户拒绝
{"action": "decline", "reason": "User declined"}

# 用户回答
{"action": "answer", "response": "用户输入的内容"}
```

**`interaction/requestPermission` 响应：**
```python
# 允许
{"decision": "allow"}

# 拒绝
{"decision": "deny", "reason": "User denied"}
```

Closes #122