### PR TITLE
fix: correct usage fetcher token attribution

### DIFF
--- a/scripts/compare_zai_usage.py
+++ b/scripts/compare_zai_usage.py
@@ -1,0 +1,325 @@
+#!/usr/bin/env python3
+"""
+Compare Open ACE Claude/ZCode usage with z.ai usage totals.
+
+This script does not mutate the database. It reads:
+  - Open ACE PostgreSQL ``daily_usage`` for Claude
+  - Raw ZCode ``turn_usage`` from ~/.zcode/cli/db/db.sqlite
+  - Raw Claude JSONL logs from ~/.claude/projects
+
+It then prints:
+  - Date-range totals by tool
+  - Provider-style source totals
+  - The implied Claude cache multiplier needed to match a known z.ai total
+  - Optional hourly comparisons for a known z.ai hourly bar
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import sqlite3
+import sys
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parent
+
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from shared import config  # noqa: E402
+
+
+def _load_fetch_claude_module():
+    spec = importlib.util.spec_from_file_location(
+        "fetch_claude_compare", SCRIPT_DIR / "fetch_claude.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@dataclass
+class Totals:
+    tokens: int = 0
+    cache_read_tokens: int = 0
+    cache_creation_tokens: int = 0
+
+    @property
+    def cache_tokens(self) -> int:
+        return self.cache_read_tokens + self.cache_creation_tokens
+
+
+def _fmt_int(value: int) -> str:
+    return f"{value:,}"
+
+
+def _fmt_float(value: float) -> str:
+    return f"{value:.4f}"
+
+
+def _connect_postgres():
+    db_url = config.get_database_url()
+    if not db_url.startswith("postgresql"):
+        raise RuntimeError(f"Expected PostgreSQL database, got: {db_url}")
+    import psycopg2
+
+    return psycopg2.connect(db_url)
+
+
+def load_claude_daily_usage(start_date: str, end_date: str) -> Totals:
+    conn = _connect_postgres()
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT
+                    COALESCE(SUM(tokens_used), 0),
+                    COALESCE(SUM(cache_tokens), 0)
+                FROM daily_usage
+                WHERE tool_name = 'claude'
+                  AND date BETWEEN %s AND %s
+                """,
+                (start_date, end_date),
+            )
+            total_tokens, cache_tokens = cur.fetchone()
+    finally:
+        conn.close()
+
+    return Totals(
+        tokens=int((total_tokens or 0) - (cache_tokens or 0)),
+        cache_read_tokens=int(cache_tokens or 0),
+        cache_creation_tokens=0,
+    )
+
+
+def _parse_iso_to_local_hour(ts_str: str) -> str | None:
+    if not ts_str:
+        return None
+    try:
+        if ts_str.endswith("Z"):
+            if "." in ts_str:
+                base, rest = ts_str.rsplit(".", 1)
+                ms = rest.rstrip("Z")
+                ms = ms[:3].ljust(3, "0")
+                dt = datetime.strptime(f"{base}.{ms}Z", "%Y-%m-%dT%H:%M:%S.%fZ")
+            else:
+                dt = datetime.strptime(ts_str, "%Y-%m-%dT%H:%M:%SZ")
+            dt = dt.replace(tzinfo=timezone.utc).astimezone()
+        else:
+            dt = datetime.fromisoformat(ts_str.replace("Z", "+00:00")).astimezone()
+        return dt.strftime("%Y-%m-%d %H:00")
+    except Exception:
+        return None
+
+
+def load_claude_source_usage(
+    start_date: str, end_date: str, hour_filter: str | None = None
+) -> Totals:
+    fetch_claude = _load_fetch_claude_module()
+    project_dir = fetch_claude.find_claude_project_dir()
+    if not project_dir:
+        raise RuntimeError("Cannot find Claude project directory")
+
+    projects: list[Path]
+    direct_files = list(project_dir.glob("*.jsonl"))
+    if direct_files:
+        projects = [project_dir]
+    else:
+        projects = [d for d in project_dir.iterdir() if d.is_dir() and list(d.glob("*.jsonl"))]
+
+    totals = Totals()
+    for proj in projects:
+        for jsonl_file in proj.glob("*.jsonl"):
+            daily, messages = fetch_claude.process_jsonl_file(jsonl_file)
+
+            if hour_filter is None:
+                for date_key, stats in daily.items():
+                    if not (start_date <= date_key <= end_date):
+                        continue
+                    totals.tokens += int(stats["input_tokens"] or 0)
+                    totals.tokens += int(stats["output_tokens"] or 0)
+                    totals.cache_read_tokens += int(stats["cache_read_tokens"] or 0)
+                    totals.cache_creation_tokens += int(stats["cache_creation_tokens"] or 0)
+                continue
+
+            for msg in messages:
+                ts = msg.get("timestamp")
+                local_hour = _parse_iso_to_local_hour(ts) if ts else None
+                if local_hour != hour_filter:
+                    continue
+                local_date = msg.get("date") or (local_hour[:10] if local_hour else None)
+                if not local_date or not (start_date <= local_date <= end_date):
+                    continue
+                totals.tokens += int(msg.get("input_tokens", 0) or 0)
+                totals.tokens += int(msg.get("output_tokens", 0) or 0)
+                totals.cache_read_tokens += int(msg.get("cache_read_tokens", 0) or 0)
+                totals.cache_creation_tokens += int(msg.get("cache_creation_tokens", 0) or 0)
+
+    return totals
+
+
+def load_zcode_source_usage(
+    start_date: str,
+    end_date: str,
+    *,
+    include_subagents: bool,
+    hour_filter: str | None = None,
+) -> Totals:
+    db_path = Path.home() / ".zcode" / "cli" / "db" / "db.sqlite"
+    if not db_path.is_file():
+        raise RuntimeError(f"Cannot find ZCode DB: {db_path}")
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        where = [
+            "date(datetime(t.started_at/1000,'unixepoch','localtime')) BETWEEN ? AND ?",
+        ]
+        params: list[Any] = [start_date, end_date]
+        if not include_subagents:
+            where.append("s.task_type = 'interactive'")
+            where.append("s.time_archived IS NULL")
+        if hour_filter is not None:
+            where.append(
+                "strftime('%Y-%m-%d %H:00', datetime(t.started_at/1000,'unixepoch','localtime')) = ?"
+            )
+            params.append(hour_filter)
+
+        sql = f"""
+            SELECT
+                COALESCE(SUM(t.computed_total_tokens), 0),
+                COALESCE(SUM(t.cache_read_input_tokens), 0),
+                COALESCE(SUM(t.cache_creation_input_tokens), 0)
+            FROM turn_usage t
+            JOIN session s ON s.id = t.session_id
+            WHERE {" AND ".join(where)}
+        """
+        row = conn.execute(sql, tuple(params)).fetchone()
+    finally:
+        conn.close()
+
+    return Totals(
+        tokens=int(row[0] or 0),
+        cache_read_tokens=int(row[1] or 0),
+        cache_creation_tokens=int(row[2] or 0),
+    )
+
+
+def implied_cache_multiplier(target_total: int, base_total: int, cache_total: int) -> float | None:
+    if cache_total == 0:
+        return None
+    return (target_total - base_total) / cache_total
+
+
+def print_totals(label: str, totals: Totals) -> None:
+    print(label)
+    print(f"  Tokens:         {_fmt_int(totals.tokens)}")
+    print(f"  Cache read:     {_fmt_int(totals.cache_read_tokens)}")
+    print(f"  Cache creation: {_fmt_int(totals.cache_creation_tokens)}")
+    print(f"  Cache total:    {_fmt_int(totals.cache_tokens)}")
+    print(f"  Tokens+cache:   {_fmt_int(totals.tokens + totals.cache_tokens)}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--start-date", default="2026-07-09", help="Start date YYYY-MM-DD")
+    parser.add_argument("--end-date", default="2026-07-15", help="End date YYYY-MM-DD")
+    parser.add_argument(
+        "--zai-total",
+        type=int,
+        default=170051875,
+        help="Known z.ai total tokens for the range",
+    )
+    parser.add_argument(
+        "--zai-hour",
+        default="2026-07-15 15:00",
+        help="Known local-hour bucket from z.ai chart",
+    )
+    parser.add_argument(
+        "--zai-hour-total",
+        type=int,
+        default=28618223,
+        help="Known z.ai token total for --zai-hour",
+    )
+    args = parser.parse_args()
+
+    print(f"Range: {args.start_date} -> {args.end_date}")
+    print(f"z.ai total: {_fmt_int(args.zai_total)}")
+    print()
+
+    claude_db = load_claude_daily_usage(args.start_date, args.end_date)
+    claude_src = load_claude_source_usage(args.start_date, args.end_date)
+    zcode_openace_scope = load_zcode_source_usage(
+        args.start_date, args.end_date, include_subagents=False
+    )
+    zcode_all_scope = load_zcode_source_usage(
+        args.start_date, args.end_date, include_subagents=True
+    )
+
+    print_totals("Claude (Open ACE daily_usage)", claude_db)
+    print()
+    print_totals("Claude (raw source logs)", claude_src)
+    print()
+    print_totals("ZCode (interactive, active sessions only)", zcode_openace_scope)
+    print()
+    print_totals("ZCode (all source sessions)", zcode_all_scope)
+    print()
+
+    for label, zcode in [
+        ("Open ACE ZCode scope", zcode_openace_scope),
+        ("All-source ZCode scope", zcode_all_scope),
+    ]:
+        base_total = zcode.tokens + claude_src.tokens
+        cache_total = claude_src.cache_tokens
+        multiplier = implied_cache_multiplier(args.zai_total, base_total, cache_total)
+        print(label)
+        print(f"  Base total without Claude cache: {_fmt_int(base_total)}")
+        print(f"  Claude cache to reconcile:       {_fmt_int(cache_total)}")
+        if multiplier is None:
+            print("  Implied Claude cache multiplier: n/a")
+        else:
+            print(f"  Implied Claude cache multiplier: {_fmt_float(multiplier)}")
+            reconciled = base_total + int(round(cache_total * multiplier))
+            print(f"  Reconciled total at multiplier:  {_fmt_int(reconciled)}")
+        print()
+
+    if args.zai_hour and args.zai_hour_total:
+        print(f"Hourly check: {args.zai_hour} -> z.ai {_fmt_int(args.zai_hour_total)}")
+        claude_hour = load_claude_source_usage(
+            args.zai_hour[:10], args.zai_hour[:10], hour_filter=args.zai_hour
+        )
+        zcode_hour = load_zcode_source_usage(
+            args.zai_hour[:10],
+            args.zai_hour[:10],
+            include_subagents=True,
+            hour_filter=args.zai_hour,
+        )
+        print_totals("Claude (raw source hour)", claude_hour)
+        print()
+        print_totals("ZCode (raw source hour)", zcode_hour)
+        print()
+        hour_base = claude_hour.tokens + zcode_hour.tokens
+        hour_multiplier = implied_cache_multiplier(
+            args.zai_hour_total, hour_base, claude_hour.cache_tokens
+        )
+        print(f"  Hour base total without Claude cache: {_fmt_int(hour_base)}")
+        print(f"  Hour Claude cache to reconcile:       {_fmt_int(claude_hour.cache_tokens)}")
+        if hour_multiplier is None:
+            print("  Hour implied Claude cache multiplier: n/a")
+        else:
+            print(f"  Hour implied Claude cache multiplier: {_fmt_float(hour_multiplier)}")
+            reconciled = hour_base + int(round(claude_hour.cache_tokens * hour_multiplier))
+            print(f"  Hour reconciled total:               {_fmt_int(reconciled)}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/compare_zai_usage.py
+++ b/scripts/compare_zai_usage.py
@@ -18,17 +18,14 @@ from __future__ import annotations
 
 import argparse
 import importlib.util
-import json
 import sqlite3
 import sys
-from collections import defaultdict
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
 SCRIPT_DIR = Path(__file__).resolve().parent
-REPO_ROOT = SCRIPT_DIR.parent
 
 if str(SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPT_DIR))
@@ -227,31 +224,37 @@ def print_totals(label: str, totals: Totals) -> None:
     print(f"  Tokens+cache:   {_fmt_int(totals.tokens + totals.cache_tokens)}")
 
 
+def _default_end_date() -> str:
+    return datetime.now().astimezone().strftime("%Y-%m-%d")
+
+
+def _default_start_date() -> str:
+    return (datetime.now().astimezone() - timedelta(days=6)).strftime("%Y-%m-%d")
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--start-date", default="2026-07-09", help="Start date YYYY-MM-DD")
-    parser.add_argument("--end-date", default="2026-07-15", help="End date YYYY-MM-DD")
+    parser.add_argument("--start-date", default=_default_start_date(), help="Start date YYYY-MM-DD")
+    parser.add_argument("--end-date", default=_default_end_date(), help="End date YYYY-MM-DD")
     parser.add_argument(
         "--zai-total",
         type=int,
-        default=170051875,
-        help="Known z.ai total tokens for the range",
+        help="Optional known z.ai total tokens for the range",
     )
     parser.add_argument(
         "--zai-hour",
-        default="2026-07-15 15:00",
-        help="Known local-hour bucket from z.ai chart",
+        help="Optional known local-hour bucket from a z.ai chart (YYYY-MM-DD HH:00)",
     )
     parser.add_argument(
         "--zai-hour-total",
         type=int,
-        default=28618223,
-        help="Known z.ai token total for --zai-hour",
+        help="Optional known z.ai token total for --zai-hour",
     )
     args = parser.parse_args()
 
     print(f"Range: {args.start_date} -> {args.end_date}")
-    print(f"z.ai total: {_fmt_int(args.zai_total)}")
+    if args.zai_total is not None:
+        print(f"z.ai total: {_fmt_int(args.zai_total)}")
     print()
 
     claude_db = load_claude_daily_usage(args.start_date, args.end_date)
@@ -272,25 +275,26 @@ def main() -> int:
     print_totals("ZCode (all source sessions)", zcode_all_scope)
     print()
 
-    for label, zcode in [
-        ("Open ACE ZCode scope", zcode_openace_scope),
-        ("All-source ZCode scope", zcode_all_scope),
-    ]:
-        base_total = zcode.tokens + claude_src.tokens
-        cache_total = claude_src.cache_tokens
-        multiplier = implied_cache_multiplier(args.zai_total, base_total, cache_total)
-        print(label)
-        print(f"  Base total without Claude cache: {_fmt_int(base_total)}")
-        print(f"  Claude cache to reconcile:       {_fmt_int(cache_total)}")
-        if multiplier is None:
-            print("  Implied Claude cache multiplier: n/a")
-        else:
-            print(f"  Implied Claude cache multiplier: {_fmt_float(multiplier)}")
-            reconciled = base_total + int(round(cache_total * multiplier))
-            print(f"  Reconciled total at multiplier:  {_fmt_int(reconciled)}")
-        print()
+    if args.zai_total is not None:
+        for label, zcode in [
+            ("Open ACE ZCode scope", zcode_openace_scope),
+            ("All-source ZCode scope", zcode_all_scope),
+        ]:
+            base_total = zcode.tokens + claude_src.tokens
+            cache_total = claude_src.cache_tokens
+            multiplier = implied_cache_multiplier(args.zai_total, base_total, cache_total)
+            print(label)
+            print(f"  Base total without Claude cache: {_fmt_int(base_total)}")
+            print(f"  Claude cache to reconcile:       {_fmt_int(cache_total)}")
+            if multiplier is None:
+                print("  Implied Claude cache multiplier: n/a")
+            else:
+                print(f"  Implied Claude cache multiplier: {_fmt_float(multiplier)}")
+                reconciled = base_total + int(round(cache_total * multiplier))
+                print(f"  Reconciled total at multiplier:  {_fmt_int(reconciled)}")
+            print()
 
-    if args.zai_hour and args.zai_hour_total:
+    if args.zai_hour and args.zai_hour_total is not None:
         print(f"Hourly check: {args.zai_hour} -> z.ai {_fmt_int(args.zai_hour_total)}")
         claude_hour = load_claude_source_usage(
             args.zai_hour[:10], args.zai_hour[:10], hour_filter=args.zai_hour

--- a/scripts/fetch_claude.py
+++ b/scripts/fetch_claude.py
@@ -309,10 +309,11 @@ def _merge_messages_by_id(messages: list[dict]) -> list[dict]:
         last non-empty content. For assistant messages ``content`` is
         ``json.dumps([text,...])`` so we prefer the line whose text is non-empty
         over a ``[]`` thinking-only line.
-      * ``tokens_used`` / ``input_tokens`` / ``output_tokens``: summed (each
-        usage-bearing line reports the message's tokens; claude writes usage on
-        every block-line of a message, so dedup by taking the MAX across lines
-        within the group rather than summing, to avoid over-counting).
+      * ``tokens_used`` / ``input_tokens`` / ``output_tokens`` /
+        ``cache_read_tokens`` / ``cache_creation_tokens``:
+        claude repeats usage on every block-line of a message, so dedup by
+        taking the MAX across lines within the group rather than summing, to
+        avoid over-counting.
       * ``timestamp`` / ``full_entry`` / ``model``: keep the first occurrence.
     """
     if not messages:
@@ -350,12 +351,49 @@ def _merge_messages_by_id(messages: list[dict]) -> list[dict]:
                 g["content"] = msg.get("content", "")
         # tokens: claude repeats the message's usage on every block-line, so
         # take the max within the group (not the sum) to avoid double counting.
-        for tok_field in ("tokens_used", "input_tokens", "output_tokens"):
+        for tok_field in (
+            "tokens_used",
+            "input_tokens",
+            "output_tokens",
+            "cache_read_tokens",
+            "cache_creation_tokens",
+        ):
             cur = grouped[key].get(tok_field, 0) or 0
             new = msg.get(tok_field, 0) or 0
             grouped[key][tok_field] = max(cur, new)
 
     return [grouped[k] for k in order]
+
+
+def _build_daily_stats_from_messages(messages: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    """Build per-day Claude usage from already-merged logical messages."""
+    daily: dict[str, dict[str, Any]] = defaultdict(
+        lambda: {
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cache_read_tokens": 0,
+            "cache_creation_tokens": 0,
+            "request_count": 0,
+            "models_used": set(),
+        }
+    )
+
+    for msg in messages:
+        date_key = msg.get("date")
+        if not date_key:
+            continue
+
+        daily[date_key]["input_tokens"] += msg.get("input_tokens", 0) or 0
+        daily[date_key]["output_tokens"] += msg.get("output_tokens", 0) or 0
+        daily[date_key]["cache_read_tokens"] += msg.get("cache_read_tokens", 0) or 0
+        daily[date_key]["cache_creation_tokens"] += msg.get("cache_creation_tokens", 0) or 0
+
+        if msg.get("role") == "assistant":
+            daily[date_key]["request_count"] += 1
+            if msg.get("model"):
+                daily[date_key]["models_used"].add(msg["model"])
+
+    return dict(daily)
 
 
 def process_jsonl_file(
@@ -393,19 +431,7 @@ def process_jsonl_file(
     # Extract session_id from JSONL filename (e.g. 2675a43d-7920-4450-8983-a4b8363786ef.jsonl)
     file_session_id = filepath.stem if filepath.suffix == ".jsonl" else None
 
-    daily: dict[str, dict[str, Any]] = defaultdict(
-        lambda: {
-            "input_tokens": 0,
-            "output_tokens": 0,
-            "cache_read_tokens": 0,
-            "cache_creation_tokens": 0,
-            "request_count": 0,
-            "models_used": set(),
-        }
-    )
     messages: list[dict[str, Any]] = []
-    # Track seen message_ids per date to deduplicate request_count
-    seen_msg_ids: dict[str, set[str]] = defaultdict(set)
 
     # First pass: build message tree for conversation_id tracking
     # Key: message uuid, Value: (entry, parent_uuid)
@@ -503,7 +529,14 @@ def process_jsonl_file(
                             if tokens:
                                 input_tokens = tokens.get("input_tokens", 0)
                                 output_tokens = tokens.get("output_tokens", 0)
-                            total_tokens = input_tokens + output_tokens
+                            cache_read_tokens = tokens.get("cache_read_tokens", 0)
+                            cache_creation_tokens = tokens.get("cache_creation_tokens", 0)
+                            total_tokens = (
+                                input_tokens
+                                + output_tokens
+                                + cache_read_tokens
+                                + cache_creation_tokens
+                            )
 
                             # Get model info
                             model = msg.get("model") if entry_type == "assistant" else None
@@ -542,6 +575,8 @@ def process_jsonl_file(
                                     "tokens_used": total_tokens,
                                     "input_tokens": input_tokens,
                                     "output_tokens": output_tokens,
+                                    "cache_read_tokens": cache_read_tokens,
+                                    "cache_creation_tokens": cache_creation_tokens,
                                     "model": model,
                                     "timestamp": ts,
                                     "sender_id": "claude_user",
@@ -555,50 +590,6 @@ def process_jsonl_file(
                                     "project_path": project_path,
                                 }
                             )
-
-                if (
-                    sum(
-                        [
-                            tokens["input_tokens"],
-                            tokens["output_tokens"],
-                            tokens["cache_read_tokens"],
-                            tokens["cache_creation_tokens"],
-                        ]
-                    )
-                    == 0
-                ):
-                    # Still count requests even if tokens are 0 (e.g., cache hits)
-                    if tokens["is_assistant_message"]:
-                        msg = entry.get("message", {})
-                        mid = (
-                            (msg.get("id") if isinstance(msg, dict) else None)
-                            or entry.get("id")
-                            or entry.get("uuid")
-                        )
-                        if mid and mid not in seen_msg_ids[date_key]:
-                            seen_msg_ids[date_key].add(mid)
-                            daily[date_key]["request_count"] += 1
-                    continue
-
-                daily[date_key]["input_tokens"] += tokens["input_tokens"]
-                daily[date_key]["output_tokens"] += tokens["output_tokens"]
-                daily[date_key]["cache_read_tokens"] += tokens["cache_read_tokens"]
-                daily[date_key]["cache_creation_tokens"] += tokens["cache_creation_tokens"]
-
-                if tokens["is_assistant_message"]:
-                    msg = entry.get("message", {})
-                    mid = (
-                        (msg.get("id") if isinstance(msg, dict) else None)
-                        or entry.get("id")
-                        or entry.get("uuid")
-                    )
-                    if mid and mid not in seen_msg_ids[date_key]:
-                        seen_msg_ids[date_key].add(mid)
-                        daily[date_key]["request_count"] += 1
-
-                if tokens["model"]:
-                    daily[date_key]["models_used"].add(tokens["model"])
-
             except (json.JSONDecodeError, KeyError, TypeError):
                 # Silently skip problematic entries
                 continue
@@ -607,7 +598,8 @@ def process_jsonl_file(
     # into one logical message before insert, so the per-message_id dedup keeps
     # the full content (incl. the final assistant text) instead of just thinking.
     messages = _merge_messages_by_id(messages)
-    return dict(daily), messages
+    daily = _build_daily_stats_from_messages(messages)
+    return daily, messages
 
 
 def find_all_claude_project_dirs() -> list:
@@ -1246,9 +1238,12 @@ def fetch_and_save(
     saved = 0
     for date, stats in aggregated.items():
         if start_date <= date <= today:
-            # tokens_used should only include actual input + output
-            # cache_read is much cheaper (90% discount) and should not be counted as full tokens
-            total = stats["input_tokens"] + stats["output_tokens"]
+            total = (
+                stats["input_tokens"]
+                + stats["output_tokens"]
+                + stats["cache_read_tokens"]
+                + stats["cache_creation_tokens"]
+            )
 
             if db.save_usage(
                 date=date,

--- a/scripts/fetch_codex.py
+++ b/scripts/fetch_codex.py
@@ -725,15 +725,6 @@ def _process_sessions_dir(
                 aggregated[date][key] += stats[key]
             aggregated[date]["models_used"].update(stats["models_used"])
 
-        # Inject session-level tokens into the first assistant message for agent_sessions stats
-        if session_tokens["total_tokens"] > 0 and messages:
-            for msg in messages:
-                if msg.get("role") == "assistant":
-                    msg["tokens_used"] = session_tokens["total_tokens"]
-                    msg["input_tokens"] = session_tokens["input_tokens"]
-                    msg["output_tokens"] = session_tokens["output_tokens"]
-                    break
-
         # Collect messages for batch insert
         all_messages.extend(messages)
 
@@ -1225,6 +1216,18 @@ def fetch_and_save(
 
     # Save messages (idempotent UPSERT)
     if all_messages:
+        session_ids = sorted(
+            {
+                str(msg.get("agent_session_id")).strip()
+                for msg in all_messages
+                if msg.get("agent_session_id")
+            }
+        )
+        if session_ids:
+            print(f"Replacing existing message rows for {len(session_ids)} Codex sessions...")
+            deleted = db.delete_messages_for_agent_sessions("codex", hostname, session_ids)
+            if deleted > 0:
+                print(f"Deleted {deleted} stale Codex message rows")
         print("Saving messages to database...")
         saved_count = db_mod.save_messages_batch(all_messages, batch_size=500)
         print(f"Saved {saved_count} messages")

--- a/scripts/fetch_codex.py
+++ b/scripts/fetch_codex.py
@@ -203,18 +203,47 @@ def process_jsonl_file(
     messages = []
     session_meta = None
     session_id = None
-    accumulated_tokens = {
-        "input_tokens": 0,
-        "cached_input_tokens": 0,
-        "output_tokens": 0,
-        "reasoning_output_tokens": 0,
-        "total_tokens": 0,
-    }
     current_model = None
-    # Track turn_id -> duration/timing from task_started/task_complete
-    turn_timings: dict[str, dict] = {}
+    active_turn_id: Optional[str] = None
+    synthetic_turn_index = 0
+    turn_stats: dict[str, dict[str, Any]] = {}
+    turn_order: list[str] = []
 
-    # First pass: read all events and collect session_meta, token counts, turn context
+    def _fallback_date() -> str:
+        return file_date or "unknown"
+
+    def _ensure_turn(turn_id: Optional[str], ts: str = "") -> dict[str, Any]:
+        nonlocal synthetic_turn_index
+        if not turn_id:
+            synthetic_turn_index += 1
+            turn_id = f"orphan-turn-{synthetic_turn_index}"
+        if turn_id not in turn_stats:
+            turn_stats[turn_id] = {
+                "date": parse_timestamp(ts) if ts else _fallback_date(),
+                "input_tokens": 0,
+                "cached_tokens": 0,
+                "output_tokens": 0,
+                "reasoning_tokens": 0,
+                "total_tokens": 0,
+                "user_message_id": None,
+                "user_message_date": None,
+                "first_assistant_message_id": None,
+                "counts_as_request": False,
+                "saw_assistant_output": False,
+                "model": None,
+            }
+            turn_order.append(turn_id)
+        turn = turn_stats[turn_id]
+        if ts:
+            parsed_date = parse_timestamp(ts)
+            if parsed_date != "unknown":
+                turn["date"] = parsed_date
+        if current_model and not turn.get("model"):
+            turn["model"] = current_model
+        return turn
+
+    # First pass: read all events so we can derive stable ids and per-turn stats
+    # without reparsing the file multiple times.
     events = []
     with open(filepath, encoding="utf-8") as f:
         for line in f:
@@ -247,42 +276,6 @@ def process_jsonl_file(
             if turn_model:
                 current_model = turn_model
 
-        # ---- event_msg: token_count ----
-        elif event_type == "event_msg" and payload.get("type") == "token_count":
-            info = payload.get("info", {})
-            if isinstance(info, dict):
-                last_usage = info.get("last_token_usage", {})
-                if isinstance(last_usage, dict):
-                    accumulated_tokens["input_tokens"] += last_usage.get("input_tokens", 0)
-                    accumulated_tokens["cached_input_tokens"] += last_usage.get(
-                        "cached_input_tokens", 0
-                    )
-                    accumulated_tokens["output_tokens"] += last_usage.get("output_tokens", 0)
-                    accumulated_tokens["reasoning_output_tokens"] += last_usage.get(
-                        "reasoning_output_tokens", 0
-                    )
-                    accumulated_tokens["total_tokens"] += last_usage.get("total_tokens", 0)
-
-        # ---- event_msg: task_started ----
-        elif event_type == "event_msg" and payload.get("type") == "task_started":
-            turn_id = payload.get("turn_id")
-            if turn_id:
-                turn_timings[turn_id] = {
-                    "started_at": payload.get("started_at"),
-                    "model_context_window": payload.get("model_context_window"),
-                }
-
-        # ---- event_msg: task_complete ----
-        elif event_type == "event_msg" and payload.get("type") == "task_complete":
-            turn_id = payload.get("turn_id")
-            if turn_id and turn_id in turn_timings:
-                turn_timings[turn_id]["completed_at"] = payload.get("completed_at")
-                turn_timings[turn_id]["duration_ms"] = payload.get("duration_ms")
-                turn_timings[turn_id]["time_to_first_token_ms"] = payload.get(
-                    "time_to_first_token_ms"
-                )
-                turn_timings[turn_id]["last_agent_message"] = payload.get("last_agent_message")
-
     # Determine session date
     if session_meta and session_meta.get("id"):
         session_id = session_meta["id"]
@@ -309,7 +302,15 @@ def process_jsonl_file(
         if parsed_date != "unknown":
             date_key = parsed_date
 
-    # Second pass: process response_item events into messages
+    # Rebuild turn state in event order so token_count rows can be attributed
+    # to the correct task_started span and message timestamp.
+    current_model = None
+    active_turn_id = None
+    synthetic_turn_index = 0
+    turn_stats = {}
+    turn_order = []
+
+    # Second pass: build messages and attribute token_count events to turns.
     for event in events:
         event_type = event.get("type", "")
         payload = event.get("payload", {})
@@ -318,11 +319,27 @@ def process_jsonl_file(
         ts = event.get("timestamp", "")
         payload_type = payload.get("type", "")
 
+        if event_type == "turn_context":
+            turn_model = payload.get("model")
+            if turn_model:
+                current_model = turn_model
+                if active_turn_id:
+                    _ensure_turn(active_turn_id, ts)["model"] = turn_model
+            continue
+
+        if event_type == "event_msg" and payload_type == "task_started":
+            active_turn_id = payload.get("turn_id") or active_turn_id
+            _ensure_turn(active_turn_id, ts)["counts_as_request"] = True
+            continue
+
         # ---- response_item: user/assistant messages and tool calls ----
         if event_type == "response_item":
             role = None
             message_id = payload.get("call_id")  # For tool calls
             model = current_model
+            message_date = parse_timestamp(ts) if ts else date_key
+            if message_date == "unknown":
+                message_date = date_key
 
             if payload_type == "message":
                 msg_role = payload.get("role", "")
@@ -330,8 +347,6 @@ def process_jsonl_file(
                     role = "user"
                 elif msg_role == "assistant":
                     role = "assistant"
-                    # Count assistant messages as requests
-                    daily[date_key]["request_count"] += 1
                 else:
                     continue  # Skip unknown roles
 
@@ -391,13 +406,9 @@ def process_jsonl_file(
             # Save full entry as JSON
             full_entry_json = json.dumps(event, ensure_ascii=False)
 
-            # Token attribution: for user messages, tokens=0; for assistant messages,
-            # we don't have per-message tokens in Codex (only per-turn via token_count events).
-            # We'll attribute accumulated tokens at the session level via daily_usage.
-
             messages.append(
                 {
-                    "date": date_key,
+                    "date": message_date,
                     "tool_name": "codex",
                     "host_name": hostname,
                     "message_id": message_id,
@@ -406,7 +417,7 @@ def process_jsonl_file(
                     "content": content or "",
                     "content_blocks": content_blocks,
                     "full_entry": full_entry_json,
-                    "tokens_used": 0,  # Per-message tokens not available in Codex
+                    "tokens_used": 0,
                     "input_tokens": 0,
                     "output_tokens": 0,
                     "model": model,
@@ -420,8 +431,20 @@ def process_jsonl_file(
                     "agent_session_id": session_id,
                     "conversation_id": None,
                     "project_path": session_meta.get("cwd") if session_meta else None,
+                    "overwrite_zero_tokens": True,
+                    "counts_as_request": False,
                 }
             )
+
+            if active_turn_id:
+                turn = _ensure_turn(active_turn_id, ts)
+                if role == "user" and not turn["saw_assistant_output"]:
+                    turn["user_message_id"] = message_id
+                    turn["user_message_date"] = message_date
+                elif role == "assistant":
+                    turn["saw_assistant_output"] = True
+                    if not turn["first_assistant_message_id"]:
+                        turn["first_assistant_message_id"] = message_id
 
         # ---- event_msg: patch_apply_end -> file_change content_block ----
         elif event_type == "event_msg" and payload.get("type") == "patch_apply_end":
@@ -455,7 +478,7 @@ def process_jsonl_file(
 
                 messages.append(
                     {
-                        "date": date_key,
+                        "date": parse_timestamp(ts) if ts else date_key,
                         "tool_name": "codex",
                         "host_name": hostname,
                         "message_id": f"patch-{call_id}",
@@ -484,8 +507,29 @@ def process_jsonl_file(
                         "agent_session_id": session_id,
                         "conversation_id": None,
                         "project_path": session_meta.get("cwd") if session_meta else None,
+                        "overwrite_zero_tokens": True,
+                        "counts_as_request": False,
                     }
                 )
+
+        # ---- event_msg: token_count ----
+        elif event_type == "event_msg" and payload.get("type") == "token_count":
+            info = payload.get("info", {})
+            if isinstance(info, dict):
+                last_usage = info.get("last_token_usage", {})
+                if isinstance(last_usage, dict):
+                    turn = _ensure_turn(active_turn_id, ts)
+                    turn["input_tokens"] += int(last_usage.get("input_tokens", 0) or 0)
+                    turn["cached_tokens"] += int(last_usage.get("cached_input_tokens", 0) or 0)
+                    turn["output_tokens"] += int(last_usage.get("output_tokens", 0) or 0)
+                    turn["reasoning_tokens"] += int(
+                        last_usage.get("reasoning_output_tokens", 0) or 0
+                    )
+                    # Source semantics observed in Codex logs:
+                    # total_tokens == input_tokens + output_tokens, and cached
+                    # input is already part of input_tokens. Preserve that
+                    # provider total rather than subtracting cache locally.
+                    turn["total_tokens"] += int(last_usage.get("total_tokens", 0) or 0)
 
         # ---- event_msg: task_complete -> task_summary content_block ----
         elif event_type == "event_msg" and payload.get("type") == "task_complete":
@@ -506,7 +550,7 @@ def process_jsonl_file(
 
                 messages.append(
                     {
-                        "date": date_key,
+                        "date": parse_timestamp(ts) if ts else date_key,
                         "tool_name": "codex",
                         "host_name": hostname,
                         "message_id": f"task-complete-{turn_id}",
@@ -529,25 +573,55 @@ def process_jsonl_file(
                         "agent_session_id": session_id,
                         "conversation_id": None,
                         "project_path": session_meta.get("cwd") if session_meta else None,
+                        "overwrite_zero_tokens": True,
+                        "counts_as_request": False,
                     }
                 )
+            if active_turn_id and turn_id == active_turn_id:
+                active_turn_id = None
 
-    # Aggregate token usage for daily stats from accumulated token_count events
-    input_tokens = accumulated_tokens["input_tokens"]
-    cached_tokens = accumulated_tokens["cached_input_tokens"]
-    output_tokens = accumulated_tokens["output_tokens"]
-    reasoning_tokens = accumulated_tokens["reasoning_output_tokens"]
+    message_by_id = {msg.get("message_id"): msg for msg in messages if msg.get("message_id")}
+    session_total = 0
+    session_input = 0
+    session_output = 0
+    turns_assigned = 0
 
-    # Calculate actual input tokens (excluding cached)
-    actual_input = max(0, input_tokens - cached_tokens)
+    for turn_id in turn_order:
+        turn = turn_stats[turn_id]
+        turn_total = int(turn["total_tokens"] or 0)
+        turn_cached = int(turn["cached_tokens"] or 0)
+        turn_input = int(turn["input_tokens"] or 0)
+        turn_output = int(turn["output_tokens"] or 0)
+        turn_reasoning = int(turn["reasoning_tokens"] or 0)
+        actual_input = max(0, turn_input - turn_cached)
+        turn_date = turn["user_message_date"] or turn["date"] or date_key
 
-    daily[date_key]["prompt_tokens"] += actual_input
-    daily[date_key]["candidates_tokens"] += output_tokens
-    daily[date_key]["thoughts_tokens"] += reasoning_tokens
-    daily[date_key]["cached_tokens"] += cached_tokens
-    daily[date_key]["total_tokens"] += actual_input + output_tokens + reasoning_tokens
+        daily[turn_date]["prompt_tokens"] += actual_input
+        daily[turn_date]["candidates_tokens"] += turn_output
+        daily[turn_date]["thoughts_tokens"] += turn_reasoning
+        daily[turn_date]["cached_tokens"] += turn_cached
+        daily[turn_date]["total_tokens"] += turn_total
+        if turn["counts_as_request"]:
+            daily[turn_date]["request_count"] += 1
 
-    if current_model:
+        turn_model = turn.get("model")
+        if turn_model:
+            daily[turn_date]["models_used"].add(turn_model)
+
+        session_total += turn_total
+        session_input += actual_input
+        session_output += turn_output
+
+        target_id = turn.get("user_message_id") or turn.get("first_assistant_message_id")
+        target_msg = message_by_id.get(target_id) if target_id else None
+        if target_msg and turn_total > 0:
+            target_msg["tokens_used"] = turn_total
+            target_msg["input_tokens"] = actual_input
+            target_msg["output_tokens"] = turn_output
+            target_msg["counts_as_request"] = bool(turn["counts_as_request"])
+            turns_assigned += 1
+
+    if current_model and not turn_order:
         daily[date_key]["models_used"].add(current_model)
     if session_meta:
         # Also check git info for additional context
@@ -555,10 +629,14 @@ def process_jsonl_file(
         if isinstance(git_info, dict):
             _repo_url = git_info.get("repository_url", "")
 
-    # Attach session-level token totals to messages for agent_sessions stats
-    session_total = actual_input + output_tokens + reasoning_tokens
-    session_input = actual_input
-    session_output = output_tokens
+    if session_total > 0 and turns_assigned == 0 and messages:
+        for msg in messages:
+            if msg.get("role") == "assistant":
+                msg["tokens_used"] = session_total
+                msg["input_tokens"] = session_input
+                msg["output_tokens"] = session_output
+                msg["counts_as_request"] = True
+                break
 
     return (
         dict(daily),
@@ -751,6 +829,7 @@ def update_agent_sessions_stats(messages: list) -> int:
         role = msg.get("role", "")
         tokens = msg.get("tokens_used", 0) or 0
         model = msg.get("model")
+        counts_as_request = bool(msg.get("counts_as_request"))
         message_id = msg.get("message_id")
         message_identity = f"{role}:{message_id}" if message_id else f"message_row:{sid}:{index}"
         if message_identity not in session_stats[sid]["seen_message_ids"]:
@@ -758,7 +837,7 @@ def update_agent_sessions_stats(messages: list) -> int:
             session_stats[sid]["message_count"] += 1
             session_stats[sid]["total_tokens"] += tokens
 
-        if role == "assistant":
+        if counts_as_request:
             request_identity = (
                 f"message_id:{message_id}" if message_id else f"assistant_row:{sid}:{index}"
             )

--- a/scripts/fetch_qwen.py
+++ b/scripts/fetch_qwen.py
@@ -214,19 +214,20 @@ def extract_tokens_from_entry(entry: dict) -> dict:
         result["candidates_tokens"] = usage.get("candidatesTokenCount", 0)
         result["thoughts_tokens"] = usage.get("thoughtsTokenCount", 0)
         result["cached_tokens"] = usage.get("cachedContentTokenCount", 0)
-        result["total_tokens"] = usage.get("totalTokenCount", 0)
+        result["total_tokens"] = usage.get(
+            "totalTokenCount",
+            result["prompt_tokens"] + result["candidates_tokens"],
+        )
 
-        # Calculate actual new input tokens (excluding cached history)
-        # promptTokenCount includes full history, cachedContentTokenCount is the cached portion
+        # ``promptTokenCount`` includes cached context; store the non-cached
+        # prompt delta separately so ``input_tokens`` stays compatible with the
+        # Claude/ZCode schema while ``total_tokens`` matches provider totals.
         if result["cached_tokens"] > 0:
             result["actual_input_tokens"] = max(
                 0, result["prompt_tokens"] - result["cached_tokens"]
             )
         else:
-            # No cache info, estimate: total - output
-            result["actual_input_tokens"] = max(
-                0, result["total_tokens"] - result["candidates_tokens"] - result["thoughts_tokens"]
-            )
+            result["actual_input_tokens"] = max(0, result["prompt_tokens"])
 
     return result
 
@@ -555,12 +556,12 @@ def process_jsonl_file(
                             # Get content
                             content = extract_content_from_entry(entry)
 
-                            # Get token counts - use actual_input_tokens to avoid inflation
-                            input_tokens = tokens.get("actual_input_tokens", 0) + tokens.get(
-                                "thoughts_tokens", 0
-                            )
+                            # Keep ``input_tokens`` as non-cached input while
+                            # ``tokens_used`` tracks the provider total (which
+                            # already includes cached prompt tokens).
+                            input_tokens = tokens.get("actual_input_tokens", 0)
                             output_tokens = tokens.get("candidates_tokens", 0)
-                            total_tokens = input_tokens + output_tokens
+                            total_tokens = tokens.get("total_tokens", 0)
 
                             # Get model info
                             model = entry.get("model")
@@ -641,16 +642,14 @@ def process_jsonl_file(
                             daily[date_key]["request_count"] += 1
                     continue
 
-                # Use actual_input_tokens (excluding cached history) to avoid inflation
+                # ``totalTokenCount`` already includes cached prompt tokens.
+                # Persist provider-style totals while keeping non-cached input
+                # in ``input_tokens`` and cache in its own column.
                 daily[date_key]["prompt_tokens"] += tokens["actual_input_tokens"]
                 daily[date_key]["candidates_tokens"] += tokens["candidates_tokens"]
                 daily[date_key]["thoughts_tokens"] += tokens["thoughts_tokens"]
                 daily[date_key]["cached_tokens"] += tokens["cached_tokens"]
-                daily[date_key]["total_tokens"] += (
-                    tokens["actual_input_tokens"]
-                    + tokens["candidates_tokens"]
-                    + tokens["thoughts_tokens"]
-                )
+                daily[date_key]["total_tokens"] += tokens["total_tokens"]
 
                 if tokens["is_assistant_message"]:
                     if assistant_message_id:

--- a/scripts/fetch_zcode.py
+++ b/scripts/fetch_zcode.py
@@ -286,9 +286,7 @@ def process_zcode_session(
     # Token totals are authoritative session-level values from the turn_usage
     # table (session.total_input_tokens / total_output_tokens); per-message
     # ``data.tokens`` is sparse, so we do NOT sum it (see review feedback —
-    # that path under-counts). Tokens are attributed to the session's dominant
-    # date below and injected into the first assistant message for
-    # agent_sessions (codex pattern).
+    # that path under-counts). Tokens are attributed by turn/date below.
     session_dates: set[str] = set()
     for msg in session.messages:
         ts = msg.get("timestamp")
@@ -317,8 +315,8 @@ def process_zcode_session(
                     {"session_id": session_id, "role": role, "model": model},
                     ensure_ascii=False,
                 ),
-                # Per-message tokens left at 0; session totals are injected
-                # into the first assistant message below.
+                # Per-message tokens default to 0; matched turn_usage rows will
+                # overwrite the initiating user message below.
                 "tokens_used": 0,
                 "input_tokens": 0,
                 "output_tokens": 0,
@@ -342,15 +340,17 @@ def process_zcode_session(
     # session-level assistant row.
     message_by_id = {msg.get("message_id"): msg for msg in messages}
     turn_rows = _get_turn_usage_rows(session_id, db_path)
-    turn_assigned = False
+    matched_turns = 0
+    unmatched_turns: list[dict[str, Any]] = []
     for turn in turn_rows:
         target = message_by_id.get(turn["user_message_id"])
         if target is None:
+            unmatched_turns.append(turn)
             continue
         target["tokens_used"] = turn["tokens_used"]
         target["input_tokens"] = turn["input_tokens"]
         target["output_tokens"] = turn["output_tokens"]
-        turn_assigned = True
+        matched_turns += 1
 
     # Attribute authoritative token totals by each turn's local date so
     # long-lived sessions do not dump an entire day's usage onto the session's
@@ -375,10 +375,29 @@ def process_zcode_session(
     # message on its own date in the loop above (matches fetch_codex.py), so a
     # session reports its real assistant-turn count rather than collapsing to 1.
 
+    if unmatched_turns:
+        print(
+            "fetch_zcode: turn_usage rows could not be matched to a user message for "
+            f"session={session_id} ({matched_turns}/{len(turn_rows)} matched, "
+            f"{len(unmatched_turns)} unmatched). daily_usage remains authoritative, "
+            "but message/session attribution may be incomplete."
+        )
+
     # Fallback for older source DBs where turn_usage lacks user_message_id rows:
     # keep the previous "inject once" behavior so agent_sessions still sees the
     # full session token total.
-    if total_tokens > 0 and not turn_assigned:
+    if total_tokens > 0 and matched_turns == 0:
+        if turn_rows:
+            print(
+                "fetch_zcode: falling back to session-level assistant token attribution for "
+                f"session={session_id} because 0/{len(turn_rows)} turn_usage rows matched "
+                "a user message."
+            )
+        else:
+            print(
+                "fetch_zcode: falling back to session-level assistant token attribution for "
+                f"session={session_id} because no turn_usage rows were found."
+            )
         for msg in messages:
             if msg.get("role") == "assistant":
                 msg["tokens_used"] = total_tokens

--- a/scripts/fetch_zcode.py
+++ b/scripts/fetch_zcode.py
@@ -124,6 +124,122 @@ def _ms_to_date(ms: Optional[int]) -> str:
         return "unknown"
 
 
+def _get_turn_usage_by_date(session_id: str, db_path: Path) -> dict[str, dict[str, int]]:
+    """Return authoritative turn_usage totals grouped by local calendar date.
+
+    ZCode stores token accounting per turn in ``turn_usage``. A single session
+    may span multiple days, so attributing the whole session total to one
+    "dominant" message date skews daily/hourly usage. Grouping by
+    ``turn_usage.started_at`` preserves the source-of-truth date split while
+    keeping messages/session metadata parsing in ``ZcodeSession``.
+    """
+    import sqlite3
+
+    try:
+        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    except sqlite3.Error:
+        return {}
+
+    try:
+        rows = conn.execute(
+            """
+            SELECT
+                date(datetime(started_at / 1000, 'unixepoch', 'localtime')) AS usage_date,
+                COALESCE(SUM(input_tokens), 0) AS input_tokens,
+                COALESCE(SUM(output_tokens), 0) AS output_tokens,
+                COALESCE(SUM(cache_creation_input_tokens), 0) AS cache_creation_tokens,
+                COALESCE(SUM(cache_read_input_tokens), 0) AS cache_read_tokens,
+                COALESCE(SUM(computed_total_tokens), 0) AS computed_total_tokens
+            FROM turn_usage
+            WHERE session_id = ?
+            GROUP BY usage_date
+            """,
+            (session_id,),
+        ).fetchall()
+    except sqlite3.DatabaseError:
+        return {}
+    finally:
+        conn.close()
+
+    usage_by_date: dict[str, dict[str, int]] = {}
+    for usage_date, input_t, output_t, cache_create_t, cache_read_t, computed_total_t in rows:
+        if not usage_date:
+            continue
+        total_t = computed_total_t or ((input_t or 0) + (output_t or 0))
+        usage_by_date[str(usage_date)] = {
+            "prompt_tokens": int(input_t or 0),
+            "candidates_tokens": int(output_t or 0),
+            "cached_tokens": int(cache_create_t or 0) + int(cache_read_t or 0),
+            "total_tokens": int(total_t),
+        }
+
+    return usage_by_date
+
+
+def _get_turn_usage_rows(session_id: str, db_path: Path) -> list[dict[str, Any]]:
+    """Return per-turn usage rows keyed by the source ``user_message_id``.
+
+    ``daily_messages`` has no separate turn table, so the closest faithful
+    representation is to attach each turn's authoritative totals to the user
+    message that initiated it. That keeps hourly rollups aligned with the
+    provider's turn-start timestamp and avoids dumping a session total onto one
+    assistant row.
+    """
+    import sqlite3
+
+    try:
+        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    except sqlite3.Error:
+        return []
+
+    try:
+        rows = conn.execute(
+            """
+            SELECT
+                turn_id,
+                user_message_id,
+                started_at,
+                COALESCE(input_tokens, 0) AS input_tokens,
+                COALESCE(output_tokens, 0) AS output_tokens,
+                COALESCE(cache_creation_input_tokens, 0) AS cache_creation_tokens,
+                COALESCE(cache_read_input_tokens, 0) AS cache_read_tokens,
+                COALESCE(computed_total_tokens, 0) AS computed_total_tokens
+            FROM turn_usage
+            WHERE session_id = ?
+            ORDER BY started_at, turn_id
+            """,
+            (session_id,),
+        ).fetchall()
+    except sqlite3.DatabaseError:
+        return []
+    finally:
+        conn.close()
+
+    result: list[dict[str, Any]] = []
+    for (
+        turn_id,
+        user_message_id,
+        started_at,
+        input_t,
+        output_t,
+        cache_create_t,
+        cache_read_t,
+        total_t,
+    ) in rows:
+        result.append(
+            {
+                "turn_id": turn_id,
+                "user_message_id": user_message_id,
+                "started_at": int(started_at or 0),
+                "input_tokens": int(input_t or 0),
+                "output_tokens": int(output_t or 0),
+                "cache_tokens": int(cache_create_t or 0) + int(cache_read_t or 0),
+                "tokens_used": int(total_t or ((input_t or 0) + (output_t or 0))),
+            }
+        )
+    return result
+
+
 def process_zcode_session(
     session_id: str,
     db_path: Path,
@@ -213,28 +329,56 @@ def process_zcode_session(
                 "agent_session_id": session_id,
                 "conversation_id": None,
                 "project_path": session.project_path,
+                # Explicit zeroes are authoritative for ZCode rows because
+                # older fetches attached session totals to assistant messages.
+                # New turn-based attribution must be able to clear those
+                # stale token values during UPSERT.
+                "overwrite_zero_tokens": True,
             }
         )
 
-    # Attribute the authoritative session-level token totals to the dominant
-    # date (the date with the most messages; ties broken by recency). This
-    # keeps daily_usage aligned with the session totals rather than fragmenting
-    # sparse per-message numbers.
+    # Attribute per-turn totals to the initiating user message so downstream
+    # hourly rollups reflect the source turn timestamp rather than one
+    # session-level assistant row.
+    message_by_id = {msg.get("message_id"): msg for msg in messages}
+    turn_rows = _get_turn_usage_rows(session_id, db_path)
+    turn_assigned = False
+    for turn in turn_rows:
+        target = message_by_id.get(turn["user_message_id"])
+        if target is None:
+            continue
+        target["tokens_used"] = turn["tokens_used"]
+        target["input_tokens"] = turn["input_tokens"]
+        target["output_tokens"] = turn["output_tokens"]
+        turn_assigned = True
+
+    # Attribute authoritative token totals by each turn's local date so
+    # long-lived sessions do not dump an entire day's usage onto the session's
+    # creation/majority-message date.
+    usage_by_date = _get_turn_usage_by_date(session_id, db_path)
     total_input = int(getattr(session, "total_input_tokens", 0) or 0)
     total_output = int(getattr(session, "total_output_tokens", 0) or 0)
     total_tokens = total_input + total_output
-    dominant_date = _dominant_date(session_dates, messages)
-    daily[dominant_date]["prompt_tokens"] += total_input
-    daily[dominant_date]["candidates_tokens"] += total_output
-    daily[dominant_date]["total_tokens"] += total_tokens
+    if usage_by_date:
+        for date_key, usage in usage_by_date.items():
+            daily[date_key]["prompt_tokens"] += usage["prompt_tokens"]
+            daily[date_key]["candidates_tokens"] += usage["candidates_tokens"]
+            daily[date_key]["cached_tokens"] += usage["cached_tokens"]
+            daily[date_key]["total_tokens"] += usage["total_tokens"]
+    else:
+        # Fallback for older/partial source DBs with missing turn_usage data.
+        dominant_date = _dominant_date(session_dates, messages)
+        daily[dominant_date]["prompt_tokens"] += total_input
+        daily[dominant_date]["candidates_tokens"] += total_output
+        daily[dominant_date]["total_tokens"] += total_tokens
     # NOTE: request_count is NOT added here — it is incremented per assistant
     # message on its own date in the loop above (matches fetch_codex.py), so a
     # session reports its real assistant-turn count rather than collapsing to 1.
 
-    # Inject session-level totals into the first assistant message so
-    # update_agent_sessions_stats records the real total_tokens (codex pattern,
-    # fetch_codex.py:648-654).
-    if total_tokens > 0:
+    # Fallback for older source DBs where turn_usage lacks user_message_id rows:
+    # keep the previous "inject once" behavior so agent_sessions still sees the
+    # full session token total.
+    if total_tokens > 0 and not turn_assigned:
         for msg in messages:
             if msg.get("role") == "assistant":
                 msg["tokens_used"] = total_tokens
@@ -760,6 +904,7 @@ def fetch_and_save(
             for date, stats in daily.items():
                 aggregated[date]["prompt_tokens"] += stats["prompt_tokens"]
                 aggregated[date]["candidates_tokens"] += stats["candidates_tokens"]
+                aggregated[date]["cached_tokens"] += stats["cached_tokens"]
                 aggregated[date]["total_tokens"] += stats["total_tokens"]
                 aggregated[date]["request_count"] += stats["request_count"]
                 aggregated[date]["models_used"].update(stats["models_used"])

--- a/scripts/shared/db.py
+++ b/scripts/shared/db.py
@@ -1182,6 +1182,59 @@ def save_messages_batch(messages: list[dict], batch_size: int = 1000) -> int:
     return saved
 
 
+def delete_messages_for_agent_sessions(
+    tool_name: str, host_name: str, agent_session_ids: list[str], batch_size: int = 500
+) -> int:
+    """Delete existing daily_messages rows for a set of agent sessions.
+
+    Fetchers that re-import an authoritative whole-session snapshot can change
+    which message carries a turn's token attribution. Deleting the old rows for
+    those session ids before inserting the fresh snapshot prevents stale
+    token-bearing rows from surviving across parser changes.
+    """
+    unique_session_ids = []
+    seen = set()
+    for session_id in agent_session_ids:
+        cleaned = (session_id or "").strip()
+        if not cleaned or cleaned in seen:
+            continue
+        seen.add(cleaned)
+        unique_session_ids.append(cleaned)
+
+    if not unique_session_ids:
+        return 0
+
+    conn = get_connection()
+    cursor = conn.cursor()
+    deleted = 0
+
+    try:
+        tool_placeholder = _placeholder()
+        host_placeholder = _placeholder()
+        for i in range(0, len(unique_session_ids), batch_size):
+            chunk = unique_session_ids[i : i + batch_size]
+            placeholders = ", ".join([_placeholder()] * len(chunk))
+            _execute(
+                cursor,
+                f"""
+                DELETE FROM daily_messages
+                WHERE tool_name = {tool_placeholder}
+                  AND host_name = {host_placeholder}
+                  AND agent_session_id IN ({placeholders})
+            """,
+                [tool_name, host_name, *chunk],
+            )
+            deleted += max(cursor.rowcount or 0, 0)
+
+        conn.commit()
+        return deleted
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+
 def get_messages_by_date(
     date: str,
     tool_name: Optional[str] = None,
@@ -4210,7 +4263,7 @@ def _refresh_daily_stats_for_messages(messages: list[dict]) -> None:
 
     # Also refresh user_daily_stats for affected dates
     try:
-        from scripts.shared.user_stats_helper import _refresh_user_daily_stats_for_dates
+        from shared.user_stats_helper import _refresh_user_daily_stats_for_dates
 
         _refresh_user_daily_stats_for_dates(dates)
     except Exception as e:

--- a/scripts/shared/db.py
+++ b/scripts/shared/db.py
@@ -1032,6 +1032,7 @@ def save_messages_batch(messages: list[dict], batch_size: int = 1000) -> int:
                 tokens_used = msg.get("tokens_used", 0)
                 input_tokens = msg.get("input_tokens", 0)
                 output_tokens = msg.get("output_tokens", 0)
+                overwrite_zero_tokens = bool(msg.get("overwrite_zero_tokens"))
                 sender_id = msg.get("sender_id")
                 sender_name = msg.get("sender_name")
                 model = msg.get("model")
@@ -1049,11 +1050,23 @@ def save_messages_batch(messages: list[dict], batch_size: int = 1000) -> int:
                 if key in existing_map:
                     existing = existing_map[key]
                     # Preserve existing token values if new values are 0
-                    if tokens_used == 0 and existing.get("tokens_used", 0) > 0:
+                    if (
+                        not overwrite_zero_tokens
+                        and tokens_used == 0
+                        and existing.get("tokens_used", 0) > 0
+                    ):
                         tokens_used = existing["tokens_used"]
-                    if input_tokens == 0 and existing.get("input_tokens", 0) > 0:
+                    if (
+                        not overwrite_zero_tokens
+                        and input_tokens == 0
+                        and existing.get("input_tokens", 0) > 0
+                    ):
                         input_tokens = existing["input_tokens"]
-                    if output_tokens == 0 and existing.get("output_tokens", 0) > 0:
+                    if (
+                        not overwrite_zero_tokens
+                        and output_tokens == 0
+                        and existing.get("output_tokens", 0) > 0
+                    ):
                         output_tokens = existing["output_tokens"]
                     # Preserve sender info if new values are None
                     if sender_id is None and existing.get("sender_id"):

--- a/scripts/shared/user_stats_helper.py
+++ b/scripts/shared/user_stats_helper.py
@@ -5,9 +5,15 @@ This is imported by scripts/shared/db.py
 """
 
 import logging
+import os
+import sys
 from datetime import datetime
 
 logger = logging.getLogger(__name__)
+
+_repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+if _repo_root not in sys.path:
+    sys.path.insert(0, _repo_root)
 
 
 def _refresh_user_daily_stats_for_dates(dates: set[str]) -> None:

--- a/tests/issues/723/test_fetch_claude_merge.py
+++ b/tests/issues/723/test_fetch_claude_merge.py
@@ -36,9 +36,11 @@ class TestMergeMessagesById:
             "message_id": "msg_1",
             "content": "[]",  # thinking-only line extracts no text
             "content_blocks": [{"type": "thinking", "thinking": "Let me think..."}],
-            "tokens_used": 100,
+            "tokens_used": 300,
             "input_tokens": 80,
             "output_tokens": 20,
+            "cache_read_tokens": 200,
+            "cache_creation_tokens": 0,
             "timestamp": "2026-06-24T12:37:00Z",
         }
         text = {
@@ -47,9 +49,11 @@ class TestMergeMessagesById:
             "message_id": "msg_1",
             "content": json.dumps(["## 审查结论 方案核心架构成立"], ensure_ascii=False),
             "content_blocks": [{"type": "text", "text": "## 审查结论 方案核心架构成立"}],
-            "tokens_used": 100,  # claude repeats usage on each block-line
+            "tokens_used": 300,  # claude repeats usage on each block-line
             "input_tokens": 80,
             "output_tokens": 20,
+            "cache_read_tokens": 200,
+            "cache_creation_tokens": 0,
             "timestamp": "2026-06-24T12:39:00Z",
         }
         merged = _merge_messages_by_id([thinking, text])
@@ -63,8 +67,9 @@ class TestMergeMessagesById:
         # content is the text line, not the empty thinking line
         assert "审查结论" in m["content"]
         # tokens: max within group (not summed) to avoid double counting
-        assert m["tokens_used"] == 100
+        assert m["tokens_used"] == 300
         assert m["input_tokens"] == 80
+        assert m["cache_read_tokens"] == 200
 
     def test_distinct_message_ids_stay_separate(self):
         """Different message_ids are NOT merged."""
@@ -179,3 +184,72 @@ class TestProcessJsonlFileMerge:
         # Both blocks present.
         block_types = [b["type"] for b in (m.get("content_blocks") or [])]
         assert "thinking" in block_types and "text" in block_types
+
+    def test_daily_usage_dedups_repeated_claude_lines_and_keeps_cache(self, tmp_path):
+        """Daily stats should count one logical assistant reply once, including cache."""
+        mid = "msg_20260624203902ff56c7472512449f"
+        entries = [
+            {
+                "type": "assistant",
+                "uuid": "u-thinking",
+                "timestamp": "2026-06-24T12:39:00.000Z",
+                "sessionId": "s-jsonl",
+                "message": {
+                    "id": mid,
+                    "role": "assistant",
+                    "model": "claude-sonnet",
+                    "content": [{"type": "thinking", "thinking": "I now have enough context."}],
+                    "usage": {
+                        "input_tokens": 100,
+                        "output_tokens": 50,
+                        "cache_read_input_tokens": 200,
+                    },
+                },
+            },
+            {
+                "type": "assistant",
+                "uuid": "u-text",
+                "timestamp": "2026-06-24T12:39:05.000Z",
+                "sessionId": "s-jsonl",
+                "message": {
+                    "id": mid,
+                    "role": "assistant",
+                    "model": "claude-sonnet",
+                    "content": [{"type": "text", "text": "final answer"}],
+                    "usage": {
+                        "input_tokens": 100,
+                        "output_tokens": 50,
+                        "cache_read_input_tokens": 200,
+                    },
+                },
+            },
+            {
+                "type": "assistant",
+                "uuid": "u-tool",
+                "timestamp": "2026-06-24T12:39:06.000Z",
+                "sessionId": "s-jsonl",
+                "message": {
+                    "id": mid,
+                    "role": "assistant",
+                    "model": "claude-sonnet",
+                    "content": [{"type": "tool_use", "id": "tool-1", "name": "Read"}],
+                    "usage": {
+                        "input_tokens": 100,
+                        "output_tokens": 50,
+                        "cache_read_input_tokens": 200,
+                    },
+                },
+            },
+        ]
+        jsonl = _write_jsonl(tmp_path / "s-jsonl.jsonl", entries)
+
+        daily, messages = process_jsonl_file(jsonl)
+
+        assert daily["2026-06-24"]["input_tokens"] == 100
+        assert daily["2026-06-24"]["output_tokens"] == 50
+        assert daily["2026-06-24"]["cache_read_tokens"] == 200
+        assert daily["2026-06-24"]["request_count"] == 1
+        assert daily["2026-06-24"]["models_used"] == {"claude-sonnet"}
+
+        assert len(messages) == 1
+        assert messages[0]["tokens_used"] == 350

--- a/tests/unit/test_fetch_codex.py
+++ b/tests/unit/test_fetch_codex.py
@@ -1,7 +1,10 @@
 """Unit coverage for Codex fetch token accounting."""
 
+import importlib
 import json
+import sqlite3
 import sys
+from collections import defaultdict
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -9,7 +12,7 @@ SCRIPTS_DIR = REPO_ROOT / "scripts"
 if str(SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPTS_DIR))
 
-from fetch_codex import process_jsonl_file  # noqa: E402
+from fetch_codex import _process_sessions_dir, process_jsonl_file  # noqa: E402
 
 
 def _write_jsonl(path: Path, entries: list[dict]) -> Path:
@@ -232,3 +235,204 @@ def test_process_jsonl_file_splits_turns_by_local_date_and_counts_requests_once(
     assert session_tokens["total_tokens"] == 390
     assert session_tokens["input_tokens"] == 260
     assert session_tokens["output_tokens"] == 40
+
+
+def test_reimport_replaces_stale_codex_session_rows(monkeypatch, tmp_path):
+    db_path = tmp_path / "codex.sqlite"
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+
+    from shared import db as shared_db  # noqa: E402
+
+    importlib.reload(shared_db)
+
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        """
+        CREATE TABLE daily_messages (
+            date TEXT,
+            tool_name TEXT,
+            host_name TEXT,
+            message_id TEXT,
+            parent_id TEXT,
+            role TEXT,
+            content TEXT,
+            full_entry TEXT,
+            tokens_used INTEGER DEFAULT 0,
+            input_tokens INTEGER DEFAULT 0,
+            output_tokens INTEGER DEFAULT 0,
+            model TEXT,
+            timestamp TEXT,
+            sender_id TEXT,
+            sender_name TEXT,
+            message_source TEXT,
+            feishu_conversation_id TEXT,
+            group_subject TEXT,
+            is_group_chat INTEGER,
+            agent_session_id TEXT,
+            conversation_id TEXT,
+            PRIMARY KEY (date, tool_name, host_name, message_id)
+        )
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO daily_messages (
+            date, tool_name, host_name, message_id, role, tokens_used,
+            input_tokens, output_tokens, model, timestamp, agent_session_id
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            "2026-07-14",
+            "codex",
+            "localhost",
+            "stale-assistant",
+            "assistant",
+            1050,
+            200,
+            50,
+            "gpt-5.5",
+            "2026-07-14T01:00:03Z",
+            "sess-1",
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+    deleted = shared_db.delete_messages_for_agent_sessions("codex", "localhost", ["sess-1"])
+    assert deleted == 1
+
+    saved = shared_db.save_messages_batch(
+        [
+            {
+                "date": "2026-07-14",
+                "tool_name": "codex",
+                "host_name": "localhost",
+                "message_id": "user-1",
+                "role": "user",
+                "content": "hello",
+                "tokens_used": 1050,
+                "input_tokens": 200,
+                "output_tokens": 50,
+                "model": "gpt-5.5",
+                "timestamp": "2026-07-14T01:00:02Z",
+                "agent_session_id": "sess-1",
+                "overwrite_zero_tokens": True,
+            },
+            {
+                "date": "2026-07-14",
+                "tool_name": "codex",
+                "host_name": "localhost",
+                "message_id": "assistant-1",
+                "role": "assistant",
+                "content": "world",
+                "tokens_used": 0,
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "model": "gpt-5.5",
+                "timestamp": "2026-07-14T01:00:03Z",
+                "agent_session_id": "sess-1",
+                "overwrite_zero_tokens": True,
+            },
+        ],
+        batch_size=10,
+    )
+    assert saved == 2
+
+    conn = sqlite3.connect(str(db_path))
+    rows = conn.execute(
+        """
+        SELECT message_id, role, tokens_used
+        FROM daily_messages
+        WHERE tool_name = 'codex'
+        ORDER BY message_id
+        """
+    ).fetchall()
+    conn.close()
+
+    assert rows == [("assistant-1", "assistant", 0), ("user-1", "user", 1050)]
+
+
+def test_process_sessions_dir_does_not_reinject_session_total_into_assistant(tmp_path):
+    sessions_dir = tmp_path / "sessions" / "2026" / "07" / "14"
+    sessions_dir.mkdir(parents=True)
+    _write_jsonl(
+        sessions_dir / "rollout-test-codex.jsonl",
+        [
+            {
+                "timestamp": "2026-07-14T01:00:00Z",
+                "type": "event_msg",
+                "payload": {"type": "task_started", "turn_id": "turn-1"},
+            },
+            {
+                "timestamp": "2026-07-14T01:00:01Z",
+                "type": "turn_context",
+                "payload": {"model": "gpt-5.5"},
+            },
+            {
+                "timestamp": "2026-07-14T01:00:02Z",
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "hello"}],
+                },
+            },
+            {
+                "timestamp": "2026-07-14T01:00:03Z",
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": "world"}],
+                },
+            },
+            {
+                "timestamp": "2026-07-14T01:00:04Z",
+                "type": "event_msg",
+                "payload": {
+                    "type": "token_count",
+                    "info": {
+                        "last_token_usage": {
+                            "input_tokens": 1000,
+                            "cached_input_tokens": 800,
+                            "output_tokens": 50,
+                            "reasoning_output_tokens": 20,
+                            "total_tokens": 1050,
+                        }
+                    },
+                },
+            },
+            {
+                "timestamp": "2026-07-14T01:00:05Z",
+                "type": "event_msg",
+                "payload": {"type": "task_complete", "turn_id": "turn-1"},
+            },
+        ],
+    )
+
+    aggregated = defaultdict(
+        lambda: {
+            "prompt_tokens": 0,
+            "candidates_tokens": 0,
+            "thoughts_tokens": 0,
+            "cached_tokens": 0,
+            "total_tokens": 0,
+            "request_count": 0,
+            "models_used": set(),
+        }
+    )
+    all_messages = []
+    _process_sessions_dir(
+        tmp_path / "sessions",
+        "localhost",
+        None,
+        aggregated,
+        all_messages,
+        recent=False,
+    )
+
+    user_tokens = [m["tokens_used"] for m in all_messages if m["role"] == "user"]
+    assistant_tokens = [m["tokens_used"] for m in all_messages if m["role"] == "assistant"]
+
+    assert user_tokens == [1050]
+    assert assistant_tokens == [0]

--- a/tests/unit/test_fetch_codex.py
+++ b/tests/unit/test_fetch_codex.py
@@ -2,9 +2,12 @@
 
 import importlib
 import json
+import os
 import sqlite3
 import sys
+import time
 from collections import defaultdict
+from contextlib import contextmanager
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -20,6 +23,23 @@ def _write_jsonl(path: Path, entries: list[dict]) -> Path:
         for entry in entries:
             f.write(json.dumps(entry, ensure_ascii=False) + "\n")
     return path
+
+
+@contextmanager
+def _temporary_timezone(tz_name: str):
+    previous = os.environ.get("TZ")
+    try:
+        os.environ["TZ"] = tz_name
+        if hasattr(time, "tzset"):
+            time.tzset()
+        yield
+    finally:
+        if previous is None:
+            os.environ.pop("TZ", None)
+        else:
+            os.environ["TZ"] = previous
+        if hasattr(time, "tzset"):
+            time.tzset()
 
 
 def test_process_jsonl_file_keeps_provider_total_and_attributes_turn_to_user(tmp_path):
@@ -111,130 +131,131 @@ def test_process_jsonl_file_keeps_provider_total_and_attributes_turn_to_user(tmp
 
 
 def test_process_jsonl_file_splits_turns_by_local_date_and_counts_requests_once(tmp_path):
-    jsonl = _write_jsonl(
-        tmp_path / "rollout-test-codex-multi.jsonl",
-        [
-            {
-                "timestamp": "2026-07-14T15:55:00Z",
-                "type": "event_msg",
-                "payload": {"type": "task_started", "turn_id": "turn-1"},
-            },
-            {
-                "timestamp": "2026-07-14T15:55:01Z",
-                "type": "response_item",
-                "payload": {
-                    "type": "message",
-                    "role": "user",
-                    "content": [{"type": "input_text", "text": "first"}],
+    with _temporary_timezone("Asia/Shanghai"):
+        jsonl = _write_jsonl(
+            tmp_path / "rollout-test-codex-multi.jsonl",
+            [
+                {
+                    "timestamp": "2026-07-14T15:55:00Z",
+                    "type": "event_msg",
+                    "payload": {"type": "task_started", "turn_id": "turn-1"},
                 },
-            },
-            {
-                "timestamp": "2026-07-14T15:55:02Z",
-                "type": "response_item",
-                "payload": {
-                    "type": "message",
-                    "role": "assistant",
-                    "content": [{"type": "output_text", "text": "a1"}],
-                },
-            },
-            {
-                "timestamp": "2026-07-14T15:55:03Z",
-                "type": "response_item",
-                "payload": {
-                    "type": "message",
-                    "role": "assistant",
-                    "content": [{"type": "output_text", "text": "a2"}],
-                },
-            },
-            {
-                "timestamp": "2026-07-14T15:55:04Z",
-                "type": "event_msg",
-                "payload": {
-                    "type": "token_count",
-                    "info": {
-                        "last_token_usage": {
-                            "input_tokens": 120,
-                            "cached_input_tokens": 80,
-                            "output_tokens": 20,
-                            "reasoning_output_tokens": 5,
-                            "total_tokens": 140,
-                        }
+                {
+                    "timestamp": "2026-07-14T15:55:01Z",
+                    "type": "response_item",
+                    "payload": {
+                        "type": "message",
+                        "role": "user",
+                        "content": [{"type": "input_text", "text": "first"}],
                     },
                 },
-            },
-            {
-                "timestamp": "2026-07-14T15:55:05Z",
-                "type": "event_msg",
-                "payload": {"type": "task_complete", "turn_id": "turn-1"},
-            },
-            {
-                "timestamp": "2026-07-14T16:05:00Z",
-                "type": "event_msg",
-                "payload": {"type": "task_started", "turn_id": "turn-2"},
-            },
-            {
-                "timestamp": "2026-07-14T16:05:01Z",
-                "type": "response_item",
-                "payload": {
-                    "type": "message",
-                    "role": "user",
-                    "content": [{"type": "input_text", "text": "second"}],
-                },
-            },
-            {
-                "timestamp": "2026-07-14T16:05:02Z",
-                "type": "response_item",
-                "payload": {
-                    "type": "message",
-                    "role": "assistant",
-                    "content": [{"type": "output_text", "text": "b1"}],
-                },
-            },
-            {
-                "timestamp": "2026-07-14T16:05:03Z",
-                "type": "event_msg",
-                "payload": {
-                    "type": "token_count",
-                    "info": {
-                        "last_token_usage": {
-                            "input_tokens": 230,
-                            "cached_input_tokens": 10,
-                            "output_tokens": 20,
-                            "reasoning_output_tokens": 3,
-                            "total_tokens": 250,
-                        }
+                {
+                    "timestamp": "2026-07-14T15:55:02Z",
+                    "type": "response_item",
+                    "payload": {
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [{"type": "output_text", "text": "a1"}],
                     },
                 },
-            },
-            {
-                "timestamp": "2026-07-14T16:05:04Z",
-                "type": "event_msg",
-                "payload": {"type": "task_complete", "turn_id": "turn-2"},
-            },
-        ],
-    )
+                {
+                    "timestamp": "2026-07-14T15:55:03Z",
+                    "type": "response_item",
+                    "payload": {
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [{"type": "output_text", "text": "a2"}],
+                    },
+                },
+                {
+                    "timestamp": "2026-07-14T15:55:04Z",
+                    "type": "event_msg",
+                    "payload": {
+                        "type": "token_count",
+                        "info": {
+                            "last_token_usage": {
+                                "input_tokens": 120,
+                                "cached_input_tokens": 80,
+                                "output_tokens": 20,
+                                "reasoning_output_tokens": 5,
+                                "total_tokens": 140,
+                            }
+                        },
+                    },
+                },
+                {
+                    "timestamp": "2026-07-14T15:55:05Z",
+                    "type": "event_msg",
+                    "payload": {"type": "task_complete", "turn_id": "turn-1"},
+                },
+                {
+                    "timestamp": "2026-07-14T16:05:00Z",
+                    "type": "event_msg",
+                    "payload": {"type": "task_started", "turn_id": "turn-2"},
+                },
+                {
+                    "timestamp": "2026-07-14T16:05:01Z",
+                    "type": "response_item",
+                    "payload": {
+                        "type": "message",
+                        "role": "user",
+                        "content": [{"type": "input_text", "text": "second"}],
+                    },
+                },
+                {
+                    "timestamp": "2026-07-14T16:05:02Z",
+                    "type": "response_item",
+                    "payload": {
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [{"type": "output_text", "text": "b1"}],
+                    },
+                },
+                {
+                    "timestamp": "2026-07-14T16:05:03Z",
+                    "type": "event_msg",
+                    "payload": {
+                        "type": "token_count",
+                        "info": {
+                            "last_token_usage": {
+                                "input_tokens": 230,
+                                "cached_input_tokens": 10,
+                                "output_tokens": 20,
+                                "reasoning_output_tokens": 3,
+                                "total_tokens": 250,
+                            }
+                        },
+                    },
+                },
+                {
+                    "timestamp": "2026-07-14T16:05:04Z",
+                    "type": "event_msg",
+                    "payload": {"type": "task_complete", "turn_id": "turn-2"},
+                },
+            ],
+        )
 
-    daily, messages, _session_meta, session_tokens = process_jsonl_file(
-        jsonl, "localhost", "rhuang"
-    )
+        daily, messages, _session_meta, session_tokens = process_jsonl_file(
+            jsonl, "localhost", "rhuang"
+        )
 
-    assert daily["2026-07-14"]["prompt_tokens"] == 40
-    assert daily["2026-07-14"]["candidates_tokens"] == 20
-    assert daily["2026-07-14"]["cached_tokens"] == 80
-    assert daily["2026-07-14"]["total_tokens"] == 140
-    assert daily["2026-07-14"]["request_count"] == 1
+        assert daily["2026-07-14"]["prompt_tokens"] == 40
+        assert daily["2026-07-14"]["candidates_tokens"] == 20
+        assert daily["2026-07-14"]["cached_tokens"] == 80
+        assert daily["2026-07-14"]["total_tokens"] == 140
+        assert daily["2026-07-14"]["request_count"] == 1
 
-    assert daily["2026-07-15"]["prompt_tokens"] == 220
-    assert daily["2026-07-15"]["candidates_tokens"] == 20
-    assert daily["2026-07-15"]["cached_tokens"] == 10
-    assert daily["2026-07-15"]["total_tokens"] == 250
-    assert daily["2026-07-15"]["request_count"] == 1
+        assert daily["2026-07-15"]["prompt_tokens"] == 220
+        assert daily["2026-07-15"]["candidates_tokens"] == 20
+        assert daily["2026-07-15"]["cached_tokens"] == 10
+        assert daily["2026-07-15"]["total_tokens"] == 250
+        assert daily["2026-07-15"]["request_count"] == 1
 
-    user_messages = [msg for msg in messages if msg["role"] == "user"]
-    assert [msg["tokens_used"] for msg in user_messages] == [140, 250]
-    assert session_tokens["total_tokens"] == 390
-    assert session_tokens["input_tokens"] == 260
-    assert session_tokens["output_tokens"] == 40
+        user_messages = [msg for msg in messages if msg["role"] == "user"]
+        assert [msg["tokens_used"] for msg in user_messages] == [140, 250]
+        assert session_tokens["total_tokens"] == 390
+        assert session_tokens["input_tokens"] == 260
+        assert session_tokens["output_tokens"] == 40
 
 
 def test_reimport_replaces_stale_codex_session_rows(monkeypatch, tmp_path):

--- a/tests/unit/test_fetch_codex.py
+++ b/tests/unit/test_fetch_codex.py
@@ -43,91 +43,92 @@ def _temporary_timezone(tz_name: str):
 
 
 def test_process_jsonl_file_keeps_provider_total_and_attributes_turn_to_user(tmp_path):
-    jsonl = _write_jsonl(
-        tmp_path / "rollout-test-codex.jsonl",
-        [
-            {
-                "timestamp": "2026-07-15T01:00:00Z",
-                "type": "event_msg",
-                "payload": {"type": "task_started", "turn_id": "turn-1"},
-            },
-            {
-                "timestamp": "2026-07-15T01:00:01Z",
-                "type": "turn_context",
-                "payload": {"model": "codex-mini"},
-            },
-            {
-                "timestamp": "2026-07-15T01:00:02Z",
-                "type": "response_item",
-                "payload": {
-                    "type": "message",
-                    "role": "user",
-                    "content": [{"type": "input_text", "text": "hello"}],
+    with _temporary_timezone("Asia/Shanghai"):
+        jsonl = _write_jsonl(
+            tmp_path / "rollout-test-codex.jsonl",
+            [
+                {
+                    "timestamp": "2026-07-15T01:00:00Z",
+                    "type": "event_msg",
+                    "payload": {"type": "task_started", "turn_id": "turn-1"},
                 },
-            },
-            {
-                "timestamp": "2026-07-15T01:00:03Z",
-                "type": "response_item",
-                "payload": {
-                    "type": "message",
-                    "role": "assistant",
-                    "content": [{"type": "output_text", "text": "world"}],
+                {
+                    "timestamp": "2026-07-15T01:00:01Z",
+                    "type": "turn_context",
+                    "payload": {"model": "codex-mini"},
                 },
-            },
-            {
-                "timestamp": "2026-07-15T01:00:04Z",
-                "type": "event_msg",
-                "payload": {
-                    "type": "token_count",
-                    "info": {
-                        "last_token_usage": {
-                            "input_tokens": 1000,
-                            "cached_input_tokens": 800,
-                            "output_tokens": 50,
-                            "reasoning_output_tokens": 20,
-                            "total_tokens": 1050,
-                        }
+                {
+                    "timestamp": "2026-07-15T01:00:02Z",
+                    "type": "response_item",
+                    "payload": {
+                        "type": "message",
+                        "role": "user",
+                        "content": [{"type": "input_text", "text": "hello"}],
                     },
                 },
-            },
-            {
-                "timestamp": "2026-07-15T01:00:05Z",
-                "type": "event_msg",
-                "payload": {
-                    "type": "task_complete",
-                    "turn_id": "turn-1",
-                    "last_agent_message": "done",
+                {
+                    "timestamp": "2026-07-15T01:00:03Z",
+                    "type": "response_item",
+                    "payload": {
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [{"type": "output_text", "text": "world"}],
+                    },
                 },
-            },
-        ],
-    )
+                {
+                    "timestamp": "2026-07-15T01:00:04Z",
+                    "type": "event_msg",
+                    "payload": {
+                        "type": "token_count",
+                        "info": {
+                            "last_token_usage": {
+                                "input_tokens": 1000,
+                                "cached_input_tokens": 800,
+                                "output_tokens": 50,
+                                "reasoning_output_tokens": 20,
+                                "total_tokens": 1050,
+                            }
+                        },
+                    },
+                },
+                {
+                    "timestamp": "2026-07-15T01:00:05Z",
+                    "type": "event_msg",
+                    "payload": {
+                        "type": "task_complete",
+                        "turn_id": "turn-1",
+                        "last_agent_message": "done",
+                    },
+                },
+            ],
+        )
 
-    daily, messages, _session_meta, session_tokens = process_jsonl_file(
-        jsonl, "localhost", "rhuang"
-    )
+        daily, messages, _session_meta, session_tokens = process_jsonl_file(
+            jsonl, "localhost", "rhuang"
+        )
 
-    assert daily["2026-07-15"]["prompt_tokens"] == 200
-    assert daily["2026-07-15"]["candidates_tokens"] == 50
-    assert daily["2026-07-15"]["thoughts_tokens"] == 20
-    assert daily["2026-07-15"]["cached_tokens"] == 800
-    assert daily["2026-07-15"]["total_tokens"] == 1050
-    assert daily["2026-07-15"]["request_count"] == 1
+        assert daily["2026-07-15"]["prompt_tokens"] == 200
+        assert daily["2026-07-15"]["candidates_tokens"] == 50
+        assert daily["2026-07-15"]["thoughts_tokens"] == 20
+        assert daily["2026-07-15"]["cached_tokens"] == 800
+        assert daily["2026-07-15"]["total_tokens"] == 1050
+        assert daily["2026-07-15"]["request_count"] == 1
 
-    user_msg = next(msg for msg in messages if msg["role"] == "user")
-    assistant_msg = next(
-        msg
-        for msg in messages
-        if msg["role"] == "assistant" and msg["message_id"] != user_msg["message_id"]
-    )
-    assert user_msg["tokens_used"] == 1050
-    assert user_msg["input_tokens"] == 200
-    assert user_msg["output_tokens"] == 50
-    assert user_msg["counts_as_request"] is True
-    assert assistant_msg["tokens_used"] == 0
+        user_msg = next(msg for msg in messages if msg["role"] == "user")
+        assistant_msg = next(
+            msg
+            for msg in messages
+            if msg["role"] == "assistant" and msg["message_id"] != user_msg["message_id"]
+        )
+        assert user_msg["tokens_used"] == 1050
+        assert user_msg["input_tokens"] == 200
+        assert user_msg["output_tokens"] == 50
+        assert user_msg["counts_as_request"] is True
+        assert assistant_msg["tokens_used"] == 0
 
-    assert session_tokens["total_tokens"] == 1050
-    assert session_tokens["input_tokens"] == 200
-    assert session_tokens["output_tokens"] == 50
+        assert session_tokens["total_tokens"] == 1050
+        assert session_tokens["input_tokens"] == 200
+        assert session_tokens["output_tokens"] == 50
 
 
 def test_process_jsonl_file_splits_turns_by_local_date_and_counts_requests_once(tmp_path):

--- a/tests/unit/test_fetch_codex.py
+++ b/tests/unit/test_fetch_codex.py
@@ -1,0 +1,234 @@
+"""Unit coverage for Codex fetch token accounting."""
+
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+from fetch_codex import process_jsonl_file  # noqa: E402
+
+
+def _write_jsonl(path: Path, entries: list[dict]) -> Path:
+    with open(path, "w", encoding="utf-8") as f:
+        for entry in entries:
+            f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+    return path
+
+
+def test_process_jsonl_file_keeps_provider_total_and_attributes_turn_to_user(tmp_path):
+    jsonl = _write_jsonl(
+        tmp_path / "rollout-test-codex.jsonl",
+        [
+            {
+                "timestamp": "2026-07-15T01:00:00Z",
+                "type": "event_msg",
+                "payload": {"type": "task_started", "turn_id": "turn-1"},
+            },
+            {
+                "timestamp": "2026-07-15T01:00:01Z",
+                "type": "turn_context",
+                "payload": {"model": "codex-mini"},
+            },
+            {
+                "timestamp": "2026-07-15T01:00:02Z",
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "hello"}],
+                },
+            },
+            {
+                "timestamp": "2026-07-15T01:00:03Z",
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": "world"}],
+                },
+            },
+            {
+                "timestamp": "2026-07-15T01:00:04Z",
+                "type": "event_msg",
+                "payload": {
+                    "type": "token_count",
+                    "info": {
+                        "last_token_usage": {
+                            "input_tokens": 1000,
+                            "cached_input_tokens": 800,
+                            "output_tokens": 50,
+                            "reasoning_output_tokens": 20,
+                            "total_tokens": 1050,
+                        }
+                    },
+                },
+            },
+            {
+                "timestamp": "2026-07-15T01:00:05Z",
+                "type": "event_msg",
+                "payload": {
+                    "type": "task_complete",
+                    "turn_id": "turn-1",
+                    "last_agent_message": "done",
+                },
+            },
+        ],
+    )
+
+    daily, messages, _session_meta, session_tokens = process_jsonl_file(
+        jsonl, "localhost", "rhuang"
+    )
+
+    assert daily["2026-07-15"]["prompt_tokens"] == 200
+    assert daily["2026-07-15"]["candidates_tokens"] == 50
+    assert daily["2026-07-15"]["thoughts_tokens"] == 20
+    assert daily["2026-07-15"]["cached_tokens"] == 800
+    assert daily["2026-07-15"]["total_tokens"] == 1050
+    assert daily["2026-07-15"]["request_count"] == 1
+
+    user_msg = next(msg for msg in messages if msg["role"] == "user")
+    assistant_msg = next(
+        msg
+        for msg in messages
+        if msg["role"] == "assistant" and msg["message_id"] != user_msg["message_id"]
+    )
+    assert user_msg["tokens_used"] == 1050
+    assert user_msg["input_tokens"] == 200
+    assert user_msg["output_tokens"] == 50
+    assert user_msg["counts_as_request"] is True
+    assert assistant_msg["tokens_used"] == 0
+
+    assert session_tokens["total_tokens"] == 1050
+    assert session_tokens["input_tokens"] == 200
+    assert session_tokens["output_tokens"] == 50
+
+
+def test_process_jsonl_file_splits_turns_by_local_date_and_counts_requests_once(tmp_path):
+    jsonl = _write_jsonl(
+        tmp_path / "rollout-test-codex-multi.jsonl",
+        [
+            {
+                "timestamp": "2026-07-14T15:55:00Z",
+                "type": "event_msg",
+                "payload": {"type": "task_started", "turn_id": "turn-1"},
+            },
+            {
+                "timestamp": "2026-07-14T15:55:01Z",
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "first"}],
+                },
+            },
+            {
+                "timestamp": "2026-07-14T15:55:02Z",
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": "a1"}],
+                },
+            },
+            {
+                "timestamp": "2026-07-14T15:55:03Z",
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": "a2"}],
+                },
+            },
+            {
+                "timestamp": "2026-07-14T15:55:04Z",
+                "type": "event_msg",
+                "payload": {
+                    "type": "token_count",
+                    "info": {
+                        "last_token_usage": {
+                            "input_tokens": 120,
+                            "cached_input_tokens": 80,
+                            "output_tokens": 20,
+                            "reasoning_output_tokens": 5,
+                            "total_tokens": 140,
+                        }
+                    },
+                },
+            },
+            {
+                "timestamp": "2026-07-14T15:55:05Z",
+                "type": "event_msg",
+                "payload": {"type": "task_complete", "turn_id": "turn-1"},
+            },
+            {
+                "timestamp": "2026-07-14T16:05:00Z",
+                "type": "event_msg",
+                "payload": {"type": "task_started", "turn_id": "turn-2"},
+            },
+            {
+                "timestamp": "2026-07-14T16:05:01Z",
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "second"}],
+                },
+            },
+            {
+                "timestamp": "2026-07-14T16:05:02Z",
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": "b1"}],
+                },
+            },
+            {
+                "timestamp": "2026-07-14T16:05:03Z",
+                "type": "event_msg",
+                "payload": {
+                    "type": "token_count",
+                    "info": {
+                        "last_token_usage": {
+                            "input_tokens": 230,
+                            "cached_input_tokens": 10,
+                            "output_tokens": 20,
+                            "reasoning_output_tokens": 3,
+                            "total_tokens": 250,
+                        }
+                    },
+                },
+            },
+            {
+                "timestamp": "2026-07-14T16:05:04Z",
+                "type": "event_msg",
+                "payload": {"type": "task_complete", "turn_id": "turn-2"},
+            },
+        ],
+    )
+
+    daily, messages, _session_meta, session_tokens = process_jsonl_file(
+        jsonl, "localhost", "rhuang"
+    )
+
+    assert daily["2026-07-14"]["prompt_tokens"] == 40
+    assert daily["2026-07-14"]["candidates_tokens"] == 20
+    assert daily["2026-07-14"]["cached_tokens"] == 80
+    assert daily["2026-07-14"]["total_tokens"] == 140
+    assert daily["2026-07-14"]["request_count"] == 1
+
+    assert daily["2026-07-15"]["prompt_tokens"] == 220
+    assert daily["2026-07-15"]["candidates_tokens"] == 20
+    assert daily["2026-07-15"]["cached_tokens"] == 10
+    assert daily["2026-07-15"]["total_tokens"] == 250
+    assert daily["2026-07-15"]["request_count"] == 1
+
+    user_messages = [msg for msg in messages if msg["role"] == "user"]
+    assert [msg["tokens_used"] for msg in user_messages] == [140, 250]
+    assert session_tokens["total_tokens"] == 390
+    assert session_tokens["input_tokens"] == 260
+    assert session_tokens["output_tokens"] == 40

--- a/tests/unit/test_fetch_qwen.py
+++ b/tests/unit/test_fetch_qwen.py
@@ -1,0 +1,81 @@
+"""Unit coverage for Qwen fetch token accounting."""
+
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+from fetch_qwen import extract_tokens_from_entry, process_jsonl_file  # noqa: E402
+
+
+def _write_jsonl(path: Path, entries: list[dict]) -> Path:
+    with open(path, "w", encoding="utf-8") as f:
+        for entry in entries:
+            f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+    return path
+
+
+def test_extract_tokens_keeps_provider_total_and_separates_cache():
+    entry = {
+        "type": "assistant",
+        "model": "qwen-max",
+        "usageMetadata": {
+            "promptTokenCount": 1000,
+            "candidatesTokenCount": 50,
+            "thoughtsTokenCount": 20,
+            "cachedContentTokenCount": 800,
+            "totalTokenCount": 1050,
+        },
+    }
+
+    tokens = extract_tokens_from_entry(entry)
+
+    assert tokens["actual_input_tokens"] == 200
+    assert tokens["cached_tokens"] == 800
+    assert tokens["candidates_tokens"] == 50
+    assert tokens["thoughts_tokens"] == 20
+    assert tokens["total_tokens"] == 1050
+
+
+def test_process_jsonl_file_counts_cache_in_total_without_double_counting_thoughts(tmp_path):
+    jsonl = _write_jsonl(
+        tmp_path / "sess-qwen.jsonl",
+        [
+            {
+                "type": "assistant",
+                "timestamp": "2026-07-15T07:00:00Z",
+                "model": "qwen-max",
+                "sessionId": "sess-qwen",
+                "uuid": "assistant-1",
+                "message": {
+                    "message_id": "assistant-1",
+                    "parts": [{"text": "hello"}],
+                },
+                "usageMetadata": {
+                    "promptTokenCount": 1000,
+                    "candidatesTokenCount": 50,
+                    "thoughtsTokenCount": 20,
+                    "cachedContentTokenCount": 800,
+                    "totalTokenCount": 1050,
+                },
+            }
+        ],
+    )
+
+    daily, messages = process_jsonl_file(jsonl, "localhost", "rhuang")
+
+    assert daily["2026-07-15"]["prompt_tokens"] == 200
+    assert daily["2026-07-15"]["candidates_tokens"] == 50
+    assert daily["2026-07-15"]["thoughts_tokens"] == 20
+    assert daily["2026-07-15"]["cached_tokens"] == 800
+    assert daily["2026-07-15"]["total_tokens"] == 1050
+    assert daily["2026-07-15"]["request_count"] == 1
+
+    assert len(messages) == 1
+    assert messages[0]["tokens_used"] == 1050
+    assert messages[0]["input_tokens"] == 200
+    assert messages[0]["output_tokens"] == 50

--- a/tests/unit/test_fetch_zcode.py
+++ b/tests/unit/test_fetch_zcode.py
@@ -827,3 +827,97 @@ def test_fetch_and_save_clears_stale_assistant_tokens(fetch_mod, tmp_path, monke
         ("m1", "user", 225, 200, 25),
         ("m2", "assistant", 0, 0, 0),
     ]
+
+
+def test_process_zcode_session_warns_on_partial_turn_match(fetch_mod, tmp_path, capsys):
+    src_db = tmp_path / "source.sqlite"
+    _build_zcode_source_db(src_db)
+    now_ms = int(datetime.now(timezone.utc).timestamp() * 1000)
+    sid = "sess_partial_warn"
+    conn = sqlite3.connect(str(src_db))
+    conn.execute(
+        "INSERT INTO session (id, directory, time_created, time_updated, time_archived, task_type, title) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (sid, "/repo", now_ms, now_ms, None, "interactive", "t"),
+    )
+    conn.commit()
+    conn.close()
+    _insert_zcode_message(
+        src_db, "m1", sid, now_ms, {"role": "user"}, parts=[{"type": "text", "text": "hello"}]
+    )
+    _insert_zcode_message(
+        src_db,
+        "m2",
+        sid,
+        now_ms + 1,
+        {"role": "assistant", "modelID": "GLM-5.2"},
+        parts=[{"type": "text", "text": "world"}],
+    )
+    _insert_turn_usage(
+        src_db, sid, "turn_1", 200, 25, user_message_id="m1", started_at=now_ms, cache_read_t=75
+    )
+    _insert_turn_usage(
+        src_db,
+        sid,
+        "turn_2",
+        100,
+        10,
+        user_message_id="missing-user",
+        started_at=now_ms + 60000,
+        cache_read_t=25,
+    )
+
+    daily, messages, _project = fetch_mod.process_zcode_session(sid, src_db, hostname="localhost")
+    out = capsys.readouterr().out
+
+    assert "turn_usage rows could not be matched" in out
+    assert f"session={sid}" in out
+    user_row = next(msg for msg in messages if msg["message_id"] == "m1")
+    assistant_row = next(msg for msg in messages if msg["message_id"] == "m2")
+    assert user_row["tokens_used"] == 225
+    assert assistant_row["tokens_used"] == 0
+    msg_date = fetch_mod._ms_to_date(now_ms)
+    assert daily[msg_date]["total_tokens"] == 335
+
+
+def test_process_zcode_session_warns_when_falling_back_to_assistant(fetch_mod, tmp_path, capsys):
+    src_db = tmp_path / "source.sqlite"
+    _build_zcode_source_db(src_db)
+    now_ms = int(datetime.now(timezone.utc).timestamp() * 1000)
+    sid = "sess_fallback_warn"
+    conn = sqlite3.connect(str(src_db))
+    conn.execute(
+        "INSERT INTO session (id, directory, time_created, time_updated, time_archived, task_type, title) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (sid, "/repo", now_ms, now_ms, None, "interactive", "t"),
+    )
+    conn.commit()
+    conn.close()
+    _insert_zcode_message(
+        src_db, "m1", sid, now_ms, {"role": "user"}, parts=[{"type": "text", "text": "hello"}]
+    )
+    _insert_zcode_message(
+        src_db,
+        "m2",
+        sid,
+        now_ms + 1,
+        {"role": "assistant", "modelID": "GLM-5.2"},
+        parts=[{"type": "text", "text": "world"}],
+    )
+    _insert_turn_usage(
+        src_db,
+        sid,
+        "turn_1",
+        200,
+        25,
+        user_message_id="missing-user",
+        started_at=now_ms,
+        cache_read_t=75,
+    )
+
+    _daily, messages, _project = fetch_mod.process_zcode_session(sid, src_db, hostname="localhost")
+    out = capsys.readouterr().out
+
+    assert "falling back to session-level assistant token attribution" in out
+    assistant_row = next(msg for msg in messages if msg["message_id"] == "m2")
+    assert assistant_row["tokens_used"] == 225

--- a/tests/unit/test_fetch_zcode.py
+++ b/tests/unit/test_fetch_zcode.py
@@ -89,8 +89,14 @@ def _build_zcode_source_db(db_path: Path) -> None:
         CREATE TABLE turn_usage (
             session_id text not null,
             turn_id text not null,
+            user_message_id text,
+            status text not null default 'completed',
+            started_at integer not null default 0,
             input_tokens integer not null default 0,
             output_tokens integer not null default 0,
+            cache_creation_input_tokens integer not null default 0,
+            cache_read_input_tokens integer not null default 0,
+            computed_total_tokens integer not null default 0,
             PRIMARY KEY (session_id, turn_id)
         );
         """
@@ -123,13 +129,50 @@ def _insert_zcode_message(
 
 
 def _insert_turn_usage(
-    db_path: Path, session_id: str, turn_id: str, input_t: int, output_t: int
+    db_path: Path,
+    session_id: str,
+    turn_id: str,
+    input_t: int,
+    output_t: int,
+    *,
+    user_message_id: str | None = None,
+    started_at: int | None = None,
+    cache_creation_t: int = 0,
+    cache_read_t: int = 0,
+    computed_total_t: int | None = None,
 ) -> None:
     conn = sqlite3.connect(str(db_path))
+    if started_at is None:
+        started_at = int(datetime.now(timezone.utc).timestamp() * 1000)
+    if computed_total_t is None:
+        computed_total_t = input_t + output_t
     conn.execute(
-        "INSERT INTO turn_usage (session_id, turn_id, input_tokens, output_tokens) "
-        "VALUES (?, ?, ?, ?)",
-        (session_id, turn_id, input_t, output_t),
+        """
+        INSERT INTO turn_usage (
+            session_id,
+            turn_id,
+            user_message_id,
+            status,
+            started_at,
+            input_tokens,
+            output_tokens,
+            cache_creation_input_tokens,
+            cache_read_input_tokens,
+            computed_total_tokens
+        )
+        VALUES (?, ?, ?, 'completed', ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            session_id,
+            turn_id,
+            user_message_id,
+            started_at,
+            input_t,
+            output_t,
+            cache_creation_t,
+            cache_read_t,
+            computed_total_t,
+        ),
     )
     conn.commit()
     conn.close()
@@ -192,16 +235,26 @@ def _init_dest_schema(db_path: Path) -> None:
             tool_name TEXT,
             host_name TEXT,
             message_id TEXT,
+            parent_id TEXT,
             role TEXT,
             content TEXT,
+            full_entry TEXT,
             tokens_used INTEGER DEFAULT 0,
             input_tokens INTEGER DEFAULT 0,
             output_tokens INTEGER DEFAULT 0,
             model TEXT,
+            message_source TEXT,
+            feishu_conversation_id TEXT,
+            group_subject TEXT,
+            is_group_chat INTEGER,
             sender_id TEXT,
             sender_name TEXT,
-            timestamp TEXT
+            timestamp TEXT,
+            agent_session_id TEXT,
+            conversation_id TEXT
         );
+        CREATE UNIQUE INDEX idx_daily_messages_unique
+        ON daily_messages (date, tool_name, host_name, message_id);
         """
     )
     conn.commit()
@@ -263,7 +316,16 @@ def test_process_zcode_session_returns_messages_and_project(fetch_mod, tmp_path)
     # Authoritative session-level tokens come from turn_usage, NOT the sparse
     # per-message data.tokens above. Seed a turn_usage row with different
     # numbers to prove the session totals win.
-    _insert_turn_usage(src_db, sid, "turn_1", input_t=250, output_t=30)
+    _insert_turn_usage(
+        src_db,
+        sid,
+        "turn_1",
+        input_t=250,
+        output_t=30,
+        user_message_id="msg_1",
+        started_at=1700000000200,
+        computed_total_t=280,
+    )
 
     daily, messages, project = fetch_mod.process_zcode_session(sid, src_db, "localhost", None)
 
@@ -273,12 +335,13 @@ def test_process_zcode_session_returns_messages_and_project(fetch_mod, tmp_path)
     assert messages[0]["role"] == "user"
     assert messages[0]["content"] == "hello world"
     assert messages[0]["agent_session_id"] == sid
-    # Per-message tokens are 0; session totals injected into first assistant msg.
-    assert messages[0]["tokens_used"] == 0
+    # Per-turn tokens are attached to the initiating user message so hourly
+    # rollups align with turn start time.
+    assert messages[0]["tokens_used"] == 280
+    assert messages[0]["input_tokens"] == 250
+    assert messages[0]["output_tokens"] == 30
     assert messages[1]["role"] == "assistant"
-    assert messages[1]["input_tokens"] == 250
-    assert messages[1]["output_tokens"] == 30
-    assert messages[1]["tokens_used"] == 280
+    assert messages[1]["tokens_used"] == 0
     # daily aggregates use session totals (250 input + 30 output = 280)
     assert len(daily) == 1
     only_date = next(iter(daily))
@@ -332,6 +395,80 @@ def test_process_zcode_session_request_count_counts_assistant_messages(fetch_mod
     assert len(messages) == 4
     only_date = next(iter(daily))
     assert daily[only_date]["request_count"] == 2
+
+
+def test_process_zcode_session_splits_tokens_by_turn_date_and_tracks_cache(fetch_mod, tmp_path):
+    src_db = tmp_path / "zcode.sqlite"
+    _build_zcode_source_db(src_db)
+    sid = "sess_cross_day"
+    day1_ms = int(datetime(2026, 7, 14, 10, 0, tzinfo=timezone.utc).timestamp() * 1000)
+    day2_ms = int(datetime(2026, 7, 15, 12, 0, tzinfo=timezone.utc).timestamp() * 1000)
+    conn = sqlite3.connect(str(src_db))
+    conn.execute(
+        "INSERT INTO session (id, directory, time_created, time_updated, time_archived, task_type, title) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (sid, "/repo", day1_ms, day2_ms, None, "interactive", "t"),
+    )
+    conn.commit()
+    conn.close()
+    _insert_zcode_message(
+        src_db, "m1", sid, day1_ms, {"role": "user"}, parts=[{"type": "text", "text": "q1"}]
+    )
+    _insert_zcode_message(
+        src_db,
+        "m2",
+        sid,
+        day1_ms + 1,
+        {"role": "assistant", "modelID": "GLM-5.2"},
+        parts=[{"type": "text", "text": "a1"}],
+    )
+    _insert_zcode_message(
+        src_db, "m3", sid, day2_ms, {"role": "user"}, parts=[{"type": "text", "text": "q2"}]
+    )
+    _insert_zcode_message(
+        src_db,
+        "m4",
+        sid,
+        day2_ms + 1,
+        {"role": "assistant", "modelID": "GLM-5.2"},
+        parts=[{"type": "text", "text": "a2"}],
+    )
+    _insert_turn_usage(
+        src_db, sid, "turn_1", 120, 20, user_message_id="m1", started_at=day1_ms, cache_read_t=80
+    )
+    _insert_turn_usage(
+        src_db,
+        sid,
+        "turn_2",
+        220,
+        30,
+        user_message_id="m3",
+        started_at=day2_ms,
+        cache_creation_t=10,
+    )
+
+    daily, messages, _project = fetch_mod.process_zcode_session(sid, src_db, "localhost", None)
+
+    assert len(messages) == 4
+    date1 = fetch_mod._ms_to_date(day1_ms)
+    date2 = fetch_mod._ms_to_date(day2_ms)
+    assert daily[date1]["prompt_tokens"] == 120
+    assert daily[date1]["candidates_tokens"] == 20
+    assert daily[date1]["cached_tokens"] == 80
+    assert daily[date1]["total_tokens"] == 140
+    assert daily[date1]["request_count"] == 1
+    assert daily[date2]["prompt_tokens"] == 220
+    assert daily[date2]["candidates_tokens"] == 30
+    assert daily[date2]["cached_tokens"] == 10
+    assert daily[date2]["total_tokens"] == 250
+    assert daily[date2]["request_count"] == 1
+    # Per-turn totals land on the initiating user messages for each day.
+    assert messages[0]["tokens_used"] == 140
+    assert messages[0]["input_tokens"] == 120
+    assert messages[0]["output_tokens"] == 20
+    assert messages[2]["tokens_used"] == 250
+    assert messages[2]["input_tokens"] == 220
+    assert messages[2]["output_tokens"] == 30
 
 
 def test_process_zcode_session_skips_empty(fetch_mod, tmp_path):
@@ -558,3 +695,135 @@ def test_iter_candidate_sessions_days_filter(fetch_mod, tmp_path):
     candidates = fetch_mod._iter_candidate_sessions(src_db, days=7, recent=False)
     ids = {sid for sid, _ in candidates}
     assert ids == {"sess_recent"}
+
+
+def test_fetch_and_save_persists_zcode_cache_tokens(fetch_mod, tmp_path, monkeypatch):
+    src_db = tmp_path / "source.sqlite"
+    _build_zcode_source_db(src_db)
+    now_ms = int(datetime.now(timezone.utc).timestamp() * 1000)
+    sid = "sess_cache"
+    conn = sqlite3.connect(str(src_db))
+    conn.execute(
+        "INSERT INTO session (id, directory, time_created, time_updated, time_archived, task_type, title) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (sid, "/repo", now_ms, now_ms, None, "interactive", "t"),
+    )
+    conn.commit()
+    conn.close()
+    _insert_zcode_message(
+        src_db, "m1", sid, now_ms, {"role": "user"}, parts=[{"type": "text", "text": "hello"}]
+    )
+    _insert_zcode_message(
+        src_db,
+        "m2",
+        sid,
+        now_ms + 1,
+        {"role": "assistant", "modelID": "GLM-5.2"},
+        parts=[{"type": "text", "text": "world"}],
+    )
+    _insert_turn_usage(
+        src_db, sid, "turn_1", 200, 25, user_message_id="m1", started_at=now_ms, cache_read_t=75
+    )
+
+    monkeypatch.setattr(fetch_mod, "find_zcode_db_path", lambda: src_db)
+
+    assert fetch_mod.fetch_and_save(days=7, hostname="localhost") is True
+
+    dest_db = tmp_path / "dest.sqlite"
+    conn = sqlite3.connect(str(dest_db))
+    row = conn.execute(
+        "SELECT tokens_used, input_tokens, output_tokens, cache_tokens FROM daily_usage "
+        "WHERE tool_name = 'zcode'"
+    ).fetchone()
+    msg_row = conn.execute(
+        "SELECT role, tokens_used, input_tokens, output_tokens FROM daily_messages "
+        "WHERE tool_name = 'zcode' ORDER BY id LIMIT 2"
+    ).fetchall()
+    conn.close()
+    assert row == (225, 200, 25, 75)
+    assert msg_row[0] == ("user", 225, 200, 25)
+    assert msg_row[1] == ("assistant", 0, 0, 0)
+
+
+def test_fetch_and_save_clears_stale_assistant_tokens(fetch_mod, tmp_path, monkeypatch):
+    src_db = tmp_path / "source.sqlite"
+    _build_zcode_source_db(src_db)
+    now_ms = int(datetime.now(timezone.utc).timestamp() * 1000)
+    sid = "sess_stale"
+    conn = sqlite3.connect(str(src_db))
+    conn.execute(
+        "INSERT INTO session (id, directory, time_created, time_updated, time_archived, task_type, title) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (sid, "/repo", now_ms, now_ms, None, "interactive", "t"),
+    )
+    conn.commit()
+    conn.close()
+    _insert_zcode_message(
+        src_db, "m1", sid, now_ms, {"role": "user"}, parts=[{"type": "text", "text": "hello"}]
+    )
+    _insert_zcode_message(
+        src_db,
+        "m2",
+        sid,
+        now_ms + 1,
+        {"role": "assistant", "modelID": "GLM-5.2"},
+        parts=[{"type": "text", "text": "world"}],
+    )
+    _insert_turn_usage(
+        src_db, sid, "turn_1", 200, 25, user_message_id="m1", started_at=now_ms, cache_read_t=75
+    )
+
+    dest_db = tmp_path / "dest.sqlite"
+    msg_date = fetch_mod._ms_to_date(now_ms)
+    pre = sqlite3.connect(str(dest_db))
+    pre.execute(
+        """
+        INSERT INTO daily_messages (
+            date, tool_name, host_name, message_id, parent_id, role, content, full_entry,
+            tokens_used, input_tokens, output_tokens, model, timestamp, message_source,
+            feishu_conversation_id, group_subject, is_group_chat, sender_id, sender_name,
+            agent_session_id, conversation_id
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            msg_date,
+            "zcode",
+            "localhost",
+            "m2",
+            None,
+            "assistant",
+            "world",
+            "{}",
+            999,
+            900,
+            99,
+            "GLM-5.2",
+            datetime.now(timezone.utc).isoformat(),
+            None,
+            None,
+            None,
+            None,
+            "zcode_user",
+            "rhuang-host-zcode",
+            sid,
+            None,
+        ),
+    )
+    pre.commit()
+    pre.close()
+
+    monkeypatch.setattr(fetch_mod, "find_zcode_db_path", lambda: src_db)
+
+    assert fetch_mod.fetch_and_save(days=7, hostname="localhost") is True
+
+    conn = sqlite3.connect(str(dest_db))
+    rows = conn.execute(
+        "SELECT message_id, role, tokens_used, input_tokens, output_tokens "
+        "FROM daily_messages WHERE tool_name = 'zcode' ORDER BY message_id"
+    ).fetchall()
+    conn.close()
+    assert rows == [
+        ("m1", "user", 225, 200, 25),
+        ("m2", "assistant", 0, 0, 0),
+    ]


### PR DESCRIPTION
## Summary
- fix Claude usage dedup so repeated JSONL lines for one logical message do not double count tokens and cache is included in totals
- fix Qwen and Codex totals to preserve provider total semantics, including cache, and stop skewing hourly/daily message stats by dumping session totals onto one assistant row
- fix ZCode turn attribution to use authoritative `turn_usage` rows, clear stale assistant token rows on re-fetch, and add a comparison script for reconciling Open ACE totals with z.ai usage

## Testing
- python3 -m pytest -q tests/unit/test_fetch_codex.py tests/unit/test_fetch_qwen.py tests/unit/test_fetch_zcode.py tests/issues/723/test_fetch_claude_merge.py tests/unit/test_fetch_request_dedup.py
- pre-commit hooks during `git commit`
