### PR TITLE
fix: prevent set -e from silently killing configure_sudoers on upgrade

### DIFF
--- a/scripts/install-central/package-method/install.sh
+++ b/scripts/install-central/package-method/install.sh
@@ -2064,7 +2064,7 @@ ${line}"
         # authorization. Check the Cmnd_Alias definition line for each newer
         # CLI path; any missing one trips a rewrite.
         local cli_alias_line=""
-        cli_alias_line=$(grep "Cmnd_Alias OPENACE_CLI" "$sudoers_file" 2>/dev/null)
+        cli_alias_line=$(grep "Cmnd_Alias OPENACE_CLI" "$sudoers_file" 2>/dev/null || true)
         if [ -n "$cli_alias_line" ]; then
             for cli in claude openclaw zcode; do
                 if ! echo "$cli_alias_line" | grep -qE "/${cli} \*"; then


### PR DESCRIPTION
## What

修复 `install.sh` 第 2067 行 `set -e` + `grep` 导致升级时脚本静默退出的 bug。

## Why

当从旧版本升级时（sudoers 文件不含 `Cmnd_Alias OPENACE_CLI`），`grep` 无匹配返回 exit 1，`$()` 子 shell 继承 `set -e` 直接退出，sudoers 文件无法更新。实际影响：`fetch_codex.py` / `fetch_zcode.py` 无法免密执行，remote agent 持续 401/404。

## Fix

```diff
-        cli_alias_line=$(grep "Cmnd_Alias OPENACE_CLI" "$sudoers_file" 2>/dev/null)
+        cli_alias_line=$(grep "Cmnd_Alias OPENACE_CLI" "$sudoers_file" 2>/dev/null || true)
```

- 已有 `OPENACE_CLI` 时：`grep` 返回 0，`|| true` 无影响，行为完全不变
- 缺少 `OPENACE_CLI` 时：`grep` 返回 1，`|| true` 捕获错误，`cli_alias_line=""` 继续执行，后续 `need_update=true` 触发 sudoers 文件重写

Closes #1728