### PR TITLE
fix(webui): add webui_callback_url for HTTPS reverse-proxy deployments

### DIFF
--- a/app/services/webui_manager.py
+++ b/app/services/webui_manager.py
@@ -143,6 +143,9 @@ class WorkspaceConfig:
     cleanup_interval_minutes: int = 5
     token_secret: str = ""
     webui_path: str = ""  # Path to qwen-code-webui project directory
+    # Optional explicit URL for the webui to reach the LLM proxy (e.g. behind an
+    # HTTPS reverse proxy). When set, :web_port is NOT appended. See issue #1730.
+    webui_callback_url: str = ""
 
 
 class WebUIManager:
@@ -221,6 +224,7 @@ class WebUIManager:
                 cleanup_interval_minutes=workspace.get("cleanup_interval_minutes", 5),
                 token_secret=workspace.get("token_secret", ""),
                 webui_path=workspace.get("webui_path", ""),
+                webui_callback_url=(workspace.get("webui_callback_url", "") or "").strip(),
             )
         except Exception as e:
             logger.error(f"Error loading config: {e}")
@@ -755,10 +759,22 @@ class WebUIManager:
         # Build openace_api_url from base_url (from request host_url)
         # WebUI process needs to connect to main service's LLM proxy API
         # Use base_url (user's actual access IP) instead of config.url (container-detected IP)
-        openace_api_url = self._remove_port_from_url(base_url)
-        server_config = self._load_server_config()
-        server_port = server_config.get("web_port", 19888)
-        openace_api_url = f"{openace_api_url}:{server_port}"
+        #
+        # Issue #1730: When open-ace sits behind an HTTPS reverse proxy, the backend
+        # listens on plain HTTP (web_port) while users access it via https://<domain>.
+        # The default logic below would inject https://<domain>:<web_port> into the
+        # webui, but <web_port> is not TLS-terminated (TLS ends at the proxy on 443),
+        # causing Node fetch to fail with "fetch failed". When ``webui_callback_url``
+        # is configured, use it verbatim (already includes the correct scheme and,
+        # if needed, the proxy port) and do NOT append :web_port.
+        webui_callback_url = (getattr(self.config, "webui_callback_url", "") or "").strip()
+        if webui_callback_url:
+            openace_api_url = webui_callback_url.rstrip("/")
+        else:
+            openace_api_url = self._remove_port_from_url(base_url)
+            server_config = self._load_server_config()
+            server_port = server_config.get("web_port", 19888)
+            openace_api_url = f"{openace_api_url}:{server_port}"
 
         # Build child environment first (needed for sudo env passing)
         child_env = os.environ.copy()


### PR DESCRIPTION
## 背景

Closes #1730

在 HTTPS 反向代理部署下，本地会话（qwen-code-webui）发消息报：
```
[API Error: Connection error. (cause: fetch failed)]
```

## 根因

`WebUIManager._launch_webui_process` 无条件按 `{浏览器scheme}://{浏览器host}:{server.web_port}` 拼接 webui 回连地址。反代场景下后端 `web_port` 是明文 HTTP，但浏览器 scheme 是 `https`，于是 webui 用 HTTPS 去连一个明文端口 → TLS 握手失败 → Node undici `fetch failed`。

实测：`OPENAI_BASE_URL` 被拼成 `https://<domain>:5000/api/workspace/llm-proxy/v1`，而 5000 是 HTTP。

## 修复（方式二：opt-in 配置，零影响）

新增可选配置字段 `workspace.webui_callback_url`：
- **未设置**：完全沿用原逻辑（`_replace_host_from_request` 结果 + `:{web_port}`），现有部署行为逐字节不变。
- **已设置**：直接以其作为 `openace_api_url`，**不追加 `:web_port`**，适用于前置 HTTPS 反代、对外端口为 443 的场景。

### 改动点

`app/services/webui_manager.py`：
1. `WorkspaceConfig` 新增 `webui_callback_url: str = ""`
2. `_load_config` 读取 `workspace.webui_callback_url`
3. `_launch_webui_process` 优先使用 `webui_callback_url`，否则走原逻辑

### 兼容性

- 不用反代的部署：不设置该字段 → 行为不变。
- 反代部署：设置 `webui_callback_url=https://<对外域名>` → webui 回连走 443 → nginx → 后端 HTTP。
- 配置在 `~/.open-ace/config.json`（升级保留），代码进上游后认该字段 → 升级不复发。

## 验证

在反代部署（nginx 443 TLS → 127.0.0.1:5000 HTTP）实测：

| 项 | 修复前 | 修复后 |
|---|---|---|
| webui `--openace-api-url` | `https://<domain>:5000` | `https://<domain>` |
| webui `OPENAI_BASE_URL` | `https://<domain>:5000/api/workspace/llm-proxy/v1` | `https://<domain>/api/workspace/llm-proxy/v1` |
| 调 LLM 代理（glm-4.6v） | `fetch failed`（TLS 错配） | HTTP 200，AI 正常回复 |

未设置该字段的直连部署行为不变。

## 后续（建议，不在本 PR 范围）

- `scripts/install-central/package-method/install.sh` 生成/更新 `config.json` 时对 `webui_callback_url` 做保留（与 SECRET_KEY 同等处理），避免升级交互误清空。
- 文档补充反代部署配置说明。
