### PR TITLE
fix: add env_keep check for GH_TOKEN and GIT_* vars in sudoers incremental update

### DIFF
--- a/scripts/install-central/package-method/install.sh
+++ b/scripts/install-central/package-method/install.sh
@@ -2075,6 +2075,21 @@ ${line}"
             done
         fi
 
+        # 【修复 Issue #1522】Check env_keep contains GH_TOKEN and GIT_* vars.
+        # The env_keep list grew over time (Issue #1517 added GH_TOKEN/GIT_* vars).
+        # Without this check, incremental upgrades skip the rewrite when other
+        # checks pass, leaving GH_TOKEN missing and breaking autonomous dev
+        # workflows (gh issue view fails with "exit 4: populate the GH_TOKEN").
+        if ! grep -q "GH_TOKEN" "$sudoers_file" 2>/dev/null; then
+            print_warning "Sudoers env_keep missing GH_TOKEN (autonomous dev will fail)"
+            need_update=true
+        fi
+
+        if ! grep -q "GIT_AUTHOR_NAME" "$sudoers_file" 2>/dev/null; then
+            print_warning "Sudoers env_keep missing GIT_* vars (git commits may have wrong author)"
+            need_update=true
+        fi
+
         # 【新增】Warn about sudoers vs systemd service user mismatch
         if command -v systemctl &>/dev/null && systemctl is-enabled --quiet open-ace.service 2>/dev/null; then
             local svc_file=$(systemctl show open-ace.service -p FragmentPath 2>/dev/null | cut -d= -f2)


### PR DESCRIPTION
## 问题背景

Issue #1522: install.sh 增量更新逻辑缺少 env_keep 检查，导致 GH_TOKEN 未添加到 sudoers

## 根本原因

增量更新逻辑检查了以下项目：
- webui 规则
- OPENACE_UTILS
- secure_path
- run-as wrapper
- OPENACE_CLI

**但缺少 env_keep 检查！**

当用户从旧版本升级时，如果其他检查都通过，sudoers 不会重写，导致 GH_TOKEN 未被添加。

## 影响

自主开发工作流中 `sudo -u <user> gh issue view` 失败：
```
gh CLI ... failed (exit 4): populate the GH_TOKEN environment variable
```

## 修复方案

在 OPENACE_CLI 检查之后添加 env_keep 检查：

```bash
# 【修复 Issue #1522】Check env_keep contains GH_TOKEN and GIT_* vars.
if ! grep -q "GH_TOKEN" "$sudoers_file" 2>/dev/null; then
    print_warning "Sudoers env_keep missing GH_TOKEN (autonomous dev will fail)"
    need_update=true
fi

if ! grep -q "GIT_AUTHOR_NAME" "$sudoers_file" 2>/dev/null; then
    print_warning "Sudoers env_keep missing GIT_* vars (git commits may have wrong author)"
    need_update=true
fi
```

## 验证方法

1. 代码层面：`grep -n "GH_TOKEN.*sudoers_file" install.sh`
2. 增量升级测试：创建旧版 sudoers → 运行 install.sh → 验证 GH_TOKEN 已添加
3. 自主开发工作流验证：检查 requirements_text 是否正常获取

Fixes #1522