### PR TITLE
fix: check CI status before entering report phase

### DIFF
--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -4995,6 +4995,22 @@ class AutonomousOrchestrator:
             )
 
         if (review_passed and not force_full_rounds) or at_cap:
+            # Check CI status before proceeding to report phase (Issue #1662)
+            # If CI failed, enter CI repair loop instead of reporting
+            if ci_failures:
+                self._create_milestone(
+                    phase="pr_review",
+                    dev_round=dev_round,
+                    round_number=round_num,
+                    milestone_type="ci_failed_before_report",
+                    status="completed",
+                    title=f"CI failed after review passed: {len(ci_failures)} checks",
+                    result_summary=", ".join(c.get("name", "unknown") for c in ci_failures),
+                )
+                # Reuse merge-phase CI repair loop
+                self._start_ci_repair_round(wf, pr_number, ci_failures)
+                return
+
             # All PR review rounds completed — summarize via the main session,
             # then move to report. The main session resumes with the development
             # history (incl. fixes) and is given the last review round's feedback


### PR DESCRIPTION
## Summary

Fixes #1662

### Problem

After PR review passed, workflow enters report phase without checking CI status. CI repair loop only triggers in merge phase, delaying issue discovery. Workflow enters wait state even when CI fails.

### Solution

- Add CI check before entering report phase in `_do_pr_review`
- If CI fails, enter CI repair loop by reusing `_start_ci_repair_round`
- Create milestone `ci_failed_before_report` to track CI failures

### Changes

- `orchestrator.py`: Added CI check in `_do_pr_review` before entering report phase
  - If `ci_failures` is non-empty, call `_start_ci_repair_round` and return
  - Reuse merge-phase CI repair loop for consistency

### Test Plan

| Scenario | Expected Behavior |
|----------|-------------------|
| Normal flow | CI pass → review pass → report → merge |
| CI fail | CI fail → review pass → CI repair loop → merge |
| CI repair fail | CI fail → max retries → workflow fail |

### Related Tests

- `tests/issues/1574/test_ci_repair_verifiers.py`: All passed (5 tests)
- `tests/issues/913/test_pr909_review_feedback.py`: All passed (21 tests)
- `tests/issues/910/test_pr907_review_feedback.py`: All passed (21 tests)
- `tests/issues/822/test_merge_conflict_detection.py`: All passed (23 tests)