### PR TITLE
fix(install): 引入独立的 WORKSPACE_ENABLED 变量 (Issue #1406)

### DIFF
--- a/scripts/install-central/package-method/install.sh
+++ b/scripts/install-central/package-method/install.sh
@@ -1263,7 +1263,7 @@ update_config_workspace() {
     if command -v python3 &>/dev/null; then
         # Use environment variables to pass values safely (avoids special character issues in heredoc)
         export _CONFIG_FILE="$config_file"
-        export _WS_ENABLED="$WORKSPACE_MULTI_USER_MODE"
+        export _WS_ENABLED="$WORKSPACE_ENABLED"
         export _WS_MULTI_USER="$WORKSPACE_MULTI_USER_MODE"
         export _WS_PORT_START="$WORKSPACE_PORT_RANGE_START"
         export _WS_PORT_END="$WORKSPACE_PORT_RANGE_END"
@@ -1380,7 +1380,8 @@ with open('$config_file', 'w') as f:
 SERVICE_PORT=""       # Web server port (will be read from config or use default)
 SERVICE_HOST="0.0.0.0" # Web server host
 
-# Multi-user workspace mode settings
+# Workspace configuration defaults
+WORKSPACE_ENABLED="true"
 WORKSPACE_MULTI_USER_MODE="true"
 WORKSPACE_PORT_RANGE_START="3100"
 WORKSPACE_PORT_RANGE_END="3200"
@@ -2754,6 +2755,14 @@ detect_and_load_local_upgrade() {
         fi
         # Preserve config path for database configuration reuse
         EXISTING_CONFIG_PATH="$config_file"
+
+        # Read WORKSPACE_ENABLED from existing config (upgrade should respect original setting)
+        # Python prints True/False (capitalized), but shell expects true/false (lowercase)
+        local enabled=$(python3 -c "import json; c=json.load(open('$config_file')); print(c.get('workspace', {}).get('enabled', 'true'))" 2>/dev/null | tr '[:upper:]' '[:lower:]')
+        if [ -n "$enabled" ]; then
+            WORKSPACE_ENABLED="$enabled"
+            print_info "Read WORKSPACE_ENABLED=$WORKSPACE_ENABLED from existing config"
+        fi
 
         # Read WORKSPACE_MULTI_USER_MODE from existing config (upgrade should respect original setting)
         # Python prints True/False (capitalized), but shell expects true/false (lowercase)


### PR DESCRIPTION
## 问题描述

Issue #1406: package-method 安装脚本将 `workspace.enabled` 错误地设置为 `workspace.multi_user_mode`，导致用户选择"不启用多用户模式"时，workspace 功能被禁用，显示"工作区未配置"。

## 根因分析

**问题代码**（第1266行）：
```bash
export _WS_ENABLED="$WORKSPACE_MULTI_USER_MODE"
```

**问题本质**：
- `enabled` 应表示"workspace功能是否启用"
- `multi_user_mode` 应表示"是否使用多用户模式"
- 当前代码将两者混淆

**影响链路**：
```
用户选择"不启用多用户模式"
    ↓
WORKSPACE_MULTI_USER_MODE=false
    ↓
workspace.enabled=false（错误）
    ↓
前端显示"工作区未配置"
```

## 修复方案

**方案一增强版**（与 docker-method 保持一致）：

1. **添加 WORKSPACE_ENABLED 变量定义**（第1384行）
2. **修改 update_config_workspace 函数**（第1266行）
3. **添加升级场景 enabled 读取逻辑**（第2758行）

## 修改内容

| 位置 | 修改前 | 修改后 |
|------|--------|--------|
| 第1384行 | 无 | 添加 `WORKSPACE_ENABLED="true"` |
| 第1266行 | `export _WS_ENABLED="$WORKSPACE_MULTI_USER_MODE"` | `export _WS_ENABLED="$WORKSPACE_ENABLED"` |
| 第2758行 | 只读取 multi_user_mode | 添加 enabled 读取逻辑 |

## 测试验证

- ✅ Bash 语法检查通过：`bash -n install.sh`
- ✅ 与 docker-method 保持一致
- ✅ 向后兼容现有配置

## 影响范围

- **新安装**：workspace 功能正常启用（enabled=true）
- **升级安装**：保留现有配置，默认 enabled=true
- **向后兼容**：保留用户手动设置的 enabled 值

Fixes #1406