### PR TITLE
fix(webui): 深色模式下 API 密钥弹窗高级设置面板背景为白色 (#1739)

### DIFF
--- a/frontend/src/components/features/management/APIKeyManagement.tsx
+++ b/frontend/src/components/features/management/APIKeyManagement.tsx
@@ -816,7 +816,7 @@ export const APIKeyManagement: React.FC = () => {
             {t('advancedSettings', language)}
           </button>
           {formData.showAdvanced && (
-            <div className="mt-2 p-3 border rounded bg-light">
+            <div className="api-key-advanced-settings mt-2 p-3 border rounded bg-light">
               <div className="row">
                 <div className="col-6">
                   <label className="form-label">{t('priority', language)}</label>
@@ -1013,7 +1013,7 @@ export const APIKeyManagement: React.FC = () => {
             {t('advancedSettings', language)}
           </button>
           {formData.showAdvanced && (
-            <div className="mt-2 p-3 border rounded bg-light">
+            <div className="api-key-advanced-settings mt-2 p-3 border rounded bg-light">
               <div className="row">
                 <div className="col-6">
                   <label className="form-label">{t('priority', language)}</label>

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -4343,6 +4343,14 @@ table .latency-row:hover td {
   border-color: var(--border-color) !important;
 }
 
+/* API Key dialog — Advanced Settings panel (Issue #1739)
+   Bootstrap .bg-light stays #f8f9fa (white) in dark mode, making the
+   "Priority" / "Weight" labels appear on a white block inside the dark modal. */
+[data-theme='dark'] .api-key-advanced-settings.bg-light {
+  background-color: var(--bg-secondary) !important;
+  border-color: var(--border-color) !important;
+}
+
 /* Dark mode: global btn-secondary override (Issue #1634)
    Previously scoped to .session-detail-content only, leaving portal-rendered
    modals (NewSessionModal, ConfirmModal, etc.) with white-on-white text. */


### PR DESCRIPTION
## 关联 Issue

Closes #1739

## 问题

全局深色模式下，**管理 → 设置 → API 密钥 → 添加 API 密钥 → 高级设置** 中"优先级""权重"所在容器背景为白色，与深色主题不符。

原因：容器使用 Bootstrap 的 `.bg-light`，该类在 `[data-theme='dark']` 下仍为 `#f8f9fa`（白色），不会自动跟随主题切换。项目内已有多处 `.bg-light` 的深色模式覆盖（`.stat-card.bg-light`、`.session-meta.bg-light`、`.conversation-history .card.bg-light`），此处遗漏。

## 修复

- 为添加/编辑 API 密钥弹窗的"高级设置"面板添加语义类 `api-key-advanced-settings`（两处）
- 在 `main.css` 补充深色模式覆盖，复用 `--bg-secondary` / `--border-color` 变量，与既有模式一致：

```css
[data-theme='dark'] .api-key-advanced-settings.bg-light {
  background-color: var(--bg-secondary) !important;
  border-color: var(--border-color) !important;
}
```

## 改动

- `frontend/src/components/features/management/APIKeyManagement.tsx`（+2/-2）：添加/编辑弹窗各加一个类名
- `frontend/src/styles/main.css`（+8）：新增深色模式覆盖规则

## 验证

- 本地 `tsc --noEmit` 通过
- 前端单元测试通过（73 passed）
- 已部署到 node237（systemd package-method，前端由 `static/js/dist/` 提供）人工验证：深色模式下添加/编辑 API 密钥弹窗的高级设置面板背景已变为深色，与弹窗其余部分一致
