### PR TITLE
Fix forced password change enforcement

### DIFF
--- a/app/auth/decorators.py
+++ b/app/auth/decorators.py
@@ -18,7 +18,7 @@ import logging
 from functools import wraps
 from typing import TYPE_CHECKING, cast
 
-from flask import g, jsonify, request
+from flask import Response, g, jsonify, request
 
 logger = logging.getLogger(__name__)
 
@@ -64,6 +64,7 @@ def _load_user_from_token(token: str) -> dict | None:
             "username": result.get("username"),
             "email": result.get("email"),
             "role": result.get("role"),
+            "must_change_password": bool(result.get("must_change_password")),
         }
     except Exception as e:
         logger.error(f"Database error during authentication: {e}")
@@ -94,6 +95,46 @@ def _check_machine_admin(user_id: int, machine_id: str) -> bool:
         return cast("bool", perm == "admin")
     except Exception:
         return False
+
+
+_PASSWORD_CHANGE_ALLOWED_ENDPOINTS = {
+    ("GET", "/api/auth/check"),
+    ("GET", "/api/auth/me"),
+    ("GET", "/api/auth/profile"),
+    ("POST", "/api/auth/change-password"),
+    ("POST", "/api/auth/logout"),
+    ("GET", "/api/password-policy"),
+}
+
+
+def _is_password_change_allowed_request() -> bool:
+    """Return whether the current request is exempt from password-change enforcement."""
+    if request.method == "OPTIONS":
+        return True
+    return (request.method, request.path) in _PASSWORD_CHANGE_ALLOWED_ENDPOINTS
+
+
+def _password_change_required_response() -> tuple[Response, int]:
+    """Return the standard response for blocked requests."""
+    return (
+        jsonify(
+            {
+                "error": "Password change required",
+                "code": "password_change_required",
+                "must_change_password": True,
+            }
+        ),
+        403,
+    )
+
+
+def enforce_password_change_requirement(user: dict | None) -> tuple[Response, int] | None:
+    """Block non-exempt requests when the user must change their password."""
+    if not user or not user.get("must_change_password"):
+        return None
+    if _is_password_change_allowed_request():
+        return None
+    return _password_change_required_response()
 
 
 # ── Public API for cross-module use ──────────────────────────────────
@@ -144,6 +185,10 @@ def auth_required(f=None, *, ownership=None):
             g.user = user
             g.user_id = user.get("id")
             g.user_role = user.get("role")
+
+            password_change_response = enforce_password_change_requirement(user)
+            if password_change_response is not None:
+                return password_change_response
 
             # Ownership checks (admin bypasses)
             if g.user_role == "admin":
@@ -201,6 +246,10 @@ def admin_required(f=None):
                     g.user = user
                     g.user_id = user.get("id")
                     g.user_role = user.get("role")
+
+                    password_change_response = enforce_password_change_requirement(user)
+                    if password_change_response is not None:
+                        return password_change_response
                     return func(*args, **kwargs)
 
             # Fallback: try WebUI token from query param
@@ -225,6 +274,10 @@ def admin_required(f=None):
                             g.user = user
                             g.user_id = user_id
                             g.user_role = user.get("role")
+
+                            password_change_response = enforce_password_change_requirement(user)
+                            if password_change_response is not None:
+                                return password_change_response
                             return func(*args, **kwargs)
 
             # No valid authentication found

--- a/app/repositories/user_repo.py
+++ b/app/repositories/user_repo.py
@@ -481,7 +481,7 @@ class UserRepository:
             Optional[Dict]: Session data with user info or None.
         """
         query = """
-            SELECT s.*, u.username, u.email, u.role, u.tenant_id
+            SELECT s.*, u.username, u.email, u.role, u.tenant_id, u.must_change_password
             FROM sessions s
             JOIN users u ON s.user_id = u.id
             WHERE s.token = ? AND s.expires_at > ?

--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -11,9 +11,9 @@ from typing import Optional, cast
 
 import bcrypt
 import filetype
-from flask import Blueprint, jsonify, make_response, request
+from flask import Blueprint, g, jsonify, make_response, request
 
-from app.auth.decorators import public_endpoint
+from app.auth.decorators import auth_required, public_endpoint
 from app.modules.governance.audit_logger import AuditAction, AuditLogger
 from app.repositories.user_repo import UserRepository
 from app.services.auth_service import AuthService
@@ -196,20 +196,10 @@ def api_logout():
 
 
 @auth_bp.route("/auth/profile", methods=["GET"])
+@auth_required
 def api_profile():
     """Get current user profile."""
-    token = request.cookies.get("session_token") or request.headers.get(
-        "Authorization", ""
-    ).replace("Bearer ", "")
-
-    is_auth, session_or_error = auth_service.require_auth(token)
-    if not is_auth:
-        return jsonify(session_or_error), 401
-
-    if session_or_error is None:
-        return jsonify({"error": "Invalid session"}), 401
-
-    user_id = int(session_or_error.get("user_id", 0))
+    user_id = int(g.user_id)
     profile = auth_service.get_user_profile(user_id)
 
     if profile:
@@ -325,20 +315,10 @@ def api_auth_check():
 
 
 @auth_bp.route("/auth/me", methods=["GET"])
+@auth_required
 def api_current_user():
     """Get current user info (alias for /auth/profile)."""
-    token = request.cookies.get("session_token") or request.headers.get(
-        "Authorization", ""
-    ).replace("Bearer ", "")
-
-    is_auth, session_or_error = auth_service.require_auth(token)
-    if not is_auth:
-        return jsonify(session_or_error), 401
-
-    if session_or_error is None:
-        return jsonify({"error": "Invalid session"}), 401
-
-    user_id = int(session_or_error.get("user_id", 0))
+    user_id = int(g.user_id)
     profile = auth_service.get_user_profile(user_id)
 
     if profile:
@@ -349,19 +329,9 @@ def api_current_user():
 
 
 @auth_bp.route("/auth/change-password", methods=["POST"])
+@auth_required
 def api_change_password():
     """Change password endpoint."""
-    token = request.cookies.get("session_token") or request.headers.get(
-        "Authorization", ""
-    ).replace("Bearer ", "")
-
-    is_auth, session_or_error = auth_service.require_auth(token)
-    if not is_auth:
-        return jsonify(session_or_error), 401
-
-    if session_or_error is None:
-        return jsonify({"error": "Invalid session"}), 401
-
     data = request.get_json() or {}
     current_password = data.get("current_password")
     new_password = data.get("new_password")
@@ -369,8 +339,8 @@ def api_change_password():
     if not current_password or not new_password:
         return jsonify({"error": "Current password and new password required"}), 400
 
-    user_id = int(session_or_error.get("user_id", 0))
-    username = session_or_error.get("username")
+    user_id = int(g.user_id)
+    username = cast("Optional[str]", getattr(g, "user", {}).get("username"))
 
     success, error = auth_service.change_password(
         user_id, current_password, new_password, verify_password, hash_password
@@ -399,20 +369,10 @@ def allowed_file(filename: str) -> bool:
 
 
 @auth_bp.route("/user/avatar", methods=["POST"])
+@auth_required
 def api_upload_avatar():
     """Upload user avatar."""
-    token = request.cookies.get("session_token") or request.headers.get(
-        "Authorization", ""
-    ).replace("Bearer ", "")
-
-    is_auth, session_or_error = auth_service.require_auth(token)
-    if not is_auth:
-        return jsonify(session_or_error), 401
-
-    if session_or_error is None:
-        return jsonify({"error": "Invalid session"}), 401
-
-    user_id = int(session_or_error.get("user_id", 0))
+    user_id = int(g.user_id)
 
     if "file" not in request.files:
         return jsonify({"error": "No file provided"}), 400
@@ -484,20 +444,10 @@ def api_upload_avatar():
 
 
 @auth_bp.route("/user/avatar", methods=["DELETE"])
+@auth_required
 def api_delete_avatar():
     """Delete user avatar."""
-    token = request.cookies.get("session_token") or request.headers.get(
-        "Authorization", ""
-    ).replace("Bearer ", "")
-
-    is_auth, session_or_error = auth_service.require_auth(token)
-    if not is_auth:
-        return jsonify(session_or_error), 401
-
-    if session_or_error is None:
-        return jsonify({"error": "Invalid session"}), 401
-
-    user_id = int(session_or_error.get("user_id", 0))
+    user_id = int(g.user_id)
 
     # Get current avatar URL to delete file
     profile = auth_service.get_user_profile(user_id)

--- a/docs/cn/API.md
+++ b/docs/cn/API.md
@@ -126,6 +126,15 @@ POST /api/auth/change-password
 
 修改当前用户的密码。
 
+当用户被标记为 `must_change_password=true` 时，服务端会拒绝其访问大多数受保护接口，直到密码修改完成。此时仅保留以下最小必要接口可用：
+
+- `GET /api/auth/check`
+- `GET /api/auth/me`
+- `GET /api/auth/profile`
+- `POST /api/auth/change-password`
+- `POST /api/auth/logout`
+- `GET /api/password-policy`
+
 **请求体：**
 ```json
 {

--- a/docs/cn/PERMISSION-MODEL.md
+++ b/docs/cn/PERMISSION-MODEL.md
@@ -112,6 +112,8 @@ def health_check():
 
 大多数 `/api/*` 路由通过 blueprint 级别的 `before_request` 使用 `@auth_required`。敏感操作使用 `@admin_required`。
 
+如果用户被标记为 `must_change_password=true`，服务端会额外收紧访问范围，只允许认证检查、个人资料、密码修改、登出和密码策略等最小必要接口。
+
 ### 公开路由
 
 - `/` — SPA 全局捕获（提供 index.html）

--- a/docs/en/API.md
+++ b/docs/en/API.md
@@ -126,6 +126,15 @@ POST /api/auth/change-password
 
 Change the current user's password.
 
+When a user is marked with `must_change_password=true`, the server blocks access to most protected endpoints until the password is changed. During that state, only the minimum required endpoints remain available:
+
+- `GET /api/auth/check`
+- `GET /api/auth/me`
+- `GET /api/auth/profile`
+- `POST /api/auth/change-password`
+- `POST /api/auth/logout`
+- `GET /api/password-policy`
+
 **Request Body:**
 ```json
 {

--- a/docs/en/PERMISSION-MODEL.md
+++ b/docs/en/PERMISSION-MODEL.md
@@ -112,6 +112,8 @@ All `/manage/*` routes require admin role. Regular users and machine admins cann
 
 Most `/api/*` routes use `@auth_required` via `before_request` at the blueprint level. Sensitive operations use `@admin_required`.
 
+If a user is marked with `must_change_password=true`, the server further narrows access and only allows the minimum required auth, profile, password-change, logout, and password-policy endpoints.
+
 ### Public Routes
 
 - `/` — SPA catch-all (serves index.html)

--- a/frontend/src/components/features/ForceChangePasswordModal.tsx
+++ b/frontend/src/components/features/ForceChangePasswordModal.tsx
@@ -20,11 +20,6 @@ export const ForceChangePasswordModal: React.FC = () => {
   const [newPassword, setNewPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
   const [error, setError] = useState<string | null>(null);
-  const [skipped, setSkipped] = useState(false);
-
-  const handleSkip = () => {
-    setSkipped(true);
-  };
 
   const handleSubmit = async () => {
     setError(null);
@@ -65,26 +60,20 @@ export const ForceChangePasswordModal: React.FC = () => {
     }
   };
 
-  // Don't render if not required or user skipped (will be reminded next login)
-  if (!mustChangePassword || skipped) {
+  if (!mustChangePassword) {
     return null;
   }
 
   return (
     <Modal
       isOpen={true}
-      onClose={handleSkip}
+      onClose={() => {}}
       title={t('changePasswordRequired', language) ?? 'Change Password Required'}
       size="md"
       footer={
-        <>
-          <Button variant="outline-secondary" onClick={handleSkip}>
-            {t('skip', language) ?? 'Skip'}
-          </Button>
-          <Button variant="primary" onClick={handleSubmit} loading={isChangingPassword}>
-            {t('changePassword', language) ?? 'Change Password'}
-          </Button>
-        </>
+        <Button variant="primary" onClick={handleSubmit} loading={isChangingPassword}>
+          {t('changePassword', language) ?? 'Change Password'}
+        </Button>
       }
     >
       <div className="alert alert-warning mb-3">

--- a/tests/routes/test_auth_must_change_enforcement.py
+++ b/tests/routes/test_auth_must_change_enforcement.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""
+Route tests for must-change-password enforcement on auth blueprint endpoints.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+project_root = str(Path(__file__).resolve().parent.parent.parent)
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+
+
+@pytest.fixture
+def app():
+    from flask import Flask
+
+    from app.routes.auth import auth_bp
+
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.register_blueprint(auth_bp, url_prefix="/api")
+    return app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+MUST_CHANGE_SESSION = {
+    "user_id": 1,
+    "username": "admin",
+    "email": "admin@example.com",
+    "role": "admin",
+    "must_change_password": True,
+}
+
+
+class TestAuthPasswordChangeEnforcement:
+    def test_auth_me_stays_accessible_during_forced_password_change(self, client):
+        with patch(
+            "app.auth.decorators._authenticate",
+            return_value=(True, MUST_CHANGE_SESSION),
+        ):
+            with patch(
+                "app.routes.auth.auth_service.get_user_profile",
+                return_value={"id": 1, "username": "admin", "must_change_password": True},
+            ):
+                resp = client.get("/api/auth/me", headers={"Authorization": "Bearer t"})
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["user"]["must_change_password"] is True
+
+    def test_change_password_stays_accessible_during_forced_password_change(self, client):
+        with patch(
+            "app.auth.decorators._authenticate",
+            return_value=(True, MUST_CHANGE_SESSION),
+        ):
+            with patch(
+                "app.routes.auth.auth_service.change_password",
+                return_value=(True, None),
+            ) as change_password:
+                resp = client.post(
+                    "/api/auth/change-password",
+                    headers={"Authorization": "Bearer t"},
+                    json={
+                        "current_password": "admin123",
+                        "new_password": "Betterpass123",
+                    },
+                )
+
+        assert resp.status_code == 200
+        assert resp.get_json()["success"] is True
+        change_password.assert_called_once()
+
+    def test_avatar_upload_is_blocked_until_password_changes(self, client):
+        with patch(
+            "app.auth.decorators._authenticate",
+            return_value=(True, MUST_CHANGE_SESSION),
+        ):
+            resp = client.post("/api/user/avatar", headers={"Authorization": "Bearer t"})
+
+        assert resp.status_code == 403
+        data = resp.get_json()
+        assert data["code"] == "password_change_required"
+
+    def test_public_logout_still_succeeds(self, client):
+        with patch(
+            "app.routes.auth.auth_service.get_session",
+            return_value=MUST_CHANGE_SESSION,
+        ):
+            with patch("app.routes.auth.auth_service.logout", return_value=True) as logout:
+                resp = client.post("/api/auth/logout", headers={"Authorization": "Bearer t"})
+
+        assert resp.status_code == 200
+        assert resp.get_json()["success"] is True
+        logout.assert_called_once_with("t")

--- a/tests/unit/test_auth_decorators.py
+++ b/tests/unit/test_auth_decorators.py
@@ -53,6 +53,16 @@ def _make_app():
     def admin_route():
         return jsonify({"user_id": g.user_id, "role": g.user_role})
 
+    @app.route("/api/auth/change-password", methods=["POST"])
+    @auth_required
+    def change_password_route():
+        return jsonify({"ok": True})
+
+    @app.route("/api/password-policy")
+    @auth_required
+    def password_policy_route():
+        return jsonify({"password_min_length": 8})
+
     return app
 
 
@@ -75,6 +85,7 @@ MOCK_SESSION = {
     "username": "testuser",
     "email": "test@example.com",
     "role": "user",
+    "must_change_password": False,
 }
 
 MOCK_ADMIN_SESSION = {
@@ -82,6 +93,17 @@ MOCK_ADMIN_SESSION = {
     "username": "admin",
     "email": "admin@example.com",
     "role": "admin",
+    "must_change_password": False,
+}
+
+MOCK_MUST_CHANGE_SESSION = {
+    **MOCK_SESSION,
+    "must_change_password": True,
+}
+
+MOCK_MUST_CHANGE_ADMIN_SESSION = {
+    **MOCK_ADMIN_SESSION,
+    "must_change_password": True,
 }
 
 
@@ -174,6 +196,35 @@ class TestAuthRequired:
                 resp = client.get("/api/user", headers={"Authorization": "Bearer bad"})
                 assert resp.status_code == 401
 
+    def test_must_change_password_blocks_protected_route(self):
+        app = _make_app()
+
+        with self._mock_auth(MOCK_MUST_CHANGE_SESSION):
+            with app.test_client() as client:
+                resp = client.get("/api/user", headers={"Authorization": "Bearer t"})
+                assert resp.status_code == 403
+                data = resp.get_json()
+                assert data["code"] == "password_change_required"
+                assert data["must_change_password"] is True
+
+    def test_must_change_password_allows_change_password_route(self):
+        app = _make_app()
+
+        with self._mock_auth(MOCK_MUST_CHANGE_SESSION):
+            with app.test_client() as client:
+                resp = client.post(
+                    "/api/auth/change-password", headers={"Authorization": "Bearer t"}
+                )
+                assert resp.status_code == 200
+
+    def test_must_change_password_allows_password_policy_route(self):
+        app = _make_app()
+
+        with self._mock_auth(MOCK_MUST_CHANGE_SESSION):
+            with app.test_client() as client:
+                resp = client.get("/api/password-policy", headers={"Authorization": "Bearer t"})
+                assert resp.status_code == 200
+
 
 class TestAdminRequired:
     """Test @admin_required decorator."""
@@ -208,6 +259,19 @@ class TestAdminRequired:
         with app.test_client() as client:
             resp = client.get("/api/admin")
             assert resp.status_code == 401
+
+    def test_must_change_password_admin_gets_blocked(self):
+        app = _make_app()
+
+        with patch(
+            "app.auth.decorators._authenticate",
+            return_value=(True, MOCK_MUST_CHANGE_ADMIN_SESSION),
+        ):
+            with app.test_client() as client:
+                resp = client.get("/api/admin", headers={"Authorization": "Bearer t"})
+                assert resp.status_code == 403
+                data = resp.get_json()
+                assert data["code"] == "password_change_required"
 
 
 class TestPublicEndpoint:


### PR DESCRIPTION
## Summary
- enforce `must_change_password` server-side across protected auth/admin routes
- keep only the minimum required auth/profile/password-change endpoints available during forced rotation
- align the frontend modal and API docs with the enforced flow

## Testing
- `pytest tests/routes/test_auth_must_change_enforcement.py tests/unit/test_auth_decorators.py tests/unit/test_auth_service.py`
- `npx eslint src/components/features/ForceChangePasswordModal.tsx`

Closes #1744