### PR TITLE
Harden production secret and encryption key handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ python3 server.py
 |------|--------|------|
 | 管理员 | admin | admin123 |
 
-> ⚠️ 默认账号仅用于本地首次启动。生产环境请务必设置 `SECRET_KEY`、修改默认密码，并参考 [部署指南](docs/cn/DEPLOYMENT.md) 完成安全配置。
+> ⚠️ 默认账号仅用于本地首次启动。生产环境请务必显式设置 `SECRET_KEY`、`OPENACE_ENCRYPTION_KEY`、`UPLOAD_AUTH_KEY`，修改默认密码，并参考 [部署指南](docs/cn/DEPLOYMENT.md) 完成安全配置。
 
 ---
 
@@ -466,7 +466,7 @@ python3 server.py
 |------|----------|----------|
 | Admin | admin | admin123 |
 
-> ⚠️ The default account is only for the first local startup. For production, set `SECRET_KEY`, change the default password, and follow the [Deployment Guide](docs/en/DEPLOYMENT.md).
+> ⚠️ The default account is only for the first local startup. For production, explicitly set `SECRET_KEY`, `OPENACE_ENCRYPTION_KEY`, and `UPLOAD_AUTH_KEY`, change the default password, and follow the [Deployment Guide](docs/en/DEPLOYMENT.md).
 
 ---
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -71,21 +71,16 @@ def create_app(config=None):
     # Load configuration
     app.config["TEMPLATES_AUTO_RELOAD"] = True
 
-    # SECRET_KEY configuration with security checks
-    secret_key = os.environ.get("SECRET_KEY")
-    if not secret_key:
-        flask_env = os.environ.get("FLASK_ENV", "development")
-        if flask_env == "production":
-            raise RuntimeError("SECRET_KEY environment variable must be set in production!")
-        secret_key = "dev-secret-key"
-        logger.warning("Using development SECRET_KEY - DO NOT use in production!")
-    app.config["SECRET_KEY"] = secret_key
-
     if config:
         if isinstance(config, dict):
             app.config.update(config)
         else:
             app.config.from_object(config)
+
+    from app.utils.security_env import get_secret_key_for_app
+
+    # SECRET_KEY configuration with security checks
+    app.config["SECRET_KEY"] = get_secret_key_for_app(app.config.get("SECRET_KEY"))
 
     # Register error handlers
     register_error_handlers(app)

--- a/app/modules/workspace/api_key_proxy.py
+++ b/app/modules/workspace/api_key_proxy.py
@@ -9,7 +9,6 @@ that are exchanged for real keys by the server's LLM proxy endpoint.
 import hashlib
 import json
 import logging
-import os
 import secrets
 import sqlite3
 import threading
@@ -20,6 +19,7 @@ from typing import Any, Optional, Union, cast
 
 from app.modules.workspace.api_key_router import APIKeyRouter
 from app.repositories.database import DB_PATH, get_database_url, is_postgresql
+from app.utils.security_env import get_encryption_key_material
 from app.utils.tool_names import TOOL_NAME_ALIASES, normalize_tool_name
 
 try:
@@ -130,15 +130,7 @@ class APIKeyProxyService:
 
     def _get_encryption_key(self) -> bytes:
         """Get the AES encryption key from environment variable."""
-        key_env = os.environ.get("OPENACE_ENCRYPTION_KEY")
-        if not key_env:
-            secret = os.environ.get("SECRET_KEY")
-            if not secret:
-                raise RuntimeError(
-                    "OPENACE_ENCRYPTION_KEY or SECRET_KEY must be set for API key encryption. "
-                    "Refusing to use default key in production."
-                )
-            key_env = secret
+        key_env = get_encryption_key_material(purpose="API key encryption")
         # Derive a 32-byte key using SHA-256
         return hashlib.sha256(key_env.encode()).digest()
 

--- a/app/routes/upload.py
+++ b/app/routes/upload.py
@@ -7,7 +7,6 @@ API routes for data upload operations.
 import hmac
 import json
 import logging
-import os
 from functools import wraps
 from typing import Any, Optional
 
@@ -16,6 +15,7 @@ from flask import Blueprint, jsonify, request
 from app.services.message_service import MessageService
 from app.services.usage_service import UsageService
 from app.utils.hostname_validator import sanitize_hostname
+from app.utils.security_env import get_upload_auth_key
 
 
 def _sanitize_host_name(host_name: Optional[str]) -> str:
@@ -41,9 +41,6 @@ usage_service = UsageService()
 message_service = MessageService()
 logger = logging.getLogger(__name__)
 
-# Upload authentication key for API access
-UPLOAD_AUTH_KEY = os.environ.get("UPLOAD_AUTH_KEY")
-
 
 def require_upload_auth(f):
     """Decorator to require upload authentication."""
@@ -51,13 +48,14 @@ def require_upload_auth(f):
     @wraps(f)
     def decorated(*args, **kwargs):
         # Check for UPLOAD_AUTH_KEY in environment
-        if not UPLOAD_AUTH_KEY:
+        upload_auth_key = get_upload_auth_key()
+        if not upload_auth_key:
             logger.error("UPLOAD_AUTH_KEY not configured - upload endpoints disabled")
             return jsonify({"error": "Upload service not configured"}), 503
 
         # Check Authorization header
         auth_header = request.headers.get("X-Upload-Auth")
-        if not auth_header or not hmac.compare_digest(auth_header, UPLOAD_AUTH_KEY):
+        if not auth_header or not hmac.compare_digest(auth_header, upload_auth_key):
             logger.warning("Unauthorized upload attempt")
             return jsonify({"error": "Unauthorized"}), 401
 

--- a/app/utils/security_env.py
+++ b/app/utils/security_env.py
@@ -1,0 +1,90 @@
+"""
+Helpers for validating security-sensitive environment variables.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+_WEAK_SECRET_VALUES = frozenset(
+    {
+        "",
+        "change-me-in-production",
+        "dev-secret-key",
+        "dev-smtp-password-key",
+        "default-secret-key",
+    }
+)
+
+_DEV_SECRET_KEY = "dev-secret-key"  # nosec B105 - explicit development-only fallback
+_DEV_ENCRYPTION_KEY = (  # nosec B105 - explicit development-only fallback
+    "openace-dev-encryption-key"
+)
+
+
+def is_production_environment() -> bool:
+    """Return whether the current process is running in production mode."""
+    return os.environ.get("FLASK_ENV", "development").strip().lower() == "production"
+
+
+def is_weak_secret_value(value: str | None) -> bool:
+    """Return whether the given secret value is missing or a known placeholder."""
+    if value is None:
+        return True
+    return value.strip().lower() in _WEAK_SECRET_VALUES
+
+
+def get_secret_key_for_app(secret_key: str | None = None) -> str:
+    """Return a validated Flask SECRET_KEY."""
+    if secret_key is None:
+        secret_key = os.environ.get("SECRET_KEY")
+    if not secret_key:
+        if is_production_environment():
+            raise RuntimeError("SECRET_KEY environment variable must be set in production!")
+        logger.warning("Using development SECRET_KEY - DO NOT use in production!")
+        return _DEV_SECRET_KEY
+
+    if is_production_environment() and is_weak_secret_value(secret_key):
+        raise RuntimeError("SECRET_KEY must be set to a strong, unique value in production!")
+
+    if is_weak_secret_value(secret_key):
+        logger.warning("Using weak development SECRET_KEY - DO NOT use in production!")
+
+    return secret_key
+
+
+def get_encryption_key_material(*, purpose: str) -> str:
+    """Return validated key material for encrypted secret storage."""
+    key_env = os.environ.get("OPENACE_ENCRYPTION_KEY")
+    if key_env and not is_weak_secret_value(key_env):
+        return key_env
+
+    if is_production_environment():
+        raise RuntimeError(
+            f"OPENACE_ENCRYPTION_KEY must be set to a strong, unique value in production for {purpose}."
+        )
+
+    logger.warning(
+        "OPENACE_ENCRYPTION_KEY not set; using development-only encryption key for %s. "
+        "Encrypted data will not be portable across environments.",
+        purpose,
+    )
+    return _DEV_ENCRYPTION_KEY
+
+
+def get_upload_auth_key() -> str | None:
+    """Return a validated upload auth key, or None when upload endpoints should stay disabled."""
+    upload_auth_key = os.environ.get("UPLOAD_AUTH_KEY")
+    if not upload_auth_key:
+        return None
+
+    if is_weak_secret_value(upload_auth_key):
+        logger.error(
+            "UPLOAD_AUTH_KEY uses an insecure placeholder value; upload endpoints disabled"
+        )
+        return None
+
+    return upload_auth_key

--- a/app/utils/smtp_crypto.py
+++ b/app/utils/smtp_crypto.py
@@ -8,8 +8,9 @@ Uses Fernet (AES-128-CBC) for symmetric encryption, consistent with API key encr
 import base64
 import hashlib
 import logging
-import os
 from typing import Optional, cast
+
+from app.utils.security_env import get_encryption_key_material
 
 logger = logging.getLogger(__name__)
 
@@ -26,18 +27,7 @@ class SMTPPasswordManager:
 
     def _get_encryption_key(self) -> bytes:
         """Get the AES encryption key from environment variable."""
-        key_env = os.environ.get("OPENACE_ENCRYPTION_KEY")
-        if not key_env:
-            secret = os.environ.get("SECRET_KEY")
-            if not secret:
-                # Use a default key for development (should not be used in production)
-                logger.warning(
-                    "OPENACE_ENCRYPTION_KEY or SECRET_KEY not set. "
-                    "Using development key - DO NOT use in production!"
-                )
-                key_env = "dev-smtp-password-key"
-            else:
-                key_env = secret
+        key_env = get_encryption_key_material(purpose="SMTP password encryption")
         # Derive a 32-byte key using SHA-256
         return hashlib.sha256(key_env.encode()).digest()
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,8 +42,9 @@ services:
     environment:
       - FLASK_ENV=production
       - PYTHONUNBUFFERED=1
-      - SECRET_KEY=${SECRET_KEY:-change-me-in-production}
-      - UPLOAD_AUTH_KEY=${UPLOAD_AUTH_KEY:-change-me-in-production}
+      - SECRET_KEY=${SECRET_KEY:?SECRET_KEY must be set}
+      - OPENACE_ENCRYPTION_KEY=${OPENACE_ENCRYPTION_KEY:?OPENACE_ENCRYPTION_KEY must be set}
+      - UPLOAD_AUTH_KEY=${UPLOAD_AUTH_KEY:?UPLOAD_AUTH_KEY must be set}
       # Database
       - DATABASE_URL=postgresql://${DB_USER:-ace}:${DB_PASSWORD:-ace-secret}@postgres:5432/${DB_NAME:-ace}
       # Multi-user Workspace

--- a/docs/cn/DEPLOYMENT.md
+++ b/docs/cn/DEPLOYMENT.md
@@ -97,6 +97,12 @@ sudo ./deploy.sh
 
 **重要**：首次登录后请立即修改默认密码！
 
+在启动生产环境前，请先在 `.env` 或密钥管理系统中提供以下密钥：
+
+- `SECRET_KEY` — Flask 会话密钥，必须是强随机唯一值
+- `OPENACE_ENCRYPTION_KEY` — 专用于 API Key / SMTP 密码存储加密的独立密钥
+- `UPLOAD_AUTH_KEY` — 上传接口使用的共享认证密钥
+
 ### 目录结构
 
 ```
@@ -556,7 +562,9 @@ chmod -R 755 ~/.open-ace/
 1. **认证**：在生产环境中启用用户认证
 2. **HTTPS**：使用反向代理（nginx/Apache）配合 SSL
 3. **防火墙**：限制对 19888 端口的访问
-4. **密钥管理**：使用环境变量存储敏感数据
+4. **密钥管理**：使用环境变量或密钥管理系统存储敏感数据
+5. **独立加密密钥**：显式设置 `OPENACE_ENCRYPTION_KEY`；加密后的敏感数据不再从 `SECRET_KEY` 派生
+6. **禁止占位密钥**：不要在生产环境使用 `change-me-in-production` 之类的占位值作为 `SECRET_KEY` 或 `UPLOAD_AUTH_KEY`
 
 ## 多用户工作区部署
 

--- a/docs/cn/KUBERNETES.md
+++ b/docs/cn/KUBERNETES.md
@@ -110,7 +110,7 @@ k8s/
 
 **重要：** 部署到生产环境前，请更改所有占位值。建议使用 sealed-secrets 或外部密钥管理工具。
 
-键：`SECRET_KEY`、`UPLOAD_AUTH_KEY`、`DB_USER`、`DB_PASSWORD`、`REDIS_PASSWORD`
+键：`SECRET_KEY`、`OPENACE_ENCRYPTION_KEY`、`UPLOAD_AUTH_KEY`、`DB_USER`、`DB_PASSWORD`、`REDIS_PASSWORD`
 
 ### PersistentVolumeClaim
 

--- a/docs/cn/REMOTE-WORKSPACE.md
+++ b/docs/cn/REMOTE-WORKSPACE.md
@@ -240,8 +240,8 @@ curl -b cookies.txt -X POST \
 
 | 变量 | 必需 | 说明 | 默认值 |
 |------|------|------|--------|
-| `OPENACE_ENCRYPTION_KEY` | 推荐 | API Key 加密密钥。未设置时从 `SECRET_KEY` 派生 | `SECRET_KEY` 的 SHA-256 |
-| `SECRET_KEY` | 是 | Flask 会话密钥，也影响 API Key 加密 | `dev-secret-key` |
+| `OPENACE_ENCRYPTION_KEY` | 生产环境必需 | API Key 与 SMTP 密码的独立加密密钥 | 仅开发环境提供 fallback |
+| `SECRET_KEY` | 是 | Flask 会话密钥 | `dev-secret-key`（仅开发环境） |
 
 ### API Key 管理
 
@@ -922,8 +922,8 @@ ADAPTERS = {
 
 | 变量 | 说明 | 默认值 |
 |------|------|--------|
-| `OPENACE_ENCRYPTION_KEY` | API Key 加密密钥（推荐设置） | 从 `SECRET_KEY` 派生 |
-| `SECRET_KEY` | Flask 会话密钥 | `dev-secret-key` |
+| `OPENACE_ENCRYPTION_KEY` | API Key / SMTP 密码的独立加密密钥（生产环境必需） | 仅开发环境提供 fallback |
+| `SECRET_KEY` | Flask 会话密钥 | `dev-secret-key`（仅开发环境） |
 
 ### 远程 Agent
 

--- a/docs/en/DEPLOYMENT.md
+++ b/docs/en/DEPLOYMENT.md
@@ -97,6 +97,12 @@ Password: admin123
 
 **Important**: Change the default password immediately after first login!
 
+Before starting the production stack, define these secrets in `.env` or your secret manager:
+
+- `SECRET_KEY` — Flask session secret, must be strong and unique
+- `OPENACE_ENCRYPTION_KEY` — dedicated encryption key for stored API keys / SMTP passwords
+- `UPLOAD_AUTH_KEY` — shared secret for upload endpoints
+
 ### Directory Structure
 
 ```
@@ -554,7 +560,9 @@ chmod -R 755 ~/.open-ace/
 1. **Authentication**: Enable user authentication in production
 2. **HTTPS**: Use reverse proxy (nginx/Apache) with SSL
 3. **Firewall**: Restrict access to port 19888
-4. **Secrets**: Use environment variables for sensitive data
+4. **Secrets**: Use environment variables or a secret manager for sensitive data
+5. **Dedicated encryption key**: Set `OPENACE_ENCRYPTION_KEY` explicitly; encrypted secret storage no longer derives from `SECRET_KEY`
+6. **No placeholder secrets**: Do not use values such as `change-me-in-production` for `SECRET_KEY` or `UPLOAD_AUTH_KEY`
 
 ## Multi-User Workspace Deployment
 

--- a/docs/en/KUBERNETES.md
+++ b/docs/en/KUBERNETES.md
@@ -110,7 +110,7 @@ Application configuration keys: `FLASK_APP`, `FLASK_ENV`, `PYTHONUNBUFFERED`, `L
 
 **IMPORTANT:** Change all placeholder values before deploying to production. Use sealed-secrets or an external secret management tool.
 
-Keys: `SECRET_KEY`, `UPLOAD_AUTH_KEY`, `DB_USER`, `DB_PASSWORD`, `REDIS_PASSWORD`
+Keys: `SECRET_KEY`, `OPENACE_ENCRYPTION_KEY`, `UPLOAD_AUTH_KEY`, `DB_USER`, `DB_PASSWORD`, `REDIS_PASSWORD`
 
 ### PersistentVolumeClaim
 

--- a/docs/en/REMOTE-WORKSPACE.md
+++ b/docs/en/REMOTE-WORKSPACE.md
@@ -240,8 +240,8 @@ It also adds two columns to the `agent_sessions` table:
 
 | Variable | Required | Description | Default |
 |----------|----------|-------------|---------|
-| `OPENACE_ENCRYPTION_KEY` | Recommended | Encryption key for API keys. When unset, derived from `SECRET_KEY` | SHA-256 of `SECRET_KEY` |
-| `SECRET_KEY` | Yes | Flask session key; also affects API key encryption | `dev-secret-key` |
+| `OPENACE_ENCRYPTION_KEY` | Yes (production) | Dedicated encryption key for API keys and SMTP passwords | Development-only fallback outside production |
+| `SECRET_KEY` | Yes | Flask session key | `dev-secret-key` (development only) |
 
 ### API Key Management
 
@@ -922,8 +922,8 @@ For unregistered CLI tools, the system falls back to a generic adapter (`Generic
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `OPENACE_ENCRYPTION_KEY` | Encryption key for API keys (recommended to set) | Derived from `SECRET_KEY` |
-| `SECRET_KEY` | Flask session key | `dev-secret-key` |
+| `OPENACE_ENCRYPTION_KEY` | Dedicated encryption key for API keys / SMTP passwords (required in production) | Development-only fallback outside production |
+| `SECRET_KEY` | Flask session key | `dev-secret-key` (development only) |
 
 ### Remote Agent
 

--- a/tests/routes/test_upload_auth_config.py
+++ b/tests/routes/test_upload_auth_config.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""
+Route tests for upload auth key configuration hardening.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+project_root = str(Path(__file__).resolve().parent.parent.parent)
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+
+
+@pytest.fixture
+def app():
+    from flask import Flask
+
+    from app.routes.upload import upload_bp
+
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.register_blueprint(upload_bp, url_prefix="/api")
+    return app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+class TestUploadAuthConfig:
+    def test_placeholder_upload_auth_key_disables_endpoint(self, client, monkeypatch):
+        monkeypatch.setenv("UPLOAD_AUTH_KEY", "change-me-in-production")
+
+        resp = client.post(
+            "/api/upload/usage",
+            headers={"X-Upload-Auth": "change-me-in-production"},
+            json={"date": "2026-07-17", "tool_name": "codex", "tokens_used": 1},
+        )
+
+        assert resp.status_code == 503
+        assert resp.get_json()["error"] == "Upload service not configured"
+
+    def test_strong_upload_auth_key_still_allows_upload(self, client, monkeypatch):
+        monkeypatch.setenv("UPLOAD_AUTH_KEY", "upload-auth-key-123")
+
+        with patch("app.routes.upload.usage_service.save_usage", return_value=True) as save_usage:
+            resp = client.post(
+                "/api/upload/usage",
+                headers={"X-Upload-Auth": "upload-auth-key-123"},
+                json={"date": "2026-07-17", "tool_name": "codex", "tokens_used": 1},
+            )
+
+        assert resp.status_code == 200
+        assert resp.get_json()["success"] is True
+        save_usage.assert_called_once()

--- a/tests/unit/test_security_env.py
+++ b/tests/unit/test_security_env.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import pytest
+
+from app.utils.security_env import (
+    get_encryption_key_material,
+    get_secret_key_for_app,
+    get_upload_auth_key,
+)
+
+
+class TestSecretKeyValidation:
+    def test_missing_secret_key_uses_dev_fallback_outside_production(self, monkeypatch):
+        monkeypatch.delenv("SECRET_KEY", raising=False)
+        monkeypatch.setenv("FLASK_ENV", "development")
+
+        assert get_secret_key_for_app() == "dev-secret-key"
+
+    def test_missing_secret_key_raises_in_production(self, monkeypatch):
+        monkeypatch.delenv("SECRET_KEY", raising=False)
+        monkeypatch.setenv("FLASK_ENV", "production")
+
+        with pytest.raises(RuntimeError, match="SECRET_KEY environment variable must be set"):
+            get_secret_key_for_app()
+
+    def test_weak_secret_key_raises_in_production(self, monkeypatch):
+        monkeypatch.setenv("SECRET_KEY", "change-me-in-production")
+        monkeypatch.setenv("FLASK_ENV", "production")
+
+        with pytest.raises(RuntimeError, match="SECRET_KEY must be set to a strong, unique value"):
+            get_secret_key_for_app()
+
+    def test_explicit_config_secret_key_is_respected(self, monkeypatch):
+        monkeypatch.delenv("SECRET_KEY", raising=False)
+        monkeypatch.setenv("FLASK_ENV", "development")
+
+        assert get_secret_key_for_app("config-secret-key") == "config-secret-key"
+
+
+class TestEncryptionKeyValidation:
+    def test_encryption_key_uses_explicit_env(self, monkeypatch):
+        monkeypatch.setenv("OPENACE_ENCRYPTION_KEY", "my-strong-encryption-key")
+        monkeypatch.delenv("SECRET_KEY", raising=False)
+        monkeypatch.setenv("FLASK_ENV", "development")
+
+        assert (
+            get_encryption_key_material(purpose="API key encryption") == "my-strong-encryption-key"
+        )
+
+    def test_encryption_key_no_longer_falls_back_to_secret_key(self, monkeypatch):
+        monkeypatch.delenv("OPENACE_ENCRYPTION_KEY", raising=False)
+        monkeypatch.setenv("SECRET_KEY", "some-other-secret-key")
+        monkeypatch.setenv("FLASK_ENV", "development")
+
+        assert (
+            get_encryption_key_material(purpose="API key encryption")
+            == "openace-dev-encryption-key"
+        )
+
+    def test_missing_encryption_key_raises_in_production(self, monkeypatch):
+        monkeypatch.delenv("OPENACE_ENCRYPTION_KEY", raising=False)
+        monkeypatch.setenv("SECRET_KEY", "strong-secret-key")
+        monkeypatch.setenv("FLASK_ENV", "production")
+
+        with pytest.raises(RuntimeError, match="OPENACE_ENCRYPTION_KEY must be set"):
+            get_encryption_key_material(purpose="SMTP password encryption")
+
+
+class TestUploadAuthValidation:
+    def test_missing_upload_auth_key_disables_uploads(self, monkeypatch):
+        monkeypatch.delenv("UPLOAD_AUTH_KEY", raising=False)
+        assert get_upload_auth_key() is None
+
+    def test_weak_upload_auth_key_is_rejected(self, monkeypatch):
+        monkeypatch.setenv("UPLOAD_AUTH_KEY", "change-me-in-production")
+        assert get_upload_auth_key() is None
+
+    def test_strong_upload_auth_key_is_returned(self, monkeypatch):
+        monkeypatch.setenv("UPLOAD_AUTH_KEY", "upload-auth-key-123")
+        assert get_upload_auth_key() == "upload-auth-key-123"

--- a/tests/unit/test_security_model.py
+++ b/tests/unit/test_security_model.py
@@ -3,8 +3,8 @@ Unit tests that verify the security model documented in docs/en/SECURITY.md.
 
 These tests assert the concrete, auditable guarantees the documentation makes:
   - API keys / SMTP passwords are Fernet-encrypted (AES-128-CBC + HMAC-SHA256).
-  - The encryption key is derived via SHA-256 from OPENACE_ENCRYPTION_KEY or
-    SECRET_KEY and is never the raw value.
+  - The encryption key is derived via SHA-256 from OPENACE_ENCRYPTION_KEY and is
+    never the raw value; development fallback stays separate from SECRET_KEY.
   - Only a SHA-256 hash of a registration token is stored; tokens are one-time
     use with a 1-hour TTL.
   - Proxy tokens are HMAC-SHA256 signed and expire; tampering invalidates them.
@@ -157,14 +157,15 @@ class TestApiEncryption:
 
         Fernet(fernet_key)  # does not raise
 
-    def test_secret_key_fallback(self, monkeypatch):
-        """When OPENACE_ENCRYPTION_KEY is unset, SECRET_KEY is used."""
+    def test_dev_fallback_is_independent_from_secret_key(self, monkeypatch):
+        """Development fallback must not derive encryption from SECRET_KEY."""
         from app.modules.workspace import api_key_proxy as akp
 
         monkeypatch.delenv("OPENACE_ENCRYPTION_KEY", raising=False)
         monkeypatch.setenv("SECRET_KEY", "flask-secret")
+        monkeypatch.setenv("FLASK_ENV", "development")
         svc = akp.APIKeyProxyService.__new__(akp.APIKeyProxyService)
-        assert svc._get_encryption_key() == hashlib.sha256(b"flask-secret").digest()
+        assert svc._get_encryption_key() == hashlib.sha256(b"openace-dev-encryption-key").digest()
 
     def test_tampered_ciphertext_is_rejected(self, proxy_service):
         """Fernet's HMAC must catch tampering (integrity guarantee)."""


### PR DESCRIPTION
## Summary
- validate production `SECRET_KEY`, `OPENACE_ENCRYPTION_KEY`, and upload auth secrets consistently
- decouple API key and SMTP encryption from `SECRET_KEY` with an explicit encryption-key path
- update deployment and remote-workspace docs to match the hardened runtime behavior

## Testing
- `pytest tests/unit/test_security_env.py tests/unit/test_security_model.py tests/integration/test_security_model_integration.py tests/routes/test_upload_auth_config.py`
- `python3 -m compileall app/utils/security_env.py app/__init__.py app/modules/workspace/api_key_proxy.py app/utils/smtp_crypto.py app/routes/upload.py`
- `SKIP=bandit,no-commit-to-branch pre-commit run --files app/utils/security_env.py app/__init__.py app/modules/workspace/api_key_proxy.py app/routes/upload.py app/utils/smtp_crypto.py docker-compose.yml README.md docs/en/DEPLOYMENT.md docs/cn/DEPLOYMENT.md docs/en/REMOTE-WORKSPACE.md docs/cn/REMOTE-WORKSPACE.md docs/en/KUBERNETES.md docs/cn/KUBERNETES.md tests/unit/test_security_env.py tests/unit/test_security_model.py tests/routes/test_upload_auth_config.py`

Closes #1747