### PR TITLE
fix: encrypt SSO client secrets and complete PKCE flow

### DIFF
--- a/app/modules/sso/manager.py
+++ b/app/modules/sso/manager.py
@@ -9,7 +9,7 @@ import logging
 import secrets
 import threading
 from datetime import datetime, timedelta, timezone
-from typing import Any, Optional, cast
+from typing import Any, Optional, Union, cast
 
 from app.modules.sso.oauth2 import OAuth2Provider
 from app.modules.sso.oidc import OIDCProvider, get_provider_class
@@ -20,6 +20,7 @@ from app.modules.sso.provider import (
     get_provider_config,
 )
 from app.repositories.database import Database, adapt_boolean_condition, adapt_boolean_value
+from app.utils.smtp_crypto import get_password_manager
 
 logger = logging.getLogger(__name__)
 
@@ -48,6 +49,37 @@ class SSOManager:
         self.db = db or Database()
         self._providers: dict[str, SSOProvider] = {}
         self._providers_lock = threading.Lock()
+        self._password_manager = get_password_manager()
+
+    def serialize_provider_config(self, config_data: dict[str, Any]) -> str:
+        """Serialize provider config for storage, encrypting the client secret."""
+        stored = dict(config_data)
+        client_secret = cast("str", stored.pop("client_secret", "") or "")
+        stored.pop("client_secret_encrypted", None)
+        stored["client_secret_encrypted"] = (
+            self._password_manager.encrypt(client_secret) if client_secret else ""
+        )
+        return json.dumps(stored)
+
+    def deserialize_provider_config(self, raw_config: Union[str, dict[str, Any]]) -> dict[str, Any]:
+        """Deserialize provider config and restore the decrypted client secret."""
+        config_data = (
+            cast("dict[str, Any]", json.loads(raw_config))
+            if isinstance(raw_config, str)
+            else dict(raw_config)
+        )
+        encrypted_secret = config_data.pop("client_secret_encrypted", "")
+
+        client_secret = cast("str", config_data.get("client_secret", "") or "")
+        if encrypted_secret:
+            try:
+                client_secret = self._password_manager.decrypt(encrypted_secret)
+            except Exception as e:
+                logger.error(f"Failed to decrypt SSO client_secret: {e}")
+                client_secret = ""
+
+        config_data["client_secret"] = client_secret
+        return config_data
 
     def _ensure_tables(self) -> None:
         """Ensure SSO-related tables exist."""
@@ -177,6 +209,7 @@ class SSOManager:
         )
 
         try:
+            serialized_config = self.serialize_provider_config(config.__dict__)
             now = datetime.now(timezone.utc).replace(tzinfo=None)
             self.db.execute(
                 """
@@ -192,10 +225,10 @@ class SSOManager:
                 (
                     name,
                     provider_type,
-                    json.dumps(config.__dict__),
+                    serialized_config,
                     tenant_id,
                     provider_type,
-                    json.dumps(config.__dict__),
+                    serialized_config,
                     tenant_id,
                     now,
                 ),
@@ -281,7 +314,7 @@ class SSOManager:
             return None
 
         try:
-            config_data = json.loads(row["config"])
+            config_data = self.deserialize_provider_config(row["config"])
             config = SSOProviderConfig(
                 name=config_data.get("name", name),
                 provider_type=config_data.get("provider_type", "oauth2"),
@@ -440,11 +473,16 @@ class SSOManager:
                 error="invalid_state",
             )
 
-        # Get PKCE code verifier
-        auth_state.get("code_verifier")
+        if auth_state.get("provider_name") != provider_name:
+            return SSOAuthResult(
+                success=False,
+                error="invalid_state",
+            )
+
+        code_verifier = cast("Optional[str]", auth_state.get("code_verifier"))
 
         # Exchange code for tokens
-        result = provider.authenticate(code, redirect_uri)
+        result = provider.authenticate(code, redirect_uri, code_verifier)
 
         # Clean up state
         self._delete_auth_state(state)

--- a/app/modules/sso/provider.py
+++ b/app/modules/sso/provider.py
@@ -183,13 +183,16 @@ class SSOProvider(ABC):
         pass
 
     @abstractmethod
-    def exchange_code(self, code: str, redirect_uri: Optional[str] = None) -> SSOAuthResult:
+    def exchange_code(
+        self, code: str, redirect_uri: Optional[str] = None, code_verifier: Optional[str] = None
+    ) -> SSOAuthResult:
         """
         Exchange authorization code for tokens.
 
         Args:
             code: Authorization code from callback.
             redirect_uri: Redirect URI used in authorization.
+            code_verifier: PKCE code verifier used during authorization.
 
         Returns:
             SSOAuthResult: Authentication result with tokens.
@@ -222,19 +225,22 @@ class SSOProvider(ABC):
         """
         pass
 
-    def authenticate(self, code: str, redirect_uri: Optional[str] = None) -> SSOAuthResult:
+    def authenticate(
+        self, code: str, redirect_uri: Optional[str] = None, code_verifier: Optional[str] = None
+    ) -> SSOAuthResult:
         """
         Complete authentication flow.
 
         Args:
             code: Authorization code.
             redirect_uri: Redirect URI.
+            code_verifier: PKCE code verifier used during authorization.
 
         Returns:
             SSOAuthResult: Authentication result.
         """
         # Exchange code for tokens
-        result = self.exchange_code(code, redirect_uri)
+        result = self.exchange_code(code, redirect_uri, code_verifier)
 
         if not result.success:
             return result

--- a/app/routes/sso.py
+++ b/app/routes/sso.py
@@ -322,7 +322,7 @@ def get_provider_detail(provider_name: str):
         return jsonify({"error": "Provider not found"}), 404
 
     try:
-        config_data = json.loads(row["config"])
+        config_data = get_sso_manager().deserialize_provider_config(row["config"])
 
         # Check if it's a predefined provider
         predefined_config = get_provider_config(provider_name)
@@ -467,7 +467,7 @@ def update_provider(provider_name: str):
         return jsonify({"error": "Provider not found"}), 404
 
     try:
-        existing_config = json.loads(existing["config"])
+        existing_config = get_sso_manager().deserialize_provider_config(existing["config"])
     except Exception:
         return jsonify({"error": "Failed to parse existing configuration"}), 500
 
@@ -521,13 +521,14 @@ def update_provider(provider_name: str):
     # Check if provider was disabled - auto-enable on update
     was_disabled = not existing.get("is_active", True)
 
+    serialized_config = get_sso_manager().serialize_provider_config(new_config)
     get_sso_manager().db.execute(
         """
         UPDATE sso_providers
         SET config = ?, updated_at = ?, is_active = ?
         WHERE name = ?
     """,
-        (json.dumps(new_config), now, adapt_boolean_value(True), provider_name),
+        (serialized_config, now, adapt_boolean_value(True), provider_name),
     )
 
     # Clear cache
@@ -678,7 +679,7 @@ def reset_provider_to_defaults(provider_name: str):
         return jsonify({"error": "Provider not found"}), 404
 
     try:
-        existing_config = json.loads(existing["config"])
+        existing_config = get_sso_manager().deserialize_provider_config(existing["config"])
     except Exception:
         return jsonify({"error": "Failed to parse existing configuration"}), 500
 
@@ -700,13 +701,14 @@ def reset_provider_to_defaults(provider_name: str):
 
     # Update provider
     now = datetime.now(timezone.utc).replace(tzinfo=None)
+    serialized_config = get_sso_manager().serialize_provider_config(new_config)
     get_sso_manager().db.execute(
         """
         UPDATE sso_providers
         SET config = ?, updated_at = ?
         WHERE name = ?
     """,
-        (json.dumps(new_config), now, provider_name),
+        (serialized_config, now, provider_name),
     )
 
     # Clear cache
@@ -955,7 +957,7 @@ def export_providers():
 
     for row in rows:
         try:
-            config = json.loads(row["config"])
+            config = get_sso_manager().deserialize_provider_config(row["config"])
             provider_names.append(row["name"])
 
             # Check if predefined

--- a/docs/cn/API.md
+++ b/docs/cn/API.md
@@ -1450,6 +1450,7 @@ POST /api/sso/providers
 ```
 
 注册新的 SSO 提供商（仅管理员）。
+Provider 的密钥在持久化前会先加密。
 
 ---
 
@@ -1470,6 +1471,7 @@ GET /api/sso/login/<provider_name>
 ```
 
 发起 SSO 登录流程。
+对于 OAuth2/OIDC Provider，登录流程会启用 PKCE，并将 verifier 绑定到回调 state。
 
 ---
 

--- a/docs/cn/DATABASE-SCHEMA.md
+++ b/docs/cn/DATABASE-SCHEMA.md
@@ -306,7 +306,7 @@ AI 代理会话追踪。
 | id | integer PK | |
 | name | text | UNIQUE |
 | provider_type | text | NOT NULL (oauth2/oidc) |
-| config | text | NOT NULL (JSON) |
+| config | text | NOT NULL（JSON；保存的是加密后的 `client_secret_encrypted`，不是明文 `client_secret`） |
 | tenant_id | integer | FK → tenants(id) |
 | is_active | boolean | DEFAULT true |
 

--- a/docs/en/API.md
+++ b/docs/en/API.md
@@ -1450,6 +1450,7 @@ POST /api/sso/providers
 ```
 
 Register a new SSO provider (admin only).
+Provider secrets are encrypted before they are persisted.
 
 ---
 
@@ -1470,6 +1471,7 @@ GET /api/sso/login/<provider_name>
 ```
 
 Start SSO login flow.
+OAuth2/OIDC providers use PKCE and bind the verifier to the callback state.
 
 ---
 

--- a/docs/en/DATABASE-SCHEMA.md
+++ b/docs/en/DATABASE-SCHEMA.md
@@ -306,7 +306,7 @@ Unique: `(tenant_id, date)`
 | id | integer PK | |
 | name | text | UNIQUE |
 | provider_type | text | NOT NULL (oauth2/oidc) |
-| config | text | NOT NULL (JSON) |
+| config | text | NOT NULL (JSON; stores encrypted `client_secret_encrypted` instead of plaintext `client_secret`) |
 | tenant_id | integer | FK → tenants(id) |
 | is_active | boolean | DEFAULT true |
 

--- a/tests/routes/test_sso_provider_storage.py
+++ b/tests/routes/test_sso_provider_storage.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""
+Route tests for SSO provider secret migration and encrypted storage.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+project_root = str(Path(__file__).resolve().parent.parent.parent)
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+
+import app.utils.smtp_crypto as smtp_crypto
+from app.modules.sso.manager import SSOManager
+from app.repositories.database import Database, adapt_boolean_value
+from app.repositories.schema_init import load_schema_from_file
+from app.routes.sso import sso_bp
+
+ADMIN_SESSION = {
+    "user_id": 1,
+    "username": "admin",
+    "email": "admin@example.com",
+    "role": "admin",
+}
+
+
+@pytest.fixture
+def sso_manager(tmp_path, monkeypatch):
+    """Isolated SSO manager for route tests."""
+    monkeypatch.setenv("OPENACE_ENCRYPTION_KEY", "test-route-sso-encryption-key")
+    smtp_crypto._password_manager_instance = None
+
+    db = Database(db_url=f"sqlite:///{tmp_path / 'route-sso.db'}")
+    manager = SSOManager(db=db)
+    load_schema_from_file(db_url=manager.db.db_url, dialect="sqlite")
+
+    try:
+        yield manager
+    finally:
+        smtp_crypto._password_manager_instance = None
+
+
+@pytest.fixture
+def client(sso_manager):
+    """Flask client with auth and shared SSO manager patched in."""
+    from flask import Flask
+
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.register_blueprint(sso_bp)
+
+    audit_logger = MagicMock()
+    admin_user = {"id": 1, "username": "admin", "role": "admin", "tenant_id": None}
+
+    with (
+        patch("app.routes.sso.get_sso_manager", return_value=sso_manager),
+        patch("app.routes.sso.get_audit_logger", return_value=audit_logger),
+        patch("app.routes.sso.user_repo.get_user_by_id", return_value=admin_user),
+        patch("app.auth.decorators._authenticate", return_value=(True, ADMIN_SESSION)),
+    ):
+        yield app.test_client()
+
+
+def test_update_provider_rewrites_legacy_plaintext_secret_as_encrypted(client, sso_manager):
+    """Updating a legacy provider should preserve the secret without storing plaintext."""
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    sso_manager.db.execute(
+        """
+        INSERT INTO sso_providers (name, provider_type, config, tenant_id, is_active, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        (
+            "google",
+            "oauth2",
+            json.dumps(
+                {
+                    "name": "google",
+                    "provider_type": "oauth2",
+                    "client_id": "legacy-client",
+                    "client_secret": "legacy-secret",
+                    "authorization_url": "https://example.com/oauth/authorize",
+                    "token_url": "https://example.com/oauth/token",
+                    "redirect_uri": "https://app.example.com/callback",
+                    "scope": ["openid", "profile", "email"],
+                }
+            ),
+            None,
+            adapt_boolean_value(True),
+            now,
+        ),
+    )
+
+    resp = client.put(
+        "/api/sso/providers/google",
+        headers={"Authorization": "Bearer t"},
+        json={
+            "client_id": "updated-client",
+            "authorization_url": "https://example.com/oauth2/authorize",
+        },
+    )
+
+    assert resp.status_code == 200
+
+    row = sso_manager.db.fetch_one(
+        "SELECT config FROM sso_providers WHERE name = ?",
+        ("google",),
+    )
+    assert row is not None
+
+    raw_config = row["config"]
+    stored = json.loads(raw_config)
+    restored = sso_manager.deserialize_provider_config(raw_config)
+
+    assert "client_secret" not in stored
+    assert stored["client_secret_encrypted"]
+    assert "legacy-secret" not in raw_config
+    assert restored["client_secret"] == "legacy-secret"
+    assert restored["client_id"] == "updated-client"
+    assert restored["authorization_url"] == "https://example.com/oauth2/authorize"

--- a/tests/unit/test_sso_manager_security.py
+++ b/tests/unit/test_sso_manager_security.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""
+Security-focused tests for SSO secret storage and PKCE completion flow.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+project_root = str(Path(__file__).resolve().parent.parent.parent)
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+
+import app.utils.smtp_crypto as smtp_crypto
+from app.modules.sso.manager import SSOManager
+from app.modules.sso.provider import SSOAuthResult
+from app.repositories.database import Database
+from app.repositories.schema_init import load_schema_from_file
+
+
+@pytest.fixture
+def sso_manager(tmp_path, monkeypatch):
+    """Build an SSO manager against an isolated SQLite DB with a stable key."""
+    monkeypatch.setenv("OPENACE_ENCRYPTION_KEY", "test-sso-encryption-key")
+    smtp_crypto._password_manager_instance = None
+
+    db = Database(db_url=f"sqlite:///{tmp_path / 'sso.db'}")
+    manager = SSOManager(db=db)
+    load_schema_from_file(db_url=manager.db.db_url, dialect="sqlite")
+
+    try:
+        yield manager
+    finally:
+        smtp_crypto._password_manager_instance = None
+
+
+def test_register_provider_stores_only_encrypted_client_secret(sso_manager):
+    """Provider config at rest must not retain plaintext client_secret."""
+    assert (
+        sso_manager.register_provider(
+            name="google",
+            provider_type="oauth2",
+            client_id="client-id-123",
+            client_secret="super-secret-value",
+            authorization_url="https://example.com/oauth/authorize",
+            token_url="https://example.com/oauth/token",
+            redirect_uri="https://app.example.com/callback",
+        )
+        is True
+    )
+
+    row = sso_manager.db.fetch_one(
+        "SELECT config FROM sso_providers WHERE name = ?",
+        ("google",),
+    )
+    assert row is not None
+
+    raw_config = row["config"]
+    stored = json.loads(raw_config)
+
+    assert "client_secret" not in stored
+    assert stored["client_secret_encrypted"]
+    assert "super-secret-value" not in raw_config
+
+    restored = sso_manager.deserialize_provider_config(raw_config)
+    assert restored["client_secret"] == "super-secret-value"
+
+
+def test_deserialize_provider_config_supports_legacy_plaintext_secret(sso_manager):
+    """Legacy configs remain readable before they are rewritten in encrypted form."""
+    legacy_config = json.dumps(
+        {
+            "name": "google",
+            "provider_type": "oauth2",
+            "client_id": "legacy-client",
+            "client_secret": "legacy-secret",
+            "authorization_url": "https://example.com/oauth/authorize",
+            "token_url": "https://example.com/oauth/token",
+        }
+    )
+
+    restored = sso_manager.deserialize_provider_config(legacy_config)
+
+    assert restored["client_secret"] == "legacy-secret"
+    assert restored["client_id"] == "legacy-client"
+
+
+def test_complete_authentication_passes_pkce_verifier_to_provider(sso_manager):
+    """The stored PKCE verifier must be forwarded during code exchange."""
+    provider = MagicMock()
+    provider.authenticate.return_value = SSOAuthResult(success=True)
+
+    with sso_manager._providers_lock:
+        sso_manager._providers["google"] = provider
+
+    sso_manager._store_auth_state("state-1", "verifier-1", "google", "nonce-1")
+
+    result = sso_manager.complete_authentication(
+        provider_name="google",
+        code="auth-code-1",
+        state="state-1",
+        redirect_uri="https://app.example.com/api/sso/callback/google",
+    )
+
+    assert result.success is True
+    provider.authenticate.assert_called_once_with(
+        "auth-code-1",
+        "https://app.example.com/api/sso/callback/google",
+        "verifier-1",
+    )
+    assert sso_manager._get_auth_state("state-1") is None
+
+
+def test_complete_authentication_rejects_state_bound_to_other_provider(sso_manager):
+    """Auth state cannot be replayed across providers."""
+    provider = MagicMock()
+
+    with sso_manager._providers_lock:
+        sso_manager._providers["github"] = provider
+
+    sso_manager._store_auth_state("state-2", "verifier-2", "google", "nonce-2")
+
+    result = sso_manager.complete_authentication(
+        provider_name="github",
+        code="auth-code-2",
+        state="state-2",
+        redirect_uri="https://app.example.com/api/sso/callback/github",
+    )
+
+    assert result.success is False
+    assert result.error == "invalid_state"
+    provider.authenticate.assert_not_called()


### PR DESCRIPTION
## Summary
- encrypt `client_secret` before persisting SSO provider configs and transparently read legacy plaintext rows
- thread the PKCE `code_verifier` through SSO callback completion and reject auth state/provider mismatches
- add focused docs and regression coverage for encrypted storage and callback verifier handling

## Testing
- pytest tests/unit/test_sso_manager_security.py tests/routes/test_sso_provider_storage.py tests/issues/1453/test_sso_placeholder_regression.py tests/issues/22/test_issue22.py
- SKIP=bandit,no-commit-to-branch pre-commit run --files app/modules/sso/manager.py app/modules/sso/provider.py app/routes/sso.py tests/unit/test_sso_manager_security.py tests/routes/test_sso_provider_storage.py docs/en/API.md docs/cn/API.md docs/en/DATABASE-SCHEMA.md docs/cn/DATABASE-SCHEMA.md

Closes #1745
