### PR TITLE
fix: cap websocket frames and tighten dev cors

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -10,6 +10,7 @@ import logging
 import os
 import re
 import uuid
+from urllib.parse import urlparse
 
 from flask import Flask, g, jsonify, request
 from werkzeug.exceptions import HTTPException
@@ -27,6 +28,7 @@ REQUEST_ID_MAX_LENGTH = 128
 # C0 control chars (incl. CR/LF) + DEL. Stripped from the inbound X-Request-ID
 # to defeat header-injection (CRLF smuggling) and log-injection (log forging).
 _REQUEST_ID_CONTROL_CHARS = re.compile(r"[\x00-\x1f\x7f]")
+_LOCAL_CORS_HOSTS = {"localhost", "127.0.0.1", "::1"}
 
 
 def _sanitize_request_id(value: str | None) -> str:
@@ -41,6 +43,40 @@ def _sanitize_request_id(value: str | None) -> str:
         return ""
     cleaned = _REQUEST_ID_CONTROL_CHARS.sub("", value).strip()
     return cleaned[:REQUEST_ID_MAX_LENGTH]
+
+
+def _get_allowed_cors_origins() -> set[str]:
+    """Return explicitly allowed cross-origin API callers."""
+    raw_value = os.environ.get("OPENACE_CORS_ALLOWED_ORIGINS", "")
+    return {origin.strip() for origin in raw_value.split(",") if origin.strip()}
+
+
+def _is_allowed_local_webui_origin(origin: str) -> bool:
+    """Allow only loopback WebUI origins in the dev port range."""
+    try:
+        parsed = urlparse(origin)
+    except Exception:
+        return False
+
+    if parsed.scheme not in ("http", "https"):
+        return False
+
+    if parsed.hostname not in _LOCAL_CORS_HOSTS:
+        return False
+
+    if parsed.port is None:
+        return False
+
+    return 3100 <= parsed.port <= 3200
+
+
+def _is_allowed_cors_origin(origin: str) -> bool:
+    """Return whether an Origin should receive credentialed API CORS headers."""
+    if not origin:
+        return False
+    if origin in _get_allowed_cors_origins():
+        return True
+    return _is_allowed_local_webui_origin(origin)
 
 
 def create_app(config=None):
@@ -149,35 +185,13 @@ def register_error_handlers(app):
     @app.after_request
     def add_cors_headers(response):
         """Add CORS headers for iframe integration with qwen-code-webui."""
-        # Allow requests from any origin for API routes (needed for iframe integration)
         if request.path.startswith("/api/"):
             origin = request.headers.get("Origin", "")
-            # In multi-user mode, webui instances run on different ports
-            # Allow localhost, 127.0.0.1, and workspace URL origins (any IP on port range)
-            if origin:
-                # Parse origin to check if it's from a valid webui port
-                from urllib.parse import urlparse
-
-                try:
-                    parsed = urlparse(origin)
-                    # Allow if:
-                    # 1. localhost or 127.0.0.1
-                    # 2. Same host as server but different port (workspace webui instances)
-                    if (
-                        parsed.hostname in ("localhost", "127.0.0.1")
-                        or parsed.port
-                        and 3100 <= parsed.port <= 3200
-                    ):
-                        response.headers["Access-Control-Allow-Origin"] = origin
-                        response.headers["Access-Control-Allow-Methods"] = (
-                            "GET, POST, PUT, DELETE, OPTIONS"
-                        )
-                        response.headers["Access-Control-Allow-Headers"] = (
-                            "Content-Type, Authorization"
-                        )
-                        response.headers["Access-Control-Allow-Credentials"] = "true"
-                except Exception:
-                    pass
+            if _is_allowed_cors_origin(origin):
+                response.headers["Access-Control-Allow-Origin"] = origin
+                response.headers["Access-Control-Allow-Methods"] = "GET, POST, PUT, DELETE, OPTIONS"
+                response.headers["Access-Control-Allow-Headers"] = "Content-Type, Authorization"
+                response.headers["Access-Control-Allow-Credentials"] = "true"
         return response
 
     # Handle OPTIONS preflight requests for CORS
@@ -185,25 +199,13 @@ def register_error_handlers(app):
     def handle_options(path):
         """Handle CORS preflight requests."""
         origin = request.headers.get("Origin", "")
-        if origin:
-            from urllib.parse import urlparse
-
-            try:
-                parsed = urlparse(origin)
-                # Allow localhost, 127.0.0.1, or any origin from workspace port range
-                if parsed.hostname in ("localhost", "127.0.0.1") or (
-                    parsed.port and 3100 <= parsed.port <= 3200
-                ):
-                    response = jsonify({"status": "ok"})
-                    response.headers["Access-Control-Allow-Origin"] = origin
-                    response.headers["Access-Control-Allow-Methods"] = (
-                        "GET, POST, PUT, DELETE, OPTIONS"
-                    )
-                    response.headers["Access-Control-Allow-Headers"] = "Content-Type, Authorization"
-                    response.headers["Access-Control-Allow-Credentials"] = "true"
-                    return response
-            except Exception:
-                logger.debug("Failed to parse CORS origin header", exc_info=True)
+        if _is_allowed_cors_origin(origin):
+            response = jsonify({"status": "ok"})
+            response.headers["Access-Control-Allow-Origin"] = origin
+            response.headers["Access-Control-Allow-Methods"] = "GET, POST, PUT, DELETE, OPTIONS"
+            response.headers["Access-Control-Allow-Headers"] = "Content-Type, Authorization"
+            response.headers["Access-Control-Allow-Credentials"] = "true"
+            return response
         return jsonify({"status": "ok"}), 200
 
     @app.errorhandler(HTTPException)

--- a/app/ws_frame.py
+++ b/app/ws_frame.py
@@ -12,11 +12,16 @@ geventwebsocket 0.10.1 and newer gevent versions.
 from __future__ import annotations
 
 import hashlib
+import os
 import struct
 from base64 import b64encode
 
 # RFC 6455 magic GUID for Sec-WebSocket-Accept computation
 _WS_GUID = b"258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+
+# Cap inbound WebSocket messages to keep a malformed or malicious client from
+# forcing unbounded allocation in the raw frame bridge.
+DEFAULT_MAX_MESSAGE_SIZE = 8 * 1024 * 1024
 
 # Opcodes
 OP_CONT = 0x0
@@ -25,6 +30,24 @@ OP_BINARY = 0x2
 OP_CLOSE = 0x8
 OP_PING = 0x9
 OP_PONG = 0xA
+
+
+class WebSocketMessageTooLarge(ValueError):
+    """Raised when an inbound WebSocket message exceeds the configured cap."""
+
+
+def get_max_message_size() -> int:
+    """Get the inbound WebSocket message cap in bytes."""
+    raw_value = os.environ.get("OPENACE_WS_MAX_MESSAGE_BYTES", "").strip()
+    if not raw_value:
+        return DEFAULT_MAX_MESSAGE_SIZE
+
+    try:
+        value = int(raw_value)
+    except ValueError:
+        return DEFAULT_MAX_MESSAGE_SIZE
+
+    return value if value > 0 else DEFAULT_MAX_MESSAGE_SIZE
 
 
 def _compute_accept_key(client_key: str) -> str:
@@ -87,6 +110,8 @@ def recv_message(sock) -> bytes | str | None:
     """
     fragments: list[bytes] = []
     message_opcode: int | None = None
+    total_length = 0
+    max_message_size = get_max_message_size()
 
     while True:
         header = _recv_exactly(sock, 2)
@@ -109,6 +134,12 @@ def recv_message(sock) -> bytes | str | None:
             if len(ext) < 8:
                 return None
             length = struct.unpack("!Q", ext)[0]
+
+        if length > max_message_size:
+            send_close(sock, 1009, "Message too large")
+            raise WebSocketMessageTooLarge(
+                f"WebSocket frame length {length} exceeds limit {max_message_size}"
+            )
 
         mask_key = _recv_exactly(sock, 4) if masked else b""
         if masked and len(mask_key) < 4:
@@ -138,12 +169,20 @@ def recv_message(sock) -> bytes | str | None:
         if opcode in (OP_TEXT, OP_BINARY):
             message_opcode = opcode
             fragments = [payload]
+            total_length = len(payload)
         elif opcode == OP_CONT:
             if message_opcode is None:
                 return None
             fragments.append(payload)
+            total_length += len(payload)
         else:
             continue
+
+        if total_length > max_message_size:
+            send_close(sock, 1009, "Message too large")
+            raise WebSocketMessageTooLarge(
+                f"WebSocket message length {total_length} exceeds limit {max_message_size}"
+            )
 
         if fin:
             combined = b"".join(fragments)

--- a/docs/cn/ARCHITECTURE.md
+++ b/docs/cn/ARCHITECTURE.md
@@ -159,7 +159,7 @@ Modules (domain logic):
 | 中间件 | 用途 |
 |--------|------|
 | `ProxyFix` | 信任来自 nginx 的 `X-Forwarded-For` / `X-Forwarded-Proto` |
-| CORS 头 | `after_request` 处理器，用于 `/api/` 路由的 localhost 跨域 |
+| CORS 头 | `after_request` 处理器，用于 `/api/` 路由的 loopback WebUI 跨域和显式白名单来源 |
 | OPTIONS 处理器 | 预检 CORS 响应 |
 | 错误处理器 | API 路由返回 JSON，页面返回标准 HTTP |
 | `/health` | 返回服务状态和 git commit hash |

--- a/docs/cn/DEPLOYMENT.md
+++ b/docs/cn/DEPLOYMENT.md
@@ -283,6 +283,8 @@ cd /home/open-ace/open-ace
 |------|------|
 | `OPENCLAW_TOKEN` | OpenClaw API token |
 | `SMTP_PASSWORD` | 邮件 SMTP 密码 |
+| `OPENACE_CORS_ALLOWED_ORIGINS` | 非 loopback WebUI 源的显式 API CORS 白名单，多个值用逗号分隔 |
+| `OPENACE_WS_MAX_MESSAGE_BYTES` | 浏览器侧终端 / VSCode 原始桥接允许的入站 WebSocket 最大消息大小（默认 `8388608`） |
 
 ### 端口配置
 

--- a/docs/en/ARCHITECTURE.md
+++ b/docs/en/ARCHITECTURE.md
@@ -159,7 +159,7 @@ See [DATABASE-SCHEMA.md](DATABASE-SCHEMA.md) for the full table reference.
 | Middleware | Purpose |
 |------------|---------|
 | `ProxyFix` | Trusts `X-Forwarded-For` / `X-Forwarded-Proto` from nginx |
-| CORS headers | `after_request` handler for `/api/` routes from localhost |
+| CORS headers | `after_request` handler for `/api/` routes from loopback WebUI origins plus explicit allowlist entries |
 | OPTIONS handler | Preflight CORS responses |
 | Error handlers | JSON for API routes, standard HTTP for pages |
 | `/health` | Returns service status and git commit hash |

--- a/docs/en/DEPLOYMENT.md
+++ b/docs/en/DEPLOYMENT.md
@@ -283,6 +283,8 @@ Configuration is stored in `~/.open-ace/config.json`:
 |----------|-------------|
 | `OPENCLAW_TOKEN` | OpenClaw API token |
 | `SMTP_PASSWORD` | Email SMTP password |
+| `OPENACE_CORS_ALLOWED_ORIGINS` | Comma-separated explicit API CORS allowlist for non-loopback WebUI origins |
+| `OPENACE_WS_MAX_MESSAGE_BYTES` | Maximum inbound browser WebSocket message size for terminal / VSCode raw bridges (default: `8388608`) |
 
 ### Port Configuration
 

--- a/tests/issues/1746/test_ws_frame_cors_guards.py
+++ b/tests/issues/1746/test_ws_frame_cors_guards.py
@@ -1,0 +1,142 @@
+"""Regression tests for issue #1746: WS frame caps and dev CORS narrowing."""
+
+from __future__ import annotations
+
+import os
+import struct
+import sys
+from pathlib import Path
+
+import pytest
+
+project_root = str(Path(__file__).resolve().parent.parent.parent.parent)
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+
+import app.ws_frame as ws_frame
+from app import register_error_handlers
+
+
+class FakeSocket:
+    """Minimal socket double for frame parser tests."""
+
+    def __init__(self, recv_data: bytes = b""):
+        self._recv_buf = bytearray(recv_data)
+        self.sent: list[bytes] = []
+
+    def sendall(self, data: bytes) -> None:
+        self.sent.append(data)
+
+    def recv(self, n: int) -> bytes:
+        if not self._recv_buf:
+            return b""
+        chunk = bytes(self._recv_buf[:n])
+        self._recv_buf = self._recv_buf[n:]
+        return chunk
+
+    @property
+    def all_sent(self) -> bytes:
+        return b"".join(self.sent)
+
+
+def _mask(mask_key: bytes, payload: bytes) -> bytes:
+    return bytes(b ^ mask_key[i % 4] for i, b in enumerate(payload))
+
+
+def _build_client_frame(payload: bytes, opcode: int = ws_frame.OP_TEXT, fin: bool = True) -> bytes:
+    first = (0x80 if fin else 0x00) | opcode
+    mask_key = b"\x37\xfa\x21\x3d"
+    length = len(payload)
+
+    if length < 126:
+        header = struct.pack("!BB", first, 0x80 | length)
+    elif length < 65536:
+        header = struct.pack("!BBH", first, 0x80 | 126, length)
+    else:
+        header = struct.pack("!BBQ", first, 0x80 | 127, length)
+
+    return header + mask_key + _mask(mask_key, payload)
+
+
+@pytest.fixture(autouse=True)
+def _clear_cors_env(monkeypatch):
+    monkeypatch.delenv("OPENACE_CORS_ALLOWED_ORIGINS", raising=False)
+
+
+@pytest.fixture
+def cors_app():
+    from flask import Flask, jsonify
+
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    register_error_handlers(app)
+
+    @app.route("/api/ping", methods=["GET"])
+    def ping():
+        return jsonify({"ok": True})
+
+    return app
+
+
+class TestWebSocketFrameCap:
+    def test_oversized_64bit_frame_is_rejected_before_payload_read(self, monkeypatch):
+        monkeypatch.setenv("OPENACE_WS_MAX_MESSAGE_BYTES", "1024")
+        frame = struct.pack("!BBQ", 0x82, 0x80 | 127, 2048) + b"\x37\xfa\x21\x3d"
+        sock = FakeSocket(frame)
+
+        with pytest.raises(ws_frame.WebSocketMessageTooLarge, match="frame length 2048"):
+            ws_frame.recv_message(sock)
+
+        close_frame = sock.all_sent
+        assert close_frame[0] == 0x88
+        assert struct.unpack("!H", close_frame[2:4])[0] == 1009
+
+    def test_fragmented_message_over_limit_is_rejected(self, monkeypatch):
+        monkeypatch.setenv("OPENACE_WS_MAX_MESSAGE_BYTES", "5")
+        frame = _build_client_frame(
+            b"abc", opcode=ws_frame.OP_TEXT, fin=False
+        ) + _build_client_frame(b"def", opcode=ws_frame.OP_CONT, fin=True)
+        sock = FakeSocket(frame)
+
+        with pytest.raises(ws_frame.WebSocketMessageTooLarge, match="message length 6"):
+            ws_frame.recv_message(sock)
+
+        close_frame = sock.all_sent
+        assert close_frame[0] == 0x88
+        assert struct.unpack("!H", close_frame[2:4])[0] == 1009
+
+
+class TestCorsPolicy:
+    def test_loopback_webui_origin_is_allowed(self, cors_app):
+        client = cors_app.test_client()
+
+        resp = client.get("/api/ping", headers={"Origin": "http://localhost:3100"})
+
+        assert resp.status_code == 200
+        assert resp.headers["Access-Control-Allow-Origin"] == "http://localhost:3100"
+        assert resp.headers["Access-Control-Allow-Credentials"] == "true"
+
+    def test_arbitrary_same_port_non_loopback_origin_is_not_reflected(self, cors_app):
+        client = cors_app.test_client()
+
+        resp = client.get("/api/ping", headers={"Origin": "http://192.168.1.55:3100"})
+
+        assert resp.status_code == 200
+        assert "Access-Control-Allow-Origin" not in resp.headers
+        assert "Access-Control-Allow-Credentials" not in resp.headers
+
+    def test_preflight_honors_explicit_allowlist(self, cors_app, monkeypatch):
+        monkeypatch.setenv(
+            "OPENACE_CORS_ALLOWED_ORIGINS",
+            "https://workspace.internal.example, https://ops.example",
+        )
+        client = cors_app.test_client()
+
+        resp = client.options(
+            "/api/ping",
+            headers={"Origin": "https://workspace.internal.example"},
+        )
+
+        assert resp.status_code == 200
+        assert resp.headers["Access-Control-Allow-Origin"] == "https://workspace.internal.example"
+        assert resp.headers["Access-Control-Allow-Credentials"] == "true"


### PR DESCRIPTION
## Summary
- cap inbound browser WebSocket messages for the raw terminal / VSCode bridges and close oversized frames with code 1009
- narrow development CORS reflection to loopback WebUI origins by default, with an explicit allowlist for non-loopback deployments
- document the new deployment controls and add regression coverage for oversized frames and CORS origin handling

## Testing
- pytest tests/issues/1746/test_ws_frame_cors_guards.py tests/issues/559/test_ws_frame.py
- python3 -m compileall app/ws_frame.py app/__init__.py tests/issues/1746/test_ws_frame_cors_guards.py
- SKIP=bandit,no-commit-to-branch pre-commit run --files app/ws_frame.py app/__init__.py tests/issues/1746/test_ws_frame_cors_guards.py docs/en/DEPLOYMENT.md docs/cn/DEPLOYMENT.md docs/en/ARCHITECTURE.md docs/cn/ARCHITECTURE.md

Closes #1746
