### PR TITLE
fix: align shipped deployment manifests with runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ open-ace/
 | [远程工作区](docs/cn/REMOTE-WORKSPACE.md) | 远程机器、Agent、API Key 代理与安全设计 |
 | [远程 Agent](docs/cn/REMOTE-AGENT.md) | Agent 安装、CLI 适配器、终端和会话同步 |
 | [权限模型](docs/cn/PERMISSION-MODEL.md) | 租户、角色与访问控制 |
-| [Kubernetes](docs/cn/KUBERNETES.md) | K8s 部署参考 |
+| [Kubernetes](docs/cn/KUBERNETES.md) | K8s 单实例参考部署 |
 | [飞书配置](docs/cn/FEISHU_CONFIG.md) | 飞书集成配置 |
 | [API 文档](docs/cn/API.md) | API 接口说明 |
 | [仓库设置](docs/REPOSITORY_SETUP.md) | GitHub topics、labels、分支保护和发布检查清单 |
@@ -602,7 +602,7 @@ The `docs/` directory is the source of truth for product documentation. The publ
 | [Remote Workspace](docs/en/REMOTE-WORKSPACE.md) | Remote machines, Agent, API Key proxy, and security design |
 | [Remote Agent](docs/en/REMOTE-AGENT.md) | Agent install, CLI adapters, terminal, and session sync |
 | [Permission Model](docs/en/PERMISSION-MODEL.md) | Tenants, roles, and access control |
-| [Kubernetes](docs/en/KUBERNETES.md) | K8s deployment reference |
+| [Kubernetes](docs/en/KUBERNETES.md) | Single-instance K8s deployment reference |
 | [Feishu Config](docs/en/FEISHU_CONFIG.md) | Feishu integration |
 | [API Reference](docs/en/API.md) | API documentation |
 | [Repository Setup](docs/REPOSITORY_SETUP.md) | GitHub topics, labels, branch protection, and release checklist |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,8 @@
 # Pull pre-built image from Docker Hub:
 #   docker compose up -d
 #
-# With nginx reverse proxy:
-#   docker compose --profile production up -d
+# HTTPS reverse proxy:
+#   Follow docs/en/NGINX.md or docs/cn/NGINX.md
 #
 # Multi-user workspace:
 #   WORKSPACE_MULTI_USER_MODE=true docker compose up -d
@@ -84,31 +84,6 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
-    logging:
-      driver: "json-file"
-      options:
-        max-size: "10m"
-        max-file: "3"
-
-  # ===========================================================================
-  # Optional: Nginx Reverse Proxy (for SSL termination)
-  # ===========================================================================
-  nginx:
-    image: nginx:alpine
-    container_name: open-ace-nginx
-    restart: unless-stopped
-    ports:
-      - "80:80"
-      - "443:443"
-    volumes:
-      - ./nginx.conf:/etc/nginx/nginx.conf:ro
-      - ./ssl:/etc/nginx/ssl:ro
-    depends_on:
-      - open-ace
-    networks:
-      - open-ace-network
-    profiles:
-      - production
     logging:
       driver: "json-file"
       options:

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,7 @@ Documentation files are in the [en/](en/) directory.
 | [**REMOTE-AGENT**](en/REMOTE-AGENT.md) | Remote agent client — installation, configuration, CLI tools |
 | [**REMOTE-WORKSPACE**](en/REMOTE-WORKSPACE.md) | Remote workspace from server perspective — deployment, management UI, API |
 | [**DEPLOYMENT**](en/DEPLOYMENT.md) | Docker deployment and multi-user workspace setup |
-| [**KUBERNETES**](en/KUBERNETES.md) | Kubernetes deployment guide with manifests reference |
+| [**KUBERNETES**](en/KUBERNETES.md) | Single-instance Kubernetes deployment guide with manifests reference |
 | [**NGINX**](en/NGINX.md) | Nginx reverse proxy configuration for HTTPS and WebSocket |
 | [**DEVELOPMENT**](en/DEVELOPMENT.md) | Development environment setup, project structure, and testing |
 | [**FEISHU-CONFIG**](en/FEISHU_CONFIG.md) | Feishu/Lark integration configuration guide |
@@ -62,7 +62,7 @@ Documentation files are in the [en/](en/) directory.
 | [**REMOTE-AGENT**](cn/REMOTE-AGENT.md) | 远程代理客户端 — 安装、配置、CLI 工具 |
 | [**REMOTE-WORKSPACE**](cn/REMOTE-WORKSPACE.md) | 服务端视角的远程工作区 — 部署、管理界面、API |
 | [**DEPLOYMENT**](cn/DEPLOYMENT.md) | Docker 部署和多用户工作空间配置 |
-| [**KUBERNETES**](cn/KUBERNETES.md) | Kubernetes 部署指南及 manifests 参考 |
+| [**KUBERNETES**](cn/KUBERNETES.md) | 单实例 Kubernetes 部署指南及 manifests 参考 |
 | [**NGINX**](cn/NGINX.md) | Nginx 反向代理配置（HTTPS 和 WebSocket） |
 | [**DEVELOPMENT**](cn/DEVELOPMENT.md) | 开发环境搭建、项目结构和测试 |
 | [**FEISHU-CONFIG**](cn/FEISHU_CONFIG.md) | 飞书集成配置指南 |

--- a/docs/cn/KUBERNETES.md
+++ b/docs/cn/KUBERNETES.md
@@ -38,11 +38,11 @@ k8s/
 
 | 设置 | 值 |
 |------|-----|
-| 副本数 | 3 |
+| 副本数 | 1 |
 | 镜像 | `open-ace:latest` |
-| 容器端口 | 5001 |
+| 容器端口 | 19888 |
 | 更新策略 | RollingUpdate（maxSurge=1, maxUnavailable=0） |
-| 安全上下文 | runAsNonRoot, runAsUser=1000 |
+| 安全上下文 | `runAsUser: 0`（当前多用户工作区 entrypoint 需要） |
 
 **资源限制：**
 
@@ -55,22 +55,11 @@ k8s/
 - 存活检查：HTTP GET `/health`，initialDelay=10s，period=10s
 - 就绪检查：HTTP GET `/health`，initialDelay=5s，period=5s
 
-**Pod 反亲和性：** 优先分布在不同节点上。
-
-### HorizontalPodAutoscaler
-
-| 设置 | 值 |
-|------|-----|
-| 最小副本数 | 3 |
-| 最大副本数 | 10 |
-| CPU 目标 | 70% |
-| 内存目标 | 80% |
-| 扩容 | max(100%/15s, 2 pods/15s) |
-| 缩容 | 10%/60s，稳定期 300s |
+**Pod 反亲和性：** 仅保留为调度偏好。当前清单是单实例参考部署。
 
 ### Service 与 Ingress
 
-**ClusterIP Service：** 端口 80 → targetPort 5001
+**ClusterIP Service：** 端口 80 → targetPort 19888
 
 **Ingress：**
 - 主机：`open-ace.example.com`（需修改）
@@ -104,7 +93,7 @@ k8s/
 
 ### ConfigMap
 
-应用配置键：`FLASK_APP`、`FLASK_ENV`、`PYTHONUNBUFFERED`、`LOG_LEVEL`、`DB_HOST`、`DB_PORT`、`DB_NAME`、`REDIS_HOST`、`REDIS_PORT`、`ENABLE_SSO`、`ENABLE_MULTI_TENANT`、`ENABLE_AUDIT_LOG`、`ENABLE_CONTENT_FILTER`、`AUDIT_LOG_RETENTION_DAYS`、`DATA_RETENTION_DAYS`
+应用配置键：`FLASK_APP`、`FLASK_ENV`、`PYTHONUNBUFFERED`、`LOG_LEVEL`、`DB_HOST`、`DB_PORT`、`DB_NAME`、`REDIS_HOST`、`REDIS_PORT`、`ENABLE_SSO`、`ENABLE_MULTI_TENANT`、`ENABLE_AUDIT_LOG`、`ENABLE_CONTENT_FILTER`、`WORKSPACE_BASE_DIR`、`AUDIT_LOG_RETENTION_DAYS`、`DATA_RETENTION_DAYS`
 
 ### Secret
 
@@ -117,7 +106,9 @@ k8s/
 - 名称：`open-ace-data`
 - 大小：10Gi
 - 访问模式：ReadWriteOnce
-- 挂载路径：`/app/data`
+- 挂载路径：
+  - `/workspace`（subPath `workspace`）
+  - `/root/.open-ace`（subPath `config`）
 
 ### RBAC
 
@@ -128,7 +119,7 @@ k8s/
 ### NetworkPolicy
 
 **入站规则：**
-- 允许来自 `ingress-nginx` 命名空间到端口 5001
+- 允许来自 `ingress-nginx` 命名空间到端口 19888
 - 允许来自 `open-ace` 命名空间（健康检查）
 
 **出站规则：**
@@ -139,7 +130,7 @@ k8s/
 
 ### PodDisruptionBudget
 
-- `minAvailable: 2` — 确保中断期间至少有 2 个副本
+- `minAvailable: 1` — 在单实例支持边界内保护当前应用副本不被自愿驱逐
 
 ## 配置
 
@@ -152,6 +143,12 @@ k8s/
 3. **StorageClass** 在 `storage.yaml` 中 — 匹配集群的 StorageClass
 4. **镜像** 在 `kustomization.yaml` 中 — 设置你的容器镜像仓库路径
 
+### 当前支持边界
+
+- 仓库内提供的 Kubernetes 清单是**单实例参考部署**。
+- 远程工作区 / 终端 / 会话协调仍有关键运行时状态保存在进程内，因此这里不再宣称或启用水平扩缩容。
+- 容器当前有意以 root 身份运行，因为 entrypoint 需要动态创建多用户工作区账户；仓库中尚未提供等价的非 root 生产镜像变体。
+
 ### 使用 cert-manager 配置 TLS
 
 Ingress 已为 cert-manager 预配置了 `letsencrypt-prod` ClusterIssuer。请先安装 cert-manager：
@@ -162,20 +159,12 @@ kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/
 
 ## 监控
 
-Deployment 上设置了 Prometheus 注解：
-
-```yaml
-prometheus.io/scrape: "true"
-prometheus.io/port: "5001"
-prometheus.io/path: "/metrics"
-```
-
 `/health` 端点返回服务状态和 git commit hash。
 
 ## 扩容
 
-HPA 基于 CPU（70%）和内存（80%）利用率自动在 3-10 个副本之间扩缩。手动扩缩：
+当前参考清单固定为单实例。如需重启或重新调度：
 
 ```bash
-kubectl scale deployment open-ace -n open-ace --replicas=5
+kubectl rollout restart deployment open-ace -n open-ace
 ```

--- a/docs/en/KUBERNETES.md
+++ b/docs/en/KUBERNETES.md
@@ -38,11 +38,11 @@ Creates the `open-ace` namespace with standard Kubernetes labels.
 
 | Setting | Value |
 |---------|-------|
-| Replicas | 3 |
+| Replicas | 1 |
 | Image | `open-ace:latest` |
-| Container port | 5001 |
+| Container port | 19888 |
 | Strategy | RollingUpdate (maxSurge=1, maxUnavailable=0) |
-| Security context | runAsNonRoot, runAsUser=1000 |
+| Security context | `runAsUser: 0` (required by the current multi-user workspace entrypoint) |
 
 **Resource Limits:**
 
@@ -55,22 +55,11 @@ Creates the `open-ace` namespace with standard Kubernetes labels.
 - Liveness: HTTP GET `/health`, initialDelay=10s, period=10s
 - Readiness: HTTP GET `/health`, initialDelay=5s, period=5s
 
-**Pod Anti-Affinity:** Preferred spread across different nodes.
-
-### HorizontalPodAutoscaler
-
-| Setting | Value |
-|---------|-------|
-| Min replicas | 3 |
-| Max replicas | 10 |
-| CPU target | 70% |
-| Memory target | 80% |
-| Scale up | max(100%/15s, 2 pods/15s) |
-| Scale down | 10%/60s, stabilization 300s |
+**Pod Anti-Affinity:** Kept as a preference only. The current manifest is a single-instance reference deployment.
 
 ### Service & Ingress
 
-**ClusterIP Service:** Port 80 → targetPort 5001
+**ClusterIP Service:** Port 80 → targetPort 19888
 
 **Ingress:**
 - Host: `open-ace.example.com` (change this)
@@ -104,7 +93,7 @@ Credentials from Secret `open-ace-secrets` (keys: `DB_USER`, `DB_PASSWORD`).
 
 ### ConfigMap
 
-Application configuration keys: `FLASK_APP`, `FLASK_ENV`, `PYTHONUNBUFFERED`, `LOG_LEVEL`, `DB_HOST`, `DB_PORT`, `DB_NAME`, `REDIS_HOST`, `REDIS_PORT`, `ENABLE_SSO`, `ENABLE_MULTI_TENANT`, `ENABLE_AUDIT_LOG`, `ENABLE_CONTENT_FILTER`, `AUDIT_LOG_RETENTION_DAYS`, `DATA_RETENTION_DAYS`
+Application configuration keys: `FLASK_APP`, `FLASK_ENV`, `PYTHONUNBUFFERED`, `LOG_LEVEL`, `DB_HOST`, `DB_PORT`, `DB_NAME`, `REDIS_HOST`, `REDIS_PORT`, `ENABLE_SSO`, `ENABLE_MULTI_TENANT`, `ENABLE_AUDIT_LOG`, `ENABLE_CONTENT_FILTER`, `WORKSPACE_BASE_DIR`, `AUDIT_LOG_RETENTION_DAYS`, `DATA_RETENTION_DAYS`
 
 ### Secret
 
@@ -117,7 +106,9 @@ Keys: `SECRET_KEY`, `OPENACE_ENCRYPTION_KEY`, `UPLOAD_AUTH_KEY`, `DB_USER`, `DB_
 - Name: `open-ace-data`
 - Size: 10Gi
 - Access: ReadWriteOnce
-- Mount: `/app/data`
+- Mounts:
+  - `/workspace` via subPath `workspace`
+  - `/root/.open-ace` via subPath `config`
 
 ### RBAC
 
@@ -128,7 +119,7 @@ Keys: `SECRET_KEY`, `OPENACE_ENCRYPTION_KEY`, `UPLOAD_AUTH_KEY`, `DB_USER`, `DB_
 ### NetworkPolicy
 
 **Ingress:**
-- Allow from `ingress-nginx` namespace to port 5001
+- Allow from `ingress-nginx` namespace to port 19888
 - Allow from `open-ace` namespace (health checks)
 
 **Egress:**
@@ -139,7 +130,7 @@ Keys: `SECRET_KEY`, `OPENACE_ENCRYPTION_KEY`, `UPLOAD_AUTH_KEY`, `DB_USER`, `DB_
 
 ### PodDisruptionBudget
 
-- `minAvailable: 2` — Ensures at least 2 replicas during disruptions
+- `minAvailable: 1` — Protects the single supported application replica during voluntary disruptions
 
 ## Configuration
 
@@ -152,6 +143,12 @@ Before deploying, update:
 3. **StorageClass** in `storage.yaml` — Match your cluster's StorageClass
 4. **Image** in `kustomization.yaml` — Set your container registry path
 
+### Current support boundary
+
+- The shipped Kubernetes manifest is a **single-instance reference deployment**.
+- Remote workspace / terminal / session coordination still keeps important runtime state in-process, so horizontal scaling is not advertised or enabled here.
+- The container intentionally runs as root because the current entrypoint provisions per-user workspace accounts dynamically. A hardened non-root image variant is not shipped yet.
+
 ### TLS with cert-manager
 
 The Ingress is pre-configured for cert-manager with `letsencrypt-prod` ClusterIssuer. Install cert-manager first:
@@ -162,20 +159,12 @@ kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/
 
 ## Monitoring
 
-Prometheus annotations are set on the Deployment:
-
-```yaml
-prometheus.io/scrape: "true"
-prometheus.io/port: "5001"
-prometheus.io/path: "/metrics"
-```
-
 The `/health` endpoint returns service status and git commit hash.
 
 ## Scaling
 
-The HPA automatically scales between 3-10 replicas based on CPU (70%) and memory (80%) utilization. For manual scaling:
+This reference manifest intentionally stays at one application replica. For manual restarts or rescheduling:
 
 ```bash
-kubectl scale deployment open-ace -n open-ace --replicas=5
+kubectl rollout restart deployment open-ace -n open-ace
 ```

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -28,6 +28,7 @@ data:
   ENABLE_MULTI_TENANT: "true"
   ENABLE_AUDIT_LOG: "true"
   ENABLE_CONTENT_FILTER: "true"
+  WORKSPACE_BASE_DIR: "/workspace"
 
   # Retention settings
   AUDIT_LOG_RETENTION_DAYS: "90"
@@ -48,6 +49,7 @@ type: Opaque
 stringData:
   # These should be changed in production
   SECRET_KEY: "change-me-in-production-use-strong-secret"
+  OPENACE_ENCRYPTION_KEY: "change-me-in-production-use-dedicated-encryption-key"
   UPLOAD_AUTH_KEY: "change-me-in-production"
   DB_USER: "openace"
   DB_PASSWORD: "change-me-in-production"

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: open-ace
     app.kubernetes.io/component: web
 spec:
-  replicas: 3
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: open-ace
@@ -23,23 +23,18 @@ spec:
       labels:
         app.kubernetes.io/name: open-ace
         app.kubernetes.io/component: web
-      annotations:
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "5001"
-        prometheus.io/path: "/metrics"
     spec:
       serviceAccountName: open-ace
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
-        fsGroup: 1000
       containers:
         - name: open-ace
           image: open-ace:latest
           imagePullPolicy: IfNotPresent
+          securityContext:
+            runAsNonRoot: false
+            runAsUser: 0
           ports:
             - name: http
-              containerPort: 5001
+              containerPort: 19888
               protocol: TCP
           envFrom:
             - configMapRef:
@@ -80,12 +75,13 @@ spec:
             failureThreshold: 3
           volumeMounts:
             - name: data
-              mountPath: /app/data
+              mountPath: /workspace
+              subPath: workspace
             - name: logs
               mountPath: /app/logs
             - name: config
-              mountPath: /app/config
-              readOnly: true
+              mountPath: /root/.open-ace
+              subPath: config
       volumes:
         - name: data
           persistentVolumeClaim:
@@ -93,8 +89,8 @@ spec:
         - name: logs
           emptyDir: {}
         - name: config
-          configMap:
-            name: open-ace-config
+          persistentVolumeClaim:
+            claimName: open-ace-data
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -108,50 +104,3 @@ spec:
         - key: "node-role.kubernetes.io/master"
           operator: "Exists"
           effect: "NoSchedule"
-
----
-# Open ACE - HorizontalPodAutoscaler
-apiVersion: autoscaling/v2
-kind: HorizontalPodAutoscaler
-metadata:
-  name: open-ace
-  namespace: open-ace
-  labels:
-    app.kubernetes.io/name: open-ace
-spec:
-  scaleTargetRef:
-    apiVersion: apps/v1
-    kind: Deployment
-    name: open-ace
-  minReplicas: 3
-  maxReplicas: 10
-  metrics:
-    - type: Resource
-      resource:
-        name: cpu
-        target:
-          type: Utilization
-          averageUtilization: 70
-    - type: Resource
-      resource:
-        name: memory
-        target:
-          type: Utilization
-          averageUtilization: 80
-  behavior:
-    scaleDown:
-      stabilizationWindowSeconds: 300
-      policies:
-        - type: Percent
-          value: 10
-          periodSeconds: 60
-    scaleUp:
-      stabilizationWindowSeconds: 60
-      policies:
-        - type: Percent
-          value: 100
-          periodSeconds: 15
-        - type: Pods
-          value: 2
-          periodSeconds: 15
-      selectPolicy: Max

--- a/k8s/policies.yaml
+++ b/k8s/policies.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: open-ace
 spec:
-  minAvailable: 2
+  minAvailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: open-ace
@@ -37,7 +37,7 @@ spec:
               kubernetes.io/metadata.name: ingress-nginx
       ports:
         - protocol: TCP
-          port: 5001
+          port: 19888
     # Allow health checks from within the cluster
     - from:
         - namespaceSelector:
@@ -45,7 +45,7 @@ spec:
               kubernetes.io/metadata.name: open-ace
       ports:
         - protocol: TCP
-          port: 5001
+          port: 19888
   egress:
     # Allow DNS
     - to:

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -31,7 +31,7 @@ spec:
   type: ClusterIP
   clusterIP: None
   ports:
-    - port: 5001
+    - port: 19888
       targetPort: http
       protocol: TCP
       name: http

--- a/scripts/shared/config.py
+++ b/scripts/shared/config.py
@@ -12,6 +12,7 @@ environment variables to override defaults.
 import json
 import os
 from typing import Optional, cast
+from urllib.parse import quote
 
 # Configuration directory path
 # This is the main configuration that should be set during installation
@@ -129,7 +130,7 @@ def get_database_config() -> dict:
 
 def get_database_url() -> str:
     """
-    Get database URL with priority: environment variable > config file > default PostgreSQL > fallback SQLite.
+    Get database URL with priority: full env URL > split env settings > config file > default PostgreSQL > fallback SQLite.
 
     Returns:
         str: Database URL.
@@ -138,7 +139,18 @@ def get_database_url() -> str:
     if os.environ.get("DATABASE_URL"):
         return os.environ["DATABASE_URL"]
 
-    # Priority 2: Config file
+    # Priority 2: Split PostgreSQL environment variables (used by Kubernetes manifests)
+    db_host = os.environ.get("DB_HOST")
+    db_name = os.environ.get("DB_NAME")
+    db_user = os.environ.get("DB_USER")
+    if db_host and db_name and db_user:
+        db_port = os.environ.get("DB_PORT", "5432")
+        db_password = os.environ.get("DB_PASSWORD", "")
+        quoted_user = quote(db_user, safe="")
+        quoted_password = quote(db_password, safe="")
+        return f"postgresql://{quoted_user}:{quoted_password}@{db_host}:{db_port}/{db_name}"
+
+    # Priority 3: Config file
     db_config = get_database_config()
     db_type = db_config.get("type", "postgresql").lower()
 
@@ -151,7 +163,7 @@ def get_database_url() -> str:
         db_path = db_config.get("path", DB_PATH)
         return f"sqlite:///{db_path}"
 
-    # Priority 3: SQLite (explicitly configured)
+    # Priority 4: SQLite (explicitly configured)
     db_path = db_config.get("path", DB_PATH)
     return f"sqlite:///{db_path}"
 

--- a/tests/issues/1748/test_deployment_alignment.py
+++ b/tests/issues/1748/test_deployment_alignment.py
@@ -1,0 +1,61 @@
+"""Regression tests for issue #1748 deployment alignment."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import scripts.shared.config as shared_config
+
+ROOT = Path(__file__).resolve().parents[3]
+
+
+class TestDatabaseUrlEnvFallback:
+    def test_split_db_env_builds_postgres_url(self, monkeypatch):
+        monkeypatch.delenv("DATABASE_URL", raising=False)
+        monkeypatch.setenv("DB_HOST", "postgres")
+        monkeypatch.setenv("DB_PORT", "5432")
+        monkeypatch.setenv("DB_NAME", "openace")
+        monkeypatch.setenv("DB_USER", "openace")
+        monkeypatch.setenv("DB_PASSWORD", "p@ss word")
+
+        url = shared_config.get_database_url()
+
+        assert url == "postgresql://openace:p%40ss%20word@postgres:5432/openace"
+
+
+class TestKubernetesManifestAlignment:
+    def test_deployment_manifest_matches_single_instance_runtime_contract(self):
+        deployment = (ROOT / "k8s" / "deployment.yaml").read_text(encoding="utf-8")
+
+        assert "replicas: 1" in deployment
+        assert "containerPort: 19888" in deployment
+        assert "runAsNonRoot: false" in deployment
+        assert "runAsUser: 0" in deployment
+        assert "mountPath: /workspace" in deployment
+        assert "mountPath: /root/.open-ace" in deployment
+        assert "kind: HorizontalPodAutoscaler" not in deployment
+        assert 'prometheus.io/port: "5001"' not in deployment
+
+    def test_service_and_policy_ports_match_19888_runtime_port(self):
+        service = (ROOT / "k8s" / "service.yaml").read_text(encoding="utf-8")
+        policies = (ROOT / "k8s" / "policies.yaml").read_text(encoding="utf-8")
+
+        assert "port: 19888" in service
+        assert "port: 19888" in policies
+        assert "port: 5001" not in service
+        assert "port: 5001" not in policies
+
+    def test_k8s_secret_includes_dedicated_encryption_key(self):
+        configmap = (ROOT / "k8s" / "configmap.yaml").read_text(encoding="utf-8")
+
+        assert "OPENACE_ENCRYPTION_KEY" in configmap
+        assert "WORKSPACE_BASE_DIR" in configmap
+
+
+class TestComposeSunset:
+    def test_main_compose_no_longer_advertises_broken_nginx_profile(self):
+        compose = (ROOT / "docker-compose.yml").read_text(encoding="utf-8")
+
+        assert "--profile production" not in compose
+        assert "./nginx.conf:/etc/nginx/nginx.conf:ro" not in compose
+        assert "./ssl:/etc/nginx/ssl:ro" not in compose


### PR DESCRIPTION
## Summary
- sunset the broken built-in nginx production compose path and keep the main Docker Compose deployment focused on the working application + PostgreSQL stack
- align the shipped Kubernetes manifests with the real runtime contract: port 19888, single-instance application deployment, root entrypoint requirements, persistent config/workspace mounts, and dedicated encryption key secret
- add regression coverage for split DB env fallback and the key deployment-manifest invariants, and update README / docs navigation / Kubernetes docs to reflect the current support boundary

## Testing
- pytest tests/issues/1748/test_deployment_alignment.py tests/unit/test_config.py
- python3 -m compileall scripts/shared/config.py tests/issues/1748/test_deployment_alignment.py
- SKIP=bandit,no-commit-to-branch pre-commit run --files scripts/shared/config.py docker-compose.yml k8s/configmap.yaml k8s/deployment.yaml k8s/service.yaml k8s/policies.yaml docs/en/KUBERNETES.md docs/cn/KUBERNETES.md README.md docs/README.md tests/issues/1748/test_deployment_alignment.py

## Notes
- `docker` and `kubectl` are not installed in this workspace, so compose / kustomize runtime rendering could not be executed locally. Static manifest checks and issue-specific regression tests were added instead.

Closes #1748
