### PR TITLE
fix: restore Windows remote terminal support

### DIFF
--- a/docs/cn/REMOTE-AGENT.md
+++ b/docs/cn/REMOTE-AGENT.md
@@ -12,7 +12,7 @@
      │
      ├── subprocess ──► CLI Tool (claude/qwen/codex/openclaw)
      │
-     └── WebSocket ──► Terminal Server (PTY)
+     └── WebSocket ──► Terminal Server（PTY / 管道子进程）
                          │
                     Browser (xterm.js)
 ```
@@ -88,13 +88,15 @@ curl -fsSL https://<server>/api/remote/agent/install.sh | bash -s -- \
 
 ## 终端服务器
 
-终端服务器提供基于 WebSocket 的 PTY 访问：
+终端服务器提供基于 WebSocket 的终端访问：
 
-- **单 PTY 模型** — 每个终端服务器实例一个 PTY
+- **终端进程模型** — Linux/macOS 使用持久 PTY，Windows 使用持久的管道子进程
 - **认证** — 通过查询参数的 HMAC token
-- **重连** — PTY 在 WebSocket 断开后保持；64KB 输出历史用于屏幕恢复
+- **重连** — 终端进程在 WebSocket 断开后保持；64KB 输出历史用于屏幕恢复
 - **调整大小** — JSON 控制消息 `{"type":"resize","cols":N,"rows":N}`
 - **环境** — 自动从代理 token 注入 `ANTHROPIC_API_KEY`/`OPENAI_API_KEY`
+
+在 Windows 上，`openace menu` 会使用编号式文本菜单，而不是 Unix 上基于原始终端的方向键菜单，这样在 PowerShell/cmd 和浏览器终端里都可以继续使用同一套流程。
 
 ## 会话同步
 

--- a/docs/en/REMOTE-AGENT.md
+++ b/docs/en/REMOTE-AGENT.md
@@ -12,7 +12,7 @@ The remote agent is a Python daemon that runs on remote machines to provide AI c
      │
      ├── subprocess ──► CLI Tool (claude/qwen/codex/openclaw)
      │
-     └── WebSocket ──► Terminal Server (PTY)
+     └── WebSocket ──► Terminal Server (PTY / piped subprocess)
                          │
                     Browser (xterm.js)
 ```
@@ -88,13 +88,15 @@ The `openace` command-line tool is installed alongside the agent:
 
 ## Terminal Server
 
-The terminal server provides WebSocket-based PTY access:
+The terminal server provides WebSocket-based terminal access:
 
-- **Single PTY model** — One PTY per terminal server instance
+- **Terminal process model** — Uses a persistent PTY on Linux/macOS and a persistent piped subprocess on Windows
 - **Authentication** — HMAC token via query parameters
-- **Reconnection** — PTY persists across WebSocket disconnects; 64KB output history for screen restore
+- **Reconnection** — Terminal process persists across WebSocket disconnects; 64KB output history for screen restore
 - **Resize** — JSON control messages `{"type":"resize","cols":N,"rows":N}`
 - **Environment** — Auto-injects `ANTHROPIC_API_KEY`/`OPENAI_API_KEY` from proxy tokens
+
+On Windows, `openace menu` uses a numbered text menu instead of the Unix arrow-key raw-terminal UI so the same workflow remains available in PowerShell/cmd and browser terminals.
 
 ## Session Sync
 

--- a/remote-agent/agent.py
+++ b/remote-agent/agent.py
@@ -18,6 +18,7 @@ import socket
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 from datetime import datetime
 from typing import Any
@@ -1817,15 +1818,36 @@ class RemoteAgent:
 
     def _read_terminal_port(self, proc: subprocess.Popen, terminal_id: str) -> int | None:
         """Read the port number from terminal server's READY:port stdout."""
-        import select as _select
-
         try:
-            # Use select to avoid blocking indefinitely
-            ready, _, _ = _select.select([proc.stdout], [], [], 10.0)
-            if not ready:
+            if proc.stdout is None:
+                logger.warning("Terminal process %s has no stdout pipe", terminal_id[:8])
+                return None
+
+            result: dict[str, str | Exception] = {}
+            ready = threading.Event()
+
+            def _reader() -> None:
+                try:
+                    raw = proc.stdout.readline()
+                    if isinstance(raw, bytes):
+                        result["line"] = raw.decode(errors="replace").strip()
+                    else:
+                        result["line"] = raw.strip()
+                except Exception as exc:  # pragma: no cover - defensive
+                    result["error"] = exc
+                finally:
+                    ready.set()
+
+            threading.Thread(target=_reader, daemon=True).start()
+            if not ready.wait(10.0):
                 logger.warning("Timeout waiting for terminal port from %s", terminal_id[:8])
                 return None
-            line = proc.stdout.readline().decode().strip()
+
+            error = result.get("error")
+            if isinstance(error, Exception):
+                raise error
+
+            line = str(result.get("line") or "")
             if line.startswith("READY:"):
                 return int(line.split(":")[1])
         except Exception as e:

--- a/remote-agent/openace_cli.py
+++ b/remote-agent/openace_cli.py
@@ -13,6 +13,7 @@ import getpass
 import json
 import logging
 import os
+import shutil
 import stat
 import subprocess
 import sys
@@ -233,6 +234,22 @@ def _clear_active_terminal() -> None:
         pass
 
 
+def _windows_shell_args() -> list[str]:
+    for candidate in (
+        shutil.which("pwsh"),
+        shutil.which("powershell"),
+        os.environ.get("COMSPEC"),
+        "cmd.exe",
+    ):
+        if not candidate:
+            continue
+        shell_name = os.path.basename(candidate).lower()
+        if shell_name in {"pwsh", "pwsh.exe", "powershell", "powershell.exe"}:
+            return [candidate, "-NoLogo"]
+        return [candidate]
+    return ["cmd.exe"]
+
+
 def cmd_login(args: argparse.Namespace) -> int:
     server_url = _server_url()
     machine_id = _machine_id()
@@ -273,13 +290,6 @@ def cmd_status(_: argparse.Namespace) -> int:
 
 
 def cmd_menu(args: argparse.Namespace) -> int:
-    # Windows does not support termios module used by terminal_menu.py
-    # Fall back to shell mode on Windows
-    if os.name == "nt":
-        print("Note: Interactive menu is not supported on Windows.")
-        print("Starting shell instead. You can run AI tools directly from the shell.\n")
-        return cmd_shell(args)
-
     work_dir = os.path.abspath(args.work_dir or os.getcwd())
     terminal = _start_cli_terminal(work_dir)
     _apply_local_cli_settings(terminal)
@@ -296,10 +306,8 @@ def cmd_shell(args: argparse.Namespace) -> int:
     env = _session_env(terminal)
 
     try:
-        # Windows: use COMSPEC (cmd.exe)
         if os.name == "nt":
-            shell = os.environ.get("COMSPEC") or "cmd.exe"
-            subprocess.run([shell], env=env, cwd=work_dir, check=False)
+            subprocess.run(_windows_shell_args(), env=env, cwd=work_dir, check=False)
         else:
             # Unix/Linux: login shell
             shell = os.environ.get("SHELL") or "/bin/sh"

--- a/remote-agent/terminal_menu.py
+++ b/remote-agent/terminal_menu.py
@@ -13,10 +13,9 @@ from __future__ import annotations
 
 import os
 import shlex
+import shutil
 import subprocess
 import sys
-import termios
-import tty
 from pathlib import Path
 
 TOOLS = [
@@ -54,6 +53,7 @@ TOOLS = [
 
 MENU_PATH = os.path.abspath(__file__)
 ACTIVE_TERMINAL_PATH = Path.home() / ".open-ace-agent" / "active_terminal.json"
+IS_WINDOWS = os.name == "nt"
 
 # ANSI codes
 CLEAR = "\x1b[2J\x1b[H"
@@ -68,11 +68,7 @@ YELLOW = "\x1b[33m"
 
 
 def check_installed(cli_name: str) -> bool:
-    try:
-        result = subprocess.run(["which", cli_name], capture_output=True, timeout=5)
-        return result.returncode == 0
-    except Exception:
-        return False
+    return shutil.which(cli_name) is not None
 
 
 def get_menu_items() -> list[dict]:
@@ -113,7 +109,10 @@ def render_menu(items: list[dict], selected: int) -> None:
         else:
             lines.append(f"    {label}")
     lines.append("")
-    lines.append(f"  {DIM}↑↓ Navigate   Enter Select{RESET}")
+    if IS_WINDOWS:
+        lines.append(f"  {DIM}Type a number, then press Enter{RESET}")
+    else:
+        lines.append(f"  {DIM}↑↓ Navigate   Enter Select{RESET}")
     lines.append("")
 
     output = CLEAR + "\r\n".join(lines)
@@ -124,6 +123,13 @@ def render_menu(items: list[dict], selected: int) -> None:
 def show_message(message: str) -> None:
     sys.stdout.write(f"\r\n  {message}\r\n\r\n  {DIM}Press any key to continue...{RESET}")
     sys.stdout.flush()
+
+
+def wait_for_continue() -> None:
+    if IS_WINDOWS:
+        input("\n  Press Enter to continue...")
+        return
+    os.read(sys.stdin.fileno(), 1)
 
 
 def read_key(fd: int) -> str:
@@ -143,17 +149,30 @@ def read_key(fd: int) -> str:
 
 
 def get_shell_path() -> str:
+    if IS_WINDOWS:
+        for candidate in (
+            shutil.which("pwsh"),
+            shutil.which("powershell"),
+            os.environ.get("COMSPEC"),
+            "cmd.exe",
+        ):
+            if candidate:
+                return candidate
     return os.environ.get("SHELL") or "/bin/sh"
 
 
 def get_login_shell_args() -> list[str]:
     shell = get_shell_path()
+    if IS_WINDOWS:
+        shell_name = os.path.basename(shell).lower()
+        if shell_name in {"pwsh", "pwsh.exe", "powershell", "powershell.exe"}:
+            return [shell, "-NoLogo"]
+        return [shell]
     return [shell, "-l"]
 
 
 def get_login_shell_command() -> str:
-    shell = get_shell_path()
-    return f"{shlex.quote(shell)} -l"
+    return " ".join(shlex.quote(part) for part in get_login_shell_args())
 
 
 def clear_active_terminal() -> None:
@@ -173,6 +192,9 @@ def exec_command(command: str) -> None:
 
 def handle_select(item: dict) -> None:
     if item.get("is_shell_return"):
+        if IS_WINDOWS:
+            subprocess.run(get_login_shell_args(), check=False)
+            return
         cmd = (
             'echo "Type \\"exit\\" to return to the Open ACE menu. '
             'Type \\"openace menu\\" to restart it anytime."; '
@@ -185,7 +207,7 @@ def handle_select(item: dict) -> None:
         sys.stdout.write("\r\n  Type 'openace menu' to return to the Open ACE menu.\r\n\r\n")
         sys.stdout.flush()
         clear_active_terminal()
-        os.execvp(get_shell_path(), get_login_shell_args())
+        os.execvp(get_login_shell_args()[0], get_login_shell_args())
         return
 
     if item["installed"] and not item["configured"]:
@@ -193,7 +215,17 @@ def handle_select(item: dict) -> None:
             f"{BOLD_YELLOW}⚠ {item['name']} is installed but API is not configured.\r\n"
             f"  Please contact your admin to configure the {item['env_key']} token.{RESET}"
         )
-        os.read(sys.stdin.fileno(), 1)
+        wait_for_continue()
+        return
+
+    if IS_WINDOWS:
+        if not item["installed"]:
+            install_result = subprocess.run(item["install_cmd"], shell=True, check=False)
+            if install_result.returncode != 0:
+                show_message(f"{BOLD_RED}Failed to install {item['name']}.{RESET}")
+                wait_for_continue()
+                return
+        subprocess.run(item["cmd"], shell=True, check=False)
         return
 
     if not item["installed"]:
@@ -203,8 +235,55 @@ def handle_select(item: dict) -> None:
     exec_command(cmd)
 
 
+def run_windows_menu() -> None:
+    while True:
+        items = get_menu_items()
+        lines = [
+            "",
+            f"  {BOLD_CYAN}========================================{RESET}",
+            f"  {BOLD_CYAN}  Open ACE Remote Terminal{RESET}",
+            f"  {BOLD_CYAN}========================================{RESET}",
+            "",
+            "  Select a tool:",
+            "",
+        ]
+        for index, item in enumerate(items, start=1):
+            lines.append(f"    {index}. {get_label(item)}")
+        lines.append("")
+        lines.append(f"  {DIM}Type a number and press Enter{RESET}")
+        lines.append("")
+
+        sys.stdout.write(CLEAR + "\r\n".join(lines))
+        sys.stdout.flush()
+
+        choice = input("  Select a tool: ").strip()
+        if not choice:
+            continue
+
+        try:
+            selected = int(choice) - 1
+        except ValueError:
+            show_message(f"{BOLD_RED}Invalid selection.{RESET}")
+            wait_for_continue()
+            continue
+
+        if selected < 0 or selected >= len(items):
+            show_message(f"{BOLD_RED}Selection out of range.{RESET}")
+            wait_for_continue()
+            continue
+
+        handle_select(items[selected])
+
+
 def main() -> None:
+    if IS_WINDOWS:
+        run_windows_menu()
+        return
+
     items = get_menu_items()
+
+    import termios
+    import tty
 
     fd = sys.stdin.fileno()
     old_settings = termios.tcgetattr(fd)

--- a/remote-agent/terminal_relay.py
+++ b/remote-agent/terminal_relay.py
@@ -16,6 +16,7 @@ import asyncio
 import logging
 import os
 import sys
+import tempfile
 
 try:
     import websockets
@@ -152,7 +153,7 @@ def main() -> None:
         sys.exit(1)
 
     # Set up logging
-    log_file = f"/tmp/terminal_relay_{TERMINAL_ID[:8]}.log"
+    log_file = os.path.join(tempfile.gettempdir(), f"terminal_relay_{TERMINAL_ID[:8]}.log")
     logging.basicConfig(
         level=logging.INFO,
         format="%(asctime)s [%(name)s] %(levelname)s: %(message)s",

--- a/remote-agent/terminal_server.py
+++ b/remote-agent/terminal_server.py
@@ -12,19 +12,28 @@ from __future__ import annotations
 
 import argparse
 import asyncio
-import fcntl
 import hmac
 import json
 import logging
 import os
-import pty
 import select
+import shlex
 import signal
 import struct
+import subprocess
 import sys
-import termios
+import tempfile
 import urllib.parse
 from pathlib import Path
+
+if os.name != "nt":
+    import fcntl
+    import pty
+    import termios
+else:  # pragma: no cover - exercised by Windows runtime/tests via monkeypatch
+    fcntl = None
+    pty = None
+    termios = None
 
 from cli_adapters.base import collect_custom_envkeys
 
@@ -63,6 +72,7 @@ class SinglePtyTerminalServer:
     def __init__(self):
         self.master_fd: int | None = None
         self.pty_pid: int | None = None
+        self.process: subprocess.Popen[bytes] | None = None
         self._output_buffer: bytearray = bytearray()
         self._active_websockets: set = set()
         self._pty_alive = True
@@ -70,11 +80,12 @@ class SinglePtyTerminalServer:
         self._ws_lock = asyncio.Lock()
         self._pty_cols = 80
         self._pty_rows = 24
+        self._uses_pty = os.name != "nt"
 
     def spawn_pty(self) -> bool:
         """Spawn PTY process once at startup."""
         if SHELL_CMD:
-            cmd = [SHELL_CMD]
+            cmd = _parse_shell_command(SHELL_CMD)
         else:
             menu_script = os.path.join(
                 os.path.dirname(os.path.abspath(__file__)), "terminal_menu.py"
@@ -84,20 +95,30 @@ class SinglePtyTerminalServer:
         work_dir = WORK_DIR or os.path.expanduser("~")
 
         # Update bashrc with aliases (for "Exit to shell" option)
-        self._update_bashrc()
+        self._update_shell_profile()
 
         try:
-            self.master_fd, self.pty_pid = _spawn_pty(cmd, env, work_dir)
-            logger.info(
-                "PTY spawned: pid=%d fd=%d work_dir=%s", self.pty_pid, self.master_fd, work_dir
-            )
+            if self._uses_pty:
+                self.master_fd, self.pty_pid = _spawn_pty(cmd, env, work_dir)
+                logger.info(
+                    "PTY spawned: pid=%d fd=%d work_dir=%s",
+                    self.pty_pid,
+                    self.master_fd,
+                    work_dir,
+                )
+            else:
+                self.process = _spawn_pipe_process(cmd, env, work_dir)
+                self.pty_pid = self.process.pid
+                logger.info("Pipe terminal spawned: pid=%d work_dir=%s", self.pty_pid, work_dir)
             return True
         except Exception as e:
             logger.error("Failed to spawn PTY: %s", e)
             return False
 
-    def _update_bashrc(self) -> None:
-        """Update bashrc with AI CLI aliases (creates backup first)."""
+    def _update_shell_profile(self) -> None:
+        """Update shell profile with AI CLI aliases on Unix shells."""
+        if os.name == "nt":
+            return
         bashrc_path = os.path.join(os.path.expanduser("~"), ".bashrc")
         try:
             aliases = []
@@ -135,7 +156,7 @@ class SinglePtyTerminalServer:
         """Resize the PTY terminal."""
         self._pty_cols = cols
         self._pty_rows = rows
-        if self.master_fd is not None:
+        if self._uses_pty and self.master_fd is not None:
             try:
                 winsize = struct.pack("HHHH", rows, cols, 0, 0)
                 fcntl.ioctl(self.master_fd, termios.TIOCSWINSZ, winsize)
@@ -190,6 +211,10 @@ class SinglePtyTerminalServer:
 
     async def relay_output_loop(self) -> None:
         """Read PTY output continuously and broadcast to WebSockets."""
+        if not self._uses_pty:
+            await self._relay_pipe_output_loop()
+            return
+
         loop = asyncio.get_event_loop()
         while self._pty_alive and self.master_fd is not None:
             try:
@@ -216,6 +241,27 @@ class SinglePtyTerminalServer:
                 break
 
         # PTY exited - notify all WebSockets
+        if not self._pty_alive:
+            await self._notify_pty_exit()
+
+    async def _relay_pipe_output_loop(self) -> None:
+        """Read subprocess output continuously and broadcast to WebSockets."""
+        loop = asyncio.get_event_loop()
+        while self._pty_alive and self.process is not None and self.process.stdout is not None:
+            try:
+                reader = getattr(self.process.stdout, "read1", self.process.stdout.read)
+                data = await loop.run_in_executor(None, reader, 65536)
+                if data:
+                    await self.broadcast_output(data)
+                else:
+                    logger.info("Terminal output stream closed (process likely exited)")
+                    self._pty_alive = False
+                    break
+            except Exception as e:
+                logger.error("Output relay error: %s", e)
+                self._pty_alive = False
+                break
+
         if not self._pty_alive:
             await self._notify_pty_exit()
 
@@ -250,7 +296,11 @@ class SinglePtyTerminalServer:
 
                 if isinstance(message, bytes):
                     try:
-                        os.write(self.master_fd, message)
+                        if self._uses_pty:
+                            os.write(self.master_fd, message)
+                        elif self.process is not None and self.process.stdin is not None:
+                            self.process.stdin.write(message)
+                            self.process.stdin.flush()
                     except OSError as e:
                         logger.warning("PTY write error: %s", e)
                         break
@@ -262,7 +312,7 @@ class SinglePtyTerminalServer:
     def kill_pty(self) -> None:
         """Terminate the PTY process."""
         self._pty_alive = False
-        if self.pty_pid is not None:
+        if self._uses_pty and self.pty_pid is not None:
             try:
                 os.kill(self.pty_pid, signal.SIGTERM)
                 logger.info("Sent SIGTERM to PTY pid=%d", self.pty_pid)
@@ -270,15 +320,44 @@ class SinglePtyTerminalServer:
                 pass
             except Exception as e:
                 logger.warning("Failed to kill PTY: %s", e)
+        elif self.process is not None:
+            try:
+                self.process.terminate()
+                self.process.wait(timeout=5)
+                logger.info("Terminated terminal process pid=%d", self.process.pid)
+            except subprocess.TimeoutExpired:
+                self.process.kill()
+            except Exception as e:
+                logger.warning("Failed to kill terminal process: %s", e)
         if self.master_fd is not None:
             try:
                 os.close(self.master_fd)
             except OSError:
                 pass
             self.master_fd = None
+        if self.process is not None:
+            for stream_name in ("stdin", "stdout", "stderr"):
+                stream = getattr(self.process, stream_name, None)
+                if stream is None:
+                    continue
+                try:
+                    stream.close()
+                except Exception:
+                    pass
+            self.process = None
 
     def is_pty_alive(self) -> bool:
         """Check if PTY process is still running."""
+        if not self._uses_pty:
+            if self.process is None:
+                return False
+            return_code = self.process.poll()
+            if return_code is None:
+                return True
+            logger.info("Terminal process %d exited with status %d", self.process.pid, return_code)
+            self._pty_alive = False
+            return False
+
         if self.pty_pid is None:
             return False
         try:
@@ -312,6 +391,35 @@ def _spawn_pty(shell_cmd: list[str], env: dict[str, str], work_dir: str) -> tupl
             print(f"Shell not found: {shell_cmd[0]}", file=sys.stderr)
             os._exit(1)
     return master_fd, pid
+
+
+def _spawn_pipe_process(
+    shell_cmd: list[str], env: dict[str, str], work_dir: str
+) -> subprocess.Popen[bytes]:
+    """Spawn a subprocess with stdin/stdout pipes for Windows-compatible terminal I/O."""
+    cwd = work_dir or os.path.expanduser("~")
+    if not os.path.isdir(cwd):
+        cwd = os.path.expanduser("~")
+
+    creationflags = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+    return subprocess.Popen(
+        shell_cmd,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        env=env,
+        cwd=cwd,
+        bufsize=0,
+        creationflags=creationflags,
+    )
+
+
+def _parse_shell_command(command: str) -> list[str]:
+    """Split a user-provided shell command into argv with platform-aware rules."""
+    try:
+        return shlex.split(command, posix=os.name != "nt")
+    except ValueError:
+        return [command]
 
 
 def _build_env() -> dict[str, str]:
@@ -458,7 +566,12 @@ def main() -> None:
         format="%(asctime)s [%(name)s] %(levelname)s: %(message)s",
         handlers=[
             # Log to file to avoid filling stderr pipe buffer
-            logging.FileHandler(f"/tmp/terminal_server_{args.terminal_id[:8]}.log"),
+            logging.FileHandler(
+                os.path.join(
+                    tempfile.gettempdir(),
+                    f"terminal_server_{args.terminal_id[:8]}.log",
+                )
+            ),
         ],
     )
 
@@ -475,7 +588,10 @@ def main() -> None:
         loop.stop()
 
     for sig in (signal.SIGTERM, signal.SIGINT):
-        loop.add_signal_handler(sig, _shutdown_handler)
+        try:
+            loop.add_signal_handler(sig, _shutdown_handler)
+        except NotImplementedError:
+            signal.signal(sig, lambda *_: _shutdown_handler())
 
     try:
         loop.run_until_complete(_run_server(port))

--- a/tests/unit/test_openace_cli.py
+++ b/tests/unit/test_openace_cli.py
@@ -168,3 +168,38 @@ def test_clear_active_terminal_metadata(monkeypatch, tmp_path):
     openace_cli._clear_active_terminal()
 
     assert not active_path.exists()
+
+
+def test_cmd_menu_execs_terminal_menu_on_windows(monkeypatch):
+    openace_cli = load_openace_cli()
+    calls = {}
+
+    monkeypatch.setattr(openace_cli.os, "name", "nt", raising=False)
+    monkeypatch.setattr(
+        openace_cli,
+        "_start_cli_terminal",
+        lambda work_dir: {"session_id": "term-123", "proxy_url": "https://openace.example"},
+    )
+    monkeypatch.setattr(openace_cli, "_apply_local_cli_settings", lambda terminal: None)
+    monkeypatch.setattr(openace_cli, "_write_active_terminal", lambda terminal: None)
+    monkeypatch.setattr(openace_cli, "_session_env", lambda terminal: {"ENV": "1"})
+
+    def fake_execvpe(file, argv, env):
+        calls["file"] = file
+        calls["argv"] = argv
+        calls["env"] = env
+        raise RuntimeError("stop")
+
+    monkeypatch.setattr(openace_cli.os, "execvpe", fake_execvpe)
+
+    args = type("Args", (), {"work_dir": "/repo"})()
+    try:
+        openace_cli.cmd_menu(args)
+    except RuntimeError as exc:
+        assert str(exc) == "stop"
+    else:  # pragma: no cover - defensive
+        raise AssertionError("cmd_menu did not attempt to exec the terminal menu")
+
+    assert calls["file"] == openace_cli.sys.executable
+    assert calls["argv"] == [openace_cli.sys.executable, str(openace_cli.MENU_PATH)]
+    assert calls["env"] == {"ENV": "1"}

--- a/tests/unit/test_remote_agent_terminal.py
+++ b/tests/unit/test_remote_agent_terminal.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Unit tests for remote-agent terminal management helpers."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def load_agent_module():
+    module_path = Path(__file__).resolve().parents[2] / "remote-agent" / "agent.py"
+    agent_dir = module_path.parent
+    if str(agent_dir) in sys.path:
+        sys.path.remove(str(agent_dir))
+    sys.path.insert(0, str(agent_dir))
+    sys.modules.pop("config", None)
+    spec = importlib.util.spec_from_file_location("remote_agent", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_read_terminal_port_returns_ready_port():
+    agent_module = load_agent_module()
+    agent = agent_module.RemoteAgent.__new__(agent_module.RemoteAgent)
+
+    class FakeStdout:
+        def readline(self):
+            return b"READY:31337\n"
+
+    proc = type("Proc", (), {"stdout": FakeStdout()})()
+
+    assert agent._read_terminal_port(proc, "terminal-123") == 31337
+
+
+def test_read_terminal_port_rejects_non_ready_line():
+    agent_module = load_agent_module()
+    agent = agent_module.RemoteAgent.__new__(agent_module.RemoteAgent)
+
+    class FakeStdout:
+        def readline(self):
+            return b"BOOTING\n"
+
+    proc = type("Proc", (), {"stdout": FakeStdout()})()
+
+    assert agent._read_terminal_port(proc, "terminal-123") is None

--- a/tests/unit/test_terminal_menu.py
+++ b/tests/unit/test_terminal_menu.py
@@ -65,3 +65,29 @@ def test_menu_includes_shell_return_and_permanent_exit(monkeypatch):
     assert any(item.get("is_shell_return") for item in items)
     assert any(item.get("is_shell_exit") for item in items)
     assert any(item["name"] == "Claude Code" and not item["installed"] for item in items)
+
+
+def test_handle_select_runs_command_via_subprocess_on_windows(monkeypatch):
+    terminal_menu = load_terminal_menu()
+    calls = []
+
+    class Result:
+        returncode = 0
+
+    def fake_run(command, shell=False, check=False):
+        calls.append((command, shell, check))
+        return Result()
+
+    monkeypatch.setattr(terminal_menu, "IS_WINDOWS", True)
+    monkeypatch.setattr(terminal_menu.subprocess, "run", fake_run)
+
+    terminal_menu.handle_select(
+        {
+            "name": "Claude Code",
+            "installed": True,
+            "configured": True,
+            "cmd": "claude --bare",
+        }
+    )
+
+    assert calls == [("claude --bare", True, False)]

--- a/tests/unit/test_terminal_server.py
+++ b/tests/unit/test_terminal_server.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Unit tests for the remote terminal server."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def load_terminal_server():
+    module_path = Path(__file__).resolve().parents[2] / "remote-agent" / "terminal_server.py"
+    agent_dir = module_path.parent
+    if str(agent_dir) not in sys.path:
+        sys.path.insert(0, str(agent_dir))
+    spec = importlib.util.spec_from_file_location("terminal_server", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_spawn_pty_uses_pipe_process_on_windows(monkeypatch):
+    terminal_server = load_terminal_server()
+    monkeypatch.setattr(terminal_server.os, "name", "nt", raising=False)
+
+    calls = {}
+
+    class FakeProc:
+        pid = 4321
+        stdin = None
+        stdout = None
+        stderr = None
+
+        def poll(self):
+            return None
+
+    def fake_spawn_pipe(cmd, env, work_dir):
+        calls["cmd"] = cmd
+        calls["env"] = env
+        calls["work_dir"] = work_dir
+        return FakeProc()
+
+    monkeypatch.setattr(terminal_server, "WORK_DIR", "C:/repo")
+    monkeypatch.setattr(terminal_server, "SHELL_CMD", "")
+    monkeypatch.setattr(terminal_server, "_build_env", lambda: {"OPENAI_API_KEY": "token"})
+    monkeypatch.setattr(terminal_server, "_spawn_pipe_process", fake_spawn_pipe)
+
+    server = terminal_server.SinglePtyTerminalServer()
+    monkeypatch.setattr(server, "_update_shell_profile", lambda: None)
+
+    assert server.spawn_pty() is True
+    assert server.process is not None
+    assert server.process.pid == 4321
+    assert server.master_fd is None
+    assert calls["work_dir"] == "C:/repo"
+    assert calls["cmd"][0] == terminal_server.sys.executable
+    assert calls["cmd"][1].endswith("terminal_menu.py")


### PR DESCRIPTION
## Summary
- make the remote terminal server start on Windows by avoiding Unix-only PTY assumptions at import/runtime
- keep `openace menu` available on Windows with a compatible numbered text menu and PowerShell/cmd shell selection
- switch terminal port handshakes and relay logging to Windows-safe implementations, with focused regression tests

## Testing
- `ruff check remote-agent/openace_cli.py remote-agent/terminal_menu.py remote-agent/terminal_server.py remote-agent/agent.py remote-agent/terminal_relay.py tests/unit/test_openace_cli.py tests/unit/test_terminal_menu.py tests/unit/test_terminal_server.py tests/unit/test_remote_agent_terminal.py`
- `pytest tests/unit/test_openace_cli.py tests/unit/test_terminal_menu.py tests/unit/test_terminal_server.py tests/unit/test_remote_agent_terminal.py tests/unit/test_remote_agent_installer.py -q`

Closes #1765.
