### PR TITLE
feat: add dingtalk identity resolution for imported sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ python3 server.py
 | 角色权限 | 管理员/普通用户角色区分 |
 | SSO 集成 | 支持企业单点登录 |
 | 飞书同步 | 自动同步飞书组织架构 |
+| 钉钉解析 | 导入 OpenClaw 会话时解析钉钉用户名和群名称 |
 
 ### 📋 合规与报表
 
@@ -301,6 +302,7 @@ open-ace/
 | [权限模型](docs/cn/PERMISSION-MODEL.md) | 租户、角色与访问控制 |
 | [Kubernetes](docs/cn/KUBERNETES.md) | K8s 单实例参考部署 |
 | [飞书配置](docs/cn/FEISHU_CONFIG.md) | 飞书集成配置 |
+| [钉钉配置](docs/cn/DINGTALK_CONFIG.md) | 钉钉集成配置 |
 | [API 文档](docs/cn/API.md) | API 接口说明 |
 | [仓库设置](docs/REPOSITORY_SETUP.md) | GitHub topics、labels、分支保护和发布检查清单 |
 
@@ -517,6 +519,7 @@ python3 server.py
 | Role Permissions | Admin/user role distinction |
 | SSO Integration | Enterprise single sign-on support |
 | Feishu Sync | Auto-sync Feishu organization structure |
+| DingTalk Resolution | Resolve DingTalk user and group names during OpenClaw import |
 
 ### 📋 Compliance and Reporting
 
@@ -604,6 +607,7 @@ The `docs/` directory is the source of truth for product documentation. The publ
 | [Permission Model](docs/en/PERMISSION-MODEL.md) | Tenants, roles, and access control |
 | [Kubernetes](docs/en/KUBERNETES.md) | Single-instance K8s deployment reference |
 | [Feishu Config](docs/en/FEISHU_CONFIG.md) | Feishu integration |
+| [DingTalk Config](docs/en/DINGTALK_CONFIG.md) | DingTalk integration |
 | [API Reference](docs/en/API.md) | API documentation |
 | [Repository Setup](docs/REPOSITORY_SETUP.md) | GitHub topics, labels, branch protection, and release checklist |
 

--- a/app/models/user_tool_account.py
+++ b/app/models/user_tool_account.py
@@ -2,7 +2,7 @@
 Open ACE - User Tool Account Model
 
 Model for mapping users to their tool accounts (sender_name in different tools).
-Supports multi-source accounts: Slack, Feishu, Qwen, Claude, Openclaw, etc.
+Supports multi-source accounts: Slack, Feishu, DingTalk, Qwen, Claude, Openclaw, etc.
 """
 
 from dataclasses import dataclass
@@ -17,7 +17,7 @@ class UserToolAccount:
     id: int
     user_id: int
     tool_account: str  # sender_name in the tool
-    tool_type: Optional[str] = None  # qwen, claude, openclaw, feishu, slack, etc.
+    tool_type: Optional[str] = None  # qwen, claude, openclaw, feishu, dingtalk, slack, etc.
     description: Optional[str] = None
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
@@ -43,6 +43,7 @@ TOOL_TYPES = {
     "codex": "Codex",
     "zcode": "ZCode",
     "feishu": "飞书",
+    "dingtalk": "钉钉",
     "slack": "Slack",
     "other": "其他",
 }

--- a/app/routes/tool_accounts.py
+++ b/app/routes/tool_accounts.py
@@ -82,6 +82,8 @@ def get_unmapped_tool_accounts():
                 tool_type = "openclaw"
             elif sender_name.startswith("ou_"):
                 tool_type = "feishu"
+            elif "-dingtalk" in sender_name:
+                tool_type = "dingtalk"
 
         result.append(
             {

--- a/config/CONFIG_GUIDE.md
+++ b/config/CONFIG_GUIDE.md
@@ -117,6 +117,12 @@
 | `feishu.app_id` | 飞书应用 App ID | `cli_xxxxxxxxxxxxx` |
 | `feishu.app_secret` | 飞书应用 Secret | `xxxxxxxxxxxxxxxxx` |
 
+#### 钉钉集成（可选）
+| 参数 | 说明 | 示例值 |
+|------|------|--------|
+| `dingtalk.app_key` | 钉钉内部应用 AppKey | `dingxxxxxxxxxxxxxx` |
+| `dingtalk.app_secret` | 钉钉内部应用 AppSecret | `xxxxxxxxxxxxxxxxx` |
+
 ---
 
 ## 配置步骤

--- a/config/config.json.sample
+++ b/config/config.json.sample
@@ -53,6 +53,10 @@
     "app_id": "<FEISHU_APP_ID>",
     "app_secret": "<FEISHU_APP_SECRET>"
   },
+  "dingtalk": {
+    "app_key": "<DINGTALK_APP_KEY>",
+    "app_secret": "<DINGTALK_APP_SECRET>"
+  },
   "auth": {
     "auth_type": "openai",
     "env": {

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,7 @@ Documentation files are in the [en/](en/) directory.
 | [**NGINX**](en/NGINX.md) | Nginx reverse proxy configuration for HTTPS and WebSocket |
 | [**DEVELOPMENT**](en/DEVELOPMENT.md) | Development environment setup, project structure, and testing |
 | [**FEISHU-CONFIG**](en/FEISHU_CONFIG.md) | Feishu/Lark integration configuration guide |
+| [**DINGTALK-CONFIG**](en/DINGTALK_CONFIG.md) | DingTalk integration configuration guide |
 | [**CONCEPTS**](en/CONCEPTS.md) | Core concept definitions — Request, Message, Session, Conversation |
 | [**TOKEN-ACCOUNTING**](en/token-accounting.md) | Deep dive into Claude / Codex / ZCode / Qwen token collection, computation, storage, and downstream usage |
 | [**REPOSITORY-SETUP**](REPOSITORY_SETUP.md) | GitHub repository topics, labels, releases, and demo checklist |
@@ -66,6 +67,7 @@ Documentation files are in the [en/](en/) directory.
 | [**NGINX**](cn/NGINX.md) | Nginx 反向代理配置（HTTPS 和 WebSocket） |
 | [**DEVELOPMENT**](cn/DEVELOPMENT.md) | 开发环境搭建、项目结构和测试 |
 | [**FEISHU-CONFIG**](cn/FEISHU_CONFIG.md) | 飞书集成配置指南 |
+| [**DINGTALK-CONFIG**](cn/DINGTALK_CONFIG.md) | 钉钉集成配置指南 |
 | [**CONCEPTS**](cn/CONCEPTS.md) | 核心概念定义 — Request、Message、Session、Conversation |
 | [**TOKEN-ACCOUNTING**](cn/token-accounting.md) | Claude / Codex / ZCode / Qwen token 抓取、计算、落库和下游消费链路说明 |
 | [**REPOSITORY-SETUP**](REPOSITORY_SETUP.md) | GitHub 仓库 topics、labels、releases 和 Demo 检查清单 |
@@ -89,8 +91,8 @@ Documentation files are in the [en/](en/) directory.
 ```
 docs/
 ├── README.md          ← You are here / 你在这里
-├── en/                # English documentation (16 files)
-├── cn/                # 中文文档（16 个文件）
+├── en/                # English documentation (17 files)
+├── cn/                # 中文文档（17 个文件）
 ├── marketing/         # Launch and outreach materials / 发布传播材料
 └── images/            # Documentation images / 文档图片
 ```

--- a/docs/cn/DINGTALK_CONFIG.md
+++ b/docs/cn/DINGTALK_CONFIG.md
@@ -1,0 +1,85 @@
+# 钉钉集成配置
+
+本指南说明如何配置钉钉集成，使 Open ACE 在导入 OpenClaw 会话日志时能够解析钉钉用户名和群名称。
+
+## 概述
+
+Open ACE 可以与钉钉集成以实现：
+
+- 显示真实的钉钉用户名，而不是原始 `userId`
+- 在元数据包含群 `chatId` 时，显示钉钉群名称，而不是原始群标识
+
+当前支持范围：
+
+- OpenClaw 消息导入链路
+- 钉钉用户名解析
+- 元数据包含 DingTalk `chatId` 时的群名解析
+
+## 前置条件
+
+1. 一个钉钉开发者账号
+2. 一个具有 API 调用权限的企业内部应用
+3. 该应用的 AppKey 和 AppSecret
+
+## 配置步骤
+
+### 1. 创建钉钉应用
+
+1. 打开钉钉开放平台
+2. 创建企业内部应用
+3. 保存 **AppKey** 和 **AppSecret**
+
+### 2. 配置 Open ACE
+
+编辑 `~/.open-ace/config.json`：
+
+```json
+{
+  "dingtalk": {
+    "app_key": "dingxxxxxxxxxxxxxx",
+    "app_secret": "your_app_secret_here"
+  }
+}
+```
+
+### 3. 测试配置
+
+```bash
+# 测试用户名解析
+python3 scripts/shared/dingtalk_user_cache.py test manager123 <app_key> <app_secret>
+
+# 测试群名解析
+python3 scripts/shared/dingtalk_group_cache.py test chatabcd1234 <app_key> <app_secret>
+```
+
+## 缓存管理
+
+| 命令 | 说明 |
+|------|------|
+| `python3 scripts/shared/dingtalk_user_cache.py list` | 列出缓存的用户 |
+| `python3 scripts/shared/dingtalk_user_cache.py clear` | 清除用户缓存 |
+| `python3 scripts/shared/dingtalk_group_cache.py list` | 列出缓存的群组 |
+| `python3 scripts/shared/dingtalk_group_cache.py clear` | 清除群组缓存 |
+
+缓存文件：
+
+- `~/.open-ace/dingtalk_users.json`
+- `~/.open-ace/dingtalk_groups.json`
+
+## 故障排查
+
+### 用户名没有解析出来
+
+- 检查钉钉应用凭证是否正确
+- 确认应用具备调用用户详情 API 的权限
+- 确认导入的会话元数据包含 DingTalk `sender_id`
+
+### 群名没有解析出来
+
+- 确认导入的会话元数据包含钉钉 `chatId`
+- 检查应用是否具备调用群信息 API 的权限
+- 确认缓存标签中包含 `chat...` 形式的标识
+
+## 禁用集成
+
+如需禁用钉钉集成，请从配置文件中删除 `dingtalk` 配置段。

--- a/docs/cn/INTRO.md
+++ b/docs/cn/INTRO.md
@@ -498,6 +498,7 @@ docker compose restart
 | [DEPLOYMENT.md](./DEPLOYMENT.md) | 部署指南（本地、Docker、企业） |
 | [DEVELOPMENT.md](./DEVELOPMENT.md) | 开发设置和贡献指南 |
 | [FEISHU_CONFIG.md](./FEISHU_CONFIG.md) | 飞书集成配置 |
+| [DINGTALK_CONFIG.md](./DINGTALK_CONFIG.md) | 钉钉集成配置 |
 
 ---
 

--- a/docs/en/DINGTALK_CONFIG.md
+++ b/docs/en/DINGTALK_CONFIG.md
@@ -1,0 +1,85 @@
+# DingTalk Integration Configuration
+
+This guide explains how to configure DingTalk integration so Open ACE can resolve DingTalk user names and group names from imported OpenClaw session logs.
+
+## Overview
+
+Open ACE can integrate with DingTalk to:
+
+- Display real DingTalk user names instead of raw `userId` values
+- Display DingTalk group names instead of raw `chatId` metadata when available
+
+Current scope:
+
+- OpenClaw message import path
+- DingTalk user name resolution
+- DingTalk group name resolution when session metadata contains a DingTalk `chatId`
+
+## Prerequisites
+
+1. A DingTalk developer account
+2. An internal enterprise application with API access
+3. An AppKey and AppSecret for that application
+
+## Setup
+
+### 1. Create a DingTalk app
+
+1. Visit the DingTalk Open Platform
+2. Create an internal enterprise application
+3. Save the **AppKey** and **AppSecret**
+
+### 2. Configure Open ACE
+
+Edit `~/.open-ace/config.json`:
+
+```json
+{
+  "dingtalk": {
+    "app_key": "dingxxxxxxxxxxxxxx",
+    "app_secret": "your_app_secret_here"
+  }
+}
+```
+
+### 3. Test configuration
+
+```bash
+# Test user name lookup
+python3 scripts/shared/dingtalk_user_cache.py test manager123 <app_key> <app_secret>
+
+# Test group name lookup
+python3 scripts/shared/dingtalk_group_cache.py test chatabcd1234 <app_key> <app_secret>
+```
+
+## Cache management
+
+| Command | Description |
+|---------|-------------|
+| `python3 scripts/shared/dingtalk_user_cache.py list` | List cached users |
+| `python3 scripts/shared/dingtalk_user_cache.py clear` | Clear user cache |
+| `python3 scripts/shared/dingtalk_group_cache.py list` | List cached groups |
+| `python3 scripts/shared/dingtalk_group_cache.py clear` | Clear group cache |
+
+Cache files:
+
+- `~/.open-ace/dingtalk_users.json`
+- `~/.open-ace/dingtalk_groups.json`
+
+## Troubleshooting
+
+### User names are not resolving
+
+- Check that the DingTalk app credentials are correct
+- Verify the app can call user-detail APIs
+- Confirm the imported session metadata contains a DingTalk `sender_id`
+
+### Group names are not resolving
+
+- Confirm the imported session metadata contains a DingTalk `chatId`
+- Check that the app can call group-info APIs
+- Verify the cached label includes a `chat...` identifier
+
+## Disabling integration
+
+To disable DingTalk integration, remove the `dingtalk` section from your config file.

--- a/docs/en/INTRO.md
+++ b/docs/en/INTRO.md
@@ -498,6 +498,7 @@ Password: admin123
 | [DEPLOYMENT.md](./DEPLOYMENT.md) | Deployment guides (local, Docker, enterprise) |
 | [DEVELOPMENT.md](./DEVELOPMENT.md) | Development setup & contribution guide |
 | [FEISHU_CONFIG.md](./FEISHU_CONFIG.md) | Feishu integration configuration |
+| [DINGTALK_CONFIG.md](./DINGTALK_CONFIG.md) | DingTalk integration configuration |
 
 ---
 

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -1750,6 +1750,11 @@ table .latency-row:hover td {
   color: white;
 }
 
+.message-source.dingtalk {
+  background-color: #1677ff;
+  color: white;
+}
+
 .message-source.openclaw {
   background-color: var(--color-info);
   color: white;

--- a/frontend/src/utils/formatToolName.test.ts
+++ b/frontend/src/utils/formatToolName.test.ts
@@ -13,6 +13,7 @@ describe('formatToolName', () => {
     expect(formatToolName('openai')).toBe('OpenAI');
     expect(formatToolName('codex')).toBe('Codex');
     expect(formatToolName('zcode')).toBe('ZCode');
+    expect(formatToolName('dingtalk')).toBe('DingTalk');
     expect(formatToolName('run_shell_command')).toBe('Shell');
   });
 
@@ -45,6 +46,7 @@ describe('TOOL_DISPLAY_NAMES', () => {
     expect(TOOL_DISPLAY_NAMES).toHaveProperty('openai');
     expect(TOOL_DISPLAY_NAMES).toHaveProperty('codex');
     expect(TOOL_DISPLAY_NAMES).toHaveProperty('zcode');
+    expect(TOOL_DISPLAY_NAMES).toHaveProperty('dingtalk');
     expect(TOOL_DISPLAY_NAMES).toHaveProperty('run_shell_command');
   });
 });

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -43,6 +43,7 @@ const TOOL_DISPLAY_NAMES: Record<string, string> = {
   openai: 'OpenAI',
   codex: 'Codex',
   zcode: 'ZCode',
+  dingtalk: 'DingTalk',
   run_shell_command: 'Shell',
 };
 

--- a/scripts/fetch_openclaw.py
+++ b/scripts/fetch_openclaw.py
@@ -33,10 +33,10 @@ shared_dir = os.path.join(script_dir, "shared")
 if shared_dir not in sys.path:
     sys.path.insert(0, shared_dir)
 
-import feishu_group_cache
-import feishu_user_cache
 import dingtalk_group_cache
 import dingtalk_user_cache
+import feishu_group_cache
+import feishu_user_cache
 import utils
 
 from shared import db
@@ -1123,8 +1123,8 @@ def process_jsonl_file(
                                 and sender_id
                                 and (not sender_name or sender_name == sender_id)
                             ):
-                                cached_name = (
-                                    dingtalk_user_cache.get_user_display_name_from_cache(sender_id)
+                                cached_name = dingtalk_user_cache.get_user_display_name_from_cache(
+                                    sender_id
                                 )
                                 if cached_name:
                                     sender_name = cached_name

--- a/scripts/fetch_openclaw.py
+++ b/scripts/fetch_openclaw.py
@@ -35,6 +35,8 @@ if shared_dir not in sys.path:
 
 import feishu_group_cache
 import feishu_user_cache
+import dingtalk_group_cache
+import dingtalk_user_cache
 import utils
 
 from shared import db
@@ -703,9 +705,10 @@ def extract_user_message_metadata(text: str) -> Optional[dict]:
     - Conversation info (untrusted metadata)
     - Sender (untrusted metadata)
     - [message_id: ...]
-    - Channel info from slack/feishu
+    - Channel info from slack/feishu/dingtalk
     - System: [...] Slack message in #channel from User: content
     - System: [...] Feishu[default] message in group XXX: ACTUAL_CONTENT
+    - System: [...] DingTalk[default] message in group XXX: ACTUAL_CONTENT
 
     This function extracts the actual user content and sender information.
     """
@@ -723,7 +726,9 @@ def extract_user_message_metadata(text: str) -> Optional[dict]:
     is_group_chat = None
 
     # ========== Step 1: Detect message source ==========
-    if "conversation_label" in text or "Feishu" in text:
+    if '"message_source": "dingtalk"' in text or "DingTalk" in text or "钉钉" in text:
+        message_source = "dingtalk"
+    elif "conversation_label" in text or "Feishu" in text:
         message_source = "feishu"
     elif "Slack" in text:
         message_source = "slack"
@@ -756,7 +761,28 @@ def extract_user_message_metadata(text: str) -> Optional[dict]:
             "message_source": "feishu",
         }
 
-    # ========== Step 3: Handle Slack System message format ==========
+    # ========== Step 3: Handle DingTalk System message format ==========
+    dingtalk_system_match = re.search(
+        r"System:\s*\[[^\]]+\]\s*DingTalk\[[^\]]*\]\s*(?:message\s+in\s+group\s+\S+|message\s+from\s+\S+):\s*(.+?)(?:\n\nConversation info|$)",
+        text,
+        re.DOTALL,
+    )
+    if dingtalk_system_match:
+        actual_content = dingtalk_system_match.group(1).strip()
+        sender_name_match = re.search(r'"label":\s*"([^"]+)"', text)
+        if sender_name_match:
+            sender_name = sender_name_match.group(1)
+        sender_id_match = re.search(r'"sender_id":\s*"([^"]+)"', text)
+        if sender_id_match:
+            sender_id = sender_id_match.group(1)
+        return {
+            "sender_id": sender_id,
+            "sender_name": sender_name,
+            "cleaned_content": actual_content,
+            "message_source": "dingtalk",
+        }
+
+    # ========== Step 4: Handle Slack System message format ==========
     # Pattern: "System: [...] Slack message in #channel from Name: ACTUAL_CONTENT"
     slack_match = re.search(
         r"Slack\s+(?:message\s+in\s+\S+\s+from|DM\s+from)\s+([^:]+):\s*(.+?)(?:\n\nConversation info|$)",
@@ -780,7 +806,7 @@ def extract_user_message_metadata(text: str) -> Optional[dict]:
             "message_source": "slack",
         }
 
-    # ========== Step 4: Handle simple sender_id: content format ==========
+    # ========== Step 5: Handle simple sender_id: content format ==========
     # Pattern: "ou_xxxxx: content" or "on_xxxxx: content" or "oc_xxxxx: content" or "Uxxxx: content"
     simple_match = re.match(
         r"^(ou_[a-f0-9]+|on_[a-f0-9]+|oc_[a-f0-9]+|U[A-Z0-9]+):\s*(.+)$", text.strip(), re.DOTALL
@@ -802,7 +828,7 @@ def extract_user_message_metadata(text: str) -> Optional[dict]:
             "message_source": message_source,
         }
 
-    # ========== Step 5: Fallback - try to extract content from metadata blocks ==========
+    # ========== Step 6: Fallback - try to extract content from metadata blocks ==========
     # Remove ```json``` code blocks
     content = re.sub(r"```json\s*\n?\s*```", "", text)
     content = re.sub(r"```\s*\n?\s*```", "", content)
@@ -889,8 +915,11 @@ def extract_user_message_metadata(text: str) -> Optional[dict]:
                         sender_id = data.get("sender_id")
                     if "sender" in data and not sender_id:
                         sender_id = data.get("sender")
+                    source_value = data.get("message_source") or data.get("source")
+                    if isinstance(source_value, str) and source_value.lower() == "dingtalk":
+                        message_source = "dingtalk"
                     # Only extract sender_name from Sender metadata blocks (have 'id' field starting with ou_/on_/oc_)
-                    # This prevents extracting 'name' from other JSON blocks like Gitee repo lists
+                    # or from DingTalk sender metadata once source is known.
                     block_id = data.get("id", "")
                     if (
                         block_id
@@ -899,6 +928,7 @@ def extract_user_message_metadata(text: str) -> Optional[dict]:
                             block_id.startswith("ou_")
                             or block_id.startswith("on_")
                             or block_id.startswith("oc_")
+                            or message_source == "dingtalk"
                         )
                     ):
                         if "label" in data and data.get("label") != sender_id:
@@ -1051,6 +1081,21 @@ def process_jsonl_file(
                                     if group_name:
                                         group_subject = group_name
 
+                            if message_source == "dingtalk" and (
+                                not group_subject and conversation_label
+                            ):
+                                dingtalk_config = utils.load_config().get("dingtalk", {})
+                                app_key = dingtalk_config.get("app_key")
+                                app_secret = dingtalk_config.get("app_secret")
+                                if app_key and app_secret:
+                                    group_name = (
+                                        dingtalk_group_cache.get_group_name_from_conversation_label(
+                                            conversation_label, app_key, app_secret
+                                        )
+                                    )
+                                    if group_name:
+                                        group_subject = group_name
+
                             # Try to get Feishu user name if not already found
                             if (
                                 message_source == "feishu"
@@ -1069,6 +1114,27 @@ def process_jsonl_file(
                                     if app_id and app_secret:
                                         api_name = feishu_user_cache.get_user_name(
                                             sender_id, app_id, app_secret
+                                        )
+                                        if api_name:
+                                            sender_name = api_name
+
+                            if (
+                                message_source == "dingtalk"
+                                and sender_id
+                                and (not sender_name or sender_name == sender_id)
+                            ):
+                                cached_name = (
+                                    dingtalk_user_cache.get_user_display_name_from_cache(sender_id)
+                                )
+                                if cached_name:
+                                    sender_name = cached_name
+                                else:
+                                    dingtalk_config = utils.load_config().get("dingtalk", {})
+                                    app_key = dingtalk_config.get("app_key")
+                                    app_secret = dingtalk_config.get("app_secret")
+                                    if app_key and app_secret:
+                                        api_name = dingtalk_user_cache.get_user_display_name(
+                                            sender_id, app_key, app_secret
                                         )
                                         if api_name:
                                             sender_name = api_name

--- a/scripts/install-central/package-method/README.md
+++ b/scripts/install-central/package-method/README.md
@@ -226,6 +226,8 @@ cd /home/openace && python3 server.py
 
 - `~/.open-ace/config.json` - 配置文件
 - `~/.open-ace/feishu_users.json` - 飞书用户配置
+- `~/.open-ace/dingtalk_users.json` - 钉钉用户缓存
+- `~/.open-ace/dingtalk_groups.json` - 钉钉群缓存
 - `logs/` - 日志目录
 
 ## 卸载

--- a/scripts/install-central/package-method/install.sh
+++ b/scripts/install-central/package-method/install.sh
@@ -1404,6 +1404,8 @@ DATA_FILES=(
     "usage.db"
     "config.json"
     "feishu_users.json"
+    "dingtalk_users.json"
+    "dingtalk_groups.json"
     "upload_marker.json"
 )
 

--- a/scripts/manage.py
+++ b/scripts/manage.py
@@ -531,7 +531,7 @@ def sync_remote():
     # Sync shared modules
     print("Syncing shared modules...")
     run_command(
-        f"rsync -avz scripts/shared/__init__.py scripts/shared/db.py scripts/shared/config.py scripts/shared/utils.py scripts/shared/feishu_user_cache.py {user}@{host}:{remote_dir}/scripts/shared/"
+        f"rsync -avz scripts/shared/__init__.py scripts/shared/db.py scripts/shared/config.py scripts/shared/utils.py scripts/shared/feishu_user_cache.py scripts/shared/feishu_group_cache.py scripts/shared/dingtalk_user_cache.py scripts/shared/dingtalk_group_cache.py {user}@{host}:{remote_dir}/scripts/shared/"
     )
 
     # Sync main scripts

--- a/scripts/shared/__init__.py
+++ b/scripts/shared/__init__.py
@@ -1,3 +1,19 @@
-from . import config, db, feishu_group_cache, feishu_user_cache, utils
+from . import (
+    config,
+    db,
+    dingtalk_group_cache,
+    dingtalk_user_cache,
+    feishu_group_cache,
+    feishu_user_cache,
+    utils,
+)
 
-__all__ = ["db", "utils", "config", "feishu_user_cache", "feishu_group_cache"]
+__all__ = [
+    "db",
+    "utils",
+    "config",
+    "feishu_user_cache",
+    "feishu_group_cache",
+    "dingtalk_user_cache",
+    "dingtalk_group_cache",
+]

--- a/scripts/shared/dingtalk_group_cache.py
+++ b/scripts/shared/dingtalk_group_cache.py
@@ -13,7 +13,6 @@ from pathlib import Path
 from typing import Optional, cast
 
 import requests
-
 from dingtalk_user_cache import get_dingtalk_access_token
 
 CACHE_DIR = Path.home() / ".open-ace"
@@ -171,5 +170,7 @@ if __name__ == "__main__":
         print("Usage:")
         print("  python3 dingtalk_group_cache.py clear     - Clear group cache")
         print("  python3 dingtalk_group_cache.py list      - List cached groups")
-        print("  python3 dingtalk_group_cache.py test <conversation_label|chat_id> <app_key> [app_secret]")
+        print(
+            "  python3 dingtalk_group_cache.py test <conversation_label|chat_id> <app_key> [app_secret]"
+        )
         print("                                             - Test fetching group info")

--- a/scripts/shared/dingtalk_group_cache.py
+++ b/scripts/shared/dingtalk_group_cache.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""
+DingTalk Group Cache Module
+
+Caches DingTalk group information to avoid frequent API calls.
+Fetches group details from DingTalk APIs when needed.
+"""
+
+import json
+import re
+import time
+from pathlib import Path
+from typing import Optional, cast
+
+import requests
+
+from dingtalk_user_cache import get_dingtalk_access_token
+
+CACHE_DIR = Path.home() / ".open-ace"
+CACHE_FILE = CACHE_DIR / "dingtalk_groups.json"
+CACHE_TTL = 86400  # 24 hours
+
+
+def ensure_cache_dir():
+    """Ensure cache directory exists."""
+    CACHE_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def load_cache() -> dict:
+    """Load group cache from file."""
+    ensure_cache_dir()
+    if not CACHE_FILE.exists():
+        return {"groups": {}, "last_updated": 0}
+
+    try:
+        with open(CACHE_FILE, encoding="utf-8") as f:
+            return cast(dict, json.load(f))
+    except (OSError, json.JSONDecodeError):
+        return {"groups": {}, "last_updated": 0}
+
+
+def save_cache(cache: dict):
+    """Save group cache to file."""
+    ensure_cache_dir()
+    with open(CACHE_FILE, "w", encoding="utf-8") as f:
+        json.dump(cache, f, ensure_ascii=False, indent=2)
+
+
+def extract_chat_id(label: str) -> Optional[str]:
+    """Extract a DingTalk chat ID from a metadata label."""
+    if not label:
+        return None
+
+    stripped = label.strip()
+    if stripped.startswith("chat"):
+        return stripped
+
+    match = re.search(r"(chat[a-zA-Z0-9_-]+)", stripped)
+    if match:
+        return match.group(1)
+
+    return None
+
+
+def get_group_info(chat_id: str, app_key: str, app_secret: str) -> Optional[dict]:
+    """Get group info from DingTalk API."""
+    cache = load_cache()
+    if chat_id in cache["groups"]:
+        group_cache = cache["groups"][chat_id]
+        if time.time() - group_cache.get("cached_at", 0) < CACHE_TTL:
+            return cast(Optional[dict], group_cache.get("data"))
+
+    token = get_dingtalk_access_token(app_key, app_secret)
+    if not token:
+        return None
+
+    url = "https://oapi.dingtalk.com/chat/get"
+    params = {"access_token": token, "chatid": chat_id}
+
+    try:
+        response = requests.get(url, params=params, timeout=10)
+        response.raise_for_status()
+        data = response.json()
+
+        if data.get("errcode") == 0:
+            group_info = data
+            cache["groups"][chat_id] = {"data": group_info, "cached_at": time.time()}
+            save_cache(cache)
+            return cast(Optional[dict], group_info)
+    except Exception as e:
+        print(f"Error getting DingTalk group info: {e}")
+
+    return None
+
+
+def get_group_name(chat_id: str, app_key: str, app_secret: str) -> Optional[str]:
+    """Get group name from cache or DingTalk API."""
+    if not chat_id:
+        return None
+
+    group_info = get_group_info(chat_id, app_key, app_secret)
+    if not group_info:
+        return None
+
+    return cast(Optional[str], group_info.get("name") or group_info.get("title"))
+
+
+def get_group_name_from_conversation_label(
+    label: str, app_key: str, app_secret: str
+) -> Optional[str]:
+    """Resolve group name using a conversation label that may embed chat ID."""
+    cache = load_cache()
+    if label in cache["groups"]:
+        group_cache = cache["groups"][label]
+        if time.time() - group_cache.get("cached_at", 0) < CACHE_TTL:
+            data = group_cache.get("data", {})
+            return cast(Optional[str], data.get("name") or data.get("title"))
+
+    chat_id = extract_chat_id(label)
+    if not chat_id:
+        return None
+
+    group_info = get_group_info(chat_id, app_key, app_secret)
+    if not group_info:
+        return None
+
+    cache["groups"][label] = {"data": group_info, "cached_at": time.time()}
+    save_cache(cache)
+    return cast(Optional[str], group_info.get("name") or group_info.get("title"))
+
+
+def clear_cache():
+    """Clear group cache."""
+    if CACHE_FILE.exists():
+        CACHE_FILE.unlink()
+    print("DingTalk group cache cleared.")
+
+
+def list_cached_groups():
+    """List all cached groups."""
+    cache = load_cache()
+    print(f"Cached DingTalk groups ({len(cache['groups'])}):")
+    for group_id, group_cache in cache["groups"].items():
+        data = group_cache.get("data", {})
+        name = data.get("name") or data.get("title") or "Unknown"
+        cached_ago = time.time() - group_cache.get("cached_at", 0)
+        print(f"  {group_id}: {name} (cached {cached_ago:.0f}s ago)")
+
+
+if __name__ == "__main__":
+    import sys
+
+    if len(sys.argv) > 1:
+        command = sys.argv[1]
+
+        if command == "clear":
+            clear_cache()
+        elif command == "list":
+            list_cached_groups()
+        elif command == "test" and len(sys.argv) >= 4:
+            label_or_id = sys.argv[2]
+            app_key = sys.argv[3]
+            app_secret = sys.argv[4] if len(sys.argv) > 4 else None
+
+            if not app_secret:
+                app_secret = input("Enter App Secret: ")
+
+            name = get_group_name_from_conversation_label(label_or_id, app_key, app_secret)
+            print(f"Group {label_or_id}: {name or 'Not found'}")
+    else:
+        print("Usage:")
+        print("  python3 dingtalk_group_cache.py clear     - Clear group cache")
+        print("  python3 dingtalk_group_cache.py list      - List cached groups")
+        print("  python3 dingtalk_group_cache.py test <conversation_label|chat_id> <app_key> [app_secret]")
+        print("                                             - Test fetching group info")

--- a/scripts/shared/dingtalk_user_cache.py
+++ b/scripts/shared/dingtalk_user_cache.py
@@ -141,10 +141,7 @@ def list_cached_users():
     for user_id, user_cache in cache["users"].items():
         user_data = user_cache.get("data", {})
         name = (
-            user_data.get("name")
-            or user_data.get("nick")
-            or user_data.get("nickname")
-            or "Unknown"
+            user_data.get("name") or user_data.get("nick") or user_data.get("nickname") or "Unknown"
         )
         cached_ago = time.time() - user_cache.get("cached_at", 0)
         print(f"  {user_id}: {name} (cached {cached_ago:.0f}s ago)")

--- a/scripts/shared/dingtalk_user_cache.py
+++ b/scripts/shared/dingtalk_user_cache.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""
+DingTalk User Cache Module
+
+Caches DingTalk user information to avoid frequent API calls.
+Fetches user details from DingTalk APIs when needed.
+"""
+
+import json
+import time
+from pathlib import Path
+from typing import Optional, cast
+
+import requests
+
+CACHE_DIR = Path.home() / ".open-ace"
+CACHE_FILE = CACHE_DIR / "dingtalk_users.json"
+CACHE_TTL = 3600  # 1 hour
+
+
+def ensure_cache_dir():
+    """Ensure cache directory exists."""
+    CACHE_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def load_cache() -> dict:
+    """Load user cache from file."""
+    ensure_cache_dir()
+    if not CACHE_FILE.exists():
+        return {"users": {}, "last_updated": 0}
+
+    try:
+        with open(CACHE_FILE, encoding="utf-8") as f:
+            return cast(dict, json.load(f))
+    except (OSError, json.JSONDecodeError):
+        return {"users": {}, "last_updated": 0}
+
+
+def save_cache(cache: dict):
+    """Save user cache to file."""
+    ensure_cache_dir()
+    with open(CACHE_FILE, "w", encoding="utf-8") as f:
+        json.dump(cache, f, ensure_ascii=False, indent=2)
+
+
+def get_dingtalk_access_token(app_key: str, app_secret: str) -> Optional[str]:
+    """Get DingTalk access token for an internal application."""
+    url = "https://api.dingtalk.com/v1.0/oauth2/accessToken"
+    payload = {"appKey": app_key, "appSecret": app_secret}
+
+    try:
+        response = requests.post(url, json=payload, timeout=10)
+        response.raise_for_status()
+        data = response.json()
+        return cast(Optional[str], data.get("accessToken"))
+    except Exception as e:
+        print(f"Error getting DingTalk access token: {e}")
+        return None
+
+
+def get_user_info(user_id: str, app_key: str, app_secret: str) -> Optional[dict]:
+    """Get user info from DingTalk API."""
+    cache = load_cache()
+    if user_id in cache["users"]:
+        user_cache = cache["users"][user_id]
+        if time.time() - user_cache.get("cached_at", 0) < CACHE_TTL:
+            return cast(Optional[dict], user_cache.get("data"))
+
+    token = get_dingtalk_access_token(app_key, app_secret)
+    if not token:
+        return None
+
+    url = f"https://oapi.dingtalk.com/topapi/v2/user/get?access_token={token}"
+    payload = {"userid": user_id}
+
+    try:
+        response = requests.post(url, json=payload, timeout=10)
+        response.raise_for_status()
+        data = response.json()
+
+        if data.get("errcode") == 0:
+            user_info = data.get("result", {})
+            cache["users"][user_id] = {"data": user_info, "cached_at": time.time()}
+            save_cache(cache)
+            return cast(Optional[dict], user_info)
+    except Exception as e:
+        print(f"Error getting DingTalk user info: {e}")
+
+    return None
+
+
+def get_user_display_name(user_id: str, app_key: str, app_secret: str) -> Optional[str]:
+    """Get user's display name from DingTalk API."""
+    if not user_id:
+        return None
+
+    user_info = get_user_info(user_id, app_key, app_secret)
+    if not user_info:
+        return None
+
+    display_name = (
+        user_info.get("name")
+        or user_info.get("nick")
+        or user_info.get("nickname")
+        or user_info.get("realAuthedName")
+    )
+    return cast(Optional[str], display_name)
+
+
+def get_user_display_name_from_cache(user_id: str) -> Optional[str]:
+    """Get user display name from local cache without API call."""
+    cache = load_cache()
+    if user_id not in cache["users"]:
+        return None
+
+    user_cache = cache["users"][user_id]
+    if time.time() - user_cache.get("cached_at", 0) >= CACHE_TTL:
+        return None
+
+    user_data = user_cache.get("data", {})
+    return cast(
+        Optional[str],
+        user_data.get("name")
+        or user_data.get("nick")
+        or user_data.get("nickname")
+        or user_data.get("realAuthedName"),
+    )
+
+
+def clear_cache():
+    """Clear user cache."""
+    if CACHE_FILE.exists():
+        CACHE_FILE.unlink()
+    print("DingTalk user cache cleared.")
+
+
+def list_cached_users():
+    """List all cached users."""
+    cache = load_cache()
+    print(f"Cached DingTalk users ({len(cache['users'])}):")
+    for user_id, user_cache in cache["users"].items():
+        user_data = user_cache.get("data", {})
+        name = (
+            user_data.get("name")
+            or user_data.get("nick")
+            or user_data.get("nickname")
+            or "Unknown"
+        )
+        cached_ago = time.time() - user_cache.get("cached_at", 0)
+        print(f"  {user_id}: {name} (cached {cached_ago:.0f}s ago)")
+
+
+if __name__ == "__main__":
+    import sys
+
+    if len(sys.argv) > 1:
+        command = sys.argv[1]
+
+        if command == "clear":
+            clear_cache()
+        elif command == "list":
+            list_cached_users()
+        elif command == "test" and len(sys.argv) >= 4:
+            user_id = sys.argv[2]
+            app_key = sys.argv[3]
+            app_secret = sys.argv[4] if len(sys.argv) > 4 else None
+
+            if not app_secret:
+                app_secret = input("Enter App Secret: ")
+
+            name = get_user_display_name(user_id, app_key, app_secret)
+            print(f"User {user_id}: {name or 'Not found'}")
+    else:
+        print("Usage:")
+        print("  python3 dingtalk_user_cache.py clear     - Clear user cache")
+        print("  python3 dingtalk_user_cache.py list      - List cached users")
+        print("  python3 dingtalk_user_cache.py test <user_id> <app_key> [app_secret]")
+        print("                                            - Test fetching user info")

--- a/scripts/upload-to-central/shared/__init__.py
+++ b/scripts/upload-to-central/shared/__init__.py
@@ -1,3 +1,19 @@
-from . import config, db, feishu_group_cache, feishu_user_cache, utils
+from . import (
+    config,
+    db,
+    dingtalk_group_cache,
+    dingtalk_user_cache,
+    feishu_group_cache,
+    feishu_user_cache,
+    utils,
+)
 
-__all__ = ["db", "utils", "config", "feishu_user_cache", "feishu_group_cache"]
+__all__ = [
+    "db",
+    "utils",
+    "config",
+    "feishu_user_cache",
+    "feishu_group_cache",
+    "dingtalk_user_cache",
+    "dingtalk_group_cache",
+]

--- a/tests/e2e/ui/test_tool_accounts.py
+++ b/tests/e2e/ui/test_tool_accounts.py
@@ -112,7 +112,16 @@ def test_tool_accounts_dropdown(ui_screenshot_dir):
 
             # Step 5: 验证选项
             print("Step 5: 验证选项...")
-            expected_values = ["", "qwen", "claude", "openclaw", "feishu", "slack", "other"]
+            expected_values = [
+                "",
+                "qwen",
+                "claude",
+                "openclaw",
+                "feishu",
+                "dingtalk",
+                "slack",
+                "other",
+            ]
             actual_values = [v for v, t in option_values]
 
             for expected in expected_values:

--- a/tests/unit/test_dingtalk_group_cache.py
+++ b/tests/unit/test_dingtalk_group_cache.py
@@ -9,7 +9,9 @@ from pathlib import Path
 
 
 def load_dingtalk_group_cache():
-    module_path = Path(__file__).resolve().parents[2] / "scripts" / "shared" / "dingtalk_group_cache.py"
+    module_path = (
+        Path(__file__).resolve().parents[2] / "scripts" / "shared" / "dingtalk_group_cache.py"
+    )
     module_dir = module_path.parent
     if str(module_dir) not in sys.path:
         sys.path.insert(0, str(module_dir))
@@ -44,5 +46,11 @@ def test_get_group_name_from_conversation_label(monkeypatch, tmp_path):
     monkeypatch.setattr(mod.requests, "get", lambda *args, **kwargs: FakeResponse())
 
     label = "conversation_label=chatabcd1234"
-    assert mod.get_group_name_from_conversation_label(label, "app-key", "app-secret") == "Engineering Group"
-    assert mod.get_group_name_from_conversation_label(label, "app-key", "app-secret") == "Engineering Group"
+    assert (
+        mod.get_group_name_from_conversation_label(label, "app-key", "app-secret")
+        == "Engineering Group"
+    )
+    assert (
+        mod.get_group_name_from_conversation_label(label, "app-key", "app-secret")
+        == "Engineering Group"
+    )

--- a/tests/unit/test_dingtalk_group_cache.py
+++ b/tests/unit/test_dingtalk_group_cache.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Unit tests for DingTalk group cache helpers."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def load_dingtalk_group_cache():
+    module_path = Path(__file__).resolve().parents[2] / "scripts" / "shared" / "dingtalk_group_cache.py"
+    module_dir = module_path.parent
+    if str(module_dir) not in sys.path:
+        sys.path.insert(0, str(module_dir))
+    spec = importlib.util.spec_from_file_location("dingtalk_group_cache", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_extract_chat_id():
+    mod = load_dingtalk_group_cache()
+
+    assert mod.extract_chat_id("chatabcd1234") == "chatabcd1234"
+    assert mod.extract_chat_id("conversation_label=chatXYZ_456") == "chatXYZ_456"
+    assert mod.extract_chat_id("cid123456") is None
+
+
+def test_get_group_name_from_conversation_label(monkeypatch, tmp_path):
+    mod = load_dingtalk_group_cache()
+    monkeypatch.setattr(mod, "CACHE_DIR", tmp_path)
+    monkeypatch.setattr(mod, "CACHE_FILE", tmp_path / "dingtalk_groups.json")
+    monkeypatch.setattr(mod, "get_dingtalk_access_token", lambda *_: "token-123")
+
+    class FakeResponse:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"errcode": 0, "name": "Engineering Group"}
+
+    monkeypatch.setattr(mod.requests, "get", lambda *args, **kwargs: FakeResponse())
+
+    label = "conversation_label=chatabcd1234"
+    assert mod.get_group_name_from_conversation_label(label, "app-key", "app-secret") == "Engineering Group"
+    assert mod.get_group_name_from_conversation_label(label, "app-key", "app-secret") == "Engineering Group"

--- a/tests/unit/test_dingtalk_user_cache.py
+++ b/tests/unit/test_dingtalk_user_cache.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Unit tests for DingTalk user cache helpers."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def load_dingtalk_user_cache():
+    module_path = Path(__file__).resolve().parents[2] / "scripts" / "shared" / "dingtalk_user_cache.py"
+    module_dir = module_path.parent
+    if str(module_dir) not in sys.path:
+        sys.path.insert(0, str(module_dir))
+    spec = importlib.util.spec_from_file_location("dingtalk_user_cache", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_get_dingtalk_access_token(monkeypatch):
+    mod = load_dingtalk_user_cache()
+
+    class FakeResponse:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"accessToken": "token-123"}
+
+    monkeypatch.setattr(mod.requests, "post", lambda *args, **kwargs: FakeResponse())
+
+    assert mod.get_dingtalk_access_token("app-key", "app-secret") == "token-123"
+
+
+def test_get_user_display_name_caches_result(monkeypatch, tmp_path):
+    mod = load_dingtalk_user_cache()
+    monkeypatch.setattr(mod, "CACHE_DIR", tmp_path)
+    monkeypatch.setattr(mod, "CACHE_FILE", tmp_path / "dingtalk_users.json")
+    monkeypatch.setattr(mod, "get_dingtalk_access_token", lambda *_: "token-123")
+
+    class FakeResponse:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"errcode": 0, "result": {"name": "Alice DingTalk"}}
+
+    monkeypatch.setattr(mod.requests, "post", lambda *args, **kwargs: FakeResponse())
+
+    assert mod.get_user_display_name("manager123", "app-key", "app-secret") == "Alice DingTalk"
+    assert mod.get_user_display_name_from_cache("manager123") == "Alice DingTalk"

--- a/tests/unit/test_dingtalk_user_cache.py
+++ b/tests/unit/test_dingtalk_user_cache.py
@@ -9,7 +9,9 @@ from pathlib import Path
 
 
 def load_dingtalk_user_cache():
-    module_path = Path(__file__).resolve().parents[2] / "scripts" / "shared" / "dingtalk_user_cache.py"
+    module_path = (
+        Path(__file__).resolve().parents[2] / "scripts" / "shared" / "dingtalk_user_cache.py"
+    )
     module_dir = module_path.parent
     if str(module_dir) not in sys.path:
         sys.path.insert(0, str(module_dir))

--- a/tests/unit/test_fetch_openclaw_dingtalk.py
+++ b/tests/unit/test_fetch_openclaw_dingtalk.py
@@ -64,7 +64,7 @@ def test_process_jsonl_file_resolves_dingtalk_names(monkeypatch, tmp_path):
                         {
                             "type": "text",
                             "text": (
-                                'DingTalk relay text\n\nConversation info\n'
+                                "DingTalk relay text\n\nConversation info\n"
                                 '{"message_source":"dingtalk","sender_id":"user123","conversation_label":"chatabcd1234","is_group_chat":true}'
                             ),
                         }

--- a/tests/unit/test_fetch_openclaw_dingtalk.py
+++ b/tests/unit/test_fetch_openclaw_dingtalk.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Focused DingTalk coverage for scripts/fetch_openclaw.py."""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+SHARED_DIR = SCRIPTS_DIR / "shared"
+
+
+def load_fetch_openclaw(tmp_db_url: str):
+    os.environ["DATABASE_URL"] = tmp_db_url
+
+    if str(SCRIPTS_DIR) not in sys.path:
+        sys.path.insert(0, str(SCRIPTS_DIR))
+    if str(SHARED_DIR) not in sys.path:
+        sys.path.insert(0, str(SHARED_DIR))
+
+    from shared import db as db_mod
+
+    importlib.reload(db_mod)
+
+    spec = importlib.util.spec_from_file_location(
+        "fetch_openclaw_under_test", SCRIPTS_DIR / "fetch_openclaw.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_extract_user_message_metadata_detects_dingtalk(tmp_path):
+    mod = load_fetch_openclaw(f"sqlite:///{tmp_path / 'ace.db'}")
+
+    parsed = mod.extract_user_message_metadata(
+        'DingTalk relay text\n\nConversation info\n{"message_source":"dingtalk","sender_id":"user123","conversation_label":"chatabcd1234"}'
+    )
+
+    assert parsed["message_source"] == "dingtalk"
+    assert parsed["sender_id"] == "user123"
+    assert parsed["conversation_label"] == "chatabcd1234"
+    assert parsed["cleaned_content"] == "DingTalk relay text"
+
+
+def test_process_jsonl_file_resolves_dingtalk_names(monkeypatch, tmp_path):
+    mod = load_fetch_openclaw(f"sqlite:///{tmp_path / 'ace.db'}")
+    jsonl = tmp_path / "session.jsonl"
+    jsonl.write_text(
+        json.dumps(
+            {
+                "timestamp": "2026-07-17T02:00:00Z",
+                "type": "message",
+                "message": {
+                    "id": "msg-1",
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": (
+                                'DingTalk relay text\n\nConversation info\n'
+                                '{"message_source":"dingtalk","sender_id":"user123","conversation_label":"chatabcd1234","is_group_chat":true}'
+                            ),
+                        }
+                    ],
+                    "usage": {"input": 12, "output": 0, "cacheRead": 0, "cacheWrite": 0},
+                },
+            },
+            ensure_ascii=False,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        mod.utils,
+        "load_config",
+        lambda: {"dingtalk": {"app_key": "app-key", "app_secret": "app-secret"}},
+    )
+    monkeypatch.setattr(
+        mod.dingtalk_user_cache,
+        "get_user_display_name_from_cache",
+        lambda user_id: None,
+    )
+    monkeypatch.setattr(
+        mod.dingtalk_user_cache,
+        "get_user_display_name",
+        lambda user_id, app_key, app_secret: "Alice DingTalk",
+    )
+    monkeypatch.setattr(
+        mod.dingtalk_group_cache,
+        "get_group_name_from_conversation_label",
+        lambda label, app_key, app_secret: "Engineering Group",
+    )
+
+    daily, messages = mod.process_jsonl_file(jsonl, "localhost", "openclaw", "tester")
+
+    assert daily["2026-07-17"]["input_tokens"] == 12
+    assert messages[0]["message_source"] == "dingtalk"
+    assert messages[0]["sender_name"] == "Alice DingTalk"
+    assert messages[0]["group_subject"] == "Engineering Group"
+    assert messages[0]["feishu_conversation_id"] == "chatabcd1234"

--- a/tests/unit/test_models_user_tool_account.py
+++ b/tests/unit/test_models_user_tool_account.py
@@ -72,7 +72,7 @@ class TestUserToolAccount:
         assert d["description"] is None
 
     def test_different_tool_types(self):
-        for tool_type in ["qwen", "claude", "openclaw", "feishu", "slack"]:
+        for tool_type in ["qwen", "claude", "openclaw", "feishu", "dingtalk", "slack"]:
             uta = UserToolAccount(id=1, user_id=1, tool_account="acc", tool_type=tool_type)
             assert uta.tool_type == tool_type
 
@@ -94,6 +94,9 @@ class TestGetToolTypeDisplay:
 
     def test_slack(self):
         assert get_tool_type_display("slack") == "Slack"
+
+    def test_dingtalk(self):
+        assert get_tool_type_display("dingtalk") == "钉钉"
 
     def test_other(self):
         assert get_tool_type_display("other") == "其他"
@@ -126,6 +129,9 @@ class TestToolTypes:
     def test_has_feishu(self):
         assert "feishu" in TOOL_TYPES
 
+    def test_has_dingtalk(self):
+        assert "dingtalk" in TOOL_TYPES
+
     def test_has_slack(self):
         assert "slack" in TOOL_TYPES
 
@@ -133,7 +139,7 @@ class TestToolTypes:
         assert "other" in TOOL_TYPES
 
     def test_total_count(self):
-        assert len(TOOL_TYPES) == 8
+        assert len(TOOL_TYPES) == 9
 
     def test_all_values_are_strings(self):
         for key, value in TOOL_TYPES.items():


### PR DESCRIPTION
## Summary
- add real DingTalk user/group resolution helpers and config docs instead of only advertising support in README
- wire DingTalk metadata detection and name resolution into `scripts/fetch_openclaw.py`
- register DingTalk across config samples, tool-account typing, frontend display names, and relevant docs

## Testing
- `python3 -m py_compile scripts/shared/dingtalk_user_cache.py scripts/shared/dingtalk_group_cache.py scripts/fetch_openclaw.py app/models/user_tool_account.py app/routes/tool_accounts.py`
- `ruff check scripts/shared/dingtalk_user_cache.py scripts/shared/dingtalk_group_cache.py scripts/shared/__init__.py scripts/upload-to-central/shared/__init__.py scripts/fetch_openclaw.py app/models/user_tool_account.py app/routes/tool_accounts.py tests/unit/test_dingtalk_user_cache.py tests/unit/test_dingtalk_group_cache.py tests/unit/test_fetch_openclaw_dingtalk.py tests/unit/test_models_user_tool_account.py`
- `pytest tests/unit/test_dingtalk_user_cache.py tests/unit/test_dingtalk_group_cache.py tests/unit/test_fetch_openclaw_dingtalk.py tests/unit/test_models_user_tool_account.py -q`
- `cd frontend && npm test -- --run src/utils/formatToolName.test.ts`

Closes #1767.
