### PR TITLE
feat: enable autonomous development by default

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -331,7 +331,7 @@ def start_background_services():
         else:
             logger.info("Autonomous scheduler disabled by configuration")
             logger.info(
-                "To enable: set autonomous.enabled=true in config.json and restart the server"
+                "To enable it again: set autonomous.enabled=true in config.json and restart the server"
             )
     except Exception as e:
         logger.warning(f"Failed to start autonomous scheduler: {e}")

--- a/app/routes/workspace.py
+++ b/app/routes/workspace.py
@@ -1828,7 +1828,7 @@ def get_workspace_config():
             "max_instances": 30,
             "idle_timeout_minutes": 30,
             "base_dir": base_dir,  # For path validation in frontend
-            "autonomous_enabled": False,
+            "autonomous_enabled": True,
         }
 
         if os.path.exists(config_path):
@@ -1845,7 +1845,7 @@ def get_workspace_config():
 
             # Expose autonomous feature status
             autonomous_config = config.get("autonomous", {})
-            workspace_config["autonomous_enabled"] = autonomous_config.get("enabled", False)
+            workspace_config["autonomous_enabled"] = autonomous_config.get("enabled", True)
 
         return jsonify(workspace_config)
     except Exception as e:
@@ -1856,7 +1856,7 @@ def get_workspace_config():
                 "url": "",
                 "multi_user_mode": False,
                 "base_dir": get_workspace_base_dir(),
-                "autonomous_enabled": False,
+                "autonomous_enabled": True,
             }
         )
 

--- a/app/utils/config.py
+++ b/app/utils/config.py
@@ -73,7 +73,7 @@ def get_config_value(section: str, key: str, default=None):
 
 def is_autonomous_enabled() -> bool:
     """Check whether the autonomous development feature is enabled."""
-    return bool(get_config_value("autonomous", "enabled", False))
+    return bool(get_config_value("autonomous", "enabled", True))
 
 
 def is_run_timeline_enabled() -> bool:

--- a/config/CONFIG_GUIDE.md
+++ b/config/CONFIG_GUIDE.md
@@ -60,7 +60,7 @@
 
 | 参数 | 说明 | 默认值 |
 |------|------|--------|
-| `autonomous.enabled` | 是否启用 AI 自主开发功能 | `false` |
+| `autonomous.enabled` | 是否启用 AI 自主开发功能 | `true` |
 
 **多用户模式说明：**
 

--- a/config/config.json.sample
+++ b/config/config.json.sample
@@ -24,7 +24,7 @@
     "webui_path": ""
   },
   "autonomous": {
-    "enabled": false
+    "enabled": true
   },
   "run_timeline": {
     "enabled": false

--- a/frontend/src/api/workspace.ts
+++ b/frontend/src/api/workspace.ts
@@ -77,7 +77,7 @@ export const workspaceApi = {
         port_range_end: 3200,
         max_instances: 30,
         idle_timeout_minutes: 30,
-        autonomous_enabled: false,
+        autonomous_enabled: true,
       };
     }
   },

--- a/frontend/src/store/index.test.ts
+++ b/frontend/src/store/index.test.ts
@@ -36,7 +36,7 @@ describe('App Store', () => {
       sidebarCollapsed: false,
       workspaceTabs: [],
       workspaceActiveTabId: '',
-      autonomousEnabled: false,
+      autonomousEnabled: true,
       modelGatewayEnabled: false,
       runTimelineEnabled: false,
       policyEnabled: false,
@@ -62,7 +62,7 @@ describe('App Store', () => {
       expect(state.theme).toBe('light');
       expect(state.language).toBe('en');
       expect(state.sidebarCollapsed).toBe(false);
-      expect(state.autonomousEnabled).toBe(false);
+      expect(state.autonomousEnabled).toBe(true);
       expect(state.configLoaded).toBe(false);
     });
   });
@@ -305,12 +305,6 @@ describe('App Store', () => {
 
   describe('feature flag actions', () => {
     it('should set autonomousEnabled', () => {
-      expect(useAppStore.getState().autonomousEnabled).toBe(false);
-
-      act(() => {
-        useAppStore.getState().setAutonomousEnabled(true);
-      });
-
       expect(useAppStore.getState().autonomousEnabled).toBe(true);
 
       act(() => {
@@ -318,6 +312,12 @@ describe('App Store', () => {
       });
 
       expect(useAppStore.getState().autonomousEnabled).toBe(false);
+
+      act(() => {
+        useAppStore.getState().setAutonomousEnabled(true);
+      });
+
+      expect(useAppStore.getState().autonomousEnabled).toBe(true);
     });
 
     it('should set modelGatewayEnabled', () => {

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -157,7 +157,7 @@ export const useAppStore = create<AppState>()(
       showFileChangesPanel: true,
 
       // Feature flags
-      autonomousEnabled: false,
+      autonomousEnabled: true,
       modelGatewayEnabled: false,
       runTimelineEnabled: false,
       policyEnabled: false,

--- a/tests/issues/762/test_autonomous_config.py
+++ b/tests/issues/762/test_autonomous_config.py
@@ -82,10 +82,10 @@ class TestGetConfigValue:
 
 
 class TestIsAutonomousEnabled:
-    def test_default_false(self, config_file, config_dir):
+    def test_default_true(self, config_file, config_dir):
         config_file.write_text(json.dumps({}))
         with _patch_config_dir(config_dir):
-            assert cfg_mod.is_autonomous_enabled() is False
+            assert cfg_mod.is_autonomous_enabled() is True
 
     def test_explicit_true(self, config_file, config_dir):
         config_file.write_text(json.dumps({"autonomous": {"enabled": True}}))
@@ -194,15 +194,15 @@ class TestWorkspaceConfigAutonomousField:
             result = autonomous_config.get("enabled", False)
             assert result is True
 
-    def test_autonomous_enabled_false_when_missing(self, config_file, config_dir):
+    def test_autonomous_enabled_true_when_missing(self, config_file, config_dir):
         config_file.write_text(json.dumps({"workspace": {"enabled": False}}))
         with _patch_config_dir(config_dir):
             config_path = os.path.join(str(config_dir), "config.json")
             with open(config_path) as f:
                 config = json.load(f)
             autonomous_config = config.get("autonomous", {})
-            result = autonomous_config.get("enabled", False)
-            assert result is False
+            result = autonomous_config.get("enabled", True)
+            assert result is True
 
     def test_autonomous_enabled_false_when_explicit(self, config_file, config_dir):
         config_file.write_text(


### PR DESCRIPTION
## Summary
- default autonomous development to enabled in backend config fallbacks and workspace config responses
- align frontend defaults and store expectations with the new default
- update the existing autonomous config regression test coverage

## Testing
- pytest tests/issues/762/test_autonomous_config.py -q
