### PR TITLE
feat: deliver alert webhooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ python3 server.py
 | 配额告警 | 用量达到阈值自动提醒 |
 | 异常检测 | 识别异常使用模式 |
 | 邮件通知 | 定期发送用量报告 |
-| 飞书推送 | 实时告警推送到飞书群 |
+| Webhook / 飞书推送 | 实时推送告警到 Webhook，支持飞书 / Lark 群机器人 |
 
 ### 👥 用户管理
 
@@ -507,7 +507,7 @@ python3 server.py
 | Quota Alerts | Automatic notifications when thresholds reached |
 | Anomaly Detection | Identify unusual usage patterns |
 | Email Reports | Periodic usage reports via email |
-| Feishu Push | Real-time alerts to Feishu groups |
+| Webhook / Feishu Push | Real-time alerts to webhooks, including Feishu / Lark group bots |
 
 ### 👥 User Management
 

--- a/app/modules/governance/alert_notifier.py
+++ b/app/modules/governance/alert_notifier.py
@@ -10,14 +10,19 @@ Supports WebSocket push, email, and webhook notifications.
 """
 
 import asyncio
+import ipaddress
 import json
 import logging
+import socket
 import sqlite3
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from enum import Enum
 from typing import Any, Callable, Optional, Union
+from urllib.parse import urlparse
+
+import requests
 
 from app.repositories.database import (
     DB_PATH,
@@ -28,8 +33,13 @@ from app.repositories.database import (
     is_postgresql,
 )
 from app.services.email_notification_service import get_email_notification_service
+from app.utils.config import get_config_value
 
 logger = logging.getLogger(__name__)
+
+_SEVERITY_ORDER = {"info": 0, "warning": 1, "critical": 2}
+_WEBHOOK_TIMEOUT_SECONDS = 5
+_FEISHU_WEBHOOK_HOST_SNIPPETS = ("feishu.cn", "larksuite.com", "larkoffice.com")
 
 
 class AlertType(Enum):
@@ -118,6 +128,175 @@ class AlertNotifier:
         self._user_clients: dict[int, set[str]] = {}  # user_id -> set of client_ids
         self._email_config: dict[str, Any] = {}
         self._webhooks: dict[str, str] = {}
+
+    def _matches_notification_preferences(
+        self, alert: Alert, prefs: NotificationPreference, channel: str
+    ) -> bool:
+        """Return whether the alert matches the user's notification preferences."""
+        if alert.alert_type not in prefs.alert_types:
+            logger.debug(
+                "Alert type %s not in user %s preferences for %s: %s",
+                alert.alert_type,
+                prefs.user_id,
+                channel,
+                prefs.alert_types,
+            )
+            return False
+
+        if _SEVERITY_ORDER.get(alert.severity, 0) < _SEVERITY_ORDER.get(prefs.min_severity, 1):
+            logger.debug(
+                "Alert severity %s below user %s threshold %s for %s",
+                alert.severity,
+                prefs.user_id,
+                prefs.min_severity,
+                channel,
+            )
+            return False
+
+        return True
+
+    def _allow_private_webhook_urls(self) -> bool:
+        """Whether private/loopback webhook targets are explicitly allowed."""
+        return bool(get_config_value("alerts", "allow_private_webhook_urls", False))
+
+    def _is_disallowed_webhook_ip(self, ip: ipaddress._BaseAddress) -> bool:
+        """Return whether the resolved webhook IP is blocked by default."""
+        return (
+            ip.is_private
+            or ip.is_loopback
+            or ip.is_link_local
+            or ip.is_multicast
+            or ip.is_reserved
+            or ip.is_unspecified
+        )
+
+    def validate_webhook_url(
+        self, webhook_url: Optional[str], resolve_dns: bool = True
+    ) -> tuple[bool, Optional[str]]:
+        """Validate a webhook URL for syntax and outbound safety."""
+        if not webhook_url:
+            return True, None
+
+        parsed = urlparse(webhook_url.strip())
+        if parsed.scheme not in ("http", "https"):
+            return False, "Webhook URL must start with http:// or https://"
+
+        if not parsed.hostname:
+            return False, "Webhook URL must include a hostname"
+
+        if self._allow_private_webhook_urls():
+            return True, None
+
+        host = parsed.hostname.strip().lower()
+        if host in {"localhost", "localhost.localdomain"}:
+            return False, "Private and loopback webhook targets are blocked by default"
+
+        try:
+            ip = ipaddress.ip_address(host.split("%", 1)[0])
+        except ValueError:
+            ip = None
+
+        if ip is not None:
+            if self._is_disallowed_webhook_ip(ip):
+                return False, "Private and loopback webhook targets are blocked by default"
+            return True, None
+
+        if not resolve_dns:
+            return True, None
+
+        try:
+            resolved = socket.getaddrinfo(
+                parsed.hostname, parsed.port or 443, type=socket.SOCK_STREAM
+            )
+        except OSError:
+            return False, "Webhook hostname could not be resolved"
+
+        for entry in resolved:
+            resolved_ip = ipaddress.ip_address(entry[4][0].split("%", 1)[0])
+            if self._is_disallowed_webhook_ip(resolved_ip):
+                return False, "Private and loopback webhook targets are blocked by default"
+
+        return True, None
+
+    def _is_feishu_webhook(self, webhook_url: str) -> bool:
+        """Return whether the webhook target looks like a Feishu/Lark bot webhook."""
+        host = (urlparse(webhook_url).hostname or "").lower()
+        return any(snippet in host for snippet in _FEISHU_WEBHOOK_HOST_SNIPPETS)
+
+    def _format_webhook_text(self, alert: Alert) -> str:
+        """Render a plain-text alert summary suitable for chat webhook bots."""
+        lines = [
+            f"[Open ACE] {alert.severity.upper()} - {alert.title}",
+            alert.message,
+            f"Type: {alert.alert_type}",
+        ]
+        if alert.username:
+            lines.append(f"User: {alert.username}")
+        if alert.tool_name:
+            lines.append(f"Tool: {alert.tool_name}")
+        if alert.action_url:
+            lines.append(f"Action: {alert.action_url}")
+        return "\n".join(line for line in lines if line)
+
+    def _build_webhook_payload(self, alert: Alert, webhook_url: str) -> dict[str, Any]:
+        """Build the outbound webhook payload for the given target."""
+        summary = self._format_webhook_text(alert)
+        if self._is_feishu_webhook(webhook_url):
+            return {"msg_type": "text", "content": {"text": summary}}
+        return {
+            "event": "openace.alert",
+            "source": "open-ace",
+            "summary": summary,
+            "alert": alert.to_dict(),
+        }
+
+    def _send_webhook_notification(self, alert: Alert, user_id: int) -> None:
+        """Send a webhook notification for an alert if user preferences allow."""
+        try:
+            prefs = self.get_notification_preferences(user_id)
+
+            if not prefs.push_enabled:
+                logger.debug("Webhook notifications disabled for user %s", user_id)
+                return
+
+            if not prefs.webhook_url:
+                logger.debug("No webhook URL configured for user %s", user_id)
+                return
+
+            if not self._matches_notification_preferences(alert, prefs, "webhook"):
+                return
+
+            valid, error = self.validate_webhook_url(prefs.webhook_url, resolve_dns=True)
+            if not valid:
+                logger.warning(
+                    "Skipping webhook notification for user %s alert %s: %s",
+                    user_id,
+                    alert.alert_id,
+                    error,
+                )
+                return
+
+            payload = self._build_webhook_payload(alert, prefs.webhook_url)
+            response = requests.post(
+                prefs.webhook_url,
+                json=payload,
+                timeout=_WEBHOOK_TIMEOUT_SECONDS,
+                allow_redirects=False,
+                headers={"User-Agent": "Open-ACE Alert Webhook"},
+            )
+            response.raise_for_status()
+            logger.info(
+                "Webhook notification delivered for alert %s to user %s",
+                alert.alert_id,
+                user_id,
+            )
+        except Exception as e:
+            logger.warning(
+                "Failed to deliver webhook notification for alert %s to user %s: %s",
+                alert.alert_id,
+                user_id,
+                e,
+            )
 
     def _get_connection(self) -> Union[sqlite3.Connection, Any]:
         """Get database connection (SQLite or PostgreSQL)."""
@@ -326,6 +505,7 @@ class AlertNotifier:
         # Send email notification if user preferences allow
         if user_id:
             self._send_email_notification(alert, user_id, language)
+            self._send_webhook_notification(alert, user_id)
 
         logger.info(f"Created alert: [{severity}] {title}")
         return alert
@@ -358,19 +538,7 @@ class AlertNotifier:
                 logger.debug(f"No notification email set for user {user_id}")
                 return
 
-            # Check alert type is in user's preferences
-            if alert.alert_type not in prefs.alert_types:
-                logger.debug(
-                    f"Alert type {alert.alert_type} not in user {user_id} preferences: {prefs.alert_types}"
-                )
-                return
-
-            # Check severity meets minimum threshold
-            severity_order = {"info": 0, "warning": 1, "critical": 2}
-            if severity_order.get(alert.severity, 0) < severity_order.get(prefs.min_severity, 1):
-                logger.debug(
-                    f"Alert severity {alert.severity} below user {user_id} threshold {prefs.min_severity}"
-                )
+            if not self._matches_notification_preferences(alert, prefs, "email"):
                 return
 
             # Prepare alert data for email

--- a/app/routes/alerts.py
+++ b/app/routes/alerts.py
@@ -200,11 +200,19 @@ def update_preferences():
             return jsonify({"success": False, "error": "No data provided"}), 400
 
         notifier = get_alert_notifier()
+        webhook_url = data.get("webhook_url")
+        if isinstance(webhook_url, str):
+            webhook_url = webhook_url.strip() or None
+
+        valid, error = notifier.validate_webhook_url(webhook_url, resolve_dns=False)
+        if not valid:
+            return jsonify({"success": False, "error": error}), 400
+
         prefs = NotificationPreference(
             user_id=user_id,
             email_enabled=data.get("email_enabled", True),
             push_enabled=data.get("push_enabled", True),
-            webhook_url=data.get("webhook_url"),
+            webhook_url=webhook_url,
             alert_types=data.get("alert_types", ["quota", "system", "security"]),
             min_severity=data.get("min_severity", "warning"),
             notification_email=data.get("notification_email"),

--- a/config/CONFIG_GUIDE.md
+++ b/config/CONFIG_GUIDE.md
@@ -62,6 +62,14 @@
 |------|------|--------|
 | `autonomous.enabled` | 是否启用 AI 自主开发功能 | `true` |
 
+### Alerts（告警推送）
+
+| 参数 | 说明 | 默认值 |
+|------|------|--------|
+| `alerts.allow_private_webhook_urls` | 是否允许告警 webhook 指向私网 / 回环 / 链路本地地址。默认关闭，用于阻断 SSRF 风险。 | `false` |
+
+> 默认情况下，告警 webhook 仅允许公开可达的 `http(s)` 地址。飞书 / Lark 群机器人 webhook 可直接使用；如果你确实需要向内网地址推送，请显式打开 `alerts.allow_private_webhook_urls`，并在网络层自行控制访问范围。
+
 **多用户模式说明：**
 
 多用户模式下，Open ACE 会为每个用户启动独立的 `qwen-code-webui` 进程，以该用户的 `system_account` 身份运行。这确保了：

--- a/config/config.json.sample
+++ b/config/config.json.sample
@@ -29,6 +29,9 @@
   "run_timeline": {
     "enabled": false
   },
+  "alerts": {
+    "allow_private_webhook_urls": false
+  },
   "tools": {
     "openclaw": {
       "enabled": true,

--- a/tests/unit/test_alert_notifier_webhook.py
+++ b/tests/unit/test_alert_notifier_webhook.py
@@ -1,0 +1,134 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from app.modules.governance.alert_notifier import AlertNotifier, NotificationPreference
+
+
+class TestAlertNotifierWebhook(unittest.TestCase):
+    def test_validate_webhook_url_rejects_private_ip_by_default(self):
+        notifier = AlertNotifier()
+
+        with patch("app.modules.governance.alert_notifier.get_config_value", return_value=False):
+            valid, error = notifier.validate_webhook_url("http://127.0.0.1:8000/hook")
+
+        assert not valid
+        assert error and "blocked by default" in error
+
+    def test_validate_webhook_url_allows_private_ip_when_enabled(self):
+        notifier = AlertNotifier()
+
+        with patch("app.modules.governance.alert_notifier.get_config_value", return_value=True):
+            valid, error = notifier.validate_webhook_url("http://127.0.0.1:8000/hook")
+
+        assert valid
+        assert error is None
+
+    @patch("app.modules.governance.alert_notifier.AlertNotifier.validate_webhook_url")
+    @patch("app.modules.governance.alert_notifier.requests.post")
+    @patch("app.modules.governance.alert_notifier.AlertNotifier.get_notification_preferences")
+    @patch("app.modules.governance.alert_notifier.AlertNotifier._save_alert")
+    def test_create_alert_triggers_generic_webhook(
+        self, mock_save, mock_get_prefs, mock_post, mock_validate
+    ):
+        notifier = AlertNotifier()
+        notifier._subscribers = []
+
+        mock_validate.return_value = (True, None)
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
+        mock_post.return_value = mock_response
+        mock_get_prefs.return_value = NotificationPreference(
+            user_id=1,
+            email_enabled=False,
+            push_enabled=True,
+            webhook_url="https://alerts.example.com/webhook",
+            alert_types=["quota", "system", "security"],
+            min_severity="warning",
+        )
+
+        notifier.create_alert(
+            alert_type="quota",
+            severity="warning",
+            title="Quota Warning",
+            message="Usage reached 80%",
+            user_id=1,
+            username="alice",
+        )
+
+        mock_post.assert_called_once()
+        assert mock_post.call_args.kwargs["allow_redirects"] is False
+        payload = mock_post.call_args.kwargs["json"]
+        assert payload["event"] == "openace.alert"
+        assert payload["alert"]["title"] == "Quota Warning"
+        assert "Usage reached 80%" in payload["summary"]
+
+    @patch("app.modules.governance.alert_notifier.AlertNotifier.validate_webhook_url")
+    @patch("app.modules.governance.alert_notifier.requests.post")
+    @patch("app.modules.governance.alert_notifier.AlertNotifier.get_notification_preferences")
+    @patch("app.modules.governance.alert_notifier.AlertNotifier._save_alert")
+    def test_create_alert_uses_feishu_payload(
+        self, mock_save, mock_get_prefs, mock_post, mock_validate
+    ):
+        notifier = AlertNotifier()
+        notifier._subscribers = []
+
+        mock_validate.return_value = (True, None)
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
+        mock_post.return_value = mock_response
+        mock_get_prefs.return_value = NotificationPreference(
+            user_id=1,
+            email_enabled=False,
+            push_enabled=True,
+            webhook_url="https://open.feishu.cn/open-apis/bot/v2/hook/abc123",
+            alert_types=["system"],
+            min_severity="info",
+        )
+
+        notifier.create_alert(
+            alert_type="system",
+            severity="critical",
+            title="System Alert",
+            message="Service unavailable",
+            user_id=1,
+            username="alice",
+        )
+
+        payload = mock_post.call_args.kwargs["json"]
+        assert payload["msg_type"] == "text"
+        assert "System Alert" in payload["content"]["text"]
+        assert "Service unavailable" in payload["content"]["text"]
+
+    @patch("app.modules.governance.alert_notifier.AlertNotifier.validate_webhook_url")
+    @patch("app.modules.governance.alert_notifier.requests.post")
+    @patch("app.modules.governance.alert_notifier.AlertNotifier.get_notification_preferences")
+    @patch("app.modules.governance.alert_notifier.AlertNotifier._save_alert")
+    def test_create_alert_skips_webhook_when_push_disabled(
+        self, mock_save, mock_get_prefs, mock_post, mock_validate
+    ):
+        notifier = AlertNotifier()
+        notifier._subscribers = []
+
+        mock_validate.return_value = (True, None)
+        mock_get_prefs.return_value = NotificationPreference(
+            user_id=1,
+            email_enabled=False,
+            push_enabled=False,
+            webhook_url="https://alerts.example.com/webhook",
+            alert_types=["quota"],
+            min_severity="warning",
+        )
+
+        notifier.create_alert(
+            alert_type="quota",
+            severity="critical",
+            title="Quota Critical",
+            message="Quota exhausted",
+            user_id=1,
+        )
+
+        mock_post.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary\n- deliver real alert webhook notifications from the alert center, including Feishu/Lark bot compatible payloads\n- validate webhook URLs and block private/loopback targets by default to reduce SSRF risk\n- document the new alert webhook behavior and config toggle, with regression coverage for webhook delivery\n\n## Testing\n- pytest tests/unit/test_alert_notifier_webhook.py tests/test_email_notification_service.py tests/test_email_notification_integration.py -q\n- ruff check app/modules/governance/alert_notifier.py app/routes/alerts.py tests/unit/test_alert_notifier_webhook.py\n- SKIP=bandit,no-commit-to-branch pre-commit run --files app/modules/governance/alert_notifier.py app/routes/alerts.py tests/unit/test_alert_notifier_webhook.py config/config.json.sample config/CONFIG_GUIDE.md README.md\n