### PR TITLE
Implement Feishu org sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,8 +212,8 @@ python3 server.py
 |------|------|
 | 多租户 | 支持多部门/团队隔离 |
 | 角色权限 | 管理员/普通用户角色区分 |
-| SSO 集成 | 支持企业单点登录 |
-| 飞书同步 | 自动同步飞书组织架构 |
+| SSO 集成 | 支持 SAML 2.0、OIDC、OAuth2 企业单点登录 |
+| 飞书同步 | 手动触发并可按配置自动同步飞书组织架构 |
 | 钉钉解析 | 导入 OpenClaw 会话时解析钉钉用户名和群名称 |
 
 ### 📋 合规与报表
@@ -517,9 +517,11 @@ python3 server.py
 |---------|-------------|
 | Multi-tenant | Department/team isolation |
 | Role Permissions | Admin/user role distinction |
-| SSO Integration | Enterprise single sign-on support |
-| Feishu Sync | Auto-sync Feishu organization structure |
+| SSO Integration | Enterprise single sign-on via SAML 2.0, OIDC, and OAuth2 |
+| Feishu Sync | Manual and optionally scheduled Feishu organization sync |
 | DingTalk Resolution | Resolve DingTalk user and group names during OpenClaw import |
+| Feishu Sync | Manual and optionally scheduled Feishu organization sync |
+>>>>>>> 997c5054 (Implement Feishu org sync)
 
 ### 📋 Compliance and Reporting
 

--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -453,3 +453,28 @@ def api_quota_stats():
             },
         }
     )
+
+
+@admin_bp.route("/admin/feishu/sync", methods=["POST"])
+@admin_required
+def api_sync_feishu_org():
+    """Manually trigger a Feishu organization sync."""
+    data = request.get_json(silent=True) or {}
+    tenant_id = data.get("tenant_id")
+
+    if tenant_id is not None:
+        try:
+            tenant_id = int(tenant_id)
+        except (TypeError, ValueError):
+            return jsonify({"error": "tenant_id must be an integer"}), 400
+
+    try:
+        from app.services.feishu_org_sync import FeishuOrgSyncService
+
+        result = FeishuOrgSyncService().sync_org(tenant_id=tenant_id)
+        return jsonify({"success": True, "result": result.to_dict()})
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 400
+    except Exception as e:
+        logger.exception("Failed to sync Feishu org: %s", e)
+        return jsonify({"error": "Failed to sync Feishu org"}), 500

--- a/app/services/data_fetch_scheduler.py
+++ b/app/services/data_fetch_scheduler.py
@@ -260,6 +260,9 @@ class DataFetchScheduler:
         # Check quotas after data is fresh
         self._check_quotas()
 
+        # Optionally synchronize Feishu org structure.
+        self._maybe_sync_feishu_org()
+
     def _refresh_materialized_views(self):
         """Refresh materialized views for PostgreSQL performance optimization."""
         from app.repositories.database import Database, is_postgresql
@@ -450,6 +453,22 @@ class DataFetchScheduler:
             f"requests={row[req_key]}/{row.get('daily_request_quota' if not month_prefix else 'monthly_request_quota')}, "
             f"tokens={row[tok_key]}/{row.get('daily_token_quota' if not month_prefix else 'monthly_token_quota', 0) * 1_000_000}"
         )
+
+    def _maybe_sync_feishu_org(self):
+        """Synchronize Feishu org data when auto-sync is enabled."""
+        try:
+            from app.services.feishu_org_sync import FeishuOrgSyncService
+
+            result = FeishuOrgSyncService().maybe_sync_from_scheduler()
+            if result:
+                logger.info(
+                    "Scheduled Feishu org sync completed: tenant=%s departments=%s users=%s",
+                    result.tenant_id,
+                    result.departments_seen,
+                    result.users_seen,
+                )
+        except Exception as e:
+            logger.warning(f"Scheduled Feishu org sync failed: {e}")
 
 
 # Global scheduler instance

--- a/app/services/feishu_org_sync.py
+++ b/app/services/feishu_org_sync.py
@@ -1,0 +1,657 @@
+"""
+Feishu organization sync service.
+
+Synchronizes Feishu departments and users into local Open ACE teams, team
+memberships, and SSO identity mappings.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import threading
+import uuid
+from collections import deque
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Any, cast
+
+import requests
+
+from app.modules.sso.manager import SSOManager
+from app.modules.workspace.collaboration import CollaborationManager
+from app.repositories.database import Database
+from app.repositories.user_repo import UserRepository
+from app.utils.config import get_config_value
+
+logger = logging.getLogger(__name__)
+
+FEISHU_PROVIDER_NAME = "feishu"
+FEISHU_ROOT_DEPARTMENT_ID = "0"
+FEISHU_PLACEHOLDER_EMAIL_DOMAIN = "feishu.local"
+
+
+@dataclass
+class FeishuDepartment:
+    """Feishu department record used during synchronization."""
+
+    department_id: str
+    name: str
+    parent_department_id: str | None = None
+    leader_user_id: str | None = None
+    order: int | None = None
+
+
+@dataclass
+class FeishuUser:
+    """Feishu user record used during synchronization."""
+
+    open_id: str
+    name: str
+    email: str | None = None
+    department_ids: list[str] = field(default_factory=list)
+    status: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class FeishuOrgSyncResult:
+    """Summary returned to admin/API callers after a sync run."""
+
+    tenant_id: int
+    departments_seen: int = 0
+    users_seen: int = 0
+    teams_created: int = 0
+    teams_updated: int = 0
+    users_created: int = 0
+    users_linked: int = 0
+    users_updated: int = 0
+    memberships_added: int = 0
+    memberships_removed: int = 0
+    started_at: str | None = None
+    finished_at: str | None = None
+    warnings: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert result to a JSON-friendly dictionary."""
+        return {
+            "tenant_id": self.tenant_id,
+            "departments_seen": self.departments_seen,
+            "users_seen": self.users_seen,
+            "teams_created": self.teams_created,
+            "teams_updated": self.teams_updated,
+            "users_created": self.users_created,
+            "users_linked": self.users_linked,
+            "users_updated": self.users_updated,
+            "memberships_added": self.memberships_added,
+            "memberships_removed": self.memberships_removed,
+            "started_at": self.started_at,
+            "finished_at": self.finished_at,
+            "warnings": list(self.warnings),
+        }
+
+
+class FeishuOrgSyncService:
+    """Synchronize Feishu org data into local users and collaboration teams."""
+
+    _sync_lock = threading.Lock()
+    _schedule_lock = threading.Lock()
+    _last_scheduled_sync_at: datetime | None = None
+
+    def __init__(
+        self,
+        db: Database | None = None,
+        user_repo: UserRepository | None = None,
+        sso_manager: SSOManager | None = None,
+        collaboration_manager: CollaborationManager | None = None,
+        config_override: dict[str, Any] | None = None,
+        http_session=None,
+    ):
+        self.db = db or Database()
+        self.user_repo = user_repo or UserRepository(db=self.db)
+        self.sso_manager = sso_manager or SSOManager(db=self.db)
+        self.collaboration_manager = collaboration_manager or CollaborationManager()
+        self.config_override = config_override
+        self.http = http_session or requests
+
+    def sync_org(self, tenant_id: int | None = None) -> FeishuOrgSyncResult:
+        """Run a full Feishu org sync."""
+        config = self._get_feishu_config()
+        app_id = str(config.get("app_id") or "").strip()
+        app_secret = str(config.get("app_secret") or "").strip()
+        if not app_id or not app_secret:
+            raise ValueError("Feishu app_id and app_secret must be configured before syncing")
+
+        effective_tenant_id = int(tenant_id or config.get("org_sync_tenant_id") or 1)
+        result = FeishuOrgSyncResult(
+            tenant_id=effective_tenant_id,
+            started_at=datetime.now(timezone.utc).replace(tzinfo=None).isoformat(),
+        )
+
+        with self._sync_lock:
+            self._ensure_supporting_tables()
+            token = self._get_tenant_access_token(app_id, app_secret)
+            departments, users = self._fetch_directory_snapshot(token)
+            result.departments_seen = len(departments)
+            result.users_seen = len(users)
+
+            team_ids_by_department: dict[str, str] = {}
+            for department in departments:
+                team_id, created = self._upsert_department_team(department)
+                team_ids_by_department[department.department_id] = team_id
+                if created:
+                    result.teams_created += 1
+                else:
+                    result.teams_updated += 1
+
+            expected_memberships: set[tuple[str, int]] = set()
+            for user in users:
+                user_id, created, linked, updated = self._resolve_local_user(
+                    user=user,
+                    tenant_id=effective_tenant_id,
+                    result=result,
+                )
+                if user_id is None:
+                    continue
+                if created:
+                    result.users_created += 1
+                elif linked:
+                    result.users_linked += 1
+                if updated:
+                    result.users_updated += 1
+
+                for department_id in user.department_ids:
+                    membership_team_id = team_ids_by_department.get(department_id)
+                    if membership_team_id:
+                        expected_memberships.add((membership_team_id, user_id))
+
+            self._sync_memberships(
+                expected_memberships=expected_memberships,
+                synced_team_ids=set(team_ids_by_department.values()),
+                result=result,
+            )
+
+            result.finished_at = datetime.now(timezone.utc).replace(tzinfo=None).isoformat()
+            return result
+
+    def maybe_sync_from_scheduler(self) -> FeishuOrgSyncResult | None:
+        """Run scheduled sync when enabled and the interval has elapsed."""
+        config = self._get_feishu_config()
+        if not bool(config.get("org_sync_enabled", False)):
+            return None
+
+        interval_minutes = max(int(config.get("org_sync_interval_minutes") or 60), 5)
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
+
+        with self._schedule_lock:
+            if self._last_scheduled_sync_at and (now - self._last_scheduled_sync_at) < timedelta(
+                minutes=interval_minutes
+            ):
+                return None
+
+            result = self.sync_org(tenant_id=config.get("org_sync_tenant_id"))
+            self.__class__._last_scheduled_sync_at = now
+            return result
+
+    def _ensure_supporting_tables(self) -> None:
+        """Ensure dependent tables exist before syncing."""
+        self.sso_manager._ensure_tables()
+        self.collaboration_manager._ensure_tables()
+
+    def _get_feishu_config(self) -> dict[str, Any]:
+        """Load Feishu config from override or app config."""
+        if self.config_override:
+            if "feishu" in self.config_override:
+                config = dict(self.config_override.get("feishu") or {})
+            else:
+                config = dict(self.config_override)
+        else:
+            config = {
+                "app_id": get_config_value("feishu", "app_id", ""),
+                "app_secret": get_config_value("feishu", "app_secret", ""),
+                "org_sync_enabled": bool(get_config_value("feishu", "org_sync_enabled", False)),
+                "org_sync_tenant_id": int(get_config_value("feishu", "org_sync_tenant_id", 1) or 1),
+                "org_sync_interval_minutes": int(
+                    get_config_value("feishu", "org_sync_interval_minutes", 60) or 60
+                ),
+            }
+
+        config.setdefault("org_sync_enabled", False)
+        config.setdefault("org_sync_tenant_id", 1)
+        config.setdefault("org_sync_interval_minutes", 60)
+        return config
+
+    def _get_tenant_access_token(self, app_id: str, app_secret: str) -> str:
+        """Exchange app credentials for a Feishu tenant access token."""
+        response = self.http.post(
+            "https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal",
+            json={"app_id": app_id, "app_secret": app_secret},
+            timeout=15,
+        )
+        response.raise_for_status()
+        data = response.json()
+        if data.get("code") != 0 or not data.get("tenant_access_token"):
+            raise RuntimeError(f"Failed to get Feishu tenant access token: {data}")
+        return str(data["tenant_access_token"])
+
+    def _fetch_directory_snapshot(
+        self, token: str
+    ) -> tuple[list[FeishuDepartment], list[FeishuUser]]:
+        """Recursively fetch departments and users starting from the root department."""
+        departments: dict[str, FeishuDepartment] = {}
+        users: dict[str, FeishuUser] = {}
+
+        queue: deque[str] = deque([FEISHU_ROOT_DEPARTMENT_ID])
+        visited: set[str] = set()
+
+        while queue:
+            current_department_id = queue.popleft()
+            if current_department_id in visited:
+                continue
+            visited.add(current_department_id)
+
+            child_departments = self._fetch_child_departments(token, current_department_id)
+            for department in child_departments:
+                if department.department_id not in departments:
+                    departments[department.department_id] = department
+                    queue.append(department.department_id)
+
+            if current_department_id == FEISHU_ROOT_DEPARTMENT_ID:
+                continue
+
+            direct_users = self._fetch_department_users(token, current_department_id)
+            for user in direct_users:
+                existing = users.get(user.open_id)
+                if existing is None:
+                    users[user.open_id] = user
+                    continue
+
+                merged_departments = set(existing.department_ids)
+                merged_departments.update(user.department_ids)
+                existing.department_ids = sorted(merged_departments)
+                if not existing.email and user.email:
+                    existing.email = user.email
+                if user.name:
+                    existing.name = user.name
+                if user.status:
+                    existing.status = user.status
+
+        sorted_departments = sorted(
+            departments.values(),
+            key=lambda d: (
+                d.parent_department_id or "",
+                d.order if d.order is not None else 0,
+                d.name.lower(),
+            ),
+        )
+        sorted_users = sorted(users.values(), key=lambda u: (u.name.lower(), u.open_id))
+        return sorted_departments, sorted_users
+
+    def _fetch_child_departments(self, token: str, department_id: str) -> list[FeishuDepartment]:
+        """Fetch immediate child departments for a Feishu department."""
+        items: list[dict[str, Any]] = []
+        page_token: str | None = None
+
+        while True:
+            params = {
+                "department_id_type": "open_department_id",
+                "page_size": 100,
+            }
+            if page_token:
+                params["page_token"] = page_token
+
+            data = self._request_json(
+                method="GET",
+                url=f"https://open.feishu.cn/open-apis/contact/v3/departments/{department_id}/children",
+                token=token,
+                params=params,
+            )
+            items.extend(self._extract_items(data, ("items", "departments")))
+            if not data.get("has_more"):
+                break
+            page_token = data.get("page_token")
+            if not page_token:
+                break
+
+        departments: list[FeishuDepartment] = []
+        for item in items:
+            department_id_value = item.get("open_department_id") or item.get("department_id")
+            if not department_id_value:
+                continue
+
+            parent_ids = item.get("parent_department_ids") or []
+            parent_department_id = None
+            if isinstance(parent_ids, list) and parent_ids:
+                parent_department_id = str(parent_ids[0])
+            elif item.get("parent_department_id"):
+                parent_department_id = str(item["parent_department_id"])
+            elif department_id != FEISHU_ROOT_DEPARTMENT_ID:
+                parent_department_id = department_id
+
+            departments.append(
+                FeishuDepartment(
+                    department_id=str(department_id_value),
+                    name=str(item.get("name") or department_id_value),
+                    parent_department_id=parent_department_id,
+                    leader_user_id=(
+                        str(item.get("leader_user_id"))
+                        if item.get("leader_user_id") is not None
+                        else None
+                    ),
+                    order=int(item["order"]) if item.get("order") is not None else None,
+                )
+            )
+
+        return departments
+
+    def _fetch_department_users(self, token: str, department_id: str) -> list[FeishuUser]:
+        """Fetch users directly under a Feishu department."""
+        items: list[dict[str, Any]] = []
+        page_token: str | None = None
+
+        while True:
+            params = {
+                "department_id": department_id,
+                "department_id_type": "open_department_id",
+                "user_id_type": "open_id",
+                "page_size": 100,
+            }
+            if page_token:
+                params["page_token"] = page_token
+
+            data = self._request_json(
+                method="GET",
+                url="https://open.feishu.cn/open-apis/contact/v3/users/find_by_department",
+                token=token,
+                params=params,
+            )
+            items.extend(self._extract_items(data, ("items", "users")))
+            if not data.get("has_more"):
+                break
+            page_token = data.get("page_token")
+            if not page_token:
+                break
+
+        users: list[FeishuUser] = []
+        for item in items:
+            open_id = item.get("open_id") or item.get("user_id")
+            if not open_id:
+                continue
+
+            department_ids = item.get("department_ids") or [department_id]
+            if not isinstance(department_ids, list):
+                department_ids = [department_id]
+            raw_status = item.get("status")
+            status = cast(dict[str, Any], raw_status) if isinstance(raw_status, dict) else {}
+
+            users.append(
+                FeishuUser(
+                    open_id=str(open_id),
+                    name=str(item.get("name") or open_id),
+                    email=str(item.get("email")) if item.get("email") else None,
+                    department_ids=[str(dep_id) for dep_id in department_ids if dep_id],
+                    status=status,
+                )
+            )
+
+        return users
+
+    def _request_json(
+        self,
+        method: str,
+        url: str,
+        token: str | None = None,
+        params: dict[str, Any] | None = None,
+        json_payload: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Call a Feishu JSON API and return its data payload."""
+        headers = {"Content-Type": "application/json"}
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+
+        response = self.http.request(
+            method=method,
+            url=url,
+            headers=headers,
+            params=params,
+            json=json_payload,
+            timeout=15,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        if payload.get("code") != 0:
+            raise RuntimeError(f"Feishu API request failed: {payload}")
+        return payload.get("data") or {}
+
+    @staticmethod
+    def _extract_items(data: dict[str, Any], keys: tuple[str, ...]) -> list[dict[str, Any]]:
+        """Pull the first list-valued key from a Feishu API payload."""
+        for key in keys:
+            value = data.get(key)
+            if isinstance(value, list):
+                return [item for item in value if isinstance(item, dict)]
+        return []
+
+    def _upsert_department_team(self, department: FeishuDepartment) -> tuple[str, bool]:
+        """Create or update a local team representing a Feishu department."""
+        existing_teams = self._load_synced_teams()
+        existing = existing_teams.get(department.department_id)
+        now = datetime.now(timezone.utc).replace(tzinfo=None).isoformat()
+
+        settings = {
+            "sync_source": FEISHU_PROVIDER_NAME,
+            "feishu_department_id": department.department_id,
+            "feishu_parent_department_id": department.parent_department_id,
+            "feishu_leader_user_id": department.leader_user_id,
+        }
+        settings_json = json.dumps(settings, ensure_ascii=False)
+
+        if existing:
+            self.db.execute(
+                """
+                UPDATE teams
+                SET name = ?, settings = ?, updated_at = ?
+                WHERE team_id = ?
+                """,
+                (
+                    department.name,
+                    settings_json,
+                    now,
+                    existing["team_id"],
+                ),
+            )
+            return str(existing["team_id"]), False
+
+        team_id = str(uuid.uuid4())
+        self.db.execute(
+            """
+            INSERT INTO teams (team_id, name, description, owner_id, settings, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                team_id,
+                department.name,
+                "",
+                None,
+                settings_json,
+                now,
+                now,
+            ),
+        )
+        return team_id, True
+
+    def _load_synced_teams(self) -> dict[str, dict[str, Any]]:
+        """Return existing teams that are owned by Feishu org sync."""
+        rows = self.db.fetch_all("SELECT team_id, name, settings FROM teams")
+        synced: dict[str, dict[str, Any]] = {}
+        for row in rows:
+            settings_raw = row.get("settings")
+            if not settings_raw:
+                continue
+            try:
+                settings = (
+                    json.loads(settings_raw) if isinstance(settings_raw, str) else settings_raw
+                )
+            except (TypeError, json.JSONDecodeError):
+                continue
+            if not isinstance(settings, dict):
+                continue
+            if settings.get("sync_source") != FEISHU_PROVIDER_NAME:
+                continue
+            department_id = settings.get("feishu_department_id")
+            if department_id:
+                synced[str(department_id)] = row
+        return synced
+
+    def _resolve_local_user(
+        self,
+        user: FeishuUser,
+        tenant_id: int,
+        result: FeishuOrgSyncResult,
+    ) -> tuple[int | None, bool, bool, bool]:
+        """Resolve or provision a local user for a Feishu user."""
+        existing_user_id = self.sso_manager.get_user_by_sso_identity(
+            FEISHU_PROVIDER_NAME,
+            user.open_id,
+        )
+        created = False
+        linked = False
+        updated = False
+
+        existing_user = (
+            self.user_repo.get_user_by_id(existing_user_id)
+            if existing_user_id is not None
+            else None
+        )
+        if existing_user and existing_user.get("tenant_id") not in (None, tenant_id):
+            result.warnings.append(
+                f"Skipped Feishu user {user.open_id}: linked local user belongs to tenant "
+                f"{existing_user.get('tenant_id')}, expected tenant {tenant_id}"
+            )
+            return None, False, False, False
+
+        if existing_user is None and user.email:
+            email_user = self.user_repo.get_user_by_email(user.email)
+            if email_user:
+                if email_user.get("tenant_id") not in (None, tenant_id):
+                    result.warnings.append(
+                        f"Skipped Feishu user {user.open_id}: email {user.email} is already "
+                        f"owned by tenant {email_user.get('tenant_id')}"
+                    )
+                    return None, False, False, False
+                existing_user = email_user
+                existing_user_id = int(email_user["id"])
+                linked = True
+
+        if existing_user is None:
+            username = self._build_username(user.name, user.email, user.open_id)
+            email = user.email or f"{user.open_id}@{FEISHU_PLACEHOLDER_EMAIL_DOMAIN}"
+            existing_user_id = self.user_repo.create_user(
+                username=username,
+                email=email,
+                password_hash="",
+                role="user",
+                tenant_id=tenant_id,
+            )
+            if existing_user_id is None:
+                result.warnings.append(
+                    f"Failed to create local user for Feishu user {user.open_id}"
+                )
+                return None, False, False, False
+            existing_user = self.user_repo.get_user_by_id(existing_user_id)
+            created = True
+        else:
+            existing_user_id = int(existing_user["id"])
+
+        if existing_user is None:
+            return None, created, linked, updated
+
+        current_email = str(existing_user.get("email") or "")
+        next_email = user.email or current_email
+        if (
+            user.email
+            and user.email != current_email
+            and (not current_email or current_email.endswith(f"@{FEISHU_PLACEHOLDER_EMAIL_DOMAIN}"))
+        ):
+            if self.user_repo.update_user(user_id=existing_user_id, email=user.email):
+                updated = True
+
+        provider_data = {
+            "open_id": user.open_id,
+            "name": user.name,
+            "email": next_email,
+            "department_ids": list(user.department_ids),
+            "status": user.status,
+            "synced_by": "feishu_org_sync",
+            "synced_at": datetime.now(timezone.utc).replace(tzinfo=None).isoformat(),
+        }
+        self.sso_manager.link_identity(
+            user_id=existing_user_id,
+            provider_name=FEISHU_PROVIDER_NAME,
+            provider_user_id=user.open_id,
+            provider_data=provider_data,
+        )
+        return existing_user_id, created, linked or not created, updated
+
+    def _sync_memberships(
+        self,
+        expected_memberships: set[tuple[str, int]],
+        synced_team_ids: set[str],
+        result: FeishuOrgSyncResult,
+    ) -> None:
+        """Reconcile team memberships for Feishu-synced teams."""
+        if not synced_team_ids:
+            return
+
+        all_rows = self.db.fetch_all("SELECT team_id, user_id FROM team_members")
+        current_memberships = {
+            (str(row["team_id"]), int(row["user_id"]))
+            for row in all_rows
+            if str(row["team_id"]) in synced_team_ids
+        }
+
+        to_remove = current_memberships - expected_memberships
+        for team_id, user_id in sorted(to_remove):
+            self.db.execute(
+                "DELETE FROM team_members WHERE team_id = ? AND user_id = ?",
+                (team_id, user_id),
+            )
+            result.memberships_removed += 1
+
+        to_add = expected_memberships - current_memberships
+        for team_id, user_id in sorted(to_add):
+            local_user = self.user_repo.get_user_by_id(user_id)
+            username = str(local_user.get("username") or "") if local_user else ""
+            self.db.execute(
+                """
+                INSERT INTO team_members (team_id, user_id, username, role, joined_at)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                (
+                    team_id,
+                    user_id,
+                    username,
+                    "member",
+                    datetime.now(timezone.utc).replace(tzinfo=None).isoformat(),
+                ),
+            )
+            result.memberships_added += 1
+
+    def _build_username(self, display_name: str, email: str | None, open_id: str) -> str:
+        """Generate a stable, unique username for a synced Feishu user."""
+        base = ""
+        if email and "@" in email:
+            base = email.split("@", 1)[0]
+        if not base:
+            base = display_name or f"feishu_{open_id[-8:]}"
+
+        slug = re.sub(r"[^a-zA-Z0-9._-]+", "_", base).strip("._-").lower()
+        if not slug:
+            slug = f"feishu_{open_id[-8:]}"
+
+        candidate = slug
+        counter = 1
+        while self.user_repo.get_user_by_username(candidate):
+            candidate = f"{slug}_{counter}"
+            counter += 1
+        return candidate

--- a/config/CONFIG_GUIDE.md
+++ b/config/CONFIG_GUIDE.md
@@ -119,11 +119,14 @@
 | `cron.enabled` | 是否启用定时任务 | `true` |
 | `cron.run_time` | 每日运行时间（HH:MM 格式） | `00:30` |
 
-#### 飞书通知（可选）
-| 参数 | 说明 | 示例值 |
-|------|------|--------|
+#### 飞书集成（可选）
+| 参数 | 说明 | 默认值 / 示例值 |
+|------|------|----------------|
 | `feishu.app_id` | 飞书应用 App ID | `cli_xxxxxxxxxxxxx` |
 | `feishu.app_secret` | 飞书应用 Secret | `xxxxxxxxxxxxxxxxx` |
+| `feishu.org_sync_enabled` | 是否启用飞书组织架构自动同步 | `false` |
+| `feishu.org_sync_tenant_id` | 同步写入的租户 ID | `1` |
+| `feishu.org_sync_interval_minutes` | 自动同步间隔（分钟） | `60` |
 
 #### 钉钉集成（可选）
 | 参数 | 说明 | 示例值 |

--- a/config/config.json.sample
+++ b/config/config.json.sample
@@ -54,7 +54,10 @@
   },
   "feishu": {
     "app_id": "<FEISHU_APP_ID>",
-    "app_secret": "<FEISHU_APP_SECRET>"
+    "app_secret": "<FEISHU_APP_SECRET>",
+    "org_sync_enabled": false,
+    "org_sync_tenant_id": 1,
+    "org_sync_interval_minutes": 60
   },
   "dingtalk": {
     "app_key": "<DINGTALK_APP_KEY>",

--- a/docs/cn/FEISHU_CONFIG.md
+++ b/docs/cn/FEISHU_CONFIG.md
@@ -2,7 +2,10 @@
 
 > **ACE** = **AI Computing Explorer**
 
-本指南说明如何配置飞书（Lark）集成，以显示真实用户名和群组名而非 ID。
+本指南说明如何配置飞书（Lark）集成，实现以下两类能力：
+
+- 导入会话时把飞书用户/群组 ID 解析成人名/群名
+- 将飞书组织架构同步到 Open ACE 的本地用户与团队
 
 ## 概述
 
@@ -10,6 +13,8 @@ Open ACE 可以与飞书集成以实现以下功能：
 
 - 显示真实用户名而非 `ou_xxxxx` ID
 - 显示群组名而非 `oc_xxxxx` 标识符
+- 将飞书部门同步为 Open ACE 协作团队
+- 将飞书用户同步为本地用户与团队成员关系
 
 ## 前提条件
 
@@ -35,6 +40,7 @@ Open ACE 可以与飞书集成以实现以下功能：
 | 权限 | 说明 |
 |------|------|
 | `contact:contact:user:readonly` | 读取用户信息 |
+| `contact:contact:department:readonly` | 读取部门信息 |
 | `chat:chat:readonly` | 读取群聊信息 |
 
 3. 如有需要，提交审批
@@ -48,7 +54,10 @@ Open ACE 可以与飞书集成以实现以下功能：
 {
   "feishu": {
     "app_id": "cli_xxxxxxxxxxxxxxxx",
-    "app_secret": "your_app_secret_here"
+    "app_secret": "your_app_secret_here",
+    "org_sync_enabled": true,
+    "org_sync_tenant_id": 1,
+    "org_sync_interval_minutes": 60
   }
 }
 ```
@@ -62,6 +71,29 @@ python3 scripts/shared/feishu_user_cache.py test ou_xxxxx <app_id> <app_secret>
 # 测试群组信息查询
 python3 scripts/shared/feishu_group_cache.py test chat_xxxxx <app_id> <app_secret>
 ```
+
+### 5. 同步组织架构
+
+保存配置后：
+
+1. 如果修改了 `config.json`，先重启 Open ACE
+2. 打开 `管理 -> 用户`
+3. 点击 `同步飞书`
+
+当 `feishu.org_sync_enabled=true` 时，后台数据抓取调度器还会按照 `feishu.org_sync_interval_minutes` 周期性执行自动同步。
+
+当前同步行为：
+
+- 部门会映射为协作 `teams`
+- 用户会同步到本地 `users`
+- 飞书身份会写入 `sso_identities`
+- 飞书管理的团队成员关系会按最新组织结构对齐
+
+当前暂不处理：
+
+- 用户从飞书消失后自动禁用/删除本地账号
+- 部门删除后自动删除本地团队
+- 飞书 SSO 登录流程
 
 ## 缓存管理
 
@@ -98,6 +130,12 @@ python3 scripts/shared/feishu_group_cache.py test chat_xxxxx <app_id> <app_secre
 - 验证 App ID 和 App Secret
 - 确保应用已发布
 - 检查权限是否已审批
+
+### 组织同步人数少于预期
+
+- 检查应用是否对目标部门有读取权限
+- 检查同邮箱的本地用户是否已归属到其他租户
+- 查看服务端日志中的 `Skipped Feishu user ...` 告警
 
 ## 禁用集成
 

--- a/docs/en/FEISHU_CONFIG.md
+++ b/docs/en/FEISHU_CONFIG.md
@@ -2,7 +2,10 @@
 
 > **ACE** = **AI Computing Explorer**
 
-This guide explains how to configure Feishu (Lark) integration to display real user names and group names instead of IDs.
+This guide explains how to configure Feishu (Lark) integration for:
+
+- imported-session user and group name resolution
+- local org sync of Feishu departments and users into Open ACE teams and users
 
 ## Overview
 
@@ -10,6 +13,8 @@ Open ACE can integrate with Feishu to:
 
 - Display real user names instead of `ou_xxxxx` IDs
 - Display group names instead of `oc_xxxxx` identifiers
+- Sync Feishu departments into Open ACE collaboration teams
+- Sync Feishu users into local users + team memberships
 
 ## Prerequisites
 
@@ -35,6 +40,7 @@ In the app settings:
 | Permission | Description |
 |------------|-------------|
 | `contact:contact:user:readonly` | Read user information |
+| `contact:contact:department:readonly` | Read department information |
 | `chat:chat:readonly` | Read chat information |
 
 3. Submit for approval if required
@@ -48,7 +54,10 @@ Edit `~/.open-ace/config.json`:
 {
   "feishu": {
     "app_id": "cli_xxxxxxxxxxxxxxxx",
-    "app_secret": "your_app_secret_here"
+    "app_secret": "your_app_secret_here",
+    "org_sync_enabled": true,
+    "org_sync_tenant_id": 1,
+    "org_sync_interval_minutes": 60
   }
 }
 ```
@@ -62,6 +71,29 @@ python3 scripts/shared/feishu_user_cache.py test ou_xxxxx <app_id> <app_secret>
 # Test group info query
 python3 scripts/shared/feishu_group_cache.py test chat_xxxxx <app_id> <app_secret>
 ```
+
+### 5. Sync the organization structure
+
+After saving the config:
+
+1. Restart Open ACE if you changed `config.json`
+2. Open `Manage -> Users`
+3. Click `Sync Feishu`
+
+When `feishu.org_sync_enabled=true`, the background data-fetch scheduler also performs periodic sync based on `feishu.org_sync_interval_minutes`.
+
+Current sync behavior:
+
+- departments are mirrored into collaboration `teams`
+- users are provisioned into local `users`
+- Feishu identities are linked through `sso_identities`
+- team memberships are reconciled for Feishu-managed teams
+
+Current non-goals:
+
+- disabling or deleting local users when they disappear from Feishu
+- removing Feishu-managed teams automatically when departments disappear
+- Feishu SSO login flow
 
 ## Cache Management
 
@@ -98,6 +130,12 @@ User and group information is cached to avoid frequent API calls.
 - Verify App ID and App Secret
 - Ensure the app is published
 - Check if permissions are approved
+
+### Org sync creates fewer users than expected
+
+- Check whether the app can read the relevant departments
+- Check whether an existing local user with the same email belongs to another tenant
+- Review server logs for `Skipped Feishu user ...` warnings
 
 ## Disabling Integration
 

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -88,6 +88,22 @@ export interface QuotaStats {
   };
 }
 
+export interface FeishuSyncResult {
+  tenant_id: number;
+  departments_seen: number;
+  users_seen: number;
+  teams_created: number;
+  teams_updated: number;
+  users_created: number;
+  users_linked: number;
+  users_updated: number;
+  memberships_added: number;
+  memberships_removed: number;
+  started_at?: string | null;
+  finished_at?: string | null;
+  warnings: string[];
+}
+
 export interface AuditLogEntry {
   id: number;
   user_id: number;
@@ -170,5 +186,12 @@ export const adminApi = {
 
   async updateUserQuota(userId: number, data: UpdateQuotaRequest): Promise<{ success: boolean }> {
     return apiClient.put<{ success: boolean }>(`/api/admin/users/${userId}/quota`, data);
+  },
+
+  async syncFeishuOrg(tenantId?: number): Promise<{ success: boolean; result: FeishuSyncResult }> {
+    return apiClient.post<{ success: boolean; result: FeishuSyncResult }>(
+      '/api/admin/feishu/sync',
+      tenantId ? { tenant_id: tenantId } : {}
+    );
   },
 };

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -32,6 +32,7 @@ export type {
   UpdateUserRequest,
   UpdateQuotaRequest,
   QuotaUsage,
+  FeishuSyncResult,
 } from './admin';
 export { governanceApi } from './governance';
 export type {

--- a/frontend/src/components/features/management/UserManagement.tsx
+++ b/frontend/src/components/features/management/UserManagement.tsx
@@ -9,6 +9,7 @@ import {
   useUpdateUser,
   useDeleteUser,
   useResetUserPassword,
+  useSyncFeishuOrg,
   usePageRefresh,
   useSecuritySettings,
   useTenants,
@@ -43,6 +44,7 @@ export const UserManagement: React.FC = () => {
   const updateUser = useUpdateUser();
   const deleteUser = useDeleteUser();
   const resetUserPassword = useResetUserPassword();
+  const syncFeishuOrg = useSyncFeishuOrg();
 
   // Temporary password modal state
   const [showTempPasswordModal, setShowTempPasswordModal] = useState(false);
@@ -269,6 +271,26 @@ export const UserManagement: React.FC = () => {
     }
   };
 
+  const handleSyncFeishu = async () => {
+    const buttonLabel = language === 'zh' ? '同步飞书' : 'Sync Feishu';
+    try {
+      const response = await syncFeishuOrg.mutateAsync(selectedTenantId);
+      const summary = response.result;
+      const message =
+        language === 'zh'
+          ? `部门 ${summary.departments_seen}，用户 ${summary.users_seen}，新增团队 ${summary.teams_created}，新增成员关系 ${summary.memberships_added}`
+          : `Departments ${summary.departments_seen}, users ${summary.users_seen}, teams created ${summary.teams_created}, memberships added ${summary.memberships_added}`;
+      toast.success(buttonLabel, message);
+      await refetch();
+    } catch (err) {
+      console.error('Failed to sync Feishu org:', err);
+      toast.error(
+        buttonLabel,
+        (err as Error)?.message || (language === 'zh' ? '飞书同步失败' : 'Feishu sync failed')
+      );
+    }
+  };
+
   const handleCloseTempPasswordModal = () => {
     setShowTempPasswordModal(false);
     setTempPassword('');
@@ -328,6 +350,16 @@ export const UserManagement: React.FC = () => {
             showIntervalSelector={false}
             showLastRefreshTime={true}
           />
+
+          <Button
+            variant="outline-primary"
+            size="sm"
+            onClick={handleSyncFeishu}
+            disabled={syncFeishuOrg.isPending}
+          >
+            <i className="bi bi-cloud-arrow-down me-1" />
+            {language === 'zh' ? '同步飞书' : 'Sync Feishu'}
+          </Button>
 
           {/* 添加用户按钮：柔和圆角主色按钮 */}
           <Button variant="primary" size="sm" onClick={handleOpenCreate}>

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -27,6 +27,7 @@ export {
   useDeleteUser,
   useUpdateUserPassword,
   useResetUserPassword,
+  useSyncFeishuOrg,
   useTenants,
   useQuotaUsage,
   useQuotaStats,

--- a/frontend/src/hooks/useAdmin.ts
+++ b/frontend/src/hooks/useAdmin.ts
@@ -74,6 +74,17 @@ export function useResetUserPassword() {
   });
 }
 
+export function useSyncFeishuOrg() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (tenantId?: number) => adminApi.syncFeishuOrg(tenantId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['admin', 'users'] });
+    },
+  });
+}
+
 // Tenant Management Hooks
 export function useTenants() {
   return useQuery({

--- a/tests/routes/test_admin_feishu_sync.py
+++ b/tests/routes/test_admin_feishu_sync.py
@@ -1,0 +1,69 @@
+"""Route tests for manual Feishu org sync admin API."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture
+def app():
+    """Create a minimal Flask app with admin routes."""
+    from flask import Flask
+
+    from app.routes.admin import admin_bp
+
+    app = Flask(__name__)
+    app.register_blueprint(admin_bp, url_prefix="/api")
+    app.config["TESTING"] = True
+    app.config["SECRET_KEY"] = "test-secret-key"
+    return app
+
+
+@pytest.fixture
+def admin_client(app):
+    """Create an admin-authenticated client."""
+    test_client = app.test_client()
+
+    class AuthenticatedClient:
+        def __init__(self, client):
+            self._client = client
+
+        def post(self, *args, **kwargs):
+            with patch("app.auth.decorators._extract_token", return_value="test-token"):
+                with patch(
+                    "app.auth.decorators._load_user_from_token",
+                    return_value={"id": 1, "role": "admin", "username": "test_admin"},
+                ):
+                    return self._client.post(*args, **kwargs)
+
+    return AuthenticatedClient(test_client)
+
+
+def test_manual_feishu_sync_returns_summary(admin_client):
+    """Admin API should return the sync result payload."""
+
+    class DummyResult:
+        def to_dict(self):
+            return {"tenant_id": 3, "users_seen": 2, "teams_created": 1}
+
+    with patch(
+        "app.services.feishu_org_sync.FeishuOrgSyncService.sync_org",
+        return_value=DummyResult(),
+    ) as sync_org:
+        response = admin_client.post("/api/admin/feishu/sync", json={"tenant_id": 3})
+
+    assert response.status_code == 200
+    assert response.get_json() == {
+        "success": True,
+        "result": {"tenant_id": 3, "users_seen": 2, "teams_created": 1},
+    }
+    sync_org.assert_called_once_with(tenant_id=3)
+
+
+def test_manual_feishu_sync_validates_tenant_id(admin_client):
+    """Admin API should reject non-integer tenant_id values."""
+    response = admin_client.post("/api/admin/feishu/sync", json={"tenant_id": "oops"})
+    assert response.status_code == 400
+    assert "tenant_id" in response.get_json()["error"]

--- a/tests/unit/test_feishu_org_sync.py
+++ b/tests/unit/test_feishu_org_sync.py
@@ -1,0 +1,234 @@
+"""Unit tests for Feishu org synchronization."""
+
+from __future__ import annotations
+
+import pytest
+
+import app.utils.smtp_crypto as smtp_crypto
+from app.repositories.database import Database
+from app.repositories.schema_init import load_schema_from_file
+from app.repositories.user_repo import UserRepository
+from app.services.feishu_org_sync import (
+    FEISHU_PROVIDER_NAME,
+    FeishuDepartment,
+    FeishuOrgSyncService,
+    FeishuUser,
+)
+
+
+class FakeFeishuOrgSyncService(FeishuOrgSyncService):
+    """Deterministic Feishu sync service for tests."""
+
+    def __init__(self, *args, departments=None, users=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._departments = list(departments or [])
+        self._users = list(users or [])
+
+    def _get_tenant_access_token(self, app_id: str, app_secret: str) -> str:
+        assert app_id == "test-app-id"
+        assert app_secret == "test-app-secret"
+        return "test-token"
+
+    def _fetch_directory_snapshot(self, token: str):
+        assert token == "test-token"
+        return self._departments, self._users
+
+
+@pytest.fixture
+def sync_env(tmp_path, monkeypatch):
+    """Create an isolated SQLite-backed sync environment."""
+    monkeypatch.setenv("OPENACE_ENCRYPTION_KEY", "test-feishu-org-sync-key")
+    smtp_crypto._password_manager_instance = None
+
+    db = Database(db_url=f"sqlite:///{tmp_path / 'feishu-sync.db'}")
+    load_schema_from_file(db_url=db.db_url, dialect="sqlite")
+
+    config = {
+        "feishu": {
+            "app_id": "test-app-id",
+            "app_secret": "test-app-secret",
+            "org_sync_enabled": True,
+            "org_sync_tenant_id": 7,
+            "org_sync_interval_minutes": 60,
+        }
+    }
+
+    try:
+        yield db, config
+    finally:
+        smtp_crypto._password_manager_instance = None
+
+
+def test_sync_creates_users_teams_and_memberships(sync_env):
+    """A sync run should provision users, teams, memberships, and SSO links."""
+    db, config = sync_env
+    service = FakeFeishuOrgSyncService(
+        db=db,
+        user_repo=UserRepository(db=db),
+        config_override=config,
+        departments=[
+            FeishuDepartment(department_id="dep-eng", name="Engineering"),
+            FeishuDepartment(
+                department_id="dep-qa",
+                name="QA",
+                parent_department_id="dep-eng",
+            ),
+        ],
+        users=[
+            FeishuUser(
+                open_id="ou_alice",
+                name="Alice",
+                email="alice@example.com",
+                department_ids=["dep-eng"],
+            ),
+            FeishuUser(
+                open_id="ou_bob",
+                name="Bob",
+                department_ids=["dep-qa"],
+            ),
+        ],
+    )
+
+    result = service.sync_org()
+
+    assert result.tenant_id == 7
+    assert result.departments_seen == 2
+    assert result.users_seen == 2
+    assert result.teams_created == 2
+    assert result.users_created == 2
+    assert result.memberships_added == 2
+    assert result.warnings == []
+
+    users = db.fetch_all("SELECT username, email, tenant_id FROM users ORDER BY email ASC")
+    assert users == [
+        {
+            "username": "alice",
+            "email": "alice@example.com",
+            "tenant_id": 7,
+        },
+        {
+            "username": "bob",
+            "email": "ou_bob@feishu.local",
+            "tenant_id": 7,
+        },
+    ]
+
+    teams = db.fetch_all("SELECT team_id, name, settings FROM teams ORDER BY name ASC")
+    assert [team["name"] for team in teams] == ["Engineering", "QA"]
+    assert all(FEISHU_PROVIDER_NAME in team["settings"] for team in teams)
+
+    identities = db.fetch_all(
+        """
+        SELECT provider_name, provider_user_id
+        FROM sso_identities
+        ORDER BY provider_user_id ASC
+        """
+    )
+    assert identities == [
+        {"provider_name": FEISHU_PROVIDER_NAME, "provider_user_id": "ou_alice"},
+        {"provider_name": FEISHU_PROVIDER_NAME, "provider_user_id": "ou_bob"},
+    ]
+
+    memberships = db.fetch_all(
+        """
+        SELECT tm.user_id, t.name AS team_name
+        FROM team_members tm
+        JOIN teams t ON t.team_id = tm.team_id
+        ORDER BY team_name ASC
+        """
+    )
+    assert [row["team_name"] for row in memberships] == ["Engineering", "QA"]
+
+
+def test_sync_reuses_existing_user_by_email_and_removes_stale_membership(sync_env):
+    """Sync should link by email and prune memberships on Feishu-managed teams."""
+    db, config = sync_env
+    user_repo = UserRepository(db=db)
+
+    existing_user_id = user_repo.create_user(
+        username="alice_local",
+        email="alice@example.com",
+        password_hash="hash",
+        tenant_id=7,
+    )
+    stale_user_id = user_repo.create_user(
+        username="stale",
+        email="stale@example.com",
+        password_hash="hash",
+        tenant_id=7,
+    )
+    assert existing_user_id is not None
+    assert stale_user_id is not None
+
+    service = FakeFeishuOrgSyncService(
+        db=db,
+        user_repo=user_repo,
+        config_override=config,
+        departments=[FeishuDepartment(department_id="dep-eng", name="Engineering")],
+        users=[
+            FeishuUser(
+                open_id="ou_alice",
+                name="Alice",
+                email="alice@example.com",
+                department_ids=["dep-eng"],
+            )
+        ],
+    )
+
+    first_result = service.sync_org()
+    assert first_result.users_created == 0
+    assert first_result.users_linked == 1
+
+    synced_team = db.fetch_one("SELECT team_id FROM teams WHERE name = ?", ("Engineering",))
+    assert synced_team is not None
+    db.execute(
+        """
+        INSERT INTO team_members (team_id, user_id, username, role, joined_at)
+        VALUES (?, ?, ?, ?, ?)
+        """,
+        (
+            synced_team["team_id"],
+            stale_user_id,
+            "stale",
+            "member",
+            "2026-07-17T00:00:00",
+        ),
+    )
+
+    second_result = service.sync_org()
+    assert second_result.memberships_removed == 1
+
+    members = db.fetch_all(
+        "SELECT user_id FROM team_members WHERE team_id = ? ORDER BY user_id ASC",
+        (synced_team["team_id"],),
+    )
+    assert members == [{"user_id": existing_user_id}]
+
+
+def test_scheduler_gate_runs_only_when_enabled(sync_env):
+    """Scheduled sync should obey config and interval gates."""
+    db, config = sync_env
+    service = FakeFeishuOrgSyncService(
+        db=db,
+        user_repo=UserRepository(db=db),
+        config_override=config,
+        departments=[],
+        users=[],
+    )
+
+    service.__class__._last_scheduled_sync_at = None
+
+    first = service.maybe_sync_from_scheduler()
+    assert first is not None
+
+    second = service.maybe_sync_from_scheduler()
+    assert second is None
+
+    disabled = FakeFeishuOrgSyncService(
+        db=db,
+        user_repo=UserRepository(db=db),
+        config_override={"feishu": {**config["feishu"], "org_sync_enabled": False}},
+        departments=[],
+        users=[],
+    )
+    assert disabled.maybe_sync_from_scheduler() is None


### PR DESCRIPTION
## Summary
- add a real Feishu organization sync service that provisions departments, users, identities, and memberships
- expose manual sync from admin user management and optional scheduled sync via config
- document the supported Feishu scope, sync behavior, and current non-goals

## Testing
- ruff check app/services/feishu_org_sync.py app/routes/admin.py app/services/data_fetch_scheduler.py tests/unit/test_feishu_org_sync.py tests/routes/test_admin_feishu_sync.py
- pytest tests/unit/test_feishu_org_sync.py tests/routes/test_admin_feishu_sync.py tests/routes/test_auth_must_change_enforcement.py tests/issues/762/test_autonomous_config.py -q

Closes #1772