### PR TITLE
fix: guard SSO outbound URLs against SSRF

### DIFF
--- a/app/modules/sso/oauth2.py
+++ b/app/modules/sso/oauth2.py
@@ -12,6 +12,8 @@ import urllib.parse
 from datetime import datetime, timedelta, timezone
 from typing import Any, Optional
 
+import requests
+
 from app.modules.sso.provider import (
     SSOAuthResult,
     SSOProvider,
@@ -19,6 +21,7 @@ from app.modules.sso.provider import (
     SSOToken,
     SSOUser,
 )
+from app.utils.outbound_url_guard import OutboundUrlBlockedError, assert_public_http_url
 
 logger = logging.getLogger(__name__)
 
@@ -98,22 +101,41 @@ class OAuth2Provider(SSOProvider):
             data["code_verifier"] = code_verifier
 
         try:
-            # Use synchronous HTTP request
-            import json
-            import urllib.request
-
-            req = urllib.request.Request(
+            assert_public_http_url(self.config.token_url)
+            response = requests.post(
                 self.config.token_url,
-                data=urllib.parse.urlencode(data).encode("utf-8"),
+                data=urllib.parse.urlencode(data),
                 headers={
                     "Accept": "application/json",
                     "Content-Type": "application/x-www-form-urlencoded",
                 },
+                timeout=30,
+                allow_redirects=False,
             )
 
-            with urllib.request.urlopen(req, timeout=30) as response:
-                token_data = json.loads(response.read().decode("utf-8"))
+            if 300 <= response.status_code < 400:
+                return SSOAuthResult(
+                    success=False,
+                    error="token_exchange_blocked",
+                    error_description="Token endpoint redirects are blocked",
+                )
 
+            if response.status_code >= 400:
+                try:
+                    error_data = response.json()
+                    return SSOAuthResult(
+                        success=False,
+                        error=error_data.get("error", "token_exchange_failed"),
+                        error_description=error_data.get("error_description"),
+                    )
+                except ValueError:
+                    return SSOAuthResult(
+                        success=False,
+                        error="token_exchange_failed",
+                        error_description=response.text,
+                    )
+
+            token_data = response.json()
             token = self._parse_token_response(token_data)
 
             return SSOAuthResult(
@@ -121,24 +143,13 @@ class OAuth2Provider(SSOProvider):
                 token=token,
             )
 
-        except urllib.error.HTTPError as e:
-            error_body = e.read().decode("utf-8")
-            logger.error(f"OAuth2 token exchange failed: {e.code} - {error_body}")
-
-            try:
-                error_data = json.loads(error_body)
-                return SSOAuthResult(
-                    success=False,
-                    error=error_data.get("error", "token_exchange_failed"),
-                    error_description=error_data.get("error_description"),
-                )
-            except json.JSONDecodeError:
-                return SSOAuthResult(
-                    success=False,
-                    error="token_exchange_failed",
-                    error_description=error_body,
-                )
-
+        except OutboundUrlBlockedError as e:
+            logger.error(f"OAuth2 token endpoint blocked: {e}")
+            return SSOAuthResult(
+                success=False,
+                error="token_exchange_blocked",
+                error_description=str(e),
+            )
         except Exception as e:
             logger.error(f"OAuth2 token exchange error: {e}")
             return SSOAuthResult(
@@ -162,22 +173,29 @@ class OAuth2Provider(SSOProvider):
             return None
 
         try:
-            import json
-            import urllib.request
-
-            req = urllib.request.Request(
+            assert_public_http_url(self.config.userinfo_url)
+            response = requests.get(
                 self.config.userinfo_url,
                 headers={
                     "Authorization": f"Bearer {access_token}",
                     "Accept": "application/json",
                 },
+                timeout=30,
+                allow_redirects=False,
             )
 
-            with urllib.request.urlopen(req, timeout=30) as response:
-                user_data = json.loads(response.read().decode("utf-8"))
+            if 300 <= response.status_code < 400:
+                logger.error("SSO userinfo endpoint redirect blocked")
+                return None
+
+            response.raise_for_status()
+            user_data = response.json()
 
             return self._parse_user_info(user_data)
 
+        except OutboundUrlBlockedError as e:
+            logger.error(f"SSO userinfo endpoint blocked: {e}")
+            return None
         except Exception as e:
             logger.error(f"Failed to get user info: {e}")
             return None
@@ -200,23 +218,30 @@ class OAuth2Provider(SSOProvider):
         }
 
         try:
-            import json
-            import urllib.request
-
-            req = urllib.request.Request(
+            assert_public_http_url(self.config.token_url)
+            response = requests.post(
                 self.config.token_url,
-                data=urllib.parse.urlencode(data).encode("utf-8"),
+                data=urllib.parse.urlencode(data),
                 headers={
                     "Accept": "application/json",
                     "Content-Type": "application/x-www-form-urlencoded",
                 },
+                timeout=30,
+                allow_redirects=False,
             )
 
-            with urllib.request.urlopen(req, timeout=30) as response:
-                token_data = json.loads(response.read().decode("utf-8"))
+            if 300 <= response.status_code < 400:
+                logger.error("SSO token refresh endpoint redirect blocked")
+                return None
+
+            response.raise_for_status()
+            token_data = response.json()
 
             return self._parse_token_response(token_data)
 
+        except OutboundUrlBlockedError as e:
+            logger.error(f"SSO token refresh endpoint blocked: {e}")
+            return None
         except Exception as e:
             logger.error(f"Failed to refresh token: {e}")
             return None
@@ -323,19 +348,24 @@ class GitHubProvider(OAuth2Provider):
         if user and not user.email:
             # Fetch emails endpoint if primary email not in user info
             try:
-                import json
-                import urllib.request
-
-                req = urllib.request.Request(
-                    "https://api.github.com/user/emails",
+                email_url = "https://api.github.com/user/emails"
+                assert_public_http_url(email_url)
+                response = requests.get(
+                    email_url,
                     headers={
                         "Authorization": f"Bearer {access_token}",
                         "Accept": "application/json",
                     },
+                    timeout=30,
+                    allow_redirects=False,
                 )
 
-                with urllib.request.urlopen(req, timeout=30) as response:
-                    emails = json.loads(response.read().decode("utf-8"))
+                if 300 <= response.status_code < 400:
+                    logger.warning("GitHub emails endpoint redirect blocked")
+                    return user
+
+                response.raise_for_status()
+                emails = response.json()
 
                 # Find primary verified email
                 for email_info in emails:

--- a/app/modules/sso/oidc.py
+++ b/app/modules/sso/oidc.py
@@ -18,6 +18,7 @@ import requests
 
 from app.modules.sso.oauth2 import OAuth2Provider
 from app.modules.sso.provider import SSOAuthResult, SSOProviderConfig, SSOUser
+from app.utils.outbound_url_guard import OutboundUrlBlockedError, assert_public_http_url
 
 logger = logging.getLogger(__name__)
 
@@ -155,7 +156,11 @@ class OIDCProvider(OAuth2Provider):
         jwks_url = f"{self.config.issuer_url.rstrip('/')}/.well-known/jwks.json"
 
         try:
-            response = requests.get(jwks_url, timeout=10)
+            assert_public_http_url(jwks_url)
+            response = requests.get(jwks_url, timeout=10, allow_redirects=False)
+            status_code = response.status_code if isinstance(response.status_code, int) else 200
+            if 300 <= status_code < 400:
+                raise ValueError("JWKS endpoint redirects are blocked")
             response.raise_for_status()
             jwks = response.json()
 
@@ -166,6 +171,9 @@ class OIDCProvider(OAuth2Provider):
             logger.debug(f"Successfully fetched JWKS from {jwks_url}")
             return cast("dict[str, Any]", jwks)
 
+        except OutboundUrlBlockedError as e:
+            logger.error(f"JWKS endpoint blocked: {e}")
+            raise ValueError(f"JWKS endpoint blocked: {e}")
         except requests.RequestException as e:
             logger.error(f"Failed to fetch JWKS from {jwks_url}: {e}")
             raise ValueError(f"Failed to fetch JWKS: {e}")

--- a/app/routes/sso.py
+++ b/app/routes/sso.py
@@ -21,6 +21,7 @@ from app.modules.sso.provider import get_provider_config, list_providers
 from app.repositories.database import adapt_boolean_value
 from app.repositories.user_repo import UserRepository
 from app.services.auth_service import _get_session_timeout_hours
+from app.utils.outbound_url_guard import OutboundUrlBlockedError, assert_public_http_url
 
 logger = logging.getLogger(__name__)
 
@@ -900,23 +901,49 @@ def _test_url_accessible(url: str) -> dict:
         dict: {"success": bool, "error": str or None}
     """
     try:
-        # Try HEAD first
-        response = requests.head(url, timeout=10, allow_redirects=True)
+        current_url = url
+        method = "HEAD"
 
-        # If HEAD not allowed (405), try GET
-        if response.status_code == 405:
-            response = requests.get(url, timeout=10, stream=True, allow_redirects=True)
-            response.close()  # Don't read body
+        for _ in range(6):
+            assert_public_http_url(current_url)
 
-        if response.status_code < 400:
-            return {"success": True}
-        else:
+            if method == "HEAD":
+                response = requests.head(current_url, timeout=10, allow_redirects=False)
+            else:
+                response = requests.get(
+                    current_url,
+                    timeout=10,
+                    stream=True,
+                    allow_redirects=False,
+                )
+                response.close()  # Don't read body
+
+            if response.status_code == 405 and method == "HEAD":
+                method = "GET"
+                continue
+
+            if 300 <= response.status_code < 400:
+                from urllib.parse import urljoin
+
+                location = response.headers.get("Location")
+                if not location:
+                    return {"success": False, "error": "重定向响应缺少 Location"}
+                current_url = urljoin(current_url, location)
+                assert_public_http_url(current_url)
+                continue
+
+            if response.status_code < 400:
+                return {"success": True}
             return {"success": False, "error": f"HTTP {response.status_code}"}
+
+        return {"success": False, "error": "重定向次数过多"}
 
     except requests.Timeout:
         return {"success": False, "error": "连接超时"}
     except requests.ConnectionError:
         return {"success": False, "error": "无法连接到服务器"}
+    except OutboundUrlBlockedError as e:
+        return {"success": False, "error": f"URL 被安全策略拦截: {e}"}
     except Exception as e:
         return {"success": False, "error": str(e)}
 

--- a/app/utils/outbound_url_guard.py
+++ b/app/utils/outbound_url_guard.py
@@ -1,0 +1,119 @@
+"""
+Security checks for administrator-configured outbound HTTP(S) URLs.
+
+The guard is intentionally conservative: only globally routable HTTP(S)
+destinations are allowed by default. This prevents SSRF against loopback,
+private networks, link-local metadata endpoints, and other non-public ranges.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import socket
+from dataclasses import dataclass
+from typing import Callable, Iterable, Union
+from urllib.parse import urlparse
+
+Resolver = Callable[..., Iterable[tuple]]
+IPAddress = Union[ipaddress.IPv4Address, ipaddress.IPv6Address]
+
+BLOCKED_HOSTNAMES = {
+    "localhost",
+    "localhost.localdomain",
+    "metadata",
+    "metadata.google.internal",
+}
+
+
+@dataclass(frozen=True)
+class OutboundUrlValidationResult:
+    """Result for an outbound URL security validation."""
+
+    allowed: bool
+    error: str | None = None
+
+
+class OutboundUrlBlockedError(ValueError):
+    """Raised when an outbound URL fails SSRF protection."""
+
+
+def validate_public_http_url(
+    url: str,
+    *,
+    resolver: Resolver = socket.getaddrinfo,
+) -> OutboundUrlValidationResult:
+    """Validate that a URL points to a public HTTP(S) destination."""
+    if not url:
+        return OutboundUrlValidationResult(False, "URL is empty")
+
+    try:
+        parsed = urlparse(url)
+    except Exception:
+        return OutboundUrlValidationResult(False, "URL is invalid")
+
+    if parsed.scheme not in {"http", "https"}:
+        return OutboundUrlValidationResult(False, "Only http and https URLs are allowed")
+
+    if not parsed.hostname:
+        return OutboundUrlValidationResult(False, "URL host is required")
+
+    if parsed.username or parsed.password:
+        return OutboundUrlValidationResult(False, "URL credentials are not allowed")
+
+    host = parsed.hostname.rstrip(".").lower()
+    if host in BLOCKED_HOSTNAMES:
+        return OutboundUrlValidationResult(False, f"Blocked non-public host: {host}")
+
+    try:
+        ascii_host = host.encode("idna").decode("ascii")
+    except UnicodeError:
+        return OutboundUrlValidationResult(False, "URL host is invalid")
+
+    try:
+        addresses = _resolve_addresses(ascii_host, parsed.port, resolver)
+    except OSError as exc:
+        return OutboundUrlValidationResult(False, f"Host could not be resolved: {exc}")
+    except ValueError as exc:
+        return OutboundUrlValidationResult(False, str(exc))
+
+    if not addresses:
+        return OutboundUrlValidationResult(False, "Host did not resolve to an IP address")
+
+    for address in addresses:
+        if not _is_public_address(address):
+            return OutboundUrlValidationResult(
+                False,
+                f"Blocked non-public address: {address}",
+            )
+
+    return OutboundUrlValidationResult(True)
+
+
+def assert_public_http_url(url: str, *, resolver: Resolver = socket.getaddrinfo) -> None:
+    """Raise OutboundUrlBlockedError if a URL is not safe for outbound requests."""
+    result = validate_public_http_url(url, resolver=resolver)
+    if not result.allowed:
+        raise OutboundUrlBlockedError(result.error or "URL is blocked by outbound policy")
+
+
+def _resolve_addresses(host: str, port: int | None, resolver: Resolver) -> set[IPAddress]:
+    try:
+        return {_parse_ip_address(host)}
+    except ValueError:
+        pass
+
+    resolved: set[IPAddress] = set()
+    for info in resolver(host, port or 443, type=socket.SOCK_STREAM):
+        sockaddr = info[4]
+        if not sockaddr:
+            continue
+        resolved.add(_parse_ip_address(str(sockaddr[0])))
+    return resolved
+
+
+def _parse_ip_address(value: str) -> IPAddress:
+    return ipaddress.ip_address(value.split("%", 1)[0])
+
+
+def _is_public_address(address: IPAddress) -> bool:
+    return bool(address.is_global)

--- a/docs/cn/DEPLOYMENT.md
+++ b/docs/cn/DEPLOYMENT.md
@@ -286,6 +286,13 @@ cd /home/open-ace/open-ace
 | `OPENACE_CORS_ALLOWED_ORIGINS` | 非 loopback WebUI 源的显式 API CORS 白名单，多个值用逗号分隔 |
 | `OPENACE_WS_MAX_MESSAGE_BYTES` | 浏览器侧终端 / VSCode 原始桥接允许的入站 WebSocket 最大消息大小（默认 `8388608`） |
 
+### 出站 URL 安全
+
+管理员配置的 SSO/OIDC 端点 URL 会在 Open ACE 发起测试、token、userinfo 或 JWKS
+请求前进行校验。默认仅允许公网 `http` 和 `https` 目标；loopback、localhost、内网地址、
+link-local 网段、云 metadata 服务主机、带账号密码的 URL，以及解析到非公网地址的 DNS
+结果都会被拦截，以降低 SSRF 风险。
+
 ### 端口配置
 
 Open ACE 默认监听 19888 端口。如需修改端口，可根据部署方式选择以下方法。

--- a/docs/en/DEPLOYMENT.md
+++ b/docs/en/DEPLOYMENT.md
@@ -286,6 +286,14 @@ Configuration is stored in `~/.open-ace/config.json`:
 | `OPENACE_CORS_ALLOWED_ORIGINS` | Comma-separated explicit API CORS allowlist for non-loopback WebUI origins |
 | `OPENACE_WS_MAX_MESSAGE_BYTES` | Maximum inbound browser WebSocket message size for terminal / VSCode raw bridges (default: `8388608`) |
 
+### Outbound URL Security
+
+Administrator-configured SSO/OIDC endpoint URLs are validated before Open ACE sends
+test, token, userinfo, or JWKS requests. By default, only public `http` and
+`https` destinations are allowed. Loopback, localhost, private networks,
+link-local ranges, metadata service hosts, URL credentials, and non-public DNS
+results are blocked to reduce SSRF risk.
+
 ### Port Configuration
 
 Open ACE listens on port 19888 by default (Issue #1372: AI + ace mnemonic port). To change the port, use the appropriate method based on your deployment type.

--- a/tests/routes/test_sso_provider_storage.py
+++ b/tests/routes/test_sso_provider_storage.py
@@ -21,7 +21,8 @@ import app.utils.smtp_crypto as smtp_crypto
 from app.modules.sso.manager import SSOManager
 from app.repositories.database import Database, adapt_boolean_value
 from app.repositories.schema_init import load_schema_from_file
-from app.routes.sso import sso_bp
+from app.routes.sso import _test_url_accessible, sso_bp
+from app.utils.outbound_url_guard import OutboundUrlBlockedError
 
 ADMIN_SESSION = {
     "user_id": 1,
@@ -124,3 +125,27 @@ def test_update_provider_rewrites_legacy_plaintext_secret_as_encrypted(client, s
     assert restored["client_secret"] == "legacy-secret"
     assert restored["client_id"] == "updated-client"
     assert restored["authorization_url"] == "https://example.com/oauth2/authorize"
+
+
+def test_test_url_accessible_blocks_metadata_url_before_request():
+    with patch("app.routes.sso.requests.head") as mock_head:
+        result = _test_url_accessible("http://169.254.169.254/latest/meta-data/")
+
+    assert not result["success"]
+    assert "安全策略" in result["error"]
+    mock_head.assert_not_called()
+
+
+def test_test_url_accessible_blocks_redirect_to_private_address():
+    first_response = MagicMock()
+    first_response.status_code = 302
+    first_response.headers = {"Location": "http://127.0.0.1/admin"}
+
+    with patch("app.routes.sso.requests.head", return_value=first_response) as mock_head:
+        with patch("app.routes.sso.assert_public_http_url") as mock_guard:
+            mock_guard.side_effect = [None, OutboundUrlBlockedError("blocked non-public address")]
+            result = _test_url_accessible("https://sso.example.com/authorize")
+
+    assert not result["success"]
+    assert "blocked non-public address" in result["error"]
+    assert mock_head.call_count == 1

--- a/tests/unit/test_outbound_url_guard.py
+++ b/tests/unit/test_outbound_url_guard.py
@@ -1,0 +1,89 @@
+"""Unit tests for outbound URL SSRF protection."""
+
+import socket
+
+import pytest
+
+from app.utils.outbound_url_guard import (
+    OutboundUrlBlockedError,
+    assert_public_http_url,
+    validate_public_http_url,
+)
+
+
+def _resolver(*addresses):
+    def resolve(host, port, type=socket.SOCK_STREAM):
+        return [
+            (
+                socket.AF_INET6 if ":" in address else socket.AF_INET,
+                socket.SOCK_STREAM,
+                6,
+                "",
+                (address, port),
+            )
+            for address in addresses
+        ]
+
+    return resolve
+
+
+def test_allows_public_http_url_resolved_by_dns():
+    result = validate_public_http_url(
+        "https://login.example.com/oauth/token",
+        resolver=_resolver("93.184.216.34"),
+    )
+
+    assert result.allowed
+
+
+def test_allows_public_ip_address_without_dns_lookup():
+    result = validate_public_http_url("https://8.8.8.8/oauth/token")
+
+    assert result.allowed
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://localhost/admin",
+        "http://127.0.0.1:8080/admin",
+        "http://[::1]/admin",
+        "http://169.254.169.254/latest/meta-data/",
+        "http://metadata.google.internal/computeMetadata/v1/",
+        "ftp://example.com/file",
+        "https://user:pass@example.com/token",
+    ],
+)
+def test_rejects_non_public_and_unsafe_urls(url):
+    result = validate_public_http_url(url)
+
+    assert not result.allowed
+    assert result.error
+
+
+def test_rejects_dns_name_that_resolves_to_private_address():
+    result = validate_public_http_url(
+        "https://sso.example.com/token",
+        resolver=_resolver("10.1.2.3"),
+    )
+
+    assert not result.allowed
+    assert "10.1.2.3" in result.error
+
+
+def test_rejects_dns_name_when_any_address_is_not_public():
+    result = validate_public_http_url(
+        "https://sso.example.com/token",
+        resolver=_resolver("93.184.216.34", "192.168.1.10"),
+    )
+
+    assert not result.allowed
+    assert "192.168.1.10" in result.error
+
+
+def test_assert_public_http_url_raises_clear_exception():
+    with pytest.raises(OutboundUrlBlockedError, match="non-public"):
+        assert_public_http_url(
+            "https://sso.example.com/token",
+            resolver=_resolver("172.16.1.10"),
+        )


### PR DESCRIPTION
## Summary
- add a shared outbound URL guard for administrator-configured SSO/OIDC endpoints
- block localhost, private/link-local/non-global addresses, metadata hostnames, URL credentials, unsafe schemes, and unsafe redirect targets
- apply the guard to SSO connection tests, OAuth token/userinfo/refresh calls, GitHub email lookup, and OIDC JWKS fetches
- document the default outbound URL policy in deployment docs

## Tests
- /Users/rhuang/Library/Python/3.9/bin/pytest tests/unit/test_outbound_url_guard.py tests/routes/test_sso_provider_storage.py tests/issues/22/test_issue22.py -q
- SKIP=bandit /Users/rhuang/Library/Python/3.9/bin/pre-commit run --all-files

Closes #1762