### PR TITLE
docs: clarify session scaling boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ open-ace/
 | [远程工作区](docs/cn/REMOTE-WORKSPACE.md) | 远程机器、Agent、API Key 代理与安全设计 |
 | [远程 Agent](docs/cn/REMOTE-AGENT.md) | Agent 安装、CLI 适配器、终端和会话同步 |
 | [权限模型](docs/cn/PERMISSION-MODEL.md) | 租户、角色与访问控制 |
-| [Kubernetes](docs/cn/KUBERNETES.md) | K8s 单实例参考部署 |
+| [Kubernetes](docs/cn/KUBERNETES.md) | K8s 部署参考（多副本 + 粘性会话边界） |
 | [飞书配置](docs/cn/FEISHU_CONFIG.md) | 飞书集成配置 |
 | [钉钉配置](docs/cn/DINGTALK_CONFIG.md) | 钉钉集成配置 |
 | [API 文档](docs/cn/API.md) | API 接口说明 |
@@ -605,7 +605,7 @@ The `docs/` directory is the source of truth for product documentation. The publ
 | [Remote Workspace](docs/en/REMOTE-WORKSPACE.md) | Remote machines, Agent, API Key proxy, and security design |
 | [Remote Agent](docs/en/REMOTE-AGENT.md) | Agent install, CLI adapters, terminal, and session sync |
 | [Permission Model](docs/en/PERMISSION-MODEL.md) | Tenants, roles, and access control |
-| [Kubernetes](docs/en/KUBERNETES.md) | Single-instance K8s deployment reference |
+| [Kubernetes](docs/en/KUBERNETES.md) | K8s deployment reference with multi-replica sticky-session boundaries |
 | [Feishu Config](docs/en/FEISHU_CONFIG.md) | Feishu integration |
 | [DingTalk Config](docs/en/DINGTALK_CONFIG.md) | DingTalk integration |
 | [API Reference](docs/en/API.md) | API documentation |

--- a/app/modules/workspace/remote_agent_manager.py
+++ b/app/modules/workspace/remote_agent_manager.py
@@ -46,6 +46,11 @@ class RemoteAgentManager:
 
     Tracks active agent connections, monitors heartbeats, dispatches
     commands to agents, and routes agent responses back to sessions.
+
+    Runtime boundary: connection objects, output buffers, HTTP polling command
+    queues, and pending request events are process-local. Multi-pod deployments
+    require sticky routing for active remote sessions until issue #1782 moves
+    shareable state into Redis or another persistent coordination layer.
     """
 
     HEARTBEAT_TIMEOUT_SECONDS = 180  # 3 minutes without heartbeat = offline
@@ -78,7 +83,9 @@ class RemoteAgentManager:
             self.db = Database(db_url=f"sqlite:///{self.db_path}")
         else:
             self.db = Database()
-        # Active WebSocket connections: {machine_id: websocket_connection}
+        # Process-local WebSocket connections: {machine_id: websocket_connection}.
+        # See the class docstring and issue #1782 before removing sticky routing
+        # from Kubernetes or other horizontally scaled deployments.
         self._connections: dict[str, Any] = {}
         # Session to machine mapping: {session_id: machine_id}
         self._session_machines: dict[str, str] = {}

--- a/app/modules/workspace/session_access.py
+++ b/app/modules/workspace/session_access.py
@@ -34,7 +34,8 @@ def check_session_access(
     status = session_mgr.get_session_status(session_id)
     if not status:
         return None, (jsonify({"error": "Session not found"}), 404)
-    # System admin
+    # System admins intentionally have global session visibility for operations.
+    # Tenant-scoped data-model hardening is tracked in issue #1781.
     if g.user.get("role") == "admin":
         return status, None
     # Session owner

--- a/app/modules/workspace/terminal_relay_store.py
+++ b/app/modules/workspace/terminal_relay_store.py
@@ -6,6 +6,10 @@ bridges browser WebSocket connections through this relay to the remote terminal.
 
 This solves the issue where backend cannot directly connect to ws://192.168.x.x:port
 because the remote machine is behind NAT or on a private network.
+
+The relay WebSocket objects are process-local. Multi-pod deployments must keep
+agent/browser traffic for an active terminal on the same web pod until issue
+#1782 provides a shared coordination layer and reconnect protocol.
 """
 
 from __future__ import annotations

--- a/app/modules/workspace/terminal_store.py
+++ b/app/modules/workspace/terminal_store.py
@@ -1,4 +1,9 @@
-"""In-memory store for terminal session info with TTL-based cleanup."""
+"""In-memory store for terminal session info with TTL-based cleanup.
+
+This store is process-local. Kubernetes and other multi-pod deployments must
+use sticky routing for active terminal sessions until issue #1782 externalizes
+the shareable remote-session runtime state.
+"""
 
 from __future__ import annotations
 

--- a/docs/cn/KUBERNETES.md
+++ b/docs/cn/KUBERNETES.md
@@ -59,6 +59,8 @@ k8s/
 
 **HorizontalPodAutoscaler：** 参考清单至少保留 3 个副本，并可根据 CPU 与内存利用率扩展到 10 个副本。
 
+**粘性路由：** Service 使用 `sessionAffinity: ClientIP`，nginx Ingress 使用 cookie affinity。远程工作区终端 / relay 的活跃会话仍有部分运行态保存在单个 Web 进程内，因此同一个浏览器 / Agent 会话的请求必须持续回到同一个 Pod。
+
 **多用户工作区说明：** 默认 Kubernetes 清单以非 root 用户运行 Web 容器。如果启用 `workspace.multi_user_mode` 且需要在容器内动态创建 Linux 用户，请使用专门的 overlay 显式让 Web Pod 以 root 运行，并在集群变更流程中记录该例外。
 
 ### Service 与 Ingress
@@ -134,7 +136,7 @@ k8s/
 
 ### PodDisruptionBudget
 
-- `minAvailable: 1` — 在单实例支持边界内保护当前应用副本不被自愿驱逐
+- `minAvailable: 2` — 自愿驱逐期间至少保留两个 Web Pod 可用
 
 ## 配置
 
@@ -149,9 +151,11 @@ k8s/
 
 ### 当前支持边界
 
-- 仓库内提供的 Kubernetes 清单是**单实例参考部署**。
-- 远程工作区 / 终端 / 会话协调仍有关键运行时状态保存在进程内，因此这里不再宣称或启用水平扩缩容。
-- 容器当前有意以 root 身份运行，因为 entrypoint 需要动态创建多用户工作区账户；仓库中尚未提供等价的非 root 生产镜像变体。
+- 仓库内提供的 Kubernetes 清单是**带粘性路由的多副本参考部署**，不是完全无状态的活跃会话 HA 设计。
+- 普通 HTTP/API 请求可以在 Pod 间负载均衡。活跃的远程工作区终端 relay、输出缓冲、命令队列和 WebSocket 对象仍保存在单个进程内。
+- 如果承载某个活跃终端 / relay 会话的 Pod 重启，数据库中的持久记录仍在，但内存缓冲和实时 relay socket 会中断；用户可能需要重新连接、恢复或重建该活跃终端 / 会话。
+- 移除粘性路由需要完成 [#1782](https://github.com/open-ace/open-ace/issues/1782) 中的运行态外置化。
+- 更强的 tenant-aware schema / query 隔离在 [#1781](https://github.com/open-ace/open-ace/issues/1781) 中继续推进。
 
 ### 使用 cert-manager 配置 TLS
 
@@ -167,7 +171,7 @@ kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/
 
 ## 扩容
 
-当前参考清单固定为单实例。如需重启或重新调度：
+当前参考清单以三个 Web 副本和粘性路由作为起点。如需重启或重新调度：
 
 ```bash
 kubectl rollout restart deployment open-ace -n open-ace

--- a/docs/cn/PERMISSION-MODEL.md
+++ b/docs/cn/PERMISSION-MODEL.md
@@ -142,3 +142,8 @@ has_perm = PermissionService.has_permission(user_id, 'export_analysis')
 - 租户配额强制执行每个租户的 token 和请求限制
 - `QuotaEnforcementScheduler` 每 60 秒运行一次，检查并执行限制
 - 超额用户会被终止会话并生成告警
+
+当前边界：
+- 远程机器、远程会话、机器权限、用户身份和配额已经具备租户感知。
+- 系统管理员有意保留全局运维可见性，用于支持和故障处理。
+- 部分历史分析与项目相关表仍通过间接方式获得租户上下文，或尚未显式携带 `tenant_id`；这些 schema / query 边界加固在 [#1781](https://github.com/open-ace/open-ace/issues/1781) 中继续推进。

--- a/docs/cn/REMOTE-WORKSPACE.md
+++ b/docs/cn/REMOTE-WORKSPACE.md
@@ -76,6 +76,19 @@ Agent 优先尝试 WebSocket 连接，失败时自动降级为 HTTP 轮询。当
 
 ---
 
+## 部署拓扑与运行态边界
+
+Remote Workspace 可以运行在仓库提供的 Kubernetes 参考部署后面，但活跃远程会话目前还不是完全无状态：
+
+- Remote agent WebSocket 连接、终端 relay socket、进行中的命令队列和短期输出缓冲保存在承载该活跃会话的 Web 进程内。
+- Kubernetes 部署必须保留粘性路由（仓库清单中已配置 Service `ClientIP` affinity 和 nginx cookie affinity），让同一个活跃会话的浏览器与 Agent 流量持续回到同一个 Pod。
+- 如果该 Pod 重启，远程机器、会话、消息、配额和审计等持久记录仍保存在数据库中，但实时终端 relay socket 和内存输出缓冲会中断。
+- 移除粘性路由、支持活跃会话故障转移，需要完成 [#1782](https://github.com/open-ace/open-ace/issues/1782) 的运行态外置化。
+
+当前租户隔离覆盖用户、远程机器、会话所有权、机器权限和配额。系统管理员有意保留全局运维可见性。历史分析与项目相关表的 tenant-aware schema / query 加固在 [#1781](https://github.com/open-ace/open-ace/issues/1781) 中继续推进。
+
+---
+
 ## 部署检查清单
 
 从零到可用，按顺序完成以下步骤：

--- a/docs/en/KUBERNETES.md
+++ b/docs/en/KUBERNETES.md
@@ -59,6 +59,8 @@ Creates the `open-ace` namespace with standard Kubernetes labels.
 
 **HorizontalPodAutoscaler:** The reference manifest keeps at least 3 replicas and can scale to 10 replicas based on CPU and memory utilization.
 
+**Sticky routing:** The Service uses `sessionAffinity: ClientIP`, and the nginx Ingress uses cookie affinity. Active Remote Workspace terminal/relay sessions keep some runtime state inside one web process, so requests for a given browser/agent session must keep returning to the same pod.
+
 **Multi-user workspace note:** The default Kubernetes manifest runs the web container as a non-root user. If you enable `workspace.multi_user_mode` and need dynamic Linux user creation inside the container, deploy a dedicated overlay that intentionally runs the web pod as root and document that exception in your cluster change process.
 
 ### Service & Ingress
@@ -134,7 +136,7 @@ Keys: `SECRET_KEY`, `OPENACE_ENCRYPTION_KEY`, `UPLOAD_AUTH_KEY`, `DB_USER`, `DB_
 
 ### PodDisruptionBudget
 
-- `minAvailable: 1` — Protects the single supported application replica during voluntary disruptions
+- `minAvailable: 2` — Keeps at least two web pods available during voluntary disruptions
 
 ## Configuration
 
@@ -149,9 +151,11 @@ Before deploying, update:
 
 ### Current support boundary
 
-- The shipped Kubernetes manifest is a **single-instance reference deployment**.
-- Remote workspace / terminal / session coordination still keeps important runtime state in-process, so horizontal scaling is not advertised or enabled here.
-- The container intentionally runs as root because the current entrypoint provisions per-user workspace accounts dynamically. A hardened non-root image variant is not shipped yet.
+- The shipped Kubernetes manifest is a **multi-replica reference deployment with sticky routing**, not a fully stateless active-session HA design.
+- Ordinary HTTP/API requests can be balanced across pods. Active Remote Workspace terminal relay, output buffering, command queues, and in-flight WebSocket objects still keep process-local state.
+- If the pod that owns an active terminal/relay session restarts, the persisted database records remain, but in-memory buffers and live relay sockets are interrupted. Users may need to reconnect, resume, or recreate that active terminal/session.
+- Removing sticky routing requires the runtime-state externalization tracked in [#1782](https://github.com/open-ace/open-ace/issues/1782).
+- Stronger tenant-aware schema/query isolation is tracked separately in [#1781](https://github.com/open-ace/open-ace/issues/1781).
 
 ### TLS with cert-manager
 
@@ -167,7 +171,7 @@ The `/health` endpoint returns service status and git commit hash.
 
 ## Scaling
 
-This reference manifest intentionally stays at one application replica. For manual restarts or rescheduling:
+The reference manifest starts with three web replicas plus sticky routing. For manual restarts or rescheduling:
 
 ```bash
 kubectl rollout restart deployment open-ace -n open-ace

--- a/docs/en/PERMISSION-MODEL.md
+++ b/docs/en/PERMISSION-MODEL.md
@@ -142,3 +142,8 @@ When multi-tenant mode is enabled:
 - Tenant quotas enforce per-tenant token and request limits
 - `QuotaEnforcementScheduler` runs every 60s to check and enforce limits
 - Exceeded users get sessions terminated and alerts generated
+
+Current boundary:
+- Remote machines, remote sessions, machine permissions, user identity, and quotas are tenant-aware.
+- System administrators intentionally retain global operational visibility for support and incident response.
+- Some historical analytics and project tables derive tenant context indirectly or do not yet carry an explicit `tenant_id`; tightening those schema/query boundaries is tracked in [#1781](https://github.com/open-ace/open-ace/issues/1781).

--- a/docs/en/REMOTE-WORKSPACE.md
+++ b/docs/en/REMOTE-WORKSPACE.md
@@ -76,6 +76,19 @@ The Agent tries WebSocket first and falls back to HTTP polling on failure. For t
 
 ---
 
+## Deployment Topology and Runtime State
+
+Remote Workspace is safe to run behind the Kubernetes reference deployment, but active remote sessions are not fully stateless yet:
+
+- Remote agent WebSocket connections, terminal relay sockets, in-flight command queues, and short-lived output buffers are held in the web process that owns the active session.
+- Kubernetes deployments must keep sticky routing enabled (`ClientIP` Service affinity and nginx cookie affinity in the shipped manifests) so browser and agent traffic for an active session returns to the same pod.
+- If that pod restarts, durable records such as machines, sessions, messages, quotas, and audit entries remain in the database, but live terminal relay sockets and in-memory output buffers are interrupted.
+- Removing sticky routing and supporting active-session failover requires the runtime-state externalization tracked in [#1782](https://github.com/open-ace/open-ace/issues/1782).
+
+Tenant isolation currently covers users, remote machines, session ownership, machine permissions, and quotas. System administrators intentionally have global operational visibility. Broader tenant-aware schema/query hardening for historical analytics and project tables is tracked in [#1781](https://github.com/open-ace/open-ace/issues/1781).
+
+---
+
 ## Deployment Checklist
 
 From zero to working, complete these steps in order:

--- a/k8s/policies.yaml
+++ b/k8s/policies.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: open-ace
 spec:
-  minAvailable: 1
+  minAvailable: 2
   selector:
     matchLabels:
       app.kubernetes.io/name: open-ace

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -9,6 +9,10 @@ metadata:
     app.kubernetes.io/component: service
 spec:
   type: ClusterIP
+  sessionAffinity: ClientIP
+  sessionAffinityConfig:
+    clientIP:
+      timeoutSeconds: 10800
   ports:
     - port: 80
       targetPort: http
@@ -55,6 +59,9 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-body-size: "50m"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "300"
+    nginx.ingress.kubernetes.io/affinity: "cookie"
+    nginx.ingress.kubernetes.io/session-cookie-name: "openace_route"
+    nginx.ingress.kubernetes.io/session-cookie-max-age: "10800"
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
 spec:
   tls:

--- a/tests/issues/1748/test_deployment_alignment.py
+++ b/tests/issues/1748/test_deployment_alignment.py
@@ -48,6 +48,9 @@ class TestKubernetesManifestAlignment:
         assert "port: 19888" in policies
         assert "port: 5001" not in service
         assert "port: 5001" not in policies
+        assert "sessionAffinity: ClientIP" in service
+        assert 'nginx.ingress.kubernetes.io/affinity: "cookie"' in service
+        assert "minAvailable: 2" in policies
 
     def test_k8s_secret_includes_dedicated_encryption_key(self):
         configmap = (ROOT / "k8s" / "configmap.yaml").read_text(encoding="utf-8")
@@ -60,6 +63,14 @@ class TestKubernetesManifestAlignment:
         storage = (ROOT / "k8s" / "storage.yaml").read_text(encoding="utf-8")
 
         assert "ReadWriteMany" in storage
+
+    def test_k8s_docs_describe_sticky_multi_replica_boundary(self):
+        docs = (ROOT / "docs" / "en" / "KUBERNETES.md").read_text(encoding="utf-8")
+
+        assert "multi-replica reference deployment with sticky routing" in docs
+        assert "#1782" in docs
+        assert "#1781" in docs
+        assert "single-instance reference deployment" not in docs
 
 
 class TestComposeSunset:


### PR DESCRIPTION
## Summary

Closes #1750.

This PR tightens the deployment and tenant-boundary language around Remote Workspace and Kubernetes:

- configures Kubernetes sticky routing for active remote/terminal sessions:
  - Service `sessionAffinity: ClientIP`
  - nginx Ingress cookie affinity
- raises the web PodDisruptionBudget to `minAvailable: 2` for the 3-replica reference manifest
- documents that the K8s manifest is multi-replica with sticky routing, not fully stateless active-session HA
- documents process-local runtime state in `RemoteAgentManager`, terminal info store, and terminal relay store
- makes the system-admin global session access boundary explicit in code comments and permission docs
- updates README/Kubernetes/Remote Workspace/Permission Model docs in English and Chinese
- creates follow-up backlog issues:
  - #1782 runtime-state externalization to Redis/persistent coordination
  - #1781 tenant-aware schema/query hardening

## Tests

- `pytest tests/issues/1748/test_deployment_alignment.py -q`
- `pre-commit run check-yaml --files k8s/service.yaml k8s/policies.yaml`
- `SKIP=bandit pre-commit run --all-files`
