### PR TITLE
feat: add DingTalk org sync and alert bots

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@
 - 通过 Remote Agent 把 Claude Code、Qwen Code、Codex、OpenClaw 等 CLI 跑在团队自己的开发机、测试机或 GPU 机器上
 - 加密保存 LLM API Key，通过短生命周期、可回收的代理令牌给本地和远程会话安全调用模型
 - 给管理者一套控制面板，查看 Token、成本、异常、配额、审计、合规报告和 ROI
-- 在自己的网络里部署，保留企业数据边界，并接入 OIDC/OAuth2 SSO、飞书同步、钉钉导入解析和 Kubernetes
+- 在自己的网络里部署，保留企业数据边界，并接入 OIDC/OAuth2 SSO、飞书/钉钉同步和 Kubernetes
 
 ## 🔥 近期功能亮点
 
@@ -111,7 +111,7 @@
 | 🌐 **多工具工作台** | Claude Code、Qwen Code、Codex、OpenClaw 统一入口、统一历史、统一治理 |
 | 🖥️ **远程执行** | Remote Agent 让 AI CLI 在目标机器运行，适合研发服务器、测试环境和 GPU 机器 |
 | 📊 **治理可观测** | Token、成本、配额、异常、审计、合规和 ROI 统一分析 |
-| 🔌 **企业集成** | 支持 OIDC/OAuth2 SSO、飞书组织同步、钉钉导入解析、Kubernetes、反向代理和多租户权限模型；SAML 2.0 计划见 [#1784](https://github.com/open-ace/open-ace/issues/1784) |
+| 🔌 **企业集成** | 支持 OIDC/OAuth2 SSO、飞书/钉钉组织同步、钉钉/飞书告警机器人、Kubernetes、反向代理和多租户权限模型；SAML 2.0 计划见 [#1784](https://github.com/open-ace/open-ace/issues/1784) |
 | 🆓 **开放协作** | Apache 2.0 协议，Roadmap、贡献指南和 good first issue 已就位 |
 
 ---
@@ -204,7 +204,7 @@ python3 server.py
 | 配额告警 | 用量达到阈值自动提醒 |
 | 异常检测 | 识别异常使用模式 |
 | 邮件通知 | 定期发送用量报告 |
-| Webhook / 飞书推送 | 实时推送告警到 Webhook，支持飞书 / Lark 群机器人 |
+| Webhook / 机器人推送 | 实时推送告警到 Webhook，支持飞书 / Lark 和钉钉群机器人 |
 
 ### 👥 用户管理
 
@@ -214,7 +214,7 @@ python3 server.py
 | 角色权限 | 管理员/普通用户角色区分 |
 | SSO 集成 | 支持 OIDC/OAuth2 企业单点登录；SAML 2.0 Provider 尚未实现，跟踪见 [#1784](https://github.com/open-ace/open-ace/issues/1784) |
 | 飞书同步 | 手动触发并可按配置自动同步飞书组织架构 |
-| 钉钉解析 | 导入 OpenClaw 会话时解析钉钉用户名和群名称；完整通讯录同步/机器人能力跟踪见 [#1785](https://github.com/open-ace/open-ace/issues/1785) |
+| 钉钉同步 | 手动触发并可按配置自动同步钉钉组织架构，导入 OpenClaw 会话时解析钉钉用户名和群名称 |
 
 ### 📋 合规与报表
 
@@ -302,7 +302,7 @@ open-ace/
 | [权限模型](docs/cn/PERMISSION-MODEL.md) | 租户、角色与访问控制 |
 | [Kubernetes](docs/cn/KUBERNETES.md) | K8s 部署参考（多副本 + 粘性会话边界） |
 | [飞书配置](docs/cn/FEISHU_CONFIG.md) | 飞书集成配置 |
-| [钉钉配置](docs/cn/DINGTALK_CONFIG.md) | 钉钉导入解析配置 |
+| [钉钉配置](docs/cn/DINGTALK_CONFIG.md) | 钉钉集成配置 |
 | [API 文档](docs/cn/API.md) | API 接口说明 |
 | [仓库设置](docs/REPOSITORY_SETUP.md) | GitHub topics、labels、分支保护和发布检查清单 |
 
@@ -356,7 +356,7 @@ It is built for teams moving AI coding agents into real engineering workflows, e
 - Run Claude Code, Qwen Code, Codex, OpenClaw, and similar CLIs on your own development, staging, or GPU machines through the Remote Agent
 - Store LLM API keys centrally and issue short-lived, revocable proxy tokens to local and remote sessions
 - Give administrators a control plane for tokens, cost, anomalies, quotas, audits, compliance reports, and ROI
-- Deploy inside your own network while integrating OIDC/OAuth2 SSO, Feishu sync, DingTalk import resolution, and Kubernetes
+- Deploy inside your own network while integrating OIDC/OAuth2 SSO, Feishu/DingTalk sync, and Kubernetes
 
 ## 🔥 Recent Highlights
 
@@ -416,7 +416,7 @@ It is built for teams moving AI coding agents into real engineering workflows, e
 | 🌐 **Multi-tool workspace** | Claude Code, Qwen Code, Codex, and OpenClaw with unified access, history, and governance |
 | 🖥️ **Remote execution** | Remote Agent runs AI CLIs on development servers, staging boxes, or GPU machines |
 | 📊 **Governance observability** | Analyze tokens, cost, quotas, anomalies, audits, compliance, and ROI together |
-| 🔌 **Enterprise integration** | OIDC/OAuth2 SSO, Feishu org sync, DingTalk import resolution, Kubernetes, reverse proxy, and multi-tenant permissions; SAML 2.0 is tracked in [#1784](https://github.com/open-ace/open-ace/issues/1784) |
+| 🔌 **Enterprise integration** | OIDC/OAuth2 SSO, Feishu/DingTalk org sync, Feishu/DingTalk alert bots, Kubernetes, reverse proxy, and multi-tenant permissions; SAML 2.0 is tracked in [#1784](https://github.com/open-ace/open-ace/issues/1784) |
 | 🆓 **Open collaboration** | Apache 2.0, roadmap, contributor guide, and good first issues are ready |
 
 ---
@@ -509,7 +509,7 @@ python3 server.py
 | Quota Alerts | Automatic notifications when thresholds reached |
 | Anomaly Detection | Identify unusual usage patterns |
 | Email Reports | Periodic usage reports via email |
-| Webhook / Feishu Push | Real-time alerts to webhooks, including Feishu / Lark group bots |
+| Webhook / Bot Push | Real-time alerts to webhooks, including Feishu / Lark and DingTalk group bots |
 
 ### 👥 User Management
 
@@ -519,7 +519,7 @@ python3 server.py
 | Role Permissions | Admin/user role distinction |
 | SSO Integration | Enterprise single sign-on via OIDC/OAuth2; SAML 2.0 Provider is not implemented yet and is tracked in [#1784](https://github.com/open-ace/open-ace/issues/1784) |
 | Feishu Sync | Manual and optionally scheduled Feishu organization sync |
-| DingTalk Resolution | Resolve DingTalk user and group names during OpenClaw import; full org sync/bot support is tracked in [#1785](https://github.com/open-ace/open-ace/issues/1785) |
+| DingTalk Sync | Manual and optionally scheduled DingTalk organization sync, plus DingTalk user/group name resolution during OpenClaw import |
 
 ### 📋 Compliance and Reporting
 
@@ -607,7 +607,7 @@ The `docs/` directory is the source of truth for product documentation. The publ
 | [Permission Model](docs/en/PERMISSION-MODEL.md) | Tenants, roles, and access control |
 | [Kubernetes](docs/en/KUBERNETES.md) | K8s deployment reference with multi-replica sticky-session boundaries |
 | [Feishu Config](docs/en/FEISHU_CONFIG.md) | Feishu integration |
-| [DingTalk Config](docs/en/DINGTALK_CONFIG.md) | DingTalk import resolution |
+| [DingTalk Config](docs/en/DINGTALK_CONFIG.md) | DingTalk integration |
 | [API Reference](docs/en/API.md) | API documentation |
 | [Repository Setup](docs/REPOSITORY_SETUP.md) | GitHub topics, labels, branch protection, and release checklist |
 

--- a/app/modules/governance/alert_notifier.py
+++ b/app/modules/governance/alert_notifier.py
@@ -10,17 +10,21 @@ Supports WebSocket push, email, and webhook notifications.
 """
 
 import asyncio
+import base64
+import hashlib
+import hmac
 import ipaddress
 import json
 import logging
 import socket
 import sqlite3
+import time
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from enum import Enum
 from typing import Any, Callable, Optional, Union
-from urllib.parse import urlparse
+from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
 import requests
 
@@ -40,6 +44,8 @@ logger = logging.getLogger(__name__)
 _SEVERITY_ORDER = {"info": 0, "warning": 1, "critical": 2}
 _WEBHOOK_TIMEOUT_SECONDS = 5
 _FEISHU_WEBHOOK_HOST_SNIPPETS = ("feishu.cn", "larksuite.com", "larkoffice.com")
+_DINGTALK_WEBHOOK_HOST_SNIPPETS = ("dingtalk.com",)
+_DINGTALK_SECRET_QUERY_KEYS = ("openace_dingtalk_secret", "dingtalk_secret")
 
 
 class AlertType(Enum):
@@ -223,6 +229,19 @@ class AlertNotifier:
         host = (urlparse(webhook_url).hostname or "").lower()
         return any(snippet in host for snippet in _FEISHU_WEBHOOK_HOST_SNIPPETS)
 
+    def _matches_webhook_host(self, host: str, domains: tuple[str, ...]) -> bool:
+        """Return whether host is exactly a known domain or one of its subdomains."""
+        return any(host == domain or host.endswith(f".{domain}") for domain in domains)
+
+    def _is_dingtalk_webhook(self, webhook_url: str) -> bool:
+        """Return whether the webhook target looks like a DingTalk bot webhook."""
+        parsed = urlparse(webhook_url)
+        host = (parsed.hostname or "").lower()
+        path = parsed.path.lower()
+        return self._matches_webhook_host(host, _DINGTALK_WEBHOOK_HOST_SNIPPETS) and (
+            "/robot/send" in path or "/robot/" in path
+        )
+
     def _format_webhook_text(self, alert: Alert) -> str:
         """Render a plain-text alert summary suitable for chat webhook bots."""
         lines = [
@@ -243,12 +262,39 @@ class AlertNotifier:
         summary = self._format_webhook_text(alert)
         if self._is_feishu_webhook(webhook_url):
             return {"msg_type": "text", "content": {"text": summary}}
+        if self._is_dingtalk_webhook(webhook_url):
+            return {"msgtype": "text", "text": {"content": summary}}
         return {
             "event": "openace.alert",
             "source": "open-ace",
             "summary": summary,
             "alert": alert.to_dict(),
         }
+
+    def _prepare_webhook_url(self, webhook_url: str) -> str:
+        """Return the outbound webhook URL, applying DingTalk signing when configured."""
+        if not self._is_dingtalk_webhook(webhook_url):
+            return webhook_url
+
+        parsed = urlparse(webhook_url)
+        query_items = parse_qsl(parsed.query, keep_blank_values=True)
+        secret = str(get_config_value("alerts", "dingtalk_webhook_secret", "") or "").strip()
+        sanitized_items: list[tuple[str, str]] = []
+        for key, value in query_items:
+            if key in _DINGTALK_SECRET_QUERY_KEYS:
+                if value and not secret:
+                    secret = value
+                continue
+            sanitized_items.append((key, value))
+
+        if secret:
+            timestamp = str(int(time.time() * 1000))
+            string_to_sign = f"{timestamp}\n{secret}".encode()
+            digest = hmac.new(secret.encode("utf-8"), string_to_sign, hashlib.sha256).digest()
+            sign = base64.b64encode(digest).decode("utf-8")
+            sanitized_items.extend([("timestamp", timestamp), ("sign", sign)])
+
+        return urlunparse(parsed._replace(query=urlencode(sanitized_items)))
 
     def _send_webhook_notification(self, alert: Alert, user_id: int) -> None:
         """Send a webhook notification for an alert if user preferences allow."""
@@ -277,8 +323,9 @@ class AlertNotifier:
                 return
 
             payload = self._build_webhook_payload(alert, prefs.webhook_url)
+            outbound_url = self._prepare_webhook_url(prefs.webhook_url)
             response = requests.post(
-                prefs.webhook_url,
+                outbound_url,
                 json=payload,
                 timeout=_WEBHOOK_TIMEOUT_SECONDS,
                 allow_redirects=False,

--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -478,3 +478,28 @@ def api_sync_feishu_org():
     except Exception as e:
         logger.exception("Failed to sync Feishu org: %s", e)
         return jsonify({"error": "Failed to sync Feishu org"}), 500
+
+
+@admin_bp.route("/admin/dingtalk/sync", methods=["POST"])
+@admin_required
+def api_sync_dingtalk_org():
+    """Manually trigger a DingTalk organization sync."""
+    data = request.get_json(silent=True) or {}
+    tenant_id = data.get("tenant_id")
+
+    if tenant_id is not None:
+        try:
+            tenant_id = int(tenant_id)
+        except (TypeError, ValueError):
+            return jsonify({"error": "tenant_id must be an integer"}), 400
+
+    try:
+        from app.services.dingtalk_org_sync import DingTalkOrgSyncService
+
+        result = DingTalkOrgSyncService().sync_org(tenant_id=tenant_id)
+        return jsonify({"success": True, "result": result.to_dict()})
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 400
+    except Exception as e:
+        logger.exception("Failed to sync DingTalk org: %s", e)
+        return jsonify({"error": "Failed to sync DingTalk org"}), 500

--- a/app/services/data_fetch_scheduler.py
+++ b/app/services/data_fetch_scheduler.py
@@ -263,6 +263,9 @@ class DataFetchScheduler:
         # Optionally synchronize Feishu org structure.
         self._maybe_sync_feishu_org()
 
+        # Optionally synchronize DingTalk org structure.
+        self._maybe_sync_dingtalk_org()
+
     def _refresh_materialized_views(self):
         """Refresh materialized views for PostgreSQL performance optimization."""
         from app.repositories.database import Database, is_postgresql
@@ -469,6 +472,22 @@ class DataFetchScheduler:
                 )
         except Exception as e:
             logger.warning(f"Scheduled Feishu org sync failed: {e}")
+
+    def _maybe_sync_dingtalk_org(self):
+        """Synchronize DingTalk org data when auto-sync is enabled."""
+        try:
+            from app.services.dingtalk_org_sync import DingTalkOrgSyncService
+
+            result = DingTalkOrgSyncService().maybe_sync_from_scheduler()
+            if result:
+                logger.info(
+                    "Scheduled DingTalk org sync completed: tenant=%s departments=%s users=%s",
+                    result.tenant_id,
+                    result.departments_seen,
+                    result.users_seen,
+                )
+        except Exception as e:
+            logger.warning(f"Scheduled DingTalk org sync failed: {e}")
 
 
 # Global scheduler instance

--- a/app/services/dingtalk_org_sync.py
+++ b/app/services/dingtalk_org_sync.py
@@ -1,0 +1,659 @@
+"""DingTalk organization sync service.
+
+Synchronizes DingTalk departments and users into local Open ACE teams, team
+memberships, and SSO identity mappings.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import threading
+import uuid
+from collections import deque
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Any, cast
+
+import requests
+
+from app.modules.sso.manager import SSOManager
+from app.modules.workspace.collaboration import CollaborationManager
+from app.repositories.database import Database
+from app.repositories.user_repo import UserRepository
+from app.utils.config import get_config_value
+
+logger = logging.getLogger(__name__)
+
+DINGTALK_PROVIDER_NAME = "dingtalk"
+DINGTALK_ROOT_DEPARTMENT_ID = "1"
+DINGTALK_PLACEHOLDER_EMAIL_DOMAIN = "dingtalk.local"
+
+
+@dataclass
+class DingTalkDepartment:
+    """DingTalk department record used during synchronization."""
+
+    department_id: str
+    name: str
+    parent_department_id: str | None = None
+    order: int | None = None
+
+
+@dataclass
+class DingTalkUser:
+    """DingTalk user record used during synchronization."""
+
+    user_id: str
+    name: str
+    email: str | None = None
+    department_ids: list[str] = field(default_factory=list)
+    status: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class DingTalkOrgSyncResult:
+    """Summary returned to admin/API callers after a sync run."""
+
+    tenant_id: int
+    departments_seen: int = 0
+    users_seen: int = 0
+    teams_created: int = 0
+    teams_updated: int = 0
+    users_created: int = 0
+    users_linked: int = 0
+    users_updated: int = 0
+    memberships_added: int = 0
+    memberships_removed: int = 0
+    started_at: str | None = None
+    finished_at: str | None = None
+    warnings: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert result to a JSON-friendly dictionary."""
+        return {
+            "tenant_id": self.tenant_id,
+            "departments_seen": self.departments_seen,
+            "users_seen": self.users_seen,
+            "teams_created": self.teams_created,
+            "teams_updated": self.teams_updated,
+            "users_created": self.users_created,
+            "users_linked": self.users_linked,
+            "users_updated": self.users_updated,
+            "memberships_added": self.memberships_added,
+            "memberships_removed": self.memberships_removed,
+            "started_at": self.started_at,
+            "finished_at": self.finished_at,
+            "warnings": list(self.warnings),
+        }
+
+
+class DingTalkOrgSyncService:
+    """Synchronize DingTalk org data into local users and collaboration teams."""
+
+    _sync_lock = threading.Lock()
+    _schedule_lock = threading.Lock()
+    _last_scheduled_sync_at: datetime | None = None
+
+    def __init__(
+        self,
+        db: Database | None = None,
+        user_repo: UserRepository | None = None,
+        sso_manager: SSOManager | None = None,
+        collaboration_manager: CollaborationManager | None = None,
+        config_override: dict[str, Any] | None = None,
+        http_session=None,
+    ):
+        self.db = db or Database()
+        self.user_repo = user_repo or UserRepository(db=self.db)
+        self.sso_manager = sso_manager or SSOManager(db=self.db)
+        self.collaboration_manager = collaboration_manager or CollaborationManager()
+        self.config_override = config_override
+        self.http = http_session or requests
+
+    def sync_org(self, tenant_id: int | None = None) -> DingTalkOrgSyncResult:
+        """Run a full DingTalk org sync."""
+        config = self._get_dingtalk_config()
+        app_key = str(config.get("app_key") or "").strip()
+        app_secret = str(config.get("app_secret") or "").strip()
+        if not app_key or not app_secret:
+            raise ValueError("DingTalk app_key and app_secret must be configured before syncing")
+
+        effective_tenant_id = int(tenant_id or config.get("org_sync_tenant_id") or 1)
+        root_department_id = str(config.get("org_sync_root_dept_id") or DINGTALK_ROOT_DEPARTMENT_ID)
+        result = DingTalkOrgSyncResult(
+            tenant_id=effective_tenant_id,
+            started_at=datetime.now(timezone.utc).replace(tzinfo=None).isoformat(),
+        )
+
+        with self._sync_lock:
+            self._ensure_supporting_tables()
+            token = self._get_access_token(app_key, app_secret)
+            departments, users = self._fetch_directory_snapshot(token, root_department_id)
+            result.departments_seen = len(departments)
+            result.users_seen = len(users)
+
+            team_ids_by_department: dict[str, str] = {}
+            for department in departments:
+                team_id, created = self._upsert_department_team(department)
+                team_ids_by_department[department.department_id] = team_id
+                if created:
+                    result.teams_created += 1
+                else:
+                    result.teams_updated += 1
+
+            expected_memberships: set[tuple[str, int]] = set()
+            for user in users:
+                user_id, created, linked, updated = self._resolve_local_user(
+                    user=user,
+                    tenant_id=effective_tenant_id,
+                    result=result,
+                )
+                if user_id is None:
+                    continue
+                if created:
+                    result.users_created += 1
+                elif linked:
+                    result.users_linked += 1
+                if updated:
+                    result.users_updated += 1
+
+                for department_id in user.department_ids:
+                    membership_team_id = team_ids_by_department.get(department_id)
+                    if membership_team_id:
+                        expected_memberships.add((membership_team_id, user_id))
+
+            self._sync_memberships(
+                expected_memberships=expected_memberships,
+                synced_team_ids=set(team_ids_by_department.values()),
+                result=result,
+            )
+
+            result.finished_at = datetime.now(timezone.utc).replace(tzinfo=None).isoformat()
+            return result
+
+    def maybe_sync_from_scheduler(self) -> DingTalkOrgSyncResult | None:
+        """Run scheduled sync when enabled and the interval has elapsed."""
+        config = self._get_dingtalk_config()
+        if not bool(config.get("org_sync_enabled", False)):
+            return None
+
+        interval_minutes = max(int(config.get("org_sync_interval_minutes") or 60), 5)
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
+
+        with self._schedule_lock:
+            if self._last_scheduled_sync_at and (now - self._last_scheduled_sync_at) < timedelta(
+                minutes=interval_minutes
+            ):
+                return None
+
+            result = self.sync_org(tenant_id=config.get("org_sync_tenant_id"))
+            self.__class__._last_scheduled_sync_at = now
+            return result
+
+    def _ensure_supporting_tables(self) -> None:
+        """Ensure dependent tables exist before syncing."""
+        self.sso_manager._ensure_tables()
+        self.collaboration_manager._ensure_tables()
+
+    def _get_dingtalk_config(self) -> dict[str, Any]:
+        """Load DingTalk config from override or app config."""
+        if self.config_override:
+            if "dingtalk" in self.config_override:
+                config = dict(self.config_override.get("dingtalk") or {})
+            else:
+                config = dict(self.config_override)
+        else:
+            config = {
+                "app_key": get_config_value("dingtalk", "app_key", ""),
+                "app_secret": get_config_value("dingtalk", "app_secret", ""),
+                "org_sync_enabled": bool(get_config_value("dingtalk", "org_sync_enabled", False)),
+                "org_sync_tenant_id": int(
+                    get_config_value("dingtalk", "org_sync_tenant_id", 1) or 1
+                ),
+                "org_sync_interval_minutes": int(
+                    get_config_value("dingtalk", "org_sync_interval_minutes", 60) or 60
+                ),
+                "org_sync_root_dept_id": str(
+                    get_config_value("dingtalk", "org_sync_root_dept_id", "1") or "1"
+                ),
+            }
+
+        config.setdefault("org_sync_enabled", False)
+        config.setdefault("org_sync_tenant_id", 1)
+        config.setdefault("org_sync_interval_minutes", 60)
+        config.setdefault("org_sync_root_dept_id", DINGTALK_ROOT_DEPARTMENT_ID)
+        return config
+
+    def _get_access_token(self, app_key: str, app_secret: str) -> str:
+        """Exchange app credentials for a DingTalk access token."""
+        response = self.http.post(
+            "https://api.dingtalk.com/v1.0/oauth2/accessToken",
+            json={"appKey": app_key, "appSecret": app_secret},
+            timeout=15,
+        )
+        response.raise_for_status()
+        data = response.json()
+        token = data.get("accessToken") or data.get("access_token")
+        if not token:
+            raise RuntimeError(f"Failed to get DingTalk access token: {data}")
+        return str(token)
+
+    def _fetch_directory_snapshot(
+        self, token: str, root_department_id: str
+    ) -> tuple[list[DingTalkDepartment], list[DingTalkUser]]:
+        """Recursively fetch departments and users starting from the configured root."""
+        departments: dict[str, DingTalkDepartment] = {}
+        users: dict[str, DingTalkUser] = {}
+
+        queue: deque[str] = deque([root_department_id])
+        visited: set[str] = set()
+
+        while queue:
+            current_department_id = queue.popleft()
+            if current_department_id in visited:
+                continue
+            visited.add(current_department_id)
+
+            child_departments = self._fetch_child_departments(token, current_department_id)
+            for department in child_departments:
+                if department.department_id not in departments:
+                    departments[department.department_id] = department
+                    queue.append(department.department_id)
+
+            direct_users = self._fetch_department_users(token, current_department_id)
+            for user in direct_users:
+                existing = users.get(user.user_id)
+                if existing is None:
+                    users[user.user_id] = user
+                    continue
+
+                merged_departments = set(existing.department_ids)
+                merged_departments.update(user.department_ids)
+                existing.department_ids = sorted(merged_departments)
+                if not existing.email and user.email:
+                    existing.email = user.email
+                if user.name:
+                    existing.name = user.name
+                if user.status:
+                    existing.status.update(user.status)
+
+        sorted_departments = sorted(
+            departments.values(),
+            key=lambda d: (
+                d.parent_department_id or "",
+                d.order if d.order is not None else 0,
+                d.name.lower(),
+            ),
+        )
+        sorted_users = sorted(users.values(), key=lambda u: (u.name.lower(), u.user_id))
+        return sorted_departments, sorted_users
+
+    def _fetch_child_departments(self, token: str, department_id: str) -> list[DingTalkDepartment]:
+        """Fetch immediate child departments for a DingTalk department."""
+        payload: dict[str, Any] = {"dept_id": self._coerce_dept_id(department_id)}
+        data = self._request_oapi(
+            "https://oapi.dingtalk.com/topapi/v2/department/listsub",
+            token=token,
+            json_payload=payload,
+        )
+        items = self._extract_items(data, ("result", "dept_list", "departments"))
+
+        departments: list[DingTalkDepartment] = []
+        for item in items:
+            department_id_value = item.get("dept_id") or item.get("id")
+            if department_id_value is None:
+                continue
+
+            parent_id = item.get("parent_id")
+            if parent_id is None and department_id != DINGTALK_ROOT_DEPARTMENT_ID:
+                parent_id = department_id
+
+            departments.append(
+                DingTalkDepartment(
+                    department_id=str(department_id_value),
+                    name=str(item.get("name") or department_id_value),
+                    parent_department_id=str(parent_id) if parent_id is not None else None,
+                    order=int(item["order"]) if item.get("order") is not None else None,
+                )
+            )
+
+        return departments
+
+    def _fetch_department_users(self, token: str, department_id: str) -> list[DingTalkUser]:
+        """Fetch users directly under a DingTalk department."""
+        user_ids: list[str] = []
+        cursor = 0
+
+        while True:
+            data = self._request_oapi(
+                "https://oapi.dingtalk.com/topapi/user/listid",
+                token=token,
+                json_payload={
+                    "dept_id": self._coerce_dept_id(department_id),
+                    "cursor": cursor,
+                    "size": 100,
+                },
+            )
+            result = data.get("result") if isinstance(data.get("result"), dict) else data
+            if not isinstance(result, dict):
+                result = {}
+            values = result.get("userid_list") or result.get("userids") or []
+            if isinstance(values, list):
+                user_ids.extend(str(value) for value in values if value)
+            if not result.get("has_more"):
+                break
+            next_cursor = result.get("next_cursor")
+            if next_cursor is None:
+                break
+            cursor = int(next_cursor)
+
+        users: list[DingTalkUser] = []
+        for user_id in sorted(set(user_ids)):
+            user_info = self._fetch_user_info(token, user_id)
+            if not user_info:
+                continue
+
+            department_ids = user_info.get("dept_id_list") or user_info.get("dept_id_list_ext")
+            if not isinstance(department_ids, list):
+                department_ids = [department_id]
+
+            email = user_info.get("email") or user_info.get("org_email")
+            status = {
+                "active": user_info.get("active"),
+                "admin": user_info.get("admin"),
+                "boss": user_info.get("boss"),
+            }
+
+            users.append(
+                DingTalkUser(
+                    user_id=user_id,
+                    name=str(
+                        user_info.get("name")
+                        or user_info.get("nick")
+                        or user_info.get("nickname")
+                        or user_id
+                    ),
+                    email=str(email) if email else None,
+                    department_ids=[str(dep_id) for dep_id in department_ids if dep_id],
+                    status={k: v for k, v in status.items() if v is not None},
+                )
+            )
+
+        return users
+
+    def _fetch_user_info(self, token: str, user_id: str) -> dict[str, Any]:
+        """Fetch a DingTalk user detail record."""
+        data = self._request_oapi(
+            "https://oapi.dingtalk.com/topapi/v2/user/get",
+            token=token,
+            json_payload={"userid": user_id},
+        )
+        result = data.get("result")
+        return result if isinstance(result, dict) else {}
+
+    def _request_oapi(
+        self,
+        url: str,
+        token: str,
+        json_payload: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Call a DingTalk oapi endpoint and return the response payload."""
+        response = self.http.post(
+            url,
+            params={"access_token": token},
+            json=json_payload or {},
+            timeout=15,
+        )
+        response.raise_for_status()
+        payload = cast(dict[str, Any], response.json())
+        if payload.get("errcode", 0) != 0:
+            raise RuntimeError(f"DingTalk API request failed: {payload}")
+        return payload
+
+    @staticmethod
+    def _extract_items(data: dict[str, Any], keys: tuple[str, ...]) -> list[dict[str, Any]]:
+        """Pull the first list-valued key from a DingTalk API payload."""
+        for key in keys:
+            value = data.get(key)
+            if isinstance(value, list):
+                return [item for item in value if isinstance(item, dict)]
+            if isinstance(value, dict):
+                nested = DingTalkOrgSyncService._extract_items(value, keys)
+                if nested:
+                    return nested
+        return []
+
+    @staticmethod
+    def _coerce_dept_id(value: str) -> int | str:
+        """Return an integer department id when possible for DingTalk APIs."""
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return value
+
+    def _upsert_department_team(self, department: DingTalkDepartment) -> tuple[str, bool]:
+        """Create or update a local team representing a DingTalk department."""
+        existing_teams = self._load_synced_teams()
+        existing = existing_teams.get(department.department_id)
+        now = datetime.now(timezone.utc).replace(tzinfo=None).isoformat()
+
+        settings = {
+            "sync_source": DINGTALK_PROVIDER_NAME,
+            "dingtalk_department_id": department.department_id,
+            "dingtalk_parent_department_id": department.parent_department_id,
+        }
+        settings_json = json.dumps(settings, ensure_ascii=False)
+
+        if existing:
+            self.db.execute(
+                """
+                UPDATE teams
+                SET name = ?, settings = ?, updated_at = ?
+                WHERE team_id = ?
+                """,
+                (
+                    department.name,
+                    settings_json,
+                    now,
+                    existing["team_id"],
+                ),
+            )
+            return str(existing["team_id"]), False
+
+        team_id = str(uuid.uuid4())
+        self.db.execute(
+            """
+            INSERT INTO teams (team_id, name, description, owner_id, settings, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                team_id,
+                department.name,
+                "",
+                None,
+                settings_json,
+                now,
+                now,
+            ),
+        )
+        return team_id, True
+
+    def _load_synced_teams(self) -> dict[str, dict[str, Any]]:
+        """Return existing teams that are owned by DingTalk org sync."""
+        rows = self.db.fetch_all("SELECT team_id, name, settings FROM teams")
+        synced: dict[str, dict[str, Any]] = {}
+        for row in rows:
+            settings_raw = row.get("settings")
+            if not settings_raw:
+                continue
+            try:
+                settings = (
+                    json.loads(settings_raw) if isinstance(settings_raw, str) else settings_raw
+                )
+            except (TypeError, json.JSONDecodeError):
+                continue
+            if not isinstance(settings, dict):
+                continue
+            if settings.get("sync_source") != DINGTALK_PROVIDER_NAME:
+                continue
+            department_id = settings.get("dingtalk_department_id")
+            if department_id:
+                synced[str(department_id)] = row
+        return synced
+
+    def _resolve_local_user(
+        self,
+        user: DingTalkUser,
+        tenant_id: int,
+        result: DingTalkOrgSyncResult,
+    ) -> tuple[int | None, bool, bool, bool]:
+        """Resolve or provision a local user for a DingTalk user."""
+        existing_user_id = self.sso_manager.get_user_by_sso_identity(
+            DINGTALK_PROVIDER_NAME,
+            user.user_id,
+        )
+        created = False
+        linked = False
+        updated = False
+
+        existing_user = (
+            self.user_repo.get_user_by_id(existing_user_id)
+            if existing_user_id is not None
+            else None
+        )
+        if existing_user and existing_user.get("tenant_id") not in (None, tenant_id):
+            result.warnings.append(
+                f"Skipped DingTalk user {user.user_id}: linked local user belongs to tenant "
+                f"{existing_user.get('tenant_id')}, expected tenant {tenant_id}"
+            )
+            return None, False, False, False
+
+        if existing_user is None and user.email:
+            email_user = self.user_repo.get_user_by_email(user.email)
+            if email_user:
+                if email_user.get("tenant_id") not in (None, tenant_id):
+                    result.warnings.append(
+                        f"Skipped DingTalk user {user.user_id}: email {user.email} is already "
+                        f"owned by tenant {email_user.get('tenant_id')}"
+                    )
+                    return None, False, False, False
+                existing_user = email_user
+                existing_user_id = int(email_user["id"])
+                linked = True
+
+        if existing_user is None:
+            username = self._build_username(user.name, user.email, user.user_id)
+            email = user.email or f"{user.user_id}@{DINGTALK_PLACEHOLDER_EMAIL_DOMAIN}"
+            existing_user_id = self.user_repo.create_user(
+                username=username,
+                email=email,
+                password_hash="",
+                role="user",
+                tenant_id=tenant_id,
+            )
+            if existing_user_id is None:
+                result.warnings.append(
+                    f"Failed to create local user for DingTalk user {user.user_id}"
+                )
+                return None, False, False, False
+            existing_user = self.user_repo.get_user_by_id(existing_user_id)
+            created = True
+        else:
+            existing_user_id = int(existing_user["id"])
+
+        if existing_user is None:
+            return None, created, linked, updated
+
+        current_email = str(existing_user.get("email") or "")
+        next_email = user.email or current_email
+        if (
+            user.email
+            and user.email != current_email
+            and (
+                not current_email or current_email.endswith(f"@{DINGTALK_PLACEHOLDER_EMAIL_DOMAIN}")
+            )
+        ):
+            if self.user_repo.update_user(user_id=existing_user_id, email=user.email):
+                updated = True
+
+        provider_data = {
+            "user_id": user.user_id,
+            "name": user.name,
+            "email": next_email,
+            "department_ids": list(user.department_ids),
+            "status": user.status,
+            "synced_by": "dingtalk_org_sync",
+            "synced_at": datetime.now(timezone.utc).replace(tzinfo=None).isoformat(),
+        }
+        self.sso_manager.link_identity(
+            user_id=existing_user_id,
+            provider_name=DINGTALK_PROVIDER_NAME,
+            provider_user_id=user.user_id,
+            provider_data=provider_data,
+        )
+        return existing_user_id, created, linked or not created, updated
+
+    def _sync_memberships(
+        self,
+        expected_memberships: set[tuple[str, int]],
+        synced_team_ids: set[str],
+        result: DingTalkOrgSyncResult,
+    ) -> None:
+        """Reconcile team memberships for DingTalk-synced teams."""
+        if not synced_team_ids:
+            return
+
+        all_rows = self.db.fetch_all("SELECT team_id, user_id FROM team_members")
+        current_memberships = {
+            (str(row["team_id"]), int(row["user_id"]))
+            for row in all_rows
+            if str(row["team_id"]) in synced_team_ids
+        }
+
+        to_remove = current_memberships - expected_memberships
+        for team_id, user_id in sorted(to_remove):
+            self.db.execute(
+                "DELETE FROM team_members WHERE team_id = ? AND user_id = ?",
+                (team_id, user_id),
+            )
+            result.memberships_removed += 1
+
+        to_add = expected_memberships - current_memberships
+        for team_id, user_id in sorted(to_add):
+            local_user = self.user_repo.get_user_by_id(user_id)
+            username = str(local_user.get("username") or "") if local_user else ""
+            self.db.execute(
+                """
+                INSERT INTO team_members (team_id, user_id, username, role, joined_at)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                (
+                    team_id,
+                    user_id,
+                    username,
+                    "member",
+                    datetime.now(timezone.utc).replace(tzinfo=None).isoformat(),
+                ),
+            )
+            result.memberships_added += 1
+
+    def _build_username(self, display_name: str, email: str | None, user_id: str) -> str:
+        """Generate a stable, unique username for a synced DingTalk user."""
+        base = ""
+        if email and "@" in email:
+            base = email.split("@", 1)[0]
+        if not base:
+            base = display_name or f"dingtalk_{user_id[-8:]}"
+
+        slug = re.sub(r"[^a-zA-Z0-9._-]+", "_", base).strip("._-").lower()
+        if not slug:
+            slug = f"dingtalk_{user_id[-8:]}"
+
+        candidate = slug
+        counter = 1
+        while self.user_repo.get_user_by_username(candidate):
+            candidate = f"{slug}_{counter}"
+            counter += 1
+        return candidate

--- a/config/CONFIG_GUIDE.md
+++ b/config/CONFIG_GUIDE.md
@@ -67,8 +67,9 @@
 | 参数 | 说明 | 默认值 |
 |------|------|--------|
 | `alerts.allow_private_webhook_urls` | 是否允许告警 webhook 指向私网 / 回环 / 链路本地地址。默认关闭，用于阻断 SSRF 风险。 | `false` |
+| `alerts.dingtalk_webhook_secret` | 钉钉自定义机器人“加签”密钥。留空时按普通 webhook 发送；配置后发送前自动附加 `timestamp` / `sign`。 | `""` |
 
-> 默认情况下，告警 webhook 仅允许公开可达的 `http(s)` 地址。飞书 / Lark 群机器人 webhook 可直接使用；如果你确实需要向内网地址推送，请显式打开 `alerts.allow_private_webhook_urls`，并在网络层自行控制访问范围。
+> 默认情况下，告警 webhook 仅允许公开可达的 `http(s)` 地址。飞书 / Lark 和钉钉群机器人 webhook 可直接使用；如果你确实需要向内网地址推送，请显式打开 `alerts.allow_private_webhook_urls`，并在网络层自行控制访问范围。
 
 **多用户模式说明：**
 
@@ -131,14 +132,18 @@
 | `feishu.org_sync_tenant_id` | 同步写入的租户 ID | `1` |
 | `feishu.org_sync_interval_minutes` | 自动同步间隔（分钟） | `60` |
 
-#### 钉钉导入解析（可选）
+#### 钉钉集成（可选）
 
-当前钉钉能力仅用于 OpenClaw 导入链路中的用户/群名解析和本地缓存，不包含钉钉通讯录同步或群机器人集成；完整能力跟踪见 [#1785](https://github.com/open-ace/open-ace/issues/1785)。
+当前钉钉能力覆盖 OpenClaw 导入链路中的用户/群名解析、手动或定时的钉钉组织架构同步，以及告警中心向钉钉自定义机器人 webhook 推送告警。
 
-| 参数 | 说明 | 示例值 |
-|------|------|--------|
+| 参数 | 说明 | 默认值 / 示例值 |
+|------|------|----------------|
 | `dingtalk.app_key` | 钉钉内部应用 AppKey | `dingxxxxxxxxxxxxxx` |
 | `dingtalk.app_secret` | 钉钉内部应用 AppSecret | `xxxxxxxxxxxxxxxxx` |
+| `dingtalk.org_sync_enabled` | 是否启用钉钉组织架构自动同步 | `false` |
+| `dingtalk.org_sync_tenant_id` | 同步写入的租户 ID | `1` |
+| `dingtalk.org_sync_interval_minutes` | 自动同步间隔（分钟） | `60` |
+| `dingtalk.org_sync_root_dept_id` | 同步起始部门 ID。钉钉根部门通常为 `1`。 | `"1"` |
 
 ---
 

--- a/config/config.json.sample
+++ b/config/config.json.sample
@@ -30,7 +30,8 @@
     "enabled": false
   },
   "alerts": {
-    "allow_private_webhook_urls": false
+    "allow_private_webhook_urls": false,
+    "dingtalk_webhook_secret": ""
   },
   "tools": {
     "openclaw": {
@@ -61,7 +62,11 @@
   },
   "dingtalk": {
     "app_key": "<DINGTALK_APP_KEY>",
-    "app_secret": "<DINGTALK_APP_SECRET>"
+    "app_secret": "<DINGTALK_APP_SECRET>",
+    "org_sync_enabled": false,
+    "org_sync_tenant_id": 1,
+    "org_sync_interval_minutes": 60,
+    "org_sync_root_dept_id": "1"
   },
   "auth": {
     "auth_type": "openai",

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,7 +26,7 @@ Documentation files are in the [en/](en/) directory.
 | [**NGINX**](en/NGINX.md) | Nginx reverse proxy configuration for HTTPS and WebSocket |
 | [**DEVELOPMENT**](en/DEVELOPMENT.md) | Development environment setup, project structure, and testing |
 | [**FEISHU-CONFIG**](en/FEISHU_CONFIG.md) | Feishu/Lark integration configuration guide |
-| [**DINGTALK-CONFIG**](en/DINGTALK_CONFIG.md) | DingTalk import resolution configuration guide |
+| [**DINGTALK-CONFIG**](en/DINGTALK_CONFIG.md) | DingTalk integration configuration guide |
 | [**CONCEPTS**](en/CONCEPTS.md) | Core concept definitions — Request, Message, Session, Conversation |
 | [**TOKEN-ACCOUNTING**](en/token-accounting.md) | Deep dive into Claude / Codex / ZCode / Qwen token collection, computation, storage, and downstream usage |
 | [**REPOSITORY-SETUP**](REPOSITORY_SETUP.md) | GitHub repository topics, labels, releases, and demo checklist |
@@ -67,7 +67,7 @@ Documentation files are in the [en/](en/) directory.
 | [**NGINX**](cn/NGINX.md) | Nginx 反向代理配置（HTTPS 和 WebSocket） |
 | [**DEVELOPMENT**](cn/DEVELOPMENT.md) | 开发环境搭建、项目结构和测试 |
 | [**FEISHU-CONFIG**](cn/FEISHU_CONFIG.md) | 飞书集成配置指南 |
-| [**DINGTALK-CONFIG**](cn/DINGTALK_CONFIG.md) | 钉钉导入解析配置指南 |
+| [**DINGTALK-CONFIG**](cn/DINGTALK_CONFIG.md) | 钉钉集成配置指南 |
 | [**CONCEPTS**](cn/CONCEPTS.md) | 核心概念定义 — Request、Message、Session、Conversation |
 | [**TOKEN-ACCOUNTING**](cn/token-accounting.md) | Claude / Codex / ZCode / Qwen token 抓取、计算、落库和下游消费链路说明 |
 | [**REPOSITORY-SETUP**](REPOSITORY_SETUP.md) | GitHub 仓库 topics、labels、releases 和 Demo 检查清单 |

--- a/docs/cn/API.md
+++ b/docs/cn/API.md
@@ -281,6 +281,44 @@ PUT /api/admin/users/<user_id>/quota
 
 ---
 
+### 同步飞书组织架构
+
+```
+POST /api/admin/feishu/sync
+```
+
+手动将飞书部门和用户同步为本地团队、用户、成员关系和 SSO 身份关联。
+
+**请求体：**
+```json
+{
+  "tenant_id": 1
+}
+```
+
+`tenant_id` 可选，默认使用 `feishu.org_sync_tenant_id` 配置。
+
+---
+
+### 同步钉钉组织架构
+
+```
+POST /api/admin/dingtalk/sync
+```
+
+手动将钉钉部门和用户同步为本地团队、用户、成员关系和 SSO 身份关联。
+
+**请求体：**
+```json
+{
+  "tenant_id": 1
+}
+```
+
+`tenant_id` 可选，默认使用 `dingtalk.org_sync_tenant_id` 配置。
+
+---
+
 ### 获取配额使用情况
 
 ```

--- a/docs/cn/DINGTALK_CONFIG.md
+++ b/docs/cn/DINGTALK_CONFIG.md
@@ -1,8 +1,10 @@
-# 钉钉导入解析配置
+# 钉钉集成配置
 
-本指南说明如何配置钉钉导入解析，使 Open ACE 在导入 OpenClaw 会话日志时能够解析钉钉用户名和群名称。
+本指南说明如何配置钉钉集成，实现以下能力：
 
-当前范围仅限 OpenClaw 导入链路中的名称解析和本地缓存。钉钉通讯录同步、钉钉群机器人或 webhook 能力尚未实现，后续工作见 [#1785](https://github.com/open-ace/open-ace/issues/1785)。
+- 导入会话时把钉钉用户/群组 ID 解析成人名/群名
+- 将钉钉组织架构同步到 Open ACE 的本地用户与团队
+- 将告警中心通知推送到钉钉自定义机器人 webhook
 
 ## 概述
 
@@ -10,23 +12,24 @@ Open ACE 可以调用钉钉 API 以实现：
 
 - 显示真实的钉钉用户名，而不是原始 `userId`
 - 在元数据包含群 `chatId` 时，显示钉钉群名称，而不是原始群标识
+- 将钉钉部门同步为 Open ACE 协作团队
+- 将钉钉用户同步为本地用户与团队成员关系
+- 向钉钉群机器人推送告警中心通知
 
 当前支持范围：
 
 - OpenClaw 消息导入链路
 - 钉钉用户名解析
 - 元数据包含 DingTalk `chatId` 时的群名解析
-
-当前不包含：
-
-- 将钉钉部门/用户同步为 Open ACE 本地用户和团队
-- 钉钉群机器人命令或告警推送
+- 手动或按配置定时同步钉钉组织架构
+- 钉钉自定义机器人 webhook 告警 payload
 
 ## 前置条件
 
 1. 一个钉钉开发者账号
 2. 一个具有 API 调用权限的企业内部应用
 3. 该应用的 AppKey 和 AppSecret
+4. 可选：用于告警推送的钉钉自定义机器人 webhook URL
 
 ## 配置步骤
 
@@ -44,12 +47,16 @@ Open ACE 可以调用钉钉 API 以实现：
 {
   "dingtalk": {
     "app_key": "dingxxxxxxxxxxxxxx",
-    "app_secret": "your_app_secret_here"
+    "app_secret": "your_app_secret_here",
+    "org_sync_enabled": true,
+    "org_sync_tenant_id": 1,
+    "org_sync_interval_minutes": 60,
+    "org_sync_root_dept_id": "1"
   }
 }
 ```
 
-### 3. 测试配置
+### 3. 测试名称解析配置
 
 ```bash
 # 测试用户名解析
@@ -58,6 +65,39 @@ python3 scripts/shared/dingtalk_user_cache.py test manager123 <app_key> <app_sec
 # 测试群名解析
 python3 scripts/shared/dingtalk_group_cache.py test chatabcd1234 <app_key> <app_secret>
 ```
+
+### 4. 同步组织架构
+
+保存配置后：
+
+1. 如果修改了 `config.json`，先重启 Open ACE
+2. 管理员调用 `POST /api/admin/dingtalk/sync`，可选请求体为 `{"tenant_id": 1}`
+
+当 `dingtalk.org_sync_enabled=true` 时，后台数据抓取调度器还会按照 `dingtalk.org_sync_interval_minutes` 周期性执行自动同步。
+
+当前同步行为：
+
+- 部门会映射为协作 `teams`
+- 用户会同步到本地 `users`
+- 钉钉身份会写入 `sso_identities`
+- 钉钉管理的团队成员关系会按最新组织结构对齐
+
+当前暂不处理：
+
+- 用户从钉钉消失后自动禁用/删除本地账号
+- 部门删除后自动删除本地团队
+- 钉钉 SSO 登录流程
+- 入站钉钉机器人命令
+
+### 5. 配置钉钉机器人告警
+
+在 `管理 -> 配额告警 -> 通知偏好` 中，将 webhook URL 设置为钉钉自定义机器人 URL，例如：
+
+```text
+https://oapi.dingtalk.com/robot/send?access_token=xxxxxxxx
+```
+
+Open ACE 会为告警通知发送钉钉兼容的 `text` payload。如果钉钉机器人启用了加签，请在 `config.json` 中设置 `alerts.dingtalk_webhook_secret`。如果需要按单个 webhook 配置，也可以在保存的 URL 中加入 `openace_dingtalk_secret=<secret>`；Open ACE 发送前会移除该参数，并自动追加钉钉要求的 `timestamp` / `sign` 参数。
 
 ## 缓存管理
 
@@ -89,4 +129,4 @@ python3 scripts/shared/dingtalk_group_cache.py test chatabcd1234 <app_key> <app_
 
 ## 禁用集成
 
-如需禁用钉钉导入解析，请从配置文件中删除 `dingtalk` 配置段。
+如需禁用钉钉集成，请从配置文件中删除 `dingtalk` 配置段。如需保留名称解析但停止定时组织同步，请设置 `dingtalk.org_sync_enabled=false`。

--- a/docs/cn/INTRO.md
+++ b/docs/cn/INTRO.md
@@ -498,7 +498,7 @@ docker compose restart
 | [DEPLOYMENT.md](./DEPLOYMENT.md) | 部署指南（本地、Docker、企业） |
 | [DEVELOPMENT.md](./DEVELOPMENT.md) | 开发设置和贡献指南 |
 | [FEISHU_CONFIG.md](./FEISHU_CONFIG.md) | 飞书集成配置 |
-| [DINGTALK_CONFIG.md](./DINGTALK_CONFIG.md) | 钉钉导入解析配置 |
+| [DINGTALK_CONFIG.md](./DINGTALK_CONFIG.md) | 钉钉集成配置 |
 
 ---
 

--- a/docs/en/API.md
+++ b/docs/en/API.md
@@ -281,6 +281,44 @@ Update a user's token/request quotas.
 
 ---
 
+### Sync Feishu Organization
+
+```
+POST /api/admin/feishu/sync
+```
+
+Manually sync Feishu departments and users into local teams, users, memberships, and SSO identity links.
+
+**Request Body:**
+```json
+{
+  "tenant_id": 1
+}
+```
+
+`tenant_id` is optional and defaults to the configured `feishu.org_sync_tenant_id`.
+
+---
+
+### Sync DingTalk Organization
+
+```
+POST /api/admin/dingtalk/sync
+```
+
+Manually sync DingTalk departments and users into local teams, users, memberships, and SSO identity links.
+
+**Request Body:**
+```json
+{
+  "tenant_id": 1
+}
+```
+
+`tenant_id` is optional and defaults to the configured `dingtalk.org_sync_tenant_id`.
+
+---
+
 ### Get Quota Usage
 
 ```

--- a/docs/en/DINGTALK_CONFIG.md
+++ b/docs/en/DINGTALK_CONFIG.md
@@ -1,8 +1,10 @@
-# DingTalk Import Resolution Configuration
+# DingTalk Integration Configuration
 
-This guide explains how to configure DingTalk import resolution so Open ACE can resolve DingTalk user names and group names from imported OpenClaw session logs.
+This guide explains how to configure DingTalk integration for:
 
-Current scope is limited to OpenClaw import name resolution and local caches. DingTalk organization sync and DingTalk bot/webhook features are not implemented yet; follow [#1785](https://github.com/open-ace/open-ace/issues/1785) for that work.
+- imported-session user and group name resolution
+- local org sync of DingTalk departments and users into Open ACE teams and users
+- alert delivery to DingTalk custom robot webhooks
 
 ## Overview
 
@@ -10,23 +12,24 @@ Open ACE can use DingTalk APIs to:
 
 - Display real DingTalk user names instead of raw `userId` values
 - Display DingTalk group names instead of raw `chatId` metadata when available
+- Sync DingTalk departments into Open ACE collaboration teams
+- Sync DingTalk users into local users + team memberships
+- Send alert center notifications to DingTalk group robots
 
 Current scope:
 
 - OpenClaw message import path
 - DingTalk user name resolution
 - DingTalk group name resolution when session metadata contains a DingTalk `chatId`
-
-Out of scope today:
-
-- DingTalk department/user synchronization into Open ACE users and teams
-- DingTalk group bot commands or alert delivery
+- Manual and optionally scheduled DingTalk organization sync
+- DingTalk custom robot webhook notification payloads
 
 ## Prerequisites
 
 1. A DingTalk developer account
 2. An internal enterprise application with API access
 3. An AppKey and AppSecret for that application
+4. Optional: a DingTalk custom robot webhook URL for alert delivery
 
 ## Setup
 
@@ -44,12 +47,16 @@ Edit `~/.open-ace/config.json`:
 {
   "dingtalk": {
     "app_key": "dingxxxxxxxxxxxxxx",
-    "app_secret": "your_app_secret_here"
+    "app_secret": "your_app_secret_here",
+    "org_sync_enabled": true,
+    "org_sync_tenant_id": 1,
+    "org_sync_interval_minutes": 60,
+    "org_sync_root_dept_id": "1"
   }
 }
 ```
 
-### 3. Test configuration
+### 3. Test name-resolution configuration
 
 ```bash
 # Test user name lookup
@@ -58,6 +65,39 @@ python3 scripts/shared/dingtalk_user_cache.py test manager123 <app_key> <app_sec
 # Test group name lookup
 python3 scripts/shared/dingtalk_group_cache.py test chatabcd1234 <app_key> <app_secret>
 ```
+
+### 4. Sync the organization structure
+
+After saving the config:
+
+1. Restart Open ACE if you changed `config.json`
+2. Call `POST /api/admin/dingtalk/sync` as an administrator, optionally with `{"tenant_id": 1}`
+
+When `dingtalk.org_sync_enabled=true`, the background data-fetch scheduler also performs periodic sync based on `dingtalk.org_sync_interval_minutes`.
+
+Current sync behavior:
+
+- departments are mirrored into collaboration `teams`
+- users are provisioned into local `users`
+- DingTalk identities are linked through `sso_identities`
+- team memberships are reconciled for DingTalk-managed teams
+
+Current non-goals:
+
+- disabling or deleting local users when they disappear from DingTalk
+- removing DingTalk-managed teams automatically when departments disappear
+- DingTalk SSO login flow
+- inbound DingTalk chatbot commands
+
+### 5. Configure DingTalk robot alerts
+
+In `Manage -> Quota Alerts -> Notification Preferences`, set the webhook URL to a DingTalk custom robot URL such as:
+
+```text
+https://oapi.dingtalk.com/robot/send?access_token=xxxxxxxx
+```
+
+Open ACE sends DingTalk-compatible `text` payloads for alert notifications. If the DingTalk robot requires signing, set `alerts.dingtalk_webhook_secret` in `config.json`. As a per-webhook fallback, `openace_dingtalk_secret=<secret>` can be added to the saved URL; Open ACE strips that parameter before sending and adds DingTalk's `timestamp` / `sign` parameters.
 
 ## Cache management
 
@@ -89,4 +129,4 @@ Cache files:
 
 ## Disabling integration
 
-To disable DingTalk import resolution, remove the `dingtalk` section from your config file.
+To disable DingTalk integration, remove the `dingtalk` section from your config file. To keep name resolution but stop scheduled org sync, set `dingtalk.org_sync_enabled=false`.

--- a/docs/en/INTRO.md
+++ b/docs/en/INTRO.md
@@ -498,7 +498,7 @@ Password: admin123
 | [DEPLOYMENT.md](./DEPLOYMENT.md) | Deployment guides (local, Docker, enterprise) |
 | [DEVELOPMENT.md](./DEVELOPMENT.md) | Development setup & contribution guide |
 | [FEISHU_CONFIG.md](./FEISHU_CONFIG.md) | Feishu integration configuration |
-| [DINGTALK_CONFIG.md](./DINGTALK_CONFIG.md) | DingTalk import resolution configuration |
+| [DINGTALK_CONFIG.md](./DINGTALK_CONFIG.md) | DingTalk integration configuration |
 
 ---
 

--- a/tests/issues/1751/test_doc_capability_alignment.py
+++ b/tests/issues/1751/test_doc_capability_alignment.py
@@ -27,25 +27,25 @@ def test_readme_marks_saml_as_planned_not_supported() -> None:
     assert "SAML 2.0 Provider is not implemented yet" in readme
 
 
-def test_dingtalk_docs_limit_scope_to_import_resolution() -> None:
+def test_dingtalk_docs_advertise_implemented_sync_and_bot_support() -> None:
     readme = read_doc("README.md")
     en_config = read_doc("docs/en/DINGTALK_CONFIG.md")
     cn_config = read_doc("docs/cn/DINGTALK_CONFIG.md")
     config_guide = read_doc("config/CONFIG_GUIDE.md")
 
-    assert "Feishu/DingTalk" not in readme
-    assert "飞书/钉钉" not in readme
-    assert "DingTalk import resolution" in readme
-    assert "钉钉导入解析" in readme
+    assert "#1785" not in readme
+    assert "#1785" not in en_config
+    assert "DingTalk Sync" in readme
+    assert "钉钉同步" in readme
 
-    assert "Current scope is limited to OpenClaw import name resolution" in en_config
-    assert "Out of scope today" in en_config
-    assert "#1785" in en_config
+    assert "local org sync of DingTalk departments and users" in en_config
+    assert "alert delivery to DingTalk custom robot webhooks" in en_config
+    assert "POST /api/admin/dingtalk/sync" in en_config
 
-    assert "当前范围仅限 OpenClaw 导入链路中的名称解析" in cn_config
-    assert "当前不包含" in cn_config
-    assert "#1785" in cn_config
-    assert "当前钉钉能力仅用于 OpenClaw 导入链路" in config_guide
+    assert "将钉钉组织架构同步到 Open ACE" in cn_config
+    assert "钉钉自定义机器人 webhook" in cn_config
+    assert "POST /api/admin/dingtalk/sync" in cn_config
+    assert "当前钉钉能力覆盖 OpenClaw 导入链路" in config_guide
 
 
 def test_terminal_docs_describe_windows_piped_subprocess() -> None:

--- a/tests/routes/test_admin_feishu_sync.py
+++ b/tests/routes/test_admin_feishu_sync.py
@@ -67,3 +67,31 @@ def test_manual_feishu_sync_validates_tenant_id(admin_client):
     response = admin_client.post("/api/admin/feishu/sync", json={"tenant_id": "oops"})
     assert response.status_code == 400
     assert "tenant_id" in response.get_json()["error"]
+
+
+def test_manual_dingtalk_sync_returns_summary(admin_client):
+    """Admin API should return the DingTalk sync result payload."""
+
+    class DummyResult:
+        def to_dict(self):
+            return {"tenant_id": 4, "users_seen": 3, "teams_created": 2}
+
+    with patch(
+        "app.services.dingtalk_org_sync.DingTalkOrgSyncService.sync_org",
+        return_value=DummyResult(),
+    ) as sync_org:
+        response = admin_client.post("/api/admin/dingtalk/sync", json={"tenant_id": 4})
+
+    assert response.status_code == 200
+    assert response.get_json() == {
+        "success": True,
+        "result": {"tenant_id": 4, "users_seen": 3, "teams_created": 2},
+    }
+    sync_org.assert_called_once_with(tenant_id=4)
+
+
+def test_manual_dingtalk_sync_validates_tenant_id(admin_client):
+    """Admin API should reject non-integer tenant_id values for DingTalk sync."""
+    response = admin_client.post("/api/admin/dingtalk/sync", json={"tenant_id": "oops"})
+    assert response.status_code == 400
+    assert "tenant_id" in response.get_json()["error"]

--- a/tests/unit/test_alert_notifier_webhook.py
+++ b/tests/unit/test_alert_notifier_webhook.py
@@ -103,6 +103,95 @@ class TestAlertNotifierWebhook(unittest.TestCase):
     @patch("app.modules.governance.alert_notifier.requests.post")
     @patch("app.modules.governance.alert_notifier.AlertNotifier.get_notification_preferences")
     @patch("app.modules.governance.alert_notifier.AlertNotifier._save_alert")
+    def test_create_alert_uses_dingtalk_payload(
+        self, mock_save, mock_get_prefs, mock_post, mock_validate
+    ):
+        notifier = AlertNotifier()
+        notifier._subscribers = []
+
+        mock_validate.return_value = (True, None)
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
+        mock_post.return_value = mock_response
+        mock_get_prefs.return_value = NotificationPreference(
+            user_id=1,
+            email_enabled=False,
+            push_enabled=True,
+            webhook_url="https://oapi.dingtalk.com/robot/send?access_token=abc123",
+            alert_types=["system"],
+            min_severity="info",
+        )
+
+        notifier.create_alert(
+            alert_type="system",
+            severity="critical",
+            title="System Alert",
+            message="Service unavailable",
+            user_id=1,
+            username="alice",
+        )
+
+        payload = mock_post.call_args.kwargs["json"]
+        assert payload["msgtype"] == "text"
+        assert "System Alert" in payload["text"]["content"]
+        assert "Service unavailable" in payload["text"]["content"]
+
+    @patch("app.modules.governance.alert_notifier.AlertNotifier.validate_webhook_url")
+    @patch("app.modules.governance.alert_notifier.requests.post")
+    @patch("app.modules.governance.alert_notifier.AlertNotifier.get_notification_preferences")
+    @patch("app.modules.governance.alert_notifier.AlertNotifier._save_alert")
+    def test_create_alert_does_not_treat_lookalike_host_as_dingtalk(
+        self, mock_save, mock_get_prefs, mock_post, mock_validate
+    ):
+        notifier = AlertNotifier()
+        notifier._subscribers = []
+
+        mock_validate.return_value = (True, None)
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
+        mock_post.return_value = mock_response
+        mock_get_prefs.return_value = NotificationPreference(
+            user_id=1,
+            email_enabled=False,
+            push_enabled=True,
+            webhook_url="https://notdingtalk.com/robot/send?access_token=abc123",
+            alert_types=["system"],
+            min_severity="info",
+        )
+
+        notifier.create_alert(
+            alert_type="system",
+            severity="critical",
+            title="System Alert",
+            message="Service unavailable",
+            user_id=1,
+            username="alice",
+        )
+
+        payload = mock_post.call_args.kwargs["json"]
+        assert payload["event"] == "openace.alert"
+        assert "System Alert" in payload["summary"]
+
+    @patch("app.modules.governance.alert_notifier.time.time", return_value=1710000000.123)
+    @patch(
+        "app.modules.governance.alert_notifier.get_config_value",
+        return_value="global-dingtalk-secret",
+    )
+    def test_prepare_dingtalk_webhook_url_adds_signature(self, mock_config, mock_time):
+        notifier = AlertNotifier()
+
+        url = notifier._prepare_webhook_url(
+            "https://oapi.dingtalk.com/robot/send?access_token=abc123"
+        )
+
+        assert "access_token=abc123" in url
+        assert "timestamp=1710000000123" in url
+        assert "sign=" in url
+
+    @patch("app.modules.governance.alert_notifier.AlertNotifier.validate_webhook_url")
+    @patch("app.modules.governance.alert_notifier.requests.post")
+    @patch("app.modules.governance.alert_notifier.AlertNotifier.get_notification_preferences")
+    @patch("app.modules.governance.alert_notifier.AlertNotifier._save_alert")
     def test_create_alert_skips_webhook_when_push_disabled(
         self, mock_save, mock_get_prefs, mock_post, mock_validate
     ):

--- a/tests/unit/test_dingtalk_org_sync.py
+++ b/tests/unit/test_dingtalk_org_sync.py
@@ -1,0 +1,307 @@
+"""Unit tests for DingTalk org synchronization."""
+
+from __future__ import annotations
+
+import pytest
+
+import app.utils.smtp_crypto as smtp_crypto
+from app.repositories.database import Database
+from app.repositories.schema_init import load_schema_from_file
+from app.repositories.user_repo import UserRepository
+from app.services.dingtalk_org_sync import (
+    DINGTALK_PROVIDER_NAME,
+    DingTalkDepartment,
+    DingTalkOrgSyncService,
+    DingTalkUser,
+)
+
+
+class FakeDingTalkOrgSyncService(DingTalkOrgSyncService):
+    """Deterministic DingTalk sync service for tests."""
+
+    def __init__(self, *args, departments=None, users=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._departments = list(departments or [])
+        self._users = list(users or [])
+
+    def _get_access_token(self, app_key: str, app_secret: str) -> str:
+        assert app_key == "test-app-key"
+        assert app_secret == "test-app-secret"
+        return "test-token"
+
+    def _fetch_directory_snapshot(self, token: str, root_department_id: str):
+        assert token == "test-token"
+        assert root_department_id == "1"
+        return self._departments, self._users
+
+
+@pytest.fixture
+def sync_env(tmp_path, monkeypatch):
+    """Create an isolated SQLite-backed sync environment."""
+    monkeypatch.setenv("OPENACE_ENCRYPTION_KEY", "test-dingtalk-org-sync-key")
+    smtp_crypto._password_manager_instance = None
+
+    db = Database(db_url=f"sqlite:///{tmp_path / 'dingtalk-sync.db'}")
+    load_schema_from_file(db_url=db.db_url, dialect="sqlite")
+
+    config = {
+        "dingtalk": {
+            "app_key": "test-app-key",
+            "app_secret": "test-app-secret",
+            "org_sync_enabled": True,
+            "org_sync_tenant_id": 8,
+            "org_sync_interval_minutes": 60,
+            "org_sync_root_dept_id": "1",
+        }
+    }
+
+    try:
+        yield db, config
+    finally:
+        smtp_crypto._password_manager_instance = None
+
+
+def test_sync_creates_users_teams_memberships_and_sso_links(sync_env):
+    """A sync run should provision DingTalk users, teams, memberships, and SSO links."""
+    db, config = sync_env
+    service = FakeDingTalkOrgSyncService(
+        db=db,
+        user_repo=UserRepository(db=db),
+        config_override=config,
+        departments=[
+            DingTalkDepartment(department_id="100", name="Engineering"),
+            DingTalkDepartment(
+                department_id="200",
+                name="QA",
+                parent_department_id="100",
+            ),
+        ],
+        users=[
+            DingTalkUser(
+                user_id="manager123",
+                name="Alice DingTalk",
+                email="alice@example.com",
+                department_ids=["100"],
+            ),
+            DingTalkUser(
+                user_id="staff456",
+                name="Bob DingTalk",
+                department_ids=["200"],
+            ),
+        ],
+    )
+
+    result = service.sync_org()
+
+    assert result.tenant_id == 8
+    assert result.departments_seen == 2
+    assert result.users_seen == 2
+    assert result.teams_created == 2
+    assert result.users_created == 2
+    assert result.memberships_added == 2
+    assert result.warnings == []
+
+    users = db.fetch_all("SELECT username, email, tenant_id FROM users ORDER BY email ASC")
+    assert users == [
+        {
+            "username": "alice",
+            "email": "alice@example.com",
+            "tenant_id": 8,
+        },
+        {
+            "username": "bob_dingtalk",
+            "email": "staff456@dingtalk.local",
+            "tenant_id": 8,
+        },
+    ]
+
+    teams = db.fetch_all("SELECT team_id, name, settings FROM teams ORDER BY name ASC")
+    assert [team["name"] for team in teams] == ["Engineering", "QA"]
+    assert all(DINGTALK_PROVIDER_NAME in team["settings"] for team in teams)
+
+    identities = db.fetch_all(
+        """
+        SELECT provider_name, provider_user_id
+        FROM sso_identities
+        ORDER BY provider_user_id ASC
+        """
+    )
+    assert identities == [
+        {"provider_name": DINGTALK_PROVIDER_NAME, "provider_user_id": "manager123"},
+        {"provider_name": DINGTALK_PROVIDER_NAME, "provider_user_id": "staff456"},
+    ]
+
+    memberships = db.fetch_all(
+        """
+        SELECT tm.user_id, t.name AS team_name
+        FROM team_members tm
+        JOIN teams t ON t.team_id = tm.team_id
+        ORDER BY team_name ASC
+        """
+    )
+    assert [row["team_name"] for row in memberships] == ["Engineering", "QA"]
+
+
+def test_sync_reuses_existing_user_by_email_and_removes_stale_membership(sync_env):
+    """Sync should link by email and prune memberships on DingTalk-managed teams."""
+    db, config = sync_env
+    user_repo = UserRepository(db=db)
+
+    existing_user_id = user_repo.create_user(
+        username="alice_local",
+        email="alice@example.com",
+        password_hash="hash",
+        tenant_id=8,
+    )
+    stale_user_id = user_repo.create_user(
+        username="stale",
+        email="stale@example.com",
+        password_hash="hash",
+        tenant_id=8,
+    )
+    assert existing_user_id is not None
+    assert stale_user_id is not None
+
+    service = FakeDingTalkOrgSyncService(
+        db=db,
+        user_repo=user_repo,
+        config_override=config,
+        departments=[DingTalkDepartment(department_id="100", name="Engineering")],
+        users=[
+            DingTalkUser(
+                user_id="manager123",
+                name="Alice DingTalk",
+                email="alice@example.com",
+                department_ids=["100"],
+            )
+        ],
+    )
+
+    first_result = service.sync_org()
+    assert first_result.users_created == 0
+    assert first_result.users_linked == 1
+
+    synced_team = db.fetch_one("SELECT team_id FROM teams WHERE name = ?", ("Engineering",))
+    assert synced_team is not None
+    db.execute(
+        """
+        INSERT INTO team_members (team_id, user_id, username, role, joined_at)
+        VALUES (?, ?, ?, ?, ?)
+        """,
+        (
+            synced_team["team_id"],
+            stale_user_id,
+            "stale",
+            "member",
+            "2026-07-18T00:00:00",
+        ),
+    )
+
+    second_result = service.sync_org()
+    assert second_result.memberships_removed == 1
+
+    members = db.fetch_all(
+        "SELECT user_id FROM team_members WHERE team_id = ? ORDER BY user_id ASC",
+        (synced_team["team_id"],),
+    )
+    assert members == [{"user_id": existing_user_id}]
+
+
+def test_scheduler_gate_runs_only_when_enabled(sync_env):
+    """Scheduled sync should obey config and interval gates."""
+    db, config = sync_env
+    service = FakeDingTalkOrgSyncService(
+        db=db,
+        user_repo=UserRepository(db=db),
+        config_override=config,
+        departments=[],
+        users=[],
+    )
+
+    service.__class__._last_scheduled_sync_at = None
+
+    first = service.maybe_sync_from_scheduler()
+    assert first is not None
+
+    second = service.maybe_sync_from_scheduler()
+    assert second is None
+
+    disabled = FakeDingTalkOrgSyncService(
+        db=db,
+        user_repo=UserRepository(db=db),
+        config_override={"dingtalk": {**config["dingtalk"], "org_sync_enabled": False}},
+        departments=[],
+        users=[],
+    )
+    assert disabled.maybe_sync_from_scheduler() is None
+
+
+def test_fetch_directory_snapshot_uses_dingtalk_department_and_user_apis():
+    """API parsing should match DingTalk department/user endpoint shapes."""
+
+    class FakeResponse:
+        def __init__(self, payload):
+            self._payload = payload
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return self._payload
+
+    class FakeHttp:
+        def __init__(self):
+            self.calls = []
+
+        def post(self, url, **kwargs):
+            self.calls.append((url, kwargs))
+            if url.endswith("/department/listsub"):
+                dept_id = kwargs["json"]["dept_id"]
+                if dept_id == 1:
+                    return FakeResponse(
+                        {
+                            "errcode": 0,
+                            "result": [{"dept_id": 100, "name": "Engineering"}],
+                        }
+                    )
+                return FakeResponse({"errcode": 0, "result": []})
+            if url.endswith("/user/listid"):
+                dept_id = kwargs["json"]["dept_id"]
+                userids = ["manager123"] if dept_id == 100 else []
+                return FakeResponse(
+                    {
+                        "errcode": 0,
+                        "result": {"userid_list": userids, "has_more": False},
+                    }
+                )
+            if url.endswith("/user/get"):
+                return FakeResponse(
+                    {
+                        "errcode": 0,
+                        "result": {
+                            "userid": "manager123",
+                            "name": "Alice DingTalk",
+                            "email": "alice@example.com",
+                            "dept_id_list": [100],
+                        },
+                    }
+                )
+            raise AssertionError(f"unexpected URL {url}")
+
+    service = DingTalkOrgSyncService(
+        config_override={"dingtalk": {"app_key": "unused", "app_secret": "unused"}},
+        http_session=FakeHttp(),
+    )
+
+    departments, users = service._fetch_directory_snapshot("token", "1")
+
+    assert departments == [DingTalkDepartment(department_id="100", name="Engineering")]
+    assert users == [
+        DingTalkUser(
+            user_id="manager123",
+            name="Alice DingTalk",
+            email="alice@example.com",
+            department_ids=["100"],
+            status={},
+        )
+    ]


### PR DESCRIPTION
## Summary
- add DingTalk organization sync for departments, users, SSO links, and team memberships
- add admin-triggered and scheduled sync paths plus DingTalk alert robot payload/signing support
- update config samples, README, API docs, DingTalk docs, and capability-alignment tests

## Verification
- pytest tests/unit/test_dingtalk_org_sync.py tests/routes/test_admin_feishu_sync.py tests/unit/test_alert_notifier_webhook.py tests/issues/1751/test_doc_capability_alignment.py tests/unit/test_feishu_org_sync.py tests/unit/test_dingtalk_user_cache.py tests/unit/test_dingtalk_group_cache.py tests/unit/test_fetch_openclaw_dingtalk.py -q
- SKIP=bandit /Users/rhuang/Library/Python/3.9/bin/pre-commit run --all-files

Closes #1785