### PR TITLE
Persist remote runtime state

### DIFF
--- a/app/modules/workspace/remote_agent_manager.py
+++ b/app/modules/workspace/remote_agent_manager.py
@@ -47,10 +47,10 @@ class RemoteAgentManager:
     Tracks active agent connections, monitors heartbeats, dispatches
     commands to agents, and routes agent responses back to sessions.
 
-    Runtime boundary: connection objects, output buffers, HTTP polling command
-    queues, and pending request events are process-local. Multi-pod deployments
-    require sticky routing for active remote sessions until issue #1782 moves
-    shareable state into Redis or another persistent coordination layer.
+    Runtime boundary: live connection objects are process-local, but HTTP
+    polling commands, command responses, session-machine bindings, and SSE
+    output replay are persisted so active remote-session control APIs do not
+    depend on hitting the same web process.
     """
 
     HEARTBEAT_TIMEOUT_SECONDS = 180  # 3 minutes without heartbeat = offline
@@ -63,6 +63,12 @@ class RemoteAgentManager:
     # Prevents unbounded memory growth when SSE disconnects but CLI continues
     # 5000 messages ≈ 3-5 minutes of AI output, covers most brief disconnect scenarios
     MAX_BUFFER_SIZE = 5000
+
+    # Persisted runtime-state retention. These tables externalize the shareable
+    # control plane state for HTTP-polling agents; live socket objects remain
+    # process-local by design.
+    COMMAND_TTL_SECONDS = 3600
+    OUTPUT_RETENTION_SECONDS = 24 * 3600
 
     # Session recovery window (seconds) - allows reconnection after brief disconnects
     # Sessions are only cleaned up if they've been inactive longer than this window
@@ -83,9 +89,9 @@ class RemoteAgentManager:
             self.db = Database(db_url=f"sqlite:///{self.db_path}")
         else:
             self.db = Database()
-        # Process-local WebSocket connections: {machine_id: websocket_connection}.
-        # See the class docstring and issue #1782 before removing sticky routing
-        # from Kubernetes or other horizontally scaled deployments.
+        # Process-local live connection markers: {machine_id: websocket_connection}.
+        # HTTP polling commands/responses are persisted for cross-pod delivery;
+        # actual socket objects remain tied to the process that owns them.
         self._connections: dict[str, Any] = {}
         # Session to machine mapping: {session_id: machine_id}
         self._session_machines: dict[str, str] = {}
@@ -1013,10 +1019,12 @@ class RemoteAgentManager:
         Returns:
             True if command was queued successfully.
         """
-        with self._lock:
-            if machine_id not in self._command_queues:
-                self._command_queues[machine_id] = []
-            self._command_queues[machine_id].append(command)
+        queued = self._persist_command(machine_id, command)
+        if not queued:
+            with self._lock:
+                if machine_id not in self._command_queues:
+                    self._command_queues[machine_id] = []
+                self._command_queues[machine_id].append(command)
 
         if machine_id not in self._connections:
             logger.info(
@@ -1030,7 +1038,88 @@ class RemoteAgentManager:
     def get_pending_commands(self, machine_id: str) -> list[dict]:
         """Get and clear pending commands for an HTTP-mode agent."""
         with self._lock:
-            return self._command_queues.pop(machine_id, [])
+            memory_commands = self._command_queues.pop(machine_id, [])
+        return memory_commands + self._claim_persisted_commands(machine_id)
+
+    def _persist_command(self, machine_id: str, command: dict[str, Any]) -> bool:
+        """Persist an HTTP-polling command so any web pod can deliver it."""
+        command = dict(command)
+        command_id = str(command.get("command_id") or command.get("request_id") or uuid.uuid4())
+        command["command_id"] = command_id
+        session_id = command.get("session_id")
+        command_type = command.get("command") or command.get("type") or ""
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
+        expires_at = (now + timedelta(seconds=self.COMMAND_TTL_SECONDS)).isoformat()
+        try:
+            with self.db.connection() as conn:
+                cursor = conn.cursor()
+                cursor.execute(
+                    f"""
+                    INSERT INTO remote_runtime_commands
+                    (command_id, machine_id, session_id, command_type, payload,
+                     status, created_at, expires_at)
+                    VALUES ({_params(8)})
+                    """,
+                    (
+                        command_id,
+                        machine_id,
+                        str(session_id) if session_id else None,
+                        str(command_type),
+                        json.dumps(command),
+                        "pending",
+                        now.isoformat(),
+                        expires_at,
+                    ),
+                )
+                conn.commit()
+            return True
+        except Exception as e:
+            logger.warning("Falling back to in-memory command queue for %s: %s", machine_id, e)
+            return False
+
+    def _claim_persisted_commands(self, machine_id: str) -> list[dict]:
+        """Claim pending persisted commands for a polling agent."""
+        now = datetime.now(timezone.utc).replace(tzinfo=None).isoformat()
+        claimed: list[dict] = []
+        try:
+            with self.db.connection() as conn:
+                cursor = conn.cursor()
+                cursor.execute(
+                    f"""
+                    SELECT id, payload
+                    FROM remote_runtime_commands
+                    WHERE machine_id = {_param()}
+                      AND status = 'pending'
+                      AND (expires_at IS NULL OR expires_at > {_param()})
+                    ORDER BY id ASC
+                    LIMIT 100
+                    """,
+                    (machine_id, now),
+                )
+                rows = cursor.fetchall()
+                for row in rows:
+                    command_id = row["id"]
+                    cursor.execute(
+                        f"""
+                        UPDATE remote_runtime_commands
+                        SET status = 'delivered', delivered_at = {_param()}
+                        WHERE id = {_param()} AND status = 'pending'
+                        """,
+                        (now, command_id),
+                    )
+                    if cursor.rowcount != 1:
+                        continue
+                    try:
+                        payload = json.loads(row["payload"])
+                    except (TypeError, ValueError, json.JSONDecodeError):
+                        logger.warning("Skipping corrupt remote command payload id=%s", command_id)
+                        continue
+                    if isinstance(payload, dict):
+                        claimed.append(payload)
+                conn.commit()
+        except Exception as e:
+            logger.warning("Failed to claim persisted commands for %s: %s", machine_id, e)
+        return claimed
 
     def send_command_with_response(
         self,
@@ -1075,12 +1164,21 @@ class RemoteAgentManager:
             },
         )
 
-        # Wait for response (gevent Event.wait is coroutine-safe)
+        # Wait for response. The in-process Event handles the same-pod fast
+        # path; the DB poll handles non-sticky deployments where the agent's
+        # command_response lands on another web pod.
         pending = self._pending_requests[request_id]
-        if pending["event"].wait(timeout):
-            result = pending["result"]
-        else:
-            result = None  # Timeout
+        deadline = time.time() + timeout
+        result = None
+        while time.time() < deadline:
+            remaining = max(0.0, deadline - time.time())
+            if pending["event"].wait(min(0.2, remaining)):
+                result = pending["result"]
+                break
+            result = self._get_persisted_command_response(request_id)
+            if result is not None:
+                break
+        if result is None:
             logger.warning(
                 "Timeout waiting for %s response from agent %s (session %s)",
                 command,
@@ -1093,6 +1191,23 @@ class RemoteAgentManager:
             self._pending_requests.pop(request_id, None)
 
         return cast("dict | None", result)
+
+    def _get_persisted_command_response(self, request_id: str) -> dict | None:
+        """Read a command response persisted by another web process."""
+        try:
+            row = self.db.fetch_one(
+                f"SELECT response_payload FROM remote_runtime_commands WHERE command_id = {_param()}",
+                (request_id,),
+            )
+        except Exception:
+            return None
+        if not row or not row.get("response_payload"):
+            return None
+        try:
+            result = json.loads(row["response_payload"])
+        except (TypeError, ValueError, json.JSONDecodeError):
+            return None
+        return result if isinstance(result, dict) else None
 
     def handle_command_response(self, data: dict) -> None:
         """
@@ -1115,6 +1230,27 @@ class RemoteAgentManager:
             logger.warning(
                 "Received response for unknown request %s", request_id[:8] if request_id else "N/A"
             )
+        if request_id:
+            self._persist_command_response(request_id, data.get("result"))
+
+    def _persist_command_response(self, request_id: str, result: Any) -> None:
+        """Persist a command response for cross-pod waiters."""
+        try:
+            self.db.execute(
+                f"""
+                UPDATE remote_runtime_commands
+                SET status = {_param()}, response_payload = {_param()}, responded_at = {_param()}
+                WHERE command_id = {_param()}
+                """,
+                (
+                    "responded",
+                    json.dumps(result) if result is not None else None,
+                    datetime.now(timezone.utc).replace(tzinfo=None).isoformat(),
+                    request_id,
+                ),
+            )
+        except Exception as e:
+            logger.debug("Failed to persist command response %s: %s", request_id[:8], e)
 
     def store_browse_result(self, request_id: str, result: dict) -> None:
         """Store browse result from agent for later retrieval."""
@@ -1251,6 +1387,7 @@ class RemoteAgentManager:
         Limitation: If SSE disconnects for >3-5 minutes during high-frequency
         output (>5000 messages), old data will be trimmed and lost on reconnect.
         """
+        self._persist_output(session_id, output)
         with self._lock:
             if session_id not in self._output_buffers:
                 self._output_buffers[session_id] = deque(maxlen=self.MAX_BUFFER_SIZE)
@@ -1276,6 +1413,10 @@ class RemoteAgentManager:
         Returns:
             List of output entries (converted from deque slice).
         """
+        persisted = self._get_persisted_output(session_id, after_index=after_index)
+        if persisted:
+            return persisted
+
         with self._lock:
             buf: deque[dict] = self._output_buffers.get(session_id, deque())
             offset = self._buffer_offsets.get(session_id, 0)
@@ -1284,6 +1425,79 @@ class RemoteAgentManager:
             if effective_index >= len(buf):
                 return []
             return list(buf)[effective_index:]
+
+    def _persist_output(self, session_id: str, output: dict[str, Any]) -> None:
+        """Persist stream output for cross-pod SSE replay and restart recovery."""
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
+        try:
+            with self.db.connection() as conn:
+                cursor = conn.cursor()
+                cursor.execute(
+                    f"""
+                    SELECT COALESCE(MAX(event_index), 0) + 1 AS next_index
+                    FROM remote_runtime_outputs
+                    WHERE session_id = {_param()}
+                    """,
+                    (session_id,),
+                )
+                row = cursor.fetchone()
+                event_index = int(row["next_index"] if row else 1)
+                cursor.execute(
+                    f"""
+                    INSERT INTO remote_runtime_outputs
+                    (session_id, event_index, stream, payload, created_at, expires_at)
+                    VALUES ({_params(6)})
+                    """,
+                    (
+                        session_id,
+                        event_index,
+                        str(output.get("stream", "stdout")),
+                        json.dumps(output),
+                        now.isoformat(),
+                        (now + timedelta(seconds=self.OUTPUT_RETENTION_SECONDS)).isoformat(),
+                    ),
+                )
+                conn.commit()
+        except Exception as e:
+            logger.debug("Failed to persist output for session %s: %s", session_id[:8], e)
+
+    def _get_persisted_output(self, session_id: str, after_index: int = 0) -> list[dict]:
+        """Read persisted output events after the delivered event index."""
+        try:
+            with self.db.connection() as conn:
+                cursor = conn.cursor()
+                cursor.execute(
+                    f"""
+                    SELECT event_index, payload
+                    FROM remote_runtime_outputs
+                    WHERE session_id = {_param()}
+                      AND event_index > {_param()}
+                      AND (expires_at IS NULL OR expires_at > {_param()})
+                    ORDER BY event_index ASC
+                    LIMIT {_param()}
+                    """,
+                    (
+                        session_id,
+                        max(0, after_index),
+                        datetime.now(timezone.utc).replace(tzinfo=None).isoformat(),
+                        self.MAX_BUFFER_SIZE,
+                    ),
+                )
+                rows = cursor.fetchall()
+        except Exception as e:
+            logger.debug("Failed to read persisted output for session %s: %s", session_id[:8], e)
+            return []
+
+        events: list[dict] = []
+        for row in rows:
+            try:
+                payload = json.loads(row["payload"])
+            except (TypeError, ValueError, json.JSONDecodeError):
+                continue
+            if isinstance(payload, dict):
+                payload.setdefault("event_index", row["event_index"])
+                events.append(payload)
+        return events
 
     def mark_session_ended(self, session_id: str) -> None:
         """Mark a session as ended (completed/stopped/error).
@@ -1297,7 +1511,20 @@ class RemoteAgentManager:
     def is_session_ended(self, session_id: str) -> bool:
         """Check if a session has ended (in-memory, no DB query)."""
         with self._lock:
-            return self._session_end_flags.get(session_id, False)
+            if self._session_end_flags.get(session_id, False):
+                return True
+        try:
+            row = self.db.fetch_one(
+                f"SELECT status FROM agent_sessions WHERE session_id = {_param()}",
+                (session_id,),
+            )
+        except Exception:
+            return False
+        if row and row.get("status") in ("completed", "error", "stopped"):
+            with self._lock:
+                self._session_end_flags[session_id] = True
+            return True
+        return False
 
     # ==================== SSE Last Delivered ====================
 

--- a/app/modules/workspace/terminal_relay_store.py
+++ b/app/modules/workspace/terminal_relay_store.py
@@ -7,9 +7,9 @@ bridges browser WebSocket connections through this relay to the remote terminal.
 This solves the issue where backend cannot directly connect to ws://192.168.x.x:port
 because the remote machine is behind NAT or on a private network.
 
-The relay WebSocket objects are process-local. Multi-pod deployments must keep
-agent/browser traffic for an active terminal on the same web pod until issue
-#1782 provides a shared coordination layer and reconnect protocol.
+The relay WebSocket objects are process-local. HTTP remote-session control
+state is persisted, but an active browser-to-agent terminal bridge must still
+use the web pod that owns the live relay socket or reconnect after failover.
 """
 
 from __future__ import annotations

--- a/app/modules/workspace/terminal_store.py
+++ b/app/modules/workspace/terminal_store.py
@@ -1,8 +1,8 @@
 """In-memory store for terminal session info with TTL-based cleanup.
 
-This store is process-local. Kubernetes and other multi-pod deployments must
-use sticky routing for active terminal sessions until issue #1782 externalizes
-the shareable remote-session runtime state.
+This metadata cache is process-local. Remote-session commands and SSE output
+are durable, but active terminal bridge sockets still require the owning web
+process or a reconnect after failover.
 """
 
 from __future__ import annotations

--- a/docs/cn/DATABASE-SCHEMA.md
+++ b/docs/cn/DATABASE-SCHEMA.md
@@ -539,6 +539,45 @@ AI 生成的使用洞察报告。
 | updated_at | timestamp | 更新时间 |
 | last_heartbeat | timestamp | 最后心跳时间 |
 
+### remote_runtime_commands
+
+远程 Agent 的持久化 HTTP polling 命令队列。
+
+| 列名 | 类型 | 说明 |
+|------|------|------|
+| id | integer PK | |
+| command_id | varchar(64) | UNIQUE；同步命令响应路径使用 request_id |
+| machine_id | text | 目标远程机器 |
+| session_id | text | 可选远程会话 |
+| command_type | text | 命令名称 |
+| payload | text | JSON 命令载荷 |
+| status | varchar(32) | `pending`、`delivered` 或 `responded` |
+| response_payload | text | 同步命令的 JSON 响应载荷 |
+| created_at | timestamp | 创建时间 |
+| delivered_at | timestamp | Agent poll claim 时间 |
+| responded_at | timestamp | 响应到达时间 |
+| expires_at | timestamp | 保留截止时间 |
+
+索引：`idx_remote_runtime_commands_machine_status`、`idx_remote_runtime_commands_expires`
+
+### remote_runtime_outputs
+
+远程会话输出的持久化 SSE 回放缓冲。
+
+| 列名 | 类型 | 说明 |
+|------|------|------|
+| id | integer PK | |
+| session_id | text | 远程会话 ID |
+| event_index | integer | 每个会话内单调递增的输出序号 |
+| stream | text | stdout、stderr、system、permission、request_state |
+| payload | text | JSON 输出载荷 |
+| created_at | timestamp | 创建时间 |
+| expires_at | timestamp | 保留截止时间 |
+
+唯一约束：`(session_id, event_index)`
+
+索引：`idx_remote_runtime_outputs_session_index`、`idx_remote_runtime_outputs_expires`
+
 ### machine_assignments
 
 用户与远程机器的分配关系。

--- a/docs/cn/KUBERNETES.md
+++ b/docs/cn/KUBERNETES.md
@@ -59,7 +59,7 @@ k8s/
 
 **HorizontalPodAutoscaler：** 参考清单至少保留 3 个副本，并可根据 CPU 与内存利用率扩展到 10 个副本。
 
-**粘性路由：** Service 使用 `sessionAffinity: ClientIP`，nginx Ingress 使用 cookie affinity。远程工作区终端 / relay 的活跃会话仍有部分运行态保存在单个 Web 进程内，因此同一个浏览器 / Agent 会话的请求必须持续回到同一个 Pod。
+**粘性路由：** Service 使用 `sessionAffinity: ClientIP`，nginx Ingress 使用 cookie affinity。远程会话 HTTP 控制态已经持久化并可跨 Pod，但实时终端 relay WebSocket bridge 仍属于单个 Web 进程；对活跃终端会话而言，粘性路由仍是最稳妥的默认配置。
 
 **多用户工作区说明：** 默认 Kubernetes 清单以非 root 用户运行 Web 容器。如果启用 `workspace.multi_user_mode` 且需要在容器内动态创建 Linux 用户，请使用专门的 overlay 显式让 Web Pod 以 root 运行，并在集群变更流程中记录该例外。
 
@@ -151,10 +151,10 @@ k8s/
 
 ### 当前支持边界
 
-- 仓库内提供的 Kubernetes 清单是**带粘性路由的多副本参考部署**，不是完全无状态的活跃会话 HA 设计。
-- 普通 HTTP/API 请求可以在 Pod 间负载均衡。活跃的远程工作区终端 relay、输出缓冲、命令队列和 WebSocket 对象仍保存在单个进程内。
-- 如果承载某个活跃终端 / relay 会话的 Pod 重启，数据库中的持久记录仍在，但内存缓冲和实时 relay socket 会中断；用户可能需要重新连接、恢复或重建该活跃终端 / 会话。
-- 移除粘性路由需要完成 [#1782](https://github.com/open-ace/open-ace/issues/1782) 中的运行态外置化。
+- 仓库内提供的 Kubernetes 清单仍是**带粘性路由的多副本参考部署**，因为这对实时终端 relay WebSocket 仍是最稳妥的默认配置。
+- 普通 HTTP/API 请求可以在 Pod 间负载均衡。远程会话命令、命令响应、会话输出回放、session-machine 绑定、远程机器、会话、消息、配额和审计记录均已持久化。
+- 如果承载某个活跃终端 / relay socket 的 Pod 重启，已持久化的远程会话状态仍可用，但该实时终端 bridge 需要重新连接。
+- 浏览器 SSE 重连可以在 Web Pod 重启后回放已持久化的远程会话输出。
 - tenant-aware schema / query 边界覆盖用户、项目、工作区会话与消息、用量聚合、审计日志、远程机器、权限和配额；系统管理员保留有意设计的全局可见性。
 
 ### 使用 cert-manager 配置 TLS

--- a/docs/cn/REMOTE-WORKSPACE.md
+++ b/docs/cn/REMOTE-WORKSPACE.md
@@ -78,12 +78,12 @@ Agent 优先尝试 WebSocket 连接，失败时自动降级为 HTTP 轮询。当
 
 ## 部署拓扑与运行态边界
 
-Remote Workspace 可以运行在仓库提供的 Kubernetes 参考部署后面，但活跃远程会话目前还不是完全无状态：
+Remote Workspace 可以运行在仓库提供的 Kubernetes 参考部署后面。可共享的控制面状态已经持久化，实时 socket bridge 仍保留在进程内：
 
-- Remote agent WebSocket 连接、终端 relay socket、进行中的命令队列和短期输出缓冲保存在承载该活跃会话的 Web 进程内。
-- Kubernetes 部署必须保留粘性路由（仓库清单中已配置 Service `ClientIP` affinity 和 nginx cookie affinity），让同一个活跃会话的浏览器与 Agent 流量持续回到同一个 Pod。
-- 如果该 Pod 重启，远程机器、会话、消息、配额和审计等持久记录仍保存在数据库中，但实时终端 relay socket 和内存输出缓冲会中断。
-- 移除粘性路由、支持活跃会话故障转移，需要完成 [#1782](https://github.com/open-ace/open-ace/issues/1782) 的运行态外置化。
+- HTTP polling 命令队列、命令响应、session-to-machine 绑定、会话输出回放、远程机器、会话、消息、配额和审计记录均已持久化。
+- 发送消息、暂停、恢复、停止、终止请求、切换模型和权限响应等远程会话控制 API 可以由任意 Web Pod 服务；下一次 Agent poll 会 claim 已持久化的命令。
+- SSE 重连可以在浏览器断开或 Web Pod 重启后回放已持久化的会话输出。
+- 实时终端 relay WebSocket 对象仍是进程内对象。活跃的浏览器到 Agent 终端 bridge 应使用粘性路由，或在故障转移后重新连接。
 
 当前租户隔离覆盖用户、项目、工作区会话与消息、每日用量聚合、审计日志、远程机器、会话所有权、机器权限和配额。系统管理员有意保留全局运维可见性，用于支持和故障处理。
 

--- a/docs/en/DATABASE-SCHEMA.md
+++ b/docs/en/DATABASE-SCHEMA.md
@@ -577,6 +577,45 @@ Remote workspace machine registry.
 | updated_at | timestamp | Update time |
 | last_heartbeat | timestamp | Last heartbeat time |
 
+### remote_runtime_commands
+
+Persistent HTTP-polling command queue for remote agents.
+
+| Column | Type | Notes |
+|--------|------|-------|
+| id | integer PK | |
+| command_id | varchar(64) | UNIQUE; request_id for command-response calls |
+| machine_id | text | Target remote machine |
+| session_id | text | Optional remote session |
+| command_type | text | Command name |
+| payload | text | JSON command payload |
+| status | varchar(32) | `pending`, `delivered`, or `responded` |
+| response_payload | text | JSON response payload for synchronous commands |
+| created_at | timestamp | Creation time |
+| delivered_at | timestamp | Agent poll claim time |
+| responded_at | timestamp | Response arrival time |
+| expires_at | timestamp | Retention cutoff |
+
+Indexes: `idx_remote_runtime_commands_machine_status`, `idx_remote_runtime_commands_expires`
+
+### remote_runtime_outputs
+
+Persistent SSE replay buffer for remote session output.
+
+| Column | Type | Notes |
+|--------|------|-------|
+| id | integer PK | |
+| session_id | text | Remote session ID |
+| event_index | integer | Monotonic per-session output index |
+| stream | text | stdout, stderr, system, permission, request_state |
+| payload | text | JSON output payload |
+| created_at | timestamp | Creation time |
+| expires_at | timestamp | Retention cutoff |
+
+Unique: `(session_id, event_index)`
+
+Indexes: `idx_remote_runtime_outputs_session_index`, `idx_remote_runtime_outputs_expires`
+
 ### machine_assignments
 
 User-to-remote-machine assignment relationships.

--- a/docs/en/KUBERNETES.md
+++ b/docs/en/KUBERNETES.md
@@ -59,7 +59,7 @@ Creates the `open-ace` namespace with standard Kubernetes labels.
 
 **HorizontalPodAutoscaler:** The reference manifest keeps at least 3 replicas and can scale to 10 replicas based on CPU and memory utilization.
 
-**Sticky routing:** The Service uses `sessionAffinity: ClientIP`, and the nginx Ingress uses cookie affinity. Active Remote Workspace terminal/relay sessions keep some runtime state inside one web process, so requests for a given browser/agent session must keep returning to the same pod.
+**Sticky routing:** The Service uses `sessionAffinity: ClientIP`, and the nginx Ingress uses cookie affinity. Remote session HTTP control state is persisted and can cross pods, but live terminal relay WebSocket bridges still belong to one web process; sticky routing remains the safest default for active terminal sessions.
 
 **Multi-user workspace note:** The default Kubernetes manifest runs the web container as a non-root user. If you enable `workspace.multi_user_mode` and need dynamic Linux user creation inside the container, deploy a dedicated overlay that intentionally runs the web pod as root and document that exception in your cluster change process.
 
@@ -151,10 +151,10 @@ Before deploying, update:
 
 ### Current support boundary
 
-- The shipped Kubernetes manifest is a **multi-replica reference deployment with sticky routing**, not a fully stateless active-session HA design.
-- Ordinary HTTP/API requests can be balanced across pods. Active Remote Workspace terminal relay, output buffering, command queues, and in-flight WebSocket objects still keep process-local state.
-- If the pod that owns an active terminal/relay session restarts, the persisted database records remain, but in-memory buffers and live relay sockets are interrupted. Users may need to reconnect, resume, or recreate that active terminal/session.
-- Removing sticky routing requires the runtime-state externalization tracked in [#1782](https://github.com/open-ace/open-ace/issues/1782).
+- The shipped Kubernetes manifest is a **multi-replica reference deployment with sticky routing** because that is still the safest default for live terminal relay WebSockets.
+- Ordinary HTTP/API requests can be balanced across pods. Remote session commands, command responses, session output replay, session-machine bindings, machines, sessions, messages, quotas, and audit records are persisted.
+- If the pod that owns an active terminal/relay socket restarts, persisted remote-session state remains available, but that live terminal bridge must reconnect.
+- Browser SSE reconnects can replay persisted remote session output after a web-pod restart.
 - Tenant-aware schema and query boundaries cover users, projects, workspace sessions/messages, usage aggregates, audit logs, remote machines, permissions, and quotas; system administrators retain intentional global visibility.
 
 ### TLS with cert-manager

--- a/docs/en/REMOTE-WORKSPACE.md
+++ b/docs/en/REMOTE-WORKSPACE.md
@@ -78,12 +78,12 @@ The Agent tries WebSocket first and falls back to HTTP polling on failure. For t
 
 ## Deployment Topology and Runtime State
 
-Remote Workspace is safe to run behind the Kubernetes reference deployment, but active remote sessions are not fully stateless yet:
+Remote Workspace is safe to run behind the Kubernetes reference deployment. The shareable control-plane state is persisted, while live socket bridges remain process-local:
 
-- Remote agent WebSocket connections, terminal relay sockets, in-flight command queues, and short-lived output buffers are held in the web process that owns the active session.
-- Kubernetes deployments must keep sticky routing enabled (`ClientIP` Service affinity and nginx cookie affinity in the shipped manifests) so browser and agent traffic for an active session returns to the same pod.
-- If that pod restarts, durable records such as machines, sessions, messages, quotas, and audit entries remain in the database, but live terminal relay sockets and in-memory output buffers are interrupted.
-- Removing sticky routing and supporting active-session failover requires the runtime-state externalization tracked in [#1782](https://github.com/open-ace/open-ace/issues/1782).
+- HTTP-polling command queues, command responses, session-to-machine bindings, session output replay, machines, sessions, messages, quotas, and audit entries are persisted.
+- Remote session control APIs such as send, pause, resume, stop, abort, model update, and permission response can be served by any web pod; the next agent poll claims the persisted command.
+- SSE reconnects can replay persisted session output after a browser disconnect or web-pod restart.
+- Live terminal relay WebSocket objects are still process-local. An active browser-to-agent terminal bridge should use sticky routing or reconnect after failover.
 
 Tenant isolation covers users, projects, workspace sessions and messages, daily usage aggregates, audit logs, remote machines, session ownership, machine permissions, and quotas. System administrators intentionally have global operational visibility for support and incident response.
 

--- a/migrations/versions/20260718_001_add_remote_runtime_state.py
+++ b/migrations/versions/20260718_001_add_remote_runtime_state.py
@@ -1,0 +1,95 @@
+"""Add persistent remote runtime state tables.
+
+Revision ID: 20260718_001_add_remote_runtime_state
+Revises: 20260717_004_scope_usage_and_audit_to_tenant
+Create Date: 2026-07-18
+
+Issue: #1782
+
+Externalize the shareable portions of the remote workspace runtime state so
+HTTP-polling agents and SSE reconnects do not require every control-plane
+request to hit the same web process.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260718_001_add_remote_runtime_state"
+down_revision: str | None = "20260717_004_scope_usage_and_audit_to_tenant"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    """Create persistent remote-runtime command and output queues."""
+    op.create_table(
+        "remote_runtime_commands",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("command_id", sa.String(length=64), nullable=False, unique=True),
+        sa.Column("machine_id", sa.Text(), nullable=False),
+        sa.Column("session_id", sa.Text(), nullable=True),
+        sa.Column("command_type", sa.Text(), nullable=False, server_default=""),
+        sa.Column("payload", sa.Text(), nullable=False),
+        sa.Column("status", sa.String(length=32), nullable=False, server_default="pending"),
+        sa.Column("response_payload", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at", sa.DateTime(), nullable=True, server_default=sa.text("CURRENT_TIMESTAMP")
+        ),
+        sa.Column("delivered_at", sa.DateTime(), nullable=True),
+        sa.Column("responded_at", sa.DateTime(), nullable=True),
+        sa.Column("expires_at", sa.DateTime(), nullable=True),
+    )
+    op.create_index(
+        "idx_remote_runtime_commands_machine_status",
+        "remote_runtime_commands",
+        ["machine_id", "status", "id"],
+        unique=False,
+    )
+    op.create_index(
+        "idx_remote_runtime_commands_expires",
+        "remote_runtime_commands",
+        ["expires_at"],
+        unique=False,
+    )
+
+    op.create_table(
+        "remote_runtime_outputs",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("session_id", sa.Text(), nullable=False),
+        sa.Column("event_index", sa.Integer(), nullable=False),
+        sa.Column("stream", sa.Text(), nullable=False, server_default="stdout"),
+        sa.Column("payload", sa.Text(), nullable=False),
+        sa.Column(
+            "created_at", sa.DateTime(), nullable=True, server_default=sa.text("CURRENT_TIMESTAMP")
+        ),
+        sa.Column("expires_at", sa.DateTime(), nullable=True),
+        sa.UniqueConstraint(
+            "session_id", "event_index", name="uq_remote_runtime_outputs_session_index"
+        ),
+    )
+    op.create_index(
+        "idx_remote_runtime_outputs_session_index",
+        "remote_runtime_outputs",
+        ["session_id", "event_index"],
+        unique=False,
+    )
+    op.create_index(
+        "idx_remote_runtime_outputs_expires",
+        "remote_runtime_outputs",
+        ["expires_at"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Drop persistent remote-runtime state tables."""
+    op.drop_index("idx_remote_runtime_outputs_expires", table_name="remote_runtime_outputs")
+    op.drop_index("idx_remote_runtime_outputs_session_index", table_name="remote_runtime_outputs")
+    op.drop_table("remote_runtime_outputs")
+    op.drop_index("idx_remote_runtime_commands_expires", table_name="remote_runtime_commands")
+    op.drop_index(
+        "idx_remote_runtime_commands_machine_status", table_name="remote_runtime_commands"
+    )
+    op.drop_table("remote_runtime_commands")

--- a/schema/schema-postgres.sql
+++ b/schema/schema-postgres.sql
@@ -1037,6 +1037,49 @@ CREATE SEQUENCE remote_machines_id_seq
     CACHE 1;
 
 ALTER SEQUENCE remote_machines_id_seq OWNED BY remote_machines.id;
+CREATE TABLE remote_runtime_commands (
+    id integer NOT NULL,
+    command_id character varying(64) NOT NULL,
+    machine_id text NOT NULL,
+    session_id text,
+    command_type text DEFAULT ''::text NOT NULL,
+    payload text NOT NULL,
+    status character varying(32) DEFAULT 'pending'::character varying NOT NULL,
+    response_payload text,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
+    delivered_at timestamp without time zone,
+    responded_at timestamp without time zone,
+    expires_at timestamp without time zone
+);
+
+CREATE SEQUENCE remote_runtime_commands_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+ALTER SEQUENCE remote_runtime_commands_id_seq OWNED BY remote_runtime_commands.id;
+CREATE TABLE remote_runtime_outputs (
+    id integer NOT NULL,
+    session_id text NOT NULL,
+    event_index integer NOT NULL,
+    stream text DEFAULT 'stdout'::text NOT NULL,
+    payload text NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
+    expires_at timestamp without time zone
+);
+
+CREATE SEQUENCE remote_runtime_outputs_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+ALTER SEQUENCE remote_runtime_outputs_id_seq OWNED BY remote_runtime_outputs.id;
 CREATE TABLE retention_history (
     id integer NOT NULL,
     "timestamp" timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
@@ -1802,6 +1845,10 @@ ALTER TABLE ONLY registration_tokens ALTER COLUMN id SET DEFAULT nextval('regist
 
 ALTER TABLE ONLY remote_machines ALTER COLUMN id SET DEFAULT nextval('remote_machines_id_seq'::regclass);
 
+ALTER TABLE ONLY remote_runtime_commands ALTER COLUMN id SET DEFAULT nextval('remote_runtime_commands_id_seq'::regclass);
+
+ALTER TABLE ONLY remote_runtime_outputs ALTER COLUMN id SET DEFAULT nextval('remote_runtime_outputs_id_seq'::regclass);
+
 ALTER TABLE ONLY retention_history ALTER COLUMN id SET DEFAULT nextval('retention_history_id_seq'::regclass);
 
 ALTER TABLE ONLY role_permissions ALTER COLUMN id SET DEFAULT nextval('role_permissions_id_seq'::regclass);
@@ -2017,6 +2064,15 @@ ALTER TABLE ONLY remote_machines
 ALTER TABLE ONLY remote_machines
     ADD CONSTRAINT remote_machines_pkey PRIMARY KEY (id);
 
+ALTER TABLE ONLY remote_runtime_commands
+    ADD CONSTRAINT remote_runtime_commands_command_id_key UNIQUE (command_id);
+
+ALTER TABLE ONLY remote_runtime_commands
+    ADD CONSTRAINT remote_runtime_commands_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY remote_runtime_outputs
+    ADD CONSTRAINT remote_runtime_outputs_pkey PRIMARY KEY (id);
+
 ALTER TABLE ONLY retention_history
     ADD CONSTRAINT retention_history_pkey PRIMARY KEY (id);
 
@@ -2139,6 +2195,9 @@ ALTER TABLE ONLY tool_account_mapping_rules
 
 ALTER TABLE ONLY quota_usage
     ADD CONSTRAINT uq_quota_usage_user_date_period_new UNIQUE (user_id, date, period);
+
+ALTER TABLE ONLY remote_runtime_outputs
+    ADD CONSTRAINT uq_remote_runtime_outputs_session_index UNIQUE (session_id, event_index);
 
 ALTER TABLE ONLY smtp_settings
     ADD CONSTRAINT uq_smtp_settings_single PRIMARY KEY (id);
@@ -2614,6 +2673,22 @@ CREATE INDEX idx_remote_machines_machine_id ON remote_machines USING btree (mach
 --
 
 CREATE INDEX idx_remote_machines_status ON remote_machines USING btree (status);
+
+CREATE INDEX idx_remote_runtime_commands_expires ON remote_runtime_commands USING btree (expires_at);
+
+
+--
+--
+
+CREATE INDEX idx_remote_runtime_commands_machine_status ON remote_runtime_commands USING btree (machine_id, status, id);
+
+CREATE INDEX idx_remote_runtime_outputs_expires ON remote_runtime_outputs USING btree (expires_at);
+
+
+--
+--
+
+CREATE INDEX idx_remote_runtime_outputs_session_index ON remote_runtime_outputs USING btree (session_id, event_index);
 
 CREATE INDEX idx_run_events_created_at ON agent_run_events USING btree (created_at);
 

--- a/schema/schema-sqlite.sql
+++ b/schema/schema-sqlite.sql
@@ -688,6 +688,31 @@ CREATE TABLE remote_machines (
  legacy_mode INTEGER DEFAULT 0
 );
 
+CREATE TABLE remote_runtime_commands (
+ id INTEGER PRIMARY KEY AUTOINCREMENT,
+ command_id TEXT NOT NULL,
+ machine_id text NOT NULL,
+ session_id text,
+ command_type text DEFAULT '' NOT NULL,
+ payload text NOT NULL,
+ status TEXT DEFAULT 'pending' NOT NULL,
+ response_payload text,
+ created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+ delivered_at TIMESTAMP,
+ responded_at TIMESTAMP,
+ expires_at TIMESTAMP
+);
+
+CREATE TABLE remote_runtime_outputs (
+ id INTEGER PRIMARY KEY AUTOINCREMENT,
+ session_id text NOT NULL,
+ event_index integer NOT NULL,
+ stream text DEFAULT 'stdout' NOT NULL,
+ payload text NOT NULL,
+ created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+ expires_at TIMESTAMP
+);
+
 CREATE TABLE retention_history (
  id INTEGER PRIMARY KEY AUTOINCREMENT,
  "timestamp" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
@@ -1122,6 +1147,8 @@ CREATE UNIQUE INDEX registration_tokens_token_hash_key ON registration_tokens (t
 
 CREATE UNIQUE INDEX remote_machines_machine_id_key ON remote_machines (machine_id);
 
+CREATE UNIQUE INDEX remote_runtime_commands_command_id_key ON remote_runtime_commands (command_id);
+
 CREATE UNIQUE INDEX role_permissions_role_permission_key ON role_permissions (role, permission);
 
 CREATE UNIQUE INDEX security_settings_setting_key_key ON security_settings (setting_key);
@@ -1163,6 +1190,8 @@ CREATE UNIQUE INDEX uq_hourly_stats_date_hour_tool_host ON hourly_stats (date, h
 CREATE UNIQUE INDEX uq_mapping_rule_user_pattern ON tool_account_mapping_rules (user_id, pattern, match_type);
 
 CREATE UNIQUE INDEX uq_quota_usage_user_date_period_new ON quota_usage (user_id, date, period);
+
+CREATE UNIQUE INDEX uq_remote_runtime_outputs_session_index ON remote_runtime_outputs (session_id, event_index);
 
 CREATE UNIQUE INDEX uq_tenant_usage_tenant_date_new ON tenant_usage (tenant_id, date);
 
@@ -1391,6 +1420,14 @@ CREATE INDEX idx_remote_machines_hostname_tenant ON remote_machines (hostname, t
 CREATE INDEX idx_remote_machines_machine_id ON remote_machines (machine_id);
 
 CREATE INDEX idx_remote_machines_status ON remote_machines (status);
+
+CREATE INDEX idx_remote_runtime_commands_expires ON remote_runtime_commands (expires_at);
+
+CREATE INDEX idx_remote_runtime_commands_machine_status ON remote_runtime_commands (machine_id, status, id);
+
+CREATE INDEX idx_remote_runtime_outputs_expires ON remote_runtime_outputs (expires_at);
+
+CREATE INDEX idx_remote_runtime_outputs_session_index ON remote_runtime_outputs (session_id, event_index);
 
 CREATE INDEX idx_run_events_created_at ON agent_run_events (created_at);
 

--- a/tests/issues/1748/test_deployment_alignment.py
+++ b/tests/issues/1748/test_deployment_alignment.py
@@ -68,7 +68,7 @@ class TestKubernetesManifestAlignment:
         docs = (ROOT / "docs" / "en" / "KUBERNETES.md").read_text(encoding="utf-8")
 
         assert "multi-replica reference deployment with sticky routing" in docs
-        assert "#1782" in docs
+        assert "Remote session commands, command responses, session output replay" in docs
         assert "Tenant-aware schema and query boundaries cover users" in docs
         assert "single-instance reference deployment" not in docs
 

--- a/tests/issues/1782/test_remote_runtime_state.py
+++ b/tests/issues/1782/test_remote_runtime_state.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import threading
+import time
+
+import pytest
+
+from app.modules.workspace import remote_agent_manager as ram_mod
+from app.modules.workspace.remote_agent_manager import RemoteAgentManager
+from app.repositories.database import Database
+from app.repositories.schema_init import load_schema_from_file
+
+
+@pytest.fixture
+def runtime_db(tmp_path, monkeypatch):
+    """RemoteAgentManager instances sharing one SQLite runtime database."""
+    monkeypatch.setattr(ram_mod, "is_postgresql", lambda: False)
+    monkeypatch.setattr(RemoteAgentManager, "_start_heartbeat_monitor", lambda self: None)
+    db_path = tmp_path / "remote_runtime.db"
+    load_schema_from_file(db_url=f"sqlite:///{db_path}", dialect="sqlite")
+    return db_path, Database(db_url=f"sqlite:///{db_path}")
+
+
+def test_http_polling_commands_survive_web_process_restart(runtime_db):
+    db_path, db = runtime_db
+    first_pod = RemoteAgentManager(db_path=str(db_path))
+    second_pod = RemoteAgentManager(db_path=str(db_path))
+
+    assert first_pod.send_command(
+        "machine-1",
+        {"type": "command", "command": "send_message", "session_id": "session-1"},
+    )
+
+    pending = second_pod.get_pending_commands("machine-1")
+    assert [cmd["command"] for cmd in pending] == ["send_message"]
+    assert second_pod.get_pending_commands("machine-1") == []
+    row = db.fetch_one("SELECT status FROM remote_runtime_commands")
+    assert row["status"] == "delivered"
+
+
+def test_session_output_replays_from_persistent_buffer_after_restart(runtime_db):
+    db_path, _ = runtime_db
+    first_pod = RemoteAgentManager(db_path=str(db_path))
+    second_pod = RemoteAgentManager(db_path=str(db_path))
+
+    first_pod.buffer_output("session-1", {"stream": "stdout", "data": "one"})
+    first_pod.buffer_output("session-1", {"stream": "stderr", "data": "two"})
+
+    assert [entry["data"] for entry in second_pod.get_buffered_output("session-1")] == [
+        "one",
+        "two",
+    ]
+    assert [
+        entry["data"] for entry in second_pod.get_buffered_output("session-1", after_index=1)
+    ] == ["two"]
+
+
+def test_command_response_can_arrive_on_another_web_process(runtime_db):
+    db_path, _ = runtime_db
+    request_pod = RemoteAgentManager(db_path=str(db_path))
+    response_pod = RemoteAgentManager(db_path=str(db_path))
+    result_holder: dict[str, dict | None] = {}
+
+    def wait_for_response() -> None:
+        result_holder["result"] = request_pod.send_command_with_response(
+            "machine-1",
+            "get_session_info",
+            "session-1",
+            timeout=2.0,
+        )
+
+    waiter = threading.Thread(target=wait_for_response)
+    waiter.start()
+
+    deadline = time.time() + 1.0
+    request_id = None
+    db = Database(db_url=f"sqlite:///{db_path}")
+    while time.time() < deadline:
+        row = db.fetch_one("SELECT command_id FROM remote_runtime_commands")
+        if row:
+            request_id = row["command_id"]
+            break
+        time.sleep(0.05)
+
+    assert request_id
+    response_pod.handle_command_response(
+        {"request_id": request_id, "result": {"ok": True, "cwd": "/workspace"}}
+    )
+    waiter.join(timeout=3.0)
+
+    assert result_holder["result"] == {"ok": True, "cwd": "/workspace"}


### PR DESCRIPTION
## Summary
- Persist remote HTTP polling commands, command responses, and SSE output replay state for cross-pod remote-session control
- Add remote runtime state migration/schema entries and document the remaining process-local WebSocket boundary
- Cover pod-restart/cross-process command delivery, output replay, and response recovery with issue tests

## Tests
- pytest tests/issues/1782/test_remote_runtime_state.py tests/issues/1748/test_deployment_alignment.py tests/issues/1781/test_tenant_boundaries.py -q
- pytest tests/issues/604/test_remote_session_ha.py tests/issues/604/test_session_models_route.py tests/unit/test_remote_projects_api.py tests/unit/test_session_access.py tests/unit/test_remote_session_manager_timeline.py tests/unit/test_remote_assistant_message.py -q
- SKIP=bandit,no-commit-to-branch /Users/rhuang/Library/Python/3.9/bin/pre-commit run --all-files

Closes #1782