### PR TITLE
feat: automate extended test gates

### DIFF
--- a/.github/workflows/extended-tests.yml
+++ b/.github/workflows/extended-tests.yml
@@ -1,0 +1,292 @@
+name: Extended Tests
+
+on:
+  pull_request:
+    branches: [main, master]
+    types: [opened, synchronize, reopened, labeled]
+  schedule:
+    - cron: '0 2 * * 0'
+  workflow_dispatch:
+    inputs:
+      category:
+        description: 'Test category to run'
+        required: true
+        default: 'critical'
+        type: choice
+        options:
+          - critical
+          - regression
+          - e2e
+          - issues
+          - all
+          - specific
+      issue_numbers:
+        description: 'Comma-separated issue numbers for category=issues'
+        required: false
+        default: ''
+      target:
+        description: 'Specific pytest target for category=specific'
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+
+concurrency:
+  group: extended-tests-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  critical-pr:
+    name: Critical PR E2E
+    if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'skip-extended-tests')
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Build frontend
+        working-directory: frontend
+        run: |
+          npm ci
+          npm run build
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install playwright
+          playwright install chromium --with-deps
+
+      - name: Run critical extended tests
+        run: |
+          python scripts/run_extended_tests.py \
+            --category critical \
+            --isolated-home \
+            --reruns 1 \
+            --timeout 180 \
+            --maxfail 5 \
+            --junitxml test-results/critical-pr.xml
+        env:
+          CI: true
+          HEADLESS: true
+
+      - name: Upload critical test report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: critical-pr-extended-tests
+          path: |
+            test-results/
+            screenshots/
+          if-no-files-found: ignore
+          retention-days: 14
+
+  full-e2e:
+    name: Full E2E
+    if: |
+      github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' && (inputs.category == 'e2e' || inputs.category == 'all')) ||
+      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-full-e2e'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Build frontend
+        working-directory: frontend
+        run: |
+          npm ci
+          npm run build
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install playwright
+          playwright install chromium --with-deps
+
+      - name: Run full E2E tests
+        run: |
+          python scripts/run_extended_tests.py \
+            --category e2e \
+            --isolated-home \
+            --reruns 1 \
+            --timeout 240 \
+            --junitxml test-results/full-e2e.xml
+        env:
+          CI: true
+          HEADLESS: true
+
+      - name: Upload full E2E report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: full-e2e
+          path: |
+            test-results/
+            screenshots/
+          if-no-files-found: ignore
+          retention-days: 14
+
+  issue-tests:
+    name: Issue Tests (${{ matrix.group }}/4)
+    if: |
+      github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' && (inputs.category == 'issues' || inputs.category == 'all')) ||
+      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-issue-tests'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    strategy:
+      fail-fast: false
+      matrix:
+        group: [1, 2, 3, 4]
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Build frontend
+        working-directory: frontend
+        run: |
+          npm ci
+          npm run build
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install playwright
+          playwright install chromium --with-deps
+
+      - name: Run issue regression shard
+        run: |
+          python scripts/run_extended_tests.py \
+            --category issues \
+            --issue-numbers "${{ github.event.inputs.issue_numbers || '' }}" \
+            --split-total 4 \
+            --split-group "${{ matrix.group }}" \
+            --isolated-home \
+            --reruns 1 \
+            --timeout 240 \
+            --junitxml "test-results/issues-${{ matrix.group }}.xml"
+        env:
+          CI: true
+          HEADLESS: true
+
+      - name: Upload issue test report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: issue-tests-${{ matrix.group }}
+          path: |
+            test-results/
+            screenshots/
+          if-no-files-found: ignore
+          retention-days: 14
+
+  manual-extended:
+    name: Manual Extended Tests
+    if: github.event_name == 'workflow_dispatch' && inputs.category != 'issues' && inputs.category != 'all'
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Build frontend
+        working-directory: frontend
+        run: |
+          npm ci
+          npm run build
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install playwright
+          playwright install chromium --with-deps
+
+      - name: Run selected extended tests
+        run: |
+          if [ -n "$TARGET" ]; then
+            python scripts/run_extended_tests.py \
+              --category "$CATEGORY" \
+              --target "$TARGET" \
+              --isolated-home \
+              --reruns 1 \
+              --timeout 240 \
+              --junitxml test-results/manual-extended.xml
+          else
+            python scripts/run_extended_tests.py \
+              --category "$CATEGORY" \
+              --isolated-home \
+              --reruns 1 \
+              --timeout 240 \
+              --junitxml test-results/manual-extended.xml
+          fi
+        env:
+          CATEGORY: ${{ github.event.inputs.category }}
+          TARGET: ${{ github.event.inputs.target }}
+          CI: true
+          HEADLESS: true
+
+      - name: Upload manual test report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: manual-extended-tests
+          path: |
+            test-results/
+            screenshots/
+          if-no-files-found: ignore
+          retention-days: 14

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,13 +3,72 @@ name: Release
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 permissions:
   contents: write
 
 jobs:
+  pre-release-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v6
+      with:
+        node-version: '20'
+        cache: 'npm'
+        cache-dependency-path: frontend/package-lock.json
+
+    - name: Build frontend
+      working-directory: frontend
+      run: |
+        npm ci
+        npm run build
+
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: '3.11'
+        cache: pip
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install playwright
+        playwright install chromium --with-deps
+
+    - name: Run critical release regression tests
+      run: |
+        python scripts/run_extended_tests.py \
+          --category critical \
+          --isolated-home \
+          --reruns 1 \
+          --timeout 180 \
+          --maxfail 5 \
+          --junitxml test-results/release-critical.xml
+      env:
+        CI: true
+        HEADLESS: true
+
+    - name: Upload release test report
+      if: always()
+      uses: actions/upload-artifact@v7
+      with:
+        name: release-critical-extended-tests
+        path: |
+          test-results/
+          screenshots/
+        if-no-files-found: ignore
+        retention-days: 30
+
   build-and-publish:
     runs-on: ubuntu-latest
+    needs: [pre-release-tests]
     env:
       PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
 

--- a/docs/REPOSITORY_SETUP.md
+++ b/docs/REPOSITORY_SETUP.md
@@ -59,6 +59,8 @@ gh release create v1.2.0 --title "Open ACE v1.2.0" --notes-file release_notes.md
 ### Release Checklist
 
 - Publish releases from Git tags such as `v1.1.0`.
+- The Release workflow runs `scripts/run_extended_tests.py --category critical`
+  before building and publishing release artifacts.
 - Use `scripts/generate_changelog.py` to collect commits since last release:
   ```bash
   python3 scripts/generate_changelog.py --since v1.1.0

--- a/docs/cn/DEVELOPMENT.md
+++ b/docs/cn/DEVELOPMENT.md
@@ -121,6 +121,14 @@ npm run test
 
 # 使用 Playwright 运行 E2E 测试
 npx playwright test
+
+# CI PR / 发布门禁使用的服务依赖扩展测试
+cd frontend && npm ci && npm run build && cd ..
+python scripts/run_extended_tests.py --category critical --isolated-home
+
+# 完整 E2E 或 issue 回归分片
+python scripts/run_extended_tests.py --category e2e --isolated-home
+python scripts/run_extended_tests.py --category issues --split-total 4 --split-group 1 --isolated-home
 ```
 
 完整前端参考请参阅 [FRONTEND-GUIDE.md](FRONTEND-GUIDE.md)。

--- a/docs/en/DEVELOPMENT.md
+++ b/docs/en/DEVELOPMENT.md
@@ -121,6 +121,14 @@ npm run test
 
 # E2E tests with Playwright
 npx playwright test
+
+# Server-dependent extended tests used by CI PR/release gates
+cd frontend && npm ci && npm run build && cd ..
+python scripts/run_extended_tests.py --category critical --isolated-home
+
+# Full E2E or issue regression shards
+python scripts/run_extended_tests.py --category e2e --isolated-home
+python scripts/run_extended_tests.py --category issues --split-total 4 --split-group 1 --isolated-home
 ```
 
 See [FRONTEND-GUIDE.md](FRONTEND-GUIDE.md) for the complete frontend reference.

--- a/pytest.ini
+++ b/pytest.ini
@@ -12,6 +12,9 @@ markers =
     unit: Unit tests (fast, no external dependencies)
     ui: UI tests using Playwright
     regression: Regression tests for core functionality
+    priority_p0: Critical functionality that must run on every PR and before releases
+    priority_p1: Important functionality covered by scheduled extended tests
+    priority_p2: Broad or expensive coverage covered by periodic/manual runs
     issue: Issue-specific tests (use --issue=N to run specific issue)
     postgres: Requires a live PostgreSQL server (auto-skipped via pg_db fixture when unreachable)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,6 +29,10 @@ psycogreen>=1.0.0,<2.0.0
 pytest>=7.0.0
 pytest-cov>=4.0.0
 pytest-asyncio>=0.21.0
+pytest-rerunfailures>=10.0
+pytest-split>=0.8.0
+pytest-timeout>=2.0
+pytest-xdist>=3.0
 
 # Report generation
 openpyxl>=3.1.0,<4.0.0

--- a/scripts/run_extended_tests.py
+++ b/scripts/run_extended_tests.py
@@ -41,7 +41,8 @@ SERVER_CATEGORIES = {
 CATEGORY_TARGETS = {
     "critical": [
         "tests/e2e/regression/test_login.py",
-        "tests/e2e/regression/test_navigation.py",
+        "tests/e2e/regression/test_navigation.py::test_sidebar_menu_visible",
+        "tests/e2e/regression/test_navigation.py::test_menu_navigation",
     ],
     "regression": ["tests/e2e/regression"],
     "ui": ["tests/e2e/ui"],
@@ -129,8 +130,12 @@ def parse_issue_numbers(args: argparse.Namespace) -> list[str]:
     return clean
 
 
+def target_path(target: str) -> str:
+    return target.split("::", 1)[0]
+
+
 def target_exists(target: str) -> bool:
-    return (PROJECT_ROOT / target).exists()
+    return (PROJECT_ROOT / target_path(target)).exists()
 
 
 def select_targets(args: argparse.Namespace) -> list[str]:
@@ -158,7 +163,7 @@ def select_targets(args: argparse.Namespace) -> list[str]:
 def discover_test_files(targets: list[str]) -> list[str]:
     files: list[Path] = []
     for target in targets:
-        path = PROJECT_ROOT / target
+        path = PROJECT_ROOT / target_path(target)
         if path.is_file():
             files.append(path)
             continue

--- a/scripts/run_extended_tests.py
+++ b/scripts/run_extended_tests.py
@@ -1,0 +1,393 @@
+#!/usr/bin/env python3
+"""
+Run the server-dependent Open ACE test suites from CI or a local checkout.
+
+The default CI suite intentionally excludes tests/e2e and tests/issues because
+they need a live web server and can be slow. This runner is the shared entry
+point for scheduled, release, PR critical, and manual extended-test runs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import signal
+import socket
+import sqlite3
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_BASE_URL = "http://localhost:19888"
+SERVER_CATEGORIES = {
+    "all",
+    "critical",
+    "e2e",
+    "issues",
+    "regression",
+    "ui",
+    "remote",
+    "terminal",
+    "manage",
+    "work",
+    "performance",
+    "specific",
+}
+CATEGORY_TARGETS = {
+    "critical": [
+        "tests/e2e/regression/test_login.py",
+        "tests/e2e/regression/test_navigation.py",
+    ],
+    "regression": ["tests/e2e/regression"],
+    "ui": ["tests/e2e/ui"],
+    "remote": ["tests/e2e/remote"],
+    "terminal": ["tests/e2e/terminal"],
+    "manage": ["tests/e2e/manage"],
+    "work": ["tests/e2e/work"],
+    "performance": ["tests/e2e/performance"],
+    "e2e": ["tests/e2e"],
+    "issues": ["tests/issues"],
+    "all": ["tests/e2e", "tests/issues"],
+}
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--category",
+        choices=sorted(CATEGORY_TARGETS.keys() | {"specific"}),
+        default="critical",
+        help="Extended test group to run.",
+    )
+    parser.add_argument(
+        "--target",
+        action="append",
+        default=[],
+        help="Specific pytest target. Required for --category specific.",
+    )
+    parser.add_argument(
+        "--issue",
+        dest="issues",
+        action="append",
+        default=[],
+        help="Issue number under tests/issues to run. Can be repeated.",
+    )
+    parser.add_argument(
+        "--issue-numbers",
+        default="",
+        help="Comma-separated issue numbers under tests/issues.",
+    )
+    parser.add_argument("--split-total", type=int, default=1, help="Total number of shards.")
+    parser.add_argument("--split-group", type=int, default=1, help="1-based shard index to run.")
+    parser.add_argument("--parallel", type=int, default=0, help="pytest-xdist worker count.")
+    parser.add_argument("--reruns", type=int, default=0, help="Retry failed tests this many times.")
+    parser.add_argument("--timeout", type=int, default=0, help="Per-test timeout in seconds.")
+    parser.add_argument("--maxfail", type=int, default=0, help="Stop after this many failures.")
+    parser.add_argument("--junitxml", default="", help="Write a pytest JUnit XML report.")
+    parser.add_argument("--extra-pytest-arg", action="append", default=[], help="Extra pytest arg.")
+    parser.add_argument(
+        "--server",
+        choices=["auto", "reuse", "skip"],
+        default="auto",
+        help="auto starts Open ACE when the health endpoint is unavailable.",
+    )
+    parser.add_argument("--base-url", default=os.environ.get("BASE_URL", DEFAULT_BASE_URL))
+    parser.add_argument(
+        "--isolated-home",
+        action="store_true",
+        help="Use a temporary HOME so test data never touches the developer database.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the pytest command without running it.",
+    )
+    return parser.parse_args(argv)
+
+
+def category_needs_server(category: str) -> bool:
+    return category in SERVER_CATEGORIES
+
+
+def parse_issue_numbers(args: argparse.Namespace) -> list[str]:
+    numbers: list[str] = []
+    numbers.extend(args.issues)
+    if args.issue_numbers:
+        numbers.extend(part.strip() for part in args.issue_numbers.split(","))
+    clean = []
+    for number in numbers:
+        if not number:
+            continue
+        if not number.isdigit():
+            raise ValueError(f"Invalid issue number: {number!r}")
+        clean.append(number)
+    return clean
+
+
+def target_exists(target: str) -> bool:
+    return (PROJECT_ROOT / target).exists()
+
+
+def select_targets(args: argparse.Namespace) -> list[str]:
+    if args.category == "specific":
+        if not args.target:
+            raise ValueError("--category specific requires at least one --target")
+        targets = args.target
+    elif args.category == "issues":
+        issue_numbers = parse_issue_numbers(args)
+        targets = [f"tests/issues/{number}" for number in issue_numbers] or CATEGORY_TARGETS[
+            "issues"
+        ]
+    else:
+        targets = CATEGORY_TARGETS[args.category]
+
+    existing = [target for target in targets if target_exists(target)]
+    missing = sorted(set(targets) - set(existing))
+    if missing:
+        print(f"Skipping missing targets: {', '.join(missing)}")
+    if not existing:
+        raise FileNotFoundError(f"No selected test targets exist: {targets}")
+    return existing
+
+
+def discover_test_files(targets: list[str]) -> list[str]:
+    files: list[Path] = []
+    for target in targets:
+        path = PROJECT_ROOT / target
+        if path.is_file():
+            files.append(path)
+            continue
+        files.extend(path.rglob("test_*.py"))
+        files.extend(path.rglob("e2e_*.py"))
+    unique = sorted({file.relative_to(PROJECT_ROOT).as_posix() for file in files})
+    return unique
+
+
+def apply_split(targets: list[str], split_total: int, split_group: int) -> list[str]:
+    if split_total < 1:
+        raise ValueError("--split-total must be >= 1")
+    if split_group < 1 or split_group > split_total:
+        raise ValueError("--split-group must be between 1 and --split-total")
+    if split_total == 1:
+        return targets
+
+    files = discover_test_files(targets)
+    selected = [
+        file for index, file in enumerate(files) if (index % split_total) == (split_group - 1)
+    ]
+    if not selected:
+        raise ValueError(f"Shard {split_group}/{split_total} selected no test files")
+    print(f"Selected {len(selected)} files for shard {split_group}/{split_total}")
+    return selected
+
+
+def build_pytest_command(args: argparse.Namespace) -> list[str]:
+    targets = select_targets(args)
+    targets = apply_split(targets, args.split_total, args.split_group)
+    cmd = [sys.executable, "-m", "pytest", *targets, "-m", "not postgres"]
+    if args.parallel > 0:
+        cmd.extend(["-n", str(args.parallel)])
+    if args.reruns > 0:
+        cmd.extend(["--reruns", str(args.reruns), "--reruns-delay", "5"])
+    if args.timeout > 0:
+        cmd.extend(["--timeout", str(args.timeout)])
+    if args.maxfail > 0:
+        cmd.append(f"--maxfail={args.maxfail}")
+    if args.junitxml:
+        cmd.append(f"--junitxml={args.junitxml}")
+    cmd.extend(args.extra_pytest_arg)
+    return cmd
+
+
+def frontend_dist_index() -> Path:
+    return PROJECT_ROOT / "static" / "js" / "dist" / "index.html"
+
+
+def ensure_frontend_built(category: str) -> None:
+    if not category_needs_server(category):
+        return
+    if frontend_dist_index().exists():
+        return
+    raise RuntimeError(
+        "Frontend build is missing. Run 'cd frontend && npm ci && npm run build' "
+        "before server-dependent extended tests."
+    )
+
+
+def can_connect(host: str, port: int, timeout: float = 1.0) -> bool:
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
+def health_url(base_url: str) -> str:
+    return base_url.rstrip("/") + "/health"
+
+
+def is_healthy(base_url: str) -> bool:
+    try:
+        with urllib.request.urlopen(health_url(base_url), timeout=2) as response:
+            return 200 <= response.status < 300
+    except (OSError, urllib.error.URLError):
+        return False
+
+
+def wait_for_health(base_url: str, timeout: int = 120) -> None:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if is_healthy(base_url):
+            return
+        time.sleep(2)
+    raise TimeoutError(f"Open ACE did not become healthy at {health_url(base_url)}")
+
+
+def default_playwright_browsers_path(home: Path) -> Path:
+    if sys.platform == "darwin":
+        return home / "Library" / "Caches" / "ms-playwright"
+    return home / ".cache" / "ms-playwright"
+
+
+def preserve_playwright_browser_cache(env: dict[str, str]) -> None:
+    if env.get("PLAYWRIGHT_BROWSERS_PATH"):
+        return
+    home = Path(env.get("HOME", str(Path.home()))).expanduser()
+    browsers_path = default_playwright_browsers_path(home)
+    if browsers_path.exists():
+        env["PLAYWRIGHT_BROWSERS_PATH"] = str(browsers_path)
+
+
+def prepare_test_home(
+    env: dict[str, str], isolated_home: bool
+) -> tempfile.TemporaryDirectory | None:
+    if not isolated_home:
+        return None
+    preserve_playwright_browser_cache(env)
+    tmp_home = tempfile.TemporaryDirectory(prefix="open-ace-extended-tests-")
+    env["HOME"] = tmp_home.name
+    return tmp_home
+
+
+def sqlite_has_table(db_path: Path, table_name: str) -> bool:
+    if not db_path.exists():
+        return False
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+            (table_name,),
+        ).fetchone()
+    return row is not None
+
+
+def ensure_sqlite_schema(env: dict[str, str]) -> None:
+    config_dir = Path(env["HOME"]) / ".open-ace"
+    db_path = config_dir / "ace.db"
+    if sqlite_has_table(db_path, "tenants"):
+        return
+
+    schema_path = PROJECT_ROOT / "schema" / "schema-sqlite.sql"
+    if not schema_path.exists():
+        raise FileNotFoundError(f"SQLite schema not found: {schema_path}")
+
+    config_dir.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(schema_path.read_text())
+
+
+def initialize_database(env: dict[str, str]) -> None:
+    config_dir = Path(env["HOME"]) / ".open-ace"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    ensure_sqlite_schema(env)
+    subprocess.run([sys.executable, "scripts/init_db.py"], cwd=PROJECT_ROOT, env=env, check=True)
+
+
+def start_server_if_needed(
+    args: argparse.Namespace, env: dict[str, str]
+) -> subprocess.Popen | None:
+    if not category_needs_server(args.category) or args.server == "skip":
+        return None
+    ensure_frontend_built(args.category)
+    if is_healthy(args.base_url):
+        print(f"Reusing healthy Open ACE server at {args.base_url}")
+        return None
+    if args.server == "reuse":
+        raise RuntimeError(f"No healthy Open ACE server found at {args.base_url}")
+
+    initialize_database(env)
+    host_port = args.base_url.replace("http://", "").replace("https://", "").split("/", 1)[0]
+    host, port_text = host_port.rsplit(":", 1)
+    if can_connect(host, int(port_text)):
+        raise RuntimeError(
+            f"Port {port_text} is in use, but {health_url(args.base_url)} is not healthy"
+        )
+
+    env.setdefault("FLASK_ENV", "testing")
+    env.setdefault("SCHEDULER_HEALTH_MONITOR_ENABLED", "false")
+    env.setdefault("DATA_FETCH_ENABLED", "false")
+    env.setdefault("HEADLESS", "true")
+    env["BASE_URL"] = args.base_url
+
+    print(f"Starting Open ACE test server for {args.base_url}")
+    proc = subprocess.Popen(
+        [sys.executable, "server.py"],
+        cwd=PROJECT_ROOT,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    try:
+        wait_for_health(args.base_url)
+    except Exception:
+        if proc.poll() is None:
+            proc.terminate()
+        output = ""
+        if proc.stdout:
+            try:
+                output = proc.stdout.read()
+            except OSError:
+                output = ""
+        raise RuntimeError(f"Failed to start Open ACE test server.\n{output}") from None
+    return proc
+
+
+def stop_server(proc: subprocess.Popen | None) -> None:
+    if proc is None or proc.poll() is not None:
+        return
+    proc.send_signal(signal.SIGTERM)
+    try:
+        proc.wait(timeout=15)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait(timeout=5)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    env = os.environ.copy()
+    env.setdefault("BASE_URL", args.base_url)
+    test_home = prepare_test_home(env, args.isolated_home)
+    server_proc: subprocess.Popen | None = None
+
+    try:
+        cmd = build_pytest_command(args)
+        print("Pytest command:")
+        print(" ".join(cmd))
+        if args.dry_run:
+            return 0
+        server_proc = start_server_if_needed(args, env)
+        return subprocess.run(cmd, cwd=PROJECT_ROOT, env=env, check=False).returncode
+    finally:
+        stop_server(server_proc)
+        if test_home is not None:
+            test_home.cleanup()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/README.md
+++ b/tests/README.md
@@ -106,6 +106,26 @@ python tests/e2e/regression/run_regression.py
 pytest tests/integration/ -m postgres
 ```
 
+### 扩展测试自动化
+```bash
+# 每个 PR 和发布前运行的关键 E2E 门禁
+cd frontend && npm ci && npm run build && cd ..
+python scripts/run_extended_tests.py --category critical --isolated-home
+
+# 手动运行完整 E2E
+python scripts/run_extended_tests.py --category e2e --isolated-home
+
+# 手动运行指定 issue 回归测试
+python scripts/run_extended_tests.py --category issues --issue 716 --issue 740 --isolated-home
+
+# 分片运行 issue 测试
+python scripts/run_extended_tests.py --category issues --split-total 4 --split-group 1 --isolated-home
+```
+
+GitHub Actions 的 `Extended Tests` workflow 会在每个 PR 自动运行
+`critical`，每周运行 issue 分片；给 PR 添加 `run-full-e2e` 或
+`run-issue-tests` 标签可触发更重的测试范围。
+
 ### 运行特定 issue 的测试
 ```bash
 # 运行 issue 50 的测试

--- a/tests/e2e/regression/test_helpers.py
+++ b/tests/e2e/regression/test_helpers.py
@@ -14,6 +14,7 @@ BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
 USERNAME = os.environ.get("TEST_USERNAME", "admin")
 PASSWORD = os.environ.get("TEST_PASSWORD", "admin123")
 HEADLESS = os.environ.get("HEADLESS", "true").lower() == "true"
+PAGE_LOAD_TIMEOUT_MS = int(os.environ.get("E2E_PAGE_LOAD_TIMEOUT_MS", "60000"))
 SCREENSHOT_DIR = os.path.join(
     os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))),
     "screenshots",
@@ -49,7 +50,7 @@ def login(page: Page):
     避免使用 networkidle，改用 domcontentloaded 和显式等待
     """
     # 导航到登录页面，等待 DOM 加载完成
-    page.goto(f"{BASE_URL}/login", wait_until="domcontentloaded")
+    page.goto(f"{BASE_URL}/login", wait_until="domcontentloaded", timeout=PAGE_LOAD_TIMEOUT_MS)
 
     # 等待登录表单元素可见
     page.wait_for_selector("#username", state="visible", timeout=10000)
@@ -80,7 +81,7 @@ def navigate_to(page: Page, path: str):
 
     避免使用 networkidle，改用 domcontentloaded 和元素等待
     """
-    page.goto(f"{BASE_URL}{path}", wait_until="domcontentloaded")
+    page.goto(f"{BASE_URL}{path}", wait_until="domcontentloaded", timeout=PAGE_LOAD_TIMEOUT_MS)
 
     # 等待骨架屏消失（如果存在）
     try:

--- a/tests/e2e/regression/test_login.py
+++ b/tests/e2e/regression/test_login.py
@@ -12,6 +12,8 @@
 import os
 import sys
 
+import pytest
+
 sys.path.insert(
     0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 )
@@ -20,6 +22,7 @@ from playwright.sync_api import sync_playwright
 
 from tests.e2e.regression.test_helpers import (
     BASE_URL,
+    PAGE_LOAD_TIMEOUT_MS,
     TestRunner,
     check_element_exists,
     create_browser_context,
@@ -27,6 +30,7 @@ from tests.e2e.regression.test_helpers import (
 )
 
 MODULE_NAME = "login"
+pytestmark = [pytest.mark.regression, pytest.mark.priority_p0]
 
 
 BASE_URL = os.environ.get("BASE_URL", "http://localhost:19888")
@@ -39,7 +43,11 @@ def test_login_page_loads():
         page = context.new_page()
 
         try:
-            page.goto(f"{BASE_URL}/login", wait_until="domcontentloaded")
+            page.goto(
+                f"{BASE_URL}/login",
+                wait_until="domcontentloaded",
+                timeout=PAGE_LOAD_TIMEOUT_MS,
+            )
             page.wait_for_selector("#username", state="visible", timeout=10000)
 
             # 验证登录页面元素
@@ -60,7 +68,11 @@ def test_login_success():
         page = context.new_page()
 
         try:
-            page.goto(f"{BASE_URL}/login", wait_until="domcontentloaded")
+            page.goto(
+                f"{BASE_URL}/login",
+                wait_until="domcontentloaded",
+                timeout=PAGE_LOAD_TIMEOUT_MS,
+            )
             page.wait_for_selector("#username", state="visible", timeout=10000)
 
             # 输入凭据
@@ -93,7 +105,11 @@ def test_login_failure():
         page = context.new_page()
 
         try:
-            page.goto(f"{BASE_URL}/login", wait_until="domcontentloaded")
+            page.goto(
+                f"{BASE_URL}/login",
+                wait_until="domcontentloaded",
+                timeout=PAGE_LOAD_TIMEOUT_MS,
+            )
             page.wait_for_selector("#username", state="visible", timeout=10000)
 
             # 输入错误凭据
@@ -121,7 +137,11 @@ def test_logout():
 
         try:
             # 先登录
-            page.goto(f"{BASE_URL}/login", wait_until="domcontentloaded")
+            page.goto(
+                f"{BASE_URL}/login",
+                wait_until="domcontentloaded",
+                timeout=PAGE_LOAD_TIMEOUT_MS,
+            )
             page.wait_for_selector("#username", state="visible", timeout=10000)
             page.fill("#username", "admin")
             page.fill("#password", "admin123")

--- a/tests/e2e/regression/test_navigation.py
+++ b/tests/e2e/regression/test_navigation.py
@@ -29,9 +29,10 @@ from tests.e2e.regression.test_helpers import (
 )
 
 MODULE_NAME = "navigation"
-pytestmark = [pytest.mark.regression, pytest.mark.priority_p0]
+pytestmark = pytest.mark.regression
 
 
+@pytest.mark.priority_p0
 def test_sidebar_menu_visible():
     """测试侧边栏菜单显示"""
     with sync_playwright() as p:
@@ -70,6 +71,7 @@ def test_sidebar_menu_visible():
             browser.close()
 
 
+@pytest.mark.priority_p0
 def test_menu_navigation():
     """测试菜单项点击导航"""
     with sync_playwright() as p:

--- a/tests/e2e/regression/test_navigation.py
+++ b/tests/e2e/regression/test_navigation.py
@@ -11,6 +11,8 @@
 import os
 import sys
 
+import pytest
+
 sys.path.insert(
     0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 )
@@ -27,6 +29,7 @@ from tests.e2e.regression.test_helpers import (
 )
 
 MODULE_NAME = "navigation"
+pytestmark = [pytest.mark.regression, pytest.mark.priority_p0]
 
 
 def test_sidebar_menu_visible():

--- a/tests/issues/1469/test_extended_tests_runner.py
+++ b/tests/issues/1469/test_extended_tests_runner.py
@@ -9,7 +9,9 @@ def test_critical_category_selects_pr_gate_targets():
     cmd = run_extended_tests.build_pytest_command(args)
 
     assert "tests/e2e/regression/test_login.py" in cmd
-    assert "tests/e2e/regression/test_navigation.py" in cmd
+    assert "tests/e2e/regression/test_navigation.py::test_sidebar_menu_visible" in cmd
+    assert "tests/e2e/regression/test_navigation.py::test_menu_navigation" in cmd
+    assert "tests/e2e/regression/test_navigation.py::test_page_title_updates" not in cmd
     assert "-m" in cmd
     assert "not postgres" in cmd
 

--- a/tests/issues/1469/test_extended_tests_runner.py
+++ b/tests/issues/1469/test_extended_tests_runner.py
@@ -1,0 +1,77 @@
+import pytest
+
+from scripts import run_extended_tests
+
+
+def test_critical_category_selects_pr_gate_targets():
+    args = run_extended_tests.parse_args(["--category", "critical", "--dry-run"])
+
+    cmd = run_extended_tests.build_pytest_command(args)
+
+    assert "tests/e2e/regression/test_login.py" in cmd
+    assert "tests/e2e/regression/test_navigation.py" in cmd
+    assert "-m" in cmd
+    assert "not postgres" in cmd
+
+
+def test_issue_numbers_select_specific_issue_directories():
+    args = run_extended_tests.parse_args(
+        ["--category", "issues", "--issue", "716", "--issue-numbers", "740,762", "--dry-run"]
+    )
+
+    assert run_extended_tests.select_targets(args) == [
+        "tests/issues/716",
+        "tests/issues/740",
+        "tests/issues/762",
+    ]
+
+
+def test_specific_category_requires_target():
+    args = run_extended_tests.parse_args(["--category", "specific"])
+
+    with pytest.raises(ValueError, match="requires at least one --target"):
+        run_extended_tests.select_targets(args)
+
+
+def test_split_uses_deterministic_file_shards():
+    files = run_extended_tests.apply_split(["tests/e2e/regression"], split_total=2, split_group=1)
+
+    assert files
+    assert files == sorted(files)
+    assert all(file.startswith("tests/e2e/regression/") for file in files)
+
+
+def test_invalid_issue_number_is_rejected():
+    args = run_extended_tests.parse_args(["--category", "issues", "--issue", "../716"])
+
+    with pytest.raises(ValueError, match="Invalid issue number"):
+        run_extended_tests.select_targets(args)
+
+
+def test_ensure_sqlite_schema_creates_isolated_test_database(tmp_path):
+    run_extended_tests.ensure_sqlite_schema({"HOME": str(tmp_path)})
+
+    db_path = tmp_path / ".open-ace" / "ace.db"
+    assert run_extended_tests.sqlite_has_table(db_path, "tenants")
+    assert run_extended_tests.sqlite_has_table(db_path, "users")
+
+
+def test_prepare_test_home_preserves_existing_playwright_browser_cache(tmp_path):
+    browsers_path = run_extended_tests.default_playwright_browsers_path(tmp_path)
+    browsers_path.mkdir(parents=True)
+    env = {"HOME": str(tmp_path)}
+
+    test_home = run_extended_tests.prepare_test_home(env, isolated_home=True)
+    try:
+        assert env["HOME"] != str(tmp_path)
+        assert env["PLAYWRIGHT_BROWSERS_PATH"] == str(browsers_path)
+    finally:
+        assert test_home is not None
+        test_home.cleanup()
+
+
+def test_frontend_build_check_fails_fast_when_dist_is_missing(tmp_path, monkeypatch):
+    monkeypatch.setattr(run_extended_tests, "PROJECT_ROOT", tmp_path)
+
+    with pytest.raises(RuntimeError, match="Frontend build is missing"):
+        run_extended_tests.ensure_frontend_built("critical")


### PR DESCRIPTION
## Summary
- add a shared scripts/run_extended_tests.py runner for critical, E2E, issue, specific, and sharded extended test runs
- add Extended Tests workflow for PR critical gates, scheduled full E2E plus issue shards, and manual/label-triggered runs
- add release critical regression gate and document local/CI usage
- stabilize critical login/navigation regression tests for server-dependent CI runs

Closes #1469

## Validation
- pytest tests/issues/1469/test_extended_tests_runner.py -q
- cd frontend && npm ci && npm run build
- /tmp/openace-1469-venv312/bin/python scripts/run_extended_tests.py --category critical --isolated-home --reruns 1 --timeout 180 --maxfail 5 --junitxml /tmp/openace-1469-critical.xml
- SKIP=bandit,no-commit-to-branch /Users/rhuang/Library/Python/3.9/bin/pre-commit run --all-files