### PR TITLE
fix(high): enforce password-change requirement on before_request blueprints

### DIFF
--- a/app/modules/workspace/session_access.py
+++ b/app/modules/workspace/session_access.py
@@ -19,7 +19,11 @@ from typing import Any
 
 from flask import g, jsonify, request
 
-from app.auth.decorators import _extract_token, _load_user_from_token
+from app.auth.decorators import (
+    _extract_token,
+    _load_user_from_token,
+    enforce_password_change_requirement,
+)
 from app.modules.workspace.remote_agent_manager import get_remote_agent_manager
 from app.modules.workspace.remote_session_manager import get_remote_session_manager
 
@@ -103,6 +107,7 @@ def _set_user_from_webui_token() -> bool:
                         "email": user_data.get("email"),
                         "role": user_data.get("role"),
                         "tenant_id": user_data.get("tenant_id"),
+                        "must_change_password": bool(user_data.get("must_change_password")),
                     }
                 )
                 return True
@@ -121,9 +126,17 @@ def load_remote_user() -> tuple | None:
     """
     if request.method == "OPTIONS":
         return None
-    if _set_user_from_token():
-        return None
-    if _set_user_from_webui_token():
+    if _set_user_from_token() or _set_user_from_webui_token():
+        # Enforce the forced-password-change lockdown here (the shared
+        # chokepoint for remote_bp and run_timeline_bp) so a user flagged
+        # must_change_password=True cannot reach the ~40 before_request-only
+        # remote endpoints or either run-timeline endpoint. Mirrors the gate
+        # used in auth_required/admin_required. The proxy-token path sets
+        # g.user without must_change_password, which the gate treats as falsy
+        # (allow), so proxy auth is unaffected.
+        password_change_response = enforce_password_change_requirement(getattr(g, "user", None))
+        if password_change_response is not None:
+            return password_change_response
         return None
     return jsonify({"error": "Authentication required"}), 401
 

--- a/app/routes/alerts.py
+++ b/app/routes/alerts.py
@@ -16,7 +16,11 @@ from datetime import datetime, timezone
 
 from flask import Blueprint, g, jsonify, request
 
-from app.auth.decorators import _extract_token, _load_user_from_token
+from app.auth.decorators import (
+    _extract_token,
+    _load_user_from_token,
+    enforce_password_change_requirement,
+)
 from app.modules.governance.alert_notifier import (
     NotificationPreference,
     _redact_dingtalk_secret,
@@ -38,6 +42,9 @@ def load_user():
             g.user = user
             g.user_id = user.get("id")
             g.user_role = user.get("role")
+            password_change_response = enforce_password_change_requirement(user)
+            if password_change_response is not None:
+                return password_change_response
             return None
     return jsonify({"error": "Authentication required"}), 401
 

--- a/app/routes/fs.py
+++ b/app/routes/fs.py
@@ -65,7 +65,11 @@ def _authenticate_user():
         return None
 
     # Try session token first
-    from app.auth.decorators import _extract_token, _load_user_from_token
+    from app.auth.decorators import (
+        _extract_token,
+        _load_user_from_token,
+        enforce_password_change_requirement,
+    )
 
     token = _extract_token()
     if token:
@@ -76,6 +80,9 @@ def _authenticate_user():
                 g.user = user
                 g.user_id = user.get("id")
                 g.user_role = user.get("role")
+                password_change_response = enforce_password_change_requirement(user)
+                if password_change_response is not None:
+                    return password_change_response
                 return None
 
     # Fallback: try WebUI token from query param (for iframe integration)
@@ -92,6 +99,9 @@ def _authenticate_user():
                     g.user = user
                     g.user_id = user_id
                     g.user_role = user.get("role")
+                    password_change_response = enforce_password_change_requirement(user)
+                    if password_change_response is not None:
+                        return password_change_response
                     return None
 
     return jsonify({"error": "Authentication required"}), 401

--- a/app/routes/project_categories.py
+++ b/app/routes/project_categories.py
@@ -8,7 +8,11 @@ import logging
 
 from flask import Blueprint, g, jsonify, request
 
-from app.auth.decorators import _extract_token, _load_user_from_token
+from app.auth.decorators import (
+    _extract_token,
+    _load_user_from_token,
+    enforce_password_change_requirement,
+)
 from app.repositories.project_category_repo import ProjectCategoryRepository
 from app.repositories.user_repo import UserRepository
 
@@ -30,6 +34,9 @@ def _authenticate_user():
             if user:
                 g.user = user
                 g.user_id = user.get("id")
+                password_change_response = enforce_password_change_requirement(user)
+                if password_change_response is not None:
+                    return password_change_response
                 return None
     return jsonify({"error": "Authentication required"}), 401
 

--- a/app/routes/projects.py
+++ b/app/routes/projects.py
@@ -15,7 +15,12 @@ from typing import Any, cast
 
 from flask import Blueprint, g, jsonify, request
 
-from app.auth.decorators import _extract_token, _load_user_from_token, require_tenant_scope
+from app.auth.decorators import (
+    _extract_token,
+    _load_user_from_token,
+    enforce_password_change_requirement,
+    require_tenant_scope,
+)
 from app.repositories.project_repo import ProjectRepository
 from app.repositories.user_repo import UserRepository
 
@@ -52,6 +57,9 @@ def _authenticate_user():
                 g.user_id = user.get("id")
                 g.user_role = user.get("role")
                 g.tenant_id = user.get("tenant_id")
+                password_change_response = enforce_password_change_requirement(user)
+                if password_change_response is not None:
+                    return password_change_response
                 return None
 
     # Fallback: try WebUI token from query param
@@ -69,6 +77,9 @@ def _authenticate_user():
                     g.user_id = user_id
                     g.user_role = user.get("role")
                     g.tenant_id = user.get("tenant_id")
+                    password_change_response = enforce_password_change_requirement(user)
+                    if password_change_response is not None:
+                        return password_change_response
                     return None
 
     return jsonify({"error": "Authentication required"}), 401

--- a/app/routes/remote.py
+++ b/app/routes/remote.py
@@ -24,7 +24,7 @@ from typing import Any
 
 from flask import Blueprint, Response, g, jsonify, request, stream_with_context
 
-from app.auth.decorators import _extract_token, admin_required
+from app.auth.decorators import _extract_token, admin_required, enforce_password_change_requirement
 from app.modules.governance.audit_logger import AuditAction, AuditLogger
 from app.modules.workspace.agent_token import token_hash_prefix
 from app.modules.workspace.api_key_proxy import get_api_key_proxy_service
@@ -98,6 +98,13 @@ def load_user():
 
     # Shared session/Authorization-token loading.
     if _set_user_from_token():
+        # Enforce the forced-password-change lockdown before letting the
+        # request reach the ~40 before_request-only remote endpoints (only a
+        # handful carry @admin_required/@machine_access_required, which re-run
+        # their own checks). Mirrors auth_required/admin_required.
+        password_change_response = enforce_password_change_requirement(getattr(g, "user", None))
+        if password_change_response is not None:
+            return password_change_response
         return None  # Authenticated
 
     # Special case: WebSocket proxy token for terminal status endpoint.
@@ -128,6 +135,9 @@ def load_user():
 
     # Shared WebUI URL-token fallback (iframe requests from qwen-code-webui).
     if _set_user_from_webui_token():
+        password_change_response = enforce_password_change_requirement(getattr(g, "user", None))
+        if password_change_response is not None:
+            return password_change_response
         return None
 
     return jsonify({"error": "Authentication required"}), 401

--- a/app/routes/system.py
+++ b/app/routes/system.py
@@ -12,7 +12,11 @@ from datetime import datetime, timezone
 
 from flask import Blueprint, g, jsonify, request
 
-from app.auth.decorators import _extract_token, _load_user_from_token
+from app.auth.decorators import (
+    _extract_token,
+    _load_user_from_token,
+    enforce_password_change_requirement,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -29,6 +33,9 @@ def load_user():
             g.user = user
             g.user_id = user.get("id")
             g.user_role = user.get("role")
+            password_change_response = enforce_password_change_requirement(user)
+            if password_change_response is not None:
+                return password_change_response
             return None
     return jsonify({"error": "Authentication required"}), 401
 

--- a/app/routes/workspace.py
+++ b/app/routes/workspace.py
@@ -15,7 +15,11 @@ from typing import Any, Optional
 
 from flask import Blueprint, abort, g, jsonify, request
 
-from app.auth.decorators import _extract_token, _load_user_from_token
+from app.auth.decorators import (
+    _extract_token,
+    _load_user_from_token,
+    enforce_password_change_requirement,
+)
 from app.modules.workspace.api_key_proxy import get_api_key_proxy_service
 from app.modules.workspace.collaboration import SharePermission, get_collaboration_manager
 from app.modules.workspace.llm_proxy_handler import handle_llm_proxy_request
@@ -123,6 +127,9 @@ def load_user():
             g.user_role = user.get("role")
             g.tenant_id = user.get("tenant_id")
             _refresh_session(token)
+            password_change_response = enforce_password_change_requirement(user)
+            if password_change_response is not None:
+                return password_change_response
             return None
 
         # Session token failed — try WebUI token validation
@@ -143,11 +150,15 @@ def load_user():
                         "email": user_data.get("email"),
                         "role": user_data.get("role"),
                         "tenant_id": user_data.get("tenant_id"),
+                        "must_change_password": bool(user_data.get("must_change_password")),
                     }
                     g.user_id = user_id
                     g.user_role = user_data.get("role")
                     g.tenant_id = user_data.get("tenant_id")
                     _refresh_session(token, user_repo=user_repo)
+                    password_change_response = enforce_password_change_requirement(g.user)
+                    if password_change_response is not None:
+                        return password_change_response
                     return None
         except Exception as e:
             logger.warning(f"Failed to validate URL token: {e}")

--- a/tests/routes/test_must_change_enforcement_blueprints.py
+++ b/tests/routes/test_must_change_enforcement_blueprints.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""
+Route tests for must-change-password enforcement on the blueprints that
+authenticate via a custom ``@<bp>.before_request`` hook instead of the
+``@auth_required`` / ``@admin_required`` decorators.
+
+These blueprints historically bypassed ``enforce_password_change_requirement``
+because that helper is only wired into the decorators in
+``app/auth/decorators.py``. A user flagged with ``must_change_password=True``
+could therefore keep using workspace, projects, system, alerts,
+project-categories and fs endpoints.
+
+Addresses review findings on #1752.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+project_root = str(Path(__file__).resolve().parent.parent.parent)
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+
+
+# One session dict returned by the mocked ``_authenticate`` (session-token
+# path used by every before_request hook). ``must_change_password=True`` is
+# the forced-password-change state that must be blocked.
+MUST_CHANGE_SESSION = {
+    "user_id": 1,
+    "username": "admin",
+    "email": "admin@example.com",
+    "role": "admin",
+    "must_change_password": True,
+}
+
+CLEAR_SESSION = {
+    "user_id": 1,
+    "username": "admin",
+    "email": "admin@example.com",
+    "role": "admin",
+    "must_change_password": False,
+}
+
+# Full user row returned by user_repo.get_user_by_id() for the blueprints that
+# re-fetch the user (projects / project_categories / fs). SELECT * includes
+# must_change_password.
+MUST_CHANGE_USER = {
+    "id": 1,
+    "username": "admin",
+    "email": "admin@example.com",
+    "role": "admin",
+    "tenant_id": None,
+    "must_change_password": True,
+}
+
+CLEAR_USER = {
+    "id": 1,
+    "username": "admin",
+    "email": "admin@example.com",
+    "role": "admin",
+    "tenant_id": None,
+    "must_change_password": False,
+}
+
+
+@pytest.fixture
+def app():
+    """Register all blueprints under /api."""
+    from flask import Flask
+
+    from app.routes.alerts import alerts_bp
+    from app.routes.fs import fs_bp
+    from app.routes.project_categories import project_categories_bp
+    from app.routes.projects import projects_bp
+    from app.routes.remote import remote_bp
+    from app.routes.run_timeline import run_timeline_bp
+    from app.routes.system import system_bp
+    from app.routes.workspace import workspace_bp
+
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    # Mount each blueprint with the SAME url_prefix used in app/__init__.py so
+    # the before_request hooks and route paths behave exactly as in production.
+    app.register_blueprint(workspace_bp, url_prefix="/api/workspace")
+    app.register_blueprint(projects_bp, url_prefix="/api")
+    app.register_blueprint(system_bp, url_prefix="/api")
+    app.register_blueprint(alerts_bp, url_prefix="/api")
+    app.register_blueprint(project_categories_bp, url_prefix="/api")
+    app.register_blueprint(fs_bp, url_prefix="/api")
+    app.register_blueprint(remote_bp, url_prefix="/api/remote")
+    app.register_blueprint(run_timeline_bp, url_prefix="/api/remote")
+    return app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+@pytest.mark.parametrize(
+    "method,path,user_role",
+    [
+        ("GET", "/api/workspace/prompts", "user"),
+        ("GET", "/api/projects", "user"),
+        ("GET", "/api/schedulers", "admin"),
+        ("GET", "/api/alerts", "user"),
+        ("GET", "/api/project-categories", "user"),
+        ("GET", "/api/fs/browse", "user"),
+    ],
+)
+def test_must_change_user_is_blocked_on_every_blueprint(client, method, path, user_role):
+    """A forced-reset user must get 403 password_change_required on all six."""
+    blocked_session = dict(MUST_CHANGE_SESSION, role=user_role, must_change_password=True)
+    blocked_user = dict(MUST_CHANGE_USER, role=user_role, must_change_password=True)
+
+    with patch("app.auth.decorators._authenticate", return_value=(True, blocked_session)):
+        with patch("app.routes.projects.user_repo.get_user_by_id", return_value=blocked_user):
+            with patch(
+                "app.routes.project_categories.user_repo.get_user_by_id",
+                return_value=blocked_user,
+            ):
+                with patch("app.routes.fs.user_repo.get_user_by_id", return_value=blocked_user):
+                    resp = client.open(path, method=method, headers={"Authorization": "Bearer t"})
+
+    assert resp.status_code == 403, f"{path} did not block must-change user"
+    data = resp.get_json()
+    assert data["code"] == "password_change_required"
+
+
+@pytest.mark.parametrize(
+    "method,path",
+    [
+        ("GET", "/api/workspace/prompts"),
+        ("GET", "/api/projects"),
+        ("GET", "/api/schedulers"),
+        ("GET", "/api/alerts"),
+        ("GET", "/api/project-categories"),
+        ("GET", "/api/fs/browse"),
+    ],
+)
+def test_clear_user_is_not_over_blocked(client, method, path):
+    """A user without must_change_password must not be over-blocked by the gate.
+
+    The gate must let the request through before_request, i.e. the response
+    must NOT be the password_change_required 403 (downstream errors from the
+    unmocked DB are acceptable and irrelevant to this assertion).
+    """
+    with patch("app.auth.decorators._authenticate", return_value=(True, CLEAR_SESSION)):
+        with patch("app.routes.projects.user_repo.get_user_by_id", return_value=CLEAR_USER):
+            with patch(
+                "app.routes.project_categories.user_repo.get_user_by_id",
+                return_value=CLEAR_USER,
+            ):
+                with patch("app.routes.fs.user_repo.get_user_by_id", return_value=CLEAR_USER):
+                    try:
+                        resp = client.open(
+                            path, method=method, headers={"Authorization": "Bearer t"}
+                        )
+                    except sqlite3.OperationalError:
+                        # The bare Flask app has no DB schema. The alerts,
+                        # system, fs and workspace handlers wrap their DB
+                        # access in try/except and return 500; the projects
+                        # and project-categories handlers do not, so a
+                        # "no such table" error escapes client.open. Reaching
+                        # the handler proves the gate let the clear user
+                        # through - the only behaviour this test asserts.
+                        return
+
+    if resp.status_code == 403:
+        body = resp.get_json(silent=True) or {}
+        assert (
+            body.get("code") != "password_change_required"
+        ), f"{path} was over-blocked by the password-change gate for a clear user"
+
+
+def test_must_change_user_is_blocked_on_remote_blueprint_session_token(client):
+    """remote_bp authenticates via load_remote_user (shared with run_timeline_bp).
+
+    A must_change_password user must be blocked at before_request before reaching
+    any of the ~40 before_request-only remote endpoints (here GET /machines),
+    which have no per-route auth decorator.
+    """
+    blocked_session = dict(MUST_CHANGE_SESSION, role="user", must_change_password=True)
+    with patch("app.auth.decorators._authenticate", return_value=(True, blocked_session)):
+        # load_remote_user does not re-fetch via user_repo; g.user comes straight
+        # from _load_user_from_token, so no get_user_by_id patch is needed.
+        resp = client.get("/api/remote/machines", headers={"Authorization": "Bearer t"})
+
+    assert resp.status_code == 403
+    assert resp.get_json()["code"] == "password_change_required"
+
+
+def test_set_user_from_webui_token_populates_must_change_password():
+    """The WebUI-token g.user literal must carry must_change_password.
+
+    Without the flag, enforce_password_change_requirement silently no-ops and a
+    must_change_password user authenticated via the WebUI-token branch slips
+    through the gate. This pins the literal built in
+    session_access._set_user_from_webui_token.
+    """
+    from flask import Flask, g
+
+    from app.modules.workspace import session_access
+
+    with patch.dict("os.environ", {}, clear=False):
+        with patch("app.services.webui_manager.WebUIManager") as mgr_cls:
+            mgr_cls.return_value.validate_token.return_value = (True, 1, None)
+            with patch("app.repositories.user_repo.UserRepository") as repo_cls:
+                repo_cls.return_value.get_user_by_id.return_value = MUST_CHANGE_USER
+                app = Flask(__name__)
+                with app.test_request_context("/?token=webui-token"):
+                    result = session_access._set_user_from_webui_token()
+                    # Assert inside the app context: g.user only exists while the
+                    # request context is active.
+                    assert result is True
+                    assert g.user["must_change_password"] is True
+
+
+def test_clear_user_is_not_over_blocked_on_remote_blueprint(client):
+    """A clear user must not be over-blocked on the remote blueprint."""
+    with patch("app.auth.decorators._authenticate", return_value=(True, CLEAR_SESSION)):
+        try:
+            resp = client.get("/api/remote/machines", headers={"Authorization": "Bearer t"})
+        except sqlite3.OperationalError:
+            # No DB schema -> handler raises; reaching it proves the gate passed.
+            return
+
+    if resp.status_code == 403:
+        body = resp.get_json(silent=True) or {}
+        assert body.get("code") != "password_change_required"


### PR DESCRIPTION
## Root cause

Six blueprints authenticate via a custom `@<bp>.before_request` hook instead of the `@auth_required`/`@admin_required` decorators in `app/auth/decorators.py`. The password-change enforcement helper `enforce_password_change_requirement` was only wired into those decorators, so the hooks never called it. A user flagged with `must_change_password=True` therefore retained full access to every route on **workspace, projects, system, alerts, project_categories, and fs** (workspace prompts/sessions, project data, admin scheduler/system endpoints, alert feeds, project-category admin, and the fs browse API).

Additionally, the WebUI-token `g.user` dict literal in `workspace.py` omitted the `must_change_password` key, so that fallback branch would have silently treated the flag as `False` even after enforcement was added.

## Fix

Call `enforce_password_change_requirement(user)` at the tail of each `before_request` success branch (right before `return None`) on all six blueprints, returning the blocking 403 response when the helper returns non-`None`. Also add `"must_change_password": bool(user_data.get("must_change_password"))` to the workspace WebUI-token `g.user` literal so that branch reads the flag correctly.

This is the per-hook centralized guard (review option a): enforcement can no longer be forgotten on a blueprint that authenticates via `before_request`.

## TDD test added

`tests/routes/test_must_change_enforcement_blueprints.py` registers all six blueprints (with the same `url_prefix` values used in `app/__init__.py`) and parametrically hits one authenticated endpoint per blueprint:
- `GET /api/workspace/prompts`
- `GET /api/projects`
- `GET /api/schedulers` (admin)
- `GET /api/alerts`
- `GET /api/project-categories`
- `GET /api/fs/browse`

It asserts each returns **403** with `json.code == "password_change_required"` for a `must_change_password=True` user, and a companion case asserts a clear (`must_change_password=False`) user is **not** over-blocked by the gate. Verified red on unmodified main (all six endpoints returned 200/404 instead of 403) and green after the fix.

Addresses review findings on #1752.

Severity: high.