### PR TITLE
fix(high): couple SAML signature verification to the consumed assertion

### DIFF
--- a/app/modules/sso/saml.py
+++ b/app/modules/sso/saml.py
@@ -197,8 +197,8 @@ class SAMLProvider(SSOProvider):
 
         try:
             root = self._parse_xml(response_xml)
-            self._verify_signature(root)
-            assertion = self._select_assertion(root)
+            verified_element = self._verify_signature(root)
+            assertion = self._select_assertion(root, verified_element)
             effective_acs_url = acs_url or self.acs_url
             self._validate_response(root, assertion, request_id, effective_acs_url)
             user, expires_in = self._build_user(assertion, response_xml)
@@ -316,7 +316,13 @@ class SAMLProvider(SSOProvider):
         self._validate_conditions(assertion, acs_url)
         self._validate_subject_confirmation(assertion, request_id, acs_url)
 
-    def _verify_signature(self, root: etree._Element) -> None:
+    def _verify_signature(self, root: etree._Element) -> etree._Element:
+        """Verify a SAML signature and return the element whose signature verified.
+
+        Returns the verified element (the Response root or a saml:Assertion) so the
+        caller can couple assertion selection to verification, preventing XML signature
+        wrapping where an unsigned assertion is consumed alongside a verified sibling.
+        """
         certs = self._configured_certificates()
         if not certs:
             raise ValueError("missing_idp_certificate")
@@ -336,18 +342,87 @@ class SAMLProvider(SSOProvider):
                         validate_schema=False,
                         expect_config=expect_config,
                     )
-                    return
+                    return candidate
                 except Exception as e:
                     last_error = e
 
         logger.warning("SAML signature validation failed: %s", last_error)
         raise ValueError("invalid_signature")
 
-    def _select_assertion(self, root: etree._Element) -> etree._Element:
-        assertion = root.find(".//saml:Assertion", namespaces=NSMAP)
-        if assertion is None:
-            raise ValueError("missing_assertion")
-        return assertion
+    def _select_assertion(
+        self,
+        root: etree._Element,
+        verified_element: etree._Element,
+    ) -> etree._Element:
+        """Return the assertion to consume, coupled to the verified element.
+
+        - If the Assertion itself was signed, the consumed assertion MUST be that exact
+          verified element (object identity). Any unsigned sibling placed ahead of it
+          (signature wrapping) is rejected.
+        - If the Response (message) was signed, the consumed assertion must be the
+          single assertion whose ID is referenced by the verified Signature. Ambiguous
+          multi-assertion responses are rejected to avoid wrapping.
+        """
+        assertion_tag = f"{{{SAML_ASSERTION_NS}}}Assertion"
+        if verified_element.tag == assertion_tag:
+            # Fail closed if any sibling assertion exists that was not the verified
+            # element: an attacker can prepend an unsigned (or differently-signed)
+            # Assertion ahead of the signed one (signature wrapping). Reject rather
+            # than risk consuming an attacker-controlled assertion.
+            all_assertions = root.findall(".//saml:Assertion", namespaces=NSMAP)
+            if any(assertion is not verified_element for assertion in all_assertions):
+                raise ValueError("signature_wrapping")
+            if verified_element not in root.iter():
+                raise ValueError("signature_wrapping")
+            return verified_element
+
+        referenced_ids = self._signature_reference_ids(verified_element)
+        all_assertions = root.findall(".//saml:Assertion", namespaces=NSMAP)
+
+        # When the Response (message) is signed, the Signature reference typically
+        # points at the Response ID (it covers the whole document), not at an
+        # Assertion ID. Accept the single contained assertion; reject any wrapped
+        # multi-assertion response where coverage is ambiguous.
+        if referenced_ids and verified_element.get("ID") in referenced_ids:
+            if len(all_assertions) != 1:
+                raise ValueError("signature_wrapping")
+            return all_assertions[0]
+
+        matching = []
+        for assertion in all_assertions:
+            if (
+                assertion is verified_element
+                or assertion.get("ID")
+                and assertion.get("ID") in referenced_ids
+            ):
+                matching.append(assertion)
+
+        if not matching:
+            raise ValueError("signature_wrapping")
+        if len(matching) > 1:
+            raise ValueError("signature_wrapping")
+        # Fail closed if any assertion is present that the verified Signature does not
+        # cover: an attacker can inject an unsigned sibling (signature wrapping).
+        if any(
+            assertion is not matching[0]
+            and (not assertion.get("ID") or assertion.get("ID") not in referenced_ids)
+            for assertion in all_assertions
+        ):
+            raise ValueError("signature_wrapping")
+        return matching[0]
+
+    def _signature_reference_ids(self, signed_element: etree._Element) -> set[str]:
+        """Return the set of ID URIs referenced by the element's Signature."""
+        ids: set[str] = set()
+        for reference in signed_element.findall(
+            ".//ds:Signature/ds:SignedInfo/ds:Reference", namespaces=NSMAP
+        ):
+            uri = reference.get("URI") or ""
+            if uri.startswith("#"):
+                uri = uri[1:]
+            if uri:
+                ids.add(uri)
+        return ids
 
     def _validate_issuer(self, root: etree._Element, assertion: etree._Element) -> None:
         expected_issuer = self.idp_entity_id

--- a/tests/unit/test_saml_provider.py
+++ b/tests/unit/test_saml_provider.py
@@ -256,3 +256,154 @@ def test_saml_response_rejects_missing_required_email_attribute():
 
     assert result.success is False
     assert result.error == "missing_attribute"
+
+
+def _evil_unsigned_assertion(*, name_id: str, email: str) -> etree._Element:
+    """Build a validly-structured but UNSIGNED Assertion element for wrapping attacks."""
+    now = datetime.now(timezone.utc)
+    assertion = etree.Element(
+        f"{{{SAML_ASSERTION_NS}}}Assertion",
+        nsmap={"saml": SAML_ASSERTION_NS},
+        ID="_evil-1",
+        Version="2.0",
+        IssueInstant=_saml_time(now),
+    )
+    etree.SubElement(assertion, f"{{{SAML_ASSERTION_NS}}}Issuer").text = IDP_ENTITY_ID
+    subject = etree.SubElement(assertion, f"{{{SAML_ASSERTION_NS}}}Subject")
+    etree.SubElement(subject, f"{{{SAML_ASSERTION_NS}}}NameID").text = name_id
+    confirmation = etree.SubElement(subject, f"{{{SAML_ASSERTION_NS}}}SubjectConfirmation")
+    etree.SubElement(
+        confirmation,
+        f"{{{SAML_ASSERTION_NS}}}SubjectConfirmationData",
+        Recipient=ACS_URL,
+        InResponseTo="_request-1",
+        NotOnOrAfter=_saml_time(now + timedelta(minutes=5)),
+    )
+    conditions = etree.SubElement(
+        assertion,
+        f"{{{SAML_ASSERTION_NS}}}Conditions",
+        NotBefore=_saml_time(now - timedelta(minutes=1)),
+        NotOnOrAfter=_saml_time(now + timedelta(minutes=5)),
+    )
+    audience_restriction = etree.SubElement(
+        conditions,
+        f"{{{SAML_ASSERTION_NS}}}AudienceRestriction",
+    )
+    etree.SubElement(audience_restriction, f"{{{SAML_ASSERTION_NS}}}Audience").text = SP_ENTITY_ID
+    attr_statement = etree.SubElement(assertion, f"{{{SAML_ASSERTION_NS}}}AttributeStatement")
+    email_attr = etree.SubElement(attr_statement, f"{{{SAML_ASSERTION_NS}}}Attribute", Name="email")
+    etree.SubElement(email_attr, f"{{{SAML_ASSERTION_NS}}}AttributeValue").text = email
+    return assertion
+
+
+def test_saml_response_rejects_unsigned_wrapped_assertion():
+    """Signature wrapping: an UNSIGNED assertion placed before a signed one must be rejected.
+
+    A legitimate single-Assertion response is signed. An attacker inserts an unsigned
+    "evil" Assertion as the first child of <Response>, ahead of the signed one. On the
+    vulnerable code path, _verify_signature verifies the signed (second) Assertion while
+    _select_assertion returns the first (unsigned, evil) Assertion, leading to account
+    takeover. The fix couples verification to selection.
+    """
+    key_pem, cert_pem, cert_body = _idp_key_and_cert()
+    provider = _provider(cert_body)
+    signed_response = _signed_response(
+        key_pem, cert_pem, name_id="legit-user", email="legit@example.com"
+    )
+
+    root = etree.fromstring(base64.b64decode(signed_response))
+    evil_assertion = _evil_unsigned_assertion(
+        name_id="victim-admin@example.com", email="victim-admin@example.com"
+    )
+    # Insert the unsigned evil assertion BEFORE the signed one so that document-order
+    # lookup (.//saml:Assertion) returns it first.
+    root.insert(0, evil_assertion)
+    wrapped_response = base64.b64encode(etree.tostring(root)).decode("ascii")
+
+    result = provider.authenticate_saml_response(wrapped_response, "_request-1", ACS_URL)
+
+    assert result.success is False
+    assert result.error in ("invalid_signature", "signature_wrapping")
+
+
+def test_saml_response_single_signed_assertion_still_authenticates():
+    """Guard against over-rejecting: a normal single signed Assertion must still succeed."""
+    key_pem, cert_pem, cert_body = _idp_key_and_cert()
+    provider = _provider(cert_body)
+    saml_response = _signed_response(key_pem, cert_pem)
+
+    result = provider.authenticate_saml_response(saml_response, "_request-1", ACS_URL)
+
+    assert result.success is True
+    assert result.user is not None
+    assert result.user.email == "alice@example.com"
+
+
+def test_saml_response_message_signed_single_assertion_authenticates():
+    """A Response-signed (message-signed) single Assertion must still authenticate.
+
+    Real-world IdPs sometimes sign the Response instead of the Assertion. The fix must
+    not break that legitimate path while closing the signature-wrapping hole.
+    """
+    key_pem, cert_pem, cert_body = _idp_key_and_cert()
+    provider = _provider(cert_body)
+    now = datetime.now(timezone.utc)
+    response_id = "_response-1"
+    assertion_id = "_assertion-1"
+    response = etree.Element(
+        f"{{{SAML_PROTOCOL_NS}}}Response",
+        nsmap={"samlp": SAML_PROTOCOL_NS, "saml": SAML_ASSERTION_NS},
+        ID=response_id,
+        Version="2.0",
+        IssueInstant=_saml_time(now),
+        Destination=ACS_URL,
+        InResponseTo="_request-1",
+    )
+    etree.SubElement(response, f"{{{SAML_ASSERTION_NS}}}Issuer").text = IDP_ENTITY_ID
+    status = etree.SubElement(response, f"{{{SAML_PROTOCOL_NS}}}Status")
+    etree.SubElement(status, f"{{{SAML_PROTOCOL_NS}}}StatusCode", Value=SAML_SUCCESS_STATUS)
+    assertion = etree.SubElement(
+        response,
+        f"{{{SAML_ASSERTION_NS}}}Assertion",
+        ID=assertion_id,
+        Version="2.0",
+        IssueInstant=_saml_time(now),
+    )
+    etree.SubElement(assertion, f"{{{SAML_ASSERTION_NS}}}Issuer").text = IDP_ENTITY_ID
+    subject = etree.SubElement(assertion, f"{{{SAML_ASSERTION_NS}}}Subject")
+    etree.SubElement(subject, f"{{{SAML_ASSERTION_NS}}}NameID").text = "msg-user"
+    confirmation = etree.SubElement(subject, f"{{{SAML_ASSERTION_NS}}}SubjectConfirmation")
+    etree.SubElement(
+        confirmation,
+        f"{{{SAML_ASSERTION_NS}}}SubjectConfirmationData",
+        Recipient=ACS_URL,
+        InResponseTo="_request-1",
+        NotOnOrAfter=_saml_time(now + timedelta(minutes=5)),
+    )
+    conditions = etree.SubElement(
+        assertion,
+        f"{{{SAML_ASSERTION_NS}}}Conditions",
+        NotBefore=_saml_time(now - timedelta(minutes=1)),
+        NotOnOrAfter=_saml_time(now + timedelta(minutes=5)),
+    )
+    audience_restriction = etree.SubElement(
+        conditions,
+        f"{{{SAML_ASSERTION_NS}}}AudienceRestriction",
+    )
+    etree.SubElement(audience_restriction, f"{{{SAML_ASSERTION_NS}}}Audience").text = SP_ENTITY_ID
+    attr_statement = etree.SubElement(assertion, f"{{{SAML_ASSERTION_NS}}}AttributeStatement")
+    email_attr = etree.SubElement(attr_statement, f"{{{SAML_ASSERTION_NS}}}Attribute", Name="email")
+    etree.SubElement(email_attr, f"{{{SAML_ASSERTION_NS}}}AttributeValue").text = "msg@example.com"
+
+    signed_response = XMLSigner(
+        method=methods.enveloped,
+        signature_algorithm="rsa-sha256",
+        digest_algorithm="sha256",
+    ).sign(response, key=key_pem, cert=cert_pem, reference_uri=response_id)
+    b64 = base64.b64encode(etree.tostring(signed_response, xml_declaration=False)).decode("ascii")
+
+    result = provider.authenticate_saml_response(b64, "_request-1", ACS_URL)
+
+    assert result.success is True
+    assert result.user is not None
+    assert result.user.email == "msg@example.com"


### PR DESCRIPTION
## Root cause
`SAMLProvider._verify_signature` verified the first signed candidate element and returned `None`, while `_select_assertion` independently returned the first `saml:Assertion` in document order. These two steps were never coupled, so an attacker could prepend an **unsigned** assertion ahead of a legitimately signed one (XML signature wrapping) and have the unsigned, attacker-controlled assertion consumed — leading to account takeover (e.g. inject a victim admin's email as the first assertion).

## Fix
- `_verify_signature` now **returns the verified element** (Response root or `saml:Assertion`) instead of `None`.
- `_select_assertion(root, verified_element)` couples selection to verification:
  - **Assertion-signed**: the consumed assertion must be the verified element (object identity) and no unsigned/differently-signed sibling may exist.
  - **Response (message)-signed**: accept only the single contained assertion whose coverage is unambiguous; reject multi-assertion responses.
  - Ambiguous or wrapped responses fail closed with `ValueError("signature_wrapping")`.

## TDD test added
`tests/unit/test_saml_provider.py::test_saml_response_rejects_unsigned_wrapped_assertion` — builds a legitimately signed single-assertion response, injects an unsigned "evil" assertion as the **first** child (so document-order lookup returns it first), and asserts authentication is rejected (`success is False`, error in `{invalid_signature, signature_wrapping}`). This test **fails on main** (`success=True`, consumed user email = `victim-admin@example.com`) and **passes after the fix**.

Guard tests confirm legitimate paths are not over-rejected: `test_saml_response_single_signed_assertion_still_authenticates` and a new `test_saml_response_message_signed_single_assertion_authenticates` (IdPs that sign the Response rather than the Assertion).

Severity: high.

Addresses review findings on #1788.