### PR TITLE
fix(high): fix Windows WebSocket terminal input drop on the pipe path

### DIFF
--- a/remote-agent/terminal_server.py
+++ b/remote-agent/terminal_server.py
@@ -278,7 +278,12 @@ class SinglePtyTerminalServer:
         """Handle input from a single WebSocket connection."""
         try:
             async for message in websocket:
-                if not self._pty_alive or self.master_fd is None:
+                # Path-aware guard: the PTY model needs master_fd to write to,
+                # while the Windows pipe model writes via process.stdin and never
+                # assigns master_fd. The old `master_fd is None` check short-
+                # circuited the pipe path on the first message, making the
+                # restored Windows terminal receive-only.
+                if not self._pty_alive or (self._uses_pty and self.master_fd is None):
                     break
 
                 if isinstance(message, str):

--- a/tests/unit/test_terminal_server.py
+++ b/tests/unit/test_terminal_server.py
@@ -3,10 +3,11 @@
 
 from __future__ import annotations
 
-import asyncio
 import importlib.util
 import sys
 from pathlib import Path
+
+import pytest
 
 
 def load_terminal_server():
@@ -97,12 +98,18 @@ class _FakeWebSocket:
         return None
 
 
-def test_handle_websocket_input_writes_to_pipe_on_windows(monkeypatch):
+@pytest.mark.asyncio
+async def test_handle_websocket_input_writes_to_pipe_on_windows(monkeypatch):
     """Windows pipe path: keystrokes must reach process.stdin.
 
     On the pipe path ``master_fd`` is never assigned (stays None) while
     ``self.process`` holds the subprocess. The top-of-loop guard must be
     path-aware so the loop body can fall through to the pipe write.
+
+    Marked ``asyncio`` so ``SinglePtyTerminalServer()`` (whose ``__init__``
+    eagerly binds an ``asyncio.Lock``) constructs inside the running event
+    loop on Python 3.9, where ``asyncio.run()`` would otherwise close and
+    unset the thread's loop and pollute later tests.
     """
     terminal_server = load_terminal_server()
 
@@ -114,12 +121,13 @@ def test_handle_websocket_input_writes_to_pipe_on_windows(monkeypatch):
     monkeypatch.setattr(server, "process", _FakeProc())
 
     ws = _FakeWebSocket([b"ls\r", b"exit\r"])
-    asyncio.run(server.handle_websocket_input(ws))
+    await server.handle_websocket_input(ws)
 
     assert server.process.stdin.written == [b"ls\r", b"exit\r"]
 
 
-def test_handle_websocket_input_writes_to_master_fd_on_pty(monkeypatch):
+@pytest.mark.asyncio
+async def test_handle_websocket_input_writes_to_master_fd_on_pty(monkeypatch):
     """PTY path regression guard: the path-aware change must keep PTY writes working."""
     terminal_server = load_terminal_server()
 
@@ -144,7 +152,7 @@ def test_handle_websocket_input_writes_to_master_fd_on_pty(monkeypatch):
         monkeypatch.setattr(terminal_server.os, "write", fake_os_write)
 
         ws = _FakeWebSocket([b"pwd\n", b"ls\n"])
-        asyncio.run(server.handle_websocket_input(ws))
+        await server.handle_websocket_input(ws)
     finally:
         terminal_server.os.close(read_fd)
         terminal_server.os.close(write_fd)

--- a/tests/unit/test_terminal_server.py
+++ b/tests/unit/test_terminal_server.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import importlib.util
 import sys
 from pathlib import Path
@@ -56,3 +57,96 @@ def test_spawn_pty_uses_pipe_process_on_windows(monkeypatch):
     assert calls["work_dir"] == "C:/repo"
     assert calls["cmd"][0] == terminal_server.sys.executable
     assert calls["cmd"][1].endswith("terminal_menu.py")
+
+
+class _FakeStdin:
+    def __init__(self) -> None:
+        self.written: list[bytes] = []
+
+    def write(self, data: bytes) -> int:
+        self.written.append(data)
+        return len(data)
+
+    def flush(self) -> None:
+        return None
+
+
+class _FakeProc:
+    def __init__(self) -> None:
+        self.pid = 4321
+        self.stdin = _FakeStdin()
+        self.stdout = None
+        self.stderr = None
+
+
+class _FakeWebSocket:
+    """Async iterable yielding a fixed list of messages."""
+
+    def __init__(self, messages: list[bytes]) -> None:
+        self._messages = list(messages)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self._messages:
+            raise StopAsyncIteration
+        return self._messages.pop(0)
+
+    async def send(self, _data) -> None:
+        return None
+
+
+def test_handle_websocket_input_writes_to_pipe_on_windows(monkeypatch):
+    """Windows pipe path: keystrokes must reach process.stdin.
+
+    On the pipe path ``master_fd`` is never assigned (stays None) while
+    ``self.process`` holds the subprocess. The top-of-loop guard must be
+    path-aware so the loop body can fall through to the pipe write.
+    """
+    terminal_server = load_terminal_server()
+
+    server = terminal_server.SinglePtyTerminalServer()
+    # Reproduce the real Windows state: pipe model, no master_fd, live process.
+    monkeypatch.setattr(server, "_uses_pty", False)
+    monkeypatch.setattr(server, "master_fd", None)
+    monkeypatch.setattr(server, "_pty_alive", True)
+    monkeypatch.setattr(server, "process", _FakeProc())
+
+    ws = _FakeWebSocket([b"ls\r", b"exit\r"])
+    asyncio.run(server.handle_websocket_input(ws))
+
+    assert server.process.stdin.written == [b"ls\r", b"exit\r"]
+
+
+def test_handle_websocket_input_writes_to_master_fd_on_pty(monkeypatch):
+    """PTY path regression guard: the path-aware change must keep PTY writes working."""
+    terminal_server = load_terminal_server()
+
+    server = terminal_server.SinglePtyTerminalServer()
+    read_fd, write_fd = terminal_server.os.pipe()
+
+    written: list[tuple[int, bytes]] = []
+    real_os_write = terminal_server.os.write
+
+    def fake_os_write(fd: int, data: bytes) -> int:
+        # Only intercept writes to our master_fd; let everything else through.
+        if fd == server.master_fd:
+            written.append((fd, data))
+            return len(data)
+        return real_os_write(fd, data)
+
+    try:
+        monkeypatch.setattr(server, "_uses_pty", True)
+        monkeypatch.setattr(server, "master_fd", write_fd)
+        monkeypatch.setattr(server, "_pty_alive", True)
+        monkeypatch.setattr(server, "process", None)
+        monkeypatch.setattr(terminal_server.os, "write", fake_os_write)
+
+        ws = _FakeWebSocket([b"pwd\n", b"ls\n"])
+        asyncio.run(server.handle_websocket_input(ws))
+    finally:
+        terminal_server.os.close(read_fd)
+        terminal_server.os.close(write_fd)
+
+    assert [data for _fd, data in written] == [b"pwd\n", b"ls\n"]


### PR DESCRIPTION
## Severity: High

## Root cause
`SinglePtyTerminalServer.handle_websocket_input` guarded every loop iteration with `if not self._pty_alive or self.master_fd is None: break`. On the Windows pipe path `master_fd` is never assigned (it stays at its `__init__` default of `None`; the pipe branch only sets `self.process`/`self.pty_pid`). So the loop broke on the very first WebSocket message and the real pipe write at the `elif self.process is not None ... self.process.stdin.write(message)` branch was unreachable. The restored Windows terminal was effectively receive-only: output streamed to the browser but no keystrokes reached the shell.

## Fix
Make the alive/destination guard path-aware so it only enforces `master_fd` on the PTY model:
```python
if not self._pty_alive or (self._uses_pty and self.master_fd is None):
    break
```
This keeps the PTY safety check intact (no `master_fd` = nothing to write to) while letting the Windows pipe path fall through to `process.stdin.write`. The write dispatch already branches on `self._uses_pty` correctly, so only the top-of-loop guard needed changing.

## TDD test added
Two tests in `tests/unit/test_terminal_server.py`:
- `test_handle_websocket_input_writes_to_pipe_on_windows` — drives `handle_websocket_input` with a fake websocket (`b"ls\r"`, `b"exit\r"`) and a fake subprocess `stdin`, with `_uses_pty=False`, `master_fd=None`, `_pty_alive=True`. Asserts `stdin.written == [b"ls\r", b"exit\r"]`. Fails on main (loop breaks on first message, list stays empty); passes after the fix.
- `test_handle_websocket_input_writes_to_master_fd_on_pty` — paired regression guard: `_uses_pty=True`, real `os.pipe()` master_fd, monkeypatches `os.write`. Asserts both messages hit `master_fd`. Proves the guard change did not regress the PTY write path.

Addresses review findings on #1766.
