### PR TITLE
fix(high): run Docker image as non-root open-ace user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- The Docker image now defaults to the non-root `open-ace` user (uid 1000) via a `USER 1000` directive in the production stage, so `docker run`, docker-compose, and Kubernetes all run non-root without relying solely on the manifest `securityContext`. Multi-user workspace mode (which needs root for `useradd`/`chown`/`sudo -u`) is now an explicit, fail-fast opt-in: run as uid 0 (`docker run --user 0` / manifest `runAsUser: 0`) and set `OPENACE_ALLOW_ROOT_MULTI_USER=1`, otherwise the entrypoint exits with a clear error instead of silently swallowing permission failures.
 - Kubernetes reference manifests now run the web pod as non-root with 3 replicas, HPA, and Prometheus scrape annotations restored; multi-user workspace deployments that require root must opt in via an explicit overlay.
 - Docker-generated default config now enables AI autonomous development by default and only enables multi-user workspace mode when `WORKSPACE_MULTI_USER_MODE=true`.
 - Documented the encrypted-secret upgrade path: existing deployments should set `OPENACE_ENCRYPTION_KEY` to the previous `SECRET_KEY` value before first restart after the security-hardening upgrade, then rotate in a planned maintenance window if desired.

--- a/Dockerfile
+++ b/Dockerfile
@@ -163,15 +163,22 @@ RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 COPY scripts/openace-run-as.sh /usr/local/bin/openace-run-as
 RUN chmod 755 /usr/local/bin/openace-run-as && chown root:root /usr/local/bin/openace-run-as
 
-# NOTE: Container runs as root to support multi-user workspace mode (sudo -u <user>)
-# The entrypoint script handles privilege management and user creation.
+# NOTE: The image defaults to the non-root open-ace user (uid 1000) so that
+# `docker run`, docker-compose, and Kubernetes all execute the entrypoint as
+# uid 1000 without relying solely on the K8s manifest's securityContext.
+# This matches the stable uid/gid 1000 created above and the COPY --chown
+# ownership baked into the image.
 #
 # SECURITY CONSIDERATIONS:
-# - Multi-user mode requires root to create system users (useradd) dynamically
+# - Single-user mode (the default) needs only uid 1000 and runs non-root here.
+# - Multi-user workspace mode genuinely needs root (it runs useradd/chown and
+#   sudo -u across /home). For those deployments, opt back into root explicitly:
+#   set `--user 0` (docker run) / `runAsUser: 0` (manifest) AND the env
+#   OPENACE_ALLOW_ROOT_MULTI_USER=1. docker-entrypoint.sh fail-fasts otherwise.
 # - sudoers is configured to allow open-ace user to run specific commands only
-# - For single-user deployments, consider running as non-root (USER open-ace)
 # - In production, use network isolation and limit container privileges
 # - Refer to docker-entrypoint.sh for sudoers configuration details
+USER 1000
 
 # Environment variables (Issue #1192: add LANG/LC_ALL for Unicode support)
 ENV PYTHONUNBUFFERED=1 \
@@ -196,6 +203,11 @@ ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 # =============================================================================
 FROM production AS development
 
+# The development target installs extra tools into /opt/venv (root-owned by
+# the builder stage), so it opts back into root for the build. The default
+# `open-ace:latest` image stays non-root.
+USER root
+
 # Install development tools
 RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple/ --trusted-host mirrors.aliyun.com \
     pytest \
@@ -217,6 +229,11 @@ CMD ["python", "server.py"]
 # Migration Stage (for running database migrations)
 # =============================================================================
 FROM production AS migration
+
+# The migration target is a one-shot init Job (alembic upgrade), not the
+# long-running web image, so it opts back into root to write /entrypoint.sh
+# under / (owned by root). The default `open-ace:latest` image stays non-root.
+USER root
 
 # Create migration entrypoint script
 RUN echo '#!/bin/bash\n\

--- a/Dockerfile
+++ b/Dockerfile
@@ -119,9 +119,14 @@ RUN echo "deb http://mirrors.aliyun.com/debian/ trixie main" > /etc/apt/sources.
 
 # Create non-root user for security. Keep uid/gid stable so Kubernetes
 # runAsUser/runAsGroup can match the filesystem ownership baked into the image.
+# Pre-create /home/open-ace/.open-ace (uid 1000) so the entrypoint's uid-aware
+# default config dir is writable as soon as the container starts, including
+# when docker-compose mounts the `config-data` named volume there: Docker's
+# named-volume init copies existing uid-1000 ownership into the volume on first
+# run, so `mkdir -p`/config generation won't hit Permission denied under uid 1000.
 RUN groupadd -g 1000 open-ace && \
     useradd -u 1000 -g open-ace -d /home/open-ace -s /bin/bash -c "Open ACE user" open-ace && \
-    mkdir -p /home/open-ace && \
+    mkdir -p /home/open-ace/.open-ace && \
     chown -R open-ace:open-ace /home/open-ace
 
 # ============================================================================

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,9 +63,13 @@ services:
       - "host.docker.internal:host-gateway"
     volumes:
       # Config: Use named volume for persistence (Issue #1260)
-      # Entrypoint will auto-generate config.json if not exists
-      # Users can mount custom config: - ./my-config.json:/root/.open-ace/config.json:ro
-      - config-data:/root/.open-ace
+      # Entrypoint will auto-generate config.json if not exists.
+      # Mount under the non-root open-ace user's home (/home/open-ace) so uid
+      # 1000 (the image default, Dockerfile `USER 1000`) can write to it. The
+      # directory is pre-created and chowned in the Dockerfile so Docker's named
+      # volume init copies uid-1000 ownership into the volume on first run.
+      # Users can mount custom config: - ./my-config.json:/home/open-ace/.open-ace/config.json:ro
+      - config-data:/home/open-ace/.open-ace
       - ./logs:/app/logs
       # Workspace data: per-user project directories, persisted across restarts
       - workspace-data:/workspace

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -46,9 +46,20 @@ fi
 # Create logs directory (Issue #1205)
 mkdir -p /app/logs
 
-# Keep the legacy Docker path by default, but let non-root deployments (K8s)
-# mount and write config under the application user's home.
-OPENACE_CONFIG_DIR="${OPENACE_CONFIG_DIR:-/root/.open-ace}"
+# Default the config dir to a path the current uid can actually write.
+# The image runs as the non-root open-ace user (uid 1000) by default
+# (Dockerfile `USER 1000`). /root is root:root 0700, so defaulting to
+# /root/.open-ace made `generate_default_config`'s `mkdir -p /root/.open-ace`
+# fail with Permission denied under `set -e`, breaking bare `docker run` and
+# the default docker-compose single-user path. Pick a writable home-based dir
+# unless the caller overrides OPENACE_CONFIG_DIR (e.g. K8s sets it explicitly).
+if [ -z "${OPENACE_CONFIG_DIR:-}" ]; then
+    if [ "$(id -u)" = "0" ]; then
+        OPENACE_CONFIG_DIR="/root/.open-ace"
+    else
+        OPENACE_CONFIG_DIR="${HOME:-/home/open-ace}/.open-ace"
+    fi
+fi
 OPENACE_CONFIG_FILE="${OPENACE_CONFIG_FILE:-${OPENACE_CONFIG_DIR}/config.json}"
 export OPENACE_CONFIG_DIR OPENACE_CONFIG_FILE
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -5,6 +5,42 @@
 set -e
 
 # ============================================================================
+# 0. Non-root runtime guard (PR #1780 review / docker-root)
+# ============================================================================
+# The image defaults to the non-root open-ace user (uid 1000). Single-user
+# mode works fine as uid 1000. Multi-user workspace mode genuinely needs root
+# (it runs useradd/chown and `sudo -u <user>` across /home), so it must opt
+# back into root explicitly via OPENACE_ALLOW_ROOT_MULTI_USER=1 AND run as
+# uid 0 (`docker run --user 0` / manifest `runAsUser: 0`). Fail fast instead
+# of silently swallowing the useradd/chown permission errors that a naive
+# non-root multi-user deployment would hit.
+require_root_for_multi_user() {
+    if [ "$(id -u)" != "0" ]; then
+        echo "ERROR: multi-user workspace mode requires root to create system users."
+        echo "       The image defaults to the non-root open-ace user (uid 1000)."
+        echo "       To run multi-user mode, start the container as root AND set"
+        echo "       OPENACE_ALLOW_ROOT_MULTI_USER=1, e.g.:"
+        echo "         docker run --user 0 -e OPENACE_ALLOW_ROOT_MULTI_USER=1 ..."
+        echo "       or set runAsUser: 0 in your manifest. Otherwise keep"
+        echo "       single-user mode (the default)."
+        exit 1
+    fi
+    if [ "${OPENACE_ALLOW_ROOT_MULTI_USER}" != "1" ]; then
+        echo "ERROR: multi-user workspace mode is running as root but the explicit"
+        echo "       opt-in OPENACE_ALLOW_ROOT_MULTI_USER=1 is not set."
+        echo "       Set OPENACE_ALLOW_ROOT_MULTI_USER=1 (and run as uid 0) to"
+        echo "       acknowledge that multi-user mode requires root, or keep"
+        echo "       single-user mode (the default, non-root)."
+        exit 1
+    fi
+}
+
+# Early fail-fast for the env-var trigger (before any setup work runs).
+if [ "${WORKSPACE_MULTI_USER_MODE}" = "true" ]; then
+    require_root_for_multi_user
+fi
+
+# ============================================================================
 # 0. Pre-flight Setup
 # ============================================================================
 # Create logs directory (Issue #1205)
@@ -421,6 +457,9 @@ fi
 
 if [ "$WORKSPACE_MULTI_USER_MODE" = "true" ] || [ "$CONFIG_MULTI_USER" = "true" ]; then
     echo "Configuring multi-user workspace mode (env=$WORKSPACE_MULTI_USER_MODE, config=$CONFIG_MULTI_USER)..."
+    # Fail fast if multi-user mode was enabled via config.json but the container
+    # is not running as root with the explicit opt-in (see top-of-file guard).
+    require_root_for_multi_user
 
     # Ensure workspace base directory exists
     WORKSPACE_DIR="${WORKSPACE_BASE_DIR:-/workspace}"

--- a/docs/cn/DEPLOYMENT.md
+++ b/docs/cn/DEPLOYMENT.md
@@ -45,6 +45,28 @@ python3 server.py
 - Open ACE Docker 镜像（`open-ace:latest`）
 - PostgreSQL 镜像（`postgres:15-alpine`）
 
+### 非 root 运行（默认）
+
+Open ACE 镜像默认以非 root 用户 `open-ace`（uid 1000）运行。生产阶段中的
+`USER 1000` 指令意味着 `docker run`、docker-compose 与 Kubernetes 都会以
+uid 1000 执行入口脚本，而不再仅依赖清单中的 `securityContext`。uid/gid 1000
+是稳定的，并与镜像中内置的文件属主、K8s 的 `runAsUser`/`runAsGroup: 1000`
+保持一致。
+
+多用户工作区模式（`WORKSPACE_MULTI_USER_MODE=true` 或配置中的
+`workspace.multi_user_mode: true`）确实需要 root——它会创建系统用户
+（`useradd`）、修复属主（`chown`）并在 `/home` 下切换身份
+（`sudo -u <user>`）。多用户部署必须显式回退到 root：
+
+```bash
+docker run --user 0 -e WORKSPACE_MULTI_USER_MODE=true \
+  -e OPENACE_ALLOW_ROOT_MULTI_USER=1 ...
+```
+
+必须同时设置 `--user 0`（或清单中的 `runAsUser: 0`）与
+`OPENACE_ALLOW_ROOT_MULTI_USER=1`，否则入口脚本会以清晰的错误信息退出，
+而不是默默吞掉非 root 多用户部署会遇到的 `useradd`/`chown` 权限失败。
+
 ### 初始部署
 
 ```bash

--- a/docs/cn/KUBERNETES.md
+++ b/docs/cn/KUBERNETES.md
@@ -61,7 +61,7 @@ k8s/
 
 **粘性路由：** Service 使用 `sessionAffinity: ClientIP`，nginx Ingress 使用 cookie affinity。远程会话 HTTP 控制态已经持久化并可跨 Pod，但实时终端 relay WebSocket bridge 仍属于单个 Web 进程；对活跃终端会话而言，粘性路由仍是最稳妥的默认配置。
 
-**多用户工作区说明：** 默认 Kubernetes 清单以非 root 用户运行 Web 容器。如果启用 `workspace.multi_user_mode` 且需要在容器内动态创建 Linux 用户，请使用专门的 overlay 显式让 Web Pod 以 root 运行，并在集群变更流程中记录该例外。
+**多用户工作区说明：** Docker 镜像本身通过 `USER 1000` 指令默认以非 root 用户 `open-ace`（uid 1000）运行，默认 Kubernetes 清单也通过 `runAsNonRoot: true` / `runAsUser: 1000` 予以加强。如果启用 `workspace.multi_user_mode` 且需要在容器内动态创建 Linux 用户，请使用专门的 overlay 显式让 Web Pod 以 root 运行（`runAsUser: 0`）**并** 设置 `OPENACE_ALLOW_ROOT_MULTI_USER=1`；入口脚本在缺少两者之一时会直接报错退出，并请在集群变更流程中记录该例外。
 
 ### Service 与 Ingress
 

--- a/docs/en/DEPLOYMENT.md
+++ b/docs/en/DEPLOYMENT.md
@@ -45,6 +45,31 @@ python3 server.py
 - Open ACE Docker image (`open-ace:latest`)
 - PostgreSQL image (`postgres:15-alpine`)
 
+### Non-root runtime (default)
+
+The Open ACE image runs as the non-root `open-ace` user (uid 1000) by default.
+A `USER 1000` directive in the production stage means `docker run`,
+docker-compose, and Kubernetes all execute the entrypoint as uid 1000 without
+relying solely on a manifest `securityContext`. The uid/gid 1000 is stable and
+matches the filesystem ownership baked into the image and the K8s
+`runAsUser`/`runAsGroup: 1000`.
+
+Multi-user workspace mode (`WORKSPACE_MULTI_USER_MODE=true` or
+`workspace.multi_user_mode: true` in config) genuinely needs root — it creates
+system users (`useradd`), fixes ownership (`chown`), and switches identity
+(`sudo -u <user>`) across `/home`. For multi-user deployments you must opt back
+into root explicitly:
+
+```bash
+docker run --user 0 -e WORKSPACE_MULTI_USER_MODE=true \
+  -e OPENACE_ALLOW_ROOT_MULTI_USER=1 ...
+```
+
+Without both `--user 0` (or manifest `runAsUser: 0`) and
+`OPENACE_ALLOW_ROOT_MULTI_USER=1`, the entrypoint exits with a clear error
+rather than silently swallowing the `useradd`/`chown` permission failures that
+a naive non-root multi-user deployment would hit.
+
 ### Initial Deployment
 
 ```bash

--- a/docs/en/KUBERNETES.md
+++ b/docs/en/KUBERNETES.md
@@ -61,7 +61,7 @@ Creates the `open-ace` namespace with standard Kubernetes labels.
 
 **Sticky routing:** The Service uses `sessionAffinity: ClientIP`, and the nginx Ingress uses cookie affinity. Remote session HTTP control state is persisted and can cross pods, but live terminal relay WebSocket bridges still belong to one web process; sticky routing remains the safest default for active terminal sessions.
 
-**Multi-user workspace note:** The default Kubernetes manifest runs the web container as a non-root user. If you enable `workspace.multi_user_mode` and need dynamic Linux user creation inside the container, deploy a dedicated overlay that intentionally runs the web pod as root and document that exception in your cluster change process.
+**Multi-user workspace note:** The Docker image itself defaults to the non-root `open-ace` user (uid 1000) via a `USER 1000` directive, and the default Kubernetes manifest reinforces this with `runAsNonRoot: true` / `runAsUser: 1000`. If you enable `workspace.multi_user_mode` and need dynamic Linux user creation inside the container, deploy a dedicated overlay that intentionally runs the web pod as root (`runAsUser: 0`) **and** sets `OPENACE_ALLOW_ROOT_MULTI_USER=1`; the entrypoint fail-fasts without both, and you should document that exception in your cluster change process.
 
 ### Service & Ingress
 

--- a/tests/issues/1748/test_deployment_alignment.py
+++ b/tests/issues/1748/test_deployment_alignment.py
@@ -143,7 +143,6 @@ import os as _os
 import re as _re
 import subprocess as _subprocess
 
-
 _CONFIG_DIR_BLOCK_RE = _re.compile(
     r'if \[ -z "\$\{OPENACE_CONFIG_DIR:-\}" \]; then.*?\nfi',
     _re.DOTALL,
@@ -172,10 +171,7 @@ def _run_entrypoint_block(block, env, id_u):
             full_env[key] = value
 
     # id() returns the stubbed uid for `-u`, delegates to the real binary otherwise.
-    id_shim = (
-        'id() { if [ "$1" = "-u" ]; then echo "%s"; else command id "$@"; fi; }'
-        % id_u
-    )
+    id_shim = 'id() { if [ "$1" = "-u" ]; then echo "%s"; else command id "$@"; fi; }' % id_u
     print_shim = 'printf %s "$OPENACE_CONFIG_DIR"'
     script = "\n".join([id_shim, block, print_shim])
 
@@ -185,8 +181,9 @@ def _run_entrypoint_block(block, env, id_u):
         text=True,
         env=full_env,
     )
-    assert proc.returncode == 0, (
-        "entrypoint block exited %d: stderr=%r" % (proc.returncode, proc.stderr)
+    assert proc.returncode == 0, "entrypoint block exited %d: stderr=%r" % (
+        proc.returncode,
+        proc.stderr,
     )
     return proc.stdout
 
@@ -196,9 +193,9 @@ class TestEntrypointNonRootConfigDirDefault:
 
     def test_uid_aware_branch_exists(self):
         entrypoint = (ROOT / "docker-entrypoint.sh").read_text(encoding="utf-8")
-        assert '"$(id -u)" = "0"' in entrypoint, (
-            "entrypoint must branch the config dir default on the runtime uid"
-        )
+        assert (
+            '"$(id -u)" = "0"' in entrypoint
+        ), "entrypoint must branch the config dir default on the runtime uid"
 
     def test_no_unguarded_root_default(self):
         """Every non-comment /root/.open-ace literal must sit inside the
@@ -215,19 +212,15 @@ class TestEntrypointNonRootConfigDirDefault:
             preceding = "\n".join(entrypoint.splitlines()[:lineno])
             assert '"$(id -u)" = "0"' in preceding, (
                 "/root/.open-ace in code at line %d is not behind the root-only "
-                "branch; non-root startup would default to an unwritable path."
-                % lineno
+                "branch; non-root startup would default to an unwritable path." % lineno
             )
 
     def test_non_root_uid_resolves_home_based_default(self):
         entrypoint = (ROOT / "docker-entrypoint.sh").read_text(encoding="utf-8")
         block = _extract_config_dir_default_block(entrypoint)
-        result = _run_entrypoint_block(
-            block, env={"HOME": "/home/open-ace"}, id_u="1000"
-        )
+        result = _run_entrypoint_block(block, env={"HOME": "/home/open-ace"}, id_u="1000")
         assert result == "/home/open-ace/.open-ace", (
-            "non-root default config dir should be /home/open-ace/.open-ace, "
-            "got %r" % result
+            "non-root default config dir should be /home/open-ace/.open-ace, " "got %r" % result
         )
 
     def test_root_uid_keeps_legacy_root_default(self):
@@ -255,8 +248,7 @@ class TestEntrypointNonRootConfigDirDefault:
         block = _extract_config_dir_default_block(entrypoint)
         result = _run_entrypoint_block(block, env={}, id_u="1000")
         assert result == "/home/open-ace/.open-ace", (
-            "missing HOME should fall back to /home/open-ace/.open-ace, "
-            "got %r" % result
+            "missing HOME should fall back to /home/open-ace/.open-ace, " "got %r" % result
         )
 
 

--- a/tests/issues/1748/test_deployment_alignment.py
+++ b/tests/issues/1748/test_deployment_alignment.py
@@ -82,6 +82,39 @@ class TestComposeSunset:
         assert "./ssl:/etc/nginx/ssl:ro" not in compose
 
 
+class TestDockerImageDefaultsToNonRoot:
+    def test_dockerfile_sets_non_root_user_directive(self):
+        """The image must default to non-root everywhere, not only under K8s.
+
+        Regression for PR #1780 review: image had no USER directive so
+        `docker run` executed as root even though deployment.yaml set 1000.
+        """
+        dockerfile = (ROOT / "Dockerfile").read_text(encoding="utf-8")
+        # Strip comment lines so the line-172 suggestion comment doesn't false-pass.
+        lines = [
+            ln for ln in dockerfile.splitlines() if ln.strip() and not ln.lstrip().startswith("#")
+        ]
+        body = "\n".join(lines)
+        # Require an active USER directive naming the non-root user or its uid.
+        assert re.search(r"^USER\s+(open-ace|1000)\s*$", body, re.MULTILINE), (
+            "Dockerfile must declare `USER open-ace` (or `USER 1000`) in the "
+            "production stage so the image is non-root by default, not just "
+            "under the K8s manifest."
+        )
+
+    def test_dockerfile_non_root_user_matches_manifest_uid(self):
+        """If the image sets USER <uid>, it must match deployment.yaml runAsUser."""
+        dockerfile = (ROOT / "Dockerfile").read_text(encoding="utf-8")
+        deployment = (ROOT / "k8s" / "deployment.yaml").read_text(encoding="utf-8")
+        m = re.search(r"runAsUser:\s*(\d+)", deployment)
+        assert m, "deployment.yaml must set runAsUser"
+        manifest_uid = m.group(1)
+        # The image must not contradict the manifest (either name or same uid).
+        assert re.search(
+            rf"^USER\s+(open-ace|{manifest_uid})\s*$", dockerfile, re.MULTILINE
+        ), f"Dockerfile USER directive must resolve to uid {manifest_uid}"
+
+
 class TestDockerEntrypointDefaults:
     def test_generated_config_enables_autonomous_by_default(self):
         entrypoint = (ROOT / "docker-entrypoint.sh").read_text(encoding="utf-8")

--- a/tests/issues/1748/test_deployment_alignment.py
+++ b/tests/issues/1748/test_deployment_alignment.py
@@ -128,3 +128,159 @@ class TestDockerEntrypointDefaults:
         assert (
             'DEFAULT_WORKSPACE_MULTI_USER_MODE="${WORKSPACE_MULTI_USER_MODE:-false}"' in entrypoint
         )
+
+
+# ============================================================================
+# Regression tests for PR #1797: non-root (USER 1000) startup path.
+# ============================================================================
+# The image defaults to the non-root open-ace user (uid 1000). Before the fix,
+# docker-entrypoint.sh hardcoded `OPENACE_CONFIG_DIR="${OPENACE_CONFIG_DIR:-/root/.open-ace}"`.
+# Under uid 1000, /root is root:root 0700, so `generate_default_config`'s
+# `mkdir -p /root/.open-ace` hit Permission denied and, with `set -e`, the
+# container exited on startup. These tests guard that path so CI catches the
+# regression instead of only static-Dockerfile checks (which stayed green).
+import os as _os
+import re as _re
+import subprocess as _subprocess
+
+
+_CONFIG_DIR_BLOCK_RE = _re.compile(
+    r'if \[ -z "\$\{OPENACE_CONFIG_DIR:-\}" \]; then.*?\nfi',
+    _re.DOTALL,
+)
+
+
+def _extract_config_dir_default_block(entrypoint_src):
+    """Pull the OPENACE_CONFIG_DIR default-resolution `if ... fi` block out of
+    the entrypoint so tests can eval just that logic without sourcing the whole
+    script (which needs node/gh/postgres and runs mkdir)."""
+    m = _CONFIG_DIR_BLOCK_RE.search(entrypoint_src)
+    assert m, "Could not find OPENACE_CONFIG_DIR default block in entrypoint"
+    return m.group(0)
+
+
+def _run_entrypoint_block(block, env, id_u):
+    """Eval the extracted default-resolution block under a stubbed `id -u` and
+    return the resolved OPENACE_CONFIG_DIR.
+
+    The block calls `$(id -u)`; we redefine `id` as a shell function so the test
+    is deterministic regardless of the host runner's real uid. Only the env
+    keys the caller passed are exported (so an unset HOME stays unset)."""
+    full_env = {"PATH": _os.environ.get("PATH", "/usr/bin:/bin")}
+    for key, value in env.items():
+        if value is not None:
+            full_env[key] = value
+
+    # id() returns the stubbed uid for `-u`, delegates to the real binary otherwise.
+    id_shim = (
+        'id() { if [ "$1" = "-u" ]; then echo "%s"; else command id "$@"; fi; }'
+        % id_u
+    )
+    print_shim = 'printf %s "$OPENACE_CONFIG_DIR"'
+    script = "\n".join([id_shim, block, print_shim])
+
+    proc = _subprocess.run(
+        ["bash", "-c", script],
+        capture_output=True,
+        text=True,
+        env=full_env,
+    )
+    assert proc.returncode == 0, (
+        "entrypoint block exited %d: stderr=%r" % (proc.returncode, proc.stderr)
+    )
+    return proc.stdout
+
+
+class TestEntrypointNonRootConfigDirDefault:
+    """The config dir default must be writable by the runtime uid."""
+
+    def test_uid_aware_branch_exists(self):
+        entrypoint = (ROOT / "docker-entrypoint.sh").read_text(encoding="utf-8")
+        assert '"$(id -u)" = "0"' in entrypoint, (
+            "entrypoint must branch the config dir default on the runtime uid"
+        )
+
+    def test_no_unguarded_root_default(self):
+        """Every non-comment /root/.open-ace literal must sit inside the
+        root-only branch. (Occurrences inside `#` comments are explanatory and
+        are ignored.)"""
+        entrypoint = (ROOT / "docker-entrypoint.sh").read_text(encoding="utf-8")
+        for lineno, line in enumerate(entrypoint.splitlines(), start=1):
+            if "/root/.open-ace" not in line:
+                continue
+            stripped = line.lstrip()
+            if stripped.startswith("#"):
+                continue  # explanatory comment, not a code default
+            # Code occurrences must be guarded by the root-only uid branch.
+            preceding = "\n".join(entrypoint.splitlines()[:lineno])
+            assert '"$(id -u)" = "0"' in preceding, (
+                "/root/.open-ace in code at line %d is not behind the root-only "
+                "branch; non-root startup would default to an unwritable path."
+                % lineno
+            )
+
+    def test_non_root_uid_resolves_home_based_default(self):
+        entrypoint = (ROOT / "docker-entrypoint.sh").read_text(encoding="utf-8")
+        block = _extract_config_dir_default_block(entrypoint)
+        result = _run_entrypoint_block(
+            block, env={"HOME": "/home/open-ace"}, id_u="1000"
+        )
+        assert result == "/home/open-ace/.open-ace", (
+            "non-root default config dir should be /home/open-ace/.open-ace, "
+            "got %r" % result
+        )
+
+    def test_root_uid_keeps_legacy_root_default(self):
+        entrypoint = (ROOT / "docker-entrypoint.sh").read_text(encoding="utf-8")
+        block = _extract_config_dir_default_block(entrypoint)
+        result = _run_entrypoint_block(block, env={"HOME": "/root"}, id_u="0")
+        assert result == "/root/.open-ace", (
+            "root default config dir should stay /root/.open-ace, got %r" % result
+        )
+
+    def test_explicit_override_is_respected(self):
+        entrypoint = (ROOT / "docker-entrypoint.sh").read_text(encoding="utf-8")
+        block = _extract_config_dir_default_block(entrypoint)
+        result = _run_entrypoint_block(
+            block,
+            env={"HOME": "/home/open-ace", "OPENACE_CONFIG_DIR": "/custom/cfg"},
+            id_u="1000",
+        )
+        assert result == "/custom/cfg", (
+            "explicit OPENACE_CONFIG_DIR override ignored, got %r" % result
+        )
+
+    def test_home_fallback_when_unset(self):
+        entrypoint = (ROOT / "docker-entrypoint.sh").read_text(encoding="utf-8")
+        block = _extract_config_dir_default_block(entrypoint)
+        result = _run_entrypoint_block(block, env={}, id_u="1000")
+        assert result == "/home/open-ace/.open-ace", (
+            "missing HOME should fall back to /home/open-ace/.open-ace, "
+            "got %r" % result
+        )
+
+
+class TestComposeConfigVolumeWritableByNonRoot:
+    """docker-compose must mount the config volume where uid 1000 can write."""
+
+    def test_config_volume_mounted_under_non_root_home(self):
+        compose = (ROOT / "docker-compose.yml").read_text(encoding="utf-8")
+        assert "config-data:/root/.open-ace" not in compose, (
+            "docker-compose still mounts config-data to /root/.open-ace, which "
+            "uid 1000 (image default) cannot write."
+        )
+        assert "config-data:/home/open-ace/.open-ace" in compose, (
+            "docker-compose must mount config-data under /home/open-ace/.open-ace "
+            "so the non-root user can persist generated config.json."
+        )
+
+    def test_dockerfile_precreates_non_root_config_dir(self):
+        """The image must pre-create + chown the non-root config dir so the
+        named-volume mount is writable on first run."""
+        dockerfile = (ROOT / "Dockerfile").read_text(encoding="utf-8")
+        assert _re.search(
+            r"mkdir -p /home/open-ace/\.open-ace", dockerfile
+        ), "Dockerfile must pre-create /home/open-ace/.open-ace"
+        assert _re.search(
+            r"chown -R open-ace:open-ace /home/open-ace\b", dockerfile
+        ), "Dockerfile must chown /home/open-ace to open-ace"


### PR DESCRIPTION
## Root cause

The production Docker stage created the `open-ace` user (uid/gid 1000) and chowned `/app` to it, but never declared `USER`. As a result `docker run`, docker-compose, and any manifest omitting `securityContext` all executed the entrypoint as **root**. Non-root was enforced only at the Kubernetes layer (`k8s/deployment.yaml` `runAsUser: 1000`), so the image itself was brittle: any future manifest/helm chart/compose file that forgot `securityContext` silently fell back to root, and the image did not protect itself.

## Fix

- **`Dockerfile`**: add `USER 1000` to the production stage so the image defaults to non-root everywhere. The numeric form works even if name resolution is stripped, and uid 1000 matches the stable user created by `groupadd -g 1000`/`useradd -u 1000`, the `COPY --chown` ownership, and the K8s `runAsUser`/`runAsGroup: 1000`.
- **`docker-entrypoint.sh`**: multi-user workspace mode genuinely needs root (`useradd`/`chown`/`sudo -u <user>` across `/home`). Instead of leaving the whole image root-by-default, the entrypoint now **fail-fasts** with a clear error unless the deployment opts back into root via uid 0 (`docker run --user 0` / manifest `runAsUser: 0`) **and** `OPENACE_ALLOW_ROOT_MULTI_USER=1`. This also resolves the Medium finding about silent `useradd` failures.
- **`Dockerfile` dev/migration targets**: these are one-shot init/dev targets (not the default image) and need root for their build steps (`pip install` into root-owned `/opt/venv`, writing `/entrypoint.sh` under `/`), so they opt back into `USER root` explicitly. The default `open-ace:latest` image stays non-root.
- **Docs/CHANGELOG**: `docs/{en,cn}/DEPLOYMENT.md` and `KUBERNETES.md` now state the **image** runs non-root by default, with multi-user mode as the documented, fail-fast exception. `k8s/deployment.yaml` is left unchanged (it now agrees with the image default rather than diverging).

## TDD test added

`TestDockerImageDefaultsToNonRoot` in `tests/issues/1748/test_deployment_alignment.py`:
- `test_dockerfile_sets_non_root_user_directive` — strips comment lines and asserts an active `USER open-ace` / `USER 1000` directive exists (the line-172 suggestion comment can no longer false-pass).
- `test_dockerfile_non_root_user_matches_manifest_uid` — asserts the `USER` uid resolves to the `runAsUser` in `deployment.yaml`.

Both **failed before** the fix (no active `USER` line) and **pass after** adding `USER 1000`. The existing `test_deployment_manifest_preserves_ha_and_non_root_runtime_contract` only pinned the K8s contract — this fills the gap that let the finding ship.

Net effect: `docker run` / docker-compose / K8s all default to non-root; multi-user mode is an explicit, documented, fail-fast escalation instead of a silent root default.

Addresses review findings on #1780.