### PR TITLE
fix(high): make remote output event_index assignment atomic

### DIFF
--- a/app/modules/workspace/remote_agent_manager.py
+++ b/app/modules/workspace/remote_agent_manager.py
@@ -9,6 +9,7 @@ command dispatching, and message routing for remote workspace sessions.
 
 import json
 import logging
+import sqlite3
 import threading
 import time
 import uuid
@@ -29,6 +30,28 @@ from app.modules.workspace.agent_token import (
 from app.repositories.database import DB_PATH, Database, adapt_boolean_value, is_postgresql
 
 logger = logging.getLogger(__name__)
+
+# Bounded retry count for the event_index allocation race. Concurrent producers
+# can both read the same MAX(event_index)+1; the UNIQUE(session_id, event_index)
+# constraint then rejects the second INSERT. We re-read MAX+1 and retry rather
+# than dropping the output chunk.
+_PERSIST_OUTPUT_MAX_RETRIES = 8
+
+
+def _is_unique_violation(exc: Exception) -> bool:
+    """Return True if ``exc`` is a uniqueness-constraint violation.
+
+    Covers both SQLite (``sqlite3.IntegrityError``) and PostgreSQL
+    (``psycopg2.errors.UniqueViolation``). We avoid importing psycopg2 at module
+    load time (it is optional in SQLite-only dev) and instead match by name.
+    """
+    if isinstance(exc, sqlite3.IntegrityError):
+        return True
+    # psycopg2.errors.UniqueViolation (and its pgcode 23505 on the base Error).
+    pgcode = getattr(exc, "pgcode", None) or getattr(getattr(exc, "diag", None), "sqlstate", None)
+    if pgcode == "23505":
+        return True
+    return type(exc).__name__ == "UniqueViolation"
 
 
 def _param() -> str:
@@ -118,6 +141,10 @@ class RemoteAgentManager:
         self._pending_requests: dict[str, dict] = {}
         # Lock for gevent coroutine safety
         self._lock = Semaphore(1)
+        # Serializes the _persist_output read-modify-write on event_index within
+        # this process. Cross-process/cross-pod collisions are handled by the
+        # uniqueness-constraint retry loop in _persist_output.
+        self._persist_output_lock = threading.Lock()
         # Token cleanup lazy-start flag
         self._token_cleanup_started: bool = False
         # (removed _last_rotate_unrevoked — rotate_agent_token now returns the info)
@@ -1427,39 +1454,98 @@ class RemoteAgentManager:
             return list(buf)[effective_index:]
 
     def _persist_output(self, session_id: str, output: dict[str, Any]) -> None:
-        """Persist stream output for cross-pod SSE replay and restart recovery."""
+        """Persist stream output for cross-pod SSE replay and restart recovery.
+
+        event_index is allocated per session via ``MAX(event_index)+1``. Under
+        concurrent producers (the multi-pod topology enabled by PR #1790) two
+        writers can read the same next index and the UNIQUE(session_id,
+        event_index) constraint rejects the second INSERT. Rather than swallow
+        that IntegrityError at debug level (which silently drops the output
+        chunk), we serialize the read-modify-write at the DB level and retry on
+        the rare collision: on SQLite we open an ``IMMEDIATE`` transaction (the
+        DB-wide write lock serializes SELECT+INSERT), on PostgreSQL we take a
+        transaction-scoped advisory lock keyed on the session. A per-process
+        lock additionally coalesces in-process producers so the common case
+        needs one attempt.
+        """
         now = datetime.now(timezone.utc).replace(tzinfo=None)
-        try:
-            with self.db.connection() as conn:
-                cursor = conn.cursor()
-                cursor.execute(
-                    f"""
-                    SELECT COALESCE(MAX(event_index), 0) + 1 AS next_index
-                    FROM remote_runtime_outputs
-                    WHERE session_id = {_param()}
-                    """,
-                    (session_id,),
-                )
-                row = cursor.fetchone()
-                event_index = int(row["next_index"] if row else 1)
-                cursor.execute(
-                    f"""
-                    INSERT INTO remote_runtime_outputs
-                    (session_id, event_index, stream, payload, created_at, expires_at)
-                    VALUES ({_params(6)})
-                    """,
-                    (
-                        session_id,
-                        event_index,
-                        str(output.get("stream", "stdout")),
-                        json.dumps(output),
-                        now.isoformat(),
-                        (now + timedelta(seconds=self.OUTPUT_RETENTION_SECONDS)).isoformat(),
-                    ),
-                )
-                conn.commit()
-        except Exception as e:
-            logger.debug("Failed to persist output for session %s: %s", session_id[:8], e)
+        payload = json.dumps(output)
+        stream = str(output.get("stream", "stdout"))
+        expires_at = (now + timedelta(seconds=self.OUTPUT_RETENTION_SECONDS)).isoformat()
+        # Serialize the read-modify-write within this process; the DB-level
+        # lock below handles cross-process/cross-pod collisions.
+        with self._persist_output_lock:
+            last_exc: Exception | None = None
+            for _attempt in range(_PERSIST_OUTPUT_MAX_RETRIES):
+                try:
+                    with self.db.connection() as conn:
+                        cursor = conn.cursor()
+                        if is_postgresql():
+                            # Transaction-scoped advisory lock keyed on the
+                            # session id hash; held until COMMIT/ROLLBACK.
+                            cursor.execute(
+                                "SELECT pg_advisory_xact_lock(hashtext(%s))",
+                                (session_id,),
+                            )
+                            cursor.fetchone()
+                        else:
+                            # SQLite: acquire the write lock BEFORE the SELECT so
+                            # the read-modify-write is serialized across
+                            # connections (default deferred transactions would
+                            # let two readers see the same MAX).
+                            cursor.execute("BEGIN IMMEDIATE")
+                        # Re-read on EVERY attempt so a retried insert does not
+                        # reuse a stale index.
+                        cursor.execute(
+                            f"""
+                            SELECT COALESCE(MAX(event_index), 0) + 1 AS next_index
+                            FROM remote_runtime_outputs
+                            WHERE session_id = {_param()}
+                            """,
+                            (session_id,),
+                        )
+                        row = cursor.fetchone()
+                        event_index = int(row["next_index"] if row else 1)
+                        cursor.execute(
+                            f"""
+                            INSERT INTO remote_runtime_outputs
+                            (session_id, event_index, stream, payload, created_at, expires_at)
+                            VALUES ({_params(6)})
+                            """,
+                            (
+                                session_id,
+                                event_index,
+                                stream,
+                                payload,
+                                now.isoformat(),
+                                expires_at,
+                            ),
+                        )
+                        conn.commit()
+                    return
+                except Exception as e:
+                    if _is_unique_violation(e):
+                        # Lost the event_index race against a concurrent producer;
+                        # roll back and retry with a freshly re-read index.
+                        last_exc = e
+                        continue
+                    # Unexpected failure: do NOT swallow at debug level (the old
+                    # behavior hid real outages). Surface it so callers/ops see it.
+                    logger.warning(
+                        "Failed to persist output for session %s: %s",
+                        session_id[:8],
+                        e,
+                    )
+                    raise
+        # Exhausted retries on a uniqueness collision. Log at error (not debug)
+        # and re-raise so the failure is visible instead of silently dropping output.
+        logger.error(
+            "Could not allocate event_index for session %s after %d retries: %s",
+            session_id[:8],
+            _PERSIST_OUTPUT_MAX_RETRIES,
+            last_exc,
+        )
+        raise last_exc  # type: ignore[misc]
 
     def _get_persisted_output(self, session_id: str, after_index: int = 0) -> list[dict]:
         """Read persisted output events after the delivered event index."""

--- a/tests/issues/1790/test_remote_output_event_index_race.py
+++ b/tests/issues/1790/test_remote_output_event_index_race.py
@@ -1,0 +1,206 @@
+"""Regression tests for the event-index read-modify-write race in
+``RemoteAgentManager._persist_output`` (PR #1790).
+
+Two concurrent producers buffering output for one session both read the same
+``MAX(event_index) + 1`` and the second INSERT violates
+``uq_remote_runtime_outputs_session_index UNIQUE (session_id, event_index)``.
+On current main the resulting IntegrityError is swallowed at debug level and the
+output chunk is silently dropped.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import threading
+from contextlib import contextmanager
+
+import pytest
+
+from app.modules.workspace import remote_agent_manager as ram_mod
+from app.modules.workspace.remote_agent_manager import RemoteAgentManager
+from app.repositories.schema_init import load_schema_from_file
+
+
+class _UniqueViolationError(Exception):
+    """Stand-in for a psycopg2 UniqueViolation that the production code must retry on."""
+
+    pgcode = "23505"  # matches psycopg2.errors.UniqueViolation.pgcode
+
+
+class _MockCursor:
+    """Cursor that deterministically reproduces the race.
+
+    The first two concurrent ``SELECT MAX`` calls both return the *same* stale
+    value, and the INSERT that follows raises a uniqueness violation when it
+    tries to reuse an already-allocated index. This mirrors what Postgres does
+    under two overlapping producers without any row lock, and does NOT depend on
+    SQLite's whole-DB write lock (which would incidentally hide the bug).
+    """
+
+    def __init__(self, taken_indices: set[int], max_index: int = 0) -> None:
+        self._taken = taken_indices
+        self._max = max_index
+
+    def execute(self, sql: str, params=()):  # noqa: D401
+        upper = sql.strip().upper()
+        if upper.startswith("SELECT") and "MAX(EVENT_INDEX)" in upper:
+            # Stale read: every caller sees the same next index.
+            self._max = self._max  # noqa: B018 - intentionally not advanced
+            self._result = [{"next_index": self._max + 1}]
+        elif upper.startswith("INSERT INTO REMOTE_RUNTIME_OUTPUTS"):
+            # params = (session_id, event_index, stream, payload, created_at, expires_at)
+            event_index = int(params[1])
+            if event_index in self._taken:
+                # Collision: another producer already holds this index, so the
+                # committed MAX has advanced past it. Reflect that so a re-read
+                # yields a fresh index (mirrors the real DB after a retry).
+                self._max = max(self._max, event_index)
+                raise _UniqueViolationError(f"duplicate (session_id, event_index={event_index})")
+            self._taken.add(event_index)
+            self._max = max(self._max, event_index)
+            self._result = []
+        else:
+            self._result = []
+
+    def fetchone(self):
+        return self._result[0] if self._result else None
+
+    def fetchall(self):
+        return self._result
+
+    def close(self):  # noqa: D401
+        return None
+
+
+class _MockConnection:
+    def __init__(self, cursor: _MockCursor) -> None:
+        self._cursor = cursor
+
+    def cursor(self, cursor_factory=None):
+        return self._cursor
+
+    def commit(self):
+        return None
+
+    def rollback(self):
+        return None
+
+    def close(self):
+        return None
+
+
+class _MockDatabase:
+    """Database stub whose ``connection()`` yields a shared non-serializing cursor."""
+
+    def __init__(self) -> None:
+        self.cursor = _MockCursor(taken_indices=set(), max_index=0)
+
+    @contextmanager
+    def connection(self):
+        yield _MockConnection(self.cursor)
+
+
+def _make_manager(monkeypatch) -> RemoteAgentManager:
+    monkeypatch.setattr(ram_mod, "is_postgresql", lambda: False)
+    monkeypatch.setattr(RemoteAgentManager, "_start_heartbeat_monitor", lambda self: None)
+    # Real on-disk DB just so RemoteAgentManager construction succeeds; _persist_output
+    # is the only path exercised here, and we redirect it to the mock below.
+    import tempfile
+    from pathlib import Path
+
+    tmp = Path(tempfile.mkdtemp()) / "runtime.db"
+    load_schema_from_file(db_url=f"sqlite:///{tmp}", dialect="sqlite")
+    mgr = RemoteAgentManager(db_path=str(tmp))
+    mgr.db = _MockDatabase()
+    return mgr
+
+
+def test_persist_output_does_not_drop_event_on_unique_violation(monkeypatch):
+    """A uniqueness collision must be retried, never silently dropped.
+
+    The mock cursor hands the SAME next_index to two sequential _persist_output
+    calls and raises a uniqueness violation on the colliding INSERT. After the
+    fix, _persist_output must re-read MAX+1 and succeed; on buggy main it swallows
+    the error and the event is lost.
+    """
+    mgr = _make_manager(monkeypatch)
+    mgr.buffer_output("session-race", {"stream": "stdout", "data": "first"})
+    # Force the second call to collide with the first's index (1) before the retry.
+    # _make_manager starts max_index=0 so first call took index 1; reset the cursor's
+    # max to 0 so the second call also computes next_index=1 and collides.
+    mgr.db.cursor._max = 0  # type: ignore[attr-defined]
+
+    # After the fix this must NOT raise and must persist successfully.
+    mgr.buffer_output("session-race", {"stream": "stdout", "data": "second"})
+
+    taken = mgr.db.cursor._taken  # type: ignore[attr-defined]
+    assert {1, 2} == taken, f"expected both indices persisted, got {sorted(taken)}"
+
+
+def test_persist_output_propagates_unexpected_errors(monkeypatch):
+    """Truly unexpected errors must not be swallowed at debug level.
+
+    A non-uniqueness failure (e.g. the DB disappearing) should surface rather than
+    be silently logged. On buggy main ``except Exception`` swallows everything.
+    """
+
+    class _ExplodingCursor(_MockCursor):
+        def execute(self, sql, params=()):
+            raise RuntimeError("connection lost")
+
+    mgr = _make_manager(monkeypatch)
+    mgr.db.cursor = _ExplodingCursor(taken_indices=set())  # type: ignore[attr-defined]
+
+    with pytest.raises(RuntimeError):
+        mgr.buffer_output("session-race", {"stream": "stdout", "data": "boom"})
+
+
+# ---------------------------------------------------------------------------
+# Secondary test: real SQLite concurrency (incidentally serialized, but a guard).
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def runtime_db(tmp_path, monkeypatch):
+    monkeypatch.setattr(ram_mod, "is_postgresql", lambda: False)
+    monkeypatch.setattr(RemoteAgentManager, "_start_heartbeat_monitor", lambda self: None)
+    db_path = tmp_path / "remote_runtime.db"
+    load_schema_from_file(db_url=f"sqlite:///{db_path}", dialect="sqlite")
+    return db_path
+
+
+def test_concurrent_buffer_output_assigns_distinct_event_indices(runtime_db):
+    """Two producers buffering output for one session must each get distinct
+    event_index values; no output event may be silently dropped."""
+    db_path = runtime_db
+    pod_a = RemoteAgentManager(db_path=str(db_path))
+    pod_b = RemoteAgentManager(db_path=str(db_path))
+
+    n = 200
+    barrier = threading.Barrier(2)
+
+    def produce(pod, label):
+        barrier.wait()  # maximize overlap
+        for i in range(n):
+            pod.buffer_output("session-race", {"stream": "stdout", "data": f"{label}-{i}"})
+
+    t1 = threading.Thread(target=produce, args=(pod_a, "a"))
+    t2 = threading.Thread(target=produce, args=(pod_b, "b"))
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
+
+    conn = sqlite3.connect(f"file:{db_path}", uri=True)
+    conn.row_factory = sqlite3.Row
+    rows = conn.execute(
+        "SELECT event_index FROM remote_runtime_outputs WHERE session_id=? " "ORDER BY event_index",
+        ("session-race",),
+    ).fetchall()
+    conn.close()
+    indices = [r["event_index"] for r in rows]
+
+    assert (
+        len(indices) == 2 * n
+    ), f"lost {2 * n - len(indices)} output events to swallowed IntegrityError"
+    assert indices == list(range(1, 2 * n + 1)), "event_index collision or gap"


### PR DESCRIPTION
## Root cause

`RemoteAgentManager._persist_output` allocated `event_index` via `SELECT MAX(event_index)+1` then issued the `INSERT` as a **separate** statement in the same connection with no row lock, no SERIALIZABLE isolation, and no retry. Under two concurrent producers for one session (the multi-pod topology PR #1790 explicitly enables), both read the same next index, the second `INSERT` violates `uq_remote_runtime_outputs_session_index UNIQUE (session_id, event_index)`, and the resulting `IntegrityError` was swallowed by `except Exception as e: logger.debug(...)` -- **silently dropping the stdout chunk**.

## Fix

- Serialize the read-modify-write at the DB level: `BEGIN IMMEDIATE` on SQLite (DB-wide write lock serializes SELECT+INSERT across connections) and `pg_advisory_xact_lock(hashtext(session_id))` on PostgreSQL (transaction-scoped, released on COMMIT/ROLLBACK).
- Add a per-process `threading.Lock` (`_persist_output_lock`) so in-process producers coalesce and the common case needs one attempt.
- Re-read `MAX(event_index)+1` on **every** attempt so a retried INSERT never reuses a stale index.
- Bounded retry (`_PERSIST_OUTPUT_MAX_RETRIES = 8`) on uniqueness violations instead of dropping the event.
- Narrowed exception handling: only `UniqueViolation` / `sqlite3.IntegrityError` enters the retry path; any other failure is logged at `warning` and re-raised (no longer swallowed at `debug`), and exhaustion is logged at `error` and re-raised.

## TDD test added

`tests/issues/1790/test_remote_output_event_index_race.py`:
1. `test_persist_output_does_not_drop_event_on_unique_violation` -- mock-DB isolation test that deterministically reproduces the swallow-and-drop (a shared non-serializing cursor hands the same next_index to two producers and raises `pgcode=23505` on the collision). Fails on main (event lost, `{1}` instead of `{1,2}`); passes after the fix (retry re-reads and succeeds).
2. `test_persist_output_propagates_unexpected_errors` -- a non-uniqueness `RuntimeError` must surface, not be swallowed. Fails on main (`DID NOT RAISE`); passes after.
3. `test_concurrent_buffer_output_assigns_distinct_event_indices` -- real SQLite concurrency, 2 pods x 200 events behind a `threading.Barrier`. Fails on main (17 events lost to swallowed IntegrityError); passes after (400 events, indices 1..400 contiguous).

The mock-DB form is the recommended regression test because SQLite's whole-DB write lock can incidentally mask the race; the mock deterministically reproduces the swallow-and-drop regardless of engine.

Addresses review findings on #1790.

Severity: high.