### PR TITLE
fix(high): redact DingTalk signing secret from stored URL and preferences API

### DIFF
--- a/app/modules/governance/alert_notifier.py
+++ b/app/modules/governance/alert_notifier.py
@@ -50,6 +50,32 @@ _DINGTALK_WEBHOOK_HOST_SNIPPETS = ("dingtalk.com",)
 _DINGTALK_SECRET_QUERY_KEYS = ("openace_dingtalk_secret", "dingtalk_secret")
 
 
+def _redact_dingtalk_secret(webhook_url):
+    """Strip any DingTalk signing secret query param from a webhook URL.
+
+    The per-webhook signing secret must never be persisted in, or echoed back
+    from, the stored webhook URL. Outbound signing reads the secret from the
+    global ``alerts.dingtalk_webhook_secret`` config instead. This helper is the
+    single chokepoint used on both write (before persistence) and read
+    (defensive redaction) so the credential cannot leak through the URL.
+    """
+    if not webhook_url:
+        return webhook_url
+    try:
+        parsed = urlparse(webhook_url)
+    except ValueError:
+        return webhook_url
+    if not parsed.query:
+        return webhook_url
+    original_items = parse_qsl(parsed.query, keep_blank_values=True)
+    sanitized = [
+        (key, value) for key, value in original_items if key not in _DINGTALK_SECRET_QUERY_KEYS
+    ]
+    if len(sanitized) == len(original_items):
+        return webhook_url
+    return urlunparse(parsed._replace(query=urlencode(sanitized)))
+
+
 def _pin_host_to_url(url: str, pinned_ip: str) -> str:
     """Rewrite ``url`` so its host is the IP literal ``pinned_ip``.
 
@@ -1051,19 +1077,24 @@ class AlertNotifier:
         conn.close()
 
         if row:
+            columns = set(row.keys())
             return NotificationPreference(
                 user_id=row["user_id"],
                 email_enabled=bool(row["email_enabled"]),
                 push_enabled=bool(row["push_enabled"]),
-                webhook_url=row["webhook_url"],
+                webhook_url=_redact_dingtalk_secret(row["webhook_url"]),
                 alert_types=(
                     json.loads(row["alert_types"])
                     if row["alert_types"]
                     else ["quota", "system", "security"]
                 ),
                 min_severity=row["min_severity"] or "warning",
-                notification_email=row.get("notification_email"),
-                email_verified=bool(row.get("email_verified", False)),
+                notification_email=(
+                    row["notification_email"] if "notification_email" in columns else None
+                ),
+                email_verified=bool(
+                    row["email_verified"] if "email_verified" in columns else False
+                ),
             )
 
         # Return default preferences
@@ -1079,6 +1110,11 @@ class AlertNotifier:
         Returns:
             True if successful.
         """
+        # Never persist the DingTalk signing secret inside the webhook URL;
+        # strip it before writing so the DB never holds the credential. The
+        # outbound signer reads the secret from global config instead.
+        preferences.webhook_url = _redact_dingtalk_secret(preferences.webhook_url)
+
         conn = self._get_connection()
         cursor = conn.cursor()
 

--- a/app/routes/alerts.py
+++ b/app/routes/alerts.py
@@ -17,7 +17,11 @@ from datetime import datetime, timezone
 from flask import Blueprint, g, jsonify, request
 
 from app.auth.decorators import _extract_token, _load_user_from_token
-from app.modules.governance.alert_notifier import NotificationPreference, get_alert_notifier
+from app.modules.governance.alert_notifier import (
+    NotificationPreference,
+    _redact_dingtalk_secret,
+    get_alert_notifier,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -174,7 +178,7 @@ def get_preferences():
                 "data": {
                     "email_enabled": prefs.email_enabled,
                     "push_enabled": prefs.push_enabled,
-                    "webhook_url": prefs.webhook_url,
+                    "webhook_url": _redact_dingtalk_secret(prefs.webhook_url),
                     "alert_types": prefs.alert_types,
                     "min_severity": prefs.min_severity,
                     "notification_email": prefs.notification_email,

--- a/tests/routes/test_alerts_preferences.py
+++ b/tests/routes/test_alerts_preferences.py
@@ -1,0 +1,77 @@
+"""Route tests for GET/PUT /alerts/preferences secret redaction.
+
+Ensures the DingTalk signing secret embedded in a webhook URL is never
+persisted to, nor echoed back from, the preferences API.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture
+def client():
+    """Flask test client with alerts routes and a stubbed auth user.
+
+    Backed by an AlertNotifier over a throwaway SQLite database, with
+    is_postgresql pinned to False for the whole test so all persistence
+    code paths use SQLite.
+    """
+    tmpdir = tempfile.mkdtemp()
+    db_path = os.path.join(tmpdir, "test_alerts.db")
+
+    with (
+        patch("app.repositories.database.is_postgresql", return_value=False),
+        patch("app.modules.governance.alert_notifier.is_postgresql", return_value=False),
+    ):
+        from app.modules.governance.alert_notifier import AlertNotifier
+
+        notifier = AlertNotifier(db_path=db_path)
+        notifier._ensure_tables()
+
+        from flask import Flask
+
+        from app.routes.alerts import alerts_bp
+
+        app = Flask(__name__)
+        app.config["TESTING"] = True
+        app.config["SECRET_KEY"] = "test-secret-key"
+        app.register_blueprint(alerts_bp)
+
+        with (
+            app.test_client() as test_client,
+            patch("app.routes.alerts.get_alert_notifier", return_value=notifier),
+            patch("app.routes.alerts._extract_token", return_value="test-token"),
+            patch(
+                "app.routes.alerts._load_user_from_token",
+                return_value={"id": 7, "role": "user", "username": "tester"},
+            ),
+        ):
+            yield test_client
+
+
+def test_put_then_get_preferences_redacts_dingtalk_secret(client):
+    """GET /alerts/preferences must not expose the secret stored via PUT."""
+    secret_url = (
+        "https://oapi.dingtalk.com/robot/send" "?access_token=abc&openace_dingtalk_secret=TOPSECRET"
+    )
+
+    resp = client.put(
+        "/alerts/preferences",
+        json={"webhook_url": secret_url},
+    )
+    assert resp.status_code == 200
+    assert resp.get_json()["success"] is True
+
+    resp = client.get("/alerts/preferences")
+    assert resp.status_code == 200
+    data = resp.get_json()["data"]
+
+    assert "access_token=abc" in data["webhook_url"]
+    assert "TOPSECRET" not in data["webhook_url"]
+    assert "openace_dingtalk_secret" not in data["webhook_url"]
+    assert "dingtalk_secret" not in data["webhook_url"]

--- a/tests/unit/test_alert_notifier_webhook.py
+++ b/tests/unit/test_alert_notifier_webhook.py
@@ -1,3 +1,5 @@
+import os
+import tempfile
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -226,6 +228,56 @@ class TestAlertNotifierWebhook(unittest.TestCase):
         )
 
         mock_session.return_value.post.assert_not_called()
+
+    def test_set_then_get_preferences_strips_dingtalk_secret_from_webhook_url(self):
+        """Persisted and returned webhook_url must never carry the DingTalk signing secret."""
+        with (
+            tempfile.TemporaryDirectory() as tmpdir,
+            patch("app.repositories.database.is_postgresql", return_value=False),
+            patch("app.modules.governance.alert_notifier.is_postgresql", return_value=False),
+        ):
+            db_path = os.path.join(tmpdir, "test_alerts.db")
+            notifier = AlertNotifier(db_path=db_path)
+            notifier._ensure_tables()
+
+            secret_url = (
+                "https://oapi.dingtalk.com/robot/send"
+                "?access_token=abc&openace_dingtalk_secret=TOPSECRET"
+            )
+            prefs = NotificationPreference(
+                user_id=42,
+                webhook_url=secret_url,
+                alert_types=["quota"],
+            )
+            notifier.set_notification_preferences(prefs)
+
+            stored = notifier.get_notification_preferences(42)
+
+            assert "access_token=abc" in stored.webhook_url
+            assert "TOPSECRET" not in stored.webhook_url
+            assert "openace_dingtalk_secret" not in stored.webhook_url
+            assert "dingtalk_secret" not in stored.webhook_url
+
+    def test_prepare_webhook_url_still_signs_without_in_url_secret(self):
+        """Outbound signing must keep working when the secret lives only in global config."""
+        notifier = AlertNotifier()
+        with (
+            patch("app.modules.governance.alert_notifier.time.time", return_value=1710000000.123),
+            patch(
+                "app.modules.governance.alert_notifier.get_config_value",
+                return_value="global-dingtalk-secret",
+            ),
+        ):
+            url = notifier._prepare_webhook_url(
+                "https://oapi.dingtalk.com/robot/send?access_token=abc"
+            )
+
+        assert "access_token=abc" in url
+        assert "timestamp=1710000000123" in url
+        assert "sign=" in url
+        # The cleaned URL passed in must not gain a secret query key back.
+        assert "openace_dingtalk_secret" not in url
+        assert "dingtalk_secret" not in url
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Root cause
The DingTalk per-webhook signing secret embedded as an `openace_dingtalk_secret`/`dingtalk_secret` query param was persisted verbatim into `notification_preferences.webhook_url` (by `set_notification_preferences`) and returned verbatim by `GET /alerts/preferences`, leaking the credential both at rest (DB) and to the client. Outbound signing (`_prepare_webhook_url`) already strips the param at POST time, but the secret was never removed on save or read.

## Fix
- Add `_redact_dingtalk_secret()` helper (single chokepoint that parses the URL, drops any key in `_DINGTALK_SECRET_QUERY_KEYS`, and reassembles).
- Call it **on write** in `set_notification_preferences` before the INSERT/UPSERT, so the DB never holds the secret.
- Call it **on read** in `get_notification_preferences` and in the `GET /alerts/preferences` route, as defensive redaction so a legacy stored URL cannot leak.
- Outbound signing keeps working because `_prepare_webhook_url` already falls back to the global `alerts.dingtalk_webhook_secret` config when the param is absent.
- Also made `get_notification_preferences` SQLite-safe (`sqlite3.Row` has no `.get()`), guarding column access so the read path runs on both backends.

## TDD test added
- `tests/unit/test_alert_notifier_webhook.py::test_set_then_get_preferences_strips_dingtalk_secret_from_webhook_url` — persistence round-trip: stored/returned `webhook_url` keeps `access_token` but contains neither `TOPSECRET` nor the secret query key.
- `tests/unit/test_alert_notifier_webhook.py::test_prepare_webhook_url_still_signs_without_in_url_secret` — outbound signing still adds `timestamp=`/`sign=` using global config when the param is absent.
- `tests/routes/test_alerts_preferences.py::test_put_then_get_preferences_redacts_dingtalk_secret` — route layer: PUT then GET never exposes the secret.

Both notifier and route tests were observed RED before the fix (secret present) and GREEN after.

Addresses review findings on #1787.

🤖 Generated with [Claude Code](https://claude.com/claude-code)