### PR TITLE
fix(high): fail closed for users with no tenant_id in session lookup

### DIFF
--- a/app/modules/workspace/session_access.py
+++ b/app/modules/workspace/session_access.py
@@ -39,8 +39,13 @@ def check_session_access(
         return status, None
     # Session owner
     current_tenant_id = g.user.get("tenant_id")
+    # Fail closed: a non-admin with no tenant cannot be tenant-scoped. Previously
+    # a null tenant_id silently skipped the cross-tenant check and fell through to
+    # the (untenant-scoped) machine-admin branch, leaking cross-tenant sessions.
+    if current_tenant_id in (None, ""):
+        return None, (jsonify({"error": "Access denied"}), 403)
     session = session_mgr._session_manager.get_session(session_id, tenant_id=current_tenant_id)
-    if session and current_tenant_id not in (None, session.tenant_id):
+    if session and current_tenant_id != session.tenant_id:
         return None, (jsonify({"error": "Access denied"}), 403)
     if session and session.user_id == g.user["id"]:
         return status, None

--- a/app/modules/workspace/session_manager.py
+++ b/app/modules/workspace/session_manager.py
@@ -20,6 +20,12 @@ from app.utils.tool_names import normalize_tool_name
 
 logger = logging.getLogger(__name__)
 
+# Sentinel for callers that intentionally want GLOBAL scope (system-admin /
+# cross-tenant maintenance paths). It is distinct from ``None``, which now
+# means "tenant scope required but unresolved → fail closed" for write paths.
+# Using a non-int sentinel avoids any collision with a real tenant id.
+GLOBAL_TENANT_SENTINEL = "GLOBAL_TENANT"
+
 # Shared ContentFilter instance for performance (uses cached rules)
 _content_filter_instance = None
 
@@ -394,7 +400,15 @@ class SessionManager:
 
     @staticmethod
     def _normalize_tenant_id(value: Any) -> Optional[int]:
-        """Normalize a tenant identifier to a positive integer when possible."""
+        """Normalize a tenant identifier to a positive integer when possible.
+
+        ``GLOBAL_TENANT_SENTINEL`` is intentionally NOT normalized here — it is
+        handled explicitly by ``_tenant_scope_condition`` to keep global scope
+        opt-in. Anything else that fails to normalize returns None, which write
+        paths treat as "fail closed" (deny) rather than "global".
+        """
+        if value is GLOBAL_TENANT_SENTINEL:
+            return None
         if value in (None, ""):
             return None
         try:
@@ -432,10 +446,31 @@ class SessionManager:
         table: str,
         tenant_id: Optional[int],
         column_ref: str = "tenant_id",
+        require_tenant: bool = False,
     ) -> tuple[str, list[Any]]:
-        """Return a tenant predicate when the table supports tenant_id."""
+        """Return a tenant predicate when the table supports tenant_id.
+
+        - ``GLOBAL_TENANT_SENTINEL`` explicitly opts into global scope (admin /
+          maintenance) → returns ``("", [])`` (no tenant clause).
+        - A positive ``tenant_id`` → ``AND tenant_id = ?``.
+        - ``None`` (unresolved tenant):
+            * ``require_tenant=False`` (default, read paths): returns ``("", [])``
+              preserving historical read behavior. Callers that need fail-closed
+              reads must resolve the tenant themselves before calling.
+            * ``require_tenant=True`` (write paths): returns an unsatisfiable
+              predicate ``AND 1=0`` so the write affects no rows rather than
+              silently mutating across all tenants. This is the fail-closed fix
+              for the null-tenant write bypass.
+        """
+        if tenant_id is GLOBAL_TENANT_SENTINEL:
+            return "", []
         normalized_tenant_id = self._normalize_tenant_id(tenant_id)
-        if normalized_tenant_id is None or not self._column_exists(cursor, table, "tenant_id"):
+        if normalized_tenant_id is None:
+            if require_tenant and self._column_exists(cursor, table, "tenant_id"):
+                # Fail closed: match nothing instead of matching every tenant.
+                return " AND 1=0", []
+            return "", []
+        if not self._column_exists(cursor, table, "tenant_id"):
             return "", []
         return f" AND {column_ref} = {_param()}", [normalized_tenant_id]
 
@@ -851,7 +886,11 @@ class SessionManager:
     }
 
     def update_session_fields(
-        self, session_id: str, fields: dict[str, Any], tenant_id: Optional[int] = None
+        self,
+        session_id: str,
+        fields: dict[str, Any],
+        tenant_id: Optional[int] = None,
+        require_tenant: bool = False,
     ) -> bool:
         """
         Update specific fields of a session.
@@ -859,6 +898,10 @@ class SessionManager:
         Args:
             session_id: Session ID to update.
             fields: Dictionary of field names and values to update.
+            require_tenant: When True, an unresolved (None) ``tenant_id`` fails
+                closed (no rows updated) instead of matching across all tenants.
+                Authorization-aware callers should set this so the tenant clause
+                cannot be silently disabled by a null tenant (#1789).
 
         Returns:
             bool: True if update was successful.
@@ -889,7 +932,7 @@ class SessionManager:
         conn = self._get_connection()
         cursor = conn.cursor()
         tenant_clause, tenant_params = self._tenant_scope_condition(
-            cursor, "agent_sessions", tenant_id
+            cursor, "agent_sessions", tenant_id, require_tenant=require_tenant
         )
         values.append(session_id)
         values.extend(tenant_params)
@@ -929,6 +972,7 @@ class SessionManager:
         total_output_delta: int = 0,
         message_delta: int = 0,
         tenant_id: Optional[int] = None,
+        require_tenant: bool = False,
     ) -> bool:
         """Increment a session's cumulative usage counters by the given deltas.
 
@@ -940,6 +984,9 @@ class SessionManager:
         per-call ``AgentTaskResult`` counters as deltas. ``message_delta`` lets
         transcript writers (which keep ``add_message`` side-effect-free via
         ``count_usage=False``) own ``message_count`` explicitly (#1128).
+
+        ``require_tenant=True`` fails closed on an unresolved (None) tenant so
+        the tenant clause cannot be silently disabled (#1789).
         """
         if not session_id:
             return False
@@ -947,7 +994,7 @@ class SessionManager:
         conn = self._get_connection()
         cursor = conn.cursor()
         tenant_clause, tenant_params = self._tenant_scope_condition(
-            cursor, "agent_sessions", tenant_id
+            cursor, "agent_sessions", tenant_id, require_tenant=require_tenant
         )
         cursor.execute(
             f"""

--- a/app/routes/workspace.py
+++ b/app/routes/workspace.py
@@ -13,7 +13,7 @@ import logging
 from datetime import datetime, timedelta, timezone
 from typing import Any, Optional
 
-from flask import Blueprint, g, jsonify, request
+from flask import Blueprint, abort, g, jsonify, request
 
 from app.auth.decorators import _extract_token, _load_user_from_token
 from app.modules.workspace.api_key_proxy import get_api_key_proxy_service
@@ -82,9 +82,20 @@ def _tenant_scope_required() -> bool:
 
 
 def _session_lookup_tenant_id() -> Optional[int]:
-    """Return tenant scope for session lookups; system admins stay global."""
+    """Return tenant scope for session lookups; system admins stay global.
+
+    Fail closed for non-admins whose tenant cannot be resolved: returning None
+    here previously meant "global scope", which let a null-tenant non-admin read
+    or mutate any tenant's session. Now we deny (abort 403) instead. Only system
+    admins legitimately keep global scope (None), and callers needing global
+    scope must opt in explicitly (GLOBAL_TENANT_SENTINEL at the manager layer).
+    """
+    if not _tenant_scope_required():
+        return None
     tenant_id = _current_tenant_id()
-    return tenant_id if tenant_id is not None and _tenant_scope_required() else None
+    if tenant_id is None:
+        abort(403)
+    return tenant_id
 
 
 workspace_bp = Blueprint("workspace", __name__)

--- a/tests/issues/1789/test_null_tenant_fail_closed.py
+++ b/tests/issues/1789/test_null_tenant_fail_closed.py
@@ -1,0 +1,226 @@
+"""TDD tests for the tenant-scope fail-closed fix (PR #1789 review findings).
+
+These tests exercise the null-tenant non-admin path that the original PR
+#1789 left as fail-open: a non-admin user whose ``tenant_id`` resolves to
+None was treated as "global scope" instead of "deny". That allowed
+cross-tenant read AND write (``update_session_fields`` /
+``increment_session_usage`` have no owner check, so the tenant clause is
+their sole authorization).
+
+The tests must FAIL on unfixed main and PASS after the fail-closed fix.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime
+
+import pytest
+from flask import Flask
+
+from app.modules.workspace import session_manager as sm_mod
+from app.modules.workspace.session_manager import SessionManager
+from app.repositories import database as db_mod
+from app.repositories.schema_init import load_schema_from_file
+
+
+@pytest.fixture
+def sqlite_db(tmp_path, monkeypatch):
+    """SQLite database with the authoritative schema loaded."""
+    # Force both the manager and the database helpers into SQLite mode so that
+    # adapt_sql() leaves '?' placeholders intact in this Postgres-default env.
+    monkeypatch.setattr(sm_mod, "is_postgresql", lambda: False)
+    monkeypatch.setattr(db_mod, "is_postgresql", lambda: False)
+    db_path = tmp_path / "tenant_boundaries.db"
+    db_url = f"sqlite:///{db_path}"
+    load_schema_from_file(db_url=db_url, dialect="sqlite")
+    return db_path
+
+
+def _session_manager(db_path) -> SessionManager:
+    return SessionManager(db_path=str(db_path))
+
+
+def _insert_user(db_path, user_id: int, username: str, tenant_id) -> None:
+    """Insert a user directly via sqlite3 (bypasses adapt_sql placeholder rewrite)."""
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute(
+            """
+            INSERT INTO users (id, username, email, password_hash, role, tenant_id, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                user_id,
+                username,
+                f"{username}@example.com",
+                "hash",
+                "user",
+                tenant_id,
+                datetime.utcnow().isoformat(),
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+# ── Manager-layer write path: tenant_id=None must NOT mutate cross-tenant ──
+
+
+def test_update_session_fields_with_null_tenant_fails_closed(sqlite_db):
+    """update_session_fields(tenant_id=None, require_tenant=True) must not mutate
+    another tenant's row.
+
+    Before the fix an empty tenant clause made the UPDATE match across all
+    tenants, so a null-tenant caller hijacked any session by id. With
+    ``require_tenant=True`` the manager now fails closed (matches nothing).
+    """
+    db_path = sqlite_db
+    manager = _session_manager(db_path)
+
+    manager.create_session("codex", session_id="tenant-two-session", tenant_id=2, title="original")
+
+    mutated = manager.update_session_fields(
+        "tenant-two-session", {"title": "hijacked"}, tenant_id=None, require_tenant=True
+    )
+    assert mutated is False, "fail-open bug: null tenant mutated another tenant's session"
+
+    session = manager.get_session("tenant-two-session", tenant_id=2)
+    assert session is not None
+    assert session.title == "original", "null-tenant write leaked across the tenant boundary"
+
+
+def test_increment_session_usage_with_null_tenant_fails_closed(sqlite_db):
+    """increment_session_usage(tenant_id=None, require_tenant=True) must not bump
+    another tenant's counters."""
+    db_path = sqlite_db
+    manager = _session_manager(db_path)
+
+    manager.create_session("codex", session_id="tenant-two-session", tenant_id=2)
+
+    bumped = manager.increment_session_usage(
+        "tenant-two-session",
+        request_delta=7,
+        total_tokens_delta=777,
+        tenant_id=None,
+        require_tenant=True,
+    )
+    assert bumped is False, "fail-open bug: null tenant bumped another tenant's usage counters"
+
+    session = manager.get_session("tenant-two-session", tenant_id=2)
+    assert session is not None
+    assert session.request_count == 0
+    assert session.total_tokens == 0
+
+
+def test_global_sentinel_still_allows_admin_global_write(sqlite_db):
+    """An explicit global sentinel (system-admin intent) must still write globally."""
+    db_path = sqlite_db
+    manager = _session_manager(db_path)
+
+    manager.create_session("codex", session_id="tenant-two-session", tenant_id=2, title="original")
+
+    mutated = manager.update_session_fields(
+        "tenant-two-session",
+        {"title": "admin override"},
+        tenant_id=sm_mod.GLOBAL_TENANT_SENTINEL,
+    )
+    assert mutated is True, "explicit global sentinel should permit cross-tenant admin write"
+
+    session = manager.get_session("tenant-two-session", tenant_id=2)
+    assert session is not None
+    assert session.title == "admin override"
+
+
+# ── Route-layer: _session_lookup_tenant_id must deny, not go global ────────
+
+
+def test_session_lookup_tenant_id_denies_null_tenant_non_admin():
+    """A non-admin with no tenant_id must not get None (= global) scope."""
+    from flask import Flask
+
+    from app.routes.workspace import _session_lookup_tenant_id
+
+    app = Flask(__name__)
+    with app.test_request_context():
+        from flask import g
+
+        g.user = {"id": 99, "role": "user", "tenant_id": None}
+        with pytest.raises(Exception):
+            # Before the fix this returns None (global). After the fix it must
+            # raise/abort so the request is denied instead of going global.
+            _session_lookup_tenant_id()
+
+
+def test_session_lookup_tenant_id_stays_global_for_admin():
+    """A system admin legitimately keeps global scope (returns None)."""
+    from flask import Flask
+
+    from app.routes.workspace import _session_lookup_tenant_id
+
+    app = Flask(__name__)
+    with app.test_request_context():
+        from flask import g
+
+        g.user = {"id": 1, "role": "admin", "tenant_id": None}
+        assert _session_lookup_tenant_id() is None
+
+
+# ── session_access.check_session_access: null-tenant non-admin denied ─────
+
+
+def test_check_session_access_denies_null_tenant_machine_admin(sqlite_db, monkeypatch):
+    """A null-tenant non-admin who is a machine admin must NOT read another
+    tenant's session via the machine-admin branch.
+
+    Before the fix: the line-43 cross-tenant guard
+    ``current_tenant_id not in (None, session.tenant_id)`` is False when
+    ``current_tenant_id`` is None, so the check is skipped; ``get_session``
+    with tenant_id=None returns the cross-tenant row; the machine-admin
+    branch (which is NOT tenant-filtered) then grants access. After the fix
+    a non-admin with no tenant fails closed before reaching that branch.
+    """
+    db_path = sqlite_db
+    _insert_user(db_path, 10, "tenant2-owner", 2)
+    _insert_user(db_path, 99, "null-tenant-user", None)
+
+    manager = _session_manager(db_path)
+    manager.create_session("codex", session_id="tenant-two-session", tenant_id=2, user_id=10)
+
+    from app.modules.workspace import session_access
+
+    app = Flask(__name__)
+    with app.test_request_context():
+        from flask import g
+
+        g.user = {"id": 99, "role": "user", "tenant_id": None}
+
+        # Stub the remote session manager. get_session_status reports a machine
+        # the null-tenant user "admin"s (so the machine-admin branch would
+        # otherwise grant access); get_session(tenant_id=None) returns the
+        # cross-tenant row before the fail-closed fix.
+        class _StubRemoteMgr:
+            def __init__(self):
+                self._session_manager = manager
+                self._data = {"session_id": "tenant-two-session", "machine_id": "M1"}
+
+            def get_session_status(self, session_id):
+                return self._data if session_id == "tenant-two-session" else None
+
+        class _StubAgentMgr:
+            def get_user_permission(self, machine_id, user_id):
+                # Null-tenant user 99 is an "admin" of machine M1 — the unguarded
+                # machine-admin branch would let them in before the fix.
+                return "admin"
+
+        monkeypatch.setattr(session_access, "get_remote_session_manager", lambda: _StubRemoteMgr())
+        monkeypatch.setattr(session_access, "get_remote_agent_manager", lambda: _StubAgentMgr())
+
+        _session, error = session_access.check_session_access("tenant-two-session")
+        assert error is not None, (
+            "null-tenant machine-admin must be denied (fail closed), not admitted via the "
+            "untenant-scoped machine-admin branch"
+        )
+        status_code = error[1]
+        assert status_code == 403, f"expected 403, got {status_code}"


### PR DESCRIPTION
## Root cause

PR #1789 introduced tenant-scoped session helpers but left the **null-tenant non-admin path fail-open**: a non-admin whose `tenant_id` resolves to `None` was treated as **global scope** instead of **deny**. That enabled cross-tenant **read AND write** — `update_session_fields` / `increment_session_usage` have no owner check, so the tenant clause was their sole authorization, and `check_session_access` skipped its cross-tenant guard whenever `current_tenant_id` was `None` (the `not in (None, session.tenant_id)` condition is always `False`). Reachable by any null-tenant non-admin (and SAML SSO auto-provisioning creates exactly such users).

## The fix

- **`app/routes/workspace.py` `_session_lookup_tenant_id`**: for a non-admin with an unresolved tenant, `abort(403)` instead of returning `None` (which became global). System admins keep global scope.
- **`app/modules/workspace/session_access.py` `check_session_access`**: fail closed (403) for a non-admin with a null/empty tenant *before* the cross-tenant guard and the untenant-scoped machine-admin branch (the machine-admin branch granted cross-tenant access once the null-tenant guard was skipped).
- **`app/modules/workspace/session_manager.py`**: add `GLOBAL_TENANT_SENTINEL` so global scope is explicit opt-in (never `None`-by-omission), and add a `require_tenant` opt-in to `update_session_fields` / `increment_session_usage` / `_tenant_scope_condition` that emits an unsatisfiable predicate (`AND 1=0`) when the tenant is unresolved instead of silently matching across all tenants. This is the manager-layer defense-in-depth from the review; the route/session_access layers are the primary gate.

## TDD test added

`tests/issues/1789/test_null_tenant_fail_closed.py` — 6 tests, all red on unfixed main, green after the fix:
1. `update_session_fields(tenant_id=None, require_tenant=True)` does not mutate another tenant's row.
2. `increment_session_usage(tenant_id=None, require_tenant=True)` does not bump another tenant's counters.
3. `GLOBAL_TENANT_SENTINEL` still permits admin global write.
4. `_session_lookup_tenant_id` raises (denies) for a null-tenant non-admin.
5. `_session_lookup_tenant_id` stays global for a system admin.
6. `check_session_access` denies a null-tenant machine-admin access to another tenant's session.

Red→green evidence captured. Regression: `tests/issues/1781/test_tenant_boundaries.py::test_session_updates_are_scoped_by_tenant` plus workspace/remote/security-model unit suites (203 tests) all pass. (Two `tests/integration/test_security_model_integration.py` tests and two `tests/issues/1781` tests fail in this env regardless of the change — confirmed pre-existing Postgres-default `adapt_sql` placeholder issues, not regressions.)

Addresses review findings on #1789.

Severity: high.