### PR TITLE
fix(high): fail-closed tenant scope for non-admins on governance/usage/compliance/projects routes

### DIFF
--- a/app/auth/decorators.py
+++ b/app/auth/decorators.py
@@ -314,3 +314,57 @@ def public_endpoint(f):
     # Copy the marker to the wrapper so scanner can find it
     wrapper._is_public_endpoint = True  # type: ignore[attr-defined]
     return wrapper
+
+
+# ── Tenant scope helpers ──────────────────────────────────────────────
+
+
+def _normalize_user_tenant_id(value: object) -> int | None:
+    """Coerce a raw ``tenant_id`` value into a positive int or None."""
+    if value in (None, ""):
+        return None
+    try:
+        tenant_id = int(value)  # type: ignore[call-overload]
+    except (TypeError, ValueError):
+        return None
+    return tenant_id if tenant_id > 0 else None
+
+
+def resolve_tenant_scope() -> tuple[int | None, bool]:
+    """Return ``(tenant_id, is_admin)`` for the current request.
+
+    Mirrors the workspace pattern (``_tenant_scope_required`` /
+    ``_session_lookup_tenant_id`` in ``app/routes/workspace.py``): admins
+    keep global scope (``tenant_id`` may be ``None``), while non-admins are
+    tenant-scoped to their resolved ``tenant_id``.
+
+    This helper is side-effect free; callers decide what to do when a
+    non-admin has no tenant (the route layer denies with 403, see
+    :func:`require_tenant_scope`).
+    """
+    user = getattr(g, "user", None) or {}
+    is_admin = user.get("role") == "admin"
+    tenant_id = _normalize_user_tenant_id(user.get("tenant_id"))
+    return tenant_id, is_admin
+
+
+def require_tenant_scope() -> tuple[int | None, tuple[Response, int] | None]:
+    """Resolve the request's tenant scope, denying non-admins without one.
+
+    Returns ``(tenant_id, None)`` when the caller may proceed:
+
+    * admins -> ``tenant_id`` is ``None`` (global scope preserved);
+    * tenant-scoped non-admins -> their resolved ``tenant_id``.
+
+    Returns ``(None, error_response)`` for a non-admin user with no
+    resolvable tenant — the caller must ``return`` the error response to
+    fail closed instead of passing ``None`` to the repository layer (which
+    would otherwise be treated as a wildcard/global filter and leak
+    cross-tenant data, see Issue #1775).
+    """
+    tenant_id, is_admin = resolve_tenant_scope()
+    if is_admin:
+        return None, None
+    if tenant_id is None:
+        return None, (jsonify({"error": "Tenant scope required"}), 403)
+    return tenant_id, None

--- a/app/routes/projects.py
+++ b/app/routes/projects.py
@@ -15,7 +15,7 @@ from typing import Any, cast
 
 from flask import Blueprint, g, jsonify, request
 
-from app.auth.decorators import _extract_token, _load_user_from_token
+from app.auth.decorators import _extract_token, _load_user_from_token, require_tenant_scope
 from app.repositories.project_repo import ProjectRepository
 from app.repositories.user_repo import UserRepository
 
@@ -72,6 +72,20 @@ def _authenticate_user():
                     return None
 
     return jsonify({"error": "Authentication required"}), 401
+
+
+@projects_bp.before_request
+def _require_tenant_scope():
+    """Fail closed for non-admins with no tenant (Issue #1775).
+
+    Without this gate, ``_current_tenant_id()`` returns ``None`` and the
+    project repository treats it as a wildcard/global filter, leaking
+    cross-tenant projects to a no-tenant non-admin. Admins keep global
+    scope; tenant-scoped non-admins keep their tenant.
+    """
+    _, error = require_tenant_scope()
+    if error is not None:
+        return error
 
 
 def get_effective_system_account(system_account: str | None) -> str | None:

--- a/app/routes/usage.py
+++ b/app/routes/usage.py
@@ -6,7 +6,7 @@ API routes for usage data operations.
 
 from flask import Blueprint, g, jsonify, request
 
-from app.auth.decorators import auth_required
+from app.auth.decorators import auth_required, require_tenant_scope
 from app.services.summary_service import SummaryService
 from app.services.usage_service import UsageService
 from app.utils.helpers import get_days_ago, get_today
@@ -22,8 +22,27 @@ def _require_auth():
     pass
 
 
+@usage_bp.before_request
+def _require_tenant_scope():
+    """Fail closed for non-admins with no tenant (Issue #1775).
+
+    Without this gate, ``_current_tenant_id()`` returns ``None`` and the
+    repository layer treats it as a wildcard/global filter, leaking
+    cross-tenant usage data to a no-tenant non-admin. Admins keep global
+    scope; tenant-scoped non-admins keep their tenant.
+    """
+    _, error = require_tenant_scope()
+    if error is not None:
+        return error
+
+
 def _current_tenant_id():
-    """Return the authenticated user's tenant scope."""
+    """Return the authenticated user's tenant scope.
+
+    Non-admins reaching this point are guaranteed to have a resolvable
+    tenant (``_require_tenant_scope`` denies the request otherwise); admins
+    may still be ``None`` (global scope).
+    """
     user = getattr(g, "user", None) or {}
     return user.get("tenant_id")
 

--- a/tests/issues/1775/test_route_tenant_fail_closed.py
+++ b/tests/issues/1775/test_route_tenant_fail_closed.py
@@ -1,0 +1,201 @@
+"""Route-layer tenant-isolation regression tests (Issue #1775).
+
+PR #1775 introduced ``_current_tenant_id()`` on the governance, usage,
+compliance, and projects blueprints.  When a NON-ADMIN user has no
+``tenant_id`` the helper returns ``None`` and the repository layer treats
+``None`` as "no filter" (wildcard / global).  A no-tenant non-admin could
+therefore read CROSS-TENANT audit logs, usage data, and projects.
+
+These tests pin the fail-closed behaviour at the route layer:
+non-admins without a resolvable tenant are denied (403 / empty), while
+admins keep global scope and tenant-scoped non-admins keep their tenant.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from contextlib import ExitStack
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+
+
+_DB_PATH = tempfile.mktemp(suffix="_tenant_1775.db")
+_DB_URL = f"sqlite:///{_DB_PATH}"
+
+
+def _install_db_url():
+    """Point db_mod at the shared test DB and disable SQL adaptation.
+
+    The route blueprints construct module-level singletons
+    (``usage_service``, ``project_repo``) whose ``Database()`` is bound at
+    import time.  We additionally rebind those singletons' ``db`` handles
+    in :func:`_make_client` so the test is immune to import ordering when
+    the full suite runs alongside other tests that swap the DB URL.
+    """
+    import app.repositories.database as db_mod
+
+    orig = db_mod.adapt_sql
+    orig_get_database_url = db_mod.get_database_url
+    db_mod.adapt_sql = lambda sql: sql
+    db_mod.get_database_url = lambda: _DB_URL
+    return orig, orig_get_database_url, db_mod
+
+
+def _rebind_singletons(db):
+    """Point the route-blueprint module singletons at ``db`` and return the
+    saved ``db`` values so the caller can restore them in tearDown."""
+    import app.routes.projects as projects_mod
+    import app.routes.usage as usage_mod
+
+    saved = (
+        usage_mod.usage_service.usage_repo.db,
+        projects_mod.project_repo.db,
+        projects_mod.user_repo.db,
+    )
+    usage_mod.usage_service.usage_repo.db = db
+    projects_mod.project_repo.db = db
+    projects_mod.user_repo.db = db
+    return saved
+
+
+def _restore_singletons(saved):
+    import app.routes.projects as projects_mod
+    import app.routes.usage as usage_mod
+
+    usage_db, projects_db, user_db = saved
+    usage_mod.usage_service.usage_repo.db = usage_db
+    projects_mod.project_repo.db = projects_db
+    projects_mod.user_repo.db = user_db
+
+
+def _make_client():
+    import app.repositories.database as db_mod
+    from app import create_app
+
+    app = create_app({"TESTING": True})
+    db = db_mod.Database(db_url=_DB_URL)
+    # Rebind the route-blueprint module singletons to this live DB so the
+    # test is independent of whichever DB URL was active at import time.
+    saved = _rebind_singletons(db)
+    # Seed a couple of users in different tenants so that wildcard queries
+    # would surface cross-tenant data if the route fails open.
+    with db.get_connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute("DELETE FROM users")
+        cursor.execute(
+            "INSERT INTO users (id, username, email, password_hash, role, tenant_id) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (1, "admin", "admin@test.com", "hash", "admin", None),
+        )
+        cursor.execute(
+            "INSERT INTO users (id, username, email, password_hash, role, tenant_id) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (10, "tenant_user", "tu@test.com", "hash", "user", 7),
+        )
+        cursor.execute(
+            "INSERT INTO users (id, username, email, password_hash, role, tenant_id) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (11, "notenant_user", "nt@test.com", "hash", "user", None),
+        )
+        conn.commit()
+
+    client = app.test_client()
+    client.set_cookie("session_token", "test-token")
+    return client, db_mod, saved
+
+
+def _user_dict(user_id=1, role="admin", tenant_id=None):
+    username = "admin" if role == "admin" else ("tenant_user" if tenant_id else "notenant_user")
+    return {
+        "id": user_id,
+        "username": username,
+        "email": f"{username}@test.com",
+        "role": role,
+        "tenant_id": tenant_id,
+    }
+
+
+def _mock_auth(user_id=1, role="admin", tenant_id=None):
+    """Patch _load_user_from_token in every importer so the test_client
+    bypasses real auth. projects.py binds the name into its own namespace,
+    so both patches are required."""
+    user = _user_dict(user_id, role, tenant_id)
+    return (
+        patch("app.auth.decorators._load_user_from_token", return_value=user),
+        patch("app.routes.projects._load_user_from_token", return_value=user),
+    )
+
+
+class TestRouteTenantFailClosed(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.orig, cls.orig_get_database_url, cls.db_mod = _install_db_url()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.db_mod.adapt_sql = cls.orig
+        cls.db_mod.get_database_url = cls.orig_get_database_url
+        try:
+            os.unlink(_DB_PATH)
+        except OSError:
+            pass
+
+    def setUp(self):
+        self.client, _, self.saved_singletons = _make_client()
+
+    def tearDown(self):
+        _restore_singletons(self.saved_singletons)
+
+    # --- non-admin WITHOUT a tenant must be denied (the bug) ---
+
+    def _authed_get(self, path, **auth):
+        """GET path with _load_user_from_token patched across importers."""
+        with ExitStack() as stack:
+            for p in _mock_auth(**auth):
+                stack.enter_context(p)
+            return self.client.get(path)
+
+    def test_usage_tools_denied_for_notenant_non_admin(self):
+        resp = self._authed_get("/api/tools", user_id=11, role="user", tenant_id=None)
+        # Bug on main: returns 200 with cross-tenant/global tool list.
+        self.assertNotEqual(resp.status_code, 200)
+        self.assertEqual(resp.status_code, 403)
+
+    def test_usage_today_denied_for_notenant_non_admin(self):
+        resp = self._authed_get("/api/today", user_id=11, role="user", tenant_id=None)
+        self.assertNotEqual(resp.status_code, 200)
+        self.assertEqual(resp.status_code, 403)
+
+    def test_projects_denied_for_notenant_non_admin(self):
+        resp = self._authed_get("/api/projects", user_id=11, role="user", tenant_id=None)
+        self.assertNotEqual(resp.status_code, 200)
+        self.assertEqual(resp.status_code, 403)
+
+    # --- admins keep global scope (must NOT be locked out) ---
+
+    def test_usage_tools_admin_keeps_global(self):
+        resp = self._authed_get("/api/tools", user_id=1, role="admin", tenant_id=None)
+        self.assertEqual(resp.status_code, 200)
+
+    def test_projects_admin_keeps_global(self):
+        resp = self._authed_get("/api/projects", user_id=1, role="admin", tenant_id=None)
+        # Admin with no projects -> 200 with empty list (NOT 403).
+        self.assertEqual(resp.status_code, 200)
+
+    # --- tenant-scoped non-admins keep their tenant (not denied) ---
+
+    def test_usage_tools_tenant_user_allowed(self):
+        resp = self._authed_get("/api/tools", user_id=10, role="user", tenant_id=7)
+        self.assertEqual(resp.status_code, 200)
+
+    def test_projects_tenant_user_allowed(self):
+        resp = self._authed_get("/api/projects", user_id=10, role="user", tenant_id=7)
+        self.assertEqual(resp.status_code, 200)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Root cause

PR #1775 introduced `_current_tenant_id()` on the governance, usage, compliance, and projects blueprints. It returns `user.get("tenant_id")`, which is `None` for a non-admin user with no tenant. Callers pass `tenant_id=_current_tenant_id()` to the repository layer, and **every repository treats `None` as "no filter" (wildcard/global)** rather than "deny". A non-admin user with no `tenant_id` can therefore read **cross-tenant** audit logs, usage data, and projects.

A prior review triage mislabeled #1775 as reverted — it is **not**; `_current_tenant_id` is live on `origin/main` (verified via `git show origin/main:app/routes/governance.py`).

## Attack surface (confirmed)

- `app/routes/usage.py` — `@auth_required`-level blueprint (reachable by any non-admin). Every route calls `_current_tenant_id()`.
- `app/routes/projects.py` — custom `_authenticate_user` (reachable by any non-admin). Every route calls `_current_tenant_id()`.
- `app/routes/governance.py` and `app/routes/compliance.py` — **not vulnerable at the route layer**: every `_current_tenant_id()` call there sits behind `@admin_required`, and admins legitimately have global scope.

Repo-layer confirmation (treats `None` as wildcard): `app/repositories/usage_repo.py`, `app/repositories/project_repo.py` (skip the `tenant_id` filter when normalized id is `None`).

## Fix

Add a shared, side-effect-free helper in `app/auth/decorators.py` that mirrors the **existing** workspace pattern (`_tenant_scope_required` / `_session_lookup_tenant_id` in `app/routes/workspace.py`):

- `resolve_tenant_scope()` → `(tenant_id, is_admin)` — admins global, non-admins tenant-scoped.
- `require_tenant_scope()` → `(tenant_id, error)` — returns a `403` response for a **non-admin** with no resolvable tenant; admins keep global scope (`None`); tenant-scoped non-admins keep their tenant.

Wire a `before_request` gate on `usage_bp` and `projects_bp` that denies the request when `require_tenant_scope()` returns an error. This is minimal and surgical — no per-route changes, no change to repository behaviour, admins are never locked out.

## TDD

`tests/issues/1775/test_route_tenant_fail_closed.py` (Flask `test_client`):

**RED on `origin/main`** — a no-tenant non-admin reading `/api/tools`, `/api/today`, `/api/projects` returns **200** (the leak):
```
FAILED test_usage_tools_denied_for_notenant_non_admin - AssertionError: 200 == 200
FAILED test_usage_today_denied_for_notenant_non_admin  - AssertionError: 200 == 200
FAILED test_projects_denied_for_notenant_non_admin     - AssertionError: 200 == 200
3 failed, 4 passed
```

**GREEN after fix** — the three reads become **403**, while admin-global (`/api/tools`, `/api/projects` → 200) and tenant-scoped non-admin (→ 200) paths are preserved:
```
7 passed
```

The test rebinds the route-blueprint module singletons per-test so it is immune to cross-test DB-URL pollution when the full suite runs alongside the `tests/integration/test_*_tenant_scope.py` tests (verified: 10 passed when run together).

## Lint

`black` (25.1.0), `isort`, `ruff`, `mypy`, `bandit`, `pydocstyle` all pass via pre-commit on the changed files. (A pre-existing `TC006` on an untouched line of `projects.py` remains, matching `origin/main`.)

## Scope

One commit, three source files + one test file. No repository changes, no admin lockout, no unrelated edits.

Addresses review findings on #1775. Complements #1801 (session-layer fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)