### PR TITLE
feat: link audit action and resource filters

### DIFF
--- a/app/modules/governance/audit_logger.py
+++ b/app/modules/governance/audit_logger.py
@@ -688,6 +688,7 @@ def get_action_categories() -> dict[str, dict[str, Any]]:
         "auth": {
             "label": "Authentication",
             "i18n_key": "categoryAuth",
+            "resource_types": ["session"],
             "actions": [
                 {
                     "value": "login",
@@ -714,6 +715,7 @@ def get_action_categories() -> dict[str, dict[str, Any]]:
         "user_management": {
             "label": "User Management",
             "i18n_key": "categoryUserManagement",
+            "resource_types": ["user"],
             "actions": [
                 {
                     "value": "user_create",
@@ -750,6 +752,7 @@ def get_action_categories() -> dict[str, dict[str, Any]]:
         "permission": {
             "label": "Permission",
             "i18n_key": "categoryPermission",
+            "resource_types": ["user"],
             "actions": [
                 {
                     "value": "permission_grant",
@@ -766,6 +769,7 @@ def get_action_categories() -> dict[str, dict[str, Any]]:
         "quota": {
             "label": "Quota",
             "i18n_key": "categoryQuota",
+            "resource_types": ["quota_alert"],
             "actions": [
                 {
                     "value": "quota_update",
@@ -787,6 +791,7 @@ def get_action_categories() -> dict[str, dict[str, Any]]:
         "data": {
             "label": "Data",
             "i18n_key": "categoryData",
+            "resource_types": ["analytics_report", "analytics", "data"],
             "actions": [
                 {
                     "value": "data_view",
@@ -813,6 +818,12 @@ def get_action_categories() -> dict[str, dict[str, Any]]:
         "system": {
             "label": "System",
             "i18n_key": "categorySystem",
+            "resource_types": [
+                "content_filter",
+                "filter_rule",
+                "security_settings",
+                "ai_agent_settings",
+            ],
             "actions": [
                 {
                     "value": "system_config_change",
@@ -834,6 +845,7 @@ def get_action_categories() -> dict[str, dict[str, Any]]:
         "content": {
             "label": "Content",
             "i18n_key": "categoryContent",
+            "resource_types": ["content"],
             "actions": [
                 {
                     "value": "content_blocked",
@@ -860,6 +872,7 @@ def get_action_categories() -> dict[str, dict[str, Any]]:
         "agent": {
             "label": "Agent",
             "i18n_key": "categoryAgent",
+            "resource_types": ["remote_machine", "agent_token"],
             "actions": [
                 {
                     "value": "agent_register",

--- a/app/routes/governance.py
+++ b/app/routes/governance.py
@@ -132,20 +132,34 @@ def api_audit_actions():
 
     # Build flat list of all actions
     all_actions = []
+    action_to_category: dict[str, str] = {}
+    action_to_resource_types: dict[str, list[str]] = {}
+    resource_to_categories: dict[str, list[str]] = {}
     for category_key, category_data in categories_data.items():
+        resource_types = category_data.get("resource_types", [])
         for action in category_data["actions"]:
+            action_to_category[action["value"]] = category_key
+            action_to_resource_types[action["value"]] = resource_types
             all_actions.append(
                 {
                     "value": action["value"],
                     "label": action["label"],
                     "category": category_key,
                     "i18n_key": action["i18n_key"],
+                    "resource_types": resource_types,
                 }
             )
+        for resource_type in resource_types:
+            resource_to_categories.setdefault(resource_type, []).append(category_key)
 
     # Build categories list
     categories = [
-        {"key": key, "label": data["label"], "i18n_key": data["i18n_key"]}
+        {
+            "key": key,
+            "label": data["label"],
+            "i18n_key": data["i18n_key"],
+            "resource_types": data.get("resource_types", []),
+        }
         for key, data in categories_data.items()
     ]
 
@@ -153,6 +167,9 @@ def api_audit_actions():
         {
             "actions": all_actions,
             "categories": categories,
+            "actionToCategory": action_to_category,
+            "actionToResourceTypes": action_to_resource_types,
+            "resourceToCategories": resource_to_categories,
         }
     )
 

--- a/frontend/src/components/features/management/AuditCenter.tsx
+++ b/frontend/src/components/features/management/AuditCenter.tsx
@@ -146,7 +146,11 @@ export const AuditCenter: React.FC = () => {
   const [selectedUserId, setSelectedUserId] = useState<number | null>(null);
 
   // --- Audit Actions Hook ---
-  const { actions: auditActions, categories: auditCategories } = useAuditActions();
+  const {
+    actions: auditActions,
+    categories: auditCategories,
+    actionToResourceTypes,
+  } = useAuditActions();
 
   const handleAnomalyStatusUpdate = async (
     anomalyType: string,
@@ -272,10 +276,45 @@ export const AuditCenter: React.FC = () => {
     [language]
   );
 
+  const allowedResourceTypesForAction = useMemo(
+    () => (filters.action ? (actionToResourceTypes[filters.action] ?? []) : []),
+    [actionToResourceTypes, filters.action]
+  );
+  const isResourceTypeLinked = Boolean(filters.action && allowedResourceTypesForAction.length > 0);
+
+  const filteredResourceTypeOptions = useMemo(() => {
+    if (!isResourceTypeLinked) {
+      return resourceTypeOptions;
+    }
+    return resourceTypeOptions.filter(
+      (option) => option.value === '' || allowedResourceTypesForAction.includes(option.value)
+    );
+  }, [allowedResourceTypesForAction, isResourceTypeLinked, resourceTypeOptions]);
+
   const handleFilterChange = (key: keyof AuditLogFilters, value: string) => {
-    setFilters((prev) => ({ ...prev, [key]: value || undefined }));
+    setFilters((prev) => {
+      const next = { ...prev, [key]: value || undefined };
+      if (key === 'action' && value && prev.resource_type) {
+        const allowed = actionToResourceTypes[value] ?? [];
+        if (allowed.length > 0 && !allowed.includes(prev.resource_type)) {
+          next.resource_type = undefined;
+        }
+      }
+      return next;
+    });
     setPage(1);
   };
+
+  useEffect(() => {
+    if (!filters.action || !filters.resource_type) {
+      return;
+    }
+    const allowed = actionToResourceTypes[filters.action] ?? [];
+    if (allowed.length > 0 && !allowed.includes(filters.resource_type)) {
+      setFilters((prev) => ({ ...prev, resource_type: undefined }));
+      setPage(1);
+    }
+  }, [actionToResourceTypes, filters.action, filters.resource_type]);
 
   const handleReset = () => {
     setFilters(getDefaultAuditFilters());
@@ -389,10 +428,15 @@ export const AuditCenter: React.FC = () => {
             <div className="col-md-3">
               <label className="form-label">{t('resourceType', language)}</label>
               <Select
-                options={resourceTypeOptions}
+                options={filteredResourceTypeOptions}
                 value={filters.resource_type ?? ''}
                 onChange={(value) => handleFilterChange('resource_type', value)}
               />
+              {isResourceTypeLinked && (
+                <div className="form-text" aria-live="polite">
+                  {t('resourceTypesFilteredByAction', language)}
+                </div>
+              )}
             </div>
             <div className="col-md-3">
               <label className="form-label">{t('startDate', language)}</label>

--- a/frontend/src/hooks/useAuditActions.test.ts
+++ b/frontend/src/hooks/useAuditActions.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import {
+  AUDIT_ACTION_OPTIONS_FALLBACK,
+  AUDIT_CATEGORIES_FALLBACK,
+  buildAuditActionMappings,
+} from './useAuditActions';
+
+describe('buildAuditActionMappings', () => {
+  it('maps action values to related resource types', () => {
+    const mappings = buildAuditActionMappings(
+      AUDIT_ACTION_OPTIONS_FALLBACK,
+      AUDIT_CATEGORIES_FALLBACK
+    );
+
+    expect(mappings.actionToResourceTypes.login).toEqual(['session']);
+    expect(mappings.actionToResourceTypes.user_create).toEqual(['user']);
+    expect(mappings.actionToResourceTypes.data_export).toEqual([
+      'analytics_report',
+      'analytics',
+      'data',
+    ]);
+    expect(mappings.actionToResourceTypes.agent_token_rotate).toEqual([
+      'remote_machine',
+      'agent_token',
+    ]);
+  });
+
+  it('builds reverse resource-to-category mapping for fallback data', () => {
+    const mappings = buildAuditActionMappings(
+      AUDIT_ACTION_OPTIONS_FALLBACK,
+      AUDIT_CATEGORIES_FALLBACK
+    );
+
+    expect(mappings.resourceToCategories.session).toContain('auth');
+    expect(mappings.resourceToCategories.user).toEqual(['user_management', 'permission']);
+    expect(mappings.resourceToCategories.remote_machine).toEqual(['agent']);
+  });
+});

--- a/frontend/src/hooks/useAuditActions.ts
+++ b/frontend/src/hooks/useAuditActions.ts
@@ -215,15 +215,76 @@ export const AUDIT_ACTION_OPTIONS_FALLBACK: AuditActionItem[] = [
 ];
 
 export const AUDIT_CATEGORIES_FALLBACK: AuditCategory[] = [
-  { key: 'auth', label: 'Authentication', i18n_key: 'categoryAuth' },
-  { key: 'user_management', label: 'User Management', i18n_key: 'categoryUserManagement' },
-  { key: 'permission', label: 'Permission', i18n_key: 'categoryPermission' },
-  { key: 'quota', label: 'Quota', i18n_key: 'categoryQuota' },
-  { key: 'data', label: 'Data', i18n_key: 'categoryData' },
-  { key: 'system', label: 'System', i18n_key: 'categorySystem' },
-  { key: 'content', label: 'Content', i18n_key: 'categoryContent' },
-  { key: 'agent', label: 'Agent', i18n_key: 'categoryAgent' },
+  { key: 'auth', label: 'Authentication', i18n_key: 'categoryAuth', resource_types: ['session'] },
+  {
+    key: 'user_management',
+    label: 'User Management',
+    i18n_key: 'categoryUserManagement',
+    resource_types: ['user'],
+  },
+  {
+    key: 'permission',
+    label: 'Permission',
+    i18n_key: 'categoryPermission',
+    resource_types: ['user'],
+  },
+  {
+    key: 'quota',
+    label: 'Quota',
+    i18n_key: 'categoryQuota',
+    resource_types: ['quota_alert'],
+  },
+  {
+    key: 'data',
+    label: 'Data',
+    i18n_key: 'categoryData',
+    resource_types: ['analytics_report', 'analytics', 'data'],
+  },
+  {
+    key: 'system',
+    label: 'System',
+    i18n_key: 'categorySystem',
+    resource_types: ['content_filter', 'filter_rule', 'security_settings', 'ai_agent_settings'],
+  },
+  {
+    key: 'content',
+    label: 'Content',
+    i18n_key: 'categoryContent',
+    resource_types: ['content'],
+  },
+  {
+    key: 'agent',
+    label: 'Agent',
+    i18n_key: 'categoryAgent',
+    resource_types: ['remote_machine', 'agent_token'],
+  },
 ];
+
+export function buildAuditActionMappings(actions: AuditActionItem[], categories: AuditCategory[]) {
+  const categoryResourceTypes = Object.fromEntries(
+    categories.map((category) => [category.key, category.resource_types ?? []])
+  );
+  const actionToCategory: Record<string, string> = {};
+  const actionToResourceTypes: Record<string, string[]> = {};
+  const resourceToCategories: Record<string, string[]> = {};
+
+  actions.forEach((action) => {
+    actionToCategory[action.value] = action.category;
+    actionToResourceTypes[action.value] =
+      action.resource_types ?? categoryResourceTypes[action.category] ?? [];
+  });
+
+  categories.forEach((category) => {
+    (category.resource_types ?? []).forEach((resourceType) => {
+      resourceToCategories[resourceType] = resourceToCategories[resourceType] ?? [];
+      if (!resourceToCategories[resourceType].includes(category.key)) {
+        resourceToCategories[resourceType].push(category.key);
+      }
+    });
+  });
+
+  return { actionToCategory, actionToResourceTypes, resourceToCategories };
+}
 
 /**
  * Fetches audit actions from the backend API.
@@ -256,6 +317,11 @@ export function useAuditActions() {
   // Use API data if available, otherwise fall back to hardcoded constants
   const actions = data?.actions ?? AUDIT_ACTION_OPTIONS_FALLBACK;
   const categories = data?.categories ?? AUDIT_CATEGORIES_FALLBACK;
+  const fallbackMappings = buildAuditActionMappings(actions, categories);
+  const actionToCategory = data?.actionToCategory ?? fallbackMappings.actionToCategory;
+  const actionToResourceTypes =
+    data?.actionToResourceTypes ?? fallbackMappings.actionToResourceTypes;
+  const resourceToCategories = data?.resourceToCategories ?? fallbackMappings.resourceToCategories;
 
   // Log when using fallback data
   if (!data) {
@@ -265,6 +331,9 @@ export function useAuditActions() {
   return {
     actions,
     categories,
+    actionToCategory,
+    actionToResourceTypes,
+    resourceToCategories,
     isLoading,
     error,
     refetch,

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -273,6 +273,7 @@ export const translations: Record<Language, Translations> = {
     // Audit Log
     allActions: 'All Actions',
     allResourceTypes: 'All Resource Types',
+    resourceTypesFilteredByAction: 'Resource types are filtered by the selected action.',
     tableAction: 'Action',
     resourceType: 'Resource Type',
     resourceId: 'Resource ID',
@@ -1951,6 +1952,7 @@ export const translations: Record<Language, Translations> = {
     // Audit Log
     allActions: '所有操作',
     allResourceTypes: '所有资源类型',
+    resourceTypesFilteredByAction: '资源类型已根据所选操作自动过滤。',
     tableAction: '操作',
     resourceType: '资源类型',
     resourceId: '资源 ID',
@@ -3803,6 +3805,8 @@ export const translations: Record<Language, Translations> = {
     // Audit Log
     allActions: 'すべてのアクション',
     allResourceTypes: 'すべてのリソースタイプ',
+    resourceTypesFilteredByAction:
+      'リソースタイプは選択したアクションに基づいて絞り込まれています。',
     tableAction: 'アクション',
     resourceType: 'リソースタイプ',
     resourceId: 'リソースID',
@@ -5304,6 +5308,7 @@ export const translations: Record<Language, Translations> = {
     // Audit Log
     allActions: '모든 작업',
     allResourceTypes: '모든 리소스 유형',
+    resourceTypesFilteredByAction: '선택한 작업에 따라 리소스 유형이 필터링됩니다.',
     tableAction: '작업',
     resourceType: '리소스 유형',
     resourceId: '리소스 ID',

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -397,15 +397,20 @@ export interface AuditActionItem {
   label: string;
   category: string;
   i18n_key: string;
+  resource_types?: string[];
 }
 
 export interface AuditCategory {
   key: string;
   label: string;
   i18n_key: string;
+  resource_types?: string[];
 }
 
 export interface AuditActionsResponse {
   actions: AuditActionItem[];
   categories: AuditCategory[];
+  actionToCategory?: Record<string, string>;
+  actionToResourceTypes?: Record<string, string[]>;
+  resourceToCategories?: Record<string, string[]>;
 }

--- a/tests/routes/test_audit_actions_api.py
+++ b/tests/routes/test_audit_actions_api.py
@@ -1,0 +1,45 @@
+from unittest.mock import patch
+
+import pytest
+
+MOCK_ADMIN_SESSION = {
+    "user_id": 1,
+    "username": "admin",
+    "email": "admin@example.com",
+    "role": "admin",
+}
+
+
+@pytest.fixture
+def app():
+    from flask import Flask
+
+    from app.routes.governance import governance_bp
+
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.register_blueprint(governance_bp, url_prefix="/api")
+    return app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def test_audit_actions_api_includes_resource_mapping(client):
+    with patch("app.auth.decorators._authenticate", return_value=(True, MOCK_ADMIN_SESSION)):
+        resp = client.get("/api/audit-actions", headers={"Authorization": "Bearer t"})
+
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["actionToCategory"]["login"] == "auth"
+    assert data["actionToResourceTypes"]["login"] == ["session"]
+    assert data["actionToResourceTypes"]["user_create"] == ["user"]
+    assert "data" in data["actionToResourceTypes"]["data_export"]
+    assert "agent" in data["resourceToCategories"]["remote_machine"]
+
+    auth_category = next(category for category in data["categories"] if category["key"] == "auth")
+    assert auth_category["resource_types"] == ["session"]
+    login_action = next(action for action in data["actions"] if action["value"] == "login")
+    assert login_action["resource_types"] == ["session"]

--- a/tests/unit/test_audit_logger.py
+++ b/tests/unit/test_audit_logger.py
@@ -525,6 +525,8 @@ class TestGetActionCategories:
         for category_key, category_data in categories.items():
             assert "label" in category_data
             assert "i18n_key" in category_data
+            assert "resource_types" in category_data
+            assert isinstance(category_data["resource_types"], list)
             assert "actions" in category_data
             for action in category_data["actions"]:
                 assert "value" in action
@@ -562,3 +564,14 @@ class TestGetActionCategories:
         action_values = [a["value"] for a in content_actions]
         assert "content_warned" in action_values
         assert "content_redacted" in action_values
+
+    def test_get_action_categories_declares_related_resource_types(self):
+        """Test action categories expose resource mappings for linked UI filters."""
+        from app.modules.governance.audit_logger import get_action_categories
+
+        categories = get_action_categories()
+        assert categories["auth"]["resource_types"] == ["session"]
+        assert categories["user_management"]["resource_types"] == ["user"]
+        assert categories["data"]["resource_types"] == ["analytics_report", "analytics", "data"]
+        assert categories["agent"]["resource_types"] == ["remote_machine", "agent_token"]
+        assert "security_settings" in categories["system"]["resource_types"]


### PR DESCRIPTION
## Summary
- add backend audit action/resource mappings to the audit-actions API while preserving existing actions/categories fields
- use fallback mappings in the frontend hook when API mapping fields are unavailable
- filter Audit Center resource-type options by the selected action and clear incompatible resource selections
- add Python and Vitest coverage for the mapping behavior

Closes #1437

## Validation
- pytest tests/unit/test_audit_logger.py tests/routes/test_audit_actions_api.py -q
- npm run typecheck
- npm test -- --run src/hooks/useAuditActions.test.ts
- npm run lint (passes with existing warnings)
- SKIP=bandit,no-commit-to-branch /Users/rhuang/Library/Python/3.9/bin/pre-commit run --all-files