### PR TITLE
fix(high): clean up Codex bearer token on stop/exit and stop persisting it plaintext

### DIFF
--- a/remote-agent/agent.py
+++ b/remote-agent/agent.py
@@ -898,8 +898,13 @@ class RemoteAgent:
         finally:
             # Scrub the persisted Codex bearer token (Windows-UWP launch path)
             # so a stopped/abandoned terminal does not leave a still-valid
-            # proxy token behind in ~/.codex/config.toml.
-            clear_codex_bearer_token()
+            # proxy token behind in ~/.codex/config.toml. Only do this once no
+            # other terminal remains: the bearer token lives in a single shared
+            # config file, and other still-running terminals may depend on it
+            # (the UWP path cannot read it from the environment). The current id
+            # has already been popped by _stop_terminal_process above.
+            if not self._terminal_processes:
+                clear_codex_bearer_token()
         self._http_send(
             {
                 "type": "terminal_status",

--- a/remote-agent/agent.py
+++ b/remote-agent/agent.py
@@ -24,7 +24,7 @@ from datetime import datetime
 from typing import Any
 
 import requests
-from cli_settings import apply_cli_settings
+from cli_settings import apply_cli_settings, clear_codex_bearer_token
 from executor import ProcessExecutor
 from session_sync import SessionSyncService
 from system_info import get_capabilities
@@ -893,7 +893,13 @@ class RemoteAgent:
         """Handle a stop_terminal command."""
         terminal_id = data.get("terminal_id", "")
         logger.info("Stopping terminal %s", terminal_id[:8])
-        self._stop_terminal_process(terminal_id)
+        try:
+            self._stop_terminal_process(terminal_id)
+        finally:
+            # Scrub the persisted Codex bearer token (Windows-UWP launch path)
+            # so a stopped/abandoned terminal does not leave a still-valid
+            # proxy token behind in ~/.codex/config.toml.
+            clear_codex_bearer_token()
         self._http_send(
             {
                 "type": "terminal_status",

--- a/remote-agent/cli_settings.py
+++ b/remote-agent/cli_settings.py
@@ -288,10 +288,53 @@ def write_codex_settings(
     if isinstance(provider, dict):
         _set_codex_auth_mode(provider, bearer_token=bearer_token)
     _atomic_write_text(config_path, dump_toml(merged))
-    # Ensure config file has secure permissions (0600) when containing bearer token
-    if bearer_token:
+    # Ensure config file has secure permissions when it carries a bearer token.
+    # chmod(0o600) only enforces ACLs on POSIX; on Windows it merely toggles the
+    # read-only attribute and leaves the file world-readable, so callers relying
+    # on file-permission isolation on Windows must layer a Win32 ACL (icacls /
+    # pywin32) on top rather than trusting the POSIX bits here.
+    if bearer_token and os.name == "posix":
         config_path.chmod(0o600)
     return config_path
+
+
+def clear_codex_bearer_token(home_dir: Path | None = None) -> None:
+    """Remove a persisted Codex bearer token from ``~/.codex/config.toml``.
+
+    The Windows-UWP launch path writes ``experimental_bearer_token`` into the
+    on-disk Codex config because Codex desktop cannot read environment
+    variables. That token is a still-valid proxy token until server-side
+    expiry, so it must be scrubbed as soon as the terminal session that needed
+    it stops or exits. This helper rewrites the config to drop the bearer
+    token and fall back to ``env_key`` auth, preserving all non-sensitive
+    user preferences and proxy routing.
+
+    Args:
+        home_dir: Optional home directory path; defaults to ``Path.home()``.
+
+    This is idempotent: a missing config file or a config without a bearer
+    token is a no-op.
+    """
+    base_dir = home_dir or Path.home()
+    config_path = base_dir / ".codex" / "config.toml"
+    if not config_path.exists():
+        return
+    try:
+        merged = _load_toml_file(config_path)
+    except OSError:
+        return
+    providers = merged.get("model_providers")
+    if not isinstance(providers, dict):
+        return
+    openace = providers.get("openace")
+    if not isinstance(openace, dict) or "experimental_bearer_token" not in openace:
+        return
+    # Re-apply env-key auth, which also pops the bearer token, then persist.
+    _set_codex_auth_mode(openace, bearer_token=None)
+    try:
+        _atomic_write_text(config_path, dump_toml(merged))
+    except OSError as exc:
+        logger.warning("Failed to clear Codex bearer token from %s: %s", config_path, exc)
 
 
 def write_zcode_settings(

--- a/remote-agent/cli_settings.py
+++ b/remote-agent/cli_settings.py
@@ -7,6 +7,7 @@ import logging
 import os
 import re
 import tempfile
+import threading
 from pathlib import Path
 from typing import Any
 
@@ -21,6 +22,14 @@ except ModuleNotFoundError:  # pragma: no cover - Python < 3.11
 logger = logging.getLogger(__name__)
 
 _BARE_TOML_KEY_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+
+# Serializes all read-modify-write access to ~/.codex/config.toml within this
+# process. write_codex_settings and clear_codex_bearer_token each do a
+# load -> mutate -> _atomic_write cycle; without a lock, a concurrent caller's
+# stale snapshot can clobber another's freshly written field (lost update) even
+# though each individual write is atomic. RemoteAgent is a long-lived process
+# driving multiple terminals concurrently, so this race is reachable.
+_CODEX_CONFIG_LOCK = threading.Lock()
 
 
 def _atomic_write_json(filepath: Path, data: dict | list) -> None:
@@ -283,11 +292,15 @@ def write_codex_settings(
         proxy_base_url,
         bearer_token=bearer_token,
     )
-    merged = _deep_merge_dicts(_load_toml_file(config_path), normalized)
-    provider = merged.get("model_providers", {}).get("openace")
-    if isinstance(provider, dict):
-        _set_codex_auth_mode(provider, bearer_token=bearer_token)
-    _atomic_write_text(config_path, dump_toml(merged))
+    # Hold the process-wide lock across load->mutate->write so a concurrent
+    # clear_codex_bearer_token (or another write_codex_settings) cannot interleave
+    # and lose fields via a stale-snapshot overwrite.
+    with _CODEX_CONFIG_LOCK:
+        merged = _deep_merge_dicts(_load_toml_file(config_path), normalized)
+        provider = merged.get("model_providers", {}).get("openace")
+        if isinstance(provider, dict):
+            _set_codex_auth_mode(provider, bearer_token=bearer_token)
+        _atomic_write_text(config_path, dump_toml(merged))
     # Ensure config file has secure permissions when it carries a bearer token.
     # chmod(0o600) only enforces ACLs on POSIX; on Windows it merely toggles the
     # read-only attribute and leaves the file world-readable, so callers relying
@@ -319,22 +332,31 @@ def clear_codex_bearer_token(home_dir: Path | None = None) -> None:
     config_path = base_dir / ".codex" / "config.toml"
     if not config_path.exists():
         return
-    try:
-        merged = _load_toml_file(config_path)
-    except OSError:
-        return
-    providers = merged.get("model_providers")
-    if not isinstance(providers, dict):
-        return
-    openace = providers.get("openace")
-    if not isinstance(openace, dict) or "experimental_bearer_token" not in openace:
-        return
-    # Re-apply env-key auth, which also pops the bearer token, then persist.
-    _set_codex_auth_mode(openace, bearer_token=None)
-    try:
-        _atomic_write_text(config_path, dump_toml(merged))
-    except OSError as exc:
-        logger.warning("Failed to clear Codex bearer token from %s: %s", config_path, exc)
+    # Hold the process-wide lock across load->mutate->write so a concurrent
+    # write_codex_settings cannot interleave and lose fields via a stale-snapshot
+    # overwrite. The early-return no-op checks stay outside the lock only when
+    # the file is absent; once it exists we serialize the full RMW.
+    with _CODEX_CONFIG_LOCK:
+        try:
+            merged = _load_toml_file(config_path)
+        except OSError:
+            return
+        providers = merged.get("model_providers")
+        if not isinstance(providers, dict):
+            logger.warning(
+                "Codex config %s is missing model_providers; cannot scrub bearer token",
+                config_path,
+            )
+            return
+        openace = providers.get("openace")
+        if not isinstance(openace, dict) or "experimental_bearer_token" not in openace:
+            return
+        # Re-apply env-key auth, which also pops the bearer token, then persist.
+        _set_codex_auth_mode(openace, bearer_token=None)
+        try:
+            _atomic_write_text(config_path, dump_toml(merged))
+        except OSError as exc:
+            logger.warning("Failed to clear Codex bearer token from %s: %s", config_path, exc)
 
 
 def write_zcode_settings(

--- a/remote-agent/openace_cli.py
+++ b/remote-agent/openace_cli.py
@@ -27,7 +27,7 @@ AGENT_DIR = Path(__file__).resolve().parent
 if str(AGENT_DIR) not in sys.path:
     sys.path.insert(0, str(AGENT_DIR))
 
-from cli_settings import apply_cli_settings
+from cli_settings import apply_cli_settings, clear_codex_bearer_token
 
 AGENT_CONFIG_PATH = AGENT_DIR / "config.json"
 CLI_CONFIG_DIR = Path.home() / ".open-ace-cli"
@@ -307,7 +307,21 @@ def cmd_menu(args: argparse.Namespace) -> int:
     _apply_local_cli_settings(terminal)
     _write_active_terminal(terminal)
     env = _session_env(terminal)
-    os.execvpe(sys.executable, [sys.executable, str(MENU_PATH)], env)
+    # Run the menu as a child process we wait on so a ``finally`` block can
+    # scrub the persisted Codex bearer token and the active-terminal pointer
+    # when the menu exits. ``os.execvpe`` would replace the process image and
+    # leave the bearer token orphaned on disk indefinitely.
+    try:
+        completed = subprocess.run(
+            [sys.executable, str(MENU_PATH)],
+            env=env,
+            cwd=work_dir,
+            check=False,
+        )
+        return int(completed.returncode)
+    finally:
+        clear_codex_bearer_token()
+        _clear_active_terminal()
 
 
 def cmd_shell(args: argparse.Namespace) -> int:
@@ -326,6 +340,7 @@ def cmd_shell(args: argparse.Namespace) -> int:
             subprocess.run([shell, "-l"], env=env, cwd=work_dir, check=False)
     finally:
         _clear_active_terminal()
+        clear_codex_bearer_token()
     return 0
 
 

--- a/remote-agent/openace_cli.py
+++ b/remote-agent/openace_cli.py
@@ -340,6 +340,10 @@ def cmd_shell(args: argparse.Namespace) -> int:
             subprocess.run([shell, "-l"], env=env, cwd=work_dir, check=False)
     finally:
         _clear_active_terminal()
+        # Defensive cleanup: the SSH-CLI shell path passes the token via env
+        # (_session_env) and does not normally persist it to config.toml, so
+        # this is usually a no-op. We still call it in case some upstream path
+        # wrote a bearer token, so no terminal exit leaves one on disk.
         clear_codex_bearer_token()
     return 0
 

--- a/tests/issues/1776/test_codex_bearer_token_cleanup.py
+++ b/tests/issues/1776/test_codex_bearer_token_cleanup.py
@@ -301,6 +301,11 @@ def _bare_agent(agent_module):
         machine_id = "machine-123"
 
     agent.config = _FakeConfig()
+    # _cmd_stop_terminal's finally now checks whether any other terminal is
+    # still active before scrubbing the shared token, so the agent must carry
+    # the active-terminal map. Default to empty (no other terminals) so the
+    # single-stop path still clears the token.
+    agent._terminal_processes = {}
     return agent
 
 
@@ -345,6 +350,140 @@ def test_cmd_stop_terminal_clears_token_even_when_process_stop_fails(monkeypatch
     assert cleared == [
         None
     ], "bearer-token cleanup must run in the finally path of _cmd_stop_terminal"
+
+
+# ---------------------------------------------------------------------------
+# Severe#1 (round-2 review): multi-terminal concurrency
+# Stopping one terminal must NOT scrub the shared ~/.codex/config.toml token
+# while other terminals are still running (they may depend on it via the
+# Windows-UWP file-only path). Cleanup is only safe when no active terminal
+# remains. _stop_terminal_process pops the current id, so the finally branch
+# can simply check ``not self._terminal_processes``.
+# ---------------------------------------------------------------------------
+
+
+def test_cmd_stop_terminal_skips_clear_when_other_terminals_active(monkeypatch):
+    """Stopping terminal A while terminal B still runs must keep the token."""
+    agent_module = load_agent_module()
+    agent = _bare_agent(agent_module)
+    # Two terminals are active; _stop_terminal_process (real pop) removes the
+    # one being stopped, leaving the other in the map.
+    agent._terminal_processes = {"term-a": object(), "term-b": object()}
+
+    cleared = []
+
+    def fake_stop(terminal_id):
+        agent._terminal_processes.pop(terminal_id, None)
+
+    monkeypatch.setattr(agent, "_stop_terminal_process", fake_stop)
+    monkeypatch.setattr(agent, "_http_send", lambda payload: None)
+    monkeypatch.setattr(
+        agent_module, "clear_codex_bearer_token", lambda home_dir=None: cleared.append(home_dir)
+    )
+
+    agent._cmd_stop_terminal({"terminal_id": "term-a"})
+
+    assert (
+        cleared == []
+    ), "must NOT clear the shared bearer token while another terminal is still active"
+    assert "term-b" in agent._terminal_processes, "the other terminal must remain tracked"
+
+
+def test_cmd_stop_terminal_clears_token_when_last_terminal_stops(monkeypatch):
+    """Stopping the only/last terminal must scrub the token (regression guard)."""
+    agent_module = load_agent_module()
+    agent = _bare_agent(agent_module)
+    agent._terminal_processes = {"term-solo": object()}
+
+    cleared = []
+
+    def fake_stop(terminal_id):
+        agent._terminal_processes.pop(terminal_id, None)
+
+    monkeypatch.setattr(agent, "_stop_terminal_process", fake_stop)
+    monkeypatch.setattr(agent, "_http_send", lambda payload: None)
+    monkeypatch.setattr(
+        agent_module, "clear_codex_bearer_token", lambda home_dir=None: cleared.append(home_dir)
+    )
+
+    agent._cmd_stop_terminal({"terminal_id": "term-solo"})
+
+    assert cleared == [None], "must clear the shared bearer token once no active terminal remains"
+    assert agent._terminal_processes == {}
+
+
+# ---------------------------------------------------------------------------
+# Severe#2 (round-2 review): clear_codex_bearer_token / write_codex_settings
+# read-modify-write races. A process-wide threading.Lock must serialize all
+# access to ~/.codex/config.toml so a concurrent writer cannot lose fields.
+# ---------------------------------------------------------------------------
+
+
+def test_codex_config_writes_are_serialized(tmp_path, monkeypatch):
+    """Concurrent write_codex_settings + clear_codex_bearer_token must not lose
+    fields. Without a process lock, a slow reader's stale snapshot can clobber a
+    concurrent writer's newly-added field (lost update).
+
+    This is made deterministic by intercepting ``_load_toml_file`` inside
+    ``clear_codex_bearer_token``: the clearer reads a stale snapshot, then yields
+    so the writer can persist a fresh config, then the clearer writes its stale
+    snapshot back - clobbering the writer's change. A process-wide lock must
+    make the whole read-modify-write atomic so no field is lost.
+    """
+    cli_settings = load_cli_settings()
+
+    config_path = _seed_codex_token(cli_settings, tmp_path, "proxy-token-123")
+    assert config_path.exists()
+
+    import threading
+
+    real_load = cli_settings._load_toml_file
+    clearer_ready = threading.Event()
+    clearer_read = threading.Event()
+    writer_done = threading.Event()
+    in_clearer = threading.local()
+
+    def racing_load(filepath):
+        # Only inject the stall for reads issued by the clearer thread.
+        if getattr(in_clearer, "value", False) and not clearer_read.is_set():
+            clearer_read.set()
+            # Let the writer land its fresh config while we hold a stale snapshot.
+            writer_done.wait(timeout=5)
+        return real_load(filepath)
+
+    monkeypatch.setattr(cli_settings, "_load_toml_file", racing_load)
+
+    def clearer():
+        in_clearer.value = True
+        clearer_ready.set()
+        cli_settings.clear_codex_bearer_token(home_dir=tmp_path)
+
+    def writer():
+        # Wait until the clearer has captured its stale snapshot, then write a
+        # fresh config carrying a brand-new field the clearer never saw.
+        clearer_read.wait(timeout=5)
+        cli_settings.write_codex_settings(
+            {"model_provider": "openace"},
+            proxy_base_url="https://openace.example/api/remote/llm-proxy/v1",
+            home_dir=tmp_path,
+            bearer_token="writer-token-999",
+        )
+        writer_done.set()
+
+    t_clear = threading.Thread(target=clearer)
+    t_write = threading.Thread(target=writer)
+    t_clear.start()
+    t_write.start()
+    t_clear.join(timeout=10)
+    t_write.join(timeout=10)
+
+    parsed = cli_settings.tomllib.loads(config_path.read_text(encoding="utf-8"))
+    openace = parsed["model_providers"]["openace"]
+    # The writer's bearer token must survive the clearer's stale rewrite.
+    assert openace.get("experimental_bearer_token") == "writer-token-999", (
+        "writer's field was lost to a concurrent read-modify-write race "
+        "(missing serialization lock on ~/.codex/config.toml)"
+    )
 
 
 def _ns(work_dir: str | None = None):

--- a/tests/issues/1776/test_codex_bearer_token_cleanup.py
+++ b/tests/issues/1776/test_codex_bearer_token_cleanup.py
@@ -1,0 +1,353 @@
+#!/usr/bin/env python3
+"""Regression tests for the Codex bearer-token cleanup (review on PR #1776).
+
+These cover four confirmed findings all rooted in the bearer token being
+persisted to ``~/.codex/config.toml`` and never removed:
+
+1. ``cmd_menu`` (default entry point) used ``os.execvpe`` which replaces the
+   process image, so no ``finally`` / ``atexit`` cleanup ever ran.
+2. ``_cmd_stop_terminal`` / ``_cmd_attach_terminal`` re-applied tokens but
+   never removed them, leaving stale tokens on disk.
+3. The bearer token was persisted in plaintext with no eviction path.
+4. ``chmod(0o600)`` is a no-op on Windows, so the POSIX-only assertion gave a
+   false sense of protection.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import stat
+import sys
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Module loading helpers (mirrors tests/unit/test_cli_settings_apply.py style)
+# ---------------------------------------------------------------------------
+
+
+def load_cli_settings():
+    module_path = Path(__file__).resolve().parents[3] / "remote-agent" / "cli_settings.py"
+    agent_dir = str(module_path.parent)
+    if agent_dir not in sys.path:
+        sys.path.insert(0, agent_dir)
+    spec = importlib.util.spec_from_file_location("cli_settings_1776", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+def load_openace_cli():
+    module_path = Path(__file__).resolve().parents[3] / "remote-agent" / "openace_cli.py"
+    agent_dir = str(module_path.parent)
+    if agent_dir not in sys.path:
+        sys.path.insert(0, agent_dir)
+    spec = importlib.util.spec_from_file_location("openace_cli_1776", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+def _seed_codex_token(cli_settings, tmp_path: Path, token: str) -> Path:
+    """Write a config.toml carrying an experimental_bearer_token."""
+    config_path = tmp_path / ".codex" / "config.toml"
+    cli_settings.write_codex_settings(
+        {},
+        proxy_base_url="https://openace.example/api/remote/llm-proxy/v1",
+        home_dir=tmp_path,
+        bearer_token=token,
+    )
+    assert config_path.exists()
+    return config_path
+
+
+# ---------------------------------------------------------------------------
+# Finding: clear_codex_bearer_token must remove a persisted bearer token
+# ---------------------------------------------------------------------------
+
+
+def test_clear_codex_bearer_token_removes_persisted_token(tmp_path):
+    cli_settings = load_cli_settings()
+    config_path = _seed_codex_token(cli_settings, tmp_path, "proxy-token-123")
+
+    cli_settings.clear_codex_bearer_token(home_dir=tmp_path)
+
+    parsed = cli_settings.tomllib.loads(config_path.read_text(encoding="utf-8"))
+    openace = parsed["model_providers"]["openace"]
+    assert (
+        "experimental_bearer_token" not in openace
+    ), "clear_codex_bearer_token must scrub the persisted bearer token"
+    # Non-sensitive routing must be preserved.
+    assert openace["base_url"] == "https://openace.example/api/remote/llm-proxy/v1"
+
+
+def test_clear_codex_bearer_token_is_idempotent_when_absent(tmp_path):
+    cli_settings = load_cli_settings()
+    config_path = tmp_path / ".codex" / "config.toml"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(
+        '[model_providers.openace]\nenv_key = "OPENAI_API_KEY"\n',
+        encoding="utf-8",
+    )
+
+    # Should not raise even though there is no bearer token to remove.
+    cli_settings.clear_codex_bearer_token(home_dir=tmp_path)
+
+    parsed = cli_settings.tomllib.loads(config_path.read_text(encoding="utf-8"))
+    assert "experimental_bearer_token" not in parsed["model_providers"]["openace"]
+
+
+def test_clear_codex_bearer_token_handles_missing_config(tmp_path):
+    cli_settings = load_cli_settings()
+    # No config.toml exists at all.
+    cli_settings.clear_codex_bearer_token(home_dir=tmp_path)
+    assert not (tmp_path / ".codex" / "config.toml").exists()
+
+
+# ---------------------------------------------------------------------------
+# Finding: write_codex_settings chmod must be POSIX-only / no false guarantee
+# ---------------------------------------------------------------------------
+
+
+def test_write_codex_settings_skips_chmod_on_windows(tmp_path):
+    """On Windows chmod is a no-op, so the writer must gate it on POSIX only.
+
+    Monkeypatching ``os.name`` globally also rewrites ``os.path`` internals
+    and breaks ``os.replace``/``Path`` instantiation on this POSIX host, so we
+    instead prove the contract two ways that do not perturb ``os.name``:
+    (1) the source gates the chmod on ``os.name == "posix"``, and
+    (2) on this POSIX host the chmod actually fires when a token is written.
+    """
+    cli_settings = load_cli_settings()
+
+    # (1) The chmod call site must be guarded by a POSIX check, not run on all
+    # platforms (chmod is a no-op on Windows and would give a false guarantee).
+    module_path = Path(__file__).resolve().parents[3] / "remote-agent" / "cli_settings.py"
+    source = module_path.read_text(encoding="utf-8")
+    assert (
+        'os.name == "posix"' in source
+    ), "write_codex_settings must gate the bearer-token chmod on os.name == 'posix'"
+
+    # (2) On POSIX the file is chmod'd 0600 when a token is written.
+    config_path = cli_settings.write_codex_settings(
+        {},
+        proxy_base_url="https://openace.example/api/remote/llm-proxy/v1",
+        home_dir=tmp_path,
+        bearer_token="proxy-token-123",
+    )
+    assert stat.S_IMODE(config_path.stat().st_mode) == 0o600
+
+
+def test_write_codex_settings_chmods_on_posix(tmp_path, monkeypatch):
+    cli_settings = load_cli_settings()
+    monkeypatch.setattr(cli_settings.os, "name", "posix")
+
+    config_path = cli_settings.write_codex_settings(
+        {},
+        proxy_base_url="https://openace.example/api/remote/llm-proxy/v1",
+        home_dir=tmp_path,
+        bearer_token="proxy-token-123",
+    )
+
+    assert stat.S_IMODE(config_path.stat().st_mode) == 0o600
+
+
+# ---------------------------------------------------------------------------
+# Finding: cmd_menu must clean up the bearer token (no exec-without-cleanup)
+# ---------------------------------------------------------------------------
+
+
+def _fake_terminal() -> dict:
+    return {
+        "session_id": "term-123",
+        "proxy_url": "https://openace.example/api/remote/llm-proxy",
+        "cli_settings": {"codex-cli": {"model_provider": "openace"}},
+        "tokens": {"openai": "proxy-token-123"},
+        "source": "ssh_cli",
+    }
+
+
+def test_cmd_menu_clears_bearer_token_after_menu_exits(monkeypatch, tmp_path):
+    openace_cli = load_openace_cli()
+
+    started = []
+    cleared_tokens = []
+
+    monkeypatch.setattr(openace_cli, "_start_cli_terminal", lambda work_dir: _fake_terminal())
+    monkeypatch.setattr(
+        openace_cli, "_apply_local_cli_settings", lambda terminal: started.append(terminal)
+    )
+    monkeypatch.setattr(openace_cli, "_write_active_terminal", lambda terminal: None)
+    monkeypatch.setattr(openace_cli, "_session_env", lambda terminal: {})
+    monkeypatch.setattr(openace_cli, "_clear_active_terminal", lambda: None)
+    monkeypatch.setattr(
+        openace_cli,
+        "clear_codex_bearer_token",
+        lambda home_dir=None: cleared_tokens.append(home_dir),
+    )
+
+    # The menu is launched as a subprocess we can wait on; simulate it returning.
+    class FakeProc:
+        returncode = 0
+
+        def wait(self):
+            return 0
+
+    captured = {}
+
+    def fake_run(args, env=None, cwd=None, check=False):
+        captured["called"] = True
+        captured["args"] = list(args)
+        return FakeProc()
+
+    monkeypatch.setattr(openace_cli.subprocess, "run", fake_run)
+
+    rc = openace_cli.cmd_menu(_ns(work_dir=str(tmp_path)))
+
+    assert rc == 0
+    assert captured.get("called") is True, "menu should still launch"
+    assert captured["args"][0] == sys.executable
+    assert cleared_tokens == [
+        None
+    ], "cmd_menu must clear the persisted bearer token after the menu exits"
+
+
+def test_cmd_menu_clears_token_even_when_menu_fails(monkeypatch, tmp_path):
+    openace_cli = load_openace_cli()
+
+    cleared_tokens = []
+    monkeypatch.setattr(openace_cli, "_start_cli_terminal", lambda work_dir: _fake_terminal())
+    monkeypatch.setattr(openace_cli, "_apply_local_cli_settings", lambda terminal: None)
+    monkeypatch.setattr(openace_cli, "_write_active_terminal", lambda terminal: None)
+    monkeypatch.setattr(openace_cli, "_session_env", lambda terminal: {})
+    monkeypatch.setattr(openace_cli, "_clear_active_terminal", lambda: None)
+    monkeypatch.setattr(
+        openace_cli,
+        "clear_codex_bearer_token",
+        lambda home_dir=None: cleared_tokens.append(home_dir),
+    )
+
+    def fake_run(args, env=None, cwd=None, check=False):
+        raise RuntimeError("menu crashed")
+
+    monkeypatch.setattr(openace_cli.subprocess, "run", fake_run)
+
+    # The cleanup must run regardless of menu failure.
+    with pytest.raises(RuntimeError):
+        openace_cli.cmd_menu(_ns(work_dir=str(tmp_path)))
+
+    assert cleared_tokens == [
+        None
+    ], "bearer-token cleanup must run in the finally path even if the menu crashes"
+
+
+def test_cmd_shell_clears_bearer_token_in_finally(monkeypatch, tmp_path):
+    openace_cli = load_openace_cli()
+
+    cleared_tokens = []
+    monkeypatch.setattr(openace_cli, "_start_cli_terminal", lambda work_dir: _fake_terminal())
+    monkeypatch.setattr(openace_cli, "_apply_local_cli_settings", lambda terminal: None)
+    monkeypatch.setattr(openace_cli, "_write_active_terminal", lambda terminal: None)
+    monkeypatch.setattr(openace_cli, "_session_env", lambda terminal: {})
+    monkeypatch.setattr(openace_cli, "_clear_active_terminal", lambda: None)
+    monkeypatch.setattr(
+        openace_cli,
+        "clear_codex_bearer_token",
+        lambda home_dir=None: cleared_tokens.append(home_dir),
+    )
+
+    ran = {"shell": False}
+
+    def fake_run(args, env=None, cwd=None, check=False):
+        ran["shell"] = True
+        return None
+
+    monkeypatch.setattr(openace_cli.subprocess, "run", fake_run)
+    monkeypatch.setattr(openace_cli, "_windows_shell_args", lambda: ["cmd.exe"])
+
+    rc = openace_cli.cmd_shell(_ns(work_dir=str(tmp_path)))
+
+    assert rc == 0
+    assert ran["shell"] is True
+    assert cleared_tokens == [None], "cmd_shell must clear the persisted bearer token"
+
+
+# ---------------------------------------------------------------------------
+# Finding: _cmd_stop_terminal must revoke the persisted bearer token
+# ---------------------------------------------------------------------------
+
+
+def load_agent_module():
+    module_path = Path(__file__).resolve().parents[3] / "remote-agent" / "agent.py"
+    agent_dir = str(module_path.parent)
+    if agent_dir in sys.path:
+        sys.path.remove(agent_dir)
+    sys.path.insert(0, agent_dir)
+    sys.modules.pop("config", None)
+    spec = importlib.util.spec_from_file_location("remote_agent_1776", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+def _bare_agent(agent_module):
+    agent = agent_module.RemoteAgent.__new__(agent_module.RemoteAgent)
+
+    class _FakeConfig:
+        machine_id = "machine-123"
+
+    agent.config = _FakeConfig()
+    return agent
+
+
+def test_cmd_stop_terminal_clears_persisted_bearer_token(monkeypatch):
+    """Stopping a terminal must scrub the on-disk Codex bearer token."""
+    agent_module = load_agent_module()
+    agent = _bare_agent(agent_module)
+
+    cleared = []
+    monkeypatch.setattr(agent, "_stop_terminal_process", lambda terminal_id: None)
+
+    sent = []
+    monkeypatch.setattr(agent, "_http_send", lambda payload: sent.append(payload))
+    monkeypatch.setattr(
+        agent_module, "clear_codex_bearer_token", lambda home_dir=None: cleared.append(home_dir)
+    )
+
+    agent._cmd_stop_terminal({"terminal_id": "term-123"})
+
+    assert cleared == [None], "_cmd_stop_terminal must clear the persisted bearer token on stop"
+    assert any(msg.get("status") == "stopped" for msg in sent)
+
+
+def test_cmd_stop_terminal_clears_token_even_when_process_stop_fails(monkeypatch):
+    agent_module = load_agent_module()
+    agent = _bare_agent(agent_module)
+
+    cleared = []
+    monkeypatch.setattr(
+        agent,
+        "_stop_terminal_process",
+        lambda terminal_id: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+    monkeypatch.setattr(agent, "_http_send", lambda payload: None)
+    monkeypatch.setattr(
+        agent_module, "clear_codex_bearer_token", lambda home_dir=None: cleared.append(home_dir)
+    )
+
+    with pytest.raises(RuntimeError):
+        agent._cmd_stop_terminal({"terminal_id": "term-123"})
+
+    assert cleared == [
+        None
+    ], "bearer-token cleanup must run in the finally path of _cmd_stop_terminal"
+
+
+def _ns(work_dir: str | None = None):
+    import argparse
+
+    return argparse.Namespace(work_dir=work_dir)

--- a/tests/unit/test_openace_cli.py
+++ b/tests/unit/test_openace_cli.py
@@ -199,11 +199,17 @@ def test_clear_active_terminal_metadata(monkeypatch, tmp_path):
     assert not active_path.exists()
 
 
-def test_cmd_menu_execs_terminal_menu_on_windows(monkeypatch):
+def test_cmd_menu_runs_terminal_menu_and_clears_token(monkeypatch):
+    """cmd_menu launches the menu as a waitable child and cleans up afterwards.
+
+    Previously cmd_menu used ``os.execvpe``, which replaces the process image
+    so no ``finally``/``atexit`` cleanup could run, leaving the persisted Codex
+    bearer token orphaned on disk. The menu now runs via ``subprocess.run`` and
+    the bearer token + active-terminal pointer are scrubbed in a ``finally``.
+    """
     openace_cli = load_openace_cli()
     calls = {}
 
-    monkeypatch.setattr(openace_cli.os, "name", "nt", raising=False)
     monkeypatch.setattr(
         openace_cli,
         "_start_cli_terminal",
@@ -213,22 +219,38 @@ def test_cmd_menu_execs_terminal_menu_on_windows(monkeypatch):
     monkeypatch.setattr(openace_cli, "_write_active_terminal", lambda terminal: None)
     monkeypatch.setattr(openace_cli, "_session_env", lambda terminal: {"ENV": "1"})
 
-    def fake_execvpe(file, argv, env):
-        calls["file"] = file
-        calls["argv"] = argv
-        calls["env"] = env
-        raise RuntimeError("stop")
+    cleared_tokens = []
+    cleared_terminal = []
+    monkeypatch.setattr(
+        openace_cli,
+        "clear_codex_bearer_token",
+        lambda home_dir=None: cleared_tokens.append(home_dir),
+    )
+    monkeypatch.setattr(
+        openace_cli, "_clear_active_terminal", lambda: cleared_terminal.append(True)
+    )
 
-    monkeypatch.setattr(openace_cli.os, "execvpe", fake_execvpe)
+    class FakeProc:
+        returncode = 0
+
+        def wait(self):
+            return 0
+
+    def fake_run(args, env=None, cwd=None, check=False):
+        calls["args"] = list(args)
+        calls["env"] = env
+        calls["cwd"] = cwd
+        return FakeProc()
+
+    monkeypatch.setattr(openace_cli.subprocess, "run", fake_run)
 
     args = type("Args", (), {"work_dir": "/repo"})()
-    try:
-        openace_cli.cmd_menu(args)
-    except RuntimeError as exc:
-        assert str(exc) == "stop"
-    else:  # pragma: no cover - defensive
-        raise AssertionError("cmd_menu did not attempt to exec the terminal menu")
+    rc = openace_cli.cmd_menu(args)
 
-    assert calls["file"] == openace_cli.sys.executable
-    assert calls["argv"] == [openace_cli.sys.executable, str(openace_cli.MENU_PATH)]
+    assert rc == 0
+    assert calls["args"] == [openace_cli.sys.executable, str(openace_cli.MENU_PATH)]
     assert calls["env"] == {"ENV": "1"}
+    assert calls["cwd"] == "/repo"
+    # Cleanup must run in the finally path after the menu exits.
+    assert cleared_tokens == [None]
+    assert cleared_terminal == [True]


### PR DESCRIPTION
## Summary

Fixes the Codex bearer-token cleanup findings from the review on #1776. All four are rooted in the same cause: the Windows-UWP launch path writes `experimental_bearer_token` into `~/.codex/config.toml` (because Codex desktop cannot read environment variables), and no launch/stop path ever removed it, so a still-valid proxy token was orphaned on disk indefinitely.

## Per-finding root cause + fix

### High — `cmd_menu` (default entry point) never cleared the bearer token
**Root cause:** `cmd_menu` called `os.execvpe`, which replaces the process image, so no `finally`/`atexit`/signal cleanup could run. Since `main()` defaults to `cmd_menu`, the most common launch path orphaned the token on disk indefinitely.
**Fix:** `cmd_menu` now launches the menu as a waitable `subprocess.run` child and scrubs the bearer token plus the active-terminal pointer in a `finally` block (`remote-agent/openace_cli.py`).

### High — `_cmd_stop_terminal` re-applied tokens but never removed them
**Root cause:** `_cmd_stop_terminal` only stopped the process and emitted a `terminal_status:stopped` event; it never rewrote `config.toml`. Across stop/start cycles stale tokens accumulated with no revocation.
**Fix:** `_cmd_stop_terminal` now calls `clear_codex_bearer_token()` in a `finally` so the persisted token is scrubbed even if process-stop raises (`remote-agent/agent.py`).

### Medium — Bearer token persisted in plaintext with no eviction path
**Root cause:** `write_codex_settings` wrote `experimental_bearer_token` into the merged config and atomically persisted it to disk. A leaked `config.toml` (backup/sync/support bundle) exposed a still-valid proxy token until server-side expiry.
**Fix:** Cleanup is centralized in `cli_settings.clear_codex_bearer_token`, which re-drops `experimental_bearer_token` and restores `env_key` auth while preserving all non-sensitive user preferences and proxy routing. It is idempotent (missing config / no token → no-op). `cmd_shell` also clears the token in its existing `finally`.

### Medium — `chmod(0o600)` is a no-op on Windows
**Root cause:** `write_codex_settings` ran `config_path.chmod(0o600)` on all platforms, but on Windows `chmod` only toggles the read-only attribute and leaves the file world-readable — the exact platform (UWP) that needs protection got a false guarantee.
**Fix:** The chmod is now gated on `os.name == "posix"` and the docstring documents that Windows callers must layer a Win32 ACL (icacls / pywin32) on top rather than trusting the POSIX bits.

## Tests

New regression suite at `tests/issues/1776/test_codex_bearer_token_cleanup.py` (10 tests, TDD red→green):
- `clear_codex_bearer_token` removes a persisted token, is idempotent when absent, and handles a missing config.
- `write_codex_settings` chmod is gated on POSIX (verified via source + actual 0600 on this POSIX host).
- `cmd_menu` clears the bearer token after the menu exits, and even when the menu crashes (finally path).
- `cmd_shell` clears the bearer token in its finally.
- `_cmd_stop_terminal` clears the persisted bearer token, and even when process-stop raises.

The existing `tests/unit/test_openace_cli.py::test_cmd_menu_execs_terminal_menu_on_windows` asserted the old `os.execvpe` contract; it was rewritten to `test_cmd_menu_runs_terminal_menu_and_clears_token` to assert the new subprocess + finally-cleanup contract.

All pre-commit hooks pass (black, isort, ruff, mypy, bandit, pydocstyle).

Addresses review findings on #1776.
