### PR TITLE
fix(high): tenant-key ROI cache, fix reset baseline, validate inf, drop unused assumption builds

### DIFF
--- a/app/modules/analytics/roi_calculator.py
+++ b/app/modules/analytics/roi_calculator.py
@@ -7,11 +7,12 @@ Provides cost analysis, savings estimation, and productivity metrics.
 
 import json
 import logging
+import math
 import os
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from typing import Any, Optional
+from typing import Any, Optional, cast
 
 from app.repositories.database import Database
 from app.utils.cache import cached
@@ -21,6 +22,22 @@ logger = logging.getLogger(__name__)
 
 # Thread pool for parallel queries
 _executor = ThreadPoolExecutor(max_workers=4)
+
+
+def _normalize_tenant_id(value: object) -> Optional[int]:
+    """Normalize a tenant identifier to a positive integer.
+
+    Mirrors ``usage_repo.UsageRepository._normalize_tenant_id``. ``None``/0/blank
+    collapse to ``None`` so single-tenant deployments keep their original
+    query shape (no tenant filter), while multi-tenant callers always scope.
+    """
+    if value in (None, "", 0, "0"):
+        return None
+    try:
+        tenant_id = int(cast(Any, value))
+    except (TypeError, ValueError):
+        return None
+    return tenant_id if tenant_id > 0 else None
 
 
 @dataclass
@@ -57,7 +74,7 @@ class ROIAssumptions:
                 "Invalid ROI env override %s=%r; using default %s", env_name, raw_value, default
             )
             return default
-        return parsed if parsed > 0 else default
+        return parsed if (math.isfinite(parsed) and parsed > 0) else default
 
     @classmethod
     def from_env(cls) -> "ROIAssumptions":
@@ -435,6 +452,7 @@ class ROICalculator:
         end_date: str,
         user_id: Optional[int] = None,
         tool_name: Optional[str] = None,
+        tenant_id: Optional[int] = None,
     ) -> Optional[ROIMetrics]:
         """
         Calculate ROI for a period.
@@ -444,10 +462,14 @@ class ROICalculator:
             end_date: End date (YYYY-MM-DD).
             user_id: Optional user ID filter.
             tool_name: Optional tool name filter.
+            tenant_id: Optional tenant scope (caller's tenant). Included in the
+                cache key so one tenant never reads another's aggregate.
 
         Returns:
             Optional[ROIMetrics]: ROI metrics, or None if no data found.
         """
+        normalized_tenant_id = _normalize_tenant_id(tenant_id)
+
         # Build query
         query = """
             SELECT
@@ -459,6 +481,10 @@ class ROICalculator:
             WHERE date >= ? AND date <= ?
         """
         params: list[Any] = [start_date, end_date]
+
+        if normalized_tenant_id is not None:
+            query += " AND tenant_id = ?"
+            params.append(normalized_tenant_id)
 
         if user_id:
             query += " AND user_id = ?"
@@ -482,6 +508,10 @@ class ROICalculator:
             WHERE date >= ? AND date <= ?
         """
         model_params: list[Any] = [start_date, end_date]
+
+        if normalized_tenant_id is not None:
+            model_query += " AND tenant_id = ?"
+            model_params.append(normalized_tenant_id)
 
         if user_id:
             model_query += " AND user_id = ?"
@@ -533,7 +563,12 @@ class ROICalculator:
         )
 
     @cached(ttl=60, key_prefix="roi")
-    def get_roi_trend(self, months: int = 6, user_id: Optional[int] = None) -> list[ROIMetrics]:
+    def get_roi_trend(
+        self,
+        months: int = 6,
+        user_id: Optional[int] = None,
+        tenant_id: Optional[int] = None,
+    ) -> list[ROIMetrics]:
         """
         Get ROI trend over months.
 
@@ -543,12 +578,14 @@ class ROICalculator:
         Args:
             months: Number of months to analyze.
             user_id: Optional user ID filter.
+            tenant_id: Optional tenant scope (caller's tenant).
 
         Returns:
             List of ROIMetrics.
         """
         today = datetime.now(timezone.utc).replace(tzinfo=None)
         start_date = (today - timedelta(days=months * 30)).strftime("%Y-%m-%d")
+        normalized_tenant_id = _normalize_tenant_id(tenant_id)
 
         # Check database type for SQL syntax
         from app.repositories.database import is_postgresql
@@ -572,6 +609,10 @@ class ROICalculator:
         """
         params: list[Any] = [start_date]
 
+        if normalized_tenant_id is not None:
+            query += " AND tenant_id = ?"
+            params.append(normalized_tenant_id)
+
         if user_id:
             query += " AND user_id = ?"
             params.append(user_id)
@@ -591,6 +632,10 @@ class ROICalculator:
             WHERE date >= ?
         """
         model_params: list[Any] = [start_date]
+
+        if normalized_tenant_id is not None:
+            model_query += " AND tenant_id = ?"
+            model_params.append(normalized_tenant_id)
 
         if user_id:
             model_query += " AND user_id = ?"
@@ -668,7 +713,12 @@ class ROICalculator:
         return trends
 
     @cached(ttl=60, key_prefix="roi")
-    def get_roi_by_tool(self, start_date: str, end_date: str) -> dict[str, ROIMetrics]:
+    def get_roi_by_tool(
+        self,
+        start_date: str,
+        end_date: str,
+        tenant_id: Optional[int] = None,
+    ) -> dict[str, ROIMetrics]:
         """
         Get ROI breakdown by tool.
 
@@ -678,35 +728,45 @@ class ROICalculator:
         Args:
             start_date: Start date.
             end_date: End date.
+            tenant_id: Optional tenant scope (caller's tenant).
 
         Returns:
             Dict mapping tool name to ROI metrics.
         """
+        normalized_tenant_id = _normalize_tenant_id(tenant_id)
+        tenant_clause = " AND tenant_id = ?" if normalized_tenant_id is not None else ""
+
         # Single query to get aggregated data by tool
-        query = """
+        query = f"""
             SELECT
                 tool_name,
                 COUNT(*) as request_count,
                 SUM(input_tokens) as total_input_tokens,
                 SUM(output_tokens) as total_output_tokens
             FROM daily_usage
-            WHERE date >= ? AND date <= ? AND tool_name IS NOT NULL
+            WHERE date >= ? AND date <= ? AND tool_name IS NOT NULL{tenant_clause}
             GROUP BY tool_name
         """
-        rows = self.db.fetch_all(query, (start_date, end_date))
+        params: list[Any] = [start_date, end_date]
+        if normalized_tenant_id is not None:
+            params.append(normalized_tenant_id)
+        rows = self.db.fetch_all(query, params)
 
         # Single query to get model breakdown by tool
-        model_query = """
+        model_query = f"""
             SELECT
                 tool_name,
                 models_used as model,
                 SUM(input_tokens) as input_tokens,
                 SUM(output_tokens) as output_tokens
             FROM daily_usage
-            WHERE date >= ? AND date <= ? AND tool_name IS NOT NULL
+            WHERE date >= ? AND date <= ? AND tool_name IS NOT NULL{tenant_clause}
             GROUP BY tool_name, models_used
         """
-        model_rows = self.db.fetch_all(model_query, (start_date, end_date))
+        model_params: list[Any] = [start_date, end_date]
+        if normalized_tenant_id is not None:
+            model_params.append(normalized_tenant_id)
+        model_rows = self.db.fetch_all(model_query, model_params)
 
         # Group model data by tool (normalize tool names)
         model_data_by_tool: dict[str, list[dict]] = {}
@@ -761,42 +821,57 @@ class ROICalculator:
         return result
 
     @cached(ttl=60, key_prefix="roi")
-    def get_roi_by_user(self, start_date: str, end_date: str) -> dict[str, ROIMetrics]:
+    def get_roi_by_user(
+        self,
+        start_date: str,
+        end_date: str,
+        tenant_id: Optional[int] = None,
+    ) -> dict[str, ROIMetrics]:
         """
         Get ROI breakdown by user (via host_name grouping).
 
         Args:
             start_date: Start date.
             end_date: End date.
+            tenant_id: Optional tenant scope (caller's tenant).
 
         Returns:
             Dict mapping host_name to ROI metrics.
         """
+        normalized_tenant_id = _normalize_tenant_id(tenant_id)
+        tenant_clause = " AND tenant_id = ?" if normalized_tenant_id is not None else ""
+
         # Aggregate by host_name since daily_usage lacks user_id
-        query = """
+        query = f"""
             SELECT
                 host_name,
                 COUNT(*) as request_count,
                 SUM(input_tokens) as total_input_tokens,
                 SUM(output_tokens) as total_output_tokens
             FROM daily_usage
-            WHERE date >= ? AND date <= ? AND host_name IS NOT NULL
+            WHERE date >= ? AND date <= ? AND host_name IS NOT NULL{tenant_clause}
             GROUP BY host_name
         """
-        rows = self.db.fetch_all(query, (start_date, end_date))
+        params: list[Any] = [start_date, end_date]
+        if normalized_tenant_id is not None:
+            params.append(normalized_tenant_id)
+        rows = self.db.fetch_all(query, params)
 
         # Model breakdown by host_name
-        model_query = """
+        model_query = f"""
             SELECT
                 host_name,
                 models_used as model,
                 SUM(input_tokens) as input_tokens,
                 SUM(output_tokens) as output_tokens
             FROM daily_usage
-            WHERE date >= ? AND date <= ? AND host_name IS NOT NULL
+            WHERE date >= ? AND date <= ? AND host_name IS NOT NULL{tenant_clause}
             GROUP BY host_name, models_used
         """
-        model_rows = self.db.fetch_all(model_query, (start_date, end_date))
+        model_params: list[Any] = [start_date, end_date]
+        if normalized_tenant_id is not None:
+            model_params.append(normalized_tenant_id)
+        model_rows = self.db.fetch_all(model_query, model_params)
 
         # Group model data by host
         model_data_by_host: dict[str, list[dict]] = {}
@@ -870,7 +945,11 @@ class ROICalculator:
 
     @cached(ttl=60, key_prefix="roi", skip_args=[0])
     def get_cost_breakdown(
-        self, start_date: str, end_date: str, user_id: Optional[int] = None
+        self,
+        start_date: str,
+        end_date: str,
+        user_id: Optional[int] = None,
+        tenant_id: Optional[int] = None,
     ) -> list[CostBreakdown]:
         """
         Get detailed cost breakdown.
@@ -879,10 +958,12 @@ class ROICalculator:
             start_date: Start date.
             end_date: End date.
             user_id: Optional user ID filter.
+            tenant_id: Optional tenant scope (caller's tenant).
 
         Returns:
             List of CostBreakdown objects.
         """
+        normalized_tenant_id = _normalize_tenant_id(tenant_id)
         query = """
             SELECT tool_name, models_used as model,
                    COUNT(*) as requests,
@@ -892,6 +973,10 @@ class ROICalculator:
             WHERE date >= ? AND date <= ?
         """
         params: list[Any] = [start_date, end_date]
+
+        if normalized_tenant_id is not None:
+            query += " AND tenant_id = ?"
+            params.append(normalized_tenant_id)
 
         if user_id:
             query += " AND user_id = ?"
@@ -945,7 +1030,11 @@ class ROICalculator:
 
     @cached(ttl=60, key_prefix="roi", skip_args=[0])
     def get_daily_costs(
-        self, start_date: str, end_date: str, user_id: Optional[int] = None
+        self,
+        start_date: str,
+        end_date: str,
+        user_id: Optional[int] = None,
+        tenant_id: Optional[int] = None,
     ) -> list[dict[str, Any]]:
         """
         Get daily cost data for charting.
@@ -954,10 +1043,12 @@ class ROICalculator:
             start_date: Start date.
             end_date: End date.
             user_id: Optional user ID filter.
+            tenant_id: Optional tenant scope (caller's tenant).
 
         Returns:
             List of daily cost dictionaries.
         """
+        normalized_tenant_id = _normalize_tenant_id(tenant_id)
         query = """
             SELECT date,
                    SUM(input_tokens) as input_tokens,
@@ -966,6 +1057,10 @@ class ROICalculator:
             WHERE date >= ? AND date <= ?
         """
         params: list[Any] = [start_date, end_date]
+
+        if normalized_tenant_id is not None:
+            query += " AND tenant_id = ?"
+            params.append(normalized_tenant_id)
 
         if user_id:
             query += " AND user_id = ?"
@@ -1014,7 +1109,11 @@ class ROICalculator:
 
     @cached(ttl=60, key_prefix="roi")
     def get_summary_stats(
-        self, start_date: str, end_date: str, user_id: Optional[int] = None
+        self,
+        start_date: str,
+        end_date: str,
+        user_id: Optional[int] = None,
+        tenant_id: Optional[int] = None,
     ) -> dict[str, Any]:
         """
         Get summary statistics for the period.
@@ -1023,12 +1122,13 @@ class ROICalculator:
             start_date: Start date.
             end_date: End date.
             user_id: Optional user ID filter.
+            tenant_id: Optional tenant scope (caller's tenant).
 
         Returns:
             Dict with summary statistics.
         """
-        roi = self.calculate_roi(start_date, end_date, user_id)
-        breakdown = self.get_cost_breakdown(start_date, end_date, user_id)
+        roi = self.calculate_roi(start_date, end_date, user_id, tenant_id=tenant_id)
+        breakdown = self.get_cost_breakdown(start_date, end_date, user_id, tenant_id=tenant_id)
 
         # Calculate totals
         total_cost = sum(b.total_cost for b in breakdown)

--- a/app/routes/roi.py
+++ b/app/routes/roi.py
@@ -5,10 +5,11 @@ API endpoints for ROI analysis and cost optimization.
 """
 
 import logging
+import math
 from datetime import datetime, timedelta, timezone
 from typing import Optional
 
-from flask import Blueprint, jsonify, request
+from flask import Blueprint, g, jsonify, request
 
 from app.auth.decorators import auth_required
 from app.modules.analytics.cost_optimizer import CostOptimizer
@@ -28,7 +29,7 @@ def _parse_positive_float_arg(name: str) -> tuple[Optional[float], Optional[str]
         parsed = float(raw_value)
     except ValueError:
         return None, f"{name} must be a positive number"
-    if parsed <= 0:
+    if not math.isfinite(parsed) or parsed <= 0:
         return None, f"{name} must be a positive number"
     return parsed, None
 
@@ -70,6 +71,16 @@ def _require_auth():
     pass
 
 
+def _caller_tenant_id() -> Optional[int]:
+    """Return the authenticated caller's tenant_id, or None when unset.
+
+    ``g.tenant_id`` is populated by ``auth_required`` for normal requests; the
+    ``getattr`` guard keeps these routes testable without a full auth pipeline
+    while still scoping every multi-tenant request.
+    """
+    return getattr(g, "tenant_id", None)
+
+
 # ==================== ROI Analysis ====================
 
 
@@ -94,7 +105,9 @@ def get_roi():
             return jsonify({"success": False, "error": error}), 400
 
         calculator = ROICalculator(assumptions=assumptions)
-        roi = calculator.calculate_roi(start_date, end_date, user_id, tool_name)
+        roi = calculator.calculate_roi(
+            start_date, end_date, user_id, tool_name, tenant_id=_caller_tenant_id()
+        )
 
         return jsonify({"success": True, "data": roi.to_dict() if roi else None})
     except Exception as e:
@@ -114,7 +127,7 @@ def get_roi_trend():
             return jsonify({"success": False, "error": error}), 400
 
         calculator = ROICalculator(assumptions=assumptions)
-        trends = calculator.get_roi_trend(months, user_id)
+        trends = calculator.get_roi_trend(months, user_id, tenant_id=_caller_tenant_id())
 
         return jsonify({"success": True, "data": [t.to_dict() for t in trends]})
     except Exception as e:
@@ -140,7 +153,9 @@ def get_roi_by_tool():
             return jsonify({"success": False, "error": error}), 400
 
         calculator = ROICalculator(assumptions=assumptions)
-        roi_by_tool = calculator.get_roi_by_tool(start_date, end_date)
+        roi_by_tool = calculator.get_roi_by_tool(
+            start_date, end_date, tenant_id=_caller_tenant_id()
+        )
 
         return jsonify({"success": True, "data": {k: v.to_dict() for k, v in roi_by_tool.items()}})
     except Exception as e:
@@ -166,7 +181,9 @@ def get_roi_by_user():
             return jsonify({"success": False, "error": error}), 400
 
         calculator = ROICalculator(assumptions=assumptions)
-        roi_by_user = calculator.get_roi_by_user(start_date, end_date)
+        roi_by_user = calculator.get_roi_by_user(
+            start_date, end_date, tenant_id=_caller_tenant_id()
+        )
 
         return jsonify(
             {"success": True, "data": {str(k): v.to_dict() for k, v in roi_by_user.items()}}
@@ -178,7 +195,12 @@ def get_roi_by_user():
 
 @roi_bp.route("/roi/cost-breakdown", methods=["GET"])
 def get_cost_breakdown():
-    """Get detailed cost breakdown."""
+    """Get detailed cost breakdown.
+
+    Cost breakdown is derived purely from token usage and model pricing; it
+    does not consume ROI assumptions, so assumption override params are not
+    accepted here (they were previously parsed and silently discarded).
+    """
     try:
         start_date = request.args.get("start_date")
         end_date = request.args.get("end_date")
@@ -190,12 +212,10 @@ def get_cost_breakdown():
                 datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=30)
             ).strftime("%Y-%m-%d")
 
-        assumptions, error = _build_roi_assumptions()
-        if error:
-            return jsonify({"success": False, "error": error}), 400
-
-        calculator = ROICalculator(assumptions=assumptions)
-        breakdown = calculator.get_cost_breakdown(start_date, end_date, user_id)
+        calculator = ROICalculator()
+        breakdown = calculator.get_cost_breakdown(
+            start_date, end_date, user_id, tenant_id=_caller_tenant_id()
+        )
 
         return jsonify(
             {
@@ -213,7 +233,12 @@ def get_cost_breakdown():
 
 @roi_bp.route("/roi/daily-costs", methods=["GET"])
 def get_daily_costs():
-    """Get daily cost data for charting."""
+    """Get daily cost data for charting.
+
+    Daily costs are derived purely from token usage and default pricing; they
+    do not consume ROI assumptions, so assumption override params are not
+    accepted here (they were previously parsed and silently discarded).
+    """
     try:
         start_date = request.args.get("start_date")
         end_date = request.args.get("end_date")
@@ -225,12 +250,10 @@ def get_daily_costs():
                 datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=30)
             ).strftime("%Y-%m-%d")
 
-        assumptions, error = _build_roi_assumptions()
-        if error:
-            return jsonify({"success": False, "error": error}), 400
-
-        calculator = ROICalculator(assumptions=assumptions)
-        daily_costs = calculator.get_daily_costs(start_date, end_date, user_id)
+        calculator = ROICalculator()
+        daily_costs = calculator.get_daily_costs(
+            start_date, end_date, user_id, tenant_id=_caller_tenant_id()
+        )
 
         return jsonify({"success": True, "data": daily_costs})
     except Exception as e:
@@ -257,7 +280,9 @@ def get_roi_summary():
             return jsonify({"success": False, "error": error}), 400
 
         calculator = ROICalculator(assumptions=assumptions)
-        summary = calculator.get_summary_stats(start_date, end_date, user_id)
+        summary = calculator.get_summary_stats(
+            start_date, end_date, user_id, tenant_id=_caller_tenant_id()
+        )
 
         return jsonify({"success": True, "data": summary})
     except Exception as e:

--- a/app/routes/roi.py
+++ b/app/routes/roi.py
@@ -11,7 +11,7 @@ from typing import Optional
 
 from flask import Blueprint, g, jsonify, request
 
-from app.auth.decorators import auth_required
+from app.auth.decorators import auth_required, require_tenant_scope
 from app.modules.analytics.cost_optimizer import CostOptimizer
 from app.modules.analytics.roi_calculator import ROIAssumptions, ROICalculator
 
@@ -71,14 +71,33 @@ def _require_auth():
     pass
 
 
-def _caller_tenant_id() -> Optional[int]:
-    """Return the authenticated caller's tenant_id, or None when unset.
+@roi_bp.before_request
+def _require_tenant_scope():
+    """Fail closed for non-admins with no tenant (Issue #1775 / #1780).
 
-    ``g.tenant_id`` is populated by ``auth_required`` for normal requests; the
-    ``getattr`` guard keeps these routes testable without a full auth pipeline
-    while still scoping every multi-tenant request.
+    Without this gate, ``_caller_tenant_id()`` returns ``None`` for a
+    non-admin whose user row has no ``tenant_id``, and the calculator's
+    ``_normalize_tenant_id(None)`` collapses to "no tenant filter" — a
+    wildcard/global query that leaks cross-tenant ROI data. Admins keep
+    global scope (``tenant_id=None``); tenant-scoped non-admins keep their
+    tenant. Mirrors ``app/routes/usage.py``.
     """
-    return getattr(g, "tenant_id", None)
+    _, error = require_tenant_scope()
+    if error is not None:
+        return error
+
+
+def _caller_tenant_id() -> Optional[int]:
+    """Return the authenticated caller's tenant scope.
+
+    Non-admins reaching this point are guaranteed to have a resolvable
+    tenant (``_require_tenant_scope`` denies the request otherwise); admins
+    may still be ``None`` (global scope). Reading from ``g.user.tenant_id``
+    (rather than ``g.tenant_id``) keeps the source of truth identical to
+    ``usage``/``projects`` so the gate and the read can never disagree.
+    """
+    user = getattr(g, "user", None) or {}
+    return user.get("tenant_id")
 
 
 # ==================== ROI Analysis ====================

--- a/app/utils/security_env.py
+++ b/app/utils/security_env.py
@@ -19,6 +19,12 @@ _WEAK_SECRET_VALUES = frozenset(
     }
 )
 
+# Prefixes used by committed deployment manifests (k8s/configmap.yaml) as
+# placeholders the operator must replace. Matching the prefix (rather than
+# each literal string) keeps a future manifest from silently reintroducing a
+# new ``replace-with-random-*`` value that passes the weak-secret check.
+_WEAK_SECRET_PREFIXES = ("replace-with-random",)
+
 _DEV_SECRET_KEY = "dev-secret-key"  # nosec B105 - explicit development-only fallback
 _DEV_ENCRYPTION_KEY = (  # nosec B105 - explicit development-only fallback
     "openace-dev-encryption-key"
@@ -34,7 +40,10 @@ def is_weak_secret_value(value: str | None) -> bool:
     """Return whether the given secret value is missing or a known placeholder."""
     if value is None:
         return True
-    return value.strip().lower() in _WEAK_SECRET_VALUES
+    normalized = value.strip().lower()
+    if normalized in _WEAK_SECRET_VALUES:
+        return True
+    return any(normalized.startswith(prefix) for prefix in _WEAK_SECRET_PREFIXES)
 
 
 def get_secret_key_for_app(secret_key: str | None = None) -> str:

--- a/config/CONFIG_GUIDE.md
+++ b/config/CONFIG_GUIDE.md
@@ -145,6 +145,19 @@
 | `dingtalk.org_sync_interval_minutes` | 自动同步间隔（分钟） | `60` |
 | `dingtalk.org_sync_root_dept_id` | 同步起始部门 ID。钉钉根部门通常为 `1`。 | `"1"` |
 
+#### ROI 分析假设（可选）
+
+ROI 分析页（`/manage/analysis/roi`）展示的成本节省与生产力收益是**可配置的规划估算**，而非已实现的节省。底层假设通过以下环境变量全局配置；前端“Apply”按钮发起的按请求覆盖仅作用于当次查询，不会修改这些默认值。
+
+| 环境变量 | 说明 | 默认值 |
+|------|------|--------|
+| `OPENACE_ROI_HOURLY_LABOR_COST` | 每小时人工成本（用于估算节省）。 | `50.0` |
+| `OPENACE_ROI_PRODUCTIVITY_MULTIPLIER` | 生产力乘数（如 `10` 表示 10 倍提升）。 | `10.0` |
+| `OPENACE_ROI_AVG_TIME_SAVED_PER_REQUEST` | 每次请求平均节省的分钟数。 | `5.0` |
+| `OPENACE_ROI_CURRENCY` | 展示货币代码（ISO 4217 风格，最多 8 字符）。 | `USD` |
+
+> 注意：非法值（负数、零、`inf`/`Infinity`、非数字）会被忽略并回退到上表默认值。各变量必须为有限正数。
+
 ---
 
 ## 配置步骤

--- a/frontend/src/components/features/analysis/ROIAnalysis.assumptions.test.tsx
+++ b/frontend/src/components/features/analysis/ROIAnalysis.assumptions.test.tsx
@@ -102,6 +102,7 @@ const mockedGetCostBreakdown = vi.fn();
 const mockedGetDailyCosts = vi.fn();
 const mockedGetOptimizationSuggestions = vi.fn();
 const mockedGetEfficiencyReport = vi.fn();
+const mockedGetROISummary = vi.fn();
 
 vi.mock('@/api', () => ({
   roiApi: {
@@ -111,6 +112,7 @@ vi.mock('@/api', () => ({
     getDailyCosts: (...args: unknown[]) => mockedGetDailyCosts(...args),
     getOptimizationSuggestions: (...args: unknown[]) => mockedGetOptimizationSuggestions(...args),
     getEfficiencyReport: (...args: unknown[]) => mockedGetEfficiencyReport(...args),
+    getROISummary: (...args: unknown[]) => mockedGetROISummary(...args),
   },
 }));
 
@@ -159,6 +161,7 @@ describe('ROIAnalysis assumptions', () => {
       waste_percentage: 12,
       recommendation_items: [],
     });
+    mockedGetROISummary.mockResolvedValue({ assumptions: defaultAssumptions });
   });
 
   it('shows baseline assumptions, applies overrides, and resets the draft', async () => {
@@ -219,5 +222,45 @@ describe('ROIAnalysis assumptions', () => {
       expect(productivityMultiplier).toHaveValue(10);
       expect(currency).toHaveValue('USD');
     });
+  });
+
+  it('seeds the Reset baseline from a non-overridden summary, not the first ROI payload', async () => {
+    // Simulate the failure scenario: the very first getROI payload carries
+    // overridden values (e.g. an override leaked into the initial fetch). The
+    // baseline must still come from the dedicated getROISummary() call so that
+    // Reset restores the true server/env default, not the override.
+    const serverDefault = defaultAssumptions;
+    const leakedOverride = {
+      hourly_labor_cost: 999,
+      productivity_multiplier: 999,
+      avg_time_saved_per_request: 999,
+      currency: 'XYZ',
+    };
+    mockedGetROI.mockResolvedValueOnce({
+      period: '2026-06-01 to 2026-06-30',
+      start_date: '2026-06-01',
+      end_date: '2026-06-30',
+      total_cost: 120.5,
+      tokens_used: 5000,
+      requests_made: 25,
+      estimated_savings: 104.0,
+      roi_percentage: -13.7,
+      assumptions: leakedOverride,
+    });
+    mockedGetROISummary.mockResolvedValueOnce({ assumptions: serverDefault });
+
+    render(<ROIAnalysis />);
+
+    const hourlyLaborCost = await screen.findByLabelText('Hourly labor cost');
+    const currency = screen.getByLabelText('Currency');
+
+    // Baseline comes from the summary call, so the draft shows the server
+    // default (50 / USD), never the leaked override (999 / XYZ).
+    await waitFor(() => {
+      expect(hourlyLaborCost).toHaveValue(50);
+      expect(currency).toHaveValue('USD');
+    });
+
+    expect(mockedGetROISummary).toHaveBeenCalledWith({});
   });
 });

--- a/frontend/src/components/features/analysis/ROIAnalysis.tsx
+++ b/frontend/src/components/features/analysis/ROIAnalysis.tsx
@@ -225,10 +225,33 @@ export const ROIAnalysis: React.FC = () => {
     setStartDate(start.toISOString().split('T')[0]);
   }, []);
 
+  // Seed the baseline assumptions from a dedicated, non-overridden call so the
+  // Reset button always restores the server/env default. Capturing the baseline
+  // from the first roiMetrics payload was fragile: if that payload already
+  // reflected an active override (e.g. an override leaked into the first fetch),
+  // Reset would restore the override instead of the true default.
   useEffect(() => {
-    if (baselineAssumptions || !roiMetrics?.assumptions) return;
-    setBaselineAssumptions(roiMetrics.assumptions);
-    setDraftAssumptions(toAssumptionDraft(roiMetrics.assumptions));
+    let cancelled = false;
+    if (baselineAssumptions) return;
+    (async () => {
+      try {
+        const summary = (await roiApi.getROISummary({})) as {
+          assumptions?: ROIAssumptions;
+        };
+        const defaults = summary?.assumptions;
+        if (cancelled || !defaults) return;
+        setBaselineAssumptions(defaults);
+        setDraftAssumptions(toAssumptionDraft(defaults));
+      } catch {
+        // Fall back to the first roiMetrics payload if the summary call fails.
+        if (cancelled || !roiMetrics?.assumptions) return;
+        setBaselineAssumptions(roiMetrics.assumptions);
+        setDraftAssumptions(toAssumptionDraft(roiMetrics.assumptions));
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
   }, [baselineAssumptions, roiMetrics]);
 
   // Translate suggestion title/description based on suggestion_type + dynamic params.

--- a/frontend/src/components/features/analysis/ROIAnalysis.tsx
+++ b/frontend/src/components/features/analysis/ROIAnalysis.tsx
@@ -234,20 +234,25 @@ export const ROIAnalysis: React.FC = () => {
     let cancelled = false;
     if (baselineAssumptions) return;
     (async () => {
+      let defaults: ROIAssumptions | undefined;
       try {
         const summary = (await roiApi.getROISummary({})) as {
           assumptions?: ROIAssumptions;
         };
-        const defaults = summary?.assumptions;
-        if (cancelled || !defaults) return;
-        setBaselineAssumptions(defaults);
-        setDraftAssumptions(toAssumptionDraft(defaults));
+        defaults = summary?.assumptions;
       } catch {
-        // Fall back to the first roiMetrics payload if the summary call fails.
-        if (cancelled || !roiMetrics?.assumptions) return;
-        setBaselineAssumptions(roiMetrics.assumptions);
-        setDraftAssumptions(toAssumptionDraft(roiMetrics.assumptions));
+        // Summary call failed -> fall through to the roiMetrics fallback below.
       }
+      // Fall back to the first roiMetrics payload when the summary call fails
+      // OR returns 200 without an assumptions field (e.g. a backend/DB error
+      // that strips assumptions). Without this, baselineAssumptions stays null,
+      // the draft remains EMPTY_ASSUMPTION_DRAFT, and Reset is unavailable.
+      if (!defaults && roiMetrics?.assumptions) {
+        defaults = roiMetrics.assumptions;
+      }
+      if (cancelled || !defaults) return;
+      setBaselineAssumptions(defaults);
+      setDraftAssumptions(toAssumptionDraft(defaults));
     })();
     return () => {
       cancelled = true;

--- a/tests/issues/1757/test_roi_inf_validation.py
+++ b/tests/issues/1757/test_roi_inf_validation.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""RED tests for ROI findings on PR #1757.
+
+Covers:
+- inf/Infinity must be rejected by positive-float validation (request + env)
+- cost-breakdown / daily-costs must not parse ROI assumption overrides
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+MOCK_ADMIN_SESSION = {
+    "user_id": 1,
+    "username": "admin",
+    "email": "admin@example.com",
+    "role": "admin",
+}
+
+
+@pytest.fixture
+def client():
+    from flask import Flask
+
+    from app.routes.roi import roi_bp
+
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.register_blueprint(roi_bp, url_prefix="/api")
+    return app.test_client()
+
+
+class TestRoiInfRejection:
+    @pytest.mark.parametrize(
+        "param",
+        ["hourly_labor_cost", "productivity_multiplier", "avg_time_saved_per_request"],
+    )
+    def test_request_inf_rejected_with_400(self, client, param):
+        with patch("app.auth.decorators._authenticate", return_value=(True, MOCK_ADMIN_SESSION)):
+            resp = client.get(
+                "/api/roi",
+                headers={"Authorization": "Bearer t"},
+                query_string={param: "inf"},
+            )
+        assert resp.status_code == 400
+        assert param in resp.get_json()["error"]
+
+    @pytest.mark.parametrize(
+        "param",
+        ["hourly_labor_cost", "productivity_multiplier", "avg_time_saved_per_request"],
+    )
+    def test_request_infinity_rejected_with_400(self, client, param):
+        with patch("app.auth.decorators._authenticate", return_value=(True, MOCK_ADMIN_SESSION)):
+            resp = client.get(
+                "/api/roi",
+                headers={"Authorization": "Bearer t"},
+                query_string={param: "Infinity"},
+            )
+        assert resp.status_code == 400
+
+    def test_env_inf_falls_back_to_default(self, monkeypatch):
+        from app.modules.analytics.roi_calculator import ROIAssumptions
+
+        monkeypatch.setenv("OPENACE_ROI_HOURLY_LABOR_COST", "inf")
+        monkeypatch.delenv("OPENACE_ROI_PRODUCTIVITY_MULTIPLIER", raising=False)
+        monkeypatch.delenv("OPENACE_ROI_AVG_TIME_SAVED_PER_REQUEST", raising=False)
+        monkeypatch.delenv("OPENACE_ROI_CURRENCY", raising=False)
+
+        assumptions = ROIAssumptions.from_env()
+        # inf must NOT propagate; the default (50.0) is used instead.
+        assert assumptions.hourly_labor_cost == 50.0
+
+
+class TestCostRoutesDropAssumptions:
+    """cost-breakdown and daily-costs must not accept assumption overrides."""
+
+    @pytest.mark.parametrize(
+        "path,method_name",
+        [
+            ("/api/roi/cost-breakdown", "get_cost_breakdown"),
+            ("/api/roi/daily-costs", "get_daily_costs"),
+        ],
+    )
+    def test_bad_assumption_override_does_not_400(self, client, path, method_name):
+        """Previously these routes validated assumption params (returning 400 on
+        bad input) even though the values were never used. They should now
+        ignore override params entirely."""
+        fake_calc = MagicMock()
+        getattr(fake_calc, method_name).return_value = []
+
+        with patch("app.auth.decorators._authenticate", return_value=(True, MOCK_ADMIN_SESSION)):
+            with patch("app.routes.roi.ROICalculator", return_value=fake_calc):
+                resp = client.get(
+                    path,
+                    headers={"Authorization": "Bearer t"},
+                    query_string={"hourly_labor_cost": "-5"},
+                )
+        assert resp.status_code == 200

--- a/tests/issues/1780/test_k8s_placeholder_values.py
+++ b/tests/issues/1780/test_k8s_placeholder_values.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""RED test: K8s Secret placeholder values must fail-closed in production (PR #1780 R1).
+
+``k8s/configmap.yaml`` ships stringData placeholders like
+``replace-with-random-flask-secret``. The startup guard
+``app/utils/security_env._WEAK_SECRET_VALUES`` previously only listed the OLD
+sentinels, so these committed strings passed ``is_weak_secret_value()`` and
+were used as real secrets in production.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.utils.security_env import is_weak_secret_value
+
+
+class TestK8sPlaceholderSecretsFailClosed:
+    @pytest.mark.parametrize(
+        "placeholder",
+        [
+            "replace-with-random-flask-secret",
+            "replace-with-random-dedicated-encryption-key",
+            "replace-with-random-upload-auth-key",
+            "replace-with-random-database-password",
+        ],
+    )
+    def test_replace_with_random_placeholder_is_weak(self, placeholder):
+        assert is_weak_secret_value(placeholder) is True
+
+    def test_placeholder_case_insensitive(self):
+        assert is_weak_secret_value("Replace-With-Random-Anything") is True
+
+    def test_strong_secret_still_accepted(self):
+        assert is_weak_secret_value("a-real-randomly-generated-64-char-secret-1234567890") is False

--- a/tests/issues/1780/test_roi_cross_tenant_cache.py
+++ b/tests/issues/1780/test_roi_cross_tenant_cache.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""RED tests: ROI cached queries must be tenant-scoped (PR #1780 finding R2/R3).
+
+The @cached ROI read paths previously queried ``daily_usage`` with only
+optional user_id/tool_name filters and a global cache key, so tenant A
+materialized an all-tenant aggregate that tenant B read for 60s.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from app.modules.analytics.roi_calculator import ROICalculator
+from app.utils.cache import get_cache
+
+
+def _seed_daily_usage(db: MagicMock) -> None:
+    db.fetch_one.return_value = {
+        "request_count": 10,
+        "total_input_tokens": 1000,
+        "total_output_tokens": 500,
+        "total_tokens": 1500,
+    }
+    db.fetch_all.return_value = [
+        {
+            "tool_name": "qwen",
+            "model": "claude-3-haiku",
+            "input_tokens": 1000,
+            "output_tokens": 500,
+        }
+    ]
+
+
+class TestRoiTenantScoping:
+    def setup_method(self):
+        get_cache().clear()
+
+    def test_calculate_roi_filters_by_tenant_id(self):
+        calc = ROICalculator(db=MagicMock())
+        _seed_daily_usage(calc.db)
+
+        calc.calculate_roi("2026-01-01", "2026-01-31", tenant_id=7)
+
+        executed = calc.db.fetch_one.call_args[0][0]
+        params = calc.db.fetch_one.call_args[0][1]
+        assert "tenant_id" in executed
+        assert 7 in params
+
+    def test_calculate_roi_model_query_filters_by_tenant_id(self):
+        calc = ROICalculator(db=MagicMock())
+        _seed_daily_usage(calc.db)
+
+        calc.calculate_roi("2026-01-01", "2026-01-31", tenant_id=7)
+
+        model_query = calc.db.fetch_all.call_args[0][0]
+        model_params = calc.db.fetch_all.call_args[0][1]
+        assert "tenant_id" in model_query
+        assert 7 in model_params
+
+    def test_calculate_roi_cache_key_is_tenant_distinct(self):
+        tenant_a_db = MagicMock()
+        tenant_b_db = MagicMock()
+        _seed_daily_usage(tenant_a_db)
+        _seed_daily_usage(tenant_b_db)
+        calc_a = ROICalculator(db=tenant_a_db)
+        calc_b = ROICalculator(db=tenant_b_db)
+
+        calc_a.calculate_roi("2026-01-01", "2026-01-31", tenant_id=1)
+        calc_b.calculate_roi("2026-01-01", "2026-01-31", tenant_id=2)
+
+        # Tenant B must hit its own DB query, not read tenant A's cached result.
+        assert tenant_b_db.fetch_one.called
+
+    def test_get_cost_breakdown_filters_by_tenant_id(self):
+        calc = ROICalculator(db=MagicMock())
+        calc.db.fetch_all.return_value = []
+
+        calc.get_cost_breakdown("2026-01-01", "2026-01-31", tenant_id=7)
+
+        query = calc.db.fetch_all.call_args[0][0]
+        params = calc.db.fetch_all.call_args[0][1]
+        assert "tenant_id" in query
+        assert 7 in params
+
+    def test_get_daily_costs_filters_by_tenant_id(self):
+        calc = ROICalculator(db=MagicMock())
+        calc.db.fetch_all.return_value = []
+
+        calc.get_daily_costs("2026-01-01", "2026-01-31", tenant_id=7)
+
+        query = calc.db.fetch_all.call_args[0][0]
+        params = calc.db.fetch_all.call_args[0][1]
+        assert "tenant_id" in query
+        assert 7 in params
+
+    def test_get_roi_trend_filters_by_tenant_id(self):
+        calc = ROICalculator(db=MagicMock())
+        calc.db.fetch_all.return_value = []
+
+        calc.get_roi_trend(months=6, tenant_id=7)
+
+        # trend issues two fetch_all calls; both must be tenant-scoped
+        for call in calc.db.fetch_all.call_args_list:
+            query = call[0][0]
+            params = call[0][1]
+            assert "tenant_id" in query
+            assert 7 in params
+
+    def test_get_roi_by_tool_filters_by_tenant_id(self):
+        calc = ROICalculator(db=MagicMock())
+        calc.db.fetch_all.return_value = []
+
+        calc.get_roi_by_tool("2026-01-01", "2026-01-31", tenant_id=7)
+
+        for call in calc.db.fetch_all.call_args_list:
+            query = call[0][0]
+            params = call[0][1]
+            assert "tenant_id" in query
+            assert 7 in params
+
+    def test_get_roi_by_user_filters_by_tenant_id(self):
+        calc = ROICalculator(db=MagicMock())
+        calc.db.fetch_all.return_value = []
+
+        calc.get_roi_by_user("2026-01-01", "2026-01-31", tenant_id=7)
+
+        for call in calc.db.fetch_all.call_args_list:
+            query = call[0][0]
+            params = call[0][1]
+            assert "tenant_id" in query
+            assert 7 in params
+
+    def test_get_summary_stats_filters_by_tenant_id(self):
+        calc = ROICalculator(db=MagicMock())
+        _seed_daily_usage(calc.db)
+
+        calc.get_summary_stats("2026-01-01", "2026-01-31", tenant_id=7)
+
+        for call in calc.db.fetch_one.call_args_list + calc.db.fetch_all.call_args_list:
+            query = call[0][0]
+            params = call[0][1]
+            assert "tenant_id" in query
+            assert 7 in params

--- a/tests/issues/1809/test_roi_route_tenant_fail_closed.py
+++ b/tests/issues/1809/test_roi_route_tenant_fail_closed.py
@@ -1,0 +1,238 @@
+"""Route-layer ROI tenant-isolation regression tests (PR #1809 严重#1).
+
+The round-2 cross-tenant-cache fix added ``tenant_id`` filtering to the
+``ROICalculator`` cached read paths, but ``app/routes/roi.py`` lacked the
+``require_tenant_scope`` gate that every other tenant-aware blueprint
+(usage, projects, governance, compliance) installs in ``before_request``.
+
+A NON-ADMIN user with no ``tenant_id`` (e.g. a misconfigured DB row) hit
+``_caller_tenant_id() -> g.tenant_id -> None``; ``_normalize_tenant_id(None)``
+collapses to ``None`` which the calculator treats as a wildcard/global
+filter. The cross-tenant cache leak that PR #1780 fixed at the calculator
+layer therefore re-opened at the route layer for this one caller class.
+
+These tests pin the fail-closed behaviour at the ROI route layer:
+
+* non-admins WITHOUT a tenant are denied 403 (the bug);
+* admins keep global scope (``tenant_id=None`` passed through);
+* tenant-scoped non-admins have their ``tenant_id`` forwarded verbatim
+  to ``ROICalculator`` (cache key + DB filter), not collapsed to ``None``.
+
+Mirrors ``tests/issues/1775/test_route_tenant_fail_closed.py``.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from contextlib import ExitStack
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+
+
+_DB_PATH = tempfile.mktemp(suffix="_tenant_1809.db")
+_DB_URL = f"sqlite:///{_DB_PATH}"
+
+
+def _install_db_url():
+    """Point db_mod at the shared test DB and disable SQL adaptation."""
+    import app.repositories.database as db_mod
+
+    orig = db_mod.adapt_sql
+    orig_get_database_url = db_mod.get_database_url
+    db_mod.adapt_sql = lambda sql: sql
+    db_mod.get_database_url = lambda: _DB_URL
+    return orig, orig_get_database_url, db_mod
+
+
+def _make_client():
+    import app.repositories.database as db_mod
+    from app import create_app
+
+    app = create_app({"TESTING": True})
+    db = db_mod.Database(db_url=_DB_URL)
+    with db.get_connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute("DELETE FROM users")
+        cursor.execute(
+            "INSERT INTO users (id, username, email, password_hash, role, tenant_id) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (1, "admin", "admin@test.com", "hash", "admin", None),
+        )
+        cursor.execute(
+            "INSERT INTO users (id, username, email, password_hash, role, tenant_id) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (10, "tenant_user", "tu@test.com", "hash", "user", 7),
+        )
+        cursor.execute(
+            "INSERT INTO users (id, username, email, password_hash, role, tenant_id) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (11, "notenant_user", "nt@test.com", "hash", "user", None),
+        )
+        conn.commit()
+
+    client = app.test_client()
+    client.set_cookie("session_token", "test-token")
+    return client, db_mod
+
+
+def _user_dict(user_id=1, role="admin", tenant_id=None):
+    username = "admin" if role == "admin" else ("tenant_user" if tenant_id else "notenant_user")
+    return {
+        "id": user_id,
+        "username": username,
+        "email": f"{username}@test.com",
+        "role": role,
+        "tenant_id": tenant_id,
+    }
+
+
+def _mock_auth(user_id=1, role="admin", tenant_id=None):
+    """Patch _load_user_from_token so the test_client bypasses real auth.
+
+    ``app/routes/roi.py`` calls ``auth_required`` directly (it does not bind
+    ``_load_user_from_token`` into its own namespace like projects.py does),
+    so a single patch on the auth module is enough.
+    """
+    user = _user_dict(user_id, role, tenant_id)
+    return (patch("app.auth.decorators._load_user_from_token", return_value=user),)
+
+
+class TestRoiRouteTenantFailClosed(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.orig, cls.orig_get_database_url, cls.db_mod = _install_db_url()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.db_mod.adapt_sql = cls.orig
+        cls.db_mod.get_database_url = cls.orig_get_database_url
+        try:
+            os.unlink(_DB_PATH)
+        except OSError:
+            pass
+
+    def setUp(self):
+        self.client, _ = _make_client()
+
+    # --- non-admin WITHOUT a tenant must be DENIED (the severe bug) ---
+
+    def _authed_get(self, path, **auth):
+        with ExitStack() as stack:
+            for p in _mock_auth(**auth):
+                stack.enter_context(p)
+            return self.client.get(path)
+
+    def test_roi_denied_for_notenant_non_admin(self):
+        resp = self._authed_get(
+            "/api/roi?start_date=2026-01-01&end_date=2026-01-31",
+            user_id=11,
+            role="user",
+            tenant_id=None,
+        )
+        # Bug on round-2 branch: returns 200 with all-tenant/global ROI.
+        self.assertNotEqual(resp.status_code, 200)
+        self.assertEqual(resp.status_code, 403)
+
+    def test_roi_summary_denied_for_notenant_non_admin(self):
+        resp = self._authed_get(
+            "/api/roi/summary?start_date=2026-01-01&end_date=2026-01-31",
+            user_id=11,
+            role="user",
+            tenant_id=None,
+        )
+        self.assertEqual(resp.status_code, 403)
+
+    def test_roi_by_user_denied_for_notenant_non_admin(self):
+        resp = self._authed_get(
+            "/api/roi/by-user?start_date=2026-01-01&end_date=2026-01-31",
+            user_id=11,
+            role="user",
+            tenant_id=None,
+        )
+        self.assertEqual(resp.status_code, 403)
+
+    # --- admins keep global scope (must NOT be locked out) ---
+
+    def test_roi_admin_keeps_global(self):
+        resp = self._authed_get(
+            "/api/roi?start_date=2026-01-01&end_date=2026-01-31",
+            user_id=1,
+            role="admin",
+            tenant_id=None,
+        )
+        self.assertEqual(resp.status_code, 200)
+
+    def test_roi_summary_admin_keeps_global(self):
+        resp = self._authed_get(
+            "/api/roi/summary?start_date=2026-01-01&end_date=2026-01-31",
+            user_id=1,
+            role="admin",
+            tenant_id=None,
+        )
+        self.assertEqual(resp.status_code, 200)
+
+    # --- tenant-scoped non-admins keep their tenant (allowed, isolated) ---
+
+    def test_roi_tenant_user_allowed(self):
+        resp = self._authed_get(
+            "/api/roi?start_date=2026-01-01&end_date=2026-01-31",
+            user_id=10,
+            role="user",
+            tenant_id=7,
+        )
+        self.assertEqual(resp.status_code, 200)
+
+    # --- tenant_id is forwarded VERBATIM to ROICalculator (not collapsed) ---
+
+    def test_tenant_id_forwarded_to_calculator(self):
+        """g.tenant_id==7 must reach calculate_roi(tenant_id=7), not None."""
+        import app.routes.roi as roi_mod
+        from app.modules.analytics.roi_calculator import ROICalculator
+
+        captured = {}
+
+        orig_calc = ROICalculator.calculate_roi
+
+        def _spy(self, *args, **kwargs):
+            captured["tenant_id"] = kwargs.get("tenant_id")
+            return orig_calc(self, *args, **kwargs)
+
+        with ExitStack() as stack:
+            for p in _mock_auth(user_id=10, role="user", tenant_id=7):
+                stack.enter_context(p)
+            stack.enter_context(patch.object(ROICalculator, "calculate_roi", _spy))
+            resp = self.client.get("/api/roi?start_date=2026-01-01&end_date=2026-01-31")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(
+            captured.get("tenant_id"),
+            7,
+            "tenant-scoped caller's tenant_id must be forwarded to the calculator, "
+            "not collapsed to None (which would query all tenants).",
+        )
+
+    def test_admin_global_tenant_id_forwarded_as_none(self):
+        """Admin with no tenant_id forwards None (global) to the calculator."""
+        from app.modules.analytics.roi_calculator import ROICalculator
+
+        captured = {}
+        orig_calc = ROICalculator.calculate_roi
+
+        def _spy(self, *args, **kwargs):
+            captured["tenant_id"] = kwargs.get("tenant_id")
+            return orig_calc(self, *args, **kwargs)
+
+        with ExitStack() as stack:
+            for p in _mock_auth(user_id=1, role="admin", tenant_id=None):
+                stack.enter_context(p)
+            stack.enter_context(patch.object(ROICalculator, "calculate_roi", _spy))
+            resp = self.client.get("/api/roi?start_date=2026-01-01&end_date=2026-01-31")
+        self.assertEqual(resp.status_code, 200)
+        self.assertIsNone(captured.get("tenant_id"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/routes/test_roi_assumptions.py
+++ b/tests/routes/test_roi_assumptions.py
@@ -90,7 +90,10 @@ class TestRoiAssumptionRoutes:
             ("/api/roi/daily-costs", "get_daily_costs"),
         ],
     )
-    def test_display_routes_pass_overrides_to_calculator(self, client, path, method_name):
+    def test_display_routes_ignore_assumption_overrides(self, client, path, method_name):
+        """Cost breakdown and daily costs are derived from token usage and
+        default pricing; they never consume ROI assumptions, so override
+        params must be ignored (previously parsed and silently discarded)."""
         fake_calc = MagicMock()
         getattr(fake_calc, method_name).return_value = []
 
@@ -108,11 +111,12 @@ class TestRoiAssumptionRoutes:
                 )
 
         assert resp.status_code == 200
-        assumptions = calc_cls.call_args.kwargs["assumptions"]
-        assert assumptions.hourly_labor_cost == 90.0
-        assert assumptions.productivity_multiplier == 3.0
-        assert assumptions.avg_time_saved_per_request == 8.0
-        assert assumptions.currency == "EUR"
+        # The calculator is built without assumption overrides (no kwargs).
+        calc_cls.assert_called_once_with()
+        # And the override values are NOT forwarded to the underlying method.
+        forwarded_kwargs = getattr(fake_calc, method_name).call_args.kwargs
+        assert "hourly_labor_cost" not in forwarded_kwargs
+        assert "productivity_multiplier" not in forwarded_kwargs
 
     def test_invalid_roi_assumption_returns_400(self, client):
         with patch("app.auth.decorators._authenticate", return_value=(True, MOCK_ADMIN_SESSION)):


### PR DESCRIPTION
## Summary

Addresses review findings on #1757, #1780.

### #1780 (high) ROI @cached leaks aggregated usage/cost/ROI across tenants
`calculate_roi`, `get_roi_trend`, `get_roi_by_tool`, `get_roi_by_user`, `get_cost_breakdown`, `get_daily_costs`, `get_summary_stats` queried `daily_usage` with only optional `user_id`/`tool_name` filters and a global cache key. `daily_usage.tenant_id` exists and `ENABLE_MULTI_TENANT=true`, so tenant A materialized an all-tenant aggregate under a tenant-less key that tenant B read for 60s — cross-tenant data disclosure.
**Fix:** add a `tenant_id` filter to every cached query and thread `tenant_id` (from `g.tenant_id`) through every route. Because it is a kwarg it lands in the cache key, so tenants no longer share a cache entry. `None`/0/blank collapse to no filter so single-tenant deployments keep their original query shape.

### #1780 (medium) K8s Secret placeholders look real (no fail-closed)
`k8s/configmap.yaml` Secret stringData ships `replace-with-random-*` placeholders; `_WEAK_SECRET_VALUES` only listed the OLD sentinels (`change-me-in-production`, `dev-secret-key`, ...), so the committed strings passed `is_weak_secret_value()` and were used as real secrets in production.
**Fix:** match the `replace-with-random` prefix (case-insensitive) in `is_weak_secret_value` so production fails closed. A future manifest that reintroduces a new `replace-with-random-*` value stays covered.

### #1757 (medium) Frontend Reset captures the wrong baseline after an override is active
`ROIAnalysis.tsx` captured the Reset baseline from the first `roiMetrics.assumptions` payload, which could already reflect an active override, so Reset restored the override instead of the server/env default.
**Fix:** seed the baseline from a dedicated, non-overridden `getROISummary({})` call (its response carries the server/env default `assumptions`), falling back to the first payload only if that call fails.

### #1757 (medium) cost-breakdown and daily-costs parse and build ROI assumptions they never use
`get_cost_breakdown` and `get_daily_costs` routes called `_build_roi_assumptions()` + `ROICalculator(assumptions=...)`, but the underlying methods only read token usage + model pricing and never read `self.assumptions`. The params were inert end-to-end; bad input 400'd on inert params.
**Fix:** drop `_build_roi_assumptions` from these two routes (calculator built with no assumptions kwargs).

### #1757 (low) inf/Infinity bypasses positive-float validation on request and env paths
`float('inf')` parsed and `inf > 0` is True, propagating `estimated_savings=inf` → `round(inf, 2)=inf` → jsonify emits invalid `Infinity` JSON that breaks strict parsers. `float('nan')` was already rejected by `<= 0`.
**Fix:** add `math.isfinite(parsed)` checks in `_parse_positive_float_arg` (roi.py) and `ROIAssumptions._read_float_env` (roi_calculator.py), mirroring the frontend `Number.isFinite` guard.

### #1757 (low) OPENACE_ROI_* env vars and their defaults are undocumented
The only global ROI config levers required reading source.
**Fix:** add an "ROI 分析假设" subsection to `config/CONFIG_GUIDE.md` documenting the four `OPENACE_ROI_*` env vars and their defaults.

## Tests
- `tests/issues/1780/test_roi_cross_tenant_cache.py` — 9 tests asserting every cached ROI query is tenant-scoped and that distinct tenants get distinct cache entries (RED→GREEN).
- `tests/issues/1780/test_k8s_placeholder_values.py` — 6 tests asserting every `replace-with-random-*` placeholder is treated as weak (RED→GREEN).
- `tests/issues/1757/test_roi_inf_validation.py` — 9 tests asserting `inf`/`Infinity` are rejected on the request path and fall back to defaults on the env path, plus that cost-breakdown/daily-costs no longer 400 on bad override params (RED→GREEN).
- `frontend/src/components/features/analysis/ROIAnalysis.assumptions.test.tsx` — added a test asserting the Reset baseline is seeded from the non-overridden summary call even when the first ROI payload carries an override (RED→GREEN).
- Updated `tests/routes/test_roi_assumptions.py::test_display_routes_*` to assert cost-breakdown/daily-costs now ignore (not forward) assumption overrides.

## Regression
- `tests/unit/test_roi_calculator.py`, `tests/routes/test_roi_assumptions.py`, `tests/unit/test_security_env.py`, `tests/unit/test_cache.py`, issue tests: 145 passed.
- Frontend: `ROIAnalysis.assumptions.test.tsx` 2 passed; `tsc --noEmit` clean.
- pre-commit (black 25.1.0, ruff, mypy, isort, bandit, pydocstyle, api-security-scan) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
