### PR TITLE
fix(autonomous): CI repair 细粒度 fingerprint + excerpt 提取全错误行 (Issue #1811)

### DIFF
--- a/app/modules/workspace/autonomous/github_ops.py
+++ b/app/modules/workspace/autonomous/github_ops.py
@@ -66,6 +66,38 @@ def _is_transient_error(stderr: str, returncode: int) -> bool:
     return any(kw in combined for kw in _TRANSIENT_ERROR_KEYWORDS)
 
 
+# Failure markers used to locate the real error lines inside a long pre-commit /
+# pytest / mypy log. The tail-only approach drops errors that sit in the middle
+# of the output (e.g. mypy failing while later hooks keep printing).
+_FAILURE_LINE_RE = re.compile(
+    r"(error:|Error:|ERROR:|Failed|failed|FAIL\b|"
+    r"would reformat|not formatted|not sorted|isort.*skipped|"
+    r"no-any-return|undefined name|"
+    r"\b[FEW]\d{3}\b)",  # flake8/ruff error codes
+    re.IGNORECASE,
+)
+
+
+def _extract_failure_lines(lines: list[str], max_lines: int = 80) -> list[str]:
+    """Return lines that look like failure output, plus 1 line of context.
+
+    Falls back to the tail when no line matches (keeps the original behavior
+    for logs without recognizable markers).
+    """
+    hit_indices: set[int] = set()
+    for i, line in enumerate(lines):
+        if _FAILURE_LINE_RE.search(line):
+            hit_indices.add(i)
+            if i > 0:
+                hit_indices.add(i - 1)
+            if i < len(lines) - 1:
+                hit_indices.add(i + 1)
+    if not hit_indices:
+        return lines[-max_lines:]
+    result = [lines[i] for i in sorted(hit_indices)]
+    return result[-max_lines:] if len(result) > max_lines else result
+
+
 class GitHubOpsError(Exception):
     """Error raised when a GitHub operation fails."""
 
@@ -938,6 +970,12 @@ class GitHubOps:
 
         Currently supports GitHub Actions job URLs. Non-Actions URLs return an
         empty string so callers can degrade gracefully for other CI providers.
+
+        pre-commit / pytest / mypy output interleaves many passing hooks with a
+        few failing ones; taking the last N lines can drop the actual error
+        (e.g. mypy fails in the middle while later hooks continue). Instead we
+        scan every line for failure markers and return those lines (with a
+        little context), falling back to the tail when no markers match.
         """
         parsed = self._parse_github_actions_job_url(str(check.get("link") or ""))
         if not parsed:
@@ -966,7 +1004,7 @@ class GitHubOps:
         if not lines:
             return ""
 
-        excerpt = "\n".join(lines[-max_lines:]).strip()
+        excerpt = "\n".join(_extract_failure_lines(lines, max_lines)).strip()
         if len(excerpt) > max_chars:
             excerpt = excerpt[-max_chars:].lstrip()
         return excerpt

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -658,7 +658,7 @@ _TRANSIENT_API_ERROR_RE = re.compile(
 # Test failure retry configuration.
 MAX_TEST_RETRIES = 2  # max retries when test agent itself fails
 MAX_DEV_RETRIES_ON_TEST_FAIL = 2  # max dev round retries for unfixable test failures
-MAX_CI_REPAIR_ATTEMPTS = 2  # max automatic dev-round retries for merge-phase CI failures
+MAX_CI_REPAIR_ATTEMPTS = 3  # max automatic dev-round retries for merge-phase CI failures
 
 
 def _next_phase(current_phase: str) -> str:
@@ -1141,6 +1141,70 @@ class AutonomousOrchestrator:
                 )
             )
         return "\n".join(sorted(parts))
+
+    def _ci_failure_fingerprint(self, gh: GitHubOps, checks: list[dict]) -> str:
+        """Fine-grained failure signature including the actual error lines.
+
+        ``_ci_failure_signature`` only captures the CI check NAME, which is too
+        coarse for Actions jobs that bundle multiple tools (one ``lint`` job
+        runs black/isort/ruff/mypy). When the agent fixes one sub-tool but
+        another still fails, the coarse signature stays identical and the
+        exhausted-unchanged guard wrongly gives up. This fingerprint appends a
+        normalized hash of the per-check error excerpt so partial fixes change
+        the signature and earn another repair attempt.
+        """
+        import hashlib
+
+        parts = []
+        for check in checks or []:
+            if check.get("bucket") != "fail":
+                continue
+            name = str(check.get("name") or "").strip()
+            try:
+                excerpt = gh.get_check_failure_excerpt(check)
+            except Exception:
+                excerpt = ""
+            # Normalize: strip volatile bits (timestamps, absolute paths,
+            # run/job ids) so the hash is stable across re-runs of the same
+            # error but differs when the error set changes.
+            normalized = self._normalize_failure_excerpt(excerpt)
+            digest = hashlib.sha256(normalized.encode()).hexdigest()[:12]
+            parts.append(f"{name}::{digest}")
+        return "\n".join(sorted(parts))
+
+    @staticmethod
+    def _normalize_failure_excerpt(excerpt: str) -> str:
+        """Reduce an excerpt to its error-bearing essence for fingerprinting.
+
+        Keeps only lines that look like real errors (strips CI chrome, blank
+        lines, hook banners) and normalizes file paths so the hash captures
+        *which* errors remain, not their line numbers or local paths.
+        """
+        if not excerpt:
+            return ""
+        lines = []
+        for raw in excerpt.splitlines():
+            line = raw.strip()
+            if not line:
+                continue
+            # Keep lines that carry an error marker; drop pre-commit banners
+            # ("black....Passed", "mypy....Failed") which are too noisy.
+            if not re.search(
+                r"error:|Error:|ERROR:|Failed|failed|FAIL\b|"
+                r"would reformat|not formatted|not sorted|"
+                r"no-any-return|undefined name|\b[FEW]\d{3}\b",
+                line,
+                re.IGNORECASE,
+            ):
+                continue
+            # Normalize file paths: /abs/path/to/file.py:12:3 → file.py
+            line = re.sub(
+                r"(?<![\w/])[\w./-]+\.py(?=:\d+)", lambda m: m.group(0).split("/")[-1], line
+            )
+            # Drop line:col numbers (file.py:10:5 or file.py:99)
+            line = re.sub(r":\d+(:\d+)?(?=:|\s|$)", "", line)
+            lines.append(line)
+        return "\n".join(lines)
 
     def _get_preferred_worktree_path(self, wf: dict) -> str:
         """Return the canonical worktree path the workflow should reuse."""
@@ -2034,14 +2098,6 @@ class AutonomousOrchestrator:
         dev_round = int(wf.get("dev_round", 1) or 1)
         previous_attempts = int(wf.get("ci_repair_attempts", 0) or 0)
         next_attempt = previous_attempts + 1
-        signature = self._ci_failure_signature(failed_checks)
-        previous_signature = (wf.get("last_ci_failure_signature") or "").strip()
-        previous_head_sha = (wf.get("last_ci_failure_head_sha") or "").strip()
-        failure_names = ", ".join(
-            check.get("name") or "unknown"
-            for check in failed_checks
-            if check.get("bucket") == "fail"
-        )
         preferred_worktree_path = self._get_preferred_worktree_path(wf)
         gh = self._get_gh()
         current_head_sha = ""
@@ -2051,6 +2107,22 @@ class AutonomousOrchestrator:
             logger.warning(
                 "Failed to resolve PR head SHA for CI repair on PR #%s: %s", pr_number, e
             )
+
+        # Fine-grained fingerprint: check name + the specific error lines from
+        # the CI log excerpt. The coarse-grained _ci_failure_signature only
+        # captures the check NAME (e.g. "lint"), so a single Actions job that
+        # runs black/isort/ruff/mypy shows the same signature even when the
+        # failing sub-tool changes (black fixed but mypy still fails). Including
+        # the actual error lines makes the fingerprint react to partial fixes,
+        # so the agent gets another attempt instead of being marked exhausted.
+        signature = self._ci_failure_fingerprint(gh, failed_checks)
+        previous_signature = (wf.get("last_ci_failure_signature") or "").strip()
+        previous_head_sha = (wf.get("last_ci_failure_head_sha") or "").strip()
+        failure_names = ", ".join(
+            check.get("name") or "unknown"
+            for check in failed_checks
+            if check.get("bucket") == "fail"
+        )
 
         if (
             previous_signature

--- a/tests/issues/1811/test_ci_repair_fingerprint.py
+++ b/tests/issues/1811/test_ci_repair_fingerprint.py
@@ -1,0 +1,150 @@
+"""Tests for CI repair fingerprint and failure-excerpt extraction (issue #1811).
+
+Two bugs caused the merge-phase CI repair to give up after a single attempt
+even though only a subset of the failing tools had been fixed:
+
+Bug 1 (coarse signature): ``_ci_failure_signature`` only used the CI check NAME
+(e.g. ``lint``). A single Actions job bundles black/isort/ruff/mypy, so fixing
+black+ruff while mypy still fails left the signature identical — the
+exhausted-unchanged guard wrongly marked the workflow failed.
+
+Bug 2 (tail-only excerpt): ``get_check_failure_excerpt`` took the last 80 lines
+of the log. pre-commit prints passing hooks *after* failing ones, so the mypy
+error in the middle was truncated away and the agent never saw it.
+"""
+
+from unittest.mock import MagicMock
+
+from app.modules.workspace.autonomous.github_ops import _extract_failure_lines
+
+# ── Bug 2: _extract_failure_lines finds mid-log errors ───────────────────
+
+
+class TestExtractFailureLines:
+    """The failure extractor must surface error lines that sit in the middle of
+    a long pre-commit log, not just the tail."""
+
+    def test_finds_mypy_error_in_middle(self):
+        # pre-commit runs black (pass) → isort (pass) → ruff (pass) → mypy (FAIL)
+        # → bandit (pass). mypy's error is NOT in the last 3 lines.
+        lines = [
+            "black....................................................Passed",
+            "isort....................................................Passed",
+            "ruff.....................................................Passed",
+            "mypy.....................................................Failed",
+            "app/modules/workspace/api_key_proxy.py:1818:9: error: Returning Any",
+            "Found 1 error in 1 file (checked 14 source files)",
+            "bandit...................................................Passed",
+            "trim trailing whitespace................................Passed",
+            "check for added large files..............................Passed",
+        ]
+        result = _extract_failure_lines(lines, max_lines=80)
+        text = "\n".join(result)
+        # The mypy error line must be present even though it's not in the tail.
+        assert "Returning Any" in text, "mid-log mypy error must be extracted"
+        assert "mypy" in text
+
+    def test_finds_multiple_distinct_errors(self):
+        lines = [
+            "black....................................................Failed",
+            "would reformat app/foo.py",
+            "ruff.....................................................Failed",
+            "app/bar.py:10:5: F841 local variable 'x' is assigned to but never used",
+            "mypy.....................................................Failed",
+            "app/baz.py:5: error: no-any-return",
+            "some passing hook........................................Passed",
+        ]
+        result = _extract_failure_lines(lines, max_lines=80)
+        text = "\n".join(result)
+        assert "would reformat" in text
+        assert "F841" in text
+        assert "no-any-return" in text
+
+    def test_fallback_to_tail_when_no_markers(self):
+        # Log with no recognizable failure markers → fall back to tail.
+        lines = [f"line {i} nothing interesting" for i in range(100)]
+        result = _extract_failure_lines(lines, max_lines=10)
+        assert len(result) == 10
+        assert result[-1] == "line 99 nothing interesting"
+
+    def test_respects_max_lines_limit(self):
+        lines = [f"file{i}.py:{i}: error: something {i}" for i in range(200)]
+        result = _extract_failure_lines(lines, max_lines=20)
+        assert len(result) <= 20
+
+
+# ── Bug 1: fine-grained fingerprint reacts to partial fixes ──────────────
+
+
+def _make_orchestrator():
+    from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+    orch = AutonomousOrchestrator.__new__(AutonomousOrchestrator)
+    return orch
+
+
+class TestCiFailureFingerprint:
+    """The fingerprint must differ when the set of failing sub-tools changes,
+    so that fixing black+ruff (while mypy still fails) is NOT treated as
+    'no change' by the exhausted-unchanged guard."""
+
+    def test_different_excerpts_produce_different_fingerprints(self):
+        orch = _make_orchestrator()
+        gh = MagicMock()
+
+        # Round 1: black + ruff + mypy all fail
+        gh.get_check_failure_excerpt.return_value = (
+            "black....Failed\nwould reformat app/foo.py\n"
+            "ruff....Failed\napp/bar.py:10 F841\n"
+            "mypy....Failed\napp/baz.py:5 error: no-any-return\n"
+        )
+        checks = [{"name": "lint", "state": "failure", "bucket": "fail"}]
+        fp1 = orch._ci_failure_fingerprint(gh, checks)
+
+        # Round 2: black + ruff fixed, only mypy fails
+        gh.get_check_failure_excerpt.return_value = (
+            "mypy....Failed\napp/baz.py:5 error: no-any-return\n"
+        )
+        fp2 = orch._ci_failure_fingerprint(gh, checks)
+
+        assert fp1 != fp2, (
+            "fingerprint must change when the failing sub-tools change "
+            "(partial fix should not be treated as 'no change')"
+        )
+
+    def test_same_excerpt_produces_same_fingerprint(self):
+        orch = _make_orchestrator()
+        gh = MagicMock()
+        excerpt = "mypy....Failed\napp/baz.py:5 error: no-any-return\n"
+        gh.get_check_failure_excerpt.return_value = excerpt
+        checks = [{"name": "lint", "state": "failure", "bucket": "fail"}]
+        fp1 = orch._ci_failure_fingerprint(gh, checks)
+        fp2 = orch._ci_failure_fingerprint(gh, checks)
+        assert fp1 == fp2, "identical failures must produce identical fingerprint"
+
+    def test_empty_excerpt_falls_back_to_name_only(self):
+        orch = _make_orchestrator()
+        gh = MagicMock()
+        gh.get_check_failure_excerpt.return_value = ""
+        checks = [{"name": "lint", "state": "failure", "bucket": "fail"}]
+        fp = orch._ci_failure_fingerprint(gh, checks)
+        # Still has the check name, just with an empty-content hash.
+        assert "lint" in fp
+
+    def test_path_normalization_in_fingerprint(self):
+        """The fingerprint should ignore line-number/path noise so the same
+        logical error is stable across re-runs."""
+        orch = _make_orchestrator()
+        gh = MagicMock()
+
+        # Same error, different line number and absolute path prefix
+        gh.get_check_failure_excerpt.return_value = (
+            "/home/runner/work/open-ace/app/modules/x.py:10:5: error: Returning Any"
+        )
+        n1 = orch._normalize_failure_excerpt(
+            "/home/runner/work/open-ace/app/modules/x.py:10:5: error: Returning Any"
+        )
+        n2 = orch._normalize_failure_excerpt("x.py:99: error: Returning Any")
+        # After normalization both should collapse to the same error text
+        # (path → basename, line:col stripped).
+        assert n1 == n2, "same error at different line/path must normalize equal"


### PR DESCRIPTION
## 背景

issue #1811 的 PR #1834 lint CI 失败，agent 修了 black+ruff 但 mypy 仍失败，CI repair 只跑了 1 次就判定 \`ci_repair_exhausted\`。

实际 mypy 错误：
\`\`\`
app/modules/workspace/api_key_proxy.py:1818:9: error: Returning Any from
function declared to return "bool"  [no-any-return]
\`\`\`

## 两个根因

### 根因 1：CI failure signature 太粗粒度

\`_ci_failure_signature\` 只用 \`check_name|state|bucket\`。GitHub Actions 的 \`lint\` 是一个 job，内含 black/isort/ruff/mypy/pydocstyle 多个 hook。签名只看到 "lint|failure|fail"。agent 修了 black+ruff 但 mypy 还在 → 签名不变 → \`exhausted-unchanged\` 判定命中（签名相同 + HEAD SHA 变了）→ 只跑 1 次就放弃。

### 根因 2：failure_excerpt 取末尾 80 行

\`get_check_failure_excerpt\` 取 \`lines[-max_lines:]\`。pre-commit 按 hook 顺序输出（black → isort → ruff → mypy → bandit → ...），mypy 失败行在中间，末尾 80 行是后续 hook的 Passed 输出。agent 看到的摘录里没有 mypy 错误 → 漏修。

## 修复

### 1. 细粒度 failure fingerprint（orchestrator.py）

新增 \`_ci_failure_fingerprint\`：签名纳入每个 check 的 excerpt 错误行 hash（路径/行号归一化）。
- 第一轮：\`lint::hash(black Failed, ruff Failed, mypy Failed)\`
- agent 修了 black+ruff，第二轮：\`lint::hash(mypy Failed)\`
- **指纹变了** → 不命中 exhausted → 继续修复 mypy

### 2. excerpt 提取全错误行（github_ops.py）

新增 \`_extract_failure_lines\`：扫描全日志提取含错误标记的行（\`error:\`/\`Failed\`/\`F841\` 等）+ 1 行上下文，无匹配时回退末尾 N 行。

### 3. MAX_CI_REPAIR_ATTEMPTS 2→3

给 agent 更多机会修复多 hook CI 失败。

## 测试

\`tests/issues/1811/test_ci_repair_fingerprint.py\`（8 用例）：
- mypy 中间错误提取 / 多错误提取 / 无标记回退 / max_lines 限制
- 不同 excerpt 不同指纹 / 相同 excerpt 相同指纹 / 空 excerpt 回退 / 路径归一化

## 关联

- issue #1811（CI repair 在多 hook CI 失败时过早放弃）