### PR TITLE
fix(autonomous): CI repair commit_before 从 PR head 取 + #1837 评论清理

### DIFF
--- a/app/modules/workspace/autonomous/github_ops.py
+++ b/app/modules/workspace/autonomous/github_ops.py
@@ -71,7 +71,7 @@ def _is_transient_error(stderr: str, returncode: int) -> bool:
 # of the output (e.g. mypy failing while later hooks keep printing).
 _FAILURE_LINE_RE = re.compile(
     r"(error:|Error:|ERROR:|Failed|failed|FAIL\b|"
-    r"would reformat|not formatted|not sorted|isort.*skipped|"
+    r"would reformat|not formatted|not sorted|"
     r"no-any-return|undefined name|"
     r"\b[FEW]\d{3}\b)",  # flake8/ruff error codes
     re.IGNORECASE,

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -27,7 +27,7 @@ from app.modules.workspace.autonomous.artifact_text import (
     sanitize_artifact_text,
 )
 from app.modules.workspace.autonomous.event_emitter import AutonomousEventEmitter
-from app.modules.workspace.autonomous.github_ops import GitHubOps, GitHubOpsError
+from app.modules.workspace.autonomous.github_ops import _FAILURE_LINE_RE, GitHubOps, GitHubOpsError
 from app.modules.workspace.autonomous.models import AgentTaskResult
 from app.modules.workspace.autonomous.progress_report_i18n import (
     build_progress_payload,
@@ -1124,31 +1124,13 @@ class AutonomousOrchestrator:
             f"{feedback}\n\n"
         )
 
-    @staticmethod
-    def _ci_failure_signature(checks: list[dict]) -> str:
-        """Build a stable signature for the current set of failed CI checks."""
-        parts = []
-        for check in checks or []:
-            if check.get("bucket") != "fail":
-                continue
-            parts.append(
-                "|".join(
-                    [
-                        str(check.get("name") or "").strip(),
-                        str(check.get("state") or "").strip(),
-                        str(check.get("bucket") or "").strip(),
-                    ]
-                )
-            )
-        return "\n".join(sorted(parts))
-
     def _ci_failure_fingerprint(self, gh: GitHubOps, checks: list[dict]) -> str:
         """Fine-grained failure signature including the actual error lines.
 
-        ``_ci_failure_signature`` only captures the CI check NAME, which is too
-        coarse for Actions jobs that bundle multiple tools (one ``lint`` job
-        runs black/isort/ruff/mypy). When the agent fixes one sub-tool but
-        another still fails, the coarse signature stays identical and the
+        The coarse-grained approach (check name only) is too coarse for Actions
+        jobs that bundle multiple tools (one ``lint`` job runs
+        black/isort/ruff/mypy). When the agent fixes one sub-tool but another
+        still fails, a name-only signature stays identical and the
         exhausted-unchanged guard wrongly gives up. This fingerprint appends a
         normalized hash of the per-check error excerpt so partial fixes change
         the signature and earn another repair attempt.
@@ -1189,13 +1171,8 @@ class AutonomousOrchestrator:
                 continue
             # Keep lines that carry an error marker; drop pre-commit banners
             # ("black....Passed", "mypy....Failed") which are too noisy.
-            if not re.search(
-                r"error:|Error:|ERROR:|Failed|failed|FAIL\b|"
-                r"would reformat|not formatted|not sorted|"
-                r"no-any-return|undefined name|\b[FEW]\d{3}\b",
-                line,
-                re.IGNORECASE,
-            ):
+            # Reuse the shared _FAILURE_LINE_RE from github_ops to avoid drift.
+            if not _FAILURE_LINE_RE.search(line):
                 continue
             # Normalize file paths: /abs/path/to/file.py:12:3 → file.py
             line = re.sub(
@@ -1327,11 +1304,22 @@ class AutonomousOrchestrator:
                 repair_prompt += f"## 当前失败检查\n{failure_list}\n\n"
         repair_prompt += self._get_user_feedback_prompt(wf)
 
+        # Capture the PR's remote head SHA (not the local worktree HEAD) as the
+        # baseline. If a prior repair round committed locally but didn't push
+        # (or pushed after this capture), the local HEAD would already include
+        # that commit, making commit_sha == commit_before and falsely reporting
+        # "no code changes". Using the remote PR head as baseline ensures we
+        # measure against what's actually on the PR branch on GitHub.
         commit_before = ""
         try:
-            commit_before = gh.get_current_commit()
+            commit_before = gh.get_pr_head_sha(pr_number)
         except Exception:
-            pass
+            # Fallback to local HEAD if the PR head lookup fails — better than
+            # skipping the check entirely.
+            try:
+                commit_before = gh.get_current_commit()
+            except Exception:
+                pass
 
         repair_result = self._run_agent(
             wf=wf,
@@ -2108,21 +2096,38 @@ class AutonomousOrchestrator:
                 "Failed to resolve PR head SHA for CI repair on PR #%s: %s", pr_number, e
             )
 
-        # Fine-grained fingerprint: check name + the specific error lines from
-        # the CI log excerpt. The coarse-grained _ci_failure_signature only
-        # captures the check NAME (e.g. "lint"), so a single Actions job that
-        # runs black/isort/ruff/mypy shows the same signature even when the
-        # failing sub-tool changes (black fixed but mypy still fails). Including
-        # the actual error lines makes the fingerprint react to partial fixes,
-        # so the agent gets another attempt instead of being marked exhausted.
-        signature = self._ci_failure_fingerprint(gh, failed_checks)
-        previous_signature = (wf.get("last_ci_failure_signature") or "").strip()
-        previous_head_sha = (wf.get("last_ci_failure_head_sha") or "").strip()
+        # Check attempt limit FIRST so the terminal round skips the fingerprint
+        # network fetches (gh run view --log-failed for each failing check).
         failure_names = ", ".join(
             check.get("name") or "unknown"
             for check in failed_checks
             if check.get("bucket") == "fail"
         )
+
+        if next_attempt > MAX_CI_REPAIR_ATTEMPTS:
+            message = (
+                f"PR #{pr_number} CI failed after {MAX_CI_REPAIR_ATTEMPTS} automatic repair rounds: "
+                f"{failure_names}"
+            )
+            self._create_milestone(
+                phase="merge",
+                dev_round=dev_round,
+                milestone_type="ci_repair_exhausted",
+                status="failed",
+                title="CI automatic repair limit reached",
+                error_message=message,
+            )
+            self._update_workflow({"status": "failed", "error_message": message})
+            return
+
+        # Fine-grained fingerprint: check name + the specific error lines from
+        # the CI log excerpt. A name-only signature is too coarse for Actions
+        # jobs that bundle multiple tools (one ``lint`` job runs
+        # black/isort/ruff/mypy) — fixing one sub-tool while another still
+        # fails would leave the signature identical and wrongly give up.
+        signature = self._ci_failure_fingerprint(gh, failed_checks)
+        previous_signature = (wf.get("last_ci_failure_signature") or "").strip()
+        previous_head_sha = (wf.get("last_ci_failure_head_sha") or "").strip()
 
         if (
             previous_signature
@@ -2139,22 +2144,6 @@ class AutonomousOrchestrator:
                 milestone_type="ci_repair_exhausted",
                 status="failed",
                 title="CI failures unchanged after automatic repair",
-                error_message=message,
-            )
-            self._update_workflow({"status": "failed", "error_message": message})
-            return
-
-        if next_attempt > MAX_CI_REPAIR_ATTEMPTS:
-            message = (
-                f"PR #{pr_number} CI failed after {MAX_CI_REPAIR_ATTEMPTS} automatic repair rounds: "
-                f"{failure_names or signature}"
-            )
-            self._create_milestone(
-                phase="merge",
-                dev_round=dev_round,
-                milestone_type="ci_repair_exhausted",
-                status="failed",
-                title="CI automatic repair limit reached",
                 error_message=message,
             )
             self._update_workflow({"status": "failed", "error_message": message})

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -1262,7 +1262,7 @@ class AutonomousOrchestrator:
         gh: GitHubOps,
         commit_before: str,
         attempt: int,
-        branch_name: str | None,
+        branch_name: Optional[str],
         pr_number: int,
     ) -> tuple[str, bool, str]:
         """Detect whether the CI repair agent produced changes and push them.

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -1313,9 +1313,16 @@ class AutonomousOrchestrator:
         commit_before = ""
         try:
             commit_before = gh.get_pr_head_sha(pr_number)
-        except Exception:
+        except Exception as exc:
             # Fallback to local HEAD if the PR head lookup fails — better than
-            # skipping the check entirely.
+            # skipping the check entirely. Log so ops can see when the fix
+            # degrades to the old (buggy) local-vs-local comparison.
+            logger.warning(
+                "get_pr_head_sha failed for PR #%s, falling back to local HEAD "
+                "for commit_before: %s",
+                pr_number,
+                exc,
+            )
             try:
                 commit_before = gh.get_current_commit()
             except Exception:

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -1257,6 +1257,51 @@ class AutonomousOrchestrator:
             f"{context}\n\n"
         )
 
+    @staticmethod
+    def _detect_and_push_ci_repair_changes(
+        gh: GitHubOps,
+        commit_before: str,
+        attempt: int,
+        branch_name: str | None,
+        pr_number: int,
+    ) -> tuple[str, bool, str]:
+        """Detect whether the CI repair agent produced changes and push them.
+
+        Returns ``(commit_sha, sha_changed, push_error)``. Extracted so the
+        "remote A, local B, agent no new commit → still push B" behavior is
+        unit-testable without running the full ``_run_merge_ci_repair`` flow
+        (#1838 review suggestion 1).
+        """
+        commit_sha = ""
+        try:
+            commit_sha = gh.get_current_commit()
+        except Exception:
+            pass
+        sha_changed = bool(commit_before and commit_sha and commit_before != commit_sha)
+
+        if not sha_changed:
+            try:
+                if gh.has_uncommitted_changes():
+                    gh.git_add_all()
+                    gh.git_commit(
+                        f"auto: ci repair (attempt {attempt})",
+                        no_verify=True,
+                    )
+                    commit_sha = gh.get_current_commit()
+                    sha_changed = bool(commit_before and commit_sha and commit_before != commit_sha)
+            except Exception as e:
+                logger.warning("CI repair auto-commit failed: %s", e)
+
+        push_error = ""
+        if sha_changed:
+            try:
+                gh.git_push(branch=branch_name)
+            except Exception as e:
+                push_error = str(e)
+                logger.warning("CI repair git_push failed for PR #%s: %s", pr_number, e)
+
+        return commit_sha, sha_changed, push_error
+
     def _run_merge_ci_repair(
         self, wf: dict, gh: GitHubOps, pr_number: int, failed_checks: list[dict]
     ) -> None:
@@ -1371,34 +1416,9 @@ class AutonomousOrchestrator:
 
         self._accumulate_tokens(repair_result)
 
-        commit_sha = ""
-        diff_stats = {}
-        push_error = ""
-        try:
-            commit_sha = gh.get_current_commit()
-        except Exception:
-            pass
-        sha_changed = bool(commit_before and commit_sha and commit_before != commit_sha)
-
-        if not sha_changed:
-            try:
-                if gh.has_uncommitted_changes():
-                    gh.git_add_all()
-                    gh.git_commit(
-                        f"auto: ci repair (attempt {attempt})",
-                        no_verify=True,
-                    )
-                    commit_sha = gh.get_current_commit()
-                    sha_changed = bool(commit_before and commit_sha and commit_before != commit_sha)
-            except Exception as e:
-                logger.warning("CI repair auto-commit failed: %s", e)
-
-        if sha_changed:
-            try:
-                gh.git_push(branch=branch_name or None)
-            except Exception as e:
-                push_error = str(e)
-                logger.warning("CI repair git_push failed for PR #%s: %s", pr_number, e)
+        commit_sha, sha_changed, push_error = self._detect_and_push_ci_repair_changes(
+            gh, commit_before, attempt, branch_name or None, pr_number
+        )
 
         try:
             diff_stats = gh.get_commit_diff_stats(commit_sha) if commit_sha else {}
@@ -2105,6 +2125,10 @@ class AutonomousOrchestrator:
 
         # Check attempt limit FIRST so the terminal round skips the fingerprint
         # network fetches (gh run view --log-failed for each failing check).
+        # Note: when BOTH "over MAX" and "signature unchanged" would match, this
+        # reports "limit reached" (more accurate — the real stop reason is the
+        # cap, not the unchanged signature). No downstream code depends on the
+        # milestone title wording (verified via grep).
         failure_names = ", ".join(
             check.get("name") or "unknown"
             for check in failed_checks

--- a/tests/issues/1574/test_ci_repair_verifiers.py
+++ b/tests/issues/1574/test_ci_repair_verifiers.py
@@ -133,19 +133,33 @@ def test_start_ci_repair_round_stays_in_merge_and_runs_merge_repair():
 
 
 def test_start_ci_repair_round_fails_when_signature_unchanged_after_new_head():
+    from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
     failed_checks = [
         {"name": "lint", "state": "failure", "bucket": "fail", "link": "https://example.com"}
     ]
+    # Use the new fine-grained fingerprint format (lint::<digest>). The digest
+    # must match what _ci_failure_fingerprint produces for the same excerpt.
+    # We mock get_check_failure_excerpt so the fingerprint is deterministic.
+    import hashlib
+
+    excerpt = "mypy....Failed\napp/baz.py:5 error: no-any-return\n"
+    expected_digest = hashlib.sha256(
+        AutonomousOrchestrator._normalize_failure_excerpt(excerpt).encode()
+    ).hexdigest()[:12]
+    expected_fingerprint = f"lint::{expected_digest}"
+
     wf = _make_workflow(
         status="merging",
         current_phase="merge",
         ci_repair_attempts=1,
-        last_ci_failure_signature="lint|failure|fail",
+        last_ci_failure_signature=expected_fingerprint,
         last_ci_failure_head_sha="sha-old",
     )
     orch, mock_repo = _make_orchestrator(wf)
     gh = MagicMock()
     gh.get_pr_head_sha.return_value = "sha-new"
+    gh.get_check_failure_excerpt.return_value = excerpt
     orch._get_gh = MagicMock(return_value=gh)
     orch._run_merge_ci_repair = MagicMock()
 

--- a/tests/issues/1811/test_ci_repair_fingerprint.py
+++ b/tests/issues/1811/test_ci_repair_fingerprint.py
@@ -179,3 +179,89 @@ class TestCiRepairCommitBeforeFromPrHead:
         # Verify get_pr_head_sha appears BEFORE get_current_commit (primary
         # path first, fallback second).
         assert source.index("get_pr_head_sha") < source.index("get_current_commit")
+
+
+# ── Behavior test: detect_and_push with remote vs local SHA (#1838 review) ─
+
+
+class TestDetectAndPushCiRepairChanges:
+    """The extracted ``_detect_and_push_ci_repair_changes`` must push when the
+    local HEAD is ahead of the PR's remote head — even if the agent made NO
+    new commit this round. This is the exact #1812 scenario: prior round
+    committed locally (B) but didn't push (remote still A); this round the
+    agent does nothing, but commit_before=A (remote), commit_sha=B (local)
+    → sha_changed=True → push B."""
+
+    def test_pushes_unpushed_commit_even_without_new_changes(self):
+        from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+        gh = MagicMock()
+        gh.get_current_commit.return_value = "sha-B"  # local has unpushed commit
+        gh.has_uncommitted_changes.return_value = False
+        gh.git_push.return_value = None
+
+        commit_sha, sha_changed, push_error = (
+            AutonomousOrchestrator._detect_and_push_ci_repair_changes(
+                gh,
+                commit_before="sha-A",  # PR remote head (behind local)
+                attempt=1,
+                branch_name="auto-dev/x",
+                pr_number=1812,
+            )
+        )
+        assert sha_changed is True
+        assert commit_sha == "sha-B"
+        assert push_error == ""
+        gh.git_push.assert_called_once_with(branch="auto-dev/x")
+
+    def test_no_changes_when_remote_equals_local(self):
+        from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+        gh = MagicMock()
+        gh.get_current_commit.return_value = "sha-A"  # same as remote
+        gh.has_uncommitted_changes.return_value = False
+
+        commit_sha, sha_changed, push_error = (
+            AutonomousOrchestrator._detect_and_push_ci_repair_changes(
+                gh, "sha-A", 1, "auto-dev/x", 1812
+            )
+        )
+        assert sha_changed is False
+        assert push_error == ""
+        gh.git_push.assert_not_called()
+
+    def test_auto_commits_uncommitted_changes(self):
+        from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+        gh = MagicMock()
+        gh.get_current_commit.return_value = "sha-A"  # initial: same as remote
+        gh.has_uncommitted_changes.return_value = True
+        # After auto-commit, HEAD advances
+        gh.git_commit.side_effect = lambda *a, **kw: setattr(
+            gh, "get_current_commit", MagicMock(return_value="sha-C")
+        )
+
+        commit_sha, sha_changed, push_error = (
+            AutonomousOrchestrator._detect_and_push_ci_repair_changes(
+                gh, "sha-A", 1, "auto-dev/x", 1812
+            )
+        )
+        assert sha_changed is True
+        gh.git_add_all.assert_called_once()
+        gh.git_push.assert_called_once()
+
+    def test_push_error_captured_not_raised(self):
+        from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+        gh = MagicMock()
+        gh.get_current_commit.return_value = "sha-B"
+        gh.has_uncommitted_changes.return_value = False
+        gh.git_push.side_effect = Exception("network error")
+
+        commit_sha, sha_changed, push_error = (
+            AutonomousOrchestrator._detect_and_push_ci_repair_changes(
+                gh, "sha-A", 1, "auto-dev/x", 1812
+            )
+        )
+        assert sha_changed is True
+        assert "network error" in push_error

--- a/tests/issues/1811/test_ci_repair_fingerprint.py
+++ b/tests/issues/1811/test_ci_repair_fingerprint.py
@@ -148,3 +148,34 @@ class TestCiFailureFingerprint:
         # After normalization both should collapse to the same error text
         # (path → basename, line:col stripped).
         assert n1 == n2, "same error at different line/path must normalize equal"
+
+
+# ── CI repair commit_before from PR head (not local worktree) ────────────
+
+
+class TestCiRepairCommitBeforeFromPrHead:
+    """``_run_merge_ci_repair`` must capture ``commit_before`` from the PR's
+    remote head SHA, not the local worktree HEAD. If a prior repair round
+    committed locally but didn't push, the local HEAD already includes that
+    commit — making the SHA comparison report "no changes" and falsely failing
+    the workflow (#1812 regression)."""
+
+    def test_commit_before_uses_pr_head_sha(self):
+        """The source code must use get_pr_head_sha for commit_before, with
+        get_current_commit only as fallback. Verified by inspecting the method
+        source (avoids a heavy integration test)."""
+        import inspect
+
+        from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+        source = inspect.getsource(AutonomousOrchestrator._run_merge_ci_repair)
+        # The primary path must be get_pr_head_sha (the PR's remote head).
+        assert "get_pr_head_sha" in source, (
+            "commit_before must use get_pr_head_sha to compare against the "
+            "remote PR head, not the local worktree HEAD"
+        )
+        # get_current_commit should only appear as a fallback.
+        assert "get_current_commit" in source, "fallback to local HEAD expected"
+        # Verify get_pr_head_sha appears BEFORE get_current_commit (primary
+        # path first, fallback second).
+        assert source.index("get_pr_head_sha") < source.index("get_current_commit")


### PR DESCRIPTION
## Bug 修复：CI repair SHA 检测

### 现象
issue #1812 的 CI repair agent 提交了 black 格式化修复（\`82dd3c5b\`），但 orchestrator 误判 "agent produced no code changes" → 工作流失败。

### 根因
\`_run_merge_ci_repair\` 的 \`commit_before\` 从**本地 worktree HEAD** 取。如果上一轮 agent 在本地提交了但没 push，HEAD 已包含该 commit。下一轮 \`commit_before = commit_sha\` → 误判 "no code changes"。

### 修复
\`commit_before\` 改为从 \`gh.get_pr_head_sha(pr_number)\` 取（PR 的远程 head SHA），fallback 到本地 HEAD：

\`\`\`python
commit_before = ""
try:
    commit_before = gh.get_pr_head_sha(pr_number)  # 远程 PR head
except Exception:
    commit_before = gh.get_current_commit()  # fallback
\`\`\`

这样即使 agent 本地提交了但没 push，\`commit_before\`（远程）≠ \`commit_sha\`（本地）→ 正确检测到需要 push。

## #1837 评论清理（非阻塞）

| 清理项 | 改动 |
|---|---|
| 死代码 \`_ci_failure_signature\` | 删除（无调用方，已被 \`_ci_failure_fingerprint\` 替代） |
| 正则重复漂移 | \`_normalize_failure_excerpt\` 复用 \`github_ops._FAILURE_LINE_RE\` |
| \`isort.*skipped\` 误标 | 从 \`_FAILURE_LINE_RE\` 移除（Skipped 是 pass 态） |
| 终止轮多余网络调用 | MAX 检查挪到 fingerprint 计算之前 |
| 残留 \`@staticmethod\` | 移除 |

## 测试
45 个测试通过（1811 fingerprint 9 + 1574 verifiers 5 + 1002 scheduler 31）。