### PR TITLE
fix(autonomous): pr_review_summary 创建移到 CI 检查之前 (Issue #1813)

### DIFF
--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -5106,27 +5106,17 @@ class AutonomousOrchestrator:
             )
 
         if (review_passed and not force_full_rounds) or at_cap:
-            # Check CI status before proceeding to report phase (Issue #1662)
-            # If CI failed, enter CI repair loop instead of reporting
-            if ci_failures:
-                self._create_milestone(
-                    phase="pr_review",
-                    dev_round=dev_round,
-                    round_number=round_num,
-                    milestone_type="ci_failed_before_report",
-                    status="completed",
-                    title=f"CI failed after review passed: {len(ci_failures)} checks",
-                    result_summary=", ".join(c.get("name", "unknown") for c in ci_failures),
-                )
-                # Reuse merge-phase CI repair loop
-                self._start_ci_repair_round(wf, pr_number, ci_failures)
-                return
-
             # All PR review rounds completed — summarize via the main session,
             # then move to report. The main session resumes with the development
             # history (incl. fixes) and is given the last review round's feedback
             # (review runs on the review session, so it must be injected), then
             # asked whether all review points were addressed and the PR is ready.
+            #
+            # The summary is created BEFORE the CI check so that a CI failure
+            # (which redirects to the CI repair loop and returns) doesn't skip
+            # it. Without this ordering, the frontend "PR Review Summary" button
+            # stays permanently disabled when CI fails after review passes
+            # (#1813 regression — pr_review_summary milestone never created).
             last_pr_review = ""
             pr_milestones = self.repo.list_milestones(self._workflow_id, phase="pr_review")
             for ms in reversed(pr_milestones):
@@ -5142,6 +5132,22 @@ class AutonomousOrchestrator:
                 status="in_progress",
                 title="PR Review Summary",
             )
+
+            # Check CI status before proceeding to report phase (Issue #1662)
+            # If CI failed, enter CI repair loop instead of reporting
+            if ci_failures:
+                self._create_milestone(
+                    phase="pr_review",
+                    dev_round=dev_round,
+                    round_number=round_num,
+                    milestone_type="ci_failed_before_report",
+                    status="completed",
+                    title=f"CI failed after review passed: {len(ci_failures)} checks",
+                    result_summary=", ".join(c.get("name", "unknown") for c in ci_failures),
+                )
+                # Reuse merge-phase CI repair loop
+                self._start_ci_repair_round(wf, pr_number, ci_failures)
+                return
 
             summary_prompt = (
                 AUTONOMOUS_CONTEXT + "代码审查已全部完成。请根据最后一轮审查意见，"

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -5112,11 +5112,12 @@ class AutonomousOrchestrator:
             # (review runs on the review session, so it must be injected), then
             # asked whether all review points were addressed and the PR is ready.
             #
-            # The summary is created BEFORE the CI check so that a CI failure
-            # (which redirects to the CI repair loop and returns) doesn't skip
-            # it. Without this ordering, the frontend "PR Review Summary" button
-            # stays permanently disabled when CI fails after review passes
-            # (#1813 regression — pr_review_summary milestone never created).
+            # The ENTIRE summary block (create milestone → run agent → fill
+            # review_content → post comment) must run BEFORE the CI check.
+            # Otherwise a CI failure redirects to the CI repair loop and
+            # returns, leaving the milestone with status="in_progress" and
+            # empty review_content — the frontend "PR Review Summary" button
+            # checks review_content?.trim() and stays disabled (#1813).
             last_pr_review = ""
             pr_milestones = self.repo.list_milestones(self._workflow_id, phase="pr_review")
             for ms in reversed(pr_milestones):
@@ -5132,22 +5133,6 @@ class AutonomousOrchestrator:
                 status="in_progress",
                 title="PR Review Summary",
             )
-
-            # Check CI status before proceeding to report phase (Issue #1662)
-            # If CI failed, enter CI repair loop instead of reporting
-            if ci_failures:
-                self._create_milestone(
-                    phase="pr_review",
-                    dev_round=dev_round,
-                    round_number=round_num,
-                    milestone_type="ci_failed_before_report",
-                    status="completed",
-                    title=f"CI failed after review passed: {len(ci_failures)} checks",
-                    result_summary=", ".join(c.get("name", "unknown") for c in ci_failures),
-                )
-                # Reuse merge-phase CI repair loop
-                self._start_ci_repair_round(wf, pr_number, ci_failures)
-                return
 
             summary_prompt = (
                 AUTONOMOUS_CONTEXT + "代码审查已全部完成。请根据最后一轮审查意见，"
@@ -5204,6 +5189,22 @@ class AutonomousOrchestrator:
                     is_pr=True,
                     context="review-summary",
                 )
+
+            # Check CI status before proceeding to report phase (Issue #1662)
+            # If CI failed, enter CI repair loop instead of reporting
+            if ci_failures:
+                self._create_milestone(
+                    phase="pr_review",
+                    dev_round=dev_round,
+                    round_number=round_num,
+                    milestone_type="ci_failed_before_report",
+                    status="completed",
+                    title=f"CI failed after review passed: {len(ci_failures)} checks",
+                    result_summary=", ".join(c.get("name", "unknown") for c in ci_failures),
+                )
+                # Reuse merge-phase CI repair loop
+                self._start_ci_repair_round(wf, pr_number, ci_failures)
+                return
 
             # Move to report
             self._update_workflow(

--- a/tests/issues/1813/test_pr_review_summary_before_ci.py
+++ b/tests/issues/1813/test_pr_review_summary_before_ci.py
@@ -1,62 +1,162 @@
 """Tests for pr_review_summary created before CI check (issue #1813).
 
 When PR review passes but CI fails, the workflow enters the CI repair loop
-and returns early. Previously the ``pr_review_summary`` milestone was created
-AFTER the CI check — so when CI failed, the summary was never created, and
-the frontend "PR Review Summary" button stayed permanently disabled even
-after the workflow completed successfully.
+and returns early. Previously the ``pr_review_summary`` milestone's agent run
++ ``review_content`` fill happened AFTER the CI check — so when CI failed,
+the summary was never generated (empty ``review_content``), and the frontend
+"PR Review Summary" button stayed permanently disabled.
 
-The fix moves the ``pr_review_summary`` creation BEFORE the CI check.
+The fix moves the ENTIRE summary block (create → run agent → fill
+review_content → post comment) BEFORE the CI check.
 """
+
+from unittest.mock import MagicMock, patch
+
+from app.modules.workspace.autonomous.models import AgentTaskResult
+
+
+def _make_workflow(**overrides):
+    base = {
+        "workflow_id": "wf-1813",
+        "user_id": 1,
+        "title": "Test",
+        "status": "pr_review",
+        "requirements_text": "Build feature",
+        "requirements_issue_url": "",
+        "project_path": "/tmp/p",
+        "project_repo_url": "",
+        "is_new_project": False,
+        "cli_tool": "claude-code",
+        "model": "glm-5",
+        "permission_mode": "auto-edit",
+        "branch_name": "auto-dev/x",
+        "branch_strategy": "worktree",
+        "workspace_type": "local",
+        "remote_machine_id": "",
+        "worktree_path": "/tmp/p",
+        "github_issue_number": 1813,
+        "github_pr_number": 99,
+        "github_pr_url": "",
+        "current_phase": "pr_review",
+        "current_round": 0,
+        "dev_round": 1,
+        "max_plan_rounds": 3,
+        "max_pr_review_rounds": 3,
+        "require_full_review_rounds": False,
+        "total_tokens": 0,
+        "total_input_tokens": 0,
+        "total_output_tokens": 0,
+        "total_requests": 0,
+        "error_message": "",
+        "content_language": "zh",
+    }
+    base.update(overrides)
+    return base
 
 
 class TestPrReviewSummaryBeforeCiCheck:
-    """``pr_review_summary`` must be created BEFORE the CI failure check so
-    that a CI failure (which redirects to CI repair and returns) doesn't skip
-    the summary milestone.
+    """The ENTIRE summary block (create → agent → review_content → completed)
+    must run BEFORE the CI failure check. When CI fails, the summary must
+    still be completed with non-empty review_content — otherwise the frontend
+    "PR Review Summary" button stays disabled (#1813)."""
 
-    Verified by source inspection: in ``_do_pr_review``, the
-    ``pr_review_summary`` milestone creation must appear textually before the
-    ``ci_failed_before_report`` milestone creation (and the ``return`` that
-    follows it). A full integration test is impractical here because
-    ``_do_pr_review`` requires extensive mocking of CI polling, agent runs,
-    diff inspection, and JSON-serializable milestone fields."""
+    def test_review_content_filled_before_ci_return(self):
+        """When review passes but CI fails, the pr_review_summary milestone
+        must be updated with non-empty review_content AND status=completed
+        BEFORE the CI failure path returns.
 
-    def test_summary_creation_appears_before_ci_check_in_source(self):
-        import inspect
-
+        We mock the agent runner to return summary text, then verify
+        update_milestone was called with review_content before
+        _start_ci_repair_round."""
         from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
 
-        source = inspect.getsource(AutonomousOrchestrator._do_pr_review)
-        summary_pos = source.find('"pr_review_summary"')
-        ci_fail_pos = source.find('"ci_failed_before_report"')
-        assert summary_pos != -1, "pr_review_summary milestone creation not found"
-        assert ci_fail_pos != -1, "ci_failed_before_report milestone creation not found"
-        assert summary_pos < ci_fail_pos, (
-            "pr_review_summary must be created BEFORE ci_failed_before_report "
-            "so CI failure doesn't skip the summary (#1813 regression)"
+        wf = _make_workflow()
+        call_order = []  # track method call order
+
+        with (
+            patch("app.modules.workspace.autonomous.orchestrator.Database"),
+            patch(
+                "app.modules.workspace.autonomous.orchestrator.AutonomousWorkflowRepository"
+            ) as mock_repo_cls,
+        ):
+            mock_repo = MagicMock()
+            mock_repo.get_workflow.return_value = wf
+            mock_repo.list_milestones.return_value = []
+            mock_repo.create_milestone.return_value = {
+                "milestone_id": "ms-summary",
+                "workflow_id": "wf-1813",
+            }
+            mock_repo.create_event.return_value = {"id": 1}
+            mock_repo.update_workflow.return_value = wf
+
+            # Track update_milestone calls to capture review_content.
+            def track_update(ms_id, fields):
+                call_order.append(("update_milestone", dict(fields)))
+
+            mock_repo.update_milestone.side_effect = track_update
+            mock_repo.update_workflow_tokens.return_value = None
+            mock_repo_cls.return_value = mock_repo
+
+            orch = AutonomousOrchestrator("wf-1813")
+            orch.repo = mock_repo
+            orch.emitter = MagicMock()
+            # Bypass _emit's json.dumps to avoid MagicMock serialization issues.
+            orch._emit = MagicMock()
+            orch._accumulate_tokens = MagicMock()
+            orch._gh = MagicMock()
+            orch._gh.get_current_commit.return_value = "abc"
+            orch._gh.get_current_branch.return_value = "auto-dev/x"
+            orch._gh.get_pr_head_sha.return_value = "abc"
+            orch._gh.get_diff.return_value = "diff content"
+            orch._gh.get_diff_stats.return_value = {
+                "additions": 10,
+                "deletions": 2,
+                "files": 3,
+                "commits": 1,
+            }
+            orch._gh.create_pr.return_value = {
+                "number": 99,
+                "url": "https://github.com/pull/99",
+            }
+            orch._post_github_comment = MagicMock()
+            # Skip the PR review fix path — we only care about the summary
+            # ordering relative to the CI check, not the fix mechanics.
+            orch._apply_pr_review_fix = MagicMock()
+
+            orch._runner = MagicMock()
+            orch._runner.run_agent_task.return_value = AgentTaskResult(
+                session_id="s",
+                response_text="代码审查通过",
+                visible_response_text="代码审查通过",
+                success=True,
+            )
+
+            # Track CI repair call order.
+            def track_ci_repair(*a, **kw):
+                call_order.append(("ci_repair",))
+
+            with (
+                patch.object(
+                    orch, "_poll_ci_status", return_value=[{"name": "lint", "bucket": "fail"}]
+                ),
+                patch.object(orch, "_start_ci_repair_round", side_effect=track_ci_repair),
+            ):
+                orch._do_pr_review(wf)
+
+        # Find the update_milestone call that set review_content.
+        review_updates = [
+            c for c in call_order if c[0] == "update_milestone" and c[1].get("review_content")
+        ]
+        assert review_updates, (
+            "pr_review_summary must be updated with non-empty review_content " "even when CI fails"
         )
+        assert review_updates[0][1]["review_content"].strip(), "review_content must be non-empty"
+        assert review_updates[0][1]["status"] == "completed", "pr_review_summary must be completed"
 
-    def test_summary_creation_not_inside_ci_failure_block(self):
-        """The summary creation must NOT be inside the ``if ci_failures:``
-        block that creates ci_failed_before_report — it must run
-        unconditionally when review passes."""
-        import inspect
-
-        from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
-
-        source = inspect.getsource(AutonomousOrchestrator._do_pr_review)
-        summary_pos = source.find('"pr_review_summary"')
-        # Find the "if ci_failures:" that immediately precedes
-        # ci_failed_before_report (the one that returns to CI repair).
-        ci_fail_milestone_pos = source.find('"ci_failed_before_report"')
-        assert ci_fail_milestone_pos != -1
-        # Search backwards from ci_failed_before_report to find its enclosing
-        # "if ci_failures:" block.
-        ci_block_start = source.rfind("if ci_failures:", 0, ci_fail_milestone_pos)
-        assert ci_block_start != -1
-        # The summary must appear BEFORE this CI-failure block.
-        assert summary_pos < ci_block_start, (
-            "pr_review_summary must be created before the `if ci_failures:` "
-            "block that creates ci_failed_before_report"
-        )
+        # Verify review_content update happened BEFORE ci_repair.
+        review_idx = call_order.index(review_updates[0])
+        ci_repair_calls = [i for i, c in enumerate(call_order) if c[0] == "ci_repair"]
+        assert ci_repair_calls, "ci_repair should have been called"
+        assert (
+            review_idx < ci_repair_calls[0]
+        ), "review_content must be filled BEFORE entering CI repair"

--- a/tests/issues/1813/test_pr_review_summary_before_ci.py
+++ b/tests/issues/1813/test_pr_review_summary_before_ci.py
@@ -82,16 +82,22 @@ class TestPrReviewSummaryBeforeCiCheck:
             mock_repo = MagicMock()
             mock_repo.get_workflow.return_value = wf
             mock_repo.list_milestones.return_value = []
-            mock_repo.create_milestone.return_value = {
-                "milestone_id": "ms-summary",
-                "workflow_id": "wf-1813",
-            }
+
+            # Return a distinct milestone_id per type so we can filter
+            # update_milestone calls by the SUMMARY milestone only.
+            def fake_create(kwargs):
+                return {
+                    "milestone_id": f"ms-{kwargs.get('milestone_type', '')}",
+                    "workflow_id": "wf-1813",
+                }
+
+            mock_repo.create_milestone.side_effect = fake_create
             mock_repo.create_event.return_value = {"id": 1}
             mock_repo.update_workflow.return_value = wf
 
-            # Track update_milestone calls to capture review_content.
+            # Track update_milestone calls WITH ms_id to distinguish milestones.
             def track_update(ms_id, fields):
-                call_order.append(("update_milestone", dict(fields)))
+                call_order.append(("update_milestone", ms_id, dict(fields)))
 
             mock_repo.update_milestone.side_effect = track_update
             mock_repo.update_workflow_tokens.return_value = None
@@ -143,20 +149,26 @@ class TestPrReviewSummaryBeforeCiCheck:
             ):
                 orch._do_pr_review(wf)
 
-        # Find the update_milestone call that set review_content.
-        review_updates = [
-            c for c in call_order if c[0] == "update_milestone" and c[1].get("review_content")
+        # Find the update_milestone call for pr_review_summary (by id) that
+        # set review_content. Using ms_id avoids false-positives from
+        # pr_reviewed milestones which also carry review_content.
+        summary_updates = [
+            c
+            for c in call_order
+            if c[0] == "update_milestone"
+            and c[1] == "ms-pr_review_summary"
+            and c[2].get("review_content")
         ]
-        assert review_updates, (
+        assert summary_updates, (
             "pr_review_summary must be updated with non-empty review_content " "even when CI fails"
         )
-        assert review_updates[0][1]["review_content"].strip(), "review_content must be non-empty"
-        assert review_updates[0][1]["status"] == "completed", "pr_review_summary must be completed"
+        assert summary_updates[0][2]["review_content"].strip(), "review_content must be non-empty"
+        assert summary_updates[0][2]["status"] == "completed", "pr_review_summary must be completed"
 
         # Verify review_content update happened BEFORE ci_repair.
-        review_idx = call_order.index(review_updates[0])
+        summary_idx = call_order.index(summary_updates[0])
         ci_repair_calls = [i for i, c in enumerate(call_order) if c[0] == "ci_repair"]
         assert ci_repair_calls, "ci_repair should have been called"
         assert (
-            review_idx < ci_repair_calls[0]
+            summary_idx < ci_repair_calls[0]
         ), "review_content must be filled BEFORE entering CI repair"

--- a/tests/issues/1813/test_pr_review_summary_before_ci.py
+++ b/tests/issues/1813/test_pr_review_summary_before_ci.py
@@ -1,0 +1,63 @@
+"""Tests for pr_review_summary created before CI check (issue #1813).
+
+When PR review passes but CI fails, the workflow enters the CI repair loop
+and returns early. Previously the ``pr_review_summary`` milestone was created
+AFTER the CI check — so when CI failed, the summary was never created, and
+the frontend "PR Review Summary" button stayed permanently disabled even
+after the workflow completed successfully.
+
+The fix moves the ``pr_review_summary`` creation BEFORE the CI check.
+"""
+
+
+class TestPrReviewSummaryBeforeCiCheck:
+    """``pr_review_summary`` must be created BEFORE the CI failure check so
+    that a CI failure (which redirects to CI repair and returns) doesn't skip
+    the summary milestone.
+
+    Verified by source inspection: in ``_do_pr_review``, the
+    ``pr_review_summary`` milestone creation must appear textually before the
+    ``ci_failed_before_report`` milestone creation (and the ``return`` that
+    follows it). A full integration test is impractical here because
+    ``_do_pr_review`` requires extensive mocking of CI polling, agent runs,
+    diff inspection, and JSON-serializable milestone fields."""
+
+    def test_summary_creation_appears_before_ci_check_in_source(self):
+        import inspect
+
+        from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+        source = inspect.getsource(AutonomousOrchestrator._do_pr_review)
+        summary_pos = source.find('"pr_review_summary"')
+        ci_fail_pos = source.find('"ci_failed_before_report"')
+        assert summary_pos != -1, "pr_review_summary milestone creation not found"
+        assert ci_fail_pos != -1, "ci_failed_before_report milestone creation not found"
+        assert summary_pos < ci_fail_pos, (
+            "pr_review_summary must be created BEFORE ci_failed_before_report "
+            "so CI failure doesn't skip the summary (#1813 regression)"
+        )
+
+    def test_summary_creation_not_inside_ci_failure_block(self):
+        """The summary creation must NOT be inside the ``if ci_failures:``
+        block that creates ci_failed_before_report — it must run
+        unconditionally when review passes."""
+        import inspect
+
+        from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+        source = inspect.getsource(AutonomousOrchestrator._do_pr_review)
+        summary_pos = source.find('"pr_review_summary"')
+        # Find the "if ci_failures:" that immediately precedes
+        # ci_failed_before_report (the one that returns to CI repair).
+        ci_fail_milestone_pos = source.find('"ci_failed_before_report"')
+        assert ci_fail_milestone_pos != -1
+        # Search backwards from ci_failed_before_report to find its enclosing
+        # "if ci_failures:" block.
+        ci_block_start = source.rfind("if ci_failures:", 0, ci_fail_milestone_pos)
+        assert ci_block_start != -1
+        # The summary must appear BEFORE this CI-failure block.
+        assert summary_pos < ci_block_start, (
+            "pr_review_summary must be created before the `if ci_failures:` "
+            "block that creates ci_failed_before_report"
+        )
+

--- a/tests/issues/1813/test_pr_review_summary_before_ci.py
+++ b/tests/issues/1813/test_pr_review_summary_before_ci.py
@@ -60,4 +60,3 @@ class TestPrReviewSummaryBeforeCiCheck:
             "pr_review_summary must be created before the `if ci_failures:` "
             "block that creates ci_failed_before_report"
         )
-


### PR DESCRIPTION
## 现象

issue #1813 工作流 PR review 通过后 CI 失败，进入 CI repair 流程。CI repair 成功并 merge 后工作流 completed，但前端 timeline header 的"PR评审总结"按钮一直是虚的（disabled）。

## 根因

\`_do_pr_review\`（orchestrator.py）在 review 通过时的流程：

\`\`\`python
if (review_passed and not force_full_rounds) or at_cap:
    if ci_failures:                        # ← CI 失败
        # 创建 ci_failed_before_report
        self._start_ci_repair_round(...)   # ← 进 CI repair
        return                              # ← 跳过 pr_review_summary！

    # 只有 CI 通过才走到这里
    summary_ms = self._create_milestone(..., "pr_review_summary")
\`\`\`

CI 失败时 \`return\` 在 \`pr_review_summary\` 创建之前。即使 CI repair 成功并 merge 了，\`pr_review_summary\` milestone 也永远不会被创建。前端按钮（\`disabled={!latestPrReviewSummary}\`）永远 disabled。

## 修复

把 \`pr_review_summary\` 的 \`_create_milestone\` 移到 CI 检查之前：

\`\`\`python
if (review_passed and not force_full_rounds) or at_cap:
    # 1. 先创建 pr_review_summary（review 通过就总结，不受 CI 影响）
    summary_ms = self._create_milestone(..., "pr_review_summary")
    summary_result = self._run_agent(...)  # 跑总结 agent

    # 2. 再检查 CI
    if ci_failures:
        # 创建 ci_failed_before_report
        self._start_ci_repair_round(...)
        return
\`\`\`

PR review 总结是对代码审查的总结，不应该依赖 CI 状态。

## 测试

\`tests/issues/1813/test_pr_review_summary_before_ci.py\`（2 用例）：
- \`pr_review_summary\` 创建位置在 \`ci_failed_before_report\` 之前
- \`pr_review_summary\` 不在 \`if ci_failures:\` 块内

## 关联

issue #1813（PR review 通过但 CI 失败时 pr_review_summary 被跳过）