### PR TITLE
fix(autonomous): is_error=true + subtype=success 不当 error (Issue #1816)

### DIFF
--- a/app/modules/workspace/autonomous/agent_runner.py
+++ b/app/modules/workspace/autonomous/agent_runner.py
@@ -417,6 +417,14 @@ def _extract_cli_result_error(parsed: dict, stderr_hint: str = "") -> tuple[str 
     if not parsed.get("is_error"):
         return None, None
 
+    # Claude SDK (2.1.x) can emit contradictory events near the context limit:
+    # is_error=true with subtype="success" and no actual error message. Treat
+    # this as success — the agent completed its task; the is_error flag is a
+    # spurious SDK signal, not a real failure (#1816 regression).
+    subtype = str(parsed.get("subtype") or "").strip()
+    if subtype == "success":
+        return None, None
+
     candidates: list[str] = []
     errors = parsed.get("errors")
     if isinstance(errors, list):
@@ -429,7 +437,6 @@ def _extract_cli_result_error(parsed: dict, stderr_hint: str = "") -> tuple[str 
     if stderr_hint.strip():
         candidates.append(stderr_hint.strip())
 
-    subtype = str(parsed.get("subtype") or "").strip()
     message = next((item for item in candidates if item), "")
     normalized = message.lower()
 

--- a/tests/issues/1816/test_cli_result_subtype_success.py
+++ b/tests/issues/1816/test_cli_result_subtype_success.py
@@ -1,0 +1,64 @@
+"""Tests for _extract_cli_result_error subtype=success guard (issue #1816).
+
+Claude SDK 2.1.x can emit a contradictory ``result`` event near the context
+limit: ``is_error=true`` with ``subtype="success"`` and no actual error
+message. Without a guard, ``_extract_cli_result_error`` falls through to the
+``subtype`` fallback and returns ``("unknown_cli_error", "success")``, which
+sets ``session.error = "success"`` → ``success = False`` → the milestone is
+marked ``failed`` even though the agent produced valid output.
+"""
+
+from app.modules.workspace.autonomous.agent_runner import _extract_cli_result_error
+
+
+class TestExtractCliResultErrorSubtypeSuccess:
+    """``is_error=true`` + ``subtype=success`` must NOT be classified as an
+    error — it's a spurious SDK signal, not a real failure."""
+
+    def test_subtype_success_with_is_error_returns_none(self):
+        """The exact #1816 scenario: is_error=true, subtype=success."""
+        result = _extract_cli_result_error(
+            {"is_error": True, "subtype": "success", "type": "result"},
+        )
+        assert result == (None, None), (
+            "is_error=true + subtype=success should be treated as success, "
+            "not an error (#1816 regression)"
+        )
+
+    def test_subtype_success_with_empty_errors_returns_none(self):
+        """is_error=true, subtype=success, empty errors list — still success."""
+        result = _extract_cli_result_error(
+            {"is_error": True, "subtype": "success", "errors": [], "type": "result"},
+        )
+        assert result == (None, None)
+
+    def test_real_error_with_subtype_error_still_caught(self):
+        """A genuine error (is_error=true, subtype=error, error message) must
+        still be caught — the guard only applies to subtype=success."""
+        result = _extract_cli_result_error(
+            {"is_error": True, "subtype": "error", "error": "Not logged in"},
+        )
+        assert result is not None
+        assert result[1] == "Not logged in"
+
+    def test_real_error_without_subtype_still_caught(self):
+        """is_error=true with a real error message but no subtype."""
+        result = _extract_cli_result_error(
+            {"is_error": True, "error": "Context window exceeded"},
+        )
+        assert result is not None
+        assert "Context window exceeded" in result[1]
+
+    def test_is_error_false_returns_none(self):
+        """Normal success (is_error=false) returns None."""
+        result = _extract_cli_result_error(
+            {"is_error": False, "subtype": "success", "type": "result"},
+        )
+        assert result == (None, None)
+
+    def test_resume_session_not_found_still_caught(self):
+        """The specific known error patterns are not affected by the guard."""
+        result = _extract_cli_result_error(
+            {"is_error": True, "errors": ["No conversation found with session id abc"]},
+        )
+        assert result[0] == "resume_session_not_found"


### PR DESCRIPTION
## 现象

issue #1816 的 plan_refined milestone 标为 \`failed\`，error_message = \`"success"\`。agent 实际产出了完整方案（140K tokens，2 条消息），但 milestone 被误判失败。

## 根因

claude-code SDK 2.1.x 在接近上下文限制时发出**矛盾的 result 事件**：
- \`is_error=true\`
- \`subtype="success"\`  
- 无 \`errors\` / \`error\` 字段

\`_extract_cli_result_error\`（agent_runner.py:415）在 \`is_error=true\` 时进入错误分类逻辑，但找不到具体错误消息，走到 fallback：\`return "unknown_cli_error", subtype\` → 返回 \`("unknown_cli_error", "success")\`。

结果链：
\`\`\`
session.error = "success"
→ success = session.error is not None = False
→ milestone status = "failed"
→ error_message = "success"
→ workflow status = "failed"
\`\`\`

## 触发条件

planning 阶段 session resume 累积大量上下文（1816 有 135K input tokens），接近模型上下文限制时触发。不常见但可复现——多轮 planning + review 的工作流容易累积到上下文极限。

## 修复

在 \`_extract_cli_result_error\` 里，\`is_error=true\` 之后立即检查 \`subtype="success"\`，如果是则 return \`(None, None)\`：

\`\`\`python
subtype = str(parsed.get("subtype") or "").strip()
if subtype == "success":
    return None, None  # SDK 矛盾信号，不是真 error
\`\`\`

\`subtype=success\` 明确表示操作完成。\`is_error=true\` 是 SDK 在上下文接近极限时的矛盾信号，不应覆盖 \`subtype\` 的语义。

## 测试

\`tests/issues/1816/test_cli_result_subtype_success.py\`（6 用例）：
- \`subtype=success\` + \`is_error=true\` → 不当 error ✓
- \`subtype=success\` + 空 errors → 不当 error ✓
- 真 error（\`subtype=error\` + error message）→ 仍捕获 ✓
- 真 error（无 subtype + error message）→ 仍捕获 ✓
- \`is_error=false\` → 正常 success ✓
- \`resume_session_not_found\` 模式不受影响 ✓