### PR TITLE
fix: 统一 AI 自主开发对话框所有布尔开关为 form-switch 样式

### DIFF
--- a/frontend/src/components/work/NewAutonomousModal.test.tsx
+++ b/frontend/src/components/work/NewAutonomousModal.test.tsx
@@ -451,4 +451,51 @@ describe('NewAutonomousModal', () => {
       expect(screen.queryByPlaceholderText('autoRequirementsPlaceholder')).not.toBeInTheDocument();
     });
   });
+
+  describe('auto-merge toggle in URL batch mode', () => {
+    // The auto-merge option only renders for batch workflows (URL mode with
+    // a non-empty requirements URL). Switch to that mode by entering a bare
+    // issue number and accepting the suggestion.
+    const switchToBatchMode = () => {
+      fireEvent.change(screen.getByPlaceholderText('autoRequirementsPlaceholder'), {
+        target: { value: '830' },
+      });
+      fireEvent.click(screen.getByText('autoIssueSuggestionSwitch'));
+    };
+
+    it('renders the auto-merge option as a switch matching the other toggles', () => {
+      render(<NewAutonomousModal {...defaultProps} />);
+
+      switchToBatchMode();
+
+      const autoMergeSwitch = screen.getByLabelText('autoMergeAfterPR');
+      // Style parity with the other boolean toggle in the modal
+      // (requireFullReviewRounds): both must render as form-switch toggles,
+      // not plain checkboxes.
+      expect(autoMergeSwitch.closest('.form-switch')).not.toBeNull();
+    });
+
+    it('defaults to enabled and submits auto_merge reflecting the toggled state', async () => {
+      render(<NewAutonomousModal {...defaultProps} />);
+
+      switchToBatchMode();
+
+      const autoMergeSwitch = screen.getByLabelText('autoMergeAfterPR');
+      expect(autoMergeSwitch).toBeChecked(); // autoMerge defaults to true
+
+      // Flip it off and submit.
+      fireEvent.click(autoMergeSwitch);
+      fireEvent.change(screen.getByPlaceholderText('autoProjectPathPlaceholder'), {
+        target: { value: '/Users/batch/project' },
+      });
+      selectModel();
+
+      fireEvent.click(screen.getByText('autoCreateTask'));
+
+      await waitFor(() => {
+        expect(mutateAsyncMock).toHaveBeenCalledTimes(1);
+      });
+      expect(mutateAsyncMock).toHaveBeenCalledWith(expect.objectContaining({ auto_merge: false }));
+    });
+  });
 });

--- a/frontend/src/components/work/NewAutonomousModal.test.tsx
+++ b/frontend/src/components/work/NewAutonomousModal.test.tsx
@@ -498,4 +498,23 @@ describe('NewAutonomousModal', () => {
       expect(mutateAsyncMock).toHaveBeenCalledWith(expect.objectContaining({ auto_merge: false }));
     });
   });
+
+  describe('other boolean toggles render as switches', () => {
+    // Style parity with autoMerge / requireFullReviewRounds: the modal's other
+    // two boolean options (isNewProject, isPrivate) must also use the
+    // form-switch variant, not plain checkboxes.
+    it('renders isNewProject as a switch', () => {
+      render(<NewAutonomousModal {...defaultProps} />);
+
+      expect(screen.getByLabelText('autoNewProject').closest('.form-switch')).not.toBeNull();
+    });
+
+    it('renders isPrivate as a switch once new-project mode is enabled', () => {
+      render(<NewAutonomousModal {...defaultProps} />);
+
+      fireEvent.click(screen.getByLabelText('autoNewProject'));
+
+      expect(screen.getByLabelText('autoPrivateRepo').closest('.form-switch')).not.toBeNull();
+    });
+  });
 });

--- a/frontend/src/components/work/NewAutonomousModal.tsx
+++ b/frontend/src/components/work/NewAutonomousModal.tsx
@@ -512,7 +512,7 @@ export const NewAutonomousModal: React.FC<NewAutonomousModalProps> = ({
 
           {/* Project Path */}
           <div className="col-12">
-            <div className="form-check mb-2">
+            <div className="form-check form-switch mb-2">
               <input
                 type="checkbox"
                 className="form-check-input"
@@ -536,7 +536,7 @@ export const NewAutonomousModal: React.FC<NewAutonomousModalProps> = ({
                   />
                 </div>
                 <div className="col-md-4">
-                  <div className="form-check">
+                  <div className="form-check form-switch">
                     <input
                       type="checkbox"
                       className="form-check-input"

--- a/frontend/src/components/work/NewAutonomousModal.tsx
+++ b/frontend/src/components/work/NewAutonomousModal.tsx
@@ -649,7 +649,7 @@ export const NewAutonomousModal: React.FC<NewAutonomousModalProps> = ({
           {/* Auto Merge - only show for batch workflows (URL mode with multiple issues) */}
           {requirementsMode === 'url' && requirementsUrl.trim() && (
             <div className="col-12">
-              <div className="form-check">
+              <div className="form-check form-switch">
                 <input
                   type="checkbox"
                   className="form-check-input"


### PR DESCRIPTION
## 背景
创建 AI 自主开发对话框里的布尔开/关选项样式不统一：`requireFullReviewRounds` 用拨动开关（`form-check form-switch`），而 `autoMerge`、`isNewProject`、`isPrivate` 仍是普通复选框（`form-check`）。

## 改动
把其余三处布尔开关统一为 `form-check form-switch`（toggle 样式）：
- `autoMerge`（「PR 创建后自动合并」）
- `isNewProject`（「新项目」）
- `isPrivate`（「私有仓库」）

`requireFullReviewRounds` 本就是 `form-switch`，无需改。纯样式改动，无行为变化。

## 测试
`NewAutonomousModal.test.tsx` 补充组件测试：
- URL 批量模式下 `autoMerge` 渲染为 `form-switch`、默认勾选、切换后影响 `auto_merge` 提交值
- `isNewProject` / `isPrivate` 也渲染为 `form-switch`

`vitest run`：**27 passed**（含新增 4 个）。

## 关于 a11y（不阻塞）
`form-switch` 底层 `<input type="checkbox">` 的 `role` 仍是 `checkbox`，未自动变 `switch`。本 PR 仅做视觉样式统一，不混入 `role="switch"` + `aria-checked` 的语义改动（留作后续 a11y 专项 PR 对四个 switch 一并收敛）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)