### PR TITLE
fix(autonomous): transient API error 正则不再误匹配 plan 文本里的 HTTP 状态码 (Issue #1816)

### DIFF
--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -670,7 +670,13 @@ _TRANSIENT_API_ERROR_RE = re.compile(
     # "API Error: 429" / "API Error: 5xx". Only 429 among 4xx is transient;
     # 400/401/403/404/422 are permanent client errors and must NOT trigger retry.
     r"api\s*error:?\s*(?:429|5\d{2})"
-    r"|(?:429|quota\s+exceeded|rate[\s-]?limit|too\s+many\s+requests)"
+    # Bare "429" must have context that distinguishes a real API error from a
+    # plan discussing HTTP status codes (e.g. "return 429" in a rate-limit
+    # design). Require "status" or "error" nearby, not just the number alone.
+    r"|status\s*(?:code)?\s*[:：]\s*429"
+    r"|error\s*(?:code)?\s*[:：]\s*429"
+    r"|429\s*too\s+many\s+requests"
+    r"|quota\s+exceeded|rate[\s-]?limit(?:ed)?|too\s+many\s+requests"
     r"|overloaded"  # "The service may be temporarily overloaded"
     r"|bad\s+gateway|service\s+unavailable|gateway\s+timeout|internal\s+server\s+error",
     re.IGNORECASE,

--- a/tests/issues/1816/test_transient_api_error_regex.py
+++ b/tests/issues/1816/test_transient_api_error_regex.py
@@ -1,0 +1,82 @@
+"""Tests for _TRANSIENT_API_ERROR_RE false-positive fix (issue #1816).
+
+The regex used to detect transient API errors (429 rate limit, 5xx) in agent
+output had a bare ``429`` alternative that matched any occurrence of the number
+"429" — including HTTP status codes in legitimate plan/review text discussing
+rate-limiting or error handling. This caused the orchestrator to retry a
+perfectly good agent response as if it were an API error, wasting time and
+eventually timing out (#1816 regression).
+
+The fix requires contextual clues (``status``, ``error``, ``too many requests``)
+around a bare ``429``, while still catching real API error messages.
+"""
+
+from app.modules.workspace.autonomous.orchestrator import _TRANSIENT_API_ERROR_RE
+
+
+class TestTransientApiErrorRegex:
+    """The regex must not match HTTP status codes in legitimate agent output."""
+
+    # ── Should NOT match (plan/review text with HTTP status codes) ──
+
+    def test_plan_with_429_in_table(self):
+        """The exact #1816 case: plan text has '429' in a design table."""
+        text = "| T1 | 窗口内连续失败 5 次 | 5 次错误密码 | 第 5 次 429 | 触发锁定 |"
+        assert not _TRANSIENT_API_ERROR_RE.search(text), (
+            "HTTP 429 in a plan design table must not be treated as an API error"
+        )
+
+    def test_plan_with_return_429(self):
+        text = "锁定时直接返回 429 错误"
+        assert not _TRANSIENT_API_ERROR_RE.search(text)
+
+    def test_plan_with_http_500(self):
+        text = "数据库操作失败 | 500 + 错误消息"
+        assert not _TRANSIENT_API_ERROR_RE.search(text)
+
+    def test_code_with_429_constant(self):
+        text = 'if status == 429: retry()'
+        assert not _TRANSIENT_API_ERROR_RE.search(text)
+
+    def test_bare_number_429(self):
+        """A bare '429' with no API error context must not match."""
+        assert not _TRANSIENT_API_ERROR_RE.search("429")
+        assert not _TRANSIENT_API_ERROR_RE.search("error 429 is returned")
+        assert not _TRANSIENT_API_ERROR_RE.search("returns 429 to client")
+
+    # ── Should match (real API error messages) ──
+
+    def test_api_error_429(self):
+        assert _TRANSIENT_API_ERROR_RE.search("API Error: 429")
+
+    def test_api_error_503(self):
+        assert _TRANSIENT_API_ERROR_RE.search("api error: 503")
+
+    def test_status_code_429(self):
+        assert _TRANSIENT_API_ERROR_RE.search("status code: 429")
+        assert _TRANSIENT_API_ERROR_RE.search("status: 429")
+
+    def test_error_code_429(self):
+        assert _TRANSIENT_API_ERROR_RE.search("error code: 429")
+        assert _TRANSIENT_API_ERROR_RE.search("error: 429")
+
+    def test_429_too_many_requests(self):
+        assert _TRANSIENT_API_ERROR_RE.search("429 Too Many Requests")
+
+    def test_quota_exceeded(self):
+        assert _TRANSIENT_API_ERROR_RE.search("quota exceeded")
+
+    def test_rate_limited(self):
+        assert _TRANSIENT_API_ERROR_RE.search("rate limited")
+
+    def test_rate_limit_exceeded(self):
+        assert _TRANSIENT_API_ERROR_RE.search("rate limit exceeded")
+
+    def test_overloaded(self):
+        assert _TRANSIENT_API_ERROR_RE.search("The service may be temporarily overloaded")
+
+    def test_bad_gateway(self):
+        assert _TRANSIENT_API_ERROR_RE.search("502 Bad Gateway")
+
+    def test_service_unavailable(self):
+        assert _TRANSIENT_API_ERROR_RE.search("503 Service Unavailable")

--- a/tests/issues/1816/test_transient_api_error_regex.py
+++ b/tests/issues/1816/test_transient_api_error_regex.py
@@ -22,9 +22,9 @@ class TestTransientApiErrorRegex:
     def test_plan_with_429_in_table(self):
         """The exact #1816 case: plan text has '429' in a design table."""
         text = "| T1 | 窗口内连续失败 5 次 | 5 次错误密码 | 第 5 次 429 | 触发锁定 |"
-        assert not _TRANSIENT_API_ERROR_RE.search(text), (
-            "HTTP 429 in a plan design table must not be treated as an API error"
-        )
+        assert not _TRANSIENT_API_ERROR_RE.search(
+            text
+        ), "HTTP 429 in a plan design table must not be treated as an API error"
 
     def test_plan_with_return_429(self):
         text = "锁定时直接返回 429 错误"
@@ -35,7 +35,7 @@ class TestTransientApiErrorRegex:
         assert not _TRANSIENT_API_ERROR_RE.search(text)
 
     def test_code_with_429_constant(self):
-        text = 'if status == 429: retry()'
+        text = "if status == 429: retry()"
         assert not _TRANSIENT_API_ERROR_RE.search(text)
 
     def test_bare_number_429(self):


### PR DESCRIPTION
## 现象

issue #1816 重跑后 plan_refined agent 产出了完整方案，但 orchestrator 误判为 transient API error 反复重试（30s → 60s → 120s → 240s 退避），最终超时失败。

## 根因

\`_TRANSIENT_API_ERROR_RE\`（orchestrator.py:669）的第二个分支：

\`\`\`python
r"|(?:429|quota\s+exceeded|rate[\s-]?limit|too\s+many\s+requests)"
\`\`\`

裸 \`429\` 只搜数字，不管上下文。plan 方案里讨论密码锁定返回 HTTP 429（\`| 第 5 次 429 | 触发锁定 |\`）就被误匹配为 API rate limit error。

\`_is_transient_api_error\` 检查的是 agent 的**完整输出文本**（plan/review/code），不只是 error message。任何讨论 HTTP 状态码的工作流都会误触发。

## 触发条件

agent 输出里包含 \`429\`、\`500\` 等 HTTP 状态码文本——在涉及 API 设计、错误处理、限流、状态码讨论的工作流中**非常常见**。

## 修复

裸 \`429\` 需要上下文线索才匹配：
- \`status: 429\` / \`status code: 429\`（冒号分隔）
- \`error: 429\` / \`error code: 429\`（冒号分隔）
- \`429 Too Many Requests\`
- \`quota exceeded\` / \`rate limit\` / \`rate limited\`

移除了 \`error 429\` 的宽松匹配（太容易和 plan 文本 \`"error 429 is returned"\` 混淆）。

\`api error: 429\` / \`api error: 5xx\` 分支不变（已有 \`api error:\` 前缀约束）。

## 测试

\`tests/issues/1816/test_transient_api_error_regex.py\`（16 用例）：
- **False-positive 场景**（不应匹配）：plan 表格里的 429、return 429、HTTP 500、裸 429、error 429 is returned
- **True-positive 场景**（应匹配）：API Error: 429、status: 429、error: 429、429 Too Many Requests、quota exceeded、rate limit、overloaded、bad gateway、service unavailable

## 关联

- issue #1816（plan_refined 反复重试导致超时）
- 影响**所有**涉及 HTTP 状态码讨论的工作流，不只是 1816