### PR TITLE
fix(autonomous): CI repair context 超限时降级到 fresh session 重试 (Issue #1816)

### DIFF
--- a/app/modules/workspace/autonomous/github_ops.py
+++ b/app/modules/workspace/autonomous/github_ops.py
@@ -607,6 +607,15 @@ class GitHubOps:
         """Checkout a branch or commit."""
         self._run_git(["checkout", ref])
 
+    def reset_hard_to_head(self) -> None:
+        """Discard all uncommitted changes and staged state, reset to HEAD.
+
+        Used by CI repair before a fresh-session retry to ensure the worktree
+        is clean after an aborted agent run (e.g. a context-overflow failure
+        that produced partial tool edits but no commit).
+        """
+        self._run_git(["reset", "--hard", "HEAD"])
+
     def delete_branch(self, name: str, remote: bool = True) -> None:
         """Delete a branch locally and optionally remotely."""
         self._run_git(["branch", "-D", name], check=False)

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -1350,7 +1350,7 @@ class AutonomousOrchestrator:
             lines.append("")
         return "\n".join(lines)
 
-    def _build_ci_repair_prompt(
+    def _build_merge_ci_repair_agent_prompt(
         self,
         wf: dict,
         pr_number: int,
@@ -1467,7 +1467,7 @@ class AutonomousOrchestrator:
             title=f"CI repair attempt {attempt} for PR #{pr_number}",
         )
 
-        repair_prompt = self._build_ci_repair_prompt(wf, pr_number, failed_checks)
+        repair_prompt = self._build_merge_ci_repair_agent_prompt(wf, pr_number, failed_checks)
 
         # Capture the PR's remote head SHA (not the local worktree HEAD) as the
         # baseline. If a prior repair round committed locally but didn't push
@@ -1530,7 +1530,7 @@ class AutonomousOrchestrator:
             except Exception as e:
                 logger.warning("Failed to reset worktree before fresh CI repair: %s", e)
 
-            fresh_prompt = self._build_ci_repair_prompt(
+            fresh_prompt = self._build_merge_ci_repair_agent_prompt(
                 wf, pr_number, failed_checks, include_prior_failures=True
             )
             repair_result = self._run_agent(
@@ -1614,7 +1614,16 @@ class AutonomousOrchestrator:
             return
 
         if not sha_changed:
-            message = "CI repair failed: agent produced no code changes"
+            # Preserve the context-overflow signal in the error message so the
+            # next round's _collect_prior_ci_repair_failures filters it out
+            # (an overflow failure has no actionable signal — the agent never
+            # produced output). Without this, a double-overflow round would
+            # be misclassified as "no code changes" and wrongly injected into
+            # the next fresh prompt. (#1816 review suggestion)
+            if self._is_context_overflow(repair_result):
+                message = f"CI repair failed: context overflow - {repair_result.error}"
+            else:
+                message = "CI repair failed: agent produced no code changes"
             milestone_updates["status"] = "failed"
             milestone_updates["error_message"] = message
             self.repo.update_milestone(repair_ms.get("milestone_id", ""), milestone_updates)

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -682,6 +682,25 @@ _TRANSIENT_API_ERROR_RE = re.compile(
     re.IGNORECASE,
 )
 
+# Context-window / input-length overflow signatures. A PERMANENT client
+# error (NOT transient — must not trigger the transient-retry backoff loop).
+# Used by CI repair to detect a resumed-session-too-large failure and switch
+# to a fresh minimal-context session on the next in-round retry. Kept broad
+# enough to catch provider-specific phrasings:
+#   GLM:      "Range of input length should be [1, 202752]"
+#   OpenAI:   "maximum context length" / "too many input tokens"
+#   Anthropic:"prompt is too long" / "context window"
+_CONTEXT_OVERFLOW_RE = re.compile(
+    r"range\s+of\s+input\s+length"
+    r"|maximum\s+context\s+length"
+    r"|context[_ ]?length\s*.{0,12}exceed"
+    r"|prompt\s+is\s+too\s+long"
+    r"|input\s+length\s+should\s+be"
+    r"|context[_ ]?window\s+.{0,12}exceed"
+    r"|too\s+many\s+input\s+tokens",
+    re.IGNORECASE,
+)
+
 # Test failure retry configuration.
 MAX_TEST_RETRIES = 2  # max retries when test agent itself fails
 MAX_DEV_RETRIES_ON_TEST_FAIL = 2  # max dev round retries for unfixable test failures
@@ -1284,6 +1303,101 @@ class AutonomousOrchestrator:
             f"{context}\n\n"
         )
 
+    def _collect_prior_ci_repair_failures(self) -> list[dict]:
+        """Return prior failed ``ci_repair_applied`` milestones.
+
+        Used to inject "what was already tried and failed" into a fresh
+        CI repair prompt so the agent doesn't repeat the same fix.
+        Context-overflow failures are excluded — the agent never produced
+        output in those rounds, so there's nothing actionable to avoid.
+        """
+        out: list[dict] = []
+        for ms in self.repo.list_milestones(self._workflow_id, phase="merge"):
+            if ms.get("milestone_type") != "ci_repair_applied":
+                continue
+            if ms.get("status") != "failed":
+                continue
+            body = f"{ms.get('error_message') or ''}\n{ms.get('result_summary') or ''}"
+            if _CONTEXT_OVERFLOW_RE.search(body):
+                continue
+            out.append(ms)
+        return out
+
+    def _build_prior_repair_failures_prompt(self) -> str:
+        """Inject full text of prior CI repair failures.
+
+        Returns empty on the first attempt (no history). Full error_message +
+        result_summary are injected verbatim (not summarized): a fresh session
+        starts with minimal context, so prior-failure text won't risk overflow.
+        """
+        prior = self._collect_prior_ci_repair_failures()
+        if not prior:
+            return ""
+        lines = [
+            "\n\n## ⚠️ 历史 CI 修复失败记录（请勿重复同样的修法）",
+            "以下是此前已经尝试过但失败的修复。当前会话是全新开始的，",
+            "请基于这些失败信息采用不同的修复思路，不要重复同样的改动。\n",
+        ]
+        for i, ms in enumerate(prior, 1):
+            title = ms.get("title") or ""
+            err = ms.get("error_message") or ""
+            summary = ms.get("result_summary") or ""
+            lines.append(f"### 失败记录 {i}: {title}")
+            if err:
+                lines.append(f"- 失败原因：\n```\n{err}\n```")
+            if summary:
+                lines.append(f"- 当时的修复摘要 / 报错：\n```\n{summary}\n```")
+            lines.append("")
+        return "\n".join(lines)
+
+    def _build_ci_repair_prompt(
+        self,
+        wf: dict,
+        pr_number: int,
+        failed_checks: list[dict],
+        *,
+        include_prior_failures: bool = False,
+    ) -> str:
+        """Assemble the CI repair agent prompt.
+
+        When ``include_prior_failures`` is set (used by the fresh-session
+        retry after a context overflow), appends full text of prior failed
+        CI repair attempts so the agent avoids repeating them.
+        """
+        issue_number = wf.get("github_issue_number") or self.workflow.get("github_issue_number")
+        prompt = (
+            AUTONOMOUS_CONTEXT
+            + "当前任务是在已有 PR 上修复 merge 阶段失败的 CI，不是开始新一轮完整开发。\n\n"
+        )
+        if issue_number:
+            prompt += (
+                f"## 关联 Issue\n"
+                f"本任务关联 GitHub Issue #{issue_number}。\n"
+                f"修复时请确保修改继续满足 Issue #{issue_number} 的所有需求。\n\n"
+            )
+        prompt += (
+            "## 重要约束\n"
+            "1. 保持在当前工作分支上修复，不要创建新的 PR，不要切换到其他分支。\n"
+            "2. 不要进入新的代码审查、进度汇报或等待流程；当前唯一目标是让现有 PR 的 CI 通过。\n"
+            "3. 必须优先根据 CI 工作流、失败日志摘录和仓库脚本定位问题，复现 CI 真实执行的命令。\n"
+            "4. 修复后重新运行对应命令，以及你改动涉及到的必要相关测试。\n"
+            "5. 只有在确实产生代码或配置修改后，才能提交 git commit 并推送到当前 PR 分支。\n"
+            "6. 结束时请明确说明：你复现了哪些命令、修复了什么、还剩什么风险。\n"
+        )
+        prompt += self._get_ci_repair_prompt(wf)
+        if failed_checks:
+            failure_list = "\n".join(
+                f"- **{check.get('name') or 'unknown'}**: {check.get('state') or 'unknown'}"
+                for check in failed_checks
+                if check.get("bucket") == "fail"
+            )
+            if failure_list:
+                prompt += f"## 当前失败检查\n{failure_list}\n\n"
+        prompt += self._get_user_feedback_prompt(wf)
+        if include_prior_failures:
+            prompt += self._build_prior_repair_failures_prompt()
+        return prompt
+
     @staticmethod
     def _detect_and_push_ci_repair_changes(
         gh: GitHubOps,
@@ -1344,7 +1458,6 @@ class AutonomousOrchestrator:
         dev_round = int(wf.get("dev_round", 1) or 1)
         attempt = int(wf.get("ci_repair_attempts", 0) or 0)
         branch_name = wf.get("branch_name", "")
-        issue_number = wf.get("github_issue_number") or self.workflow.get("github_issue_number")
 
         repair_ms = self._create_milestone(
             phase="merge",
@@ -1354,35 +1467,7 @@ class AutonomousOrchestrator:
             title=f"CI repair attempt {attempt} for PR #{pr_number}",
         )
 
-        repair_prompt = (
-            AUTONOMOUS_CONTEXT
-            + "当前任务是在已有 PR 上修复 merge 阶段失败的 CI，不是开始新一轮完整开发。\n\n"
-        )
-        if issue_number:
-            repair_prompt += (
-                f"## 关联 Issue\n"
-                f"本任务关联 GitHub Issue #{issue_number}。\n"
-                f"修复时请确保修改继续满足 Issue #{issue_number} 的所有需求。\n\n"
-            )
-        repair_prompt += (
-            "## 重要约束\n"
-            "1. 保持在当前工作分支上修复，不要创建新的 PR，不要切换到其他分支。\n"
-            "2. 不要进入新的代码审查、进度汇报或等待流程；当前唯一目标是让现有 PR 的 CI 通过。\n"
-            "3. 必须优先根据 CI 工作流、失败日志摘录和仓库脚本定位问题，复现 CI 真实执行的命令。\n"
-            "4. 修复后重新运行对应命令，以及你改动涉及到的必要相关测试。\n"
-            "5. 只有在确实产生代码或配置修改后，才能提交 git commit 并推送到当前 PR 分支。\n"
-            "6. 结束时请明确说明：你复现了哪些命令、修复了什么、还剩什么风险。\n"
-        )
-        repair_prompt += self._get_ci_repair_prompt(wf)
-        if failed_checks:
-            failure_list = "\n".join(
-                f"- **{check.get('name') or 'unknown'}**: {check.get('state') or 'unknown'}"
-                for check in failed_checks
-                if check.get("bucket") == "fail"
-            )
-            if failure_list:
-                repair_prompt += f"## 当前失败检查\n{failure_list}\n\n"
-        repair_prompt += self._get_user_feedback_prompt(wf)
+        repair_prompt = self._build_ci_repair_prompt(wf, pr_number, failed_checks)
 
         # Capture the PR's remote head SHA (not the local worktree HEAD) as the
         # baseline. If a prior repair round committed locally but didn't push
@@ -1423,6 +1508,48 @@ class AutonomousOrchestrator:
             timeout=int(wf.get("task_timeout") or DEFAULT_TASK_TIMEOUT),
             milestone_id=repair_ms.get("milestone_id", ""),
         )
+
+        # Context-overflow recovery: the resumed main session can exceed the
+        # model's input-token limit by merge time (plan + every dev/review
+        # round accumulate on `main`). The agent then produces nothing (400
+        # on the first API call). Retry the SAME repair attempt on a fresh
+        # minimal-context session (no --resume), injecting prior CI repair
+        # failures so the agent doesn't repeat failed approaches. Does NOT
+        # increment ci_repair_attempts — this is in-round recovery for the
+        # current attempt, not a new attempt. (#1816)
+        if self._is_context_overflow(repair_result):
+            logger.warning(
+                "CI repair attempt %d hit context overflow on main session; "
+                "retrying on fresh session with prior-failure context",
+                attempt,
+            )
+            # Discard any half-applied changes from the aborted main run so the
+            # fresh agent starts from a clean worktree.
+            try:
+                gh.reset_hard_to_head()
+            except Exception as e:
+                logger.warning("Failed to reset worktree before fresh CI repair: %s", e)
+
+            fresh_prompt = self._build_ci_repair_prompt(
+                wf, pr_number, failed_checks, include_prior_failures=True
+            )
+            repair_result = self._run_agent(
+                wf=wf,
+                workflow_id=self._workflow_id,
+                cli_tool=wf.get("cli_tool", "claude-code"),
+                model=wf.get("model", ""),
+                project_path=wf.get("worktree_path") or wf.get("project_path", ""),
+                prompt=fresh_prompt,
+                workspace_type=wf.get("workspace_type", "local"),
+                remote_machine_id=wf.get("remote_machine_id"),
+                permission_mode=wf.get("permission_mode", "auto-edit"),
+                allowed_tools=AUTONOMOUS_DEV_ALLOWED_TOOLS.get(
+                    wf.get("cli_tool", "claude-code"), []
+                ),
+                session_line="fresh",
+                timeout=int(wf.get("task_timeout") or DEFAULT_TASK_TIMEOUT),
+                milestone_id=repair_ms.get("milestone_id", ""),
+            )
 
         self._gh = None
         gh = self._get_gh()
@@ -2452,6 +2579,23 @@ class AutonomousOrchestrator:
         if not response:
             return False
         return bool(_TRANSIENT_API_ERROR_RE.search(response))
+
+    @staticmethod
+    def _is_context_overflow(result: AgentTaskResult) -> bool:
+        """True if the agent call failed because the resumed session context
+        exceeded the model's input-token limit (e.g. GLM ``400
+        InvalidParameter: Range of input length``).
+
+        Such failures are recoverable: the agent produced nothing because the
+        very first API call was rejected, so retrying on a fresh
+        minimal-context session (no ``--resume``) can succeed. This is a
+        permanent client error (NOT transient), so it deliberately does not
+        match ``_TRANSIENT_API_ERROR_RE`` and won't trigger the backoff loop.
+        """
+        if result.success:
+            return False
+        body = f"{result.error or ''}\n{result.response_text or ''}"
+        return bool(_CONTEXT_OVERFLOW_RE.search(body))
 
     def _run_agent(
         self, wf: dict = None, *, session_line: str = "fresh", milestone_id: str = "", **kwargs

--- a/tests/issues/1816/test_ci_repair_context_overflow.py
+++ b/tests/issues/1816/test_ci_repair_context_overflow.py
@@ -1,0 +1,281 @@
+"""Regression tests for CI repair context-overflow recovery (Issue #1816).
+
+When a CI repair attempt on the resumed ``main`` session fails because the
+accumulated conversation exceeds the model's input-token limit (GLM ``400
+InvalidParameter: Range of input length``), the orchestrator must retry the
+SAME attempt on a fresh minimal-context session (no ``--resume``), injecting
+prior CI repair failures so the agent avoids repeating them.
+
+See orchestrator._run_merge_ci_repair + _is_context_overflow.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.modules.workspace.autonomous.models import AgentTaskResult
+
+
+def _make_workflow(**overrides):
+    base = {
+        "workflow_id": "wf-1816",
+        "user_id": 5,
+        "title": "issue-1816",
+        "status": "merging",
+        "current_phase": "merge",
+        "requirements_text": "Fix change-password rate limiting",
+        "requirements_issue_url": "",
+        "project_path": "/tmp/repo",
+        "project_repo_url": "",
+        "is_new_project": False,
+        "cli_tool": "claude-code",
+        "model": "glm-5",
+        "permission_mode": "auto-edit",
+        "branch_name": "auto-dev/wf-1816",
+        "branch_strategy": "worktree",
+        "workspace_type": "local",
+        "remote_machine_id": "",
+        "worktree_path": "/tmp/repo",
+        "preferred_worktree_path": "/tmp/repo",
+        "github_issue_number": 1816,
+        "github_pr_number": 1849,
+        "github_pr_url": "",
+        "current_round": 0,
+        "dev_round": 1,
+        "max_plan_rounds": 2,
+        "max_pr_review_rounds": 3,
+        "require_full_review_rounds": False,
+        "total_tokens": 0,
+        "total_input_tokens": 0,
+        "total_output_tokens": 0,
+        "total_requests": 0,
+        "error_message": "",
+        "ci_repair_attempts": 1,
+        "ci_repair_context": "### test (3.9)\n- 状态: failure",
+        "last_ci_failure_head_sha": "",
+    }
+    base.update(overrides)
+    return base
+
+
+def _make_orchestrator(wf_data, prior_milestones=None):
+    from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+    with (
+        patch("app.modules.workspace.autonomous.orchestrator.Database"),
+        patch(
+            "app.modules.workspace.autonomous.orchestrator.AutonomousWorkflowRepository"
+        ) as mock_repo_cls,
+    ):
+        mock_repo = MagicMock()
+        mock_repo.get_workflow.return_value = wf_data
+        # _collect_prior_ci_repair_failures queries phase="merge"; other callers
+        # (e.g. _create_milestone's idempotency guard) may query with other
+        # filters — return prior_milestones only for the merge query.
+        if prior_milestones is None:
+            prior_milestones = []
+        mock_repo.list_milestones.side_effect = lambda *a, **k: (
+            prior_milestones
+            if (k.get("phase") == "merge" or (len(a) >= 2 and a[1] == "merge"))
+            else []
+        )
+        mock_repo.create_milestone.return_value = {
+            "milestone_id": "ms-1",
+            "workflow_id": wf_data["workflow_id"],
+        }
+        mock_repo.create_event.return_value = {"id": 1}
+        mock_repo.update_workflow.return_value = wf_data
+        mock_repo_cls.return_value = mock_repo
+
+        orch = AutonomousOrchestrator(wf_data["workflow_id"])
+        orch.repo = mock_repo
+        orch.emitter = MagicMock()
+    return orch, mock_repo
+
+
+def _make_gh(commit_before="sha-old", commit_after="sha-new"):
+    gh = MagicMock()
+    gh.get_pr_head_sha.return_value = commit_before
+    gh.get_current_commit.side_effect = [commit_before, commit_after]
+    gh.get_current_branch.return_value = "auto-dev/wf-1816"
+    gh.get_commit_diff_stats.return_value = {
+        "files": 1,
+        "additions": 3,
+        "deletions": 1,
+    }
+    return gh
+
+
+_FAILED_CHECKS = [
+    {"name": "test (3.9)", "state": "failure", "bucket": "fail", "link": "https://example.com"}
+]
+
+
+# ── Detection: _is_context_overflow ──────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "error,response_text,expected,success",
+    [
+        # GLM-5 actual signature observed in production (issue #1816 workflow #2)
+        (
+            "API Error: 400 <400> InternalError.Algo.InvalidParameter: "
+            "Range of input length should be [1, 202752]",
+            "",
+            True,
+            False,
+        ),
+        # OpenAI signature
+        ("This model's maximum context length is 8192 tokens.", "", True, False),
+        ("too many input tokens", "", True, False),
+        # Anthropic signature
+        ("prompt is too long: 250000 tokens > 200000 maximum", "", True, False),
+        # In response_text rather than error
+        ("", "API Error: 400 Range of input length should be [1, 202752]", True, False),
+        # Not an overflow — must NOT match
+        ("CI repair failed: agent produced no code changes", "", False, False),
+        ("API Error: 429 too many requests", "", False, False),
+        ("", "normal plan output discussing input validation", False, False),
+        # Successful result must never match, even if body mentions length
+        ("Range of input length should be [1, 202752]", "", False, True),
+    ],
+)
+def test_is_context_overflow_matches_provider_signatures(error, response_text, expected, success):
+    """The detector must catch GLM/OpenAI/Anthropic overflow phrasings and
+    ignore transient errors, generic failures, and successful results."""
+    from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+    result = AgentTaskResult(success=success, error=error, response_text=response_text)
+    assert AutonomousOrchestrator._is_context_overflow(result) is expected
+
+
+# ── End-to-end: _run_merge_ci_repair switches to fresh on overflow ──────
+
+
+def test_context_overflow_triggers_fresh_retry():
+    """When main session hits context overflow, _run_merge_ci_repair must
+    retry the same attempt on a fresh session and NOT fail the workflow."""
+    wf = _make_workflow()
+    orch, mock_repo = _make_orchestrator(wf)
+    gh = _make_gh()
+    orch._get_gh = MagicMock(return_value=gh)
+    orch._accumulate_tokens = MagicMock()
+    orch._post_github_comment = MagicMock()
+
+    # First call (main) overflows; second call (fresh) succeeds with a commit.
+    overflow = AgentTaskResult(
+        success=False,
+        error="API Error: 400 <400> InternalError.Algo.InvalidParameter: "
+        "Range of input length should be [1, 202752]",
+    )
+    fresh_ok = AgentTaskResult(
+        success=True,
+        session_id="sess-fresh",
+        response_text="Reproduced test (3.9) failure and fixed it.",
+        visible_response_text="Reproduced test (3.9) failure and fixed it.",
+    )
+    orch._run_agent = MagicMock(side_effect=[overflow, fresh_ok])
+
+    orch._run_merge_ci_repair(wf, gh, 1849, _FAILED_CHECKS)
+
+    assert orch._run_agent.call_count == 2
+    # First call on main (resumed dev session), second on fresh (clean session).
+    assert orch._run_agent.call_args_list[0].kwargs["session_line"] == "main"
+    assert orch._run_agent.call_args_list[1].kwargs["session_line"] == "fresh"
+    # Worktree reset before the fresh retry to discard the aborted main run.
+    gh.reset_hard_to_head.assert_called_once()
+    # Workflow stayed in merge (not failed) — the fresh retry recovered it.
+    final_updates = mock_repo.update_workflow.call_args.args[1]
+    assert final_updates["status"] == "merging"
+    assert final_updates["error_message"] == ""
+    orch._post_github_comment.assert_called_once()
+
+
+def test_fresh_retry_injects_prior_failures_into_prompt():
+    """The fresh retry prompt must include full text of prior CI repair
+    failures so the agent avoids repeating them."""
+    prior_failure = {
+        "milestone_id": "ms-prior",
+        "milestone_type": "ci_repair_applied",
+        "status": "failed",
+        "title": "CI repair attempt 1 for PR #1849",
+        "error_message": "CI repair failed: agent produced no code changes",
+        "result_summary": "尝试修改 auth_service.py 的 rate limiter 但 test (3.9) 仍失败: ImportError",
+    }
+    wf = _make_workflow()
+    orch, mock_repo = _make_orchestrator(wf, prior_milestones=[prior_failure])
+    gh = _make_gh()
+    orch._get_gh = MagicMock(return_value=gh)
+    orch._accumulate_tokens = MagicMock()
+    orch._post_github_comment = MagicMock()
+
+    overflow = AgentTaskResult(
+        success=False,
+        error="Range of input length should be [1, 202752]",
+    )
+    fresh_ok = AgentTaskResult(
+        success=True,
+        session_id="sess-fresh",
+        response_text="fixed",
+        visible_response_text="fixed",
+    )
+    orch._run_agent = MagicMock(side_effect=[overflow, fresh_ok])
+
+    orch._run_merge_ci_repair(wf, gh, 1849, _FAILED_CHECKS)
+
+    fresh_prompt = orch._run_agent.call_args_list[1].kwargs["prompt"]
+    # Header signalling "don't repeat"
+    assert "请勿重复同样的修法" in fresh_prompt
+    # Full prior error_message injected verbatim (not summarized)
+    assert "CI repair failed: agent produced no code changes" in fresh_prompt
+    # Full prior result_summary injected verbatim
+    assert "ImportError" in fresh_prompt
+
+
+def test_context_overflow_failure_not_injected():
+    """A prior failure whose body matches the context-overflow signature must
+    be filtered out — the agent produced nothing in that round, so there is
+    nothing actionable to avoid repeating."""
+    overflow_failure = {
+        "milestone_id": "ms-overflow",
+        "milestone_type": "ci_repair_applied",
+        "status": "failed",
+        "title": "CI repair attempt 1 for PR #1849",
+        "error_message": "API Error: 400 Range of input length should be [1, 202752]",
+        "result_summary": "",
+    }
+    orch, _ = _make_orchestrator(_make_workflow(), prior_milestones=[overflow_failure])
+
+    prior = orch._collect_prior_ci_repair_failures()
+    assert prior == []
+
+
+def test_normal_ci_failure_does_not_trigger_fresh_retry():
+    """A non-overflow agent failure (no code changes, no context-length text)
+    must NOT trigger the fresh retry — it should fall through to the existing
+    failure path and fail the workflow as before."""
+    wf = _make_workflow()
+    orch, mock_repo = _make_orchestrator(wf)
+    gh = _make_gh(commit_before="sha-old", commit_after="sha-old")  # no new commit
+    orch._get_gh = MagicMock(return_value=gh)
+    orch._accumulate_tokens = MagicMock()
+    orch._post_github_comment = MagicMock()
+
+    # Generic failure, no overflow signature.
+    orch._run_agent = MagicMock(
+        return_value=AgentTaskResult(
+            success=False,
+            error="agent produced no output",
+        )
+    )
+
+    orch._run_merge_ci_repair(wf, gh, 1849, _FAILED_CHECKS)
+
+    # Only one call (main); no fresh retry.
+    assert orch._run_agent.call_count == 1
+    assert orch._run_agent.call_args_list[0].kwargs["session_line"] == "main"
+    gh.reset_hard_to_head.assert_not_called()
+    # Existing behavior preserved: workflow failed.
+    final_updates = mock_repo.update_workflow.call_args.args[1]
+    assert final_updates["status"] == "failed"
+    assert "no code changes" in final_updates["error_message"]

--- a/tests/issues/1816/test_ci_repair_context_overflow.py
+++ b/tests/issues/1816/test_ci_repair_context_overflow.py
@@ -279,3 +279,44 @@ def test_normal_ci_failure_does_not_trigger_fresh_retry():
     final_updates = mock_repo.update_workflow.call_args.args[1]
     assert final_updates["status"] == "failed"
     assert "no code changes" in final_updates["error_message"]
+
+
+def test_double_overflow_falls_through_to_failed_and_preserves_signal():
+    """When BOTH main and fresh sessions overflow, the workflow must fail
+    (no infinite retry loop), and the milestone error_message must preserve
+    the overflow signature so the next round's _collect_prior_ci_repair_failures
+    filters it out (instead of misclassifying it as 'no code changes' and
+    injecting it as actionable). #1816 review suggestions #1 + #2."""
+    wf = _make_workflow()
+    orch, mock_repo = _make_orchestrator(wf)
+    gh = _make_gh(commit_before="sha-old", commit_after="sha-old")  # no new commit
+    orch._get_gh = MagicMock(return_value=gh)
+    orch._accumulate_tokens = MagicMock()
+    orch._post_github_comment = MagicMock()
+
+    overflow_err = (
+        "API Error: 400 <400> InternalError.Algo.InvalidParameter: "
+        "Range of input length should be [1, 202752]"
+    )
+    overflow = AgentTaskResult(success=False, error=overflow_err)
+    # Both main and fresh overflow — no infinite retry.
+    orch._run_agent = MagicMock(side_effect=[overflow, overflow])
+
+    orch._run_merge_ci_repair(wf, gh, 1849, _FAILED_CHECKS)
+
+    # Exactly 2 calls (main + fresh), no third attempt.
+    assert orch._run_agent.call_count == 2
+    assert orch._run_agent.call_args_list[0].kwargs["session_line"] == "main"
+    assert orch._run_agent.call_args_list[1].kwargs["session_line"] == "fresh"
+    # Workflow failed, not stuck retrying.
+    final_updates = mock_repo.update_workflow.call_args.args[1]
+    assert final_updates["status"] == "failed"
+    # Overflow signal preserved in error_message so the next round filters it
+    # (NOT the generic "no code changes" message).
+    assert "context overflow" in final_updates["error_message"]
+    assert "Range of input length" in final_updates["error_message"]
+    # Verify the stored error_message would be matched by the overflow regex,
+    # so _collect_prior_ci_repair_failures filters it on the next round.
+    from app.modules.workspace.autonomous.orchestrator import _CONTEXT_OVERFLOW_RE
+
+    assert _CONTEXT_OVERFLOW_RE.search(final_updates["error_message"])


### PR DESCRIPTION
## 背景

CI repair（merge 阶段）复用 workflow 全程累积的 `main` dev session（`--resume`），到 merge 时累积 context 常超过模型输入上限（GLM 202752 token），导致首个 API 调用即 `400 InvalidParameter: Range of input length should be [1, 202752]`，agent 0 产出，workflow 直接 `failed`。

issue #1816 的 workflow #2（PR #1849）就是栽在这——代码 review 全过、PR 建好，但 merge repair attempt 1 撞 context 超限，agent 没产出代码，workflow 终结。

## 方案

按 review 讨论：**默认仍用 main session 保持上下文连续性，只在撞到模型输入上限后，同轮内立即切 fresh session 重试**，并把历史所有 CI repair 失败报错（排除 context 超限本身）注入 fresh prompt，让 agent 别再试同样的修法。

## 改动

### `orchestrator.py`
- **新增 `_CONTEXT_OVERFLOW_RE` + `_is_context_overflow()`**：独立于 `_TRANSIENT_API_ERROR_RE`（不触发 backoff，context 超限是永久错误）。覆盖 GLM `Range of input length`、OpenAI `maximum context length` / `too many input tokens`、Anthropic `prompt is too long` 等文案。
- **`_run_merge_ci_repair`**：main session 跑完后，若 `_is_context_overflow` 为真 → `reset_hard_to_head` 清理半成品 → 用 `session_line="fresh"` 重跑同一次 attempt（**不增加 `ci_repair_attempts`**，是同轮内恢复）。
- **新增 `_collect_prior_ci_repair_failures()`**：查 `phase=merge, milestone_type=ci_repair_applied, status=failed` 的历史 milestone，**过滤掉 context 超限的失败**（agent 没产出，无可借鉴）。
- **新增 `_build_prior_repair_failures_prompt()`**：把历史失败的 `error_message` + `result_summary` **全文注入**（不摘要），带"请勿重复同样的修法"标题。
- **抽取 `_build_ci_repair_prompt()`**：带 `include_prior_failures` 参数，复用 prompt 构造逻辑。

### `github_ops.py`
- 新增 `reset_hard_to_head()`：fresh 重试前清理 main session 可能留下的半成品改动。

### 测试 `tests/issues/1816/test_ci_repair_context_overflow.py`（13 个用例）
- 9 个 parametrize 覆盖检测器（GLM/OpenAI/Anthropic 文案 + 反例：429、普通失败、成功结果）
- `test_context_overflow_triggers_fresh_retry`：main 失败 → fresh 重试 → workflow 保持 merging（不 failed）
- `test_fresh_retry_injects_prior_failures_into_prompt`：历史失败全文注入
- `test_context_overflow_failure_not_injected`：context 超限的失败被过滤
- `test_normal_ci_failure_does_not_trigger_fresh_retry`：普通失败走原路径，不触发 fresh

## 验证

- ✅ 新测试 13 个全过
- ✅ 既有 CI repair 测试 96 个全过（1574/1811/1814/913/1816）
- ✅ pre-commit（black/isort/ruff/mypy/bandit/pydocstyle）全过
- ⚠️ `test_start_ci_repair_round_fails_when_signature_repeats` 失败已确认是预先存在的问题（`git stash` 到干净 main 上同样失败），与本 PR 无关

## 不在范围

- 不改 `MAX_CI_REPAIR_ATTEMPTS = 3`（fresh 重试不占 attempt 计数）
- 不改 transient-retry 逻辑（context 超限是永久错误）
- 不改 PR review fixes / review summary 的 `session_line="main"`（那些阶段 context 通常还没超限）
- 不改前端 / 数据库 schema（复用现有字段）

Closes #1816