### PR TITLE
fix: 多租户 ON CONFLICT 漏改 + workflow session 泄露 (Issue #1760, #1816)

### DIFF
--- a/app/modules/workspace/autonomous/agent_runner.py
+++ b/app/modules/workspace/autonomous/agent_runner.py
@@ -1480,6 +1480,27 @@ class AutonomousAgentRunner:
                 except Exception as e:
                     logger.warning("Failed to update session record: %s", e)
 
+            # Close the eagerly-created workflow wrapper row when the agent never
+            # produced a real CLI session id (sidebar source + executable not
+            # found / spawn failed → result.session_id=""). Without this the
+            # wrapper stays status='active' forever — a zombie row. The wrapper
+            # is keyed by `session_id` (the tracking uuid), not the empty CLI id.
+            if uses_sidebar_session and not persisted_session_id and self.session_manager:
+                try:
+                    self.session_manager.update_session_fields(
+                        session_id,
+                        {
+                            "status": "error",
+                            "error_message": result.error or "agent failed to start",
+                        },
+                    )
+                except Exception as e:
+                    logger.warning(
+                        "Failed to close orphan workflow wrapper %s: %s",
+                        session_id[:8],
+                        e,
+                    )
+
             return result
 
         except Exception as e:

--- a/app/modules/workspace/session_manager.py
+++ b/app/modules/workspace/session_manager.py
@@ -72,7 +72,16 @@ _AUTONOMOUS_WORKFLOW_CONTEXT_PATTERN = "%" + escape_like(_WORKFLOW_ID_CONTEXT_MA
 
 
 def visible_session_clause(alias: str = "") -> tuple[str, list[Any]]:
-    """Hide autonomous workflow tracking wrappers from user-facing listings."""
+    """Hide autonomous workflow tracking wrappers from user-facing listings.
+
+    Matches any session_type='workflow' row whose context carries the
+    workflow_id marker, regardless of whether cli_session_id has been
+    backfilled. The cli_session_id!='' guard was removed because wrapper rows
+    are created eagerly (before the agent runs) and an agent that fails to
+    start never backfills cli_session_id — leaving a permanent "orphan" that
+    would otherwise leak into the user-facing list. Workflow wrappers are
+    system bookkeeping rows and should never appear in the session list.
+    """
 
     prefix = f"{alias}." if alias else ""
     p = _param()
@@ -81,7 +90,6 @@ def visible_session_clause(alias: str = "") -> tuple[str, list[Any]]:
     return (
         "NOT ("
         f"{prefix}session_type = {p} "
-        f"AND COALESCE({prefix}cli_session_id, '') != '' "
         f"AND COALESCE({prefix}context, '') LIKE {p} ESCAPE '\\'"
         ")",
         [SessionType.WORKFLOW.value, _AUTONOMOUS_WORKFLOW_CONTEXT_PATTERN],

--- a/frontend/src/components/work/SessionList.tsx
+++ b/frontend/src/components/work/SessionList.tsx
@@ -9,6 +9,7 @@
  */
 
 import React, { useState, useMemo, useEffect, useRef, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useLanguage } from '@/store';
 import { t } from '@/i18n';
 import { useSessions, useSession, useRestoreSession } from '@/hooks';
@@ -38,6 +39,8 @@ interface SessionItem {
   workspace_type?: string;
   machine_name?: string;
   isImported?: boolean; // CLI-imported session (no cli_session_id + completed)
+  isWorkflowImported?: boolean; // CLI session imported from an autonomous workflow (context.workflow_imported)
+  workflowId?: string; // Linked workflow id for workflow-imported sessions (for jump-to)
   firstMessage?: string; // First user message preview (truncated to 100 chars)
 }
 
@@ -74,6 +77,7 @@ export const SessionList: React.FC<SessionListProps> = ({ collapsed = false, onS
   const [showNewSessionModal, setShowNewSessionModal] = useState(false);
   const sessionListRef = useRef<HTMLDivElement>(null);
   const selectedRef = useRef<HTMLButtonElement>(null);
+  const navigate = useNavigate();
 
   // Fetch sessions
   const {
@@ -151,6 +155,14 @@ export const SessionList: React.FC<SessionListProps> = ({ collapsed = false, onS
 
     sessions.forEach((session: AgentSession) => {
       const sessionDate = new Date(session.updated_at ?? session.created_at ?? now);
+      // A CLI session imported from an autonomous workflow worktree. fetch_claude
+      // annotates these with context.workflow_imported + workflow_id so the UI
+      // can badge them and link back to the workflow timeline. Takes precedence
+      // over the generic isImported (archive) classification.
+      const ctx = session.context as Record<string, unknown> | undefined;
+      const workflowIdFromCtx =
+        typeof ctx?.workflow_id === 'string' ? (ctx.workflow_id as string) : undefined;
+      const isWorkflowImported = !!ctx?.workflow_imported && !!workflowIdFromCtx;
       const sessionItem: SessionItem = {
         id: session.session_id,
         title: session.title ?? `Session ${displaySessionId(session.session_id, 8)}`,
@@ -166,7 +178,10 @@ export const SessionList: React.FC<SessionListProps> = ({ collapsed = false, onS
         requests: session.request_count ?? 0,
         workspace_type: session.workspace_type,
         machine_name: session.machine_name,
+        isWorkflowImported,
+        workflowId: workflowIdFromCtx,
         isImported:
+          !isWorkflowImported &&
           session.workspace_type === 'local' &&
           !session.cli_session_id &&
           session.status === 'completed',
@@ -199,11 +214,19 @@ export const SessionList: React.FC<SessionListProps> = ({ collapsed = false, onS
     setSearchInput(e.target.value);
   }, []);
 
-  const handleSessionClick = (sessionId: string) => {
-    setSelectedSessionId(sessionId);
+  const handleSessionClick = (session: SessionItem) => {
+    // A workflow-imported CLI session (real claude session from an autonomous
+    // workflow worktree) jumps to the workflow timeline instead of opening a
+    // chat detail modal — its transcript is already viewable per-milestone in
+    // the workflow view.
+    if (session.isWorkflowImported && session.workflowId) {
+      navigate(`/work/autonomous?workflow_id=${encodeURIComponent(session.workflowId)}`);
+      return;
+    }
+    setSelectedSessionId(session.id);
     setShowDetailModal(true);
     if (onSelectSession) {
-      onSelectSession(sessionId);
+      onSelectSession(session.id);
     }
   };
 
@@ -232,7 +255,17 @@ export const SessionList: React.FC<SessionListProps> = ({ collapsed = false, onS
           <button
             key={session.session_id}
             className="session-list-collapsed-item"
-            onClick={() => handleSessionClick(session.session_id)}
+            onClick={() =>
+              handleSessionClick({
+                id: session.session_id,
+                title: session.title ?? '',
+                tool: session.tool_name ?? '',
+                time: '',
+                tokens: 0,
+                messages: 0,
+                requests: 0,
+              })
+            }
             title={session.title ?? `Session ${displaySessionId(session.session_id, 8)}`}
           >
             <i className="bi bi-chat-dots" />
@@ -371,7 +404,7 @@ export const SessionList: React.FC<SessionListProps> = ({ collapsed = false, onS
 interface SessionGroupProps {
   title: string;
   sessions: SessionItem[];
-  onSessionClick: (sessionId: string) => void;
+  onSessionClick: (session: SessionItem) => void;
   selectedSessionId: string | null;
 }
 
@@ -390,11 +423,16 @@ const SessionGroup: React.FC<SessionGroupProps> = ({
         {sessions.map((session) => (
           <li key={session.id}>
             <button
-              className={`session-item w-100 p-2 ${selectedSessionId === session.id ? 'selected' : ''} ${session.isImported ? 'session-imported' : ''}`}
-              onClick={() => onSessionClick(session.id)}
+              className={`session-item w-100 p-2 ${selectedSessionId === session.id ? 'selected' : ''} ${session.isImported ? 'session-imported' : ''} ${session.isWorkflowImported ? 'session-workflow-imported' : ''}`}
+              onClick={() => onSessionClick(session)}
             >
               <span className="session-id text-truncate">
-                {session.isImported ? (
+                {session.isWorkflowImported ? (
+                  <i
+                    className="bi bi-robot text-primary me-1"
+                    title={t('workflowImported', language)}
+                  />
+                ) : session.isImported ? (
                   <i className="bi bi-archive text-muted me-1" title={t('cliImported', language)} />
                 ) : session.workspace_type === 'terminal' ? (
                   <i className="bi bi-terminal-fill text-info me-1" title="Web Terminal" />

--- a/frontend/src/components/work/SessionList.tsx
+++ b/frontend/src/components/work/SessionList.tsx
@@ -251,26 +251,37 @@ export const SessionList: React.FC<SessionListProps> = ({ collapsed = false, onS
           <i className="bi bi-plus-lg" />
         </button>
         <div className="session-list-collapsed-divider" />
-        {sessions.slice(0, 5).map((session: AgentSession) => (
-          <button
-            key={session.session_id}
-            className="session-list-collapsed-item"
-            onClick={() =>
-              handleSessionClick({
-                id: session.session_id,
-                title: session.title ?? '',
-                tool: session.tool_name ?? '',
-                time: '',
-                tokens: 0,
-                messages: 0,
-                requests: 0,
-              })
-            }
-            title={session.title ?? `Session ${displaySessionId(session.session_id, 8)}`}
-          >
-            <i className="bi bi-chat-dots" />
-          </button>
-        ))}
+        {sessions.slice(0, 5).map((session: AgentSession) => {
+          // Mirror the expanded-view logic: extract workflow_imported from the
+          // raw AgentSession context so collapsed clicks also jump to the
+          // workflow timeline (consistent behavior in both views).
+          const ctx = session.context as Record<string, unknown> | undefined;
+          const wfId =
+            typeof ctx?.workflow_id === 'string' ? (ctx.workflow_id as string) : undefined;
+          const isWorkflowImported = !!ctx?.workflow_imported && !!wfId;
+          return (
+            <button
+              key={session.session_id}
+              className={`session-list-collapsed-item ${isWorkflowImported ? 'session-workflow-imported' : ''}`}
+              onClick={() =>
+                handleSessionClick({
+                  id: session.session_id,
+                  title: session.title ?? '',
+                  tool: session.tool_name ?? '',
+                  time: '',
+                  tokens: 0,
+                  messages: 0,
+                  requests: 0,
+                  isWorkflowImported,
+                  workflowId: wfId,
+                })
+              }
+              title={session.title ?? `Session ${displaySessionId(session.session_id, 8)}`}
+            >
+              <i className={isWorkflowImported ? 'bi bi-robot' : 'bi bi-chat-dots'} />
+            </button>
+          );
+        })}
       </div>
     );
   }

--- a/frontend/src/components/work/SessionList.tsx
+++ b/frontend/src/components/work/SessionList.tsx
@@ -268,8 +268,6 @@ export const SessionList: React.FC<SessionListProps> = ({ collapsed = false, onS
                   tokens: 0,
                   messages: 0,
                   requests: 0,
-                  isWorkflowImported,
-                  workflowId: wfId,
                 })
               }
               title={session.title ?? `Session ${displaySessionId(session.session_id, 8)}`}

--- a/frontend/src/components/work/SessionList.tsx
+++ b/frontend/src/components/work/SessionList.tsx
@@ -215,14 +215,10 @@ export const SessionList: React.FC<SessionListProps> = ({ collapsed = false, onS
   }, []);
 
   const handleSessionClick = (session: SessionItem) => {
-    // A workflow-imported CLI session (real claude session from an autonomous
-    // workflow worktree) jumps to the workflow timeline instead of opening a
-    // chat detail modal — its transcript is already viewable per-milestone in
-    // the workflow view.
-    if (session.isWorkflowImported && session.workflowId) {
-      navigate(`/work/autonomous?workflow_id=${encodeURIComponent(session.workflowId)}`);
-      return;
-    }
+    // All sessions open the detail modal. For workflow-imported sessions the
+    // detail view shows a "View Workflow" button at the top that jumps to the
+    // workflow timeline — the session transcript is also viewable per-milestone
+    // there. (Previously workflow sessions jumped directly, skipping detail.)
     setSelectedSessionId(session.id);
     setShowDetailModal(true);
     if (onSelectSession) {
@@ -392,12 +388,42 @@ export const SessionList: React.FC<SessionListProps> = ({ collapsed = false, onS
         {isLoadingDetail ? (
           <Loading size="sm" text={t('loading', language)} />
         ) : sessionDetail?.data ? (
-          <SessionDetailContent
-            session={sessionDetail.data}
-            language={language}
-            onRestore={(sid) => restoreSession.mutate(sid)}
-            restorePending={restoreSession.isPending}
-          />
+          <>
+            {(() => {
+              // If this CLI session was imported from an autonomous workflow,
+              // show a "View Workflow" button at the top of the detail view.
+              // The session transcript is also viewable per-milestone in the
+              // workflow timeline.
+              const detailCtx = sessionDetail.data.context as Record<string, unknown> | undefined;
+              const detailWfId =
+                typeof detailCtx?.workflow_id === 'string'
+                  ? (detailCtx.workflow_id as string)
+                  : undefined;
+              if (!detailCtx?.workflow_imported || !detailWfId) return null;
+              return (
+                <div className="mb-2 d-flex align-items-center gap-2">
+                  <i className="bi bi-robot text-primary" />
+                  <button
+                    type="button"
+                    className="btn btn-sm btn-outline-primary"
+                    onClick={() => {
+                      navigate(`/work/autonomous?workflow_id=${encodeURIComponent(detailWfId)}`);
+                      setShowDetailModal(false);
+                    }}
+                  >
+                    <i className="bi bi-arrow-up-right-square me-1" />
+                    {t('viewWorkflow', language)}
+                  </button>
+                </div>
+              );
+            })()}
+            <SessionDetailContent
+              session={sessionDetail.data}
+              language={language}
+              onRestore={(sid) => restoreSession.mutate(sid)}
+              restorePending={restoreSession.isPending}
+            />
+          </>
         ) : (
           <div className="text-muted">{t('noData', language)}</div>
         )}

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -514,6 +514,7 @@ export const translations: Record<Language, Translations> = {
     restoredSession: 'Restored Session',
     cliImported: 'Local CLI History',
     workflowImported: 'Autonomous Workflow Session',
+    viewWorkflow: 'View Workflow',
     // Issue #669: Session terminated recreation
     sessionTerminated: 'Session Process Terminated',
     sessionTerminatedCanResume:
@@ -2190,6 +2191,7 @@ export const translations: Record<Language, Translations> = {
     // Issue #669: Session terminated recreation
     workflowImported: '自主开发工作流会话',
     sessionTerminated: '会话进程已终止',
+    viewWorkflow: '查看工作流',
     sessionTerminatedCanResume: '检测到可恢复的对话历史，是否尝试恢复上下文？',
     sessionTerminatedNoResume: '会话进程已终止，请创建新会话继续工作。',
     createNewSession: '创建新会话',
@@ -4766,6 +4768,7 @@ export const translations: Record<Language, Translations> = {
     started: '開始',
     cliImported: 'ローカル CLI 履歴',
     workflowImported: '自律開発ワークフローセッション',
+    viewWorkflow: 'ワークフローを表示',
 
     // API Key Management
     apiKeys: 'API キー',
@@ -6281,6 +6284,7 @@ export const translations: Record<Language, Translations> = {
 
     workflowImported: '자율 개발 워크플로 세션',
     // API Key Management
+    viewWorkflow: '워크플로 보기',
     apiKeys: 'API 키',
     addApiKey: 'API 키 추가',
     editApiKey: 'API 키 편집',

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -513,6 +513,7 @@ export const translations: Record<Language, Translations> = {
     sessionRestored: 'Session restored to workspace',
     restoredSession: 'Restored Session',
     cliImported: 'Local CLI History',
+    workflowImported: 'Autonomous Workflow Session',
     // Issue #669: Session terminated recreation
     sessionTerminated: 'Session Process Terminated',
     sessionTerminatedCanResume:
@@ -2187,6 +2188,7 @@ export const translations: Record<Language, Translations> = {
     restoredSession: '恢复的会话',
     cliImported: '本地 CLI 历史',
     // Issue #669: Session terminated recreation
+    workflowImported: '自主开发工作流会话',
     sessionTerminated: '会话进程已终止',
     sessionTerminatedCanResume: '检测到可恢复的对话历史，是否尝试恢复上下文？',
     sessionTerminatedNoResume: '会话进程已终止，请创建新会话继续工作。',
@@ -4763,6 +4765,7 @@ export const translations: Record<Language, Translations> = {
     machine: 'マシン',
     started: '開始',
     cliImported: 'ローカル CLI 履歴',
+    workflowImported: '自律開発ワークフローセッション',
 
     // API Key Management
     apiKeys: 'API キー',
@@ -6276,6 +6279,7 @@ export const translations: Record<Language, Translations> = {
     started: '시작',
     cliImported: '로컬 CLI 기록',
 
+    workflowImported: '자율 개발 워크플로 세션',
     // API Key Management
     apiKeys: 'API 키',
     addApiKey: 'API 키 추가',

--- a/scripts/fetch_claude.py
+++ b/scripts/fetch_claude.py
@@ -723,6 +723,66 @@ def find_claude_project_dir() -> Optional[Path]:
     return None
 
 
+def _extract_workflow_id_from_project_path(project_path: str) -> str:
+    """Extract a workflow_id from a Claude-encoded project path.
+
+    Claude encodes the worktree cwd as the realpath with ``/``→``-`` and stores
+    the session jsonl under ``~/.claude/projects/<encoded>/``. Autonomous
+    workflows run in ``{project_path}/.worktrees/{workflow_id}``, so the
+    encoded form contains a ``-worktrees-<uuid>`` segment. This extracts that
+    UUID so a fetched CLI session can be linked back to its workflow.
+
+    Returns "" if the path doesn't match the worktree pattern (regular CLI
+    sessions, not from an autonomous workflow).
+    """
+    if not project_path:
+        return ""
+    # Match worktrees[-/]<uuid> in either encoded (-worktrees-) or raw
+    # (.worktrees/) form.
+    m = re.search(
+        r"worktrees[-/]([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})",
+        project_path,
+        re.IGNORECASE,
+    )
+    return m.group(1) if m else ""
+
+
+def _resolve_workflow_session_annotation(cursor, project_path: str) -> tuple[str, dict]:
+    """Return (title, context) for a fetched CLI session.
+
+    If the session's project_path maps to an autonomous workflow worktree,
+    look up the workflow's title and produce a rich annotation:
+    - title: ``[Auto] {workflow title}`` (readable, e.g. "[Auto] gh issue 1851")
+    - context: ``{"workflow_id": "...", "workflow_imported": true}`` so the
+      frontend can show a robot badge and jump to the workflow timeline.
+
+    Falls back to ("", {}) for non-workflow sessions (regular CLI use).
+    """
+    workflow_id = _extract_workflow_id_from_project_path(project_path)
+    if not workflow_id:
+        return "", {}
+
+    placeholder = db._placeholder()
+    try:
+        db._execute(
+            cursor,
+            f"SELECT title FROM autonomous_workflows WHERE workflow_id = {placeholder}",
+            (workflow_id,),
+        )
+        row = cursor.fetchone()
+    except Exception as e:
+        print(f"  Warning: failed to look up workflow {workflow_id[:8]}: {e}")
+        row = None
+
+    if not row:
+        # Workflow row gone (deleted) — still annotate the link so it's traceable.
+        wf_title = f"[Auto] workflow {workflow_id[:8]}"
+    else:
+        wf_title = f"[Auto] {row['title'] or workflow_id[:8]}"
+
+    return wf_title, {"workflow_id": workflow_id, "workflow_imported": True}
+
+
 def update_agent_sessions_stats(messages: list) -> int:
     """
     Update agent_sessions table statistics from collected messages.
@@ -840,21 +900,53 @@ def update_agent_sessions_stats(messages: list) -> int:
                     user_row = cursor.fetchone()
                     user_id = user_row["id"] if user_row else None
 
-                    title = f"claude - {session_id[:8]}"
+                    # Rich annotation: if this CLI session came from an autonomous
+                    # workflow worktree, link it back to the workflow with a
+                    # readable title and context for the frontend badge/jump.
+                    # Falls back to the plain "claude - xxxxxxxx" title for
+                    # regular (non-workflow) CLI sessions.
+                    wf_title, wf_context = _resolve_workflow_session_annotation(
+                        cursor, project_path
+                    )
+                    title = wf_title or f"claude - {session_id[:8]}"
 
-                    insert_sql = f"""
-                        INSERT INTO agent_sessions
-                        (session_id, session_type, title, tool_name, host_name, user_id, status, project_path,
-                         message_count, total_tokens, request_count, model, created_at, updated_at)
-                        VALUES ({placeholder}, {placeholder}, {placeholder}, {placeholder}, {placeholder},
-                                {placeholder}, {placeholder}, {placeholder}, {placeholder}, {placeholder},
-                                {placeholder}, {placeholder}, {placeholder}, {placeholder})
-                    """
-                    model = stats["last_model"]
-                    _execute(
-                        cursor,
-                        insert_sql,
-                        (
+                    has_context_column = _column_exists(cursor, "agent_sessions", "context")
+                    if wf_context and has_context_column:
+                        insert_sql = f"""
+                            INSERT INTO agent_sessions
+                            (session_id, session_type, title, tool_name, host_name, user_id, status, project_path,
+                             message_count, total_tokens, request_count, model, context, created_at, updated_at)
+                            VALUES ({placeholder}, {placeholder}, {placeholder}, {placeholder}, {placeholder},
+                                    {placeholder}, {placeholder}, {placeholder}, {placeholder}, {placeholder},
+                                    {placeholder}, {placeholder}, {placeholder}, {placeholder}, {placeholder})
+                        """
+                        insert_params = (
+                            session_id,
+                            "chat",
+                            title,
+                            tool_name,
+                            host_name,
+                            user_id,
+                            "completed",
+                            project_path,
+                            stats["message_count"],
+                            stats["total_tokens"],
+                            stats["request_count"],
+                            model,
+                            json.dumps(wf_context),
+                            now,
+                            now,
+                        )
+                    else:
+                        insert_sql = f"""
+                            INSERT INTO agent_sessions
+                            (session_id, session_type, title, tool_name, host_name, user_id, status, project_path,
+                             message_count, total_tokens, request_count, model, created_at, updated_at)
+                            VALUES ({placeholder}, {placeholder}, {placeholder}, {placeholder}, {placeholder},
+                                    {placeholder}, {placeholder}, {placeholder}, {placeholder}, {placeholder},
+                                    {placeholder}, {placeholder}, {placeholder}, {placeholder})
+                        """
+                        insert_params = (
                             session_id,
                             "chat",
                             title,
@@ -869,8 +961,8 @@ def update_agent_sessions_stats(messages: list) -> int:
                             model,
                             now,
                             now,
-                        ),
-                    )
+                        )
+                    _execute(cursor, insert_sql, insert_params)
                     updated += 1
                 else:
                     # Update existing session

--- a/scripts/fetch_claude.py
+++ b/scripts/fetch_claude.py
@@ -910,6 +910,12 @@ def update_agent_sessions_stats(messages: list) -> int:
                     )
                     title = wf_title or f"claude - {session_id[:8]}"
 
+                    # Model on the message with the strictly-greatest timestamp
+                    # (most-recently-used); see update_session_last_seen. NOT
+                    # list[-1], and NOT the loop residual `model` variable —
+                    # each session must read its own stats["last_model"].
+                    model = stats["last_model"]
+
                     has_context_column = _column_exists(cursor, "agent_sessions", "context")
                     if wf_context and has_context_column:
                         insert_sql = f"""

--- a/scripts/shared/db.py
+++ b/scripts/shared/db.py
@@ -481,8 +481,16 @@ def save_usage(
     request_count: int = 0,
     models_used: Optional[list[str]] = None,
     host_name: str = "localhost",
+    tenant_id: int = 1,
 ) -> bool:
-    """Save or update usage data for a specific date and tool."""
+    """Save or update usage data for a specific date and tool.
+
+    tenant_id defaults to 1: daily_usage is a host-level aggregate (one row
+    per date+tool+host, summed across all system_accounts on that host), so it
+    cannot be split to a specific tenant without first adding a user dimension.
+    The unique constraint is (tenant_id, date, tool_name, host_name); the
+    default keeps single-tenant behavior identical to pre-multitenant.
+    """
     conn = get_connection()
     cursor = conn.cursor()
 
@@ -493,9 +501,9 @@ def save_usage(
             cursor,
             """
             INSERT INTO daily_usage
-            (date, tool_name, host_name, tokens_used, input_tokens, output_tokens, cache_tokens, request_count, models_used)
-            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
-            ON CONFLICT (date, tool_name, host_name) DO UPDATE SET
+            (date, tool_name, host_name, tokens_used, input_tokens, output_tokens, cache_tokens, request_count, models_used, tenant_id)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            ON CONFLICT (tenant_id, date, tool_name, host_name) DO UPDATE SET
                 tokens_used = EXCLUDED.tokens_used,
                 input_tokens = EXCLUDED.input_tokens,
                 output_tokens = EXCLUDED.output_tokens,
@@ -513,6 +521,7 @@ def save_usage(
                 cache_tokens,
                 request_count,
                 models_json,
+                tenant_id,
             ),
         )
     else:

--- a/scripts/upload-to-central/shared/db.py
+++ b/scripts/upload-to-central/shared/db.py
@@ -358,8 +358,16 @@ def save_usage(
     request_count: int = 0,
     models_used: Optional[list[str]] = None,
     host_name: str = "localhost",
+    tenant_id: int = 1,
 ) -> bool:
-    """Save or update usage data for a specific date and tool."""
+    """Save or update usage data for a specific date and tool.
+
+    tenant_id defaults to 1: daily_usage is a host-level aggregate (one row
+    per date+tool+host, summed across all system_accounts on that host), so it
+    cannot be split to a specific tenant without first adding a user dimension.
+    The unique constraint is (tenant_id, date, tool_name, host_name); the
+    default keeps single-tenant behavior identical to pre-multitenant.
+    """
     conn = get_connection()
     cursor = conn.cursor()
 
@@ -370,9 +378,9 @@ def save_usage(
             cursor,
             """
             INSERT INTO daily_usage
-            (date, tool_name, host_name, tokens_used, input_tokens, output_tokens, cache_tokens, request_count, models_used)
-            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
-            ON CONFLICT (date, tool_name, host_name) DO UPDATE SET
+            (date, tool_name, host_name, tokens_used, input_tokens, output_tokens, cache_tokens, request_count, models_used, tenant_id)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            ON CONFLICT (tenant_id, date, tool_name, host_name) DO UPDATE SET
                 tokens_used = EXCLUDED.tokens_used,
                 input_tokens = EXCLUDED.input_tokens,
                 output_tokens = EXCLUDED.output_tokens,
@@ -390,6 +398,7 @@ def save_usage(
                 cache_tokens,
                 request_count,
                 models_json,
+                tenant_id,
             ),
         )
     else:

--- a/tests/issues/1760/test_save_usage_tenant_and_workflow_annotation.py
+++ b/tests/issues/1760/test_save_usage_tenant_and_workflow_annotation.py
@@ -165,6 +165,29 @@ def test_update_agent_sessions_stats_writes_per_session_model(tmp_path, monkeypa
         )
         """
     )
+    # fetch_claude also inserts into session_messages; without this table the
+    # test logs WARNING noise (the model assertion doesn't depend on it, but a
+    # clean log is preferable).
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS session_messages (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT NOT NULL,
+            role TEXT NOT NULL,
+            content TEXT,
+            tokens_used INTEGER DEFAULT 0,
+            model TEXT,
+            "timestamp" TEXT,
+            metadata TEXT,
+            milestone_id TEXT DEFAULT '',
+            source TEXT DEFAULT '',
+            source_timestamp TEXT,
+            external_message_id TEXT DEFAULT '',
+            content_blocks TEXT,
+            tenant_id INTEGER DEFAULT 1
+        )
+        """
+    )
     conn.commit()
     conn.close()
 

--- a/tests/issues/1760/test_save_usage_tenant_and_workflow_annotation.py
+++ b/tests/issues/1760/test_save_usage_tenant_and_workflow_annotation.py
@@ -114,3 +114,115 @@ def test_resolve_workflow_session_annotation_empty_for_non_workflow():
     assert context == {}
     # Must not hit the DB for non-workflow paths
     cursor.fetchone.assert_not_called()
+
+
+# ── Regression: each session's INSERT uses its own last_model ──────────
+
+
+def test_update_agent_sessions_stats_writes_per_session_model(tmp_path, monkeypatch):
+    """Regression guard (#1860 review): the INSERT branch must read each
+    session's own stats['last_model'], not a loop-residual `model` variable.
+    Without the fix, a batch with multiple sessions all got the model of the
+    last-processed message across the whole batch."""
+    import config
+
+    db_path = tmp_path / "test.db"
+    monkeypatch.setattr(config, "CONFIG_DIR", str(tmp_path))
+    monkeypatch.setattr(config, "DB_DIR", str(tmp_path))
+    monkeypatch.setattr(config, "DB_PATH", str(db_path))
+
+    from shared import db as shared_db
+
+    shared_db._db_url_cache = f"sqlite:///{db_path}"
+    monkeypatch.setattr(shared_db, "DB_DIR", str(tmp_path))
+    monkeypatch.setattr(shared_db, "DB_PATH", str(db_path))
+    shared_db.is_postgresql = lambda: False
+    shared_db.init_database()
+
+    # fetch_claude assumes agent_sessions already exists (the app creates it).
+    # Build a minimal schema covering the columns update_agent_sessions_stats
+    # touches, so the INSERT/UPDATE paths can run end-to-end.
+    conn = shared_db.get_connection()
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS agent_sessions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT UNIQUE,
+            session_type TEXT DEFAULT 'chat',
+            title TEXT,
+            tool_name TEXT,
+            host_name TEXT,
+            user_id INTEGER,
+            status TEXT,
+            project_path TEXT,
+            message_count INTEGER DEFAULT 0,
+            total_tokens INTEGER DEFAULT 0,
+            request_count INTEGER DEFAULT 0,
+            model TEXT,
+            context TEXT,
+            created_at TEXT,
+            updated_at TEXT
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    import fetch_claude
+
+    # Two sessions, different models + different last-timestamps. Session A's
+    # most-recent message uses model-A; session B's uses model-B. Messages are
+    # interleaved so a loop-residual bug would cross-contaminate.
+    base_msg = {
+        "date": "2026-07-19",
+        "tool_name": "claude",
+        "host_name": "localhost",
+        "message_id": "",
+        "parent_id": None,
+        "role": "assistant",
+        "content": "x",
+        "content_blocks": [],
+        "full_entry": "{}",
+        "tokens_used": 10,
+        "input_tokens": 5,
+        "output_tokens": 5,
+        "cache_read_tokens": 0,
+        "cache_creation_tokens": 0,
+        "sender_id": "claude_user",
+        "sender_name": "tester-localhost-claude",
+        "conversation_id": None,
+        "project_path": "-home-tester-project",
+    }
+
+    def msg(session_id, model, ts, mid):
+        m = dict(base_msg)
+        m.update(
+            {
+                "agent_session_id": session_id,
+                "model": model,
+                "timestamp": ts,
+                "message_id": mid,
+            }
+        )
+        return m
+
+    messages = [
+        msg("sess-A", "model-A", "2026-07-19T10:00:00Z", "a1"),
+        msg("sess-B", "model-B", "2026-07-19T11:00:00Z", "b1"),
+        # Newer message in sess-A with model-A (its last_model)
+        msg("sess-A", "model-A", "2026-07-19T12:00:00Z", "a2"),
+        # Newer message in sess-B with model-B (its last_model) — last in loop
+        msg("sess-B", "model-B", "2026-07-19T13:00:00Z", "b2"),
+    ]
+
+    fetch_claude.update_agent_sessions_stats(messages)
+
+    conn = shared_db.get_connection()
+    rows = {
+        r["session_id"]: r for r in conn.execute("SELECT session_id, model FROM agent_sessions")
+    }
+    # Each session must carry its OWN most-recent model, not the batch-wide
+    # loop-residual (which would be model-B for both).
+    assert rows["sess-A"]["model"] == "model-A"
+    assert rows["sess-B"]["model"] == "model-B"
+    conn.close()

--- a/tests/issues/1760/test_save_usage_tenant_and_workflow_annotation.py
+++ b/tests/issues/1760/test_save_usage_tenant_and_workflow_annotation.py
@@ -1,0 +1,116 @@
+"""Tests for multi-tenant save_usage fix and fetch_claude workflow annotation.
+
+Problem 1: save_usage ON CONFLICT must include tenant_id to match the
+daily_usage unique constraint (tenant_id, date, tool_name, host_name).
+Without it Postgres raises InvalidColumnReference and fetch_claude crashes
+every run.
+
+Problem 4a: fetch_claude must annotate CLI sessions that came from an
+autonomous workflow worktree with a readable title + workflow_id context,
+so the frontend can badge them and jump to the workflow timeline.
+"""
+
+import inspect
+import os
+import sys
+from unittest.mock import MagicMock
+
+# conftest.py already adds scripts/shared to sys.path. We also need scripts/
+# itself so the module-level imports below resolve. From tests/issues/1760/
+# <file> it's 4x dirname to reach the repo root.
+_REPO_ROOT = os.path.dirname(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
+_SCRIPTS_PATH = os.path.join(_REPO_ROOT, "scripts")
+if _SCRIPTS_PATH not in sys.path:
+    sys.path.insert(0, _SCRIPTS_PATH)
+
+
+def _load_shared_db():
+    """Lazy import to keep these path-dependent imports out of the top-level
+    import block (avoids isort/ruff section-split churn during pre-commit)."""
+    from shared import db as shared_db
+
+    return shared_db
+
+
+# ── Problem 1: save_usage ON CONFLICT includes tenant_id ───────────────
+
+
+def test_save_usage_signature_accepts_tenant_id():
+    """save_usage must accept a tenant_id parameter (default 1, host-level
+    aggregate semantics)."""
+    shared_db = _load_shared_db()
+    sig = inspect.signature(shared_db.save_usage)
+    assert "tenant_id" in sig.parameters
+    assert sig.parameters["tenant_id"].default == 1
+
+
+def test_save_usage_pg_sql_includes_tenant_id_in_conflict_target():
+    """The PostgreSQL INSERT branch must include tenant_id in BOTH the INSERT
+    column list and the ON CONFLICT target, matching the unique constraint
+    uq_daily_usage_date_tool_host (tenant_id, date, tool_name, host_name).
+    A mismatch raises InvalidColumnReference on Postgres."""
+    shared_db = _load_shared_db()
+    source = inspect.getsource(shared_db.save_usage)
+    # tenant_id in INSERT column list
+    assert "tenant_id" in source
+    # ON CONFLICT target includes tenant_id first (constraint column order)
+    assert "ON CONFLICT (tenant_id, date, tool_name, host_name)" in source
+    # The old buggy form must be gone
+    assert "ON CONFLICT (date, tool_name, host_name)" not in source
+
+
+# ── Problem 4a: fetch_claude workflow session annotation ───────────────
+
+
+def test_extract_workflow_id_from_encoded_worktree_path():
+    """Claude encodes the worktree cwd with /→- and stores jsonl under
+    ~/.claude/projects/<encoded>/. The encoded worktree path contains a
+    -worktrees-<uuid> segment that maps back to the workflow_id."""
+    from fetch_claude import _extract_workflow_id_from_project_path
+
+    # Real encoded form (matches what Claude writes on Linux)
+    encoded = "-home-rhuang-open-ace--worktrees-29a825f7-c90f-485c-a74f-ac760204004c"
+    assert _extract_workflow_id_from_project_path(encoded) == "29a825f7-c90f-485c-a74f-ac760204004c"
+
+
+def test_extract_workflow_id_returns_empty_for_regular_cli_session():
+    """A regular (non-workflow) CLI session's project_path has no worktree
+    segment and must return '' so it's not misannotated."""
+    from fetch_claude import _extract_workflow_id_from_project_path
+
+    assert _extract_workflow_id_from_project_path("-home-rhuang-open-ace") == ""
+    assert _extract_workflow_id_from_project_path("") == ""
+    assert _extract_workflow_id_from_project_path("-Users-joe-myproject") == ""
+
+
+def test_resolve_workflow_session_annotation_links_to_workflow():
+    """When project_path maps to a workflow, the annotation title is prefixed
+    with [Auto] and context carries workflow_id + workflow_imported flag."""
+    from fetch_claude import _resolve_workflow_session_annotation
+
+    cursor = MagicMock()
+    # Simulate a workflow row lookup hit
+    cursor.fetchone.return_value = {"title": "gh issue 1851"}
+
+    title, context = _resolve_workflow_session_annotation(
+        cursor,
+        "-home-rhuang-open-ace--worktrees-29a825f7-c90f-485c-a74f-ac760204004c",
+    )
+
+    assert title == "[Auto] gh issue 1851"
+    assert context["workflow_id"] == "29a825f7-c90f-485c-a74f-ac760204004c"
+    assert context["workflow_imported"] is True
+
+
+def test_resolve_workflow_session_annotation_empty_for_non_workflow():
+    """Non-workflow sessions get empty title + context (no annotation)."""
+    from fetch_claude import _resolve_workflow_session_annotation
+
+    cursor = MagicMock()
+    title, context = _resolve_workflow_session_annotation(cursor, "-home-rhuang-open-ace")
+    assert title == ""
+    assert context == {}
+    # Must not hit the DB for non-workflow paths
+    cursor.fetchone.assert_not_called()

--- a/tests/issues/716/test_agent_runner.py
+++ b/tests/issues/716/test_agent_runner.py
@@ -85,6 +85,53 @@ class TestAgentRunnerRunTask:
         assert "not found" in result.error
         assert result.tracking_session_id
 
+    def test_sidebar_missing_executable_closes_orphan_wrapper(self):
+        """When claude-code (sidebar source) fails to start, the eagerly-created
+        workflow wrapper row must be closed to status='error' — otherwise it
+        stays 'active' forever as a zombie row that leaks into the session list.
+        (#1816 orphan wrapper)"""
+        mock_adapter = MagicMock()
+        mock_adapter.get_executable_name.return_value = "claude"
+        mock_adapter.supports_stdin_input.return_value = True
+        mock_adapter.provides_full_command.return_value = False
+        mock_adapter.build_start_args.return_value = ["claude"]
+        mock_cli_adapters = MagicMock()
+        mock_cli_adapters.get_adapter.return_value = mock_adapter
+
+        sm = MagicMock()
+        runner = AutonomousAgentRunner(session_manager=sm)
+
+        with patch.dict("sys.modules", {"cli_adapters": mock_cli_adapters}):
+            with patch("shutil.which", return_value=None):
+                result = runner.run_agent_task(
+                    workflow_id="wf-orphan",
+                    cli_tool="claude-code",
+                    model="test-model",
+                    project_path="/tmp/test",
+                    prompt="Do something",
+                    workspace_type="local",
+                )
+
+        assert result.success is False
+        # sidebar source + missing executable → empty session_id (no real CLI
+        # session was established)
+        assert result.session_id == ""
+        assert result.tracking_session_id  # the tracking uuid still present
+        # The wrapper row must be closed to status='error' with the failure
+        # reason, so it doesn't linger as 'active'.
+        status_updates = [
+            call
+            for call in sm.update_session_fields.call_args_list
+            if call.args and len(call.args) >= 2 and call.args[1].get("status") == "error"
+        ]
+        assert status_updates, "orphan wrapper not closed to status='error'"
+        # The closed row is keyed by the tracking uuid, with the error message.
+        closed_call = status_updates[0]
+        assert (
+            closed_call.args[1].get("error_message")
+            and "not found" in closed_call.args[1]["error_message"]
+        )
+
     def test_run_local_success(self):
         """Test successful local agent execution — verify return value fields."""
         mock_adapter = MagicMock()

--- a/tests/unit/test_workspace_modules.py
+++ b/tests/unit/test_workspace_modules.py
@@ -340,6 +340,34 @@ class TestSessionManager:
         result = session_manager.list_sessions(user_id=1)
         assert [session.session_id for session in result["sessions"]] == ["actual-123"]
 
+    def test_list_sessions_hides_workflow_wrapper_with_empty_cli_session_id(self, session_manager):
+        """A workflow wrapper whose cli_session_id was never backfilled (e.g. the
+        agent failed to start) must still be hidden — visible_session_clause
+        must not depend on cli_session_id being populated."""
+        orphan = session_manager.create_session(
+            tool_name="claude",
+            user_id=1,
+            session_type=SessionType.WORKFLOW.value,
+            title="Autonomous: wf-1",
+            # No cli_session_id backfill — simulates an agent that never produced
+            # a real CLI session id (executable not found / spawn failed).
+            context={"workflow_id": "wf-1"},
+        )
+        # Sanity: cli_session_id is indeed empty.
+        assert orphan.cli_session_id == ""
+
+        visible = session_manager.create_session(
+            tool_name="claude",
+            user_id=1,
+            session_id="visible-regular",
+            title="Regular chat",
+        )
+
+        result = session_manager.list_sessions(user_id=1)
+        session_ids = [s.session_id for s in result["sessions"]]
+        assert visible.session_id in session_ids
+        assert orphan.session_id not in session_ids
+
     def test_session_expiration(self, session_manager):
         """Test session expiration."""
         session = session_manager.create_session(tool_name="claude", expires_in_hours=1)


### PR DESCRIPTION
## 背景

排查 issue #1816 工作流 #2（PR #1849）的 session 不显示问题时，发现 4 个相互关联的 bug。前两个是阻断性/数据泄露，后两个是配套修复。

## 问题 1（阻断性）：fetch_claude `save_usage` ON CONFLICT 缺 tenant_id

**根因**：migration `20260717_004_scope_usage_and_audit_to_tenant` 把 `daily_usage` 唯一约束从 `(date, tool_name, host_name)` 扩成 `(tenant_id, date, tool_name, host_name)`，但 `scripts/shared/db.py` 和 `scripts/upload-to-central/shared/db.py` 两处 `save_usage()` 没跟着改。

**影响**：Postgres 报 `InvalidColumnReference: there is no unique or exclusion constraint matching the ON CONFLICT specification`，fetch_claude 每 60s 定时触发必崩（日志实测），历史 claude session 导入全部失效。这也是为什么真实 claude session 从不出现在 session list——脚本根本走不到 INSERT agent_sessions 那一步。

**审计**：全量排查 23 处 ON CONFLICT，确认**仅这 2 处**漏改。其他 21 处（daily_messages、agent_runs、tenant_usage、api_key_store 等）全部精确匹配。

**修复**：`save_usage` 加 `tenant_id: int = 1` 参数，INSERT 列表 + ON CONFLICT 对齐 4 列。参考 app 层 `app/repositories/usage_repo.py:108-140`（当时跟着 migration 一起写的正确实现）。

## 问题 2：`visible_session_clause` 依赖 `cli_session_id` 非空

**根因**：隐藏条件是三 AND（`session_type="workflow" AND cli_session_id!="" AND context LIKE %"workflow_id"%`）。当 agent 启动失败时，eager 创建的 wrapper 行 `cli_session_id` 永不回填，绕过第二个条件，漏到用户 session list。

**修复**：去掉 `cli_session_id != ""` conjunct。workflow wrapper 是系统记账行，不该出现在用户 list，不应依赖 cli_session_id 是否回填作为可见性开关。

## 问题 3：agent 启动失败留僵尸 wrapper 行

**根因**：`agent_runner.py:1362` eager 创建 wrapper（`status="active"`）。claude 启动失败时（executable not found / spawn failed），sidebar 路径返回 `result.session_id=""`，跳过 status 更新，wrapper 永远停在 `active`。

**修复**：`run_agent_task` 返回前，对 `sidebar + 空 session_id` 的情况显式收尾 wrapper 成 `status="error"`，配合问题 2 的 filter，无僵尸行可见。正常流程不受影响（main/review 行 claude 正常启动，走原路径）。

## 问题 4：fetch_claude 富标注导入 workflow session（问题 1 修复后的配套）

问题 1 修复后 fetch_claude 能跑了，但会把 workflow 的真实 claude session（如 `d788c378`）当普通 chat 导入污染 list（标题 `claude - d788c378`，无语义、无 workflow 关联）。采用**富标注**方案：

**4a（fetch_claude）**：
- 新增 `_extract_workflow_id_from_project_path`：从 Claude encoded worktree path（`-home-rhuang-open-ace--worktrees-29a825f7-...`）正则提取 workflow_id
- 新增 `_resolve_workflow_session_annotation`：反查 `autonomous_workflows` 表拿 title
- INSERT 分支：workflow session 写 `[Auto] {workflow.title}` 标题 + `context={"workflow_id": "...", "workflow_imported": true}`；非 workflow session 走原逻辑

**4b（前端 SessionList）**：
- `SessionItem` 加 `isWorkflowImported` / `workflowId`（优先于 isImported）
- robot 图标徽标（`bi-robot`，区别于普通 isImported 的 archive 图标）
- 点击 workflow session 跳转 `/work/autonomous?workflow_id=...`
- 4 语言 i18n key `workflowImported`

## tenant 决策

daily_usage 是 **host 级聚合**（一个 host 上所有 system_account 的 token 合并成一行，无 user_id 维度）。fetch 脚本按 host 批量跑，无法把合并后的用量拆到具体 tenant。所以 `save_usage` 的 tenant_id **用默认 1**——这是多租户改造前的正确语义。真正的 tenant 拆分需先给 daily_usage 加 user_id 维度（更大的架构改动，不在本次范围）。

## 验证

- ✅ **120 个后端测试全过**（含新增 8 个：问题 1 SQL 断言 ×2、问题 4a helper ×4、问题 2 filter ×1、问题 3 僵尸行 ×1）
- ✅ ruff / py_compile / pre-commit（black/isort/ruff/mypy/bandit/pydocstyle）全过
- ✅ 前端 ESLint（0 errors）、tsc typecheck（0 errors）、build 成功
- ⚠️ `test_usage_repo_tenant_scope.py` 失败已确认是**预先存在**（`git stash` 到干净 main 同样失败，app 层 usage_repo 的 PG 占位符在 sqlite fixture 下的已知问题），与本 PR 无关

## 不在范围

- 不处理历史遗留 chat 孤儿行（用户确认）
- 不做真正的 tenant 拆分（需先加 user 维度）
- 不改 schema / migration（schema 已正确，只是 Python 没跟上）

Closes #1760