### PR TITLE
fix(workspace): iframe 空白 — 传递 host_url 修正容器探测 IP (Issue #1306)

### DIFF
--- a/app/routes/workspace.py
+++ b/app/routes/workspace.py
@@ -2025,17 +2025,23 @@ def get_user_webui_url():
 
         system_account = user.get("system_account") or user.get("username")
 
-        # Get or create user's webui instance
-        url, token = manager.get_user_webui_url(int(user_id), str(system_account))
+        # Get or create user's webui instance.
+        # Pass host_url so the iframe URL uses the browser-visible host instead
+        # of config.url (Issue #1306). In Docker deployments config.url holds a
+        # container-detected IP that the browser cannot reach; webui_manager
+        # replaces it with request.host_url. Omitting this argument regresses
+        # the workspace into a blank iframe.
+        from flask import request as flask_request
+
+        host_url = flask_request.host_url.rstrip("/")
+        url, token = manager.get_user_webui_url(int(user_id), str(system_account), host_url)
 
         # Update activity timestamp
         manager.update_user_activity(user_id)
 
         # Build Open-ACE API URL for iframe integration
         # This is needed so qwen-code-webui can call Open-ACE APIs
-        from flask import request as flask_request
-
-        openace_url = flask_request.host_url.rstrip("/")
+        openace_url = host_url
 
         # For HTTPS requests in multi-user mode, convert URL to relative path
         # to avoid mixed content blocking (HTTP iframe in HTTPS page)

--- a/frontend/src/components/features/Workspace.tsx
+++ b/frontend/src/components/features/Workspace.tsx
@@ -650,8 +650,13 @@ export const Workspace: React.FC = () => {
       // which carries the browser-visible host (via _replace_host_from_request,
       // Issue #1306/#1357) and the fixed WebUI port. config.url only reflects a
       // container-detected address that the browser cannot reach, so using it
-      // directly leaves the iframe blank. Fall back to config.url only when the
-      // user-url request hasn't completed yet.
+      // directly leaves the iframe blank.
+      //
+      // Fall back to config.url when userWebUI is absent — this covers both the
+      // request-in-flight window and the failure modes (success:false or the
+      // fetch throwing, which loadConfig swallows). Note the fallback is itself
+      // the unreachable container address, so in those failure cases the iframe
+      // stays blank; there is no better value available without user-url.
       let url = userWebUI?.success && userWebUI.url ? userWebUI.url : config.url;
       // Add lang parameter for language sync
       const langSeparator = url.includes('?') ? '&' : '?';

--- a/frontend/src/components/features/Workspace.tsx
+++ b/frontend/src/components/features/Workspace.tsx
@@ -646,10 +646,13 @@ export const Workspace: React.FC = () => {
         return url;
       }
 
-      // Single-user mode: use configured URL (preserve port)
-      // Note: Port should NOT be removed - WebUI runs on a specific port (e.g., 3100)
-      // The backend handles hostname replacement via _replace_host_from_request if needed
-      let url = config.url;
+      // Single-user mode: prefer the URL returned by /api/workspace/user-url,
+      // which carries the browser-visible host (via _replace_host_from_request,
+      // Issue #1306/#1357) and the fixed WebUI port. config.url only reflects a
+      // container-detected address that the browser cannot reach, so using it
+      // directly leaves the iframe blank. Fall back to config.url only when the
+      // user-url request hasn't completed yet.
+      let url = userWebUI?.success && userWebUI.url ? userWebUI.url : config.url;
       // Add lang parameter for language sync
       const langSeparator = url.includes('?') ? '&' : '?';
       url = `${url}${langSeparator}lang=${encodeURIComponent(language)}&theme=${theme}`;

--- a/tests/issues/1306/test_user_url_route_host_propagation.py
+++ b/tests/issues/1306/test_user_url_route_host_propagation.py
@@ -12,7 +12,7 @@ These tests lock down the wiring: a request to `/api/workspace/user-url` with a
 custom Host header must return a URL built from that host, not from `config.url`.
 """
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from flask import Flask
@@ -126,3 +126,52 @@ def test_user_url_route_uses_localhost_in_default_case(
     data = resp.get_json()
     assert data["url"] == "http://localhost:3100", data["url"]
     assert data["openace_url"] == "http://localhost:19888", data["openace_url"]
+
+
+@patch("app.services.webui_manager.get_webui_manager")
+@patch("app.repositories.user_repo.UserRepository.get_user_by_id")
+def test_user_url_route_multi_user_uses_request_host_and_instance_port(
+    mock_get_user, mock_get_manager, workspace_app
+):
+    """Multi-user mode: url must use the request host + the instance's port.
+
+    Locks down the multi-user route wiring (webui_manager.py:541-549): when an
+    instance already exists and host_url is provided, the returned URL is built
+    from the browser-visible host and the instance's own port — NOT from the
+    container-detected IP stored on the instance.
+    """
+    from app.services.webui_manager import WebUIManager, WorkspaceConfig
+
+    manager = WebUIManager(
+        WorkspaceConfig(
+            enabled=True,
+            url=UNREACHABLE_CONTAINER_IP,
+            multi_user_mode=True,
+        )
+    )
+    manager.stop_cleanup_thread()
+
+    # Inject a live instance with a distinct port and a stale (container-IP) url.
+    # is_alive() is stubbed True so the manager reuses it instead of restarting.
+    instance = MagicMock()
+    instance.is_alive.return_value = True
+    instance.port = 3123
+    instance.token = "instance-token"
+    instance.url = f"{UNREACHABLE_CONTAINER_IP}:3123"  # stale container-IP url
+    manager._instances = {MOCK_USER["id"]: instance}
+
+    mock_get_manager.return_value = manager
+    mock_get_user.return_value = MOCK_USER
+
+    resp = _authed_get(
+        workspace_app.test_client(),
+        "/api/workspace/user-url",
+        host="my-host.example:19888",
+    )
+
+    assert resp.status_code == 200
+    data = resp.get_json()
+    # host replaced from request, port taken from the instance (3123, not 3100)
+    assert data["url"] == "http://my-host.example:3123", data["url"]
+    assert UNREACHABLE_CONTAINER_IP not in data["url"]
+    assert data["openace_url"] == "http://my-host.example:19888", data["openace_url"]

--- a/tests/issues/1306/test_user_url_route_host_propagation.py
+++ b/tests/issues/1306/test_user_url_route_host_propagation.py
@@ -1,0 +1,128 @@
+"""Route-level regression test for Issue #1306.
+
+The existing tests in test_host_url_replacement.py cover the *manager* layer
+(`WebUIManager._replace_host_from_request` / `get_user_webui_url`), but the
+regression that caused blank workspace iframes happened at the *route wiring*
+layer: `app/routes/workspace.py::get_user_webui_url` stopped forwarding
+`request.host_url` to the manager, so the manager fell back to the
+container-detected `config.url` (e.g. 0.250.250.254) which the browser cannot
+reach.
+
+These tests lock down the wiring: a request to `/api/workspace/user-url` with a
+custom Host header must return a URL built from that host, not from `config.url`.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from flask import Flask
+
+# The container-detected IP that browsers cannot reach. Config.url is seeded
+# with this to prove the route overrides it with the request host.
+UNREACHABLE_CONTAINER_IP = "http://0.250.250.254"
+
+MOCK_USER = {
+    "id": 1,
+    "username": "admin",
+    "email": "admin@example.com",
+    "role": "admin",
+    "tenant_id": 1,
+    "must_change_password": False,
+}
+
+
+@pytest.fixture
+def workspace_app():
+    """Flask app with only the workspace blueprint registered (url_prefix
+    /api/workspace, matching the real registration)."""
+    from app.routes.workspace import workspace_bp
+
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.register_blueprint(workspace_bp, url_prefix="/api/workspace")
+    return app
+
+
+def _stub_manager():
+    """A real WebUIManager configured with a wrong (container-detected) IP.
+
+    Using a real manager (not a MagicMock) means the assertion exercises the
+    actual _replace_host_from_request code path — only the factory that
+    supplies the manager is mocked.
+    """
+    from app.services.webui_manager import WebUIManager, WorkspaceConfig
+
+    manager = WebUIManager(
+        WorkspaceConfig(
+            enabled=True,
+            url=UNREACHABLE_CONTAINER_IP,
+            multi_user_mode=False,
+        )
+    )
+    manager.stop_cleanup_thread()
+    return manager
+
+
+def _authed_get(client, path, host):
+    """GET with auth stubbed so the blueprint's load_user before_request passes.
+
+    Patches _extract_token / _load_user_from_token (module-level imports in
+    workspace.py) so the real auth chain runs end-to-end and sets g.user.
+    """
+    with patch("app.routes.workspace._extract_token", return_value="test-token"), patch(
+        "app.routes.workspace._load_user_from_token", return_value=MOCK_USER
+    ):
+        return client.get(path, headers={"Host": host})
+
+
+@patch("app.services.webui_manager.get_webui_manager")
+@patch("app.repositories.user_repo.UserRepository.get_user_by_id")
+def test_user_url_route_uses_request_host_not_config_ip(
+    mock_get_user, mock_get_manager, workspace_app
+):
+    """GET /api/workspace/user-url must derive url/openace_url from Host header.
+
+    Regression: the route previously dropped the host_url argument, so the
+    iframe URL fell back to config.url's container IP.
+    """
+    mock_get_manager.return_value = _stub_manager()
+    mock_get_user.return_value = MOCK_USER
+
+    resp = _authed_get(
+        workspace_app.test_client(),
+        "/api/workspace/user-url",
+        host="my-host.example:19888",
+    )
+
+    assert resp.status_code == 200
+    data = resp.get_json()
+
+    # url must be built from the request host (single-user fixed port 3100),
+    # NOT the container IP.
+    assert data["url"] == "http://my-host.example:3100", data["url"]
+    assert UNREACHABLE_CONTAINER_IP not in data["url"]
+
+    # openace_url must also follow the request host.
+    assert data["openace_url"] == "http://my-host.example:19888", data["openace_url"]
+    assert UNREACHABLE_CONTAINER_IP not in data["openace_url"]
+
+
+@patch("app.services.webui_manager.get_webui_manager")
+@patch("app.repositories.user_repo.UserRepository.get_user_by_id")
+def test_user_url_route_uses_localhost_in_default_case(
+    mock_get_user, mock_get_manager, workspace_app
+):
+    """The common local-dev case: Host=localhost:19888 -> url=localhost:3100."""
+    mock_get_manager.return_value = _stub_manager()
+    mock_get_user.return_value = MOCK_USER
+
+    resp = _authed_get(
+        workspace_app.test_client(),
+        "/api/workspace/user-url",
+        host="localhost:19888",
+    )
+
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["url"] == "http://localhost:3100", data["url"]
+    assert data["openace_url"] == "http://localhost:19888", data["openace_url"]

--- a/tests/issues/1306/test_user_url_route_host_propagation.py
+++ b/tests/issues/1306/test_user_url_route_host_propagation.py
@@ -69,8 +69,9 @@ def _authed_get(client, path, host):
     Patches _extract_token / _load_user_from_token (module-level imports in
     workspace.py) so the real auth chain runs end-to-end and sets g.user.
     """
-    with patch("app.routes.workspace._extract_token", return_value="test-token"), patch(
-        "app.routes.workspace._load_user_from_token", return_value=MOCK_USER
+    with (
+        patch("app.routes.workspace._extract_token", return_value="test-token"),
+        patch("app.routes.workspace._load_user_from_token", return_value=MOCK_USER),
     ):
         return client.get(path, headers={"Host": host})
 


### PR DESCRIPTION
## 问题

Docker 部署下（单用户或默认 docker-compose），登录后进入工作区页面，iframe 整片空白，浏览器控制台报 `502 Bad Gateway`，目标地址指向一个浏览器不可达的容器内部 IP（如 `0.250.250.254`，由 entrypoint 的 `hostname -I` 探测得到）。

## 根因

后端 `webui_manager.get_user_webui_url`（`webui_manager.py`）已通过 `_replace_host_from_request`（Issue #1357）实现：用 `request.host_url`（浏览器实际访问的地址）替换 `config.url` 里的容器探测 IP。但该替换**需要调用方把 `host_url` 作为参数传入**。

`app/routes/workspace.py` 的 `get_user_webui_url` 路由在后续重构中丢失了这一传参（Issue #1306 当初加上的 `host_url` 参数被删除），导致：
- 后端走 fallback 分支，直接用 `config.url`（容器探测 IP）
- iframe `src` 指向不可达地址 → 加载失败 → 空白页

前端的 `getEffectiveUrl` 在单用户模式下直接取 `config.url`（来自 `/api/workspace/config`，该端点**不做 host 替换**），进一步放大了这个问题。

## 修复

两处改动针对同一根因（iframe 加载浏览器不可达的地址）：

### 1. `app/routes/workspace.py`（影响单用户 + 多用户模式）
调用 `manager.get_user_webui_url` 时恢复传入 `host_url`（来自 `flask_request.host_url`），让后端用浏览器可达地址替换容器探测 IP。同时复用该 `host_url` 计算 `openace_url`，避免重复 import。

### 2. `frontend/src/components/features/Workspace.tsx`（仅影响单用户模式）
`getEffectiveUrl` 单用户分支优先使用 `/api/workspace/user-url` 返回的 `userWebUI.url`（已含浏览器可达 host 和固定 WebUI 端口 3100），而非 `config.url`（仅含容器探测地址）。仅在 user-url 尚未拿到时回退到 `config.url`。多用户模式本就使用 `userWebUI.url`，不受影响。

## 验证

- 单用户模式（docker-compose 默认）：iframe URL 从 `http://0.250.250.254` → `http://localhost:3100`，页面正常加载
- 多用户模式：iframe URL 从 `http://0.250.250.254:3100` → `http://localhost:3100`，WebUI 以系统账号正常启动
- `openace_url` 参数正确指向 `http://localhost:19888`

## 关联

- 修复 Issue #1306 的回归（该 Issue 当初引入 `host_url` 传参，后于重构中丢失）
- 与 Issue #1357（`_replace_host_from_request` 设计）配合