### PR TITLE
chore(deploy): docker compose 零配置部署 + SERVER_IP 不可达兜底

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,47 @@
+# Open ACE - Docker Compose 环境变量示例
+#
+# 用法：
+#   cp .env.example .env   # 然后按需修改
+#   docker compose up -d --build
+#
+# 不创建 .env 也能直接 `docker compose up -d --build`：缺失的密钥会在
+# 容器首次启动时由 docker-entrypoint.sh 自动生成强随机值。本文件主要用于
+# 生产环境显式配置（自动生成的密钥仅存在于运行环境，不会落盘到 .env）。
+
+# ── 安全密钥 ──────────────────────────────────────────────────────────────
+# 留空 = 首次启动自动生成。生产环境建议显式设置并妥善保管：
+#   生成方式：python3 -c "import secrets; print(secrets.token_hex(32))"
+# SECRET_KEY 用于 Flask 会话签名。丢失会使所有已登录会话失效。
+SECRET_KEY=
+# OPENACE_ENCRYPTION_KEY 用于加密存储的 API Key 等敏感数据。一旦设置后
+# 修改，此前加密的数据将无法解密。
+OPENACE_ENCRYPTION_KEY=
+# UPLOAD_AUTH_KEY 用于工作区文件上传接口鉴权。留空则该接口禁用。
+UPLOAD_AUTH_KEY=
+
+# ── 数据库 ────────────────────────────────────────────────────────────────
+# 与 docker-compose.yml 里的 postgres 服务默认值保持一致，一般无需修改。
+DB_USER=ace
+DB_PASSWORD=ace-secret
+DB_NAME=ace
+
+# ── 网络 ──────────────────────────────────────────────────────────────────
+# 宿主机暴露端口（容器内固定 19888）
+PORT=19888
+# 工作区 WebUI 实例端口范围（多用户模式按需分配）
+WORKSPACE_PORT_RANGE_START=3100
+WORKSPACE_PORT_RANGE_END=3200
+
+# 浏览器访问服务的地址。留空时 entrypoint 自动探测；探测到不可达地址
+# （如 0.0.0.0/8 保留段）时回退到 localhost。从其他机器访问时显式设置，
+# 例如 SERVER_IP=192.168.1.100
+SERVER_IP=
+
+# ── 工作区模式 ────────────────────────────────────────────────────────────
+# false（默认）：单用户模式，容器以非 root 运行
+# true：多用户模式，每个用户独立的系统账号 + WebUI 实例（需 root 运行）
+WORKSPACE_MULTI_USER_MODE=false
+
+# ── 国内网络加速（可选）──────────────────────────────────────────────────
+# 构建时若拉取 Docker Hub 基础镜像超时，取消注释并设置为国内镜像源：
+# BASE_REGISTRY=docker.m.daocloud.io

--- a/.env.example
+++ b/.env.example
@@ -9,12 +9,14 @@
 # 生产环境显式配置（自动生成的密钥仅存在于运行环境，不会落盘到 .env）。
 
 # ── 安全密钥 ──────────────────────────────────────────────────────────────
-# 留空 = 首次启动自动生成。生产环境建议显式设置并妥善保管：
+# 留空 = 首次启动时由 docker-entrypoint.sh 自动生成强随机值，并持久化到
+# config 卷的 generated-secrets.env，后续重启复用（不会轮转）。
+# 显式设置则始终优先、且不会被持久化文件覆盖。
 #   生成方式：python3 -c "import secrets; print(secrets.token_hex(32))"
-# SECRET_KEY 用于 Flask 会话签名。丢失会使所有已登录会话失效。
+# SECRET_KEY 用于 Flask 会话签名。丢失/轮转会使所有已登录会话失效。
 SECRET_KEY=
-# OPENACE_ENCRYPTION_KEY 用于加密存储的 API Key 等敏感数据。一旦设置后
-# 修改，此前加密的数据将无法解密。
+# OPENACE_ENCRYPTION_KEY 用于加密存储的 API Key / SMTP 密码等敏感数据。
+# 务必稳定：轮转后此前加密的数据将永久无法解密。
 OPENACE_ENCRYPTION_KEY=
 # UPLOAD_AUTH_KEY 用于工作区文件上传接口鉴权。留空则该接口禁用。
 UPLOAD_AUTH_KEY=

--- a/.env.example
+++ b/.env.example
@@ -5,8 +5,9 @@
 #   docker compose up -d --build
 #
 # 不创建 .env 也能直接 `docker compose up -d --build`：缺失的密钥会在
-# 容器首次启动时由 docker-entrypoint.sh 自动生成强随机值。本文件主要用于
-# 生产环境显式配置（自动生成的密钥仅存在于运行环境，不会落盘到 .env）。
+# 容器首次启动时由 docker-entrypoint.sh 自动生成强随机值，并持久化到 config
+# 卷的 generated-secrets.env（后续重启复用，不会轮转）。本文件主要用于生产
+# 环境显式配置——显式设置的值优先于自动生成的，且不会被写入 generated-secrets.env。
 
 # ── 安全密钥 ──────────────────────────────────────────────────────────────
 # 留空 = 首次启动时由 docker-entrypoint.sh 自动生成强随机值，并持久化到

--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ VERSION
 *.pem
 *.key
 .env.*
+!.env.example
 
 # Qwen local settings
 .qwen/

--- a/README.md
+++ b/README.md
@@ -131,7 +131,11 @@ docker compose up -d --build
 # 访问 http://localhost:19888
 ```
 
-> 💡 生产环境部署请参考 [部署指南](scripts/install-central/docker-method/README.md)
+> 💡 **零配置**：安全密钥（`SECRET_KEY` / `OPENACE_ENCRYPTION_KEY` / `UPLOAD_AUTH_KEY`）在首次启动时自动生成，无需预先配置。
+>
+> ⚠️ 生产环境请通过 `.env` 显式设置强密钥（参考 `.env.example`）、修改默认密码，并参阅 [部署指南](docs/cn/DEPLOYMENT.md)。自动生成的密钥仅存在于运行环境，容器/卷销毁后不保留。
+
+> 🇨🇳 **国内网络**：若构建时拉取基础镜像卡住或超时，见 [国内网络加速](#-国内网络加速)。
 
 ### 方式二：源码安装
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,9 +42,12 @@ services:
     environment:
       - FLASK_ENV=production
       - PYTHONUNBUFFERED=1
-      - SECRET_KEY=${SECRET_KEY:?SECRET_KEY must be set}
-      - OPENACE_ENCRYPTION_KEY=${OPENACE_ENCRYPTION_KEY:?OPENACE_ENCRYPTION_KEY must be set}
-      - UPLOAD_AUTH_KEY=${UPLOAD_AUTH_KEY:?UPLOAD_AUTH_KEY must be set}
+      # Secrets: empty by default — docker-entrypoint.sh auto-generates strong
+      # random values on first start if unset (see ensure_secret_env). For
+      # production, set them explicitly in .env (see .env.example).
+      - SECRET_KEY=${SECRET_KEY:-}
+      - OPENACE_ENCRYPTION_KEY=${OPENACE_ENCRYPTION_KEY:-}
+      - UPLOAD_AUTH_KEY=${UPLOAD_AUTH_KEY:-}
       # Database
       - DATABASE_URL=postgresql://${DB_USER:-ace}:${DB_PASSWORD:-ace-secret}@postgres:5432/${DB_NAME:-ace}
       # Multi-user Workspace

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -188,6 +188,31 @@ echo "=========================================="
 # ============================================================================
 # 0.2. Generate Default Config (Issue #1260)
 # ============================================================================
+
+# Auto-generate strong random secrets when the operator did not set them.
+# Lets `docker compose up` work with zero configuration: the entrypoint fills
+# SECRET_KEY / OPENACE_ENCRYPTION_KEY / UPLOAD_AUTH_KEY so the Python app
+# (which runs as FLASK_ENV=production and strictly validates these) starts.
+# Generated values are exported into the environment the app inherits. Setting
+# any of them explicitly (e.g. via .env) is always honored.
+ensure_secret_env() {
+    if [ -z "$SECRET_KEY" ]; then
+        SECRET_KEY=$(python3 -c "import secrets; print(secrets.token_hex(32))")
+        export SECRET_KEY
+        echo "Generated SECRET_KEY (set SECRET_KEY to override)."
+    fi
+    if [ -z "$OPENACE_ENCRYPTION_KEY" ]; then
+        OPENACE_ENCRYPTION_KEY=$(python3 -c "import secrets; print(secrets.token_hex(16))")
+        export OPENACE_ENCRYPTION_KEY
+        echo "Generated OPENACE_ENCRYPTION_KEY (set OPENACE_ENCRYPTION_KEY to override)."
+    fi
+    if [ -z "$UPLOAD_AUTH_KEY" ]; then
+        UPLOAD_AUTH_KEY=$(python3 -c "import secrets; print(secrets.token_hex(16))")
+        export UPLOAD_AUTH_KEY
+        echo "Generated UPLOAD_AUTH_KEY (set UPLOAD_AUTH_KEY to override)."
+    fi
+}
+
 # Generate default config.json if not exists (one-click deploy support)
 generate_default_config() {
     CONFIG_FILE="$OPENACE_CONFIG_FILE"
@@ -220,6 +245,20 @@ generate_default_config() {
             echo "WARNING: Could not auto-detect SERVER_IP, falling back to host.docker.internal"
             SERVER_IP="host.docker.internal"
         else
+            # Validate the detected address is plausibly browser-reachable.
+            # Some runtimes (e.g. OrbStack) resolve host.docker.internal /
+            # hostname -I to a container-internal address in the 0.0.0.0/8
+            # reserved block (e.g. 0.250.250.254) that browsers cannot reach,
+            # which leaves the workspace iframe blank. Default docker-compose
+            # deployments are accessed locally, so localhost is the safe
+            # fallback. Private IPs (192.168/10.x/172.16-31.x) are legit
+            # production access addresses and are left untouched.
+            case "$SERVER_IP" in
+                0.*)
+                    echo "WARNING: detected SERVER_IP $SERVER_IP is in the reserved 0.0.0.0/8 block (unreachable from browser); using localhost"
+                    SERVER_IP="localhost"
+                    ;;
+            esac
             echo "Auto-detected SERVER_IP: $SERVER_IP"
         fi
     fi
@@ -314,6 +353,10 @@ CONFIG_EOF
     echo "Default config generated with permissions 600."
 }
 
+# Ensure security secrets exist before the app starts. Must run before
+# generate_default_config (which embeds UPLOAD_AUTH_KEY into config.json) and
+# before gunicorn (which needs SECRET_KEY / OPENACE_ENCRYPTION_KEY in env).
+ensure_secret_env
 generate_default_config
 
 # ============================================================================

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -204,22 +204,32 @@ echo "=========================================="
 ensure_secret_env() {
     local secrets_file="${OPENACE_CONFIG_DIR}/generated-secrets.env"
 
+    # NOTE on persistence location: secrets_file lives under OPENACE_CONFIG_DIR,
+    # which is also where config.json lives, so both persist together on the
+    # config-data volume. In the default (uid 1000) compose deployment that dir
+    # is /home/open-ace/.open-ace and the volume is mounted there — matches. If
+    # an operator switches to root/multi-user mode they must ensure the volume
+    # is mounted at the matching path (/root/.open-ace for root), otherwise
+    # neither config.json nor these secrets persist. See .env.example.
+
     # 1. Reload previously generated secrets (persisted across restarts), but
     #    ONLY for variables not already set in the environment — explicit env
     #    values (e.g. from .env) always take precedence. We avoid `set -a; source`
     #    because that would clobber operator-provided values. Python parses the
-    #    file (NAME='value' lines we wrote) and prints assignments only for
-    #    still-unset names.
+    #    file (NAME='value' lines we wrote), validates NAME is an identifier and
+    #    VALUE is hex (the only format we ever write), and prints assignments
+    #    only for still-unset names.
     if [ -f "$secrets_file" ]; then
         local reloaded
         reloaded=$(python3 -c "
-import os
+import os, re
 for line in open('$secrets_file'):
     line = line.strip()
     if not line or line.startswith('#') or '=' not in line:
         continue
-    name = line.split('=', 1)[0]
-    if name.isidentifier() and not os.environ.get(name):
+    name, value = line.split('=', 1)
+    # We only ever write NAME='hex' — reject anything else to avoid eval risk.
+    if name.isidentifier() and re.fullmatch(r\"'[0-9a-f]+'\", value) and not os.environ.get(name):
         print(line)
 ")
         if [ -n "$reloaded" ]; then

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -193,23 +193,77 @@ echo "=========================================="
 # Lets `docker compose up` work with zero configuration: the entrypoint fills
 # SECRET_KEY / OPENACE_ENCRYPTION_KEY / UPLOAD_AUTH_KEY so the Python app
 # (which runs as FLASK_ENV=production and strictly validates these) starts.
-# Generated values are exported into the environment the app inherits. Setting
-# any of them explicitly (e.g. via .env) is always honored.
+#
+# Persistence: generated values are written to $OPENACE_CONFIG_DIR/generated-
+# secrets.env (the config-data named volume) and re-sourced on subsequent
+# starts. This is critical because OPENACE_ENCRYPTION_KEY encrypts data that is
+# itself persisted (SMTP passwords, API keys in postgres) — a fresh random key
+# on every restart would silently make that ciphertext undecryptable. Setting
+# any secret explicitly via env (e.g. .env) always takes precedence and is
+# never overwritten.
 ensure_secret_env() {
-    if [ -z "$SECRET_KEY" ]; then
-        SECRET_KEY=$(python3 -c "import secrets; print(secrets.token_hex(32))")
-        export SECRET_KEY
-        echo "Generated SECRET_KEY (set SECRET_KEY to override)."
+    local secrets_file="${OPENACE_CONFIG_DIR}/generated-secrets.env"
+
+    # 1. Reload previously generated secrets (persisted across restarts), but
+    #    ONLY for variables not already set in the environment — explicit env
+    #    values (e.g. from .env) always take precedence. We avoid `set -a; source`
+    #    because that would clobber operator-provided values. Python parses the
+    #    file (NAME='value' lines we wrote) and prints assignments only for
+    #    still-unset names.
+    if [ -f "$secrets_file" ]; then
+        local reloaded
+        reloaded=$(python3 -c "
+import os
+for line in open('$secrets_file'):
+    line = line.strip()
+    if not line or line.startswith('#') or '=' not in line:
+        continue
+    name = line.split('=', 1)[0]
+    if name.isidentifier() and not os.environ.get(name):
+        print(line)
+")
+        if [ -n "$reloaded" ]; then
+            eval "$reloaded"
+            export SECRET_KEY OPENACE_ENCRYPTION_KEY UPLOAD_AUTH_KEY
+        fi
     fi
-    if [ -z "$OPENACE_ENCRYPTION_KEY" ]; then
-        OPENACE_ENCRYPTION_KEY=$(python3 -c "import secrets; print(secrets.token_hex(16))")
-        export OPENACE_ENCRYPTION_KEY
-        echo "Generated OPENACE_ENCRYPTION_KEY (set OPENACE_ENCRYPTION_KEY to override)."
-    fi
-    if [ -z "$UPLOAD_AUTH_KEY" ]; then
-        UPLOAD_AUTH_KEY=$(python3 -c "import secrets; print(secrets.token_hex(16))")
-        export UPLOAD_AUTH_KEY
-        echo "Generated UPLOAD_AUTH_KEY (set UPLOAD_AUTH_KEY to override)."
+
+    # 2. Generate any still-unset secret. Single python invocation generates
+    #    only the missing ones and prints NAME='value' lines for eval.
+    local generated
+    generated=$(python3 -c "
+import os, secrets
+if not os.environ.get('SECRET_KEY'):
+    print(\"SECRET_KEY='\" + secrets.token_hex(32) + \"'\")
+if not os.environ.get('OPENACE_ENCRYPTION_KEY'):
+    print(\"OPENACE_ENCRYPTION_KEY='\" + secrets.token_hex(16) + \"'\")
+if not os.environ.get('UPLOAD_AUTH_KEY'):
+    print(\"UPLOAD_AUTH_KEY='\" + secrets.token_hex(16) + \"'\")
+")
+    if [ -n "$generated" ]; then
+        eval "$generated"
+        export SECRET_KEY OPENACE_ENCRYPTION_KEY UPLOAD_AUTH_KEY
+        # Log which keys were generated (name only, never the value).
+        local line name
+        while IFS= read -r line; do
+            name="${line%%=*}"
+            echo "Generated $name (set $name env to override)."
+        done <<< "$generated"
+
+        # 3. Persist ONLY the secrets we generated this run (not values the
+        #    operator set explicitly via env — those belong in .env, not here).
+        #    Idempotent: drop any prior assignment for these names, append new.
+        local names=""
+        while IFS= read -r line; do
+            name="${line%%=*}"
+            names="${names:+$names|}$name"
+        done <<< "$generated"
+        mkdir -p "$OPENACE_CONFIG_DIR"
+        grep -vE "^($names)=" "$secrets_file" 2>/dev/null > "${secrets_file}.tmp" || true
+        printf '%s\n' "$generated" >> "${secrets_file}.tmp"
+        mv "${secrets_file}.tmp" "$secrets_file"
+        chmod 600 "$secrets_file"
+        echo "Persisted generated secrets to $secrets_file (survives restart)."
     fi
 }
 
@@ -271,9 +325,11 @@ generate_default_config() {
     # Get hostname dynamically (matches install.sh behavior)
     HOST_NAME=$(hostname -f 2>/dev/null || hostname 2>/dev/null || echo "docker-container")
 
-    # Generate random token secret and upload auth key (32 chars hex)
+    # Generate random token secret (32 chars hex). UPLOAD_AUTH_KEY is sourced
+    # from ensure_secret_env above (env or persisted file) so the value stays
+    # stable across restarts; only generate here as a last-resort fallback.
     TOKEN_SECRET=$(python3 -c "import secrets; print(secrets.token_hex(16))")
-    UPLOAD_AUTH_KEY=$(python3 -c "import secrets; print(secrets.token_hex(16))")
+    UPLOAD_AUTH_KEY="${UPLOAD_AUTH_KEY:-$(python3 -c "import secrets; print(secrets.token_hex(16))")}"
 
     # Generate default config (matches install.sh defaults)
     # Note: DATABASE_URL env var takes precedence over config file for database connection
@@ -354,8 +410,9 @@ CONFIG_EOF
 }
 
 # Ensure security secrets exist before the app starts. Must run before
-# generate_default_config (which embeds UPLOAD_AUTH_KEY into config.json) and
-# before gunicorn (which needs SECRET_KEY / OPENACE_ENCRYPTION_KEY in env).
+# generate_default_config (which reuses UPLOAD_AUTH_KEY from env when present,
+# falling back to generation only if still unset) and before gunicorn (which
+# needs SECRET_KEY / OPENACE_ENCRYPTION_KEY in env).
 ensure_secret_env
 generate_default_config
 


### PR DESCRIPTION
## 目标

让 \`git clone && cd open-ace && docker compose up -d --build\` 真正开箱即用，无需预先创建 \`.env\` 或手动生成密钥。

## 问题

1. **密钥强制报错**：\`docker-compose.yml\` 用 \`${SECRET_KEY:?}\` 等强制要求三个密钥，项目未提供 \`.env.example\`。新用户克隆后第一条命令即在 compose 解析阶段报错退出（\`SECRET_KEY must be set\`）。
2. **SERVER_IP 探测不可达**：entrypoint 的 \`hostname -I\` / \`getent host.docker.internal\` 在某些运行时（如 OrbStack）返回 \`0.0.0.0/8\` 保留段的容器内部地址（实测 \`0.250.250.254\`），浏览器不可达，工作区 iframe 空白。

## 修复

| 文件 | 改动 |
|------|------|
| \`docker-compose.yml\` | 三个密钥 \`${VAR:?}\` → \`${VAR:-}\`，软默认空值，compose 不再因缺失密钥报错。保留 \`FLASK_ENV=production\`。 |
| \`docker-entrypoint.sh\` | 新增 \`ensure_secret_env\`：启动时若密钥为空则 \`secrets.token_hex\` 生成强随机值并 \`export\`。已设值不覆盖；生成的值非 weak placeholder，production 严格校验通过。 |
| \`docker-entrypoint.sh\` | SERVER_IP 探测后加可达性校验——命中 \`0.*\` 保留段时回退 \`localhost\`。私网 IP（192.168/10.x/172.16）保留。 |
| \`.env.example\` | 新增模板，供生产环境显式配置参考（gitignore 加 \`!.env.example\` 例外）。 |
| \`README.md\` | 方式一补说明：密钥首次自动生成；生产环境改看 \`.env.example\`。 |

## 设计说明

- **密钥生成时机**：\`ensure_secret_env\` 在 \`generate_default_config\` 和 gunicorn 启动前运行。生成的值 export 到环境，gunicorn/Python 子进程继承。
- **不削弱 production 安全**：Python 端 \`security_env.py\` 在 \`FLASK_ENV=production\` 下仍严格校验密钥强度。生成的 32 字节 hex 不是 weak placeholder（\`is_weak_secret_value\` 通过），不会绕过校验。
- **SERVER_IP 兜底保守**：只拦截 \`0.0.0.0/8\`（明确异常的保留段），不误伤私网 IP。默认 docker-compose 为本地访问，\`localhost\` 是安全兜底。

## 本地验证

- ✅ 移除 \`.env\` 后 \`docker compose config\` 不再报 \"must be set\"，三个密钥解析为空串
- ✅ \`ensure_secret_env\` 空环境生成 64/32/32 位 hex，子进程可继承，已设值不覆盖
- ✅ SERVER_IP 校验：\`0.250.250.254\` → localhost；\`192.168.1.100\` / \`10.0.0.5\` / \`172.16.0.1\` / \`host.docker.internal\` 均保留
- ✅ \`bash -n docker-entrypoint.sh\` 语法检查通过

## 关联

配合 PR #1870（iframe host_url 回归修复）共同解决 docker-compose 部署的工作区空白问题。本 PR 解决「部署能否启动」，#1870 解决「启动后工作区能否显示」。

## 不在范围

- 国内 Docker Hub 基础镜像不可达（单独 PR 处理，build arg 注入 registry）
- 单用户模式 WebUI 不自启动（设计问题）