### PR TITLE
chore(build): ARG BASE_REGISTRY 支持 Docker Hub 镜像源覆盖（国内网络）

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,18 @@
 # Docker build for production deployment
 #
 # Frontend is built inside Docker (Issue #1260: one-click deploy support)
+#
+# Base image registry override (for networks where Docker Hub is unreachable,
+# e.g. mainland China). Pass at build time:
+#   docker compose build --build-arg BASE_REGISTRY=docker.m.daocloud.io
+# or export BASE_REGISTRY=docker.m.daocloud.io before `docker compose up -d --build`
+# (docker-compose.yml forwards it as a build arg). Defaults to docker.io.
+ARG BASE_REGISTRY=docker.io
 
 # =============================================================================
 # Frontend Build Stage (Issue #1260)
 # =============================================================================
-FROM node:20-alpine AS frontend-builder
+FROM ${BASE_REGISTRY}/node:20-alpine AS frontend-builder
 
 WORKDIR /app/frontend
 
@@ -28,7 +35,8 @@ RUN npm run build
 # =============================================================================
 # Python Build Stage
 # =============================================================================
-FROM python:3.11-slim AS builder
+ARG BASE_REGISTRY=docker.io
+FROM ${BASE_REGISTRY}/python:3.11-slim AS builder
 
 WORKDIR /app
 
@@ -54,7 +62,8 @@ RUN pip install --no-cache-dir --upgrade pip -i https://mirrors.aliyun.com/pypi/
 # =============================================================================
 # Production Stage
 # =============================================================================
-FROM python:3.11-slim AS production
+ARG BASE_REGISTRY=docker.io
+FROM ${BASE_REGISTRY}/python:3.11-slim AS production
 
 # Labels for container metadata
 LABEL maintainer="Open ACE Team"

--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ docker compose up -d --build
 | DaoCloud | `docker.m.daocloud.io` |
 | 1Panel | `docker.1panel.live` |
 
+> 镜像源可用性会随时间变化，表中任选一个能 pull 通即可；也可换用其他公开的 Docker Hub 镜像。
+
 > 也可在 Docker daemon 配置 `registry-mirrors`（Docker Desktop / OrbStack 的镜像加速设置），效果相同但作用于全局。
 
 ### 方式二：源码安装

--- a/README.md
+++ b/README.md
@@ -133,6 +133,24 @@ docker compose up -d --build
 
 > 💡 生产环境部署请参考 [部署指南](scripts/install-central/docker-method/README.md)
 
+#### 🇨🇳 国内网络加速
+
+若构建时拉取 Docker Hub 基础镜像（`python`、`node`、`postgres`）卡住或超时，设置 `BASE_REGISTRY` 指向国内镜像源后重新构建：
+
+```bash
+export BASE_REGISTRY=docker.m.daocloud.io
+docker compose up -d --build
+```
+
+该变量会同时作用于 Dockerfile 的基础镜像拉取和 postgres 镜像拉取。可选镜像源：
+
+| 镜像源 | 地址 |
+|--------|------|
+| DaoCloud | `docker.m.daocloud.io` |
+| 1Panel | `docker.1panel.live` |
+
+> 也可在 Docker daemon 配置 `registry-mirrors`（Docker Desktop / OrbStack 的镜像加速设置），效果相同但作用于全局。
+
 ### 方式二：源码安装
 
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,10 @@ services:
       context: .
       dockerfile: Dockerfile
       target: production
+      args:
+        # Base image registry. Override for networks where Docker Hub is
+        # unreachable (e.g. mainland China): BASE_REGISTRY=docker.m.daocloud.io
+        BASE_REGISTRY: ${BASE_REGISTRY:-docker.io}
     image: ${IMAGE_NAME:-openace/open-ace:latest}
     container_name: open-ace
     restart: unless-stopped
@@ -98,7 +102,9 @@ services:
   # PostgreSQL Database (required for production)
   # ===========================================================================
   postgres:
-    image: postgres:15-alpine
+    # Same registry override as the app build (BASE_REGISTRY). When unset this
+    # resolves to docker.io's postgres:15-alpine via the library/ auto-prefix.
+    image: ${BASE_REGISTRY:-docker.io}/postgres:15-alpine
     container_name: open-ace-postgres
     restart: unless-stopped
     environment:


### PR DESCRIPTION
## 问题

国内网络下拉取 Docker Hub 基础镜像（\`python:3.11-slim\`、\`node:20-alpine\`、\`postgres:15-alpine\`）常超时（\`auth.docker.io\` i/o timeout），导致 \`docker compose up -d --build\` 失败。

基础镜像拉取发生在**用户 Docker daemon 层**，Dockerfile 控制不了 daemon 的 \`registry-mirrors\`。但可以通过 build arg 让 \`FROM\` 指向镜像源。

## 修复

| 文件 | 改动 |
|------|------|
| \`Dockerfile\` | 顶部 \`ARG BASE_REGISTRY=docker.io\`；前 3 个真实镜像阶段 \`FROM\` 改为 \`\${BASE_REGISTRY}/<image>\`。每个阶段重新声明 ARG（Docker 跨 FROM 作用域规则）。内部 stage（\`FROM production AS development/migration\`）不变。 |
| \`docker-compose.yml\` | \`build.args\` 透传 \`BASE_REGISTRY=\${BASE_REGISTRY:-docker.io}\`；postgres image 改 \`\${BASE_REGISTRY:-docker.io}/postgres:15-alpine\`。 |
| \`README.md\` | 方式一后加"🇨🇳 国内网络加速"小节。 |

## 用法

\`\`\`bash
# 默认（走 Docker Hub 官方源）
docker compose up -d --build

# 国内加速
export BASE_REGISTRY=docker.m.daocloud.io
docker compose up -d --build
\`\`\`

该变量同时作用于 Dockerfile 基础镜像拉取和 postgres 镜像拉取，单一变量控制。

## 本地验证

- ✅ 默认：\`docker build --check\` 通过，FROM 解析为 \`docker.io/library/node:20-alpine\` 等
- ✅ mirror：\`--build-arg BASE_REGISTRY=docker.m.daocloud.io\` 解析为 \`docker.m.daocloud.io/node:20-alpine\`、\`docker.m.daocloud.io/python:3.11-slim\`
- ✅ \`docker compose config\`：默认 \`docker.io\`，设变量后正确透传到 build args 和 postgres image

## 设计说明

- **为何用 build arg 而非改 daemon**：daemon \`registry-mirrors\` 是全局设置，需要用户改 Docker Desktop/OrbStack 配置并重启。build arg 是项目层面的、可版本控制的、一次性设置，对用户侵入小。
- **Dockerfile 内部 stage 不改**：\`FROM production AS development\` 引用的是构建阶段名，不是 registry 镜像，无需前缀。
- **默认值 docker.io**：未设变量时行为与改动前完全一致（\`docker.io/node:20-alpine\` 等价于 \`node:20-alpine\`），零行为变化。

## 关联

配合 PR #1871（零配置部署）共同实现 \`git clone && docker compose up -d --build\` 的完整开箱体验。#1871 解决「能否启动」，本 PR 解决「国内网络能否构建」。