### PR TITLE
fix(autonomous): CI repair 空摘录 fingerprint 误杀 + REST API link 抓不到日志 (Issue #1855)

### DIFF
--- a/app/modules/workspace/autonomous/github_ops.py
+++ b/app/modules/workspace/autonomous/github_ops.py
@@ -901,6 +901,10 @@ class GitHubOps:
                     "state": state or "unknown",
                     "bucket": self._bucket_from_status_state(state),
                     "link": status.get("target_url") or "",
+                    # Attach head_sha so get_check_failure_excerpt can fall back
+                    # to `gh run list --commit` when the link isn't a parseable
+                    # Actions job URL (REST API returns /runs/<id>).
+                    "head_sha": head_sha,
                 }
             )
 
@@ -913,6 +917,7 @@ class GitHubOps:
                     "state": conclusion or status or "unknown",
                     "bucket": self._bucket_from_check_run(status, conclusion),
                     "link": check_run.get("html_url") or "",
+                    "head_sha": head_sha,
                 }
             )
 
@@ -982,13 +987,87 @@ class GitHubOps:
         """Remove ANSI escape sequences from GitHub Actions logs."""
         return _ANSI_ESCAPE_RE.sub("", text or "")
 
+    def _clean_log_to_excerpt(self, raw_log: str, max_lines: int, max_chars: int) -> str:
+        """Strip ANSI, keep failure-marker lines, truncate to max_chars."""
+        cleaned = self._strip_ansi(raw_log or "").strip()
+        if not cleaned:
+            return ""
+        lines = [line.rstrip() for line in cleaned.splitlines() if line.strip()]
+        if not lines:
+            return ""
+        excerpt = "\n".join(_extract_failure_lines(lines, max_lines)).strip()
+        if len(excerpt) > max_chars:
+            excerpt = excerpt[-max_chars:].lstrip()
+        return excerpt
+
+    def _fetch_log_excerpt_via_run_list(self, check: dict, max_lines: int, max_chars: int) -> str:
+        """Fallback when the check link isn't a parseable Actions job URL.
+
+        The REST API path (`_get_pr_checks_via_api`) populates `link` with the
+        check-run `html_url` (`/runs/<check_run_id>`), which does NOT carry the
+        workflow run/job ids that `gh run view --job` needs. Locate the workflow
+        run by the PR head sha + check name, then pull `--log-failed` for the
+        whole run. `gh run list/view` are core commands available on older gh
+        versions that lack `gh pr checks --json`.
+        """
+        head_sha = (check.get("head_sha") or "").strip()
+        if not head_sha:
+            return ""
+        name = str(check.get("name") or "").strip()
+
+        # Find workflow runs for this commit.
+        list_result = self._run_gh(
+            ["run", "list", "--commit", head_sha, "--json", "databaseId,name", "--limit", "30"],
+            check=False,
+        )
+        if list_result.returncode != 0:
+            logger.warning(
+                "gh run list --commit failed for check '%s' (sha=%s): %s",
+                name,
+                head_sha[:8],
+                (list_result.stderr or list_result.stdout or "").strip()[:200],
+            )
+            return ""
+        try:
+            runs = json.loads((list_result.stdout or "").strip() or "[]")
+        except json.JSONDecodeError:
+            runs = []
+        # Prefer the run whose name matches the check (Actions "lint" check ↔
+        # workflow run named "lint"); fall back to the first run if no match.
+        run_id = ""
+        for run in runs:
+            if str(run.get("name") or "").strip() == name:
+                run_id = str(run.get("databaseId") or "").strip()
+                break
+        if not run_id and runs:
+            run_id = str(runs[0].get("databaseId") or "").strip()
+        if not run_id:
+            return ""
+
+        view_result = self._run_gh(
+            ["run", "view", run_id, "--log-failed"],
+            check=False,
+        )
+        if view_result.returncode != 0:
+            logger.warning(
+                "gh run view --log-failed failed for check '%s' (run=%s): %s",
+                name,
+                run_id,
+                (view_result.stderr or view_result.stdout or "").strip()[:200],
+            )
+            return ""
+        return self._clean_log_to_excerpt(view_result.stdout or "", max_lines, max_chars)
+
     def get_check_failure_excerpt(
         self, check: dict, max_lines: int = 80, max_chars: int = 4000
     ) -> str:
         """Fetch a concise failed-log excerpt for a CI check when available.
 
-        Currently supports GitHub Actions job URLs. Non-Actions URLs return an
-        empty string so callers can degrade gracefully for other CI providers.
+        Supports GitHub Actions job URLs (`gh pr checks --json` link format).
+        When the link is a REST-API check-run URL without run/job ids, falls
+        back to locating the workflow run via `gh run list --commit <sha>`
+        (requires the check dict to carry `head_sha`). Non-Actions URLs with
+        no head_sha return an empty string so callers degrade gracefully.
 
         pre-commit / pytest / mypy output interleaves many passing hooks with a
         few failing ones; taking the last N lines can drop the actual error
@@ -997,36 +1076,27 @@ class GitHubOps:
         little context), falling back to the tail when no markers match.
         """
         parsed = self._parse_github_actions_job_url(str(check.get("link") or ""))
-        if not parsed:
-            return ""
-
-        run_id, job_id = parsed
-        result = self._run_gh(
-            ["run", "view", run_id, "--job", job_id, "--log-failed"],
-            check=False,
-        )
-        if result.returncode != 0:
-            logger.warning(
-                "Failed to fetch failed log excerpt for check '%s' (run=%s job=%s): %s",
-                check.get("name") or "unknown",
-                run_id,
-                job_id,
-                (result.stderr or result.stdout or "").strip()[:200],
+        if parsed:
+            run_id, job_id = parsed
+            result = self._run_gh(
+                ["run", "view", run_id, "--job", job_id, "--log-failed"],
+                check=False,
             )
-            return ""
+            if result.returncode != 0:
+                logger.warning(
+                    "Failed to fetch failed log excerpt for check '%s' (run=%s job=%s): %s",
+                    check.get("name") or "unknown",
+                    run_id,
+                    job_id,
+                    (result.stderr or result.stdout or "").strip()[:200],
+                )
+                return ""
+            return self._clean_log_to_excerpt(result.stdout or "", max_lines, max_chars)
 
-        cleaned = self._strip_ansi(result.stdout or "").strip()
-        if not cleaned:
-            return ""
-
-        lines = [line.rstrip() for line in cleaned.splitlines() if line.strip()]
-        if not lines:
-            return ""
-
-        excerpt = "\n".join(_extract_failure_lines(lines, max_lines)).strip()
-        if len(excerpt) > max_chars:
-            excerpt = excerpt[-max_chars:].lstrip()
-        return excerpt
+        # Fallback: link is not a parseable Actions job URL (e.g. REST-API
+        # check-run html_url "/runs/<id>"). Try to find the workflow run by
+        # the PR head sha and pull --log-failed for the whole run.
+        return self._fetch_log_excerpt_via_run_list(check, max_lines, max_chars)
 
     def get_pr_diff(self, number: int) -> str:
         """Get the full diff of a PR (head vs base) via `gh pr diff`.

--- a/app/modules/workspace/autonomous/github_ops.py
+++ b/app/modules/workspace/autonomous/github_ops.py
@@ -1009,6 +1009,19 @@ class GitHubOps:
         run by the PR head sha + check name, then pull `--log-failed` for the
         whole run. `gh run list/view` are core commands available on older gh
         versions that lack `gh pr checks --json`.
+
+        Known limitation: `gh run list --json name` returns the WORKFLOW run
+        name (the workflow YAML's top-level `name:`, defaulting to the repo
+        name), while `check.name` is the JOB name inside the workflow (e.g.
+        "lint", "test (3.9)"). For an umbrella workflow (run name "CI",
+        jobs "lint"/"test") the name match fails and we fall back to runs[0].
+        If a commit triggers multiple workflows, runs[0] may belong to a
+        different workflow and its failure log gets attributed to this check.
+        This does NOT affect the give-up guard (the fingerprint stays stable
+        across rounds — same wrong log each time), but the repair context
+        fed to the agent may be off-topic in multi-workflow repos. Single-
+        workflow repos (the common case) are unaffected. Could be tightened
+        with `--workflow` filtering if this becomes a real problem.
         """
         head_sha = (check.get("head_sha") or "").strip()
         if not head_sha:

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -706,6 +706,16 @@ MAX_TEST_RETRIES = 2  # max retries when test agent itself fails
 MAX_DEV_RETRIES_ON_TEST_FAIL = 2  # max dev round retries for unfixable test failures
 MAX_CI_REPAIR_ATTEMPTS = 3  # max automatic dev-round retries for merge-phase CI failures
 
+# Sentinel digest used by _ci_failure_fingerprint when get_check_failure_excerpt
+# returns empty (old gh CLI / token / REST-API URL-format issues). Deliberately
+# contains non-hex chars so it can never collide with a real sha256[:12].
+# The give-up guard in _start_ci_repair_round checks for this sentinel to skip
+# the "unchanged signature" misfire — a name-only fingerprint has no
+# discriminative power, so firing the guard would wrongly kill workflows whose
+# real failure did change (#1855, #1856). Shared constant so producer
+# (_ci_failure_fingerprint) and consumer (_start_ci_repair_round) can't drift.
+NO_EXCERPT_SENTINEL = "<no-excerpt>"
+
 
 def _next_phase(current_phase: str) -> str:
     """Return the phase that follows current_phase."""
@@ -1207,7 +1217,7 @@ class AutonomousOrchestrator:
                 # fingerprint can't tell whether the agent's fix changed the
                 # error set. Misfiring it would kill workflows (e.g. #1855)
                 # whose real failure did change.
-                digest = "<no-excerpt>"
+                digest = NO_EXCERPT_SENTINEL
             parts.append(f"{name}::{digest}")
         return "\n".join(sorted(parts))
 
@@ -2352,7 +2362,7 @@ class AutonomousOrchestrator:
         # here would misfire and kill workflows whose real failure did change
         # (#1855). Skip the guard in that case; the MAX_CI_REPAIR_ATTEMPTS
         # cap still bounds retries.
-        fingerprint_is_meaningful = "<no-excerpt>" not in signature
+        fingerprint_is_meaningful = NO_EXCERPT_SENTINEL not in signature
         if (
             fingerprint_is_meaningful
             and previous_signature

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -1196,7 +1196,18 @@ class AutonomousOrchestrator:
             # run/job ids) so the hash is stable across re-runs of the same
             # error but differs when the error set changes.
             normalized = self._normalize_failure_excerpt(excerpt)
-            digest = hashlib.sha256(normalized.encode()).hexdigest()[:12]
+            if normalized:
+                digest = hashlib.sha256(normalized.encode()).hexdigest()[:12]
+            else:
+                # Excerpt unavailable (old gh CLI / token / URL-format issue).
+                # Use a sentinel distinct from any real hash so the caller
+                # knows the fingerprint is name-only and should NOT trigger the
+                # "unchanged signature" give-up guard — that guard requires the
+                # fingerprint to reflect actual error lines, and a name-only
+                # fingerprint can't tell whether the agent's fix changed the
+                # error set. Misfiring it would kill workflows (e.g. #1855)
+                # whose real failure did change.
+                digest = "<no-excerpt>"
             parts.append(f"{name}::{digest}")
         return "\n".join(sorted(parts))
 
@@ -2333,8 +2344,18 @@ class AutonomousOrchestrator:
         previous_signature = (wf.get("last_ci_failure_signature") or "").strip()
         previous_head_sha = (wf.get("last_ci_failure_head_sha") or "").strip()
 
+        # The "signature unchanged → give up" guard only fires when the
+        # fingerprint reflects actual CI error lines. When the excerpt was
+        # unavailable (old gh CLI / token / URL-format issues), the fingerprint
+        # degrades to a name-only "<no-excerpt>" sentinel that can't tell
+        # whether the agent's fix changed the error set — applying the guard
+        # here would misfire and kill workflows whose real failure did change
+        # (#1855). Skip the guard in that case; the MAX_CI_REPAIR_ATTEMPTS
+        # cap still bounds retries.
+        fingerprint_is_meaningful = "<no-excerpt>" not in signature
         if (
-            previous_signature
+            fingerprint_is_meaningful
+            and previous_signature
             and signature
             and previous_signature == signature
             and previous_head_sha

--- a/tests/issues/1811/test_ci_repair_fingerprint.py
+++ b/tests/issues/1811/test_ci_repair_fingerprint.py
@@ -128,8 +128,25 @@ class TestCiFailureFingerprint:
         gh.get_check_failure_excerpt.return_value = ""
         checks = [{"name": "lint", "state": "failure", "bucket": "fail"}]
         fp = orch._ci_failure_fingerprint(gh, checks)
-        # Still has the check name, just with an empty-content hash.
-        assert "lint" in fp
+        # Still has the check name, but with an explicit sentinel (NOT the
+        # sha256("") constant) so the give-up guard can detect the fingerprint
+        # is name-only and skip the "unchanged signature" misfire (#1855).
+        assert fp == "lint::<no-excerpt>"
+
+    def test_empty_excerpt_does_not_match_real_hash(self):
+        """The <no-excerpt> sentinel must never collide with a real excerpt's
+        sha256[:12], and must differ from the old buggy empty-string hash
+        (e3b0c44298fc) so pre-fix fingerprints in the DB don't match either."""
+        import hashlib
+
+        orch = _make_orchestrator()
+        gh = MagicMock()
+        gh.get_check_failure_excerpt.return_value = ""
+        checks = [{"name": "lint", "state": "failure", "bucket": "fail"}]
+        fp = orch._ci_failure_fingerprint(gh, checks)
+        empty_string_hash = hashlib.sha256(b"").hexdigest()[:12]
+        assert empty_string_hash not in fp
+        assert "<no-excerpt>" in fp
 
     def test_path_normalization_in_fingerprint(self):
         """The fingerprint should ignore line-number/path noise so the same

--- a/tests/issues/1855/test_ci_repair_no_excerpt_no_misfire.py
+++ b/tests/issues/1855/test_ci_repair_no_excerpt_no_misfire.py
@@ -1,0 +1,199 @@
+"""Tests for CI repair no-excerpt fingerprint handling (issue #1855).
+
+When `get_check_failure_excerpt` returns empty (old gh CLI / token /
+REST-API URL-format issues), the fingerprint degrades to a name-only
+`<no-excerpt>` sentinel. The "signature unchanged → give up" guard must
+NOT fire in that case — it would misfire and kill workflows whose real
+failure did change, because a name-only fingerprint can't tell whether the
+agent's fix changed the error set. The MAX_CI_REPAIR_ATTEMPTS cap still
+bounds retries.
+
+Also covers layer-1 fix: the REST-API check-run `link` (`/runs/<id>`)
+falls back to `gh run list --commit` + `gh run view --log-failed`.
+"""
+
+from unittest.mock import MagicMock, patch
+
+
+def _make_workflow(**overrides):
+    base = {
+        "workflow_id": "wf-1855",
+        "user_id": 1,
+        "status": "merging",
+        "current_phase": "merge",
+        "ci_repair_attempts": 1,
+        "last_ci_failure_signature": "",
+        "last_ci_failure_head_sha": "",
+        "branch_name": "auto-dev/wf-1855",
+        "branch_strategy": "worktree",
+        "worktree_path": "/tmp/repo",
+        "preferred_worktree_path": "/tmp/repo",
+        "dev_round": 1,
+    }
+    base.update(overrides)
+    return base
+
+
+def _make_orchestrator(wf_data):
+    from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+    with (
+        patch("app.modules.workspace.autonomous.orchestrator.Database"),
+        patch(
+            "app.modules.workspace.autonomous.orchestrator.AutonomousWorkflowRepository"
+        ) as mock_repo_cls,
+    ):
+        mock_repo = MagicMock()
+        mock_repo.get_workflow.return_value = wf_data
+        mock_repo.list_milestones.return_value = []
+        mock_repo.create_milestone.return_value = {
+            "milestone_id": "ms-1",
+            "workflow_id": wf_data["workflow_id"],
+        }
+        mock_repo.create_event.return_value = {"id": 1}
+        mock_repo.update_workflow.return_value = wf_data
+        mock_repo_cls.return_value = mock_repo
+
+        orch = AutonomousOrchestrator(wf_data["workflow_id"])
+        orch.repo = mock_repo
+        orch.emitter = MagicMock()
+    return orch, mock_repo
+
+
+_FAILED_CHECKS = [
+    {
+        "name": "lint",
+        "state": "failure",
+        "bucket": "fail",
+        "link": "https://github.com/open-ace/open-ace/runs/123",
+    }
+]
+
+
+# ── Layer 2: empty-excerpt fingerprint does not misfire give-up guard ──
+
+
+def test_no_excerpt_does_not_give_up_even_if_head_changed():
+    """When excerpt is unavailable, the fingerprint is name-only (<no-excerpt>).
+    Even if previous_sig == sig AND head_sha changed, the give-up guard must
+    NOT fire — it cannot tell whether the agent's fix changed the error set.
+    Reproduces #1855 where lint failed, agent fixed trailing newlines, but
+    fingerprint stayed lint::<empty-hash> and the workflow was wrongly killed."""
+    wf = _make_workflow(
+        # Previous round also had no excerpt → both sigs are lint::<no-excerpt>
+        last_ci_failure_signature="lint::<no-excerpt>",
+        last_ci_failure_head_sha="sha-old",
+    )
+    orch, mock_repo = _make_orchestrator(wf)
+    gh = MagicMock()
+    gh.get_pr_head_sha.return_value = "sha-new"  # head changed (agent pushed)
+    gh.get_check_failure_excerpt.return_value = ""  # excerpt unavailable
+    gh.get_check_failure_excerpt  # explicit
+    orch._get_gh = MagicMock(return_value=gh)
+    orch._run_merge_ci_repair = MagicMock()
+
+    orch._start_ci_repair_round(wf, 1873, _FAILED_CHECKS)
+
+    # Must proceed to repair, NOT give up — guard skipped because <no-excerpt>.
+    orch._run_merge_ci_repair.assert_called_once()
+    # And the workflow stayed merging (not failed).
+    last_updates = [c.args[1] for c in mock_repo.update_workflow.call_args_list]
+    assert not any(
+        u.get("status") == "failed" for u in last_updates
+    ), "workflow wrongly failed on no-excerpt fingerprint"
+
+
+def test_meaningful_fingerprint_still_gives_up_when_unchanged():
+    """Sanity: when excerpt IS available and signature truly unchanged, the
+    guard still fires (regression guard for the layer-2 change)."""
+    from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+    excerpt = "mypy....Failed\napp/baz.py:5 error: no-any-return\n"
+    import hashlib
+
+    expected_digest = hashlib.sha256(
+        AutonomousOrchestrator._normalize_failure_excerpt(excerpt).encode()
+    ).hexdigest()[:12]
+    expected_fingerprint = f"lint::{expected_digest}"
+
+    wf = _make_workflow(
+        last_ci_failure_signature=expected_fingerprint,
+        last_ci_failure_head_sha="sha-old",
+    )
+    orch, mock_repo = _make_orchestrator(wf)
+    gh = MagicMock()
+    gh.get_pr_head_sha.return_value = "sha-new"
+    gh.get_check_failure_excerpt.return_value = excerpt
+    orch._get_gh = MagicMock(return_value=gh)
+    orch._run_merge_ci_repair = MagicMock()
+
+    orch._start_ci_repair_round(wf, 1873, _FAILED_CHECKS)
+
+    # Guard fires → no repair, workflow failed.
+    orch._run_merge_ci_repair.assert_not_called()
+    last_updates = [c.args[1] for c in mock_repo.update_workflow.call_args_list]
+    assert any(u.get("status") == "failed" for u in last_updates)
+
+
+# ── Layer 1: REST-API check-run link falls back to gh run list ─────────
+
+
+def test_get_check_failure_excerpt_falls_back_to_run_list_for_rest_api_link():
+    """When the check link is a REST-API check-run URL (/runs/<id>, not
+    /actions/runs/<run>/job/<job>), the excerpt fetch must fall back to
+    `gh run list --commit <sha>` + `gh run view --log-failed` instead of
+    returning empty."""
+    from app.modules.workspace.autonomous.github_ops import GitHubOps
+
+    gh = GitHubOps.__new__(GitHubOps)
+
+    # Simulate gh command outputs via _run_gh.
+    run_list_json = '[{"databaseId": 999, "name": "lint"}]'
+    log_failed_output = (
+        "end-of-file-fixer................................................Failed\n"
+        "- files were without new line at the end.\n"
+        "black....................................................Passed\n"
+    )
+
+    def fake_run(args, check=True, **_kw):
+        m = MagicMock()
+        if "run" in args and "list" in args:
+            m.returncode = 0
+            m.stdout = run_list_json
+            m.stderr = ""
+        elif "run" in args and "view" in args:
+            m.returncode = 0
+            m.stdout = log_failed_output
+            m.stderr = ""
+        else:
+            m.returncode = 1
+            m.stdout = ""
+            m.stderr = "unexpected"
+        return m
+
+    with patch.object(gh, "_run_gh", side_effect=fake_run):
+        excerpt = gh.get_check_failure_excerpt(
+            {
+                "name": "lint",
+                "link": "https://github.com/open-ace/open-ace/runs/12345678",
+                "head_sha": "abc123def456",
+                "bucket": "fail",
+            }
+        )
+
+    # The end-of-file-fixer failure line must be surfaced.
+    assert "end-of-file-fixer" in excerpt
+
+
+def test_get_check_failure_excerpt_run_list_fallback_returns_empty_without_head_sha():
+    """No head_sha in the check dict → can't query gh run list → return empty
+    (graceful degradation, same as pre-fix behavior for non-Actions checks)."""
+    from app.modules.workspace.autonomous.github_ops import GitHubOps
+
+    gh = GitHubOps.__new__(GitHubOps)
+    with patch.object(gh, "_run_gh") as mock_run:
+        excerpt = gh.get_check_failure_excerpt(
+            {"name": "lint", "link": "https://example.com/other-ci/42"}
+        )
+    assert excerpt == ""
+    mock_run.assert_not_called()

--- a/tests/issues/1855/test_ci_repair_no_excerpt_no_misfire.py
+++ b/tests/issues/1855/test_ci_repair_no_excerpt_no_misfire.py
@@ -197,3 +197,56 @@ def test_get_check_failure_excerpt_run_list_fallback_returns_empty_without_head_
         )
     assert excerpt == ""
     mock_run.assert_not_called()
+
+
+# ── Mixed fingerprint: some checks have real excerpt, some don't ───────
+
+
+def test_mixed_fingerprint_skips_guard_when_any_check_has_no_excerpt():
+    """When a batch has multiple failing checks and at least one's excerpt is
+    unavailable, the combined signature contains <no-excerpt> and the give-up
+    guard must skip (treat the whole signature as non-discriminative). This
+    locks the current safe behavior so a future per-check 'optimization' does
+    not reintroduce the #1855 misfire.
+
+    Scenario: check 'lint' has a real excerpt (real hash), check 'test (3.9)'
+    has no excerpt (REST-API URL issue → <no-excerpt>). Previous round had the
+    same mixed signature + head changed. Guard must NOT fire."""
+    from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+    excerpt_lint = "black....Failed\nwould reformat app/foo.py\n"
+    import hashlib
+
+    lint_digest = hashlib.sha256(
+        AutonomousOrchestrator._normalize_failure_excerpt(excerpt_lint).encode()
+    ).hexdigest()[:12]
+    # Mixed signature: lint has real hash, test (3.9) has sentinel.
+    mixed_signature = sorted([f"lint::{lint_digest}", "test (3.9)::<no-excerpt>"])
+    mixed_signature_str = "\n".join(mixed_signature)
+
+    wf = _make_workflow(
+        last_ci_failure_signature=mixed_signature_str,
+        last_ci_failure_head_sha="sha-old",
+    )
+    orch, mock_repo = _make_orchestrator(wf)
+    gh = MagicMock()
+    gh.get_pr_head_sha.return_value = "sha-new"
+    # lint gets its excerpt back; test (3.9) still gets empty.
+    gh.get_check_failure_excerpt.side_effect = lambda check: (
+        excerpt_lint if check.get("name") == "lint" else ""
+    )
+    orch._get_gh = MagicMock(return_value=gh)
+    orch._run_merge_ci_repair = MagicMock()
+
+    failed_checks = [
+        {"name": "lint", "state": "failure", "bucket": "fail"},
+        {"name": "test (3.9)", "state": "failure", "bucket": "fail"},
+    ]
+    orch._start_ci_repair_round(wf, 1875, failed_checks)
+
+    # Mixed signature → guard skipped → proceeds to repair, not failed.
+    orch._run_merge_ci_repair.assert_called_once()
+    last_updates = [c.args[1] for c in mock_repo.update_workflow.call_args_list]
+    assert not any(
+        u.get("status") == "failed" for u in last_updates
+    ), "mixed fingerprint with <no-excerpt> wrongly triggered give-up"

--- a/tests/issues/822/test_merge_conflict_detection.py
+++ b/tests/issues/822/test_merge_conflict_detection.py
@@ -321,15 +321,34 @@ class TestDoMergeDeferredRetry:
         )
 
     def test_start_ci_repair_round_fails_when_signature_repeats(self):
-        """A repeated failed-check signature should stop the auto-repair loop."""
+        """A repeated failed-check signature should stop the auto-repair loop.
+
+        Uses a real fine-grained fingerprint (name::sha256[:12] of the normalized
+        excerpt) so the give-up guard's signature comparison is meaningful. The
+        excerpt is mocked to be deterministic. Previously this test used the
+        pre-#1811 pipe format ("test (3.9)|failure|fail") which never matched
+        the new name::hash signature, so the guard never fired and the test
+        fell through to _build_ci_repair_context hitting an unmocked MagicMock.
+        """
+        import hashlib
+
+        from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+        excerpt = "FAILED tests/test_x.py::test_y - AssertionError\n"
+        expected_digest = hashlib.sha256(
+            AutonomousOrchestrator._normalize_failure_excerpt(excerpt).encode()
+        ).hexdigest()[:12]
+        expected_fingerprint = f"test (3.9)::{expected_digest}"
+
         wf = _make_workflow(
             ci_repair_attempts=1,
-            last_ci_failure_signature="test (3.9)|failure|fail",
+            last_ci_failure_signature=expected_fingerprint,
             last_ci_failure_head_sha="sha-old",
         )
         o, _ = _make_orchestrator(wf)
         mock_gh = MagicMock()
         mock_gh.get_pr_head_sha.return_value = "sha-new"
+        mock_gh.get_check_failure_excerpt.return_value = excerpt
         o._get_gh = MagicMock(return_value=mock_gh)
 
         o._start_ci_repair_round(

--- a/tests/issues/913/test_pr909_review_feedback.py
+++ b/tests/issues/913/test_pr909_review_feedback.py
@@ -86,12 +86,14 @@ class TestGetPRChecks:
                 "state": "success",
                 "bucket": "pass",
                 "link": "https://example.com/lint",
+                "head_sha": "abc123",
             },
             {
                 "name": "test",
                 "state": "failure",
                 "bucket": "fail",
                 "link": "https://example.com/test",
+                "head_sha": "abc123",
             },
         ]
 


### PR DESCRIPTION
## 背景

workflow #1855（PR #1873）在 CI repair 阶段被误杀：dev → PR review → report 都正常完成，agent 推了 lint 修复 commit（`8a7c901b`，修了 7 个脚本的末尾换行），但 workflow 还是 `failed`，错误信息 `PR #1873 CI 失败在自动修复后仍未变化: lint`。

排查发现两层根因叠加。

## 第二层（误杀，必修）：fingerprint 空摘录退化成常量

`_ci_failure_fingerprint` 对每个失败 check 算 `name::sha256(normalized_excerpt)[:12]`。当 `get_check_failure_excerpt` 抓不到日志返回空时：
- `_normalize_failure_excerpt("")` 返回 `""`
- `sha256("").hexdigest()[:12]` = 固定常量 `e3b0c44298fc`

于是所有"抓不到日志"的失败共享同一指纹 `lint::e3b0c44298fc`。agent 推了 commit、CI 重跑后还是 lint 失败（哪怕失败原因变了），fingerprint 不变 → 触发"signature 未变即放弃"误杀（`orchestrator.py:2347`）。

数据库实测确认：workflow 1855 的 `last_ci_failure_signature = lint::e3b0c44298fc`（正是 sha256("") 的前缀）。

**修复**：
- `_ci_failure_fingerprint`：空摘录用 `<no-excerpt>` 占位（区别于任何真实哈希，也不与旧的 `e3b0c44298fc` 碰撞）
- 放弃逻辑：signature 含 `<no-excerpt>` 时跳过"未变即放弃"判断（这种 fingerprint 没有鉴别力，放弃就是误杀）。`MAX_CI_REPAIR_ATTEMPTS=3` 仍兜底重试次数。

## 第一层（抓不到日志，改善）：REST API link 格式不匹配

部署机 `gh pr checks --json` 不支持（旧版 gh）→ 走 REST API fallback `_get_pr_checks_via_api`。该 fallback 用 `check_run.html_url`（格式 `/runs/<check_run_id>`）作为 link，但 `_GITHUB_ACTIONS_JOB_URL_RE` 只认 `/actions/runs/<run_id>/job/<job_id>` → 解析失败 → excerpt 返回空。

（叠加：rhuang 的 gh token 还 401 失效，但即使 token 有效，URL 格式问题依然存在。）

**修复**：
- `_get_pr_checks_via_api`：给每个 check dict 塞 `head_sha`（它本来就在调 `_get_pr_head_sha`）
- `get_check_failure_excerpt`：link 解析失败时 fallback 到 `gh run list --commit <sha> --json databaseId,name` + `gh run view <run_id> --log-failed`，绕开 URL 格式问题。`gh run list/view` 是 gh CLI 核心命令（比 `gh pr checks --json` 老），部署机已确认支持 `--commit` flag。
- 抽取 `_clean_log_to_excerpt` 复用日志清洗逻辑；新增 `_fetch_log_excerpt_via_run_list` 封装 fallback。

## 改动文件

| 文件 | 改动 |
|---|---|
| `orchestrator.py` | fingerprint `<no-excerpt>` 占位 + 放弃逻辑跳过 |
| `github_ops.py` | check dict 塞 head_sha + excerpt fallback 到 gh run list |
| `test_ci_repair_fingerprint.py` | 加强空摘录断言 + sha256("") 不碰撞 |
| `test_pr909_review_feedback.py` | 更新断言接受 head_sha 字段 |
| `test_ci_repair_no_excerpt_no_misfire.py`（新） | 4 用例：空摘录不误杀、有意义指纹仍放弃、fallback 抓到失败行、无 head_sha 优雅降级 |

## 验证

- ✅ **102 个 CI repair 相关测试全过**（含新增 6 个）
- ✅ ruff / py_compile 全过
- ⚠️ `test_start_ci_repair_round_fails_when_signature_repeats`（822）失败已用 `git stash` 确认是**预先存在的 test mock 缺陷**（clean main 同样失败），与本 PR 无关

## 不在范围

- 不修 gh token 401 失效（运维层面，需 `gh auth login`）
- 不改 `_FAILURE_LINE_RE`（pre-commit 的 end-of-file-fixer 输出能否被抓到，待第一层上线后用真实日志评估）
- 不改 `MAX_CI_REPAIR_ATTEMPTS = 3`

Closes #1855