### PR TITLE
fix(autonomous): _do_pr_review 重入时重复建 PR 导致 workflow failed (Issue #1857)

### DIFF
--- a/app/modules/workspace/autonomous/github_ops.py
+++ b/app/modules/workspace/autonomous/github_ops.py
@@ -720,6 +720,39 @@ class GitHubOps:
         )
         return json.loads(result.stdout.strip())
 
+    def find_existing_pr(self, head_branch: str) -> Optional[dict]:
+        """Find an existing open PR for a head branch.
+
+        Returns the first matching PR dict ({number, url, title, ...}) or None.
+        Used by the PR-creation path to recover gracefully when gh pr create
+        reports "already exists" (race between the github_pr_number guard and
+        the API call, or a re-entrant advance()).
+        """
+        if not head_branch:
+            return None
+        result = self._run_gh(
+            [
+                "pr",
+                "list",
+                "--head",
+                head_branch,
+                "--state",
+                "open",
+                "--json",
+                "number,url,title",
+                "--limit",
+                "1",
+            ],
+            check=False,
+        )
+        if result.returncode != 0:
+            return None
+        try:
+            prs = json.loads((result.stdout or "").strip() or "[]")
+        except json.JSONDecodeError:
+            return None
+        return prs[0] if prs else None
+
     def add_pr_comment(self, number: int, body: str) -> dict:
         """Add a comment to a PR."""
         self._run_gh(["pr", "comment", str(number), "--body", body])

--- a/app/modules/workspace/autonomous/github_ops.py
+++ b/app/modules/workspace/autonomous/github_ops.py
@@ -721,12 +721,13 @@ class GitHubOps:
         return json.loads(result.stdout.strip())
 
     def find_existing_pr(self, head_branch: str) -> Optional[dict]:
-        """Find an existing open PR for a head branch.
+        """Find an existing open PR for a head branch (scoped to base=main).
 
         Returns the first matching PR dict ({number, url, title, ...}) or None.
         Used by the PR-creation path to recover gracefully when gh pr create
         reports "already exists" (race between the github_pr_number guard and
-        the API call, or a re-entrant advance()).
+        the API call, or a re-entrant advance()). ``--base main`` avoids
+        matching PRs into other bases (fork / cross-repo).
         """
         if not head_branch:
             return None
@@ -736,6 +737,8 @@ class GitHubOps:
                 "list",
                 "--head",
                 head_branch,
+                "--base",
+                "main",
                 "--state",
                 "open",
                 "--json",

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -5138,6 +5138,15 @@ class AutonomousOrchestrator:
         # would call gh pr create again and hit "a pull request ... already
         # exists", failing the whole workflow (#1857). Checking github_pr_number
         # covers both re-entry and process-restart resume.
+        #
+        # Reads from both the passed-in wf dict AND self.workflow: self.workflow
+        # is a @property that re-queries the repo on every access, so once an
+        # earlier advance() persisted github_pr_number, a later advance()'s
+        # fallback (self.workflow.get) sees the fresh value even though the
+        # caller's wf snapshot is stale. This is what makes the guard reliable
+        # across re-entries (the test suite mocks get_workflow statically, so
+        # this property-refresh path is exercised in production but not in the
+        # PR-creation unit tests — see test_create_pr_already_exists_recovers).
         existing_pr_number = wf.get("github_pr_number") or self.workflow.get("github_pr_number")
         if round_num == 1 and not existing_pr_number:
             try:
@@ -5170,12 +5179,27 @@ class AutonomousOrchestrator:
                     }
                 )
             except GitHubOpsError as e:
-                # Graceful recovery: if gh reports a PR already exists for this
-                # branch (race between the guard above and the API call), look
-                # up the existing PR and reuse it instead of failing the
-                # workflow. Reaching here means github_pr_number wasn't set yet
-                # but the PR was created by a concurrent advance() call.
+                # Graceful recovery ONLY for the "already exists" case (race
+                # between the github_pr_number guard above and the API call, or
+                # a re-entrant advance()). Other GitHubOpsError causes (network
+                # / auth / body-too-long) must NOT be masked by reusing an
+                # unrelated leftover open PR on this branch — those still raise.
+                if "already exists" not in str(e).lower():
+                    self._create_milestone(
+                        phase="pr_review",
+                        milestone_type="pr_created",
+                        status="failed",
+                        title="PR creation failed",
+                        error_message=str(e),
+                    )
+                    raise
                 existing = gh.find_existing_pr(branch_name)
+                if not existing:
+                    # GitHub's PR list API is eventually consistent — the PR
+                    # that "already exists" may not be indexed yet right after
+                    # a concurrent create. One short retry covers that window.
+                    time.sleep(2)
+                    existing = gh.find_existing_pr(branch_name)
                 if existing:
                     pr_number = existing.get("number")
                     pr_url = existing.get("url", "")

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -5130,8 +5130,16 @@ class AutonomousOrchestrator:
                 # 推送失败必须阻止后续 PR 创建，避免 "No commits" 错误 (Issue #1736)
                 raise RuntimeError(f"Branch push failed before PR creation: {e}") from e
 
-        # Create PR on first round
-        if round_num == 1:
+        # Create PR on first round (idempotent: skip if a PR already exists for
+        # this workflow). advance() is reentrant — the scheduler may call it
+        # again while a review agent is still running and current_round hasn't
+        # been persisted yet (it's written at the end of the review round). On
+        # re-entry round_num is still 1, so without this guard the workflow
+        # would call gh pr create again and hit "a pull request ... already
+        # exists", failing the whole workflow (#1857). Checking github_pr_number
+        # covers both re-entry and process-restart resume.
+        existing_pr_number = wf.get("github_pr_number") or self.workflow.get("github_pr_number")
+        if round_num == 1 and not existing_pr_number:
             try:
                 # Build PR body with issue linkage
                 pr_body = f"Autonomous development for dev round {dev_round}.\n\nRequirements: {wf.get('requirements_text', '')}"
@@ -5162,14 +5170,44 @@ class AutonomousOrchestrator:
                     }
                 )
             except GitHubOpsError as e:
-                self._create_milestone(
-                    phase="pr_review",
-                    milestone_type="pr_created",
-                    status="failed",
-                    title="PR creation failed",
-                    error_message=str(e),
-                )
-                raise
+                # Graceful recovery: if gh reports a PR already exists for this
+                # branch (race between the guard above and the API call), look
+                # up the existing PR and reuse it instead of failing the
+                # workflow. Reaching here means github_pr_number wasn't set yet
+                # but the PR was created by a concurrent advance() call.
+                existing = gh.find_existing_pr(branch_name)
+                if existing:
+                    pr_number = existing.get("number")
+                    pr_url = existing.get("url", "")
+                    logger.warning(
+                        "PR create for %s returned 'already exists'; reusing PR #%s",
+                        branch_name,
+                        pr_number,
+                    )
+                    self._create_milestone(
+                        phase="pr_review",
+                        dev_round=dev_round,
+                        milestone_type="pr_created",
+                        status="completed",
+                        title=f"PR #{pr_number} already exists (reused)",
+                        github_pr_number=pr_number,
+                        result_summary=pr_url,
+                    )
+                    self._update_workflow(
+                        {
+                            "github_pr_number": pr_number,
+                            "github_pr_url": pr_url,
+                        }
+                    )
+                else:
+                    self._create_milestone(
+                        phase="pr_review",
+                        milestone_type="pr_created",
+                        status="failed",
+                        title="PR creation failed",
+                        error_message=str(e),
+                    )
+                    raise
 
             # Check CI status after PR creation — poll until finished or timeout
             if pr_number:

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -557,6 +557,24 @@ _REVIEW_APPROVAL_PHRASES = {
 }
 
 
+def _extract_pr_number_from_error(error_text: str) -> Optional[int]:
+    """Extract a PR number from a gh "already exists" error message.
+
+    gh's already-exists message includes the PR URL, e.g.:
+      "a pull request for branch X into branch main already exists:
+       https://github.com/owner/repo/pull/1877"
+    Parsing the /pull/<n> URL gives the PR number directly — this avoids
+    coupling recovery to the exact "already exists" wording, skips the
+    eventually-consistent find_existing_pr API call, and proves the error
+    really is the already-exists case (no URL → not recoverable here).
+    Returns the PR number or None.
+    """
+    if not error_text:
+        return None
+    m = re.search(r"/pull/(\d+)", error_text)
+    return int(m.group(1)) if m else None
+
+
 def _review_approval_phrase(content_language: Optional[str]) -> str:
     """Approval marker for PR review in the given content language."""
     return _REVIEW_APPROVAL_PHRASES.get(
@@ -5184,22 +5202,37 @@ class AutonomousOrchestrator:
                 # a re-entrant advance()). Other GitHubOpsError causes (network
                 # / auth / body-too-long) must NOT be masked by reusing an
                 # unrelated leftover open PR on this branch — those still raise.
-                if "already exists" not in str(e).lower():
-                    self._create_milestone(
-                        phase="pr_review",
-                        milestone_type="pr_created",
-                        status="failed",
-                        title="PR creation failed",
-                        error_message=str(e),
-                    )
-                    raise
-                existing = gh.find_existing_pr(branch_name)
-                if not existing:
-                    # GitHub's PR list API is eventually consistent — the PR
-                    # that "already exists" may not be indexed yet right after
-                    # a concurrent create. One short retry covers that window.
-                    time.sleep(2)
+                #
+                # Prefer parsing the PR URL out of gh's error text (gh's
+                # already-exists message includes the PR URL, e.g.
+                # "... already exists: https://github.com/o/r/pull/1877").
+                # This avoids coupling to the exact "already exists" wording
+                # AND skips the eventually-consistent find_existing_pr race
+                # AND saves an API call. find_existing_pr is the fallback when
+                # the error text has no parseable URL.
+                pr_number_reused = _extract_pr_number_from_error(str(e))
+                if pr_number_reused:
+                    existing = {"number": pr_number_reused}
+                else:
+                    # Only treat as recoverable if it really is the
+                    # already-exists case (no PR URL to prove it). Other
+                    # errors have no PR URL and fall through to raise below.
+                    if "already exists" not in str(e).lower():
+                        self._create_milestone(
+                            phase="pr_review",
+                            milestone_type="pr_created",
+                            status="failed",
+                            title="PR creation failed",
+                            error_message=str(e),
+                        )
+                        raise
                     existing = gh.find_existing_pr(branch_name)
+                    if not existing:
+                        # GitHub's PR list API is eventually consistent — the
+                        # PR that "already exists" may not be indexed yet right
+                        # after a concurrent create. One short retry covers it.
+                        time.sleep(2)
+                        existing = gh.find_existing_pr(branch_name)
                 if existing:
                     pr_number = existing.get("number")
                     pr_url = existing.get("url", "")

--- a/tests/issues/1857/test_pr_review_duplicate_create.py
+++ b/tests/issues/1857/test_pr_review_duplicate_create.py
@@ -136,13 +136,15 @@ def test_re_entry_skips_create_pr_when_pr_already_exists():
     gh.find_existing_pr.assert_not_called()
 
 
-# ── Layer 2: recover via find_existing_pr when 'already exists' slips through ─
+# ── Layer 2: recover when 'already exists' slips through the guard ─────
 
 
-def test_create_pr_already_exists_recovers_via_find_existing_pr():
-    """If gh pr create returns 'already exists' (race past the guard),
-    find_existing_pr must locate and reuse the existing PR instead of
-    failing the workflow."""
+def test_create_pr_already_exists_recovers_by_parsing_pr_url_from_error():
+    """When gh pr create returns 'already exists' with a PR URL in the error
+    text, the PR number is parsed directly from the URL (no find_existing_pr
+    API call needed). This is the preferred path — it avoids the eventually-
+    consistent find_existing_pr race AND avoids coupling to the 'already
+    exists' wording."""
     wf = _make_workflow(current_round=0, github_pr_number=None)
     orch, mock_repo = _make_orchestrator(wf)
     gh = _make_gh_with_changes()
@@ -151,6 +153,33 @@ def test_create_pr_already_exists_recovers_via_find_existing_pr():
         'into branch "main" already exists: '
         "https://github.com/open-ace/open-ace/pull/1877"
     )
+    orch._get_gh = MagicMock(return_value=gh)
+    orch._run_agent = MagicMock(side_effect=RuntimeError("stop-after-pr-block"))
+
+    try:
+        orch._do_pr_review(wf)
+    except RuntimeError:
+        pass
+
+    # Recovery: PR number parsed from the URL in the error text.
+    updates = [c.args[1] for c in mock_repo.update_workflow.call_args_list]
+    pr_updates = [u for u in updates if u.get("github_pr_number") == 1877]
+    assert pr_updates, "PR number not parsed from error URL and persisted"
+    # find_existing_pr is the FALLBACK — must NOT be called when the URL was
+    # parseable.
+    gh.find_existing_pr.assert_not_called()
+    assert not any(
+        u.get("status") == "failed" for u in updates
+    ), "workflow wrongly failed on 'already exists' instead of recovering"
+
+
+def test_create_pr_already_exists_falls_back_to_find_existing_pr_without_url():
+    """When the 'already exists' error has NO parseable PR URL (older gh / GHES
+    / truncated message), recovery falls back to find_existing_pr."""
+    wf = _make_workflow(current_round=0, github_pr_number=None)
+    orch, mock_repo = _make_orchestrator(wf)
+    gh = _make_gh_with_changes()
+    gh.create_pr.side_effect = GitHubOpsError("a pull request for this branch already exists")
     gh.find_existing_pr.return_value = {
         "number": 1877,
         "url": "https://github.com/open-ace/open-ace/pull/1877",
@@ -164,14 +193,79 @@ def test_create_pr_already_exists_recovers_via_find_existing_pr():
     except RuntimeError:
         pass
 
-    # Recovery happened: workflow updated with the reused PR number.
+    gh.find_existing_pr.assert_called_once_with("auto-dev/wf-1857")
     updates = [c.args[1] for c in mock_repo.update_workflow.call_args_list]
-    pr_updates = [u for u in updates if u.get("github_pr_number") == 1877]
-    assert pr_updates, "reused PR number not persisted to workflow"
-    # And the workflow was NOT failed by the GitHubOpsError.
-    assert not any(
-        u.get("status") == "failed" for u in updates
-    ), "workflow wrongly failed on 'already exists' instead of recovering"
+    assert any(u.get("github_pr_number") == 1877 for u in updates)
+
+
+def test_create_pr_already_exists_retries_find_when_first_returns_none():
+    """When the 'already exists' error has no URL AND find_existing_pr returns
+    None the first time (GitHub eventual consistency), recovery retries once
+    after a short sleep and reuses the PR found on retry."""
+    wf = _make_workflow(current_round=0, github_pr_number=None)
+    orch, mock_repo = _make_orchestrator(wf)
+    gh = _make_gh_with_changes()
+    gh.create_pr.side_effect = GitHubOpsError("a pull request for this branch already exists")
+    # First lookup None (not indexed yet), second lookup hits.
+    gh.find_existing_pr.side_effect = [
+        None,
+        {"number": 1877, "url": "https://github.com/open-ace/open-ace/pull/1877"},
+    ]
+    orch._get_gh = MagicMock(return_value=gh)
+    orch._run_agent = MagicMock(side_effect=RuntimeError("stop-after-pr-block"))
+
+    # Patch sleep so the test doesn't actually wait.
+    with patch("app.modules.workspace.autonomous.orchestrator.time.sleep") as mock_sleep:
+        try:
+            orch._do_pr_review(wf)
+        except RuntimeError:
+            pass
+
+    assert gh.find_existing_pr.call_count == 2
+    mock_sleep.assert_called_once_with(2)
+    updates = [c.args[1] for c in mock_repo.update_workflow.call_args_list]
+    assert any(u.get("github_pr_number") == 1877 for u in updates)
+
+
+def test_create_pr_already_exists_fails_when_retry_still_finds_nothing():
+    """When the 'already exists' error has no URL AND find_existing_pr returns
+    None even after the retry, the workflow must fail (can't recover)."""
+    wf = _make_workflow(current_round=0, github_pr_number=None)
+    orch, mock_repo = _make_orchestrator(wf)
+    gh = _make_gh_with_changes()
+    gh.create_pr.side_effect = GitHubOpsError("a pull request for this branch already exists")
+    gh.find_existing_pr.return_value = None  # both attempts
+    orch._get_gh = MagicMock(return_value=gh)
+
+    with patch("app.modules.workspace.autonomous.orchestrator.time.sleep"):
+        raised = False
+        try:
+            orch._do_pr_review(wf)
+        except GitHubOpsError:
+            raised = True
+
+    assert raised, "should fail when recovery can't locate the existing PR"
+    assert gh.find_existing_pr.call_count == 2
+
+
+# ── _extract_pr_number_from_error unit tests ────────────────────────────
+
+
+def test_extract_pr_number_from_error_parses_url():
+    from app.modules.workspace.autonomous.orchestrator import _extract_pr_number_from_error
+
+    err = (
+        'a pull request for branch "x" into branch "main" already exists: '
+        "https://github.com/open-ace/open-ace/pull/1877"
+    )
+    assert _extract_pr_number_from_error(err) == 1877
+
+
+def test_extract_pr_number_from_error_returns_none_without_url():
+    from app.modules.workspace.autonomous.orchestrator import _extract_pr_number_from_error
+
+    assert _extract_pr_number_from_error("network unreachable") is None
+    assert _extract_pr_number_from_error("") is None
 
 
 def test_create_pr_unrecoverable_error_still_fails():

--- a/tests/issues/1857/test_pr_review_duplicate_create.py
+++ b/tests/issues/1857/test_pr_review_duplicate_create.py
@@ -1,0 +1,233 @@
+"""Tests for idempotent PR creation in _do_pr_review (Issue #1857).
+
+advance() is reentrant — the scheduler may call it again while a PR-review
+agent is still running and current_round hasn't been persisted yet (it's
+written at the end of the review round, orchestrator.py ~5293). On re-entry
+round_num is still 1, so the old code called gh pr create again and hit
+"a pull request ... already exists", failing the whole workflow.
+
+Fix: skip create_pr when github_pr_number is already set, and recover
+gracefully (reuse the existing PR) if gh reports "already exists" anyway.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from app.modules.workspace.autonomous.github_ops import GitHubOps, GitHubOpsError
+
+
+def _make_workflow(**overrides):
+    base = {
+        "workflow_id": "wf-1857",
+        "user_id": 1,
+        "title": "issue-1857",
+        "status": "pr_review",
+        "current_phase": "pr_review",
+        "requirements_text": "Fix encryption doc/code mismatch",
+        "requirements_issue_url": "",
+        "project_path": "/tmp/repo",
+        "project_repo_url": "",
+        "is_new_project": False,
+        "cli_tool": "claude-code",
+        "model": "glm-5",
+        "permission_mode": "auto-edit",
+        "branch_name": "auto-dev/wf-1857",
+        "branch_strategy": "worktree",
+        "workspace_type": "local",
+        "remote_machine_id": "",
+        "worktree_path": "/tmp/repo",
+        "preferred_worktree_path": "/tmp/repo",
+        "github_issue_number": 1857,
+        "github_pr_number": None,
+        "github_pr_url": "",
+        "current_round": 0,
+        "dev_round": 1,
+        "max_plan_rounds": 2,
+        "max_pr_review_rounds": 3,
+        "require_full_review_rounds": False,
+        "content_language": "zh",
+    }
+    base.update(overrides)
+    return base
+
+
+def _make_orchestrator(wf_data):
+    from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+    with (
+        patch("app.modules.workspace.autonomous.orchestrator.Database"),
+        patch(
+            "app.modules.workspace.autonomous.orchestrator.AutonomousWorkflowRepository"
+        ) as mock_repo_cls,
+    ):
+        mock_repo = MagicMock()
+        mock_repo.get_workflow.return_value = wf_data
+        mock_repo.list_milestones.return_value = []
+        mock_repo.create_milestone.return_value = {
+            "milestone_id": "ms-1",
+            "workflow_id": wf_data["workflow_id"],
+        }
+        mock_repo.create_event.return_value = {"id": 1}
+        mock_repo.update_workflow.return_value = wf_data
+        mock_repo_cls.return_value = mock_repo
+
+        orch = AutonomousOrchestrator(wf_data["workflow_id"])
+        orch.repo = mock_repo
+        orch.emitter = MagicMock()
+    return orch, mock_repo
+
+
+def _make_gh_with_changes():
+    """A gh mock where the branch has changes vs main (so PR creation proceeds).
+
+    _do_pr_review checks: rev-parse branch/main (distinct shas), merge-base
+    --is-ancestor (returncode 1 = NOT ancestor, so has_changes path runs),
+    get_diff_stats (commits>0)."""
+    gh = MagicMock()
+
+    def run_git(args, **kw):
+        # rev-parse branch_name → branch sha
+        if args[:2] == ["rev-parse", "auto-dev/wf-1857"]:
+            return MagicMock(stdout="branch-sha-abc\n", returncode=0)
+        # rev-parse main → main sha (different)
+        if args[:2] == ["rev-parse", "main"]:
+            return MagicMock(stdout="main-sha-xyz\n", returncode=0)
+        # merge-base --is-ancestor branch main → NOT ancestor (returncode 1)
+        if args[:1] == ["merge-base"]:
+            return MagicMock(stdout="", returncode=1)
+        return MagicMock(stdout="", returncode=0)
+
+    gh._run_git.side_effect = run_git
+    gh.get_diff_stats.return_value = {"commits": 1, "additions": 5, "deletions": 1}
+    gh.get_current_branch.return_value = "auto-dev/wf-1857"
+    gh.git_push.return_value = None
+    gh.get_diff.return_value = "diff --git a/app/x.py b/app/x.py\n+new line"
+    gh.get_pr_checks.return_value = []  # no CI fails for simplicity
+    gh.get_pr_head_sha.return_value = "head-sha-123"
+    gh.get_pr.return_value = {"number": 1877, "url": "https://x/pull/1877"}
+    return gh
+
+
+# ── Layer 1: skip create_pr when github_pr_number already set ──────────
+
+
+def test_re_entry_skips_create_pr_when_pr_already_exists():
+    """When advance() re-enters _do_pr_review with round_num=1 but the PR was
+    already created (github_pr_number set), create_pr must NOT be called again.
+    Reproduces #1857 where the re-entry hit 'already exists' and failed."""
+    wf = _make_workflow(
+        current_round=0,  # not yet persisted → round_num computes to 1
+        github_pr_number=1877,  # PR already created by the first entry
+        github_pr_url="https://github.com/open-ace/open-ace/pull/1877",
+    )
+    orch, mock_repo = _make_orchestrator(wf)
+    gh = _make_gh_with_changes()
+    orch._get_gh = MagicMock(return_value=gh)
+    # Short-circuit the review agent + downstream — we only care that
+    # create_pr isn't called. Raise to stop execution after the PR-creation
+    # block; the assertion is on gh.create_pr before that point.
+    orch._run_agent = MagicMock(side_effect=RuntimeError("stop-after-pr-block"))
+
+    try:
+        orch._do_pr_review(wf)
+    except RuntimeError:
+        pass
+
+    gh.create_pr.assert_not_called()
+    gh.find_existing_pr.assert_not_called()
+
+
+# ── Layer 2: recover via find_existing_pr when 'already exists' slips through ─
+
+
+def test_create_pr_already_exists_recovers_via_find_existing_pr():
+    """If gh pr create returns 'already exists' (race past the guard),
+    find_existing_pr must locate and reuse the existing PR instead of
+    failing the workflow."""
+    wf = _make_workflow(current_round=0, github_pr_number=None)
+    orch, mock_repo = _make_orchestrator(wf)
+    gh = _make_gh_with_changes()
+    gh.create_pr.side_effect = GitHubOpsError(
+        'gh pr create failed: a pull request for branch "auto-dev/wf-1857" '
+        'into branch "main" already exists: '
+        "https://github.com/open-ace/open-ace/pull/1877"
+    )
+    gh.find_existing_pr.return_value = {
+        "number": 1877,
+        "url": "https://github.com/open-ace/open-ace/pull/1877",
+        "title": "[Auto] Dev round 1",
+    }
+    orch._get_gh = MagicMock(return_value=gh)
+    orch._run_agent = MagicMock(side_effect=RuntimeError("stop-after-pr-block"))
+
+    try:
+        orch._do_pr_review(wf)
+    except RuntimeError:
+        pass
+
+    # Recovery happened: workflow updated with the reused PR number.
+    updates = [c.args[1] for c in mock_repo.update_workflow.call_args_list]
+    pr_updates = [u for u in updates if u.get("github_pr_number") == 1877]
+    assert pr_updates, "reused PR number not persisted to workflow"
+    # And the workflow was NOT failed by the GitHubOpsError.
+    assert not any(
+        u.get("status") == "failed" for u in updates
+    ), "workflow wrongly failed on 'already exists' instead of recovering"
+
+
+def test_create_pr_unrecoverable_error_still_fails():
+    """If gh pr create fails for a reason OTHER than 'already exists'
+    (and find_existing_pr finds nothing), the workflow must still fail —
+    don't mask real errors with the recovery path."""
+    wf = _make_workflow(current_round=0, github_pr_number=None)
+    orch, mock_repo = _make_orchestrator(wf)
+    gh = _make_gh_with_changes()
+    gh.create_pr.side_effect = GitHubOpsError("network unreachable")
+    gh.find_existing_pr.return_value = None
+    orch._get_gh = MagicMock(return_value=gh)
+
+    raised = False
+    try:
+        orch._do_pr_review(wf)
+    except GitHubOpsError:
+        raised = True
+
+    assert raised, "non-'already exists' error should propagate, not be masked"
+    # A failed pr_created milestone should have been recorded.
+    milestone_create_calls = mock_repo.create_milestone.call_args_list
+    failed_milestones = [
+        c
+        for c in milestone_create_calls
+        if c.args
+        and isinstance(c.args[0], dict)
+        and c.args[0].get("status") == "failed"
+        and c.args[0].get("milestone_type") == "pr_created"
+    ]
+    assert failed_milestones, "no failed pr_created milestone recorded"
+
+
+# ── GitHubOps.find_existing_pr unit tests ───────────────────────────────
+
+
+def test_find_existing_pr_returns_pr_for_branch():
+    gh = GitHubOps.__new__(GitHubOps)
+    pr_list_json = '[{"number": 1877, "url": "https://x/pull/1877", "title": "t"}]'
+    with patch.object(gh, "_run_gh") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout=pr_list_json, stderr="")
+        result = gh.find_existing_pr("auto-dev/wf-1857")
+    assert result == {"number": 1877, "url": "https://x/pull/1877", "title": "t"}
+
+
+def test_find_existing_pr_returns_none_when_no_pr():
+    gh = GitHubOps.__new__(GitHubOps)
+    with patch.object(gh, "_run_gh") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout="[]", stderr="")
+        result = gh.find_existing_pr("auto-dev/wf-1857")
+    assert result is None
+
+
+def test_find_existing_pr_empty_branch_returns_none():
+    gh = GitHubOps.__new__(GitHubOps)
+    with patch.object(gh, "_run_gh") as mock_run:
+        result = gh.find_existing_pr("")
+    assert result is None
+    mock_run.assert_not_called()


### PR DESCRIPTION
## 背景

workflow #1857（PR #1877）在 pr_review 阶段 failed，错误信息：
```
gh pr create ... failed: a pull request for branch "auto-dev/a44c2e84" into branch "main" already exists: #1877
```

但 PR #1877 **明明已经创建成功了**（timeline 有 "PR #1877 created" completed milestone）。为什么又调了一次 gh pr create？

## 根因：advance() 可重入 + current_round 延迟持久化

`_do_pr_review`（`orchestrator.py:4983`）开头算 `round_num = current_round + 1`。`current_round` **直到 review round 跑完才持久化**（`orchestrator.py:5293`）。

PR review agent 是长任务（跑几十秒到几分钟）。这期间 scheduler 可能再次调用 `advance()`（workflow 还是 `status=pr_review`、`current_round=0`、`current_phase=pr_review`）。重入时：
- `round_num = 0 + 1 = 1`（还是 1）
- 走到 `if round_num == 1: create_pr`（行 5103）
- **不看 PR 是否已存在**就再调 `gh pr create`
- 撞 "already exists" → GitHubOpsError 冒泡到 advance 顶层 except → workflow 标 failed

同时第一个 review round 1 milestone 停在 `in_progress`（僵尸 milestone）。

触发条件：batch 多 workflow 共享 worker 时，一个 workflow 的 review agent 长跑，scheduler 对它的 advance 重入。#1857 是 batch 7/8，正好踩中。

## 修复（两层防御）

**1. 建 PR 前检查 github_pr_number**（主防御）：
```python
existing_pr_number = wf.get("github_pr_number") or self.workflow.get("github_pr_number")
if round_num == 1 and not existing_pr_number:
    # ... create_pr ...
```
重入时已有 PR 号直接跳过 create_pr。

**2. "already exists" 时用 find_existing_pr 恢复**（竞态兜底）：
即使检查遗漏（guard 和 API 调用间的竞态），`create_pr` 撞 "already exists" 时，用新方法 `find_existing_pr(head_branch)` 查已有 PR 并复用，而非 fail workflow：
```python
except GitHubOpsError as e:
    existing = gh.find_existing_pr(branch_name)
    if existing:
        # reuse, persist github_pr_number, log warning
    else:
        # real failure → failed milestone + raise
```

**3. 新增 GitHubOps.find_existing_pr**：`gh pr list --head <branch> --state open --json number,url,title --limit 1` 查分支上已有的 open PR。

## 测试（6 个，全过）

- `test_re_entry_skips_create_pr_when_pr_already_exists`：重入时 github_pr_number 已存在 → create_pr 不被调用
- `test_create_pr_already_exists_recovers_via_find_existing_pr`：create_pr 撞 already exists → find_existing_pr 恢复、复用 PR、workflow 不 fail
- `test_create_pr_unrecoverable_error_still_fails`：非 already exists 的真错误 → 仍正确 fail + 记 failed milestone（不掩盖真错误）
- `find_existing_pr` 三个单元测试：有 PR / 无 PR / 空 branch 优雅返回 None

## 验证

- ✅ 45 个 pr_review 相关测试全过（含新增 6 个）
- ✅ ruff / py_compile 全干净

## 关于僵尸 milestone

重入时第一个 review round milestone 留在 in_progress——这是 advance 缺乏 in-progress 幂等检查的副作用。本 PR 的主防御（跳过重复 create_pr）消除了重入导致的 failed，间接也避免了重复 review milestone。完整的 advance 幂等性是更大的改动，不在本 PR 范围。

Closes #1857