### PR TITLE
fix(work): 非回环地址访问工作区新建会话报 NetworkError / FORBIDDEN (#1883)

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -12,7 +12,7 @@ import re
 import uuid
 from urllib.parse import urlparse
 
-from flask import Flask, g, jsonify, request
+from flask import Flask, g, has_request_context, jsonify, request
 from werkzeug.exceptions import HTTPException
 from werkzeug.middleware.proxy_fix import ProxyFix
 
@@ -167,11 +167,15 @@ def _is_allowed_local_webui_origin(origin: str) -> bool:
     # origin does not open a credential-reuse vector for arbitrary third
     # parties (they would have to control a webui port on the same host the
     # victim is browsing).
+    #
+    # Parse the Host header via ``urlparse("//" + host)`` so IPv6 literals
+    # (e.g. ``[2001:db8::1]:5000``) are normalized to the bare address
+    # (``2001:db8::1``), matching ``parsed.hostname``. A naive
+    # ``host.split(":", 1)[0]`` would yield ``"[2001"`` for IPv6 and silently
+    # fail closed. (Issue #1859 review follow-up.)
     try:
-        from flask import has_request_context, request
-
         if has_request_context():
-            host_header = (request.host or "").split(":", 1)[0].lower()
+            host_header = (urlparse(f"//{request.host or ''}").hostname or "").lower()
             if host_header and parsed.hostname == host_header:
                 return True
     except Exception:

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -131,7 +131,18 @@ def _reset_cors_origins_cache():
 
 
 def _is_allowed_local_webui_origin(origin: str) -> bool:
-    """Allow only loopback WebUI origins in the dev port range."""
+    """Allow WebUI origins in the dev port range when loopback or same-host.
+
+    Loopback hostnames (``localhost``/``127.0.0.1``/``::1``) are always
+    allowed on the webui port range 3100-3200. Non-loopback hostnames are
+    allowed only when they match the hostname the browser used to reach the
+    backend (taken from the current request's ``Host`` header). This covers
+    LAN IP / container-hostname access where the per-user qwen-code-webui
+    iframe is served on a webui port using the same hostname the browser used
+    to reach the backend. Without this, Firefox blocks the iframe's
+    credentialed API calls with "NetworkError when attempting to fetch
+    resource." (Issue #1859)
+    """
     try:
         parsed = urlparse(origin)
     except Exception:
@@ -140,13 +151,33 @@ def _is_allowed_local_webui_origin(origin: str) -> bool:
     if parsed.scheme not in ("http", "https"):
         return False
 
-    if parsed.hostname not in _LOCAL_CORS_HOSTS:
-        return False
-
     if parsed.port is None:
         return False
 
-    return 3100 <= parsed.port <= 3200
+    if not (3100 <= parsed.port <= 3200):
+        return False
+
+    if parsed.hostname in _LOCAL_CORS_HOSTS:
+        return True
+
+    # Allow the server's own hostname (e.g. LAN IP / container hostname) so
+    # that browsers reaching the backend via a non-loopback address can still
+    # load the per-user qwen-code-webui iframe on a webui port. The Host
+    # header reflects the address the browser itself used, so reflecting this
+    # origin does not open a credential-reuse vector for arbitrary third
+    # parties (they would have to control a webui port on the same host the
+    # victim is browsing).
+    try:
+        from flask import has_request_context, request
+
+        if has_request_context():
+            host_header = (request.host or "").split(":", 1)[0].lower()
+            if host_header and parsed.hostname == host_header:
+                return True
+    except Exception:
+        pass
+
+    return False
 
 
 def _is_allowed_cors_origin(origin: str) -> bool:

--- a/app/routes/projects.py
+++ b/app/routes/projects.py
@@ -93,7 +93,16 @@ def _require_tenant_scope():
     project repository treats it as a wildcard/global filter, leaking
     cross-tenant projects to a no-tenant non-admin. Admins keep global
     scope; tenant-scoped non-admins keep their tenant.
+
+    The list endpoint ``GET /api/projects`` is exempted so a no-tenant
+    non-admin still receives an empty list (rather than a 403) — this
+    unblocks the qwen-code-webui new-session picker, which otherwise
+    surfaces "Failed to fetch projects: FORBIDDEN". The handler itself
+    returns an empty result without touching the repository when the
+    tenant scope is missing, so no wildcard leak occurs (Issue #1859).
     """
+    if request.endpoint == "projects.api_get_projects" and request.method == "GET":
+        return None
     _, error = require_tenant_scope()
     if error is not None:
         return error
@@ -128,6 +137,18 @@ def api_get_projects():
     """Get projects accessible by current user."""
     user_id = g.user_id
     tenant_id = _current_tenant_id()
+
+    # Non-admin without a tenant has no accessible projects — return an
+    # empty list instead of falling through to the repository with
+    # ``tenant_id=None`` (which is treated as a wildcard and would leak
+    # cross-tenant data). The before_request gate exempts this route from
+    # the 403 so the qwen-code-webui project picker still renders.
+    # Admins keep their global scope when their own tenant_id is unset.
+    # (Issue #1859)
+    if tenant_id is None:
+        user = getattr(g, "user", None) or {}
+        if user.get("role") != "admin":
+            return jsonify({"success": True, "projects": []})
 
     # Get user's projects
     projects = project_repo.get_user_projects(user_id, tenant_id=tenant_id)

--- a/tests/issues/1746/test_ws_frame_cors_guards.py
+++ b/tests/issues/1746/test_ws_frame_cors_guards.py
@@ -145,22 +145,46 @@ class TestCorsPolicy:
         """Issue #1859: LAN IP access must allow the WebUI iframe origin.
 
         When the browser reaches the backend via a non-loopback address (e.g.
-        ``http://192.168.1.237:5000``), the per-user qwen-code-webui iframe
+        ``http://198.51.100.1:5000``), the per-user qwen-code-webui iframe
         is served on a webui port using the same hostname
-        (``http://192.168.1.237:3101``). The backend must emit CORS headers
+        (``http://198.51.100.1:3101``). The backend must emit CORS headers
         for that origin so the iframe's credentialed API calls are not blocked
         by the browser ("NetworkError when attempting to fetch resource.").
+
+        Uses RFC 5737 TEST-NET-2 documentation address to avoid embedding
+        real infrastructure IPs in the repo.
         """
         client = cors_app.test_client()
 
         resp = client.get(
             "/api/ping",
-            headers={"Origin": "http://192.168.1.237:3101"},
-            base_url="http://192.168.1.237:5000",
+            headers={"Origin": "http://198.51.100.1:3101"},
+            base_url="http://198.51.100.1:5000",
         )
 
         assert resp.status_code == 200
-        assert resp.headers["Access-Control-Allow-Origin"] == "http://192.168.1.237:3101"
+        assert resp.headers["Access-Control-Allow-Origin"] == "http://198.51.100.1:3101"
+        assert resp.headers["Access-Control-Allow-Credentials"] == "true"
+
+    def test_same_host_ipv6_webui_origin_is_allowed(self, cors_app):
+        """Issue #1859 review follow-up: IPv6 same-host access must work.
+
+        ``Host: [2001:db8::1]:5000`` must be parsed to ``2001:db8::1`` and
+        match the origin hostname from ``http://[2001:db8::1]:3101``. A naive
+        ``host.split(":", 1)[0]`` would yield ``"[2001"`` and fail closed.
+
+        Uses RFC 3849 documentation IPv6 prefix ``2001:db8::/32``.
+        """
+        client = cors_app.test_client()
+
+        resp = client.get(
+            "/api/ping",
+            headers={"Origin": "http://[2001:db8::1]:3101"},
+            base_url="http://[2001:db8::1]:5000",
+        )
+
+        assert resp.status_code == 200
+        assert resp.headers["Access-Control-Allow-Origin"] == "http://[2001:db8::1]:3101"
         assert resp.headers["Access-Control-Allow-Credentials"] == "true"
 
     def test_mismatched_host_webui_origin_is_not_reflected(self, cors_app):
@@ -172,7 +196,7 @@ class TestCorsPolicy:
         resp = client.get(
             "/api/ping",
             headers={"Origin": "http://evil.example:3101"},
-            base_url="http://192.168.1.237:5000",
+            base_url="http://198.51.100.1:5000",
         )
 
         assert resp.status_code == 200

--- a/tests/issues/1746/test_ws_frame_cors_guards.py
+++ b/tests/issues/1746/test_ws_frame_cors_guards.py
@@ -141,6 +141,44 @@ class TestCorsPolicy:
         assert "Access-Control-Allow-Origin" not in resp.headers
         assert "Access-Control-Allow-Credentials" not in resp.headers
 
+    def test_same_host_lan_ip_webui_origin_is_allowed(self, cors_app):
+        """Issue #1859: LAN IP access must allow the WebUI iframe origin.
+
+        When the browser reaches the backend via a non-loopback address (e.g.
+        ``http://192.168.1.237:5000``), the per-user qwen-code-webui iframe
+        is served on a webui port using the same hostname
+        (``http://192.168.1.237:3101``). The backend must emit CORS headers
+        for that origin so the iframe's credentialed API calls are not blocked
+        by the browser ("NetworkError when attempting to fetch resource.").
+        """
+        client = cors_app.test_client()
+
+        resp = client.get(
+            "/api/ping",
+            headers={"Origin": "http://192.168.1.237:3101"},
+            base_url="http://192.168.1.237:5000",
+        )
+
+        assert resp.status_code == 200
+        assert resp.headers["Access-Control-Allow-Origin"] == "http://192.168.1.237:3101"
+        assert resp.headers["Access-Control-Allow-Credentials"] == "true"
+
+    def test_mismatched_host_webui_origin_is_not_reflected(self, cors_app):
+        """Issue #1859: a WebUI origin whose host differs from the backend
+        Host header must still be rejected to prevent credential reflection
+        onto an attacker-controlled host."""
+        client = cors_app.test_client()
+
+        resp = client.get(
+            "/api/ping",
+            headers={"Origin": "http://evil.example:3101"},
+            base_url="http://192.168.1.237:5000",
+        )
+
+        assert resp.status_code == 200
+        assert "Access-Control-Allow-Origin" not in resp.headers
+        assert "Access-Control-Allow-Credentials" not in resp.headers
+
     def test_preflight_honors_explicit_allowlist(self, monkeypatch, request):
         # Use monkeypatch to set env - this happens AFTER autouse fixture clears it
         # Create a fresh app for this test to avoid state pollution

--- a/tests/issues/1775/test_route_tenant_fail_closed.py
+++ b/tests/issues/1775/test_route_tenant_fail_closed.py
@@ -182,10 +182,20 @@ class TestRouteTenantFailClosed(unittest.TestCase):
     def test_projects_notenant_non_admin_leaks_no_cross_tenant_rows(self):
         # Seed a project owned by tenant_user (tenant 7) and verify the
         # no-tenant non-admin (user 11) cannot see it via GET /api/projects.
+        #
+        # Isolation: snapshot existing projects rows, truncate, seed our
+        # fixture, then restore the snapshot in ``finally`` so the test does
+        # not pollute sibling tests that may rely on a pre-seeded table
+        # (Issue #1859 review follow-up).
         import app.routes.projects as projects_mod
 
-        with projects_mod.project_repo.db.get_connection() as conn:
+        db = projects_mod.project_repo.db
+        with db.get_connection() as conn:
             cursor = conn.cursor()
+            snapshot = cursor.execute("SELECT * FROM projects").fetchall()
+            cols = (
+                [d[0] for d in cursor.description] if cursor.description else []
+            )
             cursor.execute("DELETE FROM projects")
             cursor.execute(
                 "INSERT INTO projects (path, name, created_by, is_shared, tenant_id) "
@@ -200,8 +210,16 @@ class TestRouteTenantFailClosed(unittest.TestCase):
             self.assertNotIn("Tenant Seven Secret", names)
             self.assertEqual(names, [])
         finally:
-            with projects_mod.project_repo.db.get_connection() as conn:
-                conn.cursor().execute("DELETE FROM projects")
+            with db.get_connection() as conn:
+                cursor = conn.cursor()
+                cursor.execute("DELETE FROM projects")
+                if snapshot and cols:
+                    placeholders = ", ".join(["?"] * len(cols))
+                    col_list = ", ".join(cols)
+                    cursor.executemany(
+                        f"INSERT INTO projects ({col_list}) VALUES ({placeholders})",
+                        [tuple(row) for row in snapshot],
+                    )
                 conn.commit()
 
     # --- admins keep global scope (must NOT be locked out) ---

--- a/tests/issues/1775/test_route_tenant_fail_closed.py
+++ b/tests/issues/1775/test_route_tenant_fail_closed.py
@@ -193,9 +193,7 @@ class TestRouteTenantFailClosed(unittest.TestCase):
         with db.get_connection() as conn:
             cursor = conn.cursor()
             snapshot = cursor.execute("SELECT * FROM projects").fetchall()
-            cols = (
-                [d[0] for d in cursor.description] if cursor.description else []
-            )
+            cols = [d[0] for d in cursor.description] if cursor.description else []
             cursor.execute("DELETE FROM projects")
             cursor.execute(
                 "INSERT INTO projects (path, name, created_by, is_shared, tenant_id) "

--- a/tests/issues/1775/test_route_tenant_fail_closed.py
+++ b/tests/issues/1775/test_route_tenant_fail_closed.py
@@ -171,9 +171,38 @@ class TestRouteTenantFailClosed(unittest.TestCase):
         self.assertEqual(resp.status_code, 403)
 
     def test_projects_denied_for_notenant_non_admin(self):
+        # Issue #1859: the list endpoint returns an empty list (not 403) so
+        # the qwen-code-webui project picker renders for no-tenant non-admins.
+        # This is still fail-closed — no cross-tenant rows are returned.
         resp = self._authed_get("/api/projects", user_id=11, role="user", tenant_id=None)
-        self.assertNotEqual(resp.status_code, 200)
-        self.assertEqual(resp.status_code, 403)
+        self.assertEqual(resp.status_code, 200)
+        payload = resp.get_json()
+        self.assertEqual(payload.get("projects"), [])
+
+    def test_projects_notenant_non_admin_leaks_no_cross_tenant_rows(self):
+        # Seed a project owned by tenant_user (tenant 7) and verify the
+        # no-tenant non-admin (user 11) cannot see it via GET /api/projects.
+        import app.routes.projects as projects_mod
+
+        with projects_mod.project_repo.db.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute("DELETE FROM projects")
+            cursor.execute(
+                "INSERT INTO projects (path, name, created_by, is_shared, tenant_id) "
+                "VALUES (?, ?, ?, ?, ?)",
+                ("/projects/tenant-seven-secret", "Tenant Seven Secret", 10, 1, 7),
+            )
+            conn.commit()
+        try:
+            resp = self._authed_get("/api/projects", user_id=11, role="user", tenant_id=None)
+            self.assertEqual(resp.status_code, 200)
+            names = [p.get("name") for p in resp.get_json().get("projects", [])]
+            self.assertNotIn("Tenant Seven Secret", names)
+            self.assertEqual(names, [])
+        finally:
+            with projects_mod.project_repo.db.get_connection() as conn:
+                conn.cursor().execute("DELETE FROM projects")
+                conn.commit()
 
     # --- admins keep global scope (must NOT be locked out) ---
 


### PR DESCRIPTION
## Summary

Fixes #1883

修复浏览器通过 **非 loopback 地址(LAN IP / 容器主机名)** 访问工作区 `/work` 时新建会话的两个阻断性错误：

1. `错误: NetworkError when attempting to fetch resource.` — CORS 未放行同主机 WebUI 端口段
2. `错误: Failed to fetch projects: FORBIDDEN` — 无 tenant 的非 admin 用户被 `GET /api/projects` 以 403 拒绝

## Root Cause

### A. CORS

`/work` 页面在 iframe 中加载每用户 `qwen-code-webui`(端口段 `3100-3200`)。iframe 内的 webui 向后端 `5000` 端口发起的请求是跨域请求，浏览器带 `Origin: http://<server-ip>:<webui-port>`。

`_is_allowed_local_webui_origin` 仅允许 loopback 主机名在 webui 端口段跨域。非 loopback 访问时 origin 主机名不在 loopback 集合，后端不返回 CORS 头 → Firefox 阻断 → `NetworkError`。

### B. Projects 403

`qwen-code-webui` 新建会话调用 `GET /api/projects`。该端点的 `_require_tenant_scope`(Issue #1775 的 fail-closed 门槛)对无 tenant 的非 admin 用户返回 `403 "Tenant scope required"`。门槛本身正确(防 wildcard 泄漏)，但对只读列表场景过度阻断。

## Fix

### A. `app/__init__.py` — 放宽同主机 WebUI 端口 CORS

`_is_allowed_local_webui_origin` 额外允许 origin 主机名与当前请求 `Host` 头主机名相同的 WebUI 端口来源。`Host` 头反映浏览器自身使用的地址，反射该 origin 不为第三方打开凭据复用面。主机名不匹配的来源仍被拒绝。

### B. `app/routes/projects.py` — 无 tenant 非 admin 返回空列表

1. `_require_tenant_scope` 豁免 `GET /api/projects` 列表端点(其余路由仍 403 fail-closed)。
2. `api_get_projects` 对无 tenant 的非 admin 用户直接返回 `{"success": True, "projects": []}`，不进入仓库层(避免 `tenant_id=None` 被当作通配符)。admin 保留全局范围。

## Security

- CORS：不匹配 `Host` 头的来源仍被拒绝；原有 loopback 与 `OPENACE_CORS_ALLOWED_ORIGINS` 白名单逻辑不变。
- Projects：空列表不泄漏任何数据，仍是 fail-closed；新增跨租户泄漏回归测试。

## Test

- 新增 `test_same_host_lan_ip_webui_origin_is_allowed` / `test_mismatched_host_webui_origin_is_not_reflected`
- 新增 `test_projects_notenant_non_admin_leaks_no_cross_tenant_rows`(tenant 7 种子共享项目，断言无 tenant 用户看不到)
- 原 `test_projects_denied_for_notenant_non_admin` 更新为断言 `200 + 空列表`
- 原有 13 项 CORS 测试 + 24 项 tenant-scope 测试全部通过

## Verification (线上验证)

- 非 admin 无 tenant 用户 `GET /api/projects` → `200 {"projects":[],"success":true}` ✅(原 `403`)
- admin `GET /api/projects` → 完整项目列表 ✅(全局范围未变)
- `Origin: http://<server-ip>:3101` → 返回完整 CORS 头 ✅(原无 CORS 头)
- `Origin: http://evil.example:3101` → 无 CORS 头 ✅
- OPTIONS 预检通过 ✅