### PR TITLE
fix(users): 回填无 tenant_id 的非 admin 用户到默认租户 (Issue #1888)

### DIFF
--- a/migrations/versions/20260720_001_backfill_notenant_users.py
+++ b/migrations/versions/20260720_001_backfill_notenant_users.py
@@ -1,0 +1,93 @@
+"""Backfill default tenant for non-admin users with NULL tenant_id
+
+Revision ID: 20260720_001_backfill_notenant_users
+Revises: 20260719_002_add_tenant_id_to_analysis_tables
+Create Date: 2026-07-20
+
+Issue: #1888
+
+A non-admin user with ``tenant_id IS NULL`` is non-functional: the
+fail-closed tenant gate in :func:`require_tenant_scope` (Issue #1775)
+denies every write/query endpoint with ``403 Tenant scope required``,
+so the user can log in and see an empty project list (GET is exempted
+by Issue #1859) but cannot create projects, sessions, API keys, etc.
+
+Every ``create_user`` call site already defaults ``tenant_id=1`` (admin
+panel, SSO provisioning, Feishu/DingTalk org sync, tenant-onboarding
+admin). The only way a non-admin ends up with ``NULL`` is:
+
+  * the row predates the tenant_id column (created before the 2026-06-23
+    baseline, which is a no-op when ``users`` already exists), or
+  * direct DB manipulation / a deleted tenant (``ON DELETE SET NULL``).
+
+This migration backfills such stranded non-admins to the default tenant
+(id=1, seeded by ``scripts/init_db.py``) so they become functional again
+without weakening the route-layer fail-closed guarantee. Admins are left
+alone — ``NULL`` is legitimate for them (global scope).
+"""
+
+from __future__ import annotations
+
+import logging
+
+import sqlalchemy as sa
+from alembic import op
+
+logger = logging.getLogger(__name__)
+
+revision: str = "20260720_001_backfill_notenant_users"
+down_revision: str | None = "20260719_002_add_tenant_id_to_analysis_tables"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def backfill_null_tenant_users(conn) -> int:
+    """Assign stranded non-admins to the default tenant (id=1).
+
+    Returns the number of rows updated. Exposed as a module-level helper so
+    tests (and a future operational script) can invoke it against an
+    arbitrary connection without standing up the full Alembic context.
+
+    Only non-admins are touched: admins may legitimately have ``NULL``
+    ``tenant_id`` (global scope). The default tenant must exist — otherwise
+    the backfill is a no-op so we never create dangling FK rows.
+    """
+    default_tenant = conn.execute(sa.text("SELECT id FROM tenants WHERE id = 1")).scalar()
+
+    if default_tenant is None:
+        # Nothing safe to backfill to — leave rows untouched and let the
+        # fail-closed gate keep denying until an operator fixes the data.
+        logger.warning(
+            "backfill_null_tenant_users: default tenant (id=1) not found; "
+            "skipping backfill of NULL tenant_id users."
+        )
+        return 0
+
+    result = conn.execute(sa.text("""
+            UPDATE users
+            SET tenant_id = 1
+            WHERE tenant_id IS NULL
+              AND COALESCE(role, 'user') <> 'admin'
+            """))
+    # ``result.rowcount`` may be -1 on some drivers; log best-effort.
+    try:
+        affected = result.rowcount
+    except Exception:  # pragma: no cover - driver-specific
+        affected = -1
+    if affected and affected > 0:
+        logger.info(
+            "backfill_null_tenant_users: assigned %s non-admin user(s) "
+            "with NULL tenant_id to the default tenant (id=1).",
+            affected,
+        )
+    return affected or 0
+
+
+def upgrade() -> None:
+    """Assign stranded non-admins to the default tenant (id=1)."""
+    backfill_null_tenant_users(op.get_bind())
+
+
+def downgrade() -> None:
+    """Downgrade is a no-op — we cannot reconstruct the original NULLs."""
+    pass

--- a/migrations/versions/20260720_001_backfill_notenant_users.py
+++ b/migrations/versions/20260720_001_backfill_notenant_users.py
@@ -63,12 +63,16 @@ def backfill_null_tenant_users(conn) -> int:
         )
         return 0
 
-    result = conn.execute(sa.text("""
+    result = conn.execute(
+        sa.text(
+            """
             UPDATE users
             SET tenant_id = 1
             WHERE tenant_id IS NULL
               AND COALESCE(role, 'user') <> 'admin'
-            """))
+            """
+        )
+    )
     # ``result.rowcount`` may be -1 on some drivers; log best-effort.
     try:
         affected = result.rowcount

--- a/tests/issues/1888/test_backfill_notenant_users.py
+++ b/tests/issues/1888/test_backfill_notenant_users.py
@@ -1,0 +1,130 @@
+"""Regression test for the no-tenant non-admin backfill (Issue #1888).
+
+A non-admin user with ``tenant_id IS NULL`` is locked out of every
+write/query endpoint by the fail-closed gate from Issue #1775
+(``403 Tenant scope required``), yet can still log in and see an empty
+project list (Issue #1859 exempts GET). The user is stranded with no
+self-service recovery.
+
+Migration ``20260720_001_backfill_notenant_users`` assigns such stranded
+non-admins to the default tenant (id=1) so they become functional again.
+Admins are left alone because ``NULL`` is legitimate for them (global
+scope).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+
+_MIGRATION_PATH = os.path.join(
+    os.path.dirname(__file__),
+    "..",
+    "..",
+    "..",
+    "migrations",
+    "versions",
+    "20260720_001_backfill_notenant_users.py",
+)
+
+
+def _load_migration_module():
+    spec = importlib.util.spec_from_file_location(
+        "migration_backfill_notenant_users_1888", _MIGRATION_PATH
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class BackfillNoTenantUsersMigrationTest(unittest.TestCase):
+    """Exercise the migration's backfill helper against a throwaway SQLite DB."""
+
+    def setUp(self):
+        from sqlalchemy import create_engine
+
+        self._db_path = tempfile.mktemp(suffix="_backfill_1888.db")
+        self._engine = create_engine(f"sqlite:///{self._db_path}")
+        with self._engine.begin() as conn:
+            conn.exec_driver_sql(
+                "CREATE TABLE tenants (id INTEGER PRIMARY KEY, name TEXT, "
+                "slug TEXT, status TEXT, plan TEXT)"
+            )
+            conn.exec_driver_sql(
+                "CREATE TABLE users (id INTEGER PRIMARY KEY, username TEXT, "
+                "email TEXT, password_hash TEXT, role TEXT, tenant_id INTEGER)"
+            )
+            conn.exec_driver_sql(
+                "INSERT INTO tenants (id, name, slug, status, plan) "
+                "VALUES (1, 'Default', 'default', 'active', 'standard')"
+            )
+            conn.exec_driver_sql(
+                "INSERT INTO users (id, username, email, password_hash, role, tenant_id) "
+                "VALUES (1, 'admin', 'a@x', 'h', 'admin', NULL)"
+            )
+            conn.exec_driver_sql(
+                "INSERT INTO users (id, username, email, password_hash, role, tenant_id) "
+                "VALUES (2, 'wd237', 'w@x', 'h', 'user', NULL)"
+            )
+            conn.exec_driver_sql(
+                "INSERT INTO users (id, username, email, password_hash, role, tenant_id) "
+                "VALUES (3, 'tenant_user', 't@x', 'h', 'user', 7)"
+            )
+
+    def tearDown(self):
+        self._engine.dispose()
+        try:
+            os.unlink(self._db_path)
+        except OSError:
+            pass
+
+    def _run_backfill(self):
+        mod = _load_migration_module()
+        with self._engine.begin() as conn:
+            return mod.backfill_null_tenant_users(conn)
+
+    def _tenant_id(self, user_id):
+        with self._engine.connect() as conn:
+            row = conn.exec_driver_sql(
+                "SELECT tenant_id FROM users WHERE id = ?", (user_id,)
+            ).fetchone()
+            return row[0]
+
+    def test_non_admin_null_tenant_backfilled_to_default(self):
+        affected = self._run_backfill()
+        self.assertEqual(affected, 1)
+        self.assertEqual(self._tenant_id(2), 1)
+
+    def test_admin_null_tenant_preserved(self):
+        """Admins keep NULL tenant_id (global scope)."""
+        self._run_backfill()
+        self.assertIsNone(self._tenant_id(1))
+
+    def test_existing_tenant_assignment_preserved(self):
+        """A user already in tenant 7 is not moved to the default tenant."""
+        self._run_backfill()
+        self.assertEqual(self._tenant_id(3), 7)
+
+    def test_no_default_tenant_is_noop(self):
+        """If the default tenant is missing, backfill is skipped (fail-safe)."""
+        with self._engine.begin() as conn:
+            conn.exec_driver_sql("DELETE FROM tenants WHERE id = 1")
+        affected = self._run_backfill()
+        self.assertEqual(affected, 0)
+        self.assertIsNone(self._tenant_id(2))
+
+    def test_idempotent(self):
+        """Running the backfill twice does not move already-assigned users."""
+        self._run_backfill()
+        affected = self._run_backfill()
+        self.assertEqual(affected, 0)
+        self.assertEqual(self._tenant_id(2), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 关联 Issue

Closes #1888

## 变更内容

新增 Alembic 迁移 `20260720_001_backfill_notenant_users`，将 `tenant_id IS NULL` 的**非 admin** 用户回填到默认租户 `id=1`。

### 背景

非 admin 用户 `tenant_id` 为 NULL 时，`require_tenant_scope()`（Issue #1775 的 fail-closed 门禁）会拒绝所有写操作，报 `403 Tenant scope required`。`GET /api/projects` 在 #1859 中被豁免（返回空列表），导致用户能登录、能看空列表，但无法建项目 / session / API key，且无自助恢复路径——形成死锁态。

### 为什么会有 NULL tenant_id 的非 admin

- `users.tenant_id` nullable，无 server default / NOT NULL 约束
- `baseline_2026_06_23` 在 `users` 表已存在时是 no-op，未回填 `users.tenant_id`（而 sessions/projects/analysis 等业务表都已被后续迁移回填）
- 当前所有 `create_user` 调用点均已默认 `tenant_id=1`，NULL 数据只来自历史遗留

### 迁移行为

- 非 admin 且 `tenant_id IS NULL` → 回填到默认租户 `id=1`
- admin 保留 NULL（合法的全局 scope，由代码层 `role == 'admin'` 判断）
- 默认租户不存在时跳过（fail-safe，不产生悬空外键）
- 幂等

回填逻辑抽取为模块级 `backfill_null_tenant_users(conn)` 方便测试与未来运维脚本调用。

## 测试

新增 `tests/issues/1888/test_backfill_notenant_users.py`（5 个用例）：

- 非 admin 且 NULL → 回填到默认租户 1
- admin 且 NULL → 保留 NULL
- 已有租户（如 7）→ 不动
- 默认租户不存在 → no-op（fail-safe）
- 重复执行幂等

```
tests/issues/1888/test_backfill_notenant_users.py .....  [100%]
tests/issues/1775/test_route_tenant_fail_closed.py ........  [100%]
```

black / ruff 均通过。

## 安全性

保留 #1775 的 fail-closed 安全保证——路由层仍对无 tenant 的非 admin 返回 403，不弱化门禁。本 PR 只补齐 baseline 漏掉的 `users` 表回填，消除"用户理应有 tenant 却为 NULL"的数据完整性缺口。
