### PR TITLE
fix: 降级 sensitive_keyword 为 warn-only 防止误拦截 (#1898)

### DIFF
--- a/app/modules/governance/content_filter.py
+++ b/app/modules/governance/content_filter.py
@@ -179,7 +179,7 @@ class ContentFilter:
             "pii_email": "medium",
             "pii_phone_us": "medium",
             "pii_phone_intl": "medium",
-            "sensitive_keyword": "high",
+            "sensitive_keyword": "medium",  # Downgraded: prone to false positives with substring match
             "custom_pattern": "medium",
         }
 
@@ -372,9 +372,11 @@ class ContentFilter:
             if overall_risk not in ["critical", "high"]:
                 overall_risk = "medium"
 
-            # Do NOT update overall_action - let sensitive_keyword warn only
+            # Set action to 'warn' for audit visibility, but do NOT block
             # This prevents blocking legitimate messages containing words like
             # "password" or "secret" in non-sensitive contexts
+            if overall_action not in ["block", "warn"]:
+                overall_action = "warn"
 
         # Determine passed based on action
         passed = overall_action != "block"

--- a/app/modules/governance/content_filter.py
+++ b/app/modules/governance/content_filter.py
@@ -361,18 +361,20 @@ class ContentFilter:
                 {
                     "type": "sensitive_keyword",
                     "count": len(keyword_matches),
-                    "risk": "high",
+                    "risk": "medium",  # Downgrade: sensitive_keyword sub-match is prone to false positives
                     "keywords": list(keyword_matches),
                     "source": "builtin",
                 }
             )
 
-            if overall_risk not in ["critical"]:
-                overall_risk = "high"
+            # Update overall_risk but do NOT force overall_action to block
+            # sensitive_keyword should only generate audit logs, not block requests
+            if overall_risk not in ["critical", "high"]:
+                overall_risk = "medium"
 
-            # For keywords, use block_high_risk config for action
-            if self.block_high_risk and overall_action not in ["block"]:
-                overall_action = "block"
+            # Do NOT update overall_action - let sensitive_keyword warn only
+            # This prevents blocking legitimate messages containing words like
+            # "password" or "secret" in non-sensitive contexts
 
         # Determine passed based on action
         passed = overall_action != "block"

--- a/tests/issues/1898/test_sensitive_keyword_fix.py
+++ b/tests/issues/1898/test_sensitive_keyword_fix.py
@@ -1,0 +1,132 @@
+"""
+Test for Issue #1898: Sensitive keyword false positives blocking normal messages.
+
+This test verifies that sensitive_keyword is downgraded to warn-only,
+not block, to prevent false positives from blocking legitimate messages
+containing words like "password" or "secret" in non-sensitive contexts.
+"""
+
+import pytest
+
+from app.modules.governance.content_filter import ContentFilter
+
+
+class TestSensitiveKeywordFix:
+    """Test suite for sensitive_keyword downgrade fix."""
+
+    def test_sensitive_keyword_does_not_block(self):
+        """Verify that sensitive_keyword matches do NOT block requests."""
+        content_filter = ContentFilter()
+
+        # Test various sensitive keywords
+        test_cases = [
+            "my password is xxx",
+            "the secret is yyy",
+            "API_KEY=zzz",
+            "credential data",
+        ]
+
+        for content in test_cases:
+            result = content_filter.check_content(content)
+
+            # Should match sensitive_keyword
+            assert len(result.matched_rules) > 0, f"Should match rules: {content}"
+            sensitive_matches = [
+                r for r in result.matched_rules if r.get("type") == "sensitive_keyword"
+            ]
+            assert len(sensitive_matches) > 0, f"Should match sensitive_keyword: {content}"
+
+            # Should NOT block
+            assert result.passed is True, f"Should pass: {content}"
+            assert result.action != "block", f"Action should not be 'block': {content}"
+
+            # Should warn or none (not block)
+            assert result.action in [
+                "warn",
+                "none",
+            ], f"Action should be warn or none: {content}"
+
+    def test_sensitive_keyword_risk_is_medium(self):
+        """Verify that sensitive_keyword is now classified as medium risk."""
+        content_filter = ContentFilter()
+
+        result = content_filter.check_content("my password is xxx")
+
+        # Find the sensitive_keyword rule
+        sensitive_matches = [
+            r for r in result.matched_rules if r.get("type") == "sensitive_keyword"
+        ]
+        assert len(sensitive_matches) > 0
+
+        # Verify risk is medium
+        sensitive_rule = sensitive_matches[0]
+        assert sensitive_rule.get("risk") == "medium"
+
+    def test_real_high_risk_pii_still_blocks(self):
+        """Verify that real high-risk PII (SSN, credit card) still blocks."""
+        content_filter = ContentFilter()
+
+        # Test SSN (should block)
+        result = content_filter.check_content("SSN: 123-45-6789")
+        assert result.passed is False
+        assert result.action == "block"
+
+        # Test credit card (should block)
+        result = content_filter.check_content("Credit card: 1234-5678-9012-3456")
+        assert result.passed is False
+        assert result.action == "block"
+
+    def test_pii_medium_only_redacts(self):
+        """Verify that medium-risk PII only triggers redact, not block."""
+        content_filter = ContentFilter()
+
+        # PII that should only redact
+        result = content_filter.check_content("Port: 1763, Email: test@example.com")
+
+        # Should pass (redact only)
+        assert result.passed is True
+        # Should have PII matches
+        assert len(result.matched_rules) > 0
+
+    def test_sensitive_keyword_plus_pii_does_not_block(self):
+        """Verify that sensitive_keyword + PII together don't block."""
+        content_filter = ContentFilter()
+
+        # Both sensitive_keyword and PII
+        result = content_filter.check_content("my password is xxx, Port: 1763")
+
+        # Should pass because sensitive_keyword is now warn-only
+        assert result.passed is True
+        assert result.action != "block"
+
+    def test_only_hi_passes(self):
+        """Verify that simple 'hi' message passes without any matches."""
+        content_filter = ContentFilter()
+
+        result = content_filter.check_content("hi")
+        assert result.passed is True
+        assert result.action == "none"
+        assert len(result.matched_rules) == 0
+
+    def test_audit_log_still_records_sensitive_keyword(self):
+        """Verify that sensitive_keyword matches are still logged for audit."""
+        # Use config to enable log_matches
+        config = {"enabled": True, "log_matches": True}
+        content_filter = ContentFilter(config=config)
+
+        result = content_filter.check_content("my password is xxx")
+
+        # Should have matched rules (for audit)
+        assert len(result.matched_rules) > 0
+        sensitive_matches = [
+            r for r in result.matched_rules if r.get("type") == "sensitive_keyword"
+        ]
+        assert len(sensitive_matches) > 0
+
+        # Should have recorded the keywords
+        assert "keywords" in sensitive_matches[0]
+        assert "password" in sensitive_matches[0]["keywords"]
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/issues/1898/test_sensitive_keyword_fix.py
+++ b/tests/issues/1898/test_sensitive_keyword_fix.py
@@ -76,6 +76,28 @@ class TestSensitiveKeywordFix:
         assert result.passed is False
         assert result.action == "block"
 
+    def test_critical_pii_plus_keyword_still_blocks(self):
+        """Verify that critical PII + sensitive_keyword still blocks.
+
+        Regression test for PR #1903 review feedback:
+        - SSN (critical) + password should still block
+        - Credit card (critical) + password should still block
+        """
+        content_filter = ContentFilter()
+
+        # SSN + password should still block (critical takes precedence)
+        result = content_filter.check_content("SSN: 123-45-6789 and my password is secret")
+        assert result.passed is False, "Critical PII + keyword should still block"
+        assert result.action == "block", "Critical PII should keep action='block'"
+        assert result.risk_level == "critical"
+
+        # Credit card + password should still block
+        result = content_filter.check_content(
+            "Credit card: 4111-1111-1111-1111, password is secret123"
+        )
+        assert result.passed is False, "Critical PII + keyword should still block"
+        assert result.action == "block"
+
     def test_pii_medium_only_redacts(self):
         """Verify that medium-risk PII only triggers redact, not block."""
         content_filter = ContentFilter()

--- a/tests/unit/test_content_filter.py
+++ b/tests/unit/test_content_filter.py
@@ -70,7 +70,7 @@ class TestContentFilter:
         # sensitive_keyword is now warn-only (Issue #1898), does not block
         assert result.passed is True
         assert result.risk_level in ("medium", "high")
-        assert result.action == "none"  # warn-only, no blocking
+        assert result.action == "warn"  # warn-only, generates audit log but no blocking
         assert any(r["type"] == "sensitive_keyword" for r in result.matched_rules)
 
     def test_redaction_enabled(self):
@@ -93,7 +93,7 @@ class TestContentFilter:
         result = cf.check_content("This is confidential information")
         # sensitive_keyword is now warn-only (Issue #1898), does not block
         assert result.passed is True
-        assert result.action == "none"  # warn-only, no blocking
+        assert result.action == "warn"  # warn-only, generates audit log but no blocking
         assert any(r["type"] == "sensitive_keyword" for r in result.matched_rules)
 
     def test_get_stats(self):

--- a/tests/unit/test_content_filter.py
+++ b/tests/unit/test_content_filter.py
@@ -67,8 +67,11 @@ class TestContentFilter:
     def test_detect_sensitive_keyword(self):
         cf = ContentFilter()
         result = cf.check_content("The password is secret123")
-        assert result.passed is False
+        # sensitive_keyword is now warn-only (Issue #1898), does not block
+        assert result.passed is True
         assert result.risk_level in ("medium", "high")
+        assert result.action == "none"  # warn-only, no blocking
+        assert any(r["type"] == "sensitive_keyword" for r in result.matched_rules)
 
     def test_redaction_enabled(self):
         cf = ContentFilter(config={"redact_pii": True, "block_high_risk": False})
@@ -88,7 +91,10 @@ class TestContentFilter:
         cf = ContentFilter()
         cf.add_custom_keyword("confidential")
         result = cf.check_content("This is confidential information")
-        assert result.passed is False
+        # sensitive_keyword is now warn-only (Issue #1898), does not block
+        assert result.passed is True
+        assert result.action == "none"  # warn-only, no blocking
+        assert any(r["type"] == "sensitive_keyword" for r in result.matched_rules)
 
     def test_get_stats(self):
         cf = ContentFilter(custom_patterns={"test": r"\d+"}, custom_keywords=["secret"])


### PR DESCRIPTION
## 问题描述

Fixes #1898 - 用户发送包含 `password`、`secret` 等英文敏感词的消息时收到 `403 Content blocked` 错误。

## 根因分析（感谢 @blueberry521 的指正）

**之前的错误判断**：归因为"PII 规则过于宽松"

**正确的根因**：
- **sensitive_keyword（high）触发 block**
- PII（medium）只触发 redact
- 即使修复 PII，只要含英文敏感词仍会 403

## 修复方案

### P0 - 最高优先级：精细化处理 sensitive_keyword

**问题**：sensitive_keyword 使用子串匹配，`secret` 会命中 `SECRET_KEY`，误伤率高。

**修复**：
- 将 sensitive_keyword 的风险从 `high` 降级为 `medium`
- 移除强制 block，只保留 warn
- 保留审计日志记录

**代码修改**：

```python
# app/modules/governance/content_filter.py:358-377

# 修改前
matched_rules.append({
    "type": "sensitive_keyword",
    "risk": "high",  # ← 问题：总是 high
})
if self.block_high_risk:
    overall_action = "block"  # ← 总是 block

# 修改后
matched_rules.append({
    "type": "sensitive_keyword",
    "risk": "medium",  # ← 降级为 medium
})
# 不再强制更新 overall_action
```

## 测试结果

```
tests/issues/1898/test_sensitive_keyword_fix.py::test_sensitive_keyword_does_not_block PASSED
tests/issues/1898/test_sensitive_keyword_fix.py::test_sensitive_keyword_risk_is_medium PASSED
tests/issues/1898/test_sensitive_keyword_fix.py::test_real_high_risk_pii_still_blocks PASSED
tests/issues/1898/test_sensitive_keyword_fix.py::test_pii_medium_only_redacts PASSED
tests/issues/1898/test_sensitive_keyword_fix.py::test_sensitive_keyword_plus_pii_does_not_block PASSED
tests/issues/1898/test_sensitive_keyword_fix.py::test_only_hi_passes PASSED
tests/issues/1898/test_sensitive_keyword_fix.py::test_audit_log_still_records_sensitive_keyword PASSED

============================== 7 passed in 0.30s ===============================
```

## 影响范围

✅ **解决的问题**：
- 用户可以正常发送包含 `password`、`secret` 等词的消息
- WebUI 附带的系统提示词不再触发拦截

✅ **保留的能力**：
- 真正的高风险规则（pii_ssn、pii_credit_card）仍然拦截
- 审计日志正常记录 sensitive_keyword 匹配
- 可以事后分析真实风险

## 验证案例

| 内容 | matched_rules | action | passed |
|------|---------------|--------|--------|
| 仅 PII（端口1763）| pii_phone_intl(medium) | redact | ✅ True |
| 含敏感词（password）| sensitive_keyword(medium) | warn | ✅ True |
| 真实高风险（SSN）| pii_ssn(critical) | block | ❌ False |

## 与之前修复的区别

| 维度 | 之前修复 | 新方案 |
|------|---------|--------|
| 方式 | 关闭 `block_high_risk` | 精细化处理 sensitive_keyword |
| 影响范围 | 所有 high-risk 规则 | 只影响 sensitive_keyword |
| 高风险规则 | 全部降级 ❌ | 仍然拦截 ✅ |

## 检查清单

- [x] 基于 main 最新代码创建分支
- [x] 修改代码（精细化的 P0 修复）
- [x] 编写测试
- [x] 运行测试通过
- [x] 格式化代码（black + isort）
- [x] 提交代码
- [x] 推送到远程仓库
- [ ] 等待 CI 检查
- [ ] Code Review
- [ ] 合并

## 相关链接

- Issue: #1898
- 评论分析: https://github.com/open-ace/open-ace/issues/1898#issuecomment-5020085049
- 分支: `fix/issue-1898-sensitive-keyword-v2`