### PR TITLE
Fix autonomous workflow list dark-mode contrast and accessibility

### DIFF
--- a/frontend/src/components/work/AutonomousWorkflowList.css
+++ b/frontend/src/components/work/AutonomousWorkflowList.css
@@ -31,6 +31,11 @@
   box-shadow: none;
 }
 
+[data-theme='dark'] .auto-workflow-search .input-group:focus-within {
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 0.2rem rgba(var(--color-primary-rgb), 0.18);
+}
+
 [data-theme='dark'] .auto-workflow-search .form-control::placeholder {
   color: var(--text-muted);
 }
@@ -39,6 +44,17 @@
   cursor: pointer;
   border-bottom: 1px solid rgba(15, 23, 42, 0.06) !important;
   background: var(--bg-primary);
+}
+
+.auto-workflow-select-btn {
+  align-self: stretch;
+  min-width: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  text-align: inherit;
+  cursor: pointer;
 }
 
 .auto-workflow-item:hover {
@@ -64,6 +80,7 @@
 
 .auto-workflow-item-standard .auto-workflow-title {
   font-size: 0.875rem;
+  color: var(--text-primary);
 }
 
 .auto-workflow-item-standard .auto-workflow-meta {
@@ -223,6 +240,37 @@
   background: rgba(255, 255, 255, 0.72);
   color: var(--color-primary);
   box-shadow: inset 0 0 0 1px rgba(59, 130, 246, 0.1);
+}
+
+.auto-workflow-select-btn:focus-visible,
+.auto-workflow-batch:focus-visible {
+  z-index: 3;
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+[data-theme='dark'] .auto-workflow-batch-meta-pill {
+  border-color: rgba(148, 163, 184, 0.28);
+  background: rgba(148, 163, 184, 0.12);
+  color: var(--text-secondary);
+}
+
+[data-theme='dark'] .auto-workflow-batch-count {
+  border-color: rgba(var(--color-primary-rgb), 0.36);
+  background: rgba(var(--color-primary-rgb), 0.14);
+  color: var(--color-primary);
+}
+
+[data-theme='dark'] .auto-workflow-batch-chevron {
+  background: rgba(var(--color-primary-rgb), 0.14);
+  color: var(--color-primary);
+  box-shadow: inset 0 0 0 1px rgba(var(--color-primary-rgb), 0.3);
+}
+
+[data-theme='dark'] .auto-workflow-item .badge.bg-light {
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  background-color: rgba(148, 163, 184, 0.14) !important;
+  color: var(--text-secondary) !important;
 }
 
 .auto-workflow-batch-children {

--- a/frontend/src/components/work/AutonomousWorkflowList.css
+++ b/frontend/src/components/work/AutonomousWorkflowList.css
@@ -41,7 +41,6 @@
 }
 
 .auto-workflow-item {
-  cursor: pointer;
   border-bottom: 1px solid rgba(15, 23, 42, 0.06) !important;
   background: var(--bg-primary);
 }

--- a/frontend/src/components/work/AutonomousWorkflowList.test.tsx
+++ b/frontend/src/components/work/AutonomousWorkflowList.test.tsx
@@ -147,20 +147,21 @@ describe('AutonomousWorkflowList', () => {
       }),
     ]);
 
-    render(
+    const { container } = render(
       <AutonomousWorkflowList selectedId={null} onSelect={onSelect} onClearSelection={vi.fn()} />
     );
 
     const workflowButton = screen.getByRole('button', { name: 'Keyboard workflow' });
     expect(workflowButton.tagName).toBe('BUTTON');
+    expect(workflowButton.querySelector('div')).toBeNull();
     onSelect.mockClear();
     fireEvent.click(workflowButton);
 
     expect(onSelect).toHaveBeenCalledWith(
       expect.objectContaining({ workflow_id: 'wf-1', title: 'Keyboard workflow' })
     );
-    expect(screen.getByRole('textbox', { name: 'Search workflows...' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument();
+    expect(screen.getByRole('textbox')).toHaveAttribute('aria-label');
+    expect(container.querySelector('.auto-workflow-delete-btn')).toHaveAttribute('aria-label');
   });
 
   it('requests the next page with a 50 item offset', () => {

--- a/frontend/src/components/work/AutonomousWorkflowList.test.tsx
+++ b/frontend/src/components/work/AutonomousWorkflowList.test.tsx
@@ -138,6 +138,31 @@ describe('AutonomousWorkflowList', () => {
     expect(lastFilters?.offset).toBe('0');
   });
 
+  it('uses semantic workflow buttons and exposes accessible controls', () => {
+    const onSelect = vi.fn();
+    mockWorkflowList([
+      workflow({
+        title: 'Keyboard workflow',
+        status: 'completed',
+      }),
+    ]);
+
+    render(
+      <AutonomousWorkflowList selectedId={null} onSelect={onSelect} onClearSelection={vi.fn()} />
+    );
+
+    const workflowButton = screen.getByRole('button', { name: 'Keyboard workflow' });
+    expect(workflowButton.tagName).toBe('BUTTON');
+    onSelect.mockClear();
+    fireEvent.click(workflowButton);
+
+    expect(onSelect).toHaveBeenCalledWith(
+      expect.objectContaining({ workflow_id: 'wf-1', title: 'Keyboard workflow' })
+    );
+    expect(screen.getByRole('textbox', { name: 'Search workflows...' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument();
+  });
+
   it('requests the next page with a 50 item offset', () => {
     mockWorkflowList([workflow()], 75);
 

--- a/frontend/src/components/work/AutonomousWorkflowList.tsx
+++ b/frontend/src/components/work/AutonomousWorkflowList.tsx
@@ -488,21 +488,21 @@ export const AutonomousWorkflowList: React.FC<AutonomousWorkflowListProps> = ({
           onClick={() => onSelect(workflow)}
         >
           {compact ? (
-            <div className="d-flex align-items-start justify-content-between gap-2">
-              <div className="min-width-0">
-                <div className="d-flex align-items-center gap-2 flex-wrap">
-                  <div className="auto-workflow-issue-label">
+            <span className="d-flex align-items-start justify-content-between gap-2">
+              <span className="d-block min-width-0">
+                <span className="d-flex align-items-center gap-2 flex-wrap">
+                  <span className="auto-workflow-issue-label">
                     {isForkChild && <i className="bi bi-diagram-3 text-info me-1"></i>}
                     {getIssueLabel(workflow)}
-                  </div>
+                  </span>
                   {workflow.batch_order && workflow.batch_total && (
                     <Badge variant="light">
                       {workflow.batch_order}/{workflow.batch_total}
                     </Badge>
                   )}
                   {workflow.dev_round > 1 && <Badge variant="light">R{workflow.dev_round}</Badge>}
-                </div>
-                <div className="d-flex align-items-center gap-1 mt-2 flex-wrap">
+                </span>
+                <span className="d-flex align-items-center gap-1 mt-2 flex-wrap">
                   <Badge
                     variant={
                       statusCfg.variant as
@@ -522,20 +522,20 @@ export const AutonomousWorkflowList: React.FC<AutonomousWorkflowListProps> = ({
                       {t('autoForkedFrom', language)}
                     </Badge>
                   )}
-                </div>
-              </div>
-            </div>
+                </span>
+              </span>
+            </span>
           ) : (
             <>
-              <div className="fw-semibold text-truncate auto-workflow-title">
+              <span className="d-block fw-semibold text-truncate auto-workflow-title">
                 {isForkChild && (
                   <i className="bi bi-diagram-3 text-info me-1" style={{ fontSize: '0.75rem' }}></i>
                 )}
                 {workflow.title ||
                   workflow.requirements_text?.slice(0, 50) ||
                   `Workflow ${workflow.workflow_id.slice(0, 8)}`}
-              </div>
-              <div className="d-flex align-items-center gap-1 mt-1 flex-wrap">
+              </span>
+              <span className="d-flex align-items-center gap-1 mt-1 flex-wrap">
                 <Badge
                   variant={
                     statusCfg.variant as
@@ -561,14 +561,14 @@ export const AutonomousWorkflowList: React.FC<AutonomousWorkflowListProps> = ({
                     {t('autoForkedFrom', language)}
                   </Badge>
                 )}
-              </div>
-              <div className="text-muted mt-1 auto-workflow-meta">
+              </span>
+              <span className="d-block text-muted mt-1 auto-workflow-meta">
                 <i
                   className={`bi ${workflow.workspace_type === 'remote' ? 'bi-cloud' : 'bi-laptop'} me-1`}
                 ></i>
                 {workflow.cli_tool}
                 {workflowDate && <span className="ms-2">{workflowDate}</span>}
-              </div>
+              </span>
             </>
           )}
         </button>

--- a/frontend/src/components/work/AutonomousWorkflowList.tsx
+++ b/frontend/src/components/work/AutonomousWorkflowList.tsx
@@ -461,7 +461,6 @@ export const AutonomousWorkflowList: React.FC<AutonomousWorkflowListProps> = ({
     const workflowDate = formatWorkflowDate(workflow.created_at);
     const itemClasses = [
       'list-group-item',
-      'list-group-item-action',
       'border-0',
       'px-3',
       'py-2',
@@ -476,8 +475,18 @@ export const AutonomousWorkflowList: React.FC<AutonomousWorkflowListProps> = ({
       .join(' ');
 
     return (
-      <div key={workflow.workflow_id} className={itemClasses} onClick={() => onSelect(workflow)}>
-        <div className="flex-grow-1 min-width-0">
+      <div key={workflow.workflow_id} className={itemClasses}>
+        <button
+          type="button"
+          className="flex-grow-1 auto-workflow-select-btn"
+          aria-current={isSelected ? 'true' : undefined}
+          aria-label={
+            workflow.title ||
+            workflow.requirements_text?.slice(0, 50) ||
+            `Workflow ${workflow.workflow_id.slice(0, 8)}`
+          }
+          onClick={() => onSelect(workflow)}
+        >
           {compact ? (
             <div className="d-flex align-items-start justify-content-between gap-2">
               <div className="min-width-0">
@@ -562,7 +571,7 @@ export const AutonomousWorkflowList: React.FC<AutonomousWorkflowListProps> = ({
               </div>
             </>
           )}
-        </div>
+        </button>
         <div className="d-flex align-items-center gap-1 ms-2">
           {isActive && (
             <span className="spinner-border spinner-border-sm text-primary" role="status">
@@ -571,8 +580,10 @@ export const AutonomousWorkflowList: React.FC<AutonomousWorkflowListProps> = ({
           )}
           {!isActive && (
             <button
+              type="button"
               className={`btn btn-sm border-0 p-0 auto-workflow-delete-btn ${isConfirming ? 'btn-outline-danger' : 'btn-outline-secondary'}`}
               title={t('autoDeleteWorkflow', language)}
+              aria-label={t('autoDeleteWorkflow', language)}
               disabled={deleteMutation.isPending}
               onClick={(e) => handleDeleteClick(e, workflow.workflow_id)}
             >
@@ -690,8 +701,10 @@ export const AutonomousWorkflowList: React.FC<AutonomousWorkflowListProps> = ({
               )}
               {!hasActiveWorkflow && (
                 <button
+                  type="button"
                   className={`btn btn-sm border-0 p-0 auto-workflow-delete-btn ${confirmDeleteId === batchDeleteConfirmKey ? 'btn-outline-danger' : 'btn-outline-secondary'}`}
                   title={t('autoDeleteWorkflow', language)}
+                  aria-label={t('autoDeleteWorkflow', language)}
                   disabled={deleteBatchMutation.isPending}
                   onClick={(event) => handleBatchDeleteClick(event, entry.batchId)}
                 >
@@ -727,6 +740,7 @@ export const AutonomousWorkflowList: React.FC<AutonomousWorkflowListProps> = ({
           <input
             className="form-control"
             placeholder={t('autoSearchWorkflows', language)}
+            aria-label={t('autoSearchWorkflows', language)}
             value={searchInput}
             onChange={(e) => handleSearchChange(e.target.value)}
           />
@@ -746,6 +760,7 @@ export const AutonomousWorkflowList: React.FC<AutonomousWorkflowListProps> = ({
         {STATUS_FILTER_TABS.map((tab) => (
           <button
             key={tab.key}
+            type="button"
             className={`btn btn-sm px-2 py-1 border-0 rounded-0 ${statusFilter === tab.key ? 'fw-bold text-primary border-bottom border-2 border-primary' : 'text-muted'}`}
             style={{ borderBottomWidth: '2px' }}
             onClick={() => handleStatusFilterChange(tab.key)}


### PR DESCRIPTION
## Summary

- replace light-mode batch metadata surfaces with theme-aware dark-mode tints
- improve workflow title hierarchy and dark-mode styling for light badges
- add visible focus treatment and semantic controls for workflow selection, search, and delete actions
- add coverage for the accessible workflow-list controls

## Root cause

The batch metadata pills, workflow count pill, expand control, and light badges used light-mode surface colors without scoped dark-theme overrides. In dark mode this produced light text on light backgrounds and made metadata look disabled.

## Impact

The autonomous workflow list now preserves readable contrast and a consistent hierarchy in dark mode while leaving light mode unchanged. Workflow rows and icon-only controls are also keyboard- and screen-reader-accessible.

## Validation

- `npm test -- --run src/components/work/AutonomousWorkflowList.test.tsx` (9 tests passed)
- `npm run build`
- `npx prettier --check src/components/work/AutonomousWorkflowList.css src/components/work/AutonomousWorkflowList.tsx src/components/work/AutonomousWorkflowList.test.tsx`
- targeted ESLint (0 errors; 2 pre-existing non-null-assertion warnings)
