### PR TITLE
fix(autonomous): worktree 策略下外部 git pull 误判 agent 越界（repo-drift 护栏修复）

### DIFF
--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -920,32 +920,45 @@ class AutonomousOrchestrator:
             "head": head,
         }
 
-    def _is_fast_forward(
+    def _main_head_is_remote_sourced(
         self,
         repo_path: str,
         before: str,
         after: str,
         system_account: str | None,
     ) -> bool:
-        """Return True if ``after`` is a descendant of ``before`` (fast-forward).
+        """Return True if ``after`` already exists on ``origin/main``.
 
-        Distinguishes a benign external ``git pull`` on the main repo (HEAD
-        fast-forwards during an agent run) from an agent committing outside the
-        workflow worktree (#1890). On any git probe failure we conservatively
-        return True so a transient probe error cannot fail an otherwise-healthy
-        workflow.
+        Tells a benign external ``git pull`` on the main repo (HEAD moves to a
+        remote-sourced commit during an agent run) apart from an agent
+        committing outside the workflow worktree. The previous fast-forward
+        check (``is-ancestor before after``) could not make this distinction:
+        a local escape ``git commit`` on main is *also* a descendant of
+        ``before``, so it was wrongly allowed. Membership in ``origin/main``
+        can — a pull brings a commit already on the remote, a local escape
+        commit is not yet pushed (#1890 review).
+
+        On any probe failure (network, missing ref) we conservatively return
+        True so a transient error cannot fail an otherwise-healthy workflow.
         """
         if not before or not after or before == after:
             return True
         try:
             gh = GitHubOps(repo_path, system_account=system_account)
+            # Refresh origin/main so the membership check sees the latest
+            # remote tip. A concurrent `git pull` updates this ref too, but an
+            # explicit fetch closes the fetch↔merge race window.
+            gh._run_git(["fetch", "origin", "main"])
             return (
-                gh._run_git(["merge-base", "--is-ancestor", before, after], check=False).returncode
+                gh._run_git(
+                    ["merge-base", "--is-ancestor", after, "origin/main"], check=False
+                ).returncode
                 == 0
             )
         except Exception as e:
             logger.warning(
-                "Workflow %s: fast-forward probe failed (%s..%s): %s; assuming fast-forward.",
+                "Workflow %s: remote-source probe failed for main HEAD %s..%s: %s; "
+                "assuming remote-sourced.",
                 self._workflow_id,
                 before[:8],
                 after[:8],
@@ -1024,18 +1037,20 @@ class AutonomousOrchestrator:
             ):
                 # main HEAD moved but the worktree did not. This is either an
                 # agent committing outside the worktree, or an external `git
-                # pull` on the main repo fast-forwarding HEAD during the agent
-                # run (#1890). The latter is benign — only treat it as an
-                # escape when the main HEAD did NOT fast-forward before→after.
-                if self._is_fast_forward(
+                # pull` on the main repo moving HEAD to a remote commit during
+                # the agent run (#1890). Allow only when the new HEAD already
+                # exists on origin/main (i.e. it was pulled, not locally
+                # committed); a local escape commit is not yet on the remote
+                # and is still blocked.
+                if self._main_head_is_remote_sourced(
                     ctx.get("project_path", ""),
                     before_main.get("head"),
                     after_main.get("head"),
                     system_account,
                 ):
                     logger.info(
-                        "Workflow %s: main repo HEAD fast-forwarded %s..%s during "
-                        "agent run (external pull); allowing.",
+                        "Workflow %s: main repo HEAD moved to a remote-sourced "
+                        "commit %s..%s during agent run (external pull); allowing.",
                         self._workflow_id,
                         before_main.get("head", "")[:8],
                         after_main.get("head", "")[:8],

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -920,6 +920,23 @@ class AutonomousOrchestrator:
             "head": head,
         }
 
+    def _ancestor_check(self, gh: "GitHubOps", a: str, b: str) -> bool | None:
+        """Return True if ``a`` is an ancestor of ``b``, False if not, None on
+        a git error.
+
+        ``git merge-base --is-ancestor`` exits 0 (yes), 1 (no), or 128+ (git
+        error such as a missing object). The 1-vs-error distinction matters:
+        a "no" is a definitive commit-graph answer we act on, a git error is
+        an indeterminate probe that must fail closed (see
+        ``_main_drift_is_benign_pull``).
+        """
+        rc = gh._run_git(["merge-base", "--is-ancestor", a, b], check=False).returncode
+        if rc == 0:
+            return True
+        if rc == 1:
+            return False
+        return None
+
     def _main_drift_is_benign_pull(
         self,
         repo_path: str,
@@ -930,56 +947,63 @@ class AutonomousOrchestrator:
         """Return True if main HEAD moving ``before`` → ``after`` is a benign
         external ``git pull`` (rather than an agent escaping the worktree).
 
-        Requires BOTH:
-          1. ``before`` is an ancestor of ``after`` — main moved *forward*.
-             A bare remote-membership check is not enough: ``reset --hard`` to
-             an older remote commit leaves ``after`` on origin/main but is a
-             non-fast-forward rollback that must be blocked.
-          2. ``after`` is an ancestor of ``origin/main`` — the new HEAD came
-             from the remote. A local escape ``git commit`` is a forward
-             descendant of ``before`` too, but is not yet pushed, so this
-             catches the common escape form.
+        Requires BOTH commit-graph conditions:
+          1. ``before`` is an ancestor of ``after`` — main moved *forward*
+             (rules out reset/rollback/history-rewrite).
+          2. ``after`` is an ancestor of ``origin/main`` — the new HEAD is a
+             remote-sourced commit (rules out a local, not-yet-pushed
+             ``git commit``).
 
-        Guarantee scope (this guardrail is commit-graph based and cannot prove
-        the *source* of an operation): it blocks an agent that runs ``git
-        commit`` / ``reset`` / ``checkout`` on the main repo without pushing.
-        It CANNOT block an agent that commits on main and then pushes to
-        ``origin/main`` — that forges the "remote-sourced" signal. Defending
-        against that requires main branch protection or revoking the agent's
-        push credentials, which is outside this guardrail's scope.
+        What this detects, stated as commit-graph states rather than as claims
+        about who ran which command: it blocks (a) a local un-pushed commit on
+        main (after is not on origin/main) and (b) a non-fast-forward change
+        (main did not move forward). It does NOT identify the operation's
+        source: an agent running ``git pull`` / ``reset --hard origin/main`` /
+        checking out a newer remote commit is graph-identical to an external
+        pull (forward + on remote) and is likewise allowed. That boundary is
+        inherent to a commit-graph check.
 
-        On any probe failure (network, missing ref) we conservatively return
-        True so a transient error cannot fail an otherwise-healthy workflow.
+        Failure policy is fail-closed. Reaching this method already means main
+        HEAD moved suspiciously during an agent run, so a probe that cannot
+        produce a definitive answer (a git error on merge-base) defaults to
+        "not proven benign" → block. ``fetch`` is best-effort (``check=False``):
+        a network/auth failure does not short-circuit — we fall back to the
+        existing origin/main ref, which a concurrent external pull has already
+        updated, so the two conditions remain distinguishable.
         """
         if not before or not after or before == after:
             return True
+        gh = GitHubOps(repo_path, system_account=system_account)
         try:
-            gh = GitHubOps(repo_path, system_account=system_account)
-            # Refresh origin/main so the membership check sees the latest
-            # remote tip. A concurrent `git pull` updates this ref too, but an
-            # explicit fetch closes the fetch↔merge race window.
-            gh._run_git(["fetch", "origin", "main"])
-            moved_forward = (
-                gh._run_git(["merge-base", "--is-ancestor", before, after], check=False).returncode
-                == 0
-            )
-            after_on_remote = (
-                gh._run_git(
-                    ["merge-base", "--is-ancestor", after, "origin/main"], check=False
-                ).returncode
-                == 0
-            )
+            # Best-effort refresh of origin/main. A concurrent external pull
+            # runs its own fetch and updates this ref, so even if this fetch
+            # fails the local ref is fresh enough to tell pull from local commit.
+            gh._run_git(["fetch", "origin", "main"], check=False)
+            moved_forward = self._ancestor_check(gh, before, after)
+            after_on_remote = self._ancestor_check(gh, after, "origin/main")
+            # A git error on either probe → cannot prove benign → fail closed.
+            if moved_forward is None or after_on_remote is None:
+                logger.warning(
+                    "Workflow %s: benign-pull probe indeterminate for main HEAD "
+                    "%s..%s (git error); failing closed.",
+                    self._workflow_id,
+                    before[:8],
+                    after[:8],
+                )
+                return False
             return moved_forward and after_on_remote
         except Exception as e:
+            # Unexpected exception (not a merge-base exit code). main HEAD has
+            # already moved suspiciously, so do not assume benign.
             logger.warning(
-                "Workflow %s: benign-pull probe failed for main HEAD %s..%s: %s; "
-                "assuming benign.",
+                "Workflow %s: benign-pull probe raised for main HEAD %s..%s: %s; "
+                "failing closed.",
                 self._workflow_id,
                 before[:8],
                 after[:8],
                 e,
             )
-            return True
+            return False
 
     def _snapshot_repo_context(
         self, wf: dict | None, workspace_type: str, system_account: str | None

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -972,6 +972,10 @@ class AutonomousOrchestrator:
         updated, so the two conditions remain distinguishable.
         """
         if not before or not after or before == after:
+            # Defensive: the sole caller (_validate_repo_context_after_run)
+            # only reaches this method when before_main != after_main, so
+            # before == after is currently unreachable. Kept so a future caller
+            # gets the correct "no drift → benign" answer instead of a probe.
             return True
         gh = GitHubOps(repo_path, system_account=system_account)
         try:

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -920,6 +920,39 @@ class AutonomousOrchestrator:
             "head": head,
         }
 
+    def _is_fast_forward(
+        self,
+        repo_path: str,
+        before: str,
+        after: str,
+        system_account: str | None,
+    ) -> bool:
+        """Return True if ``after`` is a descendant of ``before`` (fast-forward).
+
+        Distinguishes a benign external ``git pull`` on the main repo (HEAD
+        fast-forwards during an agent run) from an agent committing outside the
+        workflow worktree (#1890). On any git probe failure we conservatively
+        return True so a transient probe error cannot fail an otherwise-healthy
+        workflow.
+        """
+        if not before or not after or before == after:
+            return True
+        try:
+            gh = GitHubOps(repo_path, system_account=system_account)
+            return (
+                gh._run_git(["merge-base", "--is-ancestor", before, after], check=False).returncode
+                == 0
+            )
+        except Exception as e:
+            logger.warning(
+                "Workflow %s: fast-forward probe failed (%s..%s): %s; assuming fast-forward.",
+                self._workflow_id,
+                before[:8],
+                after[:8],
+                e,
+            )
+            return True
+
     def _snapshot_repo_context(
         self, wf: dict | None, workspace_type: str, system_account: str | None
     ) -> dict | None:
@@ -989,6 +1022,25 @@ class AutonomousOrchestrator:
                 and before_main.get("head") != after_main.get("head")
                 and before_effective.get("head") == after_effective.get("head")
             ):
+                # main HEAD moved but the worktree did not. This is either an
+                # agent committing outside the worktree, or an external `git
+                # pull` on the main repo fast-forwarding HEAD during the agent
+                # run (#1890). The latter is benign — only treat it as an
+                # escape when the main HEAD did NOT fast-forward before→after.
+                if self._is_fast_forward(
+                    ctx.get("project_path", ""),
+                    before_main.get("head"),
+                    after_main.get("head"),
+                    system_account,
+                ):
+                    logger.info(
+                        "Workflow %s: main repo HEAD fast-forwarded %s..%s during "
+                        "agent run (external pull); allowing.",
+                        self._workflow_id,
+                        before_main.get("head", "")[:8],
+                        after_main.get("head", "")[:8],
+                    )
+                    return ""
                 return (
                     "Detected commits on the main repository while the workflow worktree "
                     "HEAD did not move; the agent likely executed git commands outside "

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -920,23 +920,33 @@ class AutonomousOrchestrator:
             "head": head,
         }
 
-    def _main_head_is_remote_sourced(
+    def _main_drift_is_benign_pull(
         self,
         repo_path: str,
         before: str,
         after: str,
         system_account: str | None,
     ) -> bool:
-        """Return True if ``after`` already exists on ``origin/main``.
+        """Return True if main HEAD moving ``before`` → ``after`` is a benign
+        external ``git pull`` (rather than an agent escaping the worktree).
 
-        Tells a benign external ``git pull`` on the main repo (HEAD moves to a
-        remote-sourced commit during an agent run) apart from an agent
-        committing outside the workflow worktree. The previous fast-forward
-        check (``is-ancestor before after``) could not make this distinction:
-        a local escape ``git commit`` on main is *also* a descendant of
-        ``before``, so it was wrongly allowed. Membership in ``origin/main``
-        can — a pull brings a commit already on the remote, a local escape
-        commit is not yet pushed (#1890 review).
+        Requires BOTH:
+          1. ``before`` is an ancestor of ``after`` — main moved *forward*.
+             A bare remote-membership check is not enough: ``reset --hard`` to
+             an older remote commit leaves ``after`` on origin/main but is a
+             non-fast-forward rollback that must be blocked.
+          2. ``after`` is an ancestor of ``origin/main`` — the new HEAD came
+             from the remote. A local escape ``git commit`` is a forward
+             descendant of ``before`` too, but is not yet pushed, so this
+             catches the common escape form.
+
+        Guarantee scope (this guardrail is commit-graph based and cannot prove
+        the *source* of an operation): it blocks an agent that runs ``git
+        commit`` / ``reset`` / ``checkout`` on the main repo without pushing.
+        It CANNOT block an agent that commits on main and then pushes to
+        ``origin/main`` — that forges the "remote-sourced" signal. Defending
+        against that requires main branch protection or revoking the agent's
+        push credentials, which is outside this guardrail's scope.
 
         On any probe failure (network, missing ref) we conservatively return
         True so a transient error cannot fail an otherwise-healthy workflow.
@@ -949,16 +959,21 @@ class AutonomousOrchestrator:
             # remote tip. A concurrent `git pull` updates this ref too, but an
             # explicit fetch closes the fetch↔merge race window.
             gh._run_git(["fetch", "origin", "main"])
-            return (
+            moved_forward = (
+                gh._run_git(["merge-base", "--is-ancestor", before, after], check=False).returncode
+                == 0
+            )
+            after_on_remote = (
                 gh._run_git(
                     ["merge-base", "--is-ancestor", after, "origin/main"], check=False
                 ).returncode
                 == 0
             )
+            return moved_forward and after_on_remote
         except Exception as e:
             logger.warning(
-                "Workflow %s: remote-source probe failed for main HEAD %s..%s: %s; "
-                "assuming remote-sourced.",
+                "Workflow %s: benign-pull probe failed for main HEAD %s..%s: %s; "
+                "assuming benign.",
                 self._workflow_id,
                 before[:8],
                 after[:8],
@@ -1036,21 +1051,20 @@ class AutonomousOrchestrator:
                 and before_effective.get("head") == after_effective.get("head")
             ):
                 # main HEAD moved but the worktree did not. This is either an
-                # agent committing outside the worktree, or an external `git
-                # pull` on the main repo moving HEAD to a remote commit during
-                # the agent run (#1890). Allow only when the new HEAD already
-                # exists on origin/main (i.e. it was pulled, not locally
-                # committed); a local escape commit is not yet on the remote
-                # and is still blocked.
-                if self._main_head_is_remote_sourced(
+                # agent operating on the main repo, or an external `git pull`
+                # moving HEAD to a remote commit during the agent run. Allow
+                # only when the move is a forward update to a remote-sourced
+                # commit (a benign pull); a local escape commit (not pushed),
+                # a reset/rollback, or a non-fast-forward rewrite is blocked.
+                if self._main_drift_is_benign_pull(
                     ctx.get("project_path", ""),
                     before_main.get("head"),
                     after_main.get("head"),
                     system_account,
                 ):
                     logger.info(
-                        "Workflow %s: main repo HEAD moved to a remote-sourced "
-                        "commit %s..%s during agent run (external pull); allowing.",
+                        "Workflow %s: main repo HEAD moved %s..%s during agent run "
+                        "(benign external pull); allowing.",
                         self._workflow_id,
                         before_main.get("head", "")[:8],
                         after_main.get("head", "")[:8],

--- a/tests/autonomous/test_repo_drift_integration.py
+++ b/tests/autonomous/test_repo_drift_integration.py
@@ -57,16 +57,19 @@ def _add_remote_commit(origin, clone):
     """Add a new commit on origin/main (simulating a collaborator push).
 
     Returns the new commit SHA. Pushed via a second clone so the original
-    clone's main isn't moved yet.
+    clone's main isn't moved yet. Uses ``HEAD:refs/heads/main`` so the push is
+    independent of the clone's default branch name (CI runners may default to
+    ``master``).
     """
     other = clone.parent / "other"
     _git(clone.parent, "clone", "-q", str(origin), str(other))
     _git(other, "config", "user.email", "t@t.test")
     _git(other, "config", "user.name", "Test")
+    _git(other, "checkout", "-q", "-B", "main", "origin/main")
     (other / "f.txt").write_text("v2\n")
     _git(other, "add", "f.txt")
     _git(other, "commit", "-q", "-m", "remote c2")
-    _git(other, "push", "-q", "origin", "main")
+    _git(other, "push", "-q", "origin", "HEAD:refs/heads/main")
     return _git(other, "rev-parse", "HEAD").stdout.strip()
 
 

--- a/tests/autonomous/test_repo_drift_integration.py
+++ b/tests/autonomous/test_repo_drift_integration.py
@@ -1,0 +1,117 @@
+"""Integration tests for the repo-drift guardrail using a real git repo.
+
+The unit tests in ``test_repo_drift_validation.py`` mock ``GitHubOps`` and
+verify the orchestrator's if/else and fail-closed branching. They do NOT
+exercise real ``git merge-base`` / ``git fetch`` semantics. These tests build a
+real local git repository (a bare "origin" + a working clone) and drive
+``_main_drift_is_benign_pull`` against it with ``system_account=None``, so the
+two core paths run through actual git:
+
+  - An external ``git pull`` (main fast-forwards to a remote commit) → allowed.
+  - A local escape ``git commit`` on main (not pushed) → blocked.
+
+This protects the key assumption the unit-mocked tests rely on: that a
+forward, remote-sourced move is graph-distinguishable from a local commit.
+"""
+
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+
+def _git(repo, *args, check=True):
+    """Run git in ``repo`` and return the completed process."""
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True,
+        text=True,
+        check=check,
+    )
+
+
+def _build_repo(tmp_path):
+    """Create a bare origin + a working clone with one commit on main.
+
+    Returns (clone_path, base_commit_sha).
+    """
+    origin = tmp_path / "origin.git"
+    _git(tmp_path, "init", "--bare", str(origin))
+    clone = tmp_path / "repo"
+    _git(tmp_path, "clone", str(origin), str(clone))
+    _git(clone, "config", "user.email", "t@t.test")
+    _git(clone, "config", "user.name", "Test")
+    (clone / "f.txt").write_text("v1\n")
+    _git(clone, "add", "f.txt")
+    _git(clone, "commit", "-m", "c1")
+    _git(clone, "branch", "-M", "main")
+    _git(clone, "push", "-q", "origin", "main")
+    _git(clone, "fetch", "-q", "origin")
+    base = _git(clone, "rev-parse", "HEAD").stdout.strip()
+    return clone, base
+
+
+def _add_remote_commit(origin, clone):
+    """Add a new commit on origin/main (simulating a collaborator push).
+
+    Returns the new commit SHA. Pushed via a second clone so the original
+    clone's main isn't moved yet.
+    """
+    other = clone.parent / "other"
+    _git(clone.parent, "clone", "-q", str(origin), str(other))
+    _git(other, "config", "user.email", "t@t.test")
+    _git(other, "config", "user.name", "Test")
+    (other / "f.txt").write_text("v2\n")
+    _git(other, "add", "f.txt")
+    _git(other, "commit", "-q", "-m", "remote c2")
+    _git(other, "push", "-q", "origin", "main")
+    return _git(other, "rev-parse", "HEAD").stdout.strip()
+
+
+def _make_orchestrator():
+    wf = {"workflow_id": "wf-drift-int"}
+    with (
+        patch("app.modules.workspace.autonomous.orchestrator.Database"),
+        patch(
+            "app.modules.workspace.autonomous.orchestrator.AutonomousWorkflowRepository"
+        ) as mock_repo_cls,
+    ):
+        mock_repo = MagicMock()
+        mock_repo.get_workflow.return_value = wf
+        mock_repo_cls.return_value = mock_repo
+        o = AutonomousOrchestrator(wf["workflow_id"])
+        o.repo = mock_repo
+    return o
+
+
+@pytest.mark.regression
+class TestRepoDriftIntegration:
+    def test_external_pull_is_allowed(self, tmp_path):
+        # main starts at base. A collaborator pushes c2 to origin; the local
+        # clone then `git pull`s it. before=base, after=c2: forward AND on
+        # origin/main → benign → allowed.
+        clone, base = _build_repo(tmp_path)
+        origin = tmp_path / "origin.git"
+        c2 = _add_remote_commit(origin, clone)
+        # Simulate the external pull on the working clone.
+        _git(clone, "pull", "-q", "--ff-only", "origin", "main")
+        after = _git(clone, "rev-parse", "HEAD").stdout.strip()
+        assert after == c2
+
+        o = _make_orchestrator()
+        assert o._main_drift_is_benign_pull(str(clone), base, after, None) is True
+
+    def test_local_escape_commit_is_blocked(self, tmp_path):
+        # main starts at base. Agent makes a local commit on main WITHOUT
+        # pushing. before=base, after=local: forward BUT not on origin/main →
+        # blocked.
+        clone, base = _build_repo(tmp_path)
+        (clone / "g.txt").write_text("agent hack\n")
+        _git(clone, "add", "g.txt")
+        _git(clone, "commit", "-q", "-m", "agent escape")
+        after = _git(clone, "rev-parse", "HEAD").stdout.strip()
+
+        o = _make_orchestrator()
+        assert o._main_drift_is_benign_pull(str(clone), base, after, None) is False

--- a/tests/autonomous/test_repo_drift_validation.py
+++ b/tests/autonomous/test_repo_drift_validation.py
@@ -1,20 +1,19 @@
-"""Regression tests for repo-drift validation (#1890).
+"""Regression tests for the repo-drift post-run guardrail.
 
-The post-run guardrail in ``_validate_repo_context_after_run`` flags any case
-where the main repo HEAD moved during an agent run while the worktree HEAD did
-not. Issue #1890 exposed that this also fires for a benign external ``git pull``
-on the main repo, which is common on shared dev machines.
-
-The guardrail distinguishes the two by checking whether the new main HEAD
-already exists on ``origin/main``: a pull brings a remote-sourced commit, while
-a local escape commit (agent running ``git commit`` on main) is not yet pushed.
+``_validate_repo_context_after_run`` flags any case where the main repo HEAD
+moved during an agent run while the worktree HEAD did not. That signal alone
+also fires for a benign external ``git pull`` on the main repo, which is common
+on shared dev machines. The guardrail distinguishes the two by requiring BOTH
+that main moved *forward* (``before`` is an ancestor of ``after``) AND that the
+new HEAD came from the remote (``after`` is an ancestor of ``origin/main``).
 
 Covers:
-  - External ``git pull`` (new HEAD is on origin/main) → allowed.
-  - Agent local commit on main (new HEAD NOT on origin/main) → blocked.
-  - Non-fast-forward main rewrite (HEAD NOT on origin/main) → blocked.
+  - External ``git pull`` (forward + on origin/main) → allowed.
+  - Agent local commit on main (forward, NOT on origin/main) → blocked.
+  - Main reset to an older remote commit (NOT forward, on origin/main) → blocked.
+  - Non-fast-forward main rewrite (NOT forward, NOT on origin/main) → blocked.
   - Worktree HEAD also moved → allowed (pre-existing behaviour preserved).
-  - Remote-source probe itself raises → conservatively allowed.
+  - Benign-pull probe itself raises → conservatively allowed.
 """
 
 import os
@@ -23,21 +22,24 @@ from unittest.mock import MagicMock, patch
 from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
 
 MAIN_REPO = "/srv/open-ace"
-WORKTREE = "/srv/open-ace/.worktrees/wf-1890"
+WORKTREE = "/srv/open-ace/.worktrees/wf-drift"
 
 # SHAs used as HEAD values in the scenarios below.
 MAIN_BEFORE = "93f4753ae15c5e7cb0dec5c5bbfe5971e93dfec9"
-MAIN_AFTER_PULL = "a7409645a750904ecf1d313aa412169db41c4866"  # on origin/main (pulled)
-MAIN_AFTER_LOCAL = "a1b2c3d40000000000000000000000000000aaaa"  # local-only escape commit
+MAIN_AFTER_PULL = "a7409645a750904ecf1d313aa412169db41c4866"  # forward + on origin/main
+MAIN_AFTER_LOCAL = "a1b2c3d40000000000000000000000000000aaaa"  # forward, NOT on origin/main
+MAIN_AFTER_ROLLBACK = (
+    "522e220a0000000000000000000000000000000"  # older remote commit (reset target)
+)
 MAIN_AFTER_REWRITE = "ff00bad0000000000000000000000000000bad00"  # history rewrite
 WORKTREE_HEAD = "a7409645a750904ecf1d313aa412169db41c4866"
 
 
 def _make_orchestrator():
     wf = {
-        "workflow_id": "wf-1890",
+        "workflow_id": "wf-drift",
         "branch_strategy": "worktree",
-        "branch_name": "auto-dev/wf-1890",
+        "branch_name": "auto-dev/wf-drift",
         "worktree_path": WORKTREE,
         "project_path": MAIN_REPO,
         "workspace_type": "local",
@@ -64,12 +66,12 @@ def _before_state(main_head, effective_head=WORKTREE_HEAD):
             "project_path": MAIN_REPO,
             "worktree_path": WORKTREE,
             "repo_path": WORKTREE,
-            "expected_branch": "auto-dev/wf-1890",
+            "expected_branch": "auto-dev/wf-drift",
         },
         "effective": {
             "repo_path": WORKTREE,
             "top_level": WORKTREE,
-            "branch": "auto-dev/wf-1890",
+            "branch": "auto-dev/wf-drift",
             "head": effective_head,
         },
         "main": {
@@ -86,29 +88,32 @@ def _install_fake_gh(
     *,
     after_main_head,
     effective_head=WORKTREE_HEAD,
-    on_origin_main=True,
+    moved_forward=True,
+    after_on_remote=True,
     probe_raises=False,
 ):
     """Patch GitHubOps so _capture_repo_state returns scripted heads.
 
-    - Worktree repo (repo_path == WORKTREE) → effective_head, branch auto-dev/wf-1890.
+    - Worktree repo (repo_path == WORKTREE) → effective_head, branch auto-dev/wf-drift.
     - Main repo (repo_path == MAIN_REPO) → after_main_head, branch main.
     - ``fetch origin main`` → success (or raises when probe_raises).
-    - ``merge-base --is-ancestor <after> origin/main`` exits 0 when
-      on_origin_main else 1, modeling whether after_main_head is on the remote.
+    - ``merge-base --is-ancestor before after`` → exit 0 iff moved_forward
+      (main moved forward; False for reset/rollback/rewrite).
+    - ``merge-base --is-ancestor after origin/main`` → exit 0 iff
+      after_on_remote (after came from the remote).
     """
 
     def factory(repo_path, system_account=None):
         gh = MagicMock()
         if os.path.realpath(repo_path) == os.path.realpath(WORKTREE):
-            gh.get_current_branch.return_value = "auto-dev/wf-1890"
+            gh.get_current_branch.return_value = "auto-dev/wf-drift"
             gh.get_current_commit.return_value = effective_head
         else:  # main repo
             gh.get_current_branch.return_value = "main"
             gh.get_current_commit.return_value = after_main_head
 
         def run_git(args, check=True):
-            # probe_raises only breaks the remote-source probe (fetch +
+            # probe_raises only breaks the benign-pull probe (fetch +
             # merge-base), NOT the rev-parse/branch/commit probes used by
             # _capture_repo_state — otherwise the after-snapshot itself fails
             # before the probe is ever reached.
@@ -120,7 +125,12 @@ def _install_fake_gh(
             if args[:3] == ["fetch", "origin", "main"]:
                 return MagicMock(returncode=0)
             if args[:2] == ["merge-base", "--is-ancestor"]:
-                return MagicMock(returncode=0 if on_origin_main else 1)
+                # Distinguish the two probes by argument order:
+                #   before→after  (forward check)    args[2]=before, args[3]=after
+                #   after→origin  (remote check)     args[2]=after,  args[3]="origin/main"
+                if len(args) >= 4 and args[3] == "origin/main":
+                    return MagicMock(returncode=0 if after_on_remote else 1)
+                return MagicMock(returncode=0 if moved_forward else 1)
             # rev-parse --show-toplevel used by _capture_repo_state
             if args and args[0] == "rev-parse":
                 return MagicMock(stdout=repo_path)
@@ -133,14 +143,16 @@ def _install_fake_gh(
 
 
 class TestRepoDriftValidation:
-    def test_external_pull_with_remote_sourced_head_is_allowed(self, monkeypatch):
-        # Regression core: main HEAD moved to a commit already on origin/main
-        # (external git pull) while the worktree stayed put → NOT an escape.
+    def test_external_pull_is_allowed(self, monkeypatch):
+        # Regression core: main HEAD moved forward to a commit already on
+        # origin/main (external git pull) while the worktree stayed put →
+        # NOT an escape.
         _install_fake_gh(
             monkeypatch,
             after_main_head=MAIN_AFTER_PULL,
             effective_head=WORKTREE_HEAD,
-            on_origin_main=True,
+            moved_forward=True,
+            after_on_remote=True,
         )
         o = _make_orchestrator()
         before = _before_state(MAIN_BEFORE)
@@ -148,14 +160,32 @@ class TestRepoDriftValidation:
         assert o._validate_repo_context_after_run(before, system_account=None) == ""
 
     def test_agent_local_commit_on_main_is_blocked(self, monkeypatch):
-        # The case the fast-forward check missed (#1890 review): agent ran a
-        # plain `git commit` on main. The new HEAD is a descendant of before
-        # but is NOT on origin/main (not pushed) → must still be blocked.
+        # Agent ran a plain `git commit` on main. The new HEAD is forward from
+        # before but is NOT on origin/main (not pushed) → must be blocked.
         _install_fake_gh(
             monkeypatch,
             after_main_head=MAIN_AFTER_LOCAL,
             effective_head=WORKTREE_HEAD,
-            on_origin_main=False,
+            moved_forward=True,
+            after_on_remote=False,
+        )
+        o = _make_orchestrator()
+        before = _before_state(MAIN_BEFORE)
+
+        err = o._validate_repo_context_after_run(before, system_account=None)
+        assert "Detected commits on the main repository" in err
+
+    def test_main_reset_to_older_remote_commit_is_blocked(self, monkeypatch):
+        # The case the single remote-membership check missed: agent ran
+        # `reset --hard <older-remote-commit>`. The new HEAD IS on origin/main
+        # (it's an old remote commit) but main did NOT move forward — this is a
+        # non-fast-forward rollback that must be blocked.
+        _install_fake_gh(
+            monkeypatch,
+            after_main_head=MAIN_AFTER_ROLLBACK,
+            effective_head=WORKTREE_HEAD,
+            moved_forward=False,
+            after_on_remote=True,
         )
         o = _make_orchestrator()
         before = _before_state(MAIN_BEFORE)
@@ -164,13 +194,14 @@ class TestRepoDriftValidation:
         assert "Detected commits on the main repository" in err
 
     def test_non_fast_forward_main_rewrite_is_blocked(self, monkeypatch):
-        # main HEAD changed to a commit not on origin/main (history rewrite /
-        # branch switch) — real escape, still blocked.
+        # main HEAD changed to a commit that neither moves forward nor is on
+        # origin/main (history rewrite / branch switch) — real escape, blocked.
         _install_fake_gh(
             monkeypatch,
             after_main_head=MAIN_AFTER_REWRITE,
             effective_head=WORKTREE_HEAD,
-            on_origin_main=False,
+            moved_forward=False,
+            after_on_remote=False,
         )
         o = _make_orchestrator()
         before = _before_state(MAIN_BEFORE)
@@ -192,7 +223,7 @@ class TestRepoDriftValidation:
 
         assert o._validate_repo_context_after_run(before, system_account=None) == ""
 
-    def test_remote_source_probe_failure_is_allowed(self, monkeypatch):
+    def test_benign_pull_probe_failure_is_allowed(self, monkeypatch):
         # If the fetch / merge-base probe itself raises (network, missing ref)
         # we must NOT escalate a transient probe error into a workflow failure
         # — conservatively allow.

--- a/tests/autonomous/test_repo_drift_validation.py
+++ b/tests/autonomous/test_repo_drift_validation.py
@@ -7,13 +7,19 @@ on shared dev machines. The guardrail distinguishes the two by requiring BOTH
 that main moved *forward* (``before`` is an ancestor of ``after``) AND that the
 new HEAD came from the remote (``after`` is an ancestor of ``origin/main``).
 
+Failure policy is fail-closed: once main HEAD has moved suspiciously, a probe
+that cannot give a definitive answer (git error on merge-base) defaults to
+block, and a failed fetch falls back to the existing origin/main ref rather
+than short-circuiting to allow.
+
 Covers:
   - External ``git pull`` (forward + on origin/main) → allowed.
   - Agent local commit on main (forward, NOT on origin/main) → blocked.
   - Main reset to an older remote commit (NOT forward, on origin/main) → blocked.
   - Non-fast-forward main rewrite (NOT forward, NOT on origin/main) → blocked.
   - Worktree HEAD also moved → allowed (pre-existing behaviour preserved).
-  - Benign-pull probe itself raises → conservatively allowed.
+  - Local escape commit + fetch failure → still blocked (fetch is best-effort).
+  - merge-base git error (exit 128) → fail-closed (blocked).
 """
 
 import os
@@ -90,17 +96,19 @@ def _install_fake_gh(
     effective_head=WORKTREE_HEAD,
     moved_forward=True,
     after_on_remote=True,
-    probe_raises=False,
+    fetch_fail=False,
+    git_error=False,
 ):
     """Patch GitHubOps so _capture_repo_state returns scripted heads.
 
     - Worktree repo (repo_path == WORKTREE) → effective_head, branch auto-dev/wf-drift.
     - Main repo (repo_path == MAIN_REPO) → after_main_head, branch main.
-    - ``fetch origin main`` → success (or raises when probe_raises).
-    - ``merge-base --is-ancestor before after`` → exit 0 iff moved_forward
-      (main moved forward; False for reset/rollback/rewrite).
-    - ``merge-base --is-ancestor after origin/main`` → exit 0 iff
-      after_on_remote (after came from the remote).
+    - ``fetch origin main`` → exit 0, or exit 1 when fetch_fail (best-effort:
+      fetch failure must NOT short-circuit; the probe falls back to the
+      existing origin/main ref).
+    - ``merge-base --is-ancestor before after`` → exit 0 iff moved_forward.
+    - ``merge-base --is-ancestor after origin/main`` → exit 0 iff after_on_remote.
+    - When git_error, both merge-base calls return 128 (git error) → fail-closed.
     """
 
     def factory(repo_path, system_account=None):
@@ -113,18 +121,11 @@ def _install_fake_gh(
             gh.get_current_commit.return_value = after_main_head
 
         def run_git(args, check=True):
-            # probe_raises only breaks the benign-pull probe (fetch +
-            # merge-base), NOT the rev-parse/branch/commit probes used by
-            # _capture_repo_state — otherwise the after-snapshot itself fails
-            # before the probe is ever reached.
-            if probe_raises and (
-                args[:3] == ["fetch", "origin", "main"]
-                or args[:2] == ["merge-base", "--is-ancestor"]
-            ):
-                raise RuntimeError("probe boom")
             if args[:3] == ["fetch", "origin", "main"]:
-                return MagicMock(returncode=0)
+                return MagicMock(returncode=1 if fetch_fail else 0)
             if args[:2] == ["merge-base", "--is-ancestor"]:
+                if git_error:
+                    return MagicMock(returncode=128)  # indeterminate → fail closed
                 # Distinguish the two probes by argument order:
                 #   before→after  (forward check)    args[2]=before, args[3]=after
                 #   after→origin  (remote check)     args[2]=after,  args[3]="origin/main"
@@ -176,9 +177,8 @@ class TestRepoDriftValidation:
         assert "Detected commits on the main repository" in err
 
     def test_main_reset_to_older_remote_commit_is_blocked(self, monkeypatch):
-        # The case the single remote-membership check missed: agent ran
-        # `reset --hard <older-remote-commit>`. The new HEAD IS on origin/main
-        # (it's an old remote commit) but main did NOT move forward — this is a
+        # Agent ran `reset --hard <older-remote-commit>`. The new HEAD IS on
+        # origin/main (an old remote commit) but main did NOT move forward — a
         # non-fast-forward rollback that must be blocked.
         _install_fake_gh(
             monkeypatch,
@@ -223,17 +223,36 @@ class TestRepoDriftValidation:
 
         assert o._validate_repo_context_after_run(before, system_account=None) == ""
 
-    def test_benign_pull_probe_failure_is_allowed(self, monkeypatch):
-        # If the fetch / merge-base probe itself raises (network, missing ref)
-        # we must NOT escalate a transient probe error into a workflow failure
-        # — conservatively allow.
+    def test_local_escape_with_fetch_failure_is_still_blocked(self, monkeypatch):
+        # fetch fails (network/auth), but the probe must NOT short-circuit to
+        # allow. It falls back to the existing origin/main ref, which still
+        # shows the local escape commit is NOT on the remote → blocked.
         _install_fake_gh(
             monkeypatch,
-            after_main_head=MAIN_AFTER_PULL,
+            after_main_head=MAIN_AFTER_LOCAL,
             effective_head=WORKTREE_HEAD,
-            probe_raises=True,
+            moved_forward=True,
+            after_on_remote=False,
+            fetch_fail=True,
         )
         o = _make_orchestrator()
         before = _before_state(MAIN_BEFORE)
 
-        assert o._validate_repo_context_after_run(before, system_account=None) == ""
+        err = o._validate_repo_context_after_run(before, system_account=None)
+        assert "Detected commits on the main repository" in err
+
+    def test_merge_base_git_error_fails_closed(self, monkeypatch):
+        # merge-base returns 128 (git error, e.g. missing object) → the probe
+        # is indeterminate. Since main HEAD has already moved suspiciously,
+        # the guardrail fails closed (block) rather than assuming benign.
+        _install_fake_gh(
+            monkeypatch,
+            after_main_head=MAIN_AFTER_PULL,
+            effective_head=WORKTREE_HEAD,
+            git_error=True,
+        )
+        o = _make_orchestrator()
+        before = _before_state(MAIN_BEFORE)
+
+        err = o._validate_repo_context_after_run(before, system_account=None)
+        assert "Detected commits on the main repository" in err

--- a/tests/issues/1890/test_repo_drift_validation.py
+++ b/tests/issues/1890/test_repo_drift_validation.py
@@ -1,0 +1,176 @@
+"""Regression tests for repo-drift validation (#1890).
+
+The post-run guardrail in ``_validate_repo_context_after_run`` flags any case
+where the main repo HEAD moved during an agent run while the worktree HEAD did
+not. Issue #1890 exposed that this also fires for a benign external ``git pull``
+on the main repo (a fast-forward), which is common on shared dev machines.
+
+Covers:
+  - External ``git pull`` fast-forward on main during an agent run → allowed.
+  - Real escape (non-fast-forward main rewrite) → still blocked.
+  - Worktree HEAD also moved → allowed (pre-existing behaviour preserved).
+  - Fast-forward probe itself raises → conservatively allowed.
+"""
+
+import os
+from unittest.mock import MagicMock, patch
+
+from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+MAIN_REPO = "/srv/open-ace"
+WORKTREE = "/srv/open-ace/.worktrees/wf-1890"
+
+# Short SHAs used as HEAD values in the scenarios below.
+MAIN_BEFORE = "93f4753ae15c5e7cb0dec5c5bbfe5971e93dfec9"
+MAIN_AFTER_FF = "a7409645a750904ecf1d313aa412169db41c4866"  # descendant of MAIN_BEFORE
+MAIN_AFTER_ESCAPE = "ff00bad0000000000000000000000000000bad00"  # not a descendant
+WORKTREE_HEAD = "a7409645a750904ecf1d313aa412169db41c4866"
+
+
+def _make_orchestrator():
+    wf = {
+        "workflow_id": "wf-1890",
+        "branch_strategy": "worktree",
+        "branch_name": "auto-dev/wf-1890",
+        "worktree_path": WORKTREE,
+        "project_path": MAIN_REPO,
+        "workspace_type": "local",
+    }
+    with (
+        patch("app.modules.workspace.autonomous.orchestrator.Database"),
+        patch(
+            "app.modules.workspace.autonomous.orchestrator.AutonomousWorkflowRepository"
+        ) as mock_repo_cls,
+    ):
+        mock_repo = MagicMock()
+        mock_repo.get_workflow.return_value = wf
+        mock_repo_cls.return_value = mock_repo
+        o = AutonomousOrchestrator(wf["workflow_id"])
+        o.repo = mock_repo
+    return o
+
+
+def _before_state(main_head, effective_head=WORKTREE_HEAD):
+    """Build the dict shape produced by _snapshot_repo_context (worktree)."""
+    return {
+        "context": {
+            "strategy": "worktree",
+            "project_path": MAIN_REPO,
+            "worktree_path": WORKTREE,
+            "repo_path": WORKTREE,
+            "expected_branch": "auto-dev/wf-1890",
+        },
+        "effective": {
+            "repo_path": WORKTREE,
+            "top_level": WORKTREE,
+            "branch": "auto-dev/wf-1890",
+            "head": effective_head,
+        },
+        "main": {
+            "repo_path": MAIN_REPO,
+            "top_level": MAIN_REPO,
+            "branch": "main",
+            "head": main_head,
+        },
+    }
+
+
+def _install_fake_gh(
+    monkeypatch,
+    *,
+    after_main_head,
+    effective_head=WORKTREE_HEAD,
+    is_ancestor=True,
+    is_ancestor_raises=False,
+):
+    """Patch GitHubOps so _capture_repo_state returns scripted heads.
+
+    - Worktree repo (repo_path == WORKTREE) → effective_head, branch auto-dev/wf-1890.
+    - Main repo (repo_path == MAIN_REPO) → after_main_head, branch main.
+    - merge-base --is-ancestor exits 0 when is_ancestor else 1, unless
+      is_ancestor_raises (then _run_git raises) to test probe-failure handling.
+    """
+
+    def factory(repo_path, system_account=None):
+        gh = MagicMock()
+        if os.path.realpath(repo_path) == os.path.realpath(WORKTREE):
+            gh.get_current_branch.return_value = "auto-dev/wf-1890"
+            gh.get_current_commit.return_value = effective_head
+        else:  # main repo
+            gh.get_current_branch.return_value = "main"
+            gh.get_current_commit.return_value = after_main_head
+
+        def run_git(args, check=True):
+            if args[:2] == ["merge-base", "--is-ancestor"]:
+                if is_ancestor_raises:
+                    raise RuntimeError("probe boom")
+                return MagicMock(returncode=0 if is_ancestor else 1)
+            # rev-parse --show-toplevel used by _capture_repo_state
+            if args and args[0] == "rev-parse":
+                return MagicMock(stdout=repo_path)
+            return MagicMock(stdout="", returncode=0)
+
+        gh._run_git.side_effect = run_git
+        return gh
+
+    monkeypatch.setattr("app.modules.workspace.autonomous.orchestrator.GitHubOps", factory)
+
+
+class TestRepoDriftValidation:
+    def test_external_pull_fast_forward_is_allowed(self, monkeypatch):
+        # Regression core: main HEAD fast-forwarded (external git pull) while
+        # the worktree stayed put — must NOT be treated as an escape.
+        _install_fake_gh(
+            monkeypatch,
+            after_main_head=MAIN_AFTER_FF,
+            effective_head=WORKTREE_HEAD,
+            is_ancestor=True,  # MAIN_BEFORE is an ancestor of MAIN_AFTER_FF
+        )
+        o = _make_orchestrator()
+        before = _before_state(MAIN_BEFORE)
+
+        assert o._validate_repo_context_after_run(before, system_account=None) == ""
+
+    def test_non_fast_forward_main_rewrite_is_blocked(self, monkeypatch):
+        # main HEAD changed to a commit that is NOT a descendant of the before
+        # commit (history rewrite / branch switch) — real escape, still blocked.
+        _install_fake_gh(
+            monkeypatch,
+            after_main_head=MAIN_AFTER_ESCAPE,
+            effective_head=WORKTREE_HEAD,
+            is_ancestor=False,
+        )
+        o = _make_orchestrator()
+        before = _before_state(MAIN_BEFORE)
+
+        err = o._validate_repo_context_after_run(before, system_account=None)
+        assert "Detected commits on the main repository" in err
+
+    def test_worktree_also_moved_is_allowed(self, monkeypatch):
+        # Pre-existing behaviour: if the worktree HEAD also moved, the
+        # four-part condition never trips — validation passes regardless of
+        # what main did. Guards against regressing the original logic.
+        _install_fake_gh(
+            monkeypatch,
+            after_main_head=MAIN_AFTER_FF,
+            effective_head="cccccccc000000000000000000000000000000",  # worktree moved
+        )
+        o = _make_orchestrator()
+        before = _before_state(MAIN_BEFORE)
+
+        assert o._validate_repo_context_after_run(before, system_account=None) == ""
+
+    def test_fast_forward_probe_failure_is_allowed(self, monkeypatch):
+        # If the merge-base probe itself raises (detached HEAD, shallow clone,
+        # etc.) we must NOT escalate a transient probe error into a workflow
+        # failure — conservatively allow.
+        _install_fake_gh(
+            monkeypatch,
+            after_main_head=MAIN_AFTER_FF,
+            effective_head=WORKTREE_HEAD,
+            is_ancestor_raises=True,
+        )
+        o = _make_orchestrator()
+        before = _before_state(MAIN_BEFORE)
+
+        assert o._validate_repo_context_after_run(before, system_account=None) == ""

--- a/tests/issues/1890/test_repo_drift_validation.py
+++ b/tests/issues/1890/test_repo_drift_validation.py
@@ -3,13 +3,18 @@
 The post-run guardrail in ``_validate_repo_context_after_run`` flags any case
 where the main repo HEAD moved during an agent run while the worktree HEAD did
 not. Issue #1890 exposed that this also fires for a benign external ``git pull``
-on the main repo (a fast-forward), which is common on shared dev machines.
+on the main repo, which is common on shared dev machines.
+
+The guardrail distinguishes the two by checking whether the new main HEAD
+already exists on ``origin/main``: a pull brings a remote-sourced commit, while
+a local escape commit (agent running ``git commit`` on main) is not yet pushed.
 
 Covers:
-  - External ``git pull`` fast-forward on main during an agent run → allowed.
-  - Real escape (non-fast-forward main rewrite) → still blocked.
+  - External ``git pull`` (new HEAD is on origin/main) → allowed.
+  - Agent local commit on main (new HEAD NOT on origin/main) → blocked.
+  - Non-fast-forward main rewrite (HEAD NOT on origin/main) → blocked.
   - Worktree HEAD also moved → allowed (pre-existing behaviour preserved).
-  - Fast-forward probe itself raises → conservatively allowed.
+  - Remote-source probe itself raises → conservatively allowed.
 """
 
 import os
@@ -20,10 +25,11 @@ from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
 MAIN_REPO = "/srv/open-ace"
 WORKTREE = "/srv/open-ace/.worktrees/wf-1890"
 
-# Short SHAs used as HEAD values in the scenarios below.
+# SHAs used as HEAD values in the scenarios below.
 MAIN_BEFORE = "93f4753ae15c5e7cb0dec5c5bbfe5971e93dfec9"
-MAIN_AFTER_FF = "a7409645a750904ecf1d313aa412169db41c4866"  # descendant of MAIN_BEFORE
-MAIN_AFTER_ESCAPE = "ff00bad0000000000000000000000000000bad00"  # not a descendant
+MAIN_AFTER_PULL = "a7409645a750904ecf1d313aa412169db41c4866"  # on origin/main (pulled)
+MAIN_AFTER_LOCAL = "a1b2c3d40000000000000000000000000000aaaa"  # local-only escape commit
+MAIN_AFTER_REWRITE = "ff00bad0000000000000000000000000000bad00"  # history rewrite
 WORKTREE_HEAD = "a7409645a750904ecf1d313aa412169db41c4866"
 
 
@@ -80,15 +86,16 @@ def _install_fake_gh(
     *,
     after_main_head,
     effective_head=WORKTREE_HEAD,
-    is_ancestor=True,
-    is_ancestor_raises=False,
+    on_origin_main=True,
+    probe_raises=False,
 ):
     """Patch GitHubOps so _capture_repo_state returns scripted heads.
 
     - Worktree repo (repo_path == WORKTREE) → effective_head, branch auto-dev/wf-1890.
     - Main repo (repo_path == MAIN_REPO) → after_main_head, branch main.
-    - merge-base --is-ancestor exits 0 when is_ancestor else 1, unless
-      is_ancestor_raises (then _run_git raises) to test probe-failure handling.
+    - ``fetch origin main`` → success (or raises when probe_raises).
+    - ``merge-base --is-ancestor <after> origin/main`` exits 0 when
+      on_origin_main else 1, modeling whether after_main_head is on the remote.
     """
 
     def factory(repo_path, system_account=None):
@@ -101,10 +108,19 @@ def _install_fake_gh(
             gh.get_current_commit.return_value = after_main_head
 
         def run_git(args, check=True):
+            # probe_raises only breaks the remote-source probe (fetch +
+            # merge-base), NOT the rev-parse/branch/commit probes used by
+            # _capture_repo_state — otherwise the after-snapshot itself fails
+            # before the probe is ever reached.
+            if probe_raises and (
+                args[:3] == ["fetch", "origin", "main"]
+                or args[:2] == ["merge-base", "--is-ancestor"]
+            ):
+                raise RuntimeError("probe boom")
+            if args[:3] == ["fetch", "origin", "main"]:
+                return MagicMock(returncode=0)
             if args[:2] == ["merge-base", "--is-ancestor"]:
-                if is_ancestor_raises:
-                    raise RuntimeError("probe boom")
-                return MagicMock(returncode=0 if is_ancestor else 1)
+                return MagicMock(returncode=0 if on_origin_main else 1)
             # rev-parse --show-toplevel used by _capture_repo_state
             if args and args[0] == "rev-parse":
                 return MagicMock(stdout=repo_path)
@@ -117,28 +133,44 @@ def _install_fake_gh(
 
 
 class TestRepoDriftValidation:
-    def test_external_pull_fast_forward_is_allowed(self, monkeypatch):
-        # Regression core: main HEAD fast-forwarded (external git pull) while
-        # the worktree stayed put — must NOT be treated as an escape.
+    def test_external_pull_with_remote_sourced_head_is_allowed(self, monkeypatch):
+        # Regression core: main HEAD moved to a commit already on origin/main
+        # (external git pull) while the worktree stayed put → NOT an escape.
         _install_fake_gh(
             monkeypatch,
-            after_main_head=MAIN_AFTER_FF,
+            after_main_head=MAIN_AFTER_PULL,
             effective_head=WORKTREE_HEAD,
-            is_ancestor=True,  # MAIN_BEFORE is an ancestor of MAIN_AFTER_FF
+            on_origin_main=True,
         )
         o = _make_orchestrator()
         before = _before_state(MAIN_BEFORE)
 
         assert o._validate_repo_context_after_run(before, system_account=None) == ""
 
-    def test_non_fast_forward_main_rewrite_is_blocked(self, monkeypatch):
-        # main HEAD changed to a commit that is NOT a descendant of the before
-        # commit (history rewrite / branch switch) — real escape, still blocked.
+    def test_agent_local_commit_on_main_is_blocked(self, monkeypatch):
+        # The case the fast-forward check missed (#1890 review): agent ran a
+        # plain `git commit` on main. The new HEAD is a descendant of before
+        # but is NOT on origin/main (not pushed) → must still be blocked.
         _install_fake_gh(
             monkeypatch,
-            after_main_head=MAIN_AFTER_ESCAPE,
+            after_main_head=MAIN_AFTER_LOCAL,
             effective_head=WORKTREE_HEAD,
-            is_ancestor=False,
+            on_origin_main=False,
+        )
+        o = _make_orchestrator()
+        before = _before_state(MAIN_BEFORE)
+
+        err = o._validate_repo_context_after_run(before, system_account=None)
+        assert "Detected commits on the main repository" in err
+
+    def test_non_fast_forward_main_rewrite_is_blocked(self, monkeypatch):
+        # main HEAD changed to a commit not on origin/main (history rewrite /
+        # branch switch) — real escape, still blocked.
+        _install_fake_gh(
+            monkeypatch,
+            after_main_head=MAIN_AFTER_REWRITE,
+            effective_head=WORKTREE_HEAD,
+            on_origin_main=False,
         )
         o = _make_orchestrator()
         before = _before_state(MAIN_BEFORE)
@@ -152,7 +184,7 @@ class TestRepoDriftValidation:
         # what main did. Guards against regressing the original logic.
         _install_fake_gh(
             monkeypatch,
-            after_main_head=MAIN_AFTER_FF,
+            after_main_head=MAIN_AFTER_PULL,
             effective_head="cccccccc000000000000000000000000000000",  # worktree moved
         )
         o = _make_orchestrator()
@@ -160,15 +192,15 @@ class TestRepoDriftValidation:
 
         assert o._validate_repo_context_after_run(before, system_account=None) == ""
 
-    def test_fast_forward_probe_failure_is_allowed(self, monkeypatch):
-        # If the merge-base probe itself raises (detached HEAD, shallow clone,
-        # etc.) we must NOT escalate a transient probe error into a workflow
-        # failure — conservatively allow.
+    def test_remote_source_probe_failure_is_allowed(self, monkeypatch):
+        # If the fetch / merge-base probe itself raises (network, missing ref)
+        # we must NOT escalate a transient probe error into a workflow failure
+        # — conservatively allow.
         _install_fake_gh(
             monkeypatch,
-            after_main_head=MAIN_AFTER_FF,
+            after_main_head=MAIN_AFTER_PULL,
             effective_head=WORKTREE_HEAD,
-            is_ancestor_raises=True,
+            probe_raises=True,
         )
         o = _make_orchestrator()
         before = _before_state(MAIN_BEFORE)


### PR DESCRIPTION
## v4：fail-closed 失败策略 + 提交图状态表述（third review 处理）

> **四轮 review 让护栏的失败策略和保证范围逐步收敛到正确状态。** 每轮都暴露了前一版的疏漏，感谢 @richardhuang 的细致审查。
>
> | 版本 | 判据 / 失败策略 | review 发现的漏洞 |
> |------|----------------|------------------|
> | v1 | 快进（`is-ancestor before after`） | agent 本地 commit 也是后代 → 漏放 |
> | v2 | 远端成员（`is-ancestor after origin/main`） | reset 回退到旧远端 commit 仍在远端 → 漏放 |
> | v3 | 双条件（前进 AND 远端） | 保证范围表述说满；未处理失败策略 |
> | **v4** | **双条件 + fail-closed + 提交图状态表述** | — |

---

## 问题

worktree 策略的工作流在 planning 阶段失败，报错：
> Detected commits on the main repository while the workflow worktree HEAD did not move; the agent likely executed git commands outside the workflow worktree.

调查确认这是一次**误报**：planning 运行期间，主仓库 `main` 被外部 `git pull` 快进，而 worktree 分支 HEAD 不变。原护栏无法区分「外部 pull」与「agent 越界提交」，把前者误判成后者，导致整个工作流失败。护栏挂在底层 `_run_agent` 上，**所有阶段**（planning/dev/test/review/merge）在 worktree 策略下都受影响。

## 修复方案（v4）

`_main_drift_is_benign_pull`：放行需**同时**满足两个提交图条件：

1. `is-ancestor before after` = 0 → **main 前进了**（排除 reset/回退/改写）
2. `is-ancestor after origin/main` = 0 → **after 来自远端**（排除本地未 push commit）

| 场景 | 前进? | 远端? | 结果 | 正确行为 |
|------|-------|-------|------|---------|
| 外部 `git pull` | ✓ | ✓ | ✅ 放行 | ✓ |
| agent 本地 commit（未 push） | ✓ | ✗ | ❌ 拦截 | ✓ |
| **本地 commit + fetch 失败** | ✓ | ✗ | ❌ 拦截 | ✓（fetch 不短路） |
| reset 回退到旧远端 commit | ✗ | ✓ | ❌ 拦截 | ✓ |
| 非快进改写 | ✗ | ✗ | ❌ 拦截 | ✓ |
| merge-base git 错误(128) | None | — | ❌ 拦截(fail-closed) | ✓ |
| worktree 也产生提交 | 四元条件不成立 | — | ✅ 放行 | ✓ |

## ⚠️ 失败策略：fail-closed

进入 `_main_drift_is_benign_pull` 已经说明 main HEAD 在 agent 运行期间发生了可疑变化，所以探测失败时**倾向拦截**，不假定良性：

- `fetch` 用 `check=False`，失败（网络/认证/lock）不抛、不短路，回退用现有 `origin/main`（外部 pull 自带 fetch 已更新该 ref，仍能区分 pull vs 本地 commit）
- `merge-base` 通过 `_ancestor_check` 区分三态 exit code：0=祖先、1=非祖先、其它(128+)=git错误；git 错误 → None → fail-closed 拦截
- 外层异常也 fail-closed

## 📐 保证范围（提交图状态表述，不声称识别操作来源）

护栏检测的是**可由提交图判定的越界**：
- (a) 本地未 push 的 commit — after 不在 origin/main
- (b) 非快进改写 — main 未前进（reset/回退/历史改写）

**不声称识别操作来源**：agent 执行 `git pull`、`reset --hard origin/main`、checkout 到更新的远端提交，在提交图上与外部 pull 不可区分（都满足前进+远端），会被放行。这是 commit 图判据的固有边界。

## 改动

- `app/modules/workspace/autonomous/orchestrator.py`：新增 `_ancestor_check`（三态 exit code 映射）；`_main_drift_is_benign_pull` 改 fail-closed + 提交图状态 docstring；`_validate_repo_context_after_run` 调用点同步。
- `tests/autonomous/test_repo_drift_validation.py`：7 个回归测试（含 fetch 失败拦截 + git 错误 fail-closed）。

不改任何签名 / DB schema / 调用点 / 配置。

## 测试

```
tests/autonomous/test_repo_drift_validation.py .......  [100%]
7 passed
```

相邻 `tests/issues/716/test_orchestrator.py` 63 passed，无破坏。