### PR TITLE
fix(terminal): Windows 上隐藏 macOS 专用工具 ZCode

### DIFF
--- a/remote-agent/terminal_menu.py
+++ b/remote-agent/terminal_menu.py
@@ -48,6 +48,9 @@ TOOLS = [
         # On Linux, install/symlink the engine per ZCode's docs instead.
         "install_cmd": "sudo ln -s /Applications/ZCode.app/Contents/Resources/glm/zcode.cjs /usr/local/bin/zcode",
         "env_key": "ANTHROPIC_API_KEY",
+        # ZCode is macOS-only (ships as a desktop app bundle).
+        # Exclude from Windows menu to avoid confusing error messages.
+        "platforms": ["darwin", "linux"],
     },
 ]
 
@@ -72,8 +75,15 @@ def check_installed(cli_name: str) -> bool:
 
 
 def get_menu_items() -> list[dict]:
+    import platform
+
+    current_platform = platform.system().lower()  # "darwin", "linux", "windows"
     items = []
     for tool in TOOLS:
+        # Filter tools by platform if "platforms" field is specified
+        allowed_platforms = tool.get("platforms")
+        if allowed_platforms and current_platform not in allowed_platforms:
+            continue
         installed = check_installed(tool["cli"])
         configured = bool(os.environ.get(tool["env_key"]))
         items.append({**tool, "installed": installed, "configured": configured})

--- a/tests/unit/test_terminal_menu.py
+++ b/tests/unit/test_terminal_menu.py
@@ -16,6 +16,44 @@ def load_terminal_menu():
     return module
 
 
+def test_zcode_shown_on_linux_macos(monkeypatch):
+    """ZCode should appear in menu on Linux and macOS platforms."""
+    terminal_menu = load_terminal_menu()
+    monkeypatch.setattr(terminal_menu, "check_installed", lambda _: False)
+
+    # Mock platform.system to return "Linux"
+    import platform
+    monkeypatch.setattr(platform, "system", lambda: "Linux")
+
+    items = terminal_menu.get_menu_items()
+    zcode_items = [item for item in items if item.get("cli") == "zcode"]
+    assert len(zcode_items) == 1, "ZCode should appear in menu on Linux"
+
+    # Mock platform.system to return "Darwin" (macOS)
+    monkeypatch.setattr(platform, "system", lambda: "Darwin")
+    items = terminal_menu.get_menu_items()
+    zcode_items = [item for item in items if item.get("cli") == "zcode"]
+    assert len(zcode_items) == 1, "ZCode should appear in menu on macOS"
+
+
+def test_zcode_hidden_on_windows(monkeypatch):
+    """ZCode should NOT appear in menu on Windows (it's macOS-only)."""
+    terminal_menu = load_terminal_menu()
+    monkeypatch.setattr(terminal_menu, "check_installed", lambda _: False)
+
+    # Mock platform.system to return "Windows"
+    import platform
+    monkeypatch.setattr(platform, "system", lambda: "Windows")
+
+    items = terminal_menu.get_menu_items()
+    zcode_items = [item for item in items if item.get("cli") == "zcode"]
+    assert len(zcode_items) == 0, "ZCode should NOT appear in menu on Windows"
+
+    # Verify other tools are still shown
+    claude_items = [item for item in items if item.get("cli") == "claude"]
+    assert len(claude_items) == 1, "Claude Code should still appear on Windows"
+
+
 def test_handle_select_execs_command(monkeypatch):
     terminal_menu = load_terminal_menu()
     executed_commands = []


### PR DESCRIPTION
## 问题描述

Fixes #1911

Windows 环境下选择 "Install ZCode" 报 "找不到命令" 错误。

## 根因分析

ZCode 是 macOS 桌面应用，安装命令使用 `sudo ln -s` 等 Unix 命令：

```python
"install_cmd": "sudo ln -s /Applications/ZCode.app/Contents/Resources/glm/zcode.cjs /usr/local/bin/zcode"
```

在 Windows 上执行此命令会报错，因为：
1. Windows 没有 `sudo` 命令
2. Windows 没有 `ln` 命令
3. 路径 `/Applications/ZCode.app/...` 在 Windows 上不存在

## 修复方案

为 `TOOLS` 数组添加 `platforms` 字段，指定工具支持的平台：

```python
{
    "name": "ZCode",
    "cli": "zcode",
    ...
    "platforms": ["darwin", "linux"],  # macOS 和 Linux
}
```

`get_menu_items()` 函数根据当前平台过滤工具列表，Windows 上不显示 ZCode。

## 测试

- `test_zcode_shown_on_linux_macos` - 验证 Linux/macOS 显示 ZCode
- `test_zcode_hidden_on_windows` - 验证 Windows 隐藏 ZCode

## 影响范围

- Windows 用户不再看到无法安装的 ZCode 选项
- Linux/macOS 行为保持不变