### PR TITLE
fix(work/files): PersonalFiles usability + backend locale bug (Issue #1912)

### DIFF
--- a/app/routes/fs.py
+++ b/app/routes/fs.py
@@ -708,7 +708,14 @@ def list_subdirectories(
                 if not st:
                     # stat failed for this entry (e.g. broken symlink) — skip.
                     continue
-                is_dir = st["type"] == "directory"
+                # %F (st["type"]) is locale-dependent — under non-C locales
+                # stat emits a translated string (e.g. "目录" under zh_CN),
+                # which would misclassify every directory as a non-directory
+                # and break PersonalFiles navigation (Issue #1912). The %A
+                # perm string is always ASCII ("drwxr-xr-x" / "-rw-r--r--"),
+                # so its first char is a locale-independent type marker.
+                perm = st.get("perm") or ""
+                is_dir = perm[:1] == "d"
 
                 if full_path in access_cache:
                     # owner != system_account: use the accurate access check.

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -3,9 +3,9 @@
  * Provides offline support and caching for PWA
  */
 
-const CACHE_NAME = 'open-ace-v5';
-const STATIC_CACHE_NAME = 'open-ace-static-v5';
-const API_CACHE_NAME = 'open-ace-api-v5';
+const CACHE_NAME = 'open-ace-v6';
+const STATIC_CACHE_NAME = 'open-ace-static-v6';
+const API_CACHE_NAME = 'open-ace-api-v6';
 
 // Static assets to cache immediately
 const STATIC_ASSETS = ['/', '/app', '/login', '/static/js/dist/index.html'];
@@ -78,7 +78,17 @@ self.addEventListener('fetch', (event) => {
     return;
   }
 
-  // Handle static assets
+  // Navigation requests (HTML pages) MUST be network-first so that new
+  // deploys (new index.html referencing new content-hashed JS/CSS chunks)
+  // are picked up immediately. A cache-first strategy here would freeze
+  // users on the stale app shell from a previous deploy, defeating the
+  // purpose of content-hashed assets. Issue #1912.
+  if (request.mode === 'navigate') {
+    event.respondWith(handleNavigationRequest(request));
+    return;
+  }
+
+  // Handle static assets (content-hashed, immutable) — cache-first is safe.
   event.respondWith(handleStaticRequest(request));
 });
 
@@ -114,6 +124,36 @@ async function handleApiRequest(request) {
       status: 503,
       headers: { 'Content-Type': 'application/json' },
     });
+  }
+}
+
+/**
+ * Handle navigation requests with network-first strategy.
+ *
+ * Always try the network first so new deploys are visible immediately; fall
+ * back to the cached app shell only when offline. The fetched response is
+ * cloned into the static cache so subsequent offline loads work.
+ */
+async function handleNavigationRequest(request) {
+  try {
+    const response = await fetch(request);
+    if (response.ok && response.type === 'basic') {
+      const cache = await caches.open(STATIC_CACHE_NAME);
+      cache.put(request, response.clone());
+    }
+    return response;
+  } catch (error) {
+    const cachedResponse = await caches.match(request);
+    if (cachedResponse) {
+      return cachedResponse;
+    }
+    // Last-resort fallbacks for offline navigation.
+    const fallback =
+      (await caches.match('/app')) || (await caches.match('/static/js/dist/index.html'));
+    if (fallback) {
+      return fallback;
+    }
+    return new Response('Offline', { status: 503 });
   }
 }
 

--- a/frontend/src/components/work/LocalDirectoryBrowser.test.tsx
+++ b/frontend/src/components/work/LocalDirectoryBrowser.test.tsx
@@ -249,4 +249,92 @@ describe('LocalDirectoryBrowser', () => {
     // Upload button hidden too (only shown when isWritable)
     expect(screen.queryByText('uploadFile')).not.toBeInTheDocument();
   });
+
+  // Issue #1912: double-clicking a directory should also navigate into it
+  // (matches desktop file-manager muscle memory).
+  it('navigates into a subdirectory on double-click', async () => {
+    browseDirectoryMock.mockResolvedValue(
+      browseResponse({
+        directories: [
+          { name: 'subdir', path: '/home/alice/subdir', is_writable: true },
+        ],
+      })
+    );
+
+    render(
+      <LocalDirectoryBrowser initialPath="/home/alice" onSelectPath={() => {}} enableFileActions />
+    );
+
+    const row = await screen.findByText('subdir');
+    fireEvent.doubleClick(row);
+    await waitFor(() => {
+      expect(browseDirectoryMock).toHaveBeenCalledWith('/home/alice/subdir', {
+        includeFiles: true,
+      });
+    });
+  });
+
+  // Issue #1912: a failed browseDirectory should surface a toast so the
+  // error is not missed when the list visually does not change.
+  it('surfaces a toast error when browseDirectory fails', async () => {
+    browseDirectoryMock.mockRejectedValue(new Error('boom'));
+
+    render(
+      <LocalDirectoryBrowser initialPath="/home/alice" onSelectPath={() => {}} enableFileActions />
+    );
+
+    await waitFor(() => {
+      expect(toastMock.error).toHaveBeenCalledWith(
+        'browseDirectory',
+        expect.stringContaining('boom')
+      );
+    });
+  });
+
+  // Issue #1912: when manual input is hidden (PersonalFiles use case), the
+  // action button should read "Open Session Here" and show the path that
+  // will be used, instead of the misleading "Select" label.
+  it('renders "Open Session Here" button and path preview when hideManualInput=true', async () => {
+    browseDirectoryMock.mockResolvedValue(
+      browseResponse({ path: '/home/alice' })
+    );
+
+    render(
+      <LocalDirectoryBrowser
+        initialPath="/home/alice"
+        onSelectPath={() => {}}
+        hideManualInput
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('openSessionHere')).toBeInTheDocument();
+    });
+    // Path preview label present (only rendered in the hideManualInput branch)
+    expect(screen.getByText(/willUsePath/)).toBeInTheDocument();
+    // Legacy "Select" label absent
+    expect(screen.queryByText('select')).not.toBeInTheDocument();
+  });
+
+  // Issue #1912: directories and files must be visually distinguishable —
+  // directories use the solid filled folder icon, files use the file-earmark.
+  it('uses bi-folder-fill for directories and bi-file-earmark for files', async () => {
+    browseDirectoryMock.mockResolvedValue(
+      browseResponse({
+        directories: [{ name: 'subdir', path: '/home/alice/subdir', is_writable: true }],
+        files: [{ name: 'note.txt', path: '/home/alice/note.txt', size: 4, is_readable: true }],
+      })
+    );
+
+    const { container } = render(
+      <LocalDirectoryBrowser initialPath="/home/alice" onSelectPath={() => {}} enableFileActions />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('subdir')).toBeInTheDocument();
+    });
+
+    expect(container.querySelector('.bi-folder-fill')).not.toBeNull();
+    expect(container.querySelector('.bi-file-earmark')).not.toBeNull();
+  });
 });

--- a/frontend/src/components/work/LocalDirectoryBrowser.test.tsx
+++ b/frontend/src/components/work/LocalDirectoryBrowser.test.tsx
@@ -255,9 +255,7 @@ describe('LocalDirectoryBrowser', () => {
   it('navigates into a subdirectory on double-click', async () => {
     browseDirectoryMock.mockResolvedValue(
       browseResponse({
-        directories: [
-          { name: 'subdir', path: '/home/alice/subdir', is_writable: true },
-        ],
+        directories: [{ name: 'subdir', path: '/home/alice/subdir', is_writable: true }],
       })
     );
 
@@ -295,16 +293,10 @@ describe('LocalDirectoryBrowser', () => {
   // action button should read "Open Session Here" and show the path that
   // will be used, instead of the misleading "Select" label.
   it('renders "Open Session Here" button and path preview when hideManualInput=true', async () => {
-    browseDirectoryMock.mockResolvedValue(
-      browseResponse({ path: '/home/alice' })
-    );
+    browseDirectoryMock.mockResolvedValue(browseResponse({ path: '/home/alice' }));
 
     render(
-      <LocalDirectoryBrowser
-        initialPath="/home/alice"
-        onSelectPath={() => {}}
-        hideManualInput
-      />
+      <LocalDirectoryBrowser initialPath="/home/alice" onSelectPath={() => {}} hideManualInput />
     );
 
     await waitFor(() => {

--- a/frontend/src/components/work/LocalDirectoryBrowser.tsx
+++ b/frontend/src/components/work/LocalDirectoryBrowser.tsx
@@ -182,12 +182,17 @@ export const LocalDirectoryBrowser: React.FC<LocalDirectoryBrowserProps> = ({
           setFallbackNote(result.fallback_note);
         }
       } catch (err) {
-        setError((err as Error)?.message || 'Failed to browse directory');
+        const msg = (err as Error)?.message || 'Failed to browse directory';
+        setError(msg);
+        // Issue #1912: Also surface the error as a toast so a failed
+        // navigation into a subdirectory is not missed (the inline alert
+        // can be overlooked when the list state visually does not change).
+        toast.error(t('browseDirectory', language) || 'Browse Directory', msg);
       } finally {
         setIsLoading(false);
       }
     },
-    [enableFileActions]
+    [enableFileActions, toast, language]
   );
 
   useEffect(() => {
@@ -581,18 +586,28 @@ export const LocalDirectoryBrowser: React.FC<LocalDirectoryBrowserProps> = ({
                   key={dir.path}
                   className="list-group-item list-group-item-action d-flex justify-content-between align-items-center"
                   onClick={() => handleNavigate(dir)}
+                  onDoubleClick={() => handleNavigate(dir)}
+                  title={t('doubleClickToOpen', language) || 'Double-click to open'}
                   style={{ cursor: 'pointer' }}
                 >
-                  <div>
-                    <i className="bi bi-folder me-2" />
-                    <span>{dir.name}</span>
+                  <div className="d-flex align-items-center text-truncate">
+                    <i
+                      className="bi bi-folder-fill me-2 text-warning"
+                      role="img"
+                      aria-label={t('folder', language) || 'Folder'}
+                    />
+                    <span className="text-truncate">{dir.name}</span>
                   </div>
-                  {dir.is_writable && (
-                    <span className="badge bg-success-subtle text-success small">
-                      <i className="bi bi-pencil me-1" />
-                      {t('writable', language) || 'Writable'}
-                    </span>
-                  )}
+                  <div className="d-flex align-items-center gap-1 flex-shrink-0">
+                    {dir.is_writable && (
+                      <span className="badge bg-success-subtle text-success small">
+                        <i className="bi bi-pencil me-1" />
+                        {t('writable', language) || 'Writable'}
+                      </span>
+                    )}
+                    {/* Issue #1912: visual affordance that the row enters a subdirectory */}
+                    <i className="bi bi-chevron-right text-muted small" aria-hidden="true" />
+                  </div>
                 </li>
               ))}
             </ul>
@@ -604,7 +619,11 @@ export const LocalDirectoryBrowser: React.FC<LocalDirectoryBrowserProps> = ({
                     className="list-group-item file-list-item d-flex justify-content-between align-items-center"
                   >
                     <div className="text-truncate">
-                      <i className="bi bi-file-earmark me-2" />
+                      <i
+                        className="bi bi-file-earmark me-2 text-muted"
+                        role="img"
+                        aria-label={t('file', language) || 'File'}
+                      />
                       <span className="text-truncate">{file.name}</span>
                       <span className="badge text-muted fw-normal ms-2 small">
                         {formatBytes(file.size)}
@@ -679,11 +698,19 @@ export const LocalDirectoryBrowser: React.FC<LocalDirectoryBrowserProps> = ({
       )}
 
       {/* Issue #1813: Always show Select button when manual input is hidden */}
+      {/* Issue #1912: Rename to "Open Session Here" + show the path that will be used, */}
+      {/* so the button's behaviour matches its label (it opens a new session in currentPath). */}
       {hideManualInput && (
-        <div className="mt-3">
+        <div className="mt-3 d-flex flex-column gap-2 align-items-start">
+          {currentPath && (
+            <span className="small text-muted text-break">
+              <i className="bi bi-folder2-open me-1" aria-hidden="true" />
+              {t('willUsePath', language, { path: currentPath }) || `Will use: ${currentPath}`}
+            </span>
+          )}
           <Button variant="primary" onClick={handleSelect}>
-            <i className="bi bi-check-lg me-1" />
-            {t('select', language) || 'Select'}
+            <i className="bi bi-folder-plus me-1" />
+            {t('openSessionHere', language) || 'Open Session Here'}
           </Button>
         </div>
       )}

--- a/frontend/src/components/work/LocalDirectoryBrowser.tsx
+++ b/frontend/src/components/work/LocalDirectoryBrowser.tsx
@@ -592,7 +592,7 @@ export const LocalDirectoryBrowser: React.FC<LocalDirectoryBrowserProps> = ({
                 >
                   <div className="d-flex align-items-center text-truncate">
                     <i
-                      className="bi bi-folder-fill me-2 text-warning"
+                      className="bi bi-folder-fill me-2"
                       role="img"
                       aria-label={t('folder', language) || 'Folder'}
                     />
@@ -620,7 +620,7 @@ export const LocalDirectoryBrowser: React.FC<LocalDirectoryBrowserProps> = ({
                   >
                     <div className="text-truncate">
                       <i
-                        className="bi bi-file-earmark me-2 text-muted"
+                        className="bi bi-file-earmark me-2"
                         role="img"
                         aria-label={t('file', language) || 'File'}
                       />

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -1454,6 +1454,14 @@ export const translations: Record<Language, Translations> = {
     noSubdirectories: 'No subdirectories found',
     folderName: 'Folder name',
     createDirError: 'Failed to create directory.',
+    // Issue #1912: Personal files browser clarity
+    folder: 'Folder',
+    file: 'File',
+    folders: 'Folders',
+    files: 'Files',
+    doubleClickToOpen: 'Double-click to open',
+    openSessionHere: 'Open Session Here',
+    willUsePath: 'Will use: {path}',
 
     // AI Autonomous Development
     autonomousDev: 'AI Autonomous Dev',
@@ -3120,6 +3128,13 @@ export const translations: Record<Language, Translations> = {
     noSubdirectories: '没有子目录',
     folderName: '文件夹名称',
     createDirError: '创建目录失败。',
+    folder: '文件夹',
+    file: '文件',
+    folders: '文件夹',
+    files: '文件',
+    doubleClickToOpen: '双击打开',
+    openSessionHere: '在此目录新建会话',
+    willUsePath: '将使用：{path}',
 
     // AI 自主开发
     autonomousDev: 'AI 自主开发',
@@ -4565,6 +4580,13 @@ export const translations: Record<Language, Translations> = {
     noSubdirectories: 'サブディレクトリがありません',
     folderName: 'フォルダ名',
     createDirError: 'ディレクトリの作成に失敗しました。',
+    folder: 'フォルダ',
+    file: 'ファイル',
+    folders: 'フォルダ',
+    files: 'ファイル',
+    doubleClickToOpen: 'ダブルクリックで開く',
+    openSessionHere: 'ここでセッションを開く',
+    willUsePath: '使用パス: {path}',
 
     // AI自律開発
     autonomousDev: 'AI自律開発',
@@ -6100,6 +6122,13 @@ export const translations: Record<Language, Translations> = {
     noSubdirectories: '하위 디렉토리 없음',
     folderName: '폴더 이름',
     createDirError: '디렉토리 생성에 실패했습니다.',
+    folder: '폴더',
+    file: '파일',
+    folders: '폴더',
+    files: '파일',
+    doubleClickToOpen: '더블클릭하여 열기',
+    openSessionHere: '이 디렉토리에서 세션 열기',
+    willUsePath: '사용 경로: {path}',
 
     // AI 자율 개발
     autonomousDev: 'AI 자율 개발',

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -3379,6 +3379,20 @@ table .latency-row:hover td {
   border-top: 1px solid var(--border-color);
 }
 
+/* Issue #1912: Tint folder/file icons so directories and files are
+   distinguishable at a glance (solid yellow folder vs muted file). */
+.personal-files .directory-list .bi-folder-fill {
+  color: #e0a800;
+}
+
+.personal-files .directory-list .bi-file-earmark {
+  color: var(--bs-secondary-color, #6c757d);
+}
+
+[data-bs-theme='dark'] .personal-files .directory-list .bi-folder-fill {
+  color: #f0ad4e;
+}
+
 .personal-files .file-list .file-list-item {
   padding: 0.35rem 0.75rem;
 }

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -3379,20 +3379,6 @@ table .latency-row:hover td {
   border-top: 1px solid var(--border-color);
 }
 
-/* Issue #1912: Tint folder/file icons so directories and files are
-   distinguishable at a glance (solid yellow folder vs muted file). */
-.personal-files .directory-list .bi-folder-fill {
-  color: #e0a800;
-}
-
-.personal-files .directory-list .bi-file-earmark {
-  color: var(--bs-secondary-color, #6c757d);
-}
-
-[data-bs-theme='dark'] .personal-files .directory-list .bi-folder-fill {
-  color: #f0ad4e;
-}
-
 .personal-files .file-list .file-list-item {
   padding: 0.35rem 0.75rem;
 }


### PR DESCRIPTION
## Summary

Fixes #1912 — `/work/files` (PersonalFiles) interaction & usability issues.

The issue report identified three frontend problems (misleading "Select" button, can't enter subdirectories, directories/files visually indistinguishable). Investigation during deployment surfaced **two deeper root causes** that the frontend-only fixes alone could not solve — both are included here.

## Root causes found

### 1. Backend locale bug — the real reason subdirectories were unreachable
`list_subdirectories` in `app/routes/fs.py` classified entries with `stat -c '%F'` and compared the result to the literal `"directory"`. Under a non-C locale (the deployed server runs `LANG=zh_CN.UTF-8`), `%F` emits a **translated** string (`目录`), so `is_dir` was always `False`. Every subdirectory was misclassified as a file, rendered with the file icon, and given no click-to-enter handler — which is why "double-click/click can't enter directory" and "no folder icon" were reported. Verified live:
```
LANG=zh_CN.UTF-8 stat -c '%F' /home/wd237/logs   →  目录
LANG=C          stat -c '%F' /home/wd237/logs   →  directory
```

### 2. Service Worker cache-first navigation — new deploys invisible
`public/sw.js` served **all** requests (including the SPA shell `/`) cache-first and cached `/` on install. Because `index.html` references content-hashed chunks, a stale `index.html` pinned users to the old chunks forever, and hard refresh does **not** bypass the SW cache. This masked the frontend fix after the first deployment.

## Changes

| Commit | Area | Change |
|---|---|---|
| `3d17029a` | backend | `is_dir` now derived from the `%A` perm string's first char (`d`), which coreutils always emits as ASCII regardless of locale. No new `stat` fork — `%A` was already captured. |
| `4ff836f1` | frontend | Solid `bi-folder-fill` for directories vs outline `bi-file-earmark` for files; `onDoubleClick` to enter directories (matches desktop muscle memory); failed `browseDirectory` surfaced as a toast; rename the misleading "✓ Select" button to "Open Session Here" with a path preview (only when `hideManualInput`); `aria-label` on icons. |
| `d8415a10` | frontend | Per reviewer feedback, drop icon color tinting — distinguish by shape only (solid folder vs outline file) + `›` affordance. |
| `c98797ec` | sw | Bump cache v5→v6; route navigation through a new network-first `handleNavigationRequest`, falling back to cache only offline. Hashed static assets stay cache-first. |

## i18n
Added keys (en/zh/ja/ko): `folder`, `file`, `folders`, `files`, `doubleClickToOpen`, `openSessionHere`, `willUsePath`.

## Tests
- Frontend: +4 tests in `LocalDirectoryBrowser.test.tsx` (double-click navigation, toast on browse failure, "Open Session Here" + path preview, icon classes). `work/` + `i18n/` suites green (130 passing).
- Backend: the locale fix verified live against the running instance — `GET /api/fs/browse?path=home&include_files=1` now returns `logs`/`open-ace` under `directories` (previously under `files`); navigating into `/home/wd237/logs` succeeds. Pre-existing `/root`-blacklist test failures are unrelated (confirmed via `git stash`).

## Verification on deployed host
- Backend restarted via systemd; API returns correct directory/file split under `zh_CN.UTF-8`.
- New `LocalDirectoryBrowser` chunk served with `bi-folder-fill`, `onDoubleClick`, `openSessionHere` (no `text-warning`).
- SW v6 with `handleNavigationRequest` served.
- After clearing the old SW (DevTools → Application → Service Workers → Unregister) and hard refresh, directories show as solid folder icons and single/double-click enters them.

/cc @blueberry521
