### PR TITLE
fix(work): 个人文件删除改用 useConfirm 二次确认 (Issue #1917)

### DIFF
--- a/frontend/src/components/work/LocalDirectoryBrowser.test.tsx
+++ b/frontend/src/components/work/LocalDirectoryBrowser.test.tsx
@@ -21,8 +21,12 @@ const toastMock = {
   warning: vi.fn(),
   info: vi.fn(),
 };
+// Issue #1917: handleDelete uses the app's useConfirm() hook instead of
+// window.confirm(). Tests drive this mock to resolve true/false per case.
+const confirmMock = vi.fn<(opts?: any) => Promise<boolean>>();
 vi.mock('@/components/common', () => ({
   useToast: () => toastMock,
+  useConfirm: () => confirmMock,
   Loading: ({ text }: any) => <div>{text}</div>,
   Button: ({ children, onClick, disabled, variant, size }: any) => (
     <button onClick={onClick} disabled={disabled} data-variant={variant} data-size={size}>
@@ -152,7 +156,7 @@ describe('LocalDirectoryBrowser', () => {
   });
 
   it('calls fsApi.deleteFile on delete click after confirm', async () => {
-    window.confirm = vi.fn(() => true);
+    confirmMock.mockResolvedValue(true);
     deleteFileMock.mockResolvedValue({ success: true });
     browseDirectoryMock.mockResolvedValue(
       browseResponse({
@@ -174,10 +178,13 @@ describe('LocalDirectoryBrowser', () => {
       expect(deleteFileMock).toHaveBeenCalledWith('/home/alice/trash.txt');
     });
     expect(toastMock.success).toHaveBeenCalledWith('deleteSuccess', 'trash.txt');
+    // Issue #1917: the app confirm modal (not window.confirm) must be invoked
+    // with the danger variant before the delete fires.
+    expect(confirmMock).toHaveBeenCalledWith({ message: 'confirmDeleteFile', variant: 'danger' });
   });
 
   it('aborts delete when confirm dialog is cancelled', async () => {
-    window.confirm = vi.fn(() => false);
+    confirmMock.mockResolvedValue(false);
     deleteFileMock.mockResolvedValue({ success: true });
     browseDirectoryMock.mockResolvedValue(
       browseResponse({

--- a/frontend/src/components/work/LocalDirectoryBrowser.tsx
+++ b/frontend/src/components/work/LocalDirectoryBrowser.tsx
@@ -15,7 +15,7 @@ import { useLanguage, useAppStore } from '@/store';
 import { t } from '@/i18n';
 import { fsApi, type DirectoryEntry, type FileEntry, MAX_UPLOAD_SIZE_MB } from '@/api/fs';
 import { Loading, Button, EmptyState } from '@/components/common';
-import { useToast } from '@/components/common';
+import { useToast, useConfirm } from '@/components/common';
 import { downloadBlob, formatBytes } from '@/utils';
 
 interface LocalDirectoryBrowserProps {
@@ -336,6 +336,14 @@ export const LocalDirectoryBrowser: React.FC<LocalDirectoryBrowserProps> = ({
     }
   };
 
+  // Issue #1917: use the app's rendered confirm modal instead of the native
+  // `window.confirm()`. The native dialog can be silently suppressed in
+  // sandboxed/iframe contexts (resolving without ever showing a UI), which
+  // previously caused files to be deleted immediately on click with no
+  // confirmation. `useConfirm()` is the project-wide standard for destructive
+  // actions and is already used by Prompts/Sessions/UserManagement/etc.
+  const confirm = useConfirm();
+
   const handleDelete = async (file: FileEntry) => {
     // The delete button is only shown when the parent directory is writable,
     // but we still gate on is_readable: an unreadable file (e.g. root-owned
@@ -348,9 +356,10 @@ export const LocalDirectoryBrowser: React.FC<LocalDirectoryBrowserProps> = ({
       );
       return;
     }
-    const ok = window.confirm(
-      (t('confirmDeleteFile', language) as string) || `Delete "${file.name}"?`
-    );
+    const ok = await confirm({
+      message: (t('confirmDeleteFile', language) as string) || `Delete "${file.name}"?`,
+      variant: 'danger',
+    });
     if (!ok) return;
 
     setDeletingPath(file.path);


### PR DESCRIPTION
## Summary

Fixes #1917

On the personal files page (`/work/files`), clicking the **Delete** button removed the file immediately without any confirmation dialog.

## Root Cause

`LocalDirectoryBrowser.handleDelete` used the native `window.confirm()`. The native dialog can be silently suppressed in sandboxed iframe / embedded-webview contexts (it resolves without ever showing a UI), which matches the observed "click → deleted instantly" behavior.

The project already ships a standard, app-styled confirm dialog via `useConfirm()` (`components/common/Confirm.tsx`), mounted once at the app root through `<ConfirmHost />` in `App.tsx`. Every other destructive delete flow already uses it — `Prompts`, `Sessions`, `UserManagement`, `TenantManagement`, `MappingRulesEditor`, etc. The `Confirm.tsx` comment explicitly states this hook is meant to "replace scattered `window.confirm()` calls".

## Changes

- `frontend/src/components/work/LocalDirectoryBrowser.tsx`
  - Import `useConfirm` from `@/components/common`.
  - Replace the `window.confirm(...)` call in `handleDelete` with `await confirm({ message, variant: 'danger' })`, reusing the existing i18n key `confirmDeleteFile` (en/zh/ja/ko already present).
- `frontend/src/components/work/LocalDirectoryBrowser.test.tsx`
  - Add `useConfirm` to the `@/components/common` mock as a controllable `confirmMock`.
  - Replace `window.confirm = vi.fn(...)` in the two delete tests with `confirmMock.mockResolvedValue(true/false)`.
  - Assert the modal is invoked with `{ message: 'confirmDeleteFile', variant: 'danger' }`.

## Verification

- `vitest run LocalDirectoryBrowser.test.tsx` → 7/7 pass
- `vitest run PersonalFiles.test.tsx` → 2/2 pass
- `tsc --noEmit` → clean
- `eslint` → clean
- No remaining functional `window.confirm()` calls in `src/` (only comments referencing it)

## Risk

Low. The change only affects the delete confirmation path in `LocalDirectoryBrowser` when `enableFileActions` is on (i.e. the personal files page). All other callers of `LocalDirectoryBrowser` (which do not enable file actions) are unaffected. The `ConfirmHost` is already mounted app-wide.