### PR TITLE
fix(autonomous): stabilize retry sessions and activity

### DIFF
--- a/app/modules/workspace/autonomous/agent_runner.py
+++ b/app/modules/workspace/autonomous/agent_runner.py
@@ -989,7 +989,11 @@ class AutonomousAgentRunner:
         if not project_path:
             return ""
         resolved = os.path.realpath(project_path)
-        return resolved.replace("/", "-")
+        # Claude Code 2.1.x replaces every non-alphanumeric path character
+        # with ``-``. In particular ``/.worktrees`` becomes ``--worktrees``;
+        # replacing slashes alone leaves ``-.worktrees`` and misses the
+        # directory the CLI actually created.
+        return re.sub(r"[^A-Za-z0-9]", "-", resolved)
 
     def _find_latest_claude_session_id(
         self,
@@ -2834,14 +2838,17 @@ class AutonomousAgentRunner:
                         # UI showed "no AI activity" for minutes until the
                         # first `assistant` event finally arrived.
                         subtype = parsed.get("subtype", "")
+                        # This is a high-frequency cumulative estimate, not a
+                        # discrete user-visible activity. Skipping the event
+                        # also prevents one sidebar fallback probe per token.
+                        if subtype == "thinking_tokens":
+                            continue
                         if self._activity_callback and subtype:
                             activity: dict[str, Any] = {
                                 "type": "system",
                                 "subtype": subtype,
                             }
-                            if subtype == "thinking_tokens":
-                                activity["estimated_tokens"] = parsed.get("estimated_tokens", 0)
-                            elif subtype == "api_retry":
+                            if subtype == "api_retry":
                                 activity["attempt"] = parsed.get("attempt", 0)
                             self._activity_callback(session.session_id, activity)
 

--- a/app/modules/workspace/autonomous/agent_runner.py
+++ b/app/modules/workspace/autonomous/agent_runner.py
@@ -989,8 +989,9 @@ class AutonomousAgentRunner:
         if not project_path:
             return ""
         resolved = os.path.realpath(project_path)
-        # Claude Code 2.1.x replaces every non-alphanumeric path character
-        # with ``-``. In particular ``/.worktrees`` becomes ``--worktrees``;
+        # Claude Code 2.1.201's embedded project-path diagnostic specifies
+        # ``pwd | sed 's|[^a-zA-Z0-9]|-|g'`` (also observed in its project-dir
+        # function). In particular ``/.worktrees`` becomes ``--worktrees``;
         # replacing slashes alone leaves ``-.worktrees`` and misses the
         # directory the CLI actually created.
         return re.sub(r"[^A-Za-z0-9]", "-", resolved)

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -640,7 +640,8 @@ def _github_truncation_notice(content_language: str | None) -> str:
 REVIEW_SESSION_MILESTONE_TYPES = {"plan_reviewed", "pr_reviewed"}
 
 # Session lines that span multiple milestones via --resume. Each maps to a
-# workflow column holding the real CLI session id once the line is established.
+# workflow column holding one stable tracking id; the provider/CLI resume id is
+# stored on that agent_sessions row in ``cli_session_id``.
 #   main:   plan_created → plan_refined → plan_finalized → dev_started →
 #           pr_updated → pr_review_summary
 #   review: plan_reviewed → pr_reviewed
@@ -755,6 +756,10 @@ class AutonomousOrchestrator:
         self._workflow_id = workflow_id
         self._current_session_id: str | None = None
         self._session_lock = threading.Lock()
+        # Usage consumed by earlier transient-error attempts in the same
+        # milestone. Live milestone totals apply this runtime offset when the
+        # stable main/review/test session starts its next provider request.
+        self._session_usage_offsets: dict[str, dict[str, int]] = {}
         self._cancel_requested = threading.Event()  # in-memory cancel signal
 
         # Wire session_manager so agent sessions are persisted to DB
@@ -2478,15 +2483,42 @@ class AutonomousOrchestrator:
 
     def _on_agent_activity(self, session_id: str, activity: dict):
         """Forward agent activity to the SSE event stream and refresh usage."""
+        # A thinking-token event is a high-frequency cumulative estimate, not
+        # a discrete activity or authoritative usage. Keep it out of SSE even
+        # when a runner other than the local Claude path emits one.
+        if activity.get("type") == "system" and activity.get("subtype") == "thinking_tokens":
+            return
+
+        emitted_activity = activity
+        if activity.get("type") == "usage":
+            offsets = getattr(self, "_session_usage_offsets", {})
+            session_lock = getattr(self, "_session_lock", None)
+            if session_lock is None:
+                offset = dict(offsets.get(session_id, {}))
+            else:
+                with session_lock:
+                    offset = dict(offsets.get(session_id, {}))
+            emitted_activity = {
+                **activity,
+                "total_tokens": int(activity.get("total_tokens", 0) or 0)
+                + int(offset.get("total_tokens", 0) or 0),
+                "total_input_tokens": int(activity.get("total_input_tokens", 0) or 0)
+                + int(offset.get("total_input_tokens", 0) or 0),
+                "total_output_tokens": int(activity.get("total_output_tokens", 0) or 0)
+                + int(offset.get("total_output_tokens", 0) or 0),
+                "request_count": int(activity.get("request_count", 0) or 0)
+                + int(offset.get("request_count", 0) or 0),
+            }
+
         self.emitter.emit(
             self._workflow_id,
             "agent_activity",
             {
                 "session_id": session_id,
-                **activity,
+                **emitted_activity,
             },
         )
-        activity_type = activity.get("type")
+        activity_type = emitted_activity.get("type")
         if activity_type == "session_resolved":
             try:
                 self._link_session_to_current_milestone(session_id)
@@ -2500,7 +2532,7 @@ class AutonomousOrchestrator:
                 # freezing until the call returns. phase_* is overwritten per
                 # event (session totals are cumulative within the call) and
                 # finalized by _write_phase_usage at _run_agent return.
-                self._write_realtime_phase_usage(activity)
+                self._write_realtime_phase_usage(emitted_activity)
                 self.repo.refresh_workflow_usage_from_sessions(self._workflow_id)
             except Exception:
                 logger.warning("Failed to refresh workflow tokens in real-time", exc_info=True)
@@ -2641,6 +2673,22 @@ class AutonomousOrchestrator:
             return False
         return bool(_TRANSIENT_API_ERROR_RE.search(response))
 
+    @classmethod
+    def _should_retry_transient_api_failure(cls, result: AgentTaskResult) -> bool:
+        """Return whether *result* represents a real transient API failure.
+
+        Explicit runner errors are always eligible. Some Claude versions put
+        an upstream error envelope in assistant text, but that fallback is
+        safe only when the call produced no tokens. Scanning token-bearing
+        plan/review text caused phrases such as "Rate Limit" to restart an
+        otherwise successful phase (#1891).
+        """
+        if cls._is_transient_api_error(result.error or ""):
+            return True
+        return (result.total_tokens or 0) == 0 and cls._is_transient_api_error(
+            result.response_text or ""
+        )
+
     @staticmethod
     def _is_context_overflow(result: AgentTaskResult) -> bool:
         """True if the agent call failed because the resumed session context
@@ -2683,6 +2731,13 @@ class AutonomousOrchestrator:
         if milestone_id:
             kwargs["milestone_id"] = milestone_id
         tracking_session_id = session_id
+        retry_usage = {
+            "total_tokens": 0,
+            "total_input_tokens": 0,
+            "total_output_tokens": 0,
+            "request_count": 0,
+        }
+        usage_session_ids = {tracking_session_id}
         if "user_id" not in kwargs and workflow_data:
             kwargs["user_id"] = workflow_data.get("user_id")
 
@@ -2703,6 +2758,7 @@ class AutonomousOrchestrator:
 
         with self._session_lock:
             self._current_session_id = tracking_session_id
+            self._session_usage_offsets[tracking_session_id] = dict(retry_usage)
 
         should_prelink_tracking_session = not self._runner._uses_sidebar_session_source(
             kwargs.get("cli_tool", ""),
@@ -2731,31 +2787,40 @@ class AutonomousOrchestrator:
 
         result = self._runner.run_agent_task(**kwargs)
         if result.session_id:
+            # The runner is authoritative for the tracking id it actually
+            # persisted (notably app-server adapters that create sessions
+            # after dispatch). Adopt it once, then keep it stable for every
+            # retry on this named line.
+            resolved_tracking_session_id = result.tracking_session_id or result.session_id
+            if resolved_tracking_session_id != tracking_session_id:
+                with self._session_lock:
+                    offset = self._session_usage_offsets.pop(tracking_session_id, retry_usage)
+                    self._session_usage_offsets[resolved_tracking_session_id] = offset
+                    self._current_session_id = resolved_tracking_session_id
+                usage_session_ids.add(resolved_tracking_session_id)
+                tracking_session_id = resolved_tracking_session_id
+
             # Workflow milestones must keep the stable session-line tracking id
             # (main/review/test), not the provider's real CLI id. The timeline
             # resolves the actual transcript session at read time via
             # agent_sessions.cli_session_id, which keeps DB identity stable
             # while still letting the UI open the real transcript.
+            field = SESSION_LINE_FIELDS.get(session_line)
             link_session_id = (
-                (result.tracking_session_id or result.session_id)
-                if self._runner._uses_sidebar_session_source(
-                    kwargs.get("cli_tool", ""),
-                    kwargs.get("workspace_type", "local"),
-                )
-                else result.session_id
+                tracking_session_id if field else (result.tracking_session_id or result.session_id)
             )
             self._link_session_to_current_milestone(link_session_id)
             # Persist the stable tracking id for this line. Fresh lines write
             # their first tracking id here; established lines keep reusing the
             # same wrapper row across milestones so timeline/session identity
             # does not drift with every resume attempt.
-            field = SESSION_LINE_FIELDS.get(session_line)
             if field:
-                self._update_workflow({field: result.session_id})
+                self._update_workflow({field: tracking_session_id})
                 # Keep the in-memory wf dict in sync so the next _resolve_session_line
                 # call in the same phase (e.g. planning → finalize) sees the updated
                 # line identity and resumes it instead of rotating wrappers.
-                wf[field] = result.session_id
+                if workflow_data is not None:
+                    workflow_data[field] = tracking_session_id
 
         # Transient API error retry (429 / 5xx / overload) — exponential
         # backoff, max 30 minutes total. Interruptible sleep (cancel check
@@ -2772,26 +2837,27 @@ class AutonomousOrchestrator:
             if _status in ("failed", "cancelled"):
                 logger.info("API error retry aborted (workflow status=%s)", _status)
                 self._synthesize_transient_failure(result)
-                self._write_phase_usage(milestone_id, result)
+                self._write_phase_usage(milestone_id, result, retry_usage)
+                self._clear_session_usage_offsets(usage_session_ids)
                 with self._session_lock:
-                    self._current_session_id = result.session_id
+                    self._current_session_id = tracking_session_id
                 return result
 
-            response_text = result.response_text or ""
-            error_text = result.error or ""
-            if not (
-                self._is_transient_api_error(response_text)
-                or self._is_transient_api_error(error_text)
-            ):
+            if not self._should_retry_transient_api_failure(result):
                 break  # Not a transient API error, no retry needed
 
             elapsed = int(time.monotonic() - retry_start)
+            retry_source = (
+                "result.error"
+                if self._is_transient_api_error(result.error or "")
+                else "zero-token response"
+            )
             logger.warning(
-                "Transient API error detected, retrying in %ds (elapsed: %ds / %ds): %s",
+                "Transient API error detected, retrying in %ds " "(elapsed: %ds / %ds, source=%s)",
                 delay,
                 elapsed,
                 API_RETRY_TOTAL_TIMEOUT,
-                (response_text or error_text)[:160],
+                retry_source,
             )
             self._emit(
                 "api_error_retry",
@@ -2799,6 +2865,7 @@ class AutonomousOrchestrator:
                     "delay": delay,
                     "elapsed": elapsed,
                     "total_timeout": API_RETRY_TOTAL_TIMEOUT,
+                    "source": retry_source,
                 },
             )
 
@@ -2812,21 +2879,46 @@ class AutonomousOrchestrator:
                 if self._cancel_requested.is_set():
                     logger.info("API error retry cancelled (cancel requested)")
                     self._synthesize_transient_failure(result)
-                    self._write_phase_usage(milestone_id, result)
+                    self._write_phase_usage(milestone_id, result, retry_usage)
+                    self._clear_session_usage_offsets(usage_session_ids)
                     with self._session_lock:
-                        self._current_session_id = result.session_id
+                        self._current_session_id = tracking_session_id
                     return result
 
             delay = min(delay * 2, API_RETRY_MAX_DELAY)
 
-            # Rotate tracking id only; resume_session_id stays so the line holds.
-            kwargs["session_id"] = str(uuid.uuid4())
+            for key in retry_usage:
+                retry_usage[key] += int(getattr(result, key, 0) or 0)
+
+            # Strict main/review/test topology: retries reuse the line's stable
+            # tracking id and, when possible, the provider transcript created
+            # by the preceding attempt. One-off "fresh" calls may rotate.
+            field = SESSION_LINE_FIELDS.get(session_line)
+            retry_session_id = tracking_session_id if field else str(uuid.uuid4())
+            kwargs["session_id"] = retry_session_id
+            if field:
+                resume_target = result.source_session_id or kwargs.get("resume_session_id")
+                if not resume_target and not self._runner._uses_sidebar_session_source(
+                    kwargs.get("cli_tool", ""), kwargs.get("workspace_type", "local")
+                ):
+                    resume_target = tracking_session_id
+                if resume_target:
+                    kwargs["resume"] = True
+                    kwargs["resume_session_id"] = resume_target
+            usage_session_ids.add(retry_session_id)
             with self._session_lock:
-                self._current_session_id = kwargs["session_id"]
-            self._link_session_to_current_milestone(kwargs["session_id"])
+                self._current_session_id = retry_session_id
+                self._session_usage_offsets[retry_session_id] = dict(retry_usage)
+            self._link_session_to_current_milestone(
+                tracking_session_id if field else retry_session_id
+            )
             result = self._runner.run_agent_task(**kwargs)
             if result.session_id:
-                self._link_session_to_current_milestone(result.session_id)
+                self._link_session_to_current_milestone(
+                    tracking_session_id
+                    if field
+                    else (result.tracking_session_id or result.session_id)
+                )
 
         # A transient-error body (e.g. a 529 "overloaded" returned as
         # assistant_text with no tokens generated) must not be handed back as a
@@ -2845,10 +2937,11 @@ class AutonomousOrchestrator:
                 result.error = repo_validation_error
 
         # Attribute this call's own usage to its milestone (increment, not cumulative).
-        self._write_phase_usage(milestone_id, result)
+        self._write_phase_usage(milestone_id, result, retry_usage)
+        self._clear_session_usage_offsets(usage_session_ids)
 
         with self._session_lock:
-            self._current_session_id = result.tracking_session_id or result.session_id
+            self._current_session_id = tracking_session_id
         return result
 
     def _synthesize_transient_failure(self, result: AgentTaskResult) -> None:
@@ -2862,9 +2955,7 @@ class AutonomousOrchestrator:
         path AND its early-exit paths (status failed/cancelled, cancel-requested)
         all apply it consistently. #1001, #1036.
         """
-        if not (result.success and self._is_transient_api_error(result.response_text or "")):
-            return
-        if (result.total_tokens or 0) != 0:
+        if not (result.success and self._should_retry_transient_api_failure(result)):
             return
         err_snippet = (result.response_text or "")[:200]
         logger.warning(
@@ -2879,22 +2970,39 @@ class AutonomousOrchestrator:
         result.visible_response_text = ""
         result.structured_tags = {}
 
-    def _write_phase_usage(self, milestone_id: str, result: AgentTaskResult) -> None:
+    def _write_phase_usage(
+        self,
+        milestone_id: str,
+        result: AgentTaskResult,
+        prior_usage: dict[str, int] | None = None,
+    ) -> None:
         """Write this call's token/request increment to its milestone."""
         if not milestone_id:
             return
+        prior_usage = prior_usage or {}
         try:
             self.repo.update_milestone(
                 milestone_id,
                 {
-                    "phase_total_tokens": result.total_tokens or 0,
-                    "phase_input_tokens": result.total_input_tokens or 0,
-                    "phase_output_tokens": result.total_output_tokens or 0,
-                    "phase_request_count": result.request_count or 0,
+                    "phase_total_tokens": int(prior_usage.get("total_tokens", 0) or 0)
+                    + int(result.total_tokens or 0),
+                    "phase_input_tokens": int(prior_usage.get("total_input_tokens", 0) or 0)
+                    + int(result.total_input_tokens or 0),
+                    "phase_output_tokens": int(prior_usage.get("total_output_tokens", 0) or 0)
+                    + int(result.total_output_tokens or 0),
+                    "phase_request_count": int(prior_usage.get("request_count", 0) or 0)
+                    + int(result.request_count or 0),
                 },
             )
         except Exception:
             logger.warning("Failed to write phase usage to milestone", exc_info=True)
+
+    def _clear_session_usage_offsets(self, session_ids: set[str]) -> None:
+        """Discard runtime-only retry usage state after an agent call ends."""
+        with self._session_lock:
+            offsets = getattr(self, "_session_usage_offsets", {})
+            for session_id in session_ids:
+                offsets.pop(session_id, None)
 
     def _write_realtime_phase_usage(self, activity: dict) -> None:
         """Write the current call's running cumulative usage to the in-progress milestone.

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -2720,6 +2720,7 @@ class AutonomousOrchestrator:
             milestone_id: Milestone to attribute this call's phase usage to.
         """
         workflow_data = wf or self.workflow
+        field = SESSION_LINE_FIELDS.get(session_line)
 
         # Resolve the session line: resume an established session or start new.
         session_id, resume_session_id, resume = self._resolve_session_line(
@@ -2805,7 +2806,6 @@ class AutonomousOrchestrator:
             # resolves the actual transcript session at read time via
             # agent_sessions.cli_session_id, which keeps DB identity stable
             # while still letting the UI open the real transcript.
-            field = SESSION_LINE_FIELDS.get(session_line)
             link_session_id = (
                 tracking_session_id if field else (result.tracking_session_id or result.session_id)
             )
@@ -2840,7 +2840,13 @@ class AutonomousOrchestrator:
                 self._write_phase_usage(milestone_id, result, retry_usage)
                 self._clear_session_usage_offsets(usage_session_ids)
                 with self._session_lock:
-                    self._current_session_id = tracking_session_id
+                    self._current_session_id = (
+                        tracking_session_id
+                        if field
+                        else (
+                            result.tracking_session_id or result.session_id or tracking_session_id
+                        )
+                    )
                 return result
 
             if not self._should_retry_transient_api_failure(result):
@@ -2853,7 +2859,7 @@ class AutonomousOrchestrator:
                 else "zero-token response"
             )
             logger.warning(
-                "Transient API error detected, retrying in %ds " "(elapsed: %ds / %ds, source=%s)",
+                "Transient API retry in %ds (elapsed=%ds/%ds, source=%s)",
                 delay,
                 elapsed,
                 API_RETRY_TOTAL_TIMEOUT,
@@ -2882,18 +2888,31 @@ class AutonomousOrchestrator:
                     self._write_phase_usage(milestone_id, result, retry_usage)
                     self._clear_session_usage_offsets(usage_session_ids)
                     with self._session_lock:
-                        self._current_session_id = tracking_session_id
+                        self._current_session_id = (
+                            tracking_session_id
+                            if field
+                            else (
+                                result.tracking_session_id
+                                or result.session_id
+                                or tracking_session_id
+                            )
+                        )
                     return result
 
             delay = min(delay * 2, API_RETRY_MAX_DELAY)
 
+            # AgentTaskResult's runner contract is usage for one
+            # run_agent_task invocation: Claude reports per-request values and
+            # cumulative-result adapters difference turns before building the
+            # result. Any provider that replays pre-resume history must
+            # normalize that in its adapter; the orchestrator sums only these
+            # per-invocation deltas.
             for key in retry_usage:
                 retry_usage[key] += int(getattr(result, key, 0) or 0)
 
             # Strict main/review/test topology: retries reuse the line's stable
             # tracking id and, when possible, the provider transcript created
             # by the preceding attempt. One-off "fresh" calls may rotate.
-            field = SESSION_LINE_FIELDS.get(session_line)
             retry_session_id = tracking_session_id if field else str(uuid.uuid4())
             kwargs["session_id"] = retry_session_id
             if field:
@@ -2941,7 +2960,11 @@ class AutonomousOrchestrator:
         self._clear_session_usage_offsets(usage_session_ids)
 
         with self._session_lock:
-            self._current_session_id = tracking_session_id
+            self._current_session_id = (
+                tracking_session_id
+                if field
+                else (result.tracking_session_id or result.session_id or tracking_session_id)
+            )
         return result
 
     def _synthesize_transient_failure(self, result: AgentTaskResult) -> None:

--- a/frontend/src/components/work/WorkflowTimeline.tsx
+++ b/frontend/src/components/work/WorkflowTimeline.tsx
@@ -230,9 +230,6 @@ function getActivitySummary(
     case 'assistant':
       return { icon: 'bi-chat-text', text: t('autoActivityGenerating', language) };
     case 'system':
-      if (activity.subtype === 'thinking_tokens') {
-        return { icon: 'bi-lightbulb', text: t('autoActivityThinking', language) };
-      }
       if (activity.subtype === 'api_retry') {
         return { icon: 'bi-arrow-repeat', text: t('autoActivityRetrying', language) };
       }
@@ -768,7 +765,6 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
     tool_input?: string;
     total_tokens?: number;
     subtype?: string;
-    estimated_tokens?: number;
     attempt?: number;
   }) => {
     const timestamp = formatMilestoneTime(activity.timestamp ?? null) || '--:--:--';
@@ -800,18 +796,6 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
 
     if (activity.type === 'system') {
       const sub = activity.subtype ?? '';
-      if (sub === 'thinking_tokens') {
-        return {
-          icon: 'bi-lightbulb text-secondary',
-          timestamp,
-          content: (
-            <>
-              <span className="opacity-75">thinking…</span>{' '}
-              {activity.estimated_tokens ? `~${activity.estimated_tokens} tokens` : ''}
-            </>
-          ),
-        };
-      }
       if (sub === 'api_retry') {
         return {
           icon: 'bi-arrow-repeat text-warning',

--- a/frontend/src/hooks/useAutonomous.ts
+++ b/frontend/src/hooks/useAutonomous.ts
@@ -66,7 +66,6 @@ export interface AgentActivity {
   total_output_tokens?: number;
   // system-type fields
   subtype?: string;
-  estimated_tokens?: number;
   attempt?: number;
 }
 

--- a/tests/issues/1001/test_api_error_retry.py
+++ b/tests/issues/1001/test_api_error_retry.py
@@ -162,6 +162,12 @@ class TestRunAgentApiErrorRetry:
         result = o._run_agent(wf=_make_workflow(), prompt="x")
 
         assert o._runner.run_agent_task.call_count == 2  # retried once
+        first_call, second_call = o._runner.run_agent_task.call_args_list
+        assert first_call.kwargs["session_id"] == "sess-track"
+        assert second_call.kwargs["session_id"] != first_call.kwargs["session_id"]
+        assert second_call.kwargs["resume"] is False
+        assert second_call.kwargs["resume_session_id"] is None
+        assert o._current_session_id == "s2"
         assert result.success is True
         assert result.response_text == "## Plan\nrecovered plan"
 
@@ -176,6 +182,7 @@ class TestRunAgentApiErrorRetry:
     def test_named_line_retry_reuses_tracking_and_provider_session(
         self, monkeypatch, session_line, workflow_field
     ):
+        """Retry usage values are per-run deltas, not resumed-session totals."""
         monkeypatch.setattr("time.sleep", lambda *a, **k: None)
         o = _make_orchestrator(_make_workflow())
         o._runner._uses_sidebar_session_source = MagicMock(return_value=True)

--- a/tests/issues/1001/test_api_error_retry.py
+++ b/tests/issues/1001/test_api_error_retry.py
@@ -13,6 +13,8 @@ Covers:
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from app.modules.workspace.autonomous import orchestrator as orch_module
 from app.modules.workspace.autonomous.models import AgentTaskResult
 from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
@@ -119,6 +121,29 @@ class TestRunAgentApiErrorRetry:
         assert result.success is True
         assert result.response_text == "## Plan\nreal plan"
 
+    def test_no_retry_on_token_bearing_plan_that_mentions_rate_limit(self, monkeypatch):
+        """The exact issue-1891 false positive must remain a normal success."""
+        monkeypatch.setattr("time.sleep", lambda *a, **k: None)
+        o = _make_orchestrator(_make_workflow())
+        plan = AgentTaskResult(
+            session_id="sess-track",
+            tracking_session_id="sess-track",
+            response_text=(
+                "## Security plan\n"
+                "#### Step 4.2: Rate Limit\n"
+                "| R6 | Rate limit | P2 | Prevent abuse |"
+            ),
+            total_tokens=1200,
+            success=True,
+        )
+        o._runner.run_agent_task = MagicMock(return_value=plan)
+
+        result = o._run_agent(wf=_make_workflow(), session_line="main", prompt="x")
+
+        assert o._runner.run_agent_task.call_count == 1
+        assert result.success is True
+        assert "Rate Limit" in result.response_text
+
     def test_retries_transient_error_then_succeeds(self, monkeypatch):
         # Simulate time.sleep as a no-op so the backoff loop is instant.
         monkeypatch.setattr("time.sleep", lambda *a, **k: None)
@@ -139,6 +164,73 @@ class TestRunAgentApiErrorRetry:
         assert o._runner.run_agent_task.call_count == 2  # retried once
         assert result.success is True
         assert result.response_text == "## Plan\nrecovered plan"
+
+    @pytest.mark.parametrize(
+        ("session_line", "workflow_field"),
+        [
+            ("main", "main_session_id"),
+            ("review", "review_session_id"),
+            ("test", "test_session_id"),
+        ],
+    )
+    def test_named_line_retry_reuses_tracking_and_provider_session(
+        self, monkeypatch, session_line, workflow_field
+    ):
+        monkeypatch.setattr("time.sleep", lambda *a, **k: None)
+        o = _make_orchestrator(_make_workflow())
+        o._runner._uses_sidebar_session_source = MagicMock(return_value=True)
+        err = AgentTaskResult(
+            session_id="sess-track",
+            tracking_session_id="sess-track",
+            source_session_id="cli-main",
+            error="API Error: 503 Service Unavailable",
+            total_tokens=100,
+            total_input_tokens=80,
+            total_output_tokens=20,
+            request_count=1,
+            success=False,
+        )
+        ok = AgentTaskResult(
+            session_id="sess-track",
+            tracking_session_id="sess-track",
+            source_session_id="cli-main",
+            response_text="## Plan\nrecovered plan",
+            total_tokens=200,
+            total_input_tokens=150,
+            total_output_tokens=50,
+            request_count=2,
+            success=True,
+        )
+        o._runner.run_agent_task = MagicMock(side_effect=[err, ok])
+
+        result = o._run_agent(
+            wf=_make_workflow(),
+            session_line=session_line,
+            milestone_id="ms-plan",
+            prompt="x",
+        )
+
+        first_call, second_call = o._runner.run_agent_task.call_args_list
+        assert first_call.kwargs["session_id"] == "sess-track"
+        assert second_call.kwargs["session_id"] == "sess-track"
+        assert second_call.kwargs["resume"] is True
+        assert second_call.kwargs["resume_session_id"] == "cli-main"
+        assert all(
+            call.args[0] == "sess-track"
+            for call in o._link_session_to_current_milestone.call_args_list
+        )
+        o._update_workflow.assert_called_with({workflow_field: "sess-track"})
+        o._write_phase_usage.assert_called_once_with(
+            "ms-plan",
+            ok,
+            {
+                "total_tokens": 100,
+                "total_input_tokens": 80,
+                "total_output_tokens": 20,
+                "request_count": 1,
+            },
+        )
+        assert result is ok
 
     def test_synthesizes_failure_after_exhaustion(self, monkeypatch):
         # Retry loop disabled (0 timeout) + always-error runner -> the post-loop

--- a/tests/issues/1395/test_system_event_activity.py
+++ b/tests/issues/1395/test_system_event_activity.py
@@ -4,8 +4,8 @@ During long LLM waits (api_retry from upstream overload, slow first-token),
 claude --print emits only ``system`` events (api_retry, thinking_tokens, init).
 _read_stdout previously forwarded only assistant/tool_use/usage events to
 _activity_callback, so the UI showed "no AI activity" for minutes until the
-first ``assistant`` event arrived. Now key system subtypes also trigger the
-callback so the workflow detail shows live progress throughout the wait.
+first ``assistant`` event arrived. Low-frequency lifecycle events still reach
+the UI, while high-frequency cumulative ``thinking_tokens`` events are ignored.
 """
 
 import json
@@ -75,7 +75,7 @@ class TestSystemEventActivityForwarding:
             {"type": "system", "subtype": "api_retry", "attempt": 3},
         )
 
-    def test_thinking_tokens_triggers_activity(self):
+    def test_thinking_tokens_is_not_forwarded(self):
         runner = _make_runner()
         session = _make_session(
             [
@@ -85,10 +85,7 @@ class TestSystemEventActivityForwarding:
             ]
         )
         runner._read_stdout(session)
-        runner._activity_callback.assert_called_once_with(
-            "sess-1",
-            {"type": "system", "subtype": "thinking_tokens", "estimated_tokens": 42},
-        )
+        runner._activity_callback.assert_not_called()
 
     def test_init_triggers_activity(self):
         runner = _make_runner()

--- a/tests/issues/771/test_realtime_activity.py
+++ b/tests/issues/771/test_realtime_activity.py
@@ -10,6 +10,7 @@ Covers:
 from __future__ import annotations
 
 import json
+import threading
 from unittest.mock import MagicMock, call, patch
 
 import pytest
@@ -212,6 +213,67 @@ class TestOrchestratorActivityForwarding:
         )
 
         orch.repo.refresh_workflow_usage_from_sessions.assert_not_called()
+
+    def test_drops_thinking_token_activity(self):
+        from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+        orch = AutonomousOrchestrator.__new__(AutonomousOrchestrator)
+        orch._workflow_id = "wf-123"
+        orch.emitter = MagicMock()
+        orch.repo = MagicMock()
+
+        orch._on_agent_activity(
+            "sess-456",
+            {
+                "type": "system",
+                "subtype": "thinking_tokens",
+                "estimated_tokens": 245,
+            },
+        )
+
+        orch.emitter.emit.assert_not_called()
+        orch.repo.refresh_workflow_usage_from_sessions.assert_not_called()
+
+    def test_usage_event_includes_prior_retry_offset(self):
+        from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+        orch = AutonomousOrchestrator.__new__(AutonomousOrchestrator)
+        orch._workflow_id = "wf-123"
+        orch._session_lock = threading.Lock()
+        orch._session_usage_offsets = {
+            "sess-456": {
+                "total_tokens": 100,
+                "total_input_tokens": 80,
+                "total_output_tokens": 20,
+                "request_count": 1,
+            }
+        }
+        orch.emitter = MagicMock()
+        orch.repo = MagicMock()
+        orch._write_realtime_phase_usage = MagicMock()
+
+        orch._on_agent_activity(
+            "sess-456",
+            {
+                "type": "usage",
+                "total_tokens": 200,
+                "total_input_tokens": 150,
+                "total_output_tokens": 50,
+                "request_count": 2,
+            },
+        )
+
+        expected = {
+            "type": "usage",
+            "total_tokens": 300,
+            "total_input_tokens": 230,
+            "total_output_tokens": 70,
+            "request_count": 3,
+        }
+        orch.emitter.emit.assert_called_once_with(
+            "wf-123", "agent_activity", {"session_id": "sess-456", **expected}
+        )
+        orch._write_realtime_phase_usage.assert_called_once_with(expected)
 
 
 class TestLinkSessionToMilestone:

--- a/tests/issues/814/test_worktree_path_selfheal.py
+++ b/tests/issues/814/test_worktree_path_selfheal.py
@@ -23,6 +23,8 @@ import os
 import re
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from app.modules.workspace.autonomous.agent_runner import AutonomousAgentRunner
 from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
 
@@ -55,10 +57,21 @@ class TestEncodeProjectPathNormalizes:
             r"[^A-Za-z0-9]", "-", os.path.realpath(path)
         )
 
-    def test_dot_worktree_matches_claude_code_encoding(self):
-        path = "/home/rhuang/open-ace/.worktrees/workflow-id"
-        encoded = AutonomousAgentRunner._encode_project_path(path)
-        assert "open-ace--worktrees-workflow-id" in encoded
+    @pytest.mark.parametrize(
+        ("path", "expected"),
+        [
+            (
+                "/Users/open_ace/repo name/.worktrees/workflow.v1",
+                "-Users-open-ace-repo-name--worktrees-workflow-v1",
+            ),
+            ("/Users/rhuang/open-ace", "-Users-rhuang-open-ace"),
+        ],
+    )
+    def test_matches_claude_code_non_alphanumeric_contract(self, path, expected):
+        # Fixed expected values intentionally do not reuse the implementation's
+        # regex. Claude Code 2.1.201 embeds the equivalent shell rule:
+        #   pwd | sed 's|[^a-zA-Z0-9]|-|g'
+        assert AutonomousAgentRunner._encode_project_path(path) == expected
 
     def test_empty_string_returns_empty(self):
         assert AutonomousAgentRunner._encode_project_path("") == ""

--- a/tests/issues/814/test_worktree_path_selfheal.py
+++ b/tests/issues/814/test_worktree_path_selfheal.py
@@ -20,6 +20,7 @@ Covers:
 """
 
 import os
+import re
 from unittest.mock import MagicMock, patch
 
 from app.modules.workspace.autonomous.agent_runner import AutonomousAgentRunner
@@ -36,7 +37,7 @@ class TestEncodeProjectPathNormalizes:
         encoded = AutonomousAgentRunner._encode_project_path(raw)
         # realpath collapses the ".." — encoding must match what Claude CLI
         # writes, not the raw input.
-        expected = os.path.realpath(raw).replace("/", "-")
+        expected = re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(raw))
         assert encoded == expected
         assert ".." not in encoded
 
@@ -46,13 +47,18 @@ class TestEncodeProjectPathNormalizes:
         link_target = tmp_path / "real"
         link_target.mkdir()
         encoded = AutonomousAgentRunner._encode_project_path(str(link_target))
-        assert encoded == os.path.realpath(str(link_target)).replace("/", "-")
+        assert encoded == re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(str(link_target)))
 
     def test_already_canonical_unchanged(self):
         path = "/Users/rhuang/workspace/open-ace"
-        assert AutonomousAgentRunner._encode_project_path(path) == os.path.realpath(path).replace(
-            "/", "-"
+        assert AutonomousAgentRunner._encode_project_path(path) == re.sub(
+            r"[^A-Za-z0-9]", "-", os.path.realpath(path)
         )
+
+    def test_dot_worktree_matches_claude_code_encoding(self):
+        path = "/home/rhuang/open-ace/.worktrees/workflow-id"
+        encoded = AutonomousAgentRunner._encode_project_path(path)
+        assert "open-ace--worktrees-workflow-id" in encoded
 
     def test_empty_string_returns_empty(self):
         assert AutonomousAgentRunner._encode_project_path("") == ""


### PR DESCRIPTION
## Description

Fixes autonomous workflow retry behavior reproduced by workflow `issue-1891` while processing GitHub #1891.

- Drop high-frequency `system/thinking_tokens` events in the runner and orchestrator, and remove the frontend rendering/type path.
- Retry response-text API errors only for zero-token results; explicit runner errors remain retryable. This prevents plan content such as `Rate Limit` from being mistaken for an API failure.
- Keep one stable tracking session for each named `main`, `review`, and `test` line across transient retries, resuming the resolved provider session when available.
- Preserve usage from completed retry attempts in live and finalized milestone totals.
- Match Claude Code 2.1.x project-path encoding for dotted worktree directories so sidebar session discovery finds the correct JSONL directory.

This PR intentionally performs no historical usage or session repair for workflow `issue-1891`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit tests pass locally
- [x] Integration tests pass locally

Commands:

- `python3 -m pytest -q ...` — 71 targeted activity, retry, session-line, milestone-link, context-overflow, and timeline tests passed.
- `black --check` and `ruff check` on changed Python files.
- `npx prettier --check`, `npx eslint`, and `npm run typecheck` on the frontend changes.
- Repository pre-commit suite passed, including black, isort, ruff, mypy, bandit, SQL compatibility, and security checks.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing targeted unit tests pass locally with my changes

## Additional Notes

GitHub #1891 is the workload used to reproduce the issue; this PR changes generic autonomous orchestration behavior and does not alter that issue or its historical workflow records.