### PR TITLE
fix(fs): 非 root 多用户模式下普通用户上传失败 Permission denied (Issue #1916)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -184,13 +184,14 @@ COPY scripts/openace-chown.sh /usr/local/bin/openace-chown
 COPY scripts/openace-useradd.sh /usr/local/bin/openace-useradd
 COPY scripts/openace-cat.sh /usr/local/bin/openace-cat
 COPY scripts/openace-mkdir.sh /usr/local/bin/openace-mkdir
+COPY scripts/openace-write-as.sh /usr/local/bin/openace-write-as
 COPY scripts/openace-restore-sudoers.sh /usr/local/bin/openace-restore-sudoers
 RUN chmod 755 /usr/local/bin/openace-chown /usr/local/bin/openace-useradd \
              /usr/local/bin/openace-cat /usr/local/bin/openace-mkdir \
-             /usr/local/bin/openace-restore-sudoers && \
+             /usr/local/bin/openace-write-as /usr/local/bin/openace-restore-sudoers && \
     chown root:root /usr/local/bin/openace-chown /usr/local/bin/openace-useradd \
                     /usr/local/bin/openace-cat /usr/local/bin/openace-mkdir \
-                    /usr/local/bin/openace-restore-sudoers && \
+                    /usr/local/bin/openace-write-as /usr/local/bin/openace-restore-sudoers && \
     mkdir -p /var/lock && chmod 1777 /var/lock
 
 # NOTE: The image defaults to the non-root open-ace user (uid 1000) so that

--- a/app/routes/fs.py
+++ b/app/routes/fs.py
@@ -16,13 +16,14 @@ import re
 import subprocess
 import tempfile
 from pathlib import Path
-from typing import Any
+from typing import IO, Any, cast
 
 from flask import Blueprint, Response, g, jsonify, request, stream_with_context
 
 from app.repositories.user_repo import UserRepository
 from app.utils.workspace import (
     OPENACE_CHOWN_WRAPPER,
+    OPENACE_WRITE_AS_WRAPPER,
     _is_wrapper_available,
     get_workspace_base_dir,
     get_workspace_base_dirs,
@@ -1024,6 +1025,11 @@ def api_create_directory():
 #   atomically rename. No sudo is involved — root uses kernel capabilities
 #   (os.chown / os.replace / os.remove) directly. This deliberately avoids
 #   the sudoers whitelist (which does not include cp/cat/rm/tee).
+# - Package non-root multi-user mode: the process is a service account that
+#   cannot traverse the target user's 0700 home. cp/tee/mv are NOT in the
+#   sudoers OPENACE_UTILS whitelist, so uploads delegate to the
+#   openace-write-as wrapper (root via a dedicated sudoers rule, drops to
+#   the target user via runuser). Content is streamed on stdin (Issue #1916).
 # - Single-user / non-root package mode: the process already owns its home
 #   tree, so we write/read/remove directly.
 # - os.chown is root-only; non-root uses the openace-chown wrapper as a
@@ -1111,6 +1117,67 @@ def api_upload_file():
             except Exception:
                 _safe_remove(tmp_path)
                 raise
+        elif not _is_direct_access(system_account):
+            # Package non-root multi-user: the process is a service account
+            # (e.g. openace) that cannot write to /home/<system_account>/...
+            # (0700). cp/tee/mv are NOT in the sudoers OPENACE_UTILS
+            # whitelist, so we cannot `sudo -u <user> cp` directly. Delegate
+            # to the openace-write-as wrapper, which runs as root via its
+            # own sudoers rule and drops to the target user via runuser
+            # (Issue #1916). Content is streamed to the wrapper's stdin.
+            if not _is_wrapper_available(OPENACE_WRITE_AS_WRAPPER):
+                return (
+                    jsonify(
+                        {
+                            "error": "Upload not available in multi-user mode "
+                            "(openace-write-as wrapper not installed)"
+                        }
+                    ),
+                    500,
+                )
+            effective = get_effective_system_account(system_account)
+            assert effective is not None  # _is_direct_access 为 False 时 effective 必定非 None
+            proc = subprocess.Popen(
+                ["sudo", "-n", OPENACE_WRITE_AS_WRAPPER, effective, target_path],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.PIPE,
+            )
+            stdin = cast(IO[bytes], proc.stdin)
+            try:
+                # Stream uploaded content to the wrapper's stdin in chunks so
+                # large uploads don't buffer fully in memory.
+                while True:
+                    chunk = file.stream.read(64 * 1024)
+                    if not chunk:
+                        break
+                    try:
+                        stdin.write(chunk)
+                    except BrokenPipeError:
+                        # Wrapper exited early (e.g. path validation failure);
+                        # stop writing and let communicate() collect stderr.
+                        break
+                stdin.close()
+                _, stderr = proc.communicate(timeout=300)
+            except Exception:
+                proc.kill()
+                proc.wait()
+                raise
+            if proc.returncode != 0:
+                err = (stderr or b"").decode(errors="replace").strip()
+                logger.warning(f"openace-write-as failed for {target_path} as {effective}: {err}")
+                low = err.lower()
+                if "not allowed" in low or "sudo" in low or "a password is required" in low:
+                    return (
+                        jsonify(
+                            {
+                                "error": "Cannot upload file as owner "
+                                "(sudoers policy missing 'openace-write-as' for this deployment)"
+                            }
+                        ),
+                        500,
+                    )
+                return jsonify({"error": "Permission denied"}), 403
         else:
             # Single-user / non-root: write directly to the final path.
             file.save(target_path)

--- a/app/utils/workspace.py
+++ b/app/utils/workspace.py
@@ -29,6 +29,12 @@ __all__ = [
 OPENACE_USERADD_WRAPPER = "/usr/local/bin/openace-useradd"
 OPENACE_CHOWN_WRAPPER = "/usr/local/bin/openace-chown"
 OPENACE_MKDIR_WRAPPER = "/usr/local/bin/openace-mkdir"
+# Cross-user file write wrapper (Issue #1916): used by the upload endpoint in
+# Package non-root multi-user mode to write into a user's 0700 home directory.
+# cp/tee/mv are NOT in the sudoers OPENACE_UTILS whitelist, so uploads delegate
+# through this root-authorized wrapper (which drops to the target user via
+# runuser). Docker multi-user runs as root and never hits this path.
+OPENACE_WRITE_AS_WRAPPER = "/usr/local/bin/openace-write-as"
 
 
 def _is_wrapper_available(wrapper_path: str) -> bool:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -767,7 +767,7 @@ openace ALL=(root) NOPASSWD: ${WRAPPER_PATH} *"
         # 【安全加固 Issue #1855】安全 wrapper 脚本 sudoers 规则
         # 使用 wrapper 替代通配命令，wrapper 内部做参数校验和审计日志
         SECURITY_WRAPPERS_RULE=""
-        for wrapper in openace-chown openace-useradd openace-cat openace-mkdir; do
+        for wrapper in openace-chown openace-useradd openace-cat openace-mkdir openace-write-as; do
             wrapper_path="/usr/local/bin/${wrapper}"
             if [ -x "$wrapper_path" ]; then
                 SECURITY_WRAPPERS_RULE="${SECURITY_WRAPPERS_RULE}open-ace ALL=(root) NOPASSWD: ${wrapper_path} *

--- a/scripts/install-central/package-method/install.sh
+++ b/scripts/install-central/package-method/install.sh
@@ -1825,6 +1825,32 @@ install_run_as_wrapper() {
     return 0
 }
 
+# Install the cross-user file write wrapper (Issue #1916).
+# In Package non-root multi-user mode the service account cannot write to a
+# user's 0700 home directory, and cp/tee/mv are NOT in the sudoers OPENACE_UTILS
+# whitelist. This wrapper is invoked as root (via a dedicated sudoers rule) and
+# drops to the target user via runuser to write uploaded file content. Must run
+# BEFORE configure_sudoers so the sudoers rule (which keys off -x $wrapper_path)
+# sees it.
+install_write_as_wrapper() {
+    local install_dir="$1"
+    local src="$install_dir/scripts/openace-write-as.sh"
+    local dst="/usr/local/bin/openace-write-as"
+
+    if [ ! -f "$src" ]; then
+        print_warning "openace-write-as.sh not found at $src; skipping wrapper install"
+        return 1
+    fi
+    if ! cp "$src" "$dst" 2>/dev/null; then
+        print_warning "Failed to copy openace-write-as.sh to $dst (need root?)"
+        return 1
+    fi
+    chown root:root "$dst" 2>/dev/null || true
+    chmod 755 "$dst"
+    print_success "Installed write-as wrapper to $dst"
+    return 0
+}
+
 # Configure sudoers for multi-user workspace mode
 # Uses incremental update: only adds/modifies $run_user's rules, preserves other users' rules
 configure_sudoers() {
@@ -1904,6 +1930,16 @@ $run_user ALL=(root) NOPASSWD: /usr/bin/python3 $script_path *"
         wrapper_rule="$run_user ALL=(root) NOPASSWD: $wrapper_path *"
     fi
 
+    # 【修复 Issue #1916】跨用户文件写入 wrapper 权限。
+    # Package 非 root 多用户模式下，服务账号无法写入用户 0700 家目录，
+    # 且 cp/tee/mv 不在 OPENACE_UTILS 白名单。该 wrapper 以 root 身份运行，
+    # 内部用 runuser 切换到目标用户写文件。只授权 wrapper 本身。
+    local write_as_wrapper_path="/usr/local/bin/openace-write-as"
+    local write_as_wrapper_rule=""
+    if [ -x "$write_as_wrapper_path" ]; then
+        write_as_wrapper_rule="$run_user ALL=(root) NOPASSWD: $write_as_wrapper_path *"
+    fi
+
     # Build current user's complete rule block (avoid empty lines from empty variables)
     local current_user_rules="# Rules for $run_user (updated on $(date '+%Y-%m-%d %H:%M:%S'))
 $run_user ALL=(ALL) NOPASSWD: $webui_path *"
@@ -1923,6 +1959,12 @@ ${cli_rule}"
     if [ -n "$wrapper_rule" ]; then
         current_user_rules="${current_user_rules}
 ${wrapper_rule}"
+    fi
+
+    # Add write-as wrapper rule if the wrapper is installed (Issue #1916)
+    if [ -n "$write_as_wrapper_rule" ]; then
+        current_user_rules="${current_user_rules}
+${write_as_wrapper_rule}"
     fi
 
     # Only add fetch_rules if not empty
@@ -2059,6 +2101,18 @@ ${line}"
         if [ -x "$wrapper_path" ] && \
            ! grep -E "^${run_user} .*(NOPASSWD: )?${wrapper_path}( |\*|$)" "$sudoers_file" 2>/dev/null; then
             print_warning "Sudoers missing run-as wrapper rule for user '$run_user' (wrapper installed but not authorized)"
+            need_update=true
+        fi
+
+        # 【修复 Issue #1916】Check write-as wrapper rule.
+        # Mirrors the run-as probe above: the wrapper is installed before
+        # configure_sudoers, but incremental upgrades skip the rewrite when
+        # existing checks pass, leaving the new wrapper unauthorized. Match
+        # user+path on the same line so a foreign user's rule doesn't false-pass.
+        local write_as_wrapper_path="/usr/local/bin/openace-write-as"
+        if [ -x "$write_as_wrapper_path" ] && \
+           ! grep -E "^${run_user} .*(NOPASSWD: )?${write_as_wrapper_path}( |\*|$)" "$sudoers_file" 2>/dev/null; then
+            print_warning "Sudoers missing write-as wrapper rule for user '$run_user' (wrapper installed but not authorized)"
             need_update=true
         fi
 
@@ -3277,6 +3331,10 @@ install_local() {
         # Install the run-as wrapper BEFORE configure_sudoers (Issue #1395):
         # the sudoers rule keys off `[ -x /usr/local/bin/openace-run-as ]`.
         install_run_as_wrapper "$sudoers_install_dir"
+
+        # Install the write-as wrapper BEFORE configure_sudoers (Issue #1916):
+        # the sudoers rule keys off `[ -x /usr/local/bin/openace-write-as ]`.
+        install_write_as_wrapper "$sudoers_install_dir"
 
         configure_sudoers "$sudoers_run_user" "$sudoers_install_dir"
         if [ $? -ne 0 ]; then

--- a/scripts/openace-write-as.sh
+++ b/scripts/openace-write-as.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+# openace-write-as — Secure cross-user file write wrapper for multi-user mode.
+#
+# Problem (Issue #1916): in Package non-root multi-user mode the openace
+# service account cannot write to /home/<system_account>/... (0700 home).
+# Upload must write as the target user. cp/tee/mv/install are NOT in the
+# sudoers OPENACE_UTILS whitelist, so `sudo -u <user> cp ...` is denied.
+# This wrapper is invoked as root via a dedicated sudoers rule, validates
+# user + path, then drops to the target user via runuser and writes stdin
+# to the target path. No sudoers rule for cp/tee/mv is required.
+#
+# Usage: openace-write-as <user> <path>
+#   File content arrives on stdin; the file is created/truncated at <path>.
+#
+# Exit codes:
+#   0 - Success
+#   1 - Invalid arguments
+#   2 - Path validation failed
+#   3 - User validation failed
+#   4 - Write failed
+
+set -euo pipefail
+
+AUDIT_LOG="/app/logs/sudoers-audit.log"
+MIN_UID=1000
+ALLOWED_PREFIXES=("/workspace/" "/home/")
+
+log_audit() {
+    local msg="$1"
+    local timestamp
+    timestamp=$(date '+%Y-%m-%d %H:%M:%S')
+    local log_entry="[$timestamp] [openace-write-as] $msg"
+    if ! echo "$log_entry" >> "$AUDIT_LOG" 2>/dev/null; then
+        echo "[AUDIT_FALLBACK] $log_entry" >&2
+    fi
+}
+
+usage() {
+    echo "Usage: $0 <user> <path>" >&2
+    echo "  File content must be piped on stdin." >&2
+    echo "  Path must be under /workspace/* or /home/*" >&2
+    exit 1
+}
+
+if [ "$#" -ne 2 ]; then
+    usage
+fi
+
+TARGET_USER="$1"
+TARGET_PATH="$2"
+
+# Validate user exists
+if ! id "$TARGET_USER" &>/dev/null; then
+    echo "ERROR: User '$TARGET_USER' does not exist" >&2
+    log_audit "caller=$(whoami) target_user=${TARGET_USER} path=${TARGET_PATH} result=reject_user_not_found"
+    exit 3
+fi
+
+# Validate UID >= MIN_UID (no system users)
+TARGET_UID=$(id -u "$TARGET_USER")
+if [ "$TARGET_UID" -lt "$MIN_UID" ]; then
+    echo "ERROR: UID $TARGET_UID is below minimum $MIN_UID (system users not allowed)" >&2
+    log_audit "caller=$(whoami) target_user=${TARGET_USER} path=${TARGET_PATH} result=reject_uid_low"
+    exit 3
+fi
+
+# Resolve path (handle symlinks and ..). For non-existent paths, resolve the
+# parent directory then re-append the basename so path-prefix validation sees
+# the real location the file will land in.
+RESOLVED_PATH=""
+if [ -e "$TARGET_PATH" ]; then
+    RESOLVED_PATH=$(readlink -f "$TARGET_PATH" 2>/dev/null || echo "$TARGET_PATH")
+else
+    PARENT_DIR=$(dirname "$TARGET_PATH")
+    if [ -d "$PARENT_DIR" ]; then
+        RESOLVED_PARENT=$(readlink -f "$PARENT_DIR" 2>/dev/null || echo "$PARENT_DIR")
+        RESOLVED_PATH="${RESOLVED_PARENT}/$(basename "$TARGET_PATH")"
+    else
+        RESOLVED_PATH="$TARGET_PATH"
+    fi
+fi
+
+# Validate path prefix
+PATH_VALID=false
+for prefix in "${ALLOWED_PREFIXES[@]}"; do
+    if [[ "$RESOLVED_PATH" == "$prefix"* ]]; then
+        PATH_VALID=true
+        break
+    fi
+done
+
+if [ "$PATH_VALID" = false ]; then
+    echo "ERROR: Path '$RESOLVED_PATH' is outside allowed directories (/workspace/*, /home/*)" >&2
+    log_audit "caller=$(whoami) target_user=${TARGET_USER} path=${TARGET_PATH} resolved=${RESOLVED_PATH} result=reject_path"
+    exit 2
+fi
+
+log_audit "caller=$(whoami) target_user=${TARGET_USER} path=${RESOLVED_PATH} result=attempt"
+
+# Drop to target user via runuser and write stdin to the target path. runuser
+# (not sudo) performs the user drop, so no extra sudoers rule for cp/tee is
+# needed; the wrapper is already root via its own sudoers rule. tee truncates
+# the file and writes stdin to it; stdout is discarded so it doesn't echo
+# back. A temp file + atomic rename would be nicer for crash safety, but tee
+# matches the simplicity of the single-user file.save() path.
+if runuser -u "$TARGET_USER" -- tee "$RESOLVED_PATH" > /dev/null; then
+    log_audit "caller=$(whoami) target_user=${TARGET_USER} path=${RESOLVED_PATH} result=success"
+    exit 0
+else
+    EXIT_CODE=$?
+    log_audit "caller=$(whoami) target_user=${TARGET_USER} path=${RESOLVED_PATH} result=fail code=${EXIT_CODE}"
+    exit 4
+fi

--- a/tests/routes/test_fs_file_ops.py
+++ b/tests/routes/test_fs_file_ops.py
@@ -99,6 +99,7 @@ if "app.routes.fs" not in sys.modules:
     _ws.get_workspace_base_dir = _rw.get_workspace_base_dir
     _ws.get_workspace_base_dirs = _rw.get_workspace_base_dirs
     _ws.OPENACE_CHOWN_WRAPPER = "/usr/local/bin/openace-chown"
+    _ws.OPENACE_WRITE_AS_WRAPPER = _rw.OPENACE_WRITE_AS_WRAPPER
     _ws._is_wrapper_available = lambda p: False  # type: ignore[attr-defined]
     _ws.run_as_root_if_needed = lambda cmd: None  # type: ignore[attr-defined]
 
@@ -1235,3 +1236,201 @@ class TestDirectAccessHelper:
         call = run_mock.call_args[0]
         assert call[0] == "alice"
         assert call[1] == ["test", "-f", "/p/f.txt"]
+
+
+class TestUploadNonRootMultiUserBranch:
+    """Cover the Package non-root multi-user upload path (Issue #1916).
+
+    In this mode the Flask process is a service account (non-root) with a
+    ``system_account`` user whose 0700 home it cannot traverse. The endpoint
+    must delegate the write to the ``openace-write-as`` wrapper (sudoers-
+    authorized, runs as root, drops to the target user via runuser) instead
+    of calling ``file.save()`` directly (which would hit EACCES).
+    """
+
+    @pytest.fixture
+    def sudo_client(self, workspace):
+        from flask import Flask, g
+
+        from app.routes.fs import fs_bp
+
+        ws_root, user_home = workspace
+        home_root = ws_root / "testuser"
+        home_root.mkdir(exist_ok=True)
+
+        app = Flask(__name__)
+        app.config["TESTING"] = True
+        app.register_blueprint(fs_bp, url_prefix="/api")
+        app.before_request_funcs["fs"] = []
+
+        @app.before_request
+        def _set_user():
+            g.user = {"id": 1, "username": "testuser", "system_account": "testuser"}
+
+        with (
+            patch("app.routes.fs.get_workspace_base_dir", return_value=str(ws_root)),
+            patch("app.routes.fs.get_workspace_base_dirs", return_value=[str(ws_root)]),
+            patch("app.routes.fs.get_home_directory", return_value=str(home_root)),
+            # Non-root process → _is_direct_access returns False.
+            patch("app.routes.fs.os.geteuid", return_value=1000),
+            patch("app.routes.fs.get_effective_system_account", return_value="testuser"),
+            # Wrapper is installed.
+            patch("app.routes.fs._is_wrapper_available", return_value=True),
+            # Bypass the sudo-based writable pre-check (no real "testuser" OS
+            # user exists on the dev machine).
+            patch(
+                "app.routes.fs.get_directory_info",
+                return_value={
+                    "exists": True,
+                    "is_dir": True,
+                    "is_writable": True,
+                    "is_readable": True,
+                },
+            ),
+        ):
+            yield app.test_client()
+
+    class _FakeProc:
+        """Minimal Popen stand-in that records stdin writes and exits 0."""
+
+        def __init__(self, returncode=0, stderr=b""):
+            self._returncode = returncode
+            self._stderr = stderr
+            self._written = bytearray()
+            self.stdin = self._FakeStream(self)
+            self.stdout = None
+            self.returncode = None
+
+        class _FakeStream:
+            def __init__(self, parent):
+                self._parent = parent
+
+            def write(self, data):
+                self._parent._written.extend(data)
+                return len(data)
+
+            def close(self):
+                pass
+
+        def communicate(self, timeout=None):
+            self.returncode = self._returncode
+            return (b"", self._stderr)
+
+        def wait(self):
+            self.returncode = self._returncode
+            return self._returncode
+
+        def kill(self):
+            self.returncode = -9
+
+    def test_upload_streams_via_write_as_wrapper(self, sudo_client, workspace):
+        """Upload in non-root multi-user mode streams content to the
+        openace-write-as wrapper and returns 200 on success."""
+        _, user_home = workspace
+        target = user_home / "up.txt"
+
+        fake = self._FakeProc(returncode=0)
+        with patch("app.routes.fs.subprocess.Popen", return_value=fake) as popen_mock:
+            data = {
+                "file": (io.BytesIO(b"hello-upload"), "up.txt"),
+                "path": str(user_home),
+            }
+            resp = sudo_client.post("/api/fs/upload", data=data, content_type="multipart/form-data")
+
+        assert resp.status_code == 200
+        assert resp.get_json()["success"] is True
+        # The wrapper was invoked as: sudo -n /usr/local/bin/openace-write-as <user> <path>
+        cmd = popen_mock.call_args[0][0]
+        assert cmd[:2] == ["sudo", "-n"]
+        assert "/usr/local/bin/openace-write-as" in cmd
+        assert "testuser" in cmd
+        assert str(target) in cmd
+        # The uploaded bytes were streamed to the wrapper's stdin.
+        assert bytes(fake._written) == b"hello-upload"
+
+    def test_upload_wrapper_failure_returns_403(self, sudo_client, workspace):
+        """When the wrapper exits non-zero with a filesystem error, surface 403."""
+        _, user_home = workspace
+
+        fake = self._FakeProc(returncode=4, stderr=b"Permission denied")
+        with patch("app.routes.fs.subprocess.Popen", return_value=fake):
+            data = {
+                "file": (io.BytesIO(b"x"), "up.txt"),
+                "path": str(user_home),
+            }
+            resp = sudo_client.post("/api/fs/upload", data=data, content_type="multipart/form-data")
+
+        assert resp.status_code == 403
+        assert resp.get_json()["error"] == "Permission denied"
+
+    def test_upload_sudoers_policy_missing_returns_500(self, sudo_client, workspace):
+        """When the wrapper is denied by sudoers (not authorized), return a
+        clear 500 referencing the missing sudoers policy — mirroring delete's
+        run_as_user failure handling."""
+        _, user_home = workspace
+
+        fake = self._FakeProc(
+            returncode=1,
+            stderr=b"sudo: a password is required for openace",
+        )
+        with patch("app.routes.fs.subprocess.Popen", return_value=fake):
+            data = {
+                "file": (io.BytesIO(b"x"), "up.txt"),
+                "path": str(user_home),
+            }
+            resp = sudo_client.post("/api/fs/upload", data=data, content_type="multipart/form-data")
+
+        assert resp.status_code == 500
+        assert "sudoers policy" in resp.get_json()["error"]
+
+    def test_upload_wrapper_not_installed_returns_500(self, workspace):
+        """When the openace-write-as wrapper is absent, upload in multi-user
+        mode fails with a clear error rather than falling through to the
+        broken direct-write path (which would EACCES)."""
+        from flask import Flask, g
+
+        from app.routes.fs import fs_bp
+
+        ws_root, user_home = workspace
+        home_root = ws_root / "testuser"
+        home_root.mkdir(exist_ok=True)
+
+        app = Flask(__name__)
+        app.config["TESTING"] = True
+        app.register_blueprint(fs_bp, url_prefix="/api")
+        app.before_request_funcs["fs"] = []
+
+        @app.before_request
+        def _set_user():
+            g.user = {"id": 1, "username": "testuser", "system_account": "testuser"}
+
+        with (
+            patch("app.routes.fs.get_workspace_base_dir", return_value=str(ws_root)),
+            patch("app.routes.fs.get_workspace_base_dirs", return_value=[str(ws_root)]),
+            patch("app.routes.fs.get_home_directory", return_value=str(home_root)),
+            patch("app.routes.fs.os.geteuid", return_value=1000),
+            patch("app.routes.fs.get_effective_system_account", return_value="testuser"),
+            # Wrapper NOT installed.
+            patch("app.routes.fs._is_wrapper_available", return_value=False),
+            patch(
+                "app.routes.fs.get_directory_info",
+                return_value={
+                    "exists": True,
+                    "is_dir": True,
+                    "is_writable": True,
+                    "is_readable": True,
+                },
+            ),
+            patch("app.routes.fs.subprocess.Popen") as popen_mock,
+        ):
+            client = app.test_client()
+            data = {
+                "file": (io.BytesIO(b"x"), "up.txt"),
+                "path": str(home_root),
+            }
+            resp = client.post("/api/fs/upload", data=data, content_type="multipart/form-data")
+
+        assert resp.status_code == 500
+        assert "openace-write-as" in resp.get_json()["error"]
+        # Must not have spawned the wrapper at all.
+        popen_mock.assert_not_called()


### PR DESCRIPTION
## 背景

Package 多用户部署下 Flask 进程以服务账号（如 `ivyent`）运行，普通用户的 `system_account` 指向另一个 OS 用户，其家目录 `0700`。`api_upload_file()` 的 `else` 分支假设"非 root 一定是单用户模式"，直接 `file.save()` 写入 `/home/<user>/...` 触发 `PermissionError`，返回"上传失败 Permission denied"。下载/删除已在 Issue #1902 改造为 `sudo -u <user>` 执行，唯独上传遗漏。

`cp/tee/mv` 不在 sudoers `OPENACE_UTILS` 白名单，无法直接 `sudo -u <user> cp`。按 issue 建议新增可审计的 `openace-write-as` wrapper（sudoers 单独授权 → root → `runuser` 切到目标用户 → `tee` 写入）。

## 修改

- **`scripts/openace-write-as.sh`**（新文件）— wrapper：路径校验（仅 `/workspace/`、`/home/`）+ uid≥1000 校验 + 审计日志，内部 `runuser -u <user> -- tee <path>` 写入 stdin。
- **`app/utils/workspace.py`** — 新增 `OPENACE_WRITE_AS_WRAPPER` 常量。
- **`app/routes/fs.py`** — `api_upload_file` 新增第三个分支：非 root 多用户时（`_is_direct_access` 为 False）通过该 wrapper 以 64KB 流式写入 stdin；错误处理与下载/删除一致（sudoers 策略缺失→500，文件系统权限错→403）。
- **`Dockerfile` / `docker-entrypoint.sh`** — 容器镜像安装 wrapper + sudoers 规则。
- **`scripts/install-central/package-method/install.sh`** — Package 安装 wrapper + sudoers 规则 + 增量升级探测（`need_update` 检查新 wrapper 规则）。
- **`tests/routes/test_fs_file_ops.py`** — 新增 `TestUploadNonRootMultiUserBranch` 4 个回归测试。

## 验证

### 单元测试

`tests/routes/test_fs_file_ops.py` 54 个测试全部通过（含新增 4 个：流式写入成功 / wrapper 失败 403 / sudoers 策略缺失 500 / wrapper 未安装 500）。

### 人工验证（当前主机）

部署到运行中的 `open-ace` 服务（服务账号 `ivyent`，`WORKSPACE_BASE_DIR=/home`），以普通用户 `wd237`（uid 1002，家目录 `0700`）登录测试：

- ✅ **根因确认**：`ivyent` 直接写 `/home/wd237/` → "权限不够"（修复前必现）
- ✅ **上传成功**：API 上传到 `/home/wd237/`，文件属主 `wd237:wd237`，内容正确
- ✅ **子目录上传**：`/home/wd237/docs/` 成功
- ✅ **非 ASCII 文件名**：`测试文件.txt` 成功
- ✅ **大文件（200KB）**：多 chunk 流式写入，完整性校验通过
- ✅ **路径越界拒绝**：上传到 `/etc` 返回 400
- ✅ **下载/删除（#1902）** 仍正常
- ✅ 审计日志记录每次写入；sudo 日志确认 `ivyent → root → openace-write-as wd237 <path>`

Closes #1916