### PR TITLE
Raise Python requirement to 3.10+

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ What actually happened.
 
 ### Prerequisites
 
-- Python 3.9+
+- Python 3.10+
 - pip
 
 ### Setup

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ python3 server.py
 <td width="50%">
 
 ### 后端
-- **Python 3.9+**
+- **Python 3.10+**
 - **Flask** — Web 框架
 - **SQLAlchemy** — ORM
 - **PostgreSQL / SQLite** — 数据库
@@ -563,7 +563,7 @@ python3 server.py
 <td width="50%">
 
 ### Backend
-- **Python 3.9+**
+- **Python 3.10+**
 - **Flask** — Web Framework
 - **SQLAlchemy** — ORM
 - **PostgreSQL / SQLite** — Database

--- a/docs/cn/DEVELOPMENT.md
+++ b/docs/cn/DEVELOPMENT.md
@@ -8,7 +8,7 @@
 
 ### 前提条件
 
-- Python 3.9+
+- Python 3.10+
 - Git
 - 代码编辑器（VS Code、PyCharm 等）
 

--- a/docs/cn/INTRO.md
+++ b/docs/cn/INTRO.md
@@ -195,7 +195,7 @@ Open ACE 根据用户角色提供两个不同的界面：
 
 | 层级 | 技术 |
 |------|------|
-| **后端** | Python 3.9+, Flask |
+| **后端** | Python 3.10+, Flask |
 | **前端** | React 18, TypeScript, Bootstrap 5, Chart.js |
 | **数据库** | SQLite (开发), PostgreSQL (生产) |
 | **构建** | Vite, TypeScript |

--- a/docs/en/DEVELOPMENT.md
+++ b/docs/en/DEVELOPMENT.md
@@ -8,7 +8,7 @@ This guide covers setting up a development environment and contributing to Open 
 
 ### Prerequisites
 
-- Python 3.9+
+- Python 3.10+
 - Git
 - A code editor (VS Code, PyCharm, etc.)
 

--- a/docs/en/INTRO.md
+++ b/docs/en/INTRO.md
@@ -195,7 +195,7 @@ The workspace can be configured to connect to various AI tool services:
 
 | Layer | Technology |
 |-------|-----------|
-| **Backend** | Python 3.9+, Flask |
+| **Backend** | Python 3.10+, Flask |
 | **Frontend** | React 18, TypeScript, Bootstrap 5, Chart.js |
 | **Database** | SQLite (dev), PostgreSQL (production) |
 | **Build** | Vite, TypeScript |

--- a/scripts/install-central/package-method/install.sh
+++ b/scripts/install-central/package-method/install.sh
@@ -58,41 +58,35 @@ DEPLOY_PATH=""        # Will be set based on DEPLOY_USER
 # Python Version Check
 # ============================================================================
 
-# Check Python version (Open ACE requires Python >= 3.9)
+# Check Python version (Open ACE requires Python >= 3.10)
 check_python_version() {
     if ! command -v python3 &>/dev/null; then
         print_error "Python 3 is not installed"
-        print_info "Open ACE requires Python 3.9 or later"
+        print_info "Open ACE requires Python 3.10 or later"
         print_info ""
-        print_info "On CentOS/RHEL 7, you can install Python 3.9 via:"
-        print_info "  yum install rh-python39 rh-python39-python-pip"
-        print_info "  source /opt/rh/rh-python39/enable"
+        print_info "On CentOS/RHEL 7, install Python 3.10 manually or use a newer OS release"
         print_info ""
         print_info "On Ubuntu/Debian:"
-        print_info "  apt install python3.9 python3.9-venv python3.9-dev"
+        print_info "  apt install python3.10 python3.10-venv python3.10-dev"
         exit 1
     fi
 
     local python_version=$(python3 -c "import sys; print(sys.version_info.major * 100 + sys.version_info.minor)")
 
-    if [ "$python_version" -lt 309 ]; then
+    if [ "$python_version" -lt 310 ]; then
         local actual_version=$(python3 --version 2>&1 | head -1)
         print_error "Python version too old: $actual_version"
-        print_error "Open ACE requires Python 3.9 or later"
+        print_error "Open ACE requires Python 3.10 or later"
         print_info ""
-        print_info "On CentOS/RHEL 7, you can install Python 3.9 via Software Collections:"
-        print_info "  yum install centos-release-scl"
-        print_info "  yum install rh-python39 rh-python39-python-pip"
-        print_info "  source /opt/rh/rh-python39/enable  # Activate Python 3.9"
-        print_info "  Then run this install script again"
+        print_info "On CentOS/RHEL 7, install Python 3.10 manually or use a newer OS release"
         print_info ""
         print_info "On Rocky Linux 8/9 or RHEL 8/9:"
-        print_info "  dnf install python39 python39-pip"
-        print_info "  alternatives --set python3 /usr/bin/python3.9"
+        print_info "  dnf install python3.10 python3.10-pip"
+        print_info "  alternatives --set python3 /usr/bin/python3.10"
         print_info ""
         print_info "On Ubuntu/Debian:"
-        print_info "  apt install python3.9 python3.9-venv python3.9-dev"
-        print_info "  update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.9 1"
+        print_info "  apt install python3.10 python3.10-venv python3.10-dev"
+        print_info "  update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.10 1"
         exit 1
     fi
 
@@ -106,16 +100,16 @@ check_python_version_remote() {
 
     if ! ssh "$remote" "command -v python3 &>/dev/null"; then
         print_error "Python 3 is not installed on $remote"
-        print_info "Open ACE requires Python 3.9 or later"
+        print_info "Open ACE requires Python 3.10 or later"
         return 1
     fi
 
     local python_version=$(ssh "$remote" "python3 -c \"import sys; print(sys.version_info.major * 100 + sys.version_info.minor)\"")
 
-    if [ "$python_version" -lt 309 ]; then
+    if [ "$python_version" -lt 310 ]; then
         local actual_version=$(ssh "$remote" "python3 --version 2>&1 | head -1")
         print_error "Python version too old on $remote: $actual_version"
-        print_error "Open ACE requires Python 3.9 or later"
+        print_error "Open ACE requires Python 3.10 or later"
         return 1
     fi
 
@@ -3154,7 +3148,7 @@ configure_deploy_remaining() {
 install_local() {
     print_header "Installing on Local Machine"
 
-    # Check Python version first (Open ACE requires Python >= 3.9)
+    # Check Python version first (Open ACE requires Python >= 3.10)
     check_python_version
 
     # Validate source directory first
@@ -3376,7 +3370,7 @@ install_deploy() {
     local remote="$DEPLOY_USER@$DEPLOY_HOST"
     local target_path="$DEPLOY_PATH"
 
-    # Check Python version on remote system (Open ACE requires Python >= 3.9)
+    # Check Python version on remote system (Open ACE requires Python >= 3.10)
     check_python_version_remote "$remote" || exit 1
 
     # Test SSH connection

--- a/scripts/install-central/package-method/package.sh
+++ b/scripts/install-central/package-method/package.sh
@@ -451,7 +451,7 @@ if [ "$SKIP_DOWNLOAD" = false ] && [ -f "$PROJECT_DIR/requirements.txt" ]; then
 
     # Download dependencies
     # Note: --prefer-binary requires pip 20.3+, check version before using
-    # Note: We target Python 3.9 minimum (Open ACE requires Python >= 3.9)
+    # Note: We target Python 3.10 minimum (Open ACE requires Python >= 3.10)
     PIP_CMD=""
     PIP_VERSION=""
 
@@ -465,14 +465,14 @@ if [ "$SKIP_DOWNLOAD" = false ] && [ -f "$PROJECT_DIR/requirements.txt" ]; then
     fi
 
     if [ -n "$PIP_CMD" ]; then
-        # Download wheels for Python 3.9/3.10/3.11/3.12 to support all target versions.
+        # Download wheels for Python 3.10/3.11/3.12 to support all target versions.
         # pip install will automatically select the matching wheel during installation.
         # Note: This increases vendor directory size but ensures offline compatibility.
-        echo -e "${YELLOW}Downloading packages for Python 3.9/3.10/3.11/3.12...${NC}"
+        echo -e "${YELLOW}Downloading packages for Python 3.10/3.11/3.12...${NC}"
 
         # Supported Python versions (ABI tags)
-        PYTHON_VERSIONS=("3.9" "3.10" "3.11" "3.12")
-        ABI_TAGS=("cp39" "cp310" "cp311" "cp312")
+        PYTHON_VERSIONS=("3.10" "3.11" "3.12")
+        ABI_TAGS=("cp310" "cp311" "cp312")
 
         for i in "${!PYTHON_VERSIONS[@]}"; do
             py_ver="${PYTHON_VERSIONS[$i]}"
@@ -510,7 +510,7 @@ if [ "$SKIP_DOWNLOAD" = false ] && [ -f "$PROJECT_DIR/requirements.txt" ]; then
         done
 
         # Final pass: download pure Python wheels (py3-none-any) and any missing packages.
-        # These wheels are architecture-independent and work across all Python versions.
+        # These wheels are architecture-independent and work across all supported Python versions.
         # pip will skip already-downloaded files, so this only adds missing items.
         echo -e "${YELLOW}Downloading pure Python wheels...${NC}"
         $PIP_CMD download -r "$TEMP_REQ" -d "$VENDOR_DIR" \


### PR DESCRIPTION
## Summary
- update docs and README to Python 3.10+
- raise installer minimum Python version checks to 3.10+
- align offline package download logic with the 3.10+ support policy

## Verification
- bash -n scripts/install-central/package-method/install.sh
- bash -n scripts/install-central/package-method/package.sh
- verified https://www.open-ace.com/ shows Python 3.10+