### PR TITLE
fix(autonomous): launch isolated agents across private homes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -179,8 +179,16 @@ RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 # chdir'ing as root then runuser -u <owner>. Owned by root so the sudoers rule
 # (ALL=(root) NOPASSWD) above can apply.
 COPY scripts/openace-run-as.sh /usr/local/bin/openace-run-as
-RUN chmod 755 /usr/local/bin/openace-run-as && \
+COPY app/modules/workspace/autonomous/agent_bin/ /usr/local/libexec/openace-agent-bin/
+RUN chmod 755 /usr/local/bin/openace-run-as \
+        /usr/local/libexec/openace-agent-bin/_guard_exec.py \
+        /usr/local/libexec/openace-agent-bin/git \
+        /usr/local/libexec/openace-agent-bin/gh \
+        /usr/local/libexec/openace-agent-bin/python \
+        /usr/local/libexec/openace-agent-bin/python3 \
+        /usr/local/libexec/openace-agent-bin/pytest && \
     chown root:root /usr/local/bin/openace-run-as && \
+    chown -R root:root /usr/local/libexec/openace-agent-bin && \
     printf '%s\n' \
         '# Credentialless autonomous agent launcher' \
         'open-ace ALL=(root) NOPASSWD: /usr/local/bin/openace-run-as --isolated *' \

--- a/app/modules/workspace/autonomous/agent_runner.py
+++ b/app/modules/workspace/autonomous/agent_runner.py
@@ -16,6 +16,7 @@ import pwd
 import re
 import shutil
 import signal
+import stat
 import subprocess
 import sys
 import threading
@@ -148,6 +149,10 @@ _APPSERVER_TOOLS = frozenset({"zcode", "zcode-code"})
 # wrapper (root via a narrow sudoers rule) chdir's then drops to system_account
 # via runuser. See scripts/openace-run-as.sh.
 _OPENACE_RUN_AS = os.environ.get("OPENACE_RUN_AS", "/usr/local/bin/openace-run-as")
+_OPENACE_AGENT_GUARD_BIN = os.environ.get(
+    "OPENACE_AGENT_GUARD_BIN", "/usr/local/libexec/openace-agent-bin"
+)
+_AGENT_GUARD_EXECUTABLES = ("_guard_exec.py", "git", "gh", "python", "python3", "pytest")
 
 # Security wrapper paths (Issue #1855)
 _OPENACE_CAT_WRAPPER = os.environ.get("OPENACE_CAT_WRAPPER", "/usr/local/bin/openace-cat")
@@ -862,17 +867,15 @@ class AutonomousAgentRunner:
 
     @staticmethod
     def _ensure_project_dir(project_path: str, system_account: str | None) -> None:
-        """Ensure ``project_path`` exists, cross-user safe (Issue #1395).
+        """Ensure ``project_path`` is reachable by the selected agent account.
 
-        ``Path.mkdir`` stats/creates as the service user and raises
-        ``PermissionError`` when the path lives under a user-private parent
-        (e.g. a 0700 home). When ``system_account`` differs from the service
-        user, route through ``sudo -u <account> mkdir -p`` (``mkdir`` is
-        covered by the sudoers ``OPENACE_UTILS`` alias). Same-user skips sudo
-        to avoid failing under systemd ``NoNewPrivileges`` (mirrors
-        ``github_ops._needs_sudo``).
-
-        Issue #1855: 优先使用 openace-mkdir 安全 wrapper，wrapper 内部做路径校验和审计日志。
+        Trusted orchestration creates local worktrees as the repository owner
+        before an AI process starts.  A credentialless cross-user agent cannot
+        traverse the owner's 0700 home until ``openace-run-as --isolated``
+        grants its temporary ACLs, so probing with ``Path`` or asking that
+        account to run ``mkdir`` produces a false "missing directory" error.
+        Use the same root-owned launcher as the real process for the existence
+        check; it grants and revokes the scoped ACL in one short invocation.
         """
         same_user = False
         if system_account:
@@ -881,29 +884,28 @@ class AutonomousAgentRunner:
             except (KeyError, OverflowError):
                 same_user = False
         if system_account and not same_user:
-            # Issue #1855: 优先使用安全 wrapper
-            if os.path.isfile(_OPENACE_MKDIR_WRAPPER) and os.access(
-                _OPENACE_MKDIR_WRAPPER, os.X_OK
-            ):
-                result = subprocess.run(
-                    ["sudo", _OPENACE_MKDIR_WRAPPER, system_account, project_path],
-                    capture_output=True,
-                    text=True,
-                    timeout=30,
-                    check=False,
-                )
-            else:
-                # Fallback: 使用传统 sudo -u mkdir 命令
-                result = subprocess.run(
-                    ["sudo", "-u", system_account, "mkdir", "-p", project_path],
-                    capture_output=True,
-                    text=True,
-                    timeout=30,
-                    check=False,
-                )
+            result = subprocess.run(
+                [
+                    "sudo",
+                    "-n",
+                    "-u",
+                    "root",
+                    _OPENACE_RUN_AS,
+                    "--isolated",
+                    system_account,
+                    project_path,
+                    "/usr/bin/test",
+                    "-d",
+                    ".",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=30,
+                check=False,
+            )
             if result.returncode != 0:
                 raise PermissionError(
-                    f"Failed to create project dir {project_path} as "
+                    f"Failed to access project dir {project_path} as "
                     f"{system_account} (exit {result.returncode}): "
                     f"{result.stderr.strip()}"
                 )
@@ -944,6 +946,8 @@ class AutonomousAgentRunner:
         """
         if AutonomousAgentRunner._is_cross_user(system_account):
             assert system_account is not None  # _is_cross_user guarantees non-empty
+            if env:
+                AutonomousAgentRunner._validate_cross_user_guard_bin(env)
             guard_env = []
             for key in (
                 "PATH",
@@ -985,6 +989,47 @@ class AutonomousAgentRunner:
         return cmd, project_path
 
     @staticmethod
+    def _validate_cross_user_guard_bin(env: dict[str, str]) -> None:
+        """Fail closed unless cross-user command guards are safely installed.
+
+        A source-tree guard path under a 0700 service home is visible to the
+        service but not to ``openace-agent``.  PATH would then silently fall
+        through to unguarded system binaries.  Cross-user launches therefore
+        require the root-owned packaged guard directory installed by every
+        supported deployment path.
+        """
+        path_head = (env.get("PATH") or "").split(os.pathsep, 1)[0]
+        expected = os.path.realpath(_OPENACE_AGENT_GUARD_BIN)
+        if not path_head or os.path.realpath(path_head) != expected:
+            raise RuntimeError(
+                "Cross-user autonomous launch requires the packaged agent command guards"
+            )
+        try:
+            directory_stat = os.stat(expected, follow_symlinks=False)
+        except OSError as exc:
+            raise RuntimeError(f"Missing packaged agent guard directory: {expected}") from exc
+        if (
+            not stat.S_ISDIR(directory_stat.st_mode)
+            or directory_stat.st_uid != 0
+            or directory_stat.st_mode & 0o022
+            or directory_stat.st_mode & 0o555 != 0o555
+        ):
+            raise RuntimeError(f"Unsafe packaged agent guard directory: {expected}")
+        for name in _AGENT_GUARD_EXECUTABLES:
+            guard_path = os.path.join(expected, name)
+            try:
+                stat_result = os.stat(guard_path, follow_symlinks=False)
+            except OSError as exc:
+                raise RuntimeError(f"Missing packaged agent guard: {guard_path}") from exc
+            if (
+                not stat.S_ISREG(stat_result.st_mode)
+                or stat_result.st_uid != 0
+                or stat_result.st_mode & 0o022
+                or stat_result.st_mode & 0o555 != 0o555
+            ):
+                raise RuntimeError(f"Unsafe packaged agent guard: {guard_path}")
+
+    @staticmethod
     def _build_agent_env(
         adapter: Any,
         cli_tool: str,
@@ -1007,7 +1052,12 @@ class AutonomousAgentRunner:
         keeps working.
         """
         env = dict(os.environ)
-        guard_bin = str(Path(__file__).with_name("agent_bin"))
+        packaged_guard_bin = Path(_OPENACE_AGENT_GUARD_BIN)
+        guard_bin = (
+            str(packaged_guard_bin)
+            if all((packaged_guard_bin / name).is_file() for name in _AGENT_GUARD_EXECUTABLES)
+            else str(Path(__file__).with_name("agent_bin"))
+        )
         real_git = shutil.which("git", path=env.get("PATH"))
         real_gh = shutil.which("gh", path=env.get("PATH"))
         if real_git:

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -1695,9 +1695,12 @@ class AutonomousOrchestrator:
         if not minimum:
             return [], ""
         required = (int(minimum.group(1)), int(minimum.group(2)))
-        system_account = getattr(gh, "system_account", None) if gh is not None else None
-        if sys.version_info[:2] >= required and not system_account:
-            return [sys.executable], ""
+        # Runtime commands are ultimately launched through the isolated
+        # wrapper, not through the repository owner's sudo allowlist.  Probe
+        # executable paths as the service account here.  Prefixing probes with
+        # ``sudo -u <repo-owner>`` both violates the narrow sudo policy and can
+        # make a compatible service interpreter look unavailable.  Preserve
+        # the normal preference for an accessible repository virtualenv.
         candidates = [
             os.path.join(project_path, ".venv", "bin", "python"),
             os.path.join(project_path, "venv", "bin", "python"),
@@ -1706,26 +1709,6 @@ class AutonomousOrchestrator:
             candidates.append(sys.executable)
         for minor in range(required[1], required[1] + 6):
             candidates.append(shutil.which(f"python{required[0]}.{minor}") or "")
-            if system_account:
-                try:
-                    located = subprocess.run(
-                        [
-                            "sudo",
-                            "-u",
-                            system_account,
-                            "sh",
-                            "-lc",
-                            f"command -v python{required[0]}.{minor}",
-                        ],
-                        capture_output=True,
-                        text=True,
-                        timeout=5,
-                        check=False,
-                    )
-                    if located.returncode == 0:
-                        candidates.append(located.stdout.strip())
-                except (OSError, subprocess.SubprocessError):
-                    pass
         for executable in candidates:
             if not executable:
                 continue
@@ -1735,8 +1718,6 @@ class AutonomousOrchestrator:
                     "-c",
                     "import sys; print(f'{sys.version_info[0]}.{sys.version_info[1]}')",
                 ]
-                if system_account:
-                    probe_command = ["sudo", "-u", system_account, *probe_command]
                 detected = subprocess.run(
                     probe_command,
                     capture_output=True,
@@ -1750,19 +1731,6 @@ class AutonomousOrchestrator:
             except (OSError, ValueError, subprocess.SubprocessError):
                 continue
         uv = shutil.which("uv")
-        if not uv and system_account:
-            try:
-                located_uv = subprocess.run(
-                    ["sudo", "-u", system_account, "sh", "-lc", "command -v uv"],
-                    capture_output=True,
-                    text=True,
-                    timeout=5,
-                    check=False,
-                )
-                if located_uv.returncode == 0:
-                    uv = located_uv.stdout.strip()
-            except (OSError, subprocess.SubprocessError):
-                pass
         if uv:
             return [
                 uv,

--- a/scripts/install-central/package-method/install.sh
+++ b/scripts/install-central/package-method/install.sh
@@ -1837,6 +1837,23 @@ install_run_as_wrapper() {
     chown root:root "$dst" 2>/dev/null || true
     chmod 755 "$dst"
 
+    local guard_src="$install_dir/app/modules/workspace/autonomous/agent_bin"
+    local guard_dst="/usr/local/libexec/openace-agent-bin"
+    if [ ! -d "$guard_src" ]; then
+        print_warning "Autonomous agent command guards not found at $guard_src"
+        return 1
+    fi
+    install -d -o root -g root -m 755 "$guard_dst" || return 1
+    local guard_name
+    for guard_name in _guard_exec.py git gh python python3 pytest; do
+        if [ ! -f "$guard_src/$guard_name" ]; then
+            print_warning "Missing autonomous agent command guard: $guard_name"
+            return 1
+        fi
+        install -o root -g root -m 755 "$guard_src/$guard_name" "$guard_dst/$guard_name" \
+            || return 1
+    done
+
     # The AI process must never share the repository owner's GitHub/SSH
     # credentials.  Provision a locked, non-login principal used only by the
     # isolated run-as path; the wrapper grants per-worktree ACLs at launch.
@@ -1900,10 +1917,11 @@ configure_autonomous_agent_remote() {
         ssh "$remote" "rm -f '$staged_wrapper'" 2>/dev/null || true
         return 1
     fi
-    if ! ssh "$remote" "bash -s -- '$staged_wrapper' '$DEPLOY_USER'" <<'REMOTE_AUTONOMOUS_SETUP'
+    if ! ssh "$remote" "bash -s -- '$staged_wrapper' '$DEPLOY_USER' '$target_path'" <<'REMOTE_AUTONOMOUS_SETUP'
 set -euo pipefail
 staged_wrapper="$1"
 deploy_user="$2"
+target_path="$3"
 rule_tmp=""
 cleanup_remote_setup() {
     rm -f "$staged_wrapper" "$rule_tmp"
@@ -1918,6 +1936,14 @@ as_root() {
 }
 
 as_root install -o root -g root -m 755 "$staged_wrapper" /usr/local/bin/openace-run-as
+guard_src="$target_path/app/modules/workspace/autonomous/agent_bin"
+guard_dst="/usr/local/libexec/openace-agent-bin"
+[ -d "$guard_src" ] || { echo "Missing autonomous agent command guards: $guard_src" >&2; exit 1; }
+as_root install -d -o root -g root -m 755 "$guard_dst"
+for guard_name in _guard_exec.py git gh python python3 pytest; do
+    [ -f "$guard_src/$guard_name" ] || { echo "Missing agent guard: $guard_name" >&2; exit 1; }
+    as_root install -o root -g root -m 755 "$guard_src/$guard_name" "$guard_dst/$guard_name"
+done
 if ! id openace-agent >/dev/null 2>&1; then
     nologin_shell="$(command -v nologin 2>/dev/null || echo /bin/false)"
     as_root useradd --system --create-home --home-dir /var/lib/openace-agent \

--- a/scripts/openace-run-as.sh
+++ b/scripts/openace-run-as.sh
@@ -164,7 +164,13 @@ if [ "$isolated" = true ]; then
         done
         setfacl -R -m "u:${target_user}:rX" "$metadata_dir"
     done
-    [ ! -e "$project_dir/.git" ] || setfacl -m "u:${target_user}:r" "$project_dir/.git"
+    # A linked worktree stores .git as a pointer file (read-only is enough),
+    # while a normal clone stores it as a directory and needs execute/traverse.
+    if [ -f "$project_dir/.git" ]; then
+        setfacl -m "u:${target_user}:r" "$project_dir/.git"
+    elif [ -d "$project_dir/.git" ]; then
+        setfacl -m "u:${target_user}:rX" "$project_dir/.git"
+    fi
 fi
 
 # Root can traverse any directory; chdir here so the CLI inherits the project
@@ -181,7 +187,9 @@ if [ "$isolated" = true ]; then
     set +e
     /usr/sbin/runuser -u "$target_user" -- /usr/bin/env -i \
         "HOME=$target_home" "USER=$target_user" "LOGNAME=$target_user" \
-        "LANG=${LANG:-C.UTF-8}" "LC_ALL=${LC_ALL:-}" "TMPDIR=/tmp" "$@"
+        "LANG=${LANG:-C.UTF-8}" "LC_ALL=${LC_ALL:-}" "TMPDIR=/tmp" \
+        "GIT_CONFIG_COUNT=1" "GIT_CONFIG_KEY_0=safe.directory" \
+        "GIT_CONFIG_VALUE_0=$project_dir" "$@"
     child_status=$?
     set -e
     cleanup_isolated

--- a/tests/issues/1395/test_cross_user_permissions.py
+++ b/tests/issues/1395/test_cross_user_permissions.py
@@ -319,8 +319,8 @@ class TestPreparationWorktreeCleanup:
 
 
 class TestEnsureProjectDir:
-    def test_cross_user_mkdir_uses_sudo(self, monkeypatch, tmp_path):
-        # project_path under a user-private dir → mkdir goes through sudo.
+    def test_cross_user_directory_probe_uses_isolated_wrapper(self, monkeypatch, tmp_path):
+        # The isolated wrapper grants the ACL before checking the worktree.
         from app.modules.workspace.autonomous import agent_runner
 
         monkeypatch.setattr(agent_runner.pwd, "getpwuid", lambda _uid: MagicMock(pw_name="openace"))
@@ -336,7 +336,19 @@ class TestEnsureProjectDir:
 
         agent_runner.AutonomousAgentRunner._ensure_project_dir(target, "rhuang")
 
-        assert captured["cmd"] == ["sudo", "-u", "rhuang", "mkdir", "-p", target]
+        assert captured["cmd"] == [
+            "sudo",
+            "-n",
+            "-u",
+            "root",
+            agent_runner._OPENACE_RUN_AS,
+            "--isolated",
+            "rhuang",
+            target,
+            "/usr/bin/test",
+            "-d",
+            ".",
+        ]
         assert captured["kwargs"]["timeout"] == 30
 
     def test_same_user_mkdir_uses_path(self, monkeypatch, tmp_path):
@@ -363,8 +375,7 @@ class TestEnsureProjectDir:
         agent_runner.AutonomousAgentRunner._ensure_project_dir(str(target), None)
         assert target.is_dir()
 
-    def test_cross_user_existing_dir_still_sudo_mkdir_p(self, monkeypatch, tmp_path):
-        # mkdir -p is idempotent; even if the dir exists, sudo mkdir is fine.
+    def test_cross_user_existing_dir_still_uses_wrapper(self, monkeypatch, tmp_path):
         from app.modules.workspace.autonomous import agent_runner
 
         monkeypatch.setattr(agent_runner.pwd, "getpwuid", lambda _uid: MagicMock(pw_name="openace"))
@@ -378,7 +389,14 @@ class TestEnsureProjectDir:
 
         monkeypatch.setattr(agent_runner.subprocess, "run", fake_run)
         agent_runner.AutonomousAgentRunner._ensure_project_dir(str(target), "rhuang")
-        assert captured["cmd"][:3] == ["sudo", "-u", "rhuang"]
+        assert captured["cmd"][:6] == [
+            "sudo",
+            "-n",
+            "-u",
+            "root",
+            agent_runner._OPENACE_RUN_AS,
+            "--isolated",
+        ]
 
     def test_cross_user_mkdir_failure_raises(self, monkeypatch, tmp_path):
         # sudo/mkdir failure must raise (fail-fast) instead of being swallowed,
@@ -398,6 +416,17 @@ class TestEnsureProjectDir:
 
         with pytest.raises(PermissionError, match="Permission denied"):
             agent_runner.AutonomousAgentRunner._ensure_project_dir("/home/rhuang/no-perm", "rhuang")
+
+
+def test_isolated_wrapper_scopes_git_safe_directory_to_worktree():
+    from pathlib import Path
+
+    wrapper = Path("scripts/openace-run-as.sh").read_text(encoding="utf-8")
+
+    assert '"GIT_CONFIG_COUNT=1"' in wrapper
+    assert '"GIT_CONFIG_KEY_0=safe.directory"' in wrapper
+    assert '"GIT_CONFIG_VALUE_0=$project_dir"' in wrapper
+    assert "git config --global" not in wrapper
 
 
 # ── _wrap_agent_cmd / _is_cross_user (agent launch) ─────────────────────

--- a/tests/unit/test_autonomous_ci_guardrails.py
+++ b/tests/unit/test_autonomous_ci_guardrails.py
@@ -1,7 +1,10 @@
 """Regression tests for autonomous CI/development guardrails."""
 
 import json
+import sys
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from app.modules.workspace.autonomous.models import AgentTaskResult
 
@@ -142,14 +145,36 @@ def test_runtime_gate_blocks_incompatible_host_without_provisioner(tmp_path):
     assert "compatibility rewrites are blocked" in reason
 
 
-def test_agent_environment_binds_python_and_git_guards():
+def test_runtime_selection_uses_compatible_service_python_with_cross_user_repo(tmp_path):
+    from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nrequires-python = ">=3.10"\n', encoding="utf-8"
+    )
+    gh = MagicMock(system_account="repo-owner")
+
+    command, reason = AutonomousOrchestrator._select_project_python_runtime(str(tmp_path), gh)
+
+    assert command == [sys.executable]
+    assert reason == ""
+
+
+def test_agent_environment_binds_python_and_git_guards(monkeypatch, tmp_path):
     import json
 
-    from app.modules.workspace.autonomous.agent_runner import AutonomousAgentRunner
+    from app.modules.workspace.autonomous import agent_runner
+
+    guard_dir = tmp_path / "agent-bin"
+    guard_dir.mkdir()
+    for name in agent_runner._AGENT_GUARD_EXECUTABLES:
+        guard = guard_dir / name
+        guard.write_text("#!/bin/sh\n", encoding="utf-8")
+        guard.chmod(0o755)
+    monkeypatch.setattr(agent_runner, "_OPENACE_AGENT_GUARD_BIN", str(guard_dir))
 
     adapter = MagicMock()
     adapter.get_env_vars.return_value = {}
-    env = AutonomousAgentRunner._build_agent_env(
+    env = agent_runner.AutonomousAgentRunner._build_agent_env(
         adapter,
         "claude-code",
         None,
@@ -159,32 +184,110 @@ def test_agent_environment_binds_python_and_git_guards():
     )
 
     assert json.loads(env["OPENACE_PYTHON_COMMAND"]) == ["/opt/python3.11/bin/python"]
-    assert env["PATH"].split(":", 1)[0].endswith("autonomous/agent_bin")
+    assert env["PATH"].split(":", 1)[0] == str(guard_dir)
     assert env["OPENACE_REAL_GIT"]
     assert env["GH_CONFIG_DIR"] == "/var/empty/openace-autonomous-gh"
     assert "GH_TOKEN" not in env
 
 
-def test_cross_user_launch_preserves_nonsecret_guard_environment():
-    from app.modules.workspace.autonomous.agent_runner import AutonomousAgentRunner
+def test_cross_user_launch_preserves_nonsecret_guard_environment(monkeypatch, tmp_path):
+    from app.modules.workspace.autonomous import agent_runner
+
+    guard_dir = tmp_path / "agent-bin"
+    guard_dir.mkdir()
+    for name in agent_runner._AGENT_GUARD_EXECUTABLES:
+        guard = guard_dir / name
+        guard.write_text("#!/bin/sh\n", encoding="utf-8")
+        guard.chmod(0o755)
+    monkeypatch.setattr(agent_runner, "_OPENACE_AGENT_GUARD_BIN", str(guard_dir))
 
     env = {
-        "PATH": "/guard:/usr/bin",
+        "PATH": f"{guard_dir}:/usr/bin",
         "OPENACE_REAL_GIT": "/usr/bin/git",
         "OPENACE_PYTHON_COMMAND": '["/usr/bin/python3"]',
         "GH_CONFIG_DIR": "/var/empty/openace-autonomous-gh",
         "GIT_TERMINAL_PROMPT": "0",
     }
-    with patch.object(AutonomousAgentRunner, "_is_cross_user", return_value=True):
-        command, cwd = AutonomousAgentRunner._wrap_agent_cmd(
+    with (
+        patch.object(agent_runner.AutonomousAgentRunner, "_is_cross_user", return_value=True),
+        patch.object(
+            agent_runner.AutonomousAgentRunner,
+            "_validate_cross_user_guard_bin",
+        ),
+    ):
+        command, cwd = agent_runner.AutonomousAgentRunner._wrap_agent_cmd(
             ["/usr/bin/claude"], "/private/repo", "repo-user", env
         )
 
     assert cwd is None
     assert "--isolated" in command
     assert "/usr/bin/env" in command
-    assert "PATH=/guard:/usr/bin" in command
+    assert f"PATH={guard_dir}:/usr/bin" in command
     assert "OPENACE_REAL_GIT=/usr/bin/git" in command
+
+
+def test_cross_user_launch_rejects_source_tree_guard_path():
+    from app.modules.workspace.autonomous.agent_runner import AutonomousAgentRunner
+
+    env = {"PATH": "/private/service/app/agent_bin:/usr/bin"}
+    with patch.object(AutonomousAgentRunner, "_is_cross_user", return_value=True):
+        with pytest.raises(RuntimeError, match="packaged agent command guards"):
+            AutonomousAgentRunner._wrap_agent_cmd(
+                ["/usr/bin/claude"], "/private/repo", "openace-agent", env
+            )
+
+
+def test_cross_user_guard_rejects_root_group_only_permissions(monkeypatch, tmp_path):
+    import stat
+    from types import SimpleNamespace
+
+    from app.modules.workspace.autonomous import agent_runner
+
+    guard_dir = tmp_path / "agent-bin"
+    guard_dir.mkdir(mode=0o750)
+    for name in agent_runner._AGENT_GUARD_EXECUTABLES:
+        guard = guard_dir / name
+        guard.write_text("#!/bin/sh\n", encoding="utf-8")
+        guard.chmod(0o750)
+    monkeypatch.setattr(agent_runner, "_OPENACE_AGENT_GUARD_BIN", str(guard_dir))
+    real_stat = agent_runner.os.stat
+
+    def root_owned_group_only(path, *, follow_symlinks=True):
+        result = real_stat(path, follow_symlinks=follow_symlinks)
+        kind = stat.S_IFDIR if stat.S_ISDIR(result.st_mode) else stat.S_IFREG
+        return SimpleNamespace(st_uid=0, st_mode=kind | 0o750)
+
+    monkeypatch.setattr(agent_runner.os, "stat", root_owned_group_only)
+
+    with pytest.raises(RuntimeError, match="Unsafe packaged agent guard directory"):
+        agent_runner.AutonomousAgentRunner._validate_cross_user_guard_bin(
+            {"PATH": f"{guard_dir}:/usr/bin"}
+        )
+
+
+def test_cross_user_guard_accepts_root_owned_world_executable_install(monkeypatch, tmp_path):
+    from types import SimpleNamespace
+
+    from app.modules.workspace.autonomous import agent_runner
+
+    guard_dir = tmp_path / "agent-bin"
+    guard_dir.mkdir(mode=0o755)
+    for name in agent_runner._AGENT_GUARD_EXECUTABLES:
+        guard = guard_dir / name
+        guard.write_text("#!/bin/sh\n", encoding="utf-8")
+        guard.chmod(0o755)
+    monkeypatch.setattr(agent_runner, "_OPENACE_AGENT_GUARD_BIN", str(guard_dir))
+    real_stat = agent_runner.os.stat
+
+    def root_owned(path, *, follow_symlinks=True):
+        result = real_stat(path, follow_symlinks=follow_symlinks)
+        return SimpleNamespace(st_uid=0, st_mode=result.st_mode)
+
+    monkeypatch.setattr(agent_runner.os, "stat", root_owned)
+
+    agent_runner.AutonomousAgentRunner._validate_cross_user_guard_bin(
+        {"PATH": f"{guard_dir}:/usr/bin"}
+    )
 
 
 def test_local_agent_fails_closed_without_trusted_repo_snapshot():


### PR DESCRIPTION
## Summary
- select a compatible service Python without probing through the repository owner sudo policy
- verify private-home worktrees through the same isolated wrapper used for agent launch
- add regression coverage for both deployment-only failures

## Validation
- `pytest tests/issues/1395/test_cross_user_permissions.py tests/unit/test_autonomous_ci_guardrails.py -q` (68 passed)
- Ruff, Black, `git diff --check`

Follow-up to #1939, found during live validation of replacement workflows for #1891-#1897.