### PR TITLE
fix(autonomous): release isolated agent locks after results

### DIFF
--- a/app/modules/workspace/autonomous/agent_runner.py
+++ b/app/modules/workspace/autonomous/agent_runner.py
@@ -3221,6 +3221,17 @@ class AutonomousAgentRunner:
                         self._sync_sidebar_session_totals(
                             session, status="error" if session.error else "active"
                         )
+                        # ``--input-format stream-json`` keeps the CLI alive for
+                        # another turn until stdin reaches EOF. A result event is
+                        # terminal for this one-shot invocation, so close the
+                        # write side before waking the caller. Otherwise killing
+                        # only the sudo launcher can strand the isolated wrapper
+                        # while it still holds the per-agent ACL lock.
+                        try:
+                            if session.process and session.process.stdin:
+                                session.process.stdin.close()
+                        except (OSError, BrokenPipeError, AttributeError, ValueError):
+                            pass
                         session.completed.set()
                         # Emit usage activity for real-time token display
                         if self._activity_callback:

--- a/scripts/openace-run-as.sh
+++ b/scripts/openace-run-as.sh
@@ -130,7 +130,14 @@ if [ "$isolated" = true ]; then
     # Recover safely after a previously interrupted wrapper before granting
     # this run access to anything. The registry is root-owned under /run.
     cleanup_isolated
-    trap cleanup_isolated EXIT HUP INT TERM
+    trap cleanup_isolated EXIT
+    # Bash services traps promptly while waiting for a background job. With a
+    # foreground external command it may defer the trap until that command
+    # exits, stranding this wrapper and its ACL lock after the parent sudo
+    # process is terminated.
+    trap 'exit 129' HUP
+    trap 'exit 130' INT
+    trap 'exit 143' TERM
 
     # Record every path before the first ACL grant. If this wrapper is
     # interrupted at any later instruction, the next serialized invocation
@@ -189,7 +196,9 @@ if [ "$isolated" = true ]; then
         "HOME=$target_home" "USER=$target_user" "LOGNAME=$target_user" \
         "LANG=${LANG:-C.UTF-8}" "LC_ALL=${LC_ALL:-}" "TMPDIR=/tmp" \
         "GIT_CONFIG_COUNT=1" "GIT_CONFIG_KEY_0=safe.directory" \
-        "GIT_CONFIG_VALUE_0=$project_dir" "$@"
+        "GIT_CONFIG_VALUE_0=$project_dir" "$@" <&0 &
+    agent_child_pid=$!
+    wait "$agent_child_pid"
     child_status=$?
     set -e
     cleanup_isolated

--- a/tests/issues/1395/test_cross_user_permissions.py
+++ b/tests/issues/1395/test_cross_user_permissions.py
@@ -429,6 +429,39 @@ def test_isolated_wrapper_scopes_git_safe_directory_to_worktree():
     assert "git config --global" not in wrapper
 
 
+def test_isolated_wrapper_can_handle_signals_while_waiting_for_agent():
+    from pathlib import Path
+
+    wrapper = Path("scripts/openace-run-as.sh").read_text(encoding="utf-8")
+
+    assert "trap cleanup_isolated EXIT" in wrapper
+    assert "trap 'exit 129' HUP" in wrapper
+    assert "trap 'exit 130' INT" in wrapper
+    assert "trap 'exit 143' TERM" in wrapper
+    assert '"GIT_CONFIG_VALUE_0=$project_dir" "$@" <&0 &' in wrapper
+    assert "agent_child_pid=$!" in wrapper
+    assert 'wait "$agent_child_pid"' in wrapper
+
+
+def test_background_wait_keeps_runner_stdin_until_eof():
+    import subprocess
+
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            '{ IFS= read -r line; printf "received=%s" "$line"; } <&0 & ' 'child=$!; wait "$child"',
+        ],
+        input="hello-from-runner\n",
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert result.stdout == "received=hello-from-runner"
+
+
 # ── _wrap_agent_cmd / _is_cross_user (agent launch) ─────────────────────
 
 

--- a/tests/unit/test_autonomous_ci_guardrails.py
+++ b/tests/unit/test_autonomous_ci_guardrails.py
@@ -226,6 +226,43 @@ def test_cross_user_launch_preserves_nonsecret_guard_environment(monkeypatch, tm
     assert "OPENACE_REAL_GIT=/usr/bin/git" in command
 
 
+def test_terminal_result_closes_stream_json_stdin():
+    from types import SimpleNamespace
+
+    from app.modules.workspace.autonomous.agent_runner import AutonomousAgentRunner, _LocalSession
+
+    class FakeStdout:
+        def __init__(self):
+            self.lines = [json.dumps({"type": "result", "session_id": "cli-session"}).encode()]
+
+        def readline(self):
+            return self.lines.pop(0) if self.lines else b""
+
+    class FakeStdin:
+        def __init__(self):
+            self.closed = False
+
+        def close(self):
+            self.closed = True
+
+    runner = AutonomousAgentRunner.__new__(AutonomousAgentRunner)
+    runner._activity_callback = None
+    runner._capture_cli_session_id = lambda *_args: "cli-session"
+    runner._sync_sidebar_session_totals = lambda *_args, **_kwargs: None
+    runner._resolve_sidebar_session = lambda *_args, **_kwargs: "cli-session"
+    process = SimpleNamespace(stdout=FakeStdout(), stdin=FakeStdin(), returncode=None)
+    session = _LocalSession(session_id="tracking-session", process=process)
+
+    with patch(
+        "app.modules.workspace.autonomous.agent_runner._extract_stream_usage",
+        return_value=None,
+    ):
+        runner._read_stdout(session)
+
+    assert session.completed.is_set()
+    assert process.stdin.closed
+
+
 def test_cross_user_launch_rejects_source_tree_guard_path():
     from app.modules.workspace.autonomous.agent_runner import AutonomousAgentRunner
 


### PR DESCRIPTION
## Summary

- close the stream-json stdin pipe when a terminal agent result arrives so Claude exits naturally
- make the isolated launcher wait on its child as a background job, allowing signal traps to run promptly
- guarantee EXIT cleanup releases the credentialless agent, ACL grants, and serialized per-agent lock

## Production evidence

After #1941 was deployed, issue-1891 completed its first planning call but the Claude process kept waiting for another stream-json turn. The runner terminated the top-level sudo process after five seconds, leaving the wrapper and Claude process orphaned in the original process group. The next review probe blocked on `/run/lock/openace-agent-386.lock` and timed out after 30 seconds. Terminating the orphaned Claude child let the wrapper revoke ACLs and the review session start immediately.

## Verification

- 74 focused tests passed
- Ruff, Black, isort, mypy, bandit, shell syntax, and pre-commit passed
