### PR TITLE
fix(install): 保留 frontend 构建产物防止升级时丢失 static/js/dist (Issue #1943)

### DIFF
--- a/scripts/install-central/package-method/install.sh
+++ b/scripts/install-central/package-method/install.sh
@@ -4014,6 +4014,16 @@ do_upgrade() {
             cp "$target_path/usage.db" "$backup_dir/"
         fi
 
+        # Backup frontend build artifacts if source doesn't have them (Issue #1943)
+        # static/js/dist is not tracked in git, so upgrading from git repo would lose it
+        local preserve_frontend=false
+        if [ -d "$target_path/static/js/dist" ] && [ ! -d "$SOURCE_DIR/static/js/dist" ]; then
+            print_info "Backing up frontend build artifacts (static/js/dist)..."
+            mkdir -p "$backup_dir/static/js"
+            cp -r "$target_path/static/js/dist" "$backup_dir/static/js/"
+            preserve_frontend=true
+        fi
+
         # Update files (preserve logs, data, and config)
         print_info "Updating files..."
         # Remove old files except logs, data, and config directory
@@ -4071,6 +4081,16 @@ do_upgrade() {
         # Set permissions
         chmod +x "$target_path/scripts/"*.py 2>/dev/null || true
         chmod +x "$target_path/scripts/"*.sh 2>/dev/null || true
+
+        # Restore frontend build artifacts if source didn't have them (Issue #1943)
+        if [ "$preserve_frontend" = true ]; then
+            print_info "Restoring frontend build artifacts (source directory lacks static/js/dist)..."
+            mkdir -p "$target_path/static/js"
+            cp -r "$backup_dir/static/js/dist" "$target_path/static/js/"
+            print_warning "Preserved existing frontend build artifacts"
+            print_warning "To rebuild frontend with latest code, run:"
+            print_warning "  cd $target_path/frontend && npm install && npm run build"
+        fi
     fi
 
     # Fix ownership if running as root and a different user is specified


### PR DESCRIPTION
## 问题描述

从 git 仓库直接运行 `install.sh` 升级时，`static/js/dist` 目录会被删除且不会恢复，导致访问 Web UI 时返回 `React app not built` 错误。

Closes #1943

## 修改内容

### 1. 在 `do_upgrade` 函数中添加备份逻辑

- 检测目标目录是否存在 `static/js/dist`
- 检测源目录是否缺少 `static/js/dist`
- 如果目标有、源没有，则备份到临时目录

### 2. 复制新文件后添加恢复逻辑

- 如果已备份，恢复 `static/js/dist` 到目标目录
- 给用户警告，提示如何手动构建最新的 frontend

## 测试验证

| 步骤 | 结果 |
|------|------|
| 模拟 git 仓库没有 `static/js/dist` | ✅ |
| 备份目标目录的 `static/js/dist` | ✅ |
| 删除目标目录的 `static/js/dist` | ✅ |
| 恢复备份的 `static/js/dist` | ✅ |
| Web UI 正常访问 | ✅ |

## 为什么选择这个方案

1. **安全性**: 不会因为升级中断服务
2. **兼容性**: 目标机器可能没有 Node.js
3. **用户体验**: 最小化用户操作，升级后服务能正常启动