### PR TITLE
fix(autonomous): preserve test evidence across quota pauses

### DIFF
--- a/app/modules/workspace/autonomous/agent_runner.py
+++ b/app/modules/workspace/autonomous/agent_runner.py
@@ -3122,6 +3122,39 @@ class AutonomousAgentRunner:
                                     "model": msg.get("model"),
                                 }
                             )
+                        # Current Claude stream-json embeds tool_use blocks in
+                        # the assistant message instead of emitting the legacy
+                        # top-level ``type=tool_use`` shape handled below.
+                        # Preserve both the invocation and its stable id so a
+                        # later user/tool_result block can prove which test
+                        # command actually completed.
+                        if isinstance(content, list):
+                            for block in content:
+                                if not isinstance(block, dict) or block.get("type") != "tool_use":
+                                    continue
+                                tool_info = {
+                                    "name": block.get("name", "unknown"),
+                                    "input": block.get("input", {}),
+                                    "id": block.get("id"),
+                                }
+                                session.tool_calls.append({"type": "tool_use", "tool": tool_info})
+                                session.event_log.append(
+                                    {
+                                        "type": "tool_use",
+                                        "tool_name": tool_info["name"],
+                                        "tool_input": tool_info["input"],
+                                        "tool_use_id": tool_info["id"],
+                                    }
+                                )
+                                if self._activity_callback:
+                                    self._activity_callback(
+                                        session.session_id,
+                                        {
+                                            "type": "tool_use",
+                                            "tool_name": tool_info["name"],
+                                            "tool_input": str(tool_info["input"])[:200],
+                                        },
+                                    )
                         # Emit activity for real-time frontend display
                         if self._activity_callback and text_delta:
                             self._activity_callback(

--- a/app/modules/workspace/session_manager.py
+++ b/app/modules/workspace/session_manager.py
@@ -71,6 +71,27 @@ _WORKFLOW_ID_CONTEXT_MARKER = '"workflow_id"'
 _AUTONOMOUS_WORKFLOW_CONTEXT_PATTERN = "%" + escape_like(_WORKFLOW_ID_CONTEXT_MARKER) + "%"
 
 
+def is_autonomous_workflow_session(session: Any) -> bool:
+    """Return whether ``session`` is owned by the autonomous scheduler.
+
+    Autonomous workflow sessions have a separate lifecycle owner.  Quota
+    enforcement pauses their parent workflow between orchestrator cycles; a
+    generic session sweeper must not complete the backing session mid-agent,
+    because completion revokes its LLM proxy token while the process is still
+    running.
+    """
+    session_type = getattr(session, "session_type", None)
+    context = getattr(session, "context", None)
+    if isinstance(session, dict):
+        session_type = session.get("session_type")
+        context = session.get("context")
+    return (
+        session_type == SessionType.WORKFLOW.value
+        and isinstance(context, dict)
+        and bool(context.get("workflow_id"))
+    )
+
+
 def visible_session_clause(alias: str = "") -> tuple[str, list[Any]]:
     """Hide autonomous workflow tracking wrappers from user-facing listings.
 

--- a/app/services/autonomous_scheduler.py
+++ b/app/services/autonomous_scheduler.py
@@ -55,9 +55,9 @@ QUEUE_BLOCKING_STATUSES = {"paused", "cancelled"}
 # Prefix written to error_message when a workflow is paused because its owner
 # exceeded quota. The scheduler auto-resumes only workflows paused with this
 # prefix — a user's manual pause (error_message empty / different text) is left
-# untouched. Autonomous agents bypass the LLM proxy (local mode connects to the
-# model API directly), so the proxy's 429 can't enforce quota for them; the
-# scheduler gate below is the enforcement point.
+# untouched. This scheduler owns autonomous workflow lifecycle enforcement;
+# generic quota sweepers deliberately leave workflow sessions alone so they do
+# not revoke an in-flight agent's LLM proxy token.
 QUOTA_PAUSE_REASON_PREFIX = "Quota exceeded"
 
 
@@ -255,9 +255,9 @@ class AutonomousScheduler:
             return workflow_id
 
         # Quota gate (fail-closed): a user over quota (or whose quota check
-        # errored) must not advance. Local autonomous agents bypass the LLM
-        # proxy, so this scheduler gate — not the proxy's 429 — is what bounds
-        # them.
+        # errored) must not advance. This scheduler is the lifecycle authority
+        # for workflow-owned sessions, so it pauses before a new advance cycle
+        # without revoking a proxy token out from under an in-flight agent.
         #
         # Enforcement granularity is between advance() cycles, not mid-step:
         # while an agent is mid-flight, advance() is blocked and workflow_id
@@ -547,10 +547,35 @@ class AutonomousScheduler:
             )
         )
 
-        # Limit to concurrency cap, accounting for already-running workflows
+        # Limit to the concurrency cap while reserving conflict keys inside
+        # this same selection pass.  Filtering above only sees workflows that
+        # were already running before this poll; without local reservations,
+        # multiple newly auto-resumed siblings from one batch (or workflows
+        # sharing a worktree/branch) can all enter ``to_process`` together.
         with self._in_progress_lock:
             slots_available = MAX_CONCURRENT_WORKFLOWS - len(self._in_progress_ids)
-        to_process = active[: max(0, slots_available)]
+            selected_batches: set[str] = set()
+            selected_workspaces: set[str] = set()
+            selected_branches: set[str] = set()
+            to_process: list[dict] = []
+            for wf in active:
+                if len(to_process) >= max(0, slots_available):
+                    break
+                batch_id = wf.get("batch_id")
+                workspace, branch = self._conflict_keys(wf)
+                if batch_id and batch_id in selected_batches:
+                    continue
+                if workspace and workspace in selected_workspaces:
+                    continue
+                if branch and branch in selected_branches:
+                    continue
+                to_process.append(wf)
+                if batch_id:
+                    selected_batches.add(batch_id)
+                if workspace:
+                    selected_workspaces.add(workspace)
+                if branch:
+                    selected_branches.add(branch)
 
         if not to_process:
             return

--- a/app/services/data_fetch_scheduler.py
+++ b/app/services/data_fetch_scheduler.py
@@ -431,11 +431,21 @@ class DataFetchScheduler:
 
         # Terminate active sessions
         try:
-            from app.modules.workspace.session_manager import SessionManager
+            from app.modules.workspace.session_manager import (
+                SessionManager,
+                is_autonomous_workflow_session,
+            )
 
             sm = SessionManager()
             active_sessions = sm.get_active_sessions(user_id)
             for session in active_sessions:
+                if is_autonomous_workflow_session(session):
+                    logger.info(
+                        "Deferring quota enforcement for autonomous workflow session %s "
+                        "to AutonomousScheduler",
+                        session.session_id[:8],
+                    )
+                    continue
                 try:
                     sm.complete_session(session.session_id)
                     logger.info(

--- a/app/services/quota_enforcement_scheduler.py
+++ b/app/services/quota_enforcement_scheduler.py
@@ -365,11 +365,21 @@ class QuotaEnforcementScheduler:
 
         # Terminate active sessions
         try:
-            from app.modules.workspace.session_manager import SessionManager
+            from app.modules.workspace.session_manager import (
+                SessionManager,
+                is_autonomous_workflow_session,
+            )
 
             sm = SessionManager()
             active_sessions = sm.get_active_sessions(user_id)
             for session in active_sessions:
+                if is_autonomous_workflow_session(session):
+                    logger.info(
+                        "Deferring quota enforcement for autonomous workflow session %s "
+                        "to AutonomousScheduler",
+                        session.session_id[:8],
+                    )
+                    continue
                 try:
                     sm.complete_session(session.session_id)
                     logger.info(

--- a/tests/issues/716/test_scheduler.py
+++ b/tests/issues/716/test_scheduler.py
@@ -170,6 +170,44 @@ class TestSchedulerProcessWorkflows:
 
                 assert mock_orch.advance.call_count == MAX_CONCURRENT_WORKFLOWS
 
+    def test_same_poll_selects_only_one_workflow_per_batch(self):
+        scheduler = AutonomousScheduler()
+        mock_repo = MagicMock()
+        mock_repo.get_active_workflows.return_value = [
+            {
+                "workflow_id": "batch-wf-1",
+                "status": "planning",
+                "batch_id": "batch-1",
+                "worktree_path": "/wt/1",
+                "branch_name": "auto/1",
+            },
+            {
+                "workflow_id": "batch-wf-2",
+                "status": "planning",
+                "batch_id": "batch-1",
+                "worktree_path": "/wt/2",
+                "branch_name": "auto/2",
+            },
+            {
+                "workflow_id": "independent-wf",
+                "status": "planning",
+                "batch_id": "batch-2",
+                "worktree_path": "/wt/3",
+                "branch_name": "auto/3",
+            },
+        ]
+
+        with (
+            patch("app.routes.autonomous._get_repo", return_value=mock_repo),
+            patch.object(
+                scheduler, "_advance_single", side_effect=lambda workflow_id: workflow_id
+            ) as advance,
+        ):
+            scheduler._process_workflows()
+
+        selected = [call.args[0] for call in advance.call_args_list]
+        assert selected == ["batch-wf-1", "independent-wf"]
+
     def test_single_workflow_error_continues(self):
         """Error in one workflow should not stop others."""
         scheduler = AutonomousScheduler()

--- a/tests/unit/test_autonomous_ci_guardrails.py
+++ b/tests/unit/test_autonomous_ci_guardrails.py
@@ -435,6 +435,60 @@ def test_runner_preserves_tool_result_for_test_evidence():
     }
 
 
+def test_claude_embedded_tool_use_pairs_with_test_result():
+    from types import SimpleNamespace
+
+    from app.modules.workspace.autonomous.agent_runner import AutonomousAgentRunner, _LocalSession
+    from app.modules.workspace.autonomous.orchestrator import _has_passing_test_tool_result
+
+    lines = [
+        {
+            "type": "assistant",
+            "message": {
+                "id": "msg-test",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "tool-test",
+                        "name": "Bash",
+                        "input": {"command": "python -m pytest tests/issues/1891 -q"},
+                    }
+                ],
+            },
+        },
+        {
+            "type": "user",
+            "message": {
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "tool-test",
+                        "content": "65 passed in 3.2s",
+                        "is_error": False,
+                    }
+                ]
+            },
+        },
+    ]
+
+    class FakeStdout:
+        def __init__(self):
+            self.lines = [json.dumps(line).encode() for line in lines]
+
+        def readline(self):
+            return self.lines.pop(0) if self.lines else b""
+
+    runner = AutonomousAgentRunner.__new__(AutonomousAgentRunner)
+    runner._activity_callback = None
+    process = SimpleNamespace(stdout=FakeStdout(), returncode=None)
+    session = _LocalSession(session_id="test-session", process=process)
+
+    runner._read_stdout(session)
+
+    assert session.tool_calls[0]["tool"]["name"] == "Bash"
+    assert _has_passing_test_tool_result(session.event_log, "python")
+
+
 def test_codex_command_execution_normalizes_tool_evidence():
     from app.modules.workspace.autonomous.agent_runner import AutonomousAgentRunner
     from app.modules.workspace.autonomous.orchestrator import _has_passing_test_tool_result

--- a/tests/unit/test_data_fetch_scheduler.py
+++ b/tests/unit/test_data_fetch_scheduler.py
@@ -433,6 +433,37 @@ class TestDataFetchSchedulerEnforceUserQuota:
 
     @patch("app.modules.governance.alert_transaction_manager.create_quota_alert_transactional")
     @patch("app.modules.workspace.session_manager.SessionManager")
+    def test_enforce_defers_autonomous_workflow_sessions(self, mock_sm_cls, mock_alert):
+        s = DataFetchScheduler()
+        today = datetime.now(timezone.utc).replace(tzinfo=None).strftime("%Y-%m-%d")
+        row = {
+            "user_id": 1,
+            "username": "testuser",
+            "today_requests": 100,
+            "today_tokens": 5000000,
+            "daily_request_quota": 50,
+            "daily_token_quota": 1,
+        }
+        workflow_session = MagicMock(
+            session_id="workflow-session",
+            session_type="workflow",
+            context={"workflow_id": "wf-123"},
+        )
+        regular_session = MagicMock(
+            session_id="regular-session",
+            session_type="agent",
+            context={},
+        )
+        mock_sm = MagicMock()
+        mock_sm.get_active_sessions.return_value = [workflow_session, regular_session]
+        mock_sm_cls.return_value = mock_sm
+
+        s._enforce_user_quota(row, today, "daily")
+
+        mock_sm.complete_session.assert_called_once_with("regular-session")
+
+    @patch("app.modules.governance.alert_transaction_manager.create_quota_alert_transactional")
+    @patch("app.modules.workspace.session_manager.SessionManager")
     def test_enforce_session_failure_continues(self, mock_sm_cls, mock_alert):
         s = DataFetchScheduler()
         today = datetime.now(timezone.utc).replace(tzinfo=None).strftime("%Y-%m-%d")

--- a/tests/unit/test_quota_enforcement_scheduler.py
+++ b/tests/unit/test_quota_enforcement_scheduler.py
@@ -357,6 +357,37 @@ class TestQuotaEnforcementSchedulerEnforcement:
 
     @patch("app.modules.governance.alert_transaction_manager.create_quota_alert_transactional")
     @patch("app.modules.workspace.session_manager.SessionManager")
+    def test_enforce_user_defers_autonomous_workflow_sessions(self, mock_sm_cls, mock_create_alert):
+        scheduler = QuotaEnforcementScheduler()
+        today = datetime.now(timezone.utc).replace(tzinfo=None).strftime("%Y-%m-%d")
+        row = {
+            "user_id": 1,
+            "username": "testuser",
+            "today_requests": 100,
+            "today_tokens": 5000000,
+            "daily_request_quota": 50,
+            "daily_token_quota": 1,
+        }
+        workflow_session = MagicMock(
+            session_id="workflow-session",
+            session_type="workflow",
+            context={"workflow_id": "wf-123"},
+        )
+        regular_session = MagicMock(
+            session_id="regular-session",
+            session_type="terminal",
+            context={},
+        )
+        mock_sm = MagicMock()
+        mock_sm.get_active_sessions.return_value = [workflow_session, regular_session]
+        mock_sm_cls.return_value = mock_sm
+
+        scheduler._enforce_user(row, today, "daily")
+
+        mock_sm.complete_session.assert_called_once_with("regular-session")
+
+    @patch("app.modules.governance.alert_transaction_manager.create_quota_alert_transactional")
+    @patch("app.modules.workspace.session_manager.SessionManager")
     def test_enforce_user_alert_failure_continues(self, mock_sm_cls, mock_create_alert):
         mock_create_alert.side_effect = Exception("Alert service down")
 


### PR DESCRIPTION
## Summary

- keep autonomous workflow sessions under AutonomousScheduler lifecycle ownership when user quota is exceeded, avoiding mid-agent proxy-token revocation
- preserve Claude stream-json tool_use blocks embedded in assistant messages so Bash test results can be paired with the command that produced them
- reserve batch, worktree, and branch keys during one scheduler selection pass so quota auto-resume cannot start sibling workflows concurrently

## Production evidence

During clean retry of issue #1891, monthly quota enforcement completed the active test session and revoked its proxy token while Claude was still running. After quota recovery, the rerun executed 65 tests successfully, but the strict evidence validator rejected it because the embedded Bash tool_use event was not in AgentTaskResult.event_log. Quota auto-resume also selected three siblings from the same batch in one poll.

## Validation

- 132 targeted tests passed (2 unrelated SQLite schema-initialization cases deselected)
- 44 agent-runner and scheduler-dedup tests passed
- pre-commit: Black, isort, Ruff, mypy, Bandit and repository policy hooks passed
