### PR TITLE
fix(fs): add cwd parameter to run_as_user functions (#1946)

### DIFF
--- a/app/routes/autonomous.py
+++ b/app/routes/autonomous.py
@@ -66,7 +66,7 @@ def _get_effective_system_account(system_account: str | None) -> str | None:
 def _run_as_user(system_account: str, command: list) -> subprocess.CompletedProcess:
     """Run a command as a specific user using sudo."""
     sudo_cmd = ["sudo", "-u", system_account] + command
-    return subprocess.run(sudo_cmd, capture_output=True, text=True, timeout=10)
+    return subprocess.run(sudo_cmd, capture_output=True, text=True, timeout=10, cwd="/tmp")
 
 
 def _get_repo() -> AutonomousWorkflowRepository:

--- a/app/routes/fs.py
+++ b/app/routes/fs.py
@@ -153,7 +153,7 @@ def get_effective_system_account(system_account: str | None) -> str | None:
 def run_as_user(system_account: str, command: list) -> subprocess.CompletedProcess:
     """Run a command as a specific user using sudo."""
     sudo_cmd = ["sudo", "-u", system_account] + command
-    return subprocess.run(sudo_cmd, capture_output=True, text=True, timeout=10)
+    return subprocess.run(sudo_cmd, capture_output=True, text=True, timeout=10, cwd="/tmp")
 
 
 def get_current_user():

--- a/app/routes/projects.py
+++ b/app/routes/projects.py
@@ -132,7 +132,7 @@ def get_effective_system_account(system_account: str | None) -> str | None:
 def run_as_user(system_account: str, command: list) -> subprocess.CompletedProcess:
     """Run a command as a specific user using sudo."""
     sudo_cmd = ["sudo", "-u", system_account] + command
-    return subprocess.run(sudo_cmd, capture_output=True, text=True, timeout=30)
+    return subprocess.run(sudo_cmd, capture_output=True, text=True, timeout=30, cwd="/tmp")
 
 
 @projects_bp.route("/projects", methods=["GET"])

--- a/app/utils/workspace.py
+++ b/app/utils/workspace.py
@@ -82,8 +82,8 @@ def run_as_root_if_needed(cmd: list) -> subprocess.CompletedProcess:
         subprocess.CompletedProcess 结果。
     """
     if os.geteuid() != 0:
-        return subprocess.run(["sudo"] + cmd, capture_output=True, text=True)
-    return subprocess.run(cmd, capture_output=True, text=True)
+        return subprocess.run(["sudo"] + cmd, capture_output=True, text=True, cwd="/tmp")
+    return subprocess.run(cmd, capture_output=True, text=True, cwd="/tmp")
 
 
 def _is_docker_multi_user_mode() -> bool:


### PR DESCRIPTION
## 修复说明

关联 Issue：#1946

## 根因

`subprocess.run` 调用缺少 `cwd` 参数，导致 sudo 命令继承服务进程工作目录。当目标用户对该目录无权限时，`find` 等命令报错 "Failed to restore initial working directory"。

## 修复方案

在所有 `run_as_user`/`_run_as_user`/`run_as_root_if_needed` 函数的 `subprocess.run` 调用中添加 `cwd="/tmp"` 参数，确保命令在一个所有用户都能访问的目录下执行。

## 主要变更

| 文件 | 函数名 | 修改 |
|------|--------|------|
| `app/routes/fs.py` | `run_as_user` | 添加 `cwd="/tmp"` |
| `app/routes/projects.py` | `run_as_user` | 添加 `cwd="/tmp"` |
| `app/routes/autonomous.py` | `_run_as_user` | 添加 `cwd="/tmp"` |
| `app/utils/workspace.py` | `run_as_root_if_needed` | 添加 `cwd="/tmp"` |

## 测试

- 本地导入测试通过
- 受影响功能：文件搜索、项目创建目录检查、自主开发路径检查

## 风险

- 兼容性：无风险，`/tmp` 目录所有用户可访问
- 性能：无影响，仅改变工作目录
- 安全：无风险，`/tmp` 是 Linux 标准临时目录
- 回归：低风险，现有测试使用 mock