### PR TITLE
fix(autonomous): pause workflows when provider quota is exhausted

### DIFF
--- a/app/modules/governance/alert_notifier.py
+++ b/app/modules/governance/alert_notifier.py
@@ -1085,7 +1085,9 @@ class AlertNotifier:
 
         threshold = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(hours=hours)
 
-        # PostgreSQL uses ->> for JSON extraction, SQLite uses json_extract
+        # ``alerts.metadata`` is TEXT in both schemas.  PostgreSQL therefore
+        # needs an explicit JSONB cast before using ``->>``; without it the
+        # upstream-quota alert path fails while trying to de-duplicate alerts.
         if is_postgresql():
             cursor.execute(
                 """
@@ -1093,7 +1095,7 @@ class AlertNotifier:
                 WHERE user_id = %s
                   AND alert_type = %s
                   AND created_at >= %s
-                  AND metadata->>'quota_type' = %s
+                  AND (metadata::jsonb)->>'quota_type' = %s
                 """,
                 (user_id, AlertType.QUOTA.value, threshold.isoformat(), quota_type),
             )

--- a/app/modules/governance/alert_state_synchronizer.py
+++ b/app/modules/governance/alert_state_synchronizer.py
@@ -468,7 +468,7 @@ class AlertStateSynchronizer:
                         SELECT 1 FROM alerts a
                         WHERE a.user_id = qa.user_id
                         AND a.alert_type = 'quota'
-                        AND a.metadata->>'quota_type' = qa.quota_type
+                        AND (a.metadata::jsonb)->>'quota_type' = qa.quota_type
                         AND DATE(a.created_at) = DATE(qa.created_at)
                     )
                 """
@@ -507,13 +507,15 @@ class AlertStateSynchronizer:
             if is_postgresql():
                 orphan_alerts = self.db.fetch_all(
                     """
-                    SELECT a.alert_id, a.user_id, a.metadata->>'quota_type' as quota_type, a.created_at
+                    SELECT a.alert_id, a.user_id,
+                           (a.metadata::jsonb)->>'quota_type' as quota_type,
+                           a.created_at
                     FROM alerts a
                     WHERE a.alert_type = 'quota'
                     AND NOT EXISTS (
                         SELECT 1 FROM quota_alerts qa
                         WHERE qa.user_id = a.user_id
-                        AND qa.quota_type = a.metadata->>'quota_type'
+                        AND qa.quota_type = (a.metadata::jsonb)->>'quota_type'
                         AND DATE(qa.created_at) = DATE(a.created_at)
                     )
                 """

--- a/app/modules/governance/alert_transaction_manager.py
+++ b/app/modules/governance/alert_transaction_manager.py
@@ -321,7 +321,7 @@ class AlertTransactionManager:
                 """
                     SELECT COUNT(*) as count FROM alerts
                     WHERE user_id = %s AND alert_type = %s AND created_at >= %s
-                    AND metadata->>'quota_type' = %s
+                    AND (metadata::jsonb)->>'quota_type' = %s
                 """,
                 (user_id, "quota", threshold_str, quota_type),
             )

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -43,6 +43,17 @@ from app.repositories.user_repo import UserRepository
 
 logger = logging.getLogger(__name__)
 
+UPSTREAM_QUOTA_PAUSE_REASON_PREFIX = "Upstream provider quota exhausted:"
+
+
+class WorkflowPaused(RuntimeError):
+    """Control-flow signal for a persisted workflow pause."""
+
+
+class UpstreamQuotaPaused(WorkflowPaused):
+    """Control-flow signal used after persisting a recoverable quota pause."""
+
+
 # Completion keywords to detect in issue comments
 COMPLETION_KEYWORDS = [
     "开发完成",
@@ -780,6 +791,9 @@ _TRANSIENT_API_ERROR_RE = re.compile(
     # "API Error: 429" / "API Error: 5xx". Only 429 among 4xx is transient;
     # 400/401/403/404/422 are permanent client errors and must NOT trigger retry.
     r"api\s*error:?\s*(?:429|5\d{2})"
+    # Claude may wrap the status later in the same short envelope:
+    # ``API Error: Request rejected (429)``.
+    r"|api\s*error[^\n]{0,80}\(\s*(?:429|5\d{2})\s*\)"
     # Bare "429" must have context that distinguishes a real API error from a
     # plan discussing HTTP status codes (e.g. "return 429" in a rate-limit
     # design). Require "status" or "error" nearby, not just the number alone.
@@ -789,6 +803,16 @@ _TRANSIENT_API_ERROR_RE = re.compile(
     r"|quota\s+exceeded|rate[\s-]?limit(?:ed)?|too\s+many\s+requests"
     r"|overloaded"  # "The service may be temporarily overloaded"
     r"|bad\s+gateway|service\s+unavailable|gateway\s+timeout|internal\s+server\s+error",
+    re.IGNORECASE,
+)
+
+# The proxy emits this explicit message only after the provider reports a
+# quota-exhaustion response.  Unlike burst rate limiting, retrying it for the
+# full 30-minute transient window cannot make progress and amplifies traffic.
+_UPSTREAM_QUOTA_EXHAUSTED_RE = re.compile(
+    r"platform\s+quota\s+exceeded"
+    r"|upstream\s+(?:provider\s+)?quota\s+(?:exceeded|exhausted)"
+    r"|usage\s+allocated\s+quota\s+exceeded",
     re.IGNORECASE,
 )
 
@@ -3268,10 +3292,58 @@ class AutonomousOrchestrator:
         plan/review text caused phrases such as "Rate Limit" to restart an
         otherwise successful phase (#1891).
         """
+        if cls._is_upstream_quota_exhausted(result):
+            return False
         if cls._is_transient_api_error(result.error or ""):
             return True
         return (result.total_tokens or 0) == 0 and cls._is_transient_api_error(
             result.response_text or ""
+        )
+
+    @staticmethod
+    def _is_upstream_quota_exhausted(result: AgentTaskResult) -> bool:
+        """Return whether a provider allocation is exhausted.
+
+        Error fields are authoritative.  Assistant text is considered only
+        for a zero-token envelope so a legitimate design discussion about
+        quota handling cannot pause a workflow.
+        """
+        if _UPSTREAM_QUOTA_EXHAUSTED_RE.search(result.error or ""):
+            return True
+        return (result.total_tokens or 0) == 0 and bool(
+            _UPSTREAM_QUOTA_EXHAUSTED_RE.search(result.response_text or "")
+        )
+
+    def _pause_for_upstream_quota(self, result: AgentTaskResult, milestone_id: str = "") -> None:
+        """Persist a non-spinning pause that an operator may resume later."""
+        message = (
+            f"{UPSTREAM_QUOTA_PAUSE_REASON_PREFIX} "
+            "the configured model provider rejected requests; resume after "
+            "provider allocation is restored"
+        )
+        result.success = False
+        result.error_code = "upstream_quota_exhausted"
+        result.error = message
+        if milestone_id:
+            self.repo.update_milestone(
+                milestone_id,
+                {
+                    "status": "failed",
+                    "session_id": result.session_id,
+                    "error_message": message,
+                },
+            )
+        self._update_workflow(
+            {
+                "status": "paused",
+                "error_message": message,
+                "paused_at": datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S"),
+                "agent_pid": None,
+            }
+        )
+        self._emit(
+            "upstream_quota_paused",
+            {"reason": "upstream_quota_exhausted", "message": message},
         )
 
     @staticmethod
@@ -3504,12 +3576,37 @@ class AutonomousOrchestrator:
         _CANCEL_POLL_INTERVAL = 5  # seconds between cancel checks
         retry_start = time.monotonic()
         delay = API_RETRY_INITIAL_DELAY
+
+        def abort_paused_retry() -> None:
+            """Finalize retry bookkeeping before unwinding a manual pause."""
+            logger.info("API error retry aborted (workflow status=paused)")
+            if milestone_id:
+                self.repo.update_milestone(
+                    milestone_id,
+                    {
+                        "status": "cancelled",
+                        "session_id": result.session_id,
+                        "error_message": "Workflow paused during API error retry",
+                    },
+                )
+            self._write_phase_usage(milestone_id, result, retry_usage)
+            self._clear_session_usage_offsets(usage_session_ids)
+            with self._session_lock:
+                self._current_session_id = (
+                    tracking_session_id
+                    if field
+                    else (result.tracking_session_id or result.session_id or tracking_session_id)
+                )
+            raise WorkflowPaused("Workflow paused during API error retry")
+
         while (time.monotonic() - retry_start) < API_RETRY_TOTAL_TIMEOUT:
             # Re-check workflow status each iteration: a failure/cancellation
             # set on the row (by a concurrent path or a prior failure in this
             # advance()) must abort retries, otherwise we keep spawning agent
             # subprocesses on a dead workflow for the full 30-min window. #1029
             _status = (self.workflow or {}).get("status")
+            if _status == "paused":
+                abort_paused_retry()
             if _status in ("failed", "cancelled"):
                 logger.info("API error retry aborted (workflow status=%s)", _status)
                 self._synthesize_transient_failure(result)
@@ -3551,13 +3648,16 @@ class AutonomousOrchestrator:
                 },
             )
 
-            # Interruptible sleep: check for cancellation every 5s.
-            # Use in-memory flag instead of DB query to avoid overhead.
+            # Interruptible sleep: check cancellation and manual pause every
+            # five seconds so a long backoff cannot wake up and launch another
+            # agent after the workflow row was paused.
             slept = 0
             self._cancel_requested.clear()
             while slept < delay:
                 time.sleep(min(_CANCEL_POLL_INTERVAL, delay - slept))
                 slept += _CANCEL_POLL_INTERVAL
+                if (self.workflow or {}).get("status") == "paused":
+                    abort_paused_retry()
                 if self._cancel_requested.is_set():
                     logger.info("API error retry cancelled (cancel requested)")
                     self._synthesize_transient_failure(result)
@@ -3621,6 +3721,7 @@ class AutonomousOrchestrator:
         # gate avoids flagging a legitimate plan that merely mentions these
         # phrases. #1001. Centralized in a helper so the retry loop's early-exit
         # paths (status failed/cancelled, cancel-requested) apply it too. #1036.
+        upstream_quota_exhausted = self._is_upstream_quota_exhausted(result)
         self._synthesize_transient_failure(result)
         repo_validation_error = self._validate_repo_context_after_run(
             repo_state_before, project_system_account
@@ -3641,6 +3742,9 @@ class AutonomousOrchestrator:
                 if field
                 else (result.tracking_session_id or result.session_id or tracking_session_id)
             )
+        if upstream_quota_exhausted:
+            self._pause_for_upstream_quota(result, milestone_id)
+            raise UpstreamQuotaPaused(result.error)
         return result
 
     def _synthesize_transient_failure(self, result: AgentTaskResult) -> None:
@@ -3881,6 +3985,13 @@ class AutonomousOrchestrator:
             # blip starts fresh.
             if wf.get("transient_retry_count", 0):
                 self._update_workflow({"transient_retry_count": 0, "error_message": ""})
+        except WorkflowPaused as e:
+            logger.info(
+                "Workflow %s stopped advancing because it is paused: %s",
+                self._workflow_id[:8],
+                e,
+            )
+            return
         except Exception as e:
             err_str = str(e).lower()
             is_transient = isinstance(e, GitHubOpsError) and any(

--- a/app/routes/autonomous.py
+++ b/app/routes/autonomous.py
@@ -1035,13 +1035,18 @@ def resume_workflow(workflow_id):
     phase = workflow.get("current_phase", "preparation")
     status = PHASE_TO_STATUS.get(phase, "pending")
 
-    _get_repo().update_workflow(
-        workflow_id,
-        {
-            "status": status,
-            "paused_at": None,
-        },
-    )
+    # Upstream allocation pauses are deliberately operator-resumable rather
+    # than automatically retried.  Once the operator resumes, remove the stale
+    # provider error so the active workflow is not displayed as still blocked.
+    from app.modules.workspace.autonomous.orchestrator import UPSTREAM_QUOTA_PAUSE_REASON_PREFIX
+
+    error_message = workflow.get("error_message") or ""
+
+    updates = {"status": status, "paused_at": None}
+    if error_message.startswith(UPSTREAM_QUOTA_PAUSE_REASON_PREFIX):
+        updates["error_message"] = ""
+
+    _get_repo().update_workflow(workflow_id, updates)
 
     _emit_event_safe(workflow_id, "status_change", {"status": status})
     return jsonify({"success": True})

--- a/tests/unit/test_upstream_quota_pause.py
+++ b/tests/unit/test_upstream_quota_pause.py
@@ -1,0 +1,185 @@
+"""Regression tests for upstream provider quota exhaustion handling."""
+
+import threading
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.modules.workspace.autonomous.models import AgentTaskResult
+from app.modules.workspace.autonomous.orchestrator import (
+    UPSTREAM_QUOTA_PAUSE_REASON_PREFIX,
+    AutonomousOrchestrator,
+    UpstreamQuotaPaused,
+    WorkflowPaused,
+)
+
+
+def _result(**updates) -> AgentTaskResult:
+    values = {
+        "session_id": "session-1",
+        "success": False,
+        "error": "API Error: 429 · Platform quota exceeded. Please wait.",
+    }
+    values.update(updates)
+    return AgentTaskResult(**values)
+
+
+def _orchestrator_for_run(result: AgentTaskResult) -> AutonomousOrchestrator:
+    orchestrator = AutonomousOrchestrator.__new__(AutonomousOrchestrator)
+    orchestrator._workflow_id = "workflow-1"
+    orchestrator.repo = MagicMock()
+    orchestrator.emitter = MagicMock()
+    orchestrator._runner = MagicMock()
+    orchestrator._runner._uses_sidebar_session_source.return_value = True
+    orchestrator._runner.run_agent_task.return_value = result
+    orchestrator._resolve_session_line = MagicMock(return_value=("session-1", "", False))
+    orchestrator._resolve_effective_repo_context = MagicMock(
+        return_value={"repo_path": "/tmp/worktree"}
+    )
+    orchestrator._resolve_system_account = MagicMock(return_value="openace-agent")
+    orchestrator._snapshot_repo_context = MagicMock(return_value=None)
+    orchestrator._validate_repo_context_after_run = MagicMock(return_value="")
+    orchestrator._select_project_python_runtime = MagicMock(return_value=(None, ""))
+    orchestrator._link_session_to_current_milestone = MagicMock()
+    orchestrator._write_phase_usage = MagicMock()
+    orchestrator._clear_session_usage_offsets = MagicMock()
+    orchestrator._build_repo_execution_contract = MagicMock(return_value="")
+    orchestrator._session_lock = threading.Lock()
+    orchestrator._session_usage_offsets = {}
+    orchestrator._current_session_id = None
+    orchestrator._cancel_requested = threading.Event()
+    return orchestrator
+
+
+def test_provider_allocation_exhaustion_is_not_transient_retry():
+    result = _result()
+
+    assert AutonomousOrchestrator._is_upstream_quota_exhausted(result)
+    assert not AutonomousOrchestrator._should_retry_transient_api_failure(result)
+
+
+def test_zero_token_provider_envelope_is_detected():
+    result = _result(
+        success=True,
+        error=None,
+        total_tokens=0,
+        response_text="usage allocated quota exceeded. please try again later.",
+    )
+
+    assert AutonomousOrchestrator._is_upstream_quota_exhausted(result)
+
+
+def test_token_bearing_design_text_does_not_pause():
+    result = _result(
+        success=True,
+        error=None,
+        total_tokens=120,
+        response_text="Handle 'Platform quota exceeded' by showing a banner.",
+    )
+
+    assert not AutonomousOrchestrator._is_upstream_quota_exhausted(result)
+
+
+def test_pause_persists_workflow_milestone_and_event():
+    orchestrator = AutonomousOrchestrator.__new__(AutonomousOrchestrator)
+    orchestrator._workflow_id = "workflow-1"
+    orchestrator.repo = MagicMock()
+    orchestrator.emitter = MagicMock()
+    result = _result()
+
+    orchestrator._pause_for_upstream_quota(result, "milestone-1")
+
+    milestone_update = orchestrator.repo.update_milestone.call_args.args[1]
+    assert milestone_update["status"] == "failed"
+    assert milestone_update["error_message"].startswith(UPSTREAM_QUOTA_PAUSE_REASON_PREFIX)
+
+    workflow_update = orchestrator.repo.update_workflow.call_args.args[1]
+    assert workflow_update["status"] == "paused"
+    assert workflow_update["agent_pid"] is None
+    assert workflow_update["error_message"].startswith(UPSTREAM_QUOTA_PAUSE_REASON_PREFIX)
+    assert result.error_code == "upstream_quota_exhausted"
+    emitted_types = [call.args[1] for call in orchestrator.emitter.emit.call_args_list]
+    assert emitted_types == ["workflow_updated", "upstream_quota_paused"]
+
+
+def test_run_agent_pauses_immediately_without_retry():
+    orchestrator = _orchestrator_for_run(_result())
+
+    with pytest.raises(UpstreamQuotaPaused):
+        orchestrator._run_agent(
+            wf={"user_id": 1, "content_language": "en"},
+            session_line="main",
+            milestone_id="milestone-1",
+            workspace_type="remote",
+            project_path="/tmp/worktree",
+            prompt="do work",
+        )
+
+    orchestrator._runner.run_agent_task.assert_called_once()
+    updates = [call.args[1] for call in orchestrator.repo.update_workflow.call_args_list]
+    assert any(update.get("status") == "paused" for update in updates)
+
+
+def test_manual_pause_interrupts_backoff_before_second_agent_attempt():
+    result = _result(
+        error="API Error: 503 Service unavailable",
+        response_text="",
+    )
+    orchestrator = _orchestrator_for_run(result)
+    orchestrator.repo.get_workflow.side_effect = [
+        {"status": "developing"},
+        {"status": "paused"},
+    ]
+
+    with patch("app.modules.workspace.autonomous.orchestrator.time.sleep"):
+        with pytest.raises(WorkflowPaused, match="Workflow paused during API error retry"):
+            orchestrator._run_agent(
+                wf={"user_id": 1, "content_language": "en"},
+                session_line="main",
+                milestone_id="milestone-1",
+                workspace_type="remote",
+                project_path="/tmp/worktree",
+                prompt="do work",
+            )
+
+    orchestrator._runner.run_agent_task.assert_called_once()
+    milestone_update = orchestrator.repo.update_milestone.call_args.args[1]
+    assert milestone_update["status"] == "cancelled"
+
+
+def test_advance_treats_quota_pause_as_control_flow():
+    orchestrator = AutonomousOrchestrator.__new__(AutonomousOrchestrator)
+    orchestrator._workflow_id = "workflow-1"
+    orchestrator.repo = MagicMock()
+    orchestrator.repo.get_workflow.return_value = {
+        "workflow_id": "workflow-1",
+        "status": "developing",
+        "current_phase": "development",
+        "worktree_path": "/tmp/worktree",
+    }
+    orchestrator._ensure_worktree = MagicMock()
+    orchestrator._do_development = MagicMock(side_effect=UpstreamQuotaPaused("provider quota"))
+
+    orchestrator.advance()
+
+    assert not any(
+        call.args[1].get("status") == "failed"
+        for call in orchestrator.repo.update_workflow.call_args_list
+    )
+
+
+def test_postgres_alert_dedup_casts_text_metadata_to_jsonb():
+    from app.modules.governance.alert_notifier import AlertNotifier
+
+    notifier = AlertNotifier.__new__(AlertNotifier)
+    connection = MagicMock()
+    cursor = MagicMock()
+    cursor.fetchone.return_value = {"count": 0}
+    connection.cursor.return_value = cursor
+    notifier._get_connection = MagicMock(return_value=connection)
+
+    with patch("app.modules.governance.alert_notifier.is_postgresql", return_value=True):
+        assert not notifier.has_recent_quota_alert(1, "platform")
+
+    query = cursor.execute.call_args.args[0]
+    assert "(metadata::jsonb)->>'quota_type'" in query


### PR DESCRIPTION
## Summary

- classify provider allocation exhaustion separately from transient 429/5xx responses
- pause the autonomous workflow immediately instead of retrying for up to 30 minutes
- make manual pause terminate an in-flight API backoff before it launches another agent
- preserve a clear operator-resumable reason and clear it when the workflow is resumed
- cast `alerts.metadata` from TEXT to JSONB before PostgreSQL `->>` queries

## Production evidence

During clean-batch validation for issues 1892-1897, workflow `6ababdd1-0be8-4908-a669-fa2071d1980a` reached development successfully, then both configured DashScope compatibility keys returned `usage allocated quota exceeded`. The existing retry loop continued spawning agent attempts after the workflow row was manually paused. Alert de-duplication also failed with `operator does not exist: text ->> unknown` because `alerts.metadata` is TEXT in the PostgreSQL schema.

The workflow has been safely stopped and reconciled to `paused` at the development phase; sibling workflows remain paused.

## Behavior

- burst rate limits and 5xx responses retain exponential retry behavior
- explicit provider quota exhaustion ends the current attempt, records the milestone failure, and leaves the workflow paused for operator recovery
- a token-bearing plan that merely discusses `Platform quota exceeded` is not treated as an outage
- manual pause during backoff records the interrupted milestone as cancelled and exits control flow without converting the workflow to failed

## Validation

- 75 targeted and adjacent tests passed
- 144 broad orchestrator tests: 130 passed; 14 pre-existing legacy-mock failures require trusted Git-context fixture updates and are unrelated to this patch
- autonomous quota-gate suite: 10 passed; 2 pre-existing SQLite fixture errors (`no such column: deleted_at`)
- Black 25.1, Ruff, mypy, Bandit, SQL compatibility, API security, and all applicable pre-commit hooks passed
- production PostgreSQL read-only query verified `(metadata::jsonb)->>'quota_type'` works against the live `alerts` table
