### PR TITLE
fix(autonomous): keep Bailian allocation limits retryable

### DIFF
--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -2311,7 +2311,7 @@ class AutonomousOrchestrator:
             return ""
 
         try:
-            merge_base = gh._run_git(["merge-base", "main", branch_name]).stdout.strip()
+            merge_base = gh._run_git(["merge-base", "origin/main", branch_name]).stdout.strip()
             if not merge_base:
                 return ""
             return gh.get_diff(merge_base, branch_name)

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -51,7 +51,7 @@ class WorkflowPaused(RuntimeError):
 
 
 class UpstreamQuotaPaused(WorkflowPaused):
-    """Control-flow signal used after persisting a recoverable quota pause."""
+    """Control-flow signal used after persisting a hard-quota pause."""
 
 
 # Completion keywords to detect in issue comments
@@ -806,13 +806,11 @@ _TRANSIENT_API_ERROR_RE = re.compile(
     re.IGNORECASE,
 )
 
-# The proxy emits this explicit message only after the provider reports a
-# quota-exhaustion response.  Unlike burst rate limiting, retrying it for the
-# full 30-minute transient window cannot make progress and amplifies traffic.
-_UPSTREAM_QUOTA_EXHAUSTED_RE = re.compile(
-    r"platform\s+quota\s+exceeded"
-    r"|upstream\s+(?:provider\s+)?quota\s+(?:exceeded|exhausted)"
-    r"|usage\s+allocated\s+quota\s+exceeded",
+# Hard provider quota failures are distinct from Bailian Coding Plan's
+# ``usage allocated quota exceeded`` wording, which is a temporary allocation
+# rate limit and must remain on the transient retry path.
+_UPSTREAM_HARD_QUOTA_EXHAUSTED_RE = re.compile(
+    r"platform\s+quota\s+exceeded" r"|upstream\s+(?:provider\s+)?quota\s+(?:exceeded|exhausted)",
     re.IGNORECASE,
 )
 
@@ -2292,6 +2290,40 @@ class AutonomousOrchestrator:
         return "\n".join(result_parts)
 
     @staticmethod
+    def _get_pr_review_diff(gh: GitHubOps, pr_number: int | None, branch_name: str) -> str:
+        """Return only the changes introduced by the workflow branch.
+
+        A two-point ``git diff main branch`` includes unrelated changes that
+        landed on ``main`` after a long-running workflow branched. Prefer
+        GitHub's PR diff, whose semantics are based on the PR merge base. If
+        the PR API is temporarily unavailable, reproduce those semantics
+        locally by resolving the merge base explicitly.
+        """
+        if pr_number:
+            try:
+                pr_diff = gh.get_pr_diff(pr_number)
+                if pr_diff:
+                    return pr_diff
+            except Exception as exc:
+                logger.warning("Failed to load PR #%s diff for review: %s", pr_number, exc)
+
+        if not branch_name:
+            return ""
+
+        try:
+            merge_base = gh._run_git(["merge-base", "main", branch_name]).stdout.strip()
+            if not merge_base:
+                return ""
+            return gh.get_diff(merge_base, branch_name)
+        except Exception as exc:
+            logger.warning(
+                "Failed to load merge-base diff for review branch %s: %s",
+                branch_name,
+                exc,
+            )
+            return ""
+
+    @staticmethod
     def _is_pre_existing_ci_failure(response: str) -> bool:
         """Whether the agent identified CI failures as pre-existing.
 
@@ -3292,7 +3324,7 @@ class AutonomousOrchestrator:
         plan/review text caused phrases such as "Rate Limit" to restart an
         otherwise successful phase (#1891).
         """
-        if cls._is_upstream_quota_exhausted(result):
+        if cls._is_upstream_hard_quota_exhausted(result):
             return False
         if cls._is_transient_api_error(result.error or ""):
             return True
@@ -3301,21 +3333,22 @@ class AutonomousOrchestrator:
         )
 
     @staticmethod
-    def _is_upstream_quota_exhausted(result: AgentTaskResult) -> bool:
-        """Return whether a provider allocation is exhausted.
+    def _is_upstream_hard_quota_exhausted(result: AgentTaskResult) -> bool:
+        """Return whether a provider reports a non-transient hard quota.
 
-        Error fields are authoritative.  Assistant text is considered only
-        for a zero-token envelope so a legitimate design discussion about
-        quota handling cannot pause a workflow.
+        Error fields are authoritative. Assistant text is considered only for
+        a zero-token envelope so prose discussing quota handling cannot pause
+        a workflow. Bailian's allocated-quota rate limit is intentionally not
+        part of the hard-quota pattern.
         """
-        if _UPSTREAM_QUOTA_EXHAUSTED_RE.search(result.error or ""):
+        if _UPSTREAM_HARD_QUOTA_EXHAUSTED_RE.search(result.error or ""):
             return True
         return (result.total_tokens or 0) == 0 and bool(
-            _UPSTREAM_QUOTA_EXHAUSTED_RE.search(result.response_text or "")
+            _UPSTREAM_HARD_QUOTA_EXHAUSTED_RE.search(result.response_text or "")
         )
 
     def _pause_for_upstream_quota(self, result: AgentTaskResult, milestone_id: str = "") -> None:
-        """Persist a non-spinning pause that an operator may resume later."""
+        """Persist a non-spinning hard-quota pause that an operator may resume."""
         message = (
             f"{UPSTREAM_QUOTA_PAUSE_REASON_PREFIX} "
             "the configured model provider rejected requests; resume after "
@@ -3721,7 +3754,6 @@ class AutonomousOrchestrator:
         # gate avoids flagging a legitimate plan that merely mentions these
         # phrases. #1001. Centralized in a helper so the retry loop's early-exit
         # paths (status failed/cancelled, cancel-requested) apply it too. #1036.
-        upstream_quota_exhausted = self._is_upstream_quota_exhausted(result)
         self._synthesize_transient_failure(result)
         repo_validation_error = self._validate_repo_context_after_run(
             repo_state_before, project_system_account
@@ -3731,6 +3763,7 @@ class AutonomousOrchestrator:
             result.success = False
             result.error_code = "repo_integrity_violation"
             result.error = repo_validation_error
+        upstream_hard_quota_exhausted = self._is_upstream_hard_quota_exhausted(result)
 
         # Attribute this call's own usage to its milestone (increment, not cumulative).
         self._write_phase_usage(milestone_id, result, retry_usage)
@@ -3742,7 +3775,7 @@ class AutonomousOrchestrator:
                 if field
                 else (result.tracking_session_id or result.session_id or tracking_session_id)
             )
-        if upstream_quota_exhausted:
+        if upstream_hard_quota_exhausted:
             self._pause_for_upstream_quota(result, milestone_id)
             raise UpstreamQuotaPaused(result.error)
         return result
@@ -6317,11 +6350,7 @@ class AutonomousOrchestrator:
         )
 
         # Get diff for review
-        diff_text = ""
-        try:
-            diff_text = gh.get_diff("main", branch_name)
-        except Exception:
-            pass
+        diff_text = self._get_pr_review_diff(gh, pr_number, branch_name)
 
         # Check CI status for the PR — poll until checks finish or timeout
         ci_checks: list = []

--- a/app/modules/workspace/llm_proxy_handler.py
+++ b/app/modules/workspace/llm_proxy_handler.py
@@ -899,6 +899,7 @@ def handle_llm_proxy_request(
         )
 
     exclude_key_ids: set[int] = set()
+    allocated_rate_limited_key_ids: set[int] = set()
     attempt = 0
 
     while True:
@@ -919,6 +920,21 @@ def handle_llm_proxy_request(
             )
 
         if not key_result:
+            if allocated_rate_limited_key_ids:
+                return (
+                    jsonify(
+                        {
+                            "error": {
+                                "message": (
+                                    "All available upstream keys are temporarily allocation "
+                                    "rate limited. Please retry later."
+                                ),
+                                "type": "rate_limit_error",
+                            }
+                        }
+                    ),
+                    429,
+                )
             if exclude_key_ids:
                 return (
                     jsonify(
@@ -1059,6 +1075,19 @@ def handle_llm_proxy_request(
 
                 # 检测上游 quota exceeded 错误并触发告警 (Issue #1060)
                 if resp.status_code == 429 and "quota exceeded" in error_text.lower():
+                    # Bailian Coding Plan uses this wording for a temporary
+                    # allocation rate limit, not for a depleted paid quota.
+                    # Keep it retryable and avoid a false platform-quota alert.
+                    allocated_rate_limited = "usage allocated quota exceeded" in error_text.lower()
+                    if allocated_rate_limited:
+                        logger.warning(
+                            "Upstream allocated rate limit reached for user %d; retry later",
+                            user_id,
+                        )
+                        allocated_rate_limited_key_ids.add(key_id)
+                        exclude_key_ids.add(key_id)
+                        continue
+
                     try:
                         from app.modules.governance.alert_notifier import (
                             create_quota_alert,
@@ -1089,7 +1118,6 @@ def handle_llm_proxy_request(
                     except Exception as alert_exc:
                         logger.error("Failed to create quota exceeded alert: %s", alert_exc)
 
-                    # 返回明确的 quota exceeded 错误
                     return (
                         jsonify(
                             {

--- a/app/routes/autonomous.py
+++ b/app/routes/autonomous.py
@@ -1035,13 +1035,11 @@ def resume_workflow(workflow_id):
     phase = workflow.get("current_phase", "preparation")
     status = PHASE_TO_STATUS.get(phase, "pending")
 
-    # Upstream allocation pauses are deliberately operator-resumable rather
-    # than automatically retried.  Once the operator resumes, remove the stale
-    # provider error so the active workflow is not displayed as still blocked.
+    # Clear only the stale hard-quota error after an operator resumes. Bailian
+    # allocated-quota rate limits never enter the paused state.
     from app.modules.workspace.autonomous.orchestrator import UPSTREAM_QUOTA_PAUSE_REASON_PREFIX
 
     error_message = workflow.get("error_message") or ""
-
     updates = {"status": status, "paused_at": None}
     if error_message.startswith(UPSTREAM_QUOTA_PAUSE_REASON_PREFIX):
         updates["error_message"] = ""

--- a/tests/issues/604/test_llm_proxy_handler_1060.py
+++ b/tests/issues/604/test_llm_proxy_handler_1060.py
@@ -69,6 +69,15 @@ def _mock_upstream_429_quota_exceeded():
     return resp
 
 
+def _mock_bailian_allocated_rate_limit():
+    """Mock Bailian Coding Plan's temporary allocation limit response."""
+    resp = MagicMock()
+    resp.status_code = 429
+    resp.content = b'{"error": {"message": "usage allocated quota exceeded"}}'
+    resp.headers = {"Content-Type": "application/json"}
+    return resp
+
+
 _PROXY_PATH = "app.routes.remote.get_api_key_proxy_service"
 _QUOTA_PATH = "app.modules.governance.quota_manager.QuotaManager"
 _HTTP_PATH = "requests.request"
@@ -81,6 +90,44 @@ _HTTP_PATH = "requests.request"
 
 class TestUpstreamQuotaExceededAlert:
     """Tests for upstream 429 quota exceeded alert handling."""
+
+    @patch("app.modules.governance.alert_notifier.get_alert_notifier")
+    @patch(_HTTP_PATH)
+    @patch(_QUOTA_PATH)
+    @patch(_PROXY_PATH)
+    def test_bailian_allocated_limit_is_retryable_and_does_not_alert(
+        self, mock_get_proxy, mock_quota_cls, mock_http, mock_get_notifier, remote_app
+    ):
+        """Bailian allocated quota wording is rate limiting, not depletion."""
+        mock_proxy = MagicMock()
+        mock_proxy.validate_proxy_token.return_value = _mock_proxy_token()
+        mock_proxy.resolve_api_key_for_scope.side_effect = [
+            (
+                "sk-key",
+                "https://coding.dashscope.aliyuncs.com/apps/anthropic/v1",
+                18,
+                None,
+            ),
+            None,
+        ]
+        mock_get_proxy.return_value = mock_proxy
+        mock_quota_cls.return_value = _make_quota_ok()
+        mock_http.return_value = _mock_bailian_allocated_rate_limit()
+
+        client = remote_app.test_client()
+        resp = client.post(
+            "/api/remote/llm-proxy",
+            json={"model": "glm-5", "messages": [{"role": "user", "content": "hi"}]},
+            headers={"Authorization": "Bearer tok"},
+        )
+
+        assert resp.status_code == 429
+        data = resp.get_json()
+        assert data["error"]["type"] == "rate_limit_error"
+        assert "retry later" in data["error"]["message"].lower()
+        mock_get_notifier.assert_not_called()
+        assert mock_proxy.resolve_api_key_for_scope.call_count == 2
+        assert mock_proxy.resolve_api_key_for_scope.call_args.kwargs["exclude_key_ids"] == {18}
 
     @patch("app.modules.governance.alert_notifier.get_alert_notifier")
     @patch(_HTTP_PATH)

--- a/tests/issues/716/test_orchestrator.py
+++ b/tests/issues/716/test_orchestrator.py
@@ -1420,6 +1420,7 @@ class TestOrchestratorPrReview:
                 "commits": 1,
             }
             orch._gh.get_diff.return_value = "diff content"
+            orch._gh.get_pr_diff.return_value = "diff content"
             orch._gh.git_push.return_value = None
             orch._gh.create_pr.return_value = {"number": 99, "url": "https://github.com/pull/99"}
             orch._gh.get_current_branch.return_value = wf_data.get("branch_name") or "main"
@@ -1450,6 +1451,30 @@ class TestOrchestratorPrReview:
         assert pr_call[1]["head"] == wf["branch_name"]
         assert pr_call[1]["base"] == "main"
         assert "Closes #42" in pr_call[1]["body"]
+
+    def test_pr_review_uses_github_pr_diff_not_two_point_main_diff(self):
+        """Main advancing after branch creation must not pollute review context."""
+        wf = _make_workflow(
+            current_phase="pr_review",
+            status="pr_review",
+            current_round=0,
+            max_pr_review_rounds=1,
+            github_pr_number=99,
+            branch_name="auto-dev/test-wf",
+        )
+        orch, _ = self._make_orchestrator(wf)
+        orch._runner = MagicMock()
+        orch._gh.get_pr_diff.return_value = "diff --git a/feature.py b/feature.py\n+feature"
+        orch._gh.get_diff.return_value = "diff --git a/unrelated.py b/unrelated.py\n-main"
+        orch._runner.run_agent_task.return_value = _make_agent_result(text="Code review passed")
+
+        orch._do_pr_review(wf)
+
+        review_prompt = orch._runner.run_agent_task.call_args_list[0].kwargs["prompt"]
+        assert "feature.py" in review_prompt
+        assert "unrelated.py" not in review_prompt
+        orch._gh.get_pr_diff.assert_called_with(99)
+        orch._gh.get_diff.assert_not_called()
 
     def test_pr_review_max_rounds_moves_to_report(self):
         """When the round count exceeds max, the workflow moves to report.

--- a/tests/unit/test_pr_review_diff_merge_base.py
+++ b/tests/unit/test_pr_review_diff_merge_base.py
@@ -1,0 +1,42 @@
+"""Regression tests for autonomous PR review diff selection."""
+
+from unittest.mock import MagicMock
+
+from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+
+def test_review_diff_prefers_github_pr_diff():
+    gh = MagicMock()
+    gh.get_pr_diff.return_value = "pr-only diff"
+
+    result = AutonomousOrchestrator._get_pr_review_diff(gh, 1950, "auto-dev/example")
+
+    assert result == "pr-only diff"
+    gh.get_pr_diff.assert_called_once_with(1950)
+    gh._run_git.assert_not_called()
+    gh.get_diff.assert_not_called()
+
+
+def test_review_diff_fallback_starts_at_merge_base():
+    gh = MagicMock()
+    gh.get_pr_diff.return_value = ""
+    gh._run_git.return_value.stdout = "abc123\n"
+    gh.get_diff.return_value = "merge-base diff"
+
+    result = AutonomousOrchestrator._get_pr_review_diff(gh, 1950, "auto-dev/example")
+
+    assert result == "merge-base diff"
+    gh._run_git.assert_called_once_with(["merge-base", "main", "auto-dev/example"])
+    gh.get_diff.assert_called_once_with("abc123", "auto-dev/example")
+
+
+def test_review_diff_without_pr_still_uses_merge_base():
+    gh = MagicMock()
+    gh._run_git.return_value.stdout = "base456\n"
+    gh.get_diff.return_value = "local merge-base diff"
+
+    result = AutonomousOrchestrator._get_pr_review_diff(gh, None, "auto-dev/example")
+
+    assert result == "local merge-base diff"
+    gh.get_pr_diff.assert_not_called()
+    gh.get_diff.assert_called_once_with("base456", "auto-dev/example")

--- a/tests/unit/test_pr_review_diff_merge_base.py
+++ b/tests/unit/test_pr_review_diff_merge_base.py
@@ -1,7 +1,9 @@
 """Regression tests for autonomous PR review diff selection."""
 
+import subprocess
 from unittest.mock import MagicMock
 
+from app.modules.workspace.autonomous.github_ops import GitHubOps
 from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
 
 
@@ -26,7 +28,7 @@ def test_review_diff_fallback_starts_at_merge_base():
     result = AutonomousOrchestrator._get_pr_review_diff(gh, 1950, "auto-dev/example")
 
     assert result == "merge-base diff"
-    gh._run_git.assert_called_once_with(["merge-base", "main", "auto-dev/example"])
+    gh._run_git.assert_called_once_with(["merge-base", "origin/main", "auto-dev/example"])
     gh.get_diff.assert_called_once_with("abc123", "auto-dev/example")
 
 
@@ -40,3 +42,42 @@ def test_review_diff_without_pr_still_uses_merge_base():
     assert result == "local merge-base diff"
     gh.get_pr_diff.assert_not_called()
     gh.get_diff.assert_called_once_with("base456", "auto-dev/example")
+
+
+def test_review_diff_fallback_ignores_stale_local_main(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    def git(*args: str) -> str:
+        return subprocess.run(
+            ["git", "-C", str(repo), *args],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+
+    git("init", "-b", "main")
+    git("config", "user.name", "Test User")
+    git("config", "user.email", "test@example.com")
+    (repo / "base.txt").write_text("base\n", encoding="utf-8")
+    git("add", "base.txt")
+    git("commit", "-m", "base")
+    stale_main = git("rev-parse", "HEAD")
+
+    (repo / "main-before-branch.txt").write_text("already in PR base\n", encoding="utf-8")
+    git("add", "main-before-branch.txt")
+    git("commit", "-m", "advance main before branch")
+    branch_base = git("rev-parse", "HEAD")
+    git("update-ref", "refs/remotes/origin/main", branch_base)
+
+    git("switch", "-c", "auto-dev/example")
+    (repo / "feature.txt").write_text("feature\n", encoding="utf-8")
+    git("add", "feature.txt")
+    git("commit", "-m", "feature")
+    git("branch", "-f", "main", stale_main)
+
+    gh = GitHubOps(str(repo))
+    result = AutonomousOrchestrator._get_pr_review_diff(gh, None, "auto-dev/example")
+
+    assert "feature.txt" in result
+    assert "main-before-branch.txt" not in result

--- a/tests/unit/test_upstream_quota_pause.py
+++ b/tests/unit/test_upstream_quota_pause.py
@@ -1,4 +1,4 @@
-"""Regression tests for upstream provider quota exhaustion handling."""
+"""Regression tests for transient provider limits and manual pause handling."""
 
 import threading
 from unittest.mock import MagicMock, patch
@@ -7,7 +7,6 @@ import pytest
 
 from app.modules.workspace.autonomous.models import AgentTaskResult
 from app.modules.workspace.autonomous.orchestrator import (
-    UPSTREAM_QUOTA_PAUSE_REASON_PREFIX,
     AutonomousOrchestrator,
     UpstreamQuotaPaused,
     WorkflowPaused,
@@ -18,7 +17,7 @@ def _result(**updates) -> AgentTaskResult:
     values = {
         "session_id": "session-1",
         "success": False,
-        "error": "API Error: 429 · Platform quota exceeded. Please wait.",
+        "error": "API Error: 429 · usage allocated quota exceeded. Please try again later.",
     }
     values.update(updates)
     return AgentTaskResult(**values)
@@ -28,6 +27,7 @@ def _orchestrator_for_run(result: AgentTaskResult) -> AutonomousOrchestrator:
     orchestrator = AutonomousOrchestrator.__new__(AutonomousOrchestrator)
     orchestrator._workflow_id = "workflow-1"
     orchestrator.repo = MagicMock()
+    orchestrator.repo.get_workflow.return_value = {"status": "developing"}
     orchestrator.emitter = MagicMock()
     orchestrator._runner = MagicMock()
     orchestrator._runner._uses_sidebar_session_source.return_value = True
@@ -51,14 +51,18 @@ def _orchestrator_for_run(result: AgentTaskResult) -> AutonomousOrchestrator:
     return orchestrator
 
 
-def test_provider_allocation_exhaustion_is_not_transient_retry():
-    result = _result()
+def test_provider_allocated_quota_limit_is_transient():
+    assert AutonomousOrchestrator._should_retry_transient_api_failure(_result())
 
-    assert AutonomousOrchestrator._is_upstream_quota_exhausted(result)
+
+def test_hard_platform_quota_is_not_transient():
+    result = _result(error="API Error: 429 · Platform quota exceeded. Please wait.")
+
+    assert AutonomousOrchestrator._is_upstream_hard_quota_exhausted(result)
     assert not AutonomousOrchestrator._should_retry_transient_api_failure(result)
 
 
-def test_zero_token_provider_envelope_is_detected():
+def test_zero_token_allocated_limit_envelope_is_transient():
     result = _result(
         success=True,
         error=None,
@@ -66,44 +70,53 @@ def test_zero_token_provider_envelope_is_detected():
         response_text="usage allocated quota exceeded. please try again later.",
     )
 
-    assert AutonomousOrchestrator._is_upstream_quota_exhausted(result)
+    assert AutonomousOrchestrator._should_retry_transient_api_failure(result)
 
 
-def test_token_bearing_design_text_does_not_pause():
+def test_token_bearing_design_text_does_not_retry():
     result = _result(
         success=True,
         error=None,
         total_tokens=120,
-        response_text="Handle 'Platform quota exceeded' by showing a banner.",
+        response_text="Handle 'usage allocated quota exceeded' with exponential backoff.",
     )
 
-    assert not AutonomousOrchestrator._is_upstream_quota_exhausted(result)
+    assert not AutonomousOrchestrator._should_retry_transient_api_failure(result)
 
 
-def test_pause_persists_workflow_milestone_and_event():
-    orchestrator = AutonomousOrchestrator.__new__(AutonomousOrchestrator)
-    orchestrator._workflow_id = "workflow-1"
-    orchestrator.repo = MagicMock()
-    orchestrator.emitter = MagicMock()
-    result = _result()
+def test_run_agent_retries_allocated_limit_instead_of_pausing():
+    limited = _result()
+    recovered = _result(
+        success=True,
+        error=None,
+        response_text="completed",
+        total_tokens=20,
+        request_count=1,
+    )
+    orchestrator = _orchestrator_for_run(limited)
+    orchestrator._runner.run_agent_task.side_effect = [limited, recovered]
 
-    orchestrator._pause_for_upstream_quota(result, "milestone-1")
+    with patch("app.modules.workspace.autonomous.orchestrator.time.sleep"):
+        result = orchestrator._run_agent(
+            wf={"user_id": 1, "content_language": "en"},
+            session_line="main",
+            milestone_id="milestone-1",
+            workspace_type="remote",
+            project_path="/tmp/worktree",
+            prompt="do work",
+        )
 
-    milestone_update = orchestrator.repo.update_milestone.call_args.args[1]
-    assert milestone_update["status"] == "failed"
-    assert milestone_update["error_message"].startswith(UPSTREAM_QUOTA_PAUSE_REASON_PREFIX)
-
-    workflow_update = orchestrator.repo.update_workflow.call_args.args[1]
-    assert workflow_update["status"] == "paused"
-    assert workflow_update["agent_pid"] is None
-    assert workflow_update["error_message"].startswith(UPSTREAM_QUOTA_PAUSE_REASON_PREFIX)
-    assert result.error_code == "upstream_quota_exhausted"
-    emitted_types = [call.args[1] for call in orchestrator.emitter.emit.call_args_list]
-    assert emitted_types == ["workflow_updated", "upstream_quota_paused"]
+    assert result is recovered
+    assert orchestrator._runner.run_agent_task.call_count == 2
+    assert not any(
+        call.args[1].get("status") == "paused"
+        for call in orchestrator.repo.update_workflow.call_args_list
+    )
 
 
-def test_run_agent_pauses_immediately_without_retry():
-    orchestrator = _orchestrator_for_run(_result())
+def test_run_agent_pauses_only_for_hard_platform_quota():
+    hard_quota = _result(error="API Error: 429 · Platform quota exceeded. Please wait.")
+    orchestrator = _orchestrator_for_run(hard_quota)
 
     with pytest.raises(UpstreamQuotaPaused):
         orchestrator._run_agent(
@@ -116,15 +129,14 @@ def test_run_agent_pauses_immediately_without_retry():
         )
 
     orchestrator._runner.run_agent_task.assert_called_once()
-    updates = [call.args[1] for call in orchestrator.repo.update_workflow.call_args_list]
-    assert any(update.get("status") == "paused" for update in updates)
+    assert any(
+        call.args[1].get("status") == "paused"
+        for call in orchestrator.repo.update_workflow.call_args_list
+    )
 
 
 def test_manual_pause_interrupts_backoff_before_second_agent_attempt():
-    result = _result(
-        error="API Error: 503 Service unavailable",
-        response_text="",
-    )
+    result = _result(error="API Error: 503 Service unavailable", response_text="")
     orchestrator = _orchestrator_for_run(result)
     orchestrator.repo.get_workflow.side_effect = [
         {"status": "developing"},
@@ -147,7 +159,7 @@ def test_manual_pause_interrupts_backoff_before_second_agent_attempt():
     assert milestone_update["status"] == "cancelled"
 
 
-def test_advance_treats_quota_pause_as_control_flow():
+def test_advance_treats_manual_pause_as_control_flow():
     orchestrator = AutonomousOrchestrator.__new__(AutonomousOrchestrator)
     orchestrator._workflow_id = "workflow-1"
     orchestrator.repo = MagicMock()
@@ -158,7 +170,7 @@ def test_advance_treats_quota_pause_as_control_flow():
         "worktree_path": "/tmp/worktree",
     }
     orchestrator._ensure_worktree = MagicMock()
-    orchestrator._do_development = MagicMock(side_effect=UpstreamQuotaPaused("provider quota"))
+    orchestrator._do_development = MagicMock(side_effect=WorkflowPaused("manual pause"))
 
     orchestrator.advance()
 


### PR DESCRIPTION
## Summary

- classify Bailian Coding Plan `usage allocated quota exceeded` as a temporary rate limit, fail over across eligible keys, and keep the autonomous workflow on interruptible exponential backoff
- retain operator-resumable pause only for genuine hard provider quota exhaustion
- build autonomous PR-review context from the GitHub PR diff (merge-base semantics), with a local merge-base fallback, so main-branch changes do not pollute review
- keep manual pause able to interrupt an API retry before another agent process starts

## Root causes observed on issue-1892 / PR #1950

1. Bailian allocation rate limiting was incorrectly treated as permanent quota depletion by #1951, which paused the workflow.
2. PR review used `git diff main branch` after main advanced, so unrelated main changes were presented as reverse changes in the review prompt.

## Verification

- 124 targeted autonomous/proxy/review tests passed
- changed-files pre-commit passed: Black, isort, Ruff, mypy, Bandit, SQL compatibility, API security, pydocstyle, and repository checks
- `git diff --check` passed

## Notes

`tests/issues/716/test_autonomous_api.py::TestResumeWorkflow` remains blocked by the pre-existing SQLite schema fixture error `no such column: deleted_at`; this PR does not touch that schema.

Follow-up to #1951.