### PR TITLE
fix(autonomous): stabilize timeline activity and workflow controls

### DIFF
--- a/app/modules/workspace/autonomous/github_ops.py
+++ b/app/modules/workspace/autonomous/github_ops.py
@@ -1450,6 +1450,11 @@ class GitHubOps:
                     f"force_with_lease refused on non-auto-dev branch '{target}' "
                     "(only auto-dev/* workflow branches may be force-pushed)"
                 )
+            # Never leave a validated force-push target implicit. An auto-dev
+            # worktree can inherit ``main`` as its upstream, and
+            # ``push.default=simple`` then rejects a plain ``git push`` even
+            # though the current local branch is safe and was validated above.
+            branch = target
         args = ["push", remote]
         if branch:
             args.append(branch)

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -3673,12 +3673,21 @@ class AutonomousOrchestrator:
             self._current_session_id = tracking_session_id
             self._session_usage_offsets[tracking_session_id] = dict(retry_usage)
 
-        should_prelink_tracking_session = not self._runner._uses_sidebar_session_source(
-            kwargs.get("cli_tool", ""),
-            kwargs.get("workspace_type", "local"),
-        )
-        if should_prelink_tracking_session:
-            self._link_session_to_current_milestone(tracking_session_id)
+        # The tracking id is the stable UI identity for every session line and
+        # is known before the blocking runner call starts. Link the exact
+        # milestone now, including Claude/sidebar runs, so live activity can be
+        # attributed from the first event instead of only after process exit.
+        if milestone_id and tracking_session_id:
+            milestone_session_field = (
+                "review_session_id" if session_line == "review" else "session_id"
+            )
+            try:
+                self.repo.update_milestone(
+                    milestone_id,
+                    {milestone_session_field: tracking_session_id},
+                )
+            except Exception:
+                logger.warning("Failed to pre-link session to milestone", exc_info=True)
 
         # Inject per-workflow timeout if specified
         if "timeout" not in kwargs:

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -6905,7 +6905,7 @@ class AutonomousOrchestrator:
                 logger.error("Review fix scope rejected before push: %s", push_error_msg)
             try:
                 if not push_failed:
-                    gh.git_push(force_with_lease=True)
+                    gh.git_push(branch=wf.get("branch_name"), force_with_lease=True)
             except Exception as e:
                 # Distinguish transient vs non-transient to enable Layer-2 retry
                 # (Issue #1814).

--- a/frontend/src/api/autonomous.ts
+++ b/frontend/src/api/autonomous.ts
@@ -88,6 +88,10 @@ export interface AutonomousWorkflow {
   updated_at: string | null;
   completed_at: string | null;
   paused_at: string | null;
+  /** Stable session lines used by autonomous main/review/test agents. */
+  main_session_id?: string;
+  review_session_id?: string;
+  test_session_id?: string;
 }
 
 export interface WorkflowMilestone {

--- a/frontend/src/components/work/WorkflowTimeline.css
+++ b/frontend/src/components/work/WorkflowTimeline.css
@@ -923,6 +923,48 @@
   word-break: break-word;
 }
 
+.timeline-milestone-activity-empty {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-height: 52px;
+  padding: 8px 10px;
+  border-radius: 10px;
+  color: var(--text-secondary);
+  background: color-mix(in srgb, var(--color-primary) 4%, var(--bg-primary) 96%);
+}
+
+.timeline-milestone-activity-empty-icon {
+  display: inline-flex;
+  flex: 0 0 32px;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  color: var(--color-primary);
+  background: color-mix(in srgb, var(--color-primary) 12%, var(--bg-primary) 88%);
+}
+
+.timeline-milestone-activity-empty-copy {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 2px;
+  font-size: 0.76rem;
+  line-height: 1.45;
+}
+
+.timeline-milestone-activity-empty-copy strong {
+  color: var(--text-primary);
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.timeline-milestone-activity-empty-copy > span {
+  color: var(--text-muted);
+}
+
 .timeline-content-modal {
   max-width: min(1040px, calc(100vw - 2rem));
 }

--- a/frontend/src/components/work/WorkflowTimeline.css
+++ b/frontend/src/components/work/WorkflowTimeline.css
@@ -22,7 +22,7 @@
 
 .timeline-header-top {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
   gap: 12px;
   grid-column: 1 / -1;
@@ -30,18 +30,19 @@
 
 .timeline-header-main {
   display: flex;
-  align-items: center;
-  gap: 12px;
-  min-width: 0;
   flex: 1;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 8px;
+  min-width: 0;
 }
 
 .timeline-header-title-row {
   display: flex;
   align-items: center;
   gap: 10px;
+  width: 100%;
   min-width: 0;
-  flex: 0 1 30rem;
 }
 
 .timeline-header-fork-icon {
@@ -65,8 +66,8 @@
   flex-wrap: wrap;
   gap: 6px;
   margin-top: 0;
+  width: 100%;
   min-width: 0;
-  flex: 1;
 }
 
 .timeline-header-actions {
@@ -225,17 +226,22 @@
 
 .timeline-header-meta-grid {
   display: grid;
-  grid-template-columns: repeat(5, minmax(0, 1fr));
+  grid-template-columns:
+    minmax(110px, 0.75fr) minmax(205px, 1.4fr)
+    repeat(3, minmax(105px, 0.8fr));
   gap: 6px;
   min-width: 0;
 }
 
 .timeline-meta-item {
   display: flex;
-  align-items: baseline;
-  gap: 6px;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center;
+  gap: 2px;
   min-width: 0;
-  padding: 6px 8px;
+  min-height: 48px;
+  padding: 7px 10px;
   border: 1px solid var(--border-color);
   border-radius: var(--border-radius);
   background: color-mix(in srgb, var(--bg-primary) 88%, var(--bg-secondary) 12%);
@@ -248,6 +254,7 @@
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.06em;
+  white-space: nowrap;
 }
 
 .timeline-meta-item__value {
@@ -364,6 +371,7 @@
 .timeline-output-rail__buttons {
   display: flex;
   flex-wrap: wrap;
+  justify-content: flex-end;
   gap: 6px;
 }
 
@@ -1107,7 +1115,7 @@
   }
 }
 
-@media (max-width: 1200px) {
+@media (max-width: 1440px) {
   .timeline-header {
     grid-template-columns: minmax(0, 1fr);
   }
@@ -1115,6 +1123,10 @@
   .timeline-header-meta-grid,
   .timeline-output-rail {
     grid-column: 1;
+  }
+
+  .timeline-output-rail__buttons {
+    justify-content: flex-start;
   }
 }
 

--- a/frontend/src/components/work/WorkflowTimeline.tsx
+++ b/frontend/src/components/work/WorkflowTimeline.tsx
@@ -52,6 +52,7 @@ import {
   formatTokens,
   getActivityHostMilestoneId,
   isAiMilestoneType,
+  isDisplayableTimelineActivity,
   parseDiffFiles,
   parseDiffStats,
   type ParsedDiffFileStatus,
@@ -1413,7 +1414,10 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
     );
     const isActivityHost = activityHostMilestoneId === milestone.milestone_id;
     const milestoneActivities = isActivityHost
-      ? activities.filter((activity) => milestoneSessionIds.has(activity.session_id))
+      ? activities.filter(
+          (activity) =>
+            milestoneSessionIds.has(activity.session_id) && isDisplayableTimelineActivity(activity)
+        )
       : [];
     const visibleMilestoneActivities = [...milestoneActivities]
       .sort((a, b) => {
@@ -1785,11 +1789,16 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
                           );
                         })
                       ) : (
-                        <div className="timeline-milestone-activity-item">
-                          <span className="timeline-milestone-activity-time">--:--:--</span>
-                          <i className="bi bi-hourglass"></i>
-                          <span className="timeline-milestone-activity-text">
-                            {t('autoActivityWaiting', language)}
+                        <div className="timeline-milestone-activity-empty" role="status">
+                          <span
+                            className="timeline-milestone-activity-empty-icon"
+                            aria-hidden="true"
+                          >
+                            <i className="bi bi-hourglass-split"></i>
+                          </span>
+                          <span className="timeline-milestone-activity-empty-copy">
+                            <strong>{t('autoActivityWaiting', language)}</strong>
+                            <span>{t('autoActivityWaitingHint', language)}</span>
                           </span>
                         </div>
                       )}

--- a/frontend/src/components/work/WorkflowTimeline.tsx
+++ b/frontend/src/components/work/WorkflowTimeline.tsx
@@ -51,6 +51,7 @@ import {
   findForkMilestoneIndex,
   formatTokens,
   getActivityHostMilestoneId,
+  getWorkflowSessionIdForMilestone,
   isAiMilestoneType,
   isDisplayableTimelineActivity,
   parseDiffFiles,
@@ -1394,11 +1395,20 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
     };
     const diffStats = parseDiffStats(milestone.diff_stats);
     const milestoneTime = formatMilestoneTime(getMilestoneAnchorTime(milestone));
+    const isActivityHost = activityHostMilestoneId === milestone.milestone_id;
+    const persistedLlmSessionId = [
+      milestone.actual_llm_session_id,
+      milestone.llm_session_id,
+      milestone.review_session_id,
+      milestone.session_id,
+    ].find((sessionId) => sessionId?.trim());
+    // A resumed Claude session can emit activity before the orchestrator has
+    // persisted its id on the new milestone. Use the workflow's stable
+    // three-line topology during that brief window so the panel is live from
+    // the first event instead of appearing stuck on "Waiting".
     const llmSessionId =
-      milestone.actual_llm_session_id ??
-      milestone.llm_session_id ??
-      milestone.review_session_id ??
-      milestone.session_id;
+      persistedLlmSessionId ??
+      (isActivityHost ? getWorkflowSessionIdForMilestone(milestone.milestone_type, workflow) : '');
     const llmTotalTokens = milestone.llm_total_tokens ?? 0;
     const llmRequestCount = milestone.llm_request_count ?? 0;
     const isAiMilestone = isAiMilestoneType(milestone.milestone_type);
@@ -1412,7 +1422,6 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
     const milestoneSessionIds = new Set(
       [llmSessionId, milestone.session_id, milestone.review_session_id].filter(Boolean)
     );
-    const isActivityHost = activityHostMilestoneId === milestone.milestone_id;
     const milestoneActivities = isActivityHost
       ? activities.filter(
           (activity) =>

--- a/frontend/src/components/work/WorkflowTimeline.utils.test.ts
+++ b/frontend/src/components/work/WorkflowTimeline.utils.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   findForkMilestoneIndex,
   getActivityHostMilestoneId,
+  getWorkflowSessionIdForMilestone,
   isAiMilestoneType,
   isDisplayableTimelineActivity,
   parseDiffFiles,
@@ -20,6 +21,20 @@ describe('WorkflowTimeline.utils', () => {
     expect(isDisplayableTimelineActivity({ type: 'tool_use' })).toBe(true);
     expect(isDisplayableTimelineActivity({ type: 'system' })).toBe(true);
     expect(isDisplayableTimelineActivity({ type: 'usage' })).toBe(true);
+  });
+
+  it('maps in-flight milestones to the strict main/review/test session lines', () => {
+    const workflow = {
+      main_session_id: 'main-session',
+      review_session_id: 'review-session',
+      test_session_id: 'test-session',
+    };
+
+    expect(getWorkflowSessionIdForMilestone('pr_updated', workflow)).toBe('main-session');
+    expect(getWorkflowSessionIdForMilestone('plan_finalized', workflow)).toBe('main-session');
+    expect(getWorkflowSessionIdForMilestone('pr_reviewed', workflow)).toBe('review-session');
+    expect(getWorkflowSessionIdForMilestone('plan_reviewed', workflow)).toBe('review-session');
+    expect(getWorkflowSessionIdForMilestone('tests_run', workflow)).toBe('test-session');
   });
 
   it('classifies AI-backed and system-only milestone cards', () => {

--- a/frontend/src/components/work/WorkflowTimeline.utils.test.ts
+++ b/frontend/src/components/work/WorkflowTimeline.utils.test.ts
@@ -4,11 +4,24 @@ import {
   findForkMilestoneIndex,
   getActivityHostMilestoneId,
   isAiMilestoneType,
+  isDisplayableTimelineActivity,
   parseDiffFiles,
   parseDiffStats,
 } from './WorkflowTimeline.utils';
 
 describe('WorkflowTimeline.utils', () => {
+  it('filters empty assistant placeholders without hiding real activity events', () => {
+    expect(isDisplayableTimelineActivity({ type: 'assistant' })).toBe(false);
+    expect(isDisplayableTimelineActivity({ type: 'assistant', text: '   ' })).toBe(false);
+    expect(isDisplayableTimelineActivity({ type: 'assistant', text: '-' })).toBe(false);
+    expect(isDisplayableTimelineActivity({ type: 'assistant', text: 'Reviewing files' })).toBe(
+      true
+    );
+    expect(isDisplayableTimelineActivity({ type: 'tool_use' })).toBe(true);
+    expect(isDisplayableTimelineActivity({ type: 'system' })).toBe(true);
+    expect(isDisplayableTimelineActivity({ type: 'usage' })).toBe(true);
+  });
+
   it('classifies AI-backed and system-only milestone cards', () => {
     for (const type of [
       'plan_created',

--- a/frontend/src/components/work/WorkflowTimeline.utils.ts
+++ b/frontend/src/components/work/WorkflowTimeline.utils.ts
@@ -59,6 +59,24 @@ export function isDisplayableTimelineActivity(activity: TimelineActivityLike): b
   return text !== '' && text !== '-';
 }
 
+export interface WorkflowSessionLinesLike {
+  main_session_id?: string;
+  review_session_id?: string;
+  test_session_id?: string;
+}
+
+/** Return the stable session line that owns an in-flight AI milestone. */
+export function getWorkflowSessionIdForMilestone(
+  milestoneType: string,
+  workflow: WorkflowSessionLinesLike
+): string {
+  if (milestoneType === 'tests_run') return workflow.test_session_id?.trim() ?? '';
+  if (milestoneType === 'plan_reviewed' || milestoneType === 'pr_reviewed') {
+    return workflow.review_session_id?.trim() ?? '';
+  }
+  return workflow.main_session_id?.trim() ?? '';
+}
+
 export function getActivityHostMilestoneId(
   milestones: ActivityHostMilestoneLike[],
   workflowDevRound: number,

--- a/frontend/src/components/work/WorkflowTimeline.utils.ts
+++ b/frontend/src/components/work/WorkflowTimeline.utils.ts
@@ -43,6 +43,22 @@ export interface ActivityHostMilestoneLike {
   dev_round: number;
 }
 
+export interface TimelineActivityLike {
+  type: 'assistant' | 'tool_use' | 'usage' | 'system';
+  text?: string;
+}
+
+/**
+ * Ignore empty assistant placeholders. They carry no user-facing progress and
+ * otherwise render as a blank row (or a lone dash) in the activity panel.
+ * Tool, usage and system events remain useful even when they have no text.
+ */
+export function isDisplayableTimelineActivity(activity: TimelineActivityLike): boolean {
+  if (activity.type !== 'assistant') return true;
+  const text = activity.text?.trim() ?? '';
+  return text !== '' && text !== '-';
+}
+
 export function getActivityHostMilestoneId(
   milestones: ActivityHostMilestoneLike[],
   workflowDevRound: number,

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -1561,6 +1561,8 @@ export const translations: Record<Language, Translations> = {
     autoSystemStep: 'System step',
     // Issue #1531: Activity summary & heartbeat
     autoActivityWaiting: 'Waiting…',
+    autoActivityWaitingHint:
+      'Preparing context or waiting for a response. New activity appears here automatically.',
     autoActivityExecuting: 'Executing {tool}…',
     autoActivityGenerating: 'Generating response…',
     autoActivityThinking: 'Thinking…',
@@ -3244,6 +3246,7 @@ export const translations: Record<Language, Translations> = {
     autoSystemStep: '系统步骤',
     // Issue #1531: Activity summary & heartbeat
     autoActivityWaiting: '等待中…',
+    autoActivityWaitingHint: '可能正在准备上下文或等待响应，收到新活动后会自动显示。',
     autoActivityExecuting: '正在执行 {tool}…',
     autoActivityGenerating: '正在生成回复…',
     autoActivityThinking: '正在思考…',
@@ -4710,6 +4713,8 @@ export const translations: Record<Language, Translations> = {
     autoSystemStep: 'システムステップ',
     // Issue #1531: Activity summary & heartbeat
     autoActivityWaiting: '待機中…',
+    autoActivityWaitingHint:
+      'コンテキストの準備中または応答待ちです。新しいアクティビティは自動的に表示されます。',
     autoActivityExecuting: '{tool}を実行中…',
     autoActivityGenerating: '応答生成中…',
     autoActivityThinking: '思考中…',
@@ -6262,6 +6267,8 @@ export const translations: Record<Language, Translations> = {
     autoSystemStep: '시스템 단계',
     // Issue #1531: Activity summary & heartbeat
     autoActivityWaiting: '대기 중…',
+    autoActivityWaitingHint:
+      '컨텍스트를 준비하거나 응답을 기다리는 중입니다. 새 활동은 자동으로 표시됩니다.',
     autoActivityExecuting: '{tool} 실행 중…',
     autoActivityGenerating: '응답 생성 중…',
     autoActivityThinking: '생각 중…',

--- a/tests/issues/1854/test_force_with_lease_push.py
+++ b/tests/issues/1854/test_force_with_lease_push.py
@@ -66,9 +66,11 @@ class TestGitPushForceWithLease:
         mock_run.return_value = MagicMock(returncode=0, stdout="")
         self.gh.git_push(force_with_lease=True)
         mock_branch.assert_called_once()
-        # The push cmd must carry --force-with-lease.
+        # The validated current branch must be explicit. Otherwise an
+        # inherited upstream (often main) makes push.default=simple reject it.
         push_cmd = mock_run.call_args[0][0]
         assert "--force-with-lease" in push_cmd
+        assert "auto-dev/def67890" in push_cmd
 
     @patch("app.modules.workspace.autonomous.github_ops.subprocess.run")
     @patch.object(GitHubOps, "get_current_branch", return_value="main")

--- a/tests/issues/723/test_milestone_session_link.py
+++ b/tests/issues/723/test_milestone_session_link.py
@@ -59,15 +59,63 @@ def _make_orchestrator(wf_data, milestones=None):
         orch.repo = mock_repo
         orch.emitter = MagicMock()
         orch._gh = MagicMock()
+        # These tests exercise session wiring, not the privileged git-context
+        # guard. Keep repository validation deterministic and in scope.
+        orch._snapshot_repo_context = MagicMock(
+            return_value={"effective": {"repo_path": "/tmp/p"}, "main": {}}
+        )
+        orch._validate_repo_context_after_run = MagicMock(return_value="")
         return orch, mock_repo
 
 
 class TestMilestoneTracksWorkflowSession:
+    def test_sidebar_session_is_linked_before_blocking_runner_starts(self):
+        """Live activity has a milestone owner throughout a Claude call."""
+        from app.modules.workspace.autonomous.models import AgentTaskResult
+
+        wf = _make_workflow(main_session_id="main-wrapper")
+        orch, mock_repo = _make_orchestrator(wf)
+        orch._runner = MagicMock()
+        orch._runner._uses_sidebar_session_source.return_value = True
+
+        def run_agent_task(**_kwargs):
+            mock_repo.update_milestone.assert_any_call("ms-active", {"session_id": "main-wrapper"})
+            return AgentTaskResult(
+                session_id="main-wrapper",
+                tracking_session_id="main-wrapper",
+                source_session_id="real-cli-session",
+                response_text="done",
+                visible_response_text="done",
+                success=True,
+            )
+
+        orch._runner.run_agent_task.side_effect = run_agent_task
+        mock_repo.list_milestones.return_value = [
+            {
+                "milestone_id": "ms-active",
+                "milestone_type": "pr_updated",
+                "status": "in_progress",
+            }
+        ]
+
+        orch._run_agent(
+            wf=wf,
+            workflow_id=wf["workflow_id"],
+            cli_tool="claude-code",
+            model="m",
+            project_path="/tmp/p",
+            prompt="do it",
+            workspace_type="local",
+            session_line="main",
+            milestone_id="ms-active",
+        )
+        orch._runner.run_agent_task.assert_called_once()
+
     def test_sidebar_sessions_link_milestone_to_tracking_id(self):
         """Claude workflow milestones keep the stable tracking session id."""
         from app.modules.workspace.autonomous.models import AgentTaskResult
 
-        wf = _make_workflow()
+        wf = _make_workflow(main_session_id="wrapper-uuid-1")
         orch, mock_repo = _make_orchestrator(wf)
         orch._runner = MagicMock()
         orch._runner._uses_sidebar_session_source.return_value = True
@@ -117,7 +165,7 @@ class TestMilestoneTracksWorkflowSession:
         """If provider resolution is missing, milestone still keeps tracking id."""
         from app.modules.workspace.autonomous.models import AgentTaskResult
 
-        wf = _make_workflow()
+        wf = _make_workflow(main_session_id="wrapper-uuid-2")
         orch, mock_repo = _make_orchestrator(wf)
         orch._runner = MagicMock()
         orch._runner._uses_sidebar_session_source.return_value = True

--- a/tests/issues/996/test_agent_permissions.py
+++ b/tests/issues/996/test_agent_permissions.py
@@ -7,7 +7,7 @@ Verifies:
     didn't commit, so review fixes actually reach the PR.
 """
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 from app.modules.workspace.autonomous.models import AgentTaskResult
 from app.modules.workspace.autonomous.orchestrator import (
@@ -93,6 +93,7 @@ def _make_orchestrator(wf):
     orch._poll_ci_status = MagicMock(return_value=[])
     orch._smart_truncate_diff = MagicMock(return_value="DIFF_TEXT")
     orch._clean_agent_text = MagicMock(side_effect=lambda x: x or "")
+    orch._validate_autonomous_change_scope = MagicMock(return_value="")
     orch._create_milestone = MagicMock(return_value={"milestone_id": "ms-x"})
     orch._update_workflow = MagicMock()
     orch._accumulate_tokens = MagicMock()
@@ -183,7 +184,8 @@ class TestFixPhasePermissionsAndFallback:
         gh.git_add_all.assert_called_once()
         gh.git_commit.assert_called_once()
         assert gh.git_commit.call_args.kwargs.get("no_verify") is True
-        gh.git_push.assert_called()  # pushed after salvage
+        expected_push = call(branch=wf["branch_name"], force_with_lease=True)
+        gh.git_push.assert_has_calls([expected_push, expected_push])
 
     def test_fix_no_salvage_when_no_uncommitted_changes(self):
         wf = _make_workflow()


### PR DESCRIPTION
## Summary
- keep the workflow title, context badges, metrics, output actions, and active Pause/Stop controls readable across desktop and narrow layouts
- replace the fake AI Activity timestamp row with a dedicated accessible waiting state; filter empty assistant placeholders
- replay live activity against the correct strict main/review/test session line, including the interval before a resumed Claude run finishes
- pre-link the stable session id to the exact in-flight milestone before the blocking agent call starts
- always push the validated auto-dev target explicitly so an inherited `main` upstream cannot break review-fix pushes under `push.default=simple`

## Status behavior
- active workflows show Pause and Stop; paused workflows show Resume and Stop
- completed workflows intentionally show no destructive controls
- real activities retain real timestamps; an empty stream shows explanatory waiting copy without `--:--:--` or a wrapped lone dash

## Validation
- frontend: 15 focused tests, Prettier, TypeScript, ESLint, production build
- backend: 17 targeted session-link / force-with-lease / review-fix tests; Black, Ruff, mypy and pre-commit hooks
- responsive rendering checked at 1704 / 1440 / 960 / 720 px

## Production failure addressed
Issue #1893 review fixes were completed but could not push because the auto-dev worktree inherited `main` as upstream. This PR makes the workflow branch an explicit push target and preserves the force-with-lease auto-dev safety guard.