### PR TITLE
fix(remote): session_sync token accumulation for web terminal (Issue #1955)

### DIFF
--- a/app/routes/remote.py
+++ b/app/routes/remote.py
@@ -1645,6 +1645,8 @@ def agent_message():
 
                 # Mirror messages to daily_messages for ConversationHistory visibility
                 synced_message_delta = 0
+                synced_input_tokens = 0
+                synced_output_tokens = 0
                 for msg in messages:
                     role = msg.get("role", "")
                     content = msg.get("content", "")
@@ -1700,6 +1702,8 @@ def agent_message():
                         )
                         if getattr(stored, "_was_inserted", False):
                             synced_message_delta += 1
+                            synced_input_tokens += input_tokens
+                            synced_output_tokens += output_tokens
                     except Exception as e:
                         logger.debug("Failed to add session_message: %s", e)
 
@@ -1801,10 +1805,29 @@ def agent_message():
                 # (count_usage=False), so the session owner must advance
                 # message_count itself — otherwise remote-synced sessions
                 # never reflect their imported messages (#1128).
-                if synced_message_delta:
+                if synced_message_delta or synced_input_tokens or synced_output_tokens:
                     sync_session_mgr.increment_session_usage(
-                        session_id, message_delta=synced_message_delta
+                        session_id,
+                        message_delta=synced_message_delta,
+                        total_tokens_delta=synced_input_tokens + synced_output_tokens,
+                        total_input_delta=synced_input_tokens,
+                        total_output_delta=synced_output_tokens,
                     )
+
+                    # Record usage in QuotaManager for quota tracking
+                    if sync_user_id and (synced_input_tokens or synced_output_tokens):
+                        try:
+                            from app.modules.governance.quota_manager import QuotaManager
+
+                            quota_mgr = QuotaManager()
+                            quota_mgr.record_usage(
+                                user_id=sync_user_id,
+                                tokens=synced_input_tokens + synced_output_tokens,
+                                requests=1,  # Each session_sync counts as 1 request
+                            )
+                        except Exception as e:
+                            logger.error("Failed to record quota usage: %s", e)
+
             except Exception as e:
                 logger.debug("Failed to mirror messages: %s", e)
 

--- a/tests/unit/test_remote_sync_message_count.py
+++ b/tests/unit/test_remote_sync_message_count.py
@@ -120,3 +120,87 @@ def test_append_transcript_message_alone_does_not_advance_count(sqlite_sm):
 
     session = sqlite_sm.get_session("sess-sync")
     assert session.message_count == 0
+
+
+def _import_with_tokens(sm: SessionManager, session_id: str, messages: list) -> dict:
+    """Mirror the remote.py session_sync token accumulation pattern.
+
+    Issue #1955: session_sync must accumulate tokens and pass them to
+    increment_session_usage for proper usage tracking.
+    """
+    synced_message_delta = 0
+    synced_input_tokens = 0
+    synced_output_tokens = 0
+    for msg in messages:
+        stored = sm.append_transcript_message(
+            session_id=session_id,
+            role=msg["role"],
+            content=msg["content"],
+            source="remote_sync",
+            external_message_id=msg["external_message_id"],
+        )
+        if getattr(stored, "_was_inserted", False):
+            synced_message_delta += 1
+            synced_input_tokens += msg.get("input_tokens", 0)
+            synced_output_tokens += msg.get("output_tokens", 0)
+    if synced_message_delta or synced_input_tokens or synced_output_tokens:
+        sm.increment_session_usage(
+            session_id,
+            message_delta=synced_message_delta,
+            total_tokens_delta=synced_input_tokens + synced_output_tokens,
+            total_input_delta=synced_input_tokens,
+            total_output_delta=synced_output_tokens,
+        )
+    return {
+        "message_delta": synced_message_delta,
+        "input_tokens": synced_input_tokens,
+        "output_tokens": synced_output_tokens,
+    }
+
+
+def test_remote_sync_import_advances_token_count(sqlite_sm):
+    """Issue #1955: session_sync must advance token counts.
+
+    Without the token accumulation fix, total_tokens would stay 0 even though
+    session_sync reports usage.
+    """
+    _create_session(sqlite_sm)
+    messages = [
+        {"role": "user", "content": "what is 2+2?", "external_message_id": "m1", "input_tokens": 5},
+        {"role": "assistant", "content": "4", "external_message_id": "m2", "output_tokens": 10},
+        {
+            "role": "assistant",
+            "content": "let me elaborate",
+            "external_message_id": "m3",
+            "output_tokens": 20,
+        },
+    ]
+
+    result = _import_with_tokens(sqlite_sm, "sess-sync", messages)
+
+    assert result["message_delta"] == 3
+    assert result["input_tokens"] == 5
+    assert result["output_tokens"] == 30
+    session = sqlite_sm.get_session("sess-sync")
+    assert session.message_count == 3
+    assert session.total_tokens == 35
+    assert session.total_input_tokens == 5
+    assert session.total_output_tokens == 30
+
+
+def test_remote_sync_reimport_does_not_double_count_tokens(sqlite_sm):
+    """Issue #1955: Re-syncing must not double-count tokens."""
+    _create_session(sqlite_sm)
+    messages = [
+        {"role": "user", "content": "again", "external_message_id": "m1", "input_tokens": 7},
+        {"role": "assistant", "content": "ok", "external_message_id": "m2", "output_tokens": 15},
+    ]
+
+    _import_with_tokens(sqlite_sm, "sess-sync", messages)
+    result = _import_with_tokens(sqlite_sm, "sess-sync", messages)
+
+    assert result["message_delta"] == 0
+    assert result["input_tokens"] == 0
+    assert result["output_tokens"] == 0
+    session = sqlite_sm.get_session("sess-sync")
+    assert session.total_tokens == 22  # unchanged after re-sync


### PR DESCRIPTION
## Summary

Fixes #1955: Web terminal sessions via session_sync were not advancing token counts, causing `total_tokens` to stay 0 even though session_sync reported usage.

## Problem

ZCode desktop connected via web terminal had:
- `session_messages.tokens_used` correctly recorded
- `agent_sessions.total_tokens = 0`
- `/api/quota/status` showing `monthly.tokens.used: 0`

Root cause: `session_sync` handler only passed `message_delta` to `increment_session_usage`, missing token parameters.

## Solution

Mirror the CLI subprocess path (`process_usage_report`) token handling:

1. Initialize token accumulators (`synced_input_tokens`, `synced_output_tokens`)
2. Accumulate tokens inside `_was_inserted` check (dedup-safe)
3. Pass token parameters to `increment_session_usage`
4. Add `QuotaManager.record_usage` call for quota tracking

## Changes

| File | Change |
|------|--------|
| `app/routes/remote.py` | Token accumulation and QuotaManager call |
| `tests/unit/test_remote_sync_message_count.py` | Token counting test cases |

## Test Plan

```
python -m pytest tests/unit/test_remote_sync_message_count.py -v
```

All 5 tests pass, including new token-specific tests.