### PR TITLE
fix(timeline): make layout responsive and ordering stable

### DIFF
--- a/app/repositories/autonomous_repo.py
+++ b/app/repositories/autonomous_repo.py
@@ -1039,7 +1039,7 @@ class AutonomousWorkflowRepository:
 
         where = f"WHERE {' AND '.join(conditions)}"
         return self.db.fetch_all(
-            f"SELECT * FROM workflow_milestones {where} ORDER BY created_at ASC",
+            f"SELECT * FROM workflow_milestones {where} ORDER BY created_at ASC, id ASC",
             tuple(params),
         )
 
@@ -1130,7 +1130,8 @@ class AutonomousWorkflowRepository:
     def list_events(self, workflow_id: str, limit: int = 200, offset: int = 0) -> list:
         """List events for a workflow."""
         return self.db.fetch_all(
-            "SELECT * FROM workflow_events WHERE workflow_id = ? ORDER BY created_at ASC LIMIT ? OFFSET ?",
+            "SELECT * FROM workflow_events WHERE workflow_id = ? "
+            "ORDER BY created_at ASC, id ASC LIMIT ? OFFSET ?",
             (workflow_id, limit, offset),
         )
 

--- a/frontend/src/components/work/WorkflowTimeline.css
+++ b/frontend/src/components/work/WorkflowTimeline.css
@@ -1,6 +1,8 @@
 .timeline-shell {
   background: var(--bg-primary);
   color: var(--text-primary);
+  container-name: workflow-timeline;
+  container-type: inline-size;
 }
 
 .timeline-header {
@@ -1157,7 +1159,10 @@
   }
 }
 
-@media (max-width: 1440px) {
+/* The timeline often lives beside the app sidebar, so viewport breakpoints do
+   not describe its usable width. Reflow the header against the component's
+   own inline size before the output actions can crowd the metrics rail. */
+@container workflow-timeline (max-width: 1440px) {
   .timeline-header {
     grid-template-columns: minmax(0, 1fr);
   }
@@ -1169,6 +1174,17 @@
 
   .timeline-output-rail__buttons {
     justify-content: flex-start;
+  }
+}
+
+@container workflow-timeline (max-width: 720px) {
+  .timeline-output-rail__buttons {
+    flex-direction: column;
+  }
+
+  .timeline-output-btn {
+    width: 100%;
+    justify-content: center;
   }
 }
 
@@ -1245,15 +1261,6 @@
   .timeline-header-title {
     font-size: 1.36rem;
     white-space: normal;
-  }
-
-  .timeline-output-rail__buttons {
-    flex-direction: column;
-  }
-
-  .timeline-output-btn {
-    width: 100%;
-    justify-content: center;
   }
 
   .timeline-header-meta-grid {

--- a/frontend/src/components/work/WorkflowTimeline.css
+++ b/frontend/src/components/work/WorkflowTimeline.css
@@ -1188,7 +1188,7 @@
   }
 }
 
-@media (max-width: 960px) {
+@container workflow-timeline (max-width: 960px) {
   .timeline-header-top,
   .timeline-state-banner,
   .timeline-round-title,
@@ -1253,7 +1253,7 @@
   }
 }
 
-@media (max-width: 720px) {
+@container workflow-timeline (max-width: 720px) {
   .timeline-header {
     padding: 14px 14px 12px;
   }
@@ -1275,7 +1275,11 @@
   .timeline-body {
     padding: 14px;
   }
+}
 
+/* Content modals are portalled outside .timeline-shell, so their sizing must
+   remain tied to the viewport rather than the timeline container. */
+@media (max-width: 720px) {
   .timeline-content-modal {
     max-width: calc(100vw - 0.75rem);
   }

--- a/tests/issues/716/test_autonomous_repo.py
+++ b/tests/issues/716/test_autonomous_repo.py
@@ -2,7 +2,7 @@
 
 import json
 import os
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -548,6 +548,17 @@ class TestMilestoneCRUD:
         all_ms = repo.list_milestones(wf_id)
         assert len(all_ms) == 3
 
+    def test_list_milestones_uses_id_to_order_equal_timestamps(self):
+        db = Mock()
+        db.fetch_all.return_value = []
+        repo = AutonomousWorkflowRepository(db)
+
+        repo.list_milestones("workflow-1")
+
+        query, params = db.fetch_all.call_args.args
+        assert query.endswith("ORDER BY created_at ASC, id ASC")
+        assert params == ("workflow-1",)
+
     def test_list_milestones_filter_phase(self, auto_db):
         repo = AutonomousWorkflowRepository(auto_db)
         wf = self._create_workflow(repo)
@@ -688,6 +699,17 @@ class TestEventCRUD:
 
         events = repo.list_events(wf_id)
         assert len(events) == 5
+
+    def test_list_events_uses_id_to_order_equal_timestamps(self):
+        db = Mock()
+        db.fetch_all.return_value = []
+        repo = AutonomousWorkflowRepository(db)
+
+        repo.list_events("workflow-1", limit=25, offset=5)
+
+        query, params = db.fetch_all.call_args.args
+        assert "ORDER BY created_at ASC, id ASC" in query
+        assert params == ("workflow-1", 25, 5)
 
     def test_list_events_with_limit(self, auto_db):
         repo = AutonomousWorkflowRepository(auto_db)


### PR DESCRIPTION
## Summary
- make the timeline header respond to its own container width, so output actions wrap without overlapping metrics
- reflow the title, controls, metadata, and output rail consistently in narrow embedded layouts
- preserve viewport-based sizing for portalled content modals
- order milestones and workflow events by `created_at`, then `id`, so records created in the same second remain chronological
- add regression coverage for both deterministic repository queries

## Why
The app sidebar can reduce the timeline content width while the browser viewport remains wide, so viewport-only breakpoints did not prevent the final-output buttons from crossing the metric cards. Separately, milestone timestamps have second precision; ordering only by `created_at` allowed a repair milestone to appear above the earlier system milestone that triggered it.

## Validation
- targeted repository ordering tests: 2 passed
- pre-commit hooks: passed (black, isort, ruff, mypy, bandit, SQL compatibility, boundary checks)
- Prettier: passed
- ESLint: passed with zero errors
- TypeScript and production Vite build: passed