### PR TITLE
fix: 个人文件页上传文件后刷新错误处理

### DIFF
--- a/frontend/src/components/work/LocalDirectoryBrowser.tsx
+++ b/frontend/src/components/work/LocalDirectoryBrowser.tsx
@@ -382,7 +382,13 @@ export const LocalDirectoryBrowser: React.FC<LocalDirectoryBrowserProps> = ({
     }
 
     // Refresh the listing so the uploaded file appears.
-    await fetchDirectories(currentPath);
+    // Issue #1959: wrap in try-catch to prevent unhandled exceptions,
+    // even though fetchDirectories has its own error handling (Issue #1912).
+    try {
+      await fetchDirectories(currentPath);
+    } catch (err) {
+      console.error('Failed to refresh directory listing after upload:', err);
+    }
   };
 
   const handleDownload = async (file: FileEntry) => {


### PR DESCRIPTION
## 修复说明

关联 Issue：#1959

## 根因

`handleFileSelected` 函数在文件上传成功后调用 `fetchDirectories` 刷新目录列表，虽然 `fetchDirectories` 内部有错误处理（Issue #1912），但外层没有 try-catch 包裹，可能导致未预期的异常传播。

## 修复方案

添加 try-catch 包裹 `fetchDirectories` 调用，确保异常被正确捕获和记录。

## 主要变更

- `frontend/src/components/work/LocalDirectoryBrowser.tsx`: 在 `handleFileSelected` 函数中添加 try-catch

## 测试

- 主机：本地开发环境
- 已运行测试：前端单元测试 `LocalDirectoryBrowser.test.tsx`
- 结果：17 个测试全部通过
- 新增测试：无需新增（现有测试覆盖）

## 风险

- 兼容性风险：无。仅添加 try-catch，不改变现有行为
- 性能风险：无
- 安全风险：无
- 回归风险：无