### PR TITLE
fix(ci-repair): converge full pre-commit checks

### DIFF
--- a/app/modules/workspace/autonomous/agent_bin/_guard_exec.py
+++ b/app/modules/workspace/autonomous/agent_bin/_guard_exec.py
@@ -17,6 +17,7 @@ def main() -> None:
     if invoked == "git":
         command = next((arg.lower() for arg in args if not arg.startswith("-")), "")
         if command not in {
+            "check-attr",
             "diff",
             "grep",
             "log",

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -942,6 +942,8 @@ _CONTEXT_OVERFLOW_RE = re.compile(
 MAX_TEST_RETRIES = 2  # max retries when test agent itself fails
 MAX_DEV_RETRIES_ON_TEST_FAIL = 2  # max dev round retries for unfixable test failures
 MAX_CI_REPAIR_ATTEMPTS = 3  # max automatic dev-round retries for merge-phase CI failures
+MAX_PRE_COMMIT_CONVERGENCE_PASSES = 3
+PRE_COMMIT_CONVERGENCE_TIMEOUT = 600
 MAX_CI_DIAGNOSTICS_ATTEMPTS = 6  # bound scheduler polls when failed job logs stay unavailable
 try:
     MAX_AUTONOMOUS_CHANGED_FILES = int(os.environ.get("AUTONOMOUS_MAX_CHANGED_FILES", "60"))
@@ -2035,9 +2037,12 @@ class AutonomousOrchestrator:
             "1. 保持在当前工作分支上修复，不要创建新的 PR，不要切换到其他分支。\n"
             "2. 不要进入新的代码审查、进度汇报或等待流程；当前唯一目标是让现有 PR 的 CI 通过。\n"
             "3. 必须优先根据 CI 工作流、失败日志摘录和仓库脚本定位问题，复现 CI 真实执行的命令。\n"
-            "4. 修复后重新运行对应命令，以及你改动涉及到的必要相关测试。\n"
-            "5. 不要执行 git add、git commit 或 git push；编排器会在范围校验通过后统一提交并推送。\n"
-            "6. 结束时请明确说明：你复现了哪些命令、修复了什么、还剩什么风险。\n"
+            "4. 修复后必须重新运行 CI 的完整对应命令，而不是只运行单个 hook、单个文件或你认为相关的子集。\n"
+            "5. 如果命令中的 formatter / pre-commit hook 自动修改了文件并以非零状态退出，这只是修复过程，"
+            "不代表验证完成；必须保留这些修改并重复运行同一完整命令，直到 exit 0 或确认存在不可自动修复的错误。\n"
+            "6. 对 `pre-commit run --all-files` 这类全仓检查，必须原样保留 `--all-files`，并在结束前取得一次干净的 exit 0。\n"
+            "7. 不要执行 git add、git commit 或 git push；编排器会在范围校验通过后统一提交并推送。\n"
+            "8. 结束时请明确说明：你复现了哪些完整命令、最终 exit code、修复了什么、还剩什么风险。\n"
         )
         # Runtime contract is already embedded in ci_repair_context; do not
         # duplicate it in the fresh-session prompt.
@@ -2054,6 +2059,110 @@ class AutonomousOrchestrator:
         if include_prior_failures:
             prompt += self._build_prior_repair_failures_prompt()
         return prompt
+
+    @staticmethod
+    def _ci_failure_uses_pre_commit(failed_checks: list[dict]) -> bool:
+        """Whether collected CI evidence identifies a pre-commit failure."""
+        evidence = "\n".join(
+            str(check.get("failure_excerpt") or "") for check in failed_checks
+        ).lower()
+        return any(
+            marker in evidence
+            for marker in (
+                "pre-commit",
+                "pre_commit",
+                "hook id:",
+                "files were modified by this hook",
+            )
+        )
+
+    def _converge_pre_commit_fixes(
+        self,
+        wf: dict,
+        gh: GitHubOps,
+        failed_checks: list[dict],
+    ) -> tuple[bool, str]:
+        """Run the CI's full pre-commit command under the isolated agent account.
+
+        Some hooks intentionally modify files and return 1 on their first pass.
+        A repair agent can mistake that for completion and push a still-red
+        branch. Re-run the full command until it is clean, while preserving the
+        same credentialless OS boundary used for all autonomous repository code.
+
+        Returns ``(attempted, remaining_error)``. A remaining error is reported
+        in the repair summary but does not discard safe hook edits: the next CI
+        run remains the authoritative check and can feed a subsequent repair.
+        """
+        if wf.get("workspace_type") == "remote" or not self._ci_failure_uses_pre_commit(
+            failed_checks
+        ):
+            return False, ""
+
+        project_path = wf.get("worktree_path") or wf.get("project_path", "")
+        config_path = os.path.join(project_path, ".pre-commit-config.yaml")
+        if not project_path or not gh.path_exists_as_user(config_path, file_only=True):
+            return False, ""
+
+        pre_commit = shutil.which("pre-commit")
+        real_git = shutil.which("git")
+        if not pre_commit or not real_git:
+            logger.warning("Skipping isolated pre-commit convergence: executable unavailable")
+            return False, ""
+
+        isolated_account = self._resolve_isolated_agent_account()
+        runtime_command, _ = self._select_project_python_runtime(project_path, gh)
+        guard_bin = os.path.join(os.path.dirname(__file__), "agent_bin")
+        env = {
+            "PATH": guard_bin + os.pathsep + os.environ.get("PATH", ""),
+            "OPENACE_REAL_GIT": real_git,
+            "OPENACE_PYTHON_COMMAND": json.dumps(runtime_command or [sys.executable]),
+            "GH_CONFIG_DIR": "/var/empty/openace-autonomous-gh",
+            "GIT_TERMINAL_PROMPT": "0",
+        }
+        command, cwd = AutonomousAgentRunner._wrap_agent_cmd(
+            [pre_commit, "run", "--all-files"],
+            project_path,
+            isolated_account,
+            env,
+        )
+        last_output = ""
+        passes_run = 0
+        for pass_number in range(1, MAX_PRE_COMMIT_CONVERGENCE_PASSES + 1):
+            passes_run = pass_number
+            try:
+                result = subprocess.run(
+                    command,
+                    cwd=cwd,
+                    env=None if cwd is None else {**os.environ, **env},
+                    capture_output=True,
+                    text=True,
+                    timeout=PRE_COMMIT_CONVERGENCE_TIMEOUT,
+                    check=False,
+                )
+            except (OSError, subprocess.TimeoutExpired) as exc:
+                return True, f"isolated pre-commit validation could not run: {exc}"
+
+            last_output = "\n".join(part for part in (result.stdout, result.stderr) if part).strip()
+            if result.returncode == 0:
+                logger.info("Isolated pre-commit convergence passed on run %d", pass_number)
+                return True, ""
+
+            hooks_modified_files = any(
+                marker in last_output.lower()
+                for marker in (
+                    "files were modified by this hook",
+                    "fixing ",
+                    "reformatted ",
+                )
+            )
+            if not hooks_modified_files:
+                break
+
+        concise_output = last_output[-4000:] if last_output else "no output"
+        return True, (
+            "isolated `pre-commit run --all-files` did not reach exit 0 after "
+            f"{passes_run} pass(es):\n{concise_output}"
+        )
 
     @staticmethod
     def _detect_and_push_ci_repair_changes(
@@ -2252,6 +2361,20 @@ class AutonomousOrchestrator:
         if wf.get("user_feedback", "").strip():
             self._update_workflow({"user_feedback": ""})
 
+        pre_commit_attempted = False
+        pre_commit_error = ""
+        try:
+            pre_commit_attempted, pre_commit_error = self._converge_pre_commit_fixes(
+                wf, gh, failed_checks
+            )
+        except Exception as exc:
+            # The isolated validation is defense-in-depth. Preserve the agent's
+            # edits and let GitHub CI remain authoritative if the local wrapper
+            # itself is unavailable or misconfigured.
+            pre_commit_attempted = True
+            pre_commit_error = f"isolated pre-commit validation failed to start: {exc}"
+            logger.warning(pre_commit_error, exc_info=True)
+
         self._accumulate_tokens(repair_result)
 
         commit_sha, sha_changed, push_error = self._detect_and_push_ci_repair_changes(
@@ -2277,6 +2400,11 @@ class AutonomousOrchestrator:
             commit_sha,
             repair_result.success or salvaged,
         )
+        if pre_commit_attempted:
+            validation_summary = (
+                pre_commit_error or "isolated `pre-commit run --all-files` converged with exit 0"
+            )
+            summary = f"{summary}\n\nValidation: {validation_summary}".strip()
 
         milestone_updates = {
             "status": "completed" if (repair_result.success or salvaged) else "failed",

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -2194,20 +2194,27 @@ class AutonomousOrchestrator:
             commit_sha = gh.get_current_commit()
         except Exception:
             pass
-        sha_changed = bool(commit_before and commit_sha and commit_before != commit_sha)
 
-        if not sha_changed:
-            try:
-                if gh.has_uncommitted_changes():
-                    gh.git_add_all()
-                    gh.git_commit(
-                        f"auto: ci repair (attempt {attempt})",
-                        no_verify=True,
-                    )
-                    commit_sha = gh.get_current_commit()
-                    sha_changed = bool(commit_before and commit_sha and commit_before != commit_sha)
-            except Exception as e:
-                logger.warning("CI repair auto-commit failed: %s", e)
+        # Always commit working-tree edits before comparing/pushing. The local
+        # HEAD may already be ahead of the remote PR after a transient push
+        # failure; pre-commit convergence can then add fresh edits on top of
+        # that commit. Skipping this check when HEAD differs would push the old
+        # commit and silently strand the validated hook fixes in the worktree.
+        try:
+            if gh.has_uncommitted_changes():
+                gh.git_add_all()
+                gh.git_commit(
+                    f"auto: ci repair (attempt {attempt})",
+                    no_verify=True,
+                )
+                commit_sha = gh.get_current_commit()
+        except Exception as e:
+            message = f"CI repair auto-commit failed: {e}"
+            logger.warning(message)
+            sha_changed = bool(commit_before and commit_sha and commit_before != commit_sha)
+            return commit_sha, sha_changed, message
+
+        sha_changed = bool(commit_before and commit_sha and commit_before != commit_sha)
 
         push_error = ""
         if sha_changed:

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -1126,6 +1126,10 @@ class AutonomousOrchestrator:
             return configured
         if account.pw_uid == 0:
             raise RuntimeError("Autonomous agent account must never have UID 0")
+        if account.pw_uid == os.getuid():
+            raise RuntimeError(
+                "Autonomous agent account must differ from the Open ACE service account"
+            )
         group_ids = set(os.getgrouplist(configured, account.pw_gid))
         group_names = set()
         for group_id in group_ids:
@@ -2110,6 +2114,11 @@ class AutonomousOrchestrator:
             return False, ""
 
         isolated_account = self._resolve_isolated_agent_account()
+        project_system_account = self._resolve_system_account(wf)
+        if project_system_account and isolated_account == project_system_account:
+            raise RuntimeError(
+                "Autonomous validation account must differ from the repository owner account"
+            )
         runtime_command, _ = self._select_project_python_runtime(project_path, gh)
         guard_bin = os.path.join(os.path.dirname(__file__), "agent_bin")
         env = {

--- a/tests/issues/1811/test_ci_repair_fingerprint.py
+++ b/tests/issues/1811/test_ci_repair_fingerprint.py
@@ -267,6 +267,47 @@ class TestDetectAndPushCiRepairChanges:
         gh.git_add_all.assert_called_once()
         gh.git_push.assert_called_once()
 
+    def test_commits_hook_edits_when_local_head_already_leads_remote(self):
+        from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+        gh = MagicMock()
+        gh.get_current_commit.side_effect = ["sha-B", "sha-C"]
+        gh.has_uncommitted_changes.return_value = True
+
+        commit_sha, sha_changed, push_error = (
+            AutonomousOrchestrator._detect_and_push_ci_repair_changes(
+                gh,
+                commit_before="sha-A",
+                attempt=2,
+                branch_name="auto-dev/x",
+                pr_number=1812,
+            )
+        )
+
+        assert (commit_sha, sha_changed, push_error) == ("sha-C", True, "")
+        gh.git_add_all.assert_called_once()
+        gh.git_commit.assert_called_once_with("auto: ci repair (attempt 2)", no_verify=True)
+        gh.git_push.assert_called_once_with(branch="auto-dev/x", force_with_lease=True)
+
+    def test_commit_failure_does_not_push_stale_local_head(self):
+        from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+        gh = MagicMock()
+        gh.get_current_commit.return_value = "sha-B"
+        gh.has_uncommitted_changes.return_value = True
+        gh.git_commit.side_effect = RuntimeError("hook edits could not be committed")
+
+        commit_sha, sha_changed, push_error = (
+            AutonomousOrchestrator._detect_and_push_ci_repair_changes(
+                gh, "sha-A", 2, "auto-dev/x", 1812
+            )
+        )
+
+        assert commit_sha == "sha-B"
+        assert sha_changed is True
+        assert "could not be committed" in push_error
+        gh.git_push.assert_not_called()
+
     def test_push_error_captured_not_raised(self):
         from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
 

--- a/tests/unit/test_autonomous_ci_guardrails.py
+++ b/tests/unit/test_autonomous_ci_guardrails.py
@@ -784,6 +784,83 @@ def test_fresh_ci_repair_prompt_keeps_requirements_plan_and_diff():
     assert "APPROVED PLAN" in prompt
     assert "diff --git" in prompt
     assert "CI EXCERPT" in prompt
+    assert "pre-commit run --all-files" in prompt
+    assert "直到 exit 0" in prompt
+
+
+def test_pre_commit_detection_requires_log_evidence():
+    from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+    assert AutonomousOrchestrator._ci_failure_uses_pre_commit(
+        [
+            {
+                "name": "lint",
+                "failure_excerpt": "hook id: end-of-file-fixer\nfiles were modified by this hook",
+            }
+        ]
+    )
+    assert not AutonomousOrchestrator._ci_failure_uses_pre_commit(
+        [{"name": "lint", "failure_excerpt": "ruff: F401 unused import"}]
+    )
+
+
+def test_pre_commit_convergence_reruns_modified_hooks_as_isolated_agent():
+    from app.modules.workspace.autonomous.agent_runner import AutonomousAgentRunner
+    from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+    orch = AutonomousOrchestrator.__new__(AutonomousOrchestrator)
+    orch._resolve_isolated_agent_account = MagicMock(return_value="openace-agent")
+    orch._select_project_python_runtime = MagicMock(return_value=(["python3"], ""))
+    gh = MagicMock()
+    gh.path_exists_as_user.return_value = True
+    failed_checks = [
+        {
+            "name": "lint",
+            "failure_excerpt": "pre-commit hook(s) made changes",
+        }
+    ]
+    modified = MagicMock(
+        returncode=1,
+        stdout="files were modified by this hook\nFixing docker-compose.yml",
+        stderr="",
+    )
+    clean = MagicMock(returncode=0, stdout="All checks passed", stderr="")
+
+    with (
+        patch(
+            "app.modules.workspace.autonomous.orchestrator.shutil.which",
+            side_effect=["/usr/local/bin/pre-commit", "/usr/bin/git"],
+        ),
+        patch.object(
+            AutonomousAgentRunner,
+            "_wrap_agent_cmd",
+            return_value=(["isolated-wrapper", "pre-commit"], None),
+        ) as wrap,
+        patch(
+            "app.modules.workspace.autonomous.orchestrator.subprocess.run",
+            side_effect=[modified, clean],
+        ) as run,
+    ):
+        attempted, error = orch._converge_pre_commit_fixes(
+            {
+                "workspace_type": "local",
+                "worktree_path": "/private/repo",
+            },
+            gh,
+            failed_checks,
+        )
+
+    assert attempted
+    assert error == ""
+    assert run.call_count == 2
+    wrap.assert_called_once()
+    assert wrap.call_args.args[:3] == (
+        ["/usr/local/bin/pre-commit", "run", "--all-files"],
+        "/private/repo",
+        "openace-agent",
+    )
+    assert run.call_args.kwargs["cwd"] is None
+    assert run.call_args.kwargs["env"] is None
 
 
 def test_nonstandard_report_with_real_test_evidence_does_not_retry():

--- a/tests/unit/test_autonomous_ci_guardrails.py
+++ b/tests/unit/test_autonomous_ci_guardrails.py
@@ -411,6 +411,20 @@ def test_isolated_agent_account_rejects_root(monkeypatch):
         raise AssertionError("UID 0 autonomous agent account was accepted")
 
 
+def test_isolated_agent_account_rejects_service_principal(monkeypatch):
+    from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+    monkeypatch.setenv("OPENACE_AUTONOMOUS_AGENT_ACCOUNT", "openace")
+    monkeypatch.setattr(
+        "app.modules.workspace.autonomous.orchestrator.pwd.getpwnam",
+        lambda _name: MagicMock(pw_uid=501, pw_gid=20),
+    )
+    monkeypatch.setattr("app.modules.workspace.autonomous.orchestrator.os.getuid", lambda: 501)
+
+    with pytest.raises(RuntimeError, match="must differ from the Open ACE service account"):
+        AutonomousOrchestrator._resolve_isolated_agent_account()
+
+
 def test_trusted_git_context_rejects_replaced_git_directory():
     from app.modules.workspace.autonomous.github_ops import GitHubOps, GitHubOpsError
 
@@ -442,6 +456,40 @@ def test_agent_command_policy_denies_push_and_mutating_pr_commands():
     assert _is_forbidden_autonomous_command("Bash", {"command": "gh pr merge 42"})
     assert _is_forbidden_autonomous_command("Bash", {"command": "/usr/bin/python3 -m pytest"})
     assert not _is_forbidden_autonomous_command("Bash", {"command": "git status"})
+
+
+def test_isolated_git_guard_allows_pre_commit_check_attr(tmp_path):
+    """pre-commit's large-file hook needs this read-only plumbing command."""
+    import os
+    import subprocess
+    from pathlib import Path
+
+    real_git = tmp_path / "real-git"
+    real_git.write_text(
+        f"#!{sys.executable}\nimport sys\nprint(' '.join(sys.argv[1:]))\n",
+        encoding="utf-8",
+    )
+    real_git.chmod(0o755)
+    guard = (
+        Path(__file__).parents[2]
+        / "app"
+        / "modules"
+        / "workspace"
+        / "autonomous"
+        / "agent_bin"
+        / "git"
+    )
+    result = subprocess.run(
+        [str(guard), "check-attr", "filter", "-z", "--stdin"],
+        input="",
+        capture_output=True,
+        text=True,
+        env={**os.environ, "OPENACE_REAL_GIT": str(real_git)},
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert result.stdout.strip() == "check-attr filter -z --stdin"
 
 
 def test_runner_preserves_tool_result_for_test_evidence():
@@ -810,6 +858,7 @@ def test_pre_commit_convergence_reruns_modified_hooks_as_isolated_agent():
 
     orch = AutonomousOrchestrator.__new__(AutonomousOrchestrator)
     orch._resolve_isolated_agent_account = MagicMock(return_value="openace-agent")
+    orch._resolve_system_account = MagicMock(return_value="repo-owner")
     orch._select_project_python_runtime = MagicMock(return_value=(["python3"], ""))
     gh = MagicMock()
     gh.path_exists_as_user.return_value = True
@@ -861,6 +910,32 @@ def test_pre_commit_convergence_reruns_modified_hooks_as_isolated_agent():
     )
     assert run.call_args.kwargs["cwd"] is None
     assert run.call_args.kwargs["env"] is None
+
+
+def test_pre_commit_convergence_rejects_repository_owner_account():
+    from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+    orch = AutonomousOrchestrator.__new__(AutonomousOrchestrator)
+    orch._resolve_isolated_agent_account = MagicMock(return_value="repo-owner")
+    orch._resolve_system_account = MagicMock(return_value="repo-owner")
+    gh = MagicMock()
+    gh.path_exists_as_user.return_value = True
+
+    with (
+        patch(
+            "app.modules.workspace.autonomous.orchestrator.shutil.which",
+            side_effect=["/usr/local/bin/pre-commit", "/usr/bin/git"],
+        ),
+        patch("app.modules.workspace.autonomous.orchestrator.subprocess.run") as run,
+        pytest.raises(RuntimeError, match="repository owner"),
+    ):
+        orch._converge_pre_commit_fixes(
+            {"workspace_type": "local", "worktree_path": "/private/repo", "user_id": 7},
+            gh,
+            [{"failure_excerpt": "pre-commit hook(s) made changes"}],
+        )
+
+    run.assert_not_called()
 
 
 def test_nonstandard_report_with_real_test_evidence_does_not_retry():


### PR DESCRIPTION
## Summary

- require CI-repair agents to rerun the complete CI command, preserving `--all-files`, until a clean exit
- detect pre-commit failures from collected Actions log evidence
- after the AI repair, run `pre-commit run --all-files` under the credentialless `openace-agent` account and repeat auto-fixing hooks up to three times
- preserve resulting safe edits for the existing scope validation, commit, and push pipeline
- expose convergence success or residual errors in the repair milestone summary

## Root cause

Issue #1893 exhausted all three CI repair rounds because each fresh repair agent fixed only a subset of files reported by the lint job. The job runs `pre-commit run --all-files`; hooks such as `end-of-file-fixer` modify files and intentionally return non-zero on that pass. The workflow treated the agent turn as complete without requiring the full command to be rerun to exit 0, so the next CI run revealed another small batch of unchanged files.

## Security

Repository hooks are untrusted executable code. The deterministic convergence pass therefore uses the same isolated, credentialless OS account and guarded PATH as autonomous agents. It does not execute hooks as root, the Open ACE service account, or the repository owner.

## Validation

- `tests/unit/test_autonomous_ci_guardrails.py`: 35 passed
- targeted CI-repair regression suite: 83 passed; the same 8 failures reproduce unchanged on `origin/main`
- Black, isort, Ruff, mypy, Bandit, pydocstyle, SQL compatibility and repository boundary hooks passed on the changed files
- new tests cover log-evidence gating, prompt requirements, isolated-account execution, and rerunning after an auto-fixing hook
