### PR TITLE
fix(autonomous): use packaged guards for CI convergence

### DIFF
--- a/app/modules/workspace/autonomous/agent_runner.py
+++ b/app/modules/workspace/autonomous/agent_runner.py
@@ -997,7 +997,11 @@ class AutonomousAgentRunner:
         Same-user development can still use the guards shipped beside this
         module when the package has not been installed system-wide.
         """
-        packaged_guard_bin = Path(_OPENACE_AGENT_GUARD_BIN)
+        # Freeze a canonical path before checking its contents. Returning a
+        # configured symlink would let PATH traverse that link after the
+        # cross-user ownership validation, creating a check/use race if the
+        # link were replaced in between.
+        packaged_guard_bin = Path(os.path.realpath(_OPENACE_AGENT_GUARD_BIN))
         if all((packaged_guard_bin / name).is_file() for name in _AGENT_GUARD_EXECUTABLES):
             return str(packaged_guard_bin)
         return str(Path(__file__).with_name("agent_bin"))

--- a/app/modules/workspace/autonomous/agent_runner.py
+++ b/app/modules/workspace/autonomous/agent_runner.py
@@ -989,6 +989,20 @@ class AutonomousAgentRunner:
         return cmd, project_path
 
     @staticmethod
+    def _resolve_agent_guard_bin() -> str:
+        """Return the installed guard directory, with a source-tree fallback.
+
+        Cross-user launches require the root-owned packaged directory because
+        the isolated agent cannot traverse the service account's private home.
+        Same-user development can still use the guards shipped beside this
+        module when the package has not been installed system-wide.
+        """
+        packaged_guard_bin = Path(_OPENACE_AGENT_GUARD_BIN)
+        if all((packaged_guard_bin / name).is_file() for name in _AGENT_GUARD_EXECUTABLES):
+            return str(packaged_guard_bin)
+        return str(Path(__file__).with_name("agent_bin"))
+
+    @staticmethod
     def _validate_cross_user_guard_bin(env: dict[str, str]) -> None:
         """Fail closed unless cross-user command guards are safely installed.
 
@@ -1052,12 +1066,7 @@ class AutonomousAgentRunner:
         keeps working.
         """
         env = dict(os.environ)
-        packaged_guard_bin = Path(_OPENACE_AGENT_GUARD_BIN)
-        guard_bin = (
-            str(packaged_guard_bin)
-            if all((packaged_guard_bin / name).is_file() for name in _AGENT_GUARD_EXECUTABLES)
-            else str(Path(__file__).with_name("agent_bin"))
-        )
+        guard_bin = AutonomousAgentRunner._resolve_agent_guard_bin()
         real_git = shutil.which("git", path=env.get("PATH"))
         real_gh = shutil.which("gh", path=env.get("PATH"))
         if real_git:

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -2120,7 +2120,7 @@ class AutonomousOrchestrator:
                 "Autonomous validation account must differ from the repository owner account"
             )
         runtime_command, _ = self._select_project_python_runtime(project_path, gh)
-        guard_bin = os.path.join(os.path.dirname(__file__), "agent_bin")
+        guard_bin = AutonomousAgentRunner._resolve_agent_guard_bin()
         env = {
             "PATH": guard_bin + os.pathsep + os.environ.get("PATH", ""),
             "OPENACE_REAL_GIT": real_git,

--- a/tests/unit/test_autonomous_ci_guardrails.py
+++ b/tests/unit/test_autonomous_ci_guardrails.py
@@ -228,6 +228,39 @@ def test_agent_environment_binds_python_and_git_guards(monkeypatch, tmp_path):
     assert "GH_TOKEN" not in env
 
 
+def test_agent_guard_bin_falls_back_to_source_when_install_is_incomplete(monkeypatch, tmp_path):
+    from pathlib import Path
+
+    from app.modules.workspace.autonomous import agent_runner
+
+    incomplete_install = tmp_path / "agent-bin"
+    incomplete_install.mkdir()
+    for name in agent_runner._AGENT_GUARD_EXECUTABLES[:-1]:
+        (incomplete_install / name).write_text("#!/bin/sh\n", encoding="utf-8")
+    monkeypatch.setattr(agent_runner, "_OPENACE_AGENT_GUARD_BIN", str(incomplete_install))
+
+    resolved = agent_runner.AutonomousAgentRunner._resolve_agent_guard_bin()
+
+    assert resolved == str(Path(agent_runner.__file__).with_name("agent_bin"))
+
+
+def test_cross_user_launch_rejects_resolved_source_fallback(monkeypatch, tmp_path):
+    from app.modules.workspace.autonomous import agent_runner
+
+    missing_install = tmp_path / "missing-agent-bin"
+    monkeypatch.setattr(agent_runner, "_OPENACE_AGENT_GUARD_BIN", str(missing_install))
+    source_fallback = agent_runner.AutonomousAgentRunner._resolve_agent_guard_bin()
+    env = {"PATH": f"{source_fallback}:/usr/bin"}
+
+    with (
+        patch.object(agent_runner.AutonomousAgentRunner, "_is_cross_user", return_value=True),
+        pytest.raises(RuntimeError, match="packaged agent command guards"),
+    ):
+        agent_runner.AutonomousAgentRunner._wrap_agent_cmd(
+            ["/usr/bin/pre-commit"], "/private/repo", "openace-agent", env
+        )
+
+
 def test_cross_user_launch_preserves_nonsecret_guard_environment(monkeypatch, tmp_path):
     from app.modules.workspace.autonomous import agent_runner
 

--- a/tests/unit/test_autonomous_ci_guardrails.py
+++ b/tests/unit/test_autonomous_ci_guardrails.py
@@ -885,6 +885,11 @@ def test_pre_commit_convergence_reruns_modified_hooks_as_isolated_agent():
             "_wrap_agent_cmd",
             return_value=(["isolated-wrapper", "pre-commit"], None),
         ) as wrap,
+        patch.object(
+            AutonomousAgentRunner,
+            "_resolve_agent_guard_bin",
+            return_value="/usr/local/libexec/openace-agent-bin",
+        ),
         patch(
             "app.modules.workspace.autonomous.orchestrator.subprocess.run",
             side_effect=[modified, clean],
@@ -908,6 +913,7 @@ def test_pre_commit_convergence_reruns_modified_hooks_as_isolated_agent():
         "/private/repo",
         "openace-agent",
     )
+    assert wrap.call_args.args[3]["PATH"].split(":", 1)[0] == "/usr/local/libexec/openace-agent-bin"
     assert run.call_args.kwargs["cwd"] is None
     assert run.call_args.kwargs["env"] is None
 

--- a/tests/unit/test_autonomous_ci_guardrails.py
+++ b/tests/unit/test_autonomous_ci_guardrails.py
@@ -244,6 +244,24 @@ def test_agent_guard_bin_falls_back_to_source_when_install_is_incomplete(monkeyp
     assert resolved == str(Path(agent_runner.__file__).with_name("agent_bin"))
 
 
+def test_agent_guard_bin_canonicalizes_packaged_directory_symlink(monkeypatch, tmp_path):
+    from app.modules.workspace.autonomous import agent_runner
+
+    installed_guard_dir = tmp_path / "installed-agent-bin"
+    installed_guard_dir.mkdir()
+    for name in agent_runner._AGENT_GUARD_EXECUTABLES:
+        guard = installed_guard_dir / name
+        guard.write_text("#!/bin/sh\n", encoding="utf-8")
+        guard.chmod(0o755)
+    configured_link = tmp_path / "configured-agent-bin"
+    configured_link.symlink_to(installed_guard_dir, target_is_directory=True)
+    monkeypatch.setattr(agent_runner, "_OPENACE_AGENT_GUARD_BIN", str(configured_link))
+
+    resolved = agent_runner.AutonomousAgentRunner._resolve_agent_guard_bin()
+
+    assert resolved == str(installed_guard_dir.resolve())
+
+
 def test_cross_user_launch_rejects_resolved_source_fallback(monkeypatch, tmp_path):
     from app.modules.workspace.autonomous import agent_runner
 


### PR DESCRIPTION
## Summary

- share the packaged agent guard directory resolver between normal agent launches and deterministic pre-commit convergence
- preserve the source-tree fallback for same-user development installs
- assert that CI convergence passes the root-owned packaged guard directory into the isolated wrapper

## Root cause

The deterministic CI repair convergence added in #1964 constructed PATH from the source-tree `agent_bin`. Production runs repair validation as a separate credentialless OS account under a private service home, so `_validate_cross_user_guard_bin` correctly rejected that path. This prevented the convergence pass from starting even though the packaged guards were installed.

## Verification

- `python -m pytest tests/unit/test_autonomous_ci_guardrails.py -q` (38 passed)
- black / isort / ruff on touched files
- repository pre-commit hooks passed during commit