### PR TITLE
fix(autonomous): drain workflows on service shutdown

### DIFF
--- a/app/modules/workspace/autonomous/agent_runner.py
+++ b/app/modules/workspace/autonomous/agent_runner.py
@@ -1615,6 +1615,7 @@ class AutonomousAgentRunner:
             if workspace_type == "remote" and remote_machine_id:
                 result = self._run_remote(
                     session_id=session_id,
+                    user_id=user_id,
                     cli_tool=cli_tool,
                     model=model,
                     project_path=project_path,
@@ -2792,6 +2793,7 @@ class AutonomousAgentRunner:
     def _run_remote(
         self,
         session_id: str,
+        user_id: int | None,
         cli_tool: str,
         model: str,
         project_path: str,
@@ -2810,15 +2812,18 @@ class AutonomousAgentRunner:
                 error="Remote session manager not available",
             )
 
+        remote_session_id = session_id
         try:
             # Register a tracker so orchestrator can signal cancellation
-            self._local_sessions[session_id] = _LocalSession(
+            tracker = _LocalSession(
                 session_id=session_id,
                 process=None,  # type: ignore[arg-type]
             )
+            self._local_sessions[session_id] = tracker
 
             # Create remote session
             result = self.remote_session_manager.create_remote_session(
+                user_id=user_id,
                 machine_id=remote_machine_id,
                 project_path=project_path,
                 cli_tool=cli_tool,
@@ -2835,9 +2840,12 @@ class AutonomousAgentRunner:
                     error=result.get("error", "Failed to create remote session"),
                 )
 
+            remote_session_id = result.get("session_id") or session_id
+            tracker.persisted_session_id = remote_session_id
+
             # Send the prompt
             self.remote_session_manager.send_message(
-                session_id=session_id,
+                session_id=remote_session_id,
                 message=prompt,
             )
 
@@ -2858,25 +2866,25 @@ class AutonomousAgentRunner:
                 local_session = self._local_sessions.get(session_id)
                 if local_session and local_session._stopped.is_set():
                     return AgentTaskResult(
-                        session_id=session_id,
+                        session_id=remote_session_id,
                         tracking_session_id=session_id,
                         success=False,
                         error="Remote session cancelled by orchestrator",
                     )
 
-                session_data = self.session_manager.get_session(session_id)
+                session_data = self.session_manager.get_session(remote_session_id)
                 if session_data:
                     status = session_data.get("status", "active")
                     if status in ("completed", "stopped", "error", "exited"):
                         # Get messages
                         messages = []
                         if hasattr(self.session_manager, "get_messages"):
-                            messages = self.session_manager.get_messages(session_id) or []
+                            messages = self.session_manager.get_messages(remote_session_id) or []
 
                         remote_events, remote_tool_calls = self._normalize_remote_messages(messages)
 
                         return _build_agent_task_result(
-                            session_id=session_id,
+                            session_id=remote_session_id,
                             tracking_session_id=session_id,
                             event_log=remote_events,
                             messages=messages,
@@ -2893,7 +2901,7 @@ class AutonomousAgentRunner:
                 time.sleep(5)
 
             return AgentTaskResult(
-                session_id=session_id,
+                session_id=remote_session_id,
                 tracking_session_id=session_id,
                 success=False,
                 error=f"Remote agent task timed out after {timeout}s",
@@ -2901,7 +2909,7 @@ class AutonomousAgentRunner:
 
         except Exception as e:
             return AgentTaskResult(
-                session_id=session_id,
+                session_id=remote_session_id,
                 tracking_session_id=session_id,
                 success=False,
                 error=f"Remote execution error: {e}",
@@ -3439,7 +3447,24 @@ class AutonomousAgentRunner:
         first with SIGCONT so it can handle SIGTERM.
         """
         session = self._local_sessions.get(session_id)
-        if not session or not session.process or session.process.returncode is not None:
+        if not session:
+            return
+        if session.process is None:
+            # Remote autonomous calls use a process-less local tracker so the
+            # synchronous poll loop can observe cancellation. Stop the actual
+            # remote session when possible, but always trip the local events:
+            # shutdown must drain even if the remote machine is unreachable.
+            try:
+                if self.remote_session_manager:
+                    remote_session_id = session.persisted_session_id or session_id
+                    self.remote_session_manager.stop_session(remote_session_id)
+            except Exception as exc:
+                logger.warning("Failed to stop remote session %s: %s", session_id[:8], exc)
+            finally:
+                session._stopped.set()
+                session.completed.set()
+            return
+        if session.process.returncode is not None:
             return
 
         try:

--- a/app/modules/workspace/autonomous/agent_runner.py
+++ b/app/modules/workspace/autonomous/agent_runner.py
@@ -229,6 +229,10 @@ class _LocalSession:
     # claude emits multiple assistant events per message: thinking then text).
     _counted_message_ids: set = field(default_factory=set)
     _paused: threading.Event = field(default_factory=threading.Event)  # set when SIGSTOPed
+    # Serializes remote session-id publication/message dispatch with shutdown.
+    # Local subprocess sessions do not use it, but keeping it on the tracker
+    # avoids a second tracker type and closes the create-vs-stop race.
+    _remote_lifecycle_lock: threading.Lock = field(default_factory=threading.Lock)
 
 
 # Top-level keys that indicate a JSON object is a leaked tool-call blob
@@ -1664,7 +1668,7 @@ class AutonomousAgentRunner:
             # so the session columns stay cumulative and Σ milestone == Σ session
             # holds (#1003). The previous overwrite reset the columns to each
             # call's local count, breaking the invariant.
-            if self.session_manager and persisted_session_id:
+            if self.session_manager and persisted_session_id and workspace_type != "remote":
                 try:
                     self.session_manager.increment_session_usage(
                         persisted_session_id,
@@ -1680,6 +1684,20 @@ class AutonomousAgentRunner:
                     )
                 except Exception as e:
                     logger.warning("Failed to update session record: %s", e)
+
+            # RemoteSessionManager owns the actual remote row's transcript,
+            # usage and status lifecycle. Re-applying the result totals here
+            # would double-count usage reports that the remote endpoint has
+            # already persisted. Only close the hidden stable tracking row;
+            # its cli_session_id mapping was written by _run_remote.
+            if self.session_manager and workspace_type == "remote":
+                try:
+                    self.session_manager.update_session_fields(
+                        session_id,
+                        {"status": "completed" if result.success else "error"},
+                    )
+                except Exception as e:
+                    logger.warning("Failed to update remote tracking session: %s", e)
 
             # Close the eagerly-created workflow wrapper row when the agent never
             # produced a real CLI session id (sidebar source + executable not
@@ -2811,6 +2829,20 @@ class AutonomousAgentRunner:
                 success=False,
                 error="Remote session manager not available",
             )
+        if not self.session_manager:
+            return AgentTaskResult(
+                session_id=session_id,
+                tracking_session_id=session_id,
+                success=False,
+                error="Session manager not available for remote session polling",
+            )
+        if user_id is None:
+            return AgentTaskResult(
+                session_id=session_id,
+                tracking_session_id=session_id,
+                success=False,
+                error="User ID is required for remote autonomous execution",
+            )
 
         remote_session_id = session_id
         try:
@@ -2832,50 +2864,92 @@ class AutonomousAgentRunner:
                 allowed_tools=allowed_tools,
             )
 
-            if not result.get("success"):
+            # The concrete RemoteSessionManager returns the session payload
+            # directly (without a success=True envelope). Keep compatibility
+            # with older/test adapters that explicitly return success=False.
+            if not result or result.get("success") is False or not result.get("session_id"):
                 return AgentTaskResult(
                     session_id=session_id,
                     tracking_session_id=session_id,
                     success=False,
-                    error=result.get("error", "Failed to create remote session"),
+                    error=(result or {}).get("error", "Failed to create remote session"),
                 )
 
-            remote_session_id = result.get("session_id") or session_id
-            tracker.persisted_session_id = remote_session_id
+            remote_session_id = result["session_id"]
+            with tracker._remote_lifecycle_lock:
+                tracker.persisted_session_id = remote_session_id
+                if tracker._stopped.is_set():
+                    # Shutdown won while create_remote_session was in flight.
+                    # Stop the newly discovered real session before any prompt
+                    # can be dispatched.
+                    self.remote_session_manager.stop_session(remote_session_id)
+                    return self._build_remote_cancelled_result(remote_session_id, session_id)
 
-            # Send the prompt
-            self.remote_session_manager.send_message(
-                session_id=remote_session_id,
-                message=prompt,
-            )
+                # Map the hidden stable workflow line to the real remote row so
+                # milestone details resolve the transcript without replacing
+                # the main/review/test tracking identity.
+                tracking_row = self.session_manager.get_session(session_id)
+                context = dict(getattr(tracking_row, "context", {}) or {})
+                if isinstance(tracking_row, dict):
+                    context = dict(tracking_row.get("context", {}) or {})
+                context.update(
+                    {
+                        "workflow_id": context.get("workflow_id", ""),
+                        "cli_session_id": remote_session_id,
+                    }
+                )
+                self.session_manager.update_session_fields(
+                    session_id,
+                    {
+                        "context": context,
+                        "status": "active",
+                        "cli_session_id": remote_session_id,
+                    },
+                )
+
+                if tracker._stopped.is_set():
+                    self.remote_session_manager.stop_session(remote_session_id)
+                    return self._build_remote_cancelled_result(remote_session_id, session_id)
+
+                # The real manager names this argument ``content``. Treat an
+                # explicit False as a dispatch failure while retaining support
+                # for legacy adapters that returned None on success.
+                sent = self.remote_session_manager.send_message(
+                    session_id=remote_session_id,
+                    content=prompt,
+                    user_id=user_id,
+                )
+                if sent is False:
+                    self.remote_session_manager.stop_session(remote_session_id)
+                    return AgentTaskResult(
+                        session_id=remote_session_id,
+                        tracking_session_id=session_id,
+                        source_session_id=remote_session_id,
+                        success=False,
+                        error="Failed to send prompt to remote session",
+                    )
 
             # Poll until session completes
             import time
-
-            if not self.session_manager:
-                return AgentTaskResult(
-                    session_id=session_id,
-                    tracking_session_id=session_id,
-                    success=False,
-                    error="Session manager not available for remote session polling",
-                )
 
             start_time = time.time()
             while time.time() - start_time < timeout:
                 # Check if the session has been cancelled externally
                 local_session = self._local_sessions.get(session_id)
                 if local_session and local_session._stopped.is_set():
-                    return AgentTaskResult(
-                        session_id=remote_session_id,
-                        tracking_session_id=session_id,
-                        success=False,
-                        error="Remote session cancelled by orchestrator",
-                    )
+                    return self._build_remote_cancelled_result(remote_session_id, session_id)
 
                 session_data = self.session_manager.get_session(remote_session_id)
                 if session_data:
-                    status = session_data.get("status", "active")
-                    if status in ("completed", "stopped", "error", "exited"):
+                    status = self._session_field(session_data, "status", "active")
+                    remote_state = None
+                    get_remote_status = getattr(
+                        self.remote_session_manager, "get_session_status", None
+                    )
+                    if callable(get_remote_status):
+                        remote_state = get_remote_status(remote_session_id)
+                    turn_complete = self._remote_turn_complete(remote_state)
+                    if status in ("completed", "stopped", "error", "exited") or turn_complete:
                         # Get messages
                         messages = []
                         if hasattr(self.session_manager, "get_messages"):
@@ -2886,37 +2960,103 @@ class AutonomousAgentRunner:
                         return _build_agent_task_result(
                             session_id=remote_session_id,
                             tracking_session_id=session_id,
+                            source_session_id=remote_session_id,
                             event_log=remote_events,
                             messages=messages,
-                            total_tokens=session_data.get("total_tokens", 0),
-                            total_input_tokens=session_data.get("total_input_tokens", 0),
-                            total_output_tokens=session_data.get("total_output_tokens", 0),
-                            request_count=session_data.get("request_count", 0),
+                            total_tokens=self._session_field(session_data, "total_tokens", 0),
+                            total_input_tokens=self._session_field(
+                                session_data, "total_input_tokens", 0
+                            ),
+                            total_output_tokens=self._session_field(
+                                session_data, "total_output_tokens", 0
+                            ),
+                            request_count=self._session_field(session_data, "request_count", 0),
                             tool_calls=remote_tool_calls,
-                            success=status == "completed",
+                            # A normal remote CLI turn reports completion via
+                            # an is_complete output entry while its reusable
+                            # sidebar session deliberately remains active.
+                            success=(status in ("active", "completed", "exited")),
                             error=(
-                                session_data.get("error_message") if status != "completed" else None
+                                self._session_field(session_data, "error_message", None)
+                                if status != "completed"
+                                else None
                             ),
                         )
                 time.sleep(5)
 
-            return AgentTaskResult(
-                session_id=remote_session_id,
-                tracking_session_id=session_id,
-                success=False,
-                error=f"Remote agent task timed out after {timeout}s",
-            )
+            timeout_result = self._build_remote_cancelled_result(remote_session_id, session_id)
+            try:
+                self.remote_session_manager.stop_session(remote_session_id)
+            except Exception:
+                logger.warning(
+                    "Failed to stop timed-out remote session %s",
+                    remote_session_id[:8],
+                    exc_info=True,
+                )
+            timeout_result.error = f"Remote agent task timed out after {timeout}s"
+            return timeout_result
 
         except Exception as e:
+            # Once a real remote id exists, never drop its local tracker while
+            # leaving the remote task running after a mapping/polling failure.
+            if remote_session_id != session_id:
+                try:
+                    self.remote_session_manager.stop_session(remote_session_id)
+                except Exception:
+                    logger.warning(
+                        "Failed to stop remote session after runner error %s",
+                        remote_session_id[:8],
+                        exc_info=True,
+                    )
             return AgentTaskResult(
                 session_id=remote_session_id,
                 tracking_session_id=session_id,
+                source_session_id=remote_session_id,
                 success=False,
                 error=f"Remote execution error: {e}",
             )
         finally:
             # Clean up the remote session tracker
             self._local_sessions.pop(session_id, None)
+
+    @staticmethod
+    def _session_field(session_data: Any, field_name: str, default: Any = None) -> Any:
+        """Read SessionManager dataclasses and legacy/test dict rows uniformly."""
+        if isinstance(session_data, dict):
+            return session_data.get(field_name, default)
+        return getattr(session_data, field_name, default)
+
+    @staticmethod
+    def _remote_turn_complete(remote_state: Any) -> bool:
+        """Whether the remote manager observed the current request finish."""
+        if not isinstance(remote_state, dict):
+            return False
+        output = remote_state.get("output") or []
+        return any(
+            isinstance(entry, dict)
+            and bool(entry.get("is_complete"))
+            and entry.get("stream") in ("stdout", "stderr", "system")
+            for entry in output
+        )
+
+    def _build_remote_cancelled_result(
+        self, remote_session_id: str, tracking_session_id: str
+    ) -> AgentTaskResult:
+        """Snapshot durable partial remote usage before unwinding shutdown."""
+        session_data = (
+            self.session_manager.get_session(remote_session_id) if self.session_manager else None
+        )
+        return AgentTaskResult(
+            session_id=remote_session_id,
+            tracking_session_id=tracking_session_id,
+            source_session_id=remote_session_id,
+            total_tokens=self._session_field(session_data, "total_tokens", 0),
+            total_input_tokens=self._session_field(session_data, "total_input_tokens", 0),
+            total_output_tokens=self._session_field(session_data, "total_output_tokens", 0),
+            request_count=self._session_field(session_data, "request_count", 0),
+            success=False,
+            error="Remote session cancelled by orchestrator",
+        )
 
     # ── Local helpers ──────────────────────────────────────────────
 
@@ -3454,15 +3594,19 @@ class AutonomousAgentRunner:
             # synchronous poll loop can observe cancellation. Stop the actual
             # remote session when possible, but always trip the local events:
             # shutdown must drain even if the remote machine is unreachable.
-            try:
-                if self.remote_session_manager:
-                    remote_session_id = session.persisted_session_id or session_id
-                    self.remote_session_manager.stop_session(remote_session_id)
-            except Exception as exc:
-                logger.warning("Failed to stop remote session %s: %s", session_id[:8], exc)
-            finally:
-                session._stopped.set()
-                session.completed.set()
+            # Publish cancellation before waiting for an in-flight mapping or
+            # send call. _run_remote re-checks this flag immediately before
+            # dispatch, so shutdown cannot be hidden behind the lifecycle lock.
+            session._stopped.set()
+            with session._remote_lifecycle_lock:
+                try:
+                    if self.remote_session_manager:
+                        remote_session_id = session.persisted_session_id or session_id
+                        self.remote_session_manager.stop_session(remote_session_id)
+                except Exception as exc:
+                    logger.warning("Failed to stop remote session %s: %s", session_id[:8], exc)
+                finally:
+                    session.completed.set()
             return
         if session.process.returncode is not None:
             return

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -4242,7 +4242,40 @@ class AutonomousOrchestrator:
         tracking_session_id: str,
     ) -> None:
         """Persist an interrupted attempt and unwind without failing its workflow."""
+        if result.error_code == "repo_integrity_violation":
+            # Shutdown must never downgrade an already-detected security
+            # violation into a retryable cancellation. The protected .git
+            # entry may have been replaced, so a new process must not adopt
+            # that state as its trusted baseline.
+            self._persist_shutdown_usage(
+                milestone_id,
+                result,
+                retry_usage,
+                usage_session_ids,
+                tracking_session_id,
+            )
+            self._abort_on_repo_integrity_violation(result, milestone_id)
+            raise WorkflowPaused("Service shutdown observed a repository integrity violation")
+
         self._cancel_milestone_for_shutdown(milestone_id)
+        self._persist_shutdown_usage(
+            milestone_id,
+            result,
+            retry_usage,
+            usage_session_ids,
+            tracking_session_id,
+        )
+        raise WorkflowPaused("Service shutdown interrupted the current attempt")
+
+    def _persist_shutdown_usage(
+        self,
+        milestone_id: str,
+        result: AgentTaskResult,
+        retry_usage: dict[str, int],
+        usage_session_ids: set[str],
+        tracking_session_id: str,
+    ) -> None:
+        """Finalize usage/session bookkeeping for either shutdown outcome."""
         self._write_phase_usage(milestone_id, result, retry_usage)
         try:
             self.repo.refresh_workflow_usage_from_sessions(self._workflow_id)
@@ -4251,7 +4284,6 @@ class AutonomousOrchestrator:
         self._clear_session_usage_offsets(usage_session_ids)
         with self._session_lock:
             self._current_session_id = tracking_session_id
-        raise WorkflowPaused("Service shutdown interrupted the current attempt")
 
     def _cancel_milestone_for_shutdown(self, milestone_id: str) -> None:
         """Best-effort milestone cancellation that cannot fail the workflow."""

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -4118,6 +4118,14 @@ class AutonomousOrchestrator:
         repo_validation_error = self._validate_repo_context_after_run(
             repo_state_before, project_system_account
         )
+        if repo_validation_error:
+            logger.error("Workflow repo validation failed: %s", repo_validation_error)
+            result.success = False
+            result.error_code = "repo_integrity_violation"
+            result.error = repo_validation_error
+        # Apply repository validation to the result before observing shutdown.
+        # Otherwise SIGTERM racing with this validation window could downgrade
+        # a newly detected integrity violation into a retryable cancellation.
         if self._is_shutdown_requested():
             self._abort_agent_run_for_shutdown(
                 milestone_id,
@@ -4126,11 +4134,6 @@ class AutonomousOrchestrator:
                 usage_session_ids,
                 tracking_session_id,
             )
-        if repo_validation_error:
-            logger.error("Workflow repo validation failed: %s", repo_validation_error)
-            result.success = False
-            result.error_code = "repo_integrity_violation"
-            result.error = repo_validation_error
         upstream_hard_quota_exhausted = self._is_upstream_hard_quota_exhausted(result)
 
         # Attribute this call's own usage to its milestone (increment, not cumulative).

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -3108,6 +3108,8 @@ class AutonomousOrchestrator:
         deadline = time.monotonic() + CI_POLL_MAX_WAIT
         last_error = ""
         while True:
+            if AutonomousOrchestrator._is_shutdown_requested(self):
+                raise WorkflowPaused("Service shutdown interrupted CI polling")
             try:
                 checks = gh.get_pr_checks(pr_number)
             except Exception as e:
@@ -3118,7 +3120,7 @@ class AutonomousOrchestrator:
                         f"Failed to query CI checks for PR #{pr_number} within "
                         f"{CI_POLL_MAX_WAIT}s: {last_error}"
                     ) from e
-                time.sleep(CI_POLL_INTERVAL)
+                AutonomousOrchestrator._wait_for_ci_poll_or_shutdown(self)
                 continue
             if not checks:
                 # No checks configured — nothing to wait for.
@@ -3140,7 +3142,16 @@ class AutonomousOrchestrator:
                 len(pending),
                 CI_POLL_INTERVAL,
             )
+            AutonomousOrchestrator._wait_for_ci_poll_or_shutdown(self)
+
+    def _wait_for_ci_poll_or_shutdown(self) -> None:
+        """Wait one CI poll interval while remaining interruptible by shutdown."""
+        shutdown_event = getattr(self, "_shutdown_requested", None)
+        if shutdown_event is None:
             time.sleep(CI_POLL_INTERVAL)
+            return
+        if shutdown_event.wait(CI_POLL_INTERVAL):
+            raise WorkflowPaused("Service shutdown interrupted CI polling")
 
     def _start_ci_repair_round(self, wf: dict, pr_number: int, failed_checks: list[dict]) -> None:
         """Repair merge-phase CI failures in-place on the existing PR branch."""
@@ -4015,20 +4026,32 @@ class AutonomousOrchestrator:
             # agent after the workflow row was paused.
             slept = 0
             self._cancel_requested.clear()
+            # Shutdown may race exactly between the loop-top check and the
+            # clear above.  The shutdown event is monotonic and authoritative;
+            # re-check it directly so clearing the shared cancel event cannot
+            # consume SIGTERM and let a new retry dispatch.
+            if self._is_shutdown_requested():
+                self._abort_agent_run_for_shutdown(
+                    milestone_id,
+                    result,
+                    retry_usage,
+                    usage_session_ids,
+                    tracking_session_id,
+                )
             while slept < delay:
                 time.sleep(min(_CANCEL_POLL_INTERVAL, delay - slept))
                 slept += _CANCEL_POLL_INTERVAL
                 if (self.workflow or {}).get("status") == "paused":
                     abort_paused_retry()
+                if self._is_shutdown_requested():
+                    self._abort_agent_run_for_shutdown(
+                        milestone_id,
+                        result,
+                        retry_usage,
+                        usage_session_ids,
+                        tracking_session_id,
+                    )
                 if self._cancel_requested.is_set():
-                    if self._is_shutdown_requested():
-                        self._abort_agent_run_for_shutdown(
-                            milestone_id,
-                            result,
-                            retry_usage,
-                            usage_session_ids,
-                            tracking_session_id,
-                        )
                     logger.info("API error retry cancelled (cancel requested)")
                     self._synthesize_transient_failure(result)
                     self._write_phase_usage(milestone_id, result, retry_usage)
@@ -4219,7 +4242,22 @@ class AutonomousOrchestrator:
         tracking_session_id: str,
     ) -> None:
         """Persist an interrupted attempt and unwind without failing its workflow."""
-        if milestone_id:
+        self._cancel_milestone_for_shutdown(milestone_id)
+        self._write_phase_usage(milestone_id, result, retry_usage)
+        try:
+            self.repo.refresh_workflow_usage_from_sessions(self._workflow_id)
+        except Exception:
+            logger.warning("Failed to refresh workflow usage during shutdown", exc_info=True)
+        self._clear_session_usage_offsets(usage_session_ids)
+        with self._session_lock:
+            self._current_session_id = tracking_session_id
+        raise WorkflowPaused("Service shutdown interrupted the current attempt")
+
+    def _cancel_milestone_for_shutdown(self, milestone_id: str) -> None:
+        """Best-effort milestone cancellation that cannot fail the workflow."""
+        if not milestone_id:
+            return
+        try:
             self.repo.update_milestone(
                 milestone_id,
                 {
@@ -4229,11 +4267,12 @@ class AutonomousOrchestrator:
                     ),
                 },
             )
-        self._write_phase_usage(milestone_id, result, retry_usage)
-        self._clear_session_usage_offsets(usage_session_ids)
-        with self._session_lock:
-            self._current_session_id = tracking_session_id
-        raise WorkflowPaused("Service shutdown interrupted the current attempt")
+        except Exception:
+            # The process is intentionally winding down. A late DB failure
+            # must not escape as a generic orchestrator error and mark the
+            # still-active workflow failed; the replacement process can
+            # reconcile the stale in-progress milestone on retry.
+            logger.warning("Failed to cancel milestone during shutdown", exc_info=True)
 
     def _write_realtime_phase_usage(self, activity: dict) -> None:
         """Write the current call's running cumulative usage to the in-progress milestone.
@@ -6731,6 +6770,8 @@ class AutonomousOrchestrator:
             if pr_number:
                 try:
                     ci_checks_post = self._poll_ci_status(gh, pr_number)
+                except WorkflowPaused:
+                    raise
                 except Exception:
                     ci_checks_post = []
                 ci_fails_post = [c for c in ci_checks_post if c.get("bucket") == "fail"]
@@ -6772,6 +6813,9 @@ class AutonomousOrchestrator:
             try:
                 ci_checks = self._poll_ci_status(gh, pr_number)
                 ci_failures = [c for c in ci_checks if c.get("bucket") == "fail"]
+            except WorkflowPaused:
+                self._cancel_milestone_for_shutdown(review_ms.get("milestone_id", ""))
+                raise
             except Exception:
                 pass
 

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -988,6 +988,10 @@ class AutonomousOrchestrator:
         # stable main/review/test session starts its next provider request.
         self._session_usage_offsets: dict[str, dict[str, int]] = {}
         self._cancel_requested = threading.Event()  # in-memory cancel signal
+        # Set only by the application shutdown path. Unlike a user stop, this
+        # interrupts the current attempt without changing the workflow's active
+        # phase/status, so the next process can retry it automatically.
+        self._shutdown_requested = threading.Event()
 
         # Wire session_manager so agent sessions are persisted to DB
         from app.modules.workspace.session_manager import SessionManager
@@ -3713,6 +3717,18 @@ class AutonomousOrchestrator:
             "request_count": 0,
         }
         usage_session_ids = {tracking_session_id}
+        if self._is_shutdown_requested():
+            self._abort_agent_run_for_shutdown(
+                milestone_id,
+                AgentTaskResult(
+                    session_id=tracking_session_id,
+                    tracking_session_id=tracking_session_id,
+                    success=False,
+                ),
+                retry_usage,
+                usage_session_ids,
+                tracking_session_id,
+            )
         if "user_id" not in kwargs and workflow_data:
             kwargs["user_id"] = workflow_data.get("user_id")
 
@@ -3851,6 +3867,18 @@ class AutonomousOrchestrator:
                 + build_language_instruction(content_language)
             )
 
+        if self._is_shutdown_requested():
+            self._abort_agent_run_for_shutdown(
+                milestone_id,
+                AgentTaskResult(
+                    session_id=tracking_session_id,
+                    tracking_session_id=tracking_session_id,
+                    success=False,
+                ),
+                retry_usage,
+                usage_session_ids,
+                tracking_session_id,
+            )
         result = self._runner.run_agent_task(**kwargs)
         if result.session_id:
             # The runner is authoritative for the tracking id it actually
@@ -3887,6 +3915,15 @@ class AutonomousOrchestrator:
                 if workflow_data is not None:
                     workflow_data[field] = tracking_session_id
 
+        if self._is_shutdown_requested():
+            self._abort_agent_run_for_shutdown(
+                milestone_id,
+                result,
+                retry_usage,
+                usage_session_ids,
+                tracking_session_id,
+            )
+
         # Transient API error retry (429 / 5xx / overload) — exponential
         # backoff, max 30 minutes total. Interruptible sleep (cancel check
         # every 5s) so the orchestrator can be paused/stopped during a wait.
@@ -3917,6 +3954,14 @@ class AutonomousOrchestrator:
             raise WorkflowPaused("Workflow paused during API error retry")
 
         while (time.monotonic() - retry_start) < API_RETRY_TOTAL_TIMEOUT:
+            if self._is_shutdown_requested():
+                self._abort_agent_run_for_shutdown(
+                    milestone_id,
+                    result,
+                    retry_usage,
+                    usage_session_ids,
+                    tracking_session_id,
+                )
             # Re-check workflow status each iteration: a failure/cancellation
             # set on the row (by a concurrent path or a prior failure in this
             # advance()) must abort retries, otherwise we keep spawning agent
@@ -3976,6 +4021,14 @@ class AutonomousOrchestrator:
                 if (self.workflow or {}).get("status") == "paused":
                     abort_paused_retry()
                 if self._cancel_requested.is_set():
+                    if self._is_shutdown_requested():
+                        self._abort_agent_run_for_shutdown(
+                            milestone_id,
+                            result,
+                            retry_usage,
+                            usage_session_ids,
+                            tracking_session_id,
+                        )
                     logger.info("API error retry cancelled (cancel requested)")
                     self._synthesize_transient_failure(result)
                     self._write_phase_usage(milestone_id, result, retry_usage)
@@ -4042,6 +4095,14 @@ class AutonomousOrchestrator:
         repo_validation_error = self._validate_repo_context_after_run(
             repo_state_before, project_system_account
         )
+        if self._is_shutdown_requested():
+            self._abort_agent_run_for_shutdown(
+                milestone_id,
+                result,
+                retry_usage,
+                usage_session_ids,
+                tracking_session_id,
+            )
         if repo_validation_error:
             logger.error("Workflow repo validation failed: %s", repo_validation_error)
             result.success = False
@@ -4143,6 +4204,36 @@ class AutonomousOrchestrator:
             offsets = getattr(self, "_session_usage_offsets", {})
             for session_id in session_ids:
                 offsets.pop(session_id, None)
+
+    def _is_shutdown_requested(self) -> bool:
+        """Support lightweight test/legacy instances constructed without ``__init__``."""
+        event = getattr(self, "_shutdown_requested", None)
+        return bool(event and event.is_set())
+
+    def _abort_agent_run_for_shutdown(
+        self,
+        milestone_id: str,
+        result: AgentTaskResult,
+        retry_usage: dict[str, int],
+        usage_session_ids: set[str],
+        tracking_session_id: str,
+    ) -> None:
+        """Persist an interrupted attempt and unwind without failing its workflow."""
+        if milestone_id:
+            self.repo.update_milestone(
+                milestone_id,
+                {
+                    "status": "cancelled",
+                    "error_message": (
+                        "Service shutdown interrupted this attempt; it will retry automatically"
+                    ),
+                },
+            )
+        self._write_phase_usage(milestone_id, result, retry_usage)
+        self._clear_session_usage_offsets(usage_session_ids)
+        with self._session_lock:
+            self._current_session_id = tracking_session_id
+        raise WorkflowPaused("Service shutdown interrupted the current attempt")
 
     def _write_realtime_phase_usage(self, activity: dict) -> None:
         """Write the current call's running cumulative usage to the in-progress milestone.
@@ -4259,6 +4350,26 @@ class AutonomousOrchestrator:
                 logger.warning("Failed to stop session %s: %s", session_id[:8], e)
             with self._session_lock:
                 self._current_session_id = None
+
+    def prepare_for_shutdown(self):
+        """Interrupt the current attempt so a replacement process can retry it."""
+        self._shutdown_requested.set()
+        self._cancel_requested.set()
+        with self._session_lock:
+            session_id = self._current_session_id
+        if session_id:
+            logger.info(
+                "Stopping agent task for service shutdown session=%s",
+                session_id[:8],
+            )
+            try:
+                self._runner.stop_session(session_id)
+            except Exception as e:
+                logger.warning(
+                    "Failed to stop shutdown session %s: %s",
+                    session_id[:8],
+                    e,
+                )
 
     def advance(self):
         """Advance the workflow one step. Called by the scheduler."""

--- a/app/services/autonomous_scheduler.py
+++ b/app/services/autonomous_scheduler.py
@@ -119,11 +119,22 @@ class AutonomousScheduler:
         logger.info("Autonomous scheduler started")
 
     def stop(self):
-        """Stop the scheduler."""
+        """Stop scheduling and drain active orchestrators before interpreter exit."""
         self._stop_event.set()
+        with self._orchestrator_lock:
+            orchestrators = list(self._running_orchestrators.values())
+        for orchestrator in orchestrators:
+            try:
+                orchestrator.prepare_for_shutdown()
+            except Exception:
+                logger.warning("Failed to prepare autonomous workflow for shutdown", exc_info=True)
         if self._thread:
-            self._thread.join(timeout=10)
-        logger.info("Autonomous scheduler stopped")
+            self._thread.join(timeout=20)
+            if self._thread.is_alive():
+                logger.warning("Autonomous scheduler did not drain before shutdown timeout")
+        logger.info(
+            "Autonomous scheduler stopped (%d active attempts interrupted)", len(orchestrators)
+        )
 
     def get_running_orchestrator(self, workflow_id: str):
         """Get the currently running orchestrator for a workflow, if any."""
@@ -294,6 +305,12 @@ class AutonomousScheduler:
             orchestrator = AutonomousOrchestrator(workflow_id)
             with self._orchestrator_lock:
                 self._running_orchestrators[workflow_id] = orchestrator
+            # stop() may race with this worker after its orchestrator snapshot.
+            # Register first, then re-check the event so no new agent task can
+            # start after graceful shutdown has begun.
+            if self._stop_event.is_set():
+                orchestrator.prepare_for_shutdown()
+                return workflow_id
             orchestrator.advance()
         except Exception as e:
             logger.error(

--- a/server.py
+++ b/server.py
@@ -115,6 +115,12 @@ if __name__ == "__main__":
 
     def _shutdown_and_stop():
         try:
+            from app.services.autonomous_scheduler import AutonomousScheduler
+
+            AutonomousScheduler.instance().stop()
+        except Exception as e:
+            print(f"Error stopping autonomous scheduler: {e}")
+        try:
             from app.services.webui_manager import shutdown_webui_manager
 
             shutdown_webui_manager()

--- a/tests/issues/1001/test_api_error_retry.py
+++ b/tests/issues/1001/test_api_error_retry.py
@@ -235,6 +235,39 @@ class TestRunAgentApiErrorRetry:
         )
         o._write_phase_usage.assert_called_once()
 
+    def test_shutdown_racing_with_post_run_validation_fails_closed(self):
+        o = _make_orchestrator(_make_workflow())
+        o._runner.run_agent_task = MagicMock(
+            return_value=AgentTaskResult(
+                session_id="sess-track",
+                tracking_session_id="sess-track",
+                success=True,
+                total_tokens=90,
+            )
+        )
+
+        def detect_violation_as_shutdown_arrives(*_args):
+            o._shutdown_requested.set()
+            return "protected Git metadata changed"
+
+        o._validate_repo_context_after_run.side_effect = detect_violation_as_shutdown_arrives
+
+        with pytest.raises(orch_module.WorkflowPaused, match="integrity violation"):
+            o._run_agent(wf=_make_workflow(), milestone_id="ms-shutdown", prompt="x")
+
+        o.repo.update_milestone.assert_called_with(
+            "ms-shutdown",
+            {
+                "status": "failed",
+                "session_id": "sess-track",
+                "error_message": "protected Git metadata changed",
+            },
+        )
+        o._update_workflow.assert_called_with(
+            {"status": "failed", "error_message": "protected Git metadata changed"}
+        )
+        o._write_phase_usage.assert_called_once()
+
     def test_shutdown_racing_with_retry_cancel_clear_never_dispatches(self, monkeypatch):
         monkeypatch.setattr("time.sleep", lambda *_args, **_kwargs: None)
         o = _make_orchestrator(_make_workflow())

--- a/tests/issues/1001/test_api_error_retry.py
+++ b/tests/issues/1001/test_api_error_retry.py
@@ -202,6 +202,39 @@ class TestRunAgentApiErrorRetry:
         o._write_phase_usage.assert_called_once()
         assert o._current_session_id == "sess-track"
 
+    def test_shutdown_never_downgrades_repo_integrity_violation(self):
+        o = _make_orchestrator(_make_workflow())
+        violation = AgentTaskResult(
+            session_id="sess-track",
+            tracking_session_id="sess-track",
+            success=False,
+            error_code="repo_integrity_violation",
+            error="protected .git entry changed",
+            total_tokens=75,
+        )
+
+        def stop_with_violation(**_kwargs):
+            o._shutdown_requested.set()
+            return violation
+
+        o._runner.run_agent_task = MagicMock(side_effect=stop_with_violation)
+
+        with pytest.raises(orch_module.WorkflowPaused, match="integrity violation"):
+            o._run_agent(wf=_make_workflow(), milestone_id="ms-shutdown", prompt="x")
+
+        o.repo.update_milestone.assert_called_with(
+            "ms-shutdown",
+            {
+                "status": "failed",
+                "session_id": "sess-track",
+                "error_message": "protected .git entry changed",
+            },
+        )
+        o._update_workflow.assert_called_with(
+            {"status": "failed", "error_message": "protected .git entry changed"}
+        )
+        o._write_phase_usage.assert_called_once()
+
     def test_shutdown_racing_with_retry_cancel_clear_never_dispatches(self, monkeypatch):
         monkeypatch.setattr("time.sleep", lambda *_args, **_kwargs: None)
         o = _make_orchestrator(_make_workflow())

--- a/tests/issues/1001/test_api_error_retry.py
+++ b/tests/issues/1001/test_api_error_retry.py
@@ -51,6 +51,27 @@ def _make_orchestrator(wf):
     o.emitter = MagicMock()
     # Stub _run_agent's collaborators so we test IT, not its dependencies.
     o._resolve_session_line = MagicMock(return_value=("sess-track", None, False))
+    o._snapshot_repo_context = MagicMock(
+        return_value={
+            "context": {
+                "repo_path": wf["worktree_path"],
+                "project_path": wf["project_path"],
+                "strategy": "worktree",
+                "expected_branch": "auto-dev/test",
+            },
+            "effective": {
+                "repo_path": wf["worktree_path"],
+                "top_level": wf["worktree_path"],
+                "git_dir": f"{wf['worktree_path']}/.git",
+                "git_identity": "1:1",
+                "common_dir": f"{wf['worktree_path']}/.git",
+                "common_identity": "1:1",
+                "origin": "git@github.com:open-ace/open-ace.git",
+            },
+        }
+    )
+    o._validate_repo_context_after_run = MagicMock(return_value="")
+    o._get_gh = MagicMock()
     o._link_session_to_current_milestone = MagicMock()
     o._write_phase_usage = MagicMock()
     o._update_workflow = MagicMock()
@@ -107,6 +128,56 @@ class TestIsTransientApiError:
 
 
 class TestRunAgentApiErrorRetry:
+    def test_shutdown_before_dispatch_does_not_launch_agent(self):
+        o = _make_orchestrator(_make_workflow())
+        o._shutdown_requested.set()
+
+        with pytest.raises(orch_module.WorkflowPaused, match="Service shutdown"):
+            o._run_agent(wf=_make_workflow(), milestone_id="ms-shutdown", prompt="x")
+
+        o._runner.run_agent_task.assert_not_called()
+        o.repo.update_milestone.assert_called_with(
+            "ms-shutdown",
+            {
+                "status": "cancelled",
+                "error_message": (
+                    "Service shutdown interrupted this attempt; it will retry automatically"
+                ),
+            },
+        )
+
+    def test_shutdown_cancels_attempt_without_returning_failure(self):
+        o = _make_orchestrator(_make_workflow())
+        result = AgentTaskResult(
+            session_id="sess-track",
+            tracking_session_id="sess-track",
+            response_text="partial result",
+            total_tokens=500,
+            success=False,
+            error="stopped",
+        )
+
+        def stop_during_run(**_kwargs):
+            o._shutdown_requested.set()
+            return result
+
+        o._runner.run_agent_task = MagicMock(side_effect=stop_during_run)
+
+        with pytest.raises(orch_module.WorkflowPaused, match="Service shutdown"):
+            o._run_agent(wf=_make_workflow(), milestone_id="ms-shutdown", prompt="x")
+
+        o.repo.update_milestone.assert_called_with(
+            "ms-shutdown",
+            {
+                "status": "cancelled",
+                "error_message": (
+                    "Service shutdown interrupted this attempt; it will retry automatically"
+                ),
+            },
+        )
+        o._write_phase_usage.assert_called_once()
+        assert o._current_session_id == "sess-track"
+
     def test_no_retry_on_normal_response(self, monkeypatch):
         monkeypatch.setattr("time.sleep", lambda *a, **k: None)
         o = _make_orchestrator(_make_workflow())

--- a/tests/issues/1001/test_api_error_retry.py
+++ b/tests/issues/1001/test_api_error_retry.py
@@ -145,6 +145,30 @@ class TestRunAgentApiErrorRetry:
                 ),
             },
         )
+        o.repo.refresh_workflow_usage_from_sessions.assert_called_once_with("test-wf-1001")
+
+    def test_shutdown_milestone_write_failure_still_unwinds_as_pause(self):
+        o = _make_orchestrator(_make_workflow())
+        o._shutdown_requested.set()
+        o.repo.update_milestone.side_effect = RuntimeError("database is closing")
+
+        with pytest.raises(orch_module.WorkflowPaused, match="Service shutdown"):
+            o._run_agent(wf=_make_workflow(), milestone_id="ms-shutdown", prompt="x")
+
+        o._runner.run_agent_task.assert_not_called()
+        o._update_workflow.assert_not_called()
+
+    def test_shutdown_interrupts_ci_poll_wait(self):
+        o = _make_orchestrator(_make_workflow())
+        o._shutdown_requested.wait = MagicMock(return_value=True)
+        gh = MagicMock()
+        gh.get_pr_checks.return_value = [{"name": "lint", "bucket": "pending"}]
+
+        with pytest.raises(orch_module.WorkflowPaused, match="CI polling"):
+            o._poll_ci_status(gh, 1966)
+
+        gh.get_pr_checks.assert_called_once_with(1966)
+        o._shutdown_requested.wait.assert_called_once_with(orch_module.CI_POLL_INTERVAL)
 
     def test_shutdown_cancels_attempt_without_returning_failure(self):
         o = _make_orchestrator(_make_workflow())
@@ -177,6 +201,34 @@ class TestRunAgentApiErrorRetry:
         )
         o._write_phase_usage.assert_called_once()
         assert o._current_session_id == "sess-track"
+
+    def test_shutdown_racing_with_retry_cancel_clear_never_dispatches(self, monkeypatch):
+        monkeypatch.setattr("time.sleep", lambda *_args, **_kwargs: None)
+        o = _make_orchestrator(_make_workflow())
+        transient = AgentTaskResult(
+            session_id="sess-track",
+            tracking_session_id="sess-track",
+            response_text="API Error: 529 [overloaded]",
+            success=True,
+        )
+        o._runner.run_agent_task = MagicMock(return_value=transient)
+
+        class ShutdownDuringClear:
+            def clear(self):
+                # Reproduce SIGTERM after the retry loop checked shutdown but
+                # before it cleared the ordinary cancellation signal.
+                o._shutdown_requested.set()
+
+            def is_set(self):
+                return False
+
+        o._cancel_requested = ShutdownDuringClear()
+
+        with pytest.raises(orch_module.WorkflowPaused, match="Service shutdown"):
+            o._run_agent(wf=_make_workflow(), milestone_id="ms-shutdown", prompt="x")
+
+        o._runner.run_agent_task.assert_called_once()
+        o._write_phase_usage.assert_called_once()
 
     def test_no_retry_on_normal_response(self, monkeypatch):
         monkeypatch.setattr("time.sleep", lambda *a, **k: None)

--- a/tests/issues/716/test_agent_runner.py
+++ b/tests/issues/716/test_agent_runner.py
@@ -14,6 +14,7 @@ from app.modules.workspace.autonomous.agent_runner import (
     _extract_cli_result_error,
     _LocalSession,
 )
+from app.modules.workspace.session_manager import AgentSession
 
 
 class TestAgentRunnerInit:
@@ -201,6 +202,7 @@ class TestAgentRunnerRunTask:
         runner = AutonomousAgentRunner()
         result = runner.run_agent_task(
             workflow_id="wf-1",
+            user_id=1,
             cli_tool="claude-code",
             model="m1",
             project_path="/tmp/test",
@@ -214,20 +216,36 @@ class TestAgentRunnerRunTask:
     def test_run_remote_success(self):
         """Test remote agent execution via mocked RemoteSessionManager."""
         rsm = MagicMock()
-        rsm.create_remote_session.return_value = {"success": True, "session_id": "rs-1"}
+        # Concrete RemoteSessionManager returns the payload directly, without
+        # a success=True wrapper.
+        rsm.create_remote_session.return_value = {"session_id": "rs-1"}
 
         sm = MagicMock()
-        sm.get_session.return_value = {
-            "status": "completed",
-            "total_tokens": 500,
-            "total_input_tokens": 300,
-            "total_output_tokens": 200,
-        }
+        tracking = AgentSession(
+            session_id="track-1",
+            session_type="workflow",
+            context={"workflow_id": "wf-1"},
+        )
+        remote = AgentSession(
+            session_id="rs-1",
+            # Reusable remote sidebar sessions remain active after a turn;
+            # request completion is carried by the buffered output entry.
+            status="active",
+            total_tokens=500,
+            total_input_tokens=300,
+            total_output_tokens=200,
+            request_count=2,
+        )
+        sm.get_session.side_effect = lambda sid: remote if sid == "rs-1" else tracking
         sm.get_messages.return_value = [
             {"role": "assistant", "content": "Task completed successfully"}
         ]
 
         runner = AutonomousAgentRunner(session_manager=sm, remote_session_manager=rsm)
+        rsm.get_session_status.return_value = {
+            "status": "active",
+            "output": [{"stream": "stdout", "is_complete": True}],
+        }
 
         with patch("time.sleep"):
             result = runner.run_agent_task(
@@ -240,6 +258,7 @@ class TestAgentRunnerRunTask:
                 workspace_type="remote",
                 remote_machine_id="machine-1",
                 timeout=5,
+                session_id="track-1",
             )
 
         assert result.success is True
@@ -248,17 +267,57 @@ class TestAgentRunnerRunTask:
         assert result.session_id == "rs-1"
         rsm.create_remote_session.assert_called_once()
         assert rsm.create_remote_session.call_args.kwargs["user_id"] == 7
-        rsm.send_message.assert_called_once_with(session_id="rs-1", message="Do something")
+        rsm.send_message.assert_called_once_with(
+            session_id="rs-1", content="Do something", user_id=7
+        )
         sm.get_session.assert_any_call("rs-1")
+        assert any(
+            call.args[0] == "track-1" and call.args[1].get("cli_session_id") == "rs-1"
+            for call in sm.update_session_fields.call_args_list
+        )
+        # Remote usage reports already own the actual row's counters.
+        sm.increment_session_usage.assert_not_called()
+
+    def test_run_remote_requires_user_id_before_creation(self):
+        rsm = MagicMock()
+        runner = AutonomousAgentRunner(session_manager=MagicMock(), remote_session_manager=rsm)
+
+        result = runner.run_agent_task(
+            workflow_id="wf-1",
+            cli_tool="claude-code",
+            model="m1",
+            project_path="/tmp/test",
+            prompt="Do something",
+            workspace_type="remote",
+            remote_machine_id="machine-1",
+        )
+
+        assert result.success is False
+        assert "User ID" in result.error
+        rsm.create_remote_session.assert_not_called()
+
+    def test_remote_abort_failed_event_is_not_successful_turn_completion(self):
+        assert not AutonomousAgentRunner._remote_turn_complete(
+            {
+                "output": [
+                    {
+                        "stream": "request_state",
+                        "is_complete": True,
+                        "data": '{"type":"abort_failed"}',
+                    }
+                ]
+            }
+        )
 
     def test_run_remote_creation_failure(self):
         """Remote session creation failure."""
         rsm = MagicMock()
         rsm.create_remote_session.return_value = {"success": False, "error": "Machine offline"}
 
-        runner = AutonomousAgentRunner(remote_session_manager=rsm)
+        runner = AutonomousAgentRunner(session_manager=MagicMock(), remote_session_manager=rsm)
         result = runner.run_agent_task(
             workflow_id="wf-1",
+            user_id=1,
             cli_tool="claude-code",
             model="m1",
             project_path="/tmp/test",
@@ -864,6 +923,56 @@ class TestStopSession:
 
         assert session._stopped.is_set()
         assert session.completed.is_set()
+
+    def test_shutdown_during_remote_creation_stops_actual_before_prompt(self):
+        create_started = threading.Event()
+        allow_create_to_finish = threading.Event()
+        remote_manager = MagicMock()
+
+        def create_remote_session(**_kwargs):
+            create_started.set()
+            assert allow_create_to_finish.wait(timeout=2)
+            return {"session_id": "remote-actual-race"}
+
+        remote_manager.create_remote_session.side_effect = create_remote_session
+        session_manager = MagicMock()
+        session_manager.get_session.return_value = AgentSession(
+            session_id="remote-actual-race",
+            status="active",
+        )
+        runner = AutonomousAgentRunner(
+            session_manager=session_manager,
+            remote_session_manager=remote_manager,
+        )
+        result_box = {}
+
+        def run_remote():
+            result_box["result"] = runner._run_remote(
+                session_id="tracking-race",
+                user_id=8,
+                cli_tool="claude-code",
+                model="m1",
+                project_path="/tmp/test",
+                prompt="must not dispatch",
+                remote_machine_id="machine-1",
+                permission_mode="auto-edit",
+                timeout=5,
+            )
+
+        worker = threading.Thread(target=run_remote)
+        worker.start()
+        assert create_started.wait(timeout=2)
+        runner.stop_session("tracking-race")
+        allow_create_to_finish.set()
+        worker.join(timeout=2)
+
+        assert not worker.is_alive()
+        assert result_box["result"].success is False
+        remote_manager.send_message.assert_not_called()
+        assert any(
+            call.args[0] == "remote-actual-race"
+            for call in remote_manager.stop_session.call_args_list
+        )
 
 
 class TestPersistLocalSessionMessages:

--- a/tests/issues/716/test_agent_runner.py
+++ b/tests/issues/716/test_agent_runner.py
@@ -232,6 +232,7 @@ class TestAgentRunnerRunTask:
         with patch("time.sleep"):
             result = runner.run_agent_task(
                 workflow_id="wf-1",
+                user_id=7,
                 cli_tool="claude-code",
                 model="m1",
                 project_path="/tmp/test",
@@ -244,6 +245,11 @@ class TestAgentRunnerRunTask:
         assert result.success is True
         assert "Task completed" in result.response_text
         assert result.total_tokens == 500
+        assert result.session_id == "rs-1"
+        rsm.create_remote_session.assert_called_once()
+        assert rsm.create_remote_session.call_args.kwargs["user_id"] == 7
+        rsm.send_message.assert_called_once_with(session_id="rs-1", message="Do something")
+        sm.get_session.assert_any_call("rs-1")
 
     def test_run_remote_creation_failure(self):
         """Remote session creation failure."""
@@ -830,6 +836,34 @@ class TestStopSession:
         runner = AutonomousAgentRunner()
         # Should not raise
         runner.stop_session("nonexistent")
+
+    def test_stop_remote_session_marks_tracker_and_notifies_manager(self):
+        remote_manager = MagicMock()
+        runner = AutonomousAgentRunner(remote_session_manager=remote_manager)
+        session = _LocalSession(
+            session_id="remote-1",
+            process=None,
+            persisted_session_id="remote-actual-1",
+        )
+        runner._local_sessions["remote-1"] = session
+
+        runner.stop_session("remote-1")
+
+        remote_manager.stop_session.assert_called_once_with("remote-actual-1")
+        assert session._stopped.is_set()
+        assert session.completed.is_set()
+
+    def test_stop_remote_session_still_drains_when_manager_fails(self):
+        remote_manager = MagicMock()
+        remote_manager.stop_session.side_effect = RuntimeError("remote unavailable")
+        runner = AutonomousAgentRunner(remote_session_manager=remote_manager)
+        session = _LocalSession(session_id="remote-2", process=None)
+        runner._local_sessions["remote-2"] = session
+
+        runner.stop_session("remote-2")
+
+        assert session._stopped.is_set()
+        assert session.completed.is_set()
 
 
 class TestPersistLocalSessionMessages:

--- a/tests/issues/716/test_scheduler.py
+++ b/tests/issues/716/test_scheduler.py
@@ -1,6 +1,7 @@
 """Unit tests for AutonomousScheduler."""
 
 import threading
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -38,6 +39,30 @@ class TestSchedulerStartStop:
         scheduler._stop_event.clear()
         scheduler.stop()
         assert scheduler._stop_event.is_set()
+
+    def test_stop_interrupts_active_orchestrators_before_join(self):
+        scheduler = AutonomousScheduler()
+        orchestrator = MagicMock()
+        scheduler._running_orchestrators = {"wf-1": orchestrator}
+        thread = MagicMock()
+        thread.is_alive.return_value = False
+        scheduler._thread = thread
+
+        scheduler.stop()
+
+        orchestrator.prepare_for_shutdown.assert_called_once_with()
+        thread.join.assert_called_once_with(timeout=20)
+
+    def test_server_shutdown_stops_autonomous_scheduler(self):
+        server_source = (Path(__file__).resolve().parents[3] / "server.py").read_text(
+            encoding="utf-8"
+        )
+
+        scheduler_stop = server_source.index("AutonomousScheduler.instance().stop()")
+        webui_stop = server_source.index("shutdown_webui_manager()")
+        server_stop = server_source.index("server.stop()")
+
+        assert scheduler_stop < webui_stop < server_stop
 
     def test_start_creates_daemon_thread(self):
         scheduler = AutonomousScheduler()
@@ -101,6 +126,29 @@ class TestSchedulerProcessWorkflows:
 
                 assert mock_orch_cls.call_count == 2
                 assert mock_orch.advance.call_count == 2
+
+    def test_worker_created_during_shutdown_never_advances(self):
+        scheduler = AutonomousScheduler()
+        scheduler._stop_event.set()
+        mock_repo = MagicMock()
+        mock_repo.get_workflow.return_value = {
+            "workflow_id": "wf-race",
+            "status": "planning",
+        }
+        mock_repo.acquire_lock.return_value = True
+
+        with (
+            patch("app.routes.autonomous._get_repo", return_value=mock_repo),
+            patch(
+                "app.modules.workspace.autonomous.orchestrator.AutonomousOrchestrator"
+            ) as orchestrator_cls,
+        ):
+            orchestrator = orchestrator_cls.return_value
+            scheduler._advance_single("wf-race")
+
+        orchestrator.prepare_for_shutdown.assert_called_once_with()
+        orchestrator.advance.assert_not_called()
+        mock_repo.release_lock.assert_called_once()
 
     def test_skips_paused_workflows(self):
         scheduler = AutonomousScheduler()

--- a/tests/issues/740/test_batch1_session_wiring.py
+++ b/tests/issues/740/test_batch1_session_wiring.py
@@ -367,6 +367,7 @@ class TestRemoteNullGuard:
 
         result = runner._run_remote(
             session_id="remote-sess-1",
+            user_id=1,
             cli_tool="claude-code",
             model="test-model",
             project_path="/tmp/test",
@@ -404,6 +405,7 @@ class TestRemoteNullGuard:
 
         result = runner._run_remote(
             session_id="remote-sess-2",
+            user_id=1,
             cli_tool="claude-code",
             model="test-model",
             project_path="/tmp/test",
@@ -427,6 +429,7 @@ class TestRemoteNullGuard:
 
         result = runner._run_remote(
             session_id="remote-sess-3",
+            user_id=1,
             cli_tool="claude-code",
             model="test-model",
             project_path="/tmp/test",
@@ -473,6 +476,7 @@ class TestRemoteNullGuard:
 
         result = runner._run_remote(
             session_id="remote-sess-cancel",
+            user_id=1,
             cli_tool="claude-code",
             model="test-model",
             project_path="/tmp/test",


### PR DESCRIPTION
## Summary

- stop and drain active autonomous orchestrators before the Python interpreter exits
- mark only the interrupted milestone as cancelled while leaving the workflow phase active for automatic retry after restart
- preserve partial usage and block new agent dispatches once shutdown begins
- wire the autonomous scheduler into the existing SIGTERM/SIGINT shutdown sequence

## Production root cause

During deployment, issue-1894 finished an agent response while the Python interpreter was shutting down. Post-run repository validation tried to spawn Git and raised `can't fork at interpreter shutdown`; the plan-refine milestone and entire workflow were then marked failed. The scheduler previously stopped only at interpreter finalization and did not drain active orchestrators.

## Verification

- 40 focused shutdown / retry / scheduler / guardrail tests passed
- Black, isort, Ruff and `git diff --check` passed
- complete repository commit hooks passed

## Baseline note

The broader legacy `tests/issues/716/test_orchestrator.py` currently has pre-existing mock incompatibilities with the recently tightened repo-scope security checks on main; the shutdown-specific tests and existing scheduler/retry suites are green.