### PR TITLE
fix(autonomous): recognize passing pytest reruns

### DIFF
--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -324,21 +324,25 @@ def _normalize_test_command(command: str) -> str:
     return re.sub(r"\s+2>\&1\s*$", "", normalized).strip()
 
 
-def _pytest_test_scope(command: str) -> frozenset[str] | None:
-    """Return pytest selectors, or ``None`` for a full-suite invocation.
+_PytestScope = tuple[str, frozenset[str]]
 
-    An empty frozenset means the command is too complex for safe scope
-    comparison.  This lets a later passing superset rerun clear earlier
-    failures for the same files while ensuring a targeted pass can never clear
+
+def _pytest_test_scope(command: str) -> _PytestScope | None:
+    """Return the pytest execution context and selectors when safely comparable.
+
+    ``None`` means the command is too complex for safe scope comparison.  An
+    empty selector set means a full-suite invocation.  This lets a later
+    passing superset rerun clear earlier failures for the same files while
+    ensuring a targeted pass or a different Python environment can never clear
     a failed full-suite command.
     """
     normalized = _normalize_test_command(command)
     if any(operator in normalized for operator in ("&&", "||", ";", "|")):
-        return frozenset()
+        return None
     try:
         tokens = shlex.split(normalized)
     except ValueError:
-        return frozenset()
+        return None
 
     pytest_index = -1
     for index, token in enumerate(tokens):
@@ -346,7 +350,7 @@ def _pytest_test_scope(command: str) -> frozenset[str] | None:
             pytest_index = index
             break
     if pytest_index < 0:
-        return frozenset()
+        return None
 
     # Only compare scopes when the invocation prefix has ordinary pytest
     # semantics.  Environment assignments and wrappers can change collection
@@ -359,7 +363,10 @@ def _pytest_test_scope(command: str) -> frozenset[str] | None:
             or prefix[1] != "-m"
             or re.fullmatch(r"python(?:\d+(?:\.\d+)*)?", python_name) is None
         ):
-            return frozenset()
+            return None
+        execution_context = f"{prefix[0]} -m {tokens[pytest_index]}"
+    else:
+        execution_context = tokens[pytest_index]
 
     scope_narrowing_options = {
         "-k",
@@ -422,7 +429,7 @@ def _pytest_test_scope(command: str) -> frozenset[str] | None:
         if not selectors_only and token.startswith("-"):
             option_name = token.split("=", 1)[0]
             if option_name in scope_narrowing_options:
-                return frozenset()
+                return None
             if token in safe_flags:
                 index += 1
                 continue
@@ -430,28 +437,32 @@ def _pytest_test_scope(command: str) -> frozenset[str] | None:
                 if "=" not in token:
                     index += 1
                     if index >= len(args):
-                        return frozenset()
+                        return None
                 index += 1
                 continue
             # Plugin and future pytest options are unknown here.  Exact-command
             # retries remain supported, but cross-command scope coverage is not.
-            return frozenset()
+            return None
         selectors.add(token.rstrip("/") or ".")
         index += 1
 
-    return frozenset(selectors) if selectors else None
+    return execution_context, frozenset(selectors)
 
 
 def _pytest_scope_covers(
-    passing_scope: frozenset[str] | None,
-    earlier_scope: frozenset[str] | None,
+    passing_scope: _PytestScope | None,
+    earlier_scope: _PytestScope | None,
 ) -> bool:
     """Whether a passing pytest command covers an earlier command's scope."""
-    if earlier_scope == frozenset() or passing_scope == frozenset():
+    if passing_scope is None or earlier_scope is None:
         return False
-    if passing_scope is None:
+    passing_context, passing_selectors = passing_scope
+    earlier_context, earlier_selectors = earlier_scope
+    if passing_context != earlier_context:
+        return False
+    if not passing_selectors:
         return True
-    if earlier_scope is None:
+    if not earlier_selectors:
         return False
 
     def _selector_covers(passing: str, earlier: str) -> bool:
@@ -466,8 +477,8 @@ def _pytest_scope_covers(
         return "::" not in passing and earlier_path.startswith(f"{passing_path}/")
 
     return all(
-        any(_selector_covers(passing, earlier) for passing in passing_scope)
-        for earlier in earlier_scope
+        any(_selector_covers(passing, earlier) for passing in passing_selectors)
+        for earlier in earlier_selectors
     )
 
 
@@ -478,8 +489,8 @@ def _has_passing_test_tool_result(event_log: list, framework_type: str) -> bool:
     the same normalized command.  This deliberately prevents a failing full
     suite followed by one passing targeted test from opening a PR.
     """
-    test_tools: dict[str, tuple[str, frozenset[str] | None]] = {}
-    anonymous_test_calls: list[tuple[str, frozenset[str] | None]] = []
+    test_tools: dict[str, tuple[str, _PytestScope | None]] = {}
+    anonymous_test_calls: list[tuple[str, _PytestScope | None]] = []
     for event in event_log or []:
         if not isinstance(event, dict) or event.get("type") != "tool_use":
             continue
@@ -501,14 +512,14 @@ def _has_passing_test_tool_result(event_log: list, framework_type: str) -> bool:
                     or ""
                 )
             command_key = _normalize_test_command(command) or (f"tool:{event.get('tool_name', '')}")
-            scope = _pytest_test_scope(command) if framework_type == "python" else frozenset()
+            scope = _pytest_test_scope(command) if framework_type == "python" else None
             if tool_id:
                 test_tools[tool_id] = (command_key, scope)
             else:
                 anonymous_test_calls.append((command_key, scope))
 
     states: dict[str, bool] = {}
-    scopes: dict[str, frozenset[str] | None] = {}
+    scopes: dict[str, _PytestScope | None] = {}
     result_orders: dict[str, int] = {}
     anonymous_index = 0
     for event_order, event in enumerate(event_log or []):
@@ -577,7 +588,7 @@ def _has_passing_test_tool_result(event_log: list, framework_type: str) -> bool:
     for command_key in expected_commands:
         if states.get(command_key) is True:
             continue
-        earlier_scope = scopes.get(command_key, frozenset())
+        earlier_scope = scopes.get(command_key)
         earlier_order = result_orders.get(command_key, -1)
         if framework_type != "python" or not any(
             passing_order > earlier_order and _pytest_scope_covers(passing_scope, earlier_scope)

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -490,58 +490,36 @@ def _has_passing_test_tool_result(event_log: list, framework_type: str) -> bool:
     suite followed by one passing targeted test from opening a PR.
     """
     test_tools: dict[str, tuple[str, _PytestScope | None]] = {}
-    anonymous_tool_calls: list[tuple[str, _PytestScope | None] | None] = []
-    for event in event_log or []:
-        if not isinstance(event, dict) or event.get("type") != "tool_use":
-            continue
-        tool_id = str(event.get("tool_use_id") or "")
+    states: dict[str, bool] = {}
+    scopes: dict[str, _PytestScope | None] = {}
+    result_orders: dict[str, int] = {}
+    expected_commands: set[str] = set()
+    anonymous_pending: tuple[str, _PytestScope | None] | None = None
+    anonymous_has_pending = False
+    anonymous_evidence_ambiguous = False
+
+    def _command_info(event: dict) -> tuple[str, _PytestScope | None] | None:
         as_tool_call = {
             "tool": {
                 "name": event.get("tool_name", ""),
                 "input": event.get("tool_input", {}),
             }
         }
-        command_info = None
-        if _has_test_tool_call([as_tool_call], framework_type):
-            tool_input = event.get("tool_input") or {}
-            command = ""
-            if isinstance(tool_input, dict):
-                command = str(
-                    tool_input.get("command")
-                    or tool_input.get("cmd")
-                    or tool_input.get("args")
-                    or ""
-                )
-            command_key = _normalize_test_command(command) or (f"tool:{event.get('tool_name', '')}")
-            scope = _pytest_test_scope(command) if framework_type == "python" else None
-            command_info = (command_key, scope)
-            if tool_id:
-                test_tools[tool_id] = command_info
-        if not tool_id:
-            # Preserve every anonymous call's position.  Otherwise an unrelated
-            # anonymous result can be paired with the next pytest invocation,
-            # potentially turning a real failure into a false pass.
-            anonymous_tool_calls.append(command_info)
+        if not _has_test_tool_call([as_tool_call], framework_type):
+            return None
+        tool_input = event.get("tool_input") or {}
+        command = ""
+        if isinstance(tool_input, dict):
+            command = str(
+                tool_input.get("command") or tool_input.get("cmd") or tool_input.get("args") or ""
+            )
+        command_key = _normalize_test_command(command) or f"tool:{event.get('tool_name', '')}"
+        scope = _pytest_test_scope(command) if framework_type == "python" else None
+        return command_key, scope
 
-    states: dict[str, bool] = {}
-    scopes: dict[str, _PytestScope | None] = {}
-    result_orders: dict[str, int] = {}
-    anonymous_index = 0
-    for event_order, event in enumerate(event_log or []):
-        if not isinstance(event, dict) or event.get("type") != "tool_result":
-            continue
-        tool_id = str(event.get("tool_use_id") or "")
-        if tool_id:
-            command_info = test_tools.get(tool_id)
-            if not command_info:
-                continue
-        else:
-            if anonymous_index >= len(anonymous_tool_calls):
-                continue
-            command_info = anonymous_tool_calls[anonymous_index]
-            anonymous_index += 1
-            if command_info is None:
-                continue
+    def _record_result(
+        command_info: tuple[str, _PytestScope | None], event: dict, event_order: int
+    ) -> None:
         command_key, scope = command_info
         text = str(event.get("text") or "")
         exit_code = event.get("exit_code")
@@ -576,22 +554,48 @@ def _has_passing_test_tool_result(event_log: list, framework_type: str) -> bool:
         scopes[command_key] = scope
         result_orders[command_key] = event_order
 
-    expected_commands = {command_key for command_key, _scope in test_tools.values()} | {
-        command_key
-        for command_info in anonymous_tool_calls
-        if command_info is not None
-        for command_key, _scope in (command_info,)
-    }
+    for event_order, event in enumerate(event_log or []):
+        if not isinstance(event, dict):
+            continue
+        event_type = event.get("type")
+        if event_type == "tool_use":
+            tool_id = str(event.get("tool_use_id") or "")
+            command_info = _command_info(event)
+            if command_info is not None:
+                command_key, scope = command_info
+                expected_commands.add(command_key)
+                scopes.setdefault(command_key, scope)
+            if tool_id:
+                if command_info is not None:
+                    test_tools[tool_id] = command_info
+                continue
+            if anonymous_has_pending:
+                # Without IDs, overlapping calls cannot be paired safely.  Do
+                # not trust any anonymous result in this event stream.
+                anonymous_evidence_ambiguous = True
+            anonymous_pending = command_info
+            anonymous_has_pending = True
+            continue
+        if event_type != "tool_result":
+            continue
+
+        tool_id = str(event.get("tool_use_id") or "")
+        if tool_id:
+            command_info = test_tools.get(tool_id)
+            if not command_info:
+                continue
+        else:
+            if not anonymous_has_pending:
+                continue
+            command_info = anonymous_pending
+            anonymous_pending = None
+            anonymous_has_pending = False
+            if anonymous_evidence_ambiguous or command_info is None:
+                continue
+        _record_result(command_info, event, event_order)
+
     if not expected_commands:
         return False
-
-    for command_key, scope in test_tools.values():
-        scopes.setdefault(command_key, scope)
-    for command_info in anonymous_tool_calls:
-        if command_info is None:
-            continue
-        command_key, scope = command_info
-        scopes.setdefault(command_key, scope)
 
     passing_commands = [
         (command_key, scopes.get(command_key), result_orders.get(command_key, -1))

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -485,20 +485,25 @@ def _pytest_scope_covers(
 def _has_passing_test_tool_result(event_log: list, framework_type: str) -> bool:
     """Require conclusive success for every distinct test command in this run.
 
-    A later successful retry only supersedes an earlier failure when it reruns
-    the same normalized command.  This deliberately prevents a failing full
-    suite followed by one passing targeted test from opening a PR.
+    A later successful retry can supersede an earlier failure only when it
+    reruns the same normalized command or a safely comparable pytest superset.
+    Every new invocation resets its command to pending, so stale success from
+    before a code change cannot satisfy an interrupted rerun.
     """
-    test_tools: dict[str, tuple[str, _PytestScope | None]] = {}
+    _CommandInfo = tuple[str, _PytestScope | None]
+    _Invocation = tuple[_CommandInfo, int]
+
+    test_tools: dict[str, _Invocation] = {}
     states: dict[str, bool] = {}
     scopes: dict[str, _PytestScope | None] = {}
-    result_orders: dict[str, int] = {}
+    state_orders: dict[str, int] = {}
+    latest_invocation_orders: dict[str, int] = {}
     expected_commands: set[str] = set()
-    anonymous_pending: tuple[str, _PytestScope | None] | None = None
+    anonymous_pending: _Invocation | None = None
     anonymous_has_pending = False
     anonymous_evidence_ambiguous = False
 
-    def _command_info(event: dict) -> tuple[str, _PytestScope | None] | None:
+    def _command_info(event: dict) -> _CommandInfo | None:
         as_tool_call = {
             "tool": {
                 "name": event.get("tool_name", ""),
@@ -517,10 +522,13 @@ def _has_passing_test_tool_result(event_log: list, framework_type: str) -> bool:
         scope = _pytest_test_scope(command) if framework_type == "python" else None
         return command_key, scope
 
-    def _record_result(
-        command_info: tuple[str, _PytestScope | None], event: dict, event_order: int
-    ) -> None:
+    def _record_result(invocation: _Invocation, event: dict, event_order: int) -> None:
+        command_info, invocation_order = invocation
         command_key, scope = command_info
+        if latest_invocation_orders.get(command_key) != invocation_order:
+            # A newer invocation of this command is pending or has completed;
+            # an out-of-order result from an older call must not replace it.
+            return
         text = str(event.get("text") or "")
         exit_code = event.get("exit_code")
         explicit_error = bool(event.get("is_error")) or (
@@ -552,7 +560,7 @@ def _has_passing_test_tool_result(event_log: list, framework_type: str) -> bool:
         )
         states[command_key] = not explicit_error and not has_failure and has_pass
         scopes[command_key] = scope
-        result_orders[command_key] = event_order
+        state_orders[command_key] = event_order
 
     for event_order, event in enumerate(event_log or []):
         if not isinstance(event, dict):
@@ -564,16 +572,22 @@ def _has_passing_test_tool_result(event_log: list, framework_type: str) -> bool:
             if command_info is not None:
                 command_key, scope = command_info
                 expected_commands.add(command_key)
-                scopes.setdefault(command_key, scope)
+                scopes[command_key] = scope
+                states[command_key] = False
+                state_orders[command_key] = event_order
+                latest_invocation_orders[command_key] = event_order
+                invocation = (command_info, event_order)
+            else:
+                invocation = None
             if tool_id:
-                if command_info is not None:
-                    test_tools[tool_id] = command_info
+                if invocation is not None:
+                    test_tools[tool_id] = invocation
                 continue
             if anonymous_has_pending:
                 # Without IDs, overlapping calls cannot be paired safely.  Do
                 # not trust any anonymous result in this event stream.
                 anonymous_evidence_ambiguous = True
-            anonymous_pending = command_info
+            anonymous_pending = invocation
             anonymous_has_pending = True
             continue
         if event_type != "tool_result":
@@ -581,24 +595,24 @@ def _has_passing_test_tool_result(event_log: list, framework_type: str) -> bool:
 
         tool_id = str(event.get("tool_use_id") or "")
         if tool_id:
-            command_info = test_tools.get(tool_id)
-            if not command_info:
+            invocation = test_tools.get(tool_id)
+            if not invocation:
                 continue
         else:
             if not anonymous_has_pending:
                 continue
-            command_info = anonymous_pending
+            invocation = anonymous_pending
             anonymous_pending = None
             anonymous_has_pending = False
-            if anonymous_evidence_ambiguous or command_info is None:
+            if anonymous_evidence_ambiguous or invocation is None:
                 continue
-        _record_result(command_info, event, event_order)
+        _record_result(invocation, event, event_order)
 
     if not expected_commands:
         return False
 
     passing_commands = [
-        (command_key, scopes.get(command_key), result_orders.get(command_key, -1))
+        (command_key, scopes.get(command_key), state_orders.get(command_key, -1))
         for command_key, passed in states.items()
         if passed
     ]
@@ -606,7 +620,7 @@ def _has_passing_test_tool_result(event_log: list, framework_type: str) -> bool:
         if states.get(command_key) is True:
             continue
         earlier_scope = scopes.get(command_key)
-        earlier_order = result_orders.get(command_key, -1)
+        earlier_order = state_orders.get(command_key, -1)
         if framework_type != "python" or not any(
             passing_order > earlier_order and _pytest_scope_covers(passing_scope, earlier_scope)
             for _passing_key, passing_scope, passing_order in passing_commands

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -13,6 +13,7 @@ import logging
 import os
 import pwd
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -295,6 +296,99 @@ def _has_test_tool_call(tool_calls: list, framework_type: str) -> bool:
     return False
 
 
+_TEST_OUTPUT_FILTER_RE = re.compile(
+    r"(?:\s+2>\&1)?\s*\|\s*(?:head|tail)(?:\s+-[^\s]+|\s+\d+)*\s*$",
+    re.IGNORECASE,
+)
+
+
+def _normalize_test_command(command: str) -> str:
+    """Return a stable identity for a test command across output-only filters.
+
+    Autonomous agents commonly run ``pytest ... | head -100`` while exploring
+    a failure and rerun the same target as ``pytest ... | tail -20`` after the
+    fix.  Those filters change only which output is displayed, not the tests
+    executed.  Treating the two strings as distinct left the truncated first
+    run permanently inconclusive even when the later rerun passed.
+
+    Strip only trailing ``head``/``tail`` pipelines (and their adjacent stderr
+    merge).  Execution-affecting shell operators such as ``&&``/``||`` and
+    pytest selectors/options remain part of the identity.
+    """
+    normalized = " ".join(str(command or "").split())
+    while True:
+        stripped = _TEST_OUTPUT_FILTER_RE.sub("", normalized).strip()
+        if stripped == normalized:
+            break
+        normalized = stripped
+    return re.sub(r"\s+2>\&1\s*$", "", normalized).strip()
+
+
+def _pytest_test_scope(command: str) -> frozenset[str] | None:
+    """Return pytest selectors, or ``None`` for a full-suite invocation.
+
+    An empty frozenset means the command is too complex for safe scope
+    comparison.  This lets a later passing superset rerun clear earlier
+    failures for the same files while ensuring a targeted pass can never clear
+    a failed full-suite command.
+    """
+    normalized = _normalize_test_command(command)
+    if any(operator in normalized for operator in ("&&", "||", ";", "|")):
+        return frozenset()
+    try:
+        tokens = shlex.split(normalized)
+    except ValueError:
+        return frozenset()
+
+    pytest_index = -1
+    for index, token in enumerate(tokens):
+        if os.path.basename(token) in {"pytest", "py.test"}:
+            pytest_index = index
+            break
+    if pytest_index < 0:
+        return frozenset()
+
+    selectors = {
+        token.rstrip("/") or "."
+        for token in tokens[pytest_index + 1 :]
+        if not token.startswith("-")
+        and (
+            token in {".", "test", "tests"}
+            or "/" in token
+            or "::" in token
+            or token.endswith(".py")
+        )
+    }
+    return frozenset(selectors) if selectors else None
+
+
+def _pytest_scope_covers(
+    passing_scope: frozenset[str] | None,
+    earlier_scope: frozenset[str] | None,
+) -> bool:
+    """Whether a passing pytest command covers an earlier command's scope."""
+    if earlier_scope == frozenset() or passing_scope == frozenset():
+        return False
+    if passing_scope is None:
+        return True
+    if earlier_scope is None:
+        return False
+
+    def _selector_covers(passing: str, earlier: str) -> bool:
+        if passing == earlier:
+            return True
+        passing_path = passing.split("::", 1)[0].rstrip("/")
+        earlier_path = earlier.split("::", 1)[0].rstrip("/")
+        if "::" not in passing and passing_path == earlier_path:
+            return True
+        return "::" not in passing and earlier_path.startswith(f"{passing_path}/")
+
+    return all(
+        any(_selector_covers(passing, earlier) for passing in passing_scope)
+        for earlier in earlier_scope
+    )
+
+
 def _has_passing_test_tool_result(event_log: list, framework_type: str) -> bool:
     """Require conclusive success for every distinct test command in this run.
 
@@ -302,8 +396,8 @@ def _has_passing_test_tool_result(event_log: list, framework_type: str) -> bool:
     the same normalized command.  This deliberately prevents a failing full
     suite followed by one passing targeted test from opening a PR.
     """
-    test_tools: dict[str, str] = {}
-    anonymous_test_calls: list[str] = []
+    test_tools: dict[str, tuple[str, frozenset[str] | None]] = {}
+    anonymous_test_calls: list[tuple[str, frozenset[str] | None]] = []
     for event in event_log or []:
         if not isinstance(event, dict) or event.get("type") != "tool_use":
             continue
@@ -324,27 +418,31 @@ def _has_passing_test_tool_result(event_log: list, framework_type: str) -> bool:
                     or tool_input.get("args")
                     or ""
                 )
-            command_key = " ".join(command.split()) or f"tool:{event.get('tool_name', '')}"
+            command_key = _normalize_test_command(command) or (f"tool:{event.get('tool_name', '')}")
+            scope = _pytest_test_scope(command) if framework_type == "python" else frozenset()
             if tool_id:
-                test_tools[tool_id] = command_key
+                test_tools[tool_id] = (command_key, scope)
             else:
-                anonymous_test_calls.append(command_key)
+                anonymous_test_calls.append((command_key, scope))
 
     states: dict[str, bool] = {}
+    scopes: dict[str, frozenset[str] | None] = {}
+    result_orders: dict[str, int] = {}
     anonymous_index = 0
-    for event in event_log or []:
+    for event_order, event in enumerate(event_log or []):
         if not isinstance(event, dict) or event.get("type") != "tool_result":
             continue
         tool_id = str(event.get("tool_use_id") or "")
         if tool_id:
-            command_key = test_tools.get(tool_id)
-            if not command_key:
+            command_info = test_tools.get(tool_id)
+            if not command_info:
                 continue
         else:
             if anonymous_index >= len(anonymous_test_calls):
                 continue
-            command_key = anonymous_test_calls[anonymous_index]
+            command_info = anonymous_test_calls[anonymous_index]
             anonymous_index += 1
+        command_key, scope = command_info
         text = str(event.get("text") or "")
         exit_code = event.get("exit_code")
         explicit_error = bool(event.get("is_error")) or (
@@ -375,11 +473,36 @@ def _has_passing_test_tool_result(event_log: list, framework_type: str) -> bool:
             )
         )
         states[command_key] = not explicit_error and not has_failure and has_pass
+        scopes[command_key] = scope
+        result_orders[command_key] = event_order
 
-    expected_commands = set(test_tools.values()) | set(anonymous_test_calls)
-    return bool(expected_commands) and all(
-        states.get(command) is True for command in expected_commands
-    )
+    expected_commands = {command_key for command_key, _scope in test_tools.values()} | {
+        command_key for command_key, _scope in anonymous_test_calls
+    }
+    if not expected_commands:
+        return False
+
+    for command_key, scope in test_tools.values():
+        scopes.setdefault(command_key, scope)
+    for command_key, scope in anonymous_test_calls:
+        scopes.setdefault(command_key, scope)
+
+    passing_commands = [
+        (command_key, scopes.get(command_key), result_orders.get(command_key, -1))
+        for command_key, passed in states.items()
+        if passed
+    ]
+    for command_key in expected_commands:
+        if states.get(command_key) is True:
+            continue
+        earlier_scope = scopes.get(command_key, frozenset())
+        earlier_order = result_orders.get(command_key, -1)
+        if framework_type != "python" or not any(
+            passing_order > earlier_order and _pytest_scope_covers(passing_scope, earlier_scope)
+            for _passing_key, passing_scope, passing_order in passing_commands
+        ):
+            return False
+    return True
 
 
 # Prefix added to all prompts to inform the agent it is running autonomously

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -348,17 +348,97 @@ def _pytest_test_scope(command: str) -> frozenset[str] | None:
     if pytest_index < 0:
         return frozenset()
 
-    selectors = {
-        token.rstrip("/") or "."
-        for token in tokens[pytest_index + 1 :]
-        if not token.startswith("-")
-        and (
-            token in {".", "test", "tests"}
-            or "/" in token
-            or "::" in token
-            or token.endswith(".py")
-        )
+    # Only compare scopes when the invocation prefix has ordinary pytest
+    # semantics.  Environment assignments and wrappers can change collection
+    # even when the visible selectors are identical.
+    prefix = tokens[:pytest_index]
+    if prefix:
+        python_name = os.path.basename(prefix[0])
+        if (
+            len(prefix) != 2
+            or prefix[1] != "-m"
+            or re.fullmatch(r"python(?:\d+(?:\.\d+)*)?", python_name) is None
+        ):
+            return frozenset()
+
+    scope_narrowing_options = {
+        "-k",
+        "-m",
+        "--ignore",
+        "--ignore-glob",
+        "--deselect",
+        "--lf",
+        "--last-failed",
+        "--ff",
+        "--failed-first",
+        "--nf",
+        "--new-first",
+        "--sw",
+        "--stepwise",
+        "--stepwise-skip",
     }
+    safe_flags = {
+        "-q",
+        "--quiet",
+        "-v",
+        "-vv",
+        "--verbose",
+        "-s",
+        "-x",
+        "--exitfirst",
+        "--disable-warnings",
+        "--strict-config",
+        "--strict-markers",
+        "--continue-on-collection-errors",
+        "--full-trace",
+        "--showlocals",
+        "-l",
+        "--no-header",
+        "--no-summary",
+    }
+    safe_value_options = {
+        "--tb",
+        "--color",
+        "--capture",
+        "--durations",
+        "--durations-min",
+        "--junitxml",
+        "--junit-prefix",
+        "--basetemp",
+        "--verbosity",
+        "--maxfail",
+    }
+
+    selectors: set[str] = set()
+    args = tokens[pytest_index + 1 :]
+    index = 0
+    selectors_only = False
+    while index < len(args):
+        token = args[index]
+        if token == "--":
+            selectors_only = True
+            index += 1
+            continue
+        if not selectors_only and token.startswith("-"):
+            option_name = token.split("=", 1)[0]
+            if option_name in scope_narrowing_options:
+                return frozenset()
+            if token in safe_flags:
+                index += 1
+                continue
+            if option_name in safe_value_options:
+                if "=" not in token:
+                    index += 1
+                    if index >= len(args):
+                        return frozenset()
+                index += 1
+                continue
+            # Plugin and future pytest options are unknown here.  Exact-command
+            # retries remain supported, but cross-command scope coverage is not.
+            return frozenset()
+        selectors.add(token.rstrip("/") or ".")
+        index += 1
+
     return frozenset(selectors) if selectors else None
 
 
@@ -376,6 +456,8 @@ def _pytest_scope_covers(
 
     def _selector_covers(passing: str, earlier: str) -> bool:
         if passing == earlier:
+            return True
+        if passing in {".", "./"}:
             return True
         passing_path = passing.split("::", 1)[0].rstrip("/")
         earlier_path = earlier.split("::", 1)[0].rstrip("/")

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -490,18 +490,19 @@ def _has_passing_test_tool_result(event_log: list, framework_type: str) -> bool:
     suite followed by one passing targeted test from opening a PR.
     """
     test_tools: dict[str, tuple[str, _PytestScope | None]] = {}
-    anonymous_test_calls: list[tuple[str, _PytestScope | None]] = []
+    anonymous_tool_calls: list[tuple[str, _PytestScope | None] | None] = []
     for event in event_log or []:
         if not isinstance(event, dict) or event.get("type") != "tool_use":
             continue
+        tool_id = str(event.get("tool_use_id") or "")
         as_tool_call = {
             "tool": {
                 "name": event.get("tool_name", ""),
                 "input": event.get("tool_input", {}),
             }
         }
+        command_info = None
         if _has_test_tool_call([as_tool_call], framework_type):
-            tool_id = str(event.get("tool_use_id") or "")
             tool_input = event.get("tool_input") or {}
             command = ""
             if isinstance(tool_input, dict):
@@ -513,10 +514,14 @@ def _has_passing_test_tool_result(event_log: list, framework_type: str) -> bool:
                 )
             command_key = _normalize_test_command(command) or (f"tool:{event.get('tool_name', '')}")
             scope = _pytest_test_scope(command) if framework_type == "python" else None
+            command_info = (command_key, scope)
             if tool_id:
-                test_tools[tool_id] = (command_key, scope)
-            else:
-                anonymous_test_calls.append((command_key, scope))
+                test_tools[tool_id] = command_info
+        if not tool_id:
+            # Preserve every anonymous call's position.  Otherwise an unrelated
+            # anonymous result can be paired with the next pytest invocation,
+            # potentially turning a real failure into a false pass.
+            anonymous_tool_calls.append(command_info)
 
     states: dict[str, bool] = {}
     scopes: dict[str, _PytestScope | None] = {}
@@ -531,10 +536,12 @@ def _has_passing_test_tool_result(event_log: list, framework_type: str) -> bool:
             if not command_info:
                 continue
         else:
-            if anonymous_index >= len(anonymous_test_calls):
+            if anonymous_index >= len(anonymous_tool_calls):
                 continue
-            command_info = anonymous_test_calls[anonymous_index]
+            command_info = anonymous_tool_calls[anonymous_index]
             anonymous_index += 1
+            if command_info is None:
+                continue
         command_key, scope = command_info
         text = str(event.get("text") or "")
         exit_code = event.get("exit_code")
@@ -570,14 +577,20 @@ def _has_passing_test_tool_result(event_log: list, framework_type: str) -> bool:
         result_orders[command_key] = event_order
 
     expected_commands = {command_key for command_key, _scope in test_tools.values()} | {
-        command_key for command_key, _scope in anonymous_test_calls
+        command_key
+        for command_info in anonymous_tool_calls
+        if command_info is not None
+        for command_key, _scope in (command_info,)
     }
     if not expected_commands:
         return False
 
     for command_key, scope in test_tools.values():
         scopes.setdefault(command_key, scope)
-    for command_key, scope in anonymous_test_calls:
+    for command_info in anonymous_tool_calls:
+        if command_info is None:
+            continue
+        command_key, scope = command_info
         scopes.setdefault(command_key, scope)
 
     passing_commands = [

--- a/tests/unit/test_autonomous_ci_guardrails.py
+++ b/tests/unit/test_autonomous_ci_guardrails.py
@@ -938,6 +938,44 @@ def test_test_evidence_different_pytest_context_does_not_cover_failure(
     assert not _has_passing_test_tool_result(events, "python")
 
 
+@pytest.mark.parametrize(
+    ("test_output", "test_exit_code", "expected"),
+    [
+        ("1 failed in 0.2s", 1, False),
+        ("1 passed in 0.2s", 0, True),
+    ],
+)
+def test_test_evidence_pairs_anonymous_results_with_all_tool_calls(
+    test_output, test_exit_code, expected
+):
+    from app.modules.workspace.autonomous.orchestrator import _has_passing_test_tool_result
+
+    events = [
+        {
+            "type": "tool_use",
+            "tool_name": "Read",
+            "tool_input": {"file_path": "test-summary.txt"},
+        },
+        {
+            "type": "tool_result",
+            "text": "Historical note: 1 passed",
+            "exit_code": 0,
+        },
+        {
+            "type": "tool_use",
+            "tool_name": "Bash",
+            "tool_input": {"command": "python -m pytest tests/test_a.py -q"},
+        },
+        {
+            "type": "tool_result",
+            "text": test_output,
+            "exit_code": test_exit_code,
+        },
+    ]
+
+    assert _has_passing_test_tool_result(events, "python") is expected
+
+
 def test_test_evidence_targeted_pass_does_not_cover_failed_full_suite():
     from app.modules.workspace.autonomous.orchestrator import _has_passing_test_tool_result
 

--- a/tests/unit/test_autonomous_ci_guardrails.py
+++ b/tests/unit/test_autonomous_ci_guardrails.py
@@ -847,6 +847,49 @@ def test_test_evidence_earlier_passing_superset_does_not_clear_later_failure():
     assert not _has_passing_test_tool_result(events, "python")
 
 
+@pytest.mark.parametrize(
+    "restricted_command",
+    [
+        "python -m pytest tests/test_a.py -q -k passing_case",
+        "python -m pytest tests -q --ignore tests/test_a.py",
+        "ONLY_FAST=1 python -m pytest tests/test_a.py -q",
+    ],
+)
+def test_test_evidence_restricted_pass_does_not_cover_earlier_failure(
+    restricted_command,
+):
+    from app.modules.workspace.autonomous.orchestrator import _has_passing_test_tool_result
+
+    events = [
+        {
+            "type": "tool_use",
+            "tool_name": "Bash",
+            "tool_input": {"command": "python -m pytest tests/test_a.py -q"},
+            "tool_use_id": "file-failed",
+        },
+        {
+            "type": "tool_result",
+            "tool_use_id": "file-failed",
+            "text": "1 failed, 1 passed in 0.4s",
+            "exit_code": 1,
+        },
+        {
+            "type": "tool_use",
+            "tool_name": "Bash",
+            "tool_input": {"command": restricted_command},
+            "tool_use_id": "restricted-pass",
+        },
+        {
+            "type": "tool_result",
+            "tool_use_id": "restricted-pass",
+            "text": "1 passed in 0.2s",
+            "exit_code": 0,
+        },
+    ]
+
+    assert not _has_passing_test_tool_result(events, "python")
+
+
 def test_test_evidence_targeted_pass_does_not_cover_failed_full_suite():
     from app.modules.workspace.autonomous.orchestrator import _has_passing_test_tool_result
 

--- a/tests/unit/test_autonomous_ci_guardrails.py
+++ b/tests/unit/test_autonomous_ci_guardrails.py
@@ -976,6 +976,38 @@ def test_test_evidence_pairs_anonymous_results_with_all_tool_calls(
     assert _has_passing_test_tool_result(events, "python") is expected
 
 
+@pytest.mark.parametrize(
+    "events",
+    [
+        [
+            {
+                "type": "tool_use",
+                "tool_name": "Bash",
+                "tool_input": {"command": "python -m pytest tests/test_a.py -q"},
+            },
+            {
+                "type": "tool_use",
+                "tool_name": "Read",
+                "tool_input": {"file_path": "old-results.txt"},
+            },
+            {"type": "tool_result", "text": "Historical: 1 passed", "exit_code": 0},
+        ],
+        [
+            {"type": "tool_result", "text": "Historical: 1 passed", "exit_code": 0},
+            {
+                "type": "tool_use",
+                "tool_name": "Bash",
+                "tool_input": {"command": "python -m pytest tests/test_a.py -q"},
+            },
+        ],
+    ],
+)
+def test_test_evidence_rejects_incomplete_or_out_of_order_anonymous_events(events):
+    from app.modules.workspace.autonomous.orchestrator import _has_passing_test_tool_result
+
+    assert not _has_passing_test_tool_result(events, "python")
+
+
 def test_test_evidence_targeted_pass_does_not_cover_failed_full_suite():
     from app.modules.workspace.autonomous.orchestrator import _has_passing_test_tool_result
 

--- a/tests/unit/test_autonomous_ci_guardrails.py
+++ b/tests/unit/test_autonomous_ci_guardrails.py
@@ -1008,6 +1008,60 @@ def test_test_evidence_rejects_incomplete_or_out_of_order_anonymous_events(event
     assert not _has_passing_test_tool_result(events, "python")
 
 
+@pytest.mark.parametrize("tool_id", ["named-run", None])
+def test_test_evidence_new_invocation_invalidates_stale_pass(tool_id):
+    from app.modules.workspace.autonomous.orchestrator import _has_passing_test_tool_result
+
+    first_use = {
+        "type": "tool_use",
+        "tool_name": "Bash",
+        "tool_input": {"command": "python -m pytest tests/test_a.py -q"},
+    }
+    first_result = {
+        "type": "tool_result",
+        "text": "1 passed in 0.2s",
+        "exit_code": 0,
+    }
+    second_use = {
+        "type": "tool_use",
+        "tool_name": "Bash",
+        "tool_input": {"command": "python -m pytest tests/test_a.py -q"},
+    }
+    if tool_id is not None:
+        first_use["tool_use_id"] = tool_id
+        first_result["tool_use_id"] = tool_id
+        second_use["tool_use_id"] = tool_id
+
+    assert not _has_passing_test_tool_result([first_use, first_result, second_use], "python")
+
+
+def test_test_evidence_older_named_result_cannot_resolve_newer_invocation():
+    from app.modules.workspace.autonomous.orchestrator import _has_passing_test_tool_result
+
+    events = [
+        {
+            "type": "tool_use",
+            "tool_name": "Bash",
+            "tool_input": {"command": "python -m pytest tests/test_a.py -q"},
+            "tool_use_id": "older",
+        },
+        {
+            "type": "tool_use",
+            "tool_name": "Bash",
+            "tool_input": {"command": "python -m pytest tests/test_a.py -q"},
+            "tool_use_id": "newer",
+        },
+        {
+            "type": "tool_result",
+            "tool_use_id": "older",
+            "text": "1 passed in 0.2s",
+            "exit_code": 0,
+        },
+    ]
+
+    assert not _has_passing_test_tool_result(events, "python")
+
+
 def test_test_evidence_targeted_pass_does_not_cover_failed_full_suite():
     from app.modules.workspace.autonomous.orchestrator import _has_passing_test_tool_result
 

--- a/tests/unit/test_autonomous_ci_guardrails.py
+++ b/tests/unit/test_autonomous_ci_guardrails.py
@@ -733,6 +733,153 @@ def test_test_evidence_requires_every_distinct_command_to_pass():
     assert not _has_passing_test_tool_result(events, "python")
 
 
+def test_test_evidence_treats_head_and_tail_as_same_pytest_rerun():
+    from app.modules.workspace.autonomous.orchestrator import _has_passing_test_tool_result
+
+    events = [
+        {
+            "type": "tool_use",
+            "tool_name": "Bash",
+            "tool_input": {
+                "command": (
+                    "python -m pytest tests/unit/test_insights_service.py "
+                    "-v --tb=short 2>&1 | head -100"
+                )
+            },
+            "tool_use_id": "truncated",
+        },
+        {
+            "type": "tool_result",
+            "tool_use_id": "truncated",
+            "text": "================ test session starts ================",
+            "exit_code": 0,
+        },
+        {
+            "type": "tool_use",
+            "tool_name": "Bash",
+            "tool_input": {
+                "command": (
+                    "python -m pytest tests/unit/test_insights_service.py "
+                    "-v --tb=short 2>&1 | tail -20"
+                )
+            },
+            "tool_use_id": "rerun",
+        },
+        {
+            "type": "tool_result",
+            "tool_use_id": "rerun",
+            "text": "49 passed in 0.47s",
+            "exit_code": 0,
+        },
+    ]
+
+    assert _has_passing_test_tool_result(events, "python")
+
+
+def test_test_evidence_accepts_later_passing_pytest_superset():
+    from app.modules.workspace.autonomous.orchestrator import _has_passing_test_tool_result
+
+    events = [
+        {
+            "type": "tool_use",
+            "tool_name": "Bash",
+            "tool_input": {"command": "python -m pytest tests/test_a.py tests/test_b.py -v"},
+            "tool_use_id": "group-failed",
+        },
+        {
+            "type": "tool_result",
+            "tool_use_id": "group-failed",
+            "text": "1 failed, 1 passed in 0.4s",
+            "exit_code": 1,
+        },
+        {
+            "type": "tool_use",
+            "tool_name": "Bash",
+            "tool_input": {
+                "command": (
+                    "python -m pytest tests/test_a.py tests/test_b.py tests/test_c.py "
+                    "-v 2>&1 | tail -10"
+                )
+            },
+            "tool_use_id": "final-matrix",
+        },
+        {
+            "type": "tool_result",
+            "tool_use_id": "final-matrix",
+            "text": "3 passed in 0.8s",
+            "exit_code": 0,
+        },
+    ]
+
+    assert _has_passing_test_tool_result(events, "python")
+
+
+def test_test_evidence_earlier_passing_superset_does_not_clear_later_failure():
+    from app.modules.workspace.autonomous.orchestrator import _has_passing_test_tool_result
+
+    events = [
+        {
+            "type": "tool_use",
+            "tool_name": "Bash",
+            "tool_input": {"command": "python -m pytest tests/test_a.py tests/test_b.py -q"},
+            "tool_use_id": "matrix-passed",
+        },
+        {
+            "type": "tool_result",
+            "tool_use_id": "matrix-passed",
+            "text": "2 passed in 0.4s",
+            "exit_code": 0,
+        },
+        {
+            "type": "tool_use",
+            "tool_name": "Bash",
+            "tool_input": {"command": "python -m pytest tests/test_a.py -q"},
+            "tool_use_id": "later-failure",
+        },
+        {
+            "type": "tool_result",
+            "tool_use_id": "later-failure",
+            "text": "1 failed in 0.2s",
+            "exit_code": 1,
+        },
+    ]
+
+    assert not _has_passing_test_tool_result(events, "python")
+
+
+def test_test_evidence_targeted_pass_does_not_cover_failed_full_suite():
+    from app.modules.workspace.autonomous.orchestrator import _has_passing_test_tool_result
+
+    events = [
+        {
+            "type": "tool_use",
+            "tool_name": "Bash",
+            "tool_input": {"command": "python -m pytest -q"},
+            "tool_use_id": "full-suite",
+        },
+        {
+            "type": "tool_result",
+            "tool_use_id": "full-suite",
+            "text": "1 failed, 200 passed",
+            "exit_code": 1,
+        },
+        {
+            "type": "tool_use",
+            "tool_name": "Bash",
+            "tool_input": {"command": "python -m pytest tests/test_one.py -q"},
+            "tool_use_id": "targeted",
+        },
+        {
+            "type": "tool_result",
+            "tool_use_id": "targeted",
+            "text": "1 passed",
+            "exit_code": 0,
+        },
+    ]
+
+    assert not _has_passing_test_tool_result(events, "python")
+
+
 def test_test_evidence_accepts_common_framework_success_summaries():
     from app.modules.workspace.autonomous.orchestrator import _has_passing_test_tool_result
 

--- a/tests/unit/test_autonomous_ci_guardrails.py
+++ b/tests/unit/test_autonomous_ci_guardrails.py
@@ -890,6 +890,54 @@ def test_test_evidence_restricted_pass_does_not_cover_earlier_failure(
     assert not _has_passing_test_tool_result(events, "python")
 
 
+@pytest.mark.parametrize(
+    ("failed_command", "passing_command"),
+    [
+        (
+            "python3.10 -m pytest tests/test_a.py -q",
+            "python3.12 -m pytest tests/test_a.py tests/test_b.py -q",
+        ),
+        (
+            "pytest tests/test_a.py -q",
+            "python -m pytest tests/test_a.py tests/test_b.py -q",
+        ),
+    ],
+)
+def test_test_evidence_different_pytest_context_does_not_cover_failure(
+    failed_command, passing_command
+):
+    from app.modules.workspace.autonomous.orchestrator import _has_passing_test_tool_result
+
+    events = [
+        {
+            "type": "tool_use",
+            "tool_name": "Bash",
+            "tool_input": {"command": failed_command},
+            "tool_use_id": "failed-context",
+        },
+        {
+            "type": "tool_result",
+            "tool_use_id": "failed-context",
+            "text": "1 failed, 1 passed in 0.4s",
+            "exit_code": 1,
+        },
+        {
+            "type": "tool_use",
+            "tool_name": "Bash",
+            "tool_input": {"command": passing_command},
+            "tool_use_id": "passing-context",
+        },
+        {
+            "type": "tool_result",
+            "tool_use_id": "passing-context",
+            "text": "3 passed in 0.3s",
+            "exit_code": 0,
+        },
+    ]
+
+    assert not _has_passing_test_tool_result(events, "python")
+
+
 def test_test_evidence_targeted_pass_does_not_cover_failed_full_suite():
     from app.modules.workspace.autonomous.orchestrator import _has_passing_test_tool_result
 


### PR DESCRIPTION
## Summary

- normalize pytest commands across trailing `head`/`tail` output filters
- allow a later passing pytest superset to supersede earlier failed or truncated subset runs
- preserve strict ordering and scope guards so an earlier pass or a targeted pass cannot clear a later/full-suite failure

## Root cause

Issue #1894 ran and reported a successful final matrix (`170 passed`), but the autonomous test gate retained earlier command variants such as `pytest ... | head -100` and `pytest ... | tail -20` as separate unresolved executions. It also could not recognize that the later passing matrix covered earlier failed grouped subsets. The workflow therefore exhausted all three test attempts with an inconclusive-evidence error despite real passing test results.

## Impact

Autonomous workflows can proceed when a genuine later pytest rerun conclusively covers earlier failures. The gate still requires structured tool results and rejects targeted passes after a failed full suite, complex shell pipelines, nonzero exits, and later failures.

## Validation

- `pytest tests/unit/test_autonomous_ci_guardrails.py tests/issues/716/test_agent_runner.py tests/issues/1001/test_api_error_retry.py -q` — 106 passed
- pre-commit on both changed files — all hooks passed
- extended suite baseline comparison: 24 failures in `tests/issues/716/test_orchestrator.py` reproduce unchanged on clean `bd6c79ed`; they are unrelated to this patch

## Independent review

An independent agent will review the final patch and publish its findings before this PR is merged.
