### PR TITLE
fix(autonomous): recover oversized review sessions

### DIFF
--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -7324,6 +7324,19 @@ class AutonomousOrchestrator:
             return
 
         review_text = self._artifact_text(review_result)
+        if not review_text.strip():
+            message = "PR review agent returned no result"
+            self.repo.update_milestone(
+                review_ms.get("milestone_id", ""),
+                {
+                    "status": "failed",
+                    "review_content": "",
+                    "review_session_id": review_result.session_id,
+                    "error_message": message,
+                },
+            )
+            self._update_workflow({"status": "failed", "error_message": message})
+            return
         # Detect approval using the language-aware marker, then persist a
         # structured verdict so progress_reported doesn't re-scan review text.
         # The legacy zh marker is accepted too, for workflows whose content
@@ -7461,6 +7474,18 @@ class AutonomousOrchestrator:
                 self._update_workflow({"status": "failed", "error_message": message})
                 return
             summary_text = self._artifact_text(summary_result)
+            if not summary_text.strip():
+                message = "PR review summary agent returned no result"
+                self.repo.update_milestone(
+                    summary_ms.get("milestone_id", ""),
+                    {
+                        "status": "failed",
+                        "review_content": "",
+                        "error_message": message,
+                    },
+                )
+                self._update_workflow({"status": "failed", "error_message": message})
+                return
             self.repo.update_milestone(
                 summary_ms.get("milestone_id", ""),
                 {
@@ -7646,8 +7671,8 @@ class AutonomousOrchestrator:
         diff_stats = {}
         try:
             commit_sha = gh.get_current_commit()
-        except Exception:
-            pass
+        except Exception as exc:
+            return fail_fix(f"Unable to inspect branch HEAD after PR review fix: {exc}", fix_result)
         sha_changed = commit_before and commit_sha and commit_before != commit_sha
         if not sha_changed:
             try:
@@ -7658,9 +7683,12 @@ class AutonomousOrchestrator:
                         no_verify=True,
                     )
                     commit_sha = gh.get_current_commit()
+                    if not commit_sha or commit_sha == commit_before:
+                        raise RuntimeError("review-fix commit did not advance branch HEAD")
                     sha_changed = True
             except Exception as e:
                 logger.warning("Fix auto-commit failed: %s", e)
+                return fail_fix(f"Unable to commit PR review fix: {e}", fix_result)
 
         # Track push failure to decide milestone status and avoid misleading comment
         push_failed = False

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -3942,6 +3942,58 @@ class AutonomousOrchestrator:
         visible = (result.response_text or "").strip()
         return bool(re.match(r"^API Error:\s*400\b", visible, re.IGNORECASE))
 
+    def _run_agent_with_context_recovery(
+        self,
+        wf: dict,
+        *,
+        session_line: str,
+        milestone_id: str = "",
+        **kwargs,
+    ) -> AgentTaskResult:
+        """Retry one overflowing stable session on a new session-line head.
+
+        Main/review/test remain the workflow's three logical session lines,
+        but a provider context limit can make an established line impossible
+        to resume. Rotate only that line once and retry the same self-contained
+        prompt without history. The rejected attempt is accounted here; the
+        caller accounts the returned final attempt as usual.
+        """
+        result = self._run_agent(
+            wf=wf,
+            session_line=session_line,
+            milestone_id=milestone_id,
+            **kwargs,
+        )
+        if not self._is_context_overflow(result):
+            return result
+
+        field = SESSION_LINE_FIELDS.get(session_line)
+        if not field:
+            return result
+
+        self._accumulate_tokens(result)
+        logger.warning(
+            "Session line %s exceeded provider context; rotating it and retrying once",
+            session_line,
+        )
+        self._update_workflow(
+            {
+                field: "",
+                "agent_session_id": "",
+                "agent_pid": None,
+            }
+        )
+        retry_wf = dict(wf)
+        retry_wf[field] = ""
+        retry_wf["agent_session_id"] = ""
+        retry_wf["agent_pid"] = None
+        return self._run_agent(
+            wf=retry_wf,
+            session_line=session_line,
+            milestone_id=milestone_id,
+            **kwargs,
+        )
+
     def _run_agent(
         self, wf: dict = None, *, session_line: str = "fresh", milestone_id: str = "", **kwargs
     ) -> AgentTaskResult:
@@ -7179,7 +7231,7 @@ class AutonomousOrchestrator:
                 "如果是预先存在的问题，在审查结论中明确说明。"
             )
 
-        review_result = self._run_agent(
+        review_result = self._run_agent_with_context_recovery(
             wf=wf,
             workflow_id=self._workflow_id,
             cli_tool=review_tool,
@@ -7199,6 +7251,22 @@ class AutonomousOrchestrator:
         if self._abort_on_repo_integrity_violation(
             review_result, review_ms.get("milestone_id", "")
         ):
+            return
+
+        if not review_result.success or self._is_context_overflow(review_result):
+            message = (
+                "PR review agent failed: "
+                f"{review_result.error or self._artifact_text(review_result) or 'no result'}"
+            )
+            self.repo.update_milestone(
+                review_ms.get("milestone_id", ""),
+                {
+                    "status": "failed",
+                    "review_session_id": review_result.session_id,
+                    "error_message": message,
+                },
+            )
+            self._update_workflow({"status": "failed", "error_message": message})
             return
 
         review_text = self._artifact_text(review_result)
@@ -7244,9 +7312,15 @@ class AutonomousOrchestrator:
         # the cap ends the loop. There is never an (N+1)-th review.
         at_cap = round_num >= max_rounds
         if not review_passed:
-            self._apply_pr_review_fix(
+            fix_succeeded = self._apply_pr_review_fix(
                 wf, gh, review_text, round_num, dev_round, ci_failures, pr_number
             )
+            if not fix_succeeded:
+                return
+            # Context recovery may have rotated the main session line during
+            # the fix. The cap-round summary runs in this same scheduler call,
+            # so refresh before it resumes main again.
+            wf = self.workflow
 
         if (review_passed and not force_full_rounds) or at_cap:
             # All PR review rounds completed — summarize via the main session,
@@ -7296,7 +7370,7 @@ class AutonomousOrchestrator:
                 "如果审查意见已全部落实、无遗留问题，请明确说明'可以合并'。"
                 "直接输出总结，不要添加引导文字。"
             )
-            summary_result = self._run_agent(
+            summary_result = self._run_agent_with_context_recovery(
                 wf=wf,
                 workflow_id=self._workflow_id,
                 cli_tool=wf.get("cli_tool", "claude-code"),
@@ -7316,6 +7390,21 @@ class AutonomousOrchestrator:
             if self._abort_on_repo_integrity_violation(
                 summary_result, summary_ms.get("milestone_id", "")
             ):
+                return
+            if not summary_result.success or self._is_context_overflow(summary_result):
+                message = (
+                    "PR review summary agent failed: "
+                    f"{summary_result.error or self._artifact_text(summary_result) or 'no result'}"
+                )
+                self.repo.update_milestone(
+                    summary_ms.get("milestone_id", ""),
+                    {
+                        "status": "failed",
+                        "review_content": "",
+                        "error_message": message,
+                    },
+                )
+                self._update_workflow({"status": "failed", "error_message": message})
                 return
             summary_text = self._artifact_text(summary_result)
             self.repo.update_milestone(
@@ -7375,7 +7464,7 @@ class AutonomousOrchestrator:
         dev_round: int,
         ci_failures: list,
         pr_number,
-    ) -> None:
+    ) -> bool:
         """Apply one round of code-review fixes (pr_updated milestone).
 
         Runs for every non-passing review — including the cap round — so the
@@ -7427,7 +7516,7 @@ class AutonomousOrchestrator:
         except Exception:
             pass
 
-        fix_result = self._run_agent(
+        fix_result = self._run_agent_with_context_recovery(
             wf=wf,
             workflow_id=self._workflow_id,
             cli_tool=wf.get("cli_tool", "claude-code"),
@@ -7445,7 +7534,24 @@ class AutonomousOrchestrator:
         self._accumulate_tokens(fix_result)
 
         if self._abort_on_repo_integrity_violation(fix_result, fix_ms.get("milestone_id", "")):
-            return
+            return False
+
+        if self._is_context_overflow(fix_result):
+            message = (
+                "PR review fix failed after context recovery: "
+                f"{fix_result.error or self._artifact_text(fix_result) or 'no result'}"
+            )
+            self.repo.update_milestone(
+                fix_ms.get("milestone_id", ""),
+                {
+                    "status": "failed",
+                    "session_id": fix_result.session_id,
+                    "error_message": message,
+                    "result_summary": "",
+                },
+            )
+            self._update_workflow({"status": "failed", "error_message": message})
+            return False
 
         # Clear user feedback after it has been injected into the prompt
         if wf.get("user_feedback", "").strip():
@@ -7532,7 +7638,7 @@ class AutonomousOrchestrator:
                     "error_message": f"Review fix was not pushed: {push_error_msg}",
                 }
             )
-            return
+            return False
         else:
             self.repo.update_milestone(
                 fix_ms.get("milestone_id", ""),
@@ -7565,6 +7671,7 @@ class AutonomousOrchestrator:
             ):
                 comment += "\n> ⚠️ 部分 CI 检查失败，但经分析为预先存在的问题，非本 PR 引入。\n"
             self._post_github_comment(gh, pr_number, comment, is_pr=True, context="fix")
+        return True
 
     # ── Phase: Report ───────────────────────────────────────────────
 
@@ -8020,10 +8127,21 @@ class AutonomousOrchestrator:
             # failure, abandoning merge without ever invoking the AI resolver.
             combined_output = f"{merge_result.stdout}\n{merge_result.stderr}"
             if merge_result.returncode != 0:
-                if "CONFLICT" not in combined_output:
-                    raise GitHubOpsError(
-                        f"git merge failed (non-conflict): {merge_result.stderr.strip()}"
+                # Locale-dependent git builds may print "CONFLICT" translated.
+                # The index is authoritative: any unmerged path has a U-stage
+                # entry regardless of stdout/stderr language.
+                has_conflict_marker = "CONFLICT" in combined_output
+                if not has_conflict_marker:
+                    unmerged_result = wt_gh._run_git(
+                        ["diff", "--name-only", "--diff-filter=U"], check=False
                     )
+                    unmerged_output = getattr(unmerged_result, "stdout", "")
+                    has_conflict_marker = isinstance(unmerged_output, str) and bool(
+                        unmerged_output.strip()
+                    )
+                if not has_conflict_marker:
+                    detail = combined_output.strip() or f"exit code {merge_result.returncode}"
+                    raise GitHubOpsError(f"git merge failed (non-conflict): {detail}")
 
                 # Ask AI agent to resolve conflicts inside the temp worktree.
                 conflict_prompt = (

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -3950,13 +3950,14 @@ class AutonomousOrchestrator:
         milestone_id: str = "",
         **kwargs,
     ) -> AgentTaskResult:
-        """Retry one overflowing stable session on a new session-line head.
+        """Retry one overflowing stable line without creating a fourth session.
 
-        Main/review/test remain the workflow's three logical session lines,
-        but a provider context limit can make an established line impossible
-        to resume. Rotate only that line once and retry the same self-contained
-        prompt without history. The rejected attempt is accounted here; the
-        caller accounts the returned final attempt as usual.
+        The workflow's main/review/test tracking ids are permanent identities.
+        When a provider transcript is too large, clear only that tracking row's
+        provider mapping and run the same self-contained prompt without resume.
+        The runner then rebinds the new provider transcript to the SAME tracking
+        row. Usage from the rejected attempt is carried into the retry's final
+        milestone write; the caller accounts the returned result as usual.
         """
         result = self._run_agent(
             wf=wf,
@@ -3971,31 +3972,69 @@ class AutonomousOrchestrator:
         if not field:
             return result
 
+        prior_usage = {
+            "total_tokens": int(result.total_tokens or 0),
+            "total_input_tokens": int(result.total_input_tokens or 0),
+            "total_output_tokens": int(result.total_output_tokens or 0),
+            "request_count": int(result.request_count or 0),
+        }
         self._accumulate_tokens(result)
         logger.warning(
-            "Session line %s exceeded provider context; rotating it and retrying once",
+            "Session line %s exceeded provider context; rebinding it and retrying once",
             session_line,
         )
-        self._update_workflow(
-            {
-                field: "",
-                "agent_session_id": "",
-                "agent_pid": None,
-            }
-        )
-        retry_wf = dict(wf)
-        retry_wf[field] = ""
-        retry_wf["agent_session_id"] = ""
-        retry_wf["agent_pid"] = None
+        tracking_session_id = ((wf or {}).get(field) or "").strip()
+        if not tracking_session_id:
+            tracking_session_id = ((self.workflow or {}).get(field) or "").strip()
+        session_manager = getattr(self._runner, "session_manager", None)
+        if tracking_session_id and session_manager is not None:
+            try:
+                session_row = session_manager.get_session(tracking_session_id) or {}
+                context = getattr(session_row, "context", None)
+                if not isinstance(context, dict):
+                    context = (
+                        session_row.get("context", {}) if isinstance(session_row, dict) else {}
+                    )
+                context = dict(context or {})
+                context.pop("cli_session_id", None)
+                if not session_manager.update_session_fields(
+                    tracking_session_id,
+                    {
+                        "cli_session_id": "",
+                        "context": context,
+                        "status": "active",
+                    },
+                ):
+                    raise RuntimeError("tracking session row was not updated")
+            except Exception as exc:
+                logger.error(
+                    "Failed to clear provider context for session line %s",
+                    session_line,
+                    exc_info=True,
+                )
+                result.success = False
+                result.error = f"Context recovery could not rebind {session_line} session: {exc}"
+                return result
+
+        self._update_workflow({"agent_session_id": "", "agent_pid": None})
         return self._run_agent(
-            wf=retry_wf,
+            wf=wf,
             session_line=session_line,
             milestone_id=milestone_id,
+            force_fresh=True,
+            prior_usage=prior_usage,
             **kwargs,
         )
 
     def _run_agent(
-        self, wf: dict = None, *, session_line: str = "fresh", milestone_id: str = "", **kwargs
+        self,
+        wf: dict = None,
+        *,
+        session_line: str = "fresh",
+        milestone_id: str = "",
+        force_fresh: bool = False,
+        prior_usage: dict[str, int] | None = None,
+        **kwargs,
     ) -> AgentTaskResult:
         """Run an agent task with session-line tracking and transient-API-error retry.
 
@@ -4006,25 +4045,40 @@ class AutonomousOrchestrator:
                 "review", "test" (resumed across milestones via --resume), or
                 "fresh" (a brand-new one-off session).
             milestone_id: Milestone to attribute this call's phase usage to.
+            force_fresh: Start a new provider transcript while retaining a
+                named line's stable tracking id.
+            prior_usage: Usage from a preceding attempt that belongs to the
+                same milestone and must be included in the final phase totals.
         """
         workflow_data = wf or self.workflow
         field = SESSION_LINE_FIELDS.get(session_line)
 
         # Resolve the session line: resume an established session or start new.
-        session_id, resume_session_id, resume = self._resolve_session_line(
-            workflow_data, session_line
-        )
+        # Context recovery forces a fresh provider transcript while retaining
+        # the named line's stable tracking id.
+        if force_fresh and field:
+            session_id = ((workflow_data or {}).get(field) or "").strip()
+            if not session_id:
+                session_id = ((self.workflow or {}).get(field) or "").strip()
+            session_id = session_id or str(uuid.uuid4())
+            resume_session_id = None
+            resume = False
+        else:
+            session_id, resume_session_id, resume = self._resolve_session_line(
+                workflow_data, session_line
+            )
         kwargs["session_id"] = session_id
         kwargs["resume"] = resume
         kwargs["resume_session_id"] = resume_session_id
         if milestone_id:
             kwargs["milestone_id"] = milestone_id
         tracking_session_id = session_id
+        prior_usage = prior_usage or {}
         retry_usage = {
-            "total_tokens": 0,
-            "total_input_tokens": 0,
-            "total_output_tokens": 0,
-            "request_count": 0,
+            "total_tokens": int(prior_usage.get("total_tokens", 0) or 0),
+            "total_input_tokens": int(prior_usage.get("total_input_tokens", 0) or 0),
+            "total_output_tokens": int(prior_usage.get("total_output_tokens", 0) or 0),
+            "request_count": int(prior_usage.get("request_count", 0) or 0),
         }
         usage_session_ids = {tracking_session_id}
         if self._is_shutdown_requested():
@@ -7479,6 +7533,22 @@ class AutonomousOrchestrator:
             title=f"PR fixes round {round_num}",
         )
 
+        def fail_fix(message: str, result: AgentTaskResult | None = None) -> bool:
+            """Fail closed before the orchestrator stages or pushes anything."""
+            self.repo.update_milestone(
+                fix_ms.get("milestone_id", ""),
+                {
+                    "status": "failed",
+                    "session_id": result.session_id if result else "",
+                    "error_message": message,
+                    "result_summary": (
+                        self._artifact_text(result)[:200] if result is not None else ""
+                    ),
+                },
+            )
+            self._update_workflow({"status": "failed", "error_message": message})
+            return False
+
         fix_prompt = (
             AUTONOMOUS_CONTEXT
             + f"根据以下代码审查意见修改代码：\n\n{self._clean_agent_text(review_text)}\n\n"
@@ -7510,11 +7580,23 @@ class AutonomousOrchestrator:
                 "如果确认是预先存在的问题，在回复末尾单独一行输出 `CI_STATUS: pre-existing`。"
             )
 
+        # A review-fix call can only attribute and auto-stage changes safely
+        # when it starts from a clean tree. Never let an unrelated test/manual
+        # edit hitchhike on a successful recovery or a no-op agent response.
+        try:
+            dirty_before = gh.has_uncommitted_changes()
+        except Exception as exc:
+            return fail_fix(f"Unable to verify clean worktree before PR review fix: {exc}")
+        if dirty_before is True:
+            return fail_fix(
+                "PR review fix refused: worktree already had uncommitted changes before agent run"
+            )
+
         commit_before = ""
         try:
             commit_before = gh.get_current_commit()
-        except Exception:
-            pass
+        except Exception as exc:
+            return fail_fix(f"Unable to capture branch HEAD before PR review fix: {exc}")
 
         fix_result = self._run_agent_with_context_recovery(
             wf=wf,
@@ -7541,17 +7623,17 @@ class AutonomousOrchestrator:
                 "PR review fix failed after context recovery: "
                 f"{fix_result.error or self._artifact_text(fix_result) or 'no result'}"
             )
-            self.repo.update_milestone(
-                fix_ms.get("milestone_id", ""),
-                {
-                    "status": "failed",
-                    "session_id": fix_result.session_id,
-                    "error_message": message,
-                    "result_summary": "",
-                },
+            return fail_fix(message, fix_result)
+
+        if not fix_result.success:
+            message = (
+                "PR review fix agent failed: "
+                f"{fix_result.error or self._artifact_text(fix_result) or 'no result'}"
             )
-            self._update_workflow({"status": "failed", "error_message": message})
-            return False
+            return fail_fix(message, fix_result)
+
+        if not self._artifact_text(fix_result).strip():
+            return fail_fix("PR review fix agent returned no result", fix_result)
 
         # Clear user feedback after it has been injected into the prompt
         if wf.get("user_feedback", "").strip():
@@ -8131,16 +8213,22 @@ class AutonomousOrchestrator:
                 # The index is authoritative: any unmerged path has a U-stage
                 # entry regardless of stdout/stderr language.
                 has_conflict_marker = "CONFLICT" in combined_output
+                unmerged_query_error = ""
                 if not has_conflict_marker:
-                    unmerged_result = wt_gh._run_git(
-                        ["diff", "--name-only", "--diff-filter=U"], check=False
-                    )
-                    unmerged_output = getattr(unmerged_result, "stdout", "")
-                    has_conflict_marker = isinstance(unmerged_output, str) and bool(
-                        unmerged_output.strip()
-                    )
+                    try:
+                        unmerged_result = wt_gh._run_git(
+                            ["diff", "--name-only", "--diff-filter=U"], check=False
+                        )
+                        unmerged_output = getattr(unmerged_result, "stdout", "")
+                        has_conflict_marker = isinstance(unmerged_output, str) and bool(
+                            unmerged_output.strip()
+                        )
+                    except Exception as exc:
+                        unmerged_query_error = str(exc)
                 if not has_conflict_marker:
                     detail = combined_output.strip() or f"exit code {merge_result.returncode}"
+                    if unmerged_query_error:
+                        detail += f"; unable to inspect unmerged index: {unmerged_query_error}"
                     raise GitHubOpsError(f"git merge failed (non-conflict): {detail}")
 
                 # Ask AI agent to resolve conflicts inside the temp worktree.

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -3978,6 +3978,32 @@ class AutonomousOrchestrator:
             "total_output_tokens": int(result.total_output_tokens or 0),
             "request_count": int(result.request_count or 0),
         }
+        # _run_agent may itself have consumed transient retries before its
+        # final attempt overflowed. Those attempts live in its local
+        # retry_usage and have already been persisted to phase_*; they are not
+        # represented by the returned final AgentTaskResult. Carry forward the
+        # milestone aggregate so the recovery write cannot erase them.
+        if milestone_id:
+            try:
+                milestone = self.repo.get_milestone(milestone_id)
+                if isinstance(milestone, dict):
+                    for usage_key, phase_key in (
+                        ("total_tokens", "phase_total_tokens"),
+                        ("total_input_tokens", "phase_input_tokens"),
+                        ("total_output_tokens", "phase_output_tokens"),
+                        ("request_count", "phase_request_count"),
+                    ):
+                        prior_usage[usage_key] = max(
+                            prior_usage[usage_key], int(milestone.get(phase_key, 0) or 0)
+                        )
+            except Exception:
+                # The final result remains a safe lower bound. A repository
+                # read outage must not make context recovery lose even that
+                # attempt's usage.
+                logger.warning(
+                    "Failed to read aggregate phase usage before context recovery",
+                    exc_info=True,
+                )
         self._accumulate_tokens(result)
         logger.warning(
             "Session line %s exceeded provider context; rebinding it and retrying once",

--- a/tests/issues/1813/test_pr_review_summary_before_ci.py
+++ b/tests/issues/1813/test_pr_review_summary_before_ci.py
@@ -176,3 +176,76 @@ class TestPrReviewSummaryBeforeCiCheck:
         assert (
             summary_idx < ci_repair_calls[0]
         ), "review_content must be filled BEFORE entering CI repair"
+
+    def test_summary_overflow_fails_workflow_instead_of_entering_report(self):
+        """A terminal 400 summary is not valid review content or a success."""
+        from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+        wf = _make_workflow()
+        with (
+            patch("app.modules.workspace.autonomous.orchestrator.Database"),
+            patch(
+                "app.modules.workspace.autonomous.orchestrator.AutonomousWorkflowRepository"
+            ) as mock_repo_cls,
+        ):
+            mock_repo = MagicMock()
+            mock_repo.get_workflow.return_value = wf
+            mock_repo.list_milestones.return_value = []
+            mock_repo.create_milestone.side_effect = lambda fields: {
+                "milestone_id": f"ms-{fields.get('milestone_type')}",
+                "workflow_id": wf["workflow_id"],
+            }
+            mock_repo.create_event.return_value = {"id": 1}
+            mock_repo.update_workflow.return_value = wf
+            mock_repo_cls.return_value = mock_repo
+
+            orch = AutonomousOrchestrator(wf["workflow_id"])
+            orch.repo = mock_repo
+            orch._emit = MagicMock()
+            orch._accumulate_tokens = MagicMock()
+            orch._post_github_comment = MagicMock()
+            orch._gh = MagicMock()
+            orch._gh.get_pr_diff.return_value = "diff"
+            orch._gh.get_diff_stats.return_value = {"commits": 1}
+            orch._gh.get_current_branch.return_value = wf["branch_name"]
+            orch._gh.get_current_commit.return_value = "branch-sha"
+
+            def run_git(args, check=True):
+                if args[:1] == ["rev-parse"]:
+                    return MagicMock(stdout=f"{args[1]}-sha\n", returncode=0)
+                if args[:2] == ["merge-base", "--is-ancestor"]:
+                    return MagicMock(stdout="", returncode=1)
+                return MagicMock(stdout="", returncode=0)
+
+            orch._gh._run_git.side_effect = run_git
+            orch._validate_autonomous_change_scope = MagicMock(return_value="")
+            approved = AgentTaskResult(
+                session_id="review",
+                success=True,
+                response_text=(
+                    '代码审查通过\nREVIEW_RESULT: {"verdict":"APPROVE",' '"blocking_findings":[]}'
+                ),
+            )
+            overflow = AgentTaskResult(
+                session_id="main-replacement",
+                success=True,
+                response_text=(
+                    "API Error: 400 InternalError.Algo.InvalidParameter: "
+                    "Range of input length should be [1, 202752]"
+                ),
+            )
+            orch._run_agent_with_context_recovery = MagicMock(side_effect=[approved, overflow])
+
+            with patch.object(orch, "_poll_ci_status", return_value=[]):
+                orch._do_pr_review(wf)
+
+        workflow_updates = [call.args[1] for call in mock_repo.update_workflow.call_args_list]
+        assert any(update.get("status") == "failed" for update in workflow_updates)
+        assert not any(update.get("status") == "reporting" for update in workflow_updates)
+        summary_updates = [
+            call.args[1]
+            for call in mock_repo.update_milestone.call_args_list
+            if call.args[0] == "ms-pr_review_summary"
+        ]
+        assert summary_updates[-1]["status"] == "failed"
+        assert summary_updates[-1]["review_content"] == ""

--- a/tests/issues/1816/test_ci_repair_context_overflow.py
+++ b/tests/issues/1816/test_ci_repair_context_overflow.py
@@ -156,6 +156,77 @@ def test_is_context_overflow_matches_provider_signatures(error, response_text, e
     assert AutonomousOrchestrator._is_context_overflow(result) is expected
 
 
+def test_stable_session_line_rotates_once_after_context_overflow():
+    """PR review/fix/summary calls keep one logical line but replace its head."""
+    wf = _make_workflow(main_session_id="main-too-large")
+    orch, _ = _make_orchestrator(wf)
+    orch._update_workflow = MagicMock()
+    orch._accumulate_tokens = MagicMock()
+    overflow = AgentTaskResult(
+        session_id="main-too-large",
+        success=True,
+        response_text="API Error: 400 Range of input length should be [1, 202752]",
+    )
+    recovered = AgentTaskResult(
+        session_id="main-replacement",
+        success=True,
+        response_text="修复完成",
+    )
+    orch._run_agent = MagicMock(side_effect=[overflow, recovered])
+
+    result = orch._run_agent_with_context_recovery(
+        wf,
+        session_line="main",
+        milestone_id="ms-pr-fix",
+        prompt="fix review findings",
+    )
+
+    assert result is recovered
+    assert orch._run_agent.call_count == 2
+    assert orch._run_agent.call_args_list[0].kwargs["wf"]["main_session_id"] == "main-too-large"
+    assert orch._run_agent.call_args_list[1].kwargs["wf"]["main_session_id"] == ""
+    orch._update_workflow.assert_called_once_with(
+        {"main_session_id": "", "agent_session_id": "", "agent_pid": None}
+    )
+    orch._accumulate_tokens.assert_called_once_with(overflow)
+
+
+def test_review_fix_double_overflow_fails_before_committing_dirty_tree():
+    """A terminal API envelope must never commit unrelated pending changes."""
+    wf = _make_workflow(current_phase="pr_review", status="pr_review")
+    orch, mock_repo = _make_orchestrator(wf)
+    orch._create_milestone = MagicMock(return_value={"milestone_id": "ms-fix"})
+    orch._update_workflow = MagicMock()
+    orch._accumulate_tokens = MagicMock()
+    overflow = AgentTaskResult(
+        session_id="replacement-overflowed",
+        success=True,
+        response_text="API Error: 400 Range of input length should be [1, 202752]",
+    )
+    orch._run_agent_with_context_recovery = MagicMock(return_value=overflow)
+    gh = MagicMock()
+    gh.has_uncommitted_changes.return_value = True
+
+    succeeded = orch._apply_pr_review_fix(
+        wf,
+        gh,
+        "B1 must be fixed",
+        round_num=1,
+        dev_round=1,
+        ci_failures=[],
+        pr_number=1849,
+    )
+
+    assert succeeded is False
+    gh.git_add_all.assert_not_called()
+    gh.git_commit.assert_not_called()
+    milestone_update = mock_repo.update_milestone.call_args.args[1]
+    assert milestone_update["status"] == "failed"
+    assert "context recovery" in milestone_update["error_message"]
+    workflow_update = orch._update_workflow.call_args.args[0]
+    assert workflow_update["status"] == "failed"
+
+
 # ── End-to-end: _run_merge_ci_repair switches to fresh on overflow ──────
 
 

--- a/tests/issues/1816/test_ci_repair_context_overflow.py
+++ b/tests/issues/1816/test_ci_repair_context_overflow.py
@@ -156,23 +156,48 @@ def test_is_context_overflow_matches_provider_signatures(error, response_text, e
     assert AutonomousOrchestrator._is_context_overflow(result) is expected
 
 
-def test_stable_session_line_rotates_once_after_context_overflow():
-    """PR review/fix/summary calls keep one logical line but replace its head."""
-    wf = _make_workflow(main_session_id="main-too-large")
+@pytest.mark.parametrize("recovered_success", [True, False])
+def test_stable_session_line_rebinds_once_and_preserves_usage(recovered_success):
+    """Recovery keeps the tracking line and combines both attempts' usage."""
+    wf = _make_workflow(
+        main_session_id="main-track",
+        review_session_id="review-track",
+        test_session_id="test-track",
+    )
     orch, _ = _make_orchestrator(wf)
     orch._update_workflow = MagicMock()
     orch._accumulate_tokens = MagicMock()
+    orch._runner.session_manager = MagicMock()
+    orch._runner.session_manager.get_session.return_value = MagicMock(
+        context={"cli_session_id": "provider-too-large", "keep": "value"}
+    )
+    orch._runner.session_manager.update_session_fields.return_value = True
     overflow = AgentTaskResult(
-        session_id="main-too-large",
+        session_id="main-track",
         success=True,
         response_text="API Error: 400 Range of input length should be [1, 202752]",
+        total_tokens=11,
+        total_input_tokens=7,
+        total_output_tokens=4,
+        request_count=1,
     )
     recovered = AgentTaskResult(
-        session_id="main-replacement",
-        success=True,
-        response_text="修复完成",
+        session_id="main-track",
+        success=recovered_success,
+        response_text="修复完成" if recovered_success else "",
+        error="agent exited 1" if not recovered_success else "",
+        total_tokens=23,
+        total_input_tokens=17,
+        total_output_tokens=6,
+        request_count=2,
     )
-    orch._run_agent = MagicMock(side_effect=[overflow, recovered])
+
+    def run_agent(**kwargs):
+        result = overflow if not kwargs.get("force_fresh") else recovered
+        orch._write_phase_usage(kwargs["milestone_id"], result, kwargs.get("prior_usage"))
+        return result
+
+    orch._run_agent = MagicMock(side_effect=run_agent)
 
     result = orch._run_agent_with_context_recovery(
         wf,
@@ -183,12 +208,36 @@ def test_stable_session_line_rotates_once_after_context_overflow():
 
     assert result is recovered
     assert orch._run_agent.call_count == 2
-    assert orch._run_agent.call_args_list[0].kwargs["wf"]["main_session_id"] == "main-too-large"
-    assert orch._run_agent.call_args_list[1].kwargs["wf"]["main_session_id"] == ""
-    orch._update_workflow.assert_called_once_with(
-        {"main_session_id": "", "agent_session_id": "", "agent_pid": None}
+    assert orch._run_agent.call_args_list[0].kwargs["wf"]["main_session_id"] == "main-track"
+    retry_kwargs = orch._run_agent.call_args_list[1].kwargs
+    assert retry_kwargs["wf"]["main_session_id"] == "main-track"
+    assert retry_kwargs["force_fresh"] is True
+    assert retry_kwargs["prior_usage"] == {
+        "total_tokens": 11,
+        "total_input_tokens": 7,
+        "total_output_tokens": 4,
+        "request_count": 1,
+    }
+    orch._runner.session_manager.update_session_fields.assert_called_once_with(
+        "main-track",
+        {
+            "cli_session_id": "",
+            "context": {"keep": "value"},
+            "status": "active",
+        },
     )
+    orch._update_workflow.assert_called_once_with({"agent_session_id": "", "agent_pid": None})
     orch._accumulate_tokens.assert_called_once_with(overflow)
+    usage_update = orch.repo.update_milestone.call_args.args[1]
+    assert usage_update == {
+        "phase_total_tokens": 34,
+        "phase_input_tokens": 24,
+        "phase_output_tokens": 10,
+        "phase_request_count": 3,
+    }
+    assert wf["main_session_id"] == "main-track"
+    assert wf["review_session_id"] == "review-track"
+    assert wf["test_session_id"] == "test-track"
 
 
 def test_review_fix_double_overflow_fails_before_committing_dirty_tree():
@@ -205,7 +254,7 @@ def test_review_fix_double_overflow_fails_before_committing_dirty_tree():
     )
     orch._run_agent_with_context_recovery = MagicMock(return_value=overflow)
     gh = MagicMock()
-    gh.has_uncommitted_changes.return_value = True
+    gh.has_uncommitted_changes.return_value = False
 
     succeeded = orch._apply_pr_review_fix(
         wf,
@@ -225,6 +274,131 @@ def test_review_fix_double_overflow_fails_before_committing_dirty_tree():
     assert "context recovery" in milestone_update["error_message"]
     workflow_update = orch._update_workflow.call_args.args[0]
     assert workflow_update["status"] == "failed"
+
+
+def test_review_fix_refuses_preexisting_dirty_tree_before_agent():
+    """Pre-existing edits can never hitchhike on a recovered review fix."""
+    wf = _make_workflow(current_phase="pr_review", status="pr_review")
+    orch, mock_repo = _make_orchestrator(wf)
+    orch._create_milestone = MagicMock(return_value={"milestone_id": "ms-fix"})
+    orch._update_workflow = MagicMock()
+    orch._run_agent_with_context_recovery = MagicMock()
+    gh = MagicMock()
+    gh.has_uncommitted_changes.return_value = True
+
+    succeeded = orch._apply_pr_review_fix(
+        wf,
+        gh,
+        "B1 must be fixed",
+        round_num=1,
+        dev_round=1,
+        ci_failures=[],
+        pr_number=1849,
+    )
+
+    assert succeeded is False
+    orch._run_agent_with_context_recovery.assert_not_called()
+    gh.git_add_all.assert_not_called()
+    gh.git_commit.assert_not_called()
+    gh.git_push.assert_not_called()
+    assert (
+        "already had uncommitted changes"
+        in mock_repo.update_milestone.call_args.args[1]["error_message"]
+    )
+
+
+@pytest.mark.parametrize(
+    "result, expected_error",
+    [
+        (AgentTaskResult(success=False, error="agent process exited 1"), "agent failed"),
+        (AgentTaskResult(success=True, response_text=""), "returned no result"),
+    ],
+)
+def test_review_fix_failed_or_empty_agent_never_mutates_git(result, expected_error):
+    """All unsuccessful agent outcomes stop before salvage, push, or cap summary."""
+    wf = _make_workflow(current_phase="pr_review", status="pr_review")
+    orch, mock_repo = _make_orchestrator(wf)
+    orch._create_milestone = MagicMock(return_value={"milestone_id": "ms-fix"})
+    orch._update_workflow = MagicMock()
+    orch._accumulate_tokens = MagicMock()
+    orch._run_agent_with_context_recovery = MagicMock(return_value=result)
+    gh = MagicMock()
+    gh.has_uncommitted_changes.return_value = False
+    gh.get_current_commit.return_value = "sha-before"
+
+    succeeded = orch._apply_pr_review_fix(
+        wf,
+        gh,
+        "B1 must be fixed",
+        round_num=3,
+        dev_round=1,
+        ci_failures=[],
+        pr_number=1849,
+    )
+
+    assert succeeded is False
+    gh.git_add_all.assert_not_called()
+    gh.git_commit.assert_not_called()
+    gh.git_push.assert_not_called()
+    assert expected_error in mock_repo.update_milestone.call_args.args[1]["error_message"]
+    assert orch._update_workflow.call_args.args[0]["status"] == "failed"
+
+
+def test_failed_cap_round_fix_does_not_create_summary_or_enter_report():
+    """A failed fix on the last review round must stop the state machine."""
+    wf = _make_workflow(
+        current_phase="pr_review",
+        status="pr_review",
+        current_round=0,
+        max_pr_review_rounds=1,
+        github_pr_number=1849,
+    )
+    orch, _ = _make_orchestrator(wf)
+    milestone_types = []
+
+    def create_milestone(**fields):
+        milestone_types.append(fields.get("milestone_type"))
+        return {"milestone_id": f"ms-{fields.get('milestone_type')}"}
+
+    orch._create_milestone = MagicMock(side_effect=create_milestone)
+    orch._update_workflow = MagicMock()
+    orch._get_pr_review_diff = MagicMock(return_value="diff")
+    orch._validate_autonomous_change_scope = MagicMock(return_value="")
+    orch._poll_ci_status = MagicMock(return_value=[])
+    orch._post_github_comment = MagicMock()
+    orch._accumulate_tokens = MagicMock()
+    orch._apply_pr_review_fix = MagicMock(return_value=False)
+    orch._gh = MagicMock()
+    orch._get_gh = MagicMock(return_value=orch._gh)
+    orch._gh.get_current_branch.return_value = wf["branch_name"]
+    orch._gh.get_diff_stats.return_value = {"commits": 1}
+
+    def run_git(args, check=True):
+        if args[:1] == ["rev-parse"]:
+            return MagicMock(stdout=f"{args[1]}-sha\n", returncode=0)
+        if args[:2] == ["merge-base", "--is-ancestor"]:
+            return MagicMock(stdout="", returncode=1)
+        return MagicMock(stdout="", returncode=0)
+
+    orch._gh._run_git.side_effect = run_git
+    orch._run_agent_with_context_recovery = MagicMock(
+        return_value=AgentTaskResult(
+            session_id="review-track",
+            success=True,
+            response_text=(
+                '发现阻塞问题\nREVIEW_RESULT: {"verdict":"REQUEST_CHANGES",'
+                '"blocking_findings":["B1"]}'
+            ),
+        )
+    )
+
+    orch._do_pr_review(wf)
+
+    orch._apply_pr_review_fix.assert_called_once()
+    assert "pr_review_summary" not in milestone_types
+    assert not any(
+        call.args[0].get("status") == "reporting" for call in orch._update_workflow.call_args_list
+    )
 
 
 # ── End-to-end: _run_merge_ci_repair switches to fresh on overflow ──────

--- a/tests/issues/1816/test_ci_repair_context_overflow.py
+++ b/tests/issues/1816/test_ci_repair_context_overflow.py
@@ -240,6 +240,73 @@ def test_stable_session_line_rebinds_once_and_preserves_usage(recovered_success)
     assert wf["test_session_id"] == "test-track"
 
 
+@pytest.mark.parametrize("recovered_success", [True, False])
+def test_context_recovery_carries_transient_retry_usage(recovered_success):
+    """Transient usage before overflow is read from the persisted milestone."""
+    wf = _make_workflow(main_session_id="main-track")
+    orch, mock_repo = _make_orchestrator(wf)
+    orch._update_workflow = MagicMock()
+    orch._accumulate_tokens = MagicMock()
+    orch._runner.session_manager = MagicMock()
+    orch._runner.session_manager.get_session.return_value = MagicMock(context={})
+    orch._runner.session_manager.update_session_fields.return_value = True
+    # First _run_agent aggregate: transient 5/3/2/1 + overflow 11/7/4/1.
+    mock_repo.get_milestone.return_value = {
+        "phase_total_tokens": 16,
+        "phase_input_tokens": 10,
+        "phase_output_tokens": 6,
+        "phase_request_count": 2,
+    }
+    overflow = AgentTaskResult(
+        session_id="main-track",
+        success=True,
+        response_text="API Error: 400 Range of input length should be [1, 202752]",
+        total_tokens=11,
+        total_input_tokens=7,
+        total_output_tokens=4,
+        request_count=1,
+    )
+    recovered = AgentTaskResult(
+        session_id="main-track",
+        success=recovered_success,
+        response_text="fixed" if recovered_success else "",
+        error="agent exited 1" if not recovered_success else "",
+        total_tokens=23,
+        total_input_tokens=17,
+        total_output_tokens=6,
+        request_count=2,
+    )
+
+    def run_agent(**kwargs):
+        result = overflow if not kwargs.get("force_fresh") else recovered
+        orch._write_phase_usage(kwargs["milestone_id"], result, kwargs.get("prior_usage"))
+        return result
+
+    orch._run_agent = MagicMock(side_effect=run_agent)
+
+    result = orch._run_agent_with_context_recovery(
+        wf,
+        session_line="main",
+        milestone_id="ms-pr-fix",
+        prompt="fix review findings",
+    )
+
+    assert result is recovered
+    assert orch._run_agent.call_args_list[1].kwargs["prior_usage"] == {
+        "total_tokens": 16,
+        "total_input_tokens": 10,
+        "total_output_tokens": 6,
+        "request_count": 2,
+    }
+    usage_update = mock_repo.update_milestone.call_args.args[1]
+    assert usage_update == {
+        "phase_total_tokens": 39,
+        "phase_input_tokens": 27,
+        "phase_output_tokens": 12,
+        "phase_request_count": 4,
+    }
+
+
 def test_review_fix_double_overflow_fails_before_committing_dirty_tree():
     """A terminal API envelope must never commit unrelated pending changes."""
     wf = _make_workflow(current_phase="pr_review", status="pr_review")

--- a/tests/issues/1816/test_ci_repair_context_overflow.py
+++ b/tests/issues/1816/test_ci_repair_context_overflow.py
@@ -344,8 +344,111 @@ def test_review_fix_failed_or_empty_agent_never_mutates_git(result, expected_err
     assert orch._update_workflow.call_args.args[0]["status"] == "failed"
 
 
-def test_failed_cap_round_fix_does_not_create_summary_or_enter_report():
-    """A failed fix on the last review round must stop the state machine."""
+def test_review_fix_fails_when_committed_head_cannot_be_read():
+    """A commit is not pushable until its resulting HEAD is verified."""
+    wf = _make_workflow(current_phase="pr_review", status="pr_review")
+    orch, _ = _make_orchestrator(wf)
+    orch._create_milestone = MagicMock(return_value={"milestone_id": "ms-fix"})
+    orch._update_workflow = MagicMock()
+    orch._accumulate_tokens = MagicMock()
+    orch._run_agent_with_context_recovery = MagicMock(
+        return_value=AgentTaskResult(success=True, response_text="fixed")
+    )
+    gh = MagicMock()
+    gh.has_uncommitted_changes.side_effect = [False, True]
+    gh.get_current_commit.side_effect = ["sha-before", "sha-before", RuntimeError("head denied")]
+
+    succeeded = orch._apply_pr_review_fix(
+        wf,
+        gh,
+        "B1 must be fixed",
+        round_num=1,
+        dev_round=1,
+        ci_failures=[],
+        pr_number=1849,
+    )
+
+    assert succeeded is False
+    gh.git_commit.assert_called_once()
+    gh.git_push.assert_not_called()
+    assert "head denied" in orch._update_workflow.call_args.args[0]["error_message"]
+
+
+@pytest.mark.parametrize("empty_stage", ["review", "summary"])
+def test_empty_review_or_summary_fails_closed(empty_stage):
+    """Whitespace-only review artifacts never complete a milestone or advance."""
+    wf = _make_workflow(
+        current_phase="pr_review",
+        status="pr_review",
+        current_round=0,
+        max_pr_review_rounds=1,
+        github_pr_number=1849,
+    )
+    orch, mock_repo = _make_orchestrator(wf)
+    milestone_types = []
+
+    def create_milestone(**fields):
+        milestone_type = fields.get("milestone_type")
+        milestone_types.append(milestone_type)
+        return {"milestone_id": f"ms-{milestone_type}"}
+
+    orch._create_milestone = MagicMock(side_effect=create_milestone)
+    orch._update_workflow = MagicMock()
+    orch._get_pr_review_diff = MagicMock(return_value="diff")
+    orch._validate_autonomous_change_scope = MagicMock(return_value="")
+    orch._poll_ci_status = MagicMock(return_value=[])
+    orch._post_github_comment = MagicMock()
+    orch._accumulate_tokens = MagicMock()
+    orch._gh = MagicMock()
+    orch._get_gh = MagicMock(return_value=orch._gh)
+    orch._gh.get_current_branch.return_value = wf["branch_name"]
+    orch._gh.get_diff_stats.return_value = {"commits": 1}
+
+    def run_git(args, check=True):
+        if args[:1] == ["rev-parse"]:
+            return MagicMock(stdout=f"{args[1]}-sha\n", returncode=0)
+        if args[:2] == ["merge-base", "--is-ancestor"]:
+            return MagicMock(stdout="", returncode=1)
+        return MagicMock(stdout="", returncode=0)
+
+    orch._gh._run_git.side_effect = run_git
+    empty = AgentTaskResult(session_id=f"{empty_stage}-track", success=True, response_text="  \n")
+    if empty_stage == "review":
+        results = [empty]
+    else:
+        results = [
+            AgentTaskResult(
+                session_id="review-track",
+                success=True,
+                response_text=(
+                    '批准\nREVIEW_RESULT: {"verdict":"APPROVE",' '"blocking_findings":[]}'
+                ),
+            ),
+            empty,
+        ]
+    orch._run_agent_with_context_recovery = MagicMock(side_effect=results)
+
+    orch._do_pr_review(wf)
+
+    assert not any(
+        call.args[0].get("status") == "reporting" for call in orch._update_workflow.call_args_list
+    )
+    assert any(
+        call.args[0].get("status") == "failed"
+        and "returned no result" in call.args[0].get("error_message", "")
+        for call in orch._update_workflow.call_args_list
+    )
+    failed_ms_id = f"ms-{'pr_reviewed' if empty_stage == 'review' else 'pr_review_summary'}"
+    assert any(
+        call.args[0] == failed_ms_id and call.args[1].get("status") == "failed"
+        for call in mock_repo.update_milestone.call_args_list
+    )
+    if empty_stage == "review":
+        assert "pr_review_summary" not in milestone_types
+
+
+def test_cap_round_commit_failure_does_not_create_summary_or_enter_report():
+    """A failed fix commit on the last round must stop the state machine."""
     wf = _make_workflow(
         current_phase="pr_review",
         status="pr_review",
@@ -367,11 +470,13 @@ def test_failed_cap_round_fix_does_not_create_summary_or_enter_report():
     orch._poll_ci_status = MagicMock(return_value=[])
     orch._post_github_comment = MagicMock()
     orch._accumulate_tokens = MagicMock()
-    orch._apply_pr_review_fix = MagicMock(return_value=False)
     orch._gh = MagicMock()
     orch._get_gh = MagicMock(return_value=orch._gh)
     orch._gh.get_current_branch.return_value = wf["branch_name"]
     orch._gh.get_diff_stats.return_value = {"commits": 1}
+    orch._gh.has_uncommitted_changes.side_effect = [False, True]
+    orch._gh.get_current_commit.side_effect = ["sha-before", "sha-before"]
+    orch._gh.git_commit.side_effect = RuntimeError("commit denied")
 
     def run_git(args, check=True):
         if args[:1] == ["rev-parse"]:
@@ -382,22 +487,36 @@ def test_failed_cap_round_fix_does_not_create_summary_or_enter_report():
 
     orch._gh._run_git.side_effect = run_git
     orch._run_agent_with_context_recovery = MagicMock(
-        return_value=AgentTaskResult(
-            session_id="review-track",
-            success=True,
-            response_text=(
-                '发现阻塞问题\nREVIEW_RESULT: {"verdict":"REQUEST_CHANGES",'
-                '"blocking_findings":["B1"]}'
+        side_effect=[
+            AgentTaskResult(
+                session_id="review-track",
+                success=True,
+                response_text=(
+                    '发现阻塞问题\nREVIEW_RESULT: {"verdict":"REQUEST_CHANGES",'
+                    '"blocking_findings":["B1"]}'
+                ),
             ),
-        )
+            AgentTaskResult(
+                session_id="main-track",
+                success=True,
+                response_text="fixed",
+            ),
+        ]
     )
 
     orch._do_pr_review(wf)
 
-    orch._apply_pr_review_fix.assert_called_once()
+    orch._gh.git_commit.assert_called_once()
+    # The sole push is the normal pre-review branch sync; no fix push follows.
+    orch._gh.git_push.assert_called_once_with(branch=wf["branch_name"], force_with_lease=True)
     assert "pr_review_summary" not in milestone_types
     assert not any(
         call.args[0].get("status") == "reporting" for call in orch._update_workflow.call_args_list
+    )
+    assert any(
+        call.args[0].get("status") == "failed"
+        and "Unable to commit PR review fix" in call.args[0].get("error_message", "")
+        for call in orch._update_workflow.call_args_list
     )
 
 

--- a/tests/issues/822/test_merge_conflict_detection.py
+++ b/tests/issues/822/test_merge_conflict_detection.py
@@ -178,6 +178,46 @@ class TestResolveMergeConflictsStdoutConflict:
 
         o._run_agent.assert_called_once()
 
+    @patch("app.modules.workspace.autonomous.orchestrator.GitHubOps")
+    def test_empty_merge_diagnostics_report_exit_code(self, mock_gh_cls):
+        """An empty localized failure still exposes an actionable exit code."""
+        o, _ = _make_orchestrator(_make_workflow())
+        mock_gh = MagicMock()
+        mock_gh_cls.return_value = mock_gh
+
+        def run_git(args, check=True):
+            if args[:2] == ["merge", "origin/main"] and not check:
+                return MagicMock(returncode=128, stdout="", stderr="")
+            if args == ["diff", "--name-only", "--diff-filter=U"]:
+                return MagicMock(returncode=0, stdout="", stderr="")
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        mock_gh._run_git.side_effect = run_git
+        import pytest
+
+        with pytest.raises(GitHubOpsError, match="exit code 128"):
+            o._resolve_merge_conflicts(mock_gh, "auto-dev/fc82f22a", 1103)
+
+    @patch("app.modules.workspace.autonomous.orchestrator.GitHubOps")
+    def test_unmerged_index_query_failure_is_reported(self, mock_gh_cls):
+        """Index inspection errors must not be mistaken for real conflicts."""
+        o, _ = _make_orchestrator(_make_workflow())
+        mock_gh = MagicMock()
+        mock_gh_cls.return_value = mock_gh
+
+        def run_git(args, check=True):
+            if args[:2] == ["merge", "origin/main"] and not check:
+                return MagicMock(returncode=1, stdout="", stderr="")
+            if args == ["diff", "--name-only", "--diff-filter=U"]:
+                raise GitHubOpsError("index unavailable")
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        mock_gh._run_git.side_effect = run_git
+        import pytest
+
+        with pytest.raises(GitHubOpsError, match="index unavailable"):
+            o._resolve_merge_conflicts(mock_gh, "auto-dev/fc82f22a", 1103)
+
 
 # ── Bug 2: branch-policy rejection uses --auto ───────────────────────────
 

--- a/tests/issues/822/test_merge_conflict_detection.py
+++ b/tests/issues/822/test_merge_conflict_detection.py
@@ -95,6 +95,8 @@ class TestResolveMergeConflictsStdoutConflict:
                     ),
                     stderr="",
                 )
+            if args == ["diff", "--name-only", "--diff-filter=U"]:
+                return MagicMock(returncode=0, stdout="app/services/auth_service.py\n", stderr="")
             return MagicMock()
 
         mock_gh._run_git = MagicMock(side_effect=run_git)
@@ -133,6 +135,8 @@ class TestResolveMergeConflictsStdoutConflict:
             if args[:2] == ["merge", "origin/main"] and not check:
                 # No CONFLICT anywhere — a genuine non-conflict failure.
                 return MagicMock(returncode=1, stdout="fatal: bad object", stderr="")
+            if args == ["diff", "--name-only", "--diff-filter=U"]:
+                return MagicMock(returncode=0, stdout="", stderr="")
             return MagicMock()
 
         mock_gh._run_git = MagicMock(side_effect=run_git)
@@ -142,6 +146,37 @@ class TestResolveMergeConflictsStdoutConflict:
 
         with pytest.raises(GitHubOpsError, match="non-conflict"):
             o._resolve_merge_conflicts(mock_gh, "auto-dev/fc82f22a", 1103)
+
+    @patch("app.modules.workspace.autonomous.orchestrator.GitHubOps")
+    def test_localized_conflict_uses_unmerged_index(self, mock_gh_cls):
+        """Translated git output still enters conflict resolution via U paths."""
+        o, _ = _make_orchestrator(_make_workflow())
+        mock_gh = MagicMock()
+        mock_gh_cls.return_value = mock_gh
+
+        def run_git(args, check=True):
+            if args[:2] == ["merge", "origin/main"] and not check:
+                return MagicMock(
+                    returncode=1,
+                    stdout="自动合并失败；修正冲突后提交结果。\n",
+                    stderr="",
+                )
+            if args == ["diff", "--name-only", "--diff-filter=U"]:
+                return MagicMock(returncode=0, stdout="app/routes/auth.py\n", stderr="")
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        mock_gh._run_git.side_effect = run_git
+        from app.modules.workspace.autonomous.models import AgentTaskResult
+
+        o._run_agent = MagicMock(
+            return_value=AgentTaskResult(
+                session_id="resolver", success=True, response_text="42 passed"
+            )
+        )
+
+        o._resolve_merge_conflicts(mock_gh, "auto-dev/fc82f22a", 1103)
+
+        o._run_agent.assert_called_once()
 
 
 # ── Bug 2: branch-policy rejection uses --auto ───────────────────────────


### PR DESCRIPTION
## Summary

- rotate an oversized stable main/review session line once and retry the same self-contained PR task on a clean context
- fail PR review, fix, and summary milestones instead of treating terminal provider envelopes as completed work
- prevent failed PR-fix calls from committing unrelated pending changes or advancing to the next review/report phase
- detect merge conflicts from Git's unmerged index so localized Git output cannot be misclassified as an empty non-conflict failure
- include combined stdout/stderr or exit code in genuine non-conflict merge diagnostics

## Production root cause

Workflow for Issue #1894 repeatedly received Bailian/GLM `400 Range of input length should be [1, 202752]` while resuming its long-lived main session for PR fixes and summary. The CLI exited with a terminal API-error envelope that was persisted as a completed milestone, and existing dirty test changes were committed as if they were review fixes. The workflow then advanced through all review rounds and report.

At merge, the host's localized Git output did not contain the literal English `CONFLICT` token. Although Git had unmerged index entries, conflict resolution was skipped and the workflow failed with an empty `git merge failed (non-conflict)` diagnostic.

## Safety behavior

- the workflow still has exactly three logical session lines: main, review, and test; only the oversized line's current head is replaced
- context recovery is bounded to one retry
- a second overflow or failed review/summary is terminal and cannot advance the state machine
- a PR-fix overflow is rejected before dirty-tree salvage/commit/push
- conflict classification uses `git diff --name-only --diff-filter=U`, independent of locale

## Validation

- 90 targeted guardrail/context/merge tests passed
- changed-files pre-commit passed (black, isort, ruff, mypy, bandit, security and repository hooks)
- `git diff --check` passed
- the 6 existing `TestDoMergeDeferredRetry` failures reproduce unchanged on the pre-patch main baseline and are excluded from the targeted run

## Independent review

An independent agent will review the final patch, run adversarial tests, and publish its findings before merge.
