### PR TITLE
fix(autonomous): bind conflict resolver to isolated worktree

### DIFF
--- a/app/modules/workspace/autonomous/github_ops.py
+++ b/app/modules/workspace/autonomous/github_ops.py
@@ -1400,6 +1400,53 @@ class GitHubOps:
         result = self._run_git(["status", "--porcelain"])
         return bool(result.stdout.strip())
 
+    def get_unmerged_paths(self) -> list[str]:
+        """Return paths that still have unmerged index entries."""
+        result = self._run_git(["diff", "--name-only", "--diff-filter=U"], check=False)
+        if result.returncode != 0:
+            raise GitHubOpsError(
+                f"Unable to inspect unmerged index (exit code {result.returncode}): "
+                f"{(result.stderr or result.stdout).strip()}"
+            )
+        return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+    def get_conflict_marker_paths(self, paths: list[str]) -> list[str]:
+        """Return files that still contain standard merge-conflict markers.
+
+        The caller supplies the authoritative U-stage path list captured before
+        staging.  Restricting the search to those files avoids false positives
+        from fixtures or documentation elsewhere in the repository.
+        """
+        if not paths:
+            return []
+        result = self._run_git(
+            [
+                "grep",
+                "--no-index",
+                "-l",
+                "-I",
+                "-E",
+                "-e",
+                r"^<<<<<<<( |$)",
+                "-e",
+                r"^=======$",
+                "-e",
+                r"^>>>>>>>( |$)",
+                "--",
+                *paths,
+            ],
+            check=False,
+        )
+        # git grep returns 1 when there are no matches.
+        if result.returncode not in (0, 1):
+            raise GitHubOpsError(
+                f"Unable to inspect conflict markers (exit code {result.returncode}): "
+                f"{(result.stderr or result.stdout).strip()}"
+            )
+        if result.returncode == 1:
+            return []
+        return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
     def git_add_all(self) -> None:
         """Stage all changes."""
         self._run_git(["add", "-A"])

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -8254,6 +8254,8 @@ class AutonomousOrchestrator:
         wt_gh = GitHubOps(temp_wt_path, system_account=system_account)
         try:
             original_pr_head = wt_gh.get_current_commit()
+            conflict_ms_id = ""
+            milestone_result = {}
             # Fetch latest main and merge into the branch.
             wt_gh._run_git(["fetch", "origin", "main"])
             merge_result = wt_gh._run_git(["merge", "origin/main"], check=False)
@@ -8290,6 +8292,10 @@ class AutonomousOrchestrator:
                     AUTONOMOUS_CONTEXT
                     + "当前分支与 main 存在合并冲突。请解决所有冲突文件中的冲突标记，"
                     "保留两边的有效修改。\n\n"
+                    f"编排器已经把你放在唯一允许操作的临时 worktree：`{temp_wt_path}`。\n"
+                    f"该 worktree 已检出目标分支 `{branch_name}` 并处于 merge conflict 状态。\n"
+                    "禁止切换/checkout 其他分支，禁止调用 EnterWorktree，禁止到主仓或其他"
+                    " worktree 查找冲突；直接处理当前目录的 U-stage 文件。\n\n"
                 )
                 # Issue reference is available in this method's scope
                 issue_number = wf.get("github_issue_number") or self.workflow.get(
@@ -8305,14 +8311,14 @@ class AutonomousOrchestrator:
                     "步骤：\n"
                     "1. 查看所有冲突文件：git diff --name-only --diff-filter=U\n"
                     "2. 逐个解决冲突标记（<<<<<<, ======, >>>>>>）\n"
-                    "3. git add 所有解决后的文件\n"
-                    "4. 运行测试验证冲突解决没有破坏功能（不能跳过）：\n"
+                    "3. 运行测试验证冲突解决没有破坏功能（不能跳过）：\n"
                     "   - python -m pytest 或 python3 -m pytest\n"
                     "   - 如果有测试失败，分析原因并修复，然后重新测试\n"
                     "   - 特别注意：main 上的改动可能修改了函数签名/SQL/接口，\n"
                     "     冲突文件相关的测试也需要同步更新\n"
                     "   - 重复直到所有测试通过\n"
-                    "5. 测试全部通过后，git commit 完成合并\n\n"
+                    "4. 测试全部通过后直接返回总结；不要执行 git add、git commit 或 git push，\n"
+                    "   暂存、提交与推送由编排器在校验冲突标记和提交图后完成。\n\n"
                     "## 总结报告（必须）\n"
                     "在回复末尾简要总结：\n"
                     "- 解决了哪些文件的冲突\n"
@@ -8322,6 +8328,20 @@ class AutonomousOrchestrator:
                 )
 
                 wf = self.workflow
+                # _run_agent derives its authoritative repository path and the
+                # prompt execution contract from ``wf``. Passing project_path
+                # alone is insufficient: the workflow's cleared worktree_path
+                # would otherwise override it back to the shared main repo.
+                # Bind a per-call workflow snapshot to the isolated resolver
+                # worktree without changing the persisted workflow row.
+                conflict_wf = dict(wf)
+                conflict_wf.update(
+                    {
+                        "branch_strategy": "worktree",
+                        "worktree_path": temp_wt_path,
+                        "branch_name": branch_name,
+                    }
+                )
                 # Track this as its own milestone so conflict-resolution usage is
                 # captured in phase_* (and thus workflow totals = SUM(phase_*)).
                 conflict_ms = self._create_milestone(
@@ -8332,7 +8352,7 @@ class AutonomousOrchestrator:
                     title=f"Resolving merge conflicts (PR #{pr_number})",
                 )
                 result = self._run_agent(
-                    wf=wf,
+                    wf=conflict_wf,
                     workflow_id=self._workflow_id,
                     cli_tool=wf.get("cli_tool", "claude-code"),
                     model=wf.get("model", ""),
@@ -8349,42 +8369,126 @@ class AutonomousOrchestrator:
                 )
                 self._accumulate_tokens(result)
                 response_text = self._artifact_text(result)
-                self.repo.update_milestone(
-                    conflict_ms.get("milestone_id", ""),
-                    {
-                        "status": "completed" if result.success else "failed",
-                        "session_id": result.session_id,
-                        "error_message": result.error or "",
-                        "result_summary": response_text,
-                        "tldr": self._artifact_tldr(result),
-                    },
-                )
-
+                conflict_ms_id = conflict_ms.get("milestone_id", "")
+                milestone_result = {
+                    "session_id": result.session_id,
+                    "result_summary": response_text,
+                    "tldr": self._artifact_tldr(result),
+                }
                 if not result.success:
+                    self.repo.update_milestone(
+                        conflict_ms_id,
+                        {
+                            **milestone_result,
+                            "status": "failed",
+                            "error_message": result.error or "Conflict resolution failed",
+                        },
+                    )
                     raise RuntimeError(f"Conflict resolution failed: {result.error}")
 
-            # Push the resolved branch. The new merge commit triggers a fresh
-            # CI run, so we do NOT merge here — _do_merge will retry on the
-            # next scheduler cycle once CI passes (it checks for pending CI
-            # at the top and defers until checks are green).
-            # P1 修复（Issue #1611）：Conflict 解决后检查分支一致性
-            current_branch = wt_gh.get_current_branch()
-            if isinstance(current_branch, str) and current_branch and current_branch != branch_name:
-                logger.warning(
-                    "Conflict resolution branch mismatch: expected=%s, actual=%s",
-                    branch_name,
-                    current_branch,
+                try:
+                    # The agent is intentionally edit/test-only: its command
+                    # guard denies mutating git operations.  The trusted
+                    # orchestrator owns staging and the merge commit after
+                    # verifying both the working tree and branch identity.
+                    current_branch = wt_gh.get_current_branch()
+                    if not isinstance(current_branch, str) or current_branch != branch_name:
+                        raise RuntimeError(
+                            "Conflict resolution branch mismatch before commit: "
+                            f"expected={branch_name!r}, actual={current_branch!r}"
+                        )
+                    unmerged_paths = wt_gh.get_unmerged_paths()
+                    marker_paths = wt_gh.get_conflict_marker_paths(unmerged_paths)
+                    if marker_paths:
+                        raise RuntimeError(
+                            "Conflict resolver left conflict markers in: "
+                            + ", ".join(marker_paths[:10])
+                        )
+                    wt_gh.git_add_all()
+                    remaining_unmerged = wt_gh.get_unmerged_paths()
+                    if remaining_unmerged:
+                        raise RuntimeError(
+                            "Conflict resolver left unmerged paths after staging: "
+                            + ", ".join(remaining_unmerged[:10])
+                        )
+                    wt_gh.git_commit(
+                        f"merge: resolve conflicts for PR #{pr_number}", no_verify=True
+                    )
+                except Exception as exc:
+                    self.repo.update_milestone(
+                        conflict_ms_id,
+                        {
+                            **milestone_result,
+                            "status": "failed",
+                            "error_message": str(exc),
+                        },
+                    )
+                    raise
+
+                # Do not mark the milestone complete until the shared
+                # pre-push commit-graph postconditions below have passed.
+
+            try:
+                # Push the resolved branch. The new merge commit triggers a
+                # fresh CI run, so _do_merge retries on the next scheduler
+                # cycle once checks are green.
+                # Fail closed on branch drift. Rewriting branch_name from the
+                # current checkout could push an unrelated branch.
+                current_branch = wt_gh.get_current_branch()
+                if not isinstance(current_branch, str) or current_branch != branch_name:
+                    raise RuntimeError(
+                        "Conflict resolution branch mismatch before push: "
+                        f"expected={branch_name!r}, actual={current_branch!r}"
+                    )
+                resolved_head = wt_gh.get_current_commit()
+                if (
+                    not isinstance(original_pr_head, str)
+                    or not original_pr_head
+                    or not isinstance(resolved_head, str)
+                    or not resolved_head
+                ):
+                    raise RuntimeError("Unable to verify merge commit identity before push")
+                if resolved_head == original_pr_head:
+                    raise RuntimeError("Merge resolution made no commit; refusing unchanged push")
+
+                pr_head_in_result = self._ancestor_check(wt_gh, original_pr_head, resolved_head)
+                main_head_in_result = self._ancestor_check(wt_gh, "origin/main", resolved_head)
+                if pr_head_in_result is not True or main_head_in_result is not True:
+                    raise RuntimeError(
+                        "Merge commit ancestry verification failed before push: "
+                        f"pr_head={pr_head_in_result!r}, origin_main={main_head_in_result!r}"
+                    )
+                merge_scope_wf = dict(wf)
+                merge_scope_wf["base_commit_sha"] = "origin/main"
+                scope_error = self._validate_autonomous_change_scope(
+                    wt_gh, merge_scope_wf, original_pr_head, resolved_head
                 )
-                branch_name = current_branch
-            resolved_head = wt_gh.get_current_commit()
-            merge_scope_wf = dict(wf)
-            merge_scope_wf["base_commit_sha"] = "origin/main"
-            scope_error = self._validate_autonomous_change_scope(
-                wt_gh, merge_scope_wf, original_pr_head, resolved_head
-            )
-            if scope_error:
-                raise RuntimeError(f"Conflict resolution scope rejected before push: {scope_error}")
-            wt_gh.git_push(branch=branch_name, force_with_lease=True)
+                if scope_error:
+                    raise RuntimeError(
+                        f"Conflict resolution scope rejected before push: {scope_error}"
+                    )
+                wt_gh.git_push(branch=branch_name, force_with_lease=True)
+            except Exception as exc:
+                if conflict_ms_id:
+                    self.repo.update_milestone(
+                        conflict_ms_id,
+                        {
+                            **milestone_result,
+                            "status": "failed",
+                            "error_message": str(exc),
+                        },
+                    )
+                raise
+
+            if conflict_ms_id:
+                self.repo.update_milestone(
+                    conflict_ms_id,
+                    {
+                        **milestone_result,
+                        "status": "completed",
+                        "error_message": "",
+                    },
+                )
             self._create_milestone(
                 phase="merge",
                 milestone_type="conflicts_pushed",

--- a/tests/issues/822/test_merge_conflict_detection.py
+++ b/tests/issues/822/test_merge_conflict_detection.py
@@ -15,6 +15,8 @@ Two bugs caused worktrees in the 807-845 batch to fail at the merge phase:
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from app.modules.workspace.autonomous.github_ops import GitHubOps, GitHubOpsError
 from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
 
@@ -67,6 +69,24 @@ def _make_orchestrator(wf):
     return o, mock_repo
 
 
+def _set_valid_merge_result(
+    orchestrator,
+    gh,
+    *,
+    conflict: bool = True,
+    original_head: str = "head-before",
+    resolved_head: str = "head-after",
+):
+    """Configure strict branch/index/commit-graph postconditions for a success test."""
+    gh.get_current_branch.return_value = "auto-dev/fc82f22a"
+    gh.get_current_commit.side_effect = [original_head, resolved_head]
+    if conflict:
+        gh.get_unmerged_paths.side_effect = [["app/x.py"], []]
+        gh.get_conflict_marker_paths.return_value = []
+    orchestrator._ancestor_check = MagicMock(return_value=True)
+    orchestrator._validate_autonomous_change_scope = MagicMock(return_value="")
+
+
 # ── Bug 1: conflict detection must check stdout ──────────────────────────
 
 
@@ -101,6 +121,7 @@ class TestResolveMergeConflictsStdoutConflict:
 
         mock_gh._run_git = MagicMock(side_effect=run_git)
         o._gh = mock_gh
+        _set_valid_merge_result(o, mock_gh)
 
         # Stub the AI conflict resolver so we verify it IS reached.
         o._run_agent = MagicMock()
@@ -166,6 +187,7 @@ class TestResolveMergeConflictsStdoutConflict:
             return MagicMock(returncode=0, stdout="", stderr="")
 
         mock_gh._run_git.side_effect = run_git
+        _set_valid_merge_result(o, mock_gh)
         from app.modules.workspace.autonomous.models import AgentTaskResult
 
         o._run_agent = MagicMock(
@@ -464,6 +486,69 @@ class TestMergePrAutoFlag:
             assert "--auto" not in cmd
 
 
+class TestGetUnmergedPaths:
+    def test_returns_authoritative_u_stage_paths(self):
+        gh = GitHubOps("/tmp/repo")
+        with patch.object(
+            gh,
+            "_run_git",
+            return_value=MagicMock(
+                returncode=0,
+                stdout="app/a.py\nfrontend/b.tsx\n",
+                stderr="",
+            ),
+        ):
+            assert gh.get_unmerged_paths() == ["app/a.py", "frontend/b.tsx"]
+
+    def test_query_failure_raises(self):
+        gh = GitHubOps("/tmp/repo")
+        with patch.object(
+            gh,
+            "_run_git",
+            return_value=MagicMock(returncode=128, stdout="", stderr="bad index"),
+        ):
+            import pytest
+
+            with pytest.raises(GitHubOpsError, match="exit code 128"):
+                gh.get_unmerged_paths()
+
+
+class TestGetConflictMarkerPaths:
+    def test_returns_only_matching_conflict_files(self):
+        gh = GitHubOps("/tmp/repo")
+        with patch.object(
+            gh,
+            "_run_git",
+            return_value=MagicMock(returncode=0, stdout="app/a.py\napp/b.py\n", stderr=""),
+        ) as mock_run:
+            assert gh.get_conflict_marker_paths(["app/a.py", "app/b.py"]) == [
+                "app/a.py",
+                "app/b.py",
+            ]
+        command = mock_run.call_args.args[0]
+        assert command[:4] == ["grep", "--no-index", "-l", "-I"]
+        assert command[-3:] == ["--", "app/a.py", "app/b.py"]
+
+    def test_no_matches_returns_empty_list(self):
+        gh = GitHubOps("/tmp/repo")
+        with patch.object(
+            gh,
+            "_run_git",
+            return_value=MagicMock(returncode=1, stdout="", stderr=""),
+        ):
+            assert gh.get_conflict_marker_paths(["app/a.py"]) == []
+
+    def test_probe_failure_raises(self):
+        gh = GitHubOps("/tmp/repo")
+        with patch.object(
+            gh,
+            "_run_git",
+            return_value=MagicMock(returncode=128, stdout="", stderr="bad path"),
+        ):
+            with pytest.raises(GitHubOpsError, match="exit code 128"):
+                gh.get_conflict_marker_paths(["app/a.py"])
+
+
 # ── Bug 3: isolated temp worktree for conflict resolution ────────────────
 
 
@@ -492,6 +577,7 @@ class TestResolveMergeConflictsWorktreeIsolation:
             MagicMock(returncode=0, stdout="", stderr=""),  # merge (clean)
         ]
         mock_gh_cls.side_effect = [main_gh, wt_gh, caller_gh]
+        _set_valid_merge_result(o, wt_gh, conflict=False)
 
         o._resolve_merge_conflicts(caller_gh, "auto-dev/fc82f22a", 1103)
 
@@ -524,6 +610,7 @@ class TestResolveMergeConflictsWorktreeIsolation:
             ),  # merge (conflict)
         ]
         mock_gh_cls.side_effect = [main_gh, wt_gh, caller_gh]
+        _set_valid_merge_result(o, wt_gh)
 
         import pytest
 
@@ -558,6 +645,7 @@ class TestResolveMergeConflictsWorktreeIsolation:
             ),  # merge (conflict)
         ]
         mock_gh_cls.side_effect = [main_gh, wt_gh, caller_gh]
+        _set_valid_merge_result(o, wt_gh)
 
         o._run_agent = MagicMock()
         from app.modules.workspace.autonomous.models import AgentTaskResult
@@ -574,6 +662,19 @@ class TestResolveMergeConflictsWorktreeIsolation:
         assert agent_project_path.endswith("merge-wf-822")  # temp worktree, not main repo
         # Must NOT be the main repo project_path.
         assert agent_project_path != _make_workflow()["project_path"]
+        agent_wf = o._run_agent.call_args.kwargs["wf"]
+        assert agent_wf["worktree_path"] == agent_project_path
+        assert agent_wf["branch_strategy"] == "worktree"
+        assert agent_wf["branch_name"] == "auto-dev/fc82f22a"
+        effective = o._resolve_effective_repo_context(agent_wf)
+        assert effective["repo_path"] == agent_project_path
+        contract = o._build_repo_execution_contract(agent_wf)
+        assert agent_project_path in contract
+        assert "`/srv/repo`" not in contract
+        wt_gh.git_add_all.assert_called_once()
+        wt_gh.git_commit.assert_called_once_with(
+            "merge: resolve conflicts for PR #1103", no_verify=True
+        )
 
     @patch("app.modules.workspace.autonomous.orchestrator.GitHubOps")
     def test_agent_uses_fresh_session_not_main(self, mock_gh_cls):
@@ -597,6 +698,7 @@ class TestResolveMergeConflictsWorktreeIsolation:
             ),  # merge (conflict)
         ]
         mock_gh_cls.side_effect = [main_gh, wt_gh, caller_gh]
+        _set_valid_merge_result(o, wt_gh)
 
         o._run_agent = MagicMock()
         from app.modules.workspace.autonomous.models import AgentTaskResult
@@ -614,11 +716,7 @@ class TestResolveMergeConflictsWorktreeIsolation:
 
     @patch("app.modules.workspace.autonomous.orchestrator.GitHubOps")
     def test_conflict_prompt_requires_test_verification(self, mock_gh_cls):
-        """The conflict prompt must instruct the agent to run tests before
-        committing. Without this, the agent resolves conflict markers and
-        commits immediately — missing semantic breakage (e.g. main changed a
-        SQL query structure but the branch's tests still assert the old one).
-        """
+        """The edit-only agent must test before orchestration commits."""
         o, _ = _make_orchestrator(_make_workflow())
         main_gh = MagicMock()
         wt_gh = MagicMock()
@@ -632,6 +730,7 @@ class TestResolveMergeConflictsWorktreeIsolation:
             ),  # merge (conflict)
         ]
         mock_gh_cls.side_effect = [main_gh, wt_gh, caller_gh]
+        _set_valid_merge_result(o, wt_gh)
 
         o._run_agent = MagicMock()
         from app.modules.workspace.autonomous.models import AgentTaskResult
@@ -645,15 +744,187 @@ class TestResolveMergeConflictsWorktreeIsolation:
         o._resolve_merge_conflicts(caller_gh, "auto-dev/fc82f22a", 1103)
 
         prompt = o._run_agent.call_args.kwargs.get("prompt", "")
-        # Must instruct the agent to run tests before committing.
+        # The agent only edits and tests. Trusted orchestration owns all
+        # mutating git operations because the agent command guard denies them.
         assert "pytest" in prompt
         assert "测试" in prompt or "test" in prompt.lower()
-        # Test step must come BEFORE the commit step.
-        test_pos = prompt.lower().find("pytest")
-        commit_pos = prompt.lower().find("git commit")
-        assert test_pos < commit_pos, "tests must run before git commit"
+        assert "不要执行 git add、git commit 或 git push" in prompt
+        assert "暂存、提交与推送由编排器" in prompt
         # Must require a summary report (for timeline tldr visibility).
         assert "总结" in prompt, "prompt must require a summary report"
+        assert "merge-wf-822" in prompt
+        assert "禁止调用 EnterWorktree" in prompt
+
+    @patch("app.modules.workspace.autonomous.orchestrator.GitHubOps")
+    def test_success_with_conflict_markers_fails_before_push(self, mock_gh_cls):
+        """Model success cannot bypass conflict-marker verification."""
+        o, _ = _make_orchestrator(_make_workflow())
+        main_gh = MagicMock()
+        wt_gh = MagicMock()
+        caller_gh = MagicMock()
+        wt_gh.get_current_commit.return_value = "head-before"
+        wt_gh.get_current_branch.return_value = "auto-dev/fc82f22a"
+        wt_gh._run_git.side_effect = [
+            MagicMock(returncode=0, stdout="", stderr=""),  # fetch
+            MagicMock(
+                returncode=1,
+                stdout="CONFLICT (content): app/x.py\n",
+                stderr="",
+            ),
+        ]
+        wt_gh.get_unmerged_paths.return_value = ["app/x.py"]
+        wt_gh.get_conflict_marker_paths.return_value = ["app/x.py"]
+        mock_gh_cls.side_effect = [main_gh, wt_gh]
+        from app.modules.workspace.autonomous.models import AgentTaskResult
+
+        o._run_agent = MagicMock(
+            return_value=AgentTaskResult(
+                session_id="resolver", success=True, response_text="resolved"
+            )
+        )
+
+        import pytest
+
+        with pytest.raises(RuntimeError, match="conflict markers"):
+            o._resolve_merge_conflicts(caller_gh, "auto-dev/fc82f22a", 1103)
+
+        wt_gh.git_push.assert_not_called()
+        main_gh.remove_worktree.assert_called_once()
+
+    @patch("app.modules.workspace.autonomous.orchestrator.GitHubOps")
+    def test_success_without_merge_commit_fails_before_push(self, mock_gh_cls):
+        """A no-op resolver response must terminate instead of looping forever."""
+        o, _ = _make_orchestrator(_make_workflow())
+        main_gh = MagicMock()
+        wt_gh = MagicMock()
+        caller_gh = MagicMock()
+        wt_gh.get_current_commit.side_effect = ["head-before", "head-before"]
+        wt_gh.get_current_branch.return_value = "auto-dev/fc82f22a"
+        wt_gh._run_git.side_effect = [
+            MagicMock(returncode=0, stdout="", stderr=""),  # fetch
+            MagicMock(
+                returncode=1,
+                stdout="CONFLICT (content): app/x.py\n",
+                stderr="",
+            ),
+        ]
+        wt_gh.get_unmerged_paths.side_effect = [["app/x.py"], []]
+        wt_gh.get_conflict_marker_paths.return_value = []
+        mock_gh_cls.side_effect = [main_gh, wt_gh]
+        from app.modules.workspace.autonomous.models import AgentTaskResult
+
+        o._run_agent = MagicMock(
+            return_value=AgentTaskResult(
+                session_id="resolver", success=True, response_text="resolved"
+            )
+        )
+
+        import pytest
+
+        with pytest.raises(RuntimeError, match="made no commit"):
+            o._resolve_merge_conflicts(caller_gh, "auto-dev/fc82f22a", 1103)
+
+        wt_gh.git_push.assert_not_called()
+        main_gh.remove_worktree.assert_called_once()
+
+    @patch("app.modules.workspace.autonomous.orchestrator.GitHubOps")
+    def test_post_stage_unmerged_paths_fail_before_commit(self, mock_gh_cls):
+        """Trusted staging must actually clear every U-stage entry."""
+        o, _ = _make_orchestrator(_make_workflow())
+        main_gh = MagicMock()
+        wt_gh = MagicMock()
+        caller_gh = MagicMock()
+        wt_gh.get_current_commit.return_value = "head-before"
+        wt_gh.get_current_branch.return_value = "auto-dev/fc82f22a"
+        wt_gh._run_git.side_effect = [
+            MagicMock(returncode=0, stdout="", stderr=""),
+            MagicMock(returncode=1, stdout="CONFLICT (content): app/x.py\n", stderr=""),
+        ]
+        wt_gh.get_unmerged_paths.side_effect = [["app/x.py"], ["app/x.py"]]
+        wt_gh.get_conflict_marker_paths.return_value = []
+        mock_gh_cls.side_effect = [main_gh, wt_gh]
+        from app.modules.workspace.autonomous.models import AgentTaskResult
+
+        o._run_agent = MagicMock(
+            return_value=AgentTaskResult(
+                session_id="resolver", success=True, response_text="resolved"
+            )
+        )
+
+        with pytest.raises(RuntimeError, match="unmerged paths after staging"):
+            o._resolve_merge_conflicts(caller_gh, "auto-dev/fc82f22a", 1103)
+
+        wt_gh.git_add_all.assert_called_once()
+        wt_gh.git_commit.assert_not_called()
+        wt_gh.git_push.assert_not_called()
+        failed_updates = [
+            call.args[1]
+            for call in o.repo.update_milestone.call_args_list
+            if call.args[1].get("status") == "failed"
+        ]
+        assert failed_updates
+
+    @patch("app.modules.workspace.autonomous.orchestrator.GitHubOps")
+    def test_clean_merge_no_op_refuses_unchanged_push(self, mock_gh_cls):
+        """A clean but unchanged merge must not be pushed and retried forever."""
+        o, _ = _make_orchestrator(_make_workflow())
+        main_gh = MagicMock()
+        wt_gh = MagicMock()
+        wt_gh._run_git.side_effect = [
+            MagicMock(returncode=0, stdout="", stderr=""),
+            MagicMock(returncode=0, stdout="Already up to date.\n", stderr=""),
+        ]
+        wt_gh.get_current_branch.return_value = "auto-dev/fc82f22a"
+        wt_gh.get_current_commit.side_effect = ["same-head", "same-head"]
+        mock_gh_cls.side_effect = [main_gh, wt_gh]
+
+        with pytest.raises(RuntimeError, match="made no commit"):
+            o._resolve_merge_conflicts(MagicMock(), "auto-dev/fc82f22a", 1103)
+
+        wt_gh.git_push.assert_not_called()
+
+    @pytest.mark.parametrize("actual_branch", ["", "auto-dev/unrelated"])
+    @patch("app.modules.workspace.autonomous.orchestrator.GitHubOps")
+    def test_branch_mismatch_fails_closed(self, mock_gh_cls, actual_branch):
+        """Empty or different branches are never rewritten into the push target."""
+        o, _ = _make_orchestrator(_make_workflow())
+        main_gh = MagicMock()
+        wt_gh = MagicMock()
+        wt_gh._run_git.side_effect = [
+            MagicMock(returncode=0, stdout="", stderr=""),
+            MagicMock(returncode=0, stdout="merged\n", stderr=""),
+        ]
+        wt_gh.get_current_branch.return_value = actual_branch
+        wt_gh.get_current_commit.side_effect = ["head-before", "head-after"]
+        mock_gh_cls.side_effect = [main_gh, wt_gh]
+
+        with pytest.raises(RuntimeError, match="branch mismatch"):
+            o._resolve_merge_conflicts(MagicMock(), "auto-dev/fc82f22a", 1103)
+
+        wt_gh.git_push.assert_not_called()
+
+    @pytest.mark.parametrize("ancestry", [(False, True), (True, False), (None, True)])
+    @patch("app.modules.workspace.autonomous.orchestrator.GitHubOps")
+    def test_both_merge_parents_must_be_ancestors(self, mock_gh_cls, ancestry):
+        """The resolved head must contain both the PR head and fetched main."""
+        o, _ = _make_orchestrator(_make_workflow())
+        main_gh = MagicMock()
+        wt_gh = MagicMock()
+        wt_gh._run_git.side_effect = [
+            MagicMock(returncode=0, stdout="", stderr=""),
+            MagicMock(returncode=0, stdout="merged\n", stderr=""),
+        ]
+        wt_gh.get_current_branch.return_value = "auto-dev/fc82f22a"
+        wt_gh.get_current_commit.side_effect = ["head-before", "head-after"]
+        o._ancestor_check = MagicMock(side_effect=list(ancestry))
+        mock_gh_cls.side_effect = [main_gh, wt_gh]
+
+        with pytest.raises(RuntimeError, match="ancestry verification failed"):
+            o._resolve_merge_conflicts(MagicMock(), "auto-dev/fc82f22a", 1103)
+
+        assert o._ancestor_check.call_args_list[0].args[1:] == ("head-before", "head-after")
+        assert o._ancestor_check.call_args_list[1].args[1:] == ("origin/main", "head-after")
+        wt_gh.git_push.assert_not_called()
 
     @patch("app.modules.workspace.autonomous.orchestrator.GitHubOps")
     def test_conflict_milestone_records_tldr_and_summary(self, mock_gh_cls):
@@ -673,6 +944,7 @@ class TestResolveMergeConflictsWorktreeIsolation:
             ),  # merge (conflict)
         ]
         mock_gh_cls.side_effect = [main_gh, wt_gh, caller_gh]
+        _set_valid_merge_result(o, wt_gh)
 
         o._run_agent = MagicMock()
         from app.modules.workspace.autonomous.models import AgentTaskResult
@@ -707,6 +979,7 @@ class TestResolveMergeConflictsWorktreeIsolation:
             MagicMock(returncode=0, stdout="", stderr=""),  # merge clean
         ]
         mock_gh_cls.side_effect = [main_gh, wt_gh, caller_gh]
+        _set_valid_merge_result(o, wt_gh, conflict=False)
 
         o._resolve_merge_conflicts(caller_gh, "auto-dev/fc82f22a", 1103)
 
@@ -735,6 +1008,7 @@ class TestResolveMergeConflictsWorktreeIsolation:
         ]
         # GitHubOps construction order: main_gh, rebound_gh (after removal), wt_gh
         mock_gh_cls.side_effect = [main_gh, rebound_gh, wt_gh]
+        _set_valid_merge_result(o, wt_gh, conflict=False)
 
         # caller_gh simulates the stale handle from _do_merge; it should be
         # replaced by rebound_gh after worktree removal.


### PR DESCRIPTION
## Summary
- bind merge-conflict agent calls to a per-call workflow snapshot whose authoritative worktree is the isolated `merge-<workflow>` directory
- explicitly prohibit branch switching / nested worktrees in the conflict prompt
- fail closed before push when U-stage paths remain or no merge commit was created
- add an authoritative `GitHubOps.get_unmerged_paths()` helper and regression coverage

## Production root cause
Workflow 1894 correctly created `/home/rhuang/merge-72c08ad2` with an unmerged index, but `_run_agent()` recomputed the repository from the persisted workflow (whose `worktree_path` had already been cleared) and overwrote the explicit temp path with `/home/rhuang/open-ace`. The conflict agent therefore searched main instead of the isolated merge worktree.

The workflow was paused before the agent modified main; source status remained clean apart from the existing `.worktrees/` directory.

## Validation
- `21 passed, 9 deselected` in `tests/issues/822/test_merge_conflict_detection.py` (the deselected `TestDoMergeDeferredRetry` group is an existing documented baseline fixture issue)
- combined issue 822 + cross-user suite: 62 passed; 4 existing preparation mock failures reproduce outside this patch
- changed-files pre-commit: all passed
- `git diff --check`: passed

Independent agent review is required before merge and deployment.
