### PR TITLE
fix(autonomous): isolate merge resolver scope

### DIFF
--- a/app/modules/workspace/autonomous/github_ops.py
+++ b/app/modules/workspace/autonomous/github_ops.py
@@ -723,6 +723,14 @@ class GitHubOps:
         result = self._run_git(["rev-parse", "HEAD"])
         return result.stdout.strip()
 
+    def resolve_commit(self, ref: str) -> str:
+        """Resolve a ref to an immutable commit SHA."""
+        result = self._run_git(["rev-parse", "--verify", f"{ref}^{{commit}}"])
+        sha = result.stdout.strip()
+        if not sha:
+            raise GitHubOpsError(f"Unable to resolve commit ref: {ref}")
+        return sha
+
     def checkout(self, ref: str) -> None:
         """Checkout a branch or commit."""
         self._run_git(["checkout", ref])
@@ -1410,6 +1418,68 @@ class GitHubOps:
             )
         return [line.strip() for line in result.stdout.splitlines() if line.strip()]
 
+    def get_worktree_changed_paths(self) -> list[str]:
+        """Return tracked working-tree changes plus untracked files.
+
+        During a conflicted merge, clean changes brought in from the other
+        parent are already staged in the index.  This view therefore isolates
+        the resolver's still-unstaged edits (including U-stage paths) instead
+        of counting every file that arrived from ``origin/main``.
+        """
+        tracked = self._run_git(["diff", "--name-only"], check=False)
+        if tracked.returncode != 0:
+            raise GitHubOpsError(
+                f"Unable to inspect working-tree changes (exit code {tracked.returncode}): "
+                f"{(tracked.stderr or tracked.stdout).strip()}"
+            )
+        untracked = self._run_git(["ls-files", "--others", "--exclude-standard"], check=False)
+        if untracked.returncode != 0:
+            raise GitHubOpsError(
+                f"Unable to inspect untracked files (exit code {untracked.returncode}): "
+                f"{(untracked.stderr or untracked.stdout).strip()}"
+            )
+        return sorted(
+            {
+                line.strip()
+                for output in (tracked.stdout, untracked.stdout)
+                for line in output.splitlines()
+                if line.strip()
+            }
+        )
+
+    def get_index_snapshot(self) -> dict[str, tuple[str, ...]]:
+        """Return the complete staged-index identity grouped by path.
+
+        Each value contains the mode/blob/stage tuples emitted by
+        ``git ls-files --stage``.  U-stage paths therefore retain all base,
+        ours, and theirs entries, while normal staged files have one stage-0
+        entry.  ``-z`` keeps unusual filenames unambiguous.
+        """
+        result = self._run_git(["ls-files", "--stage", "-z"], check=False)
+        if result.returncode != 0:
+            raise GitHubOpsError(
+                f"Unable to snapshot git index (exit code {result.returncode}): "
+                f"{(result.stderr or result.stdout).strip()}"
+            )
+        entries: dict[str, list[str]] = {}
+        for record in result.stdout.split("\0"):
+            if not record:
+                continue
+            identity, separator, path = record.partition("\t")
+            if not separator or not identity or not path:
+                raise GitHubOpsError("Unable to parse git index snapshot")
+            entries.setdefault(path, []).append(identity)
+        return {path: tuple(sorted(identities)) for path, identities in entries.items()}
+
+    @staticmethod
+    def get_index_changed_paths(
+        before: dict[str, tuple[str, ...]], after: dict[str, tuple[str, ...]]
+    ) -> list[str]:
+        """Return paths whose stage entries were added, removed, or changed."""
+        return sorted(
+            path for path in set(before) | set(after) if before.get(path) != after.get(path)
+        )
+
     def get_conflict_marker_paths(self, paths: list[str]) -> list[str]:
         """Return files that still contain standard merge-conflict markers.
 
@@ -1419,6 +1489,15 @@ class GitHubOps:
         """
         if not paths:
             return []
+        existing_paths = [
+            path
+            for path in sorted(set(paths))
+            if self.path_exists_as_user(os.path.join(self.repo_path, path), file_only=True)
+        ]
+        # Deleting a conflicted file is a valid resolution. Owner-side
+        # ``git add -A`` records that deletion after this marker check.
+        if not existing_paths:
+            return []
         result = self._run_git(
             [
                 "grep",
@@ -1427,13 +1506,13 @@ class GitHubOps:
                 "-I",
                 "-E",
                 "-e",
-                r"^<<<<<<<( |$)",
+                r"^<{7,}( |$)",
                 "-e",
-                r"^=======$",
+                r"^={7,}$",
                 "-e",
-                r"^>>>>>>>( |$)",
+                r"^>{7,}( |$)",
                 "--",
-                *paths,
+                *existing_paths,
             ],
             check=False,
         )

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -8258,7 +8258,12 @@ class AutonomousOrchestrator:
             milestone_result = {}
             # Fetch latest main and merge into the branch.
             wt_gh._run_git(["fetch", "origin", "main"])
-            merge_result = wt_gh._run_git(["merge", "origin/main"], check=False)
+            # Worktrees share their common git dir, so another workflow can
+            # move origin/main while this resolver spends minutes editing and
+            # testing. FETCH_HEAD is the object guaranteed by the command
+            # above; pin it for the merge and every later graph/scope gate.
+            fetched_main_head = wt_gh.resolve_commit("FETCH_HEAD")
+            merge_result = wt_gh._run_git(["merge", fetched_main_head], check=False)
             # git writes conflict summaries to STDOUT (not stderr), so we must
             # check both streams. Checking only stderr left stderr empty on a
             # real conflict and the code misclassified it as a "non-conflict"
@@ -8286,6 +8291,17 @@ class AutonomousOrchestrator:
                     if unmerged_query_error:
                         detail += f"; unable to inspect unmerged index: {unmerged_query_error}"
                     raise GitHubOpsError(f"git merge failed (non-conflict): {detail}")
+
+                initial_unmerged_paths = wt_gh.get_unmerged_paths()
+                if not initial_unmerged_paths:
+                    raise GitHubOpsError(
+                        "git merge reported a conflict but the index has no unmerged paths"
+                    )
+                # Snapshot the complete conflicted index before exposing the
+                # worktree to the agent. PATH wrappers are policy guidance,
+                # not a security boundary: an agent or repository script can
+                # invoke an absolute git binary or write the index indirectly.
+                resolver_index_before = wt_gh.get_index_snapshot()
 
                 # Ask AI agent to resolve conflicts inside the temp worktree.
                 conflict_prompt = (
@@ -8398,11 +8414,35 @@ class AutonomousOrchestrator:
                             f"expected={branch_name!r}, actual={current_branch!r}"
                         )
                     unmerged_paths = wt_gh.get_unmerged_paths()
-                    marker_paths = wt_gh.get_conflict_marker_paths(unmerged_paths)
+                    marker_paths = wt_gh.get_conflict_marker_paths(
+                        sorted(set(initial_unmerged_paths) | set(unmerged_paths))
+                    )
                     if marker_paths:
                         raise RuntimeError(
                             "Conflict resolver left conflict markers in: "
                             + ", ".join(marker_paths[:10])
+                        )
+                    agent_head = wt_gh.get_current_commit()
+                    if agent_head != original_pr_head:
+                        raise RuntimeError(
+                            "Conflict resolver changed HEAD; commits and merge-state changes "
+                            "are reserved for the orchestrator"
+                        )
+                    resolver_index_after = wt_gh.get_index_snapshot()
+                    resolver_index_changes = wt_gh.get_index_changed_paths(
+                        resolver_index_before, resolver_index_after
+                    )
+                    if resolver_index_changes:
+                        raise RuntimeError(
+                            "Conflict resolver changed the Git index; staging is reserved for "
+                            "the orchestrator. Paths: " + ", ".join(resolver_index_changes[:10])
+                        )
+                    resolver_changed_paths = wt_gh.get_worktree_changed_paths()
+                    resolver_scope_error = self._scope_violation(resolver_changed_paths)
+                    if resolver_scope_error:
+                        raise RuntimeError(
+                            "Conflict resolver scope rejected before staging: "
+                            f"{resolver_scope_error}"
                         )
                     wt_gh.git_add_all()
                     remaining_unmerged = wt_gh.get_unmerged_paths()
@@ -8452,16 +8492,22 @@ class AutonomousOrchestrator:
                     raise RuntimeError("Merge resolution made no commit; refusing unchanged push")
 
                 pr_head_in_result = self._ancestor_check(wt_gh, original_pr_head, resolved_head)
-                main_head_in_result = self._ancestor_check(wt_gh, "origin/main", resolved_head)
+                main_head_in_result = self._ancestor_check(wt_gh, fetched_main_head, resolved_head)
                 if pr_head_in_result is not True or main_head_in_result is not True:
                     raise RuntimeError(
                         "Merge commit ancestry verification failed before push: "
                         f"pr_head={pr_head_in_result!r}, origin_main={main_head_in_result!r}"
                     )
                 merge_scope_wf = dict(wf)
-                merge_scope_wf["base_commit_sha"] = "origin/main"
+                merge_scope_wf["base_commit_sha"] = fetched_main_head
+                # original_pr_head..resolved_head includes every upstream file
+                # brought in by the merge.  That is not autonomous resolver
+                # scope and can exceed the file cap on an old PR even when the
+                # agent touched one conflict.  The resolver's actual edit set
+                # was checked before staging above; this common gate now checks
+                # the cumulative PR delta relative to the fetched main.
                 scope_error = self._validate_autonomous_change_scope(
-                    wt_gh, merge_scope_wf, original_pr_head, resolved_head
+                    wt_gh, merge_scope_wf, fetched_main_head, resolved_head
                 )
                 if scope_error:
                     raise RuntimeError(

--- a/tests/issues/822/test_merge_conflict_detection.py
+++ b/tests/issues/822/test_merge_conflict_detection.py
@@ -69,6 +69,18 @@ def _make_orchestrator(wf):
     return o, mock_repo
 
 
+def _set_unchanged_index(gh, path: str = "app/x.py"):
+    snapshot = {
+        path: (
+            "100644 base 1",
+            "100644 ours 2",
+            "100644 theirs 3",
+        )
+    }
+    gh.get_index_snapshot.side_effect = [snapshot, snapshot]
+    gh.get_index_changed_paths.side_effect = GitHubOps.get_index_changed_paths
+
+
 def _set_valid_merge_result(
     orchestrator,
     gh,
@@ -78,11 +90,18 @@ def _set_valid_merge_result(
     resolved_head: str = "head-after",
 ):
     """Configure strict branch/index/commit-graph postconditions for a success test."""
+    gh.resolve_commit.return_value = "main-head"
     gh.get_current_branch.return_value = "auto-dev/fc82f22a"
-    gh.get_current_commit.side_effect = [original_head, resolved_head]
+    gh.get_current_commit.side_effect = (
+        [original_head, original_head, resolved_head]
+        if conflict
+        else [original_head, resolved_head]
+    )
     if conflict:
-        gh.get_unmerged_paths.side_effect = [["app/x.py"], []]
+        gh.get_unmerged_paths.side_effect = [["app/x.py"], ["app/x.py"], []]
         gh.get_conflict_marker_paths.return_value = []
+        gh.get_worktree_changed_paths.return_value = ["app/x.py"]
+        _set_unchanged_index(gh)
     orchestrator._ancestor_check = MagicMock(return_value=True)
     orchestrator._validate_autonomous_change_scope = MagicMock(return_value="")
 
@@ -103,11 +122,11 @@ class TestResolveMergeConflictsStdoutConflict:
         # Model _run_git so the *second* merge (check=False) returns CONFLICT
         # on stdout with empty stderr — the exact shape that broke #822.
         def run_git(args, check=True):
-            # Only the "merge origin/main" call matters; merge --abort and
+            # Only the merge of the pinned FETCH_HEAD commit matters; merge --abort and
             # other ops are no-ops.
-            if args[:2] == ["merge", "origin/main"] and check:
-                raise GitHubOpsError("git merge origin/main failed")
-            if args[:2] == ["merge", "origin/main"] and not check:
+            if args[:2] == ["merge", "main-head"] and check:
+                raise GitHubOpsError("git merge main-head failed")
+            if args[:2] == ["merge", "main-head"] and not check:
                 return MagicMock(
                     returncode=1,
                     stdout=(
@@ -149,11 +168,12 @@ class TestResolveMergeConflictsStdoutConflict:
         o, _ = _make_orchestrator(_make_workflow())
         mock_gh = MagicMock()
         mock_gh_cls.return_value = mock_gh
+        mock_gh.resolve_commit.return_value = "main-head"
 
         def run_git(args, check=True):
-            if args[:2] == ["merge", "origin/main"] and check:
+            if args[:2] == ["merge", "main-head"] and check:
                 raise GitHubOpsError("git merge failed")
-            if args[:2] == ["merge", "origin/main"] and not check:
+            if args[:2] == ["merge", "main-head"] and not check:
                 # No CONFLICT anywhere — a genuine non-conflict failure.
                 return MagicMock(returncode=1, stdout="fatal: bad object", stderr="")
             if args == ["diff", "--name-only", "--diff-filter=U"]:
@@ -176,7 +196,7 @@ class TestResolveMergeConflictsStdoutConflict:
         mock_gh_cls.return_value = mock_gh
 
         def run_git(args, check=True):
-            if args[:2] == ["merge", "origin/main"] and not check:
+            if args[:2] == ["merge", "main-head"] and not check:
                 return MagicMock(
                     returncode=1,
                     stdout="自动合并失败；修正冲突后提交结果。\n",
@@ -206,9 +226,10 @@ class TestResolveMergeConflictsStdoutConflict:
         o, _ = _make_orchestrator(_make_workflow())
         mock_gh = MagicMock()
         mock_gh_cls.return_value = mock_gh
+        mock_gh.resolve_commit.return_value = "main-head"
 
         def run_git(args, check=True):
-            if args[:2] == ["merge", "origin/main"] and not check:
+            if args[:2] == ["merge", "main-head"] and not check:
                 return MagicMock(returncode=128, stdout="", stderr="")
             if args == ["diff", "--name-only", "--diff-filter=U"]:
                 return MagicMock(returncode=0, stdout="", stderr="")
@@ -226,9 +247,10 @@ class TestResolveMergeConflictsStdoutConflict:
         o, _ = _make_orchestrator(_make_workflow())
         mock_gh = MagicMock()
         mock_gh_cls.return_value = mock_gh
+        mock_gh.resolve_commit.return_value = "main-head"
 
         def run_git(args, check=True):
-            if args[:2] == ["merge", "origin/main"] and not check:
+            if args[:2] == ["merge", "main-head"] and not check:
                 return MagicMock(returncode=1, stdout="", stderr="")
             if args == ["diff", "--name-only", "--diff-filter=U"]:
                 raise GitHubOpsError("index unavailable")
@@ -239,6 +261,26 @@ class TestResolveMergeConflictsStdoutConflict:
 
         with pytest.raises(GitHubOpsError, match="index unavailable"):
             o._resolve_merge_conflicts(mock_gh, "auto-dev/fc82f22a", 1103)
+
+    @patch("app.modules.workspace.autonomous.orchestrator.GitHubOps")
+    def test_conflict_text_without_u_stage_fails_closed(self, mock_gh_cls):
+        """English output alone cannot launch a resolver without an unmerged index."""
+        o, _ = _make_orchestrator(_make_workflow())
+        main_gh = MagicMock()
+        wt_gh = MagicMock()
+        wt_gh.resolve_commit.return_value = "main-head"
+        wt_gh._run_git.side_effect = [
+            MagicMock(returncode=0, stdout="", stderr=""),
+            MagicMock(returncode=1, stdout="CONFLICT (content): app/x.py\n", stderr=""),
+        ]
+        wt_gh.get_unmerged_paths.return_value = []
+        mock_gh_cls.side_effect = [main_gh, wt_gh]
+        o._run_agent = MagicMock()
+
+        with pytest.raises(GitHubOpsError, match="no unmerged paths"):
+            o._resolve_merge_conflicts(MagicMock(), "auto-dev/fc82f22a", 1103)
+
+        o._run_agent.assert_not_called()
 
 
 # ── Bug 2: branch-policy rejection uses --auto ───────────────────────────
@@ -513,14 +555,141 @@ class TestGetUnmergedPaths:
                 gh.get_unmerged_paths()
 
 
-class TestGetConflictMarkerPaths:
-    def test_returns_only_matching_conflict_files(self):
+class TestResolveCommit:
+    def test_resolves_ref_to_immutable_commit(self):
         gh = GitHubOps("/tmp/repo")
         with patch.object(
             gh,
             "_run_git",
-            return_value=MagicMock(returncode=0, stdout="app/a.py\napp/b.py\n", stderr=""),
+            return_value=MagicMock(returncode=0, stdout="abc123\n", stderr=""),
         ) as mock_run:
+            assert gh.resolve_commit("origin/main") == "abc123"
+        mock_run.assert_called_once_with(["rev-parse", "--verify", "origin/main^{commit}"])
+
+    def test_empty_resolution_raises(self):
+        gh = GitHubOps("/tmp/repo")
+        with patch.object(
+            gh,
+            "_run_git",
+            return_value=MagicMock(returncode=0, stdout="", stderr=""),
+        ):
+            with pytest.raises(GitHubOpsError, match="Unable to resolve"):
+                gh.resolve_commit("origin/main")
+
+
+class TestGetWorktreeChangedPaths:
+    def test_combines_tracked_unmerged_and_untracked_paths(self):
+        gh = GitHubOps("/tmp/repo")
+        with patch.object(
+            gh,
+            "_run_git",
+            side_effect=[
+                MagicMock(
+                    returncode=0,
+                    stdout="app/conflict.py\napp/edited.py\n",
+                    stderr="",
+                ),
+                MagicMock(returncode=0, stdout="tests/new_test.py\n", stderr=""),
+            ],
+        ) as mock_run:
+            assert gh.get_worktree_changed_paths() == [
+                "app/conflict.py",
+                "app/edited.py",
+                "tests/new_test.py",
+            ]
+        assert mock_run.call_args_list[0].args[0] == ["diff", "--name-only"]
+        assert mock_run.call_args_list[1].args[0] == [
+            "ls-files",
+            "--others",
+            "--exclude-standard",
+        ]
+
+    @pytest.mark.parametrize("failed_probe", [0, 1])
+    def test_probe_failure_raises(self, failed_probe):
+        results = [
+            MagicMock(returncode=0, stdout="app/x.py\n", stderr=""),
+            MagicMock(returncode=0, stdout="", stderr=""),
+        ]
+        results[failed_probe] = MagicMock(returncode=128, stdout="", stderr="probe failed")
+        gh = GitHubOps("/tmp/repo")
+        with patch.object(gh, "_run_git", side_effect=results):
+            with pytest.raises(GitHubOpsError, match="exit code 128"):
+                gh.get_worktree_changed_paths()
+
+
+class TestIndexSnapshot:
+    def test_parses_stage_zero_and_unmerged_entries(self):
+        output = (
+            "100644 blob-a 0\tapp/clean.py\0"
+            "100644 blob-base 1\tapp/conflict.py\0"
+            "100644 blob-ours 2\tapp/conflict.py\0"
+            "100644 blob-theirs 3\tapp/conflict.py\0"
+        )
+        gh = GitHubOps("/tmp/repo")
+        with patch.object(
+            gh,
+            "_run_git",
+            return_value=MagicMock(returncode=0, stdout=output, stderr=""),
+        ) as mock_run:
+            assert gh.get_index_snapshot() == {
+                "app/clean.py": ("100644 blob-a 0",),
+                "app/conflict.py": (
+                    "100644 blob-base 1",
+                    "100644 blob-ours 2",
+                    "100644 blob-theirs 3",
+                ),
+            }
+        mock_run.assert_called_once_with(["ls-files", "--stage", "-z"], check=False)
+
+    def test_snapshot_probe_and_parse_fail_closed(self):
+        gh = GitHubOps("/tmp/repo")
+        with patch.object(
+            gh,
+            "_run_git",
+            return_value=MagicMock(returncode=128, stdout="", stderr="bad index"),
+        ):
+            with pytest.raises(GitHubOpsError, match="exit code 128"):
+                gh.get_index_snapshot()
+        with patch.object(
+            gh,
+            "_run_git",
+            return_value=MagicMock(returncode=0, stdout="malformed\0", stderr=""),
+        ):
+            with pytest.raises(GitHubOpsError, match="parse git index"):
+                gh.get_index_snapshot()
+
+    def test_diff_detects_added_removed_blob_and_stage_changes(self):
+        before = {
+            "deleted.py": ("100644 old 0",),
+            "modified.py": ("100644 old 0",),
+            "resolved.py": ("100644 base 1", "100644 ours 2", "100644 theirs 3"),
+            "unchanged.py": ("100644 same 0",),
+        }
+        after = {
+            "added.py": ("100644 new 0",),
+            "modified.py": ("100644 new 0",),
+            "resolved.py": ("100644 resolved 0",),
+            "unchanged.py": ("100644 same 0",),
+        }
+        assert GitHubOps.get_index_changed_paths(before, after) == [
+            "added.py",
+            "deleted.py",
+            "modified.py",
+            "resolved.py",
+        ]
+
+
+class TestGetConflictMarkerPaths:
+    def test_returns_only_matching_conflict_files(self):
+        gh = GitHubOps("/tmp/repo")
+        with (
+            patch.object(gh, "path_exists_as_user", return_value=True),
+            patch.object(
+                gh,
+                "_run_git",
+                return_value=MagicMock(returncode=0, stdout="app/a.py\napp/b.py\n", stderr=""),
+            ) as mock_run,
+        ):
             assert gh.get_conflict_marker_paths(["app/a.py", "app/b.py"]) == [
                 "app/a.py",
                 "app/b.py",
@@ -528,25 +697,52 @@ class TestGetConflictMarkerPaths:
         command = mock_run.call_args.args[0]
         assert command[:4] == ["grep", "--no-index", "-l", "-I"]
         assert command[-3:] == ["--", "app/a.py", "app/b.py"]
+        assert r"^<{7,}( |$)" in command
+        assert r"^={7,}$" in command
+        assert r"^>{7,}( |$)" in command
 
     def test_no_matches_returns_empty_list(self):
         gh = GitHubOps("/tmp/repo")
-        with patch.object(
-            gh,
-            "_run_git",
-            return_value=MagicMock(returncode=1, stdout="", stderr=""),
+        with (
+            patch.object(gh, "path_exists_as_user", return_value=True),
+            patch.object(
+                gh,
+                "_run_git",
+                return_value=MagicMock(returncode=1, stdout="", stderr=""),
+            ),
         ):
             assert gh.get_conflict_marker_paths(["app/a.py"]) == []
 
     def test_probe_failure_raises(self):
         gh = GitHubOps("/tmp/repo")
-        with patch.object(
-            gh,
-            "_run_git",
-            return_value=MagicMock(returncode=128, stdout="", stderr="bad path"),
+        with (
+            patch.object(gh, "path_exists_as_user", return_value=True),
+            patch.object(
+                gh,
+                "_run_git",
+                return_value=MagicMock(returncode=128, stdout="", stderr="bad path"),
+            ),
         ):
             with pytest.raises(GitHubOpsError, match="exit code 128"):
                 gh.get_conflict_marker_paths(["app/a.py"])
+
+    def test_deleted_conflict_path_is_a_valid_marker_free_resolution(self):
+        gh = GitHubOps("/tmp/repo")
+        with (
+            patch.object(gh, "path_exists_as_user", return_value=False),
+            patch.object(gh, "_run_git") as mock_run,
+        ):
+            assert gh.get_conflict_marker_paths(["app/deleted.py"]) == []
+        mock_run.assert_not_called()
+
+    def test_detects_custom_marker_size_larger_than_seven(self, tmp_path):
+        conflict_file = tmp_path / "conflict.py"
+        conflict_file.write_text(
+            "<<<<<<<<<< HEAD\nours\n==========\ntheirs\n>>>>>>>>>> main\n",
+            encoding="utf-8",
+        )
+        gh = GitHubOps(str(tmp_path))
+        assert gh.get_conflict_marker_paths(["conflict.py"]) == ["conflict.py"]
 
 
 # ── Bug 3: isolated temp worktree for conflict resolution ────────────────
@@ -792,13 +988,132 @@ class TestResolveMergeConflictsWorktreeIsolation:
         main_gh.remove_worktree.assert_called_once()
 
     @patch("app.modules.workspace.autonomous.orchestrator.GitHubOps")
+    def test_staged_file_still_scans_initial_conflict_path(self, mock_gh_cls):
+        """Clearing U-stage cannot hide unresolved markers from the owner gate."""
+        o, _ = _make_orchestrator(_make_workflow())
+        main_gh = MagicMock()
+        wt_gh = MagicMock()
+        caller_gh = MagicMock()
+        wt_gh.resolve_commit.return_value = "main-head"
+        wt_gh.get_current_commit.return_value = "head-before"
+        wt_gh.get_current_branch.return_value = "auto-dev/fc82f22a"
+        wt_gh._run_git.side_effect = [
+            MagicMock(returncode=0, stdout="", stderr=""),
+            MagicMock(returncode=1, stdout="CONFLICT (content): app/x.py\n", stderr=""),
+        ]
+        # Agent bypasses the PATH guard and stages the path, clearing U-stage.
+        wt_gh.get_unmerged_paths.side_effect = [["app/x.py"], []]
+        wt_gh.get_conflict_marker_paths.return_value = ["app/x.py"]
+        wt_gh.get_index_snapshot.return_value = {"app/x.py": ("100644 ours 2",)}
+        mock_gh_cls.side_effect = [main_gh, wt_gh]
+        from app.modules.workspace.autonomous.models import AgentTaskResult
+
+        o._run_agent = MagicMock(
+            return_value=AgentTaskResult(
+                session_id="resolver", success=True, response_text="staged"
+            )
+        )
+
+        with pytest.raises(RuntimeError, match="left conflict markers"):
+            o._resolve_merge_conflicts(caller_gh, "auto-dev/fc82f22a", 1103)
+
+        wt_gh.get_conflict_marker_paths.assert_called_once_with(["app/x.py"])
+        wt_gh.git_add_all.assert_not_called()
+        wt_gh.git_push.assert_not_called()
+
+    @patch("app.modules.workspace.autonomous.orchestrator.GitHubOps")
+    def test_agent_head_change_fails_before_owner_staging(self, mock_gh_cls):
+        """An absolute git commit/abort cannot be adopted by orchestration."""
+        o, _ = _make_orchestrator(_make_workflow())
+        main_gh = MagicMock()
+        wt_gh = MagicMock()
+        caller_gh = MagicMock()
+        wt_gh.resolve_commit.return_value = "main-head"
+        wt_gh.get_current_commit.side_effect = ["head-before", "agent-head"]
+        wt_gh.get_current_branch.return_value = "auto-dev/fc82f22a"
+        wt_gh._run_git.side_effect = [
+            MagicMock(returncode=0, stdout="", stderr=""),
+            MagicMock(returncode=1, stdout="CONFLICT (content): app/x.py\n", stderr=""),
+        ]
+        wt_gh.get_unmerged_paths.side_effect = [["app/x.py"], []]
+        wt_gh.get_conflict_marker_paths.return_value = []
+        wt_gh.get_index_snapshot.return_value = {"app/x.py": ("100644 resolved 0",)}
+        mock_gh_cls.side_effect = [main_gh, wt_gh]
+        from app.modules.workspace.autonomous.models import AgentTaskResult
+
+        o._run_agent = MagicMock(
+            return_value=AgentTaskResult(
+                session_id="resolver", success=True, response_text="committed"
+            )
+        )
+
+        with pytest.raises(RuntimeError, match="changed HEAD"):
+            o._resolve_merge_conflicts(caller_gh, "auto-dev/fc82f22a", 1103)
+
+        wt_gh.git_add_all.assert_not_called()
+        wt_gh.git_push.assert_not_called()
+
+    @patch("app.modules.workspace.autonomous.orchestrator.GitHubOps")
+    def test_deleted_conflict_file_is_staged_and_committed_by_owner(self, mock_gh_cls):
+        """Deleting a conflicted path is a valid edit-only resolver outcome."""
+        o, _ = _make_orchestrator(_make_workflow())
+        main_gh = MagicMock()
+        wt_gh = MagicMock()
+        caller_gh = MagicMock()
+        wt_gh.resolve_commit.return_value = "main-head"
+        wt_gh.get_current_commit.side_effect = [
+            "head-before",
+            "head-before",
+            "head-after",
+        ]
+        wt_gh.get_current_branch.return_value = "auto-dev/fc82f22a"
+        wt_gh._run_git.side_effect = [
+            MagicMock(returncode=0, stdout="", stderr=""),
+            MagicMock(
+                returncode=1,
+                stdout="CONFLICT (modify/delete): app/deleted.py\n",
+                stderr="",
+            ),
+        ]
+        wt_gh.get_unmerged_paths.side_effect = [
+            ["app/deleted.py"],
+            ["app/deleted.py"],
+            [],
+        ]
+        wt_gh.get_conflict_marker_paths.return_value = []
+        wt_gh.get_worktree_changed_paths.return_value = ["app/deleted.py"]
+        _set_unchanged_index(wt_gh, "app/deleted.py")
+        o._ancestor_check = MagicMock(return_value=True)
+        o._validate_autonomous_change_scope = MagicMock(return_value="")
+        mock_gh_cls.side_effect = [main_gh, wt_gh]
+        from app.modules.workspace.autonomous.models import AgentTaskResult
+
+        o._run_agent = MagicMock(
+            return_value=AgentTaskResult(
+                session_id="resolver", success=True, response_text="deleted intentionally"
+            )
+        )
+
+        o._resolve_merge_conflicts(caller_gh, "auto-dev/fc82f22a", 1103)
+
+        wt_gh.get_conflict_marker_paths.assert_called_once_with(["app/deleted.py"])
+        wt_gh.git_add_all.assert_called_once()
+        wt_gh.git_commit.assert_called_once()
+        wt_gh.git_push.assert_called_once()
+
+    @patch("app.modules.workspace.autonomous.orchestrator.GitHubOps")
     def test_success_without_merge_commit_fails_before_push(self, mock_gh_cls):
         """A no-op resolver response must terminate instead of looping forever."""
         o, _ = _make_orchestrator(_make_workflow())
         main_gh = MagicMock()
         wt_gh = MagicMock()
         caller_gh = MagicMock()
-        wt_gh.get_current_commit.side_effect = ["head-before", "head-before"]
+        wt_gh.get_current_commit.side_effect = [
+            "head-before",
+            "head-before",
+            "head-before",
+        ]
+        wt_gh.resolve_commit.return_value = "main-head"
         wt_gh.get_current_branch.return_value = "auto-dev/fc82f22a"
         wt_gh._run_git.side_effect = [
             MagicMock(returncode=0, stdout="", stderr=""),  # fetch
@@ -808,8 +1123,10 @@ class TestResolveMergeConflictsWorktreeIsolation:
                 stderr="",
             ),
         ]
-        wt_gh.get_unmerged_paths.side_effect = [["app/x.py"], []]
+        wt_gh.get_unmerged_paths.side_effect = [["app/x.py"], ["app/x.py"], []]
         wt_gh.get_conflict_marker_paths.return_value = []
+        wt_gh.get_worktree_changed_paths.return_value = ["app/x.py"]
+        _set_unchanged_index(wt_gh)
         mock_gh_cls.side_effect = [main_gh, wt_gh]
         from app.modules.workspace.autonomous.models import AgentTaskResult
 
@@ -835,13 +1152,20 @@ class TestResolveMergeConflictsWorktreeIsolation:
         wt_gh = MagicMock()
         caller_gh = MagicMock()
         wt_gh.get_current_commit.return_value = "head-before"
+        wt_gh.resolve_commit.return_value = "main-head"
         wt_gh.get_current_branch.return_value = "auto-dev/fc82f22a"
         wt_gh._run_git.side_effect = [
             MagicMock(returncode=0, stdout="", stderr=""),
             MagicMock(returncode=1, stdout="CONFLICT (content): app/x.py\n", stderr=""),
         ]
-        wt_gh.get_unmerged_paths.side_effect = [["app/x.py"], ["app/x.py"]]
+        wt_gh.get_unmerged_paths.side_effect = [
+            ["app/x.py"],
+            ["app/x.py"],
+            ["app/x.py"],
+        ]
         wt_gh.get_conflict_marker_paths.return_value = []
+        wt_gh.get_worktree_changed_paths.return_value = ["app/x.py"]
+        _set_unchanged_index(wt_gh)
         mock_gh_cls.side_effect = [main_gh, wt_gh]
         from app.modules.workspace.autonomous.models import AgentTaskResult
 
@@ -916,6 +1240,7 @@ class TestResolveMergeConflictsWorktreeIsolation:
         ]
         wt_gh.get_current_branch.return_value = "auto-dev/fc82f22a"
         wt_gh.get_current_commit.side_effect = ["head-before", "head-after"]
+        wt_gh.resolve_commit.return_value = "main-head"
         o._ancestor_check = MagicMock(side_effect=list(ancestry))
         mock_gh_cls.side_effect = [main_gh, wt_gh]
 
@@ -923,7 +1248,132 @@ class TestResolveMergeConflictsWorktreeIsolation:
             o._resolve_merge_conflicts(MagicMock(), "auto-dev/fc82f22a", 1103)
 
         assert o._ancestor_check.call_args_list[0].args[1:] == ("head-before", "head-after")
-        assert o._ancestor_check.call_args_list[1].args[1:] == ("origin/main", "head-after")
+        assert o._ancestor_check.call_args_list[1].args[1:] == ("main-head", "head-after")
+        wt_gh.git_push.assert_not_called()
+
+    @patch("app.modules.workspace.autonomous.orchestrator.GitHubOps")
+    def test_scope_excludes_files_brought_in_from_main(self, mock_gh_cls):
+        """An old PR may merge many upstream files while the resolver edits two."""
+        o, _ = _make_orchestrator(_make_workflow())
+        main_gh = MagicMock()
+        wt_gh = MagicMock()
+        caller_gh = MagicMock()
+        wt_gh._run_git.side_effect = [
+            MagicMock(returncode=0, stdout="", stderr=""),
+            MagicMock(returncode=1, stdout="CONFLICT (content): app/x.py\n", stderr=""),
+        ]
+        wt_gh.get_current_branch.return_value = "auto-dev/fc82f22a"
+        wt_gh.get_current_commit.side_effect = [
+            "old-pr-head",
+            "old-pr-head",
+            "resolved-head",
+        ]
+        wt_gh.resolve_commit.return_value = "fetched-main-head"
+        wt_gh.get_unmerged_paths.side_effect = [["app/x.py"], ["app/x.py"], []]
+        wt_gh.get_conflict_marker_paths.return_value = []
+        wt_gh.get_worktree_changed_paths.return_value = ["app/x.py", "tests/test_x.py"]
+        _set_unchanged_index(wt_gh)
+
+        def changed_files(base, _head):
+            if base == "old-pr-head":
+                return [f"upstream/file-{index}.py" for index in range(97)]
+            assert base == "fetched-main-head"
+            return ["app/x.py", "tests/test_x.py"]
+
+        wt_gh.get_changed_files.side_effect = changed_files
+        o._ancestor_check = MagicMock(return_value=True)
+        mock_gh_cls.side_effect = [main_gh, wt_gh]
+        from app.modules.workspace.autonomous.models import AgentTaskResult
+
+        o._run_agent = MagicMock(
+            return_value=AgentTaskResult(
+                session_id="resolver", success=True, response_text="77 passed"
+            )
+        )
+
+        o._resolve_merge_conflicts(caller_gh, "auto-dev/fc82f22a", 1103)
+
+        wt_gh.resolve_commit.assert_called_once_with("FETCH_HEAD")
+        assert wt_gh._run_git.call_args_list[1].args[0] == [
+            "merge",
+            "fetched-main-head",
+        ]
+        wt_gh.get_changed_files.assert_called_once_with("fetched-main-head", "resolved-head")
+        wt_gh.git_push.assert_called_once_with(branch="auto-dev/fc82f22a", force_with_lease=True)
+
+    @patch("app.modules.workspace.autonomous.orchestrator.GitHubOps")
+    def test_resolver_actual_edit_set_still_enforces_scope_cap(self, mock_gh_cls):
+        """Excluding upstream files must not weaken the resolver's own cap."""
+        o, _ = _make_orchestrator(_make_workflow())
+        main_gh = MagicMock()
+        wt_gh = MagicMock()
+        caller_gh = MagicMock()
+        wt_gh._run_git.side_effect = [
+            MagicMock(returncode=0, stdout="", stderr=""),
+            MagicMock(returncode=1, stdout="CONFLICT (content): app/x.py\n", stderr=""),
+        ]
+        wt_gh.get_current_commit.return_value = "old-pr-head"
+        wt_gh.resolve_commit.return_value = "fetched-main-head"
+        wt_gh.get_current_branch.return_value = "auto-dev/fc82f22a"
+        wt_gh.get_unmerged_paths.return_value = ["app/x.py"]
+        wt_gh.get_conflict_marker_paths.return_value = []
+        wt_gh.get_worktree_changed_paths.return_value = [
+            f"agent/file-{index}.py" for index in range(61)
+        ]
+        _set_unchanged_index(wt_gh)
+        mock_gh_cls.side_effect = [main_gh, wt_gh]
+        from app.modules.workspace.autonomous.models import AgentTaskResult
+
+        o._run_agent = MagicMock(
+            return_value=AgentTaskResult(
+                session_id="resolver", success=True, response_text="resolved"
+            )
+        )
+
+        with pytest.raises(RuntimeError, match="resolver scope rejected.*61 files"):
+            o._resolve_merge_conflicts(caller_gh, "auto-dev/fc82f22a", 1103)
+
+        wt_gh.git_add_all.assert_not_called()
+        wt_gh.git_commit.assert_not_called()
+        wt_gh.git_push.assert_not_called()
+
+    @patch("app.modules.workspace.autonomous.orchestrator.GitHubOps")
+    def test_agent_index_mutations_cannot_bypass_scope_cap(self, mock_gh_cls):
+        """Absolute git or scripts that stage files are included in resolver scope."""
+        o, _ = _make_orchestrator(_make_workflow())
+        main_gh = MagicMock()
+        wt_gh = MagicMock()
+        caller_gh = MagicMock()
+        wt_gh._run_git.side_effect = [
+            MagicMock(returncode=0, stdout="", stderr=""),
+            MagicMock(returncode=1, stdout="CONFLICT (content): agent/file-0.py\n", stderr=""),
+        ]
+        wt_gh.get_current_commit.return_value = "old-pr-head"
+        wt_gh.resolve_commit.return_value = "fetched-main-head"
+        wt_gh.get_current_branch.return_value = "auto-dev/fc82f22a"
+        wt_gh.get_unmerged_paths.return_value = ["agent/file-0.py"]
+        wt_gh.get_conflict_marker_paths.return_value = []
+        # A staged file disappears from normal `git diff`; only the remaining
+        # conflict is visible in the working tree.
+        wt_gh.get_worktree_changed_paths.return_value = ["agent/file-0.py"]
+        before = {f"agent/file-{index}.py": (f"100644 old-{index} 0",) for index in range(61)}
+        after = {f"agent/file-{index}.py": (f"100644 new-{index} 0",) for index in range(61)}
+        wt_gh.get_index_snapshot.side_effect = [before, after]
+        wt_gh.get_index_changed_paths.side_effect = GitHubOps.get_index_changed_paths
+        mock_gh_cls.side_effect = [main_gh, wt_gh]
+        from app.modules.workspace.autonomous.models import AgentTaskResult
+
+        o._run_agent = MagicMock(
+            return_value=AgentTaskResult(
+                session_id="resolver", success=True, response_text="resolved and staged"
+            )
+        )
+
+        with pytest.raises(RuntimeError, match="changed the Git index"):
+            o._resolve_merge_conflicts(caller_gh, "auto-dev/fc82f22a", 1103)
+
+        wt_gh.git_add_all.assert_not_called()
+        wt_gh.git_commit.assert_not_called()
         wt_gh.git_push.assert_not_called()
 
     @patch("app.modules.workspace.autonomous.orchestrator.GitHubOps")


### PR DESCRIPTION
## 问题

1894 的真实冲突 resolver 正确解决 audit_logger.py 并跑完 77 项测试后，push 前 scope gate 把 old PR head 到 merge result 之间由 main 带入的 97 个文件全部算作 agent 本轮修改，超过 60 文件上限并误判失败。

## 修复

- 在暂存前统计 tracked unstaged、U-stage 和 untracked 文件，作为 resolver 本轮真实编辑范围。
- resolver 本轮仍严格执行 60 文件上限。
- merge commit 的累计 PR 范围改为比较 origin/main 到 resolved head，不再把上游 main 自身变化算成 autonomous change。
- 分支、冲突标记、U-stage、双祖先和 push 门禁保持不变。

## 验证

- resolver 定向用例：36 passed。
- 模拟 main 带来 97 个文件、resolver 改 2 个文件：允许并推送。
- 模拟 resolver 自己改 61 个文件：暂存前拒绝。
- 与 Issue 1395 组合：82 passed；4 个既有 MagicMock JSON 序列化基线失败。
- changed-files pre-commit hooks 全部通过。

这是工作流代码修复，按约定保持 Draft，等待独立 agent 审查。