### PR TITLE
fix(files): prevent race condition in file upload by capturing state

### DIFF
--- a/frontend/src/components/work/LocalDirectoryBrowser.tsx
+++ b/frontend/src/components/work/LocalDirectoryBrowser.tsx
@@ -395,7 +395,7 @@ export const LocalDirectoryBrowser: React.FC<LocalDirectoryBrowserProps> = ({
     // If the user uploaded while in search mode, they expect to see the
     // uploaded file in the normal listing. Clearing the search state
     // restores the regular directory view so the new file is visible.
-    setSearchQuery("");
+    setSearchQuery('');
     setSearchResults(null);
     setSearchTruncated(false);
 

--- a/frontend/src/components/work/LocalDirectoryBrowser.tsx
+++ b/frontend/src/components/work/LocalDirectoryBrowser.tsx
@@ -345,13 +345,22 @@ export const LocalDirectoryBrowser: React.FC<LocalDirectoryBrowserProps> = ({
     // Reset input so selecting the same file again fires onChange.
     e.target.value = '';
 
-    if (!isWritable) {
+    const targetIsWritable = isWritable;
+
+    if (!targetIsWritable) {
       toast.error(
         t('uploadFailed', language) || 'Upload failed',
         t('notWritable', language) || 'Directory is not writable'
       );
       return;
     }
+
+    // Issue #1959 (root cause): Capture the target directory at the start.
+    // `currentPath` is React state and can change during async operations
+    // (e.g., if the user navigates to another directory while uploading).
+    // Using the captured value ensures files are uploaded to and refreshed
+    // from the intended directory.
+    const targetDir = currentPath;
 
     for (const file of Array.from(selected)) {
       if (file.size > MAX_UPLOAD_SIZE_MB * 1024 * 1024) {
@@ -365,7 +374,7 @@ export const LocalDirectoryBrowser: React.FC<LocalDirectoryBrowserProps> = ({
 
       setIsUploading(true);
       try {
-        const result = await fsApi.uploadFile(file, currentPath);
+        const result = await fsApi.uploadFile(file, targetDir);
         if (result.success) {
           toast.success(t('uploadSuccess', language) || 'File uploaded', file.name);
         } else {
@@ -382,10 +391,18 @@ export const LocalDirectoryBrowser: React.FC<LocalDirectoryBrowserProps> = ({
     }
 
     // Refresh the listing so the uploaded file appears.
+    // Issue #1959 (follow-up): Exit search mode before refreshing.
+    // If the user uploaded while in search mode, they expect to see the
+    // uploaded file in the normal listing. Clearing the search state
+    // restores the regular directory view so the new file is visible.
+    setSearchQuery("");
+    setSearchResults(null);
+    setSearchTruncated(false);
+
     // Issue #1959: wrap in try-catch to prevent unhandled exceptions,
     // even though fetchDirectories has its own error handling (Issue #1912).
     try {
-      await fetchDirectories(currentPath);
+      await fetchDirectories(targetDir);
     } catch (err) {
       console.error('Failed to refresh directory listing after upload:', err);
     }


### PR DESCRIPTION
## Summary

Fixes #1959 (root cause)

### Problem
When users upload files, the `currentPath` and `isWritable` state values could change during the async upload operation if:
- User navigates to another directory during upload
- Browser re-renders component for other reasons

This caused files to be uploaded to the wrong directory or the wrong directory to be refreshed after upload, making uploaded files appear missing.

### Solution
Capture `currentPath` and `isWritable` at upload initiation:
- Permission check uses captured `targetIsWritable`
- Upload target uses captured `targetDir`
- Directory refresh uses captured `targetDir`

Also clears search state after upload so user sees uploaded file in normal directory listing.

## Test Plan
- All 17 LocalDirectoryBrowser tests pass
- Deployed to node237 for manual verification