### PR TITLE
fix(usage): remove tenant_id condition from refresh logic

### DIFF
--- a/app/routes/usage.py
+++ b/app/routes/usage.py
@@ -159,8 +159,8 @@ def api_tools():
 def api_hosts():
     """Get list of all hosts from pre-aggregated summary table."""
     tenant_id = _current_tenant_id()
-    # Ensure summary is up to date for global scope
-    if tenant_id is None and summary_service.needs_refresh():
+    # Ensure summary is up to date
+    if summary_service.needs_refresh():
         summary_service.refresh_summary()
 
     if tenant_id is None:
@@ -182,7 +182,7 @@ def api_trend():
 
     # Ensure daily_stats is up to date
     daily_stats_repo = DailyStatsRepository()
-    if tenant_id is None and daily_stats_repo.needs_refresh():
+    if daily_stats_repo.needs_refresh():
         daily_stats_repo.refresh_stats()
 
     entries = usage_service.get_trend_data(


### PR DESCRIPTION
## Summary

Fixes #1972

Dashboard trend chart shows no data because `daily_stats` is never refreshed for admin users with `tenant_id=1`.

## Problem

The condition `tenant_id is None` was preventing refresh for admin users who have `tenant_id=1`. 

## Solution

Remove the `tenant_id is None` condition from refresh logic. The refresh should not be tied to tenant_id since:

1. `daily_stats` and `usage_summary` are global pre-aggregated tables
2. Tenant isolation is enforced at query time via `tenant_id` parameter
3. `needs_refresh()` already correctly determines if refresh is needed

## Changes

- `/api/hosts`: Remove tenant_id condition from summary refresh
- `/api/trend`: Remove tenant_id condition from daily_stats refresh

## Test Plan

- [ ] Admin user can see trend data on `/manage/dashboard`
- [ ] Tenant users only see their own tenant data
- [ ] No performance regression (refresh only triggers when needed)