### PR TITLE
fix(usage): inject stream_options and fix session message query

### DIFF
--- a/app/modules/workspace/llm_proxy_handler.py
+++ b/app/modules/workspace/llm_proxy_handler.py
@@ -1075,6 +1075,21 @@ def handle_llm_proxy_request(
 
             if not converted_from_responses:
                 body = request.get_data()
+                # 注入 stream_options 以获取流式响应的 usage 字段
+                # 参考: model_gateway/attribution.py build_body_transformer()
+                # 注意: converted_from_responses=True 时，请求体已转换且 stream=False，
+                #       不会进入此分支，无需额外检查
+                try:
+                    data = json.loads(body)
+                    if data.get("stream") is True:
+                        existing_so = data.get("stream_options")
+                        if isinstance(existing_so, dict):
+                            existing_so.setdefault("include_usage", True)
+                        else:
+                            data["stream_options"] = {"include_usage": True}
+                        body = json.dumps(data).encode("utf-8")
+                except (json.JSONDecodeError, ValueError, TypeError):
+                    pass  # 解析失败，使用原始请求体
 
             resp = http_requests.request(
                 method=request.method,

--- a/app/repositories/usage_repo.py
+++ b/app/repositories/usage_repo.py
@@ -1375,25 +1375,22 @@ class UsageRepository:
         start_date: str,
         end_date: str,
     ) -> tuple[int, int]:
-        """Query agent_sessions for session-backed tokens/requests in a window.
+        """Query session_messages for tokens/requests in a date window.
 
-        Shared by get_combined_usage (Manage page) and get_session_only_usage
-        (Work page) so the workspace_type/date/request-subquery filter lives in
-        one place — see #1272 review (avoid two copies drifting).
+        Changed from agent_sessions.created_at to session_messages.timestamp
+        to correctly count messages for long-running sessions like webui:N.
+        See Issue #1974 for details.
         """
         session_row = self.db.fetch_one(
             """
             SELECT
-                COALESCE(SUM(total_tokens), 0) as tokens,
-                COALESCE(SUM(
-                    (SELECT COUNT(*) FROM session_messages sm
-                     WHERE sm.session_id = agent_sessions.session_id
-                       AND sm.role = 'assistant')
-                ), 0) as requests
-            FROM agent_sessions
-            WHERE user_id = ?
-              AND workspace_type IN ('local', 'remote', 'terminal')
-              AND CAST(created_at AS DATE) >= ? AND CAST(created_at AS DATE) <= ?
+                COALESCE(SUM(sm.tokens_used), 0) as tokens,
+                COUNT(CASE WHEN sm.role = 'assistant' THEN 1 END) as requests
+            FROM session_messages sm
+            JOIN agent_sessions a ON sm.session_id = a.session_id
+            WHERE a.user_id = ?
+              AND a.workspace_type IN ('local', 'remote', 'terminal')
+              AND CAST(sm.timestamp AS DATE) >= ? AND CAST(sm.timestamp AS DATE) <= ?
         """,
             (user_id, start_date, end_date),
         )

--- a/tests/unit/test_usage_repo_session_only.py
+++ b/tests/unit/test_usage_repo_session_only.py
@@ -1,8 +1,11 @@
 """Tests for UsageRepository.get_session_only_usage (#1269 P1).
 
-Pins that the Work-page quota display reads agent_sessions only and does NOT
-touch daily_messages, per the #1125 data-contract rule that analysis fact
+Pins that the Work-page quota display reads session_messages (filtered by timestamp)
+and never daily_messages, per the #1125 data-contract rule that analysis fact
 tables must not participate in Workspace runtime display.
+
+Updated for Issue #1974: Query now filters by session_messages.timestamp instead
+of agent_sessions.created_at to correctly count messages for long-running sessions.
 """
 
 from unittest.mock import MagicMock
@@ -17,8 +20,8 @@ def _make_repo(db):
 
 
 class TestGetSessionOnlyUsage:
-    def test_does_not_query_daily_messages(self):
-        """The query must read agent_sessions and never daily_messages."""
+    def test_queries_session_messages_by_timestamp(self):
+        """The query must read session_messages and filter by message timestamp."""
         db = MagicMock()
         db.fetch_one.return_value = {"tokens": 12345, "requests": 7}
         repo = _make_repo(db)
@@ -28,8 +31,12 @@ class TestGetSessionOnlyUsage:
         )
 
         sql = db.fetch_one.call_args[0][0]
-        assert "FROM agent_sessions" in sql
+        # Query now starts from session_messages and joins agent_sessions
+        assert "FROM session_messages" in sql
+        assert "JOIN agent_sessions" in sql
         assert "daily_messages" not in sql
+        # Must filter by message timestamp, not session created_at
+        assert "CAST(sm.timestamp AS DATE)" in sql
         # Must cover all workspace types (local autonomous/terminal/remote).
         assert "workspace_type IN ('local', 'remote', 'terminal')" in sql
         assert result["tokens"] == 12345


### PR DESCRIPTION
## Summary

Fixes #1974: WebUI local workspace messages, tokens, and requests not being recorded.

## Root Causes

1. **Direct provider path missing stream_options injection**
   - When using Alibaba Cloud Bailian API directly (bypassing LiteLLM gateway), streaming responses returned `usage=None`
   - OpenAI API requires `stream_options: {include_usage: true}` parameter to include usage data in streaming responses
   - This caused `_record_llm_usage()` to silently return without recording any usage

2. **Session usage query filtering by wrong timestamp**
   - `_session_usage` method filtered by `agent_sessions.created_at` instead of `session_messages.timestamp`
   - Long-running sessions that span multiple days would only have their first day's messages counted
   - Messages sent on subsequent days were not included in the date range filter

## Changes

### `app/modules/workspace/llm_proxy_handler.py`
- Inject `stream_options: {include_usage: true}` before direct provider request
- Mirrors the same logic already present in the gateway path (`build_body_transformer`)

### `app/repositories/usage_repo.py`
- Rewrite `_session_usage` query to start from `session_messages` table
- Join `agent_sessions` to filter by workspace type
- Filter by `CAST(sm.timestamp AS DATE)` instead of `a.created_at`

### `tests/unit/test_usage_repo_session_only.py`
- Update test to verify new SQL structure: `FROM session_messages JOIN agent_sessions`
- Add assertion for timestamp filtering: `CAST(sm.timestamp AS DATE)`

## Verification

- Bailian API behavior verified: without `stream_options`, streaming returns `usage: None`; with it, returns actual token counts
- Test updated to match new query structure

## Related

- Issue analysis: https://github.com/open-ace/open-ace/issues/1974#issuecomment-5046142423