### PR TITLE
fix(fetch): 使用正确Python版本执行fetch脚本

### DIFF
--- a/app/routes/fetch.py
+++ b/app/routes/fetch.py
@@ -84,7 +84,9 @@ def run_fetch_scripts():
         # For production, configure a dedicated service account with read-only
         # access to user home dirs and set FETCH_USE_SUDO=false in config.
         use_sudo = os.environ.get("FETCH_USE_SUDO", "true").lower() == "true"
-        python_path = "/usr/bin/python3" if use_sudo else sys.executable
+        # Use the same Python interpreter as the main process to ensure compatibility
+        # with type annotation syntax (e.g., str | None requires Python 3.10+)
+        python_path = sys.executable
 
         def _build_cmd(script_path, args):
             cmd = []

--- a/scripts/install-central/package-method/install.sh
+++ b/scripts/install-central/package-method/install.sh
@@ -2063,6 +2063,15 @@ configure_sudoers() {
     local sudoers_file="/etc/sudoers.d/open-ace-webui"
 
     # Build fetch script rules (check all 5 scripts)
+    # 【修复 Issue #1977】支持 Python 3.10+ 类型注解语法
+    # 使用安装的 Python 版本，而非系统 /usr/bin/python3（可能是 3.9）
+    local python_bin="${install_dir}/agent_bin/python3"
+    if [ ! -x "$python_bin" ]; then
+        python_bin="/usr/local/bin/python3.12"
+    fi
+    if [ ! -x "$python_bin" ]; then
+        python_bin="/usr/bin/python3"
+    fi
     local fetch_scripts=("fetch_qwen.py" "fetch_claude.py" "fetch_openclaw.py" "fetch_codex.py" "fetch_zcode.py")
     local fetch_rules=""
     for script in "${fetch_scripts[@]}"; do
@@ -2070,7 +2079,7 @@ configure_sudoers() {
         if [ -f "$script_path" ]; then
             fetch_rules="${fetch_rules}
 # Allow $run_user to run $script as root for multi-user data collection
-$run_user ALL=(root) NOPASSWD: /usr/bin/python3 $script_path *"
+$run_user ALL=(root) NOPASSWD: $python_bin $script_path *"
         fi
     done
 


### PR DESCRIPTION
## 问题

Fixes #1977

fetch 脚本使用 `/usr/bin/python3`（Python 3.9），导致类型注解语法错误：

```
TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'
```

所有 fetch 脚本（qwen、claude、codex、openclaw、zcode）都因此失败，消息无法同步到数据库。

## 根因

```
服务器主进程: Python 3.12
fetch 脚本调用: sudo -n /usr/bin/python3 → Python 3.9 ❌
```

`str | None` 类型注解语法需要 Python 3.10+。

## 修改内容

| 文件 | 修改 |
|------|------|
| `app/routes/fetch.py` | `python_path = sys.executable` 使用当前 Python |
| `install.sh` | sudoers 动态选择 Python 路径 |

## 测试

- [ ] 本地 pre-commit 通过
- [ ] CI 通过

## 部署说明

已部署服务器需手动更新 sudoers：

```bash
sudo sed -i 's|/usr/bin/python3|/usr/local/bin/python3.12|g' /etc/sudoers.d/open-ace-webui
sudo systemctl restart openace
```

Generated with Qwen Code (17-shotted by Qwen-Coder)