### PR TITLE
fix(autonomous): validate effective pre-merge PR scope

### DIFF
--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -2187,6 +2187,52 @@ class AutonomousOrchestrator:
                 return f"{label.capitalize()} {violation}"
         return ""
 
+    def _validate_pre_merge_change_scope(
+        self,
+        gh: GitHubOps,
+        wf: dict,
+        pr_head_sha: str,
+    ) -> str:
+        """Validate the effective PR delta against an immutable main snapshot.
+
+        A conflict resolver can merge months of upstream main history into an
+        old PR branch.  The workflow's original ``base_commit_sha`` must not be
+        used as the pre-merge "current round" boundary after that merge: doing
+        so counts every upstream file as an autonomous edit.  The graph merge
+        base with the just-fetched main commit is the effective PR base both
+        before and after an upstream merge.
+        """
+        if not pr_head_sha:
+            return "Pre-merge change scope could not be verified: missing PR head"
+        try:
+            gh._run_git(["fetch", "origin", "main"])
+            fetched_main_head = gh.resolve_commit("FETCH_HEAD")
+            merge_base_result = gh._run_git(
+                ["merge-base", pr_head_sha, fetched_main_head], check=False
+            )
+            effective_base = merge_base_result.stdout.strip()
+            if merge_base_result.returncode != 0 or not effective_base:
+                raise GitHubOpsError("git merge-base returned no commit")
+        except Exception as exc:
+            return f"Pre-merge change scope could not derive effective PR base: {exc}"
+
+        effective_wf = dict(wf)
+        effective_wf["base_commit_sha"] = effective_base
+        scope_error = self._validate_autonomous_change_scope(
+            gh, effective_wf, effective_base, pr_head_sha
+        )
+        if not scope_error and (wf.get("base_commit_sha") or "").strip() != effective_base:
+            # Once upstream main has been merged, subsequent CI-repair rounds
+            # must use the same effective PR base rather than the stale branch
+            # creation point.  This updates only scope metadata, never usage or
+            # session history.
+            self._update_workflow({"base_commit_sha": effective_base})
+            # _do_merge can enter CI repair later in this same scheduler cycle.
+            # Keep that in-memory snapshot aligned with the persisted value so
+            # its scope validator cannot reuse the stale branch-creation base.
+            wf["base_commit_sha"] = effective_base
+        return scope_error
+
     def _get_ci_repair_prompt(self, wf: dict) -> str:
         """Return merge-phase CI repair context, or empty."""
         context = wf.get("ci_repair_context", "")
@@ -8086,9 +8132,7 @@ class AutonomousOrchestrator:
         if pr_number:
             try:
                 pr_head_sha = gh.get_pr_head_sha(pr_number)
-                scope_error = self._validate_autonomous_change_scope(
-                    gh, wf, (wf.get("base_commit_sha") or pr_head_sha), pr_head_sha
-                )
+                scope_error = self._validate_pre_merge_change_scope(gh, wf, pr_head_sha)
             except Exception as exc:
                 scope_error = f"Pre-merge change scope could not be verified: {exc}"
             if scope_error:

--- a/tests/issues/822/test_merge_conflict_detection.py
+++ b/tests/issues/822/test_merge_conflict_detection.py
@@ -13,7 +13,7 @@ Two bugs caused worktrees in the 807-845 batch to fail at the merge phase:
    needs ``--auto`` so GitHub merges asynchronously once requirements pass.
 """
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 
@@ -66,6 +66,7 @@ def _make_orchestrator(wf):
     o._create_milestone = MagicMock(return_value={"milestone_id": "ms-1"})
     o._accumulate_tokens = MagicMock()
     o._write_phase_usage = MagicMock()
+    o._validate_pre_merge_change_scope = MagicMock(return_value="")
     return o, mock_repo
 
 
@@ -304,6 +305,96 @@ class TestDoMergeDeferredRetry:
         o._do_merge(_make_workflow())
 
         mock_gh.merge_pr.assert_not_called()
+
+    # Pre-merge scope must exclude upstream files merged into an old PR.
+
+    def test_uses_graph_merge_base_and_backfills_stale_scope_base(self):
+        wf = _make_workflow(base_commit_sha="old-branch-base")
+        o, _ = _make_orchestrator(wf)
+        gh = MagicMock()
+        gh.resolve_commit.return_value = "fetched-main-head"
+        gh._run_git.side_effect = [
+            MagicMock(returncode=0, stdout="", stderr=""),
+            MagicMock(returncode=0, stdout="fetched-main-head\n", stderr=""),
+        ]
+        gh.get_changed_files.return_value = [f"business/file-{index}.py" for index in range(16)]
+
+        assert (
+            AutonomousOrchestrator._validate_pre_merge_change_scope(o, gh, wf, "resolved-pr-head")
+            == ""
+        )
+
+        assert gh._run_git.call_args_list == [
+            call(["fetch", "origin", "main"]),
+            call(["merge-base", "resolved-pr-head", "fetched-main-head"], check=False),
+        ]
+        gh.get_changed_files.assert_called_once_with("fetched-main-head", "resolved-pr-head")
+        o._update_workflow.assert_called_once_with({"base_commit_sha": "fetched-main-head"})
+        assert wf["base_commit_sha"] == "fetched-main-head"
+
+    def test_effective_pr_delta_still_enforces_scope_cap(self):
+        wf = _make_workflow(base_commit_sha="old-branch-base")
+        o, _ = _make_orchestrator(wf)
+        gh = MagicMock()
+        gh.resolve_commit.return_value = "fetched-main-head"
+        gh._run_git.side_effect = [
+            MagicMock(returncode=0, stdout="", stderr=""),
+            MagicMock(returncode=0, stdout="effective-base\n", stderr=""),
+        ]
+        gh.get_changed_files.return_value = [f"agent/file-{index}.py" for index in range(61)]
+
+        error = AutonomousOrchestrator._validate_pre_merge_change_scope(
+            o, gh, wf, "resolved-pr-head"
+        )
+
+        assert "61 files changed" in error
+        o._update_workflow.assert_not_called()
+
+    def test_merge_base_failure_fails_closed(self):
+        o, _ = _make_orchestrator(_make_workflow())
+        gh = MagicMock()
+        gh.resolve_commit.return_value = "fetched-main-head"
+        gh._run_git.side_effect = [
+            MagicMock(returncode=0, stdout="", stderr=""),
+            MagicMock(returncode=1, stdout="", stderr="no common ancestor"),
+        ]
+
+        error = AutonomousOrchestrator._validate_pre_merge_change_scope(
+            o, gh, _make_workflow(), "pr-head"
+        )
+
+        assert "could not derive effective PR base" in error
+        gh.get_changed_files.assert_not_called()
+        o._update_workflow.assert_not_called()
+
+    def test_same_cycle_ci_repair_receives_refreshed_scope_base(self):
+        wf = _make_workflow(base_commit_sha="old-branch-base")
+        o, _ = _make_orchestrator(wf)
+        o._validate_pre_merge_change_scope = (
+            AutonomousOrchestrator._validate_pre_merge_change_scope.__get__(
+                o, AutonomousOrchestrator
+            )
+        )
+        o._start_ci_repair_round = MagicMock()
+        gh = MagicMock()
+        o._gh = gh
+        gh.get_pr_head_sha.return_value = "resolved-pr-head"
+        gh.resolve_commit.return_value = "fetched-main-head"
+        gh._run_git.side_effect = [
+            MagicMock(returncode=0, stdout="", stderr=""),
+            MagicMock(returncode=0, stdout="fetched-main-head\n", stderr=""),
+        ]
+        gh.get_changed_files.return_value = [f"business/file-{index}.py" for index in range(18)]
+        failed_checks = [{"name": "migration", "bucket": "fail"}]
+        gh.get_pr_checks.return_value = failed_checks
+
+        o._do_merge(wf)
+
+        o._start_ci_repair_round.assert_called_once_with(wf, 1103, failed_checks)
+        assert o._start_ci_repair_round.call_args.args[0]["base_commit_sha"] == (
+            "fetched-main-head"
+        )
+        gh.merge_pr.assert_not_called()
 
     @patch("app.modules.workspace.autonomous.orchestrator.GitHubOps")
     def test_ci_pass_merges_successfully(self, mock_gh_cls):


### PR DESCRIPTION
## 问题

旧 PR 经冲突 resolver 合入最新 main 后，merge 阶段仍以工作流创建时的旧 `base_commit_sha` 作为 current-round 边界，导致把所有上游文件误算为 AI 自主改动。1894 因此在 resolver 已成功推送后被 119 files > 60 的守卫错误终止。

## 修复

- pre-merge 守卫先 fetch main，并固定 `FETCH_HEAD` 的不可变 SHA。
- 使用 PR head 与该 main SHA 的 graph merge-base 作为有效 PR 基线。
- 仅按有效 PR delta 执行累计 scope 校验。
- 校验通过后回填 `base_commit_sha`，使后续 CI Repair 继续使用正确基线。
- merge-base 无法求得时 fail closed。

## 验证

- `tests/issues/822/test_merge_conflict_detection.py`: 60 passed
- 新增：16 个真实 PR 文件通过；61 个自主文件仍拒绝；merge-base 失败时拒绝。
- changed-files pre-commit hooks 全部通过。