### PR TITLE
fix(autonomous): restore PR worktree before CI repair

### DIFF
--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -3624,6 +3624,31 @@ class AutonomousOrchestrator:
             return
 
         context = self._build_ci_repair_context(wf, gh, pr_number, failed_checks)
+        restore_worktree = bool(
+            wf.get("branch_strategy") == "worktree"
+            and not wf.get("worktree_path")
+            and preferred_worktree_path
+        )
+        repair_wf = dict(wf)
+        if restore_worktree:
+            repair_wf["preferred_worktree_path"] = preferred_worktree_path
+            repair_wf["worktree_path"] = preferred_worktree_path
+            # Conflict resolution deliberately removes the workflow worktree
+            # while its branch is attached to an isolated resolver worktree.
+            # Restore the PR branch before consuming an attempt or announcing
+            # that repair started. A transient fetch/worktree-add error can
+            # then use the orchestrator's normal retry budget without burning
+            # the bounded AI repair budget or leaving a false milestone.
+            self._ensure_worktree(repair_wf)
+            refreshed_wf = self.workflow
+            if refreshed_wf and refreshed_wf.get("worktree_path"):
+                repair_wf = refreshed_wf
+            # _ensure_worktree can create/rebind the checkout. Discard the
+            # main-repository GitHubOps handle so all repair commits and pushes
+            # are pinned to the restored worktree.
+            self._gh = None
+            gh = self._get_gh()
+
         self._create_milestone(
             phase="merge",
             dev_round=dev_round,
@@ -3647,9 +3672,12 @@ class AutonomousOrchestrator:
         }
         if wf.get("branch_strategy") == "worktree" and preferred_worktree_path:
             updates["preferred_worktree_path"] = preferred_worktree_path
-            updates["worktree_path"] = preferred_worktree_path
+            updates["worktree_path"] = repair_wf.get("worktree_path") or preferred_worktree_path
         self._update_workflow(updates)
-        self._run_merge_ci_repair(self.workflow or wf, gh, pr_number, failed_checks)
+        repair_wf.update(updates)
+        if not restore_worktree:
+            repair_wf = self.workflow or repair_wf
+        self._run_merge_ci_repair(repair_wf, gh, pr_number, failed_checks)
 
     def _update_workflow(self, updates: dict):
         """Update workflow and emit event."""

--- a/tests/issues/822/test_merge_conflict_detection.py
+++ b/tests/issues/822/test_merge_conflict_detection.py
@@ -521,13 +521,15 @@ class TestDoMergeDeferredRetry:
         mock_gh.delete_branch.assert_called_once_with("auto-dev/fc82f22a")
 
     def test_start_ci_repair_round_restores_preferred_worktree(self):
-        """CI repair loop should restore the preferred worktree path for worktree strategy."""
+        """CI repair recreates and binds the PR worktree before launching its agent."""
         wf = _make_workflow(worktree_path="", preferred_worktree_path="/srv/repo/.worktrees/wf-822")
         o, _ = _make_orchestrator(wf)
-        mock_gh = MagicMock()
-        mock_gh.get_pr_head_sha.return_value = "sha-old"
-        mock_gh.get_check_failure_excerpt.return_value = "pytest failed"
-        o._get_gh = MagicMock(return_value=mock_gh)
+        main_gh = MagicMock()
+        main_gh.get_pr_head_sha.return_value = "sha-old"
+        main_gh.get_check_failure_excerpt.return_value = "pytest failed"
+        worktree_gh = MagicMock()
+        o._get_gh = MagicMock(side_effect=[main_gh, worktree_gh])
+        o._ensure_worktree = MagicMock(return_value="/srv/repo/.worktrees/wf-822")
         o._run_merge_ci_repair = MagicMock()
 
         o._start_ci_repair_round(
@@ -543,9 +545,12 @@ class TestDoMergeDeferredRetry:
         assert update_payload["ci_repair_attempts"] == 1
         assert update_payload["worktree_path"] == "/srv/repo/.worktrees/wf-822"
         assert update_payload["preferred_worktree_path"] == "/srv/repo/.worktrees/wf-822"
+        restore_wf = o._ensure_worktree.call_args.args[0]
+        assert restore_wf["worktree_path"] == "/srv/repo/.worktrees/wf-822"
+        assert restore_wf["branch_name"] == "auto-dev/fc82f22a"
         o._run_merge_ci_repair.assert_called_once_with(
-            wf,
-            mock_gh,
+            restore_wf,
+            worktree_gh,
             1103,
             [
                 {
@@ -556,6 +561,41 @@ class TestDoMergeDeferredRetry:
                 }
             ],
         )
+
+    def test_worktree_restore_failure_does_not_consume_ci_repair_attempt(self):
+        """Infrastructure retries must not spend the bounded AI repair budget."""
+        wf = _make_workflow(
+            worktree_path="",
+            preferred_worktree_path="/srv/repo/.worktrees/wf-822",
+        )
+        o, _ = _make_orchestrator(wf)
+        main_gh = MagicMock()
+        main_gh.get_pr_head_sha.return_value = "sha-old"
+        main_gh.get_check_failure_excerpt.return_value = "pytest failed"
+        o._get_gh = MagicMock(return_value=main_gh)
+        o._ensure_worktree = MagicMock(side_effect=GitHubOpsError("network timed out"))
+        o._run_merge_ci_repair = MagicMock()
+
+        with pytest.raises(GitHubOpsError, match="network timed out"):
+            o._start_ci_repair_round(
+                wf,
+                1103,
+                [{"name": "test (3.9)", "bucket": "fail", "state": "failure"}],
+            )
+
+        o._run_merge_ci_repair.assert_not_called()
+        attempt_updates = [
+            call_args.args[0]
+            for call_args in o._update_workflow.call_args_list
+            if call_args.args and "ci_repair_attempts" in call_args.args[0]
+        ]
+        assert attempt_updates == []
+        started_milestones = [
+            call_args.kwargs
+            for call_args in o._create_milestone.call_args_list
+            if call_args.kwargs.get("milestone_type") == "ci_repair_started"
+        ]
+        assert started_milestones == []
 
     def test_start_ci_repair_round_fails_when_signature_repeats(self):
         """A repeated failed-check signature should stop the auto-repair loop.


### PR DESCRIPTION
## 问题

冲突 resolver 为隔离处理会移除原 workflow worktree，并在推送后清理临时 resolver worktree。merge 阶段发现 CI 失败时，`_start_ci_repair_round` 只把 `worktree_path` 写回数据库，却没有创建目录；agent 启动前的 trusted Git context 校验因此以 `Cannot establish a trusted Git context before agent execution` 安全失败。

## 修复

- 仅在 worktree strategy 且 live worktree path 为空时触发恢复。
- 写入 repair 状态后，调用既有 `_ensure_worktree` 在 preferred path 重建 PR 分支 worktree。
- 重读 canonical workflow 状态，清空旧 `_gh` handle，并从恢复后的 worktree 重新绑定 GitHubOps。
- 保持 trusted Git context 守卫不变，不降级安全校验。

## 验证

- issue-822 定向测试：61 passed。
- 回归测试验证调用顺序：先恢复 worktree，再以新的 worktree GitHubOps 启动 CI Repair。
- changed-files pre-commit hooks 全部通过。