### PR TITLE
fix: allow isolated pre-commit cache setup

### DIFF
--- a/app/modules/workspace/autonomous/agent_bin/_guard_exec.py
+++ b/app/modules/workspace/autonomous/agent_bin/_guard_exec.py
@@ -5,32 +5,128 @@ import json
 import os
 import sys
 
+_READ_ONLY_GIT_COMMANDS = {
+    "check-attr",
+    "diff",
+    "grep",
+    "log",
+    "ls-files",
+    "rev-parse",
+    "show",
+    "status",
+}
+
 
 def _deny(message: str) -> None:
     print(message, file=sys.stderr)
     raise SystemExit(126)
 
 
+def _is_within(path: str, root: str) -> bool:
+    try:
+        return os.path.commonpath((os.path.realpath(path), root)) == root
+    except (OSError, ValueError):
+        return False
+
+
+def _resolve_from(path: str, base: str) -> str:
+    return os.path.realpath(path if os.path.isabs(path) else os.path.join(base, path))
+
+
+def _parse_git_command(args: list[str]) -> tuple[str, list[str], str, list[str]]:
+    """Return command, command args, effective cwd, and path redirections."""
+    effective_cwd = os.path.realpath(os.getcwd())
+    redirected_paths: list[str] = []
+    index = 0
+    while index < len(args):
+        arg = args[index]
+        if arg in {"-c", "--config-env"}:
+            index += 2
+            continue
+        if arg.startswith("-c") and arg != "-c":
+            index += 1
+            continue
+        if arg == "-C":
+            if index + 1 >= len(args):
+                return "", [], effective_cwd, redirected_paths
+            effective_cwd = _resolve_from(args[index + 1], effective_cwd)
+            redirected_paths.append(effective_cwd)
+            index += 2
+            continue
+        if arg in {"--git-dir", "--work-tree"}:
+            if index + 1 >= len(args):
+                return "", [], effective_cwd, redirected_paths
+            redirected_paths.append(_resolve_from(args[index + 1], effective_cwd))
+            index += 2
+            continue
+        if arg.startswith("--git-dir=") or arg.startswith("--work-tree="):
+            redirected_paths.append(_resolve_from(arg.split("=", 1)[1], effective_cwd))
+            index += 1
+            continue
+        if arg.startswith("-"):
+            index += 1
+            continue
+        return arg.lower(), args[index + 1 :], effective_cwd, redirected_paths
+    return "", [], effective_cwd, redirected_paths
+
+
+def _cache_git_mutation_allowed(args: list[str]) -> bool:
+    """Allow pre-commit to manage only its credentialless cache repositories."""
+    configured_root = os.environ.get("OPENACE_GIT_CACHE_ROOT", "").strip()
+    if not configured_root:
+        return False
+    cache_root = os.path.realpath(configured_root)
+    command, command_args, effective_cwd, redirected_paths = _parse_git_command(args)
+    if not command:
+        return False
+
+    for env_name in ("GIT_DIR", "GIT_WORK_TREE", "GIT_COMMON_DIR", "GIT_INDEX_FILE"):
+        env_path = os.environ.get(env_name, "").strip()
+        if env_path and not _is_within(_resolve_from(env_path, effective_cwd), cache_root):
+            return False
+    if any(not _is_within(path, cache_root) for path in redirected_paths):
+        return False
+
+    # Once pre-commit is inside its cache clone, remote/fetch/checkout and
+    # other normal repository setup operations are safe. Explicit -C,
+    # --git-dir and environment redirects above cannot escape the cache root.
+    if _is_within(effective_cwd, cache_root):
+        return True
+
+    # The first operation starts outside the cache and initializes a new cache
+    # repository. Accept only an init target below the configured root; never
+    # allow a separate git dir that could redirect metadata elsewhere.
+    if command != "init" or any(
+        arg == "--separate-git-dir" or arg.startswith("--separate-git-dir=") for arg in command_args
+    ):
+        return False
+    positional: list[str] = []
+    skip_next = False
+    for arg in command_args:
+        if skip_next:
+            skip_next = False
+            continue
+        if arg in {"--template", "--object-format", "--ref-format"}:
+            skip_next = True
+            continue
+        if arg.startswith("-"):
+            continue
+        positional.append(arg)
+    target = _resolve_from(positional[-1], effective_cwd) if positional else effective_cwd
+    return _is_within(target, cache_root)
+
+
 def main() -> None:
     invoked = os.path.basename(sys.argv[0])
     args = sys.argv[1:]
     if invoked == "git":
-        command = next((arg.lower() for arg in args if not arg.startswith("-")), "")
-        if command not in {
-            "check-attr",
-            "diff",
-            "grep",
-            "log",
-            "ls-files",
-            "rev-parse",
-            "show",
-            "status",
-        }:
+        command, _, _, _ = _parse_git_command(args)
+        if command not in _READ_ONLY_GIT_COMMANDS and not _cache_git_mutation_allowed(args):
             _deny("mutating git commands are reserved for the Open ACE orchestrator")
         target = os.environ.get("OPENACE_REAL_GIT", "")
         if not target:
             _deny("OPENACE_REAL_GIT is not configured")
-        os.execv(target, [target, *args])
+        os.execv(target, [target, *args])  # nosec B606
     if invoked == "gh":
         normalized = [arg.lower() for arg in args]
         allowed = len(normalized) >= 2 and (normalized[0], normalized[1]) in {
@@ -45,7 +141,7 @@ def main() -> None:
         target = os.environ.get("OPENACE_REAL_GH", "")
         if not target:
             _deny("OPENACE_REAL_GH is not configured")
-        os.execv(target, [target, *args])
+        os.execv(target, [target, *args])  # nosec B606
 
     raw_command = os.environ.get("OPENACE_PYTHON_COMMAND", "")
     try:
@@ -60,7 +156,7 @@ def main() -> None:
         _deny("OPENACE_PYTHON_COMMAND is not configured")
     if invoked == "pytest":
         command = [*command, "-m", "pytest"]
-    os.execvpe(command[0], [*command, *args], os.environ)
+    os.execvpe(command[0], [*command, *args], os.environ)  # nosec B606
 
 
 if __name__ == "__main__":

--- a/app/modules/workspace/autonomous/agent_bin/_guard_exec.py
+++ b/app/modules/workspace/autonomous/agent_bin/_guard_exec.py
@@ -1,8 +1,11 @@
 #!/usr/bin/python3
 """Execution guards injected into autonomous agent PATH."""
 
+from __future__ import annotations
+
 import json
 import os
+import shlex
 import sys
 
 _READ_ONLY_GIT_COMMANDS = {
@@ -14,6 +17,11 @@ _READ_ONLY_GIT_COMMANDS = {
     "rev-parse",
     "show",
     "status",
+}
+_SAFE_CACHE_GIT_CONFIGS = {
+    ("core.autocrlf", "false"),
+    ("core.usebuiltinfsmonitor", "false"),
+    ("protocol.version", "2"),
 }
 
 
@@ -33,29 +41,43 @@ def _resolve_from(path: str, base: str) -> str:
     return os.path.realpath(path if os.path.isabs(path) else os.path.join(base, path))
 
 
-def _parse_git_command(args: list[str]) -> tuple[str, list[str], str, list[str]]:
-    """Return command, command args, effective cwd, and path redirections."""
+def _safe_cache_git_config(value: str) -> bool:
+    key, separator, setting = value.partition("=")
+    return bool(separator) and (key.lower(), setting.lower()) in _SAFE_CACHE_GIT_CONFIGS
+
+
+def _parse_git_command(args: list[str]) -> tuple[str, list[str], str, list[str], bool]:
+    """Return command details and whether its global options are cache-safe."""
     effective_cwd = os.path.realpath(os.getcwd())
     redirected_paths: list[str] = []
+    safe_global_options = True
     index = 0
     while index < len(args):
         arg = args[index]
-        if arg in {"-c", "--config-env"}:
+        if arg == "-c":
+            if index + 1 >= len(args) or not _safe_cache_git_config(args[index + 1]):
+                safe_global_options = False
             index += 2
             continue
         if arg.startswith("-c") and arg != "-c":
+            if not _safe_cache_git_config(arg[2:]):
+                safe_global_options = False
             index += 1
+            continue
+        if arg == "--config-env" or arg.startswith("--config-env="):
+            safe_global_options = False
+            index += 2 if arg == "--config-env" else 1
             continue
         if arg == "-C":
             if index + 1 >= len(args):
-                return "", [], effective_cwd, redirected_paths
+                return "", [], effective_cwd, redirected_paths, False
             effective_cwd = _resolve_from(args[index + 1], effective_cwd)
             redirected_paths.append(effective_cwd)
             index += 2
             continue
         if arg in {"--git-dir", "--work-tree"}:
             if index + 1 >= len(args):
-                return "", [], effective_cwd, redirected_paths
+                return "", [], effective_cwd, redirected_paths, False
             redirected_paths.append(_resolve_from(args[index + 1], effective_cwd))
             index += 2
             continue
@@ -64,10 +86,76 @@ def _parse_git_command(args: list[str]) -> tuple[str, list[str], str, list[str]]
             index += 1
             continue
         if arg.startswith("-"):
+            safe_global_options = False
             index += 1
             continue
-        return arg.lower(), args[index + 1 :], effective_cwd, redirected_paths
-    return "", [], effective_cwd, redirected_paths
+        return (
+            arg.lower(),
+            args[index + 1 :],
+            effective_cwd,
+            redirected_paths,
+            safe_global_options,
+        )
+    return "", [], effective_cwd, redirected_paths, False
+
+
+def _safe_environment_git_configs() -> bool:
+    parameters = os.environ.get("GIT_CONFIG_PARAMETERS", "").strip()
+    if parameters:
+        try:
+            if not all(_safe_cache_git_config(item) for item in shlex.split(parameters)):
+                return False
+        except ValueError:
+            return False
+
+    raw_count = os.environ.get("GIT_CONFIG_COUNT", "").strip()
+    if not raw_count:
+        return True
+    try:
+        count = int(raw_count)
+    except ValueError:
+        return False
+    return count >= 0 and all(
+        _safe_cache_git_config(
+            f"{os.environ.get(f'GIT_CONFIG_KEY_{index}', '')}="
+            f"{os.environ.get(f'GIT_CONFIG_VALUE_{index}', '')}"
+        )
+        for index in range(count)
+    )
+
+
+def _cache_init_target(command_args: list[str], effective_cwd: str) -> str | None:
+    """Accept only pre-commit's `init --template[=]... <cache-path>` form."""
+    target: str | None = None
+    index = 0
+    while index < len(command_args):
+        arg = command_args[index]
+        if arg == "--template":
+            if index + 1 >= len(command_args):
+                return None
+            index += 2
+            continue
+        if arg.startswith("--template="):
+            index += 1
+            continue
+        if arg.startswith("-") or target is not None:
+            return None
+        target = _resolve_from(arg, effective_cwd)
+        index += 1
+    return target
+
+
+def _cache_setup_command_allowed(command: str, command_args: list[str]) -> bool:
+    """Allow only the Git mutations used while cloning pre-commit hook repos."""
+    if command == "remote":
+        return len(command_args) == 3 and command_args[:2] == ["add", "origin"]
+    if command == "fetch":
+        return bool(command_args) and command_args[0] == "origin"
+    if command == "checkout":
+        return bool(command_args)
+    if command == "submodule":
+        return bool(command_args) and command_args[0] == "update"
+    return False
 
 
 def _cache_git_mutation_allowed(args: list[str]) -> bool:
@@ -76,51 +164,48 @@ def _cache_git_mutation_allowed(args: list[str]) -> bool:
     if not configured_root:
         return False
     cache_root = os.path.realpath(configured_root)
-    command, command_args, effective_cwd, redirected_paths = _parse_git_command(args)
-    if not command:
+    command, command_args, effective_cwd, redirected_paths, safe_global_options = (
+        _parse_git_command(args)
+    )
+    if not command or not safe_global_options or not _safe_environment_git_configs():
         return False
 
-    for env_name in ("GIT_DIR", "GIT_WORK_TREE", "GIT_COMMON_DIR", "GIT_INDEX_FILE"):
+    for env_name in (
+        "GIT_DIR",
+        "GIT_WORK_TREE",
+        "GIT_COMMON_DIR",
+        "GIT_INDEX_FILE",
+        "GIT_OBJECT_DIRECTORY",
+        "GIT_QUARANTINE_PATH",
+    ):
         env_path = os.environ.get(env_name, "").strip()
         if env_path and not _is_within(_resolve_from(env_path, effective_cwd), cache_root):
             return False
+    if any(
+        os.environ.get(name, "").strip()
+        for name in (
+            "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+            "GIT_CONFIG_GLOBAL",
+            "GIT_CONFIG_SYSTEM",
+        )
+    ):
+        return False
     if any(not _is_within(path, cache_root) for path in redirected_paths):
         return False
 
-    # Once pre-commit is inside its cache clone, remote/fetch/checkout and
-    # other normal repository setup operations are safe. Explicit -C,
-    # --git-dir and environment redirects above cannot escape the cache root.
-    if _is_within(effective_cwd, cache_root):
-        return True
-
-    # The first operation starts outside the cache and initializes a new cache
-    # repository. Accept only an init target below the configured root; never
-    # allow a separate git dir that could redirect metadata elsewhere.
-    if command != "init" or any(
-        arg == "--separate-git-dir" or arg.startswith("--separate-git-dir=") for arg in command_args
-    ):
-        return False
-    positional: list[str] = []
-    skip_next = False
-    for arg in command_args:
-        if skip_next:
-            skip_next = False
-            continue
-        if arg in {"--template", "--object-format", "--ref-format"}:
-            skip_next = True
-            continue
-        if arg.startswith("-"):
-            continue
-        positional.append(arg)
-    target = _resolve_from(positional[-1], effective_cwd) if positional else effective_cwd
-    return _is_within(target, cache_root)
+    if command == "init":
+        target = _cache_init_target(command_args, effective_cwd)
+        return target is not None and _is_within(target, cache_root)
+    return _is_within(effective_cwd, cache_root) and _cache_setup_command_allowed(
+        command, command_args
+    )
 
 
 def main() -> None:
     invoked = os.path.basename(sys.argv[0])
     args = sys.argv[1:]
     if invoked == "git":
-        command, _, _, _ = _parse_git_command(args)
+        command, _, _, _, _ = _parse_git_command(args)
         if command not in _READ_ONLY_GIT_COMMANDS and not _cache_git_mutation_allowed(args):
             _deny("mutating git commands are reserved for the Open ACE orchestrator")
         target = os.environ.get("OPENACE_REAL_GIT", "")

--- a/app/modules/workspace/autonomous/agent_runner.py
+++ b/app/modules/workspace/autonomous/agent_runner.py
@@ -951,12 +951,19 @@ class AutonomousAgentRunner:
         if AutonomousAgentRunner._is_cross_user(system_account):
             assert system_account is not None  # _is_cross_user guarantees non-empty
             if env:
+                env = dict(env)
+                env["OPENACE_GIT_CACHE_ROOT"] = str(
+                    AutonomousAgentRunner._resolve_home_dir(system_account)
+                    / ".cache"
+                    / "pre-commit"
+                )
                 AutonomousAgentRunner._validate_cross_user_guard_bin(env)
             guard_env = []
             for key in (
                 "PATH",
                 "OPENACE_REAL_GIT",
                 "OPENACE_REAL_GH",
+                "OPENACE_GIT_CACHE_ROOT",
                 "OPENACE_PYTHON_COMMAND",
                 "OPENACE_PROXY_URL",
                 "OPENACE_PROXY_TOKEN",
@@ -1082,6 +1089,11 @@ class AutonomousAgentRunner:
         if real_gh:
             env["OPENACE_REAL_GH"] = real_gh
         env["OPENACE_PYTHON_COMMAND"] = json.dumps(runtime_python_command or [sys.executable])
+        try:
+            agent_home = Path(pwd.getpwuid(os.getuid()).pw_dir)
+        except (KeyError, OverflowError):
+            agent_home = Path.home()
+        env["OPENACE_GIT_CACHE_ROOT"] = str(agent_home / ".cache" / "pre-commit")
         # The orchestrator owns all remote mutations. Agent subprocesses use
         # the LLM proxy for model auth and do not need GitHub credentials.
         # This environment cleanup is defense-in-depth; the actual credential

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -2421,6 +2421,9 @@ class AutonomousOrchestrator:
         env = {
             "PATH": guard_bin + os.pathsep + os.environ.get("PATH", ""),
             "OPENACE_REAL_GIT": real_git,
+            "OPENACE_GIT_CACHE_ROOT": str(
+                AutonomousAgentRunner._resolve_home_dir(isolated_account) / ".cache" / "pre-commit"
+            ),
             "OPENACE_PYTHON_COMMAND": json.dumps(runtime_command or [sys.executable]),
             "GH_CONFIG_DIR": "/var/empty/openace-autonomous-gh",
             "GIT_TERMINAL_PROMPT": "0",

--- a/tests/unit/test_autonomous_ci_guardrails.py
+++ b/tests/unit/test_autonomous_ci_guardrails.py
@@ -313,6 +313,8 @@ def test_cross_user_launch_preserves_nonsecret_guard_environment(monkeypatch, tm
     assert "/usr/bin/env" in command
     assert f"PATH={guard_dir}:/usr/bin" in command
     assert "OPENACE_REAL_GIT=/usr/bin/git" in command
+    expected_cache = str(agent_runner.AutonomousAgentRunner._resolve_home_dir("repo-user"))
+    assert f"OPENACE_GIT_CACHE_ROOT={expected_cache}/.cache/pre-commit" in command
 
 
 def test_terminal_result_closes_stream_json_stdin():
@@ -541,6 +543,146 @@ def test_isolated_git_guard_allows_pre_commit_check_attr(tmp_path):
 
     assert result.returncode == 0
     assert result.stdout.strip() == "check-attr filter -z --stdin"
+
+
+def _fake_real_git(tmp_path):
+    real_git = tmp_path / "real-git"
+    real_git.write_text(
+        f"#!{sys.executable}\nimport sys\nprint(' '.join(sys.argv[1:]))\n",
+        encoding="utf-8",
+    )
+    real_git.chmod(0o755)
+    return real_git
+
+
+def _source_git_guard():
+    from pathlib import Path
+
+    return (
+        Path(__file__).parents[2]
+        / "app"
+        / "modules"
+        / "workspace"
+        / "autonomous"
+        / "agent_bin"
+        / "git"
+    )
+
+
+def test_isolated_git_guard_allows_pre_commit_cache_init(tmp_path):
+    """Global -c options must not hide cache-scoped git init from the guard."""
+    import os
+    import subprocess
+
+    project = tmp_path / "project"
+    project.mkdir()
+    cache_root = tmp_path / "agent-home" / ".cache" / "pre-commit"
+    cache_root.mkdir(parents=True)
+    target = cache_root / "repo123"
+    result = subprocess.run(
+        [
+            str(_source_git_guard()),
+            "-c",
+            "core.useBuiltinFSMonitor=false",
+            "init",
+            "--template=",
+            str(target),
+        ],
+        cwd=project,
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "OPENACE_REAL_GIT": str(_fake_real_git(tmp_path)),
+            "OPENACE_GIT_CACHE_ROOT": str(cache_root),
+        },
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "init --template=" in result.stdout
+    assert str(target) in result.stdout
+
+
+def test_isolated_git_guard_allows_mutation_inside_pre_commit_cache(tmp_path):
+    import os
+    import subprocess
+
+    cache_repo = tmp_path / "agent-home" / ".cache" / "pre-commit" / "repo123"
+    cache_repo.mkdir(parents=True)
+    result = subprocess.run(
+        [str(_source_git_guard()), "remote", "add", "origin", "https://example.invalid/hook"],
+        cwd=cache_repo,
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "OPENACE_REAL_GIT": str(_fake_real_git(tmp_path)),
+            "OPENACE_GIT_CACHE_ROOT": str(cache_repo.parent),
+        },
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert result.stdout.strip().startswith("remote add origin")
+
+
+def test_isolated_git_guard_denies_cache_escape(tmp_path):
+    import os
+    import subprocess
+
+    project = tmp_path / "project"
+    project.mkdir()
+    cache_repo = tmp_path / "agent-home" / ".cache" / "pre-commit" / "repo123"
+    cache_repo.mkdir(parents=True)
+    env = {
+        **os.environ,
+        "OPENACE_REAL_GIT": str(_fake_real_git(tmp_path)),
+        "OPENACE_GIT_CACHE_ROOT": str(cache_repo.parent),
+    }
+
+    outside_init = subprocess.run(
+        [str(_source_git_guard()), "init", str(project / "nested")],
+        cwd=project,
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+    redirected_commit = subprocess.run(
+        [str(_source_git_guard()), "-C", str(project), "commit", "-m", "escape"],
+        cwd=cache_repo,
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+    separate_git_dir = subprocess.run(
+        [
+            str(_source_git_guard()),
+            "init",
+            f"--separate-git-dir={project / 'metadata'}",
+            str(cache_repo / "nested"),
+        ],
+        cwd=project,
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+    env_redirect = subprocess.run(
+        [str(_source_git_guard()), "commit", "-m", "escape"],
+        cwd=cache_repo,
+        capture_output=True,
+        text=True,
+        env={**env, "GIT_DIR": str(project / ".git")},
+        check=False,
+    )
+
+    assert outside_init.returncode == 126
+    assert redirected_commit.returncode == 126
+    assert separate_git_dir.returncode == 126
+    assert env_redirect.returncode == 126
 
 
 def test_runner_preserves_tool_result_for_test_evidence():

--- a/tests/unit/test_autonomous_ci_guardrails.py
+++ b/tests/unit/test_autonomous_ci_guardrails.py
@@ -709,6 +709,35 @@ def test_isolated_git_guard_denies_cache_escape(tmp_path):
         env=env,
         check=False,
     )
+    clone_escape = subprocess.run(
+        [
+            str(_source_git_guard()),
+            "clone",
+            "https://example.invalid/hook",
+            str(project / "clone"),
+        ],
+        cwd=cache_repo,
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+    global_config_escape = subprocess.run(
+        [str(_source_git_guard()), "config", "--global", "user.name", "escape"],
+        cwd=cache_repo,
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+    environment_config_escape = subprocess.run(
+        [str(_source_git_guard()), "checkout", "HEAD"],
+        cwd=cache_repo,
+        capture_output=True,
+        text=True,
+        env={**env, "GIT_CONFIG_PARAMETERS": f"'core.worktree'='{project}'"},
+        check=False,
+    )
 
     assert outside_init.returncode == 126
     assert redirected_commit.returncode == 126
@@ -717,6 +746,9 @@ def test_isolated_git_guard_denies_cache_escape(tmp_path):
     assert cache_cwd_init_escape.returncode == 126
     assert object_directory_escape.returncode == 126
     assert unsafe_config_escape.returncode == 126
+    assert clone_escape.returncode == 126
+    assert global_config_escape.returncode == 126
+    assert environment_config_escape.returncode == 126
 
 
 def test_runner_preserves_tool_result_for_test_evidence():

--- a/tests/unit/test_autonomous_ci_guardrails.py
+++ b/tests/unit/test_autonomous_ci_guardrails.py
@@ -678,11 +678,45 @@ def test_isolated_git_guard_denies_cache_escape(tmp_path):
         env={**env, "GIT_DIR": str(project / ".git")},
         check=False,
     )
+    cache_cwd_init_escape = subprocess.run(
+        [str(_source_git_guard()), "init", str(project / "escaped")],
+        cwd=cache_repo,
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+    object_directory_escape = subprocess.run(
+        [str(_source_git_guard()), "hash-object", "-w", "--stdin"],
+        cwd=cache_repo,
+        input="outside cache",
+        capture_output=True,
+        text=True,
+        env={**env, "GIT_OBJECT_DIRECTORY": str(project / "objects")},
+        check=False,
+    )
+    unsafe_config_escape = subprocess.run(
+        [
+            str(_source_git_guard()),
+            "-c",
+            f"core.worktree={project}",
+            "checkout",
+            "HEAD",
+        ],
+        cwd=cache_repo,
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
 
     assert outside_init.returncode == 126
     assert redirected_commit.returncode == 126
     assert separate_git_dir.returncode == 126
     assert env_redirect.returncode == 126
+    assert cache_cwd_init_escape.returncode == 126
+    assert object_directory_escape.returncode == 126
+    assert unsafe_config_escape.returncode == 126
 
 
 def test_runner_preserves_tool_result_for_test_evidence():


### PR DESCRIPTION
## Summary
- allow mutating Git operations only inside the isolated pre-commit cache
- pass the target system account cache root through guarded agent and convergence environments
- reject cwd, Git-dir, index, and separate-Git-dir escapes

## Validation
- 60 autonomous CI guardrail tests passed
- changed-file pre-commit suite passed
- a fresh guarded pre-commit cache initialized and installed all hook repositories successfully

## Context
This fixes issue-1894 CI repair attempts failing before the agent could change code because pre-commit's credentialless cache initialization was blocked by the repository Git mutation guard.