### PR TITLE
fix: scope CI repair pre-commit convergence

### DIFF
--- a/app/modules/workspace/autonomous/agent_bin/_guard_exec.py
+++ b/app/modules/workspace/autonomous/agent_bin/_guard_exec.py
@@ -43,7 +43,15 @@ def _resolve_from(path: str, base: str) -> str:
 
 def _safe_cache_git_config(value: str) -> bool:
     key, separator, setting = value.partition("=")
-    return bool(separator) and (key.lower(), setting.lower()) in _SAFE_CACHE_GIT_CONFIGS
+    if not separator:
+        return False
+    normalized_key = key.lower()
+    if normalized_key == "safe.directory":
+        # openace-run-as injects the absolute, validated worktree path through
+        # GIT_CONFIG_COUNT after clearing the inherited environment. This
+        # setting changes repository trust only; it cannot redirect Git writes.
+        return os.path.isabs(setting) and setting != "*"
+    return (normalized_key, setting.lower()) in _SAFE_CACHE_GIT_CONFIGS
 
 
 def _parse_git_command(args: list[str]) -> tuple[str, list[str], str, list[str], bool]:

--- a/app/modules/workspace/autonomous/agent_runner.py
+++ b/app/modules/workspace/autonomous/agent_runner.py
@@ -981,6 +981,7 @@ class AutonomousAgentRunner:
                 "GIT_COMMITTER_EMAIL",
                 "GH_CONFIG_DIR",
                 "GIT_TERMINAL_PROMPT",
+                "SKIP",
             ):
                 if env and env.get(key):
                     guard_env.append(f"{key}={env[key]}")
@@ -1101,6 +1102,10 @@ class AutonomousAgentRunner:
         # and the isolated run-as wrapper's clean environment/worktree ACLs.
         for key in ("GH_TOKEN", "GITHUB_TOKEN", "GH_ENTERPRISE_TOKEN", "SSH_AUTH_SOCK"):
             env.pop(key, None)
+        # CI-only hook exclusions are set explicitly by the orchestrator's
+        # convergence command. Never let a service-level SKIP leak into a
+        # normal autonomous agent and silently suppress repository hooks.
+        env.pop("SKIP", None)
         env["GH_CONFIG_DIR"] = "/var/empty/openace-autonomous-gh"
         env["GIT_TERMINAL_PROMPT"] = "0"
         env["PATH"] = guard_bin + os.pathsep + env.get("PATH", "")

--- a/app/modules/workspace/autonomous/github_ops.py
+++ b/app/modules/workspace/autonomous/github_ops.py
@@ -744,6 +744,10 @@ class GitHubOps:
         """
         self._run_git(["reset", "--hard", "HEAD"])
 
+    def reset_hard_to(self, ref: str) -> None:
+        """Discard local CI-repair state and reset to a trusted immutable ref."""
+        self._run_git(["reset", "--hard", ref])
+
     def delete_branch(self, name: str, remote: bool = True) -> None:
         """Delete a branch locally and optionally remotely."""
         self._run_git(["branch", "-D", name], check=False)

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -1191,6 +1191,7 @@ MAX_DEV_RETRIES_ON_TEST_FAIL = 2  # max dev round retries for unfixable test fai
 MAX_CI_REPAIR_ATTEMPTS = 3  # max automatic dev-round retries for merge-phase CI failures
 MAX_PRE_COMMIT_CONVERGENCE_PASSES = 3
 PRE_COMMIT_CONVERGENCE_TIMEOUT = 600
+CI_PRE_COMMIT_SKIP = "bandit,no-commit-to-branch"
 MAX_CI_DIAGNOSTICS_ATTEMPTS = 6  # bound scheduler polls when failed job logs stay unavailable
 try:
     MAX_AUTONOMOUS_CHANGED_FILES = int(os.environ.get("AUTONOMOUS_MAX_CHANGED_FILES", "60"))
@@ -2338,10 +2339,13 @@ class AutonomousOrchestrator:
             "1. 保持在当前工作分支上修复，不要创建新的 PR，不要切换到其他分支。\n"
             "2. 不要进入新的代码审查、进度汇报或等待流程；当前唯一目标是让现有 PR 的 CI 通过。\n"
             "3. 必须优先根据 CI 工作流、失败日志摘录和仓库脚本定位问题，复现 CI 真实执行的命令。\n"
-            "4. 修复后必须重新运行 CI 的完整对应命令，而不是只运行单个 hook、单个文件或你认为相关的子集。\n"
+            "4. 修复后必须重新运行 CI 的完整对应检查语义，而不是只运行单个 hook 或你主观挑选的子集。\n"
             "5. 如果命令中的 formatter / pre-commit hook 自动修改了文件并以非零状态退出，这只是修复过程，"
             "不代表验证完成；必须保留这些修改并重复运行同一完整命令，直到 exit 0 或确认存在不可自动修复的错误。\n"
-            "6. 对 `pre-commit run --all-files` 这类全仓检查，必须原样保留 `--all-files`，并在结束前取得一次干净的 exit 0。\n"
+            "6. GitHub 的 `pre-commit run --all-files` 针对当前 main 与 PR 的合并结果；本地 PR 分支可能落后于 main，"
+            "禁止直接对旧分支运行 `--all-files` 并保留无关格式化。请对相对工作流 base 的全部现存 PR 变更文件"
+            "运行 `SKIP=bandit,no-commit-to-branch pre-commit run --files ...`，重复至 exit 0；"
+            "Bandit 由 CI 独立检查，编排器会用同一范围再次收敛。\n"
             "7. 不要执行 git add、git commit 或 git push；编排器会在范围校验通过后统一提交并推送。\n"
             "8. 结束时请明确说明：你复现了哪些完整命令、最终 exit code、修复了什么、还剩什么风险。\n"
         )
@@ -2417,6 +2421,41 @@ class AutonomousOrchestrator:
                 "Autonomous validation account must differ from the repository owner account"
             )
         runtime_command, _ = self._select_project_python_runtime(project_path, gh)
+        base_commit = (wf.get("base_commit_sha") or "").strip()
+        if not base_commit:
+            return True, "isolated pre-commit validation could not derive the PR base commit"
+        try:
+            candidate_paths = {
+                *gh.get_changed_files(base_commit, "HEAD"),
+                *gh.get_worktree_changed_paths(),
+            }
+        except Exception as exc:
+            return True, f"isolated pre-commit validation could not list PR changes: {exc}"
+
+        project_root = os.path.realpath(project_path)
+        scoped_files: list[str] = []
+        for raw_path in sorted(candidate_paths):
+            raw_path = str(raw_path)
+            normalized = os.path.normpath(raw_path)
+            absolute_path = os.path.realpath(os.path.join(project_root, normalized))
+            try:
+                within_project = os.path.commonpath((absolute_path, project_root)) == project_root
+            except ValueError:
+                within_project = False
+            if (
+                not normalized
+                or normalized == "."
+                or os.path.isabs(normalized)
+                or not within_project
+            ):
+                return True, f"isolated pre-commit validation rejected unsafe path: {raw_path}"
+            # Deleted PR files do not exist in the effective merge tree and
+            # must not be passed to filename-based hooks.
+            if gh.path_exists_as_user(absolute_path, file_only=True):
+                scoped_files.append(f"./{normalized}")
+        if not scoped_files:
+            return True, "isolated pre-commit validation found no existing PR-scoped files"
+
         guard_bin = AutonomousAgentRunner._resolve_agent_guard_bin()
         env = {
             "PATH": guard_bin + os.pathsep + os.environ.get("PATH", ""),
@@ -2427,9 +2466,10 @@ class AutonomousOrchestrator:
             "OPENACE_PYTHON_COMMAND": json.dumps(runtime_command or [sys.executable]),
             "GH_CONFIG_DIR": "/var/empty/openace-autonomous-gh",
             "GIT_TERMINAL_PROMPT": "0",
+            "SKIP": CI_PRE_COMMIT_SKIP,
         }
         command, cwd = AutonomousAgentRunner._wrap_agent_cmd(
-            [pre_commit, "run", "--all-files"],
+            [pre_commit, "run", "--files", *scoped_files],
             project_path,
             isolated_account,
             env,
@@ -2469,7 +2509,7 @@ class AutonomousOrchestrator:
 
         concise_output = last_output[-4000:] if last_output else "no output"
         return True, (
-            "isolated `pre-commit run --all-files` did not reach exit 0 after "
+            "isolated PR-scoped `pre-commit run --files ...` did not reach exit 0 after "
             f"{passes_run} pass(es):\n{concise_output}"
         )
 
@@ -2521,6 +2561,12 @@ class AutonomousOrchestrator:
             if scope_validator is not None:
                 push_error = str(scope_validator(commit_before, commit_sha) or "")
                 if push_error:
+                    try:
+                        gh.reset_hard_to(commit_before)
+                    except Exception as exc:
+                        push_error += (
+                            "; failed to discard the rejected local CI-repair commit: " f"{exc}"
+                        )
                     return commit_sha, sha_changed, push_error
             try:
                 gh.git_push(branch=branch_name, force_with_lease=True)
@@ -2718,7 +2764,8 @@ class AutonomousOrchestrator:
         )
         if pre_commit_attempted:
             validation_summary = (
-                pre_commit_error or "isolated `pre-commit run --all-files` converged with exit 0"
+                pre_commit_error
+                or "isolated PR-scoped `pre-commit run --files ...` converged with exit 0"
             )
             summary = f"{summary}\n\nValidation: {validation_summary}".strip()
 

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -2339,13 +2339,12 @@ class AutonomousOrchestrator:
             "1. 保持在当前工作分支上修复，不要创建新的 PR，不要切换到其他分支。\n"
             "2. 不要进入新的代码审查、进度汇报或等待流程；当前唯一目标是让现有 PR 的 CI 通过。\n"
             "3. 必须优先根据 CI 工作流、失败日志摘录和仓库脚本定位问题，复现 CI 真实执行的命令。\n"
-            "4. 修复后必须重新运行 CI 的完整对应检查语义，而不是只运行单个 hook 或你主观挑选的子集。\n"
+            "4. 修复后必须重新运行 CI 的完整对应命令，而不是只运行单个 hook、单个文件或你认为相关的子集。\n"
             "5. 如果命令中的 formatter / pre-commit hook 自动修改了文件并以非零状态退出，这只是修复过程，"
             "不代表验证完成；必须保留这些修改并重复运行同一完整命令，直到 exit 0 或确认存在不可自动修复的错误。\n"
-            "6. GitHub 的 `pre-commit run --all-files` 针对当前 main 与 PR 的合并结果；本地 PR 分支可能落后于 main，"
-            "禁止直接对旧分支运行 `--all-files` 并保留无关格式化。请对相对工作流 base 的全部现存 PR 变更文件"
-            "运行 `SKIP=bandit,no-commit-to-branch pre-commit run --files ...`，重复至 exit 0；"
-            "Bandit 由 CI 独立检查，编排器会用同一范围再次收敛。\n"
+            "6. 编排器已先把当前 main 合并进 PR 分支，因此对 "
+            "`SKIP=bandit,no-commit-to-branch pre-commit run --all-files` 必须原样运行并重复至 exit 0；"
+            "Bandit 由 CI 独立检查。\n"
             "7. 不要执行 git add、git commit 或 git push；编排器会在范围校验通过后统一提交并推送。\n"
             "8. 结束时请明确说明：你复现了哪些完整命令、最终 exit code、修复了什么、还剩什么风险。\n"
         )
@@ -2421,41 +2420,6 @@ class AutonomousOrchestrator:
                 "Autonomous validation account must differ from the repository owner account"
             )
         runtime_command, _ = self._select_project_python_runtime(project_path, gh)
-        base_commit = (wf.get("base_commit_sha") or "").strip()
-        if not base_commit:
-            return True, "isolated pre-commit validation could not derive the PR base commit"
-        try:
-            candidate_paths = {
-                *gh.get_changed_files(base_commit, "HEAD"),
-                *gh.get_worktree_changed_paths(),
-            }
-        except Exception as exc:
-            return True, f"isolated pre-commit validation could not list PR changes: {exc}"
-
-        project_root = os.path.realpath(project_path)
-        scoped_files: list[str] = []
-        for raw_path in sorted(candidate_paths):
-            raw_path = str(raw_path)
-            normalized = os.path.normpath(raw_path)
-            absolute_path = os.path.realpath(os.path.join(project_root, normalized))
-            try:
-                within_project = os.path.commonpath((absolute_path, project_root)) == project_root
-            except ValueError:
-                within_project = False
-            if (
-                not normalized
-                or normalized == "."
-                or os.path.isabs(normalized)
-                or not within_project
-            ):
-                return True, f"isolated pre-commit validation rejected unsafe path: {raw_path}"
-            # Deleted PR files do not exist in the effective merge tree and
-            # must not be passed to filename-based hooks.
-            if gh.path_exists_as_user(absolute_path, file_only=True):
-                scoped_files.append(f"./{normalized}")
-        if not scoped_files:
-            return True, "isolated pre-commit validation found no existing PR-scoped files"
-
         guard_bin = AutonomousAgentRunner._resolve_agent_guard_bin()
         env = {
             "PATH": guard_bin + os.pathsep + os.environ.get("PATH", ""),
@@ -2469,7 +2433,7 @@ class AutonomousOrchestrator:
             "SKIP": CI_PRE_COMMIT_SKIP,
         }
         command, cwd = AutonomousAgentRunner._wrap_agent_cmd(
-            [pre_commit, "run", "--files", *scoped_files],
+            [pre_commit, "run", "--all-files"],
             project_path,
             isolated_account,
             env,
@@ -2509,7 +2473,7 @@ class AutonomousOrchestrator:
 
         concise_output = last_output[-4000:] if last_output else "no output"
         return True, (
-            "isolated PR-scoped `pre-commit run --files ...` did not reach exit 0 after "
+            "isolated `pre-commit run --all-files` did not reach exit 0 after "
             f"{passes_run} pass(es):\n{concise_output}"
         )
 
@@ -2530,8 +2494,10 @@ class AutonomousOrchestrator:
         (#1838 review suggestion 1).
         """
         commit_sha = ""
+        local_start_sha = ""
         try:
             commit_sha = gh.get_current_commit()
+            local_start_sha = commit_sha
         except Exception:
             pass
 
@@ -2562,7 +2528,7 @@ class AutonomousOrchestrator:
                 push_error = str(scope_validator(commit_before, commit_sha) or "")
                 if push_error:
                     try:
-                        gh.reset_hard_to(commit_before)
+                        gh.reset_hard_to(local_start_sha or commit_before)
                     except Exception as exc:
                         push_error += (
                             "; failed to discard the rejected local CI-repair commit: " f"{exc}"
@@ -2764,8 +2730,7 @@ class AutonomousOrchestrator:
         )
         if pre_commit_attempted:
             validation_summary = (
-                pre_commit_error
-                or "isolated PR-scoped `pre-commit run --files ...` converged with exit 0"
+                pre_commit_error or "isolated `pre-commit run --all-files` converged with exit 0"
             )
             summary = f"{summary}\n\nValidation: {validation_summary}".strip()
 
@@ -3496,6 +3461,35 @@ class AutonomousOrchestrator:
         if shutdown_event.wait(CI_POLL_INTERVAL):
             raise WorkflowPaused("Service shutdown interrupted CI polling")
 
+    def _sync_failed_pr_with_main(
+        self,
+        gh: GitHubOps,
+        branch_name: str,
+        pr_number: int,
+        pr_head_sha: str,
+    ) -> bool:
+        """Merge current main into a stale failed PR before spending an AI round.
+
+        GitHub's pull_request checks run against a synthetic merge commit. A
+        stale local PR branch therefore cannot reproduce all-files checks
+        faithfully. Reuse the trusted merge/conflict resolver to update and
+        push the branch first; the resulting CI run becomes authoritative and
+        the next repair cycle sees the same tree locally.
+        """
+        gh._run_git(["fetch", "origin", "main"])
+        main_head = gh.resolve_commit("FETCH_HEAD")
+        contains_main = self._ancestor_check(gh, main_head, pr_head_sha)
+        if contains_main is None:
+            raise GitHubOpsError("Unable to verify whether the failed PR contains current main")
+        if contains_main:
+            return False
+        logger.info(
+            "PR #%s failed CI on a branch behind main; synchronizing main before AI repair",
+            pr_number,
+        )
+        self._resolve_merge_conflicts(gh, branch_name, pr_number)
+        return True
+
     def _start_ci_repair_round(self, wf: dict, pr_number: int, failed_checks: list[dict]) -> None:
         """Repair merge-phase CI failures in-place on the existing PR branch."""
         dev_round = int(wf.get("dev_round", 1) or 1)
@@ -3511,8 +3505,18 @@ class AutonomousOrchestrator:
                 "Failed to resolve PR head SHA for CI repair on PR #%s: %s", pr_number, e
             )
 
-        # Check attempt limit FIRST so the terminal round skips the fingerprint
-        # network fetches (gh run view --log-failed for each failing check).
+        branch_name = (wf.get("branch_name") or "").strip()
+        if (
+            current_head_sha
+            and branch_name
+            and self._sync_failed_pr_with_main(gh, branch_name, pr_number, current_head_sha)
+        ):
+            # The push starts a new synthetic-merge CI run. Do not consume a
+            # bounded AI repair attempt for stale-tree synchronization.
+            return
+
+        # After the non-AI main synchronization above, check the attempt limit
+        # before fingerprint/log fetches (gh run view --log-failed per check).
         # Note: when BOTH "over MAX" and "signature unchanged" would match, this
         # reports "limit reached" (more accurate — the real stop reason is the
         # cap, not the unchanged signature). No downstream code depends on the
@@ -8661,7 +8665,11 @@ class AutonomousOrchestrator:
                 phase="merge",
                 milestone_type="conflicts_pushed",
                 status="completed",
-                title=f"PR #{pr_number} conflicts resolved, waiting for CI to merge",
+                title=(
+                    f"PR #{pr_number} conflicts resolved, waiting for CI to merge"
+                    if conflict_ms_id
+                    else f"PR #{pr_number} synchronized with main, waiting for CI"
+                ),
             )
         finally:
             # Always tear down the temp worktree, even on failure, so it does

--- a/tests/issues/1574/test_ci_repair_verifiers.py
+++ b/tests/issues/1574/test_ci_repair_verifiers.py
@@ -37,6 +37,7 @@ def _make_workflow(**overrides):
         "total_output_tokens": 0,
         "total_requests": 0,
         "error_message": "",
+        "base_commit_sha": "base-sha",
         "last_ci_failure_head_sha": "",
     }
     base.update(overrides)
@@ -66,6 +67,7 @@ def _make_orchestrator(wf_data):
         orch = AutonomousOrchestrator(wf_data["workflow_id"])
         orch.repo = mock_repo
         orch.emitter = MagicMock()
+        orch._sync_failed_pr_with_main = MagicMock(return_value=False)
     return orch, mock_repo
 
 

--- a/tests/issues/1851/test_ci_repair_milestone_rounds.py
+++ b/tests/issues/1851/test_ci_repair_milestone_rounds.py
@@ -86,6 +86,7 @@ def _make_orchestrator(wf_data):
         orch = AutonomousOrchestrator(wf_data["workflow_id"])
         orch.repo = mock_repo
         orch.emitter = MagicMock()
+        orch._sync_failed_pr_with_main = MagicMock(return_value=False)
     return orch, mock_repo
 
 
@@ -292,8 +293,9 @@ class TestSecondAttemptCreatesDistinctMilestone:
             mock_repo.get_workflow.return_value = wf
             mock_repo.create_event.return_value = {"id": 1}
             mock_repo.update_workflow.return_value = wf
-            # _find_existing_milestone: in_progress empty, completed has attempt1
-            mock_repo.list_milestones.side_effect = [[], [attempt1_started]]
+            # First pair checks for a stale diagnostics milestone; second pair
+            # checks the attempt-specific ci_repair_started milestone.
+            mock_repo.list_milestones.side_effect = [[], [], [], [attempt1_started]]
             mock_repo.create_milestone.return_value = {
                 "milestone_id": "ms-attempt2-started",
                 "workflow_id": wf["workflow_id"],
@@ -303,6 +305,7 @@ class TestSecondAttemptCreatesDistinctMilestone:
             orch = AutonomousOrchestrator(wf["workflow_id"])
             orch.repo = mock_repo
             orch.emitter = MagicMock()
+            orch._sync_failed_pr_with_main = MagicMock(return_value=False)
             gh = MagicMock()
             gh.get_pr_head_sha.return_value = "sha-2"
             gh.get_check_failure_excerpt.return_value = "black failed"

--- a/tests/issues/1855/test_ci_repair_no_excerpt_no_misfire.py
+++ b/tests/issues/1855/test_ci_repair_no_excerpt_no_misfire.py
@@ -57,6 +57,7 @@ def _make_orchestrator(wf_data):
         orch = AutonomousOrchestrator(wf_data["workflow_id"])
         orch.repo = mock_repo
         orch.emitter = MagicMock()
+        orch._sync_failed_pr_with_main = MagicMock(return_value=False)
     return orch, mock_repo
 
 

--- a/tests/issues/822/test_merge_conflict_detection.py
+++ b/tests/issues/822/test_merge_conflict_detection.py
@@ -67,6 +67,7 @@ def _make_orchestrator(wf):
     o._accumulate_tokens = MagicMock()
     o._write_phase_usage = MagicMock()
     o._validate_pre_merge_change_scope = MagicMock(return_value="")
+    o._sync_failed_pr_with_main = MagicMock(return_value=False)
     return o, mock_repo
 
 

--- a/tests/unit/test_autonomous_ci_guardrails.py
+++ b/tests/unit/test_autonomous_ci_guardrails.py
@@ -168,6 +168,7 @@ def test_ci_repair_scope_rejection_prevents_push():
 
     assert result == ("head", True, "scope rejected")
     gh.git_push.assert_not_called()
+    gh.reset_hard_to.assert_called_once_with("base")
 
 
 def test_runtime_gate_blocks_incompatible_host_without_provisioner(tmp_path):
@@ -209,6 +210,7 @@ def test_agent_environment_binds_python_and_git_guards(monkeypatch, tmp_path):
         guard.write_text("#!/bin/sh\n", encoding="utf-8")
         guard.chmod(0o755)
     monkeypatch.setattr(agent_runner, "_OPENACE_AGENT_GUARD_BIN", str(guard_dir))
+    monkeypatch.setenv("SKIP", "all-hooks")
 
     adapter = MagicMock()
     adapter.get_env_vars.return_value = {}
@@ -226,6 +228,7 @@ def test_agent_environment_binds_python_and_git_guards(monkeypatch, tmp_path):
     assert env["OPENACE_REAL_GIT"]
     assert env["GH_CONFIG_DIR"] == "/var/empty/openace-autonomous-gh"
     assert "GH_TOKEN" not in env
+    assert "SKIP" not in env
 
 
 def test_agent_guard_bin_falls_back_to_source_when_install_is_incomplete(monkeypatch, tmp_path):
@@ -595,6 +598,11 @@ def test_isolated_git_guard_allows_pre_commit_cache_init(tmp_path):
             **os.environ,
             "OPENACE_REAL_GIT": str(_fake_real_git(tmp_path)),
             "OPENACE_GIT_CACHE_ROOT": str(cache_root),
+            # openace-run-as clears the environment and injects this trusted
+            # ownership exception for the validated workflow worktree.
+            "GIT_CONFIG_COUNT": "1",
+            "GIT_CONFIG_KEY_0": "safe.directory",
+            "GIT_CONFIG_VALUE_0": str(project),
         },
         check=False,
     )
@@ -1453,7 +1461,9 @@ def test_fresh_ci_repair_prompt_keeps_requirements_plan_and_diff():
     assert "APPROVED PLAN" in prompt
     assert "diff --git" in prompt
     assert "CI EXCERPT" in prompt
-    assert "pre-commit run --all-files" in prompt
+    assert "pre-commit run --files" in prompt
+    assert "禁止直接对旧分支运行 `--all-files`" in prompt
+    assert "SKIP=bandit,no-commit-to-branch" in prompt
     assert "直到 exit 0" in prompt
 
 
@@ -1483,6 +1493,8 @@ def test_pre_commit_convergence_reruns_modified_hooks_as_isolated_agent():
     orch._select_project_python_runtime = MagicMock(return_value=(["python3"], ""))
     gh = MagicMock()
     gh.path_exists_as_user.return_value = True
+    gh.get_changed_files.return_value = ["app/a.py", "tests/test_a.py"]
+    gh.get_worktree_changed_paths.return_value = ["app/a.py", "app/new.py"]
     failed_checks = [
         {
             "name": "lint",
@@ -1520,6 +1532,7 @@ def test_pre_commit_convergence_reruns_modified_hooks_as_isolated_agent():
             {
                 "workspace_type": "local",
                 "worktree_path": "/private/repo",
+                "base_commit_sha": "pr-base",
             },
             gh,
             failed_checks,
@@ -1530,11 +1543,19 @@ def test_pre_commit_convergence_reruns_modified_hooks_as_isolated_agent():
     assert run.call_count == 2
     wrap.assert_called_once()
     assert wrap.call_args.args[:3] == (
-        ["/usr/local/bin/pre-commit", "run", "--all-files"],
+        [
+            "/usr/local/bin/pre-commit",
+            "run",
+            "--files",
+            "./app/a.py",
+            "./app/new.py",
+            "./tests/test_a.py",
+        ],
         "/private/repo",
         "openace-agent",
     )
     assert wrap.call_args.args[3]["PATH"].split(":", 1)[0] == "/usr/local/libexec/openace-agent-bin"
+    assert wrap.call_args.args[3]["SKIP"] == "bandit,no-commit-to-branch"
     assert run.call_args.kwargs["cwd"] is None
     assert run.call_args.kwargs["env"] is None
 
@@ -1562,6 +1583,40 @@ def test_pre_commit_convergence_rejects_repository_owner_account():
             [{"failure_excerpt": "pre-commit hook(s) made changes"}],
         )
 
+    run.assert_not_called()
+
+
+def test_pre_commit_convergence_rejects_paths_outside_worktree():
+    from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+    orch = AutonomousOrchestrator.__new__(AutonomousOrchestrator)
+    orch._resolve_isolated_agent_account = MagicMock(return_value="openace-agent")
+    orch._resolve_system_account = MagicMock(return_value="repo-owner")
+    orch._select_project_python_runtime = MagicMock(return_value=(["python3"], ""))
+    gh = MagicMock()
+    gh.path_exists_as_user.return_value = True
+    gh.get_changed_files.return_value = ["../outside.py"]
+    gh.get_worktree_changed_paths.return_value = []
+
+    with (
+        patch(
+            "app.modules.workspace.autonomous.orchestrator.shutil.which",
+            side_effect=["/usr/local/bin/pre-commit", "/usr/bin/git"],
+        ),
+        patch("app.modules.workspace.autonomous.orchestrator.subprocess.run") as run,
+    ):
+        attempted, error = orch._converge_pre_commit_fixes(
+            {
+                "workspace_type": "local",
+                "worktree_path": "/private/repo",
+                "base_commit_sha": "pr-base",
+            },
+            gh,
+            [{"failure_excerpt": "pre-commit hook(s) made changes"}],
+        )
+
+    assert attempted
+    assert "rejected unsafe path" in error
     run.assert_not_called()
 
 

--- a/tests/unit/test_autonomous_ci_guardrails.py
+++ b/tests/unit/test_autonomous_ci_guardrails.py
@@ -168,7 +168,28 @@ def test_ci_repair_scope_rejection_prevents_push():
 
     assert result == ("head", True, "scope rejected")
     gh.git_push.assert_not_called()
-    gh.reset_hard_to.assert_called_once_with("base")
+    gh.reset_hard_to.assert_called_once_with("head")
+
+
+def test_ci_repair_scope_rejection_preserves_prior_unpushed_head():
+    from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+    gh = MagicMock()
+    gh.get_current_commit.side_effect = ["local-B", "rejected-C"]
+    gh.has_uncommitted_changes.return_value = True
+
+    result = AutonomousOrchestrator._detect_and_push_ci_repair_changes(
+        gh,
+        "remote-A",
+        2,
+        "auto-dev/test",
+        42,
+        scope_validator=lambda before, after: "scope rejected",
+    )
+
+    assert result == ("rejected-C", True, "scope rejected")
+    gh.reset_hard_to.assert_called_once_with("local-B")
+    gh.git_push.assert_not_called()
 
 
 def test_runtime_gate_blocks_incompatible_host_without_provisioner(tmp_path):
@@ -1461,8 +1482,8 @@ def test_fresh_ci_repair_prompt_keeps_requirements_plan_and_diff():
     assert "APPROVED PLAN" in prompt
     assert "diff --git" in prompt
     assert "CI EXCERPT" in prompt
-    assert "pre-commit run --files" in prompt
-    assert "禁止直接对旧分支运行 `--all-files`" in prompt
+    assert "pre-commit run --all-files" in prompt
+    assert "编排器已先把当前 main 合并进 PR 分支" in prompt
     assert "SKIP=bandit,no-commit-to-branch" in prompt
     assert "直到 exit 0" in prompt
 
@@ -1493,8 +1514,6 @@ def test_pre_commit_convergence_reruns_modified_hooks_as_isolated_agent():
     orch._select_project_python_runtime = MagicMock(return_value=(["python3"], ""))
     gh = MagicMock()
     gh.path_exists_as_user.return_value = True
-    gh.get_changed_files.return_value = ["app/a.py", "tests/test_a.py"]
-    gh.get_worktree_changed_paths.return_value = ["app/a.py", "app/new.py"]
     failed_checks = [
         {
             "name": "lint",
@@ -1532,7 +1551,6 @@ def test_pre_commit_convergence_reruns_modified_hooks_as_isolated_agent():
             {
                 "workspace_type": "local",
                 "worktree_path": "/private/repo",
-                "base_commit_sha": "pr-base",
             },
             gh,
             failed_checks,
@@ -1543,14 +1561,7 @@ def test_pre_commit_convergence_reruns_modified_hooks_as_isolated_agent():
     assert run.call_count == 2
     wrap.assert_called_once()
     assert wrap.call_args.args[:3] == (
-        [
-            "/usr/local/bin/pre-commit",
-            "run",
-            "--files",
-            "./app/a.py",
-            "./app/new.py",
-            "./tests/test_a.py",
-        ],
+        ["/usr/local/bin/pre-commit", "run", "--all-files"],
         "/private/repo",
         "openace-agent",
     )
@@ -1586,38 +1597,63 @@ def test_pre_commit_convergence_rejects_repository_owner_account():
     run.assert_not_called()
 
 
-def test_pre_commit_convergence_rejects_paths_outside_worktree():
+def test_failed_pr_sync_skips_branch_that_already_contains_main():
     from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
 
     orch = AutonomousOrchestrator.__new__(AutonomousOrchestrator)
-    orch._resolve_isolated_agent_account = MagicMock(return_value="openace-agent")
-    orch._resolve_system_account = MagicMock(return_value="repo-owner")
-    orch._select_project_python_runtime = MagicMock(return_value=(["python3"], ""))
+    orch._ancestor_check = MagicMock(return_value=True)
+    orch._resolve_merge_conflicts = MagicMock()
     gh = MagicMock()
-    gh.path_exists_as_user.return_value = True
-    gh.get_changed_files.return_value = ["../outside.py"]
-    gh.get_worktree_changed_paths.return_value = []
+    gh.resolve_commit.return_value = "main-head"
 
-    with (
-        patch(
-            "app.modules.workspace.autonomous.orchestrator.shutil.which",
-            side_effect=["/usr/local/bin/pre-commit", "/usr/bin/git"],
-        ),
-        patch("app.modules.workspace.autonomous.orchestrator.subprocess.run") as run,
-    ):
-        attempted, error = orch._converge_pre_commit_fixes(
-            {
-                "workspace_type": "local",
-                "worktree_path": "/private/repo",
-                "base_commit_sha": "pr-base",
-            },
-            gh,
-            [{"failure_excerpt": "pre-commit hook(s) made changes"}],
-        )
+    synced = orch._sync_failed_pr_with_main(gh, "auto-dev/test", 42, "pr-head")
 
-    assert attempted
-    assert "rejected unsafe path" in error
-    run.assert_not_called()
+    assert not synced
+    gh._run_git.assert_called_once_with(["fetch", "origin", "main"])
+    orch._ancestor_check.assert_called_once_with(gh, "main-head", "pr-head")
+    orch._resolve_merge_conflicts.assert_not_called()
+
+
+def test_failed_pr_sync_pushes_main_before_ai_repair():
+    from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+    orch = AutonomousOrchestrator.__new__(AutonomousOrchestrator)
+    orch._ancestor_check = MagicMock(return_value=False)
+    orch._resolve_merge_conflicts = MagicMock()
+    gh = MagicMock()
+    gh.resolve_commit.return_value = "main-head"
+
+    synced = orch._sync_failed_pr_with_main(gh, "auto-dev/test", 42, "pr-head")
+
+    assert synced
+    orch._resolve_merge_conflicts.assert_called_once_with(gh, "auto-dev/test", 42)
+
+
+def test_failed_pr_sync_happens_before_ai_attempt_limit():
+    from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+    orch = AutonomousOrchestrator.__new__(AutonomousOrchestrator)
+    orch._workflow_id = "wf-sync-before-limit"
+    gh = MagicMock()
+    gh.get_pr_head_sha.return_value = "pr-head"
+    orch._get_gh = MagicMock(return_value=gh)
+    orch._sync_failed_pr_with_main = MagicMock(return_value=True)
+    orch._create_milestone = MagicMock()
+    orch._update_workflow = MagicMock()
+
+    orch._start_ci_repair_round(
+        {
+            "dev_round": 1,
+            "ci_repair_attempts": 3,
+            "branch_name": "auto-dev/test",
+        },
+        42,
+        [{"name": "lint", "bucket": "fail"}],
+    )
+
+    orch._sync_failed_pr_with_main.assert_called_once_with(gh, "auto-dev/test", 42, "pr-head")
+    orch._create_milestone.assert_not_called()
+    orch._update_workflow.assert_not_called()
 
 
 def test_nonstandard_report_with_real_test_evidence_does_not_retry():


### PR DESCRIPTION
## Summary
- accept the trusted absolute `safe.directory` injected by the isolated run-as wrapper without allowing Git write redirection
- before spending an AI CI-repair round, merge current main into a stale PR branch and push it so the next local tree matches GitHub synthetic-merge semantics
- run the exact CI pre-commit command (`--all-files`) with `SKIP=bandit,no-commit-to-branch`, while preventing SKIP leakage into normal agents
- when scope validation rejects a new local repair commit, reset to the local HEAD captured at the start of that round, preserving a prior valid unpushed commit

## Production finding
Issue-1894 attempt 3 reached the model successfully, then a cold pre-commit init was rejected because the guard did not accept `openace-run-as`'s trusted `safe.directory`. The stale local PR branch also caused `--all-files` to format 112 files that differ from current main; the 60-file guard correctly prevented the push.

## Validation
- 181 CI repair / merge / diagnostics / scope / push regression tests passed
- 6 focused agent environment tests passed
- changed-file pre-commit suite passed
- fresh pre-commit cache with real Git, wrapper `safe.directory`, and CI SKIP completed successfully
- independent review findings are addressed in commit `9d680520`