### PR TITLE
fix: preserve CI repair runner failures

### DIFF
--- a/app/modules/workspace/autonomous/agent_runner.py
+++ b/app/modules/workspace/autonomous/agent_runner.py
@@ -726,6 +726,47 @@ class AutonomousAgentRunner:
         return workspace_type == "local" and cli_tool == "claude-code"
 
     @staticmethod
+    def _classify_sidebar_start_failure(
+        return_code: int | None,
+        error_code: str = "",
+        stderr: str = "",
+    ) -> str:
+        """Return a safe, actionable reason for a pre-session Claude exit.
+
+        Raw stderr can contain command arguments or provider credentials, so it
+        must never be copied into workflow milestones.  Classify only known
+        launcher/guard signatures and otherwise report the numeric exit code.
+        """
+        lowered = (stderr or "").lower()
+        if error_code == "repo_integrity_violation" or (
+            "openace_repo_integrity_violation:" in lowered
+        ):
+            return "Protected .git entry changed during autonomous agent execution"
+
+        # openace-run-as forwards the child process status unchanged, so exit
+        # codes 64-68 alone do not identify launcher failures. Match only its
+        # exact sentinel prefix and stable message fragments.
+        if lowered.startswith("openace-run-as:"):
+            if "cannot chdir" in lowered:
+                return "Isolated launcher could not enter the project directory"
+            if "is required for isolated" in lowered:
+                return "Isolated launcher prerequisites are unavailable"
+            if "isolated agent must" in lowered or "isolated project path must" in lowered:
+                return "Isolated agent launch was rejected by safety checks"
+            if "usage:" in lowered:
+                return "Invalid isolated launcher invocation"
+            return "Isolated agent launcher failed before Claude session initialization"
+
+        if "mutating git commands are reserved" in lowered:
+            return "Agent command guard rejected a mutating Git operation during CLI startup"
+        if "fatal: detected dubious ownership" in lowered:
+            return "Git safe-directory validation failed during CLI startup"
+
+        if return_code not in (None, 0):
+            return f"Claude CLI exited before session initialization (exit code {return_code})"
+        return "Failed to detect Claude sidebar session JSONL for autonomous task"
+
+    @staticmethod
     def _extract_stream_session_id(parsed: dict[str, Any]) -> str:
         """Best-effort extraction of Claude's real session_id from a stream event."""
         if not isinstance(parsed, dict):
@@ -2038,7 +2079,12 @@ class AutonomousAgentRunner:
                 request_count=session.request_count,
                 tool_calls=session.tool_calls,
                 success=False,
-                error="Failed to detect Claude sidebar session JSONL for autonomous task",
+                error=self._classify_sidebar_start_failure(
+                    process.returncode,
+                    session.error_code,
+                    session.last_stderr,
+                ),
+                error_code=session.error_code,
             )
 
         if not completed:

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -2761,6 +2761,8 @@ class AutonomousOrchestrator:
             # the next fresh prompt. (#1816 review suggestion)
             if self._is_context_overflow(repair_result):
                 message = f"CI repair failed: context overflow - {repair_result.error}"
+            elif primary_error := self._primary_result_error(repair_result):
+                message = f"CI repair agent failed before producing code changes: {primary_error}"
             else:
                 message = "CI repair failed: agent produced no code changes"
             milestone_updates["status"] = "failed"

--- a/tests/issues/1816/test_ci_repair_context_overflow.py
+++ b/tests/issues/1816/test_ci_repair_context_overflow.py
@@ -667,10 +667,12 @@ def test_context_overflow_failure_not_injected():
     assert prior == []
 
 
-def test_normal_ci_failure_does_not_trigger_fresh_retry():
-    """A non-overflow agent failure (no code changes, no context-length text)
-    must NOT trigger the fresh retry — it should fall through to the existing
-    failure path and fail the workflow as before."""
+def test_normal_ci_failure_preserves_runner_error_without_fresh_retry():
+    """A non-overflow runner failure must remain actionable in the milestone.
+
+    It must not trigger a fresh retry, and the no-change fallback must not
+    overwrite the first-class runner error.
+    """
     wf = _make_workflow()
     orch, mock_repo = _make_orchestrator(wf)
     gh = _make_gh(commit_before="sha-old", commit_after="sha-old")  # no new commit
@@ -695,7 +697,8 @@ def test_normal_ci_failure_does_not_trigger_fresh_retry():
     # Existing behavior preserved: workflow failed.
     final_updates = mock_repo.update_workflow.call_args.args[1]
     assert final_updates["status"] == "failed"
-    assert "no code changes" in final_updates["error_message"]
+    assert "failed before producing code changes" in final_updates["error_message"]
+    assert "agent produced no output" in final_updates["error_message"]
 
 
 def test_single_fresh_overflow_preserves_signal():

--- a/tests/unit/test_autonomous_ci_guardrails.py
+++ b/tests/unit/test_autonomous_ci_guardrails.py
@@ -9,6 +9,62 @@ import pytest
 from app.modules.workspace.autonomous.models import AgentTaskResult
 
 
+@pytest.mark.parametrize(
+    ("return_code", "error_code", "stderr", "expected"),
+    [
+        (
+            126,
+            "",
+            "mutating git commands are reserved for the Open ACE orchestrator",
+            "command guard rejected",
+        ),
+        (1, "", "fatal: detected dubious ownership", "safe-directory validation failed"),
+        (
+            67,
+            "",
+            "openace-run-as: isolated agent must differ from project owner",
+            "rejected by safety checks",
+        ),
+        (
+            68,
+            "",
+            "OPENACE_REPO_INTEGRITY_VIOLATION: .git entry changed",
+            "Protected .git entry changed",
+        ),
+        (23, "", "provider-key=must-not-leak", "exit code 23"),
+        (
+            64,
+            "",
+            "ordinary child usage error",
+            "exit code 64",
+        ),
+        (
+            1,
+            "",
+            "API Error: model not found",
+            "exit code 1",
+        ),
+        (
+            0,
+            "",
+            "",
+            "Failed to detect Claude sidebar session JSONL",
+        ),
+    ],
+)
+def test_sidebar_start_failure_is_actionable_without_raw_stderr(
+    return_code, error_code, stderr, expected
+):
+    from app.modules.workspace.autonomous.agent_runner import AutonomousAgentRunner
+
+    message = AutonomousAgentRunner._classify_sidebar_start_failure(return_code, error_code, stderr)
+
+    assert expected in message
+    assert "must-not-leak" not in message
+    assert "ordinary child usage error" not in message
+    assert "model not found" not in message
+
+
 def test_actions_job_log_prefers_rest_api_without_run_cache():
     from app.modules.workspace.autonomous.github_ops import GitHubOps
 


### PR DESCRIPTION
## Summary
- classify pre-session Claude exits into safe actionable reasons without exposing raw stderr
- preserve first-class runner errors when a CI repair produces no commit
- keep the existing context-overflow handling and genuine no-change fallback

## Validation
- `96 passed`: autonomous CI guardrails + issue 1816 regression suite
- `109 passed`: above plus issue 1851/1855 CI repair suites
- targeted pre-commit hooks passed (black, isort, ruff, mypy, bandit, security checks)
- `git diff --check` passed

## Production observation
Issue-1894 exited before creating a Claude sidebar session, then the merge repair path overwrote the runner failure with `agent produced no code changes`. This patch keeps the diagnostic safe and actionable so the underlying launcher/guard class is visible on retry.