### PR TITLE
fix: normalize isolated git integrity baseline

### DIFF
--- a/scripts/openace-run-as.sh
+++ b/scripts/openace-run-as.sh
@@ -56,19 +56,19 @@ if [ "$isolated" = true ]; then
         exit 66
     fi
     git_entry_signature() {
-        if [ -L "$project_dir/.git" ]; then
-            printf 'link:%s' "$(readlink "$project_dir/.git")"
-        elif [ -f "$project_dir/.git" ]; then
+        local signature_project="$1"
+        if [ -L "$signature_project/.git" ]; then
+            printf 'link:%s' "$(readlink "$signature_project/.git")"
+        elif [ -f "$signature_project/.git" ]; then
             printf 'file:%s:%s' \
-                "$(stat -c '%d:%i:%a:%U:%G' "$project_dir/.git")" \
-                "$(sha256sum "$project_dir/.git" | cut -d' ' -f1)"
-        elif [ -d "$project_dir/.git" ]; then
-            printf 'dir:%s' "$(stat -c '%d:%i:%a:%U:%G' "$project_dir/.git")"
+                "$(stat -c '%d:%i:%a:%U:%G' "$signature_project/.git")" \
+                "$(sha256sum "$signature_project/.git" | cut -d' ' -f1)"
+        elif [ -d "$signature_project/.git" ]; then
+            printf 'dir:%s' "$(stat -c '%d:%i:%a:%U:%G' "$signature_project/.git")"
         else
             printf 'missing'
         fi
     }
-    git_entry_before="$(git_entry_signature)"
     if ! command -v setfacl >/dev/null 2>&1; then
         echo "openace-run-as: setfacl is required for isolated agent execution" >&2
         exit 66
@@ -93,6 +93,8 @@ if [ "$isolated" = true ]; then
         esac
     done
     acl_registry="/run/openace-agent-acl-${target_uid}"
+    signature_registry="/run/openace-agent-git-signature-${target_uid}"
+    signature_tmp="${signature_registry}.next"
     exec 9>"/run/lock/openace-agent-${target_uid}.lock"
     flock -x 9
 
@@ -125,11 +127,42 @@ if [ "$isolated" = true ]; then
         fi
         : > "$acl_registry"
         chmod 600 "$acl_registry" 2>/dev/null || true
+        rm -f "$signature_tmp"
     }
 
     # Recover safely after a previously interrupted wrapper before granting
-    # this run access to anything. The registry is root-owned under /run.
+    # this run access to anything. The registries are root-owned under /run.
+    #
+    # Capture the prior run's protected .git baseline before cleanup, but only
+    # compare it after cleanup has removed the launcher's own temporary ACLs.
+    # POSIX ACL mask changes are reflected in stat(2)'s mode bits; comparing a
+    # pre-cleanup signature with a post-cleanup signature therefore produced a
+    # false integrity violation even for the read-only project-dir probe.
+    previous_signature_project=""
+    previous_git_signature=""
+    if [ -f "$signature_registry" ]; then
+        IFS= read -r previous_signature_project < "$signature_registry" || true
+        previous_git_signature="$(sed -n '2p' "$signature_registry")"
+    fi
     cleanup_isolated
+    if [ -n "$previous_signature_project" ] && [ -n "$previous_git_signature" ]; then
+        recovered_git_signature="$(git_entry_signature "$previous_signature_project")"
+        if [ "$previous_git_signature" != "$recovered_git_signature" ]; then
+            echo "OPENACE_REPO_INTEGRITY_VIOLATION: .git entry changed during interrupted agent execution" >&2
+            exit 68
+        fi
+        rm -f "$signature_registry"
+    else
+        rm -f "$signature_registry"
+    fi
+
+    # Persist the normalized baseline before granting this run any ACLs. If
+    # the wrapper is interrupted, the next serialized invocation verifies this
+    # exact project after revoking the abandoned grants.
+    git_entry_before="$(git_entry_signature "$project_dir")"
+    printf '%s\n%s\n' "$project_dir" "$git_entry_before" > "$signature_tmp"
+    chmod 600 "$signature_tmp"
+    mv -f "$signature_tmp" "$signature_registry"
     trap cleanup_isolated EXIT
     # Bash services traps promptly while waiting for a background job. With a
     # foreground external command it may defer the trap until that command
@@ -196,18 +229,19 @@ if [ "$isolated" = true ]; then
         "HOME=$target_home" "USER=$target_user" "LOGNAME=$target_user" \
         "LANG=${LANG:-C.UTF-8}" "LC_ALL=${LC_ALL:-}" "TMPDIR=/tmp" \
         "GIT_CONFIG_COUNT=1" "GIT_CONFIG_KEY_0=safe.directory" \
-        "GIT_CONFIG_VALUE_0=$project_dir" "$@" <&0 &
+        "GIT_CONFIG_VALUE_0=$project_dir" "$@" <&0 9>&- &
     agent_child_pid=$!
     wait "$agent_child_pid"
     child_status=$?
     set -e
     cleanup_isolated
     trap - EXIT HUP INT TERM
-    git_entry_after="$(git_entry_signature)"
+    git_entry_after="$(git_entry_signature "$project_dir")"
     if [ "$git_entry_before" != "$git_entry_after" ]; then
         echo "OPENACE_REPO_INTEGRITY_VIOLATION: .git entry changed during agent execution" >&2
         exit 68
     fi
+    rm -f "$signature_registry"
     exit "$child_status"
 fi
 

--- a/tests/issues/1395/test_cross_user_permissions.py
+++ b/tests/issues/1395/test_cross_user_permissions.py
@@ -20,7 +20,14 @@ Covers the four fixes:
      cross-user.
 """
 
+import os
+import shutil
+import signal
+import subprocess
+import time
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from app.modules.workspace.autonomous.github_ops import GitHubOps
 
@@ -438,9 +445,94 @@ def test_isolated_wrapper_can_handle_signals_while_waiting_for_agent():
     assert "trap 'exit 129' HUP" in wrapper
     assert "trap 'exit 130' INT" in wrapper
     assert "trap 'exit 143' TERM" in wrapper
-    assert '"GIT_CONFIG_VALUE_0=$project_dir" "$@" <&0 &' in wrapper
+    assert '"GIT_CONFIG_VALUE_0=$project_dir" "$@" <&0 9>&- &' in wrapper
     assert "agent_child_pid=$!" in wrapper
     assert 'wait "$agent_child_pid"' in wrapper
+
+
+def test_background_child_does_not_inherit_acl_lock(tmp_path):
+    """A SIGKILLed wrapper must not strand fd 9 in its live child."""
+    if not shutil.which("flock"):
+        pytest.skip("flock is required for the launcher lock regression")
+
+    lock_path = tmp_path / "agent.lock"
+    child_pid_path = tmp_path / "child.pid"
+    wrapper = subprocess.Popen(
+        [
+            "bash",
+            "-c",
+            (
+                'exec 9>"$1"; flock -x 9; '
+                'sleep 30 9>&- & child=$!; printf "%s" "$child" > "$2"; wait "$child"'
+            ),
+            "openace-lock-test",
+            str(lock_path),
+            str(child_pid_path),
+        ]
+    )
+    child_pid = 0
+    try:
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline:
+            if child_pid_path.exists() and child_pid_path.read_text().strip():
+                child_pid = int(child_pid_path.read_text().strip())
+                break
+            time.sleep(0.05)
+        assert child_pid > 0
+
+        wrapper.kill()
+        wrapper.wait(timeout=5)
+        acquired = subprocess.run(
+            ["flock", "-w", "1", str(lock_path), "true"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert acquired.returncode == 0
+    finally:
+        if wrapper.poll() is None:
+            wrapper.kill()
+            wrapper.wait(timeout=5)
+        if child_pid:
+            try:
+                os.kill(child_pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+
+
+def test_isolated_wrapper_normalizes_recovered_acls_before_git_baseline():
+    """Launcher-owned ACL recovery must not look like agent .git tampering.
+
+    The prior baseline remains durable across interruption, is checked only
+    after abandoned ACLs are revoked, and the current run snapshots the
+    normalized entry before granting new ACLs.
+    """
+    from pathlib import Path
+
+    wrapper = Path("scripts/openace-run-as.sh").read_text(encoding="utf-8")
+
+    signature_registry = 'signature_registry="/run/openace-agent-git-signature-${target_uid}"'
+    recovery = 'recovered_git_signature="$(git_entry_signature "$previous_signature_project")"'
+    current_baseline = 'git_entry_before="$(git_entry_signature "$project_dir")"'
+    first_acl_grant = 'setfacl -m "u:${target_user}:x" "$parent"'
+    final_signature = 'git_entry_after="$(git_entry_signature "$project_dir")"'
+
+    assert signature_registry in wrapper
+    assert wrapper.index("cleanup_isolated\n") < wrapper.index(recovery)
+    assert wrapper.index(recovery) < wrapper.index(current_baseline)
+    assert wrapper.index(current_baseline) < wrapper.index(first_acl_grant)
+    assert wrapper.index(
+        'printf \'%s\\n%s\\n\' "$project_dir" "$git_entry_before" > "$signature_tmp"'
+    ) < wrapper.index(first_acl_grant)
+    assert wrapper.index("cleanup_isolated\n", wrapper.index('wait "$agent_child_pid"')) < (
+        wrapper.index(final_signature)
+    )
+    final_comparison = wrapper.index(
+        'if [ "$git_entry_before" != "$git_entry_after" ]',
+        wrapper.index(final_signature),
+    )
+    assert wrapper.index(final_signature) < final_comparison
+    assert final_comparison < wrapper.index('rm -f "$signature_registry"', final_comparison)
 
 
 def test_background_wait_keeps_runner_stdin_until_eof():


### PR DESCRIPTION
## Summary
- normalize abandoned ACL state before taking the current `.git` integrity baseline
- persist the project path and protected `.git` signature across interrupted launcher runs
- verify an interrupted run after ACL cleanup, then verify the current run again after cleanup
- retain inode, mode, owner/group and content-hash protection for `.git`

## Root cause
`openace-run-as --isolated` captured `.git` before recovering a prior ACL grant, then compared it after cleanup. POSIX ACL masks affect mode bits, so a launcher-owned ACL recovery could be reported as agent tampering (exit 68) before Claude started. Issue-1894 reproduced this in the project-dir probe.

## Validation
- `bash -n scripts/openace-run-as.sh`
- 5 focused issue-1395 launcher tests passed
- targeted pre-commit hooks passed
- production-host temporary-script read-only probe passed with identical inode/mode/owner/hash and ACL cleanup
- disposable-repo tamper test still returned exit 68 with `OPENACE_REPO_INTEGRITY_VIOLATION`
- `git diff --check` passed

The four unrelated preparation tests in the full issue-1395 file still have their pre-existing standalone MagicMock serialization failures; none touch this launcher path.