### PR TITLE
fix: restore exact git ACL state after isolated runs

### DIFF
--- a/scripts/openace-run-as.sh
+++ b/scripts/openace-run-as.sh
@@ -55,6 +55,18 @@ if [ "$isolated" = true ]; then
         echo "openace-run-as: flock and pkill are required for isolated execution" >&2
         exit 66
     fi
+    normalize_group_class_signature() {
+        local signature="$1"
+        local entry_mode
+        if [[ "$signature" =~ ^((file|dir):[^:]+:[^:]+:)([0-7]{3,4})(:.*)$ ]]; then
+            entry_mode="${BASH_REMATCH[3]}"
+            printf '%s%s-%s%s' \
+                "${BASH_REMATCH[1]}" "${entry_mode%??}" "${entry_mode: -1}" "${BASH_REMATCH[4]}"
+        else
+            printf '%s' "$signature"
+        fi
+    }
+
     git_entry_signature() {
         local signature_project="$1"
         if [ -L "$signature_project/.git" ]; then
@@ -69,8 +81,86 @@ if [ "$isolated" = true ]; then
             printf 'missing'
         fi
     }
-    if ! command -v setfacl >/dev/null 2>&1; then
-        echo "openace-run-as: setfacl is required for isolated agent execution" >&2
+
+    git_entry_acl_snapshot() {
+        local signature_project="$1"
+        if [ -f "$signature_project/.git" ] || [ -d "$signature_project/.git" ]; then
+            getfacl -cpE "$signature_project/.git" | base64 -w 0
+        else
+            printf '-'
+        fi
+    }
+
+    acl_snapshot_without_mask() {
+        local acl_snapshot="$1"
+        printf '%s' "$acl_snapshot" | base64 --decode | \
+            grep -v '^mask::' | base64 -w 0
+    }
+
+    acl_snapshot_has_mask() {
+        local acl_snapshot="$1"
+        printf '%s' "$acl_snapshot" | base64 --decode | grep -q '^mask::'
+    }
+
+    verify_and_restore_git_entry() {
+        local signature_project="$1"
+        local expected_signature="$2"
+        local expected_acl_snapshot="${3:-}"
+        local actual_signature
+        local actual_acl_snapshot
+        local restored_signature
+        local restored_acl_snapshot
+
+        actual_signature="$(git_entry_signature "$signature_project")"
+        actual_acl_snapshot="$(git_entry_acl_snapshot "$signature_project")"
+        if [ "$expected_signature" = "$actual_signature" ] && \
+            [ -n "$expected_acl_snapshot" ] && \
+            [ "$expected_acl_snapshot" = "$actual_acl_snapshot" ]; then
+            return 0
+        fi
+
+        # Before restoring launcher-owned ACL state, fail closed on every
+        # structural/content/ownership change. Only the group-class digit may
+        # differ here because POSIX exposes its ACL mask in those mode bits.
+        if [ "$(normalize_group_class_signature "$expected_signature")" != \
+            "$(normalize_group_class_signature "$actual_signature")" ]; then
+            return 1
+        fi
+
+        if [ -n "$expected_acl_snapshot" ] && [ "$expected_acl_snapshot" != "-" ]; then
+            # The launcher may add or recalculate only mask::. All base and
+            # named ACL entries must still exactly match before restoration.
+            if [ "$(acl_snapshot_without_mask "$expected_acl_snapshot")" != \
+                "$(acl_snapshot_without_mask "$actual_acl_snapshot")" ]; then
+                return 1
+            fi
+            printf '%s' "$expected_acl_snapshot" | base64 --decode | \
+                setfacl -n --set-file=- "$signature_project/.git" || return 1
+            restored_signature="$(git_entry_signature "$signature_project")"
+            restored_acl_snapshot="$(git_entry_acl_snapshot "$signature_project")"
+            [ "$expected_signature" = "$restored_signature" ] && \
+                [ "$expected_acl_snapshot" = "$restored_acl_snapshot" ]
+            return
+        fi
+
+        if [ "$expected_acl_snapshot" = "-" ]; then
+            [ "$expected_signature" = "$actual_signature" ]
+            return
+        fi
+
+        # Rolling-upgrade compatibility for a registry written by the previous
+        # release, which has no ACL snapshot. This one-time fallback still
+        # protects type, device/inode, owner/group, owner/other permissions and
+        # content, and is allowed only when the recovered entry actually has
+        # the extended ACL mask responsible for the legacy false positive. A
+        # successful recovery immediately writes the new exact format.
+        acl_snapshot_has_mask "$actual_acl_snapshot"
+    }
+
+    if ! command -v setfacl >/dev/null 2>&1 \
+        || ! command -v getfacl >/dev/null 2>&1 \
+        || ! command -v base64 >/dev/null 2>&1; then
+        echo "openace-run-as: setfacl, getfacl and base64 are required for isolated execution" >&2
         exit 66
     fi
     project_owner="$(stat -c '%U' "$project_dir")"
@@ -140,14 +230,18 @@ if [ "$isolated" = true ]; then
     # false integrity violation even for the read-only project-dir probe.
     previous_signature_project=""
     previous_git_signature=""
+    previous_git_acl_snapshot=""
     if [ -f "$signature_registry" ]; then
         IFS= read -r previous_signature_project < "$signature_registry" || true
         previous_git_signature="$(sed -n '2p' "$signature_registry")"
+        previous_git_acl_snapshot="$(sed -n '3p' "$signature_registry")"
     fi
     cleanup_isolated
     if [ -n "$previous_signature_project" ] && [ -n "$previous_git_signature" ]; then
-        recovered_git_signature="$(git_entry_signature "$previous_signature_project")"
-        if [ "$previous_git_signature" != "$recovered_git_signature" ]; then
+        if ! verify_and_restore_git_entry \
+            "$previous_signature_project" \
+            "$previous_git_signature" \
+            "$previous_git_acl_snapshot"; then
             echo "OPENACE_REPO_INTEGRITY_VIOLATION: .git entry changed during interrupted agent execution" >&2
             exit 68
         fi
@@ -156,11 +250,13 @@ if [ "$isolated" = true ]; then
         rm -f "$signature_registry"
     fi
 
-    # Persist the normalized baseline before granting this run any ACLs. If
-    # the wrapper is interrupted, the next serialized invocation verifies this
-    # exact project after revoking the abandoned grants.
+    # Persist the exact signature and ACL baseline before granting this run any
+    # access. If interrupted, the next invocation first verifies structural
+    # integrity, restores this ACL, and then requires an exact match.
     git_entry_before="$(git_entry_signature "$project_dir")"
-    printf '%s\n%s\n' "$project_dir" "$git_entry_before" > "$signature_tmp"
+    git_acl_before="$(git_entry_acl_snapshot "$project_dir")"
+    printf '%s\n%s\n%s\n' \
+        "$project_dir" "$git_entry_before" "$git_acl_before" > "$signature_tmp"
     chmod 600 "$signature_tmp"
     mv -f "$signature_tmp" "$signature_registry"
     trap cleanup_isolated EXIT
@@ -236,8 +332,7 @@ if [ "$isolated" = true ]; then
     set -e
     cleanup_isolated
     trap - EXIT HUP INT TERM
-    git_entry_after="$(git_entry_signature "$project_dir")"
-    if [ "$git_entry_before" != "$git_entry_after" ]; then
+    if ! verify_and_restore_git_entry "$project_dir" "$git_entry_before" "$git_acl_before"; then
         echo "OPENACE_REPO_INTEGRITY_VIOLATION: .git entry changed during agent execution" >&2
         exit 68
     fi

--- a/tests/issues/1395/test_cross_user_permissions.py
+++ b/tests/issues/1395/test_cross_user_permissions.py
@@ -20,10 +20,12 @@ Covers the four fixes:
      cross-user.
 """
 
+import base64
 import os
 import shutil
 import signal
 import subprocess
+import sys
 import time
 from unittest.mock import MagicMock, patch
 
@@ -501,38 +503,157 @@ def test_background_child_does_not_inherit_acl_lock(tmp_path):
 
 
 def test_isolated_wrapper_normalizes_recovered_acls_before_git_baseline():
-    """Launcher-owned ACL recovery must not look like agent .git tampering.
+    """Launcher ACL recovery precedes exact signature/ACL verification.
 
-    The prior baseline remains durable across interruption, is checked only
-    after abandoned ACLs are revoked, and the current run snapshots the
-    normalized entry before granting new ACLs.
+    The durable registry carries the exact ACL snapshot, cleanup runs before
+    recovery, and the next baseline is published before any new ACL grant.
     """
     from pathlib import Path
 
     wrapper = Path("scripts/openace-run-as.sh").read_text(encoding="utf-8")
 
     signature_registry = 'signature_registry="/run/openace-agent-git-signature-${target_uid}"'
-    recovery = 'recovered_git_signature="$(git_entry_signature "$previous_signature_project")"'
+    recovery = '"$previous_git_acl_snapshot"; then'
     current_baseline = 'git_entry_before="$(git_entry_signature "$project_dir")"'
+    current_acl_baseline = 'git_acl_before="$(git_entry_acl_snapshot "$project_dir")"'
     first_acl_grant = 'setfacl -m "u:${target_user}:x" "$parent"'
-    final_signature = 'git_entry_after="$(git_entry_signature "$project_dir")"'
+    final_verification = (
+        'if ! verify_and_restore_git_entry "$project_dir" "$git_entry_before" "$git_acl_before";'
+    )
 
     assert signature_registry in wrapper
+    assert 'previous_git_acl_snapshot="$(sed -n \'3p\' "$signature_registry")"' in wrapper
     assert wrapper.index("cleanup_isolated\n") < wrapper.index(recovery)
     assert wrapper.index(recovery) < wrapper.index(current_baseline)
     assert wrapper.index(current_baseline) < wrapper.index(first_acl_grant)
-    assert wrapper.index(
-        'printf \'%s\\n%s\\n\' "$project_dir" "$git_entry_before" > "$signature_tmp"'
-    ) < wrapper.index(first_acl_grant)
+    assert wrapper.index(current_acl_baseline) < wrapper.index(first_acl_grant)
+    assert wrapper.index("printf '%s\\n%s\\n%s\\n' \\") < wrapper.index(first_acl_grant)
     assert wrapper.index("cleanup_isolated\n", wrapper.index('wait "$agent_child_pid"')) < (
-        wrapper.index(final_signature)
+        wrapper.index(final_verification)
     )
-    final_comparison = wrapper.index(
-        'if [ "$git_entry_before" != "$git_entry_after" ]',
-        wrapper.index(final_signature),
+    assert wrapper.index(final_verification) < wrapper.index(
+        'rm -f "$signature_registry"', wrapper.index(final_verification)
     )
-    assert wrapper.index(final_signature) < final_comparison
-    assert final_comparison < wrapper.index('rm -f "$signature_registry"', final_comparison)
+
+
+def test_git_entry_acl_restore_preserves_exact_integrity(tmp_path):
+    """Only launcher-shaped mask churn is restored; real changes fail."""
+    if sys.platform != "linux":
+        pytest.skip("GNU stat signature regression is Linux-specific")
+    if not shutil.which("setfacl"):
+        pytest.skip("setfacl is required for the ACL mask regression")
+
+    from pathlib import Path
+    from textwrap import dedent
+
+    wrapper = Path("scripts/openace-run-as.sh").read_text(encoding="utf-8")
+    function_start = wrapper.index("    normalize_group_class_signature() {")
+    function_end = function_start
+    for _ in range(6):
+        function_end = wrapper.index("\n    }\n", function_end + 1) + len("\n    }")
+    signature_functions = dedent(wrapper[function_start:function_end])
+    project = tmp_path / "project"
+    project.mkdir()
+    git_entry = project / ".git"
+    git_entry.write_text("gitdir: /safe/metadata\n", encoding="utf-8")
+
+    def shell_value(expression: str) -> str:
+        result = subprocess.run(
+            ["bash", "-c", f"{signature_functions}\n{expression}", "signature", project],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return result.stdout
+
+    def signature() -> str:
+        return shell_value('git_entry_signature "$1"')
+
+    def acl_snapshot() -> str:
+        return shell_value('git_entry_acl_snapshot "$1"')
+
+    def verify(expected_signature: str, expected_acl: str) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [
+                "bash",
+                "-c",
+                f'{signature_functions}\nverify_and_restore_git_entry "$1" "$2" "$3"',
+                "verify",
+                project,
+                expected_signature,
+                expected_acl,
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    # Extended ACL: launcher mask churn is restored to the exact baseline.
+    subprocess.run(
+        ["setfacl", "-m", f"u:{os.getuid()}:rwx,m::rw", str(git_entry)],
+        check=True,
+    )
+    git_entry.chmod(0o664)
+    baseline = signature()
+    baseline_acl = acl_snapshot()
+    git_entry.chmod(0o674)
+    assert signature() != baseline
+    assert verify(baseline, baseline_acl).returncode == 0
+    assert signature() == baseline
+    assert acl_snapshot() == baseline_acl
+
+    # Owner/other permissions, content, inode, and non-mask ACL changes fail.
+    git_entry.chmod(0o675)
+    assert verify(baseline, baseline_acl).returncode != 0
+    git_entry.chmod(0o664)
+    git_entry.write_text("gitdir: /tampered/metadata\n", encoding="utf-8")
+    assert verify(baseline, baseline_acl).returncode != 0
+    git_entry.write_text("gitdir: /safe/metadata\n", encoding="utf-8")
+    subprocess.run(["setfacl", "-m", "g::rwx", str(git_entry)], check=True)
+    assert verify(baseline, baseline_acl).returncode != 0
+    subprocess.run(
+        ["setfacl", "-n", "--set-file=-", str(git_entry)],
+        input=base64.b64decode(baseline_acl),
+        check=True,
+    )
+    git_entry.unlink()
+    git_entry.write_text("gitdir: /safe/metadata\n", encoding="utf-8")
+    git_entry.chmod(0o664)
+    assert verify(baseline, baseline_acl).returncode != 0
+
+    # Plain ACL -> launcher mask-only ACL is restored exactly, while a plain
+    # Unix group-mode change (group::, not mask::) is rejected.
+    git_entry.unlink()
+    git_entry.write_text("gitdir: /safe/metadata\n", encoding="utf-8")
+    subprocess.run(["setfacl", "-b", str(git_entry)], check=True)
+    git_entry.chmod(0o600)
+    plain_baseline = signature()
+    plain_acl = acl_snapshot()
+    subprocess.run(["setfacl", "-m", f"u:{os.getuid()}:r", str(git_entry)], check=True)
+    subprocess.run(["setfacl", "-x", f"u:{os.getuid()}", str(git_entry)], check=True)
+    assert verify(plain_baseline, plain_acl).returncode == 0
+    assert signature() == plain_baseline
+    assert acl_snapshot() == plain_acl
+
+    git_entry.chmod(0o640)
+    assert verify(plain_baseline, plain_acl).returncode != 0
+
+    # Legacy two-line registries get one restricted group-class-compatible
+    # recovery, then the caller immediately writes the exact ACL-aware format.
+    subprocess.run(
+        ["setfacl", "-n", "--set-file=-", str(git_entry)],
+        input="user::rw-\ngroup::---\nother::---\n",
+        text=True,
+        check=True,
+    )
+    git_entry.chmod(0o674)
+    legacy_expected = signature().replace(":674:", ":664:")
+    assert verify(legacy_expected, "").returncode != 0
+    subprocess.run(
+        ["setfacl", "-m", f"u:{os.getuid()}:rwx,m::rwx", str(git_entry)],
+        check=True,
+    )
+    assert verify(legacy_expected, "").returncode == 0
 
 
 def test_background_wait_keeps_runner_stdin_until_eof():


### PR DESCRIPTION
## Summary
- persist the protected .git entry's exact raw signature and ACL snapshot atomically before isolated ACL grants
- after cleanup, preflight structural/content/ownership integrity, allow only launcher-shaped mask:: churn, restore the original ACL exactly, then require exact raw signature and ACL equality
- support one-time recovery of legacy two-line registries only when an extended ACL mask actually exists
- add Linux regressions for plain-to-mask-only ACL lifecycle, inherited ACL masks, legacy recovery, and real mode/content/inode/ACL tampering

## Root cause
A linked-worktree .git pointer inherited a named owner ACL. Adding/removing the isolated agent ACL caused GNU setfacl to recompute ACL mask bits surfaced by stat. The first candidate normalized group bits dynamically, but independent review correctly found that plain baselines could transition to a mask-only ACL and switch signature representation.

## Validation
- bash -n scripts/openace-run-as.sh
- targeted pre-commit: all passed
- focused pytest: 1 passed, 2 platform skips on macOS
- production-Linux disposable matrix: linked worktree, normal clone, plain ACL baseline, inherited ACL, repeated runs, SIGKILL recovery, legacy registry, lock/ACL cleanup, mask churn, and fail-closed non-mask ACL, owner/other mode, content and inode changes

The four unrelated standalone preparation tests in this file still hit their existing MagicMock base_commit_sha JSON serialization issue; no code in those paths changed.