### PR TITLE
fix: clear recovered merge policy pauses

### DIFF
--- a/app/routes/autonomous.py
+++ b/app/routes/autonomous.py
@@ -77,6 +77,18 @@ def _get_repo() -> AutonomousWorkflowRepository:
     return auto_repo
 
 
+def _is_recoverable_system_pause_reason(error_message: str) -> bool:
+    """Whether resume should clear a stale system-generated pause reason."""
+    from app.modules.workspace.autonomous.orchestrator import (
+        MERGE_POLICY_PAUSE_REASON_PREFIX,
+        UPSTREAM_QUOTA_PAUSE_REASON_PREFIX,
+    )
+
+    return error_message.startswith(
+        (UPSTREAM_QUOTA_PAUSE_REASON_PREFIX, MERGE_POLICY_PAUSE_REASON_PREFIX)
+    )
+
+
 autonomous_bp = Blueprint("autonomous", __name__)
 
 
@@ -1035,13 +1047,12 @@ def resume_workflow(workflow_id):
     phase = workflow.get("current_phase", "preparation")
     status = PHASE_TO_STATUS.get(phase, "pending")
 
-    # Clear only the stale hard-quota error after an operator resumes. Bailian
-    # allocated-quota rate limits never enter the paused state.
-    from app.modules.workspace.autonomous.orchestrator import UPSTREAM_QUOTA_PAUSE_REASON_PREFIX
-
+    # Clear stale recoverable system-pause errors after an operator resumes.
+    # Bailian allocated-quota rate limits never enter the paused state, while a
+    # manual pause may retain an unrelated diagnostic for the user's context.
     error_message = workflow.get("error_message") or ""
     updates = {"status": status, "paused_at": None}
-    if error_message.startswith(UPSTREAM_QUOTA_PAUSE_REASON_PREFIX):
+    if _is_recoverable_system_pause_reason(error_message):
         updates["error_message"] = ""
 
     _get_repo().update_workflow(workflow_id, updates)

--- a/tests/unit/test_autonomous_resume_pause_reason.py
+++ b/tests/unit/test_autonomous_resume_pause_reason.py
@@ -1,0 +1,28 @@
+"""Regression tests for recoverable autonomous pause reasons."""
+
+import pytest
+
+from app.routes.autonomous import _is_recoverable_system_pause_reason
+
+
+@pytest.mark.parametrize(
+    "pause_error",
+    [
+        "Upstream provider quota exhausted: restore allocation",
+        "Merge blocked by repository policy: PR #1989 requires approval",
+    ],
+)
+def test_recoverable_system_pause_reason_is_cleared_on_resume(pause_error):
+    assert _is_recoverable_system_pause_reason(pause_error)
+
+
+@pytest.mark.parametrize(
+    "pause_error",
+    [
+        "",
+        "Operator paused to inspect an external deployment",
+        "Transient network error (retry 1/3)",
+    ],
+)
+def test_manual_or_unrelated_diagnostic_is_preserved_on_resume(pause_error):
+    assert not _is_recoverable_system_pause_reason(pause_error)


### PR DESCRIPTION
## Summary

- clear the persisted merge-policy pause reason when an operator resumes the workflow
- preserve unrelated manual-pause diagnostics
- share the existing hard-quota and new merge-policy prefix classification through a small tested helper

## Why

PR #1989 introduced a manually recoverable pause for explicit no-pending repository-policy blocks. The resume route only cleared the older hard-quota prefix, so a resumed merge workflow could continue while still displaying a stale policy error.

## Validation

- `pytest -q tests/unit/test_autonomous_resume_pause_reason.py` — 5 passed
- relevant pre-commit hooks passed
- `git diff --check`

Follow-up to #1989.