### PR TITLE
fix: skip no-op conflict resolve on stale dirty mergeable_state

### DIFF
--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -3482,9 +3482,7 @@ class AutonomousOrchestrator:
         integrations patch it, but final merge now uses the same synchronization
         gate before asking GitHub to merge.
         """
-        gh._run_git(["fetch", "origin", "main"])
-        main_head = gh.resolve_commit("FETCH_HEAD")
-        contains_main = self._ancestor_check(gh, main_head, pr_head_sha)
+        contains_main = self._branch_contains_main(gh, pr_head_sha)
         if contains_main is None:
             raise GitHubOpsError("Unable to verify whether the failed PR contains current main")
         if contains_main:
@@ -3495,6 +3493,17 @@ class AutonomousOrchestrator:
         )
         self._resolve_merge_conflicts(gh, branch_name, pr_number)
         return True
+
+    def _branch_contains_main(self, gh: "GitHubOps", pr_head_sha: str) -> bool | None:
+        """Whether the PR branch already contains current main.
+
+        Returns True if the PR head has main as an ancestor (nothing to merge),
+        False if the branch is behind main, or None when the probe is
+        indeterminate and the caller must fail closed.
+        """
+        gh._run_git(["fetch", "origin", "main"])
+        main_head = gh.resolve_commit("FETCH_HEAD")
+        return self._ancestor_check(gh, main_head, pr_head_sha)
 
     def _start_ci_repair_round(self, wf: dict, pr_number: int, failed_checks: list[dict]) -> None:
         """Repair merge-phase CI failures in-place on the existing PR branch."""
@@ -8342,6 +8351,27 @@ class AutonomousOrchestrator:
                     or is_conflict_rejection
                     or (mergeable is False and not mergeable_state)
                 )
+                # GitHub's mergeability cache can report a stale "dirty"
+                # immediately after a synchronization push, before the
+                # synthetic merge commit is recomputed. The PR branch already
+                # contains main in that case, so verifying ancestry avoids a
+                # no-op merge that fails with "made no commit". Only the
+                # cache-derived "dirty" path needs the probe; text evidence
+                # and a definitive non-mergeable branch are authoritative.
+                if (
+                    is_real_conflict
+                    and mergeable_state == "dirty"
+                    and not is_conflict_rejection
+                    and mergeable is not False
+                    and pr_head_sha
+                    and self._branch_contains_main(gh, pr_head_sha) is True
+                ):
+                    logger.info(
+                        "PR #%s mergeable_state=dirty is stale (branch has main); "
+                        "deferring to policy/check path",
+                        pr_number,
+                    )
+                    is_real_conflict = False
                 if is_real_conflict:
                     try:
                         # Authoritative conflict evidence wins over generic

--- a/tests/issues/822/test_merge_conflict_detection.py
+++ b/tests/issues/822/test_merge_conflict_detection.py
@@ -1791,3 +1791,39 @@ class TestAddWorktreeExistingBranch:
         with patch.object(gh, "_run_git"):
             result = gh.add_worktree("/tmp/wt", "feature/x")
             assert result == {"worktree_path": "/tmp/wt", "branch": "feature/x"}
+
+    @patch("app.modules.workspace.autonomous.orchestrator.GitHubOps")
+    def test_stale_dirty_when_branch_has_main_does_not_resolve(self, mock_gh_cls):
+        """A stale ``dirty`` cache (branch already has main) must not no-op resolve.
+
+        Reproduces issue #1895: after a synchronization push, GitHub briefly
+        reports ``mergeable_state == "dirty"`` while the synthetic merge commit
+        is recomputed, even though the branch already contains main. Driving
+        conflict resolution in that case ran ``git merge`` to "Already up to
+        date" and failed with "made no commit". The guard verifies ancestry and
+        defers to the policy/check path instead.
+        """
+        o, _ = _make_orchestrator(_make_workflow())
+        mock_gh = MagicMock()
+        mock_gh_cls.return_value = mock_gh
+        o._gh = mock_gh
+        mock_gh.get_pr_head_sha.return_value = "pr-head-sha"
+        mock_gh.get_pr_checks.return_value = [{"name": "test", "bucket": "pass"}]
+        mock_gh.merge_pr.side_effect = [
+            GitHubOpsError("gh pr merge 1103 failed: the base branch policy prohibits the merge"),
+        ]
+        mock_gh.get_pr_merge_state.return_value = {
+            "mergeable": True,
+            "mergeable_state": "dirty",
+        }
+        o._sync_failed_pr_with_main = MagicMock(return_value=False)
+        o._branch_contains_main = MagicMock(return_value=True)
+        o._resolve_merge_conflicts = MagicMock()
+
+        with pytest.raises(WorkflowPaused, match="Merge blocked by repository policy"):
+            o._do_merge(_make_workflow())
+
+        o._resolve_merge_conflicts.assert_not_called()
+        o._branch_contains_main.assert_called_once()
+        pause_update = o._update_workflow.call_args.args[0]
+        assert pause_update["status"] == "paused"


### PR DESCRIPTION
## 问题

工作流 #1895（PR #1988）在 merge 阶段失败，错误为 `Merge resolution made no commit; refusing unchanged push`。

## 根因

在 `_do_merge` 中，PR 同步推送（synchronization push）后，GitHub 的 mergeability 缓存会在重新计算 synthetic merge commit 期间短暂报告 `mergeable_state == "dirty"`，即使 PR 分支**已经包含 main**。`is_real_conflict` 把这个陈旧的 `dirty` 当成真实冲突，调用 `_resolve_merge_conflicts`，后者执行 `git merge main` 得到 **"Already up to date"**，没有产生新 commit，于是在 push 守卫（`resolved_head == original_pr_head`）处以 "made no commit" 失败。这个守卫本身是对的，问题是路径不该走到这里。

## 修复

在 `_do_merge` 调用 `_resolve_merge_conflicts` 之前，当唯一的冲突证据是缓存派生的 `dirty` 状态时，用祖先检查验证分支是否已包含 main：
- 已包含 main → `dirty` 是陈旧缓存 → 跳过冲突解决，落入 policy/check 路径
- 文本证据（`is_conflict_rejection`）或 `mergeable is False` 仍视为权威冲突，不做探针

把共享的 fetch+ancestor 探针抽取为 `_branch_contains_main`（`_sync_failed_pr_with_main` 也复用）。

## 测试

- 新增 `test_stale_dirty_when_branch_has_main_does_not_resolve`：复现 #1895 场景，断言不调用 `_resolve_merge_conflicts`、走 policy pause 路径。
- `tests/issues/822/test_merge_conflict_detection.py`：69 passed（含新测试）
- `tests/issues/1552/`、`tests/issues/1851/`、`tests/unit/test_autonomous_ci_guardrails.py`、`tests/issues/1574/`：116 passed
- `black --check`：通过

## 影响

仅影响 merge 阶段对 `mergeable_state == "dirty"` 的判定。真实冲突（文本证据 / `mergeable is False`）路径不变。