### PR TITLE
fix(files): preserve FileList references before clearing input value

### DIFF
--- a/frontend/src/components/work/LocalDirectoryBrowser.tsx
+++ b/frontend/src/components/work/LocalDirectoryBrowser.tsx
@@ -339,8 +339,11 @@ export const LocalDirectoryBrowser: React.FC<LocalDirectoryBrowserProps> = ({
   };
 
   const handleFileSelected = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const selected = e.target.files;
-    if (!selected || selected.length === 0) return;
+    // Issue #1959: FileList is a "live" object bound to the input element.
+    // When e.target.value is cleared, e.target.files is also cleared.
+    // Must convert to array immediately to preserve the file references.
+    const selected = e.target.files ? Array.from(e.target.files) : [];
+    if (selected.length === 0) return;
 
     // Reset input so selecting the same file again fires onChange.
     e.target.value = '';


### PR DESCRIPTION
## 问题描述

Issue #1959：文件上传功能静默失败，点击上传按钮并选择文件后，实际没有上传，页面也没有任何提示。

## 根本原因

`HTMLInputElement.files` 返回的是 **"live" FileList 对象**，与 input 元素绑定。当执行 `e.target.value = ''` 清除输入值时，`e.target.files` 也会被同步清空。

原有代码：
```javascript
const selected = e.target.files;  // 捕获 live FileList 引用
if (!selected || selected.length === 0) return;
e.target.value = '';  // 此时 selected 也被清空！
// 后续遍历 selected 时已无内容
```

## 修复方案

将 `FileList` 立即转换为数组副本，保留文件引用：

```javascript
const selected = e.target.files ? Array.from(e.target.files) : [];
if (selected.length === 0) return;
e.target.value = '';  // selected 数组保持不变
```

## 验证

已在 node237 环境验证，文件上传功能正常。

Closes #1959