### PR TITLE
fix: fetch PR head before merge-base in merge scope checks

### DIFF
--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -2207,6 +2207,14 @@ class AutonomousOrchestrator:
         if not pr_head_sha:
             return "Pre-merge change scope could not be verified: missing PR head"
         try:
+            # The PR head SHA comes from the GitHub API and may not be present
+            # in the local object DB (the worktree can be torn down between
+            # rounds). Fetch the PR branch so merge-base has both objects.
+            if not self._ensure_pr_head_local(gh, pr_head_sha, wf.get("branch_name", "")):
+                return (
+                    "Pre-merge change scope could not be verified: "
+                    "PR head not present in local object DB"
+                )
             gh._run_git(["fetch", "origin", "main"])
             fetched_main_head = gh.resolve_commit("FETCH_HEAD")
             merge_base_result = gh._run_git(
@@ -3501,9 +3509,38 @@ class AutonomousOrchestrator:
         False if the branch is behind main, or None when the probe is
         indeterminate and the caller must fail closed.
         """
+        if not self._ensure_pr_head_local(gh, pr_head_sha):
+            return None
         gh._run_git(["fetch", "origin", "main"])
         main_head = gh.resolve_commit("FETCH_HEAD")
         return self._ancestor_check(gh, main_head, pr_head_sha)
+
+    def _ensure_pr_head_local(
+        self, gh: "GitHubOps", pr_head_sha: str, branch_name: str = ""
+    ) -> bool:
+        """Ensure ``pr_head_sha`` is present in the local object DB.
+
+        ``get_pr_head_sha`` queries the GitHub API for the SHA without fetching
+        the PR branch, so the object may be absent after the worktree is torn
+        down (or when the head is not reachable from main). A subsequent
+        ``git merge-base`` then fails with "no commit" and fails the workflow.
+        Fetch the branch first so the merge-base probe has both objects.
+        Returns False if the object still cannot be resolved after fetching.
+        """
+        if (
+            pr_head_sha
+            and gh._run_git(["cat-file", "-e", pr_head_sha], check=False).returncode == 0
+        ):
+            return True
+        ref = branch_name or self.workflow.get("branch_name", "")
+        if ref:
+            gh._run_git(["fetch", "origin", ref])
+        if (
+            pr_head_sha
+            and gh._run_git(["cat-file", "-e", pr_head_sha], check=False).returncode == 0
+        ):
+            return True
+        return False
 
     def _start_ci_repair_round(self, wf: dict, pr_number: int, failed_checks: list[dict]) -> None:
         """Repair merge-phase CI failures in-place on the existing PR branch."""

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -3490,7 +3490,7 @@ class AutonomousOrchestrator:
         integrations patch it, but final merge now uses the same synchronization
         gate before asking GitHub to merge.
         """
-        contains_main = self._branch_contains_main(gh, pr_head_sha)
+        contains_main = self._branch_contains_main(gh, pr_head_sha, branch_name)
         if contains_main is None:
             raise GitHubOpsError("Unable to verify whether the failed PR contains current main")
         if contains_main:
@@ -3502,14 +3502,16 @@ class AutonomousOrchestrator:
         self._resolve_merge_conflicts(gh, branch_name, pr_number)
         return True
 
-    def _branch_contains_main(self, gh: "GitHubOps", pr_head_sha: str) -> bool | None:
+    def _branch_contains_main(
+        self, gh: "GitHubOps", pr_head_sha: str, branch_name: str = ""
+    ) -> bool | None:
         """Whether the PR branch already contains current main.
 
         Returns True if the PR head has main as an ancestor (nothing to merge),
         False if the branch is behind main, or None when the probe is
         indeterminate and the caller must fail closed.
         """
-        if not self._ensure_pr_head_local(gh, pr_head_sha):
+        if not self._ensure_pr_head_local(gh, pr_head_sha, branch_name):
             return None
         gh._run_git(["fetch", "origin", "main"])
         main_head = gh.resolve_commit("FETCH_HEAD")
@@ -3535,12 +3537,10 @@ class AutonomousOrchestrator:
         ref = branch_name or self.workflow.get("branch_name", "")
         if ref:
             gh._run_git(["fetch", "origin", ref])
-        if (
+        return bool(
             pr_head_sha
             and gh._run_git(["cat-file", "-e", pr_head_sha], check=False).returncode == 0
-        ):
-            return True
-        return False
+        )
 
     def _start_ci_repair_round(self, wf: dict, pr_number: int, failed_checks: list[dict]) -> None:
         """Repair merge-phase CI failures in-place on the existing PR branch."""
@@ -8401,7 +8401,7 @@ class AutonomousOrchestrator:
                     and not is_conflict_rejection
                     and mergeable is not False
                     and pr_head_sha
-                    and self._branch_contains_main(gh, pr_head_sha) is True
+                    and self._branch_contains_main(gh, pr_head_sha, branch_name) is True
                 ):
                     logger.info(
                         "PR #%s mergeable_state=dirty is stale (branch has main); "

--- a/tests/issues/822/test_merge_conflict_detection.py
+++ b/tests/issues/822/test_merge_conflict_detection.py
@@ -333,6 +333,7 @@ class TestDoMergeDeferredRetry:
     def test_uses_graph_merge_base_and_backfills_stale_scope_base(self):
         wf = _make_workflow(base_commit_sha="old-branch-base")
         o, _ = _make_orchestrator(wf)
+        o._ensure_pr_head_local = MagicMock(return_value=True)
         gh = MagicMock()
         gh.resolve_commit.return_value = "fetched-main-head"
         gh._run_git.side_effect = [
@@ -357,6 +358,7 @@ class TestDoMergeDeferredRetry:
     def test_effective_pr_delta_still_enforces_scope_cap(self):
         wf = _make_workflow(base_commit_sha="old-branch-base")
         o, _ = _make_orchestrator(wf)
+        o._ensure_pr_head_local = MagicMock(return_value=True)
         gh = MagicMock()
         gh.resolve_commit.return_value = "fetched-main-head"
         gh._run_git.side_effect = [
@@ -389,6 +391,30 @@ class TestDoMergeDeferredRetry:
         gh.get_changed_files.assert_not_called()
         o._update_workflow.assert_not_called()
 
+    def test_pre_merge_scope_fails_when_pr_head_missing_locally(self):
+        """A PR head absent from the local object DB must fail closed, not crash.
+
+        Reproduces issue #1895 retry: after the worktree is torn down the PR
+        head SHA (from the GitHub API) is not in the local object DB, so
+        ``git merge-base`` failed. ``_ensure_pr_head_local`` now fetches the PR
+        branch; if the object still cannot be resolved the scope check returns a
+        clear error instead of "git merge-base returned no commit".
+        """
+        wf = _make_workflow(base_commit_sha="old-branch-base")
+        o, _ = _make_orchestrator(wf)
+        gh = MagicMock()
+        gh.resolve_commit.return_value = "fetched-main-head"
+        # PR head object never resolves locally even after a branch fetch.
+        gh._run_git.return_value = MagicMock(returncode=1, stdout="", stderr="")
+
+        error = AutonomousOrchestrator._validate_pre_merge_change_scope(
+            o, gh, wf, "resolved-pr-head"
+        )
+
+        assert "not present in local object DB" in error
+        gh.get_changed_files.assert_not_called()
+        o._update_workflow.assert_not_called()
+
     def test_same_cycle_ci_repair_receives_refreshed_scope_base(self):
         wf = _make_workflow(base_commit_sha="old-branch-base")
         o, _ = _make_orchestrator(wf)
@@ -400,6 +426,7 @@ class TestDoMergeDeferredRetry:
         o._start_ci_repair_round = MagicMock()
         gh = MagicMock()
         o._gh = gh
+        o._ensure_pr_head_local = MagicMock(return_value=True)
         gh.get_pr_head_sha.return_value = "resolved-pr-head"
         gh.resolve_commit.return_value = "fetched-main-head"
         gh._run_git.side_effect = [

--- a/tests/unit/test_autonomous_ci_guardrails.py
+++ b/tests/unit/test_autonomous_ci_guardrails.py
@@ -1659,6 +1659,7 @@ def test_failed_pr_sync_skips_branch_that_already_contains_main():
     orch = AutonomousOrchestrator.__new__(AutonomousOrchestrator)
     orch._ancestor_check = MagicMock(return_value=True)
     orch._resolve_merge_conflicts = MagicMock()
+    orch._ensure_pr_head_local = MagicMock(return_value=True)
     gh = MagicMock()
     gh.resolve_commit.return_value = "main-head"
 
@@ -1676,6 +1677,7 @@ def test_failed_pr_sync_pushes_main_before_ai_repair():
     orch = AutonomousOrchestrator.__new__(AutonomousOrchestrator)
     orch._ancestor_check = MagicMock(return_value=False)
     orch._resolve_merge_conflicts = MagicMock()
+    orch._ensure_pr_head_local = MagicMock(return_value=True)
     gh = MagicMock()
     gh.resolve_commit.return_value = "main-head"
 


### PR DESCRIPTION
See description in the linked commit. Reproduces and fixes the #1895 retry failure: get_pr_head_sha queries the API for the PR head SHA without fetching the branch, so after the worktree is torn down the object is absent from the local DB and git merge-base fails with 'no commit'. _ensure_pr_head_local cat-file-checks the SHA, fetches the PR branch if absent, and verifies again.