### PR TITLE
fix: retry force-with-lease stale-info rejections as transient

### DIFF
--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -837,6 +837,15 @@ _TRANSIENT_ORCHESTRATOR_KEYWORDS = [
     "unable to access",
     "rpc failed",
     "early eof",
+    # --force-with-lease rejects the push when the remote auto-dev tip moved
+    # between git's read of the remote-tracking ref and the actual push (a
+    # concurrent push, or a freshly-fetched ref). The worktree is unchanged, so
+    # a Layer-2 retry that re-reads the remote ref succeeds; treating it as
+    # non-transient strands the workflow on a recoverable race.
+    "stale info",
+    "fetch first",
+    "non-fast-forward",
+    "[rejected]",
 ]
 
 

--- a/tests/issues/1814/test_orchestrator_push_retry.py
+++ b/tests/issues/1814/test_orchestrator_push_retry.py
@@ -354,3 +354,29 @@ class TestTransientKeywordsCoverage:
 
         e = GitHubOpsError("git push failed: early EOF")
         assert _is_transient_git_error(e) is True
+
+    def test_force_with_lease_stale_info_is_transient(self):
+        """--force-with-lease stale-info rejection is a recoverable race."""
+        from app.modules.workspace.autonomous.orchestrator import _is_transient_git_error
+
+        e = GitHubOpsError(
+            "git push origin auto-dev/3c5aefb9 --force-with-lease failed (exit 1): "
+            "To https://github.com/open-ace/open-ace "
+            "! [rejected] auto-dev/3c5aefb9 -> auto-dev/3c5aefb9 (stale info) "
+            "错误：无法推送一些引用"
+        )
+        assert _is_transient_git_error(e) is True
+
+    def test_fetch_first_is_transient(self):
+        """git 'fetch first' rejection is transient."""
+        from app.modules.workspace.autonomous.orchestrator import _is_transient_git_error
+
+        e = GitHubOpsError("git push failed: ! [rejected] main -> main (fetch first)")
+        assert _is_transient_git_error(e) is True
+
+    def test_non_fast_forward_is_transient(self):
+        """non-fast-forward rejection is transient."""
+        from app.modules.workspace.autonomous.orchestrator import _is_transient_git_error
+
+        e = GitHubOpsError("git push failed: ! [rejected] (non-fast-forward)")
+        assert _is_transient_git_error(e) is True


### PR DESCRIPTION
## Problem

Workflow 1895 failed at merge-round CI repair:

```
git push origin auto-dev/3c5aefb9 --force-with-lease failed (exit 1):
To https://github.com/open-ace/open-ace
 ! [rejected] auto-dev/3c5aefb9 -> auto-dev/3c5aefb9 (stale info)
 错误：无法推送一些引用
```

`--force-with-lease` (used for re-pushing an `auto-dev/*` branch after CI repair / review-fix / dev re-commit) rejects the push with `(stale info)` when the remote tip moved between git reading the remote-tracking ref and the actual push — a concurrent push or a freshly-fetched ref. The worktree is unchanged, so a Layer-2 retry that re-reads the remote ref succeeds.

`_is_transient_git_error` only covered network/SSL errors (`ssl`, `tls`, `connection reset`, `rpc failed`, …). The `stale info` rejection matched none of them, so the CI-repair push handler captured it as **non-transient** and stranded the workflow instead of propagating for Layer-2 retry.

## Fix

Add force-with-lease rejection signals to `_TRANSIENT_ORCHESTRATOR_KEYWORDS` so they propagate for Layer-2 retry:

- `"stale info"` — the exact rejection from this failure
- `"fetch first"` — the other `--force-with-lease` rejection form (remote ahead)
- `"non-fast-forward"` / `"[rejected]"` — generic non-fast-forward race

A retry re-reads the remote-tracking ref and the lease then matches, so the push succeeds.

## Scope

Only `_is_transient_git_error` classification. Push mechanics, branch validation (`auto-dev/*` guard), and the Layer-2 retry loop are unchanged. Auth errors (`permission denied`) remain non-transient.

## Tests

- New: `test_force_with_lease_stale_info_is_transient`, `test_fetch_first_is_transient`, `test_non_fast_forward_is_transient`
- Existing push-retry suite (1814): 24 passed
- Network-retry (1002) + ci_guardrails + resume_pause_reason: 132 passed total
- `ruff check` (CI-grade, SIM on): clean; `black --check`: clean

## Why retry, not a smarter lease

The implicit `--force-with-lease` (no `<ref>:<expect>`) is intentional: it lets git use its own freshness check. When that race fires, the correct response is to retry (cheap, re-reads the ref) rather than re-engineer the lease contract. Treating it as transient matches how the engine already handles network races.