### PR TITLE
fix: sync merge worktree to PR remote head before merging main

### DIFF
--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -8529,6 +8529,31 @@ class AutonomousOrchestrator:
         )
         self._emit("phase_change", {"phase": "completed"})
 
+    def _sync_worktree_to_pr_remote_head(self, wt_gh: "GitHubOps", branch_name: str) -> None:
+        """Sync a merge worktree to the PR branch's authoritative remote head.
+
+        ``add_worktree`` checks out the *local* ``auto-dev/*`` ref, which can
+        drift ahead of the remote tip: a prior merge/repair attempt may have
+        advanced it locally (e.g. a merge commit that already contains main)
+        without ever pushing. A later cycle then re-checks out that stale local
+        branch, the merge into main becomes a no-op ("Already up to date"), and
+        the resolver fails with "made no commit" even though the remote PR head
+        is still behind main and genuinely needs the sync (workflow 1895).
+        Fetch the remote branch and reset the local ref/HEAD to it so the merge
+        starts from the real PR state. Failure is non-fatal: a fetch/reset error
+        leaves the worktree at the local ref, preserving prior behavior.
+        """
+        try:
+            wt_gh._run_git(["fetch", "origin", branch_name])
+            remote_head = wt_gh.resolve_commit("FETCH_HEAD")
+            wt_gh._run_git(["reset", "--hard", remote_head])
+        except Exception as sync_exc:
+            logger.warning(
+                "Could not sync merge worktree to remote head of %s: %s",
+                branch_name,
+                sync_exc,
+            )
+
     def _resolve_merge_conflicts(self, gh: GitHubOps, branch_name: str, pr_number: int):
         """Resolve merge conflicts in an isolated worktree, push, and merge the PR.
 
@@ -8577,6 +8602,9 @@ class AutonomousOrchestrator:
         # All subsequent git ops run inside the temp worktree.
         wt_gh = GitHubOps(temp_wt_path, system_account=system_account)
         try:
+            # Sync the checked-out branch to the PR's authoritative remote head
+            # before merging main (see _sync_worktree_to_pr_remote_head).
+            self._sync_worktree_to_pr_remote_head(wt_gh, branch_name)
             original_pr_head = wt_gh.get_current_commit()
             conflict_ms_id = ""
             milestone_result = {}

--- a/tests/issues/822/test_merge_conflict_detection.py
+++ b/tests/issues/822/test_merge_conflict_detection.py
@@ -68,6 +68,9 @@ def _make_orchestrator(wf):
     o._write_phase_usage = MagicMock()
     o._validate_pre_merge_change_scope = MagicMock(return_value="")
     o._sync_failed_pr_with_main = MagicMock(return_value=False)
+    # The remote-head sync runs real git ops; stub it so tests model only the
+    # merge/resolve sequence (the sync itself is unit-tested separately).
+    o._sync_worktree_to_pr_remote_head = MagicMock()
     return o, mock_repo
 
 
@@ -1854,3 +1857,44 @@ class TestAddWorktreeExistingBranch:
         o._branch_contains_main.assert_called_once()
         pause_update = o._update_workflow.call_args.args[0]
         assert pause_update["status"] == "paused"
+
+
+class TestSyncWorktreeToPrRemoteHead:
+    """``_sync_worktree_to_pr_remote_head`` resets the local branch to the remote
+    tip before merging main (workflow 1895: stale local branch ahead of remote)."""
+
+    def test_fetches_branch_and_resets_hard_to_remote_head(self):
+        from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+        o, _ = _make_orchestrator(_make_workflow())
+        # _make_orchestrator stubs this out; restore the real implementation.
+        o._sync_worktree_to_pr_remote_head = (
+            AutonomousOrchestrator._sync_worktree_to_pr_remote_head.__get__(o)
+        )
+        wt_gh = MagicMock()
+        wt_gh.resolve_commit.return_value = "remote-tip-sha"
+
+        o._sync_worktree_to_pr_remote_head(wt_gh, "auto-dev/3c5aefb9")
+
+        # fetch origin <branch>, then reset --hard <remote_head>
+        assert wt_gh._run_git.call_args_list == [
+            call(["fetch", "origin", "auto-dev/3c5aefb9"]),
+            call(["reset", "--hard", "remote-tip-sha"]),
+        ]
+        wt_gh.resolve_commit.assert_called_once_with("FETCH_HEAD")
+
+    def test_sync_failure_is_non_fatal_and_warns(self):
+        """A fetch/reset failure must not raise; it falls back to the local ref."""
+        from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+        o, _ = _make_orchestrator(_make_workflow())
+        o._sync_worktree_to_pr_remote_head = (
+            AutonomousOrchestrator._sync_worktree_to_pr_remote_head.__get__(o)
+        )
+        wt_gh = MagicMock()
+        wt_gh._run_git.side_effect = GitHubOpsError("fetch failed: network down")
+
+        # Should not raise.
+        o._sync_worktree_to_pr_remote_head(wt_gh, "auto-dev/3c5aefb9")
+
+        wt_gh._run_git.assert_called_once_with(["fetch", "origin", "auto-dev/3c5aefb9"])


### PR DESCRIPTION
## Problem

Workflow 1895 failed at merge round 3:

```
Merge resolution made no commit; refusing unchanged push
```

**Root cause** (verified on the server): `_resolve_merge_conflicts` checks out the *local* `auto-dev/*` ref via `add_worktree`, but that ref can drift ahead of the remote tip. In 1895:

- local `auto-dev/3c5aefb9` = `6095cf4e` = "Merge commit 93acea51 (main) into auto-dev/3c5aefb9" — **already contains current main**, from a prior merge attempt that was **never pushed**
- remote PR head = `c6f3d148` — does **not** contain current main (still behind)

On retry, the resolver re-checks out the stale local branch, runs `git merge 93acea51` → **"Already up to date"** (no conflict, no commit) → `git_commit` is a no-op → `resolved_head == original_pr_head` → "made no commit". Meanwhile the **remote PR head is genuinely behind main** and its CI (lint) is failing — the sync the workflow needs never happens.

`git merge-base --is-ancestor 93acea51(main) c6f3d148(remote)` = false, so the branch-contains-main probe correctly says "needs sync", but the merge operates on the drifted local ref, not the remote head.

## Fix

New `_sync_worktree_to_pr_remote_head(wt_gh, branch_name)`: after the temp worktree is created, `fetch origin <branch>` + `resolve_commit FETCH_HEAD` + `reset --hard <remote_head>` so the merge into main starts from the PR's authoritative remote state. Called once in `_resolve_merge_conflicts` before `git merge main`.

- Failure is **non-fatal**: a fetch/reset error logs a warning and leaves the worktree at the local ref (preserves prior behavior rather than failing the workflow on a transient fetch error).
- The `made no commit` guard remains — it now only fires when the merge genuinely produces no change, which is the correct fail-closed behavior.

## Why a helper (testability)

The new git ops are isolated in `_sync_worktree_to_pr_remote_head` so the existing 24 merge-isolation tests stub it out (`o._sync_worktree_to_pr_remote_head = MagicMock()` in the fixture) and keep modeling only the merge/resolve sequence. The helper itself has 2 dedicated tests (fetch+reset happy path; non-fatal failure).

## Tests

- New: `test_fetches_branch_and_resets_hard_to_remote_head`, `test_sync_failure_is_non_fatal_and_warns`
- Existing 822 merge-detection (142) + ci_guardrails + 1814 push-retry: **168 passed**
- `ruff check` (CI-grade, SIM on): clean; `black --check`: clean

## Scope

Only `_resolve_merge_conflicts` startup. Merge mechanics, conflict-detection, scope guards, and the branch-contains-main probe are unchanged.