### PR TITLE
fix(scripts): use absolute path for runuser in openace-write-as wrapper

### DIFF
--- a/scripts/openace-write-as.sh
+++ b/scripts/openace-write-as.sh
@@ -103,7 +103,7 @@ log_audit "caller=$(whoami) target_user=${TARGET_USER} path=${RESOLVED_PATH} res
 # the file and writes stdin to it; stdout is discarded so it doesn't echo
 # back. A temp file + atomic rename would be nicer for crash safety, but tee
 # matches the simplicity of the single-user file.save() path.
-if runuser -u "$TARGET_USER" -- tee "$RESOLVED_PATH" > /dev/null; then
+if /usr/sbin/runuser -u "$TARGET_USER" -- tee "$RESOLVED_PATH" > /dev/null; then
     log_audit "caller=$(whoami) target_user=${TARGET_USER} path=${RESOLVED_PATH} result=success"
     exit 0
 else


### PR DESCRIPTION
## 问题描述

Package 版多用户模式下，文件上传失败，错误信息：
```
Cannot upload file as owner (sudoers policy missing 'openace-write-as' for this deployment)
```

## 根本原因

`openace-write-as` wrapper 脚本使用 `runuser` 命令切换用户，但：
- `runuser` 位于 `/usr/sbin/` 目录
- 非 shell 登录环境（sudo 调用）的默认 PATH 不包含 `/usr/sbin/`
- 导致 `runuser: command not found` 错误

## 修复方案

将 `runuser` 改为绝对路径 `/usr/sbin/runuser`：

```bash
# 修复前
if runuser -u "$TARGET_USER" -- tee "$RESOLVED_PATH" > /dev/null; then

# 修复后
if /usr/sbin/runuser -u "$TARGET_USER" -- tee "$RESOLVED_PATH" > /dev/null; then
```

## 验证

已在本地环境验证，文件上传功能正常。

## 相关 Issue

这是 Issue #1916 引入的 `openace-write-as` wrapper 的路径问题。