### PR TITLE
fix(launcher): skip cross-project stale integrity registry on interrupt

### DIFF
--- a/scripts/openace-run-as.sh
+++ b/scripts/openace-run-as.sh
@@ -238,10 +238,23 @@ if [ "$isolated" = true ]; then
     fi
     cleanup_isolated
     if [ -n "$previous_signature_project" ] && [ -n "$previous_git_signature" ]; then
-        if ! verify_and_restore_git_entry \
-            "$previous_signature_project" \
-            "$previous_git_signature" \
-            "$previous_git_acl_snapshot"; then
+        # The signature registry is keyed by the shared isolation account
+        # (uid), not the project path. Any workflow using this account that is
+        # interrupted leaves a registry behind; the next (possibly different)
+        # workflow would then compare its own .git against the stale entry and
+        # fail with a false integrity violation — most commonly because the
+        # interrupted run's worktree (e.g. a throwaway merge-<wf> worktree) was
+        # already cleaned up, so its .git is now "missing". Only verify when
+        # the previous run operated on the same project as this one; otherwise
+        # the registry belongs to a different, already-finalized run and is
+        # discarded.
+        if [ "$previous_signature_project" = "$project_dir" ] && \
+            verify_and_restore_git_entry \
+                "$previous_signature_project" \
+                "$previous_git_signature" \
+                "$previous_git_acl_snapshot"; then
+            : # integrity verified for the same project
+        elif [ "$previous_signature_project" = "$project_dir" ]; then
             echo "OPENACE_REPO_INTEGRITY_VIOLATION: .git entry changed during interrupted agent execution" >&2
             exit 68
         fi


### PR DESCRIPTION
## Problem

Workflows 169/170/171/172 all failed with `OPENACE_REPO_INTEGRITY_VIOLATION: .git entry changed during interrupted agent execution` (exit 68) repeatedly today, **starting before any of my deploys** (workflow 169 at 04:44/05:12/05:47 UTC, before #1997/#1999 were deployed).

**Root cause** (verified on the server): the `.git` signature registry at `/run/openace-agent-git-signature-${target_uid}` is keyed by the **shared isolation account (uid 386 = openace-agent)**, not the project path. When a workflow using that account is interrupted (e.g. a service restart mid-agent, or a SIGTERM), it leaves a registry pointing at *its own* `.git`. The next workflow — a **different worktree** — reads that stale registry and calls `verify_and_restore_git_entry` with the *interrupted* project path.

In the common case the interrupted run was a throwaway `merge-<wf>` worktree, which is cleaned up after merge — so its `.git` is now `missing`, `git_entry_signature` returns `missing`, that != the stored signature, and the launcher fails closed with a false integrity violation.

Evidence on the server: the stale registry for uid 386 contained `/home/rhuang/merge-f8a1ef36` (a deleted merge worktree); 1897 then failed verifying its *own* dev worktree against that stale entry. **Every workflow sharing the account was stranded** until the registry was manually cleared.

## Fix

Only verify the interrupted-run registry when its `previous_signature_project` **equals the current `project_dir`**. A registry from a different project belongs to an already-finalized run and is discarded. Same-project tampering is still detected and fails closed exactly as before (the `elif` branch).

## Why this is correct

- The registry is per-account (uid), shared across all workflows using `openace-agent`. A leftover registry from workflow A is meaningless to workflow B running in a different worktree.
- The interrupted-run check exists to catch `.git` tampering *between* a crash and the retry of the **same** project. Cross-project registries can never represent tampering of the current project, so comparing them is a category error.
- `git worktree` operations (add/remove) legitimately create and delete `.git` entries across concurrent workflows — these are not integrity violations.
- Same-project detection is unchanged: if `previous_signature_project == project_dir` and `.git` differs, it still exits 68.

## Tests / verification

- `bash -n scripts/openace-run-as.sh`: clean
- Pre-existing 4 failures in `tests/issues/1395/test_cross_user_permissions.py::TestPreparationWorktreeCleanup` are unrelated (confirmed to fail on clean main: `MagicMock is not JSON serializable` in `_emit`); this PR does not touch orchestrator.py.
- `tests/unit/test_autonomous_ci_guardrails.py`: 119 passed, 2 skipped
- Runtime verification: removing the stale uid-386 registry unblocked retries (1896/1897 advanced past the violation).

## Scope

Only the interrupted-run registry check (`scripts/openace-run-as.sh`). The post-agent same-project check (L336) and ACL restore logic are unchanged.