### PR TITLE
fix: skip stale signature registry when previous project dir is gone

### DIFF
--- a/scripts/openace-run-as.sh
+++ b/scripts/openace-run-as.sh
@@ -238,14 +238,23 @@ if [ "$isolated" = true ]; then
     fi
     cleanup_isolated
     if [ -n "$previous_signature_project" ] && [ -n "$previous_git_signature" ]; then
-        if ! verify_and_restore_git_entry \
+        # The signature registry is keyed per-agent-user, not per-project.
+        # When the previous project directory no longer exists, it was removed
+        # by a trusted component (the orchestrator deletes temporary merge
+        # worktrees after each phase). The credentialless agent cannot delete
+        # the project directory or its .git entry, so a missing directory is
+        # not a tamper signal — discard the stale registry and proceed.
+        if [ ! -e "$previous_signature_project" ]; then
+            rm -f "$signature_registry"
+        elif ! verify_and_restore_git_entry \
             "$previous_signature_project" \
             "$previous_git_signature" \
             "$previous_git_acl_snapshot"; then
             echo "OPENACE_REPO_INTEGRITY_VIOLATION: .git entry changed during interrupted agent execution" >&2
             exit 68
+        else
+            rm -f "$signature_registry"
         fi
-        rm -f "$signature_registry"
     else
         rm -f "$signature_registry"
     fi

--- a/tests/issues/1395/test_cross_user_permissions.py
+++ b/tests/issues/1395/test_cross_user_permissions.py
@@ -536,6 +536,36 @@ def test_isolated_wrapper_normalizes_recovered_acls_before_git_baseline():
     )
 
 
+def test_stale_signature_registry_skipped_when_previous_project_gone():
+    """A per-user signature registry whose project dir was cleaned up (e.g.
+    a temporary merge worktree removed by the orchestrator) must not trigger
+    OPENACE_REPO_INTEGRITY_VIOLATION for an unrelated subsequent run.
+
+    The credentialless agent cannot delete the project directory, so a missing
+    directory is not a tamper signal — the stale registry is discarded.
+    """
+    from pathlib import Path
+
+    wrapper = Path("scripts/openace-run-as.sh").read_text(encoding="utf-8")
+
+    previous_block = (
+        'if [ -n "$previous_signature_project" ] && [ -n "$previous_git_signature" ]; then'
+    )
+    missing_guard = '[ ! -e "$previous_signature_project" ]'
+    interrupted_violation = (
+        "OPENACE_REPO_INTEGRITY_VIOLATION: .git entry changed during interrupted agent execution"
+    )
+
+    assert previous_block in wrapper
+    block_start = wrapper.index(previous_block)
+
+    # The missing-project guard must appear inside the previous-signature block…
+    assert missing_guard in wrapper[block_start:]
+    guard_pos = wrapper.index(missing_guard, block_start)
+    # …and it must come before the interrupted-execution violation message.
+    assert guard_pos < wrapper.index(interrupted_violation, guard_pos)
+
+
 def test_git_entry_acl_restore_preserves_exact_integrity(tmp_path):
     """Only launcher-shaped mask churn is restored; real changes fail."""
     if sys.platform != "linux":


### PR DESCRIPTION
## Problem

Autonomous workflows 1895 and 1896 (and others sharing the same `openace-agent` account) are stuck in `failed` status with `OPENACE_REPO_INTEGRITY_VIOLATION: .git entry changed during interrupted agent execution`.

### Root cause

The `openace-run-as.sh` signature registry (`/run/openace-agent-git-signature-<uid>`) is keyed **per-agent-user**, not per-project. During the merge phase, the orchestrator creates a temporary merge worktree at `<repo>/../merge-<wf_id[:8]>` and the wrapper records its `.git` signature. After the merge phase completes (or fails), the orchestrator deletes the merge worktree — but the signature registry is **not** cleaned up.

The next run for the same agent user reads the stale registry, which references the now-deleted project directory. `git_entry_signature` returns `"missing"` for the non-existent path, which does not match the stored `file:...` signature, so the wrapper exits with code 68 (`OPENACE_REPO_INTEGRITY_VIOLATION`), aborting the workflow. This blocks **all** subsequent workflows sharing that agent account, even unrelated ones.

The credentialless agent has read-only access to `.git` and cannot delete the project directory or its `.git` entry, so a missing directory is not a tamper signal — it was removed by a trusted component (the orchestrator).

## Fix

In `openace-run-as.sh`, before calling `verify_and_restore_git_entry` on the previous signature, check whether the previous project directory still exists. If it does not, discard the stale registry and proceed with the current run instead of aborting.

The integrity check still fully applies when the previous project directory **exists** — only the missing-directory case is skipped.

## Testing

- Added `test_stale_signature_registry_skipped_when_previous_project_gone` verifying the guard exists and is ordered before the violation message.
- All 75 existing signature/integrity/guardrail tests still pass.