### PR TITLE
fix: clear stale scheduler in-progress state on workflow retry

### DIFF
--- a/app/routes/autonomous.py
+++ b/app/routes/autonomous.py
@@ -1164,6 +1164,18 @@ def retry_workflow(workflow_id):
     phase = workflow.get("current_phase", "preparation")
     status = PHASE_TO_STATUS.get(phase, "pending")
 
+    # Clear stale scheduler in-progress state so the scheduler doesn't skip
+    # this workflow on every cycle. If the previous orchestrator thread exited
+    # without running its finally cleanup (e.g. OOM kill, hard crash), the
+    # workflow_id would be permanently stuck in _in_progress_ids, making retry
+    # ineffective — the DB status changes but the scheduler never advances.
+    try:
+        from app.services.autonomous_scheduler import AutonomousScheduler
+
+        AutonomousScheduler.instance().clear_in_progress(workflow_id)
+    except Exception as e:
+        logger.warning("Failed to clear in-progress state for %s: %s", workflow_id[:8], e)
+
     _get_repo().update_workflow(
         workflow_id,
         {

--- a/app/routes/autonomous.py
+++ b/app/routes/autonomous.py
@@ -1172,7 +1172,7 @@ def retry_workflow(workflow_id):
     try:
         from app.services.autonomous_scheduler import AutonomousScheduler
 
-        AutonomousScheduler.instance().clear_in_progress(workflow_id)
+        AutonomousScheduler.instance().clear_in_progress(workflow_id, wf=workflow)
     except Exception as e:
         logger.warning("Failed to clear in-progress state for %s: %s", workflow_id[:8], e)
 

--- a/app/services/autonomous_scheduler.py
+++ b/app/services/autonomous_scheduler.py
@@ -141,6 +141,64 @@ class AutonomousScheduler:
         with self._orchestrator_lock:
             return self._running_orchestrators.get(workflow_id)
 
+    def clear_in_progress(self, workflow_id: str) -> None:
+        """Clear stale in-progress state for a workflow.
+
+        Called by the retry endpoint to ensure a retried workflow is not
+        permanently skipped by the scheduler due to a stale ``_in_progress_ids``
+        entry left behind by an orchestrator thread that exited without running
+        its ``finally`` cleanup (e.g. hard crash, OOM kill). Also removes any
+        orphaned orchestrator reference and releases the DB-level lock so the
+        next scheduler cycle can acquire a fresh lock.
+        """
+        # Remove any orphaned orchestrator reference. If the orchestrator is
+        # genuinely still running, this is a no-op because the caller (retry
+        # endpoint) already verified status == "failed" — a failed workflow has
+        # no live orchestrator.
+        with self._orchestrator_lock:
+            self._running_orchestrators.pop(workflow_id, None)
+
+        with self._in_progress_lock:
+            self._in_progress_ids.discard(workflow_id)
+            # We don't know the exact workspace/branch/batch values here, but
+            # that's fine — _conflict_keys are also re-checked dynamically in
+            # _advance_single's finally block. The critical cleanup is removing
+            # workflow_id from _in_progress_ids, which is what causes the
+            # scheduler to skip the workflow every cycle.
+
+        # Release the DB-level lock so the next cycle can acquire it.
+        try:
+            from app.routes.autonomous import _get_repo
+
+            repo = _get_repo()
+            # Force-release regardless of owner — the previous owner is gone.
+            conn = repo.db.get_connection()
+            try:
+                cursor = conn.cursor()
+                import app.repositories.database as _db_mod
+
+                cursor.execute(
+                    _db_mod.adapt_sql(
+                        """
+                        UPDATE autonomous_workflows
+                        SET locked_at = NULL, locked_by = NULL
+                        WHERE workflow_id = ?
+                        """
+                    ),
+                    (workflow_id,),
+                )
+                conn.commit()
+            finally:
+                conn.close()
+        except Exception:
+            logger.warning(
+                "Failed to release DB lock for workflow %s during clear_in_progress",
+                workflow_id[:8],
+                exc_info=True,
+            )
+
+        logger.info("Cleared stale in-progress state for workflow %s", workflow_id[:8])
+
     @staticmethod
     def _conflict_keys(wf: dict) -> tuple[str, str]:
         """Git-conflict identity for a workflow: ``(workspace, branch)``.

--- a/app/services/autonomous_scheduler.py
+++ b/app/services/autonomous_scheduler.py
@@ -141,15 +141,21 @@ class AutonomousScheduler:
         with self._orchestrator_lock:
             return self._running_orchestrators.get(workflow_id)
 
-    def clear_in_progress(self, workflow_id: str) -> None:
+    def clear_in_progress(self, workflow_id: str, wf: dict | None = None) -> None:
         """Clear stale in-progress state for a workflow.
 
         Called by the retry endpoint to ensure a retried workflow is not
         permanently skipped by the scheduler due to a stale ``_in_progress_ids``
         entry left behind by an orchestrator thread that exited without running
         its ``finally`` cleanup (e.g. hard crash, OOM kill). Also removes any
-        orphaned orchestrator reference and releases the DB-level lock so the
-        next scheduler cycle can acquire a fresh lock.
+        orphaned orchestrator reference, clears git-conflict keys, and releases
+        the DB-level lock so the next scheduler cycle can acquire a fresh lock.
+
+        Args:
+            workflow_id: The workflow to clear.
+            wf: Optional workflow dict for computing conflict keys. When
+                provided, also clears ``_in_progress_workspaces``,
+                ``_in_progress_branches``, and ``_in_progress_batch_ids``.
         """
         # Remove any orphaned orchestrator reference. If the orchestrator is
         # genuinely still running, this is a no-op because the caller (retry
@@ -160,11 +166,18 @@ class AutonomousScheduler:
 
         with self._in_progress_lock:
             self._in_progress_ids.discard(workflow_id)
-            # We don't know the exact workspace/branch/batch values here, but
-            # that's fine — _conflict_keys are also re-checked dynamically in
-            # _advance_single's finally block. The critical cleanup is removing
-            # workflow_id from _in_progress_ids, which is what causes the
-            # scheduler to skip the workflow every cycle.
+            # Also clear git-conflict keys so _process_workflows doesn't skip
+            # the retried workflow on workspace/branch/batch collision. The
+            # workflow dict is available from the retry endpoint.
+            if wf:
+                workspace, branch = self._conflict_keys(wf)
+                if workspace:
+                    self._in_progress_workspaces.discard(workspace)
+                if branch:
+                    self._in_progress_branches.discard(branch)
+                batch_id = wf.get("batch_id")
+                if batch_id:
+                    self._in_progress_batch_ids.discard(batch_id)
 
         # Release the DB-level lock so the next cycle can acquire it.
         try:

--- a/tests/issues/1897/test_retry_clears_in_progress.py
+++ b/tests/issues/1897/test_retry_clears_in_progress.py
@@ -32,6 +32,29 @@ class TestRetryClearsInProgress:
         sched._running_orchestrators[wf_id] = MagicMock()
         return sched, wf_id
 
+    @pytest.fixture
+    def scheduler_with_wf(self):
+        """Create scheduler with stuck state and a workflow dict for conflict keys."""
+        from app.services.autonomous_scheduler import AutonomousScheduler
+
+        sched = AutonomousScheduler()
+        wf_id = "stuck-workflow-456"
+        wf = {
+            "workflow_id": wf_id,
+            "worktree_path": "/home/repo/.worktrees/stuck-456",
+            "project_path": "/home/repo",
+            "branch_name": "auto-dev/stuck-456",
+            "batch_id": "batch-42",
+            "current_phase": "development",
+        }
+        sched._in_progress_ids.add(wf_id)
+        workspace, branch = sched._conflict_keys(wf)
+        sched._in_progress_workspaces.add(workspace)
+        sched._in_progress_branches.add(branch)
+        sched._in_progress_batch_ids.add("batch-42")
+        sched._running_orchestrators[wf_id] = MagicMock()
+        return sched, wf_id, wf
+
     def test_clear_in_progress_removes_from_in_progress_ids(self, scheduler):
         """clear_in_progress must remove workflow_id from _in_progress_ids."""
         sched, wf_id = scheduler
@@ -53,6 +76,30 @@ class TestRetryClearsInProgress:
             sched.clear_in_progress(wf_id)
 
         assert wf_id not in sched._running_orchestrators
+
+    def test_clear_in_progress_clears_conflict_keys_with_wf(self, scheduler_with_wf):
+        """clear_in_progress must clear workspace/branch/batch keys when wf is provided."""
+        sched, wf_id, wf = scheduler_with_wf
+        workspace, branch = sched._conflict_keys(wf)
+        assert workspace in sched._in_progress_workspaces
+        assert branch in sched._in_progress_branches
+        assert "batch-42" in sched._in_progress_batch_ids
+
+        with patch("app.routes.autonomous._get_repo"):
+            sched.clear_in_progress(wf_id, wf=wf)
+
+        assert workspace not in sched._in_progress_workspaces
+        assert branch not in sched._in_progress_branches
+        assert "batch-42" not in sched._in_progress_batch_ids
+
+    def test_clear_in_progress_skips_conflict_keys_without_wf(self, scheduler):
+        """clear_in_progress without wf should still clear _in_progress_ids."""
+        sched, wf_id = scheduler
+
+        with patch("app.routes.autonomous._get_repo"):
+            sched.clear_in_progress(wf_id)
+
+        assert wf_id not in sched._in_progress_ids
 
     def test_clear_in_progress_releases_db_lock(self, scheduler):
         """clear_in_progress must force-release the DB lock regardless of owner."""
@@ -133,7 +180,10 @@ class TestRetryClearsInProgress:
             with app.test_request_context():
                 retry_workflow(wf_id)
 
-            # Verify clear_in_progress was called
-            mock_sched.clear_in_progress.assert_called_once_with(wf_id)
+            # Verify clear_in_progress was called with workflow dict
+            mock_sched.clear_in_progress.assert_called_once()
+            call_args = mock_sched.clear_in_progress.call_args
+            assert call_args[0][0] == wf_id  # workflow_id positional
+            assert call_args[1]["wf"]["workflow_id"] == wf_id  # wf kwarg
             # Verify DB was still updated
             mock_repo.update_workflow.assert_called_once()

--- a/tests/issues/1897/test_retry_clears_in_progress.py
+++ b/tests/issues/1897/test_retry_clears_in_progress.py
@@ -1,0 +1,139 @@
+"""Tests for retry endpoint clearing stale scheduler in-progress state.
+
+When an orchestrator thread exits abnormally (OOM kill, hard crash) without
+running its ``finally`` cleanup, the workflow_id remains permanently in the
+scheduler's ``_in_progress_ids`` set. The scheduler then skips this workflow
+on every cycle, making retry ineffective — the DB status changes to "developing"
+but no orchestrator ever advances it.
+
+The fix: ``retry_workflow`` calls ``AutonomousScheduler.clear_in_progress()``
+to remove the stale entry before updating the DB.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestRetryClearsInProgress:
+    """Test that retry clears stale scheduler in-progress state."""
+
+    @pytest.fixture
+    def scheduler(self):
+        """Create a real AutonomousScheduler instance with a stuck workflow_id."""
+        from app.services.autonomous_scheduler import AutonomousScheduler
+
+        sched = AutonomousScheduler()
+        wf_id = "stuck-workflow-123"
+        sched._in_progress_ids.add(wf_id)
+        sched._in_progress_workspaces.add("/fake/workspace")
+        sched._in_progress_branches.add("auto-dev/stuck")
+        sched._in_progress_batch_ids.add("batch-1")
+        sched._running_orchestrators[wf_id] = MagicMock()
+        return sched, wf_id
+
+    def test_clear_in_progress_removes_from_in_progress_ids(self, scheduler):
+        """clear_in_progress must remove workflow_id from _in_progress_ids."""
+        sched, wf_id = scheduler
+        assert wf_id in sched._in_progress_ids
+
+        with patch("app.routes.autonomous._get_repo") as mock_get_repo:
+            mock_repo = MagicMock()
+            mock_get_repo.return_value = mock_repo
+            sched.clear_in_progress(wf_id)
+
+        assert wf_id not in sched._in_progress_ids
+
+    def test_clear_in_progress_removes_orphaned_orchestrator(self, scheduler):
+        """clear_in_progress must remove orphaned orchestrator reference."""
+        sched, wf_id = scheduler
+        assert wf_id in sched._running_orchestrators
+
+        with patch("app.routes.autonomous._get_repo"):
+            sched.clear_in_progress(wf_id)
+
+        assert wf_id not in sched._running_orchestrators
+
+    def test_clear_in_progress_releases_db_lock(self, scheduler):
+        """clear_in_progress must force-release the DB lock regardless of owner."""
+        sched, wf_id = scheduler
+
+        mock_cursor = MagicMock()
+        mock_conn = MagicMock()
+        mock_conn.cursor.return_value = mock_cursor
+
+        mock_repo = MagicMock()
+        mock_repo.db.get_connection.return_value = mock_conn
+
+        with patch("app.routes.autonomous._get_repo", return_value=mock_repo):
+            sched.clear_in_progress(wf_id)
+
+        # Verify UPDATE was executed to clear locked_at / locked_by
+        mock_cursor.execute.assert_called_once()
+        sql_arg = mock_cursor.execute.call_args[0][0]
+        assert "locked_at = NULL" in sql_arg
+        assert "locked_by = NULL" in sql_arg
+        mock_conn.commit.assert_called_once()
+
+    def test_clear_in_progress_safe_on_missing_workflow(self):
+        """clear_in_progress must not crash for a workflow_id not in any set."""
+        from app.services.autonomous_scheduler import AutonomousScheduler
+
+        sched = AutonomousScheduler()
+        # No workflow_id in any set — should be a no-op, not crash
+        with patch("app.routes.autonomous._get_repo"):
+            sched.clear_in_progress("nonexistent-wf")
+
+    def test_clear_in_progress_continues_on_db_error(self, scheduler):
+        """clear_in_progress must still clear in-memory state even if DB update fails."""
+        sched, wf_id = scheduler
+
+        mock_repo = MagicMock()
+        mock_repo.db.get_connection.side_effect = Exception("DB connection lost")
+
+        with patch("app.routes.autonomous._get_repo", return_value=mock_repo):
+            sched.clear_in_progress(wf_id)
+
+        # In-memory state should still be cleared even if DB lock release failed
+        assert wf_id not in sched._in_progress_ids
+        assert wf_id not in sched._running_orchestrators
+
+    def test_retry_endpoint_calls_clear_in_progress(self):
+        """retry_workflow must call clear_in_progress before updating DB."""
+        from app.routes.autonomous import retry_workflow
+
+        wf_id = "wf-retry-test"
+        fake_user = {"id": 1, "role": "admin", "tenant_id": 1}
+
+        with (
+            patch("app.routes.autonomous._get_repo") as mock_get_repo,
+            patch("app.services.autonomous_scheduler.AutonomousScheduler") as mock_sched_cls,
+            patch("app.routes.autonomous._emit_event_safe"),
+            patch("app.auth.decorators._extract_token", return_value="fake-token"),
+            patch("app.auth.decorators._load_user_from_token", return_value=fake_user),
+            patch("app.auth.decorators.enforce_password_change_requirement", return_value=None),
+        ):
+
+            mock_repo = MagicMock()
+            mock_repo.get_workflow.return_value = {
+                "workflow_id": wf_id,
+                "status": "failed",
+                "user_id": 1,
+                "current_phase": "development",
+                "retry_count": 3,
+            }
+            mock_get_repo.return_value = mock_repo
+
+            mock_sched = MagicMock()
+            mock_sched_cls.instance.return_value = mock_sched
+
+            from flask import Flask
+
+            app = Flask(__name__)
+            with app.test_request_context():
+                retry_workflow(wf_id)
+
+            # Verify clear_in_progress was called
+            mock_sched.clear_in_progress.assert_called_once_with(wf_id)
+            # Verify DB was still updated
+            mock_repo.update_workflow.assert_called_once()


### PR DESCRIPTION
## Problem

When an orchestrator thread exits abnormally (OOM kill, hard crash) without running its `finally` cleanup, the workflow_id remains permanently in the scheduler's `_in_progress_ids` set. The scheduler then skips this workflow on every cycle, making retry ineffective — the DB status changes to "developing" but no orchestrator ever advances it. Milestones never update.

This was observed on workflow 172 (#1897): after retry, the status was set to "developing" but the scheduler never picked it up because the workflow_id was stuck in `_in_progress_ids` from a previous failed orchestrator run.

## Root Cause

The `retry_workflow` endpoint ([autonomous.py:1148](https://github.com/open-ace/open-ace/blob/main/app/routes/autonomous.py#L1148)) only updates the database (status, error_message, retry_count). It does not clear the scheduler's in-memory `_in_progress_ids` set. If the previous orchestrator thread crashed without running its `finally` block, the workflow_id stays in this set forever.

## Fix

1. **Add `AutonomousScheduler.clear_in_progress(workflow_id)`** — removes the workflow_id from `_in_progress_ids`, `_running_orchestrators`, and force-releases the DB lock (regardless of owner, since the previous owner is gone).

2. **Call it from `retry_workflow`** — before updating the DB status, clear any stale scheduler state so the next scheduler cycle can acquire a fresh lock and advance the workflow.

## Tests

`tests/issues/1897/test_retry_clears_in_progress.py` — 6 tests covering:
- `clear_in_progress` removes from `_in_progress_ids`
- `clear_in_progress` removes orphaned orchestrator reference
- `clear_in_progress` releases DB lock
- `clear_in_progress` is safe on missing workflow
- `clear_in_progress` continues on DB error (in-memory state still cleared)
- `retry_workflow` calls `clear_in_progress` before DB update