### PR TITLE
fix(migration): skip migration if auto_provision_users column does not exist

### DIFF
--- a/migrations/versions/20260625_001_fix_auto_provision_users_type.py
+++ b/migrations/versions/20260625_001_fix_auto_provision_users_type.py
@@ -49,6 +49,10 @@ def upgrade() -> None:
     # Check current column type
     current_type = get_column_type(conn, "tenant_settings", "auto_provision_users")
 
+    # If column does not exist, skip (baseline databases may not have this column)
+    if current_type is None:
+        return
+
     # If already boolean, no conversion needed (new databases from baseline)
     if current_type == "boolean":
         return
@@ -73,6 +77,10 @@ def downgrade() -> None:
 
     # Check current column type
     current_type = get_column_type(conn, "tenant_settings", "auto_provision_users")
+
+    # If column does not exist, skip
+    if current_type is None:
+        return
 
     # If already integer, no conversion needed
     if current_type == "integer":


### PR DESCRIPTION
## Summary

Fixes #2007

The migration `20260625_001_fix_auto_provision_users_type.py` fails when the `auto_provision_users` column does not exist in `tenant_settings` table. This happens when the database was created from a baseline that does not include this column.

## Problem

The migration attempts to execute:
```sql
ALTER TABLE tenant_settings ALTER COLUMN auto_provision_users DROP DEFAULT
```

But if the column doesn't exist, this causes:
```
sqlalchemy.exc.ProgrammingError: (psycopg2.errors.UndefinedColumn) column "auto_provision_users" of relation "tenant_settings" does not exist
```

This leads to:
1. Container crash loop during startup
2. `proxy_token_jtis` table never gets created
3. All LLM proxy requests fail with 401 error

## Solution

Check if the column exists before attempting ALTER operations. Return early if `current_type` is `None` (column does not exist).

## Changes

- Added `None` check in `upgrade()` function
- Added `None` check in `downgrade()` function
- Added explanatory comment

## Testing

This fix will allow the migration to succeed on databases where `auto_provision_users` column does not exist, enabling subsequent migrations (including `proxy_token_jtis` table creation) to run.