### PR TITLE
fix: proxy token timezone handling and rotation bug

### DIFF
--- a/app/modules/workspace/api_key_proxy.py
+++ b/app/modules/workspace/api_key_proxy.py
@@ -488,7 +488,7 @@ class APIKeyProxyService:
         """Revoke every active proxy token issued for a session id."""
         if not session_id:
             return 0
-        now = datetime.now(timezone.utc).replace(tzinfo=None).isoformat()
+        now = datetime.now().isoformat()
         conn = self._get_connection()
         try:
             cursor = conn.cursor()
@@ -1782,7 +1782,7 @@ class APIKeyProxyService:
             if expires_minutes is not None
             else self._get_default_proxy_token_ttl_minutes(session_type)
         )
-        expires_at = datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(
+        expires_at = datetime.now() + timedelta(
             minutes=effective_ttl
         )
         payload = {
@@ -1954,7 +1954,7 @@ class APIKeyProxyService:
                 logger.warning("Proxy token revoked: %s", jti[:8])
                 return None
 
-            now = datetime.now(timezone.utc).replace(tzinfo=None)
+            now = datetime.now()
             exp = datetime.fromisoformat(str(payload["exp"]))
             session_id = payload.get("session_id")
             session_type = payload.get("session_type", "agent")
@@ -2139,7 +2139,7 @@ class APIKeyProxyService:
         conn = self._get_connection()
         try:
             cursor = conn.cursor()
-            now = datetime.now(timezone.utc).replace(tzinfo=None)
+            now = datetime.now()
 
             # Delete expired records older than days_old
             # Delete consumed records older than 1 day

--- a/app/modules/workspace/api_key_proxy.py
+++ b/app/modules/workspace/api_key_proxy.py
@@ -15,7 +15,7 @@ import sqlite3
 import threading
 from base64 import b64decode, b64encode
 from copy import deepcopy
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from typing import Any, cast
 
 from app.modules.workspace.api_key_router import APIKeyRouter
@@ -1782,9 +1782,7 @@ class APIKeyProxyService:
             if expires_minutes is not None
             else self._get_default_proxy_token_ttl_minutes(session_type)
         )
-        expires_at = datetime.now() + timedelta(
-            minutes=effective_ttl
-        )
+        expires_at = datetime.now() + timedelta(minutes=effective_ttl)
         payload = {
             "user_id": user_id,
             "session_id": session_id,

--- a/app/routes/remote.py
+++ b/app/routes/remote.py
@@ -2370,11 +2370,10 @@ def attach_terminal(terminal_id):
     stored_key_id = context.get("key_id")
 
     # Generate fresh API tokens for LLM proxy auth
+    # Note: We don't revoke old tokens here because the terminal_server
+    # process might still be using them. Tokens have a TTL (240 minutes)
+    # and will expire naturally. Only revoke if we need to restart the server.
     api_proxy = get_api_key_proxy_service()
-    api_proxy.revoke_proxy_tokens_for_session(
-        terminal_id,
-        reason="terminal_tokens_rotated",
-    )
 
     # Determine token generation based on stored model/key selection
     anthropic_token = None


### PR DESCRIPTION
Fixes #2007

## Summary

Fixed two critical bugs causing remote terminal sessions to fail with "401 Invalid or expired proxy token" error.

## Changes

### 1. Timezone Handling Bug (Primary Issue)

**File:** `app/modules/workspace/api_key_proxy.py`

Fixed 4 locations where UTC time was used but timezone info was removed:
- Line 491: revocation time handling
- Line 1785: token expiration time calculation
- Line 1957: token validation time comparison  
- Line 2142: cleanup task time handling

**Problem:** `datetime.now(timezone.utc).replace(tzinfo=None)` stores UTC time without timezone info in PostgreSQL `TIMESTAMP WITHOUT TIME ZONE`, which interprets it as local time, making `expires_at` earlier than `issued_at`.

**Fix:** Changed to `datetime.now()` to use local time consistently.

### 2. Token Rotation Bug (Secondary Issue)

**File:** `app/routes/remote.py`

Removed immediate token revocation in `attach_terminal()` function.

**Problem:** Frontend calling `attach_terminal()` immediately revoked tokens used by running `terminal_server` processes.

**Fix:** Don't revoke tokens actively; let them expire naturally (TTL: 240 minutes).

## Root Cause

See detailed analysis in issue #2007: https://github.com/open-ace/open-ace/issues/2007#issuecomment-5067893038

## Testing

✅ Created new terminal session on remote machine
✅ Sent message to AI (Qwen Code)
✅ AI responds normally, no 401 error
✅ Token status in database shows VALID with correct expiration

## Related

- Issue: #2007
- Related code: `app/modules/workspace/api_key_proxy.py`, `app/routes/remote.py`, `remote-agent/agent.py`