### PR TITLE
fix: restore workflow worktree after merge conflict resolution

### DIFF
--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -1697,10 +1697,11 @@ class AutonomousOrchestrator:
         worktree_path = wf.get("worktree_path", "")
 
         # An empty worktree_path is NOT the "dir gone, recreate it" case — it
-        # is set deliberately by merge cleanup (_resolve_merge_conflicts /
-        # _do_merge) when the worktree is removed to free the main repo for
-        # conflict resolution. Treating it as missing would fall back to
-        # project_path as canonical and try `git worktree add <main_repo>`,
+        # is set deliberately by _do_merge final cleanup when the PR is merged
+        # and the worktree is no longer needed. (_resolve_merge_conflicts
+        # restores worktree_path in its finally block, so it no longer leaves
+        # the field empty.) Treating an empty path as missing would fall back
+        # to project_path as canonical and try `git worktree add <main_repo>`,
         # which fails and turns a retried merge into a hard failure. Only a
         # non-empty path whose dir is gone represents external loss (#814).
         if strategy != "worktree" or not project_path or not worktree_path:
@@ -8484,8 +8485,8 @@ class AutonomousOrchestrator:
                 raise
 
         # Clean up branch/worktree. Re-read wf because _resolve_merge_conflicts
-        # may have cleared worktree_path (removed the original worktree to free
-        # the branch for the temp merge worktree); using the stale snapshot
+        # restores worktree_path in its finally block (so the restored value
+        # may differ from the caller's stale snapshot); using the stale snapshot
         # would retry the removal and fail, skipping branch deletion (#1107).
         wf = self.workflow
         branch_name = wf.get("branch_name", "")
@@ -8563,6 +8564,12 @@ class AutonomousOrchestrator:
         on scheduler re-entry). Now a throwaway worktree is created for the
         branch, all merge/resolve/push happens inside it, and it is removed in
         a ``finally`` — the main repo's index and HEAD are never touched.
+
+        The workflow's own worktree is temporarily removed to free the branch
+        for the temp worktree (git forbids the same branch in two worktrees),
+        then **restored** in the ``finally`` block. Without restoration,
+        subsequent phases (PR review push, CI repair re-entry) operate on the
+        main repo (HEAD=main) and fail with a branch mismatch.
         """
         wf = self.workflow
         project_path = wf.get("project_path", "")
@@ -8906,3 +8913,30 @@ class AutonomousOrchestrator:
                 logger.info("Removed temporary merge worktree at %s", temp_wt_path)
             except GitHubOpsError as e:
                 logger.warning("Failed to remove temp worktree %s: %s", temp_wt_path, e)
+
+            # Restore the workflow's original worktree so subsequent phases
+            # (PR review push, CI repair, _do_merge re-entry) operate on the
+            # isolated branch, not the main repo (HEAD=main). Without this,
+            # _do_pr_review's pre-push branch check fails with
+            # "expected auto-dev/xxx, actual main" and the workflow is stuck.
+            if worktree_path:
+                try:
+                    # If remove_worktree succeeded earlier, the dir is gone
+                    # and we recreate it. If it failed, the dir is still
+                    # there and add_worktree would error — check first.
+                    git_file = os.path.join(worktree_path, ".git")
+                    if not main_gh.path_exists_as_user(git_file, file_only=True):
+                        main_gh.add_worktree(worktree_path, branch_name)
+                    # Always restore the DB entry — it was cleared at the top
+                    # of this method regardless of whether remove_worktree
+                    # succeeded.
+                    self._update_workflow({"worktree_path": worktree_path})
+                    self._gh = GitHubOps(worktree_path, system_account=system_account)
+                    logger.info("Restored workflow worktree at %s", worktree_path)
+                except Exception as e:
+                    logger.error(
+                        "Failed to restore worktree %s after merge resolution: %s",
+                        worktree_path,
+                        e,
+                        exc_info=True,
+                    )

--- a/tests/issues/822/test_merge_conflict_detection.py
+++ b/tests/issues/822/test_merge_conflict_detection.py
@@ -1763,6 +1763,9 @@ class TestResolveMergeConflictsWorktreeIsolation:
     def test_removes_existing_worktree_before_adding_temp(self, mock_gh_cls):
         """Git forbids the same branch in two worktrees, so the workflow's own
         worktree must be removed first to free the branch for the temp worktree.
+
+        The original worktree is then **restored** in the finally block so
+        subsequent phases operate on the isolated branch, not the main repo.
         """
         # worktree_path is non-empty — simulates a worktree-strategy workflow
         # entering merge resolution with its dev worktree still attached.
@@ -1771,12 +1774,19 @@ class TestResolveMergeConflictsWorktreeIsolation:
         main_gh = MagicMock()
         rebound_gh = MagicMock()  # gh rebound to project_path after worktree removal
         wt_gh = MagicMock()
+        restored_gh = MagicMock()  # gh rebound to restored worktree in finally
         wt_gh._run_git.side_effect = [
             MagicMock(),  # fetch
             MagicMock(returncode=0, stdout="", stderr=""),  # merge clean
         ]
-        # GitHubOps construction order: main_gh, rebound_gh (after removal), wt_gh
-        mock_gh_cls.side_effect = [main_gh, rebound_gh, wt_gh]
+        # GitHubOps construction order:
+        #   1. main_gh (add_worktree / remove_worktree)
+        #   2. rebound_gh (after original worktree removal)
+        #   3. wt_gh (temp worktree ops)
+        #   4. restored_gh (restored worktree gh in finally)
+        mock_gh_cls.side_effect = [main_gh, rebound_gh, wt_gh, restored_gh]
+        # path_exists_as_user returns False → add_worktree is called to recreate
+        main_gh.path_exists_as_user.return_value = False
         _set_valid_merge_result(o, wt_gh, conflict=False)
 
         # caller_gh simulates the stale handle from _do_merge; it should be
@@ -1792,14 +1802,62 @@ class TestResolveMergeConflictsWorktreeIsolation:
         # worktree_path was cleared in DB.
         o._update_workflow.assert_any_call({"worktree_path": ""})
         # Then the temp worktree was added (branch now free).
-        main_gh.add_worktree.assert_called_once()
+        assert main_gh.add_worktree.call_count == 2  # temp + restore
+        temp_path = main_gh.add_worktree.call_args_list[0].args[0]
         # Second removal is the temp worktree (finally cleanup).
-        temp_path = main_gh.add_worktree.call_args.args[0]
         assert remove_calls[1].args[0] == temp_path
+        # Original worktree restored in finally block.
+        restore_path = main_gh.add_worktree.call_args_list[1].args[0]
+        assert restore_path == wf["worktree_path"]
+        o._update_workflow.assert_any_call({"worktree_path": wf["worktree_path"]})
+        # self._gh rebound to the restored worktree.
+        assert o._gh is restored_gh
         # _resolve_merge_conflicts only pushes now — merge is deferred to
         # _do_merge's next cycle. No merge_pr call on either gh.
         rebound_gh.merge_pr.assert_not_called()
         stale_gh.merge_pr.assert_not_called()
+
+    @patch("app.modules.workspace.autonomous.orchestrator.GitHubOps")
+    def test_restores_worktree_even_on_resolution_failure(self, mock_gh_cls):
+        """The original worktree must be restored in finally even when conflict
+        resolution fails, so the workflow can be retried on its own branch.
+        """
+        wf = _make_workflow(worktree_path="/srv/repo/.worktrees/wf-822")
+        o, _ = _make_orchestrator(wf)
+        main_gh = MagicMock()
+        rebound_gh = MagicMock()
+        wt_gh = MagicMock()
+        restored_gh = MagicMock()
+        wt_gh._run_git.side_effect = [
+            MagicMock(),  # fetch
+            MagicMock(
+                returncode=1,
+                stdout="CONFLICT (content): Merge conflict in app/x.py\n",
+                stderr="",
+            ),  # merge (conflict)
+        ]
+        mock_gh_cls.side_effect = [main_gh, rebound_gh, wt_gh, restored_gh]
+        main_gh.path_exists_as_user.return_value = False
+        _set_valid_merge_result(o, wt_gh)
+
+        o._run_agent = MagicMock()
+        from app.modules.workspace.autonomous.models import AgentTaskResult
+
+        o._run_agent.return_value = AgentTaskResult(
+            session_id="s1", success=False, error="agent failed"
+        )
+        o._resolve_session_line = MagicMock(return_value=("sess", None, False))
+        o._link_session_to_current_milestone = MagicMock()
+
+        with pytest.raises(RuntimeError, match="Conflict resolution failed"):
+            o._resolve_merge_conflicts(MagicMock(), "auto-dev/fc82f22a", 1103)
+
+        # Temp worktree was removed (finally cleanup).
+        main_gh.remove_worktree.assert_called()
+        # Original worktree was restored despite the failure.
+        main_gh.add_worktree.assert_called_with(wf["worktree_path"], "auto-dev/fc82f22a")
+        o._update_workflow.assert_any_call({"worktree_path": wf["worktree_path"]})
+        assert o._gh is restored_gh
 
 
 # ── github_ops.add_worktree (no -b) ──────────────────────────────────────


### PR DESCRIPTION
## Problem

`_resolve_merge_conflicts` removes the workflow's own worktree at the top of the method (to free the branch for a temp merge worktree — git forbids the same branch in two worktrees) and clears `worktree_path` in the DB. The `finally` block only removed the temp worktree, leaving `worktree_path` empty permanently.

This caused subsequent phases (PR review push, CI repair re-entry, `_do_merge` re-entry) to operate on the **main repo** (HEAD=main) instead of the isolated worktree branch, failing with:

```
Branch push failed before PR creation: Branch mismatch before push: expected auto-dev/xxx, actual main
```

This was observed repeatedly on workflow 172 (#1897) — each time `_resolve_merge_conflicts` was called (for CI repair sync), the worktree was lost and the workflow could not recover.

## Fix

Restore the original worktree in the `finally` block of `_resolve_merge_conflicts`:

1. If the worktree dir is gone (`remove_worktree` succeeded earlier), recreate it via `add_worktree`
2. If the worktree dir still exists (`remove_worktree` failed earlier), skip recreation — just restore the DB entry
3. Always restore the `worktree_path` DB entry (it was cleared at the top of the method)
4. Rebind `self._gh` to the restored worktree so subsequent operations use the correct branch

## Test coverage

- Updated `test_removes_existing_worktree_before_adding_temp` to verify the worktree is restored in the finally block (add_worktree called twice: temp + restore; DB worktree_path restored; self._gh rebound)
- Added `test_restores_worktree_even_on_resolution_failure` to verify restoration happens even when conflict resolution fails (so the workflow can be retried on its own branch)