### PR TITLE
fix: QueryParamSanitizer breaks token validation and session time handling

### DIFF
--- a/app/auth/decorators.py
+++ b/app/auth/decorators.py
@@ -53,6 +53,7 @@ URL_TOKEN_ALLOWED_PATHS = [
     "/api/remote/terminal/",  # Proxy token for terminal routes
     "/api/remote/vscode/",  # Browser token for VSCode routes
     "/api/workspace/",  # WebUI token for workspace routes
+    "/api/projects",  # WebUI token for project list (needed for new session dialog)
 ]
 
 

--- a/app/middleware/query_param_sanitizer.py
+++ b/app/middleware/query_param_sanitizer.py
@@ -98,6 +98,10 @@ class QueryParamSanitizer:
     This middleware wraps the WSGI application and sanitizes the query
     string before it's logged or stored in access logs.
 
+    IMPORTANT: This middleware now stores the sanitized query string in a
+    separate environ key to avoid breaking request.args. The original
+    QUERY_STRING is preserved for actual request processing.
+
     Usage:
         app = Flask(__name__)
         app.wsgi_app = QueryParamSanitizer(app.wsgi_app)
@@ -112,7 +116,7 @@ class QueryParamSanitizer:
         self.app = app
 
     def __call__(self, environ: dict, start_response: Any) -> Any:
-        """Process the request, sanitizing the query string in environ.
+        """Process the request, creating a sanitized query string for logging.
 
         Args:
             environ: WSGI environ dict.
@@ -121,21 +125,21 @@ class QueryParamSanitizer:
         Returns:
             Response iterator.
         """
-        # Sanitize QUERY_STRING
+        # Create sanitized versions for logging (stored in separate keys)
+        # DO NOT modify the original QUERY_STRING to preserve request.args
         query_string = environ.get("QUERY_STRING", "")
         if query_string:
-            environ["QUERY_STRING"] = sanitize_query_string(query_string)
+            # Store sanitized version for logging
+            environ["SANITIZED_QUERY_STRING"] = sanitize_query_string(query_string)
+        else:
+            environ["SANITIZED_QUERY_STRING"] = ""
 
-        # Sanitize REQUEST_URI if present (for some WSGI servers)
+        # Sanitize REQUEST_URI for logging if present
         request_uri = environ.get("REQUEST_URI", "")
         if request_uri:
-            environ["REQUEST_URI"] = sanitize_url(request_uri)
-
-        # Sanitize PATH_INFO's query string if present
-        path_info = environ.get("PATH_INFO", "")
-        if "?" in path_info:
-            base, query = path_info.split("?", 1)
-            environ["PATH_INFO"] = f"{base}?{sanitize_query_string(query)}"
+            environ["SANITIZED_REQUEST_URI"] = sanitize_url(request_uri)
+        else:
+            environ["SANITIZED_REQUEST_URI"] = ""
 
         return self.app(environ, start_response)
 

--- a/app/repositories/user_repo.py
+++ b/app/repositories/user_repo.py
@@ -462,8 +462,9 @@ class UserRepository:
         """
 
         try:
+            # Use local time to match database TIMESTAMP WITHOUT TIME ZONE behavior
             self.db.execute(
-                query, (user_id, token, datetime.now(timezone.utc).replace(tzinfo=None), expires_at)
+                query, (user_id, token, datetime.now(), expires_at)
             )
             return True
         except Exception as e:
@@ -487,7 +488,8 @@ class UserRepository:
             WHERE s.token = ? AND s.expires_at > ?
         """
 
-        return self.db.fetch_one(query, (token, datetime.now(timezone.utc).replace(tzinfo=None)))
+        # Use local time to match database TIMESTAMP WITHOUT TIME ZONE behavior
+        return self.db.fetch_one(query, (token, datetime.now()))
 
     def delete_session(self, token: str) -> bool:
         """

--- a/app/repositories/user_repo.py
+++ b/app/repositories/user_repo.py
@@ -463,9 +463,7 @@ class UserRepository:
 
         try:
             # Use local time to match database TIMESTAMP WITHOUT TIME ZONE behavior
-            self.db.execute(
-                query, (user_id, token, datetime.now(), expires_at)
-            )
+            self.db.execute(query, (user_id, token, datetime.now(), expires_at))
             return True
         except Exception as e:
             logger.error(f"Error creating session: {e}")

--- a/app/services/auth_service.py
+++ b/app/services/auth_service.py
@@ -434,9 +434,8 @@ class AuthService:
         # Create session token
         token = secrets.token_hex(32)
         timeout_hours = _get_session_timeout_hours()
-        expires_at = datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(
-            hours=timeout_hours
-        )
+        # Use local time to match database TIMESTAMP WITHOUT TIME ZONE behavior
+        expires_at = datetime.now() + timedelta(hours=timeout_hours)
 
         if not self.user_repo.create_session(user["id"], token, expires_at):
             logger.error(f"Failed to create session for user - {username}")
@@ -577,7 +576,9 @@ class AuthService:
             return False
         if isinstance(expires_at, str):
             expires_at = datetime.fromisoformat(expires_at)
-        return bool(expires_at < datetime.now(timezone.utc).replace(tzinfo=None))
+        # Use local time to match database TIMESTAMP WITHOUT TIME ZONE behavior
+        # Database stores times as local time without timezone info
+        return bool(expires_at < datetime.now())
 
     def get_user_profile(self, user_id: int) -> dict | None:
         """


### PR DESCRIPTION
## Summary

Fixes two critical bugs that caused authentication failures after upgrading to the latest version.

## Issues Fixed

Fixes #2013

## Changes

### 1. Fix QueryParamSanitizer middleware (Critical)

**Problem:** Middleware was modifying the original `QUERY_STRING` in WSGI environ, replacing token values with `[REDACTED]`. This caused Flask's `request.args.get('token')` to return `'[REDACTED]'` instead of the actual token value.

**Solution:** Store sanitized values in separate environ keys for logging while preserving the original `QUERY_STRING` for request processing:
- `SANITIZED_QUERY_STRING` - for logging
- `SANITIZED_REQUEST_URI` - for logging

### 2. Fix session time handling

**Problem:** Session creation and validation used `datetime.now(timezone.utc).replace(tzinfo=None)` which created UTC times, but PostgreSQL's `TIMESTAMP WITHOUT TIME ZONE` columns store times as local time when database timezone is not UTC.

**Solution:** Use `datetime.now()` (local time) consistently across all session time handling:
- `app/services/auth_service.py` - session creation and expiration check
- `app/repositories/user_repo.py` - session creation and query

### 3. Add /api/projects to URL token allowed paths

WebUI token needs access to the project list endpoint for the new session dialog.

## Testing

✅ WebUI token authentication succeeds  
✅ Session token authentication succeeds  
✅ New session creation works properly  
✅ Project list loads correctly in new session dialog  

## Root Cause

Recent security enhancement for query parameter sanitization (#1896) incorrectly modified actual request data instead of only log output.

## Related

- #2009 - Previous proxy token timezone fix (same timezone handling issue)
- #1896 - URL token security (introduced the sanitizer)