### PR TITLE
fix: allow waiting workflows to bypass batch conflict locks

### DIFF
--- a/app/routes/autonomous.py
+++ b/app/routes/autonomous.py
@@ -1247,11 +1247,9 @@ def cancel_milestone(workflow_id, milestone_id):
     if not milestone or milestone.get("workflow_id") != workflow_id:
         return jsonify({"error": "Milestone not found"}), 404
 
-    # Parse user feedback (required)
+    # Parse user feedback (optional — cancel may proceed without feedback)
     data = request.get_json(silent=True) or {}
     user_feedback = data.get("user_feedback", "").strip()
-    if not user_feedback:
-        return jsonify({"error": "user_feedback is required"}), 400
     if len(user_feedback) > 5000:
         return jsonify({"error": "user_feedback too long (max 5000 characters)"}), 400
 

--- a/app/routes/autonomous.py
+++ b/app/routes/autonomous.py
@@ -1272,7 +1272,7 @@ def cancel_milestone(workflow_id, milestone_id):
             "phase": "wait",
             "milestone_type": "requirement_received",
             "status": "completed",
-            "title": "User feedback received",
+            "title": "User feedback received" if user_feedback else "Round cancelled",
             "description": user_feedback[:500],
             "result_summary": user_feedback[:200],
         }
@@ -1285,7 +1285,7 @@ def cancel_milestone(workflow_id, milestone_id):
             "action": "cancel_with_feedback",
             "milestone_id": milestone_id,
             "cancelled_count": len(cancelled),
-            "has_feedback": True,
+            "has_feedback": bool(user_feedback),
         },
     )
     return jsonify({"success": True, "cancelled": len(cancelled)})

--- a/app/services/autonomous_scheduler.py
+++ b/app/services/autonomous_scheduler.py
@@ -322,17 +322,20 @@ class AutonomousScheduler:
         workflow = repo.get_workflow(workflow_id)
         batch_id = workflow.get("batch_id") if workflow else None
         workspace, branch = self._conflict_keys(workflow) if workflow else ("", "")
+        # Waiting workflows bypass conflict locks (see _process_workflows).
+        # Capture this so cleanup paths don't release another workflow's keys.
+        was_waiting = bool(workflow and workflow.get("status") == "waiting")
 
         # Acquire DB-level distributed lock
         if not repo.acquire_lock(workflow_id, lock_owner):
             logger.debug("Workflow %s is locked by another instance, skipping", workflow_id[:8])
             with self._in_progress_lock:
                 self._in_progress_ids.discard(workflow_id)
-                if batch_id:
+                if batch_id and not was_waiting:
                     self._in_progress_batch_ids.discard(batch_id)
-                if workspace:
+                if workspace and not was_waiting:
                     self._in_progress_workspaces.discard(workspace)
-                if branch:
+                if branch and not was_waiting:
                     self._in_progress_branches.discard(branch)
             return workflow_id
 
@@ -413,11 +416,11 @@ class AutonomousScheduler:
                 logger.warning("Failed to release lock for workflow %s", workflow_id[:8])
             with self._in_progress_lock:
                 self._in_progress_ids.discard(workflow_id)
-                if batch_id:
+                if batch_id and not was_waiting:
                     self._in_progress_batch_ids.discard(batch_id)
-                if workspace:
+                if workspace and not was_waiting:
                     self._in_progress_workspaces.discard(workspace)
-                if branch:
+                if branch and not was_waiting:
                     self._in_progress_branches.discard(branch)
         return workflow_id
 
@@ -613,15 +616,21 @@ class AutonomousScheduler:
                     continue
                 if wf.get("workflow_id", "") in self._in_progress_ids:
                     continue
+                # Waiting workflows only do a lightweight state transition in
+                # _do_wait (DB update, no agent/git) — bypass batch/workspace/
+                # branch conflict locks so they can resume even while a batch
+                # sibling is still running. The lock re-applies on the next
+                # cycle once the workflow leaves "waiting" status.
+                is_waiting = wf.get("status") == "waiting"
                 # For batch workflows, check if the batch is already being processed
                 batch_id = wf.get("batch_id")
-                if batch_id and batch_id in self._in_progress_batch_ids:
+                if batch_id and batch_id in self._in_progress_batch_ids and not is_waiting:
                     continue
                 # git-conflict guard: same working tree OR same branch (#1002)
                 workspace, branch = self._conflict_keys(wf)
-                if workspace and workspace in self._in_progress_workspaces:
+                if workspace and workspace in self._in_progress_workspaces and not is_waiting:
                     continue
-                if branch and branch in self._in_progress_branches:
+                if branch and branch in self._in_progress_branches and not is_waiting:
                     continue
                 active.append(wf)
 
@@ -651,11 +660,12 @@ class AutonomousScheduler:
                     break
                 batch_id = wf.get("batch_id")
                 workspace, branch = self._conflict_keys(wf)
-                if batch_id and batch_id in selected_batches:
+                is_waiting = wf.get("status") == "waiting"
+                if batch_id and batch_id in selected_batches and not is_waiting:
                     continue
-                if workspace and workspace in selected_workspaces:
+                if workspace and workspace in selected_workspaces and not is_waiting:
                     continue
-                if branch and branch in selected_branches:
+                if branch and branch in selected_branches and not is_waiting:
                     continue
                 to_process.append(wf)
                 if batch_id:
@@ -672,13 +682,17 @@ class AutonomousScheduler:
         with self._in_progress_lock:
             for wf in to_process:
                 self._in_progress_ids.add(wf.get("workflow_id", ""))
+                # Waiting workflows bypass conflict locks — don't reserve their
+                # keys so we don't block other workflows, and don't release
+                # another workflow's keys in _advance_single's finally.
+                is_waiting = wf.get("status") == "waiting"
                 batch_id = wf.get("batch_id")
-                if batch_id:
+                if batch_id and not is_waiting:
                     self._in_progress_batch_ids.add(batch_id)
                 workspace, branch = self._conflict_keys(wf)
-                if workspace:
+                if workspace and not is_waiting:
                     self._in_progress_workspaces.add(workspace)
-                if branch:
+                if branch and not is_waiting:
                     self._in_progress_branches.add(branch)
 
         with ThreadPoolExecutor(

--- a/frontend/src/components/work/CancelRoundModal.tsx
+++ b/frontend/src/components/work/CancelRoundModal.tsx
@@ -25,7 +25,7 @@ export default function CancelRoundModal({
   const cancelMutation = useCancelMilestone();
 
   const handleSubmit = () => {
-    if (!feedback.trim() || feedback.trim().length < 10) return;
+    if (!feedback.trim()) return;
     cancelMutation.mutate(
       { workflowId, milestoneId, feedback: feedback.trim() },
       {
@@ -44,7 +44,7 @@ export default function CancelRoundModal({
     }
   };
 
-  const isValid = feedback.trim().length >= 10;
+  const isValid = feedback.trim().length > 0;
 
   return (
     <Modal isOpen={isOpen} onClose={handleClose} title={t('autoCancelRound', language)}>

--- a/frontend/src/components/work/ForkFromHereModal.tsx
+++ b/frontend/src/components/work/ForkFromHereModal.tsx
@@ -74,7 +74,7 @@ export default function ForkFromHereModal({
           disabled={forkMutation.isPending}
         />
         {!isValid && feedback.length > 0 && (
-          <div className="form-text text-danger">{t('autoFeedbackRequired', language)}</div>
+          <div className="form-text text-danger">{t('autoForkFeedbackRequired', language)}</div>
         )}
       </div>
 

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -1586,7 +1586,7 @@ export const translations: Record<Language, Translations> = {
       'Cancel this and subsequent milestones. The workflow will wait, and AI will resume with your feedback from the interruption point.',
     autoFeedbackLabel: 'Your Feedback / Instructions',
     autoFeedbackPlaceholder: 'Describe what should be done differently...',
-    autoFeedbackRequired: 'Please provide feedback (at least 10 characters)',
+    autoFeedbackRequired: 'Please enter valid feedback',
     autoForkDesc:
       'Create a new workflow starting from this point. Both workflows can run in parallel with different approaches.',
     autoForkInstructionsLabel: 'Fork Instructions',
@@ -3274,7 +3274,7 @@ export const translations: Record<Language, Translations> = {
     autoCancelRoundDesc: '取消此里程碑及后续步骤。工作流将等待，AI 将根据您的反馈从中断处恢复。',
     autoFeedbackLabel: '您的反馈/指令',
     autoFeedbackPlaceholder: '描述应该怎样调整...',
-    autoFeedbackRequired: '请提供反馈（至少10个字符）',
+    autoFeedbackRequired: '请输入有效反馈',
     autoForkDesc: '从此点创建新的工作流。两个工作流可以用不同方案并行运行。',
     autoForkInstructionsLabel: '分叉指令',
     autoForkBranchLabel: '新分支名称（可选）',
@@ -4748,7 +4748,7 @@ export const translations: Record<Language, Translations> = {
       'このマイルストーン以降をキャンセルします。ワークフローは待機し、AIはフィードバックに基づいて再開します。',
     autoFeedbackLabel: 'フィードバック/指示',
     autoFeedbackPlaceholder: 'どう変更すべきか説明してください...',
-    autoFeedbackRequired: 'フィードバックを入力してください（10文字以上）',
+    autoFeedbackRequired: '有効なフィードバックを入力してください',
     autoForkDesc:
       'このポイントから新しいワークフローを作成します。異なるアプローチで並行実行できます。',
     autoForkInstructionsLabel: '分岐の指示',
@@ -6307,7 +6307,7 @@ export const translations: Record<Language, Translations> = {
       '이 마일스톤 이후를 취소합니다. 워크플로우가 대기하며 AI가 피드백에 따라 재개합니다.',
     autoFeedbackLabel: '피드백/지시사항',
     autoFeedbackPlaceholder: '어떻게 변경해야 하는지 설명해주세요...',
-    autoFeedbackRequired: '피드백을 입력해주세요 (최소 10자)',
+    autoFeedbackRequired: '유효한 피드백을 입력해주세요',
     autoForkDesc:
       '이 지점에서 새 워크플로우를 생성합니다. 다른 접근 방식으로 병렬 실행할 수 있습니다.',
     autoForkInstructionsLabel: '분기 지시사항',

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -1590,6 +1590,7 @@ export const translations: Record<Language, Translations> = {
     autoForkDesc:
       'Create a new workflow starting from this point. Both workflows can run in parallel with different approaches.',
     autoForkInstructionsLabel: 'Fork Instructions',
+    autoForkFeedbackRequired: 'Please provide feedback (at least 10 characters)',
     autoForkBranchLabel: 'New Branch Name (optional)',
     autoForkPauseOriginal: 'Pause original workflow',
     autoForkContinueOriginal: 'Continue both in parallel',
@@ -3277,6 +3278,7 @@ export const translations: Record<Language, Translations> = {
     autoFeedbackRequired: '请输入有效反馈',
     autoForkDesc: '从此点创建新的工作流。两个工作流可以用不同方案并行运行。',
     autoForkInstructionsLabel: '分叉指令',
+    autoForkFeedbackRequired: '请提供反馈（至少10个字符）',
     autoForkBranchLabel: '新分支名称（可选）',
     autoForkPauseOriginal: '暂停原始工作流',
     autoForkContinueOriginal: '两者并行运行',
@@ -4752,6 +4754,7 @@ export const translations: Record<Language, Translations> = {
     autoForkDesc:
       'このポイントから新しいワークフローを作成します。異なるアプローチで並行実行できます。',
     autoForkInstructionsLabel: '分岐の指示',
+    autoForkFeedbackRequired: 'フィードバックを入力してください（10文字以上）',
     autoForkBranchLabel: '新しいブランチ名（任意）',
     autoForkPauseOriginal: '元のワークフローを一時停止',
     autoForkContinueOriginal: '両方を並行して続行',
@@ -6311,6 +6314,7 @@ export const translations: Record<Language, Translations> = {
     autoForkDesc:
       '이 지점에서 새 워크플로우를 생성합니다. 다른 접근 방식으로 병렬 실행할 수 있습니다.',
     autoForkInstructionsLabel: '분기 지시사항',
+    autoForkFeedbackRequired: '피드백을 입력해주세요 (최소 10자)',
     autoForkBranchLabel: '새 브랜치 이름 (선택)',
     autoForkPauseOriginal: '원본 워크플로우 일시정지',
     autoForkContinueOriginal: '둘 다 병렬로 계속',

--- a/tests/issues/1002/test_waiting_bypass.py
+++ b/tests/issues/1002/test_waiting_bypass.py
@@ -1,0 +1,212 @@
+"""Tests for waiting-workflow conflict-lock bypass.
+
+Waiting workflows only execute ``_do_wait`` — a lightweight state transition
+(DB update, no agent, no git). They must bypass batch/workspace/branch
+conflict locks so they can resume (e.g. after cancel-with-feedback) even
+while a batch sibling is actively running. Critically, the bypass must NOT
+clobber another running workflow's locks in ``_advance_single``'s cleanup.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from app.services.autonomous_scheduler import AutonomousScheduler
+
+
+def _scheduler() -> AutonomousScheduler:
+    """A fresh, non-singleton scheduler instance for isolation."""
+    return AutonomousScheduler()
+
+
+# ── filtering: waiting workflows bypass all conflict locks ──────────────
+
+
+class TestWaitingBypassFiltering:
+    """Replicates the _process_workflows conflict filter to verify waiting
+    workflows are not blocked by batch/workspace/branch locks."""
+
+    def _would_block(self, sched: AutonomousScheduler, wf: dict) -> bool:
+        """Replicate the git-conflict + batch filter in _process_workflows."""
+        is_waiting = wf.get("status") == "waiting"
+        batch_id = wf.get("batch_id")
+        if batch_id and batch_id in sched._in_progress_batch_ids and not is_waiting:
+            return True
+        workspace, branch = sched._conflict_keys(wf)
+        if workspace and workspace in sched._in_progress_workspaces and not is_waiting:
+            return True
+        if branch and branch in sched._in_progress_branches and not is_waiting:
+            return True
+        return False
+
+    def test_waiting_bypasses_batch_lock(self):
+        sched = _scheduler()
+        sched._in_progress_batch_ids.add("batch-1")
+        waiting_wf = {
+            "workflow_id": "w-wait",
+            "status": "waiting",
+            "batch_id": "batch-1",
+            "project_path": "/proj",
+            "branch_name": "shared/branch",
+        }
+        assert not self._would_block(sched, waiting_wf)
+
+    def test_waiting_bypasses_workspace_lock(self):
+        sched = _scheduler()
+        sched._in_progress_workspaces.add("/proj")
+        waiting_wf = {
+            "workflow_id": "w-wait",
+            "status": "waiting",
+            "batch_id": "batch-1",
+            "project_path": "/proj",
+            "branch_name": "shared/branch",
+        }
+        assert not self._would_block(sched, waiting_wf)
+
+    def test_waiting_bypasses_branch_lock(self):
+        sched = _scheduler()
+        sched._in_progress_branches.add("shared/branch")
+        waiting_wf = {
+            "workflow_id": "w-wait",
+            "status": "waiting",
+            "batch_id": "batch-1",
+            "project_path": "/proj",
+            "branch_name": "shared/branch",
+        }
+        assert not self._would_block(sched, waiting_wf)
+
+    def test_developing_still_blocked_by_batch_lock(self):
+        sched = _scheduler()
+        sched._in_progress_batch_ids.add("batch-1")
+        developing_wf = {
+            "workflow_id": "w-dev",
+            "status": "developing",
+            "batch_id": "batch-1",
+            "project_path": "/proj",
+            "branch_name": "shared/branch",
+        }
+        assert self._would_block(sched, developing_wf)
+
+    def test_developing_still_blocked_by_workspace_lock(self):
+        sched = _scheduler()
+        sched._in_progress_workspaces.add("/proj")
+        developing_wf = {
+            "workflow_id": "w-dev",
+            "status": "developing",
+            "batch_id": "",
+            "project_path": "/proj",
+            "branch_name": "auto-dev/x",
+        }
+        assert self._would_block(sched, developing_wf)
+
+    def test_developing_still_blocked_by_branch_lock(self):
+        sched = _scheduler()
+        sched._in_progress_branches.add("shared/branch")
+        developing_wf = {
+            "workflow_id": "w-dev",
+            "status": "planning",
+            "batch_id": "batch-1",
+            "project_path": "/proj",
+            "branch_name": "shared/branch",
+        }
+        assert self._would_block(sched, developing_wf)
+
+
+# ── _advance_single: waiting workflows don't clobber locks ──────────────
+
+
+class TestAdvanceSingleWaitingCleanup:
+    """Verify _advance_single does not discard conflict keys for waiting
+    workflows, preventing clobbering of a concurrently running sibling's
+    locks."""
+
+    def _run_advance_single(self, wf: dict, sched: AutonomousScheduler, lock_ok: bool = True):
+        """Helper: run _advance_single with all external deps mocked."""
+        repo = MagicMock()
+        repo.get_workflow.return_value = wf
+        repo.acquire_lock.return_value = lock_ok
+
+        with (
+            patch("app.routes.autonomous._get_repo", return_value=repo),
+            patch(
+                "app.modules.workspace.autonomous.orchestrator.AutonomousOrchestrator"
+            ) as mock_orch_cls,
+            patch("app.modules.governance.quota_manager.QuotaManager") as mock_qm,
+        ):
+            mock_orch_cls.return_value = MagicMock()
+            mock_qm.return_value.check_quota.return_value = {"allowed": True, "reason": ""}
+            sched._advance_single(wf["workflow_id"])
+        return repo
+
+    def test_waiting_does_not_discard_batch_id(self):
+        """A waiting workflow's finally must not remove another workflow's
+        batch_id from _in_progress_batch_ids."""
+        sched = _scheduler()
+        # Simulate a running sibling holding the batch lock
+        sched._in_progress_batch_ids.add("batch-1")
+        sched._in_progress_workspaces.add("/proj")
+        sched._in_progress_branches.add("shared/branch")
+
+        waiting_wf = {
+            "workflow_id": "w-wait",
+            "status": "waiting",
+            "batch_id": "batch-1",
+            "project_path": "/proj",
+            "branch_name": "shared/branch",
+            "user_id": 1,
+        }
+
+        self._run_advance_single(waiting_wf, sched)
+
+        # The waiting workflow's cleanup must NOT have removed the sibling's keys
+        assert "batch-1" in sched._in_progress_batch_ids
+        assert "/proj" in sched._in_progress_workspaces
+        assert "shared/branch" in sched._in_progress_branches
+        # workflow_id IS removed (the advance completed)
+        assert "w-wait" not in sched._in_progress_ids
+
+    def test_developing_does_discard_batch_id(self):
+        """A non-waiting workflow's finally DOES remove its own batch_id."""
+        sched = _scheduler()
+        sched._in_progress_batch_ids.add("batch-1")
+        sched._in_progress_workspaces.add("/proj")
+        sched._in_progress_branches.add("shared/branch")
+
+        developing_wf = {
+            "workflow_id": "w-dev",
+            "status": "developing",
+            "batch_id": "batch-1",
+            "project_path": "/proj",
+            "branch_name": "shared/branch",
+            "user_id": 1,
+        }
+
+        self._run_advance_single(developing_wf, sched)
+
+        # Non-waiting workflow's cleanup DOES remove its keys
+        assert "batch-1" not in sched._in_progress_batch_ids
+        assert "/proj" not in sched._in_progress_workspaces
+        assert "shared/branch" not in sched._in_progress_branches
+        assert "w-dev" not in sched._in_progress_ids
+
+    def test_waiting_lock_failure_does_not_discard(self):
+        """Even on lock-failure early return, a waiting workflow must not
+        clobber another workflow's keys."""
+        sched = _scheduler()
+        sched._in_progress_batch_ids.add("batch-1")
+        sched._in_progress_workspaces.add("/proj")
+        sched._in_progress_branches.add("shared/branch")
+
+        waiting_wf = {
+            "workflow_id": "w-wait",
+            "status": "waiting",
+            "batch_id": "batch-1",
+            "project_path": "/proj",
+            "branch_name": "shared/branch",
+            "user_id": 1,
+        }
+
+        self._run_advance_single(waiting_wf, sched, lock_ok=False)
+
+        assert "batch-1" in sched._in_progress_batch_ids
+        assert "/proj" in sched._in_progress_workspaces
+        assert "shared/branch" in sched._in_progress_branches
+        assert "w-wait" not in sched._in_progress_ids

--- a/tests/issues/886/test_cancel_fork_redesign.py
+++ b/tests/issues/886/test_cancel_fork_redesign.py
@@ -267,11 +267,12 @@ def _make_milestone(**overrides):
 class TestCancelMilestoneWithFeedback:
     """Tests for POST /api/autonomous/workflows/<id>/milestones/<id>/cancel."""
 
-    def test_cancel_requires_feedback(self, client):
-        """Cancel endpoint returns 400 if user_feedback is missing."""
+    def test_cancel_without_feedback_succeeds(self, client):
+        """Cancel endpoint accepts missing user_feedback (optional)."""
         repo = _make_repo()
         repo.get_workflow.return_value = _make_workflow()
         repo.get_milestone.return_value = _make_milestone()
+        repo.cancel_milestones_after.return_value = []
 
         with _mock_auth():
             with patch("app.routes.autonomous.auto_repo", repo):
@@ -280,15 +281,16 @@ class TestCancelMilestoneWithFeedback:
                     json={},
                 )
 
-        assert resp.status_code == 400
+        assert resp.status_code == 200
         data = resp.get_json()
-        assert "feedback" in data.get("error", "").lower()
+        assert data["success"] is True
 
-    def test_cancel_empty_feedback_rejected(self, client):
-        """Cancel endpoint returns 400 if user_feedback is empty string."""
+    def test_cancel_empty_feedback_succeeds(self, client):
+        """Cancel endpoint accepts empty/whitespace user_feedback (optional)."""
         repo = _make_repo()
         repo.get_workflow.return_value = _make_workflow()
         repo.get_milestone.return_value = _make_milestone()
+        repo.cancel_milestones_after.return_value = []
 
         with _mock_auth():
             with patch("app.routes.autonomous.auto_repo", repo):
@@ -297,7 +299,7 @@ class TestCancelMilestoneWithFeedback:
                     json={"user_feedback": "   "},
                 )
 
-        assert resp.status_code == 400
+        assert resp.status_code == 200
 
     def test_cancel_stores_feedback_on_workflow(self, client):
         """Cancel stores user_feedback on the workflow and sets wait phase."""


### PR DESCRIPTION
## Problem

Waiting workflows (status=`waiting`) were blocked by batch/workspace/branch conflict locks held by a concurrently running batch sibling. After a user performed cancel-with-feedback, the workflow could not resume because the scheduler's conflict-lock checks prevented it from being scheduled — even though `_do_wait` only does a lightweight DB state transition (no agent, no git operations).

Additionally, the cancel-round modal enforced a 10-character minimum on feedback, and the backend required non-empty feedback.

## Fix

### Scheduler: waiting workflows bypass conflict locks
- **`_process_workflows`**: For `status=="waiting"` workflows, bypass batch_id / workspace / branch conflict-lock checks. Don't reserve their conflict keys in the marking step.
- **`_advance_single`**: Capture `was_waiting` flag at start. In all cleanup paths (lock-failure early return + finally block), skip conflict key discards for waiting workflows — prevents clobbering another running workflow's locks.

The batch lock re-applies on the next scheduler cycle once the workflow leaves `waiting` (transitions to `developing`/`merging`/`planning`), so batch serialization is preserved for actual agent execution.

### Cancel-round feedback: optional, no 10-char minimum
- **Backend** (`autonomous.py`): removed `if not user_feedback: return 400`; kept max-length (5000) check.
- **Frontend** (`CancelRoundModal.tsx`): changed validation from `length >= 10` to `length > 0`.
- **i18n**: updated `autoFeedbackRequired` text in en/zh/ja/ko.

## Why this is safe

`_do_wait` never touches the git working tree:
1. **user_feedback path**: DB update (phase/status/dev_round) — no git
2. **auto_merge path**: DB update (phase→merge) — no git
3. **poll comments path**: GitHub API call — no git
4. **new requirements path**: DB update + GitHub API — no git

So concurrent execution with a batch sibling that IS doing git work is safe.

## Tests

New test file: `tests/issues/1002/test_waiting_bypass.py` (9 tests)
- Filtering: waiting bypasses batch/workspace/branch locks; developing still blocked
- `_advance_single`: waiting doesn't clobber sibling's keys; developing does discard; lock-failure path also safe