### PR TITLE
fix: make get_path_identity cross-platform for macOS local workflows

### DIFF
--- a/app/modules/workspace/autonomous/github_ops.py
+++ b/app/modules/workspace/autonomous/github_ops.py
@@ -12,11 +12,17 @@ import os
 import pwd
 import re
 import subprocess
+import sys
 import time
 from pathlib import Path
 from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)
+
+# macOS BSD ``stat`` takes the format via ``-f``; GNU ``stat`` (Linux) uses
+# ``-c``.  ``-L`` (follow symlinks) is supported by both.  Hard-coded
+# ``stat -c`` breaks on macOS with "illegal option -- c".
+_STAT_FORMAT_FLAG = "-f" if sys.platform == "darwin" else "-c"
 
 _GITHUB_ACTIONS_JOB_PATH_RE = re.compile(
     r"^/[^/]+/[^/]+/actions/runs/(?P<run_id>\d+)/job/(?P<job_id>\d+)(?:/|$)"
@@ -199,15 +205,38 @@ class GitHubOps:
         self._owner_repo_resolved = False
 
     def get_path_identity(self, path: str) -> str:
-        """Return device+inode for ``path`` using the repository owner identity."""
+        """Return device+inode for ``path`` using the repository owner identity.
+
+        Uses an in-process ``os.stat`` (cross-platform, follows symlinks like
+        ``stat -L``) when the service already runs as the repo owner — the
+        common same-user case.  Only the cross-user case shells out through
+        ``sudo -u <account> stat ...``, where the GNU ``-c`` vs BSD ``-f``
+        format-flag split is handled per platform: macOS BSD ``stat`` rejects
+        ``-c`` with "illegal option -- c", which previously made every local
+        workflow fail at the trusted-Git-context snapshot on macOS.
+        """
+        if not self._needs_sudo():
+            try:
+                st = os.stat(path)  # follows symlinks, matching ``stat -L``
+            except OSError as e:
+                raise GitHubOpsError(f"Cannot verify protected Git path {path}: {e}")
+            return f"{st.st_dev}:{st.st_ino}"
         kwargs = self._build_subprocess_kwargs()
         kwargs.pop("cwd", None)
         kwargs["timeout"] = 10
-        command = ["stat", "-Lc", "%d:%i", path]
-        if self._needs_sudo():
-            account = self.system_account
-            assert account is not None  # _needs_sudo() guarantees non-empty
-            command = ["sudo", "-n", "-u", account, *command]
+        account = self.system_account
+        assert account is not None  # _needs_sudo() guarantees non-empty
+        command = [
+            "sudo",
+            "-n",
+            "-u",
+            account,
+            "stat",
+            "-L",
+            _STAT_FORMAT_FLAG,
+            "%d:%i",
+            path,
+        ]
         result = subprocess.run(command, **kwargs)
         if result.returncode != 0 or not result.stdout.strip():
             raise GitHubOpsError(


### PR DESCRIPTION
## Problem

All local autonomous workflows (e.g. batch `auto-1824-1832`, 9 workflows) failed at the planning phase with:

```
Planning failed: Cannot establish a trusted Git context before agent execution
```

Server log showed the underlying cause:

```
WARNING - Skipping repo-state snapshot for workflow ...: Cannot verify protected Git path /.../.git/worktrees/...: stat: illegal option -- c
```

## Root cause

`GitHubOps.get_path_identity` shelled out to `stat -Lc "%d:%i"` (GNU/Linux syntax) **unconditionally**, even for the same-user case. macOS BSD `stat` has no `-c` option (it uses `-f`), so the command failed with `stat: illegal option -- c`. That made `_snapshot_repo_context` raise -> return `None` -> the orchestrator refused to start the agent (`orchestrator.py:4339-4350`).

This blocks **every** local worktree-strategy workflow on macOS at the trusted-Git-context snapshot, before the agent even runs.

## Fix

- For the common same-user case (`_needs_sudo()` is False), use an in-process `os.stat(path)` -- cross-platform, follows symlinks like `stat -L`, and avoids the GNU/BSD flag split entirely. Output `f"{st.st_dev}:{st.st_ino}"` matches the `%d:%i` format the shell command produced.
- For the cross-user sudo case, select the format flag per platform: `-f` on darwin, `-c` elsewhere.

This mirrors the pattern already used in `agent_runner._stat_mtime` (Python `path.stat()` for same-user, shell-out only for sudo).

## Verification

- Reproduced: old `stat -Lc "%d:%i"` -> `stat: illegal option -- c` (rc=1); new path -> `16777234:280471737`, matches BSD `stat -L -f "%d:%i"` exactly.
- `tests/unit/test_autonomous_ci_guardrails.py` + `tests/autonomous/test_repo_drift_validation.py`: 79 passed.

## Scope

Workflow-platform code only (`github_ops.py`). No business-PR logic touched.