### PR TITLE
fix: fallback to same-user mode when isolated agent launcher unavailable on macOS

### DIFF
--- a/app/modules/workspace/autonomous/agent_runner.py
+++ b/app/modules/workspace/autonomous/agent_runner.py
@@ -974,6 +974,22 @@ class AutonomousAgentRunner:
             return True
 
     @staticmethod
+    def is_isolated_launcher_available() -> bool:
+        """Whether the privileged ``openace-run-as --isolated`` launcher is
+        installed and executable.
+
+        The isolated-agent path (a credentialless principal + scoped ACLs via
+        ``openace-run-as``) is the security model for multi-user Linux
+        deployments. The launcher is Linux-only (setfacl/getent/runuser) and is
+        not provisioned on dev installs or non-Linux platforms (macOS/Windows),
+        where the service already runs as the repository owner and there is no
+        security benefit to a second account. Callers use this to decide
+        whether to engage isolated-agent mode or fall back to same-user
+        execution (mirroring the Windows single-user downgrade).
+        """
+        return os.path.isfile(_OPENACE_RUN_AS) and os.access(_OPENACE_RUN_AS, os.X_OK)
+
+    @staticmethod
     def _wrap_agent_cmd(
         cmd: list[str],
         project_path: str,

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -23,6 +23,7 @@ import uuid
 from datetime import datetime, timezone
 
 from app.modules.workspace.autonomous.agent_runner import (
+    _OPENACE_RUN_AS,
     DEFAULT_TASK_TIMEOUT,
     AutonomousAgentRunner,
 )
@@ -2432,12 +2433,25 @@ class AutonomousOrchestrator:
             logger.warning("Skipping isolated pre-commit convergence: executable unavailable")
             return False, ""
 
-        isolated_account = self._resolve_isolated_agent_account()
         project_system_account = self._resolve_system_account(wf)
-        if project_system_account and isolated_account == project_system_account:
-            raise RuntimeError(
-                "Autonomous validation account must differ from the repository owner account"
+        # Engage the credentialless isolated-agent principal only when the
+        # privileged launcher is provisioned (Linux multi-user). On dev/macOS
+        # installs without openace-run-as, fall back to the repository owner
+        # account in same-user mode — mirroring _run_agent's downgrade.
+        if AutonomousAgentRunner.is_isolated_launcher_available():
+            isolated_account = self._resolve_isolated_agent_account()
+            if project_system_account and isolated_account == project_system_account:
+                raise RuntimeError(
+                    "Autonomous validation account must differ from the repository owner account"
+                )
+        else:
+            logger.warning(
+                "Workflow %s: isolated agent launcher unavailable; running pre-commit "
+                "convergence as the repository owner (%s) in same-user mode.",
+                getattr(self, "_workflow_id", ""),
+                project_system_account or "(unknown)",
             )
+            isolated_account = project_system_account
         runtime_command, _ = self._select_project_python_runtime(project_path, gh)
         guard_bin = AutonomousAgentRunner._resolve_agent_guard_bin()
         env = {
@@ -4392,22 +4406,40 @@ class AutonomousOrchestrator:
                         "contains embedded credentials; configure a credential helper instead"
                     ),
                 )
-            isolated_account = self._resolve_isolated_agent_account()
-            try:
-                service_account = pwd.getpwuid(os.getuid()).pw_name
-            except (KeyError, OverflowError):
-                service_account = ""
-            if isolated_account in {project_system_account, service_account}:
-                return AgentTaskResult(
-                    session_id=tracking_session_id,
-                    tracking_session_id=tracking_session_id,
-                    success=False,
-                    error=(
-                        "Autonomous agent isolation is invalid: the credentialless agent "
-                        "account must differ from the service and repository owner accounts"
-                    ),
+            # Engage the credentialless isolated-agent principal only when the
+            # privileged launcher (openace-run-as --isolated) is actually
+            # provisioned. The launcher is Linux-only (setfacl/getent/runuser)
+            # and absent on dev/macOS installs where the service already runs as
+            # the repo owner; in that same-user case isolation provides no
+            # benefit and cannot run. Mirrors the Windows single-user downgrade.
+            if AutonomousAgentRunner.is_isolated_launcher_available():
+                isolated_account = self._resolve_isolated_agent_account()
+                try:
+                    service_account = pwd.getpwuid(os.getuid()).pw_name
+                except (KeyError, OverflowError):
+                    service_account = ""
+                if isolated_account in {project_system_account, service_account}:
+                    return AgentTaskResult(
+                        session_id=tracking_session_id,
+                        tracking_session_id=tracking_session_id,
+                        success=False,
+                        error=(
+                            "Autonomous agent isolation is invalid: the credentialless agent "
+                            "account must differ from the service and repository owner accounts"
+                        ),
+                    )
+                kwargs["system_account"] = isolated_account
+            else:
+                logger.warning(
+                    "Workflow %s: isolated agent launcher %s unavailable; running the "
+                    "agent as the repository owner (%s) in same-user mode. This is expected "
+                    "on dev/macOS installs where the service runs as the repo owner; "
+                    "isolated agent mode requires the openace-run-as launcher "
+                    "(Linux multi-user only).",
+                    self._workflow_id,
+                    _OPENACE_RUN_AS,
+                    project_system_account or "(unknown)",
                 )
-            kwargs["system_account"] = isolated_account
 
         with self._session_lock:
             self._current_session_id = tracking_session_id

--- a/tests/unit/test_autonomous_ci_guardrails.py
+++ b/tests/unit/test_autonomous_ci_guardrails.py
@@ -1565,6 +1565,7 @@ def test_pre_commit_convergence_reruns_modified_hooks_as_isolated_agent():
     from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
 
     orch = AutonomousOrchestrator.__new__(AutonomousOrchestrator)
+    orch._workflow_id = "wf-test"
     orch._resolve_isolated_agent_account = MagicMock(return_value="openace-agent")
     orch._resolve_system_account = MagicMock(return_value="repo-owner")
     orch._select_project_python_runtime = MagicMock(return_value=(["python3"], ""))
@@ -1587,6 +1588,11 @@ def test_pre_commit_convergence_reruns_modified_hooks_as_isolated_agent():
         patch(
             "app.modules.workspace.autonomous.orchestrator.shutil.which",
             side_effect=["/usr/local/bin/pre-commit", "/usr/bin/git"],
+        ),
+        patch.object(
+            AutonomousAgentRunner,
+            "is_isolated_launcher_available",
+            return_value=True,
         ),
         patch.object(
             AutonomousAgentRunner,
@@ -1627,7 +1633,66 @@ def test_pre_commit_convergence_reruns_modified_hooks_as_isolated_agent():
     assert run.call_args.kwargs["env"] is None
 
 
+def test_pre_commit_convergence_falls_back_to_same_user_without_launcher():
+    """When openace-run-as is unavailable (dev/macOS), converge as repo owner."""
+    from app.modules.workspace.autonomous.agent_runner import AutonomousAgentRunner
+    from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+    orch = AutonomousOrchestrator.__new__(AutonomousOrchestrator)
+    orch._workflow_id = "wf-test"
+    orch._resolve_isolated_agent_account = MagicMock(return_value="openace-agent")
+    orch._resolve_system_account = MagicMock(return_value="repo-owner")
+    orch._select_project_python_runtime = MagicMock(return_value=(["python3"], ""))
+    gh = MagicMock()
+    gh.path_exists_as_user.return_value = True
+
+    modified = MagicMock(
+        returncode=1,
+        stdout="files were modified by this hook\nFixing docker-compose.yml",
+        stderr="",
+    )
+    clean = MagicMock(returncode=0, stdout="All checks passed", stderr="")
+
+    with (
+        patch(
+            "app.modules.workspace.autonomous.orchestrator.shutil.which",
+            side_effect=["/usr/local/bin/pre-commit", "/usr/bin/git"],
+        ),
+        patch.object(
+            AutonomousAgentRunner,
+            "is_isolated_launcher_available",
+            return_value=False,
+        ),
+        patch.object(
+            AutonomousAgentRunner,
+            "_wrap_agent_cmd",
+            return_value=(["same-user-wrapper", "pre-commit"], None),
+        ) as wrap,
+        patch.object(
+            AutonomousAgentRunner,
+            "_resolve_agent_guard_bin",
+            return_value="/usr/local/libexec/openace-agent-bin",
+        ),
+        patch(
+            "app.modules.workspace.autonomous.orchestrator.subprocess.run",
+            side_effect=[modified, clean],
+        ) as run,
+    ):
+        attempted, error = orch._converge_pre_commit_fixes(
+            {"workspace_type": "local", "worktree_path": "/private/repo"},
+            gh,
+            [{"failure_excerpt": "pre-commit hook(s) made changes"}],
+        )
+
+    assert attempted
+    assert error == ""
+    # Same-user fallback passes the repo owner account, NOT the isolated one.
+    assert wrap.call_args.args[2] == "repo-owner"
+    assert run.call_count == 2
+
+
 def test_pre_commit_convergence_rejects_repository_owner_account():
+    from app.modules.workspace.autonomous.agent_runner import AutonomousAgentRunner
     from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
 
     orch = AutonomousOrchestrator.__new__(AutonomousOrchestrator)
@@ -1640,6 +1705,11 @@ def test_pre_commit_convergence_rejects_repository_owner_account():
         patch(
             "app.modules.workspace.autonomous.orchestrator.shutil.which",
             side_effect=["/usr/local/bin/pre-commit", "/usr/bin/git"],
+        ),
+        patch.object(
+            AutonomousAgentRunner,
+            "is_isolated_launcher_available",
+            return_value=True,
         ),
         patch("app.modules.workspace.autonomous.orchestrator.subprocess.run") as run,
         pytest.raises(RuntimeError, match="repository owner"),


### PR DESCRIPTION
## Problem

All local autonomous workflows on macOS fail during the planning phase with:
```
Planning failed: Failed to access project dir ... as openace-agent (exit 1): sudo: /usr/local/bin/openace-run-as: command not found
```

The isolated-agent path (`openace-run-as --isolated`) is Linux-only (depends on `setfacl`/`getent`/`runuser`) and is not provisioned on dev/macOS installs where the service already runs as the repository owner. Two code paths unconditionally engaged the credentialless principal without checking launcher availability:

1. **`_run_agent`** (orchestrator.py): set `kwargs["system_account"]` to the isolated account unconditionally → `_ensure_project_dir` tried `sudo openace-run-as` and failed.
2. **`_converge_pre_commit_fixes`** (orchestrator.py): resolved the isolated account unconditionally for CI repair pre-commit convergence.

## Fix

Add `AutonomousAgentRunner.is_isolated_launcher_available()` static method that checks whether `/usr/local/bin/openace-run-as` exists and is executable. Gate both paths on it:

- **Launcher available** (Linux multi-user): unchanged — engage the credentialless isolated principal.
- **Launcher unavailable** (dev/macOS): fall back to the repo owner account in same-user mode and emit a warning log. This mirrors the existing Windows single-user downgrade.

## Files Changed

- `app/modules/workspace/autonomous/agent_runner.py`: add `is_isolated_launcher_available()`.
- `app/modules/workspace/autonomous/orchestrator.py`: gate `_run_agent` and `_converge_pre_commit_fixes` on launcher availability.
- `tests/unit/test_autonomous_ci_guardrails.py`: mock `is_isolated_launcher_available` in existing isolated-path tests; add new same-user fallback test.

## Test Plan

- [x] `pytest tests/unit/test_autonomous_ci_guardrails.py` — 73 passed
- [x] pre-commit hooks (black, isort, ruff, mypy, bandit, pydocstyle) all pass
- [ ] Independent agent code review (workflow code only)
- [ ] Deploy + retry 9 failed workflows (auto-1824-1832)