### PR TITLE
fix(agent-runner): call poll() in _read_stdout finally to detect process exit

### DIFF
--- a/app/modules/workspace/autonomous/agent_runner.py
+++ b/app/modules/workspace/autonomous/agent_runner.py
@@ -3635,11 +3635,19 @@ class AutonomousAgentRunner:
         except (OSError, ValueError):
             pass
         finally:
-            # If process exited without sending result, mark completed
+            # If process exited without sending result, mark completed.
+            # poll() must be called to reap the child and populate
+            # returncode — readline() returning EOF does NOT set it
+            # automatically, so without poll() the returncode check
+            # would fail and session.completed would never be set,
+            # causing _wait_for_completion to block until the 1-hour
+            # timeout (#2031).
             if not session.completed.is_set():
                 session._stopped.wait(2.0)
-                if session.process and session.process.returncode is not None:
-                    session.completed.set()
+                if session.process:
+                    session.process.poll()
+                    if session.process.returncode is not None:
+                        session.completed.set()
 
     def _read_stderr(self, session: _LocalSession) -> None:
         """Read stderr from the subprocess."""

--- a/tests/issues/716/test_agent_runner.py
+++ b/tests/issues/716/test_agent_runner.py
@@ -870,6 +870,31 @@ class TestStdoutParsing:
             "Final answer"
         ]
 
+    def test_process_exit_without_result_marks_completed_via_poll(self):
+        """When the agent exits without a result event, the finally block
+        must call poll() to populate returncode and set session.completed.
+
+        Regression test for #2031: without poll(), returncode stays None
+        (readline EOF does not set it), session.completed is never set,
+        and _wait_for_completion blocks until the 1-hour timeout.
+        """
+        mock_process = MagicMock()
+        mock_stdout = MagicMock()
+        mock_stdout.readline = MagicMock(side_effect=[b""])  # immediate EOF
+        mock_process.stdout = mock_stdout
+        # returncode is None until poll() is called — simulates a process
+        # that exited but has not been waited on yet.
+        mock_process.returncode = None
+        mock_process.poll = MagicMock(side_effect=lambda: setattr(mock_process, "returncode", 0))
+
+        session = _LocalSession(session_id="s-1", process=mock_process)
+        self.runner._read_stdout(session)
+
+        # poll() must have been called to reap the child process
+        mock_process.poll.assert_called_once()
+        # session.completed must be set so _wait_for_completion returns
+        assert session.completed.is_set()
+
 
 class TestStopSession:
     """Tests for stop_session."""

--- a/tests/unit/test_autonomous_ci_guardrails.py
+++ b/tests/unit/test_autonomous_ci_guardrails.py
@@ -421,7 +421,9 @@ def test_terminal_result_closes_stream_json_stdin():
     runner._capture_cli_session_id = lambda *_args: "cli-session"
     runner._sync_sidebar_session_totals = lambda *_args, **_kwargs: None
     runner._resolve_sidebar_session = lambda *_args, **_kwargs: "cli-session"
-    process = SimpleNamespace(stdout=FakeStdout(), stdin=FakeStdin(), returncode=None)
+    process = SimpleNamespace(
+        stdout=FakeStdout(), stdin=FakeStdin(), returncode=None, poll=lambda: None
+    )
     session = _LocalSession(session_id="tracking-session", process=process)
 
     with patch(
@@ -910,7 +912,7 @@ def test_claude_embedded_tool_use_pairs_with_test_result():
 
     runner = AutonomousAgentRunner.__new__(AutonomousAgentRunner)
     runner._activity_callback = None
-    process = SimpleNamespace(stdout=FakeStdout(), returncode=None)
+    process = SimpleNamespace(stdout=FakeStdout(), returncode=None, poll=lambda: None)
     session = _LocalSession(session_id="test-session", process=process)
 
     runner._read_stdout(session)


### PR DESCRIPTION
## Problem

Workflows stall for the full 1-hour task timeout in `pr_review` / `development` phases when the agent process exits without emitting a `result` event.

Root cause: `_read_stdout`'s `finally` block checks `session.process.returncode` directly, but on POSIX `readline()` returning EOF does **not** populate `returncode` — the child must be reaped via `poll()`/`wait()`. So `returncode` stays `None`, `session.completed` is never set, and `_wait_for_completion` blocks until the timeout.

## Fix

Call `session.process.poll()` before checking `returncode` in the `finally` block. This reaps the exited child and populates `returncode`, so `session.completed` is set and `_wait_for_completion` returns promptly.

## Test

Added `test_process_exit_without_result_marks_completed_via_poll` — simulates immediate EOF with `returncode=None`, verifies `poll()` is called and `session.completed` is set.

Refs #2031