### PR TITLE
fix(merge): skip CI repair for mergeable_state=unstable PRs (#2034)

### DIFF
--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -8335,8 +8335,34 @@ class AutonomousOrchestrator:
                 ) from e
             failed = [c for c in checks if c.get("bucket") == "fail"]
             if failed:
-                self._start_ci_repair_round(wf, pr_number, failed)
-                return
+                # Before consuming a CI repair attempt, check whether the PR
+                # is mergeable despite the failing checks.
+                # mergeable_state=unstable means only non-required checks are
+                # failing (e.g. Security Audit Gate) and the merge will succeed.
+                # Attempting CI repair on such checks often fails (the agent
+                # can't fix dependency vulnerabilities) and causes the workflow
+                # to fail unnecessarily (#2034).
+                try:
+                    pre_merge_state = gh.get_pr_merge_state(pr_number)
+                    pre_mergeable_state = str(pre_merge_state.get("mergeable_state") or "").lower()
+                except Exception as state_err:
+                    logger.warning(
+                        "PR #%s: failed to query merge state before CI repair: %s",
+                        pr_number,
+                        state_err,
+                    )
+                    pre_mergeable_state = ""
+
+                if pre_mergeable_state != "unstable":
+                    self._start_ci_repair_round(wf, pr_number, failed)
+                    return
+                # mergeable_state == "unstable": fall through to merge attempt
+                logger.info(
+                    "PR #%s: %d checks failed but mergeable_state=unstable; "
+                    "attempting merge before CI repair",
+                    pr_number,
+                    len(failed),
+                )
             # If CI is still running, defer this merge to the next scheduler
             # cycle instead of blocking (synchronous poll) or failing. The
             # scheduler re-enters _do_merge every ~10s.

--- a/tests/issues/716/test_orchestrator.py
+++ b/tests/issues/716/test_orchestrator.py
@@ -1064,8 +1064,77 @@ class TestOrchestratorMerge:
         status_updates = [c for c in update_calls if c[0][1].get("status") == "completed"]
         assert len(status_updates) > 0
 
+    @patch("app.modules.workspace.autonomous.orchestrator.GitHubOps")
+    def test_merge_unstable_skips_ci_repair(self, mock_gh_cls):
+        """PR with mergeable_state=unstable should merge directly, skipping
+        CI repair. Non-required failing checks (e.g. Security Audit Gate)
+        should not block the merge or consume a CI repair attempt (#2034).
+        """
+        wf = _make_workflow(
+            current_phase="merge",
+            github_pr_number=42,
+            branch_name="feature/test",
+        )
+        orch, mock_repo = self._make_orchestrator(wf)
 
-# ── _do_development Tests ─────────────────────────────────────────────
+        mock_gh = MagicMock()
+        mock_gh.merge_pr.return_value = {"merged": True}
+        mock_gh.get_pr_head_sha.return_value = "pr-head"
+        # Security Audit Gate fails but is non-required
+        mock_gh.get_pr_checks.return_value = [
+            {"name": "test", "bucket": "pass"},
+            {"name": "Security Audit Gate", "bucket": "fail"},
+        ]
+        mock_gh.get_pr_merge_state.return_value = {
+            "mergeable": True,
+            "mergeable_state": "unstable",
+        }
+        mock_gh_cls.return_value = mock_gh
+        orch._gh = mock_gh
+        orch._validate_pre_merge_change_scope = MagicMock(return_value="")
+        orch._sync_failed_pr_with_main = MagicMock(return_value=False)
+        orch._start_ci_repair_round = MagicMock()
+
+        orch._do_merge(wf)
+
+        # Merge should be attempted despite the failing non-required check
+        mock_gh.merge_pr.assert_called_once_with(42, strategy="merge")
+        # CI repair should NOT be started
+        orch._start_ci_repair_round.assert_not_called()
+
+    @patch("app.modules.workspace.autonomous.orchestrator.GitHubOps")
+    def test_merge_blocked_state_triggers_ci_repair(self, mock_gh_cls):
+        """PR with mergeable_state=blocked should start CI repair as usual
+        when required checks fail (#2034).
+        """
+        wf = _make_workflow(
+            current_phase="merge",
+            github_pr_number=43,
+            branch_name="feature/test",
+        )
+        orch, _ = self._make_orchestrator(wf)
+
+        mock_gh = MagicMock()
+        mock_gh.get_pr_head_sha.return_value = "pr-head"
+        mock_gh.get_pr_checks.return_value = [
+            {"name": "lint", "bucket": "fail"},
+        ]
+        mock_gh.get_pr_merge_state.return_value = {
+            "mergeable": False,
+            "mergeable_state": "blocked",
+        }
+        mock_gh_cls.return_value = mock_gh
+        orch._gh = mock_gh
+        orch._validate_pre_merge_change_scope = MagicMock(return_value="")
+        orch._sync_failed_pr_with_main = MagicMock(return_value=False)
+        orch._start_ci_repair_round = MagicMock()
+
+        orch._do_merge(wf)
+
+        # CI repair should be started for blocked PRs
+        orch._start_ci_repair_round.assert_called_once()
+        # Merge should NOT be attempted
+        mock_gh.merge_pr.assert_not_called()
 
 
 class TestOrchestratorDevelopment:


### PR DESCRIPTION
## Problem

Workflows fail in the merge phase when a PR has only non-required check failures (e.g. `Security Audit Gate`). The workflow starts CI repair on **any** failing check, but the agent cannot fix dependency vulnerabilities, so CI repair fails with `"agent produced no code changes"` and the workflow terminates — even though the PR is mergeable.

**Confirmed case:** Workflow `auto-1824-1832 (#1829)` failed on PR #2028, which has `mergeStateStatus: UNSTABLE` with only `Security Audit Gate: FAILURE` (all required checks pass).

## Fix

`_do_merge` now queries `mergeable_state` before starting CI repair:
- **`unstable`** — only non-required checks are failing; the merge will succeed. Skip CI repair and attempt the merge directly.
- **`blocked` / `dirty` / other** — required checks are failing; start CI repair as before.

## Changes

- `app/modules/workspace/autonomous/orchestrator.py`: added `mergeable_state` check before `_start_ci_repair_round`
- `tests/issues/716/test_orchestrator.py`: added `test_merge_unstable_skips_ci_repair` and `test_merge_blocked_state_triggers_ci_repair`

Closes #2034