### PR TITLE
fix(drift): skip main-HEAD-drift check when developer switched branches (#1831)

### DIFF
--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -1641,6 +1641,7 @@ class AutonomousOrchestrator:
                 before_main.get("head")
                 and after_main.get("head")
                 and before_main.get("head") != after_main.get("head")
+                and before_main.get("branch") == after_main.get("branch")
                 and before_effective.get("head") == after_effective.get("head")
             ):
                 # main HEAD moved but the worktree did not. This is either an
@@ -1649,6 +1650,17 @@ class AutonomousOrchestrator:
                 # only when the move is a forward update to a remote-sourced
                 # commit (a benign pull); a local escape commit (not pushed),
                 # a reset/rollback, or a non-fast-forward rewrite is blocked.
+                #
+                # The branch-equality guard (before.branch == after.branch)
+                # skips the check entirely when the developer switched the main
+                # repo to another branch during the agent run (e.g. to work on
+                # a fix PR from the same checkout on a dev/single-user host).
+                # In that case the "HEAD moved" signal is from the branch
+                # switch, not an agent escape, and the worktree-only validation
+                # above already confirms the agent stayed inside its worktree.
+                # Without this guard, any local (unpushed) commit on the
+                # feature branch trips after_on_remote=False and produces a
+                # false-positive escape report (#1831 regression).
                 if self._main_drift_is_benign_pull(
                     ctx.get("project_path", ""),
                     before_main.get("head"),
@@ -1667,6 +1679,30 @@ class AutonomousOrchestrator:
                     "Detected commits on the main repository while the workflow worktree "
                     "HEAD did not move; the agent likely executed git commands outside "
                     "the workflow worktree."
+                )
+            if (
+                before_main.get("head")
+                and after_main.get("head")
+                and before_main.get("head") != after_main.get("head")
+                and before_main.get("branch") != after_main.get("branch")
+                and before_effective.get("head") == after_effective.get("head")
+            ):
+                # Main repo HEAD moved because the developer switched branches
+                # (e.g. checked out a feature branch to work on a fix PR while
+                # a workflow was running on the same host). This is not an
+                # agent escape — the agent runs inside the worktree and cannot
+                # affect the main repo's checked-out branch. Log and allow;
+                # the worktree-only validation above already confirmed the
+                # agent stayed inside its worktree (#1831).
+                logger.info(
+                    "Workflow %s: main repo branch changed %s..%s during agent run "
+                    "(developer switched branches: %s -> %s); skipping main-HEAD-drift "
+                    "check, allowing.",
+                    self._workflow_id,
+                    before_main.get("head", "")[:8],
+                    after_main.get("head", "")[:8],
+                    before_main.get("branch", ""),
+                    after_main.get("branch", ""),
                 )
         return ""
 

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -1650,17 +1650,6 @@ class AutonomousOrchestrator:
                 # only when the move is a forward update to a remote-sourced
                 # commit (a benign pull); a local escape commit (not pushed),
                 # a reset/rollback, or a non-fast-forward rewrite is blocked.
-                #
-                # The branch-equality guard (before.branch == after.branch)
-                # skips the check entirely when the developer switched the main
-                # repo to another branch during the agent run (e.g. to work on
-                # a fix PR from the same checkout on a dev/single-user host).
-                # In that case the "HEAD moved" signal is from the branch
-                # switch, not an agent escape, and the worktree-only validation
-                # above already confirms the agent stayed inside its worktree.
-                # Without this guard, any local (unpushed) commit on the
-                # feature branch trips after_on_remote=False and produces a
-                # false-positive escape report (#1831 regression).
                 if self._main_drift_is_benign_pull(
                     ctx.get("project_path", ""),
                     before_main.get("head"),
@@ -1680,30 +1669,79 @@ class AutonomousOrchestrator:
                     "HEAD did not move; the agent likely executed git commands outside "
                     "the workflow worktree."
                 )
+            after_main_branch = after_main.get("branch", "")
             if (
                 before_main.get("head")
                 and after_main.get("head")
                 and before_main.get("head") != after_main.get("head")
-                and before_main.get("branch") != after_main.get("branch")
+                and before_main.get("branch") != after_main_branch
                 and before_effective.get("head") == after_effective.get("head")
             ):
-                # Main repo HEAD moved because the developer switched branches
-                # (e.g. checked out a feature branch to work on a fix PR while
-                # a workflow was running on the same host). This is not an
-                # agent escape — the agent runs inside the worktree and cannot
-                # affect the main repo's checked-out branch. Log and allow;
-                # the worktree-only validation above already confirmed the
-                # agent stayed inside its worktree (#1831).
-                logger.info(
-                    "Workflow %s: main repo branch changed %s..%s during agent run "
-                    "(developer switched branches: %s -> %s); skipping main-HEAD-drift "
-                    "check, allowing.",
-                    self._workflow_id,
-                    before_main.get("head", "")[:8],
-                    after_main.get("head", "")[:8],
-                    before_main.get("branch", ""),
-                    after_main.get("branch", ""),
-                )
+                # Main repo HEAD moved AND its checked-out branch changed
+                # during the agent run. On a dev/single-user host this is the
+                # common case: the developer checked out a feature branch to
+                # work on a fix PR while a workflow was running against the
+                # same repo, and the feature branch's local (unpushed) commits
+                # would otherwise trip after_on_remote=False in the
+                # benign-pull probe (#1831 false positive).
+                #
+                # Security tradeoff: this skip is ambiguous on same-user
+                # deployments (macOS / dev installs without the
+                # openace-run-as launcher). In same-user mode the agent has no
+                # command guard and COULD theoretically `cd` to the main repo
+                # and `git checkout <branch> && git commit`. The worktree-only
+                # validation above (repo root / branch / origin / git_dir)
+                # does NOT catch this — it only confirms the worktree was not
+                # modified, not that the agent stayed inside the worktree.
+                # Mitigations:
+                #   - auto-dev/* branches are NOT skipped (see below), since
+                #     those are workflow branches and a switch to one in the
+                #     main repo is more likely an escape than developer work.
+                #   - The branch change is logged at WARNING so operators on
+                #     security-sensitive multi-user hosts can monitor it.
+                #   - On multi-user Linux hosts with the launcher, the agent
+                #     runs as a credentialless principal and CANNOT touch the
+                #     main repo, so this tradeoff is dev-host-only.
+                if after_main_branch.startswith("auto-dev/"):
+                    # A switch to an auto-dev/* branch in the main repo is
+                    # suspicious — workflow branches belong in worktrees, not
+                    # the main checkout. Run the benign-pull probe; if it
+                    # doesn't pass, block as a likely escape.
+                    logger.warning(
+                        "Workflow %s: main repo branch changed to %s (an auto-dev/* "
+                        "workflow branch) during agent run; running drift check.",
+                        self._workflow_id,
+                        after_main_branch,
+                    )
+                    if self._main_drift_is_benign_pull(
+                        ctx.get("project_path", ""),
+                        before_main.get("head"),
+                        after_main.get("head"),
+                        system_account,
+                    ):
+                        return ""
+                    return (
+                        "Detected commits on the main repository while the workflow "
+                        "worktree HEAD did not move; the main repo branch changed to "
+                        f"{after_main_branch} (an auto-dev/* workflow branch), which "
+                        "is not a developer action — the agent likely executed git "
+                        "commands outside the workflow worktree."
+                    )
+                else:
+                    logger.warning(
+                        "Workflow %s: main repo branch changed %s..%s during agent "
+                        "run (developer switched branches: %s -> %s); skipping "
+                        "main-HEAD-drift check. NOTE: on same-user deployments this "
+                        "skip cannot distinguish developer action from an agent "
+                        "escape via branch switch — monitor this log on "
+                        "security-sensitive hosts.",
+                        self._workflow_id,
+                        before_main.get("head", "")[:8],
+                        after_main.get("head", "")[:8],
+                        before_main.get("branch", ""),
+                        after_main_branch,
+                    )
+                    return ""
         return ""
 
     def _ensure_worktree(self, wf: dict) -> str:

--- a/tests/autonomous/test_repo_drift_validation.py
+++ b/tests/autonomous/test_repo_drift_validation.py
@@ -326,3 +326,46 @@ class TestRepoDriftValidation:
 
         err = o._validate_repo_context_after_run(before, system_account=None)
         assert "Detected commits on the main repository" in err
+
+    def test_branch_switch_to_auto_dev_is_blocked(self, monkeypatch):
+        # Security hardening: a branch switch to an auto-dev/* workflow
+        # branch in the main repo is suspicious — workflow branches belong in
+        # worktrees, not the main checkout. Even though the branch changed,
+        # the drift check must still run and block when the commit is local
+        # (not on origin/main). This prevents an agent escape via
+        # `git checkout auto-dev/<wf> && git commit` from hiding behind the
+        # branch-switch exemption.
+        _install_fake_gh(
+            monkeypatch,
+            after_main_head=MAIN_AFTER_LOCAL,  # forward, NOT on origin/main
+            effective_head=WORKTREE_HEAD,  # worktree did not move
+            moved_forward=True,
+            after_on_remote=False,
+            after_main_branch="auto-dev/wf-drift",  # workflow branch!
+        )
+        o = _make_orchestrator()
+        before = _before_state(MAIN_BEFORE)
+
+        err = o._validate_repo_context_after_run(before, system_account=None)
+        assert "Detected commits on the main repository" in err
+        assert "auto-dev/* workflow branch" in err
+
+    def test_branch_switch_to_auto_dev_with_benign_pull_is_allowed(self, monkeypatch):
+        # Edge case: if the main repo switched to an auto-dev/* branch AND the
+        # new HEAD happens to be a forward update from origin/main (e.g. the
+        # developer pushed the workflow branch and pulled it on main), the
+        # benign-pull probe should still allow it. This locks in that the
+        # auto-dev path runs the probe rather than unconditionally blocking.
+        _install_fake_gh(
+            monkeypatch,
+            after_main_head=MAIN_AFTER_PULL,  # forward + on origin/main
+            effective_head=WORKTREE_HEAD,
+            moved_forward=True,
+            after_on_remote=True,
+            after_main_branch="auto-dev/some-wf",
+        )
+        o = _make_orchestrator()
+        before = _before_state(MAIN_BEFORE)
+
+        err = o._validate_repo_context_after_run(before, system_account=None)
+        assert err == ""

--- a/tests/autonomous/test_repo_drift_validation.py
+++ b/tests/autonomous/test_repo_drift_validation.py
@@ -103,11 +103,12 @@ def _install_fake_gh(
     after_on_remote=True,
     fetch_fail=False,
     git_error=False,
+    after_main_branch="main",
 ):
     """Patch GitHubOps so _capture_repo_state returns scripted heads.
 
     - Worktree repo (repo_path == WORKTREE) → effective_head, branch auto-dev/wf-drift.
-    - Main repo (repo_path == MAIN_REPO) → after_main_head, branch main.
+    - Main repo (repo_path == MAIN_REPO) → after_main_head, branch after_main_branch.
     - ``fetch origin main`` → exit 0, or exit 1 when fetch_fail (best-effort:
       fetch failure must NOT short-circuit; the probe falls back to the
       existing origin/main ref).
@@ -123,7 +124,7 @@ def _install_fake_gh(
             gh.get_current_branch.return_value = "auto-dev/wf-drift"
             gh.get_current_commit.return_value = effective_head
         else:  # main repo
-            gh.get_current_branch.return_value = "main"
+            gh.get_current_branch.return_value = after_main_branch
             gh.get_current_commit.return_value = after_main_head
 
         def run_git(args, check=True):
@@ -259,6 +260,66 @@ class TestRepoDriftValidation:
             after_main_head=MAIN_AFTER_PULL,
             effective_head=WORKTREE_HEAD,
             git_error=True,
+        )
+        o = _make_orchestrator()
+        before = _before_state(MAIN_BEFORE)
+
+        err = o._validate_repo_context_after_run(before, system_account=None)
+        assert "Detected commits on the main repository" in err
+
+    def test_developer_branch_switch_is_allowed(self, monkeypatch):
+        # Regression for #1831: the developer checked out a feature branch on
+        # the main repo (same checkout, dev/single-user host) to work on a fix
+        # PR while a workflow was running. The main repo HEAD moved (because
+        # the feature branch has its own commits) but this is NOT an agent
+        # escape — the agent runs inside the worktree. The branch change
+        # (main -> fix/something) must skip the main-HEAD-drift check so the
+        # unpushed feature-branch commits don't trip after_on_remote=False.
+        _install_fake_gh(
+            monkeypatch,
+            after_main_head=MAIN_AFTER_LOCAL,  # forward, NOT on origin/main
+            effective_head=WORKTREE_HEAD,  # worktree did not move
+            moved_forward=True,
+            after_on_remote=False,  # would block without the branch guard
+            after_main_branch="fix/some-feature-pr",  # branch changed
+        )
+        o = _make_orchestrator()
+        before = _before_state(MAIN_BEFORE)  # before.branch == "main"
+
+        err = o._validate_repo_context_after_run(before, system_account=None)
+        assert err == ""
+
+    def test_developer_branch_switch_with_worktree_also_moved_is_allowed(self, monkeypatch):
+        # Branch switch + worktree also moved: both signals are benign. The
+        # branch-switch path returns "" before the worktree-moved check, but
+        # this test locks in that the branch-switch allow is not accidentally
+        # reversed when the worktree also moved.
+        _install_fake_gh(
+            monkeypatch,
+            after_main_head=MAIN_AFTER_LOCAL,
+            effective_head="cccccccc000000000000000000000000000000",  # worktree moved
+            after_on_remote=False,
+            after_main_branch="fix/another-pr",
+        )
+        o = _make_orchestrator()
+        before = _before_state(MAIN_BEFORE)
+
+        err = o._validate_repo_context_after_run(before, system_account=None)
+        assert err == ""
+
+    def test_same_branch_local_escape_still_blocked(self, monkeypatch):
+        # Negative control for the branch-switch fix: when the main repo is
+        # STILL on "main" (branch unchanged) and the agent committed locally
+        # (forward, NOT on origin/main), the escape must still be blocked.
+        # This locks in that the branch guard didn't accidentally disable the
+        # existing escape detection on the same branch.
+        _install_fake_gh(
+            monkeypatch,
+            after_main_head=MAIN_AFTER_LOCAL,
+            effective_head=WORKTREE_HEAD,
+            moved_forward=True,
+            after_on_remote=False,
+            after_main_branch="main",  # branch unchanged → check still applies
         )
         o = _make_orchestrator()
         before = _before_state(MAIN_BEFORE)


### PR DESCRIPTION
Fixes #1831 false-positive: post-run guardrail flagged workflow as agent escape when developer switched main repo to a feature branch during the run. Root cause, reflog evidence, and fix details in commit message.