### PR TITLE
fix: WebUI iframe authentication error handling

### DIFF
--- a/app/services/webui_manager.py
+++ b/app/services/webui_manager.py
@@ -445,8 +445,11 @@ class WebUIManager:
         """
         Generate an authentication token for a user.
 
-        Uses v2 format with timestamp for TTL support (Issue #1896):
+        Uses v2 format with timestamp for TTL support:
         v2:{user_id}:{port}:{timestamp}:{random}:{signature}
+
+        The v2 format is supported by qwen-code-webui PR #210.
+        Tokens expire after TOKEN_TTL_SECONDS (1800s = 30 minutes).
 
         Args:
             user_id: User ID.

--- a/frontend/src/components/features/Workspace.tsx
+++ b/frontend/src/components/features/Workspace.tsx
@@ -221,9 +221,21 @@ export const Workspace: React.FC = () => {
               const userWebUIResponse = await workspaceApi.getUserWebUIUrl();
               if (userWebUIResponse.success) {
                 setUserWebUI(userWebUIResponse);
+              } else {
+                // Log the error when API returns success: false
+                console.error('[Workspace] getUserWebUIUrl failed:', userWebUIResponse.error);
+                // In multi-user mode, token is required - show error to user
+                if (workspaceConfig.multi_user_mode) {
+                  setError('WebUI authentication failed. Please refresh the page.');
+                }
               }
-            } catch {
-              // In single-user mode, token may not be critical for local tabs
+            } catch (error) {
+              // Log the error when API call fails
+              console.error('[Workspace] getUserWebUIUrl error:', error);
+              // In multi-user mode, token is required for authentication
+              if (workspaceConfig.multi_user_mode) {
+                setError('WebUI authentication failed. Please refresh the page.');
+              }
             }
           }
           setLoadingStage('ready');
@@ -627,7 +639,13 @@ export const Workspace: React.FC = () => {
       };
 
       // Multi-user mode: use user-specific URL with token and openace_url
-      if (config.multi_user_mode && userWebUI?.success) {
+      if (config.multi_user_mode) {
+        // Issue #2037: In multi-user mode, token is required for WebUI authentication
+        // If userWebUI is not available, return empty string to prevent creating invalid iframe
+        if (!userWebUI?.success || !userWebUI.token) {
+          console.error('[Workspace] getEffectiveUrl: userWebUI not available in multi-user mode');
+          return '';
+        }
         const baseUrl = applyProjectsPath(userWebUI.url);
         const token = userWebUI.token;
         const openaceUrl = userWebUI.openace_url;
@@ -745,6 +763,13 @@ export const Workspace: React.FC = () => {
 
     // Skip if tabs already initialized
     if (tabsInitialized) return;
+
+    // In multi-user mode, userWebUI must be successfully loaded before creating tabs
+    // Otherwise iframe URL will lack the required token parameter (Issue #2037)
+    if (config.multi_user_mode && !userWebUI?.success) {
+      console.warn('[Workspace] Waiting for userWebUI in multi-user mode');
+      return;
+    }
 
     // Check for session restore parameters from URL
     // API returns: /work/workspace?sessionId=xxx&encodedProjectName=yyy&toolName=zzz


### PR DESCRIPTION
## Problem

When creating a new local session in workspace, the WebUI iframe failed with `Unauthorized: Invalid token` error due to incomplete frontend error handling.

Fixes #2037

## Root Cause Analysis

### Incomplete Frontend Error Handling
When `getUserWebUIUrl()` API failed (returns `success: false` or throws), the frontend:
- Did not log the error properly
- Continued to create iframe without token
- Users saw confusing "JSON parse" errors instead of clear error messages

## Solution

### Frontend: Add proper error handling (`Workspace.tsx`)

1. **Error logging and user notification**:
   - Log errors when `getUserWebUIUrl()` returns `success: false` or throws
   - Show user-friendly error message in multi-user mode

2. **Prevent invalid iframe creation**:
   - In `getEffectiveUrl()`: return empty string if `userWebUI` not available in multi-user mode
   - In `initializeTabs`: wait for `userWebUI` to load before creating tabs

### Backend: No changes required

The backend `generate_token()` continues to use **v2 format** with TTL support:
```
v2:{user_id}:{port}:{timestamp}:{random}:{signature}
```

This format is now supported by deploying [qwen-code-webui PR #210](https://github.com/ivycomputing/qwen-code-webui/pull/210) to the local installation, which adds v2 token validation with 30-minute TTL.

## Deployment Note

This fix was deployed together with [qwen-code-webui PR #210](https://github.com/ivycomputing/qwen-code-webui/pull/210) changes applied directly to the local installation. The WebUI token validation was patched to support both v1 and v2 formats.

## Testing

- ✅ WebUI iframe loads correctly
- ✅ Messages can be sent to AI
- ✅ No more `Unauthorized` errors
- ✅ Clear error message when authentication fails

## Related

- [qwen-code-webui PR #210](https://github.com/ivycomputing/qwen-code-webui/pull/210): Adds v2 token support with TTL validation
- [open-ace PR #2014](https://github.com/open-ace/open-ace/pull/2014): Fixed different issue (QueryParamSanitizer token redaction)