### PR TITLE
fix: merge worktree path macOS EPERM + claude-code Bash sandbox bypass (#1827/#1828/#1830)

### DIFF
--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -8795,7 +8795,15 @@ class AutonomousOrchestrator:
         # is cleared only AFTER git confirms removal, temp creation lives inside
         # the try, and a restore failure fails closed.
         main_gh = GitHubOps(project_path, system_account=system_account)
-        temp_wt_path = os.path.normpath(f"{project_path}/../merge-{self._workflow_id[:8]}")
+        # Place the temp merge worktree inside the project's .worktrees/ dir
+        # (the same convention as normal workflow worktrees — see
+        # _get_preferred_worktree_path). The previous ../merge-{id} sibling
+        # path failed on macOS with EPERM "could not create leading
+        # directories" because the server process lacks TCC/write permission
+        # to create new directories directly under ~/workspace (#1827).
+        temp_wt_path = os.path.normpath(
+            os.path.join(project_path, ".worktrees", f"merge-{self._workflow_id[:8]}")
+        )
         original_removed = False
         temp_created = False
         try:

--- a/remote-agent/cli_adapters/claude_code.py
+++ b/remote-agent/cli_adapters/claude_code.py
@@ -76,14 +76,25 @@ class ClaudeCodeAdapter(BaseCLIAdapter):
         if model:
             args.extend(["--model", model])
 
-        # Map internal permission_mode to Claude CLI --permission-mode flag
-        # Choices: "acceptEdits", "auto", "bypassPermissions", "default"
-        if permission_mode:
+        # Map internal permission_mode to Claude CLI flags.
+        #
+        # bypass/full-auto: use --dangerously-skip-permissions, the only flag
+        # that disables the Bash tool's macOS sandbox (sandbox-exec profile).
+        # --permission-mode bypassPermissions alone still enforces the Bash
+        # sandbox, which blocks writes to ~/.claude/session-env/ and prevents
+        # the agent from running ANY shell command — including tests (#1828,
+        # #1830). This mirrors the codex adapter's use of
+        # --dangerously-bypass-approvals-and-sandbox for auto mode. The
+        # settings.json skipDangerousModePermissionPrompt flag suppresses the
+        # interactive confirmation that this flag would otherwise require.
+        # acceptEdits/auto: keep the sandbox; these modes are for safer
+        # interactive-style runs where the Bash sandbox is desirable.
+        if permission_mode in ("bypass", "full-auto"):
+            args.append("--dangerously-skip-permissions")
+        elif permission_mode:
             mode_map = {
                 "auto-edit": "acceptEdits",
                 "auto": "auto",
-                "bypass": "bypassPermissions",
-                "full-auto": "bypassPermissions",
             }
             cli_mode = mode_map.get(permission_mode)
             if cli_mode:

--- a/tests/issues/2041/test_worktree_transition_safety.py
+++ b/tests/issues/2041/test_worktree_transition_safety.py
@@ -83,7 +83,9 @@ def _db_updates(o):
 def _temp_path(wf):
     import os
 
-    return os.path.normpath(f"{wf['project_path']}/../merge-{wf['workflow_id'][:8]}")
+    return os.path.normpath(
+        os.path.join(wf["project_path"], ".worktrees", f"merge-{wf['workflow_id'][:8]}")
+    )
 
 
 class TestWorktreeTransitionSafety:

--- a/tests/issues/761/test_planning_restriction.py
+++ b/tests/issues/761/test_planning_restriction.py
@@ -126,6 +126,90 @@ class TestClaudeCodeAdapterAllowedTools:
         assert "--allowedTools" not in args
 
 
+class TestClaudeCodeAdapterPermissionMode:
+    """Verify Claude Code adapter maps permission_mode to the right CLI flags.
+
+    bypass/full-auto must use --dangerously-skip-permissions (the only way to
+    disable the macOS Bash sandbox that blocks ~/.claude/session-env/ writes,
+    #1828/#1830). acceptEdits/auto keep --permission-mode (sandbox stays on).
+    """
+
+    @pytest.fixture(autouse=True)
+    def _add_remote_agent_to_path(self):
+        import os
+        import sys
+
+        ra = os.path.normpath(
+            os.path.join(os.path.dirname(__file__), "..", "..", "..", "remote-agent")
+        )
+        if ra not in sys.path:
+            sys.path.insert(0, ra)
+
+    def test_bypass_uses_dangerously_skip_permissions(self):
+        from cli_adapters.claude_code import ClaudeCodeAdapter
+
+        adapter = ClaudeCodeAdapter()
+        args = adapter.build_start_args(
+            session_id="sess-123",
+            project_path="/tmp/project",
+            permission_mode="bypass",
+        )
+        assert "--dangerously-skip-permissions" in args
+        # Should NOT also pass --permission-mode bypassPermissions
+        assert "--permission-mode" not in args
+
+    def test_full_auto_uses_dangerously_skip_permissions(self):
+        from cli_adapters.claude_code import ClaudeCodeAdapter
+
+        adapter = ClaudeCodeAdapter()
+        args = adapter.build_start_args(
+            session_id="sess-123",
+            project_path="/tmp/project",
+            permission_mode="full-auto",
+        )
+        assert "--dangerously-skip-permissions" in args
+        assert "--permission-mode" not in args
+
+    def test_auto_edit_uses_accept_edits_mode(self):
+        from cli_adapters.claude_code import ClaudeCodeAdapter
+
+        adapter = ClaudeCodeAdapter()
+        args = adapter.build_start_args(
+            session_id="sess-123",
+            project_path="/tmp/project",
+            permission_mode="auto-edit",
+        )
+        assert "--permission-mode" in args
+        idx = args.index("--permission-mode")
+        assert args[idx + 1] == "acceptEdits"
+        assert "--dangerously-skip-permissions" not in args
+
+    def test_auto_uses_auto_mode(self):
+        from cli_adapters.claude_code import ClaudeCodeAdapter
+
+        adapter = ClaudeCodeAdapter()
+        args = adapter.build_start_args(
+            session_id="sess-123",
+            project_path="/tmp/project",
+            permission_mode="auto",
+        )
+        assert "--permission-mode" in args
+        idx = args.index("--permission-mode")
+        assert args[idx + 1] == "auto"
+        assert "--dangerously-skip-permissions" not in args
+
+    def test_no_permission_mode_adds_neither_flag(self):
+        from cli_adapters.claude_code import ClaudeCodeAdapter
+
+        adapter = ClaudeCodeAdapter()
+        args = adapter.build_start_args(
+            session_id="sess-123",
+            project_path="/tmp/project",
+        )
+        assert "--permission-mode" not in args
+        assert "--dangerously-skip-permissions" not in args
+
+
 class TestQwenCodeAdapterAllowedTools:
     """Verify Qwen Code adapter still works with --allowed-tools."""
 


### PR DESCRIPTION
## Summary

Two independent fixes blocking autonomous workflows #1827, #1828, #1830 on macOS.

### 1. Temp merge worktree path (orchestrator.py) — #1827

The temp merge worktree was created at `{project_path}/../merge-{workflow_id}` (a sibling of the project). On macOS this fails with:
```
git worktree add ... failed (exit 128):
fatal: could not create leading directories of '.../merge-xxx/.git': Operation not permitted
```
The server process lacks TCC/write permission to create new directories directly under `~/workspace`.

**Fix**: place the temp worktree inside the project's `.worktrees/` dir — the same convention already used by normal workflow worktrees (`_get_preferred_worktree_path`).

### 2. Claude Code Bash sandbox bypass (claude_code.py adapter) — #1828/#1830

Claude Code 2.x's Bash tool runs commands in a macOS `sandbox-exec` profile that blocks writes to `~/.claude/session-env/`. The agent cannot create its session shell-state directory, so **no shell command can execute** — including tests. The agent confirmed `dangerouslyDisableSandbox: true` cannot bypass it.

`--permission-mode bypassPermissions` alone still enforces the Bash sandbox. The only way to disable it is `--dangerously-skip-permissions`.

**Fix**: for `bypass`/`full-auto` permission modes, use `--dangerously-skip-permissions` instead of `--permission-mode bypassPermissions`. This mirrors the codex adapter's `--dangerously-bypass-approvals-and-sandbox` for `auto` mode. The `settings.json` `skipDangerousModePermissionPrompt` flag suppresses the interactive confirmation. `acceptEdits`/`auto` modes keep the sandbox.

## Test plan
- [x] 5 new `TestClaudeCodeAdapterPermissionMode` tests (bypass/full-auto/auto-edit/auto/none)
- [x] Updated `test_worktree_transition_safety.py` path assertion
- [x] All 13 worktree/adapter tests pass
- [ ] Independent agent review

## Workflow impact
After merge + deploy:
- #1827: retry at merge phase — temp worktree now creates inside `.worktrees/`
- #1828/#1830: change `permission_mode` to `bypass` in DB, then retry — adapter will pass `--dangerously-skip-permissions`