### PR TITLE
fix(autonomous): accept text-based test pass evidence when tool_result capture is incomplete (#1830)

### DIFF
--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -7048,7 +7048,20 @@ class AutonomousOrchestrator:
         has_passing_tool_result = _has_passing_test_tool_result(
             test_result.event_log or [], framework_type
         )
-        tests_actually_run = has_passing_tool_result
+        # Fallback: if the event log's tool_result capture is incomplete (e.g.
+        # Claude Code stream-json truncation on long pytest output, or tool
+        # results exceeding the per-event size limit), accept text-based
+        # evidence: a real test tool call in the event log PLUS a "N passed"
+        # pattern in the agent's visible text. The tool call proves the agent
+        # invoked a test command; the "N passed" pattern proves it reported
+        # passing results. Together they provide strong evidence that tests
+        # ran and passed, even without structured tool_result events (#1830).
+        has_text_pass_evidence = has_test_result and bool(
+            re.search(r"\b[1-9]\d*\s+passed\b", test_response_text, re.IGNORECASE)
+        )
+        tests_actually_run = has_passing_tool_result or (
+            has_test_tool_call and has_text_pass_evidence
+        )
         test_result_inconclusive = (
             test_result.success
             and (has_test_tool_call or has_test_result or test_status_tag in ("passed", "failed"))

--- a/tests/unit/test_autonomous_ci_guardrails.py
+++ b/tests/unit/test_autonomous_ci_guardrails.py
@@ -2093,3 +2093,62 @@ def test_model_pass_summary_without_tool_result_is_inconclusive():
     updates = [call.args[0] for call in orch._update_workflow.call_args_list]
     assert any(update.get("test_retries") == 1 for update in updates)
     assert not any(update.get("status") == "pr_review" for update in updates)
+
+
+def test_text_pass_evidence_fallback_when_tool_result_missing():
+    """#1830: tool_result capture can be incomplete (stream-json truncation,
+    per-event size limit). When the agent invoked a real test command AND the
+    visible text contains a "N passed" pattern, accept it as strong evidence
+    that tests ran and passed — even without structured tool_result events."""
+    from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+    orch = AutonomousOrchestrator.__new__(AutonomousOrchestrator)
+    orch._workflow_id = "wf-1830-fallback"
+    orch.repo = MagicMock()
+    orch._create_milestone = MagicMock(return_value={"milestone_id": "ms-test"})
+    orch._build_test_execution_context = MagicMock(return_value="targeted")
+    orch._accumulate_tokens = MagicMock()
+    orch._post_github_comment = MagicMock()
+    orch._emit = MagicMock()
+    orch._update_workflow = MagicMock()
+    # Agent invoked pytest (tool_calls present) and text reports "162 passed",
+    # but event_log has no tool_result entry (truncated/incomplete capture).
+    orch._run_agent = MagicMock(
+        return_value=AgentTaskResult(
+            success=True,
+            response_text="Ran the test suite.\n\n162 passed in 3.45s",
+            tool_calls=[
+                {
+                    "tool": {
+                        "name": "Bash",
+                        "input": {"command": "python -m pytest"},
+                        "id": "tool-1830-1",
+                    }
+                }
+            ],
+            event_log=[
+                {
+                    "type": "tool_use",
+                    "tool_name": "Bash",
+                    "tool_input": {"command": "python -m pytest"},
+                    "tool_use_id": "tool-1830-1",
+                },
+                # NOTE: no tool_result entry — simulates stream-json truncation
+            ],
+        )
+    )
+    wf = {
+        "workflow_id": "wf-1830-fallback",
+        "project_path": "/tmp/repo",
+        "worktree_path": "/tmp/repo",
+        "cli_tool": "claude-code",
+        "dev_round": 1,
+        "branch_name": "auto-dev/wf-1830-fallback",
+    }
+
+    orch._run_test_phase(wf, 1, MagicMock())
+
+    updates = [call.args[0] for call in orch._update_workflow.call_args_list]
+    # Should advance to pr_review (tests considered as run), NOT be inconclusive
+    assert any(update.get("status") == "pr_review" for update in updates)
+    assert not any(update.get("test_retries") == 1 for update in updates)


### PR DESCRIPTION
## Problem

Workflow #1830 failed with `Test execution is inconclusive: a test command was invoked, but no structured TEST_STATUS or recognizable pass/fail output was captured` even though the agent's visible text clearly reported `162 passed in 3.45s`.

**Root cause:** Claude Code's stream-json output can truncate long pytest output or exceed the per-event size limit, causing the event_log's `tool_result` capture to be incomplete. The previous logic (`tests_actually_run = has_passing_tool_result`) required a structured passing `tool_result` event to consider tests as actually run, so legitimate test runs were incorrectly flagged as inconclusive.

## Fix

Add a text-evidence fallback in `_run_test_phase`:

```python
has_text_pass_evidence = has_test_result and bool(
    re.search(r"\b[1-9]\d*\s+passed\b", test_response_text, re.IGNORECASE)
)
tests_actually_run = has_passing_tool_result or (
    has_test_tool_call and has_text_pass_evidence
)
```

When the event log has a real test tool call **AND** the agent's visible text contains a `N passed` pattern (N ≥ 1), accept it as strong evidence that tests ran and passed:
- The **tool call** proves the agent invoked a test command (not a hallucination).
- The `N passed` pattern proves it reported passing results.

This is intentionally stricter than `has_test_result` alone — `has_test_result` can be True from session-start markers like `collected 5 items` which don't prove passing. The dedicated `\b[1-9]\d*\s+passed\b` regex requires an actual positive pass count.

## Test

Added `test_text_pass_evidence_fallback_when_tool_result_missing` verifying the #1830 scenario: tool_call present, text contains `162 passed`, but no `tool_result` event in event_log → workflow advances to `pr_review` (not inconclusive).

Existing regression tests `test_test_tool_call_without_result_is_inconclusive` and `test_model_pass_summary_without_tool_result_is_inconclusive` still pass — the fallback only applies when **both** a real tool call AND a `N passed` text pattern are present.