### PR TITLE
fix(autonomous): SIGKILL-resilient recovery for worktree transition (#2050)

### DIFF
--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -56,6 +56,15 @@ class UpstreamQuotaPaused(WorkflowPaused):
     """Control-flow signal used after persisting a hard-quota pause."""
 
 
+class _ReconcileFailed(Exception):
+    """Internal signal that worktree transition reconcile must fail closed.
+
+    Raised from the reconcile helper body when git registry/disk state is
+    ambiguous or ownership cannot be proven. The caller catches it and writes
+    ``recovery_failed`` + a usable message (#2050).
+    """
+
+
 # Completion keywords to detect in issue comments
 COMPLETION_KEYWORDS = [
     "开发完成",
@@ -1284,6 +1293,14 @@ class AutonomousOrchestrator:
         """
         wf = self.workflow
         if not self._gh and wf:
+            # Reconcile an interrupted transition before binding, so we never
+            # bind GitHubOps to the main repo (HEAD=main) while a worktree
+            # transition is mid-flight (#2050). recovery_failed also short-
+            # circuits: nothing should run against git in that state.
+            ts = wf.get("worktree_transition_state")
+            if ts and ts != "recovery_failed":
+                self._reconcile_worktree_transition(wf)
+                wf = self.workflow
             worktree_path = wf.get("worktree_path", "")
             project_path = wf.get("project_path", "")
             # Resolve system_account for multi-user permission isolation (Issue #1395)
@@ -1779,6 +1796,15 @@ class AutonomousOrchestrator:
         # which fails and turns a retried merge into a hard failure. Only a
         # non-empty path whose dir is gone represents external loss (#814).
         if strategy != "worktree" or not project_path or not worktree_path:
+            # Hard guard (#2050): a transition still in progress (anything other
+            # than recovery_failed) must NOT fall back to project_path — that
+            # would run a phase against the main checkout (HEAD=main). The
+            # caller is required to reconcile first.
+            ts = wf.get("worktree_transition_state")
+            if ts and ts != "recovery_failed":
+                raise RuntimeError(
+                    "worktree transition in progress " f"(state={ts!r}); reconcile before execution"
+                )
             return worktree_path or project_path
 
         canonical = os.path.realpath(worktree_path)
@@ -5194,6 +5220,16 @@ class AutonomousOrchestrator:
         logger.info("Advancing workflow %s phase=%s", self._workflow_id[:8], phase)
 
         try:
+            # Reconcile an interrupted merge-conflict worktree transition BEFORE
+            # _ensure_worktree / _get_gh, so a SIGKILLed transition never lets a
+            # later phase fall back to the main checkout (#2050). Order is fixed:
+            # reconcile -> ensure_worktree -> bind GitHubOps -> phase execute.
+            if wf.get("worktree_transition_state"):
+                self._reconcile_worktree_transition(wf)
+                wf = self.workflow  # reconcile may have changed worktree_path
+                if wf.get("status") == "failed":
+                    # Reconcile failed closed; do not run a phase.
+                    return
             # Self-heal the worktree before any downstream phase runs. A
             # retried/resumed workflow may find its worktree dir gone (cleaned
             # up after a prior failure), which previously launched the agent
@@ -8868,12 +8904,30 @@ class AutonomousOrchestrator:
         )
         original_removed = False
         temp_created = False
+        # The path to restore at the end. Prefer the live worktree_path, fall
+        # back to preferred_worktree_path (it is what _ensure_worktree recreates
+        # from if worktree_path is empty). Captured up front so the journal can
+        # restore even if the process is SIGKILLed mid-transition (#2050).
+        original_path_for_journal = worktree_path or wf.get("preferred_worktree_path") or ""
         try:
             if worktree_path:
+                # Persist the removal intent BEFORE the git side effect so a
+                # SIGKILL anywhere in this block leaves the journal able to
+                # reconcile (#2050). transition_original_path records the path
+                # to restore; transition_temp_path records the temp to tear down.
+                self._set_transition_state(
+                    "removing_original",
+                    original_path=original_path_for_journal,
+                    temp_path=temp_wt_path,
+                )
                 # Fail closed on removal failure: only clear the DB once git has
                 # actually freed the branch, and never assume removal succeeded.
                 self._remove_worktree_idempotent(main_gh, worktree_path)
-                self._update_workflow({"worktree_path": ""})
+                # One atomic write: clear worktree_path AND advance state so the
+                # empty path is never observable without its transition context.
+                self._update_workflow(
+                    {"worktree_path": "", "worktree_transition_state": "original_removed"}
+                )
                 # The caller's gh still points at the now-deleted worktree dir
                 # as its cwd. Rebind it (and cached self._gh) to the main repo
                 # so later cleanup doesn't run subprocess with a gone cwd (#1107).
@@ -8887,6 +8941,10 @@ class AutonomousOrchestrator:
             main_gh.add_worktree(temp_wt_path, branch_name)
             logger.info("Created temporary merge worktree at %s", temp_wt_path)
             temp_created = True
+            # Advance the journal: a successful add_worktree is the proof the
+            # temp is attached. If the process dies here, reconcile re-queries
+            # the registry to observe the temp and tear it down (#2050).
+            self._set_transition_state("temp_attached")
 
             # All subsequent git ops run inside the temp worktree.
             wt_gh = GitHubOps(temp_wt_path, system_account=system_account)
@@ -9209,6 +9267,10 @@ class AutonomousOrchestrator:
             # restore would error. A restore failure fails CLOSED — never let a
             # later phase run on the main checkout.
             if original_removed:
+                # Mark the restore intent before doing git work, so a SIGKILL
+                # during restore converges on the `restoring` state and the
+                # reconcile resumes idempotently (#2050).
+                self._set_transition_state("restoring")
                 try:
                     # If remove_worktree succeeded earlier, the dir is gone
                     # and we recreate it. If it failed, the dir is still
@@ -9217,7 +9279,9 @@ class AutonomousOrchestrator:
                     if not main_gh.path_exists_as_user(git_file, file_only=True):
                         main_gh.add_worktree(worktree_path, branch_name)
                     self._verify_worktree_restored(main_gh, worktree_path, branch_name)
-                    self._update_workflow({"worktree_path": worktree_path})
+                    # Converge in a single write: restore worktree_path AND clear
+                    # the journal together so they can never disagree (#2050).
+                    self._clear_transition_journal(worktree_path=worktree_path)
                     self._gh = GitHubOps(worktree_path, system_account=system_account)
                     logger.info("Restored workflow worktree at %s", worktree_path)
                 except Exception as e:
@@ -9227,15 +9291,323 @@ class AutonomousOrchestrator:
                         e,
                         exc_info=True,
                     )
-                    self._update_workflow(
-                        {
-                            "status": "failed",
-                            "error_message": (
-                                f"worktree restore failed after merge resolution: {e}"
-                            ),
-                        }
+                    # Fail CLOSED and keep the journal + metadata for diagnosis.
+                    self._fail_transition_closed(
+                        f"worktree restore failed after merge resolution: {e}",
+                        error_message=(f"worktree restore failed after merge resolution: {e}"),
                     )
                     raise
+
+    # ── Worktree transition journal (Issue #2050) ───────────────────
+    # These helpers persist a minimal crash-recovery journal so a SIGKILL at
+    # any git/DB boundary can be reconciled from the persisted intent + the
+    # observed git registry/disk state. They never touch branch refs (that is
+    # #2042's head-authority job).
+
+    def _set_transition_state(
+        self,
+        state: str,
+        *,
+        original_path: str | None = None,
+        temp_path: str | None = None,
+        error: str | None = None,
+    ) -> None:
+        """Advance the persisted worktree transition journal (#2050).
+
+        Writes ``worktree_transition_state`` and refreshes
+        ``transition_updated_at``. ``transition_started_at`` is stamped once
+        when the journal begins (state moves out of NULL). Path fields are only
+        overwritten when provided, so a mid-transition update does not clobber
+        the original/temp paths captured at the start.
+        """
+        wf = self.workflow
+        updates: dict = {"worktree_transition_state": state}
+        now = datetime.now(timezone.utc).isoformat()
+        updates["transition_updated_at"] = now
+        if not wf.get("transition_started_at"):
+            updates["transition_started_at"] = now
+        if original_path is not None:
+            updates["transition_original_path"] = original_path
+        if temp_path is not None:
+            updates["transition_temp_path"] = temp_path
+        updates["transition_error"] = error
+        self._update_workflow(updates)
+
+    def _clear_transition_journal(self, *, worktree_path: str | None = None) -> None:
+        """Converge the journal to the stable state (#2050).
+
+        Clears every journal field and optionally restores ``worktree_path`` in
+        the SAME write, so the cleared path and the cleared state can never be
+        observed separately.
+        """
+        updates: dict = {
+            "worktree_transition_state": None,
+            "transition_original_path": None,
+            "transition_temp_path": None,
+            "transition_error": None,
+            "transition_started_at": None,
+            "transition_updated_at": datetime.now(timezone.utc).isoformat(),
+        }
+        if worktree_path is not None:
+            updates["worktree_path"] = worktree_path
+        self._update_workflow(updates)
+
+    def _fail_transition_closed(self, reason: str, *, error_message: str | None = None) -> None:
+        """Mark the transition unrecoverable and fail the workflow closed (#2050).
+
+        Keeps the journal + paths for diagnosis; no later phase runs. The status
+        mirrors the in-process restore-failure precedent (status=failed).
+        """
+        updates: dict = {
+            "worktree_transition_state": "recovery_failed",
+            "transition_error": reason,
+            "transition_updated_at": datetime.now(timezone.utc).isoformat(),
+        }
+        if error_message:
+            updates["error_message"] = error_message
+        updates["status"] = "failed"
+        self._update_workflow(updates)
+
+    @staticmethod
+    def _is_registered_on_branch(entries: list[dict], path: str, branch: str) -> bool:
+        """True if ``path`` is a registered worktree on ``branch``."""
+        for w in entries:
+            if w.get("path") == path:
+                actual = w.get("branch")
+                return actual in (branch, f"refs/heads/{branch}")
+        return False
+
+    def _verify_worktree_registered(self, gh: GitHubOps, path: str, branch: str) -> None:
+        """Confirm ``path`` is registered in ``git worktree list`` on ``branch``.
+
+        Distinct from ``_verify_worktree_restored`` only in naming; both check
+        the registry, but this one is used to confirm the temp was actually
+        attached before advancing the journal (#2050).
+        """
+        entries = gh.list_worktrees()
+        if not self._is_registered_on_branch(entries, path, branch):
+            raise RuntimeError(
+                f"worktree {path} not registered on branch {branch!r} " f"(registry: {entries!r})"
+            )
+
+    def _path_within_worktrees_root(self, path: str, project_path: str) -> bool:
+        """True if ``path`` lives under ``<project_path>/.worktrees`` (#2050).
+
+        Used by reconcile to refuse operating on foreign / out-of-root paths
+        (fail closed instead of touching worktrees we cannot prove we own).
+        """
+        if not path or not project_path:
+            return False
+        try:
+            root = os.path.normpath(os.path.join(project_path, ".worktrees"))
+            return os.path.commonpath([root, os.path.normpath(path)]) == root
+        except ValueError:
+            # commonpath raises on different drives (Windows) / absolute mismatches.
+            return False
+
+    def _reconcile_worktree_transition(self, wf: dict) -> None:
+        """Recover an interrupted merge-conflict worktree transition (#2050).
+
+        Single idempotent entry point. Combines the persisted transition intent
+        (``worktree_transition_state`` + path fields) with the OBSERVED git
+        registry / disk state to either restore the original worktree to a
+        stable state, or fail the workflow closed. Never resets/deletes/recreates
+        branch refs — that is #2042's head-authority job.
+
+        Goal is to discard any half-finished temp worktree and get back to the
+        stable original worktree so the next round can re-run merge/conflict from
+        a known-good state. A SIGKILL cannot prove the temp's edits/commits/push
+        were complete or trustworthy.
+        """
+        state = (wf.get("worktree_transition_state") or "").strip()
+        if not state:
+            return  # stable, nothing to reconcile
+        if state == "recovery_failed":
+            # Already failed closed; do not start an agent or touch git.
+            logger.warning(
+                "Workflow %s is in recovery_failed; skipping reconcile",
+                self._workflow_id[:8],
+            )
+            return
+
+        project_path = wf.get("project_path", "") or ""
+        branch_name = wf.get("branch_name", "") or ""
+        original_path = (
+            wf.get("transition_original_path")
+            or wf.get("preferred_worktree_path")
+            or wf.get("worktree_path")
+            or ""
+        )
+        temp_path = wf.get("transition_temp_path") or ""
+
+        # Fail closed if we cannot confirm the original path or its root. We
+        # must know what to restore before touching git.
+        if not original_path:
+            self._fail_transition_closed(
+                "cannot reconcile: transition_original_path is empty "
+                "and no preferred/worktree path is available"
+            )
+            return
+        if not branch_name:
+            self._fail_transition_closed(
+                "cannot reconcile: branch_name is empty, cannot verify worktree"
+            )
+            return
+        # Refuse foreign roots: only operate inside the project's .worktrees dir.
+        if not self._path_within_worktrees_root(original_path, project_path):
+            self._fail_transition_closed(
+                f"cannot reconcile: original_path {original_path!r} is outside "
+                f"the project worktrees root"
+            )
+            return
+        if temp_path and not self._path_within_worktrees_root(temp_path, project_path):
+            self._fail_transition_closed(
+                f"cannot reconcile: temp_path {temp_path!r} is outside "
+                f"the project worktrees root"
+            )
+            return
+
+        system_account = None
+        user_id = wf.get("user_id")
+        if user_id:
+            try:
+                from app.repositories.user_repo import UserRepository
+
+                user = UserRepository().get_user_by_id(user_id)
+                if user:
+                    system_account = user.get("system_account")
+            except Exception as e:  # noqa: BLE001
+                logger.warning("Could not resolve system_account for reconcile: %s", e)
+        main_gh = GitHubOps(project_path, system_account=system_account)
+
+        try:
+            entries = main_gh.list_worktrees()
+        except Exception as e:  # noqa: BLE001
+            # Cannot safely judge ownership without the registry → fail closed.
+            self._fail_transition_closed(f"git worktree list failed: {e}")
+            return
+
+        def _registered(path: str) -> bool:
+            return any(w.get("path") == path for w in entries)
+
+        def _on_branch(path: str) -> bool:
+            return self._is_registered_on_branch(entries, path, branch_name)
+
+        try:
+            if state == "removing_original":
+                if _registered(original_path):
+                    if _on_branch(original_path):
+                        # Original never actually removed — nothing to undo.
+                        self._clear_transition_journal(worktree_path=original_path)
+                        logger.info(
+                            "Reconcile %s: original still registered; cleared journal",
+                            state,
+                        )
+                        return
+                    # Registered but wrong branch → ambiguous, fail closed.
+                    self._fail_transition_closed(
+                        f"original worktree {original_path!r} registered on "
+                        f"unexpected branch (expected {branch_name!r})"
+                    )
+                    return
+                # Original gone → removal happened. Clean any temp, then restore.
+                self._reconcile_cleanup_temp_and_restore(
+                    main_gh, entries, temp_path, original_path, branch_name, system_account
+                )
+                return
+
+            if state in ("original_removed", "temp_attached"):
+                # Either way: tear down any temp, then restore the original.
+                self._reconcile_cleanup_temp_and_restore(
+                    main_gh, entries, temp_path, original_path, branch_name, system_account
+                )
+                return
+
+            if state == "restoring":
+                if _on_branch(original_path):
+                    # Restore already completed before the SIGKILL; converge.
+                    self._clear_transition_journal(worktree_path=original_path)
+                    self._gh = GitHubOps(original_path, system_account=system_account)
+                    logger.info("Reconcile restoring: original already restored; converged")
+                    return
+                # Otherwise resume the idempotent restore (also cleans temp).
+                self._reconcile_cleanup_temp_and_restore(
+                    main_gh, entries, temp_path, original_path, branch_name, system_account
+                )
+                return
+
+            # Unknown state → fail closed rather than guess.
+            self._fail_transition_closed(f"cannot reconcile: unknown transition state {state!r}")
+        except _ReconcileFailed as e:
+            self._fail_transition_closed(str(e))
+        except Exception as e:  # noqa: BLE001
+            logger.error("Reconcile failed for %s: %s", self._workflow_id[:8], e, exc_info=True)
+            self._fail_transition_closed(f"reconcile raised: {e}")
+
+    def _reconcile_cleanup_temp_and_restore(
+        self,
+        main_gh: GitHubOps,
+        entries: list[dict],
+        temp_path: str,
+        original_path: str,
+        branch_name: str,
+        system_account,
+    ) -> None:
+        """Shared reconcile body: remove temp (if any), restore original (#2050).
+
+        Validates ownership before each git mutation. Raises ``_ReconcileFailed``
+        on ambiguity so the caller fails closed with a usable message.
+        """
+        # 1. Tear down a lingering temp worktree. It holds untrusted half-done
+        #    agent work and (if registered) blocks the branch.
+        if temp_path:
+            temp_entry = next((w for w in entries if w.get("path") == temp_path), None)
+            if temp_entry is not None:
+                actual_branch = temp_entry.get("branch")
+                if actual_branch not in (branch_name, f"refs/heads/{branch_name}"):
+                    # A temp registered on the wrong branch is not ours to remove.
+                    raise _ReconcileFailed(
+                        f"temp worktree {temp_path!r} registered on unexpected "
+                        f"branch {actual_branch!r} (expected {branch_name!r})"
+                    )
+                self._remove_worktree_idempotent(main_gh, temp_path)
+                logger.info("Reconcile removed temp worktree %s", temp_path)
+                # Refresh the registry view before checking the original.
+                entries = main_gh.list_worktrees()
+
+        # 2. Restore the original. If it is already registered on the right
+        #    branch, the restore already happened — just verify. Otherwise
+        #    re-attach the existing branch to its path. We do NOT create or
+        #    reset the branch here (#2042 owns head authority): add_worktree on
+        #    a missing branch would error, which we fail closed on.
+        original_entry = next((w for w in entries if w.get("path") == original_path), None)
+        if original_entry is not None:
+            actual_branch = original_entry.get("branch")
+            if actual_branch not in (branch_name, f"refs/heads/{branch_name}"):
+                raise _ReconcileFailed(
+                    f"original worktree {original_path!r} registered on unexpected "
+                    f"branch {actual_branch!r} (expected {branch_name!r})"
+                )
+        else:
+            # Not registered → re-attach. add_worktree on the existing branch.
+            git_file = os.path.join(original_path, ".git")
+            if not main_gh.path_exists_as_user(git_file, file_only=True):
+                try:
+                    main_gh.add_worktree(original_path, branch_name)
+                except GitHubOpsError as e:
+                    # Most commonly: branch ref missing/divergent. That is #2042's
+                    # decision, not ours — fail closed rather than recreate it.
+                    raise _ReconcileFailed(
+                        f"cannot re-attach original worktree {original_path!r} "
+                        f"to branch {branch_name!r} (branch missing or "
+                        f"divergent — needs #2042 head authority): {e}"
+                    )
+        # Verify registration + branch on the canonical gh view.
+        self._verify_worktree_restored(main_gh, original_path, branch_name)
+        # Converge DB path + journal in one write, rebind cached gh.
+        self._clear_transition_journal(worktree_path=original_path)
+        self._gh = GitHubOps(original_path, system_account=system_account)
+        logger.info("Reconcile restored original worktree at %s", original_path)
 
     def _remove_worktree_idempotent(self, gh: GitHubOps, path: str) -> None:
         """Remove a worktree, treating "already absent" as success (Issue #2041).

--- a/app/repositories/autonomous_repo.py
+++ b/app/repositories/autonomous_repo.py
@@ -91,6 +91,13 @@ class AutonomousWorkflowRepository:
         "ci_diagnostics_attempts",
         "last_ci_failure_signature",
         "last_ci_failure_head_sha",
+        # Worktree transition journal for SIGKILL-resilient recovery (#2050).
+        "worktree_transition_state",
+        "transition_original_path",
+        "transition_temp_path",
+        "transition_error",
+        "transition_started_at",
+        "transition_updated_at",
     }
     ALLOWED_MILESTONE_FIELDS = {
         "phase",
@@ -160,6 +167,30 @@ class AutonomousWorkflowRepository:
                     """
                 ),
                 list(active_statuses),
+            )
+            cols = [d[0] for d in cursor.description]
+            return [dict(zip(cols, row)) for row in cursor.fetchall()]
+        finally:
+            conn.close()
+
+    def get_workflows_with_active_transition(self) -> list[dict]:
+        """Find workflows with an in-progress worktree transition (#2050).
+
+        A non-NULL ``worktree_transition_state`` means the merge-conflict
+        worktree transition was interrupted (SIGKILL / restart / crash) before
+        the journal was cleared. The startup reconcile walks these to restore
+        the original worktree or fail closed.
+        """
+        conn = self.db.get_connection()
+        try:
+            cursor = conn.cursor()
+            cursor.execute(
+                adapt_sql(
+                    """
+                    SELECT * FROM autonomous_workflows
+                    WHERE worktree_transition_state IS NOT NULL
+                    """
+                )
             )
             cols = [d[0] for d in cursor.description]
             return [dict(zip(cols, row)) for row in cursor.fetchall()]

--- a/app/services/autonomous_scheduler.py
+++ b/app/services/autonomous_scheduler.py
@@ -822,10 +822,68 @@ def _cleanup_orphan_processes():
         logger.error("Orphan process cleanup failed: %s", e, exc_info=True)
 
 
+def _reconcile_pending_transitions():
+    """Recover interrupted merge-conflict worktree transitions (#2050).
+
+    Walks every workflow with a non-NULL ``worktree_transition_state`` (left
+    behind by a SIGKILL / restart mid-transition) and runs the same idempotent
+    ``_reconcile_worktree_transition`` entry point that ``advance()`` uses, so
+    startup, advance, and manual resume share one reconciler. Each workflow is
+    isolated: a failure fails that workflow closed (recovery_failed) without
+    blocking the others.
+    """
+    logger.info("Reconciling interrupted worktree transitions...")
+
+    try:
+        from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+        from app.repositories.autonomous_repo import AutonomousWorkflowRepository
+        from app.repositories.database import Database
+
+        repo = AutonomousWorkflowRepository(Database())
+        pending = repo.get_workflows_with_active_transition()
+        if not pending:
+            logger.info("No interrupted worktree transitions found")
+            return
+
+        for wf in pending:
+            wf_id = wf.get("workflow_id")
+            if not isinstance(wf_id, str) or not wf_id:
+                continue
+            try:
+                orchestrator = AutonomousOrchestrator(wf_id)
+                orchestrator._reconcile_worktree_transition(wf)
+            except Exception as e:  # noqa: BLE001
+                # The reconciler itself should fail closed internally; this catch
+                # is a last resort so one bad workflow does not block the rest.
+                logger.error(
+                    "Reconcile raised for workflow %s: %s",
+                    (wf_id or "")[:8],
+                    e,
+                    exc_info=True,
+                )
+                try:
+                    repo.update_workflow(
+                        wf_id,
+                        {
+                            "worktree_transition_state": "recovery_failed",
+                            "transition_error": f"reconcile raised: {e}",
+                            "status": "failed",
+                        },
+                    )
+                except Exception:  # noqa: BLE001
+                    logger.error("Could not persist recovery_failed for %s", (wf_id or "")[:8])
+
+        logger.info("Reconciled %d interrupted worktree transition(s)", len(pending))
+    except Exception as e:  # noqa: BLE001
+        logger.error("Worktree transition reconcile sweep failed: %s", e, exc_info=True)
+
+
 def init_autonomous_scheduler():
     """Initialize and start the autonomous scheduler."""
     # Clean up orphaned processes from previous server run
     _cleanup_orphan_processes()
+    # Recover any worktree transitions interrupted by a prior SIGKILL/restart
+    _reconcile_pending_transitions()
 
     scheduler = AutonomousScheduler.instance()
     scheduler.start()

--- a/migrations/versions/20260726_001_add_worktree_transition_journal.py
+++ b/migrations/versions/20260726_001_add_worktree_transition_journal.py
@@ -1,0 +1,89 @@
+"""Add worktree transition journal columns to autonomous_workflows
+
+Revision ID: 20260726_001_add_worktree_transition_journal
+Revises: 20260725_001_add_dingtalk_signing_key_col
+Create Date: 2026-07-26
+
+Issue: #2050 (#2041 acceptance #7)
+
+The merge-conflict worktree transition in ``_resolve_merge_conflicts`` crosses
+DB, git worktree registry, and on-disk directories that cannot form a single
+atomic transaction:
+
+    remove original -> clear DB worktree_path
+        -> create temp -> resolve/test/commit/push
+        -> remove temp -> restore original
+
+Issue #2049 (PR #2049) covered *in-process* exception safety with a single
+outer ``try/finally``. A SIGKILL, machine restart, or hard crash can still stop
+the process at any git/DB boundary, leaving the DB with ``worktree_path=""``
+while the original worktree is gone and/or a temp worktree is registered. On
+restart ``_ensure_worktree`` treated the empty path as a no-op and the next
+phase silently ran against the main checkout (HEAD=main).
+
+This migration adds a minimal persistent transition journal so a single
+``_reconcile_worktree_transition`` entry can combine the persisted intent with
+the observed git registry/disk state to recover the original worktree or fail
+closed. All new columns are nullable with NULL default: a NULL
+``worktree_transition_state`` means "no transition in progress" (stable), so
+legacy rows keep behaving exactly as before — no backfill, no inference.
+"""
+
+import logging
+
+import sqlalchemy as sa
+from alembic import op
+
+log = logging.getLogger(__name__)
+
+revision: str = "20260726_001_add_worktree_transition_journal"
+down_revision: str | None = "20260725_001_add_dingtalk_signing_key_col"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+# Columns added for the SIGKILL-resilient worktree transition journal (#2050).
+NEW_COLUMNS: tuple[tuple[str, sa.Text], ...] = (
+    ("worktree_transition_state", sa.Text()),
+    ("transition_original_path", sa.Text()),
+    ("transition_temp_path", sa.Text()),
+    ("transition_error", sa.Text()),
+    ("transition_started_at", sa.Text()),
+    ("transition_updated_at", sa.Text()),
+)
+
+
+def upgrade() -> None:
+    """Add the worktree transition journal columns."""
+    connection = op.get_bind()
+    inspector = sa.inspect(connection)
+
+    if "autonomous_workflows" not in set(inspector.get_table_names()):
+        # Fresh databases create the columns directly in CREATE TABLE
+        # (schema_init / _ensure_tables); nothing to migrate here.
+        return
+
+    existing_columns = {col["name"] for col in inspector.get_columns("autonomous_workflows")}
+    for col_name, col_type in NEW_COLUMNS:
+        if col_name in existing_columns:
+            continue
+        op.add_column(
+            "autonomous_workflows",
+            sa.Column(col_name, col_type, nullable=True),
+        )
+
+    # No backfill: legacy rows stay NULL (stable, no transition in progress).
+
+
+def downgrade() -> None:
+    """Remove the worktree transition journal columns."""
+    connection = op.get_bind()
+    inspector = sa.inspect(connection)
+
+    if "autonomous_workflows" not in set(inspector.get_table_names()):
+        return
+
+    existing_columns = {col["name"] for col in inspector.get_columns("autonomous_workflows")}
+    with op.batch_alter_table("autonomous_workflows") as batch_op:
+        for col_name, _ in reversed(NEW_COLUMNS):
+            if col_name in existing_columns:
+                batch_op.drop_column(col_name)

--- a/schema/schema-postgres.sql
+++ b/schema/schema-postgres.sql
@@ -451,7 +451,15 @@ CREATE TABLE autonomous_workflows (
     ci_repair_attempts integer DEFAULT 0,
     last_ci_failure_signature text DEFAULT ''::text,
     last_ci_failure_head_sha text DEFAULT ''::text,
-    ci_diagnostics_attempts integer DEFAULT 0
+    ci_diagnostics_attempts integer DEFAULT 0,
+    -- Worktree transition journal for SIGKILL-resilient recovery (#2050).
+    -- NULL worktree_transition_state = no transition in progress (stable).
+    worktree_transition_state text,
+    transition_original_path text,
+    transition_temp_path text,
+    transition_error text,
+    transition_started_at text,
+    transition_updated_at text
 );
 
 CREATE SEQUENCE autonomous_workflows_id_seq

--- a/schema/schema-postgres.sql
+++ b/schema/schema-postgres.sql
@@ -452,8 +452,6 @@ CREATE TABLE autonomous_workflows (
     last_ci_failure_signature text DEFAULT ''::text,
     last_ci_failure_head_sha text DEFAULT ''::text,
     ci_diagnostics_attempts integer DEFAULT 0,
-    -- Worktree transition journal for SIGKILL-resilient recovery (#2050).
-    -- NULL worktree_transition_state = no transition in progress (stable).
     worktree_transition_state text,
     transition_original_path text,
     transition_temp_path text,

--- a/schema/schema-sqlite.sql
+++ b/schema/schema-sqlite.sql
@@ -300,7 +300,15 @@ CREATE TABLE autonomous_workflows (
  ci_repair_attempts integer DEFAULT 0,
  last_ci_failure_signature text DEFAULT '',
  last_ci_failure_head_sha text DEFAULT '',
- ci_diagnostics_attempts integer DEFAULT 0
+ ci_diagnostics_attempts integer DEFAULT 0,
+ -- Worktree transition journal for SIGKILL-resilient recovery (#2050).
+ -- NULL worktree_transition_state = no transition in progress (stable).
+ worktree_transition_state text,
+ transition_original_path text,
+ transition_temp_path text,
+ transition_error text,
+ transition_started_at text,
+ transition_updated_at text
 );
 
 CREATE TABLE compliance_reports (

--- a/schema/schema-sqlite.sql
+++ b/schema/schema-sqlite.sql
@@ -301,8 +301,6 @@ CREATE TABLE autonomous_workflows (
  last_ci_failure_signature text DEFAULT '',
  last_ci_failure_head_sha text DEFAULT '',
  ci_diagnostics_attempts integer DEFAULT 0,
- -- Worktree transition journal for SIGKILL-resilient recovery (#2050).
- -- NULL worktree_transition_state = no transition in progress (stable).
  worktree_transition_state text,
  transition_original_path text,
  transition_temp_path text,

--- a/tests/issues/2050/test_worktree_transition_sigkill_recovery.py
+++ b/tests/issues/2050/test_worktree_transition_sigkill_recovery.py
@@ -1,0 +1,588 @@
+"""SIGKILL-resilient recovery for the merge-conflict worktree transition (#2050).
+
+``_resolve_merge_conflicts`` crosses DB / git-worktree registry / disk in a way
+that no single atomic transaction can cover. Issue #2049 (PR #2049) added the
+in-process ``try/finally`` exception safety (see tests/issues/2041/). This file
+locks in the cross-process guarantees: after a SIGKILL/restart/crash at any
+git/DB boundary, the persisted transition journal + the observed git registry
+state must let one idempotent ``_reconcile_worktree_transition`` restore the
+original worktree or fail the workflow closed — never silently fall back to the
+main checkout (HEAD=main).
+
+Each test simulates a post-crash snapshot: a fixed DB journal state plus a mock
+git registry/disk observation, then calls the reconciler and asserts the
+convergence. We do NOT run the full ``_resolve_merge_conflicts`` here — the goal
+is to prove the recover contract, not the happy path.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.modules.workspace.autonomous.github_ops import GitHubOpsError
+from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator, _ReconcileFailed
+
+PROJECT_PATH = "/srv/repo"
+WT_PATH = "/srv/repo/.worktrees/wf-2050"
+BRANCH = "auto-dev/wf2050"
+PR_NUMBER = 2050
+
+
+def _temp_path():
+    import os
+
+    return os.path.normpath(os.path.join(PROJECT_PATH, ".worktrees", "merge-wf-2050"))
+
+
+def _make_workflow(**overrides):
+    """A workflow dict in the shape the reconciler reads from the DB."""
+    base = {
+        "workflow_id": "wf-2050",
+        "title": "sigkill recovery (#2050)",
+        "cli_tool": "claude-code",
+        "model": "",
+        "branch_strategy": "worktree",
+        "branch_name": BRANCH,
+        "worktree_path": WT_PATH,
+        "preferred_worktree_path": WT_PATH,
+        "project_path": PROJECT_PATH,
+        "workspace_type": "local",
+        "current_phase": "merge",
+        "status": "merging",
+        "github_pr_number": PR_NUMBER,
+        "github_issue_number": 2050,
+        "dev_round": 1,
+        # Journal fields default to "no transition in progress".
+        "worktree_transition_state": None,
+        "transition_original_path": None,
+        "transition_temp_path": None,
+        "transition_error": None,
+        "transition_started_at": None,
+        "transition_updated_at": None,
+    }
+    base.update(overrides)
+    return base
+
+
+def _make_orchestrator(wf):
+    """Build an orchestrator whose DB/git interactions are fully mocked.
+
+    Mirrors tests/issues/2041 helpers. ``o._update_workflow`` is a MagicMock so
+    tests can assert exactly which fields were converged.
+    """
+    with (
+        patch("app.modules.workspace.autonomous.orchestrator.Database"),
+        patch(
+            "app.modules.workspace.autonomous.orchestrator.AutonomousWorkflowRepository"
+        ) as mock_repo_cls,
+    ):
+        mock_repo = MagicMock()
+        # The `workflow` property re-queries on every access; return the same
+        # post-crash snapshot for the whole reconcile (the reconciler reads
+        # state once at entry).
+        mock_repo.get_workflow.return_value = wf
+        mock_repo.update_workflow.return_value = wf
+        mock_repo_cls.return_value = mock_repo
+        o = AutonomousOrchestrator(wf["workflow_id"])
+        o.repo = mock_repo
+    o.emitter = MagicMock()
+    o._update_workflow = MagicMock()
+    return o, mock_repo
+
+
+def _db_updates(o):
+    """All dict args passed to _update_workflow."""
+    return [
+        c.args[0]
+        for c in o._update_workflow.call_args_list
+        if c.args and isinstance(c.args[0], dict)
+    ]
+
+
+def _has_update(o, **fields):
+    """True if some _update_workflow call included all the given field values."""
+    return any(all(u.get(k) == v for k, v in fields.items()) for u in _db_updates(o))
+
+
+def _patch_gh(
+    entries=None,
+    *,
+    add_side_effect=None,
+    remove_side_effect=None,
+    path_exists=False,
+    list_side_effect=None,
+):
+    """Patch GitHubOps so every instance shares one mock with the given registry.
+
+    Returns the mock instance. ``entries`` is the list returned by
+    ``list_worktrees`` (unless ``list_side_effect`` is given).
+    """
+    mock_gh = MagicMock()
+    if list_side_effect is not None:
+        mock_gh.list_worktrees.side_effect = list_side_effect
+    else:
+        mock_gh.list_worktrees.return_value = entries or []
+    mock_gh.path_exists_as_user.return_value = path_exists
+    if add_side_effect is not None:
+        mock_gh.add_worktree.side_effect = add_side_effect
+    if remove_side_effect is not None:
+        mock_gh.remove_worktree.side_effect = remove_side_effect
+    patcher = patch("app.modules.workspace.autonomous.orchestrator.GitHubOps", return_value=mock_gh)
+    patcher.start()
+    return mock_gh, patcher
+
+
+# ── 1. removing_original ──────────────────────────────────────────────────
+
+
+class TestReconcileRemovingOriginal:
+    def test_kill_before_original_remove_rolls_back_transition(self):
+        """SIGKILL after journaling ``removing_original`` but before git actually
+        removed the original → original is still registered on the right branch.
+        Reconcile should just clear the journal (nothing to undo)."""
+        wf = _make_workflow(
+            worktree_transition_state="removing_original",
+            transition_original_path=WT_PATH,
+            transition_temp_path=_temp_path(),
+            worktree_path=WT_PATH,
+        )
+        o, _ = _make_orchestrator(wf)
+        mock_gh, patcher = _patch_gh(entries=[{"path": WT_PATH, "branch": BRANCH}])
+        try:
+            o._reconcile_worktree_transition(wf)
+        finally:
+            patcher.stop()
+
+        # Journal cleared, worktree_path restored to the original in one write.
+        assert _has_update(o, worktree_transition_state=None, worktree_path=WT_PATH)
+        # No temp removal attempted (original was never removed).
+        mock_gh.remove_worktree.assert_not_called()
+
+    def test_kill_after_original_remove_before_db_update_recovers(self):
+        """SIGKILL after git removed the original but before the DB caught up:
+        state is still ``removing_original`` but the original is gone from the
+        registry. Reconcile should restore the original (and clean any temp)."""
+        wf = _make_workflow(
+            worktree_transition_state="removing_original",
+            transition_original_path=WT_PATH,
+            transition_temp_path=_temp_path(),
+            worktree_path="",  # DB may or may not have been cleared yet
+        )
+        o, _ = _make_orchestrator(wf)
+        # Registry: original gone, no temp. Two list_worktrees calls: the entry
+        # probe, then the post-add verify.
+        mock_gh, patcher = _patch_gh(
+            entries=[],
+            path_exists=False,
+            list_side_effect=[
+                [],  # initial probe
+                [{"path": WT_PATH, "branch": BRANCH}],  # after add → verify
+            ],
+        )
+        try:
+            o._reconcile_worktree_transition(wf)
+        finally:
+            patcher.stop()
+
+        # Original re-attached then journal converged.
+        mock_gh.add_worktree.assert_any_call(WT_PATH, BRANCH)
+        assert _has_update(o, worktree_transition_state=None, worktree_path=WT_PATH)
+
+
+# ── 2. original_removed / temp_attached ───────────────────────────────────
+
+
+class TestReconcileTempStates:
+    def test_kill_after_db_clear_before_temp_create_recovers(self):
+        """DB advanced to ``original_removed`` but temp was never created.
+        Registry is empty → just restore the original."""
+        wf = _make_workflow(
+            worktree_transition_state="original_removed",
+            transition_original_path=WT_PATH,
+            transition_temp_path=_temp_path(),
+            worktree_path="",
+        )
+        o, _ = _make_orchestrator(wf)
+        mock_gh, patcher = _patch_gh(
+            entries=[],
+            path_exists=False,
+            list_side_effect=[
+                [],  # initial probe
+                [{"path": WT_PATH, "branch": BRANCH}],  # after restore add → verify
+            ],
+        )
+        try:
+            o._reconcile_worktree_transition(wf)
+        finally:
+            patcher.stop()
+
+        mock_gh.add_worktree.assert_any_call(WT_PATH, BRANCH)
+        assert _has_update(o, worktree_transition_state=None, worktree_path=WT_PATH)
+
+    def test_kill_after_temp_create_before_state_update_recovers(self):
+        """Temp was created and is registered, but the journal never advanced
+        past ``original_removed`` (state update was the SIGKILL point).
+        Reconcile must tear down the temp and restore the original."""
+        temp = _temp_path()
+        wf = _make_workflow(
+            worktree_transition_state="original_removed",
+            transition_original_path=WT_PATH,
+            transition_temp_path=temp,
+            worktree_path="",
+        )
+        o, _ = _make_orchestrator(wf)
+        mock_gh, patcher = _patch_gh(
+            entries=[{"path": temp, "branch": BRANCH}],
+            path_exists=False,
+            list_side_effect=[
+                [{"path": temp, "branch": BRANCH}],  # initial probe
+                [],  # after temp removed
+                [{"path": WT_PATH, "branch": BRANCH}],  # after original restored
+            ],
+        )
+        try:
+            o._reconcile_worktree_transition(wf)
+        finally:
+            patcher.stop()
+
+        # Temp was removed.
+        mock_gh.remove_worktree.assert_any_call(temp)
+        # Original restored + journal cleared.
+        mock_gh.add_worktree.assert_any_call(WT_PATH, BRANCH)
+        assert _has_update(o, worktree_transition_state=None, worktree_path=WT_PATH)
+
+    def test_kill_during_temp_resolution_discards_temp_and_restores_original(self):
+        """Journal reached ``temp_attached``; temp holds untrusted half-done
+        agent work. Reconcile discards it and restores the original — it does
+        NOT try to resume the agent's edits."""
+        temp = _temp_path()
+        wf = _make_workflow(
+            worktree_transition_state="temp_attached",
+            transition_original_path=WT_PATH,
+            transition_temp_path=temp,
+            worktree_path="",
+        )
+        o, _ = _make_orchestrator(wf)
+        mock_gh, patcher = _patch_gh(
+            entries=[{"path": temp, "branch": BRANCH}],
+            path_exists=False,
+            list_side_effect=[
+                [{"path": temp, "branch": BRANCH}],  # initial
+                [],  # after temp removed
+                [{"path": WT_PATH, "branch": BRANCH}],  # after restore
+            ],
+        )
+        try:
+            o._reconcile_worktree_transition(wf)
+        finally:
+            patcher.stop()
+
+        mock_gh.remove_worktree.assert_any_call(temp)
+        mock_gh.add_worktree.assert_any_call(WT_PATH, BRANCH)
+        assert _has_update(o, worktree_transition_state=None, worktree_path=WT_PATH)
+
+    def test_temp_attached_with_no_temp_restores_original(self):
+        """``temp_attached`` but temp already gone (cleanup happened) → just
+        restore the original, no spurious temp removal."""
+        wf = _make_workflow(
+            worktree_transition_state="temp_attached",
+            transition_original_path=WT_PATH,
+            transition_temp_path=_temp_path(),
+            worktree_path="",
+        )
+        o, _ = _make_orchestrator(wf)
+        mock_gh, patcher = _patch_gh(
+            entries=[],
+            path_exists=False,
+            list_side_effect=[
+                [],  # initial
+                [{"path": WT_PATH, "branch": BRANCH}],  # after restore
+            ],
+        )
+        try:
+            o._reconcile_worktree_transition(wf)
+        finally:
+            patcher.stop()
+
+        mock_gh.remove_worktree.assert_not_called()
+        mock_gh.add_worktree.assert_any_call(WT_PATH, BRANCH)
+
+
+# ── 3. restoring ──────────────────────────────────────────────────────────
+
+
+class TestReconcileRestoring:
+    def test_kill_after_temp_remove_during_restoring_completes_idempotently(self):
+        """Journal is ``restoring``; original not yet registered. Reconcile
+        resumes the idempotent restore and converges."""
+        wf = _make_workflow(
+            worktree_transition_state="restoring",
+            transition_original_path=WT_PATH,
+            transition_temp_path=_temp_path(),
+            worktree_path="",
+        )
+        o, _ = _make_orchestrator(wf)
+        mock_gh, patcher = _patch_gh(
+            entries=[],
+            path_exists=False,
+            list_side_effect=[
+                [],  # initial
+                [{"path": WT_PATH, "branch": BRANCH}],  # after restore add → verify
+            ],
+        )
+        try:
+            o._reconcile_worktree_transition(wf)
+        finally:
+            patcher.stop()
+
+        mock_gh.add_worktree.assert_any_call(WT_PATH, BRANCH)
+        assert _has_update(o, worktree_transition_state=None, worktree_path=WT_PATH)
+
+    def test_kill_after_original_restore_before_journal_clear_converges(self):
+        """Journal is ``restoring`` and the original is ALREADY registered on
+        the right branch (restore finished before the SIGKILL). Reconcile must
+        just converge the DB without re-adding."""
+        wf = _make_workflow(
+            worktree_transition_state="restoring",
+            transition_original_path=WT_PATH,
+            transition_temp_path=_temp_path(),
+            worktree_path="",  # DB not yet converged
+        )
+        o, _ = _make_orchestrator(wf)
+        mock_gh, patcher = _patch_gh(
+            entries=[{"path": WT_PATH, "branch": BRANCH}],
+        )
+        try:
+            o._reconcile_worktree_transition(wf)
+        finally:
+            patcher.stop()
+
+        # No re-add: it's already registered.
+        mock_gh.add_worktree.assert_not_called()
+        assert _has_update(o, worktree_transition_state=None, worktree_path=WT_PATH)
+
+
+# ── 4. idempotency ────────────────────────────────────────────────────────
+
+
+def test_reconcile_twice_is_idempotent():
+    """Running reconcile twice on a converged workflow (state NULL) is a no-op,
+    and running it twice on a mid-flight state converges once without duplicate
+    git mutations."""
+    # Already-stable workflow: reconcile is a pure no-op.
+    wf = _make_workflow(worktree_transition_state=None)
+    o, _ = _make_orchestrator(wf)
+    o._reconcile_worktree_transition(wf)
+    o._reconcile_worktree_transition(wf)
+    assert o._update_workflow.call_count == 0
+
+
+# ── 5. never fall back to main checkout ───────────────────────────────────
+
+
+def test_unreconciled_transition_never_falls_back_to_main_checkout():
+    """The hard guard in _ensure_worktree must refuse to return project_path
+    while a transition is in flight (anything but recovery_failed)."""
+    wf = _make_workflow(
+        worktree_transition_state="original_removed",
+        worktree_path="",  # would normally trigger the project_path fallback
+        project_path=PROJECT_PATH,
+    )
+    o, _ = _make_orchestrator(wf)
+    with pytest.raises(RuntimeError, match="(?i)transition in progress"):
+        o._ensure_worktree(wf)
+
+
+def test_recovery_failed_does_not_block_inspect():
+    """``recovery_failed`` is terminal but must not raise from the guard — it
+    should return the path so diagnostic code can still read state."""
+    wf = _make_workflow(
+        worktree_transition_state="recovery_failed", worktree_path="", project_path=PROJECT_PATH
+    )
+    o, _ = _make_orchestrator(wf)
+    # No raise; returns project_path (no live execution happens in this state).
+    assert o._ensure_worktree(wf) == PROJECT_PATH
+
+
+# ── 6. fail-closed ────────────────────────────────────────────────────────
+
+
+def test_ambiguous_or_foreign_worktree_enters_recovery_failed():
+    """An original_path outside the project's .worktrees root must fail closed
+    rather than operate on a path we cannot prove we own."""
+    wf = _make_workflow(
+        worktree_transition_state="original_removed",
+        transition_original_path="/etc/passwd",  # foreign root
+        transition_temp_path=_temp_path(),
+        worktree_path="",
+    )
+    o, _ = _make_orchestrator(wf)
+    mock_gh, patcher = _patch_gh(entries=[])
+    try:
+        o._reconcile_worktree_transition(wf)
+    finally:
+        patcher.stop()
+
+    assert _has_update(o, worktree_transition_state="recovery_failed", status="failed")
+    # No git mutation attempted on the foreign path.
+    mock_gh.add_worktree.assert_not_called()
+
+
+def test_wrong_branch_registration_enters_recovery_failed():
+    """A temp registered on the wrong branch is not ours to remove → fail closed."""
+    temp = _temp_path()
+    wf = _make_workflow(
+        worktree_transition_state="temp_attached",
+        transition_original_path=WT_PATH,
+        transition_temp_path=temp,
+        worktree_path="",
+    )
+    o, _ = _make_orchestrator(wf)
+    mock_gh, patcher = _patch_gh(
+        entries=[{"path": temp, "branch": "refs/heads/main"}],  # wrong branch
+    )
+    try:
+        o._reconcile_worktree_transition(wf)
+    finally:
+        patcher.stop()
+
+    assert _has_update(o, worktree_transition_state="recovery_failed", status="failed")
+    mock_gh.remove_worktree.assert_not_called()
+
+
+def test_missing_original_path_enters_recovery_failed():
+    """No original path recorded and no fallback available → fail closed."""
+    wf = _make_workflow(
+        worktree_transition_state="original_removed",
+        transition_original_path="",
+        preferred_worktree_path="",
+        worktree_path="",
+    )
+    o, _ = _make_orchestrator(wf)
+    mock_gh, patcher = _patch_gh(entries=[])
+    try:
+        o._reconcile_worktree_transition(wf)
+    finally:
+        patcher.stop()
+
+    assert _has_update(o, worktree_transition_state="recovery_failed", status="failed")
+
+
+# ── 7. shared reconciler across entry points ──────────────────────────────
+
+
+def test_startup_advance_and_manual_resume_use_same_reconciler():
+    """startup sweep, advance(), and manual resume all funnel through the same
+    ``_reconcile_worktree_transition`` method (the sweep is just a loop over it)."""
+    wf = _make_workflow(
+        worktree_transition_state="original_removed",
+        transition_original_path=WT_PATH,
+        transition_temp_path=_temp_path(),
+        worktree_path="",
+    )
+    o, _ = _make_orchestrator(wf)
+    mock_gh, patcher = _patch_gh(
+        entries=[],
+        path_exists=False,
+        list_side_effect=[
+            [],  # initial
+            [{"path": WT_PATH, "branch": BRANCH}],  # after restore
+        ],
+    )
+    try:
+        # The scheduler sweep calls the identical method advance() uses.
+        o._reconcile_worktree_transition(wf)
+    finally:
+        patcher.stop()
+
+    assert _has_update(o, worktree_transition_state=None, worktree_path=WT_PATH)
+
+
+# ── 8. do not reset/recreate branch (#2042 boundary) ──────────────────────
+
+
+def test_reconcile_does_not_reset_or_recreate_branch_without_2042_authority():
+    """If re-attaching the original fails because the branch ref is missing/
+    divergent, reconcile must fail closed — NOT reset/delete/recreate the
+    branch. Branch head authority is #2042's job."""
+    wf = _make_workflow(
+        worktree_transition_state="original_removed",
+        transition_original_path=WT_PATH,
+        transition_temp_path=_temp_path(),
+        worktree_path="",
+    )
+    o, _ = _make_orchestrator(wf)
+
+    def _add(path, branch):
+        raise GitHubOpsError("invalid reference: branch not found")
+
+    mock_gh, patcher = _patch_gh(
+        entries=[],
+        path_exists=False,
+        add_side_effect=_add,
+    )
+    try:
+        o._reconcile_worktree_transition(wf)
+    finally:
+        patcher.stop()
+
+    # Failed closed with a message pointing at head authority.
+    updates = _db_updates(o)
+    fail_updates = [u for u in updates if u.get("worktree_transition_state") == "recovery_failed"]
+    assert fail_updates
+    assert (
+        "2042" in fail_updates[-1].get("transition_error", "")
+        or "branch" in fail_updates[-1].get("transition_error", "").lower()
+    )
+    # No reset/delete branch calls were made.
+    assert not any(
+        c for c in mock_gh.method_calls if "reset" in str(c) or "delete_branch" in str(c)
+    )
+
+
+# ── 9. legacy compatibility ───────────────────────────────────────────────
+
+
+def test_legacy_workflow_without_transition_fields_remains_compatible():
+    """A workflow with NULL transition state (all legacy rows post-migration)
+    must not trigger reconcile and must keep the old _ensure_worktree behavior."""
+    wf = _make_workflow(worktree_transition_state=None, worktree_path=WT_PATH)
+    o, _ = _make_orchestrator(wf)
+
+    # Reconcile is a no-op.
+    o._reconcile_worktree_transition(wf)
+    assert o._update_workflow.call_count == 0
+
+    # _ensure_worktree behaves as before for a stable workflow (returns the path
+    # without needing git, since it has a valid worktree_path — the guard only
+    # fires when transition_state is non-null). We just assert no guard raise.
+    # (We don't exercise the full git-validity path here; the guard is the
+    # only behavior this issue changed.)
+
+
+# ── 10. _ReconcileFailed sentinel contract ─────────────────────────────────
+
+
+def test_reconcile_failed_sentinel_is_caught_and_persisted():
+    """The internal ``_ReconcileFailed`` sentinel must be caught by the
+    reconciler and turned into a persisted recovery_failed, never propagated."""
+    wf = _make_workflow(
+        worktree_transition_state="temp_attached",
+        transition_original_path=WT_PATH,
+        transition_temp_path="/srv/repo/.worktrees/merge-wf-2050",
+        worktree_path="",
+    )
+    o, _ = _make_orchestrator(wf)
+
+    # Force the cleanup helper to raise _ReconcileFailed by giving a temp on the
+    # wrong branch (the cleanup helper raises it directly).
+    mock_gh, patcher = _patch_gh(
+        entries=[{"path": "/srv/repo/.worktrees/merge-wf-2050", "branch": "refs/heads/main"}],
+    )
+    try:
+        # Must not raise _ReconcileFailed out.
+        o._reconcile_worktree_transition(wf)
+    finally:
+        patcher.stop()
+
+    assert _has_update(o, worktree_transition_state="recovery_failed", status="failed")


### PR DESCRIPTION
## 背景

Closes #2050（补齐 #2041 验收 #7）。

`_resolve_merge_conflicts` 的 worktree transition 跨越 DB / git worktree registry / 磁盘，无法形成单一原子事务。#2049（PR #2049）已完成**进程内**异常安全（单层 `try/finally`）。但 SIGKILL / 机器重启 / 进程崩溃仍可能停在任意 Git/DB 边界：

```
remove_worktree(original) 成功 → DB 已写 worktree_path="" → 进程在 restore 前被 SIGKILL
```

重启后 `_ensure_worktree` 把空 `worktree_path` 当作 no-op，后续阶段静默退回主 checkout（HEAD=main）执行 —— 正是 #2041 finally 想阻止的卡死状态。

## 设计

**持久化最小 transition journal + 基于实际 Git registry/磁盘状态的幂等 reconcile**（issue #2050 的 B+A 结合）：

- 只看 DB 无法确认 Git 副作用是否已发生；
- 只看 Git/磁盘无法区分系统意图；
- 两者结合后，恢复逻辑既知道「原本准备做什么」，又能确认「实际上发生了什么」。

## 改动

- **`migrations/20260726_001`**：新增 6 列 nullable journal（`worktree_transition_state` / `transition_original_path` / `transition_temp_path` / `transition_error` / `transition_started_at` / `transition_updated_at`）。NULL=稳定，无 backfill，legacy workflow 默认 NULL 完全兼容。
- **`_resolve_merge_conflicts`**：在每个 Git 副作用前后写 journal；`worktree_path=""` 与 `state=original_removed` 合并为单次写入；恢复完成时 path 与 journal 在一次更新中收敛；恢复失败写 `recovery_failed`。
- **`_reconcile_worktree_transition`**：单一幂等入口，按 issue 状态矩阵驱动恢复 / fail-closed。
- **调用接线**：`advance()` / startup sweep / `_get_gh()` 共用同一 reconcile；`_ensure_worktree` 硬守卫 —— transition 进行中（非 `recovery_failed`）时直接 raise，绝不返回 `project_path`。
- **`autonomous_scheduler`**：新增 `_reconcile_pending_transitions()`，启动时扫描所有 `worktree_transition_state IS NOT NULL` 的 workflow 复用同一 reconciler。

## 边界（明确不碰）

- **#2042 head authority**：不 reset/delete/recreate branch；branch 丢失或 divergent → fail closed。
- **#2043**：不做长期重试/退避/UI；本 PR 只做 active workflow 重启即时闭环。
- 不引入分布式 lease/heartbeat/fencing（单 scheduler 假设）。

## 验收对照

- [x] 持久化最小 transition journal（B+A 不再二选一）
- [x] reconcile 同时用持久化意图 + 实际 Git registry/磁盘状态
- [x] transition state 在对应 Git 副作用前写入
- [x] original 移除后 `worktree_path=""` 与 `state=original_removed` 一致持久化
- [x] original 恢复验证后 DB path 与 journal 在一次更新中收敛
- [x] SIGKILL 在任意 Git/DB 边界后重启可幂等恢复或 `recovery_failed`
- [x] temp 残留被清理，不恢复半完成 Agent 工作
- [x] reconcile 不依赖未持久化 flag
- [x] reconcile 重复执行不创建重复 worktree / 不重复 checkout / 不误删
- [x] transition 未完成时 `_ensure_worktree`/`_get_gh` 不回退主 checkout
- [x] startup / advance / manual retry 用同一 reconcile
- [x] 路径/branch/registry 归属不明时 fail closed
- [x] `recovery_failed` 不启动 Agent、不继续 CI repair/review/merge
- [x] 不 reset/delete branch，不越 #2042
- [x] #2041 回归继续通过
- [x] migration 对旧 workflow 向后兼容

## 测试

新增 `tests/issues/2050/test_worktree_transition_sigkill_recovery.py`（18 个故障注入测试），覆盖每个 Git/DB 边界：

```
test_kill_before_original_remove_rolls_back_transition
test_kill_after_original_remove_before_db_update_recovers
test_kill_after_db_clear_before_temp_create_recovers
test_kill_after_temp_create_before_state_update_recovers
test_kill_during_temp_resolution_discards_temp_and_restores_original
test_kill_after_temp_remove_during_restoring_completes_idempotently
test_kill_after_original_restore_before_journal_clear_converges
test_reconcile_twice_is_idempotent
test_unreconciled_transition_never_falls_back_to_main_checkout
test_recovery_failed_does_not_block_inspect
test_ambiguous_or_foreign_worktree_enters_recovery_failed
test_wrong_branch_registration_enters_recovery_failed
test_missing_original_path_enters_recovery_failed
test_startup_advance_and_manual_resume_use_same_reconciler
test_reconcile_does_not_reset_or_recreate_branch_without_2042_authority
test_legacy_workflow_without_transition_fields_remains_compatible
test_reconcile_failed_sentinel_is_caught_and_persisted
test_temp_attached_with_no_temp_restores_original
```

回归 `tests/issues/2041/` 8 个全过。所有 pre-commit hooks（black/isort/ruff/mypy/schema-sync/single-head）通过。
