### PR TITLE
feat(autonomous): verify-before-act evidence contract (#2045 Phase A)

### DIFF
--- a/app/modules/workspace/autonomous/evidence.py
+++ b/app/modules/workspace/autonomous/evidence.py
@@ -1,0 +1,90 @@
+"""Evidence contract for verifying external/derived signals before irreversible ops.
+
+Issue #2045 Phase A introduces a uniform tri-state verification semantic so that
+GitHub PR head SHAs, remote branch state, commit-graph ancestry, and (in Phase B)
+merge readiness / CI failures are never trusted raw. Every verification returns
+an :class:`Evidence` carrying a :class:`Verdict` plus enough metadata to audit
+*why* a decision was made, not just the outcome.
+
+This module only defines the immutable types; the verification logic lives in
+:mod:`app.modules.workspace.autonomous.evidence_service`. The tri-state semantics
+mirrors the existing ``bool | None`` pattern already proven by
+``AutonomousOrchestrator._ancestor_check`` (True=confirmed, False=rejected,
+None=indeterminate).
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from enum import Enum
+
+
+class Verdict(str, Enum):
+    """Tri-state outcome of any external-signal verification.
+
+    ``CONFIRMED`` and ``REJECTED`` are definitive commit-graph / API answers the
+    caller may act on; ``INDETERMINATE`` is a probe that could not produce a
+    definitive answer (git error, missing object, API failure, head mismatch) and
+    must fail closed — the caller defers or aborts rather than guessing.
+    """
+
+    CONFIRMED = "confirmed"
+    REJECTED = "rejected"
+    INDETERMINATE = "indeterminate"
+
+    def to_bool_or_none(self) -> bool | None:
+        """Map CONFIRMED→True, REJECTED→False, INDETERMINATE→None.
+
+        Convenience for the legacy ``bool | None`` return contract used by the
+        orchestrator delegation layer; new callers should branch on the verdict
+        directly.
+        """
+        if self is Verdict.CONFIRMED:
+            return True
+        if self is Verdict.REJECTED:
+            return False
+        return None
+
+
+@dataclass(frozen=True)
+class Evidence:
+    """A single verified external signal consumed before an irreversible op.
+
+    Carries enough metadata to audit a decision. See issue #2045 Phase A
+    acceptance criteria: evidence must record source, subject, observed/verified
+    timestamps, commit SHAs, verification method, and reason.
+
+    Attributes:
+        source: Where the raw signal originated — ``"github_api"``,
+            ``"local_object_db"``, ``"git_fetch"``, or ``"git_ancestor"``.
+        subject: What was verified — ``"pr_head"``, ``"commit_availability"``,
+            ``"branch_contains"``, or ``"remote_branch_state"``.
+        verdict: Tri-state outcome; never silently resolved away from
+            :attr:`Verdict.INDETERMINATE`.
+        observed_at: When the raw signal was read (before verification).
+        verified_at: When the verification probe completed.
+        verification_method: How the verdict was reached, e.g.
+            ``"cat-file -e"`` or ``"merge-base --is-ancestor"``.
+        commit_shas: SHAs the evidence binds to; the order is method-specific
+            (e.g. for ancestry: ``(head, base)``).
+        reason: Human-readable explanation of the verdict.
+    """
+
+    source: str
+    subject: str
+    verdict: Verdict
+    observed_at: datetime
+    verified_at: datetime
+    verification_method: str
+    commit_shas: tuple[str, ...] = ()
+    reason: str = ""
+
+    def to_dict(self) -> dict:
+        """Serialize to a JSON-friendly dict for milestone/event metadata."""
+        data = asdict(self)
+        data["verdict"] = self.verdict.value
+        data["observed_at"] = self.observed_at.isoformat()
+        data["verified_at"] = self.verified_at.isoformat()
+        data["commit_shas"] = list(self.commit_shas)
+        return data

--- a/app/modules/workspace/autonomous/evidence_service.py
+++ b/app/modules/workspace/autonomous/evidence_service.py
@@ -1,0 +1,262 @@
+"""Verification service for external/derived signals before irreversible git ops.
+
+Issue #2045 Phase A. Each method returns an :class:`Evidence` carrying a tri-state
+:class:`Verdict`. Indeterminate results must never silently resolve to
+confirmed/rejected; callers fail closed (defer or abort rather than guess).
+
+The logic here is migrated from the inline helpers on ``AutonomousOrchestrator``
+(``_ancestor_check``, ``_ensure_pr_head_local``, ``_branch_contains_main``) so
+that all external-signal verification flows through one auditable contract.
+Those orchestrator methods are retained as thin delegation wrappers to preserve
+the existing call sites and test patches.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+from .evidence import Evidence, Verdict
+
+if TYPE_CHECKING:
+    from .github_ops import GitHubOps
+
+
+class EvidenceService:
+    """Verifies external/derived signals before irreversible git ops.
+
+    Each method returns an :class:`Evidence` carrying a tri-state
+    :class:`Verdict`. Indeterminate results never silently resolve to
+    confirmed/rejected; callers fail closed (see issue #2045 Phase A).
+    """
+
+    @staticmethod
+    def _now() -> datetime:
+        """Current UTC timestamp; centralized so tests can patch one seam."""
+        return datetime.now(timezone.utc)
+
+    def verify_commit_available(
+        self,
+        gh: GitHubOps,
+        sha: str,
+        branch_name: str = "",
+    ) -> Evidence:
+        """Whether the local object DB can resolve ``sha`` (``cat-file -e``).
+
+        Fetches ``branch_name`` first if the object is absent, so the probe has a
+        chance to succeed after a worktree teardown (the prior
+        ``_ensure_pr_head_local`` behavior). REJECTED means the object truly
+        cannot be resolved after fetching; callers must treat that as a
+        definitive "no" rather than retrying.
+        """
+        observed_at = self._now()
+        method = "cat-file -e"
+        if sha and gh._run_git(["cat-file", "-e", sha], check=False).returncode == 0:
+            return Evidence(
+                source="local_object_db",
+                subject="commit_availability",
+                verdict=Verdict.CONFIRMED,
+                observed_at=observed_at,
+                verified_at=self._now(),
+                verification_method=method,
+                commit_shas=(sha,),
+                reason="object present in local DB",
+            )
+        if branch_name:
+            gh._run_git(["fetch", "origin", branch_name])
+            method = f"fetch origin {branch_name} + cat-file -e"
+        if sha and gh._run_git(["cat-file", "-e", sha], check=False).returncode == 0:
+            return Evidence(
+                source="git_fetch",
+                subject="commit_availability",
+                verdict=Verdict.CONFIRMED,
+                observed_at=observed_at,
+                verified_at=self._now(),
+                verification_method=method,
+                commit_shas=(sha,),
+                reason="object fetched then resolved",
+            )
+        return Evidence(
+            source="local_object_db",
+            subject="commit_availability",
+            verdict=Verdict.REJECTED,
+            observed_at=observed_at,
+            verified_at=self._now(),
+            verification_method=method,
+            commit_shas=(sha,) if sha else (),
+            reason="object absent after fetch attempt",
+        )
+
+    def verify_branch_contains(
+        self,
+        gh: GitHubOps,
+        head: str,
+        base: str,
+        branch_name: str = "",
+    ) -> Evidence:
+        """Whether ``head`` has ``base`` as an ancestor.
+
+        Distinguishes a definitive REJECTED (``base`` is NOT reachable from
+        ``head``, rc=1) from INDETERMINATE (git error / missing object, rc>=128).
+        Ensures ``head`` is local first via :meth:`verify_commit_available`; an
+        unavailable head object is INDETERMINATE, not REJECTED, because the
+        ancestry probe cannot run.
+        """
+        observed_at = self._now()
+        head_ev = self.verify_commit_available(gh, head, branch_name)
+        if head_ev.verdict is not Verdict.CONFIRMED:
+            return Evidence(
+                source=head_ev.source,
+                subject="branch_contains",
+                verdict=Verdict.INDETERMINATE,
+                observed_at=observed_at,
+                verified_at=self._now(),
+                verification_method="merge-base --is-ancestor (blocked)",
+                commit_shas=(head, base),
+                reason=f"head object unavailable: {head_ev.reason}",
+            )
+        rc = gh._run_git(["merge-base", "--is-ancestor", base, head], check=False).returncode
+        if rc == 0:
+            return Evidence(
+                source="git_ancestor",
+                subject="branch_contains",
+                verdict=Verdict.CONFIRMED,
+                observed_at=observed_at,
+                verified_at=self._now(),
+                verification_method="merge-base --is-ancestor",
+                commit_shas=(head, base),
+                reason=f"{base[:8]} is ancestor of {head[:8]}",
+            )
+        if rc == 1:
+            return Evidence(
+                source="git_ancestor",
+                subject="branch_contains",
+                verdict=Verdict.REJECTED,
+                observed_at=observed_at,
+                verified_at=self._now(),
+                verification_method="merge-base --is-ancestor",
+                commit_shas=(head, base),
+                reason=f"{base[:8]} NOT ancestor of {head[:8]}",
+            )
+        return Evidence(
+            source="git_ancestor",
+            subject="branch_contains",
+            verdict=Verdict.INDETERMINATE,
+            observed_at=observed_at,
+            verified_at=self._now(),
+            verification_method="merge-base --is-ancestor",
+            commit_shas=(head, base),
+            reason=f"git error rc={rc}",
+        )
+
+    def verify_remote_branch_state(
+        self,
+        gh: GitHubOps,
+        branch_name: str,
+        expected_head: str,
+    ) -> Evidence:
+        """Compare the remote ``branch_name`` head against ``expected_head``.
+
+        Fetches the remote ref, resolves FETCH_HEAD, and compares. Mismatch or
+        fetch failure is INDETERMINATE (never silently pick one side); a match
+        is CONFIRMED. There is no REJECTED here because a mismatch does not tell
+        us which SHA is authoritative — the caller must re-derive expected_head.
+        """
+        observed_at = self._now()
+        fetch_res = gh._run_git(["fetch", "origin", branch_name], check=False)
+        if fetch_res.returncode != 0:
+            return Evidence(
+                source="git_fetch",
+                subject="remote_branch_state",
+                verdict=Verdict.INDETERMINATE,
+                observed_at=observed_at,
+                verified_at=self._now(),
+                verification_method=f"fetch origin {branch_name}",
+                commit_shas=(expected_head,),
+                reason=f"fetch failed rc={fetch_res.returncode}",
+            )
+        try:
+            remote_head = gh.resolve_commit("FETCH_HEAD")
+        except Exception as exc:  # noqa: BLE001 — surface any resolve failure as indeterminate
+            return Evidence(
+                source="git_fetch",
+                subject="remote_branch_state",
+                verdict=Verdict.INDETERMINATE,
+                observed_at=observed_at,
+                verified_at=self._now(),
+                verification_method="resolve FETCH_HEAD",
+                commit_shas=(expected_head,),
+                reason=f"resolve failed: {exc}",
+            )
+        if remote_head == expected_head:
+            return Evidence(
+                source="git_fetch",
+                subject="remote_branch_state",
+                verdict=Verdict.CONFIRMED,
+                observed_at=observed_at,
+                verified_at=self._now(),
+                verification_method="fetch + resolve FETCH_HEAD",
+                commit_shas=(expected_head,),
+                reason="remote head matches expected",
+            )
+        return Evidence(
+            source="git_fetch",
+            subject="remote_branch_state",
+            verdict=Verdict.INDETERMINATE,
+            observed_at=observed_at,
+            verified_at=self._now(),
+            verification_method="fetch + resolve FETCH_HEAD",
+            commit_shas=(expected_head, remote_head),
+            reason=f"remote {remote_head[:8]} != expected {expected_head[:8]}",
+        )
+
+    def resolve_verified_pr_head(
+        self,
+        gh: GitHubOps,
+        pr_number: int,
+        branch_name: str,
+    ) -> Evidence:
+        """The GitHub API head SHA + fetch + local object existence, in one call.
+
+        Composite of :meth:`verify_commit_available`; this is the canonical entry
+        point before any irreversible op on a PR head. Subject is ``pr_head``;
+        ``commit_shas[0]`` is the verified SHA (only set when CONFIRMED). An API
+        failure or an unverifiable local object is INDETERMINATE so the caller
+        defers rather than acting on a raw API SHA.
+        """
+        observed_at = self._now()
+        try:
+            api_sha = gh.get_pr_head_sha(pr_number)
+        except Exception as exc:  # noqa: BLE001 — any API failure is indeterminate
+            return Evidence(
+                source="github_api",
+                subject="pr_head",
+                verdict=Verdict.INDETERMINATE,
+                observed_at=observed_at,
+                verified_at=self._now(),
+                verification_method="get_pr_head_sha",
+                commit_shas=(),
+                reason=f"API error: {exc}",
+            )
+        avail = self.verify_commit_available(gh, api_sha, branch_name)
+        if avail.verdict is Verdict.CONFIRMED:
+            return Evidence(
+                source="github_api",
+                subject="pr_head",
+                verdict=Verdict.CONFIRMED,
+                observed_at=observed_at,
+                verified_at=avail.verified_at,
+                verification_method=f"get_pr_head_sha + {avail.verification_method}",
+                commit_shas=(api_sha,),
+                reason=f"verified local: {avail.reason}",
+            )
+        return Evidence(
+            source="github_api",
+            subject="pr_head",
+            verdict=Verdict.INDETERMINATE,
+            observed_at=observed_at,
+            verified_at=avail.verified_at,
+            verification_method=f"get_pr_head_sha + {avail.verification_method}",
+            commit_shas=(api_sha,),
+            reason=f"head not verifiable locally: {avail.reason}",
+        )

--- a/app/modules/workspace/autonomous/evidence_service.py
+++ b/app/modules/workspace/autonomous/evidence_service.py
@@ -47,9 +47,23 @@ class EvidenceService:
         chance to succeed after a worktree teardown (the prior
         ``_ensure_pr_head_local`` behavior). REJECTED means the object truly
         cannot be resolved after fetching; callers must treat that as a
-        definitive "no" rather than retrying.
+        definitive "no" rather than retrying. An empty ``sha`` is a caller error
+        (no object to probe), returned as INDETERMINATE rather than REJECTED so
+        the composite ``resolve_verified_pr_head`` surfaces it as "cannot verify"
+        instead of "definitively absent".
         """
         observed_at = self._now()
+        if not sha:
+            return Evidence(
+                source="local_object_db",
+                subject="commit_availability",
+                verdict=Verdict.INDETERMINATE,
+                observed_at=observed_at,
+                verified_at=self._now(),
+                verification_method="cat-file -e",
+                commit_shas=(),
+                reason="empty sha: no object to probe",
+            )
         method = "cat-file -e"
         if sha and gh._run_git(["cat-file", "-e", sha], check=False).returncode == 0:
             return Evidence(

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -32,6 +32,8 @@ from app.modules.workspace.autonomous.artifact_text import (
     sanitize_artifact_text,
 )
 from app.modules.workspace.autonomous.event_emitter import AutonomousEventEmitter
+from app.modules.workspace.autonomous.evidence import Verdict
+from app.modules.workspace.autonomous.evidence_service import EvidenceService
 from app.modules.workspace.autonomous.github_ops import _FAILURE_LINE_RE, GitHubOps, GitHubOpsError
 from app.modules.workspace.autonomous.models import AgentTaskResult
 from app.modules.workspace.autonomous.progress_report_i18n import (
@@ -1273,6 +1275,20 @@ class AutonomousOrchestrator:
         self._gh: GitHubOps | None = None
 
     @property
+    def _evidence(self) -> EvidenceService:
+        """Lazily attach the verify-before-act evidence service (issue #2045).
+
+        Some unit tests construct the orchestrator via ``__new__`` (bypassing
+        ``__init__``) and stub individual methods; this property keeps those
+        tests working without each needing to set ``self._evidence`` explicitly.
+        """
+        cached = self.__dict__.get("_evidence_instance")
+        if cached is None:
+            cached = EvidenceService()
+            self.__dict__["_evidence_instance"] = cached
+        return cached
+
+    @property
     def workflow(self) -> dict | None:
         return self.repo.get_workflow(self._workflow_id)
 
@@ -1497,13 +1513,13 @@ class AutonomousOrchestrator:
         a "no" is a definitive commit-graph answer we act on, a git error is
         an indeterminate probe that must fail closed (see
         ``_main_drift_is_benign_pull``).
+
+        Issue #2045 Phase A: delegates to :class:`EvidenceService`, which returns
+        a tri-state :class:`Evidence`. The bool|None return is preserved for
+        existing callers (True=CONFIRMED, False=REJECTED, None=INDETERMINATE).
         """
-        rc = gh._run_git(["merge-base", "--is-ancestor", a, b], check=False).returncode
-        if rc == 0:
-            return True
-        if rc == 1:
-            return False
-        return None
+        evidence = self._evidence.verify_branch_contains(gh, head=b, base=a)
+        return evidence.verdict.to_bool_or_none()
 
     def _main_drift_is_benign_pull(
         self,
@@ -3633,7 +3649,15 @@ class AutonomousOrchestrator:
         Returns True if the PR head has main as an ancestor (nothing to merge),
         False if the branch is behind main, or None when the probe is
         indeterminate and the caller must fail closed.
+
+        Issue #2045 Phase A: the pr-head existence check (``_ensure_pr_head_local``)
+        and the ancestry probe (``_ancestor_check``) each delegate to
+        :class:`EvidenceService`; this method composes them as before so the
+        bool|None contract and the test-visible call structure are preserved.
         """
+        # Ensure pr_head_sha is local first; an unverifiable head is indeterminate.
+        # ``_ensure_pr_head_local`` already applies the workflow branch_name
+        # fallback, so reuse it to keep the historical fetch-ref behavior.
         if not self._ensure_pr_head_local(gh, pr_head_sha, branch_name):
             return None
         gh._run_git(["fetch", "origin", "main"])
@@ -3651,19 +3675,12 @@ class AutonomousOrchestrator:
         ``git merge-base`` then fails with "no commit" and fails the workflow.
         Fetch the branch first so the merge-base probe has both objects.
         Returns False if the object still cannot be resolved after fetching.
+
+        Issue #2045 Phase A: delegates to :class:`EvidenceService`.
         """
-        if (
-            pr_head_sha
-            and gh._run_git(["cat-file", "-e", pr_head_sha], check=False).returncode == 0
-        ):
-            return True
         ref = branch_name or self.workflow.get("branch_name", "")
-        if ref:
-            gh._run_git(["fetch", "origin", ref])
-        return bool(
-            pr_head_sha
-            and gh._run_git(["cat-file", "-e", pr_head_sha], check=False).returncode == 0
-        )
+        evidence = self._evidence.verify_commit_available(gh, pr_head_sha, ref)
+        return evidence.verdict is Verdict.CONFIRMED
 
     def _start_ci_repair_round(self, wf: dict, pr_number: int, failed_checks: list[dict]) -> None:
         """Repair merge-phase CI failures in-place on the existing PR branch."""

--- a/tests/unit/test_evidence_contract.py
+++ b/tests/unit/test_evidence_contract.py
@@ -88,6 +88,22 @@ def test_commit_available_rejected_when_absent_after_fetch():
     assert ev.reason
 
 
+def test_commit_available_empty_sha_is_indeterminate_not_rejected():
+    """Empty sha is a caller error → INDETERMINATE, not a definitive REJECTED.
+
+    A missing sha means there is no object to probe; surfacing it as
+    INDETERMINATE (rather than REJECTED) lets ``resolve_verified_pr_head``
+    classify it as "cannot verify" instead of "definitively absent", and never
+    touches git.
+    """
+    gh = MagicMock()
+    svc = EvidenceService()
+    ev = svc.verify_commit_available(gh, "", "feat")
+    assert ev.verdict is Verdict.INDETERMINATE
+    assert "empty sha" in ev.reason
+    gh._run_git.assert_not_called()
+
+
 # ── verify_branch_contains (ancestry) ──────────────────────────────────────
 
 

--- a/tests/unit/test_evidence_contract.py
+++ b/tests/unit/test_evidence_contract.py
@@ -1,0 +1,259 @@
+"""Contract tests for the Phase A verify-before-act evidence layer (issue #2045).
+
+These cover the five Phase-A acceptance criteria that the EvidenceService must
+satisfy before any orchestrator path consumes it for irreversible git ops:
+
+* PR head is fetched and verified local before use.
+* Ancestry distinguishes a definitive False from an indeterminate None.
+* Commit availability has distinct confirmed/rejected/indeterminate states.
+* Remote branch mismatch is indeterminate (never silently picks one head).
+* Evidence metadata records source, SHAs, and verification method.
+
+Tests follow the style in ``test_autonomous_ci_guardrails.py``: local imports,
+``MagicMock`` for ``GitHubOps``, and ``_run_git`` returncode control for the
+``cat-file -e`` / ``merge-base --is-ancestor`` / ``fetch`` probes.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.modules.workspace.autonomous.evidence import Evidence, Verdict
+from app.modules.workspace.autonomous.evidence_service import EvidenceService
+
+
+def _gh_with_git(returncodes_by_cmd):
+    """Build a MagicMock GitHubOps whose ``_run_git`` returncode depends on args.
+
+    ``returncodes_by_cmd`` maps a discriminator (first arg element, e.g.
+    ``"cat-file"`` or ``"merge-base"`` or ``"fetch"``) to the returncode to
+    return for that command. Unknown commands default to rc=0. This is more
+    robust than call-order indexing because verify_commit_available interleaves
+    cat-file / fetch / cat-file.
+    """
+    gh = MagicMock()
+
+    def fake_run_git(args, check=True):
+        key = args[0] if args else ""
+        rc = returncodes_by_cmd.get(key, 0)
+        return MagicMock(returncode=rc, stdout="", stderr="")
+
+    gh._run_git.side_effect = fake_run_git
+    return gh
+
+
+# ── verify_commit_available ────────────────────────────────────────────────
+
+
+def test_commit_available_confirmed_when_object_present():
+    """cat-file -e succeeds immediately → CONFIRMED without fetching."""
+    gh = _gh_with_git({"cat-file": 0})  # cat-file -e succeeds
+    svc = EvidenceService()
+    ev = svc.verify_commit_available(gh, "abc123", "feat")
+    assert ev.verdict is Verdict.CONFIRMED
+    assert ev.source == "local_object_db"
+    assert ev.commit_shas == ("abc123",)
+    assert ev.verification_method == "cat-file -e"
+
+
+def test_commit_available_confirmed_after_fetch():
+    """Object absent locally but resolves after fetch → CONFIRMED, source git_fetch."""
+    # cat-file -e fails, fetch (rc irrelevant), second cat-file -e succeeds.
+    gh = _gh_with_git({"cat-file": 1})
+    # Override: first cat-file fails, second succeeds — simulate via side_effect list.
+    gh._run_git.side_effect = [
+        MagicMock(returncode=1, stdout="", stderr=""),  # first cat-file -e
+        MagicMock(returncode=0, stdout="", stderr=""),  # fetch origin feat
+        MagicMock(returncode=0, stdout="", stderr=""),  # second cat-file -e
+    ]
+    svc = EvidenceService()
+    ev = svc.verify_commit_available(gh, "abc123", "feat")
+    assert ev.verdict is Verdict.CONFIRMED
+    assert ev.source == "git_fetch"
+    assert "fetch origin feat" in ev.verification_method
+
+
+def test_commit_available_rejected_when_absent_after_fetch():
+    """Object absent even after fetch → REJECTED (definitive, not indeterminate)."""
+    # cat-file -e fails before AND after fetch.
+    gh = MagicMock()
+    gh._run_git.side_effect = [
+        MagicMock(returncode=1),  # first cat-file -e
+        MagicMock(returncode=0),  # fetch origin feat
+        MagicMock(returncode=1),  # second cat-file -e
+    ]
+    svc = EvidenceService()
+    ev = svc.verify_commit_available(gh, "abc123", "feat")
+    assert ev.verdict is Verdict.REJECTED
+    assert ev.reason
+
+
+# ── verify_branch_contains (ancestry) ──────────────────────────────────────
+
+
+def test_ancestry_confirmed_when_base_is_ancestor():
+    """merge-base rc=0 → CONFIRMED (base is ancestor of head)."""
+    # cat-file -e head succeeds (0), then merge-base rc=0.
+    gh = _gh_with_git({"cat-file": 0, "merge-base": 0})
+    svc = EvidenceService()
+    ev = svc.verify_branch_contains(gh, head="head1", base="base1", branch_name="feat")
+    assert ev.verdict is Verdict.CONFIRMED
+
+
+def test_ancestry_false_and_indeterminate_are_distinct():
+    """rc=1 (REJECTED) vs rc=128 (INDETERMINATE) must not collapse to the same value.
+
+    This is the core Phase A acceptance criterion: a definitive 'no ancestry' is
+    a commit-graph answer the caller acts on, while a git error must fail closed.
+    """
+    svc = EvidenceService()
+    # cat-file -e head succeeds, merge-base rc=1 → REJECTED.
+    ev_rejected = svc.verify_branch_contains(
+        _gh_with_git({"cat-file": 0, "merge-base": 1}),
+        head="h",
+        base="b",
+        branch_name="feat",
+    )
+    # cat-file -e head succeeds, merge-base rc=128 → INDETERMINATE.
+    ev_indeterminate = svc.verify_branch_contains(
+        _gh_with_git({"cat-file": 0, "merge-base": 128}),
+        head="h",
+        base="b",
+        branch_name="feat",
+    )
+    assert ev_rejected.verdict is Verdict.REJECTED
+    assert ev_indeterminate.verdict is Verdict.INDETERMINATE
+    assert ev_rejected.verdict is not ev_indeterminate.verdict
+    # bool|None mapping must also differ (False vs None).
+    assert ev_rejected.verdict.to_bool_or_none() is False
+    assert ev_indeterminate.verdict.to_bool_or_none() is None
+
+
+def test_ancestry_indeterminate_when_head_object_missing():
+    """Head unavailable after fetch → INDETERMINATE (probe cannot run)."""
+    # cat-file -e head fails before AND after fetch; merge-base never runs.
+    gh = MagicMock()
+    gh._run_git.side_effect = [
+        MagicMock(returncode=1),  # first cat-file -e head
+        MagicMock(returncode=0),  # fetch origin feat
+        MagicMock(returncode=1),  # second cat-file -e head
+    ]
+    svc = EvidenceService()
+    ev = svc.verify_branch_contains(gh, head="h", base="b", branch_name="feat")
+    assert ev.verdict is Verdict.INDETERMINATE
+    assert "head object unavailable" in ev.reason
+
+
+# ── verify_remote_branch_state ─────────────────────────────────────────────
+
+
+def test_remote_branch_state_confirmed_when_heads_match():
+    gh = _gh_with_git({"fetch": 0})  # fetch succeeds
+    gh.resolve_commit.return_value = "remote1"
+    svc = EvidenceService()
+    ev = svc.verify_remote_branch_state(gh, "feat", "remote1")
+    assert ev.verdict is Verdict.CONFIRMED
+
+
+def test_remote_branch_state_mismatch_is_indeterminate_not_silent():
+    """Heads differ → INDETERMINATE; never silently trust one side.
+
+    The whole point of issue #2045: a mismatch does not tell us which SHA is
+    authoritative, so the caller must re-derive expected_head rather than pick.
+    """
+    gh = _gh_with_git({"fetch": 0})  # fetch succeeds
+    gh.resolve_commit.return_value = "actual"
+    svc = EvidenceService()
+    ev = svc.verify_remote_branch_state(gh, "feat", "expected")
+    assert ev.verdict is Verdict.INDETERMINATE
+    assert "actual" in ev.reason and "expected" in ev.reason
+
+
+def test_remote_branch_state_indeterminate_when_fetch_fails():
+    gh = _gh_with_git({"fetch": 2})  # fetch fails
+    svc = EvidenceService()
+    ev = svc.verify_remote_branch_state(gh, "feat", "expected")
+    assert ev.verdict is Verdict.INDETERMINATE
+    assert "fetch failed" in ev.reason
+
+
+# ── resolve_verified_pr_head (composite) ───────────────────────────────────
+
+
+def test_api_pr_head_is_fetched_and_verified_before_use():
+    """PR head SHA from the API is CONFIRMED only after local object verification.
+
+    Guards the historical bug where ``get_pr_head_sha`` returned an API SHA that
+    was never fetched, so ``merge-base`` later failed with 'no commit'.
+    """
+    gh = MagicMock()
+    gh.get_pr_head_sha.return_value = "api-sha"
+    # cat-file -e succeeds (object already local).
+    gh._run_git.return_value = MagicMock(returncode=0, stdout="", stderr="")
+    svc = EvidenceService()
+    ev = svc.resolve_verified_pr_head(gh, 42, "feat")
+    assert ev.verdict is Verdict.CONFIRMED
+    assert ev.subject == "pr_head"
+    assert ev.commit_shas == ("api-sha",)
+    gh.get_pr_head_sha.assert_called_once_with(42)
+
+
+def test_api_pr_head_indeterminate_when_object_unverifiable():
+    """API SHA that cannot be resolved locally → INDETERMINATE, not CONFIRMED."""
+    gh = MagicMock()
+    gh.get_pr_head_sha.return_value = "api-sha"
+    # cat-file -e fails both before and after fetch.
+    gh._run_git.side_effect = [
+        MagicMock(returncode=1),  # first cat-file -e
+        MagicMock(returncode=0),  # fetch origin feat
+        MagicMock(returncode=1),  # second cat-file -e
+    ]
+    svc = EvidenceService()
+    ev = svc.resolve_verified_pr_head(gh, 42, "feat")
+    assert ev.verdict is Verdict.INDETERMINATE
+    assert ev.commit_shas == ("api-sha",)
+
+
+def test_api_pr_head_indeterminate_on_api_error():
+    """get_pr_head_sha raising → INDETERMINATE, never an unhandled exception."""
+    gh = MagicMock()
+    gh.get_pr_head_sha.side_effect = RuntimeError("api down")
+    svc = EvidenceService()
+    ev = svc.resolve_verified_pr_head(gh, 42, "feat")
+    assert ev.verdict is Verdict.INDETERMINATE
+    assert "API error" in ev.reason
+
+
+# ── evidence metadata ──────────────────────────────────────────────────────
+
+
+def test_evidence_metadata_records_source_sha_and_method():
+    """Evidence.to_dict() carries the audit fields required by #2045 Phase A."""
+    gh = _gh_with_git({"cat-file": 0})  # cat-file -e succeeds
+    svc = EvidenceService()
+    ev = svc.verify_commit_available(gh, "abc123", "feat")
+    data = ev.to_dict()
+    assert data["source"] == "local_object_db"
+    assert data["subject"] == "commit_availability"
+    assert data["verdict"] == "confirmed"
+    assert data["verification_method"] == "cat-file -e"
+    assert data["commit_shas"] == ["abc123"]
+    assert "observed_at" in data and "verified_at" in data
+    assert data["reason"]
+
+
+def test_verdict_to_bool_or_none_mapping():
+    """Tri-state maps cleanly to the legacy bool|None contract."""
+    assert Verdict.CONFIRMED.to_bool_or_none() is True
+    assert Verdict.REJECTED.to_bool_or_none() is False
+    assert Verdict.INDETERMINATE.to_bool_or_none() is None
+
+
+def test_evidence_is_frozen():
+    """Evidence is immutable so it can be safely cached/shared."""
+    gh = _gh_with_git({"cat-file": 0})
+    svc = EvidenceService()
+    ev = svc.verify_commit_available(gh, "abc123", "feat")
+    assert isinstance(ev, Evidence)
+    with pytest.raises((AttributeError, Exception)):
+        ev.reason = "mutated"


### PR DESCRIPTION
## Summary

Implements **Phase A** of #2045: a uniform tri-state (//) verification layer so external/derived signals (PR head SHA, commit availability, ancestry, remote branch state) are never trusted raw before irreversible git ops.

This is the foundational contract;  integration, #2042 worktree recovery, and Phase B (merge readiness / CI required-optional classification / PhaseHandler preflight) are deferred to follow-up PRs per the issue's phased plan.

## Background

Open ACE added ancestry / object-existence / remote-head / merge-state helpers one at a time across multiple incidents (#1991, #1993/#1994, #1999, #1989, #2034). The root cause is not any single GitHub field but the absence of unified verification semantics for external/cached/derived signals before irreversible operations. This PR establishes that contract.

## Changes

### New modules

- **`app/modules/workspace/autonomous/evidence.py`** — pure types:
  - `Verdict` enum (`CONFIRMED`/`REJECTED`/`INDETERMINATE`) with `to_bool_or_none()` for the legacy `bool | None` contract.
  - `Evidence` frozen dataclass carrying `source`, `subject`, `observed_at`, `verified_at`, `verification_method`, `commit_shas`, `reason` + `to_dict()` for milestone metadata serialization.

- **`app/modules/workspace/autonomous/evidence_service.py`** — `EvidenceService` with 4 verification interfaces:
  - `verify_commit_available` — `cat-file -e` + on-demand fetch → CONFIRMED/REJECTED.
  - `verify_branch_contains` — object existence + `merge-base --is-ancestor` → **distinguishes REJECTED (rc=1) from INDETERMINATE (rc≥128)**.
  - `verify_remote_branch_state` — fetch + compare head → mismatch is INDETERMINATE (never silently picks a side).
  - `resolve_verified_pr_head` — composite: API SHA + local object verification in one call.

### Orchestrator delegation (`orchestrator.py`, +34/-17)

`_ancestor_check`, `_ensure_pr_head_local`, `_branch_contains_main` now delegate to `EvidenceService` while:
- Preserving their `bool | None` return contract (all existing call sites and test patches unchanged).
- Preserving the test-visible call structure (`_branch_contains_main` still calls `self._ancestor_check` and `self._ensure_pr_head_local`).
- `_evidence` is a lazy `@property` so tests using `__new__` (bypassing `__init__`) keep working without per-test setup.

## Tests

`tests/unit/test_evidence_contract.py` — 15 contract tests covering the Phase A acceptance criteria:

| Test | Acceptance criterion |
|------|---------------------|
| `test_ancestry_false_and_indeterminate_are_distinct` | ancestry False vs indeterminate are distinct |
| `test_api_pr_head_is_fetched_and_verified_before_use` | PR head fetched + verified before use |
| `test_remote_branch_state_mismatch_is_indeterminate_not_silent` | head mismatch does not silently pick a side |
| `test_commit_available_*` (3 tests) | confirmed/rejected/indeterminate distinct |
| `test_evidence_metadata_records_source_sha_and_method` | evidence records source/SHA/method |

## Verification

- ✅ 15 new evidence contract tests pass
- ✅ 78 CI guardrails regression tests pass (no behavior change)
- ✅ ruff (line-length=100) + pydocstyle clean (all pre-commit hooks pass)
- ⚠️ `tests/issues/822/` has 4 pre-existing failures on macOS (`/tmp`→`/private/tmp` symlink path-containment assertion), unrelated to this change — verified via `git stash` on clean main.

## Acceptance criteria (Phase A)

- [x] Define confirmed/rejected/indeterminate result (`Verdict`)
- [x] PR head fetched and commit object resolvable before use (`resolve_verified_pr_head`)
- [x] Branch containment distinguishes False from indeterminate (`verify_branch_contains`)
- [x] local/API/fetch/expected head mismatch does not silently choose (returns INDETERMINATE)
- [ ] #2042 recovers fully through the verified-head interface *(deferred — #2042 itself incomplete)*
- [ ] evidence written to milestone/event metadata *(deferred to integration PR)*

## Not in scope (follow-up PRs)

- `_do_merge` consuming `resolve_verified_pr_head` (fixes the stale-SHA in the dirty probe at orchestrator.py:8549 vs 8714)
- #2042 worktree recovery integration (recovery code currently does not consult PR head at all)
- Phase B: `classify_merge_readiness`, `collect_actionable_ci_failures` (required/optional), PhaseHandler preflight
- DB schema: evidence currently returns in-memory objects only

Closes #2045 (Phase A portion).