### PR TITLE
fix(autonomous): separate delivery and Git cleanup status with retry (#2043)

### DIFF
--- a/app/modules/workspace/autonomous/github_ops.py
+++ b/app/modules/workspace/autonomous/github_ops.py
@@ -805,11 +805,46 @@ class GitHubOps:
         """Discard local CI-repair state and reset to a trusted immutable ref."""
         self._run_git(["reset", "--hard", ref])
 
-    def delete_branch(self, name: str, remote: bool = True) -> None:
-        """Delete a branch locally and optionally remotely."""
-        self._run_git(["branch", "-D", name], check=False)
+    def delete_branch(self, name: str, remote: bool = True) -> dict:
+        """Delete a branch locally and optionally remotely.
+
+        Returns a structured result so callers can distinguish a real failure
+        from an already-absent branch (#2043). Previously both commands used
+        ``check=False`` and returned ``None``, silently swallowing failures —
+        the caller could not tell whether deletion succeeded.
+
+        Result shape::
+
+            {"local": "deleted"|"absent"|"failed",
+             "remote": "deleted"|"absent"|"failed"|"skipped",
+             "errors": [str, ...]}
+
+        ``absent`` is success-equivalent (the resource was already gone).
+        ``failed`` means a real error warranting retry; ``errors`` carries the
+        truncated stderr for diagnostics.
+        """
+        local_res = self._run_git(["branch", "-D", name], check=False)
+        local_stderr = (local_res.stderr or "").lower()
+        if local_res.returncode == 0:
+            local = "deleted"
+        elif "not found" in local_stderr:
+            local = "absent"
+        else:
+            local = "failed"
+        result: dict = {"local": local, "remote": "skipped", "errors": []}
+        if local == "failed":
+            result["errors"].append((local_res.stderr or "").strip()[:500])
         if remote:
-            self._run_git(["push", "origin", "--delete", name], check=False)
+            remote_res = self._run_git(["push", "origin", "--delete", name], check=False)
+            remote_stderr = (remote_res.stderr or "").lower()
+            if remote_res.returncode == 0:
+                result["remote"] = "deleted"
+            elif "not found" in remote_stderr or "does not exist" in remote_stderr:
+                result["remote"] = "absent"
+            else:
+                result["remote"] = "failed"
+                result["errors"].append((remote_res.stderr or "").strip()[:500])
+        return result
 
     # ── Worktree Operations ─────────────────────────────────────────
 

--- a/app/modules/workspace/autonomous/github_ops.py
+++ b/app/modules/workspace/autonomous/github_ops.py
@@ -822,12 +822,24 @@ class GitHubOps:
         ``absent`` is success-equivalent (the resource was already gone).
         ``failed`` means a real error warranting retry; ``errors`` carries the
         truncated stderr for diagnostics.
+
+        Existence is checked via returncode-based probes (``show-ref`` locally,
+        ``ls-remote`` remotely) rather than parsing stderr text, which varies
+        across git versions and server implementations (GitHub.com / GitLab /
+        GHES). A non-zero delete that follows a confirmed-existing resource is a
+        real failure; a delete of an already-absent resource is reported absent.
         """
+        # Local existence check: show-ref returncode is stable across git versions.
+        local_exists = (
+            self._run_git(
+                ["show-ref", "--verify", "--quiet", f"refs/heads/{name}"], check=False
+            ).returncode
+            == 0
+        )
         local_res = self._run_git(["branch", "-D", name], check=False)
-        local_stderr = (local_res.stderr or "").lower()
         if local_res.returncode == 0:
             local = "deleted"
-        elif "not found" in local_stderr:
+        elif not local_exists:
             local = "absent"
         else:
             local = "failed"
@@ -835,11 +847,14 @@ class GitHubOps:
         if local == "failed":
             result["errors"].append((local_res.stderr or "").strip()[:500])
         if remote:
+            # Remote existence check: ls-remote returncode is stable; an empty
+            # stdout means the ref does not exist on the remote.
+            ls_res = self._run_git(["ls-remote", "origin", name], check=False)
+            remote_exists = ls_res.returncode == 0 and bool((ls_res.stdout or "").strip())
             remote_res = self._run_git(["push", "origin", "--delete", name], check=False)
-            remote_stderr = (remote_res.stderr or "").lower()
             if remote_res.returncode == 0:
                 result["remote"] = "deleted"
-            elif "not found" in remote_stderr or "does not exist" in remote_stderr:
+            elif not remote_exists:
                 result["remote"] = "absent"
             else:
                 result["remote"] = "failed"

--- a/app/modules/workspace/autonomous/models.py
+++ b/app/modules/workspace/autonomous/models.py
@@ -49,6 +49,11 @@ class AutonomousWorkflow:
     batch_total: int | None = None
     base_commit_sha: str | None = None  # Locked SHA for batch workflows (Issue #1552)
     expected_head_sha: str | None = None  # Last trusted workflow head (Issue #2042)
+    cleanup_status: str | None = None  # not_started|pending|completed|failed (Issue #2043)
+    cleanup_attempts: int | None = 0  # Git cleanup retry counter (Issue #2043)
+    cleanup_error: str | None = None  # Last cleanup error message (Issue #2043)
+    cleanup_updated_at: str | None = None  # ISO timestamp of last cleanup attempt
+    cleanup_next_retry_at: str | None = None  # ISO timestamp; backoff-gated
     auto_merge: bool = True  # Auto merge PR and proceed to next workflow in batch
     definition_snapshot: dict | None = None
     current_phase: str = (
@@ -127,6 +132,11 @@ class AutonomousWorkflow:
             "batch_total": self.batch_total,
             "base_commit_sha": self.base_commit_sha,
             "expected_head_sha": self.expected_head_sha,
+            "cleanup_status": self.cleanup_status,
+            "cleanup_attempts": self.cleanup_attempts,
+            "cleanup_error": self.cleanup_error,
+            "cleanup_updated_at": self.cleanup_updated_at,
+            "cleanup_next_retry_at": self.cleanup_next_retry_at,
             "auto_merge": self.auto_merge,
             "definition_snapshot": self.definition_snapshot,
             "current_phase": self.current_phase,
@@ -185,6 +195,11 @@ class AutonomousWorkflow:
             batch_total=data.get("batch_total"),
             base_commit_sha=data.get("base_commit_sha"),
             expected_head_sha=data.get("expected_head_sha"),
+            cleanup_status=data.get("cleanup_status"),
+            cleanup_attempts=data.get("cleanup_attempts"),
+            cleanup_error=data.get("cleanup_error"),
+            cleanup_updated_at=data.get("cleanup_updated_at"),
+            cleanup_next_retry_at=data.get("cleanup_next_retry_at"),
             auto_merge=bool(data.get("auto_merge", True)),
             definition_snapshot=data.get("definition_snapshot"),
             current_phase=data.get("current_phase", "preparation"),

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -1215,6 +1215,17 @@ MAX_PRE_COMMIT_CONVERGENCE_PASSES = 3
 PRE_COMMIT_CONVERGENCE_TIMEOUT = 600
 CI_PRE_COMMIT_SKIP = "bandit,no-commit-to-branch"
 MAX_CI_DIAGNOSTICS_ATTEMPTS = 6  # bound scheduler polls when failed job logs stay unavailable
+MAX_CLEANUP_ATTEMPTS = 10  # post-merge Git cleanup retries before giving up (#2043)
+
+
+def _cleanup_backoff_time(attempts: int) -> str:
+    """ISO timestamp for the next cleanup retry; exponential backoff capped at 1h (#2043)."""
+    from datetime import timedelta
+
+    delay = min(60 * (2 ** max(attempts - 1, 0)), 3600)
+    return (datetime.now(timezone.utc) + timedelta(seconds=delay)).strftime("%Y-%m-%d %H:%M:%S")
+
+
 try:
     MAX_AUTONOMOUS_CHANGED_FILES = int(os.environ.get("AUTONOMOUS_MAX_CHANGED_FILES", "60"))
 except ValueError:
@@ -4235,7 +4246,22 @@ class AutonomousOrchestrator:
                 self._update_workflow({"worktree_path": ""})
             if remove_branch and branch_name:
                 gh = GitHubOps(project_path, system_account=system_account)
-                gh.delete_branch(branch_name)
+                result = gh.delete_branch(branch_name)
+                # delete_branch returns a structured {local, remote, errors} dict
+                # (#2043). 'absent' is success-equivalent; only 'failed' counts.
+                if result.get("local") == "failed" or result.get("remote") == "failed":
+                    failed_parts = [
+                        p
+                        for p, v in (
+                            ("local", result.get("local")),
+                            ("remote", result.get("remote")),
+                        )
+                        if v == "failed"
+                    ]
+                    raise GitHubOpsError(
+                        f"Branch deletion failed ({'/'.join(failed_parts)}): "
+                        + "; ".join(result.get("errors") or [])[:300]
+                    )
                 self._update_workflow({"branch_name": ""})
         except GitHubOpsError as e:
             logger.warning("Cleanup (%s) failed: %s", reason, e)
@@ -4244,6 +4270,46 @@ class AutonomousOrchestrator:
             logger.warning("Cleanup (%s) raised: %s", reason, e)
             return False
         return True
+
+    def _perform_git_cleanup(self) -> tuple[str, str]:
+        """Retry entry point for post-merge Git cleanup (#2043).
+
+        Wraps :meth:`_cleanup_worktree_and_branch` and persists the
+        ``cleanup_*`` tracking fields so delivery completion and resource
+        convergence stay independent. Idempotent: a workflow whose worktree and
+        branch are already gone reports ``completed``. Returns
+        ``(status, error)`` where status is ``completed`` or ``failed``.
+        """
+        wf = self.workflow or {}
+        attempts = int(wf.get("cleanup_attempts") or 0) + 1
+        now_iso = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+        ok = self._cleanup_worktree_and_branch(
+            reason="completed", remove_worktree=True, remove_branch=True
+        )
+        if ok:
+            self._update_workflow(
+                {
+                    "cleanup_status": "completed",
+                    "cleanup_attempts": attempts,
+                    "cleanup_error": "",
+                    "cleanup_updated_at": now_iso,
+                    "cleanup_next_retry_at": "",
+                }
+            )
+            return "completed", ""
+        # Transient/partial failure — schedule a backoff retry unless exhausted.
+        error = wf.get("error_message") or "Git cleanup failed (worktree or branch)"
+        status = "pending" if attempts < MAX_CLEANUP_ATTEMPTS else "failed"
+        self._update_workflow(
+            {
+                "cleanup_status": status,
+                "cleanup_attempts": attempts,
+                "cleanup_error": error[:500],
+                "cleanup_updated_at": now_iso,
+                "cleanup_next_retry_at": _cleanup_backoff_time(attempts),
+            }
+        )
+        return status, error
 
     def _mark_failed(self, error_message: str, *, phase: str | None = None) -> None:
         """Record a terminal workflow failure (status + error event) only.
@@ -9240,31 +9306,43 @@ class AutonomousOrchestrator:
                 # error so the workflow fails visibly instead of spinning.
                 raise
 
-        # Clean up branch/worktree. Re-read wf because _resolve_merge_conflicts
-        # restores worktree_path in its finally block (so the restored value
-        # may differ from the caller's stale snapshot); using the stale snapshot
-        # would retry the removal and fail, skipping branch deletion (#1107).
-        # _cleanup_worktree_and_branch re-reads self.workflow itself, so it sees
-        # the restored value. The branch IS removed here — the PR is merged.
-        cleanup_ok = self._cleanup_worktree_and_branch(
-            reason="completed", remove_worktree=True, remove_branch=True
+        # Persist delivery completion FIRST, independent of cleanup outcome
+        # (#2043). Previously a cleanup failure only logged a warning and the
+        # workflow still went completed — but with no record that resources were
+        # still leaked. Now cleanup_status tracks resource convergence so the
+        # scheduler/startup sweep can retry; the business status is already final.
+        self._update_workflow(
+            {
+                "status": "completed",
+                "completed_at": datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S"),
+                "cleanup_status": "pending",
+                "cleanup_updated_at": datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S"),
+            }
         )
-        if cleanup_ok:
+        self._emit("phase_change", {"phase": "completed"})
+
+        # Best-effort immediate cleanup. _perform_git_cleanup persists the
+        # cleanup_* fields (completed on success, pending/failed on retry).
+        # Re-reads self.workflow so it sees the restored worktree_path value
+        # (#1107: _resolve_merge_conflicts restores it in its finally block).
+        cleanup_status, cleanup_error = self._perform_git_cleanup()
+        if cleanup_status == "completed":
             self._create_milestone(
                 phase="merge",
                 milestone_type="cleaned_up",
                 status="completed",
                 title="Branch/worktree cleaned up",
             )
-
-        # Mark workflow completed
-        self._update_workflow(
-            {
-                "status": "completed",
-                "completed_at": datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S"),
-            }
-        )
-        self._emit("phase_change", {"phase": "completed"})
+        else:
+            # cleanup_status is pending or failed — record why without faking
+            # a cleaned_up milestone. The scheduler sweep retries pending ones.
+            self._create_milestone(
+                phase="merge",
+                milestone_type="cleanup_pending",
+                status="failed",
+                title="Git cleanup pending retry",
+                error_message=(cleanup_error or "")[:300],
+            )
 
     def _sync_worktree_to_pr_remote_head(self, wt_gh: "GitHubOps", branch_name: str) -> None:
         """Sync a merge worktree to the PR branch's authoritative remote head.

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -4296,6 +4296,17 @@ class AutonomousOrchestrator:
                     "cleanup_next_retry_at": "",
                 }
             )
+            # Record a cleaned_up milestone when a retry converges, so the audit
+            # trail shows the eventual success (not just the prior cleanup_pending
+            # failure). The immediate-success path in _do_merge records its own
+            # cleaned_up milestone; this covers the retry-recovered case.
+            if attempts > 1:
+                self._create_milestone(
+                    phase="merge",
+                    milestone_type="cleaned_up",
+                    status="completed",
+                    title=f"Git cleanup recovered after {attempts} attempt(s)",
+                )
             return "completed", ""
         # Transient/partial failure — schedule a backoff retry unless exhausted.
         error = wf.get("error_message") or "Git cleanup failed (worktree or branch)"

--- a/app/repositories/autonomous_repo.py
+++ b/app/repositories/autonomous_repo.py
@@ -99,6 +99,12 @@ class AutonomousWorkflowRepository:
         "transition_error",
         "transition_started_at",
         "transition_updated_at",
+        # Post-merge Git cleanup tracking (#2043).
+        "cleanup_status",
+        "cleanup_attempts",
+        "cleanup_error",
+        "cleanup_updated_at",
+        "cleanup_next_retry_at",
     }
     ALLOWED_MILESTONE_FIELDS = {
         "phase",
@@ -486,6 +492,22 @@ class AutonomousWorkflowRepository:
             WHERE status IN ('pending', 'preparing', 'planning', 'developing',
                              'pr_review', 'reporting', 'waiting', 'merging')
             ORDER BY created_at ASC
+            """
+        )
+
+    def get_workflows_pending_cleanup(self) -> list:
+        """Get delivered workflows whose Git cleanup is still pending (#2043).
+
+        Returns ``status='completed'`` rows with ``cleanup_status='pending'`` so
+        the startup sweep and scheduler retry pass can re-attempt worktree/branch
+        removal. Ordered by ``cleanup_updated_at`` so the oldest failures retry
+        first. Legacy rows (NULL cleanup_status) are excluded.
+        """
+        return self.db.fetch_all(
+            """
+            SELECT * FROM autonomous_workflows
+            WHERE status = 'completed' AND cleanup_status = 'pending'
+            ORDER BY cleanup_updated_at ASC NULLS LAST, created_at ASC
             """
         )
 

--- a/app/services/autonomous_scheduler.py
+++ b/app/services/autonomous_scheduler.py
@@ -634,8 +634,9 @@ class AutonomousScheduler:
         self._reclaim_paused_slots(repo)
         # Retry Git cleanup for delivered-but-uncleaned workflows (#2043). Runs
         # each tick so transient cleanup failures converge without waiting for a
-        # restart; honors per-workflow backoff via cleanup_next_retry_at.
-        _retry_pending_git_cleanups()
+        # restart; honors per-workflow backoff via cleanup_next_retry_at. Reuses
+        # the scheduler's own repo so test mocks of _get_repo stay effective.
+        _retry_pending_git_cleanups(repo)
 
         try:
             workflows = repo.get_active_workflows()
@@ -882,7 +883,7 @@ def _reconcile_pending_transitions():
         logger.error("Worktree transition reconcile sweep failed: %s", e, exc_info=True)
 
 
-def _retry_pending_git_cleanups():
+def _retry_pending_git_cleanups(repo=None):
     """Re-attempt post-merge Git cleanup for delivered workflows (#2043).
 
     Walks every ``status='completed'`` workflow with ``cleanup_status='pending'``
@@ -891,13 +892,18 @@ def _retry_pending_git_cleanups():
     tick. This is shared by the startup sweep and the periodic scheduler tick so
     both converge leaked worktrees/branches without a separate worker. Failures
     are isolated per workflow.
+
+    ``repo`` lets the periodic tick reuse the scheduler's own (mock-friendly)
+    repository; the startup sweep omits it and constructs one.
     """
     try:
         from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
-        from app.repositories.autonomous_repo import AutonomousWorkflowRepository
-        from app.repositories.database import Database
 
-        repo = AutonomousWorkflowRepository(Database())
+        if repo is None:
+            from app.repositories.autonomous_repo import AutonomousWorkflowRepository
+            from app.repositories.database import Database
+
+            repo = AutonomousWorkflowRepository(Database())
         pending = repo.get_workflows_pending_cleanup()
         if not pending:
             return

--- a/app/services/autonomous_scheduler.py
+++ b/app/services/autonomous_scheduler.py
@@ -632,6 +632,10 @@ class AutonomousScheduler:
         # Release git-conflict keys held by workflows paused mid-advance, so a
         # forked child sharing the parent's project_path isn't starved (#1002).
         self._reclaim_paused_slots(repo)
+        # Retry Git cleanup for delivered-but-uncleaned workflows (#2043). Runs
+        # each tick so transient cleanup failures converge without waiting for a
+        # restart; honors per-workflow backoff via cleanup_next_retry_at.
+        _retry_pending_git_cleanups()
 
         try:
             workflows = repo.get_active_workflows()
@@ -878,12 +882,66 @@ def _reconcile_pending_transitions():
         logger.error("Worktree transition reconcile sweep failed: %s", e, exc_info=True)
 
 
+def _retry_pending_git_cleanups():
+    """Re-attempt post-merge Git cleanup for delivered workflows (#2043).
+
+    Walks every ``status='completed'`` workflow with ``cleanup_status='pending'``
+    and re-runs the idempotent ``_perform_git_cleanup``. Honors the per-workflow
+    ``cleanup_next_retry_at`` backoff so a transient failure is not retried every
+    tick. This is shared by the startup sweep and the periodic scheduler tick so
+    both converge leaked worktrees/branches without a separate worker. Failures
+    are isolated per workflow.
+    """
+    try:
+        from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+        from app.repositories.autonomous_repo import AutonomousWorkflowRepository
+        from app.repositories.database import Database
+
+        repo = AutonomousWorkflowRepository(Database())
+        pending = repo.get_workflows_pending_cleanup()
+        if not pending:
+            return
+
+        now = datetime.now(timezone.utc)
+        for wf in pending:
+            wf_id = wf.get("workflow_id")
+            if not isinstance(wf_id, str) or not wf_id:
+                continue
+            # Backoff: skip until cleanup_next_retry_at has passed.
+            next_retry = wf.get("cleanup_next_retry_at") or ""
+            if next_retry:
+                try:
+                    due = datetime.strptime(next_retry, "%Y-%m-%d %H:%M:%S").replace(
+                        tzinfo=timezone.utc
+                    )
+                except ValueError:
+                    due = now
+                if due > now:
+                    continue
+            try:
+                orchestrator = AutonomousOrchestrator(wf_id)
+                orchestrator._perform_git_cleanup()
+            except Exception as e:  # noqa: BLE001
+                logger.error(
+                    "Git cleanup retry raised for workflow %s: %s",
+                    (wf_id or "")[:8],
+                    e,
+                    exc_info=True,
+                )
+
+        logger.info("Processed %d pending Git cleanup(s)", len(pending))
+    except Exception as e:  # noqa: BLE001
+        logger.error("Git cleanup retry sweep failed: %s", e, exc_info=True)
+
+
 def init_autonomous_scheduler():
     """Initialize and start the autonomous scheduler."""
     # Clean up orphaned processes from previous server run
     _cleanup_orphan_processes()
     # Recover any worktree transitions interrupted by a prior SIGKILL/restart
     _reconcile_pending_transitions()
+    # Retry Git cleanup for workflows delivered but not yet cleaned up (#2043)
+    _retry_pending_git_cleanups()
 
     scheduler = AutonomousScheduler.instance()
     scheduler.start()

--- a/migrations/versions/20260726_005_add_cleanup_tracking.py
+++ b/migrations/versions/20260726_005_add_cleanup_tracking.py
@@ -54,11 +54,14 @@ def upgrade() -> None:
     for col_name, col_type in NEW_COLUMNS:
         if col_name in existing_columns:
             continue
-        nullable = col_name != "cleanup_attempts"
-        default = 0 if col_name == "cleanup_attempts" else None
+        # All cleanup_* columns are nullable: NULL = legacy row (no cleanup
+        # tracking), consistent with cleanup_status. The sweep treats NULL
+        # attempts as 0 via int(... or 0). Avoiding NOT NULL here means an
+        # in-place upgrade of a populated table succeeds (no server default
+        # needed); a NOT NULL add would fail on existing rows.
         op.add_column(
             "autonomous_workflows",
-            sa.Column(col_name, col_type, nullable=nullable, default=default),
+            sa.Column(col_name, col_type, nullable=True),
         )
 
 

--- a/migrations/versions/20260726_005_add_cleanup_tracking.py
+++ b/migrations/versions/20260726_005_add_cleanup_tracking.py
@@ -1,0 +1,77 @@
+"""Add cleanup tracking columns to autonomous_workflows
+
+Revision ID: 20260726_005_add_cleanup_tracking
+Revises: 20260726_004_add_webhook_deliveries
+Create Date: 2026-07-26
+
+Issue: #2043
+
+Post-merge Git cleanup (worktree + branch) previously ran as a fire-and-forget
+``try/except`` inside ``_do_merge``: a failure only logged a warning, then the
+workflow was unconditionally marked ``completed`` and never re-examined. Residual
+worktrees/branches blocked later retries (#1442) with no record that cleanup
+had failed.
+
+This migration adds a cleanup-tracking facet so delivery completion and resource
+convergence become independent, observable states. All columns are nullable with
+no backfill: a NULL ``cleanup_status`` means "legacy row, no cleanup tracking" —
+those rows are invisible to the cleanup retry scan and keep behaving as before.
+"""
+
+import logging
+
+import sqlalchemy as sa
+from alembic import op
+
+log = logging.getLogger(__name__)
+
+revision: str = "20260726_005_add_cleanup_tracking"
+down_revision: str | None = "20260726_004_add_webhook_deliveries"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+# Columns added for post-merge Git resource cleanup tracking (#2043).
+NEW_COLUMNS: tuple[tuple[str, sa.types.TypeEngine], ...] = (
+    ("cleanup_status", sa.Text()),  # not_started | pending | completed | failed
+    ("cleanup_attempts", sa.Integer()),  # retry counter
+    ("cleanup_error", sa.Text()),  # last error message
+    ("cleanup_updated_at", sa.Text()),  # ISO timestamp of last attempt
+    ("cleanup_next_retry_at", sa.Text()),  # ISO timestamp; backoff-gated
+)
+
+
+def upgrade() -> None:
+    """Add the cleanup tracking columns."""
+    connection = op.get_bind()
+    inspector = sa.inspect(connection)
+
+    if "autonomous_workflows" not in set(inspector.get_table_names()):
+        # Fresh databases create the columns directly in CREATE TABLE
+        # (schema_init / _ensure_tables); nothing to migrate here.
+        return
+
+    existing_columns = {col["name"] for col in inspector.get_columns("autonomous_workflows")}
+    for col_name, col_type in NEW_COLUMNS:
+        if col_name in existing_columns:
+            continue
+        nullable = col_name != "cleanup_attempts"
+        default = 0 if col_name == "cleanup_attempts" else None
+        op.add_column(
+            "autonomous_workflows",
+            sa.Column(col_name, col_type, nullable=nullable, default=default),
+        )
+
+
+def downgrade() -> None:
+    """Remove the cleanup tracking columns."""
+    connection = op.get_bind()
+    inspector = sa.inspect(connection)
+
+    if "autonomous_workflows" not in set(inspector.get_table_names()):
+        return
+
+    existing_columns = {col["name"] for col in inspector.get_columns("autonomous_workflows")}
+    with op.batch_alter_table("autonomous_workflows") as batch_op:
+        for col_name, _ in reversed(NEW_COLUMNS):
+            if col_name in existing_columns:
+                batch_op.drop_column(col_name)

--- a/schema/schema-postgres.sql
+++ b/schema/schema-postgres.sql
@@ -458,7 +458,12 @@ CREATE TABLE autonomous_workflows (
     transition_error text,
     transition_started_at text,
     transition_updated_at text,
-    expected_head_sha text
+    expected_head_sha text,
+    cleanup_status text,
+    cleanup_attempts integer NOT NULL,
+    cleanup_error text,
+    cleanup_updated_at text,
+    cleanup_next_retry_at text
 );
 
 CREATE SEQUENCE autonomous_workflows_id_seq

--- a/schema/schema-postgres.sql
+++ b/schema/schema-postgres.sql
@@ -460,7 +460,7 @@ CREATE TABLE autonomous_workflows (
     transition_updated_at text,
     expected_head_sha text,
     cleanup_status text,
-    cleanup_attempts integer NOT NULL,
+    cleanup_attempts integer,
     cleanup_error text,
     cleanup_updated_at text,
     cleanup_next_retry_at text

--- a/schema/schema-sqlite.sql
+++ b/schema/schema-sqlite.sql
@@ -309,7 +309,7 @@ CREATE TABLE autonomous_workflows (
  transition_updated_at text,
  expected_head_sha text,
  cleanup_status text,
- cleanup_attempts integer NOT NULL,
+ cleanup_attempts integer,
  cleanup_error text,
  cleanup_updated_at text,
  cleanup_next_retry_at text

--- a/schema/schema-sqlite.sql
+++ b/schema/schema-sqlite.sql
@@ -307,7 +307,12 @@ CREATE TABLE autonomous_workflows (
  transition_error text,
  transition_started_at text,
  transition_updated_at text,
- expected_head_sha text
+ expected_head_sha text,
+ cleanup_status text,
+ cleanup_attempts integer NOT NULL,
+ cleanup_error text,
+ cleanup_updated_at text,
+ cleanup_next_retry_at text
 );
 
 CREATE TABLE command_execution_evidence (

--- a/tests/unit/test_git_cleanup_2043.py
+++ b/tests/unit/test_git_cleanup_2043.py
@@ -92,8 +92,12 @@ def test_remote_branch_delete_failure_is_not_silently_cleaned():
 
 
 def _set_workflow(orch, wf):
-    """Stub self.workflow to return the given dict."""
-    type(orch).workflow = property(lambda self: wf)
+    """Stub self.workflow to return the given dict.
+
+    Uses repo.get_workflow (the property's source) rather than overwriting the
+    class-level property, which would leak into later tests in the same process.
+    """
+    orch.repo.get_workflow.return_value = wf
 
 
 def test_cleanup_completion_persists_completed_status():

--- a/tests/unit/test_git_cleanup_2043.py
+++ b/tests/unit/test_git_cleanup_2043.py
@@ -35,7 +35,9 @@ def test_delete_branch_returns_structured_result_on_success():
     gh = GitHubOps.__new__(GitHubOps)
     gh._run_git = MagicMock(
         side_effect=[
+            MagicMock(returncode=0, stdout="", stderr=""),  # show-ref (exists)
             MagicMock(returncode=0, stderr=""),  # git branch -D
+            MagicMock(returncode=0, stdout="abc123\theads/x", stderr=""),  # ls-remote (exists)
             MagicMock(returncode=0, stderr=""),  # git push origin --delete
         ]
     )
@@ -44,14 +46,21 @@ def test_delete_branch_returns_structured_result_on_success():
 
 
 def test_delete_branch_distinguishes_absent_from_failed():
-    """Already-gone branch → 'absent' (success-equivalent), not 'failed'."""
+    """Already-gone branch → 'absent' (success-equivalent), not 'failed'.
+
+    Existence is determined by the show-ref/ls-remote precheck returncode/stdout,
+    not stderr text — so an absent branch reports absent even though the delete
+    command itself returns non-zero.
+    """
     from app.modules.workspace.autonomous.github_ops import GitHubOps
 
     gh = GitHubOps.__new__(GitHubOps)
     gh._run_git = MagicMock(
         side_effect=[
-            MagicMock(returncode=1, stderr="error: branch 'auto-dev/x' not found."),
-            MagicMock(returncode=1, stderr="remote ref does not exist"),
+            MagicMock(returncode=1, stdout="", stderr=""),  # show-ref (not found)
+            MagicMock(returncode=1, stderr="error: not found"),  # branch -D (no-op)
+            MagicMock(returncode=0, stdout="", stderr=""),  # ls-remote (empty → absent)
+            MagicMock(returncode=1, stderr="remote ref absent"),  # push --delete (no-op)
         ]
     )
     result = gh.delete_branch("auto-dev/x")
@@ -61,14 +70,16 @@ def test_delete_branch_distinguishes_absent_from_failed():
 
 
 def test_remote_branch_delete_failure_is_not_silently_cleaned():
-    """Remote delete rejected → 'failed' with stderr captured for retry."""
+    """Remote exists but delete rejected → 'failed' with stderr captured for retry."""
     from app.modules.workspace.autonomous.github_ops import GitHubOps
 
     gh = GitHubOps.__new__(GitHubOps)
     gh._run_git = MagicMock(
         side_effect=[
-            MagicMock(returncode=0, stderr=""),  # local ok
-            MagicMock(returncode=1, stderr="! [remote rejected] ..."),  # remote fail
+            MagicMock(returncode=0, stdout="", stderr=""),  # show-ref (exists)
+            MagicMock(returncode=0, stderr=""),  # branch -D ok
+            MagicMock(returncode=0, stdout="abc123\theads/x", stderr=""),  # ls-remote (exists)
+            MagicMock(returncode=1, stderr="! [remote rejected] ..."),  # push fail
         ]
     )
     result = gh.delete_branch("auto-dev/x")

--- a/tests/unit/test_git_cleanup_2043.py
+++ b/tests/unit/test_git_cleanup_2043.py
@@ -1,0 +1,306 @@
+"""Contract tests for post-merge Git cleanup tracking (Issue #2043).
+
+Covers the separation of delivery completion from resource-convergence, the
+structured ``delete_branch`` result, and the retry semantics. Tests follow
+``test_autonomous_ci_guardrails.py``: ``AutonomousOrchestrator.__new__`` to
+skip ``__init__``, ``MagicMock`` for GitHubOps, method-level stubs.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _make_orch():
+    """Build a minimal AutonomousOrchestrator via __new__ (skip __init__)."""
+    from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+    orch = AutonomousOrchestrator.__new__(AutonomousOrchestrator)
+    orch._workflow_id = "wf-2043"
+    orch.repo = MagicMock()
+    orch.emitter = MagicMock()
+    orch._create_milestone = MagicMock(return_value={"milestone_id": "ms-1"})
+    orch._update_workflow = MagicMock()
+    orch._gh = None
+    return orch
+
+
+# ── delete_branch structured result ───────────────────────────────────────
+
+
+def test_delete_branch_returns_structured_result_on_success():
+    """Both local + remote deletion succeed → deleted/deleted, no errors."""
+    from app.modules.workspace.autonomous.github_ops import GitHubOps
+
+    gh = GitHubOps.__new__(GitHubOps)
+    gh._run_git = MagicMock(
+        side_effect=[
+            MagicMock(returncode=0, stderr=""),  # git branch -D
+            MagicMock(returncode=0, stderr=""),  # git push origin --delete
+        ]
+    )
+    result = gh.delete_branch("auto-dev/x")
+    assert result == {"local": "deleted", "remote": "deleted", "errors": []}
+
+
+def test_delete_branch_distinguishes_absent_from_failed():
+    """Already-gone branch → 'absent' (success-equivalent), not 'failed'."""
+    from app.modules.workspace.autonomous.github_ops import GitHubOps
+
+    gh = GitHubOps.__new__(GitHubOps)
+    gh._run_git = MagicMock(
+        side_effect=[
+            MagicMock(returncode=1, stderr="error: branch 'auto-dev/x' not found."),
+            MagicMock(returncode=1, stderr="remote ref does not exist"),
+        ]
+    )
+    result = gh.delete_branch("auto-dev/x")
+    assert result["local"] == "absent"
+    assert result["remote"] == "absent"
+    assert result["errors"] == []
+
+
+def test_remote_branch_delete_failure_is_not_silently_cleaned():
+    """Remote delete rejected → 'failed' with stderr captured for retry."""
+    from app.modules.workspace.autonomous.github_ops import GitHubOps
+
+    gh = GitHubOps.__new__(GitHubOps)
+    gh._run_git = MagicMock(
+        side_effect=[
+            MagicMock(returncode=0, stderr=""),  # local ok
+            MagicMock(returncode=1, stderr="! [remote rejected] ..."),  # remote fail
+        ]
+    )
+    result = gh.delete_branch("auto-dev/x")
+    assert result["local"] == "deleted"
+    assert result["remote"] == "failed"
+    assert any("remote rejected" in e for e in result["errors"])
+
+
+# ── _perform_git_cleanup status persistence ───────────────────────────────
+
+
+def _set_workflow(orch, wf):
+    """Stub self.workflow to return the given dict."""
+    type(orch).workflow = property(lambda self: wf)
+
+
+def test_cleanup_completion_persists_completed_status():
+    """Successful cleanup → cleanup_status=completed, cleared error."""
+    orch = _make_orch()
+    _set_workflow(
+        orch,
+        {
+            "worktree_path": "/tmp/wt",
+            "branch_name": "x",
+            "project_path": "/tmp/repo",
+            "cleanup_attempts": 0,
+        },
+    )
+    with (
+        patch("app.modules.workspace.autonomous.orchestrator.GitHubOps"),
+        patch.object(orch, "_cleanup_worktree_and_branch", return_value=True),
+    ):
+        status, error = orch._perform_git_cleanup()
+    assert status == "completed"
+    assert error == ""
+    # The update_workflow call must carry cleanup_status=completed.
+    updates = [c.args[0] for c in orch._update_workflow.call_args_list]
+    assert any(u.get("cleanup_status") == "completed" for u in updates)
+
+
+def test_cleanup_failure_sets_pending_for_retry():
+    """Cleanup failure (not exhausted) → cleanup_status=pending + backoff."""
+    orch = _make_orch()
+    _set_workflow(
+        orch,
+        {
+            "worktree_path": "/tmp/wt",
+            "branch_name": "x",
+            "project_path": "/tmp/repo",
+            "cleanup_attempts": 0,
+            "error_message": "worktree busy",
+        },
+    )
+    with (
+        patch("app.modules.workspace.autonomous.orchestrator.GitHubOps"),
+        patch.object(orch, "_cleanup_worktree_and_branch", return_value=False),
+    ):
+        status, error = orch._perform_git_cleanup()
+    assert status == "pending"
+    assert "busy" in error or error
+    updates = [c.args[0] for c in orch._update_workflow.call_args_list]
+    pending_update = next(u for u in updates if u.get("cleanup_status") == "pending")
+    assert pending_update["cleanup_attempts"] == 1
+    assert pending_update["cleanup_next_retry_at"]  # backoff timestamp set
+
+
+def test_cleanup_exhausts_to_failed_after_max_attempts():
+    """Beyond MAX_CLEANUP_ATTEMPTS → cleanup_status=failed (terminal)."""
+    from app.modules.workspace.autonomous.orchestrator import MAX_CLEANUP_ATTEMPTS
+
+    orch = _make_orch()
+    _set_workflow(
+        orch,
+        {
+            "worktree_path": "/tmp/wt",
+            "branch_name": "x",
+            "project_path": "/tmp/repo",
+            "cleanup_attempts": MAX_CLEANUP_ATTEMPTS,
+            "error_message": "persistent fail",
+        },
+    )
+    with (
+        patch("app.modules.workspace.autonomous.orchestrator.GitHubOps"),
+        patch.object(orch, "_cleanup_worktree_and_branch", return_value=False),
+    ):
+        status, _ = orch._perform_git_cleanup()
+    assert status == "failed"
+
+
+# ── _do_merge delivery/cleanup separation ─────────────────────────────────
+
+
+def test_merge_success_with_cleanup_failure_sets_pending():
+    """A merge that succeeds but whose cleanup fails keeps the workflow
+    delivered (status=completed) while cleanup_status=pending.
+
+    _do_merge writes status=completed + cleanup_status=pending BEFORE calling
+    _perform_git_cleanup. The cleanup helper then either completes or leaves
+    pending. This test verifies the helper, on failure, does NOT touch the
+    business status (only cleanup_* fields) and signals pending for retry.
+    """
+    orch = _make_orch()
+    # Pretend _do_merge already persisted the delivery state.
+    _set_workflow(
+        orch,
+        {
+            "worktree_path": "/tmp/wt",
+            "branch_name": "x",
+            "project_path": "/tmp/repo",
+            "cleanup_attempts": 0,
+            "error_message": "cleanup transient",
+            "status": "completed",
+            "cleanup_status": "pending",
+        },
+    )
+    with (
+        patch("app.modules.workspace.autonomous.orchestrator.GitHubOps"),
+        patch.object(orch, "_cleanup_worktree_and_branch", return_value=False),
+    ):
+        cleanup_status, _ = orch._perform_git_cleanup()
+
+    assert cleanup_status == "pending"
+    # The helper must never overwrite the business status=completed.
+    updates = [c.args[0] for c in orch._update_workflow.call_args_list]
+    assert all("status" not in u or u.get("cleanup_status") for u in updates)
+    assert any(u.get("cleanup_status") == "pending" for u in updates)
+
+
+def test_cleanup_is_idempotent_when_resources_absent():
+    """A workflow whose worktree + branch are already gone still reports completed.
+
+    _cleanup_worktree_and_branch returns True when there is nothing to remove,
+    so _perform_git_cleanup marks the workflow cleanup_status=completed.
+    """
+    orch = _make_orch()
+    _set_workflow(
+        orch,
+        {
+            "worktree_path": "",
+            "branch_name": "",
+            "project_path": "/tmp/repo",
+            "cleanup_attempts": 2,
+        },
+    )
+    with patch.object(orch, "_cleanup_worktree_and_branch", return_value=True):
+        status, _ = orch._perform_git_cleanup()
+    assert status == "completed"
+
+
+# ── scheduler retry sweep ─────────────────────────────────────────────────
+
+
+def test_startup_retries_pending_git_cleanup():
+    """_retry_pending_git_cleanups processes pending workflows via the repo."""
+    from app.services.autonomous_scheduler import _retry_pending_git_cleanups
+
+    fake_repo = MagicMock()
+    fake_repo.get_workflows_pending_cleanup.return_value = [
+        {
+            "workflow_id": "wf-a",
+            "cleanup_next_retry_at": "",
+            "worktree_path": "/tmp/wt",
+            "branch_name": "x",
+        }
+    ]
+    with (
+        patch(
+            "app.repositories.autonomous_repo.AutonomousWorkflowRepository",
+            return_value=fake_repo,
+        ),
+        patch("app.repositories.database.Database"),
+        patch(
+            "app.modules.workspace.autonomous.orchestrator.AutonomousOrchestrator"
+        ) as mock_orch_cls,
+    ):
+        mock_orch = mock_orch_cls.return_value
+        mock_orch._perform_git_cleanup.return_value = ("completed", "")
+        _retry_pending_git_cleanups()
+    fake_repo.get_workflows_pending_cleanup.assert_called_once()
+    mock_orch._perform_git_cleanup.assert_called_once()
+
+
+def test_sandbox_destroy_does_not_complete_git_cleanup():
+    """Sandbox destruction (#2022) is out of scope; cleanup_status tracks Git only.
+
+    This is a boundary assertion: _perform_git_cleanup never touches sandbox
+    state and only converges Git resources. There is no sandbox hook here.
+    """
+    orch = _make_orch()
+    _set_workflow(
+        orch,
+        {
+            "worktree_path": "",
+            "branch_name": "",
+            "project_path": "/tmp/repo",
+            "cleanup_attempts": 0,
+        },
+    )
+    with patch.object(orch, "_cleanup_worktree_and_branch", return_value=True) as mock_cleanup:
+        status, _ = orch._perform_git_cleanup()
+    assert status == "completed"
+    # Only the Git worktree/branch cleanup path was invoked.
+    args, kwargs = mock_cleanup.call_args
+    assert kwargs.get("remove_worktree") is True
+    assert kwargs.get("remove_branch") is True
+
+
+def test_cleanup_completion_clears_paths_and_records_event():
+    """On full completion the worktree_path/branch_name are cleared (via the
+    cleanup helper) and a cleaned_up milestone is recorded."""
+    from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+    # This exercises the _do_merge success tail by calling _perform_git_cleanup
+    # with a successful helper, then asserting the milestone type on the caller.
+    orch = _make_orch()
+    _set_workflow(
+        orch,
+        {
+            "worktree_path": "/tmp/wt",
+            "branch_name": "x",
+            "project_path": "/tmp/repo",
+            "cleanup_attempts": 0,
+        },
+    )
+    with (
+        patch("app.modules.workspace.autonomous.orchestrator.GitHubOps"),
+        patch.object(orch, "_cleanup_worktree_and_branch", return_value=True),
+    ):
+        status, _ = orch._perform_git_cleanup()
+    assert status == "completed"
+    # The helper cleared the paths internally (mocked), and _perform_git_cleanup
+    # persisted cleanup_status=completed. The milestone is created by the
+    # _do_merge caller when status == completed.
+    updates = [c.args[0] for c in orch._update_workflow.call_args_list]
+    assert any(u.get("cleanup_status") == "completed" for u in updates)


### PR DESCRIPTION
## Summary

Post-merge Git cleanup (worktree + branch) previously ran as a fire-and-forget `try/except`: a failure only logged a warning, the workflow was unconditionally marked `completed`, and `delete_branch` used `check=False` silently swallowing all failures. Residual worktrees/branches blocked later retries (#1442) with no record that cleanup had failed.

This PR separates **delivery completion** from **resource convergence**, adds structured cleanup results, and a startup + periodic retry sweep so leaked resources eventually converge or enter a terminal `failed` state.

## Changes

### 1. Data layer — cleanup tracking columns

Migration `20260726_005_add_cleanup_tracking` adds 5 nullable columns (no backfill; NULL = legacy row, invisible to the retry scan):
- `cleanup_status` (`not_started|pending|completed|failed`)
- `cleanup_attempts`, `cleanup_error`, `cleanup_updated_at`, `cleanup_next_retry_at`

Schema snapshots rebuilt via `rebuild_schema_snapshots.py` (column order/case match `op.add_column` append semantics). Added to `ALLOWED_WORKFLOW_FIELDS`, `AutonomousWorkflow` model, and new repo query `get_workflows_pending_cleanup()`.

### 2. Structured cleanup results

`GitHubOps.delete_branch` now returns `{local, remote, errors}` inspecting each command's returncode (was `check=False` returning `None`, swallowing all failures):
- `deleted` / `absent` (already gone, success-equivalent) / `failed` (real error, truncated stderr captured)
- `_cleanup_worktree_and_branch` raises on `delete_branch` `failed` so partial deletion no longer silently clears `branch_name`.

### 3. Delivery/cleanup separation (`_do_merge` + `_perform_git_cleanup`)

- `_do_merge` persists `status=completed` + `cleanup_status=pending` **before** attempting cleanup — delivery is final regardless of cleanup outcome.
- `_perform_git_cleanup` converges resources and persists `cleanup_*` fields: `completed` on success, `pending` (with backoff) for retry, or `failed` after `MAX_CLEANUP_ATTEMPTS` (10).
- `cleaned_up` milestone only on true convergence; a `cleanup_pending` milestone records failures. Business status is never reverted on a cleanup failure.

### 4. Retry sweep (startup + periodic)

`_retry_pending_git_cleanups` is shared by `init_autonomous_scheduler` (startup) and the periodic `_process_workflows` tick. It re-attempts pending cleanup, honoring per-workflow `cleanup_next_retry_at` exponential backoff (1min→2min→4min...→1h cap). Does not consume active concurrency slots (completed workflows don't share branches with active ones).

## Tests

`tests/unit/test_git_cleanup_2043.py` — 11 contract tests:
- `test_delete_branch_returns_structured_result_on_success`
- `test_delete_branch_distinguishes_absent_from_failed`
- `test_remote_branch_delete_failure_is_not_silently_cleaned`
- `test_cleanup_completion_persists_completed_status`
- `test_cleanup_failure_sets_pending_for_retry`
- `test_cleanup_exhausts_to_failed_after_max_attempts`
- `test_merge_success_with_cleanup_failure_sets_pending`
- `test_cleanup_is_idempotent_when_resources_absent`
- `test_startup_retries_pending_git_cleanup`
- `test_sandbox_destroy_does_not_complete_git_cleanup` (boundary)
- `test_cleanup_completion_clears_paths_and_records_event`

## Verification

- ✅ 134 related tests pass (11 new + 78 CI guardrails + 10 worktree-recovery + 16 evidence + 19 command-evidence)
- ✅ schema-sync green (sqlite + postgres match alembic head)
- ✅ single migration head (`20260726_005`)
- ✅ ruff + pydocstyle + mypy clean (one pre-existing SIM103 in scheduler unrelated to this change)

## Acceptance criteria (#2043)

- [x] PR merge saves `cleanup_status=pending` before cleanup
- [x] worktree/branch cleanup failure does not fake `cleaned_up`
- [x] local/remote branch deletion distinguishes deleted/absent/failed
- [x] startup and scheduler auto-retry pending cleanup
- [x] cleanup is idempotent (absent resources = success)
- [x] #1442 residual path auto-converges via the retry sweep
- [x] sandbox cleanup state is separate (Git-only `cleanup_status`)
- [x] completed delivery is not reverted to business `failed` on cleanup failure
- [ ] cleanup refuses foreign/reused worktree *(deferred — current cleanup only touches the workflow's own `worktree_path`; ownership validation across workflows is a hardening follow-up)*
- [ ] #2041 transition residue reconciliation *(already handled by `_reconcile_pending_transitions`; this PR is post-merge cleanup only)*

## Not in scope

- Sandbox/container destruction (#2022)
- Generic `resource_cleanup_jobs` queue table (issue marks optional)
- PhaseHandler `CleanupPhase` (#2044-B)
- Cross-worktree ownership validation hardening (deferred)

Closes #2043.