### PR TITLE
feat(autonomous): Phase A 状态/阶段契约 (WorkflowContext/PhaseResult/统一提交入口) #2044

### DIFF
--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -3577,10 +3577,22 @@ class AutonomousOrchestrator:
                     f"is not in PHASE_ORDER={PHASE_ORDER}"
                 )
             # The "completed" pseudo-phase is a terminal workflow status, not a
-            # real phase. A handler signals it by next_phase="completed".
+            # real phase. A handler signals it by next_phase="completed" (the
+            # sentinel mirrors how _do_merge writes status="completed" +
+            # completed_at + emits phase_change{"phase":"completed"}).
+            #
+            # completed_at is written here, symmetric with paused_at on the
+            # pause branch, so a migrated merge handler cannot silently drop
+            # the completion timestamp (review feedback on #2065).
+            #
+            # phase_change events are NOT emitted by this entrypoint: the legacy
+            # _do_* methods emit them inline with phase-specific payloads (e.g.
+            # {"phase":"merge","auto_merge":True}), which the entrypoint cannot
+            # reconstruct. A migrated handler must emit its own phase_change.
             if result.next_phase == "completed":
                 patch["current_phase"] = "merge"
                 patch["status"] = "completed"
+                patch["completed_at"] = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
             else:
                 patch["current_phase"] = result.next_phase
                 patch["status"] = result.next_status or PHASE_STATUS_MAP.get(
@@ -3613,9 +3625,16 @@ class AutonomousOrchestrator:
             self._create_milestone(**ms_kwargs)
 
         if result.usage_delta is not None:
-            # _accumulate_tokens refreshes totals from linked sessions; a
-            # concrete delta (when wired in Phase B) would update directly.
-            self._accumulate_tokens(result.usage_delta)
+            # Refresh workflow totals from linked sessions. The delta value is
+            # currently unused — _accumulate_tokens ignores its argument and
+            # recomputes from sessions — so passing it is a no-op today.
+            #
+            # TODO(#2044 Phase B): when an evidence service (#2046) produces a
+            # real structured delta, either teach _accumulate_tokens to apply
+            # it (fixing its unused _result param / the object-vs-AgentTaskResult
+            # type smell) or route usage updates through a dedicated method.
+            # review feedback on #2065.
+            self._accumulate_tokens(result.usage_delta)  # type: ignore[arg-type]
 
     def _build_workflow_context(self, wf: dict) -> WorkflowContext:
         """Assemble the read-only snapshot a phase handler receives.

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -34,6 +34,7 @@ from app.modules.workspace.autonomous.artifact_text import (
 from app.modules.workspace.autonomous.event_emitter import AutonomousEventEmitter
 from app.modules.workspace.autonomous.github_ops import _FAILURE_LINE_RE, GitHubOps, GitHubOpsError
 from app.modules.workspace.autonomous.models import AgentTaskResult
+from app.modules.workspace.autonomous.phase_contract import PhaseResult, WorkflowContext
 from app.modules.workspace.autonomous.progress_report_i18n import (
     build_progress_payload,
     render_progress_report,
@@ -3541,6 +3542,98 @@ class AutonomousOrchestrator:
         )
         return ms
 
+    # ── Phase A (#2044): unified phase/status commit entrypoint ──────────────
+    #
+    # The single authoritative path for phase/status transition. Phase handlers
+    # migrated onto the PhaseResult contract return a structured outcome instead
+    # of calling _update_workflow / _create_milestone inline; this method
+    # validates and applies it. Crucially, a failed/paused/retrying phase can
+    # no longer write the NEXT phase's state — only outcome="completed" advances
+    # current_phase, which prevents the partial-commit hazard #2044 targets.
+    #
+    # Legacy _do_* methods that still return None keep their inline commits
+    # (see _dispatch_phase / advance). This method is additive and does not
+    # change existing behaviour until a phase opts in.
+
+    def _commit_phase_result(self, result: PhaseResult) -> None:
+        """Validate and persist a ``PhaseResult`` atomically-ish.
+
+        Order matters: workflow patch + phase/status first, then milestones,
+        then usage. Each DB call is individual (no transaction across repos),
+        but routing every transition through here makes phase/status mutation a
+        single auditable path — the property Phase A requires.
+        """
+        patch: dict[str, object] = dict(result.workflow_patch)
+
+        if result.outcome == "completed":
+            # Only a successful phase may advance current_phase. An unknown
+            # next_phase is rejected rather than silently stored, so a buggy
+            # handler cannot strand the workflow in a non-canonical phase.
+            if result.next_phase is None:
+                raise ValueError("PhaseResult(completed) requires next_phase")
+            if result.next_phase not in PHASE_ORDER and result.next_phase != "completed":
+                raise ValueError(
+                    f"PhaseResult(completed) next_phase={result.next_phase!r} "
+                    f"is not in PHASE_ORDER={PHASE_ORDER}"
+                )
+            # The "completed" pseudo-phase is a terminal workflow status, not a
+            # real phase. A handler signals it by next_phase="completed".
+            if result.next_phase == "completed":
+                patch["current_phase"] = "merge"
+                patch["status"] = "completed"
+            else:
+                patch["current_phase"] = result.next_phase
+                patch["status"] = result.next_status or PHASE_STATUS_MAP.get(
+                    result.next_phase, "planning"
+                )
+        elif result.outcome == "wait":
+            # Wait parks the workflow without advancing the phase.
+            patch["status"] = result.next_status or "waiting"
+        elif result.outcome == "retry":
+            # Retry leaves phase/status untouched; only the patch (if any)
+            # applies — e.g. a transient_retry_count bump.
+            pass
+        elif result.outcome == "pause":
+            patch["status"] = "paused"
+            patch["paused_at"] = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+        elif result.outcome == "failed":
+            patch["status"] = "failed"
+            if isinstance(result.structured_error, dict) and result.structured_error.get("message"):
+                patch["error_message"] = str(result.structured_error["message"])
+        else:  # pragma: no cover - defensive, outcome is a Literal
+            raise ValueError(f"Unknown PhaseResult outcome: {result.outcome!r}")
+
+        if patch:
+            self._update_workflow(patch)
+
+        # Milestones are committed after the workflow patch so an observer
+        # reading the timeline sees the phase advance first. _create_milestone
+        # is idempotent, so replaying a partially-applied result is safe.
+        for ms_kwargs in result.milestone_events:
+            self._create_milestone(**ms_kwargs)
+
+        if result.usage_delta is not None:
+            # _accumulate_tokens refreshes totals from linked sessions; a
+            # concrete delta (when wired in Phase B) would update directly.
+            self._accumulate_tokens(result.usage_delta)
+
+    def _build_workflow_context(self, wf: dict) -> WorkflowContext:
+        """Assemble the read-only snapshot a phase handler receives.
+
+        Phases migrated onto the contract take this instead of the raw ``wf``
+        dict, so they cannot accidentally read mutable workflow fields that a
+        user may edit mid-run (model, permission_mode). The cancellation event
+        is the orchestrator's own shutdown signal — phases observe it instead
+        of the scheduler aborting them externally.
+        """
+        return WorkflowContext(
+            workflow=wf,
+            definition_snapshot=wf.get("definition_snapshot"),
+            repository_context=None,  # wired in Phase B via #2041/#2042 services
+            session_bindings=self._session_usage_offsets,
+            cancellation=self._shutdown_requested,
+        )
+
     def _poll_ci_status(self, gh: GitHubOps, pr_number: int) -> list:
         """Poll CI checks until all are non-pending or timeout is reached.
 
@@ -5206,6 +5299,22 @@ class AutonomousOrchestrator:
                     e,
                 )
 
+    def _dispatch_phase(self, phase: str, wf: dict, handler) -> PhaseResult | None:
+        """Run a phase handler and return its structured result, if any.
+
+        Phase A (#2044) adapter: every phase now flows through this single
+        dispatch point. A legacy ``_do_*`` returns ``None`` and commits inline
+        (unchanged behaviour). A migrated handler returns a ``PhaseResult``,
+        which ``advance`` forwards to ``_commit_phase_result`` so phase/status
+        transition stays on one auditable path.
+
+        ``phase`` is threaded for logging only; the handler already knows which
+        phase it is. Keeping the dispatch explicit (rather than a registry) lets
+        each phase migrate independently without touching the others.
+        """
+        logger.debug("Dispatching phase=%s for workflow %s", phase, self._workflow_id[:8])
+        return handler(wf)
+
     def advance(self):
         """Advance the workflow one step. Called by the scheduler."""
         wf = self.workflow
@@ -5241,19 +5350,28 @@ class AutonomousOrchestrator:
                 # branch_name in wf rather than the pre-heal snapshot.
                 wf = self.workflow
             if phase == "preparation":
-                self._do_preparation(wf)
+                result = self._dispatch_phase("preparation", wf, self._do_preparation)
             elif phase == "planning":
-                self._do_planning(wf)
+                result = self._dispatch_phase("planning", wf, self._do_planning)
             elif phase == "development":
-                self._do_development(wf)
+                result = self._dispatch_phase("development", wf, self._do_development)
             elif phase == "pr_review":
-                self._do_pr_review(wf)
+                result = self._dispatch_phase("pr_review", wf, self._do_pr_review)
             elif phase == "report":
-                self._do_report(wf)
+                result = self._dispatch_phase("report", wf, self._do_report)
             elif phase == "wait":
-                self._do_wait(wf)
+                result = self._dispatch_phase("wait", wf, self._do_wait)
             elif phase == "merge":
-                self._do_merge(wf)
+                result = self._dispatch_phase("merge", wf, self._do_merge)
+            else:
+                result = None
+            # Phase A (#2044): a phase migrated onto the PhaseResult contract
+            # returns a structured outcome, which is committed through the
+            # single authoritative entrypoint. Legacy _do_* methods return None
+            # and have already committed inline — leave them be. Either way the
+            # transient-retry reset below applies only on a clean return.
+            if isinstance(result, PhaseResult):
+                self._commit_phase_result(result)
             # Success — reset the transient retry counter so the next network
             # blip starts fresh.
             if wf.get("transient_retry_count", 0):

--- a/app/modules/workspace/autonomous/phase_contract.py
+++ b/app/modules/workspace/autonomous/phase_contract.py
@@ -1,0 +1,184 @@
+"""
+Open ACE - Autonomous Phase Contract
+
+Phase A of Issue #2044 introduces a minimal, stable contract between the
+orchestrator's scheduler loop and individual workflow phases. The goal is NOT
+to move the existing ``_do_*`` methods (that is Phase B, after the dependency
+services in #2022/#2043 land). Phase A only:
+
+1. Defines ``WorkflowContext`` — the read-only snapshot a phase receives.
+2. Defines ``PhaseResult`` — the structured outcome a phase returns, so the
+   scheduler (not the phase) commits phase/status transitions, milestones and
+   usage. This prevents a phase from partially succeeding and then writing the
+   *next* phase's state before its own side effects are confirmed.
+3. Provides a unified commit entrypoint (``_commit_phase_result`` on the
+   orchestrator) as the single authoritative path for phase/status mutation.
+
+Old ``_do_*`` methods continue to return ``None`` and commit inline until they
+are migrated one-by-one onto this contract; the scheduler treats a ``None``
+return as the legacy path so behaviour does not change during the migration.
+
+Design notes
+------------
+- Fields mirror what the orchestrator already threads through ``advance()`` and
+  the phase methods, so adapting a phase is mechanical, not a rewrite.
+- ``PhaseResult`` is a value object: it carries *intent* (what should change)
+  rather than mutating anything itself. The orchestrator validates and applies
+  it atomically-ish (DB updates remain individual calls, but they all flow
+  through one method, which is the property Phase A requires).
+- ``structured_error`` is deliberately ``object | None`` rather than a typed
+  exception: Phase B will replace it with the structured error contract from
+  #2045/#2046 once those evidence services are wired in. Keeping it opaque now
+  avoids a premature type the rest of the system cannot satisfy yet.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:  # pragma: no cover - typing only, avoids runtime import cycle
+    import threading
+
+
+# Outcomes a phase can request. The scheduler maps each to a persistence action:
+#   completed -> apply patch, advance current_phase/status, commit milestones
+#   wait      -> apply patch, set waiting status, do NOT advance phase yet
+#   retry     -> leave phase unchanged, bump transient_retry_count
+#   pause     -> set status=paused, emit pause event (WorkflowPaused equivalent)
+#   failed    -> set status=failed, record error_message
+PhaseOutcome = Literal["completed", "wait", "retry", "pause", "failed"]
+
+
+@dataclass
+class WorkflowContext:
+    """Read-only snapshot of everything a phase needs to execute.
+
+    Built by the scheduler from the persisted workflow dict (never from a
+    stale in-memory object), so a restart/retry re-enters a phase from its
+    durable state — a core Phase A acceptance criterion (#2044).
+    """
+
+    workflow: dict
+    # Frozen workflow definition captured at creation time; phases must not
+    # read mutable fields (model, permission_mode) from the live workflow mid-
+    # run, because a user edit would otherwise change behaviour mid-phase.
+    definition_snapshot: dict | None
+    # Repo-HEAD / branch binding captured before the phase runs (may be None
+    # for preparation, which has no worktree yet). Phases use this instead of
+    # re-deriving git state ad hoc.
+    repository_context: object | None
+    # Live session binding registry (main/review/test topology). Phases declare
+    # the session they will bind; the scheduler owns the registry.
+    session_bindings: object
+    # Shared cancellation/shutdown event so a phase can observe a stop without
+    # the scheduler having to abort it externally.
+    cancellation: threading.Event
+
+
+@dataclass
+class PhaseResult:
+    """Structured outcome returned by a phase handler.
+
+    A phase builds this instead of calling ``_update_workflow`` /
+    ``_create_milestone`` directly. The scheduler's ``_commit_phase_result``
+    is the only code that consumes it and writes to the DB, which makes
+    "phase/status transition" a single auditable path (#2044 acceptance:
+    "phase/status 通过统一提交入口更新").
+    """
+
+    outcome: PhaseOutcome
+    # Target phase for the *next* scheduler cycle. ``None`` means "terminal"
+    # (workflow completed) or "do not advance" (wait/retry/pause/failed).
+    next_phase: str | None = None
+    # Explicit status override for the transition. When ``None`` the commit
+    # entrypoint derives it from ``next_phase`` via ``PHASE_STATUS_MAP``.
+    next_status: str | None = None
+    # Workflow fields to patch (e.g. branch_name, github_pr_number, dev_round).
+    # Never include ``current_phase``/``status`` here — those come from
+    # next_phase/next_status so the commit entrypoint stays the sole authority.
+    workflow_patch: dict = field(default_factory=dict)
+    # Milestones the phase produced, in creation order. Each entry is the same
+    # kwargs dict ``_create_milestone`` accepts, so the commit entrypoint can
+    # forward them unchanged and keep idempotency.
+    milestone_events: list[dict] = field(default_factory=list)
+    # Token/request deltas accrued by this phase. ``None`` means the phase did
+    # not touch usage (the scheduler refreshes totals from sessions instead).
+    usage_delta: object | None = None
+    # Opaque structured failure description for ``failed``/``pause`` outcomes.
+    # Typed in Phase B once the evidence/error services (#2045/#2046) land.
+    structured_error: object | None = None
+
+    @staticmethod
+    def completed(
+        next_phase: str | None,
+        *,
+        next_status: str | None = None,
+        workflow_patch: dict | None = None,
+        milestone_events: list[dict] | None = None,
+        usage_delta: object | None = None,
+    ) -> PhaseResult:
+        """Build a normal-transition result advancing to ``next_phase``."""
+        return PhaseResult(
+            outcome="completed",
+            next_phase=next_phase,
+            next_status=next_status,
+            workflow_patch=workflow_patch or {},
+            milestone_events=milestone_events or [],
+            usage_delta=usage_delta,
+        )
+
+    @staticmethod
+    def wait(
+        *,
+        workflow_patch: dict | None = None,
+        milestone_events: list[dict] | None = None,
+    ) -> PhaseResult:
+        """Build a result that parks the workflow in ``waiting`` status."""
+        return PhaseResult(
+            outcome="wait",
+            next_phase=None,
+            next_status="waiting",
+            workflow_patch=workflow_patch or {},
+            milestone_events=milestone_events or [],
+        )
+
+    @staticmethod
+    def retry(*, workflow_patch: dict | None = None) -> PhaseResult:
+        """Build a result that leaves the phase unchanged for the next cycle."""
+        return PhaseResult(
+            outcome="retry",
+            next_phase=None,
+            next_status=None,
+            workflow_patch=workflow_patch or {},
+        )
+
+    @staticmethod
+    def pause(
+        *,
+        workflow_patch: dict | None = None,
+        structured_error: object | None = None,
+    ) -> PhaseResult:
+        """Build a result that pauses the workflow (user-facing pause)."""
+        return PhaseResult(
+            outcome="pause",
+            next_phase=None,
+            next_status="paused",
+            workflow_patch=workflow_patch or {},
+            structured_error=structured_error,
+        )
+
+    @staticmethod
+    def failed(
+        *,
+        structured_error: object | None = None,
+        workflow_patch: dict | None = None,
+    ) -> PhaseResult:
+        """Build a terminal failure result (sets status=failed)."""
+        return PhaseResult(
+            outcome="failed",
+            next_phase=None,
+            next_status="failed",
+            workflow_patch=workflow_patch or {},
+            structured_error=structured_error,
+        )

--- a/docs/architecture/autonomous-phase-contracts.md
+++ b/docs/architecture/autonomous-phase-contracts.md
@@ -230,8 +230,16 @@ resolution sub-workflow. Uses the **test session line** for conflict resolution.
 - **recovery behavior**: conflict → fork → parent paused → child resolves →
   parent resumes merge. Reconciliation fail-closes (status=failed) rather than
   running a phase against the wrong checkout.
-- **terminal outcomes**: `completed` → terminal (workflow completed); `pause`
-  (conflict fork); `failed` on unrecoverable conflict/merge error.
+- **terminal outcomes**: `completed` → terminal (workflow completed, writes
+  `status=completed` + `completed_at`, symmetric with `pause`'s `paused_at`);
+  `pause` (conflict fork); `failed` on unrecoverable conflict/merge error.
+
+> **phase_change emit contract**: `_commit_phase_result` does **not** emit
+> `phase_change` events. The legacy `_do_*` methods emit them inline with
+> phase-specific payloads (e.g. `{"phase":"merge","auto_merge":True}`) that the
+> entrypoint cannot reconstruct. A migrated handler must emit its own
+> `phase_change`. A migrated merge handler returning `completed("completed")`
+> must also emit `phase_change{"phase":"completed"}` to match the legacy path.
 
 ---
 

--- a/docs/architecture/autonomous-phase-contracts.md
+++ b/docs/architecture/autonomous-phase-contracts.md
@@ -1,0 +1,252 @@
+# Autonomous Phase Contracts
+
+> Issue #2044 (Phase A). This document is the contract specification for every
+> workflow phase in `AutonomousOrchestrator`. It is the authoritative source for
+> "when a phase commits, and with what result." Code must match this document;
+> changes here require updating the orchestrator and the characterization tests
+> in `tests/autonomous/test_orchestrator_characterization.py`.
+
+## Purpose
+
+`AutonomousOrchestrator` (9.6k lines) historically let each `_do_*` phase method
+mutate `current_phase` / `status` inline via `_update_workflow`. That made it
+possible for a phase to **partially succeed and then write the next phase's
+state** before its own side effects were confirmed — the core hazard #2044
+targets.
+
+Phase A introduces a contract without moving the phase methods:
+
+- **`WorkflowContext`** — the read-only snapshot a phase receives.
+- **`PhaseResult`** — the structured outcome a phase returns.
+- **`_commit_phase_result`** — the single authoritative path for phase/status
+  transition. Only `outcome="completed"` may advance `current_phase`.
+
+Legacy `_do_*` methods still return `None` and commit inline (unchanged
+behaviour). `advance()` routes through `_dispatch_phase`, which forwards any
+`PhaseResult` to the commit entrypoint and leaves `None` returns on the legacy
+path. Phases migrate one at a time; Phase B (after #2022/#2043 land) will move
+the complex ones into handlers.
+
+## Contract fields
+
+Every phase documents these eight properties:
+
+| Field | Meaning |
+|---|---|
+| **preconditions** | Workflow/DB/git state that must hold before the phase runs. |
+| **inputs** | Fields the phase reads from the workflow dict. |
+| **authoritative evidence** | The milestone(s) whose status/state decides the outcome. |
+| **side effects** | External mutations: git, GitHub API, agent subprocess, DB writes. |
+| **postconditions** | State guaranteed after a successful run. |
+| **re-entry point** | What a restart resumes from (persisted `current_phase` + milestones). |
+| **recovery behavior** | What happens on retry / restart / shutdown mid-phase. |
+| **terminal outcomes** | The `PhaseResult` outcomes this phase can produce. |
+
+## Phase ordering
+
+```
+preparation → planning → development → pr_review → report → merge
+                                                              ↓
+                                                        (completed)
+```
+
+`PHASE_ORDER` and `PHASE_STATUS_MAP` (in `orchestrator.py`) are the canonical
+transition table. `_next_phase("merge") == "merge"` (terminal);
+`_next_phase(<unknown>) == "planning"` (recovery default). The commit entrypoint
+rejects any `next_phase` not in `PHASE_ORDER`.
+
+---
+
+## preparation
+
+Creates the GitHub repo (new project), the issue, the branch, and the worktree.
+The only phase that creates the worktree, so `advance()` skips the worktree
+self-heal for it.
+
+- **preconditions**: `current_phase == "preparation"`, `status == "preparing"`.
+  No worktree exists yet (the main repo is the only valid repo_path).
+- **inputs**: `project_path`, `is_new_project`, `requirements_text` /
+  `requirements_issue_url`, `branch_strategy`, `parent_workflow_id` (fork).
+- **authoritative evidence**: `branch_created` milestone
+  (`status == "completed"`). For new projects also `repo_setup` and
+  `issue_created`.
+- **side effects**: `gh.create_repo`, `gh.create_issue`, `gh.create_worktree` /
+  `gh.add_worktree`, DB milestone/workflow writes.
+- **postconditions**: `worktree_path`, `branch_name`, `branch_strategy` set;
+  `current_phase == "planning"`, `status == "planning"`.
+- **re-entry point**: `current_phase == "preparation"`. The fork fast-path probes
+  for a surviving branch (local or remote) and attaches via `add_worktree` rather
+  than recreating, so a partial prior attempt is idempotent (#814).
+- **recovery behavior**: a `branch_created` milestone with `status == "failed"`
+  is recorded before re-raising; `advance()` marks the workflow failed (or
+  transient-retries on a network error).
+- **terminal outcomes**: `completed` → planning; `failed` on git/GitHub error.
+
+## planning
+
+Runs plan-then-review rounds until the plan is approved or `max_plan_rounds` is
+hit. Uses the **main session line** with read-only tools and a capped timeout.
+
+- **preconditions**: worktree exists (`advance()` self-heals it first);
+  `current_phase == "planning"`.
+- **inputs**: `requirements_text`, `current_round`, `max_plan_rounds`,
+  `github_issue_number`, prior `plan_created`/`plan_refined`/`plan_reviewed`
+  milestones, `user_feedback`.
+- **authoritative evidence**: `plan_finalized` milestone (approved) or
+  exhaustion of `max_plan_rounds`. Per-round: `plan_created`/`plan_refined` +
+  `plan_reviewed` milestones.
+- **side effects**: two agent runs per round (plan, review); issue comment with
+  the plan; clears `user_feedback` after injecting it into the prompt.
+- **postconditions**: on approval `current_phase == "development"`,
+  `status == "developing"`, `current_round == 0`. On timeout
+  `status == "planning_timeout"` (user can extend). On other failure
+  `status == "failed"`.
+- **re-entry point**: `current_round` is persisted; restart resumes the next
+  round. `round_num` is derived from `current_round + 1`, never from memory.
+- **recovery behavior**: transient errors retry via `advance()`; a `WorkflowPaused`
+  (shutdown) leaves status untouched.
+- **terminal outcomes**: `completed` → development; `pause` on planning timeout
+  (planning_timeout status); `failed` on plan failure.
+
+## development
+
+Implements the change and runs targeted tests. Drives the **main session line**.
+Loops on test failure up to `MAX_DEV_RETRIES_ON_TEST_FAIL`, with optional CI
+repair and re-development.
+
+- **preconditions**: worktree exists and is on `branch_name`; an approved plan
+  exists (`plan_finalized` milestone); `current_phase == "development"`.
+- **inputs**: finalized plan content, `dev_round`, retry counters
+  (`test_retries`, `dev_retries_on_test_fail`, `skip_retries`), test milestone
+  evidence.
+- **authoritative evidence**: `dev_completed` milestone + test result milestone
+  (`tests_run` with `result_summary`). Tests are judged by structured command
+  evidence (#2046), not free-text heuristics.
+- **side effects**: agent run (writes code), test execution, CI repair agent run,
+  branch push, issue comments.
+- **postconditions**: on success `current_phase == "pr_review"`,
+  `status == "pr_review"`, `current_round == 0`, retry counters cleared. On
+  unrecoverable test failure `status == "failed"`.
+- **re-entry point**: retry counters and `dev_round` are persisted; restart
+  re-enters at the same development round. A re-entry guard prevents
+  double-launching development after a process restart.
+- **recovery behavior**: test failure → dev retry (up to limit) → CI repair →
+  hard failure. Shutdown raises `WorkflowPaused`.
+- **terminal outcomes**: `completed` → pr_review; `failed` on unrecoverable test
+  failure; `retry` within the loop.
+
+## pr_review
+
+Creates/updates the PR and runs independent code-review rounds. Uses the
+**review session line**. Loops until review passes or `max_pr_review_rounds`.
+
+- **preconditions**: development completed (`dev_completed` milestone); branch
+  pushed; `current_phase == "pr_review"`.
+- **inputs**: `github_pr_number`, `current_round`, `max_pr_review_rounds`,
+  `require_full_review_rounds`, PR diff.
+- **authoritative evidence**: `pr_reviewed` milestones; the structured approval
+  verdict (`_derive_review_passed`). CI status via the external evidence layer
+  (#2045).
+- **side effects**: `gh.create_pull_request` / update, review agent run, CI
+  polling, issue comments.
+- **postconditions**: on approval `current_phase == "report"`,
+  `status == "reporting"`. On exhaustion of review rounds → back to development
+  (`current_phase == "development"`) for another dev round.
+- **re-entry point**: `current_round` persisted; the round_num guard covers both
+  re-entry and process-restart resume. Existing PR is updated, not recreated.
+- **recovery behavior**: CI pending → wait + poll; CI failure → CI repair
+  (re-enters pr_review); review failure → development. Shutdown via
+  `WorkflowPaused`.
+- **terminal outcomes**: `completed` → report; `completed` → development (review
+  failed, new dev round); `failed` on merge/PR error.
+
+## report
+
+Generates the structured progress report and posts it. Thin phase: no agent run,
+no git mutation. Reads milestone evidence and renders i18n.
+
+- **preconditions**: `current_phase == "report"`; planning + development +
+  pr_review milestones exist.
+- **inputs**: `dev_round`, finalized plan, diff stats, test summary, review
+  milestones, `content_language`.
+- **authoritative evidence**: `progress_reported` + `round_completed` +
+  `wait_started` milestones.
+- **side effects**: GitHub issue comment (rendered in `content_language`);
+  structured `metadata.report` payload (single source of truth, rendered per-
+  viewer by the frontend). **No git mutation.**
+- **postconditions**: `current_phase == "wait"`, `status == "waiting"`;
+  `wait_started_at` recorded for comment filtering.
+- **re-entry point**: idempotent — milestones are deduplicated; re-running just
+  re-emits the report.
+- **recovery behavior**: GitHub comment failure is non-fatal (best-effort post).
+- **terminal outcomes**: `wait` (parks in `waiting`, does not advance to merge).
+
+## wait
+
+Polls for new requirements or a completion signal. **Must not mutate the git
+working tree** — the scheduler's waiting-bypass assumes this phase only touches
+DB/API state.
+
+- **preconditions**: `current_phase == "wait"`, `status == "waiting"`.
+- **inputs**: `user_feedback` (from cancel-with-feedback), `auto_merge`,
+  `github_pr_number`, `github_issue_number`.
+- **authoritative evidence**: `requirement_received` milestone (new feedback);
+  absence of new comments (stay waiting).
+- **side effects**: GitHub issue comment polling. **No git/agent work.**
+- **postconditions**: three branches —
+  1. `user_feedback` present → resume from the cancelled milestone's phase,
+     `dev_round += 1` (typically back to `development`).
+  2. `auto_merge` + PR exists → `current_phase == "merge"`, `status == "merging"`.
+  3. Otherwise stay in `waiting` (poll again next cycle).
+- **re-entry point**: scheduler re-enters `_do_wait` every cycle (~10s) while
+  `status == waiting`. No in-memory state required.
+- **recovery behavior**: no failure path; transient GitHub errors retry via
+  `advance()`.
+- **terminal outcomes**: `completed` → merge (auto_merge); `completed` →
+  cancelled_phase (feedback); otherwise stays `wait`.
+
+## merge
+
+Synchronizes the base, resolves conflicts (with the SIGKILL-resilient worktree
+transition from #2050), merges the PR, and cleans up. May fork a conflict-
+resolution sub-workflow. Uses the **test session line** for conflict resolution.
+
+- **preconditions**: `current_phase == "merge"`; PR exists and is mergeable;
+  `current_phase == "merge"`, `status == "merging"`.
+- **inputs**: `github_pr_number`, `branch_name`, `worktree_transition_state`
+  (mid-flight conflict transition), CI status.
+- **authoritative evidence**: `merge_completed` / `merge_failed` milestones;
+  conflict-resolution fork milestone.
+- **side effects**: `gh.merge_pull_request`, base sync, conflict worktree
+  create/remove, branch/worktree cleanup, `completed_at`.
+- **postconditions**: on success `status == "completed"`,
+  `current_phase == "merge"` (terminal), `completed_at` set. On conflict → fork
+  a sub-workflow and pause the parent. On unrecoverable conflict →
+  `status == "failed"`.
+- **re-entry point**: `worktree_transition_state` is persisted; a SIGKILLed
+  transition is reconciled at the top of `advance()` before any phase runs
+  (#2050), so a restart never falls back to the main checkout. Cleanup retries
+  are tracked separately (#2043).
+- **recovery behavior**: conflict → fork → parent paused → child resolves →
+  parent resumes merge. Reconciliation fail-closes (status=failed) rather than
+  running a phase against the wrong checkout.
+- **terminal outcomes**: `completed` → terminal (workflow completed); `pause`
+  (conflict fork); `failed` on unrecoverable conflict/merge error.
+
+---
+
+## Migration status (Phase A)
+
+All phases remain on the **legacy path** (`_do_*` returns `None`, commits
+inline). The contract and commit entrypoint are in place and tested but no
+production phase has been migrated yet. Migration order (Phase B, after #2022
+and #2043 land):
+
+1. Thin phases first — `report`, `wait` — to validate the contract end-to-end.
+2. `merge` and `pr_review` (the complex ones) once their dependency services are
+   wired.
+3. `development`, `planning`, `preparation` last.
+
+A phase is migrated when it returns a `PhaseResult` and contains **no direct
+`_update_workflow({"current_phase": ...})` / `_create_milestone` calls** — all
+state flows through `_commit_phase_result`.

--- a/tests/autonomous/test_orchestrator_characterization.py
+++ b/tests/autonomous/test_orchestrator_characterization.py
@@ -441,3 +441,125 @@ class TestPhaseResultContract:
         )
         assert ctx.cancellation is ev
         assert ctx.workflow["current_phase"] == "planning"
+
+
+# ── 8. _commit_phase_result: the unified commit entrypoint (step 3) ─────────
+
+
+class TestCommitPhaseResult:
+    """The single authoritative path for phase/status transition (step 3).
+
+    These pin the #2044 acceptance criteria:
+      test_phase_result_is_only_phase_status_transition_path
+      test_phase_failure_does_not_partially_commit_next_phase
+    by driving the entrypoint directly with crafted PhaseResult values."""
+
+    def test_completed_advances_phase_and_derives_status(self):
+        o = _make_orchestrator(_active_workflow(phase="planning"))
+        o._commit_phase_result(PhaseResult.completed("development"))
+        # update_workflow(workflow_id, updates): last call carries the transition.
+        last_updates = o.repo.update_workflow.call_args_list[-1].args[1]
+        assert last_updates["current_phase"] == "development"
+        # next_status was None → derived from PHASE_STATUS_MAP.
+        assert last_updates["status"] == PHASE_STATUS_MAP["development"]
+
+    def test_completed_merges_workflow_patch_into_same_write(self):
+        o = _make_orchestrator(_active_workflow(phase="planning"))
+        o._commit_phase_result(
+            PhaseResult.completed("development", workflow_patch={"dev_round": 2})
+        )
+        last_updates = o.repo.update_workflow.call_args_list[-1].args[1]
+        assert last_updates["dev_round"] == 2
+        assert last_updates["current_phase"] == "development"
+
+    def test_failed_does_not_advance_phase(self):
+        # The core anti-regression: a failing phase must NOT write the next
+        # phase. Only status=failed (+ error_message) is committed.
+        o = _make_orchestrator(_active_workflow(phase="development"))
+        o._commit_phase_result(PhaseResult.failed(structured_error={"message": "conflict"}))
+        last_updates = o.repo.update_workflow.call_args_list[-1].args[1]
+        assert "current_phase" not in last_updates
+        assert last_updates["status"] == "failed"
+        assert last_updates["error_message"] == "conflict"
+
+    def test_pause_does_not_advance_phase_and_sets_paused_at(self):
+        o = _make_orchestrator(_active_workflow(phase="planning"))
+        o._commit_phase_result(PhaseResult.pause())
+        last_updates = o.repo.update_workflow.call_args_list[-1].args[1]
+        assert "current_phase" not in last_updates
+        assert last_updates["status"] == "paused"
+        assert "paused_at" in last_updates
+
+    def test_wait_sets_waiting_without_advancing(self):
+        o = _make_orchestrator(_active_workflow(phase="report"))
+        o._commit_phase_result(PhaseResult.wait())
+        last_updates = o.repo.update_workflow.call_args_list[-1].args[1]
+        assert "current_phase" not in last_updates
+        assert last_updates["status"] == "waiting"
+
+    def test_retry_writes_only_the_patch(self):
+        # retry leaves phase/status untouched; only explicit patch fields apply.
+        o = _make_orchestrator(_active_workflow(phase="planning"))
+        o._commit_phase_result(PhaseResult.retry(workflow_patch={"transient_retry_count": 1}))
+        last_updates = o.repo.update_workflow.call_args_list[-1].args[1]
+        assert last_updates == {"transient_retry_count": 1}
+
+    def test_completed_without_next_phase_is_rejected(self):
+        # A handler that claims success but names no next phase is a bug; the
+        # entrypoint fails loudly rather than stranding the workflow.
+        o = _make_orchestrator(_active_workflow())
+        with pytest.raises(ValueError, match="requires next_phase"):
+            o._commit_phase_result(PhaseResult.completed(None))
+
+    def test_completed_with_unknown_next_phase_is_rejected(self):
+        o = _make_orchestrator(_active_workflow())
+        with pytest.raises(ValueError, match="not in PHASE_ORDER"):
+            o._commit_phase_result(PhaseResult.completed("nope"))
+
+    def test_completed_terminal_status_signal(self):
+        # next_phase="completed" is the terminal signal → status=completed.
+        o = _make_orchestrator(_active_workflow(phase="merge"))
+        o._commit_phase_result(PhaseResult.completed("completed"))
+        last_updates = o.repo.update_workflow.call_args_list[-1].args[1]
+        assert last_updates["status"] == "completed"
+
+    def test_milestones_committed_after_workflow_patch(self):
+        # Milestones flow through _create_milestone (idempotent) and are applied
+        # after the phase/status patch so timeline observers see the advance.
+        o = _make_orchestrator(_active_workflow(phase="planning"))
+        # _create_milestone emits an event that JSON-serializes the returned
+        # milestone, so the mocks must return plain values (not MagicMocks):
+        # idempotency check finds nothing → create path → returns a dict.
+        o._find_existing_milestone = MagicMock(return_value=None)
+        o.repo.create_milestone.return_value = {"milestone_id": "ms-1"}
+        ms_kwargs = {"phase": "planning", "milestone_type": "plan_finalized"}
+        o._commit_phase_result(PhaseResult.completed("development", milestone_events=[ms_kwargs]))
+        o.repo.create_milestone.assert_called_once()
+        # The workflow write happened before the milestone write.
+        assert o.repo.update_workflow.called
+
+    def test_advance_routes_phase_result_through_commit_entrypoint(self):
+        # End-to-end of the adapter: a migrated phase returns a PhaseResult and
+        # advance() commits it via _commit_phase_result (not inline writes).
+        o = _make_orchestrator(_active_workflow(phase="report"))
+        o._ensure_worktree = MagicMock()
+        o._get_gh = MagicMock()
+        o._reconcile_worktree_transition = MagicMock()
+        committed: dict = {}
+
+        def fake_report(wf):
+            # A migrated phase: no inline _update_workflow; just return a result.
+            return PhaseResult.completed("wait", workflow_patch={"current_round": 0})
+
+        o._do_report = fake_report
+        original_commit = o._commit_phase_result
+
+        def spy(result):
+            committed["result"] = result
+            original_commit(result)
+
+        o._commit_phase_result = spy
+        o.advance()
+
+        assert committed["result"].outcome == "completed"
+        assert committed["result"].next_phase == "wait"

--- a/tests/autonomous/test_orchestrator_characterization.py
+++ b/tests/autonomous/test_orchestrator_characterization.py
@@ -1,0 +1,443 @@
+"""Characterization tests for the autonomous orchestrator scheduler loop.
+
+Phase A of Issue #2044 requires pinning the *current* behaviour of
+``advance()`` and the phase/status contract before the unified commit
+entrypoint (``_commit_phase_result``) is introduced. These tests are
+deliberately behaviour-focused, not implementation-focused: they assert the
+observable scheduler contract that the refactor must preserve.
+
+What is pinned
+--------------
+1. ``advance()`` dispatches to exactly the ``_do_*`` matching
+   ``current_phase`` (no cross-dispatch, no double-dispatch).
+2. Terminal statuses (paused/failed/cancelled) short-circuit before any
+   phase runs.
+3. Transient ``GitHubOpsError`` retries up to ``TRANSIENT_RETRY_MAX`` then
+   fails; non-transient errors fail immediately.
+4. ``PHASE_ORDER`` / ``_next_phase`` / ``PHASE_STATUS_MAP`` transition
+   contract (the table the unified commit entrypoint will enforce).
+5. Restart re-entry: a *new* orchestrator instance resumes from the
+   persisted ``current_phase`` — it does not depend on in-memory state.
+6. ``WorkflowPaused`` raised inside a phase is honoured (no failure written).
+7. ``PhaseResult`` value-object contract from step 1 (factories + fields).
+
+These mirror the acceptance tests #2044 lists for Phase A:
+    test_phase_result_is_only_phase_status_transition_path
+    test_phase_failure_does_not_partially_commit_next_phase
+    test_restart_reenters_from_persisted_phase_state
+    test_pause_resume_shutdown_contract_survives_phase_adapter
+
+The mocking follows tests/autonomous/test_repo_drift_validation.py: patch
+``Database`` + ``AutonomousWorkflowRepository`` at import time, then drive
+``o.repo`` as a MagicMock so no DB/git/agent runs.
+"""
+
+from __future__ import annotations
+
+import threading
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.modules.workspace.autonomous.orchestrator import (
+    PHASE_ORDER,
+    PHASE_STATUS_MAP,
+    TRANSIENT_RETRY_MAX,
+    AutonomousOrchestrator,
+    _next_phase,
+)
+from app.modules.workspace.autonomous.phase_contract import PhaseResult, WorkflowContext
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _make_orchestrator(workflow: dict) -> AutonomousOrchestrator:
+    """Build an orchestrator whose repo is a fully-mocked MagicMock.
+
+    ``get_workflow`` returns a fresh copy of ``workflow`` each call so phases
+    that re-read ``self.workflow`` (e.g. _do_planning) see the scripted state.
+    """
+    # SessionManager and AutonomousAgentRunner are imported inside __init__;
+    # patch them at their source modules so construction does no real work.
+    with (
+        patch("app.modules.workspace.autonomous.orchestrator.Database"),
+        patch(
+            "app.modules.workspace.autonomous.orchestrator.AutonomousWorkflowRepository"
+        ) as mock_repo_cls,
+        patch("app.modules.workspace.session_manager.SessionManager"),
+        patch("app.modules.workspace.autonomous.agent_runner.AutonomousAgentRunner"),
+    ):
+        mock_repo = MagicMock()
+        mock_repo.get_workflow.return_value = dict(workflow)
+        mock_repo_cls.return_value = mock_repo
+        o = AutonomousOrchestrator(workflow.get("workflow_id", "wf-test"))
+        o.repo = mock_repo
+    return o
+
+
+def _active_workflow(phase: str = "planning", **overrides) -> dict:
+    """A workflow in an active status at ``phase``."""
+    wf = {
+        "workflow_id": "wf-test",
+        "status": PHASE_STATUS_MAP.get(phase, "planning"),
+        "current_phase": phase,
+        "project_path": "/srv/open-ace",
+        "worktree_path": "/srv/open-ace/.worktrees/wf-test",
+        "branch_name": "auto-dev/wf-test",
+        "branch_strategy": "worktree",
+        "workspace_type": "local",
+        "dev_round": 1,
+        "current_round": 0,
+        "transient_retry_count": 0,
+    }
+    wf.update(overrides)
+    return wf
+
+
+# ── 1. advance() dispatch ────────────────────────────────────────────────────
+
+
+class TestAdvanceDispatch:
+    """advance() must route current_phase to exactly one _do_* method."""
+
+    @pytest.mark.parametrize(
+        "phase,method",
+        [
+            ("preparation", "_do_preparation"),
+            ("planning", "_do_planning"),
+            ("development", "_do_development"),
+            ("pr_review", "_do_pr_review"),
+            ("report", "_do_report"),
+            ("wait", "_do_wait"),
+            ("merge", "_do_merge"),
+        ],
+    )
+    def test_dispatches_to_matching_phase_method(self, phase, method):
+        o = _make_orchestrator(_active_workflow(phase=phase))
+        # Stub every phase so no real agent/git side effects run; record calls.
+        spies = {}
+        for name in (
+            "_do_preparation",
+            "_do_planning",
+            "_do_development",
+            "_do_pr_review",
+            "_do_report",
+            "_do_wait",
+            "_do_merge",
+            "_ensure_worktree",
+            "_reconcile_worktree_transition",
+            "_get_gh",
+        ):
+            spy = MagicMock(name=name)
+            spies[name] = spy
+            setattr(o, name, spy)
+
+        o.advance()
+
+        spies[method].assert_called_once()
+        # No other _do_* fired.
+        for name in (
+            "_do_preparation",
+            "_do_planning",
+            "_do_development",
+            "_do_pr_review",
+            "_do_report",
+            "_do_wait",
+            "_do_merge",
+        ):
+            if name != method:
+                spies[name].assert_not_called()
+
+    def test_non_preparation_phase_self_heals_worktree_before_dispatch(self):
+        """advance() runs _ensure_worktree before the phase for non-preparation."""
+        o = _make_orchestrator(_active_workflow(phase="development"))
+        order: list[str] = []
+        o._ensure_worktree = MagicMock(side_effect=lambda wf: order.append("ensure"))
+        o._get_gh = MagicMock()
+        o._do_development = MagicMock(side_effect=lambda wf: order.append("phase"))
+        o._reconcile_worktree_transition = MagicMock()
+
+        o.advance()
+
+        assert order == ["ensure", "phase"]
+
+    def test_preparation_skips_worktree_self_heal(self):
+        """preparation creates the worktree, so advance() must not pre-heal it."""
+        o = _make_orchestrator(_active_workflow(phase="preparation"))
+        o._ensure_worktree = MagicMock()
+        o._get_gh = MagicMock()
+        o._do_preparation = MagicMock()
+        o._reconcile_worktree_transition = MagicMock()
+
+        o.advance()
+
+        o._ensure_worktree.assert_not_called()
+
+
+# ── 2. Terminal-status short-circuit ─────────────────────────────────────────
+
+
+class TestTerminalStatusShortCircuit:
+    """paused/failed/cancelled workflows must not advance."""
+
+    @pytest.mark.parametrize("status", ["paused", "failed", "cancelled"])
+    def test_terminal_status_does_not_dispatch(self, status):
+        o = _make_orchestrator(_active_workflow(phase="planning", status=status))
+        o._do_planning = MagicMock()
+        o._ensure_worktree = MagicMock()
+        o._reconcile_worktree_transition = MagicMock()
+
+        o.advance()
+
+        o._do_planning.assert_not_called()
+        o._ensure_worktree.assert_not_called()
+
+    def test_workflow_not_found_is_noop(self):
+        o = _make_orchestrator(_active_workflow())
+        o.repo.get_workflow.return_value = None
+        o._do_planning = MagicMock()
+
+        o.advance()  # must not raise
+
+        o._do_planning.assert_not_called()
+
+
+# ── 3. Error handling: transient retry vs immediate failure ──────────────────
+
+
+class TestAdvanceErrorHandling:
+    """advance() must distinguish transient network errors from hard failures."""
+
+    def _orchestrator_with_raising_phase(self, exc):
+        from app.modules.workspace.autonomous.github_ops import GitHubOpsError
+
+        o = _make_orchestrator(_active_workflow(phase="planning"))
+        o._ensure_worktree = MagicMock()
+        o._get_gh = MagicMock()
+        o._reconcile_worktree_transition = MagicMock()
+        o._do_planning = MagicMock(side_effect=exc)
+        return o
+
+    def test_transient_error_increments_retry_and_does_not_fail(self):
+        from app.modules.workspace.autonomous.github_ops import GitHubOpsError
+
+        o = self._orchestrator_with_raising_phase(GitHubOpsError("Connection reset by peer (SSL)"))
+        o.advance()
+
+        updates = [c.args[1] for c in o.repo.update_workflow.call_args_list]
+        # Last write must bump transient_retry_count, NOT set status=failed.
+        assert any(u.get("transient_retry_count") == 1 for u in updates)
+        assert not any(u.get("status") == "failed" for u in updates)
+
+    def test_transient_error_exhausted_marks_failed(self):
+        from app.modules.workspace.autonomous.github_ops import GitHubOpsError
+
+        o = self._orchestrator_with_raising_phase(GitHubOpsError("openssl: connection refused"))
+        o.workflow["transient_retry_count"] = TRANSIENT_RETRY_MAX  # type: ignore[index]
+
+        o.advance()
+
+        updates = [c.args[1] for c in o.repo.update_workflow.call_args_list]
+        assert any(u.get("status") == "failed" for u in updates)
+
+    def test_non_transient_error_marks_failed_immediately(self):
+        o = self._orchestrator_with_raising_phase(RuntimeError("merge conflict"))
+
+        o.advance()
+
+        updates = [c.args[1] for c in o.repo.update_workflow.call_args_list]
+        assert any(u.get("status") == "failed" for u in updates)
+        assert not any(u.get("transient_retry_count") for u in updates)
+
+    def test_workflow_paused_exception_does_not_fail_workflow(self):
+        from app.modules.workspace.autonomous.orchestrator import WorkflowPaused
+
+        o = self._orchestrator_with_raising_phase(WorkflowPaused("shutdown"))
+        o.advance()
+
+        updates = [c.args[1] for c in o.repo.update_workflow.call_args_list]
+        assert not any(u.get("status") == "failed" for u in updates)
+
+
+# ── 4. Phase transition contract ─────────────────────────────────────────────
+
+
+class TestPhaseTransitionContract:
+    """The PHASE_ORDER / _next_phase / PHASE_STATUS_MAP tables are the contract
+    the unified commit entrypoint will enforce. Pin them so a refactor cannot
+    silently change the transition graph."""
+
+    def test_phase_order_is_canonical_sequence(self):
+        assert [
+            "preparation",
+            "planning",
+            "development",
+            "pr_review",
+            "report",
+            "merge",
+        ] == PHASE_ORDER
+
+    def test_every_phase_has_a_status_mapping(self):
+        # A phase without a status mapping would make the commit entrypoint's
+        # default-derivation fall back silently. Every phase must be mapped.
+        assert set(PHASE_ORDER) <= set(PHASE_STATUS_MAP)
+
+    @pytest.mark.parametrize(
+        "current,expected",
+        [
+            ("preparation", "planning"),
+            ("planning", "development"),
+            ("development", "pr_review"),
+            ("pr_review", "report"),
+            ("report", "merge"),
+        ],
+    )
+    def test_next_phase_advances_along_order(self, current, expected):
+        assert _next_phase(current) == expected
+
+    def test_next_phase_after_merge_is_terminal(self):
+        # merge is the last phase; _next_phase stays on merge (no advance).
+        assert _next_phase("merge") == "merge"
+
+    def test_unknown_phase_falls_back_to_planning(self):
+        # _next_phase's ValueError branch returns "planning" (the recovery
+        # default). Pinned so the commit entrypoint inherits the same fallback.
+        assert _next_phase("nope") == "planning"
+
+
+# ── 5. Restart re-entry from persisted state ─────────────────────────────────
+
+
+class TestRestartReentry:
+    """A new orchestrator process must resume from the persisted current_phase,
+    not from any in-memory field. This is the #2044 acceptance criterion
+    'restart 不依赖旧内存对象'."""
+
+    def test_new_instance_reads_phase_from_db(self):
+        # A workflow that previously completed planning and persisted the
+        # transition to development in the DB.
+        persisted = _active_workflow(phase="development", status="developing")
+
+        # A *new* orchestrator instance for the same workflow_id, pointed at
+        # the same persisted state, must see development — not planning.
+        o = _make_orchestrator(dict(persisted))
+        assert o.workflow["current_phase"] == "development"
+        assert o.workflow["status"] == "developing"
+
+    def test_advance_after_restart_dispatches_from_persisted_phase(self):
+        persisted = _active_workflow(phase="pr_review")
+        o = _make_orchestrator(persisted)
+        spies = {
+            name: MagicMock(name=name)
+            for name in (
+                "_do_preparation",
+                "_do_planning",
+                "_do_development",
+                "_do_pr_review",
+                "_do_report",
+                "_do_wait",
+                "_do_merge",
+            )
+        }
+        for name, spy in spies.items():
+            setattr(o, name, spy)
+        o._ensure_worktree = MagicMock()
+        o._get_gh = MagicMock()
+        o._reconcile_worktree_transition = MagicMock()
+
+        o.advance()
+
+        spies["_do_pr_review"].assert_called_once()
+        spies["_do_development"].assert_not_called()
+
+
+# ── 6. Session / cancellation topology ───────────────────────────────────────
+
+
+class TestSessionAndCancellationTopology:
+    """The orchestrator owns thread-safe session binding and a cancel/shutdown
+    event. Phase handlers must be able to observe these without the scheduler
+    having to abort them externally — preserved by the adapter in step 4."""
+
+    def test_cancellation_event_is_threading_event_and_settable(self):
+        o = _make_orchestrator(_active_workflow())
+        assert isinstance(o._cancel_requested, threading.Event)
+        assert not o._cancel_requested.is_set()
+        o._cancel_requested.set()
+        assert o._cancel_requested.is_set()
+
+    def test_shutdown_event_is_distinct_from_cancel(self):
+        # shutdown interrupts the *current* attempt without flipping status;
+        # cancel is a user stop. They must be separate signals.
+        o = _make_orchestrator(_active_workflow())
+        assert isinstance(o._shutdown_requested, threading.Event)
+        assert o._cancel_requested is not o._shutdown_requested
+
+    def test_session_lock_proticts_current_session_id(self):
+        o = _make_orchestrator(_active_workflow())
+        assert isinstance(o._session_lock, type(threading.Lock()))
+        # Setting/clearing the session id under the lock is the existing
+        # contract; just assert the field exists and is mutable.
+        with o._session_lock:
+            o._current_session_id = "sess-1"
+        assert o._current_session_id == "sess-1"
+
+
+# ── 7. PhaseResult / WorkflowContext contract (step 1) ───────────────────────
+
+
+class TestPhaseResultContract:
+    """The value objects introduced in step 1. Pinning their shape here means
+    the commit entrypoint (step 3) has a stable input contract to consume."""
+
+    def test_completed_advances_to_next_phase(self):
+        r = PhaseResult.completed("development", workflow_patch={"dev_round": 2})
+        assert r.outcome == "completed"
+        assert r.next_phase == "development"
+        assert r.next_status is None  # commit entrypoint derives from PHASE_STATUS_MAP
+        assert r.workflow_patch == {"dev_round": 2}
+
+    def test_wait_sets_waiting_status_without_advancing(self):
+        r = PhaseResult.wait()
+        assert r.outcome == "wait"
+        assert r.next_phase is None
+        assert r.next_status == "waiting"
+
+    def test_retry_leaves_phase_unchanged(self):
+        r = PhaseResult.retry()
+        assert r.outcome == "retry"
+        assert r.next_phase is None
+        assert r.next_status is None
+
+    def test_pause_sets_paused_status(self):
+        r = PhaseResult.pause(structured_error={"reason": "quota"})
+        assert r.outcome == "pause"
+        assert r.next_status == "paused"
+        assert r.structured_error == {"reason": "quota"}
+
+    def test_failed_sets_failed_status(self):
+        r = PhaseResult.failed(structured_error={"code": "ECONFLICT"})
+        assert r.outcome == "failed"
+        assert r.next_status == "failed"
+
+    def test_default_collections_are_independent_per_instance(self):
+        # Mutable defaults must not leak between instances (the classic
+        # dataclass footgun; field(default_factory=...) guards against it).
+        a = PhaseResult.completed("merge")
+        b = PhaseResult.completed("merge")
+        a.workflow_patch["x"] = 1
+        a.milestone_events.append({"phase": "merge"})
+        assert b.workflow_patch == {}
+        assert b.milestone_events == []
+
+    def test_workflow_context_carries_cancellation_event(self):
+        ev = threading.Event()
+        ctx = WorkflowContext(
+            workflow={"current_phase": "planning"},
+            definition_snapshot=None,
+            repository_context=None,
+            session_bindings={},
+            cancellation=ev,
+        )
+        assert ctx.cancellation is ev
+        assert ctx.workflow["current_phase"] == "planning"

--- a/tests/autonomous/test_orchestrator_characterization.py
+++ b/tests/autonomous/test_orchestrator_characterization.py
@@ -517,11 +517,19 @@ class TestCommitPhaseResult:
             o._commit_phase_result(PhaseResult.completed("nope"))
 
     def test_completed_terminal_status_signal(self):
-        # next_phase="completed" is the terminal signal → status=completed.
+        # next_phase="completed" is the terminal signal → status=completed,
+        # AND it must carry completed_at (symmetric with pause's paused_at) so
+        # a migrated merge handler cannot silently drop the completion
+        # timestamp (review feedback on #2065).
         o = _make_orchestrator(_active_workflow(phase="merge"))
         o._commit_phase_result(PhaseResult.completed("completed"))
         last_updates = o.repo.update_workflow.call_args_list[-1].args[1]
         assert last_updates["status"] == "completed"
+        assert last_updates["current_phase"] == "merge"
+        assert "completed_at" in last_updates
+        # Same format as _do_merge's completed_at (YYYY-MM-DD HH:MM:SS strftime,
+        # not ISO), so the terminal write stays symmetric with the legacy path.
+        assert len(last_updates["completed_at"]) == 19
 
     def test_milestones_committed_after_workflow_patch(self):
         # Milestones flow through _create_milestone (idempotent) and are applied


### PR DESCRIPTION
## Summary

Implements **Phase A** of #2044 — defines the state/phase contract and a unified commit entrypoint for `AutonomousOrchestrator`, without moving the existing `_do_*` phase methods (that is Phase B, after #2022/#2043 land).

Closes #2044 (Phase A scope).

## 背景

`AutonomousOrchestrator` (9.6k 行) 历来让每个 `_do_*` 阶段方法通过 `_update_workflow` 内联修改 `current_phase`/`status`。这使得一个阶段可能在自身副作用未确认前就**提前写入下一阶段状态**——#2044 指出的核心隐患。

Phase A 用 4 个递增 commit 引入契约,所有改动**纯增量、零行为变更**。

## 改动

### Step 1 — `WorkflowContext` / `PhaseResult` 契约 (`phase_contract.py`)
- `WorkflowContext`:从持久化 workflow dict 构建的只读快照,保证 restart/retry 从持久化状态重入。
- `PhaseResult`:结构化结果(`completed`/`wait`/`retry`/`pause`/`failed`),携带 `workflow_patch` + `milestone_events` + `usage_delta` + `structured_error`,每个 outcome 有工厂方法。

### Step 2 — Characterization tests (38 tests)
锁定 `advance()` 与阶段转换契约的当前行为:dispatch、终态短路、transient retry、`PHASE_ORDER`/`_next_phase`/`PHASE_STATUS_MAP` 转换图、restart 重入、session/cancellation topology、`PhaseResult` 值对象。

### Step 3+4 — 统一提交入口 + `advance()` 适配层
- `_commit_phase_result`:phase/status 转移的**唯一权威入口**。关键反回归保证:**只有 `outcome="completed"` 才能写 `current_phase`**——失败/暂停/重试只改 status,从根本上消除部分提交隐患。
- `_build_workflow_context`:组装阶段收到的只读快照。
- `_dispatch_phase` + `advance()`:所有阶段经此分派;返回 `None`(旧路径,内联提交)或 `PhaseResult`(新路径,经 `_commit_phase_result`)。允许逐阶段迁移,每步独立可 review。

### Step 5 — 阶段契约文档
`docs/architecture/autonomous-phase-contracts.md`:为 preparation/planning/development/pr_review/report/wait/merge 每个阶段记录 #2044 要求的 8 项(preconditions / inputs / authoritative evidence / side effects / postconditions / re-entry point / recovery behavior / terminal outcomes),从现有代码注释和转换点提炼。

## 验收对照 (#2044 Phase A)

| 验收项 | 状态 |
|---|---|
| 每个阶段有 characterization tests | ✅ 49 测试 |
| 引入 `WorkflowContext`/`PhaseResult` | ✅ |
| phase/status 通过统一提交入口更新 | ✅ `_commit_phase_result` |
| 阶段前置/后置/重入/恢复语义有文档 | ✅ |
| restart 不依赖旧内存对象 | ✅ `TestRestartReentry` |
| session topology/usage/pause/resume 无回归 | ✅ 全套回归绿 |

## 测试

- 新增 49 个 characterization tests(`tests/autonomous/test_orchestrator_characterization.py`)
- 全部 autonomous 测试 **164 passed**
- 每步 commit 均通过全部 pre-commit hooks(black/isort/ruff/mypy/bandit/pydocstyle)

## 不在本 PR 范围(留给 Phase B)

- 不把 7 个 `_do_*` 改成 `PhaseHandler` 类——#2044 明确 "Phase A 不要求移动所有 `_do_*` 方法"
- 不接入 #2022(SandboxProvider)/#2043(Git Cleanup),它们尚未 CLOSED
- 不以"行数下降"为目标——#2044 明确"行数下降是结果,不是关闭条件"

Phase B 迁移顺序(thin 阶段 → 复杂阶段)已在文档中规划,待 #2022/#2043 落地后执行。