### PR TITLE
feat(autonomous): SandboxProvider 契约 — capability/spec/event/handle (#2022 P1)

### DIFF
--- a/app/modules/workspace/autonomous/sandbox/__init__.py
+++ b/app/modules/workspace/autonomous/sandbox/__init__.py
@@ -1,0 +1,39 @@
+"""SandboxProvider contract package (Issue #2022 Phase 1).
+
+Re-exports the stable contract surface so callers depend on the package, not
+the internal module layout.
+"""
+
+from __future__ import annotations
+
+from app.modules.workspace.autonomous.sandbox.fake import FakeSandboxProvider
+from app.modules.workspace.autonomous.sandbox.provider import (
+    CapabilityUnsupported,
+    SandboxError,
+    SandboxProvider,
+    require_capabilities,
+)
+from app.modules.workspace.autonomous.sandbox.types import (
+    ExecHandle,
+    SandboxCapability,
+    SandboxEvent,
+    SandboxEventKind,
+    SandboxHandle,
+    SandboxSpec,
+    SandboxStatus,
+)
+
+__all__ = [
+    "CapabilityUnsupported",
+    "ExecHandle",
+    "FakeSandboxProvider",
+    "SandboxCapability",
+    "SandboxError",
+    "SandboxEvent",
+    "SandboxEventKind",
+    "SandboxHandle",
+    "SandboxProvider",
+    "SandboxSpec",
+    "SandboxStatus",
+    "require_capabilities",
+]

--- a/app/modules/workspace/autonomous/sandbox/fake.py
+++ b/app/modules/workspace/autonomous/sandbox/fake.py
@@ -1,0 +1,138 @@
+"""In-memory SandboxProvider for contract tests (Issue #2022 Phase 1).
+
+``FakeSandboxProvider`` is the shared vehicle for contract tests: Phase 3
+(``LegacyPosixProvider``) and Phase 4 (``RemoteMachineProvider``) must satisfy
+the same tests against their own implementations. Phase 1 implements the
+creation/destroy/inspect surface; Phase 3 extends it with
+``exec``/``stream``/``pause``/``resume``/``stop``/``collect_execution_evidence``.
+
+It is NOT a production provider — it owns no process, no ACL, no cgroup. It
+records state in memory so tests can assert on the contract without a real
+sandbox.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from typing import Any
+
+from app.modules.workspace.autonomous.sandbox.provider import require_capabilities
+from app.modules.workspace.autonomous.sandbox.types import (
+    ExecHandle,
+    SandboxCapability,
+    SandboxEvent,
+    SandboxEventKind,
+    SandboxHandle,
+    SandboxSpec,
+    SandboxStatus,
+)
+
+# The four isolation guarantees the Legacy POSIX backend will declare in
+# Phase 3. The fake defaults to these so ``FakeSandboxProvider()`` stands in
+# for Legacy without each test repeating the set.
+_LEGACY_CAPS = frozenset(
+    {
+        SandboxCapability.PRIVATE_HOME_TMP_XDG,
+        SandboxCapability.FILESYSTEM_ACL,
+        SandboxCapability.CPU_MEM_PIDS_TIME_QUOTA,
+        SandboxCapability.CREDENTIAL_TOKEN_BINDING,
+    }
+)
+
+
+class FakeSandboxProvider:
+    """In-memory provider satisfying the :class:`SandboxProvider` contract."""
+
+    def __init__(self, capabilities: frozenset[SandboxCapability] | None = None) -> None:
+        self._capabilities: frozenset[SandboxCapability] = (
+            frozenset(capabilities) if capabilities is not None else _LEGACY_CAPS
+        )
+        # sandbox_id -> live status. Unknown ids inspect as DESTROYED so
+        # reconciling an orphan handle (one this provider never minted) is a
+        # no-op rather than a KeyError.
+        self._status: dict[str, SandboxStatus] = {}
+        # command_id -> the command argv + owning sandbox_id, so stream() can
+        # replay a deterministic lifecycle without a real process.
+        self._execs: dict[str, dict[str, Any]] = {}
+
+    def capabilities(self) -> frozenset[SandboxCapability]:
+        return self._capabilities
+
+    def create(self, spec: SandboxSpec) -> SandboxHandle:
+        require_capabilities(self._capabilities, spec.required_capabilities)
+        sandbox_id = uuid.uuid4().hex
+        self._status[sandbox_id] = SandboxStatus.CREATED
+        return SandboxHandle(
+            sandbox_id=sandbox_id,
+            generation=1,
+            provider_name="fake",
+            spec=spec,
+            status=SandboxStatus.CREATED,
+        )
+
+    def exec(
+        self,
+        handle: SandboxHandle,
+        command: list[str],
+        env: dict[str, str] | None,
+        policy: Any | None,
+    ) -> ExecHandle:
+        command_id = uuid.uuid4().hex
+        self._execs[command_id] = {
+            "sandbox_id": handle.sandbox_id,
+            "command": list(command),
+        }
+        return ExecHandle(sandbox_id=handle.sandbox_id, command_id=command_id)
+
+    def stream(self, exec_handle: ExecHandle) -> Iterator[SandboxEvent]:
+        meta = self._execs[exec_handle.command_id]
+        sandbox_id = exec_handle.sandbox_id
+        command = meta["command"]
+        # The canonical happy-path sequence every provider must emit.
+        self._status[sandbox_id] = SandboxStatus.RUNNING
+        yield SandboxEvent(kind=SandboxEventKind.PROCESS_STARTED, sandbox_id=sandbox_id)
+        yield SandboxEvent(
+            kind=SandboxEventKind.COMMAND_STARTED,
+            sandbox_id=sandbox_id,
+            command_id=exec_handle.command_id,
+        )
+        yield SandboxEvent(
+            kind=SandboxEventKind.STDOUT_CHUNK,
+            sandbox_id=sandbox_id,
+            command_id=exec_handle.command_id,
+            data=" ".join(command),
+        )
+        yield SandboxEvent(
+            kind=SandboxEventKind.COMMAND_COMPLETED,
+            sandbox_id=sandbox_id,
+            command_id=exec_handle.command_id,
+            exit_code=0,
+        )
+        yield SandboxEvent(
+            kind=SandboxEventKind.PROCESS_EXITED,
+            sandbox_id=sandbox_id,
+            exit_code=0,
+        )
+
+    def pause(self, exec_handle: ExecHandle) -> None:
+        self._status[exec_handle.sandbox_id] = SandboxStatus.PAUSED
+
+    def resume(self, exec_handle: ExecHandle) -> None:
+        self._status[exec_handle.sandbox_id] = SandboxStatus.RUNNING
+
+    def stop(self, exec_handle: ExecHandle) -> None:
+        self._status[exec_handle.sandbox_id] = SandboxStatus.STOPPED
+
+    def collect_execution_evidence(self, handle: SandboxHandle) -> list[Any]:
+        # Phase 1: the contract method exists; Phase 3 fills it from the real
+        # command stream (test_exec_emits_command_execution_evidence).
+        return []
+
+    def destroy(self, handle: SandboxHandle) -> None:
+        # Idempotent: destroy of an already-destroyed or unknown handle is a
+        # no-op. Reconciliation (Phase 2) relies on this for orphan sandboxes.
+        self._status[handle.sandbox_id] = SandboxStatus.DESTROYED
+
+    def inspect(self, handle: SandboxHandle) -> SandboxStatus:
+        return self._status.get(handle.sandbox_id, SandboxStatus.DESTROYED)

--- a/app/modules/workspace/autonomous/sandbox/fake.py
+++ b/app/modules/workspace/autonomous/sandbox/fake.py
@@ -68,7 +68,7 @@ class FakeSandboxProvider:
             generation=1,
             provider_name="fake",
             spec=spec,
-            status=SandboxStatus.CREATED,
+            initial_status=SandboxStatus.CREATED,
         )
 
     def exec(
@@ -76,7 +76,7 @@ class FakeSandboxProvider:
         handle: SandboxHandle,
         command: list[str],
         env: dict[str, str] | None,
-        policy: Any | None,
+        exec_policy: Any | None,
     ) -> ExecHandle:
         command_id = uuid.uuid4().hex
         self._execs[command_id] = {
@@ -84,6 +84,12 @@ class FakeSandboxProvider:
             "command": list(command),
         }
         return ExecHandle(sandbox_id=handle.sandbox_id, command_id=command_id)
+
+    def upload_workspace(self, handle: SandboxHandle, snapshot: Any | None) -> None:
+        # Phase 1 placeholder. LegacyPosixProvider (P3) is a no-op (the local
+        # worktree is already in place); container/K8s backends (#2023) upload
+        # the snapshot. P1 just freezes the seam.
+        return None
 
     def stream(self, exec_handle: ExecHandle) -> Iterator[SandboxEvent]:
         meta = self._execs[exec_handle.command_id]
@@ -128,6 +134,12 @@ class FakeSandboxProvider:
         # Phase 1: the contract method exists; Phase 3 fills it from the real
         # command stream (test_exec_emits_command_execution_evidence).
         return []
+
+    def collect_changes(self, handle: SandboxHandle) -> Any:
+        # Phase 1 placeholder (ChangeSet schema fixed in P3/P4). Legacy
+        # delegates to the git-workspace service (#2041-2043); non-local
+        # backends own collection. P1 just freezes the seam.
+        return None
 
     def destroy(self, handle: SandboxHandle) -> None:
         # Idempotent: destroy of an already-destroyed or unknown handle is a

--- a/app/modules/workspace/autonomous/sandbox/provider.py
+++ b/app/modules/workspace/autonomous/sandbox/provider.py
@@ -3,9 +3,9 @@
 The Protocol is the stable seam between the orchestrator (which only knows the
 contract) and concrete backends (``LegacyPosixProvider`` Phase 3,
 ``RemoteMachineProvider`` Phase 4, OpenSandbox/Kubernetes #2023). Phase 1
-declares the creation/destroy/inspect surface; Phase 3 extends it with
-``exec``/``stream``/``pause``/``resume``/``stop``/``collect_execution_evidence``
-as those tests land.
+freezes the full lifecycle surface here so P2-P5 implement against a fixed
+seam; two result schemas (``collect_changes``/``collect_execution_evidence``)
+stay ``Any`` until their owning services (#2041-2043, #2046) land.
 """
 
 from __future__ import annotations
@@ -36,15 +36,15 @@ class CapabilityUnsupported(SandboxError):
     unsatisfied rather than silently degrading.
     """
 
-    def __init__(self, missing_capabilities) -> None:
+    def __init__(self, missing_capabilities: frozenset[SandboxCapability]) -> None:
         self.missing_capabilities = frozenset(missing_capabilities)
         names = ", ".join(sorted(cap.value for cap in self.missing_capabilities))
         super().__init__(f"provider cannot supply required capabilities: {names}")
 
 
 def require_capabilities(
-    available,
-    required,
+    available: frozenset[SandboxCapability],
+    required: frozenset[SandboxCapability],
 ) -> None:
     """Raise :class:`CapabilityUnsupported` if *required* is not a subset.
 
@@ -58,7 +58,15 @@ def require_capabilities(
 
 
 class SandboxProvider(Protocol):
-    """Stable execution contract independent of the sandboxing backend."""
+    """Stable execution contract independent of the sandboxing backend.
+
+    The full lifecycle surface is frozen here so P2-P5 implement against a
+    fixed seam (the point of Phase 1). Two methods return ``Any`` for now —
+    ``collect_changes`` and ``collect_execution_evidence`` — because their
+    result schemas bind to services (#2041-2043 git-workspace, #2046 evidence)
+    that land in later phases; tightening ``Any`` to concrete types later is
+    backward-compatible and does not churn the seam.
+    """
 
     def capabilities(self) -> frozenset[SandboxCapability]:
         """Declare the isolation guarantees this backend can actually supply."""
@@ -68,14 +76,31 @@ class SandboxProvider(Protocol):
         """Create a sandbox for *spec*, fail-closed on unsupported requirements."""
         ...
 
+    def upload_workspace(self, handle: SandboxHandle, snapshot: Any | None) -> None:
+        """Push a project snapshot into the sandbox.
+
+        ``LegacyPosixProvider`` (Phase 3) is a no-op — the local worktree is
+        already in place. Container/K8s backends (#2023) materialize the
+        snapshot into the ephemeral sandbox filesystem. Frozen here so #2023
+        does not grow its own upload path outside the contract.
+        """
+        ...
+
     def exec(
         self,
         handle: SandboxHandle,
         command: list[str],
         env: dict[str, str] | None,
-        policy: Any | None,
+        exec_policy: Any | None,
     ) -> ExecHandle:
-        """Start one command in the sandbox; return its :class:`ExecHandle`."""
+        """Start one command in the sandbox; return its :class:`ExecHandle`.
+
+        ``exec_policy`` is the *per-command* execution policy (wall-clock
+        budget, resource overrides) — distinct from :attr:`SandboxSpec.policy`,
+        which is the *sandbox-isolation* policy (HOME/TMP/quota from #2020).
+        It stays ``Any`` until Phase 3 binds it to the wall-clock budget and
+        cgroup knobs.
+        """
         ...
 
     def stream(self, exec_handle: ExecHandle) -> Iterator[SandboxEvent]:
@@ -92,6 +117,20 @@ class SandboxProvider(Protocol):
 
     def stop(self, exec_handle: ExecHandle) -> None:
         """Stop the running command (graceful → forceful escalation is backend-specific)."""
+        ...
+
+    def collect_changes(self, handle: SandboxHandle) -> Any:
+        """Return the changes the agent made inside the sandbox.
+
+        Load-bearing for non-local backends: a ``RemoteMachineProvider``'s agent
+        edits live on the remote machine and the orchestrator cannot read them
+        with local git, so the diff/ChangeSet must come back through the
+        provider. Ownership: ``LegacyPosixProvider`` delegates to the existing
+        git-workspace service (#2041-2043) rather than reimplementing git;
+        container/K8s backends (#2023) own collection from the ephemeral FS
+        before destroy. Result typed ``Any`` (``ChangeSet``) until P3/P4 fix
+        the schema.
+        """
         ...
 
     def collect_execution_evidence(self, handle: SandboxHandle) -> list[Any]:

--- a/app/modules/workspace/autonomous/sandbox/provider.py
+++ b/app/modules/workspace/autonomous/sandbox/provider.py
@@ -1,0 +1,112 @@
+"""SandboxProvider Protocol and contract errors (Issue #2022 Phase 1).
+
+The Protocol is the stable seam between the orchestrator (which only knows the
+contract) and concrete backends (``LegacyPosixProvider`` Phase 3,
+``RemoteMachineProvider`` Phase 4, OpenSandbox/Kubernetes #2023). Phase 1
+declares the creation/destroy/inspect surface; Phase 3 extends it with
+``exec``/``stream``/``pause``/``resume``/``stop``/``collect_execution_evidence``
+as those tests land.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import TYPE_CHECKING, Any, Protocol
+
+if TYPE_CHECKING:  # pragma: no cover - annotations only (PEP 563)
+    from app.modules.workspace.autonomous.sandbox.types import (
+        ExecHandle,
+        SandboxCapability,
+        SandboxEvent,
+        SandboxHandle,
+        SandboxSpec,
+        SandboxStatus,
+    )
+
+
+class SandboxError(Exception):
+    """Base for all sandbox-contract failures (creation, lifecycle, teardown)."""
+
+
+class CapabilityUnsupported(SandboxError):
+    """A spec required a capability the provider cannot supply.
+
+    Raised fail-closed at ``create`` time. Carries the missing capabilities so
+    callers (and the workflow UI) can report which isolation guarantee was
+    unsatisfied rather than silently degrading.
+    """
+
+    def __init__(self, missing_capabilities) -> None:
+        self.missing_capabilities = frozenset(missing_capabilities)
+        names = ", ".join(sorted(cap.value for cap in self.missing_capabilities))
+        super().__init__(f"provider cannot supply required capabilities: {names}")
+
+
+def require_capabilities(
+    available,
+    required,
+) -> None:
+    """Raise :class:`CapabilityUnsupported` if *required* is not a subset.
+
+    Shared by every provider's ``create`` so the fail-closed gate has one
+    implementation. ``available`` is what the provider declares; ``required``
+    is what the spec demands.
+    """
+    missing = frozenset(required) - frozenset(available)
+    if missing:
+        raise CapabilityUnsupported(missing)
+
+
+class SandboxProvider(Protocol):
+    """Stable execution contract independent of the sandboxing backend."""
+
+    def capabilities(self) -> frozenset[SandboxCapability]:
+        """Declare the isolation guarantees this backend can actually supply."""
+        ...
+
+    def create(self, spec: SandboxSpec) -> SandboxHandle:
+        """Create a sandbox for *spec*, fail-closed on unsupported requirements."""
+        ...
+
+    def exec(
+        self,
+        handle: SandboxHandle,
+        command: list[str],
+        env: dict[str, str] | None,
+        policy: Any | None,
+    ) -> ExecHandle:
+        """Start one command in the sandbox; return its :class:`ExecHandle`."""
+        ...
+
+    def stream(self, exec_handle: ExecHandle) -> Iterator[SandboxEvent]:
+        """Yield the normalized lifecycle events for an execution."""
+        ...
+
+    def pause(self, exec_handle: ExecHandle) -> None:
+        """Pause the sandbox (best-effort; not every backend supports it)."""
+        ...
+
+    def resume(self, exec_handle: ExecHandle) -> None:
+        """Resume a paused sandbox."""
+        ...
+
+    def stop(self, exec_handle: ExecHandle) -> None:
+        """Stop the running command (graceful → forceful escalation is backend-specific)."""
+        ...
+
+    def collect_execution_evidence(self, handle: SandboxHandle) -> list[Any]:
+        """Return ``CommandExecutionEvidence`` rows produced in this sandbox.
+
+        Typed loosely (``list[Any]``) in Phase 1; Phase 3 binds it to the
+        #2046 :class:`CommandExecutionEvidence` once the provider fills
+        ``sandbox_id``/``sandbox_generation``/``signal``/``stderr_*``.
+        """
+        ...
+
+    def destroy(self, handle: SandboxHandle) -> None:
+        """Tear down the sandbox. Idempotent: repeated calls do not raise."""
+        ...
+
+    def inspect(self, handle: SandboxHandle) -> SandboxStatus:
+        """Return the live status of the sandbox."""
+        ...

--- a/app/modules/workspace/autonomous/sandbox/types.py
+++ b/app/modules/workspace/autonomous/sandbox/types.py
@@ -1,0 +1,161 @@
+"""SandboxProvider contract types (Issue #2022 Phase 1).
+
+Phase 1 fixes the stable contract surface — capability taxonomy, the
+``SandboxSpec`` value object, lifecycle status, handles, and the normalized
+event stream — that later phases implement:
+
+* Phase 2 — persistence + reconciliation (``sandbox_*`` columns on
+  ``autonomous_workflows``).
+* Phase 3 — ``LegacyPosixProvider`` wrapping the existing local POSIX path
+  (``openace-run-as`` + ACL + per-task HOME/TMP/cgroup from #2020).
+* Phase 4 — ``RemoteMachineProvider`` wrapping the autonomous remote-agent
+  execution surface.
+* Phase 5 — wiring + UI.
+
+Scope (#2022 comment, 2026-07-26): this contract abstracts ONLY the autonomous
+agent execution path. It does not touch ``app/routes/fs.py::run_as_user`` or
+the ordinary remote-session lifecycle in ``remote_session_manager.py``.
+
+Design note — provider vs CLI protocol boundary
+------------------------------------------------
+The provider owns *sandbox mechanics*: environment build, the
+``sudo``/``openace-run-as``/ACL command wrap, the ``subprocess.Popen`` and its
+process group, signal delivery (pause/resume/stop), and exit classification.
+It deliberately does NOT own the CLI protocol (stream-json stdin handshake,
+``tool_use``/``tool_result`` parsing, session-id resolution, usage accounting)
+— that stays in ``agent_runner`` and consumes the provider's raw byte streams.
+This separation is what keeps a provider from re-leaking backend detail into
+the orchestrator.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - typing only, avoids runtime import cycle
+    from app.modules.workspace.autonomous.task_isolation import AgentTaskPolicy
+
+
+class SandboxCapability(str, Enum):
+    """What isolation guarantees a provider can actually supply.
+
+    A spec's ``required_capabilities`` is checked against a provider's
+    declared capabilities at ``create`` time; an unsupported *required*
+    capability must refuse creation (fail-closed) rather than silently
+    degrade. ``LegacyPosixProvider`` (Phase 3) satisfies the first four;
+    ``namespace_isolation`` / ``network_egress_policy`` are reserved for the
+    OpenSandbox/Kubernetes backend (#2023).
+    """
+
+    PRIVATE_HOME_TMP_XDG = "private_home_tmp_xdg"
+    FILESYSTEM_ACL = "filesystem_acl"
+    CPU_MEM_PIDS_TIME_QUOTA = "cpu_mem_pids_time_quota"
+    CREDENTIAL_TOKEN_BINDING = "credential_token_binding"
+    NAMESPACE_ISOLATION = "namespace_isolation"
+    NETWORK_EGRESS_POLICY = "network_egress_policy"
+
+
+@dataclass(frozen=True)
+class SandboxSpec:
+    """Immutable description of the sandbox a task needs.
+
+    Carries identity (``task_id`` / ``cli_tool`` / ``system_account``) plus the
+    isolation intent. The HOME/TMP/quota knobs are NOT redefined here — they
+    ride on the #2020 :class:`AgentTaskPolicy` via ``policy`` — so there is one
+    source of truth for the per-task isolation tree. ``required_capabilities``
+    is the fail-closed gate: a provider that cannot meet a required capability
+    must reject the spec at creation.
+    """
+
+    task_id: str
+    project_path: str
+    cli_tool: str
+    system_account: str | None = None
+    policy: AgentTaskPolicy | None = None
+    required_capabilities: frozenset[SandboxCapability] = field(default_factory=frozenset)
+
+
+class SandboxStatus(str, Enum):
+    """Live lifecycle state of a sandbox, as observed via ``inspect``.
+
+    The :class:`SandboxHandle` snapshots ``CREATED`` at creation; subsequent
+    transitions are observed through ``provider.inspect(handle)`` rather than
+    by mutating the frozen handle, so a stale handle from a prior generation
+    cannot fabricate a live status.
+    """
+
+    CREATED = "created"
+    RUNNING = "running"
+    PAUSED = "paused"
+    STOPPED = "stopped"
+    DESTROYED = "destroyed"
+    ERROR = "error"
+
+
+@dataclass(frozen=True)
+class SandboxHandle:
+    """Identity + creation snapshot for a sandbox.
+
+    ``sandbox_id`` is provider-minted and stable across the task; ``generation``
+    is bumped on restart/reconciliation so a stale handle (e.g. one held across
+    a provider restart) cannot operate on a new sandbox with the same id. The
+    ``status`` field is the creation-time snapshot only — use
+    :meth:`SandboxProvider.inspect` for the live status.
+    """
+
+    sandbox_id: str
+    generation: int
+    provider_name: str
+    spec: SandboxSpec
+    status: SandboxStatus = SandboxStatus.CREATED
+
+
+@dataclass(frozen=True)
+class ExecHandle:
+    """Identity for one command execution within a sandbox.
+
+    ``pause``/``resume``/``stop`` key off the exec handle; ``sandbox_id`` links
+    it back to the owning sandbox so lifecycle ops resolve the live status.
+    """
+
+    sandbox_id: str
+    command_id: str
+
+
+class SandboxEventKind(str, Enum):
+    """Normalized lifecycle event every provider must emit (issue §3).
+
+    These are the *sandbox-lifecycle* events — distinct from the CLI-protocol
+    events (``tool_use``/``tool_result``) the runner emits from parsing the
+    agent's stream-json. A consumer correlates them via ``sandbox_id``.
+    """
+
+    PROCESS_STARTED = "process_started"
+    COMMAND_STARTED = "command_started"
+    STDOUT_CHUNK = "stdout_chunk"
+    STDERR_CHUNK = "stderr_chunk"
+    COMMAND_COMPLETED = "command_completed"
+    COMMAND_TIMED_OUT = "command_timed_out"
+    COMMAND_CANCELLED = "command_cancelled"
+    PROCESS_EXITED = "process_exited"
+    RESOURCE_LIMIT_EXCEEDED = "resource_limit_exceeded"
+    SANDBOX_ERROR = "sandbox_error"
+
+
+@dataclass(frozen=True)
+class SandboxEvent:
+    """One normalized lifecycle event from a provider's ``stream``.
+
+    ``data`` carries the chunk text for ``STDOUT_CHUNK``/``STDERR_CHUNK``;
+    ``exit_code`` is authoritative for ``COMMAND_COMPLETED``/``PROCESS_EXITED``
+    (#2046 contract); ``signal`` is set for ``RESOURCE_LIMIT_EXCEEDED``.
+    """
+
+    kind: SandboxEventKind
+    sandbox_id: str = ""
+    command_id: str = ""
+    exit_code: int | None = None
+    signal: int | None = None
+    data: str = ""

--- a/app/modules/workspace/autonomous/sandbox/types.py
+++ b/app/modules/workspace/autonomous/sandbox/types.py
@@ -101,15 +101,16 @@ class SandboxHandle:
     ``sandbox_id`` is provider-minted and stable across the task; ``generation``
     is bumped on restart/reconciliation so a stale handle (e.g. one held across
     a provider restart) cannot operate on a new sandbox with the same id. The
-    ``status`` field is the creation-time snapshot only — use
-    :meth:`SandboxProvider.inspect` for the live status.
+    ``initial_status`` field is the creation-time snapshot only — use
+    :meth:`SandboxProvider.inspect` for the live status (a frozen handle cannot
+    track transitions).
     """
 
     sandbox_id: str
     generation: int
     provider_name: str
     spec: SandboxSpec
-    status: SandboxStatus = SandboxStatus.CREATED
+    initial_status: SandboxStatus = SandboxStatus.CREATED
 
 
 @dataclass(frozen=True)

--- a/tests/issues/2022/test_sandbox_events.py
+++ b/tests/issues/2022/test_sandbox_events.py
@@ -52,7 +52,7 @@ def test_sandbox_event_is_frozen():
 def test_exec_returns_exec_handle_bound_to_sandbox():
     provider = FakeSandboxProvider()
     handle = provider.create(_spec())
-    eh = provider.exec(handle, command=["echo", "hi"], env={}, policy=None)
+    eh = provider.exec(handle, command=["echo", "hi"], env={}, exec_policy=None)
     assert isinstance(eh, ExecHandle)
     assert eh.sandbox_id == handle.sandbox_id
     assert eh.command_id  # provider-minted, non-empty
@@ -61,7 +61,7 @@ def test_exec_returns_exec_handle_bound_to_sandbox():
 def test_stream_emits_normalized_lifecycle_sequence():
     provider = FakeSandboxProvider()
     handle = provider.create(_spec())
-    eh = provider.exec(handle, command=["echo", "hi"], env={}, policy=None)
+    eh = provider.exec(handle, command=["echo", "hi"], env={}, exec_policy=None)
     events = list(provider.stream(eh))
     kinds = [e.kind for e in events]
     # The canonical happy-path sequence every provider must emit.
@@ -83,7 +83,7 @@ def test_stream_emits_normalized_lifecycle_sequence():
 def test_stream_stdout_chunk_carries_command_output():
     provider = FakeSandboxProvider()
     handle = provider.create(_spec())
-    eh = provider.exec(handle, command=["pytest", "-q"], env={}, policy=None)
+    eh = provider.exec(handle, command=["pytest", "-q"], env={}, exec_policy=None)
     events = list(provider.stream(eh))
     chunk = next(e for e in events if e.kind == SandboxEventKind.STDOUT_CHUNK)
     assert isinstance(chunk.data, str)
@@ -92,7 +92,7 @@ def test_stream_stdout_chunk_carries_command_output():
 def test_pause_resume_transitions_status():
     provider = FakeSandboxProvider()
     handle = provider.create(_spec())
-    eh = provider.exec(handle, command=["sleep", "1"], env={}, policy=None)
+    eh = provider.exec(handle, command=["sleep", "1"], env={}, exec_policy=None)
     provider.pause(eh)
     assert provider.inspect(handle) == SandboxStatus.PAUSED
     provider.resume(eh)
@@ -102,7 +102,7 @@ def test_pause_resume_transitions_status():
 def test_stop_transitions_to_stopped():
     provider = FakeSandboxProvider()
     handle = provider.create(_spec())
-    eh = provider.exec(handle, command=["echo", "hi"], env={}, policy=None)
+    eh = provider.exec(handle, command=["echo", "hi"], env={}, exec_policy=None)
     provider.stop(eh)
     assert provider.inspect(handle) == SandboxStatus.STOPPED
 
@@ -112,7 +112,7 @@ def test_collect_execution_evidence_is_a_list():
     # real command stream (test_exec_emits_command_execution_evidence).
     provider = FakeSandboxProvider()
     handle = provider.create(_spec())
-    eh = provider.exec(handle, command=["echo", "hi"], env={}, policy=None)
+    eh = provider.exec(handle, command=["echo", "hi"], env={}, exec_policy=None)
     list(provider.stream(eh))
     evidence = provider.collect_execution_evidence(handle)
     assert isinstance(evidence, list)

--- a/tests/issues/2022/test_sandbox_events.py
+++ b/tests/issues/2022/test_sandbox_events.py
@@ -1,0 +1,118 @@
+"""SandboxProvider contract — normalized events + exec/stream/lifecycle (#2022 P1).
+
+Pins the normalized lifecycle event taxonomy (issue §3) and the
+exec/stream/pause/resume/stop surface on the in-memory Fake. Phase 3's
+``LegacyPosixProvider`` and Phase 4's ``RemoteMachineProvider`` must emit this
+same event sequence (acceptance: "local 与 remote 使用同一 provider contract"),
+so this is the shared contract test those phases replay against.
+"""
+
+from __future__ import annotations
+
+from app.modules.workspace.autonomous.sandbox.fake import FakeSandboxProvider
+from app.modules.workspace.autonomous.sandbox.types import (
+    ExecHandle,
+    SandboxEvent,
+    SandboxEventKind,
+    SandboxSpec,
+    SandboxStatus,
+)
+
+_EXPECTED_EVENT_KINDS = {
+    "process_started",
+    "command_started",
+    "stdout_chunk",
+    "stderr_chunk",
+    "command_completed",
+    "command_timed_out",
+    "command_cancelled",
+    "process_exited",
+    "resource_limit_exceeded",
+    "sandbox_error",
+}
+
+
+def _spec() -> SandboxSpec:
+    return SandboxSpec(task_id="t-1", project_path="/repo", cli_tool="claude-code")
+
+
+def test_sandbox_event_kinds_documented():
+    assert {kind.value for kind in SandboxEventKind} == _EXPECTED_EVENT_KINDS
+
+
+def test_sandbox_event_is_frozen():
+    event = SandboxEvent(kind=SandboxEventKind.STDOUT_CHUNK, data="hello")
+    try:
+        event.data = "tampered"  # type: ignore[misc]
+    except AttributeError:
+        return
+    raise AssertionError("SandboxEvent must be frozen")
+
+
+def test_exec_returns_exec_handle_bound_to_sandbox():
+    provider = FakeSandboxProvider()
+    handle = provider.create(_spec())
+    eh = provider.exec(handle, command=["echo", "hi"], env={}, policy=None)
+    assert isinstance(eh, ExecHandle)
+    assert eh.sandbox_id == handle.sandbox_id
+    assert eh.command_id  # provider-minted, non-empty
+
+
+def test_stream_emits_normalized_lifecycle_sequence():
+    provider = FakeSandboxProvider()
+    handle = provider.create(_spec())
+    eh = provider.exec(handle, command=["echo", "hi"], env={}, policy=None)
+    events = list(provider.stream(eh))
+    kinds = [e.kind for e in events]
+    # The canonical happy-path sequence every provider must emit.
+    assert kinds == [
+        SandboxEventKind.PROCESS_STARTED,
+        SandboxEventKind.COMMAND_STARTED,
+        SandboxEventKind.STDOUT_CHUNK,
+        SandboxEventKind.COMMAND_COMPLETED,
+        SandboxEventKind.PROCESS_EXITED,
+    ]
+    # Each event carries the sandbox id so consumers can correlate.
+    assert all(e.sandbox_id == handle.sandbox_id for e in events)
+    # The completed event carries the authoritative exit code (#2046 contract).
+    completed = next(e for e in events if e.kind == SandboxEventKind.COMMAND_COMPLETED)
+    assert completed.exit_code == 0
+    assert completed.command_id == eh.command_id
+
+
+def test_stream_stdout_chunk_carries_command_output():
+    provider = FakeSandboxProvider()
+    handle = provider.create(_spec())
+    eh = provider.exec(handle, command=["pytest", "-q"], env={}, policy=None)
+    events = list(provider.stream(eh))
+    chunk = next(e for e in events if e.kind == SandboxEventKind.STDOUT_CHUNK)
+    assert isinstance(chunk.data, str)
+
+
+def test_pause_resume_transitions_status():
+    provider = FakeSandboxProvider()
+    handle = provider.create(_spec())
+    eh = provider.exec(handle, command=["sleep", "1"], env={}, policy=None)
+    provider.pause(eh)
+    assert provider.inspect(handle) == SandboxStatus.PAUSED
+    provider.resume(eh)
+    assert provider.inspect(handle) == SandboxStatus.RUNNING
+
+
+def test_stop_transitions_to_stopped():
+    provider = FakeSandboxProvider()
+    handle = provider.create(_spec())
+    eh = provider.exec(handle, command=["echo", "hi"], env={}, policy=None)
+    provider.stop(eh)
+    assert provider.inspect(handle) == SandboxStatus.STOPPED
+
+
+def test_collect_execution_evidence_is_a_list():
+    # P1: the contract method exists and returns a list; P3 fills it from the
+    # real command stream (test_exec_emits_command_execution_evidence).
+    provider = FakeSandboxProvider()
+    handle = provider.create(_spec())
+    eh = provider.exec(handle, command=["echo", "hi"], env={}, policy=None)
+    list(provider.stream(eh))
+    evidence = provider.collect_execution_evidence(handle)
+    assert isinstance(evidence, list)

--- a/tests/issues/2022/test_sandbox_provider.py
+++ b/tests/issues/2022/test_sandbox_provider.py
@@ -76,7 +76,7 @@ def test_create_mints_handle_with_id_generation_and_status():
     assert handle.generation == 1
     assert handle.provider_name == "fake"
     # Handle snapshots status at creation; live status comes from inspect().
-    assert handle.status == SandboxStatus.CREATED
+    assert handle.initial_status == SandboxStatus.CREATED
     assert handle.spec.task_id == "t-1"
 
 
@@ -119,3 +119,24 @@ def test_destroy_unknown_handle_is_idempotent():
         spec=_spec(),
     )
     provider.destroy(orphan)  # no raise
+
+
+def test_upload_workspace_is_noop_in_p1():
+    # The frozen Protocol carries upload_workspace so #2023 container/K8s
+    # backends (which must push a snapshot into the sandbox) have a seam.
+    # LegacyPosixProvider (P3) is a no-op: the local worktree is already in
+    # place. P1 just pins the method exists and does not raise.
+    provider = FakeSandboxProvider()
+    handle = provider.create(_spec())
+    provider.upload_workspace(handle, snapshot=None)  # must not raise
+
+
+def test_collect_changes_returns_placeholder_in_p1():
+    # collect_changes is load-bearing: P4 RemoteMachineProvider's agent edits
+    # live on the remote machine and the orchestrator cannot read them with
+    # local git, so the diff must come back through the provider. P1 pins the
+    # seam; the ChangeSet schema is fixed in P3/P4 (Any+TODO for now).
+    provider = FakeSandboxProvider()
+    handle = provider.create(_spec())
+    changes = provider.collect_changes(handle)
+    assert changes is None  # P1 placeholder; P3/P4 return a ChangeSet

--- a/tests/issues/2022/test_sandbox_provider.py
+++ b/tests/issues/2022/test_sandbox_provider.py
@@ -1,0 +1,121 @@
+"""SandboxProvider contract — creation gate, handle, destroy, inspect (#2022 P1).
+
+Pins the fail-closed capability gate (issue acceptance: "unsupported required
+policy fail closed") and the handle/destroy/inspect surface, using the
+in-memory ``FakeSandboxProvider`` that Phase 3/4 contract tests will reuse.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.modules.workspace.autonomous.sandbox.fake import FakeSandboxProvider
+from app.modules.workspace.autonomous.sandbox.provider import CapabilityUnsupported, SandboxError
+from app.modules.workspace.autonomous.sandbox.types import (
+    SandboxCapability,
+    SandboxHandle,
+    SandboxSpec,
+    SandboxStatus,
+)
+
+_FAKE_CAPS = frozenset(
+    {
+        SandboxCapability.PRIVATE_HOME_TMP_XDG,
+        SandboxCapability.FILESYSTEM_ACL,
+        SandboxCapability.CPU_MEM_PIDS_TIME_QUOTA,
+        SandboxCapability.CREDENTIAL_TOKEN_BINDING,
+    }
+)
+
+
+def _spec(**overrides) -> SandboxSpec:
+    base = {"task_id": "t-1", "project_path": "/repo", "cli_tool": "claude-code"}
+    base.update(overrides)
+    return SandboxSpec(**base)
+
+
+def test_capabilities_returns_declared_frozenset():
+    provider = FakeSandboxProvider(capabilities=frozenset({SandboxCapability.PRIVATE_HOME_TMP_XDG}))
+    assert provider.capabilities() == frozenset({SandboxCapability.PRIVATE_HOME_TMP_XDG})
+
+
+def test_create_rejects_unsupported_required_capability():
+    # Fake only offers the four Legacy-style caps; demanding namespace
+    # isolation (a #2023-only capability) must fail closed at creation.
+    provider = FakeSandboxProvider(capabilities=_FAKE_CAPS)
+    spec = _spec(required_capabilities=frozenset({SandboxCapability.NAMESPACE_ISOLATION}))
+    with pytest.raises(CapabilityUnsupported) as exc:
+        provider.create(spec)
+    assert SandboxCapability.NAMESPACE_ISOLATION in exc.value.missing_capabilities
+    # SandboxError is the base type so callers can catch the family.
+    assert isinstance(exc.value, SandboxError)
+
+
+def test_create_rejects_when_any_required_capability_missing():
+    provider = FakeSandboxProvider(capabilities=frozenset({SandboxCapability.PRIVATE_HOME_TMP_XDG}))
+    spec = _spec(
+        required_capabilities=frozenset(
+            {SandboxCapability.PRIVATE_HOME_TMP_XDG, SandboxCapability.NETWORK_EGRESS_POLICY}
+        )
+    )
+    with pytest.raises(CapabilityUnsupported) as exc:
+        provider.create(spec)
+    assert exc.value.missing_capabilities == frozenset({SandboxCapability.NETWORK_EGRESS_POLICY})
+
+
+def test_create_accepts_when_all_required_capabilities_supported():
+    provider = FakeSandboxProvider(capabilities=_FAKE_CAPS)
+    handle = provider.create(_spec(required_capabilities=_FAKE_CAPS))
+    assert isinstance(handle, SandboxHandle)
+
+
+def test_create_mints_handle_with_id_generation_and_status():
+    provider = FakeSandboxProvider()
+    handle = provider.create(_spec())
+    assert handle.sandbox_id  # provider-minted, non-empty
+    assert handle.generation == 1
+    assert handle.provider_name == "fake"
+    # Handle snapshots status at creation; live status comes from inspect().
+    assert handle.status == SandboxStatus.CREATED
+    assert handle.spec.task_id == "t-1"
+
+
+def test_create_mints_distinct_sandbox_ids():
+    provider = FakeSandboxProvider()
+    h1 = provider.create(_spec(task_id="t-a"))
+    h2 = provider.create(_spec(task_id="t-b"))
+    assert h1.sandbox_id != h2.sandbox_id
+
+
+def test_inspect_returns_live_status_after_create():
+    provider = FakeSandboxProvider()
+    handle = provider.create(_spec())
+    assert provider.inspect(handle) == SandboxStatus.CREATED
+
+
+def test_destroy_marks_destroyed():
+    provider = FakeSandboxProvider()
+    handle = provider.create(_spec())
+    provider.destroy(handle)
+    assert provider.inspect(handle) == SandboxStatus.DESTROYED
+
+
+def test_destroy_is_idempotent():
+    provider = FakeSandboxProvider()
+    handle = provider.create(_spec())
+    provider.destroy(handle)
+    provider.destroy(handle)  # second call must not raise
+    assert provider.inspect(handle) == SandboxStatus.DESTROYED
+
+
+def test_destroy_unknown_handle_is_idempotent():
+    # A handle this provider never minted (e.g. orphan from a prior generation)
+    # must not raise on destroy — reconciliation relies on this.
+    provider = FakeSandboxProvider()
+    orphan = SandboxHandle(
+        sandbox_id="never-created",
+        generation=1,
+        provider_name="fake",
+        spec=_spec(),
+    )
+    provider.destroy(orphan)  # no raise

--- a/tests/issues/2022/test_sandbox_spec.py
+++ b/tests/issues/2022/test_sandbox_spec.py
@@ -1,0 +1,90 @@
+"""SandboxProvider contract — SandboxCapability + SandboxSpec (Issue #2022 Phase 1).
+
+Phase 1 fixes the *contract surface* the later phases (LegacyPosixProvider,
+RemoteMachineProvider, persistence, reconciliation) build on. These tests pin
+the capability taxonomy and the ``SandboxSpec`` value object before any
+production provider exists.
+
+Scope (#2022 comment, 2026-07-26): this contract abstracts ONLY the autonomous
+agent execution path. ``SandboxSpec.policy`` reuses the per-task isolation
+policy from #2020 (``AgentTaskPolicy``) rather than redefining HOME/TMP/quota.
+"""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+
+from app.modules.workspace.autonomous.sandbox.types import SandboxCapability, SandboxSpec
+from app.modules.workspace.autonomous.task_isolation import AgentTaskPolicy
+
+# The capability taxonomy a spec may require. LegacyPosixProvider (Phase 3)
+# satisfies the first four; namespace/network isolation is reserved for the
+# OpenSandbox/Kubernetes backend (#2023) and MUST make Legacy refuse creation
+# (fail-closed, tested in test_sandbox_provider.py).
+_EXPECTED_CAPABILITIES = {
+    "private_home_tmp_xdg",
+    "filesystem_acl",
+    "cpu_mem_pids_time_quota",
+    "credential_token_binding",
+    "namespace_isolation",
+    "network_egress_policy",
+}
+
+
+def test_sandbox_capability_enum_has_documented_values():
+    values = {cap.value for cap in SandboxCapability}
+    assert values == _EXPECTED_CAPABILITIES
+
+
+def test_sandbox_capability_is_string_enum():
+    # str-enum so capability sets serialize to JSON for sandbox_policy_digest.
+    assert SandboxCapability.PRIVATE_HOME_TMP_XDG == "private_home_tmp_xdg"
+    assert isinstance(SandboxCapability.FILESYSTEM_ACL.value, str)
+
+
+def test_sandbox_spec_is_frozen_dataclass():
+    spec = SandboxSpec(task_id="t-1", project_path="/repo", cli_tool="claude-code")
+    try:
+        spec.task_id = "tampered"  # type: ignore[misc]
+    except FrozenInstanceError:
+        return
+    raise AssertionError("SandboxSpec must be frozen")
+
+
+def test_sandbox_spec_required_capabilities_defaults_empty():
+    spec = SandboxSpec(task_id="t-1", project_path="/repo", cli_tool="claude-code")
+    assert spec.required_capabilities == frozenset()
+    # system_account / policy are optional — a local same-user task has neither.
+    assert spec.system_account is None
+    assert spec.policy is None
+
+
+def test_sandbox_spec_round_trips_fields():
+    caps = frozenset({SandboxCapability.PRIVATE_HOME_TMP_XDG, SandboxCapability.FILESYSTEM_ACL})
+    spec = SandboxSpec(
+        task_id="task-abc",
+        project_path="/srv/worktrees/x",
+        cli_tool="qwen-code",
+        system_account="openace-agent",
+        required_capabilities=caps,
+    )
+    assert spec.task_id == "task-abc"
+    assert spec.project_path == "/srv/worktrees/x"
+    assert spec.cli_tool == "qwen-code"
+    assert spec.system_account == "openace-agent"
+    assert spec.required_capabilities is caps
+
+
+def test_sandbox_spec_reuses_agent_task_policy_from_issue_2020():
+    # The spec does NOT redefine HOME/TMP/quota; it carries the #2020 policy.
+    policy = AgentTaskPolicy(memory_max_bytes=536870912, pids_max=256, max_concurrent_workflows=2)
+    spec = SandboxSpec(
+        task_id="t-1",
+        project_path="/repo",
+        cli_tool="claude-code",
+        policy=policy,
+    )
+    assert spec.policy is policy
+    assert spec.policy.memory_max_bytes == 536870912
+    assert spec.policy.pids_max == 256
+    assert spec.policy.max_concurrent_workflows == 2


### PR DESCRIPTION
## What

#2022 Phase 1 — 固化 `SandboxProvider` 稳定契约（纯类型，零生产接线）。这是后续 P2–P5 的地基：先冻结 contract surface，再让 LegacyPosixProvider / RemoteMachineProvider / 持久化 / 接线 在固定接缝上实现，而不是追着移动目标跑。

> 关联：#1998（总问题）。前置全部 CLOSED：#2018/#2019/#2020/#2044/#2046/#2047。后续 #2023（OpenSandbox/K8s）。

## Contract surface

新增包 `app/modules/workspace/autonomous/sandbox/`（450 行）：

| 文件 | 内容 |
|---|---|
| `types.py` | `SandboxCapability`(6)、`SandboxSpec`(frozen，复用 #2020 `AgentTaskPolicy` 表达 HOME/TMP/quota)、`SandboxStatus`、`SandboxHandle`(id+generation)、`ExecHandle`、`SandboxEventKind`(10)、`SandboxEvent` |
| `provider.py` | `SandboxProvider` Protocol + `CapabilityUnsupported`/`SandboxError` + `require_capabilities()` fail-closed 闸门 |
| `fake.py` | `FakeSandboxProvider` 内存实现（P3/P4 contract test 共用载体） |

**归一化生命周期事件**（provider 只发这 10 种，与 runner 的 CLI 协议事件 tool_use/tool_result 分离）：`process_started · command_started · stdout_chunk · stderr_chunk · command_completed · command_timed_out · command_cancelled · process_exited · resource_limit_exceeded · sandbox_error`

## 关键设计决策：Provider vs CLI-Protocol 边界

当前 `agent_runner._run_local` 把两类逻辑熔在一起：

- **Sandbox 机制（provider 拥有）**：env build、`sudo`/`openace-run-as`/ACL wrap、`Popen`+进程组、信号(pause/resume/stop)、退出分类
- **CLI 协议（runner 保留）**：stream-json stdin 握手、`tool_use`/`tool_result` 解析、session-id 解析、usage 累积

`_read_stdout` 是 SDK 驱动器，不是流读取器。本契约把边界定在：provider 暴露**原始字节流 + 进程控制 + 退出分类**，runner 的协议层逻辑不变、只是改为从 `ExecHandle` 拿流。这正是阻止 backend 细节重新侵入 orchestrator 的关键。

## fail-closed 闸门

`required_capabilities` 是硬闸门：Legacy 将声明前 4 个（PRIVATE_HOME_TMP_XDG / FILESYSTEM_ACL / CPU_MEM_PIDS_TIME_QUOTA / CREDENTIAL_TOKEN_BINDING）；spec 要求 `NAMESPACE_ISOLATION` 或 `NETWORK_EGRESS_POLICY`（#2023 only）时，provider **拒绝创建**并报缺哪个 capability——对应验收「unsupported required policy fail closed」。

## 范围合规（#2022 comment 2026-07-26）

- ✅ 抽象**仅限 autonomous agent 执行路径**
- ✅ 不碰 `app/routes/fs.py::run_as_user`
- ✅ 不改 `remote_session_manager.py` 普通远程会话生命周期
- ✅ `git diff` 零生产文件改动（仅新增 `sandbox/` + `tests/issues/2022/`）

## 测试

`tests/issues/2022/` — **24 个 contract test，全绿**：
- `test_sandbox_spec.py`(6) — capability 枚举 / frozen / 复用 AgentTaskPolicy
- `test_sandbox_provider.py`(10) — fail-closed 闸门 / handle mint / destroy 幂等 / unknown handle 幂等
- `test_sandbox_events.py`(8) — 10 种事件 / Fake.stream() 归一化序列 / pause·resume·stop 状态转换

**lint**：`pre-commit`（black 25.1.0 / isort / ruff / mypy v1.9.0 / bandit / pydocstyle …）全部 Passed。

## 分阶段路线（本 PR = P1）

| 阶段 | 内容 |
|---|---|
| **P1 本 PR** | 契约类型 + FakeProvider + contract tests |
| P2 | 持久化（`sandbox_*` 列）+ reconciliation sweep |
| P3 | `LegacyPosixProvider` 包装本地路径 |
| P4 | `RemoteMachineProvider` 包装 autonomous 远程路径 |
| P5 | 接线 + workflow UI |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
