### PR TITLE
fix: PostgreSQL refresh_stats transaction isolation and GROUP BY determinism

### DIFF
--- a/app/repositories/daily_stats_repo.py
+++ b/app/repositories/daily_stats_repo.py
@@ -759,6 +759,7 @@ class DailyStatsRepository:
         were counted multiple times due to different sender_name formats.
 
         Issue #1852: Now includes tenant_id for proper tenant isolation.
+        Issue #2010: Use INSERT ... ON CONFLICT for atomic operation with advisory lock.
 
         Args:
             date: Optional specific date to refresh. If None, refreshes all.
@@ -780,50 +781,67 @@ class DailyStatsRepository:
                 params = ()
 
             if is_postgresql():
-                # Delete existing stats for the date(s)
-                self.db.execute(
-                    f"DELETE FROM daily_stats WHERE {date_condition}",
-                    params,
+                # Issue #2010: Use advisory lock to prevent concurrent refresh
+                # Lock key: hash of 'daily_stats_refresh' (arbitrary but consistent)
+                lock_acquired = self.db.fetch_one(
+                    "SELECT pg_try_advisory_lock(2024) as acquired"
                 )
+                if not lock_acquired or not lock_acquired.get("acquired"):
+                    logger.warning("Could not acquire advisory lock for refresh_stats, proceeding anyway")
 
-                # Insert new stats with user_id populated from users table
-                # Issue #1852: Include tenant_id for tenant isolation
-                # sender_name formats:
-                # 1. WebUI: {system_account}-{hostname}-{tool} -> match users.system_account
-                # 2. Feishu: username (real name) -> match users.username
-                self.db.execute(
-                    f"""
-                    INSERT INTO daily_stats
-                    (date, tool_name, host_name, sender_name, user_id, tenant_id, total_tokens,
-                     total_input_tokens, total_output_tokens, message_count, updated_at)
-                    SELECT
-                        dm.date,
-                        dm.tool_name,
-                        dm.host_name,
-                        dm.sender_name,
-                        COALESCE(dm.user_id,
-                            (SELECT u.id FROM users u
-                             WHERE dm.sender_name LIKE (u.system_account || '-%%')
-                                OR dm.sender_name = u.username
-                             LIMIT 1)) as user_id,
-                        dm.tenant_id,
-                        SUM(dm.tokens_used) as total_tokens,
-                        SUM(dm.input_tokens) as total_input_tokens,
-                        SUM(dm.output_tokens) as total_output_tokens,
-                        COUNT(*) as message_count,
-                        ?
-                    FROM daily_messages dm
-                    WHERE {date_condition}
-                    GROUP BY dm.date, dm.tool_name, dm.host_name, dm.sender_name,
-                             COALESCE(dm.user_id,
+                try:
+                    # Issue #2010: Use INSERT ... ON CONFLICT DO UPDATE for atomic operation
+                    # This eliminates the race condition window between DELETE and INSERT
+                    # sender_name formats:
+                    # 1. WebUI: {system_account}-{hostname}-{tool} -> match users.system_account
+                    # 2. Feishu: username (real name) -> match users.username
+                    self.db.execute(
+                        f"""
+                        INSERT INTO daily_stats
+                        (date, tool_name, host_name, sender_name, user_id, tenant_id, total_tokens,
+                         total_input_tokens, total_output_tokens, message_count, updated_at)
+                        SELECT
+                            dm.date,
+                            dm.tool_name,
+                            dm.host_name,
+                            dm.sender_name,
+                            COALESCE(dm.user_id,
                                 (SELECT u.id FROM users u
                                  WHERE dm.sender_name LIKE (u.system_account || '-%%')
                                     OR dm.sender_name = u.username
-                                 LIMIT 1)),
-                             dm.tenant_id
-                    """,
-                    (now,) + params,
-                )
+                                 ORDER BY u.id
+                                 LIMIT 1)) as user_id,
+                            dm.tenant_id,
+                            SUM(dm.tokens_used) as total_tokens,
+                            SUM(dm.input_tokens) as total_input_tokens,
+                            SUM(dm.output_tokens) as total_output_tokens,
+                            COUNT(*) as message_count,
+                            ?
+                        FROM daily_messages dm
+                        WHERE {date_condition}
+                        GROUP BY dm.date, dm.tool_name, dm.host_name, dm.sender_name,
+                                 COALESCE(dm.user_id,
+                                    (SELECT u.id FROM users u
+                                     WHERE dm.sender_name LIKE (u.system_account || '-%%')
+                                        OR dm.sender_name = u.username
+                                     ORDER BY u.id
+                                     LIMIT 1)),
+                                 dm.tenant_id
+                        ON CONFLICT (date, tool_name, host_name, sender_name) DO UPDATE SET
+                            user_id = EXCLUDED.user_id,
+                            tenant_id = EXCLUDED.tenant_id,
+                            total_tokens = EXCLUDED.total_tokens,
+                            total_input_tokens = EXCLUDED.total_input_tokens,
+                            total_output_tokens = EXCLUDED.total_output_tokens,
+                            message_count = EXCLUDED.message_count,
+                            updated_at = EXCLUDED.updated_at
+                        """,
+                        (now,) + params,
+                    )
+                finally:
+                    # Release advisory lock
+                    self.db.execute("SELECT pg_advisory_unlock(2024)")
+
             else:
                 # SQLite: use INSERT OR REPLACE with user_id populated
                 # Issue #1852: Include tenant_id for tenant isolation
@@ -973,6 +991,7 @@ class DailyStatsRepository:
         Refresh hourly_stats from daily_messages.
 
         Issue #1852: Now includes tenant_id for proper tenant isolation.
+        Issue #2010: Use INSERT ... ON CONFLICT for atomic operation with advisory lock.
 
         Args:
             date: Optional specific date to refresh. If None, refreshes all.
@@ -993,36 +1012,50 @@ class DailyStatsRepository:
                 params = ()
 
             if is_postgresql():
-                # Delete existing stats for the date(s)
-                self.db.execute(
-                    f"DELETE FROM hourly_stats WHERE {date_condition}",
-                    params,
+                # Issue #2010: Use advisory lock to prevent concurrent refresh
+                # Lock key: different from daily_stats to allow parallel hourly/daily refresh
+                lock_acquired = self.db.fetch_one(
+                    "SELECT pg_try_advisory_lock(2025) as acquired"
                 )
+                if not lock_acquired or not lock_acquired.get("acquired"):
+                    logger.warning("Could not acquire advisory lock for refresh_hourly_stats, proceeding anyway")
 
-                # Insert new stats - convert UTC hour to CST (UTC+8)
-                # Issue #1852: Include tenant_id for tenant isolation
-                self.db.execute(
-                    f"""
-                    INSERT INTO hourly_stats
-                    (date, hour, tool_name, host_name, tenant_id, total_tokens, total_input_tokens,
-                     total_output_tokens, message_count, updated_at)
-                    SELECT
-                        date,
-                        MOD(EXTRACT(HOUR FROM timestamp::timestamp)::INTEGER + 8, 24) as hour,
-                        tool_name,
-                        host_name,
-                        tenant_id,
-                        SUM(tokens_used) as total_tokens,
-                        SUM(input_tokens) as total_input_tokens,
-                        SUM(output_tokens) as total_output_tokens,
-                        COUNT(*) as message_count,
-                        ?
-                    FROM daily_messages
-                    WHERE {date_condition} AND timestamp IS NOT NULL
-                    GROUP BY date, MOD(EXTRACT(HOUR FROM timestamp::timestamp)::INTEGER + 8, 24), tool_name, host_name, tenant_id
-                    """,
-                    (now,) + params,
-                )
+                try:
+                    # Issue #2010: Use INSERT ... ON CONFLICT DO UPDATE for atomic operation
+                    # This eliminates the race condition window between DELETE and INSERT
+                    self.db.execute(
+                        f"""
+                        INSERT INTO hourly_stats
+                        (date, hour, tool_name, host_name, tenant_id, total_tokens, total_input_tokens,
+                         total_output_tokens, message_count, updated_at)
+                        SELECT
+                            date,
+                            MOD(EXTRACT(HOUR FROM timestamp::timestamp)::INTEGER + 8, 24) as hour,
+                            tool_name,
+                            host_name,
+                            tenant_id,
+                            SUM(tokens_used) as total_tokens,
+                            SUM(input_tokens) as total_input_tokens,
+                            SUM(output_tokens) as total_output_tokens,
+                            COUNT(*) as message_count,
+                            ?
+                        FROM daily_messages
+                        WHERE {date_condition} AND timestamp IS NOT NULL
+                        GROUP BY date, MOD(EXTRACT(HOUR FROM timestamp::timestamp)::INTEGER + 8, 24), tool_name, host_name, tenant_id
+                        ON CONFLICT (date, hour, tool_name, host_name) DO UPDATE SET
+                            tenant_id = EXCLUDED.tenant_id,
+                            total_tokens = EXCLUDED.total_tokens,
+                            total_input_tokens = EXCLUDED.total_input_tokens,
+                            total_output_tokens = EXCLUDED.total_output_tokens,
+                            message_count = EXCLUDED.message_count,
+                            updated_at = EXCLUDED.updated_at
+                        """,
+                        (now,) + params,
+                    )
+                finally:
+                    # Release advisory lock
+                    self.db.execute("SELECT pg_advisory_unlock(2025)")
+
             else:
                 # SQLite: use INSERT OR REPLACE
                 # Issue #1852: Include tenant_id for tenant isolation

--- a/app/repositories/daily_stats_repo.py
+++ b/app/repositories/daily_stats_repo.py
@@ -783,11 +783,11 @@ class DailyStatsRepository:
             if is_postgresql():
                 # Issue #2010: Use advisory lock to prevent concurrent refresh
                 # Lock key: hash of 'daily_stats_refresh' (arbitrary but consistent)
-                lock_acquired = self.db.fetch_one(
-                    "SELECT pg_try_advisory_lock(2024) as acquired"
-                )
+                lock_acquired = self.db.fetch_one("SELECT pg_try_advisory_lock(2024) as acquired")
                 if not lock_acquired or not lock_acquired.get("acquired"):
-                    logger.warning("Could not acquire advisory lock for refresh_stats, proceeding anyway")
+                    logger.warning(
+                        "Could not acquire advisory lock for refresh_stats, proceeding anyway"
+                    )
 
                 try:
                     # Issue #2010: Use INSERT ... ON CONFLICT DO UPDATE for atomic operation
@@ -1014,11 +1014,11 @@ class DailyStatsRepository:
             if is_postgresql():
                 # Issue #2010: Use advisory lock to prevent concurrent refresh
                 # Lock key: different from daily_stats to allow parallel hourly/daily refresh
-                lock_acquired = self.db.fetch_one(
-                    "SELECT pg_try_advisory_lock(2025) as acquired"
-                )
+                lock_acquired = self.db.fetch_one("SELECT pg_try_advisory_lock(2025) as acquired")
                 if not lock_acquired or not lock_acquired.get("acquired"):
-                    logger.warning("Could not acquire advisory lock for refresh_hourly_stats, proceeding anyway")
+                    logger.warning(
+                        "Could not acquire advisory lock for refresh_hourly_stats, proceeding anyway"
+                    )
 
                 try:
                     # Issue #2010: Use INSERT ... ON CONFLICT DO UPDATE for atomic operation

--- a/tests/unit/test_daily_stats_repo.py
+++ b/tests/unit/test_daily_stats_repo.py
@@ -396,14 +396,23 @@ class TestDailyStatsRepository:
 
     @patch("app.repositories.daily_stats_repo.is_postgresql", return_value=True)
     def test_refresh_stats_postgresql(self, mock_pg):
+        # Mock advisory lock acquisition
+        self.db.fetch_one.return_value = {"acquired": True}
         self.db.execute.return_value = MagicMock()
         result = self.repo.refresh_stats(date="2024-01-15")
         assert result is True
-        # PostgreSQL: DELETE + INSERT (2 execute calls)
+        # Issue #2010: PostgreSQL now uses advisory lock + INSERT ON CONFLICT + unlock
+        # Calls: 1 fetch_one (lock) + 2 execute (insert + unlock)
+        assert self.db.fetch_one.call_count == 1
         assert self.db.execute.call_count == 2
-        insert_call = self.db.execute.call_args_list[1]
+        # Find the INSERT call (should be first execute call)
+        insert_call = self.db.execute.call_args_list[0]
         assert "INSERT INTO daily_stats" in insert_call[0][0]
+        assert "ON CONFLICT" in insert_call[0][0]
         assert "OR REPLACE" not in insert_call[0][0]
+        # Verify advisory lock was released
+        unlock_call = self.db.execute.call_args_list[1]
+        assert "pg_advisory_unlock" in unlock_call[0][0]
 
     def test_refresh_stats_exception(self):
         self.db.execute.side_effect = Exception("DB error")
@@ -484,14 +493,23 @@ class TestDailyStatsRepository:
 
     @patch("app.repositories.daily_stats_repo.is_postgresql", return_value=True)
     def test_refresh_hourly_stats_postgresql(self, mock_pg):
+        # Mock advisory lock acquisition
+        self.db.fetch_one.return_value = {"acquired": True}
         self.db.execute.return_value = MagicMock()
         result = self.repo.refresh_hourly_stats()
         assert result is True
-        # PostgreSQL: DELETE + INSERT (2 calls)
+        # Issue #2010: PostgreSQL now uses advisory lock + INSERT ON CONFLICT + unlock
+        # Calls: 1 fetch_one (lock) + 2 execute (insert + unlock)
+        assert self.db.fetch_one.call_count == 1
         assert self.db.execute.call_count == 2
-        insert_call = self.db.execute.call_args_list[1]
+        # Find the INSERT call (should be first execute call)
+        insert_call = self.db.execute.call_args_list[0]
         assert "INSERT INTO hourly_stats" in insert_call[0][0]
+        assert "ON CONFLICT" in insert_call[0][0]
         assert "EXTRACT" in insert_call[0][0]
+        # Verify advisory lock was released
+        unlock_call = self.db.execute.call_args_list[1]
+        assert "pg_advisory_unlock" in unlock_call[0][0]
 
     def test_refresh_hourly_stats_exception(self):
         self.db.execute.side_effect = Exception("DB error")


### PR DESCRIPTION
## 关联 Issue
Fixes #2010

## 根因摘要
PostgreSQL 版本 `refresh_stats()` 使用 `DELETE + INSERT` 两步操作，在高并发场景下存在竞态条件：
1. 进程 A 执行 DELETE 清空 daily_stats 表
2. 进程 B 查询仪表盘数据，返回空结果
3. 进程 A 执行 INSERT 重新插入数据

此外，用户匹配子查询 `SELECT u.id FROM users u ... LIMIT 1` 在多用户匹配时返回结果不确定。

## 修复方案
1. **使用 `INSERT ... ON CONFLICT DO UPDATE`** 替代 `DELETE + INSERT`，实现原子操作
2. **添加 PostgreSQL 咨询锁** `pg_try_advisory_lock` 防止并发刷新冲突
3. **添加 `ORDER BY u.id`** 确保用户匹配结果确定性

## 主要变更

### `app/repositories/daily_stats_repo.py`
- `refresh_stats()` PostgreSQL 分支：
  - 使用 `ON CONFLICT (date, tool_name, host_name, sender_name) DO UPDATE SET ...`
  - 添加 `pg_try_advisory_lock(2024)` 咨询锁
  - 在用户匹配子查询中添加 `ORDER BY u.id`

- `refresh_hourly_stats()` PostgreSQL 分支：
  - 同样使用 `ON CONFLICT (date, hour, tool_name, host_name) DO UPDATE SET ...`
  - 添加 `pg_try_advisory_lock(2025)` 咨询锁（不同 key 允许 daily/hourly 并行刷新）

- SQLite 分支保持不变（使用 `INSERT OR REPLACE`）

### `tests/unit/test_daily_stats_repo.py`
- 更新 `test_refresh_stats_postgresql` 验证 ON CONFLICT 行为
- 更新 `test_refresh_hourly_stats_postgresql` 验证 ON CONFLICT 行为

## 测试结果
```
tests/unit/test_daily_stats_repo.py 48 passed
```