### PR TITLE
feat(autonomous): wire _run_local through SandboxProvider (#2022 P3b)

### DIFF
--- a/app/modules/workspace/autonomous/agent_runner.py
+++ b/app/modules/workspace/autonomous/agent_runner.py
@@ -25,14 +25,19 @@ import uuid
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from app.modules.workspace.autonomous.artifact_text import pick_best_artifact_text
 from app.modules.workspace.autonomous.models import AgentTaskResult
+from app.modules.workspace.autonomous.sandbox.legacy_posix import LegacyPosixProvider
+from app.modules.workspace.autonomous.sandbox.types import SandboxSpec
 from app.modules.workspace.autonomous.task_isolation import (
     DEFAULT_TASK_ROOT,
     ensure_task_runtime_dirs,
 )
+
+if TYPE_CHECKING:  # pragma: no cover - annotations only (PEP 563)
+    from app.modules.workspace.autonomous.sandbox.types import ExecHandle, SandboxHandle
 
 logger = logging.getLogger(__name__)
 
@@ -237,6 +242,12 @@ class _LocalSession:
     # Local subprocess sessions do not use it, but keeping it on the tracker
     # avoids a second tracker type and closes the create-vs-stop race.
     _remote_lifecycle_lock: threading.Lock = field(default_factory=threading.Lock)
+    # #2022 P3b: the SandboxProvider handle/exec_handle for the local spawn.
+    # process (above) is the raw Popen the provider exposed; these let the
+    # session release the provider sandbox at teardown. None on remote/legacy
+    # tracker paths that don't go through the provider.
+    sandbox_handle: SandboxHandle | None = None
+    exec_handle: ExecHandle | None = None
 
 
 # Top-level keys that indicate a JSON object is a leaked tool-call blob
@@ -711,6 +722,7 @@ class AutonomousAgentRunner:
         activity_callback=None,
         on_pid_registered=None,
         on_pid_cleared=None,
+        sandbox_provider=None,
     ):
         """
         Args:
@@ -724,6 +736,9 @@ class AutonomousAgentRunner:
                 when a local subprocess is created, for PID persistence.
             on_pid_cleared: Optional callback ``(session_id)`` called when a
                 local subprocess exits, for PID cleanup.
+            sandbox_provider: #2022 P3b — the SandboxProvider that owns local
+                spawn/ACL-wrap. Defaults to LegacyPosixProvider; injectable for
+                tests. P4 will branch on workspace_type for RemoteMachineProvider.
         """
         self.session_manager = session_manager
         self.remote_session_manager = remote_session_manager
@@ -734,6 +749,11 @@ class AutonomousAgentRunner:
         self._on_pid_registered = on_pid_registered
         self._on_pid_cleared = on_pid_cleared
         self._local_sessions: dict[str, _LocalSession] = {}
+        # #2022 P3b: local spawns route through the SandboxProvider so the
+        # orchestrator no longer touches sudo/_wrap_agent_cmd/Popen directly
+        # for spawn. The CLI protocol layer (reader threads, stdin handshake)
+        # still drives the raw Popen the provider exposes via get_process().
+        self._sandbox_provider = sandbox_provider or LegacyPosixProvider()
 
     @staticmethod
     def _uses_sidebar_session_source(cli_tool: str, workspace_type: str) -> bool:
@@ -2164,28 +2184,47 @@ class AutonomousAgentRunner:
                 )
             cmd = [executable] + (adapter_args[1:] if len(adapter_args) > 1 else [])
 
-        # Cross-user launch: the run-as wrapper chdir's as root then drops to
-        # system_account (claude-code/qwen-code infer project root from cwd
-        # and have no --cwd flag). Same-user runs verbatim with cwd=project.
-        cmd, cwd = (
-            self._wrap_agent_cmd(cmd, project_path, system_account, env, task_id=session_id)
-            if self._is_cross_user(system_account)
-            else self._wrap_agent_cmd(cmd, project_path, system_account, task_id=session_id)
+        # #2022 P3b: spawn through the SandboxProvider. The orchestrator no
+        # longer touches sudo/_wrap_agent_cmd/Popen directly for spawn; the
+        # provider owns the ACL wrap (build_launch_argv) + spawn + cwd. The CLI
+        # stream-json protocol (reader threads, stdin handshake below) still
+        # drives the raw Popen the provider exposes via get_process().
+        if self._is_cross_user(system_account):
+            # Env finalization moved here from _wrap_agent_cmd's cross-user
+            # branch. The launcher forwards guard_env verbatim (runuser ...
+            # /usr/bin/env -i <env_args> "$@" — env_args sets only HOME/TMPDIR/
+            # XDG/GIT_CONFIG, NOT OPENACE_GIT_CACHE_ROOT) and does NOT re-derive
+            # it, so the agent user's pre-commit cache path must be set here;
+            # the guard-bin safety check fails closed before spawn. _build_agent_env
+            # set it to the service user's path (it has no system_account), so
+            # this overwrite is load-bearing for cross-user.
+            env["OPENACE_GIT_CACHE_ROOT"] = str(
+                self._resolve_home_dir(system_account) / ".cache" / "pre-commit"
+            )
+            self._validate_cross_user_guard_bin(env)
+        sandbox_handle = self._sandbox_provider.create(
+            SandboxSpec(
+                task_id=session_id,
+                project_path=project_path,
+                cli_tool=cli_tool,
+                system_account=system_account,
+            )
+        )
+        # Preserve the old log: the wrapped launch argv (sudo/openace-run-as for
+        # cross-user, verbatim for same-user). build_launch_argv is pure, so
+        # calling it for display is harmless; exec re-derives it internally.
+        logger.info(
+            "Launching local agent: %s",
+            " ".join(self._sandbox_provider.build_launch_argv(sandbox_handle, cmd, env)),
         )
 
-        logger.info("Launching local agent: %s", " ".join(cmd))
-
         try:
-            process = subprocess.Popen(
-                cmd,
-                stdin=subprocess.PIPE,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                cwd=cwd,
-                env=env,
-                start_new_session=True,
+            exec_handle = self._sandbox_provider.exec(
+                sandbox_handle, command=cmd, env=env, exec_policy=None
             )
+            process = self._sandbox_provider.get_process(exec_handle)
         except (OSError, subprocess.SubprocessError) as e:
+            self._sandbox_provider.destroy(sandbox_handle)
             return AgentTaskResult(
                 session_id=(
                     ""
@@ -2210,6 +2249,8 @@ class AutonomousAgentRunner:
             started_at_epoch=time.time(),
             milestone_id=milestone_id,
             system_account=system_account,
+            sandbox_handle=sandbox_handle,
+            exec_handle=exec_handle,
         )
         # For a resumed session the real CLI session_id is known up front; pin
         # it so sidebar detection reuses the existing record instead of guessing.
@@ -2268,6 +2309,15 @@ class AutonomousAgentRunner:
                     os.killpg(os.getpgid(process.pid), signal.SIGKILL)
                 except (ProcessLookupError, OSError):
                     pass
+
+        # #2022 P3b: release the provider sandbox (reap any stragglers the
+        # process-group signal missed + clear its _procs so a shared provider
+        # instance does not leak across sessions). The reap above already killed
+        # the proc; destroy is idempotent on an already-dead sandbox.
+        try:
+            self._sandbox_provider.destroy(sandbox_handle)
+        except Exception as e:
+            logger.warning("sandbox destroy failed for %s: %s", session_id[:8], e)
 
         self._local_sessions.pop(session_id, None)
 

--- a/app/modules/workspace/autonomous/sandbox/legacy_posix.py
+++ b/app/modules/workspace/autonomous/sandbox/legacy_posix.py
@@ -184,6 +184,15 @@ class LegacyPosixProvider:
         # credentials). Spawn with an empty env instead; callers must pass a
         # scrubbed env (#2019 / _build_agent_env output) for the agent to work.
         spawn_env: dict[str, str] | None = env if env is not None else {}
+        # cwd mirrors _wrap_agent_cmd's (cmd, cwd) return: same-user agents
+        # (claude-code/qwen-code) infer project root from cwd (no --cwd flag),
+        # so the spawn must chdir into project_path; cross-user launches leave
+        # cwd=None because the run-as launcher chdir's as root before dropping
+        # to system_account. Omitting cwd (the P3a default) would run the
+        # same-user agent in the orchestrator's cwd — wrong project.
+        cwd: str | None = (
+            None if _is_cross_user(handle.spec.system_account) else handle.spec.project_path
+        )
         # start_new_session=True puts the child in its own process group/session
         # (pgid == child pid), which is what later lets pause/resume/stop reach
         # the whole tree via os.killpg(os.getpgid(pid), sig). This invariant
@@ -193,6 +202,7 @@ class LegacyPosixProvider:
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
+            cwd=cwd,
             env=spawn_env,
             start_new_session=True,
         )
@@ -200,6 +210,20 @@ class LegacyPosixProvider:
         self._procs[command_id] = proc
         self._sandbox_of[command_id] = handle.sandbox_id
         return ExecHandle(sandbox_id=handle.sandbox_id, command_id=command_id)
+
+    def get_process(self, exec_handle: ExecHandle) -> subprocess.Popen[Any]:
+        """Return the raw ``Popen`` for an execution (#2022 P3b).
+
+        The CLI stream-json protocol (``_read_stdout``/``_read_stderr``/
+        ``_send_sdk_init``/``_send_message``) drives the stdin/stdout handshake
+        directly and needs the raw process; the provider's normalized
+        ``stream()`` events are too high-level to carry it. This is a
+        Legacy-specific escape hatch — it is deliberately NOT on the
+        ``SandboxProvider`` Protocol: ``RemoteMachineProvider`` (P4) has no
+        local ``Popen`` and the remote agent speaks a different transport, so
+        exposing a local process would not make sense cross-backend.
+        """
+        return self._procs[exec_handle.command_id]
 
     def build_launch_argv(
         self,

--- a/app/modules/workspace/autonomous/sandbox/legacy_posix.py
+++ b/app/modules/workspace/autonomous/sandbox/legacy_posix.py
@@ -390,12 +390,16 @@ class LegacyPosixProvider:
             pass
 
     def _reap_sandbox(self, sandbox_id: str) -> None:
-        # SIGTERM→SIGKILL any live proc whose command belongs to this sandbox.
-        # _sandbox_of tracks command_id -> sandbox_id at exec time.
-        for command_id, proc in list(self._procs.items()):
-            if self._sandbox_of.get(command_id) != sandbox_id:
-                continue
-            if proc.poll() is None and proc.pid is not None:
+        # SIGTERM→SIGKILL any live proc whose command belongs to this sandbox,
+        # then DROP its bookkeeping so a long-lived shared provider does not
+        # leak entries across sessions. _sandbox_of tracks command_id ->
+        # sandbox_id at exec time; _status is left for destroy() to mark
+        # DESTROYED (inspect() returns DESTROYED for unknown ids too, so the
+        # dropped _procs/_sandbox_of entries do not break idempotent inspect).
+        owned = [cid for cid, sid in self._sandbox_of.items() if sid == sandbox_id]
+        for command_id in owned:
+            proc = self._procs.get(command_id)
+            if proc is not None and proc.poll() is None and proc.pid is not None:
                 try:
                     os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
                     proc.wait(timeout=5)
@@ -404,3 +408,5 @@ class LegacyPosixProvider:
                         os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
                     except (ProcessLookupError, OSError):
                         pass
+            self._procs.pop(command_id, None)
+            self._sandbox_of.pop(command_id, None)

--- a/tests/issues/2022/test_legacy_posix_provider.py
+++ b/tests/issues/2022/test_legacy_posix_provider.py
@@ -13,6 +13,7 @@ untouched in P3a — zero production behavior change.
 from __future__ import annotations
 
 import signal
+import tempfile
 
 from app.modules.workspace.autonomous.sandbox.legacy_posix import LegacyPosixProvider
 from app.modules.workspace.autonomous.sandbox.provider import CapabilityUnsupported
@@ -32,9 +33,18 @@ _LEGACY_CAPS = frozenset(
     }
 )
 
+# P3b made exec chdir into project_path (same-user), so specs that drive a
+# REAL Popen need an existing directory. Mock-Popen tests still pass "/repo"
+# explicitly (no real chdir happens).
+_REAL_PROJECT_PATH = tempfile.gettempdir()
+
 
 def _spec(**overrides) -> SandboxSpec:
-    base = {"task_id": "t-1", "project_path": "/repo", "cli_tool": "claude-code"}
+    base = {
+        "task_id": "t-1",
+        "project_path": _REAL_PROJECT_PATH,
+        "cli_tool": "claude-code",
+    }
     base.update(overrides)
     return SandboxSpec(**base)
 
@@ -215,7 +225,7 @@ def test_build_launch_argv_cross_user_wraps_with_run_as():
     assert "--isolated" in argv
     assert "--task-id" in argv
     assert "openace-agent" in argv
-    assert "/repo" in argv  # project_path
+    assert _REAL_PROJECT_PATH in argv  # project_path
     assert "/usr/bin/env" in argv
     assert "OPENACE_PROXY_TOKEN=tok" in argv
     assert "claude" in argv and "--print" in argv
@@ -285,6 +295,139 @@ def test_exec_env_none_does_not_inherit_credentials():
         mock_popen.return_value = MagicMock()
         provider.exec(handle, command=["/bin/echo", "hi"], env=None, exec_policy=None)
     assert mock_popen.call_args.kwargs["env"] == {}
+
+
+# ── #2022 P3b: cwd + get_process (spawn-cut prerequisites) ──
+
+
+def test_exec_passes_project_path_cwd_for_same_user():
+    # Same-user agents (claude-code/qwen-code) infer project root from cwd —
+    # there is no --cwd flag — so the provider must spawn with cwd=project_path,
+    # matching the inline ``Popen(..., cwd=project_path)`` it replaces. P3a
+    # omitted cwd; this closes the gap (otherwise the agent runs in the
+    # orchestrator's cwd).
+    provider = LegacyPosixProvider()
+    handle = provider.create(_spec(project_path="/repo"))  # no system_account → same-user
+    with patch(
+        "app.modules.workspace.autonomous.sandbox.legacy_posix.subprocess.Popen"
+    ) as mock_popen:
+        mock_popen.return_value = MagicMock()
+        provider.exec(handle, command=["claude", "--print"], env={"PATH": "/x"}, exec_policy=None)
+    assert mock_popen.call_args.kwargs.get("cwd") == "/repo"
+
+
+def test_exec_cwd_none_for_cross_user():
+    # Cross-user: the run-as launcher chdir's as root before dropping to
+    # system_account, so Popen cwd must be None (mirrors _wrap_agent_cmd's
+    # ``(wrapped, None)`` return). A set cwd would chdir the service user.
+    provider = LegacyPosixProvider()
+    handle = provider.create(_spec(project_path="/repo", system_account="openace-agent"))
+    with patch(
+        "app.modules.workspace.autonomous.sandbox.legacy_posix.subprocess.Popen"
+    ) as mock_popen:
+        mock_popen.return_value = MagicMock()
+        provider.exec(handle, command=["claude", "--print"], env={"PATH": "/x"}, exec_policy=None)
+    assert mock_popen.call_args.kwargs.get("cwd") is None
+
+
+def test_exec_start_new_session_preserved():
+    # The process-group invariant (pgid == child pid) that pause/resume/stop
+    # rely on must survive the spawn cut.
+    provider = LegacyPosixProvider()
+    handle = provider.create(_spec())
+    with patch(
+        "app.modules.workspace.autonomous.sandbox.legacy_posix.subprocess.Popen"
+    ) as mock_popen:
+        mock_popen.return_value = MagicMock()
+        provider.exec(handle, command=["claude"], env={"PATH": "/x"}, exec_policy=None)
+    assert mock_popen.call_args.kwargs.get("start_new_session") is True
+
+
+def test_get_process_returns_spawned_popen():
+    # The CLI protocol layer (_read_stdout/_read_stderr/_send_sdk_init) needs
+    # the raw Popen to drive the stream-json handshake over stdin/stdout. The
+    # provider exposes it via this Legacy-specific escape hatch (not on the
+    # Protocol — RemoteMachineProvider has no local Popen).
+    provider = LegacyPosixProvider()
+    handle = provider.create(_spec())
+    eh = provider.exec(handle, command=["/bin/echo", "hi"], env=None, exec_policy=None)
+    proc = provider.get_process(eh)
+    assert proc is provider._procs[eh.command_id]  # noqa: SLF001 - white-box
+    assert proc.stdout is not None  # real Popen pipe, not the mock
+
+
+def test_get_process_after_destroy_inspects_destroyed():
+    provider = LegacyPosixProvider()
+    handle = provider.create(_spec())
+    provider.exec(handle, command=["/bin/sleep", "30"], env=None, exec_policy=None)
+    provider.destroy(handle)
+    assert provider.inspect(handle) == SandboxStatus.DESTROYED
+
+
+# ── #2022 P3b: golden spawn equivalence vs the old inline path ──
+#
+# Locks the invariant the _run_local cut relies on: provider.exec must spawn
+# byte-identical (argv, cwd, env, start_new_session) to the old _wrap_agent_cmd
+# + inline Popen, for both same-user and cross-user. If these break, C2's cut
+# would silently change execution behavior.
+
+from app.modules.workspace.autonomous.agent_runner import AutonomousAgentRunner  # noqa: E402
+
+
+def test_exec_spawn_argv_matches_wrap_agent_cmd_same_user():
+    cmd = ["claude", "--print", "--model", "sonnet"]
+    expected_argv, expected_cwd = AutonomousAgentRunner._wrap_agent_cmd(
+        list(cmd), _REAL_PROJECT_PATH, None, task_id="t-1"
+    )
+    provider = LegacyPosixProvider()
+    handle = provider.create(_spec(task_id="t-1", project_path=_REAL_PROJECT_PATH))
+    with patch(
+        "app.modules.workspace.autonomous.sandbox.legacy_posix.subprocess.Popen"
+    ) as mock_popen:
+        mock_popen.return_value = MagicMock()
+        provider.exec(handle, command=list(cmd), env={"PATH": "/x"}, exec_policy=None)
+    call = mock_popen.call_args
+    assert call.args[0] == expected_argv
+    assert call.kwargs.get("cwd") == expected_cwd == _REAL_PROJECT_PATH
+    assert call.kwargs.get("start_new_session") is True
+
+
+def test_exec_spawn_argv_matches_wrap_agent_cmd_cross_user():
+    # Cross-user: build_launch_argv must produce the same wrapped argv as
+    # _wrap_agent_cmd, GIVEN the same finalized env. P3b moves the cross-user
+    # env finalization (OPENACE_GIT_CACHE_ROOT overwrite + guard validation)
+    # out of _wrap_agent_cmd into _run_local's env-prep, so this test feeds
+    # both paths an already-finalized env (cacheroot pre-set; guard validation
+    # mocked out of _wrap_agent_cmd) and asserts the spawn shape matches.
+    cmd = ["claude", "--print"]
+    account = "openace-agent"
+    finalized_env = {
+        "PATH": "/guard/bin:/usr/bin",
+        "OPENACE_PROXY_TOKEN": "tok",
+        "OPENACE_REAL_GIT": "/usr/bin/git",
+        "OPENACE_GIT_CACHE_ROOT": str(
+            AutonomousAgentRunner._resolve_home_dir(account) / ".cache" / "pre-commit"
+        ),
+    }
+    with patch.object(AutonomousAgentRunner, "_validate_cross_user_guard_bin"):
+        expected_argv, expected_cwd = AutonomousAgentRunner._wrap_agent_cmd(
+            list(cmd), _REAL_PROJECT_PATH, account, dict(finalized_env), task_id="t-1"
+        )
+
+    provider = LegacyPosixProvider()
+    handle = provider.create(
+        _spec(task_id="t-1", project_path=_REAL_PROJECT_PATH, system_account=account)
+    )
+    with patch(
+        "app.modules.workspace.autonomous.sandbox.legacy_posix.subprocess.Popen"
+    ) as mock_popen:
+        mock_popen.return_value = MagicMock()
+        provider.exec(handle, command=list(cmd), env=dict(finalized_env), exec_policy=None)
+    call = mock_popen.call_args
+    assert call.args[0] == expected_argv
+    assert call.kwargs.get("cwd") is expected_cwd is None
+    assert call.kwargs.get("env") == finalized_env
+    assert call.kwargs.get("start_new_session") is True
 
 
 # keep the signal import referenced

--- a/tests/issues/2022/test_legacy_posix_provider.py
+++ b/tests/issues/2022/test_legacy_posix_provider.py
@@ -122,8 +122,8 @@ def test_legacy_destroy_reaps_process():
     provider = LegacyPosixProvider()
     handle = provider.create(_spec())
     eh = provider.exec(handle, command=["/bin/sleep", "30"], env=None, exec_policy=None)
+    proc = provider._procs[eh.command_id]  # noqa: SLF001 - capture before destroy clears it
     provider.destroy(handle)
-    proc = provider._procs[eh.command_id]  # noqa: SLF001
     assert proc.poll() is not None
     assert provider.inspect(handle) == SandboxStatus.DESTROYED
 
@@ -361,6 +361,24 @@ def test_get_process_after_destroy_inspects_destroyed():
     handle = provider.create(_spec())
     provider.exec(handle, command=["/bin/sleep", "30"], env=None, exec_policy=None)
     provider.destroy(handle)
+    assert provider.inspect(handle) == SandboxStatus.DESTROYED
+
+
+def test_destroy_clears_proc_tracking_entries():
+    # destroy must release the provider's per-sandbox bookkeeping (_procs /
+    # _sandbox_of) so a long-lived shared provider does not leak entries across
+    # sessions. Today the per-orchestrator lifetime bounds it, but P4/P5 may
+    # lift the provider to a shared singleton (remote connection pool reuse) —
+    # then a monotonic leak would surface. (Review #2074 🟢#1.)
+    provider = LegacyPosixProvider()
+    handle = provider.create(_spec())
+    eh = provider.exec(handle, command=["/bin/echo", "hi"], env=None, exec_policy=None)
+    assert eh.command_id in provider._procs  # noqa: SLF001 - white-box
+    assert eh.command_id in provider._sandbox_of  # noqa: SLF001
+    provider.destroy(handle)
+    assert eh.command_id not in provider._procs  # noqa: SLF001
+    assert eh.command_id not in provider._sandbox_of  # noqa: SLF001
+    # _status stays DESTROYED for idempotent inspect (unknown id → DESTROYED).
     assert provider.inspect(handle) == SandboxStatus.DESTROYED
 
 


### PR DESCRIPTION
P3b — the #2022 strangler cut on the primary local spawn path. The generic `_run_local` branch (claude-code / qwen-code stream-json) no longer touches `sudo` / `_wrap_agent_cmd` / `subprocess.Popen` directly; spawn + ACL wrap + cwd now go through `LegacyPosixProvider`.

Builds on P1 (#2068), P2 (#2069), P3a (#2070) — all on `main`. **Does not close #2022** (P3c zcode/single_shot + P4 remote + P5 remain).

## Two commits

**C1 — `LegacyPosixProvider` cwd + `get_process` (additive, zero production change)**
- `exec()` now passes `cwd` to `Popen`, computed from the spec the way `_wrap_agent_cmd` returns `(cmd, cwd)`: same-user → `project_path` (agents infer project root from cwd, no `--cwd` flag), cross-user → `None` (the run-as launcher chdir's as root). Closes the P3a cwd gap.
- `get_process(exec_handle) -> Popen` — Legacy-specific escape hatch (**not** on the `SandboxProvider` Protocol; `RemoteMachineProvider` P4 has no local Popen) exposing the raw process so the CLI stream-json protocol layer drives the stdin/stdout handshake directly.
- +8 tests, incl. two **golden-equivalence** tests asserting `provider.exec` spawns byte-identical `(argv, cwd, env, start_new_session)` to `_wrap_agent_cmd` + inline `Popen`, same-user AND cross-user.

**C2 — the cut (`_run_local` generic path)**
- Replaces inline `_wrap_agent_cmd` + `Popen` with `provider.create` / `exec` / `get_process`. The raw `Popen` feeds the **unchanged** CLI protocol layer (reader threads, stdin handshake, reap, exit classification) — only spawn moved.
- Cross-user env finalization (the `OPENACE_GIT_CACHE_ROOT` overwrite to the agent user's home + `_validate_cross_user_guard_bin`) moves from `_wrap_agent_cmd` into `_run_local` env-prep. **Load-bearing:** the launcher forwards `guard_env` verbatim (`runuser … /usr/bin/env -i <env_args> "$@"` sets only HOME/TMPDIR/XDG/GIT_CONFIG, **not** `OPENACE_GIT_CACHE_ROOT`), so without the overwrite the agent would receive the service user's unreadable cache path.
- `_LocalSession` gains `sandbox_handle` / `exec_handle`; `provider.destroy` at teardown reaps stragglers + clears the shared provider's `_procs`.
- The old log line is preserved (displays `build_launch_argv(...)`, so cross-user still logs the sudo wrapper).
- `_wrap_agent_cmd` is **kept verbatim** — zcode / single_shot (P3c) still use it. Pause/resume/stop signals stay on the raw proc (those methods also handle the remote branch; routing through the provider would add risk for no #2022 benefit).

## Validation (this is the riskiest #2022 phase — verified rigorously)
- C1 golden-equivalence tests lock the spawn shape the cut relies on.
- Across a broad autonomous slice (`tests/autonomous` + 740 / 771 / 776 / 826 / 1003 / 1140 / 1461 / 1813, and 1138 / 1005 / 2019 / 2020 / 2022 earlier), C2 produces the **exact same failure set** as stashed-`main` (34 == 34, test-level) — zero new failures, zero accidental fixes. All 34 are pre-existing local-only failures (sudo-admin / `/private/tmp` containment / DB-unavailable), green in CI.
- All 28 #2022 provider tests pass.

## Scope (#2022, autonomous-only)
- In: `_run_local` generic stream-json path.
- Out (follow-up): `_run_zcode_appserver` + `_run_single_shot` (P3c); routing pause/resume/stop through the provider; `RemoteMachineProvider` (P4); wire + UI (P5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)