### PR TITLE
fix: add daily_stats refresh to scheduler (closes #2075)

### DIFF
--- a/app/services/data_fetch_scheduler.py
+++ b/app/services/data_fetch_scheduler.py
@@ -254,6 +254,9 @@ class DataFetchScheduler:
         # Safety net: aggregate user_daily_stats periodically
         self._aggregate_user_stats()
 
+        # Refresh daily_stats table (aggregate from daily_messages)
+        self._refresh_daily_stats()
+
         # Refresh usage_summary table
         self._refresh_usage_summary()
 
@@ -293,6 +296,17 @@ class DataFetchScheduler:
             aggregate_user_stats_background()
         except Exception as e:
             logger.warning(f"Scheduled user stats aggregation failed: {e}")
+
+    def _refresh_daily_stats(self):
+        """Refresh daily_stats table by aggregating from daily_messages."""
+        from app.repositories.daily_stats_repo import DailyStatsRepository
+
+        try:
+            daily_stats_repo = DailyStatsRepository()
+            daily_stats_repo.refresh_stats()
+            logger.info("Daily stats refreshed")
+        except Exception as e:
+            logger.warning(f"Daily stats refresh failed: {e}")
 
     def _refresh_usage_summary(self):
         """Refresh usage_summary table after new data is fetched."""

--- a/tests/unit/test_data_fetch_scheduler.py
+++ b/tests/unit/test_data_fetch_scheduler.py
@@ -279,6 +279,22 @@ class TestDataFetchSchedulerRunFetch:
         s = DataFetchScheduler()
         s._refresh_usage_summary()  # Should not raise
 
+    @patch("app.repositories.daily_stats_repo.DailyStatsRepository")
+    def test_refresh_daily_stats_success(self, mock_repo_cls):
+        mock_repo = MagicMock()
+        mock_repo.refresh_stats.return_value = True
+        mock_repo_cls.return_value = mock_repo
+
+        s = DataFetchScheduler()
+        s._refresh_daily_stats()
+        mock_repo.refresh_stats.assert_called_once()
+
+    @patch("app.repositories.daily_stats_repo.DailyStatsRepository")
+    def test_refresh_daily_stats_error(self, mock_repo_cls):
+        mock_repo_cls.side_effect = Exception("Stats refresh error")
+        s = DataFetchScheduler()
+        s._refresh_daily_stats()  # Should not raise
+
 
 class TestDataFetchSchedulerCheckQuotas:
     """Test _check_quotas method."""


### PR DESCRIPTION
## 修复说明

关联 Issue：#2075

## 根因

`data_fetch_scheduler.py` 缺少 `daily_stats` 定时刷新调用，导致 Trend Analysis 页面只显示 QWEN 工具，缺少其他工具数据。

## 修复方案

在 `DataFetchScheduler` 中添加 `_refresh_daily_stats()` 方法，在定时调度中调用 `daily_stats_repo.refresh_stats()` 刷新 `daily_stats` 表。

## 主要变更

- `app/services/data_fetch_scheduler.py`：添加 `_refresh_daily_stats()` 方法并在 `_do_fetch()` 中调用
- `tests/unit/test_data_fetch_scheduler.py`：添加 `_refresh_daily_stats` 的成功和异常测试

## 测试

- 主机：本地开发环境
- 已运行测试：`pytest tests/unit/test_data_fetch_scheduler.py -k "refresh"` - 8 passed
- 新增测试：`test_refresh_daily_stats_success`, `test_refresh_daily_stats_error`

## 风险

- 兼容性风险：无。新增方法不影响现有功能
- 性能风险：低。`refresh_stats()` 已有 advisory lock 保护并发
- 回归风险：低。新增方法独立，不影响其他刷新逻辑