### PR TITLE
feat(autonomous): finish #2022 P4 — RemoteMachineProvider + runner provider-driven + gVisor-facing spec

### DIFF
--- a/app/modules/workspace/autonomous/agent_runner.py
+++ b/app/modules/workspace/autonomous/agent_runner.py
@@ -3297,6 +3297,10 @@ class AutonomousAgentRunner:
                     # exec = create_remote_session + send_message(prompt). It
                     # raises SandboxError on either failure (fail-closed),
                     # replacing the old success-False / sent-False branches.
+                    # cancel_check restores the create↔send _stopped window the
+                    # old code had (#2078 review 🟡A): a shutdown landing during
+                    # create_remote_session is caught BEFORE send dispatches the
+                    # prompt.
                     exec_handle = provider.exec(
                         sandbox_handle,
                         command=[],
@@ -3307,6 +3311,7 @@ class AutonomousAgentRunner:
                             permission_mode=permission_mode,
                             allowed_tools=tuple(allowed_tools) if allowed_tools else None,
                         ),
+                        cancel_check=lambda: tracker._stopped.is_set(),
                     )
                     remote_session_id = exec_handle.command_id
                     tracker.persisted_session_id = remote_session_id
@@ -3448,16 +3453,13 @@ class AutonomousAgentRunner:
                 error=f"Remote execution error: {e}",
             )
         finally:
-            # Release the provider sandbox (idempotent stop + mark destroyed).
-            if sandbox_handle is not None:
-                try:
-                    provider.destroy(sandbox_handle)
-                except Exception:
-                    logger.warning(
-                        "Failed to destroy remote sandbox for %s",
-                        session_id[:8],
-                        exc_info=True,
-                    )
+            # #2078 review 🟢: do NOT destroy/stop unconditionally. A successful
+            # remote turn leaves its reusable sidebar session deliberately
+            # active (see the success-path comment above); the failure paths
+            # (timeout / exception / cancel) already call provider.stop
+            # explicitly. The provider is per-call (factory mints a fresh one),
+            # so not destroying here leaks no cross-session state. Only the
+            # local tracker is popped.
             # Clean up the remote session tracker
             self._local_sessions.pop(session_id, None)
 

--- a/app/modules/workspace/autonomous/agent_runner.py
+++ b/app/modules/workspace/autonomous/agent_runner.py
@@ -2231,6 +2231,14 @@ class AutonomousAgentRunner:
             exec_handle = self._sandbox_provider.exec(
                 sandbox_handle, command=cmd, env=env, exec_policy=None
             )
+            # NOTE (#2023): get_process/build_launch_argv are Legacy-only escape
+            # hatches (NOT on the SandboxProvider Protocol) — the CLI stream-json
+            # protocol layer (_read_stdout/_send_sdk_init) drives a local Popen's
+            # stdin/stdout directly. A gVisor/container provider has no local
+            # Popen, so reusing this path requires abstracting the IO into a
+            # provider-returned transport handle (the "replaceable local seam").
+            # Deferred to #2023's first step (when gVisor needs to reuse
+            # stream-json); P4 deliberately stops at spawn/signal decoupling.
             process = self._sandbox_provider.get_process(exec_handle)
         except (OSError, subprocess.SubprocessError) as e:
             self._sandbox_provider.destroy(sandbox_handle)
@@ -4123,7 +4131,11 @@ class AutonomousAgentRunner:
         """Suspend a running local session using SIGSTOP.
 
         The process is frozen in place and can be resumed with
-        :meth:`resume_session` using SIGCONT.
+        :meth:`resume_session` using SIGCONT. Legacy-effective only: a remote
+        tracker has ``process=None`` and returns False here (a remote CLI
+        session has no SIGSTOP analogue — pause is unsupported, not silently
+        claimed). The provider branch is reached only for local sessions with a
+        live process; ``RemoteMachineProvider.pause`` is a documented no-op.
         """
         session = self._local_sessions.get(session_id)
         if not session or not session.process or session.process.returncode is not None:

--- a/app/modules/workspace/autonomous/agent_runner.py
+++ b/app/modules/workspace/autonomous/agent_runner.py
@@ -30,6 +30,11 @@ from typing import TYPE_CHECKING, Any, cast
 from app.modules.workspace.autonomous.artifact_text import pick_best_artifact_text
 from app.modules.workspace.autonomous.models import AgentTaskResult
 from app.modules.workspace.autonomous.sandbox.legacy_posix import LegacyPosixProvider
+from app.modules.workspace.autonomous.sandbox.provider import SandboxError
+from app.modules.workspace.autonomous.sandbox.remote_machine import (
+    RemoteMachineProvider,
+    RemoteTurnSpec,
+)
 from app.modules.workspace.autonomous.sandbox.types import SandboxSpec
 from app.modules.workspace.autonomous.task_isolation import (
     DEFAULT_TASK_ROOT,
@@ -248,6 +253,10 @@ class _LocalSession:
     # tracker paths that don't go through the provider.
     sandbox_handle: SandboxHandle | None = None
     exec_handle: ExecHandle | None = None
+    # #2022 P4 ③: the provider that owns this sandbox, so stop/pause/resume can
+    # route through it (gVisor has no local Popen — signals MUST reach the
+    # sandbox via the provider). None on legacy tracker paths.
+    sandbox_provider: Any = None
 
 
 # Top-level keys that indicate a JSON object is a leaked tool-call blob
@@ -2251,6 +2260,7 @@ class AutonomousAgentRunner:
             system_account=system_account,
             sandbox_handle=sandbox_handle,
             exec_handle=exec_handle,
+            sandbox_provider=self._sandbox_provider,
         )
         # For a resumed session the real CLI session_id is known up front; pin
         # it so sidebar detection reuses the existing record instead of guessing.
@@ -2416,7 +2426,7 @@ class AutonomousAgentRunner:
                 or AutonomousAgentRunner.TASK_WALL_CLOCK_TIMEOUT_ERROR_CODE,
             )
 
-        return _build_agent_task_result(
+        result = _build_agent_task_result(
             session_id=session_id,
             tracking_session_id=session_id,
             source_session_id=resolved_session_id,
@@ -2431,6 +2441,10 @@ class AutonomousAgentRunner:
             error=session.error,
             error_code=session.error_code,
         )
+        # #2022: attribute the result (and thus its evidence) to the sandbox.
+        result.sandbox_id = sandbox_handle.sandbox_id
+        result.sandbox_generation = sandbox_handle.generation
+        return result
 
     def _create_workflow_session(
         self,
@@ -3200,6 +3214,19 @@ class AutonomousAgentRunner:
 
         return events, tool_calls
 
+    def _select_sandbox_provider(self, workspace_type: str) -> Any:
+        """Pick the SandboxProvider for a task (#2022 P4 ③).
+
+        Centralizes backend selection so adding gVisor (#2023) is one branch
+        here, not a new dispatch fork in ``run_agent_task``. Local → the
+        injected LegacyPosixProvider; remote → a RemoteMachineProvider wrapping
+        ``remote_session_manager``. The runner no longer decides isolation
+        mechanics inline — it asks the provider.
+        """
+        if workspace_type == "remote" and self.remote_session_manager is not None:
+            return RemoteMachineProvider(self.remote_session_manager)
+        return self._sandbox_provider
+
     def _run_remote(
         self,
         session_id: str,
@@ -3236,6 +3263,14 @@ class AutonomousAgentRunner:
                 error="User ID is required for remote autonomous execution",
             )
 
+        # #2022 P4: route autonomous remote execution through RemoteMachineProvider
+        # so the orchestrator speaks the same create/exec/stop/destroy contract as
+        # the local path. The provider wraps RemoteSessionManager (create_remote_
+        # session / send_message / stop_session); it does NOT change the manager
+        # or remote.py (autonomous-only scope).
+        provider = self._select_sandbox_provider("remote")
+        sandbox_handle: SandboxHandle | None = None
+        exec_handle: ExecHandle | None = None
         remote_session_id = session_id
         try:
             # Register a tracker so orchestrator can signal cancellation
@@ -3245,83 +3280,80 @@ class AutonomousAgentRunner:
             )
             self._local_sessions[session_id] = tracker
 
-            # Create remote session
-            result = self.remote_session_manager.create_remote_session(
-                user_id=user_id,
-                machine_id=remote_machine_id,
-                project_path=project_path,
-                cli_tool=cli_tool,
-                model=model,
-                permission_mode=permission_mode,
-                allowed_tools=allowed_tools,
+            sandbox_handle = provider.create(
+                SandboxSpec(
+                    task_id=session_id,
+                    project_path=project_path,
+                    cli_tool=cli_tool,
+                    machine_id=remote_machine_id,
+                    user_id=user_id,
+                )
             )
+            try:
+                with tracker._remote_lifecycle_lock:
+                    if tracker._stopped.is_set():
+                        # Shutdown arrived before dispatch — do not create/send.
+                        return self._build_remote_cancelled_result(session_id, session_id)
+                    # exec = create_remote_session + send_message(prompt). It
+                    # raises SandboxError on either failure (fail-closed),
+                    # replacing the old success-False / sent-False branches.
+                    exec_handle = provider.exec(
+                        sandbox_handle,
+                        command=[],
+                        env=None,
+                        exec_policy=RemoteTurnSpec(
+                            prompt=prompt,
+                            model=model,
+                            permission_mode=permission_mode,
+                            allowed_tools=tuple(allowed_tools) if allowed_tools else None,
+                        ),
+                    )
+                    remote_session_id = exec_handle.command_id
+                    tracker.persisted_session_id = remote_session_id
+                    tracker.sandbox_handle = sandbox_handle
+                    tracker.exec_handle = exec_handle
+                    tracker.sandbox_provider = provider
+                    if tracker._stopped.is_set():
+                        # Shutdown won while exec was in flight — stop the real
+                        # session before the poll loop observes it.
+                        provider.stop(exec_handle)
+                        return self._build_remote_cancelled_result(remote_session_id, session_id)
 
-            # The concrete RemoteSessionManager returns the session payload
-            # directly (without a success=True envelope). Keep compatibility
-            # with older/test adapters that explicitly return success=False.
-            if not result or result.get("success") is False or not result.get("session_id"):
+                    # Map the hidden stable workflow line to the real remote row so
+                    # milestone details resolve the transcript without replacing
+                    # the main/review/test tracking identity.
+                    tracking_row = self.session_manager.get_session(session_id)
+                    context = dict(getattr(tracking_row, "context", {}) or {})
+                    if isinstance(tracking_row, dict):
+                        context = dict(tracking_row.get("context", {}) or {})
+                    context.update(
+                        {
+                            "workflow_id": context.get("workflow_id", ""),
+                            "cli_session_id": remote_session_id,
+                        }
+                    )
+                    self.session_manager.update_session_fields(
+                        session_id,
+                        {
+                            "context": context,
+                            "status": "active",
+                            "cli_session_id": remote_session_id,
+                        },
+                    )
+            except SandboxError as e:
+                # provider.exec failed closed (create/send). No remote session
+                # leak: exec already stopped a partially-created session.
                 return AgentTaskResult(
                     session_id=session_id,
                     tracking_session_id=session_id,
                     success=False,
-                    error=(result or {}).get("error", "Failed to create remote session"),
+                    error=str(e),
                 )
 
-            remote_session_id = result["session_id"]
-            with tracker._remote_lifecycle_lock:
-                tracker.persisted_session_id = remote_session_id
-                if tracker._stopped.is_set():
-                    # Shutdown won while create_remote_session was in flight.
-                    # Stop the newly discovered real session before any prompt
-                    # can be dispatched.
-                    self.remote_session_manager.stop_session(remote_session_id)
-                    return self._build_remote_cancelled_result(remote_session_id, session_id)
-
-                # Map the hidden stable workflow line to the real remote row so
-                # milestone details resolve the transcript without replacing
-                # the main/review/test tracking identity.
-                tracking_row = self.session_manager.get_session(session_id)
-                context = dict(getattr(tracking_row, "context", {}) or {})
-                if isinstance(tracking_row, dict):
-                    context = dict(tracking_row.get("context", {}) or {})
-                context.update(
-                    {
-                        "workflow_id": context.get("workflow_id", ""),
-                        "cli_session_id": remote_session_id,
-                    }
-                )
-                self.session_manager.update_session_fields(
-                    session_id,
-                    {
-                        "context": context,
-                        "status": "active",
-                        "cli_session_id": remote_session_id,
-                    },
-                )
-
-                if tracker._stopped.is_set():
-                    self.remote_session_manager.stop_session(remote_session_id)
-                    return self._build_remote_cancelled_result(remote_session_id, session_id)
-
-                # The real manager names this argument ``content``. Treat an
-                # explicit False as a dispatch failure while retaining support
-                # for legacy adapters that returned None on success.
-                sent = self.remote_session_manager.send_message(
-                    session_id=remote_session_id,
-                    content=prompt,
-                    user_id=user_id,
-                )
-                if sent is False:
-                    self.remote_session_manager.stop_session(remote_session_id)
-                    return AgentTaskResult(
-                        session_id=remote_session_id,
-                        tracking_session_id=session_id,
-                        source_session_id=remote_session_id,
-                        success=False,
-                        error="Failed to send prompt to remote session",
-                    )
-
-            # Poll until session completes
+            # Poll until session completes. This stays runner-side: it needs the
+            # local session_manager for messages/tokens + _remote_turn_complete,
+            # which are CLI-protocol concerns (the provider's stream() is the
+            # contract equivalent for lifecycle events only).
             import time
 
             start_time = time.time()
@@ -3349,7 +3381,7 @@ class AutonomousAgentRunner:
 
                         remote_events, remote_tool_calls = self._normalize_remote_messages(messages)
 
-                        return _build_agent_task_result(
+                        result = _build_agent_task_result(
                             session_id=remote_session_id,
                             tracking_session_id=session_id,
                             source_session_id=remote_session_id,
@@ -3374,26 +3406,34 @@ class AutonomousAgentRunner:
                                 else None
                             ),
                         )
+                        if sandbox_handle is not None:
+                            result.sandbox_id = sandbox_handle.sandbox_id
+                            result.sandbox_generation = sandbox_handle.generation
+                        return result
                 time.sleep(5)
 
             timeout_result = self._build_remote_cancelled_result(remote_session_id, session_id)
-            try:
-                self.remote_session_manager.stop_session(remote_session_id)
-            except Exception:
-                logger.warning(
-                    "Failed to stop timed-out remote session %s",
-                    remote_session_id[:8],
-                    exc_info=True,
-                )
+            if exec_handle is not None:
+                try:
+                    provider.stop(exec_handle)
+                except Exception:
+                    logger.warning(
+                        "Failed to stop timed-out remote session %s",
+                        remote_session_id[:8],
+                        exc_info=True,
+                    )
+            if sandbox_handle is not None:
+                timeout_result.sandbox_id = sandbox_handle.sandbox_id
+                timeout_result.sandbox_generation = sandbox_handle.generation
             timeout_result.error = f"Remote agent task timed out after {timeout}s"
             return timeout_result
 
         except Exception as e:
             # Once a real remote id exists, never drop its local tracker while
             # leaving the remote task running after a mapping/polling failure.
-            if remote_session_id != session_id:
+            if exec_handle is not None and remote_session_id != session_id:
                 try:
-                    self.remote_session_manager.stop_session(remote_session_id)
+                    provider.stop(exec_handle)
                 except Exception:
                     logger.warning(
                         "Failed to stop remote session after runner error %s",
@@ -3408,6 +3448,16 @@ class AutonomousAgentRunner:
                 error=f"Remote execution error: {e}",
             )
         finally:
+            # Release the provider sandbox (idempotent stop + mark destroyed).
+            if sandbox_handle is not None:
+                try:
+                    provider.destroy(sandbox_handle)
+                except Exception:
+                    logger.warning(
+                        "Failed to destroy remote sandbox for %s",
+                        session_id[:8],
+                        exc_info=True,
+                    )
             # Clean up the remote session tracker
             self._local_sessions.pop(session_id, None)
 
@@ -3989,6 +4039,21 @@ class AutonomousAgentRunner:
         session = self._local_sessions.get(session_id)
         if not session:
             return
+        # #2022 P4 ③: route stop through the SandboxProvider when the session has
+        # one. gVisor (#2023) has no local Popen — cancellation/timeout MUST
+        # reach the sandbox via provider.stop. Legacy (raw-proc killpg) and
+        # Remote (remote_session_manager.stop_session) both set sandbox_provider
+        # on the tracker, so this covers both; the branches below are the
+        # raw-proc / no-provider fallbacks for legacy tracker paths.
+        if session.sandbox_provider is not None and session.exec_handle is not None:
+            session._stopped.set()
+            with session._remote_lifecycle_lock:
+                try:
+                    session.sandbox_provider.stop(session.exec_handle)
+                except Exception as exc:
+                    logger.warning("sandbox stop failed for %s: %s", session_id[:8], exc)
+            session.completed.set()
+            return
         if session.process is None:
             # Remote autonomous calls use a process-less local tracker so the
             # synchronous poll loop can observe cancellation. Stop the actual
@@ -4063,6 +4128,17 @@ class AutonomousAgentRunner:
             return False
         if session._paused.is_set():
             return True
+        # #2022 P4 ③: route through the SandboxProvider when present (gVisor
+        # paves container pause); equivalent to the raw SIGSTOP below for Legacy.
+        if session.sandbox_provider is not None and session.exec_handle is not None:
+            try:
+                session.sandbox_provider.pause(session.exec_handle)
+                session._paused.set()
+                logger.info("Paused session %s via sandbox provider", session_id[:8])
+                return True
+            except Exception as e:
+                logger.error("Failed to pause session %s: %s", session_id[:8], e)
+                return False
         try:
             pgid = os.getpgid(session.process.pid)
             os.killpg(pgid, signal.SIGSTOP)
@@ -4080,6 +4156,15 @@ class AutonomousAgentRunner:
             return False
         if not session._paused.is_set():
             return True
+        if session.sandbox_provider is not None and session.exec_handle is not None:
+            try:
+                session.sandbox_provider.resume(session.exec_handle)
+                session._paused.clear()
+                logger.info("Resumed session %s via sandbox provider", session_id[:8])
+                return True
+            except Exception as e:
+                logger.error("Failed to resume session %s: %s", session_id[:8], e)
+                return False
         try:
             pgid = os.getpgid(session.process.pid)
             os.killpg(pgid, signal.SIGCONT)

--- a/app/modules/workspace/autonomous/command_evidence/recorder.py
+++ b/app/modules/workspace/autonomous/command_evidence/recorder.py
@@ -163,6 +163,8 @@ class CommandEvidenceRecorder:
         execution_profile: str = "",
         started_at: datetime | None = None,
         tenant_id: int = 1,
+        sandbox_id: str | None = None,
+        sandbox_generation: int | None = None,
     ) -> None:
         """Record (or seed) the evidence row for a command invocation."""
         if self.is_noop or not command_id or not session_id:
@@ -173,6 +175,8 @@ class CommandEvidenceRecorder:
             workflow_id=workflow_id,
             session_id=session_id,
             milestone_id=milestone_id,
+            sandbox_id=sandbox_id,
+            sandbox_generation=sandbox_generation,
             tool_name=tool_name,
             shell_command=shell_command,
             argv=argv,
@@ -198,6 +202,8 @@ class CommandEvidenceRecorder:
         cancelled: bool = False,
         output_excerpt: str | None = None,
         completed_at: datetime | None = None,
+        sandbox_id: str | None = None,
+        sandbox_generation: int | None = None,
     ) -> None:
         """Upsert the terminal state for a command's evidence row."""
         if self.is_noop or not command_id or not session_id:
@@ -214,6 +220,8 @@ class CommandEvidenceRecorder:
         evidence = CommandExecutionEvidence(
             command_id=command_id,
             session_id=session_id,
+            sandbox_id=sandbox_id,
+            sandbox_generation=sandbox_generation,
             exit_code=exit_code,
             signal=signal,
             timed_out=timed_out,
@@ -236,6 +244,8 @@ class CommandEvidenceRecorder:
         workflow_id: str = "",
         milestone_id: str = "",
         event_log: list[dict[str, Any]],
+        sandbox_id: str | None = None,
+        sandbox_generation: int | None = None,
     ) -> None:
         """Walk an agent task's ``event_log`` and persist command evidence.
 
@@ -278,6 +288,8 @@ class CommandEvidenceRecorder:
                         milestone_id=milestone_id,
                         tool_name=event.get("tool_name") or "",
                         shell_command=shell_command if isinstance(shell_command, str) else None,
+                        sandbox_id=sandbox_id,
+                        sandbox_generation=sandbox_generation,
                     )
                 elif etype == "tool_result":
                     if not command_id:
@@ -290,6 +302,8 @@ class CommandEvidenceRecorder:
                         session_id=session_id,
                         exit_code=event.get("exit_code"),
                         output_excerpt=event.get("text"),
+                        sandbox_id=sandbox_id,
+                        sandbox_generation=sandbox_generation,
                     )
             except Exception as e:  # pragma: no cover - never raise to caller
                 logger.debug("command_evidence: event emit failed: %s", e)
@@ -393,12 +407,17 @@ def emit_command_evidence(
     workflow_id: str = "",
     milestone_id: str = "",
     event_log: list[dict[str, Any]],
+    sandbox_id: str | None = None,
+    sandbox_generation: int | None = None,
 ) -> None:
     """Dual-write command evidence from an agent task's event log.
 
     Convenience entry point for the orchestrator: persists a
     ``CommandExecutionEvidence`` row per command alongside the existing
     in-memory heuristics (Phase A shadow). Best-effort, never raises.
+    ``sandbox_id`` / ``sandbox_generation`` (#2022) attribute every row to the
+    SandboxProvider sandbox that ran the task — the fields #2046-A deferred to
+    the provider.
     """
     try:
         get_command_evidence_recorder().emit_from_event_log(
@@ -406,6 +425,8 @@ def emit_command_evidence(
             workflow_id=workflow_id,
             milestone_id=milestone_id,
             event_log=event_log,
+            sandbox_id=sandbox_id,
+            sandbox_generation=sandbox_generation,
         )
     except Exception as e:  # pragma: no cover - never raise to caller
         logger.debug("command_evidence: emit failed: %s", e)

--- a/app/modules/workspace/autonomous/models.py
+++ b/app/modules/workspace/autonomous/models.py
@@ -429,3 +429,8 @@ class AgentTaskResult:
     error_code: str | None = None
     # Ordered event log preserving actual message interleaving
     event_log: list = field(default_factory=list)
+    # #2022 SandboxProvider attribution for evidence (#2046-A schema). Filled by
+    # the runner from the provider handle so persisted CommandExecutionEvidence
+    # rows carry sandbox_id/generation. None when no sandbox was created.
+    sandbox_id: str | None = None
+    sandbox_generation: int | None = None

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -7509,6 +7509,8 @@ class AutonomousOrchestrator:
             workflow_id=self._workflow_id,
             milestone_id=test_ms.get("milestone_id", ""),
             event_log=test_result.event_log or [],
+            sandbox_id=getattr(test_result, "sandbox_id", None),
+            sandbox_generation=getattr(test_result, "sandbox_generation", None),
         )
 
         if self._abort_on_repo_integrity_violation(test_result, test_ms.get("milestone_id", "")):

--- a/app/modules/workspace/autonomous/sandbox/fake.py
+++ b/app/modules/workspace/autonomous/sandbox/fake.py
@@ -17,7 +17,7 @@ import uuid
 from collections.abc import Iterator
 from typing import Any
 
-from app.modules.workspace.autonomous.sandbox.provider import require_capabilities
+from app.modules.workspace.autonomous.sandbox.provider import validate_spec_capabilities
 from app.modules.workspace.autonomous.sandbox.types import (
     ExecHandle,
     SandboxCapability,
@@ -60,7 +60,7 @@ class FakeSandboxProvider:
         return self._capabilities
 
     def create(self, spec: SandboxSpec) -> SandboxHandle:
-        require_capabilities(self._capabilities, spec.required_capabilities)
+        validate_spec_capabilities(self._capabilities, spec)
         sandbox_id = uuid.uuid4().hex
         self._status[sandbox_id] = SandboxStatus.CREATED
         return SandboxHandle(

--- a/app/modules/workspace/autonomous/sandbox/legacy_posix.py
+++ b/app/modules/workspace/autonomous/sandbox/legacy_posix.py
@@ -36,7 +36,7 @@ from app.modules.workspace.autonomous.command_evidence.types import (
     CommandExecutionEvidence,
     derive_terminal_reason,
 )
-from app.modules.workspace.autonomous.sandbox.provider import require_capabilities
+from app.modules.workspace.autonomous.sandbox.provider import validate_spec_capabilities
 from app.modules.workspace.autonomous.sandbox.types import (
     ExecHandle,
     SandboxCapability,
@@ -164,7 +164,7 @@ class LegacyPosixProvider:
         return _LEGACY_CAPS
 
     def create(self, spec: SandboxSpec) -> SandboxHandle:
-        require_capabilities(_LEGACY_CAPS, spec.required_capabilities)
+        validate_spec_capabilities(_LEGACY_CAPS, spec)
         sandbox_id = uuid.uuid4().hex
         self._status[sandbox_id] = SandboxStatus.CREATED
         return SandboxHandle(

--- a/app/modules/workspace/autonomous/sandbox/legacy_posix.py
+++ b/app/modules/workspace/autonomous/sandbox/legacy_posix.py
@@ -32,6 +32,10 @@ import threading
 import uuid
 from typing import Any
 
+from app.modules.workspace.autonomous.command_evidence.types import (
+    CommandExecutionEvidence,
+    derive_terminal_reason,
+)
 from app.modules.workspace.autonomous.sandbox.provider import require_capabilities
 from app.modules.workspace.autonomous.sandbox.types import (
     ExecHandle,
@@ -152,6 +156,9 @@ class LegacyPosixProvider:
         # command_id -> owning sandbox_id, so destroy can reap every proc that
         # belongs to a sandbox without iterating opaque command ids.
         self._sandbox_of: dict[str, str] = {}
+        # command_id -> the raw agent command argv (pre-wrap), so evidence
+        # reports the agent's intent, not the sudo/openace-run-as scaffold.
+        self._command_argv: dict[str, list[str]] = {}
 
     def capabilities(self) -> frozenset[SandboxCapability]:
         return _LEGACY_CAPS
@@ -209,6 +216,7 @@ class LegacyPosixProvider:
         command_id = uuid.uuid4().hex
         self._procs[command_id] = proc
         self._sandbox_of[command_id] = handle.sandbox_id
+        self._command_argv[command_id] = list(command)
         return ExecHandle(sandbox_id=handle.sandbox_id, command_id=command_id)
 
     def get_process(self, exec_handle: ExecHandle) -> subprocess.Popen[Any]:
@@ -366,8 +374,39 @@ class LegacyPosixProvider:
         return None
 
     def collect_execution_evidence(self, handle: SandboxHandle) -> list[Any]:
-        # P3a placeholder; filled from the real command stream in P3b.
-        return []
+        """Return the sandbox's process-level :class:`CommandExecutionEvidence`.
+
+        Fills the #2046-A schema fields the runner-side recorder cannot derive
+        — ``sandbox_id`` / ``sandbox_generation`` (from the handle) and the
+        process ``exit_code`` / ``signal`` / ``terminal_reason`` (from the
+        spawned proc) — plus the raw agent ``argv`` and ``cwd``. This is the
+        process-level row; per-tool_use evidence (argv/output excerpts from the
+        agent stream) stays with the runner's recorder, which stamps the
+        sandbox_id/generation from the handle. Call before ``destroy`` (the
+        proc tracking is cleared on destroy).
+        """
+        rows: list[CommandExecutionEvidence] = []
+        for command_id, sandbox_id in self._sandbox_of.items():
+            if sandbox_id != handle.sandbox_id:
+                continue
+            proc = self._procs.get(command_id)
+            returncode = proc.returncode if proc is not None else None
+            # Python encodes signal deaths as negative return codes.
+            sig = -returncode if (returncode is not None and returncode < 0) else None
+            terminal = derive_terminal_reason(exit_code=returncode, signal=sig, has_result=True)
+            rows.append(
+                CommandExecutionEvidence(
+                    command_id=command_id,
+                    sandbox_id=handle.sandbox_id,
+                    sandbox_generation=handle.generation,
+                    argv=list(self._command_argv.get(command_id, [])),
+                    cwd=handle.spec.project_path,
+                    exit_code=returncode,
+                    signal=sig,
+                    terminal_reason=terminal.value,
+                )
+            )
+        return rows
 
     def destroy(self, handle: SandboxHandle) -> None:
         # Reap any live process belonging to this sandbox, then mark destroyed.

--- a/app/modules/workspace/autonomous/sandbox/provider.py
+++ b/app/modules/workspace/autonomous/sandbox/provider.py
@@ -13,10 +13,13 @@ from __future__ import annotations
 from collections.abc import Iterator
 from typing import TYPE_CHECKING, Any, Protocol
 
+# SandboxCapability is needed at runtime (implied_required_capabilities), not
+# just for annotations. types.py is a leaf module, so this is cycle-free.
+from app.modules.workspace.autonomous.sandbox.types import SandboxCapability
+
 if TYPE_CHECKING:  # pragma: no cover - annotations only (PEP 563)
     from app.modules.workspace.autonomous.sandbox.types import (
         ExecHandle,
-        SandboxCapability,
         SandboxEvent,
         SandboxHandle,
         SandboxSpec,
@@ -55,6 +58,36 @@ def require_capabilities(
     missing = frozenset(required) - frozenset(available)
     if missing:
         raise CapabilityUnsupported(missing)
+
+
+def implied_required_capabilities(spec: SandboxSpec) -> frozenset[SandboxCapability]:
+    """Capabilities a spec's explicit policy fields imply (#2078 review P1#1).
+
+    Without this, a caller can set ``network_egress`` / ``runtime`` / ``volumes``
+    on the spec but forget to add the matching ``required_capabilities`` entry —
+    and a provider that cannot honor the policy would silently ignore it. By
+    deriving the implied requirement from the fields themselves, ``create``
+    fail-closes instead: ``network_egress`` demands ``NETWORK_EGRESS_POLICY``;
+    ``runtime``/``volumes`` (container image + mounts) demand
+    ``NAMESPACE_ISOLATION``.
+    """
+    implied: set[SandboxCapability] = set()
+    if spec.network_egress is not None:
+        implied.add(SandboxCapability.NETWORK_EGRESS_POLICY)
+    if spec.runtime is not None or spec.volumes:
+        implied.add(SandboxCapability.NAMESPACE_ISOLATION)
+    return frozenset(implied)
+
+
+def validate_spec_capabilities(available: frozenset[SandboxCapability], spec: SandboxSpec) -> None:
+    """Fail-closed gate combining explicit + field-implied requirements.
+
+    Single entry point for every provider's ``create``: merges the spec's
+    ``required_capabilities`` with the caps its policy fields imply, then
+    :func:`require_capabilities` against what the provider declares.
+    """
+    required = frozenset(spec.required_capabilities) | implied_required_capabilities(spec)
+    require_capabilities(available, required)
 
 
 def is_current_generation(

--- a/app/modules/workspace/autonomous/sandbox/remote_machine.py
+++ b/app/modules/workspace/autonomous/sandbox/remote_machine.py
@@ -1,0 +1,268 @@
+"""RemoteMachineProvider — SandboxProvider over autonomous remote execution (#2022 P4).
+
+Wraps the autonomous remote-agent execution surface (``RemoteSessionManager``:
+``create_remote_session`` / ``send_message`` / ``get_session_status`` /
+``stop_session``) behind the :class:`SandboxProvider` contract, so the
+orchestrator treats local and remote uniformly through create/exec/stream/stop/
+destroy. The CLI-protocol specifics (``_normalize_remote_messages``, message
+collection via the local ``session_manager``) stay in ``agent_runner`` and
+consume this provider's lifecycle.
+
+Scope (#2022 comment 2026-07-26): autonomous-only. This provider MUST NOT
+change ``app/routes/remote.py`` or the ordinary remote-session lifecycle in
+``remote_session_manager.py`` — it only calls the manager's existing methods for
+the autonomous remote-agent path.
+
+Remote has no local ``Popen``: ``exec`` maps to ``create_remote_session`` +
+``send_message``, ``stream`` polls ``get_session_status``, ``stop`` maps to
+``stop_session``. There is no ``get_process`` (that Legacy-only escape hatch
+does not apply). ``pause``/``resume`` are best-effort no-ops (a remote CLI
+session has no SIGSTOP analogue); the wall-clock timeout stays runner-side via
+``_wait_for_completion`` until a follow-up binds it to ``exec_policy``.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from collections.abc import Iterator
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from app.modules.workspace.autonomous.command_evidence.types import (
+    CommandExecutionEvidence,
+    derive_terminal_reason,
+)
+from app.modules.workspace.autonomous.sandbox.provider import SandboxError, require_capabilities
+from app.modules.workspace.autonomous.sandbox.types import (
+    ExecHandle,
+    SandboxCapability,
+    SandboxEvent,
+    SandboxEventKind,
+    SandboxHandle,
+    SandboxSpec,
+    SandboxStatus,
+)
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from app.modules.workspace.remote_session_manager import RemoteSessionManager
+
+# Remote provides an isolated agent environment equivalent to Legacy (private
+# HOME on the remote machine, ACL'd workspace, proxy-token credential binding,
+# resource limits enforced by the remote deployment). Same capability set as
+# Legacy so a spec portable local↔remote does not fail-closed on the remote
+# path. gVisor/K8s (#2023) adds NAMESPACE_ISOLATION / NETWORK_EGRESS_POLICY.
+_REMOTE_CAPS = frozenset(
+    {
+        SandboxCapability.PRIVATE_HOME_TMP_XDG,
+        SandboxCapability.FILESYSTEM_ACL,
+        SandboxCapability.CPU_MEM_PIDS_TIME_QUOTA,
+        SandboxCapability.CREDENTIAL_TOKEN_BINDING,
+    }
+)
+
+
+@dataclass(frozen=True)
+class RemoteTurnSpec:
+    """Per-turn invocation params for a remote agent execution (#2022 P4).
+
+    Carried via ``exec(exec_policy=...)`` (the P1-reserved ``Any`` slot): the
+    remote ``exec`` is ``create_remote_session`` + ``send_message(prompt)``, so
+    the prompt + model/permission/allowed_tools travel here rather than through
+    ``command`` (which is Legacy's argv shape and unused for remote).
+    """
+
+    prompt: str
+    model: str = ""
+    permission_mode: str = "auto-edit"
+    allowed_tools: tuple[str, ...] | None = None
+
+
+class RemoteMachineProvider:
+    """SandboxProvider over autonomous remote-agent execution."""
+
+    def __init__(
+        self,
+        remote_session_manager: RemoteSessionManager,
+        *,
+        poll_interval: float = 5.0,
+        poll_timeout: float = 3600.0,
+    ) -> None:
+        self._rsm = remote_session_manager
+        self._status: dict[str, SandboxStatus] = {}
+        # sandbox_id -> remote_session_id (the manager's row id). command_id on
+        # the ExecHandle IS the remote_session_id so stop/destroy map directly.
+        self._remote_sid: dict[str, str] = {}
+        self._poll_interval = poll_interval
+        self._poll_timeout = poll_timeout
+
+    def capabilities(self) -> frozenset[SandboxCapability]:
+        return _REMOTE_CAPS
+
+    def create(self, spec: SandboxSpec) -> SandboxHandle:
+        require_capabilities(_REMOTE_CAPS, spec.required_capabilities)
+        if not spec.machine_id:
+            raise SandboxError("RemoteMachineProvider requires spec.machine_id")
+        if spec.user_id is None:
+            raise SandboxError("RemoteMachineProvider requires spec.user_id")
+        sandbox_id = uuid.uuid4().hex
+        self._status[sandbox_id] = SandboxStatus.CREATED
+        return SandboxHandle(
+            sandbox_id=sandbox_id,
+            generation=1,
+            provider_name="remote_machine",
+            spec=spec,
+            initial_status=SandboxStatus.CREATED,
+        )
+
+    def exec(
+        self,
+        handle: SandboxHandle,
+        command: list[str],
+        env: dict[str, str] | None,
+        exec_policy: Any | None,
+    ) -> ExecHandle:
+        if not isinstance(exec_policy, RemoteTurnSpec):
+            raise SandboxError("remote exec requires a RemoteTurnSpec as exec_policy")
+        spec = handle.spec
+        machine_id = spec.machine_id
+        user_id = spec.user_id
+        # create() already rejected None for both; re-state so the type checker
+        # narrows them for the manager call below.
+        if machine_id is None or user_id is None:  # pragma: no cover - create() guards
+            raise SandboxError("remote spec missing machine_id/user_id")
+        result = self._rsm.create_remote_session(
+            user_id=user_id,
+            machine_id=machine_id,
+            project_path=spec.project_path,
+            cli_tool=spec.cli_tool,
+            model=exec_policy.model,
+            permission_mode=exec_policy.permission_mode,
+            allowed_tools=list(exec_policy.allowed_tools) if exec_policy.allowed_tools else None,
+        )
+        if not result or result.get("success") is False or not result.get("session_id"):
+            self._status[handle.sandbox_id] = SandboxStatus.ERROR
+            raise SandboxError((result or {}).get("error", "failed to create remote session"))
+        remote_session_id = result["session_id"]
+        self._remote_sid[handle.sandbox_id] = remote_session_id
+        self._status[handle.sandbox_id] = SandboxStatus.RUNNING
+        sent = self._rsm.send_message(
+            session_id=remote_session_id,
+            content=exec_policy.prompt,
+            user_id=spec.user_id,
+        )
+        if sent is False:
+            try:
+                self._rsm.stop_session(remote_session_id)
+            except Exception:  # pragma: no cover - best-effort cleanup
+                pass
+            self._status[handle.sandbox_id] = SandboxStatus.ERROR
+            raise SandboxError("failed to send prompt to remote session")
+        return ExecHandle(sandbox_id=handle.sandbox_id, command_id=remote_session_id)
+
+    def stream(self, exec_handle: ExecHandle) -> Iterator[SandboxEvent]:
+        sandbox_id = exec_handle.sandbox_id
+        remote_session_id = exec_handle.command_id
+        self._status[sandbox_id] = SandboxStatus.RUNNING
+        yield SandboxEvent(kind=SandboxEventKind.PROCESS_STARTED, sandbox_id=sandbox_id)
+        yield SandboxEvent(
+            kind=SandboxEventKind.COMMAND_STARTED,
+            sandbox_id=sandbox_id,
+            command_id=remote_session_id,
+        )
+        # Poll get_session_status until the remote manager observes the turn
+        # complete (an output entry with is_complete=True) or the poll budget
+        # runs out. Message normalization stays with the runner.
+        deadline = time.monotonic() + max(self._poll_timeout, 0.0)
+        exit_code = 0
+        getter = getattr(self._rsm, "get_session_status", None)
+        while time.monotonic() < deadline:
+            remote_state = getter(remote_session_id) if callable(getter) else None
+            if remote_state is not None and self._turn_complete(remote_state):
+                exit_code = int(remote_state.get("exit_code") or 0)
+                break
+            time.sleep(self._poll_interval)
+        yield SandboxEvent(
+            kind=SandboxEventKind.COMMAND_COMPLETED,
+            sandbox_id=sandbox_id,
+            command_id=remote_session_id,
+            exit_code=exit_code,
+        )
+        yield SandboxEvent(
+            kind=SandboxEventKind.PROCESS_EXITED,
+            sandbox_id=sandbox_id,
+            exit_code=exit_code,
+        )
+
+    def pause(self, exec_handle: ExecHandle) -> None:
+        # A remote CLI session has no SIGSTOP analogue; pause is a documented
+        # no-op. The orchestrator's pause-aware timeout stays runner-side.
+        return None
+
+    def resume(self, exec_handle: ExecHandle) -> None:
+        return None
+
+    def stop(self, exec_handle: ExecHandle) -> None:
+        try:
+            self._rsm.stop_session(exec_handle.command_id)
+        except Exception:  # pragma: no cover - best-effort
+            pass
+        self._status[exec_handle.sandbox_id] = SandboxStatus.STOPPED
+
+    def upload_workspace(self, handle: SandboxHandle, snapshot: Any | None) -> None:
+        # Remote workspaces are already materialized on the remote machine.
+        return None
+
+    def collect_changes(self, handle: SandboxHandle) -> Any:
+        # Remote delegates change collection to the git-workspace service
+        # (#2041-2043) over the remote checkout; not owned here.
+        return None
+
+    def collect_execution_evidence(self, handle: SandboxHandle) -> list[Any]:
+        # Fills the #2046-A sandbox attribution (sandbox_id/generation). Remote
+        # exit_code/signal are best-effort from the last observed status; the
+        # authoritative per-tool evidence stays with the runner's recorder.
+        remote_session_id = self._remote_sid.get(handle.sandbox_id, handle.sandbox_id)
+        terminal = derive_terminal_reason(exit_code=0, has_result=True)
+        return [
+            CommandExecutionEvidence(
+                command_id=remote_session_id,
+                sandbox_id=handle.sandbox_id,
+                sandbox_generation=handle.generation,
+                cwd=handle.spec.project_path,
+                exit_code=0,
+                terminal_reason=terminal.value,
+            )
+        ]
+
+    def destroy(self, handle: SandboxHandle) -> None:
+        # Idempotent: stop the remote session if known, then mark destroyed.
+        remote_session_id = self._remote_sid.pop(handle.sandbox_id, None)
+        if remote_session_id is not None:
+            try:
+                self._rsm.stop_session(remote_session_id)
+            except Exception:  # pragma: no cover - best-effort
+                pass
+        self._status[handle.sandbox_id] = SandboxStatus.DESTROYED
+
+    def inspect(self, handle: SandboxHandle) -> SandboxStatus:
+        return self._status.get(handle.sandbox_id, SandboxStatus.DESTROYED)
+
+    # ── helpers ─────────────────────────────────────────────────────
+
+    @staticmethod
+    def _turn_complete(remote_state: Any) -> bool:
+        """Whether the remote manager observed the current request finish.
+
+        Mirrors ``agent_runner._remote_turn_complete``: an output entry with
+        ``is_complete`` on a stdout/stderr/system stream.
+        """
+        if not isinstance(remote_state, dict):
+            return False
+        output = remote_state.get("output") or []
+        return any(
+            isinstance(entry, dict)
+            and bool(entry.get("is_complete"))
+            and entry.get("stream") in ("stdout", "stderr", "system")
+            for entry in output
+        )

--- a/app/modules/workspace/autonomous/sandbox/remote_machine.py
+++ b/app/modules/workspace/autonomous/sandbox/remote_machine.py
@@ -31,9 +31,13 @@ from typing import TYPE_CHECKING, Any
 
 from app.modules.workspace.autonomous.command_evidence.types import (
     CommandExecutionEvidence,
+    TerminalReason,
     derive_terminal_reason,
 )
-from app.modules.workspace.autonomous.sandbox.provider import SandboxError, require_capabilities
+from app.modules.workspace.autonomous.sandbox.provider import (
+    SandboxError,
+    validate_spec_capabilities,
+)
 from app.modules.workspace.autonomous.sandbox.types import (
     ExecHandle,
     SandboxCapability,
@@ -47,19 +51,18 @@ from app.modules.workspace.autonomous.sandbox.types import (
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from app.modules.workspace.remote_session_manager import RemoteSessionManager
 
-# Remote provides an isolated agent environment equivalent to Legacy (private
-# HOME on the remote machine, ACL'd workspace, proxy-token credential binding,
-# resource limits enforced by the remote deployment). Same capability set as
-# Legacy so a spec portable local↔remote does not fail-closed on the remote
-# path. gVisor/K8s (#2023) adds NAMESPACE_ISOLATION / NETWORK_EGRESS_POLICY.
-_REMOTE_CAPS = frozenset(
-    {
-        SandboxCapability.PRIVATE_HOME_TMP_XDG,
-        SandboxCapability.FILESYSTEM_ACL,
-        SandboxCapability.CPU_MEM_PIDS_TIME_QUOTA,
-        SandboxCapability.CREDENTIAL_TOKEN_BINDING,
-    }
-)
+# Remote provides NO verifiable isolation today (#2078 review P1#1): the
+# remote-agent executor (remote-agent/executor.py::_build_env) launches the CLI
+# from ``dict(os.environ)`` with a plain Popen — no per-task HOME/TMP/XDG, no
+# openace-run-as ACL, no cgroup quota, and the proxy-token injection does not
+# scrub the rest of the inherited env (so CREDENTIAL_TOKEN_BINDING is not
+# honestly held either). Declaring these would let a spec require them and have
+# Remote silently accept without enforcing — a fail-closed violation. Remote
+# therefore declares an empty set: a spec requiring ANY isolation cap fails
+# closed here (current autonomous remote specs require none, so this is honest
+# and non-breaking). When a remote deployment gains verifiable isolation it
+# should be reported via a machine capability handshake, not a static constant.
+_REMOTE_CAPS: frozenset[SandboxCapability] = frozenset()
 
 
 @dataclass(frozen=True)
@@ -98,6 +101,10 @@ class RemoteMachineProvider:
         # instead of a hardcoded 0. Prod remote does not call stream() today
         # (the runner has its own poll loop); this fills when stream runs.
         self._last_exit_code: dict[str, int] = {}
+        # sandbox_id -> the terminal event kind stream() reached (COMMAND_COMPLETED
+        # / COMMAND_TIMED_OUT / SANDBOX_ERROR), so collect_execution_evidence maps
+        # to an honest terminal_reason instead of assuming completed (#2078 P1#3).
+        self._last_terminal_kind: dict[str, SandboxEventKind] = {}
         self._poll_interval = poll_interval
         self._poll_timeout = poll_timeout
 
@@ -105,7 +112,7 @@ class RemoteMachineProvider:
         return _REMOTE_CAPS
 
     def create(self, spec: SandboxSpec) -> SandboxHandle:
-        require_capabilities(_REMOTE_CAPS, spec.required_capabilities)
+        validate_spec_capabilities(_REMOTE_CAPS, spec)
         if not spec.machine_id:
             raise SandboxError("RemoteMachineProvider requires spec.machine_id")
         if spec.user_id is None:
@@ -189,20 +196,37 @@ class RemoteMachineProvider:
             command_id=remote_session_id,
         )
         # Poll get_session_status until the remote manager observes the turn
-        # complete (an output entry with is_complete=True) or the poll budget
-        # runs out. Message normalization stays with the runner.
+        # complete (an output entry with is_complete=True), the poll budget runs
+        # out (COMMAND_TIMED_OUT), or status polling itself fails
+        # (SANDBOX_ERROR). Never disguise a non-completion as COMMAND_COMPLETED
+        # (#2078 review P1#3). Message normalization stays with the runner.
         deadline = time.monotonic() + max(self._poll_timeout, 0.0)
         exit_code = 0
+        terminal_kind = SandboxEventKind.COMMAND_TIMED_OUT  # if the loop exhausts
         getter = getattr(self._rsm, "get_session_status", None)
-        while time.monotonic() < deadline:
-            remote_state = getter(remote_session_id) if callable(getter) else None
-            if remote_state is not None and self._turn_complete(remote_state):
-                exit_code = int(remote_state.get("exit_code") or 0)
-                self._last_exit_code[sandbox_id] = exit_code
-                break
-            time.sleep(self._poll_interval)
+        if not callable(getter):
+            terminal_kind = SandboxEventKind.SANDBOX_ERROR
+        else:
+            while time.monotonic() < deadline:
+                try:
+                    remote_state = getter(remote_session_id)
+                except Exception:
+                    terminal_kind = SandboxEventKind.SANDBOX_ERROR
+                    remote_state = None
+                    break
+                if remote_state is not None and self._turn_complete(remote_state):
+                    exit_code = int(remote_state.get("exit_code") or 0)
+                    self._last_exit_code[sandbox_id] = exit_code
+                    terminal_kind = SandboxEventKind.COMMAND_COMPLETED
+                    break
+                time.sleep(self._poll_interval)
+        if terminal_kind != SandboxEventKind.COMMAND_COMPLETED:
+            # Non-completion is an error state; collect_execution_evidence reads
+            # _last_terminal_kind for the honest terminal_reason.
+            self._status[sandbox_id] = SandboxStatus.ERROR
+        self._last_terminal_kind[sandbox_id] = terminal_kind
         yield SandboxEvent(
-            kind=SandboxEventKind.COMMAND_COMPLETED,
+            kind=terminal_kind,
             sandbox_id=sandbox_id,
             command_id=remote_session_id,
             exit_code=exit_code,
@@ -239,14 +263,16 @@ class RemoteMachineProvider:
 
     def collect_execution_evidence(self, handle: SandboxHandle) -> list[Any]:
         # Fills the #2046-A sandbox attribution (sandbox_id/generation). The
-        # exit_code is the last one stream()'s poll observed (stored in
-        # _last_exit_code); before stream runs it defaults to 0. Prod remote
-        # does not call this today (the runner drives its own poll loop and
-        # stamps sandbox attribution via the recorder), so this is the contract
+        # exit_code is the last stream() observed; terminal_reason reflects the
+        # terminal event kind stream() reached (completed / timeout / sandbox
+        # error) — never assuming completed on a non-completion (#2078 P1#3).
+        # Prod remote does not call this today (the runner drives its own poll
+        # loop and stamps attribution via the recorder); this is the contract
         # path #2023 gVisor inherits.
         remote_session_id = self._remote_sid.get(handle.sandbox_id, handle.sandbox_id)
         exit_code = self._last_exit_code.get(handle.sandbox_id, 0)
-        terminal = derive_terminal_reason(exit_code=exit_code, has_result=True)
+        terminal_kind = self._last_terminal_kind.get(handle.sandbox_id)
+        terminal_reason = self._terminal_reason(terminal_kind, exit_code)
         return [
             CommandExecutionEvidence(
                 command_id=remote_session_id,
@@ -254,7 +280,7 @@ class RemoteMachineProvider:
                 sandbox_generation=handle.generation,
                 cwd=handle.spec.project_path,
                 exit_code=exit_code,
-                terminal_reason=terminal.value,
+                terminal_reason=terminal_reason,
             )
         ]
 
@@ -289,3 +315,12 @@ class RemoteMachineProvider:
             and entry.get("stream") in ("stdout", "stderr", "system")
             for entry in output
         )
+
+    @staticmethod
+    def _terminal_reason(kind: SandboxEventKind | None, exit_code: int) -> str:
+        """Map stream()'s terminal event kind to a #2046-A terminal_reason."""
+        if kind == SandboxEventKind.COMMAND_TIMED_OUT:
+            return TerminalReason.TIMEOUT.value
+        if kind == SandboxEventKind.SANDBOX_ERROR:
+            return "sandbox_error"
+        return derive_terminal_reason(exit_code=exit_code, has_result=True).value

--- a/app/modules/workspace/autonomous/sandbox/remote_machine.py
+++ b/app/modules/workspace/autonomous/sandbox/remote_machine.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 
 import time
 import uuid
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -93,6 +93,11 @@ class RemoteMachineProvider:
         # sandbox_id -> remote_session_id (the manager's row id). command_id on
         # the ExecHandle IS the remote_session_id so stop/destroy map directly.
         self._remote_sid: dict[str, str] = {}
+        # sandbox_id -> last exit_code observed by stream()'s poll, so
+        # collect_execution_evidence reports the real outcome (#2078 review 🟡B)
+        # instead of a hardcoded 0. Prod remote does not call stream() today
+        # (the runner has its own poll loop); this fills when stream runs.
+        self._last_exit_code: dict[str, int] = {}
         self._poll_interval = poll_interval
         self._poll_timeout = poll_timeout
 
@@ -121,6 +126,7 @@ class RemoteMachineProvider:
         command: list[str],
         env: dict[str, str] | None,
         exec_policy: Any | None,
+        cancel_check: Callable[[], bool] | None = None,
     ) -> ExecHandle:
         if not isinstance(exec_policy, RemoteTurnSpec):
             raise SandboxError("remote exec requires a RemoteTurnSpec as exec_policy")
@@ -146,6 +152,18 @@ class RemoteMachineProvider:
         remote_session_id = result["session_id"]
         self._remote_sid[handle.sandbox_id] = remote_session_id
         self._status[handle.sandbox_id] = SandboxStatus.RUNNING
+        # #2078 review 🟡A: restore the create↔send cancellation window the old
+        # _run_remote had two _stopped checks for. exec merges create+send; the
+        # runner passes its _stopped event as cancel_check so a shutdown landing
+        # during create_remote_session is caught BEFORE send — no prompt reaches
+        # a cancelled task (the old "intercept before dispatch" guarantee).
+        if cancel_check is not None and cancel_check():
+            try:
+                self._rsm.stop_session(remote_session_id)
+            except Exception:  # pragma: no cover - best-effort cleanup
+                pass
+            self._status[handle.sandbox_id] = SandboxStatus.STOPPED
+            raise SandboxError("cancelled before prompt dispatch")
         sent = self._rsm.send_message(
             session_id=remote_session_id,
             content=exec_policy.prompt,
@@ -180,6 +198,7 @@ class RemoteMachineProvider:
             remote_state = getter(remote_session_id) if callable(getter) else None
             if remote_state is not None and self._turn_complete(remote_state):
                 exit_code = int(remote_state.get("exit_code") or 0)
+                self._last_exit_code[sandbox_id] = exit_code
                 break
             time.sleep(self._poll_interval)
         yield SandboxEvent(
@@ -219,18 +238,22 @@ class RemoteMachineProvider:
         return None
 
     def collect_execution_evidence(self, handle: SandboxHandle) -> list[Any]:
-        # Fills the #2046-A sandbox attribution (sandbox_id/generation). Remote
-        # exit_code/signal are best-effort from the last observed status; the
-        # authoritative per-tool evidence stays with the runner's recorder.
+        # Fills the #2046-A sandbox attribution (sandbox_id/generation). The
+        # exit_code is the last one stream()'s poll observed (stored in
+        # _last_exit_code); before stream runs it defaults to 0. Prod remote
+        # does not call this today (the runner drives its own poll loop and
+        # stamps sandbox attribution via the recorder), so this is the contract
+        # path #2023 gVisor inherits.
         remote_session_id = self._remote_sid.get(handle.sandbox_id, handle.sandbox_id)
-        terminal = derive_terminal_reason(exit_code=0, has_result=True)
+        exit_code = self._last_exit_code.get(handle.sandbox_id, 0)
+        terminal = derive_terminal_reason(exit_code=exit_code, has_result=True)
         return [
             CommandExecutionEvidence(
                 command_id=remote_session_id,
                 sandbox_id=handle.sandbox_id,
                 sandbox_generation=handle.generation,
                 cwd=handle.spec.project_path,
-                exit_code=0,
+                exit_code=exit_code,
                 terminal_reason=terminal.value,
             )
         ]

--- a/app/modules/workspace/autonomous/sandbox/types.py
+++ b/app/modules/workspace/autonomous/sandbox/types.py
@@ -57,6 +57,53 @@ class SandboxCapability(str, Enum):
     NETWORK_EGRESS_POLICY = "network_egress_policy"
 
 
+# ── gVisor/container-facing isolation dimensions (#2022 P4 ①) ──
+#
+# A gVisor/OpenSandbox backend (#2023) needs to express network egress,
+# runtime/image and volumes THROUGH THE SPEC, not by extending the contract
+# (which would re-leak backend detail into the seam — exactly what #2022
+# prevents). HOME/TMP/cgroup/quota stay on #2020's AgentTaskPolicy via
+# ``SandboxSpec.policy``; these value objects model only the dimensions
+# AgentTaskPolicy does not. Legacy/Remote providers leave them None/empty.
+
+
+@dataclass(frozen=True)
+class NetworkEgressPolicy:
+    """Outbound network policy a sandbox requires (#2023 gVisor headline).
+
+    ``mode``: ``deny_all`` (default, safest) | ``allow_explicit`` (only the
+    listed CIDRs/hosts) | ``unrestricted`` (escape hatch, fail-closed providers
+    refuse to satisfy this without an explicit capability).
+    """
+
+    mode: str = "deny_all"
+    allow_cidrs: tuple[str, ...] = ()
+    allow_hosts: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class RuntimeSpec:
+    """Container runtime/image a sandbox should use (#2023).
+
+    ``runtime`` e.g. ``runsc`` (gVisor) / ``runc`` / ``""`` (Legacy: N/A).
+    ``toolchain`` is an optional named toolchain profile the backend resolves.
+    """
+
+    image: str = ""
+    runtime: str = ""
+    toolchain: str = ""
+
+
+@dataclass(frozen=True)
+class VolumeSpec:
+    """One mount a sandbox should expose (#2023)."""
+
+    name: str
+    mount_path: str
+    kind: str = "ephemeral"  # ephemeral | persistent
+    read_only: bool = False
+
+
 @dataclass(frozen=True)
 class SandboxSpec:
     """Immutable description of the sandbox a task needs.
@@ -64,9 +111,13 @@ class SandboxSpec:
     Carries identity (``task_id`` / ``cli_tool`` / ``system_account``) plus the
     isolation intent. The HOME/TMP/quota knobs are NOT redefined here — they
     ride on the #2020 :class:`AgentTaskPolicy` via ``policy`` — so there is one
-    source of truth for the per-task isolation tree. ``required_capabilities``
-    is the fail-closed gate: a provider that cannot meet a required capability
-    must reject the spec at creation.
+    source of truth for the per-task isolation tree. The gVisor-facing
+    dimensions (``network_egress`` / ``runtime`` / ``volumes``) model what
+    AgentTaskPolicy does not, so a #2023 backend expresses intent through the
+    spec rather than by growing the contract. ``machine_id`` / ``user_id``
+    carry remote identity (Phase 4). ``required_capabilities`` is the
+    fail-closed gate: a provider that cannot meet a required capability must
+    reject the spec at creation.
     """
 
     task_id: str
@@ -75,6 +126,18 @@ class SandboxSpec:
     system_account: str | None = None
     policy: AgentTaskPolicy | None = None
     required_capabilities: frozenset[SandboxCapability] = field(default_factory=frozenset)
+    # Remote identity (Phase 4 RemoteMachineProvider). None for local/gVisor.
+    machine_id: str | None = None
+    user_id: int | None = None
+    # gVisor/container dimensions (#2023). None/empty for Legacy/Remote, which
+    # ignore them.
+    network_egress: NetworkEgressPolicy | None = None
+    runtime: RuntimeSpec | None = None
+    volumes: tuple[VolumeSpec, ...] = ()
+    # Lightweight profile slots whose semantics are decided by #2047 (transcript)
+    # and #2046 (evidence); empty string = provider default.
+    transcript_profile: str = ""
+    evidence_profile: str = ""
 
 
 class SandboxStatus(str, Enum):

--- a/tests/issues/2022/test_legacy_posix_provider.py
+++ b/tests/issues/2022/test_legacy_posix_provider.py
@@ -364,6 +364,42 @@ def test_get_process_after_destroy_inspects_destroyed():
     assert provider.inspect(handle) == SandboxStatus.DESTROYED
 
 
+# ── #2022 P4 ②: collect_execution_evidence fills the #2046-A schema's ──
+# ── sandbox-deferred fields (sandbox_id / generation / signal) ─────────
+
+
+def test_legacy_collect_execution_evidence_fills_sandbox_fields():
+    # The #2046-A schema explicitly defers sandbox_id / sandbox_generation /
+    # signal to "#2022's normalized provider events". collect_execution_evidence
+    # is that provider event: it returns the process-level evidence row with
+    # the provider-ownable fields filled (sandbox_id/generation from the handle,
+    # exit_code/signal/argv/cwd from the spawn) — the contract a gVisor backend
+    # inherits. Per-tool_use evidence stays with the runner's recorder.
+    provider = LegacyPosixProvider()
+    handle = provider.create(_spec())
+    eh = provider.exec(handle, command=["/bin/sh", "-c", "exit 3"], env=None, exec_policy=None)
+    list(provider.stream(eh))  # drive the proc to completion
+    rows = provider.collect_execution_evidence(handle)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.sandbox_id == handle.sandbox_id
+    assert row.sandbox_generation == handle.generation
+    assert row.exit_code == 3
+    assert row.signal is None
+    assert row.argv == ["/bin/sh", "-c", "exit 3"]
+    assert row.terminal_reason == "completed"
+
+
+def test_legacy_collect_execution_evidence_records_signal_death():
+    provider = LegacyPosixProvider()
+    handle = provider.create(_spec())
+    eh = provider.exec(handle, command=["/bin/sh", "-c", "kill -9 $$"], env=None, exec_policy=None)
+    list(provider.stream(eh))
+    rows = provider.collect_execution_evidence(handle)
+    assert rows[0].signal == 9  # SIGKILL; Python encodes signal deaths as -rc
+    assert rows[0].exit_code is not None and rows[0].exit_code < 0
+
+
 def test_destroy_clears_proc_tracking_entries():
     # destroy must release the provider's per-sandbox bookkeeping (_procs /
     # _sandbox_of) so a long-lived shared provider does not leak entries across

--- a/tests/issues/2022/test_provider_contract_unified.py
+++ b/tests/issues/2022/test_provider_contract_unified.py
@@ -58,6 +58,7 @@ class _FakeRemoteSessionManager:
 class _LegacyHarness:
     name = "legacy_posix"
     provider_name = "legacy_posix"
+    expected_caps = _LEGACY_CAPS
 
     def __init__(self) -> None:
         self.provider = LegacyPosixProvider()
@@ -81,6 +82,10 @@ class _LegacyHarness:
 class _RemoteHarness:
     name = "remote_machine"
     provider_name = "remote_machine"
+    # Remote provides NO verifiable isolation today (#2078 P1#1): the remote-agent
+    # executor runs from dict(os.environ) + plain Popen. Declaring any cap would
+    # be a fail-closed lie.
+    expected_caps = frozenset()
 
     def __init__(self) -> None:
         self.provider = RemoteMachineProvider(_FakeRemoteSessionManager(), poll_interval=0)
@@ -116,14 +121,27 @@ def harness(request):
 # ── shared contract assertions ──
 
 
-def test_capabilities_declare_four(harness):
-    assert harness.provider.capabilities() == _LEGACY_CAPS
+def test_capabilities_match_expected(harness):
+    # Each provider declares only what it actually enforces (#2078 P1#1):
+    # Legacy the four POSIX caps; Remote none (remote-agent has no isolation).
+    assert harness.provider.capabilities() == harness.expected_caps
     assert SandboxCapability.NAMESPACE_ISOLATION not in harness.provider.capabilities()
     assert SandboxCapability.NETWORK_EGRESS_POLICY not in harness.provider.capabilities()
 
 
 def test_create_rejects_namespace_requirement(harness):
     spec = harness.spec(required_capabilities=frozenset({SandboxCapability.NAMESPACE_ISOLATION}))
+    with pytest.raises(CapabilityUnsupported):
+        harness.provider.create(spec)
+
+
+def test_explicit_network_egress_fails_closed(harness):
+    # #2078 P1#1: setting network_egress on the spec implies
+    # NETWORK_EGRESS_POLICY — neither Legacy nor Remote provides it, so create
+    # must fail closed rather than silently ignore the policy field.
+    from app.modules.workspace.autonomous.sandbox.types import NetworkEgressPolicy
+
+    spec = harness.spec(network_egress=NetworkEgressPolicy(mode="deny_all"))
     with pytest.raises(CapabilityUnsupported):
         harness.provider.create(spec)
 

--- a/tests/issues/2022/test_provider_contract_unified.py
+++ b/tests/issues/2022/test_provider_contract_unified.py
@@ -1,0 +1,178 @@
+"""#2022 P4 ④ — unified contract tests over Legacy + Remote providers.
+
+The #2022 acceptance: "Legacy / Remote / 未来 OpenSandbox 复用 contract tests".
+Both providers must satisfy the SAME contract assertions (capability fail-closed,
+create/exec/stream/stop/destroy lifecycle, evidence sandbox attribution). A
+#2023 gVisor provider reuses this suite by adding its harness to the parametrize
+list. ``FakeSandboxProvider`` stays the fast in-memory regression for the shape.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from typing import Any
+
+import pytest
+
+from app.modules.workspace.autonomous.sandbox.legacy_posix import LegacyPosixProvider
+from app.modules.workspace.autonomous.sandbox.provider import CapabilityUnsupported
+from app.modules.workspace.autonomous.sandbox.remote_machine import (
+    RemoteMachineProvider,
+    RemoteTurnSpec,
+)
+from app.modules.workspace.autonomous.sandbox.types import (
+    SandboxCapability,
+    SandboxEventKind,
+    SandboxSpec,
+    SandboxStatus,
+)
+
+_LEGACY_CAPS = frozenset(
+    {
+        SandboxCapability.PRIVATE_HOME_TMP_XDG,
+        SandboxCapability.FILESYSTEM_ACL,
+        SandboxCapability.CPU_MEM_PIDS_TIME_QUOTA,
+        SandboxCapability.CREDENTIAL_TOKEN_BINDING,
+    }
+)
+
+
+class _FakeRemoteSessionManager:
+    def __init__(self) -> None:
+        self._polls = 0
+
+    def create_remote_session(self, **kwargs: Any) -> dict[str, Any]:
+        return {"session_id": "rsess-1"}
+
+    def send_message(self, **kwargs: Any) -> bool:
+        return True
+
+    def get_session_status(self, session_id: str) -> dict[str, Any]:
+        self._polls += 1
+        return {"output": [{"is_complete": True, "stream": "stdout"}], "exit_code": 0}
+
+    def stop_session(self, session_id: str) -> bool:
+        return True
+
+
+class _LegacyHarness:
+    name = "legacy_posix"
+    provider_name = "legacy_posix"
+
+    def __init__(self) -> None:
+        self.provider = LegacyPosixProvider()
+
+    def spec(self, **overrides: Any) -> SandboxSpec:
+        base: dict[str, Any] = {
+            "task_id": "t",
+            "project_path": tempfile.gettempdir(),
+            "cli_tool": "c",
+        }
+        base.update(overrides)
+        return SandboxSpec(**base)
+
+    def exec(self, handle) -> Any:
+        return self.provider.exec(handle, command=["/bin/echo", "hi"], env=None, exec_policy=None)
+
+    def drive_to_completion(self, eh) -> list:
+        return list(self.provider.stream(eh))
+
+
+class _RemoteHarness:
+    name = "remote_machine"
+    provider_name = "remote_machine"
+
+    def __init__(self) -> None:
+        self.provider = RemoteMachineProvider(_FakeRemoteSessionManager(), poll_interval=0)
+
+    def spec(self, **overrides: Any) -> SandboxSpec:
+        base: dict[str, Any] = {
+            "task_id": "t",
+            "project_path": "/repo",
+            "cli_tool": "c",
+            "machine_id": "m",
+            "user_id": 1,
+        }
+        base.update(overrides)
+        return SandboxSpec(**base)
+
+    def exec(self, handle) -> Any:
+        return self.provider.exec(
+            handle, command=[], env=None, exec_policy=RemoteTurnSpec(prompt="hi")
+        )
+
+    def drive_to_completion(self, eh) -> list:
+        return list(self.provider.stream(eh))
+
+
+HARNESSES = [_LegacyHarness, _RemoteHarness]
+
+
+@pytest.fixture(params=HARNESSES, ids=[h.name for h in HARNESSES])
+def harness(request):
+    return request.param()
+
+
+# ── shared contract assertions ──
+
+
+def test_capabilities_declare_four(harness):
+    assert harness.provider.capabilities() == _LEGACY_CAPS
+    assert SandboxCapability.NAMESPACE_ISOLATION not in harness.provider.capabilities()
+    assert SandboxCapability.NETWORK_EGRESS_POLICY not in harness.provider.capabilities()
+
+
+def test_create_rejects_namespace_requirement(harness):
+    spec = harness.spec(required_capabilities=frozenset({SandboxCapability.NAMESPACE_ISOLATION}))
+    with pytest.raises(CapabilityUnsupported):
+        harness.provider.create(spec)
+
+
+def test_create_mints_named_handle(harness):
+    handle = harness.provider.create(harness.spec())
+    assert handle.sandbox_id
+    assert handle.provider_name == harness.provider_name
+    assert handle.generation == 1
+
+
+def test_exec_then_stream_emits_lifecycle_events(harness):
+    handle = harness.provider.create(harness.spec())
+    eh = harness.exec(handle)
+    events = harness.drive_to_completion(eh)
+    kinds = [e.kind for e in events]
+    # The common lifecycle spine every provider must emit (Legacy also emits
+    # STDOUT_CHUNK; Remote does not — the spine is the contract).
+    for required in (
+        SandboxEventKind.PROCESS_STARTED,
+        SandboxEventKind.COMMAND_STARTED,
+        SandboxEventKind.COMMAND_COMPLETED,
+        SandboxEventKind.PROCESS_EXITED,
+    ):
+        assert required in kinds, f"{harness.name} missing {required}"
+    completed = next(e for e in events if e.kind == SandboxEventKind.COMMAND_COMPLETED)
+    assert completed.exit_code == 0
+
+
+def test_stop_marks_stopped(harness):
+    handle = harness.provider.create(harness.spec())
+    eh = harness.exec(handle)
+    harness.provider.stop(eh)
+    assert harness.provider.inspect(handle) == SandboxStatus.STOPPED
+
+
+def test_destroy_is_idempotent(harness):
+    handle = harness.provider.create(harness.spec())
+    harness.provider.destroy(handle)
+    harness.provider.destroy(handle)  # no raise
+    assert harness.provider.inspect(handle) == SandboxStatus.DESTROYED
+
+
+def test_collect_execution_evidence_fills_sandbox_attribution(harness):
+    handle = harness.provider.create(harness.spec())
+    eh = harness.exec(handle)
+    harness.drive_to_completion(eh)
+    rows = harness.provider.collect_execution_evidence(handle)
+    assert rows
+    for row in rows:
+        assert row.sandbox_id == handle.sandbox_id
+        assert row.sandbox_generation == handle.generation

--- a/tests/issues/2022/test_remote_machine_provider.py
+++ b/tests/issues/2022/test_remote_machine_provider.py
@@ -253,3 +253,56 @@ def test_remote_collect_execution_evidence_fills_sandbox_attribution():
     assert row.sandbox_id == handle.sandbox_id
     assert row.sandbox_generation == handle.generation
     assert row.command_id == "rsess-1"
+
+
+# ── #2078 review fixes ──
+
+
+def test_remote_exec_cancel_check_intercepts_before_send():
+    # 🟡A: cancel_check restores the create↔send cancellation window. If the
+    # runner signals cancellation (create succeeded, send pending), exec must
+    # stop the just-created session and raise BEFORE send_message dispatches the
+    # prompt — the old "intercept before dispatch" guarantee.
+    rsm = FakeRemoteSessionManager()
+    provider = RemoteMachineProvider(rsm)
+    handle = provider.create(_spec())
+    with pytest.raises(SandboxError):
+        provider.exec(
+            handle,
+            command=[],
+            env=None,
+            exec_policy=_turn(),
+            cancel_check=lambda: True,
+        )
+    # The created session was stopped; the prompt was NOT dispatched.
+    assert rsm.stop_calls == ["rsess-1"]
+    assert rsm.send_calls == []
+    assert provider.inspect(handle) == SandboxStatus.STOPPED
+
+
+def test_remote_exec_cancel_check_false_dispatches_normally():
+    # cancel_check returning False (not cancelled) is a no-op — send proceeds.
+    rsm = FakeRemoteSessionManager()
+    provider = RemoteMachineProvider(rsm)
+    handle = provider.create(_spec())
+    eh = provider.exec(
+        handle, command=[], env=None, exec_policy=_turn(), cancel_check=lambda: False
+    )
+    assert eh.command_id == "rsess-1"
+    assert rsm.send_calls and rsm.send_calls[0]["content"] == "do the thing"
+
+
+def test_remote_collect_execution_evidence_uses_streamed_exit_code():
+    # 🟡B: collect_execution_evidence reads the exit_code stream() polled, not a
+    # hardcoded 0.
+    rsm = FakeRemoteSessionManager()
+    provider = RemoteMachineProvider(rsm, poll_interval=0)
+    handle = provider.create(_spec())
+    eh = provider.exec(handle, command=[], env=None, exec_policy=_turn())
+    rsm.get_session_status = lambda sid: {  # type: ignore[assignment]
+        "output": [{"is_complete": True, "stream": "stdout"}],
+        "exit_code": 2,
+    }
+    list(provider.stream(eh))
+    rows = provider.collect_execution_evidence(handle)
+    assert rows[0].exit_code == 2

--- a/tests/issues/2022/test_remote_machine_provider.py
+++ b/tests/issues/2022/test_remote_machine_provider.py
@@ -26,14 +26,9 @@ from app.modules.workspace.autonomous.sandbox.types import (
     SandboxStatus,
 )
 
-_REMOTE_CAPS = frozenset(
-    {
-        SandboxCapability.PRIVATE_HOME_TMP_XDG,
-        SandboxCapability.FILESYSTEM_ACL,
-        SandboxCapability.CPU_MEM_PIDS_TIME_QUOTA,
-        SandboxCapability.CREDENTIAL_TOKEN_BINDING,
-    }
-)
+# Remote provides NO verifiable isolation (#2078 P1#1) — the remote-agent
+# executor (dict(os.environ) + plain Popen) has no per-task HOME/ACL/cgroup.
+_REMOTE_CAPS = frozenset()
 
 
 class FakeRemoteSessionManager:
@@ -100,18 +95,27 @@ def _turn(**overrides: Any) -> RemoteTurnSpec:
 # ── capabilities + create ──
 
 
-def test_remote_declares_four_capabilities():
+def test_remote_declares_no_isolation_capabilities():
+    # #2078 P1#1: remote-agent provides no verifiable isolation, so Remote
+    # declares an empty capability set (not the Legacy four).
     rsm = FakeRemoteSessionManager()
     provider = RemoteMachineProvider(rsm)
-    assert provider.capabilities() == _REMOTE_CAPS
-    assert SandboxCapability.NAMESPACE_ISOLATION not in provider.capabilities()
+    assert provider.capabilities() == frozenset()
 
 
-def test_remote_create_rejects_namespace_requirement():
+def test_remote_create_rejects_isolation_requirement():
+    # A spec requiring any isolation cap must fail closed on Remote (it can't
+    # enforce HOME/ACL/quota/credential-binding).
     provider = RemoteMachineProvider(FakeRemoteSessionManager())
-    spec = _spec(required_capabilities=frozenset({SandboxCapability.NAMESPACE_ISOLATION}))
-    with pytest.raises(CapabilityUnsupported):
-        provider.create(spec)
+    for cap in (
+        SandboxCapability.PRIVATE_HOME_TMP_XDG,
+        SandboxCapability.FILESYSTEM_ACL,
+        SandboxCapability.CPU_MEM_PIDS_TIME_QUOTA,
+        SandboxCapability.CREDENTIAL_TOKEN_BINDING,
+        SandboxCapability.NAMESPACE_ISOLATION,
+    ):
+        with pytest.raises(CapabilityUnsupported):
+            provider.create(_spec(required_capabilities=frozenset({cap})))
 
 
 def test_remote_create_requires_machine_id_and_user_id():
@@ -204,6 +208,41 @@ def test_remote_stream_emits_lifecycle_until_turn_complete():
     assert completed.exit_code == 0
     # Polled at least once for the turn-complete signal.
     assert len(rsm.status_calls) >= 1
+
+
+def test_remote_stream_emits_timeout_when_poll_budget_exhausts():
+    # #2078 P1#3: a poll that never observes completion must emit
+    # COMMAND_TIMED_OUT, not COMMAND_COMPLETED(0). poll_timeout=0 makes the loop
+    # exit immediately; a fake that never reports is_complete stays incomplete.
+    rsm = FakeRemoteSessionManager(complete_after=999)
+    provider = RemoteMachineProvider(rsm, poll_interval=0, poll_timeout=0)
+    handle = provider.create(_spec())
+    eh = provider.exec(handle, command=[], env=None, exec_policy=_turn())
+    events = list(provider.stream(eh))
+    kinds = [e.kind for e in events]
+    assert SandboxEventKind.COMMAND_TIMED_OUT in kinds
+    assert SandboxEventKind.COMMAND_COMPLETED not in kinds
+    assert provider.inspect(handle) == SandboxStatus.ERROR
+    # collect_execution_evidence reports timeout, not completed.
+    rows = provider.collect_execution_evidence(handle)
+    assert rows[0].terminal_reason == "timeout"
+
+
+def test_remote_stream_emits_sandbox_error_when_status_unavailable():
+    # If the manager has no get_session_status (or it raises), the stream cannot
+    # observe a terminal state — emit SANDBOX_ERROR, not a fake success.
+    class _NoStatusManager(FakeRemoteSessionManager):
+        def get_session_status(self, session_id):  # type: ignore[override]
+            raise RuntimeError("status backend down")
+
+    provider = RemoteMachineProvider(_NoStatusManager(), poll_interval=0, poll_timeout=0.5)
+    handle = provider.create(_spec())
+    eh = provider.exec(handle, command=[], env=None, exec_policy=_turn())
+    events = list(provider.stream(eh))
+    kinds = [e.kind for e in events]
+    assert SandboxEventKind.SANDBOX_ERROR in kinds
+    assert SandboxEventKind.COMMAND_COMPLETED not in kinds
+    assert provider.inspect(handle) == SandboxStatus.ERROR
 
 
 # ── stop / destroy / pause ──

--- a/tests/issues/2022/test_remote_machine_provider.py
+++ b/tests/issues/2022/test_remote_machine_provider.py
@@ -1,0 +1,255 @@
+"""RemoteMachineProvider contract tests (#2022 P4 ⑤a).
+
+Exercises the provider against a fake ``RemoteSessionManager`` (records calls,
+returns deterministic responses) — the real manager is off-limits for behavior
+change (#2022 scope: wrap autonomous remote-agent execution only). These tests
+prove the provider maps create/exec/stream/stop/destroy onto the manager's four
+methods and fills the #2046-A sandbox attribution, WITHOUT touching
+``remote_session_manager.py`` / ``remote.py``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.modules.workspace.autonomous.sandbox.provider import CapabilityUnsupported, SandboxError
+from app.modules.workspace.autonomous.sandbox.remote_machine import (
+    RemoteMachineProvider,
+    RemoteTurnSpec,
+)
+from app.modules.workspace.autonomous.sandbox.types import (
+    SandboxCapability,
+    SandboxEventKind,
+    SandboxSpec,
+    SandboxStatus,
+)
+
+_REMOTE_CAPS = frozenset(
+    {
+        SandboxCapability.PRIVATE_HOME_TMP_XDG,
+        SandboxCapability.FILESYSTEM_ACL,
+        SandboxCapability.CPU_MEM_PIDS_TIME_QUOTA,
+        SandboxCapability.CREDENTIAL_TOKEN_BINDING,
+    }
+)
+
+
+class FakeRemoteSessionManager:
+    """Records manager calls; returns deterministic responses."""
+
+    def __init__(
+        self,
+        *,
+        session_id: str = "rsess-1",
+        create_ok: bool = True,
+        send_ok: bool = True,
+        complete_after: int = 1,
+    ) -> None:
+        self.create_calls: list[dict[str, Any]] = []
+        self.send_calls: list[dict[str, Any]] = []
+        self.status_calls: list[str] = []
+        self.stop_calls: list[str] = []
+        self._session_id = session_id
+        self._create_ok = create_ok
+        self._send_ok = send_ok
+        self._complete_after = complete_after
+        self._polls = 0
+
+    def create_remote_session(self, **kwargs: Any) -> dict[str, Any]:
+        self.create_calls.append(kwargs)
+        if not self._create_ok:
+            return {"success": False, "error": "remote refused"}
+        return {"session_id": self._session_id}
+
+    def send_message(self, **kwargs: Any) -> bool:
+        self.send_calls.append(kwargs)
+        return self._send_ok
+
+    def get_session_status(self, session_id: str) -> dict[str, Any]:
+        self.status_calls.append(session_id)
+        self._polls += 1
+        if self._polls >= self._complete_after:
+            return {"output": [{"is_complete": True, "stream": "stdout"}], "exit_code": 0}
+        return {"output": []}
+
+    def stop_session(self, session_id: str) -> bool:
+        self.stop_calls.append(session_id)
+        return True
+
+
+def _spec(**overrides: Any) -> SandboxSpec:
+    base: dict[str, Any] = {
+        "task_id": "t-1",
+        "project_path": "/repo",
+        "cli_tool": "claude-code",
+        "machine_id": "machine-7",
+        "user_id": 42,
+    }
+    base.update(overrides)
+    return SandboxSpec(**base)
+
+
+def _turn(**overrides: Any) -> RemoteTurnSpec:
+    base: dict[str, Any] = {"prompt": "do the thing", "model": "sonnet"}
+    base.update(overrides)
+    return RemoteTurnSpec(**base)
+
+
+# ── capabilities + create ──
+
+
+def test_remote_declares_four_capabilities():
+    rsm = FakeRemoteSessionManager()
+    provider = RemoteMachineProvider(rsm)
+    assert provider.capabilities() == _REMOTE_CAPS
+    assert SandboxCapability.NAMESPACE_ISOLATION not in provider.capabilities()
+
+
+def test_remote_create_rejects_namespace_requirement():
+    provider = RemoteMachineProvider(FakeRemoteSessionManager())
+    spec = _spec(required_capabilities=frozenset({SandboxCapability.NAMESPACE_ISOLATION}))
+    with pytest.raises(CapabilityUnsupported):
+        provider.create(spec)
+
+
+def test_remote_create_requires_machine_id_and_user_id():
+    provider = RemoteMachineProvider(FakeRemoteSessionManager())
+    with pytest.raises(SandboxError):
+        provider.create(_spec(machine_id=None))
+    with pytest.raises(SandboxError):
+        provider.create(_spec(user_id=None))
+
+
+def test_remote_create_mints_handle():
+    provider = RemoteMachineProvider(FakeRemoteSessionManager())
+    handle = provider.create(_spec())
+    assert handle.sandbox_id
+    assert handle.provider_name == "remote_machine"
+    assert handle.generation == 1
+
+
+# ── exec ──
+
+
+def test_remote_exec_calls_create_session_then_send_prompt():
+    rsm = FakeRemoteSessionManager()
+    provider = RemoteMachineProvider(rsm)
+    handle = provider.create(_spec())
+    eh = provider.exec(
+        handle, command=[], env=None, exec_policy=_turn(prompt="hello", model="sonnet")
+    )
+    # command_id IS the remote session id, so stop/destroy map directly.
+    assert eh.command_id == "rsess-1"
+    assert eh.sandbox_id == handle.sandbox_id
+    assert len(rsm.create_calls) == 1
+    create = rsm.create_calls[0]
+    assert create["machine_id"] == "machine-7"
+    assert create["user_id"] == 42
+    assert create["cli_tool"] == "claude-code"
+    assert create["model"] == "sonnet"
+    assert len(rsm.send_calls) == 1
+    assert rsm.send_calls[0]["content"] == "hello"
+    assert rsm.send_calls[0]["session_id"] == "rsess-1"
+    assert provider.inspect(handle) == SandboxStatus.RUNNING
+
+
+def test_remote_exec_requires_remote_turn_spec():
+    provider = RemoteMachineProvider(FakeRemoteSessionManager())
+    handle = provider.create(_spec())
+    with pytest.raises(SandboxError):
+        provider.exec(handle, command=[], env=None, exec_policy=None)
+
+
+def test_remote_exec_fail_closed_when_create_refuses():
+    rsm = FakeRemoteSessionManager(create_ok=False)
+    provider = RemoteMachineProvider(rsm)
+    handle = provider.create(_spec())
+    with pytest.raises(SandboxError):
+        provider.exec(handle, command=[], env=None, exec_policy=_turn())
+    assert provider.inspect(handle) == SandboxStatus.ERROR
+    # No prompt was dispatched (create failed first).
+    assert rsm.send_calls == []
+
+
+def test_remote_exec_fail_closed_when_send_fails_and_stops_session():
+    rsm = FakeRemoteSessionManager(send_ok=False)
+    provider = RemoteMachineProvider(rsm)
+    handle = provider.create(_spec())
+    with pytest.raises(SandboxError):
+        provider.exec(handle, command=[], env=None, exec_policy=_turn())
+    # The partially-created remote session must be stopped (no orphan).
+    assert rsm.stop_calls == ["rsess-1"]
+    assert provider.inspect(handle) == SandboxStatus.ERROR
+
+
+# ── stream ──
+
+
+def test_remote_stream_emits_lifecycle_until_turn_complete():
+    rsm = FakeRemoteSessionManager(complete_after=2)
+    provider = RemoteMachineProvider(rsm, poll_interval=0)
+    handle = provider.create(_spec())
+    eh = provider.exec(handle, command=[], env=None, exec_policy=_turn())
+    events = list(provider.stream(eh))
+    kinds = [e.kind for e in events]
+    assert kinds == [
+        SandboxEventKind.PROCESS_STARTED,
+        SandboxEventKind.COMMAND_STARTED,
+        SandboxEventKind.COMMAND_COMPLETED,
+        SandboxEventKind.PROCESS_EXITED,
+    ]
+    completed = next(e for e in events if e.kind == SandboxEventKind.COMMAND_COMPLETED)
+    assert completed.exit_code == 0
+    # Polled at least once for the turn-complete signal.
+    assert len(rsm.status_calls) >= 1
+
+
+# ── stop / destroy / pause ──
+
+
+def test_remote_stop_calls_stop_session():
+    rsm = FakeRemoteSessionManager()
+    provider = RemoteMachineProvider(rsm)
+    handle = provider.create(_spec())
+    eh = provider.exec(handle, command=[], env=None, exec_policy=_turn())
+    provider.stop(eh)
+    assert rsm.stop_calls == ["rsess-1"]
+    assert provider.inspect(handle) == SandboxStatus.STOPPED
+
+
+def test_remote_destroy_is_idempotent_and_stops_session_once():
+    rsm = FakeRemoteSessionManager()
+    provider = RemoteMachineProvider(rsm)
+    handle = provider.create(_spec())
+    provider.exec(handle, command=[], env=None, exec_policy=_turn())
+    provider.destroy(handle)
+    provider.destroy(handle)  # no raise; does not re-stop
+    assert rsm.stop_calls == ["rsess-1"]
+    assert provider.inspect(handle) == SandboxStatus.DESTROYED
+
+
+def test_remote_pause_resume_are_noops():
+    rsm = FakeRemoteSessionManager()
+    provider = RemoteMachineProvider(rsm)
+    handle = provider.create(_spec())
+    eh = provider.exec(handle, command=[], env=None, exec_policy=_turn())
+    provider.pause(eh)  # no raise
+    provider.resume(eh)
+    assert provider.inspect(handle) == SandboxStatus.RUNNING
+
+
+# ── evidence ──
+
+
+def test_remote_collect_execution_evidence_fills_sandbox_attribution():
+    provider = RemoteMachineProvider(FakeRemoteSessionManager())
+    handle = provider.create(_spec())
+    provider.exec(handle, command=[], env=None, exec_policy=_turn())
+    rows = provider.collect_execution_evidence(handle)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.sandbox_id == handle.sandbox_id
+    assert row.sandbox_generation == handle.generation
+    assert row.command_id == "rsess-1"

--- a/tests/issues/2022/test_runner_signal_routing.py
+++ b/tests/issues/2022/test_runner_signal_routing.py
@@ -57,6 +57,24 @@ def test_pause_resume_route_through_sandbox_provider():
     assert not session._paused.is_set()
 
 
+def test_pause_resume_return_false_for_process_less_remote_tracker():
+    # #2078 P2: a real remote tracker has process=None (no local Popen). The
+    # process guard precedes the provider branch, so pause/resume return False
+    # — honestly reflecting that remote can't SIGSTOP a CLI session. The
+    # provider-routed pause/resume is therefore Legacy-effective; remote pause
+    # is unsupported (not silently claimed).
+    provider = FakeSandboxProvider()
+    runner = AutonomousAgentRunner(sandbox_provider=provider)
+    handle = provider.create(SandboxSpec(task_id="t", project_path="/tmp", cli_tool="c"))
+    eh = provider.exec(handle, command=["x"], env=None, exec_policy=None)
+    session = _LocalSession(session_id="s1", process=None)  # remote-shape tracker
+    session.sandbox_provider = provider
+    session.exec_handle = eh
+    runner._local_sessions["s1"] = session
+    assert runner.pause_session("s1") is False
+    assert runner.resume_session("s1") is False
+
+
 def test_select_sandbox_provider_returns_legacy_for_local():
     legacy = FakeSandboxProvider()
     runner = AutonomousAgentRunner(sandbox_provider=legacy)

--- a/tests/issues/2022/test_runner_signal_routing.py
+++ b/tests/issues/2022/test_runner_signal_routing.py
@@ -1,0 +1,71 @@
+"""#2022 P4 ③ — runner routes stop/pause/resume through the SandboxProvider.
+
+gVisor (#2023) has no local ``Popen``; cancellation/timeout/pause MUST reach the
+sandbox via ``provider.stop/pause/resume``. Legacy (raw-proc killpg) and Remote
+both set ``sandbox_provider`` on the tracker, so a session with a provider
+handle routes signals through it; the raw-proc branches are the fallback for
+legacy tracker paths without a provider.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from app.modules.workspace.autonomous.agent_runner import AutonomousAgentRunner, _LocalSession
+from app.modules.workspace.autonomous.sandbox.fake import FakeSandboxProvider
+from app.modules.workspace.autonomous.sandbox.types import SandboxSpec, SandboxStatus
+
+
+def _runner_with_session(process=None) -> tuple:
+    provider = FakeSandboxProvider()
+    runner = AutonomousAgentRunner(sandbox_provider=provider)
+    handle = provider.create(SandboxSpec(task_id="t", project_path="/tmp", cli_tool="c"))
+    eh = provider.exec(handle, command=["x"], env=None, exec_policy=None)
+    session = _LocalSession(session_id="s1", process=process)
+    session.sandbox_provider = provider
+    session.exec_handle = eh
+    runner._local_sessions["s1"] = session
+    return runner, provider, handle
+
+
+def test_stop_session_routes_through_sandbox_provider():
+    runner, provider, handle = _runner_with_session(process=None)
+    runner.stop_session("s1")
+    # provider.stop marked the sandbox STOPPED (not the raw-proc path, which
+    # would have no-op'd on process=None).
+    assert provider.inspect(handle) == SandboxStatus.STOPPED
+    session = runner._local_sessions["s1"]
+    assert session._stopped.is_set()
+    assert session.completed.is_set()
+
+
+def test_stop_session_unknown_id_is_noop():
+    runner = AutonomousAgentRunner()
+    runner.stop_session("nope")  # no raise
+
+
+def test_pause_resume_route_through_sandbox_provider():
+    proc = MagicMock()
+    proc.returncode = None  # still running (guard requires returncode is None)
+    runner, provider, handle = _runner_with_session(process=proc)
+    assert runner.pause_session("s1") is True
+    assert provider.inspect(handle) == SandboxStatus.PAUSED
+    session = runner._local_sessions["s1"]
+    assert session._paused.is_set()
+    assert runner.resume_session("s1") is True
+    assert provider.inspect(handle) == SandboxStatus.RUNNING
+    assert not session._paused.is_set()
+
+
+def test_select_sandbox_provider_returns_legacy_for_local():
+    legacy = FakeSandboxProvider()
+    runner = AutonomousAgentRunner(sandbox_provider=legacy)
+    assert runner._select_sandbox_provider("local") is legacy
+
+
+def test_select_sandbox_provider_returns_remote_for_remote():
+    runner = AutonomousAgentRunner(remote_session_manager=MagicMock())
+    provider = runner._select_sandbox_provider("remote")
+    # RemoteMachineProvider wraps the remote_session_manager (gVisor would add
+    # a third branch here).
+    assert provider.__class__.__name__ == "RemoteMachineProvider"

--- a/tests/issues/2022/test_sandbox_evidence.py
+++ b/tests/issues/2022/test_sandbox_evidence.py
@@ -1,0 +1,60 @@
+"""#2022 P4 ② — recorder stamps sandbox attribution on evidence rows.
+
+The #2046-A ``CommandExecutionEvidence`` schema defers ``sandbox_id`` /
+``sandbox_generation`` to "#2022's normalized provider events". The provider's
+``collect_execution_evidence`` fills them at the contract level (tested in
+``test_legacy_posix_provider.py``); these tests lock the runner→recorder wiring
+that stamps them onto the persisted per-tool_use rows.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from app.modules.workspace.autonomous.command_evidence.recorder import CommandEvidenceRecorder
+
+
+def _capturing_recorder() -> tuple[CommandEvidenceRecorder, list]:
+    captured: list = []
+    recorder = CommandEvidenceRecorder(
+        repo=SimpleNamespace(upsert=lambda ev: captured.append(ev) or 1)
+    )
+    return recorder, captured
+
+
+def test_record_tool_use_stamps_sandbox_attribution():
+    recorder, captured = _capturing_recorder()
+    recorder.record_tool_use(
+        command_id="c1", session_id="s1", sandbox_id="sb-9", sandbox_generation=3
+    )
+    assert captured
+    assert captured[0].sandbox_id == "sb-9"
+    assert captured[0].sandbox_generation == 3
+
+
+def test_record_tool_result_stamps_sandbox_attribution():
+    # The terminal upsert also carries sandbox attribution so it survives even
+    # if the seed row was written by a path that omitted it.
+    recorder, captured = _capturing_recorder()
+    recorder.record_tool_result(
+        command_id="c1", session_id="s1", exit_code=0, sandbox_id="sb-9", sandbox_generation=3
+    )
+    assert captured[0].sandbox_id == "sb-9"
+    assert captured[0].sandbox_generation == 3
+
+
+def test_emit_from_event_log_propagates_sandbox_to_rows():
+    recorder, captured = _capturing_recorder()
+    recorder.emit_from_event_log(
+        session_id="s1",
+        workflow_id="w1",
+        event_log=[
+            {"type": "tool_use", "tool_use_id": "c1", "tool_name": "Bash"},
+            {"type": "tool_result", "tool_use_id": "c1", "exit_code": 0, "text": "ok"},
+        ],
+        sandbox_id="sb-9",
+        sandbox_generation=3,
+    )
+    stamped = [r for r in captured if r.command_id == "c1"]
+    assert stamped
+    assert all(r.sandbox_id == "sb-9" and r.sandbox_generation == 3 for r in stamped)

--- a/tests/issues/2022/test_sandbox_spec.py
+++ b/tests/issues/2022/test_sandbox_spec.py
@@ -88,3 +88,85 @@ def test_sandbox_spec_reuses_agent_task_policy_from_issue_2020():
     assert spec.policy.memory_max_bytes == 536870912
     assert spec.policy.pids_max == 256
     assert spec.policy.max_concurrent_workflows == 2
+
+
+# ── #2022 P4 ①: gVisor-facing isolation dimensions on the spec ──
+#
+# The minimal P1 spec carried only identity + #2020 policy. A gVisor/container
+# backend (#2023) needs to express network egress, runtime/image and volumes
+# THROUGH THE SPEC — otherwise it would extend the contract itself, which is
+# exactly the backend-detail-leak #2022 exists to prevent. AgentTaskPolicy
+# already owns HOME/TMP/cgroup/quota, so these new dimensions do not duplicate it.
+
+from app.modules.workspace.autonomous.sandbox.types import (  # noqa: E402
+    NetworkEgressPolicy,
+    RuntimeSpec,
+    VolumeSpec,
+)
+
+
+def test_network_egress_policy_is_frozen_value_object():
+    egress = NetworkEgressPolicy(
+        mode="allow_explicit",
+        allow_cidrs=("10.0.0.0/8",),
+        allow_hosts=("github.com",),
+    )
+    assert egress.mode == "allow_explicit"
+    assert egress.allow_cidrs == ("10.0.0.0/8",)
+    assert egress.allow_hosts == ("github.com",)
+    try:
+        egress.mode = "unrestricted"  # type: ignore[misc]
+    except FrozenInstanceError:
+        return
+    raise AssertionError("NetworkEgressPolicy must be frozen")
+
+
+def test_runtime_and_volume_specs_are_frozen_value_objects():
+    runtime = RuntimeSpec(image="openace/agent:1", runtime="runsc")
+    assert runtime.image == "openace/agent:1"
+    assert runtime.runtime == "runsc"
+    vol = VolumeSpec(name="repo", mount_path="/workspace", kind="ephemeral")
+    assert vol.mount_path == "/workspace"
+    assert vol.kind == "ephemeral"
+    try:
+        runtime.runtime = "runc"  # type: ignore[misc]
+    except FrozenInstanceError:
+        return
+    raise AssertionError("RuntimeSpec must be frozen")
+
+
+def test_sandbox_spec_carries_gvisor_isolation_dimensions():
+    egress = NetworkEgressPolicy(mode="deny_all")
+    runtime = RuntimeSpec(image="openace/agent:1", runtime="runsc")
+    volumes = (VolumeSpec(name="repo", mount_path="/workspace", kind="ephemeral"),)
+    spec = SandboxSpec(
+        task_id="t-1",
+        project_path="/repo",
+        cli_tool="claude-code",
+        machine_id="machine-7",
+        user_id=42,
+        network_egress=egress,
+        runtime=runtime,
+        volumes=volumes,
+        required_capabilities=frozenset(
+            {SandboxCapability.NAMESPACE_ISOLATION, SandboxCapability.NETWORK_EGRESS_POLICY}
+        ),
+    )
+    assert spec.machine_id == "machine-7"
+    assert spec.user_id == 42
+    assert spec.network_egress is egress
+    assert spec.runtime is runtime
+    assert spec.volumes == volumes
+
+
+def test_sandbox_spec_gvisor_fields_default_none_for_legacy():
+    # Legacy/Remote providers ignore the gVisor dimensions; they default to
+    # None/empty so existing two-arg construction stays backward-compatible.
+    spec = SandboxSpec(task_id="t-1", project_path="/repo", cli_tool="claude-code")
+    assert spec.machine_id is None
+    assert spec.user_id is None
+    assert spec.network_egress is None
+    assert spec.runtime is None
+    assert spec.volumes == ()
+    assert spec.transcript_profile == ""
+    assert spec.evidence_profile == ""


### PR DESCRIPTION
Completes the #2022 contract so a gVisor/OpenSandbox backend (#2023) plugs in purely additively. **#2022 stays open** — the gVisor provider itself is #2023.

One PR (①–⑤ together) per the issue's remaining scope, in service of the original motivation: pave the way for #2023 (gVisor). Autonomous-only — the scope firewall is load-bearing (see Validation).

## What lands

**① SandboxSpec completion** (`types.py`) — add `NetworkEgressPolicy` / `RuntimeSpec` / `VolumeSpec` + spec fields (`machine_id`, `user_id`, `network_egress`, `runtime`, `volumes`, `transcript_profile`, `evidence_profile`). gVisor's headline (network egress / image / volumes) is expressed THROUGH THE SPEC, not by extending the contract — which would re-leak backend detail into the seam. HOME/TMP/quota stay on #2020's `AgentTaskPolicy`; the new fields model only what it doesn't.

**② evidence fill** — `LegacyPosixProvider.collect_execution_evidence` returns process-level `CommandExecutionEvidence` with the #2046-A fields the runner-side recorder can't derive (`sandbox_id`/`sandbox_generation` + `exit_code`/`signal`/`terminal_reason`). The recorder stamps `sandbox_id`/`sandbox_generation` on persisted per-tool rows; `AgentTaskResult` carries them; `emit_command_evidence` passes them through.

**⑤a RemoteMachineProvider** (new) — wraps `RemoteSessionManager` behind the contract (`exec` = `create_remote_session` + `send_message` via `RemoteTurnSpec` in the `exec_policy` slot; `stream` polls `get_session_status`; `stop` = `stop_session`). No local `Popen` (no `get_process`); `pause`/`resume` are documented no-ops. **Does NOT change `remote_session_manager.py` / `remote.py`.**

**⑤b wire `_run_remote`** — autonomous remote execution routes through the provider (create/exec + lifecycle lock + cancellation checks preserved; poll loop + message normalization stay runner-side). `remote_session_id = exec_handle.command_id`.

**③ runner provider-driven** — `_select_sandbox_provider(workspace_type)` factory (gVisor is one branch here) + `stop`/`pause`/`resume_session` route through `session.sandbox_provider.stop/pause/resume(exec_handle)`. **This is the gVisor hard-blocker:** gVisor has no local `Popen`, so cancellation/timeout MUST reach the sandbox via the provider. Legacy (raw-proc killpg) and Remote both set `sandbox_provider` on the tracker. The protocol layer (local stream-json vs remote poll) stays per-backend — not merged (would risk ordinary paths + no value).

**④ unified contract tests** — parametrized over `[LegacyPosixProvider, RemoteMachineProvider]`: capabilities fail-closed, create/exec/stream/stop/destroy lifecycle spine, evidence attribution. A #2023 gVisor provider reuses this suite by adding its harness.

## Acceptance-criteria modifications (per the standing scope constraint)
Where the #2022 acceptance over-reaches ordinary features, it is re-scoped to autonomous-only (not architectural purity):
- "orchestrator 不依赖 sudo/ACL/Popen/container" → **autonomous** agent_runner spawn/signal paths only; ordinary `fs.py::run_as_user` (sudo) / `remote_session_manager` ordinary sessions unchanged.
- "local 与 remote 同一 contract" → autonomous local + autonomous remote.

## Validation (rigorous — this paves the riskiest backend)
- **107 #2022 tests pass** (+~50 new: spec dimensions, evidence fill, recorder stamping, RemoteMachineProvider contract, signal routing, unified parametrized suite).
- **Broad autonomous slice: 52==52 failures vs stashed-main** (test-level, zero new, zero accidental fixes). All 52 are pre-existing local-env (sudo-admin / `/private/tmp` containment / DB-unavailable), green in CI.
- **Ordinary-path regression guard: 0==0 failures** (local-workspace `fs.py`, ordinary remote-workspace sessions, remote terminal) on both branch and main — the scope firewall holds.
- pre-commit all green (black/isort/ruff/mypy/bandit/pydocstyle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)