### PR TITLE
fix(usage): add NULL user_id fallback for tenant filtering (#2077)

### DIFF
--- a/app/repositories/usage_repo.py
+++ b/app/repositories/usage_repo.py
@@ -974,8 +974,18 @@ class UsageRepository:
         normalized_tenant_id = self._normalize_tenant_id(tenant_id)
 
         if normalized_tenant_id is not None:
-            conditions.append(self._tenant_user_condition("dm.user_id"))
-            params.append(normalized_tenant_id)
+            # Issue #2077: Add NULL user_id fallback via sender_name matching.
+            # When user_id is NULL (e.g., from save_messages_batch which doesn't write user_id),
+            # fall back to matching sender_name against the tenant's users' system_account.
+            # sender_name format: {system_account}-{hostname}-{tool}
+            conditions.append(
+                f"({self._tenant_user_condition('dm.user_id')} "
+                f"OR (dm.user_id IS NULL AND EXISTS ("
+                f"SELECT 1 FROM users u WHERE u.tenant_id = ? "
+                f"AND (dm.sender_name LIKE (u.system_account || '-%%') "
+                f"OR dm.sender_name = u.username))))"
+            )
+            params.extend([normalized_tenant_id, normalized_tenant_id])
 
         if host_name:
             conditions.append("dm.host_name = ?")

--- a/tests/integration/test_usage_repo_tenant_scope.py
+++ b/tests/integration/test_usage_repo_tenant_scope.py
@@ -189,7 +189,16 @@ def test_get_request_stats_by_user_null_user_id_fallback(tmp_db):
         (date, tool_name, host_name, message_id, role, tokens_used, sender_name, user_id)
         VALUES (?, ?, ?, ?, ?, ?, ?, ?)
         """,
-        ("2026-07-17", "codex", "host", "req-with-id", "assistant", 50, "alice-host-codex", alice_id),
+        (
+            "2026-07-17",
+            "codex",
+            "host",
+            "req-with-id",
+            "assistant",
+            50,
+            "alice-host-codex",
+            alice_id,
+        ),
     )
 
     # Query for tenant 1 - should see both Alice's messages

--- a/tests/integration/test_usage_repo_tenant_scope.py
+++ b/tests/integration/test_usage_repo_tenant_scope.py
@@ -129,3 +129,144 @@ def test_get_request_stats_by_user_filters_by_tenant(tmp_db):
 
     assert [row["user"] for row in tenant_one_stats] == ["alice"]
     assert [row["user"] for row in tenant_two_stats] == ["bob"]
+
+
+def test_get_request_stats_by_user_null_user_id_fallback(tmp_db):
+    """Issue #2077: Verify NULL user_id fallback via sender_name matching.
+
+    When user_id is NULL (e.g., from save_messages_batch), the query should
+    fall back to matching sender_name against the tenant's users' system_account.
+    """
+    repo = UsageRepository(db=tmp_db)
+
+    # Create users with system_account matching sender_name pattern
+    # sender_name format: {system_account}-{hostname}-{tool}
+    _ensure_tenant(tmp_db, 1)
+    _ensure_tenant(tmp_db, 2)
+
+    cursor = tmp_db.execute(
+        """
+        INSERT INTO users (username, email, password_hash, role, tenant_id, system_account)
+        VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        ("alice", "alice@example.com", "hashed_pw", "user", 1, "alice-host"),
+    )
+    alice_id = cursor.lastrowid
+
+    tmp_db.execute(
+        """
+        INSERT INTO users (username, email, password_hash, role, tenant_id, system_account)
+        VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        ("bob", "bob@example.com", "hashed_pw", "user", 2, "bob-server"),
+    )
+
+    # Insert messages with NULL user_id (simulating save_messages_batch behavior)
+    # Alice's message - belongs to tenant 1
+    tmp_db.execute(
+        """
+        INSERT INTO daily_messages
+        (date, tool_name, host_name, message_id, role, tokens_used, sender_name, user_id)
+        VALUES (?, ?, ?, ?, ?, ?, ?, NULL)
+        """,
+        ("2026-07-17", "codex", "host", "req-null-1", "assistant", 100, "alice-host-codex"),
+    )
+
+    # Bob's message - belongs to tenant 2
+    tmp_db.execute(
+        """
+        INSERT INTO daily_messages
+        (date, tool_name, host_name, message_id, role, tokens_used, sender_name, user_id)
+        VALUES (?, ?, ?, ?, ?, ?, ?, NULL)
+        """,
+        ("2026-07-17", "codex", "server", "req-null-2", "assistant", 200, "bob-server-codex"),
+    )
+
+    # Insert a message with non-NULL user_id for comparison
+    tmp_db.execute(
+        """
+        INSERT INTO daily_messages
+        (date, tool_name, host_name, message_id, role, tokens_used, sender_name, user_id)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        ("2026-07-17", "codex", "host", "req-with-id", "assistant", 50, "alice-host-codex", alice_id),
+    )
+
+    # Query for tenant 1 - should see both Alice's messages
+    tenant_one_stats = repo.get_request_stats_by_user(date="2026-07-17", tenant_id=1)
+    assert len(tenant_one_stats) == 1
+    assert tenant_one_stats[0]["user"] == "alice"
+    # Should count both messages: one with NULL user_id + one with valid user_id
+    assert tenant_one_stats[0]["requests"] == 2
+
+    # Query for tenant 2 - should see Bob's message
+    tenant_two_stats = repo.get_request_stats_by_user(date="2026-07-17", tenant_id=2)
+    assert len(tenant_two_stats) == 1
+    assert tenant_two_stats[0]["user"] == "bob"
+    assert tenant_two_stats[0]["requests"] == 1
+
+    # Query for admin (no tenant filter) - should see all
+    admin_stats = repo.get_request_stats_by_user(date="2026-07-17")
+    users = {row["user"] for row in admin_stats}
+    assert "alice" in users
+    assert "bob" in users
+
+
+def test_get_request_stats_by_user_null_user_id_cross_tenant_isolation(tmp_db):
+    """Issue #2077: Verify cross-tenant isolation for NULL user_id fallback.
+
+    A message with NULL user_id should only appear for the tenant whose
+    user's system_account matches the sender_name prefix.
+    """
+    repo = UsageRepository(db=tmp_db)
+
+    _ensure_tenant(tmp_db, 1)
+    _ensure_tenant(tmp_db, 2)
+
+    # User in tenant 1
+    tmp_db.execute(
+        """
+        INSERT INTO users (username, email, password_hash, role, tenant_id, system_account)
+        VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        ("alice", "alice@example.com", "hashed_pw", "user", 1, "alice-host"),
+    )
+
+    # User in tenant 2 with different system_account
+    tmp_db.execute(
+        """
+        INSERT INTO users (username, email, password_hash, role, tenant_id, system_account)
+        VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        ("bob", "bob@example.com", "hashed_pw", "user", 2, "bob-server"),
+    )
+
+    # Message with NULL user_id belonging to tenant 1's user
+    tmp_db.execute(
+        """
+        INSERT INTO daily_messages
+        (date, tool_name, host_name, message_id, role, tokens_used, sender_name, user_id)
+        VALUES (?, ?, ?, ?, ?, ?, ?, NULL)
+        """,
+        ("2026-07-17", "codex", "host", "req-1", "assistant", 100, "alice-host-codex"),
+    )
+
+    # Message with NULL user_id belonging to tenant 2's user
+    tmp_db.execute(
+        """
+        INSERT INTO daily_messages
+        (date, tool_name, host_name, message_id, role, tokens_used, sender_name, user_id)
+        VALUES (?, ?, ?, ?, ?, ?, ?, NULL)
+        """,
+        ("2026-07-17", "codex", "server", "req-2", "assistant", 200, "bob-server-codex"),
+    )
+
+    # Tenant 1 should only see alice's message
+    tenant_one_stats = repo.get_request_stats_by_user(date="2026-07-17", tenant_id=1)
+    assert len(tenant_one_stats) == 1
+    assert tenant_one_stats[0]["user"] == "alice"
+
+    # Tenant 2 should only see bob's message
+    tenant_two_stats = repo.get_request_stats_by_user(date="2026-07-17", tenant_id=2)
+    assert len(tenant_two_stats) == 1
+    assert tenant_two_stats[0]["user"] == "bob"


### PR DESCRIPTION
## 修复说明

关联 Issue：#2077

## 根因

`save_messages_batch()` 写入的 `daily_messages` 记录缺少 `user_id` 字段（为 NULL），导致 tenant 过滤 `_tenant_user_condition("dm.user_id")` 将这些记录错误过滤掉，因为 SQL 中 `NULL IN (...)` 返回 FALSE。

## 修复方案

在 `get_request_stats_by_user()` 的 WHERE 条件中添加 NULL user_id 回退逻辑：

```sql
WHERE (
  dm.user_id IN (SELECT id FROM users WHERE tenant_id = ?)
  OR (dm.user_id IS NULL AND EXISTS (
    SELECT 1 FROM users u 
    WHERE u.tenant_id = ?
    AND (dm.sender_name LIKE (u.system_account || '-%')
         OR dm.sender_name = u.username)
  ))
)
```

当 `user_id` 为 NULL 时，通过 `sender_name` 匹配当前 tenant 的用户：
- `sender_name` 格式：`{system_account}-{hostname}-{tool}`
- 支持直接匹配 `username`

## 主要变更

- `app/repositories/usage_repo.py`：修改 `get_request_stats_by_user()` 的 WHERE 条件
- `tests/integration/test_usage_repo_tenant_scope.py`：添加 NULL user_id 场景测试

## 测试

- 测试环境：本地开发环境
- 已运行测试：`tests/integration/test_usage_repo_tenant_scope.py`（5 个测试全部通过）
- 新增测试：
  - `test_get_request_stats_by_user_null_user_id_fallback`
  - `test_get_request_stats_by_user_null_user_id_cross_tenant_isolation`

## 风险

- **兼容性**：无变化，新增回退逻辑不影响正常 user_id 记录
- **性能**：NULL 记录需额外 EXISTS 子查询，但数据量有限影响可忽略
- **安全**：tenant 隔离保持有效，NULL 记录只能匹配当前 tenant 的用户
- **回归**：仅修改查询层，影响范围可控