### PR TITLE
fix: add tooltip to remote machine action buttons

### DIFF
--- a/frontend/src/components/features/management/RemoteMachineManagement.tsx
+++ b/frontend/src/components/features/management/RemoteMachineManagement.tsx
@@ -430,6 +430,8 @@ export const RemoteMachineManagement: React.FC = () => {
                         variant="outline-primary"
                         size="sm"
                         onClick={() => handleViewDetails(machine)}
+                        title={t('viewDetails', language)}
+                        aria-label={t('viewDetails', language)}
                       >
                         <i className="bi bi-eye" />
                       </Button>
@@ -439,6 +441,8 @@ export const RemoteMachineManagement: React.FC = () => {
                             variant="outline-success"
                             size="sm"
                             onClick={() => handleOpenRotate(machine)}
+                            title={t('rotateToken', language)}
+                            aria-label={t('rotateToken', language)}
                           >
                             <i className="bi bi-key" />
                           </Button>
@@ -446,6 +450,8 @@ export const RemoteMachineManagement: React.FC = () => {
                             variant="outline-warning"
                             size="sm"
                             onClick={() => handleOpenRevoke(machine)}
+                            title={t('revokeToken', language)}
+                            aria-label={t('revokeToken', language)}
                           >
                             <i className="bi bi-shield-lock" />
                           </Button>
@@ -453,6 +459,8 @@ export const RemoteMachineManagement: React.FC = () => {
                             variant="outline-danger"
                             size="sm"
                             onClick={() => handleOpenDeregister(machine)}
+                            title={t('deregister', language)}
+                            aria-label={t('deregister', language)}
                           >
                             <i className="bi bi-x-lg" />
                           </Button>


### PR DESCRIPTION
## 修复说明

关联 Issue：#2079

## 根因

远程机器列表页面的操作按钮（查看详情、轮换 Token、吊销 Token、注销机器）缺少 `title` 属性，用户悬停时无法显示功能提示。

## 修复方案

为每个图标按钮添加 `title` 和 `aria-label` 属性：
- 使用已存在的 i18n 翻译键
- 支持多语言显示
- 提升可访问性（aria-label）

## 主要变更

- 文件：`frontend/src/components/features/management/RemoteMachineManagement.tsx`
- 为 4 个操作按钮添加 `title` 和 `aria-label` 属性：
  - 查看详情：`viewDetails`
  - 轮换 Token：`rotateToken`
  - 吊销 Token：`revokeToken`
  - 注销机器：`deregister`

## 测试

- 本地 lint 检查通过
- 待 CI 验证

## 风险

- 兼容性风险：无（标准 HTML 属性）
- 性能风险：无
- 回归风险：无（仅添加属性，不修改功能）