### PR TITLE
feat(autonomous): #2022 P5 production wiring — spec.policy + sandbox attribution + workflow persistence

### DIFF
--- a/app/modules/workspace/autonomous/agent_runner.py
+++ b/app/modules/workspace/autonomous/agent_runner.py
@@ -774,21 +774,54 @@ class AutonomousAgentRunner:
     # them so the orchestrator sees a structured reason, not an opaque exit.
     TASK_WALL_CLOCK_TIMEOUT_ERROR_CODE = "task_wall_clock_timeout"
 
-    @staticmethod
-    def _resource_policy_configured() -> bool:
-        """Whether agent-launcher.conf sets a non-zero memory/pids/cpu limit.
+    def _load_task_policy(self) -> Any:
+        """Load the #2020 AgentTaskPolicy from agent-launcher.conf, or None.
 
-        Used to gate signal-kill classification: ``task_resource_limit_exceeded``
-        should mean a configured limit was actually hit, not an unrelated kill.
+        Passed into ``SandboxSpec.policy`` so #2020 HOME/TMP/quota is *expressed
+        via the spec* (the #2022 acceptance), not only enforced ad hoc by
+        _build_agent_env + openace-run-as. Legacy does not yet consume
+        spec.policy (the existing isolation path stands), but the spec now
+        carries it for contract completeness and future providers. None if the
+        conf is missing/unreadable.
         """
         try:
             from app.modules.workspace.autonomous.task_isolation import read_agent_task_policy
 
             conf = os.environ.get("OPENACE_LAUNCHER_CONF", "/etc/openace/agent-launcher.conf")
-            policy = read_agent_task_policy(conf)
+            return read_agent_task_policy(conf)
         except Exception:
-            return False
-        return bool(policy.memory_max_bytes or policy.pids_max or policy.cpu_max)
+            return None
+
+    def _resource_policy_configured(self) -> bool:
+        """Whether agent-launcher.conf sets a non-zero memory/pids/cpu limit.
+
+        Used to gate signal-kill classification: ``task_resource_limit_exceeded``
+        should mean a configured limit was actually hit, not an unrelated kill.
+        """
+        policy = self._load_task_policy()
+        return bool(policy and (policy.memory_max_bytes or policy.pids_max or policy.cpu_max))
+
+    @staticmethod
+    def _stamp_sandbox_attribution(
+        result: AgentTaskResult, sandbox_handle: Any, provider: Any
+    ) -> AgentTaskResult:
+        """Stamp sandbox identity + final state onto a result (#2022 P5).
+
+        Called at every _run_local/_run_remote return path where a sandbox was
+        created, so the orchestrator can persist sandbox_provider/id/generation/
+        state onto the workflow row and every evidence path carries attribution.
+        No-op when sandbox_handle is None (spawn failed before create).
+        """
+        if sandbox_handle is None:
+            return result
+        result.sandbox_id = sandbox_handle.sandbox_id
+        result.sandbox_generation = sandbox_handle.generation
+        result.sandbox_provider = sandbox_handle.provider_name
+        try:
+            result.sandbox_state = provider.inspect(sandbox_handle).value
+        except Exception:  # pragma: no cover - best-effort
+            result.sandbox_state = ""
+        return result
 
     @staticmethod
     def _classify_isolated_exit_code(
@@ -2217,6 +2250,9 @@ class AutonomousAgentRunner:
                 project_path=project_path,
                 cli_tool=cli_tool,
                 system_account=system_account,
+                # #2022 P5: express #2020 HOME/TMP/quota via the spec (not just
+                # enforce ad hoc); Legacy doesn't consume it yet, future providers do.
+                policy=self._load_task_policy(),
             )
         )
         # Preserve the old log: the wrapped launch argv (sudo/openace-run-as for
@@ -2242,15 +2278,19 @@ class AutonomousAgentRunner:
             process = self._sandbox_provider.get_process(exec_handle)
         except (OSError, subprocess.SubprocessError) as e:
             self._sandbox_provider.destroy(sandbox_handle)
-            return AgentTaskResult(
-                session_id=(
-                    ""
-                    if self._uses_sidebar_session_source(cli_tool, workspace_type)
-                    else session_id
+            return self._stamp_sandbox_attribution(
+                AgentTaskResult(
+                    session_id=(
+                        ""
+                        if self._uses_sidebar_session_source(cli_tool, workspace_type)
+                        else session_id
+                    ),
+                    tracking_session_id=session_id,
+                    success=False,
+                    error=f"Failed to start process: {e}",
                 ),
-                tracking_session_id=session_id,
-                success=False,
-                error=f"Failed to start process: {e}",
+                sandbox_handle,
+                self._sandbox_provider,
             )
 
         session = _LocalSession(
@@ -2417,21 +2457,25 @@ class AutonomousAgentRunner:
                 and self._uses_sidebar_session_source(cli_tool, workspace_type)
             ):
                 self._replay_usage_from_jsonl(session, resolved_session_id)
-            return _build_agent_task_result(
-                session_id=session_id,
-                tracking_session_id=session_id,
-                source_session_id=resolved_session_id,
-                event_log=session.event_log,
-                fallback_text=session.assistant_text,
-                total_tokens=session.total_tokens,
-                total_input_tokens=session.total_input_tokens,
-                total_output_tokens=session.total_output_tokens,
-                request_count=session.request_count,
-                tool_calls=session.tool_calls,
-                success=False,
-                error=f"Agent task timed out after {timeout}s",
-                error_code=session.error_code
-                or AutonomousAgentRunner.TASK_WALL_CLOCK_TIMEOUT_ERROR_CODE,
+            return self._stamp_sandbox_attribution(
+                _build_agent_task_result(
+                    session_id=session_id,
+                    tracking_session_id=session_id,
+                    source_session_id=resolved_session_id,
+                    event_log=session.event_log,
+                    fallback_text=session.assistant_text,
+                    total_tokens=session.total_tokens,
+                    total_input_tokens=session.total_input_tokens,
+                    total_output_tokens=session.total_output_tokens,
+                    request_count=session.request_count,
+                    tool_calls=session.tool_calls,
+                    success=False,
+                    error=f"Agent task timed out after {timeout}s",
+                    error_code=session.error_code
+                    or AutonomousAgentRunner.TASK_WALL_CLOCK_TIMEOUT_ERROR_CODE,
+                ),
+                sandbox_handle,
+                self._sandbox_provider,
             )
 
         result = _build_agent_task_result(
@@ -2449,10 +2493,9 @@ class AutonomousAgentRunner:
             error=session.error,
             error_code=session.error_code,
         )
-        # #2022: attribute the result (and thus its evidence) to the sandbox.
-        result.sandbox_id = sandbox_handle.sandbox_id
-        result.sandbox_generation = sandbox_handle.generation
-        return result
+        # #2022 P5: attribute the result (provider/id/generation/state) so the
+        # orchestrator can persist sandbox identity + every evidence path carries it.
+        return self._stamp_sandbox_attribution(result, sandbox_handle, self._sandbox_provider)
 
     def _create_workflow_session(
         self,
@@ -3295,6 +3338,8 @@ class AutonomousAgentRunner:
                     cli_tool=cli_tool,
                     machine_id=remote_machine_id,
                     user_id=user_id,
+                    # #2022 P5: express #2020 HOME/TMP/quota via the spec.
+                    policy=self._load_task_policy(),
                 )
             )
             try:
@@ -3419,10 +3464,7 @@ class AutonomousAgentRunner:
                                 else None
                             ),
                         )
-                        if sandbox_handle is not None:
-                            result.sandbox_id = sandbox_handle.sandbox_id
-                            result.sandbox_generation = sandbox_handle.generation
-                        return result
+                        return self._stamp_sandbox_attribution(result, sandbox_handle, provider)
                 time.sleep(5)
 
             timeout_result = self._build_remote_cancelled_result(remote_session_id, session_id)
@@ -3435,11 +3477,8 @@ class AutonomousAgentRunner:
                         remote_session_id[:8],
                         exc_info=True,
                     )
-            if sandbox_handle is not None:
-                timeout_result.sandbox_id = sandbox_handle.sandbox_id
-                timeout_result.sandbox_generation = sandbox_handle.generation
             timeout_result.error = f"Remote agent task timed out after {timeout}s"
-            return timeout_result
+            return self._stamp_sandbox_attribution(timeout_result, sandbox_handle, provider)
 
         except Exception as e:
             # Once a real remote id exists, never drop its local tracker while

--- a/app/modules/workspace/autonomous/models.py
+++ b/app/modules/workspace/autonomous/models.py
@@ -434,3 +434,8 @@ class AgentTaskResult:
     # rows carry sandbox_id/generation. None when no sandbox was created.
     sandbox_id: str | None = None
     sandbox_generation: int | None = None
+    # #2022 P5: which provider ran the task (legacy_posix / remote_machine / …)
+    # + final sandbox_state, so the orchestrator can persist sandbox identity +
+    # lifecycle state onto the workflow row. Empty/None when no sandbox ran.
+    sandbox_provider: str = ""
+    sandbox_state: str = ""

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -4464,6 +4464,33 @@ class AutonomousOrchestrator:
         """Refresh workflow totals from the sessions linked to milestones."""
         self.repo.refresh_workflow_usage_from_sessions(self._workflow_id)
 
+    def _persist_sandbox_attribution(self, result: AgentTaskResult) -> None:
+        """Write the task's sandbox identity + final state to the workflow row.
+
+        #2022 P5: records which SandboxProvider ran the task (provider/id/
+        generation/state) so the workflow carries sandbox attribution for audit,
+        the (deferred) UI, and P6 reconciliation. Best-effort: never raises to
+        the caller (runs on the result path).
+        """
+        provider = getattr(result, "sandbox_provider", "") or ""
+        sandbox_id = getattr(result, "sandbox_id", None)
+        if not provider and not sandbox_id:
+            return  # no sandbox ran (e.g. CLI not found before create)
+        try:
+            self.repo.update_workflow(
+                self._workflow_id,
+                {
+                    "sandbox_provider": provider,
+                    "sandbox_id": sandbox_id,
+                    "sandbox_generation": getattr(result, "sandbox_generation", None),
+                    "sandbox_state": getattr(result, "sandbox_state", "") or None,
+                },
+            )
+        except Exception as e:  # pragma: no cover - best-effort attribution
+            logger.warning(
+                "Failed to persist sandbox attribution for %s: %s", self._workflow_id[:8], e
+            )
+
     def _shadow_compare_evidence(
         self,
         *,
@@ -7512,6 +7539,10 @@ class AutonomousOrchestrator:
             sandbox_id=getattr(test_result, "sandbox_id", None),
             sandbox_generation=getattr(test_result, "sandbox_generation", None),
         )
+        # #2022 P5: persist sandbox identity + final state onto the workflow row
+        # (provider/id/generation/state) so the workflow records which sandbox ran
+        # each task and reconciliation (#2022 P6) can probe/clean orphans.
+        self._persist_sandbox_attribution(test_result)
 
         if self._abort_on_repo_integrity_violation(test_result, test_ms.get("milestone_id", "")):
             return

--- a/tests/issues/2022/test_runner_signal_routing.py
+++ b/tests/issues/2022/test_runner_signal_routing.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 from unittest.mock import MagicMock
 
 from app.modules.workspace.autonomous.agent_runner import AutonomousAgentRunner, _LocalSession
+from app.modules.workspace.autonomous.models import AgentTaskResult
 from app.modules.workspace.autonomous.sandbox.fake import FakeSandboxProvider
 from app.modules.workspace.autonomous.sandbox.types import SandboxSpec, SandboxStatus
 
@@ -79,6 +80,27 @@ def test_select_sandbox_provider_returns_legacy_for_local():
     legacy = FakeSandboxProvider()
     runner = AutonomousAgentRunner(sandbox_provider=legacy)
     assert runner._select_sandbox_provider("local") is legacy
+
+
+def test_stamp_sandbox_attribution_fills_provider_and_state():
+    # #2022 P5: every return path stamps provider/id/generation/state so the
+    # orchestrator can persist sandbox identity + every evidence path carries it.
+    provider = FakeSandboxProvider()
+    handle = provider.create(SandboxSpec(task_id="t", project_path="/tmp", cli_tool="c"))
+    result = AgentTaskResult(session_id="s")
+    AutonomousAgentRunner._stamp_sandbox_attribution(result, handle, provider)
+    assert result.sandbox_id == handle.sandbox_id
+    assert result.sandbox_generation == handle.generation
+    assert result.sandbox_provider == "fake"
+    assert result.sandbox_state == SandboxStatus.CREATED.value
+
+
+def test_stamp_sandbox_attribution_noop_without_handle():
+    # Spawn-failed-before-create paths pass sandbox_handle=None → no attribution.
+    result = AgentTaskResult(session_id="s")
+    AutonomousAgentRunner._stamp_sandbox_attribution(result, None, FakeSandboxProvider())
+    assert result.sandbox_id is None
+    assert result.sandbox_provider == ""
 
 
 def test_select_sandbox_provider_returns_remote_for_remote():


### PR DESCRIPTION
Continues #2022 (production wiring). **#2022 stays open** — P6 operations + the murkier profile/continuous-lifecycle wiring remain. Autonomous-only; UI deliberately skipped per request.

Addresses the P5 production-wiring gaps from the #2022 acceptance re-audit (#2082 round 2).

## What lands

**P5.1 — #2020 policy expressed via SandboxSpec** (`agent_runner.py`)
`_load_task_policy()` loads `AgentTaskPolicy` from agent-launcher.conf; `_run_local`/`_run_remote` pass it into `SandboxSpec.policy`. Legacy doesn't yet consume `spec.policy` (the existing `_build_agent_env` + openace-run-as path stands), but the spec now carries #2020 HOME/TMP/quota for contract completeness + future providers — the "#2020 via SandboxSpec" acceptance.

**P5.3 — sandbox attribution on EVERY return path**
`_stamp_sandbox_attribution(result, handle, provider)` stamps `sandbox_id`/`generation`/`provider`/`state`; applied at all `_run_local`/`_run_remote` return paths where a sandbox was created (success, timeout, spawn-failure, remote success/timeout). No-op when `sandbox_handle is None`. Every evidence path now carries attribution, not just the happy path.

**P5.4a — workflow row persistence** (`orchestrator.py`, `models.py`)
`AgentTaskResult` += `sandbox_provider`/`sandbox_state`. The orchestrator's `_persist_sandbox_attribution(result)` writes `provider`/`id`/`generation`/`state` onto the workflow row after the test phase (best-effort), so the workflow records which sandbox ran each task — for audit + P6 reconciliation.

## Deferred (documented)
- `transcript_profile`/`evidence_profile` injection — needs a profile source (#2047/#2046 policy).
- Continuous per-transition lifecycle writes — pairs with the skipped UI + P6 reconciliation.
- `get_process` IO-transport abstraction — #2023's first step (P4 deferral).

## Verification
- 117 #2022 tests pass (+2: `_stamp_sandbox_attribution` fills provider/state; noop without handle).
- Broad slice (autonomous + 740/1138/1395/1813 + fs/remote ordinary paths) **0==0 vs stashed-main** — zero new failures, ordinary paths untouched (scope firewall holds).
- pre-commit all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)