### PR TITLE
fix(i18n): add missing Japanese and Korean translations for deregister keys

### DIFF
--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -3865,6 +3865,13 @@ export const translations: Record<Language, Translations> = {
     aiGithubTestSavedToken: '保存済みトークンをテスト',
     aiGithubEnterTokenFirst: 'テストする前に新しいトークンを入力してください',
 
+    generateToken: 'トークン生成',
+    registrationToken: '登録トークン',
+    deregister: '登録解除',
+    deregisterMachine: 'マシン登録解除',
+    deregisterConfirm:
+      'このマシンを登録解除しますか？関連するすべてのデータが削除されます。',
+
     // Quota Management
     quotaUsage: 'クォータ使用量',
     noQuotaData: 'クォータデータがありません',
@@ -5417,6 +5424,13 @@ export const translations: Record<Language, Translations> = {
     aiGithubAccountConfigured: 'AI GitHub 계정 구성됨',
     aiGithubTestSavedToken: '저장된 토큰 테스트',
     aiGithubEnterTokenFirst: '테스트 전 새 토큰을 입력하세요',
+
+    generateToken: '토큰 생성',
+    registrationToken: '등록 토큰',
+    deregister: '등록 해제',
+    deregisterMachine: '머신 등록 해제',
+    deregisterConfirm:
+      '이 머신을 등록 해제하시겠습니까? 모든 관련 데이터가 삭제됩니다.',
 
     // Quota Management
     quotaUsage: '할당량 사용',

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -3869,8 +3869,7 @@ export const translations: Record<Language, Translations> = {
     registrationToken: '登録トークン',
     deregister: '登録解除',
     deregisterMachine: 'マシン登録解除',
-    deregisterConfirm:
-      'このマシンを登録解除しますか？関連するすべてのデータが削除されます。',
+    deregisterConfirm: 'このマシンを登録解除しますか？関連するすべてのデータが削除されます。',
 
     // Quota Management
     quotaUsage: 'クォータ使用量',
@@ -5429,8 +5428,7 @@ export const translations: Record<Language, Translations> = {
     registrationToken: '등록 토큰',
     deregister: '등록 해제',
     deregisterMachine: '머신 등록 해제',
-    deregisterConfirm:
-      '이 머신을 등록 해제하시겠습니까? 모든 관련 데이터가 삭제됩니다.',
+    deregisterConfirm: '이 머신을 등록 해제하시겠습니까? 모든 관련 데이터가 삭제됩니다.',
 
     // Quota Management
     quotaUsage: '할당량 사용',


### PR DESCRIPTION
## 修复说明

关联 Issue：#2086

## 根因

日语和韩语翻译部分缺失远程机器管理功能的 5 个翻译键（`generateToken`、`registrationToken`、`deregister`、`deregisterMachine`、`deregisterConfirm`）

## 修复方案

在日语和韩语部分添加缺失的翻译键

## 主要变更

- `frontend/src/i18n/index.ts`：添加 5 个日语翻译键
- `frontend/src/i18n/index.ts`：添加 5 个韩语翻译键

## 测试

- 前端构建验证通过
- 语言切换验证：日语/韩语界面下远程机器管理页面显示正确翻译

## 风险

- 兼容性风险：无（仅添加翻译）
- 性能风险：无
- 安全风险：无
- 回归风险：无