### PR TITLE
feat(autonomous): #2022 P6 operations — real reconcile, TTL reaper, registry

### DIFF
--- a/app/modules/workspace/autonomous/agent_runner.py
+++ b/app/modules/workspace/autonomous/agent_runner.py
@@ -732,6 +732,7 @@ class AutonomousAgentRunner:
         on_pid_registered=None,
         on_pid_cleared=None,
         sandbox_provider=None,
+        on_sandbox_created=None,
     ):
         """
         Args:
@@ -748,6 +749,12 @@ class AutonomousAgentRunner:
             sandbox_provider: #2022 P3b — the SandboxProvider that owns local
                 spawn/ACL-wrap. Defaults to LegacyPosixProvider; injectable for
                 tests. P4 will branch on workspace_type for RemoteMachineProvider.
+            on_sandbox_created: Optional callback
+                ``(session_id, sandbox_id, provider_name, remote_session_id_or_None)``
+                called right after the provider execs (#2022 P6), so the
+                orchestrator can persist a mid-run ``sandbox_state='running'``
+                row + attribution. A crash between exec and task completion then
+                leaves a row the startup reconciler can destroy by id.
         """
         self.session_manager = session_manager
         self.remote_session_manager = remote_session_manager
@@ -757,6 +764,7 @@ class AutonomousAgentRunner:
         self._activity_callback = activity_callback
         self._on_pid_registered = on_pid_registered
         self._on_pid_cleared = on_pid_cleared
+        self._on_sandbox_created = on_sandbox_created
         self._local_sessions: dict[str, _LocalSession] = {}
         # #2022 P3b: local spawns route through the SandboxProvider so the
         # orchestrator no longer touches sudo/_wrap_agent_cmd/Popen directly
@@ -828,6 +836,33 @@ class AutonomousAgentRunner:
         # 'running'/'paused' row is a genuine crash orphan.
         result.sandbox_state = "destroyed" if result.success else "error"
         return result
+
+    def _notify_sandbox_created(
+        self,
+        session_id: str,
+        sandbox_handle: Any,
+        remote_session_id: str | None,
+    ) -> None:
+        """Fire ``on_sandbox_created`` so the orchestrator persists mid-run state (#2022 P6).
+
+        Called right after ``provider.exec()`` returns (local + remote), so a
+        crash between exec and task completion leaves a ``sandbox_state='running'``
+        workflow row the startup/periodic reconciler can destroy by id. The
+        remote path passes the manager's session id; local/gVisor pass ``None``.
+        Best-effort: a callback failure is logged, never propagated to the run
+        path (mirrors ``on_pid_registered``).
+        """
+        if self._on_sandbox_created is None or sandbox_handle is None:
+            return
+        try:
+            self._on_sandbox_created(
+                session_id,
+                sandbox_handle.sandbox_id,
+                sandbox_handle.provider_name,
+                remote_session_id,
+            )
+        except Exception as e:
+            logger.warning("on_sandbox_created callback failed: %s", e)
 
     @staticmethod
     def _classify_isolated_exit_code(
@@ -2282,6 +2317,10 @@ class AutonomousAgentRunner:
             # Deferred to #2023's first step (when gVisor needs to reuse
             # stream-json); P4 deliberately stops at spawn/signal decoupling.
             process = self._sandbox_provider.get_process(exec_handle)
+            # #2022 P6: persist a mid-run 'running' row so a crash between exec
+            # and task completion leaves an orphan the reconciler can destroy.
+            # Local has no external session id → None.
+            self._notify_sandbox_created(session_id, sandbox_handle, None)
         except (OSError, subprocess.SubprocessError) as e:
             self._sandbox_provider.destroy(sandbox_handle)
             return self._stamp_sandbox_attribution(
@@ -3373,6 +3412,9 @@ class AutonomousAgentRunner:
                         cancel_check=lambda: tracker._stopped.is_set(),
                     )
                     remote_session_id = exec_handle.command_id
+                    # #2022 P6: persist mid-run 'running' + remote_session_id so
+                    # a crash leaves an orphan the reconciler can destroy by id.
+                    self._notify_sandbox_created(session_id, sandbox_handle, remote_session_id)
                     tracker.persisted_session_id = remote_session_id
                     tracker.sandbox_handle = sandbox_handle
                     tracker.exec_handle = exec_handle

--- a/app/modules/workspace/autonomous/agent_runner.py
+++ b/app/modules/workspace/autonomous/agent_runner.py
@@ -817,10 +817,16 @@ class AutonomousAgentRunner:
         result.sandbox_id = sandbox_handle.sandbox_id
         result.sandbox_generation = sandbox_handle.generation
         result.sandbox_provider = sandbox_handle.provider_name
-        try:
-            result.sandbox_state = provider.inspect(sandbox_handle).value
-        except Exception:  # pragma: no cover - best-effort
-            result.sandbox_state = ""
+        # #2022 P6: stamp the TASK-terminal state, not provider.inspect(). A
+        # remote CLI session is deliberately left alive on success (reusable
+        # sidebar), so inspect() returns 'running' — which the startup
+        # reconciler would mis-flag as an orphan and destroy. The workflow row's
+        # sandbox_state must mean "is THIS task's sandbox still occupying
+        # resources": success → destroyed (task done; local literally, remote
+        # task-done even if the session is reused), failure → error. A 'running'
+        # row therefore only exists from a mid-task write — and at startup, any
+        # 'running'/'paused' row is a genuine crash orphan.
+        result.sandbox_state = "destroyed" if result.success else "error"
         return result
 
     @staticmethod

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -1284,6 +1284,7 @@ class AutonomousOrchestrator:
             activity_callback=self._on_agent_activity,
             on_pid_registered=self._on_pid_registered,
             on_pid_cleared=self._on_pid_cleared,
+            on_sandbox_created=self._on_sandbox_created,
         )
         self._gh: GitHubOps | None = None
 
@@ -4572,6 +4573,41 @@ class AutonomousOrchestrator:
             )
         except Exception as e:
             logger.warning("Failed to persist agent PID: %s", e)
+
+    def _on_sandbox_created(
+        self,
+        session_id: str,
+        sandbox_id: str,
+        provider_name: str,
+        remote_session_id: str | None,
+    ) -> None:
+        """Persist mid-run sandbox identity so a crash leaves a reconcilable row (#2022 P6).
+
+        Sandbox-lifecycle mirror of ``_on_pid_registered``: write
+        ``sandbox_state='running'`` + sandbox_id/provider between exec and task
+        completion. A crash here leaves an orphan the startup/periodic reconciler
+        destroys by ``sandbox_remote_session_id`` (remote) or DB-resets (local).
+        The remote id is written only when present so a local row never carries a
+        stale/NULL remote id. Best-effort: never raises to the run path.
+        """
+        try:
+            updates: dict[str, object] = {
+                "sandbox_state": "running",
+                "sandbox_id": sandbox_id,
+                "sandbox_provider": provider_name,
+            }
+            if remote_session_id is not None:
+                updates["sandbox_remote_session_id"] = remote_session_id
+            self.repo.update_workflow(self._workflow_id, updates)
+            logger.info(
+                "Registered sandbox %s (provider=%s) for workflow %s%s",
+                sandbox_id[:8],
+                provider_name,
+                self._workflow_id[:8],
+                f" remote_session={remote_session_id[:8]}" if remote_session_id else "",
+            )
+        except Exception as e:
+            logger.warning("Failed to persist mid-run sandbox state: %s", e)
 
     def _on_pid_cleared(self, session_id: str):
         """Clear agent subprocess PID from database after process exits."""

--- a/app/modules/workspace/autonomous/sandbox/fake.py
+++ b/app/modules/workspace/autonomous/sandbox/fake.py
@@ -55,6 +55,8 @@ class FakeSandboxProvider:
         # command_id -> the command argv + owning sandbox_id, so stream() can
         # replay a deterministic lifecycle without a real process.
         self._execs: dict[str, dict[str, Any]] = {}
+        # P6.2: record reconcile-time destroy_attribution calls for assertions.
+        self.destroy_attribution_calls: list[tuple[str, str | None]] = []
 
     def capabilities(self) -> frozenset[SandboxCapability]:
         return self._capabilities
@@ -145,6 +147,10 @@ class FakeSandboxProvider:
         # Idempotent: destroy of an already-destroyed or unknown handle is a
         # no-op. Reconciliation (Phase 2) relies on this for orphan sandboxes.
         self._status[handle.sandbox_id] = SandboxStatus.DESTROYED
+
+    def destroy_attribution(self, sandbox_id: str, remote_session_id: str | None) -> None:
+        # P6.2: record the reconcile-path destroy-by-attribution for assertions.
+        self.destroy_attribution_calls.append((sandbox_id, remote_session_id))
 
     def inspect(self, handle: SandboxHandle) -> SandboxStatus:
         return self._status.get(handle.sandbox_id, SandboxStatus.DESTROYED)

--- a/app/modules/workspace/autonomous/sandbox/legacy_posix.py
+++ b/app/modules/workspace/autonomous/sandbox/legacy_posix.py
@@ -414,6 +414,15 @@ class LegacyPosixProvider:
         self._reap_sandbox(handle.sandbox_id)
         self._status[handle.sandbox_id] = SandboxStatus.DESTROYED
 
+    def destroy_attribution(self, sandbox_id: str, remote_session_id: str | None) -> None:
+        # Reconcile-path destroy (#2022 P6): the local proc died with the
+        # server, so there is nothing to stop — the reconciler's DB-reset
+        # (state -> destroyed, generation bump) is the real cleanup. Kept on the
+        # contract (not a local-only skip in the reconciler) so the sweep treats
+        # every provider uniformly and gVisor (#2023) overrides it with a real
+        # kill-by-id. Idempotent no-op.
+        return None
+
     def inspect(self, handle: SandboxHandle) -> SandboxStatus:
         return self._status.get(handle.sandbox_id, SandboxStatus.DESTROYED)
 

--- a/app/modules/workspace/autonomous/sandbox/provider.py
+++ b/app/modules/workspace/autonomous/sandbox/provider.py
@@ -198,6 +198,22 @@ class SandboxProvider(Protocol):
         """Tear down the sandbox. Idempotent: repeated calls do not raise."""
         ...
 
+    def destroy_attribution(self, sandbox_id: str, remote_session_id: str | None) -> None:
+        """Tear down a sandbox identified only by persisted attribution (#2022 P6).
+
+        Used by the startup/periodic reconciler after a crash/restart, when the
+        per-call provider instance (and its ``sandbox_id`` -> handle map) is gone
+        and only the strings persisted to the workflow row remain. ``destroy()``
+        cannot be used here — it keys off a live handle this provider no longer
+        holds. Idempotent + best-effort: never raises (the reconciler sweeps many
+        rows and must not abort on one failure).
+
+        Legacy/local: no-op (the process died with the server; the reconciler's
+        DB-reset is the real cleanup). Remote: ``stop_session(remote_session_id)``
+        when set. Container/gVisor (#2023) kills its sandbox by id here.
+        """
+        ...
+
     def inspect(self, handle: SandboxHandle) -> SandboxStatus:
         """Return the live status of the sandbox."""
         ...

--- a/app/modules/workspace/autonomous/sandbox/registry.py
+++ b/app/modules/workspace/autonomous/sandbox/registry.py
@@ -1,0 +1,54 @@
+"""SandboxProvider factory by persisted provider name (#2022 P6).
+
+The startup/periodic reconciler rebuilds a provider from the
+``sandbox_provider`` string on the workflow row — the per-call instance that
+ran the task (and held its ``sandbox_id`` -> handle map) is gone after a
+restart, so the sweep mints a fresh provider solely to reach
+``destroy_attribution``.
+
+Lives in its own module (not ``provider.py``) so the contract leaf does not
+import the concrete backends: ``LegacyPosixProvider`` and
+``RemoteMachineProvider`` both import ``provider.py``, so a factory there would
+cycle.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from app.modules.workspace.autonomous.sandbox.legacy_posix import LegacyPosixProvider
+from app.modules.workspace.autonomous.sandbox.provider import SandboxError
+from app.modules.workspace.autonomous.sandbox.remote_machine import RemoteMachineProvider
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from app.modules.workspace.autonomous.sandbox.provider import SandboxProvider
+    from app.modules.workspace.remote_session_manager import RemoteSessionManager
+
+# Persisted names that resolve to the local POSIX backend. ``""``/``None`` cover
+# pre-P5 rows (no sandbox_provider was written) — they ran locally, so treat them
+# as Legacy. ``fake`` is test-only and never persisted to a prod workflow row.
+_PROVIDER_LEGACY_NAMES = frozenset({"", "legacy_posix"})
+
+
+def provider_for(
+    name: str | None,
+    remote_session_manager: RemoteSessionManager | None = None,
+) -> SandboxProvider:
+    """Rebuild a SandboxProvider from its persisted name (#2022 P6).
+
+    * ``legacy_posix`` (also ``""`` / ``None`` for pre-P5 rows) →
+      :class:`LegacyPosixProvider`.
+    * ``remote_machine`` → :class:`RemoteMachineProvider`(remote_session_manager).
+      The manager is required: without it remote ``destroy_attribution`` cannot
+      reach the session, so the call fails closed rather than silently no-op'ing.
+    * Anything else (including not-yet-implemented backends like gVisor) raises
+      :class:`SandboxError` — fail closed on an unknown backend rather than guess.
+    """
+    normalized = (name or "").strip()
+    if normalized == "remote_machine":
+        if remote_session_manager is None:
+            raise SandboxError("remote_machine provider requires a remote_session_manager")
+        return RemoteMachineProvider(remote_session_manager)
+    if normalized in _PROVIDER_LEGACY_NAMES:
+        return LegacyPosixProvider()
+    raise SandboxError(f"unknown sandbox_provider: {name!r}")

--- a/app/modules/workspace/autonomous/sandbox/remote_machine.py
+++ b/app/modules/workspace/autonomous/sandbox/remote_machine.py
@@ -294,6 +294,19 @@ class RemoteMachineProvider:
                 pass
         self._status[handle.sandbox_id] = SandboxStatus.DESTROYED
 
+    def destroy_attribution(self, sandbox_id: str, remote_session_id: str | None) -> None:
+        # Reconcile-path destroy (#2022 P6): the per-call provider instance (and
+        # its _remote_sid map) is gone after a restart, so destroy(handle) cannot
+        # resolve the session. Stop directly by the persisted id. Best-effort +
+        # idempotent: a failing/repeated stop must not raise (the sweep walks many
+        # rows). local/gVisor rows pass remote_session_id=None -> no-op.
+        if not remote_session_id:
+            return
+        try:
+            self._rsm.stop_session(remote_session_id)
+        except Exception:  # pragma: no cover - best-effort
+            pass
+
     def inspect(self, handle: SandboxHandle) -> SandboxStatus:
         return self._status.get(handle.sandbox_id, SandboxStatus.DESTROYED)
 

--- a/app/repositories/autonomous_repo.py
+++ b/app/repositories/autonomous_repo.py
@@ -112,6 +112,7 @@ class AutonomousWorkflowRepository:
         "sandbox_state",
         "sandbox_policy_digest",
         "sandbox_last_error",
+        "sandbox_remote_session_id",  # #2022 P6: remote-agent session id for orphan destroy
     }
     ALLOWED_MILESTONE_FIELDS = {
         "phase",

--- a/app/services/autonomous_scheduler.py
+++ b/app/services/autonomous_scheduler.py
@@ -17,10 +17,11 @@ import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+    from app.modules.workspace.remote_session_manager import RemoteSessionManager
 
 logger = logging.getLogger(__name__)
 
@@ -31,6 +32,15 @@ MAX_CONCURRENT_WORKFLOWS = 3
 # agent-launcher.conf the launcher reads. The constant above is the default
 # when the conf is absent or the key is missing/invalid.
 _AGENT_LAUNCHER_CONF = os.environ.get("OPENACE_LAUNCHER_CONF", "/etc/openace/agent-launcher.conf")
+
+# #2022 P6: periodic TTL reaper. A 'running' sandbox row the scheduler is not
+# actively driving (not in _in_progress_ids) and has not been touched for longer
+# than this TTL is treated as a live-process orphan and destroyed. 7200s is well
+# past any agent step's wall-clock budget, so a legitimately in-flight task (held
+# in _in_progress_ids, or freshly updated) is never reaped. The reaper cadence is
+# how often the sweep runs inside _run_loop.
+_SANDBOX_TTL_SECONDS = int(os.environ.get("OPENACE_SANDBOX_TTL_SECONDS", "7200"))
+_SANDBOX_REAP_INTERVAL_SECONDS = float(os.environ.get("OPENACE_SANDBOX_REAP_INTERVAL", "300"))
 
 
 def get_max_concurrent_workflows() -> int:
@@ -113,6 +123,12 @@ class AutonomousScheduler:
         self._in_progress_lock = threading.Lock()
         self._running_orchestrators: dict[str, AutonomousOrchestrator] = {}
         self._orchestrator_lock = threading.Lock()
+        # #2022 P6: RemoteSessionManager shared with the periodic reaper so a
+        # remote orphan is destroyed by its persisted session id. Set by
+        # init_autonomous_scheduler; read via getattr-default in the reaper so
+        # construction paths that don't set it (tests, direct AutonomousScheduler())
+        # degrade gracefully (local-only sweep).
+        self.remote_session_manager: RemoteSessionManager | None = None
 
     @classmethod
     def instance(cls) -> AutonomousScheduler:
@@ -345,14 +361,84 @@ class AutonomousScheduler:
 
     def _run_loop(self):
         """Main loop: poll for active workflows and advance them."""
+        # Seed so the first reap is delayed one interval — init_autonomous_scheduler
+        # already ran the startup reconcile, so reaping on the very first poll
+        # cycle would only repeat that no-op.
+        last_reap_monotonic = time.monotonic()
         while not self._stop_event.is_set():
             try:
                 self._process_workflows()
+                # #2022 P6: periodically reap stuck 'running' sandbox rows the
+                # scheduler is not driving. Bounded by _SANDBOX_REAP_INTERVAL
+                # so the hot 10s poll loop does not hit the DB each cycle.
+                now_monotonic = time.monotonic()
+                if now_monotonic - last_reap_monotonic >= _SANDBOX_REAP_INTERVAL_SECONDS:
+                    last_reap_monotonic = now_monotonic
+                    try:
+                        self._reap_stale_running_sandboxes()
+                    except Exception as e:  # noqa: BLE001
+                        logger.error("Sandbox TTL reap failed: %s", e, exc_info=True)
             except Exception as e:
                 logger.error("Scheduler error: %s", e, exc_info=True)
 
             # Wait 10 seconds between checks (or stop signal)
             self._stop_event.wait(10)
+
+    def _reap_stale_running_sandboxes(self, repo=None, *, now_epoch=None) -> None:
+        """Reap stuck 'running' sandbox rows the scheduler isn't driving (#2022 P6).
+
+        Catches live-process orphans the startup reconcile misses: a workflow
+        whose ``sandbox_state`` still claims ``running`` but which the scheduler
+        is not actively advancing (not in ``_in_progress_ids``) and has not been
+        touched for longer than ``_SANDBOX_TTL_SECONDS``. The double guard
+        (not-driven + stale) avoids reaping a long task in flight.
+
+        Paused workflows are left alone — their sandbox is intentionally retained
+        for a later resume (a paused workflow is not in ``_in_progress_ids`` by
+        design, so the not-driven guard alone would mis-reap it; the status check
+        excludes it). Remote orphans are stopped by their persisted session id;
+        local rows are DB-reset only (the proc died).
+
+        Accepts injected ``repo`` / ``now_epoch`` for hermetic testing.
+        """
+        if repo is None:
+            from app.repositories.autonomous_repo import AutonomousWorkflowRepository
+            from app.repositories.database import Database
+
+            repo = AutonomousWorkflowRepository(Database())
+        if now_epoch is None:
+            now_epoch = time.time()
+        remote_session_manager = getattr(self, "remote_session_manager", None)
+
+        with self._in_progress_lock:
+            driven = set(self._in_progress_ids)
+
+        ttl = _SANDBOX_TTL_SECONDS
+        workflows = repo.get_workflows_with_active_sandbox()
+        for wf in workflows:
+            if wf.get("sandbox_state") != "running":
+                continue  # only 'running' occupies resources right now
+            if wf.get("status") == "paused":
+                continue  # intentional; keep the sandbox for resume
+            if wf.get("workflow_id") in driven:
+                continue  # scheduler is actively advancing it
+            updated = _parse_epoch(wf.get("updated_at"))
+            if updated is None or now_epoch - updated < ttl:
+                continue  # fresh (or no timestamp) — not stale yet
+            _destroy_orphan_sandbox(wf, remote_session_manager)
+            repo.update_workflow(
+                wf["workflow_id"],
+                {
+                    "sandbox_state": "destroyed",
+                    "sandbox_id": None,
+                    "sandbox_remote_session_id": None,
+                    "sandbox_last_error": (f"reaped by TTL sweep: running sandbox stale > {ttl}s"),
+                },
+            )
+            logger.info(
+                "Reaped stale running sandbox for workflow %s",
+                wf.get("workflow_id", "")[:8],
+            )
 
     def _advance_single(self, workflow_id: str) -> str:
         """Advance a single workflow. Returns workflow_id for tracking."""
@@ -958,20 +1044,82 @@ def _retry_pending_git_cleanups(repo=None):
         logger.error("Git cleanup retry sweep failed: %s", e, exc_info=True)
 
 
-def _reconcile_orphan_sandboxes(repo=None):
-    """Reset orphan sandbox state at startup (#2022 P2).
+def _parse_epoch(value: Any) -> float | None:
+    """Coerce a workflow-row timestamp to epoch seconds (cross-DB tolerant).
+
+    Postgres returns ``datetime``; SQLite may return a string or epoch. Returns
+    ``None`` when the value is missing or unparseable so the caller can treat
+    "no timestamp" as "not stale" (don't reap what we can't age).
+    """
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, datetime):
+        return value.timestamp()
+    try:
+        return datetime.fromisoformat(str(value)).timestamp()
+    except Exception:
+        try:
+            return float(value)
+        except Exception:
+            return None
+
+
+def _destroy_orphan_sandbox(wf: dict, remote_session_manager: Any) -> None:
+    """Best-effort real destroy of one orphan sandbox by persisted attribution (#2022 P6).
+
+    Rebuilds the provider from the workflow row's ``sandbox_provider`` name and
+    calls ``destroy_attribution`` with the persisted ids. The per-call provider
+    instance that ran the task (and held its ``sandbox_id`` -> handle map) is
+    gone after a restart, so ``destroy(handle)`` cannot resolve the session —
+    only the persisted strings remain. Local/gVisor rows without an external id
+    no-op (the proc died with the server); ``destroy_attribution`` swallows its
+    own failures so a bad row never aborts the sweep.
+
+    Scope firewall: this acts ONLY on the autonomous workflow row's own
+    persisted ``sandbox_remote_session_id`` — it never enumerates or stops
+    ordinary (non-autonomous) remote sessions.
+    """
+    provider_name = wf.get("sandbox_provider") or ""
+    raw_sid = wf.get("sandbox_remote_session_id")
+    remote_sid = raw_sid if isinstance(raw_sid, str) else ""
+    raw_sandbox = wf.get("sandbox_id")
+    sandbox_id = raw_sandbox if isinstance(raw_sandbox, str) else ""
+    # Only remote_machine has an external resource still alive after a restart;
+    # legacy/gVisor rows without an id have nothing to stop.
+    if provider_name != "remote_machine" or not remote_sid:
+        return
+    try:
+        from app.modules.workspace.autonomous.sandbox.registry import provider_for
+
+        provider = provider_for(provider_name, remote_session_manager)
+        provider.destroy_attribution(sandbox_id, remote_sid)
+    except Exception as e:  # noqa: BLE001
+        logger.warning(
+            "Failed to destroy orphan sandbox %s for workflow %s: %s",
+            sandbox_id,
+            wf.get("workflow_id", "")[:8],
+            e,
+            exc_info=True,
+        )
+
+
+def _reconcile_orphan_sandboxes(repo=None, remote_session_manager=None):
+    """Reset orphan sandbox state at startup (#2022 P2 state reset, P6 real destroy).
 
     Walks workflows whose ``sandbox_state`` claims an active sandbox
     (created/running/paused) but whose owning process is gone — the server
     crashed/restarted mid-task before the sandbox was destroyed. At startup
     nothing is running, so every active-sandbox-state row is an orphan.
 
-    For each: reset ``sandbox_state`` to ``destroyed``, bump
-    ``sandbox_generation`` (so a handle minted before the restart is stale and
-    a future provider rejects it), clear ``sandbox_id``, and record the
-    reconcile reason. This is STATE reconciliation only — there is no real
-    ``provider.destroy()`` until P3 (LegacyPosixProvider), which will add
-    actual per-task resource teardown to this sweep.
+    #2022 P6: real resource teardown now. A ``remote_machine`` orphan carries the
+    persisted ``sandbox_remote_session_id`` (the manager row id written mid-run
+    via ``on_sandbox_created``); the sweep rebuilds a provider via the registry
+    and stops that session by id. Local/gVisor rows have no external id — the
+    proc died with the server, so ``destroy_attribution`` is a no-op and the
+    DB-reset is the real cleanup. Then reset state/generation/sandbox_id/
+    remote_session_id so a second sweep is a no-op.
     """
     logger.info("Reconciling orphan sandbox state...")
 
@@ -988,6 +1136,7 @@ def _reconcile_orphan_sandboxes(repo=None):
             return
 
         for wf in workflows:
+            _destroy_orphan_sandbox(wf, remote_session_manager)
             current_gen = int(wf.get("sandbox_generation") or 0)
             repo.update_workflow(
                 wf["workflow_id"],
@@ -995,10 +1144,8 @@ def _reconcile_orphan_sandboxes(repo=None):
                     "sandbox_state": "destroyed",
                     "sandbox_generation": current_gen + 1,
                     "sandbox_id": None,
-                    "sandbox_last_error": (
-                        "reconciled at startup: orphan sandbox "
-                        "(state reset; provider destroy lands in P3)"
-                    ),
+                    "sandbox_remote_session_id": None,
+                    "sandbox_last_error": ("reconciled at startup: orphan sandbox destroyed"),
                 },
             )
             logger.info(
@@ -1019,8 +1166,14 @@ def init_autonomous_scheduler():
     _reconcile_pending_transitions()
     # Retry Git cleanup for workflows delivered but not yet cleaned up (#2043)
     _retry_pending_git_cleanups()
-    # Reset orphan sandbox state from a prior crash/restart (#2022 P2)
-    _reconcile_orphan_sandboxes()
+    # Reset orphan sandbox state from a prior crash/restart (#2022 P2/P6).
+    # RemoteSessionManager is shared with the periodic reaper so a remote orphan
+    # is actually stopped by its persisted session id, not just DB-reset.
+    from app.modules.workspace.remote_session_manager import RemoteSessionManager
+
+    remote_session_manager = RemoteSessionManager()
+    _reconcile_orphan_sandboxes(remote_session_manager=remote_session_manager)
 
     scheduler = AutonomousScheduler.instance()
+    scheduler.remote_session_manager = remote_session_manager
     scheduler.start()

--- a/migrations/versions/20260727_007_add_sandbox_remote_session_id.py
+++ b/migrations/versions/20260727_007_add_sandbox_remote_session_id.py
@@ -1,0 +1,64 @@
+"""Add sandbox_remote_session_id to autonomous_workflows
+
+Revision ID: 20260727_007_add_sandbox_remote_session_id
+Revises: 20260726_006_add_sandbox_state
+Create Date: 2026-07-27
+
+Issue: #2022 (Phase 6 operations)
+
+Persist the remote-agent session id (``RemoteSessionManager``'s row id) next to
+the provider-minted ``sandbox_id`` so the startup/periodic reconciliation sweep
+can destroy a crash-orphaned remote CLI session by id after a server restart —
+when the per-call ``RemoteMachineProvider`` instance (which held the
+sandbox_id→remote_session_id mapping) is gone. NULL for local/gVisor sandboxes
+(their destroy does not need an external id).
+
+Mirrors 20260726_006 (inspector-idempotent add; nullable, no backfill).
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260727_007_add_sandbox_remote_session_id"
+down_revision: str | None = "20260726_006_add_sandbox_state"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+NEW_COLUMNS: tuple[tuple[str, sa.types.TypeEngine], ...] = (
+    ("sandbox_remote_session_id", sa.Text()),  # RemoteSessionManager row id (remote only)
+)
+
+
+def upgrade() -> None:
+    """Add the sandbox_remote_session_id column."""
+    connection = op.get_bind()
+    inspector = sa.inspect(connection)
+
+    if "autonomous_workflows" not in set(inspector.get_table_names()):
+        # Fresh databases create the column directly in CREATE TABLE; nothing
+        # to migrate here.
+        return
+
+    existing_columns = {col["name"] for col in inspector.get_columns("autonomous_workflows")}
+    for col_name, col_type in NEW_COLUMNS:
+        if col_name in existing_columns:
+            continue
+        op.add_column(
+            "autonomous_workflows",
+            sa.Column(col_name, col_type, nullable=True),
+        )
+
+
+def downgrade() -> None:
+    """Remove the sandbox_remote_session_id column."""
+    connection = op.get_bind()
+    inspector = sa.inspect(connection)
+
+    if "autonomous_workflows" not in set(inspector.get_table_names()):
+        return
+
+    existing_columns = {col["name"] for col in inspector.get_columns("autonomous_workflows")}
+    with op.batch_alter_table("autonomous_workflows") as batch_op:
+        for col_name, _ in reversed(NEW_COLUMNS):
+            if col_name in existing_columns:
+                batch_op.drop_column(col_name)

--- a/schema/schema-postgres.sql
+++ b/schema/schema-postgres.sql
@@ -469,7 +469,8 @@ CREATE TABLE autonomous_workflows (
     sandbox_generation integer,
     sandbox_state text,
     sandbox_policy_digest text,
-    sandbox_last_error text
+    sandbox_last_error text,
+    sandbox_remote_session_id text
 );
 
 CREATE SEQUENCE autonomous_workflows_id_seq

--- a/schema/schema-sqlite.sql
+++ b/schema/schema-sqlite.sql
@@ -318,7 +318,8 @@ CREATE TABLE autonomous_workflows (
  sandbox_generation integer,
  sandbox_state text,
  sandbox_policy_digest text,
- sandbox_last_error text
+ sandbox_last_error text,
+ sandbox_remote_session_id text
 );
 
 CREATE TABLE command_execution_evidence (

--- a/tests/issues/2022/test_destroy_attribution.py
+++ b/tests/issues/2022/test_destroy_attribution.py
@@ -1,0 +1,69 @@
+"""#2022 P6.2: destroy_attribution — reconcile-time destroy by persisted id.
+
+After a crash/restart the per-call provider instance (and its sandbox_id ->
+remote_session_id map) is gone. The reconciler has only the strings persisted
+to the workflow row, so ``destroy()`` — which keys off a live handle — cannot
+resolve the remote session. ``destroy_attribution(sandbox_id, remote_session_id)``
+is the contract path for teardown-by-attribution: Legacy no-ops (the local proc
+died with the server; DB-reset is correct), Remote stops the session by id.
+gVisor (#2023) will kill its sandbox by id here.
+"""
+
+from __future__ import annotations
+
+from app.modules.workspace.autonomous.sandbox.fake import FakeSandboxProvider
+from app.modules.workspace.autonomous.sandbox.legacy_posix import LegacyPosixProvider
+from app.modules.workspace.autonomous.sandbox.remote_machine import RemoteMachineProvider
+
+
+class _FakeRSM:
+    """Minimal RemoteSessionManager double for the destroy path."""
+
+    def __init__(self) -> None:
+        self.stop_calls: list[str] = []
+        self.stop_raises = False
+
+    def stop_session(self, session_id: str) -> bool:
+        self.stop_calls.append(session_id)
+        if self.stop_raises:
+            raise RuntimeError("boom")
+        return True
+
+
+def test_legacy_destroy_attribution_is_noop() -> None:
+    # Local proc died with the server; nothing to destroy. Must not raise.
+    provider = LegacyPosixProvider()
+    provider.destroy_attribution("any-sandbox-id", None)
+
+
+def test_remote_destroy_attribution_stops_session_by_id() -> None:
+    rsm = _FakeRSM()
+    provider = RemoteMachineProvider(rsm)
+    # Fresh instance — _remote_sid is empty, so destroy(handle) could not find
+    # this. destroy_attribution must use the PASSED id (persisted attribution).
+    provider.destroy_attribution("sandbox-1", "remote-session-42")
+    assert rsm.stop_calls == ["remote-session-42"]
+
+
+def test_remote_destroy_attribution_none_remote_id_is_noop() -> None:
+    # A local/gVisor row (or pre-P6 remote row) has no remote_session_id.
+    rsm = _FakeRSM()
+    provider = RemoteMachineProvider(rsm)
+    provider.destroy_attribution("sandbox-1", None)
+    assert rsm.stop_calls == []
+
+
+def test_remote_destroy_attribution_swallows_stop_errors() -> None:
+    # Best-effort + idempotent: a failing or repeated stop must not raise
+    # (the reconciler sweeps many rows and must not abort on one failure).
+    rsm = _FakeRSM()
+    rsm.stop_raises = True
+    provider = RemoteMachineProvider(rsm)
+    provider.destroy_attribution("sandbox-1", "remote-session-42")
+    provider.destroy_attribution("sandbox-1", "remote-session-42")
+
+
+def test_fake_records_destroy_attribution() -> None:
+    provider = FakeSandboxProvider()
+    provider.destroy_attribution("sandbox-1", "remote-9")
+    assert provider.destroy_attribution_calls == [("sandbox-1", "remote-9")]

--- a/tests/issues/2022/test_on_sandbox_created_handler.py
+++ b/tests/issues/2022/test_on_sandbox_created_handler.py
@@ -1,0 +1,67 @@
+"""#2022 P6.4 — orchestrator ``_on_sandbox_created`` persists mid-run sandbox state.
+
+The callback fires right after the provider execs; the handler writes a
+``sandbox_state='running'`` row + attribution so a crash between exec and task
+completion leaves an orphan the startup reconciler can destroy by id.
+"""
+
+from __future__ import annotations
+
+from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+
+class _FakeRepo:
+    def __init__(self) -> None:
+        self.updates: list[tuple[str, dict]] = []
+
+    def update_workflow(self, wf_id: str, updates: dict) -> None:
+        self.updates.append((wf_id, dict(updates)))
+
+
+def _make_orch() -> AutonomousOrchestrator:
+    orch = AutonomousOrchestrator.__new__(AutonomousOrchestrator)
+    orch.repo = _FakeRepo()
+    orch._workflow_id = "wf-123"
+    return orch
+
+
+def test_on_sandbox_created_writes_running_state_for_remote() -> None:
+    orch = _make_orch()
+    orch._on_sandbox_created("s1", "sandbox-abc", "remote_machine", "remote-42")
+    assert orch.repo.updates == [
+        (
+            "wf-123",
+            {
+                "sandbox_state": "running",
+                "sandbox_id": "sandbox-abc",
+                "sandbox_provider": "remote_machine",
+                "sandbox_remote_session_id": "remote-42",
+            },
+        )
+    ]
+
+
+def test_on_sandbox_created_omits_remote_id_for_local() -> None:
+    orch = _make_orch()
+    orch._on_sandbox_created("s1", "sandbox-abc", "legacy_posix", None)
+    wf_id, updates = orch.repo.updates[0]
+    assert wf_id == "wf-123"
+    assert updates["sandbox_state"] == "running"
+    assert updates["sandbox_id"] == "sandbox-abc"
+    assert updates["sandbox_provider"] == "legacy_posix"
+    # Local has no remote_session_id — the key must be absent so a NULL is not
+    # written over a real value, and the column stays clean for local rows.
+    assert "sandbox_remote_session_id" not in updates
+
+
+def test_on_sandbox_created_best_effort_repo_failure() -> None:
+    # A repo failure must not propagate to the run path (mirrors _on_pid_registered).
+
+    class _BoomRepo:
+        def update_workflow(self, *a, **k) -> None:
+            raise RuntimeError("db down")
+
+    orch = AutonomousOrchestrator.__new__(AutonomousOrchestrator)
+    orch.repo = _BoomRepo()
+    orch._workflow_id = "wf-123"
+    orch._on_sandbox_created("s1", "sb", "legacy_posix", None)  # no raise

--- a/tests/issues/2022/test_provider_registry.py
+++ b/tests/issues/2022/test_provider_registry.py
@@ -1,0 +1,43 @@
+"""#2022 P6.3: provider_for — rebuild a SandboxProvider from its persisted name.
+
+The reconciler rebuilds a provider from the ``sandbox_provider`` string on the
+workflow row (the per-call instance that ran the task is gone after a restart).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.modules.workspace.autonomous.sandbox.legacy_posix import LegacyPosixProvider
+from app.modules.workspace.autonomous.sandbox.provider import SandboxError
+from app.modules.workspace.autonomous.sandbox.registry import provider_for
+from app.modules.workspace.autonomous.sandbox.remote_machine import RemoteMachineProvider
+
+
+class _FakeRSM:
+    """Stand-in for RemoteSessionManager (RemoteMachineProvider stores it as-is)."""
+
+
+def test_legacy_name_returns_legacy_provider() -> None:
+    assert isinstance(provider_for("legacy_posix"), LegacyPosixProvider)
+
+
+def test_empty_and_none_treated_as_legacy() -> None:
+    # Pre-P5 rows have no sandbox_provider; treat as the local default.
+    assert isinstance(provider_for(""), LegacyPosixProvider)
+    assert isinstance(provider_for(None), LegacyPosixProvider)
+
+
+def test_remote_name_returns_remote_provider() -> None:
+    provider = provider_for("remote_machine", _FakeRSM())
+    assert isinstance(provider, RemoteMachineProvider)
+
+
+def test_remote_name_without_rsm_fails_closed() -> None:
+    with pytest.raises(SandboxError):
+        provider_for("remote_machine", None)
+
+
+def test_unknown_name_fails_closed() -> None:
+    with pytest.raises(SandboxError):
+        provider_for("gVisor-future", None)

--- a/tests/issues/2022/test_runner_signal_routing.py
+++ b/tests/issues/2022/test_runner_signal_routing.py
@@ -83,16 +83,20 @@ def test_select_sandbox_provider_returns_legacy_for_local():
 
 
 def test_stamp_sandbox_attribution_fills_provider_and_state():
-    # #2022 P5: every return path stamps provider/id/generation/state so the
-    # orchestrator can persist sandbox identity + every evidence path carries it.
+    # #2022 P6: state is TASK-terminal (success→destroyed, failure→error), NOT
+    # provider.inspect() — a remote session left alive on success must not read
+    # 'running' (the startup reconciler would mis-flag it as a crash orphan).
     provider = FakeSandboxProvider()
     handle = provider.create(SandboxSpec(task_id="t", project_path="/tmp", cli_tool="c"))
-    result = AgentTaskResult(session_id="s")
-    AutonomousAgentRunner._stamp_sandbox_attribution(result, handle, provider)
-    assert result.sandbox_id == handle.sandbox_id
-    assert result.sandbox_generation == handle.generation
-    assert result.sandbox_provider == "fake"
-    assert result.sandbox_state == SandboxStatus.CREATED.value
+    ok = AgentTaskResult(session_id="s", success=True)
+    AutonomousAgentRunner._stamp_sandbox_attribution(ok, handle, provider)
+    assert ok.sandbox_id == handle.sandbox_id
+    assert ok.sandbox_generation == handle.generation
+    assert ok.sandbox_provider == "fake"
+    assert ok.sandbox_state == "destroyed"
+    failed = AgentTaskResult(session_id="s", success=False)
+    AutonomousAgentRunner._stamp_sandbox_attribution(failed, handle, provider)
+    assert failed.sandbox_state == "error"
 
 
 def test_stamp_sandbox_attribution_noop_without_handle():

--- a/tests/issues/2022/test_runner_signal_routing.py
+++ b/tests/issues/2022/test_runner_signal_routing.py
@@ -113,3 +113,55 @@ def test_select_sandbox_provider_returns_remote_for_remote():
     # RemoteMachineProvider wraps the remote_session_manager (gVisor would add
     # a third branch here).
     assert provider.__class__.__name__ == "RemoteMachineProvider"
+
+
+def _spec() -> SandboxSpec:
+    return SandboxSpec(task_id="t", project_path="/tmp", cli_tool="c")
+
+
+def test_notify_sandbox_created_invokes_callback_with_attribution():
+    # #2022 P6: right after exec the runner fires on_sandbox_created so the
+    # orchestrator can persist a mid-run 'running' row (crash orphan bait for
+    # the reconciler). Callback gets (session_id, sandbox_id, provider_name,
+    # remote_session_id_or_None).
+    captured: list = []
+    provider = FakeSandboxProvider()
+    runner = AutonomousAgentRunner(
+        sandbox_provider=provider,
+        on_sandbox_created=lambda *a: captured.append(a),
+    )
+    handle = provider.create(_spec())
+    runner._notify_sandbox_created("s1", handle, "remote-42")
+    assert captured == [("s1", handle.sandbox_id, "fake", "remote-42")]
+
+
+def test_notify_sandbox_created_none_remote_id_for_local():
+    # Local path passes remote_session_id=None (no external session id).
+    captured: list = []
+    provider = FakeSandboxProvider()
+    runner = AutonomousAgentRunner(
+        sandbox_provider=provider,
+        on_sandbox_created=lambda *a: captured.append(a),
+    )
+    handle = provider.create(_spec())
+    runner._notify_sandbox_created("s1", handle, None)
+    assert captured == [("s1", handle.sandbox_id, "fake", None)]
+
+
+def test_notify_sandbox_created_noop_without_callback():
+    # No callback registered -> no-op, no raise.
+    provider = FakeSandboxProvider()
+    runner = AutonomousAgentRunner(sandbox_provider=provider)
+    handle = provider.create(_spec())
+    runner._notify_sandbox_created("s1", handle, None)
+
+
+def test_notify_sandbox_created_swallows_callback_errors():
+    # Best-effort: a failing callback must not propagate to the runner path.
+    def _boom(*a):
+        raise RuntimeError("callback failed")
+
+    provider = FakeSandboxProvider()
+    runner = AutonomousAgentRunner(sandbox_provider=provider, on_sandbox_created=_boom)
+    handle = provider.create(_spec())
+    runner._notify_sandbox_created("s1", handle, None)  # no raise

--- a/tests/issues/2022/test_sandbox_reconciliation.py
+++ b/tests/issues/2022/test_sandbox_reconciliation.py
@@ -1,11 +1,12 @@
-"""Orphan-sandbox reconciliation sweep (#2022 P2).
+"""Orphan-sandbox reconciliation sweep (#2022 P2 state reset, P6 real destroy).
 
 At startup the scheduler reconciles workflows whose ``sandbox_state`` claims an
 active sandbox but whose owning process is gone (crash / restart mid-task): it
 resets the state to ``destroyed`` and bumps ``sandbox_generation`` so a stale
-handle minted before the restart cannot operate on a future sandbox. P2 is
-state reconciliation only — real ``provider.destroy()`` resource cleanup lands
-in P3 (LegacyPosixProvider).
+handle minted before the restart cannot operate on a future sandbox. P6 adds
+real resource teardown — a ``remote_machine`` orphan is stopped by its persisted
+``sandbox_remote_session_id``; local/gVisor rows (no external id) are DB-reset
+only (the proc died with the server).
 
 Mock-repo driven (no DB), mirroring tests/issues/2050's reconciliation test.
 """
@@ -110,3 +111,130 @@ def test_reconcile_uses_injected_repo_without_constructing_default():
     repo = _mock_repo([])
     _reconcile_orphan_sandboxes(repo)
     repo.get_workflows_with_active_sandbox.assert_called_once()
+
+
+# ── #2022 P6.5: real remote destroy by persisted session id ────────────────
+
+
+def test_reconcile_destroys_remote_orphan_by_persisted_session_id():
+    # A remote_machine orphan carries sandbox_remote_session_id (the manager row
+    # id persisted mid-run). The sweep rebuilds a provider and stops that
+    # session, then DB-resets (clearing the id) so a second sweep is a no-op.
+    repo = _mock_repo(
+        [
+            {
+                "workflow_id": "wf-remote",
+                "sandbox_state": "running",
+                "sandbox_generation": 1,
+                "sandbox_id": "sb-remote",
+                "sandbox_provider": "remote_machine",
+                "sandbox_remote_session_id": "remote-session-7",
+            }
+        ]
+    )
+    rsm = MagicMock()
+    _reconcile_orphan_sandboxes(repo, remote_session_manager=rsm)
+
+    rsm.stop_session.assert_called_once_with("remote-session-7")
+    patch = repo.update_workflow.call_args.args[1]
+    assert patch["sandbox_state"] == "destroyed"
+    assert patch["sandbox_generation"] == 2
+    assert patch["sandbox_remote_session_id"] is None  # cleared for idempotency
+
+
+def test_reconcile_skips_destroy_for_local_orphan():
+    # Local proc died with the server — no external session to stop. The sweep
+    # DB-resets only (LegacyPosixProvider.destroy_attribution is a no-op).
+    repo = _mock_repo(
+        [
+            {
+                "workflow_id": "wf-local",
+                "sandbox_state": "running",
+                "sandbox_generation": 1,
+                "sandbox_id": "sb-local",
+                "sandbox_provider": "legacy_posix",
+                "sandbox_remote_session_id": None,
+            }
+        ]
+    )
+    rsm = MagicMock()
+    _reconcile_orphan_sandboxes(repo, remote_session_manager=rsm)
+
+    rsm.stop_session.assert_not_called()
+    patch = repo.update_workflow.call_args.args[1]
+    assert patch["sandbox_state"] == "destroyed"
+
+
+def test_reconcile_remote_without_session_id_only_db_resets():
+    # Defensive: a remote row without a persisted sandbox_remote_session_id
+    # (pre-P6 row, or the mid-run write raced the crash) has nothing to stop —
+    # destroy_attribution no-ops on None, and the sweep still DB-resets.
+    repo = _mock_repo(
+        [
+            {
+                "workflow_id": "wf-remote-noid",
+                "sandbox_state": "running",
+                "sandbox_generation": 1,
+                "sandbox_id": "sb-x",
+                "sandbox_provider": "remote_machine",
+                "sandbox_remote_session_id": None,
+            }
+        ]
+    )
+    rsm = MagicMock()
+    _reconcile_orphan_sandboxes(repo, remote_session_manager=rsm)
+
+    rsm.stop_session.assert_not_called()
+    assert repo.update_workflow.call_args.args[1]["sandbox_state"] == "destroyed"
+
+
+def test_reconcile_destroy_failure_does_not_abort_sweep():
+    # A failing stop on one row must not prevent DB-reset of that row or any
+    # other row in the sweep. destroy_attribution swallows the failure; the
+    # sweep continues.
+    repo = _mock_repo(
+        [
+            {
+                "workflow_id": "wf-boom",
+                "sandbox_state": "running",
+                "sandbox_generation": 1,
+                "sandbox_id": "sb-1",
+                "sandbox_provider": "remote_machine",
+                "sandbox_remote_session_id": "rs-1",
+            },
+            {
+                "workflow_id": "wf-ok",
+                "sandbox_state": "running",
+                "sandbox_generation": 1,
+                "sandbox_id": "sb-2",
+                "sandbox_provider": "remote_machine",
+                "sandbox_remote_session_id": "rs-2",
+            },
+        ]
+    )
+    rsm = MagicMock()
+    rsm.stop_session.side_effect = RuntimeError("rpc down")
+    _reconcile_orphan_sandboxes(repo, remote_session_manager=rsm)  # no raise
+
+    assert rsm.stop_session.call_count == 2  # both attempted despite failure
+    assert repo.update_workflow.call_count == 2  # both DB-reset regardless
+
+
+def test_reconcile_uses_injected_remote_session_manager():
+    # Mirror of the repo-injection test: an injected rsm must be used and no
+    # default constructed.
+    repo = _mock_repo(
+        [
+            {
+                "workflow_id": "wf-r",
+                "sandbox_state": "running",
+                "sandbox_generation": 1,
+                "sandbox_id": "sb",
+                "sandbox_provider": "remote_machine",
+                "sandbox_remote_session_id": "rs",
+            }
+        ]
+    )
+    rsm = MagicMock()
+    _reconcile_orphan_sandboxes(repo, remote_session_manager=rsm)
+    rsm.stop_session.assert_called_once_with("rs")

--- a/tests/issues/2022/test_sandbox_ttl_reaper.py
+++ b/tests/issues/2022/test_sandbox_ttl_reaper.py
@@ -1,0 +1,200 @@
+"""#2022 P6.6 — periodic TTL reaper for stuck 'running' sandbox rows.
+
+Catches live-process orphans the startup reconcile misses: a workflow whose
+``sandbox_state`` still claims ``running`` but which the scheduler is not
+actively advancing (not in ``_in_progress_ids``) and has not been touched for
+longer than the TTL. The double guard (not-driven + stale) avoids reaping a
+long task in flight; paused workflows are left alone (sandbox retained for
+resume).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from app.services.autonomous_scheduler import AutonomousScheduler
+
+
+def _make_scheduler(in_progress=()) -> AutonomousScheduler:
+    sched = AutonomousScheduler()
+    sched.remote_session_manager = MagicMock()
+    sched._in_progress_ids = set(in_progress)
+    return sched
+
+
+def _fake_repo(rows):
+    repo = MagicMock()
+    repo.get_workflows_with_active_sandbox.return_value = rows
+    return repo
+
+
+NOW = 1_700_000_000.0
+
+
+def test_reap_destroys_stale_remote_running_orphan_not_driven() -> None:
+    sched = _make_scheduler(in_progress=())
+    repo = _fake_repo(
+        [
+            {
+                "workflow_id": "wf-stale",
+                "status": "developing",
+                "sandbox_state": "running",
+                "sandbox_provider": "remote_machine",
+                "sandbox_id": "sb-1",
+                "sandbox_remote_session_id": "rs-1",
+                "updated_at": NOW - 8000,  # well past TTL (7200)
+            }
+        ]
+    )
+    sched._reap_stale_running_sandboxes(repo=repo, now_epoch=NOW)
+
+    sched.remote_session_manager.stop_session.assert_called_once_with("rs-1")
+    wid, patch = repo.update_workflow.call_args.args
+    assert wid == "wf-stale"
+    assert patch["sandbox_state"] == "destroyed"
+    assert patch["sandbox_remote_session_id"] is None
+
+
+def test_reap_skips_workflow_being_driven() -> None:
+    # The scheduler is actively advancing this workflow → leave its sandbox alone
+    # even if updated_at looks stale (the in-progress guard wins).
+    sched = _make_scheduler(in_progress={"wf-driven"})
+    repo = _fake_repo(
+        [
+            {
+                "workflow_id": "wf-driven",
+                "status": "developing",
+                "sandbox_state": "running",
+                "sandbox_provider": "remote_machine",
+                "sandbox_id": "sb",
+                "sandbox_remote_session_id": "rs",
+                "updated_at": NOW - 8000,
+            }
+        ]
+    )
+    sched._reap_stale_running_sandboxes(repo=repo, now_epoch=NOW)
+
+    sched.remote_session_manager.stop_session.assert_not_called()
+    repo.update_workflow.assert_not_called()
+
+
+def test_reap_skips_fresh_running_row() -> None:
+    # Recently-touched 'running' row — the task may genuinely still be in flight.
+    sched = _make_scheduler(in_progress=())
+    repo = _fake_repo(
+        [
+            {
+                "workflow_id": "wf-fresh",
+                "status": "developing",
+                "sandbox_state": "running",
+                "sandbox_provider": "remote_machine",
+                "sandbox_id": "sb",
+                "sandbox_remote_session_id": "rs",
+                "updated_at": NOW - 10,  # fresh
+            }
+        ]
+    )
+    sched._reap_stale_running_sandboxes(repo=repo, now_epoch=NOW)
+
+    sched.remote_session_manager.stop_session.assert_not_called()
+    repo.update_workflow.assert_not_called()
+
+
+def test_reap_skips_paused_workflow() -> None:
+    # Paused is intentional — keep the sandbox for a later resume.
+    sched = _make_scheduler(in_progress=())
+    repo = _fake_repo(
+        [
+            {
+                "workflow_id": "wf-paused",
+                "status": "paused",
+                "sandbox_state": "running",
+                "sandbox_provider": "remote_machine",
+                "sandbox_id": "sb",
+                "sandbox_remote_session_id": "rs",
+                "updated_at": NOW - 8000,
+            }
+        ]
+    )
+    sched._reap_stale_running_sandboxes(repo=repo, now_epoch=NOW)
+
+    sched.remote_session_manager.stop_session.assert_not_called()
+    repo.update_workflow.assert_not_called()
+
+
+def test_reap_skips_non_running_states() -> None:
+    # 'created'/'paused' sandbox_state are not 'running' — not the reaper's target
+    # (startup reconcile owns the full active set).
+    sched = _make_scheduler(in_progress=())
+    repo = _fake_repo(
+        [
+            {
+                "workflow_id": "wf-created",
+                "status": "developing",
+                "sandbox_state": "created",
+                "sandbox_provider": "remote_machine",
+                "sandbox_id": "sb",
+                "sandbox_remote_session_id": "rs",
+                "updated_at": NOW - 8000,
+            }
+        ]
+    )
+    sched._reap_stale_running_sandboxes(repo=repo, now_epoch=NOW)
+
+    sched.remote_session_manager.stop_session.assert_not_called()
+    repo.update_workflow.assert_not_called()
+
+
+def test_reap_local_orphan_db_resets_only() -> None:
+    # Local 'running' orphan: the proc died, so no external session to stop.
+    sched = _make_scheduler(in_progress=())
+    repo = _fake_repo(
+        [
+            {
+                "workflow_id": "wf-local",
+                "status": "developing",
+                "sandbox_state": "running",
+                "sandbox_provider": "legacy_posix",
+                "sandbox_id": "sb",
+                "sandbox_remote_session_id": None,
+                "updated_at": NOW - 8000,
+            }
+        ]
+    )
+    sched._reap_stale_running_sandboxes(repo=repo, now_epoch=NOW)
+
+    sched.remote_session_manager.stop_session.assert_not_called()
+    patch = repo.update_workflow.call_args.args[1]
+    assert patch["sandbox_state"] == "destroyed"
+
+
+def test_reap_destroy_failure_continues() -> None:
+    # stop_session raises on the first row; the sweep must still DB-reset it and
+    # continue to the second row.
+    sched = _make_scheduler(in_progress=())
+    sched.remote_session_manager.stop_session.side_effect = RuntimeError("rpc down")
+    repo = _fake_repo(
+        [
+            {
+                "workflow_id": "wf-a",
+                "status": "developing",
+                "sandbox_state": "running",
+                "sandbox_provider": "remote_machine",
+                "sandbox_id": "sb-a",
+                "sandbox_remote_session_id": "rs-a",
+                "updated_at": NOW - 8000,
+            },
+            {
+                "workflow_id": "wf-b",
+                "status": "developing",
+                "sandbox_state": "running",
+                "sandbox_provider": "remote_machine",
+                "sandbox_id": "sb-b",
+                "sandbox_remote_session_id": "rs-b",
+                "updated_at": NOW - 8000,
+            },
+        ]
+    )
+    sched._reap_stale_running_sandboxes(repo=repo, now_epoch=NOW)  # no raise
+
+    assert repo.update_workflow.call_count == 2  # both reset despite stop failure


### PR DESCRIPTION
P6 closes the sandbox lifecycle loop the prior phases opened: the orchestrator now persists a mid-run `sandbox_state='running'` row + attribution, and the scheduler destroys crash-orphaned sandboxes for real instead of only DB-resetting them.

Stacked on #2085 (P5). Base `2022-p5-wiring` so this diff is P6-only; retarget `main` after #2085 merges.

## Changes
- **`destroy_attribution(sandbox_id, remote_session_id)`** on the `SandboxProvider` contract — reconcile-time teardown by persisted id. After a restart the per-call provider instance (and its `sandbox_id`→handle map) is gone, so `destroy(handle)` cannot resolve the session. Legacy no-ops (proc died with the server); Remote `stop_session(remote_id)`; gVisor (#2023) kills by id here.
- **`sandbox/registry.py::provider_for(name, rsm)`** — rebuild a provider from the workflow row's persisted `sandbox_provider` name. Own module to avoid a `provider.py` import cycle.
- **`on_sandbox_created` callback** (runner `__init__` + `_run_local`/`_run_remote` call sites + orchestrator `_on_sandbox_created`) — writes `sandbox_state='running'` + `sandbox_id`/`provider`/`remote_session_id` between exec and task completion, so a crash leaves a reconcilable row.
- **`_reconcile_orphan_sandboxes`** now really destroys `remote_machine` orphans by their persisted `sandbox_remote_session_id`; local/gVisor rows DB-reset only. Scope firewall: acts ONLY on the workflow row's own persisted id — never enumerates ordinary remote sessions.
- **TTL reaper** in `_run_loop` — periodically reaps `sandbox_state='running'` rows the scheduler is not driving (`not in _in_progress_ids`) and older than `OPENACE_SANDBOX_TTL_SECONDS` (default 7200s). Double guard avoids reaping an in-flight task; paused workflows are left alone.
- migration `20260727_007` adds `sandbox_remote_session_id` (nullable, inspector-idempotent, mirrors P2/P6.1); schema + repo field alongside.

## Tests
29 new (146 total in `tests/issues/2022`): destroy_attribution contract, registry mapping, on_sandbox_created runner helper + orchestrator persistence, real reconcile (remote destroy / local skip / failure-continues), TTL reaper (stale / driven / fresh / paused / non-running / local / failure-continues). pre-commit (black/ruff/mypy/schema-sync/single-head) green; ordinary workspace/remote/terminal suite unaffected (scope firewall).

Refs #2022 (stays open — UI still skipped; #2023 gVisor inherits `destroy_attribution`/registry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)