### PR TITLE
fix(usage): use tenant_id directly in get_daily_by_tool for tenant filtering

### DIFF
--- a/app/repositories/usage_repo.py
+++ b/app/repositories/usage_repo.py
@@ -652,13 +652,17 @@ class UsageRepository:
 
         Note:
             Issue #1852: Added tenant_id parameter for tenant filtering.
+            Issue #2089: Changed from user_id IN (...) to direct tenant_id filtering
+                         to handle NULL user_id records correctly.
         """
         conditions = ["date >= ?", "date <= ?"]
         params: list[Any] = [start_date, end_date]
         normalized_tenant_id = self._normalize_tenant_id(tenant_id)
 
         if normalized_tenant_id is not None:
-            conditions.append(self._tenant_user_condition("user_id"))
+            # Issue #2089: Use tenant_id directly instead of user_id IN (...)
+            # to correctly filter records where user_id is NULL.
+            conditions.append("tenant_id = ?")
             params.append(normalized_tenant_id)
 
         if host_name:

--- a/tests/integration/test_usage_repo_tenant_scope.py
+++ b/tests/integration/test_usage_repo_tenant_scope.py
@@ -279,3 +279,90 @@ def test_get_request_stats_by_user_null_user_id_cross_tenant_isolation(tmp_db):
     tenant_two_stats = repo.get_request_stats_by_user(date="2026-07-17", tenant_id=2)
     assert len(tenant_two_stats) == 1
     assert tenant_two_stats[0]["user"] == "bob"
+
+
+def test_get_daily_by_tool_filters_by_tenant(tmp_db):
+    """Issue #2089: Verify get_daily_by_tool filters correctly by tenant_id.
+
+    This test ensures that tenant filtering uses tenant_id directly instead of
+    user_id IN (...), which fails when user_id is NULL.
+    """
+    repo = UsageRepository(db=tmp_db)
+
+    # Create daily_stats entries for two different tenants
+    # Tenant 1 stats
+    tmp_db.execute(
+        """
+        INSERT INTO daily_stats
+        (date, tool_name, host_name, sender_name, user_id, tenant_id, total_tokens,
+         total_input_tokens, total_output_tokens, message_count)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        ("2026-07-17", "codex", "host1", "sender1", None, 1, 100, 10, 90, 5),
+    )
+
+    # Tenant 2 stats
+    tmp_db.execute(
+        """
+        INSERT INTO daily_stats
+        (date, tool_name, host_name, sender_name, user_id, tenant_id, total_tokens,
+         total_input_tokens, total_output_tokens, message_count)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        ("2026-07-17", "qwen", "host2", "sender2", None, 2, 200, 20, 180, 10),
+    )
+
+    # Query for tenant 1 - should only see tenant 1's data
+    tenant_one_trend = repo.get_daily_by_tool("2026-07-17", "2026-07-17", tenant_id=1)
+    assert len(tenant_one_trend) == 1
+    assert tenant_one_trend[0]["tool"] == "codex"
+    assert tenant_one_trend[0]["tokens"] == 100
+
+    # Query for tenant 2 - should only see tenant 2's data
+    tenant_two_trend = repo.get_daily_by_tool("2026-07-17", "2026-07-17", tenant_id=2)
+    assert len(tenant_two_trend) == 1
+    assert tenant_two_trend[0]["tool"] == "qwen"
+    assert tenant_two_trend[0]["tokens"] == 200
+
+    # Query for admin (no tenant filter) - should see all
+    admin_trend = repo.get_daily_by_tool("2026-07-17", "2026-07-17")
+    assert len(admin_trend) == 2
+
+
+def test_get_daily_by_tool_null_user_id_tenant_filter(tmp_db):
+    """Issue #2089: Verify tenant filtering works for NULL user_id records.
+
+    The fix changes from user_id IN (...) to tenant_id = ? to correctly
+    handle records where user_id is NULL.
+    """
+    repo = UsageRepository(db=tmp_db)
+
+    # Insert records with NULL user_id for both tenants
+    tmp_db.execute(
+        """
+        INSERT INTO daily_stats
+        (date, tool_name, host_name, sender_name, user_id, tenant_id, total_tokens,
+         total_input_tokens, total_output_tokens, message_count)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        ("2026-07-17", "codex", "host", "sender-null", None, 1, 150, 15, 135, 7),
+    )
+
+    tmp_db.execute(
+        """
+        INSERT INTO daily_stats
+        (date, tool_name, host_name, sender_name, user_id, tenant_id, total_tokens,
+         total_input_tokens, total_output_tokens, message_count)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        ("2026-07-17", "qwen", "host", "sender-null-2", None, 2, 250, 25, 225, 12),
+    )
+
+    # Verify tenant filtering works correctly with NULL user_id
+    tenant_one_trend = repo.get_daily_by_tool("2026-07-17", "2026-07-17", tenant_id=1)
+    assert len(tenant_one_trend) == 1
+    assert tenant_one_trend[0]["tokens"] == 150
+
+    tenant_two_trend = repo.get_daily_by_tool("2026-07-17", "2026-07-17", tenant_id=2)
+    assert len(tenant_two_trend) == 1
+    assert tenant_two_trend[0]["tokens"] == 250


### PR DESCRIPTION
## 修复说明

关联 Issue：#2089

## 根因

`get_daily_by_tool()` 方法使用 `_tenant_user_condition("user_id")` 进行 tenant 过滤，当 `daily_stats.user_id` 为 NULL 时，SQL `NULL IN (...)` 返回 FALSE，导致 Dashboard 趋势图返回空数据。

## 修复方案

采用方案 1：直接使用 `tenant_id` 字段过滤，而非通过 `user_id` 间接过滤。

```python
# 修改前
if normalized_tenant_id is not None:
    conditions.append(self._tenant_user_condition("user_id"))
    params.append(normalized_tenant_id)

# 修改后
if normalized_tenant_id is not None:
    conditions.append("tenant_id = ?")
    params.append(normalized_tenant_id)
```

## 主要变更

- `app/repositories/usage_repo.py`: 修改 `get_daily_by_tool()` 的 tenant 过滤逻辑
- `tests/integration/test_usage_repo_tenant_scope.py`: 添加两个测试用例

## 测试

- **测试环境**: 本地开发环境
- **已运行测试**: 
  - `test_get_daily_by_tool_filters_by_tenant`: ✅ 通过
  - `test_get_daily_by_tool_null_user_id_tenant_filter`: ✅ 通过
- **新增测试**: 2 个测试用例验证 tenant 过滤和 NULL user_id 场景
- **测试结果**: 全部通过

## 风险

- **兼容性风险**: 无。修改仅影响 tenant 过滤逻辑，不影响 API 行为
- **性能风险**: 无。避免子查询，性能更好
- **安全风险**: 无。tenant 隔离仍然有效
- **回归风险**: 低。修改仅 1 行代码逻辑