### PR TITLE
feat(autonomous): structured test verdict replaces agent-prose heuristics (#2046 Phase B)

### DIFF
--- a/app/modules/workspace/autonomous/command_evidence/scope.py
+++ b/app/modules/workspace/autonomous/command_evidence/scope.py
@@ -1,0 +1,204 @@
+"""Test-command scope helpers shared by the heuristic and structured gates.
+
+Extracted from ``orchestrator`` (#2046 Phase B) so both the legacy heuristic
+(``orchestrator._has_passing_test_tool_result``) and the structured verdict
+(``test_verdict.compute_run_verdict``) reuse the same scope-comparison rules
+without a circular import — the orchestrator imports the verdict module for
+the gate, so the verdict module must not import back into the orchestrator.
+
+A test command is normalized into a stable identity (stripping output-only
+``head``/``tail`` pipelines) and a pytest "scope" (execution context +
+selectors) so a later passing superset can clear an earlier failure, but a
+targeted pass or a different runtime environment never can (#1967, #2046 §2).
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shlex
+
+_TEST_OUTPUT_FILTER_RE = re.compile(
+    r"(?:\s+2>\&1)?\s*\|\s*(?:head|tail)(?:\s+-[^\s]+|\s+\d+)*\s*$",
+    re.IGNORECASE,
+)
+
+
+def _normalize_test_command(command: str) -> str:
+    """Return a stable identity for a test command across output-only filters.
+
+    Autonomous agents commonly run ``pytest ... | head -100`` while exploring
+    a failure and rerun the same target as ``pytest ... | tail -20`` after the
+    fix.  Those filters change only which output is displayed, not the tests
+    executed.  Treating the two strings as distinct left the truncated first
+    run permanently inconclusive even when the later rerun passed.
+
+    Strip only trailing ``head``/``tail`` pipelines (and their adjacent stderr
+    merge).  Execution-affecting shell operators such as ``&&``/``||`` and
+    pytest selectors/options remain part of the identity.
+    """
+    normalized = " ".join(str(command or "").split())
+    while True:
+        stripped = _TEST_OUTPUT_FILTER_RE.sub("", normalized).strip()
+        if stripped == normalized:
+            break
+        normalized = stripped
+    return re.sub(r"\s+2>\&1\s*$", "", normalized).strip()
+
+
+_PytestScope = tuple[str, frozenset[str]]
+
+
+def _pytest_test_scope(command: str) -> _PytestScope | None:
+    """Return the pytest execution context and selectors when safely comparable.
+
+    ``None`` means the command is too complex for safe scope comparison.  An
+    empty selector set means a full-suite invocation.  This lets a later
+    passing superset rerun clear earlier failures for the same files while
+    ensuring a targeted pass or a different Python environment can never clear
+    a failed full-suite command.
+    """
+    normalized = _normalize_test_command(command)
+    if any(operator in normalized for operator in ("&&", "||", ";", "|")):
+        return None
+    try:
+        tokens = shlex.split(normalized)
+    except ValueError:
+        return None
+
+    pytest_index = -1
+    for index, token in enumerate(tokens):
+        if os.path.basename(token) in {"pytest", "py.test"}:
+            pytest_index = index
+            break
+    if pytest_index < 0:
+        return None
+
+    # Only compare scopes when the invocation prefix has ordinary pytest
+    # semantics.  Environment assignments and wrappers can change collection
+    # even when the visible selectors are identical.
+    prefix = tokens[:pytest_index]
+    if prefix:
+        python_name = os.path.basename(prefix[0])
+        if (
+            len(prefix) != 2
+            or prefix[1] != "-m"
+            or re.fullmatch(r"python(?:\d+(?:\.\d+)*)?", python_name) is None
+        ):
+            return None
+        execution_context = f"{prefix[0]} -m {tokens[pytest_index]}"
+    else:
+        execution_context = tokens[pytest_index]
+
+    scope_narrowing_options = {
+        "-k",
+        "-m",
+        "--ignore",
+        "--ignore-glob",
+        "--deselect",
+        "--lf",
+        "--last-failed",
+        "--ff",
+        "--failed-first",
+        "--nf",
+        "--new-first",
+        "--sw",
+        "--stepwise",
+        "--stepwise-skip",
+    }
+    safe_flags = {
+        "-q",
+        "--quiet",
+        "-v",
+        "-vv",
+        "--verbose",
+        "-s",
+        "-x",
+        "--exitfirst",
+        "--disable-warnings",
+        "--strict-config",
+        "--strict-markers",
+        "--continue-on-collection-errors",
+        "--full-trace",
+        "--showlocals",
+        "-l",
+        "--no-header",
+        "--no-summary",
+    }
+    safe_value_options = {
+        "--tb",
+        "--color",
+        "--capture",
+        "--durations",
+        "--durations-min",
+        "--junitxml",
+        "--junit-prefix",
+        "--basetemp",
+        "--verbosity",
+        "--maxfail",
+    }
+
+    selectors: set[str] = set()
+    args = tokens[pytest_index + 1 :]
+    index = 0
+    selectors_only = False
+    while index < len(args):
+        token = args[index]
+        if token == "--":
+            selectors_only = True
+            index += 1
+            continue
+        if not selectors_only and token.startswith("-"):
+            option_name = token.split("=", 1)[0]
+            if option_name in scope_narrowing_options:
+                return None
+            if token in safe_flags:
+                index += 1
+                continue
+            if option_name in safe_value_options:
+                if "=" not in token:
+                    index += 1
+                    if index >= len(args):
+                        return None
+                index += 1
+                continue
+            # Plugin and future pytest options are unknown here.  Exact-command
+            # retries remain supported, but cross-command scope coverage is not.
+            return None
+        selectors.add(token.rstrip("/") or ".")
+        index += 1
+
+    return execution_context, frozenset(selectors)
+
+
+def _pytest_scope_covers(
+    passing_scope: _PytestScope | None,
+    earlier_scope: _PytestScope | None,
+) -> bool:
+    """Whether a passing pytest command covers an earlier command's scope."""
+    if passing_scope is None or earlier_scope is None:
+        return False
+    passing_context, passing_selectors = passing_scope
+    earlier_context, earlier_selectors = earlier_scope
+    if passing_context != earlier_context:
+        return False
+    if not passing_selectors:
+        return True
+    if not earlier_selectors:
+        return False
+
+    def _selector_covers(passing: str, earlier: str) -> bool:
+        if passing == earlier:
+            return True
+        if passing in {".", "./"}:
+            return True
+        passing_path = passing.split("::", 1)[0].rstrip("/")
+        earlier_path = earlier.split("::", 1)[0].rstrip("/")
+        if "::" not in passing and passing_path == earlier_path:
+            return True
+        return "::" not in passing and earlier_path.startswith(f"{passing_path}/")
+
+    return all(
+        any(_selector_covers(passing, earlier) for passing in passing_selectors)
+        for earlier in earlier_selectors
+    )

--- a/app/modules/workspace/autonomous/command_evidence/test_evidence.py
+++ b/app/modules/workspace/autonomous/command_evidence/test_evidence.py
@@ -1,0 +1,459 @@
+"""Structured test-execution evidence (#2046 Phase B).
+
+Domain module under ``app/`` (not a unit test — pytest collects only ``tests/``);
+the ``test_`` prefix means *test-execution* evidence, not a test module.
+
+Where :mod:`types` captures *command* execution facts (what ran, how it
+terminated), this module captures *test* execution facts derived from a
+command's output — framework, collected/passed/failed counts, selectors,
+and an authoritative verdict. A pluggable parser per framework reads the
+``CommandExecutionEvidence.output_excerpt`` + ``exit_code``; it never reads
+the agent's free-form summary text as an authoritative source (#1967, #2046).
+
+Phase A persists ``CommandExecutionEvidence`` and shadow-compares a
+command-level verdict against the legacy heuristic. Phase B adds this
+test-level evidence: the gate's authoritative PASSED/FAILED comes from
+``compute_run_verdict`` over a list of ``TestExecutionEvidence``. The legacy
+heuristic stays only as an INCONCLUSIVE/NOT_RUN fallback (#2046 §4 降级).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import asdict, dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import Any
+
+from app.modules.workspace.autonomous.command_evidence.scope import _pytest_test_scope, _PytestScope
+from app.modules.workspace.autonomous.command_evidence.types import (
+    CommandExecutionEvidence,
+    ExecutionVerdict,
+)
+
+
+class ParserConfidence(str, Enum):
+    """How strongly a parser trusts its own parsed verdict.
+
+    ``HIGH`` — matched the framework's authoritative summary line (pytest
+    "N passed in N.Ns", jest "Tests: N passed", go "ok pkg"). ``MEDIUM`` — saw
+    a pass/fail marker or a clean exit code but no parseable count.
+    ``LOW`` — generic, fell back to exit code only with no framework signal.
+    """
+
+    HIGH = "high"
+    MEDIUM = "medium"
+    LOW = "low"
+
+
+@dataclass
+class ParsedTestResult:
+    """Framework-level parse of one command's test output (in-memory)."""
+
+    framework: str
+    collected: int | None = None
+    passed: int | None = None
+    failed: int | None = None
+    skipped: int | None = None
+    errors: int | None = None
+    selectors: list[str] = field(default_factory=list)
+    coverage_scope: dict[str, Any] | None = None
+    parser: str = ""
+    parser_confidence: str = ParserConfidence.LOW.value
+    verdict: str = ExecutionVerdict.INCONCLUSIVE.value
+
+
+@dataclass
+class TestExecutionEvidence:
+    """Authoritative test-execution facts for one command (#2046 Phase B).
+
+    Pairs 1:1 with a ``CommandExecutionEvidence`` row via
+    ``command_execution_id`` (the row PK) and shares its ``(session_id,
+    command_id)`` identity. ``verdict`` is a single command's
+    :class:`ExecutionVerdict` value; the run-level verdict is computed by
+    :func:`app.modules.workspace.autonomous.command_evidence.test_verdict.compute_run_verdict`.
+    """
+
+    command_id: str
+    command_execution_id: int | None = None
+    framework: str = ""
+    collected: int | None = None
+    passed: int | None = None
+    failed: int | None = None
+    skipped: int | None = None
+    errors: int | None = None
+    selectors: list[str] = field(default_factory=list)
+    coverage_scope: dict[str, Any] | None = None
+    parser: str = ""
+    parser_confidence: str = ""
+    verdict: str = ""
+    # Persistence / attribution (mirror CommandExecutionEvidence).
+    session_id: str = ""
+    workflow_id: str = ""
+    milestone_id: str = ""
+    tenant_id: int = 1
+    id: int | None = None
+    created_at: datetime | None = None
+
+    # pytest collects classes named ``Test*``; this is a data class, not a test.
+    __test__ = False
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-friendly dict for storage/API/metadata."""
+        data = asdict(self)
+        value = data.get("created_at")
+        data["created_at"] = value.isoformat() if isinstance(value, datetime) else value
+        return data
+
+    @classmethod
+    def from_row(cls, row: dict[str, Any]) -> TestExecutionEvidence:
+        """Build an instance from a DB row dict (JSON fields already decoded)."""
+        selectors = row.get("selectors")
+        if isinstance(selectors, str):
+            import json
+
+            try:
+                selectors = json.loads(selectors) if selectors else []
+            except (TypeError, ValueError):
+                selectors = []
+        coverage_scope = row.get("coverage_scope")
+        if isinstance(coverage_scope, str):
+            import json
+
+            try:
+                coverage_scope = json.loads(coverage_scope) if coverage_scope else None
+            except (TypeError, ValueError):
+                coverage_scope = None
+        return cls(
+            id=row.get("id"),
+            command_id=row.get("command_id") or "",
+            command_execution_id=row.get("command_execution_id"),
+            framework=row.get("framework") or "",
+            collected=row.get("collected"),
+            passed=row.get("passed"),
+            failed=row.get("failed"),
+            skipped=row.get("skipped"),
+            errors=row.get("errors"),
+            selectors=selectors or [],
+            coverage_scope=coverage_scope,
+            parser=row.get("parser") or "",
+            parser_confidence=row.get("parser_confidence") or "",
+            verdict=row.get("verdict") or "",
+            session_id=row.get("session_id") or "",
+            workflow_id=row.get("workflow_id") or "",
+            milestone_id=row.get("milestone_id") or "",
+            tenant_id=int(row.get("tenant_id") or 1),
+            created_at=_parse_dt(row.get("created_at")),
+        )
+
+
+def _parse_dt(value: Any) -> datetime | None:
+    if value is None or isinstance(value, datetime):
+        return value
+    try:
+        return datetime.fromisoformat(str(value))
+    except (TypeError, ValueError):
+        return None
+
+
+# ── Count extraction (multilingual) ─────────────────────────────────────────
+# Each list is tried in order; all matches across the excerpt are summed so a
+# summary repeated in header + footer is not double-counted past its real
+# total (we take the max per-kind, not the sum, to stay conservative — see
+# _extract_count).
+_PASSED_PATTERNS = [
+    re.compile(r"\b(\d+)\s+passed\b", re.IGNORECASE),
+    re.compile(r"test result:\s*ok\.\s*(\d+)\s+passed", re.IGNORECASE),
+    re.compile(r"(?:通过|成功)[:：\s]+(\d+)", re.IGNORECASE),
+    re.compile(r"(\d+)\s*(?:个|项|件)?\s*(?:测试)?\s*(?:全部|全都|都)?\s*(?:通过|成功)"),
+    re.compile(r"(?:通過|成功)[:：\s]+(\d+)\s*(?:件|テスト)?"),
+    re.compile(r"(?:통과|성공)[:：\s]+(\d+)\s*(?:개|테스트)?"),
+]
+_FAILED_PATTERNS = [
+    re.compile(r"\b(\d+)\s+failed\b", re.IGNORECASE),
+    re.compile(r"test result:\s*FAILED\.\s*(\d+)\s+failed", re.IGNORECASE),
+    re.compile(r"(?:失败|错误)[:：\s]+(\d+)", re.IGNORECASE),
+    re.compile(r"(\d+)\s*(?:个|项|件)?\s*(?:测试)?\s*(?:失败|错误)"),
+    re.compile(r"(?:失敗|エラー)[:：\s]+(\d+)\s*(?:件|テスト)?"),
+    re.compile(r"(?:실패|오류)[:：\s]+(\d+)\s*(?:개|테스트)?"),
+]
+_SKIPPED_PATTERNS = [
+    re.compile(r"\b(\d+)\s+skipped\b", re.IGNORECASE),
+    re.compile(r"(?:跳过|忽略)[:：\s]+(\d+)", re.IGNORECASE),
+    re.compile(r"(?:スキップ|スキップ済み)[:：\s]+(\d+)\s*(?:件|テスト)?"),
+    re.compile(r"(?:건너뜀|스킵)[:：\s]+(\d+)\s*(?:개|테스트)?"),
+]
+_ERRORS_PATTERNS = [
+    re.compile(r"\b(\d+)\s+errors?\b", re.IGNORECASE),
+    re.compile(r"errors?[:：\s]+(\d+)", re.IGNORECASE),
+]
+
+
+def _extract_count(excerpt: str, patterns: list[re.Pattern[str]]) -> int | None:
+    """Return the strongest count any pattern matched, or None.
+
+    Takes the max (not the sum) so a summary echoed in both header and footer
+    does not inflate the count past its real value.
+    """
+    best: int | None = None
+    for pattern in patterns:
+        for match in pattern.finditer(excerpt):
+            try:
+                value = int(match.group(1))
+            except (ValueError, IndexError):
+                continue
+            if best is None or value > best:
+                best = value
+    return best
+
+
+def _scope_to_dict(scope: _PytestScope | None) -> dict[str, Any] | None:
+    """Serialize a pytest scope to a JSON-friendly dict for persistence."""
+    if scope is None:
+        return None
+    context, selectors = scope
+    return {"context": context, "selectors": sorted(selectors)}
+
+
+def _scope_from_dict(data: dict[str, Any] | None) -> _PytestScope | None:
+    """Reconstruct a pytest scope from its persisted dict form."""
+    if not data:
+        return None
+    context = data.get("context")
+    selectors = data.get("selectors") or []
+    if not isinstance(context, str):
+        return None
+    return context, frozenset(str(s) for s in selectors)
+
+
+def _verdict_from_counts(
+    *, passed: int | None, failed: int | None, errors: int | None
+) -> ExecutionVerdict:
+    """Map parsed counts to a verdict. Called only when at least one matched."""
+    if (failed or 0) > 0 or (errors or 0) > 0:
+        return ExecutionVerdict.FAILED
+    if (passed or 0) > 0:
+        return ExecutionVerdict.PASSED
+    return ExecutionVerdict.INCONCLUSIVE
+
+
+def _parse_pytest(excerpt: str, exit_code: int | None, command_text: str) -> ParsedTestResult:
+    """Parse pytest (and unittest) output into structured counts + scope."""
+    passed = _extract_count(excerpt, _PASSED_PATTERNS)
+    failed = _extract_count(excerpt, _FAILED_PATTERNS)
+    skipped = _extract_count(excerpt, _SKIPPED_PATTERNS)
+    errors = _extract_count(excerpt, _ERRORS_PATTERNS)
+
+    # unittest "OK (N tests)" / "FAILED (failures=N)" have no "passed" token;
+    # synthesize a pass count so a clean unittest run is not stuck inconclusive.
+    unittest_ok = re.search(r"\bRan\s+(\d+)\s+tests?\b[\s\S]*?^OK\s*$", excerpt, re.MULTILINE)
+    if unittest_ok and passed is None and failed is None:
+        passed = int(unittest_ok.group(1))
+
+    scope = _pytest_test_scope(command_text) if command_text else None
+    selectors = sorted(scope[1]) if scope else []
+    coverage_scope = _scope_to_dict(scope)
+
+    saw_summary = passed is not None or failed is not None or errors is not None
+    if saw_summary:
+        verdict = _verdict_from_counts(passed=passed, failed=failed, errors=errors)
+        confidence = ParserConfidence.HIGH
+    elif exit_code is not None:
+        # Saw a clean/non-clean exit but no parseable pytest summary. Trust
+        # the exit code at medium confidence (the process did finish).
+        verdict = ExecutionVerdict.PASSED if exit_code == 0 else ExecutionVerdict.FAILED
+        confidence = ParserConfidence.MEDIUM
+    else:
+        verdict = ExecutionVerdict.INCONCLUSIVE
+        confidence = ParserConfidence.LOW
+
+    return ParsedTestResult(
+        framework="python",
+        passed=passed,
+        failed=failed,
+        skipped=skipped,
+        errors=errors,
+        selectors=selectors,
+        coverage_scope=coverage_scope,
+        parser="pytest",
+        parser_confidence=confidence.value,
+        verdict=verdict.value,
+    )
+
+
+def _parse_jest(excerpt: str, exit_code: int | None) -> ParsedTestResult:
+    """Parse Jest output ("Tests: N passed, N failed")."""
+    passed = _extract_count(
+        excerpt,
+        [
+            re.compile(r"Tests:\s*(\d+)\s+passed", re.IGNORECASE),
+            re.compile(r"(\d+)\s+tests?\s+passed", re.IGNORECASE),
+        ],
+    )
+    failed = _extract_count(
+        excerpt,
+        [
+            re.compile(r"Tests:\s*(\d+)\s+failed", re.IGNORECASE),
+            re.compile(r"(\d+)\s+tests?\s+failed", re.IGNORECASE),
+        ],
+    )
+    if passed is not None or failed is not None:
+        verdict = _verdict_from_counts(passed=passed, failed=failed, errors=None)
+        confidence = ParserConfidence.HIGH
+    elif exit_code is not None:
+        verdict = ExecutionVerdict.PASSED if exit_code == 0 else ExecutionVerdict.FAILED
+        confidence = ParserConfidence.MEDIUM
+    else:
+        verdict = ExecutionVerdict.INCONCLUSIVE
+        confidence = ParserConfidence.LOW
+    return ParsedTestResult(
+        framework="javascript",
+        passed=passed,
+        failed=failed,
+        parser="jest",
+        parser_confidence=confidence.value,
+        verdict=verdict.value,
+    )
+
+
+def _parse_go(excerpt: str, exit_code: int | None) -> ParsedTestResult:
+    """Parse `go test` output ("ok pkg N.Ns" / "FAIL pkg N.Ns")."""
+    ok = re.search(r"^ok\s+\S+\s+[\d.]+s", excerpt, re.MULTILINE)
+    fail = re.search(r"^FAIL\s+\S+", excerpt, re.MULTILINE)
+    if fail:
+        verdict, confidence = ExecutionVerdict.FAILED, ParserConfidence.HIGH
+    elif ok:
+        verdict, confidence = ExecutionVerdict.PASSED, ParserConfidence.HIGH
+    elif exit_code is not None:
+        verdict = ExecutionVerdict.PASSED if exit_code == 0 else ExecutionVerdict.FAILED
+        confidence = ParserConfidence.MEDIUM
+    else:
+        verdict, confidence = ExecutionVerdict.INCONCLUSIVE, ParserConfidence.LOW
+    return ParsedTestResult(
+        framework="go",
+        parser="go_test",
+        parser_confidence=confidence.value,
+        verdict=verdict.value,
+    )
+
+
+def _parse_cargo(excerpt: str, exit_code: int | None) -> ParsedTestResult:
+    """Parse `cargo test` output ("test result: ok. N passed; N failed")."""
+    passed = _extract_count(
+        excerpt, [re.compile(r"test result:\s*ok\.\s*(\d+)\s+passed", re.IGNORECASE)]
+    )
+    failed = _extract_count(
+        excerpt,
+        [re.compile(r"(\d+)\s+failed", re.IGNORECASE)],
+    )
+    saw_summary = "test result:" in excerpt.lower()
+    if saw_summary and (passed is not None or failed is not None):
+        verdict = _verdict_from_counts(passed=passed, failed=failed, errors=None)
+        confidence = ParserConfidence.HIGH
+    elif "test result: ok" in excerpt.lower():
+        verdict, confidence = ExecutionVerdict.PASSED, ParserConfidence.HIGH
+    elif exit_code is not None:
+        verdict = ExecutionVerdict.PASSED if exit_code == 0 else ExecutionVerdict.FAILED
+        confidence = ParserConfidence.MEDIUM
+    else:
+        verdict, confidence = ExecutionVerdict.INCONCLUSIVE, ParserConfidence.LOW
+    return ParsedTestResult(
+        framework="rust",
+        passed=passed,
+        failed=failed,
+        parser="cargo",
+        parser_confidence=confidence.value,
+        verdict=verdict.value,
+    )
+
+
+def _parse_generic(excerpt: str, exit_code: int | None) -> ParsedTestResult:
+    """Fallback parser: only the process exit code is authoritative.
+
+    Used when the framework is unknown or unrecognized. A zero exit with some
+    output is MEDIUM confidence (the process claimed success); no exit code at
+    all is INCONCLUSIVE — the gate then falls back to the heuristic.
+    """
+    if exit_code is None:
+        verdict, confidence = ExecutionVerdict.INCONCLUSIVE, ParserConfidence.LOW
+    elif exit_code == 0:
+        verdict, confidence = (
+            ExecutionVerdict.PASSED if excerpt.strip() else ExecutionVerdict.INCONCLUSIVE,
+            ParserConfidence.MEDIUM if excerpt.strip() else ParserConfidence.LOW,
+        )
+    else:
+        verdict, confidence = ExecutionVerdict.FAILED, ParserConfidence.MEDIUM
+    return ParsedTestResult(
+        framework="generic",
+        parser="generic",
+        parser_confidence=confidence.value,
+        verdict=verdict.value,
+    )
+
+
+def _resolve_framework(command_evidence: CommandExecutionEvidence, hint: str) -> str:
+    """Pick the parser framework from the command text, falling back to hint.
+
+    The command's shell text is authoritative for which framework ran; the
+    project-level hint is the fallback when the command gives no signal.
+    ``go`` / ``cargo`` are matched on the leading token so ``cargo test`` is
+    not mistaken for ``go test`` (``car`` + ``go test`` is a substring match).
+    """
+    command_text = (command_evidence.shell_command or "").lower()
+    tokens = command_text.split()
+    head = tokens[0] if tokens else ""
+    if any(signal in command_text for signal in ("pytest", "py.test", "unittest")):
+        return "python"
+    if any(signal in command_text for signal in ("jest", "vitest", "npm test", "yarn test")):
+        return "javascript"
+    if head == "go":
+        return "go"
+    if head == "cargo":
+        return "rust"
+    return hint or "generic"
+
+
+def parse_test_evidence(
+    command_evidence: CommandExecutionEvidence, framework_hint: str = ""
+) -> TestExecutionEvidence:
+    """Parse one command's evidence into structured :class:`TestExecutionEvidence`.
+
+    Dispatches on the resolved framework. ``framework_hint`` is the project-
+    level inference (``_infer_test_framework``); the command's own shell text
+    overrides it when it carries a stronger signal.
+    """
+    framework = _resolve_framework(command_evidence, framework_hint)
+    excerpt = command_evidence.output_excerpt or ""
+    exit_code = command_evidence.exit_code
+    command_text = command_evidence.shell_command or ""
+
+    if framework == "python":
+        parsed = _parse_pytest(excerpt, exit_code, command_text)
+    elif framework == "javascript":
+        parsed = _parse_jest(excerpt, exit_code)
+    elif framework == "go":
+        parsed = _parse_go(excerpt, exit_code)
+    elif framework == "rust":
+        parsed = _parse_cargo(excerpt, exit_code)
+    else:
+        parsed = _parse_generic(excerpt, exit_code)
+
+    return TestExecutionEvidence(
+        command_id=command_evidence.command_id,
+        command_execution_id=command_evidence.id,
+        framework=parsed.framework,
+        collected=parsed.collected,
+        passed=parsed.passed,
+        failed=parsed.failed,
+        skipped=parsed.skipped,
+        errors=parsed.errors,
+        selectors=parsed.selectors,
+        coverage_scope=parsed.coverage_scope,
+        parser=parsed.parser,
+        parser_confidence=parsed.parser_confidence,
+        verdict=parsed.verdict,
+        session_id=command_evidence.session_id,
+        workflow_id=command_evidence.workflow_id,
+        milestone_id=command_evidence.milestone_id,
+        tenant_id=command_evidence.tenant_id,
+    )

--- a/app/modules/workspace/autonomous/command_evidence/test_verdict.py
+++ b/app/modules/workspace/autonomous/command_evidence/test_verdict.py
@@ -1,0 +1,154 @@
+"""Run-level test verdict from structured evidence (#2046 Phase B).
+
+Domain module under ``app/`` (not a unit test — pytest collects only ``tests/``);
+the ``test_`` prefix means *test-verdict*, not a test module.
+
+``compute_run_verdict`` aggregates per-command :class:`TestExecutionEvidence`
+into a single run-level :class:`ExecutionVerdict`. It re-implements the
+coverage/override rules of the legacy heuristic
+(``orchestrator._has_passing_test_tool_result``) but consumes structured
+evidence instead of the raw ``event_log``:
+
+- every distinct command must pass (any HIGH/MEDIUM FAILED → run FAILED,
+  unless a later passing superset covers it);
+- a later passing pytest superset clears an earlier failure for the same
+  execution context (``_pytest_scope_covers``);
+- a targeted pass never clears a failed full suite;
+- the latest invocation of a command wins (stale pass cannot satisfy a rerun);
+- non-pytest frameworks do not cross-cover (different commands cannot clear
+  each other; only an exact retry of the same command can).
+
+Input source of truth: ``TestExecutionEvidence`` rows, never agent prose.
+"""
+
+from __future__ import annotations
+
+from app.modules.workspace.autonomous.command_evidence.scope import (
+    _pytest_scope_covers,
+    _PytestScope,
+)
+from app.modules.workspace.autonomous.command_evidence.test_evidence import (
+    ParserConfidence,
+    TestExecutionEvidence,
+    _scope_from_dict,
+)
+from app.modules.workspace.autonomous.command_evidence.types import ExecutionVerdict
+
+_AUTHORITATIVE = (ParserConfidence.HIGH.value, ParserConfidence.MEDIUM.value)
+
+
+def _command_key(evidence: TestExecutionEvidence, framework: str) -> tuple:
+    """Stable identity for grouping reruns of the same command.
+
+    For pytest, the (context, selectors) pair from ``coverage_scope`` is the
+    normalized identity — ``pytest a b | head`` and ``pytest a b | tail``
+    share it, so a truncated exploration run and its later rerun collapse to
+    one command. For other frameworks (or commands too complex to scope), the
+    raw ``command_id`` is the identity (each invocation is distinct).
+    """
+    if framework == "python" and evidence.coverage_scope:
+        context = evidence.coverage_scope.get("context")
+        selectors = frozenset(evidence.coverage_scope.get("selectors") or [])
+        if isinstance(context, str):
+            return ("pytest", context, selectors)
+    return ("cmd", evidence.command_id)
+
+
+def _latest_state(
+    authoritative: list[tuple[int, TestExecutionEvidence]], framework: str
+) -> dict[tuple, tuple[str, _PytestScope | None, int]]:
+    """Reduce to the latest verdict/scope/order per normalized command.
+
+    ``authoritative`` is ordered by execution (the caller passes evidences in
+    ``id`` order). When a command was invoked more than once, only the newest
+    invocation's verdict survives — a stale pass from before a code change
+    cannot satisfy an interrupted rerun (#1967).
+    """
+    latest: dict[tuple, tuple[str, _PytestScope | None, int]] = {}
+    for order, evidence in authoritative:
+        key = _command_key(evidence, framework)
+        scope = _scope_from_dict(evidence.coverage_scope) if framework == "python" else None
+        previous = latest.get(key)
+        if previous is None or order > previous[2]:
+            latest[key] = (evidence.verdict, scope, order)
+    return latest
+
+
+def _has_uncovered_failure(
+    authoritative: list[tuple[int, TestExecutionEvidence]], framework: str
+) -> bool:
+    """Whether any command's latest failure lacks a later passing cover.
+
+    A passing command covers an earlier failure only when it ran later and
+    (for pytest) its scope is a provable superset. Exact retries of the same
+    command are already collapsed by ``_latest_state``; this pass only
+    handles cross-command superset coverage, which is pytest-only.
+    """
+    latest = _latest_state(authoritative, framework)
+    passing = [
+        (scope, order)
+        for verdict, scope, order in latest.values()
+        if verdict == ExecutionVerdict.PASSED.value
+    ]
+    for verdict, failed_scope, order in latest.values():
+        if verdict == ExecutionVerdict.PASSED.value:
+            continue
+        # Latest verdict for this command is FAILED (or non-pass). A later
+        # passing command may clear it — but only for pytest, and only when
+        # the passing scope provably covers the failed scope.
+        covered = False
+        for passing_scope, passing_order in passing:
+            if passing_order <= order:
+                continue
+            if framework == "python" and _pytest_scope_covers(passing_scope, failed_scope):
+                covered = True
+                break
+        if not covered:
+            return True
+    return False
+
+
+def compute_run_verdict(
+    test_evidences: list[TestExecutionEvidence], framework: str
+) -> ExecutionVerdict:
+    """Aggregate per-command evidence into a run-level verdict.
+
+    Returns:
+        - ``NOT_RUN`` — no test evidence recorded for the run.
+        - ``INCONCLUSIVE`` — evidence exists but no HIGH/MEDIUM-confidence
+          signal (all generic/LOW), or some test command could not be parsed
+          while the rest passed. The gate falls back to the heuristic.
+        - ``FAILED`` — at least one HIGH/MEDIUM command failed and no later
+          passing superset covers it.
+        - ``PASSED`` — every HIGH/MEDIUM command passed (or its failure was
+          covered by a later passing superset) and no unparseable command
+          leaves the run unconfirmable.
+
+    ``framework`` is the project-level framework hint (``_infer_test_framework``);
+    it gates whether pytest superset coverage applies. Non-pytest frameworks
+    never cross-cover — only an exact retry of the same command clears a failure.
+    """
+    if not test_evidences:
+        return ExecutionVerdict.NOT_RUN
+
+    has_low = any(e.parser_confidence == ParserConfidence.LOW.value for e in test_evidences)
+    authoritative = [
+        (index, evidence)
+        for index, evidence in enumerate(test_evidences)
+        if evidence.parser_confidence in _AUTHORITATIVE
+    ]
+
+    if not authoritative:
+        # Every test command was generic/LOW — cannot authoritatively judge.
+        return ExecutionVerdict.INCONCLUSIVE
+
+    if _has_uncovered_failure(authoritative, framework):
+        return ExecutionVerdict.FAILED
+
+    if has_low:
+        # No uncovered HIGH/MEDIUM failure, but at least one command was
+        # unparseable (LOW). The structured layer cannot confirm it passed,
+        # so the run is not yet authoritative-PASSED — fall back to heuristic.
+        return ExecutionVerdict.INCONCLUSIVE
+
+    return ExecutionVerdict.PASSED

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -13,7 +13,6 @@ import logging
 import os
 import pwd
 import re
-import shlex
 import shutil
 import subprocess
 import sys
@@ -32,6 +31,14 @@ from app.modules.workspace.autonomous.artifact_text import (
     sanitize_artifact_text,
 )
 from app.modules.workspace.autonomous.command_evidence.recorder import emit_command_evidence
+from app.modules.workspace.autonomous.command_evidence.scope import (  # noqa: E402,F401; Re-imported for the legacy heuristic (_has_passing_test_tool_result) and; any in-module callers; the structured verdict (test_verdict) imports them; directly from scope to avoid a circular import (#2046 Phase B).
+    _TEST_OUTPUT_FILTER_RE,
+    _normalize_test_command,
+    _pytest_scope_covers,
+    _pytest_test_scope,
+    _PytestScope,
+)
+from app.modules.workspace.autonomous.command_evidence.types import ExecutionVerdict
 from app.modules.workspace.autonomous.event_emitter import AutonomousEventEmitter
 from app.modules.workspace.autonomous.evidence import Verdict
 from app.modules.workspace.autonomous.evidence_service import EvidenceService
@@ -310,192 +317,6 @@ def _has_test_tool_call(tool_calls: list, framework_type: str) -> bool:
     return False
 
 
-_TEST_OUTPUT_FILTER_RE = re.compile(
-    r"(?:\s+2>\&1)?\s*\|\s*(?:head|tail)(?:\s+-[^\s]+|\s+\d+)*\s*$",
-    re.IGNORECASE,
-)
-
-
-def _normalize_test_command(command: str) -> str:
-    """Return a stable identity for a test command across output-only filters.
-
-    Autonomous agents commonly run ``pytest ... | head -100`` while exploring
-    a failure and rerun the same target as ``pytest ... | tail -20`` after the
-    fix.  Those filters change only which output is displayed, not the tests
-    executed.  Treating the two strings as distinct left the truncated first
-    run permanently inconclusive even when the later rerun passed.
-
-    Strip only trailing ``head``/``tail`` pipelines (and their adjacent stderr
-    merge).  Execution-affecting shell operators such as ``&&``/``||`` and
-    pytest selectors/options remain part of the identity.
-    """
-    normalized = " ".join(str(command or "").split())
-    while True:
-        stripped = _TEST_OUTPUT_FILTER_RE.sub("", normalized).strip()
-        if stripped == normalized:
-            break
-        normalized = stripped
-    return re.sub(r"\s+2>\&1\s*$", "", normalized).strip()
-
-
-_PytestScope = tuple[str, frozenset[str]]
-
-
-def _pytest_test_scope(command: str) -> _PytestScope | None:
-    """Return the pytest execution context and selectors when safely comparable.
-
-    ``None`` means the command is too complex for safe scope comparison.  An
-    empty selector set means a full-suite invocation.  This lets a later
-    passing superset rerun clear earlier failures for the same files while
-    ensuring a targeted pass or a different Python environment can never clear
-    a failed full-suite command.
-    """
-    normalized = _normalize_test_command(command)
-    if any(operator in normalized for operator in ("&&", "||", ";", "|")):
-        return None
-    try:
-        tokens = shlex.split(normalized)
-    except ValueError:
-        return None
-
-    pytest_index = -1
-    for index, token in enumerate(tokens):
-        if os.path.basename(token) in {"pytest", "py.test"}:
-            pytest_index = index
-            break
-    if pytest_index < 0:
-        return None
-
-    # Only compare scopes when the invocation prefix has ordinary pytest
-    # semantics.  Environment assignments and wrappers can change collection
-    # even when the visible selectors are identical.
-    prefix = tokens[:pytest_index]
-    if prefix:
-        python_name = os.path.basename(prefix[0])
-        if (
-            len(prefix) != 2
-            or prefix[1] != "-m"
-            or re.fullmatch(r"python(?:\d+(?:\.\d+)*)?", python_name) is None
-        ):
-            return None
-        execution_context = f"{prefix[0]} -m {tokens[pytest_index]}"
-    else:
-        execution_context = tokens[pytest_index]
-
-    scope_narrowing_options = {
-        "-k",
-        "-m",
-        "--ignore",
-        "--ignore-glob",
-        "--deselect",
-        "--lf",
-        "--last-failed",
-        "--ff",
-        "--failed-first",
-        "--nf",
-        "--new-first",
-        "--sw",
-        "--stepwise",
-        "--stepwise-skip",
-    }
-    safe_flags = {
-        "-q",
-        "--quiet",
-        "-v",
-        "-vv",
-        "--verbose",
-        "-s",
-        "-x",
-        "--exitfirst",
-        "--disable-warnings",
-        "--strict-config",
-        "--strict-markers",
-        "--continue-on-collection-errors",
-        "--full-trace",
-        "--showlocals",
-        "-l",
-        "--no-header",
-        "--no-summary",
-    }
-    safe_value_options = {
-        "--tb",
-        "--color",
-        "--capture",
-        "--durations",
-        "--durations-min",
-        "--junitxml",
-        "--junit-prefix",
-        "--basetemp",
-        "--verbosity",
-        "--maxfail",
-    }
-
-    selectors: set[str] = set()
-    args = tokens[pytest_index + 1 :]
-    index = 0
-    selectors_only = False
-    while index < len(args):
-        token = args[index]
-        if token == "--":
-            selectors_only = True
-            index += 1
-            continue
-        if not selectors_only and token.startswith("-"):
-            option_name = token.split("=", 1)[0]
-            if option_name in scope_narrowing_options:
-                return None
-            if token in safe_flags:
-                index += 1
-                continue
-            if option_name in safe_value_options:
-                if "=" not in token:
-                    index += 1
-                    if index >= len(args):
-                        return None
-                index += 1
-                continue
-            # Plugin and future pytest options are unknown here.  Exact-command
-            # retries remain supported, but cross-command scope coverage is not.
-            return None
-        selectors.add(token.rstrip("/") or ".")
-        index += 1
-
-    return execution_context, frozenset(selectors)
-
-
-def _pytest_scope_covers(
-    passing_scope: _PytestScope | None,
-    earlier_scope: _PytestScope | None,
-) -> bool:
-    """Whether a passing pytest command covers an earlier command's scope."""
-    if passing_scope is None or earlier_scope is None:
-        return False
-    passing_context, passing_selectors = passing_scope
-    earlier_context, earlier_selectors = earlier_scope
-    if passing_context != earlier_context:
-        return False
-    if not passing_selectors:
-        return True
-    if not earlier_selectors:
-        return False
-
-    def _selector_covers(passing: str, earlier: str) -> bool:
-        if passing == earlier:
-            return True
-        if passing in {".", "./"}:
-            return True
-        passing_path = passing.split("::", 1)[0].rstrip("/")
-        earlier_path = earlier.split("::", 1)[0].rstrip("/")
-        if "::" not in passing and passing_path == earlier_path:
-            return True
-        return "::" not in passing and earlier_path.startswith(f"{passing_path}/")
-
-    return all(
-        any(_selector_covers(passing, earlier) for passing in passing_selectors)
-        for earlier in earlier_selectors
-    )
-
-
 def _has_passing_test_tool_result(event_log: list, framework_type: str) -> bool:
     """Require conclusive success for every distinct test command in this run.
 
@@ -503,6 +324,12 @@ def _has_passing_test_tool_result(event_log: list, framework_type: str) -> bool:
     reruns the same normalized command or a safely comparable pytest superset.
     Every new invocation resets its command to pending, so stale success from
     before a code change cannot satisfy an interrupted rerun.
+
+    #2046 Phase B — NON-AUTHORITATIVE FALLBACK: the gate now drives
+    PASSED/FAILED from ``compute_run_verdict`` over ``TestExecutionEvidence``.
+    This heuristic is retained only as the INCONCLUSIVE/NOT_RUN fallback (when
+    ``structured_verdict`` deferred). Do not extend it as a source of truth;
+    new frameworks belong in ``test_evidence.parse_test_evidence``.
     """
     _CommandInfo = tuple[str, _PytestScope | None]
     _Invocation = tuple[_CommandInfo, int]
@@ -4498,36 +4325,55 @@ class AutonomousOrchestrator:
         test_result: AgentTaskResult,
         milestone_id: str,
         heuristic_passed: bool,
+        structured_verdict: ExecutionVerdict | None = None,
     ) -> None:
         """Compare the heuristic test verdict against structured evidence (#2046).
 
-        Phase A shadow comparison: persists a ``workflow_events`` row + warning
-        when the structured verdict (derived purely from
-        ``CommandExecutionEvidence`` rows) disagrees with the heuristic
-        verdict. Does NOT influence the gate — the heuristic stays
-        authoritative until #2022 lands (Phase B).
+        Two divergence layers are recorded as ``evidence_shadow_divergence``
+        workflow events:
+
+        - Command-level (Phase A): ``compare_verdicts`` over
+          ``CommandExecutionEvidence`` rows — whether every recorded command
+          passed. Catches missing evidence (a heuristic pass with no commands).
+        - Run-level (Phase B): the structured ``ExecutionVerdict`` (from
+          ``compute_run_verdict`` over ``TestExecutionEvidence``) vs the
+          heuristic. This verdict now drives the gate; divergence here is the
+          signal for whether the heuristic fallback (#2046 §4) can be retired.
         """
         try:
+            import json
+
             from app.modules.workspace.autonomous.command_evidence.recorder import (
                 compare_verdicts,
                 get_command_evidence_recorder,
             )
 
             recorder = get_command_evidence_recorder()
-            if recorder.is_noop:
-                return
-            recorder.flush(timeout=1.0)
-            repo = recorder.repo
-            session_id = test_result.session_id or test_result.tracking_session_id or ""
-            if not session_id:
-                return
-            evidence_rows = repo.query_by_session(session_id)
+            evidence_rows = []
+            if not recorder.is_noop:
+                recorder.flush(timeout=1.0)
+                session_id = test_result.session_id or test_result.tracking_session_id or ""
+                if session_id:
+                    evidence_rows = recorder.repo.query_by_session(session_id)
             comparison = compare_verdicts(
                 heuristic_passed=heuristic_passed, evidence_rows=evidence_rows
             )
-            if not comparison.get("divergence"):
+
+            structured_value = (
+                structured_verdict.value
+                if structured_verdict is not None
+                else comparison.get("structured_verdict")
+            )
+            # Run-level divergence: structured PASSED/FAILED disagrees with the
+            # heuristic. NOT_RUN/INCONCLUSIVE means the structured layer deferred
+            # — only a divergence if the heuristic nonetheless claimed a pass.
+            structured_pass = structured_value == ExecutionVerdict.PASSED.value
+            run_level_divergence = (
+                structured_verdict is not None and structured_pass != heuristic_passed
+            )
+
+            if not comparison.get("divergence") and not run_level_divergence:
                 return
-            import json
 
             self.repo.create_event(
                 {
@@ -4537,23 +4383,140 @@ class AutonomousOrchestrator:
                     "event_data": json.dumps(
                         {
                             "heuristic_verdict": comparison.get("heuristic_verdict"),
-                            "structured_verdict": comparison.get("structured_verdict"),
+                            "structured_command_verdict": comparison.get("structured_verdict"),
+                            "structured_run_verdict": structured_value,
                             "reason": comparison.get("reason"),
                             "command_verdicts": comparison.get("command_verdicts", []),
                             "evidence_count": len(evidence_rows),
-                        }
+                        },
+                        ensure_ascii=False,
                     ),
                 }
             )
             logger.warning(
-                "evidence shadow divergence for %s: heuristic=%s structured=%s (%s)",
+                "evidence shadow divergence for %s: heuristic=%s structured_run=%s (%s)",
                 self._workflow_id,
                 comparison.get("heuristic_verdict"),
-                comparison.get("structured_verdict"),
+                structured_value,
                 comparison.get("reason", ""),
             )
         except Exception as e:
             logger.debug("evidence shadow comparison failed: %s", e)
+
+    def _compute_structured_test_verdict(
+        self,
+        test_result: AgentTaskResult,
+        framework_type: str,
+        test_ms: dict,
+    ) -> tuple[ExecutionVerdict, list, str]:
+        """Parse command evidence into TestExecutionEvidence and compute the run verdict.
+
+        #2046 Phase B authoritative path: reads the ``CommandExecutionEvidence``
+        rows dual-written in Phase A, parses each test command's output into a
+        ``TestExecutionEvidence`` row (persisted), and aggregates them via
+        ``compute_run_verdict``. Returns ``(verdict, evidences, reason)``.
+
+        Best-effort: any failure returns ``NOT_RUN`` with a reason so the gate
+        falls back to the legacy heuristic — the structured layer never raises
+        into the gate path.
+        """
+        try:
+            from app.modules.workspace.autonomous.command_evidence.recorder import (
+                get_command_evidence_recorder,
+            )
+            from app.modules.workspace.autonomous.command_evidence.test_evidence import (
+                parse_test_evidence,
+            )
+            from app.modules.workspace.autonomous.command_evidence.test_verdict import (
+                compute_run_verdict,
+            )
+            from app.repositories.command_evidence_repo import CommandExecutionEvidenceRepository
+            from app.repositories.test_evidence_repo import TestExecutionEvidenceRepository
+
+            recorder = get_command_evidence_recorder()
+            if not recorder.is_noop:
+                recorder.flush(timeout=1.0)
+
+            session_id = test_result.session_id or test_result.tracking_session_id or ""
+            if not session_id:
+                return ExecutionVerdict.NOT_RUN, [], "no session id on test result"
+
+            command_evidences = CommandExecutionEvidenceRepository().query_by_session(session_id)
+            if not command_evidences:
+                return ExecutionVerdict.NOT_RUN, [], "no command execution evidence"
+
+            # Only parse commands that look like test invocations; an ``echo``
+            # or ``ls`` must not be fed to the generic parser as if it were a
+            # test run (#2046 — agent prose / non-test commands cannot judge).
+            test_command_evidences = [
+                ce
+                for ce in command_evidences
+                if _has_test_tool_call(
+                    [
+                        {
+                            "tool": {
+                                "name": ce.tool_name or "",
+                                "input": {"command": ce.shell_command or ""},
+                            }
+                        }
+                    ],
+                    framework_type,
+                )
+            ]
+            if not test_command_evidences:
+                return ExecutionVerdict.NOT_RUN, [], "no test command evidence"
+
+            test_repo = TestExecutionEvidenceRepository()
+            test_evidences: list = []
+            for command_evidence in test_command_evidences:
+                parsed = parse_test_evidence(command_evidence, framework_hint=framework_type)
+                test_repo.upsert(parsed)
+                test_evidences.append(parsed)
+
+            verdict = compute_run_verdict(test_evidences, framework_type)
+            return verdict, test_evidences, f"parsed {len(test_evidences)} test command(s)"
+        except Exception as e:
+            logger.debug("structured test verdict computation failed: %s", e)
+            return ExecutionVerdict.NOT_RUN, [], f"compute failed: {e}"
+
+    def _emit_structured_test_fallback(
+        self,
+        verdict: ExecutionVerdict,
+        reason: str,
+        milestone_id: str,
+    ) -> None:
+        """Record that the structured verdict deferred to the heuristic.
+
+        Emitted whenever ``compute_run_verdict`` returns NOT_RUN/INCONCLUSIVE
+        and the gate falls back to ``_has_passing_test_tool_result`` (#2046 §4
+        降级). Tracked so parser coverage gaps are visible and the fallback can
+        be retired once shadow data proves the structured layer is sufficient.
+        """
+        try:
+            import json
+
+            self.repo.create_event(
+                {
+                    "workflow_id": self._workflow_id,
+                    "milestone_id": milestone_id,
+                    "event_type": "structured_test_fallback",
+                    "event_data": json.dumps(
+                        {
+                            "structured_verdict": verdict.value,
+                            "reason": reason,
+                        },
+                        ensure_ascii=False,
+                    ),
+                }
+            )
+            logger.info(
+                "structured test verdict deferred to heuristic for %s: verdict=%s (%s)",
+                self._workflow_id,
+                verdict.value,
+                reason,
+            )
+        except Exception as e:
+            logger.debug("structured fallback event emit failed: %s", e)
 
     def _on_pid_registered(self, session_id: str, pid: int):
         """Persist agent subprocess PID to database for reliable cancel/pause."""
@@ -7823,22 +7786,47 @@ class AutonomousOrchestrator:
         has_text_pass_evidence = has_test_result and bool(
             re.search(r"\b[1-9]\d*\s+passed\b", test_response_text, re.IGNORECASE)
         )
-        tests_actually_run = has_passing_tool_result or (
-            has_test_tool_call and has_text_pass_evidence
+        # #2046 Phase B: structured evidence is authoritative for PASSED/FAILED;
+        # the legacy heuristic stays as the INCONCLUSIVE/NOT_RUN fallback
+        # (#2046 §4 降级). Agent prose / TEST_STATUS can no longer promote a
+        # run to PASSED on its own (#1967 invariant).
+        structured_verdict, _structured_evidences, structured_reason = (
+            self._compute_structured_test_verdict(test_result, framework_type, test_ms)
         )
+        structured_authoritative = structured_verdict in (
+            ExecutionVerdict.PASSED,
+            ExecutionVerdict.FAILED,
+        )
+        if structured_verdict == ExecutionVerdict.PASSED:
+            tests_actually_run = True
+        elif structured_verdict == ExecutionVerdict.FAILED:
+            tests_actually_run = False
+        else:  # NOT_RUN / INCONCLUSIVE — fall back to the legacy heuristic.
+            tests_actually_run = has_passing_tool_result or (
+                has_test_tool_call and has_text_pass_evidence
+            )
+            self._emit_structured_test_fallback(
+                structured_verdict, structured_reason, test_ms.get("milestone_id", "")
+            )
+        # test_result_inconclusive only applies when the structured layer could
+        # not judge authoritatively; a structured FAILED is a real failure,
+        # not an inconclusive run.
         test_result_inconclusive = (
-            test_result.success
+            not structured_authoritative
+            and test_result.success
             and (has_test_tool_call or has_test_result or test_status_tag in ("passed", "failed"))
             and not tests_actually_run
         )
 
-        # #2046 Phase A shadow comparison: compare the heuristic verdict against
-        # structured CommandExecutionEvidence. Records divergence but does NOT
-        # influence the verdict (Phase B migrates the gate to evidence).
+        # #2046 shadow comparison: record divergence between the structured
+        # test verdict and the heuristic. Phase A compared at command level;
+        # Phase B compares the run-level verdict that now drives the gate.
         self._shadow_compare_evidence(
             test_result=test_result,
             milestone_id=test_ms.get("milestone_id", ""),
-            heuristic_passed=tests_actually_run,
+            heuristic_passed=has_passing_tool_result
+            or (has_test_tool_call and has_text_pass_evidence),
+            structured_verdict=structured_verdict,
         )
 
         # Issue #1547: Validate test report format
@@ -7846,7 +7834,10 @@ class AutonomousOrchestrator:
         format_valid, format_reason = self._validate_test_report_format(test_response_text)
         has_non_standard_format = not format_valid and tests_actually_run
 
-        tests_actually_skipped = (
+        # A structured PASSED/FAILED means tests really ran (and passed or
+        # failed) — that is never a "skipped" outcome. Skip detection only
+        # applies when the structured layer deferred to the heuristic.
+        tests_actually_skipped = not structured_authoritative and (
             test_status_tag == "skipped"
             or has_skip_tag
             or (test_result.success and has_skip_keyword and not tests_actually_run)

--- a/app/repositories/test_evidence_repo.py
+++ b/app/repositories/test_evidence_repo.py
@@ -1,0 +1,192 @@
+# mypy: disable-error-code="return-value,arg-type"
+"""Open ACE - Test Execution Evidence Repository (#2046 Phase B).
+
+Cross-database (SQLite + PostgreSQL) persistence for
+``test_execution_evidence``. Mirrors the ``command_evidence_repo`` pattern:
+``?`` placeholders via ``adapt_sql``, ``RETURNING id`` on Postgres /
+``lastrowid`` on SQLite. The ``(session_id, command_id)`` UNIQUE constraint
+makes ``upsert`` idempotent — a re-parse of the same command overwrites the
+prior verdict in place.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+
+from app.modules.workspace.autonomous.command_evidence.test_evidence import TestExecutionEvidence
+from app.repositories.database import Database, is_postgresql
+
+logger = logging.getLogger(__name__)
+
+
+class TestExecutionEvidenceRepository:
+    """Repository for the ``test_execution_evidence`` table."""
+
+    __test__ = False  # pytest: this is a repository class, not a test class
+
+    def __init__(self, db: Database | None = None):
+        self.db = db or Database()
+
+    def upsert(self, evidence: TestExecutionEvidence) -> int | None:
+        """Insert or update by ``(session_id, command_id)``; return the row id.
+
+        On conflict every parsed field (framework, counts, selectors,
+        coverage scope, parser, confidence, verdict) is overwritten, so a
+        re-parse after more output arrived replaces the prior verdict.
+        ``command_execution_id`` is refreshed to point at the latest matching
+        ``command_execution_evidence`` row.
+        """
+        selectors_json = json.dumps(evidence.selectors) if evidence.selectors else None
+        scope_json = json.dumps(evidence.coverage_scope) if evidence.coverage_scope else None
+        now = datetime.now(timezone.utc)
+
+        if is_postgresql():
+            return self._upsert_postgres(evidence, selectors_json, scope_json, now)
+        return self._upsert_sqlite(evidence, selectors_json, scope_json, now)
+
+    def _upsert_sqlite(
+        self,
+        evidence: TestExecutionEvidence,
+        selectors_json: str | None,
+        scope_json: str | None,
+        now: datetime,
+    ) -> int | None:
+        existing = self._fetch_by_session_command(evidence.session_id, evidence.command_id)
+        if existing is None:
+            insert_sql = """
+                INSERT INTO test_execution_evidence
+                    (command_id, command_execution_id, framework, collected,
+                     passed, failed, skipped, errors, selectors, coverage_scope,
+                     parser, parser_confidence, verdict, session_id, workflow_id,
+                     milestone_id, tenant_id, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """
+            params = self._insert_params(evidence, selectors_json, scope_json, now)
+            cursor = self.db.execute(insert_sql, params)
+            return getattr(cursor, "lastrowid", None)
+
+        self.db.execute(
+            self._update_sql(), self._update_params(evidence, selectors_json, scope_json)
+        )
+        return existing.id
+
+    def _upsert_postgres(
+        self,
+        evidence: TestExecutionEvidence,
+        selectors_json: str | None,
+        scope_json: str | None,
+        now: datetime,
+    ) -> int | None:
+        existing = self._fetch_by_session_command(evidence.session_id, evidence.command_id)
+        if existing is None:
+            insert_sql = """
+                INSERT INTO test_execution_evidence
+                    (command_id, command_execution_id, framework, collected,
+                     passed, failed, skipped, errors, selectors, coverage_scope,
+                     parser, parser_confidence, verdict, session_id, workflow_id,
+                     milestone_id, tenant_id, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                RETURNING id
+                """
+            params = self._insert_params(evidence, selectors_json, scope_json, now)
+            row = self.db.fetch_one(insert_sql, params, commit=True)
+            return row["id"] if row else None
+
+        self.db.execute(
+            self._update_sql(), self._update_params(evidence, selectors_json, scope_json)
+        )
+        return existing.id
+
+    def _fetch_by_session_command(
+        self, session_id: str, command_id: str
+    ) -> TestExecutionEvidence | None:
+        if not session_id or not command_id:
+            return None
+        row = self.db.fetch_one(
+            "SELECT * FROM test_execution_evidence WHERE session_id = ? AND command_id = ?",
+            (session_id, command_id),
+        )
+        return TestExecutionEvidence.from_row(row) if row else None
+
+    def query_by_session(self, session_id: str) -> list[TestExecutionEvidence]:
+        """Return all test evidence rows for a session in insertion (id) order."""
+        rows = self.db.fetch_all(
+            "SELECT * FROM test_execution_evidence WHERE session_id = ? ORDER BY id ASC",
+            (session_id,),
+        )
+        return [TestExecutionEvidence.from_row(r) for r in rows]
+
+    def query_by_milestone(
+        self, workflow_id: str, milestone_id: str
+    ) -> list[TestExecutionEvidence]:
+        """Return all test evidence rows for a workflow milestone in id order."""
+        rows = self.db.fetch_all(
+            "SELECT * FROM test_execution_evidence "
+            "WHERE workflow_id = ? AND milestone_id = ? ORDER BY id ASC",
+            (workflow_id, milestone_id),
+        )
+        return [TestExecutionEvidence.from_row(r) for r in rows]
+
+    @staticmethod
+    def _insert_params(
+        evidence: TestExecutionEvidence,
+        selectors_json: str | None,
+        scope_json: str | None,
+        now: datetime,
+    ) -> tuple:
+        return (
+            evidence.command_id,
+            evidence.command_execution_id,
+            evidence.framework,
+            evidence.collected,
+            evidence.passed,
+            evidence.failed,
+            evidence.skipped,
+            evidence.errors,
+            selectors_json,
+            scope_json,
+            evidence.parser,
+            evidence.parser_confidence,
+            evidence.verdict,
+            evidence.session_id,
+            evidence.workflow_id,
+            evidence.milestone_id,
+            evidence.tenant_id,
+            now,
+        )
+
+    @staticmethod
+    def _update_sql() -> str:
+        return """
+            UPDATE test_execution_evidence
+               SET command_execution_id = ?, framework = ?, collected = ?,
+                   passed = ?, failed = ?, skipped = ?, errors = ?,
+                   selectors = ?, coverage_scope = ?, parser = ?,
+                   parser_confidence = ?, verdict = ?
+             WHERE session_id = ? AND command_id = ?
+            """
+
+    @staticmethod
+    def _update_params(
+        evidence: TestExecutionEvidence,
+        selectors_json: str | None,
+        scope_json: str | None,
+    ) -> tuple:
+        return (
+            evidence.command_execution_id,
+            evidence.framework,
+            evidence.collected,
+            evidence.passed,
+            evidence.failed,
+            evidence.skipped,
+            evidence.errors,
+            selectors_json,
+            scope_json,
+            evidence.parser,
+            evidence.parser_confidence,
+            evidence.verdict,
+            evidence.session_id,
+            evidence.command_id,
+        )

--- a/migrations/versions/20260727_001_add_test_execution_evidence.py
+++ b/migrations/versions/20260727_001_add_test_execution_evidence.py
@@ -1,0 +1,87 @@
+"""add test execution evidence
+
+Revision ID: 20260727_001_add_test_execution_evidence
+Revises: 20260727_007_add_sandbox_remote_session_id
+Create Date: 2026-07-27
+
+Adds ``test_execution_evidence`` — the structured per-command test verdict
+for autonomous workflows (#2046 Phase B). Pairs 1:1 with a
+``command_execution_evidence`` row via ``command_execution_id`` (the row PK)
+and shares its ``(session_id, command_id)`` UNIQUE identity.
+
+A pluggable parser (pytest/jest/go/cargo/generic) reads the command evidence
+``output_excerpt`` + ``exit_code`` and writes one ``test_execution_evidence``
+row: framework, collected/passed/failed counts, selectors, parser confidence,
+and an authoritative per-command ``verdict``. The run-level verdict is
+computed in code (``test_verdict.compute_run_verdict``); this table is the
+persisted audit trail and the input to shadow comparison.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import sqlalchemy as sa
+from alembic import op
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+revision: str = "20260727_001_add_test_execution_evidence"
+down_revision: str | None = "20260727_007_add_sandbox_remote_session_id"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create the test_execution_evidence table and indexes."""
+    connection = op.get_bind()
+    inspector = sa.inspect(connection)
+    existing_tables = set(inspector.get_table_names())
+
+    if "test_execution_evidence" not in existing_tables:
+        op.create_table(
+            "test_execution_evidence",
+            sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
+            sa.Column("command_id", sa.Text, nullable=False),
+            sa.Column("command_execution_id", sa.Integer, nullable=True),
+            sa.Column("framework", sa.Text, nullable=False, server_default=""),
+            sa.Column("collected", sa.Integer),
+            sa.Column("passed", sa.Integer),
+            sa.Column("failed", sa.Integer),
+            sa.Column("skipped", sa.Integer),
+            sa.Column("errors", sa.Integer),
+            sa.Column("selectors", sa.Text),
+            sa.Column("coverage_scope", sa.Text),
+            sa.Column("parser", sa.Text, nullable=False, server_default=""),
+            sa.Column("parser_confidence", sa.Text, nullable=False, server_default=""),
+            sa.Column("verdict", sa.Text, nullable=False, server_default=""),
+            sa.Column("session_id", sa.Text, nullable=False, server_default=""),
+            sa.Column("workflow_id", sa.Text, nullable=False, server_default=""),
+            sa.Column("milestone_id", sa.Text, nullable=False, server_default=""),
+            sa.Column("tenant_id", sa.Integer, nullable=False, server_default="1"),
+            sa.Column("created_at", sa.TIMESTAMP, server_default=sa.text("CURRENT_TIMESTAMP")),
+            sa.UniqueConstraint(
+                "session_id", "command_id", name="uq_test_evidence_session_command"
+            ),
+            sa.ForeignKeyConstraint(
+                ["command_execution_id"],
+                ["command_execution_evidence.id"],
+                name="fk_test_evidence_command_execution",
+            ),
+        )
+        op.create_index(
+            "idx_test_evidence_session_command",
+            "test_execution_evidence",
+            ["session_id", "command_id"],
+        )
+        op.create_index(
+            "idx_test_evidence_workflow_milestone",
+            "test_execution_evidence",
+            ["workflow_id", "milestone_id"],
+        )
+
+
+def downgrade() -> None:
+    """Drop the test_execution_evidence table."""
+    op.drop_table("test_execution_evidence")

--- a/schema/schema-postgres.sql
+++ b/schema/schema-postgres.sql
@@ -1615,6 +1615,37 @@ CREATE SEQUENCE tenants_id_seq
     CACHE 1;
 
 ALTER SEQUENCE tenants_id_seq OWNED BY tenants.id;
+CREATE TABLE test_execution_evidence (
+    id integer NOT NULL,
+    command_id text NOT NULL,
+    command_execution_id integer,
+    framework text DEFAULT ''::text NOT NULL,
+    collected integer,
+    passed integer,
+    failed integer,
+    skipped integer,
+    errors integer,
+    selectors text,
+    coverage_scope text,
+    parser text DEFAULT ''::text NOT NULL,
+    parser_confidence text DEFAULT ''::text NOT NULL,
+    verdict text DEFAULT ''::text NOT NULL,
+    session_id text DEFAULT ''::text NOT NULL,
+    workflow_id text DEFAULT ''::text NOT NULL,
+    milestone_id text DEFAULT ''::text NOT NULL,
+    tenant_id integer DEFAULT 1 NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE SEQUENCE test_execution_evidence_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+ALTER SEQUENCE test_execution_evidence_id_seq OWNED BY test_execution_evidence.id;
 CREATE TABLE tool_account_mapping_rules (
     id integer NOT NULL,
     user_id integer NOT NULL,
@@ -2003,6 +2034,8 @@ ALTER TABLE ONLY tenant_usage ALTER COLUMN id SET DEFAULT nextval('tenant_usage_
 
 ALTER TABLE ONLY tenants ALTER COLUMN id SET DEFAULT nextval('tenants_id_seq'::regclass);
 
+ALTER TABLE ONLY test_execution_evidence ALTER COLUMN id SET DEFAULT nextval('test_execution_evidence_id_seq'::regclass);
+
 ALTER TABLE ONLY tool_account_mapping_rules ALTER COLUMN id SET DEFAULT nextval('tool_account_mapping_rules_id_seq'::regclass);
 
 ALTER TABLE ONLY user_daily_stats ALTER COLUMN id SET DEFAULT nextval('user_daily_stats_id_seq'::regclass);
@@ -2296,6 +2329,9 @@ ALTER TABLE ONLY tenants
 ALTER TABLE ONLY tenants
     ADD CONSTRAINT tenants_slug_key UNIQUE (slug);
 
+ALTER TABLE ONLY test_execution_evidence
+    ADD CONSTRAINT test_execution_evidence_pkey PRIMARY KEY (id);
+
 ALTER TABLE ONLY tool_account_mapping_rules
     ADD CONSTRAINT tool_account_mapping_rules_pkey PRIMARY KEY (id);
 
@@ -2328,6 +2364,9 @@ ALTER TABLE ONLY smtp_settings
 
 ALTER TABLE ONLY tenant_usage
     ADD CONSTRAINT uq_tenant_usage_tenant_date_new UNIQUE (tenant_id, date);
+
+ALTER TABLE ONLY test_execution_evidence
+    ADD CONSTRAINT uq_test_evidence_session_command UNIQUE (session_id, command_id);
 
 ALTER TABLE ONLY usage_summary
     ADD CONSTRAINT uq_usage_summary_tool_host UNIQUE (tool_name, host_name);
@@ -3039,6 +3078,14 @@ CREATE INDEX idx_tenants_slug ON tenants USING btree (slug);
 
 CREATE INDEX idx_tenants_status ON tenants USING btree (status);
 
+CREATE INDEX idx_test_evidence_session_command ON test_execution_evidence USING btree (session_id, command_id);
+
+
+--
+--
+
+CREATE INDEX idx_test_evidence_workflow_milestone ON test_execution_evidence USING btree (workflow_id, milestone_id);
+
 CREATE INDEX idx_tool_accounts_tool_account ON user_tool_accounts USING btree (tool_account);
 
 
@@ -3198,6 +3245,9 @@ ALTER TABLE ONLY autonomous_workflows
 
 ALTER TABLE ONLY consistency_violations
     ADD CONSTRAINT consistency_violations_tenant_id_fkey FOREIGN KEY (tenant_id) REFERENCES tenants(id) ON DELETE CASCADE;
+
+ALTER TABLE ONLY test_execution_evidence
+    ADD CONSTRAINT fk_test_evidence_command_execution FOREIGN KEY (command_execution_id) REFERENCES command_execution_evidence(id);
 
 ALTER TABLE ONLY user_daily_stats
     ADD CONSTRAINT fk_user_daily_stats_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE;

--- a/schema/schema-sqlite.sql
+++ b/schema/schema-sqlite.sql
@@ -1025,6 +1025,28 @@ CREATE TABLE tenants (
     CONSTRAINT chk_tenants_status CHECK (status IN ('active', 'suspended', 'trial', 'inactive'))
 );
 
+CREATE TABLE test_execution_evidence (
+ id INTEGER PRIMARY KEY AUTOINCREMENT,
+ command_id text NOT NULL,
+ command_execution_id integer,
+ framework text DEFAULT '' NOT NULL,
+ collected integer,
+ passed integer,
+ failed integer,
+ skipped integer,
+ errors integer,
+ selectors text,
+ coverage_scope text,
+ parser text DEFAULT '' NOT NULL,
+ parser_confidence text DEFAULT '' NOT NULL,
+ verdict text DEFAULT '' NOT NULL,
+ session_id text DEFAULT '' NOT NULL,
+ workflow_id text DEFAULT '' NOT NULL,
+ milestone_id text DEFAULT '' NOT NULL,
+ tenant_id integer DEFAULT 1 NOT NULL,
+ created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
 CREATE TABLE tool_account_mapping_rules (
  id INTEGER PRIMARY KEY AUTOINCREMENT,
  user_id integer NOT NULL,
@@ -1292,6 +1314,8 @@ CREATE UNIQUE INDEX uq_quota_usage_user_date_period_new ON quota_usage (user_id,
 CREATE UNIQUE INDEX uq_remote_runtime_outputs_session_index ON remote_runtime_outputs (session_id, event_index);
 
 CREATE UNIQUE INDEX uq_tenant_usage_tenant_date_new ON tenant_usage (tenant_id, date);
+
+CREATE UNIQUE INDEX uq_test_evidence_session_command ON test_execution_evidence (session_id, command_id);
 
 CREATE UNIQUE INDEX uq_usage_summary_tool_host ON usage_summary (tool_name, host_name);
 
@@ -1628,6 +1652,10 @@ CREATE INDEX idx_tenants_deleted ON tenants (deleted_at);
 CREATE INDEX idx_tenants_slug ON tenants (slug);
 
 CREATE INDEX idx_tenants_status ON tenants (status);
+
+CREATE INDEX idx_test_evidence_session_command ON test_execution_evidence (session_id, command_id);
+
+CREATE INDEX idx_test_evidence_workflow_milestone ON test_execution_evidence (workflow_id, milestone_id);
 
 CREATE INDEX idx_tool_accounts_tool_account ON user_tool_accounts (tool_account);
 

--- a/tests/integration/test_test_evidence_repo.py
+++ b/tests/integration/test_test_evidence_repo.py
@@ -1,0 +1,138 @@
+"""Persistence contract tests for TestExecutionEvidence (#2046 Phase B).
+
+Exercises the real SQLite ``test_execution_evidence`` table via the ``tmp_db``
+fixture (authoritative schema), mirroring ``test_command_evidence_repo``:
+upsert idempotency by ``(session_id, command_id)``, JSON selectors/coverage
+scope round-trip, and query ordering.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.modules.workspace.autonomous.command_evidence.test_evidence import (
+    ParserConfidence,
+    TestExecutionEvidence,
+    parse_test_evidence,
+)
+from app.modules.workspace.autonomous.command_evidence.types import (
+    CommandExecutionEvidence,
+    ExecutionVerdict,
+)
+from app.repositories.test_evidence_repo import TestExecutionEvidenceRepository
+
+
+@pytest.fixture
+def repo(tmp_db):
+    return TestExecutionEvidenceRepository(db=tmp_db)
+
+
+def _te(command_id: str = "c1", **kwargs) -> TestExecutionEvidence:
+    base = {
+        "command_id": command_id,
+        "session_id": "sess-1",
+        "workflow_id": "wf-1",
+        "milestone_id": "ms-1",
+        "framework": "python",
+        "passed": 3,
+        "failed": None,
+        "verdict": ExecutionVerdict.PASSED.value,
+        "parser": "pytest",
+        "parser_confidence": ParserConfidence.HIGH.value,
+        "selectors": ["tests/a.py"],
+        "coverage_scope": {"context": "python -m pytest", "selectors": ["tests/a.py"]},
+    }
+    base.update(kwargs)
+    return TestExecutionEvidence(**base)
+
+
+def test_upsert_insert_then_update_same_row(repo):
+    row_id = repo.upsert(_te("c1"))
+    assert row_id is not None
+    rows = repo.query_by_session("sess-1")
+    assert len(rows) == 1
+    assert rows[0].passed == 3
+
+    # Re-upsert with a different verdict → overwrites in place, no new row.
+    repo.upsert(_te("c1", passed=2, failed=1, verdict=ExecutionVerdict.FAILED.value))
+    rows = repo.query_by_session("sess-1")
+    assert len(rows) == 1
+    assert rows[0].failed == 1
+    assert rows[0].verdict == ExecutionVerdict.FAILED.value
+
+
+def test_upsert_distinct_commands_are_separate_rows(repo):
+    repo.upsert(_te("c1"))
+    repo.upsert(_te("c2", failed=1, passed=2, verdict=ExecutionVerdict.FAILED.value))
+    rows = repo.query_by_session("sess-1")
+    assert len(rows) == 2
+
+
+def test_query_by_session_returns_id_order(repo):
+    repo.upsert(_te("c1"))
+    repo.upsert(_te("c2"))
+    repo.upsert(_te("c3"))
+    rows = repo.query_by_session("sess-1")
+    assert [r.command_id for r in rows] == ["c1", "c2", "c3"]
+
+
+def test_query_by_milestone_filters(repo):
+    repo.upsert(_te("c1", milestone_id="ms-1"))
+    repo.upsert(_te("c2", milestone_id="ms-2"))
+    rows = repo.query_by_milestone("wf-1", "ms-1")
+    assert len(rows) == 1
+    assert rows[0].command_id == "c1"
+
+
+def test_from_row_decodes_json_selectors_and_scope(repo):
+    repo.upsert(
+        _te(
+            "c1",
+            selectors=["tests/a.py", "tests/b.py"],
+            coverage_scope={
+                "context": "python -m pytest",
+                "selectors": ["tests/a.py", "tests/b.py"],
+            },
+        )
+    )
+    rows = repo.query_by_session("sess-1")
+    assert rows[0].selectors == ["tests/a.py", "tests/b.py"]
+    assert rows[0].coverage_scope["context"] == "python -m pytest"
+    assert set(rows[0].coverage_scope["selectors"]) == {"tests/a.py", "tests/b.py"}
+
+
+def test_parse_then_upsert_roundtrip(repo):
+    ce = CommandExecutionEvidence(
+        command_id="c1",
+        session_id="sess-1",
+        workflow_id="wf-1",
+        milestone_id="ms-1",
+        tool_name="Bash",
+        shell_command="pytest tests/x.py",
+        exit_code=0,
+        output_excerpt="3 passed",
+    )
+    te = parse_test_evidence(ce, framework_hint="python")
+    repo.upsert(te)
+    rows = repo.query_by_session("sess-1")
+    assert len(rows) == 1
+    assert rows[0].verdict == ExecutionVerdict.PASSED.value
+    assert rows[0].passed == 3
+    assert rows[0].parser == "pytest"
+    assert rows[0].parser_confidence == ParserConfidence.HIGH.value
+
+
+def test_command_execution_id_persisted(repo):
+    te = _te("c1")
+    te.command_execution_id = 42
+    repo.upsert(te)
+    rows = repo.query_by_session("sess-1")
+    assert rows[0].command_execution_id == 42
+
+
+def test_to_dict_serializes_for_metadata():
+    te = _te("c1")
+    data = te.to_dict()
+    assert data["command_id"] == "c1"
+    assert data["verdict"] == ExecutionVerdict.PASSED.value
+    assert data["coverage_scope"]["context"] == "python -m pytest"

--- a/tests/issues/2046/test_phase_b_gate.py
+++ b/tests/issues/2046/test_phase_b_gate.py
@@ -1,0 +1,236 @@
+"""Phase B gate integration tests (#2046).
+
+Exercises the orchestrator methods that wire the structured test verdict into
+the gate: ``_compute_structured_test_verdict`` (parse + run verdict),
+``_emit_structured_test_fallback`` (INCONCLUSIVE/NOT_RUN fallback signal),
+and ``_shadow_compare_evidence`` with the new ``structured_verdict`` argument.
+
+These are method-level tests — the repos are mocked so the structured path is
+exercised without a full workflow run. The acceptance criterion is the #1967
+invariant: a structured FAILED/PASSED is authoritative and never re-derived
+from agent prose; INCONCLUSIVE/NOT_RUN defers to the heuristic.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from app.modules.workspace.autonomous.command_evidence.types import (
+    CommandExecutionEvidence,
+    ExecutionVerdict,
+)
+from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+_CMD_REPO = "app.repositories.command_evidence_repo.CommandExecutionEvidenceRepository"
+_TEST_REPO = "app.repositories.test_evidence_repo.TestExecutionEvidenceRepository"
+_RECORDER = (
+    "app.modules.workspace.autonomous.command_evidence.recorder.get_command_evidence_recorder"
+)
+
+
+def _orch() -> AutonomousOrchestrator:
+    """Build a bare orchestrator with the few attrs the gate methods touch."""
+    orch = AutonomousOrchestrator.__new__(AutonomousOrchestrator)
+    orch._workflow_id = "wf-test"
+    orch.repo = MagicMock()
+    return orch
+
+
+def _result(session_id: str = "sess-1") -> SimpleNamespace:
+    return SimpleNamespace(session_id=session_id, tracking_session_id=None)
+
+
+def _ce(
+    command_id: str, shell: str, exit_code: int | None, excerpt: str
+) -> CommandExecutionEvidence:
+    return CommandExecutionEvidence(
+        command_id=command_id,
+        session_id="sess-1",
+        tool_name="Bash",
+        shell_command=shell,
+        exit_code=exit_code,
+        output_excerpt=excerpt,
+    )
+
+
+def _patch_repos(command_evidences):
+    """Patch the recorder (noop) + command repo (returns evidences) + test repo."""
+    recorder_patch = patch(_RECORDER)
+    cmd_patch = patch(_CMD_REPO)
+    test_patch = patch(_TEST_REPO)
+    recorder_mock = recorder_patch.start()
+    cmd_mock = cmd_patch.start()
+    test_mock = test_patch.start()
+    recorder_mock.return_value.is_noop = True
+    cmd_mock.return_value.query_by_session.return_value = command_evidences
+    return recorder_patch, cmd_patch, test_patch, test_mock
+
+
+# ── _compute_structured_test_verdict ──────────────────────────────────────────
+
+
+def test_compute_verdict_passed_when_pytest_passes():
+    orch = _orch()
+    patches = _patch_repos([_ce("c1", "pytest", 0, "3 passed in 0.4s")])
+    try:
+        verdict, evidences, reason = orch._compute_structured_test_verdict(_result(), "python", {})
+    finally:
+        for p in patches[:3]:
+            p.stop()
+    assert verdict == ExecutionVerdict.PASSED
+    assert len(evidences) == 1
+    assert evidences[0].verdict == ExecutionVerdict.PASSED.value
+    patches[3].return_value.upsert.assert_called_once()
+
+
+def test_compute_verdict_failed_when_pytest_fails():
+    orch = _orch()
+    patches = _patch_repos([_ce("c1", "pytest tests/x.py", 1, "1 failed, 2 passed")])
+    try:
+        verdict, _, _ = orch._compute_structured_test_verdict(_result(), "python", {})
+    finally:
+        for p in patches[:3]:
+            p.stop()
+    assert verdict == ExecutionVerdict.FAILED
+
+
+def test_compute_verdict_not_run_when_no_command_evidence():
+    orch = _orch()
+    patches = _patch_repos([])
+    try:
+        verdict, evidences, reason = orch._compute_structured_test_verdict(_result(), "python", {})
+    finally:
+        for p in patches[:3]:
+            p.stop()
+    assert verdict == ExecutionVerdict.NOT_RUN
+    assert evidences == []
+    assert "no command execution evidence" in reason
+
+
+def test_compute_verdict_not_run_when_session_id_missing():
+    orch = _orch()
+    patches = _patch_repos([_ce("c1", "pytest", 0, "1 passed")])
+    try:
+        verdict, _, reason = orch._compute_structured_test_verdict(
+            _result(session_id=""), "python", {}
+        )
+    finally:
+        for p in patches[:3]:
+            p.stop()
+    assert verdict == ExecutionVerdict.NOT_RUN
+    assert "no session id" in reason
+
+
+def test_compute_verdict_filters_out_non_test_commands():
+    """An ``echo`` command must not be parsed as a test run (#2046)."""
+    orch = _orch()
+    patches = _patch_repos(
+        [
+            _ce("c1", "pytest", 0, "2 passed"),
+            _ce("c2", "echo hello", 0, "hello"),
+        ]
+    )
+    try:
+        verdict, evidences, _ = orch._compute_structured_test_verdict(_result(), "python", {})
+    finally:
+        for p in patches[:3]:
+            p.stop()
+    assert verdict == ExecutionVerdict.PASSED
+    assert len(evidences) == 1  # echo was filtered out
+    assert evidences[0].command_id == "c1"
+
+
+def test_compute_verdict_not_run_when_no_test_command_at_all():
+    """Only non-test commands → no test evidence → NOT_RUN (heuristic fallback)."""
+    orch = _orch()
+    patches = _patch_repos([_ce("c1", "echo hello", 0, "hello")])
+    try:
+        verdict, _, reason = orch._compute_structured_test_verdict(_result(), "python", {})
+    finally:
+        for p in patches[:3]:
+            p.stop()
+    assert verdict == ExecutionVerdict.NOT_RUN
+    assert "no test command evidence" in reason
+
+
+def test_compute_verdict_inconclusive_when_command_unparseable():
+    """A test command whose output could not be parsed (no exit code, no
+    summary) → INCONCLUSIVE → gate falls back to the heuristic."""
+    orch = _orch()
+    patches = _patch_repos([_ce("c1", "pytest", None, "starting...")])
+    try:
+        verdict, _, _ = orch._compute_structured_test_verdict(_result(), "python", {})
+    finally:
+        for p in patches[:3]:
+            p.stop()
+    assert verdict == ExecutionVerdict.INCONCLUSIVE
+
+
+def test_compute_verdict_exception_returns_not_run_best_effort():
+    """Any failure in the structured path must NOT raise into the gate."""
+    orch = _orch()
+    with patch(_CMD_REPO) as cmd_mock:
+        cmd_mock.return_value.query_by_session.side_effect = RuntimeError("db down")
+        with patch(_RECORDER) as rec:
+            rec.return_value.is_noop = True
+            verdict, evidences, reason = orch._compute_structured_test_verdict(
+                _result(), "python", {}
+            )
+    assert verdict == ExecutionVerdict.NOT_RUN
+    assert "compute failed" in reason
+
+
+# ── _emit_structured_test_fallback ────────────────────────────────────────────
+
+
+def test_emit_structured_fallback_records_workflow_event():
+    orch = _orch()
+    orch._emit_structured_test_fallback(
+        ExecutionVerdict.INCONCLUSIVE, "all commands generic/LOW", "ms-1"
+    )
+    orch.repo.create_event.assert_called_once()
+    event = orch.repo.create_event.call_args[0][0]
+    assert event["event_type"] == "structured_test_fallback"
+    assert event["milestone_id"] == "ms-1"
+    assert '"structured_verdict": "inconclusive"' in event["event_data"]
+
+
+def test_emit_structured_fallback_never_raises():
+    """Best-effort: a repo failure must not propagate into the gate."""
+    orch = _orch()
+    orch.repo.create_event.side_effect = RuntimeError("db down")
+    orch._emit_structured_test_fallback(ExecutionVerdict.NOT_RUN, "reason", "ms-1")  # no raise
+
+
+# ── _shadow_compare_evidence (Phase B run-level divergence) ───────────────────
+
+
+def test_shadow_compare_records_run_level_divergence_structured_vs_heuristic():
+    """Heuristic said pass but structured said FAILED → divergence recorded."""
+    orch = _orch()
+    with patch(_RECORDER) as rec:
+        rec.return_value.is_noop = True  # skip DB evidence fetch
+        orch._shadow_compare_evidence(
+            test_result=_result(),
+            milestone_id="ms-1",
+            heuristic_passed=True,
+            structured_verdict=ExecutionVerdict.FAILED,
+        )
+    orch.repo.create_event.assert_called_once()
+    event = orch.repo.create_event.call_args[0][0]
+    assert event["event_type"] == "evidence_shadow_divergence"
+
+
+def test_shadow_compare_no_event_when_structured_agrees_with_heuristic():
+    """Heuristic did not pass and structured FAILED → both agree, no divergence."""
+    orch = _orch()
+    with patch(_RECORDER) as rec:
+        rec.return_value.is_noop = True
+        orch._shadow_compare_evidence(
+            test_result=_result(),
+            milestone_id="ms-1",
+            heuristic_passed=False,
+            structured_verdict=ExecutionVerdict.FAILED,
+        )
+    orch.repo.create_event.assert_not_called()

--- a/tests/unit/test_test_evidence_parser.py
+++ b/tests/unit/test_test_evidence_parser.py
@@ -1,0 +1,186 @@
+"""Contract tests for the structured test-evidence parsers (#2046 Phase B).
+
+Covers per-framework output parsing, confidence grading, selector/scope
+extraction, and dispatch. These parsers replace the agent-prose heuristics
+as the authoritative source of pass/fail (#1967).
+"""
+
+from __future__ import annotations
+
+from app.modules.workspace.autonomous.command_evidence.test_evidence import (
+    ParserConfidence,
+    parse_test_evidence,
+)
+from app.modules.workspace.autonomous.command_evidence.types import (
+    CommandExecutionEvidence,
+    ExecutionVerdict,
+)
+
+
+def _ce(
+    command_id: str,
+    shell: str,
+    exit_code: int | None,
+    excerpt: str,
+    *,
+    tool_name: str = "Bash",
+) -> CommandExecutionEvidence:
+    """Build a command evidence row the way Phase A persists it."""
+    return CommandExecutionEvidence(
+        command_id=command_id,
+        session_id="sess-1",
+        workflow_id="wf-1",
+        milestone_id="ms-1",
+        tool_name=tool_name,
+        shell_command=shell,
+        exit_code=exit_code,
+        output_excerpt=excerpt,
+    )
+
+
+# ── pytest ───────────────────────────────────────────────────────────────────
+
+
+def test_pytest_parser_extracts_passed_counts_and_high_confidence():
+    te = parse_test_evidence(
+        _ce("c1", "python -m pytest tests/test_a.py", 0, "3 passed in 0.45s"), "python"
+    )
+    assert te.framework == "python"
+    assert te.parser == "pytest"
+    assert te.passed == 3
+    assert te.failed is None
+    assert te.verdict == ExecutionVerdict.PASSED.value
+    assert te.parser_confidence == ParserConfidence.HIGH.value
+
+
+def test_pytest_parser_detects_failure_from_counts():
+    te = parse_test_evidence(
+        _ce("c1", "python -m pytest tests/test_b.py", 1, "1 failed, 2 passed in 0.5s"), "python"
+    )
+    assert te.failed == 1
+    assert te.passed == 2
+    assert te.verdict == ExecutionVerdict.FAILED.value
+    assert te.parser_confidence == ParserConfidence.HIGH.value
+
+
+def test_pytest_parser_extracts_selectors_and_coverage_scope():
+    te = parse_test_evidence(
+        _ce("c1", "python -m pytest tests/test_a.py tests/test_b.py -v", 0, "2 passed"), "python"
+    )
+    assert te.selectors == ["tests/test_a.py", "tests/test_b.py"]
+    assert te.coverage_scope is not None
+    assert te.coverage_scope["context"] == "python -m pytest"
+    assert set(te.coverage_scope["selectors"]) == {"tests/test_a.py", "tests/test_b.py"}
+
+
+def test_pytest_parser_chinese_summary_is_parsed():
+    te = parse_test_evidence(_ce("c1", "pytest", 0, "通过: 2398 个, 失败: 0 个"), "python")
+    assert te.passed == 2398
+    assert te.verdict == ExecutionVerdict.PASSED.value
+
+
+def test_pytest_parser_unittest_ok_synthesizes_pass_count():
+    excerpt = "Ran 4 tests in 0.1s\n\nOK\n"
+    te = parse_test_evidence(_ce("c1", "python -m unittest discover", 0, excerpt), "python")
+    assert te.passed == 4
+    assert te.verdict == ExecutionVerdict.PASSED.value
+
+
+def test_pytest_parser_clean_exit_without_summary_is_medium_pass():
+    # Saw a real exit code but no parseable pytest summary line.
+    te = parse_test_evidence(
+        _ce("c1", "python -m pytest tests/x.py", 0, "=== test session starts ==="), "python"
+    )
+    assert te.verdict == ExecutionVerdict.PASSED.value
+    assert te.parser_confidence == ParserConfidence.MEDIUM.value
+
+
+# ── jest / go / cargo ─────────────────────────────────────────────────────────
+
+
+def test_jest_parser_extracts_counts():
+    te = parse_test_evidence(_ce("c1", "npm test", 0, "Tests: 5 passed, 0 failed"), "javascript")
+    assert te.framework == "javascript"
+    assert te.parser == "jest"
+    assert te.passed == 5
+    assert te.verdict == ExecutionVerdict.PASSED.value
+    assert te.parser_confidence == ParserConfidence.HIGH.value
+
+
+def test_go_parser_ok_is_passed():
+    te = parse_test_evidence(_ce("c1", "go test ./...", 0, "ok  github.com/acme/pkg  0.12s"), "go")
+    assert te.framework == "go"
+    assert te.verdict == ExecutionVerdict.PASSED.value
+    assert te.parser_confidence == ParserConfidence.HIGH.value
+
+
+def test_go_parser_fail_is_failed():
+    te = parse_test_evidence(
+        _ce("c1", "go test ./...", 1, "FAIL  github.com/acme/pkg  0.12s"), "go"
+    )
+    assert te.verdict == ExecutionVerdict.FAILED.value
+
+
+def test_cargo_parser_extracts_counts():
+    te = parse_test_evidence(
+        _ce("c1", "cargo test", 0, "test result: ok. 4 passed; 0 failed"), "rust"
+    )
+    assert te.framework == "rust"
+    assert te.passed == 4
+    assert te.verdict == ExecutionVerdict.PASSED.value
+
+
+# ── generic fallback ──────────────────────────────────────────────────────────
+
+
+def test_generic_parser_exit_zero_with_output_is_medium_pass():
+    te = parse_test_evidence(_ce("c1", "make test", 0, "building...\nall good"), "generic")
+    assert te.framework == "generic"
+    assert te.parser == "generic"
+    assert te.verdict == ExecutionVerdict.PASSED.value
+    assert te.parser_confidence == ParserConfidence.MEDIUM.value
+
+
+def test_generic_parser_non_zero_exit_is_failed():
+    te = parse_test_evidence(_ce("c1", "make test", 2, "make: *** [test] Error 2"), "generic")
+    assert te.verdict == ExecutionVerdict.FAILED.value
+    assert te.parser_confidence == ParserConfidence.MEDIUM.value
+
+
+def test_generic_parser_missing_exit_code_is_inconclusive_low():
+    # No exit code, no framework signal — cannot authoritatively judge.
+    te = parse_test_evidence(_ce("c1", "make test", None, "building..."), "generic")
+    assert te.verdict == ExecutionVerdict.INCONCLUSIVE.value
+    assert te.parser_confidence == ParserConfidence.LOW.value
+
+
+# ── dispatch / framework resolution ───────────────────────────────────────────
+
+
+def test_dispatch_uses_command_signal_over_hint():
+    # command says pytest but hint says javascript — command wins.
+    te = parse_test_evidence(_ce("c1", "pytest tests/x.py", 0, "2 passed"), "javascript")
+    assert te.framework == "python"
+    assert te.parser == "pytest"
+
+
+def test_dispatch_falls_back_to_hint_when_command_has_no_signal():
+    te = parse_test_evidence(_ce("c1", "./bin/run-tests", 0, "ok"), "go")
+    # No command signal → use hint. go parser sees no "ok pkg" line → medium pass.
+    assert te.framework == "go"
+
+
+def test_dispatch_falls_back_to_generic_when_hint_empty():
+    te = parse_test_evidence(_ce("c1", "./bin/run-tests", 0, "all good"), "")
+    assert te.framework == "generic"
+
+
+def test_parse_carries_command_execution_id_and_attribution():
+    ce = _ce("c1", "pytest", 0, "1 passed")
+    ce.id = 42
+    te = parse_test_evidence(ce, "python")
+    assert te.command_execution_id == 42
+    assert te.command_id == "c1"
+    assert te.session_id == "sess-1"
+    assert te.workflow_id == "wf-1"
+    assert te.milestone_id == "ms-1"

--- a/tests/unit/test_test_verdict.py
+++ b/tests/unit/test_test_verdict.py
@@ -1,0 +1,204 @@
+"""Contract tests for the run-level structured test verdict (#2046 Phase B).
+
+Migrates the 12 coverage/override rules from ``test_autonomous_ci_guardrails``
+``test_test_evidence_*`` to consume ``TestExecutionEvidence`` instead of the
+raw ``event_log``. Each rule encodes an incident from #1967 / the #1998
+reliability series.
+"""
+
+from __future__ import annotations
+
+from app.modules.workspace.autonomous.command_evidence.test_evidence import (
+    ParserConfidence,
+    TestExecutionEvidence,
+)
+from app.modules.workspace.autonomous.command_evidence.test_verdict import compute_run_verdict
+from app.modules.workspace.autonomous.command_evidence.types import ExecutionVerdict
+
+_CTX = "python -m pytest"
+
+
+def _te(
+    command_id: str,
+    verdict: str,
+    *,
+    confidence: str = ParserConfidence.HIGH.value,
+    selectors: list[str] | None = None,
+    context: str = _CTX,
+    framework: str = "python",
+) -> TestExecutionEvidence:
+    """Build a TestExecutionEvidence with an explicit scope for verdict tests."""
+    coverage_scope = None
+    if framework == "python":
+        coverage_scope = {"context": context, "selectors": sorted(selectors or [])}
+    return TestExecutionEvidence(
+        command_id=command_id,
+        framework=framework,
+        verdict=verdict,
+        parser_confidence=confidence,
+        selectors=selectors or [],
+        coverage_scope=coverage_scope,
+    )
+
+
+def _run_failed(evidences: list[TestExecutionEvidence], framework: str = "python") -> bool:
+    return compute_run_verdict(evidences, framework) == ExecutionVerdict.FAILED
+
+
+# ── coverage / override rules (incident-encoding) ─────────────────────────────
+
+
+def test_every_distinct_command_must_pass():
+    # A second command that passed does not erase a first command's failure.
+    evidences = [
+        _te("full", ExecutionVerdict.FAILED.value, selectors=["."]),  # full suite failed
+        _te("one", ExecutionVerdict.PASSED.value, selectors=["tests/test_one.py"]),
+    ]
+    assert _run_failed(evidences)
+
+
+def test_targeted_pass_does_not_cover_failed_full_suite_1967():
+    # full suite (empty selector set) failed; a targeted pass cannot clear it.
+    evidences = [
+        _te("full", ExecutionVerdict.FAILED.value, selectors=[]),  # full suite
+        _te("one", ExecutionVerdict.PASSED.value, selectors=["tests/test_one.py"]),
+    ]
+    assert _run_failed(evidences)
+
+
+def test_later_passing_superset_clears_earlier_failure():
+    # A later run of a provable superset clears the earlier failure.
+    evidences = [
+        _te("group", ExecutionVerdict.FAILED.value, selectors=["tests/a.py", "tests/b.py"]),
+        _te(
+            "superset",
+            ExecutionVerdict.PASSED.value,
+            selectors=["tests/a.py", "tests/b.py", "tests/c.py"],
+        ),
+    ]
+    assert compute_run_verdict(evidences, "python") == ExecutionVerdict.PASSED
+
+
+def test_earlier_passing_superset_does_not_clear_later_failure():
+    # Order matters: a pass that came BEFORE a later failure cannot clear it.
+    evidences = [
+        _te(
+            "superset",
+            ExecutionVerdict.PASSED.value,
+            selectors=["tests/a.py", "tests/b.py", "tests/c.py"],
+        ),
+        _te("group", ExecutionVerdict.FAILED.value, selectors=["tests/a.py", "tests/b.py"]),
+    ]
+    assert _run_failed(evidences)
+
+
+def test_different_execution_context_does_not_cover():
+    # Different python wrapper → different collection; cannot cross-cover.
+    evidences = [
+        _te(
+            "a",
+            ExecutionVerdict.FAILED.value,
+            selectors=["tests/x.py"],
+            context="python3.11 -m pytest",
+        ),
+        _te(
+            "b",
+            ExecutionVerdict.PASSED.value,
+            selectors=["tests/x.py"],
+            context="python3.12 -m pytest",
+        ),
+    ]
+    assert _run_failed(evidences)
+
+
+def test_same_command_latest_invocation_wins_head_tail_1967():
+    # head run (pass, no summary) then tail rerun (pass, summary) → run passes.
+    # Models the truncated-exploration + rerun pattern from #1967.
+    evidences = [
+        _te(
+            "head",
+            ExecutionVerdict.PASSED.value,
+            selectors=["tests/x.py"],
+            confidence=ParserConfidence.MEDIUM.value,
+        ),
+        _te("tail", ExecutionVerdict.PASSED.value, selectors=["tests/x.py"]),
+    ]
+    assert compute_run_verdict(evidences, "python") == ExecutionVerdict.PASSED
+
+
+def test_stale_pass_does_not_satisfy_rerun_that_failed():
+    # Same scope: earlier pass then later failure → the failure is the latest.
+    evidences = [
+        _te("first", ExecutionVerdict.PASSED.value, selectors=["tests/x.py"]),
+        _te("second", ExecutionVerdict.FAILED.value, selectors=["tests/x.py"]),
+    ]
+    assert _run_failed(evidences)
+
+
+def test_non_pytest_does_not_cross_cover_between_commands():
+    # jest/go/cargo: a pass on one command cannot clear a failure on another.
+    evidences = [
+        _te("c1", ExecutionVerdict.FAILED.value, framework="javascript"),
+        _te("c2", ExecutionVerdict.PASSED.value, framework="javascript"),
+    ]
+    assert _run_failed(evidences, "javascript")
+
+
+def test_restricted_pass_does_not_cover_earlier_failure():
+    # Subset pass after a wider failure does not cover (not a superset).
+    evidences = [
+        _te("wide", ExecutionVerdict.FAILED.value, selectors=["tests/a.py", "tests/b.py"]),
+        _te("narrow", ExecutionVerdict.PASSED.value, selectors=["tests/a.py"]),
+    ]
+    assert _run_failed(evidences)
+
+
+# ── verdict aggregation / fallback boundary ───────────────────────────────────
+
+
+def test_all_passed_returns_passed():
+    evidences = [
+        _te("c1", ExecutionVerdict.PASSED.value, selectors=["tests/a.py"]),
+        _te("c2", ExecutionVerdict.PASSED.value, selectors=["tests/b.py"]),
+    ]
+    assert compute_run_verdict(evidences, "python") == ExecutionVerdict.PASSED
+
+
+def test_empty_evidence_is_not_run():
+    assert compute_run_verdict([], "python") == ExecutionVerdict.NOT_RUN
+
+
+def test_all_low_confidence_is_inconclusive():
+    # Parser could not parse any command — defer to the heuristic fallback.
+    evidences = [
+        _te("c1", ExecutionVerdict.INCONCLUSIVE.value, confidence=ParserConfidence.LOW.value),
+    ]
+    assert compute_run_verdict(evidences, "python") == ExecutionVerdict.INCONCLUSIVE
+
+
+def test_low_confidence_command_makes_run_inconclusive_when_rest_pass():
+    # One command parsed-passed, another was unparseable (LOW). The structured
+    # layer cannot confirm the LOW command passed → fall back to heuristic.
+    evidences = [
+        _te("c1", ExecutionVerdict.PASSED.value, selectors=["tests/a.py"]),
+        _te("c2", ExecutionVerdict.INCONCLUSIVE.value, confidence=ParserConfidence.LOW.value),
+    ]
+    assert compute_run_verdict(evidences, "python") == ExecutionVerdict.INCONCLUSIVE
+
+
+def test_failed_takes_priority_over_inconclusive_peer():
+    # A real HIGH-confidence failure must not be masked by an unparseable peer.
+    evidences = [
+        _te("c1", ExecutionVerdict.FAILED.value, selectors=["tests/a.py"]),
+        _te("c2", ExecutionVerdict.INCONCLUSIVE.value, confidence=ParserConfidence.LOW.value),
+    ]
+    assert compute_run_verdict(evidences, "python") == ExecutionVerdict.FAILED
+
+
+def test_medium_confidence_failure_blocks_pass():
+    # MEDIUM (exit-code only) failure still counts as a real failure.
+    evidences = [
+        _te("c1", ExecutionVerdict.FAILED.value, confidence=ParserConfidence.MEDIUM.value),
+        _te("c2", ExecutionVerdict.PASSED.value, selectors=["tests/a.py"]),
+    ]
+    assert _run_failed(evidences)


### PR DESCRIPTION
## Summary

Phase B of #2046: migrates the autonomous test gate from `event_log` heuristics to structured `TestExecutionEvidence`. A pluggable parser reads `CommandExecutionEvidence.output_excerpt` + `exit_code` (**never agent prose**), and `compute_run_verdict` aggregates into an authoritative PASSED/FAILED. The legacy heuristic is retained as the INCONCLUSIVE/NOT_RUN fallback (#2046 §4 降级).

**Core invariant (#1967):** agent prose / `TEST_STATUS` can no longer promote a run to PASSED on its own — only structured evidence can.

## Decisions (brainstorming)

| Decision | Choice |
|---|---|
| Scope | 全量 §1-4 一次性 |
| INCONCLUSIVE | fail-closed + 启发式兜底 (PASSED/FAILED 权威; NOT_RUN/INCONCLUSIVE fallback `_has_passing_test_tool_result` + 记 `structured_test_fallback` event) |
| Persistence | 独立表 `test_execution_evidence` (FK `command_execution_id` → `command_execution_evidence.id`) |
| §4 | 降级为兜底 + UI 摘要（非删除）|
| Code org | 模块化 + dispatch table (plain-function, 无 ABC) |

## Changes

- **`command_evidence/scope.py`** — extract `_normalize_test_command` / `_pytest_test_scope` / `_pytest_scope_covers` to a shared module (avoids circular import: orchestrator → verdict → scope, not back into orchestrator)
- **`command_evidence/test_evidence.py`** — `TestExecutionEvidence` + `ParserConfidence` (HIGH/MEDIUM/LOW) + per-framework parsers (`_parse_pytest` / `_parse_jest` / `_parse_go` / `_parse_cargo` / `_parse_generic`, multilingual count extraction) + dispatch
- **`command_evidence/test_verdict.py`** — `compute_run_verdict`: 12 coverage/override rules migrated from `_has_passing_test_tool_result` (every command must pass; later superset clears earlier failure; targeted pass never covers full suite; latest invocation wins; non-pytest never cross-covers; LOW confidence → INCONCLUSIVE)
- **`repositories/test_evidence_repo.py`** + migration `add_test_execution_evidence` — table + FK + UNIQUE `(session_id, command_id)`; `schema.sql` rebuilt byte-exact (PG 15.18)
- **`orchestrator`** — `_compute_structured_test_verdict` drives `tests_actually_run`; shadow upgraded to run-level divergence; `_has_passing_test_tool_result` demoted to non-authoritative fallback (docstring marked)

## Migration note

`20260727_001_add_test_execution_evidence.down_revision` retargeted to `20260727_007_add_sandbox_remote_session_id` after #2090 merged to main (resolves the fork/double-head the first CI run flagged).

## Tests

- `test_test_evidence_parser.py` (17) — per-framework parse, confidence, selectors, dispatch
- `test_test_verdict.py` (15) — 12 coverage rules + verdict aggregation
- `test_phase_b_gate.py` (12) — orchestrator gate wiring (PASSED/FAILED/INCONCLUSIVE/NOT_RUN + fallback event + shadow)
- `test_test_evidence_repo.py` (8) — upsert/query/JSON roundtrip
- Regression: 97 ci_guardrails + 19 command_evidence green; `test_alembic_sqlite_upgrade` green (single head). 4 pre-existing 822 containment failures verified unchanged on main (environmental, macOS `/tmp` symlink).

## Follow-ups (not in this PR)

- **Parser coverage**: add Maven/Gradle (Java) structured parser once a workflow needs it (currently generic exit-code fallback)
- **Fallback retirement**: once shadow data shows `structured_test_fallback` fires rarely, harden INCONCLUSIVE → fail (remove heuristic dependency) — tracked separately

Refs #2046

🤖 Generated with [Claude Code](https://claude.com/claude-code)
