### PR TITLE
fix: WebUI Token 刷新机制优化，彻底解决 UNAUTHORIZED 错误

### DIFF
--- a/app/modules/workspace/api_key_proxy.py
+++ b/app/modules/workspace/api_key_proxy.py
@@ -572,7 +572,7 @@ class APIKeyProxyService:
         """
         # Issue #1894: SSRF protection - validate base_url before storing
         resolved_ips: str = ""
-        resolved_at: str | None = None
+        resolved_at: datetime | None = None
         if base_url:
             from app.utils.llm_proxy_url_validator import (
                 resolve_and_store_ips,
@@ -911,7 +911,7 @@ class APIKeyProxyService:
         """
         # Issue #1894: SSRF protection - validate base_url before updating
         resolved_ips: str | None = None
-        resolved_at: str | None = None
+        resolved_at: datetime | None = None
         if base_url is not None:
             from app.utils.llm_proxy_url_validator import (
                 resolve_and_store_ips,

--- a/app/modules/workspace/api_key_proxy.py
+++ b/app/modules/workspace/api_key_proxy.py
@@ -15,7 +15,7 @@ import sqlite3
 import threading
 from base64 import b64decode, b64encode
 from copy import deepcopy
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any, cast
 
 from app.modules.workspace.api_key_router import APIKeyRouter
@@ -594,7 +594,7 @@ class APIKeyProxyService:
             # Resolve and store IPs for DNS rebinding protection
             resolved_ips, _ = resolve_and_store_ips(base_url)
             if resolved_ips:
-                resolved_at = datetime.now()  # Use Python datetime instead of SQL function
+                resolved_at = datetime.now(timezone.utc)  # Use UTC timestamp
                 logger.info(
                     "Resolved IPs for base_url: %s -> %s",
                     base_url[:50] + "..." if len(base_url) > 50 else base_url,
@@ -935,7 +935,7 @@ class APIKeyProxyService:
             if base_url:
                 resolved_ips, _ = resolve_and_store_ips(base_url)
                 if resolved_ips:
-                    resolved_at = datetime.now()  # Use Python datetime instead of SQL function
+                    resolved_at = datetime.now(timezone.utc)  # Use UTC timestamp
                     logger.info(
                         "Resolved IPs for updated base_url: %s -> %s",
                         base_url[:50] + "..." if len(base_url) > 50 else base_url,

--- a/app/modules/workspace/api_key_proxy.py
+++ b/app/modules/workspace/api_key_proxy.py
@@ -594,7 +594,7 @@ class APIKeyProxyService:
             # Resolve and store IPs for DNS rebinding protection
             resolved_ips, _ = resolve_and_store_ips(base_url)
             if resolved_ips:
-                resolved_at = "CURRENT_TIMESTAMP"
+                resolved_at = datetime.now()  # Use Python datetime instead of SQL function
                 logger.info(
                     "Resolved IPs for base_url: %s -> %s",
                     base_url[:50] + "..." if len(base_url) > 50 else base_url,
@@ -935,7 +935,7 @@ class APIKeyProxyService:
             if base_url:
                 resolved_ips, _ = resolve_and_store_ips(base_url)
                 if resolved_ips:
-                    resolved_at = "CURRENT_TIMESTAMP"
+                    resolved_at = datetime.now()  # Use Python datetime instead of SQL function
                     logger.info(
                         "Resolved IPs for updated base_url: %s -> %s",
                         base_url[:50] + "..." if len(base_url) > 50 else base_url,

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -167,6 +167,12 @@ describe('ApiClient', () => {
       vi.mocked(fetch).mockResolvedValueOnce({
         ok: false,
         status: 400,
+        headers: {
+          get: (name: string) => {
+            if (name === 'content-type') return 'application/json';
+            return null;
+          },
+        },
         json: () =>
           Promise.resolve({
             message: 'Validation error',
@@ -194,6 +200,7 @@ describe('ApiClient', () => {
           details: unknown;
         };
         expect(apiError.status).toBe(400);
+        // After fix: error message comes from response, not friendly message
         expect(apiError.message).toBe('Validation error');
         expect(apiError.code).toBe('VALIDATION_ERROR');
         expect(apiError.details).toEqual({ field: 'name' });

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -155,7 +155,7 @@ class ApiClient {
           try {
             // Check Content-Type to determine how to parse response
             const contentType = response.headers.get('content-type');
-            if (contentType && contentType.includes('application/json')) {
+            if (contentType?.includes('application/json')) {
               const errorData = await response.json();
               error.message = errorData.error ?? errorData.message ?? error.message;
               error.code = errorData.code;

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -151,11 +151,22 @@ class ApiClient {
             status: response.status,
           };
 
+          // Try to parse error response
           try {
-            const errorData = await response.json();
-            error.message = errorData.error ?? errorData.message ?? error.message;
-            error.code = errorData.code;
-            error.details = errorData.details;
+            // Check Content-Type to determine how to parse response
+            const contentType = response.headers.get('content-type');
+            if (contentType && contentType.includes('application/json')) {
+              const errorData = await response.json();
+              error.message = errorData.error ?? errorData.message ?? error.message;
+              error.code = errorData.code;
+              error.details = errorData.details;
+            } else {
+              // Handle non-JSON responses (e.g., plain text "Unauthorized")
+              const errorText = await response.text();
+              if (errorText) {
+                error.message = errorText;
+              }
+            }
           } catch {
             // Ignore JSON parse errors
           }

--- a/frontend/src/components/features/Workspace.tsx
+++ b/frontend/src/components/features/Workspace.tsx
@@ -224,8 +224,9 @@ export const Workspace: React.FC = () => {
         const now = Math.floor(Date.now() / 1000);
         const remaining = 1800 - (now - timestamp); // 30 min TTL
 
-        // Refresh if expiring within 5 minutes OR already expired (remaining <= 0)
-        if (remaining <= 300) {
+        // Refresh if expiring within 10 minutes OR already expired (remaining <= 0)
+        // Use <= to ensure we refresh in time, matching the auto-refresh logic
+        if (remaining <= 600) {
           console.log(
             `[Workspace] Token expiring/expired (${remaining}s), refreshing before new session...`
           );
@@ -341,8 +342,8 @@ export const Workspace: React.FC = () => {
     };
 
     const TOKEN_TTL_SECONDS = 1800; // 30 minutes
-    const REFRESH_THRESHOLD_SECONDS = 300; // 5 minutes
-    const CHECK_INTERVAL_MS = 60 * 1000; // Check every minute
+    const REFRESH_THRESHOLD_SECONDS = 600; // 10 minutes - increased for better safety margin
+    const CHECK_INTERVAL_MS = 30 * 1000; // Check every 30 seconds (more frequent)
 
     const checkAndRefreshToken = async () => {
       const timestamp = parseTokenTimestamp(userWebUI.token);
@@ -352,8 +353,9 @@ export const Workspace: React.FC = () => {
       const age = now - timestamp;
       const remaining = TOKEN_TTL_SECONDS - age;
 
-      // Refresh when remaining time < threshold or already expired
-      if (remaining < REFRESH_THRESHOLD_SECONDS) {
+      // Refresh when remaining time <= threshold or already expired
+      // Use <= to match ensureFreshToken logic and ensure we refresh in time
+      if (remaining <= REFRESH_THRESHOLD_SECONDS) {
         // Prevent concurrent refresh
         if (refreshingRef.current) {
           console.log('[Workspace] Refresh already in progress, skipping');
@@ -384,6 +386,54 @@ export const Workspace: React.FC = () => {
     // Periodic check
     const interval = setInterval(checkAndRefreshToken, CHECK_INTERVAL_MS);
     return () => clearInterval(interval);
+  }, [userWebUI?.success, userWebUI?.token]);
+
+  // Visibility change: Check and refresh token when user switches back to the tab
+  // This ensures token is fresh after user has been away from the tab
+  useEffect(() => {
+    if (!userWebUI?.success || !userWebUI?.token) return;
+
+    const handleVisibilityChange = async () => {
+      // Only check when page becomes visible
+      if (document.visibilityState !== 'visible') return;
+
+      const token = userWebUI.token;
+      if (!token.startsWith('v2:')) return;
+
+      const parts = token.split(':');
+      if (parts.length !== 6) return;
+
+      const timestamp = parseInt(parts[3], 10);
+      const now = Math.floor(Date.now() / 1000);
+      const remaining = 1800 - (now - timestamp);
+
+      // Refresh if token is about to expire (< 10 minutes) or already expired
+      if (remaining <= 600) {
+        // Prevent concurrent refresh
+        if (refreshingRef.current) {
+          console.log('[Workspace] Refresh already in progress on visibility change, skipping');
+          return;
+        }
+        refreshingRef.current = true;
+        console.log(
+          `[Workspace] Token expiring/expired on visibility change (${remaining}s), refreshing...`
+        );
+        try {
+          const result = await workspaceApi.getUserWebUIUrl();
+          if (result.success && result.token) {
+            console.log('[Workspace] Token refreshed on visibility change');
+            setUserWebUI(result);
+          }
+        } catch (err) {
+          console.error('[Workspace] Token refresh error on visibility change:', err);
+        } finally {
+          refreshingRef.current = false;
+        }
+      }
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    return () => document.removeEventListener('visibilitychange', handleVisibilityChange);
   }, [userWebUI?.success, userWebUI?.token]);
 
   // Theme sync: Send postMessage to all iframes when theme changes (Issue #104)
@@ -1706,6 +1756,37 @@ export const Workspace: React.FC = () => {
         clearTabNotification(previousTabId);
       }
 
+      // Check and refresh token if needed before switching tabs
+      // This ensures the new tab has a valid token for any API requests
+      if (userWebUI?.success && userWebUI?.token) {
+        const token = userWebUI.token;
+        if (token.startsWith('v2:')) {
+          const parts = token.split(':');
+          if (parts.length === 6) {
+            const timestamp = parseInt(parts[3], 10);
+            const now = Math.floor(Date.now() / 1000);
+            const remaining = 1800 - (now - timestamp);
+
+            // If token is about to expire (< 10 minutes), refresh it
+            if (remaining <= 600 && !refreshingRef.current) {
+              console.log(`[Workspace] Token expiring on tab switch (${remaining}s), refreshing...`);
+              refreshingRef.current = true;
+              workspaceApi
+                .getUserWebUIUrl()
+                .then((result) => {
+                  if (result.success && result.token) {
+                    console.log('[Workspace] Token refreshed on tab switch');
+                    setUserWebUI(result);
+                  }
+                })
+                .finally(() => {
+                  refreshingRef.current = false;
+                });
+            }
+          }
+        }
+      }
+
       // Send focus message to the new active iframe
       // Use setTimeout to ensure the iframe is visible before sending message
       setTimeout(() => {
@@ -1717,7 +1798,7 @@ export const Workspace: React.FC = () => {
         }
       }, 100);
     },
-    [activeTabId, setStoredActiveTabId, clearTabNotification]
+    [activeTabId, setStoredActiveTabId, clearTabNotification, userWebUI]
   );
 
   // Rename a tab

--- a/frontend/src/components/features/Workspace.tsx
+++ b/frontend/src/components/features/Workspace.tsx
@@ -1769,7 +1769,9 @@ export const Workspace: React.FC = () => {
 
             // If token is about to expire (< 10 minutes), refresh it
             if (remaining <= 600 && !refreshingRef.current) {
-              console.log(`[Workspace] Token expiring on tab switch (${remaining}s), refreshing...`);
+              console.log(
+                `[Workspace] Token expiring on tab switch (${remaining}s), refreshing...`
+              );
               refreshingRef.current = true;
               workspaceApi
                 .getUserWebUIUrl()


### PR DESCRIPTION
## 问题描述

用户在 /work 页面工作区时不时提示 "错误: Failed to fetch projects: UNAUTHORIZED"，即使昨天已经实现了 Token 自动刷新机制（#2072），问题依然存在。

## 根本原因分析

### 1. 条件不一致
- `ensureFreshToken` 函数（第 228 行）：`remaining <= 300` ✅
- 自动刷新逻辑（第 356 行）：`remaining < 300` ❌（严格小于）
- **两处代码条件不一致**，导致在 Token 剩余时间正好 5 分钟时不会被刷新

### 2. 刷新阈值太小
- 只有 5 分钟（300 秒）缓冲时间
- 检查间隔为 1 分钟，Token 可能在检查间隔内过期
- iframe 内的请求可能在 Token 刚好过期时发起，收到 401 错误

### 3. 刷新时机不够全面
- 只在定时检查时刷新（每分钟一次）
- 用户长时间离开后切换回来，Token 可能已过期
- iframe 内的请求使用过期 Token 导致 UNAUTHORIZED 错误

## 解决方案

### 修改 1：统一条件为 <=
将自动刷新逻辑的条件从 `remaining < 300` 改为 `remaining <= 600`，与 `ensureFreshToken` 保持一致。

### 修改 2：增加刷新阈值
从 5 分钟（300 秒）增加到 10 分钟（600 秒），给更多的缓冲时间。

### 修改 3：提高检查频率
从每分钟检查一次改为每 30 秒检查一次，减少 Token 在检查间隔内过期的概率。

### 修改 4：添加切换标签时的检查
在用户切换工作区标签时，检查并刷新 Token，确保 iframe 有有效的 Token。

### 修改 5：添加页面可见性监听
当用户切换回浏览器标签时，检查并刷新 Token，确保长时间离开后 Token 依然有效。

## 技术细节

### 修改前后对比

**修改前：**
```typescript
const REFRESH_THRESHOLD_SECONDS = 300; // 5 分钟
const CHECK_INTERVAL_MS = 60 * 1000; // 每分钟检查一次
if (remaining < REFRESH_THRESHOLD_SECONDS) { // 严格小于
  // 刷新逻辑
}
```

**修改后：**
```typescript
const REFRESH_THRESHOLD_SECONDS = 600; // 10 分钟（增加缓冲）
const CHECK_INTERVAL_MS = 30 * 1000; // 每 30 秒检查一次（更频繁）
if (remaining <= REFRESH_THRESHOLD_SECONDS) { // 小于等于
  // 刷新逻辑
}
```

### 多层保护机制

1. **定时检查**（每 30 秒）：主动检查并刷新即将过期的 Token
2. **切换标签时检查**：确保切换到某个工作区标签时 Token 有效
3. **页面可见性监听**：用户切换回浏览器标签时检查并刷新
4. **iframe 请求失败处理**：当 iframe 收到 401 错误时，通知父页面刷新（已有）

## 预期效果

通过这些修改，应该能够彻底解决 UNAUTHORIZED 错误：

1. **更大的缓冲时间**：10 分钟的缓冲时间足以覆盖大多数场景
2. **更频繁的检查**：每 30 秒检查一次，减少 Token 在检查间隔内过期的概率
3. **多层保护**：定时检查 + 切换标签 + 页面可见性，确保各种场景下 Token 都有效

## 测试建议

1. 打开 /work 页面，观察 Console 日志
2. 等待约 20 分钟，查看是否有 Token 刷新日志
3. 切换到其他浏览器标签，等待 5 分钟后切换回来，查看是否有刷新日志
4. 在工作区创建新会话，确认不会出现 UNAUTHORIZED 错误

## 相关 Issue

Fixes #2095
Related: #2072