### PR TITLE
fix(stats): resolve ON CONFLICT duplicate row error in refresh_stats

### DIFF
--- a/app/repositories/daily_stats_repo.py
+++ b/app/repositories/daily_stats_repo.py
@@ -792,6 +792,7 @@ class DailyStatsRepository:
                 try:
                     # Issue #2010: Use INSERT ... ON CONFLICT DO UPDATE for atomic operation
                     # This eliminates the race condition window between DELETE and INSERT
+                    # Issue #2094: GROUP BY only by constraint keys, aggregate user_id/tenant_id
                     # sender_name formats:
                     # 1. WebUI: {system_account}-{hostname}-{tool} -> match users.system_account
                     # 2. Feishu: username (real name) -> match users.username
@@ -805,13 +806,13 @@ class DailyStatsRepository:
                             dm.tool_name,
                             dm.host_name,
                             dm.sender_name,
-                            COALESCE(dm.user_id,
+                            MAX(COALESCE(dm.user_id,
                                 (SELECT u.id FROM users u
                                  WHERE dm.sender_name LIKE (u.system_account || '-%%')
                                     OR dm.sender_name = u.username
                                  ORDER BY u.id
-                                 LIMIT 1)) as user_id,
-                            dm.tenant_id,
+                                 LIMIT 1))) as user_id,
+                            MAX(dm.tenant_id) as tenant_id,
                             SUM(dm.tokens_used) as total_tokens,
                             SUM(dm.input_tokens) as total_input_tokens,
                             SUM(dm.output_tokens) as total_output_tokens,
@@ -819,14 +820,7 @@ class DailyStatsRepository:
                             ?
                         FROM daily_messages dm
                         WHERE {date_condition}
-                        GROUP BY dm.date, dm.tool_name, dm.host_name, dm.sender_name,
-                                 COALESCE(dm.user_id,
-                                    (SELECT u.id FROM users u
-                                     WHERE dm.sender_name LIKE (u.system_account || '-%%')
-                                        OR dm.sender_name = u.username
-                                     ORDER BY u.id
-                                     LIMIT 1)),
-                                 dm.tenant_id
+                        GROUP BY dm.date, dm.tool_name, dm.host_name, dm.sender_name
                         ON CONFLICT (date, tool_name, host_name, sender_name) DO UPDATE SET
                             user_id = EXCLUDED.user_id,
                             tenant_id = EXCLUDED.tenant_id,
@@ -845,6 +839,7 @@ class DailyStatsRepository:
             else:
                 # SQLite: use INSERT OR REPLACE with user_id populated
                 # Issue #1852: Include tenant_id for tenant isolation
+                # Issue #2094: GROUP BY only by constraint keys, aggregate user_id/tenant_id
                 self.db.execute(
                     f"""
                     INSERT OR REPLACE INTO daily_stats
@@ -855,12 +850,12 @@ class DailyStatsRepository:
                         dm.tool_name,
                         dm.host_name,
                         dm.sender_name,
-                        COALESCE(dm.user_id,
+                        MAX(COALESCE(dm.user_id,
                             (SELECT u.id FROM users u
                              WHERE dm.sender_name LIKE (u.system_account || '-%%')
                                 OR dm.sender_name = u.username
-                             LIMIT 1)) as user_id,
-                        dm.tenant_id,
+                             LIMIT 1))) as user_id,
+                        MAX(dm.tenant_id) as tenant_id,
                         SUM(dm.tokens_used) as total_tokens,
                         SUM(dm.input_tokens) as total_input_tokens,
                         SUM(dm.output_tokens) as total_output_tokens,
@@ -868,13 +863,7 @@ class DailyStatsRepository:
                         ?
                     FROM daily_messages dm
                     WHERE {date_condition}
-                    GROUP BY dm.date, dm.tool_name, dm.host_name, dm.sender_name,
-                             COALESCE(dm.user_id,
-                                (SELECT u.id FROM users u
-                                 WHERE dm.sender_name LIKE (u.system_account || '-%%')
-                                    OR dm.sender_name = u.username
-                                 LIMIT 1)),
-                             dm.tenant_id
+                    GROUP BY dm.date, dm.tool_name, dm.host_name, dm.sender_name
                     """,
                     (now,) + params,
                 )


### PR DESCRIPTION
## 修复说明

关联 Issue：#2094

## 根因

`refresh_stats()` SQL 的 GROUP BY 包含 `user_id` 和 `tenant_id`，与唯一约束 `uq_daily_stats_date_tool_host_sender (date, tool_name, host_name, sender_name)` 不匹配，导致同一约束键产生多行数据触发 ON CONFLICT 错误。

## 修复方案

从 GROUP BY 中移除 `user_id` 和 `tenant_id`，在 SELECT 中使用 MAX() 聚合处理这些字段。

## 主要变更

- `app/repositories/daily_stats_repo.py`：
  - PostgreSQL 版 SQL：GROUP BY 仅包含约束键，使用 MAX() 聚合
  - SQLite 版 SQL：同步修改

## 测试

- **测试环境**：Package 测试环境
- **单元测试**：13 个 refresh 相关测试全部通过
- **集成验证**：`refresh_stats()` 执行成功，数据从 2 工具 7 条 → 7 工具 1609 条
- **回归测试**：Dashboard 数据正确显示所有工具

## 风险

- 兼容性风险：无（不改变 schema）
- 性能风险：无（聚合逻辑简单）
- 回归风险：低（测试覆盖充分）

Generated with Qwen Code