### PR TITLE
fix(analysis): populate top_hosts in batch analysis API

### DIFF
--- a/app/repositories/daily_stats_repo.py
+++ b/app/repositories/daily_stats_repo.py
@@ -164,6 +164,74 @@ class DailyStatsRepository:
 
         return sorted(merged.values(), key=lambda x: x.get("total_tokens", 0), reverse=True)
 
+    def get_host_totals(
+        self,
+        start_date: str | None = None,
+        end_date: str | None = None,
+        host_name: str | None = None,
+        tenant_id: int | None = None,
+    ) -> list[dict]:
+        """
+        Get host token totals from pre-aggregated data.
+
+        Issue #2093: Added to populate top_hosts in batch analysis.
+
+        Args:
+            start_date: Optional start date filter.
+            end_date: Optional end date filter.
+            host_name: Optional host name filter.
+            tenant_id: Optional tenant ID filter. If None, returns all data (admin view).
+
+        Returns:
+            List[Dict]: List of host totals.
+        """
+        conditions: list[str] = []
+        params: list[Any] = []
+
+        if start_date:
+            conditions.append("date >= ?")
+            params.append(start_date)
+
+        if end_date:
+            conditions.append("date <= ?")
+            params.append(end_date)
+
+        if host_name:
+            conditions.append("host_name = ?")
+            params.append(host_name)
+
+        if tenant_id is not None:
+            conditions.append("tenant_id = ?")
+            params.append(tenant_id)
+
+        where_clause = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+
+        query = f"""
+            SELECT
+                host_name,
+                SUM(total_tokens) as total_tokens,
+                SUM(total_input_tokens) as total_input_tokens,
+                SUM(total_output_tokens) as total_output_tokens,
+                SUM(message_count) as message_count
+            FROM daily_stats
+            {where_clause}
+            GROUP BY host_name
+            ORDER BY total_tokens DESC
+        """
+
+        rows = self.db.fetch_all(query, tuple(params))
+
+        return [
+            {
+                "host_name": row["host_name"],
+                "total_tokens": row["total_tokens"] or 0,
+                "total_input_tokens": row["total_input_tokens"] or 0,
+                "total_output_tokens": row["total_output_tokens"] or 0,
+                "message_count": row["message_count"] or 0,
+            }
+            for row in rows
+        ]
+
     def get_tool_totals_with_range(
         self,
         start_date: str | None = None,

--- a/app/services/analysis_service.py
+++ b/app/services/analysis_service.py
@@ -95,6 +95,9 @@ class AnalysisService:
                 self.daily_stats_repo.get_tool_totals, start_date, end_date, host_name, tenant_id
             ): "tool_stats",
             _executor.submit(
+                self.daily_stats_repo.get_host_totals, start_date, end_date, host_name, tenant_id
+            ): "host_stats",
+            _executor.submit(
                 self.daily_stats_repo.get_daily_totals, start_date, end_date, host_name, tenant_id
             ): "daily_data",
             _executor.submit(
@@ -127,6 +130,7 @@ class AnalysisService:
         aggregates = results.get("aggregates", {})
         user_tokens = results.get("user_tokens", [])
         tool_stats = results.get("tool_stats", [])
+        host_stats = results.get("host_stats", [])
         daily_data = results.get("daily_data", [])
         hourly_data = results.get("hourly_data", [])
         session_summary = results.get("session_summary", {})
@@ -150,6 +154,12 @@ class AnalysisService:
                 merged_tools[tool] = merged_tools.get(tool, 0) + ts.get("total_tokens", 0)
             for tool, count in sorted(merged_tools.items(), key=lambda x: -x[1])[:5]:
                 top_tools.append({"tool": tool, "count": count})
+
+        # Top hosts - Issue #2093: Populate from host_stats
+        top_hosts = []
+        if host_stats:
+            for hs in host_stats[:5]:
+                top_hosts.append({"host": hs.get("host_name", "unknown"), "count": hs.get("total_tokens", 0)})
 
         # Real conversation count + session-scoped sums from a single query
         # (message_repo.get_conversation_stats_summary). The denominator
@@ -194,7 +204,7 @@ class AnalysisService:
             "unique_tools": unique_tools if unique_tools > 0 else 1,
             "unique_hosts": unique_hosts if unique_hosts > 0 else 1,
             "top_tools": top_tools,
-            "top_hosts": [],  # Will be populated from daily_data if needed
+            "top_hosts": top_hosts,  # Issue #2093: Now populated from host_stats
             "total_sessions": total_sessions,
             "avg_tokens_per_session": (
                 session_tokens / total_sessions if total_sessions > 0 else 0

--- a/app/services/analysis_service.py
+++ b/app/services/analysis_service.py
@@ -159,7 +159,9 @@ class AnalysisService:
         top_hosts = []
         if host_stats:
             for hs in host_stats[:5]:
-                top_hosts.append({"host": hs.get("host_name", "unknown"), "count": hs.get("total_tokens", 0)})
+                top_hosts.append(
+                    {"host": hs.get("host_name", "unknown"), "count": hs.get("total_tokens", 0)}
+                )
 
         # Real conversation count + session-scoped sums from a single query
         # (message_repo.get_conversation_stats_summary). The denominator

--- a/tests/unit/test_daily_stats_repo.py
+++ b/tests/unit/test_daily_stats_repo.py
@@ -202,9 +202,7 @@ class TestDailyStatsRepository:
     def test_get_host_totals_with_filters(self):
         """get_host_totals applies date and host_name filters."""
         self.db.fetch_all.return_value = []
-        self.repo.get_host_totals(
-            start_date="2024-01-01", end_date="2024-01-31", host_name="host1"
-        )
+        self.repo.get_host_totals(start_date="2024-01-01", end_date="2024-01-31", host_name="host1")
         call_args = self.db.fetch_all.call_args
         query = call_args[0][0]
         assert "date >= ?" in query

--- a/tests/unit/test_daily_stats_repo.py
+++ b/tests/unit/test_daily_stats_repo.py
@@ -168,6 +168,80 @@ class TestDailyStatsRepository:
         assert "date <= ?" in query
 
     # -------------------------------------------------------------------------
+    # get_host_totals (Issue #2093)
+    # -------------------------------------------------------------------------
+
+    def test_get_host_totals_no_filters(self):
+        """get_host_totals returns host stats sorted by total_tokens DESC."""
+        self.db.fetch_all.return_value = [
+            {
+                "host_name": "host1",
+                "total_tokens": 1000,
+                "total_input_tokens": 600,
+                "total_output_tokens": 400,
+                "message_count": 100,
+            },
+            {
+                "host_name": "host2",
+                "total_tokens": 500,
+                "total_input_tokens": 300,
+                "total_output_tokens": 200,
+                "message_count": 50,
+            },
+        ]
+        result = self.repo.get_host_totals()
+        assert len(result) == 2
+        assert result[0]["host_name"] == "host1"
+        assert result[0]["total_tokens"] == 1000
+        assert result[1]["host_name"] == "host2"
+        self.db.fetch_all.assert_called_once()
+        query = self.db.fetch_all.call_args[0][0]
+        assert "GROUP BY host_name" in query
+        assert "ORDER BY total_tokens DESC" in query
+
+    def test_get_host_totals_with_filters(self):
+        """get_host_totals applies date and host_name filters."""
+        self.db.fetch_all.return_value = []
+        self.repo.get_host_totals(
+            start_date="2024-01-01", end_date="2024-01-31", host_name="host1"
+        )
+        call_args = self.db.fetch_all.call_args
+        query = call_args[0][0]
+        assert "date >= ?" in query
+        assert "date <= ?" in query
+        assert "host_name = ?" in query
+        params = call_args[0][1]
+        assert params == ("2024-01-01", "2024-01-31", "host1")
+
+    def test_get_host_totals_handles_none_values(self):
+        """get_host_totals handles None values from DB."""
+        self.db.fetch_all.return_value = [
+            {
+                "host_name": "unknown",
+                "total_tokens": None,
+                "total_input_tokens": None,
+                "total_output_tokens": None,
+                "message_count": None,
+            },
+        ]
+        result = self.repo.get_host_totals()
+        assert len(result) == 1
+        assert result[0]["total_tokens"] == 0
+        assert result[0]["total_input_tokens"] == 0
+        assert result[0]["total_output_tokens"] == 0
+        assert result[0]["message_count"] == 0
+
+    def test_get_host_totals_with_tenant_id(self):
+        """get_host_totals filters by tenant_id when provided."""
+        self.db.fetch_all.return_value = []
+        self.repo.get_host_totals(tenant_id=1)
+        call_args = self.db.fetch_all.call_args
+        query = call_args[0][0]
+        assert "tenant_id = ?" in query
+        params = call_args[0][1]
+        assert params == (1,)
+
+    # -------------------------------------------------------------------------
     # get_user_totals
     # -------------------------------------------------------------------------
 


### PR DESCRIPTION
## 修复说明

关联 Issue：#2093

## 根因

`top_hosts` 字段在 `/api/analysis/batch` API 中被硬编码为空数组 `[]`，代码注释表明这是一个未完成的功能。

## 修复方案

1. 在 `DailyStatsRepository` 中添加 `get_host_totals()` 方法，按 `host_name` 聚合统计
2. 在 `get_batch_analysis()` 中并行调用该方法
3. 从返回数据中计算 `top_hosts`，与 `top_tools` 实现保持一致

## 主要变更

- `app/repositories/daily_stats_repo.py`: 新增 `get_host_totals()` 方法
- `app/services/analysis_service.py`: 添加 `get_host_totals` 并行查询，计算 `top_hosts`
- `tests/unit/test_daily_stats_repo.py`: 新增 4 个单元测试

## 测试

- 测试环境：本地开发环境
- 已运行：73 个相关单元测试，全部通过
- 新增测试：
  - `test_get_host_totals_no_filters`
  - `test_get_host_totals_with_filters`
  - `test_get_host_totals_handles_none_values`
  - `test_get_host_totals_with_tenant_id`

## 风险

- 兼容性风险：无（新增功能，不影响现有 API）
- 性能风险：低（新增查询与现有查询并行执行）
- 回归风险：低（不修改现有方法）