### PR TITLE
fix(messages): add missing columns to GROUP BY in get_conversation_details

### DIFF
--- a/app/repositories/message_repo.py
+++ b/app/repositories/message_repo.py
@@ -620,6 +620,7 @@ class MessageRepository:
             Optional[Dict]: Conversation details or None.
         """
         # Use COALESCE to match session_id from multiple possible fields
+        # GROUP BY includes all non-aggregated columns for PostgreSQL compatibility (Issue #2105)
         query = """
             SELECT
                 COALESCE(conversation_id, feishu_conversation_id, agent_session_id) as conversation_id,
@@ -637,7 +638,8 @@ class MessageRepository:
                 MAX(timestamp) as last_message_time
             FROM daily_messages
             WHERE COALESCE(conversation_id, feishu_conversation_id, agent_session_id) = ?
-            GROUP BY COALESCE(conversation_id, feishu_conversation_id, agent_session_id)
+            GROUP BY COALESCE(conversation_id, feishu_conversation_id, agent_session_id),
+                     agent_session_id, tool_name, host_name, sender_name
         """
 
         return self.db.fetch_one(query, (session_id,))


### PR DESCRIPTION
## 修复说明

关联 Issue：#2105

## 根因

`get_conversation_details` SQL 查询的 GROUP BY 子句缺少非聚合列 (`agent_session_id`, `tool_name`, `host_name`, `sender_name`)，导致 PostgreSQL 严格模式下执行失败返回 500 错误。

## 修复方案

补全 GROUP BY 子句，使其与 `get_conversation_history` 保持一致：
```sql
GROUP BY COALESCE(conversation_id, feishu_conversation_id, agent_session_id),
         agent_session_id, tool_name, host_name, sender_name
```

## 主要变更

- `app/repositories/message_repo.py`: 修复 `get_conversation_details` 的 GROUP BY 子句

## 测试

- 运行环境：本地开发环境
- 已运行测试：`pytest tests/unit/test_message_service.py` - 11 passed
- 回归测试：`pytest tests/unit/ -k "message"` - 190 passed

## 风险

- 兼容性风险：无（仅修复 SQL 语法）
- 性能风险：无（GROUP BY 列已存在于查询中）
- 安全风险：无
- 回归风险：低（修改范围小）

Generated with Qwen Code (4-shotted by Qwen-Coder)