### PR TITLE
ci(schema-sync): run alembic upgrade head on a throwaway DB (#2101 follow-up)

### DIFF
--- a/.github/workflows/schema-sync.yml
+++ b/.github/workflows/schema-sync.yml
@@ -78,3 +78,27 @@ jobs:
           python scripts/check_schema_sync.py --postgres-url "$SCHEMA_SYNC_DATABASE_URL"
           python scripts/validate_schema.py
           git diff --exit-code -- schema/schema-postgres.sql schema/schema-sqlite.sql
+
+      # Guard the real upgrade path: run `alembic upgrade head` end-to-end on a
+      # throwaway database so a failure that only surfaces at upgrade time (e.g.
+      # a revision id renamed after a DB was stamped, as in issue #2101) fails
+      # the gate. The single-head check is database-free and cannot catch this.
+      - name: Run alembic upgrade head on a throwaway DB
+        env:
+          UPGRADE_DATABASE_URL: postgresql://ace:ace@127.0.0.1:5432/ace_upgrade_check
+        run: |
+          # Dedicated DB so the schema-sync snapshots above are untouched.
+          PGPASSWORD=ace psql -h 127.0.0.1 -U ace -d postgres -c \
+            "DROP DATABASE IF EXISTS ace_upgrade_check;" >/dev/null
+          PGPASSWORD=ace psql -h 127.0.0.1 -U ace -d postgres -c \
+            "CREATE DATABASE ace_upgrade_check;" >/dev/null
+          # Pin the URL on the Alembic config directly; migrations/env.py honors
+          # a caller-set sqlalchemy.url over the project's configured DB.
+          python -c "
+          from alembic.config import Config
+          from alembic import command
+          cfg = Config('alembic.ini')
+          cfg.set_main_option('sqlalchemy.url', '$UPGRADE_DATABASE_URL')
+          command.upgrade(cfg, 'head')
+          print('alembic upgrade head OK on throwaway DB')
+          "


### PR DESCRIPTION
## Summary

Follow-up to #2107 (issue #2101). Adds a step to the `schema-sync` CI job that runs `alembic upgrade head` end-to-end on a dedicated throwaway Postgres database.

## Why

The single-head check (`scripts/check_migration_heads.py`) is database-free — it only parses migration modules and resolves the revision graph in source. It **cannot** catch a phantom that lives in a stamped DB row (issue #2101's actual failure mode: a revision id renamed after a DB was stamped with the old id). Only a live `alembic upgrade head` against a real database surfaces that.

The schema-sync job already runs Postgres and installs the full `requirements.txt`, so it can exercise `env.py` end-to-end — unlike the single-head check, which runs in a synthetic pre-merged tree without `migrations/env.py` or `scripts/`.

## What it does

- Creates a dedicated `ace_upgrade_check` DB (dropped first so re-runs are clean) so the schema-sync snapshot DB is untouched.
- Pins the URL on the Alembic config via `cfg.set_main_option("sqlalchemy.url", ...)`. `migrations/env.py` (merged in #2107) honors a caller-set `sqlalchemy.url` over the project's configured database, so no `DATABASE_URL` plumbing is needed.
- Runs `command.upgrade(cfg, "head")`. A failure that only appears at upgrade time (broken/stamped revision, unresolvable parent at runtime) now fails the gate.

## Verification

- YAML validated locally (`yaml.safe_load` + `check-yaml` pre-commit hook).
- The upgrade path itself was verified end-to-end in #2107 (issue repro now succeeds against a throwaway SQLite DB).
- schema-sync CI will exercise the new step on this PR.

Follow-up to #2107. Does not close #2101 (the code fix already landed there) — this is the CI hardening called out in that PR.