### PR TITLE
fix(api-keys): remove timezone info from resolved_at for PostgreSQL compatibility

### DIFF
--- a/app/modules/workspace/api_key_proxy.py
+++ b/app/modules/workspace/api_key_proxy.py
@@ -594,7 +594,8 @@ class APIKeyProxyService:
             # Resolve and store IPs for DNS rebinding protection
             resolved_ips, _ = resolve_and_store_ips(base_url)
             if resolved_ips:
-                resolved_at = datetime.now(timezone.utc)  # Use UTC timestamp
+                # Use UTC timestamp, remove timezone info for PostgreSQL TIMESTAMP compatibility
+                resolved_at = datetime.now(timezone.utc).replace(tzinfo=None)
                 logger.info(
                     "Resolved IPs for base_url: %s -> %s",
                     base_url[:50] + "..." if len(base_url) > 50 else base_url,
@@ -935,7 +936,8 @@ class APIKeyProxyService:
             if base_url:
                 resolved_ips, _ = resolve_and_store_ips(base_url)
                 if resolved_ips:
-                    resolved_at = datetime.now(timezone.utc)  # Use UTC timestamp
+                    # Use UTC timestamp, remove timezone info for PostgreSQL TIMESTAMP compatibility
+                    resolved_at = datetime.now(timezone.utc).replace(tzinfo=None)
                     logger.info(
                         "Resolved IPs for updated base_url: %s -> %s",
                         base_url[:50] + "..." if len(base_url) > 50 else base_url,


### PR DESCRIPTION
## 问题

Fixes #2111

在提交 API Key 时报错：
```
invalid input syntax for type timestamp: "CURRENT_TIMESTAMP"
```

## 根因

`resolved_at` 字段使用了带时区的 datetime 对象 `datetime.now(timezone.utc)`，但数据库列定义为 `TIMESTAMP`（无时区），导致 PostgreSQL 无法正确处理。

## 修复

在 `app/modules/workspace/api_key_proxy.py` 中修改了两处代码：
- `store_api_key` 方法 (第 598 行)
- `update_api_key_by_id` 方法 (第 940 行)

使用 `.replace(tzinfo=None)` 移除 timezone 信息：

```python
# 修改前
resolved_at = datetime.now(timezone.utc)

# 修改后
resolved_at = datetime.now(timezone.utc).replace(tzinfo=None)
```

此模式与代码库中其他地方保持一致（如 `model_gateway/repository.py` 第 124 行）。

## 测试

- ✅ 运行 `tests/unit/test_key_rotation_scripts.py` - 6 passed
- ✅ 运行 `tests/issues/1894/test_llm_proxy_ssrf_protection.py` - 15 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)