### PR TITLE
fix: PostgreSQL 布尔值更新 SSO 设置失败

### DIFF
--- a/app/repositories/tenant_repo.py
+++ b/app/repositories/tenant_repo.py
@@ -684,7 +684,7 @@ class TenantRepository:
             tenant_id: Tenant ID.
             settings_dict: Settings dictionary to update.
         """
-        from app.repositories.database import get_param_placeholder
+        from app.repositories.database import adapt_boolean_value, get_param_placeholder
 
         p = get_param_placeholder()
 
@@ -714,10 +714,9 @@ class TenantRepository:
                 fields.append(f"{key} = {p}")
                 value = settings_dict[key]
                 if cast_type is bool:
-                    # SQLite uses 1/0 for boolean
-                    value = 1 if value else 0
+                    value = adapt_boolean_value(value)
                 elif cast_type is int and isinstance(value, bool):
-                    value = 1 if value else 0
+                    value = adapt_boolean_value(value)
                 values.append(value)
 
         if not fields:

--- a/app/repositories/tenant_repo.py
+++ b/app/repositories/tenant_repo.py
@@ -713,9 +713,7 @@ class TenantRepository:
             if key in settings_dict:
                 fields.append(f"{key} = {p}")
                 value = settings_dict[key]
-                if cast_type is bool:
-                    value = adapt_boolean_value(value)
-                elif cast_type is int and isinstance(value, bool):
+                if cast_type is bool or cast_type is int and isinstance(value, bool):
                     value = adapt_boolean_value(value)
                 values.append(value)
 

--- a/tests/unit/test_tenant_repo.py
+++ b/tests/unit/test_tenant_repo.py
@@ -627,3 +627,111 @@ class TestTenantRepository:
         self.db.fetch_one.return_value = None
         result = self.repo.count()
         assert result == 0
+
+
+class TestUpdateTenantSettingsTableBooleanHandling:
+    """Tests for _update_tenant_settings_table boolean value handling.
+
+    Verifies that boolean values are correctly adapted for PostgreSQL vs SQLite.
+    Regression test for issue where PostgreSQL boolean columns received integer values.
+    """
+
+    def setup_method(self):
+        self.db = MagicMock()
+        self.db.is_postgresql = False
+        self.repo = TenantRepository(db=self.db)
+
+    def test_update_tenant_settings_table_sqlite_uses_integer(self):
+        """SQLite should receive 1/0 for boolean columns."""
+        # Mock existing tenant_settings row
+        self.db.fetch_one.return_value = {"id": 1}
+        mock_cursor = MagicMock()
+        self.db.execute.return_value = mock_cursor
+
+        # Call update with boolean settings
+        # Note: field_mapping order is: content_filter_enabled, audit_log_enabled,
+        # audit_log_retention_days, data_retention_days, sso_enabled, sso_provider,
+        # auto_provision_users, block_sensitive_keyword, sensitive_keyword_match_mode
+        settings_dict = {
+            "content_filter_enabled": False,
+            "sso_enabled": True,
+            "auto_provision_users": True,
+        }
+
+        with patch("app.repositories.database.is_postgresql", return_value=False):
+            self.repo._update_tenant_settings_table(1, settings_dict)
+
+        # Verify execute was called
+        assert self.db.execute.called
+        call_args = self.db.execute.call_args
+        query = call_args[0][0]
+        params = call_args[0][1]
+
+        # Verify query structure
+        assert "UPDATE tenant_settings SET" in query
+        assert "sso_enabled = ?" in query
+        assert "auto_provision_users = ?" in query
+        assert "content_filter_enabled = ?" in query
+
+        # SQLite should receive integers (1/0)
+        # Order follows field_mapping: content_filter_enabled, sso_enabled, auto_provision_users
+        assert params[0] == 0  # content_filter_enabled = False
+        assert params[1] == 1  # sso_enabled = True
+        assert params[2] == 1  # auto_provision_users = True
+
+    def test_update_tenant_settings_table_postgresql_uses_boolean(self):
+        """PostgreSQL should receive True/False for boolean columns."""
+        # Mock existing tenant_settings row
+        self.db.fetch_one.return_value = {"id": 1}
+        mock_cursor = MagicMock()
+        self.db.execute.return_value = mock_cursor
+
+        # Call update with boolean settings
+        settings_dict = {
+            "content_filter_enabled": False,
+            "sso_enabled": True,
+            "auto_provision_users": True,
+        }
+
+        with patch("app.repositories.database.is_postgresql", return_value=True):
+            self.repo._update_tenant_settings_table(1, settings_dict)
+
+        # Verify execute was called
+        assert self.db.execute.called
+        call_args = self.db.execute.call_args
+        params = call_args[0][1]
+
+        # PostgreSQL should receive Python booleans (True/False)
+        # Order follows field_mapping: content_filter_enabled, sso_enabled, auto_provision_users
+        assert params[0] is False  # content_filter_enabled = False
+        assert params[1] is True  # sso_enabled = True
+        assert params[2] is True  # auto_provision_users = True
+
+    def test_update_tenant_settings_table_mixed_types(self):
+        """Test with mixed boolean and non-boolean settings."""
+        # Mock existing tenant_settings row
+        self.db.fetch_one.return_value = {"id": 1}
+        mock_cursor = MagicMock()
+        self.db.execute.return_value = mock_cursor
+
+        # Call update with mixed settings
+        # field_mapping order: audit_log_retention_days comes before sso_enabled and sso_provider
+        settings_dict = {
+            "audit_log_retention_days": 30,
+            "sso_enabled": True,
+            "sso_provider": "okta",
+        }
+
+        with patch("app.repositories.database.is_postgresql", return_value=True):
+            self.repo._update_tenant_settings_table(1, settings_dict)
+
+        # Verify execute was called
+        assert self.db.execute.called
+        call_args = self.db.execute.call_args
+        params = call_args[0][1]
+
+        # Verify types
+        # Order follows field_mapping: audit_log_retention_days, sso_enabled, sso_provider
+        assert params[0] == 30  # audit_log_retention_days (int)
+        assert params[1] is True  # sso_enabled (boolean)
+        assert params[2] == "okta"  # sso_provider (str)


### PR DESCRIPTION
## 问题

在 SSO 设置页面 (`/manage/settings/sso`) 打开 "Auto-provision Users" 开关并点击 Save 按钮时，PostgreSQL 数据库返回 "Failed to save settings" 错误。

Closes #2118

## 根因分析

`app/repositories/tenant_repo.py` 中的 `_update_tenant_settings_table` 方法在处理布尔值时，没有区分 PostgreSQL 和 SQLite：

```python
if cast_type is bool:
    # SQLite uses 1/0 for boolean
    value = 1 if value else 0  # ← 对所有数据库都使用整数
```

当 PostgreSQL 的 `tenant_settings.auto_provision_users` 列是 `boolean` 类型时，尝试用整数 1/0 更新会导致类型不匹配错误。

## 修复方案

在 `_update_tenant_settings_table` 方法中使用 `adapt_boolean_value` 函数替代硬编码的 1/0：

```python
from app.repositories.database import adapt_boolean_value, get_param_placeholder

if cast_type is bool:
    value = adapt_boolean_value(value)  # PostgreSQL: True/False, SQLite: 1/0
```

## 测试

添加了 `TestUpdateTenantSettingsTableBooleanHandling` 测试类验证修复：

- `test_update_tenant_settings_table_sqlite_uses_integer`: 验证 SQLite 接收整数 1/0
- `test_update_tenant_settings_table_postgresql_uses_boolean`: 验证 PostgreSQL 接收布尔值 True/False
- `test_update_tenant_settings_table_mixed_types`: 验证混合类型处理

## 影响范围

- 仅影响 PostgreSQL 数据库
- 所有 tenant_settings 表的布尔字段更新都受影响：`sso_enabled`, `auto_provision_users`, `content_filter_enabled`, `audit_log_enabled`, `block_sensitive_keyword`

Generated with Qwen Code (1-shotted by Qwen-Coder)