### PR TITLE
fix: SSO 用户创建时使用 Provider 的 tenant_id

### DIFF
--- a/app/routes/sso.py
+++ b/app/routes/sso.py
@@ -1545,6 +1545,10 @@ def _create_user_from_sso(sso_user, provider_name: str) -> int | None:
         username = f"{base_username}_{counter}"
         counter += 1
 
+    # Get tenant_id from Provider configuration
+    provider = get_sso_manager().get_provider(provider_name)
+    tenant_id = provider.config.tenant_id if provider and provider.config.tenant_id else 1
+
     # Create user
     try:
         user_id = user_repo.create_user(
@@ -1552,10 +1556,11 @@ def _create_user_from_sso(sso_user, provider_name: str) -> int | None:
             email=sso_user.email or "",
             password_hash="",  # No password for SSO users
             role="user",
+            tenant_id=tenant_id,
         )
 
         if user_id:
-            logger.info(f"Created user {username} from SSO provider {provider_name}")
+            logger.info(f"Created user {username} from SSO provider {provider_name} with tenant_id={tenant_id}")
 
         return user_id
 

--- a/app/routes/sso.py
+++ b/app/routes/sso.py
@@ -1560,7 +1560,9 @@ def _create_user_from_sso(sso_user, provider_name: str) -> int | None:
         )
 
         if user_id:
-            logger.info(f"Created user {username} from SSO provider {provider_name} with tenant_id={tenant_id}")
+            logger.info(
+                f"Created user {username} from SSO provider {provider_name} with tenant_id={tenant_id}"
+            )
 
         return user_id
 

--- a/tests/issues/2121/test_sso_user_tenant_id.py
+++ b/tests/issues/2121/test_sso_user_tenant_id.py
@@ -1,0 +1,145 @@
+"""
+Tests for SSO user creation with tenant_id.
+
+Issue #2121: SSO 用户创建时未使用 Provider 的 tenant_id
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from flask import Flask
+
+from app.modules.sso.provider import SSOProviderConfig, SSOUser
+from app.routes import sso as sso_module
+
+
+@pytest.fixture
+def app_ctx():
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    with app.test_request_context("/"):
+        yield app
+
+
+def _make_sso_user(username="testuser", email="test@example.com", provider_user_id="idp-123"):
+    """Create a mock SSO user."""
+    return SSOUser(
+        provider="test-provider",
+        provider_user_id=provider_user_id,
+        email=email,
+        username=username,
+        email_verified=True,
+        raw_data={},
+    )
+
+
+def _make_provider_config(tenant_id=2):
+    """Create a mock provider config with tenant_id."""
+    return SSOProviderConfig(
+        name="test-provider",
+        provider_type="oidc",
+        client_id="test-client-id",
+        client_secret="test-secret",
+        authorization_url="https://example.com/auth",
+        token_url="https://example.com/token",
+        tenant_id=tenant_id,
+    )
+
+
+class TestCreateUserFromSsoTenantId:
+    """Test cases for _create_user_from_sso tenant_id handling."""
+
+    def test_uses_provider_tenant_id_when_available(self, app_ctx):
+        """When Provider has tenant_id, use it for user creation."""
+        sso_user = _make_sso_user()
+        provider_config = _make_provider_config(tenant_id=5)
+
+        manager = MagicMock()
+        provider = MagicMock()
+        provider.config = provider_config
+        manager.get_provider.return_value = provider
+
+        user_repo_mock = MagicMock()
+        user_repo_mock.get_user_by_username.return_value = None  # No existing user
+        user_repo_mock.create_user.return_value = 42
+
+        with (
+            patch.object(sso_module, "get_sso_manager", return_value=manager),
+            patch.object(sso_module, "user_repo", user_repo_mock),
+        ):
+            result = sso_module._create_user_from_sso(sso_user, "test-provider")
+
+        assert result == 42
+        # Verify create_user was called with correct tenant_id
+        user_repo_mock.create_user.assert_called_once()
+        call_kwargs = user_repo_mock.create_user.call_args.kwargs
+        assert call_kwargs["tenant_id"] == 5
+
+    def test_uses_default_tenant_id_when_provider_not_found(self, app_ctx):
+        """When Provider is not found, use default tenant_id=1."""
+        sso_user = _make_sso_user()
+
+        manager = MagicMock()
+        manager.get_provider.return_value = None  # Provider not found
+
+        user_repo_mock = MagicMock()
+        user_repo_mock.get_user_by_username.return_value = None
+        user_repo_mock.create_user.return_value = 42
+
+        with (
+            patch.object(sso_module, "get_sso_manager", return_value=manager),
+            patch.object(sso_module, "user_repo", user_repo_mock),
+        ):
+            result = sso_module._create_user_from_sso(sso_user, "unknown-provider")
+
+        assert result == 42
+        call_kwargs = user_repo_mock.create_user.call_args.kwargs
+        assert call_kwargs["tenant_id"] == 1
+
+    def test_uses_default_tenant_id_when_provider_tenant_id_is_none(self, app_ctx):
+        """When Provider's tenant_id is None, use default tenant_id=1."""
+        sso_user = _make_sso_user()
+        provider_config = _make_provider_config(tenant_id=None)
+
+        manager = MagicMock()
+        provider = MagicMock()
+        provider.config = provider_config
+        manager.get_provider.return_value = provider
+
+        user_repo_mock = MagicMock()
+        user_repo_mock.get_user_by_username.return_value = None
+        user_repo_mock.create_user.return_value = 42
+
+        with (
+            patch.object(sso_module, "get_sso_manager", return_value=manager),
+            patch.object(sso_module, "user_repo", user_repo_mock),
+        ):
+            result = sso_module._create_user_from_sso(sso_user, "test-provider")
+
+        assert result == 42
+        call_kwargs = user_repo_mock.create_user.call_args.kwargs
+        assert call_kwargs["tenant_id"] == 1
+
+    def test_uses_tenant_id_1_when_provider_tenant_id_is_1(self, app_ctx):
+        """When Provider's tenant_id is 1, use tenant_id=1."""
+        sso_user = _make_sso_user()
+        provider_config = _make_provider_config(tenant_id=1)
+
+        manager = MagicMock()
+        provider = MagicMock()
+        provider.config = provider_config
+        manager.get_provider.return_value = provider
+
+        user_repo_mock = MagicMock()
+        user_repo_mock.get_user_by_username.return_value = None
+        user_repo_mock.create_user.return_value = 42
+
+        with (
+            patch.object(sso_module, "get_sso_manager", return_value=manager),
+            patch.object(sso_module, "user_repo", user_repo_mock),
+        ):
+            result = sso_module._create_user_from_sso(sso_user, "test-provider")
+
+        assert result == 42
+        call_kwargs = user_repo_mock.create_user.call_args.kwargs
+        assert call_kwargs["tenant_id"] == 1


### PR DESCRIPTION
## 修复说明

关联 Issue：#2121

## 根因

`_create_user_from_sso()` 函数在调用 `user_repo.create_user()` 时，未传递 `tenant_id` 参数，导致 SSO 新用户使用了默认值 `tenant_id=1`，而非 Provider 配置的 tenant_id。

## 修复方案

在 `_create_user_from_sso()` 函数中：
1. 通过 `get_sso_manager().get_provider(provider_name)` 获取 Provider 实例
2. 从 `provider.config.tenant_id` 获取租户 ID
3. 传递给 `user_repo.create_user()` 的 `tenant_id` 参数
4. 添加边界情况处理：Provider 或 tenant_id 为 None 时使用默认值 1

## 主要变更

- **app/routes/sso.py**：修改 `_create_user_from_sso()` 函数，添加 tenant_id 获取和传递逻辑
- **tests/issues/2121/test_sso_user_tenant_id.py**：添加 4 个测试用例覆盖主要场景和边界情况

## 测试

- **测试环境**：本地开发环境
- **已运行测试**：`pytest tests/issues/2121/test_sso_user_tenant_id.py -v`
- **测试结果**：4 passed
- **新增测试**：
  - `test_uses_provider_tenant_id_when_available`：验证使用 Provider 的 tenant_id
  - `test_uses_default_tenant_id_when_provider_not_found`：验证 Provider 为 None 时使用默认值
  - `test_uses_default_tenant_id_when_provider_tenant_id_is_none`：验证 tenant_id 为 None 时使用默认值
  - `test_uses_tenant_id_1_when_provider_tenant_id_is_1`：验证 tenant_id=1 的场景

## 风险

- **兼容性风险**：无。修改仅影响 `_create_user_from_sso()` 函数内部逻辑，不改变函数签名，默认值仍为 1，保持向后兼容。
- **性能风险**：无。`get_provider()` 内部有缓存机制，不会增加额外的数据库查询。
- **安全风险**：无。tenant_id 来自已配置的 Provider，非用户输入，防御性处理确保安全。
- **回归风险**：无。修改范围极小，不影响现有用户创建逻辑。