### PR TITLE
fix: SSO 登录页面查询所有已启用的 Provider (#2125)

### DIFF
--- a/frontend/src/components/features/Login.tsx
+++ b/frontend/src/components/features/Login.tsx
@@ -187,8 +187,8 @@ export const Login: React.FC = () => {
         const settings = tenant.settings as Record<string, unknown>;
 
         if (settings?.sso_enabled) {
-          // Get enabled SSO providers
-          const result = await ssoApi.getProviders(1);
+          // Get enabled SSO providers (all tenants)
+          const result = await ssoApi.getProviders();
           const enabledProviders = result.registered.filter((p) => p.is_enabled);
           setSsoProviders(enabledProviders);
         }


### PR DESCRIPTION
## 修复说明

关联 Issue：#2125

## 根因

登录页面硬编码查询 \`tenant_id=1\` 的 SSO Provider，当 Provider 注册到其他租户时，登录页面不显示 SSO 登录按钮。

问题点：
- \`Login.tsx\` 硬编码 \`ssoApi.getProviders(1)\` 仅查询 tenant_id=1 的 Provider

## 修复方案

采用 Issue 建议的方案 A：移除 tenant_id 筛选，查询所有已启用的 Provider。

**变更**：\`Login.tsx\` 中 \`ssoApi.getProviders(1)\` 改为 \`ssoApi.getProviders()\`

**保留**：\`sso_enabled\` 开关作为全局 SSO 开关（基于 tenant 1 的设置）

## 主要变更

- \`Login.tsx\`: \`ssoApi.getProviders(1)\` → \`ssoApi.getProviders()\`

## 测试

- 本地环境：前端构建成功
- 需要手动验证：在测试环境验证不同租户的 SSO Provider 显示

## 风险

- **安全风险**：低风险，\`/api/sso/providers\` 本身就是公开 API
- **回归风险**：可控，这是预期的行为变化

## 后续改进

单独创建 Issue 改进 \`sso_enabled\` 开关的命名或功能（当前开关基于 tenant 1 设置，可能需要改为全局系统设置）。