### PR TITLE
fix: 改进映射规则编辑器的认证错误提示

### DIFF
--- a/frontend/src/components/features/management/MappingRulesEditor.tsx
+++ b/frontend/src/components/features/management/MappingRulesEditor.tsx
@@ -7,6 +7,7 @@ import { useLanguage } from '@/store';
 import { t } from '@/i18n';
 import { Button, TextInput, Modal, Badge, useToast, useConfirm } from '@/components/common';
 import { mappingRulesApi, type MappingRule } from '@/api/mappingRules';
+import type { ApiError } from '@/types';
 
 // Match types with display names
 const MATCH_TYPES = [
@@ -73,7 +74,12 @@ export const MappingRulesEditor: React.FC<MappingRulesEditorProps> = ({
       onChange?.();
     } catch (err) {
       console.error('Failed to generate default rules:', err);
-      toast.error(language === 'zh' ? '生成默认规则失败' : 'Failed to generate default rules');
+      const apiError = err as ApiError;
+      if (apiError.status === 401) {
+        toast.error(language === 'zh' ? '请先登录' : 'Please log in first');
+      } else {
+        toast.error(language === 'zh' ? '生成默认规则失败' : 'Failed to generate default rules');
+      }
     } finally {
       setIsGenerating(false);
     }
@@ -110,7 +116,12 @@ export const MappingRulesEditor: React.FC<MappingRulesEditorProps> = ({
       toast.success(language === 'zh' ? '规则添加成功' : 'Rule added successfully');
     } catch (err) {
       console.error('Failed to add rule:', err);
-      toast.error(language === 'zh' ? '规则添加失败' : 'Failed to add rule');
+      const apiError = err as ApiError;
+      if (apiError.status === 401) {
+        toast.error(language === 'zh' ? '请先登录' : 'Please log in first');
+      } else {
+        toast.error(language === 'zh' ? '规则添加失败' : 'Failed to add rule');
+      }
     } finally {
       setIsAdding(false);
     }


### PR DESCRIPTION

## 修复说明

关联 Issue：#2130

## 根因

当 API 返回 401 时，前端错误处理不够精确，没有区分"未登录"和"其他错误"。用户看到通用错误消息"生成默认规则失败"，不知道需要重新登录。

## 修复方案

在错误处理中检查 `ApiError.status`，针对 401 显示不同的错误消息：
- 401 → "请先登录"
- 其他错误 → 保持原有通用错误消息

## 主要变更

- 导入 `ApiError` 类型
- 修改 `handleGenerateDefaultRules` 函数的错误处理
- 修改 `handleAddRule` 函数的错误处理

## 测试

- 前端 lint 检查通过（0 errors, 18 warnings）
- 无相关单元测试文件

## 风险

- 低风险：仅修改错误消息，不影响正常功能流程
- 兼容性：无影响

Generated with Qwen Code (4-shotted by Qwen-Coder)