### PR TITLE
fix: 恢复 terminal 会话后显示'工作区未配置'，无法新建会话 (#2138)

### DIFF
--- a/frontend/src/components/features/Workspace.tsx
+++ b/frontend/src/components/features/Workspace.tsx
@@ -322,32 +322,30 @@ export const Workspace: React.FC = () => {
         setConfig(workspaceConfig);
 
         // Get user-specific URL (needed for token and openace_url in both modes)
+        // Always fetch userWebUI — even in terminal-only scenarios, users may create
+        // new sessions or switch to non-terminal tabs, which require userWebUI.
+        // Previously we skipped this for terminal-only URLs, which caused
+        // getEffectiveUrl() to return '' and the UI to show "工作区未配置". (Issue #2138)
         if (workspaceConfig.enabled) {
-          // Check if we only need terminal — skip webui startup if so
-          const wsType = searchParams.get('workspaceType');
-          const hasOnlyTerminalParams = wsType === 'terminal' && searchParams.get('terminalId');
-
-          if (!hasOnlyTerminalParams) {
-            setLoadingStage('startingWorkspace');
-            try {
-              const userWebUIResponse = await workspaceApi.getUserWebUIUrl();
-              if (userWebUIResponse.success) {
-                setUserWebUI(userWebUIResponse);
-              } else {
-                // Log the error when API returns success: false
-                console.error('[Workspace] getUserWebUIUrl failed:', userWebUIResponse.error);
-                // In multi-user mode, token is required - show error to user
-                if (workspaceConfig.multi_user_mode) {
-                  setError('WebUI authentication failed. Please refresh the page.');
-                }
-              }
-            } catch (error) {
-              // Log the error when API call fails
-              console.error('[Workspace] getUserWebUIUrl error:', error);
-              // In multi-user mode, token is required for authentication
+          setLoadingStage('startingWorkspace');
+          try {
+            const userWebUIResponse = await workspaceApi.getUserWebUIUrl();
+            if (userWebUIResponse.success) {
+              setUserWebUI(userWebUIResponse);
+            } else {
+              // Log the error when API returns success: false
+              console.error('[Workspace] getUserWebUIUrl failed:', userWebUIResponse.error);
+              // In multi-user mode, token is required - show error to user
               if (workspaceConfig.multi_user_mode) {
                 setError('WebUI authentication failed. Please refresh the page.');
               }
+            }
+          } catch (error) {
+            // Log the error when API call fails
+            console.error('[Workspace] getUserWebUIUrl error:', error);
+            // In multi-user mode, token is required for authentication
+            if (workspaceConfig.multi_user_mode) {
+              setError('WebUI authentication failed. Please refresh the page.');
             }
           }
           setLoadingStage('ready');


### PR DESCRIPTION
## 问题描述

在 multi-user 模式下，恢复 terminal 类型的历史会话后，页面跳转到 `/work?workspaceType=terminal&terminalId=...`，工作区提示 **"工作区未配置 请联系管理员配置工作区 URL"**，并且点击【+新建会话】按钮也无法新建会话。

## 根因

`Workspace.tsx` 初始化阶段在检测到 URL 仅含 terminal 参数时，会跳过 `getUserWebUIUrl()` 的调用。但渲染阶段的 `getEffectiveUrl()` 在 multi-user 模式下依赖 `userWebUI` 状态来生成有效 URL，当 `userWebUI` 为 null 时返回空字符串，导致页面显示错误。

## 修复方案

移除 `hasOnlyTerminalParams` 条件判断，初始化阶段**始终获取 `userWebUI`**，即使当前是 terminal-only 场景。这样用户恢复 terminal 会话后仍可新建会话或切换到其他 tab。

## 变更文件

- `frontend/src/components/features/Workspace.tsx` — 移除 terminal 场景跳过 `userWebUI` 获取的条件分支

Closes #2138
