### PR TITLE
fix: 恢复历史会话 400 错误 — 使用 legacy 编码匹配 qwen-code-webui (Issue #2142)

### DIFF
--- a/app/routes/workspace.py
+++ b/app/routes/workspace.py
@@ -93,11 +93,11 @@ def encode_project_path(project_path: str) -> str:
 
 
 def encode_project_path_legacy(project_path: str) -> str:
-    """Encode a project path to the legacy CLI directory-name format.
+    r"""Encode a project path to the legacy CLI directory-name format.
 
     The qwen / claude CLI stores per-project data under
     ``~/.qwen/projects/<encoded>`` (or ``~/.claude/projects/<encoded>``) where
-    ``<encoded>`` is the project path with every path separator (``/``, ``\\``)
+    ``<encoded>`` is the project path with every path separator (``/``, ``\``)
     and common special characters replaced by ``-``.  For example::
 
         /home/user/demo-project  →  -home-user-demo-project
@@ -1662,9 +1662,7 @@ def restore_session(session_id):
                 decoded = decode_project_name(actual_path)
                 if decoded:
                     actual_path = decoded
-            encoded_project_name = (
-                encode_project_path_legacy(actual_path) if actual_path else ""
-            )
+            encoded_project_name = encode_project_path_legacy(actual_path) if actual_path else ""
         elif tool_name == "openclaw":
             # project_path is the agent_name (e.g., "main")
             encoded_project_name = project_path

--- a/app/routes/workspace.py
+++ b/app/routes/workspace.py
@@ -12,6 +12,7 @@ API endpoints for workspace functionality including:
 import base64
 import logging
 import os
+import re
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
@@ -89,6 +90,38 @@ def encode_project_path(project_path: str) -> str:
     # Remove padding for cleaner URLs
     encoded = encoded.rstrip("=")
     return f"{_B64_PREFIX}{encoded}"
+
+
+def encode_project_path_legacy(project_path: str) -> str:
+    """Encode a project path to the legacy CLI directory-name format.
+
+    The qwen / claude CLI stores per-project data under
+    ``~/.qwen/projects/<encoded>`` (or ``~/.claude/projects/<encoded>``) where
+    ``<encoded>`` is the project path with every path separator (``/``, ``\\``)
+    and common special characters replaced by ``-``.  For example::
+
+        /home/user/demo-project  →  -home-user-demo-project
+
+    This is the format the CLI creates on disk and the format qwen-code-webui
+    expects when resolving the history directory.  Unlike ``encode_project_path``
+    (which produces the ``b64:`` URL-safe base64 form used by the file-changes
+    API and other newer endpoints), this helper must be used whenever the
+    encoded name is consumed by qwen-code-webui's history endpoints or by the
+    on-disk directory lookup (Issue #2142).
+
+    Args:
+        project_path: The absolute path to encode.
+
+    Returns:
+        The legacy encoded directory name, or empty string for empty input.
+    """
+    if not project_path:
+        return ""
+    # Strip a trailing slash so /home/user/ and /home/user encode identically.
+    normalized = project_path.rstrip("/")
+    # Replace '/', '\', ':', '.', and '_' with '-' (matches the CLI encoding
+    # used by qwen-code / claude-code when creating project directories).
+    return re.sub(r"[/\\:._]", "-", normalized)
 
 
 def decode_project_name(encoded_name: str) -> str:
@@ -1612,25 +1645,26 @@ def restore_session(session_id):
                     )
 
         # Generate encodedProjectName based on tool
-        # Issue #2136: Use new encoding format (b64:<base64>)
+        # Issue #2142: qwen-code-webui's history endpoints expect the legacy
+        # CLI directory-name format (-home-user-project), not the b64: format
+        # introduced by Issue #2136.  The b64: prefix contains ':' which the
+        # webui rejects as a dangerous character (400), and even if it didn't,
+        # the on-disk history directory uses the legacy encoding.  Always
+        # produce the legacy form for qwen/claude so the webui can locate the
+        # conversation JSONL files on disk.
         if normalize_tool_name(tool_name) in ["qwen", "claude"]:
-            # project_path may be actual path or encoded name
-            if project_path:
-                if project_path.startswith("/"):
-                    # Actual path, encode using new format
-                    encoded_project_name = encode_project_path(project_path)
-                elif project_path.startswith(_B64_PREFIX):
-                    # Already encoded with new format
-                    encoded_project_name = project_path
-                else:
-                    # Legacy format or empty - try to decode then re-encode
-                    decoded = decode_project_name(project_path)
-                    if decoded:
-                        encoded_project_name = encode_project_path(decoded)
-                    else:
-                        encoded_project_name = project_path
-            else:
-                encoded_project_name = project_path
+            # Resolve project_path to an actual filesystem path first.
+            actual_path = project_path or ""
+            if actual_path.startswith(_B64_PREFIX):
+                actual_path = decode_project_name(actual_path) or ""
+            elif actual_path and not actual_path.startswith("/"):
+                # Legacy encoded or other — decode to get the real path.
+                decoded = decode_project_name(actual_path)
+                if decoded:
+                    actual_path = decoded
+            encoded_project_name = (
+                encode_project_path_legacy(actual_path) if actual_path else ""
+            )
         elif tool_name == "openclaw":
             # project_path is the agent_name (e.g., "main")
             encoded_project_name = project_path

--- a/tests/unit/test_project_path_encoding.py
+++ b/tests/unit/test_project_path_encoding.py
@@ -194,3 +194,53 @@ class TestEdgeCases:
         decoded = decode_project_name(encoded)
         assert decoded == path
         assert "--" in decoded  # Consecutive hyphens preserved
+
+
+# Issue #2142: restore_session uses legacy encoding for qwen-code-webui compatibility
+from app.routes.workspace import encode_project_path_legacy
+
+
+class TestEncodeProjectPathLegacy:
+    """Tests for encode_project_path_legacy (Issue #2142)."""
+
+    def test_legacy_simple_path(self):
+        """Legacy format replaces / with -."""
+        assert encode_project_path_legacy("/home/user/demo-project") == "-home-user-demo-project"
+
+    def test_legacy_matches_cli_encoding(self):
+        """Must match the CLI encoding: /, \\, :, ., _ → -."""
+        assert encode_project_path_legacy("/home/user_name/project.dir") == "-home-user-name-project-dir"
+
+    def test_legacy_strips_trailing_slash(self):
+        """Trailing slash should not produce a trailing hyphen."""
+        assert encode_project_path_legacy("/home/user/") == "-home-user"
+
+    def test_legacy_empty_path(self):
+        """Empty input returns empty string."""
+        assert encode_project_path_legacy("") == ""
+
+    def test_legacy_no_colon_in_output(self):
+        """Output must never contain ':' so qwen-code-webui validation passes."""
+        for path in ["/home/user/project", "/tmp/test:8080/app", "C:/Users/foo"]:
+            result = encode_project_path_legacy(path)
+            assert ":" not in result, f"Colon found in {result!r} for path {path!r}"
+
+    def test_restore_flow_from_actual_path(self):
+        """DB has actual path → restore produces legacy format."""
+        db_path = "/home/user/demo-project"
+        result = encode_project_path_legacy(db_path)
+        assert result == "-home-user-demo-project"
+
+    def test_restore_flow_from_b64(self):
+        """DB has b64: encoded path → decode then legacy encode."""
+        b64_encoded = encode_project_path("/home/user/demo-project")
+        decoded = decode_project_name(b64_encoded)
+        result = encode_project_path_legacy(decoded)
+        assert result == "-home-user-demo-project"
+
+    def test_restore_flow_from_legacy(self):
+        """DB has legacy encoded path → decode then legacy encode (round-trip)."""
+        legacy = "-home-user-demo-project"
+        decoded = decode_project_name(legacy)
+        result = encode_project_path_legacy(decoded)
+        assert result == "-home-user-demo-project"

--- a/tests/unit/test_project_path_encoding.py
+++ b/tests/unit/test_project_path_encoding.py
@@ -209,7 +209,10 @@ class TestEncodeProjectPathLegacy:
 
     def test_legacy_matches_cli_encoding(self):
         """Must match the CLI encoding: /, \\, :, ., _ → -."""
-        assert encode_project_path_legacy("/home/user_name/project.dir") == "-home-user-name-project-dir"
+        assert (
+            encode_project_path_legacy("/home/user_name/project.dir")
+            == "-home-user-name-project-dir"
+        )
 
     def test_legacy_strips_trailing_slash(self):
         """Trailing slash should not produce a trailing hyphen."""


### PR DESCRIPTION
## 问题

恢复历史会话后，工作区 iframe 提示 **"加载对话失败 Failed to load conversation: 400 Bad Request"**。

F12 显示 qwen-code-webui 对 `GET /api/projects/b64:.../histories/<sessionId>` 返回 400。

## 根因

Issue #2136 引入 `b64:` 编码格式后，`restore_session` 端点生成的 `encodedProjectName` 包含冒号 `:`，触发两层问题：

1. **直接 400**：qwen-code-webui 的 `validateEncodedProjectName` 将 `:` 列为危险字符，拒绝请求
2. **隐藏 404**：即使通过验证，webui 用 `encodedProjectName` 直接拼接 `~/.qwen/projects/<encoded>` 查找目录，而 CLI 在磁盘上创建的是旧格式目录（`-home-user-project`），目录不存在

## 修复

- 新增 `encode_project_path_legacy()` 函数，生成与 qwen-code CLI 磁盘目录一致的旧格式编码（`/home/user/project` → `-home-user-project`）
- `restore_session` 对 `qwen`/`claude` 工具改用 legacy 格式，兼容 DB 中三种存储格式（实际路径 / `b64:` / legacy）
- 新增 8 个单元测试覆盖 legacy 编码和 restore 流程

## 验证

| 格式 | URL | 状态 |
|---|---|---|
| 旧 `b64:` 格式 | `/api/projects/b64:L2hvbWUv.../histories/<id>` | 400 ❌ |
| 新 legacy 格式 | `/api/projects/-home-d237-open-ace/histories/<id>` | 200 ✅ 成功加载对话 |

restore API 返回对比：
- 修复前：`"encoded_project_name": "b64:L2hvbWUvZDIzNy9vcGVuLWFjZQ"`
- 修复后：`"encoded_project_name": "-home-d237-open-ace"`

全部 36 个编码测试通过（28 原有 + 8 新增）。

Closes #2142
