### PR TITLE
fix: 前端 API 路径错误导致 SSO 设置保存失败 (#2143)

### DIFF
--- a/frontend/src/api/system.ts
+++ b/frontend/src/api/system.ts
@@ -17,7 +17,7 @@ export async function getSSOEnabled(): Promise<{ sso_enabled: boolean }> {
   const response = await apiClient.get<{
     success: boolean;
     data: { sso_enabled: boolean };
-  }>('/api/system/settings/sso-enabled');
+  }>('/api/settings/sso-enabled');
 
   return response.data;
 }
@@ -29,7 +29,7 @@ export async function getSystemSettings(): Promise<SystemSettings> {
   const response = await apiClient.get<{
     success: boolean;
     data: SystemSettings;
-  }>('/api/system/settings');
+  }>('/api/settings');
 
   return response.data;
 }
@@ -44,7 +44,7 @@ export async function updateSystemSettings(
     success: boolean;
     message: string;
     updated: string[];
-  }>('/api/system/settings', settings);
+  }>('/api/settings', settings);
 
   return response;
 }


### PR DESCRIPTION
## 修复说明

关联 Issue：#2143

## 根因

`frontend/src/api/system.ts` 中的 API 路径与后端路由不匹配。前端代码错误地在路径中添加了 `/system` 前缀。

后端 `system_bp` 注册时 `url_prefix="/api"`，路由定义为 `/settings/...`，实际完整路径是 `/api/settings/...`。

## 修复方案

修改 `frontend/src/api/system.ts` 中的 API 路径：
- `/api/system/settings/sso-enabled` → `/api/settings/sso-enabled`
- `/api/system/settings` → `/api/settings`

## 主要变更

- `frontend/src/api/system.ts`：修正 3 处 API 路径

## 测试

- 本地前端构建成功
- 后端 API 端点验证通过（`GET /api/settings/sso-enabled` 返回正确数据）

## 风险

低风险：纯路径修正，不涉及逻辑变更。

Generated with Qwen Code