### PR TITLE
fix(autonomous): correct common_dir containment direction for worktrees

### DIFF
--- a/app/modules/workspace/autonomous/github_ops.py
+++ b/app/modules/workspace/autonomous/github_ops.py
@@ -190,13 +190,26 @@ class GitHubOps:
             raise GitHubOpsError("Cannot register an invalid trusted Git context")
         if not git_identity or not common_identity:
             raise GitHubOpsError("Cannot register Git context without filesystem identity")
-        # Containment: the common git dir must live under the canonical repo
-        # root. For a main repo common_dir == <repo>/.git; for a linked
-        # worktree common_dir also points at <repo>/.git. This rejects a
-        # common_dir that escapes the repo (e.g. via a symlink or a malicious
-        # /repo-evil-style prefix) before we pin it as trusted.
+        # Containment: the repo_path must live under the main repo root, i.e.
+        # the parent directory of common_dir. For a main repo common_dir ==
+        # <repo>/.git so its parent is <repo> == repo_path. For a linked
+        # worktree common_dir points at the MAIN repo's <repo>/.git (not under
+        # the worktree path), so we verify the worktree (repo_path) lives under
+        # the main repo root (common_dir's parent) instead. The basename check
+        # confines common_dir to a real git metadata directory named ".git",
+        # preventing an arbitrary subdir from being pinned; the root guard
+        # rejects a common_dir directly under "/" (e.g. /.git) which would
+        # otherwise contain any repo_path. realpath on both sides already
+        # rejects /repo vs /repo-evil prefix confusion and symlink escapes.
+        # NOTE: bare repos (basename "repo.git") are not supported here; open-ace
+        # only uses regular repos + linked worktrees.
         real_common_dir = os.path.realpath(common_dir)
-        _assert_path_contained(real_common_dir, real_repo, label="trusted common_dir")
+        if os.path.basename(real_common_dir) != ".git":
+            raise GitHubOpsError(f"trusted common_dir is not a .git directory: {real_common_dir}")
+        common_parent = os.path.dirname(real_common_dir)
+        if common_parent == os.sep:
+            raise GitHubOpsError(f"trusted common_dir root escape: {real_common_dir}")
+        _assert_path_contained(real_repo, common_parent, label="trusted repo_path")
         cls._trusted_git_contexts[real_repo] = {
             "git_dir": real_git_dir,
             "work_tree": real_repo,

--- a/app/modules/workspace/autonomous/github_ops.py
+++ b/app/modules/workspace/autonomous/github_ops.py
@@ -199,10 +199,13 @@ class GitHubOps:
         # confines common_dir to a real git metadata directory named ".git",
         # preventing an arbitrary subdir from being pinned; the root guard
         # rejects a common_dir directly under "/" (e.g. /.git) which would
-        # otherwise contain any repo_path. realpath on both sides already
-        # rejects /repo vs /repo-evil prefix confusion and symlink escapes.
+        # otherwise contain any repo_path. Prefix confusion (/repo vs
+        # /repo-evil) and symlink escapes are rejected by _assert_path_contained
+        # via os.path.realpath + os.path.commonpath on both sides.
         # NOTE: bare repos (basename "repo.git") are not supported here; open-ace
         # only uses regular repos + linked worktrees.
+        # NOTE: the root guard (common_parent == os.sep) is Unix-specific; this
+        # matches the orchestrator's os.sep assumption (Linux/macOS only).
         real_common_dir = os.path.realpath(common_dir)
         if os.path.basename(real_common_dir) != ".git":
             raise GitHubOpsError(f"trusted common_dir is not a .git directory: {real_common_dir}")
@@ -210,6 +213,12 @@ class GitHubOps:
         if common_parent == os.sep:
             raise GitHubOpsError(f"trusted common_dir root escape: {real_common_dir}")
         _assert_path_contained(real_repo, common_parent, label="trusted repo_path")
+        # Defense-in-depth: git_dir must live under common_dir. For a main repo
+        # git_dir == common_dir == <repo>/.git; for a linked worktree git_dir is
+        # <common_dir>/worktrees/<name>. An out-of-tree git_dir is rejected even
+        # though device:inode identity pinning is the primary defense.
+        if real_git_dir != real_common_dir:
+            _assert_path_contained(real_git_dir, real_common_dir, label="trusted git_dir")
         cls._trusted_git_contexts[real_repo] = {
             "git_dir": real_git_dir,
             "work_tree": real_repo,

--- a/tests/issues/2021/test_git_path_hardening.py
+++ b/tests/issues/2021/test_git_path_hardening.py
@@ -109,17 +109,30 @@ def test_register_trusted_git_context_rejects_common_dir_escape(tmp_path):
 def test_register_trusted_git_context_accepts_linked_worktree(tmp_path):
     """A linked worktree's common_dir points at the MAIN repo's .git (not under
     the worktree path). The new containment direction must accept this layout:
-    repo_path (worktree) lives under common_dir's parent (main repo root)."""
+    repo_path (worktree) lives under common_dir's parent (main repo root).
+
+    NOTE: the git_dir argument here is the worktree's .git *file* path. In a
+    real orchestrator run, _capture_repo_state resolves this file via
+    `git rev-parse --absolute-git-dir` to <main>/.git/worktrees/<name>, which
+    lives under common_dir and passes the git_dir containment check added
+    below. The test passes the file path directly because containment only
+    requires git_dir to be under common_dir after realpath resolution; for
+    the file path realpath returns the file itself, which is NOT under
+    common_dir — so this test uses a git_dir that equals the resolved
+    worktree gitdir directory to mirror the real capture value."""
     main_repo = tmp_path / "repo"
     (main_repo / ".git").mkdir(parents=True)
+    worktree_git_dir = main_repo / ".git" / "worktrees" / "wf-abc"
+    worktree_git_dir.mkdir(parents=True)
     worktree = main_repo / ".worktrees" / "wf-abc"
     worktree.mkdir(parents=True)
-    (worktree / ".git").write_text(f"gitdir: {main_repo}/.git/worktrees/wf-abc\n")
+    (worktree / ".git").write_text(f"gitdir: {worktree_git_dir}\n")
     gh = GitHubOps(str(worktree))
-    # Must NOT raise: worktree path is under main repo root (common_dir parent).
+    # Must NOT raise: worktree path is under main repo root (common_dir parent),
+    # and git_dir is under common_dir (main_repo/.git).
     gh.register_trusted_git_context(
         repo_path=str(worktree),
-        git_dir=str(worktree / ".git"),
+        git_dir=str(worktree_git_dir),
         git_identity="dev:1",
         common_dir=str(main_repo / ".git"),
         common_identity="dev:2",
@@ -171,6 +184,55 @@ def test_register_trusted_git_context_rejects_root_common_dir(tmp_path):
             git_dir=str(repo / ".git"),
             git_identity="dev:1",
             common_dir="/.git",
+            common_identity="dev:2",
+        )
+
+
+def test_register_trusted_git_context_rejects_symlink_common_dir(tmp_path):
+    """A common_dir that is a symlink resolving outside the main repo root
+    must be rejected after realpath canonicalization. Covers the symlink-escape
+    threat for the new containment direction."""
+    main_repo = tmp_path / "repo"
+    (main_repo / ".git").mkdir(parents=True)
+    worktree = main_repo / ".worktrees" / "wf"
+    worktree.mkdir(parents=True)
+    (worktree / ".git").write_text("gitdir: placeholder\n")
+    # evil/.git outside the main repo; symlink main_repo/.git-link -> evil/.git
+    evil = tmp_path / "evil"
+    (evil / ".git").mkdir(parents=True)
+    symlink_common = main_repo / ".git-link"
+    os.symlink(str(evil / ".git"), symlink_common)
+    gh = GitHubOps(str(worktree))
+    # real_common_dir resolves to evil/.git; common_parent=evil does not contain
+    # repo_path (worktree under main_repo) → rejected.
+    with pytest.raises(GitHubOpsError, match="trusted repo_path"):
+        gh.register_trusted_git_context(
+            repo_path=str(worktree),
+            git_dir=str(main_repo / ".git" / "worktrees" / "wf"),
+            git_identity="dev:1",
+            common_dir=str(symlink_common),
+            common_identity="dev:2",
+        )
+
+
+def test_register_trusted_git_context_rejects_git_dir_outside_common(tmp_path):
+    """git_dir must live under common_dir (defense-in-depth). A git_dir pointing
+    outside common_dir is rejected even though identity pinning is the primary
+    defense."""
+    main_repo = tmp_path / "repo"
+    (main_repo / ".git").mkdir(parents=True)
+    worktree = main_repo / ".worktrees" / "wf"
+    worktree.mkdir(parents=True)
+    # An evil git_dir outside common_dir
+    evil_git_dir = tmp_path / "evil-git"
+    evil_git_dir.mkdir()
+    gh = GitHubOps(str(worktree))
+    with pytest.raises(GitHubOpsError, match="trusted git_dir"):
+        gh.register_trusted_git_context(
+            repo_path=str(worktree),
+            git_dir=str(evil_git_dir),
+            git_identity="dev:1",
+            common_dir=str(main_repo / ".git"),
             common_identity="dev:2",
         )
 

--- a/tests/issues/2021/test_git_path_hardening.py
+++ b/tests/issues/2021/test_git_path_hardening.py
@@ -82,19 +82,95 @@ def test_pre_generated_path_rejects_symlink_or_outside_root(tmp_path):
 
 
 def test_register_trusted_git_context_rejects_common_dir_escape(tmp_path):
-    """register_trusted_git_context must reject a common_dir outside repo."""
+    """register_trusted_git_context must reject a common_dir whose parent does
+    not contain repo_path (the /repo vs /repo-evil prefix-confusion case).
+
+    The new containment direction (post-#2057 follow-up) verifies that
+    repo_path lives under the main repo root (= common_dir's parent), not
+    that common_dir lives under repo_path. A common_dir under a sibling
+    directory still fails because repo_path is not under that sibling."""
     repo = tmp_path / "repo"
     repo.mkdir()
     (repo / ".git").mkdir()
     evil = tmp_path / "repo-evil"
     evil.mkdir()
+    (evil / ".git").mkdir()
     gh = GitHubOps(str(repo))
-    with pytest.raises(GitHubOpsError, match="trusted common_dir"):
+    with pytest.raises(GitHubOpsError, match="trusted repo_path"):
         gh.register_trusted_git_context(
             repo_path=str(repo),
             git_dir=str(repo / ".git"),
             git_identity="dev:1",
             common_dir=str(evil / ".git"),
+            common_identity="dev:2",
+        )
+
+
+def test_register_trusted_git_context_accepts_linked_worktree(tmp_path):
+    """A linked worktree's common_dir points at the MAIN repo's .git (not under
+    the worktree path). The new containment direction must accept this layout:
+    repo_path (worktree) lives under common_dir's parent (main repo root)."""
+    main_repo = tmp_path / "repo"
+    (main_repo / ".git").mkdir(parents=True)
+    worktree = main_repo / ".worktrees" / "wf-abc"
+    worktree.mkdir(parents=True)
+    (worktree / ".git").write_text(f"gitdir: {main_repo}/.git/worktrees/wf-abc\n")
+    gh = GitHubOps(str(worktree))
+    # Must NOT raise: worktree path is under main repo root (common_dir parent).
+    gh.register_trusted_git_context(
+        repo_path=str(worktree),
+        git_dir=str(worktree / ".git"),
+        git_identity="dev:1",
+        common_dir=str(main_repo / ".git"),
+        common_identity="dev:2",
+    )
+
+
+def test_register_trusted_git_context_accepts_main_repo(tmp_path):
+    """For the main repo common_dir == repo_path/.git; repo_path trivially
+    lives under common_dir's parent (== repo_path itself)."""
+    repo = tmp_path / "repo"
+    (repo / ".git").mkdir(parents=True)
+    gh = GitHubOps(str(repo))
+    gh.register_trusted_git_context(
+        repo_path=str(repo),
+        git_dir=str(repo / ".git"),
+        git_identity="dev:1",
+        common_dir=str(repo / ".git"),
+        common_identity="dev:2",
+    )
+
+
+def test_register_trusted_git_context_rejects_non_git_common_dir(tmp_path):
+    """common_dir whose basename is not '.git' is rejected — prevents an
+    arbitrary subdir from being pinned as trusted."""
+    repo = tmp_path / "repo"
+    (repo / ".git").mkdir(parents=True)
+    bogus = repo / "subdir"
+    bogus.mkdir()
+    gh = GitHubOps(str(repo))
+    with pytest.raises(GitHubOpsError, match="not a .git directory"):
+        gh.register_trusted_git_context(
+            repo_path=str(repo),
+            git_dir=str(repo / ".git"),
+            git_identity="dev:1",
+            common_dir=str(bogus),
+            common_identity="dev:2",
+        )
+
+
+def test_register_trusted_git_context_rejects_root_common_dir(tmp_path):
+    """A common_dir directly under '/' (e.g. /.git) would contain any
+    repo_path and must be rejected explicitly."""
+    repo = tmp_path / "repo"
+    (repo / ".git").mkdir(parents=True)
+    gh = GitHubOps(str(repo))
+    with pytest.raises(GitHubOpsError, match="root escape"):
+        gh.register_trusted_git_context(
+            repo_path=str(repo),
+            git_dir=str(repo / ".git"),
+            git_identity="dev:1",
+            common_dir="/.git",
             common_identity="dev:2",
         )
 


### PR DESCRIPTION
## Problem

Worktree-strategy workflows created after #2057 fail at the planning phase with:
\`\`\`
trusted common_dir escapes containment: /repo/.git not under /repo/.worktrees/<wf>
\`\`\`

Workflow 58e89d84-5128-4441-8e3c-611b502addc6 is the concrete instance that hit this.

## Root Cause

The containment check added in #2057 (commit 6b123878) required \`common_dir\` to live under \`repo_path\`:

\`\`\`python
_assert_path_contained(real_common_dir, real_repo, label="trusted common_dir")
\`\`\`

This is **wrong for linked worktrees**. A worktree's \`common_dir\` points at the MAIN repo's \`.git\` directory, which is never under the worktree path — this is how git worktrees work by design.

- Main repo: \`common_dir=/repo/.git\` → under \`repo_path=/repo\` ✓
- Worktree: \`common_dir=/main/.git\` → NOT under \`repo_path=/main/.worktrees/xxx\` ✗ (false positive)

## Fix

Invert the containment direction. Instead of requiring \`common_dir\` under \`repo_path\`, require \`repo_path\` under \`common_dir\`'s parent (the main repo root).

### Verification matrix

| Scenario | common_dir | repo_path | Result |
|----------|-----------|-----------|--------|
| Main repo | /repo/.git | /repo | parent=/repo contains repo_path ✓ |
| Linked worktree | /main/.git | /main/.worktrees/xxx | parent=/main contains repo_path ✓ |
| /repo-evil attack | /repo-evil/.git | /repo | parent=/repo-evil does not contain /repo ✗ rejected |
| Root escape | /.git | /anywhere | explicitly rejected by root guard |

### Additional guards

1. \`basename(common_dir) == ".git"\` — prevents an arbitrary subdir from being pinned as trusted
2. \`dirname(common_dir) != "/"\` — rejects \`/.git\` that would contain any repo_path
3. \`realpath\` on both sides already rejects \`/repo\` vs \`/repo-evil\` prefix confusion and symlink escapes

### Security analysis

The original three threats from #2057 remain covered:
- ✅ /repo vs /repo-evil prefix confusion (commonpath after realpath)
- ✅ symlink escapes (realpath canonicalization)
- ✅ out-of-root worktree paths (repo_path must be under main repo root)

Bare repos (basename \`repo.git\`) are not supported; open-ace only uses regular repos + linked worktrees.

## Testing

- Updated \`test_register_trusted_git_context_rejects_common_dir_escape\` to match the new error label
- Added \`test_register_trusted_git_context_accepts_linked_worktree\` — the regression case
- Added \`test_register_trusted_git_context_accepts_main_repo\`
- Added \`test_register_trusted_git_context_rejects_non_git_common_dir\`
- Added \`test_register_trusted_git_context_rejects_root_common_dir\`

All 20 tests in \`tests/issues/2021/test_git_path_hardening.py\` pass.

## Cross-platform

The fix uses only \`os.path\` APIs (\`basename\`, \`dirname\`, \`os.sep\`, \`commonpath\`, \`realpath\`) — works identically on Linux and macOS.

## Note on 58e89d84

This workflow's branch and worktree have already been cleaned up (it cannot be resumed). After this fix lands, the workflow will be marked as cancelled.