### PR TITLE
fix: PostgreSQL datetime crash in quota check pauses workflows

### DIFF
--- a/app/modules/governance/alert_notifier.py
+++ b/app/modules/governance/alert_notifier.py
@@ -42,6 +42,7 @@ from app.repositories.database import (
 )
 from app.services.email_notification_service import get_email_notification_service
 from app.utils.config import get_config_value
+from app.utils.helpers import parse_db_datetime
 from app.utils.outbound_url_guard import is_public_address
 from app.utils.smtp_crypto import get_password_manager
 
@@ -2226,13 +2227,8 @@ class AlertNotifier:
             tool_name=row["tool_name"],
             metadata=json.loads(row["metadata"]) if row["metadata"] else {},
             created_at=(
-                row["created_at"]
-                if isinstance(row["created_at"], datetime)
-                else (
-                    datetime.fromisoformat(row["created_at"])
-                    if row["created_at"]
-                    else datetime.now(timezone.utc).replace(tzinfo=None)
-                )
+                parse_db_datetime(row["created_at"])
+                or datetime.now(timezone.utc).replace(tzinfo=None)
             ),
             read=bool(row["read"]),
             action_url=row["action_url"],

--- a/app/modules/governance/quota_manager.py
+++ b/app/modules/governance/quota_manager.py
@@ -19,6 +19,7 @@ from app.repositories.database import (
     escape_like,
 )
 from app.repositories.user_repo import UserRepository
+from app.utils.helpers import parse_db_datetime
 
 logger = logging.getLogger(__name__)
 
@@ -609,16 +610,11 @@ class QuotaManager:
                     percentage=row.get("percentage", 0),
                     message=row.get("message", ""),
                     created_at=(
-                        datetime.fromisoformat(row["created_at"])
-                        if row.get("created_at")
-                        else datetime.now(timezone.utc).replace(tzinfo=None)
+                        parse_db_datetime(row.get("created_at"))
+                        or datetime.now(timezone.utc).replace(tzinfo=None)
                     ),
                     acknowledged=bool(row.get("acknowledged", 0)),
-                    acknowledged_at=(
-                        datetime.fromisoformat(row["acknowledged_at"])
-                        if row.get("acknowledged_at")
-                        else None
-                    ),
+                    acknowledged_at=parse_db_datetime(row.get("acknowledged_at")),
                     acknowledged_by=row.get("acknowledged_by"),
                 )
             )
@@ -773,16 +769,11 @@ class QuotaManager:
                         percentage=row.get("percentage", 0),
                         message=row.get("message", ""),
                         created_at=(
-                            datetime.fromisoformat(row["created_at"])
-                            if row.get("created_at")
-                            else datetime.now(timezone.utc).replace(tzinfo=None)
+                            parse_db_datetime(row.get("created_at"))
+                            or datetime.now(timezone.utc).replace(tzinfo=None)
                         ),
                         acknowledged=bool(row.get("acknowledged", 0)),
-                        acknowledged_at=(
-                            datetime.fromisoformat(row["acknowledged_at"])
-                            if row.get("acknowledged_at")
-                            else None
-                        ),
+                        acknowledged_at=parse_db_datetime(row.get("acknowledged_at")),
                         acknowledged_by=row.get("acknowledged_by"),
                     )
                 )
@@ -872,16 +863,11 @@ class QuotaManager:
                     percentage=row.get("percentage", 0),
                     message=row.get("message", ""),
                     created_at=(
-                        datetime.fromisoformat(row["created_at"])
-                        if row.get("created_at")
-                        else datetime.now(timezone.utc).replace(tzinfo=None)
+                        parse_db_datetime(row.get("created_at"))
+                        or datetime.now(timezone.utc).replace(tzinfo=None)
                     ),
                     acknowledged=bool(row.get("acknowledged", 0)),
-                    acknowledged_at=(
-                        datetime.fromisoformat(row["acknowledged_at"])
-                        if row.get("acknowledged_at")
-                        else None
-                    ),
+                    acknowledged_at=parse_db_datetime(row.get("acknowledged_at")),
                     acknowledged_by=row.get("acknowledged_by"),
                 )
             )

--- a/app/modules/workspace/collaboration.py
+++ b/app/modules/workspace/collaboration.py
@@ -21,6 +21,7 @@ from app.repositories.database import (
     get_database_url,
     is_postgresql,
 )
+from app.utils.helpers import parse_db_datetime
 
 logger = logging.getLogger(__name__)
 
@@ -500,7 +501,7 @@ class CollaborationManager:
                 user_id=m["user_id"],
                 username=m["username"] or "",
                 role=m["role"],
-                joined_at=datetime.fromisoformat(m["joined_at"]) if m["joined_at"] else None,
+                joined_at=parse_db_datetime(m["joined_at"]),
             )
             for m in member_rows
         ]
@@ -513,8 +514,8 @@ class CollaborationManager:
             owner_id=row["owner_id"],
             members=members,
             settings=json.loads(row["settings"]) if row["settings"] else {},
-            created_at=datetime.fromisoformat(row["created_at"]) if row["created_at"] else None,
-            updated_at=datetime.fromisoformat(row["updated_at"]) if row["updated_at"] else None,
+            created_at=parse_db_datetime(row["created_at"]),
+            updated_at=parse_db_datetime(row["updated_at"]),
         )
 
     def add_team_member(
@@ -1145,14 +1146,12 @@ class CollaborationManager:
             share_type=row["share_type"] or "user",
             target_id=row["target_id"],
             target_name=row["target_name"] or "",
-            expires_at=datetime.fromisoformat(row["expires_at"]) if row["expires_at"] else None,
+            expires_at=parse_db_datetime(row["expires_at"]),
             allow_comments=bool(row["allow_comments"]),
             allow_copy=bool(row["allow_copy"]),
-            created_at=datetime.fromisoformat(row["created_at"]) if row["created_at"] else None,
+            created_at=parse_db_datetime(row["created_at"]),
             access_count=row["access_count"] or 0,
-            last_accessed=(
-                datetime.fromisoformat(row["last_accessed"]) if row["last_accessed"] else None
-            ),
+            last_accessed=parse_db_datetime(row["last_accessed"]),
         )
 
     def _row_to_annotation(self, row: sqlite3.Row) -> Annotation:
@@ -1168,8 +1167,8 @@ class CollaborationManager:
             annotation_type=row["annotation_type"] or "comment",
             position=json.loads(row["position"]) if row["position"] else {},
             parent_id=row["parent_id"],
-            created_at=datetime.fromisoformat(row["created_at"]) if row["created_at"] else None,
-            updated_at=datetime.fromisoformat(row["updated_at"]) if row["updated_at"] else None,
+            created_at=parse_db_datetime(row["created_at"]),
+            updated_at=parse_db_datetime(row["updated_at"]),
         )
 
     def _row_to_knowledge_entry(self, row: sqlite3.Row) -> KnowledgeEntry:
@@ -1186,8 +1185,8 @@ class CollaborationManager:
             author_name=row["author_name"] or "",
             is_published=bool(row["is_published"]),
             view_count=row["view_count"] or 0,
-            created_at=datetime.fromisoformat(row["created_at"]) if row["created_at"] else None,
-            updated_at=datetime.fromisoformat(row["updated_at"]) if row["updated_at"] else None,
+            created_at=parse_db_datetime(row["created_at"]),
+            updated_at=parse_db_datetime(row["updated_at"]),
         )
 
 

--- a/app/modules/workspace/state_sync.py
+++ b/app/modules/workspace/state_sync.py
@@ -18,6 +18,7 @@ from enum import Enum
 from typing import Any
 
 from app.repositories.database import DB_PATH, get_database_url, is_postgresql
+from app.utils.helpers import parse_db_datetime
 
 logger = logging.getLogger(__name__)
 
@@ -632,9 +633,8 @@ class StateSyncManager:
             event_id=row["event_id"],
             event_type=row["event_type"],
             timestamp=(
-                datetime.fromisoformat(row["timestamp"])
-                if row["timestamp"]
-                else datetime.now(timezone.utc).replace(tzinfo=None)
+                parse_db_datetime(row["timestamp"])
+                or datetime.now(timezone.utc).replace(tzinfo=None)
             ),
             source=row["source"] or "",
             session_id=row["session_id"],

--- a/app/utils/helpers.py
+++ b/app/utils/helpers.py
@@ -113,6 +113,10 @@ def parse_db_datetime(value) -> datetime | None:
     if isinstance(value, datetime):
         return value
     if isinstance(value, str):
+        # Empty/whitespace-only strings are treated as NULL (legacy SQLite data
+        # may store "" instead of NULL). Avoids ValueError from fromisoformat.
+        if not value.strip():
+            return None
         normalized = value.replace("Z", "+00:00")
         if len(normalized) >= 10 and normalized[10] == " ":
             normalized = normalized[:10] + "T" + normalized[11:]

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -1,6 +1,6 @@
 """Unit tests for helper utilities."""
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
 import pytest
@@ -203,3 +203,15 @@ class TestParseDbDatetime:
         assert result is not None
         assert result.tzinfo is not None
         assert result.utcoffset() == timedelta(0)
+
+    def test_empty_string_returns_none(self):
+        """Empty/whitespace strings should be treated as NULL, not raise."""
+        assert parse_db_datetime("") is None
+        assert parse_db_datetime("   ") is None
+
+    def test_aware_datetime_returned_unchanged(self):
+        """PostgreSQL TIMESTAMPTZ returns aware datetime objects."""
+        dt = datetime(2026, 1, 15, 10, 30, 0, tzinfo=timezone.utc)
+        result = parse_db_datetime(dt)
+        assert result is dt
+        assert result.tzinfo is not None

--- a/tests/unit/test_quota_datetime_compat.py
+++ b/tests/unit/test_quota_datetime_compat.py
@@ -1,0 +1,103 @@
+"""Regression tests for PostgreSQL datetime compatibility in quota_manager.
+
+PostgreSQL/psycopg2 returns ``datetime`` objects for TIMESTAMP columns, whereas
+SQLite returns ISO 8601 strings. The quota alert row-conversion code previously
+called ``datetime.fromisoformat(row["created_at"])`` unconditionally, which
+raises ``TypeError`` when handed a ``datetime`` instance. This caused
+``QuotaManager.check_quota`` to throw, which in turn paused autonomous
+workflows with a misleading "Quota check unavailable" reason.
+
+These tests verify that alert row conversion handles both ``datetime`` objects
+(PostgreSQL) and strings (SQLite) without raising.
+"""
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+from app.modules.governance.quota_manager import QuotaManager
+
+
+def _build_manager_with_rows(rows):
+    """Build a QuotaManager whose db.fetch_all returns *rows*."""
+    mgr = QuotaManager.__new__(QuotaManager)
+    mgr.db = MagicMock()
+    mgr.db.fetch_all.return_value = rows
+    return mgr
+
+
+def _sample_row(created_at, acknowledged_at=None):
+    """Build a dict row mimicking quota_alerts columns."""
+    return {
+        "id": 1,
+        "user_id": 89,
+        "alert_type": "warning",
+        "quota_type": "tokens",
+        "period": "daily",
+        "threshold": 80.0,
+        "current_usage": 90,
+        "quota_limit": 100,
+        "percentage": 90.0,
+        "message": "Approaching limit",
+        "created_at": created_at,
+        "acknowledged": 0,
+        "acknowledged_at": acknowledged_at,
+        "acknowledged_by": None,
+    }
+
+
+def test_get_recent_alerts_handles_postgres_datetime_objects():
+    """PostgreSQL returns datetime objects; conversion must not raise."""
+    created = datetime(2026, 7, 31, 11, 19, 33)
+    acknowledged = datetime(2026, 7, 31, 12, 0, 0)
+    mgr = _build_manager_with_rows([_sample_row(created, acknowledged)])
+
+    alerts = mgr._get_recent_alerts(user_id=89)
+
+    assert len(alerts) == 1
+    alert = alerts[0]
+    assert alert.created_at == created
+    assert alert.acknowledged_at == acknowledged
+
+
+def test_get_recent_alerts_handles_sqlite_strings():
+    """SQLite returns ISO strings; conversion must still work."""
+    created = "2026-07-31T11:19:33"
+    acknowledged = "2026-07-31T12:00:00"
+    mgr = _build_manager_with_rows([_sample_row(created, acknowledged)])
+
+    alerts = mgr._get_recent_alerts(user_id=89)
+
+    assert len(alerts) == 1
+    assert alerts[0].created_at == datetime(2026, 7, 31, 11, 19, 33)
+    assert alerts[0].acknowledged_at == datetime(2026, 7, 31, 12, 0, 0)
+
+
+def test_get_recent_alerts_handles_null_acknowledged_at():
+    """acknowledged_at is nullable; should resolve to None."""
+    created = datetime(2026, 7, 31, 11, 19, 33)
+    mgr = _build_manager_with_rows([_sample_row(created, acknowledged_at=None)])
+
+    alerts = mgr._get_recent_alerts(user_id=89)
+
+    assert alerts[0].acknowledged_at is None
+
+
+def test_get_recent_alerts_falls_back_when_created_at_missing():
+    """When created_at is NULL, a sensible default is used."""
+    mgr = _build_manager_with_rows([_sample_row(created_at=None)])
+
+    alerts = mgr._get_recent_alerts(user_id=89)
+
+    assert len(alerts) == 1
+    assert alerts[0].created_at is not None
+
+
+def test_get_all_alerts_handles_postgres_datetime_objects():
+    """get_all_alerts shares the same conversion path."""
+    created = datetime(2026, 7, 31, 11, 19, 33, tzinfo=timezone.utc)
+    mgr = _build_manager_with_rows([_sample_row(created)])
+
+    alerts = mgr.get_all_alerts()
+
+    assert len(alerts) == 1
+    assert alerts[0].created_at == created


### PR DESCRIPTION
## Summary

issue-1826 工作流在 pr_review 阶段被暂停，根因是配额检查服务抛出 `TypeError: fromisoformat: argument must be str`。PostgreSQL/psycopg2 返回 `datetime` 对象，而代码中 `datetime.fromisoformat(row[...])` 假设输入为字符串，导致 `QuotaManager._get_recent_alerts` 等方法崩溃，工作流被 quota-gate 暂停后无法恢复。

## Root Cause

`datetime.fromisoformat` 仅接受字符串参数。在 SQLite 环境下数据库返回 ISO 字符串，代码可正常工作；但迁移到 PostgreSQL 后，psycopg2 直接返回 `datetime` 对象，传入 `fromisoformat` 即抛 `TypeError`。受影响的位置共 18 处，分布在 4 个模块。

## Fix

统一使用 `app.utils.helpers.parse_db_datetime` 工具函数替换所有 `datetime.fromisoformat(row[...])` 调用。该函数：
- `datetime` 对象：原样返回（兼容 PostgreSQL）
- 字符串：归一化后用 `fromisoformat` 解析（兼容 SQLite，并处理 PostgreSQL 文本格式的空格分隔符和变长小数秒）
- `None` / 空字符串 / 空白字符串：返回 `None`（修复 legacy SQLite 数据存储 `""` 而非 `NULL` 的边界情况）

### Files Changed

- `app/utils/helpers.py`: `parse_db_datetime` 增加空字符串/空白字符串处理，避免 `fromisoformat("")` 抛 `ValueError`
- `app/modules/governance/quota_manager.py`: 替换 6 处 `fromisoformat` 调用（处理 dict 类型行数据，保留 `row.get`）
- `app/modules/workspace/collaboration.py`: 替换 10 处 `fromisoformat` 调用（处理 `sqlite3.Row` 类型行数据，使用 `row[...]`）
- `app/modules/workspace/state_sync.py`: 替换 1 处 `fromisoformat` 调用
- `app/modules/governance/alert_notifier.py`: 替换 1 处 `fromisoformat` 调用

### Tests

- `tests/unit/test_helpers.py`: 新增 `test_empty_string_returns_none`、`test_aware_datetime_returned_unchanged` 两个边界测试
- `tests/unit/test_quota_datetime_compat.py` (新增): 5 个回归测试，覆盖 PostgreSQL datetime 对象、SQLite 字符串、NULL `acknowledged_at`、缺失 `created_at` 回退、`_get_all_alerts` 场景

## Verification

- `pytest tests/unit/test_helpers.py tests/unit/test_quota_datetime_compat.py`: 51 passed
- 相关模块测试（alert_notifier_webhook / quota_* / upstream_quota_pause）: 92 passed
- mypy：所修改的 5 个文件无新增错误（alert_notifier.py 514/547 行的 socket 相关错误为 pre-existing，与本次改动无关）

## Compatibility

修复同时兼容 Linux 和 macOS（仅使用标准库 `datetime` / `re`，无平台相关代码）。