### PR TITLE
fix: webui_path 配置语义混淆导致工作区启动失败

### DIFF
--- a/app/services/webui_manager.py
+++ b/app/services/webui_manager.py
@@ -143,7 +143,9 @@ class WorkspaceConfig:
     idle_timeout_minutes: int = 30
     cleanup_interval_minutes: int = 5
     token_secret: str = ""
-    webui_path: str = ""  # Path to qwen-code-webui executable or project directory (leave empty for auto-detect)
+    webui_path: str = (
+        ""  # Path to qwen-code-webui executable or project directory (leave empty for auto-detect)
+    )
     # Optional explicit URL for the webui to reach the LLM proxy (e.g. behind an
     # HTTPS reverse proxy). When set, :web_port is NOT appended. See issue #1730.
     webui_callback_url: str = ""
@@ -1109,9 +1111,7 @@ class WebUIManager:
             if os.path.isfile(self.config.webui_path) and os.access(
                 self.config.webui_path, os.X_OK
             ):
-                logger.info(
-                    f"Using webui executable from config: {self.config.webui_path}"
-                )
+                logger.info(f"Using webui executable from config: {self.config.webui_path}")
                 return self.config.webui_path, None
 
             # Then, check if webui_path is a project directory (development mode)
@@ -1119,16 +1119,12 @@ class WebUIManager:
             node_entry = os.path.join(webui_backend, "dist", "cli", "node.js")
 
             if os.path.isfile(node_entry):
-                logger.info(
-                    f"Using webui from project directory: {self.config.webui_path}"
-                )
+                logger.info(f"Using webui from project directory: {self.config.webui_path}")
                 return node_entry, webui_backend
 
             # Check if project needs to be built
             if os.path.isdir(webui_backend):
-                logger.warning(
-                    f"WebUI project found but not built: {node_entry} not found"
-                )
+                logger.warning(f"WebUI project found but not built: {node_entry} not found")
                 # Try to build it
                 try:
                     subprocess.run(

--- a/app/services/webui_manager.py
+++ b/app/services/webui_manager.py
@@ -143,7 +143,7 @@ class WorkspaceConfig:
     idle_timeout_minutes: int = 30
     cleanup_interval_minutes: int = 5
     token_secret: str = ""
-    webui_path: str = ""  # Path to qwen-code-webui project directory
+    webui_path: str = ""  # Path to qwen-code-webui executable or project directory (leave empty for auto-detect)
     # Optional explicit URL for the webui to reach the LLM proxy (e.g. behind an
     # HTTPS reverse proxy). When set, :web_port is NOT appended. See issue #1730.
     webui_callback_url: str = ""
@@ -1100,18 +1100,35 @@ class WebUIManager:
             and working_directory is the backend directory.
             If running global executable, working_directory is None.
         """
-        # Check webui_path from config (project directory mode)
+        # Check webui_path from config
         if self.config.webui_path:
+            # First, check if webui_path is an executable file (global install mode)
+            # This supports users who configured webui_path as the executable path
+            # (e.g., /usr/bin/qwen-code-webui) instead of project directory.
+            # See Issue #2151 for context.
+            if os.path.isfile(self.config.webui_path) and os.access(
+                self.config.webui_path, os.X_OK
+            ):
+                logger.info(
+                    f"Using webui executable from config: {self.config.webui_path}"
+                )
+                return self.config.webui_path, None
+
+            # Then, check if webui_path is a project directory (development mode)
             webui_backend = os.path.join(self.config.webui_path, "backend")
             node_entry = os.path.join(webui_backend, "dist", "cli", "node.js")
 
             if os.path.isfile(node_entry):
-                logger.info(f"Using webui from project directory: {self.config.webui_path}")
+                logger.info(
+                    f"Using webui from project directory: {self.config.webui_path}"
+                )
                 return node_entry, webui_backend
 
             # Check if project needs to be built
             if os.path.isdir(webui_backend):
-                logger.warning(f"WebUI project found but not built: {node_entry} not found")
+                logger.warning(
+                    f"WebUI project found but not built: {node_entry} not found"
+                )
                 # Try to build it
                 try:
                     subprocess.run(

--- a/scripts/install-central/package-method/install.sh
+++ b/scripts/install-central/package-method/install.sh
@@ -3837,17 +3837,12 @@ do_fresh_install() {
             if [ "$EUID" -eq 0 ]; then
                 create_webui_symlinks
             fi
-            # Use /usr/bin/qwen-code-webui as preferred path (symlink created above)
-            # Fallback to find_webui_executable if symlink doesn't exist
-            local webui_path="/usr/bin/qwen-code-webui"
-            if [ ! -x "$webui_path" ]; then
-                if [ "$WORKSPACE_MULTI_USER_MODE" = "true" ]; then
-                    webui_path=$(find_webui_executable)
-                else
-                    webui_path=$(find_webui_executable 2>/dev/null)
-                fi
-            fi
-            update_config_workspace "$config_dir/config.json" "$webui_path"
+            # Configure webui_path for config.json
+            # Issue #2151: Leave webui_path empty for auto-detection.
+            # The _find_webui_executable method in webui_manager.py will find
+            # the executable from common paths (/usr/bin/qwen-code-webui, etc.)
+            # sudoers configuration still uses the actual path for permission rules.
+            update_config_workspace "$config_dir/config.json" ""
 
             # Generate and set secret_key for Flask session and API key encryption
             local secret_key="${SECRET_KEY:-$(openssl rand -hex 32)}"
@@ -4320,17 +4315,11 @@ with open('$config_dir/config.json', 'w') as f:
         if [ "$EUID" -eq 0 ]; then
             create_webui_symlinks
         fi
-        # Use /usr/bin/qwen-code-webui as preferred path (symlink created above)
-        # Fallback to find_webui_executable if symlink doesn't exist
-        local webui_path="/usr/bin/qwen-code-webui"
-        if [ ! -x "$webui_path" ]; then
-            if [ "$WORKSPACE_MULTI_USER_MODE" = "true" ]; then
-                webui_path=$(find_webui_executable)
-            else
-                webui_path=$(find_webui_executable 2>/dev/null)
-            fi
-        fi
-        update_config_workspace "$config_dir/config.json" "$webui_path"
+        # Configure webui_path for config.json
+        # Issue #2151: Leave webui_path empty for auto-detection.
+        # The _find_webui_executable method in webui_manager.py will find
+        # the executable from common paths (/usr/bin/qwen-code-webui, etc.)
+        update_config_workspace "$config_dir/config.json" ""
 
         # Check and set secret_key if missing (upgrade from older version)
         local current_secret=$(python3 -c "import json; c=json.load(open('$config_dir/config.json')); print(c.get('secret_key', ''))" 2>/dev/null)


### PR DESCRIPTION

## 问题描述

升级重启 open-ace 服务后，工作区无法启动，日志显示：

```
ERROR - qwen-code-webui executable not found
ERROR - Failed to start webui process: Failed to launch webui process
```

Fixes #2151

## 根本原因

1. `webui_path` 配置项设计为指向**项目目录**（用于开发模式）
2. 但安装脚本将其设置为**可执行文件路径**（如 `/usr/bin/qwen-code-webui`）
3. `_find_webui_executable` 方法首先尝试将 `webui_path` 作为项目目录处理，导致路径检测失败

## 解决方案

### 1. 修改 webui_manager.py

在 `_find_webui_executable` 方法中，先检查 `webui_path` 是否是可执行文件，再检查是否是项目目录：

```python
if self.config.webui_path:
    # 先检查是否是可执行文件（全局安装模式）
    if os.path.isfile(self.config.webui_path) and os.access(self.config.webui_path, os.X_OK):
        return self.config.webui_path, None
    
    # 然后检查是否是项目目录（开发模式）
    webui_backend = os.path.join(self.config.webui_path, "backend")
    ...
```

### 2. 修改 install.sh

保持 `webui_path` 配置为空，让 `_find_webui_executable` 自动检测：

```bash
# 不再写入具体的可执行文件路径
update_config_workspace "$config_dir/config.json" ""
```

## 测试

```bash
python3 -m pytest tests/ -k "webui" -v
# 23 passed
```

## 变更文件

- `app/services/webui_manager.py` — `_find_webui_executable` 方法增加可执行文件检测
- `scripts/install-central/package-method/install.sh` — 不再写入 `webui_path` 配置

🤖 Generated with [Claude Code](https://claude.com/claude-code)