### PR TITLE
Fix runtime isolation fallback and timeline status UI

### DIFF
--- a/app/modules/workspace/autonomous/agent_runner.py
+++ b/app/modules/workspace/autonomous/agent_runner.py
@@ -793,9 +793,14 @@ class AutonomousAgentRunner:
         conf is missing/unreadable.
         """
         try:
-            from app.modules.workspace.autonomous.task_isolation import read_agent_task_policy
+            from app.modules.workspace.autonomous.task_isolation import (
+                read_agent_task_policy,
+                resolve_agent_task_policy_path,
+            )
 
-            conf = os.environ.get("OPENACE_LAUNCHER_CONF", "/etc/openace/agent-launcher.conf")
+            conf = resolve_agent_task_policy_path(os.environ.get("OPENACE_LAUNCHER_CONF"))
+            if not conf:
+                return None
             return read_agent_task_policy(conf)
         except Exception:
             return None

--- a/app/modules/workspace/autonomous/sandbox/effective_policy.py
+++ b/app/modules/workspace/autonomous/sandbox/effective_policy.py
@@ -42,18 +42,24 @@ def build_effective_policy(
     """
     has_time_quota = SandboxCapability.CPU_MEM_PIDS_TIME_QUOTA in capabilities
     has_storage_quota = SandboxCapability.STORAGE_INODE_QUOTA in capabilities
+    policy_configured = policy is not None
     return {
         "schema_version": _SCHEMA_VERSION,
         "provider": provider_name,
         "capabilities": sorted(cap.value for cap in capabilities),
-        "limits": {
-            "memory_max_bytes": policy.memory_max_bytes if policy else 0,
-            "pids_max": policy.pids_max if policy else 0,
-            "cpu_max": policy.cpu_max if policy else "",
-            "wall_clock_limit": policy.wall_clock_limit if policy else 0,
-            "ephemeral_storage_limit": policy.ephemeral_storage_limit if policy else 0,
-            "inode_limit": policy.inode_limit if policy else 0,
-        },
+        "policy_configured": policy_configured,
+        "limits": (
+            {
+                "memory_max_bytes": policy.memory_max_bytes,
+                "pids_max": policy.pids_max,
+                "cpu_max": policy.cpu_max,
+                "wall_clock_limit": policy.wall_clock_limit,
+                "ephemeral_storage_limit": policy.ephemeral_storage_limit,
+                "inode_limit": policy.inode_limit,
+            }
+            if policy
+            else {}
+        ),
         "cgroup_enabled": policy.cgroup_enabled if policy else "",
         "task_root": policy.task_root if policy else "",
         # Derived from declared capabilities — honest, not hardcoded per provider.

--- a/app/modules/workspace/autonomous/task_isolation.py
+++ b/app/modules/workspace/autonomous/task_isolation.py
@@ -14,6 +14,7 @@ intentionally untouched.
 
 from __future__ import annotations
 
+import os
 import re
 from dataclasses import dataclass
 from pathlib import Path
@@ -21,6 +22,8 @@ from pathlib import Path
 # Ephemeral, root-owned parent for every per-task runtime tree. Lives under
 # /run so it is wiped on reboot and never lands inside a user HOME.
 DEFAULT_TASK_ROOT = "/run/openace-agent-tasks"
+DEFAULT_AGENT_LAUNCHER_CONF = "/etc/openace/agent-launcher.conf"
+USER_AGENT_LAUNCHER_CONF = os.path.expanduser("~/.open-ace/agent-launcher.conf")
 
 # Filesystem-safe charset for a task_id used as a single path component.
 # session ids (uuids or CLI-derived) occasionally carry '/', ':', or spaces;
@@ -30,6 +33,33 @@ _SAFE_TASK_ID = re.compile(r"[A-Za-z0-9._-]")
 _MAX_TASK_ID_LEN = 128
 
 _RUNTIME_VARS = ("home", "tmp", "cache", "config", "data")
+
+
+def candidate_agent_task_policy_paths(explicit_path: str | None = None) -> tuple[str, ...]:
+    """Return launcher-conf candidates in precedence order.
+
+    Priority is:
+
+    1. ``OPENACE_LAUNCHER_CONF`` / explicit caller path
+    2. system config ``/etc/openace/agent-launcher.conf``
+    3. user fallback ``~/.open-ace/agent-launcher.conf``
+    """
+
+    candidates = [explicit_path, DEFAULT_AGENT_LAUNCHER_CONF, USER_AGENT_LAUNCHER_CONF]
+    ordered: list[str] = []
+    for candidate in candidates:
+        if candidate and candidate not in ordered:
+            ordered.append(candidate)
+    return tuple(ordered)
+
+
+def resolve_agent_task_policy_path(explicit_path: str | None = None) -> str | None:
+    """Return the first existing launcher-conf path, else ``None``."""
+
+    for candidate in candidate_agent_task_policy_paths(explicit_path):
+        if Path(candidate).is_file():
+            return candidate
+    return None
 
 
 def sanitize_task_id(task_id: str) -> str:

--- a/app/services/autonomous_scheduler.py
+++ b/app/services/autonomous_scheduler.py
@@ -51,9 +51,7 @@ def get_max_concurrent_workflows() -> int:
             resolve_agent_task_policy_path,
         )
 
-        conf = resolve_agent_task_policy_path(
-            _AGENT_LAUNCHER_CONF if "OPENACE_LAUNCHER_CONF" in os.environ else None
-        )
+        conf = resolve_agent_task_policy_path(os.environ.get("OPENACE_LAUNCHER_CONF"))
         if not conf:
             return MAX_CONCURRENT_WORKFLOWS
         return read_agent_task_policy(

--- a/app/services/autonomous_scheduler.py
+++ b/app/services/autonomous_scheduler.py
@@ -46,10 +46,18 @@ _SANDBOX_REAP_INTERVAL_SECONDS = float(os.environ.get("OPENACE_SANDBOX_REAP_INTE
 def get_max_concurrent_workflows() -> int:
     """Resolve the concurrency cap from agent-launcher.conf (default 3)."""
     try:
-        from app.modules.workspace.autonomous.task_isolation import read_agent_task_policy
+        from app.modules.workspace.autonomous.task_isolation import (
+            read_agent_task_policy,
+            resolve_agent_task_policy_path,
+        )
 
+        conf = resolve_agent_task_policy_path(
+            _AGENT_LAUNCHER_CONF if "OPENACE_LAUNCHER_CONF" in os.environ else None
+        )
+        if not conf:
+            return MAX_CONCURRENT_WORKFLOWS
         return read_agent_task_policy(
-            _AGENT_LAUNCHER_CONF, concurrency_default=MAX_CONCURRENT_WORKFLOWS
+            conf, concurrency_default=MAX_CONCURRENT_WORKFLOWS
         ).max_concurrent_workflows
     except Exception:
         return MAX_CONCURRENT_WORKFLOWS

--- a/frontend/src/components/work/AutonomousWorkflowList.tsx
+++ b/frontend/src/components/work/AutonomousWorkflowList.tsx
@@ -36,7 +36,7 @@ const STATUS_CONFIG: Record<string, { variant: string; icon: string; labelKey: s
   pr_review: { variant: 'warning', icon: 'bi-eye', labelKey: 'autoStatusPRReview' },
   reporting: { variant: 'info', icon: 'bi-file-text', labelKey: 'autoStatusReporting' },
   waiting: { variant: 'secondary', icon: 'bi-clock', labelKey: 'autoStatusWaiting' },
-  merging: { variant: 'info', icon: 'bi-git-merge', labelKey: 'autoStatusMerging' },
+  merging: { variant: 'info', icon: 'bi-sign-merge-right', labelKey: 'autoStatusMerging' },
   completed: { variant: 'success', icon: 'bi-check-circle', labelKey: 'autoStatusCompleted' },
   failed: { variant: 'danger', icon: 'bi-x-circle', labelKey: 'autoStatusFailed' },
   cancelled: { variant: 'secondary', icon: 'bi-slash-circle', labelKey: 'autoStatusCancelled' },

--- a/frontend/src/components/work/RuntimeIsolationPanel.css
+++ b/frontend/src/components/work/RuntimeIsolationPanel.css
@@ -1,4 +1,5 @@
 .runtime-isolation-panel {
+  flex-shrink: 0;
   margin-bottom: 6px;
   border: 1px solid var(--border-color);
   border-radius: 12px;
@@ -58,6 +59,12 @@
   color: var(--text-secondary);
   font-size: 12px;
   font-weight: 600;
+}
+
+.runtime-isolation-panel__summary-pill--warning {
+  border-color: color-mix(in srgb, var(--color-warning) 28%, var(--border-color) 72%);
+  background: color-mix(in srgb, var(--color-warning) 10%, var(--bg-primary) 90%);
+  color: var(--text-primary);
 }
 
 .runtime-isolation-panel__provider {
@@ -132,6 +139,10 @@
   padding-top: 12px;
   color: var(--text-muted);
   font-size: 0.82rem;
+}
+
+.runtime-isolation-panel__notice--warning {
+  color: var(--color-warning-dark, var(--color-warning));
 }
 
 .runtime-isolation-panel__limit-grid {

--- a/frontend/src/components/work/RuntimeIsolationPanel.test.tsx
+++ b/frontend/src/components/work/RuntimeIsolationPanel.test.tsx
@@ -51,6 +51,7 @@ function workflow(policy: string | null | undefined): AutonomousWorkflow {
 const LEGACY_SNAPSHOT = JSON.stringify({
   schema_version: 1,
   provider: 'legacy_posix',
+  policy_configured: true,
   capabilities: ['private_home_tmp_xdg', 'filesystem_acl', 'cpu_mem_pids_time_quota'],
   limits: {
     memory_max_bytes: 2147483648,
@@ -131,6 +132,7 @@ describe('RuntimeIsolationPanel', () => {
   it('reports nothing enforced for a backend that declares no capabilities', () => {
     const remoteSnap = JSON.stringify({
       provider: 'remote_machine',
+      policy_configured: true,
       capabilities: [],
       limits: {},
       enforced: { memory: false, pids: false, cpu: false, wall_clock: false },
@@ -141,5 +143,22 @@ describe('RuntimeIsolationPanel', () => {
     expect(
       screen.getByText(/No isolation capabilities declared by this backend/)
     ).toBeInTheDocument();
+  });
+
+  it('shows an explicit notice when no launcher policy was configured for the run', () => {
+    const unconfiguredSnap = JSON.stringify({
+      provider: 'legacy_posix',
+      policy_configured: false,
+      capabilities: ['private_home_tmp_xdg', 'cpu_mem_pids_time_quota'],
+      limits: {},
+      enforced: { memory: true, pids: true, cpu: true, wall_clock: true },
+    });
+    render(<RuntimeIsolationPanel workflow={workflow(unconfiguredSnap)} />);
+    expect(screen.getByText('Policy not configured')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Expand' }));
+    expect(
+      screen.getByText(/No agent launcher policy file was found for this run/)
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Limit')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/work/RuntimeIsolationPanel.tsx
+++ b/frontend/src/components/work/RuntimeIsolationPanel.tsx
@@ -20,6 +20,7 @@ export interface EffectivePolicySnapshot {
   schema_version?: number;
   provider?: string;
   capabilities?: string[];
+  policy_configured?: boolean;
   limits?: {
     memory_max_bytes?: number;
     pids_max?: number;
@@ -104,6 +105,7 @@ export function RuntimeIsolationPanel({ workflow }: RuntimeIsolationPanelProps) 
 
   if (!snapshot) return null;
 
+  const policyConfigured = snapshot.policy_configured !== false;
   const limits = snapshot.limits ?? {};
   const enforced = snapshot.enforced ?? {};
   const rows: LimitRow[] = [
@@ -141,10 +143,12 @@ export function RuntimeIsolationPanel({ workflow }: RuntimeIsolationPanelProps) 
       enforced: enforced.inode,
     },
   ];
-  const summaryRows: LimitRow[] = SUMMARY_LIMIT_KEYS.flatMap((labelKey) => {
-    const row = rows.find((limitRow) => limitRow.labelKey === labelKey);
-    return row && row.value !== '—' ? [row] : [];
-  });
+  const summaryRows: LimitRow[] = !policyConfigured
+    ? []
+    : SUMMARY_LIMIT_KEYS.flatMap((labelKey) => {
+        const row = rows.find((limitRow) => limitRow.labelKey === labelKey);
+        return row && row.value !== '—' ? [row] : [];
+      });
   const visibleSummaryRows: LimitRow[] = summaryRows.length > 0 ? summaryRows : rows.slice(0, 4);
 
   return (
@@ -172,19 +176,33 @@ export function RuntimeIsolationPanel({ workflow }: RuntimeIsolationPanelProps) 
           </span>
         </div>
         <div className="runtime-isolation-panel__summary-pills">
-          {visibleSummaryRows.map((row) => (
-            <span key={row.labelKey} className="runtime-isolation-panel__summary-pill">
-              <span className="runtime-isolation-panel__summary-label">
-                {t(row.labelKey, language)}
+          {policyConfigured ? (
+            visibleSummaryRows.map((row) => (
+              <span key={row.labelKey} className="runtime-isolation-panel__summary-pill">
+                <span className="runtime-isolation-panel__summary-label">
+                  {t(row.labelKey, language)}
+                </span>
+                <span className="runtime-isolation-panel__summary-value">{row.value}</span>
               </span>
-              <span className="runtime-isolation-panel__summary-value">{row.value}</span>
+            ))
+          ) : (
+            <span className="runtime-isolation-panel__summary-pill runtime-isolation-panel__summary-pill--warning">
+              <i className="bi bi-exclamation-circle"></i>
+              <span>{t('autoPolicyNotConfigured', language)}</span>
             </span>
-          ))}
+          )}
         </div>
       </button>
 
       {expanded && (
         <div id={bodyId} className="runtime-isolation-panel__body">
+          {!policyConfigured ? (
+            <div className="runtime-isolation-panel__notice runtime-isolation-panel__notice--warning">
+              <i className="bi bi-exclamation-triangle me-1"></i>
+              {t('autoPolicyConfigMissing', language)}
+            </div>
+          ) : null}
+
           {snapshot.capabilities && snapshot.capabilities.length > 0 ? (
             <div className="runtime-isolation-panel__section">
               <div className="runtime-isolation-panel__section-label">
@@ -205,28 +223,30 @@ export function RuntimeIsolationPanel({ workflow }: RuntimeIsolationPanelProps) 
             </div>
           )}
 
-          <div className="runtime-isolation-panel__section">
-            <div className="runtime-isolation-panel__section-label">
-              {t('autoPolicyLimit', language)}
-            </div>
-            <div className="runtime-isolation-panel__limit-grid">
-              {rows.map((row) => (
-                <div key={row.labelKey} className="runtime-isolation-panel__limit-card">
-                  <div className="runtime-isolation-panel__limit-header">
-                    <span className="runtime-isolation-panel__limit-label">
-                      {t(row.labelKey, language)}
-                    </span>
-                    <Badge variant={row.enforced ? 'success' : 'warning'}>
-                      {row.enforced
-                        ? t('autoPolicyEnforcedYes', language)
-                        : t('autoPolicyEnforcedNo', language)}
-                    </Badge>
+          {policyConfigured ? (
+            <div className="runtime-isolation-panel__section">
+              <div className="runtime-isolation-panel__section-label">
+                {t('autoPolicyLimit', language)}
+              </div>
+              <div className="runtime-isolation-panel__limit-grid">
+                {rows.map((row) => (
+                  <div key={row.labelKey} className="runtime-isolation-panel__limit-card">
+                    <div className="runtime-isolation-panel__limit-header">
+                      <span className="runtime-isolation-panel__limit-label">
+                        {t(row.labelKey, language)}
+                      </span>
+                      <Badge variant={row.enforced ? 'success' : 'warning'}>
+                        {row.enforced
+                          ? t('autoPolicyEnforcedYes', language)
+                          : t('autoPolicyEnforcedNo', language)}
+                      </Badge>
+                    </div>
+                    <div className="runtime-isolation-panel__limit-value">{row.value}</div>
                   </div>
-                  <div className="runtime-isolation-panel__limit-value">{row.value}</div>
-                </div>
-              ))}
+                ))}
+              </div>
             </div>
-          </div>
+          ) : null}
         </div>
       )}
     </div>

--- a/frontend/src/components/work/RuntimeIsolationPanel.tsx
+++ b/frontend/src/components/work/RuntimeIsolationPanel.tsx
@@ -143,13 +143,15 @@ export function RuntimeIsolationPanel({ workflow }: RuntimeIsolationPanelProps) 
       enforced: enforced.inode,
     },
   ];
-  const summaryRows: LimitRow[] = !policyConfigured
-    ? []
-    : SUMMARY_LIMIT_KEYS.flatMap((labelKey) => {
-        const row = rows.find((limitRow) => limitRow.labelKey === labelKey);
-        return row && row.value !== '—' ? [row] : [];
-      });
-  const visibleSummaryRows: LimitRow[] = summaryRows.length > 0 ? summaryRows : rows.slice(0, 4);
+  const visibleSummaryRows: LimitRow[] | null = policyConfigured
+    ? (() => {
+        const summaryRows: LimitRow[] = SUMMARY_LIMIT_KEYS.flatMap((labelKey) => {
+          const row = rows.find((limitRow) => limitRow.labelKey === labelKey);
+          return row && row.value !== '—' ? [row] : [];
+        });
+        return summaryRows.length > 0 ? summaryRows : rows.slice(0, 4);
+      })()
+    : null;
 
   return (
     <div className="runtime-isolation-panel" data-testid="runtime-isolation-panel">
@@ -176,7 +178,7 @@ export function RuntimeIsolationPanel({ workflow }: RuntimeIsolationPanelProps) 
           </span>
         </div>
         <div className="runtime-isolation-panel__summary-pills">
-          {policyConfigured ? (
+          {visibleSummaryRows ? (
             visibleSummaryRows.map((row) => (
               <span key={row.labelKey} className="runtime-isolation-panel__summary-pill">
                 <span className="runtime-isolation-panel__summary-label">

--- a/frontend/src/components/work/WorkflowTimeline.css
+++ b/frontend/src/components/work/WorkflowTimeline.css
@@ -1,4 +1,6 @@
 .timeline-shell {
+  flex: 1 1 auto;
+  min-height: 0;
   background: var(--bg-primary);
   color: var(--text-primary);
   container-name: workflow-timeline;
@@ -208,15 +210,8 @@
   border-color: color-mix(in srgb, var(--color-danger) 24%, var(--border-color) 76%);
 }
 
-.timeline-status-pill__spinner {
-  display: inline-block;
-  width: 14px;
-  height: 14px;
-  border: 2px solid color-mix(in srgb, currentColor 24%, transparent 76%);
-  border-top-color: currentColor;
-  border-radius: 999px;
-  flex-shrink: 0;
-  animation: timeline-spin 0.9s linear infinite;
+.timeline-status-pill--live .timeline-status-pill__icon i {
+  animation: timeline-spin 2.8s linear infinite;
 }
 
 .timeline-inline-link {
@@ -243,7 +238,7 @@
 
 .timeline-header-meta-grid {
   display: grid;
-  grid-template-columns: minmax(170px, 1.45fr) repeat(3, minmax(108px, 1fr));
+  grid-template-columns: repeat(4, minmax(108px, 1fr));
   gap: 6px;
   min-width: 0;
 }
@@ -1288,7 +1283,6 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .timeline-status-pill__spinner,
   .timeline-progress-note__indicator {
     animation: none;
   }

--- a/frontend/src/components/work/WorkflowTimeline.tsx
+++ b/frontend/src/components/work/WorkflowTimeline.tsx
@@ -1911,7 +1911,7 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
   // ── Main Render ───────────────────────────────────────────────────
 
   return (
-    <div className="timeline-shell d-flex flex-column h-100">
+    <div className="timeline-shell d-flex flex-column">
       <div
         className={`timeline-header ${activeStatusHint ? 'timeline-header--active' : ''} ${
           headerCollapsed ? 'timeline-header--collapsed' : ''
@@ -1931,9 +1931,6 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
                   isLiveStatus ? 'timeline-status-pill--live' : ''
                 }`}
               >
-                {isLiveStatus && (
-                  <span className="timeline-status-pill__spinner" aria-hidden="true"></span>
-                )}
                 <span className="timeline-status-pill__icon">
                   <i className={`bi ${workflowStatusConfig.icon}`}></i>
                 </span>

--- a/frontend/src/components/work/autonomousWorkflowStatus.ts
+++ b/frontend/src/components/work/autonomousWorkflowStatus.ts
@@ -58,7 +58,7 @@ export const AUTONOMOUS_WORKFLOW_STATUS_CONFIG: Record<string, AutonomousWorkflo
   },
   merging: {
     variant: 'info',
-    icon: 'bi-git-merge',
+    icon: 'bi-sign-merge-right',
     labelKey: 'autoStatusMerging',
     tone: 'info',
   },

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -1555,6 +1555,9 @@ export const translations: Record<Language, Translations> = {
     autoPolicyPanelTitle: 'Runtime & Isolation',
     autoPolicyCapabilities: 'Declared capabilities',
     autoPolicyNoCapabilities: 'No isolation capabilities declared by this backend',
+    autoPolicyNotConfigured: 'Policy not configured',
+    autoPolicyConfigMissing:
+      'No agent launcher policy file was found for this run, so no runtime limits were recorded.',
     autoPolicyLimit: 'Limit',
     autoPolicyValue: 'Value',
     autoPolicyEnforced: 'Enforced',
@@ -3267,6 +3270,8 @@ export const translations: Record<Language, Translations> = {
     autoPolicyPanelTitle: '运行时与隔离',
     autoPolicyCapabilities: '声明的能力',
     autoPolicyNoCapabilities: '此后端未声明任何隔离能力',
+    autoPolicyNotConfigured: '未配置策略',
+    autoPolicyConfigMissing: '本次运行未找到 agent launcher 策略文件，因此没有记录任何运行时限额。',
     autoPolicyLimit: '限额',
     autoPolicyValue: '值',
     autoPolicyEnforced: '是否强制',
@@ -4768,6 +4773,9 @@ export const translations: Record<Language, Translations> = {
     autoPolicyPanelTitle: 'ランタイムと分離',
     autoPolicyCapabilities: '宣言された能力',
     autoPolicyNoCapabilities: 'このバックエンドは分離能力を宣言していません',
+    autoPolicyNotConfigured: 'ポリシー未設定',
+    autoPolicyConfigMissing:
+      'この実行では agent launcher のポリシーファイルが見つからず、ランタイム制限は記録されませんでした。',
     autoPolicyLimit: 'リミット',
     autoPolicyValue: '値',
     autoPolicyEnforced: '強制',
@@ -6356,6 +6364,9 @@ export const translations: Record<Language, Translations> = {
     autoPolicyPanelTitle: '런타임 및 격리',
     autoPolicyCapabilities: '선언된 기능',
     autoPolicyNoCapabilities: '이 백엔드는 격리 기능을 선언하지 않았습니다',
+    autoPolicyNotConfigured: '정책 미구성',
+    autoPolicyConfigMissing:
+      '이번 실행에서는 agent launcher 정책 파일을 찾지 못해 런타임 제한이 기록되지 않았습니다.',
     autoPolicyLimit: '제한',
     autoPolicyValue: '값',
     autoPolicyEnforced: '적용 여부',

--- a/scripts/openace-run-as.sh
+++ b/scripts/openace-run-as.sh
@@ -68,13 +68,30 @@ shift 2
 # `env_keep += OPENACE_*` drift or SETENV grant can redirect the gate or the
 # audit log. The OPENACE_* overrides are honored only for non-root test
 # invocation (`bash $WRAPPER`).
+_resolve_non_root_launcher_conf() {
+    local user_launcher_conf="$HOME/.open-ace/agent-launcher.conf"
+    if [ -n "${OPENACE_LAUNCHER_CONF:-}" ]; then
+        printf '%s\n' "$OPENACE_LAUNCHER_CONF"
+        return
+    fi
+    if [ -f "/etc/openace/agent-launcher.conf" ]; then
+        printf '%s\n' "/etc/openace/agent-launcher.conf"
+        return
+    fi
+    if [ -f "$user_launcher_conf" ]; then
+        printf '%s\n' "$user_launcher_conf"
+        return
+    fi
+    printf '%s\n' "/etc/openace/agent-launcher.conf"
+}
+
 if [ "$(id -u)" -eq 0 ]; then
     _OPENACE_VALIDATE_LAUNCH="/usr/local/libexec/openace-validate-launch"
     _OPENACE_LAUNCHER_CONF="/etc/openace/agent-launcher.conf"
     AUDIT_LOG="/var/log/openace/run-as-audit.log"
 else
     _OPENACE_VALIDATE_LAUNCH="${OPENACE_VALIDATE_LAUNCH:-/usr/local/libexec/openace-validate-launch}"
-    _OPENACE_LAUNCHER_CONF="${OPENACE_LAUNCHER_CONF:-/etc/openace/agent-launcher.conf}"
+    _OPENACE_LAUNCHER_CONF="$(_resolve_non_root_launcher_conf)"
     AUDIT_LOG="${OPENACE_AUDIT_LOG:-/var/log/openace/run-as-audit.log}"
 fi
 

--- a/tests/issues/2020/test_agent_task_policy.py
+++ b/tests/issues/2020/test_agent_task_policy.py
@@ -9,7 +9,12 @@ contract is pinned here.
 
 from __future__ import annotations
 
-from app.modules.workspace.autonomous.task_isolation import AgentTaskPolicy, read_agent_task_policy
+from app.modules.workspace.autonomous.task_isolation import (
+    AgentTaskPolicy,
+    candidate_agent_task_policy_paths,
+    read_agent_task_policy,
+    resolve_agent_task_policy_path,
+)
 
 
 def _write_conf(tmp_path, body: str):
@@ -91,3 +96,34 @@ def test_cgroup_enabled_normalizes_and_rejects_unknown(tmp_path):
     ):
         conf = _write_conf(tmp_path, f"agent_task_cgroup_enabled={raw}")
         assert read_agent_task_policy(conf).cgroup_enabled == expected
+
+
+def test_resolve_agent_task_policy_path_prefers_existing_candidates(tmp_path, monkeypatch):
+    explicit = tmp_path / "explicit.conf"
+    explicit.write_text("agent_task_memory_max_bytes=1\n", encoding="utf-8")
+    system = tmp_path / "system.conf"
+    system.write_text("agent_task_memory_max_bytes=2\n", encoding="utf-8")
+    user = tmp_path / "user.conf"
+    user.write_text("agent_task_memory_max_bytes=3\n", encoding="utf-8")
+
+    monkeypatch.setattr(
+        "app.modules.workspace.autonomous.task_isolation.DEFAULT_AGENT_LAUNCHER_CONF",
+        str(system),
+    )
+    monkeypatch.setattr(
+        "app.modules.workspace.autonomous.task_isolation.USER_AGENT_LAUNCHER_CONF",
+        str(user),
+    )
+
+    assert candidate_agent_task_policy_paths(str(explicit)) == (
+        str(explicit),
+        str(system),
+        str(user),
+    )
+    assert resolve_agent_task_policy_path(str(explicit)) == str(explicit)
+    explicit.unlink()
+    assert resolve_agent_task_policy_path(str(explicit)) == str(system)
+    system.unlink()
+    assert resolve_agent_task_policy_path(str(explicit)) == str(user)
+    user.unlink()
+    assert resolve_agent_task_policy_path(str(explicit)) is None

--- a/tests/issues/2020/test_effective_policy_serialization.py
+++ b/tests/issues/2020/test_effective_policy_serialization.py
@@ -72,10 +72,10 @@ def test_remote_with_no_caps_reports_nothing_enforced():
     assert snap["enforced"]["ephemeral_storage"] is False
 
 
-def test_none_policy_yields_safe_default_limits():
+def test_none_policy_marks_the_snapshot_unconfigured():
     snap = build_effective_policy("legacy_posix", _LEGACY_CAPS, None)
-    assert snap["limits"]["memory_max_bytes"] == 0
-    assert snap["limits"]["wall_clock_limit"] == 0
+    assert snap["policy_configured"] is False
+    assert snap["limits"] == {}
     assert snap["cgroup_enabled"] == ""
     # enforced is still derived from caps, independent of policy presence
     assert snap["enforced"]["memory"] is True


### PR DESCRIPTION
## Summary

This PR fixes two related workflow detail regressions in the autonomous workflow UI and runtime policy reporting.

- restores the merge status chip/icon treatment and timeline header sizing consistency
- prevents missing launcher policy files from being serialized as fake "all-zero" runtime limits
- adds a user-scoped `~/.open-ace/agent-launcher.conf` fallback for local development when `/etc/openace/agent-launcher.conf` is absent
- updates the Runtime & Isolation panel to explicitly show an unconfigured-policy state instead of a row of misleading dashes

## Root cause

There were two separate causes behind the behavior we investigated:

1. The timeline layout gave the timeline container a fixed full-height root while the Runtime & Isolation panel was still allowed to shrink, so the summary bar could be compressed down to effectively zero visible height.
2. When no launcher policy file was present, the backend fell back to a default `AgentTaskPolicy`-shaped snapshot and persisted zero/empty limit values. The frontend rendered those values as `—`, which looked like a populated policy with empty data instead of the real condition: no policy file was configured for that run.

## What changed

### Timeline / status UI

- restore the merge status icon behavior using `bi-sign-merge-right`
- remove the separate spinner treatment and return to the older icon-based active-state effect
- make the timeline header cards use consistent widths
- stop the timeline shell from squeezing the Runtime & Isolation panel out of view

### Runtime policy handling

- add explicit launcher policy path resolution precedence:
  1. `OPENACE_LAUNCHER_CONF`
  2. `/etc/openace/agent-launcher.conf`
  3. `~/.open-ace/agent-launcher.conf`
  4. built-in defaults
- return `None` when no policy file exists instead of synthesizing an all-default loaded policy
- persist `policy_configured: false` and an empty `limits` object when the launcher policy is missing
- teach the Runtime & Isolation panel to render an explicit warning state for unconfigured policy snapshots
- add a local user-scoped fallback config for development environments

## User impact

- Local development environments without `/etc/openace/agent-launcher.conf` now surface a clear policy status and can opt into real runtime limit reporting via `~/.open-ace/agent-launcher.conf`.
- Workflow detail pages no longer hide the Runtime & Isolation summary bar because of flex compression.
- The timeline header layout is visually consistent again.

## Validation

- `python -m pytest tests/issues/2020/test_agent_task_policy.py tests/issues/2020/test_effective_policy_serialization.py -q`
- `./node_modules/.bin/vitest --run src/components/work/RuntimeIsolationPanel.test.tsx`
- `npm run build`
- verified that the running local server resolved `~/.open-ace/agent-launcher.conf` and produced a runtime policy snapshot with configured limits

## Notes

A live end-to-end creation check for a brand-new workflow on the local instance was blocked by the current monthly token quota (`429 Monthly token quota exceeded`). The runtime policy snapshot generation path was verified directly from the running code after the fallback config was installed.
