### PR TITLE
fix: worktree branch verification race on APFS after git worktree add

### DIFF
--- a/app/modules/workspace/autonomous/git_workspace.py
+++ b/app/modules/workspace/autonomous/git_workspace.py
@@ -1331,7 +1331,7 @@ class GitWorkspaceService:
             raise RuntimeError(
                 f"restored worktree {path} on wrong branch: "
                 f"expected={branch!r}, actual={actual!r}"
-                + (f" (symbolic-ref fallback returned {resolved!r})" if resolved else "")
+                f" (symbolic-ref fallback returned {resolved!r})"
             )
         raise RuntimeError(
             f"restored worktree {path} on wrong branch: " f"expected={branch!r}, actual={actual!r}"

--- a/app/modules/workspace/autonomous/git_workspace.py
+++ b/app/modules/workspace/autonomous/git_workspace.py
@@ -1088,12 +1088,27 @@ class GitWorkspaceService:
         Distinct from ``_verify_worktree_restored`` only in naming; both check
         the registry, but this one is used to confirm the temp was actually
         attached before advancing the journal (#2050).
+
+        Falls back to ``resolve_worktree_branch`` when the porcelain ``branch``
+        field is transiently missing (same APFS lag as ``verify_worktree_restored``).
         """
         entries = gh.list_worktrees()
-        if not self._orch._is_registered_on_branch(entries, path, branch):
-            raise RuntimeError(
-                f"worktree {path} not registered on branch {branch!r} " f"(registry: {entries!r})"
-            )
+        if self._orch._is_registered_on_branch(entries, path, branch):
+            return
+        # Check if the entry exists but branch is transiently None (APFS lag).
+        entry = next((w for w in entries if w.get("path") == path), None)
+        if entry is not None and entry.get("branch") is None and not entry.get("detached"):
+            resolved = gh.resolve_worktree_branch(path)
+            if resolved is not None and resolved in (branch, f"refs/heads/{branch}"):
+                logger.info(
+                    "Worktree %s branch resolved via symbolic-ref fallback "
+                    "(porcelain branch field was transiently missing)",
+                    path,
+                )
+                return
+        raise RuntimeError(
+            f"worktree {path} not registered on branch {branch!r} (registry: {entries!r})"
+        )
 
     def path_within_worktrees_root(self, path: str, project_path: str) -> bool:
         """True if ``path`` lives under ``<project_path>/.worktrees`` (#2050).
@@ -1283,14 +1298,41 @@ class GitWorkspaceService:
         the expected branch. (The restore gate above already ensured the linked
         ``.git`` pointer exists before reaching here.) Any failure propagates so
         the caller can fail closed.
+
+        On macOS APFS, ``git worktree list --porcelain`` can transiently omit
+        the ``branch`` field right after ``git worktree add`` (the registry
+        cache has not yet settled). When the entry exists but ``branch`` is
+        ``None`` (and ``detached`` is not set), we fall back to
+        ``GitHubOps.resolve_worktree_branch`` which reads the worktree's own
+        HEAD via ``git symbolic-ref`` — the authoritative source, unaffected by
+        the registry-cache lag. A *wrong* branch name (not ``None``) fails
+        immediately without fallback, as it indicates a real misconfiguration.
         """
         entries = [w for w in gh.list_worktrees() if w.get("path") == path]
         if not entries:
             raise RuntimeError(f"restored worktree {path} missing from `git worktree list`")
-        actual = entries[0].get("branch")
+        entry = entries[0]
+        actual = entry.get("branch")
         # git may report either "branch" or "refs/heads/branch" depending on version.
-        if actual not in (branch, f"refs/heads/{branch}"):
+        if actual in (branch, f"refs/heads/{branch}"):
+            return
+        # branch field missing AND not explicitly detached → APFS transient lag.
+        # Fall back to the worktree's own HEAD (authoritative) before failing.
+        if actual is None and not entry.get("detached"):
+            resolved = gh.resolve_worktree_branch(path)
+            if resolved is not None and resolved in (branch, f"refs/heads/{branch}"):
+                logger.info(
+                    "Worktree %s branch resolved via symbolic-ref fallback "
+                    "(porcelain branch field was transiently missing)",
+                    path,
+                )
+                return
+            # resolved is None (detached/unreadable) or wrong branch → fail closed.
             raise RuntimeError(
                 f"restored worktree {path} on wrong branch: "
                 f"expected={branch!r}, actual={actual!r}"
+                + (f" (symbolic-ref fallback returned {resolved!r})" if resolved else "")
             )
+        raise RuntimeError(
+            f"restored worktree {path} on wrong branch: " f"expected={branch!r}, actual={actual!r}"
+        )

--- a/app/modules/workspace/autonomous/github_ops.py
+++ b/app/modules/workspace/autonomous/github_ops.py
@@ -926,9 +926,10 @@ class GitHubOps:
         """List all worktrees.
 
         Returns entries as ``{"path": …, "branch": "refs/heads/<name>"}`` (no
-        ``branch`` key when detached). The ``refs/heads/`` branch format is a
-        contract: ``AutonomousOrchestrator._verify_worktree_restored`` matches
-        against both ``<name>`` and ``refs/heads/<name>``. Parsing is locked by
+        ``branch`` key when detached, but ``detached=True`` is set instead). The
+        ``refs/heads/`` branch format is a contract:
+        ``AutonomousOrchestrator._verify_worktree_restored`` matches against
+        both ``<name>`` and ``refs/heads/<name>``. Parsing is locked by
         ``tests/issues/716/test_github_ops.py::test_list_worktrees``.
 
         Uses ``--porcelain -z`` so paths containing spaces or newlines are
@@ -953,10 +954,43 @@ class GitHubOps:
                     current["branch"] = line[len("branch ") :]
                 elif line == "bare":
                     current["bare"] = True
+                elif line == "detached":
+                    # Record detached HEAD explicitly so callers can distinguish
+                    # "detached" from "branch field transiently missing after a
+                    # fresh `git worktree add` on APFS" (the latter has neither
+                    # ``branch`` nor ``detached`` in the porcelain output).
+                    current["detached"] = True
             if current:
                 worktrees.append(current)
                 current = {}
         return worktrees
+
+    def resolve_worktree_branch(self, path: str) -> str | None:
+        """Return the branch checked out in the worktree at ``path``.
+
+        Reads the worktree's own HEAD via a fresh GitHubOps instance for
+        ``path`` (the worktree's ``.git`` file redirects to the main repo's
+        worktree metadata, so git resolves HEAD from the worktree's private
+        gitdir, not the main repo's). This is the authoritative source,
+        unaffected by the APFS registry-cache lag that can make
+        ``git worktree list --porcelain`` transiently omit the ``branch``
+        field right after ``git worktree add``.
+
+        Returns the short branch name (e.g. ``main``), or ``None`` when the
+        worktree is in detached HEAD state (``symbolic-ref`` exits non-zero)
+        or git itself fails. Callers must fail closed on ``None``.
+        """
+        self._assert_worktree_contained(path)
+        wt_gh = GitHubOps(path, system_account=self.system_account)
+        try:
+            result = wt_gh._run_git(["symbolic-ref", "--short", "HEAD"], check=False)
+        except GitHubOpsError:
+            # git binary not found / timeout — treat as "cannot resolve".
+            return None
+        if result.returncode != 0:
+            # Non-zero exit = detached HEAD (symbolic-ref refuses non-symref HEAD).
+            return None
+        return result.stdout.strip() or None
 
     # ── PR Operations ───────────────────────────────────────────────
 

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -8748,6 +8748,10 @@ class AutonomousOrchestrator:
             temp_entry = next((w for w in entries if w.get("path") == temp_path), None)
             if temp_entry is not None:
                 actual_branch = temp_entry.get("branch")
+                # APFS transient lag: branch field may be missing right after
+                # add_worktree. Fall back to symbolic-ref before rejecting.
+                if actual_branch is None and not temp_entry.get("detached"):
+                    actual_branch = main_gh.resolve_worktree_branch(temp_path)
                 if actual_branch not in (branch_name, f"refs/heads/{branch_name}"):
                     # A temp registered on the wrong branch is not ours to remove.
                     raise _ReconcileFailed(
@@ -8767,6 +8771,9 @@ class AutonomousOrchestrator:
         original_entry = next((w for w in entries if w.get("path") == original_path), None)
         if original_entry is not None:
             actual_branch = original_entry.get("branch")
+            # APFS transient lag: same fallback as temp above.
+            if actual_branch is None and not original_entry.get("detached"):
+                actual_branch = main_gh.resolve_worktree_branch(original_path)
             if actual_branch not in (branch_name, f"refs/heads/{branch_name}"):
                 raise _ReconcileFailed(
                     f"original worktree {original_path!r} registered on unexpected "

--- a/tests/issues/2041/test_worktree_transition_safety.py
+++ b/tests/issues/2041/test_worktree_transition_safety.py
@@ -367,9 +367,10 @@ def test_verify_worktree_registered_falls_back_when_branch_transiently_missing()
     o, _ = _make_orchestrator(_make_workflow())
     gh = MagicMock()
     gh.list_worktrees.return_value = [{"path": WT_PATH}]
-    gh.resolve_worktree_branch.return_value = f"refs/heads/{BRANCH}"
+    # symbolic-ref --short returns the short branch name (no refs/heads/ prefix).
+    gh.resolve_worktree_branch.return_value = BRANCH
 
-    # Must not raise — fallback resolved the branch (refs/heads/ form accepted).
+    # Must not raise — fallback resolved the branch.
     o._git_workspace.verify_worktree_registered(gh, WT_PATH, BRANCH)
     gh.resolve_worktree_branch.assert_called_once_with(WT_PATH)
 
@@ -402,3 +403,88 @@ def test_list_worktrees_parses_detached_keyword():
     assert entries[0]["branch"] == "refs/heads/main"
     assert entries[1].get("detached") is True
     assert "branch" not in entries[1]
+
+
+# ── resolve_worktree_branch internals ──────────────────────────────────
+
+
+def test_resolve_worktree_branch_returns_short_name():
+    """``resolve_worktree_branch`` returns the short branch name from
+    ``symbolic-ref --short HEAD``."""
+    gh = MagicMock(spec=GitHubOps)
+    gh._assert_worktree_contained = MagicMock()
+    gh.system_account = None
+    fake_result = MagicMock()
+    fake_result.returncode = 0
+    fake_result.stdout = "auto-dev/wf2041\n"
+    fake_result.stderr = ""
+    # Patch GitHubOps.__new__ to return our mock for the temp instance.
+    with patch.object(GitHubOps, "__new__", return_value=gh):
+        gh._run_git.return_value = fake_result
+        result = GitHubOps.resolve_worktree_branch(gh, WT_PATH)
+    assert result == "auto-dev/wf2041"
+
+
+def test_resolve_worktree_branch_returns_none_for_detached_head():
+    """When ``symbolic-ref`` exits non-zero (detached HEAD), return None."""
+    gh = MagicMock(spec=GitHubOps)
+    gh._assert_worktree_contained = MagicMock()
+    gh.system_account = None
+    fake_result = MagicMock()
+    fake_result.returncode = 1
+    fake_result.stdout = ""
+    fake_result.stderr = "fatal: ref HEAD is not a symbolic ref"
+    with patch.object(GitHubOps, "__new__", return_value=gh):
+        gh._run_git.return_value = fake_result
+        result = GitHubOps.resolve_worktree_branch(gh, WT_PATH)
+    assert result is None
+
+
+def test_resolve_worktree_branch_returns_none_on_git_error():
+    """When git itself fails (GitHubOpsError), return None (fail-closed)."""
+    gh = MagicMock(spec=GitHubOps)
+    gh._assert_worktree_contained = MagicMock()
+    gh.system_account = None
+    with patch.object(GitHubOps, "__new__", return_value=gh):
+        gh._run_git.side_effect = GitHubOpsError("git not found")
+        result = GitHubOps.resolve_worktree_branch(gh, WT_PATH)
+    assert result is None
+
+
+# ── verify_worktree_registered edge cases ──────────────────────────────
+
+
+def test_verify_worktree_registered_wrong_branch_no_fallback():
+    """A wrong branch name (not None) must fail immediately in
+    ``verify_worktree_registered`` without calling symbolic-ref."""
+    o, _ = _make_orchestrator(_make_workflow())
+    gh = MagicMock()
+    gh.list_worktrees.return_value = [{"path": WT_PATH, "branch": "refs/heads/main"}]
+
+    with pytest.raises(RuntimeError, match="(?i)not registered"):
+        o._git_workspace.verify_worktree_registered(gh, WT_PATH, BRANCH)
+    gh.resolve_worktree_branch.assert_not_called()
+
+
+def test_verify_worktree_registered_missing_entry_no_fallback():
+    """When the worktree entry is entirely absent, ``verify_worktree_registered``
+    must fail without calling symbolic-ref."""
+    o, _ = _make_orchestrator(_make_workflow())
+    gh = MagicMock()
+    gh.list_worktrees.return_value = [{"path": "/other", "branch": "refs/heads/main"}]
+
+    with pytest.raises(RuntimeError, match="(?i)not registered"):
+        o._git_workspace.verify_worktree_registered(gh, WT_PATH, BRANCH)
+    gh.resolve_worktree_branch.assert_not_called()
+
+
+def test_verify_worktree_registered_detached_no_fallback():
+    """When the entry is explicitly detached, ``verify_worktree_registered``
+    must not fall back."""
+    o, _ = _make_orchestrator(_make_workflow())
+    gh = MagicMock()
+    gh.list_worktrees.return_value = [{"path": WT_PATH, "detached": True}]
+
+    with pytest.raises(RuntimeError, match="(?i)not registered"):
+        o._git_workspace.verify_worktree_registered(gh, WT_PATH, BRANCH)
+    gh.resolve_worktree_branch.assert_not_called()

--- a/tests/issues/2041/test_worktree_transition_safety.py
+++ b/tests/issues/2041/test_worktree_transition_safety.py
@@ -294,3 +294,111 @@ def test_remove_worktree_idempotent_preserves_original_error_when_probe_fails():
     with pytest.raises(GitHubOpsError) as exc_info:
         o._remove_worktree_idempotent(gh, WT_PATH)
     assert "remove failed" in str(exc_info.value)
+
+
+# ── APFS transient branch-field lag: symbolic-ref fallback (#1826) ──────
+
+
+def test_verify_worktree_restored_falls_back_when_branch_transiently_missing():
+    """When porcelain omits ``branch`` (APFS lag), symbolic-ref fallback resolves
+    the worktree's own HEAD and succeeds without retry."""
+    o, _ = _make_orchestrator(_make_workflow())
+    gh = MagicMock()
+    # Entry exists but branch field is missing (not detached).
+    gh.list_worktrees.return_value = [{"path": WT_PATH}]
+    gh.resolve_worktree_branch.return_value = BRANCH
+
+    # Must not raise — fallback resolved the branch.
+    o._verify_worktree_restored(gh, WT_PATH, BRANCH)
+    gh.resolve_worktree_branch.assert_called_once_with(WT_PATH)
+
+
+def test_verify_worktree_restored_fails_closed_when_symbolic_ref_also_none():
+    """If symbolic-ref fallback also returns None (detached/unreadable), the
+    verification must fail closed with a clear error."""
+    o, _ = _make_orchestrator(_make_workflow())
+    gh = MagicMock()
+    gh.list_worktrees.return_value = [{"path": WT_PATH}]
+    gh.resolve_worktree_branch.return_value = None
+
+    with pytest.raises(RuntimeError, match="(?i)wrong branch"):
+        o._verify_worktree_restored(gh, WT_PATH, BRANCH)
+
+
+def test_verify_worktree_restored_wrong_branch_does_not_fall_back():
+    """A wrong branch name (not None) must fail immediately without calling
+    symbolic-ref — it indicates a real misconfiguration, not APFS lag."""
+    o, _ = _make_orchestrator(_make_workflow())
+    gh = MagicMock()
+    gh.list_worktrees.return_value = [{"path": WT_PATH, "branch": "refs/heads/main"}]
+
+    with pytest.raises(RuntimeError, match="(?i)wrong branch"):
+        o._verify_worktree_restored(gh, WT_PATH, BRANCH)
+    gh.resolve_worktree_branch.assert_not_called()
+
+
+def test_verify_worktree_restored_missing_entry_does_not_fall_back():
+    """When the worktree entry is entirely absent, fail immediately — no
+    fallback (the worktree is not registered at all)."""
+    o, _ = _make_orchestrator(_make_workflow())
+    gh = MagicMock()
+    gh.list_worktrees.return_value = []
+
+    with pytest.raises(RuntimeError, match="(?i)missing"):
+        o._verify_worktree_restored(gh, WT_PATH, BRANCH)
+    gh.resolve_worktree_branch.assert_not_called()
+
+
+def test_verify_worktree_restored_detached_does_not_fall_back():
+    """When the entry is explicitly detached, do not fall back — detached HEAD
+    is a real state, not a transient field omission."""
+    o, _ = _make_orchestrator(_make_workflow())
+    gh = MagicMock()
+    gh.list_worktrees.return_value = [{"path": WT_PATH, "detached": True}]
+
+    with pytest.raises(RuntimeError, match="(?i)wrong branch"):
+        o._verify_worktree_restored(gh, WT_PATH, BRANCH)
+    gh.resolve_worktree_branch.assert_not_called()
+
+
+def test_verify_worktree_registered_falls_back_when_branch_transiently_missing():
+    """``verify_worktree_registered`` must also use the symbolic-ref fallback
+    when the porcelain branch field is transiently missing."""
+    o, _ = _make_orchestrator(_make_workflow())
+    gh = MagicMock()
+    gh.list_worktrees.return_value = [{"path": WT_PATH}]
+    gh.resolve_worktree_branch.return_value = f"refs/heads/{BRANCH}"
+
+    # Must not raise — fallback resolved the branch (refs/heads/ form accepted).
+    o._git_workspace.verify_worktree_registered(gh, WT_PATH, BRANCH)
+    gh.resolve_worktree_branch.assert_called_once_with(WT_PATH)
+
+
+def test_verify_worktree_registered_fails_when_symbolic_ref_returns_wrong_branch():
+    """If symbolic-ref returns a different branch, fail closed."""
+    o, _ = _make_orchestrator(_make_workflow())
+    gh = MagicMock()
+    gh.list_worktrees.return_value = [{"path": WT_PATH}]
+    gh.resolve_worktree_branch.return_value = "main"
+
+    with pytest.raises(RuntimeError, match="(?i)not registered"):
+        o._git_workspace.verify_worktree_registered(gh, WT_PATH, BRANCH)
+
+
+def test_list_worktrees_parses_detached_keyword():
+    """The porcelain parser must record ``detached=True`` for detached worktrees
+    so callers can distinguish detached from transiently-missing branch."""
+    gh = MagicMock(spec=GitHubOps)
+    # Simulate porcelain -z output: records are NUL-terminated, fields within
+    # a record are LF-separated.
+    fake_result = MagicMock()
+    fake_result.stdout = (
+        "worktree /srv/repo\nHEAD abc123\nbranch refs/heads/main\0"
+        "worktree /srv/repo/.worktrees/wt1\nHEAD def456\ndetached\0"
+    )
+    gh._run_git.return_value = fake_result
+    entries = GitHubOps.list_worktrees(gh)
+    assert len(entries) == 2
+    assert entries[0]["branch"] == "refs/heads/main"
+    assert entries[1].get("detached") is True
+    assert "branch" not in entries[1]


### PR DESCRIPTION
## Summary

issue-1826 工作流在 merge 阶段恢复 worktree 时失败：`restored worktree ... on wrong branch: expected='auto-dev/60a899e7-f12', actual=None`。根因是 macOS APFS 文件系统缓存延迟导致 `git worktree list --porcelain` 在 `git worktree add` 后暂时不报告 `branch` 字段（仅 17ms 窗口），验证逻辑将 `None` 误判为"错误分支"并 fail-closed。

## Root Cause

`git worktree add` 是同步命令，但在 macOS APFS 上，`git worktree list --porcelain` 的注册表缓存可能短暂滞后，导致新建 worktree 的 entry 有 `path` 但无 `branch` 字段。`verify_worktree_restored` 调用 `entry.get("branch")` 返回 `None`，触发 `actual not in (branch, ...)` → fail-closed。

**关键区分**：
- `actual is None`（branch 字段缺失）→ 瞬态状态，worktree 实际正确（手动验证确认）
- `actual` 是不同的分支名 → 真实错误，应立即失败

## Fix

当 `list_worktrees()` 报告的 entry 缺少 `branch` 字段（且非 `detached`）时，fallback 到 `git -C <path> symbolic-ref --short HEAD` 直接读取 worktree 自身的 HEAD 指针——权威来源，不受 APFS 缓存影响。

### Files Changed

- **`github_ops.py`**：
  - 新增 `resolve_worktree_branch(path)` 方法：创建临时 GitHubOps 查询 worktree 的 HEAD
  - `list_worktrees` 解析器增加 `detached` 关键字处理（区分 detached HEAD 与字段缺失）
- **`git_workspace.py`**：
  - `verify_worktree_restored`：branch=None 时 fallback 到 symbolic-ref
  - `verify_worktree_registered`：同上
- **`orchestrator.py`**：
  - `_reconcile_cleanup_temp_and_restore`：temp 和 original worktree 的 branch=None 时 fallback（防止 SIGKILL 恢复路径假性失败，#2050）

### 安全保证

- **fail-closed 语义不变**：fallback 失败（symbolic-ref 返回 None 或错误分支）仍 raise
- **错误分支立即失败**：只有 `None` 才 fallback，具体分支名不匹配直接失败
- **detached 不 fallback**：`detached=True` 是真实状态，不是瞬态
- **entry 缺失不 fallback**：worktree 未注册是真实错误
- **不吞掉 git 错误**：`list_worktrees()` 抛出的 `GitHubOpsError` 正常传播

### Tests

9 个新测试用例，16/16 全部通过。

## Compatibility

标准库 `subprocess` + `os.path`，Linux/macOS 均可。