### PR TITLE
fix: TLS SNI broken by IP-literal pinning in outbound URL guard

### DIFF
--- a/app/utils/outbound_url_guard.py
+++ b/app/utils/outbound_url_guard.py
@@ -5,10 +5,13 @@ The guard is intentionally conservative: only globally routable HTTP(S)
 destinations are allowed by default. This prevents SSRF against loopback,
 private networks, link-local metadata endpoints, and other non-public ranges.
 
-The validation is enforced at *connect* time via :func:`safe_request`, which
-pins the verified IP into the actual HTTP request so the system resolver cannot
-rebind the destination to a private address between validation and the dial
-(closing the DNS-rebinding TOCTOU window).
+Validation is performed before the request via :func:`validate_public_http_url`
+and re-checked at *connect* time by :class:`_PinnedIPAdapter`, which resolves
+the hostname again and verifies all IPs are public. The request URL retains the
+original hostname so TLS SNI and certificate verification work correctly. A
+small TOCTOU window remains between the adapter's resolution and urllib3's
+connection, but HTTPS certificate verification mitigates rebinding to a
+different public host.
 """
 
 from __future__ import annotations
@@ -170,9 +173,9 @@ class OutboundUrlValidationResult:
     allowed: bool
     error: str | None = None
     # The public IP addresses that were verified for this URL. Populated only
-    # when ``allowed`` is True. Callers SHOULD pin one of these IPs into the
-    # actual request (see :func:`safe_request`) so the system resolver cannot
-    # rebind the destination between validation and the dial.
+    # when ``allowed`` is True. Used by :func:`safe_request` to pre-validate
+    # before the request and by :class:`_PinnedIPAdapter` to re-check at
+    # connect time.
     resolved_addresses: tuple[IPAddress, ...] = ()
 
 
@@ -187,9 +190,9 @@ def validate_public_http_url(
 ) -> OutboundUrlValidationResult:
     """Validate that a URL points to a public HTTP(S) destination.
 
-    Returns the verified public IP addresses so callers can pin them into the
-    actual request. Using these pinned IPs (via :func:`safe_request`) is what
-    closes the DNS-rebinding TOCTOU window — validation alone is advisory.
+    Returns the verified public IP addresses so callers can pass them to
+    :func:`safe_request`, which pre-validates and mounts a connect-time
+    adapter to guard against DNS rebinding.
     """
     if not url:
         return OutboundUrlValidationResult(False, "URL is empty")
@@ -268,11 +271,11 @@ def assert_public_http_url(url: str, *, resolver: Resolver = socket.getaddrinfo)
 def resolve_public_addresses(
     url: str, *, resolver: Resolver = socket.getaddrinfo
 ) -> tuple[str, tuple[IPAddress, ...], int | None, str]:
-    """Resolve and validate ``url`` once, returning the parts needed to pin a request.
+    """Resolve and validate ``url`` once, returning the parts needed for safe_request.
 
     Returns ``(original_host, public_ips, port, path_and_query)``. Raises
-    :class:`OutboundUrlBlockedError` if the URL is unsafe. Callers use the
-    returned IPs to build a pinned request URL (see :func:`safe_request`).
+    :class:`OutboundUrlBlockedError` if the URL is unsafe. The returned IPs
+    are passed to :class:`_PinnedIPAdapter` for connect-time re-validation.
     """
     result = validate_public_http_url(url, resolver=resolver)
     if not result.allowed:
@@ -293,89 +296,120 @@ def safe_request(
     resolver: Resolver = socket.getaddrinfo,
     **kwargs: Any,
 ) -> requests.Response:
-    """Issue an HTTP request with the verified IP pinned at connect time.
+    """Issue an HTTP request with DNS-rebinding validation at connect time.
 
-    This collapses validate+connect into a single resolution: the hostname is
-    resolved exactly once via ``resolver``, every returned IP is checked with
-    :func:`_is_public_address`, and the request is sent to the verified IP
-    literal while preserving the original hostname as the ``Host`` header (so
-    TLS SNI / virtual-host routing still works). Because the request URL
-    contains an IP literal, ``urllib3`` does not re-resolve via the system
-    resolver, which closes the DNS-rebinding TOCTOU window.
+    The hostname is resolved and every returned IP is checked with
+    :func:`_is_public_address` before the request is sent. The request URL
+    retains the original hostname so that TLS SNI and certificate verification
+    work correctly (HTTPS certificates are issued to domain names, not IP
+    literals).
+
+    A :class:`_PinnedIPAdapter` is mounted to re-validate the resolved IPs at
+    connect time, guarding against proxy configuration or future urllib3
+    changes re-introducing a private-address resolution.
 
     Fails closed (raises :class:`OutboundUrlBlockedError`) if no public IP can
-    be pinned.
+    be verified.
     """
-    original_host, public_ips, port, path_and_query = resolve_public_addresses(
+    original_host, public_ips, _port, _path_and_query = resolve_public_addresses(
         url, resolver=resolver
     )
 
     scheme = urlparse(url).scheme
-    pinned_ip = public_ips[0]
-    pinned_host = f"[{pinned_ip}]" if ":" in str(pinned_ip) else str(pinned_ip)
-    port_suffix = f":{port}" if port else ""
-    pinned_url = f"{scheme}://{pinned_host}{port_suffix}{path_and_query}"
-
-    headers = dict(kwargs.pop("headers", {}) or {})
-    headers.setdefault("Host", original_host)
-    # ``urllib3`` derives the TLS SNI/Host header from the URL host. Because we
-    # pinned an IP literal we must set the original host explicitly so HTTPS
-    # virtual hosting and SNI keep working.
-    headers["Host"] = original_host
 
     own_session = False
     if session is None:
         session = requests.Session()
         own_session = True
+    adapter = _PinnedIPAdapter(allowed_ips=public_ips, resolver=resolver)
     try:
-        adapter = _PinnedIPAdapter(allowed_ips=public_ips)
         session.mount(f"{scheme}://", adapter)
-        return session.request(method, pinned_url, headers=headers, **kwargs)
+        return session.request(method, url, **kwargs)
     finally:
+        # Unmount the adapter so it does not leak into subsequent requests on
+        # caller-provided shared sessions (M3).
+        session.mount(f"{scheme}://", HTTPAdapter())
         if own_session:
             session.close()
 
 
 class _PinnedIPAdapter(HTTPAdapter):
-    """HTTPAdapter that re-validates the connect-time IP against an allowlist.
+    """HTTPAdapter that re-validates the resolved IP at connect time.
 
-    Defense in depth: even though ``safe_request`` builds a URL whose host is
-    the pinned IP literal (so ``urllib3`` should not re-resolve), this adapter
-    intercepts the connection pool and refuses any IP that is not on the
-    verified allowlist or that fails the public-address predicate. This guards
-    against proxy configuration or future urllib3 changes re-introducing a
-    resolution step.
+    Defense in depth: ``safe_request`` pre-resolves the hostname and verifies
+    all IPs are public. This adapter re-checks at connect time by resolving
+    the request URL's hostname and refusing any IP that is not public.
+
+    For HTTPS URLs, the request URL retains the original hostname so TLS SNI
+    and certificate verification work correctly. The adapter blocks DNS
+    rebinding to private/internal IPs. For CDN-fronted endpoints where DNS
+    may return different public IPs between resolutions, the allowlist match
+    is logged as a warning rather than blocked (HTTPS certificate verification
+    mitigates rebinding to a different public host).
     """
 
-    def __init__(self, *args: Any, allowed_ips: Iterable[IPAddress] = (), **kwargs: Any):
+    def __init__(
+        self,
+        *args: Any,
+        allowed_ips: Iterable[IPAddress] = (),
+        resolver: Resolver = socket.getaddrinfo,
+        **kwargs: Any,
+    ):
         super().__init__(*args, **kwargs)
         self._allowed_ips = {str(ip) for ip in allowed_ips}
+        self._resolver = resolver
 
     def get_connection_with_tls_context(self, request, verify, proxies=None, cert=None):
-        self._check_pinned_url(request.url)
+        self._check_resolved_ip(request.url)
         return super().get_connection_with_tls_context(  # type: ignore[call-arg]
             request, verify, proxies=proxies, cert=cert
         )
 
     def get_connection(self, url, proxies=None):
-        self._check_pinned_url(url)
+        self._check_resolved_ip(url)
         return super().get_connection(url, proxies=proxies)
 
-    def _check_pinned_url(self, url: str) -> None:
+    def _check_resolved_ip(self, url: str) -> None:
+        """Resolve the URL hostname and verify all IPs are public."""
         parsed = urlparse(url)
         host = (parsed.hostname or "").strip("[]")
         if not host:
-            raise OutboundUrlBlockedError("Pinned request URL has no host")
+            raise OutboundUrlBlockedError("Request URL has no host")
+
+        # If host is already an IP literal, validate directly
         try:
             ip = _parse_ip_address(host)
-        except ValueError as exc:
-            raise OutboundUrlBlockedError(
-                f"Pinned request URL host is not an IP literal: {host!r}"
-            ) from exc
-        if str(ip) not in self._allowed_ips:
-            raise OutboundUrlBlockedError(f"Pinned request would reach unverified IP {ip}")
-        if not _is_public_address(ip):
-            raise OutboundUrlBlockedError(f"Pinned request would reach non-public IP {ip}")
+            if not _is_public_address(ip):
+                raise OutboundUrlBlockedError(f"Request would reach non-public IP {ip}")
+            return
+        except ValueError:
+            pass  # Not an IP literal — resolve as hostname
+
+        # Resolve hostname and verify all IPs are public
+        try:
+            addresses = _resolve_addresses(host, parsed.port or 443, self._resolver)
+        except OSError as exc:
+            raise OutboundUrlBlockedError(f"DNS resolution failed for {host}: {exc}") from exc
+
+        if not addresses:
+            raise OutboundUrlBlockedError(f"Host {host} did not resolve to any IP")
+
+        for addr in addresses:
+            if not _is_public_address(addr):
+                raise OutboundUrlBlockedError(
+                    f"DNS rebinding detected: {host} resolved to non-public IP {addr}"
+                )
+            # CDN/load-balancer endpoints may rotate IPs between resolutions.
+            # Log a warning for allowlist mismatch rather than blocking, since
+            # HTTPS certificate verification mitigates rebinding to a different
+            # public host.
+            if self._allowed_ips and str(addr) not in self._allowed_ips:
+                logger.warning(
+                    "Outbound URL %s resolved to IP %s not in pre-verified set; "
+                    "allowing (HTTPS certificate verification mitigates rebinding)",
+                    host,
+                    addr,
+                )
 
 
 def _resolve_addresses(host: str, port: int | None, resolver: Resolver) -> set[IPAddress]:

--- a/app/utils/outbound_url_guard.py
+++ b/app/utils/outbound_url_guard.py
@@ -311,7 +311,7 @@ def safe_request(
     Fails closed (raises :class:`OutboundUrlBlockedError`) if no public IP can
     be verified.
     """
-    original_host, public_ips, _port, _path_and_query = resolve_public_addresses(
+    _original_host, public_ips, _port, _path_and_query = resolve_public_addresses(
         url, resolver=resolver
     )
 
@@ -321,14 +321,16 @@ def safe_request(
     if session is None:
         session = requests.Session()
         own_session = True
+    previous_adapter = session.adapters.get(f"{scheme}://")
     adapter = _PinnedIPAdapter(allowed_ips=public_ips, resolver=resolver)
     try:
         session.mount(f"{scheme}://", adapter)
         return session.request(method, url, **kwargs)
     finally:
-        # Unmount the adapter so it does not leak into subsequent requests on
-        # caller-provided shared sessions (M3).
-        session.mount(f"{scheme}://", HTTPAdapter())
+        # Restore the previous adapter so the pinned adapter does not leak
+        # into subsequent requests on caller-provided shared sessions, and
+        # callers' custom adapters (retry config, TLS settings) are preserved.
+        session.mount(f"{scheme}://", previous_adapter or HTTPAdapter())
         if own_session:
             session.close()
 

--- a/tests/issues/1778/test_outbound_url_toctou.py
+++ b/tests/issues/1778/test_outbound_url_toctou.py
@@ -177,6 +177,74 @@ def test_safe_request_fails_closed_when_resolver_returns_metadata():
         )
 
 
+# ── safe_request: adapter unmount on shared sessions ───────────────────
+
+
+def test_safe_request_restores_previous_adapter_on_shared_session(monkeypatch):
+    """safe_request must restore the previous adapter, not replace it with a vanilla one."""
+    from requests.adapters import HTTPAdapter
+
+    def stable_resolver(host, *args, **kwargs):
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 443))]
+
+    def fake_send(self, request, **kwargs):
+        resp = requests.Response()
+        resp.status_code = 200
+        return resp
+
+    monkeypatch.setattr(_PinnedIPAdapter, "send", fake_send)
+
+    sess = requests.Session()
+    # Simulate a caller-provided custom adapter (e.g. with retry config)
+    custom_adapter = HTTPAdapter(max_retries=3)
+    sess.mount("https://", custom_adapter)
+
+    safe_request(
+        "GET",
+        "https://sso.evil.example/token",
+        session=sess,
+        resolver=stable_resolver,
+        timeout=5,
+    )
+
+    # The pinned adapter must have been removed; the original custom adapter
+    # must be restored (not replaced with a vanilla HTTPAdapter).
+    restored = sess.adapters.get("https://")
+    assert restored is custom_adapter, f"Previous adapter should be restored, got {restored!r}"
+
+
+def test_safe_request_unmounts_pinned_adapter_after_request(monkeypatch):
+    """After safe_request, the session must not retain the _PinnedIPAdapter."""
+    from requests.adapters import HTTPAdapter
+
+    def stable_resolver(host, *args, **kwargs):
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 443))]
+
+    def fake_send(self, request, **kwargs):
+        resp = requests.Response()
+        resp.status_code = 200
+        return resp
+
+    monkeypatch.setattr(_PinnedIPAdapter, "send", fake_send)
+
+    sess = requests.Session()
+
+    safe_request(
+        "GET",
+        "https://sso.evil.example/token",
+        session=sess,
+        resolver=stable_resolver,
+        timeout=5,
+    )
+
+    # The adapter must not be a _PinnedIPAdapter (it should be restored to the
+    # default or a vanilla HTTPAdapter).
+    current = sess.adapters.get("https://")
+    assert not isinstance(
+        current, _PinnedIPAdapter
+    ), f"_PinnedIPAdapter leaked into shared session: {current!r}"
+
+
 # ── _is_public_address denylist ─────────────────────────────────────────
 
 

--- a/tests/issues/1778/test_outbound_url_toctou.py
+++ b/tests/issues/1778/test_outbound_url_toctou.py
@@ -1,23 +1,20 @@
-"""TDD red tests for the SSRF TOCTOU / DNS-rebinding group (PR #1778).
+"""Tests for the SSRF TOCTOU / DNS-rebinding protection (PR #1778).
 
-These tests prove the two High-severity findings on the outbound URL guard:
+These tests verify the outbound URL guard's defense-in-depth approach:
 
-1. TOCTOU / DNS-rebinding: ``validate_public_http_url`` resolves the hostname
-   once and checks the IPs, but callers then hand the *original* URL back to
-   ``requests``/``urllib3``, which performs its OWN independent
-   ``socket.getaddrinfo`` at connect time. Between the two resolutions an
-   attacker-controlled authoritative DNS server can flip the A record
-   (public -> loopback / metadata). The guard is advisory, not enforced.
+1. ``safe_request`` pre-resolves the hostname and verifies all IPs are public.
+   The request URL retains the original hostname so TLS SNI and certificate
+   verification work correctly (HTTPS certificates are issued to domain names,
+   not IP literals).
 
-2. ``_is_public_address`` predicate only checks ``address.is_global`` which
-   returns ``True`` for NAT64-encoded metadata
-   (``64:ff9b::169.254.169.254``), NAT64 of loopback (``64:ff9b::7f00:1``),
-   CGNAT outside Python's narrow private slice (``100.128.0.1``), and
-   multicast. A host resolving to any of these passes the guard outright,
-   even without rebinding.
+2. ``_PinnedIPAdapter`` re-validates at connect time by resolving the hostname
+   again and blocking any IP that is not public. This catches DNS rebinding
+   attacks where the authoritative DNS server flips the A record between the
+   pre-validation and the actual connection.
 
-Both assertions FAIL against current main and PASS after the IP-pinning +
-denylist fix.
+3. ``_is_public_address`` uses an explicit denylist (not just ``is_global``)
+   to reject NAT64-encoded metadata, CGNAT, multicast, and other non-public
+   ranges that ``is_global`` returns ``True`` for.
 """
 
 import ipaddress
@@ -26,46 +23,41 @@ import socket
 import pytest
 import requests
 
-from app.utils.outbound_url_guard import _is_public_address, safe_request, validate_public_http_url
+from app.utils.outbound_url_guard import (
+    OutboundUrlBlockedError,
+    _is_public_address,
+    _PinnedIPAdapter,
+    safe_request,
+    validate_public_http_url,
+)
 
 
 class _RebindingResolver:
-    """getaddrinfo that flips: first call(s) from the guard return a PUBLIC ip,
-    later call(s) from the HTTP client return ``169.254.169.254`` (metadata)."""
+    """getaddrinfo that flips: first call returns a PUBLIC ip,
+    later calls return ``169.254.169.254`` (metadata)."""
 
     def __init__(self) -> None:
         self.calls = 0
 
     def __call__(self, host, *args, **kwargs):
         self.calls += 1
-        # First resolution (the guard): public IP -> passes _is_public_address.
-        # Subsequent resolutions (the connect-time pin re-check): metadata.
         ip = "93.184.216.34" if self.calls == 1 else "169.254.169.254"
         return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", (ip, 443))]
 
 
-def test_safe_request_pins_verified_ip_and_never_rebinds(monkeypatch):
-    """``safe_request`` must pin the validated IP into the dial.
+# ── safe_request: URL retains hostname for TLS SNI ──────────────────────
 
-    Before the fix: the guard passed (public) but ``requests`` was given the
-    raw hostname and re-resolved via the system resolver at connect time, so an
-    attacker who controlled DNS could flip the record to ``169.254.169.254``.
 
-    After the fix: ``safe_request`` resolves ONCE (via its ``resolver`` kwarg),
-    pins the verified public IP literal into the outgoing URL, and sets the
-    original hostname as the ``Host`` header so TLS SNI / virtual hosting keeps
-    working. Because the URL host is now an IP literal, ``urllib3`` does not
-    re-resolve — the rebinding window is closed. This test exercises exactly
-    that: the resolver is set up to rebind to metadata on its second call, but
-    only the first (public) call is ever made.
+def test_safe_request_retains_hostname_for_tls_sni(monkeypatch):
+    """safe_request must retain the original hostname in the URL.
+
+    The previous approach replaced the URL hostname with an IP literal, which
+    broke TLS SNI (urllib3 derives SNI from the URL host, not the Host header).
+    This caused SSL certificate verification failures for any HTTPS endpoint
+    with a domain-issued certificate.
     """
     resolver = _RebindingResolver()
-
     captured = {}
-
-    # Patch the pinned adapter's ``send`` so we capture the prepared request
-    # without performing a real network dial.
-    from app.utils.outbound_url_guard import _PinnedIPAdapter
 
     def fake_send(self, request, **kwargs):  # type: ignore[no-untyped-def]
         captured["url"] = request.url
@@ -84,34 +76,91 @@ def test_safe_request_pins_verified_ip_and_never_rebinds(monkeypatch):
         timeout=5,
     )
 
-    # Only ONE resolution happened — the rebinding second call was never made.
-    assert resolver.calls == 1, f"safe_request must resolve once; made {resolver.calls} calls"
-
     outgoing = captured.get("url", "")
-    # The verified public IP is pinned into the URL...
-    assert (
-        "93.184.216.34" in outgoing
-    ), f"safe_request did not pin the verified public IP. url={outgoing!r}"
-    # ...and the metadata IP the attacker wanted to rebind to never appears.
-    assert (
-        "169.254.169.254" not in outgoing
-    ), f"TOCTOU: request would reach metadata IP. url={outgoing!r}"
-    # The original hostname is preserved as Host for SNI / virtual hosting.
-    host_header = captured["headers"].get("Host")
-    assert (
-        host_header == "sso.evil.example"
-    ), f"Host header not preserved when pinning IP: {host_header!r}"
+    # URL retains the original hostname (not IP literal) for TLS SNI
+    assert "sso.evil.example" in outgoing, f"URL should retain hostname for SNI. url={outgoing!r}"
+    assert "93.184.216.34" not in outgoing, f"URL should not contain IP literal. url={outgoing!r}"
+
+
+# ── _PinnedIPAdapter._check_resolved_ip: connect-time re-validation ────
+
+
+def test_adapter_blocks_rebinding_to_metadata():
+    """Adapter must block when connect-time resolution returns a non-public IP."""
+    adapter = _PinnedIPAdapter(
+        allowed_ips={ipaddress.ip_address("93.184.216.34")},
+        resolver=lambda host, *a, **kw: [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("169.254.169.254", 443))
+        ],
+    )
+    with pytest.raises(OutboundUrlBlockedError, match="non-public IP"):
+        adapter._check_resolved_ip("https://sso.evil.example/token")
+
+
+def test_adapter_allows_matching_public_ip():
+    """Adapter must allow when connect-time resolution matches pre-verified IPs."""
+    adapter = _PinnedIPAdapter(
+        allowed_ips={ipaddress.ip_address("93.184.216.34")},
+        resolver=lambda host, *a, **kw: [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 443))
+        ],
+    )
+    # Should not raise
+    adapter._check_resolved_ip("https://sso.evil.example/token")
+
+
+def test_adapter_allows_different_public_ip_with_warning(caplog):
+    """Adapter should allow (with warning) different public IPs for CDN endpoints."""
+    adapter = _PinnedIPAdapter(
+        allowed_ips={ipaddress.ip_address("93.184.216.34")},
+        resolver=lambda host, *a, **kw: [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("104.16.123.96", 443))
+        ],
+    )
+    with caplog.at_level("WARNING"):
+        adapter._check_resolved_ip("https://sso.evil.example/token")
+    assert "not in pre-verified set" in caplog.text
+
+
+def test_adapter_validates_ip_literal_url():
+    """Adapter must validate IP-literal URLs directly."""
+    adapter = _PinnedIPAdapter(allowed_ips={ipaddress.ip_address("93.184.216.34")})
+    # Public IP literal — should pass
+    adapter._check_resolved_ip("https://93.184.216.34/token")
+    # Non-public IP literal — should block
+    with pytest.raises(OutboundUrlBlockedError, match="non-public IP"):
+        adapter._check_resolved_ip("https://169.254.169.254/token")
+
+
+def test_adapter_blocks_on_dns_failure():
+    """Adapter must block when DNS resolution fails at connect time."""
+
+    def failing_resolver(host, *args, **kwargs):
+        raise OSError("DNS server down")
+
+    adapter = _PinnedIPAdapter(
+        allowed_ips={ipaddress.ip_address("93.184.216.34")},
+        resolver=failing_resolver,
+    )
+    with pytest.raises(OutboundUrlBlockedError, match="DNS resolution failed"):
+        adapter._check_resolved_ip("https://sso.evil.example/token")
+
+
+def test_adapter_blocks_empty_resolution():
+    """Adapter must block when DNS returns no IPs."""
+    adapter = _PinnedIPAdapter(
+        allowed_ips={ipaddress.ip_address("93.184.216.34")},
+        resolver=lambda host, *a, **kw: [],
+    )
+    with pytest.raises(OutboundUrlBlockedError, match="did not resolve"):
+        adapter._check_resolved_ip("https://sso.evil.example/token")
+
+
+# ── safe_request: fails closed on non-public resolution ─────────────────
 
 
 def test_safe_request_fails_closed_when_resolver_returns_metadata():
-    """If the single resolution returns a non-public IP, the request is refused.
-
-    With the pin in place there is no second chance: a metadata answer means
-    delivery is skipped, not dialed. (``pytest.importorskip`` guard for the
-    blocklist import below is unnecessary — this module already imports the
-    guard.)
-    """
-    from app.utils.outbound_url_guard import OutboundUrlBlockedError
+    """If the resolution returns a non-public IP, the request is refused."""
 
     def metadata_resolver(host, *args, **kwargs):
         return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("169.254.169.254", 443))]
@@ -126,6 +175,9 @@ def test_safe_request_fails_closed_when_resolver_returns_metadata():
             resolver=metadata_resolver,
             timeout=5,
         )
+
+
+# ── _is_public_address denylist ─────────────────────────────────────────
 
 
 @pytest.mark.parametrize(
@@ -143,9 +195,6 @@ def test_safe_request_fails_closed_when_resolver_returns_metadata():
     ],
 )
 def test_is_public_address_rejects_metadata_and_other_non_public(addr):
-    """The predicate must use an explicit denylist, not ``is_global`` alone.
-
-    All of these return ``is_global == True`` today and slip past the guard.
-    """
+    """The predicate must use an explicit denylist, not ``is_global`` alone."""
     ip = ipaddress.ip_address(addr)
     assert not _is_public_address(ip), f"{addr} leaked through is_global-only predicate"

--- a/tests/issues/1858/test_saml_metadata_toctou.py
+++ b/tests/issues/1858/test_saml_metadata_toctou.py
@@ -47,6 +47,17 @@ class _RebindingResolver:
         return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", (ip, 443))]
 
 
+class _StableResolver:
+    """getaddrinfo that always returns the same public IP."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def __call__(self, host, *args, **kwargs):
+        self.calls += 1
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 443))]
+
+
 def _create_provider_without_metadata_config(extra_params=None):
     """Helper to create a SAMLProvider instance that needs metadata from URL."""
     params = {}
@@ -68,9 +79,9 @@ def _create_provider_without_metadata_config(extra_params=None):
     )
 
 
-def test_saml_metadata_url_pins_verified_ip(monkeypatch):
-    """Verify that safe_request pins the verified IP and prevents DNS rebinding."""
-    resolver = _RebindingResolver()
+def test_saml_metadata_url_retains_hostname_for_tls_sni(monkeypatch):
+    """Verify that safe_request retains the hostname for TLS SNI and re-validates at connect time."""
+    resolver = _StableResolver()
     captured = {}
 
     # Mock the pinned adapter's send to capture the request without network dial
@@ -104,17 +115,40 @@ def test_saml_metadata_url_pins_verified_ip(monkeypatch):
     # Trigger metadata loading by accessing idp_entity_id
     _ = provider.idp_entity_id
 
-    # Only ONE resolution happened — the rebinding second call was never made
-    assert resolver.calls == 1, f"Expected 1 resolution, got {resolver.calls}"
+    # Pre-validation resolution happened (connect-time re-validation is tested
+    # separately in test_outbound_url_toctou.py since send is mocked here)
+    assert resolver.calls >= 1, f"Expected >=1 resolution, got {resolver.calls}"
 
-    # The verified public IP is pinned into the URL
+    # The URL retains the original hostname (not IP literal) for TLS SNI
     outgoing = captured.get("url", "")
-    assert "93.184.216.34" in outgoing, f"Public IP not pinned: {outgoing}"
+    assert "idp.example.com" in outgoing, f"Hostname not retained in URL: {outgoing}"
+    assert "93.184.216.34" not in outgoing, f"IP literal should not be in URL: {outgoing}"
     assert "169.254.169.254" not in outgoing, f"Metadata IP should not appear: {outgoing}"
 
-    # The original hostname is preserved as Host header
-    host_header = captured["headers"].get("Host")
-    assert host_header == "idp.example.com", f"Host header not preserved: {host_header}"
+
+def test_saml_metadata_url_blocks_dns_rebinding(monkeypatch, caplog):
+    """Verify that DNS rebinding (public→metadata flip) is blocked at connect time."""
+    from app.utils.outbound_url_guard import safe_request as real_safe_request
+
+    resolver = _RebindingResolver()
+
+    def mock_safe_request(method, url, **kwargs):
+        return real_safe_request(method, url, resolver=resolver, **kwargs)
+
+    monkeypatch.setattr("app.modules.sso.saml.safe_request", mock_safe_request)
+
+    provider = _create_provider_without_metadata_config(
+        extra_params={"idp_metadata_url": "https://idp.example.com/metadata"}
+    )
+
+    # Access property to trigger metadata loading
+    entity_id = provider.idp_entity_id
+
+    # Should gracefully degrade to empty string (rebinding was blocked)
+    assert entity_id == "", f"Should be empty string: {entity_id}"
+
+    # Check log contains warning about metadata loading failure
+    assert any("Failed to load IdP metadata" in record.message for record in caplog.records)
 
 
 def test_saml_metadata_url_rejects_metadata_ip(monkeypatch, caplog):


### PR DESCRIPTION
## Problem

`safe_request` replaced the URL hostname with a pinned IP literal and set the `Host` header manually. `urllib3` derives TLS SNI from the URL host (not the `Host` header), so certificate verification failed for any HTTPS endpoint with a domain-issued certificate — breaking LLM proxy calls and SAML metadata fetches.

## Fix

- **`safe_request`**: Retain the original hostname in the request URL so TLS SNI and certificate verification work correctly. Mount `_PinnedIPAdapter` for connect-time re-validation.
- **`_PinnedIPAdapter._check_resolved_ip`**: Re-resolve the hostname at connect time (`get_connection` and `get_connection_with_tls_context`) and block any non-public IP. This catches DNS rebinding between pre-validation and the actual connection.
- **CDN compatibility**: For endpoints where DNS returns different public IPs between resolutions, log a warning instead of blocking — HTTPS certificate verification mitigates rebinding to a different public host.
- **Testability**: Inject `resolver` parameter into `_PinnedIPAdapter` for unit testing. Unmount adapter from shared sessions to prevent leakage.

## Security model

1. Pre-validation: `validate_public_http_url` resolves hostname, verifies all IPs are public
2. Connect-time: `_PinnedIPAdapter` re-resolves and blocks non-public IPs (DNS rebinding defense)
3. TLS: URL retains hostname → SNI + cert verification work → mitigates rebinding to different public host

## Test changes

- `test_outbound_url_toctou.py`: Rewritten to test URL hostname retention, adapter connect-time validation, CDN IP rotation handling, DNS failure, and empty resolution
- `test_saml_metadata_toctou.py`: Updated `test_saml_metadata_url_pins_verified_ip` → `test_saml_metadata_url_retains_hostname_for_tls_sni`; added `test_saml_metadata_url_blocks_dns_rebinding`

All 66 related tests pass.