### PR TITLE
fix(sandbox): cgroup v2 root does not expose cgroup.kill (#2020)

### DIFF
--- a/scripts/openace-run-as.sh
+++ b/scripts/openace-run-as.sh
@@ -337,13 +337,21 @@ if [ "$isolated" = true ]; then
     task_cgroup=""
     if [ -n "$task_id" ]; then
         cgroup_root="${OPENACE_AGENT_CGROUP_ROOT:-/sys/fs/cgroup/openace-agent}"
-        if [ -w /sys/fs/cgroup/cgroup.kill ]; then
+        # Issue #2020: cgroup v2 root does not expose cgroup.kill (kernel
+        # design — the root cgroup cannot be killed). Test whether
+        # cgroup_root exists and a subgroup can be created under it, rather
+        # than checking /sys/fs/cgroup/cgroup.kill which is never present on
+        # the root cgroup. Also use -f (file exists) instead of -w on
+        # cgroup.procs because cgroup2's virtual files do not honour
+        # traditional access(2) write checks — test -w returns false even
+        # for root on a writable cgroup.procs.
+        if [ -d "$cgroup_root" ]; then
             if [ -d "$cgroup_root/$task_id" ]; then
                 echo 1 > "$cgroup_root/$task_id/cgroup.kill" 2>/dev/null || true
                 rmdir "$cgroup_root/$task_id" 2>/dev/null || true
             fi
             if mkdir -p "$cgroup_root/$task_id" 2>/dev/null \
-               && [ -w "$cgroup_root/$task_id/cgroup.procs" ]; then
+               && [ -f "$cgroup_root/$task_id/cgroup.procs" ]; then
                 task_cgroup="$cgroup_root/$task_id"
             fi
         fi
@@ -420,7 +428,7 @@ if [ "$isolated" = true ]; then
         # descendants); as defense-in-depth also signal the recorded child.
         # The orchestrator's os.killpg(<sudo_pid>) handles the no-cgroup case
         # because the child remains in the launcher's process group.
-        if [ -n "$task_cgroup" ] && [ -w "$task_cgroup/cgroup.kill" ]; then
+        if [ -n "$task_cgroup" ] && [ -f "$task_cgroup/cgroup.kill" ]; then
             echo 1 > "$task_cgroup/cgroup.kill" 2>/dev/null || true
         fi
         if [ -n "${agent_child_pid:-}" ] && kill -0 "${agent_child_pid}" 2>/dev/null; then

--- a/tests/issues/2020/test_run_as_isolation_structure.py
+++ b/tests/issues/2020/test_run_as_isolation_structure.py
@@ -65,6 +65,7 @@ def test_launcher_no_writable_check_on_cgroup_files():
     src = _src()
     assert '[ -w "$task_cgroup/cgroup.kill" ]' not in src
     assert "[ -w /sys/fs/cgroup/cgroup.kill ]" not in src
+    assert '[ -w "$cgroup_root/$task_id/cgroup.procs" ]' not in src
 
 
 def test_launcher_sets_per_task_home_tmp_xdg():

--- a/tests/issues/2020/test_run_as_isolation_structure.py
+++ b/tests/issues/2020/test_run_as_isolation_structure.py
@@ -54,6 +54,19 @@ def test_launcher_has_task_scoped_kill():
     assert "setsid" not in src
 
 
+def test_launcher_no_writable_check_on_cgroup_files():
+    """cgroup2 virtual files do not honour access(2) write checks.
+
+    ``test -w`` returns false even for root on cgroup2 files like
+    cgroup.kill and cgroup.procs. The launcher must use ``-f`` (file exists)
+    instead, otherwise cgroup kill and resource enforcement silently
+    never fire.
+    """
+    src = _src()
+    assert '[ -w "$task_cgroup/cgroup.kill" ]' not in src
+    assert "[ -w /sys/fs/cgroup/cgroup.kill ]" not in src
+
+
 def test_launcher_sets_per_task_home_tmp_xdg():
     src = _src()
     assert "task_home" in src and "task_tmp" in src


### PR DESCRIPTION
## Problem

The launcher (`scripts/openace-run-as.sh`) checked `[ -w /sys/fs/cgroup/cgroup.kill ]` to determine whether cgroup v2 was available. This check **always fails** on cgroup v2 because:

1. **Root cgroup does not expose `cgroup.kill`** — kernel design, the root cgroup cannot be killed
2. **`test -w` on cgroup2 virtual files returns false even for root** — cgroup2 does not honour traditional `access(2)` write checks

Result: cgroup enforcement silently never engaged, even on hosts with cgroup v2 fully enabled and the `openace-agent` subgroup created.

## Fix

Replace `-w` (writable) checks with existence checks:
- `-d` for the cgroup root directory (replaces `[ -w /sys/fs/cgroup/cgroup.kill ]`)
- `-f` for cgroup2 virtual files (replaces `[ -w .../cgroup.procs ]` and `[ -w .../cgroup.kill ]` in cleanup)

Three sites fixed:
1. **Line ~348**: cgroup availability gate
2. **Line ~354**: `cgroup.procs` writability check after subgroup creation
3. **Line ~431**: cleanup `cgroup.kill` gate (found by independent review)

## Test

- Existing structural tests pass (6/6)
- New test `test_launcher_no_writable_check_on_cgroup_files` asserts `-w` is not used on cgroup files (prevents regression)
- Full #2020 test suite: 78 passed, 2 pre-existing failures (unrelated to this change)

## Review

- Independent agent review: ✅ passed (2 rounds, second round found line 431 omission which is now fixed)