### PR TITLE
fix(scheduler+launcher): use module-level conf var and preserve Claude session files

### DIFF
--- a/app/services/autonomous_scheduler.py
+++ b/app/services/autonomous_scheduler.py
@@ -51,7 +51,7 @@ def get_max_concurrent_workflows() -> int:
             resolve_agent_task_policy_path,
         )
 
-        conf = resolve_agent_task_policy_path(os.environ.get("OPENACE_LAUNCHER_CONF"))
+        conf = resolve_agent_task_policy_path(_AGENT_LAUNCHER_CONF)
         if not conf:
             return MAX_CONCURRENT_WORKFLOWS
         return read_agent_task_policy(

--- a/scripts/openace-run-as.sh
+++ b/scripts/openace-run-as.sh
@@ -323,9 +323,33 @@ if [ "$isolated" = true ]; then
         task_cache="${task_base}/cache"
         task_config="${task_base}/config"
         task_data="${task_base}/data"
+        # Issue #2035: preserve Claude CLI session files across task invocations.
+        # The per-task HOME is ephemeral, but Claude CLI stores conversation
+        # history under ~/.claude/projects/. These files must survive task_base
+        # cleanup so that --resume can find them on the next invocation with the
+        # same task_id (session line). Without this, every resume attempt fails
+        # with "no conversation found with session id", triggering repeated
+        # session_resume_recovery events and wasting agent tokens.
+        #
+        # The preserve path is fixed (not conditional on .claude existing) so
+        # that a crashed previous invocation — which moved .claude to the
+        # preserve path but never moved it back — is recovered: the
+        # unconditional restore below finds the orphaned preserve dir and
+        # restores it even though $task_home/.claude was already moved away.
+        preserve_claude_dir="${task_base}.claude-preserve"
+        if [ -d "$task_home/.claude" ]; then
+            rm -rf -- "$preserve_claude_dir" 2>/dev/null || true
+            mv "$task_home/.claude" "$preserve_claude_dir" 2>/dev/null || true
+        fi
         rm -rf -- "$task_base" 2>/dev/null || true
         mkdir -p "$task_home" "$task_tmp" "$task_cache" "$task_config" "$task_data"
         chmod 700 "$task_base" "$task_home" "$task_tmp" "$task_cache" "$task_config" "$task_data"
+        # Unconditional restore: works even if a previous invocation crashed
+        # between the preserve-mv and the restore-mv (the .claude dir was moved
+        # out but never moved back). The chown on $task_base below covers .claude.
+        if [ -d "$preserve_claude_dir" ]; then
+            mv "$preserve_claude_dir" "$task_home/.claude" 2>/dev/null || true
+        fi
         chown -R "$target_user":"$(id -g "$target_user")" "$task_base" 2>/dev/null || true
     fi
 

--- a/tests/issues/2035/test_session_resume_recovery.py
+++ b/tests/issues/2035/test_session_resume_recovery.py
@@ -286,7 +286,7 @@ class TestRunAgentSessionResumeRecovery:
 
         # Verify cli_session_id was cleared via session_manager
         orch._runner.session_manager.update_session_fields.assert_called_once_with(
-            "tracking-sess-1", {"cli_session_id": ""}
+            "tracking-sess-1", {"cli_session_id": ""}, require_tenant=False
         )
 
     def test_resume_failure_recovery_skipped_when_workflow_failed(self):


### PR DESCRIPTION
## Summary

Three fixes addressing pre-existing test failures (#2020, #2035) and Claude CLI session resume recovery (#2035).

### Change 1: `app/services/autonomous_scheduler.py`
`get_max_concurrent_workflows()` bypassed the module-level `_AGENT_LAUNCHER_CONF` variable by reading `os.environ` directly at call time. This made the test monkeypatch of `_AGENT_LAUNCHER_CONF` ineffective — tests wrote custom conf values but the function ignored them and returned the default (3).

**Fix**: Use `_AGENT_LAUNCHER_CONF` instead of `os.environ.get("OPENACE_LAUNCHER_CONF")`.

**Fixes**: `test_local_concurrency_matches_scheduler_limit`, `test_concurrency_reads_from_conf`

### Change 2: `tests/issues/2035/test_session_resume_recovery.py`
`test_resume_failure_clears_cli_session_id_mapping` did not include `require_tenant=False` in the expected `update_session_fields` call. The production code (orchestrator.py:4964) passes `require_tenant=False` because the recovery runs in a background scheduler thread with no tenant context.

**Fix**: Update the test assertion to include `require_tenant=False`.

### Change 3: `scripts/openace-run-as.sh`
Per-task HOME cleanup (`rm -rf task_base`) deletes `~/.claude/projects/` where Claude CLI stores conversation history. When the orchestrator later tries `--resume`, it fails with "no conversation found with session id", triggering repeated `session_resume_recovery` events and wasting agent tokens.

**Fix**: Preserve `.claude` by moving it to a sibling path (`${task_base}.claude-preserve`) before cleanup and restoring it after `mkdir`. The restore is **unconditional** (checks directory existence, not a flag set in the current invocation) so that a crashed previous invocation that moved `.claude` out but never moved it back is recovered on the next call.

## Test Results
- All 130 tests pass (6 skipped Linux-root integration tests)
- Pre-commit hooks: all passed (black, isort, ruff, mypy, bandit, etc.)

## Independent Agent Review
- **First review**: Found Medium-severity crash recovery issue (session files lost if script crashes between preserve-mv and restore-mv)
- **Improved fix**: Made restore unconditional — always checks if preserve dir exists, regardless of whether the current invocation set it
- **Second review**: APPROVED — no remaining opinions. All findings resolved or accepted as low-risk/by-design.