### PR TITLE
fix(cgroup): delegate controllers to task subgroups so resource limits apply

### DIFF
--- a/scripts/openace-run-as.sh
+++ b/scripts/openace-run-as.sh
@@ -370,6 +370,12 @@ if [ "$isolated" = true ]; then
         # traditional access(2) write checks — test -w returns false even
         # for root on a writable cgroup.procs.
         if [ -d "$cgroup_root" ]; then
+            # Issue #2020: delegate controllers from the parent cgroup to its
+            # children so task subgroups get memory.max, pids.max, cpu.max files.
+            # Without this, mkdir creates the subgroup but it has no resource
+            # limit files, and the writes below silently fail (|| true).
+            # Idempotent: re-writing the same controllers is a no-op.
+            echo "+memory +pids +cpu" > "$cgroup_root/cgroup.subtree_control" 2>/dev/null || true
             if [ -d "$cgroup_root/$task_id" ]; then
                 echo 1 > "$cgroup_root/$task_id/cgroup.kill" 2>/dev/null || true
                 rmdir "$cgroup_root/$task_id" 2>/dev/null || true

--- a/scripts/setup-cgroup-v2.sh
+++ b/scripts/setup-cgroup-v2.sh
@@ -196,6 +196,19 @@ else
     log "  $CGROUP_ROOT already exists"
 fi
 
+# ── step 2.5: delegate controllers to child cgroups ─────────────────────────
+
+log "step 2.5: delegating controllers to child cgroups ($CGROUP_ROOT)"
+
+# The parent cgroup's cgroup.subtree_control must list the controllers so
+# task subgroups created by openace-run-as.sh get memory.max, pids.max, and
+# cpu.max files. Without this the subgroups exist but have no resource limit
+# files, and all resource writes silently fail. openace-run-as.sh also does
+# this idempotently at runtime, but setting it here ensures correctness even
+# before the first task launches.
+write_file "$CGROUP_ROOT/cgroup.subtree_control" "+memory +pids +cpu" \
+    || { err "failed to delegate controllers to $CGROUP_ROOT (is it a valid cgroup v2 dir?)"; exit 3; }
+
 # ── step 3: apply resource limits ───────────────────────────────────────────
 
 log "step 3: applying resource limits"
@@ -302,7 +315,7 @@ Type=oneshot
 RemainAfterExit=yes
 # Read resource values from the conf so a re-run of setup-cgroup-v2.sh with
 # different values is picked up on next boot without editing this unit.
-ExecStart=/bin/bash -c 'set -eu; test -f ${CONF_PATH} || exit 0; source ${CONF_PATH}; test -n "\${agent_task_memory_max_bytes:-}" -a "\${agent_task_memory_max_bytes:-}" != "0" || exit 0; echo "+memory +pids +cpu" > /sys/fs/cgroup/cgroup.subtree_control; mkdir -p \${agent_task_cgroup_root}; echo "\${agent_task_memory_max_bytes}" > \${agent_task_cgroup_root}/memory.max; echo "\${agent_task_pids_max}" > \${agent_task_cgroup_root}/pids.max; echo "\${agent_task_cpu_max}" > \${agent_task_cgroup_root}/cpu.max'
+ExecStart=/bin/bash -c 'set -eu; test -f ${CONF_PATH} || exit 0; source ${CONF_PATH}; test -n "\${agent_task_memory_max_bytes:-}" -a "\${agent_task_memory_max_bytes:-}" != "0" || exit 0; echo "+memory +pids +cpu" > /sys/fs/cgroup/cgroup.subtree_control; mkdir -p \${agent_task_cgroup_root}; echo "+memory +pids +cpu" > \${agent_task_cgroup_root}/cgroup.subtree_control; echo "\${agent_task_memory_max_bytes}" > \${agent_task_cgroup_root}/memory.max; echo "\${agent_task_pids_max}" > \${agent_task_cgroup_root}/pids.max; echo "\${agent_task_cpu_max}" > \${agent_task_cgroup_root}/cpu.max'
 
 [Install]
 WantedBy=sysinit.target

--- a/tests/issues/2020/test_run_as_resource_structure.py
+++ b/tests/issues/2020/test_run_as_resource_structure.py
@@ -46,3 +46,12 @@ def test_launcher_fail_closed_when_cgroup_forced_but_unavailable():
     assert "agent_task_cgroup_enabled" in src
     # a fail-closed exit exists in the cgroup-unavailable branch when forced on
     assert "OPENACE_CGROUP_REQUIRED" in src or 'cgroup_enabled" = "on"' in src
+
+
+def test_launcher_delegates_cgroup_controllers():
+    # cgroup v2 requires the parent to delegate controllers to children via
+    # cgroup.subtree_control. Without this, task subgroups have no memory.max,
+    # pids.max, or cpu.max files and all resource writes silently fail.
+    src = _src()
+    assert "cgroup.subtree_control" in src
+    assert "+memory +pids +cpu" in src


### PR DESCRIPTION
## Summary

cgroup v2 requires the parent to delegate controllers to children via `cgroup.subtree_control`. Without this, task subgroups have no `memory.max`/`pids.max`/`cpu.max` files and all resource limit writes silently fail — making cgroup resource isolation completely non-functional.

## Root Cause

`openace-run-as.sh` creates task subgroups under `/sys/fs/cgroup/openace-agent/` but never writes `+memory +pids +cpu` to the parent's `cgroup.subtree_control`. The `setup-cgroup-v2.sh` script has the same gap.

Verified on remote server: parent `cgroup.subtree_control` was empty, child subgroup had only `cpu.stat` (read-only stats) but no `memory.max`, `pids.max`, `cpu.max`.

## Fix

1. **`scripts/openace-run-as.sh`**: Idempotently delegate controllers before creating the task subgroup (runtime path, `|| true` on failure for graceful degradation)
2. **`scripts/setup-cgroup-v2.sh`**: Delegate controllers as step 2.5 after creating the parent cgroup (bootstrap path, `exit 3` on failure for fail-closed)
3. **`scripts/setup-cgroup-v2.sh` systemd unit**: `ExecStart` also delegates controllers so the setting persists across reboots
4. **`tests/issues/2020/test_run_as_resource_structure.py`**: Structural test `test_launcher_delegates_cgroup_controllers` locks the delegation code in place

## Test Results
- All 112 tests pass (6 skipped Linux-root integration tests)
- `bash -n` syntax check passes for both scripts

## Independent Agent Review
- Review found the fix technically correct, placement accurate, consistent with existing error handling
- Two non-blocking observations (systemd unit gap, missing structural test) — both addressed in this PR
- **APPROVED — no remaining blocking opinions**