### PR TITLE
fix(ci-repair): defer transient API errors without consuming repair attempts (#1820)

### DIFF
--- a/app/modules/workspace/autonomous/models.py
+++ b/app/modules/workspace/autonomous/models.py
@@ -79,6 +79,7 @@ class AutonomousWorkflow:
     ci_repair_context: str = ""
     ci_repair_attempts: int = 0
     ci_diagnostics_attempts: int = 0
+    ci_repair_transient_retries: int = 0
     last_ci_failure_signature: str = ""
     last_ci_failure_head_sha: str = ""
     # Source of truth for AI-authored content language (en/zh/ja/ko). Set once
@@ -166,6 +167,7 @@ class AutonomousWorkflow:
             "ci_repair_context": self.ci_repair_context,
             "ci_repair_attempts": self.ci_repair_attempts,
             "ci_diagnostics_attempts": self.ci_diagnostics_attempts,
+            "ci_repair_transient_retries": self.ci_repair_transient_retries,
             "last_ci_failure_signature": self.last_ci_failure_signature,
             "last_ci_failure_head_sha": self.last_ci_failure_head_sha,
             "content_language": self.content_language,
@@ -235,6 +237,7 @@ class AutonomousWorkflow:
             ci_repair_context=data.get("ci_repair_context", ""),
             ci_repair_attempts=data.get("ci_repair_attempts", 0),
             ci_diagnostics_attempts=data.get("ci_diagnostics_attempts", 0),
+            ci_repair_transient_retries=data.get("ci_repair_transient_retries", 0),
             last_ci_failure_signature=data.get("last_ci_failure_signature", ""),
             last_ci_failure_head_sha=data.get("last_ci_failure_head_sha", ""),
             content_language=data.get("content_language", "en"),

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -886,6 +886,10 @@ _CONTEXT_OVERFLOW_RE = re.compile(
 MAX_TEST_RETRIES = 2  # max retries when test agent itself fails
 MAX_DEV_RETRIES_ON_TEST_FAIL = 2  # max dev round retries for unfixable test failures
 MAX_CI_REPAIR_ATTEMPTS = 3  # max automatic dev-round retries for merge-phase CI failures
+# Separate cap for transient-API deferrals during CI repair: a 503/429 must
+# not loop forever, but must allow more retries than the 3-attempt budget
+# (which is consumed only by real agent repair attempts, not infra glitches).
+MAX_CI_REPAIR_TRANSIENT_RETRIES = 6
 MAX_PRE_COMMIT_CONVERGENCE_PASSES = 3
 PRE_COMMIT_CONVERGENCE_TIMEOUT = 600
 CI_PRE_COMMIT_SKIP = "bandit,no-commit-to-branch"
@@ -2463,6 +2467,22 @@ class AutonomousOrchestrator:
             return
 
         if not sha_changed:
+            # Transient API errors (429/5xx/overload) may cause the agent to
+            # produce no code changes without consuming a real repair attempt.
+            # Defer to the next scheduler cycle instead of wasting a bounded
+            # attempt on an infra glitch (#1820: 2/3 attempts burned — 1 by a
+            # 503 — then failed). The retry budget is bounded separately by
+            # MAX_CI_REPAIR_TRANSIENT_RETRIES in _start_ci_repair_round.
+            if self._should_retry_transient_api_failure(repair_result):
+                message = (
+                    "CI repair deferred: transient API error - "
+                    f"{repair_result.error or repair_result.response_text}"
+                )
+                milestone_updates["status"] = "failed"
+                milestone_updates["error_message"] = message
+                self.repo.update_milestone(repair_ms.get("milestone_id", ""), milestone_updates)
+                self._update_workflow({"status": "merging", "error_message": message})
+                return
             # Preserve the context-overflow signal in the error message so the
             # next round's _collect_prior_ci_repair_failures filters it out
             # (an overflow failure has no actionable signal — the agent never
@@ -3430,7 +3450,36 @@ class AutonomousOrchestrator:
         """Repair merge-phase CI failures in-place on the existing PR branch."""
         dev_round = int(wf.get("dev_round", 1) or 1)
         previous_attempts = int(wf.get("ci_repair_attempts", 0) or 0)
-        next_attempt = previous_attempts + 1
+        # If the previous round was deferred by a transient API error (503/429),
+        # re-enter the same attempt instead of consuming a new one. Bound the
+        # total transient deferrals so a sustained outage cannot loop forever.
+        prev_error = wf.get("error_message", "") or ""
+        is_transient_deferred = prev_error.startswith("CI repair deferred: transient API error")
+        transient_retries = int(wf.get("ci_repair_transient_retries", 0) or 0)
+        if is_transient_deferred:
+            if transient_retries >= MAX_CI_REPAIR_TRANSIENT_RETRIES:
+                message = (
+                    f"CI repair failed: transient API errors persisted across "
+                    f"{MAX_CI_REPAIR_TRANSIENT_RETRIES} retries"
+                )
+                self._create_milestone(
+                    phase="merge",
+                    dev_round=dev_round,
+                    round_number=previous_attempts,
+                    milestone_type="ci_repair_transient_exhausted",
+                    status="failed",
+                    title="CI repair transient retry limit reached",
+                    error_message=message,
+                )
+                self._update_workflow({"status": "failed", "error_message": message})
+                return
+            # Don't increment ci_repair_attempts; bump ci_repair_transient_retries
+            # as a transient-retry counter (reset to 0 on a successful round).
+            next_attempt = previous_attempts
+            transient_retries += 1
+        else:
+            next_attempt = previous_attempts + 1
+            transient_retries = 0
         preferred_worktree_path = self._get_preferred_worktree_path(wf)
         gh = self._get_gh()
         current_head_sha = ""
@@ -3512,11 +3561,24 @@ class AutonomousOrchestrator:
 
         if actionable_count and excerpt_count < actionable_count:
             diagnostics_attempt = int(wf.get("ci_diagnostics_attempts", 0) or 0) + 1
-            message = (
-                f"PR #{pr_number} CI diagnostics incomplete "
-                f"({excerpt_count}/{actionable_count} failed checks have logs; "
-                f"poll {diagnostics_attempt}/{MAX_CI_DIAGNOSTICS_ATTEMPTS})"
-            )
+            # When re-entering a transient-deferred round, preserve the
+            # "CI repair deferred: transient API error" prefix so the next
+            # _start_ci_repair_round call still detects the transient state
+            # and does NOT consume a real ci_repair_attempts slot. Otherwise
+            # the diagnostics-incomplete message would overwrite the signal
+            # and the transient retry budget would be lost (#1820).
+            if is_transient_deferred:
+                message = (
+                    "CI repair deferred: transient API error "
+                    f"(awaiting CI diagnostics: {excerpt_count}/{actionable_count} "
+                    f"logs; poll {diagnostics_attempt}/{MAX_CI_DIAGNOSTICS_ATTEMPTS})"
+                )
+            else:
+                message = (
+                    f"PR #{pr_number} CI diagnostics incomplete "
+                    f"({excerpt_count}/{actionable_count} failed checks have logs; "
+                    f"poll {diagnostics_attempt}/{MAX_CI_DIAGNOSTICS_ATTEMPTS})"
+                )
             pending_ms = self._create_milestone(
                 phase="merge",
                 dev_round=dev_round,
@@ -3541,6 +3603,7 @@ class AutonomousOrchestrator:
                         "status": "failed",
                         "error_message": terminal,
                         "ci_diagnostics_attempts": diagnostics_attempt,
+                        "ci_repair_transient_retries": transient_retries,
                     }
                 )
                 return
@@ -3550,6 +3613,9 @@ class AutonomousOrchestrator:
                     "status": "merging",
                     "error_message": message,
                     "ci_diagnostics_attempts": diagnostics_attempt,
+                    # Persist the in-memory transient counter so it survives
+                    # across diagnostics polling cycles (#1820).
+                    "ci_repair_transient_retries": transient_retries,
                 }
             )
             return
@@ -3655,6 +3721,11 @@ class AutonomousOrchestrator:
             "agent_session_id": "",
             "error_message": "",
             "ci_repair_attempts": next_attempt,
+            "ci_repair_transient_retries": transient_retries,
+            # Reset the diagnostics poll counter: each (re-)entry into a CI
+            # repair round gets a fresh log-fetch budget (MAX_CI_DIAGNOSTICS_ATTEMPTS).
+            # This was previously a side effect of reusing ci_diagnostics_attempts
+            # for transient tracking; the fields are now separate (#1820).
             "ci_diagnostics_attempts": 0,
             "ci_repair_context": context,
             "last_ci_failure_signature": signature,

--- a/app/repositories/autonomous_repo.py
+++ b/app/repositories/autonomous_repo.py
@@ -90,6 +90,7 @@ class AutonomousWorkflowRepository:
         "ci_repair_context",
         "ci_repair_attempts",
         "ci_diagnostics_attempts",
+        "ci_repair_transient_retries",
         "last_ci_failure_signature",
         "last_ci_failure_head_sha",
         # Worktree transition journal for SIGKILL-resilient recovery (#2050).
@@ -290,9 +291,9 @@ class AutonomousWorkflowRepository:
                      max_plan_rounds, max_pr_review_rounds, require_full_review_rounds,
                      parent_workflow_id, fork_milestone_id, user_feedback,
                      original_branch_name, content_language, system_account,
-                     ci_repair_context, ci_repair_attempts, ci_diagnostics_attempts, last_ci_failure_signature,
+                     ci_repair_context, ci_repair_attempts, ci_diagnostics_attempts, ci_repair_transient_retries, last_ci_failure_signature,
                      last_ci_failure_head_sha, created_at, updated_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 RETURNING *
                 """,
                 (
@@ -335,6 +336,7 @@ class AutonomousWorkflowRepository:
                     data.get("ci_repair_context", ""),
                     data.get("ci_repair_attempts", 0),
                     data.get("ci_diagnostics_attempts", 0),
+                    data.get("ci_repair_transient_retries", 0),
                     data.get("last_ci_failure_signature", ""),
                     data.get("last_ci_failure_head_sha", ""),
                     now,
@@ -357,9 +359,9 @@ class AutonomousWorkflowRepository:
                      max_plan_rounds, max_pr_review_rounds, require_full_review_rounds,
                      parent_workflow_id, fork_milestone_id, user_feedback,
                      original_branch_name, content_language, system_account,
-                     ci_repair_context, ci_repair_attempts, ci_diagnostics_attempts, last_ci_failure_signature,
+                     ci_repair_context, ci_repair_attempts, ci_diagnostics_attempts, ci_repair_transient_retries, last_ci_failure_signature,
                      last_ci_failure_head_sha, created_at, updated_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     workflow_id,
@@ -401,6 +403,7 @@ class AutonomousWorkflowRepository:
                     data.get("ci_repair_context", ""),
                     data.get("ci_repair_attempts", 0),
                     data.get("ci_diagnostics_attempts", 0),
+                    data.get("ci_repair_transient_retries", 0),
                     data.get("last_ci_failure_signature", ""),
                     data.get("last_ci_failure_head_sha", ""),
                     now,

--- a/migrations/versions/20260731_001_add_ci_repair_transient_retries.py
+++ b/migrations/versions/20260731_001_add_ci_repair_transient_retries.py
@@ -1,0 +1,62 @@
+"""Add ci_repair_transient_retries to autonomous_workflows.
+
+Revision ID: 20260731_001_add_ci_repair_transient_retries
+Revises: 20260730_001_validate_daily_usage_tenant
+Create Date: 2026-07-31
+
+Issue: #1820
+
+Dedicated counter for transient-API deferrals (429/5xx) during merge-phase CI
+repair. Previously the transient-retry count was stored in
+``ci_diagnostics_attempts``, which is already used to bound CI log-fetch
+polling (``MAX_CI_DIAGNOSTICS_ATTEMPTS``). The dual use caused the two counters
+to clobber each other when diagnostics polling and transient deferrals
+interleaved, resetting the transient budget and allowing ``ci_repair_attempts``
+to be consumed by infra glitches. This migration introduces a separate column
+so each counter has its own lifecycle.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260731_001_add_ci_repair_transient_retries"
+down_revision: str | None = "20260730_001_validate_daily_usage_tenant"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    """Add the ci_repair_transient_retries column."""
+    connection = op.get_bind()
+    inspector = sa.inspect(connection)
+
+    if "autonomous_workflows" not in set(inspector.get_table_names()):
+        # Fresh databases create the column directly in CREATE TABLE; nothing
+        # to migrate here.
+        return
+
+    existing_columns = {col["name"] for col in inspector.get_columns("autonomous_workflows")}
+    if "ci_repair_transient_retries" not in existing_columns:
+        op.add_column(
+            "autonomous_workflows",
+            sa.Column(
+                "ci_repair_transient_retries",
+                sa.Integer(),
+                nullable=True,
+                server_default="0",
+            ),
+        )
+
+
+def downgrade() -> None:
+    """Remove the ci_repair_transient_retries column."""
+    connection = op.get_bind()
+    inspector = sa.inspect(connection)
+
+    if "autonomous_workflows" not in set(inspector.get_table_names()):
+        return
+
+    existing_columns = {col["name"] for col in inspector.get_columns("autonomous_workflows")}
+    with op.batch_alter_table("autonomous_workflows") as batch_op:
+        if "ci_repair_transient_retries" in existing_columns:
+            batch_op.drop_column("ci_repair_transient_retries")

--- a/migrations/versions/20260731_002_add_ci_repair_transient_retries.py
+++ b/migrations/versions/20260731_002_add_ci_repair_transient_retries.py
@@ -1,7 +1,7 @@
 """Add ci_repair_transient_retries to autonomous_workflows.
 
-Revision ID: 20260731_001_add_ci_repair_transient_retries
-Revises: 20260730_001_validate_daily_usage_tenant
+Revision ID: 20260731_002_add_ci_repair_transient_retries
+Revises: 20260731_001_add_tenant_version
 Create Date: 2026-07-31
 
 Issue: #1820
@@ -19,8 +19,8 @@ so each counter has its own lifecycle.
 import sqlalchemy as sa
 from alembic import op
 
-revision: str = "20260731_001_add_ci_repair_transient_retries"
-down_revision: str | None = "20260730_001_validate_daily_usage_tenant"
+revision: str = "20260731_002_add_ci_repair_transient_retries"
+down_revision: str | None = "20260731_001_add_tenant_version"
 branch_labels: str | None = None
 depends_on: str | None = None
 

--- a/schema/schema-postgres.sql
+++ b/schema/schema-postgres.sql
@@ -453,7 +453,6 @@ CREATE TABLE autonomous_workflows (
     last_ci_failure_signature text DEFAULT ''::text,
     last_ci_failure_head_sha text DEFAULT ''::text,
     ci_diagnostics_attempts integer DEFAULT 0,
-    ci_repair_transient_retries integer DEFAULT 0,
     worktree_transition_state text,
     transition_original_path text,
     transition_temp_path text,
@@ -473,7 +472,8 @@ CREATE TABLE autonomous_workflows (
     sandbox_policy_digest text,
     sandbox_last_error text,
     sandbox_remote_session_id text,
-    sandbox_effective_policy text
+    sandbox_effective_policy text,
+    ci_repair_transient_retries integer DEFAULT 0
 );
 
 CREATE SEQUENCE autonomous_workflows_id_seq

--- a/schema/schema-postgres.sql
+++ b/schema/schema-postgres.sql
@@ -453,6 +453,7 @@ CREATE TABLE autonomous_workflows (
     last_ci_failure_signature text DEFAULT ''::text,
     last_ci_failure_head_sha text DEFAULT ''::text,
     ci_diagnostics_attempts integer DEFAULT 0,
+    ci_repair_transient_retries integer DEFAULT 0,
     worktree_transition_state text,
     transition_original_path text,
     transition_temp_path text,

--- a/schema/schema-sqlite.sql
+++ b/schema/schema-sqlite.sql
@@ -302,6 +302,7 @@ CREATE TABLE autonomous_workflows (
  last_ci_failure_signature text DEFAULT '',
  last_ci_failure_head_sha text DEFAULT '',
  ci_diagnostics_attempts integer DEFAULT 0,
+ ci_repair_transient_retries integer DEFAULT 0,
  worktree_transition_state text,
  transition_original_path text,
  transition_temp_path text,

--- a/schema/schema-sqlite.sql
+++ b/schema/schema-sqlite.sql
@@ -302,7 +302,6 @@ CREATE TABLE autonomous_workflows (
  last_ci_failure_signature text DEFAULT '',
  last_ci_failure_head_sha text DEFAULT '',
  ci_diagnostics_attempts integer DEFAULT 0,
- ci_repair_transient_retries integer DEFAULT 0,
  worktree_transition_state text,
  transition_original_path text,
  transition_temp_path text,
@@ -322,7 +321,8 @@ CREATE TABLE autonomous_workflows (
  sandbox_policy_digest text,
  sandbox_last_error text,
  sandbox_remote_session_id text,
- sandbox_effective_policy text
+ sandbox_effective_policy text,
+ ci_repair_transient_retries integer DEFAULT 0
 );
 
 CREATE TABLE command_execution_evidence (

--- a/tests/issues/1820/test_ci_repair_transient_deferral.py
+++ b/tests/issues/1820/test_ci_repair_transient_deferral.py
@@ -1,0 +1,224 @@
+"""Tests for CI repair transient-API-error deferral (issue #1820).
+
+When the CI repair agent produces no code changes due to a transient API error
+(429/5xx/overload), the workflow must defer to the next scheduler cycle
+WITHOUT consuming a real ``ci_repair_attempts`` slot. A separate counter
+``ci_repair_transient_retries`` (bounded by ``MAX_CI_REPAIR_TRANSIENT_RETRIES``)
+tracks these deferrals so a sustained outage cannot loop forever.
+
+These tests verify:
+1. A transient-deferred round does NOT increment ``ci_repair_attempts``.
+2. The transient retry counter IS incremented.
+3. After ``MAX_CI_REPAIR_TRANSIENT_RETRIES``, the workflow is marked failed.
+4. Diagnostics-incomplete polling preserves the transient signal and counter.
+5. A non-transient round resets the transient counter to 0.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from app.modules.workspace.autonomous.orchestrator import MAX_CI_REPAIR_TRANSIENT_RETRIES
+
+
+def _make_workflow(**overrides):
+    base = {
+        "workflow_id": "wf-1820",
+        "user_id": 1,
+        "status": "merging",
+        "current_phase": "merge",
+        "ci_repair_attempts": 1,
+        "ci_repair_transient_retries": 0,
+        "ci_diagnostics_attempts": 0,
+        "last_ci_failure_signature": "",
+        "last_ci_failure_head_sha": "",
+        "branch_name": "auto-dev/wf-1820",
+        "branch_strategy": "worktree",
+        "worktree_path": "/tmp/repo",
+        "preferred_worktree_path": "/tmp/repo",
+        "dev_round": 1,
+    }
+    base.update(overrides)
+    return base
+
+
+def _make_orchestrator(wf_data):
+    from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+    with (
+        patch("app.modules.workspace.autonomous.orchestrator.Database"),
+        patch(
+            "app.modules.workspace.autonomous.orchestrator.AutonomousWorkflowRepository"
+        ) as mock_repo_cls,
+    ):
+        mock_repo = MagicMock()
+        mock_repo.get_workflow.return_value = wf_data
+        mock_repo.list_milestones.return_value = []
+        mock_repo.create_milestone.return_value = {
+            "milestone_id": "ms-1",
+            "workflow_id": wf_data["workflow_id"],
+        }
+        mock_repo.create_event.return_value = {"id": 1}
+        mock_repo.update_workflow.return_value = wf_data
+        mock_repo_cls.return_value = mock_repo
+
+        orch = AutonomousOrchestrator(wf_data["workflow_id"])
+        orch.repo = mock_repo
+        orch.emitter = MagicMock()
+        orch._sync_failed_pr_with_main = MagicMock(return_value=False)
+    return orch, mock_repo
+
+
+_FAILED_CHECKS = [
+    {
+        "name": "lint",
+        "state": "failure",
+        "bucket": "fail",
+        "link": "https://github.com/open-ace/open-ace/runs/123",
+    }
+]
+
+
+# ── 1. Transient-deferred round does NOT consume a real attempt ──
+
+
+def test_transient_deferred_does_not_increment_attempts():
+    """Re-entering after a transient deferral must NOT bump ci_repair_attempts."""
+    wf = _make_workflow(
+        error_message="CI repair deferred: transient API error - 503 Service Unavailable",
+        ci_repair_attempts=2,
+        ci_repair_transient_retries=1,
+    )
+    orch, mock_repo = _make_orchestrator(wf)
+    gh = MagicMock()
+    gh.get_pr_head_sha.return_value = "sha-new"
+    gh.get_check_failure_excerpt.return_value = "pytest failed\n1 failed"
+    orch._get_gh = MagicMock(return_value=gh)
+    orch._run_merge_ci_repair = MagicMock()
+
+    orch._start_ci_repair_round(wf, 1820, _FAILED_CHECKS)
+
+    orch._run_merge_ci_repair.assert_called_once()
+    updates = [c.args[1] for c in mock_repo.update_workflow.call_args_list]
+    # ci_repair_attempts must NOT have been incremented (stays at 2)
+    assert any(u.get("ci_repair_attempts") == 2 for u in updates)
+    # ci_repair_transient_retries must have been incremented (1 → 2)
+    assert any(u.get("ci_repair_transient_retries") == 2 for u in updates)
+
+
+# ── 2. After MAX_CI_REPAIR_TRANSIENT_RETRIES, workflow is marked failed ──
+
+
+def test_transient_retries_exhausted_marks_failed():
+    """When transient retries hit the cap, the workflow fails."""
+    wf = _make_workflow(
+        error_message="CI repair deferred: transient API error - 503 Service Unavailable",
+        ci_repair_attempts=2,
+        ci_repair_transient_retries=MAX_CI_REPAIR_TRANSIENT_RETRIES,
+    )
+    orch, mock_repo = _make_orchestrator(wf)
+    gh = MagicMock()
+    gh.get_pr_head_sha.return_value = "sha-new"
+    gh.get_check_failure_excerpt.return_value = "pytest failed\n1 failed"
+    orch._get_gh = MagicMock(return_value=gh)
+    orch._run_merge_ci_repair = MagicMock()
+
+    orch._start_ci_repair_round(wf, 1820, _FAILED_CHECKS)
+
+    # Agent must NOT be called — the workflow is terminal
+    orch._run_merge_ci_repair.assert_not_called()
+    updates = [c.args[1] for c in mock_repo.update_workflow.call_args_list]
+    assert any(u.get("status") == "failed" for u in updates)
+    assert any("transient" in (u.get("error_message") or "").lower() for u in updates)
+
+
+# ── 3. Non-transient round resets the transient counter ──
+
+
+def test_non_transient_round_resets_transient_counter():
+    """A fresh (non-transient) CI repair round resets transient_retries to 0."""
+    wf = _make_workflow(
+        error_message="",  # no transient signal
+        ci_repair_attempts=1,
+        ci_repair_transient_retries=3,  # stale from a previous transient cycle
+    )
+    orch, mock_repo = _make_orchestrator(wf)
+    gh = MagicMock()
+    gh.get_pr_head_sha.return_value = "sha-new"
+    gh.get_check_failure_excerpt.return_value = "pytest failed\n1 failed"
+    orch._get_gh = MagicMock(return_value=gh)
+    orch._run_merge_ci_repair = MagicMock()
+
+    orch._start_ci_repair_round(wf, 1820, _FAILED_CHECKS)
+
+    orch._run_merge_ci_repair.assert_called_once()
+    updates = [c.args[1] for c in mock_repo.update_workflow.call_args_list]
+    # ci_repair_attempts incremented (1 → 2)
+    assert any(u.get("ci_repair_attempts") == 2 for u in updates)
+    # transient counter reset to 0
+    assert any(u.get("ci_repair_transient_retries") == 0 for u in updates)
+
+
+# ── 4. Diagnostics-incomplete preserves transient signal and counter ──
+
+
+def test_diagnostics_incomplete_preserves_transient_signal():
+    """When diagnostics are incomplete during a transient-deferred round,
+    the error_message must retain the "CI repair deferred: transient API error"
+    prefix and ci_repair_transient_retries must be persisted so the next
+    scheduler cycle still detects the transient state."""
+    wf = _make_workflow(
+        error_message="CI repair deferred: transient API error - 503 Service Unavailable",
+        ci_repair_attempts=2,
+        ci_repair_transient_retries=1,
+        ci_diagnostics_attempts=0,
+    )
+    orch, mock_repo = _make_orchestrator(wf)
+    gh = MagicMock()
+    gh.get_pr_head_sha.return_value = "sha-new"
+    gh.get_check_failure_excerpt.return_value = ""  # no logs → diagnostics incomplete
+    orch._get_gh = MagicMock(return_value=gh)
+    orch._run_merge_ci_repair = MagicMock()
+
+    orch._start_ci_repair_round(wf, 1820, _FAILED_CHECKS)
+
+    # Agent must NOT be called — diagnostics incomplete
+    orch._run_merge_ci_repair.assert_not_called()
+    updates = [c.args[1] for c in mock_repo.update_workflow.call_args_list]
+    # The error_message must retain the transient-deferred prefix
+    assert any(
+        u.get("error_message", "").startswith("CI repair deferred: transient API error")
+        for u in updates
+    ), [u.get("error_message") for u in updates]
+    # ci_repair_transient_retries must be persisted (1 → 2)
+    assert any(u.get("ci_repair_transient_retries") == 2 for u in updates)
+    # ci_repair_attempts must NOT be incremented
+    assert not any(u.get("ci_repair_attempts", 0) > 2 for u in updates)
+
+
+# ── 5. Diagnostics complete after transient deferral proceeds normally ──
+
+
+def test_diagnostics_complete_after_transient_deferral_proceeds():
+    """When diagnostics complete during a transient-deferred round, the agent
+    runs and ci_repair_attempts is NOT incremented (transient retry)."""
+    wf = _make_workflow(
+        error_message="CI repair deferred: transient API error - 503 Service Unavailable",
+        ci_repair_attempts=2,
+        ci_repair_transient_retries=1,
+    )
+    orch, mock_repo = _make_orchestrator(wf)
+    gh = MagicMock()
+    gh.get_pr_head_sha.return_value = "sha-new"
+    gh.get_check_failure_excerpt.return_value = "pytest failed\n1 failed"
+    orch._get_gh = MagicMock(return_value=gh)
+    orch._run_merge_ci_repair = MagicMock()
+
+    orch._start_ci_repair_round(wf, 1820, _FAILED_CHECKS)
+
+    orch._run_merge_ci_repair.assert_called_once()
+    updates = [c.args[1] for c in mock_repo.update_workflow.call_args_list]
+    # ci_repair_attempts stays at 2 (transient retry, not a new attempt)
+    assert any(u.get("ci_repair_attempts") == 2 for u in updates)
+    # transient counter incremented
+    assert any(u.get("ci_repair_transient_retries") == 2 for u in updates)
+    # diagnostics counter reset to 0 (fresh budget for the round)
+    assert any(u.get("ci_diagnostics_attempts") == 0 for u in updates)


### PR DESCRIPTION
## Problem

When the CI repair agent produced no code changes due to a transient API error (429/5xx/overload), the workflow unconditionally marked the round as failed, burning a real `ci_repair_attempts` slot on an infra glitch. Workflow #1820 lost 2/3 attempts this way (1 wasted on a 503) and failed prematurely.

## Fix

Detect transient API errors in the `not sha_changed` branch of `_run_merge_ci_repair` and defer to the next scheduler cycle (`status=merging`) instead of failing. A dedicated counter `ci_repair_transient_retries` (bounded by `MAX_CI_REPAIR_TRANSIENT_RETRIES=6`) tracks these deferrals separately from `ci_repair_attempts`.

### Key design decisions

- **New DB column** `ci_repair_transient_retries` — NOT reusing `ci_diagnostics_attempts`, which already bounds CI log-fetch polling (`MAX_CI_DIAGNOSTICS_ATTEMPTS`). Dual use caused counter clobbering when diagnostics polling and transient deferrals interleaved, resetting the transient budget and allowing `ci_repair_attempts` to be consumed by infra glitches.
- **Diagnostics-incomplete polling** preserves the transient-deferred signal in `error_message` (prefix match) and persists `ci_repair_transient_retries` so the next scheduler cycle still detects the transient state.
- **Non-transient rounds** reset `ci_repair_transient_retries` to 0.

## Files changed

- `app/modules/workspace/autonomous/orchestrator.py` — transient detection, retry counting, diagnostics preservation
- `app/modules/workspace/autonomous/models.py` — new field in dataclass
- `app/repositories/autonomous_repo.py` — ALLOWED_WORKFLOW_FIELDS + INSERT statements
- `schema/schema-sqlite.sql` + `schema/schema-postgres.sql` — new column
- `migrations/versions/20260731_001_add_ci_repair_transient_retries.py` — Alembic migration
- `tests/issues/1820/test_ci_repair_transient_deferral.py` — 5 new tests

## Testing

- 5 new tests covering: transient deferral, exhaustion, reset, diagnostics-interleaving, diagnostics-complete
- All existing CI repair tests pass (3 pre-existing failures unrelated — verified via git stash)
- Two rounds of independent agent review passed with zero blocking issues

Closes #1820