### PR TITLE
fix(autonomous): pass --allow-escape-sequences to gh log-fetch calls

### DIFF
--- a/app/modules/workspace/autonomous/github_ops.py
+++ b/app/modules/workspace/autonomous/github_ops.py
@@ -1550,11 +1550,11 @@ class GitHubOps:
                 if self._repo_host and self._repo_host != "github.com":
                     api_args += ["--hostname", self._repo_host]
                 api_args.append(f"repos/{self._repo_slug}/actions/jobs/{job_id}/logs")
-                # gh >= 2.92 refuses to emit log text containing ANSI escape
-                # sequences unless this flag is passed; without it the job-log
-                # REST endpoint always fails and CI repair can never read
-                # failure logs. The sequences are stripped afterward by
-                # _clean_log_to_excerpt / _strip_ansi.
+                # Recent gh (verified on server's 2.97.0) refuses to emit log
+                # text containing ANSI escape sequences unless this flag is
+                # passed; without it the job-log REST endpoint always fails and
+                # CI repair can never read failure logs. The sequences are
+                # stripped afterward by _clean_log_to_excerpt / _strip_ansi.
                 api_args.append("--allow-escape-sequences")
                 api_result = self._run_gh(api_args, check=False, repo_scoped=False)
                 if api_result.returncode == 0 and (api_result.stdout or "").strip():

--- a/app/modules/workspace/autonomous/github_ops.py
+++ b/app/modules/workspace/autonomous/github_ops.py
@@ -1495,7 +1495,7 @@ class GitHubOps:
             return ""
 
         view_result = self._run_gh(
-            ["run", "view", run_id, "--log-failed"],
+            ["run", "view", run_id, "--log-failed", "--allow-escape-sequences"],
             check=False,
         )
         if view_result.returncode != 0:
@@ -1550,6 +1550,12 @@ class GitHubOps:
                 if self._repo_host and self._repo_host != "github.com":
                     api_args += ["--hostname", self._repo_host]
                 api_args.append(f"repos/{self._repo_slug}/actions/jobs/{job_id}/logs")
+                # gh >= 2.92 refuses to emit log text containing ANSI escape
+                # sequences unless this flag is passed; without it the job-log
+                # REST endpoint always fails and CI repair can never read
+                # failure logs. The sequences are stripped afterward by
+                # _clean_log_to_excerpt / _strip_ansi.
+                api_args.append("--allow-escape-sequences")
                 api_result = self._run_gh(api_args, check=False, repo_scoped=False)
                 if api_result.returncode == 0 and (api_result.stdout or "").strip():
                     return self._clean_log_to_excerpt(api_result.stdout or "", max_lines, max_chars)
@@ -1563,7 +1569,15 @@ class GitHubOps:
                 )
 
             result = self._run_gh(
-                ["run", "view", run_id, "--job", job_id, "--log-failed"],
+                [
+                    "run",
+                    "view",
+                    run_id,
+                    "--job",
+                    job_id,
+                    "--log-failed",
+                    "--allow-escape-sequences",
+                ],
                 check=False,
             )
             if result.returncode != 0:

--- a/tests/unit/test_autonomous_ci_guardrails.py
+++ b/tests/unit/test_autonomous_ci_guardrails.py
@@ -92,7 +92,12 @@ def test_actions_job_log_prefers_rest_api_without_run_cache():
         )
 
     assert "app/x.py" in excerpt
-    assert calls == [(["api", "repos/open-ace/open-ace/actions/jobs/456/logs"], False)]
+    assert calls == [
+        (
+            ["api", "repos/open-ace/open-ace/actions/jobs/456/logs", "--allow-escape-sequences"],
+            False,
+        )
+    ]
 
 
 def test_actions_job_log_uses_ghes_hostname_without_run_cache():
@@ -120,7 +125,13 @@ def test_actions_job_log_uses_ghes_hostname_without_run_cache():
     assert "failed" in excerpt
     assert calls == [
         (
-            ["api", "--hostname", "gh.example.com", "repos/team/project/actions/jobs/34/logs"],
+            [
+                "api",
+                "--hostname",
+                "gh.example.com",
+                "repos/team/project/actions/jobs/34/logs",
+                "--allow-escape-sequences",
+            ],
             False,
         )
     ]


### PR DESCRIPTION
## 根因

`get_check_failure_excerpt` 的 CI 日志获取路径在每个 PR 上都失败。gh >= 2.92 拒绝输出含 ANSI 转义序列的 GitHub Actions 日志，除非传 `--allow-escape-sequences`。这导致每次 CI 修复都报 `0/N failed checks have logs`，耗尽 6 次诊断轮询后工作流 hard-fail。

代码已有 `_strip_ansi` 在成功获取后清理转义序列，但 gh 在调用层就失败了（非零退出），清理逻辑从未执行。

## 修复

在 `github_ops.py` 的 3 个日志获取调用点添加 `--allow-escape-sequences`：
1. `gh api repos/.../actions/jobs/{job_id}/logs`（主路径，job 级 REST）
2. `gh run view --job --log-failed`（解析 URL 内回退）
3. `gh run view --log-failed`（`_fetch_log_excerpt_via_run_list` 回退）

## 影响

- 修复反复出现的 `CI diagnostics incomplete (0/1 failed checks have logs; poll 6/6)` 失败（#2179, #2181）
- 无 DB schema 变更，无迁移
- `_strip_ansi`/`_clean_log_to_excerpt` 管道已处理转义序列输出，自洽