### PR TITLE
fix(ssrf): tolerate CDN DNS round-robin in rebinding check

### DIFF
--- a/app/utils/llm_proxy_url_validator.py
+++ b/app/utils/llm_proxy_url_validator.py
@@ -452,6 +452,23 @@ def validate_ip_against_stored(
 
         # Check if any current IP matches stored
         if not current_set.intersection(stored_set):
+            # CDN providers (e.g. Alibaba dashscope, Cloudflare) use DNS
+            # round-robin, so the current resolution can return a disjoint
+            # set of *public* IPs that are all legitimate rotation — not a
+            # rebinding attack. The real SSRF-via-rebinding invariant is
+            # "no current IP is private/non-public": a genuine attack
+            # re-resolves a public hostname to an internal/metadata IP.
+            # Mirror the connect-time _PinnedIPAdapter leniency for public
+            # IP rotation while still blocking private-IP rebinding.
+            if current_addresses and all(_is_public_address(addr) for addr in current_addresses):
+                logger.debug(
+                    "DNS IP set changed for %s but all current IPs are public "
+                    "(stored=%s current=%s); treating as CDN rotation",
+                    host,
+                    sorted(stored_set),
+                    sorted(current_set),
+                )
+                return True, None
             return False, f"DNS rebinding detected: IPs changed from {stored_ips}"
 
         return True, None

--- a/tests/unit/test_llm_proxy_url_validator.py
+++ b/tests/unit/test_llm_proxy_url_validator.py
@@ -235,6 +235,36 @@ class TestIpPinning:
         assert not is_valid
         assert "rebinding" in error.lower() or "changed" in error.lower()
 
+    def test_validate_ip_against_stored_cdn_rotation_all_public(self):
+        """CDN round-robin: disjoint *public* IP sets should pass.
+
+        Providers like Alibaba dashscope use DNS round-robin, so the
+        current resolution can return IPs not seen at config time. As long
+        as every current IP is public, it is legitimate rotation, not a
+        rebinding attack.
+        """
+        is_valid, error = validate_ip_against_stored(
+            "https://coding.dashscope.aliyuncs.com/v1",
+            "47.93.100.126,47.94.106.9",  # stored at config time
+            resolver=_resolver("47.93.100.200", "47.94.106.50"),  # disjoint, all public
+        )
+        assert is_valid
+        assert error is None
+
+    def test_validate_ip_against_stored_mixed_public_private_blocked(self):
+        """Even one private IP among current IPs must be blocked.
+
+        The all-public relaxation must not mask a genuine rebinding attack
+        where one resolved IP is private (the actual SSRF vector).
+        """
+        is_valid, error = validate_ip_against_stored(
+            "https://api.custom.com/v1",
+            "93.184.216.34",
+            resolver=_resolver("47.93.100.200", "169.254.169.254"),  # one metadata IP
+        )
+        assert not is_valid
+        assert "rebinding" in error.lower() or "changed" in error.lower()
+
 
 class TestDnsCache:
     """Tests for DNS cache functionality."""


### PR DESCRIPTION
## 根因

`validate_ip_against_stored` 对 CDN 提供商做严格 IP 集合交集检查。阿里云 `coding.dashscope.aliyuncs.com` 使用 DNS 轮询，DNS 每次返回不同 IP 子集，与配置时存储的 IP 集不相交 → 误报 "DNS rebinding detected" → 403 阻断所有 agent LLM 调用 → 工作流报 "Tests were not actually run" 失败。已导致 batch 中 5+ 个工作流 failed。

## 修复

当 IP 集合不相交时，不立即判定为重绑定，而是检查当前解析的所有 IP 是否都是**公网地址**（`_is_public_address`）。如果全部是公网地址，说明是 CDN 轮询而非重绑定攻击，放行。只有当当前 IP 中存在非公网地址（私有/环回/元数据）时才判定为真正的 DNS 重绑定攻击。

### 安全不变量
DNS 重绑定攻击的本质是将公网域名重解析到私有/内部 IP 以发起 SSRF。只要当前 IP 仍是公网地址，就不构成重绑定攻击。这与连接时 `_PinnedIPAdapter` 已有的宽松行为一致。

## 测试
- `test_validate_ip_against_stored_cdn_rotation_all_public`：不相交公网 IP 集放行
- `test_validate_ip_against_stored_mixed_public_private_blocked`：含私有 IP 仍拒绝
- 现有 `test_validate_ip_against_stored_mismatch`（私有 IP 重绑定）仍通过

## 影响
- 无 DB schema 变更
- 安全性不降：私有 IP 重绑定攻击仍被阻止