### PR TITLE
fix(autonomous): accept prior agent commits on dev-phase resume

### DIFF
--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -7143,50 +7143,85 @@ class AutonomousOrchestrator:
                     except Exception:
                         pass
             elif branch_has_changes_vs_base and commit_sha == commit_before:
-                # Branch has pre-existing divergence (e.g. it was created
-                # behind main), but the agent produced NO new commit this
-                # session. The diff is NOT the agent's work — treat as failure.
-                logger.warning(
-                    "Branch has %d commits vs origin/main but HEAD unchanged "
-                    "this session (commit_sha == commit_before) — not agent work",
-                    base_diff_stats.get("commits", 0),
-                )
-                if primary_error:
-                    logger.warning(
-                        "Agent failed before producing a new commit; preserving primary error: %s",
-                        primary_error,
+                # Branch has pre-existing divergence, but the agent produced
+                # NO new commit this session. Before declaring failure, check
+                # whether the branch divergence is the agent's own work from a
+                # prior dev round (resume scenario): when a workflow is reset
+                # after an infra failure, the development phase resumes the
+                # prior session; the agent finds the task already done and
+                # correctly produces no new commit. The branch's existing
+                # commits (e.g. "auto: development changes") ARE the work.
+                branch_has_agent_commits = False
+                try:
+                    if branch_name:
+                        log_result = gh._run_git(
+                            ["log", "--oneline", "origin/main..HEAD"], check=False
+                        )
+                        commits_log = log_result.stdout or ""
+                        # Agent-authored auto-dev commits indicate prior work
+                        branch_has_agent_commits = any(
+                            "auto:" in line.lower() or "dev round" in line.lower()
+                            for line in commits_log.splitlines()
+                        )
+                except Exception:
+                    pass
+
+                if branch_has_agent_commits and not primary_error:
+                    # The branch carries the agent's own prior development
+                    # work; the resume correctly produced no duplicate commit.
+                    logger.info(
+                        "Branch '%s' has %d agent-authored commits vs "
+                        "origin/main; accepting as prior work on resume",
+                        branch_name,
+                        base_diff_stats.get("commits", 0),
                     )
+                    diff_stats = base_diff_stats
+                    sha_changed = True  # treat existing branch work as valid
                 else:
+                    # Genuinely no agent work: either no auto-dev commits in
+                    # the divergence (e.g. branch created behind main) or the
+                    # agent reported an error before producing any commit.
                     logger.warning(
-                        "Agent reported success but no new commits detected (SHA unchanged)"
+                        "Branch has %d commits vs origin/main but HEAD unchanged "
+                        "this session (commit_sha == commit_before) — not agent work",
+                        base_diff_stats.get("commits", 0),
                     )
-                milestone_error = (
-                    primary_error
-                    if primary_error
-                    else "Agent produced no code changes (commit SHA unchanged)"
-                )
-                workflow_error = (
-                    f"Development failed: {primary_error}"
-                    if primary_error
-                    else "Development failed: agent produced no code changes"
-                )
-                self.repo.update_milestone(
-                    ms.get("milestone_id", ""),
-                    {
-                        "status": "failed",
-                        "session_id": result.session_id,
-                        "result_summary": self._artifact_text(result)[:300],
-                        "tldr": self._artifact_tldr(result),
-                        "error_message": milestone_error,
-                    },
-                )
-                self._update_workflow(
-                    {
-                        "status": "failed",
-                        "error_message": workflow_error,
-                    }
-                )
-                return
+                    if primary_error:
+                        logger.warning(
+                            "Agent failed before producing a new commit; preserving primary error: %s",
+                            primary_error,
+                        )
+                    else:
+                        logger.warning(
+                            "Agent reported success but no new commits detected (SHA unchanged)"
+                        )
+                    milestone_error = (
+                        primary_error
+                        if primary_error
+                        else "Agent produced no code changes (commit SHA unchanged)"
+                    )
+                    workflow_error = (
+                        f"Development failed: {primary_error}"
+                        if primary_error
+                        else "Development failed: agent produced no code changes"
+                    )
+                    self.repo.update_milestone(
+                        ms.get("milestone_id", ""),
+                        {
+                            "status": "failed",
+                            "session_id": result.session_id,
+                            "result_summary": self._artifact_text(result)[:300],
+                            "tldr": self._artifact_tldr(result),
+                            "error_message": milestone_error,
+                        },
+                    )
+                    self._update_workflow(
+                        {
+                            "status": "failed",
+                            "error_message": workflow_error,
+                        }
+                    )
+                    return
 
         # Block accidental repository-wide rewrites before they can proceed to
         # tests/PR creation.  The threshold is intentionally configurable for

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -7158,6 +7158,12 @@ class AutonomousOrchestrator:
                             ["log", "--oneline", "origin/main..HEAD"], check=False
                         )
                         commits_log = log_result.stdout or ""
+                        if log_result.returncode != 0 and not commits_log:
+                            logger.debug(
+                                "git log origin/main..HEAD failed (rc=%s); "
+                                "treating as no agent commits",
+                                log_result.returncode,
+                            )
                         # Agent-authored auto-dev commits indicate prior work
                         branch_has_agent_commits = any(
                             "auto:" in line.lower() or "dev round" in line.lower()

--- a/tests/issues/716/test_orchestrator.py
+++ b/tests/issues/716/test_orchestrator.py
@@ -1404,6 +1404,41 @@ class TestOrchestratorDevelopment:
             for update in workflow_updates
         )
 
+    def test_development_resume_accepts_prior_agent_commits(self):
+        """Resume scenario: agent produced no NEW commit this session, but the
+        branch already has agent-authored commits from a prior dev round (e.g.
+        after an infra-failure reset). Must NOT fail as 'no code changes'."""
+        wf = _make_workflow(
+            current_phase="development",
+            status="developing",
+            branch_name="auto-dev/resume-wf",
+        )
+        orch, mock_repo = self._make_orchestrator(wf)
+        orch._runner = MagicMock()
+        orch._runner.run_agent_task.return_value = _make_agent_result(
+            success=True, text="Task already completed in prior session"
+        )
+        # commit_before == commit_sha (HEAD did not move this session)
+        orch._gh.get_current_commit.side_effect = ["abc1234", "abc1234"]
+        orch._gh.get_commit_diff_stats.return_value = {"files": 0, "additions": 0, "deletions": 0}
+        # Branch has 3 commits vs origin/main (prior agent work)
+        orch._gh.get_diff_stats.return_value = {"commits": 3, "files": 5, "additions": 100}
+        orch._gh.has_uncommitted_changes.return_value = False
+        # The branch log shows agent-authored commits
+        orch._gh._run_git.return_value = MagicMock(
+            stdout="abc1234 auto: development changes (round 1)\n"
+            "def5678 auto: ci repair (attempt 1)\n"
+            "ghi9012 Merge commit into auto-dev\n"
+        )
+
+        orch._do_development(wf)
+
+        # Must NOT set workflow to failed with "no code changes"
+        workflow_updates = [c[0][1] for c in mock_repo.update_workflow.call_args_list]
+        assert not any(
+            "no code changes" in (u.get("error_message") or "") for u in workflow_updates
+        ), "resume with prior agent commits must not fail as 'no code changes'"
+
     def test_development_test_failure_sets_error(self):
         """When tests fail past max retries, workflow status becomes failed."""
         from app.modules.workspace.autonomous.orchestrator import MAX_TEST_RETRIES


### PR DESCRIPTION
## 根因

当一个工作流因基础设施故障（DNS、网络等）被重置后，开发阶段会 resume 之前的 agent session。Agent 发现任务已完成，正确地不产生新 commit（`commit_sha == commit_before`）。但变更检测逻辑误判为 "agent produced no code changes" → failed，尽管 branch 上已有 agent 之前的工作（如 7 个 commit、14 文件、1496 行）。

这导致 #2181 在系统问题修复后重置时被误判失败，其实 PR #2193 有完整的 P0 安全实现。

## 修复

在 `orchestrator.py` 的变更检测中，当 `commit_sha == commit_before` 且 branch 相对 origin/main 有分叉时，先检查分叉的 commit 是否为 agent 作者的（`auto:` 前缀）。如果是，说明是之前 dev round 的成果，接受。只有在分叉中无 agent commit（如 branch 落后于 main 创建）或 agent 报错时才判失败。

## 测试
- 新增 `test_development_resume_accepts_prior_agent_commits`：resume 场景下接受已有 agent 工作
- 现有 `test_development_preserves_primary_error_before_no_code_change_fallback`：确认真实失败仍被捕获
- 25 个 development + change detection 测试全通过

## 影响
- 修复重置-resume 场景下的变更检测误判
- 安全性不降：无 agent commit 的分叉仍判失败，agent 报错仍判失败
- 无 DB schema 变更