### PR TITLE
fix(install): make agent-launcher.conf readable by openace (0640→0644)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -195,7 +195,7 @@ RUN chmod 755 /usr/local/bin/openace-run-as \
     mkdir -p /etc/openace && \
     printf '%s\n' \
         '# Issue #2018: constraints shared by openace-run-as and its sudoers' \
-        '# rule. root:root 0640 — the openace service account cannot edit it.' \
+        '# rule. root:root 0644 — the openace service account can read but not edit it.' \
         'OPENACE_AUTONOMOUS_AGENT_ACCOUNT="openace-agent"' \
         'ALLOWED_WORKSPACE_ROOTS="/home /workspace"' \
         '# Issue #2020: per-task isolation + resource policy (read by the' \
@@ -211,7 +211,7 @@ RUN chmod 755 /usr/local/bin/openace-run-as \
         'agent_max_concurrent_workflows=3' \
         > /etc/openace/agent-launcher.conf && \
     chown root:root /etc/openace/agent-launcher.conf && \
-    chmod 0640 /etc/openace/agent-launcher.conf && \
+    chmod 0644 /etc/openace/agent-launcher.conf && \
     printf '%s\n' \
         '# Credentialless autonomous agent launcher' \
         'open-ace ALL=(root) NOPASSWD: /usr/local/bin/openace-run-as --isolated *' \

--- a/scripts/install-central/docker-method/install.sh
+++ b/scripts/install-central/docker-method/install.sh
@@ -731,7 +731,7 @@ install_run_as_wrapper() {
     chmod 755 "$dst"
 
     # Issue #2018: install the launch validator (account pin + path confinement)
-    # consumed by openace-run-as --isolated, plus the root:root 0640 constraint
+    # consumed by openace-run-as --isolated, plus the root:root 0644 constraint
     # conf. The wrapper fail-closes without them, so a host that bind-mounts
     # /usr/local/bin (or /etc/openace) into the container must provision both
     # alongside the wrapper. Validator source lives next to the wrapper.
@@ -749,12 +749,12 @@ install_run_as_wrapper() {
     install -d -o root -g root -m 755 /etc/openace 2>/dev/null || true
     cat > /etc/openace/agent-launcher.conf 2>/dev/null <<CONF_EOF || print_warning "写入 agent-launcher.conf 失败"
 # Issue #2018: constraints for openace-run-as --isolated.
-# root:root 0640 — the openace service account cannot edit this file.
+# root:root 0644 — the openace service account can read but not edit this file.
 OPENACE_AUTONOMOUS_AGENT_ACCOUNT="${agent_account}"
 ALLOWED_WORKSPACE_ROOTS="/home /workspace"
 CONF_EOF
     chown root:root /etc/openace/agent-launcher.conf 2>/dev/null || true
-    chmod 0640 /etc/openace/agent-launcher.conf 2>/dev/null || true
+    chmod 0644 /etc/openace/agent-launcher.conf 2>/dev/null || true
     print_success "已安装 run-as wrapper 到 $dst"
     return 0
 }

--- a/scripts/install-central/package-method/install.sh
+++ b/scripts/install-central/package-method/install.sh
@@ -1950,18 +1950,18 @@ install_run_as_wrapper() {
     install -o root -g root -m 755 "$validate_src" "$validate_dst" || return 1
 
     # Single source of truth for the account pin + workspace roots, shared by
-    # the wrapper and its sudoers provisioning. root:root 0640 so the openace
-    # service account cannot alter the constraints.
+    # the wrapper and its sudoers provisioning. root:root 0644 so the openace
+    # service account can read but not alter the constraints.
     local agent_account="${OPENACE_AUTONOMOUS_AGENT_ACCOUNT:-openace-agent}"
     install -d -o root -g root -m 755 /etc/openace || return 1
     cat > /etc/openace/agent-launcher.conf <<CONF_EOF
 # Issue #2018: constraints for openace-run-as --isolated.
-# root:root 0640 — the openace service account cannot edit this file.
+# root:root 0644 — the openace service account can read but not edit this file.
 OPENACE_AUTONOMOUS_AGENT_ACCOUNT="${agent_account}"
 ALLOWED_WORKSPACE_ROOTS="/home /workspace"
 CONF_EOF
     chown root:root /etc/openace/agent-launcher.conf 2>/dev/null || true
-    chmod 0640 /etc/openace/agent-launcher.conf
+    chmod 0644 /etc/openace/agent-launcher.conf
     print_success "Installed run-as wrapper to $dst"
     return 0
 }
@@ -2071,12 +2071,12 @@ agent_account="${OPENACE_AUTONOMOUS_AGENT_ACCOUNT:-openace-agent}"
 conf_tmp="$(mktemp)"
 cat > "$conf_tmp" <<CONF_EOF
 # Issue #2018: constraints for openace-run-as --isolated.
-# root:root 0640 — the openace service account cannot edit this file.
+# root:root 0644 — the openace service account can read but not edit this file.
 OPENACE_AUTONOMOUS_AGENT_ACCOUNT="${agent_account}"
 ALLOWED_WORKSPACE_ROOTS="/home /workspace"
 CONF_EOF
 as_root install -d -o root -g root -m 755 /etc/openace
-as_root install -o root -g root -m 640 "$conf_tmp" /etc/openace/.agent-launcher.conf.new
+as_root install -o root -g root -m 644 "$conf_tmp" /etc/openace/.agent-launcher.conf.new
 as_root mv /etc/openace/.agent-launcher.conf.new /etc/openace/agent-launcher.conf
 
 service_user="$(systemctl show open-ace.service -p User --value 2>/dev/null || true)"

--- a/scripts/setup-cgroup-v2.sh
+++ b/scripts/setup-cgroup-v2.sh
@@ -278,7 +278,7 @@ else
     # Write the new config: preserve account/roots, drop stale resource keys, append fresh
     {
         echo '# Issue #2018: constraints for openace-run-as --isolated.'
-        echo '# root:root 0640 — the openace service account cannot edit this file.'
+        echo '# root:root 0644 — the openace service account can read but not edit this file.'
         echo "OPENACE_AUTONOMOUS_AGENT_ACCOUNT=\"$existing_account\""
         echo "ALLOWED_WORKSPACE_ROOTS=\"$existing_roots\""
         echo ""
@@ -290,7 +290,7 @@ else
     } > "$CONF_PATH"
 
     chown root:root "$CONF_PATH"
-    chmod 640 "$CONF_PATH"
+    chmod 644 "$CONF_PATH"
     log "  $CONF_PATH updated (backup at ${CONF_PATH}.bak.*)"
 fi
 


### PR DESCRIPTION
## 根因

`agent-launcher.conf` 权限为 `0640 root:root`，openace 服务用户不在 root 组无法读取。`read_agent_task_policy()` 捕获 `OSError` 后静默返回全默认值（memory=0, pids=0, cpu='', wall_clock=0），导致工作流 timeline header 的运行时限制（CPU/内存/pids）显示为 `-`。

## 修复（经独立方案审查）

将所有生成脚本的权限从 `0640` 改为 `0644`：
- `scripts/setup-cgroup-v2.sh`（写入资源限制值的生产者）
- `scripts/install-central/package-method/install.sh`（2 处：chmod + install -m）
- `scripts/install-central/docker-method/install.sh`

`0644 root:root` 保持 root-only 写入（openace 不可修改约束——安全性不变，`openace-validate-launch` 只拒绝 write bit），同时允许服务读取资源限制。

### 独立方案审查意见（已采纳全部）
- 补充了 `setup-cgroup-v2.sh`（方案初稿遗漏——这是实际写入资源限制的脚本）
- 补充了 `install -m 640` 的 remote/single-user 路径
- 更新了全部 6 处注释（非仅 2 处）

## 影响
- 新安装/升级后 openace 可正确读取资源限制
- 安全性不降：`openace-validate-launch` 验证器只拒绝 write bit，`0644` 通过
- 文件内容无敏感数据（仅账户名、workspace roots、资源限制），world-readable 安全