### PR TITLE
fix(autonomous): capture cli_session_id from system/init stream message

### DIFF
--- a/app/modules/workspace/autonomous/agent_runner.py
+++ b/app/modules/workspace/autonomous/agent_runner.py
@@ -4053,8 +4053,14 @@ class AutonomousAgentRunner:
                             )
 
                     elif msg_type in {"system", "initialized"}:
-                        if msg_type == "initialized" or parsed.get("subtype") == "initialized":
-                            self._capture_cli_session_id(session, parsed, "system.initialized")
+                        subtype = parsed.get("subtype", "")
+                        # Claude CLI emits subtype "init" (older versions used
+                        # "initialized"); accept both so the real cli_session_id
+                        # is captured at agent start instead of via mtime fallback.
+                        if msg_type == "initialized" or subtype in ("initialized", "init"):
+                            self._capture_cli_session_id(
+                                session, parsed, f"system.{subtype or 'init'}"
+                            )
                         # Forward key system events to the UI so the workflow
                         # detail shows progress during long LLM waits.
                         # Without this, an agent stuck in api_retry (upstream
@@ -4062,7 +4068,6 @@ class AutonomousAgentRunner:
                         # — which never triggered _activity_callback — so the
                         # UI showed "no AI activity" for minutes until the
                         # first `assistant` event finally arrived.
-                        subtype = parsed.get("subtype", "")
                         # This is a high-frequency cumulative estimate, not a
                         # discrete user-visible activity. Skipping the event
                         # also prevents one sidebar fallback probe per token.

--- a/remote-agent/executor.py
+++ b/remote-agent/executor.py
@@ -239,7 +239,8 @@ class SessionProcess:
                             continue
 
                         if msg_type in {"system", "initialized"} and (
-                            msg_type == "initialized" or parsed.get("subtype") == "initialized"
+                            msg_type == "initialized"
+                            or parsed.get("subtype") in ("initialized", "init")
                         ):
                             self._capture_cli_session_id(parsed, "system.initialized")
 

--- a/tests/unit/test_agent_runner_session_id_capture.py
+++ b/tests/unit/test_agent_runner_session_id_capture.py
@@ -1,0 +1,65 @@
+"""Regression: capture cli_session_id from the system/init stream message.
+
+The Claude CLI emits the first stream-json line as
+``{"type":"system","subtype":"init","session_id":"<uuid>", ...}``.
+agent_runner must capture that session_id at agent start so the orchestrator
+tracks the real session in real time, instead of always falling back to
+mtime-based JSONL discovery.
+"""
+
+import json
+from types import SimpleNamespace
+
+from app.modules.workspace.autonomous.agent_runner import AutonomousAgentRunner, _LocalSession
+
+
+def _run_messages(messages):
+    """Drive _read_stdout with a fake process emitting the given JSON lines."""
+
+    class FakeStdout:
+        def __init__(self, lines):
+            self.lines = [json.dumps(ln).encode() for ln in lines]
+
+        def readline(self):
+            return self.lines.pop(0) if self.lines else b""
+
+    runner = AutonomousAgentRunner.__new__(AutonomousAgentRunner)
+    runner._activity_callback = None
+    # _read_stdout calls _resolve_sidebar_session once cli_session_id becomes
+    # truthy (lines ~4158-4163); under __new__ the runner has no session_manager,
+    # so the real resolver would AttributeError. Stub it (mirrors the existing
+    # harness in test_autonomous_ci_guardrails.py). The capture path itself —
+    # _capture_cli_session_id — is intentionally left REAL: the bug is the gate
+    # that decides whether to call it.
+    runner._resolve_sidebar_session = lambda *_args, **_kwargs: ""
+    # _read_stdout's `finally` (lines ~4178-4183) calls session.process.poll()
+    # and reads .returncode when no `result` set completed. Provide both so the
+    # test exits cleanly instead of AttributeError (matches the existing harness).
+    session = _LocalSession(
+        session_id="tracking-1",
+        process=SimpleNamespace(
+            stdout=FakeStdout(messages), stdin=None, returncode=None, poll=lambda: None
+        ),
+    )
+    session.workflow_id = "wf-1"
+    runner._read_stdout(session)
+    return session
+
+
+def test_system_init_captures_cli_session_id():
+    session = _run_messages(
+        [
+            {"type": "system", "subtype": "init", "session_id": "cli-sid-1234", "uuid": "u1"},
+        ]
+    )
+    assert session.cli_session_id == "cli-sid-1234"
+
+
+def test_legacy_initialized_subtype_still_captures():
+    """Older CLI versions used subtype 'initialized' — keep supporting them."""
+    session = _run_messages(
+        [
+            {"type": "system", "subtype": "initialized", "session_id": "cli-sid-5678"},
+        ]
+    )
+    assert session.cli_session_id == "cli-sid-5678"


### PR DESCRIPTION
## Root cause

`AutonomousAgentRunner` never captured the real Claude `cli_session_id` in real time — it always fell back to mtime-based JSONL session discovery, logging a WARNING ~3659×/day (and briefly blind to the session when mtime returned `<none>`).

The system-message capture gate (`agent_runner.py`) checked `subtype == "initialized"`, but the Claude CLI actually emits the first stream-json line as:

```json
{"type":"system","subtype":"init","session_id":"<uuid>","uuid":"...","tools":[...]}
```

So the capture never fired. The `control_response.initialize` path is structurally a *commands/config* response (no `session_id` at any of the 3 extractor locations), so it was never a session_id source. Introduced by commit `c03282cb`.

## Evidence (production server 192.168.1.21)
- Live stream-json capture: first line is `system/init` with top-level `session_id`.
- Warning log: `control_response initialize success but no session_id` + `mtime fallback ... -> <none>` ~3659×/day.
- `session_manager.py:106-109`: *"agent start never backfills cli_session_id — leaving a permanent orphan."*

## Fix
- Accept both `subtype` values (`"init"` and legacy `"initialized"`) in the system-message gate.
- Use an accurate log label (`system.{subtype}`).
- Same one-line gate fix applied to `remote-agent/executor.py:241-244` (identical bug, different `_capture_cli_session_id(parsed, source)` signature).

## Test
New `tests/unit/test_agent_runner_session_id_capture.py` drives `_read_stdout` with a real `system/init` line (no mocking of `_capture_cli_session_id`): fails before the fix (`assert '' == 'cli-sid-...'`), passes after. A legacy-`initialized` test guards against regressing older CLIs. 104 neighboring tests pass; no regressions.

## Impact
The mtime-fallback warning drops from ~70-180/run to ≤1/run (only sub-second probes before the first `system/init` message). Non-blocking today (workflows completed via fallback), but removes a latent session-tracking risk and a log-noise source that was actively hampering monitoring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)