### PR TITLE
fix(autonomous): reliable CI-repair observability

### DIFF
--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -2718,7 +2718,11 @@ class AutonomousOrchestrator:
         """Prefer agent summary, but synthesize a concise fallback when it is noisy/empty."""
         cleaned = artifact_text.strip()
         if cleaned:
-            return cleaned[:300]
+            # Keep the agent's full repair summary; the PR comment body is
+            # capped later by GITHUB_COMMENT_MAX_CHARS (65000) in
+            # _post_github_comment. The previous hard [:300] cut repair
+            # summaries mid-sentence (PR #2198 attempts 2-N).
+            return cleaned
 
         status = "Development completed" if success else "Development failed"
         parts = [status]
@@ -3091,13 +3095,27 @@ class AutonomousOrchestrator:
             )
 
     def _find_existing_milestone(
-        self, phase: str, milestone_type: str, dev_round: int = None, round_number: int = None
+        self,
+        phase: str,
+        milestone_type: str,
+        dev_round: int = None,
+        round_number: int = None,
+        completed: bool = True,
     ) -> dict | None:
-        """Check if a milestone of this type already exists (idempotency guard)."""
+        """Check if a milestone of this type already exists (idempotency guard).
+
+        ``completed=False`` skips completed milestones — used for ci_repair_*
+        milestones so a prior cycle's completed milestone (same dev_round +
+        round_number, since cycle restarts don't bump dev_round) doesn't block a
+        new cycle's attempt. Only a still-in_progress milestone (a true
+        concurrent duplicate) blocks in that case.
+        """
         existing = self.repo.list_milestones(self._workflow_id, phase=phase, status="in_progress")
-        # Also check completed ones
-        completed = self.repo.list_milestones(self._workflow_id, phase=phase, status="completed")
-        candidates = existing + completed
+        candidates = existing
+        if completed:
+            candidates = candidates + self.repo.list_milestones(
+                self._workflow_id, phase=phase, status="completed"
+            )
 
         for ms in candidates:
             if ms.get("milestone_type") != milestone_type:
@@ -3113,12 +3131,18 @@ class AutonomousOrchestrator:
         """Create a milestone and emit event. Idempotent — returns existing if found."""
         kwargs.setdefault("workflow_id", self._workflow_id)
 
+        milestone_type = kwargs.get("milestone_type", "")
+        # ci_repair_* milestones are one-per-attempt; a prior cycle's completed
+        # ci_repair milestone (same dev_round + round_number, since cycle restarts
+        # don't bump dev_round) must not block a new cycle's attempt.
+        match_completed = not milestone_type.startswith("ci_repair_")
         # Idempotency guard: skip creation if matching milestone already exists
         existing = self._find_existing_milestone(
             phase=kwargs.get("phase", ""),
-            milestone_type=kwargs.get("milestone_type", ""),
+            milestone_type=milestone_type,
             dev_round=kwargs.get("dev_round"),
             round_number=kwargs.get("round_number"),
+            completed=match_completed,
         )
         if existing:
             logger.info(

--- a/tests/unit/test_ci_repair_observability.py
+++ b/tests/unit/test_ci_repair_observability.py
@@ -1,0 +1,66 @@
+"""Regression tests for CI-repair observability.
+
+Bug 1: a prior cycle's COMPLETED ci_repair milestone must not block a new cycle's
+same-round milestone (cycle restarts don't bump dev_round, so the dedup key
+(phase, type, dev_round, round_number) collides across cycles).
+
+Bug 2: the CI-repair result summary must not be hard-truncated to 300 chars.
+"""
+
+from unittest.mock import MagicMock
+
+from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+
+def test_build_dev_result_summary_preserves_long_text():
+    """Bug 2: the repair summary must not be hard-truncated to 300 chars."""
+    long_summary = "## CI fix report\n\n" + ("detail line\n" * 200)  # well over 300 chars
+    out = AutonomousOrchestrator._build_dev_result_summary(
+        long_summary, {"files": 3, "additions": 10, "deletions": 2}, "abcdef12", True
+    )
+    assert out == long_summary.strip()
+    assert len(out) > 300
+
+
+def test_ci_repair_milestone_not_blocked_by_prior_completed_cycle():
+    """Bug 1: a new cycle's ci_repair milestone must not be deduped against a
+    prior cycle's COMPLETED milestone of the same (dev_round, round_number)."""
+    orch = AutonomousOrchestrator.__new__(AutonomousOrchestrator)
+    orch._workflow_id = "wf-1"
+    orch._emit = lambda *_a, **_k: None
+
+    prior = {
+        "milestone_id": "prior-1",
+        "milestone_type": "ci_repair_applied",
+        "phase": "merge",
+        "dev_round": 1,
+        "round_number": 2,
+        "status": "completed",
+    }
+    created = {}
+
+    def fake_list(wf_id, phase=None, status=None):
+        return [prior] if status == "completed" else []
+
+    def fake_create(data):
+        created["called"] = True
+        return {"milestone_id": "new-1", **data}
+
+    repo = MagicMock()
+    repo.list_milestones = fake_list
+    repo.create_milestone = fake_create
+    orch.repo = repo
+
+    # New cycle (dev_round still 1 because the restart didn't bump it) creates
+    # ci_repair_applied for round 2 — must NOT be deduped by the prior completed one.
+    orch._create_milestone(
+        phase="merge",
+        dev_round=1,
+        round_number=2,
+        milestone_type="ci_repair_applied",
+        status="in_progress",
+        title="CI repair attempt 2 for PR #9",
+    )
+    assert created.get(
+        "called"
+    ), "new ci_repair milestone was wrongly deduped against a prior completed cycle"


### PR DESCRIPTION
Two class-2 bugs in the CI-repair/merge observability surface, both observed on production workflow 2185 / PR #2198.

## Bug 1 — ci_repair milestones froze at "attempt 1" after a cycle restart
After a workflow reactivates (cycle 2: planning→dev→merge), only the round-1 `ci_repair_applied` milestone was created; rounds 2-5 were silently dropped. The UI/milestone trail froze at "attempt 1" while `ci_repair_attempts` climbed to 5.

**Root cause:** `_create_milestone`'s idempotency guard (`orchestrator.py:3117`) matched `(phase, type, dev_round, round_number)` against **both in_progress and completed** milestones. Cycle restarts (the retry endpoint, or the monitoring-doc SQL reset) do NOT bump `dev_round`, so the new cycle's round-N collides with the prior cycle's **completed** round-N → "Milestone already exists, skipping creation". Round 1 was the exception because the prior cycle's round 1 was `failed` (not matched).

**Fix:** scope the guard to `in_progress`-only for `ci_repair_*` types (`completed=False`). Only a true concurrent (in_progress) duplicate is prevented; a prior cycle's completed milestone no longer blocks. Dedup-side (not bump-dev_round) because the restart can happen via SQL reset outside code control.

## Bug 2 — "CI Repair Attempt N" PR comment truncated to 300 chars
Comments for attempts 2-5 were all exactly 432 chars, cut off mid-sentence.

**Root cause:** `_build_dev_result_summary` (`orchestrator.py:2719`) returned `cleaned[:300]` unconditionally. The 65000-char comment cap (`GITHUB_COMMENT_MAX_CHARS`, applied in `_post_github_comment`) already handles extremes, so the 300 cap was needlessly aggressive.

**Fix:** drop the `[:300]` cap; return the full summary.

## Tests
`tests/unit/test_ci_repair_observability.py` — both fail before / pass after. 86 regression tests pass (ci_guardrails, timeline_session_identity, #1851 ci_repair_milestone_rounds).

## Deploy
Ships together with #2202 (one restart): copies `agent_runner.py` (#2202) + `orchestrator.py` (this PR) to the server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)