### PR TITLE
fix(autonomous): synthesize command-evidence exit_code from is_error (Claude)

### DIFF
--- a/app/modules/workspace/autonomous/command_evidence/recorder.py
+++ b/app/modules/workspace/autonomous/command_evidence/recorder.py
@@ -297,10 +297,17 @@ class CommandEvidenceRecorder:
                     results[command_id] = event
                     if command_id not in order:
                         order.append(command_id)
+                    exit_code = event.get("exit_code")
+                    if exit_code is None:
+                        # Claude tool_results carry is_error but not the shell
+                        # exit code; synthesize so the row is COMPLETED (not
+                        # CRASH) and parse_test_evidence's exit_code fallback
+                        # yields PASSED/FAILED instead of INCONCLUSIVE.
+                        exit_code = 1 if event.get("is_error") else 0
                     self.record_tool_result(
                         command_id=command_id,
                         session_id=session_id,
-                        exit_code=event.get("exit_code"),
+                        exit_code=exit_code,
                         output_excerpt=event.get("text"),
                         sandbox_id=sandbox_id,
                         sandbox_generation=sandbox_generation,

--- a/tests/integration/test_command_evidence_repo.py
+++ b/tests/integration/test_command_evidence_repo.py
@@ -285,3 +285,64 @@ def test_record_tool_use_persists_with_boolean_columns_on_postgres(pg_repo):
     assert len(rows) == 1, "row did not persist — boolean INSERT failed on Postgres"
     assert rows[0].timed_out is False
     assert rows[0].cancelled is False
+
+
+def test_emit_synthesizes_exit_code_from_is_error_for_claude_results(recorder, repo):
+    """Claude tool_results carry is_error but no shell exit_code; emit should
+    synthesize exit_code so the row is COMPLETED (not CRASH) and
+    parse_test_evidence's exit_code fallback yields PASSED/FAILED instead of
+    INCONCLUSIVE."""
+    recorder.emit_from_event_log(
+        session_id="syn-sess",
+        workflow_id="w",
+        milestone_id="m",
+        event_log=[
+            {
+                "type": "tool_use",
+                "tool_use_id": "syn1",
+                "tool_name": "Bash",
+                "tool_input": {"command": "pytest"},
+            },
+            {
+                "type": "tool_result",
+                "tool_use_id": "syn1",
+                "exit_code": None,
+                "is_error": False,
+                "text": "3 passed",
+            },
+        ],
+    )
+    rows = repo.query_by_session("syn-sess")
+    assert len(rows) == 1
+    assert rows[0].exit_code == 0, f"expected synthesized 0, got {rows[0].exit_code}"
+    assert (
+        rows[0].terminal_reason == "completed"
+    ), f"expected completed, got {rows[0].terminal_reason}"
+
+
+def test_emit_synthesizes_nonzero_exit_code_when_is_error(recorder, repo):
+    """is_error=True -> nonzero exit_code -> COMPLETED+FAILED (not CRASH)."""
+    recorder.emit_from_event_log(
+        session_id="syn-err-sess",
+        workflow_id="w",
+        milestone_id="m",
+        event_log=[
+            {
+                "type": "tool_use",
+                "tool_use_id": "syn2",
+                "tool_name": "Bash",
+                "tool_input": {"command": "pytest"},
+            },
+            {
+                "type": "tool_result",
+                "tool_use_id": "syn2",
+                "exit_code": None,
+                "is_error": True,
+                "text": "boom",
+            },
+        ],
+    )
+    rows = repo.query_by_session("syn-err-sess")
+    assert len(rows) == 1
+    assert rows[0].exit_code == 1
+    assert rows[0].terminal_reason == "completed"


### PR DESCRIPTION
## Root cause
After #2204 (boolean fix), \`command_execution_evidence\` rows persist but **all have \`exit_code=None\`/\`terminal_reason=crash\`** — including successful \`pytest\` runs. Claude's \`tool_result\` events carry \`is_error\` + \`content\` but **no shell \`exit_code\`\` (Claude doesn't expose it). \`emit_from_event_log\` passed \`exit_code=event.get("exit_code")\` (None) → \`derive_terminal_reason(None, has_result=True)\` → \`CRASH\`. Verified on production: all 27 rows post-#2204 are \`exit_code=None\`/\`crash\`.

## Impact (verified — lower than it first looks)
The test gate uses \`parse_test_evidence\` (**output-count parsing**, e.g. "3 passed"/"1 failed") with \`exit_code\` only as a fallback — it does **not** read \`terminal_reason\`. So the test verdict still worked (post-#2204 the gate produced real \`structured_run=passed\`/\`=failed\`). But:
1. \`terminal_reason=crash\` was wrong (cosmetic);
2. when a command's output is **unrecognized**, \`parse_test_evidence\` fell back to \`exit_code\` → \`None\` → **INCONCLUSIVE** → heuristic fallback, so those commands couldn't be structured-judged.

## Fix
In \`emit_from_event_log\`, when a \`tool_result\` event has \`exit_code is None\`, synthesize from \`is_error\` (\`False\`→0, \`True\`→1). Claude path gets a usable exit code (→ \`COMPLETED\`, and PASSED/FAILED for unrecognized output); ZCode path (which provides \`exit_code\`) is unaffected. Scoped to the recorder-only path (the agent_runner \`event_log\` that also feeds the heuristics is untouched).

Safety: for recognized test frameworks, output parsing stays authoritative (catches "1 failed" regardless of exit_code), so this can't wrongly promote a real failure to PASSED.

## Tests
Two new tests in \`tests/integration/test_command_evidence_repo.py\`: emit Claude-shaped results (\`exit_code=None\`, \`is_error\` False/True) → assert synthesized \`exit_code\` (0/1) + \`terminal_reason=completed\` (not crash). Fail-before / pass-after. Existing 13 tests unaffected.

## Deploy
One file (\`recorder.py\`) → \`/home/openace/app/\` + restart. Verify: new rows have \`terminal_reason=completed\` + \`exit_code\` 0/1; fewer INCONCLUSIVE shadow fallbacks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)