### PR TITLE
fix(webui): 主应用刷新token后通知iframe更新 (Issue #2160)

### DIFF
--- a/frontend/src/components/features/Workspace.tsx
+++ b/frontend/src/components/features/Workspace.tsx
@@ -378,6 +378,15 @@ export const Workspace: React.FC = () => {
           if (result.success && result.token) {
             console.log('[Workspace] Token refreshed successfully');
             setUserWebUI(result);
+            // Notify all iframes about the new token
+            iframeRefs.current.forEach((iframe) => {
+              if (iframe.contentWindow) {
+                iframe.contentWindow.postMessage(
+                  { type: 'openace-token-refreshed', token: result.token },
+                  '*'
+                );
+              }
+            });
           } else {
             console.error('[Workspace] Token refresh failed:', result.error);
           }
@@ -424,6 +433,15 @@ export const Workspace: React.FC = () => {
           if (result.success && result.token) {
             console.log('[Workspace] Token refreshed on visibility change');
             setUserWebUI(result);
+            // Notify all iframes about the new token
+            iframeRefs.current.forEach((iframe) => {
+              if (iframe.contentWindow) {
+                iframe.contentWindow.postMessage(
+                  { type: 'openace-token-refreshed', token: result.token },
+                  '*'
+                );
+              }
+            });
           }
         } catch (err) {
           console.error('[Workspace] Token refresh error on visibility change:', err);


### PR DESCRIPTION
## 问题

Issue #2160: AI聊天返回JSON解析错误：Unauthorized响应未正确处理

**根因**：主应用主动刷新 token 后，没有通知 iframe 更新，导致 iframe 继续使用旧 token 出现 401 错误。

## 修复内容

1. **定时检查刷新后通知 iframe**（第 377-389 行）
   - 每 60 秒检查 token 是否需要刷新
   - 刷新成功后发送 `openace-token-refreshed` 消息给 iframe

2. **Visibility change 刷新后通知 iframe**（第 432-444 行）
   - 用户切换回标签页时检查 token
   - 刷新成功后发送 `openace-token-refreshed` 消息给 iframe

## 影响范围

- 修复后 iframe 会立即收到新 token
- 避免 iframe 继续使用旧 token 导致 401 错误
- 与现有 iframe token 过期处理机制配合，形成完整闭环

## 测试

- ✅ TypeScript 类型检查通过
- ✅ ESLint 检查通过

## 关联 Issue

Fixes #2160

Generated with Qwen Code (22-shotted by Qwen-Coder)