### PR TITLE
fix(model-gateway): handle base_url with version suffix in test_connection

### DIFF
--- a/app/modules/workspace/model_gateway/service.py
+++ b/app/modules/workspace/model_gateway/service.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from app.modules.workspace.model_gateway.planner import _resolve_target_url
 from app.modules.workspace.model_gateway.repository import get_gateway_repository
 
 logger = logging.getLogger(__name__)
@@ -54,7 +55,16 @@ class ModelGatewayService:
         return self._repo.delete_config()
 
     def test_connection(self, base_url: str, api_key: str) -> dict[str, Any]:
-        """Probe the gateway with a minimal request; never echo the key back."""
+        """Probe the gateway with a minimal request; never echo the key back.
+
+        Uses planner's _resolve_target_url to handle base_url that already
+        contains version suffix (e.g., /v1, /v2) to avoid double-versioning.
+
+        Note: .rstrip("/") is CRITICAL for correct URL construction when base_url
+        ends with a slash (e.g., "http://gateway/v1/"). Without it, _resolve_target_url
+        would produce incorrect URLs like "http://gateway/v1//v1/models".
+        """
+        # CRITICAL: Must keep .rstrip("/") to handle trailing slash correctly
         base_url = (base_url or "").strip().rstrip("/")
         if not base_url:
             return {"ok": False, "status": None, "message": "Gateway base URL is required"}
@@ -62,10 +72,16 @@ class ModelGatewayService:
         try:
             import requests as http_requests
 
+            # Use planner's URL resolution logic (handles /v1, /v2, etc. deduplication)
+            # _resolve_target_url(base_url, "models") will:
+            # - Add /v1 prefix if base_url has no version suffix
+            # - Skip /v1 prefix if base_url already ends with /v{N}
+            url, _ = _resolve_target_url(base_url, "models")
+
             headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
             resp = http_requests.request(
                 method="GET",
-                url=f"{base_url}/v1/models",
+                url=url,
                 headers=headers,
                 timeout=15,
                 proxies={"http": None, "https": None},  # type: ignore[dict-item]

--- a/tests/issues/720/test_model_gateway_handler.py
+++ b/tests/issues/720/test_model_gateway_handler.py
@@ -363,5 +363,99 @@ class TestGatewayFactoryEnvOverride:
             reset_gateway_planner_for_tests()
 
 
+# ── test_connection URL deduplication ───────────────────────────────────────
+
+
+class TestModelGatewayTestConnection:
+    """Tests for test_connection URL deduplication logic (Issue #2169)."""
+
+    @pytest.mark.parametrize(
+        "base_url,expected_url",
+        [
+            # 无版本后缀：应添加 /v1
+            ("http://gateway:8000", "http://gateway:8000/v1/models"),
+            # 含 /v1 后缀：应去重
+            ("http://gateway:8000/v1", "http://gateway:8000/v1/models"),
+            # 含 /v1 后缀 + 尾部斜杠：应正确处理
+            ("http://gateway:8000/v1/", "http://gateway:8000/v1/models"),
+            # 含 /v2 后缀：应去重
+            ("http://gateway:8000/v2", "http://gateway:8000/v2/models"),
+            # 含 /v2 后缀 + 尾部斜杠：应正确处理
+            ("http://gateway:8000/v2/", "http://gateway:8000/v2/models"),
+            # 含 /v3 后缀：应去重
+            ("http://gateway:8000/v3", "http://gateway:8000/v3/models"),
+            # 非版本路径：应添加 /v1
+            ("http://gateway:8000/api", "http://gateway:8000/api/v1/models"),
+            # 混合格式 v1beta：不应去重
+            ("http://gateway:8000/v1beta", "http://gateway:8000/v1beta/v1/models"),
+        ],
+    )
+    def test_test_connection_url_deduplication(self, base_url, expected_url):
+        """验证 test_connection 对各种 base_url 格式的 URL 构建逻辑"""
+        from app.modules.workspace.model_gateway.service import ModelGatewayService
+
+        service = ModelGatewayService(repository=MagicMock())
+
+        with patch("requests.request") as mock_req:
+            mock_req.return_value.status_code = 200
+
+            result = service.test_connection(base_url, "test-key")
+
+            # 验证请求的 URL
+            called_url = mock_req.call_args.kwargs["url"]
+            assert called_url == expected_url, f"Expected {expected_url}, got {called_url}"
+            assert result["ok"] is True
+
+    def test_test_connection_with_empty_base_url(self):
+        """空 base_url 应返回错误"""
+        from app.modules.workspace.model_gateway.service import ModelGatewayService
+
+        service = ModelGatewayService(repository=MagicMock())
+
+        result = service.test_connection("", "test-key")
+
+        assert result["ok"] is False
+        assert result["message"] == "Gateway base URL is required"
+
+    def test_test_connection_with_none_base_url(self):
+        """None base_url 应返回错误"""
+        from app.modules.workspace.model_gateway.service import ModelGatewayService
+
+        service = ModelGatewayService(repository=MagicMock())
+
+        result = service.test_connection(None, "test-key")
+
+        assert result["ok"] is False
+        assert result["message"] == "Gateway base URL is required"
+
+    def test_test_connection_with_404_response(self):
+        """404 响应应返回失败"""
+        from app.modules.workspace.model_gateway.service import ModelGatewayService
+
+        service = ModelGatewayService(repository=MagicMock())
+
+        with patch("requests.request") as mock_req:
+            mock_req.return_value.status_code = 404
+
+            result = service.test_connection("http://gateway:8000/v1", "test-key")
+
+            assert result["ok"] is False
+            assert result["status"] == 404
+            assert "404" in result["message"]
+
+    def test_test_connection_with_network_error(self):
+        """网络错误应返回失败"""
+        from app.modules.workspace.model_gateway.service import ModelGatewayService
+
+        service = ModelGatewayService(repository=MagicMock())
+
+        with patch("requests.request", side_effect=Exception("Network error")):
+            result = service.test_connection("http://gateway:8000", "test-key")
+
+            assert result["ok"] is False
+            assert result["status"] is None
+            assert "unreachable" in result["message"]
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Fixes #2169 - Model Gateway Test Connection returned 404 when `base_url` already contains `/v1` suffix due to double-versioning (`/v1/v1/models`).

## Problem

When admin inputs `base_url` as `https://litellm.example.com/v1` (as suggested by UI placeholder), the test_connection method would construct URL as `/v1/v1/models`, causing 404 error and misleading admins into thinking gateway configuration is wrong.

Actual LLM proxy forwarding was not affected because `planner.py` has correct deduplication logic.

## Solution

Import and reuse `_resolve_target_url` from `planner.py` to ensure test_connection uses the same URL construction logic as actual proxy forwarding:

```python
from app.modules.workspace.model_gateway.planner import _resolve_target_url

url, _ = _resolve_target_url(base_url, "models")
```

This ensures:
- `/v1` prefix is added if base_url has no version suffix
- `/v1` prefix is skipped if base_url already ends with `/v{N}` (v1, v2, v3, etc.)
- Trailing slashes are handled correctly with `.rstrip("/")`

## Changes

- **app/modules/workspace/model_gateway/service.py**
  - Import `_resolve_target_url` from planner
  - Replace hardcoded URL construction with `_resolve_target_url`
  - Add detailed docstring explaining the fix
  
- **tests/issues/720/test_model_gateway_handler.py**
  - Add `TestModelGatewayTestConnection` test class
  - 12 test cases covering all scenarios:
    - No version suffix
    - /v1, /v2, /v3 suffixes
    - Trailing slash handling
    - Mixed formats (v1beta)
    - Error scenarios (empty URL, 404, network errors)

## Test Results

All 12 new tests passed:

```
tests/issues/720/test_model_gateway_handler.py::TestModelGatewayTestConnection::test_test_connection_url_deduplication[http://gateway:8000-http://gateway:8000/v1/models] PASSED
tests/issues/720/test_model_gateway_handler.py::TestModelGatewayTestConnection::test_test_connection_url_deduplication[http://gateway:8000/v1-http://gateway:8000/v1/models] PASSED
tests/issues/720/test_model_gateway_handler.py::TestModelGatewayTestConnection::test_test_connection_url_deduplication[http://gateway:8000/v1/-http://gateway:8000/v1/models] PASSED
tests/issues/720/test_model_gateway_handler.py::TestModelGatewayTestConnection::test_test_connection_url_deduplication[http://gateway:8000/v2-http://gateway:8000/v2/models] PASSED
tests/issues/720/test_model_gateway_handler.py::TestModelGatewayTestConnection::test_test_connection_url_deduplication[http://gateway:8000/v2/-http://gateway:8000/v2/models] PASSED
tests/issues/720/test_model_gateway_handler.py::TestModelGatewayTestConnection::test_test_connection_url_deduplication[http://gateway:8000/v3-http://gateway:8000/v3/models] PASSED
tests/issues/720/test_model_gateway_handler.py::TestModelGatewayTestConnection::test_test_connection_url_deduplication[http://gateway:8000/api-http://gateway:8000/api/v1/models] PASSED
tests/issues/720/test_model_gateway_handler.py::TestModelGatewayTestConnection::test_test_connection_url_deduplication[http://gateway:8000/v1beta-http://gateway:8000/v1beta/v1/models] PASSED
tests/issues/720/test_model_gateway_handler.py::TestModelGatewayTestConnection::test_test_connection_with_empty_base_url PASSED
tests/issues/720/test_model_gateway_handler.py::TestModelGatewayTestConnection::test_test_connection_with_none_base_url PASSED
tests/issues/720/test_model_gateway_handler.py::TestModelGatewayTestConnection::test_test_connection_with_404_response PASSED
tests/issues/720/test_model_gateway_handler.py::TestModelGatewayTestConnection::test_test_connection_with_network_error PASSED

12 passed in 0.50s
```

## Verification

Manual testing steps:
1. Login as admin, navigate to `/manage/settings/model-gateway`
2. Enter base_url: `https://litellm.example.com/v1`
3. Enter valid API key
4. Click **Test Connection** button
5. Should return "Gateway reachable" (instead of 404)

Fixes #2169