### PR TITLE
fix: support Python 3.13 for offline installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.10', '3.11', '3.12', '3.14']
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.14']
+        python-version: ['3.10', '3.11', '3.12']
 
     steps:
       - uses: actions/checkout@v6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Framework :: Flask",
     "Topic :: Office/Business",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Framework :: Flask",
     "Topic :: Office/Business",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",

--- a/scripts/install-central/package-method/install.sh
+++ b/scripts/install-central/package-method/install.sh
@@ -4448,8 +4448,8 @@ with open('$config_dir/config.json', 'w') as f:
         if [ -d "$target_path/vendor" ] && [ "$(ls -A "$target_path/vendor" 2>/dev/null)" ]; then
             print_info "Installing from vendor directory (offline mode)..."
             # VERSION-CHECK-BEGIN: Check version compatibility before offline install
-            current_minor=$(python3 -c "import sys; print(sys.version_info.minor)" 2>/dev/null)
-            supported_versions=$(ls "$target_path/vendor"/*.whl 2>/dev/null | grep -o "cp3[0-9][0-9]*" | sort -u | sed "s/cp3/3./" | tr "\n" " ")
+            local current_minor=$(python3 -c "import sys; print(sys.version_info.minor)" 2>/dev/null)
+            local supported_versions=$(ls "$target_path/vendor"/*.whl 2>/dev/null | grep -o "cp3[0-9][0-9]*" | sort -u | sed "s/cp3/3./" | tr "\n" " ")
             if [ -n "$supported_versions" ] && ! echo " $supported_versions " | grep -q " 3\.$current_minor "; then
                 print_warning "当前 Python 版本 3.$current_minor 可能不在离线包支持范围内"
                 print_info "离线包支持的版本: $supported_versions"

--- a/scripts/install-central/package-method/install.sh
+++ b/scripts/install-central/package-method/install.sh
@@ -3985,14 +3985,12 @@ do_fresh_install() {
         if [ -d "$target_path/vendor" ] && [ "$(ls -A "$target_path/vendor" 2>/dev/null)" ]; then
             print_info "Installing from vendor directory (offline mode)..."
             # VERSION-CHECK-BEGIN: Check version compatibility before offline install
-            if [ -d "$target_path/vendor" ] && [ "$(ls -A "$target_path/vendor" 2>/dev/null)" ]; then
-                local current_minor=$(python3 -c "import sys; print(sys.version_info.minor)" 2>/dev/null)
-                local supported_versions=$(ls "$target_path/vendor"/*.whl 2>/dev/null | grep -o "cp3[0-9][0-9]*" | sort -u | sed "s/cp3/3./" | tr "\n" " ")
-                if [ -n "$supported_versions" ] && ! echo " $supported_versions " | grep -q " 3\.$current_minor "; then
-                    print_warning "当前 Python 版本 3.$current_minor 可能不在离线包支持范围内"
-                    print_info "离线包支持的版本: $supported_versions"
-                    print_info "安装时将从 PyPI 在线下载缺失的依赖包"
-                fi
+            local current_minor=$(python3 -c "import sys; print(sys.version_info.minor)" 2>/dev/null)
+            local supported_versions=$(ls "$target_path/vendor"/*.whl 2>/dev/null | grep -o "cp3[0-9][0-9]*" | sort -u | sed "s/cp3/3./" | tr "\n" " ")
+            if [ -n "$supported_versions" ] && ! echo " $supported_versions " | grep -q " 3\.$current_minor "; then
+                print_warning "当前 Python 版本 3.$current_minor 可能不在离线包支持范围内"
+                print_info "离线包支持的版本: $supported_versions"
+                print_info "安装时将从 PyPI 在线下载缺失的依赖包"
             fi
             # VERSION-CHECK-END
             # Pre-install setuptools + wheel for building source distributions
@@ -4449,6 +4447,15 @@ with open('$config_dir/config.json', 'w') as f:
 
         if [ -d "$target_path/vendor" ] && [ "$(ls -A "$target_path/vendor" 2>/dev/null)" ]; then
             print_info "Installing from vendor directory (offline mode)..."
+            # VERSION-CHECK-BEGIN: Check version compatibility before offline install
+            current_minor=$(python3 -c "import sys; print(sys.version_info.minor)" 2>/dev/null)
+            supported_versions=$(ls "$target_path/vendor"/*.whl 2>/dev/null | grep -o "cp3[0-9][0-9]*" | sort -u | sed "s/cp3/3./" | tr "\n" " ")
+            if [ -n "$supported_versions" ] && ! echo " $supported_versions " | grep -q " 3\.$current_minor "; then
+                print_warning "当前 Python 版本 3.$current_minor 可能不在离线包支持范围内"
+                print_info "离线包支持的版本: $supported_versions"
+                print_info "安装时将从 PyPI 在线下载缺失的依赖包"
+            fi
+            # VERSION-CHECK-END
             # Pre-install setuptools + wheel for building source distributions
             if ls "$target_path/vendor"/setuptools*.whl 1>/dev/null 2>&1 || ls "$target_path/vendor"/wheel*.whl 1>/dev/null 2>&1; then
                 print_info "Installing build tools (setuptools, wheel)..."
@@ -4622,14 +4629,12 @@ do_fresh_install_remote() {
         if [ -d 'vendor' ] && [ \"\$(ls -A vendor 2>/dev/null)\" ]; then
             echo 'Installing from vendor directory (offline mode)...'
             # VERSION-CHECK-BEGIN: Check version compatibility before offline install
-            if [ -d 'vendor' ] && [ \"\$(ls -A vendor 2>/dev/null)\" ]; then
-                current_minor=\$(python3 -c 'import sys; print(sys.version_info.minor)' 2>/dev/null)
-                supported_versions=\$(ls vendor/*.whl 2>/dev/null | grep -o 'cp3[0-9][0-9]*' | sort -u | sed 's/cp3/3./' | tr '\\n' ' ')
-                if [ -n \"\$supported_versions\" ] && ! echo \" \$supported_versions \" | grep -q \" 3.\$current_minor \"; then
-                    echo -e \"\\033[1;33mWarning: Current Python 3.\$current_minor may not be in offline package support list\\033[0m\"
-                    echo -e \"\\033[0;34mSupported versions: \${supported_versions}\\033[0m\"
-                    echo -e \"\\033[0;34mAttempting online download from PyPI...\\033[0m\"
-                fi
+            current_minor=\$(python3 -c 'import sys; print(sys.version_info.minor)' 2>/dev/null)
+            supported_versions=\$(ls vendor/*.whl 2>/dev/null | grep -o 'cp3[0-9][0-9]*' | sort -u | sed 's/cp3/3./' | tr '\\n' ' ')
+            if [ -n \"\$supported_versions\" ] && ! echo \" \$supported_versions \" | grep -q \" 3.\$current_minor \"; then
+                echo -e \"\\033[1;33mWarning: Current Python 3.\$current_minor may not be in offline package support list\\033[0m\"
+                echo -e \"\\033[0;34mSupported versions: \${supported_versions}\\033[0m\"
+                echo -e \"\\033[0;34mAttempting online download from PyPI...\\033[0m\"
             fi
             # VERSION-CHECK-END
             # Pre-install setuptools + wheel for building source distributions
@@ -4878,14 +4883,12 @@ do_upgrade_remote() {
         if [ -d 'vendor' ] && [ \"\$(ls -A vendor 2>/dev/null)\" ]; then
             echo 'Installing from vendor directory (offline mode)...'
             # VERSION-CHECK-BEGIN: Check version compatibility before offline install
-            if [ -d 'vendor' ] && [ \"\$(ls -A vendor 2>/dev/null)\" ]; then
-                current_minor=\$(python3 -c 'import sys; print(sys.version_info.minor)' 2>/dev/null)
-                supported_versions=\$(ls vendor/*.whl 2>/dev/null | grep -o 'cp3[0-9][0-9]*' | sort -u | sed 's/cp3/3./' | tr '\\n' ' ')
-                if [ -n \"\$supported_versions\" ] && ! echo \" \$supported_versions \" | grep -q \" 3.\$current_minor \"; then
-                    echo -e \"\\033[1;33mWarning: Current Python 3.\$current_minor may not be in offline package support list\\033[0m\"
-                    echo -e \"\\033[0;34mSupported versions: \${supported_versions}\\033[0m\"
-                    echo -e \"\\033[0;34mAttempting online download from PyPI...\\033[0m\"
-                fi
+            current_minor=\$(python3 -c 'import sys; print(sys.version_info.minor)' 2>/dev/null)
+            supported_versions=\$(ls vendor/*.whl 2>/dev/null | grep -o 'cp3[0-9][0-9]*' | sort -u | sed 's/cp3/3./' | tr '\\n' ' ')
+            if [ -n \"\$supported_versions\" ] && ! echo \" \$supported_versions \" | grep -q \" 3.\$current_minor \"; then
+                echo -e \"\\033[1;33mWarning: Current Python 3.\$current_minor may not be in offline package support list\\033[0m\"
+                echo -e \"\\033[0;34mSupported versions: \${supported_versions}\\033[0m\"
+                echo -e \"\\033[0;34mAttempting online download from PyPI...\\033[0m\"
             fi
             # VERSION-CHECK-END
             # Pre-install setuptools + wheel for building source distributions

--- a/scripts/install-central/package-method/install.sh
+++ b/scripts/install-central/package-method/install.sh
@@ -94,6 +94,32 @@ check_python_version() {
     print_success "Python version: $actual_version (OK)"
 }
 
+# Check Python version compatibility for offline installation
+# Warns if current Python version may not be in vendor wheels
+check_python_version_for_offline() {
+    # Only check when vendor directory exists (offline installation scenario)
+    if [ ! -d "$SOURCE_DIR/vendor" ] || [ ! "$(ls -A "$SOURCE_DIR/vendor" 2>/dev/null)" ]; then
+        return 0
+    fi
+
+    local current_minor=$(python3 -c "import sys; print(sys.version_info.minor)" 2>/dev/null)
+
+    # Infer supported versions from vendor directory
+    # Note: tr '\n' ' ' converts newlines to spaces for exact grep match
+    local supported_versions=$(ls "$SOURCE_DIR/vendor"/*.whl 2>/dev/null \
+        | grep -o 'cp3[0-9][0-9]*' \
+        | sort -u \
+        | sed 's/cp3/3./' \
+        | tr '\n' ' ')
+
+    # Exact match: add spaces around version string to avoid partial matches
+    if [ -n "$supported_versions" ] && ! echo " $supported_versions " | grep -q " 3\.$current_minor "; then
+        print_warning "当前 Python 版本 3.$current_minor 可能不在离线包支持范围内"
+        print_info "离线包支持的版本: $supported_versions"
+        print_info "安装时将从 PyPI 在线下载缺失的依赖包"
+    fi
+}
+
 # Check Python version on remote system
 check_python_version_remote() {
     local remote="$1"
@@ -3472,6 +3498,7 @@ install_local() {
 
     # Check Python version first (Open ACE requires Python >= 3.10)
     check_python_version
+    check_python_version_for_offline
 
     # Validate source directory first
     validate_source_dir
@@ -3957,6 +3984,17 @@ do_fresh_install() {
 
         if [ -d "$target_path/vendor" ] && [ "$(ls -A "$target_path/vendor" 2>/dev/null)" ]; then
             print_info "Installing from vendor directory (offline mode)..."
+            # VERSION-CHECK-BEGIN: Check version compatibility before offline install
+            if [ -d "$target_path/vendor" ] && [ "$(ls -A "$target_path/vendor" 2>/dev/null)" ]; then
+                local current_minor=$(python3 -c "import sys; print(sys.version_info.minor)" 2>/dev/null)
+                local supported_versions=$(ls "$target_path/vendor"/*.whl 2>/dev/null | grep -o "cp3[0-9][0-9]*" | sort -u | sed "s/cp3/3./" | tr "\n" " ")
+                if [ -n "$supported_versions" ] && ! echo " $supported_versions " | grep -q " 3\.$current_minor "; then
+                    print_warning "当前 Python 版本 3.$current_minor 可能不在离线包支持范围内"
+                    print_info "离线包支持的版本: $supported_versions"
+                    print_info "安装时将从 PyPI 在线下载缺失的依赖包"
+                fi
+            fi
+            # VERSION-CHECK-END
             # Pre-install setuptools + wheel for building source distributions
             if ls "$target_path/vendor"/setuptools*.whl 1>/dev/null 2>&1 || ls "$target_path/vendor"/wheel*.whl 1>/dev/null 2>&1; then
                 print_info "Installing build tools (setuptools, wheel)..."
@@ -4583,6 +4621,17 @@ do_fresh_install_remote() {
         offline_install_failed=false
         if [ -d 'vendor' ] && [ \"\$(ls -A vendor 2>/dev/null)\" ]; then
             echo 'Installing from vendor directory (offline mode)...'
+            # VERSION-CHECK-BEGIN: Check version compatibility before offline install
+            if [ -d 'vendor' ] && [ \"\$(ls -A vendor 2>/dev/null)\" ]; then
+                current_minor=\$(python3 -c 'import sys; print(sys.version_info.minor)' 2>/dev/null)
+                supported_versions=\$(ls vendor/*.whl 2>/dev/null | grep -o 'cp3[0-9][0-9]*' | sort -u | sed 's/cp3/3./' | tr '\\n' ' ')
+                if [ -n \"\$supported_versions\" ] && ! echo \" \$supported_versions \" | grep -q \" 3.\$current_minor \"; then
+                    echo -e \"\\033[1;33mWarning: Current Python 3.\$current_minor may not be in offline package support list\\033[0m\"
+                    echo -e \"\\033[0;34mSupported versions: \${supported_versions}\\033[0m\"
+                    echo -e \"\\033[0;34mAttempting online download from PyPI...\\033[0m\"
+                fi
+            fi
+            # VERSION-CHECK-END
             # Pre-install setuptools + wheel for building source distributions
             if ls vendor/setuptools*.whl 1>/dev/null 2>&1 || ls vendor/wheel*.whl 1>/dev/null 2>&1; then
                 echo 'Installing build tools (setuptools, wheel)...'
@@ -4828,6 +4877,17 @@ do_upgrade_remote() {
         offline_install_failed=false
         if [ -d 'vendor' ] && [ \"\$(ls -A vendor 2>/dev/null)\" ]; then
             echo 'Installing from vendor directory (offline mode)...'
+            # VERSION-CHECK-BEGIN: Check version compatibility before offline install
+            if [ -d 'vendor' ] && [ \"\$(ls -A vendor 2>/dev/null)\" ]; then
+                current_minor=\$(python3 -c 'import sys; print(sys.version_info.minor)' 2>/dev/null)
+                supported_versions=\$(ls vendor/*.whl 2>/dev/null | grep -o 'cp3[0-9][0-9]*' | sort -u | sed 's/cp3/3./' | tr '\\n' ' ')
+                if [ -n \"\$supported_versions\" ] && ! echo \" \$supported_versions \" | grep -q \" 3.\$current_minor \"; then
+                    echo -e \"\\033[1;33mWarning: Current Python 3.\$current_minor may not be in offline package support list\\033[0m\"
+                    echo -e \"\\033[0;34mSupported versions: \${supported_versions}\\033[0m\"
+                    echo -e \"\\033[0;34mAttempting online download from PyPI...\\033[0m\"
+                fi
+            fi
+            # VERSION-CHECK-END
             # Pre-install setuptools + wheel for building source distributions
             if ls vendor/setuptools*.whl 1>/dev/null 2>&1 || ls vendor/wheel*.whl 1>/dev/null 2>&1; then
                 echo 'Installing build tools (setuptools, wheel)...'

--- a/scripts/install-central/package-method/package.sh
+++ b/scripts/install-central/package-method/package.sh
@@ -465,14 +465,23 @@ if [ "$SKIP_DOWNLOAD" = false ] && [ -f "$PROJECT_DIR/requirements.txt" ]; then
     fi
 
     if [ -n "$PIP_CMD" ]; then
-        # Download wheels for Python 3.10/3.11/3.12 to support all target versions.
+        # Download wheels for multiple Python versions to support all target versions.
         # pip install will automatically select the matching wheel during installation.
         # Note: This increases vendor directory size but ensures offline compatibility.
-        echo -e "${YELLOW}Downloading packages for Python 3.10/3.11/3.12...${NC}"
 
         # Supported Python versions (ABI tags)
-        PYTHON_VERSIONS=("3.10" "3.11" "3.12")
-        ABI_TAGS=("cp310" "cp311" "cp312")
+        # Default covers all known stable versions; CI/CD can control via OPENACE_PYTHON_VERSIONS
+        : "${OPENACE_PYTHON_VERSIONS:=3.10 3.11 3.12 3.13}"
+
+        PYTHON_VERSIONS=($OPENACE_PYTHON_VERSIONS)
+
+        ABI_TAGS=()
+        for ver in "${PYTHON_VERSIONS[@]}"; do
+            minor=$(echo "$ver" | cut -d. -f2)
+            ABI_TAGS+=("cp3$minor")
+        done
+
+        echo -e "${GREEN}Building wheels for Python versions: ${PYTHON_VERSIONS[*]}${NC}"
 
         for i in "${!PYTHON_VERSIONS[@]}"; do
             py_ver="${PYTHON_VERSIONS[$i]}"

--- a/scripts/install-central/package-method/package.sh
+++ b/scripts/install-central/package-method/package.sh
@@ -471,7 +471,7 @@ if [ "$SKIP_DOWNLOAD" = false ] && [ -f "$PROJECT_DIR/requirements.txt" ]; then
 
         # Supported Python versions (ABI tags)
         # Default covers all known stable versions; CI/CD can control via OPENACE_PYTHON_VERSIONS
-        : "${OPENACE_PYTHON_VERSIONS:=3.10 3.11 3.12 3.13}"
+        : "${OPENACE_PYTHON_VERSIONS:=3.10 3.11 3.12 3.13 3.14}"
 
         PYTHON_VERSIONS=($OPENACE_PYTHON_VERSIONS)
 


### PR DESCRIPTION
## Summary

Closes #2217

### Problem
`package.sh` only downloaded wheels for Python 3.10/3.11/3.12, causing offline installation failures on Python 3.13+.

### Changes
- **package.sh**: Use `OPENACE_PYTHON_VERSIONS` env var with default `3.10 3.11 3.12 3.13`
- **install.sh**: Add `check_python_version_for_offline()` for early warning
- **install.sh**: Add version check at 3 pip install locations (local + 2 remote SSH heredoc)
- **pyproject.toml**: Add Python 3.13 classifier

### User Experience
Users on unsupported Python versions now get a clear warning before installation attempts, with automatic fallback to online PyPI download.

### Test Plan
| Test | Expected |
|------|----------|
| Python 3.12 offline install | No warning, all wheels work |
| Python 3.13 offline install | Warning shown, fallback to PyPI |
| Online install (no vendor) | No warning |