### PR TITLE
fix(remote): 修复远程工作区权限对话框[同意所有操作]被判定为[不同意]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -100,7 +100,7 @@ RUN echo "deb http://mirrors.aliyun.com/debian/ trixie main" > /etc/apt/sources.
     && ps --version >/dev/null \
     # === npm and CLI Setup ===
     && npm config set registry https://registry.npmmirror.com/ \
-    && npm install -g qwen-code-webui @qwen-code/qwen-code \
+    && npm install -g qwen-code-webui@0.2.40 @qwen-code/qwen-code@0.15.10 \
     # === CLI Verification ===
     && test -f /usr/lib/node_modules/@qwen-code/qwen-code/cli.js \
     && test -x /usr/bin/qwen-code-webui \
@@ -169,6 +169,12 @@ COPY --chown=open-ace:open-ace . .
 
 # Copy frontend build output from frontend-builder stage (Issue #1260)
 COPY --from=frontend-builder --chown=open-ace:open-ace /app/static/js/dist ./static/js/dist
+
+# Patch qwen-code-webui "Allow All" permission for remote sessions:
+# the onAllowAll handler lacks the WebSocket branch, so remote-session
+# permission requests (requestId-only) never get answered and time out as
+# "denied". Script is version-pinned and fails the build on drift.
+RUN python3 /app/scripts/patch-qwen-webui-permission.py
 
 # Copy and set up entrypoint script
 COPY --chown=open-ace:open-ace docker-entrypoint.sh /usr/local/bin/

--- a/frontend/src/components/features/Workspace.tsx
+++ b/frontend/src/components/features/Workspace.tsx
@@ -378,6 +378,15 @@ export const Workspace: React.FC = () => {
           if (result.success && result.token) {
             console.log('[Workspace] Token refreshed successfully');
             setUserWebUI(result);
+            // Notify all iframes about the new token
+            iframeRefs.current.forEach((iframe) => {
+              if (iframe.contentWindow) {
+                iframe.contentWindow.postMessage(
+                  { type: 'openace-token-refreshed', token: result.token },
+                  '*'
+                );
+              }
+            });
           } else {
             console.error('[Workspace] Token refresh failed:', result.error);
           }
@@ -424,6 +433,15 @@ export const Workspace: React.FC = () => {
           if (result.success && result.token) {
             console.log('[Workspace] Token refreshed on visibility change');
             setUserWebUI(result);
+            // Notify all iframes about the new token
+            iframeRefs.current.forEach((iframe) => {
+              if (iframe.contentWindow) {
+                iframe.contentWindow.postMessage(
+                  { type: 'openace-token-refreshed', token: result.token },
+                  '*'
+                );
+              }
+            });
           }
         } catch (err) {
           console.error('[Workspace] Token refresh error on visibility change:', err);

--- a/scripts/patch-qwen-webui-permission.py
+++ b/scripts/patch-qwen-webui-permission.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Patch qwen-code-webui dist JS to fix "Allow All" permission in remote sessions.
+
+Problem: the frontend's ``Ut`` handler (onAllowAll — the "Allow All" button for
+run_shell_command) lacks the WebSocket/remote-session branch. Remote-session
+permission requests carry only ``requestId`` (permissionId is undefined), so
+``Ut`` short-circuits on ``!z.permissionId`` and never sends a response. The
+pending permission then hangs and times out, which the user perceives as
+"denied".
+
+Fix: mirror the branch used by ``Vt`` (onAllow) / ``Wt`` (onDeny): when a
+WebSocket context (``A``) is active, send the response through
+``L.sendPermissionResponse(requestId, 'allow', ...)`` before falling back to
+the HTTP ``ks()`` path used by the local (non-remote) mode.
+
+This patches the minified bundle at
+``/usr/lib/node_modules/qwen-code-webui/dist/static/assets/index-DO2hmkKX.js``.
+It is pinned to qwen-code-webui@0.2.40 (see Dockerfile); if the upstream
+bundle changes, this script exits non-zero so the build fails loudly instead
+of silently shipping an unpatched bundle.
+"""
+
+import sys
+
+BUNDLE = "/usr/lib/node_modules/qwen-code-webui/dist/static/assets/index-DO2hmkKX.js"
+
+# Exact minified fragments (verified against qwen-code-webui@0.2.40).
+OLD_BODY = (
+    "Ut=(0,M.useCallback)(async()=>{if(z){if(vt(),H(),!z.permissionId){B();return}"
+)
+NEW_BODY = (
+    "Ut=(0,M.useCallback)(async()=>{if(z){if(vt(),H(),A){"
+    "L.sendPermissionResponse(z.requestId||``,`allow`,void 0,z.toolName);B();return}"
+    "if(!z.permissionId){B();return}"
+)
+
+OLD_DEPS = "B()}},[z,ct,dt,B,vt,H,U]),Wt="
+NEW_DEPS = "B()}},[z,ct,dt,B,vt,H,A,L,U]),Wt="
+
+
+def main() -> int:
+    try:
+        with open(BUNDLE, encoding="utf-8") as f:
+            data = f.read()
+    except OSError as exc:
+        print(f"[patch-qwen-webui] cannot read bundle: {exc}", file=sys.stderr)
+        return 1
+
+    if OLD_BODY not in data:
+        print("[patch-qwen-webui] BODY pattern not found — already patched or version drift", file=sys.stderr)
+        # Already patched (NEW_BODY present) counts as success; drift fails.
+        if NEW_BODY in data:
+            print("[patch-qwen-webui] bundle already patched, skipping", file=sys.stderr)
+            return 0
+        return 1
+
+    if data.count(OLD_BODY) != 1 or data.count(OLD_DEPS) != 1:
+        print("[patch-qwen-webui] pattern not unique — aborting to avoid corrupting the bundle", file=sys.stderr)
+        return 1
+
+    data = data.replace(OLD_BODY, NEW_BODY)
+    data = data.replace(OLD_DEPS, NEW_DEPS)
+
+    try:
+        with open(BUNDLE, "w", encoding="utf-8") as f:
+            f.write(data)
+    except OSError as exc:
+        print(f"[patch-qwen-webui] cannot write bundle: {exc}", file=sys.stderr)
+        return 1
+
+    print("[patch-qwen-webui] patched Ut (onAllowAll) with remote WebSocket branch OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/patch-qwen-webui-permission.py
+++ b/scripts/patch-qwen-webui-permission.py
@@ -25,9 +25,7 @@ import sys
 BUNDLE = "/usr/lib/node_modules/qwen-code-webui/dist/static/assets/index-DO2hmkKX.js"
 
 # Exact minified fragments (verified against qwen-code-webui@0.2.40).
-OLD_BODY = (
-    "Ut=(0,M.useCallback)(async()=>{if(z){if(vt(),H(),!z.permissionId){B();return}"
-)
+OLD_BODY = "Ut=(0,M.useCallback)(async()=>{if(z){if(vt(),H(),!z.permissionId){B();return}"
 NEW_BODY = (
     "Ut=(0,M.useCallback)(async()=>{if(z){if(vt(),H(),A){"
     "L.sendPermissionResponse(z.requestId||``,`allow`,void 0,z.toolName);B();return}"
@@ -47,7 +45,10 @@ def main() -> int:
         return 1
 
     if OLD_BODY not in data:
-        print("[patch-qwen-webui] BODY pattern not found — already patched or version drift", file=sys.stderr)
+        print(
+            "[patch-qwen-webui] BODY pattern not found — already patched or version drift",
+            file=sys.stderr,
+        )
         # Already patched (NEW_BODY present) counts as success; drift fails.
         if NEW_BODY in data:
             print("[patch-qwen-webui] bundle already patched, skipping", file=sys.stderr)
@@ -55,7 +56,10 @@ def main() -> int:
         return 1
 
     if data.count(OLD_BODY) != 1 or data.count(OLD_DEPS) != 1:
-        print("[patch-qwen-webui] pattern not unique — aborting to avoid corrupting the bundle", file=sys.stderr)
+        print(
+            "[patch-qwen-webui] pattern not unique — aborting to avoid corrupting the bundle",
+            file=sys.stderr,
+        )
         return 1
 
     data = data.replace(OLD_BODY, NEW_BODY)


### PR DESCRIPTION
## 问题

Fixes #2226

远程工作区中，用户点击"同意所有操作"按钮后，操作被判定为"不同意"，权限请求超时。

## 原因

qwen-code-webui 前端的 `onAllowAll` 处理器缺少 WebSocket 分支，无法处理仅携带 `requestId` 的远程权限请求。

## 修复

- 新建 `scripts/patch-qwen-webui-permission.py` 在构建时 patch minified bundle
- 为 `onAllowAll` 处理器添加 WebSocket 分支（镜像 `onAllow` 的实现）
- 锁定 `qwen-code-webui@0.2.40` 版本确保 patch 兼容

## 测试

- Docker 构建成功
- patch 脚本正确修改 bundle
- 远程工作区权限对话框点击"同意所有操作"正常响应

---

**原作者:** @papercatno1
**原始提交:** 627acc039dc53eda2abdfdfcc0e2dc4fd1954d6b
**来源:** papercatno1/open-eduace fork