### PR TITLE
fix(analytics): 修复仪表盘时间范围统计 QWEN 数据为 0 的问题

### DIFF
--- a/scripts/fetch_qwen.py
+++ b/scripts/fetch_qwen.py
@@ -1267,7 +1267,13 @@ def fetch_and_save(
             # rows were written with user_id NULL).
             user_id = _resolve_user_id(db, system_account)
             files_processed = _process_projects_dir(
-                user_project_dir, hostname, system_account, aggregated, all_messages, recent, user_id
+                user_project_dir,
+                hostname,
+                system_account,
+                aggregated,
+                all_messages,
+                recent,
+                user_id,
             )
             total_files += files_processed
 

--- a/scripts/fetch_qwen.py
+++ b/scripts/fetch_qwen.py
@@ -407,7 +407,10 @@ def extract_content_blocks_from_entry(
 
 
 def process_jsonl_file(
-    filepath: Path, hostname: str = "localhost", system_account: str | None = None
+    filepath: Path,
+    hostname: str = "localhost",
+    system_account: str | None = None,
+    user_id: int | None = None,
 ) -> tuple:
     """Process a single JSONL file and return daily token aggregates and messages.
 
@@ -415,6 +418,9 @@ def process_jsonl_file(
         filepath: Path to the JSONL file
         hostname: Host name for this machine
         system_account: System account (linux/mac username) for multi-user mode
+        user_id: Resolved users.id for the sender, used to populate the
+            daily_messages.user_id column so tenant-scoped queries (summary,
+            analysis) can attribute these messages to the right tenant.
 
     Returns:
         tuple: (daily_stats dict, messages list)
@@ -617,6 +623,7 @@ def process_jsonl_file(
                                         if system_account
                                         else get_default_sender_name("qwen")
                                     ),
+                                    "user_id": user_id,
                                     "agent_session_id": agent_session_id,
                                     "conversation_id": conversation_id,
                                     "project_path": project_path,
@@ -727,6 +734,35 @@ def find_qwen_project_dir() -> Path | None:
     return None
 
 
+def _resolve_user_id(db, system_account: str | None) -> int | None:
+    """Resolve users.id for a system_account/username, or None if unknown.
+
+    The daily_messages.user_id column drives tenant-scoped queries
+    (get_summary_by_tool etc. filter ``user_id IN (users of tenant)``).
+    Fetched messages historically wrote user_id as NULL, which made those
+    queries miss qwen rows entirely. Resolving here restores attribution.
+    """
+    if not system_account:
+        return None
+    try:
+        from shared.db import _execute, _placeholder, get_connection
+
+        conn = get_connection()
+        cursor = conn.cursor()
+        placeholder = _placeholder()
+        _execute(
+            cursor,
+            f"SELECT id FROM users WHERE system_account = {placeholder} OR username = {placeholder}",
+            (system_account, system_account),
+        )
+        row = cursor.fetchone()
+        conn.close()
+        return row["id"] if row else None
+    except Exception as e:
+        print(f"Warning: failed to resolve user_id for {system_account}: {e}")
+        return None
+
+
 def _process_projects_dir(
     project_dir: Path,
     hostname: str,
@@ -734,6 +770,7 @@ def _process_projects_dir(
     aggregated: dict,
     all_messages: list,
     recent: bool = False,
+    user_id: int | None = None,
 ) -> int:
     """
     Process a qwen projects directory and aggregate results.
@@ -790,7 +827,7 @@ def _process_projects_dir(
         print(f"  Scanning: {proj_dir.name} ({len(jsonl_files)} files{suffix})")
         for f in jsonl_files:
             total_files += 1
-            daily, messages = process_jsonl_file(f, hostname, system_account)
+            daily, messages = process_jsonl_file(f, hostname, system_account, user_id)
             # Aggregate daily stats
             for date, stats in daily.items():
                 for key in [
@@ -1224,8 +1261,13 @@ def fetch_and_save(
         total_files = 0
         for system_account, user_project_dir in user_projects:
             print(f"\nProcessing user: {system_account}")
+            # Resolve the user_id once per system_account so tenant-scoped
+            # queries can attribute these messages (Issue: time-range summary
+            # showed 0 tokens while daily_usage had data, because daily_messages
+            # rows were written with user_id NULL).
+            user_id = _resolve_user_id(db, system_account)
             files_processed = _process_projects_dir(
-                user_project_dir, hostname, system_account, aggregated, all_messages, recent
+                user_project_dir, hostname, system_account, aggregated, all_messages, recent, user_id
             )
             total_files += files_processed
 
@@ -1239,7 +1281,7 @@ def fetch_and_save(
             return False
 
         total_files = _process_projects_dir(
-            project_dir, hostname, None, aggregated, all_messages, recent
+            project_dir, hostname, None, aggregated, all_messages, recent, None
         )
 
     print(f"\nProcessed {total_files} files, {len(all_messages)} messages")

--- a/scripts/shared/db.py
+++ b/scripts/shared/db.py
@@ -996,7 +996,7 @@ def save_messages_batch(messages: list[dict], batch_size: int = 1000) -> int:
                 _execute(
                     cursor,
                     """
-                    SELECT message_id, tokens_used, input_tokens, output_tokens, sender_id, sender_name, model
+                    SELECT message_id, tokens_used, input_tokens, output_tokens, sender_id, sender_name, model, user_id
                     FROM daily_messages
                     WHERE date = %s AND tool_name = %s AND host_name = %s
                 """,
@@ -1006,7 +1006,7 @@ def save_messages_batch(messages: list[dict], batch_size: int = 1000) -> int:
                 _execute(
                     cursor,
                     """
-                    SELECT message_id, tokens_used, input_tokens, output_tokens, sender_id, sender_name, model
+                    SELECT message_id, tokens_used, input_tokens, output_tokens, sender_id, sender_name, model, user_id
                     FROM daily_messages
                     WHERE date = ? AND tool_name = ? AND host_name = ?
                 """,
@@ -1026,6 +1026,7 @@ def save_messages_batch(messages: list[dict], batch_size: int = 1000) -> int:
                         "sender_id": row[4],
                         "sender_name": row[5],
                         "model": row[6],
+                        "user_id": row[7],
                     }
 
         # Process messages in batches
@@ -1045,6 +1046,7 @@ def save_messages_batch(messages: list[dict], batch_size: int = 1000) -> int:
                 sender_id = msg.get("sender_id")
                 sender_name = msg.get("sender_name")
                 model = msg.get("model")
+                user_id = msg.get("user_id")
 
                 # Normalize the role at the write boundary (toolResult /
                 # tool_result -> tool) so variant spellings never reach the
@@ -1085,14 +1087,17 @@ def save_messages_batch(messages: list[dict], batch_size: int = 1000) -> int:
                     # Preserve model if new value is None and existing value exists
                     if model is None and existing.get("model"):
                         model = existing["model"]
+                    # Preserve user_id if new value is None and existing value exists
+                    if user_id is None and existing.get("user_id") is not None:
+                        user_id = existing["user_id"]
 
                 if is_postgresql():
                     _execute(
                         cursor,
                         """
                         INSERT INTO daily_messages
-                        (date, tool_name, host_name, message_id, parent_id, role, content, full_entry, tokens_used, input_tokens, output_tokens, model, timestamp, sender_id, sender_name, message_source, feishu_conversation_id, group_subject, is_group_chat, agent_session_id, conversation_id)
-                        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                        (date, tool_name, host_name, message_id, parent_id, role, content, full_entry, tokens_used, input_tokens, output_tokens, model, timestamp, sender_id, sender_name, message_source, feishu_conversation_id, group_subject, is_group_chat, agent_session_id, conversation_id, user_id)
+                        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
                         ON CONFLICT (date, tool_name, host_name, message_id) DO UPDATE SET
                             parent_id = EXCLUDED.parent_id,
                             role = EXCLUDED.role,
@@ -1110,7 +1115,8 @@ def save_messages_batch(messages: list[dict], batch_size: int = 1000) -> int:
                             group_subject = EXCLUDED.group_subject,
                             is_group_chat = EXCLUDED.is_group_chat,
                             agent_session_id = EXCLUDED.agent_session_id,
-                            conversation_id = EXCLUDED.conversation_id
+                            conversation_id = EXCLUDED.conversation_id,
+                            user_id = EXCLUDED.user_id
                     """,
                         (
                             date,
@@ -1134,6 +1140,7 @@ def save_messages_batch(messages: list[dict], batch_size: int = 1000) -> int:
                             msg.get("is_group_chat"),
                             msg.get("agent_session_id"),
                             msg.get("conversation_id"),
+                            user_id,
                         ),
                     )
                 else:
@@ -1141,8 +1148,8 @@ def save_messages_batch(messages: list[dict], batch_size: int = 1000) -> int:
                         cursor,
                         """
                         INSERT OR REPLACE INTO daily_messages
-                        (date, tool_name, host_name, message_id, parent_id, role, content, full_entry, tokens_used, input_tokens, output_tokens, model, timestamp, sender_id, sender_name, message_source, feishu_conversation_id, group_subject, is_group_chat, agent_session_id, conversation_id)
-                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        (date, tool_name, host_name, message_id, parent_id, role, content, full_entry, tokens_used, input_tokens, output_tokens, model, timestamp, sender_id, sender_name, message_source, feishu_conversation_id, group_subject, is_group_chat, agent_session_id, conversation_id, user_id)
+                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                         (
                             date,
@@ -1166,6 +1173,7 @@ def save_messages_batch(messages: list[dict], batch_size: int = 1000) -> int:
                             msg.get("is_group_chat"),
                             msg.get("agent_session_id"),
                             msg.get("conversation_id"),
+                            user_id,
                         ),
                     )
 

--- a/tests/unit/test_fetch_codex.py
+++ b/tests/unit/test_fetch_codex.py
@@ -292,6 +292,7 @@ def test_reimport_replaces_stale_codex_session_rows(monkeypatch, tmp_path):
             is_group_chat INTEGER,
             agent_session_id TEXT,
             conversation_id TEXT,
+            user_id integer,
             PRIMARY KEY (date, tool_name, host_name, message_id)
         )
         """

--- a/tests/unit/test_fetch_zcode.py
+++ b/tests/unit/test_fetch_zcode.py
@@ -251,7 +251,8 @@ def _init_dest_schema(db_path: Path) -> None:
             sender_name TEXT,
             timestamp TEXT,
             agent_session_id TEXT,
-            conversation_id TEXT
+            conversation_id TEXT,
+            user_id integer
         );
         CREATE UNIQUE INDEX idx_daily_messages_unique
         ON daily_messages (date, tool_name, host_name, message_id);

--- a/tests/unit/test_message_role_normalization.py
+++ b/tests/unit/test_message_role_normalization.py
@@ -181,6 +181,7 @@ class TestSharedDbWriteBoundary:
                 is_group_chat INTEGER,
                 agent_session_id TEXT,
                 conversation_id TEXT,
+                user_id integer,
                 PRIMARY KEY (date, tool_name, host_name, message_id)
             )
             """


### PR DESCRIPTION
## 问题

Fixes #2228

仪表盘"今日使用量"显示 QWEN 数据，但"时间范围统计"中 QWEN 为 0。

## 原因

两张表的租户维度字段不一致：
- `daily_usage` 用 `tenant_id` 做租户隔离
- `daily_messages` 用 `user_id` 做租户隔离，但 fetch 写入时不写 `user_id`

## 修复

- `scripts/shared/db.py`: `save_messages_batch` 增加 `user_id` 列支持
- `scripts/fetch_qwen.py`: 新增 `_resolve_user_id()` 查询用户 ID

## 测试

- 时间范围统计正确显示 QWEN 数据
- 租户隔离正常工作

---

**原作者:** @papercatno1
**原始提交:** 627acc039dc53eda2abdfdfcc0e2dc4fd1954d6b
**来源:** papercatno1/open-eduace fork