### PR TITLE
fix: handle Unicode surrogate characters for Python 3.13+ compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
       - uses: actions/checkout@v6

--- a/scripts/shared/config.py
+++ b/scripts/shared/config.py
@@ -14,16 +14,42 @@ import os
 from typing import Optional, cast
 from urllib.parse import quote
 
+
+def _safe_path(path: str) -> str:
+    """
+    Ensure path is safe for UTF-8 encoding.
+
+    Python 3.13+ has stricter handling of Unicode surrogate characters.
+    This function ensures that path strings can be safely encoded to UTF-8.
+
+    Args:
+        path: Input path string that may contain invalid characters
+
+    Returns:
+        Safe path string with invalid characters replaced
+    """
+    if not path:
+        return path
+    try:
+        # Try to encode - if it works, the path is safe
+        path.encode("utf-8")
+        return path
+    except UnicodeEncodeError:
+        # Remove invalid surrogate characters by encoding with surrogatepass
+        # and then decoding with replace errors
+        return path.encode("utf-8", errors="surrogatepass").decode("utf-8", errors="replace")
+
+
 # Configuration directory path
 # This is the main configuration that should be set during installation
-CONFIG_DIR = os.path.expanduser("~/.open-ace")
+CONFIG_DIR = _safe_path(os.path.expanduser("~/.open-ace"))
 CONFIG_PATH = os.path.join(CONFIG_DIR, "config.json")
 DB_DIR = CONFIG_DIR  # Database is stored in the same directory
 DB_PATH = os.path.join(DB_DIR, "ace.db")
 
 # Remote user name - default is 'openclaw' but can be overridden
 # This is used for remote deployment and fetching data from remote machines
-REMOTE_USER = os.environ.get("AI_TOKEN_REMOTE_USER", "openclaw")
+REMOTE_USER = _safe_path(os.environ.get("AI_TOKEN_REMOTE_USER", "openclaw"))
 
 # Remote configuration directory on remote machines
 # This is used when deploying to or fetching data from remote machines

--- a/scripts/shared/db.py
+++ b/scripts/shared/db.py
@@ -106,7 +106,7 @@ def sanitize_utf8(text: str | None) -> str | None:
     """
     Sanitize text to remove invalid UTF-8 surrogate characters and NUL characters.
 
-    Some messages may contain invalid UTF-8 surrogate pairs (e.g., \udcdd)
+    Some messages may contain invalid UTF-8 surrogate pairs (e.g., \\udcdd)
     which cannot be encoded to UTF-8. NUL characters (\\x00) are also removed
     because PostgreSQL does not support them in string literals.
 


### PR DESCRIPTION
## Summary

Closes #2224

### Problem
Python 3.13+ has stricter handling of Unicode surrogate characters. When importing `scripts.shared.config`, a `UnicodeEncodeError` could occur if path strings contain invalid surrogate characters.

### Changes
- Add `_safe_path()` function to sanitize paths before use
- Apply to `CONFIG_DIR` and `REMOTE_USER` environment variables
- Uses `surrogatepass`/`replace` error handlers for graceful degradation

### Testing
- Re-enabled Python 3.13 and 3.14 in CI test matrix
- All Python versions (3.10-3.14) should now pass tests

### Related
- Issue #2224
- PR #2219 (where this bug was discovered)