### PR TITLE
fix(workspace): 修复多用户工作区初始化失败问题

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,8 @@ services:
     image: ${IMAGE_NAME:-openace/open-ace:latest}
     container_name: open-ace
     restart: unless-stopped
+    # Multi-user workspace mode requires root to create system users (useradd)
+    user: "0"
     ports:
       - "${PORT:-19888}:19888"
       # Multi-user workspace: expose port range for qwen-code-webui instances


### PR DESCRIPTION
## 问题

Fixes #2242

普通用户登录后工作区无法加载，iframe 为空白。

## 原因

Docker 容器默认以非 root 用户运行，而多用户模式需要 root 权限。

## 修复

添加 `user: "0"` 使容器以 root 运行。

---

**原作者:** @papercatno1
**原始提交:** 627acc039dc53eda2abdfdfcc0e2dc4fd1954d6b