### PR TITLE
fix(remote): 修复新建文件夹误报 Machine is offline 问题

### DIFF
--- a/app/routes/remote.py
+++ b/app/routes/remote.py
@@ -3318,7 +3318,7 @@ def create_remote_directory(machine_id):
     if not machine:
         return jsonify({"error": "Machine not found"}), 404
 
-    if machine.get("status") not in ("online", "idle"):
+    if machine.get("status") not in ("online", "idle", "busy"):
         return (
             jsonify(
                 {


### PR DESCRIPTION
## 问题

Fixes #2246

远程工作区浏览目录时新建文件夹误报"Machine is offline"。

## 原因

create_remote_directory 不接受 busy 状态。

## 修复

将 busy 添加到状态白名单。

---

**原作者:** @papercatno1
**原始提交:** 627acc039dc53eda2abdfdfcc0e2dc4fd1954d6b