### PR TITLE
fix(autonomous): retry genuine no-code-change CI repair rounds (#2187)

### DIFF
--- a/app/modules/workspace/autonomous/models.py
+++ b/app/modules/workspace/autonomous/models.py
@@ -80,6 +80,7 @@ class AutonomousWorkflow:
     ci_repair_attempts: int = 0
     ci_diagnostics_attempts: int = 0
     ci_repair_transient_retries: int = 0
+    ci_repair_no_change_retries: int = 0
     last_ci_failure_signature: str = ""
     last_ci_failure_head_sha: str = ""
     # Source of truth for AI-authored content language (en/zh/ja/ko). Set once
@@ -168,6 +169,7 @@ class AutonomousWorkflow:
             "ci_repair_attempts": self.ci_repair_attempts,
             "ci_diagnostics_attempts": self.ci_diagnostics_attempts,
             "ci_repair_transient_retries": self.ci_repair_transient_retries,
+            "ci_repair_no_change_retries": self.ci_repair_no_change_retries,
             "last_ci_failure_signature": self.last_ci_failure_signature,
             "last_ci_failure_head_sha": self.last_ci_failure_head_sha,
             "content_language": self.content_language,
@@ -238,6 +240,7 @@ class AutonomousWorkflow:
             ci_repair_attempts=data.get("ci_repair_attempts", 0),
             ci_diagnostics_attempts=data.get("ci_diagnostics_attempts", 0),
             ci_repair_transient_retries=data.get("ci_repair_transient_retries", 0),
+            ci_repair_no_change_retries=data.get("ci_repair_no_change_retries", 0),
             last_ci_failure_signature=data.get("last_ci_failure_signature", ""),
             last_ci_failure_head_sha=data.get("last_ci_failure_head_sha", ""),
             content_language=data.get("content_language", "en"),

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -890,6 +890,13 @@ MAX_CI_REPAIR_ATTEMPTS = 5  # max automatic dev-round retries for merge-phase CI
 # not loop forever, but must allow more retries than the 5-attempt budget
 # (which is consumed only by real agent repair attempts, not infra glitches).
 MAX_CI_REPAIR_TRANSIENT_RETRIES = 6
+# Separate cap for genuine no-code-change deferrals during CI repair: an agent
+# that runs cleanly but commits nothing must not loop forever, and the bound is
+# deliberately smaller than the transient budget (6) because no-change is
+# closer to "agent is stuck" than "infra glitch". No-change rounds do NOT
+# consume a real ci_repair_attempts slot, so MAX_CI_REPAIR_ATTEMPTS=5 is
+# preserved for rounds that produce changes (#2187).
+MAX_CI_REPAIR_NO_CHANGE_RETRIES = 2  # consecutive genuine no-change rounds before giving up
 MAX_PRE_COMMIT_CONVERGENCE_PASSES = 3
 PRE_COMMIT_CONVERGENCE_TIMEOUT = 600
 CI_PRE_COMMIT_SKIP = "bandit,no-commit-to-branch"
@@ -2491,14 +2498,23 @@ class AutonomousOrchestrator:
             # the next fresh prompt. (#1816 review suggestion)
             if self._is_context_overflow(repair_result):
                 message = f"CI repair failed: context overflow - {repair_result.error}"
+                terminal = True
             elif primary_error := self._primary_result_error(repair_result):
                 message = f"CI repair agent failed before producing code changes: {primary_error}"
+                terminal = True
             else:
-                message = "CI repair failed: agent produced no code changes"
+                # Genuine no-change: the agent ran cleanly but committed nothing.
+                # Defer (don't terminal-fail) so it gets a bounded retry — see
+                # MAX_CI_REPAIR_NO_CHANGE_RETRIES in _start_ci_repair_round (#2187).
+                message = "CI repair deferred: agent produced no code changes"
+                terminal = False
             milestone_updates["status"] = "failed"
             milestone_updates["error_message"] = message
             self.repo.update_milestone(repair_ms.get("milestone_id", ""), milestone_updates)
-            self._update_workflow({"status": "failed", "error_message": message})
+            if terminal:
+                self._update_workflow({"status": "failed", "error_message": message})
+            else:
+                self._update_workflow({"status": "merging", "error_message": message})
             return
 
         if not repair_result.success and not salvaged:
@@ -3479,7 +3495,11 @@ class AutonomousOrchestrator:
         # total transient deferrals so a sustained outage cannot loop forever.
         prev_error = wf.get("error_message", "") or ""
         is_transient_deferred = prev_error.startswith("CI repair deferred: transient API error")
+        is_no_change_deferred = prev_error.startswith(
+            "CI repair deferred: agent produced no code changes"
+        )
         transient_retries = int(wf.get("ci_repair_transient_retries", 0) or 0)
+        no_change_retries = int(wf.get("ci_repair_no_change_retries", 0) or 0)
         if is_transient_deferred:
             if transient_retries >= MAX_CI_REPAIR_TRANSIENT_RETRIES:
                 message = (
@@ -3501,9 +3521,39 @@ class AutonomousOrchestrator:
             # as a transient-retry counter (reset to 0 on a successful round).
             next_attempt = previous_attempts
             transient_retries += 1
+        elif is_no_change_deferred:
+            # Genuine no-code-change deferral: the agent ran cleanly but
+            # committed nothing. Defer to a bounded retry budget that does NOT
+            # consume a real ci_repair_attempts slot (same separation transient
+            # enjoys), so a single empty round no longer terminal-fails the
+            # workflow (#2187). Bound: see MAX_CI_REPAIR_NO_CHANGE_RETRIES.
+            if no_change_retries >= MAX_CI_REPAIR_NO_CHANGE_RETRIES:
+                message = (
+                    f"CI repair failed: agent produced no code changes across "
+                    f"{MAX_CI_REPAIR_NO_CHANGE_RETRIES} consecutive retries"
+                )
+                self._create_milestone(
+                    phase="merge",
+                    dev_round=dev_round,
+                    round_number=previous_attempts,
+                    milestone_type="ci_repair_no_change_exhausted",
+                    status="failed",
+                    title=(
+                        f"CI repair abandoned: agent produced no changes across "
+                        f"{MAX_CI_REPAIR_NO_CHANGE_RETRIES} retries"
+                    ),
+                    error_message=message,
+                )
+                self._update_workflow({"status": "failed", "error_message": message})
+                return
+            # Don't increment ci_repair_attempts; bump the no-change counter
+            # (reset to 0 on a change-producing round).
+            next_attempt = previous_attempts
+            no_change_retries += 1
         else:
             next_attempt = previous_attempts + 1
             transient_retries = 0
+            no_change_retries = 0
         preferred_worktree_path = self._get_preferred_worktree_path(wf)
         gh = self._get_gh()
         current_head_sha = ""
@@ -3597,6 +3647,16 @@ class AutonomousOrchestrator:
                     f"(awaiting CI diagnostics: {excerpt_count}/{actionable_count} "
                     f"logs; poll {diagnostics_attempt}/{MAX_CI_DIAGNOSTICS_ATTEMPTS})"
                 )
+            elif is_no_change_deferred:
+                # Preserve the no-change signal so the next _start_ci_repair_round
+                # call still classifies this as a no-change retry (mirrors the
+                # transient guard above; without this the diagnostics-incomplete
+                # message would clobber the prefix and lose the retry budget).
+                message = (
+                    "CI repair deferred: agent produced no code changes "
+                    f"(awaiting CI diagnostics: {excerpt_count}/{actionable_count} "
+                    f"logs; poll {diagnostics_attempt}/{MAX_CI_DIAGNOSTICS_ATTEMPTS})"
+                )
             else:
                 message = (
                     f"PR #{pr_number} CI diagnostics incomplete "
@@ -3628,6 +3688,7 @@ class AutonomousOrchestrator:
                         "error_message": terminal,
                         "ci_diagnostics_attempts": diagnostics_attempt,
                         "ci_repair_transient_retries": transient_retries,
+                        "ci_repair_no_change_retries": no_change_retries,
                     }
                 )
                 return
@@ -3637,9 +3698,10 @@ class AutonomousOrchestrator:
                     "status": "merging",
                     "error_message": message,
                     "ci_diagnostics_attempts": diagnostics_attempt,
-                    # Persist the in-memory transient counter so it survives
-                    # across diagnostics polling cycles (#1820).
+                    # Persist the in-memory counters so they survive across
+                    # diagnostics polling cycles (#1820, #2187).
                     "ci_repair_transient_retries": transient_retries,
+                    "ci_repair_no_change_retries": no_change_retries,
                 }
             )
             return
@@ -3746,6 +3808,7 @@ class AutonomousOrchestrator:
             "error_message": "",
             "ci_repair_attempts": next_attempt,
             "ci_repair_transient_retries": transient_retries,
+            "ci_repair_no_change_retries": no_change_retries,
             # Reset the diagnostics poll counter: each (re-)entry into a CI
             # repair round gets a fresh log-fetch budget (MAX_CI_DIAGNOSTICS_ATTEMPTS).
             # This was previously a side effect of reusing ci_diagnostics_attempts

--- a/app/repositories/autonomous_repo.py
+++ b/app/repositories/autonomous_repo.py
@@ -91,6 +91,7 @@ class AutonomousWorkflowRepository:
         "ci_repair_attempts",
         "ci_diagnostics_attempts",
         "ci_repair_transient_retries",
+        "ci_repair_no_change_retries",
         "last_ci_failure_signature",
         "last_ci_failure_head_sha",
         # Worktree transition journal for SIGKILL-resilient recovery (#2050).
@@ -291,9 +292,9 @@ class AutonomousWorkflowRepository:
                      max_plan_rounds, max_pr_review_rounds, require_full_review_rounds,
                      parent_workflow_id, fork_milestone_id, user_feedback,
                      original_branch_name, content_language, system_account,
-                     ci_repair_context, ci_repair_attempts, ci_diagnostics_attempts, ci_repair_transient_retries, last_ci_failure_signature,
+                     ci_repair_context, ci_repair_attempts, ci_diagnostics_attempts, ci_repair_transient_retries, ci_repair_no_change_retries, last_ci_failure_signature,
                      last_ci_failure_head_sha, created_at, updated_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 RETURNING *
                 """,
                 (
@@ -337,6 +338,7 @@ class AutonomousWorkflowRepository:
                     data.get("ci_repair_attempts", 0),
                     data.get("ci_diagnostics_attempts", 0),
                     data.get("ci_repair_transient_retries", 0),
+                    data.get("ci_repair_no_change_retries", 0),
                     data.get("last_ci_failure_signature", ""),
                     data.get("last_ci_failure_head_sha", ""),
                     now,
@@ -359,9 +361,9 @@ class AutonomousWorkflowRepository:
                      max_plan_rounds, max_pr_review_rounds, require_full_review_rounds,
                      parent_workflow_id, fork_milestone_id, user_feedback,
                      original_branch_name, content_language, system_account,
-                     ci_repair_context, ci_repair_attempts, ci_diagnostics_attempts, ci_repair_transient_retries, last_ci_failure_signature,
+                     ci_repair_context, ci_repair_attempts, ci_diagnostics_attempts, ci_repair_transient_retries, ci_repair_no_change_retries, last_ci_failure_signature,
                      last_ci_failure_head_sha, created_at, updated_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     workflow_id,
@@ -404,6 +406,7 @@ class AutonomousWorkflowRepository:
                     data.get("ci_repair_attempts", 0),
                     data.get("ci_diagnostics_attempts", 0),
                     data.get("ci_repair_transient_retries", 0),
+                    data.get("ci_repair_no_change_retries", 0),
                     data.get("last_ci_failure_signature", ""),
                     data.get("last_ci_failure_head_sha", ""),
                     now,

--- a/migrations/versions/20260803_005_add_ci_repair_no_change_retries.py
+++ b/migrations/versions/20260803_005_add_ci_repair_no_change_retries.py
@@ -1,0 +1,58 @@
+"""Add ci_repair_no_change_retries to autonomous_workflows.
+
+Revision ID: 20260803_005_add_ci_repair_no_change_retries
+Revises: 20260803_004_backfill_session_messages_columns
+Create Date: 2026-08-03
+
+Issue: #2187
+
+Dedicated counter for consecutive 'genuine no code changes' deferrals during
+merge-phase CI repair. Previously a single round where the agent ran cleanly
+but committed nothing terminal-failed the workflow (bypassing the
+MAX_CI_REPAIR_ATTEMPTS=5 budget). This migration adds a column so the new
+MAX_CI_REPAIR_NO_CHANGE_RETRIES bound has its own lifecycle, mirroring
+ci_repair_transient_retries.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260803_005_add_ci_repair_no_change_retries"
+down_revision: str | None = "20260803_004_backfill_session_messages_columns"  # confirm current head
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    """Add the ci_repair_no_change_retries column."""
+    connection = op.get_bind()
+    inspector = sa.inspect(connection)
+
+    if "autonomous_workflows" not in set(inspector.get_table_names()):
+        return  # fresh DBs create the column in CREATE TABLE
+
+    existing_columns = {col["name"] for col in inspector.get_columns("autonomous_workflows")}
+    if "ci_repair_no_change_retries" not in existing_columns:
+        op.add_column(
+            "autonomous_workflows",
+            sa.Column(
+                "ci_repair_no_change_retries",
+                sa.Integer(),
+                nullable=True,
+                server_default="0",
+            ),
+        )
+
+
+def downgrade() -> None:
+    """Remove the ci_repair_no_change_retries column."""
+    connection = op.get_bind()
+    inspector = sa.inspect(connection)
+
+    if "autonomous_workflows" not in set(inspector.get_table_names()):
+        return
+
+    existing_columns = {col["name"] for col in inspector.get_columns("autonomous_workflows")}
+    with op.batch_alter_table("autonomous_workflows") as batch_op:
+        if "ci_repair_no_change_retries" in existing_columns:
+            batch_op.drop_column("ci_repair_no_change_retries")

--- a/schema/schema-postgres.sql
+++ b/schema/schema-postgres.sql
@@ -500,7 +500,8 @@ CREATE TABLE autonomous_workflows (
     sandbox_last_error text,
     sandbox_remote_session_id text,
     sandbox_effective_policy text,
-    ci_repair_transient_retries integer DEFAULT 0
+    ci_repair_transient_retries integer DEFAULT 0,
+    ci_repair_no_change_retries integer DEFAULT 0
 );
 
 CREATE SEQUENCE autonomous_workflows_id_seq

--- a/schema/schema-sqlite.sql
+++ b/schema/schema-sqlite.sql
@@ -340,7 +340,8 @@ CREATE TABLE autonomous_workflows (
  sandbox_last_error text,
  sandbox_remote_session_id text,
  sandbox_effective_policy text,
- ci_repair_transient_retries integer DEFAULT 0
+ ci_repair_transient_retries integer DEFAULT 0,
+ ci_repair_no_change_retries integer DEFAULT 0
 );
 
 CREATE TABLE command_execution_evidence (

--- a/tests/issues/2187/test_ci_repair_no_change_deferral.py
+++ b/tests/issues/2187/test_ci_repair_no_change_deferral.py
@@ -1,0 +1,189 @@
+"""Tests for CI repair genuine no-code-change deferral (issue #2187).
+
+When the CI repair agent runs cleanly but produces no code changes, the round
+must defer to the next scheduler cycle WITHOUT consuming a real
+``ci_repair_attempts`` slot. A separate counter ``ci_repair_no_change_retries``
+(bounded by ``MAX_CI_REPAIR_NO_CHANGE_RETRIES``) tracks these deferrals so a
+perpetually-empty agent cannot loop forever, but a single empty round no longer
+terminal-fails the workflow (the pre-fix bug that wasted 4 of 5 attempts on
+issue 2187).
+
+Mirrors tests/issues/1820 (transient deferral) in structure.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from app.modules.workspace.autonomous.orchestrator import MAX_CI_REPAIR_NO_CHANGE_RETRIES
+
+
+def _make_workflow(**overrides):
+    base = {
+        "workflow_id": "wf-2187",
+        "user_id": 1,
+        "status": "merging",
+        "current_phase": "merge",
+        "ci_repair_attempts": 1,
+        "ci_repair_transient_retries": 0,
+        "ci_repair_no_change_retries": 0,
+        "ci_diagnostics_attempts": 0,
+        "last_ci_failure_signature": "",
+        "last_ci_failure_head_sha": "",
+        "branch_name": "auto-dev/wf-2187",
+        "branch_strategy": "worktree",
+        "worktree_path": "/tmp/repo",
+        "preferred_worktree_path": "/tmp/repo",
+        "dev_round": 1,
+    }
+    base.update(overrides)
+    return base
+
+
+def _make_orchestrator(wf_data):
+    from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+    with (
+        patch("app.modules.workspace.autonomous.orchestrator.Database"),
+        patch(
+            "app.modules.workspace.autonomous.orchestrator.AutonomousWorkflowRepository"
+        ) as mock_repo_cls,
+    ):
+        mock_repo = MagicMock()
+        mock_repo.get_workflow.return_value = wf_data
+        mock_repo.list_milestones.return_value = []
+        mock_repo.create_milestone.return_value = {
+            "milestone_id": "ms-1",
+            "workflow_id": wf_data["workflow_id"],
+        }
+        mock_repo.create_event.return_value = {"id": 1}
+        mock_repo.update_workflow.return_value = wf_data
+        mock_repo_cls.return_value = mock_repo
+
+        orch = AutonomousOrchestrator(wf_data["workflow_id"])
+        orch.repo = mock_repo
+        orch.emitter = MagicMock()
+        orch._sync_failed_pr_with_main = MagicMock(return_value=False)
+    return orch, mock_repo
+
+
+_FAILED_CHECKS = [
+    {
+        "name": "schema-sync",
+        "state": "failure",
+        "bucket": "fail",
+        "link": "https://github.com/open-ace/open-ace/runs/123",
+    }
+]
+
+
+# ── 1. No-change-deferred round does NOT consume a real attempt ──
+
+
+def test_no_change_deferred_does_not_increment_attempts():
+    """Re-entering after a no-change deferral must NOT bump ci_repair_attempts,
+    and must increment ci_repair_no_change_retries."""
+    wf = _make_workflow(
+        error_message="CI repair deferred: agent produced no code changes",
+        ci_repair_attempts=2,
+        ci_repair_no_change_retries=0,
+    )
+    orch, mock_repo = _make_orchestrator(wf)
+    gh = MagicMock()
+    gh.get_pr_head_sha.return_value = "sha-new"
+    gh.get_check_failure_excerpt.return_value = "schema-sync failed\n1 error"
+    orch._get_gh = MagicMock(return_value=gh)
+    orch._run_merge_ci_repair = MagicMock()
+
+    orch._start_ci_repair_round(wf, 2187, _FAILED_CHECKS)
+
+    orch._run_merge_ci_repair.assert_called_once()
+    updates = [c.args[1] for c in mock_repo.update_workflow.call_args_list]
+    assert any(u.get("ci_repair_attempts") == 2 for u in updates), "real attempts unchanged"
+    assert any(u.get("ci_repair_no_change_retries") == 1 for u in updates), "no-change counter 0→1"
+
+
+# ── 2. After MAX_CI_REPAIR_NO_CHANGE_RETRIES, workflow is marked failed ──
+
+
+def test_no_change_retries_exhausted_marks_failed():
+    """When no-change retries hit the cap, the workflow fails with a dedicated
+    exhausted milestone and the agent is NOT run again."""
+    wf = _make_workflow(
+        error_message="CI repair deferred: agent produced no code changes",
+        ci_repair_attempts=2,
+        ci_repair_no_change_retries=MAX_CI_REPAIR_NO_CHANGE_RETRIES,
+    )
+    orch, mock_repo = _make_orchestrator(wf)
+    gh = MagicMock()
+    gh.get_pr_head_sha.return_value = "sha-new"
+    gh.get_check_failure_excerpt.return_value = "schema-sync failed\n1 error"
+    orch._get_gh = MagicMock(return_value=gh)
+    orch._run_merge_ci_repair = MagicMock()
+
+    orch._start_ci_repair_round(wf, 2187, _FAILED_CHECKS)
+
+    orch._run_merge_ci_repair.assert_not_called()
+    updates = [c.args[1] for c in mock_repo.update_workflow.call_args_list]
+    assert any(u.get("status") == "failed" for u in updates)
+    assert any("no code changes" in (u.get("error_message") or "").lower() for u in updates)
+    assert any(
+        c.args[0].get("milestone_type") == "ci_repair_no_change_exhausted"
+        for c in mock_repo.create_milestone.call_args_list
+    )
+
+
+# ── 3. Change-producing (fresh) round resets the no-change counter ──
+
+
+def test_change_producing_round_resets_no_change_counter():
+    """A fresh round (no deferral prefix) resets no_change_retries to 0 and
+    consumes a real attempt — same as the transient reset."""
+    wf = _make_workflow(
+        error_message="",  # no deferral signal
+        ci_repair_attempts=1,
+        ci_repair_no_change_retries=2,  # stale from prior no-change cycles
+    )
+    orch, mock_repo = _make_orchestrator(wf)
+    gh = MagicMock()
+    gh.get_pr_head_sha.return_value = "sha-new"
+    gh.get_check_failure_excerpt.return_value = "schema-sync failed\n1 error"
+    orch._get_gh = MagicMock(return_value=gh)
+    orch._run_merge_ci_repair = MagicMock()
+
+    orch._start_ci_repair_round(wf, 2187, _FAILED_CHECKS)
+
+    orch._run_merge_ci_repair.assert_called_once()
+    updates = [c.args[1] for c in mock_repo.update_workflow.call_args_list]
+    assert any(u.get("ci_repair_attempts") == 2 for u in updates), "fresh round consumes an attempt"
+    assert any(u.get("ci_repair_no_change_retries") == 0 for u in updates), "counter reset to 0"
+
+
+# ── 4. Diagnostics-incomplete preserves the no-change signal ──
+
+
+def test_diagnostics_incomplete_preserves_no_change_signal():
+    """When diagnostics are incomplete during a no-change-deferred round, the
+    error_message must retain the no-change prefix and the counter must persist,
+    so the next cycle still classifies it as a no-change retry (mirrors #1820)."""
+    wf = _make_workflow(
+        error_message="CI repair deferred: agent produced no code changes",
+        ci_repair_attempts=2,
+        ci_repair_no_change_retries=1,
+        ci_diagnostics_attempts=0,
+    )
+    orch, mock_repo = _make_orchestrator(wf)
+    gh = MagicMock()
+    gh.get_pr_head_sha.return_value = "sha-new"
+    gh.get_check_failure_excerpt.return_value = ""  # no logs → diagnostics incomplete
+    orch._get_gh = MagicMock(return_value=gh)
+    orch._run_merge_ci_repair = MagicMock()
+
+    orch._start_ci_repair_round(wf, 2187, _FAILED_CHECKS)
+
+    orch._run_merge_ci_repair.assert_not_called()
+    updates = [c.args[1] for c in mock_repo.update_workflow.call_args_list]
+    assert any(
+        u.get("error_message", "").startswith("CI repair deferred: agent produced no code changes")
+        for u in updates
+    ), [u.get("error_message") for u in updates]
+    assert any(u.get("ci_repair_no_change_retries") == 2 for u in updates)
+    assert not any(u.get("ci_repair_attempts", 0) > 2 for u in updates)


### PR DESCRIPTION
## Root cause

A merge-phase CI-repair round where the agent ran cleanly but committed nothing **terminal-failed the workflow on the first occurrence**, bypassing the `MAX_CI_REPAIR_ATTEMPTS=5` budget. Verified on issue 2187: agent produced no changes once → `ci_repair_attempts=1`, terminal fail, 4 of 5 attempts wasted. The “5-round” promise only held when every round produced a commit; one empty round ended it.

`orchestrator.py` branch D (the `else` at the `if not sha_changed` block) terminal-failed, while branch A (transient API error) already deferred correctly via `ci_repair_transient_retries` / `MAX_CI_REPAIR_TRANSIENT_RETRIES`.

## Fix

Mirror the proven transient-deferral pattern with a dedicated bounded counter:
- New `MAX_CI_REPAIR_NO_CHANGE_RETRIES = 2` + column `ci_repair_no_change_retries` (migration `20260803_005`, mirroring `20260731_002`).
- Branch D now **defers** (`status=merging` + prefix `"CI repair deferred: agent produced no code changes"`) instead of terminal-failing. Branches B (context overflow) and C (primary runner error) stay terminal.
- `_start_ci_repair_round` gains a parallel `elif is_no_change_deferred` branch: bounded by the new MAX → `ci_repair_no_change_exhausted` milestone; else `next_attempt = previous_attempts` (no-change does **not** consume a real attempt, preserving the 5-round budget) + `no_change_retries += 1`.
- Change-producing rounds reset `no_change_retries = 0` (alongside the transient reset).
- Persisted at all three points; the diagnostics-poll guard preserves the no-change prefix (mirrors the #1820 signal-loss fix).

Net: with MAX=2, an empty round gets up to **2 retries (3 total agent runs)** before terminal-fail — a bounded improvement over the pre-fix “1 empty round → immediate fail.”

## Tests

`tests/issues/2187/test_ci_repair_no_change_deferral.py` (mirrors `tests/issues/1820/`): no-change deferral doesn’t consume a real attempt + increments the counter; exhaustion → failed + dedicated milestone; change-producing round resets the counter; diagnostics-incomplete preserves the signal. Regression: `tests/issues/1820/` (transient) still green (9/0).

Independent plan review (initial + focused re-review): zero blockers; code-change sites all verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)