### PR TITLE
fix(gunicorn): 修复 gevent monkey-patch 导致的 RecursionError

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1319,7 +1319,10 @@ echo "=========================================="
 echo "  Open ACE - Starting Gunicorn"
 echo "=========================================="
 
-exec gunicorn \
+# Use gunicorn_entry.py wrapper that monkey-patches gevent BEFORE gunicorn
+# (or any transitive dep) imports urllib3. This prevents urllib3.util.ssl_
+# RecursionError under the gevent event loop during LLM proxy outbound requests.
+exec python3 /app/gunicorn_entry.py \
     --bind 0.0.0.0:19888 \
     --worker-class app.gunicorn_worker.TerminalGeventWorker \
     --workers 1 \

--- a/gunicorn_entry.py
+++ b/gunicorn_entry.py
@@ -16,17 +16,17 @@ import sys
 # Must be the first thing before any urllib3 or related imports
 try:
     import gevent.monkey
+
     gevent.monkey.patch_all()
 except ImportError:
     pass
 
 # Now import gunicorn and run it
 import re
-import os
 
 from gunicorn.app.wsgiapp import run
 
 if __name__ == "__main__":
     # Pass remaining arguments to gunicorn
-    sys.argv[0] = re.sub(r'(-script/.*\.py|-$)', 'gunicorn', sys.argv[0])
+    sys.argv[0] = re.sub(r"(-script/.*\.py|-$)", "gunicorn", sys.argv[0])
     run()

--- a/gunicorn_entry.py
+++ b/gunicorn_entry.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""Gunicorn entry point wrapper for Open ACE.
+
+This wrapper monkey-patches gevent BEFORE gunicorn (or any transitive dep)
+imports urllib3. This prevents urllib3.util.ssl_ RecursionError under the
+gevent event loop during LLM proxy outbound requests.
+
+See: Issue #2244 - safe_request recursion in gevent environment
+"""
+
+import sys
+
+# ============================================================================
+# Monkey-patch gevent BEFORE any other imports
+# ============================================================================
+# Must be the first thing before any urllib3 or related imports
+try:
+    import gevent.monkey
+    gevent.monkey.patch_all()
+except ImportError:
+    pass
+
+# Now import gunicorn and run it
+import re
+import os
+
+from gunicorn.app.wsgiapp import run
+
+if __name__ == "__main__":
+    # Pass remaining arguments to gunicorn
+    sys.argv[0] = re.sub(r'(-script/.*\.py|-$)', 'gunicorn', sys.argv[0])
+    run()


### PR DESCRIPTION
## 问题

Fixes #2244

LLM 代理请求持续返回 403 错误，容器日志显示 maximum recursion depth exceeded。

## 原因

gevent monkey-patch 后的 ssl 与 urllib3 预导入的函数之间产生真无限递归。

## 修复

- 新建 gunicorn_entry.py 作为 gunicorn 入口包装器
- 在 gunicorn 导入前执行 gevent.monkey.patch_all()

---

**原作者:** @papercatno1
**原始提交:** 627acc039dc53eda2abdfdfcc0e2dc4fd1954d6b