### PR TITLE
fix(proxy): 修复 SSL 证书验证失败和 RecursionError 问题

### DIFF
--- a/app/utils/outbound_url_guard.py
+++ b/app/utils/outbound_url_guard.py
@@ -317,6 +317,11 @@ def safe_request(
 
     scheme = urlparse(url).scheme
 
+    # Explicitly disable proxy lookup to match the working code path in
+    # llm_proxy_handler. In gevent-gunicorn workers, urllib3 proxy resolution
+    # can interact badly with monkey-patched ssl, causing RecursionError.
+    kwargs.setdefault("proxies", {"http": None, "https": None})  # type: ignore[dict-item]
+
     own_session = False
     if session is None:
         session = requests.Session()

--- a/tests/issues/1778/test_outbound_url_toctou.py
+++ b/tests/issues/1778/test_outbound_url_toctou.py
@@ -282,9 +282,9 @@ def test_safe_request_disables_proxy_by_default(monkeypatch):
     {"http": None, "https": None} becomes an empty dict, which effectively
     disables proxy lookup.
     """
-    resolver = lambda host, *a, **kw: [
-        (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 443))
-    ]
+
+    def resolver(host, *a, **kw):  # type: ignore[no-untyped-def]
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 443))]
 
     captured = {}
 
@@ -308,9 +308,9 @@ def test_safe_request_preserves_caller_provided_proxies(monkeypatch):
     Using setdefault ensures that if the caller explicitly provides a proxies
     argument (including proxies=None or custom proxy settings), it is preserved.
     """
-    resolver = lambda host, *a, **kw: [
-        (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 443))
-    ]
+
+    def resolver(host, *a, **kw):  # type: ignore[no-untyped-def]
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 443))]
 
     captured = {}
 

--- a/tests/issues/1778/test_outbound_url_toctou.py
+++ b/tests/issues/1778/test_outbound_url_toctou.py
@@ -266,3 +266,71 @@ def test_is_public_address_rejects_metadata_and_other_non_public(addr):
     """The predicate must use an explicit denylist, not ``is_global`` alone."""
     ip = ipaddress.ip_address(addr)
     assert not _is_public_address(ip), f"{addr} leaked through is_global-only predicate"
+
+
+# ── safe_request: proxy configuration (PR #2252) ────────────────────────
+
+
+def test_safe_request_disables_proxy_by_default(monkeypatch):
+    """safe_request must disable proxy lookup by default to avoid RecursionError in gevent.
+
+    In gevent-gunicorn workers, urllib3 proxy resolution can interact badly with
+    monkey-patched ssl, causing RecursionError. This test verifies that safe_request
+    explicitly disables proxies by default, matching llm_proxy_handler behavior.
+
+    Note: requests.sessions.merge_setting removes keys with None values, so
+    {"http": None, "https": None} becomes an empty dict, which effectively
+    disables proxy lookup.
+    """
+    resolver = lambda host, *a, **kw: [
+        (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 443))
+    ]
+
+    captured = {}
+
+    def fake_send(self, request, proxies=None, **kwargs):  # type: ignore[no-untyped-def]
+        captured["proxies"] = proxies
+        resp = requests.Response()
+        resp.status_code = 200
+        return resp
+
+    monkeypatch.setattr(_PinnedIPAdapter, "send", fake_send)
+
+    # Default behavior - proxies should be empty (disabled)
+    safe_request("GET", "https://example.com/test", resolver=resolver, timeout=5)
+    # After merge_setting removes None values, proxies should be empty
+    assert captured.get("proxies") == {}
+
+
+def test_safe_request_preserves_caller_provided_proxies(monkeypatch):
+    """safe_request must preserve caller-provided proxies argument.
+
+    Using setdefault ensures that if the caller explicitly provides a proxies
+    argument (including proxies=None or custom proxy settings), it is preserved.
+    """
+    resolver = lambda host, *a, **kw: [
+        (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 443))
+    ]
+
+    captured = {}
+
+    def fake_send(self, request, proxies=None, **kwargs):  # type: ignore[no-untyped-def]
+        captured["proxies"] = proxies
+        resp = requests.Response()
+        resp.status_code = 200
+        return resp
+
+    monkeypatch.setattr(_PinnedIPAdapter, "send", fake_send)
+
+    # Caller-provided proxies should be preserved
+    safe_request(
+        "GET",
+        "https://example.com/test",
+        resolver=resolver,
+        timeout=5,
+        proxies={"http": "http://proxy.example.com", "https": "http://proxy.example.com"},
+    )
+    assert captured.get("proxies") == {
+        "http": "http://proxy.example.com",
+        "https": "http://proxy.example.com",
+    }


### PR DESCRIPTION
## 问题

Fixes #2243

配置 DeepSeek API Key 后，新建会话返回 403 错误。

## 原因

1. safe_request 使用 IP pinning 但 TLS 证书验证使用 URL 主机名
2. urllib3 代理查找在 gevent 环境下可能导致 RecursionError

## 修复

在 safe_request 中显式禁用代理查找，保持原始 URL。

---

**原作者:** @papercatno1
**原始提交:** 627acc039dc53eda2abdfdfcc0e2dc4fd1954d6b