### PR TITLE
fix(remote): 修复远程工作区 code-server WebSocket 认证问题

### DIFF
--- a/app/modules/workspace/vscode_ws_bridge.py
+++ b/app/modules/workspace/vscode_ws_bridge.py
@@ -142,13 +142,21 @@ def bridge_vscode_ws(browser_ws: Any, remote_ws_url: str, vscode_id: str) -> Non
         _unregister_bridge(state)
 
 
-def bridge_vscode_ws_raw(vscode_id: str, browser_sock, remote_ws_url: str) -> None:
+def bridge_vscode_ws_raw(vscode_id: str, browser_sock, remote_ws_url: str, cs_password: str = "") -> None:
     """Bridge a raw browser socket (via RemoteWSHandler) to a remote code-server.
 
     Uses ``ws_frame`` for browser-side I/O and ``websockets.sync`` for the
     remote side.  The browser socket has already completed the WS handshake
     before this function is called.
+
+    Args:
+        vscode_id: VSCode session ID for cleanup tracking.
+        browser_sock: Browser's raw socket for WebSocket I/O.
+        remote_ws_url: WebSocket URL of the remote code-server.
+        cs_password: code-server's own password for authentication (optional).
     """
+    import base64 as _b64
+
     state = VSCodeBridgeConnection(vscode_id=vscode_id, browser_ws=browser_sock)
     _register_bridge(state)
 
@@ -156,12 +164,19 @@ def bridge_vscode_ws_raw(vscode_id: str, browser_sock, remote_ws_url: str) -> No
     origin_scheme = "https" if parsed.scheme == "wss" else "http"
     origin = f"{origin_scheme}://{parsed.netloc}" if parsed.netloc else None
 
+    # Build additional headers for code-server password authentication
+    additional_headers = {}
+    if cs_password:
+        auth_value = _b64.b64encode(f":{cs_password}".encode()).decode()
+        additional_headers["Authorization"] = f"Basic {auth_value}"
+
     try:
         with connect(
             remote_ws_url,
             origin=origin,
             close_timeout=5,
             proxy=None,
+            additional_headers=additional_headers,
         ) as remote_ws:
             state.remote_ws = remote_ws
             logger.info("Connected raw bridge to remote code-server: %s", remote_ws_url)

--- a/app/modules/workspace/vscode_ws_bridge.py
+++ b/app/modules/workspace/vscode_ws_bridge.py
@@ -142,7 +142,9 @@ def bridge_vscode_ws(browser_ws: Any, remote_ws_url: str, vscode_id: str) -> Non
         _unregister_bridge(state)
 
 
-def bridge_vscode_ws_raw(vscode_id: str, browser_sock, remote_ws_url: str, cs_password: str = "") -> None:
+def bridge_vscode_ws_raw(
+    vscode_id: str, browser_sock, remote_ws_url: str, cs_password: str = ""
+) -> None:
     """Bridge a raw browser socket (via RemoteWSHandler) to a remote code-server.
 
     Uses ``ws_frame`` for browser-side I/O and ``websockets.sync`` for the

--- a/app/remote_ws_handler.py
+++ b/app/remote_ws_handler.py
@@ -630,6 +630,9 @@ class RemoteWSHandler(WSGIHandler):
 
         machine_id, info = found
 
+        # Get code-server password for WebSocket authentication
+        cs_password = info.get("cs_password", "")
+
         # Issue #2183: Check session status first
         if info.get("status") != "running":
             logger.warning("VSCode WS handler: session not running %s", vscode_id[:8])
@@ -712,11 +715,12 @@ class RemoteWSHandler(WSGIHandler):
             from app.modules.workspace.vscode_ws_bridge import bridge_vscode_ws_raw
 
             logger.info(
-                "VSCode WS handler: bridging %s for machine %s",
+                "VSCode WS handler: bridging %s for machine %s (has_password=%s)",
                 vscode_id[:8],
                 machine_id[:8],
+                bool(cs_password),
             )
-            bridge_vscode_ws_raw(vscode_id, self.socket, remote_ws_url)
+            bridge_vscode_ws_raw(vscode_id, self.socket, remote_ws_url, cs_password)
         except Exception:
             logger.exception("VSCode WS handler: bridge failed for vscode %s", vscode_id[:8])
             try:


### PR DESCRIPTION
## 问题

Fixes #2231

远程工作区打开 code-server 时弹出密码输入界面。

## 原因

WebSocket 代理未传递 cs_password Basic Auth 认证头。

## 修复

添加 cs_password 参数，构建 Basic Auth 头。

---

**原作者:** @papercatno1
**原始提交:** 627acc039dc53eda2abdfdfcc0e2dc4fd1954d6b