### PR TITLE
fix(autonomous): map RealDictRow rows by value, not column name (#2259)

### DIFF
--- a/app/repositories/autonomous_repo.py
+++ b/app/repositories/autonomous_repo.py
@@ -186,8 +186,11 @@ class AutonomousWorkflowRepository:
                 ),
                 list(active_statuses),
             )
-            cols = [d[0] for d in cursor.description]
-            return [dict(zip(cols, row)) for row in cursor.fetchall()]
+            # RealDictRow (PG) and sqlite3.Row both convert via dict(row).
+            # Do NOT use dict(zip(cols, row)): a RealDictRow iterates as its
+            # KEYS (column names), so zip yields {column_name: column_name}
+            # and every value becomes a string — see #2259.
+            return [dict(row) for row in cursor.fetchall()]
         finally:
             conn.close()
 
@@ -210,8 +213,11 @@ class AutonomousWorkflowRepository:
                     """
                 )
             )
-            cols = [d[0] for d in cursor.description]
-            return [dict(zip(cols, row)) for row in cursor.fetchall()]
+            # RealDictRow (PG) and sqlite3.Row both convert via dict(row).
+            # Do NOT use dict(zip(cols, row)): a RealDictRow iterates as its
+            # KEYS (column names), so zip yields {column_name: column_name}
+            # and every value becomes a string — see #2259.
+            return [dict(row) for row in cursor.fetchall()]
         finally:
             conn.close()
 
@@ -237,8 +243,11 @@ class AutonomousWorkflowRepository:
                     """
                 )
             )
-            cols = [d[0] for d in cursor.description]
-            return [dict(zip(cols, row)) for row in cursor.fetchall()]
+            # RealDictRow (PG) and sqlite3.Row both convert via dict(row).
+            # Do NOT use dict(zip(cols, row)): a RealDictRow iterates as its
+            # KEYS (column names), so zip yields {column_name: column_name}
+            # and every value becomes a string — see #2259.
+            return [dict(row) for row in cursor.fetchall()]
         finally:
             conn.close()
 

--- a/tests/integration/test_autonomous_workflow_repo_mapping_pg.py
+++ b/tests/integration/test_autonomous_workflow_repo_mapping_pg.py
@@ -1,0 +1,85 @@
+"""PG-only regression: AutonomousWorkflowRepository row mapping (#2259).
+
+On PostgreSQL, ``get_connection()`` defaults to ``RealDictCursor`` (rows are
+``RealDictRow`` dict-subclasses). Three repo methods historically built result
+dicts with ``dict(zip(cols, row))`` — but iterating a ``RealDictRow`` yields its
+KEYS (column names), so every value became the column-name string
+(``{"sandbox_generation": "sandbox_generation", ...}``). The startup
+``_reconcile_orphan_sandboxes`` sweep then did
+``int(wf.get("sandbox_generation") or 0)`` on the literal string
+``"sandbox_generation"`` and crashed every server restart (#2259).
+
+This is a **PG-only** bug: SQLite's ``sqlite3.Row`` iterates by index, so
+``dict(zip(cols, row))`` happens to be correct there — CI's SQLite matrix
+(``tests/issues/2022/test_sandbox_state.py``) stayed green while prod crashed.
+These tests must run on a live PostgreSQL to catch it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# Marks every test in this module as requiring a live PostgreSQL server.
+# CI's main matrix runs `pytest -m 'not postgres'` (excluded); the separate
+# postgres-test job runs these. Locally they auto-skip via pg_db when no
+# server is reachable.
+pytestmark = pytest.mark.postgres
+
+from app.repositories.autonomous_repo import AutonomousWorkflowRepository
+
+
+def _seed_user(db, user_id: int = 1) -> None:
+    """Insert the users row that autonomous_workflows.user_id references."""
+    db.execute(
+        "INSERT INTO users (username, email, password_hash, role) VALUES (%s, %s, %s, %s)",
+        (f"user{user_id}", f"user{user_id}@test.com", "hash", "user"),
+    )
+
+
+def test_active_sandbox_rows_map_values_not_column_names(pg_db):
+    """get_workflows_with_active_sandbox must return column values, not names.
+
+    Pre-fix this returned ``{"sandbox_generation": "sandbox_generation", ...}``
+    on PG (RealDictRow), so the reconcile sweep's ``int(...)`` crashed (#2259).
+    """
+    _seed_user(pg_db)
+    repo = AutonomousWorkflowRepository(db=pg_db)
+    repo.create_workflow({"workflow_id": "wf-orphan", "user_id": 1, "title": "reconcile-mapping"})
+    repo.update_workflow(
+        "wf-orphan",
+        {"sandbox_state": "running", "sandbox_generation": 5, "sandbox_id": "sb-1"},
+    )
+
+    rows = repo.get_workflows_with_active_sandbox()
+    assert len(rows) == 1
+    # The bug: value was the column-name string "sandbox_generation".
+    assert rows[0]["sandbox_generation"] == 5
+    assert rows[0]["sandbox_state"] == "running"
+    assert rows[0]["sandbox_id"] == "sb-1"
+    # Nail the crash-frame semantics from autonomous_scheduler.py:1144 — the
+    # reconcile sweep does int(wf.get("sandbox_generation") or 0) + 1. Pinning
+    # this guards against a future revert to dict(zip(...)) that the equality
+    # assertion alone wouldn't catch.
+    assert int(rows[0].get("sandbox_generation") or 0) + 1 == 6
+
+
+def test_active_transition_rows_map_values_not_column_names(pg_db):
+    """get_workflows_with_active_transition shares the broken idiom and feeds
+    _reconcile_worktree_transitions (scheduler:956) — same PG-only risk."""
+    _seed_user(pg_db)
+    repo = AutonomousWorkflowRepository(db=pg_db)
+    repo.create_workflow({"workflow_id": "wf-tx", "user_id": 1, "title": "transition-mapping"})
+    # worktree_transition_state is set out-of-band by the transition journal;
+    # mirror that with a direct UPDATE (the mapping bug is independent of how
+    # the column was set, and not every field is in update_workflow's allowlist).
+    pg_db.execute(
+        "UPDATE autonomous_workflows SET worktree_transition_state = %s, "
+        "sandbox_generation = %s WHERE workflow_id = %s",
+        ("copying", 2, "wf-tx"),
+    )
+
+    rows = repo.get_workflows_with_active_transition()
+    assert len(rows) == 1
+    assert rows[0]["workflow_id"] == "wf-tx"
+    assert rows[0]["worktree_transition_state"] == "copying"
+    assert rows[0]["sandbox_generation"] == 2


### PR DESCRIPTION
## 根因
`AutonomousWorkflowRepository` 三个方法用 `dict(zip(cols, row))` 构造结果 dict。PG 的连接游标是 `RealDictCursor`，`row` 是 `RealDictRow`（dict 子类），`zip(cols, row)` 迭代 `row` 的**键**（列名）→ 结果变成 `{列名: 列名}`。启动期 `_reconcile_orphan_sandboxes` 执行 `int(wf.get("sandbox_generation") or 0)` 拿到字面字符串 `"sandbox_generation"` → **每次 server 重启崩溃**。

prod 日志（每次重启）：
```
ERROR - Sandbox reconciliation sweep failed: invalid literal for int() with base 10: 'sandbox_generation'
```

SQLite 的 `sqlite3.Row` 按索引迭代，旧 idiom 在 SQLite 上恰好正确 → CI SQLite 矩阵全绿、掩盖此 **PG-only** 回归。

## 修法
三处 `cols=[...]; dict(zip(cols,row))` → `dict(row)`（对 RealDictRow 和 sqlite3.Row 都正确，与 `database.py::fetch_all` canonical idiom 一致）。同时清理 `get_workflows_with_active_transition` / `get_workflows_with_agent_pid` 的同病 idiom（潜伏地雷）。

## 测试
新增 `tests/integration/test_autonomous_workflow_repo_mapping_pg.py`（`@pytest.mark.postgres`，CI 的 `postgres-test` job 跑）：
- `test_active_sandbox_rows_map_values_not_column_names`：未修复时 `assert 'sandbox_generation' == 5` FAIL，修复后 PASS；并钉住崩溃栈帧语义 `int(rows[0]["sandbox_generation"] or 0) + 1 == 6`。
- `test_active_transition_rows_map_values_not_column_names`：覆盖活路径 `get_workflows_with_active_transition`（喂 `_reconcile_worktree_transitions`，等价风险）。

本地 PG14 实跑：未修复 2 FAIL（精确复现 prod 错误），修复后 2 PASS。现有 `tests/issues/2022/` 16 个 SQLite 测试无回归。

## 影响
修好后首次重启会真正执行 orphan sandbox destroy（之前崩溃在循环前从未执行）——`destroy_attribution` 已 try/except 包裹不会中断整轮，属预期修复行为。

Closes #2259.

🤖 Generated with [Claude Code](https://claude.com/claude-code)