### PR TITLE
fix(governance): write boolean (not int) to alerts.read on PostgreSQL (#2260)

### DIFF
--- a/app/modules/governance/alert_notifier.py
+++ b/app/modules/governance/alert_notifier.py
@@ -1751,7 +1751,7 @@ class AlertNotifier:
                 alert.tool_name,
                 json.dumps(alert.metadata),
                 alert.created_at.isoformat(),
-                1 if alert.read else 0,
+                adapt_boolean_value(alert.read),
                 alert.action_url,
                 alert.action_text,
             ),

--- a/app/modules/governance/alert_transaction_manager.py
+++ b/app/modules/governance/alert_transaction_manager.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 
 from app.modules.governance.alert_notifier import normalize_alert_severity
-from app.repositories.database import Database, adapt_sql, is_postgresql
+from app.repositories.database import Database, adapt_boolean_value, adapt_sql, is_postgresql
 
 logger = logging.getLogger(__name__)
 
@@ -308,7 +308,7 @@ class AlertTransactionManager:
                         alerts_data["username"],
                         alerts_data["metadata"],
                         datetime.now(timezone.utc).replace(tzinfo=None).isoformat(),
-                        0,
+                        adapt_boolean_value(False),
                         alerts_data.get("action_url"),
                         alerts_data.get("action_text"),
                     ),

--- a/tests/integration/test_alert_read_boolean_pg.py
+++ b/tests/integration/test_alert_read_boolean_pg.py
@@ -1,0 +1,100 @@
+"""PG-only regression: alert INSERTs must write a boolean to the read column (#2260).
+
+Two live code paths inserted an integer (0 / ``1 if x else 0``) into the
+boolean ``alerts.read`` column. PostgreSQL has no int->boolean assignment cast,
+so both failed with ``column "read" is of type boolean but expression is of
+type integer``:
+
+  * ``AlertTransactionManager._create_alert`` (the quota-alert path) — 3 retries,
+    then dead-lettered; no alert ever persisted (the active prod failure).
+  * ``AlertNotifier._save_alert`` (reached via ``create_alert`` / the ``/alerts``
+    HTTP endpoint at routes/alerts.py:262).
+
+SQLite's INTEGER type affinity accepts 0/1, so CI's SQLite matrix stayed green —
+a PG-only regression. These tests must run on a live PostgreSQL to catch it.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+import app.modules.governance.alert_notifier as alert_notifier_mod
+import app.repositories.database as db_mod
+
+# Marks every test in this module as requiring a live PostgreSQL server.
+pytestmark = pytest.mark.postgres
+
+from app.modules.governance.alert_notifier import Alert, AlertNotifier
+from app.modules.governance.alert_transaction_manager import AlertTransactionManager, QuotaAlertData
+
+
+def _seed_user(db, user_id: int = 1) -> None:
+    """Insert the users row that quota_alerts.user_id references (FK)."""
+    db.execute(
+        "INSERT INTO users (id, username, email, password_hash, role) "
+        "VALUES (%s, %s, %s, %s, %s)",
+        (user_id, f"user{user_id}", f"user{user_id}@test.com", "hash", "user"),
+    )
+
+
+def test_create_quota_alert_persists_with_read_false(pg_db):
+    """AlertTransactionManager._create_alert: the alerts.read boolean column
+    must accept the insert on PostgreSQL.
+
+    Pre-fix the int 0 literal caused DatatypeMismatch; the transaction rolled
+    back (no alerts row, no quota_alerts row) after 3 retries.
+    """
+    _seed_user(pg_db)
+    manager = AlertTransactionManager(db=pg_db)
+    alert_data = QuotaAlertData(
+        user_id=1,
+        username="user1",
+        quota_type="tokens",
+        usage_percent=95.0,
+        current_usage=950,
+        quota_limit=1000,
+        threshold=90.0,
+        original_alert_type="warning",
+    )
+
+    success, alert_id = manager.create_quota_alert_transactional(alert_data)
+
+    assert success is True
+    assert alert_id is not None
+    row = pg_db.fetch_one("SELECT * FROM alerts WHERE alert_id = %s", (alert_id,))
+    assert row is not None
+    # Boolean column must come back as a Python bool, not an int — and the row
+    # must exist at all (the pre-fix rollback left nothing).
+    assert row["read"] is False
+
+
+def test_save_alert_persists_with_read_false(pg_db):
+    """AlertNotifier._save_alert (via create_alert / the /alerts endpoint) shares
+    the int->boolean bug. Route it to the test DB by delegating the module-level
+    is_postgresql/get_database_url names — these are bound into alert_notifier
+    via ``from ... import``, so the pg_db fixture's patch on the database module
+    doesn't reach them; delegate to the fixture's already-patched names instead.
+    """
+    _seed_user(pg_db)
+    notifier = AlertNotifier()
+    alert = Alert(
+        alert_id="alt-save-1",
+        alert_type="system",
+        severity="warning",
+        title="save-alert-test",
+        message="m",
+        user_id=1,
+        username="user1",
+    )
+
+    with (
+        patch.object(alert_notifier_mod, "is_postgresql", db_mod.is_postgresql),
+        patch.object(alert_notifier_mod, "get_database_url", db_mod.get_database_url),
+    ):
+        notifier._save_alert(alert)
+
+    row = pg_db.fetch_one("SELECT * FROM alerts WHERE alert_id = %s", ("alt-save-1",))
+    assert row is not None
+    assert row["read"] is False


### PR DESCRIPTION
## 根因（两条同源活路径）
两条 INSERT 把整数写进 boolean ``alerts.read`` 列，PG 无 int→boolean 隐式转换 → DatatypeMismatch：

1. **``AlertTransactionManager._create_alert``**（alert_transaction_manager.py:311）硬编码 ``0`` —— 每个配额告警 3 次重试全失败后进补偿队列，**告警永远存不进库**（prod 活失败，日志 2026-08-03 20:30 起）。
2. **``AlertNotifier._save_alert``**（alert_notifier.py:1754）``1 if alert.read else 0`` —— 经 ``create_alert`` 被 4 处调用，含 ``routes/alerts.py:262`` 的 ``/alerts`` HTTP 端点；PG 上同样 DatatypeMismatch。

> ⚠️ 范围修正：issue #2260 原本误判 ``_save_alert`` 为死代码（方法名记成 ``_save_alert_to_db``）。独立审查纠正——``_save_alert`` 经 ``create_alert`` 是**活路径**，必须一并修。已在 issue 补评论。

SQLite 的 INTEGER type affinity 接受 0/1 → CI SQLite 矩阵全绿、掩盖此 **PG-only** 回归（与 #2204 command_evidence 同源类 bug）。

## 修法
两处都改用 ``adapt_boolean_value(...)``（与同模块 ``mark_as_read``/``mark_all_as_read``/``alert_state_synchronizer`` 既有 idiom 一致；PG 返回 bool、SQLite 返回 0/1）：
- ``alert_transaction_manager.py:311``：``0`` → ``adapt_boolean_value(False)``（补 import，按 isort 字母序置于 ``adapt_sql`` 前）。
- ``alert_notifier.py:1754``：``1 if alert.read else 0`` → ``adapt_boolean_value(alert.read)``（import 已在 38 行）。

## 测试
新增 ``tests/integration/test_alert_read_boolean_pg.py``（``@pytest.mark.postgres``，CI 的 ``postgres-test`` job）：
- ``test_create_quota_alert_persists_with_read_false``：transaction 路径，未修复 ``assert False is True`` FAIL（3 次重试失败），修复后 PASS。
- ``test_save_alert_persists_with_read_false``：``_save_alert`` 路径，用委托-patch 把 alert_notifier 的 ``is_postgresql``/``get_database_url`` 路由到 pg_db 测试库，未修复精确抛 ``DatatypeMismatch``，修复后 PASS。

本地 PG14 实跑：未修复 2 FAIL（精确复现 prod 错误），修复后 2 PASS。现有 ``tests/unit/`` 87 个 alert/quota SQLite 测试无回归。

## 部署
governance 模块热补丁（``alert_transaction_manager.py`` + ``alert_notifier.py``），无 schema 变更，重启即生效。

Closes #2260.

🤖 Generated with [Claude Code](https://claude.com/claude-code)