### PR TITLE
fix: 使用绝对路径修复 install.sh 中 visudo 命令找不到的问题

### DIFF
--- a/scripts/install-central/package-method/install.sh
+++ b/scripts/install-central/package-method/install.sh
@@ -2007,7 +2007,9 @@ configure_autonomous_agent_sudoers() {
 $run_user ALL=(root) NOPASSWD: $wrapper_path --isolated *
 SUDOERS_EOF
     chmod 440 "$sudoers_file"
-    if ! visudo -c -f "$sudoers_file" >/dev/null 2>&1; then
+    local visudo_cmd="/usr/sbin/visudo"
+    [ ! -x "$visudo_cmd" ] && visudo_cmd="visudo"
+    if ! $visudo_cmd -c -f "$sudoers_file" >/dev/null 2>&1; then
         unlink "$sudoers_file" 2>/dev/null || true
         print_warning "Invalid autonomous agent sudoers configuration"
         return 1
@@ -2119,7 +2121,9 @@ printf '%s\n' \
 # Validate before touching the active sudoers include. Install to an ignored
 # dot-file first, then rename atomically so interruption cannot leave a partial
 # rule that locks out subsequent sudo recovery.
-as_root visudo -c -f "$rule_tmp" >/dev/null
+local visudo_cmd="/usr/sbin/visudo"
+[ ! -x "$visudo_cmd" ] && visudo_cmd="visudo"
+as_root "$visudo_cmd" -c -f "$rule_tmp" >/dev/null
 as_root install -o root -g root -m 440 "$rule_tmp" \
     /etc/sudoers.d/.open-ace-autonomous-agent.new
 as_root mv /etc/sudoers.d/.open-ace-autonomous-agent.new \
@@ -2555,7 +2559,12 @@ ${current_user_rules}
     chmod 440 "$sudoers_file"
 
     # Validate sudoers syntax
-    if visudo -c -f "$sudoers_file" &>/dev/null; then
+    # Use absolute path for visudo (may not be in PATH on some systems)
+    local visudo_cmd="/usr/sbin/visudo"
+    if [ ! -x "$visudo_cmd" ]; then
+        visudo_cmd="visudo"  # fallback to PATH lookup
+    fi
+    if $visudo_cmd -c -f "$sudoers_file" &>/dev/null; then
         print_success "Sudoers configured successfully: $sudoers_file"
         print_info "Service account '$run_user' can execute:"
         print_info "  sudo -u <username> $webui_path --port <port>"

--- a/scripts/install-central/package-method/install.sh
+++ b/scripts/install-central/package-method/install.sh
@@ -1992,6 +1992,26 @@ CONF_EOF
     return 0
 }
 
+# Find visudo command with fallback and validation.
+# Returns the visudo command path on success, or returns 1 on failure.
+_find_visudo() {
+    # Expand PATH to include standard sbin directories for fallback scenarios
+    export PATH="/usr/sbin:/usr/local/sbin:$PATH"
+
+    local visudo_cmd="/usr/sbin/visudo"
+    if [ ! -x "$visudo_cmd" ]; then
+        visudo_cmd="visudo"  # fallback to PATH lookup
+    fi
+
+    # Verify the command exists and is executable
+    if ! command -v "$visudo_cmd" &>/dev/null; then
+        print_error "visudo command not found. Please ensure sudo is properly installed."
+        return 1
+    fi
+
+    echo "$visudo_cmd"
+}
+
 # Configure the minimal privilege required by every local autonomous workflow,
 # including the default single-user install.  This is intentionally separate
 # from the broad multi-user workspace sudoers file.
@@ -2007,8 +2027,13 @@ configure_autonomous_agent_sudoers() {
 $run_user ALL=(root) NOPASSWD: $wrapper_path --isolated *
 SUDOERS_EOF
     chmod 440 "$sudoers_file"
-    local visudo_cmd="/usr/sbin/visudo"
-    [ ! -x "$visudo_cmd" ] && visudo_cmd="visudo"
+
+    # Validate sudoers syntax
+    local visudo_cmd
+    if ! visudo_cmd="$(_find_visudo)"; then
+        unlink "$sudoers_file" 2>/dev/null || true
+        return 1
+    fi
     if ! $visudo_cmd -c -f "$sudoers_file" >/dev/null 2>&1; then
         unlink "$sudoers_file" 2>/dev/null || true
         print_warning "Invalid autonomous agent sudoers configuration"
@@ -2121,8 +2146,11 @@ printf '%s\n' \
 # Validate before touching the active sudoers include. Install to an ignored
 # dot-file first, then rename atomically so interruption cannot leave a partial
 # rule that locks out subsequent sudo recovery.
-local visudo_cmd="/usr/sbin/visudo"
-[ ! -x "$visudo_cmd" ] && visudo_cmd="visudo"
+local visudo_cmd
+if ! visudo_cmd="$(_find_visudo)"; then
+    rm -f "$rule_tmp"
+    exit 1
+fi
 as_root "$visudo_cmd" -c -f "$rule_tmp" >/dev/null
 as_root install -o root -g root -m 440 "$rule_tmp" \
     /etc/sudoers.d/.open-ace-autonomous-agent.new
@@ -2559,10 +2587,17 @@ ${current_user_rules}
     chmod 440 "$sudoers_file"
 
     # Validate sudoers syntax
-    # Use absolute path for visudo (may not be in PATH on some systems)
-    local visudo_cmd="/usr/sbin/visudo"
-    if [ ! -x "$visudo_cmd" ]; then
-        visudo_cmd="visudo"  # fallback to PATH lookup
+    local visudo_cmd
+    if ! visudo_cmd="$(_find_visudo)"; then
+        # Restore backup on failure
+        if [ -n "$sudoers_backup" ] && [ -f "$sudoers_backup" ]; then
+            cp -p "$sudoers_backup" "$sudoers_file"
+            chmod 440 "$sudoers_file"
+            print_warning "Restored previous sudoers from $sudoers_backup"
+        else
+            rm -f "$sudoers_file"
+        fi
+        return 1
     fi
     if $visudo_cmd -c -f "$sudoers_file" &>/dev/null; then
         print_success "Sudoers configured successfully: $sudoers_file"


### PR DESCRIPTION
## Summary

修复 install.sh 中 visudo 命令因路径问题导致安装失败的问题。

Fixes #2268

## Problem

在运行 `install.sh` 安装脚本时，在配置 sudoers 权限时失败：

```
[INFO] Backed up existing sudoers to /etc/sudoers.d/open-ace-webui.bak.1785809601
[FAIL] Sudoers syntax error, rolling back...
[WARN] Restored previous sudoers from /etc/sudoers.d/open-ace-webui.bak.1785809601
```

**根本原因**：脚本在调用 `visudo` 命令时没有使用绝对路径。在某些系统上，`/usr/sbin` 不在 PATH 环境变量中：

```bash
# 系统的 PATH
/root/.npm-global/bin:/root/.local/bin:/root/bin:/usr/local/bin:/usr/bin:/bin

# visudo 实际位置
/usr/sbin/visudo
```

## Solution

将所有 `visudo` 调用改为先检测 `/usr/sbin/visudo` 是否存在，如果存在则使用绝对路径，否则回退到 PATH 查找：

```bash
local visudo_cmd="/usr/sbin/visudo"
[ ! -x "$visudo_cmd" ] && visudo_cmd="visudo"
if ! $visudo_cmd -c -f "$sudoers_file" >/dev/null 2>&1; then
    # ...
fi
```

## Changes

修改了三个函数中的 `visudo` 调用：

1. **configure_autonomous_agent_sudoers()** - 自主代理 sudoers 配置（第 2010 行）
2. **configure_autonomous_agent_remote()** - 远程部署时的 sudoers 配置（第 2124 行）
3. **configure_sudoers()** - WebUI sudoers 配置（第 2558 行）

## Testing

- ✅ 验证生成的 sudoers 内容语法正确
- ✅ 使用绝对路径 `/usr/sbin/visudo` 验证成功
- ✅ 安装脚本可以正常完成 sudoers 配置

## Impact

- 修复了在某些系统上安装失败的问题
- 提高了脚本的兼容性和健壮性
- 对现有正常工作的系统无影响（fallback 机制）

## Related

- Issue: #2268
- Related PR: #2267（不冲突，修改位置不同）