### PR TITLE
fix(autonomous): recover worktree onto feature branch after read-only agent checkout (#2271)

### DIFF
--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -1230,6 +1230,7 @@ class AutonomousOrchestrator:
         branch = gh.get_current_branch()
         head = gh.get_current_commit()
         origin = gh._run_git(["remote", "get-url", "origin"], check=False).stdout.strip()
+        main_head = gh._run_git(["rev-parse", "origin/main"], check=False).stdout.strip()
         git_dir = gh._run_git(["rev-parse", "--absolute-git-dir"]).stdout.strip()
         common_dir = gh._run_git(
             ["rev-parse", "--path-format=absolute", "--git-common-dir"]
@@ -1245,12 +1246,74 @@ class AutonomousOrchestrator:
             "top_level": os.path.realpath(top_level) if top_level else "",
             "branch": branch,
             "head": head,
+            "main_head": main_head,
             "origin": origin,
             "git_dir": os.path.realpath(git_dir),
             "common_dir": os.path.realpath(common_dir),
             "git_identity": git_identity,
             "common_identity": common_identity,
         }
+
+    def _recover_worktree_branch(
+        self,
+        gh: "GitHubOps",
+        expected_branch: str,
+        before_head: str,
+        before_main_head: str,
+    ) -> str | None:
+        """Recover the worktree onto ``expected_branch`` after an agent left it
+        on another branch (e.g. a read-only ``git checkout main``). Returns a
+        non-empty reason when recovery was safe and performed (worktree is now
+        on ``expected_branch``); None when the change is NOT safely recoverable
+        and the caller must fail closed (#2271, prod 212/208).
+
+        Recovery runs only when the agent's branch switch was provably
+        read-only:
+
+        * ``expected_branch`` ref is unchanged (``== before_head``) — the agent
+          did not move the feature branch.
+        * The worktree is clean (``git status --porcelain`` empty) — staged or
+          untracked changes would otherwise ride the checkout into the feature
+          branch and get pushed.
+        * The wrong branch's HEAD still equals ``before_main_head`` (the main
+          HEAD captured before the agent ran) — the agent committed nothing to
+          / fetched no advance of the wrong branch. Live ``origin/main`` is
+          intentionally NOT trusted: an agent can ``update-ref`` it.
+
+        Anything else returns None so the caller keeps the #1611 fail-closed
+        guard.
+        """
+        if not expected_branch or not before_head or not before_main_head:
+            return None
+        try:
+            feature_ref = gh._run_git(["rev-parse", expected_branch], check=False).stdout.strip()
+        except Exception:
+            return None
+        if not feature_ref or feature_ref != before_head:
+            return None
+        try:
+            porcelain = gh._run_git(["status", "--porcelain"], check=False).stdout.strip()
+        except Exception:
+            return None
+        if porcelain:
+            return None
+        try:
+            wrong_branch_head = gh.get_current_commit()
+        except Exception:
+            return None
+        if not wrong_branch_head or wrong_branch_head != before_main_head:
+            return None
+        try:
+            gh._run_git(["checkout", expected_branch], check=True)
+        except Exception:
+            return None
+        logger.warning(
+            "Recovered worktree onto %s after an agent left it on another "
+            "branch (read-only checkout); feature ref %s unchanged, worktree clean.",
+            expected_branch,
+            before_head,
+        )
+        return f"recovered worktree onto {expected_branch} after read-only agent branch switch"
 
     def _ancestor_check(self, gh: "GitHubOps", a: str, b: str) -> bool | None:
         """Return True if ``a`` is an ancestor of ``b``, False if not, None on
@@ -1391,10 +1454,33 @@ class AutonomousOrchestrator:
                 f"expected repo root {expected_root}, actual {actual_root}"
             )
         if expected_branch and after_effective.get("branch") != expected_branch:
-            return (
-                "Agent changed the workflow branch unexpectedly: "
-                f"expected {expected_branch}, actual {after_effective.get('branch', '')}"
-            )
+            # #2271 (prod 212/208): an agent may leave the worktree on another
+            # branch via a read-only checkout (e.g. ``git checkout main`` to
+            # read a file). When that switch is provably read-only (feature
+            # branch ref unchanged, worktree clean, wrong-branch HEAD == the
+            # pre-run main HEAD), recover onto expected_branch instead of
+            # permanently failing the workflow. Anything else stays fail-closed.
+            recovered = None
+            try:
+                recover_gh = GitHubOps(repo_path, system_account=system_account)
+                recovered = self._recover_worktree_branch(
+                    recover_gh,
+                    expected_branch,
+                    before_state.get("effective", {}).get("head", ""),
+                    before_state.get("effective", {}).get("main_head", ""),
+                )
+            except Exception:
+                recovered = None
+            if recovered:
+                logger.info("Workflow %s: %s", self._workflow_id[:8], recovered)
+                # Worktree is back on expected_branch; fall through (no
+                # violation). origin/git_dir/common_dir below are unaffected by
+                # a branch-only checkout and remain valid.
+            else:
+                return (
+                    "Agent changed the workflow branch unexpectedly: "
+                    f"expected {expected_branch}, actual {after_effective.get('branch', '')}"
+                )
         before_origin = before_state.get("effective", {}).get("origin", "")
         after_origin = after_effective.get("origin", "")
         if before_origin != after_origin:

--- a/tests/issues/2271/test_worktree_branch_recovery.py
+++ b/tests/issues/2271/test_worktree_branch_recovery.py
@@ -1,0 +1,195 @@
+"""Worktree branch recovery after an agent run (#2271).
+
+When an agent leaves the worktree on ``main`` (a read-only checkout — the
+feature branch's commits are intact), the post-agent integrity guards and the
+pr_review pre-push check fail-closed and permanently fail the workflow (212/208).
+``_recover_worktree_branch`` adds a safe recovery: only when the change is
+provably read-only does it check the feature branch back out; otherwise it
+returns None so callers keep the existing fail-closed safety guard (#1611).
+
+Safe-recovery predicate (all must hold):
+  1. ``expected_branch`` ref is unchanged (``== before_head``) — agent didn't
+     move the feature branch.
+  2. Worktree is clean (``git status --porcelain`` empty) — staged/untracked
+     changes would otherwise carry across ``checkout`` into the feature branch.
+  3. Wrong-branch HEAD == ``before_main_head`` (the main HEAD captured BEFORE
+     the agent ran) — agent didn't commit to / fetch-advance the wrong branch.
+     Live ``origin/main`` is NOT trusted (an agent can ``update-ref`` it).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from unittest.mock import patch
+
+
+@dataclass
+class _GitResult:
+    stdout: str = ""
+    returncode: int = 0
+
+
+class _FakeGh:
+    """Minimal gh stub for ``_recover_worktree_branch``'s git probes."""
+
+    def __init__(self, *, feature_ref, current_head, porcelain, checkout_ok=True):
+        self._feature_ref = feature_ref
+        self._current_head = current_head
+        self._porcelain = porcelain
+        self._checkout_ok = checkout_ok
+        self.checkout_args = None
+
+    def _run_git(self, args, check=False):
+        if args[0] == "rev-parse":
+            return _GitResult(stdout=self._feature_ref)
+        if args[0] == "status" and "--porcelain" in args:
+            return _GitResult(stdout=self._porcelain)
+        if args[0] == "checkout":
+            self.checkout_args = args
+            if not self._checkout_ok:
+                raise RuntimeError("checkout failed")
+            return _GitResult(stdout="")
+        raise AssertionError(f"unexpected git call: {args}")
+
+    def get_current_commit(self):
+        return self._current_head
+
+
+def _make_orchestrator():
+    from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+    with (
+        patch("app.modules.workspace.autonomous.orchestrator.Database"),
+        patch("app.modules.workspace.autonomous.orchestrator.AutonomousWorkflowRepository"),
+    ):
+        return AutonomousOrchestrator("wf-test")
+
+
+EXPECTED = "auto-dev/abc123"
+BEFORE_HEAD = "feat-sha-111"
+BEFORE_MAIN = "main-sha-000"
+
+
+def test_recover_when_safe():
+    """Feature ref unchanged + clean worktree + HEAD == pre-run main → recover."""
+    orch = _make_orchestrator()
+    gh = _FakeGh(feature_ref=BEFORE_HEAD, current_head=BEFORE_MAIN, porcelain="")
+
+    reason = orch._recover_worktree_branch(gh, EXPECTED, BEFORE_HEAD, BEFORE_MAIN)
+
+    assert reason  # non-empty → recovered
+    assert gh.checkout_args == ["checkout", EXPECTED]
+
+
+def test_fail_closed_when_feature_branch_moved():
+    """Agent moved the feature branch ref → not read-only → refuse."""
+    orch = _make_orchestrator()
+    gh = _FakeGh(feature_ref="moved-sha", current_head=BEFORE_MAIN, porcelain="")
+
+    assert orch._recover_worktree_branch(gh, EXPECTED, BEFORE_HEAD, BEFORE_MAIN) is None
+    assert gh.checkout_args is None  # did not checkout
+
+
+def test_fail_closed_when_dirty_worktree():
+    """Staged/untracked changes carry across checkout into the feature branch → refuse."""
+    orch = _make_orchestrator()
+    gh = _FakeGh(feature_ref=BEFORE_HEAD, current_head=BEFORE_MAIN, porcelain=" M file.py\n")
+
+    assert orch._recover_worktree_branch(gh, EXPECTED, BEFORE_HEAD, BEFORE_MAIN) is None
+    assert gh.checkout_args is None
+
+
+def test_fail_closed_when_wrong_branch_head_mismatch():
+    """Wrong-branch HEAD advanced past pre-run main (agent committed/fetched) → refuse."""
+    orch = _make_orchestrator()
+    gh = _FakeGh(feature_ref=BEFORE_HEAD, current_head="newer-main-sha", porcelain="")
+
+    assert orch._recover_worktree_branch(gh, EXPECTED, BEFORE_HEAD, BEFORE_MAIN) is None
+    assert gh.checkout_args is None
+
+
+def test_fail_closed_when_missing_inputs():
+    """No baseline to prove read-only-ness → fail closed."""
+    orch = _make_orchestrator()
+    gh = _FakeGh(feature_ref=BEFORE_HEAD, current_head=BEFORE_MAIN, porcelain="")
+
+    assert orch._recover_worktree_branch(gh, "", BEFORE_HEAD, BEFORE_MAIN) is None
+    assert orch._recover_worktree_branch(gh, EXPECTED, "", BEFORE_MAIN) is None
+    assert orch._recover_worktree_branch(gh, EXPECTED, BEFORE_HEAD, "") is None
+    assert gh.checkout_args is None
+
+
+def test_fail_closed_when_checkout_raises():
+    """If the recovery checkout itself fails, surface None (caller fail-closes)."""
+    orch = _make_orchestrator()
+    gh = _FakeGh(feature_ref=BEFORE_HEAD, current_head=BEFORE_MAIN, porcelain="", checkout_ok=False)
+
+    assert orch._recover_worktree_branch(gh, EXPECTED, BEFORE_HEAD, BEFORE_MAIN) is None
+
+
+# ── central-guard wiring (_validate_repo_context_after_run) ────────────────
+
+
+def _before_state():
+    return {
+        "context": {"repo_path": "/wf", "expected_branch": EXPECTED},
+        "effective": {
+            "head": BEFORE_HEAD,
+            "main_head": BEFORE_MAIN,
+            "repo_path": "/wf",
+            "origin": "o",
+            "git_dir": "g",
+            "common_dir": "c",
+        },
+    }
+
+
+def _after_state_on_main():
+    # Worktree was left on main, but origin/git_dir/common_dir unchanged.
+    return {
+        "branch": "main",
+        "head": BEFORE_MAIN,
+        "top_level": "/wf",
+        "origin": "o",
+        "git_dir": "g",
+        "common_dir": "c",
+    }
+
+
+def test_central_guard_recovers_when_safe():
+    """Post-agent guard recovers (returns '') when the agent left the worktree
+    on main read-only, instead of failing the workflow closed (#2271, 208)."""
+    from unittest.mock import patch
+
+    orch = _make_orchestrator()
+    fake_gh = _FakeGh(feature_ref=BEFORE_HEAD, current_head=BEFORE_MAIN, porcelain="")
+    with (
+        patch.object(orch, "_capture_repo_state", return_value=_after_state_on_main()),
+        patch(
+            "app.modules.workspace.autonomous.orchestrator.GitHubOps",
+            return_value=fake_gh,
+        ),
+    ):
+        result = orch._validate_repo_context_after_run(_before_state(), system_account=None)
+
+    assert result == ""  # recovered → no violation
+    assert fake_gh.checkout_args == ["checkout", EXPECTED]
+
+
+def test_central_guard_fails_closed_when_feature_branch_moved():
+    """Feature branch ref moved → recovery refuses → guard returns the violation."""
+    from unittest.mock import patch
+
+    orch = _make_orchestrator()
+    fake_gh = _FakeGh(feature_ref="moved-sha", current_head=BEFORE_MAIN, porcelain="")
+    with (
+        patch.object(orch, "_capture_repo_state", return_value=_after_state_on_main()),
+        patch(
+            "app.modules.workspace.autonomous.orchestrator.GitHubOps",
+            return_value=fake_gh,
+        ),
+    ):
+        result = orch._validate_repo_context_after_run(_before_state(), system_account=None)
+
+    assert "Agent changed the workflow branch unexpectedly" in result
+    assert fake_gh.checkout_args is None  # did not recover


### PR DESCRIPTION
## 根因（实证）
agent 跑完后偶尔把 worktree 留在 \`main\`（只读 \`git checkout main\` 读文件），#1611 的 post-agent 完整性守卫 fail-closed \`Agent changed the workflow branch unexpectedly\` → 工作流永久 failed，即便特性分支提交完好可恢复。prod 208（planning）即此；212 的推送时切 main 是阶段间的另一触发，本 PR 先修 agent-run 触发，212 的推送路径作 follow-up。

212 的特性分支 \`auto-dev/410055bf\` 仍持有 agent 的 dev 提交（\`45b2c19f\`/\`9c7efb98\` atop main），证明 agent 是**只读切 main**（没往 main 提交、没移动特性分支）。

## 修法（recover-when-safe，放宽 #1611 分支错配分支）
新增 \`_recover_worktree_branch(gh, expected_branch, before_head, before_main_head)\`：worktree 不在特性分支时，仅当**全部**满足才 \`checkout\` 恢复：
1. 特性分支 ref 未变（\`== before_head\`）；
2. worktree 干净（\`git status --porcelain\` 为空——实测脏工作区 staged/untracked 改动会跨 checkout 带到特性分支被推送）；
3. wrong-branch HEAD == 跑前捕获的 main HEAD（**不用活的 origin/main**——agent 可 \`update-ref\` 篡改）。
任一不满足 → 返回 None，调用方保持 fail-closed。\`_capture_repo_state\` 加 \`main_head\` 捕获供 (3)。

接到中央 post-agent 守卫 \`_validate_repo_context_after_run\`（一处覆盖 planning/dev/pr_review/CI-repair agent run）；repo-escape/origin/git-metadata 校验仍 fail-closed。

## 独立审查
计划已过独立审查（4 条意见全部采纳）：clean-worktree 硬要求（致命，实测脏工作区携带）/ 不信活 origin/main（高危，update-ref 绕过）/ 只接中央守卫不接冗余二次检查（7154/2419）/ 已有盲目 checkout（_get_gh 1107、dev 7029）显式划出范围（pre-agent 无 mutation 风险）。

## 测试
8 个：6 helper 单测（recover-when-safe + 5 fail-closed 场景：feature 移动/脏工作区/wrong-branch HEAD 变/缺输入/checkout 失败）+ 2 接线测试（中央守卫安全时恢复返回空、不安全时返回违规）。236 相关测试（完整性守卫 + #2022 sandbox）无回归。

## 范围
- ✅ agent-run 触发的 worktree-on-main（208）。
- ⏳ follow-up：212 的推送时切 main（dev→pr_review 阶段间触发，需 PhaseHost-protocol 推送路径接线 + before_head 在 phase-entry 捕获）。
- ⏳ follow-up：已有盲目 checkout（1107/7029）统一走 helper。

Closes #2271.

🤖 Generated with [Claude Code](https://claude.com/claude-code)