### PR TITLE
fix(install): Package版添加OPENACE_ENCRYPTION_KEY环境变量

### DIFF
--- a/scripts/install-central/package-method/install.sh
+++ b/scripts/install-central/package-method/install.sh
@@ -2681,9 +2681,14 @@ install_systemd_service() {
     fi
     print_info "Using Python: $python_path"
 
-    # Generate SECRET_KEY for Flask session and API key encryption
+    # Generate SECRET_KEY for Flask session
     local secret_key="${SECRET_KEY:-$(openssl rand -hex 32)}"
     print_info "Generated SECRET_KEY for Flask encryption"
+
+    # Generate OPENACE_ENCRYPTION_KEY for API key and SMTP password encryption
+    # This key is separate from SECRET_KEY per PR #1871 security hardening
+    local enc_key="${OPENACE_ENCRYPTION_KEY:-$(openssl rand -hex 16)}"
+    print_info "Generated OPENACE_ENCRYPTION_KEY for sensitive data encryption"
 
     # Create service file from template
     print_info "Creating systemd service file..."
@@ -2695,6 +2700,7 @@ install_systemd_service() {
         -e "s|__PYTHON__|$python_path|g" \
         -e "s|__HOME__|$home_dir|g" \
         -e "s|__SECRET_KEY__|$secret_key|g" \
+        -e "s|__OPENACE_ENCRYPTION_KEY__|$enc_key|g" \
         -e "s|__WORKSPACE_BASE_DIR__|$WORKSPACE_BASE_DIR|g" \
         "$service_template" > "$service_file"
 
@@ -2790,9 +2796,14 @@ install_systemd_service_remote() {
     fi
     print_info "Using Python on remote: $python_path"
 
-    # Generate SECRET_KEY for Flask session and API key encryption
+    # Generate SECRET_KEY for Flask session
     local secret_key="${SECRET_KEY:-$(openssl rand -hex 32)}"
     print_info "Generated SECRET_KEY for Flask encryption"
+
+    # Generate OPENACE_ENCRYPTION_KEY for API key and SMTP password encryption
+    # This key is separate from SECRET_KEY per PR #1871 security hardening
+    local enc_key="${OPENACE_ENCRYPTION_KEY:-$(openssl rand -hex 16)}"
+    print_info "Generated OPENACE_ENCRYPTION_KEY for sensitive data encryption"
 
     # Generate service file content locally using sed
     local service_content=$(sed -e "s|__USER__|$user|g" \
@@ -2803,6 +2814,7 @@ install_systemd_service_remote() {
         -e "s|__PYTHON__|$python_path|g" \
         -e "s|__HOME__|$home_dir|g" \
         -e "s|__SECRET_KEY__|$secret_key|g" \
+        -e "s|__OPENACE_ENCRYPTION_KEY__|$enc_key|g" \
         -e "s|__WORKSPACE_BASE_DIR__|$WORKSPACE_BASE_DIR|g" \
         "$service_template")
 

--- a/scripts/open-ace.service
+++ b/scripts/open-ace.service
@@ -19,6 +19,7 @@ Environment=AI_TOKEN_WEB_PORT=__PORT__
 Environment=AI_TOKEN_WEB_HOST=__HOST__
 Environment=HOME=__HOME__
 Environment=SECRET_KEY=__SECRET_KEY__
+Environment=OPENACE_ENCRYPTION_KEY=__OPENACE_ENCRYPTION_KEY__
 Environment=WORKSPACE_BASE_DIR=__WORKSPACE_BASE_DIR__
 
 # Security settings


### PR DESCRIPTION
## 问题

Package 版部署后访问 `/api/api-keys` 页面返回 500 错误。

Fixes #2274

## 根因

- PR #1871 引入了独立的 `OPENACE_ENCRYPTION_KEY`（用于加密 API Key/SMTP 密码）
- Docker 版通过 `docker-entrypoint.sh` 的 `ensure_secret_env()` 自动生成
- Package 版的 `install.sh` 和 `scripts/open-ace.service` 未同步更新

## 修改

1. `scripts/open-ace.service`: 添加 `Environment=OPENACE_ENCRYPTION_KEY=__OPENACE_ENCRYPTION_KEY__`
2. `scripts/install-central/package-method/install.sh`:
   - `install_systemd_service()`: 生成并设置 `OPENACE_ENCRYPTION_KEY`
   - `install_systemd_service_remote()`: 同样处理远程部署

## 测试

- 用户执行 `install.sh` 后，systemd 服务正确配置 `OPENACE_ENCRYPTION_KEY`
- API Keys 页面正常加载

## 相关

- Issue #2274
- PR #1871
- Issue #998