### PR TITLE
fix(scheduler): complete web/scheduler split deployment (#2277)

### DIFF
--- a/app/scheduler_worker.py
+++ b/app/scheduler_worker.py
@@ -140,8 +140,11 @@ class SchedulerWorker:
             # Import check script
             import scripts.check_min_revision
 
-            # Run check
-            if not scripts.check_min_revision.check_min_revision():
+            # Run check. scripts.check_min_revision.main() returns 0 when the
+            # DB revision is on the supported lineage (or the DB is fresh), and
+            # non-zero when it's too old/unsupported — the same semantics the
+            # CLI entry point uses.
+            if scripts.check_min_revision.main() != 0:
                 logger.error(
                     "Database schema version is too old. "
                     "Required: baseline_2026_06_23. "

--- a/scripts/open-ace.service
+++ b/scripts/open-ace.service
@@ -21,6 +21,17 @@ Environment=HOME=__HOME__
 Environment=SECRET_KEY=__SECRET_KEY__
 Environment=WORKSPACE_BASE_DIR=__WORKSPACE_BASE_DIR__
 
+# Secrets (OPENACE_ENCRYPTION_KEY; encrypts API keys / SMTP passwords). The web
+# service must share the SAME key as the scheduler worker (openace-scheduler.
+# service) so encrypted data written by one can be read by the other. The
+# leading '-' makes the file OPTIONAL: existing deployments without it keep the
+# development-mode (ephemeral-key) behaviour; deployments that persist a key
+# there get durable encryption. See openace-scheduler.service for how to
+# generate + persist it. NOTE: SCHEDULER_MODE is intentionally unset here so
+# the web process runs NO background services (the scheduler worker owns them
+# since #2187).
+EnvironmentFile=-/etc/openace/secrets.env
+
 # Security settings
 NoNewPrivileges=true
 PrivateTmp=true

--- a/scripts/openace-scheduler.service
+++ b/scripts/openace-scheduler.service
@@ -1,0 +1,46 @@
+[Unit]
+Description=Open ACE - Scheduler Worker (background services)
+Documentation=https://github.com/open-ace/open-ace
+After=network.target
+
+[Service]
+Type=simple
+User=__USER__
+Group=__GROUP__
+WorkingDirectory=__INSTALL_PATH__
+ExecStart=__PYTHON__ -m app.scheduler_worker
+Restart=always
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+
+# Environment variables
+# SCHEDULER_MODE=scheduler makes this process run ALL background services
+# (autonomous scheduler, data fetch, quota enforcement, alert compensation,
+# SSO cleanup, health monitor) via leader election. The web service
+# (open-ace.service) runs with SCHEDULER_MODE unset (defaults to "web") and
+# starts NO background services — the two roles are split since #2187.
+Environment=SCHEDULER_MODE=scheduler
+Environment=HOME=__HOME__
+Environment=SECRET_KEY=__SECRET_KEY__
+Environment=WORKSPACE_BASE_DIR=__WORKSPACE_BASE_DIR__
+
+# Secrets (OPENACE_ENCRYPTION_KEY at minimum; encrypts API keys / SMTP
+# passwords). The leading '-' makes the file OPTIONAL: installs without it
+# keep the old (development-mode, ephemeral-key) behaviour so existing
+# deployments are not broken; installs that persist a key there get durable
+# encryption across restarts. Generate once:
+#   OPENACE_ENCRYPTION_KEY=$(python3 -c 'import secrets; print(secrets.token_hex(32))')
+# and write it to /etc/openace/secrets.env (root:root, mode 0600), then
+# reference it from BOTH this unit and open-ace.service so web + scheduler
+# share the same key (else encrypted data written by one can't be read by
+# the other). WARNING: changing the key makes existing encrypted data
+# (api_key_store, smtp_settings) unreadable — re-enter those credentials.
+EnvironmentFile=-/etc/openace/secrets.env
+
+# Security settings
+NoNewPrivileges=true
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target

--- a/tests/issues/2277/test_scheduler_worker_schema_check.py
+++ b/tests/issues/2277/test_scheduler_worker_schema_check.py
@@ -1,0 +1,48 @@
+"""scheduler_worker._check_schema_version must call check_min_revision.main() (#2277).
+
+PR#2214's scheduler_worker shipped calling ``scripts.check_min_revision.
+check_min_revision()`` — a function that does not exist (the module exposes
+``main``/``collect_active_revision_ids``/``is_supported_revision``). The
+scheduler crashed on its first prod start (AttributeError → ``sys.exit(1)`` →
+restart loop) because the worker had never been exercised in CI or prod. These
+tests pin the correct API: ``main()`` returns 0 on a supported/fresh DB and
+non-zero when too old.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+# scheduler_worker.py has a module-level guard that sys.exit(1)s unless
+# SCHEDULER_MODE=="scheduler". Set it before the deferred import in _run_check.
+os.environ["SCHEDULER_MODE"] = "scheduler"
+
+
+def _run_check() -> None:
+    """Invoke _check_schema_version without running SchedulerWorker.__init__.
+
+    The method only imports the check module and logs/exits — it touches no
+    instance state — so an un-initialized instance is sufficient and avoids
+    the heavy app-context construction of the full worker.
+    """
+    from app.scheduler_worker import SchedulerWorker
+
+    instance = SchedulerWorker.__new__(SchedulerWorker)
+    SchedulerWorker._check_schema_version(instance)
+
+
+def test_schema_check_passes_when_main_returns_zero():
+    """main() == 0 (supported revision / fresh DB) → no exit, no raise."""
+    with patch("scripts.check_min_revision.main", return_value=0):
+        _run_check()  # should not raise
+
+
+def test_schema_check_exits_when_main_returns_nonzero():
+    """main() != 0 (DB too old / unsupported) → SystemExit(1)."""
+    with patch("scripts.check_min_revision.main", return_value=1):
+        with pytest.raises(SystemExit) as exc_info:
+            _run_check()
+        assert exc_info.value.code == 1


### PR DESCRIPTION
## 背景
PR#2214（#2187）引入 web/scheduler 拆分 + 分布式调度 + leader 选举，但两个缺口导致 scheduler 无法部署：

1. **scheduler_worker.py 调了不存在的函数**：\`_check_schema_version\` 调 \`scripts.check_min_revision.check_min_revision()\`，该模块只有 \`main()\`。scheduler 首次在 prod 启动即 AttributeError → sys.exit → crash-loop（worker 从没在 CI/prod 跑过，bug 没暴露）。
2. **缺部署产物**：仓库无 scheduler 服务单元，web 单元也没设 \`OPENACE_ENCRYPTION_KEY\`/\`SCHEDULER_MODE\`。10:21 手动部署只起 web 半边（scheduler 关、加密密钥缺失）→ 所有后台服务停 + LLM 代理无法解密 API key。

## 修复
1. \`scheduler_worker.py\`：\`check_min_revision()\` → \`main() != 0\`（main 返 0=正常/非0=太旧，与 CLI 入口同语义）。加 2 个单测（mock main → 0 通过 / → 非0 exit）——缺测试正是 bug 上线的原因。
2. 加 \`scripts/openace-scheduler.service\` 模板（\`ExecStart=__PYTHON__ -m app.scheduler_worker\`、\`SCHEDULER_MODE=scheduler\`、\`EnvironmentFile\`）。
3. \`scripts/open-ace.service\`（web）加 \`EnvironmentFile=-/etc/openace/secrets.env\`（\`-\`=可选，旧部署无文件不受影响）+ 注释说明 SCHEDULER_MODE 在 web 不设（后台服务归 scheduler，#2187）。
4. 两单元都文档化了 \`OPENACE_ENCRYPTION_KEY\` 的生成 + web/scheduler 共享。

## 测试
- \`tests/issues/2277/test_scheduler_worker_schema_check.py\`：2 个（main→0 通过 / main→非0 SystemExit）。
- pre-commit 全过（black/isort/ruff/mypy/bandit/pydocstyle）。

## prod 状态（已临时修复，本 PR 入库可复现）
- scheduler_worker bug 已热补丁（main()!=0），scheduler 服务已在 prod 跑（所有后台服务恢复：autonomous/quota/data_fetch/alert/SSO/health）。
- 部署产物（scheduler.service + /etc/openace/secrets.env 密钥）已在 prod 手动配置。

Closes #2277.

🤖 Generated with [Claude Code](https://claude.com/claude-code)