### PR TITLE
fix(install): restore cross-user (ALL) runas for OPENACE_UTILS (#2280)

### DIFF
--- a/scripts/install-central/package-method/install.sh
+++ b/scripts/install-central/package-method/install.sh
@@ -2247,8 +2247,15 @@ $run_user ALL=(root) NOPASSWD: $python_bin $script_path *"
 
     # 【安全加固 Issue #1262 + #2181】使用 Cmnd_Alias 引用
     # utility_rule 在用户规则中引用 OPENACE_UTILS Cmnd_Alias
-    # 【Issue #2181】限制 runas 为 root（原 ALL 改为 root）
-    local utility_rule="$run_user ALL=(root) NOPASSWD: OPENACE_UTILS"
+    # 【Issue #2280】runas 必须保留 (ALL)：github_ops 的服务端 git/gh 以
+    # `sudo -u <system_account>` 跨用户执行（#1395），无法改走
+    # openace-run-as --isolated（reject owner==target / env -i 剥凭据 /
+    # credentialless 账户模型）；fs.py/projects.py/autonomous.py 的跨用户
+    # test/ls/stat/mkdir 同理。#2181 曾把这里从 (ALL) 收紧为 (root)，部署后
+    # 所有 system_account≠openace 的工作流在 preparation `git fetch` 处全挂。
+    # 仅还 runas 目标；#2181 的 agent CLI 隔离（run-as --isolated）、移除
+    # cat/chown/useradd/rm、env_keep 收紧均保留。
+    local utility_rule="$run_user ALL=(ALL) NOPASSWD: OPENACE_UTILS"
 
     # 【安全加固 Issue #2181】删除 AI CLI 通配规则
     # 原 cli_rule 已删除，所有 AI CLI 启动必须通过 openace-run-as --isolated

--- a/tests/issues/2280/test_sudoers_cross_user_git.py
+++ b/tests/issues/2280/test_sudoers_cross_user_git.py
@@ -1,0 +1,78 @@
+"""The OPENACE_UTILS sudoers rule must permit cross-user runas (#2280).
+
+github_ops runs the orchestrator's server-side git/gh as ``sudo -u
+<system_account>`` (Issue #1395: the openace service user drives a repo owned
+by another user under a 0700 home). ``test_github_ops_sudo.py`` pins that
+command shape (``["sudo","-u","<account>","gh"]``), so the generated sudoers
+MUST authorize non-root runas for git/gh.
+
+Autonomous commit 26508b077 (Issue #2181) tightened ``install.sh`` to emit
+``ALL=(root) NOPASSWD: OPENACE_UTILS`` on the assumption that every cross-user
+operation goes through ``openace-run-as --isolated``. That assumption is false
+for github_ops, which cannot use run-as:
+
+  1. run-as rejects ``target_user == project_owner`` (the common case: worktree
+     owned by the system_account) — exit 67.
+  2. run-as starts the child with ``env -i`` → strips ``GH_TOKEN``/git
+     credentials → gh and authenticated git push break.
+  3. run-as is a credentialless-account, worktree-only-ACL model for untrusted
+     agent CLIs — not a run-as-repo-owner runner for trusted server git.
+
+So ``(root)``-only is unrecoverable for github_ops. Once an install ran the
+regressed ``install.sh`` (prod 2026-08-04 10:21), every
+``system_account != openace`` workflow failed at preparation ``git fetch``.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+INSTALL_SH = (
+    Path(__file__).resolve().parents[3]
+    / "scripts"
+    / "install-central"
+    / "package-method"
+    / "install.sh"
+)
+
+
+def _openace_utils_runas_targets() -> list[str]:
+    """Runas targets of every OPENACE_UTILS *user-rule* in install.sh.
+
+    Matches ``<user> ALL=(<target>) NOPASSWD: OPENACE_UTILS`` (the user spec
+    that references the alias), NOT the ``Cmnd_Alias OPENACE_UTILS = ...``
+    definition line.
+    """
+    text = INSTALL_SH.read_text()
+    return re.findall(
+        r"ALL=\(([A-Za-z_][A-Za-z0-9_-]*|\*)\)\s*NOPASSWD:\s*OPENACE_UTILS\b",
+        text,
+    )
+
+
+def test_openace_utils_permits_cross_user_runas():
+    """OPENACE_UTILS must allow non-root runas so github_ops can sudo -u <account>.
+
+    Asserting ``ALL`` (not ``root``) because github_ops's cross-user git/gh has
+    no run-as alternative (#2280). A ``(root)``-only rule fails every
+    system_account!=openace workflow at the first ``git fetch``.
+    """
+    targets = _openace_utils_runas_targets()
+    assert targets, "No OPENACE_UTILS user-rule found in install.sh (did the rule move?)"
+    assert "ALL" in targets, (
+        f"OPENACE_UTILS runas tightened to {targets!r}; github_ops needs "
+        "cross-user (ALL) for `sudo -u <system_account>` (#2280, #1395)."
+    )
+
+
+def test_agent_cli_isolation_hardening_intact():
+    """Reverting OPENACE_UTILS runas must NOT undo #2181's agent-CLI hardening.
+
+    Agent CLIs still launch only through ``openace-run-as --isolated``; the
+    broad standalone AI-CLI wildcard rule (``NOPASSWD: OPENACE_CLI``) stays
+    removed. Only the OPENACE_UTILS *runas target* is restored.
+    """
+    text = INSTALL_SH.read_text()
+    assert "openace-run-as --isolated" in text, "run-as --isolated launcher rule missing"
+    assert "NOPASSWD: OPENACE_CLI" not in text, "broad OPENACE_CLI wildcard rule reintroduced"


### PR DESCRIPTION
## Problem

Autonomous workflows with `system_account != openace` fail at preparation:
```
git fetch origin main failed (exit 1): sudo: a password is required
openace : command not allowed ; USER=rhuang ; COMMAND=/usr/bin/git ... -C /home/rhuang/open-ace/.worktrees/...
```

## Root cause

Autonomous commit `26508b077` (#2181, 2026-08-02) changed `install.sh:2251`:
```diff
- local utility_rule="$run_user ALL=(ALL) NOPASSWD: OPENACE_UTILS"
+ local utility_rule="$run_user ALL=(root) NOPASSWD: OPENACE_UTILS"
```
intent: "all AI CLI launches go through openace-run-as --isolated". That premise is **false for `github_ops`**, which runs server-side git/gh as `sudo -u <system_account>` (#1395 — openace service user drives a repo owned by another user under a 0700 home). `test_github_ops_sudo.py` pins that command shape (`["sudo","-u","<account>","gh"]`).

`github_ops` **cannot** migrate to `openace-run-as --isolated`:
1. rejects `target_user == project_owner` (exit 67) — the common case (worktree owned by the system_account)
2. `env -i` strips `GH_TOKEN`/git creds → gh + git push break
3. credentialless-account, worktree-only-ACL model for untrusted agent CLIs, not a run-as-repo-owner runner

Independent review confirmed the blast radius is wider than github_ops: `fs.py`/`projects.py`/`autonomous.py`/`agent_runner.py` cross-user `test`/`ls`/`stat`/`mkdir` are equally broken under `(root)`-only.

Deployed to prod 2026-08-04 10:21 → every `system_account != openace` workflow broke at `git fetch`. 208 confirmed.

## Fix

Revert the runas target `(root)` → `(ALL)` for OPENACE_UTILS. Only this one token changes — #2181's legitimate hardening stays (guarded by a test):
- agent CLI launches still route through `openace-run-as --isolated`
- `cat/chown/useradd/rm` stay removed from the alias (routed to wrappers)
- `OPENACE_CLI` broad wildcard stays removed
- `env_keep` sensitive-var exclusion stays

Runas must be generic `(ALL)`, not scoped narrower: these commands must run **as the repo owner** (the system_account), never root, so `(root)` cannot satisfy them.

## Tests

- `tests/issues/2280/test_sudoers_cross_user_git.py`
  - `test_openace_utils_permits_cross_user_runas` — asserts the emitted rule grants cross-user runas (the missing CI assertion that let #2181 ship). Fails on main, passes with this fix.
  - `test_agent_cli_isolation_hardening_intact` — asserts run-as --isolated present + no `OPENACE_CLI` wildcard, so the revert can't silently over-revert #2181.

CI gap noted (independent review): all sudoers coverage is source-grep; nothing generates the sudoers and runs a real `sudo -u <account> git`. This PR closes the source-level gap; live-sudoers behavior remains untested (hard in CI without the deployed `openace` user + installed sudoers).

## Out of scope (separate follow-up)

Independent review flagged a **pre-existing, unrelated** regression: cross-user `cat` (`fs.py:1278`, `agent_runner.py:1061`) is broken because #2181 removed `cat` from OPENACE_UTILS (routed to `openace-cat` wrapper) — not caused by the `(root)` tightening this PR fixes. Tracked separately.

## Prod

Sudoers hotpatched on prod at the same time (OPENACE_UTILS `(root)`→`(ALL)` in `/etc/sudoers.d/open-ace-webui`, backup + visudo-validated); 208 advanced past preparation into planning immediately after. This PR makes the install reproduce that correct state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)