### PR TITLE
fix(autonomous): exclude merge-introduced changes from scope validation

### DIFF
--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -1940,6 +1940,19 @@ class AutonomousOrchestrator:
             )
         return ""
 
+    @staticmethod
+    def _is_merge_commit(gh: GitHubOps, commit_sha: str) -> bool:
+        """Check if a commit is a merge commit (has two parents).
+
+        A merge commit has at least two parent commits (SHA^1 and SHA^2).
+        Regular commits have only one parent (SHA^1).
+        """
+        try:
+            result = gh._run_git(["rev-parse", f"{commit_sha}^2"], check=False)
+            return result.returncode == 0
+        except Exception:
+            return False
+
     def _validate_autonomous_change_scope(
         self,
         gh: GitHubOps,
@@ -1950,6 +1963,33 @@ class AutonomousOrchestrator:
         """Fail closed on both per-round and cumulative branch scope."""
         if not commit_before or not commit_after:
             return "Autonomous change scope could not be verified: missing commit boundary"
+
+        # If commit_after is a merge commit, use merge-base to find effective base.
+        # This excludes changes introduced by merging upstream main, which should not
+        # count as autonomous changes. This mirrors the logic in
+        # _validate_pre_merge_change_scope for consistent scope validation.
+        if self._is_merge_commit(gh, commit_after):
+            try:
+                gh._run_git(["fetch", "origin", "main"])
+                fetched_main_head = gh.resolve_commit("FETCH_HEAD")
+                merge_base_result = gh._run_git(
+                    ["merge-base", commit_after, fetched_main_head], check=False
+                )
+                effective_base = merge_base_result.stdout.strip()
+                if merge_base_result.returncode == 0 and effective_base:
+                    # Use merge-base as the effective round base for scope validation.
+                    # This only counts changes in the PR branch, not merge-introduced changes.
+                    commit_before = effective_base
+                    logger.info(
+                        "Merge commit detected: using merge-base %s as effective round base",
+                        effective_base[:12],
+                    )
+            except Exception as exc:
+                # Fallback to original logic if merge-base derivation fails
+                logger.warning(
+                    "Failed to derive merge-base for merge commit scope validation: %s", exc
+                )
+
         ranges = [("current round", commit_before)]
         cumulative_base = (wf.get("base_commit_sha") or "").strip()
         if not cumulative_base:

--- a/tests/issues/2189/test_merge_commit_scope_validation.py
+++ b/tests/issues/2189/test_merge_commit_scope_validation.py
@@ -1,0 +1,140 @@
+"""Test merge commit scope validation fix (Issue #2189).
+
+Tests that scope validation correctly excludes changes introduced by
+merging upstream main, only counting changes made in the PR branch.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from app.modules.workspace.autonomous.github_ops import GitHubOps
+from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+
+class TestMergeCommitScopeValidation(unittest.TestCase):
+    """Test scope validation for merge commits."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.orchestrator = AutonomousOrchestrator.__new__(AutonomousOrchestrator)
+        self.gh = MagicMock(spec=GitHubOps)
+
+    def test_is_merge_commit_true(self):
+        """Test that merge commits are correctly identified."""
+        # Mock rev-parse succeeds for ^2 (second parent exists)
+        self.gh._run_git.return_value = MagicMock(returncode=0, stdout="abc123")
+
+        result = self.orchestrator._is_merge_commit(self.gh, "merge_commit_sha")
+
+        self.assertTrue(result)
+        self.gh._run_git.assert_called_once_with(["rev-parse", "merge_commit_sha^2"], check=False)
+
+    def test_is_merge_commit_false(self):
+        """Test that regular commits are correctly identified."""
+        # Mock rev-parse fails for ^2 (no second parent)
+        self.gh._run_git.return_value = MagicMock(returncode=128, stdout="")
+
+        result = self.orchestrator._is_merge_commit(self.gh, "regular_commit_sha")
+
+        self.assertFalse(result)
+        self.gh._run_git.assert_called_once_with(["rev-parse", "regular_commit_sha^2"], check=False)
+
+    def test_is_merge_commit_exception(self):
+        """Test exception handling in merge commit detection."""
+        # Mock raises exception
+        self.gh._run_git.side_effect = Exception("Git error")
+
+        result = self.orchestrator._is_merge_commit(self.gh, "any_sha")
+
+        self.assertFalse(result)
+
+    def test_scope_validation_regular_commit(self):
+        """Test that regular commits use original logic."""
+        wf = {"base_commit_sha": "commit_before"}  # Same as commit_before, so only 1 range
+
+        # Mock: not a merge commit
+        with patch.object(self.orchestrator, "_is_merge_commit", return_value=False):
+            # Mock: get_changed_files returns few files
+            self.gh.get_changed_files.return_value = ["file1.py", "file2.py"]
+
+            result = self.orchestrator._validate_autonomous_change_scope(
+                self.gh, wf, "commit_before", "commit_after"
+            )
+
+            # Should pass (only 2 files)
+            self.assertEqual(result, "")
+            # Should use original commit_before
+            self.gh.get_changed_files.assert_called_once_with("commit_before", "commit_after")
+
+    def test_scope_validation_merge_commit(self):
+        """Test that merge commits use merge-base."""
+        wf = {"base_commit_sha": "merge_base_sha"}  # Same as effective_base, so only 1 range
+
+        # Mock: is a merge commit
+        with patch.object(self.orchestrator, "_is_merge_commit", return_value=True):
+            # Mock: fetch and resolve_commit
+            self.gh._run_git.return_value = MagicMock(returncode=0, stdout="merge_base_sha\n")
+            self.gh.resolve_commit.return_value = "fetched_main_head"
+
+            # Mock: get_changed_files returns few files (PR branch only)
+            self.gh.get_changed_files.return_value = ["file1.py", "file2.py"]
+
+            result = self.orchestrator._validate_autonomous_change_scope(
+                self.gh, wf, "commit_before", "merge_commit_after"
+            )
+
+            # Should pass (only 2 files in PR branch)
+            self.assertEqual(result, "")
+            # Should use merge-base as base
+            self.gh.get_changed_files.assert_called_once_with(
+                "merge_base_sha", "merge_commit_after"
+            )
+
+    def test_scope_validation_merge_commit_excludes_upstream(self):
+        """Test that merge commits exclude upstream changes from scope."""
+        wf = {"base_commit_sha": ""}  # Legacy workflow without base_commit_sha
+
+        # Mock: is a merge commit
+        with patch.object(self.orchestrator, "_is_merge_commit", return_value=True):
+            # Mock: fetch succeeds
+            self.gh._run_git.return_value = MagicMock(returncode=0, stdout="merge_base_sha\n")
+            self.gh.resolve_commit.return_value = "fetched_main_head"
+
+            # Mock: get_changed_files - if we used wrong base, would return 87 files
+            # But with merge-base, returns only 10 files (PR branch only)
+            self.gh.get_changed_files.return_value = [f"file{i}.py" for i in range(10)]
+
+            # Mock: _update_workflow (for base_commit_sha backfill)
+            with patch.object(self.orchestrator, "_update_workflow"):
+                result = self.orchestrator._validate_autonomous_change_scope(
+                    self.gh, wf, "commit_before", "merge_commit_after"
+                )
+
+            # Should pass (only 10 files, under limit of 60)
+            self.assertEqual(result, "")
+
+    def test_scope_validation_merge_commit_fallback(self):
+        """Test fallback to original logic when merge-base derivation fails."""
+        wf = {"base_commit_sha": "commit_before"}  # Same as commit_before, so only 1 range
+
+        # Mock: is a merge commit
+        with patch.object(self.orchestrator, "_is_merge_commit", return_value=True):
+            # Mock: fetch succeeds but merge-base fails
+            self.gh._run_git.return_value = MagicMock(returncode=128, stdout="")
+            self.gh.resolve_commit.return_value = "fetched_main_head"
+
+            # Mock: get_changed_files with original base
+            self.gh.get_changed_files.return_value = ["file1.py", "file2.py"]
+
+            result = self.orchestrator._validate_autonomous_change_scope(
+                self.gh, wf, "commit_before", "merge_commit_after"
+            )
+
+            # Should fallback to original logic
+            self.assertEqual(result, "")
+            # Should use original commit_before (fallback)
+            self.gh.get_changed_files.assert_called_once_with("commit_before", "merge_commit_after")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_autonomous_ci_guardrails.py
+++ b/tests/unit/test_autonomous_ci_guardrails.py
@@ -196,7 +196,10 @@ def test_cumulative_scope_guard_derives_immutable_base_when_main_moved(monkeypat
         ["app/a.py", "app/b.py"],
     ]
 
-    reason = orch._validate_autonomous_change_scope(gh, {}, "round-base", "head")
+    # Mock _is_merge_commit to return False (not a merge commit)
+    # so the test focuses on cumulative scope guard logic
+    with patch.object(orch, "_is_merge_commit", return_value=False):
+        reason = orch._validate_autonomous_change_scope(gh, {}, "round-base", "head")
 
     assert reason == ""
     gh._run_git.assert_called_once_with(["merge-base", "head", "origin/main"], check=False)
@@ -212,7 +215,9 @@ def test_cumulative_scope_guard_fails_closed_when_base_cannot_be_derived():
     gh = MagicMock()
     gh._run_git.return_value = MagicMock(returncode=1, stdout="")
 
-    reason = orch._validate_autonomous_change_scope(gh, {}, "round-base", "head")
+    # Mock _is_merge_commit to return False (not a merge commit)
+    with patch.object(orch, "_is_merge_commit", return_value=False):
+        reason = orch._validate_autonomous_change_scope(gh, {}, "round-base", "head")
 
     assert "missing immutable base commit" in reason
     gh.get_changed_files.assert_not_called()


### PR DESCRIPTION
## Problem

Workflow 208 (Issue #2189) failed with error:
```
Current round Autonomous change scope exceeded: 96 files changed (limit 60)
```

But actual PR #2282 only modified 10 files.

## Root Cause

When the workflow merged upstream main during PR review, the scope validator used:
```python
git diff --name-only commit_before commit_after
```

This counted 87 files introduced by the merge commit, which should not count as autonomous changes.

## Fix

- Detect merge commits using `git rev-parse SHA^2`
- Use merge-base to find the effective PR base
- Only count changes in the PR branch, not merge-introduced changes
- Fallback to original logic if merge-base derivation fails

## Changes

- Add `_is_merge_commit()` helper method in orchestrator.py
- Update `_validate_autonomous_change_scope()` to handle merge commits
- Add comprehensive test coverage for merge commit scenarios

## Test Results

All tests pass:
- ✅ 7 new tests for merge commit scope validation
- ✅ 3 existing scope-related tests still pass

## Verification

This fix will allow workflow 208 to continue after deployment.

Fixes workflow 208 failure for Issue #2189