### PR TITLE
fix(install): manage openace-scheduler.service on install + upgrade (#2293)

### DIFF
--- a/scripts/install-central/package-method/install.sh
+++ b/scripts/install-central/package-method/install.sh
@@ -2635,6 +2635,95 @@ run_pip_as_user() {
     fi
 }
 
+# Install/upgrade the standalone scheduler worker service (openace-scheduler.service).
+# Since the #2187 scheduler split, background schedulers run here — NOT in the web
+# process. install.sh must manage this unit the same way it manages open-ace.service,
+# else (a) a fresh install has no scheduler → no autonomous workflows, and (b) every
+# upgrade redeployed scheduler_worker.py but never restarted the unit, so the scheduler
+# kept running pre-deploy code (Python doesn't hot-reload). #2293.
+#
+# Self-contained: derives User/Group/WorkingDirectory/Python/HOME/SECRET_KEY/
+# WORKSPACE_BASE_DIR from the installed open-ace.service unit so the same call works
+# for fresh install (open-ace.service was just written) and upgrade (it pre-exists).
+configure_scheduler_service() {
+    local scheduler_template="$SOURCE_DIR/scripts/openace-scheduler.service"
+    local scheduler_file="/etc/systemd/system/openace-scheduler.service"
+
+    # Only where the template ships (post-#2187) and systemd is available.
+    if [ ! -f "$scheduler_template" ]; then
+        return 0
+    fi
+    if ! command -v systemctl >/dev/null 2>&1; then
+        print_warning "systemctl not found; skipping scheduler service setup"
+        return 0
+    fi
+    # The scheduler mirrors open-ace.service's identity. Derive from the web unit.
+    if ! systemctl cat open-ace.service >/dev/null 2>&1; then
+        print_warning "open-ace.service not installed; cannot derive scheduler identity"
+        return 0
+    fi
+    local web_unit
+    web_unit=$(systemctl show open-ace.service -p FragmentPath --value 2>/dev/null)
+    [ -n "$web_unit" ] && [ -f "$web_unit" ] || web_unit="/etc/systemd/system/open-ace.service"
+
+    local cs_user cs_group cs_path cs_python cs_home cs_secret cs_workspace
+    cs_user=$(grep '^User=' "$web_unit" | tail -1 | cut -d= -f2)
+    cs_group=$(grep '^Group=' "$web_unit" | tail -1 | cut -d= -f2)
+    cs_path=$(grep '^WorkingDirectory=' "$web_unit" | tail -1 | cut -d= -f2)
+    # ExecStart is the python binary followed by server.py; take the first token.
+    cs_python=$(grep '^ExecStart=' "$web_unit" | tail -1 | sed -E 's/^ExecStart=([^ ]+) .*/\1/')
+    # Environment=SECRET_KEY=<value> → 3rd '='-delimited field.
+    cs_secret=$(grep '^Environment=SECRET_KEY=' "$web_unit" | tail -1 | cut -d= -f3)
+    cs_workspace=$(grep '^Environment=WORKSPACE_BASE_DIR=' "$web_unit" | tail -1 | cut -d= -f3)
+    cs_home=$(grep '^Environment=HOME=' "$web_unit" | tail -1 | cut -d= -f3)
+    [ -n "$cs_group" ] || cs_group=$(id -gn "$cs_user" 2>/dev/null || echo "$cs_user")
+    [ -n "$cs_home" ] || cs_home=$(getent passwd "$cs_user" | cut -d: -f6)
+    [ -n "$cs_workspace" ] || cs_workspace="/home"
+
+    print_info "Installing scheduler service (openace-scheduler.service)..."
+    sed -e "s|__USER__|$cs_user|g" \
+        -e "s|__GROUP__|$cs_group|g" \
+        -e "s|__INSTALL_PATH__|$cs_path|g" \
+        -e "s|__PYTHON__|$cs_python|g" \
+        -e "s|__HOME__|$cs_home|g" \
+        -e "s|__SECRET_KEY__|$cs_secret|g" \
+        -e "s|__WORKSPACE_BASE_DIR__|$cs_workspace|g" \
+        "$scheduler_template" > "$scheduler_file" || {
+        print_warning "Failed to render $scheduler_file; scheduler service not updated"
+        return 1
+    }
+
+    # The scheduler process runs the autonomous scheduler that launches agents via
+    # openace-run-as (sudo) AND drives cross-user git/fs ops (sudo -u <account>).
+    # Both need NoNewPrivileges=false regardless of multi-user mode — same as the
+    # unconditional handling open-ace.service gets in the autonomous-isolation block.
+    if grep -q '^NoNewPrivileges=' "$scheduler_file"; then
+        sed -i 's/NoNewPrivileges=.*/NoNewPrivileges=false/' "$scheduler_file"
+    else
+        sed -i '/^\[Service\]/a NoNewPrivileges=false' "$scheduler_file"
+    fi
+
+    systemctl daemon-reload
+    systemctl enable openace-scheduler.service >/dev/null 2>&1
+
+    # restart picks up redeployed code on upgrade; start covers fresh install.
+    if systemctl is-active --quiet openace-scheduler.service; then
+        print_info "Restarting openace-scheduler service..."
+        systemctl restart openace-scheduler.service
+    else
+        print_info "Starting openace-scheduler service..."
+        systemctl start openace-scheduler.service
+    fi
+    sleep 2
+    if systemctl is-active --quiet openace-scheduler.service; then
+        print_success "Scheduler service active (background autonomous schedulers)"
+    else
+        print_warning "Scheduler service failed to start; background autonomous workflows won't run"
+        print_info "Check: systemctl status openace-scheduler, journalctl -u openace-scheduler"
+    fi
+    return 0
+}
+
 install_systemd_service() {
     local target_path="$1"
     local user="$2"
@@ -2755,6 +2844,11 @@ install_systemd_service() {
         print_info "For full logs: journalctl -u open-ace -n 50"
         return 1
     fi
+
+    # Install/restart the standalone scheduler worker so background autonomous
+    # schedulers run (#2293). Non-fatal: web is up; failure just means no
+    # background autonomous workflows until the scheduler is started manually.
+    configure_scheduler_service || print_warning "Scheduler service setup failed; run journalctl -u openace-scheduler"
 
     return 0
 }
@@ -3694,6 +3788,10 @@ install_local() {
         systemctl try-restart open-ace.service || \
             print_warning "Restart open-ace manually to activate autonomous agent isolation"
     fi
+
+    # Re-render + restart the scheduler so it picks up redeployed code (#2293).
+    # Without this the scheduler keeps running pre-upgrade scheduler_worker.py.
+    configure_scheduler_service || print_warning "Scheduler service upgrade failed; restart openace-scheduler manually"
 
     # Configure sudoers for multi-user workspace mode
     # sudoers run_user should match the systemd service's actual running user

--- a/tests/issues/2293/test_install_scheduler_service.py
+++ b/tests/issues/2293/test_install_scheduler_service.py
@@ -1,0 +1,69 @@
+"""install.sh must manage openace-scheduler.service (#2293, #2187 follow-up).
+
+Since the scheduler split (#2187), background schedulers run in a separate
+``openace-scheduler.service`` systemd unit. install.sh was never updated to
+manage it, so every deploy redeployed the code + restarted ``open-ace.service``
+(web) but left the scheduler running OLD code (Python doesn't hot-reload), and
+a fresh install never installed/enabled the scheduler unit at all.
+
+These tests pin that install.sh manages the scheduler unit the same way it
+manages ``open-ace.service``: install from template, enable, restart on both
+fresh install and upgrade.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+INSTALL_SH = (
+    Path(__file__).resolve().parents[3]
+    / "scripts"
+    / "install-central"
+    / "package-method"
+    / "install.sh"
+)
+
+
+def test_install_sh_manages_scheduler_service_unit():
+    """install.sh must reference openace-scheduler.service (install/enable/restart)."""
+    text = INSTALL_SH.read_text()
+    # The unit name must appear (not zero references as before #2293).
+    assert "openace-scheduler.service" in text, (
+        "install.sh has no references to openace-scheduler.service — the "
+        "scheduler unit is unmanaged (no install/enable/restart). #2293"
+    )
+
+
+def test_install_sh_installs_scheduler_from_template():
+    """Scheduler unit is written from scripts/openace-scheduler.service template."""
+    text = INSTALL_SH.read_text()
+    assert "scripts/openace-scheduler.service" in text, (
+        "install.sh must install the scheduler unit from its template "
+        "(scripts/openace-scheduler.service)."
+    )
+    # And it writes the rendered unit to the systemd location.
+    assert re.search(
+        r"/etc/systemd/system/openace-scheduler\.service", text
+    ), "install.sh must render the scheduler unit to /etc/systemd/system/"
+
+
+def test_install_sh_restarts_scheduler_on_deploy():
+    """A deploy/upgrade must restart openace-scheduler.service to load new code.
+
+    This is the core fix: without it the scheduler keeps running pre-deploy
+    code after every install.sh run (#2293 root cause).
+    """
+    text = INSTALL_SH.read_text()
+    # systemctl restart OR try-restart of the scheduler unit.
+    assert re.search(
+        r"systemctl\s+(restart|try-restart)\s+openace-scheduler\.service", text
+    ), "install.sh must restart openace-scheduler.service on install/upgrade"
+
+
+def test_install_sh_enables_scheduler_service():
+    """The scheduler unit must be enabled (start on boot) like open-ace.service."""
+    text = INSTALL_SH.read_text()
+    assert re.search(
+        r"systemctl\s+enable\s+openace-scheduler\.service", text
+    ), "install.sh must enable openace-scheduler.service"


### PR DESCRIPTION
## Problem

Since the #2187 scheduler split, background schedulers run in a separate `openace-scheduler.service` unit, but install.sh was never updated to manage it (`git show origin/main:...install.sh | grep -c openace-scheduler` = 0). So:
- every deploy/upgrade redeployed `scheduler_worker.py` + restarted `open-ace.service` (web) but **never restarted the scheduler** → it kept running OLD code (Python doesn't hot-reload). This caused recurrent post-deploy breakage (scheduler on pre-#2278 crash-loop / pre-#2289 scope bug code after deploys).
- a **fresh install never installed/enabled the scheduler unit at all** → no autonomous workflows.

## Fix

Add `configure_scheduler_service()` to install.sh:
- renders the unit from `scripts/openace-scheduler.service` template (the one #2278 added)
- derives identity (User/Group/WorkingDirectory/Python/HOME/SECRET_KEY/WORKSPACE_BASE_DIR) from the installed `open-ace.service` unit so one self-contained call works for both fresh install + upgrade
- sets `NoNewPrivileges=false` (the scheduler process runs the autonomous scheduler that launches agents via openace-run-as AND drives cross-user git `sudo -u <account>` — both need it; mirrors the web service's autonomous-isolation handling)
- enable + start/restart + verify

Called from:
1. `install_systemd_service()` (fresh install) — after open-ace.service is confirmed active
2. the upgrade path — right after the autonomous-isolation NoNewPrivileges block, so a redeploy restarts the scheduler to load new code

Both call sites are non-fatal (`|| print_warning`) — web can still come up if the scheduler fails.

## Independent review

Subagent verified 6/6 claims CONFIRMED (diagnosis, placeholder match, `cut -d= -f3` safe for hex SECRET_KEY, ExecStart python derivation, NNP=false justified, call-site placement + non-fatal). Flagged gap (acceptable, matches existing style): tests are source-grep only — nothing runs install.sh to validate the rendered unit as systemd.

## Tests

`tests/issues/2293/test_install_scheduler_service.py` — 4 source-grep assertions (installs from template, enables, restarts, references the unit name). All fail on origin/main, pass on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)