### PR TITLE
feat(scheduler): per-user concurrency cap + raise global default 3→10 (#2295)

### DIFF
--- a/app/modules/workspace/autonomous/task_isolation.py
+++ b/app/modules/workspace/autonomous/task_isolation.py
@@ -128,7 +128,7 @@ class AgentTaskPolicy:
     memory_max_bytes: int = 0
     pids_max: int = 0
     cpu_max: str = ""
-    max_concurrent_workflows: int = 3
+    max_concurrent_workflows: int = 10
     # #2020 Phase B — complete the resource-contract dimension set. memory/pids/cpu
     # are enforced by the Legacy launcher (cgroup); wall_clock is enforced by the
     # runner (covered by the CPU_MEM_PIDS_TIME_QUOTA capability). ephemeral_storage
@@ -150,7 +150,7 @@ def _normalize_cgroup_enabled(raw: str) -> str:
     return "auto"
 
 
-def read_agent_task_policy(conf_path: str, *, concurrency_default: int = 3) -> AgentTaskPolicy:
+def read_agent_task_policy(conf_path: str, *, concurrency_default: int = 10) -> AgentTaskPolicy:
     """Parse the agent-launcher.conf keys into an :class:`AgentTaskPolicy`.
 
     Missing or unreadable file → all defaults. Malformed integer values fall

--- a/app/services/autonomous_scheduler.py
+++ b/app/services/autonomous_scheduler.py
@@ -26,7 +26,11 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 # Maximum concurrent workflow executions
-MAX_CONCURRENT_WORKFLOWS = 3
+# Global ceiling on concurrently-running workflows across ALL users (a per-user
+# cap is enforced separately via tenant ``max_sessions_per_user`` in selection).
+# Raised 3 → 10 (#2295): the former global-3 starved multi-user deployments.
+# Still overridable via ``agent_max_concurrent_workflows`` in agent-launcher.conf.
+MAX_CONCURRENT_WORKFLOWS = 10
 
 # Issue #2020: the concurrency cap is configurable via the same
 # agent-launcher.conf the launcher reads. The constant above is the default
@@ -126,6 +130,10 @@ class AutonomousScheduler:
         # See #1002: deduping on project_path alone starved forked children.
         self._in_progress_workspaces: set[str] = set()
         self._in_progress_branches: set[str] = set()
+        # Per-user running workflow_ids (#2295). Keyed by owner user_id (None/0
+        # owners bucket under 0 and count only against the global ceiling). The
+        # scheduler selection gates each user at their tenant max_sessions_per_user.
+        self._in_progress_by_user: dict[int, set[str]] = {}
         self._in_progress_lock = threading.Lock()
         self._running_orchestrators: dict[str, AutonomousOrchestrator] = {}
         self._orchestrator_lock = threading.Lock()
@@ -218,6 +226,11 @@ class AutonomousScheduler:
                 batch_id = wf.get("batch_id")
                 if batch_id:
                     self._in_progress_batch_ids.discard(batch_id)
+                # Per-user bucket (#2295). wf.get (not wf[]) — legacy/odd rows may
+                # lack the key; the review flagged wf["user_id"] would KeyError.
+                owner_id = wf.get("user_id")
+                if owner_id is not None:
+                    self._in_progress_by_user.get(owner_id, set()).discard(workflow_id)
 
         # Release the DB-level lock so the next cycle can acquire it.
         try:
@@ -456,6 +469,13 @@ class AutonomousScheduler:
         # Get workflow's batch_id and git-conflict keys for cleanup
         workflow = repo.get_workflow(workflow_id)
         batch_id = workflow.get("batch_id") if workflow else None
+        # Owner used for per-user in-progress accounting (#2295). Resolved here
+        # (NOT inside the try below) so the Site-A early return + the finally can
+        # both discard from _in_progress_by_user without a NameError.
+        owner_id = workflow.get("user_id") if workflow else None
+        # None owner (legacy rows) buckets under 0; counts only against the global
+        # ceiling, not any per-user cap (the selection gate skips None owners).
+        owner_bucket = owner_id if owner_id is not None else 0
         workspace, branch = self._conflict_keys(workflow) if workflow else ("", "")
         # Waiting workflows bypass conflict locks (see _process_workflows).
         # Capture this so cleanup paths don't release another workflow's keys.
@@ -473,6 +493,7 @@ class AutonomousScheduler:
             logger.debug("Workflow %s is locked by another instance, skipping", workflow_id[:8])
             with self._in_progress_lock:
                 self._in_progress_ids.discard(workflow_id)
+                self._in_progress_by_user.get(owner_bucket, set()).discard(workflow_id)
                 if batch_id and not was_waiting:
                     self._in_progress_batch_ids.discard(batch_id)
                 if workspace and not was_waiting:
@@ -498,7 +519,7 @@ class AutonomousScheduler:
         # quota-paused workflow would hold both forever.
         orchestrator = None
         try:
-            owner_id = workflow.get("user_id") if workflow else None
+            # owner_id resolved above (alongside batch_id) for in-progress accounting.
             if owner_id is not None:
                 try:
                     from app.modules.governance.quota_manager import QuotaManager
@@ -558,6 +579,7 @@ class AutonomousScheduler:
                 logger.warning("Failed to release lock for workflow %s", workflow_id[:8])
             with self._in_progress_lock:
                 self._in_progress_ids.discard(workflow_id)
+                self._in_progress_by_user.get(owner_bucket, set()).discard(workflow_id)
                 if batch_id and not was_waiting:
                     self._in_progress_batch_ids.discard(batch_id)
                 if workspace and not was_waiting:
@@ -722,6 +744,35 @@ class AutonomousScheduler:
             repo.update_workflow(workflow["workflow_id"], {"status": "pending"})
             _emit_event_safe(workflow["workflow_id"], "status_change", {"status": "pending"})
 
+    def _per_user_cap(self, user_id: int | None) -> int | None:
+        """The per-user running cap = the owner's tenant ``max_sessions_per_user``.
+
+        Mirrors the create-time ``_check_user_concurrent_limit`` lookup
+        (app/routes/autonomous.py). Returns None for a None owner (legacy rows),
+        which the selection gate treats as "no per-user limit" — such workflows
+        count only against the global ceiling. Default 5 when the user has no
+        tenant or the tenant has no explicit quota.
+        """
+        if user_id is None:
+            return None
+        from app.repositories.tenant_repo import TenantRepository
+        from app.repositories.user_repo import UserRepository
+
+        DEFAULT_MAX_SESSIONS = 5
+        try:
+            user = UserRepository().get_user_by_id(user_id)
+            if not user:
+                return DEFAULT_MAX_SESSIONS
+            tenant_id = user.get("tenant_id")
+            if not tenant_id:
+                return DEFAULT_MAX_SESSIONS
+            tenant = TenantRepository().get_by_id(tenant_id)
+            if tenant:
+                return tenant.quota.max_sessions_per_user
+        except Exception as exc:  # noqa: BLE001 — fail-open like the create-time check
+            logger.warning("per-user cap lookup failed for user %s: %s", user_id, exc)
+        return DEFAULT_MAX_SESSIONS
+
     def _process_workflows(self):
         """Find and process active workflows using thread pool for concurrency.
 
@@ -787,15 +838,39 @@ class AutonomousScheduler:
         # were already running before this poll; without local reservations,
         # multiple newly auto-resumed siblings from one batch (or workflows
         # sharing a worktree/branch) can all enter ``to_process`` together.
+        #
+        # Per-user running cap (#2295): resolve each owner's tenant
+        # max_sessions_per_user once per cycle (DB lookups OUTSIDE the lock),
+        # then gate inside the lock. None owners (legacy rows) skip the
+        # per-user gate and count only against the global ceiling.
+        per_user_caps: dict[int | None, int | None] = {}
+        for wf in active:
+            uid = wf.get("user_id")
+            if uid not in per_user_caps:
+                per_user_caps[uid] = self._per_user_cap(uid)
+
         with self._in_progress_lock:
             slots_available = get_max_concurrent_workflows() - len(self._in_progress_ids)
             selected_batches: set[str] = set()
             selected_workspaces: set[str] = set()
             selected_branches: set[str] = set()
+            selected_by_user: dict[int, int] = {}  # per-user reservations this cycle
             to_process: list[dict] = []
             for wf in active:
                 if len(to_process) >= max(0, slots_available):
                     break
+                # Per-user gate. Waiting workflows count against it (matching
+                # count_active_workflows_by_user); they still bypass conflict
+                # keys below. cap is None only for legacy None-owner rows.
+                uid = wf.get("user_id")
+                cap = per_user_caps.get(uid)
+                bucket = uid if uid is not None else 0
+                if cap is not None:
+                    running = len(
+                        self._in_progress_by_user.get(bucket, set())
+                    ) + selected_by_user.get(bucket, 0)
+                    if running >= cap:
+                        continue
                 batch_id = wf.get("batch_id")
                 workspace, branch = self._conflict_keys(wf)
                 is_waiting = wf.get("status") == "waiting"
@@ -806,6 +881,8 @@ class AutonomousScheduler:
                 if branch and branch in selected_branches and not is_waiting:
                     continue
                 to_process.append(wf)
+                if cap is not None:
+                    selected_by_user[bucket] = selected_by_user.get(bucket, 0) + 1
                 if batch_id:
                     selected_batches.add(batch_id)
                 if workspace:
@@ -819,7 +896,14 @@ class AutonomousScheduler:
         # Mark workflows, their batches, and git-conflict keys as in-progress
         with self._in_progress_lock:
             for wf in to_process:
-                self._in_progress_ids.add(wf.get("workflow_id", ""))
+                wf_id = wf.get("workflow_id", "")
+                self._in_progress_ids.add(wf_id)
+                # Per-user in-progress accounting (#2295). Bucket key matches the
+                # discard sites in _advance_single (Site A + finally) + clear_in_progress.
+                uid = wf.get("user_id")
+                self._in_progress_by_user.setdefault(uid if uid is not None else 0, set()).add(
+                    wf_id
+                )
                 # Waiting workflows bypass conflict locks — don't reserve their
                 # keys so we don't block other workflows, and don't release
                 # another workflow's keys in _advance_single's finally.

--- a/tests/issues/2020/test_agent_task_policy.py
+++ b/tests/issues/2020/test_agent_task_policy.py
@@ -32,7 +32,7 @@ def test_defaults_when_conf_absent(tmp_path):
     assert policy.memory_max_bytes == 0  # 0 = unset/no limit
     assert policy.pids_max == 0
     assert policy.cpu_max == ""
-    assert policy.max_concurrent_workflows == 3
+    assert policy.max_concurrent_workflows == 10
 
 
 def test_parses_resource_keys(tmp_path):

--- a/tests/issues/2020/test_scheduler_concurrency.py
+++ b/tests/issues/2020/test_scheduler_concurrency.py
@@ -2,7 +2,8 @@
 
 Acceptance #4: "单机可按配置运行 N 个 Agent". The scheduler's
 ``MAX_CONCURRENT_WORKFLOWS`` becomes configurable via the same
-agent-launcher.conf the launcher reads, defaulting to the historical 3.
+agent-launcher.conf the launcher reads, defaulting to 10 (#2295 raised it from 3;
+the per-user cap is enforced separately via tenant max_sessions_per_user).
 """
 
 from __future__ import annotations
@@ -11,11 +12,11 @@ from app.modules.workspace.autonomous import task_isolation
 from app.services import autonomous_scheduler
 
 
-def test_default_concurrency_is_three(monkeypatch, tmp_path):
+def test_default_concurrency_is_ten(monkeypatch, tmp_path):
     monkeypatch.setattr(
         autonomous_scheduler, "_AGENT_LAUNCHER_CONF", str(tmp_path / "missing.conf")
     )
-    assert autonomous_scheduler.get_max_concurrent_workflows() == 3
+    assert autonomous_scheduler.get_max_concurrent_workflows() == 10
 
 
 def test_concurrency_reads_from_conf(monkeypatch, tmp_path):
@@ -35,9 +36,9 @@ def test_concurrency_floors_at_one(monkeypatch, tmp_path):
     assert autonomous_scheduler.get_max_concurrent_workflows() >= 1
 
 
-def test_constant_unchanged_as_default():
-    # Backward compat: the module constant is still 3 and still importable.
-    assert autonomous_scheduler.MAX_CONCURRENT_WORKFLOWS == 3
+def test_constant_is_ten():
+    # The module constant is 10 (#2295) and still importable.
+    assert autonomous_scheduler.MAX_CONCURRENT_WORKFLOWS == 10
 
 
 def test_get_max_concurrent_workflows_uses_task_isolation_policy(monkeypatch, tmp_path):

--- a/tests/issues/2295/test_scheduler_per_user_concurrency.py
+++ b/tests/issues/2295/test_scheduler_per_user_concurrency.py
@@ -1,0 +1,222 @@
+"""Scheduler concurrency: global ceiling (10) + per-user cap (max_sessions_per_user).
+
+Historically the scheduler's running cap was a single GLOBAL ``MAX_CONCURRENT_WORKFLOWS=3``
+across all users, which starved multi-user deployments. #2295 makes it two-layer:
+a raised global ceiling (default 10) + a per-user running cap equal to the owner's
+tenant ``max_sessions_per_user`` (default 5), enforced at scheduler selection
+(aligned with the create-time ``_check_user_concurrent_limit``).
+
+These tests pin: the raised default, per-user cap resolution, the
+``_in_progress_by_user`` lifecycle (add on select, discard in ``_advance_single``
+including the lock-not-acquired early return — "Site A", discard in
+``clear_in_progress``), the selection gate, and that waiting workflows count
+against the per-user cap (matching ``count_active_workflows_by_user``).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _make_scheduler():
+    from app.services.autonomous_scheduler import AutonomousScheduler
+
+    return AutonomousScheduler()
+
+
+# ── per-user cap resolution ─────────────────────────────────────────────────
+
+
+def test_per_user_cap_default_is_five(monkeypatch):
+    """A user whose tenant has no explicit quota gets the default 5."""
+    sched = _make_scheduler()
+    fake_user = {"tenant_id": None}
+    with (
+        patch("app.repositories.user_repo.UserRepository.get_user_by_id", return_value=fake_user),
+    ):
+        assert sched._per_user_cap(123) == 5
+
+
+def test_per_user_cap_reads_tenant_quota(monkeypatch):
+    """The cap comes from the owner's tenant quota.max_sessions_per_user."""
+    sched = _make_scheduler()
+    fake_user = {"tenant_id": 7}
+    fake_tenant = MagicMock()
+    fake_tenant.quota.max_sessions_per_user = 2
+    with (
+        patch("app.repositories.user_repo.UserRepository.get_user_by_id", return_value=fake_user),
+        patch("app.repositories.tenant_repo.TenantRepository.get_by_id", return_value=fake_tenant),
+    ):
+        assert sched._per_user_cap(123) == 2
+
+
+def test_per_user_cap_none_owner_is_unlimited():
+    """A legacy workflow with user_id=None counts only against the global ceiling,
+    not any per-user bucket — so its per-user cap is effectively unlimited."""
+    sched = _make_scheduler()
+    # Should not even attempt a tenant lookup for a None owner.
+    cap = sched._per_user_cap(None)
+    assert cap is None  # sentinel: caller treats None as "no per-user gate"
+
+
+# ── _in_progress_by_user lifecycle ──────────────────────────────────────────
+
+
+def test_clear_in_progress_discards_by_user():
+    """clear_in_progress(wf=...) must remove the workflow from its owner's bucket."""
+    sched = _make_scheduler()
+    wf_id = "wf-bucket-1"
+    wf = {"workflow_id": wf_id, "user_id": 5, "project_path": "/p", "branch_name": "auto-dev/b"}
+    sched._in_progress_ids.add(wf_id)
+    sched._in_progress_by_user.setdefault(5, set()).add(wf_id)
+    assert wf_id in sched._in_progress_by_user[5]
+
+    with patch("app.routes.autonomous._get_repo"):
+        sched.clear_in_progress(wf_id, wf=wf)
+
+    assert wf_id not in sched._in_progress_ids
+    assert 5 not in sched._in_progress_by_user or wf_id not in sched._in_progress_by_user[5]
+
+
+def test_clear_in_progress_without_wf_still_clears_ids():
+    """Without wf we can't know the owner, but _in_progress_ids must still clear."""
+    sched = _make_scheduler()
+    wf_id = "wf-bucket-2"
+    sched._in_progress_ids.add(wf_id)
+    with patch("app.routes.autonomous._get_repo"):
+        sched.clear_in_progress(wf_id)
+    assert wf_id not in sched._in_progress_ids
+
+
+def test_advance_single_lock_not_acquired_discards_by_user():
+    """Site A: when repo.acquire_lock fails, the early return (before the try/finally)
+    must still discard _in_progress_by_user — otherwise the bucket leaks."""
+    sched = _make_scheduler()
+    wf_id = "wf-site-a"
+    workflow = {
+        "workflow_id": wf_id,
+        "user_id": 9,
+        "status": "planning",
+        "current_phase": "planning",
+        "project_path": "/p",
+        "branch_name": "auto-dev/a",
+        "batch_id": None,
+        "worktree_path": "",
+    }
+    sched._in_progress_ids.add(wf_id)
+    sched._in_progress_by_user.setdefault(9, set()).add(wf_id)
+
+    mock_repo = MagicMock()
+    mock_repo.get_workflow.return_value = workflow
+    mock_repo.acquire_lock.return_value = False  # triggers Site A early return
+
+    with patch("app.routes.autonomous._get_repo", return_value=mock_repo):
+        sched._advance_single(wf_id)
+
+    assert wf_id not in sched._in_progress_ids
+    assert 9 not in sched._in_progress_by_user or wf_id not in sched._in_progress_by_user[9]
+
+
+# ── selection gate ──────────────────────────────────────────────────────────
+
+
+def _wf(wf_id, user_id, *, branch=None, project="/p", status="planning", batch=None):
+    return {
+        "workflow_id": wf_id,
+        "user_id": user_id,
+        "status": status,
+        "current_phase": status,
+        "project_path": project,
+        "branch_name": branch or f"auto-dev/{wf_id[:8]}",
+        "batch_id": batch,
+        "worktree_path": "",
+        "created_at": "2026-08-04T00:00:00",
+    }
+
+
+def test_selection_respects_per_user_cap(monkeypatch):
+    """A user at their per-user cap has their extra workflow skipped; another user
+    under cap is selected in the same cycle."""
+    sched = _make_scheduler()
+    # user A cap=1 (already running 1), user B cap=5 (running 0).
+    sched._in_progress_by_user.setdefault(1, set()).add("running-A1")
+    sched._in_progress_ids.add("running-A1")
+
+    active = [_wf("new-A2", 1, branch="b-A2"), _wf("new-B1", 2, branch="b-B1")]
+
+    selected = []
+    with (
+        patch.object(sched, "_promote_queued_workflows"),
+        patch.object(sched, "_auto_resume_quota_paused"),
+        patch.object(sched, "_reclaim_paused_slots"),
+        patch("app.services.autonomous_scheduler._retry_pending_git_cleanups"),
+        patch.object(sched, "_advance_single", side_effect=lambda wid: selected.append(wid)),
+        patch.object(sched, "_per_user_cap", side_effect=lambda uid: 1 if uid == 1 else 5),
+    ):
+        mock_repo = MagicMock()
+        mock_repo.get_active_workflows.return_value = active
+        with patch("app.routes.autonomous._get_repo", return_value=mock_repo):
+            sched._process_workflows()
+
+    assert "new-B1" in selected  # B under cap → selected
+    assert "new-A2" not in selected  # A at cap (1 running) → skipped
+    # And A's skipped workflow was NOT recorded in A's bucket.
+    assert "new-A2" not in sched._in_progress_by_user.get(1, set())
+
+
+def test_waiting_workflow_counts_against_per_user_cap(monkeypatch):
+    """A waiting workflow still consumes its owner's per-user bucket (consistent
+    with count_active_workflows_by_user), even though it bypasses conflict keys."""
+    sched = _make_scheduler()
+    # user 1 cap=1, already running 1 waiting workflow.
+    sched._in_progress_by_user.setdefault(1, set()).add("waiting-A1")
+    sched._in_progress_ids.add("waiting-A1")
+
+    active = [_wf("new-A2", 1, branch="b-A2", status="planning")]
+    selected = []
+    with (
+        patch.object(sched, "_promote_queued_workflows"),
+        patch.object(sched, "_auto_resume_quota_paused"),
+        patch.object(sched, "_reclaim_paused_slots"),
+        patch("app.services.autonomous_scheduler._retry_pending_git_cleanups"),
+        patch.object(sched, "_advance_single", side_effect=lambda wid: selected.append(wid)),
+        patch.object(sched, "_per_user_cap", return_value=1),
+    ):
+        mock_repo = MagicMock()
+        mock_repo.get_active_workflows.return_value = active
+        with patch("app.routes.autonomous._get_repo", return_value=mock_repo):
+            sched._process_workflows()
+
+    assert "new-A2" not in selected  # waiting-A1 already consumes user 1's cap of 1
+
+
+def test_global_ceiling_still_binds(monkeypatch):
+    """Even with many users each under their per-user cap, total selected ≤ the
+    global ceiling."""
+    sched = _make_scheduler()
+    # 4 users, each with 2 ready workflows; per-user cap high (5); global=10.
+    active = []
+    for u in range(4):
+        for i in range(2):
+            active.append(_wf(f"wf-{u}-{i}", u, branch=f"b-{u}-{i}"))
+    selected = []
+    with (
+        patch.object(sched, "_promote_queued_workflows"),
+        patch.object(sched, "_auto_resume_quota_paused"),
+        patch.object(sched, "_reclaim_paused_slots"),
+        patch("app.services.autonomous_scheduler._retry_pending_git_cleanups"),
+        patch.object(sched, "_advance_single", side_effect=lambda wid: selected.append(wid)),
+        patch.object(sched, "_per_user_cap", return_value=5),
+        patch(
+            "app.services.autonomous_scheduler.get_max_concurrent_workflows",
+            return_value=10,
+        ),
+    ):
+        mock_repo = MagicMock()
+        mock_repo.get_active_workflows.return_value = active
+        with patch("app.routes.autonomous._get_repo", return_value=mock_repo):
+            sched._process_workflows()
+
+    assert len(selected) <= 10


### PR DESCRIPTION
## Problem

The scheduler's running cap was a single **global** `MAX_CONCURRENT_WORKFLOWS=3` across **all users** (`slots_available = get_max_concurrent_workflows() - len(_in_progress_ids)`), starving multi-user deployments — 3 users with ready workflows got only 3 slots total.

A per-user `max_sessions_per_user` (tenant quota, default 5) existed but was enforced **only at create time**; the scheduler never consulted it.

## Fix (two layers)

1. **Global ceiling kept, default 3 → 10** (still configurable via `agent_max_concurrent_workflows` in agent-launcher.conf). Prevents Σ per-user caps from exhausting the box.
2. **New per-user running cap** = the owner's tenant `max_sessions_per_user` (default 5), enforced at scheduler selection — aligned with the create-time `_check_user_concurrent_limit`.

Mechanism: `_in_progress_by_user: dict[int, set[str]]` tracks running workflow_ids per owner (under the existing `_in_progress_lock`); `_per_user_cap(user_id)` resolves the tenant quota (reuses the `_check_user_concurrent_limit` lookup); selection pre-resolves caps once per cycle (outside the lock) then gates each candidate inside; waiting workflows count against the cap (matching `count_active_workflows_by_user`) while still bypassing conflict keys. Discarded at all 3 release sites (Site A early-return, `_advance_single` finally, `clear_in_progress`).

## Independent review

Design review (subagent `aa3a0c7645d7527d4`) caught **3 blocking issues**, all applied:
- `owner_id` resolved alongside `batch_id` (not inside the try) so the lock-not-acquired early return can use it.
- **Site A discard** — that early return skips the try/finally, so it must discard `_in_progress_by_user` itself.
- `clear_in_progress` uses `wf.get("user_id")` (not `wf[]`).

Edge-case policies locked via consistency: waiting counts; None owner → bucket 0 (global-only); `max_sessions_per_user=0` blocks.

## Tests

- `tests/issues/2295/` — per-user cap resolution, `_in_progress_by_user` lifecycle (incl. Site A), selection gate, waiting counts, global ceiling.
- Updated 3→10 assertions in `tests/issues/2020/test_scheduler_concurrency.py` + `test_agent_task_policy.py`.
- All green locally (the 2 `tests/issues/2020` concurrency-default tests need a clean env — a local `~/.open-ace/agent-launcher.conf` with `=3` overrides on dev machines; CI has no such file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)