### PR TITLE
fix(autonomous): classify "Empty reply from server" as transient (#2299)

### DIFF
--- a/app/modules/workspace/autonomous/constants.py
+++ b/app/modules/workspace/autonomous/constants.py
@@ -127,6 +127,11 @@ _TRANSIENT_ORCHESTRATOR_KEYWORDS = [
     "unable to access",
     "rpc failed",
     "early eof",
+    # libcurl "Empty reply from server" (git emits it verbatim, in English even
+    # under a non-C locale, on a transient TLS/connection drop). Mirror the
+    # Layer-1 list in github_ops.py (#2299).
+    "empty reply",
+    "empty response",
     # --force-with-lease rejects the push when the remote auto-dev tip moved
     # between git's read of the remote-tracking ref and the actual push (a
     # concurrent push, or a freshly-fetched ref). The worktree is unchanged, so

--- a/app/modules/workspace/autonomous/github_ops.py
+++ b/app/modules/workspace/autonomous/github_ops.py
@@ -53,6 +53,12 @@ _TRANSIENT_ERROR_KEYWORDS = [
     "unable to access",
     "rpc failed",
     "early eof",
+    # libcurl "Empty reply from server" — git emits this verbatim (in English,
+    # even under a non-C host locale) on a transient TLS/connection drop to the
+    # remote. Without it, exit-128 empty-reply permanent-fails the workflow
+    # instead of retrying (#2299).
+    "empty reply",
+    "empty response",
 ]
 
 

--- a/tests/issues/2299/test_transient_empty_reply.py
+++ b/tests/issues/2299/test_transient_empty_reply.py
@@ -1,0 +1,52 @@
+"""Transient git-error classifier must catch "Empty reply from server" (#2299).
+
+git emits libcurl's ``Empty reply from server`` verbatim (in English, even under
+a non-C host locale) on a transient TLS/connection drop to the remote. Without
+it in the transient-keyword lists, the exit-128 empty-reply GitHubOpsError is
+classified NON-transient → wrapped as RuntimeError → the workflow permanent-fails
+instead of Layer-2 retrying. Workflow 212 hit this twice on ``git push``.
+"""
+
+from __future__ import annotations
+
+from app.modules.workspace.autonomous.constants import (
+    _TRANSIENT_ORCHESTRATOR_KEYWORDS,
+    _is_transient_git_error,
+)
+from app.modules.workspace.autonomous.github_ops import (
+    _TRANSIENT_ERROR_KEYWORDS,
+    GitHubOpsError,
+    _is_transient_error,
+)
+
+
+def test_layer1_classifies_empty_reply_as_transient():
+    """_is_transient_error (Layer-1 in-process retry) must catch empty-reply."""
+    assert _is_transient_error("fatal: 无法访问: Empty reply from server", 128)
+    assert _is_transient_error("error: empty response from server", 128)
+
+
+def test_layer2_classifies_empty_reply_githubopserror_as_transient():
+    """_is_transient_git_error (Layer-2 advance retry) must catch empty-reply
+    on a GitHubOpsError so it propagates (not wrapped) + retries."""
+    assert _is_transient_git_error(GitHubOpsError("git push failed: Empty reply from server"))
+    assert _is_transient_git_error(GitHubOpsError("... empty response ..."))
+
+
+def test_both_keyword_lists_in_sync_for_empty_reply():
+    """The Layer-1 + Layer-2 lists are documented mirrors — empty-reply must be
+    in BOTH so a transient empty-reply is retried at both layers."""
+    assert "empty reply" in _TRANSIENT_ERROR_KEYWORDS
+    assert "empty reply" in _TRANSIENT_ORCHESTRATOR_KEYWORDS
+
+
+def test_non_transient_git_error_still_not_classified_transient():
+    """Regression guard: a genuinely permanent git error is still non-transient."""
+    assert not _is_transient_error("fatal: not a git repository", 128)
+    assert not _is_transient_error("error: pathspec 'foo' did not match", 1)
+    assert not _is_transient_git_error(GitHubOpsError("merge conflict"))
+
+
+def test_transient_still_requires_nonzero_exit():
+    """_is_transient_error never classifies a successful (exit 0) run as transient."""
+    assert not _is_transient_error("empty reply from server", 0)


### PR DESCRIPTION
## Problem

When \`git push\` hits a transient network blip — \`exit 128: ...Empty reply from server\` — the workflow **permanent-fails** instead of retrying. \"Empty reply from server\" (libcurl's message, which git emits verbatim in English even under a non-C host locale) was missing from BOTH transient-keyword lists, so the \`GitHubOpsError\` was classified NON-transient → wrapped as \`RuntimeError\` at \`phases/pr_review.py:237\` → Layer-2 \`isinstance(e, GitHubOpsError)\` failed → \`_mark_failed\`. Workflow 212 hit this twice.

## Fix

Add \`empty reply\` + \`empty response\` to:
- \`_TRANSIENT_ERROR_KEYWORDS\` (\`github_ops.py\`) — Layer-1 in-process retry.
- \`_TRANSIENT_ORCHESTRATOR_KEYWORDS\` (\`constants.py\`) — Layer-2 advance() retry.

The two lists are documented mirrors; both updated to keep them in sync. With the keyword present, \`_is_transient_git_error\` returns True → \`phases/pr_review.py:228\` propagates the \`GitHubOpsError\` (no rewrap) → Layer-2 retries (\`TRANSIENT_RETRY_MAX=6\`).

## Independent investigation

Agent \`a63d586e8da6db203\` verified the root cause + reconstructed the 212 timeline (push timeout → \"retry 1/6\" logged → next cycle push \"Empty reply\" → not classified → RuntimeError → \`_mark_failed\` → \`transient_retry_count\` reset to 0).

## Out of scope (follow-up)

Pin \`LANG=C\`/\`LC_ALL=C\` on the git subprocess so future errors that are **entirely** in the host locale (no English substring, e.g. Chinese \"无法访问\" alone) also match the English keyword list. Under prod's \`sudo -u <account> git\` wrapper this needs \`env LANG=C\` in the cmd (sudo \`env_reset\` strips \`os.environ\`), so it's more invasive — deferred to a follow-up. The keyword fix here catches the known failure (\"Empty reply from server\" is English even under Chinese locale).

## Tests

\`tests/issues/2299/\` — Layer-1 + Layer-2 classify empty-reply as transient; both lists in sync; non-transient errors unchanged; exit 0 not classified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)