### PR TITLE
fix(autonomous): recover worktree-on-main at pr_review push before failing (#2302)

### DIFF
--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -1254,6 +1254,20 @@ class AutonomousOrchestrator:
             "common_identity": common_identity,
         }
 
+    def recover_worktree_branch(
+        self,
+        gh: "GitHubOps",
+        expected_branch: str,
+        before_head: str,
+        before_main_head: str,
+    ) -> str | None:
+        """Public PhaseHost-facing alias for ``_recover_worktree_branch`` (#2302).
+
+        Lets the pr_review push check recover a worktree the agent left on
+        another branch, without reaching past the PhaseHost protocol.
+        """
+        return self._recover_worktree_branch(gh, expected_branch, before_head, before_main_head)
+
     def _recover_worktree_branch(
         self,
         gh: "GitHubOps",

--- a/app/modules/workspace/autonomous/phase_host.py
+++ b/app/modules/workspace/autonomous/phase_host.py
@@ -87,6 +87,17 @@ class PhaseHost(Protocol):
     def validate_pre_merge_change_scope(self, gh, wf, pr_head_sha) -> str:
         """Validate the effective PR delta against an immutable main snapshot."""
 
+    def recover_worktree_branch(
+        self, gh, expected_branch: str, before_head: str, before_main_head: str
+    ) -> str | None:
+        """Recover the worktree onto ``expected_branch`` when an agent left it on
+        another branch (e.g. a read-only ``git checkout main``). Returns a
+        non-empty reason when recovery was safe + performed; None when not
+        safely recoverable (caller must fail closed). Used by the pr_review
+        push check as defense-indepth (#2302). Delegates to the orchestrator's
+        ``_recover_worktree_branch`` (#2271).
+        """
+
     def sync_failed_pr_with_main(self, gh, branch_name, pr_number, pr_head_sha) -> bool:
         """Synchronize a stale PR with main before merge.
 

--- a/app/modules/workspace/autonomous/phases/pr_review.py
+++ b/app/modules/workspace/autonomous/phases/pr_review.py
@@ -86,6 +86,42 @@ NAME = "pr_review"
 logger = logging.getLogger(__name__)
 
 
+def _ensure_branch_and_push(gh, host, branch_name, entry_feature_head, entry_main_head):
+    """Ensure the worktree is on ``branch_name`` (recovering if safe), then push.
+
+    Defense-in-depth at the pr_review push (#2302): the central guard
+    (``_validate_repo_context_after_run``) recovers a worktree the agent left on
+    another branch after each agent run, but the worktree can still be on main
+    at push time (e.g. a failure→retry→reentry sequence left it there). Try
+    recovery before failing the workflow permanently.
+
+    Raises ``RuntimeError`` if not on ``branch_name`` after the recovery attempt.
+    """
+    current_branch = gh.get_current_branch()
+    if branch_name and current_branch != branch_name:
+        recovered = None
+        try:
+            recovered = host.recover_worktree_branch(
+                gh, branch_name, entry_feature_head, entry_main_head
+            )
+        except Exception as exc:
+            logger.warning("pr_review push recovery raised for %s: %s", branch_name, exc)
+        if recovered:
+            logger.info("Workflow %s pr_review push: %s", host.workflow_id[:8], recovered)
+            current_branch = gh.get_current_branch()
+        if branch_name and current_branch != branch_name:
+            logger.error(
+                "Branch mismatch before push: workflow=%s expected=%s actual=%s",
+                host.workflow_id[:8],
+                branch_name,
+                current_branch,
+            )
+            raise RuntimeError(
+                f"Branch mismatch before push: expected {branch_name}, actual {current_branch}"
+            )
+    gh.git_push(branch=branch_name, force_with_lease=True)
+
+
 def handle(ctx, deps) -> PhaseResult:
     """Execute one PR-review-phase cycle.
 
@@ -101,6 +137,17 @@ def handle(ctx, deps) -> PhaseResult:
     force_full_rounds = host.must_run_full_review_rounds(wf)
     dev_round = wf.get("dev_round", 1)
     branch_name = wf.get("branch_name", "")
+    # Capture entry repo state for the push-check recovery (#2302). The worktree
+    # may be on main at push time (failure→retry→reentry); recover_worktree_branch
+    # needs the feature tip + main HEAD from before any in-phase switch.
+    entry_feature_head = ""
+    entry_main_head = ""
+    try:
+        if branch_name:
+            entry_feature_head = gh._run_git(["rev-parse", branch_name]).stdout.strip()
+        entry_main_head = gh._run_git(["rev-parse", "main"]).stdout.strip()
+    except Exception:
+        pass
     # Language-aware approval marker for PR review (matches what the agent,
     # writing in content_language, is asked to state).
     approval_phrase = _review_approval_phrase(wf.get("content_language"))
@@ -209,19 +256,10 @@ def handle(ctx, deps) -> PhaseResult:
     issue_number = wf.get("github_issue_number") or wf.get("github_issue_number")
     # Ensure branch is pushed to remote before PR creation
     try:
-        # P1 修复（Issue #1611）：检查当前分支是否与预期一致
-        current_branch = gh.get_current_branch()
-        if branch_name and current_branch != branch_name:
-            logger.error(
-                "Branch mismatch before push: workflow=%s expected=%s actual=%s",
-                host.workflow_id[:8],
-                branch_name,
-                current_branch,
-            )
-            raise RuntimeError(
-                f"Branch mismatch before push: expected {branch_name}, actual {current_branch}"
-            )
-        gh.git_push(branch=branch_name, force_with_lease=True)
+        # Push with defense-in-depth branch recovery (#2302): if the worktree is
+        # on main at push time (e.g. a failure→retry→reentry sequence left it),
+        # recover onto branch_name before failing. Preserves the #1611 check.
+        _ensure_branch_and_push(gh, host, branch_name, entry_feature_head, entry_main_head)
     except Exception as e:
         # Distinguish transient vs non-transient errors to enable Layer-2 retry
         # for network flakiness (Issue #1814). Failure-path raise deviation —

--- a/tests/issues/2302/test_pr_review_push_recovery.py
+++ b/tests/issues/2302/test_pr_review_push_recovery.py
@@ -1,0 +1,109 @@
+"""pr_review push check recovers worktree-on-main before failing (#2302, #28).
+
+Defense-in-depth at the pr_review push: the central guard
+(``_validate_repo_context_after_run``) recovers a worktree the agent left on
+another branch after each agent run, but the worktree can still be on main at
+push time (e.g. a failure→retry→reentry sequence — workflow 212 hit this).
+``_ensure_branch_and_push`` tries ``host.recover_worktree_branch`` before
+raising the permanent "Branch mismatch" failure.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.modules.workspace.autonomous.phases.pr_review import _ensure_branch_and_push
+
+
+def _gh(current_branch: str, *, push_ok: bool = True):
+    """Mock GitHubOps whose get_current_branch returns ``current_branch``."""
+    gh = MagicMock()
+    gh.get_current_branch.return_value = current_branch
+    if not push_ok:
+        gh.git_push.side_effect = RuntimeError("push failed")
+    return gh
+
+
+def _host(recover_return, *, recover_exc=None):
+    """Mock PhaseHost whose recover_worktree_branch returns ``recover_return``."""
+    host = MagicMock()
+    host.workflow_id = "wf-test-12345678"
+    if recover_exc is not None:
+        host.recover_worktree_branch.side_effect = recover_exc
+    else:
+        host.recover_worktree_branch.return_value = recover_return
+    return host
+
+
+def test_push_when_already_on_feature_branch():
+    """Worktree on the feature branch → no recovery, push proceeds."""
+    gh = _gh("auto-dev/feature-branch")
+    host = _host(recover_return=None)
+
+    _ensure_branch_and_push(gh, host, "auto-dev/feature-branch", "feat-tip", "main-tip")
+
+    host.recover_worktree_branch.assert_not_called()
+    gh.git_push.assert_called_once_with(branch="auto-dev/feature-branch", force_with_lease=True)
+
+
+def test_recovers_when_on_main_and_recovery_safe():
+    """Worktree on main + recovery safe → recover, re-check, push proceeds."""
+    # First get_current_branch → main (triggers recovery); after recovery the
+    # re-check returns the feature branch.
+    gh = _gh("main")
+    gh.get_current_branch.side_effect = ["main", "auto-dev/feature-branch"]
+    host = _host(recover_return="recovered worktree onto auto-dev/feature-branch")
+
+    _ensure_branch_and_push(gh, host, "auto-dev/feature-branch", "feat-tip", "main-tip")
+
+    host.recover_worktree_branch.assert_called_once_with(
+        gh, "auto-dev/feature-branch", "feat-tip", "main-tip"
+    )
+    gh.git_push.assert_called_once_with(branch="auto-dev/feature-branch", force_with_lease=True)
+
+
+def test_fails_when_on_main_and_recovery_unsafe():
+    """Worktree on main + recovery NOT safe (None) → RuntimeError, no push."""
+    gh = _gh("main")
+    host = _host(recover_return=None)  # recovery refused (dirty/moved/advanced)
+
+    with pytest.raises(RuntimeError, match="Branch mismatch before push"):
+        _ensure_branch_and_push(gh, host, "auto-dev/feature-branch", "feat-tip", "main-tip")
+
+    host.recover_worktree_branch.assert_called_once()
+    gh.git_push.assert_not_called()
+
+
+def test_recovery_exception_does_not_mask_mismatch():
+    """If recover_worktree_branch itself raises, treat as 'no recovery' → fail closed."""
+    gh = _gh("main")
+    host = _host(recover_return=None, recover_exc=RuntimeError("checkout blew up"))
+
+    with pytest.raises(RuntimeError, match="Branch mismatch before push"):
+        _ensure_branch_and_push(gh, host, "auto-dev/feature-branch", "feat-tip", "main-tip")
+
+    gh.git_push.assert_not_called()
+
+
+def test_orchestrator_public_alias_delegates_to_private():
+    """AutonomousOrchestrator.recover_worktree_branch (PhaseHost-facing) delegates
+    to _recover_worktree_branch so the pr_review push can reach it via the host."""
+    from unittest.mock import patch
+
+    from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+    with patch.object(
+        AutonomousOrchestrator, "_recover_worktree_branch", return_value="ok"
+    ) as mock_private:
+        with (
+            patch("app.modules.workspace.autonomous.orchestrator.Database"),
+            patch("app.modules.workspace.autonomous.orchestrator.AutonomousWorkflowRepository"),
+        ):
+            orch = AutonomousOrchestrator("wf-alias-test")
+        gh = MagicMock()
+        result = orch.recover_worktree_branch(gh, "auto-dev/x", "feat-tip", "main-tip")
+
+    assert result == "ok"
+    mock_private.assert_called_once_with(gh, "auto-dev/x", "feat-tip", "main-tip")


### PR DESCRIPTION
## Problem

Workflow 212 permanently failed at the pr_review push check: \"Branch mismatch before push: expected auto-dev/..., actual main\" — the worktree was on main at push time (a failure→retry→reentry sequence left it there). The central guard (\`_validate_repo_context_after_run\`, #2271) recovers a worktree the agent left on another branch **after each agent run**, but it does NOT cover the push-time check itself — so the push had no recovery attempt.

Investigation confirmed the central guard IS wired to pr_review's agent (via \`_run_agent\`), so this is not a wiring gap — it's that the push check itself had no defense-in-depth.

## Fix

Defense-in-depth recovery at the push check:
- **PhaseHost.recover_worktree_branch** (phase_host.py) — expose the orchestrator's \`_recover_worktree_branch\` to phases via the host (same pattern as \`validate_pre_merge_change_scope\`).
- **AutonomousOrchestrator.recover_worktree_branch** (orchestrator.py) — public alias delegating to the unchanged \`_recover_worktree_branch\` (the central guard still calls the private one directly).
- **phases/pr_review.py** — \`_ensure_branch_and_push\` helper: at the push, if \`current_branch != branch_name\`, call \`host.recover_worktree_branch(...)\` with the entry-captured feature tip + main HEAD; if recovered → re-check + push; else fail closed (preserves the #1611 check). Entry state captured before any agent run / branch switch.

Reuses \`_recover_worktree_branch\`'s safe predicate (feature ref unchanged + worktree clean + wrong-branch HEAD == baseline main HEAD) — only fires when the switch is provably read-only. The push check is a true defense-in-depth net: in the normal agent-run path the central guard already recovered, so this is a no-op; it only fires in the reentry case (212's) where no agent ran between entry and push.

## Independent review

Agent \`ae6fb760fc5ba9d76\`: **correct + safe, no blocking issues**. Documented nuance: entry-baseline (phase-entry) semantics differ from the central guard's pre-agent baseline, but that's exactly right for the reentry defense case (no agent between entry + push → predicate holds). Empty-baseline (capture failed) degrades fail-closed via \`_recover_worktree_branch\`'s existing guard. No double-recovery concern (central guard recovery → push-check's \`current_branch != branch_name\` is False → no-op).

## Tests

\`tests/issues/2302/\` (5): push-when-on-feature (no recovery), recover-when-safe (push proceeds), fail-when-unsafe (RuntimeError, no push), recovery-exception (fail closed), orchestrator-alias-delegates. All green; \`tests/issues/2271/\` (recovery predicate) still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)