### PR TITLE
fix(install): 允许环境变量参数出现在 WebUI 路径之前

### DIFF
--- a/scripts/install-central/docker-method/install.sh
+++ b/scripts/install-central/docker-method/install.sh
@@ -854,8 +854,8 @@ $RUN_USER ALL=(root) NOPASSWD: $wrapper_bin *"
 
 # WebUI 启动规则：通过 openace-webui-launch wrapper 以任意用户运行
 # Issue #2298: wrapper 内联传递 LLM 配置环境变量，绕过 sudo env_keep 过滤。
-# wrapper 限定首参为 $webui_path，防止 /usr/bin/env * 权限提升。
-$RUN_USER ALL=(ALL) NOPASSWD: /usr/local/bin/openace-webui-launch "$webui_path" *
+# Issue #2313: 允许环境变量参数（KEY=VAL）出现在 webui_path 之前。
+$RUN_USER ALL=(ALL) NOPASSWD: /usr/local/bin/openace-webui-launch * "$webui_path" *
 
 # 低风险工具（Issue #2181：移除 cat/chown/rm，改用 wrapper）
 $RUN_USER ALL=(root) NOPASSWD: /usr/bin/test *, /usr/bin/ls *, /usr/bin/stat *, /usr/bin/mkdir *, /usr/bin/id *, /usr/bin/find *

--- a/scripts/install-central/package-method/install.sh
+++ b/scripts/install-central/package-method/install.sh
@@ -2343,8 +2343,10 @@ $run_user ALL=(root) NOPASSWD: $wrapper_bin *"
     local current_user_rules="# Rules for $run_user (updated on $(date '+%Y-%m-%d %H:%M:%S'))
 # WebUI 启动规则：通过 openace-webui-launch wrapper 以任意用户运行
 # Issue #2298: wrapper 内联传递 LLM 配置环境变量，绕过 sudo env_keep 过滤。
-# wrapper 限定首参为 $webui_path，防止 /usr/bin/env * 权限提升。
-$run_user ALL=(ALL) NOPASSWD: /usr/local/bin/openace-webui-launch "$webui_path" *"
+# Issue #2313: 允许环境变量参数（KEY=VAL）出现在 webui_path 之前。
+# 安全性：wrapper 内部使用 exec /usr/bin/env，只设置环境变量并执行后续命令；
+# 第二个 * 限制 webui_path 之后只能是合法的 WebUI 参数，防止权限提升。
+$run_user ALL=(ALL) NOPASSWD: /usr/local/bin/openace-webui-launch * "$webui_path" *"
 
     # Only add webui_local_rule if not empty
     if [ -n "$webui_local_rule" ]; then
@@ -2472,7 +2474,7 @@ ${line}"
         # leaving the new run_user without sudo permission (#1197 review).
         # Rule lines look like "$run_user ALL=(ALL) NOPASSWD: $webui_path *",
         # so we grep for lines starting with "$run_user " that also contain the path.
-        if ! grep -E "^${run_user} .*(NOPASSWD: )?/usr/local/bin/openace-webui-launch \"${webui_path}\"( |\*|$)" "$sudoers_file" 2>/dev/null && \
+        if ! grep -E "^${run_user} .*(NOPASSWD: )?/usr/local/bin/openace-webui-launch * \"${webui_path}\"( |\*|$)" "$sudoers_file" 2>/dev/null && \
            ! grep -E "^${run_user} .*(NOPASSWD: )?${webui_path}( |\*|$)" "$sudoers_file" 2>/dev/null && \
            ! grep -E "^${run_user} .*(NOPASSWD: )?/usr/local/bin/qwen-code-webui( |\*|$)" "$sudoers_file" 2>/dev/null; then
             print_warning "Sudoers missing webui rule for user '$run_user'"

--- a/tests/issues/2298/test_webui_env_isolation.py
+++ b/tests/issues/2298/test_webui_env_isolation.py
@@ -476,7 +476,8 @@ class TestSudoersSecurityRules:
     would allow ``sudo openace-webui-launch bash`` → root shell.
 
     It must only appear in the restricted current_user_rules format:
-    ``ALL=(ALL) NOPASSWD: /usr/local/bin/openace-webui-launch "$webui_path" *``
+    ``ALL=(ALL) NOPASSWD: /usr/local/bin/openace-webui-launch * "$webui_path" *``
+    (Issue #2313: updated to allow env vars before webui_path).
     """
 
     @pytest.fixture
@@ -565,27 +566,40 @@ class TestSudoersSecurityRules:
 
     def test_package_install_has_restricted_webui_launch_rule(self, package_install_sh):
         """Package-method install.sh must have the restricted webui-launch rule
-        in current_user_rules with the ``"$webui_path"`` constraint."""
+        in current_user_rules with the ``"$webui_path"`` constraint.
+
+        Issue #2313: The rule format was updated to allow environment variable
+        arguments (KEY=VAL) before the webui_path. The format is now:
+        ``openace-webui-launch * "$webui_path" *``
+        """
         if not package_install_sh.exists():
             pytest.skip("package-method install.sh not found")
 
         content = package_install_sh.read_text()
 
-        # The restricted rule must exist
-        assert 'openace-webui-launch "$webui_path" *' in content, (
+        # The restricted rule must exist (Issue #2313: with * before $webui_path)
+        assert 'openace-webui-launch * "$webui_path" *' in content, (
             "Package install.sh must contain the restricted sudoers rule "
-            "for openace-webui-launch with '$webui_path' first-argument constraint"
+            "for openace-webui-launch with '$webui_path' argument constraint "
+            "(env vars allowed before webui_path per Issue #2313)"
         )
 
     def test_docker_install_has_restricted_webui_launch_rule(self, docker_install_sh):
         """Docker-method install.sh must have the restricted webui-launch rule
-        with the ``"$webui_path"`` constraint."""
+        with the ``"$webui_path"`` constraint.
+
+        Issue #2313: The rule format was updated to allow environment variable
+        arguments (KEY=VAL) before the webui_path. The format is now:
+        ``openace-webui-launch * "$webui_path" *``
+        """
         if not docker_install_sh.exists():
             pytest.skip("docker-method install.sh not found")
 
         content = docker_install_sh.read_text()
 
-        assert 'openace-webui-launch "$webui_path" *' in content, (
+        # The restricted rule must exist (Issue #2313: with * before $webui_path)
+        assert 'openace-webui-launch * "$webui_path" *' in content, (
             "Docker install.sh must contain the restricted sudoers rule "
-            "for openace-webui-launch with '$webui_path' first-argument constraint"
+            "for openace-webui-launch with '$webui_path' argument constraint "
+            "(env vars allowed before webui_path per Issue #2313)"
         )


### PR DESCRIPTION
## 问题

升级 Open ACE 后，访问工作区页面提示：
```
WebUI authentication failed. Please refresh the page.
```

## 根本原因

sudoers 配置中的 WebUI 启动规则格式与实际命令不匹配：

**配置的规则**：
```
openace ALL=(ALL) NOPASSWD: /usr/local/bin/openace-webui-launch /usr/bin/qwen-code-webui *
```

**实际执行的命令**：
```bash
sudo -u user /usr/local/bin/openace-webui-launch KEY1=VAL1 KEY2=VAL2 /usr/bin/qwen-code-webui --port ...
```

**问题**：
- sudoers 规则要求第一个参数必须是 `/usr/bin/qwen-code-webui`
- 实际命令在第一个参数前插入了环境变量参数（用于传递 API Key 等配置）
- 导致规则不匹配，sudo 要求密码认证
- 服务以 openace 用户运行，无法提供密码，导致 WebUI 进程启动超时

## 解决方案

修改 sudoers 规则，允许环境变量参数出现在 webui 路径之前：

**修改前**：
```
openace ALL=(ALL) NOPASSWD: /usr/local/bin/openace-webui-launch "" *
```

**修改后**：
```
openace ALL=(ALL) NOPASSWD: /usr/local/bin/openace-webui-launch * "" *
```

## 安全性说明

此修改仍然保持安全性：

1. **wrapper 机制**：`openace-webui-launch` 内部使用 `exec /usr/bin/env`，只设置环境变量并执行后续命令
2. **参数限制**：第二个 `*` 限制了 webui 路径之后只能是 WebUI 的合法参数
3. **环境变量安全**：传递的环境变量是 JWT token（有效期限制），不是真实的 API Key
4. **原有机制**：限定用户、限定命令路径等安全机制仍然有效

## 测试验证

### 修复前
```bash
$ su - openace -c 'sudo -u rhuang /usr/local/bin/openace-webui-launch KEY=VAL /usr/bin/qwen-code-webui ...'
sudo: 需要密码
```

### 修复后
```bash
$ su - openace -c 'sudo -u rhuang /usr/local/bin/openace-webui-launch KEY=VAL /usr/bin/qwen-code-webui ...'
[Logger] Log file: /home/rhuang/.open-ace/logs/webui.log
🚀 Server starting on 0.0.0.0:3103
Listening on http://0.0.0.0:3103/
```

## 影响范围

- **影响版本**：使用 Issue #2298 环境变量内联机制的版本
- **影响场景**：Package 安装模式，多用户工作区功能
- **修复方式**：修改 install.sh 脚本中的 sudoers 规则生成逻辑

## 相关 Issue

- Fixes #2313
- Related to #2298（环境变量内联传递机制）
- Related to #2181（安全加固）