### PR TITLE
fix: remove incorrect tenant scope restriction for admin/platform_admin in mapping rules

### DIFF
--- a/app/routes/mapping_rules.py
+++ b/app/routes/mapping_rules.py
@@ -62,14 +62,7 @@ def get_all_rules():
 
     repo = ToolAccountMappingRuleRepository()
 
-    if user_role == "platform_admin":
-        # Platform admin: can see all rules
-        # Issue #2286: Accept legacy 'admin' role alongside 'platform_admin' for backward compatibility.
-        rules = repo.get_all()
-    elif user_role == "admin":
-        # Legacy admin: backward compatibility - can see all rules
-        rules = repo.get_all()
-    elif user_role == "tenant_admin":
+    if user_role == "tenant_admin":
         # Tenant admin: only see rules for users in their tenant
         if user_tenant_id is None:
             return jsonify({"error": "Tenant admin must have tenant_id"}), 403
@@ -78,15 +71,10 @@ def get_all_rules():
         tenant_user_ids = set(_get_tenant_scoped_user_ids(user_tenant_id))
         rules = [r for r in all_rules if r.user_id in tenant_user_ids]
     elif User.is_admin_role(user_role):
-        # Legacy admin: backward compatibility
-        # - With tenant_id: scoped to that tenant (like tenant_admin)
-        # - Without tenant_id: global access (like platform_admin)
-        if user_tenant_id is not None:
-            all_rules = repo.get_all()
-            tenant_user_ids = set(_get_tenant_scoped_user_ids(user_tenant_id))
-            rules = [r for r in all_rules if r.user_id in tenant_user_ids]
-        else:
-            rules = repo.get_all()
+        # Platform admin and legacy admin: can see all rules.
+        # Issue #2286: 'admin' is treated as 'platform_admin' for backward compatibility,
+        # regardless of whether tenant_id is set.
+        rules = repo.get_all()
     else:
         return jsonify({"error": "Permission denied"}), 403
 
@@ -104,17 +92,13 @@ def get_user_rules(user_id: int):
     user_role = g.user.get("role")
     user_tenant_id = g.user.get("tenant_id")
 
-    # Validate user belongs to caller's tenant (for tenant admin or scoped admin)
+    # Validate user belongs to caller's tenant (tenant admin only).
+    # Issue #2286: 'admin' and 'platform_admin' have global access regardless of tenant_id.
     if user_role == "tenant_admin":
         if user_tenant_id is None:
             return jsonify({"error": "Tenant admin must have tenant_id"}), 403
         if not _validate_user_in_tenant(user_id, user_tenant_id):
             return jsonify({"error": "User not found"}), 404
-    elif User.is_admin_role(user_role) and user_tenant_id is not None:
-        # Legacy admin with tenant_id: validate tenant scope
-        if not _validate_user_in_tenant(user_id, user_tenant_id):
-            return jsonify({"error": "User not found"}), 404
-    # Platform admin and legacy admin without tenant_id: no validation
 
     repo = ToolAccountMappingRuleRepository()
     rules = repo.get_by_user_id(user_id)
@@ -141,17 +125,13 @@ def create_rule():
     user_role = g.user.get("role")
     user_tenant_id = g.user.get("tenant_id")
 
-    # Validate user belongs to caller's tenant
+    # Validate user belongs to caller's tenant (tenant admin only).
+    # Issue #2286: 'admin' and 'platform_admin' have global access regardless of tenant_id.
     if user_role == "tenant_admin":
         if user_tenant_id is None:
             return jsonify({"error": "Tenant admin must have tenant_id"}), 403
         if not _validate_user_in_tenant(user_id, user_tenant_id):
             return jsonify({"error": "Cannot create rule for user in different tenant"}), 403
-    elif User.is_admin_role(user_role) and user_tenant_id is not None:
-        # Legacy admin with tenant_id: validate tenant scope
-        if not _validate_user_in_tenant(user_id, user_tenant_id):
-            return jsonify({"error": "Cannot create rule for user in different tenant"}), 403
-    # Platform admin and legacy admin without tenant_id: no validation
 
     repo = ToolAccountMappingRuleRepository()
     rule = repo.create(
@@ -198,17 +178,10 @@ def update_rule(id: int):
             return jsonify({"error": "Tenant admin must have tenant_id"}), 403
         if not _validate_user_in_tenant(existing_rule.user_id, user_tenant_id):
             return jsonify({"error": "Rule not found"}), 404
-    elif User.is_admin_role(user_role) and user_tenant_id is not None:
-        # Legacy admin with tenant_id: validate tenant scope
-        if not _validate_user_in_tenant(existing_rule.user_id, user_tenant_id):
-            return jsonify({"error": "Rule not found"}), 404
 
-    # If user_id is being changed, validate new user too
+    # If user_id is being changed, validate new user too (tenant admin only)
     new_user_id = data.get("user_id")
-    if new_user_id and (
-        user_role == "tenant_admin"
-        or (User.is_admin_role(user_role) and user_tenant_id is not None)
-    ):
+    if new_user_id and user_role == "tenant_admin":
         if not _validate_user_in_tenant(new_user_id, user_tenant_id):
             return jsonify({"error": "Cannot assign rule to user in different tenant"}), 403
 
@@ -253,10 +226,6 @@ def delete_rule(id: int):
             return jsonify({"error": "Tenant admin must have tenant_id"}), 403
         if not _validate_user_in_tenant(existing_rule.user_id, user_tenant_id):
             return jsonify({"error": "Rule not found"}), 404
-    elif User.is_admin_role(user_role) and user_tenant_id is not None:
-        # Legacy admin with tenant_id: validate tenant scope
-        if not _validate_user_in_tenant(existing_rule.user_id, user_tenant_id):
-            return jsonify({"error": "Rule not found"}), 404
 
     success = repo.delete(id)
     if success:
@@ -277,14 +246,11 @@ def generate_default_rules(user_id: int):
     user_role = g.user.get("role")
     user_tenant_id = g.user.get("tenant_id")
 
-    # Validate user belongs to caller's tenant
+    # Validate user belongs to caller's tenant (tenant admin only).
+    # Issue #2286: 'admin' and 'platform_admin' have global access regardless of tenant_id.
     if user_role == "tenant_admin":
         if user_tenant_id is None:
             return jsonify({"error": "Tenant admin must have tenant_id"}), 403
-        if not _validate_user_in_tenant(user_id, user_tenant_id):
-            return jsonify({"error": "User not found"}), 404
-    elif User.is_admin_role(user_role) and user_tenant_id is not None:
-        # Legacy admin with tenant_id: validate tenant scope
         if not _validate_user_in_tenant(user_id, user_tenant_id):
             return jsonify({"error": "User not found"}), 404
 
@@ -323,7 +289,7 @@ def get_mapping_stats():
 
     service = ToolAccountAutoMappingService()
 
-    if user_role in ("tenant_admin", "admin") and user_tenant_id is not None:
+    if user_role == "tenant_admin" and user_tenant_id is not None:
         # Filter stats by tenant
         stats = service.get_mapping_stats(tenant_id=user_tenant_id)
     else:
@@ -348,7 +314,7 @@ def run_auto_mapping():
 
     service = ToolAccountAutoMappingService()
 
-    if user_role in ("tenant_admin", "admin") and user_tenant_id is not None:
+    if user_role == "tenant_admin" and user_tenant_id is not None:
         # Only auto-map for tenant's users
         results, still_unmapped = service.run_auto_mapping(
             dry_run=dry_run, tenant_id=user_tenant_id
@@ -408,7 +374,7 @@ def get_unmapped_accounts():
 
     repo = UserToolAccountRepository()
 
-    if user_role in ("tenant_admin", "admin") and user_tenant_id is not None:
+    if user_role == "tenant_admin" and user_tenant_id is not None:
         unmapped = repo.get_unmapped_tool_accounts(tenant_id=user_tenant_id)
     else:
         unmapped = repo.get_unmapped_tool_accounts()
@@ -460,14 +426,11 @@ def manual_map_account(sender_name: str):
     user_role = g.user.get("role")
     user_tenant_id = g.user.get("tenant_id")
 
-    # Validate user belongs to caller's tenant
+    # Validate user belongs to caller's tenant (tenant admin only).
+    # Issue #2286: 'admin' and 'platform_admin' have global access regardless of tenant_id.
     if user_role == "tenant_admin":
         if user_tenant_id is None:
             return jsonify({"error": "Tenant admin must have tenant_id"}), 403
-        if not _validate_user_in_tenant(user_id, user_tenant_id):
-            return jsonify({"error": "Cannot map to user in different tenant"}), 403
-    elif User.is_admin_role(user_role) and user_tenant_id is not None:
-        # Legacy admin with tenant_id: validate tenant scope
         if not _validate_user_in_tenant(user_id, user_tenant_id):
             return jsonify({"error": "Cannot map to user in different tenant"}), 403
 

--- a/tests/security/test_tenant_isolation_mapping_rules.py
+++ b/tests/security/test_tenant_isolation_mapping_rules.py
@@ -2,6 +2,8 @@
 Security tests for tenant isolation in mapping rules generation.
 
 Issue #2131: Verify multi-tenant permission isolation correctness.
+Issue #2286: 'admin' role treated as 'platform_admin' for backward compatibility.
+Issue #2324: Admin with tenant_id should not be tenant-scoped in mapping rules.
 """
 
 import json
@@ -395,3 +397,355 @@ class TestTenantIsolationForOtherOperations:
 
         # Should return 403 (cannot create rule for user in different tenant)
         assert response.status_code in (403, 404)
+
+
+# ---------------------------------------------------------------------------
+# Issue #2324: Admin/platform_admin with tenant_id must NOT be tenant-scoped.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def admin_with_tenant_client(app):
+    """Create test client with admin role that HAS a tenant_id.
+
+    Issue #2324: An 'admin' user with tenant_id should still have global
+    access (treated as platform_admin per Issue #2286), not be scoped
+    to their tenant.
+    """
+    test_client = app.test_client()
+
+    class AdminWithTenantAuthenticatedClient:
+        def __init__(self, client):
+            self._client = client
+
+        def _auth_patch(self):
+            return patch(
+                "app.auth.decorators._load_user_from_token",
+                return_value={
+                    "id": 1,
+                    "role": "admin",
+                    "username": "admin_with_tenant",
+                    "tenant_id": 1,  # Has tenant_id but should NOT be scoped
+                },
+            )
+
+        def _token_patch(self):
+            return patch(
+                "app.auth.decorators._extract_session_token", return_value="test-token"
+            )
+
+        def get(self, *args, **kwargs):
+            with self._token_patch():
+                with self._auth_patch():
+                    return self._client.get(*args, **kwargs)
+
+        def post(self, *args, **kwargs):
+            with self._token_patch():
+                with self._auth_patch():
+                    return self._client.post(*args, **kwargs)
+
+        def put(self, *args, **kwargs):
+            with self._token_patch():
+                with self._auth_patch():
+                    return self._client.put(*args, **kwargs)
+
+        def delete(self, *args, **kwargs):
+            with self._token_patch():
+                with self._auth_patch():
+                    return self._client.delete(*args, **kwargs)
+
+    return AdminWithTenantAuthenticatedClient(test_client)
+
+
+@pytest.fixture
+def platform_admin_with_tenant_client(app):
+    """Create test client with platform_admin role that HAS a tenant_id.
+
+    Issue #2324: A 'platform_admin' user with tenant_id should still have
+    global access, not be scoped to their tenant.
+    """
+    test_client = app.test_client()
+
+    class PlatformAdminWithTenantAuthenticatedClient:
+        def __init__(self, client):
+            self._client = client
+
+        def _auth_patch(self):
+            return patch(
+                "app.auth.decorators._load_user_from_token",
+                return_value={
+                    "id": 1,
+                    "role": "platform_admin",
+                    "username": "platform_admin_with_tenant",
+                    "tenant_id": 1,  # Has tenant_id but should NOT be scoped
+                },
+            )
+
+        def _token_patch(self):
+            return patch(
+                "app.auth.decorators._extract_session_token", return_value="test-token"
+            )
+
+        def get(self, *args, **kwargs):
+            with self._token_patch():
+                with self._auth_patch():
+                    return self._client.get(*args, **kwargs)
+
+        def post(self, *args, **kwargs):
+            with self._token_patch():
+                with self._auth_patch():
+                    return self._client.post(*args, **kwargs)
+
+        def put(self, *args, **kwargs):
+            with self._token_patch():
+                with self._auth_patch():
+                    return self._client.put(*args, **kwargs)
+
+        def delete(self, *args, **kwargs):
+            with self._token_patch():
+                with self._auth_patch():
+                    return self._client.delete(*args, **kwargs)
+
+    return PlatformAdminWithTenantAuthenticatedClient(test_client)
+
+
+class TestAdminWithTenantIdNotScoped:
+    """
+    Issue #2324: Verify that admin/platform_admin with tenant_id is NOT
+    tenant-scoped in mapping rules operations.
+
+    Per Issue #2286, 'admin' is treated as 'platform_admin' for backward
+    compatibility. Having a tenant_id should NOT restrict their access.
+    """
+
+    @patch("app.routes.mapping_rules.user_repo")
+    @patch("app.routes.mapping_rules.ToolAccountAutoMappingService")
+    def test_admin_with_tenant_can_generate_rules_for_other_tenant_user(
+        self, mock_service_class, mock_user_repo, admin_with_tenant_client
+    ):
+        """Admin with tenant_id should generate rules for cross-tenant user."""
+        from app.models.tool_account_mapping_rule import ToolAccountMappingRule
+        from app.services.tool_account_auto_mapping_service import GenerateDefaultRulesResult
+
+        # Target user belongs to different tenant (tenant_id=2)
+        mock_user_repo.get_user_by_id.return_value = {
+            "id": 5,
+            "username": "other_tenant_user",
+            "tenant_id": 2,  # Different from admin's tenant (1)
+        }
+
+        mock_service = MagicMock()
+        result = GenerateDefaultRulesResult(
+            created=[
+                ToolAccountMappingRule(
+                    id=1, user_id=5, pattern="user-*",
+                    match_type="prefix", priority=10, is_auto=True, is_active=True,
+                )
+            ],
+            skipped=[],
+            created_count=1,
+            skipped_count=0,
+        )
+        mock_service.create_default_rules_for_user.return_value = result
+        mock_service_class.return_value = mock_service
+
+        response = admin_with_tenant_client.post(
+            "/api/mapping-rules/user/5/generate-default",
+            content_type="application/json",
+        )
+
+        # Should succeed, NOT 404
+        assert response.status_code in (200, 201)
+        mock_service.create_default_rules_for_user.assert_called_once_with(5)
+
+    @patch("app.routes.mapping_rules.user_repo")
+    @patch("app.routes.mapping_rules.ToolAccountAutoMappingService")
+    def test_platform_admin_with_tenant_can_generate_rules_for_other_tenant_user(
+        self, mock_service_class, mock_user_repo, platform_admin_with_tenant_client
+    ):
+        """Platform admin with tenant_id should generate rules for cross-tenant user."""
+        from app.models.tool_account_mapping_rule import ToolAccountMappingRule
+        from app.services.tool_account_auto_mapping_service import GenerateDefaultRulesResult
+
+        mock_user_repo.get_user_by_id.return_value = {
+            "id": 5,
+            "username": "other_tenant_user",
+            "tenant_id": 2,
+        }
+
+        mock_service = MagicMock()
+        result = GenerateDefaultRulesResult(
+            created=[
+                ToolAccountMappingRule(
+                    id=1, user_id=5, pattern="user-*",
+                    match_type="prefix", priority=10, is_auto=True, is_active=True,
+                )
+            ],
+            skipped=[],
+            created_count=1,
+            skipped_count=0,
+        )
+        mock_service.create_default_rules_for_user.return_value = result
+        mock_service_class.return_value = mock_service
+
+        response = platform_admin_with_tenant_client.post(
+            "/api/mapping-rules/user/5/generate-default",
+            content_type="application/json",
+        )
+
+        assert response.status_code in (200, 201)
+        mock_service.create_default_rules_for_user.assert_called_once_with(5)
+
+    @patch("app.routes.mapping_rules.user_repo")
+    def test_admin_with_tenant_can_get_rules_for_other_tenant_user(
+        self, mock_user_repo, admin_with_tenant_client
+    ):
+        """Admin with tenant_id should get rules for cross-tenant user."""
+        mock_user_repo.get_user_by_id.return_value = {
+            "id": 5,
+            "tenant_id": 2,
+        }
+
+        with patch("app.routes.mapping_rules.ToolAccountMappingRuleRepository") as mock_repo_class:
+            mock_repo = MagicMock()
+            mock_rule = MagicMock()
+            mock_rule.to_dict.return_value = {"id": 1, "user_id": 5, "pattern": "test-*"}
+            mock_repo.get_by_user_id.return_value = [mock_rule]
+            mock_repo_class.return_value = mock_repo
+
+            response = admin_with_tenant_client.get("/api/mapping-rules/user/5")
+
+        # Should succeed, NOT 404
+        assert response.status_code == 200
+
+    @patch("app.routes.mapping_rules.user_repo")
+    def test_admin_with_tenant_can_create_rule_for_other_tenant_user(
+        self, mock_user_repo, admin_with_tenant_client
+    ):
+        """Admin with tenant_id should create rules for cross-tenant user."""
+        mock_user_repo.get_user_by_id.return_value = {
+            "id": 5,
+            "tenant_id": 2,
+        }
+
+        with patch("app.routes.mapping_rules.ToolAccountMappingRuleRepository") as mock_repo_class:
+            mock_repo = MagicMock()
+            mock_rule = MagicMock()
+            mock_rule.to_dict.return_value = {
+                "id": 1, "user_id": 5, "pattern": "test-*", "match_type": "prefix",
+            }
+            mock_repo.create.return_value = mock_rule
+            mock_repo_class.return_value = mock_repo
+
+            response = admin_with_tenant_client.post(
+                "/api/mapping-rules",
+                data=json.dumps({"user_id": 5, "pattern": "test-*", "match_type": "prefix"}),
+                content_type="application/json",
+            )
+
+        # Should succeed, NOT 403
+        assert response.status_code == 201
+
+    @patch("app.routes.mapping_rules.ToolAccountMappingRuleRepository")
+    def test_admin_with_tenant_can_delete_rule_for_other_tenant_user(
+        self, mock_repo_class, admin_with_tenant_client
+    ):
+        """Admin with tenant_id should delete rules for cross-tenant user."""
+        mock_repo = MagicMock()
+        mock_rule = MagicMock()
+        mock_rule.user_id = 5  # User in different tenant
+        mock_repo.get_by_id.return_value = mock_rule
+        mock_repo.delete.return_value = True
+        mock_repo_class.return_value = mock_repo
+
+        response = admin_with_tenant_client.delete("/api/mapping-rules/1")
+
+        # Should succeed, NOT 404
+        assert response.status_code == 200
+
+    @patch("app.routes.mapping_rules.ToolAccountMappingRuleRepository")
+    def test_admin_with_tenant_can_update_rule_for_other_tenant_user(
+        self, mock_repo_class, admin_with_tenant_client
+    ):
+        """Admin with tenant_id should update rules for cross-tenant user."""
+        mock_repo = MagicMock()
+        mock_rule = MagicMock()
+        mock_rule.user_id = 5  # User in different tenant
+        mock_repo.get_by_id.return_value = mock_rule
+        updated_rule = MagicMock()
+        updated_rule.to_dict.return_value = {"id": 1, "user_id": 5, "pattern": "updated-*"}
+        mock_repo.update.return_value = updated_rule
+        mock_repo_class.return_value = mock_repo
+
+        response = admin_with_tenant_client.put(
+            "/api/mapping-rules/1",
+            data=json.dumps({"pattern": "updated-*"}),
+            content_type="application/json",
+        )
+
+        # Should succeed, NOT 404
+        assert response.status_code == 200
+
+    @patch("app.routes.mapping_rules.user_repo")
+    def test_admin_with_tenant_can_manual_map_for_other_tenant_user(
+        self, mock_user_repo, admin_with_tenant_client
+    ):
+        """Admin with tenant_id should manually map accounts for cross-tenant user."""
+        mock_user_repo.get_user_by_id.return_value = {
+            "id": 5,
+            "tenant_id": 2,
+        }
+
+        with patch("app.routes.mapping_rules.UserToolAccountRepository") as mock_repo_class:
+            mock_repo = MagicMock()
+            mock_mapping = MagicMock()
+            mock_mapping.to_dict.return_value = {
+                "id": 1, "user_id": 5, "tool_account": "test-account",
+            }
+            mock_repo.create.return_value = mock_mapping
+            mock_repo_class.return_value = mock_repo
+
+            response = admin_with_tenant_client.post(
+                "/api/unmapped-accounts/test-account/map",
+                data=json.dumps({"user_id": 5}),
+                content_type="application/json",
+            )
+
+        # Should succeed, NOT 403
+        assert response.status_code == 201
+
+    @patch("app.routes.mapping_rules.ToolAccountAutoMappingService")
+    def test_admin_with_tenant_sees_all_stats(
+        self, mock_service_class, admin_with_tenant_client
+    ):
+        """Admin with tenant_id should see all stats, not tenant-filtered."""
+        mock_service = MagicMock()
+        mock_service.get_mapping_stats.return_value = {"total": 100}
+        mock_service_class.return_value = mock_service
+
+        admin_with_tenant_client.get("/api/mapping-stats")
+
+        # Should NOT pass tenant_id to get_mapping_stats
+        mock_service.get_mapping_stats.assert_called_once_with()
+
+    @patch("app.routes.mapping_rules.ToolAccountAutoMappingService")
+    def test_admin_with_tenant_sees_all_unmapped_accounts(
+        self, mock_service_class, admin_with_tenant_client
+    ):
+        """Admin with tenant_id should see all unmapped accounts, not tenant-filtered."""
+        mock_service = MagicMock()
+        mock_service._infer_tool_type.return_value = "qwen"
+        mock_service_class.return_value = mock_service
+
+        with patch("app.routes.mapping_rules.UserToolAccountRepository") as mock_repo_class:
+            mock_repo = MagicMock()
+            mock_repo.get_unmapped_tool_accounts.return_value = [
+                {"sender_name": "account1", "message_count": 5}
+            ]
+            mock_repo_class.return_value = mock_repo
+
+            response = admin_with_tenant_client.get("/api/unmapped-accounts")
+
+        # Should NOT pass tenant_id to get_unmapped_tool_accounts
+        mock_repo.get_unmapped_tool_accounts.assert_called_once_with()
+        assert response.status_code == 200

--- a/tests/security/test_tenant_isolation_mapping_rules.py
+++ b/tests/security/test_tenant_isolation_mapping_rules.py
@@ -749,3 +749,55 @@ class TestAdminWithTenantIdNotScoped:
         # Should NOT pass tenant_id to get_unmapped_tool_accounts
         mock_repo.get_unmapped_tool_accounts.assert_called_once_with()
         assert response.status_code == 200
+
+    @patch("app.routes.mapping_rules.ToolAccountAutoMappingService")
+    def test_admin_with_tenant_run_auto_mapping_global(
+        self, mock_service_class, admin_with_tenant_client
+    ):
+        """Admin with tenant_id should run auto-mapping globally, not tenant-scoped."""
+        mock_service = MagicMock()
+        mock_service.run_auto_mapping.return_value = ([], [])
+        mock_service_class.return_value = mock_service
+
+        admin_with_tenant_client.post(
+            "/api/mapping-rules/auto-map",
+            data=json.dumps({"dry_run": True}),
+            content_type="application/json",
+        )
+
+        # Should NOT pass tenant_id to run_auto_mapping
+        mock_service.run_auto_mapping.assert_called_once_with(dry_run=True)
+
+    @patch("app.routes.mapping_rules.ToolAccountMappingRuleRepository")
+    def test_admin_with_tenant_sees_all_rules(
+        self, mock_repo_class, admin_with_tenant_client
+    ):
+        """Admin with tenant_id should see all rules, not tenant-filtered."""
+        mock_repo = MagicMock()
+        mock_rule = MagicMock()
+        mock_rule.to_dict.return_value = {"id": 1, "user_id": 5, "pattern": "test-*"}
+        mock_repo.get_all.return_value = [mock_rule]
+        mock_repo_class.return_value = mock_repo
+
+        response = admin_with_tenant_client.get("/api/mapping-rules")
+
+        # Should return all rules without tenant filtering
+        assert response.status_code == 200
+        mock_repo.get_all.assert_called_once()
+
+    @patch("app.routes.mapping_rules.ToolAccountMappingRuleRepository")
+    def test_platform_admin_with_tenant_can_delete_rule_for_other_tenant_user(
+        self, mock_repo_class, platform_admin_with_tenant_client
+    ):
+        """Platform admin with tenant_id should delete rules for cross-tenant user."""
+        mock_repo = MagicMock()
+        mock_rule = MagicMock()
+        mock_rule.user_id = 5  # User in different tenant
+        mock_repo.get_by_id.return_value = mock_rule
+        mock_repo.delete.return_value = True
+        mock_repo_class.return_value = mock_repo
+
+        response = platform_admin_with_tenant_client.delete("/api/mapping-rules/1")
+
+        # Should succeed, NOT 404
+        assert response.status_code == 200

--- a/tests/security/test_tenant_isolation_mapping_rules.py
+++ b/tests/security/test_tenant_isolation_mapping_rules.py
@@ -55,6 +55,11 @@ def tenant_admin_client(app):
                 with self._auth_patch():
                     return self._client.post(*args, **kwargs)
 
+        def put(self, *args, **kwargs):
+            with self._token_patch():
+                with self._auth_patch():
+                    return self._client.put(*args, **kwargs)
+
     return TenantAdminAuthenticatedClient(test_client)
 
 
@@ -264,11 +269,20 @@ class TestTenantIsolationForGenerateDefaultRules:
         concurrently, verifying no cross-tenant rule creation occurs.
         """
         import threading
-        import time
         from collections import defaultdict
 
         from app.models.tool_account_mapping_rule import ToolAccountMappingRule
         from app.services.tool_account_auto_mapping_service import GenerateDefaultRulesResult
+
+        # Use side_effect to return correct user data per user_id (thread-safe)
+        # This avoids the race condition of shared return_value
+        tenant_user_map = {
+            11: {"id": 11, "tenant_id": 1},
+            12: {"id": 12, "tenant_id": 1},
+            21: {"id": 21, "tenant_id": 2},
+            22: {"id": 22, "tenant_id": 2},
+        }
+        mock_user_repo.get_user_by_id.side_effect = lambda uid: tenant_user_map.get(uid)
 
         results = defaultdict(list)
         errors = []
@@ -291,7 +305,6 @@ class TestTenantIsolationForGenerateDefaultRules:
                         with patch(
                             "app.routes.mapping_rules.ToolAccountAutoMappingService"
                         ) as mock_service:
-                            # Mock service to track calls
                             mock_service_instance = MagicMock()
                             result = GenerateDefaultRulesResult(
                                 created=[
@@ -313,12 +326,6 @@ class TestTenantIsolationForGenerateDefaultRules:
                                 result
                             )
                             mock_service.return_value = mock_service_instance
-
-                            # Mock user belongs to correct tenant
-                            mock_user_repo.get_user_by_id.return_value = {
-                                "id": user_id,
-                                "tenant_id": tenant_id,
-                            }
 
                             response = test_client.post(
                                 f"/api/mapping-rules/user/{user_id}/generate-default",
@@ -356,9 +363,16 @@ class TestTenantIsolationForGenerateDefaultRules:
         # Verify no errors occurred
         assert len(errors) == 0, f"Errors during concurrent execution: {errors}"
 
+        # Verify all operations succeeded (status 200 or 201)
+        for tenant_id, tenant_results in results.items():
+            for r in tenant_results:
+                assert r["status"] in (200, 201), (
+                    f"Tenant {tenant_id} operation on user {r['user_id']} "
+                    f"returned status {r['status']}"
+                )
+
         # Verify each tenant admin operated on correct users
-        # (This is a basic verification; full verification would require database inspection)
-        assert len(results) > 0, "No results from concurrent execution"
+        assert len(results) == 2, f"Expected 2 tenants in results, got {len(results)}"
 
 
 class TestTenantIsolationForOtherOperations:
@@ -396,13 +410,47 @@ class TestTenantIsolationForOtherOperations:
         )
 
         # Should return 403 (cannot create rule for user in different tenant)
-        assert response.status_code in (403, 404)
+        assert response.status_code == 403
+
+    @patch("app.routes.mapping_rules.user_repo")
+    def test_tenant_admin_cannot_update_rule_user_id_to_other_tenant(
+        self, mock_user_repo, tenant_admin_client
+    ):
+        """
+        Tenant admin should not be able to reassign a rule to a user in different tenant.
+
+        Expected: 403 Forbidden
+        """
+        # Use side_effect to return different data per user_id
+        # user_id=5 belongs to tenant 1 (same as admin), user_id=99 belongs to tenant 2
+        user_data = {
+            5: {"id": 5, "tenant_id": 1},
+            99: {"id": 99, "tenant_id": 2},
+        }
+        mock_user_repo.get_user_by_id.side_effect = lambda uid: user_data.get(uid)
+
+        with patch("app.routes.mapping_rules.ToolAccountMappingRuleRepository") as mock_repo_class:
+            mock_repo = MagicMock()
+            # Existing rule belongs to user in same tenant (user_id=5, tenant_id=1)
+            mock_rule = MagicMock()
+            mock_rule.user_id = 5
+            mock_repo.get_by_id.return_value = mock_rule
+            mock_repo_class.return_value = mock_repo
+
+            # Attempt to reassign rule to user in different tenant
+            response = tenant_admin_client.put(
+                "/api/mapping-rules/1",
+                data=json.dumps({"user_id": 99}),
+                content_type="application/json",
+            )
+
+        # Should return 403 (cannot assign rule to user in different tenant)
+        assert response.status_code == 403
 
 
 # ---------------------------------------------------------------------------
 # Issue #2324: Admin/platform_admin with tenant_id must NOT be tenant-scoped.
 # ---------------------------------------------------------------------------
-
 
 @pytest.fixture
 def admin_with_tenant_client(app):

--- a/tests/security/test_tenant_isolation_mapping_rules.py
+++ b/tests/security/test_tenant_isolation_mapping_rules.py
@@ -452,6 +452,7 @@ class TestTenantIsolationForOtherOperations:
 # Issue #2324: Admin/platform_admin with tenant_id must NOT be tenant-scoped.
 # ---------------------------------------------------------------------------
 
+
 @pytest.fixture
 def admin_with_tenant_client(app):
     """Create test client with admin role that HAS a tenant_id.
@@ -478,9 +479,7 @@ def admin_with_tenant_client(app):
             )
 
         def _token_patch(self):
-            return patch(
-                "app.auth.decorators._extract_session_token", return_value="test-token"
-            )
+            return patch("app.auth.decorators._extract_session_token", return_value="test-token")
 
         def get(self, *args, **kwargs):
             with self._token_patch():
@@ -530,9 +529,7 @@ def platform_admin_with_tenant_client(app):
             )
 
         def _token_patch(self):
-            return patch(
-                "app.auth.decorators._extract_session_token", return_value="test-token"
-            )
+            return patch("app.auth.decorators._extract_session_token", return_value="test-token")
 
         def get(self, *args, **kwargs):
             with self._token_patch():
@@ -586,8 +583,13 @@ class TestAdminWithTenantIdNotScoped:
         result = GenerateDefaultRulesResult(
             created=[
                 ToolAccountMappingRule(
-                    id=1, user_id=5, pattern="user-*",
-                    match_type="prefix", priority=10, is_auto=True, is_active=True,
+                    id=1,
+                    user_id=5,
+                    pattern="user-*",
+                    match_type="prefix",
+                    priority=10,
+                    is_auto=True,
+                    is_active=True,
                 )
             ],
             skipped=[],
@@ -625,8 +627,13 @@ class TestAdminWithTenantIdNotScoped:
         result = GenerateDefaultRulesResult(
             created=[
                 ToolAccountMappingRule(
-                    id=1, user_id=5, pattern="user-*",
-                    match_type="prefix", priority=10, is_auto=True, is_active=True,
+                    id=1,
+                    user_id=5,
+                    pattern="user-*",
+                    match_type="prefix",
+                    priority=10,
+                    is_auto=True,
+                    is_active=True,
                 )
             ],
             skipped=[],
@@ -680,7 +687,10 @@ class TestAdminWithTenantIdNotScoped:
             mock_repo = MagicMock()
             mock_rule = MagicMock()
             mock_rule.to_dict.return_value = {
-                "id": 1, "user_id": 5, "pattern": "test-*", "match_type": "prefix",
+                "id": 1,
+                "user_id": 5,
+                "pattern": "test-*",
+                "match_type": "prefix",
             }
             mock_repo.create.return_value = mock_rule
             mock_repo_class.return_value = mock_repo
@@ -748,7 +758,9 @@ class TestAdminWithTenantIdNotScoped:
             mock_repo = MagicMock()
             mock_mapping = MagicMock()
             mock_mapping.to_dict.return_value = {
-                "id": 1, "user_id": 5, "tool_account": "test-account",
+                "id": 1,
+                "user_id": 5,
+                "tool_account": "test-account",
             }
             mock_repo.create.return_value = mock_mapping
             mock_repo_class.return_value = mock_repo
@@ -763,9 +775,7 @@ class TestAdminWithTenantIdNotScoped:
         assert response.status_code == 201
 
     @patch("app.routes.mapping_rules.ToolAccountAutoMappingService")
-    def test_admin_with_tenant_sees_all_stats(
-        self, mock_service_class, admin_with_tenant_client
-    ):
+    def test_admin_with_tenant_sees_all_stats(self, mock_service_class, admin_with_tenant_client):
         """Admin with tenant_id should see all stats, not tenant-filtered."""
         mock_service = MagicMock()
         mock_service.get_mapping_stats.return_value = {"total": 100}
@@ -817,9 +827,7 @@ class TestAdminWithTenantIdNotScoped:
         mock_service.run_auto_mapping.assert_called_once_with(dry_run=True)
 
     @patch("app.routes.mapping_rules.ToolAccountMappingRuleRepository")
-    def test_admin_with_tenant_sees_all_rules(
-        self, mock_repo_class, admin_with_tenant_client
-    ):
+    def test_admin_with_tenant_sees_all_rules(self, mock_repo_class, admin_with_tenant_client):
         """Admin with tenant_id should see all rules, not tenant-filtered."""
         mock_repo = MagicMock()
         mock_rule = MagicMock()


### PR DESCRIPTION
## Summary

Fixes #2324

### Problem

Admin and `platform_admin` users with a `tenant_id` were incorrectly restricted to their own tenant in mapping rules operations. When an admin user (who has `tenant_id=1`) clicks "Generate Default Rules" for a user in a different tenant (tenant_id=2), the operation fails with a 404 error.

### Root Cause

`mapping_rules.py` used the pattern `elif User.is_admin_role(user_role) and user_tenant_id is not None:` to apply tenant scope validation on **all** admin roles (including `admin` and `platform_admin`) when they had a `tenant_id` set. This contradicts:

- **Issue #2286**: `admin` is treated as `platform_admin` for backward compatibility, both having global access
- **`User.is_platform_admin()`**: Returns `True` for both `admin` and `platform_admin`
- **`get_all_rules()`** in the same file: Already correctly gives `admin` and `platform_admin` global access

Since `tenant_admin` is already handled by the preceding `if user_role == "tenant_admin":` branch, the `elif` only affected `admin`/`platform_admin` incorrectly.

### Fix

1. **Removed the `elif User.is_admin_role(user_role) and user_tenant_id is not None:` branches** from 6 functions:
   - `get_user_rules`
   - `create_rule`
   - `update_rule` (including the `new_user_id` validation)
   - `delete_rule`
   - `generate_default_rules`
   - `manual_map_account`

2. **Changed tenant-filtering conditions** from `user_role in ("tenant_admin", "admin")` to `user_role == "tenant_admin"` in 3 functions:
   - `get_mapping_stats`
   - `run_auto_mapping`
   - `get_unmapped_accounts`

3. **Simplified `get_all_rules()`** by merging the explicit `platform_admin` and `admin` branches into the `User.is_admin_role()` catch-all, since all admin roles except `tenant_admin` should have global access.

### Affected Interfaces

| Function | Before | After |
|----------|--------|-------|
| `get_all_rules` | admin+tenant_id: scoped | admin+tenant_id: global |
| `get_user_rules` | admin+tenant_id: 404 for cross-tenant | admin+tenant_id: no restriction |
| `create_rule` | admin+tenant_id: 403 for cross-tenant | admin+tenant_id: no restriction |
| `update_rule` | admin+tenant_id: 404 for cross-tenant | admin+tenant_id: no restriction |
| `delete_rule` | admin+tenant_id: 404 for cross-tenant | admin+tenant_id: no restriction |
| `generate_default_rules` | admin+tenant_id: 404 for cross-tenant | admin+tenant_id: no restriction |
| `manual_map_account` | admin+tenant_id: 403 for cross-tenant | admin+tenant_id: no restriction |
| `get_mapping_stats` | admin+tenant_id: tenant-filtered | admin+tenant_id: global stats |
| `run_auto_mapping` | admin+tenant_id: tenant-scoped | admin+tenant_id: global |
| `get_unmapped_accounts` | admin+tenant_id: tenant-filtered | admin+tenant_id: global |

### Tests

Added `TestAdminWithTenantIdNotScoped` test class with 9 test cases verifying that:
- `admin` with `tenant_id` can generate rules for cross-tenant users
- `platform_admin` with `tenant_id` can generate rules for cross-tenant users
- `admin` with `tenant_id` can get/create/update/delete rules for cross-tenant users
- `admin` with `tenant_id` can manually map accounts for cross-tenant users
- `admin` with `tenant_id` sees global stats (not tenant-filtered)
- `admin` with `tenant_id` sees all unmapped accounts (not tenant-filtered)

### Backward Compatibility

- `tenant_admin` behavior is unchanged (still tenant-scoped)
- `admin`/`platform_admin` without `tenant_id` behavior is unchanged (already had global access)
- Only the incorrect restriction on `admin`/`platform_admin` **with** `tenant_id` is removed
