### PR TITLE
fix(test): use label-based locators in dismiss_force_change_password_modal

### DIFF
--- a/tests/e2e/regression/test_helpers.py
+++ b/tests/e2e/regression/test_helpers.py
@@ -74,19 +74,11 @@ def dismiss_force_change_password_modal(page: Page, new_password: str = "Admin12
         # 没有弹窗，正常情况
         pass
     else:
-        # 弹窗内三个密码输入框通过 placeholder 定位
-        current_pw_input = page.locator(
-            'div[role="dialog"] input[placeholder="Enter current password"],'
-            'div[role="dialog"] input[placeholder="输入当前密码"]'
-        )
-        new_pw_input = page.locator(
-            'div[role="dialog"] input[placeholder="Enter new password"],'
-            'div[role="dialog"] input[placeholder="输入新密码"]'
-        )
-        confirm_pw_input = page.locator(
-            'div[role="dialog"] input[placeholder="Confirm password"],'
-            'div[role="dialog"] input[placeholder="确认密码"]'
-        )
+        # 弹窗内三个密码输入框通过 label 定位（更稳定，不依赖 placeholder 文本）
+        # Issue #2312: placeholder 文本可能因 i18n 变化，使用 label 更健壮
+        current_pw_input = page.get_by_label("Current Password", exact=False)
+        new_pw_input = page.get_by_label("New Password", exact=False)
+        confirm_pw_input = page.get_by_label("Confirm Password", exact=False)
 
         # 填写改密表单
         current_pw_input.fill(PASSWORD)


### PR DESCRIPTION
## 问题描述

Extended Tests (critical) 频繁失败，主要原因是 `dismiss_force_change_password_modal` 函数中的 placeholder 选择器无法匹配前端实际文本。

## 根因分析

**问题：** placeholder 文本大小写不匹配
- 前端 i18n placeholder：`'Confirm Password'`（大写 P）
- 测试选择器查找：`'Confirm password'`（小写 p）
- 导致 Playwright 等待 30s 后超时

## 修复方案

改用 **label-based selectors**（`get_by_label`）替代 placeholder-based selectors：
- 更稳定：不依赖 placeholder 文本的精确匹配
- 更健壮：不受 i18n 翻译变化影响
- 更清晰：语义上更接近用户交互方式

## 修改内容

**文件：** `tests/e2e/regression/test_helpers.py`

**修改前：**
```python
current_pw_input = page.locator('div[role="dialog"] input[placeholder="Enter current password"]...')
new_pw_input = page.locator('div[role="dialog"] input[placeholder="Enter new password"]...')
confirm_pw_input = page.locator('div[role="dialog"] input[placeholder="Confirm password"]...')
```

**修改后：**
```python
current_pw_input = page.get_by_label("Current Password", exact=False)
new_pw_input = page.get_by_label("New Password", exact=False)
confirm_pw_input = page.get_by_label("Confirm Password", exact=False)
```

## 验证

- [ ] Extended Tests (critical) 通过
- [ ] 本地测试通过

## 关联

- Issue: #2312
- 失败 Run: #30996011498