### PR TITLE
fix(autonomous): GitHub comments post as AI bot, not repo owner (#2339)

### DIFF
--- a/app/modules/workspace/autonomous/github_ops.py
+++ b/app/modules/workspace/autonomous/github_ops.py
@@ -423,7 +423,11 @@ class GitHubOps:
         return self._owner_repo
 
     def _run_gh(
-        self, args: list[str], check: bool = True, repo_scoped: bool = True
+        self,
+        args: list[str],
+        check: bool = True,
+        repo_scoped: bool = True,
+        api_only: bool = False,
     ) -> subprocess.CompletedProcess:
         """Run a gh CLI command with transient-network-error retry.
 
@@ -436,6 +440,16 @@ class GitHubOps:
                 do not — for those the caller passes ``repo_scoped=False`` so the
                 sudo path runs plain ``gh`` without repo context (they don't need
                 an existing-repo context anyway).
+            api_only: The command is a pure GitHub API call that carries
+                ``-R owner/repo`` and needs no local repo access (e.g.
+                ``issue``/``pr comment``). When True AND a bot token is configured
+                AND the command would otherwise sudo (cross-user), run ``gh`` as
+                the *service* user instead of ``sudo -u <owner>``. This lets
+                ``GH_TOKEN`` reach ``gh`` so the action is attributed to the
+                configured AI bot account; the sudo wrapper would otherwise strip
+                ``GH_TOKEN`` via sudo ``env_reset`` and the action would post as
+                the repo owner (issue #2339). Git ops and gh commands that need
+                local repo context ignore this flag and keep the sudo path.
         """
         self._verify_trusted_git_context()
         kwargs = self._build_subprocess_kwargs()
@@ -460,7 +474,20 @@ class GitHubOps:
         env["GIT_CONFIG_VALUE_0"] = os.path.realpath(self.repo_path)
         kwargs["env"] = env
         account = self.system_account
-        if self._needs_sudo():
+        needs_sudo = self._needs_sudo()
+        # Pure-API gh subcommands (issue/pr comment with -R owner/repo) need no
+        # local repo access, so when a bot token is configured and the command
+        # would otherwise sudo, run gh as the service user directly. This lets
+        # GH_TOKEN reach gh so the action is attributed to the configured AI bot
+        # account; the sudo -u owner wrapper would otherwise strip GH_TOKEN via
+        # sudo env_reset and the action would post as the repo owner (#2339).
+        # _get_env is cached (60s TTL) so this call is cheap and matches the env
+        # _build_subprocess_kwargs already built. Note: _resolve_owner_repo may
+        # still perform a one-time sudoed git read to populate owner/repo (a read
+        # the owner is entitled to, unchanged from today); only the gh API call
+        # itself drops the sudo wrapper.
+        api_as_service = bool(api_only) and needs_sudo and self._get_env() is not None
+        if needs_sudo and not api_as_service:
             # gh has no `-C <path>` flag (that is git-only), so under a sudo
             # wrapper — where we must drop cwd to avoid a Python permission
             # check as the service user (Issue #1421) — target the repo
@@ -477,11 +504,18 @@ class GitHubOps:
                 cmd += ["gh"] + args
             kwargs.pop("cwd", None)  # cwd under sudo triggers Permission denied (Issue #1421)
         else:
-            # Same-user (or no system_account): run gh directly with cwd so it
-            # infers owner/repo from the working directory as before.
-            owner_repo = (
-                self._resolve_owner_repo() if repo_scoped and self._trusted_git_dir else None
-            )
+            # Same-user (or no system_account), OR an api_only command running as
+            # the service user (#2339): run gh directly. Same-user keeps cwd on the
+            # repo so gh infers owner/repo from the working directory as before;
+            # the api_only path drops cwd because the service user may lack access
+            # to the owner's repo, and a pure-API call carries -R anyway.
+            if api_as_service:
+                kwargs.pop("cwd", None)
+                owner_repo = self._resolve_owner_repo() if repo_scoped else None
+            else:
+                owner_repo = (
+                    self._resolve_owner_repo() if repo_scoped and self._trusted_git_dir else None
+                )
             cmd = ["gh", "-R", owner_repo, *args] if owner_repo else ["gh", *args]
         last_error: GitHubOpsError | None = None
         for attempt in range(GIT_NETWORK_RETRY_COUNT):
@@ -761,7 +795,7 @@ class GitHubOps:
 
     def add_issue_comment(self, number: int, body: str) -> dict:
         """Add a comment to an issue."""
-        self._run_gh(["issue", "comment", str(number), "--body", body])
+        self._run_gh(["issue", "comment", str(number), "--body", body], api_only=True)
         logger.info("Added comment to issue #%s", number)
         return {"number": number}
 
@@ -1162,7 +1196,7 @@ class GitHubOps:
 
     def add_pr_comment(self, number: int, body: str) -> dict:
         """Add a comment to a PR."""
-        self._run_gh(["pr", "comment", str(number), "--body", body])
+        self._run_gh(["pr", "comment", str(number), "--body", body], api_only=True)
         logger.info("Added comment to PR #%s", number)
         return {"number": number, "body": body}
 

--- a/tests/issues/2339/test_gh_comment_bot_identity.py
+++ b/tests/issues/2339/test_gh_comment_bot_identity.py
@@ -1,0 +1,201 @@
+"""GitHub comments must post as the configured AI bot account, not the repo owner (#2339).
+
+On multi-user deployments the ``open-ace`` service runs as user ``openace`` but each
+workflow's repo lives under its owner's home (``system_account`` = owner). For pure
+API ``gh`` subcommands (``issue``/``pr comment`` with ``-R owner/repo``) the
+``sudo -u <owner>`` wrapper in ``_run_gh`` strips ``GH_TOKEN`` via sudo ``env_reset``
+(sudoers ``env_keep`` keeps ``GIT_AUTHOR_*`` but not ``GH_TOKEN``), so ``gh``
+authenticates as the owner and the comment is authored by the owner's personal
+account — not the bot. See issue #2339.
+
+Fix: comment posting runs as the *service* user with ``GH_TOKEN`` when a bot token is
+configured (no ``sudo -u owner``), since these are pure API calls that need no local
+repo access. Git ops and other ``gh`` commands keep the existing sudo path.
+
+These tests pin the ``_run_gh`` cmd/env actually handed to ``subprocess.run``. The
+behaviour change is observed as the *absence* of the ``sudo`` wrapper: when ``sudo``
+is gone, ``GH_TOKEN`` reaches ``gh`` for real (today it is in the env but stripped at
+the sudo boundary, invisible to the test). ``git`` ops and non-comment ``gh`` commands
+must keep ``sudo`` (regression guard).
+"""
+
+from unittest.mock import MagicMock, patch
+
+import app.modules.workspace.autonomous.github_ops as gh_mod
+from app.modules.workspace.autonomous.github_ops import GitHubOps
+
+BOT_ENV = {
+    "GH_TOKEN": "ghp-bot-token-2339",
+    "GIT_AUTHOR_NAME": "Open ACE AI",
+    "GIT_AUTHOR_EMAIL": "bot@open-ace.com",
+    "GIT_COMMITTER_NAME": "Open ACE AI",
+    "GIT_COMMITTER_EMAIL": "bot@open-ace.com",
+}
+
+
+def _make_gh(
+    *,
+    owner_repo: str = "open-ace/open-ace",
+    repo_host: str | None = None,
+    system_account: str = "repoowner",
+) -> GitHubOps:
+    """A GitHubOps wired for a cross-user workflow with owner/repo pre-resolved."""
+    gh = GitHubOps("/srv/owners/repo", system_account=system_account)
+    # Pre-resolve owner/repo so no _run_git remote read is needed (it is a separate
+    # sudo read unaffected by this fix; we isolate the comment-posting path here).
+    gh._owner_repo_resolved = True
+    gh._owner_repo = owner_repo
+    gh._repo_host = repo_host
+    return gh
+
+
+def _patch_run_capture() -> MagicMock:
+    """Patch subprocess.run inside github_ops, returning a completed-process mock."""
+    run = MagicMock(return_value=MagicMock(returncode=0, stdout="", stderr=""))
+    return run
+
+
+# ── comment posting: bot token + cross-user ⇒ runs as service user (no sudo) ──
+
+
+def test_issue_comment_runs_as_service_user_with_bot_token_cross_user():
+    """add_issue_comment under cross-user + bot token must NOT sudo to the owner;
+    gh runs as the service user so GH_TOKEN reaches it and the post is the bot."""
+    gh = _make_gh()
+    run = _patch_run_capture()
+    with (
+        patch.object(gh, "_needs_sudo", return_value=True),
+        patch.object(gh, "_verify_trusted_git_context"),
+        patch("app.utils.config.get_ai_github_env", return_value=BOT_ENV),
+        patch.object(gh_mod, "subprocess") as sub_mod,
+    ):
+        sub_mod.run = run
+        gh.add_issue_comment(42, "body")
+    cmd = run.call_args.args[0]
+    env = run.call_args.kwargs["env"]
+    assert cmd[0] == "gh", f"must not sudo (got {cmd[:3]})"
+    assert "sudo" not in cmd
+    assert "-R" in cmd and "open-ace/open-ace" in cmd
+    assert env["GH_TOKEN"] == "ghp-bot-token-2339"
+    assert env["HOME"], "gh needs HOME to manage state; must be preserved"
+    assert "cwd" not in run.call_args.kwargs or not run.call_args.kwargs.get("cwd")
+
+
+def test_pr_comment_runs_as_service_user_with_bot_token_cross_user():
+    gh = _make_gh()
+    run = _patch_run_capture()
+    with (
+        patch.object(gh, "_needs_sudo", return_value=True),
+        patch.object(gh, "_verify_trusted_git_context"),
+        patch("app.utils.config.get_ai_github_env", return_value=BOT_ENV),
+        patch.object(gh_mod, "subprocess") as sub_mod,
+    ):
+        sub_mod.run = run
+        gh.add_pr_comment(7, "body")
+    cmd = run.call_args.args[0]
+    assert cmd[0] == "gh"
+    assert "sudo" not in cmd
+    assert "-R" in cmd
+    assert run.call_args.kwargs["env"]["GH_TOKEN"] == "ghp-bot-token-2339"
+
+
+# ── regression guards: non-comment gh + git ops keep the sudo cross-user path ──
+
+
+def test_non_comment_gh_command_still_sudos_cross_user():
+    """A non-comment gh command (default api_only=False) under cross-user keeps the
+    sudo -u owner wrapper — the fix must not widen beyond comment posting."""
+    gh = _make_gh()
+    run = _patch_run_capture()
+    with (
+        patch.object(gh, "_needs_sudo", return_value=True),
+        patch.object(gh, "_verify_trusted_git_context"),
+        patch("app.utils.config.get_ai_github_env", return_value=BOT_ENV),
+        patch.object(gh_mod, "subprocess") as sub_mod,
+    ):
+        sub_mod.run = run
+        gh._run_gh(["pr", "view", "1", "--json", "number"])
+    cmd = run.call_args.args[0]
+    assert cmd[:3] == ["sudo", "-u", "repoowner"], f"non-comment must keep sudo (got {cmd[:4]})"
+    assert "gh" in cmd
+
+
+def test_comment_degrades_to_sudo_when_no_bot_token_cross_user():
+    """No bot token configured ⇒ comment posting degrades to today's behaviour
+    (sudo as owner, post as owner). The api-only path requires a token to run as
+    the service user; without one, openace has no gh auth and must sudo."""
+    gh = _make_gh()
+    run = _patch_run_capture()
+    with (
+        patch.object(gh, "_needs_sudo", return_value=True),
+        patch.object(gh, "_verify_trusted_git_context"),
+        patch("app.utils.config.get_ai_github_env", return_value=None),
+        patch.object(gh_mod, "subprocess") as sub_mod,
+    ):
+        sub_mod.run = run
+        gh.add_issue_comment(42, "body")
+    cmd = run.call_args.args[0]
+    assert cmd[:3] == ["sudo", "-u", "repoowner"]
+
+
+# ── same-user path: unchanged (service already runs as repo owner) ────────────
+
+
+def test_comment_same_user_runs_directly_with_bot_token():
+    """Same-user (_needs_sudo False): gh runs directly, GH_TOKEN honoured — both
+    before and after the fix (the bug only manifests in the cross-user sudo path)."""
+    gh = _make_gh()
+    run = _patch_run_capture()
+    with (
+        patch.object(gh, "_needs_sudo", return_value=False),
+        patch.object(gh, "_verify_trusted_git_context"),
+        patch("app.utils.config.get_ai_github_env", return_value=BOT_ENV),
+        patch.object(gh_mod, "subprocess") as sub_mod,
+    ):
+        sub_mod.run = run
+        gh.add_issue_comment(42, "body")
+    cmd = run.call_args.args[0]
+    assert cmd[0] == "gh"
+    assert "sudo" not in cmd
+    assert run.call_args.kwargs["env"]["GH_TOKEN"] == "ghp-bot-token-2339"
+
+
+# ── no local git access on the comment path once owner/repo is resolved ───────
+
+
+def test_api_only_path_does_not_run_git_when_owner_repo_cached():
+    """With owner/repo already resolved, a comment post must not touch local git
+    (no _run_git) — the API call carries -R and needs no repo file access."""
+    gh = _make_gh()
+    run = _patch_run_capture()
+    with (
+        patch.object(gh, "_needs_sudo", return_value=True),
+        patch.object(gh, "_verify_trusted_git_context"),
+        patch("app.utils.config.get_ai_github_env", return_value=BOT_ENV),
+        patch.object(gh, "_run_git") as run_git,
+        patch.object(gh_mod, "subprocess") as sub_mod,
+    ):
+        sub_mod.run = run
+        gh.add_pr_comment(7, "body")
+    assert run_git.assert_not_called() is None
+    assert run.call_args.args[0][0] == "gh"  # no sudo
+
+
+# ── GHES: host-prefixed -R is preserved on the service-user path ──────────────
+
+
+def test_api_only_ghes_host_passes_host_prefixed_repo():
+    """A GHES host (non-github.com) must still target the right server: -R HOST/owner/repo."""
+    gh = _make_gh(owner_repo="gh.example.com/open-ace/open-ace", repo_host="gh.example.com")
+    run = _patch_run_capture()
+    with (
+        patch.object(gh, "_needs_sudo", return_value=True),
+        patch.object(gh, "_verify_trusted_git_context"),
+        patch("app.utils.config.get_ai_github_env", return_value=BOT_ENV),
+        patch.object(gh_mod, "subprocess") as sub_mod,
+    ):
+        sub_mod.run = run
+        gh.add_issue_comment(42, "body")
+    cmd = run.call_args.args[0]
+    assert cmd[0] == "gh"
+    assert "-R" in cmd and "gh.example.com/open-ace/open-ace" in cmd


### PR DESCRIPTION
## Problem

Autonomous-workflow GitHub comments (and PR comments) are authored by the **workflow owner's personal account**, not the configured AI bot account `open-ace-bot`. On the multi-user prod deployment: workflow 215 (owner rhuang) → comments by `@richardhuang`; workflow 217 (owner dwu) → comments by `@blueberry521`. The configured `ai_github_token` authenticates as `open-ace-bot`, so the token is correct — it just never reaches `gh`. Details + prod verification in #2339.

## Root cause

`GitHubOps` injects the bot token as `GH_TOKEN` for `gh` calls. Comment posting goes through `_run_gh(["issue"|"pr","comment",...])`. On multi-user prod the service runs as `openace`, each workflow's repo lives under its owner's home (`system_account` = owner), so `_needs_sudo()` is True and `_run_gh` runs `sudo -u <owner> gh …`. **`sudo`'s `env_reset` strips `GH_TOKEN`** (sudoers `env_keep` keeps `GIT_AUTHOR_*`/`GIT_COMMITTER_*`/`PATH`/`OPENACE_PROXY_*` but **not** `GH_TOKEN`), so `gh` authenticates as the owner, not the bot. Prod-verified: `GH_TOKEN=<bot> sudo -u rhuang gh api user` → `richardhuang`.

## Fix

Pure-API `gh` subcommands (`issue`/`pr comment` with `-R owner/repo`) need **no local repo access** — they carry an explicit `-R` (resolved+cached on the instance) and hit the REST API. Such commands now run **as the service user (`openace`) directly** with `GH_TOKEN` when a bot token is configured, **without** the `sudo -u <owner>` wrapper. `git` ops and all other `gh` commands keep the existing sudo cross-user path unchanged.

- New `api_only` flag on `_run_gh`; `add_issue_comment`/`add_pr_comment` pass `api_only=True`.
- `api_as_service = api_only and needs_sudo and bot_token is configured`. When True: run `gh` as the service process, drop cwd (service user may lack owner-repo access; a pure-API call carries `-R` anyway), env carries `GH_TOKEN`.
- Degrades to today's owner-identity behaviour when no bot token is configured (openace has no gh auth → must sudo).

## Security (no lowering)

- The bot token stays in the `openace` service process env (where `get_ai_github_env` already places it) and **never crosses into an owner's environment**.
- We **remove** a `sudo` escalation for these calls — strictly less privilege.
- **No sudoers change.** The rejected alternative (`env_keep += GH_TOKEN`) would push the bot token through sudo into each owner's process env / `ps`/`/proc` visibility — that widens blast radius and is not taken.
- bandit: 0 findings.

## Scope (#1998 additive + gated)

Only `add_issue_comment`/`add_pr_comment` change; only when a bot token exists. `git` operations, PR creation, and all other `gh` subcommands keep their existing sudo/same-user semantics. The one residual sudo read (`_resolve_owner_repo` populating `owner/repo` from the local remote) is a read the owner is entitled to and is unchanged from today.

## Not covered (tracked separately)

PR **creation** (`gh pr create`) still posts as the owner — it reads local git (branch/base/commits) and needs a different fix (REST API `POST repos/.../pulls` as the service user). Tracked in #2340.

## Tests

`tests/issues/2339/test_gh_comment_bot_identity.py` (7 tests): comment+bot+cross-user ⇒ no `sudo` + `GH_TOKEN` reaches `gh` + `HOME` preserved (issue & pr); non-comment gh + cross-user ⇒ still `sudo` (regression guard); comment+no-bot ⇒ degrades to `sudo`; same-user ⇒ direct; cached owner/repo ⇒ no `_run_git`; GHES host ⇒ `-R HOST/owner/repo`. All green locally; verified the 3 unrelated failures in `tests/issues/716` + `786` pre-exist on `origin/main` (local-env: `core.hooksPath`/`fsmonitor` injection + local `ANTHROPIC_*` env leak).

Refs #2339. Follow-up #2340.