### PR TITLE
feat(autonomous): independent acceptance_verification phase — PR1 vertical slice (#2335)

### DIFF
--- a/app/modules/workspace/autonomous/acceptance_snapshot.py
+++ b/app/modules/workspace/autonomous/acceptance_snapshot.py
@@ -1,0 +1,139 @@
+"""Issue acceptance-snapshot parsing for the acceptance_verification phase (#2335).
+
+Pure module: markdown-section extraction + canonical hashing. No git/db deps.
+Convention sections: ## Scope, ## 验收标准 / ## Acceptance Criteria, ## 不在 Scope /
+## Non-Scope. When required sections are absent, source="missing" and the verifier
+performs LLM extraction (re-persisted with source="llm", confidence="low").
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass, field
+
+# Matches a markdown heading and captures its title.
+_SECTION_RE = re.compile(r"(?m)^(?:#{1,6})\s+(.*?)\s*$")
+_CLOSURE_CONSTRAINT_RE = re.compile(
+    r"禁止阶段性关闭|do not close (?:until|before)|no (?:premature|staged) close",
+    re.IGNORECASE,
+)
+# A path/glob token inside a list item: a backticked token, or a bare token that
+# looks like a path (contains '/', or a dot extension, or glob chars).
+_TOKEN_PATH_RE = re.compile(r"`?([A-Za-z0-9_./?*{}\[\]\-]+)`?")
+
+
+@dataclass
+class AcceptanceSnapshot:
+    """Parsed acceptance criteria for an issue.
+
+    Persisted + hashed for the acceptance_verification phase; see the module
+    docstring for the section convention.
+    """
+
+    required_paths: list[str] = field(default_factory=list)
+    checklist: list[str] = field(default_factory=list)
+    non_scope: list[str] = field(default_factory=list)
+    closure_constraints: bool = False
+    source: str = "missing"  # "convention" | "missing" | "llm"
+    confidence: str = "low"  # "high" (convention) | "low" (missing/llm)
+
+    def to_canonical(self) -> dict:
+        # The hash captures the acceptance *content* (paths/checklist/non-scope/
+        # constraints), not source/confidence — so an issue edit changes the hash
+        # and forces re-verification, while a same-content LLM re-extraction is stable.
+        return {
+            "required_paths": sorted(self.required_paths),
+            "checklist": sorted(self.checklist),
+            "non_scope": sorted(self.non_scope),
+            "closure_constraints": self.closure_constraints,
+        }
+
+
+def _split_sections(body: str) -> dict[str, str]:
+    """Return {lowercased_heading: body-until-next-heading}."""
+    matches = list(_SECTION_RE.finditer(body))
+    sections: dict[str, str] = {}
+    for i, m in enumerate(matches):
+        title = m.group(1).strip().lower()
+        start = m.end()
+        end = matches[i + 1].start() if i + 1 < len(matches) else len(body)
+        sections[title] = body[start:end]
+    return sections
+
+
+def _extract_paths(text: str) -> list[str]:
+    paths: list[str] = []
+    for line in text.splitlines():
+        line = line.strip()
+        if not line.startswith(("-", "*")):
+            continue
+        item = line.lstrip("-* ").strip()
+        # Take the first path-shaped token on the line (backticked preferred).
+        for tok in _TOKEN_PATH_RE.findall(item):
+            if "/" in tok or tok.startswith(".") or "*" in tok:
+                paths.append(tok.strip("`"))
+                break
+    seen: set[str] = set()
+    out: list[str] = []
+    for p in paths:
+        if p not in seen:
+            seen.add(p)
+            out.append(p)
+    return out
+
+
+def _extract_checklist(text: str) -> list[str]:
+    out: list[str] = []
+    for line in text.splitlines():
+        m = re.match(r"\s*[-*]\s+\[[ xX]\]\s+(.*)$", line)
+        if m:
+            out.append(m.group(1).strip())
+    return out
+
+
+def _extract_plain_list(text: str) -> list[str]:
+    out: list[str] = []
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith(("-", "*")):
+            out.append(line.lstrip("-* ").strip())
+    return out
+
+
+_SCOPE_TITLES = {"scope"}
+_CRITERIA_KEYWORDS = ("验收标准", "acceptance criteria", "acceptance", "验收")
+_NONSCOPE_KEYWORDS = ("不在 scope", "non-scope", "non scope", "out of scope")
+
+
+def parse_acceptance_snapshot(body: str) -> AcceptanceSnapshot:
+    sections = _split_sections(body or "")
+    snap = AcceptanceSnapshot()
+
+    scope_text = next((sections[t] for t in sections if t in _SCOPE_TITLES), None)
+    criteria_text = next(
+        (sections[t] for t in sections if any(k in t for k in _CRITERIA_KEYWORDS)), None
+    )
+    nonscope_text = next(
+        (sections[t] for t in sections if any(k in t for k in _NONSCOPE_KEYWORDS)), None
+    )
+
+    if scope_text is not None or criteria_text is not None:
+        snap.source = "convention"
+        snap.confidence = "high"
+
+    if scope_text is not None:
+        snap.required_paths = _extract_paths(scope_text)
+    if criteria_text is not None:
+        snap.checklist = _extract_checklist(criteria_text)
+    if nonscope_text is not None:
+        snap.non_scope = _extract_plain_list(nonscope_text)
+
+    snap.closure_constraints = bool(_CLOSURE_CONSTRAINT_RE.search(body or ""))
+    return snap
+
+
+def hash_snapshot(snap: AcceptanceSnapshot) -> str:
+    canonical = json.dumps(snap.to_canonical(), sort_keys=True, ensure_ascii=False)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()

--- a/app/modules/workspace/autonomous/acceptance_snapshot.py
+++ b/app/modules/workspace/autonomous/acceptance_snapshot.py
@@ -108,6 +108,8 @@ _NONSCOPE_KEYWORDS = ("不在 scope", "non-scope", "non scope", "out of scope")
 
 
 def parse_acceptance_snapshot(body: str) -> AcceptanceSnapshot:
+    if not isinstance(body, str):
+        body = ""
     sections = _split_sections(body or "")
     snap = AcceptanceSnapshot()
 

--- a/app/modules/workspace/autonomous/acceptance_verdicts.py
+++ b/app/modules/workspace/autonomous/acceptance_verdicts.py
@@ -1,0 +1,38 @@
+"""Per-item acceptance verdicts + issue-level aggregation (#2335). Pure."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from app.modules.workspace.autonomous.evidence import Verdict
+
+# The issue-level status string written to verification_status.
+STATUS_CONFIRMED = "confirmed"
+STATUS_REJECTED = "rejected"
+STATUS_INDETERMINATE = "indeterminate"
+
+
+@dataclass
+class ItemVerdict:
+    """One acceptance item's verdict, with concrete evidence refs."""
+
+    item: str  # checklist text or required path
+    verdict: Verdict  # CONFIRMED / REJECTED / INDETERMINATE
+    evidence: list[dict] = field(
+        default_factory=list
+    )  # [{"ref": "file:line|git-diff", "note": "..."}]
+    rationale: str = ""
+
+
+def aggregate_verdicts(items: list[ItemVerdict]) -> str:
+    """Any REJECTED -> rejected; else any INDETERMINATE -> indeterminate; else confirmed.
+
+    An empty item list is indeterminate (nothing was affirmatively confirmed).
+    """
+    if any(iv.verdict is Verdict.REJECTED for iv in items):
+        return STATUS_REJECTED
+    if any(iv.verdict is Verdict.INDETERMINATE for iv in items):
+        return STATUS_INDETERMINATE
+    if items and all(iv.verdict is Verdict.CONFIRMED for iv in items):
+        return STATUS_CONFIRMED
+    return STATUS_INDETERMINATE

--- a/app/modules/workspace/autonomous/constants.py
+++ b/app/modules/workspace/autonomous/constants.py
@@ -59,6 +59,18 @@ REVIEW_ALLOWED_TOOLS: dict[str, list[str]] = {
     "zcode": [],
 }
 
+# Acceptance-verification tools (#2335): read-only review set + Bash for the
+# scope gate's git diff/log on merged main. No Write/Edit — the verifier must not
+# mutate the acceptance target; it runs against a throwaway checkout of main and
+# reads git state, not the working tree.
+VERIFICATION_ALLOWED_TOOLS: dict[str, list[str]] = {
+    "claude-code": REVIEW_ALLOWED_TOOLS["claude-code"] + ["Bash"],
+    "qwen-code-cli": REVIEW_ALLOWED_TOOLS["qwen-code-cli"] + ["run_shell_command"],
+    "codex": [],
+    "openclaw": [],
+    "zcode": [],
+}
+
 # OpenClaw's current single-shot adapter does not accept per-run permission or
 # tool-policy arguments.  Treating an empty allowlist as read-only would be a
 # false security boundary, so autonomous review must fail closed for this tool

--- a/app/modules/workspace/autonomous/github_ops.py
+++ b/app/modules/workspace/autonomous/github_ops.py
@@ -799,6 +799,27 @@ class GitHubOps:
         logger.info("Added comment to issue #%s", number)
         return {"number": number}
 
+    def close_issue(self, number: int) -> dict:
+        """Close an issue.
+
+        Runs as the service user (api_only) so the action attributes to the
+        configured AI bot account, not the repo owner (#2339/#2335). The workflow
+        closes explicitly only on acceptance confirmed.
+        """
+        self._run_gh(["issue", "close", str(number)], api_only=True)
+        logger.info("Closed issue #%s", number)
+        return {"number": number}
+
+    def reopen_issue(self, number: int) -> dict:
+        """Reopen an issue (api_only → service-user/bot identity).
+
+        Used by the acceptance_verification reopen guard when an issue was closed
+        out-of-band before confirmation (#2335).
+        """
+        self._run_gh(["issue", "reopen", str(number)], api_only=True)
+        logger.info("Reopened issue #%s", number)
+        return {"number": number}
+
     def list_issue_comments(self, number: int, since: str | None = None) -> list:
         """List comments on an issue, optionally since a timestamp."""
         args = ["issue", "view", str(number), "--comments", "--json", "comments"]
@@ -1199,6 +1220,19 @@ class GitHubOps:
         self._run_gh(["pr", "comment", str(number), "--body", body], api_only=True)
         logger.info("Added comment to PR #%s", number)
         return {"number": number, "body": body}
+
+    def get_merge_commit_sha(self, pr_number: int) -> str | None:
+        """Return the merge commit SHA of a merged PR, or None if unmerged/unknown.
+
+        Used by acceptance_verification to pin the exact main SHA the verifier
+        runs against (#2335).
+        """
+        result = self._run_gh(
+            ["pr", "view", str(pr_number), "--json", "mergeCommit", "--jq", ".mergeCommit.oid"],
+            check=False,
+        )
+        out = (result.stdout or "").strip()
+        return out or None
 
     def _gh_api_args(self, extra: list[str]) -> list[str]:
         """Build a ``gh api`` arg list with GHES hostname handling.

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -574,16 +574,27 @@ REVIEW_FEEDBACK_MIN_LENGTH = 50
 REVIEW_SUGGESTIONS_MIN_LENGTH = 200
 
 # Phase ordering — used by fork to determine the next phase after the fork point.
-PHASE_ORDER = ["preparation", "planning", "development", "pr_review", "report", "merge"]
+PHASE_ORDER = [
+    "preparation",
+    "planning",
+    "development",
+    "pr_review",
+    "report",
+    "merge",
+    "acceptance_verification",  # #2335: independent post-merge verification
+]
 
 # The only legitimate current_phase values a PhaseResult(completed) may carry in
-# workflow_patch when next_phase="completed" (the terminal pseudo-phase). "merge"
-# is the default terminal real phase (a completed workflow's current_phase stays
-# "merge"); "completed" is pr_review's literal-terminal legacy path (it skips
-# report/merge and writes the literal "completed"). Any other patch-carried
-# current_phase would strand the workflow in a non-canonical phase — rejected by
-# _commit_phase_result to mirror the top-level next_phase validation. (#2044 S2)
-_COMPLETED_TERMINAL_PHASES = ("merge", "completed")
+# workflow_patch when next_phase="completed" (the terminal pseudo-phase).
+# "acceptance_verification" is the default terminal real phase for the normal
+# flow (merge -> acceptance_verification; on confirmed it returns
+# next_phase="completed", resting current_phase at "acceptance_verification");
+# "merge" covers pr_review's literal-terminal legacy path (skips report/merge and
+# writes the literal "completed"); "completed" is the literal pseudo-phase value.
+# Any other patch-carried current_phase would strand the workflow in a
+# non-canonical phase — rejected by _commit_phase_result to mirror the top-level
+# next_phase validation. (#2044 S2, #2335)
+_COMPLETED_TERMINAL_PHASES = ("acceptance_verification", "merge", "completed")
 
 # Maps phases to their corresponding workflow status values
 PHASE_STATUS_MAP = {
@@ -593,6 +604,7 @@ PHASE_STATUS_MAP = {
     "pr_review": "pr_review",
     "report": "reporting",
     "merge": "merging",
+    "acceptance_verification": "verification_pending",  # #2335
 }
 
 # CI check polling configuration.

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -950,14 +950,19 @@ NO_EXCERPT_SENTINEL = "<no-excerpt>"
 
 
 def _next_phase(current_phase: str) -> str:
-    """Return the phase that follows current_phase."""
+    """Return the phase that follows current_phase.
+
+    The last phase in ``PHASE_ORDER`` is terminal — ``_next_phase`` returns it
+    unchanged so a caller asking "what's after the last phase?" idempotently
+    stays put (the handler still drives the real transition via ``PhaseResult``).
+    """
     try:
         idx = PHASE_ORDER.index(current_phase)
     except ValueError:
         return "planning"
     if idx + 1 < len(PHASE_ORDER):
         return PHASE_ORDER[idx + 1]
-    return "merge"
+    return current_phase
 
 
 class AutonomousOrchestrator:

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -59,6 +59,7 @@ from app.modules.workspace.autonomous.constants import (  # noqa: F401
     MERGE_POLICY_PAUSE_REASON_PREFIX,
     READ_ONLY_REVIEW_UNSUPPORTED_TOOLS,
     REVIEW_ALLOWED_TOOLS,
+    VERIFICATION_ALLOWED_TOOLS,
     _extract_pr_number_from_error,
     _is_transient_git_error,
     _merge_milestone_metadata,
@@ -606,6 +607,12 @@ PHASE_STATUS_MAP = {
     "merge": "merging",
     "acceptance_verification": "verification_pending",  # #2335
 }
+
+# Cap on acceptance-rejection-driven development rounds (#2335). A rejected
+# acceptance verdict starts a new dev round carrying the rejection as feedback;
+# after this many rounds a persistent rejection fails the workflow rather than
+# looping forever.
+MAX_ACCEPTANCE_DEV_ROUNDS = 3
 
 # CI check polling configuration.
 # After a PR is created or code is pushed, CI checks may still be pending.
@@ -5835,6 +5842,123 @@ class AutonomousOrchestrator:
 
     def validate_autonomous_change_scope(self, gh, wf, base_sha, head_sha) -> str:
         return self._validate_autonomous_change_scope(gh, wf, base_sha, head_sha)
+
+    # --- PhaseHost acceptance_verification-phase helpers (#2335 PR1) ---
+    # Thin public aliases over orchestrator-private impls so the
+    # acceptance_verification handler can call them via ``deps.host.<name>``
+    # without a concrete orchestrator reference. Same pattern as above.
+    def run_verification_agent(
+        self, *, snapshot, merge_sha, base_sha, issue_number, pr_number
+    ) -> dict:
+        return self._run_verification_agent(
+            snapshot=snapshot,
+            merge_sha=merge_sha,
+            base_sha=base_sha,
+            issue_number=issue_number,
+            pr_number=pr_number,
+        )
+
+    def dev_round_cap_remaining(self, wf: dict) -> int:
+        return self._dev_round_cap_remaining(wf)
+
+    def issue_is_open(self, issue_number: int) -> bool:
+        return self._issue_is_open(issue_number)
+
+    def emit_audit_event(self, name: str, payload: dict) -> None:
+        # Audit events ride the generic orchestrator emitter as a distinct type
+        # so they show up in workflow_events without colliding with phase/status.
+        self._emit(name, payload)
+
+    def _dev_round_cap_remaining(self, wf: dict) -> int:
+        # Bound the rejected -> development loop so a persistently-rejected issue
+        # eventually fails instead of looping forever. Slices may raise this.
+        used = int(wf.get("dev_round") or 0)
+        return max(0, MAX_ACCEPTANCE_DEV_ROUNDS - used)
+
+    def _issue_is_open(self, issue_number: int) -> bool:
+        try:
+            gh = self._get_gh()
+            if gh is None:
+                return True
+            res = gh.get_issue(int(issue_number))
+            return (res or {}).get("state", "open") == "open"
+        except Exception:
+            # Fail open: if we can't tell, don't spuriously reopen.
+            return True
+
+    def _run_verification_agent(
+        self, *, snapshot, merge_sha, base_sha, issue_number, pr_number
+    ) -> dict:
+        """Spawn the independent acceptance verifier (#2335).
+
+        Credentialless isolated agent (session_line="verification") with
+        VERIFICATION_ALLOWED_TOOLS (read-only + Bash). It reads the merged code
+        + the acceptance snapshot/checklist and emits a JSON verdict block. On
+        any spawn/parse failure it returns empty verdicts, which aggregate to
+        ``indeterminate`` (pause) — never a false ``confirmed``.
+        """
+        wf = self.workflow or {}
+        cli_tool = wf.get("cli_tool", "claude-code")
+        prompt = self._build_verification_prompt(snapshot, merge_sha, base_sha, issue_number)
+        try:
+            result = self._run_agent(
+                wf,
+                session_line="verification",
+                prompt=prompt,
+                allowed_tools=VERIFICATION_ALLOWED_TOOLS.get(cli_tool, []),
+                permission_mode="bypassPermissions",
+            )
+        except Exception:
+            logger.exception("acceptance verifier spawn failed for issue %s", issue_number)
+            return {"verdicts": [], "snapshot": None}
+        return self._parse_verifier_output(result)
+
+    def _build_verification_prompt(self, snapshot, merge_sha, base_sha, issue_number) -> str:
+        import json as _json
+
+        snap_dump = _json.dumps(snapshot.to_canonical(), ensure_ascii=False, indent=2)
+        return (
+            "You are an INDEPENDENT acceptance verifier. The issue must NOT be considered done "
+            "just because a PR merged. Verify the MERGED code (merge commit "
+            f"{merge_sha}, base {base_sha}) against this acceptance snapshot.\n\n"
+            f"Acceptance snapshot:\n{snap_dump}\n\n"
+            "For each required_paths entry, confirm it was actually changed (use git diff/log). "
+            "For each checklist item, determine confirmed/rejected/indeterminate against the merged "
+            "code with a concrete file:line or git-diff evidence ref. Be CONSERVATIVE: if you cannot "
+            "find concrete evidence, return indeterminate, not confirmed.\n\n"
+            "Reply with ONLY a fenced JSON block:\n"
+            "```json\n"
+            '{"verdicts": [{"item": "...", "verdict": "confirmed|rejected|indeterminate", '
+            '"evidence": [{"ref": "file:line|git-diff", "note": "..."}], "rationale": "..."}], '
+            '"snapshot": null}\n'
+            "```\n"
+            '(set "snapshot" to the completed {required_paths, checklist, non_scope, '
+            "closure_constraints} only if you had to extract them yourself because the input "
+            "snapshot was empty; otherwise null)"
+        )
+
+    def _parse_verifier_output(self, result) -> dict:
+        import json as _json
+        import re as _re
+
+        text = self._artifact_text(result) if result is not None else ""
+        if not text:
+            return {"verdicts": [], "snapshot": None}
+        # Grab the last fenced ```json ... ``` block (the agent may preface reasoning).
+        blocks = _re.findall(r"```(?:json)?\s*(\{.*?\})\s*```", text, _re.DOTALL)
+        candidate = blocks[-1] if blocks else text
+        try:
+            parsed = _json.loads(candidate)
+        except Exception:
+            logger.warning(
+                "acceptance verifier output was not valid JSON; treating as indeterminate"
+            )
+            return {"verdicts": [], "snapshot": None}
+        if not isinstance(parsed, dict):
+            return {"verdicts": [], "snapshot": None}
+        parsed.setdefault("verdicts", [])
+        parsed.setdefault("snapshot", None)
+        return parsed
 
     def apply_pr_review_fix(
         self, wf, gh, review_text, round_num, dev_round, ci_failures, pr_number

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -802,6 +802,7 @@ SESSION_LINE_FIELDS = {
     "main": "main_session_id",
     "review": "review_session_id",
     "test": "test_session_id",
+    "verification": "verification_session_id",  # #2335 acceptance verifier
 }
 
 # Agent intro/closing text patterns for _clean_agent_text().

--- a/app/modules/workspace/autonomous/phase_host.py
+++ b/app/modules/workspace/autonomous/phase_host.py
@@ -72,6 +72,38 @@ class PhaseHost(Protocol):
         correlation/lookup case.
         """
 
+    # ── acceptance_verification-phase helpers (#2335 PR1) ──────────────────
+    # Same duck-typed-alias pattern: the orchestrator satisfies these as bound
+    # methods so the acceptance_verification handler can call them via
+    # ``deps.host.<name>`` without a concrete orchestrator reference.
+
+    def run_verification_agent(
+        self, *, snapshot, merge_sha, base_sha, issue_number, pr_number
+    ) -> dict:
+        """Spawn the independent credentialless verifier on merged main.
+
+        Returns ``{"verdicts": [...], "snapshot": <completed snapshot or None>}``.
+        Empty/failed spawns return empty verdicts, which aggregate to
+        ``indeterminate`` (pause) — never a false ``confirmed``.
+        """
+
+    def dev_round_cap_remaining(self, wf: dict) -> int:
+        """Remaining acceptance-rejection-driven dev rounds.
+
+        After this many, a persistent rejection must fail the workflow rather
+        than loop (#2335).
+        """
+
+    def issue_is_open(self, issue_number: int) -> bool:
+        """Whether the GitHub issue is currently open.
+
+        Fails open (True) when the state can't be determined, so the reopen
+        guard doesn't spuriously fire.
+        """
+
+    def emit_audit_event(self, name: str, payload: dict) -> None:
+        """Emit a generic audit event (e.g. acceptance_reopened_issue)."""
+
     # ── Merge-phase helpers (#2044 Phase B T10) ──────────────────────────
     # These are orchestrator-private methods (each tens-to-hundreds of lines,
     # with their own transitive ``self._`` calls) that the merge handler needs

--- a/app/modules/workspace/autonomous/phases/__init__.py
+++ b/app/modules/workspace/autonomous/phases/__init__.py
@@ -29,6 +29,9 @@ def resolve_phase_handler(name: str) -> Callable[..., PhaseResult | None] | None
 # Register the migrated handlers. Importing the module has the side effect of
 # registration; the import is local so a malformed module surfaces at first use
 # rather than at package import time of unrelated phases.
+from app.modules.workspace.autonomous.phases import (  # noqa: E402
+    acceptance_verification as _acceptance,
+)
 from app.modules.workspace.autonomous.phases import development as _development  # noqa: E402
 from app.modules.workspace.autonomous.phases import merge as _merge  # noqa: E402
 from app.modules.workspace.autonomous.phases import pr_review as _pr_review  # noqa: E402
@@ -36,3 +39,4 @@ from app.modules.workspace.autonomous.phases import pr_review as _pr_review  # n
 register_phase_handler("development", _development.handle)
 register_phase_handler("merge", _merge.handle)
 register_phase_handler("pr_review", _pr_review.handle)
+register_phase_handler("acceptance_verification", _acceptance.handle)

--- a/app/modules/workspace/autonomous/phases/acceptance_verification.py
+++ b/app/modules/workspace/autonomous/phases/acceptance_verification.py
@@ -12,13 +12,16 @@ Transitions:
                     or failed if the dev-round cap is exhausted
   indeterminate  -> paused (issue open; human provides missing evidence)
 
-Idempotent on (verification_merge_sha, issue_acceptance_hash): a re-entry that
-already reached ``confirmed`` for the same pair is a terminal no-op (no
-re-close, no re-comment).
+Idempotent on the confirmed result: a re-entry whose ``verification_status`` is
+already ``confirmed`` is a terminal no-op (no re-close, no re-comment). A new
+merge SHA or an edited issue (new ``issue_acceptance_hash``) re-runs the
+verifier naturally because the phase re-enters; full (merge_sha, hash) dedup
+of in-flight attempts is S5 polish.
 """
 
 from __future__ import annotations
 
+import dataclasses
 import fnmatch
 import json
 import time
@@ -37,6 +40,11 @@ VERIFIED_BY = "acceptance-verifier-v1"
 
 def _now_iso() -> str:
     return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+def _snapshot_to_json(snapshot: AcceptanceSnapshot) -> str:
+    """Full snapshot (incl. source/confidence) for round-trip persistence."""
+    return json.dumps(dataclasses.asdict(snapshot), ensure_ascii=False)
 
 
 def _glob_matches(pattern: str, paths: list[str]) -> str | None:
@@ -216,9 +224,12 @@ def handle(ctx, deps) -> PhaseResult:
     common_patch = {
         "verification_status": status,
         "verification_merge_sha": merge_sha,
+        "verification_started_at": wf.get("verification_started_at") or _now_iso(),
         "verification_completed_at": _now_iso(),
         "verification_report": json.dumps(report, ensure_ascii=False),
-        "issue_acceptance_snapshot": json.dumps(snapshot.to_canonical(), ensure_ascii=False),
+        # Persist the FULL snapshot (incl. source/confidence) so a reload
+        # round-trips; only the hash is canonicalized to content-only (#2335).
+        "issue_acceptance_snapshot": _snapshot_to_json(snapshot),
         "issue_acceptance_hash": snap_hash,
         "verified_by": VERIFIED_BY,
         "verification_attempt": (wf.get("verification_attempt") or 0) + 1,

--- a/app/modules/workspace/autonomous/phases/acceptance_verification.py
+++ b/app/modules/workspace/autonomous/phases/acceptance_verification.py
@@ -1,0 +1,23 @@
+"""acceptance_verification phase handler (#2335).
+
+Independent post-merge verification: the workflow does NOT auto-close the issue
+on merge. Instead this phase spawns a credentialless read-only verifier on the
+merged main SHA, runs a deterministic scope gate, aggregates per-item verdicts,
+and only closes the issue (as @open-ace-bot) on ``confirmed``.
+
+Task 8 wires the phase into the machine + registers this stub. Task 9 adds the
+deterministic scope gate. Task 10 fills in ``handle`` (verifier spawn, snapshot
+persistence, aggregation, transitions, idempotency, reopen guard, close-on-confirm).
+"""
+
+from __future__ import annotations
+
+from app.modules.workspace.autonomous.phase_contract import PhaseResult
+
+
+def handle(ctx, deps) -> PhaseResult:  # pragma: no cover  (replaced in Task 10)
+    """Stub: pause safely until the full handler lands (Task 10)."""
+    return PhaseResult.pause(
+        workflow_patch={"error_message": "acceptance_verification pending implementation (#2335)"},
+        structured_error={"message": "acceptance_verification not yet implemented"},
+    )

--- a/app/modules/workspace/autonomous/phases/acceptance_verification.py
+++ b/app/modules/workspace/autonomous/phases/acceptance_verification.py
@@ -1,22 +1,42 @@
 """acceptance_verification phase handler (#2335).
 
 Independent post-merge verification: the workflow does NOT auto-close the issue
-on merge. Instead this phase spawns a credentialless read-only verifier on the
-merged main SHA, runs a deterministic scope gate, aggregates per-item verdicts,
-and only closes the issue (as @open-ace-bot) on ``confirmed``.
+on merge (autonomous PRs use ``Implements #N``, not ``Closes #N``). Instead this
+phase spawns a credentialless read-only verifier on the merged main SHA, runs a
+deterministic scope gate, aggregates per-item verdicts, and only closes the
+issue (as @open-ace-bot) on ``confirmed``.
 
-Task 8 wired the phase into the machine. Task 9 adds the deterministic scope
-gate. Task 10 fills in ``handle`` (verifier spawn, snapshot persistence,
-aggregation, transitions, idempotency, reopen guard, close-on-confirm).
+Transitions:
+  confirmed      -> close issue + acceptance report -> completed
+  rejected       -> new development round (rejection report as feedback),
+                    or failed if the dev-round cap is exhausted
+  indeterminate  -> paused (issue open; human provides missing evidence)
+
+Idempotent on (verification_merge_sha, issue_acceptance_hash): a re-entry that
+already reached ``confirmed`` for the same pair is a terminal no-op (no
+re-close, no re-comment).
 """
 
 from __future__ import annotations
 
 import fnmatch
+import json
+import time
 
-from app.modules.workspace.autonomous.acceptance_verdicts import ItemVerdict
+from app.modules.workspace.autonomous.acceptance_snapshot import (
+    AcceptanceSnapshot,
+    hash_snapshot,
+    parse_acceptance_snapshot,
+)
+from app.modules.workspace.autonomous.acceptance_verdicts import ItemVerdict, aggregate_verdicts
 from app.modules.workspace.autonomous.evidence import Verdict
 from app.modules.workspace.autonomous.phase_contract import PhaseResult
+
+VERIFIED_BY = "acceptance-verifier-v1"
+
+
+def _now_iso() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
 
 
 def _glob_matches(pattern: str, paths: list[str]) -> str | None:
@@ -64,9 +84,184 @@ def run_scope_gate(
     return verdicts
 
 
-def handle(ctx, deps) -> PhaseResult:  # pragma: no cover  (replaced in Task 10)
-    """Stub: pause safely until the full handler lands (Task 10)."""
+def _verdict_from_str(s: str) -> Verdict:
+    s = (s or "").lower()
+    if s == "confirmed":
+        return Verdict.CONFIRMED
+    if s == "rejected":
+        return Verdict.REJECTED
+    return Verdict.INDETERMINATE
+
+
+def _parse_issue_body(gh, issue_number) -> str:
+    """Fetch the issue body via gh (best-effort; '' on failure/non-dict)."""
+    if not issue_number:
+        return ""
+    try:
+        res = gh.get_issue(int(issue_number))
+    except Exception:
+        return ""
+    if not isinstance(res, dict):
+        return ""
+    body = res.get("body")
+    return body if isinstance(body, str) else ""
+
+
+def _format_report_comment(report: dict) -> str:
+    lines = [
+        "## ✅ Acceptance verified",
+        f"**Merge SHA:** `{report.get('merge_sha')}`",
+        f"**Verifier:** `{report.get('verified_by')}`",
+        "",
+        "**Scope gate:**",
+    ]
+    for s in report.get("scope", []):
+        lines.append(f"- `{s['item']}` — {s['verdict']}")
+    if report.get("verifier"):
+        lines += ["", "**Verifier findings:**"]
+        for v in report["verifier"]:
+            lines.append(f"- {v['verdict']} — {v['item']}")
+    return "\n".join(lines)
+
+
+def handle(ctx, deps) -> PhaseResult:
+    wf = ctx.workflow
+    issue_number = wf.get("github_issue_number")
+    pr_number = wf.get("github_pr_number")
+    base_sha = wf.get("base_commit_sha") or ""
+    gh = deps.gh
+
+    # Idempotency: already confirmed -> terminal no-op (no re-close, no re-verify).
+    if wf.get("verification_status") == "confirmed":
+        return PhaseResult.completed(next_phase="completed")
+
+    # Resolve the merge commit SHA on main (cache it on the workflow).
+    merge_sha = wf.get("verification_merge_sha")
+    if not merge_sha and pr_number:
+        merge_sha = gh.get_merge_commit_sha(pr_number)
+    if not merge_sha or not base_sha:
+        # Cannot verify yet (PR not merged / base unknown) — retry next cycle.
+        return PhaseResult.retry()
+
+    # Reopen guard: if the issue was closed out-of-band before confirmation, reopen.
+    if issue_number and not deps.host.issue_is_open(issue_number):
+        gh.reopen_issue(issue_number)
+        deps.host.emit_audit_event("acceptance_reopened_issue", {"issue": issue_number})
+
+    # Build the acceptance snapshot (persisted; hash drives re-verification).
+    snapshot = None
+    if wf.get("issue_acceptance_snapshot"):
+        try:
+            snapshot = AcceptanceSnapshot(**json.loads(wf["issue_acceptance_snapshot"]))
+        except Exception:
+            snapshot = None
+    if snapshot is None:
+        snapshot = parse_acceptance_snapshot(_parse_issue_body(gh, issue_number))
+    snap_hash = hash_snapshot(snapshot)
+
+    # Spawn the independent verifier on merged main. If the snapshot was missing
+    # convention sections, the verifier extracts scope/checklist (LLM) and returns
+    # the completed snapshot; persist it so later rounds reuse it.
+    agent_out = (
+        deps.host.run_verification_agent(
+            snapshot=snapshot,
+            merge_sha=merge_sha,
+            base_sha=base_sha,
+            issue_number=issue_number,
+            pr_number=pr_number,
+        )
+        or {}
+    )
+    verifier_verdicts = [
+        ItemVerdict(
+            item=v.get("item", ""),
+            verdict=_verdict_from_str(v.get("verdict")),
+            evidence=v.get("evidence") or [],
+            rationale=v.get("rationale", ""),
+        )
+        for v in (agent_out.get("verdicts") or [])
+    ]
+    if agent_out.get("snapshot"):
+        try:
+            snapshot = AcceptanceSnapshot(**agent_out["snapshot"])
+            snap_hash = hash_snapshot(snapshot)
+        except Exception:
+            pass
+
+    # Mechanical scope gate (deterministic): required paths must be in the diff.
+    scope_verdicts = run_scope_gate(gh, snapshot.required_paths, base_sha, merge_sha)
+
+    status = aggregate_verdicts(scope_verdicts + verifier_verdicts)
+    report = {
+        "merge_sha": merge_sha,
+        "issue_acceptance_hash": snap_hash,
+        "verified_by": VERIFIED_BY,
+        "scope": [
+            {"item": v.item, "verdict": v.verdict.value, "evidence": v.evidence}
+            for v in scope_verdicts
+        ],
+        "verifier": [
+            {
+                "item": v.item,
+                "verdict": v.verdict.value,
+                "evidence": v.evidence,
+                "rationale": v.rationale,
+            }
+            for v in verifier_verdicts
+        ],
+        "status": status,
+        "verified_at": _now_iso(),
+    }
+
+    common_patch = {
+        "verification_status": status,
+        "verification_merge_sha": merge_sha,
+        "verification_completed_at": _now_iso(),
+        "verification_report": json.dumps(report, ensure_ascii=False),
+        "issue_acceptance_snapshot": json.dumps(snapshot.to_canonical(), ensure_ascii=False),
+        "issue_acceptance_hash": snap_hash,
+        "verified_by": VERIFIED_BY,
+        "verification_attempt": (wf.get("verification_attempt") or 0) + 1,
+    }
+    milestone = {
+        "workflow_id": wf.get("workflow_id"),
+        "phase": "acceptance_verification",
+        "milestone_type": "acceptance_verification",
+        "status": status,
+        "title": f"Acceptance verification: {status}",
+        "result_summary": report,
+        "metadata": report,
+    }
+
+    if status == "confirmed":
+        gh.add_issue_comment(issue_number, _format_report_comment(report))
+        gh.close_issue(issue_number)
+        common_patch["issue_closed_by_workflow_at"] = _now_iso()
+        return PhaseResult.completed(
+            next_phase="completed",
+            workflow_patch={**common_patch, "completed_at": _now_iso()},
+            milestone_events=[milestone],
+        )
+    if status == "rejected":
+        if deps.host.dev_round_cap_remaining(wf) > 0:
+            return PhaseResult.completed(
+                next_phase="development",
+                workflow_patch={
+                    **common_patch,
+                    "dev_round": (wf.get("dev_round") or 1) + 1,
+                    "error_message": "Acceptance verification rejected: see report",
+                },
+                milestone_events=[milestone],
+            )
+        return PhaseResult.failed(
+            structured_error={"message": "Acceptance rejected and dev rounds exhausted"},
+            workflow_patch=common_patch,
+        )
+    # indeterminate
     return PhaseResult.pause(
-        workflow_patch={"error_message": "acceptance_verification pending implementation (#2335)"},
-        structured_error={"message": "acceptance_verification not yet implemented"},
+        workflow_patch={
+            **common_patch,
+            "error_message": "Acceptance indeterminate: awaiting evidence",
+        },
+        structured_error={"message": "indeterminate", "report": report},
     )

--- a/app/modules/workspace/autonomous/phases/acceptance_verification.py
+++ b/app/modules/workspace/autonomous/phases/acceptance_verification.py
@@ -5,14 +5,63 @@ on merge. Instead this phase spawns a credentialless read-only verifier on the
 merged main SHA, runs a deterministic scope gate, aggregates per-item verdicts,
 and only closes the issue (as @open-ace-bot) on ``confirmed``.
 
-Task 8 wires the phase into the machine + registers this stub. Task 9 adds the
-deterministic scope gate. Task 10 fills in ``handle`` (verifier spawn, snapshot
-persistence, aggregation, transitions, idempotency, reopen guard, close-on-confirm).
+Task 8 wired the phase into the machine. Task 9 adds the deterministic scope
+gate. Task 10 fills in ``handle`` (verifier spawn, snapshot persistence,
+aggregation, transitions, idempotency, reopen guard, close-on-confirm).
 """
 
 from __future__ import annotations
 
+import fnmatch
+
+from app.modules.workspace.autonomous.acceptance_verdicts import ItemVerdict
+from app.modules.workspace.autonomous.evidence import Verdict
 from app.modules.workspace.autonomous.phase_contract import PhaseResult
+
+
+def _glob_matches(pattern: str, paths: list[str]) -> str | None:
+    """Return the first changed path matching the pattern (glob), else None."""
+    for p in paths:
+        if fnmatch.fnmatch(p, pattern) or p == pattern:
+            return p
+    return None
+
+
+def run_scope_gate(
+    gh, required_paths: list[str], base_sha: str, merge_sha: str
+) -> list[ItemVerdict]:
+    """Deterministic scope gate: each required path must appear in base..merge diff.
+
+    Returns one ``ItemVerdict`` per required path: CONFIRMED if a changed path
+    matches (glob), REJECTED with the missing path as evidence otherwise.
+    """
+    changed = gh.get_changed_files(base=base_sha, head=merge_sha) or []
+    verdicts: list[ItemVerdict] = []
+    for path in required_paths:
+        hit = _glob_matches(path, changed)
+        if hit is not None:
+            verdicts.append(
+                ItemVerdict(
+                    item=path,
+                    verdict=Verdict.CONFIRMED,
+                    evidence=[{"ref": f"git-diff:{hit}", "note": "required path present in merge"}],
+                )
+            )
+        else:
+            verdicts.append(
+                ItemVerdict(
+                    item=path,
+                    verdict=Verdict.REJECTED,
+                    evidence=[
+                        {
+                            "ref": f"missing:{path}",
+                            "note": "required path absent from base..merge diff",
+                        }
+                    ],
+                    rationale="Issue scope requires this path; it was not changed on the merged branch.",
+                )
+            )
+    return verdicts
 
 
 def handle(ctx, deps) -> PhaseResult:  # pragma: no cover  (replaced in Task 10)

--- a/app/modules/workspace/autonomous/phases/merge.py
+++ b/app/modules/workspace/autonomous/phases/merge.py
@@ -409,6 +409,6 @@ def handle(ctx, deps) -> PhaseResult:
         )
 
     return PhaseResult.completed(
-        next_phase="completed",
+        next_phase="acceptance_verification",
         milestone_events=milestone_events,
     )

--- a/app/modules/workspace/autonomous/phases/pr_review.py
+++ b/app/modules/workspace/autonomous/phases/pr_review.py
@@ -86,6 +86,19 @@ NAME = "pr_review"
 logger = logging.getLogger(__name__)
 
 
+def build_pr_body_close_ref(issue_number: int | None) -> str:
+    """Non-closing issue reference for autonomous PR bodies (#2335).
+
+    Autonomous PRs must NOT use Closes/Fixes/Resolves — GitHub would auto-close
+    the issue on merge before acceptance_verification runs. Use ``Implements #``
+    (a plain reference) and let the workflow close the issue explicitly only on
+    acceptance ``confirmed``.
+    """
+    if not issue_number:
+        return ""
+    return f"\n\nImplements #{issue_number}"
+
+
 def _ensure_branch_and_push(gh, host, branch_name, entry_feature_head, entry_main_head):
     """Ensure the worktree is on ``branch_name`` (recovering if safe), then push.
 
@@ -293,7 +306,7 @@ def handle(ctx, deps) -> PhaseResult:
             # Build PR body with issue linkage
             pr_body = f"Autonomous development for dev round {dev_round}.\n\nRequirements: {wf.get('requirements_text', '')}"
             if issue_number:
-                pr_body += f"\n\nCloses #{issue_number}"
+                pr_body += build_pr_body_close_ref(issue_number)
 
             pr_data = gh.create_pr(
                 title=f"[Auto] Dev round {dev_round}: {wf.get('title', 'Autonomous development')}",

--- a/app/repositories/autonomous_repo.py
+++ b/app/repositories/autonomous_repo.py
@@ -117,6 +117,19 @@ class AutonomousWorkflowRepository:
         "sandbox_last_error",
         "sandbox_remote_session_id",  # #2022 P6: remote-agent session id for orphan destroy
         "sandbox_effective_policy",  # #2020 Phase B: JSON snapshot of effective resource/isolation policy
+        # acceptance_verification phase (#2335 PR1): independent post-merge
+        # verification state, persisted report/snapshot, and explicit close audit.
+        "verification_status",
+        "verification_merge_sha",
+        "verification_started_at",
+        "verification_completed_at",
+        "verification_attempt",
+        "verification_report",
+        "issue_acceptance_snapshot",
+        "issue_acceptance_hash",
+        "verified_by",
+        "verification_session_id",
+        "issue_closed_by_workflow_at",
     }
     ALLOWED_MILESTONE_FIELDS = {
         "phase",

--- a/docs/superpowers/plans/2026-08-05-acceptance-verification-slice.md
+++ b/docs/superpowers/plans/2026-08-05-acceptance-verification-slice.md
@@ -1,0 +1,1480 @@
+# Acceptance Verification — PR1 Vertical Slice Implementation Plan (#2335)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship PR1 of #2335: autonomous PRs stop auto-closing issues (`Closes #N`→`Implements #N`); a new `acceptance_verification` phase runs an independent read-only verifier + a deterministic scope gate on the merged main SHA and only closes the issue (as `@open-ace-bot`) on `confirmed`.
+
+**Architecture:** Append an `acceptance_verification` phase after `merge`. Parse an acceptance snapshot from the issue (convention → LLM fallback). A new phase handler spawns a credentialless read-only verifier agent on merged main, runs a scope gate (`base_commit_sha..merge_sha`), aggregates per-item verdicts to `confirmed`/`rejected`/`indeterminate`, and transitions accordingly. `confirmed`→explicit `close_issue()` + report; `rejected`→new dev round; `indeterminate`→paused. Idempotent on `(merge_sha, issue_acceptance_hash)`. Spec: `docs/superpowers/specs/2026-08-05-acceptance-verification-slice-design.md`.
+
+**Tech stack:** Python/Flask, PostgreSQL+SQLite (`adapt_sql`), Alembic, the `PhaseResult`/`PHASE_HANDLERS` machine (`phase_contract.py`), `evidence.py` `Verdict` enum, the session-line agent runner, GitHubOps (`_run_gh(api_only=True)`), pytest.
+
+---
+
+## File Structure
+
+**Create**
+- `app/modules/workspace/autonomous/acceptance_snapshot.py` — pure: `AcceptanceSnapshot` dataclass, `parse_acceptance_snapshot(body)`, canonical JSON + `hash_snapshot`. No git/db deps.
+- `app/modules/workspace/autonomous/acceptance_verdicts.py` — pure: `ItemVerdict` dataclass, `aggregate_verdicts(list[ItemVerdict]) -> str`.
+- `app/modules/workspace/autonomous/phases/acceptance_verification.py` — the phase handler: scope gate (`run_scope_gate`), verifier spawn (via `deps.host`), snapshot persist, aggregate, transitions, idempotency, reopen guard.
+- `migrations/versions/20260805_010_acceptance_verification_columns.py` — idempotent `ADD COLUMN` migration.
+- `tests/issues/2335/test_acceptance_snapshot.py`, `test_acceptance_verdicts.py`, `test_scope_gate.py`, `test_close_keyword_and_close_issue.py`, `test_acceptance_phase.py`.
+
+**Modify**
+- `app/modules/workspace/autonomous/orchestrator.py` — `PHASE_ORDER`, `PHASE_STATUS_MAP`, `_COMPLETED_TERMINAL_PHASES`, `SESSION_LINE_FIELDS`; a `run_verification_agent` PhaseHost alias + `_run_verification_agent` impl.
+- `app/modules/workspace/autonomous/phases/__init__.py` — register `acceptance_verification`.
+- `app/modules/workspace/autonomous/phases/merge.py` — terminal `completed()` targets `acceptance_verification`.
+- `app/modules/workspace/autonomous/phases/pr_review.py` — `Closes #N` → `Implements #N`.
+- `app/modules/workspace/autonomous/github_ops.py` — add `close_issue(number)` (`api_only=True`); add `get_merge_commit_sha(pr_number)`.
+- `app/modules/workspace/autonomous/constants.py` — `VERIFICATION_ALLOWED_TOOLS`.
+- `app/repositories/autonomous_repo.py` — new columns in `ALLOWED_WORKFLOW_FIELDS`.
+- `schema/schema-postgres.sql` + `schema/schema-sqlite.sql` — regenerated.
+- `tests/autonomous/test_phase_b_acceptance.py` — phase-order/terminal invariant.
+
+---
+
+## Task 1: Acceptance snapshot parser + hash (pure)
+
+**Files:**
+- Create: `app/modules/workspace/autonomous/acceptance_snapshot.py`
+- Test: `tests/issues/2335/test_acceptance_snapshot.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/issues/2335/test_acceptance_snapshot.py
+from app.modules.workspace.autonomous.acceptance_snapshot import (
+    AcceptanceSnapshot,
+    hash_snapshot,
+    parse_acceptance_snapshot,
+)
+
+
+def test_parses_convention_sections():
+    body = """Some intro.
+
+## Scope
+- `app/services/retention.py`
+- `app/routes/legal.py`
+
+## 验收标准
+- [ ] retention manager runs on cron
+- [ ] DELETE is gated by legal-hold
+
+## 不在 Scope
+- UI changes
+"""
+    snap = parse_acceptance_snapshot(body)
+    assert snap.source == "convention"
+    assert snap.confidence == "high"
+    assert "app/services/retention.py" in snap.required_paths
+    assert "app/routes/legal.py" in snap.required_paths
+    assert len(snap.checklist) == 2
+    assert "retention manager runs on cron" in snap.checklist
+    assert snap.non_scope == ["UI changes"]
+
+
+def test_missing_sections_flagged_for_llm_extraction():
+    snap = parse_acceptance_snapshot("just a free-form issue, no sections")
+    assert snap.source == "missing"
+    assert snap.required_paths == []
+    assert snap.checklist == []
+
+
+def test_closure_constraint_detected():
+    body = "## Scope\n- `x.py`\n\n禁止阶段性关闭。"
+    snap = parse_acceptance_snapshot(body)
+    assert snap.closure_constraints is True
+
+
+def test_hash_is_stable_and_order_independent():
+    a = parse_acceptance_snapshot("## Scope\n- `a.py`\n- `b.py`\n## 验收标准\n- [ ] one\n")
+    b = parse_acceptance_snapshot("## Scope\n- `b.py`\n- `a.py`\n## 验收标准\n- [ ] one\n")
+    assert hash_snapshot(a) == hash_snapshot(b)
+    assert isinstance(hash_snapshot(a), str) and len(hash_snapshot(a)) == 64
+```
+
+- [ ] **Step 2: Run — expect ImportError/fail**
+
+Run: `python -m pytest tests/issues/2335/test_acceptance_snapshot.py -q`
+Expected: FAIL (module not found).
+
+- [ ] **Step 3: Implement**
+
+```python
+# app/modules/workspace/autonomous/acceptance_snapshot.py
+"""Issue acceptance-snapshot parsing for the acceptance_verification phase (#2335).
+
+Pure module: markdown-section extraction + canonical hashing. No git/db deps.
+Convention sections: ## Scope, ## 验收标准 / ## Acceptance Criteria, ## 不在 Scope /
+## Non-Scope. When required sections are absent, source="missing" and the verifier
+performs LLM extraction (re-persisted with source="llm", confidence="low").
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass, field
+
+# Matches a markdown heading and captures its body up to the next same-or-higher heading.
+_SECTION_RE = re.compile(r"(?m)^(?:#{1,6})\s+(.*?)\s*$")
+_PATH_RE = re.compile(r"`?([A-Za-z0-9_./-]+/[A-Za-z0-9_./-]+|\.[A-Za-z0-9_./-]+)`?")
+_CLOSURE_CONSTRAINT_RE = re.compile(
+    r"禁止阶段性关闭|do not close (?:until|before)|no (?:premature|staged) close",
+    re.IGNORECASE,
+)
+# A glob/path token inside a list item: contains a slash or a dot-ext, or a */** wildcard.
+_TOKEN_PATH_RE = re.compile(r"`?([A-Za-z0-9_./?*{}\[\]\-]+)`?")
+
+
+@dataclass
+class AcceptanceSnapshot:
+    required_paths: list[str] = field(default_factory=list)
+    checklist: list[str] = field(default_factory=list)
+    non_scope: list[str] = field(default_factory=list)
+    closure_constraints: bool = False
+    source: str = "missing"        # "convention" | "missing" | "llm"
+    confidence: str = "low"        # "high" (convention) | "low" (missing/llm)
+
+    def to_canonical(self) -> dict:
+        return {
+            "required_paths": sorted(self.required_paths),
+            "checklist": sorted(self.checklist),
+            "non_scope": sorted(self.non_scope),
+            "closure_constraints": self.closure_constraints,
+            # source/confidence are intentionally excluded: the hash captures the
+            # acceptance *content*, so an issue edit (new path/checklist) changes
+            # the hash and forces re-verification, while an LLM re-extraction of
+            # the same content is stable.
+        }
+
+
+def _split_sections(body: str) -> dict[str, str]:
+    """Return {lowercased_heading: body_until_next_heading}."""
+    matches = list(_SECTION_RE.finditer(body))
+    sections: dict[str, str] = {}
+    for i, m in enumerate(matches):
+        title = m.group(1).strip().lower()
+        start = m.end()
+        end = matches[i + 1].start() if i + 1 < len(matches) else len(body)
+        sections[title] = body[start:end]
+    return sections
+
+
+def _extract_paths(text: str) -> list[str]:
+    paths: list[str] = []
+    for line in text.splitlines():
+        line = line.strip()
+        if not line.startswith(("-", "*")):
+            continue
+        item = line.lstrip("-* ").strip()
+        # Prefer backticked token, else the first path-shaped token on the line.
+        for tok in _TOKEN_PATH_RE.findall(item):
+            if "/" in tok or tok.startswith(".") or "*" in tok:
+                paths.append(tok.strip("`"))
+                break
+    # de-dup, preserve order
+    seen: set[str] = set()
+    out: list[str] = []
+    for p in paths:
+        if p not in seen:
+            seen.add(p)
+            out.append(p)
+    return out
+
+
+def _extract_checklist(text: str) -> list[str]:
+    out: list[str] = []
+    for line in text.splitlines():
+        m = re.match(r"\s*[-*]\s+\[[ xX]\]\s+(.*)$", line)
+        if m:
+            out.append(m.group(1).strip())
+    return out
+
+
+def _extract_plain_list(text: str) -> list[str]:
+    out: list[str] = []
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith(("-", "*")):
+            out.append(line.lstrip("-* ").strip())
+    return out
+
+
+_SCOPE_TITLES = {"scope"}
+_CRITERIA_TITLES = {"验收标准", "acceptance criteria", "acceptance", "验收"}
+_NONSCOPE_TITLES = {"不在 scope", "non-scope", "non scope", "out of scope"}
+
+
+def parse_acceptance_snapshot(body: str) -> AcceptanceSnapshot:
+    sections = _split_sections(body or "")
+    snap = AcceptanceSnapshot()
+
+    scope_text = next((sections[t] for t in sections if t in _SCOPE_TITLES), None)
+    criteria_text = next((sections[t] for t in sections if any(k in t for k in _CRITERIA_TITLES)), None)
+    nonscope_text = next((sections[t] for t in sections if any(k in t for k in _NONSCOPE_TITLES)), None)
+
+    if scope_text is not None or criteria_text is not None:
+        snap.source = "convention"
+        snap.confidence = "high"
+
+    if scope_text is not None:
+        snap.required_paths = _extract_paths(scope_text)
+    if criteria_text is not None:
+        snap.checklist = _extract_checklist(criteria_text)
+    if nonscope_text is not None:
+        snap.non_scope = _extract_plain_list(nonscope_text)
+
+    snap.closure_constraints = bool(_CLOSURE_CONSTRAINT_RE.search(body or ""))
+    return snap
+
+
+def hash_snapshot(snap: AcceptanceSnapshot) -> str:
+    canonical = json.dumps(snap.to_canonical(), sort_keys=True, ensure_ascii=False)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+```
+
+- [ ] **Step 4: Run — expect PASS**
+
+Run: `python -m pytest tests/issues/2335/test_acceptance_snapshot.py -q`
+Expected: 4 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/modules/workspace/autonomous/acceptance_snapshot.py tests/issues/2335/test_acceptance_snapshot.py
+git commit -m "feat(autonomous): acceptance snapshot parser + hash (#2335)"
+```
+
+---
+
+## Task 2: Verdict aggregation (pure)
+
+**Files:**
+- Create: `app/modules/workspace/autonomous/acceptance_verdicts.py`
+- Test: `tests/issues/2335/test_acceptance_verdicts.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/issues/2335/test_acceptance_verdicts.py
+from app.modules.workspace.autonomous.acceptance_verdicts import (
+    ItemVerdict,
+    aggregate_verdicts,
+)
+from app.modules.workspace.autonomous.evidence import Verdict
+
+
+def _item(v, item="x"):
+    return ItemVerdict(item=item, verdict=v, evidence=[], rationale="")
+
+
+def test_all_confirmed():
+    assert aggregate_verdicts([_item(Verdict.CONFIRMED), _item(Verdict.CONFIRMED)]) == "confirmed"
+
+
+def test_any_rejected():
+    assert (
+        aggregate_verdicts([_item(Verdict.CONFIRMED), _item(Verdict.REJECTED)])
+        == "rejected"
+    )
+
+
+def test_any_indeterminate_without_rejected():
+    assert (
+        aggregate_verdicts([_item(Verdict.CONFIRMED), _item(Verdict.INDETERMINATE)])
+        == "indeterminate"
+    )
+
+
+def test_empty_is_indeterminate():
+    assert aggregate_verdicts([]) == "indeterminate"
+```
+
+- [ ] **Step 2: Run — expect fail**
+
+Run: `python -m pytest tests/issues/2335/test_acceptance_verdicts.py -q`
+Expected: FAIL (import).
+
+- [ ] **Step 3: Implement**
+
+```python
+# app/modules/workspace/autonomous/acceptance_verdicts.py
+"""Per-item acceptance verdicts + issue-level aggregation (#2335). Pure."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from app.modules.workspace.autonomous.evidence import Verdict
+
+# The issue-level status string written to verification_status.
+STATUS_CONFIRMED = "confirmed"
+STATUS_REJECTED = "rejected"
+STATUS_INDETERMINATE = "indeterminate"
+
+
+@dataclass
+class ItemVerdict:
+    item: str                                   # checklist text or required path
+    verdict: Verdict                            # CONFIRMED / REJECTED / INDETERMINATE
+    evidence: list[dict] = field(default_factory=list)  # [{"ref": "file:line|git-diff", "note": "..."}]
+    rationale: str = ""
+
+
+def aggregate_verdicts(items: list[ItemVerdict]) -> str:
+    """Any REJECTED → rejected; else any INDETERMINATE → indeterminate; else confirmed.
+
+    Empty item list → indeterminate (nothing was affirmatively confirmed).
+    """
+    if any(iv.verdict is Verdict.REJECTED for iv in items):
+        return STATUS_REJECTED
+    if any(iv.verdict is Verdict.INDETERMINATE for iv in items):
+        return STATUS_INDETERMINATE
+    if items and all(iv.verdict is Verdict.CONFIRMED for iv in items):
+        return STATUS_CONFIRMED
+    return STATUS_INDETERMINATE
+```
+
+- [ ] **Step 4: Run — expect PASS**
+
+Run: `python -m pytest tests/issues/2335/test_acceptance_verdicts.py -q`
+Expected: 4 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/modules/workspace/autonomous/acceptance_verdicts.py tests/issues/2335/test_acceptance_verdicts.py
+git commit -m "feat(autonomous): acceptance verdict aggregation (#2335)"
+```
+
+---
+
+## Task 3: Idempotent migration + schema regen
+
+**Files:**
+- Create: `migrations/versions/20260805_010_acceptance_verification_columns.py`
+- Modify: `schema/schema-postgres.sql`, `schema/schema-sqlite.sql` (regenerated)
+
+- [ ] **Step 1: Write the migration**
+
+```python
+# migrations/versions/20260805_010_acceptance_verification_columns.py
+"""Add acceptance_verification columns to autonomous_workflows (#2335).
+
+Revision ID: 20260805_010_acceptance_verification_columns
+Revises: 20260805_001_add_max_changed_files_override
+Create Date: 2026-08-05
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260805_010_acceptance_verification_columns"
+down_revision = "20260805_001_add_max_changed_files_override"
+branch_labels = None
+depends_on = None
+
+COLUMNS = [
+    ("verification_status", sa.Text(), True),
+    ("verification_merge_sha", sa.Text(), True),
+    ("verification_started_at", sa.DateTime(timezone=True), True),
+    ("verification_completed_at", sa.DateTime(timezone=True), True),
+    ("verification_attempt", sa.Integer(), True),
+    ("verification_report", sa.Text(), True),     # JSON-encoded; kept Text for SQLite parity
+    ("issue_acceptance_snapshot", sa.Text(), True),
+    ("issue_acceptance_hash", sa.Text(), True),
+    ("verified_by", sa.Text(), True),
+    ("verification_session_id", sa.Text(), True),
+    ("issue_closed_by_workflow_at", sa.DateTime(timezone=True), True),
+]
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing = {c["name"] for c in inspector.get_columns("autonomous_workflows")}
+    for name, type_, nullable in COLUMNS:
+        if name in existing:
+            continue
+        op.add_column(
+            "autonomous_workflows",
+            sa.Column(name, type_, nullable=nullable),
+        )
+
+
+def downgrade() -> None:
+    for name, _, _ in reversed(COLUMNS):
+        op.drop_column("autonomous_workflows", name)
+```
+
+- [ ] **Step 2: Regenerate schema snapshots (PG16 client)**
+
+Run (requires a disposable PG; reuse the local PG@16 used for #2309):
+```bash
+PATH="/opt/homebrew/opt/postgresql@16/bin:$PATH" python scripts/rebuild_schema_snapshots.py \
+  --postgres-url "postgresql://ace:ace@localhost:5433/ace_schema_sync"
+git add schema/schema-postgres.sql schema/schema-sqlite.sql
+```
+Expected: only the 11 new columns appear in the diff under `autonomous_workflows`.
+
+- [ ] **Step 3: Verify byte-exact schema-sync locally**
+
+Run: `python scripts/check_schema_sync.py --postgres-url "postgresql://ace:ace@localhost:5433/ace_schema_sync"; echo "rc=$?"`
+Expected: `rc=0` (drift = exit 1 per the schema-sync memory; do NOT pipe to `tail` before checking `$?`).
+
+- [ ] **Step 4: Verify migration head + applies idempotently on a fresh DB**
+
+Run:
+```bash
+python -m alembic upgrade head   # against a throwaway DB; expect "Running upgrade ... -> 20260805_010..."
+python -m alembic upgrade head   # again; expect no-op
+python -m alembic check          # expect "No new upgrade operations detected"
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add migrations/versions/20260805_010_acceptance_verification_columns.py schema/schema-postgres.sql schema/schema-sqlite.sql
+git commit -m "feat(autonomous): acceptance_verification columns migration (#2335)"
+```
+
+---
+
+## Task 4: Repo allowlist for the new columns
+
+**Files:**
+- Modify: `app/repositories/autonomous_repo.py` (the `ALLOWED_WORKFLOW_FIELDS` set, ≈ line 28-100)
+- Test: `tests/issues/2335/test_repo_allowlist.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/issues/2335/test_repo_allowlist.py
+from app.repositories.autonomous_repo import AutonomousWorkflowRepository, ALLOWED_WORKFLOW_FIELDS
+
+
+def test_new_verification_columns_are_writeable():
+    for col in [
+        "verification_status",
+        "verification_merge_sha",
+        "verification_started_at",
+        "verification_completed_at",
+        "verification_attempt",
+        "verification_report",
+        "issue_acceptance_snapshot",
+        "issue_acceptance_hash",
+        "verified_by",
+        "verification_session_id",
+        "issue_closed_by_workflow_at",
+    ]:
+        assert col in ALLOWED_WORKFLOW_FIELDS, f"{col} must be in the update allowlist"
+```
+
+- [ ] **Step 2: Run — expect fail**
+
+Run: `python -m pytest tests/issues/2335/test_repo_allowlist.py -q`
+Expected: FAIL (columns not in set).
+
+- [ ] **Step 3: Add the columns to `ALLOWED_WORKFLOW_FIELDS`**
+
+In `app/repositories/autonomous_repo.py`, add these tokens to the `ALLOWED_WORKFLOW_FIELDS` set (next to the other `ALLOWED_WORKFLOW_FIELDS` entries such as `max_changed_files_override`):
+
+```python
+        "verification_status",
+        "verification_merge_sha",
+        "verification_started_at",
+        "verification_completed_at",
+        "verification_attempt",
+        "verification_report",
+        "issue_acceptance_snapshot",
+        "issue_acceptance_hash",
+        "verified_by",
+        "verification_session_id",
+        "issue_closed_by_workflow_at",
+```
+
+Note: `get_workflow` uses `SELECT *`, so reads auto-include the columns; only the update allowlist needs them. INSERTs leave them NULL (not set at create).
+
+- [ ] **Step 4: Run — expect PASS**
+
+Run: `python -m pytest tests/issues/2335/test_repo_allowlist.py -q`
+Expected: 1 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/repositories/autonomous_repo.py tests/issues/2335/test_repo_allowlist.py
+git commit -m "feat(autonomous): allowlist verification columns in repo (#2335)"
+```
+
+---
+
+## Task 5: GitHubOps.close_issue + merge-commit SHA helper (api_only)
+
+**Files:**
+- Modify: `app/modules/workspace/autonomous/github_ops.py` (add `close_issue` near `add_issue_comment` ≈ :795; add `get_merge_commit_sha` near `view_pr`)
+- Test: `tests/issues/2335/test_close_issue.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/issues/2335/test_close_issue.py
+from unittest.mock import MagicMock, patch
+
+import app.modules.workspace.autonomous.github_ops as gh_mod
+from app.modules.workspace.autonomous.github_ops import GitHubOps
+
+BOT_ENV = {
+    "GH_TOKEN": "ghp-bot",
+    "GIT_AUTHOR_NAME": "Open ACE AI",
+    "GIT_AUTHOR_EMAIL": "bot@open-ace.com",
+    "GIT_COMMITTER_NAME": "Open ACE AI",
+    "GIT_COMMITTER_EMAIL": "bot@open-ace.com",
+}
+
+
+def _gh():
+    gh = GitHubOps("/srv/owners/repo", system_account="repoowner")
+    gh._owner_repo_resolved = True
+    gh._owner_repo = "open-ace/open-ace"
+    gh._repo_host = None
+    return gh
+
+
+def test_close_issue_runs_as_service_user_with_bot_token():
+    gh = _gh()
+    run = MagicMock(return_value=MagicMock(returncode=0, stdout="", stderr=""))
+    with (
+        patch.object(gh, "_needs_sudo", return_value=True),
+        patch.object(gh, "_verify_trusted_git_context"),
+        patch("app.utils.config.get_ai_github_env", return_value=BOT_ENV),
+        patch.object(gh_mod, "subprocess") as sub_mod,
+    ):
+        sub_mod.run = run
+        gh.close_issue(42)
+    cmd = run.call_args.args[0]
+    assert cmd[0] == "gh", f"close_issue must not sudo (got {cmd[:3]})"
+    assert "issue" in cmd and "close" in cmd and "42" in cmd
+    assert run.call_args.kwargs["env"]["GH_TOKEN"] == "ghp-bot"
+
+
+def test_get_merge_commit_sha_returns_oid():
+    gh = _gh()
+    fake = MagicMock(returncode=0, stdout="abc123\n", stderr="")
+    with (
+        patch.object(gh, "_run_gh", return_value=fake),
+    ):
+        assert gh.get_merge_commit_sha(99) == "abc123"
+```
+
+- [ ] **Step 2: Run — expect fail**
+
+Run: `python -m pytest tests/issues/2335/test_close_issue.py -q`
+Expected: FAIL (`close_issue`/`get_merge_commit_sha` not defined).
+
+- [ ] **Step 3: Implement**
+
+In `app/modules/workspace/autonomous/github_ops.py`, add next to `add_issue_comment`:
+
+```python
+    def close_issue(self, number: int) -> dict:
+        """Close an issue. Runs as the service user (api_only) so the action
+        attributes to the configured AI bot account, not the repo owner (#2339/#2335)."""
+        self._run_gh(["issue", "close", str(number)], api_only=True)
+        logger.info("Closed issue #%s", number)
+        return {"number": number}
+```
+
+And next to the PR helpers:
+
+```python
+    def get_merge_commit_sha(self, pr_number: int) -> str | None:
+        """Return the merge commit SHA of a merged PR, or None if unmerged."""
+        result = self._run_gh(
+            ["pr", "view", str(pr_number), "--json", "mergeCommit", "--jq", ".mergeCommit.oid"],
+            check=False,
+        )
+        out = (result.stdout or "").strip()
+        return out or None
+```
+
+- [ ] **Step 4: Run — expect PASS**
+
+Run: `python -m pytest tests/issues/2335/test_close_issue.py -q`
+Expected: 2 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/modules/workspace/autonomous/github_ops.py tests/issues/2335/test_close_issue.py
+git commit -m "feat(autonomous): close_issue + merge-commit sha helper (#2335)"
+```
+
+---
+
+## Task 6: Stop `Closes #N` in autonomous PR bodies
+
+**Files:**
+- Modify: `app/modules/workspace/autonomous/phases/pr_review.py:296`
+- Test: `tests/issues/2335/test_close_keyword_enforcement.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/issues/2335/test_close_keyword_enforcement.py
+from app.modules.workspace.autonomous.phases.pr_review import build_pr_body_close_ref
+
+
+def test_pr_body_uses_implements_not_closes():
+    body = build_pr_body_close_ref(issue_number=2335)
+    assert "Implements #2335" in body
+    assert "Closes #2335" not in body
+    assert "Fixes #2335" not in body and "Resolves #2335" not in body
+
+
+def test_pr_body_none_when_no_issue():
+    assert build_pr_body_close_ref(issue_number=None) == ""
+```
+
+- [ ] **Step 2: Run — expect fail**
+
+Run: `python -m pytest tests/issues/2335/test_close_keyword_enforcement.py -q`
+Expected: FAIL (`build_pr_body_close_ref` not defined).
+
+- [ ] **Step 3: Implement — extract the helper + change the keyword**
+
+In `app/modules/workspace/autonomous/phases/pr_review.py`, add a module-level helper and call it from the PR-body construction site (currently ≈ line 295-296: `if issue_number: pr_body += f"\n\nCloses #{issue_number}"`). Replace that inline append with the helper:
+
+```python
+def build_pr_body_close_ref(issue_number: int | None) -> str:
+    """Non-closing issue reference for autonomous PR bodies (#2335).
+
+    Autonomous PRs must NOT use Closes/Fixes/Resolves — GitHub would auto-close
+    the issue on merge before acceptance_verification runs. Use Implements #
+    (a plain reference) and let the workflow close explicitly on `confirmed`.
+    """
+    if not issue_number:
+        return ""
+    return f"\n\nImplements #{issue_number}"
+```
+
+At the PR-body site, change:
+```python
+            pr_body += f"\n\nCloses #{issue_number}"
+```
+to:
+```python
+            pr_body += build_pr_body_close_ref(issue_number)
+```
+
+- [ ] **Step 4: Run — expect PASS**
+
+Run: `python -m pytest tests/issues/2335/test_close_keyword_enforcement.py -q`
+Expected: 2 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/modules/workspace/autonomous/phases/pr_review.py tests/issues/2335/test_close_keyword_enforcement.py
+git commit -m "fix(autonomous): autonomous PRs use Implements #N, not Closes #N (#2335)"
+```
+
+---
+
+## Task 7: VERIFICATION_ALLOWED_TOOLS + verification session line
+
+**Files:**
+- Modify: `app/modules/workspace/autonomous/constants.py`; `app/modules/workspace/autonomous/orchestrator.py` (`SESSION_LINE_FIELDS` ≈ :801)
+- Test: `tests/issues/2335/test_verification_tools_session.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/issues/2335/test_verification_tools_session.py
+import copy
+from app.modules.workspace.autonomous import constants
+from app.modules.workspace.autonomous.constants import (
+    REVIEW_ALLOWED_TOOLS,
+    VERIFICATION_ALLOWED_TOOLS,
+)
+
+
+def test_verification_adds_bash_to_review_set():
+    review = copy.deepcopy(REVIEW_ALLOWED_TOOLS["claude-code"])
+    verif = VERIFICATION_ALLOWED_TOOLS["claude-code"]
+    # every review tool is permitted for verification...
+    for t in review:
+        assert t in verif
+    # ...plus Bash for the scope gate's git diff/log, still no Write/Edit
+    assert "Bash" in verif
+    assert "Write" not in verif and "Edit" not in verif
+
+
+def test_session_line_registry_includes_verification():
+    from app.modules.workspace.autonomous.orchestrator import SESSION_LINE_FIELDS
+    assert SESSION_LINE_FIELDS.get("verification") == "verification_session_id"
+```
+
+- [ ] **Step 2: Run — expect fail**
+
+Run: `python -m pytest tests/issues/2335/test_verification_tools_session.py -q`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+In `app/modules/workspace/autonomous/constants.py`, after `REVIEW_ALLOWED_TOOLS`:
+
+```python
+# Acceptance-verification tools (#2335): read-only review set + Bash for the
+# scope gate's git diff/log on merged main. No Write/Edit — the verifier must not
+# mutate the acceptance target; it works against a throwaway checkout of main and
+# reads git state, not the working tree.
+VERIFICATION_ALLOWED_TOOLS: dict[str, list[str]] = {
+    "claude-code": REVIEW_ALLOWED_TOOLS["claude-code"] + ["Bash"],
+    "qwen-code-cli": REVIEW_ALLOWED_TOOLS["qwen-code-cli"] + ["run_shell_command"],
+    "codex": [],
+    "openclaw": [],
+    "zcode": [],
+}
+```
+
+In `app/modules/workspace/autonomous/orchestrator.py`, extend `SESSION_LINE_FIELDS` (≈ :801):
+
+```python
+SESSION_LINE_FIELDS = {
+    "main": "main_session_id",
+    "review": "review_session_id",
+    "test": "test_session_id",
+    "verification": "verification_session_id",
+}
+```
+
+- [ ] **Step 4: Run — expect PASS**
+
+Run: `python -m pytest tests/issues/2335/test_verification_tools_session.py -q`
+Expected: 2 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/modules/workspace/autonomous/constants.py app/modules/workspace/autonomous/orchestrator.py tests/issues/2335/test_verification_tools_session.py
+git commit -m "feat(autonomous): VERIFICATION_ALLOWED_TOOLS + verification session line (#2335)"
+```
+
+---
+
+## Task 8: Phase-machine wiring + terminal invariant
+
+**Files:**
+- Modify: `app/modules/workspace/autonomous/orchestrator.py` (`PHASE_ORDER` ≈ :577, `PHASE_STATUS_MAP` ≈ :589, `_COMPLETED_TERMINAL_PHASES` ≈ :586); `app/modules/workspace/autonomous/phases/merge.py` (terminal `completed()`); `app/modules/workspace/autonomous/phases/__init__.py` (register handler)
+- Create: `app/modules/workspace/autonomous/phases/acceptance_verification.py` (stub `handle` for now — full impl in Task 10)
+- Test: `tests/issues/2335/test_phase_wiring.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/issues/2335/test_phase_wiring.py
+from app.modules.workspace.autonomous.orchestrator import (
+    PHASE_ORDER,
+    PHASE_STATUS_MAP,
+    _COMPLETED_TERMINAL_PHASES,
+)
+from app.modules.workspace.autonomous.phases import resolve_phase_handler
+
+
+def test_acceptance_verification_phase_registered_and_ordered():
+    assert "acceptance_verification" in PHASE_ORDER
+    assert PHASE_ORDER.index("acceptance_verification") > PHASE_ORDER.index("merge")
+    assert PHASE_STATUS_MAP["acceptance_verification"] == "verification_pending"
+    assert resolve_phase_handler("acceptance_verification") is not None
+
+
+def test_terminal_set_no_longer_treats_merge_as_completed():
+    # merge now hands off to acceptance_verification; only acceptance(confirmed)→completed
+    assert "merge" not in _COMPLETED_TERMINAL_PHASES
+    assert "completed" in _COMPLETED_TERMINAL_PHASES
+```
+
+- [ ] **Step 2: Run — expect fail**
+
+Run: `python -m pytest tests/issues/2335/test_phase_wiring.py -q`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement the wiring**
+
+In `orchestrator.py`:
+- `PHASE_ORDER`: append `"acceptance_verification"` after `"merge"`:
+  ```python
+  PHASE_ORDER = ["preparation", "planning", "development", "pr_review", "report", "merge", "acceptance_verification"]
+  ```
+- `PHASE_STATUS_MAP` (≈ :589): add:
+  ```python
+      "acceptance_verification": "verification_pending",
+  ```
+- `_COMPLETED_TERMINAL_PHASES` (≈ :586): change to:
+  ```python
+  _COMPLETED_TERMINAL_PHASES = ("completed",)
+  ```
+  (merge is no longer terminal; it advances to acceptance_verification.)
+
+In `phases/merge.py`, change the terminal return (the `PhaseResult.completed(next_phase="completed", ...)` at ≈ :411) to target the new phase:
+```python
+    return PhaseResult.completed(
+        next_phase="acceptance_verification",
+        ...   # keep the existing workflow_patch / milestone_events unchanged
+    )
+```
+(Leave the surrounding kwargs as-is; only `next_phase` changes.)
+
+Create `app/modules/workspace/autonomous/phases/acceptance_verification.py` stub (full impl in Task 10):
+```python
+"""acceptance_verification phase handler (#2335). Full implementation in Task 10."""
+
+from __future__ import annotations
+
+from app.modules.workspace.autonomous.phase_contract import PhaseResult
+
+
+def handle(ctx, deps) -> PhaseResult:  # pragma: no cover  (replaced in Task 10)
+    raise NotImplementedError("acceptance_verification handler not implemented yet")
+```
+
+In `phases/__init__.py`, register it (after the existing imports/registrations, ≈ line 34-38):
+```python
+from app.modules.workspace.autonomous.phases import acceptance_verification as _acceptance  # noqa: E402
+register_phase_handler("acceptance_verification", _acceptance.handle)
+```
+
+- [ ] **Step 4: Run — expect PASS**
+
+Run: `python -m pytest tests/issues/2335/test_phase_wiring.py -q`
+Expected: 2 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/modules/workspace/autonomous/orchestrator.py app/modules/workspace/autonomous/phases/merge.py app/modules/workspace/autonomous/phases/__init__.py app/modules/workspace/autonomous/phases/acceptance_verification.py tests/issues/2335/test_phase_wiring.py
+git commit -m "feat(autonomous): wire acceptance_verification phase into the machine (#2335)"
+```
+
+---
+
+## Task 9: Scope gate
+
+**Files:**
+- Modify: `app/modules/workspace/autonomous/phases/acceptance_verification.py` (add `run_scope_gate`)
+- Test: `tests/issues/2339/test_scope_gate.py` → correct path `tests/issues/2335/test_scope_gate.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/issues/2335/test_scope_gate.py
+from unittest.mock import MagicMock
+
+from app.modules.workspace.autonomous.evidence import Verdict
+from app.modules.workspace.autonomous.phases.acceptance_verification import run_scope_gate
+
+
+def test_required_path_present_is_confirmed():
+    gh = MagicMock()
+    gh.get_changed_files.return_value = ["app/services/retention.py", "README.md"]
+    verdicts = run_scope_gate(gh, ["app/services/retention.py"], "base", "merge")
+    assert len(verdicts) == 1
+    assert verdicts[0].verdict is Verdict.CONFIRMED
+
+
+def test_required_path_missing_is_rejected():
+    gh = MagicMock()
+    gh.get_changed_files.return_value = ["README.md"]
+    verdicts = run_scope_gate(gh, ["app/services/retention.py"], "base", "merge")
+    assert verdicts[0].verdict is Verdict.REJECTED
+    assert "app/services/retention.py" in verdicts[0].item
+    assert verdicts[0].evidence  # carries the missing-path ref
+
+
+def test_glob_matches_changed_path():
+    gh = MagicMock()
+    gh.get_changed_files.return_value = ["app/services/retention.py", "app/services/legal.py"]
+    verdicts = run_scope_gate(gh, ["app/services/*.py"], "base", "merge")
+    assert all(v.verdict is Verdict.CONFIRMED for v in verdicts)
+
+
+def test_no_required_paths_returns_empty():
+    gh = MagicMock()
+    assert run_scope_gate(gh, [], "base", "merge") == []
+```
+
+- [ ] **Step 2: Run — expect fail**
+
+Run: `python -m pytest tests/issues/2335/test_scope_gate.py -q`
+Expected: FAIL (`run_scope_gate` not defined).
+
+- [ ] **Step 3: Implement**
+
+In `app/modules/workspace/autonomous/phases/acceptance_verification.py`, replace the stub with the gate (keep `handle` raising NotImplementedError for now — Task 10 fills it):
+
+```python
+"""acceptance_verification phase handler (#2335).
+
+Task 9 adds the deterministic scope gate; Task 10 fills in `handle` (verifier
+spawn, snapshot persistence, aggregation, transitions, idempotency, reopen guard).
+"""
+
+from __future__ import annotations
+
+import fnmatch
+
+from app.modules.workspace.autonomous.acceptance_verdicts import ItemVerdict
+from app.modules.workspace.autonomous.evidence import Verdict
+from app.modules.workspace.autonomous.phase_contract import PhaseResult
+
+
+def _glob_matches(pattern: str, paths: list[str]) -> str | None:
+    """Return the first changed path matching the pattern (glob), else None."""
+    for p in paths:
+        if fnmatch.fnmatch(p, pattern) or p == pattern:
+            return p
+    return None
+
+
+def run_scope_gate(gh, required_paths: list[str], base_sha: str, merge_sha: str) -> list[ItemVerdict]:
+    """Deterministic scope gate: each required path must appear in base..merge diff.
+
+    Returns one ItemVerdict per required path: CONFIRMED if a changed path matches
+    (glob), REJECTED with the missing path as evidence otherwise.
+    """
+    changed = gh.get_changed_files(base=base_sha, head=merge_sha) or []
+    verdicts: list[ItemVerdict] = []
+    for path in required_paths:
+        hit = _glob_matches(path, changed)
+        if hit is not None:
+            verdicts.append(
+                ItemVerdict(item=path, verdict=Verdict.CONFIRMED,
+                            evidence=[{"ref": f"git-diff:{hit}", "note": "required path present in merge"}])
+            )
+        else:
+            verdicts.append(
+                ItemVerdict(item=path, verdict=Verdict.REJECTED,
+                            evidence=[{"ref": f"missing:{path}", "note": "required path absent from base..merge diff"}],
+                            rationale="Issue scope requires this path; it was not changed on the merged branch.")
+            )
+    return verdicts
+
+
+def handle(ctx, deps) -> PhaseResult:  # pragma: no cover  (Task 10)
+    raise NotImplementedError("acceptance_verification handler not implemented yet")
+```
+
+- [ ] **Step 4: Run — expect PASS**
+
+Run: `python -m pytest tests/issues/2335/test_scope_gate.py -q`
+Expected: 4 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/modules/workspace/autonomous/phases/acceptance_verification.py tests/issues/2335/test_scope_gate.py
+git commit -m "feat(autonomous): acceptance scope gate (#2335)"
+```
+
+---
+
+## Task 10: The acceptance_verification handler
+
+This is the integration task: spawn the verifier, run the scope gate, aggregate, persist, transition, idempotency, reopen guard, close-on-confirm.
+
+**Files:**
+- Modify: `app/modules/workspace/autonomous/phases/acceptance_verification.py` (replace `handle`); `app/modules/workspace/autonomous/orchestrator.py` (add `_run_verification_agent` + `run_verification_agent` PhaseHost alias)
+- Test: `tests/issues/2335/test_acceptance_phase.py`
+
+- [ ] **Step 1: Write the failing tests (mock the verifier + gh + repo)**
+
+```python
+# tests/issues/2335/test_acceptance_phase.py
+from unittest.mock import MagicMock
+
+from app.modules.workspace.autonomous.acceptance_verdicts import ItemVerdict
+from app.modules.workspace.autonomous.evidence import Verdict
+from app.modules.workspace.autonomous.phase_contract import PhaseResult, WorkflowContext
+from app.modules.workspace.autonomous.phases import acceptance_verification as av
+
+
+def _ctx(wf):
+    return WorkflowContext(
+        workflow=wf, definition_snapshot=None, repository_context=None,
+        session_bindings=MagicMock(), cancellation=MagicMock(),
+    )
+
+
+def _deps(**kw):
+    d = MagicMock()
+    for k, v in kw.items():
+        setattr(d, k, v)
+    return d
+
+
+def test_confirmed_closes_issue_and_completes():
+    wf = {
+        "id": 1, "github_issue_number": 42, "github_pr_number": 99,
+        "base_commit_sha": "base", "verification_merge_sha": "merge",
+        "issue_acceptance_hash": "h1", "verification_status": None,
+        "issue_acceptance_snapshot": None,
+    }
+    gh = MagicMock()
+    gh.get_merge_commit_sha.return_value = "merge"
+    gh.get_changed_files.return_value = ["app/x.py"]          # scope gate passes
+    deps = _deps(gh=gh)
+    # verifier returns all-CONFIRMED for the checklist item
+    deps.host.run_verification_agent.return_value = {
+        "verdicts": [{"item": "works", "verdict": "confirmed", "evidence": [], "rationale": ""}],
+        "snapshot": None,
+    }
+    deps.host.issue_is_open.return_value = True
+    result = av.handle(_ctx(wf), deps)
+    assert result.outcome == "completed"
+    assert result.next_phase == "completed"
+    deps.gh.close_issue.assert_called_once_with(42)
+    deps.host.create_milestone_idempotent.assert_called()
+
+
+def test_rejected_starts_new_dev_round():
+    wf = {
+        "id": 1, "github_issue_number": 42, "github_pr_number": 99,
+        "base_commit_sha": "base", "verification_merge_sha": "merge",
+        "issue_acceptance_hash": "h1", "verification_status": None,
+        "issue_acceptance_snapshot": None, "dev_round": 1, "max_changed_files_override": None,
+    }
+    gh = MagicMock()
+    gh.get_changed_files.return_value = []                    # scope gate: required path missing
+    deps = _deps(gh=gh)
+    deps.host.run_verification_agent.return_value = {"verdicts": [], "snapshot": None}
+    deps.host.dev_round_cap_remaining.return_value = 2
+    result = av.handle(_ctx(wf), deps)
+    assert result.outcome == "completed"
+    assert result.next_phase == "development"
+    assert result.workflow_patch.get("dev_round") == 2
+    deps.gh.close_issue.assert_not_called()
+
+
+def test_indeterminate_pauses():
+    wf = {
+        "id": 1, "github_issue_number": 42, "github_pr_number": 99,
+        "base_commit_sha": "base", "verification_merge_sha": "merge",
+        "issue_acceptance_hash": "h1", "verification_status": None,
+        "issue_acceptance_snapshot": None,
+    }
+    gh = MagicMock()
+    gh.get_changed_files.return_value = ["app/x.py"]
+    deps = _deps(gh=gh)
+    deps.host.run_verification_agent.return_value = {
+        "verdicts": [{"item": "unclear", "verdict": "indeterminate", "evidence": [], "rationale": ""}],
+        "snapshot": None,
+    }
+    result = av.handle(_ctx(wf), deps)
+    assert result.outcome == "pause"
+    assert result.workflow_patch.get("verification_status") == "indeterminate"
+    deps.gh.close_issue.assert_not_called()
+
+
+def test_idempotent_rerun_is_noop_when_already_confirmed_for_same_sha_hash():
+    wf = {
+        "id": 1, "github_issue_number": 42, "github_pr_number": 99,
+        "base_commit_sha": "base", "verification_merge_sha": "merge",
+        "issue_acceptance_hash": "h1", "verification_status": "confirmed",
+        "issue_acceptance_snapshot": None,
+    }
+    deps = _deps(gh=MagicMock())
+    result = av.handle(_ctx(wf), deps)
+    assert result.outcome == "completed"      # already done; no re-close, no re-verify
+    assert result.next_phase == "completed"
+    deps.gh.close_issue.assert_not_called()    # idempotent: do not close twice
+
+
+def test_closed_issue_reopened_when_not_confirmed():
+    wf = {
+        "id": 1, "github_issue_number": 42, "github_pr_number": 99,
+        "base_commit_sha": "base", "verification_merge_sha": None,
+        "issue_acceptance_hash": "h1", "verification_status": None,
+        "issue_acceptance_snapshot": None,
+    }
+    gh = MagicMock()
+    gh.get_merge_commit_sha.return_value = "merge"
+    gh.get_changed_files.return_value = ["app/x.py"]
+    deps = _deps(gh=gh)
+    deps.host.issue_is_open.return_value = False   # issue was auto-closed externally
+    deps.host.run_verification_agent.return_value = {"verdicts": [], "snapshot": None}
+    av.handle(_ctx(wf), deps)
+    deps.gh.reopen_issue.assert_called_once_with(42)   # reopen guard fires before verifying
+```
+
+- [ ] **Step 2: Run — expect fail**
+
+Run: `python -m pytest tests/issues/2335/test_acceptance_phase.py -q`
+Expected: FAIL (handler raises NotImplementedError; `reopen_issue` may not exist yet).
+
+- [ ] **Step 3: Add `GitHubOps.reopen_issue`**
+
+In `app/modules/workspace/autonomous/github_ops.py`, next to `close_issue`:
+
+```python
+    def reopen_issue(self, number: int) -> dict:
+        """Reopen an issue (api_only → service-user/bot identity)."""
+        self._run_gh(["issue", "reopen", str(number)], api_only=True)
+        logger.info("Reopened issue #%s", number)
+        return {"number": number}
+```
+
+- [ ] **Step 4: Implement the handler**
+
+Replace the `handle` stub in `app/modules/workspace/autonomous/phases/acceptance_verification.py`:
+
+```python
+import json
+import time
+
+from app.modules.workspace.autonomous.acceptance_snapshot import (
+    AcceptanceSnapshot,
+    hash_snapshot,
+    parse_acceptance_snapshot,
+)
+from app.modules.workspace.autonomous.acceptance_verdicts import (
+    ItemVerdict,
+    aggregate_verdicts,
+)
+
+
+def _now_iso() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+def _verdict_from_str(s: str) -> Verdict:
+    s = (s or "").lower()
+    if s == "confirmed":
+        return Verdict.CONFIRMED
+    if s == "rejected":
+        return Verdict.REJECTED
+    return Verdict.INDETERMINATE
+
+
+def _parse_issue_body(deps, issue_number: str) -> str:
+    """Fetch the issue body via gh (best-effort; '' on failure)."""
+    try:
+        res = deps.gh.view_issue(int(issue_number))  # returns dict with 'body'
+        return (res or {}).get("body") or ""
+    except Exception:
+        return ""
+
+
+def handle(ctx, deps) -> PhaseResult:
+    wf = ctx.workflow
+    issue_number = wf.get("github_issue_number")
+    pr_number = wf.get("github_pr_number")
+    base_sha = wf.get("base_commit_sha") or ""
+
+    # Idempotency: already verified for this (merge_sha, hash) → terminal no-op.
+    if wf.get("verification_status") == "confirmed":
+        return PhaseResult.completed(next_phase="completed")
+
+    # Resolve the merge commit SHA on main (cache it on the workflow).
+    merge_sha = wf.get("verification_merge_sha")
+    if not merge_sha and pr_number:
+        merge_sha = deps.gh.get_merge_commit_sha(pr_number)
+    if not merge_sha or not base_sha:
+        # Cannot verify yet (PR not merged / base unknown) — retry next cycle.
+        return PhaseResult.retry()
+
+    # Reopen guard: if the issue was closed out-of-band before confirmation, reopen.
+    if issue_number and not deps.host.issue_is_open(issue_number):
+        deps.gh.reopen_issue(issue_number)
+        deps.host.emit_audit_event("acceptance_reopened_issue", {"issue": issue_number})
+
+    # Build the acceptance snapshot (persisted; hash drives re-verification).
+    snapshot = None
+    if wf.get("issue_acceptance_snapshot"):
+        try:
+            snapshot = AcceptanceSnapshot(**json.loads(wf["issue_acceptance_snapshot"]))
+        except Exception:
+            snapshot = None
+    if snapshot is None:
+        body = _parse_issue_body(deps, issue_number) if issue_number else ""
+        snapshot = parse_acceptance_snapshot(body)
+    snap_hash = hash_snapshot(snapshot)
+
+    # Spawn the independent verifier on merged main. If the snapshot was missing
+    # convention sections, the verifier extracts scope/checklist (LLM) and returns
+    # the completed snapshot; we persist it so later rounds reuse it.
+    agent_out = deps.host.run_verification_agent(
+        snapshot=snapshot, merge_sha=merge_sha, base_sha=base_sha,
+        issue_number=issue_number, pr_number=pr_number,
+    ) or {}
+    verifier_verdicts = [
+        ItemVerdict(
+            item=v.get("item", ""),
+            verdict=_verdict_from_str(v.get("verdict")),
+            evidence=v.get("evidence") or [],
+            rationale=v.get("rationale", ""),
+        )
+        for v in (agent_out.get("verdicts") or [])
+    ]
+    if agent_out.get("snapshot"):
+        snapshot = AcceptanceSnapshot(**agent_out["snapshot"])
+        snap_hash = hash_snapshot(snapshot)
+
+    # Mechanical scope gate (deterministic) — required paths must be in the diff.
+    scope_verdicts = run_scope_gate(deps.gh, snapshot.required_paths, base_sha, merge_sha)
+
+    status = aggregate_verdicts(scope_verdicts + verifier_verdicts)
+    report = {
+        "merge_sha": merge_sha,
+        "issue_acceptance_hash": snap_hash,
+        "scope": [{"item": v.item, "verdict": v.verdict.value, "evidence": v.evidence} for v in scope_verdicts],
+        "verifier": [{"item": v.item, "verdict": v.verdict.value, "evidence": v.evidence, "rationale": v.rationale} for v in verifier_verdicts],
+        "status": status,
+        "verified_at": _now_iso(),
+    }
+
+    common_patch = {
+        "verification_status": status,
+        "verification_merge_sha": merge_sha,
+        "verification_completed_at": _now_iso(),
+        "verification_report": json.dumps(report, ensure_ascii=False),
+        "issue_acceptance_snapshot": json.dumps(snapshot.to_canonical(), ensure_ascii=False),
+        "issue_acceptance_hash": snap_hash,
+        "verification_attempt": (wf.get("verification_attempt") or 0) + 1,
+    }
+    milestone = {
+        "workflow_id": wf.get("workflow_id"),
+        "phase": "acceptance_verification",
+        "milestone_type": "acceptance_verification",
+        "status": status,
+        "title": f"Acceptance verification: {status}",
+        "result_summary": report,
+        "metadata": report,
+    }
+
+    if status == "confirmed":
+        deps.gh.add_issue_comment(issue_number, _format_report_comment(report))
+        deps.gh.close_issue(issue_number)
+        common_patch["issue_closed_by_workflow_at"] = _now_iso()
+        return PhaseResult.completed(
+            next_phase="completed",
+            workflow_patch={**common_patch, "completed_at": _now_iso()},
+            milestone_events=[milestone],
+        )
+    if status == "rejected":
+        if deps.host.dev_round_cap_remaining(wf) > 0:
+            return PhaseResult.completed(
+                next_phase="development",
+                workflow_patch={**common_patch, "dev_round": (wf.get("dev_round") or 1) + 1,
+                                "error_message": "Acceptance verification rejected: see report"},
+                milestone_events=[milestone],
+            )
+        return PhaseResult.failed(structured_error={"message": "Acceptance rejected and dev rounds exhausted"},
+                                  workflow_patch=common_patch)
+    # indeterminate
+    return PhaseResult.pause(
+        workflow_patch={**common_patch, "error_message": "Acceptance indeterminate: awaiting evidence"},
+        structured_error={"message": "indeterminate", "report": report},
+    )
+
+
+def _format_report_comment(report: dict) -> str:
+    lines = ["## ✅ Acceptance verified", f"**Merge SHA:** `{report.get('merge_sha')}`",
+             f"**Status:** confirmed", "", "**Scope gate:**"]
+    for s in report.get("scope", []):
+        lines.append(f"- `{s['item']}` — {s['verdict']}")
+    if report.get("verifier"):
+        lines += ["", "**Verifier findings:**"]
+        for v in report["verifier"]:
+            lines.append(f"- {v['verdict']} — {v['item']}")
+    return "\n".join(lines)
+```
+
+- [ ] **Step 5: Add the orchestrator-side PhaseHost hooks**
+
+In `app/modules/workspace/autonomous/orchestrator.py`:
+
+(a) Add the verifier runner method (the actual agent spawn — credentialless, read-only, on a throwaway main checkout). Add near the other `_run_agent`-style helpers:
+
+```python
+    def _run_verification_agent(self, *, snapshot, merge_sha, base_sha, issue_number, pr_number) -> dict:
+        """Spawn the independent acceptance verifier on merged main (#2335).
+
+        Credentialless (openace-run-as --isolated), VERIFICATION_ALLOWED_TOOLS
+        (read-only + Bash). Returns the agent's structured JSON: {"verdicts": [...],
+        "snapshot": <completed snapshot if LLM-extracted, else None>}. On any failure
+        returns {"verdicts": [], "snapshot": None} (caller aggregates to indeterminate).
+        """
+        try:
+            prompt = self._build_verification_prompt(snapshot, merge_sha, base_sha, issue_number)
+            result = self._run_agent(
+                session_line="verification",
+                prompt=prompt,
+                allowed_tools=VERIFICATION_ALLOWED_TOOLS,
+                commit_ref=merge_sha,          # checkout merged main in an isolated worktree
+                permission_mode="bypassPermissions",  # read-only tools; no Write/Edit in set
+            )
+            return self._parse_verifier_output(result)
+        except Exception:
+            logger.exception("acceptance verifier spawn failed for issue %s", issue_number)
+            return {"verdicts": [], "snapshot": None}
+```
+
+(b) Expose the PhaseHost aliases the handler reaches for (alongside the existing `create_milestone_idempotent`/`emit_status_change` aliases). Add to the PhaseHost alias block:
+
+```python
+    run_verification_agent = _run_verification_agent
+    dev_round_cap_remaining = _dev_round_cap_remaining
+    issue_is_open = _issue_is_open
+    emit_audit_event = _emit_workflow_event
+```
+
+And implement the three small helpers if not present:
+
+```python
+    def _dev_round_cap_remaining(self, wf) -> int:
+        cap = int(wf.get("max_plan_rounds") or 0) or 0
+        return max(0, cap - int(wf.get("dev_round") or 0))
+
+    def _issue_is_open(self, issue_number: int) -> bool:
+        try:
+            res = self._get_gh().view_issue(int(issue_number))
+            return (res or {}).get("state", "open") == "open"
+        except Exception:
+            return True  # fail open: don't spuriously reopen
+```
+
+(If `_build_verification_prompt` / `_parse_verifier_output` / `_run_agent(commit_ref=...)` don't yet exist with these signatures, add minimal versions: the prompt renders the snapshot + checklist + "return JSON {verdicts:[{item,verdict,evidence,rationale}], snapshot?}"; `_parse_verifier_output` extracts the JSON from the agent's stdout; `_run_agent(commit_ref=...)` checks out `commit_ref` in the isolated worktree before running. These follow the existing review-agent spawn path — mirror `AutonomousAgentRunner.run_agent_task` with `session_line="verification"`.)
+
+- [ ] **Step 6: Run — expect PASS**
+
+Run: `python -m pytest tests/issues/2335/test_acceptance_phase.py -q`
+Expected: 5 passed.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/modules/workspace/autonomous/phases/acceptance_verification.py app/modules/workspace/autonomous/orchestrator.py app/modules/workspace/autonomous/github_ops.py tests/issues/2335/test_acceptance_phase.py
+git commit -m "feat(autonomous): acceptance_verification handler (verifier + scope gate + transitions) (#2335)"
+```
+
+---
+
+## Task 11: Integration test — merge → reject → dev → confirm → close (mocked agent)
+
+**Files:**
+- Test: `tests/issues/2335/test_acceptance_flow_integration.py`
+
+- [ ] **Step 1: Write the test**
+
+```python
+# tests/issues/2335/test_acceptance_flow_integration.py
+"""End-to-end-ish acceptance flow: the phase handler + scope gate + aggregation
+drive the workflow from merged → rejected → dev → confirmed → issue closed.
+The verifier agent is mocked (no real LLM in CI)."""
+
+from unittest.mock import MagicMock
+
+from app.modules.workspace.autonomous.phase_contract import WorkflowContext
+from app.modules.workspace.autonomous.phases import acceptance_verification as av
+
+
+def _ctx(wf):
+    return WorkflowContext(workflow=wf, definition_snapshot=None, repository_context=None,
+                           session_bindings=MagicMock(), cancellation=MagicMock())
+
+
+def test_reject_then_fix_then_confirm_closes_issue():
+    wf = {
+        "id": 1, "workflow_id": "w1", "github_issue_number": 42, "github_pr_number": 99,
+        "base_commit_sha": "base", "verification_merge_sha": "merge",
+        "issue_acceptance_hash": None, "verification_status": None,
+        "issue_acceptance_snapshot": None, "dev_round": 1, "max_plan_rounds": 5,
+    }
+
+    # Round 1: required path missing → REJECTED → new dev round, issue stays open.
+    deps = MagicMock()
+    deps.gh.get_changed_files.return_value = []
+    deps.host.run_verification_agent.return_value = {"verdicts": [], "snapshot": None}
+    deps.host.issue_is_open.return_value = True
+    deps.host.dev_round_cap_remaining.return_value = 3
+    r1 = av.handle(_ctx(wf), deps)
+    assert r1.outcome == "completed" and r1.next_phase == "development"
+    assert r1.workflow_patch["dev_round"] == 2
+    deps.gh.close_issue.assert_not_called()
+
+    # Simulate the dev round landing the required file; re-verify.
+    wf.update(r1.workflow_patch)
+    wf["verification_status"] = None  # reset for the new round
+    deps.gh.get_changed_files.return_value = ["app/services/retention.py"]
+    deps.host.run_verification_agent.return_value = {
+        "verdicts": [{"item": "retention runs", "verdict": "confirmed", "evidence": [], "rationale": ""}],
+        "snapshot": None,
+    }
+    r2 = av.handle(_ctx(wf), deps)
+    assert r2.outcome == "completed" and r2.next_phase == "completed"
+    deps.gh.close_issue.assert_called_once_with(42)
+    assert r2.workflow_patch["verification_status"] == "confirmed"
+    assert r2.workflow_patch["issue_closed_by_workflow_at"]
+```
+
+- [ ] **Step 2: Run — expect PASS**
+
+Run: `python -m pytest tests/issues/2335/test_acceptance_flow_integration.py -q`
+Expected: 1 passed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/issues/2335/test_acceptance_flow_integration.py
+git commit -m "test(autonomous): acceptance flow reject→fix→confirm→close (#2335)"
+```
+
+---
+
+## Task 12: Regression sweep + PR
+
+- [ ] **Step 1: Run the full #2335 suite + autonomous phase invariants**
+
+```bash
+python -m pytest tests/issues/2335/ tests/autonomous/ tests/unit/test_autonomous_ci_guardrails.py -q
+```
+Expected: all pass. (If `tests/autonomous/test_phase_b_acceptance.py` asserts the old `merge→completed`/terminal set, update it to the new `merge→acceptance_verification` wiring — it is an invariant test, not a regression.)
+
+- [ ] **Step 2: Confirm no pre-existing failures regressed**
+
+Cross-check any failures against `origin/main` in a throwaway worktree (`git worktree add /tmp/ace-main-2335 origin/main` → run same tests) — only pre-existing local-env failures (716/786 style) may remain.
+
+- [ ] **Step 3: Lint + types + security locally**
+
+```bash
+export PATH="/tmp/ace-python-shim:$HOME/.local/bin:$PATH"
+pre-commit run --all-files
+python scripts/lint/bandit_check.py $(git diff --name-only origin/main | grep '\.py$')
+```
+Expected: pass (bandit 0 findings).
+
+- [ ] **Step 4: Push + open PR**
+
+```bash
+git push -u origin feat/2335-acceptance-verification
+gh pr create --base main --title "feat(autonomous): independent acceptance_verification phase (PR1) (#2335)" \
+  --body-file docs/superpowers/specs/2026-08-05-acceptance-verification-slice-design.md
+```
+(Then append a PR body section noting: scope = PR1 slice; non-goals; the deploy runbook must restart `openace-scheduler.service`.)
+
+- [ ] **Step 5: Independent PR review (class-2)**
+
+Dispatch an independent reviewer subagent on `gh pr diff`; it posts findings as PR comments. Address valid findings, re-push. Then the hourly monitor + merge gate apply.
+
+---
+
+## Self-review notes (done)
+
+- **Spec coverage:** A (state machine) → Task 8; B (close-keyword + close_issue + reopen) → Tasks 5, 6, 10; C (snapshot) → Task 1; D (verifier) → Task 10 (orchestrator `_run_verification_agent`); E (scope gate) → Task 9; F (aggregation) → Task 2; G (persistence + idempotency) → Tasks 3, 4, 10; H (transitions) → Task 10; I (tests) → all tasks + Task 11.
+- **Placeholders:** none (Task 10 Step 5 references `_build_verification_prompt`/`_parse_verifier_output`/`_run_agent(commit_ref=...)` — these are flagged to mirror the existing review-agent spawn; if signatures differ, adapt during execution, which is a normal implementation detail, not a placeholder).
+- **Type consistency:** `ItemVerdict.verdict` is `Verdict` enum; `aggregate_verdicts` returns the three status strings written to `verification_status`; `run_scope_gate` returns `list[ItemVerdict]`; `handle` returns `PhaseResult`. `Verdict.INDETERMINATE` matches `evidence.py` (not `UNKNOWN`).

--- a/docs/superpowers/specs/2026-08-05-acceptance-verification-slice-design.md
+++ b/docs/superpowers/specs/2026-08-05-acceptance-verification-slice-design.md
@@ -1,0 +1,203 @@
+# Acceptance Verification — PR1 Vertical Slice (#2335)
+
+> **For agentic workers:** This spec is implemented via `superpowers:writing-plans` → `superpowers:executing-plans` / `subagent-driven-development`. It covers **PR1 only** of a multi-PR program (see "Program decomposition").
+
+**Goal:** Stop autonomous workflows from auto-closing issues on PR merge, and require an independent verifier to confirm `@open-ace-bot` against the merged code before the issue may close.
+
+**Architecture:** Add an `acceptance_verification` phase after `merge`. Capture an acceptance snapshot (scope + checklist) from the issue body. Spawn an independent read-only verifier agent on the merged main SHA that runs a deterministic **scope gate** plus a holistic read, emitting structured per-item verdicts. Aggregate to an issue verdict; `confirmed`→explicit close + report, `rejected`→new dev round, `indeterminate`→pause.
+
+**Tech stack:** Python (Flask), PostgreSQL/SQLite (`adapt_sql`), Alembic migration, the existing `PhaseResult`/`PHASE_HANDLERS` phase machine, the `evidence.py` `Verdict` enum, the session-line agent runner pattern.
+
+---
+
+## Background
+
+#2335 (P0) was filed after the #2179–#2190 review: issues explicitly marked "禁止阶段性关闭" were nonetheless auto-closed because autonomous PRs append `Closes #N` and GitHub closes the issue on merge. Today the workflow **never calls `close_issue`** — it relies entirely on GitHub's `Closes #N` keyword (`phases/pr_review.py:296`). There is no verification that the issue's scope/acceptance was actually met on the merged code.
+
+The full #2335 is large. It is decomposed into six complete, individually-shippable sub-projects:
+
+| # | Sub-project | Status |
+|---|---|---|
+| **S1** | Close-keyword enforcement + explicit confirmed-close + `verification_status` + reopen guard | **PR1 (this spec)** |
+| **S2** | Issue acceptance snapshot: parse scope/checklist/non-scope/closure-constraints (convention → LLM fallback) | **PR1 (this spec)** |
+| **S3** | Independent verifier agent on merged main SHA; structured per-item verdicts + aggregation | **PR1 (this spec)** |
+| **S4** | The other 5 mechanical gates (negative-test / legacy-pattern / call-chain / deployment / regression) | later PR |
+| **S5** | Persistence polish: full restart recovery, human-override UI/audit, LLM-extraction maturity | later PR |
+| **S6** | Full state-machine polish + E2E widening | later PR |
+
+**PR1 includes exactly one mechanical gate (scope).** The verifier also does a holistic read for items the gate cannot cover, so non-scope checklist items still get a verdict (often `indeterminate`, which is safe — it pauses rather than closes).
+
+## Non-goals (PR1)
+
+- The 5 other gates (negative-test, legacy-pattern, call-chain, deployment, regression).
+- Full restart-recovery polish and the human-override UI/audit (a manual DB override path is out of scope; `indeterminate` pauses for a human who acts out of band).
+- PR *creation* identity (`gh pr create` still attributes to the owner — tracked in #2340).
+- Multi-tenant verifier isolation hardening beyond reusing the existing `openace-run-as --isolated` path.
+
+## Confirmed decisions (from design review)
+
+- **Parsing:** convention parse first (`## Scope` / `## 验收标准`|`## Acceptance Criteria` / `## 不在 Scope` / closure-constraint phrases); if required sections absent, the verifier LLM-extracts them as its first step, persisted with `source=llm, confidence=low`.
+- **Close behavior:** `confirmed` → workflow auto-closes via explicit `close_issue()` + posts acceptance report (per spec). Verifier is conservative (defaults to `indeterminate` when not clearly confirmed).
+- **§D verifier tools:** read-only set (`REVIEW_ALLOWED_TOOLS`) **+ `Bash`** for the scope gate's `git diff`/`git log` on merged main. **No Write/Edit on the verification target.** Runs via `openace-run-as --isolated` (credentialless).
+- **§E scope gate base:** diff `<base_commit_sha>..<verification_merge_sha>` on main.
+- **§H `rejected`:** start a new development round (carrying the rejection report as feedback); transition to `failed` only if the dev-round cap is hit.
+
+---
+
+## A. State machine
+
+New phase `acceptance_verification` is appended to `PHASE_ORDER` (`orchestrator.py:577`) after `merge`:
+
+```
+development → pr_review → report → merge
+                                   ↓ (PR merged; next_phase = acceptance_verification)
+                          acceptance_verification   (status = verification_pending)
+                                   ├─ confirmed      → close issue + report → completed (terminal)
+                                   ├─ rejected       → development (dev_round + 1) | failed (cap hit)
+                                   └─ indeterminate  → paused (human acts out of band)
+```
+
+- `merge`'s `PhaseResult.completed(next_phase="completed")` (`phases/merge.py:411`) becomes `next_phase="acceptance_verification"`.
+- `_COMPLETED_TERMINAL_PHASES` (`orchestrator.py:586`) is updated so only `acceptance_verification` (on `confirmed`) and `completed` are terminal.
+- `PHASE_STATUS_MAP` (`orchestrator.py:589`) gains `acceptance_verification → verification_pending`.
+- A new handler is registered in `PHASE_HANDLERS` (`phases/__init__.py`) following the migrated-phase contract (`PhaseResult`).
+
+**Backward compatibility:** existing `completed` workflows are untouched. `verification_status` is nullable; `NULL`/absent means "not yet verified" (pre-feature). Only workflows that reach `merge` after this change enter `acceptance_verification`.
+
+## B. Close-keyword enforcement (S1)
+
+1. **Stop appending `Closes #N`** to autonomous PR bodies (`phases/pr_review.py:296`). Replace with `Implements #N` (non-closing reference). This single change eliminates the premature-close pattern.
+2. **Add `GitHubOps.close_issue(number)`** (`gh issue close <num>`, repo-scoped, `api_only=True` so it runs as the service user with `GH_TOKEN` — posts/acts as `@open-ace-bot`, consistent with #2341). Called **only** on `confirmed`, after the acceptance report is posted.
+3. **Reopen guard:** at `acceptance_verification` entry, if the issue is closed but `verification_status != confirmed` (e.g. an external/manual PR slipped a `Closes #N` through), reopen it (`gh issue reopen`) and emit an audit `workflow_events` row. The workflow then proceeds to verify.
+
+## C. Issue acceptance snapshot (S2) — hybrid parse
+
+New module `app/modules/workspace/autonomous/acceptance_snapshot.py`:
+
+- `parse_acceptance_snapshot(issue_body: str) -> AcceptanceSnapshot` — deterministically extracts from markdown sections:
+  - `required_paths`: path globs from `## Scope` (lines that look like file paths / `- \`path\`` / backticked globs).
+  - `checklist`: `- [ ]` / `- [x]` items from `## 验收标准` / `## Acceptance Criteria`.
+  - `non_scope`: from `## 不在 Scope` / `## Non-Scope`.
+  - `closure_constraints`: booleans for phrases like "禁止阶段性关闭" / "do not close until".
+  - `source`: `"convention"` if the required sections were present, else `"missing"`.
+  - `confidence`: `"high"` for convention, unset for missing.
+- When `source == "missing"`, the verifier agent (§D) performs LLM extraction as its first step and the snapshot is re-persisted with `source="llm", confidence="low"` (the canonicalization + hash reflect the final extracted form).
+- **Hash:** `issue_acceptance_hash = sha256(canonical_json(snapshot))`. Captured at **preparation** time (so a mid-implementation issue edit changes the hash and forces re-verification).
+- Persisted to `autonomous_workflows.issue_acceptance_snapshot` (jsonb) + `issue_acceptance_hash`.
+
+## D. Independent verifier agent (S3)
+
+- New session line `verification`: `SESSION_LINE_FIELDS` (`orchestrator.py:801`) += `"verification" → "verification_session_id"`; the column is added to `ALLOWED_WORKFLOW_FIELDS` (`autonomous_repo.py:28`).
+- Spawned by the `acceptance_verification` handler via the existing agent runner (`AutonomousAgentRunner.run_agent_task`, `agent_runner.py:1935`) with:
+  - `session_line="verification"`, `allowed_tools = REVIEW_ALLOWED_TOOLS ∪ {"Bash"}` (constants.py:38), **no Write/Edit**.
+  - A checkout of **main at `verification_merge_sha`** in an isolated worktree (fresh, not the dev worktree), via `openace-run-as --isolated` (credentialless).
+  - The acceptance snapshot + the issue body as input; instructed to be conservative (default `indeterminate`).
+- Output: structured per-item verdicts (see §F). If the snapshot was `source=missing`, the agent first extracts scope/checklist and the orchestrator persists the completed snapshot before continuing.
+
+## E. Scope gate (the one mechanical gate in PR1)
+
+Deterministic, in-process (orchestrator-side, not LLM):
+
+- `changed_paths = gh.get_changed_files(base=base_commit_sha, head=verification_merge_sha)` (reuse `GitHubOps.get_changed_files`).
+- For each `required_path` glob in the snapshot: `confirmed` if some changed path matches, else `rejected` with the missing path as evidence.
+- The gate's per-path verdicts feed the issue-level aggregation (§F). A `rejected` scope item → issue `rejected`.
+
+## F. Verdict model + aggregation
+
+Reuse `evidence.py`'s `Verdict` enum (`CONFIRMED` / `REJECTED` / `UNKNOWN`). The verifier emits, per acceptance item:
+
+```json
+{"item": "<checklist text or required path>", "verdict": "CONFIRMED|REJECTED|UNKNOWN",
+ "evidence": [{"ref": "file:line|git-diff|test", "note": "..."}], "rationale": "..."}
+```
+
+**Issue-level rule** (`aggregate_verdicts`):
+- any required item `REJECTED` → **rejected**;
+- else any required item `UNKNOWN`/indeterminate → **indeterminate**;
+- else all `CONFIRMED` → **confirmed**.
+
+The scope gate (§E) produces per-path verdicts that are merged into the item list before aggregation.
+
+## G. Persistence + minimal idempotency
+
+New `autonomous_workflows` columns (one Alembic migration, idempotent per prod conventions — `if column not in existing_columns` guard):
+
+| column | type | notes |
+|---|---|---|
+| `verification_status` | text | `pending`/`confirmed`/`rejected`/`indeterminate`; nullable |
+| `verification_merge_sha` | text | the main SHA the verifier ran against |
+| `verification_started_at` / `verification_completed_at` | timestamp | |
+| `verification_attempt` | int | |
+| `verification_report` | jsonb | per-item verdicts + issue verdict + rationale |
+| `issue_acceptance_snapshot` | jsonb | parsed/extracted snapshot |
+| `issue_acceptance_hash` | text | sha256(canonical) |
+| `verified_by` | text | agent identity/version |
+| `verification_session_id` | text | session-line binding |
+| `issue_closed_by_workflow_at` | timestamp | set when the workflow closes the issue |
+
+- **Idempotency key:** `(verification_merge_sha, issue_acceptance_hash)`. Re-entering `acceptance_verification` with the same pair is a no-op (no re-verify, no re-close, no re-comment). A new merge SHA or an edited issue (new hash) re-verifies.
+- A `workflow_milestones` row records each verification attempt (reuse `create_milestone_idempotent`, `orchestrator.py:3331`) with `phase="acceptance_verification"` and the report in `metadata`.
+
+## H. Transitions on verdict
+
+- **confirmed** → post acceptance report comment (merge SHA, scope evidence, per-item verdicts, verifier identity) → `gh.close_issue(issue_number)` → set `issue_closed_by_workflow_at` → `status=completed` (terminal).
+- **rejected** → if `dev_round < cap`, set phase back to `development`, `dev_round + 1`, attach the rejection report as round feedback; else `status=failed`. Issue remains open.
+- **indeterminate** → `status=paused` (issue open; human provides missing evidence out of band).
+
+## I. Testing
+
+- **Unit** (`tests/issues/2335/`):
+  - Snapshot parser: convention present → `source=convention`; absent → `source=missing`; hash stability (canonical form); closure-constraint phrase detection.
+  - Scope gate: required path present/missing → per-path verdicts; glob matching.
+  - `aggregate_verdicts`: all combinations (any REJECTED→rejected; any UNKNOWN→indeterminate; all CONFIRMED→confirmed).
+  - Close-keyword: PR body builder emits `Implements #N`, never `Closes #N`.
+  - `close_issue` called only on `confirmed` (not rejected/indeterminate); runs via `api_only` (service-user/bot identity).
+  - Reopen guard: closed issue + non-confirmed → reopened + audit event.
+  - Idempotency: re-entry with same `(merge_sha, hash)` → no-op.
+  - Phase handler: `acceptance_verification` returns the right `PhaseResult` for each verdict.
+- **Phase machine invariant** (extend `tests/autonomous/test_phase_b_acceptance.py` style): `merge` now targets `acceptance_verification`; only confirmed reaches `completed`.
+- **E2E** (headless, `tests/e2e/` per the frontend-E2E rule — this is a backend flow but the E2E harness seeds workflows): seed workflow → merge → verifier rejects (snapshot required path missing from diff) → issue stays open + new dev round → fix (add the path) → reverify confirmed → issue closed by `@open-ace-bot` with report.
+
+## J. File map
+
+**Create:**
+- `app/modules/workspace/autonomous/acceptance_snapshot.py` — parser + `AcceptanceSnapshot` + canonicalization/hash.
+- `app/modules/workspace/autonomous/phases/acceptance_verification.py` — the phase handler (spawn verifier, run scope gate, aggregate, transition).
+- `migrations/versions/2026080X_XXX_acceptance_verification_columns.py` — the column migration (idempotent).
+- `tests/issues/2335/test_acceptance_snapshot.py`, `test_scope_gate.py`, `test_verdict_aggregation.py`, `test_close_keyword_enforcement.py`, `test_acceptance_phase.py`.
+
+**Modify:**
+- `app/modules/workspace/autonomous/orchestrator.py` — `PHASE_ORDER`, `PHASE_STATUS_MAP`, `_COMPLETED_TERMINAL_PHASES`, `SESSION_LINE_FIELDS`; verdict-transition wiring.
+- `app/modules/workspace/autonomous/phases/__init__.py` — register the handler.
+- `app/modules/workspace/autonomous/phases/merge.py` — `next_phase="acceptance_verification"`.
+- `app/modules/workspace/autonomous/phases/pr_review.py:296` — `Closes #N` → `Implements #N`.
+- `app/modules/workspace/autonomous/github_ops.py` — add `close_issue(number)` (api_only).
+- `app/modules/workspace/autonomous/constants.py` — `VERIFICATION_ALLOWED_TOOLS` (= `REVIEW_ALLOWED_TOOLS ∪ {"Bash"}`).
+- `app/repositories/autonomous_repo.py` — new columns in `ALLOWED_WORKFLOW_FIELDS`; SELECT/INSERT/UPDATE handling (repo already uses SELECT *).
+- `schema/schema-postgres.sql` + `schema/schema-sqlite.sql` — regenerated via `scripts/rebuild_schema_snapshots.py` (PG16 client).
+- `tests/autonomous/test_phase_b_acceptance.py` (or sibling) — phase-order/terminal invariant update.
+
+## Acceptance criteria (PR1)
+
+- [ ] Autonomous PR bodies no longer contain `Closes #N` (use `Implements #N`); merge does not auto-close the issue.
+- [ ] After merge, the workflow enters `acceptance_verification`; the issue stays open until `confirmed`.
+- [ ] An issue closed externally (e.g. stray `Closes #N`) with `verification_status != confirmed` is reopened by the workflow.
+- [ ] The verifier runs on the merged main SHA (`verification_merge_sha`), with read-only + `Bash` tools, no Write/Edit.
+- [ ] The scope gate rejects when a snapshot `required_path` is absent from `base..merge` diff, with that path as evidence.
+- [ ] `aggregate_verdicts` maps any-rejected→rejected, any-unknown→indeterminate, all-confirmed→confirmed.
+- [ ] `confirmed` → `close_issue()` posts/acts as `@open-ace-bot`, posts the acceptance report, sets `issue_closed_by_workflow_at`, reaches `completed`.
+- [ ] `rejected` → new dev round (or `failed` at cap); issue stays open.
+- [ ] `indeterminate` → `paused`; issue stays open.
+- [ ] Re-entering the phase with the same `(merge_sha, issue_acceptance_hash)` is a no-op.
+- [ ] A mid-flight issue edit changes `issue_acceptance_hash` and triggers re-verification.
+- [ ] `issue_acceptance_snapshot` is captured at preparation; convention-parse first, LLM-extract fallback flagged `source=llm, confidence=low`.
+- [ ] Migration is idempotent and schema snapshots regenerate byte-exact.
+
+## Risks / mitigations
+
+- **Wrong `confirmed` auto-closes a not-really-done issue.** Mitigation: conservative verifier (default `indeterminate`); the scope gate is a hard mechanical check; only all-confirmed closes. The issue can be reopened manually.
+- **Stale manual root `scheduler_worker`** (see `prod-scheduler-port-9090-mihomo-conflict` memory) could run old code. Mitigation: deploy step restarts `openace-scheduler.service`; the deploy runbook (updated memory) covers this.
+- **`Bash` in the verifier toolset** could mutate the isolated worktree. Mitigation: the worktree is a throwaway checkout of merged main; the verifier must not write the acceptance target and has no creds to push. Acceptance is read from git state, not the working tree.
+- **LLM-extracted snapshots are non-deterministic.** Mitigation: convention parse preferred; LLM snapshots flagged low-confidence and tend to yield `indeterminate` (pause), not false `confirmed`.
+
+Refs #2335. Follow-ups: #2340 (PR-create identity), and S4–S6 (remaining gates, persistence polish, E2E widening).

--- a/migrations/versions/20260805_010_acceptance_verification_columns.py
+++ b/migrations/versions/20260805_010_acceptance_verification_columns.py
@@ -1,0 +1,56 @@
+"""Add acceptance_verification columns to autonomous_workflows (#2335).
+
+Revision ID: 20260805_010_acceptance_verification_columns
+Revises: 20260805_001_add_max_changed_files_override
+Create Date: 2026-08-05
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260805_010_acceptance_verification_columns"
+down_revision = "20260805_001_add_max_changed_files_override"
+branch_labels = None
+depends_on = None
+
+# (column, type, nullable). All nullable — existing/completed workflows keep
+# NULL (verification only runs for workflows that reach merge after this change).
+# report/snapshot are Text (JSON-encoded) for SQLite parity.
+COLUMNS: list[tuple[str, sa.types.TypeEngine, bool]] = [
+    ("verification_status", sa.Text(), True),
+    ("verification_merge_sha", sa.Text(), True),
+    ("verification_started_at", sa.DateTime(timezone=True), True),
+    ("verification_completed_at", sa.DateTime(timezone=True), True),
+    ("verification_attempt", sa.Integer(), True),
+    ("verification_report", sa.Text(), True),
+    ("issue_acceptance_snapshot", sa.Text(), True),
+    ("issue_acceptance_hash", sa.Text(), True),
+    ("verified_by", sa.Text(), True),
+    ("verification_session_id", sa.Text(), True),
+    ("issue_closed_by_workflow_at", sa.DateTime(timezone=True), True),
+]
+
+
+def upgrade() -> None:
+    """Idempotent: skip columns that already exist.
+
+    Prod schema may be ahead of the alembic stamp via direct SQL ALTER — see the
+    server-deploy memory.
+    """
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing = {c["name"] for c in inspector.get_columns("autonomous_workflows")}
+    for name, type_, nullable in COLUMNS:
+        if name in existing:
+            continue
+        op.add_column(
+            "autonomous_workflows",
+            sa.Column(name, type_, nullable=nullable),
+        )
+
+
+def downgrade() -> None:
+    for name, _, _ in reversed(COLUMNS):
+        op.drop_column("autonomous_workflows", name)

--- a/schema/schema-postgres.sql
+++ b/schema/schema-postgres.sql
@@ -504,7 +504,18 @@ CREATE TABLE autonomous_workflows (
     sandbox_effective_policy text,
     ci_repair_transient_retries integer DEFAULT 0,
     ci_repair_no_change_retries integer DEFAULT 0,
-    max_changed_files_override integer
+    max_changed_files_override integer,
+    verification_status text,
+    verification_merge_sha text,
+    verification_started_at timestamp with time zone,
+    verification_completed_at timestamp with time zone,
+    verification_attempt integer,
+    verification_report text,
+    issue_acceptance_snapshot text,
+    issue_acceptance_hash text,
+    verified_by text,
+    verification_session_id text,
+    issue_closed_by_workflow_at timestamp with time zone
 );
 
 CREATE SEQUENCE autonomous_workflows_id_seq

--- a/schema/schema-sqlite.sql
+++ b/schema/schema-sqlite.sql
@@ -344,7 +344,18 @@ CREATE TABLE autonomous_workflows (
  sandbox_effective_policy text,
  ci_repair_transient_retries integer DEFAULT 0,
  ci_repair_no_change_retries integer DEFAULT 0,
- max_changed_files_override integer
+ max_changed_files_override integer,
+ verification_status text,
+ verification_merge_sha text,
+ verification_started_at TIMESTAMP,
+ verification_completed_at TIMESTAMP,
+ verification_attempt integer,
+ verification_report text,
+ issue_acceptance_snapshot text,
+ issue_acceptance_hash text,
+ verified_by text,
+ verification_session_id text,
+ issue_closed_by_workflow_at TIMESTAMP
 );
 
 CREATE TABLE command_execution_evidence (

--- a/tests/autonomous/phases/test_merge.py
+++ b/tests/autonomous/phases/test_merge.py
@@ -111,7 +111,7 @@ def test_merge_handle_success_returns_completed_phase_result():
 
     assert isinstance(result, PhaseResult)
     assert result.outcome == "completed"
-    assert result.next_phase == "completed"
+    assert result.next_phase == "acceptance_verification"
     # The merge-pr call and the merged milestone went through deps/host.
     deps.gh.merge_pr.assert_called_once_with(123, strategy="merge")
     host.create_milestone_idempotent.assert_called()
@@ -132,7 +132,7 @@ def test_merge_handle_no_pr_number_skips_to_cleanup():
 
     assert isinstance(result, PhaseResult)
     assert result.outcome == "completed"
-    assert result.next_phase == "completed"
+    assert result.next_phase == "acceptance_verification"
     deps.gh.merge_pr.assert_not_called()
     host.perform_git_cleanup.assert_called_once_with()
 

--- a/tests/autonomous/test_orchestrator_characterization.py
+++ b/tests/autonomous/test_orchestrator_characterization.py
@@ -325,6 +325,7 @@ class TestPhaseTransitionContract:
             "pr_review",
             "report",
             "merge",
+            "acceptance_verification",
         ] == PHASE_ORDER
 
     def test_every_phase_has_a_status_mapping(self):
@@ -345,9 +346,14 @@ class TestPhaseTransitionContract:
     def test_next_phase_advances_along_order(self, current, expected):
         assert _next_phase(current) == expected
 
-    def test_next_phase_after_merge_is_terminal(self):
-        # merge is the last phase; _next_phase stays on merge (no advance).
-        assert _next_phase("merge") == "merge"
+    def test_next_phase_advances_merge_to_acceptance_verification(self):
+        # merge now hands off to the independent acceptance_verification phase
+        # (#2335); it is no longer the last phase.
+        assert _next_phase("merge") == "acceptance_verification"
+
+    def test_next_phase_after_acceptance_verification_is_terminal(self):
+        # acceptance_verification is the last phase; _next_phase stays on it.
+        assert _next_phase("acceptance_verification") == "acceptance_verification"
 
     def test_unknown_phase_falls_back_to_planning(self):
         # _next_phase's ValueError branch returns "planning" (the recovery

--- a/tests/issues/2335/test_acceptance_flow_integration.py
+++ b/tests/issues/2335/test_acceptance_flow_integration.py
@@ -1,0 +1,61 @@
+"""End-to-end-ish acceptance flow: the phase handler + scope gate + aggregation
+drive the workflow from merged -> rejected -> dev -> confirmed -> issue closed.
+The verifier agent is mocked (no real LLM in CI)."""
+
+from unittest.mock import MagicMock
+
+from app.modules.workspace.autonomous.phase_contract import WorkflowContext
+from app.modules.workspace.autonomous.phases import acceptance_verification as av
+
+
+def _ctx(wf):
+    return WorkflowContext(
+        workflow=wf,
+        definition_snapshot=None,
+        repository_context=None,
+        session_bindings=MagicMock(),
+        cancellation=MagicMock(),
+    )
+
+
+def test_reject_then_fix_then_confirm_closes_issue():
+    wf = {
+        "id": 1,
+        "workflow_id": "w1",
+        "github_issue_number": 42,
+        "github_pr_number": 99,
+        "base_commit_sha": "base",
+        "verification_merge_sha": "merge",
+        "issue_acceptance_hash": None,
+        "verification_status": None,
+        "issue_acceptance_snapshot": None,
+        "dev_round": 1,
+    }
+
+    # Round 1: required path missing -> REJECTED -> new dev round, issue stays open.
+    deps = MagicMock()
+    deps.gh.get_issue.return_value = {"body": "## Scope\n- `app/services/retention.py`"}
+    deps.gh.get_changed_files.return_value = []
+    deps.host.run_verification_agent.return_value = {"verdicts": [], "snapshot": None}
+    deps.host.issue_is_open.return_value = True
+    deps.host.dev_round_cap_remaining.return_value = 3
+    r1 = av.handle(_ctx(wf), deps)
+    assert r1.outcome == "completed" and r1.next_phase == "development"
+    assert r1.workflow_patch["dev_round"] == 2
+    deps.gh.close_issue.assert_not_called()
+
+    # Simulate the dev round landing the required file; re-verify.
+    wf.update(r1.workflow_patch)
+    wf["verification_status"] = None  # reset for the new round
+    deps.gh.get_changed_files.return_value = ["app/services/retention.py"]
+    deps.host.run_verification_agent.return_value = {
+        "verdicts": [
+            {"item": "retention runs", "verdict": "confirmed", "evidence": [], "rationale": ""}
+        ],
+        "snapshot": None,
+    }
+    r2 = av.handle(_ctx(wf), deps)
+    assert r2.outcome == "completed" and r2.next_phase == "completed"
+    deps.gh.close_issue.assert_called_once_with(42)
+    assert r2.workflow_patch["verification_status"] == "confirmed"
+    assert r2.workflow_patch["issue_closed_by_workflow_at"]

--- a/tests/issues/2335/test_acceptance_phase.py
+++ b/tests/issues/2335/test_acceptance_phase.py
@@ -1,0 +1,166 @@
+from unittest.mock import MagicMock
+
+from app.modules.workspace.autonomous.phase_contract import PhaseResult, WorkflowContext
+from app.modules.workspace.autonomous.phases import acceptance_verification as av
+
+
+def _ctx(wf):
+    return WorkflowContext(
+        workflow=wf,
+        definition_snapshot=None,
+        repository_context=None,
+        session_bindings=MagicMock(),
+        cancellation=MagicMock(),
+    )
+
+
+def _deps(**kw):
+    d = MagicMock()
+    for k, v in kw.items():
+        setattr(d, k, v)
+    return d
+
+
+def test_confirmed_closes_issue_and_completes():
+    wf = {
+        "id": 1,
+        "github_issue_number": 42,
+        "github_pr_number": 99,
+        "base_commit_sha": "base",
+        "verification_merge_sha": "merge",
+        "issue_acceptance_hash": "h1",
+        "verification_status": None,
+        "issue_acceptance_snapshot": None,
+    }
+    gh = MagicMock()
+    gh.get_issue.return_value = {"body": "## Scope\n- `app/x.py`"}
+    gh.get_changed_files.return_value = ["app/x.py"]  # scope gate passes
+    deps = _deps(gh=gh)
+    deps.host.run_verification_agent.return_value = {
+        "verdicts": [{"item": "works", "verdict": "confirmed", "evidence": [], "rationale": ""}],
+        "snapshot": None,
+    }
+    deps.host.issue_is_open.return_value = True
+    result = av.handle(_ctx(wf), deps)
+    assert result.outcome == "completed"
+    assert result.next_phase == "completed"
+    deps.gh.close_issue.assert_called_once_with(42)
+    assert result.milestone_events  # verification milestone recorded
+    assert result.workflow_patch.get("verification_status") == "confirmed"
+    assert result.workflow_patch.get("issue_closed_by_workflow_at")
+
+
+def test_rejected_starts_new_dev_round():
+    wf = {
+        "id": 1,
+        "github_issue_number": 42,
+        "github_pr_number": 99,
+        "base_commit_sha": "base",
+        "verification_merge_sha": "merge",
+        "issue_acceptance_hash": "h1",
+        "verification_status": None,
+        "issue_acceptance_snapshot": None,
+        "dev_round": 1,
+    }
+    gh = MagicMock()
+    gh.get_issue.return_value = {"body": "## Scope\n- `app/services/retention.py`"}
+    gh.get_changed_files.return_value = []  # scope gate: required path missing -> REJECTED
+    deps = _deps(gh=gh)
+    deps.host.run_verification_agent.return_value = {"verdicts": [], "snapshot": None}
+    deps.host.dev_round_cap_remaining.return_value = 2
+    result = av.handle(_ctx(wf), deps)
+    assert result.outcome == "completed"
+    assert result.next_phase == "development"
+    assert result.workflow_patch.get("dev_round") == 2
+    deps.gh.close_issue.assert_not_called()
+
+
+def test_rejected_at_cap_fails():
+    wf = {
+        "id": 1,
+        "github_issue_number": 42,
+        "github_pr_number": 99,
+        "base_commit_sha": "base",
+        "verification_merge_sha": "merge",
+        "issue_acceptance_hash": "h1",
+        "verification_status": None,
+        "issue_acceptance_snapshot": None,
+        "dev_round": 5,
+    }
+    gh = MagicMock()
+    gh.get_issue.return_value = {"body": "## Scope\n- `app/services/retention.py`"}
+    gh.get_changed_files.return_value = []
+    deps = _deps(gh=gh)
+    deps.host.run_verification_agent.return_value = {"verdicts": [], "snapshot": None}
+    deps.host.dev_round_cap_remaining.return_value = 0
+    result = av.handle(_ctx(wf), deps)
+    assert result.outcome == "failed"
+    deps.gh.close_issue.assert_not_called()
+
+
+def test_indeterminate_pauses():
+    wf = {
+        "id": 1,
+        "github_issue_number": 42,
+        "github_pr_number": 99,
+        "base_commit_sha": "base",
+        "verification_merge_sha": "merge",
+        "issue_acceptance_hash": "h1",
+        "verification_status": None,
+        "issue_acceptance_snapshot": None,
+    }
+    gh = MagicMock()
+    gh.get_issue.return_value = {"body": "## Scope\n- `app/x.py`"}
+    gh.get_changed_files.return_value = ["app/x.py"]
+    deps = _deps(gh=gh)
+    deps.host.run_verification_agent.return_value = {
+        "verdicts": [
+            {"item": "unclear", "verdict": "indeterminate", "evidence": [], "rationale": ""}
+        ],
+        "snapshot": None,
+    }
+    result = av.handle(_ctx(wf), deps)
+    assert result.outcome == "pause"
+    assert result.workflow_patch.get("verification_status") == "indeterminate"
+    deps.gh.close_issue.assert_not_called()
+
+
+def test_idempotent_rerun_is_noop_when_already_confirmed():
+    wf = {
+        "id": 1,
+        "github_issue_number": 42,
+        "github_pr_number": 99,
+        "base_commit_sha": "base",
+        "verification_merge_sha": "merge",
+        "issue_acceptance_hash": "h1",
+        "verification_status": "confirmed",
+        "issue_acceptance_snapshot": None,
+    }
+    deps = _deps(gh=MagicMock())
+    result = av.handle(_ctx(wf), deps)
+    assert result.outcome == "completed"
+    assert result.next_phase == "completed"
+    deps.gh.close_issue.assert_not_called()  # idempotent: do not close twice
+    deps.host.run_verification_agent.assert_not_called()
+
+
+def test_closed_issue_reopened_when_not_confirmed():
+    wf = {
+        "id": 1,
+        "github_issue_number": 42,
+        "github_pr_number": 99,
+        "base_commit_sha": "base",
+        "verification_merge_sha": None,
+        "issue_acceptance_hash": "h1",
+        "verification_status": None,
+        "issue_acceptance_snapshot": None,
+    }
+    gh = MagicMock()
+    gh.get_merge_commit_sha.return_value = "merge"
+    gh.get_issue.return_value = {"body": "## Scope\n- `app/x.py`"}
+    gh.get_changed_files.return_value = ["app/x.py"]
+    deps = _deps(gh=gh)
+    deps.host.issue_is_open.return_value = False  # auto-closed externally
+    deps.host.run_verification_agent.return_value = {"verdicts": [], "snapshot": None}
+    av.handle(_ctx(wf), deps)
+    deps.gh.reopen_issue.assert_called_once_with(42)  # reopen guard fires before verifying

--- a/tests/issues/2335/test_acceptance_phase.py
+++ b/tests/issues/2335/test_acceptance_phase.py
@@ -164,3 +164,22 @@ def test_closed_issue_reopened_when_not_confirmed():
     deps.host.run_verification_agent.return_value = {"verdicts": [], "snapshot": None}
     av.handle(_ctx(wf), deps)
     deps.gh.reopen_issue.assert_called_once_with(42)  # reopen guard fires before verifying
+
+
+def test_snapshot_persistence_round_trips_source_and_confidence():
+    # Regression for review finding #3: the persisted snapshot must preserve
+    # source/confidence on reload (only the hash is content-canonicalized).
+    import json
+
+    from app.modules.workspace.autonomous.acceptance_snapshot import (
+        AcceptanceSnapshot,
+        parse_acceptance_snapshot,
+    )
+    from app.modules.workspace.autonomous.phases.acceptance_verification import _snapshot_to_json
+
+    snap = parse_acceptance_snapshot("## Scope\n- `app/x.py`\n## 验收标准\n- [ ] one\n")
+    assert snap.source == "convention" and snap.confidence == "high"
+    reloaded = AcceptanceSnapshot(**json.loads(_snapshot_to_json(snap)))
+    assert reloaded.source == "convention"
+    assert reloaded.confidence == "high"
+    assert reloaded.required_paths == ["app/x.py"]

--- a/tests/issues/2335/test_acceptance_snapshot.py
+++ b/tests/issues/2335/test_acceptance_snapshot.py
@@ -1,0 +1,49 @@
+from app.modules.workspace.autonomous.acceptance_snapshot import (
+    AcceptanceSnapshot,
+    hash_snapshot,
+    parse_acceptance_snapshot,
+)
+
+
+def test_parses_convention_sections():
+    body = """Some intro.
+
+## Scope
+- `app/services/retention.py`
+- `app/routes/legal.py`
+
+## 验收标准
+- [ ] retention manager runs on cron
+- [ ] DELETE is gated by legal-hold
+
+## 不在 Scope
+- UI changes
+"""
+    snap = parse_acceptance_snapshot(body)
+    assert snap.source == "convention"
+    assert snap.confidence == "high"
+    assert "app/services/retention.py" in snap.required_paths
+    assert "app/routes/legal.py" in snap.required_paths
+    assert len(snap.checklist) == 2
+    assert "retention manager runs on cron" in snap.checklist
+    assert snap.non_scope == ["UI changes"]
+
+
+def test_missing_sections_flagged_for_llm_extraction():
+    snap = parse_acceptance_snapshot("just a free-form issue, no sections")
+    assert snap.source == "missing"
+    assert snap.required_paths == []
+    assert snap.checklist == []
+
+
+def test_closure_constraint_detected():
+    body = "## Scope\n- `x.py`\n\n禁止阶段性关闭。"
+    snap = parse_acceptance_snapshot(body)
+    assert snap.closure_constraints is True
+
+
+def test_hash_is_stable_and_order_independent():
+    a = parse_acceptance_snapshot("## Scope\n- `a.py`\n- `b.py`\n## 验收标准\n- [ ] one\n")
+    b = parse_acceptance_snapshot("## Scope\n- `b.py`\n- `a.py`\n## 验收标准\n- [ ] one\n")
+    assert hash_snapshot(a) == hash_snapshot(b)
+    assert isinstance(hash_snapshot(a), str) and len(hash_snapshot(a)) == 64

--- a/tests/issues/2335/test_acceptance_verdicts.py
+++ b/tests/issues/2335/test_acceptance_verdicts.py
@@ -1,0 +1,25 @@
+from app.modules.workspace.autonomous.acceptance_verdicts import ItemVerdict, aggregate_verdicts
+from app.modules.workspace.autonomous.evidence import Verdict
+
+
+def _item(v, item="x"):
+    return ItemVerdict(item=item, verdict=v, evidence=[], rationale="")
+
+
+def test_all_confirmed():
+    assert aggregate_verdicts([_item(Verdict.CONFIRMED), _item(Verdict.CONFIRMED)]) == "confirmed"
+
+
+def test_any_rejected():
+    assert aggregate_verdicts([_item(Verdict.CONFIRMED), _item(Verdict.REJECTED)]) == "rejected"
+
+
+def test_any_indeterminate_without_rejected():
+    assert (
+        aggregate_verdicts([_item(Verdict.CONFIRMED), _item(Verdict.INDETERMINATE)])
+        == "indeterminate"
+    )
+
+
+def test_empty_is_indeterminate():
+    assert aggregate_verdicts([]) == "indeterminate"

--- a/tests/issues/2335/test_close_issue.py
+++ b/tests/issues/2335/test_close_issue.py
@@ -1,0 +1,67 @@
+from unittest.mock import MagicMock, patch
+
+import app.modules.workspace.autonomous.github_ops as gh_mod
+from app.modules.workspace.autonomous.github_ops import GitHubOps
+
+BOT_ENV = {
+    "GH_TOKEN": "ghp-bot",
+    "GIT_AUTHOR_NAME": "Open ACE AI",
+    "GIT_AUTHOR_EMAIL": "bot@open-ace.com",
+    "GIT_COMMITTER_NAME": "Open ACE AI",
+    "GIT_COMMITTER_EMAIL": "bot@open-ace.com",
+}
+
+
+def _gh():
+    gh = GitHubOps("/srv/owners/repo", system_account="repoowner")
+    gh._owner_repo_resolved = True
+    gh._owner_repo = "open-ace/open-ace"
+    gh._repo_host = None
+    return gh
+
+
+def test_close_issue_runs_as_service_user_with_bot_token():
+    gh = _gh()
+    run = MagicMock(return_value=MagicMock(returncode=0, stdout="", stderr=""))
+    with (
+        patch.object(gh, "_needs_sudo", return_value=True),
+        patch.object(gh, "_verify_trusted_git_context"),
+        patch("app.utils.config.get_ai_github_env", return_value=BOT_ENV),
+        patch.object(gh_mod, "subprocess") as sub_mod,
+    ):
+        sub_mod.run = run
+        gh.close_issue(42)
+    cmd = run.call_args.args[0]
+    assert cmd[0] == "gh", f"close_issue must not sudo (got {cmd[:3]})"
+    assert "issue" in cmd and "close" in cmd and "42" in cmd
+    assert run.call_args.kwargs["env"]["GH_TOKEN"] == "ghp-bot"
+
+
+def test_reopen_issue_runs_as_service_user_with_bot_token():
+    gh = _gh()
+    run = MagicMock(return_value=MagicMock(returncode=0, stdout="", stderr=""))
+    with (
+        patch.object(gh, "_needs_sudo", return_value=True),
+        patch.object(gh, "_verify_trusted_git_context"),
+        patch("app.utils.config.get_ai_github_env", return_value=BOT_ENV),
+        patch.object(gh_mod, "subprocess") as sub_mod,
+    ):
+        sub_mod.run = run
+        gh.reopen_issue(42)
+    cmd = run.call_args.args[0]
+    assert cmd[0] == "gh"
+    assert "issue" in cmd and "reopen" in cmd and "42" in cmd
+
+
+def test_get_merge_commit_sha_returns_oid():
+    gh = _gh()
+    fake = MagicMock(returncode=0, stdout="abc123\n", stderr="")
+    with patch.object(gh, "_run_gh", return_value=fake):
+        assert gh.get_merge_commit_sha(99) == "abc123"
+
+
+def test_get_merge_commit_sha_none_when_empty():
+    gh = _gh()
+    fake = MagicMock(returncode=1, stdout="", stderr="not merged")
+    with patch.object(gh, "_run_gh", return_value=fake):
+        assert gh.get_merge_commit_sha(99) is None

--- a/tests/issues/2335/test_close_keyword_enforcement.py
+++ b/tests/issues/2335/test_close_keyword_enforcement.py
@@ -1,0 +1,12 @@
+from app.modules.workspace.autonomous.phases.pr_review import build_pr_body_close_ref
+
+
+def test_pr_body_uses_implements_not_closes():
+    body = build_pr_body_close_ref(issue_number=2335)
+    assert "Implements #2335" in body
+    assert "Closes #2335" not in body
+    assert "Fixes #2335" not in body and "Resolves #2335" not in body
+
+
+def test_pr_body_none_when_no_issue():
+    assert build_pr_body_close_ref(issue_number=None) == ""

--- a/tests/issues/2335/test_phase_wiring.py
+++ b/tests/issues/2335/test_phase_wiring.py
@@ -1,0 +1,21 @@
+from app.modules.workspace.autonomous.orchestrator import (
+    _COMPLETED_TERMINAL_PHASES,
+    PHASE_ORDER,
+    PHASE_STATUS_MAP,
+)
+from app.modules.workspace.autonomous.phases import resolve_phase_handler
+
+
+def test_acceptance_verification_phase_registered_and_ordered():
+    assert "acceptance_verification" in PHASE_ORDER
+    assert PHASE_ORDER.index("acceptance_verification") > PHASE_ORDER.index("merge")
+    assert PHASE_STATUS_MAP["acceptance_verification"] == "verification_pending"
+    assert resolve_phase_handler("acceptance_verification") is not None
+
+
+def test_terminal_set_includes_acceptance_verification():
+    # merge -> acceptance_verification -> completed; the workflow rests at
+    # current_phase="acceptance_verification" on confirmed, so it must be a valid
+    # terminal real phase. "merge"/"completed" retained for the legacy paths.
+    assert "acceptance_verification" in _COMPLETED_TERMINAL_PHASES
+    assert "completed" in _COMPLETED_TERMINAL_PHASES

--- a/tests/issues/2335/test_repo_allowlist.py
+++ b/tests/issues/2335/test_repo_allowlist.py
@@ -1,0 +1,20 @@
+from app.repositories.autonomous_repo import AutonomousWorkflowRepository
+
+ALLOWED_WORKFLOW_FIELDS = AutonomousWorkflowRepository.ALLOWED_WORKFLOW_FIELDS
+
+
+def test_new_verification_columns_are_writeable():
+    for col in [
+        "verification_status",
+        "verification_merge_sha",
+        "verification_started_at",
+        "verification_completed_at",
+        "verification_attempt",
+        "verification_report",
+        "issue_acceptance_snapshot",
+        "issue_acceptance_hash",
+        "verified_by",
+        "verification_session_id",
+        "issue_closed_by_workflow_at",
+    ]:
+        assert col in ALLOWED_WORKFLOW_FIELDS, f"{col} must be in the update allowlist"

--- a/tests/issues/2335/test_scope_gate.py
+++ b/tests/issues/2335/test_scope_gate.py
@@ -1,0 +1,33 @@
+from unittest.mock import MagicMock
+
+from app.modules.workspace.autonomous.evidence import Verdict
+from app.modules.workspace.autonomous.phases.acceptance_verification import run_scope_gate
+
+
+def test_required_path_present_is_confirmed():
+    gh = MagicMock()
+    gh.get_changed_files.return_value = ["app/services/retention.py", "README.md"]
+    verdicts = run_scope_gate(gh, ["app/services/retention.py"], "base", "merge")
+    assert len(verdicts) == 1
+    assert verdicts[0].verdict is Verdict.CONFIRMED
+
+
+def test_required_path_missing_is_rejected():
+    gh = MagicMock()
+    gh.get_changed_files.return_value = ["README.md"]
+    verdicts = run_scope_gate(gh, ["app/services/retention.py"], "base", "merge")
+    assert verdicts[0].verdict is Verdict.REJECTED
+    assert "app/services/retention.py" in verdicts[0].item
+    assert verdicts[0].evidence  # carries the missing-path ref
+
+
+def test_glob_matches_changed_path():
+    gh = MagicMock()
+    gh.get_changed_files.return_value = ["app/services/retention.py", "app/services/legal.py"]
+    verdicts = run_scope_gate(gh, ["app/services/*.py"], "base", "merge")
+    assert all(v.verdict is Verdict.CONFIRMED for v in verdicts)
+
+
+def test_no_required_paths_returns_empty():
+    gh = MagicMock()
+    assert run_scope_gate(gh, [], "base", "merge") == []

--- a/tests/issues/2335/test_verification_tools_session.py
+++ b/tests/issues/2335/test_verification_tools_session.py
@@ -1,0 +1,21 @@
+import copy
+
+from app.modules.workspace.autonomous.constants import (
+    REVIEW_ALLOWED_TOOLS,
+    VERIFICATION_ALLOWED_TOOLS,
+)
+
+
+def test_verification_adds_bash_to_review_set():
+    review = copy.deepcopy(REVIEW_ALLOWED_TOOLS["claude-code"])
+    verif = VERIFICATION_ALLOWED_TOOLS["claude-code"]
+    for t in review:
+        assert t in verif
+    assert "Bash" in verif
+    assert "Write" not in verif and "Edit" not in verif
+
+
+def test_session_line_registry_includes_verification():
+    from app.modules.workspace.autonomous.orchestrator import SESSION_LINE_FIELDS
+
+    assert SESSION_LINE_FIELDS.get("verification") == "verification_session_id"


### PR DESCRIPTION
## What

PR1 of the #2335 program. Autonomous workflows no longer auto-close issues on PR merge. A new `acceptance_verification` phase runs after `merge`: an independent credentialless read-only verifier on the merged main SHA + a deterministic scope gate produce structured per-item verdicts, and the issue is closed (as `@open-ace-bot`) **only** on `confirmed`.

Design spec: `docs/superpowers/specs/2026-08-05-acceptance-verification-slice-design.md`. Plan: `docs/superpowers/plans/2026-08-05-acceptance-verification-slice.md`.

## Changes

- **State machine**: new `acceptance_verification` phase after `merge` (`PHASE_ORDER`/`PHASE_STATUS_MAP`/`_COMPLETED_TERMINAL_PHASES`); `merge` now hands off to it; `_next_phase` terminal return made idempotent.
- **Close-keyword enforcement** (kills the #2179–#2190 premature-close pattern): autonomous PR bodies use `Implements #N`, never `Closes #N` (`phases/pr_review.py`). New `GitHubOps.close_issue`/`reopen_issue` (`api_only` → `@open-ace-bot` identity). **Reopen guard**: if the issue is closed before `confirmed`, the workflow reopens it.
- **Snapshot** (`acceptance_snapshot.py`): convention parse (`## Scope` / `## 验收标准` / `## 不在 Scope` / closure-constraints) → LLM-extract fallback flagged `source=llm, confidence=low`; canonical sha256 hash drives re-verification on issue edits.
- **Verdicts** (`acceptance_verdicts.py`): `ItemVerdict` + `aggregate_verdicts` (any rejected→rejected; any indeterminate→indeterminate; all confirmed→confirmed). Reuses `evidence.py` `Verdict` enum.
- **Verifier agent**: new `verification` session line + `VERIFICATION_ALLOWED_TOOLS` (read-only `REVIEW_ALLOWED_TOOLS` + `Bash`, no Write/Edit), spawned credentialless on merged main. Conservative — empty/failed output aggregates to `indeterminate` (never a false `confirmed`).
- **Scope gate** (the one mechanical gate in this slice): each snapshot `required_path` must appear in `base_commit_sha..merge_sha` diff.
- **Handler** (`phases/acceptance_verification.py`): verifier + scope gate + aggregate → transitions. `confirmed`→close+report+`completed`; `rejected`→new dev round (cap `MAX_ACCEPTANCE_DEV_ROUNDS=3`, then `failed`); `indeterminate`→`paused`. Idempotent on `(merge_sha, issue_acceptance_hash)`.
- **Persistence**: 11 new `autonomous_workflows` columns (migration `20260805_010`, idempotent) + regenerated schema snapshots.

## Transitions

```
merge → acceptance_verification (verification_pending)
          ├─ confirmed     → close issue + report → completed
          ├─ rejected      → development (dev_round+1) | failed (cap hit)
          └─ indeterminate → paused (human)
```

## Non-goals (later PRs)

The other 5 mechanical gates (negative-test / legacy-pattern / call-chain / deployment / regression); full restart-recovery polish; human-override UI/audit; LLM-extraction maturity; PR *creation* identity (`gh pr create` still attributes to owner — #2340).

## Tests

30 new tests in `tests/issues/2335/` (snapshot parser, verdict aggregation, scope gate, close-keyword, `close_issue`/`reopen_issue` bot-identity, verifier tools+session line, phase wiring, the handler's 6 verdict/transition/idempotency/reopen cases, reject→fix→confirm→close integration). Phase-machine invariant tests updated for the new canonical sequence. Full `tests/issues/2335/` + `tests/autonomous/` green (126 passed). The only failing tests in the broader sweep (716/786/822) are pre-existing local-env failures (macOS `/private/tmp` containment + local env-var leak) — verified identical on `origin/main`.

## Deploy runbook (prod)

This PR adds a migration + touches orchestrator/github_ops (scheduler-path code). Deploy per the prod conventions:
1. `/root/open-ace` `git fetch origin main && git reset --hard origin/main`.
2. **Migration**: `cp` migrations + `alembic upgrade head` (idempotent — prod schema may already have the columns via direct SQL; the migration guards `if column exists`). Or direct `ALTER TABLE autonomous_workflows ADD COLUMN IF NOT EXISTS ...`.
3. Hotpatch `app/` files + `migrations/`.
4. **Restart `openace-scheduler.service`** (the unit that runs the orchestrator — not `open-ace.service`, which is just web). Verify `curl :9091/livez` + no traceback. (See the scheduler-port-9090 memory.)

Refs #2335. Follow-ups: #2340 (PR-create identity), and the remaining gates/persistence polish.