### PR TITLE
fix(autonomous): PR creation posts as @open-ace-bot via REST API (#2340)

### DIFF
--- a/app/modules/workspace/autonomous/github_ops.py
+++ b/app/modules/workspace/autonomous/github_ops.py
@@ -1063,7 +1063,41 @@ class GitHubOps:
         base: str = "main",
         draft: bool = False,
     ) -> dict:
-        """Create a pull request and return its details."""
+        """Create a pull request and return its details.
+
+        When a bot token is configured, the PR is created via the REST API as the
+        service user (api_only) so ``GH_TOKEN`` reaches ``gh`` and the PR
+        attributes to the configured AI bot account — not the repo owner (#2340).
+        Falls back to ``gh pr create`` (owner identity) when no token is set or
+        the repo slug can't be resolved.
+        """
+        if self._get_env() is not None:
+            slug = self._repo_slug or self._resolve_owner_repo() or ""
+            if slug:
+                fields: list[tuple[str, str]] = [
+                    ("title", title),
+                    ("base", base),
+                    ("body", body or ""),
+                ]
+                if head:
+                    fields.append(("head", head))
+                if draft:
+                    fields.append(("draft", "true"))
+                api_args = ["--method", "POST", f"repos/{slug}/pulls"]
+                for key, value in fields:
+                    api_args += ["-f", f"{key}={value}"]
+                result = self._run_gh(self._gh_api_args(api_args), repo_scoped=False, api_only=True)
+                try:
+                    data = json.loads((result.stdout or "").strip() or "{}")
+                    pr_number = int(data["number"])
+                except (json.JSONDecodeError, TypeError, ValueError, KeyError):
+                    raise GitHubOpsError(
+                        f"create_pr REST API returned no PR number: {result.stdout!r}"
+                    )
+                logger.info("Created PR #%s (REST API, bot identity)", pr_number)
+                return self.get_pr(pr_number)
+
+        # Fallback: gh pr create (owner identity) — same-user / no-token path.
         args = [
             "pr",
             "create",

--- a/app/modules/workspace/autonomous/github_ops.py
+++ b/app/modules/workspace/autonomous/github_ops.py
@@ -1072,7 +1072,11 @@ class GitHubOps:
         the repo slug can't be resolved.
         """
         if self._get_env() is not None:
-            slug = self._repo_slug or self._resolve_owner_repo() or ""
+            # Resolve so _repo_slug (plain OWNER/REPO, never host-prefixed) is set;
+            # _resolve_owner_repo() returns _owner_repo which carries the GHES host
+            # and would malformed the REST path on GHES (#2340 review L1).
+            self._resolve_owner_repo()
+            slug = self._repo_slug
             if slug:
                 fields: list[tuple[str, str]] = [
                     ("title", title),
@@ -1086,7 +1090,20 @@ class GitHubOps:
                 api_args = ["--method", "POST", f"repos/{slug}/pulls"]
                 for key, value in fields:
                     api_args += ["-f", f"{key}={value}"]
-                result = self._run_gh(self._gh_api_args(api_args), repo_scoped=False, api_only=True)
+                # check=False: gh api writes the JSON error body to STDOUT (only the
+                # summary to stderr). Surface both in the exception so the
+                # "already exists" race recovery (#1857) in pr_review still detects
+                # it and falls back to find_existing_pr.
+                result = self._run_gh(
+                    self._gh_api_args(api_args), repo_scoped=False, api_only=True, check=False
+                )
+                if result.returncode != 0:
+                    detail = (result.stderr or "").strip()
+                    body_out = (result.stdout or "").strip()
+                    raise GitHubOpsError(
+                        f"create_pr REST API failed (exit {result.returncode}): {detail}"
+                        + (f" :: {body_out}" if body_out else "")
+                    )
                 try:
                     data = json.loads((result.stdout or "").strip() or "{}")
                     pr_number = int(data["number"])

--- a/tests/issues/2340/test_create_pr_bot_identity.py
+++ b/tests/issues/2340/test_create_pr_bot_identity.py
@@ -1,0 +1,99 @@
+"""PR creation must attribute to the configured AI bot account, not the repo
+owner (#2340). Mirrors the #2339 comment fix: when a bot token is configured and
+the command would otherwise sudo (cross-user), create_pr uses the REST API as the
+service user (api_only) so GH_TOKEN reaches gh. Without a token it falls back to
+`gh pr create` (owner identity) — unchanged.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import app.modules.workspace.autonomous.github_ops as gh_mod
+from app.modules.workspace.autonomous.github_ops import GitHubOps
+
+BOT_ENV = {
+    "GH_TOKEN": "ghp-bot",
+    "GIT_AUTHOR_NAME": "Open ACE AI",
+    "GIT_AUTHOR_EMAIL": "bot@open-ace.com",
+    "GIT_COMMITTER_NAME": "Open ACE AI",
+    "GIT_COMMITTER_EMAIL": "bot@open-ace.com",
+}
+
+
+def _gh():
+    gh = GitHubOps("/srv/owners/repo", system_account="repoowner")
+    gh._owner_repo_resolved = True
+    gh._owner_repo = "open-ace/open-ace"
+    gh._repo_slug = "open-ace/open-ace"
+    gh._repo_host = None
+    return gh
+
+
+def test_create_pr_uses_rest_api_as_service_user_with_bot_token():
+    gh = _gh()
+    post_resp = MagicMock(
+        returncode=0,
+        stdout='{"number": 42, "html_url": "https://github.com/open-ace/open-ace/pull/42"}',
+        stderr="",
+    )
+    view_resp = MagicMock(returncode=0, stdout='{"number": 42}', stderr="")
+    run = MagicMock(side_effect=[post_resp, view_resp])
+    with (
+        patch.object(gh, "_needs_sudo", return_value=True),
+        patch.object(gh, "_verify_trusted_git_context"),
+        patch("app.utils.config.get_ai_github_env", return_value=BOT_ENV),
+        patch.object(gh_mod, "subprocess") as sub_mod,
+        patch.object(gh, "get_pr", return_value={"number": 42}) as mock_get_pr,
+    ):
+        sub_mod.run = run
+        result = gh.create_pr(title="T", body="B", head="auto-dev/x", base="main")
+    cmd = run.call_args.args[0]
+    assert cmd[0] == "gh", f"create_pr must not sudo (got {cmd[:3]})"
+    assert "api" in cmd
+    assert "POST" in cmd
+    assert "repos/open-ace/open-ace/pulls" in cmd
+    assert run.call_args.kwargs["env"]["GH_TOKEN"] == "ghp-bot"
+    # title/head/base/body carried as -f fields
+    flat = " ".join(cmd)
+    assert "title=T" in flat and "head=auto-dev/x" in flat and "base=main" in flat
+    mock_get_pr.assert_called_once_with(42)
+    assert result["number"] == 42
+
+
+def test_create_pr_falls_back_to_gh_pr_create_without_token():
+    gh = _gh()
+    run = MagicMock(
+        return_value=MagicMock(
+            returncode=0, stdout="https://github.com/open-ace/open-ace/pull/42\n", stderr=""
+        )
+    )
+    with (
+        patch.object(gh, "_needs_sudo", return_value=True),
+        patch.object(gh, "_verify_trusted_git_context"),
+        patch("app.utils.config.get_ai_github_env", return_value=None),
+        patch.object(gh_mod, "subprocess") as sub_mod,
+        patch.object(gh, "get_pr", return_value={"number": 42}),
+    ):
+        sub_mod.run = run
+        gh.create_pr(title="T", body="B", head="auto-dev/x")
+    cmd = run.call_args.args[0]
+    assert "pr" in cmd and "create" in cmd  # legacy fallback (owner identity)
+    assert "api" not in cmd
+
+
+def test_create_pr_rest_api_uses_bot_token_same_user():
+    # Same-user (no sudo) with a bot token: api_only is a no-op for sudo, but the
+    # REST path is still taken because the token is configured -> bot identity.
+    gh = _gh()
+    post_resp = MagicMock(returncode=0, stdout='{"number": 7}', stderr="")
+    run = MagicMock(side_effect=[post_resp])
+    with (
+        patch.object(gh, "_needs_sudo", return_value=False),
+        patch.object(gh, "_verify_trusted_git_context"),
+        patch("app.utils.config.get_ai_github_env", return_value=BOT_ENV),
+        patch.object(gh_mod, "subprocess") as sub_mod,
+        patch.object(gh, "get_pr", return_value={"number": 7}),
+    ):
+        sub_mod.run = run
+        gh.create_pr(title="T", body="", head="br")
+    cmd = run.call_args.args[0]
+    assert "api" in cmd and "POST" in cmd  # REST path even same-user when token set

--- a/tests/issues/2340/test_create_pr_bot_identity.py
+++ b/tests/issues/2340/test_create_pr_bot_identity.py
@@ -97,3 +97,31 @@ def test_create_pr_rest_api_uses_bot_token_same_user():
         gh.create_pr(title="T", body="", head="br")
     cmd = run.call_args.args[0]
     assert "api" in cmd and "POST" in cmd  # REST path even same-user when token set
+
+
+def test_create_pr_rest_error_includes_stdout_body_so_race_recovery_works():
+    # gh api writes the JSON error body to STDOUT (only the summary to stderr).
+    # The exception must carry the stdout body so pr_review's "already exists"
+    # detection (#1857) still triggers find_existing_pr on the REST path.
+    import pytest
+
+    from app.modules.workspace.autonomous.github_ops import GitHubOpsError
+
+    gh = _gh()
+    err = MagicMock(
+        returncode=1,
+        stdout='{"message": "Validation Failed", "errors": [{"message": "A pull request already exists for open-ace:auto-dev/x."}]}',
+        stderr="gh: Validation Failed (HTTP 422)",
+    )
+    with (
+        patch.object(gh, "_needs_sudo", return_value=True),
+        patch.object(gh, "_verify_trusted_git_context"),
+        patch("app.utils.config.get_ai_github_env", return_value=BOT_ENV),
+        patch.object(gh_mod, "subprocess") as sub_mod,
+    ):
+        sub_mod.run = MagicMock(return_value=err)
+        with pytest.raises(GitHubOpsError) as exc:
+            gh.create_pr(title="T", body="", head="auto-dev/x")
+    msg = str(exc.value)
+    assert "already exists" in msg  # the stdout body is surfaced
+    assert "Validation Failed" in msg  # stderr summary also present

--- a/tests/issues/716/test_github_ops.py
+++ b/tests/issues/716/test_github_ops.py
@@ -190,8 +190,10 @@ class TestGitHubOpsPR:
     def setup_method(self):
         self.gh = GitHubOps("/tmp/test-repo")
 
+    @patch("app.utils.config.get_ai_github_env", return_value=None)
     @patch("app.modules.workspace.autonomous.github_ops.subprocess.run")
-    def test_create_pr(self, mock_run):
+    def test_create_pr(self, mock_run, _no_token):
+        # No bot token -> fallback `gh pr create` path (owner identity).
         # create_pr makes two gh calls: `pr create` (prints URL) then
         # `pr view --json` (structured data).
         mock_run.side_effect = [
@@ -206,8 +208,9 @@ class TestGitHubOpsPR:
         )
         assert result["number"] == 10
 
+    @patch("app.utils.config.get_ai_github_env", return_value=None)
     @patch("app.modules.workspace.autonomous.github_ops.subprocess.run")
-    def test_create_pr_draft(self, mock_run):
+    def test_create_pr_draft(self, mock_run, _no_token):
         mock_run.side_effect = [
             MagicMock(returncode=0, stdout="https://github.com/user/test/pull/11"),
             MagicMock(


### PR DESCRIPTION
## Problem

Follow-up to #2339/#2341. Comment posting was fixed to attribute to `@open-ace-bot`, but **PR creation** (`GitHubOps.create_pr`) still attributes to the workflow owner: `gh pr create` runs under the cross-user `sudo -u <owner>` wrapper, sudo's `env_reset` strips `GH_TOKEN`, and the PR is created by the owner's personal account. Evidence: PR #2311 → `@richardhuang`, PR #2318 → `@blueberry521`.

## Fix

`create_pr` can't drop sudo the way comments did — `gh pr create` reads local git (branch/base/commits) and the service user can't read the owner's repo. Instead, when a bot token is configured, `create_pr` uses the **REST API** (`gh api --method POST repos/{owner}/{repo}/pulls -f title=… -f head=… -f base=… -f body=…`) as the service user (`api_only`) — all fields are known explicitly, no local repo read, and `GH_TOKEN` reaches `gh` → the PR is created by `@open-ace-bot`. Falls back to `gh pr create` (owner identity) when no token is configured or the repo slug can't be resolved.

## Security

Same as #2341: the bot token stays in the `openace` service-process env (where `get_ai_github_env` already places it), never crosses into an owner's environment, no sudoers change, and removes a `sudo` escalation for this call.

## Tests

3 new in `tests/issues/2340/` (REST path with token cross-user + same-user; fallback `gh pr create` without token). Updated 716's `create_pr` tests to deterministically pin the no-token fallback path (the bot-token REST path is the new default when configured) — they now patch `get_ai_github_env` to control token state, avoiding the 60s-cache cross-test sensitivity.

Refs #2340. Builds on #2341.