### PR TITLE
[P0] Fix PostgreSQL health probe - use cursor() instead of execute()

### DIFF
--- a/app/utils/health_checks.py
+++ b/app/utils/health_checks.py
@@ -69,8 +69,6 @@ def check_database_connection(timeout: float = 2.0) -> dict[str, Any]:
         Dict with status and optional error message.
     """
     try:
-        import sqlalchemy as sa
-
         from app.repositories.database import is_postgresql
 
         if is_postgresql():
@@ -79,7 +77,12 @@ def check_database_connection(timeout: float = 2.0) -> dict[str, Any]:
             if conn is None:
                 return {"status": "error", "error": "connection_failed"}
             try:
-                conn.execute(sa.text("SELECT 1"))
+                # PgConnectionWrapper delegates to a psycopg2 connection, which
+                # exposes cursor() but not execute(); run the probe through a
+                # cursor instead of conn.execute() (would raise AttributeError
+                # and make /readyz report connection_failed forever).
+                with conn.cursor() as cur:
+                    cur.execute("SELECT 1")
                 return {"status": "ok"}
             finally:
                 conn.close()


### PR DESCRIPTION
## Problem

Fixes #2350

`/readyz` 端点的 `check_database_connection()` 函数对 PostgreSQL 连接使用 `conn.execute(sa.text("SELECT 1"))` 执行健康检查，但 `PgConnectionWrapper` 类只暴露了 `cursor()` 方法，没有 `execute()` 方法。

## Root Cause

1. `_get_postgresql_probe_connection()` 返回 `PgConnectionWrapper` 实例
2. `PgConnectionWrapper` 包装了 psycopg2 连接，只提供 `cursor()` 和 `close()` 方法
3. psycopg2 连接对象本身没有 `execute()` 方法，必须通过 `cursor().execute()` 执行 SQL
4. 调用 `conn.execute()` 会抛出 `AttributeError`

## Impact

- **严重程度**: P0 - 致命缺陷
- PostgreSQL 生产部署的 `/readyz` 永远返回 `connection_failed`
- Kubernetes Pod 永远无法进入 Ready 状态
- 生产环境完全无法正常部署

## Fix

将 `conn.execute(sa.text("SELECT 1"))` 改为：
```python
with conn.cursor() as cur:
    cur.execute("SELECT 1")
```

这符合 psycopg2 的标准用法，也符合 `PgConnectionWrapper` 的设计意图。

## Testing

修复后的代码：
- 使用 `cursor().execute()` 执行 SQL，符合 psycopg2 标准用法
- 添加了详细的注释说明问题根因
- 不影响 SQLite 分支的逻辑

## Credit

修复来自 papercatno1/open-eduace fork 的提交 433293cf