### PR TITLE
[P0] Fix /readyz schema version comparison logic

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -550,31 +550,33 @@ def create_app(config=None):
             try:
                 db = Database()
                 conn = db.get_connection()
-                current_revision = get_database_revision(conn)
+                try:
+                    current_revision = get_database_revision(conn)
 
-                checks["schema_version"]["current"] = current_revision
-                checks["schema_version"]["required"] = MIN_SUPPORTED_REVISION
+                    checks["schema_version"]["current"] = current_revision
+                    checks["schema_version"]["required"] = MIN_SUPPORTED_REVISION
 
-                if current_revision is None:
-                    # Fresh database
-                    checks["schema_version"]["status"] = "fresh"
-                    checks["schema_version"]["compatible"] = True
-                else:
-                    # Delegate to schema_guard's compatibility logic, which
-                    # correctly treats timestamp revisions (e.g. 20260805_001)
-                    # as >= the "baseline_*" starting point. A plain string
-                    # comparison here ("2026..." < "baseline...") always
-                    # reported incompatible and kept /readyz at 503 forever.
-                    try:
-                        check_schema_compatibility(conn)
-                        checks["schema_version"]["status"] = "ok"
+                    if current_revision is None:
+                        # Fresh database
+                        checks["schema_version"]["status"] = "fresh"
                         checks["schema_version"]["compatible"] = True
-                    except SchemaCompatibilityError as exc:
-                        checks["schema_version"]["status"] = "incompatible"
-                        checks["schema_version"]["compatible"] = False
-                        checks["schema_version"]["error"] = str(exc)
-                        status_code = 503
-                conn.close()
+                    else:
+                        # Delegate to schema_guard's compatibility logic, which
+                        # correctly treats timestamp revisions (e.g. 20260805_001)
+                        # as >= the "baseline_*" starting point. A plain string
+                        # comparison here ("2026..." < "baseline...") always
+                        # reported incompatible and kept /readyz at 503 forever.
+                        try:
+                            check_schema_compatibility(conn)
+                            checks["schema_version"]["status"] = "ok"
+                            checks["schema_version"]["compatible"] = True
+                        except SchemaCompatibilityError as exc:
+                            checks["schema_version"]["status"] = "incompatible"
+                            checks["schema_version"]["compatible"] = False
+                            checks["schema_version"]["error"] = str(exc)
+                            status_code = 503
+                finally:
+                    conn.close()  # Ensure connection is always closed
 
             except Exception as e:
                 from app.utils.health_checks import _sanitize_error_message

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -514,6 +514,8 @@ def create_app(config=None):
         from app.repositories.database import Database, is_postgresql
         from app.repositories.schema_guard import (
             MIN_SUPPORTED_REVISION,
+            SchemaCompatibilityError,
+            check_schema_compatibility,
             get_database_revision,
             get_environment_mode,
         )
@@ -549,7 +551,6 @@ def create_app(config=None):
                 db = Database()
                 conn = db.get_connection()
                 current_revision = get_database_revision(conn)
-                conn.close()
 
                 checks["schema_version"]["current"] = current_revision
                 checks["schema_version"]["required"] = MIN_SUPPORTED_REVISION
@@ -558,15 +559,22 @@ def create_app(config=None):
                     # Fresh database
                     checks["schema_version"]["status"] = "fresh"
                     checks["schema_version"]["compatible"] = True
-                elif current_revision < MIN_SUPPORTED_REVISION:
-                    # Version too old
-                    checks["schema_version"]["status"] = "incompatible"
-                    checks["schema_version"]["compatible"] = False
-                    status_code = 503
                 else:
-                    # Version OK
-                    checks["schema_version"]["status"] = "ok"
-                    checks["schema_version"]["compatible"] = True
+                    # Delegate to schema_guard's compatibility logic, which
+                    # correctly treats timestamp revisions (e.g. 20260805_001)
+                    # as >= the "baseline_*" starting point. A plain string
+                    # comparison here ("2026..." < "baseline...") always
+                    # reported incompatible and kept /readyz at 503 forever.
+                    try:
+                        check_schema_compatibility(conn)
+                        checks["schema_version"]["status"] = "ok"
+                        checks["schema_version"]["compatible"] = True
+                    except SchemaCompatibilityError as exc:
+                        checks["schema_version"]["status"] = "incompatible"
+                        checks["schema_version"]["compatible"] = False
+                        checks["schema_version"]["error"] = str(exc)
+                        status_code = 503
+                conn.close()
 
             except Exception as e:
                 from app.utils.health_checks import _sanitize_error_message


### PR DESCRIPTION
## Problem

Fixes #2351

`/readyz` 端点的 schema 版本兼容性检查使用字符串比较 `current_revision < MIN_SUPPORTED_REVISION`，但时间戳版本的格式（如 `20260805_001`）按字典序恒小于 `baseline_2026_06_23`，导致版本误判。

## Root Cause

1. `current_revision` 是时间戳格式，以数字开头（如 `20260805_001`）
2. `MIN_SUPPORTED_REVISION` 是 baseline 格式，以字母开头（`baseline_2026_06_23`）
3. 字符串比较：`'20260805_001' < 'baseline_2026_06_23'` 结果为 `True`
4. **原因**：数字 '2' 的 ASCII 码是 50，字母 'b' 的 ASCII 码是 98

## Impact

- **严重程度**: P0 - 致命缺陷
- PostgreSQL 生产部署的 `/readyz` 永远返回 503 状态码
- Kubernetes Pod 永远无法进入 Ready 状态
- 生产环境完全无法正常部署

## Fix

复用 `schema_guard.check_schema_compatibility()` 函数，该函数已正确处理：
- 时间戳版本（`startswith("20")`）vs baseline 版本（`startswith("baseline")`）的特殊比较
- 时间戳版本之间的正常字典序比较
- 未知版本格式的拒绝逻辑

## Testing

修复后的代码：
- 使用 `check_schema_compatibility()` 进行正确的版本比较
- 捕获 `SchemaCompatibilityError` 异常处理不兼容情况
- 将 `conn.close()` 移到 finally 块中确保资源释放

## Credit

修复来自 papercatno1/open-eduace fork 的提交 eccc6fa9