### PR TITLE
fix(docker): code-server 路径验证修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -102,8 +102,8 @@ RUN echo "deb http://mirrors.aliyun.com/debian/ trixie main" > /etc/apt/sources.
     && npm config set registry https://registry.npmmirror.com/ \
     && npm install -g qwen-code-webui@0.2.40 @qwen-code/qwen-code@0.15.10 \
     # === code-server Installation (for local workspace VS Code button) ===
-    && curl -fsSL --connect-timeout 15 --max-time 300 https://code-server.dev/install.sh | sh -s -- --prefix=/usr/local \
-    && test -x /usr/local/bin/code-server \
+    && curl -fsSL --connect-timeout 15 --max-time 300 https://code-server.dev/install.sh | sh -s -- \
+    && test -x /usr/bin/code-server \
     # === CLI Verification ===
     && test -f /usr/lib/node_modules/@qwen-code/qwen-code/cli.js \
     && test -x /usr/bin/qwen-code-webui \


### PR DESCRIPTION
## 问题

Docker 构建失败，code-server 安装后的可执行文件验证失败。

**CI 失败链接**: https://github.com/open-ace/open-ace/actions/runs/31067169975/job/92508141064

## 根因

code-server 的官方安装脚本在安装 deb 包时：
- `--prefix=/usr/local` 参数对 deb 包安装路径**无效**
- deb 包始终安装到系统默认路径 `/usr/bin/code-server`

Dockerfile 验证的路径 `/usr/local/bin/code-server` 与实际安装路径不匹配。

## 修复内容

- 移除无效的 `--prefix=/usr/local` 参数
- 修正验证路径为 `/usr/bin/code-server`

## 验证

本地构建测试：

```bash
docker build -t open-ace-test . -f Dockerfile
docker run --rm open-ace-test which code-server
# 预期输出: /usr/bin/code-server
```

## 风险评估

- **影响范围**: Docker 镜像构建流程
- **风险等级**: 低 - 仅修改验证路径
- **兼容性**: 无影响 - code-server 使用方式不变

Fixes #2355