### PR TITLE
fix(frontend): 删除Toast.tsx中多余的注释块

### DIFF
--- a/frontend/src/components/common/Toast.tsx
+++ b/frontend/src/components/common/Toast.tsx
@@ -117,11 +117,6 @@ export const ToastContainer: React.FC<ToastContainerProps> = ({
 };
 
 /**
- * Global toast store - imported from store/toastStore.ts to avoid circular
- * chunk dependencies between hooks and components.
- */
-
-/**
  * Stable singleton API. Returning the same object reference every call keeps
  * `toast` stable in effect dependency arrays (callers only invoke actions, they
  * never read state from it), so existing `const toast = useToast()` call sites


### PR DESCRIPTION
Fixes #2343

## 问题

Issue #2343 报告 `frontend/src/components/common/Toast.tsx` 文件中有多余的注释块。

## 评审发现

经检查发现：
1. **Issue描述不准确**：注释块下面有 `toastApi` 定义，并非"空的"
2. **实际问题**：第一个注释块（"Global toast store..."）内容与下方代码不符
   - 注释描述的是 "Global toast store"
   - 但下方代码是 `toastApi` singleton API 包装器，而非 store

## 修复方案

删除第一个注释块（第119-123行），保留第二个注释块作为 `toastApi` 的唯一说明。

### 修改前
```typescript
/**
 * Global toast store - imported from store/toastStore.ts to avoid circular
 * chunk dependencies between hooks and components.
 */

/**
 * Stable singleton API. Returning the same object reference every call keeps...
 */
const toastApi: Omit<ToastStore, 'toasts' | 'clearToasts'> = {
```

### 修改后
```typescript
/**
 * Stable singleton API. Returning the same object reference every call keeps...
 */
const toastApi: Omit<ToastStore, 'toasts' | 'clearToasts'> = {
```

## 影响

- **影响范围**：仅注释清理，不影响功能
- **风险等级**：低
- **测试需求**：无需额外测试

## 相关

- 相关PR: #2241

Generated with Qwen Code