### PR TITLE
fix(install): 升级路径补全 OPENACE_ENCRYPTION_KEY (Issue #2359)

### DIFF
--- a/scripts/install-central/package-method/install.sh
+++ b/scripts/install-central/package-method/install.sh
@@ -3799,6 +3799,22 @@ install_local() {
                 sed -i "s|^Environment=WORKSPACE_BASE_DIR=.*|Environment=WORKSPACE_BASE_DIR=/home|" "$service_file"
                 print_info "Fixed WORKSPACE_BASE_DIR=/home (Issue #1308, #2290)"
             fi
+
+            # Check if OPENACE_ENCRYPTION_KEY is missing (PR #2275 follow-up, Issue #2359)
+            # Only add if not already configured in service file AND not in secrets.env
+            # This prevents overriding user's existing encryption key configuration
+            local has_enc_key_in_service=$(grep -q "^Environment=OPENACE_ENCRYPTION_KEY=" "$service_file" 2>/dev/null && echo "yes" || echo "no")
+            local has_secrets_env=""
+            if [ -f /etc/openace/secrets.env ]; then
+                has_secrets_env=$(grep -q "^OPENACE_ENCRYPTION_KEY=" /etc/openace/secrets.env 2>/dev/null && echo "yes" || echo "no")
+            fi
+
+            if [ "$has_enc_key_in_service" = "no" ] && [ "$has_secrets_env" != "yes" ]; then
+                print_warning "Adding missing OPENACE_ENCRYPTION_KEY to systemd service..."
+                local enc_key="${OPENACE_ENCRYPTION_KEY:-$(openssl rand -hex 16)}"
+                sed -i "/^Environment=SECRET_KEY=/a Environment=OPENACE_ENCRYPTION_KEY=$enc_key" "$service_file"
+                print_info "Generated OPENACE_ENCRYPTION_KEY for sensitive data encryption (Issue #2359)"
+            fi
         fi
 
         # -- Phase 2: Update service config if user chose to switch --


### PR DESCRIPTION
## 修复说明

关联 Issue：#2359

## 根因

Package 版升级路径（`scripts/install-central/package-method/install.sh` Phase 1）缺少 `OPENACE_ENCRYPTION_KEY` 环境变量的补全逻辑，导致从旧版本升级后 systemd 服务文件中缺少该变量，API key 相关加密操作失败返回 500 错误。

**触发条件**：
- 首次安装使用的 `open-ace.service` 模板不含 `OPENACE_ENCRYPTION_KEY` 行（PR #2275 之前）
- 使用包含 PR #2275 修复的 `install.sh` 进行升级
- 升级路径未补全该变量 → 运行时 500

## 修复方案

在升级路径 Phase 1 的 WORKSPACE_BASE_DIR 检查之后，添加 OPENACE_ENCRYPTION_KEY 补全逻辑：

**关键设计**：
- **双重检查**：先检查 service 文件，再检查 `/etc/openace/secrets.env`
- **幂等性**：已有配置时不重复插入
- **兼容性**：保护用户在 secrets.env 中的已有配置，避免覆盖导致已加密数据无法解密

**修复代码**：
```bash
# Check if OPENACE_ENCRYPTION_KEY is missing (PR #2275 follow-up, Issue #2359)
# Only add if not already configured in service file AND not in secrets.env
local has_enc_key_in_service=$(grep -q "^Environment=OPENACE_ENCRYPTION_KEY=" "$service_file" 2>/dev/null && echo "yes" || echo "no")
local has_secrets_env=""
if [ -f /etc/openace/secrets.env ]; then
    has_secrets_env=$(grep -q "^OPENACE_ENCRYPTION_KEY=" /etc/openace/secrets.env 2>/dev/null && echo "yes" || echo "no")
fi

if [ "$has_enc_key_in_service" = "no" ] && [ "$has_secrets_env" != "yes" ]; then
    print_warning "Adding missing OPENACE_ENCRYPTION_KEY to systemd service..."
    local enc_key="${OPENACE_ENCRYPTION_KEY:-$(openssl rand -hex 16)}"
    sed -i "/^Environment=SECRET_KEY=/a Environment=OPENACE_ENCRYPTION_KEY=$enc_key" "$service_file"
    print_info "Generated OPENACE_ENCRYPTION_KEY for sensitive data encryption (Issue #2359)"
fi
```

## 主要变更

- **文件**：`scripts/install-central/package-method/install.sh`
- **位置**：line 3801-3814（WORKSPACE_BASE_DIR 检查之后）
- **改动**：新增 14 行代码（双重检查逻辑 + 补全逻辑）

## 测试

**集成测试场景**：
1. ✅ 模拟旧版本安装（无 OPENACE_ENCRYPTION_KEY）
2. ✅ 使用修复后的 install.sh 升级
3. ✅ 验证 systemd 服务文件中新增 OPENACE_ENCRYPTION_KEY
4. ✅ 重启服务，验证 API Keys 页面正常访问

**边界场景测试**：
1. ✅ 用户已通过 `/etc/openace/secrets.env` 配置密钥的升级场景（不插入新密钥）
2. ✅ 多次升级幂等性测试（已有 Environment= 行时不重复插入）
3. ✅ 验证已有 OPENACE_ENCRYPTION_KEY 时不重复插入

**回归测试**：
- ✅ 验证全新安装路径不受影响
- ✅ 验证已有 OPENACE_ENCRYPTION_KEY 的升级不受影响

## 风险

**兼容性风险**：无
- 双重检查机制保护用户已有配置（service 文件 + secrets.env）
- systemd 优先级处理正确（Environment > EnvironmentFile）

**性能风险**：无
- 仅增加两次 grep 检查，影响可忽略

**安全风险**：无
- 密钥生成方式与全新安装路径一致（`openssl rand -hex 16`）
- 不会泄露或暴露敏感信息

**回归风险**：无
- 仅在缺失时补全，不影响已有配置
- 与现有补全逻辑保持一致性

Closes #2359