### PR TITLE
fix(e2e): resolve E2E test stability issues (Issue #2361)

### DIFF
--- a/scripts/run_extended_tests.py
+++ b/scripts/run_extended_tests.py
@@ -479,9 +479,7 @@ def main(argv: list[str] | None = None) -> int:
         # Issue #2361: 添加 subprocess 超时保护
         # 1500秒 = 25分钟 < GitHub Actions 30分钟超时，留5分钟清理时间
         try:
-            result = subprocess.run(
-                cmd, cwd=PROJECT_ROOT, env=env, check=False, timeout=1500
-            )
+            result = subprocess.run(cmd, cwd=PROJECT_ROOT, env=env, check=False, timeout=1500)
             return result.returncode
         except subprocess.TimeoutExpired:
             print("ERROR: Extended tests timed out after 1500s (25 minutes)", flush=True)

--- a/scripts/run_extended_tests.py
+++ b/scripts/run_extended_tests.py
@@ -476,7 +476,17 @@ def main(argv: list[str] | None = None) -> int:
         if args.dry_run:
             return 0
         server_proc = start_server_if_needed(args, env)
-        return subprocess.run(cmd, cwd=PROJECT_ROOT, env=env, check=False).returncode
+        # Issue #2361: 添加 subprocess 超时保护
+        # 1500秒 = 25分钟 < GitHub Actions 30分钟超时，留5分钟清理时间
+        try:
+            result = subprocess.run(
+                cmd, cwd=PROJECT_ROOT, env=env, check=False, timeout=1500
+            )
+            return result.returncode
+        except subprocess.TimeoutExpired:
+            print("ERROR: Extended tests timed out after 1500s (25 minutes)", flush=True)
+            print(f"       Command: {' '.join(cmd)}", flush=True)
+            return 124  # Standard timeout exit code
     finally:
         stop_server(server_proc)
         if test_home is not None:

--- a/tests/e2e/regression/test_helpers.py
+++ b/tests/e2e/regression/test_helpers.py
@@ -100,6 +100,19 @@ def dismiss_force_change_password_modal(page: Page, new_password: str = "Admin12
             'div[role="dialog"] input[placeholder="确认密码"]'
         )
 
+        # Issue #2361: 等待所有输入框可见（修复 Locator.fill timeout）
+        # Modal 可见 ≠ 输入框已渲染完成（React.lazy/动画延迟）
+        try:
+            current_pw_input.wait_for(state="visible", timeout=10000)
+            new_pw_input.wait_for(state="visible", timeout=10000)
+            confirm_pw_input.wait_for(state="visible", timeout=10000)
+        except PlaywrightTimeoutError:
+            save_screenshot(page, "login", "modal_inputs_not_visible")
+            raise AssertionError(
+                "ForceChangePasswordModal inputs not visible within 10s. "
+                "Check if Modal component is rendering correctly."
+            )
+
         # 填写改密表单
         current_pw_input.fill(PASSWORD)
         new_pw_input.fill(new_password)


### PR DESCRIPTION
## 修复内容

解决E2E测试的两个稳定性问题：

### P0: 修复测试失败 - 输入框等待缺失

**问题**：`Locator.fill: Timeout 30000ms exceeded`

**根因**：`dismiss_force_change_password_modal()` 等待Modal可见后立即执行`fill()`，没有等待输入框渲染完成（React.lazy/动画延迟）

**修复**：在填充前添加输入框等待：
```python
current_pw_input.wait_for(state="visible", timeout=10000)
new_pw_input.wait_for(state="visible", timeout=10000)
confirm_pw_input.wait_for(state="visible", timeout=10000)
```

**文件**：`tests/e2e/regression/test_helpers.py`

### P1: 修复pytest卡住 - subprocess超时保护

**问题**：pytest进程卡住26分钟，直到GitHub Actions超时取消

**根因**：`browser.close()` 没有timeout参数，Chrome进程异常时会永远等待；`subprocess.run()` 也无timeout

**修复**：为subprocess添加1500秒（25分钟）硬超时：
```python
result = subprocess.run(cmd, timeout=1500)
```

**文件**：`scripts/run_extended_tests.py`

### P2: 暂不实施

`safe_close_browser()` 方案存在技术风险（SIGALRM与pytest-timeout冲突、依赖Playwright私有属性、只覆盖7/88处），作为后续优化。

## 验证方法

1. **P0验证**：CI运行Extended Tests，确认测试通过无timeout
2. **P1验证**：观察CI不再出现26分钟超时取消

## 预期效果

| 问题 | 修复前 | 修复后 |
|------|--------|--------|
| 测试失败 | `Locator.fill timeout` | 等待输入框渲染，测试通过 |
| pytest卡住 | 26分钟超时取消 | 25分钟硬超时，明确报错 |

Fixes #2361