### PR TITLE
fix: remote machine last_heartbeat timezone display offset (Issue #2364)

### DIFF
--- a/app/modules/workspace/remote_agent_manager.py
+++ b/app/modules/workspace/remote_agent_manager.py
@@ -2616,6 +2616,8 @@ class RemoteAgentManager:
             except (json.JSONDecodeError, TypeError):
                 capabilities = {}
 
+        from app.utils.datetime_utils import ensure_utc_suffix
+
         return {
             "id": get_value("id"),
             "machine_id": get_value("machine_id"),
@@ -2631,9 +2633,9 @@ class RemoteAgentManager:
             "work_dir": get_value("work_dir"),
             "tenant_id": get_value("tenant_id"),
             "created_by": get_value("created_by"),
-            "created_at": get_value("created_at"),
-            "updated_at": get_value("updated_at"),
-            "last_heartbeat": get_value("last_heartbeat"),
+            "created_at": ensure_utc_suffix(get_value("created_at")),
+            "updated_at": ensure_utc_suffix(get_value("updated_at")),
+            "last_heartbeat": ensure_utc_suffix(get_value("last_heartbeat")),
             "connected": self.is_connected(get_value("machine_id") or ""),
         }
 

--- a/app/utils/datetime_utils.py
+++ b/app/utils/datetime_utils.py
@@ -1,4 +1,5 @@
 """Datetime utilities for timestamp handling."""
+
 import re
 
 
@@ -33,6 +34,6 @@ def ensure_utc_suffix(timestamp: str | None) -> str | None:
         return None
     # Check if timestamp already has timezone info
     # Z suffix or timezone offset like +00:00 or -08:00 at the end
-    if timestamp.endswith('Z') or re.search(r'[+-]\d{2}:\d{2}$', timestamp):
+    if timestamp.endswith("Z") or re.search(r"[+-]\d{2}:\d{2}$", timestamp):
         return timestamp
-    return timestamp + 'Z'
+    return timestamp + "Z"

--- a/app/utils/datetime_utils.py
+++ b/app/utils/datetime_utils.py
@@ -1,0 +1,38 @@
+"""Datetime utilities for timestamp handling."""
+import re
+
+
+def ensure_utc_suffix(timestamp: str | None) -> str | None:
+    """Ensure timestamp has UTC 'Z' suffix for frontend parsing.
+
+    PostgreSQL TIMESTAMP WITHOUT TIME ZONE stores timestamps without timezone info.
+    JavaScript needs timezone info to correctly parse UTC timestamps.
+    This function adds 'Z' suffix when returning timestamps to frontend.
+
+    Args:
+        timestamp: ISO format timestamp string (may or may not have timezone info)
+
+    Returns:
+        Timestamp with 'Z' suffix, or None if input is None or empty
+
+    Examples:
+        >>> ensure_utc_suffix('2026-08-06T09:54:57.981635')
+        '2026-08-06T09:54:57.981635Z'
+        >>> ensure_utc_suffix('2026-08-06T09:54:57.981635Z')
+        '2026-08-06T09:54:57.981635Z'
+        >>> ensure_utc_suffix('2026-08-06T09:54:57.981635+00:00')
+        '2026-08-06T09:54:57.981635+00:00'
+        >>> ensure_utc_suffix('2026-08-06T09:54:57.981635-08:00')
+        '2026-08-06T09:54:57.981635-08:00'
+        >>> ensure_utc_suffix(None)
+        None
+        >>> ensure_utc_suffix('')
+        None
+    """
+    if not timestamp or not timestamp.strip():
+        return None
+    # Check if timestamp already has timezone info
+    # Z suffix or timezone offset like +00:00 or -08:00 at the end
+    if timestamp.endswith('Z') or re.search(r'[+-]\d{2}:\d{2}$', timestamp):
+        return timestamp
+    return timestamp + 'Z'

--- a/tests/unit/test_datetime_utils.py
+++ b/tests/unit/test_datetime_utils.py
@@ -1,0 +1,39 @@
+"""Unit tests for datetime_utils module."""
+import pytest
+from app.utils.datetime_utils import ensure_utc_suffix
+
+
+class TestEnsureUtcSuffix:
+    """Test cases for ensure_utc_suffix function."""
+
+    def test_none_input(self):
+        """Test that None input returns None."""
+        assert ensure_utc_suffix(None) is None
+
+    def test_empty_string(self):
+        """Test that empty string returns None."""
+        assert ensure_utc_suffix("") is None
+
+    def test_without_suffix(self):
+        """Test timestamp without Z suffix gets Z suffix added."""
+        result = ensure_utc_suffix('2026-08-06T09:54:57.981635')
+        assert result == '2026-08-06T09:54:57.981635Z'
+
+    def test_with_z_suffix(self):
+        """Test timestamp with Z suffix remains unchanged."""
+        result = ensure_utc_suffix('2026-08-06T09:54:57.981635Z')
+        assert result == '2026-08-06T09:54:57.981635Z'
+
+    def test_with_timezone_offset(self):
+        """Test timestamp with timezone offset remains unchanged."""
+        result = ensure_utc_suffix('2026-08-06T09:54:57.981635+00:00')
+        assert result == '2026-08-06T09:54:57.981635+00:00'
+
+    def test_with_negative_timezone_offset(self):
+        """Test timestamp with negative timezone offset remains unchanged."""
+        result = ensure_utc_suffix('2026-08-06T09:54:57.981635-08:00')
+        assert result == '2026-08-06T09:54:57.981635-08:00'
+
+    def test_whitespace_string(self):
+        """Test that whitespace-only string returns None."""
+        assert ensure_utc_suffix("   ") is None

--- a/tests/unit/test_datetime_utils.py
+++ b/tests/unit/test_datetime_utils.py
@@ -1,4 +1,5 @@
 """Unit tests for datetime_utils module."""
+
 import pytest
 
 from app.utils.datetime_utils import ensure_utc_suffix
@@ -17,23 +18,23 @@ class TestEnsureUtcSuffix:
 
     def test_without_suffix(self):
         """Test timestamp without Z suffix gets Z suffix added."""
-        result = ensure_utc_suffix('2026-08-06T09:54:57.981635')
-        assert result == '2026-08-06T09:54:57.981635Z'
+        result = ensure_utc_suffix("2026-08-06T09:54:57.981635")
+        assert result == "2026-08-06T09:54:57.981635Z"
 
     def test_with_z_suffix(self):
         """Test timestamp with Z suffix remains unchanged."""
-        result = ensure_utc_suffix('2026-08-06T09:54:57.981635Z')
-        assert result == '2026-08-06T09:54:57.981635Z'
+        result = ensure_utc_suffix("2026-08-06T09:54:57.981635Z")
+        assert result == "2026-08-06T09:54:57.981635Z"
 
     def test_with_timezone_offset(self):
         """Test timestamp with timezone offset remains unchanged."""
-        result = ensure_utc_suffix('2026-08-06T09:54:57.981635+00:00')
-        assert result == '2026-08-06T09:54:57.981635+00:00'
+        result = ensure_utc_suffix("2026-08-06T09:54:57.981635+00:00")
+        assert result == "2026-08-06T09:54:57.981635+00:00"
 
     def test_with_negative_timezone_offset(self):
         """Test timestamp with negative timezone offset remains unchanged."""
-        result = ensure_utc_suffix('2026-08-06T09:54:57.981635-08:00')
-        assert result == '2026-08-06T09:54:57.981635-08:00'
+        result = ensure_utc_suffix("2026-08-06T09:54:57.981635-08:00")
+        assert result == "2026-08-06T09:54:57.981635-08:00"
 
     def test_whitespace_string(self):
         """Test that whitespace-only string returns None."""

--- a/tests/unit/test_datetime_utils.py
+++ b/tests/unit/test_datetime_utils.py
@@ -1,5 +1,6 @@
 """Unit tests for datetime_utils module."""
 import pytest
+
 from app.utils.datetime_utils import ensure_utc_suffix
 
 


### PR DESCRIPTION
## 问题

远程机器 `last_heartbeat` 时间显示存在 8 小时时区偏差：
- PostgreSQL `TIMESTAMP WITHOUT TIME ZONE` 存储无时区信息的时间戳
- JavaScript `new Date()` 将无时区标识的字符串当作本地时间解析
- 结果：UTC 时间被错误地显示为本地时间

---

## 修复方案

采用**分层处理方案**（存储无时区，返回带时区）：

### 存储层（不变）
- 保持无时区信息的时间戳（符合 PostgreSQL 约束）
- 53 处使用 `.replace(tzinfo=None).isoformat()` 的位置不需要修改

### 表示层（新增）
- 创建 `ensure_utc_suffix()` 辅助函数
- 在 API 返回时添加 `'Z'` 后缀
- JavaScript 自动正确解析 UTC 时间

---

## 修改内容

### 1. 新建辅助函数

**文件：** `app/utils/datetime_utils.py`

```python
def ensure_utc_suffix(timestamp: str | None) -> str | None:
    """Ensure timestamp has UTC 'Z' suffix for frontend parsing."""
    if not timestamp or not timestamp.strip():
        return None
    if timestamp.endswith('Z') or re.search(r'[+-]\d{2}:\d{2}$', timestamp):
        return timestamp
    return timestamp + 'Z'
```

### 2. 修改 remote_agent_manager.py

**方法：** `_row_to_machine()` (line 2601)

**修改字段：**
- `last_heartbeat`: 远程机器心跳时间
- `created_at`: 机器创建时间
- `updated_at`: 机器更新时间

---

## 验证效果

**修复前：**
```javascript
// 后端返回: '2026-08-06T09:54:57.981635' (无时区)
// JavaScript 解析: 2026-08-06T01:54:57.981Z (错误当作本地时间)
// 前端显示: 2026/8/6 09:54:57 (错误！偏差 8 小时)
```

**修复后：**
```javascript
// 后端返回: '2026-08-06T09:54:57.981635Z' (带 Z 后缀)
// JavaScript 解析: 2026-08-06T09:54:57.981Z (正确识别 UTC)
// 前端显示: 2026/8/6 17:54:57 (UTC+8) ✓ 正确！
```

---

## 测试

- ✅ 新增 7 个单元测试，覆盖所有边界情况
- ✅ 所有测试通过
- ✅ Lint 检查通过

---

## 影响范围

- **前端**：8 处解析时间戳的位置自动受益（无需修改）
- **后端**：存储逻辑保持不变（53 处不需要修改）
- **数据库**：无影响（存储格式不变）

---

## 关联 Issue

- **Fixes #2364** - 远程机器 last_heartbeat 时区显示偏差
- **Related #2263** - 远程机器管理界面显示"离线"（根因相同）

Generated with Qwen Code (3-shotted by Qwen-Coder)