### PR TITLE
fix(autonomous): read-only pre-filter + token-based flag exclusion (#2376 PR-1)

### DIFF
--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -13,6 +13,7 @@ import logging
 import os
 import pwd
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -299,6 +300,65 @@ def _is_bot_comment(comment: dict) -> bool:
     return any(kw in login.lower() for kw in BOT_AUTHOR_KEYWORDS)
 
 
+# Commands that read, search or move test files without executing them. A
+# command headed by one of these can never be a test invocation, however many
+# framework names appear in its arguments (#2376 D1): before this filter,
+# ``grep -rn "pytest" tests/`` was recognized as a test run and — since the
+# evidence parsers judge an unrecognized framework on the exit code alone —
+# could satisfy the authoritative test gate on its own.
+_READ_ONLY_COMMANDS = frozenset(
+    {
+        "cat", "less", "more", "head", "tail", "grep", "rg", "ag", "ls", "stat",
+        "wc", "file", "git", "sed", "awk", "diff", "find", "cp", "mv", "rm",
+        "chmod", "touch", "vim", "nano", "echo", "printf", "which", "realpath",
+    }
+)  # fmt: skip
+
+# Interpreters that may legitimately head a test invocation. Used only to
+# resolve a segment's effective head — an interpreter seen before any read-only
+# command means the segment is executing something, not reading it.
+_INTERPRETER_COMMANDS = frozenset(
+    {"bash", "sh", "zsh", "python", "python3", "node", "npx", "pnpm", "yarn", "bun", "deno"}
+)
+
+# Flags that turn a test command into a help/version query. Matched as whole
+# tokens: a raw substring test discards legitimate runs whose path or flags
+# merely contain "-h" (e.g. ``pytest -q --no-header``, ``tests/test-helper.py``).
+_EXCLUDE_FLAG_TOKENS = frozenset({"--help", "--version", "-h"})
+
+_SEGMENT_SPLIT_RE = re.compile(r"&&|\|\||;|\|")
+
+
+def _shell_tokens(text: str) -> list[str]:
+    """Best-effort shell tokenization; falls back to whitespace on bad quoting."""
+    try:
+        return shlex.split(text)
+    except ValueError:
+        return text.split()
+
+
+def _command_segments(command: str) -> list[str]:
+    """Split a shell command into the segments that run as separate commands."""
+    return [seg for seg in _SEGMENT_SPLIT_RE.split(command) if seg.strip()]
+
+
+def _segment_effective_head(segment: str) -> str:
+    """Basename of the first *recognized* command token in ``segment``.
+
+    Scanning for the first token that is either read-only or an interpreter
+    (rather than taking token 0) steps over wrapper prefixes and their operands
+    — ``sudo -u openace``, ``timeout 60``, ``ONLY_FAST=1`` — without having to
+    model each wrapper's option grammar. Returns "" when neither kind of token
+    is present, which leaves the segment eligible (conservative: an unknown
+    head is not assumed to be read-only).
+    """
+    for token in _shell_tokens(segment):
+        base = token.rsplit("/", 1)[-1]
+        if base in _READ_ONLY_COMMANDS or base in _INTERPRETER_COMMANDS:
+            return base
+    return ""
+
+
 def _has_test_tool_call(tool_calls: list, framework_type: str) -> bool:
     """Check if tool_calls contains a test framework execution command.
 
@@ -320,8 +380,6 @@ def _has_test_tool_call(tool_calls: list, framework_type: str) -> bool:
     # P1: generic_patterns includes unittest for unknown frameworks
     generic_patterns = ["pytest", "unittest", "jest", "go test", "cargo test", "npm test"]
     patterns_to_check = test_commands.get(framework_type, generic_patterns)
-    # Note: -v (verbose) is NOT excluded, only --help/--version/-h
-    exclude_flags = ["--help", "--version", "-h"]
 
     for tc in tool_calls:
         tool_name = tc.get("tool", {}).get("name", "") if isinstance(tc.get("tool"), dict) else ""
@@ -337,11 +395,23 @@ def _has_test_tool_call(tool_calls: list, framework_type: str) -> bool:
         # Then check Bash/run_shell_command for test commands
         if tool_name in ("Bash", "Shell", "run_shell_command", "exec_command"):
             cmd = tool_input.get("command") or tool_input.get("cmd") or ""
-            if not cmd or any(flag in cmd for flag in exclude_flags):
+            if not cmd:
                 continue
-            for pattern in patterns_to_check:
-                if pattern in cmd:
-                    return True
+            # #2376: filter and match per segment. Both must be per-segment —
+            # matching the whole command would let a surviving segment lend its
+            # eligibility to a filtered one, so a one-token prefix would defeat
+            # the read-only filter:
+            #     python -c "print(1)" && grep -rn pytest tests/
+            for segment in _command_segments(cmd):
+                if _segment_effective_head(segment) in _READ_ONLY_COMMANDS:
+                    continue
+                tokens = _shell_tokens(segment)
+                # Note: -v (verbose) is NOT excluded, only --help/--version/-h
+                if any(token in _EXCLUDE_FLAG_TOKENS for token in tokens):
+                    continue
+                for pattern in patterns_to_check:
+                    if pattern in segment:
+                        return True
 
     return False
 

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -300,33 +300,103 @@ def _is_bot_comment(comment: dict) -> bool:
     return any(kw in login.lower() for kw in BOT_AUTHOR_KEYWORDS)
 
 
-# Commands that read, search or move test files without executing them. A
-# command headed by one of these can never be a test invocation, however many
-# framework names appear in its arguments (#2376 D1): before this filter,
+# Commands that read, search, inspect or move test files without executing
+# them. A segment headed by one of these can never be a test invocation, however
+# many framework names appear in its arguments (#2376 D1): before this filter,
 # ``grep -rn "pytest" tests/`` was recognized as a test run and — since the
 # evidence parsers judge an unrecognized framework on the exit code alone —
 # could satisfy the authoritative test gate on its own.
-_READ_ONLY_COMMANDS = frozenset(
+#
+# Named "non-executing" rather than "read-only" because it also covers commands
+# that write but still cannot run a test (``cp``, ``mv``, ``rm``, ``chmod``).
+# Deliberately excludes ``source``/``.``, which *do* execute their argument.
+_NON_EXECUTING_COMMANDS = frozenset(
     {
-        "cat", "less", "more", "head", "tail", "grep", "rg", "ag", "ls", "stat",
-        "wc", "file", "git", "sed", "awk", "diff", "find", "cp", "mv", "rm",
-        "chmod", "touch", "vim", "nano", "echo", "printf", "which", "realpath",
+        "cat",
+        "less",
+        "more",
+        "head",
+        "tail",
+        "bat",
+        "nl",
+        "grep",
+        "rg",
+        "ag",
+        "ls",
+        "stat",
+        "wc",
+        "file",
+        "du",
+        "git",
+        "sed",
+        "awk",
+        "jq",
+        "sort",
+        "uniq",
+        "cut",
+        "tr",
+        "column",
+        "tee",
+        "strings",
+        "od",
+        "xxd",
+        "md5sum",
+        "sha256sum",
+        "basename",
+        "dirname",
+        "diff",
+        "find",
+        "cp",
+        "mv",
+        "rm",
+        "mkdir",
+        "chmod",
+        "touch",
+        "vim",
+        "nano",
+        "echo",
+        "printf",
+        "which",
+        "realpath",
+        "ps",
+        "curl",
+        "wget",
     }
-)  # fmt: skip
+)
 
-# Interpreters that may legitimately head a test invocation. Used only to
-# resolve a segment's effective head — an interpreter seen before any read-only
-# command means the segment is executing something, not reading it.
+# Interpreters and test runners that mark a segment as *executing*. Whichever
+# kind of token appears first decides the segment: a runner seen before any
+# non-executing command means the segment runs tests, and vice versa.
 _INTERPRETER_COMMANDS = frozenset(
     {"bash", "sh", "zsh", "python", "python3", "node", "npx", "pnpm", "yarn", "bun", "deno"}
+)
+
+_TEST_RUNNER_COMMANDS = frozenset(
+    {
+        "pytest",
+        "py.test",
+        "unittest",
+        "nose2",
+        "tox",
+        "nox",
+        "jest",
+        "vitest",
+        "mocha",
+        "npm",
+        "go",
+        "gotestsum",
+        "cargo",
+        "mvn",
+        "gradle",
+        "gradlew",
+        "make",
+    }
 )
 
 # Flags that turn a test command into a help/version query. Matched as whole
 # tokens: a raw substring test discards legitimate runs whose path or flags
 # merely contain "-h" (e.g. ``pytest -q --no-header``, ``tests/test-helper.py``).
 _EXCLUDE_FLAG_TOKENS = frozenset({"--help", "--version", "-h"})
-
-_SEGMENT_SPLIT_RE = re.compile(r"&&|\|\||;|\|")
 
 
 def _shell_tokens(text: str) -> list[str]:
@@ -338,25 +408,78 @@ def _shell_tokens(text: str) -> list[str]:
 
 
 def _command_segments(command: str) -> list[str]:
-    """Split a shell command into the segments that run as separate commands."""
-    return [seg for seg in _SEGMENT_SPLIT_RE.split(command) if seg.strip()]
+    """Split a shell command into the segments that run as separate commands.
+
+    Quote-aware, because a regex split would cut inside a quoted string and hand
+    the tail to the filter as a headless fragment — ``grep -E "pytest|unittest"
+    tests/`` would split at the alternation and the fragment ``unittest" tests/``
+    would match a test pattern with nothing to veto it (#2376 PR-1 review).
+
+    Newlines are separators too: multi-line Bash input is one tool call but many
+    commands, and treating it as a single segment lets a ``git status`` on one
+    line veto a ``pytest`` on another.
+    """
+    segments: list[str] = []
+    buf: list[str] = []
+    in_single = in_double = False
+    i, n = 0, len(command)
+    while i < n:
+        ch = command[i]
+        if ch == "\\" and not in_single and i + 1 < n:
+            buf.append(ch)
+            buf.append(command[i + 1])
+            i += 2
+            continue
+        if ch == "'" and not in_double:
+            in_single = not in_single
+        elif ch == '"' and not in_single:
+            in_double = not in_double
+        elif not in_single and not in_double:
+            if command[i : i + 2] in ("&&", "||"):
+                segments.append("".join(buf))
+                buf = []
+                i += 2
+                continue
+            if ch in ";|\n\r":
+                segments.append("".join(buf))
+                buf = []
+                i += 1
+                continue
+            # A lone "&" backgrounds a command, but "2>&1" and "&>" are
+            # redirections and must not be treated as separators.
+            if ch == "&" and (command[i - 1] if i else "") not in ">&":
+                if (command[i + 1] if i + 1 < n else "") not in "&>":
+                    segments.append("".join(buf))
+                    buf = []
+                    i += 1
+                    continue
+        buf.append(ch)
+        i += 1
+    segments.append("".join(buf))
+    return [seg for seg in segments if seg.strip()]
 
 
-def _segment_effective_head(segment: str) -> str:
-    """Basename of the first *recognized* command token in ``segment``.
+def _segment_is_non_executing(segment: str) -> bool:
+    """Whether ``segment`` reads/inspects rather than runs something.
 
-    Scanning for the first token that is either read-only or an interpreter
-    (rather than taking token 0) steps over wrapper prefixes and their operands
-    — ``sudo -u openace``, ``timeout 60``, ``ONLY_FAST=1`` — without having to
-    model each wrapper's option grammar. Returns "" when neither kind of token
-    is present, which leaves the segment eligible (conservative: an unknown
-    head is not assumed to be read-only).
+    Resolved from the first token that is a recognized command of *either* kind,
+    scanning left to right. Scanning (rather than taking token 0) steps over
+    wrapper prefixes and their operands — ``sudo -u openace``, ``timeout 60``,
+    ``ONLY_FAST=1`` — without modelling each wrapper's option grammar. Stopping
+    at a runner is what keeps an *argument* from vetoing a genuine run:
+    ``pytest tests/cat`` must stay eligible even though ``cat`` is a basename in
+    the non-executing set (#2376 PR-1 review).
+
+    An unrecognized head leaves the segment eligible — an unknown command is not
+    assumed to be non-executing.
     """
     for token in _shell_tokens(segment):
-        base = token.rsplit("/", 1)[-1]
-        if base in _READ_ONLY_COMMANDS or base in _INTERPRETER_COMMANDS:
-            return base
-    return ""
+        base = token.rsplit("/", 1)[-1].lstrip("$(`")
+        if base in _TEST_RUNNER_COMMANDS or base in _INTERPRETER_COMMANDS:
+            return False
+        if base in _NON_EXECUTING_COMMANDS:
+            return True
+    return False
 
 
 def _has_test_tool_call(tool_calls: list, framework_type: str) -> bool:
@@ -403,7 +526,7 @@ def _has_test_tool_call(tool_calls: list, framework_type: str) -> bool:
             # the read-only filter:
             #     python -c "print(1)" && grep -rn pytest tests/
             for segment in _command_segments(cmd):
-                if _segment_effective_head(segment) in _READ_ONLY_COMMANDS:
+                if _segment_is_non_executing(segment):
                     continue
                 tokens = _shell_tokens(segment)
                 # Note: -v (verbose) is NOT excluded, only --help/--version/-h

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -418,6 +418,15 @@ def _command_segments(command: str) -> list[str]:
     Newlines are separators too: multi-line Bash input is one tool call but many
     commands, and treating it as a single segment lets a ``git status`` on one
     line veto a ``pytest`` on another.
+
+    Two constructs escape the newline rule, because their following lines are
+    *data*, not commands (#2376 PR-1 re-review):
+
+    - A heredoc body. ``cat > tests/test_x.py <<'EOF' … import pytest … EOF``
+      would otherwise contribute ``import pytest`` as its own segment, so
+      *writing* a test file would satisfy the gate.
+    - A comment. ``# TODO: run pytest later`` would otherwise be a segment with
+      no head and a matching pattern.
     """
     segments: list[str] = []
     buf: list[str] = []
@@ -435,6 +444,17 @@ def _command_segments(command: str) -> list[str]:
         elif ch == '"' and not in_single:
             in_double = not in_double
         elif not in_single and not in_double:
+            # A heredoc redirect makes everything after it body text; stop
+            # segmenting and let the rest ride with the current segment, whose
+            # head is the real command (``cat``, ``python``, …).
+            if command[i : i + 2] == "<<":
+                buf.append(command[i:])
+                break
+            # An unquoted word-initial "#" comments out the rest of the line.
+            if ch == "#" and (not buf or buf[-1].isspace()):
+                while i < n and command[i] not in "\n\r":
+                    i += 1
+                continue
             if command[i : i + 2] in ("&&", "||"):
                 segments.append("".join(buf))
                 buf = []
@@ -459,21 +479,55 @@ def _command_segments(command: str) -> list[str]:
     return [seg for seg in segments if seg.strip()]
 
 
+_ASSIGNMENT_RE = re.compile(r"^\w+=")
+
+# Installing a test runner is not running it. Checked before the head scan
+# because the package managers overlap the runner set (``npm ci`` vs
+# ``npm test``); without it, ``pip install -U pytest`` satisfies the gate —
+# the likeliest real instance of the class this filter exists to close.
+_PACKAGE_MANAGERS = frozenset(
+    {"pip", "pip3", "uv", "poetry", "npm", "yarn", "pnpm", "apt", "apt-get", "brew", "conda"}
+)
+_INSTALL_SUBCOMMANDS = frozenset({"install", "add", "ci", "uninstall", "remove"})
+
+
+def _is_package_manager_install(tokens: list[str]) -> bool:
+    """Whether the tokens are a dependency install rather than a test run."""
+    for index, token in enumerate(tokens):
+        if _ASSIGNMENT_RE.match(token):
+            continue
+        if token.rsplit("/", 1)[-1] not in _PACKAGE_MANAGERS:
+            return False
+        return any(t in _INSTALL_SUBCOMMANDS for t in tokens[index + 1 :])
+    return False
+
+
 def _segment_is_non_executing(segment: str) -> bool:
     """Whether ``segment`` reads/inspects rather than runs something.
 
     Resolved from the first token that is a recognized command of *either* kind,
     scanning left to right. Scanning (rather than taking token 0) steps over
-    wrapper prefixes and their operands — ``sudo -u openace``, ``timeout 60``,
-    ``ONLY_FAST=1`` — without modelling each wrapper's option grammar. Stopping
-    at a runner is what keeps an *argument* from vetoing a genuine run:
-    ``pytest tests/cat`` must stay eligible even though ``cat`` is a basename in
-    the non-executing set (#2376 PR-1 review).
+    wrapper prefixes and their operands — ``sudo -u openace``, ``timeout 60`` —
+    without modelling each wrapper's option grammar. Stopping at a runner is
+    what keeps an *argument* from vetoing a genuine run: ``pytest tests/cat``
+    must stay eligible even though ``cat`` is a basename in the non-executing
+    set (#2376 PR-1 review).
 
     An unrecognized head leaves the segment eligible — an unknown command is not
     assumed to be non-executing.
     """
-    for token in _shell_tokens(segment):
+    tokens = _shell_tokens(segment)
+    if _is_package_manager_install(tokens):
+        return True
+    for token in tokens:
+        # Env assignments are not the command. Skipping them (rather than
+        # resolving their basename) also stops a runner name inside an assigned
+        # path from winning the scan: ``PYTHONPATH=/opt/tox cat tests/x.py``.
+        if _ASSIGNMENT_RE.match(token):
+            continue
+        # ``$(``/backtick prefixes survive tokenization on unquoted command
+        # substitution; stripping them recovers the inner command name so
+        # ``$(grep -rn pytest tests/)`` still resolves to ``grep``.
         base = token.rsplit("/", 1)[-1].lstrip("$(`")
         if base in _TEST_RUNNER_COMMANDS or base in _INTERPRETER_COMMANDS:
             return False

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -430,6 +430,7 @@ def _command_segments(command: str) -> list[str]:
     """
     segments: list[str] = []
     buf: list[str] = []
+    pending_heredocs: list[tuple[str, bool]] = []
     in_single = in_double = False
     i, n = 0, len(command)
     while i < n:
@@ -444,12 +445,16 @@ def _command_segments(command: str) -> list[str]:
         elif ch == '"' and not in_single:
             in_double = not in_double
         elif not in_single and not in_double:
-            # A heredoc redirect makes everything after it body text; stop
-            # segmenting and let the rest ride with the current segment, whose
-            # head is the real command (``cat``, ``python``, …).
+            # A heredoc's *body* is data, but the rest of its line is still
+            # command text (``cat <<EOF && pytest``), so record the delimiter
+            # and keep scanning; the body is skipped at the newline below.
             if command[i : i + 2] == "<<":
-                buf.append(command[i:])
-                break
+                delimiter, after, strip_tabs = _parse_heredoc_delimiter(command, i)
+                if delimiter is not None:
+                    buf.append(command[i:after])
+                    pending_heredocs.append((delimiter, strip_tabs))
+                    i = after
+                    continue
             # An unquoted word-initial "#" comments out the rest of the line.
             if ch == "#" and (not buf or buf[-1].isspace()):
                 while i < n and command[i] not in "\n\r":
@@ -460,7 +465,23 @@ def _command_segments(command: str) -> list[str]:
                 buf = []
                 i += 2
                 continue
-            if ch in ";|\n\r":
+            if ch in "\n\r":
+                segments.append("".join(buf))
+                buf = []
+                i += 1
+                # Consume each pending heredoc body up to and including its
+                # terminator line, so body text is never read as commands and
+                # commands *after* the terminator are still seen.
+                while pending_heredocs:
+                    delimiter, strip_tabs = pending_heredocs.pop(0)
+                    while i < n:
+                        end = command.find("\n", i)
+                        line = command[i:end] if end != -1 else command[i:]
+                        i = end + 1 if end != -1 else n
+                        if (line.lstrip("\t") if strip_tabs else line).strip() == delimiter:
+                            break
+                continue
+            if ch in ";|":
                 segments.append("".join(buf))
                 buf = []
                 i += 1
@@ -481,6 +502,36 @@ def _command_segments(command: str) -> list[str]:
 
 _ASSIGNMENT_RE = re.compile(r"^\w+=")
 
+
+def _parse_heredoc_delimiter(command: str, i: int) -> tuple[str | None, int, bool]:
+    """Parse the delimiter word of a heredoc starting at ``command[i:i+2] == "<<"``.
+
+    Returns ``(delimiter, index_after_delimiter, strip_tabs)``, or
+    ``(None, i, False)`` when no valid delimiter follows — which is how an
+    arithmetic left shift (``$((1<<2))``) is told apart from a heredoc.
+    """
+    j = i + 2
+    strip_tabs = False
+    if j < len(command) and command[j] == "-":
+        strip_tabs = True
+        j += 1
+    while j < len(command) and command[j] in " \t":
+        j += 1
+    if j < len(command) and command[j] in "'\"":
+        quote = command[j]
+        end = command.find(quote, j + 1)
+        if end == -1:
+            return None, i, False
+        return command[j + 1 : end], end + 1, strip_tabs
+    end = j
+    while end < len(command) and (command[end].isalnum() or command[end] == "_"):
+        end += 1
+    word = command[j:end]
+    if not word or not (word[0].isalpha() or word[0] == "_"):
+        return None, i, False
+    return word, end, strip_tabs
+
+
 # Installing a test runner is not running it. Checked before the head scan
 # because the package managers overlap the runner set (``npm ci`` vs
 # ``npm test``); without it, ``pip install -U pytest`` satisfies the gate —
@@ -492,13 +543,29 @@ _INSTALL_SUBCOMMANDS = frozenset({"install", "add", "ci", "uninstall", "remove"}
 
 
 def _is_package_manager_install(tokens: list[str]) -> bool:
-    """Whether the tokens are a dependency install rather than a test run."""
+    """Whether the tokens are a dependency install rather than a test run.
+
+    Scans for the manager rather than requiring it at token 0, so wrapper and
+    interpreter prefixes do not hide it — ``python -m pip install pytest`` is
+    the form this project's own docs use, and ``sudo pip install`` is common.
+    Only the *first non-flag* token after the manager decides, so a test-name
+    filter that happens to equal a subcommand cannot veto a genuine run
+    (``npm test -- --grep install``). One manager-to-manager hop is allowed for
+    ``uv pip install`` and ``python -m pip install``.
+    """
     for index, token in enumerate(tokens):
         if _ASSIGNMENT_RE.match(token):
             continue
         if token.rsplit("/", 1)[-1] not in _PACKAGE_MANAGERS:
-            return False
-        return any(t in _INSTALL_SUBCOMMANDS for t in tokens[index + 1 :])
+            continue
+        for follower in tokens[index + 1 :]:
+            if follower.startswith("-"):
+                continue
+            base = follower.rsplit("/", 1)[-1]
+            if base in _PACKAGE_MANAGERS:
+                continue
+            return base in _INSTALL_SUBCOMMANDS
+        return False
     return False
 
 

--- a/tests/issues/2376/test_readonly_prefilter.py
+++ b/tests/issues/2376/test_readonly_prefilter.py
@@ -1,0 +1,134 @@
+"""Read-only pre-filter + token-based flag exclusion (#2376 PR-1).
+
+Two pre-existing fail-open / fail-closed defects in ``_has_test_tool_call``:
+
+D1 (fail-open) — the pattern loop substring-matches the *whole* command, so a
+command that merely reads or searches a test file counts as a test invocation.
+On ``main`` these all return True, and because ``_parse_generic`` /
+``_parse_pytest`` judge on the exit code alone, a ``grep`` can satisfy the
+authoritative test gate:
+
+    grep -rn "pytest" tests/
+    cat tests/unit/test_pytest_helpers.py
+    git log --grep=pytest
+
+Fix E (fail-closed) — the ``--help``/``--version``/``-h`` exclusion is a raw
+substring test over the whole command, so a legitimate run is discarded when
+its path or an unrelated flag happens to contain ``-h``.
+
+The filter is applied per shell segment, and so is the pattern match: a
+surviving segment must not lend its recognition to a filtered one.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.modules.workspace.autonomous.orchestrator import _has_test_tool_call
+
+
+def _tc(command: str) -> list:
+    return [{"tool": {"name": "Bash", "input": {"command": command}}}]
+
+
+# --- D1: read-only commands must never count as test invocations -------------
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        'grep -rn "pytest" tests/',
+        "cat tests/unit/test_pytest_helpers.py",
+        "git log --grep=pytest",
+        "rg vitest frontend/",
+        "head -n 50 tests/unit/test_pytest_helpers.py",
+        "sed -n '1,20p' tests/test_pytest_thing.py",
+        "git diff tests/",
+        "ls -la tests/",
+        "find . -name 'test_*.py'",
+        "wc -l tests/test_pytest_helpers.py",
+    ],
+)
+def test_read_only_commands_are_not_test_invocations(command):
+    assert _has_test_tool_call(_tc(command), "mixed") is False
+
+
+def test_read_only_head_behind_a_wrapper_is_still_filtered():
+    # The effective head is the first recognized command token, so wrapper
+    # prefixes and their operands cannot smuggle a read-only command through.
+    assert _has_test_tool_call(_tc("sudo -u openace grep -rn pytest tests/"), "mixed") is False
+    assert _has_test_tool_call(_tc("timeout 60 cat tests/test_pytest_x.py"), "mixed") is False
+
+
+def test_surviving_segment_does_not_lend_recognition_to_a_filtered_one():
+    # Per-segment matching: segment 1 survives the read-only filter but carries
+    # no test pattern; segment 2 carries the pattern but is read-only. Matching
+    # the whole command string would let a one-token prefix defeat the filter.
+    command = 'python -c "print(1)" && grep -rn pytest tests/'
+    assert _has_test_tool_call(_tc(command), "mixed") is False
+
+
+def test_read_only_segment_does_not_suppress_a_genuine_one():
+    # The filter is per segment, not per command: a genuine test run alongside
+    # a read-only command must still be recognized.
+    command = "cat tests/conftest.py && python -m pytest tests/test_a.py -q"
+    assert _has_test_tool_call(_tc(command), "mixed") is True
+
+
+# --- Genuine invocations must keep working (no regression) -------------------
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "pytest",
+        "pytest -q",
+        "pytest tests/ -v",
+        "python -m pytest tests/test_a.py -q",
+        "python -m pytest tests -q --ignore tests/test_a.py",
+        "ONLY_FAST=1 python -m pytest tests/test_a.py -q",
+        "/usr/bin/python3 -m pytest",
+        "python3.12 -m pytest tests/test_a.py tests/test_b.py -q",
+        "unittest discover",
+        "cd /w/frontend && npm test",
+        "pytest || true",
+    ],
+)
+def test_genuine_test_invocations_still_recognized(command):
+    assert _has_test_tool_call(_tc(command), "mixed") is True
+
+
+# --- Fix E: flag exclusion must be token-based, not substring ----------------
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "pytest --help",
+        "pytest --version",
+        "pytest -h",
+    ],
+)
+def test_help_and_version_are_still_excluded(command):
+    assert _has_test_tool_call(_tc(command), "mixed") is False
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # "-h" appears only inside a longer flag, never as its own token.
+        "pytest -q --no-header tests/",
+        # "-h" appears only inside a path component.
+        "python -m pytest tests/e2e/test-helper-cases.py -q",
+    ],
+)
+def test_substring_h_does_not_exclude_a_real_run(command):
+    assert _has_test_tool_call(_tc(command), "mixed") is True
+
+
+# --- Non-Bash tool names are unaffected --------------------------------------
+
+
+def test_dedicated_test_tool_names_still_recognized():
+    for name in ("pytest", "run_tests", "test"):
+        assert _has_test_tool_call([{"tool": {"name": name, "input": {}}}], "mixed") is True

--- a/tests/issues/2376/test_readonly_prefilter.py
+++ b/tests/issues/2376/test_readonly_prefilter.py
@@ -25,7 +25,12 @@ from __future__ import annotations
 
 import pytest
 
-from app.modules.workspace.autonomous.orchestrator import _command_segments, _has_test_tool_call
+from app.modules.workspace.autonomous.orchestrator import (
+    _command_segments,
+    _has_test_tool_call,
+    _is_package_manager_install,
+    _shell_tokens,
+)
 
 
 def _tc(command: str) -> list:
@@ -200,11 +205,17 @@ def test_operators_inside_quotes_do_not_split_a_read_only_command(command):
         ("sed -n '/pytest/p; /jest/p' f.py", ["sed -n '/pytest/p; /jest/p' f.py"]),
         # Newlines separate commands.
         ("git status\npytest tests/", ["git status", "pytest tests/"]),
-        # A heredoc body is data, not commands.
+        # A heredoc body is data: consumed through its terminator, never a
+        # segment, and commands after the terminator are still segmented.
+        ("cat > tests/x.py <<'EOF'\nimport pytest\nEOF", ["cat > tests/x.py <<'EOF'"]),
         (
-            "cat > tests/x.py <<'EOF'\nimport pytest\nEOF",
-            ["cat > tests/x.py <<'EOF'\nimport pytest\nEOF"],
+            "cat > tests/x.py <<'EOF'\nimport pytest\nEOF\npytest tests/",
+            ["cat > tests/x.py <<'EOF'", "pytest tests/"],
         ),
+        # The rest of the heredoc's own line is command text.
+        ("cat <<EOF && pytest tests/\nbody\nEOF", ["cat <<EOF ", " pytest tests/"]),
+        # Not a heredoc: no valid delimiter word follows.
+        ("echo $((1<<2))", ["echo $((1<<2))"]),
         # Comments are stripped, not turned into headless segments.
         ("# run pytest later\nls tests/", ["ls tests/"]),
         ("ls tests/ # then pytest", ["ls tests/ "]),
@@ -252,16 +263,93 @@ def test_data_and_dependency_commands_are_not_test_runs(command):
     assert _has_test_tool_call(_tc(command), "mixed") is False
 
 
-def test_heredoc_guard_does_not_swallow_a_later_genuine_run():
-    # The guard stops segmenting at "<<", so a run *before* the heredoc is
-    # still seen; a run after it is inside the body and correctly is not.
+@pytest.mark.parametrize(
+    "command",
+    [
+        # Write the test file, then run it — the most common heredoc shape in
+        # agent work. Consuming to the terminator (rather than swallowing the
+        # whole remainder) is what keeps the run after it visible.
+        "cat > tests/test_x.py <<'EOF'\nimport pytest\n\n\ndef test_x():\n    assert 1\n"
+        "EOF\npython -m pytest tests/test_x.py -q",
+        "cat > /tmp/x.py <<EOF\nprint(1)\nEOF\npytest tests/ -q",
+        "cat <<EOF > tests/x.sh\necho hi\nEOF\nbash tests/x.sh && pytest tests/ -q",
+        # The rest of the heredoc's own line is still command text.
+        "cat <<EOF && pytest tests/ -q\nbody\nEOF",
+        # Two heredocs in sequence.
+        "cat > a.txt <<A\nx\nA\ncat > b.txt <<B\ny\nB\npytest tests/",
+        # Tab-stripped terminator (<<-).
+        "cat <<-EOF > tests/x.py\n\timport pytest\n\tEOF\npytest tests/ -q",
+        # An arithmetic left shift is not a heredoc: no valid delimiter word.
+        "echo $((1<<2)) && pytest tests/ -q",
+    ],
+)
+def test_heredoc_body_is_skipped_but_later_commands_are_not(command):
+    assert _has_test_tool_call(_tc(command), "mixed") is True
+
+
+def test_run_before_a_heredoc_is_still_seen():
     command = "pytest tests/ -q\ncat > tests/x.py <<'EOF'\nimport pytest\nEOF"
     assert _has_test_tool_call(_tc(command), "mixed") is True
 
 
-def test_package_manager_run_is_not_mistaken_for_an_install():
-    assert _has_test_tool_call(_tc("npm test"), "mixed") is True
-    assert _has_test_tool_call(_tc("cd /w/frontend && npm test"), "mixed") is True
+@pytest.mark.parametrize(
+    "command",
+    [
+        "npm test",
+        "cd /w/frontend && npm test",
+        # A test-name filter that happens to equal an install subcommand must
+        # not veto the run: only the first non-flag token after the manager
+        # decides.
+        "npm test -- --grep install",
+        "npm test -- -t install",
+        "npm test -- --testNamePattern install",
+        "npm test -- --install-deps",
+    ],
+)
+def test_package_manager_run_is_not_mistaken_for_an_install(command):
+    assert _has_test_tool_call(_tc(command), "mixed") is True
+
+
+@pytest.mark.parametrize(
+    "command,is_install",
+    [
+        ("pip install -U pytest pytest-cov", True),
+        ("uv pip install pytest", True),
+        ("python -m pip install pytest", True),
+        ("sudo pip install pytest", True),
+        ("npm install --save-dev jest", True),
+        ("npm ci", True),
+        ("poetry add --group dev pytest", True),
+        # Only the first non-flag token after the manager decides, so a filter
+        # argument equal to a subcommand is not an install. Asserted on the
+        # predicate directly: `yarn test` is not a recognized pattern until
+        # PR-3's Fix B, so the public function cannot express this case yet.
+        ("yarn test --grep add", False),
+        ("pnpm test -- --filter remove", False),
+        ("npm test -- --grep install", False),
+        ("npm test", False),
+        ("python -m pytest tests/", False),
+    ],
+)
+def test_is_package_manager_install(command, is_install):
+    assert _is_package_manager_install(_shell_tokens(command)) is is_install
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # The manager is found by scanning, so wrapper and interpreter prefixes
+        # cannot hide it. `python -m pip install` is the form this repo's docs use.
+        "python -m pip install pytest",
+        "python3 -m pip install -U pytest pytest-cov",
+        "sudo pip install pytest",
+        "sudo -H pip3 install pytest",
+        "sudo apt-get install -y python3-pytest",
+        "env PIP_NO_CACHE=1 pip install pytest",
+    ],
+)
+def test_wrapped_installs_are_still_detected(command):
+    assert _has_test_tool_call(_tc(command), "mixed") is False
 
 
 # --- An argument must never veto its runner (PR-1 review #3) -----------------

--- a/tests/issues/2376/test_readonly_prefilter.py
+++ b/tests/issues/2376/test_readonly_prefilter.py
@@ -126,6 +126,98 @@ def test_substring_h_does_not_exclude_a_real_run(command):
     assert _has_test_tool_call(_tc(command), "mixed") is True
 
 
+# --- Multi-line commands: newlines separate commands (PR-1 review #1) --------
+#
+# A Bash tool call is routinely a multi-line script. Treating it as one segment
+# let a read-only command on any line veto a genuine run on any other line —
+# reintroducing, on a new axis, exactly the fail-closed bug #2376 exists to fix.
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "cd /w && git status\npython -m pytest tests/ -q",
+        'echo "running tests"\npython -m pytest tests/ -q',
+        "ls -la\ncat foo\npytest tests/ -q",
+        # The runner runs FIRST; a later read-only line must not retract it.
+        "pytest tests/ -q\ngit status",
+        # Agent greps for context, then actually runs the suite.
+        "grep -rn pytest tests/\npython -m pytest tests/ -q",
+        "#!/bin/bash\nset -e\ncd /w\npytest tests/ -q",
+    ],
+)
+def test_newline_separated_commands_are_separate_segments(command):
+    assert _has_test_tool_call(_tc(command), "mixed") is True
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        'python -c "print(1)"\ngrep -rn pytest tests/',
+        'node -e "1"\ncat tests/test_pytest_x.py',
+        'python -c "1" & grep -rn pytest tests/',
+    ],
+)
+def test_segment_bypass_closed_for_every_separator(command):
+    # The eligible segment carries no test pattern; the segment that does is
+    # read-only. True here would mean the filter is defeated by a prefix.
+    assert _has_test_tool_call(_tc(command), "mixed") is False
+
+
+# --- Quote-aware splitting (PR-1 review #2) ----------------------------------
+#
+# A regex split cuts inside quoted strings and hands the tail to the filter as a
+# headless fragment, so `|unittest` inside a grep pattern re-opened D1 entirely.
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        'grep -E "pytest|unittest" tests/',
+        'grep -rn "npm test|pytest" .',
+        'git log --grep="pytest|unittest"',
+        "sed -n '/pytest/p; /jest/p' f.py",
+    ],
+)
+def test_operators_inside_quotes_do_not_split_a_read_only_command(command):
+    assert _has_test_tool_call(_tc(command), "mixed") is False
+
+
+def test_redirections_are_not_treated_as_separators():
+    # "2>&1" and "&>" are redirections, not backgrounding.
+    assert _has_test_tool_call(_tc("pytest tests/ -q 2>&1"), "mixed") is True
+    assert _has_test_tool_call(_tc("pytest tests/ -q &> out.log"), "mixed") is True
+
+
+def test_pipeline_keeps_the_runner_segment():
+    # Splitting on "|" must not drop the runner: the tee/tail segment is
+    # filtered, the pytest segment survives.
+    assert _has_test_tool_call(_tc("pytest tests/ -q 2>&1 | tee out.log"), "mixed") is True
+    assert _has_test_tool_call(_tc("pytest tests/ | tail -50"), "mixed") is True
+
+
+# --- An argument must never veto its runner (PR-1 review #3) -----------------
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "pytest tests/cat",
+        "pytest -k git tests/",
+        'pytest -k "git" tests/',
+        "pytest --deselect tests/find tests/",
+        "pytest tests/ --rootdir tests/git",
+        "npm test -- tests/diff",
+        "go test ./cmd/find",
+        "cargo test --test file",
+    ],
+)
+def test_argument_basename_does_not_veto_a_genuine_run(command):
+    # The head scan stops at the runner, so a path or flag value whose basename
+    # happens to be a non-executing command name cannot disable the gate.
+    assert _has_test_tool_call(_tc(command), "mixed") is True
+
+
 # --- Non-Bash tool names are unaffected --------------------------------------
 
 

--- a/tests/issues/2376/test_readonly_prefilter.py
+++ b/tests/issues/2376/test_readonly_prefilter.py
@@ -1,9 +1,10 @@
-"""Read-only pre-filter + token-based flag exclusion (#2376 PR-1).
+"""Non-executing-command pre-filter + token-based flag exclusion (#2376 PR-1).
 
 Two pre-existing fail-open / fail-closed defects in ``_has_test_tool_call``:
 
 D1 (fail-open) — the pattern loop substring-matches the *whole* command, so a
-command that merely reads or searches a test file counts as a test invocation.
+command that merely reads, searches or writes a test file counts as a test
+invocation.
 On ``main`` these all return True, and because ``_parse_generic`` /
 ``_parse_pytest`` judge on the exit code alone, a ``grep`` can satisfy the
 authoritative test gate:
@@ -24,7 +25,7 @@ from __future__ import annotations
 
 import pytest
 
-from app.modules.workspace.autonomous.orchestrator import _has_test_tool_call
+from app.modules.workspace.autonomous.orchestrator import _command_segments, _has_test_tool_call
 
 
 def _tc(command: str) -> list:
@@ -183,10 +184,36 @@ def test_operators_inside_quotes_do_not_split_a_read_only_command(command):
     assert _has_test_tool_call(_tc(command), "mixed") is False
 
 
-def test_redirections_are_not_treated_as_separators():
-    # "2>&1" and "&>" are redirections, not backgrounding.
-    assert _has_test_tool_call(_tc("pytest tests/ -q 2>&1"), "mixed") is True
-    assert _has_test_tool_call(_tc("pytest tests/ -q &> out.log"), "mixed") is True
+@pytest.mark.parametrize(
+    "command,expected",
+    [
+        # Redirections are not separators. Asserted on the segmenter directly:
+        # going through _has_test_tool_call would pass even if "&" did split,
+        # because the runner sits in the first fragment either way.
+        ("pytest tests/ -q 2>&1", ["pytest tests/ -q 2>&1"]),
+        ("pytest tests/ -q &> out.log", ["pytest tests/ -q &> out.log"]),
+        ("pytest tests/ >& out.log", ["pytest tests/ >& out.log"]),
+        # A lone "&" backgrounds, so it *is* a separator.
+        ("pytest tests/ & echo done", ["pytest tests/ ", " echo done"]),
+        # Operators inside quotes are literal.
+        ('grep -E "pytest|unittest" tests/', ['grep -E "pytest|unittest" tests/']),
+        ("sed -n '/pytest/p; /jest/p' f.py", ["sed -n '/pytest/p; /jest/p' f.py"]),
+        # Newlines separate commands.
+        ("git status\npytest tests/", ["git status", "pytest tests/"]),
+        # A heredoc body is data, not commands.
+        (
+            "cat > tests/x.py <<'EOF'\nimport pytest\nEOF",
+            ["cat > tests/x.py <<'EOF'\nimport pytest\nEOF"],
+        ),
+        # Comments are stripped, not turned into headless segments.
+        ("# run pytest later\nls tests/", ["ls tests/"]),
+        ("ls tests/ # then pytest", ["ls tests/ "]),
+        # "#" mid-word is not a comment.
+        ("pytest tests/test_a.py::test_x#frag", ["pytest tests/test_a.py::test_x#frag"]),
+    ],
+)
+def test_command_segments_structure(command, expected):
+    assert _command_segments(command) == expected
 
 
 def test_pipeline_keeps_the_runner_segment():
@@ -194,6 +221,47 @@ def test_pipeline_keeps_the_runner_segment():
     # filtered, the pytest segment survives.
     assert _has_test_tool_call(_tc("pytest tests/ -q 2>&1 | tee out.log"), "mixed") is True
     assert _has_test_tool_call(_tc("pytest tests/ | tail -50"), "mixed") is True
+
+
+# --- Heredocs, comments, installs (PR-1 re-review N1/N2/N3/N4) ---------------
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # Writing a test file with a heredoc must not satisfy the gate: without
+        # a heredoc guard the body line `import pytest` becomes its own segment.
+        "cat > tests/test_new.py <<'EOF'\nimport pytest\n\n\ndef test_x():\n    assert 1\nEOF",
+        "cat >> conftest.py <<EOF\nimport pytest\nEOF",
+        "cat <<-EOF > tests/x.py\nimport pytest\nEOF",
+        # Comments are not commands.
+        "# TODO: run pytest after the refactor\nls -la tests/",
+        "ls tests/ ; # pytest is what we would run",
+        "# first, look at the suite\ngrep -rn TODO tests/\n# then run pytest\n",
+        # A runner basename inside an env assignment must not win the scan.
+        "PYTHONPATH=/opt/tox cat tests/test_pytest_x.py",
+        # Installing a runner is not running it.
+        "pip install -U pytest pytest-cov",
+        "uv pip install pytest",
+        "npm install --save-dev jest",
+        "npm ci",
+        "poetry add --group dev pytest",
+    ],
+)
+def test_data_and_dependency_commands_are_not_test_runs(command):
+    assert _has_test_tool_call(_tc(command), "mixed") is False
+
+
+def test_heredoc_guard_does_not_swallow_a_later_genuine_run():
+    # The guard stops segmenting at "<<", so a run *before* the heredoc is
+    # still seen; a run after it is inside the body and correctly is not.
+    command = "pytest tests/ -q\ncat > tests/x.py <<'EOF'\nimport pytest\nEOF"
+    assert _has_test_tool_call(_tc(command), "mixed") is True
+
+
+def test_package_manager_run_is_not_mistaken_for_an_install():
+    assert _has_test_tool_call(_tc("npm test"), "mixed") is True
+    assert _has_test_tool_call(_tc("cd /w/frontend && npm test"), "mixed") is True
 
 
 # --- An argument must never veto its runner (PR-1 review #3) -----------------


### PR DESCRIPTION
First of three PRs for #2376. **Pure tightening — no new blocking path, independently deployable.**

## What this fixes

Two *pre-existing* defects in `_has_test_tool_call`, both found while investigating why prod workflows 220 (#2343) / 221 (#2349) were killed despite their agents running appropriate, passing verification.

### D1 — fail-open: read-only commands counted as test invocations

The pattern loop substring-matches the **whole** command, so reading or searching a test file is recognized as running it. Measured on `main`:

```
grep -rn "pytest" tests/               -> True
cat tests/unit/test_pytest_helpers.py  -> True
git log --grep=pytest                  -> True
```

Because `_parse_generic` / `_parse_pytest` judge an unrecognized framework on the **exit code alone**, a `grep` could satisfy the authoritative test gate by itself.

### Fix E — fail-closed: `-h` matched as a substring

`--help`/`--version`/`-h` were tested with `flag in cmd` over the whole command, discarding legitimate runs whose path or flags merely contain `-h`:

```
pytest -q --no-header tests/           -> excluded (wrongly)
bash tests/e2e/test-helper.sh          -> excluded (wrongly)
```

## Design notes

**Filtering and pattern matching are both per shell segment.** This is load-bearing: whole-command matching would let a surviving segment lend its eligibility to a filtered one, so a one-token prefix would defeat the filter entirely —

```
python -c "print(1)" && grep -rn pytest tests/
```

**A segment's effective head is the first token that is either read-only or an interpreter**, rather than token 0. That steps over wrapper prefixes *and their operands* (`sudo -u openace`, `timeout 60`, `nice -n 10`, `ONLY_FAST=1`) without modelling each wrapper's option grammar. An unrecognized head leaves the segment eligible — conservative by design, since an unknown head must not be assumed read-only.

**Known residual** (documented, not closed here): matching on surviving segments is still substring-based, so a non-read-only command that merely *mentions* a runner still matches (`python -c "import pytest; print(1)"`). I1 is a narrowing, not an absolute close.

## Test plan

- [x] 30 new tests in `tests/issues/2376/test_readonly_prefilter.py` — adversarial read-only names, wrapper-hidden read-only heads, the segment-bypass case, no-regression cases for genuine invocations, and token-vs-substring flag exclusion
- [x] Affected-file cross-check (179 tests): `tests/issues/1532`, `tests/issues/1520`, `tests/unit/test_autonomous_ci_guardrails.py`, `tests/unit/test_test_verdict.py`, `tests/unit/test_test_evidence_parser.py` — all pass, no rewrites needed
- [x] **Full suite failure-set diff against a clean `origin/main` worktree: 0 new failures** (branch failure set is a strict subset of baseline's; the local baseline has 35 pre-existing env/ordering failures, branch has 23)

## Follow-ups in this series

- **PR-2** — per-evidence framework gating (D4) + `structured_authoritative = PASSED only` (D2). Must ship together: the D2 bug currently *masks* D4.
- **PR-3** — widen recognition for `mixed` repos (D3). This is the one that unblocks 220/221.

Refs #2376.

🤖 Generated with [Claude Code](https://claude.com/claude-code)