### PR TITLE
fix(frontend): 生成默认映射规则后已有规则从UI消失 (Issue #2363)

### DIFF
--- a/frontend/src/components/features/management/MappingRulesEditor.tsx
+++ b/frontend/src/components/features/management/MappingRulesEditor.tsx
@@ -66,8 +66,8 @@ export const MappingRulesEditor: React.FC<MappingRulesEditorProps> = ({
     try {
       const result = await mappingRulesApi.generateDefaultRules(userId);
 
-      // Update rules list with created rules
-      setRules(result.created);
+      // Reload full rules list from server
+      await loadRules();
 
       // Show appropriate message based on result
       if (result.created_count > 0 && result.skipped_count > 0) {


### PR DESCRIPTION
## 问题

在用户管理页面，当用户已有默认映射规则时，再次点击"生成默认规则"按钮：
- Toast 提示正确："用户已有默认规则，无需重复生成"
- 但该用户的映射规则 Badge 全部消失
- 刷新页面后规则又出现

## 根因

`MappingRulesEditor.tsx` 第 70 行：

```typescript
setRules(result.created);
```

当规则已存在时，API 返回 `created: []`，执行 `setRules([])` 导致规则列表被清空。

## 修复

改为从服务端重新加载完整规则列表：

```typescript
await loadRules();
```

## 测试

- 类型检查通过：`npm run typecheck`
- 无相关单元测试，需手动验证

Fixes #2363