### PR TITLE
fix: propagate fetch script failures to scheduler status

### DIFF
--- a/app/routes/fetch.py
+++ b/app/routes/fetch.py
@@ -65,12 +65,18 @@ def _run_subprocess(cmd, timeout=600, cwd=None):
 
 
 def run_fetch_scripts():
-    """Run data fetch scripts in background."""
+    """Run data fetch scripts in background.
+
+    Returns:
+        dict or None: Per-tool results on success (e.g. {"qwen": {"success": True, ...}, ...}).
+                      {"_skipped": True} if a concurrent fetch is already running.
+                      None if an unexpected error occurred in the outer handler.
+    """
     global _fetch_status
 
     with _fetch_lock:
         if _fetch_status["is_running"]:
-            return
+            return {"_skipped": True}
         _fetch_status["is_running"] = True
         _fetch_status["error"] = None
 
@@ -80,10 +86,14 @@ def run_fetch_scripts():
 
         results = {}
 
-        # NOTE: fetch scripts use sudo -n to read other users' home directories.
-        # For production, configure a dedicated service account with read-only
-        # access to user home dirs and set FETCH_USE_SUDO=false in config.
-        use_sudo = os.environ.get("FETCH_USE_SUDO", "true").lower() == "true"
+        # NOTE: fetch scripts may need elevated privileges to read other users'
+        # home directories. By default sudo is disabled for safety.
+        # If your deployment requires cross-user data collection, either:
+        #   - set FETCH_USE_SUDO=true in the environment AND configure
+        #     passwordless sudo for the service user, or
+        #   - configure a dedicated service account with read access to
+        #     user home directories.
+        use_sudo = os.environ.get("FETCH_USE_SUDO", "false").lower() == "true"
         # Use the same Python interpreter as the main process to ensure compatibility
         # with type annotation syntax (e.g., str | None requires Python 3.10+)
         python_path = sys.executable
@@ -98,12 +108,14 @@ def run_fetch_scripts():
             cmd.extend(args)
             return cmd
 
+        # Define config_path once before all per-script blocks to avoid
+        # NameError when individual scripts are not present on disk.
+        config_path = os.path.expanduser("~/.open-ace/config.json")
+
         # Run fetch_qwen.py to scan all users' qwen directories
         qwen_script = os.path.join(project_root, "scripts", "fetch_qwen.py")
         if os.path.exists(qwen_script):
             try:
-                config_path = os.path.expanduser("~/.open-ace/config.json")
-
                 result = _run_subprocess(
                     _build_cmd(
                         qwen_script,
@@ -231,13 +243,20 @@ def run_fetch_scripts():
             _fetch_status["last_result"] = results
             _fetch_status["is_running"] = False
 
-        logger.info(f"Data fetch completed: {results}")
+        all_failed = results and all(not r.get("success", False) for r in results.values())
+        if all_failed:
+            logger.error(f"All data fetch scripts failed: {results}")
+        else:
+            logger.info(f"Data fetch finished: {results}")
+
+        return results
 
     except Exception as e:
         logger.exception("Error running fetch scripts")
         with _fetch_lock:
             _fetch_status["error"] = str(e)
             _fetch_status["is_running"] = False
+        return None
 
 
 @fetch_bp.route("/fetch/data", methods=["POST"])

--- a/app/services/data_fetch_scheduler.py
+++ b/app/services/data_fetch_scheduler.py
@@ -60,6 +60,7 @@ class DataFetchScheduler:
         self._last_run = None
         self._next_run = None
         self._heartbeat = None
+        self._last_result_summary = None  # Summary of last fetch results for get_status()
         self._initialized = True
         self._implementation = SCHEDULER_IMPLEMENTATION
         self._scheduler = None  # APScheduler instance
@@ -210,6 +211,7 @@ class DataFetchScheduler:
             "heartbeat": self._heartbeat.isoformat() if self._heartbeat else None,
             "heartbeat_age_seconds": heartbeat_age,
             "heartbeat_ok": heartbeat_ok,
+            "last_result_summary": self._last_result_summary,
         }
 
     def _run_loop(self):
@@ -259,11 +261,63 @@ class DataFetchScheduler:
         self._last_run = datetime.now(tz.utc).replace(tzinfo=None)
 
         try:
-            run_fetch_scripts()
-            logger.info("Scheduled data fetch completed")
+            results = run_fetch_scripts()
+            logger.info("Scheduled data fetch finished: {}".format(
+                "skipped" if (results and results.get("_skipped")) else
+                "all_failed" if (results and all(not v.get("success", False) for v in results.values())) else
+                "completed"
+            ))
+
+            if results is None:
+                # Unexpected error in run_fetch_scripts() itself
+                status = "failed"
+                error_message = "Data fetch encountered an unexpected error"
+                self._last_result_summary = {"status": "failed", "error": "unexpected_error"}
+            elif results.get("_skipped"):
+                # Concurrent fetch already running
+                status = "skipped"
+                error_message = "Concurrent data fetch already running"
+                self._last_result_summary = {"status": "skipped"}
+            elif not results:
+                # No scripts available to run - not an error
+                status = "completed"
+                error_message = None
+                self._last_result_summary = {"status": "completed", "tools": 0}
+            else:
+                # Check per-tool results
+                failed_tools = [k for k, v in results.items() if not v.get("success", False)]
+
+                if len(failed_tools) == len(results):
+                    status = "failed"
+                    error_message = "All fetch scripts failed"
+                    self._last_result_summary = {
+                        "status": "failed",
+                        "tools_total": len(results),
+                        "tools_failed": len(failed_tools),
+                        "failed_tools": failed_tools,
+                    }
+                elif failed_tools:
+                    status = "completed"
+                    error_message = f"Partial failure: {', '.join(failed_tools)}"
+                    self._last_result_summary = {
+                        "status": "partial",
+                        "tools_total": len(results),
+                        "tools_failed": len(failed_tools),
+                        "failed_tools": failed_tools,
+                    }
+                else:
+                    status = "completed"
+                    error_message = None
+                    self._last_result_summary = {
+                        "status": "completed",
+                        "tools_total": len(results),
+                        "tools_failed": 0,
+                    }
+
         except Exception as e:
             status = "failed"
             error_message = str(e)
+            self._last_result_summary = {"status": "failed", "error": "exception"}
             logger.exception(f"Error in scheduled data fetch: {e}")
 
         # Refresh materialized views for PostgreSQL

--- a/app/services/data_fetch_scheduler.py
+++ b/app/services/data_fetch_scheduler.py
@@ -263,8 +263,10 @@ class DataFetchScheduler:
         try:
             results = run_fetch_scripts()
             logger.info("Scheduled data fetch finished: {}".format(
-                "skipped" if (results and results.get("_skipped")) else
-                "all_failed" if (results and all(not v.get("success", False) for v in results.values())) else
+                "errored" if results is None else
+                "skipped" if results.get("_skipped") else
+                "empty" if not results else
+                "all_failed" if all(not v.get("success", False) for v in results.values()) else
                 "completed"
             ))
 
@@ -282,7 +284,7 @@ class DataFetchScheduler:
                 # No scripts available to run - not an error
                 status = "completed"
                 error_message = None
-                self._last_result_summary = {"status": "completed", "tools": 0}
+                self._last_result_summary = {"status": "completed", "tools_total": 0, "tools_failed": 0}
             else:
                 # Check per-tool results
                 failed_tools = [k for k, v in results.items() if not v.get("success", False)]

--- a/app/services/data_fetch_scheduler.py
+++ b/app/services/data_fetch_scheduler.py
@@ -275,7 +275,7 @@ class DataFetchScheduler:
                 status = "failed"
                 error_message = "Data fetch encountered an unexpected error"
                 self._last_result_summary = {"status": "failed", "error": "unexpected_error"}
-            elif results.get("_skipped"):
+            elif isinstance(results, dict) and results.get("_skipped"):
                 # Concurrent fetch already running
                 status = "skipped"
                 error_message = "Concurrent data fetch already running"

--- a/app/services/data_fetch_scheduler.py
+++ b/app/services/data_fetch_scheduler.py
@@ -262,13 +262,25 @@ class DataFetchScheduler:
 
         try:
             results = run_fetch_scripts()
-            logger.info("Scheduled data fetch finished: {}".format(
-                "errored" if results is None else
-                "skipped" if results.get("_skipped") else
-                "empty" if not results else
-                "all_failed" if all(not v.get("success", False) for v in results.values()) else
-                "completed"
-            ))
+            logger.info(
+                "Scheduled data fetch finished: {}".format(
+                    "errored"
+                    if results is None
+                    else (
+                        "skipped"
+                        if results.get("_skipped")
+                        else (
+                            "empty"
+                            if not results
+                            else (
+                                "all_failed"
+                                if all(not v.get("success", False) for v in results.values())
+                                else "completed"
+                            )
+                        )
+                    )
+                )
+            )
 
             if results is None:
                 # Unexpected error in run_fetch_scripts() itself
@@ -284,7 +296,11 @@ class DataFetchScheduler:
                 # No scripts available to run - not an error
                 status = "completed"
                 error_message = None
-                self._last_result_summary = {"status": "completed", "tools_total": 0, "tools_failed": 0}
+                self._last_result_summary = {
+                    "status": "completed",
+                    "tools_total": 0,
+                    "tools_failed": 0,
+                }
             else:
                 # Check per-tool results
                 failed_tools = [k for k, v in results.items() if not v.get("success", False)]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,12 @@ import sys
 
 import pytest
 
+# Stub Unix-only modules on Windows so that app.routes.fs (and transitively
+# app.routes) can be imported during test collection and patching.
+if sys.platform == "win32":
+    sys.modules.setdefault("pwd", type(sys)("pwd"))
+    sys.modules.setdefault("grp", type(sys)("grp"))
+
 # =============================================================================
 # Issue #2185: Set default security mode for tests
 # Tests should run in development mode by default.

--- a/tests/unit/test_data_fetch_scheduler.py
+++ b/tests/unit/test_data_fetch_scheduler.py
@@ -341,8 +341,17 @@ class TestDataFetchSchedulerRunFetch:
     @patch("app.routes.fetch.run_fetch_scripts")
     @patch("app.services.leader_election.LeaderElectionClient")
     def test_run_fetch_all_failed(
-        self, mock_leader, mock_fetch, mock_mv, mock_agg, mock_ds,
-        mock_summary, mock_quotas, mock_feishu, mock_dingtalk, mock_ds_repo,
+        self,
+        mock_leader,
+        mock_fetch,
+        mock_mv,
+        mock_agg,
+        mock_ds,
+        mock_summary,
+        mock_quotas,
+        mock_feishu,
+        mock_dingtalk,
+        mock_ds_repo,
     ):
         """When all scripts fail, status should be 'failed'."""
         mock_leader.return_value.try_acquire_leadership.return_value = True
@@ -375,8 +384,17 @@ class TestDataFetchSchedulerRunFetch:
     @patch("app.routes.fetch.run_fetch_scripts")
     @patch("app.services.leader_election.LeaderElectionClient")
     def test_run_fetch_partial_failure(
-        self, mock_leader, mock_fetch, mock_mv, mock_agg, mock_ds,
-        mock_summary, mock_quotas, mock_feishu, mock_dingtalk, mock_ds_repo,
+        self,
+        mock_leader,
+        mock_fetch,
+        mock_mv,
+        mock_agg,
+        mock_ds,
+        mock_summary,
+        mock_quotas,
+        mock_feishu,
+        mock_dingtalk,
+        mock_ds_repo,
     ):
         """When some scripts fail, status=completed with warning."""
         mock_leader.return_value.try_acquire_leadership.return_value = True
@@ -411,8 +429,17 @@ class TestDataFetchSchedulerRunFetch:
     @patch("app.routes.fetch.run_fetch_scripts")
     @patch("app.services.leader_election.LeaderElectionClient")
     def test_run_fetch_no_scripts(
-        self, mock_leader, mock_fetch, mock_mv, mock_agg, mock_ds,
-        mock_summary, mock_quotas, mock_feishu, mock_dingtalk, mock_ds_repo,
+        self,
+        mock_leader,
+        mock_fetch,
+        mock_mv,
+        mock_agg,
+        mock_ds,
+        mock_summary,
+        mock_quotas,
+        mock_feishu,
+        mock_dingtalk,
+        mock_ds_repo,
     ):
         """Empty results (no scripts) should be 'completed', not 'failed'."""
         mock_leader.return_value.try_acquire_leadership.return_value = True
@@ -439,8 +466,17 @@ class TestDataFetchSchedulerRunFetch:
     @patch("app.routes.fetch.run_fetch_scripts")
     @patch("app.services.leader_election.LeaderElectionClient")
     def test_run_fetch_skipped(
-        self, mock_leader, mock_fetch, mock_mv, mock_agg, mock_ds,
-        mock_summary, mock_quotas, mock_feishu, mock_dingtalk, mock_ds_repo,
+        self,
+        mock_leader,
+        mock_fetch,
+        mock_mv,
+        mock_agg,
+        mock_ds,
+        mock_summary,
+        mock_quotas,
+        mock_feishu,
+        mock_dingtalk,
+        mock_ds_repo,
     ):
         """Concurrent fetch skip should be 'skipped'."""
         mock_leader.return_value.try_acquire_leadership.return_value = True
@@ -465,8 +501,17 @@ class TestDataFetchSchedulerRunFetch:
     @patch("app.routes.fetch.run_fetch_scripts")
     @patch("app.services.leader_election.LeaderElectionClient")
     def test_run_fetch_none_result(
-        self, mock_leader, mock_fetch, mock_mv, mock_agg, mock_ds,
-        mock_summary, mock_quotas, mock_feishu, mock_dingtalk, mock_ds_repo,
+        self,
+        mock_leader,
+        mock_fetch,
+        mock_mv,
+        mock_agg,
+        mock_ds,
+        mock_summary,
+        mock_quotas,
+        mock_feishu,
+        mock_dingtalk,
+        mock_ds_repo,
     ):
         """None result (unexpected error) should be 'failed'."""
         mock_leader.return_value.try_acquire_leadership.return_value = True
@@ -492,8 +537,17 @@ class TestDataFetchSchedulerRunFetch:
     @patch("app.routes.fetch.run_fetch_scripts")
     @patch("app.services.leader_election.LeaderElectionClient")
     def test_run_fetch_all_success(
-        self, mock_leader, mock_fetch, mock_mv, mock_agg, mock_ds,
-        mock_summary, mock_quotas, mock_feishu, mock_dingtalk, mock_ds_repo,
+        self,
+        mock_leader,
+        mock_fetch,
+        mock_mv,
+        mock_agg,
+        mock_ds,
+        mock_summary,
+        mock_quotas,
+        mock_feishu,
+        mock_dingtalk,
+        mock_ds_repo,
     ):
         """All scripts success should be 'completed'."""
         mock_leader.return_value.try_acquire_leadership.return_value = True

--- a/tests/unit/test_data_fetch_scheduler.py
+++ b/tests/unit/test_data_fetch_scheduler.py
@@ -232,6 +232,8 @@ class TestDataFetchSchedulerRunFetch:
         # Should still call other steps
         mock_mv.assert_called_once()
         mock_agg.assert_called_once()
+        # Verify exception path sets last_result_summary correctly
+        assert s._last_result_summary == {"status": "failed", "error": "exception"}
 
     @patch("app.repositories.database.is_postgresql", return_value=False)
     @patch("app.repositories.database.Database")

--- a/tests/unit/test_data_fetch_scheduler.py
+++ b/tests/unit/test_data_fetch_scheduler.py
@@ -328,27 +328,6 @@ class TestDataFetchSchedulerRunFetch:
 
     # ---- Issue #2375: fetch result propagation tests ----
 
-    def _make_run_fetch_mocks(self, mock_fetch_return_value):
-        """Helper to set up mocks for _run_fetch() tests.
-        
-        Mocks leader election (succeeds), run_fetch_scripts (returns given value),
-        and all post-fetch cleanup steps.
-        """
-        mocks = {
-            "leader_client": MagicMock(),
-            "fetch": MagicMock(),
-            "mv": MagicMock(),
-            "agg": MagicMock(),
-            "summary": MagicMock(),
-            "quotas": MagicMock(),
-            "daily_stats": MagicMock(),
-            "feishu": MagicMock(),
-            "dingtalk": MagicMock(),
-        }
-        mocks["leader_client"].return_value.try_acquire_leadership.return_value = True
-        mocks["fetch"].return_value = mock_fetch_return_value
-        return mocks
-
     @patch("app.repositories.daily_stats_repo.DailyStatsRepository")
     @patch("app.services.data_fetch_scheduler.DataFetchScheduler._maybe_sync_dingtalk_org")
     @patch("app.services.data_fetch_scheduler.DataFetchScheduler._maybe_sync_feishu_org")
@@ -444,7 +423,8 @@ class TestDataFetchSchedulerRunFetch:
         call_args = mock_leader.return_value.record_run.call_args[0]
         assert call_args[0] == "completed"
         assert s._last_result_summary["status"] == "completed"
-        assert s._last_result_summary["tools"] == 0
+        assert s._last_result_summary["tools_total"] == 0
+        assert s._last_result_summary["tools_failed"] == 0
 
     @patch("app.repositories.daily_stats_repo.DailyStatsRepository")
     @patch("app.services.data_fetch_scheduler.DataFetchScheduler._maybe_sync_dingtalk_org")

--- a/tests/unit/test_data_fetch_scheduler.py
+++ b/tests/unit/test_data_fetch_scheduler.py
@@ -198,11 +198,14 @@ class TestDataFetchSchedulerRunFetch:
         # Mock leader election to always succeed
         mock_client_instance = mock_leader_client.return_value
         mock_client_instance.try_acquire_leadership.return_value = True
+        mock_fetch.return_value = {"qwen": {"success": True}}
 
         s = DataFetchScheduler()
         s._run_fetch()
         mock_fetch.assert_called_once()
         assert s._last_run is not None
+        assert s._last_result_summary is not None
+        assert s._last_result_summary["status"] == "completed"
 
     @patch("app.services.leader_election.LeaderElectionClient")
     @patch("app.services.data_fetch_scheduler.DataFetchScheduler._check_quotas")
@@ -322,6 +325,213 @@ class TestDataFetchSchedulerRunFetch:
         s._refresh_daily_stats()  # Should not raise
         # Repository instantiation was attempted (and its failure swallowed)
         mock_repo_cls.assert_called_once()
+
+    # ---- Issue #2375: fetch result propagation tests ----
+
+    def _make_run_fetch_mocks(self, mock_fetch_return_value):
+        """Helper to set up mocks for _run_fetch() tests.
+        
+        Mocks leader election (succeeds), run_fetch_scripts (returns given value),
+        and all post-fetch cleanup steps.
+        """
+        mocks = {
+            "leader_client": MagicMock(),
+            "fetch": MagicMock(),
+            "mv": MagicMock(),
+            "agg": MagicMock(),
+            "summary": MagicMock(),
+            "quotas": MagicMock(),
+            "daily_stats": MagicMock(),
+            "feishu": MagicMock(),
+            "dingtalk": MagicMock(),
+        }
+        mocks["leader_client"].return_value.try_acquire_leadership.return_value = True
+        mocks["fetch"].return_value = mock_fetch_return_value
+        return mocks
+
+    @patch("app.repositories.daily_stats_repo.DailyStatsRepository")
+    @patch("app.services.data_fetch_scheduler.DataFetchScheduler._maybe_sync_dingtalk_org")
+    @patch("app.services.data_fetch_scheduler.DataFetchScheduler._maybe_sync_feishu_org")
+    @patch("app.services.data_fetch_scheduler.DataFetchScheduler._check_quotas")
+    @patch("app.services.data_fetch_scheduler.DataFetchScheduler._refresh_usage_summary")
+    @patch("app.services.data_fetch_scheduler.DataFetchScheduler._refresh_daily_stats")
+    @patch("app.services.data_fetch_scheduler.DataFetchScheduler._aggregate_user_stats")
+    @patch("app.services.data_fetch_scheduler.DataFetchScheduler._refresh_materialized_views")
+    @patch("app.routes.fetch.run_fetch_scripts")
+    @patch("app.services.leader_election.LeaderElectionClient")
+    def test_run_fetch_all_failed(
+        self, mock_leader, mock_fetch, mock_mv, mock_agg, mock_ds,
+        mock_summary, mock_quotas, mock_feishu, mock_dingtalk, mock_ds_repo,
+    ):
+        """When all scripts fail, status should be 'failed'."""
+        mock_leader.return_value.try_acquire_leadership.return_value = True
+        mock_fetch.return_value = {
+            "qwen": {"success": False, "error": "sudo: password required"},
+            "claude": {"success": False, "error": "sudo: password required"},
+            "openclaw": {"success": False, "error": "sudo: password required"},
+            "codex": {"success": False, "error": "sudo: password required"},
+            "zcode": {"success": False, "error": "sudo: password required"},
+        }
+
+        s = DataFetchScheduler()
+        s._run_fetch()
+
+        mock_leader.return_value.record_run.assert_called_once()
+        call_args = mock_leader.return_value.record_run.call_args[0]
+        assert call_args[0] == "failed"  # status
+        assert "All fetch scripts failed" in call_args[2]  # error_message
+        assert s._last_result_summary["status"] == "failed"
+        assert s._last_result_summary["tools_failed"] == 5
+
+    @patch("app.repositories.daily_stats_repo.DailyStatsRepository")
+    @patch("app.services.data_fetch_scheduler.DataFetchScheduler._maybe_sync_dingtalk_org")
+    @patch("app.services.data_fetch_scheduler.DataFetchScheduler._maybe_sync_feishu_org")
+    @patch("app.services.data_fetch_scheduler.DataFetchScheduler._check_quotas")
+    @patch("app.services.data_fetch_scheduler.DataFetchScheduler._refresh_usage_summary")
+    @patch("app.services.data_fetch_scheduler.DataFetchScheduler._refresh_daily_stats")
+    @patch("app.services.data_fetch_scheduler.DataFetchScheduler._aggregate_user_stats")
+    @patch("app.services.data_fetch_scheduler.DataFetchScheduler._refresh_materialized_views")
+    @patch("app.routes.fetch.run_fetch_scripts")
+    @patch("app.services.leader_election.LeaderElectionClient")
+    def test_run_fetch_partial_failure(
+        self, mock_leader, mock_fetch, mock_mv, mock_agg, mock_ds,
+        mock_summary, mock_quotas, mock_feishu, mock_dingtalk, mock_ds_repo,
+    ):
+        """When some scripts fail, status=completed with warning."""
+        mock_leader.return_value.try_acquire_leadership.return_value = True
+        mock_fetch.return_value = {
+            "qwen": {"success": True},
+            "claude": {"success": True},
+            "openclaw": {"success": True},
+            "codex": {"success": False, "error": "timeout"},
+            "zcode": {"success": False, "error": "disk full"},
+        }
+
+        s = DataFetchScheduler()
+        s._run_fetch()
+
+        mock_leader.return_value.record_run.assert_called_once()
+        call_args = mock_leader.return_value.record_run.call_args[0]
+        assert call_args[0] == "completed"  # partial failure is still "completed"
+        assert "Partial failure" in call_args[2]
+        assert "codex" in call_args[2]
+        assert "zcode" in call_args[2]
+        assert s._last_result_summary["status"] == "partial"
+        assert s._last_result_summary["tools_failed"] == 2
+
+    @patch("app.repositories.daily_stats_repo.DailyStatsRepository")
+    @patch("app.services.data_fetch_scheduler.DataFetchScheduler._maybe_sync_dingtalk_org")
+    @patch("app.services.data_fetch_scheduler.DataFetchScheduler._maybe_sync_feishu_org")
+    @patch("app.services.data_fetch_scheduler.DataFetchScheduler._check_quotas")
+    @patch("app.services.data_fetch_scheduler.DataFetchScheduler._refresh_usage_summary")
+    @patch("app.services.data_fetch_scheduler.DataFetchScheduler._refresh_daily_stats")
+    @patch("app.services.data_fetch_scheduler.DataFetchScheduler._aggregate_user_stats")
+    @patch("app.services.data_fetch_scheduler.DataFetchScheduler._refresh_materialized_views")
+    @patch("app.routes.fetch.run_fetch_scripts")
+    @patch("app.services.leader_election.LeaderElectionClient")
+    def test_run_fetch_no_scripts(
+        self, mock_leader, mock_fetch, mock_mv, mock_agg, mock_ds,
+        mock_summary, mock_quotas, mock_feishu, mock_dingtalk, mock_ds_repo,
+    ):
+        """Empty results (no scripts) should be 'completed', not 'failed'."""
+        mock_leader.return_value.try_acquire_leadership.return_value = True
+        mock_fetch.return_value = {}
+
+        s = DataFetchScheduler()
+        s._run_fetch()
+
+        mock_leader.return_value.record_run.assert_called_once()
+        call_args = mock_leader.return_value.record_run.call_args[0]
+        assert call_args[0] == "completed"
+        assert s._last_result_summary["status"] == "completed"
+        assert s._last_result_summary["tools"] == 0
+
+    @patch("app.repositories.daily_stats_repo.DailyStatsRepository")
+    @patch("app.services.data_fetch_scheduler.DataFetchScheduler._maybe_sync_dingtalk_org")
+    @patch("app.services.data_fetch_scheduler.DataFetchScheduler._maybe_sync_feishu_org")
+    @patch("app.services.data_fetch_scheduler.DataFetchScheduler._check_quotas")
+    @patch("app.services.data_fetch_scheduler.DataFetchScheduler._refresh_usage_summary")
+    @patch("app.services.data_fetch_scheduler.DataFetchScheduler._refresh_daily_stats")
+    @patch("app.services.data_fetch_scheduler.DataFetchScheduler._aggregate_user_stats")
+    @patch("app.services.data_fetch_scheduler.DataFetchScheduler._refresh_materialized_views")
+    @patch("app.routes.fetch.run_fetch_scripts")
+    @patch("app.services.leader_election.LeaderElectionClient")
+    def test_run_fetch_skipped(
+        self, mock_leader, mock_fetch, mock_mv, mock_agg, mock_ds,
+        mock_summary, mock_quotas, mock_feishu, mock_dingtalk, mock_ds_repo,
+    ):
+        """Concurrent fetch skip should be 'skipped'."""
+        mock_leader.return_value.try_acquire_leadership.return_value = True
+        mock_fetch.return_value = {"_skipped": True}
+
+        s = DataFetchScheduler()
+        s._run_fetch()
+
+        mock_leader.return_value.record_run.assert_called_once()
+        call_args = mock_leader.return_value.record_run.call_args[0]
+        assert call_args[0] == "skipped"
+        assert s._last_result_summary["status"] == "skipped"
+
+    @patch("app.repositories.daily_stats_repo.DailyStatsRepository")
+    @patch("app.services.data_fetch_scheduler.DataFetchScheduler._maybe_sync_dingtalk_org")
+    @patch("app.services.data_fetch_scheduler.DataFetchScheduler._maybe_sync_feishu_org")
+    @patch("app.services.data_fetch_scheduler.DataFetchScheduler._check_quotas")
+    @patch("app.services.data_fetch_scheduler.DataFetchScheduler._refresh_usage_summary")
+    @patch("app.services.data_fetch_scheduler.DataFetchScheduler._refresh_daily_stats")
+    @patch("app.services.data_fetch_scheduler.DataFetchScheduler._aggregate_user_stats")
+    @patch("app.services.data_fetch_scheduler.DataFetchScheduler._refresh_materialized_views")
+    @patch("app.routes.fetch.run_fetch_scripts")
+    @patch("app.services.leader_election.LeaderElectionClient")
+    def test_run_fetch_none_result(
+        self, mock_leader, mock_fetch, mock_mv, mock_agg, mock_ds,
+        mock_summary, mock_quotas, mock_feishu, mock_dingtalk, mock_ds_repo,
+    ):
+        """None result (unexpected error) should be 'failed'."""
+        mock_leader.return_value.try_acquire_leadership.return_value = True
+        mock_fetch.return_value = None
+
+        s = DataFetchScheduler()
+        s._run_fetch()
+
+        mock_leader.return_value.record_run.assert_called_once()
+        call_args = mock_leader.return_value.record_run.call_args[0]
+        assert call_args[0] == "failed"
+        assert "unexpected error" in call_args[2].lower()
+        assert s._last_result_summary["status"] == "failed"
+
+    @patch("app.repositories.daily_stats_repo.DailyStatsRepository")
+    @patch("app.services.data_fetch_scheduler.DataFetchScheduler._maybe_sync_dingtalk_org")
+    @patch("app.services.data_fetch_scheduler.DataFetchScheduler._maybe_sync_feishu_org")
+    @patch("app.services.data_fetch_scheduler.DataFetchScheduler._check_quotas")
+    @patch("app.services.data_fetch_scheduler.DataFetchScheduler._refresh_usage_summary")
+    @patch("app.services.data_fetch_scheduler.DataFetchScheduler._refresh_daily_stats")
+    @patch("app.services.data_fetch_scheduler.DataFetchScheduler._aggregate_user_stats")
+    @patch("app.services.data_fetch_scheduler.DataFetchScheduler._refresh_materialized_views")
+    @patch("app.routes.fetch.run_fetch_scripts")
+    @patch("app.services.leader_election.LeaderElectionClient")
+    def test_run_fetch_all_success(
+        self, mock_leader, mock_fetch, mock_mv, mock_agg, mock_ds,
+        mock_summary, mock_quotas, mock_feishu, mock_dingtalk, mock_ds_repo,
+    ):
+        """All scripts success should be 'completed'."""
+        mock_leader.return_value.try_acquire_leadership.return_value = True
+        mock_fetch.return_value = {
+            "qwen": {"success": True},
+            "claude": {"success": True},
+            "openclaw": {"success": True},
+            "codex": {"success": True},
+            "zcode": {"success": True},
+        }
+
+        s = DataFetchScheduler()
+        s._run_fetch()
+
+        mock_leader.return_value.record_run.assert_called_once()
+        call_args = mock_leader.return_value.record_run.call_args[0]
+        assert call_args[0] == "completed"
+        assert call_args[2] is None  # No error message
+        assert s._last_result_summary["status"] == "completed"
+        assert s._last_result_summary["tools_failed"] == 0
 
 
 class TestDataFetchSchedulerCheckQuotas:

--- a/tests/unit/test_fetch.py
+++ b/tests/unit/test_fetch.py
@@ -1,0 +1,175 @@
+"""Unit tests for fetch route functions (Issue #2375)."""
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+# Stub Unix-only modules on Windows
+if sys.platform == "win32":
+    sys.modules.setdefault("pwd", type(sys)("pwd"))
+    sys.modules.setdefault("grp", type(sys)("grp"))
+
+import pytest
+
+from app.routes.fetch import run_fetch_scripts
+
+
+class TestRunFetchScriptsReturns:
+    """Test that run_fetch_scripts() properly returns results."""
+
+    def setup_method(self):
+        """Reset global fetch status before each test."""
+        from app.routes import fetch as fetch_mod
+
+        fetch_mod._fetch_status = {
+            "is_running": False,
+            "last_run": None,
+            "last_result": None,
+            "error": None,
+        }
+
+    @patch("os.path.exists", return_value=False)
+    @patch("app.routes.fetch._run_subprocess")
+    def test_returns_results_when_no_scripts(self, mock_run, mock_exists):
+        """When no scripts exist, results should be empty dict."""
+        with patch.dict(os.environ, {"FETCH_USE_SUDO": "false"}):
+            result = run_fetch_scripts()
+
+        assert result == {}
+        assert "_skipped" not in result
+
+    @patch("os.path.exists", return_value=True)
+    @patch("app.routes.fetch._run_subprocess")
+    def test_returns_skipped_when_concurrent(self, mock_run, mock_exists):
+        """When is_running is True, return {"_skipped": True}."""
+        from app.routes import fetch as fetch_mod
+
+        # Simulate concurrent fetch
+        fetch_mod._fetch_status["is_running"] = True
+
+        result = run_fetch_scripts()
+
+        assert result == {"_skipped": True}
+        mock_run.assert_not_called()
+
+    @patch("os.path.exists", return_value=True)
+    @patch("app.routes.fetch._run_subprocess")
+    def test_returns_results_with_success(self, mock_run, mock_exists):
+        """Verify function returns results dict on success."""
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "OK"
+        mock_result.stderr = ""
+        mock_run.return_value = mock_result
+
+        with patch.dict(os.environ, {"FETCH_USE_SUDO": "false"}):
+            result = run_fetch_scripts()
+
+        assert isinstance(result, dict)
+        # All 5 scripts should be present
+        assert "qwen" in result
+        assert "claude" in result
+        assert "openclaw" in result
+        assert "codex" in result
+        assert "zcode" in result
+        # All should report success
+        for tool_name in ("qwen", "claude", "openclaw", "codex", "zcode"):
+            assert result[tool_name]["success"] is True
+
+    @patch("os.path.exists", return_value=True)
+    @patch("app.routes.fetch._run_subprocess")
+    def test_returns_results_with_failure(self, mock_run, mock_exists):
+        """Verify function returns results dict with failure info."""
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_result.stdout = ""
+        mock_result.stderr = "sudo: password required"
+        mock_run.return_value = mock_result
+
+        with patch.dict(os.environ, {"FETCH_USE_SUDO": "false"}):
+            result = run_fetch_scripts()
+
+        assert isinstance(result, dict)
+        assert all(not v["success"] for v in result.values())
+
+    @patch("os.path.exists", return_value=True)
+    @patch("app.routes.fetch._run_subprocess")
+    def test_returns_none_on_unexpected_error(self, mock_run, mock_exists):
+        """When outer handler catches exception, return None."""
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "OK"
+        mock_result.stderr = ""
+        mock_run.return_value = mock_result
+
+        # Force an unexpected error by making _fetch_status None
+        with patch.dict(os.environ, {"FETCH_USE_SUDO": "false"}):
+            with patch("app.routes.fetch._fetch_lock") as mock_lock:
+                # Cause an exception in the try block after scripts complete
+                with patch("app.routes.fetch.datetime") as mock_dt:
+                    mock_dt.now.side_effect = RuntimeError("Simulated unexpected error")
+                    result = run_fetch_scripts()
+
+        assert result is None
+
+
+class TestConfigPathScope:
+    """Test Bug 3 fix: config_path must be defined outside per-script blocks."""
+
+    def setup_method(self):
+        from app.routes import fetch as fetch_mod
+
+        fetch_mod._fetch_status = {
+            "is_running": False,
+            "last_run": None,
+            "last_result": None,
+            "error": None,
+        }
+
+    def test_config_path_available_when_qwen_missing(self):
+        """config_path should be usable even if qwen script doesn't exist."""
+        import app.routes.fetch as fetch_mod
+
+        # Simulate: qwen script missing, but other scripts exist
+        original_exists = os.path.exists
+
+        def selective_exists(path):
+            if "fetch_qwen" in path:
+                return False
+            if "fetch_claude" in path or "fetch_openclaw" in path or "fetch_codex" in path or "fetch_zcode" in path:
+                return True
+            return original_exists(path)
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "OK"
+        mock_result.stderr = ""
+
+        with patch.dict(os.environ, {"FETCH_USE_SUDO": "false"}):
+            with patch("os.path.exists", side_effect=selective_exists):
+                with patch("app.routes.fetch._run_subprocess", return_value=mock_result):
+                    # Should NOT raise NameError for config_path
+                    result = run_fetch_scripts()
+
+        assert isinstance(result, dict)
+        assert "qwen" not in result  # Script doesn't exist, skipped
+        assert "claude" in result  # Should run successfully
+        assert result["claude"]["success"] is True
+
+    def test_config_path_default_false_for_sudo(self):
+        """FETCH_USE_SUDO default should be false."""
+        # Verify the default by reading the source
+        import app.routes.fetch as fetch_mod
+
+        # Check the source uses "false" as default
+        source = fetch_mod.run_fetch_scripts.__code__.co_consts
+        # The default is stored as a constant in the code object
+        # Direct test: with no env var set, sudo should not be used
+        with patch.dict(os.environ, {}, clear=True):
+            with patch.dict(os.environ, {"FETCH_USE_SUDO": ""}):
+                # Clear FETCH_USE_SUDO to test default
+                pass
+            # The default "false" means use_sudo will be False
+            # This is implicitly tested by the fact that _run_subprocess
+            # commands would not include "sudo" when scripts don't exist
+            assert True  # The default is verified at code review level

--- a/tests/unit/test_fetch.py
+++ b/tests/unit/test_fetch.py
@@ -104,7 +104,7 @@ class TestRunFetchScriptsReturns:
 
         # Force an unexpected error by making _fetch_status None
         with patch.dict(os.environ, {"FETCH_USE_SUDO": "false"}):
-            with patch("app.routes.fetch._fetch_lock") as mock_lock:
+            with patch("app.routes.fetch._fetch_lock"):
                 # Cause an exception in the try block after scripts complete
                 with patch("app.routes.fetch.datetime") as mock_dt:
                     mock_dt.now.side_effect = RuntimeError("Simulated unexpected error")

--- a/tests/unit/test_fetch.py
+++ b/tests/unit/test_fetch.py
@@ -136,7 +136,12 @@ class TestConfigPathScope:
         def selective_exists(path):
             if "fetch_qwen" in path:
                 return False
-            if "fetch_claude" in path or "fetch_openclaw" in path or "fetch_codex" in path or "fetch_zcode" in path:
+            if (
+                "fetch_claude" in path
+                or "fetch_openclaw" in path
+                or "fetch_codex" in path
+                or "fetch_zcode" in path
+            ):
                 return True
             return original_exists(path)
 
@@ -158,9 +163,10 @@ class TestConfigPathScope:
 
     def test_config_path_default_false_for_sudo(self):
         """FETCH_USE_SUDO default should be false."""
+        import inspect
+
         import app.routes.fetch as fetch_mod
 
-        import inspect
         source = inspect.getsource(fetch_mod.run_fetch_scripts)
         # Verify the default is "false" in getenv call
         assert '"FETCH_USE_SUDO", "false")' in source

--- a/tests/unit/test_fetch.py
+++ b/tests/unit/test_fetch.py
@@ -158,18 +158,10 @@ class TestConfigPathScope:
 
     def test_config_path_default_false_for_sudo(self):
         """FETCH_USE_SUDO default should be false."""
-        # Verify the default by reading the source
         import app.routes.fetch as fetch_mod
 
-        # Check the source uses "false" as default
-        source = fetch_mod.run_fetch_scripts.__code__.co_consts
-        # The default is stored as a constant in the code object
-        # Direct test: with no env var set, sudo should not be used
-        with patch.dict(os.environ, {}, clear=True):
-            with patch.dict(os.environ, {"FETCH_USE_SUDO": ""}):
-                # Clear FETCH_USE_SUDO to test default
-                pass
-            # The default "false" means use_sudo will be False
-            # This is implicitly tested by the fact that _run_subprocess
-            # commands would not include "sudo" when scripts don't exist
-            assert True  # The default is verified at code review level
+        import inspect
+        source = inspect.getsource(fetch_mod.run_fetch_scripts)
+        # Verify the default is "false" in getenv call
+        assert '"FETCH_USE_SUDO", "false")' in source
+        assert '"FETCH_USE_SUDO", "true")' not in source


### PR DESCRIPTION
## 修复说明

关联 Issue：#2375

## 根因

3 个独立 Bug 导致 fetch 脚本全部失败时调度器静默报告 "completed"：

1. **Bug 1（P0）**：`run_fetch_scripts()` 不返回 results，`_run_fetch()` 仅通过异常检测失败——但 `run_fetch_scripts()` 内部吞掉所有异常，导致 except 分支成为死代码。
2. **Bug 2（P1）**：`is_running` 并发竞态——API 触发的手动 fetch 与调度器定时 fetch 重叠时，后者直接 return None，调度器仍报告 "completed"。
3. **Bug 3（P2）**：`config_path` 定义在 `if os.path.exists(qwen_script)` 块内——若 qwen script 缺失，后续 4 个脚本全部 NameError。

## 修复方案

### `app/routes/fetch.py` — `run_fetch_scripts()`
- 返回 `results` 字典（正常）或 `{"_skipped": True}`（并发跳过）或 None（意外错误）
- `config_path` 移到所有 per-script 块之外
- `FETCH_USE_SUDO` 默认改为 `"false"`
- 日志区分 all_failed 和部分成功

### `app/services/data_fetch_scheduler.py` — `_run_fetch()`
- 捕获 `run_fetch_scripts()` 返回值，6 状态决策树：

```
results is None           → failed   (意外错误)
results._skipped == True  → skipped  (并发跳过)
results == {}             → completed (无脚本)
len(failed) == len(all)   → failed   (全部失败)
len(failed) > 0           → completed (部分失败, warning)
len(failed) == 0          → completed (全部成功)
```

- `get_status()` 增加 `last_result_summary` 字段

### `tests/conftest.py`
- 添加 Windows `pwd`/`grp` stub（修复 CI Windows 测试环境）

## 主要变更

| 文件 | 变更 |
|------|------|
| `app/routes/fetch.py` | 返回 results、config_path 作用域修复、SUDO 默认值、日志改进 |
| `app/services/data_fetch_scheduler.py` | 6 状态机检查、`get_status()` 增强 |
| `tests/conftest.py` | Windows pwd/grp stub |
| `tests/unit/test_data_fetch_scheduler.py` | 新增 6 测试 + 修改 1 现有测试 |
| `tests/unit/test_fetch.py` | 新建 7 测试 |

## 测试

- 本地 `test_fetch.py`：7/7 通过
- 本地 `test_data_fetch_scheduler.py`：51/51 通过（含 6 个新增 + 1 个修改）
- 新增测试覆盖：全部失败、部分失败、无脚本、并发跳过、None 返回值、全部成功、config_path 作用域、SUDO 默认值

## 风险

- 兼容性：`run_fetch_scripts()` 返回值变更向后兼容——`api_fetch_data()` threaded 调用不捕获返回值
- `FETCH_USE_SUDO` 默认值从 `"true"` 改为 `"false"`：生产环境 `docker-compose.yml` 和 `install.sh` 已显式设置 `FETCH_USE_SUDO=false`，实际影响仅限于未设置该环境变量的裸机部署
- `last_result_summary` 为纯增量字段，不破坏现有 API 消费者