### PR TITLE
feat: add auto-mapping UI panel and fix tenant isolation vulnerabilities (#2374)

### DIFF
--- a/app/routes/mapping_rules.py
+++ b/app/routes/mapping_rules.py
@@ -283,14 +283,16 @@ def get_mapping_stats():
     Get mapping statistics.
 
     Issue #2180: Tenant admin sees only their tenant's stats.
+    Issue #2374: Changed to fail-closed pattern for consistency.
     """
     user_role = g.user.get("role")
     user_tenant_id = g.user.get("tenant_id")
 
     service = ToolAccountAutoMappingService()
 
-    if user_role == "tenant_admin" and user_tenant_id is not None:
-        # Filter stats by tenant
+    if user_role == "tenant_admin":
+        if user_tenant_id is None:
+            return jsonify({"error": "Tenant admin must have tenant_id"}), 403
         stats = service.get_mapping_stats(tenant_id=user_tenant_id)
     else:
         stats = service.get_mapping_stats()
@@ -305,6 +307,7 @@ def run_auto_mapping():
     Run auto-mapping for all unmapped accounts.
 
     Issue #2180: Tenant admin can only run for their tenant.
+    Issue #2374: Changed to fail-closed pattern for consistency.
     """
     data = request.get_json() or {}
     dry_run = data.get("dry_run", False)
@@ -314,8 +317,9 @@ def run_auto_mapping():
 
     service = ToolAccountAutoMappingService()
 
-    if user_role == "tenant_admin" and user_tenant_id is not None:
-        # Only auto-map for tenant's users
+    if user_role == "tenant_admin":
+        if user_tenant_id is None:
+            return jsonify({"error": "Tenant admin must have tenant_id"}), 403
         results, still_unmapped = service.run_auto_mapping(
             dry_run=dry_run, tenant_id=user_tenant_id
         )
@@ -335,7 +339,10 @@ def run_auto_mapping():
 @mapping_rules_bp.route("/api/mapping-rules/test-match", methods=["POST"])
 @admin_required
 def test_match():
-    """Test if a tool_account matches any rules."""
+    """Test if a tool_account matches any rules.
+
+    Issue #2374: Added tenant isolation for tenant_admin.
+    """
     data = request.get_json()
     if not data:
         return jsonify({"error": "No data provided"}), 400
@@ -344,8 +351,20 @@ def test_match():
     if not tool_account:
         return jsonify({"error": "tool_account is required"}), 400
 
+    user_role = g.user.get("role")
+    user_tenant_id = g.user.get("tenant_id")
+
     service = ToolAccountAutoMappingService()
-    result = service.auto_map_account(tool_account, data.get("tool_type"))
+
+    # Issue #2374: Pass tenant_id for tenant_admin to prevent cross-tenant matching
+    if user_role == "tenant_admin":
+        if user_tenant_id is None:
+            return jsonify({"error": "Tenant admin must have tenant_id"}), 403
+        result = service.auto_map_account(
+            tool_account, data.get("tool_type"), tenant_id=user_tenant_id
+        )
+    else:
+        result = service.auto_map_account(tool_account, data.get("tool_type"))
 
     if result:
         return jsonify(
@@ -368,13 +387,16 @@ def get_unmapped_accounts():
     Get list of unmapped tool accounts.
 
     Issue #2180: Tenant admin sees only their tenant's unmapped accounts.
+    Issue #2374: Changed to fail-closed pattern for consistency.
     """
     user_role = g.user.get("role")
     user_tenant_id = g.user.get("tenant_id")
 
     repo = UserToolAccountRepository()
 
-    if user_role == "tenant_admin" and user_tenant_id is not None:
+    if user_role == "tenant_admin":
+        if user_tenant_id is None:
+            return jsonify({"error": "Tenant admin must have tenant_id"}), 403
         unmapped = repo.get_unmapped_tool_accounts(tenant_id=user_tenant_id)
     else:
         unmapped = repo.get_unmapped_tool_accounts()
@@ -390,9 +412,22 @@ def get_unmapped_accounts():
 @mapping_rules_bp.route("/api/unmapped-accounts/<sender_name>/suggest-mapping", methods=["GET"])
 @admin_required
 def suggest_mapping(sender_name: str):
-    """Get suggested mapping for an unmapped account."""
+    """Get suggested mapping for an unmapped account.
+
+    Issue #2374: Added tenant isolation for tenant_admin.
+    """
+    user_role = g.user.get("role")
+    user_tenant_id = g.user.get("tenant_id")
+
     service = ToolAccountAutoMappingService()
-    result = service.auto_map_account(sender_name)
+
+    # Issue #2374: Pass tenant_id for tenant_admin to prevent cross-tenant matching
+    if user_role == "tenant_admin":
+        if user_tenant_id is None:
+            return jsonify({"error": "Tenant admin must have tenant_id"}), 403
+        result = service.auto_map_account(sender_name, tenant_id=user_tenant_id)
+    else:
+        result = service.auto_map_account(sender_name)
 
     if result:
         return jsonify(

--- a/app/routes/mapping_rules.py
+++ b/app/routes/mapping_rules.py
@@ -439,7 +439,14 @@ def suggest_mapping(sender_name: str):
             }
         )
     else:
-        return jsonify({"suggestion": None})
+        return jsonify(
+            {
+                "suggested_user_id": None,
+                "suggested_username": None,
+                "matched_by": None,
+                "rule_id": None,
+            }
+        )
 
 
 @mapping_rules_bp.route("/api/unmapped-accounts/<sender_name>/map", methods=["POST"])

--- a/app/services/tool_account_auto_mapping_service.py
+++ b/app/services/tool_account_auto_mapping_service.py
@@ -52,23 +52,38 @@ class ToolAccountAutoMappingService:
         self.mapping_repo = UserToolAccountRepository(db)
         self._users_cache: dict[int, User] | None = None  # Cache for N+1 optimization
 
-    def _get_users_cache(self) -> dict[int, User]:
-        """Get cached user dict (keyed by user_id) for N+1 optimization."""
+    def _get_users_cache(self, tenant_id: int | None = None) -> dict[int, User]:
+        """Get cached user dict (keyed by user_id) for N+1 optimization.
+
+        Issue #2374: Cache is request-scoped because each HTTP request creates
+        a new ToolAccountAutoMappingService instance, so there is no cross-request
+        cache pollution risk.
+        """
         if self._users_cache is None:
-            users = self.get_all_users()
+            users = self.get_all_users(tenant_id=tenant_id)
             self._users_cache = {user.id: user for user in users if user.id is not None}
         return self._users_cache
 
-    def get_all_users(self) -> list[User]:
-        """Get all active users with auto_mapping enabled."""
+    def get_all_users(self, tenant_id: int | None = None) -> list[User]:
+        """Get all active users with auto_mapping enabled.
+
+        Issue #2374: If tenant_id is provided, filter users by tenant.
+        """
+        params: tuple = ()
+        tenant_filter = ""
+        if tenant_id is not None:
+            tenant_filter = " AND tenant_id = ?"
+            params = (tenant_id,)
+
         query = f"""
-            SELECT id, username, email, role, is_active, auto_mapping_enabled
+            SELECT id, username, email, role, is_active, auto_mapping_enabled, tenant_id
             FROM users
             WHERE {adapt_boolean_condition('is_active', True)}
               AND (auto_mapping_enabled IS NULL
                    OR {adapt_boolean_condition('auto_mapping_enabled', True)})
+              {tenant_filter}
         """
-        rows = self.db.fetch_all(query)
+        rows = self.db.fetch_all(query, params if params else None)
         return [
             User(
                 id=row.get("id"),
@@ -76,6 +91,7 @@ class ToolAccountAutoMappingService:
                 email=row.get("email", ""),
                 role=row.get("role", "user"),
                 is_active=row.get("is_active", True),
+                tenant_id=row.get("tenant_id"),
             )
             for row in rows
         ]
@@ -156,18 +172,27 @@ class ToolAccountAutoMappingService:
         return None
 
     def try_match_by_rules(
-        self, tool_account: str, tool_type: str | None = None
+        self, tool_account: str, tool_type: str | None = None, tenant_id: int | None = None
     ) -> AutoMappingResult | None:
         """
         Try to match tool_account using custom rules.
 
         Rules are checked in priority order (higher priority first).
         Uses cached users to avoid N+1 queries.
+
+        Issue #2374: If tenant_id is provided, skip rules belonging to users
+        outside the tenant to prevent cross-tenant matching.
         """
         rules = self.rule_repo.get_auto_rules()
-        users_cache = self._get_users_cache()  # Use cache instead of individual queries
+        users_cache = self._get_users_cache(
+            tenant_id=tenant_id
+        )  # Use cache instead of individual queries
 
         for rule in rules:
+            # Issue #2374: Skip rules belonging to users outside the tenant
+            if tenant_id is not None and rule.user_id not in users_cache:
+                continue
+
             if rule.matches(tool_account, tool_type):
                 # Get username from cache (no DB query)
                 user = users_cache.get(rule.user_id)
@@ -184,7 +209,7 @@ class ToolAccountAutoMappingService:
         return None
 
     def auto_map_account(
-        self, tool_account: str, tool_type: str | None = None
+        self, tool_account: str, tool_type: str | None = None, tenant_id: int | None = None
     ) -> AutoMappingResult | None:
         """
         Auto-map a single tool_account using all available methods.
@@ -193,6 +218,9 @@ class ToolAccountAutoMappingService:
         1. Custom rules (highest priority rules first)
         2. Username/email matching
 
+        Issue #2374: If tenant_id is provided, only match users and rules
+        within the specified tenant.
+
         Returns the mapping result if successful, None if no match found.
         """
         # Check if already mapped
@@ -200,10 +228,10 @@ class ToolAccountAutoMappingService:
         if existing:
             return None  # Already mapped
 
-        users = self.get_all_users()
+        users = self.get_all_users(tenant_id=tenant_id)
 
         # Try rule matching first (rules have explicit priority)
-        result = self.try_match_by_rules(tool_account, tool_type)
+        result = self.try_match_by_rules(tool_account, tool_type, tenant_id=tenant_id)
         if result:
             return result
 
@@ -254,7 +282,7 @@ class ToolAccountAutoMappingService:
             tool_account = account.get("sender_name", "")
             tool_type = self._infer_tool_type(tool_account)
 
-            result = self.auto_map_account(tool_account, tool_type)
+            result = self.auto_map_account(tool_account, tool_type, tenant_id=tenant_id)
 
             if result:
                 if not dry_run:
@@ -413,9 +441,15 @@ class ToolAccountAutoMappingService:
         Get statistics about mapping status.
 
         Issue #2180: If tenant_id is provided, filter stats by tenant.
+        Issue #2374: Also filter mapped count by tenant_id.
         """
         unmapped = self.get_unmapped_accounts(tenant_id=tenant_id)
         mapped = self.mapping_repo.get_all()
+
+        # Issue #2374: Filter mapped by tenant if tenant_id is provided
+        if tenant_id is not None:
+            tenant_user_ids = set(self._get_users_cache(tenant_id=tenant_id).keys())
+            mapped = [m for m in mapped if m.user_id in tenant_user_ids]
 
         # Count unmapped by inferred tool type
         unmapped_by_tool: dict[str, int] = {}

--- a/frontend/src/components/features/management/AutoMappingPanel.tsx
+++ b/frontend/src/components/features/management/AutoMappingPanel.tsx
@@ -1,0 +1,611 @@
+/**
+ * AutoMappingPanel Component - UI for auto-mapping tool accounts
+ *
+ * Issue #2374: Provides frontend UI entry points for auto-mapping APIs:
+ * - Run auto-mapping (with dry-run preview)
+ * - View mapping statistics
+ * - Suggest mapping for unmapped accounts
+ * - Manual map accounts
+ * - Test match rules
+ */
+
+import React, { useState, useCallback, useEffect } from 'react';
+import { useLanguage } from '@/store';
+import { t } from '@/i18n';
+import { Button, Modal, Badge, useToast, useConfirm, Loading } from '@/components/common';
+import {
+  mappingRulesApi,
+  type MappingStats,
+  type AutoMappingResult,
+  type UnmappedAccount,
+  type MappingSuggestion,
+  type MatchTestResult,
+} from '@/api/mappingRules';
+import type { AdminUser } from '@/api';
+
+interface AutoMappingPanelProps {
+  users?: AdminUser[];
+  onChange?: () => void;
+}
+
+export const AutoMappingPanel: React.FC<AutoMappingPanelProps> = ({ users, onChange }) => {
+  const language = useLanguage();
+  const toast = useToast();
+  const confirm = useConfirm();
+
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [stats, setStats] = useState<MappingStats | null>(null);
+  const [isLoadingStats, setIsLoadingStats] = useState(false);
+  const [isAutoMapping, setIsAutoMapping] = useState(false);
+  const [autoMapPreview, setAutoMapPreview] = useState<{
+    mappings: AutoMappingResult[];
+    unmapped_count: number;
+    mapped_count: number;
+  } | null>(null);
+  const [showUnmappedModal, setShowUnmappedModal] = useState(false);
+  const [unmappedAccounts, setUnmappedAccounts] = useState<UnmappedAccount[]>([]);
+  const [isLoadingUnmapped, setIsLoadingUnmapped] = useState(false);
+  const [suggestions, setSuggestions] = useState<Record<string, MappingSuggestion | null>>({});
+  const [loadingSuggestions, setLoadingSuggestions] = useState<Set<string>>(new Set());
+  const [manualMapTarget, setManualMapTarget] = useState<string | null>(null);
+  const [selectedUserId, setSelectedUserId] = useState<number | ''>('');
+  const [isManualMapping, setIsManualMapping] = useState(false);
+  const [showTestMatchModal, setShowTestMatchModal] = useState(false);
+  const [testMatchInput, setTestMatchInput] = useState('');
+  const [testMatchResult, setTestMatchResult] = useState<MatchTestResult | null>(null);
+  const [isTestingMatch, setIsTestingMatch] = useState(false);
+
+  const loadStats = useCallback(async () => {
+    setIsLoadingStats(true);
+    try {
+      const data = await mappingRulesApi.getMappingStats();
+      setStats(data);
+    } catch (err) {
+      console.error('Failed to load mapping stats:', err);
+    } finally {
+      setIsLoadingStats(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (isExpanded) {
+      loadStats();
+    }
+  }, [isExpanded, loadStats]);
+
+  const handleRunAutoMap = async () => {
+    setIsAutoMapping(true);
+    try {
+      // Step 1: Dry-run preview
+      const preview = await mappingRulesApi.runAutoMapping(true);
+      setAutoMapPreview(preview);
+
+      if (preview.mapped_count === 0) {
+        toast.info(
+          language === 'zh'
+            ? '没有可自动映射的账号'
+            : 'No accounts can be auto-mapped'
+        );
+        setAutoMapPreview(null);
+        return;
+      }
+
+      // Step 2: Confirm with user
+      const message =
+        language === 'zh'
+          ? `将匹配 ${preview.mapped_count} 个账号到用户，剩余 ${preview.unmapped_count} 个无法自动匹配。确认执行？`
+          : `Will match ${preview.mapped_count} accounts to users, ${preview.unmapped_count} remaining unmapped. Confirm?`;
+
+      if (!(await confirm({ message, variant: 'primary' }))) {
+        setAutoMapPreview(null);
+        return;
+      }
+
+      // Step 3: Execute actual mapping
+      const result = await mappingRulesApi.runAutoMapping(false);
+      toast.success(
+        language === 'zh'
+          ? `自动映射完成：已映射 ${result.mapped_count} 个账号`
+          : `Auto-mapping complete: ${result.mapped_count} accounts mapped`
+      );
+      setAutoMapPreview(null);
+      await loadStats();
+      onChange?.();
+    } catch (err) {
+      console.error('Failed to run auto-mapping:', err);
+      toast.error(
+        language === 'zh' ? '自动映射失败' : 'Failed to run auto-mapping'
+      );
+    } finally {
+      setIsAutoMapping(false);
+    }
+  };
+
+  const loadUnmappedAccounts = useCallback(async () => {
+    setIsLoadingUnmapped(true);
+    try {
+      const data = await mappingRulesApi.getUnmappedAccounts();
+      setUnmappedAccounts(data);
+      setSuggestions({});
+    } catch (err) {
+      console.error('Failed to load unmapped accounts:', err);
+    } finally {
+      setIsLoadingUnmapped(false);
+    }
+  }, []);
+
+  const handleShowUnmapped = () => {
+    setShowUnmappedModal(true);
+    loadUnmappedAccounts();
+  };
+
+  const handleSuggestMapping = async (senderName: string) => {
+    setLoadingSuggestions((prev) => new Set(prev).add(senderName));
+    try {
+      const suggestion = await mappingRulesApi.suggestMapping(senderName);
+      setSuggestions((prev) => ({ ...prev, [senderName]: suggestion }));
+    } catch (err) {
+      console.error('Failed to get suggestion:', err);
+      toast.error(
+        language === 'zh' ? '获取建议失败' : 'Failed to get suggestion'
+      );
+    } finally {
+      setLoadingSuggestions((prev) => {
+        const next = new Set(prev);
+        next.delete(senderName);
+        return next;
+      });
+    }
+  };
+
+  const handleManualMap = async () => {
+    if (!manualMapTarget || !selectedUserId) return;
+
+    setIsManualMapping(true);
+    try {
+      await mappingRulesApi.manualMapAccount(manualMapTarget, Number(selectedUserId));
+      toast.success(
+        language === 'zh' ? '手动映射成功' : 'Manual mapping successful'
+      );
+      setManualMapTarget(null);
+      setSelectedUserId('');
+      // Refresh data
+      await loadUnmappedAccounts();
+      await loadStats();
+      onChange?.();
+    } catch (err) {
+      console.error('Failed to manual map:', err);
+      toast.error(
+        language === 'zh' ? '手动映射失败' : 'Failed to manual map'
+      );
+    } finally {
+      setIsManualMapping(false);
+    }
+  };
+
+  const handleTestMatch = async () => {
+    if (!testMatchInput.trim()) return;
+
+    setIsTestingMatch(true);
+    try {
+      const result = await mappingRulesApi.testMatch(testMatchInput.trim());
+      setTestMatchResult(result);
+    } catch (err) {
+      console.error('Failed to test match:', err);
+      toast.error(
+        language === 'zh' ? '测试匹配失败' : 'Failed to test match'
+      );
+    } finally {
+      setIsTestingMatch(false);
+    }
+  };
+
+  const zh = language === 'zh';
+
+  return (
+    <div className="auto-mapping-panel mb-3">
+      {/* Toggle button */}
+      <div className="d-flex align-items-center gap-2">
+        <Button
+          variant="outline-secondary"
+          size="sm"
+          onClick={() => setIsExpanded(!isExpanded)}
+        >
+          <i className={`bi ${isExpanded ? 'bi-chevron-up' : 'bi-chevron-down'} me-1`} />
+          {zh ? '自动映射' : 'Auto Mapping'}
+        </Button>
+        {stats && (
+          <span className="text-muted small">
+            <Badge variant="success" className="me-1">
+              {zh ? '已映射' : 'Mapped'}: {stats.total_mapped}
+            </Badge>
+            <Badge variant="warning">
+              {zh ? '未映射' : 'Unmapped'}: {stats.total_unmapped}
+            </Badge>
+          </span>
+        )}
+      </div>
+
+      {/* Expanded panel */}
+      {isExpanded && (
+        <div className="mt-2 p-3 border rounded bg-light">
+          {isLoadingStats ? (
+            <Loading size="sm" text={t('loading', language)} />
+          ) : stats ? (
+            <>
+              {/* Stats overview */}
+              <div className="d-flex align-items-center gap-3 mb-3">
+                <div>
+                  <strong className="text-success">{stats.total_mapped}</strong>
+                  <span className="text-muted small ms-1">
+                    {zh ? '已映射' : 'Mapped'}
+                  </span>
+                </div>
+                <div>
+                  <strong className="text-warning">{stats.total_unmapped}</strong>
+                  <span className="text-muted small ms-1">
+                    {zh ? '未映射' : 'Unmapped'}
+                  </span>
+                </div>
+                {stats.total_unmapped > 20 && (
+                  <small className="text-muted">
+                    {zh
+                      ? `(统计中仅显示前 20 条，共 ${stats.total_unmapped} 个未映射账号)`
+                      : `(Showing first 20 of ${stats.total_unmapped} unmapped accounts)`}
+                  </small>
+                )}
+              </div>
+
+              {/* Action buttons */}
+              <div className="d-flex gap-2 flex-wrap">
+                <Button
+                  variant="primary"
+                  size="sm"
+                  onClick={handleRunAutoMap}
+                  loading={isAutoMapping}
+                  disabled={isAutoMapping}
+                >
+                  <i className="bi bi-magic me-1" />
+                  {zh ? '执行自动映射' : 'Run Auto-Mapping'}
+                </Button>
+
+                {stats.total_unmapped > 0 && (
+                  <Button
+                    variant="outline-warning"
+                    size="sm"
+                    onClick={handleShowUnmapped}
+                  >
+                    <i className="bi bi-list-ul me-1" />
+                    {zh ? '查看未映射账号' : 'View Unmapped'}
+                    <Badge variant="secondary" className="ms-1">
+                      {stats.total_unmapped}
+                    </Badge>
+                  </Button>
+                )}
+
+                <Button
+                  variant="outline-info"
+                  size="sm"
+                  onClick={() => setShowTestMatchModal(true)}
+                >
+                  <i className="bi bi-search me-1" />
+                  {zh ? '测试匹配' : 'Test Match'}
+                </Button>
+
+                <Button
+                  variant="outline-secondary"
+                  size="sm"
+                  onClick={loadStats}
+                >
+                  <i className="bi bi-arrow-clockwise me-1" />
+                  {zh ? '刷新统计' : 'Refresh Stats'}
+                </Button>
+              </div>
+
+              {/* Auto-map preview result */}
+              {autoMapPreview && (
+                <div className="mt-3 alert alert-info">
+                  <div className="d-flex justify-content-between align-items-center">
+                    <div>
+                      <strong>
+                        {zh
+                          ? `预览：将匹配 ${autoMapPreview.mapped_count} 个账号`
+                          : `Preview: Will match ${autoMapPreview.mapped_count} accounts`}
+                      </strong>
+                      <span className="text-muted ms-2">
+                        {zh
+                          ? `${autoMapPreview.unmapped_count} 个无法自动匹配`
+                          : `${autoMapPreview.unmapped_count} cannot be auto-mapped`}
+                      </span>
+                    </div>
+                  </div>
+                  {autoMapPreview.mappings.length > 0 && (
+                    <div className="mt-2" style={{ maxHeight: '200px', overflowY: 'auto' }}>
+                      <table className="table table-sm table-bordered mb-0">
+                        <thead>
+                          <tr>
+                            <th>{zh ? '账号' : 'Account'}</th>
+                            <th>{zh ? '匹配用户' : 'Matched User'}</th>
+                            <th>{zh ? '匹配方式' : 'Matched By'}</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {autoMapPreview.mappings.map((m, idx) => (
+                            <tr key={idx}>
+                              <td><code>{m.tool_account}</code></td>
+                              <td>{m.username}</td>
+                              <td>
+                                <Badge variant="secondary">{m.matched_by}</Badge>
+                              </td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                  )}
+                </div>
+              )}
+            </>
+          ) : (
+            <div className="text-muted small">
+              {zh ? '无法加载统计信息' : 'Failed to load stats'}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Unmapped accounts modal */}
+      <Modal
+        isOpen={showUnmappedModal}
+        onClose={() => setShowUnmappedModal(false)}
+        title={zh ? '未映射账号' : 'Unmapped Accounts'}
+        size="xl"
+        footer={
+          <Button variant="secondary" onClick={() => setShowUnmappedModal(false)}>
+            {t('close', language)}
+          </Button>
+        }
+      >
+        {isLoadingUnmapped ? (
+          <Loading size="sm" text={t('loading', language)} />
+        ) : unmappedAccounts.length === 0 ? (
+          <div className="text-muted text-center py-3">
+            {zh ? '没有未映射的账号' : 'No unmapped accounts'}
+          </div>
+        ) : (
+          <div style={{ maxHeight: '500px', overflowY: 'auto' }}>
+            <table className="table table-sm table-hover">
+              <thead>
+                <tr>
+                  <th>{zh ? '账号' : 'Account'}</th>
+                  <th>{zh ? '消息数' : 'Messages'}</th>
+                  <th>{zh ? '建议' : 'Suggestion'}</th>
+                  <th>{zh ? '操作' : 'Actions'}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {unmappedAccounts.map((account) => {
+                  const senderName = account.sender_name;
+                  const suggestion = suggestions[senderName];
+                  const isLoadingSuggestion = loadingSuggestions.has(senderName);
+                  return (
+                    <tr key={senderName}>
+                      <td><code>{senderName}</code></td>
+                      <td>
+                        <Badge variant="secondary">{account.message_count}</Badge>
+                      </td>
+                      <td>
+                        {isLoadingSuggestion ? (
+                          <span className="text-muted small">
+                            {t('loading', language)}
+                          </span>
+                        ) : suggestion ? (
+                          suggestion.suggested_username ? (
+                            <span>
+                              <Badge variant="info" className="me-1">
+                                {suggestion.matched_by}
+                              </Badge>
+                              {suggestion.suggested_username}
+                            </span>
+                          ) : (
+                            <span className="text-muted small">
+                              {zh ? '无建议' : 'No suggestion'}
+                            </span>
+                          )
+                        ) : (
+                          <span className="text-muted">-</span>
+                        )}
+                      </td>
+                      <td>
+                        <div className="btn-group btn-group-sm">
+                          <Button
+                            variant="outline-info"
+                            size="sm"
+                            onClick={() => handleSuggestMapping(senderName)}
+                            disabled={isLoadingSuggestion}
+                            title={zh ? '获取建议' : 'Get Suggestion'}
+                          >
+                            <i className="bi bi-lightbulb" />
+                          </Button>
+                          <Button
+                            variant="outline-primary"
+                            size="sm"
+                            onClick={() => {
+                              setManualMapTarget(senderName);
+                              setSelectedUserId(
+                                suggestion?.suggested_user_id ?? ''
+                              );
+                            }}
+                            title={zh ? '手动映射' : 'Manual Map'}
+                          >
+                            <i className="bi bi-link" />
+                          </Button>
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </Modal>
+
+      {/* Manual map modal */}
+      <Modal
+        isOpen={!!manualMapTarget}
+        onClose={() => {
+          setManualMapTarget(null);
+          setSelectedUserId('');
+        }}
+        title={zh ? '手动映射账号' : 'Manual Map Account'}
+        size="md"
+        footer={
+          <>
+            <Button
+              variant="secondary"
+              onClick={() => {
+                setManualMapTarget(null);
+                setSelectedUserId('');
+              }}
+            >
+              {t('cancel', language)}
+            </Button>
+            <Button
+              variant="primary"
+              onClick={handleManualMap}
+              loading={isManualMapping}
+              disabled={isManualMapping || !selectedUserId}
+            >
+              {t('save', language)}
+            </Button>
+          </>
+        }
+      >
+        {manualMapTarget && (
+          <div>
+            <div className="mb-3">
+              <label className="form-label">
+                {zh ? '账号' : 'Account'}
+              </label>
+              <input
+                type="text"
+                className="form-control"
+                value={manualMapTarget}
+                readOnly
+              />
+            </div>
+            <div className="mb-3">
+              <label className="form-label">
+                {zh ? '映射到用户' : 'Map to User'}
+              </label>
+              <select
+                className="form-select"
+                value={selectedUserId}
+                onChange={(e) =>
+                  setSelectedUserId(e.target.value ? Number(e.target.value) : '')
+                }
+              >
+                <option value="">-- {zh ? '选择用户' : 'Select User'} --</option>
+                {users?.map((user) => (
+                  <option key={user.id} value={user.id}>
+                    {user.username} ({user.email})
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="alert alert-warning small">
+              <i className="bi bi-exclamation-triangle me-1" />
+              {zh
+                ? '此操作将创建映射并更新相关消息的用户归属，请谨慎操作。'
+                : 'This will create a mapping and update the user assignment for related messages. Proceed with caution.'}
+            </div>
+          </div>
+        )}
+      </Modal>
+
+      {/* Test match modal */}
+      <Modal
+        isOpen={showTestMatchModal}
+        onClose={() => {
+          setShowTestMatchModal(false);
+          setTestMatchInput('');
+          setTestMatchResult(null);
+        }}
+        title={zh ? '测试匹配规则' : 'Test Match Rules'}
+        size="md"
+        footer={
+          <>
+            <Button
+              variant="secondary"
+              onClick={() => {
+                setShowTestMatchModal(false);
+                setTestMatchInput('');
+                setTestMatchResult(null);
+              }}
+            >
+              {t('close', language)}
+            </Button>
+            <Button
+              variant="primary"
+              onClick={handleTestMatch}
+              loading={isTestingMatch}
+              disabled={isTestingMatch || !testMatchInput.trim()}
+            >
+              {zh ? '测试' : 'Test'}
+            </Button>
+          </>
+        }
+      >
+        <div className="mb-3">
+          <label className="form-label">
+            {zh ? '工具账号名称' : 'Tool Account Name'}
+          </label>
+          <input
+            type="text"
+            className="form-control"
+            value={testMatchInput}
+            onChange={(e) => setTestMatchInput(e.target.value)}
+            placeholder={zh ? '例如: alice-macbook-pro-qwen' : 'e.g., alice-macbook-pro-qwen'}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                handleTestMatch();
+              }
+            }}
+          />
+        </div>
+        {testMatchResult && (
+          <div className="mt-3">
+            {testMatchResult.matched ? (
+              <div className="alert alert-success">
+                <div className="d-flex align-items-center gap-2">
+                  <i className="bi bi-check-circle-fill text-success" />
+                  <div>
+                    <strong>{zh ? '匹配成功' : 'Matched'}</strong>
+                    <div className="mt-1">
+                      <Badge variant="info" className="me-1">
+                        {testMatchResult.matched_by}
+                      </Badge>
+                      {testMatchResult.username}
+                      {testMatchResult.rule_id && (
+                        <span className="text-muted ms-2 small">
+                          (Rule #{testMatchResult.rule_id})
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            ) : (
+              <div className="alert alert-secondary">
+                <i className="bi bi-x-circle me-1" />
+                {zh ? '未匹配到任何规则' : 'No rules matched'}
+              </div>
+            )}
+          </div>
+        )}
+      </Modal>
+    </div>
+  );
+};

--- a/frontend/src/components/features/management/AutoMappingPanel.tsx
+++ b/frontend/src/components/features/management/AutoMappingPanel.tsx
@@ -129,10 +129,13 @@ export const AutoMappingPanel: React.FC<AutoMappingPanelProps> = ({ users, onCha
       setSuggestions({});
     } catch (err) {
       console.error('Failed to load unmapped accounts:', err);
+      toast.error(
+        language === 'zh' ? '加载未映射账号失败' : 'Failed to load unmapped accounts'
+      );
     } finally {
       setIsLoadingUnmapped(false);
     }
-  }, []);
+  }, [language, toast]);
 
   const handleShowUnmapped = () => {
     setShowUnmappedModal(true);
@@ -210,6 +213,8 @@ export const AutoMappingPanel: React.FC<AutoMappingPanelProps> = ({ users, onCha
           variant="outline-secondary"
           size="sm"
           onClick={() => setIsExpanded(!isExpanded)}
+          aria-expanded={isExpanded}
+          aria-controls="auto-mapping-panel-content"
         >
           <i className={`bi ${isExpanded ? 'bi-chevron-up' : 'bi-chevron-down'} me-1`} />
           {zh ? '自动映射' : 'Auto Mapping'}
@@ -330,8 +335,8 @@ export const AutoMappingPanel: React.FC<AutoMappingPanelProps> = ({ users, onCha
                           </tr>
                         </thead>
                         <tbody>
-                          {autoMapPreview.mappings.map((m, idx) => (
-                            <tr key={idx}>
+                          {autoMapPreview.mappings.map((m) => (
+                            <tr key={m.tool_account}>
                               <td><code>{m.tool_account}</code></td>
                               <td>{m.username}</td>
                               <td>

--- a/frontend/src/components/features/management/AutoMappingPanel.tsx
+++ b/frontend/src/components/features/management/AutoMappingPanel.tsx
@@ -81,11 +81,7 @@ export const AutoMappingPanel: React.FC<AutoMappingPanelProps> = ({ users, onCha
       setAutoMapPreview(preview);
 
       if (preview.mapped_count === 0) {
-        toast.info(
-          language === 'zh'
-            ? '没有可自动映射的账号'
-            : 'No accounts can be auto-mapped'
-        );
+        toast.info(language === 'zh' ? '没有可自动映射的账号' : 'No accounts can be auto-mapped');
         setAutoMapPreview(null);
         return;
       }
@@ -113,9 +109,7 @@ export const AutoMappingPanel: React.FC<AutoMappingPanelProps> = ({ users, onCha
       onChange?.();
     } catch (err) {
       console.error('Failed to run auto-mapping:', err);
-      toast.error(
-        language === 'zh' ? '自动映射失败' : 'Failed to run auto-mapping'
-      );
+      toast.error(language === 'zh' ? '自动映射失败' : 'Failed to run auto-mapping');
     } finally {
       setIsAutoMapping(false);
     }
@@ -129,9 +123,7 @@ export const AutoMappingPanel: React.FC<AutoMappingPanelProps> = ({ users, onCha
       setSuggestions({});
     } catch (err) {
       console.error('Failed to load unmapped accounts:', err);
-      toast.error(
-        language === 'zh' ? '加载未映射账号失败' : 'Failed to load unmapped accounts'
-      );
+      toast.error(language === 'zh' ? '加载未映射账号失败' : 'Failed to load unmapped accounts');
     } finally {
       setIsLoadingUnmapped(false);
     }
@@ -149,9 +141,7 @@ export const AutoMappingPanel: React.FC<AutoMappingPanelProps> = ({ users, onCha
       setSuggestions((prev) => ({ ...prev, [senderName]: suggestion }));
     } catch (err) {
       console.error('Failed to get suggestion:', err);
-      toast.error(
-        language === 'zh' ? '获取建议失败' : 'Failed to get suggestion'
-      );
+      toast.error(language === 'zh' ? '获取建议失败' : 'Failed to get suggestion');
     } finally {
       setLoadingSuggestions((prev) => {
         const next = new Set(prev);
@@ -167,9 +157,7 @@ export const AutoMappingPanel: React.FC<AutoMappingPanelProps> = ({ users, onCha
     setIsManualMapping(true);
     try {
       await mappingRulesApi.manualMapAccount(manualMapTarget, Number(selectedUserId));
-      toast.success(
-        language === 'zh' ? '手动映射成功' : 'Manual mapping successful'
-      );
+      toast.success(language === 'zh' ? '手动映射成功' : 'Manual mapping successful');
       setManualMapTarget(null);
       setSelectedUserId('');
       // Refresh data
@@ -178,9 +166,7 @@ export const AutoMappingPanel: React.FC<AutoMappingPanelProps> = ({ users, onCha
       onChange?.();
     } catch (err) {
       console.error('Failed to manual map:', err);
-      toast.error(
-        language === 'zh' ? '手动映射失败' : 'Failed to manual map'
-      );
+      toast.error(language === 'zh' ? '手动映射失败' : 'Failed to manual map');
     } finally {
       setIsManualMapping(false);
     }
@@ -195,9 +181,7 @@ export const AutoMappingPanel: React.FC<AutoMappingPanelProps> = ({ users, onCha
       setTestMatchResult(result);
     } catch (err) {
       console.error('Failed to test match:', err);
-      toast.error(
-        language === 'zh' ? '测试匹配失败' : 'Failed to test match'
-      );
+      toast.error(language === 'zh' ? '测试匹配失败' : 'Failed to test match');
     } finally {
       setIsTestingMatch(false);
     }
@@ -242,15 +226,11 @@ export const AutoMappingPanel: React.FC<AutoMappingPanelProps> = ({ users, onCha
               <div className="d-flex align-items-center gap-3 mb-3">
                 <div>
                   <strong className="text-success">{stats.total_mapped}</strong>
-                  <span className="text-muted small ms-1">
-                    {zh ? '已映射' : 'Mapped'}
-                  </span>
+                  <span className="text-muted small ms-1">{zh ? '已映射' : 'Mapped'}</span>
                 </div>
                 <div>
                   <strong className="text-warning">{stats.total_unmapped}</strong>
-                  <span className="text-muted small ms-1">
-                    {zh ? '未映射' : 'Unmapped'}
-                  </span>
+                  <span className="text-muted small ms-1">{zh ? '未映射' : 'Unmapped'}</span>
                 </div>
                 {stats.total_unmapped > 20 && (
                   <small className="text-muted">
@@ -275,11 +255,7 @@ export const AutoMappingPanel: React.FC<AutoMappingPanelProps> = ({ users, onCha
                 </Button>
 
                 {stats.total_unmapped > 0 && (
-                  <Button
-                    variant="outline-warning"
-                    size="sm"
-                    onClick={handleShowUnmapped}
-                  >
+                  <Button variant="outline-warning" size="sm" onClick={handleShowUnmapped}>
                     <i className="bi bi-list-ul me-1" />
                     {zh ? '查看未映射账号' : 'View Unmapped'}
                     <Badge variant="secondary" className="ms-1">
@@ -297,11 +273,7 @@ export const AutoMappingPanel: React.FC<AutoMappingPanelProps> = ({ users, onCha
                   {zh ? '测试匹配' : 'Test Match'}
                 </Button>
 
-                <Button
-                  variant="outline-secondary"
-                  size="sm"
-                  onClick={loadStats}
-                >
+                <Button variant="outline-secondary" size="sm" onClick={loadStats}>
                   <i className="bi bi-arrow-clockwise me-1" />
                   {zh ? '刷新统计' : 'Refresh Stats'}
                 </Button>
@@ -337,7 +309,9 @@ export const AutoMappingPanel: React.FC<AutoMappingPanelProps> = ({ users, onCha
                         <tbody>
                           {autoMapPreview.mappings.map((m) => (
                             <tr key={m.tool_account}>
-                              <td><code>{m.tool_account}</code></td>
+                              <td>
+                                <code>{m.tool_account}</code>
+                              </td>
                               <td>{m.username}</td>
                               <td>
                                 <Badge variant="secondary">{m.matched_by}</Badge>
@@ -395,15 +369,15 @@ export const AutoMappingPanel: React.FC<AutoMappingPanelProps> = ({ users, onCha
                   const isLoadingSuggestion = loadingSuggestions.has(senderName);
                   return (
                     <tr key={senderName}>
-                      <td><code>{senderName}</code></td>
+                      <td>
+                        <code>{senderName}</code>
+                      </td>
                       <td>
                         <Badge variant="secondary">{account.message_count}</Badge>
                       </td>
                       <td>
                         {isLoadingSuggestion ? (
-                          <span className="text-muted small">
-                            {t('loading', language)}
-                          </span>
+                          <span className="text-muted small">{t('loading', language)}</span>
                         ) : suggestion ? (
                           suggestion.suggested_username ? (
                             <span>
@@ -437,9 +411,7 @@ export const AutoMappingPanel: React.FC<AutoMappingPanelProps> = ({ users, onCha
                             size="sm"
                             onClick={() => {
                               setManualMapTarget(senderName);
-                              setSelectedUserId(
-                                suggestion?.suggested_user_id ?? ''
-                              );
+                              setSelectedUserId(suggestion?.suggested_user_id ?? '');
                             }}
                             title={zh ? '手动映射' : 'Manual Map'}
                           >
@@ -490,26 +462,15 @@ export const AutoMappingPanel: React.FC<AutoMappingPanelProps> = ({ users, onCha
         {manualMapTarget && (
           <div>
             <div className="mb-3">
-              <label className="form-label">
-                {zh ? '账号' : 'Account'}
-              </label>
-              <input
-                type="text"
-                className="form-control"
-                value={manualMapTarget}
-                readOnly
-              />
+              <label className="form-label">{zh ? '账号' : 'Account'}</label>
+              <input type="text" className="form-control" value={manualMapTarget} readOnly />
             </div>
             <div className="mb-3">
-              <label className="form-label">
-                {zh ? '映射到用户' : 'Map to User'}
-              </label>
+              <label className="form-label">{zh ? '映射到用户' : 'Map to User'}</label>
               <select
                 className="form-select"
                 value={selectedUserId}
-                onChange={(e) =>
-                  setSelectedUserId(e.target.value ? Number(e.target.value) : '')
-                }
+                onChange={(e) => setSelectedUserId(e.target.value ? Number(e.target.value) : '')}
               >
                 <option value="">-- {zh ? '选择用户' : 'Select User'} --</option>
                 {users?.map((user) => (
@@ -563,9 +524,7 @@ export const AutoMappingPanel: React.FC<AutoMappingPanelProps> = ({ users, onCha
         }
       >
         <div className="mb-3">
-          <label className="form-label">
-            {zh ? '工具账号名称' : 'Tool Account Name'}
-          </label>
+          <label className="form-label">{zh ? '工具账号名称' : 'Tool Account Name'}</label>
           <input
             type="text"
             className="form-control"

--- a/frontend/src/components/features/management/UserManagement.tsx
+++ b/frontend/src/components/features/management/UserManagement.tsx
@@ -31,6 +31,7 @@ import {
 import { useConfirm, useToast } from '@/components/common';
 import { ToolAccountsEditor } from './ToolAccountsEditor';
 import { MappingRulesEditor } from './MappingRulesEditor';
+import { AutoMappingPanel } from './AutoMappingPanel';
 import { createMatcherConfig } from '@/utils';
 import type { AdminUser, CreateUserRequest, UpdateUserRequest } from '@/api';
 
@@ -370,6 +371,9 @@ export const UserManagement: React.FC = () => {
           </Button>
         </div>
       </div>
+
+      {/* Auto Mapping Panel - Issue #2374 */}
+      <AutoMappingPanel users={users ?? undefined} onChange={() => refetch()} />
 
       {/* User Table */}
       {!users || users.length === 0 ? (

--- a/frontend/src/components/features/management/index.ts
+++ b/frontend/src/components/features/management/index.ts
@@ -3,6 +3,7 @@
  */
 
 export { UserManagement } from './UserManagement';
+export { AutoMappingPanel } from './AutoMappingPanel';
 export { RemoteMachineManagement } from './RemoteMachineManagement';
 export { APIKeyManagement } from './APIKeyManagement';
 // model-gateway (removable)

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -5000,6 +5000,7 @@ export const translations: Record<Language, Translations> = {
     toolAccountRequired: 'ツールアカウントは必須です',
     addToolAccountSuccess: 'ツールアカウントが正常に追加されました',
     addToolAccountFailed: 'ツールアカウントの追加に失敗しました',
+    unmappedAccounts: 'マッピングされていないアカウント',
     // Run Timeline（実行タイムライン）— リモートエージェントセッション
     runTimeline: '実行タイムライン',
     runTimelineLoading: 'タイムラインを読み込み中...',
@@ -6605,6 +6606,7 @@ export const translations: Record<Language, Translations> = {
     toolAccountRequired: '도구 계정은 필수입니다',
     addToolAccountSuccess: '도구 계정이 성공적으로 추가되었습니다',
     addToolAccountFailed: '도구 계정 추가 실패',
+    unmappedAccounts: '매핑되지 않은 계정',
     // Run Timeline(실행 타임라인) — 원격 에이전트 세션
     runTimeline: '실행 타임라인',
     runTimelineLoading: '타임라인 로드 중...',

--- a/tests/security/test_tenant_isolation_mapping_rules.py
+++ b/tests/security/test_tenant_isolation_mapping_rules.py
@@ -55,10 +55,20 @@ def tenant_admin_client(app):
                 with self._auth_patch():
                     return self._client.post(*args, **kwargs)
 
+        def get(self, *args, **kwargs):
+            with self._token_patch():
+                with self._auth_patch():
+                    return self._client.get(*args, **kwargs)
+
         def put(self, *args, **kwargs):
             with self._token_patch():
                 with self._auth_patch():
                     return self._client.put(*args, **kwargs)
+
+        def delete(self, *args, **kwargs):
+            with self._token_patch():
+                with self._auth_patch():
+                    return self._client.delete(*args, **kwargs)
 
     return TenantAdminAuthenticatedClient(test_client)
 
@@ -90,6 +100,21 @@ def platform_admin_client(app):
             with self._token_patch():
                 with self._auth_patch():
                     return self._client.post(*args, **kwargs)
+
+        def get(self, *args, **kwargs):
+            with self._token_patch():
+                with self._auth_patch():
+                    return self._client.get(*args, **kwargs)
+
+        def put(self, *args, **kwargs):
+            with self._token_patch():
+                with self._auth_patch():
+                    return self._client.put(*args, **kwargs)
+
+        def delete(self, *args, **kwargs):
+            with self._token_patch():
+                with self._auth_patch():
+                    return self._client.delete(*args, **kwargs)
 
     return PlatformAdminAuthenticatedClient(test_client)
 
@@ -857,3 +882,313 @@ class TestAdminWithTenantIdNotScoped:
 
         # Should succeed, NOT 404
         assert response.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Issue #2374: Tenant isolation for suggest_mapping and test_match endpoints.
+# ---------------------------------------------------------------------------
+
+
+class TestTenantIsolationForSuggestMapping:
+    """
+    Issue #2374: Verify tenant isolation for the suggest-mapping endpoint.
+
+    Tenant admin should only get suggestions within their own tenant.
+    """
+
+    @patch("app.routes.mapping_rules.ToolAccountAutoMappingService")
+    def test_tenant_admin_suggest_mapping_passes_tenant_id(
+        self, mock_service_class, tenant_admin_client
+    ):
+        """Tenant admin's suggest-mapping call should pass tenant_id to service."""
+        mock_service = MagicMock()
+        mock_service.auto_map_account.return_value = None
+        mock_service_class.return_value = mock_service
+
+        tenant_admin_client.get("/api/unmapped-accounts/alice-pc-qwen/suggest-mapping")
+
+        # Verify tenant_id=1 (from fixture) was passed
+        mock_service.auto_map_account.assert_called_once_with("alice-pc-qwen", tenant_id=1)
+
+    @patch("app.routes.mapping_rules.ToolAccountAutoMappingService")
+    def test_tenant_admin_suggest_mapping_returns_tenant_scoped_result(
+        self, mock_service_class, tenant_admin_client
+    ):
+        """Tenant admin should receive suggestion scoped to their tenant."""
+        from app.services.tool_account_auto_mapping_service import AutoMappingResult
+
+        mock_service = MagicMock()
+        mock_service.auto_map_account.return_value = AutoMappingResult(
+            tool_account="alice-pc-qwen",
+            user_id=5,
+            username="alice",
+            matched_by="username",
+        )
+        mock_service_class.return_value = mock_service
+
+        response = tenant_admin_client.get("/api/unmapped-accounts/alice-pc-qwen/suggest-mapping")
+
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert data["suggested_user_id"] == 5
+        assert data["suggested_username"] == "alice"
+
+    @patch("app.routes.mapping_rules.ToolAccountAutoMappingService")
+    def test_platform_admin_suggest_mapping_no_tenant_id(
+        self, mock_service_class, platform_admin_client
+    ):
+        """Platform admin's suggest-mapping call should NOT pass tenant_id."""
+        mock_service = MagicMock()
+        mock_service.auto_map_account.return_value = None
+        mock_service_class.return_value = mock_service
+
+        platform_admin_client.get("/api/unmapped-accounts/bob-laptop-qwen/suggest-mapping")
+
+        # Verify no tenant_id was passed
+        mock_service.auto_map_account.assert_called_once_with("bob-laptop-qwen")
+
+
+class TestTenantIsolationForTestMatch:
+    """
+    Issue #2374: Verify tenant isolation for the test-match endpoint.
+
+    Tenant admin should only test matches within their own tenant.
+    """
+
+    @patch("app.routes.mapping_rules.ToolAccountAutoMappingService")
+    def test_tenant_admin_test_match_passes_tenant_id(
+        self, mock_service_class, tenant_admin_client
+    ):
+        """Tenant admin's test-match call should pass tenant_id to service."""
+        mock_service = MagicMock()
+        mock_service.auto_map_account.return_value = None
+        mock_service_class.return_value = mock_service
+
+        tenant_admin_client.post(
+            "/api/mapping-rules/test-match",
+            data=json.dumps({"tool_account": "alice-pc-qwen", "tool_type": "qwen"}),
+            content_type="application/json",
+        )
+
+        # Verify tenant_id=1 (from fixture) was passed
+        mock_service.auto_map_account.assert_called_once_with("alice-pc-qwen", "qwen", tenant_id=1)
+
+    @patch("app.routes.mapping_rules.ToolAccountAutoMappingService")
+    def test_tenant_admin_test_match_returns_tenant_scoped_result(
+        self, mock_service_class, tenant_admin_client
+    ):
+        """Tenant admin should receive match result scoped to their tenant."""
+        from app.services.tool_account_auto_mapping_service import AutoMappingResult
+
+        mock_service = MagicMock()
+        mock_service.auto_map_account.return_value = AutoMappingResult(
+            tool_account="alice-pc-qwen",
+            user_id=5,
+            username="alice",
+            matched_by="rule",
+            rule_id=3,
+        )
+        mock_service_class.return_value = mock_service
+
+        response = tenant_admin_client.post(
+            "/api/mapping-rules/test-match",
+            data=json.dumps({"tool_account": "alice-pc-qwen"}),
+            content_type="application/json",
+        )
+
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert data["matched"] is True
+        assert data["user_id"] == 5
+
+    @patch("app.routes.mapping_rules.ToolAccountAutoMappingService")
+    def test_platform_admin_test_match_no_tenant_id(
+        self, mock_service_class, platform_admin_client
+    ):
+        """Platform admin's test-match call should NOT pass tenant_id."""
+        mock_service = MagicMock()
+        mock_service.auto_map_account.return_value = None
+        mock_service_class.return_value = mock_service
+
+        platform_admin_client.post(
+            "/api/mapping-rules/test-match",
+            data=json.dumps({"tool_account": "bob-laptop-qwen"}),
+            content_type="application/json",
+        )
+
+        # Verify no tenant_id was passed
+        mock_service.auto_map_account.assert_called_once_with("bob-laptop-qwen", None)
+
+
+# ---------------------------------------------------------------------------
+# Issue #2374: Fail-closed pattern tests for all auto-mapping endpoints.
+# ---------------------------------------------------------------------------
+
+
+class TestFailClosedPatternForAutoMapping:
+    """
+    Issue #2374: Verify fail-closed pattern for tenant_admin with no tenant_id.
+
+    All auto-mapping endpoints should return 403 when tenant_admin has
+    tenant_id=None, instead of falling through to global access.
+    """
+
+    def _make_no_tenant_client(self, app):
+        """Create a test client for tenant_admin with tenant_id=None."""
+        test_client = app.test_client()
+
+        class NoTenantClient:
+            def __init__(self, client):
+                self._client = client
+
+            def _auth_patch(self):
+                return patch(
+                    "app.auth.decorators._load_user_from_token",
+                    return_value={
+                        "id": 10,
+                        "role": "tenant_admin",
+                        "username": "no_tenant_admin",
+                        "tenant_id": None,
+                    },
+                )
+
+            def _token_patch(self):
+                return patch(
+                    "app.auth.decorators._extract_session_token",
+                    return_value="test-token",
+                )
+
+            def get(self, *args, **kwargs):
+                with self._token_patch():
+                    with self._auth_patch():
+                        return self._client.get(*args, **kwargs)
+
+            def post(self, *args, **kwargs):
+                with self._token_patch():
+                    with self._auth_patch():
+                        return self._client.post(*args, **kwargs)
+
+        return NoTenantClient(test_client)
+
+    @patch("app.routes.mapping_rules.ToolAccountAutoMappingService")
+    def test_no_tenant_id_get_mapping_stats_403(self, mock_service_class, app):
+        """get_mapping_stats should return 403 for tenant_admin without tenant_id."""
+        client = self._make_no_tenant_client(app)
+        response = client.get("/api/mapping-stats")
+        assert response.status_code == 403
+        mock_service_class.return_value.get_mapping_stats.assert_not_called()
+
+    @patch("app.routes.mapping_rules.ToolAccountAutoMappingService")
+    def test_no_tenant_id_run_auto_mapping_403(self, mock_service_class, app):
+        """run_auto_mapping should return 403 for tenant_admin without tenant_id."""
+        client = self._make_no_tenant_client(app)
+        response = client.post(
+            "/api/mapping-rules/auto-map",
+            data=json.dumps({"dry_run": True}),
+            content_type="application/json",
+        )
+        assert response.status_code == 403
+        mock_service_class.return_value.run_auto_mapping.assert_not_called()
+
+    @patch("app.routes.mapping_rules.UserToolAccountRepository")
+    def test_no_tenant_id_get_unmapped_accounts_403(self, mock_repo_class, app):
+        """get_unmapped_accounts should return 403 for tenant_admin without tenant_id."""
+        client = self._make_no_tenant_client(app)
+        response = client.get("/api/unmapped-accounts")
+        assert response.status_code == 403
+        mock_repo_class.return_value.get_unmapped_tool_accounts.assert_not_called()
+
+    @patch("app.routes.mapping_rules.ToolAccountAutoMappingService")
+    def test_no_tenant_id_suggest_mapping_403(self, mock_service_class, app):
+        """suggest_mapping should return 403 for tenant_admin without tenant_id."""
+        client = self._make_no_tenant_client(app)
+        response = client.get("/api/unmapped-accounts/alice-pc/suggest-mapping")
+        assert response.status_code == 403
+        mock_service_class.return_value.auto_map_account.assert_not_called()
+
+    @patch("app.routes.mapping_rules.ToolAccountAutoMappingService")
+    def test_no_tenant_id_test_match_403(self, mock_service_class, app):
+        """test_match should return 403 for tenant_admin without tenant_id."""
+        client = self._make_no_tenant_client(app)
+        response = client.post(
+            "/api/mapping-rules/test-match",
+            data=json.dumps({"tool_account": "alice-pc"}),
+            content_type="application/json",
+        )
+        assert response.status_code == 403
+        mock_service_class.return_value.auto_map_account.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Issue #2374: Admin/platform_admin with tenant_id must NOT be scoped
+# for suggest_mapping and test_match endpoints.
+# ---------------------------------------------------------------------------
+
+
+class TestAdminWithTenantIdNotScopedForNewEndpoints:
+    """
+    Issue #2374: Verify that admin/platform_admin with tenant_id is NOT
+    tenant-scoped for the new suggest_mapping and test_match endpoints.
+    """
+
+    @patch("app.routes.mapping_rules.ToolAccountAutoMappingService")
+    def test_admin_with_tenant_suggest_mapping_global(
+        self, mock_service_class, admin_with_tenant_client
+    ):
+        """Admin with tenant_id should call suggest_mapping without tenant_id."""
+        mock_service = MagicMock()
+        mock_service.auto_map_account.return_value = None
+        mock_service_class.return_value = mock_service
+
+        admin_with_tenant_client.get("/api/unmapped-accounts/alice-pc/suggest-mapping")
+
+        # Should NOT pass tenant_id
+        mock_service.auto_map_account.assert_called_once_with("alice-pc")
+
+    @patch("app.routes.mapping_rules.ToolAccountAutoMappingService")
+    def test_admin_with_tenant_test_match_global(
+        self, mock_service_class, admin_with_tenant_client
+    ):
+        """Admin with tenant_id should call test_match without tenant_id."""
+        mock_service = MagicMock()
+        mock_service.auto_map_account.return_value = None
+        mock_service_class.return_value = mock_service
+
+        admin_with_tenant_client.post(
+            "/api/mapping-rules/test-match",
+            data=json.dumps({"tool_account": "alice-pc", "tool_type": "qwen"}),
+            content_type="application/json",
+        )
+
+        # Should NOT pass tenant_id
+        mock_service.auto_map_account.assert_called_once_with("alice-pc", "qwen")
+
+    @patch("app.routes.mapping_rules.ToolAccountAutoMappingService")
+    def test_platform_admin_with_tenant_suggest_mapping_global(
+        self, mock_service_class, platform_admin_with_tenant_client
+    ):
+        """Platform admin with tenant_id should call suggest_mapping without tenant_id."""
+        mock_service = MagicMock()
+        mock_service.auto_map_account.return_value = None
+        mock_service_class.return_value = mock_service
+
+        platform_admin_with_tenant_client.get("/api/unmapped-accounts/bob-laptop/suggest-mapping")
+
+        mock_service.auto_map_account.assert_called_once_with("bob-laptop")
+
+    @patch("app.routes.mapping_rules.ToolAccountAutoMappingService")
+    def test_platform_admin_with_tenant_test_match_global(
+        self, mock_service_class, platform_admin_with_tenant_client
+    ):
+        """Platform admin with tenant_id should call test_match without tenant_id."""
+        mock_service = MagicMock()
+        mock_service.auto_map_account.return_value = None
+        mock_service_class.return_value = mock_service
+
+        platform_admin_with_tenant_client.post(
+            "/api/mapping-rules/test-match",
+            data=json.dumps({"tool_account": "bob-laptop"}),
+            content_type="application/json",
+        )
+
+        mock_service.auto_map_account.assert_called_once_with("bob-laptop", None)

--- a/tests/unit/test_mapping_rules_api.py
+++ b/tests/unit/test_mapping_rules_api.py
@@ -413,7 +413,8 @@ class TestUnmappedAccounts:
         response = admin_client.get("/api/unmapped-accounts/unknown/suggest-mapping")
         assert response.status_code == 200
         data = json.loads(response.data)
-        assert data["suggestion"] is None
+        assert data["suggested_user_id"] is None
+        assert data["suggested_username"] is None
 
     @patch("app.routes.mapping_rules.UserToolAccountRepository")
     def test_manual_map_account_success(self, mock_repo_class, admin_client):

--- a/tests/unit/test_tool_account_auto_mapping_service.py
+++ b/tests/unit/test_tool_account_auto_mapping_service.py
@@ -282,6 +282,291 @@ class TestToolAccountAutoMappingService(unittest.TestCase):
         self.assertEqual(len(result.skipped), 0)
 
 
+class TestAutoMappingServiceTenantFiltering(unittest.TestCase):
+    """
+    Issue #2374: Unit tests for tenant_id filtering in auto-mapping service.
+
+    Verifies that when tenant_id is provided, the service correctly filters
+    users, rules, and stats by tenant to prevent cross-tenant data leakage.
+    """
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.mock_db = MagicMock()
+        self.service = ToolAccountAutoMappingService(db=self.mock_db)
+
+    def _make_user_row(self, user_id, username, tenant_id):
+        """Create a mock DB row for a user."""
+        return {
+            "id": user_id,
+            "username": username,
+            "email": f"{username}@example.com",
+            "role": "user",
+            "is_active": 1,
+            "auto_mapping_enabled": 1,
+            "tenant_id": tenant_id,
+        }
+
+    # --- get_all_users tenant filtering ---
+
+    def test_get_all_users_with_tenant_id_filters_users(self):
+        """get_all_users should pass tenant_id to SQL query."""
+        self.mock_db.fetch_all.return_value = [
+            self._make_user_row(1, "alice", 1),
+            self._make_user_row(2, "bob", 1),
+        ]
+
+        users = self.service.get_all_users(tenant_id=1)
+
+        self.assertEqual(len(users), 2)
+        self.assertEqual(users[0].id, 1)
+        self.assertEqual(users[0].tenant_id, 1)
+
+        # Verify fetch_all was called with tenant_id parameter
+        call_args = self.mock_db.fetch_all.call_args
+        params = call_args[0][1] if len(call_args[0]) > 1 else call_args[1].get("params")
+        self.assertIsNotNone(params)
+        self.assertIn(1, params)
+
+    def test_get_all_users_without_tenant_id_returns_all(self):
+        """get_all_users without tenant_id should not filter."""
+        self.mock_db.fetch_all.return_value = [
+            self._make_user_row(1, "alice", 1),
+            self._make_user_row(2, "bob", 2),
+        ]
+
+        users = self.service.get_all_users()
+
+        self.assertEqual(len(users), 2)
+        # Verify no tenant_id parameter was passed
+        call_args = self.mock_db.fetch_all.call_args
+        params = call_args[0][1] if len(call_args[0]) > 1 else call_args[1].get("params")
+        # params should be None (no filtering)
+        self.assertIsNone(params)
+
+    # --- try_match_by_rules tenant filtering ---
+
+    def test_try_match_by_rules_skips_cross_tenant_rules(self):
+        """try_match_by_rules should skip rules for users outside the tenant."""
+        # Tenant 1 users: user 1 and 2
+        self.mock_db.fetch_all.return_value = [
+            self._make_user_row(1, "alice", 1),
+            self._make_user_row(2, "bob", 1),
+        ]
+
+        # Rules: one for tenant 1 user, one for tenant 2 user
+        mock_rule_repo = MagicMock()
+        rule_t1 = ToolAccountMappingRule(
+            id=1,
+            user_id=1,
+            pattern="alice-*",
+            match_type="prefix",
+            is_active=True,
+            is_auto=True,
+        )
+        rule_t2 = ToolAccountMappingRule(
+            id=2,
+            user_id=99,
+            pattern="alice-*",
+            match_type="prefix",
+            is_active=True,
+            is_auto=True,
+        )
+        mock_rule_repo.get_auto_rules.return_value = [rule_t2, rule_t1]
+        self.service.rule_repo = mock_rule_repo
+
+        # With tenant_id=1, rule for user 99 should be skipped
+        result = self.service.try_match_by_rules("alice-pc-qwen", "qwen", tenant_id=1)
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result.user_id, 1)  # Matched tenant 1 user's rule
+        self.assertEqual(result.rule_id, 1)
+
+    def test_try_match_by_rules_no_tenant_id_matches_all(self):
+        """try_match_by_rules without tenant_id should match all rules."""
+        self.mock_db.fetch_all.return_value = [
+            self._make_user_row(1, "alice", 1),
+            self._make_user_row(99, "alice", 2),
+        ]
+
+        mock_rule_repo = MagicMock()
+        rule_t2 = ToolAccountMappingRule(
+            id=2,
+            user_id=99,
+            pattern="alice-*",
+            match_type="prefix",
+            is_active=True,
+            is_auto=True,
+        )
+        mock_rule_repo.get_auto_rules.return_value = [rule_t2]
+        self.service.rule_repo = mock_rule_repo
+
+        # Without tenant_id, rule for user 99 should match
+        result = self.service.try_match_by_rules("alice-pc-qwen", "qwen")
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result.user_id, 99)
+
+    def test_try_match_by_rules_tenant_filter_no_match(self):
+        """try_match_by_rules should return None if no rules match within tenant."""
+        # Tenant 1 users: only user 1
+        self.mock_db.fetch_all.return_value = [
+            self._make_user_row(1, "alice", 1),
+        ]
+
+        mock_rule_repo = MagicMock()
+        # Rule for user 99 (tenant 2) that would match the tool_account
+        rule_t2 = ToolAccountMappingRule(
+            id=2,
+            user_id=99,
+            pattern="alice-*",
+            match_type="prefix",
+            is_active=True,
+            is_auto=True,
+        )
+        mock_rule_repo.get_auto_rules.return_value = [rule_t2]
+        self.service.rule_repo = mock_rule_repo
+
+        # With tenant_id=1, the only matching rule is for user 99 (tenant 2) - should be skipped
+        result = self.service.try_match_by_rules("alice-pc-qwen", "qwen", tenant_id=1)
+
+        self.assertIsNone(result)
+
+    # --- auto_map_account tenant filtering ---
+
+    def test_auto_map_account_passes_tenant_id_to_get_all_users(self):
+        """auto_map_account should pass tenant_id to get_all_users."""
+        mock_mapping_repo = MagicMock()
+        mock_mapping_repo.get_by_tool_account.return_value = None  # Not already mapped
+        self.service.mapping_repo = mock_mapping_repo
+
+        self.mock_db.fetch_all.return_value = [
+            self._make_user_row(1, "alice", 1),
+        ]
+        mock_rule_repo = MagicMock()
+        mock_rule_repo.get_auto_rules.return_value = []
+        self.service.rule_repo = mock_rule_repo
+
+        self.service.auto_map_account("alice-pc-qwen", "qwen", tenant_id=1)
+
+        # Verify fetch_all was called (via get_all_users) with tenant_id param
+        call_args = self.mock_db.fetch_all.call_args
+        params = call_args[0][1] if len(call_args[0]) > 1 else call_args[1].get("params")
+        self.assertIsNotNone(params)
+        self.assertIn(1, params)
+
+    def test_auto_map_account_tenant_filtered_no_cross_tenant_match(self):
+        """auto_map_account should not match users from other tenants."""
+        mock_mapping_repo = MagicMock()
+        mock_mapping_repo.get_by_tool_account.return_value = None
+        self.service.mapping_repo = mock_mapping_repo
+
+        # No users in tenant 1 (fetch_all returns empty list when tenant_id=1 filters)
+        self.mock_db.fetch_all.return_value = []
+        mock_rule_repo = MagicMock()
+        mock_rule_repo.get_auto_rules.return_value = []
+        self.service.rule_repo = mock_rule_repo
+
+        # With tenant_id=1, no users in tenant 1, so no match
+        result = self.service.auto_map_account("alice-pc-qwen", "qwen", tenant_id=1)
+
+        self.assertIsNone(result)
+
+    # --- get_mapping_stats tenant filtering ---
+
+    def test_get_mapping_stats_filters_mapped_by_tenant(self):
+        """get_mapping_stats should filter mapped count by tenant."""
+        # Tenant 1 users: user 1 and 2
+        self.mock_db.fetch_all.return_value = [
+            self._make_user_row(1, "alice", 1),
+            self._make_user_row(2, "bob", 1),
+        ]
+
+        mock_mapping_repo = MagicMock()
+        # Unmapped accounts for tenant 1
+        mock_mapping_repo.get_unmapped_tool_accounts.return_value = [
+            {"sender_name": "unknown-pc-qwen", "message_count": 5},
+        ]
+        # Mapped accounts: some for tenant 1, some for tenant 2
+        mapped_t1 = MagicMock()
+        mapped_t1.user_id = 1
+        mapped_t1.tool_type = "qwen"
+        mapped_t2 = MagicMock()
+        mapped_t2.user_id = 99  # User not in tenant 1
+        mapped_t2.tool_type = "qwen"
+        mock_mapping_repo.get_all.return_value = [mapped_t1, mapped_t2]
+        self.service.mapping_repo = mock_mapping_repo
+
+        stats = self.service.get_mapping_stats(tenant_id=1)
+
+        # mapped should only count user 1 (in tenant 1), not user 99
+        self.assertEqual(stats["total_mapped"], 1)
+        self.assertEqual(stats["total_unmapped"], 1)
+
+    def test_get_mapping_stats_no_tenant_id_returns_all(self):
+        """get_mapping_stats without tenant_id should return all stats."""
+        self.mock_db.fetch_all.return_value = []
+
+        mock_mapping_repo = MagicMock()
+        mock_mapping_repo.get_unmapped_tool_accounts.return_value = []
+        mapped1 = MagicMock()
+        mapped1.user_id = 1
+        mapped1.tool_type = "qwen"
+        mapped2 = MagicMock()
+        mapped2.user_id = 99
+        mapped2.tool_type = "claude"
+        mock_mapping_repo.get_all.return_value = [mapped1, mapped2]
+        self.service.mapping_repo = mock_mapping_repo
+
+        stats = self.service.get_mapping_stats()
+
+        # Without tenant_id, all mapped should be counted
+        self.assertEqual(stats["total_mapped"], 2)
+
+    # --- _get_users_cache tenant safety ---
+
+    def test_users_cache_populated_with_tenant_filter(self):
+        """_get_users_cache should populate cache with tenant-filtered users."""
+        self.mock_db.fetch_all.return_value = [
+            self._make_user_row(1, "alice", 1),
+            self._make_user_row(2, "bob", 1),
+        ]
+
+        cache = self.service._get_users_cache(tenant_id=1)
+
+        self.assertIn(1, cache)
+        self.assertIn(2, cache)
+        self.assertNotIn(99, cache)
+
+    def test_users_cache_cleared_on_run_auto_mapping(self):
+        """run_auto_mapping should clear cache to ensure fresh data."""
+        # Pre-populate cache with stale user 99
+        self.service._users_cache = {99: MagicMock()}
+
+        mock_mapping_repo = MagicMock()
+        mock_mapping_repo.get_by_tool_account.return_value = None
+        # Provide one unmapped account so the loop executes and cache gets re-populated
+        mock_mapping_repo.get_unmapped_tool_accounts.return_value = [
+            {"sender_name": "alice-pc-qwen", "message_count": 3},
+        ]
+        self.service.mapping_repo = mock_mapping_repo
+
+        # fetch_all returns tenant 1 users only (stale user 99 should be gone)
+        self.mock_db.fetch_all.return_value = [
+            self._make_user_row(1, "alice", 1),
+        ]
+        mock_rule_repo = MagicMock()
+        mock_rule_repo.get_auto_rules.return_value = []
+        self.service.rule_repo = mock_rule_repo
+
+        self.service.run_auto_mapping(dry_run=True, tenant_id=1)
+
+        # Cache should have been cleared and re-populated with tenant-filtered users
+        # Stale user 99 should no longer be in the cache
+        self.assertIsNotNone(self.service._users_cache)
+        self.assertNotIn(99, self.service._users_cache)
+
+
 class TestToolAccountMappingRule(unittest.TestCase):
     """Test cases for ToolAccountMappingRule matches method."""
 

--- a/tests/unit/test_tool_account_auto_mapping_service.py
+++ b/tests/unit/test_tool_account_auto_mapping_service.py
@@ -435,7 +435,7 @@ class TestAutoMappingServiceTenantFiltering(unittest.TestCase):
     # --- auto_map_account tenant filtering ---
 
     def test_auto_map_account_passes_tenant_id_to_get_all_users(self):
-        """auto_map_account should pass tenant_id to get_all_users."""
+        """auto_map_account should pass tenant_id to all get_all_users calls."""
         mock_mapping_repo = MagicMock()
         mock_mapping_repo.get_by_tool_account.return_value = None  # Not already mapped
         self.service.mapping_repo = mock_mapping_repo
@@ -449,26 +449,34 @@ class TestAutoMappingServiceTenantFiltering(unittest.TestCase):
 
         self.service.auto_map_account("alice-pc-qwen", "qwen", tenant_id=1)
 
-        # Verify fetch_all was called (via get_all_users) with tenant_id param
-        call_args = self.mock_db.fetch_all.call_args
-        params = call_args[0][1] if len(call_args[0]) > 1 else call_args[1].get("params")
-        self.assertIsNotNone(params)
-        self.assertIn(1, params)
+        # Verify ALL fetch_all calls include tenant_id=1 in params
+        # (auto_map_account calls get_all_users directly AND via try_match_by_rules->_get_users_cache)
+        self.assertGreaterEqual(self.mock_db.fetch_all.call_count, 1)
+        for call in self.mock_db.fetch_all.call_args_list:
+            params = call[0][1] if len(call[0]) > 1 else call[1].get("params")
+            self.assertIsNotNone(params, f"fetch_all call {call} missing params")
+            self.assertIn(1, params, f"fetch_all call {call} missing tenant_id=1")
 
     def test_auto_map_account_tenant_filtered_no_cross_tenant_match(self):
-        """auto_map_account should not match users from other tenants."""
+        """auto_map_account should not match users from other tenants.
+
+        This test provides tenant 1 users but uses a tool_account that doesn't
+        match any of them, verifying no false positive match occurs.
+        """
         mock_mapping_repo = MagicMock()
         mock_mapping_repo.get_by_tool_account.return_value = None
         self.service.mapping_repo = mock_mapping_repo
 
-        # No users in tenant 1 (fetch_all returns empty list when tenant_id=1 filters)
-        self.mock_db.fetch_all.return_value = []
+        # Tenant 1 has user "alice", but tool_account is "bob-pc-qwen" (no match)
+        self.mock_db.fetch_all.return_value = [
+            self._make_user_row(1, "alice", 1),
+        ]
         mock_rule_repo = MagicMock()
         mock_rule_repo.get_auto_rules.return_value = []
         self.service.rule_repo = mock_rule_repo
 
-        # With tenant_id=1, no users in tenant 1, so no match
-        result = self.service.auto_map_account("alice-pc-qwen", "qwen", tenant_id=1)
+        # "bob-pc-qwen" doesn't match "alice" by username or email
+        result = self.service.auto_map_account("bob-pc-qwen", "qwen", tenant_id=1)
 
         self.assertIsNone(result)
 
@@ -502,6 +510,8 @@ class TestAutoMappingServiceTenantFiltering(unittest.TestCase):
         # mapped should only count user 1 (in tenant 1), not user 99
         self.assertEqual(stats["total_mapped"], 1)
         self.assertEqual(stats["total_unmapped"], 1)
+        # Verify unmapped accounts were fetched with tenant_id
+        mock_mapping_repo.get_unmapped_tool_accounts.assert_called_once_with(tenant_id=1)
 
     def test_get_mapping_stats_no_tenant_id_returns_all(self):
         """get_mapping_stats without tenant_id should return all stats."""


### PR DESCRIPTION
## Summary

Closes #2374

This PR adds frontend UI entry points for all 6 auto-mapping API endpoints and fixes several tenant isolation security vulnerabilities discovered during implementation.

## Frontend Changes

### New: `AutoMappingPanel.tsx`
- Collapsible panel with lazy loading, embedded in `UserManagement` above the user table
- **Mapping Statistics Overview**: Shows mapped/unmapped account counts with tool-type breakdown badges
- **Run Auto-Mapping**: Button with dry-run preview flow — shows what would be mapped before confirming
- **Unmapped Accounts Modal**: Lists unmapped accounts with "Suggest Mapping" and "Manual Map" action buttons
- **Test Match Modal**: Input a tool account name and see which rule/user it would match
- Inline `zh` language checks (consistent with existing `MappingRulesEditor` pattern)
- Stats truncation handling: shows "Showing first 20 of N" when unmapped count exceeds 20

### Modified Files
- `UserManagement.tsx`: Added import and embedded `<AutoMappingPanel>` above user table
- `management/index.ts`: Added export for `AutoMappingPanel`
- `i18n/index.ts`: Added missing `unmappedAccounts` translations for `ja` and `ko`

## Backend Security Fixes

### Route Layer (`mapping_rules.py`)

| Endpoint | Issue | Fix |
|---|---|---|
| `GET /api/unmapped-accounts/<sender>/suggest-mapping` | **No tenant isolation at all** | Added fail-closed tenant isolation with `tenant_id` passthrough |
| `POST /api/mapping-rules/test-match` | **No tenant isolation at all** | Added fail-closed tenant isolation with `tenant_id` passthrough |
| `GET /api/mapping-stats` | Fail-open pattern (`and user_tenant_id is not None`) | Changed to fail-closed: `if user_tenant_id is None: return 403` |
| `POST /api/mapping-rules/auto-map` | Fail-open pattern | Changed to fail-closed |
| `GET /api/unmapped-accounts` | Fail-open pattern | Changed to fail-closed |

### Service Layer (`tool_account_auto_mapping_service.py`)

- `get_all_users(tenant_id)`: Added SQL `WHERE tenant_id = ?` filter
- `try_match_by_rules(tenant_id)`: Added explicit rule filtering — skips rules belonging to users outside the tenant
- `auto_map_account(tenant_id)`: Passes `tenant_id` through the full call chain (rules + username/email matching)
- `get_mapping_stats(tenant_id)`: Now filters mapped count by tenant (was only filtering unmapped)
- `_get_users_cache(tenant_id)`: Added tenant_id parameter with request-scoped cache safety documentation

## Test Coverage

### Security Tests (`test_tenant_isolation_mapping_rules.py`) — 12 new tests

- **`TestTenantIsolationForSuggestMapping`** (3 tests): Verifies tenant_admin gets tenant-scoped suggestions, platform_admin gets global
- **`TestTenantIsolationForTestMatch`** (3 tests): Verifies tenant_admin gets tenant-scoped match results, platform_admin gets global
- **`TestFailClosedPatternForAutoMapping`** (5 tests): Verifies all 5 auto-mapping endpoints return 403 when tenant_admin has `tenant_id=None`
- **`TestAdminWithTenantIdNotScopedForNewEndpoints`** (4 tests): Verifies admin/platform_admin with tenant_id are NOT scoped for new endpoints
- Added `get`/`delete` methods to `tenant_admin_client` and `platform_admin_client` fixtures

### Service Unit Tests (`test_tool_account_auto_mapping_service.py`) — 12 new tests

- **`TestAutoMappingServiceTenantFiltering`**: Tests for `get_all_users`, `try_match_by_rules`, `auto_map_account`, `get_mapping_stats`, and `_get_users_cache` with `tenant_id` parameter
- Verifies cross-tenant rule skipping, tenant-filtered matching, cache clearing on `run_auto_mapping`, and stats filtering

## Verification

- [x] `ruff check` — all passed
- [x] `black --check` — all passed
- [x] `isort --check-only` — all passed
- [x] `tsc --noEmit` — zero errors
- [x] `pytest tests/unit/test_tool_account_auto_mapping_service.py` — 36/36 passed
- [ ] CI security tests (run on Linux — `pwd` module not available on Windows)

## Backward Compatibility

- `admin` and `platform_admin` roles retain global access regardless of `tenant_id` (Issue #2286/#2324)
- All existing API signatures remain backward-compatible — `tenant_id` defaults to `None`
- No database schema changes required
