### PR TITLE
test(perf): split wall-clock benchmarks out of the required test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,11 @@ jobs:
         run: |
           # E2E/Playwright/HTTP tests live under tests/e2e/ and are excluded via
           # pytest.ini's norecursedirs. PostgreSQL tests are marked and deselected
-          # here; they run in the postgres-test job below.
+          # here; they run in the postgres-test job below. Wall-clock timing
+          # benchmarks are marked 'performance' and deselected for the same reason:
+          # a shared GitHub-hosted runner cannot guarantee timing bounds, and this
+          # job is a required merge check running with fail-fast. They run in the
+          # non-blocking performance-test job below.
           # Coverage includes scripts/shared and P0 security modules (Issue #1856)
           # Issue #2189: Add coverage threshold to ensure failure propagates
           pytest tests/ -v \
@@ -147,7 +151,7 @@ jobs:
             --cov-fail-under=30 \
             --cov-report=xml \
             --cov-report=html \
-            -m "not postgres"
+            -m "not postgres and not performance"
 
       - name: Upload coverage to Codecov
         timeout-minutes: 2
@@ -273,6 +277,38 @@ jobs:
           DATABASE_URL: postgresql://ace:ace@localhost:5432/ace_test
           # Use separate database to avoid conflict with schema-sync workflow
           ACE_DATABASE_NAME: ace_test
+
+  # Wall-clock performance benchmarks
+  # Split out of the required `test` matrix for the same reason postgres-test is:
+  # these assert on elapsed time, which a shared GitHub-hosted runner cannot
+  # guarantee. Noisy neighbours produced 60-70% swings and failed `test (3.12)`
+  # on main; because `test` is a required merge check running with fail-fast, a
+  # single trip cancelled the rest of the matrix and blocked every PR until
+  # someone manually re-ran the job.
+  #
+  # This job is NOT a required check: a timing blip here must never block a merge.
+  # It still reports pass/fail so a genuine, sustained regression stays visible.
+  performance-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest pytest-asyncio
+
+      - name: Run performance benchmarks
+        run: pytest tests/ -v -m "performance and not postgres" --tb=short
 
   # Security Audit Gate (Issue #1890)
   # Blocks PRs with known high/critical vulnerabilities in production dependencies

--- a/pytest.ini
+++ b/pytest.ini
@@ -17,6 +17,7 @@ markers =
     priority_p2: Broad or expensive coverage covered by periodic/manual runs
     issue: Issue-specific tests (use --issue=N to run specific issue)
     postgres: Requires a live PostgreSQL server (auto-skipped via pg_db fixture when unreachable)
+    performance: Wall-clock timing benchmarks (deselected from the required test matrix; run in the performance-test CI job)
 
 # Exclude scripts/ and server-dependent tests from default collection.
 # All HTTP/Playwright E2E tests live under tests/e2e/ (Issue #238); the single

--- a/tests/performance/test_generate_default_rules_performance.py
+++ b/tests/performance/test_generate_default_rules_performance.py
@@ -2,6 +2,11 @@
 Performance tests for generate default rules functionality.
 
 Issue #2131: Verify response time < 500ms.
+
+Tests that assert on wall-clock time are marked ``@pytest.mark.performance`` and
+are deselected from the required ``test (3.x)`` CI matrix -- a shared runner
+cannot guarantee timing bounds. They run in the separate, non-blocking
+``performance-test`` job.
 """
 
 import time
@@ -58,6 +63,7 @@ class TestGenerateDefaultRulesPerformance:
     Issue #2131: Verify response time < 500ms.
     """
 
+    @pytest.mark.performance
     @patch("app.routes.mapping_rules.ToolAccountAutoMappingService")
     def test_response_time_first_generate(self, mock_service_class, admin_client):
         """
@@ -113,6 +119,7 @@ class TestGenerateDefaultRulesPerformance:
         # Log actual response time for monitoring
         print(f"Response time for first generate: {elapsed_time:.3f}s")
 
+    @pytest.mark.performance
     @patch("app.routes.mapping_rules.ToolAccountAutoMappingService")
     def test_response_time_repeat_generate(self, mock_service_class, admin_client):
         """
@@ -149,6 +156,7 @@ class TestGenerateDefaultRulesPerformance:
 
         print(f"Response time for repeat generate: {elapsed_time:.3f}s")
 
+    @pytest.mark.performance
     def test_response_time_under_load(self, admin_client):
         """
         Verify response time under simulated load.
@@ -263,6 +271,7 @@ class TestGenerateDefaultRulesPerformance:
         # For this test, we just verify no exceptions occurred
         print("Connection leak test: All requests succeeded without errors")
 
+    @pytest.mark.performance
     def test_no_performance_regression(self, admin_client):
         """
         Verify performance does not degrade beyond baseline.

--- a/tests/performance/test_permission_check_performance.py
+++ b/tests/performance/test_permission_check_performance.py
@@ -8,6 +8,11 @@ Tests:
 - Single permission check < 1ms
 - High-frequency API response time increase < 5%
 - Memory overhead < 1MB
+
+Tests that assert on wall-clock time are marked ``@pytest.mark.performance`` and
+are deselected from the required ``test (3.x)`` CI matrix -- a shared runner
+cannot guarantee timing bounds. They run in the separate, non-blocking
+``performance-test`` job.
 """
 
 import sys
@@ -50,6 +55,7 @@ class TestPermissionCheckPerformance:
 
         return app
 
+    @pytest.mark.performance
     def test_single_permission_check_performance(self, app):
         """
         Test that single permission check is < 1ms.
@@ -91,6 +97,7 @@ class TestPermissionCheckPerformance:
         # Note: This includes full request processing, so we use 10ms as reasonable threshold
         assert avg_time_ms < 10, f"Permission check took {avg_time_ms:.2f}ms per request"
 
+    @pytest.mark.performance
     def test_platform_admin_role_check_performance(self, app):
         """
         Test that platform_admin role check is < 1ms.
@@ -127,51 +134,81 @@ class TestPermissionCheckPerformance:
         # Should be similar to admin role check
         assert avg_time_ms < 10, f"Permission check took {avg_time_ms:.2f}ms per request"
 
-    def test_permission_check_consistency(self, app):
+    def test_permission_check_work_is_identical_across_roles(self, app):
         """
-        Test that permission check performance is consistent across roles.
+        Test that the permission check does identical work for every admin role.
 
         Issue #2276: Ensure no performance regression for different roles.
-        """
-        roles = [
-            ("admin", "admin"),
-            ("platform_admin", "platform_admin"),
-        ]
 
-        results = {}
-        for role_name, role_value in roles:
+        This asserts on the *amount of work* per request rather than on wall-clock
+        time. ``platform_admin_required`` accepts both ``platform_admin`` and the
+        legacy ``admin`` role from a single branch (Issue #2286), so both roles must
+        cost exactly one token extraction and one user load per request. A regression
+        that makes one role more expensive than the other -- an extra role lookup, a
+        per-request tenant query, a retry loop -- shows up here as a changed call
+        count, deterministically and on any machine.
+
+        The previous version of this test compared elapsed time between the two roles
+        and required <20% variance. That is not a property a shared CI runner can
+        guarantee (observed swings of 60-70% from noisy neighbours), and it made the
+        required ``test (3.x)`` jobs flaky on main.
+        """
+        requests_per_role = 50
+        # Guards the test against itself: at zero requests every count is 0 and
+        # every assertion below holds while nothing has been exercised.
+        assert requests_per_role > 1, "comparison is meaningless without repeated requests"
+        roles = ["admin", "platform_admin"]
+
+        call_counts = {}
+        for role in roles:
             with patch(
                 "app.auth.decorators._load_user_from_token",
                 return_value={
                     "id": 1,
-                    "username": role_name,
-                    "email": f"{role_name}@example.com",
-                    "role": role_value,
+                    "username": role,
+                    "email": f"{role}@example.com",
+                    "role": role,
                     "tenant_id": None,
                     "must_change_password": False,
                 },
-            ):
+            ) as load_user:
                 with patch(
                     "app.auth.decorators._extract_session_token", return_value="valid-token"
-                ):
+                ) as extract_token:
                     with app.test_client() as client:
-                        start_time = time.time()
-                        for _ in range(100):
-                            client.get(
+                        for _ in range(requests_per_role):
+                            response = client.get(
                                 "/api/test",
                                 headers={"Authorization": "Bearer valid-token"},
                             )
-                        end_time = time.time()
+                            assert (
+                                response.status_code == 200
+                            ), f"Role {role!r} was rejected with {response.status_code}"
+                            assert response.get_json()["role"] == role
 
-                        results[role_name] = end_time - start_time
+            call_counts[role] = {
+                "extract_session_token": extract_token.call_count,
+                "load_user_from_token": load_user.call_count,
+            }
 
-        # Performance difference should be minimal (< 20% variance)
-        admin_time = results["admin"]
-        platform_admin_time = results["platform_admin"]
-        variance = abs(admin_time - platform_admin_time) / max(admin_time, platform_admin_time)
+        # Each role costs exactly one token extraction + one user load per request.
+        expected = {
+            "extract_session_token": requests_per_role,
+            "load_user_from_token": requests_per_role,
+        }
+        for role in roles:
+            assert call_counts[role] == expected, (
+                f"Role {role!r} performed {call_counts[role]} auth operations for "
+                f"{requests_per_role} requests, expected {expected}"
+            )
 
-        assert variance < 0.2, f"Performance variance between roles: {variance:.2%}"
+        # ...and both roles cost the same, so neither is privileged over the other.
+        assert call_counts["admin"] == call_counts["platform_admin"], (
+            f"admin cost {call_counts['admin']} but platform_admin cost "
+            f"{call_counts['platform_admin']}"
+        )
 
+    @pytest.mark.performance
     def test_rejection_performance(self, app):
         """
         Test that rejection (403) is fast for unauthorized roles.


### PR DESCRIPTION
## Problem

`tests/performance/test_permission_check_performance.py::test_permission_check_consistency` is failing on `main` itself, not just on feature branches:

| where | job | variance |
|---|---|---|
| `main` run 31116150885 | `test (3.12)` | 70.94% |
| PR #2389 run 31141193996 | `test (3.12)` | 67.08%, then 63.72% on rerun |

It compared elapsed wall-clock time between two 100-request loops and required <20% variance. A shared GitHub-hosted runner cannot guarantee that — noisy neighbours routinely produce 60–70% swings.

The consequence is not cosmetic: `test (3.10)`, `test (3.11)` and `test (3.12)` are **required** merge checks and the matrix runs with fail-fast, so a single trip cancels the rest and blocks every PR until someone manually reruns the job.

## Fix

The two kinds of test get deliberately different treatment.

**1. The consistency test is rewritten, not deselected.** Its intent — "no admin role is more expensive than another" (#2276) — belongs in the required matrix. It now asserts on the *amount of work* per request (auth call counts) rather than on elapsed time. `platform_admin_required` accepts both `platform_admin` and legacy `admin` from a single branch (#2286), so both must cost exactly one token extraction and one user load per request. An extra role lookup, a per-request tenant query or a retry loop changes the count — deterministically, on any machine. Renamed to `test_permission_check_work_is_identical_across_roles`, since it no longer measures performance.

**2. The remaining seven tests genuinely assert on elapsed time**, so they are marked `performance` and deselected from `test (3.x)`, running in a new non-required `performance-test` job. This mirrors the split that already exists for `postgres`. They still report pass/fail, so a sustained regression stays visible; a timing blip just cannot block a merge.

## Verification

- `pytest tests/performance/ -q` → 9 passed
- Required-matrix selection `-m "not postgres and not performance"` → 2 kept, 7 deselected
- Mutation-tested the rewritten assertion: wrong expected count → killed; `requests_per_role = 0` → killed (a guard was added for that second one, which initially survived)
- `pre-commit run --all-files` clean

## Note on scope

This is a prerequisite, not a drive-by: #2388 and #2389 cannot merge while the required matrix is a coin flip.