### PR TITLE
fix: 远程机器列表添加自动刷新功能 (#2366)

### DIFF
--- a/frontend/src/hooks/useRemote.ts
+++ b/frontend/src/hooks/useRemote.ts
@@ -12,6 +12,7 @@ export function useMachines() {
   return useQuery({
     queryKey: ['remote', 'machines'],
     queryFn: () => remoteApi.listMachines(),
+    refetchInterval: 30000, // 每 30 秒自动刷新，匹配心跳更新频率
   });
 }
 


### PR DESCRIPTION
## 问题描述

管理界面的远程机器列表不会自动刷新，依赖用户手动刷新或窗口焦点触发更新，导致状态可能过时。

### 根因分析

- 代码位置：`frontend/src/hooks/useRemote.ts:11-15`
- `useMachines()` 没有设置 `refetchInterval`
- 使用全局配置的 `staleTime: 1 minute`
- 依赖用户手动刷新或窗口焦点触发更新

## 修复方案

添加 `refetchInterval: 30000`（方案 A，评审已通过）

```typescript
export function useMachines() {
  return useQuery({
    queryKey: ['remote', 'machines'],
    queryFn: () => remoteApi.listMachines(),
    refetchInterval: 30000, // 每 30 秒自动刷新，匹配心跳更新频率
  });
}
```

### 方案优势

- ✅ 与心跳机制匹配（30秒）
- ✅ 与现有实践一致（`useAutonomous.ts` 已使用 30秒）
- ✅ 实现简单，风险低（仅 1 行代码）
- ✅ API 性能影响小（已优化避免 N+1 问题，每用户每分钟仅 2 次请求）

## 验证结果

- ✅ TypeScript 类型检查通过
- ✅ ESLint 检查通过（未引入新 warning）

## 关联 Issue

Closes #2366

## 相关 Issue

- #2263 - 远程机器管理界面显示"离线"，但 agent 实际在线
- #2364 - 远程机器 last_heartbeat 时区显示偏差（已修复）
- #2365 - Agent 启动初始化期间不发送心跳（已评审）