### PR TITLE
fix(webui): pass HOME and OPENACE_LOG_DIR to webui process via sudo -u

### DIFF
--- a/app/services/webui_manager.py
+++ b/app/services/webui_manager.py
@@ -1114,6 +1114,32 @@ class WebUIManager:
                 ]:
                     if child_env.get(key):
                         env_args.append(f"{key}={child_env[key]}")
+
+                # Set HOME to the target user's home directory.
+                # sudo's always_set_home should handle this, but it doesn't
+                # work reliably in all sudo/PAM configurations (the webui
+                # process inherits the service user's HOME instead). Without
+                # the correct HOME, the webui fails to create its log
+                # directory ($HOME/logs) with EACCES, causing startup failure.
+                try:
+                    target_home = pwd.getpwnam(system_account).pw_dir
+                    env_args.append(f"HOME={target_home}")
+                except KeyError:
+                    logger.warning(
+                        f"Could not resolve home dir for '{system_account}', "
+                        "HOME will not be set explicitly"
+                    )
+
+                # Explicitly pass OPENACE_LOG_DIR. It's in
+                # _WEBUI_ENV_SUDO_KNOWN_KEYS (excluded from the dynamic loop
+                # below) because it was expected to be preserved by sudoers
+                # env_keep. However, with popen_env=None the parent process
+                # environment doesn't contain OPENACE_LOG_DIR (it's only in
+                # child_env), so env_keep has nothing to preserve. Inline it
+                # explicitly to ensure the webui logs to the correct directory.
+                if child_env.get("OPENACE_LOG_DIR"):
+                    env_args.append(f"OPENACE_LOG_DIR={child_env['OPENACE_LOG_DIR']}")
+
                 # Dynamic envKeys from model pool (e.g., BAILIAN_CODING_PLAN_API_KEY)
                 for key, value in child_env.items():
                     if key not in _WEBUI_ENV_SUDO_KNOWN_KEYS and value:


### PR DESCRIPTION
## Summary

Fixes WebUI startup failure in multi-user mode (systemd / Package deployment) where non-admin users see "WebUI authentication failed. Please refresh the page." when navigating to `/work`.

Closes #2399

## Root Cause

In `app/services/webui_manager.py`, method `_launch_webui_process`, when launching the WebUI process via `sudo -u <system_account>`, two critical environment variables are not passed:

### 1. `HOME` not explicitly set

The `env_args` only includes LLM config, locale, and proxy variables. `HOME` is not included, and the code implicitly relies on sudo's `always_set_home` — which does **not** work reliably in all sudo/PAM configurations. The WebUI process inherits the **service user's** HOME, and when the target user tries to create its log directory at `$HOME/logs`, it gets `EACCES: permission denied`.

### 2. `OPENACE_LOG_DIR` not passed

`OPENACE_LOG_DIR` is in `_WEBUI_ENV_SUDO_KNOWN_KEYS` (excluded from the dynamic env_args loop). The original design assumed it would be preserved via sudoers `env_keep`, but since `popen_env=None`, the parent process environment doesn't contain `OPENACE_LOG_DIR` — it's only in `child_env`. So `env_keep` has nothing to preserve, and the variable is silently dropped.

### Error propagation

```
WebUI process: EACCES: permission denied, mkdir '<service_user_home>/logs'
  → _start_instance_internal: ValueError("WebUI service failed to start within timeout")
  → routes/workspace.py: returns { success: false, error: "Internal server error" }
  → Frontend Workspace.tsx: "WebUI authentication failed. Please refresh the page."
```

## Fix

Explicitly append `HOME` and `OPENACE_LOG_DIR` to `env_args` before the dynamic loop:

```python
# Set HOME to the target user's home directory.
try:
    target_home = pwd.getpwnam(system_account).pw_dir
    env_args.append(f"HOME={target_home}")
except KeyError:
    logger.warning(
        f"Could not resolve home dir for '{system_account}', "
        "HOME will not be set explicitly"
    )

# Explicitly pass OPENACE_LOG_DIR
if child_env.get("OPENACE_LOG_DIR"):
    env_args.append(f"OPENACE_LOG_DIR={child_env['OPENACE_LOG_DIR']}")
```

## Testing

- Deployed fix to a production server (systemd / Package method, multi-user mode)
- Verified a non-admin user can now log in and access the workspace successfully
- The workspace loads normally with project list visible — no more "WebUI authentication failed" error

## Files Changed

- `app/services/webui_manager.py`: +26 lines (HOME and OPENACE_LOG_DIR env var passing in `_launch_webui_process`)
