### PR TITLE
fix(llm-proxy): remove tool_choice for DeepSeek thinking mode compatibility

### DIFF
--- a/app/modules/workspace/llm_proxy_handler.py
+++ b/app/modules/workspace/llm_proxy_handler.py
@@ -1305,14 +1305,17 @@ def handle_llm_proxy_request(
                     # call (e.g. create a directory); that 400 kills the whole
                     # request and the CLI shows no reply. Strip it for
                     # compatibility — the model still calls tools on its own.
+                    # Only strip for DeepSeek models to preserve tool_choice for
+                    # other providers that support it.
                     if data.get("tool_choice") is not None:
-                        logger.info(
-                            "LLM proxy: stripping tool_choice=%r (provider=%s model=%s)",
-                            data["tool_choice"],
-                            provider,
-                            requested_model or "?",
-                        )
-                        data.pop("tool_choice", None)
+                        model_lower = (requested_model or "").lower()
+                        if "deepseek" in model_lower:
+                            logger.info(
+                                "LLM proxy: stripping tool_choice=%r for DeepSeek model=%s",
+                                data["tool_choice"],
+                                requested_model or "?",
+                            )
+                            data.pop("tool_choice", None)
                     body = json.dumps(data).encode("utf-8")
                 except (json.JSONDecodeError, ValueError, TypeError):
                     pass  # 解析失败，使用原始请求体

--- a/app/modules/workspace/llm_proxy_handler.py
+++ b/app/modules/workspace/llm_proxy_handler.py
@@ -1299,7 +1299,21 @@ def handle_llm_proxy_request(
                             existing_so.setdefault("include_usage", True)
                         else:
                             data["stream_options"] = {"include_usage": True}
-                        body = json.dumps(data).encode("utf-8")
+                    # Issue #2412: DeepSeek's thinking mode rejects tool_choice
+                    # ("Thinking mode does not support this tool_choice" -> 400).
+                    # The qwen CLI sets tool_choice when it wants to force a tool
+                    # call (e.g. create a directory); that 400 kills the whole
+                    # request and the CLI shows no reply. Strip it for
+                    # compatibility — the model still calls tools on its own.
+                    if data.get("tool_choice") is not None:
+                        logger.info(
+                            "LLM proxy: stripping tool_choice=%r (provider=%s model=%s)",
+                            data["tool_choice"],
+                            provider,
+                            requested_model or "?",
+                        )
+                        data.pop("tool_choice", None)
+                    body = json.dumps(data).encode("utf-8")
                 except (json.JSONDecodeError, ValueError, TypeError):
                     pass  # 解析失败，使用原始请求体
 

--- a/tests/unit/test_deepseek_tool_choice.py
+++ b/tests/unit/test_deepseek_tool_choice.py
@@ -1,0 +1,260 @@
+"""
+Tests for Issue #2412: DeepSeek thinking mode rejects tool_choice
+
+Tests that tool_choice is stripped only for DeepSeek models.
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from flask import Flask
+
+from app.routes.remote import remote_bp
+
+_PROXY_PATH = "app.routes.remote.get_api_key_proxy_service"
+_QUOTA_PATH = "app.modules.governance.quota_manager.QuotaManager"
+_HTTP_PATH = "requests.request"
+
+
+@pytest.fixture
+def remote_app():
+    """Flask app with remote blueprint for route-level handler tests."""
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.register_blueprint(remote_bp, url_prefix="/api/remote")
+    return app
+
+
+def _mock_proxy_token(**overrides):
+    """Build a mock token payload."""
+    base = {
+        "user_id": 1,
+        "tenant_id": 1,
+        "provider": "deepseek",
+        "session_id": "sess-abc",
+        "scope": "remote",
+    }
+    base.update(overrides)
+    return base
+
+
+def _make_quota_ok():
+    mock = MagicMock()
+    mock.check_quota.return_value = {"allowed": True}
+    return mock
+
+
+def _mock_upstream_response(status_code=200, content=b'{"ok":true}'):
+    """Create a mock upstream response."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.content = content
+    resp.headers = {"Content-Type": "application/json"}
+    resp.iter_content.return_value = [content]
+    resp.json.return_value = json.loads(content)
+    return resp
+
+
+class TestDeepSeekToolChoiceStripping:
+    """Test tool_choice stripping for DeepSeek models."""
+
+    @patch(_HTTP_PATH)
+    @patch(_QUOTA_PATH)
+    @patch(_PROXY_PATH)
+    def test_strips_tool_choice_for_deepseek_model(
+        self, mock_get_proxy, mock_quota_cls, mock_http, remote_app
+    ):
+        """Test that tool_choice is stripped for DeepSeek models."""
+        # Setup mocks
+        mock_proxy = MagicMock()
+        mock_proxy.validate_proxy_token.return_value = _mock_proxy_token(
+            provider="deepseek",
+        )
+        mock_proxy.resolve_api_key_for_scope.return_value = (
+            "sk-test",
+            "https://api.deepseek.com/v1",
+            1,
+            None,
+            None,  # resolved_ips
+        )
+        mock_get_proxy.return_value = mock_proxy
+        mock_quota_cls.return_value = _make_quota_ok()
+
+        captured_body = None
+
+        def capture_request(**kwargs):
+            nonlocal captured_body
+            captured_body = kwargs.get("data")
+            return _mock_upstream_response()
+
+        mock_http.side_effect = capture_request
+
+        # Make request with tool_choice
+        client = remote_app.test_client()
+        resp = client.post(
+            "/api/remote/llm-proxy",
+            json={
+                "model": "deepseek-reasoner",
+                "messages": [{"role": "user", "content": "test"}],
+                "stream": True,
+                "tool_choice": {"type": "function", "function": {"name": "shell"}},
+            },
+            headers={"Authorization": "Bearer tok"},
+        )
+
+        assert resp.status_code == 200
+
+        # Verify tool_choice was stripped
+        assert captured_body is not None
+        data = json.loads(captured_body)
+        assert "tool_choice" not in data
+        assert data.get("stream") is True  # other fields preserved
+
+    @patch(_HTTP_PATH)
+    @patch(_QUOTA_PATH)
+    @patch(_PROXY_PATH)
+    def test_preserves_tool_choice_for_non_deepseek(
+        self, mock_get_proxy, mock_quota_cls, mock_http, remote_app
+    ):
+        """Test that tool_choice is preserved for non-DeepSeek models."""
+        # Setup mocks
+        mock_proxy = MagicMock()
+        mock_proxy.validate_proxy_token.return_value = _mock_proxy_token(
+            provider="openai",
+        )
+        mock_proxy.resolve_api_key_for_scope.return_value = (
+            "sk-test",
+            "https://api.openai.com/v1",
+            1,
+            None,
+            None,  # resolved_ips
+        )
+        mock_get_proxy.return_value = mock_proxy
+        mock_quota_cls.return_value = _make_quota_ok()
+
+        captured_body = None
+
+        def capture_request(**kwargs):
+            nonlocal captured_body
+            captured_body = kwargs.get("data")
+            return _mock_upstream_response()
+
+        mock_http.side_effect = capture_request
+
+        # Make request with tool_choice
+        client = remote_app.test_client()
+        resp = client.post(
+            "/api/remote/llm-proxy",
+            json={
+                "model": "gpt-4",
+                "messages": [{"role": "user", "content": "test"}],
+                "stream": True,
+                "tool_choice": {"type": "function", "function": {"name": "shell"}},
+            },
+            headers={"Authorization": "Bearer tok"},
+        )
+
+        assert resp.status_code == 200
+
+        # Verify tool_choice was preserved
+        assert captured_body is not None
+        data = json.loads(captured_body)
+        assert "tool_choice" in data
+        assert data["tool_choice"]["function"]["name"] == "shell"
+
+    @patch(_HTTP_PATH)
+    @patch(_QUOTA_PATH)
+    @patch(_PROXY_PATH)
+    def test_no_tool_choice_unchanged(self, mock_get_proxy, mock_quota_cls, mock_http, remote_app):
+        """Test that request without tool_choice is unchanged."""
+        # Setup mocks
+        mock_proxy = MagicMock()
+        mock_proxy.validate_proxy_token.return_value = _mock_proxy_token(
+            provider="deepseek",
+        )
+        mock_proxy.resolve_api_key_for_scope.return_value = (
+            "sk-test",
+            "https://api.deepseek.com/v1",
+            1,
+            None,
+            None,  # resolved_ips
+        )
+        mock_get_proxy.return_value = mock_proxy
+        mock_quota_cls.return_value = _make_quota_ok()
+
+        captured_body = None
+
+        def capture_request(**kwargs):
+            nonlocal captured_body
+            captured_body = kwargs.get("data")
+            return _mock_upstream_response()
+
+        mock_http.side_effect = capture_request
+
+        # Make request without tool_choice
+        client = remote_app.test_client()
+        resp = client.post(
+            "/api/remote/llm-proxy",
+            json={
+                "model": "deepseek-reasoner",
+                "messages": [{"role": "user", "content": "test"}],
+                "stream": True,
+            },
+            headers={"Authorization": "Bearer tok"},
+        )
+
+        assert resp.status_code == 200
+
+        # Verify request is valid JSON and stream preserved
+        assert captured_body is not None
+        data = json.loads(captured_body)
+        assert data.get("stream") is True
+
+    @patch(_HTTP_PATH)
+    @patch(_QUOTA_PATH)
+    @patch(_PROXY_PATH)
+    def test_deepseek_case_insensitive(self, mock_get_proxy, mock_quota_cls, mock_http, remote_app):
+        """Test that DeepSeek detection is case-insensitive."""
+        # Setup mocks
+        mock_proxy = MagicMock()
+        mock_proxy.validate_proxy_token.return_value = _mock_proxy_token(
+            provider="deepseek",
+        )
+        mock_proxy.resolve_api_key_for_scope.return_value = (
+            "sk-test",
+            "https://api.deepseek.com/v1",
+            1,
+            None,
+            None,  # resolved_ips
+        )
+        mock_get_proxy.return_value = mock_proxy
+        mock_quota_cls.return_value = _make_quota_ok()
+
+        # Test various case variations
+        for model_name in ["DeepSeek-Reasoner", "DEEPSEEK-V3", "deepseek-chat"]:
+            captured_body = None
+
+            def capture_request(**kwargs):
+                nonlocal captured_body
+                captured_body = kwargs.get("data")
+                return _mock_upstream_response()
+
+            mock_http.side_effect = capture_request
+
+            client = remote_app.test_client()
+            resp = client.post(
+                "/api/remote/llm-proxy",
+                json={
+                    "model": model_name,
+                    "messages": [{"role": "user", "content": "test"}],
+                    "stream": True,
+                    "tool_choice": "auto",
+                },
+                headers={"Authorization": "Bearer tok"},
+            )
+
+            assert resp.status_code == 200
+            assert captured_body is not None
+            data = json.loads(captured_body)
+            assert "tool_choice" not in data, f"tool_choice should be stripped for {model_name}"


### PR DESCRIPTION
# Issue #2412: DeepSeek thinking mode rejects tool_choice

## 问题

发送需调用 shell 工具的指令（如"帮我创建一个名为txt的文件夹"）→ AI 无任何回复、图标消失；普通查询正常。

## 根因

qwen CLI 在强制调用工具时发送 `tool_choice` 字段，DeepSeek **思考模式不支持 tool_choice → 400**（`"Thinking mode does not support this tool_choice"`）→ LLM 调用失败 → 无回复。

## 修复

`llm_proxy_handler.py` 转发前移除非空 `tool_choice`（模型仍会按函数定义自动调用工具）。

## 拆分说明

本 PR 拆分自 #2414，作者为 papercatno1。

**Original Author:** papercatno1

Generated with Qwen Code