### PR TITLE
fix(scripts): reclaim the per-task runtime tree on exit (#2403)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,17 @@ jobs:
             --cov-report=html \
             -m "not postgres and not performance"
 
+      # pytest.ini's norecursedirs excludes tests/issues entirely, so nothing
+      # under it is collected by the run above — ~4200 tests across 238 issue
+      # directories never execute here. Fixing that wholesale is tracked
+      # separately; until then, issue suites must opt in explicitly or they are
+      # written, reviewed, and merged without ever gating anything.
+      - name: Issue regression suites (opt-in; see norecursedirs)
+        timeout-minutes: 5
+        run: |
+          pytest tests/issues/2403 tests/issues/2428 -v \
+            -m "not postgres and not performance"
+
       - name: Upload coverage to Codecov
         timeout-minutes: 2
         continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,7 @@ jobs:
       - name: Issue regression suites (opt-in; see norecursedirs)
         timeout-minutes: 5
         run: |
-          pytest tests/issues/2403 tests/issues/2428 -v \
+          pytest tests/issues/2403 -v \
             -m "not postgres and not performance"
 
       - name: Upload coverage to Codecov

--- a/scripts/openace-run-as.sh
+++ b/scripts/openace-run-as.sh
@@ -307,7 +307,12 @@ if [ "$isolated" = true ]; then
     acl_registry="/run/openace-agent-acl-${isolation_key}"
     signature_registry="/run/openace-agent-git-signature-${isolation_key}"
     signature_tmp="${signature_registry}.next"
-    exec 9>"/run/lock/openace-agent-${isolation_key}.lock"
+    # Single source for the lock directory so the #2403 preserve reaper derives
+    # peer lock paths exactly the way this run derives its own. Deliberately a
+    # constant, not an environment override: redirecting it would silently break
+    # mutual exclusion between concurrent attempts.
+    _lock_dir="/run/lock"
+    exec 9>"${_lock_dir}/openace-agent-${isolation_key}.lock"
     flock -x 9
 
     # Per-attempt HOME/TMP/XDG runtime tree (#2020). Ephemeral parent under
@@ -315,6 +320,91 @@ if [ "$isolated" = true ]; then
     # cannot traverse. Wiped first so a retried task_id starts clean.
     task_base=""
     task_home="" ; task_tmp="" ; task_cache="" ; task_config="" ; task_data=""
+    # Issue #2403: must be initialised unconditionally. It is only assigned
+    # inside the `[ -n "$task_id" ]` block below, and reclaim_task_tree() reads
+    # it from an EXIT trap that also fires on the legacy `uid-*` path — under
+    # `set -u` an unset name would kill the wrapper there.
+    preserve_claude_dir=""
+    # Age cutoff for reaping abandoned .claude-preserve dirs (#2403 F1c) is read
+    # from the launcher conf at the call site below — _conf_value() is not
+    # defined yet at this point in the script.
+    preserve_max_age_days=30
+
+    # Issue #2403: reclaim the per-task runtime tree on the way out. Without
+    # this the wrapper only ever wiped on START, so every run left one directory
+    # behind forever; 46 of them filled the 3.1G /run tmpfs and every autonomous
+    # workflow began failing with a misleading "Failed to access project dir".
+    #
+    # Defined BEFORE the tree is built, and before the first exit that can
+    # follow it (the cgroup fail-closed `exit 66` further down), because bash
+    # resolves the function name when the EXIT trap FIRES, not when it is
+    # installed. Defining it later would silently make that trap a no-op.
+    #
+    # Deliberately NOT part of cleanup_isolated(): that one also runs pre-flight,
+    # AFTER this tree has been built and .claude restored into it, so folding
+    # the reclaim in there would delete the freshly restored session history
+    # before the agent even starts. Keeping it separate also lets tests extract
+    # and run this function without cgroup/ACL/registry privileges.
+    reclaim_task_tree() {
+        [ -n "$task_base" ] || return 0
+        [ -n "$preserve_claude_dir" ] || return 0
+        # Same three-line shape as the startup preserve-move below. The `rm -rf`
+        # MUST stay inside the `-d` guard: a second execution (a signal landing
+        # between the success-path call and `trap -`) then becomes a no-op
+        # instead of deleting the history it just saved.
+        #
+        # Both branches do real work, depending on where a signal lands:
+        #   - guard TRUE  (.claude still in task_home): rescue it to the preserve
+        #     path, then drop the tree. This is the common case.
+        #   - guard FALSE (.claude already moved out, or task_home gone): leave
+        #     the preserve dir alone and just drop the tree.
+        # Do not "simplify" this to the FALSE branch — the TRUE branch is what
+        # keeps #2035 --resume working.
+        if [ -d "$task_home/.claude" ]; then
+            rm -rf -- "$preserve_claude_dir" 2>/dev/null || true
+            mv "$task_home/.claude" "$preserve_claude_dir" 2>/dev/null || true
+        fi
+        rm -rf -- "$task_base" 2>/dev/null || true
+    }
+
+    # Issue #2403 F1c: reclaiming the tree on exit converts a fast directory
+    # leak into a slow .claude-preserve leak (one per task_id, forever), so bound
+    # that too. Scope is deliberately narrow: ONLY *.claude-preserve siblings,
+    # never task directories — reaping those needs a liveness test this script
+    # cannot make (the Python launch path in task_isolation.py creates task trees
+    # without ever taking a lock; it never creates .claude-preserve, which is why
+    # this sweep is safe and a task-dir sweep is not).
+    #
+    # Named rather than inlined so tests can extract and run it directly.
+    reap_stale_preserve_dirs() {
+        for _pdir in "$task_root"/*.claude-preserve; do
+            [ -d "$_pdir" ] || continue   # unmatched glob stays literal
+            # Test the whole TREE, not the directory inode. The CLI writes to
+            # .claude/projects/<encoded>/*.jsonl, so the top directory's mtime
+            # does not move as a session grows, and rename(2) does not touch the
+            # renamed inode's mtime either. Keying on the directory mtime would
+            # delete the most active long-lived sessions first.
+            [ -z "$(find "$_pdir" -newermt "-${preserve_max_age_days} days" \
+                    -print -quit 2>/dev/null)" ] || continue
+            _pid="${_pdir##*/}"; _pid="${_pid%.claude-preserve}"
+            _plock="${_lock_dir}/openace-agent-task-${_pid}.lock"
+            # `8<` — read only, NO O_CREAT. flock(2) does not require write
+            # access, and this must never manufacture a lock file: lock files
+            # cannot be reclaimed safely (unlink then same-name open yields a
+            # different inode, so two holders stop excluding each other). A live
+            # run creates its lock before touching anything, so an absent lock
+            # file means no live run.
+            if [ ! -e "$_plock" ]; then
+                rm -rf -- "$_pdir" 2>/dev/null || true
+                continue
+            fi
+            # The subshell scopes fd 8 so it is closed on every exit path and a
+            # large task_root cannot leak descriptors. Never reuse fd 9 — that is
+            # this run's own lock; re-locking or closing it would drop our mutex.
+            ( flock -n 8 || exit 0; rm -rf -- "$_pdir" 2>/dev/null || true ) \
+                8<"$_plock" || true
+        done
+    }
     if [ -n "$task_id" ]; then
         task_root="${OPENACE_AGENT_TASK_ROOT:-/run/openace-agent-tasks}"
         task_base="${task_root}/${task_id}"
@@ -337,6 +427,19 @@ if [ "$isolated" = true ]; then
         # unconditional restore below finds the orphaned preserve dir and
         # restores it even though $task_home/.claude was already moved away.
         preserve_claude_dir="${task_base}.claude-preserve"
+        # Issue #2403: arm reclaim HERE, not after the tree is built. Everything
+        # from the preserve-move below through the restore is a window in which
+        # an exit or a signal would otherwise strand a task tree — including the
+        # cgroup fail-closed `exit 66` and the repo-integrity `exit 68` further
+        # down, both of which run before the full on_exit trap is installed.
+        #
+        # The signal traps are pure `exit N` and are hoisted here for the same
+        # reason: until they exist, a SIGTERM kills bash outright and the EXIT
+        # trap never runs at all. They are re-registered (not duplicated) below.
+        trap reclaim_task_tree EXIT
+        trap 'exit 129' HUP
+        trap 'exit 130' INT
+        trap 'exit 143' TERM
         if [ -d "$task_home/.claude" ]; then
             rm -rf -- "$preserve_claude_dir" 2>/dev/null || true
             mv "$task_home/.claude" "$preserve_claude_dir" 2>/dev/null || true
@@ -401,6 +504,18 @@ if [ "$isolated" = true ]; then
     task_memory="$(_conf_value agent_task_memory_max_bytes)"
     task_pids="$(_conf_value agent_task_pids_max)"
     task_cpu="$(_conf_value agent_task_cpu_max)"
+    # Issue #2403 F1c: reap abandoned .claude-preserve dirs. Runs here rather
+    # than beside the task-tree setup for two reasons: _conf_value() only exists
+    # from this point on, and by now this run's own preserve dir has already been
+    # restored into $task_home/.claude, so it cannot be a candidate.
+    # Guarded on task_id because $task_root is only assigned in that block.
+    if [ -n "$task_id" ]; then
+        preserve_max_age_days="$(_conf_value agent_task_preserve_max_age_days)"
+        case "$preserve_max_age_days" in
+            ''|*[!0-9]*) preserve_max_age_days=30 ;;
+        esac
+        reap_stale_preserve_dirs
+    fi
     # Normalize to lowercase before matching so the case list can't miss a
     # variant (review #2067: the hand-enumerated list had a duplicate TRUE and
     # no mixed-case True).
@@ -451,7 +566,10 @@ if [ "$isolated" = true ]; then
         done
     }
 
-    cleanup_isolated() {
+    # Named for everything it does, not just the kill: a function called
+    # "_kill_task_processes" invites a future early-return guard that would
+    # silently stop reclaiming signature_tmp.
+    _cleanup_task_runtime() {
         # Issue #2020: kill exactly THIS attempt's processes. Never pkill by
         # UID — that would reap other concurrent attempts sharing the Agent
         # account. Prefer the task cgroup (kills every cgroup member and their
@@ -464,14 +582,45 @@ if [ "$isolated" = true ]; then
         if [ -n "${agent_child_pid:-}" ] && kill -0 "${agent_child_pid}" 2>/dev/null; then
             kill -KILL "${agent_child_pid}" 2>/dev/null || true
         fi
+        rm -f "$signature_tmp"
+    }
+
+    _revoke_task_acls() {
         if [ -f "$acl_registry" ]; then
             while IFS= read -r protected_path; do
                 revoke_agent_access "$protected_path"
             done < "$acl_registry"
         fi
-        : > "$acl_registry"
-        chmod 600 "$acl_registry" 2>/dev/null || true
-        rm -f "$signature_tmp"
+        # Issue #2403: remove rather than truncate. The registry's only reader
+        # guards on `[ -f ]`, and the writer creates it, so absent and
+        # present-but-empty are equivalent to every consumer — but removing it
+        # also stops a second execution from re-creating a stray empty file.
+        # This deletion must stay HERE, at the point of consumption: doing it in
+        # reclaim_task_tree() would, on the early `exit 66` path (where this
+        # revocation has not run yet), destroy an unconsumed record of still-live
+        # grants and orphan the agent's write ACLs permanently.
+        rm -f "$acl_registry"
+    }
+
+    cleanup_isolated() { _cleanup_task_runtime; _revoke_task_acls; }
+
+    # Issue #2403: the EXIT handler once the agent can be running.
+    #
+    # Order matters and is NOT the obvious one. The orchestrator escalates
+    # SIGTERM to SIGKILL after 5 seconds, so everything here shares one 5-second
+    # budget — and the two halves have opposite recoverability: an ACL revocation
+    # missed here is replayed from $acl_registry by the next invocation, while a
+    # task tree left behind is never reclaimed by anything. So the tree goes
+    # first and the (self-healing) ACL sweep goes last.
+    #
+    # Each step is `|| true` because errexit stays active inside trap handlers:
+    # a non-zero return from the first would otherwise skip the rest, and the
+    # most likely cause of that is a full /run — exactly the condition this
+    # issue is about.
+    on_exit() {
+        _cleanup_task_runtime || true
+        reclaim_task_tree     || true
+        _revoke_task_acls     || true
     }
 
     # Recover safely after a previously interrupted wrapper before granting
@@ -527,11 +676,18 @@ if [ "$isolated" = true ]; then
         "$project_dir" "$git_entry_before" "$git_acl_before" > "$signature_tmp"
     chmod 600 "$signature_tmp"
     mv -f "$signature_tmp" "$signature_registry"
-    trap cleanup_isolated EXIT
+    # Issue #2403: upgrade the EXIT handler now that an agent can be running —
+    # from the bare tree reclaim armed at task-setup time to the full sequence.
+    # Bash traps REPLACE rather than stack, so this expression must keep naming
+    # reclaim_task_tree (via on_exit); reverting it to `cleanup_isolated` alone
+    # would silently disarm reclamation for the whole rest of the run.
+    trap on_exit EXIT
     # Bash services traps promptly while waiting for a background job. With a
     # foreground external command it may defer the trap until that command
     # exits, stranding this wrapper and its ACL lock after the parent sudo
     # process is terminated.
+    # (These are re-registrations: the same handlers were armed at task setup so
+    # that the earlier window is covered too.)
     trap 'exit 129' HUP
     trap 'exit 130' INT
     trap 'exit 143' TERM
@@ -541,7 +697,11 @@ if [ "$isolated" = true ]; then
     # can revoke the exact abandoned grants before starting another agent.
     git_dir="$(git -C "$project_dir" rev-parse --absolute-git-dir 2>/dev/null || true)"
     common_dir="$(git -C "$project_dir" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)"
-    printf '%s\n' "$project_dir" "$git_dir" "$common_dir" > "$acl_registry"
+    # Issue #2403: the registry is now removed (not truncated) after use, so it
+    # is created fresh here every run. Create it under a tight umask in the same
+    # step as the write — a separate chmod would leave a world-readable window,
+    # and a separate truncate would leave a 0-byte registry if killed between.
+    ( umask 077; printf '%s\n' "$project_dir" "$git_dir" "$common_dir" > "$acl_registry" )
     chmod 600 "$acl_registry"
 
     # Allow traversal to the project without exposing sibling home content.
@@ -638,7 +798,9 @@ if [ "$isolated" = true ]; then
     wait "$agent_child_pid"
     child_status=$?
     set -e
-    cleanup_isolated
+    # Issue #2403: on_exit, not cleanup_isolated — the trap is disarmed on the
+    # next line, so this is the success path's only chance to reclaim the tree.
+    on_exit
     trap - EXIT HUP INT TERM
     if ! verify_and_restore_git_entry "$project_dir" "$git_entry_before" "$git_acl_before"; then
         echo "OPENACE_REPO_INTEGRITY_VIOLATION: .git entry changed during agent execution" >&2
@@ -646,8 +808,17 @@ if [ "$isolated" = true ]; then
     fi
     rm -f "$signature_registry"
     # Reap the task cgroup now that the child has exited and cleanup killed
-    # any stragglers. The runtime tree under /run is ephemeral; orphan dirs
-    # from killed attempts are reconciled by the scheduler on restart (#2020).
+    # any stragglers.
+    #
+    # Issue #2403: this used to claim orphan runtime dirs were "reconciled by
+    # the scheduler on restart (#2020)". No such reconciler was ever written —
+    # nothing outside this script has ever removed a task directory — and that
+    # comment is why one directory per run accumulated until /run was full.
+    # on_exit now reclaims the tree on the normal path, on the early exits, and
+    # on caught signals. A SIGKILL still strands one, which happens when this
+    # cleanup overruns the orchestrator's 5-second SIGTERM grace rather than
+    # from any external "crash"; the tmpfs self-heals on reboot, and a proper
+    # sweep for that residue is tracked separately.
     if [ -n "$task_cgroup" ] && [ -d "$task_cgroup" ]; then
         rmdir "$task_cgroup" 2>/dev/null || true
     fi

--- a/scripts/openace-run-as.sh
+++ b/scripts/openace-run-as.sh
@@ -366,6 +366,18 @@ if [ "$isolated" = true ]; then
         if [ -d "$task_home/.claude" ]; then
             rm -rf -- "$preserve_claude_dir" 2>/dev/null || true
             mv "$task_home/.claude" "$preserve_claude_dir" 2>/dev/null || true
+            # The preserve dir is a SIBLING of $task_base, so it inherits none
+            # of the `chmod 700` applied to the tree, and $task_root is created
+            # by `mkdir -p` under root's umask 022 (drwxr-xr-x). Without this
+            # the agent's ~/.claude — shell snapshots, settings.json,
+            # file-history copies of private source, plans, memory, todos, and
+            # the encoded project paths — sits world-readable under /run for
+            # the whole gap between two runs of a session line, and up to
+            # agent_task_preserve_max_age_days for an abandoned task. Before
+            # #2403 that layout existed only for the sub-millisecond startup
+            # window; reclaiming on exit makes it the steady state, so the mode
+            # has to be restored explicitly.
+            chmod 700 "$preserve_claude_dir" 2>/dev/null || true
         fi
         # Log rather than swallow: a partial rm on a full tmpfs is exactly the
         # condition this issue is about, and silence is why it went unnoticed
@@ -447,13 +459,20 @@ if [ "$isolated" = true ]; then
         # The signal traps are pure `exit N` and are hoisted here for the same
         # reason: until they exist, a SIGTERM kills bash outright and the EXIT
         # trap never runs at all. They are re-registered (not duplicated) below.
-        trap reclaim_task_tree EXIT
+        # `|| true` for the same reason every step of on_exit has it: errexit
+        # stays live inside a trap handler, and a failure there both truncates
+        # the handler before `rm -rf "$task_base"` and rewrites the exit status
+        # to 1 — which would make _classify_isolated_exit_code misread the
+        # fail-closed `exit 66` / `exit 68` this trap exists to cover.
+        trap 'reclaim_task_tree || true' EXIT
         trap 'exit 129' HUP
         trap 'exit 130' INT
         trap 'exit 143' TERM
         if [ -d "$task_home/.claude" ]; then
             rm -rf -- "$preserve_claude_dir" 2>/dev/null || true
             mv "$task_home/.claude" "$preserve_claude_dir" 2>/dev/null || true
+            # Same exposure as the reclaim path — see the comment there.
+            chmod 700 "$preserve_claude_dir" 2>/dev/null || true
         fi
         rm -rf -- "$task_base" 2>/dev/null || true
         mkdir -p "$task_home" "$task_tmp" "$task_cache" "$task_config" "$task_data"

--- a/scripts/openace-run-as.sh
+++ b/scripts/openace-run-as.sh
@@ -325,6 +325,9 @@ if [ "$isolated" = true ]; then
     # it from an EXIT trap that also fires on the legacy `uid-*` path — under
     # `set -u` an unset name would kill the wrapper there.
     preserve_claude_dir=""
+    # Same reason as above: only assigned inside the task_id block, but read by
+    # the preserve reaper.
+    task_root=""
     # Age cutoff for reaping abandoned .claude-preserve dirs (#2403 F1c) is read
     # from the launcher conf at the call site below — _conf_value() is not
     # defined yet at this point in the script.
@@ -364,7 +367,10 @@ if [ "$isolated" = true ]; then
             rm -rf -- "$preserve_claude_dir" 2>/dev/null || true
             mv "$task_home/.claude" "$preserve_claude_dir" 2>/dev/null || true
         fi
-        rm -rf -- "$task_base" 2>/dev/null || true
+        # Log rather than swallow: a partial rm on a full tmpfs is exactly the
+        # condition this issue is about, and silence is why it went unnoticed
+        # for so long.
+        rm -rf -- "$task_base" 2>/dev/null || log_audit "result=reclaim_failed task=${task_id:-}"
     }
 
     # Issue #2403 F1c: reclaiming the tree on exit converts a fast directory
@@ -384,8 +390,13 @@ if [ "$isolated" = true ]; then
             # does not move as a session grows, and rename(2) does not touch the
             # renamed inode's mtime either. Keying on the directory mtime would
             # delete the most active long-lived sessions first.
-            [ -z "$(find "$_pdir" -newermt "-${preserve_max_age_days} days" \
-                    -print -quit 2>/dev/null)" ] || continue
+            #
+            # Check find's exit status too: swallowing it would turn any find
+            # failure into empty output, i.e. "stale", i.e. delete. Skip on
+            # error — the safe direction for a destructive test.
+            _fresh="$(find "$_pdir" -newermt "-${preserve_max_age_days} days" \
+                      -print -quit 2>/dev/null)" || continue
+            [ -z "$_fresh" ] || continue
             _pid="${_pdir##*/}"; _pid="${_pid%.claude-preserve}"
             _plock="${_lock_dir}/openace-agent-task-${_pid}.lock"
             # `8<` — read only, NO O_CREAT. flock(2) does not require write
@@ -511,8 +522,11 @@ if [ "$isolated" = true ]; then
     # Guarded on task_id because $task_root is only assigned in that block.
     if [ -n "$task_id" ]; then
         preserve_max_age_days="$(_conf_value agent_task_preserve_max_age_days)"
+        # 0 passes a naive numeric guard but means "everything is stale": it
+        # would delete every session history on every run. Treat it, and any
+        # non-numeric value, as unset.
         case "$preserve_max_age_days" in
-            ''|*[!0-9]*) preserve_max_age_days=30 ;;
+            0|''|*[!0-9]*) preserve_max_age_days=30 ;;
         esac
         reap_stale_preserve_dirs
     fi

--- a/tests/issues/2403/test_reclaim_wiring.py
+++ b/tests/issues/2403/test_reclaim_wiring.py
@@ -44,6 +44,13 @@ def test_reclaim_is_defined_before_any_exit_that_can_strand_a_tree():
     becomes a per-attempt path the moment cgroups are enabled as designed.
     """
     definition = _line_of(r"^\s*reclaim_task_tree\(\) \{")
+    arm = _line_of(r"^\s*trap reclaim_task_tree EXIT")
+    assert definition < arm, (
+        f"reclaim_task_tree() is defined at line {definition + 1} but the trap "
+        f"naming it is armed at line {arm + 1}; everything in between — "
+        f"including the mkdir/chmod that fail under `set -e` on a full tmpfs, "
+        f"the exact incident condition — would fire an undefined function"
+    )
     tree_built = _line_of(r'^\s*mkdir -p "\$task_home"')
     cgroup_exit = _line_of(r"^\s*exit 66", start=tree_built)
     assert definition < cgroup_exit, (
@@ -72,9 +79,9 @@ def test_trap_is_armed_before_the_preserve_move_window():
 def test_signal_traps_are_armed_with_the_reclaim_trap():
     """Until HUP/INT/TERM are trapped, a signal kills bash and no EXIT trap runs."""
     arm = _line_of(r"^\s*trap reclaim_task_tree EXIT")
-    window = "\n".join(LINES[arm : arm + 6])
+    window = "\n".join(LINES[arm : arm + 8])
     for signal_name in ("HUP", "INT", "TERM"):
-        assert signal_name in window, (
+        assert re.search(rf"^\s*trap 'exit \d+' {signal_name}$", window, re.MULTILINE), (
             f"{signal_name} is not trapped alongside the reclaim trap; a signal "
             f"in that window would bypass reclamation entirely"
         )
@@ -129,12 +136,37 @@ def test_preflight_cleanup_does_not_reclaim():
 
 
 def test_success_path_reclaims_before_disarming_the_trap():
+    """Anchor on a bare CALL, never a substring of the surrounding window.
+
+    A window search is satisfied by the explanatory comment sitting right above
+    the call, so deleting the call outright — restoring the leak on the most
+    common path in production, and stopping ACL revocation too, since the very
+    next line disarms the handler — would still pass.
+    """
     disarm = _line_of(r"^\s*trap - EXIT HUP INT TERM")
-    window = "\n".join(LINES[max(0, disarm - 4) : disarm])
-    assert "on_exit" in window, (
-        "the success path must reclaim before `trap -` disarms the handler, "
-        "otherwise a clean run is the one case that still leaks"
+    call = _line_of(r"^\s*on_exit$")
+    assert call < disarm, (
+        f"on_exit call at line {call + 1} must precede the disarm at "
+        f"{disarm + 1}; otherwise a clean run is the one case that still leaks"
     )
+
+
+def test_preflight_call_site_stays_the_narrow_cleanup():
+    """The pre-flight site must call cleanup_isolated, never on_exit.
+
+    It runs after the tree is built and .claude has been restored into it, so
+    calling on_exit there would `rm -rf` the tree — and the session history —
+    before the agent starts, breaking #2035 --resume on every run. Asserting
+    only that cleanup_isolated's *body* lacks the reclaim leaves this unpinned.
+    """
+    arm_full = _line_of(r"^\s*trap on_exit EXIT")
+    preflight = _line_of(r"^\s*cleanup_isolated$")
+    assert preflight < arm_full, "the bare cleanup_isolated pre-flight call is gone"
+    for index in range(0, arm_full):
+        assert not re.match(r"^\s*on_exit$", LINES[index]), (
+            f"on_exit is called at line {index + 1}, before the full handler is "
+            f"armed — at that point it would delete the just-restored .claude"
+        )
 
 
 def test_preserve_reaper_runs_after_the_restore():
@@ -162,6 +194,42 @@ def test_lock_directory_is_a_constant_not_an_environment_override():
     assert not re.search(
         r"_lock_dir=.*\$\{?OPENACE", SRC
     ), "the lock directory must not be environment-controlled"
+
+
+def test_acl_registry_is_removed_at_its_point_of_consumption():
+    """Truncating instead of removing leaves a stray empty registry behind.
+
+    It must be removed inside the revocation helper, never in
+    reclaim_task_tree: on the early `exit 66` path the revocation has not run
+    yet, so deleting the record there would orphan the agent's write ACLs.
+    """
+    body = re.search(r"^\s*_revoke_task_acls\(\) \{\n(.*?)^\s*\}$", SRC, re.MULTILINE | re.DOTALL)
+    assert body, "_revoke_task_acls() not found"
+    assert 'rm -f "$acl_registry"' in body.group(1)
+    assert ': > "$acl_registry"' not in SRC, "registry is truncated rather than removed"
+    reclaim = re.search(
+        r"^\s*reclaim_task_tree\(\) \{\n(.*?)^\s*\}$", SRC, re.MULTILINE | re.DOTALL
+    )
+    assert reclaim and "acl_registry" not in reclaim.group(1), (
+        "reclaim_task_tree must not touch the ACL registry — on the early exit "
+        "path that record has not been consumed yet"
+    )
+
+
+def test_acl_registry_is_created_with_a_tight_umask():
+    """A separate chmod would leave a world-readable window on every run."""
+    assert re.search(r"umask 077;.*acl_registry", SRC), (
+        "the registry must be created under umask 077 in the same step as the "
+        "write; it is recreated fresh every run now that it is removed"
+    )
+
+
+def test_zero_age_threshold_is_rejected():
+    """`0` passes a naive numeric guard and means 'delete every history'."""
+    assert re.search(r"^\s*0\|''\|\*\[!0-9\]\*\)", SRC, re.MULTILINE), (
+        "agent_task_preserve_max_age_days=0 would satisfy a digits-only check "
+        "and reap every session history on every run"
+    )
 
 
 def test_the_disproven_reconciler_comment_is_gone():

--- a/tests/issues/2403/test_reclaim_wiring.py
+++ b/tests/issues/2403/test_reclaim_wiring.py
@@ -196,6 +196,21 @@ def test_lock_directory_is_a_constant_not_an_environment_override():
     ), "the lock directory must not be environment-controlled"
 
 
+def test_history_is_rescued_by_rename_not_copy():
+    """`mv` is load-bearing and the end state cannot distinguish it from `cp`.
+
+    Both leave a copy at the preserve path, so a behavioural test sees no
+    difference. The difference only shows on a full tmpfs — the condition this
+    issue is about: rename needs no space, while `cp -R` needs room for a second
+    copy, fails, is swallowed by `|| true`, and the following `rm -rf` then
+    destroys the only remaining copy of the session history.
+    """
+    body = re.search(r"^\s*reclaim_task_tree\(\) \{\n(.*?)^\s*\}$", SRC, re.MULTILINE | re.DOTALL)
+    assert body, "reclaim_task_tree() not found"
+    assert re.search(r'mv "\$task_home/\.claude" "\$preserve_claude_dir"', body.group(1))
+    assert "cp " not in body.group(1), "the rescue must be an atomic rename, not a copy"
+
+
 def test_acl_registry_is_removed_at_its_point_of_consumption():
     """Truncating instead of removing leaves a stray empty registry behind.
 

--- a/tests/issues/2403/test_reclaim_wiring.py
+++ b/tests/issues/2403/test_reclaim_wiring.py
@@ -28,6 +28,13 @@ SRC = SCRIPT.read_text(encoding="utf-8")
 LINES = SRC.splitlines()
 
 
+# The early trap must call the reclaim through a `|| true` guard: errexit is
+# live inside a trap handler, so an unguarded failure both truncates the handler
+# before it removes the tree and rewrites the exit status to 1, which would make
+# _classify_isolated_exit_code misread the fail-closed `exit 66` / `exit 68`.
+_RECLAIM_TRAP_RE = r"^\s*trap 'reclaim_task_tree \|\| true' EXIT"
+
+
 def _line_of(pattern: str, *, start: int = 0) -> int:
     for index in range(start, len(LINES)):
         if re.search(pattern, LINES[index]):
@@ -44,7 +51,7 @@ def test_reclaim_is_defined_before_any_exit_that_can_strand_a_tree():
     becomes a per-attempt path the moment cgroups are enabled as designed.
     """
     definition = _line_of(r"^\s*reclaim_task_tree\(\) \{")
-    arm = _line_of(r"^\s*trap reclaim_task_tree EXIT")
+    arm = _line_of(_RECLAIM_TRAP_RE)
     assert definition < arm, (
         f"reclaim_task_tree() is defined at line {definition + 1} but the trap "
         f"naming it is armed at line {arm + 1}; everything in between — "
@@ -68,7 +75,7 @@ def test_trap_is_armed_before_the_preserve_move_window():
     trap already installed.
     """
     derive = _line_of(r'^\s*preserve_claude_dir="\$\{task_base\}\.claude-preserve"')
-    arm = _line_of(r"^\s*trap reclaim_task_tree EXIT", start=derive)
+    arm = _line_of(_RECLAIM_TRAP_RE, start=derive)
     startup_wipe = _line_of(r'^\s*rm -rf -- "\$task_base"', start=arm)
     assert derive < arm < startup_wipe, (
         f"derive={derive + 1} arm={arm + 1} wipe={startup_wipe + 1}: the trap must "
@@ -78,7 +85,7 @@ def test_trap_is_armed_before_the_preserve_move_window():
 
 def test_signal_traps_are_armed_with_the_reclaim_trap():
     """Until HUP/INT/TERM are trapped, a signal kills bash and no EXIT trap runs."""
-    arm = _line_of(r"^\s*trap reclaim_task_tree EXIT")
+    arm = _line_of(_RECLAIM_TRAP_RE)
     window = "\n".join(LINES[arm : arm + 8])
     for signal_name in ("HUP", "INT", "TERM"):
         assert re.search(rf"^\s*trap 'exit \d+' {signal_name}$", window, re.MULTILINE), (
@@ -251,3 +258,62 @@ def test_the_disproven_reconciler_comment_is_gone():
     """That comment is why the leak went unnoticed: it described a mechanism
     nobody ever implemented."""
     assert "reconciled by the scheduler on restart" not in SRC
+
+
+def test_early_reclaim_trap_is_failure_guarded():
+    """errexit stays live inside a trap handler.
+
+    Without the guard, a failure inside reclaim_task_tree (realistically the
+    `log_audit` command substitution) aborts the handler before `rm -rf
+    "$task_base"` — restoring the leak — and replaces the process's exit status
+    with 1, so the cgroup fail-closed `exit 66` and repo-integrity `exit 68`
+    would be misclassified by _classify_isolated_exit_code.
+    """
+    assert re.search(
+        _RECLAIM_TRAP_RE, SRC, re.MULTILINE
+    ), "the early EXIT trap must be `trap 'reclaim_task_tree || true' EXIT`"
+
+
+def test_preserve_dir_mode_is_restored_after_every_move():
+    """Both preserve-moves must re-apply 0700.
+
+    The preserve dir is a SIBLING of $task_base, so the `chmod 700` on the tree
+    does not cover it, and $task_root is created by `mkdir -p` under root's
+    umask 022. Reclaiming on exit turns what used to be a sub-millisecond
+    startup window into the steady state between runs, so the agent's ~/.claude
+    would otherwise sit world-readable under /run for up to
+    agent_task_preserve_max_age_days.
+    """
+    moves = re.findall(r'mv "\$task_home/\.claude" "\$preserve_claude_dir"', SRC)
+    chmods = re.findall(r'chmod 700 "\$preserve_claude_dir"', SRC)
+    assert len(moves) == 2, f"expected the two known preserve-moves, found {len(moves)}"
+    assert len(chmods) == len(moves), (
+        f"{len(moves)} preserve-move(s) but {len(chmods)} chmod(s); every move "
+        f"must re-apply 0700 or the history is world-readable under /run"
+    )
+
+
+def test_signal_traps_are_re_registered_outside_the_task_id_block():
+    """The later trap block is the ONLY signal coverage on the legacy path.
+
+    The early block (armed beside the reclaim trap) sits inside
+    `[ -n "$task_id" ]`. A wrapper invoked the legacy `uid-*` way never enters
+    it, so deleting the re-registration leaves that path with no HUP/INT/TERM
+    traps at all: a SIGTERM kills bash outright and the EXIT handler — ACL
+    revocation and signature-registry cleanup — never runs. Asserting only on
+    the early block cannot see that.
+    """
+    early = _line_of(_RECLAIM_TRAP_RE)
+    for signal_name, code in (("HUP", 129), ("INT", 130), ("TERM", 143)):
+        occurrences = [
+            i
+            for i, line in enumerate(LINES)
+            if re.match(rf"^\s*trap 'exit {code}' {signal_name}$", line)
+        ]
+        assert len(occurrences) >= 2, (
+            f"{signal_name} is trapped {len(occurrences)} time(s); the legacy "
+            f"uid-* path needs the re-registration outside the task_id block"
+        )
+        assert any(
+            i > early for i in occurrences
+        ), f"the only {signal_name} trap is inside the task_id block"

--- a/tests/issues/2403/test_reclaim_wiring.py
+++ b/tests/issues/2403/test_reclaim_wiring.py
@@ -1,0 +1,170 @@
+"""Issue #2403: pin how the reclaim functions are wired into the wrapper.
+
+``test_task_tree_reclaim.py`` extracts each function and runs it for real, which
+proves the logic works but says nothing about whether the script ever calls it,
+or calls it at a point where it can help. Three real ways to break the fix are
+all invisible to that file:
+
+1. Defining ``reclaim_task_tree`` after the first exit that can strand a tree.
+   Bash resolves a trap's function name when the trap FIRES, so a late
+   definition makes the trap a silent no-op.
+2. Reverting the upgraded ``trap on_exit EXIT`` back to ``cleanup_isolated``.
+   Bash traps replace rather than stack, so that one edit disarms reclamation
+   for the whole run.
+3. Folding the reclaim into ``cleanup_isolated``, whose pre-flight call happens
+   *after* the tree is built and ``.claude`` restored into it.
+
+These are source assertions by necessity — they are wiring locks, and they do
+not count as behavioural coverage. The behavioural gate is the other file.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[3] / "scripts" / "openace-run-as.sh"
+SRC = SCRIPT.read_text(encoding="utf-8")
+LINES = SRC.splitlines()
+
+
+def _line_of(pattern: str, *, start: int = 0) -> int:
+    for index in range(start, len(LINES)):
+        if re.search(pattern, LINES[index]):
+            return index
+    raise AssertionError(f"pattern not found in {SCRIPT.name}: {pattern!r}")
+
+
+def test_reclaim_is_defined_before_any_exit_that_can_strand_a_tree():
+    """The cgroup fail-closed `exit 66` fires while a task tree exists.
+
+    It sits well before the other cleanup helpers, so defining reclaim beside
+    them would leave that path calling an undefined function. That path is
+    dormant in production today (no cgroup key in agent-launcher.conf) but
+    becomes a per-attempt path the moment cgroups are enabled as designed.
+    """
+    definition = _line_of(r"^\s*reclaim_task_tree\(\) \{")
+    tree_built = _line_of(r'^\s*mkdir -p "\$task_home"')
+    cgroup_exit = _line_of(r"^\s*exit 66", start=tree_built)
+    assert definition < cgroup_exit, (
+        f"reclaim_task_tree() defined at line {definition + 1} but `exit 66` at "
+        f"line {cgroup_exit + 1} can fire earlier with a tree on disk; bash "
+        f"resolves the name when the trap fires, so that trap would be a no-op"
+    )
+
+
+def test_trap_is_armed_before_the_preserve_move_window():
+    """Arming after the tree is built leaves the preserve-move window bare.
+
+    The window runs from the preserve path being derived through the wipe and
+    re-creation of the tree; a signal or early exit anywhere in it must find the
+    trap already installed.
+    """
+    derive = _line_of(r'^\s*preserve_claude_dir="\$\{task_base\}\.claude-preserve"')
+    arm = _line_of(r"^\s*trap reclaim_task_tree EXIT", start=derive)
+    startup_wipe = _line_of(r'^\s*rm -rf -- "\$task_base"', start=arm)
+    assert derive < arm < startup_wipe, (
+        f"derive={derive + 1} arm={arm + 1} wipe={startup_wipe + 1}: the trap must "
+        f"be armed between deriving the preserve path and wiping the tree"
+    )
+
+
+def test_signal_traps_are_armed_with_the_reclaim_trap():
+    """Until HUP/INT/TERM are trapped, a signal kills bash and no EXIT trap runs."""
+    arm = _line_of(r"^\s*trap reclaim_task_tree EXIT")
+    window = "\n".join(LINES[arm : arm + 6])
+    for signal_name in ("HUP", "INT", "TERM"):
+        assert signal_name in window, (
+            f"{signal_name} is not trapped alongside the reclaim trap; a signal "
+            f"in that window would bypass reclamation entirely"
+        )
+
+
+def test_exit_trap_is_upgraded_to_on_exit():
+    assert re.search(r"^\s*trap on_exit EXIT", SRC, re.MULTILINE), (
+        "the EXIT trap must name on_exit; bash traps replace rather than stack, "
+        "so reverting this to cleanup_isolated silently disarms reclamation"
+    )
+
+
+def test_on_exit_reclaims_between_runtime_cleanup_and_acl_revocation():
+    """Order is load-bearing: see the 5s SIGTERM-to-SIGKILL budget."""
+    body = re.search(r"^\s*on_exit\(\) \{\n(.*?)^\s*\}$", SRC, re.MULTILINE | re.DOTALL)
+    assert body, "on_exit() not found"
+    text = body.group(1)
+    runtime = text.index("_cleanup_task_runtime")
+    reclaim = text.index("reclaim_task_tree")
+    acls = text.index("_revoke_task_acls")
+    assert runtime < reclaim < acls, (
+        "reclaim must run after the kill and before the ACL sweep: a missed ACL "
+        "revocation is replayed from the registry next run, a stranded tree is "
+        "reclaimed by nothing"
+    )
+
+
+def test_on_exit_steps_are_individually_guarded():
+    """errexit stays live inside trap handlers."""
+    body = re.search(r"^\s*on_exit\(\) \{\n(.*?)^\s*\}$", SRC, re.MULTILINE | re.DOTALL)
+    assert body
+    for step in ("_cleanup_task_runtime", "reclaim_task_tree", "_revoke_task_acls"):
+        assert re.search(rf"{step}\s*\|\| true", body.group(1)), (
+            f"{step} is not `|| true`; a non-zero return would skip the "
+            f"remaining steps, and the likeliest cause is a full /run"
+        )
+
+
+def test_preflight_cleanup_does_not_reclaim():
+    """The pre-flight cleanup runs after the tree is built and .claude restored.
+
+    Reclaiming there would delete the freshly restored session history before
+    the agent starts — the reason this is a separate function at all.
+    """
+    body = re.search(
+        r"^\s*cleanup_isolated\(\) \{(.*?)\}$",
+        SRC,
+        re.MULTILINE | re.DOTALL,
+    )
+    assert body, "cleanup_isolated() not found"
+    assert "reclaim_task_tree" not in body.group(1)
+
+
+def test_success_path_reclaims_before_disarming_the_trap():
+    disarm = _line_of(r"^\s*trap - EXIT HUP INT TERM")
+    window = "\n".join(LINES[max(0, disarm - 4) : disarm])
+    assert "on_exit" in window, (
+        "the success path must reclaim before `trap -` disarms the handler, "
+        "otherwise a clean run is the one case that still leaks"
+    )
+
+
+def test_preserve_reaper_runs_after_the_restore():
+    """Sweeping earlier would make this run's own preserve dir a candidate."""
+    restore = _line_of(r'^\s*mv "\$preserve_claude_dir" "\$task_home/\.claude"')
+    call = _line_of(r"^\s*reap_stale_preserve_dirs$")
+    assert restore < call
+
+
+def test_preserve_dir_is_initialised_unconditionally():
+    """It is only assigned inside the task_id block, but read from a trap."""
+    init = _line_of(r'^\s*preserve_claude_dir=""')
+    # Anchor on the task-tree setup block specifically — `[ -n "$task_id" ]`
+    # guards several unrelated blocks earlier in the script.
+    block = _line_of(r'^\s*task_root="\$\{OPENACE_AGENT_TASK_ROOT')
+    assert init < block, (
+        "preserve_claude_dir must be initialised before the task_id block; "
+        "under `set -u` an unset name kills the wrapper from its own trap"
+    )
+
+
+def test_lock_directory_is_a_constant_not_an_environment_override():
+    """Redirecting it would break mutual exclusion between concurrent attempts."""
+    assert re.search(r'^\s*_lock_dir="/run/lock"', SRC, re.MULTILINE)
+    assert not re.search(
+        r"_lock_dir=.*\$\{?OPENACE", SRC
+    ), "the lock directory must not be environment-controlled"
+
+
+def test_the_disproven_reconciler_comment_is_gone():
+    """That comment is why the leak went unnoticed: it described a mechanism
+    nobody ever implemented."""
+    assert "reconciled by the scheduler on restart" not in SRC

--- a/tests/issues/2403/test_task_tree_reclaim.py
+++ b/tests/issues/2403/test_task_tree_reclaim.py
@@ -205,6 +205,39 @@ echo "rc=$?"
             paths["home"] / ".claude" / "projects" / "encoded" / "session.jsonl"
         ).is_file(), "history was destroyed with no preserve path to rescue it into"
 
+    def test_failed_reclaim_is_recorded(self, tmp_path):
+        """Silence is why this leak went unnoticed for so long.
+
+        A partial `rm -rf` on a full tmpfs is exactly the condition this issue
+        is about; if it is swallowed, the next investigation starts from zero
+        again. Provoked here by making the parent unwritable so the unlink
+        cannot succeed.
+        """
+        victim = tmp_path / "victim"
+        victim.mkdir()
+        paths = _make_tree(victim, "t6")
+        audit = tmp_path / "audit.log"  # outside the frozen directory
+        victim.chmod(0o500)  # read+execute only: children cannot be unlinked
+        try:
+            snippet = f"""
+log_audit() {{ printf '%s\\n' "$1" >> {audit!s}; }}
+{_extract_function("reclaim_task_tree")}
+task_base={paths["base"]!s}
+task_home={paths["base"]!s}/home
+preserve_claude_dir={victim!s}/t6.claude-preserve
+task_id=t6
+reclaim_task_tree
+echo "rc=$?"
+"""
+            result = _run_snippet(snippet)
+        finally:
+            victim.chmod(0o700)
+        assert result.returncode == 0, result.stderr
+        if paths["base"].exists():
+            assert audit.is_file() and "reclaim_failed" in audit.read_text(
+                encoding="utf-8"
+            ), "reclamation failed and nothing was recorded"
+
     def test_no_claude_dir_does_not_create_empty_preserve(self, tmp_path):
         paths = _make_tree(tmp_path, "t4", with_claude=False)
         result = _run_snippet(_reclaim_harness(tmp_path, "t4"))
@@ -213,7 +246,7 @@ echo "rc=$?"
         assert not paths["preserve"].exists()
 
 
-def _reap_harness(task_root: Path, lock_dir: Path, days: int = 30) -> str:
+def _reap_harness(task_root: Path, lock_dir: Path, days: object = 30) -> str:
     return f"""
 {_extract_function("reap_stale_preserve_dirs")}
 task_root={task_root!s}
@@ -409,6 +442,30 @@ class TestReapStalePreserveDirs:
         assert result.returncode == 0, result.stderr
         assert busy.exists(), "a locked (live) preserve dir was reaped"
         assert (busy / "s.jsonl").is_file()
+
+    def test_find_failure_skips_rather_than_deletes(self, tmp_path):
+        """A failing age test must not read as "stale".
+
+        The age gate is a destructive test, so its failure direction matters:
+        swallowing find's exit status turns any error into empty output, which
+        the emptiness check then reads as "nothing fresh here" and deletes. The
+        threshold is injected directly to provoke the failure — the script's own
+        guard against bad config values is pinned separately.
+        """
+        task_root = tmp_path / "tasks"
+        lock_dir = tmp_path / "lock"
+        task_root.mkdir()
+        lock_dir.mkdir()
+        precious = task_root / "keepme.claude-preserve"
+        precious.mkdir()
+        (precious / "s.jsonl").write_text("{}", encoding="utf-8")
+
+        result = _run_snippet(_reap_harness(task_root, lock_dir, days="not-a-number"))
+        assert result.returncode == 0, result.stderr
+        assert precious.exists(), (
+            "the age test errored and the directory was deleted anyway — find's "
+            "exit status is being ignored, so any failure means 'stale'"
+        )
 
     def test_no_candidates_is_a_clean_noop(self, tmp_path):
         """The glob stays literal when nothing matches; the loop must not run."""

--- a/tests/issues/2403/test_task_tree_reclaim.py
+++ b/tests/issues/2403/test_task_tree_reclaim.py
@@ -1,0 +1,285 @@
+"""Issue #2403: the wrapper must reclaim its per-task runtime tree on exit.
+
+``scripts/openace-run-as.sh`` only ever wiped ``$task_base`` on START, so every
+agent run left one directory under ``/run/openace-agent-tasks`` forever. In
+production 46 of them filled the 3.1G ``/run`` tmpfs and every autonomous
+workflow started failing with a misleading "Failed to access project dir"
+(really ENOSPC writing the signature registry).
+
+The reclaim logic lives in two self-contained shell functions so it can be
+exercised without root, cgroups, ACLs or a real agent. These tests extract each
+function from the script and run it for real against a temporary tree — they are
+behavioural, not source greps. The wiring that installs them (trap placement,
+call sites) cannot be observed that way, so it is pinned separately in
+``test_reclaim_wiring.py``.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+import textwrap
+import time
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[3] / "scripts" / "openace-run-as.sh"
+
+
+def _extract_function(name: str) -> str:
+    """Return the shell source of a top-level-in-block function definition."""
+    src = SCRIPT.read_text(encoding="utf-8")
+    match = re.search(
+        rf"^(?P<indent>[ \t]*){re.escape(name)}\(\) \{{\n(?P<body>.*?)^(?P=indent)\}}$",
+        src,
+        re.MULTILINE | re.DOTALL,
+    )
+    assert match, f"{name}() not found in {SCRIPT}; did it get renamed or inlined?"
+    return textwrap.dedent(match.group(0))
+
+
+def _run_snippet(snippet: str, env: dict[str, str] | None = None) -> subprocess.CompletedProcess:
+    full_env = {"PATH": os.environ.get("PATH", "/usr/bin:/bin")}
+    full_env.update(env or {})
+    return subprocess.run(
+        ["bash", "-euo", "pipefail", "-c", snippet],
+        capture_output=True,
+        text=True,
+        env=full_env,
+        timeout=60,
+    )
+
+
+def _gnu_find() -> bool:
+    """The reaper needs GNU findutils (-quit, and -newermt with a relative time)."""
+    probe = subprocess.run(
+        ["find", ".", "-maxdepth", "0", "-newermt", "-1 days", "-print", "-quit"],
+        capture_output=True,
+        text=True,
+    )
+    return probe.returncode == 0
+
+
+requires_gnu_find = pytest.mark.skipif(
+    not _gnu_find(), reason="requires GNU findutils (-quit / relative -newermt); BSD find on macOS"
+)
+requires_flock = pytest.mark.skipif(
+    shutil.which("flock") is None, reason="requires flock(1); absent on macOS"
+)
+
+
+def _make_tree(task_root: Path, task_id: str, *, with_claude: bool = True) -> dict[str, Path]:
+    base = task_root / task_id
+    home = base / "home"
+    (base / "tmp").mkdir(parents=True)
+    home.mkdir(parents=True)
+    (base / "tmp" / "big").write_text("x" * 1024, encoding="utf-8")
+    if with_claude:
+        projects = home / ".claude" / "projects" / "encoded"
+        projects.mkdir(parents=True)
+        (projects / "session.jsonl").write_text('{"m":"hi"}\n', encoding="utf-8")
+    return {"base": base, "home": home, "preserve": task_root / f"{task_id}.claude-preserve"}
+
+
+def _reclaim_harness(task_root: Path, task_id: str) -> str:
+    base = task_root / task_id
+    return f"""
+{_extract_function("reclaim_task_tree")}
+task_base={base!s}
+task_home={base!s}/home
+preserve_claude_dir={task_root!s}/{task_id}.claude-preserve
+reclaim_task_tree
+"""
+
+
+class TestReclaimTaskTree:
+    def test_tree_is_gone_after_reclaim(self, tmp_path):
+        """The whole point: the per-task tree must not survive the run."""
+        paths = _make_tree(tmp_path, "t1")
+        result = _run_snippet(_reclaim_harness(tmp_path, "t1"))
+        assert result.returncode == 0, result.stderr
+        assert not paths["base"].exists()
+
+    def test_claude_history_is_preserved(self, tmp_path):
+        """#2035 must not regress: --resume needs the session history to survive."""
+        paths = _make_tree(tmp_path, "t2")
+        result = _run_snippet(_reclaim_harness(tmp_path, "t2"))
+        assert result.returncode == 0, result.stderr
+        survivor = paths["preserve"] / "projects" / "encoded" / "session.jsonl"
+        assert survivor.is_file()
+        assert survivor.read_text(encoding="utf-8") == '{"m":"hi"}\n'
+
+    def test_second_execution_does_not_destroy_saved_history(self, tmp_path):
+        """A signal between the success-path call and `trap -` runs it twice.
+
+        If the `rm -rf $preserve_claude_dir` ever escapes the `-d` guard, the
+        second pass deletes exactly the history the first pass just rescued.
+        """
+        paths = _make_tree(tmp_path, "t3")
+        snippet = _reclaim_harness(tmp_path, "t3") + "\nreclaim_task_tree\n"
+        result = _run_snippet(snippet)
+        assert result.returncode == 0, result.stderr
+        assert (paths["preserve"] / "projects" / "encoded" / "session.jsonl").is_file()
+
+    def test_empty_task_base_touches_nothing(self, tmp_path):
+        """On the legacy uid-* path task_base is "" — it must be inert, not `rm -rf ""`."""
+        sentinel = tmp_path / "sentinel"
+        sentinel.mkdir()
+        (sentinel / "keep").write_text("keep", encoding="utf-8")
+        snippet = f"""
+{_extract_function("reclaim_task_tree")}
+task_base=""
+task_home=""
+preserve_claude_dir=""
+reclaim_task_tree
+echo "rc=$?"
+"""
+        result = _run_snippet(snippet)
+        assert result.returncode == 0, result.stderr
+        assert "rc=0" in result.stdout
+        assert (sentinel / "keep").is_file()
+
+    def test_unset_preserve_dir_does_not_trip_set_u(self, tmp_path):
+        """`set -u` + an unset preserve path would kill the wrapper from its trap."""
+        snippet = f"""
+{_extract_function("reclaim_task_tree")}
+task_base=""
+task_home=""
+reclaim_task_tree || echo "FAILED_RC=$?"
+echo done
+"""
+        result = _run_snippet(snippet)
+        assert "unbound variable" not in result.stderr
+        assert "done" in result.stdout
+
+    def test_no_claude_dir_does_not_create_empty_preserve(self, tmp_path):
+        paths = _make_tree(tmp_path, "t4", with_claude=False)
+        result = _run_snippet(_reclaim_harness(tmp_path, "t4"))
+        assert result.returncode == 0, result.stderr
+        assert not paths["base"].exists()
+        assert not paths["preserve"].exists()
+
+
+def _reap_harness(task_root: Path, lock_dir: Path, days: int = 30) -> str:
+    return f"""
+{_extract_function("reap_stale_preserve_dirs")}
+task_root={task_root!s}
+preserve_max_age_days={days}
+_lock_dir={lock_dir!s}
+reap_stale_preserve_dirs
+"""
+
+
+def _age(path: Path, days: int) -> None:
+    """Backdate a path's mtime.
+
+    Uses os.utime rather than `touch -d`: the relative-date form is GNU-only and
+    this machine may well have GNU find but BSD touch.
+
+    Callers must age children before parents — writing into a directory bumps
+    that directory's own mtime.
+    """
+    stamp = time.time() - days * 86400
+    os.utime(path, (stamp, stamp))
+
+
+@requires_gnu_find
+class TestReapStalePreserveDirs:
+    def test_stale_preserve_is_reaped(self, tmp_path):
+        task_root = tmp_path / "tasks"
+        lock_dir = tmp_path / "lock"
+        task_root.mkdir()
+        lock_dir.mkdir()
+        stale = task_root / "old.claude-preserve"
+        (stale / "projects").mkdir(parents=True)
+        (stale / "projects" / "s.jsonl").write_text("{}", encoding="utf-8")
+        for target in (stale / "projects" / "s.jsonl", stale / "projects", stale):
+            _age(target, 90)
+
+        result = _run_snippet(_reap_harness(task_root, lock_dir))
+        assert result.returncode == 0, result.stderr
+        assert not stale.exists()
+
+    def test_fresh_preserve_survives(self, tmp_path):
+        task_root = tmp_path / "tasks"
+        lock_dir = tmp_path / "lock"
+        task_root.mkdir()
+        lock_dir.mkdir()
+        fresh = task_root / "new.claude-preserve"
+        fresh.mkdir()
+        (fresh / "s.jsonl").write_text("{}", encoding="utf-8")
+
+        result = _run_snippet(_reap_harness(task_root, lock_dir))
+        assert result.returncode == 0, result.stderr
+        assert fresh.exists()
+
+    def test_task_directories_are_never_touched(self, tmp_path):
+        """Scope is *.claude-preserve only; reaping task dirs needs a liveness
+        test this script cannot make (the Python launch path creates them
+        without ever taking a lock)."""
+        task_root = tmp_path / "tasks"
+        lock_dir = tmp_path / "lock"
+        task_root.mkdir()
+        lock_dir.mkdir()
+        task_dir = task_root / "some-task-id"
+        (task_dir / "home").mkdir(parents=True)
+        _age(task_dir, 400)
+
+        result = _run_snippet(_reap_harness(task_root, lock_dir))
+        assert result.returncode == 0, result.stderr
+        assert (task_dir / "home").is_dir()
+
+    def test_old_directory_with_fresh_history_survives(self, tmp_path):
+        """The regression that a dir-mtime implementation would fail.
+
+        Claude CLI writes to .claude/projects/<encoded>/*.jsonl, so the top
+        directory's mtime does not move as a session grows, and rename(2) does
+        not touch the renamed inode's mtime either. Keying the age check on the
+        directory would delete the most active long-lived sessions first.
+        """
+        task_root = tmp_path / "tasks"
+        lock_dir = tmp_path / "lock"
+        task_root.mkdir()
+        lock_dir.mkdir()
+        active = task_root / "busy.claude-preserve"
+        projects = active / "projects" / "encoded"
+        projects.mkdir(parents=True)
+        (projects / "live.jsonl").write_text('{"fresh":true}', encoding="utf-8")
+        # Everything except the leaf file looks ancient.
+        _age(projects, 90)
+        _age(active / "projects", 90)
+        _age(active, 90)
+
+        result = _run_snippet(_reap_harness(task_root, lock_dir))
+        assert result.returncode == 0, result.stderr
+        assert (projects / "live.jsonl").is_file(), (
+            "a stale-looking directory holding a fresh session was reaped — the age "
+            "test is reading the directory inode instead of the tree"
+        )
+
+    def test_empty_preserve_directory_is_reaped(self, tmp_path):
+        task_root = tmp_path / "tasks"
+        lock_dir = tmp_path / "lock"
+        task_root.mkdir()
+        lock_dir.mkdir()
+        empty = task_root / "empty.claude-preserve"
+        empty.mkdir()
+        _age(empty, 90)
+
+        result = _run_snippet(_reap_harness(task_root, lock_dir))
+        assert result.returncode == 0, result.stderr
+        assert not empty.exists()
+
+    def test_no_candidates_is_a_clean_noop(self, tmp_path):
+        """The glob stays literal when nothing matches; the loop must not run."""
+        task_root = tmp_path / "tasks"
+        lock_dir = tmp_path / "lock"
+        task_root.mkdir()
+        lock_dir.mkdir()
+
+        result = _run_snippet(_reap_harness(task_root, lock_dir))
+        assert result.returncode == 0, result.stderr
+        assert not (task_root / "*.claude-preserve").exists()

--- a/tests/issues/2403/test_task_tree_reclaim.py
+++ b/tests/issues/2403/test_task_tree_reclaim.py
@@ -142,18 +142,29 @@ echo "rc=$?"
         assert "rc=0" in result.stdout
         assert (sentinel / "keep").is_file()
 
-    def test_unset_preserve_dir_does_not_trip_set_u(self, tmp_path):
-        """`set -u` + an unset preserve path would kill the wrapper from its trap."""
+    def test_blank_preserve_path_aborts_instead_of_dropping_history(self, tmp_path):
+        """A real tree plus a blank preserve path must be a no-op, not data loss.
+
+        Without the second guard the rescue `mv` silently fails (empty
+        destination) and the following `rm -rf $task_base` then takes the
+        session history with it — the tree is reclaimed but #2035 --resume is
+        permanently broken for that task.
+        """
+        paths = _make_tree(tmp_path, "t5")
         snippet = f"""
 {_extract_function("reclaim_task_tree")}
-task_base=""
-task_home=""
-reclaim_task_tree || echo "FAILED_RC=$?"
-echo done
+task_base={paths["base"]!s}
+task_home={paths["base"]!s}/home
+preserve_claude_dir=""
+reclaim_task_tree
+echo "rc=$?"
 """
         result = _run_snippet(snippet)
-        assert "unbound variable" not in result.stderr
-        assert "done" in result.stdout
+        assert result.returncode == 0, result.stderr
+        assert "rc=0" in result.stdout
+        assert (
+            paths["home"] / ".claude" / "projects" / "encoded" / "session.jsonl"
+        ).is_file(), "history was destroyed with no preserve path to rescue it into"
 
     def test_no_claude_dir_does_not_create_empty_preserve(self, tmp_path):
         paths = _make_tree(tmp_path, "t4", with_claude=False)
@@ -272,6 +283,59 @@ class TestReapStalePreserveDirs:
         result = _run_snippet(_reap_harness(task_root, lock_dir))
         assert result.returncode == 0, result.stderr
         assert not empty.exists()
+
+    def test_missing_lock_file_does_not_manufacture_one(self, tmp_path):
+        """The peer lock must be opened read-only: `8>` would create it.
+
+        Lock files cannot be reclaimed safely — unlink followed by a same-name
+        open yields a different inode, so two holders stop excluding each other.
+        A sweep that creates one per candidate would trade this leak for another.
+        """
+        task_root = tmp_path / "tasks"
+        lock_dir = tmp_path / "lock"
+        task_root.mkdir()
+        lock_dir.mkdir()
+        stale = task_root / "nolock.claude-preserve"
+        stale.mkdir()
+        _age(stale, 90)
+
+        result = _run_snippet(_reap_harness(task_root, lock_dir))
+        assert result.returncode == 0, result.stderr
+        assert not stale.exists()
+        assert (
+            list(lock_dir.iterdir()) == []
+        ), f"the sweep created lock files: {[p.name for p in lock_dir.iterdir()]}"
+
+    @requires_flock
+    def test_held_lock_protects_a_stale_looking_preserve(self, tmp_path):
+        """Age alone is not a liveness test.
+
+        The startup preserve-move and the restore bracket a window in which the
+        dir legitimately exists mid-run, and the restore can fail silently on a
+        full tmpfs. A run holding the task lock must keep its history.
+        """
+        task_root = tmp_path / "tasks"
+        lock_dir = tmp_path / "lock"
+        task_root.mkdir()
+        lock_dir.mkdir()
+        busy = task_root / "live.claude-preserve"
+        busy.mkdir()
+        (busy / "s.jsonl").write_text("{}", encoding="utf-8")
+        _age(busy / "s.jsonl", 90)
+        _age(busy, 90)
+        lock_file = lock_dir / "openace-agent-task-live.lock"
+        lock_file.touch()
+
+        # Hold the lock for the duration of the sweep, exactly as a live run would.
+        snippet = (
+            f"exec 7>{lock_file!s}\nflock -x 7\n"
+            + _reap_harness(task_root, lock_dir)
+            + "\nexec 7>&-\n"
+        )
+        result = _run_snippet(snippet)
+        assert result.returncode == 0, result.stderr
+        assert busy.exists(), "a locked (live) preserve dir was reaped"
+        assert (busy / "s.jsonl").is_file()
 
     def test_no_candidates_is_a_clean_noop(self, tmp_path):
         """The glob stays literal when nothing matches; the loop must not run."""

--- a/tests/issues/2403/test_task_tree_reclaim.py
+++ b/tests/issues/2403/test_task_tree_reclaim.py
@@ -477,3 +477,98 @@ class TestReapStalePreserveDirs:
         result = _run_snippet(_reap_harness(task_root, lock_dir))
         assert result.returncode == 0, result.stderr
         assert not (task_root / "*.claude-preserve").exists()
+
+
+def _script_default_preserve_days() -> int:
+    """The default the script itself falls back to, parsed from source.
+
+    _reap_harness always injects a threshold, so the script's own default was
+    never exercised — reverting it to 1 passed the whole suite.
+    """
+    m = re.search(r"^\s*preserve_max_age_days=(\d+)\s*$", SCRIPT.read_text(encoding="utf-8"), re.M)
+    assert m, "could not find the preserve_max_age_days default in the script"
+    return int(m.group(1))
+
+
+def _age_minutes(path: Path, minutes: int) -> None:
+    stamp = time.time() - minutes * 60
+    os.utime(path, (stamp, stamp))
+
+
+class TestPreservedHistoryIsPrivate:
+    """The reclaim must not move ~/.claude into a world-readable location.
+
+    $task_root is created by `mkdir -p` as root (umask 022) so it is 0755, and
+    the preserve dir is its child, not a child of the `chmod 700` tree. Before
+    #2403 this layout existed only for the sub-millisecond startup window;
+    reclaiming on exit makes it the steady state between runs.
+    """
+
+    def test_preserved_history_is_not_world_readable(self, tmp_path):
+        paths = _make_tree(tmp_path, "priv1")
+        (paths["home"] / ".claude").chmod(0o755)
+        result = _run_snippet(_reclaim_harness(tmp_path, "priv1"))
+        assert result.returncode == 0, result.stderr
+        mode = paths["preserve"].stat().st_mode & 0o777
+        assert mode == 0o700, (
+            f"preserve dir is {mode:o}, not 700: every local account can read the "
+            f"agent's shell snapshots, settings, file-history copies of private "
+            f"source and encoded project paths out of /run"
+        )
+
+    def test_group_and_other_bits_are_cleared_even_from_a_permissive_source(self, tmp_path):
+        paths = _make_tree(tmp_path, "priv2")
+        (paths["home"] / ".claude").chmod(0o777)
+        _run_snippet(_reclaim_harness(tmp_path, "priv2"))
+        mode = paths["preserve"].stat().st_mode & 0o777
+        assert not mode & 0o077, f"group/other bits still set: {mode:o}"
+
+
+@requires_gnu_find
+class TestAgeThresholdUnits:
+    def test_threshold_is_days_not_minutes(self, tmp_path, flock_path):
+        """`-newermt "-N days"` vs `"-N minutes"` is invisible to every other test.
+
+        The existing reaper tests use either just-written files (fresh in any
+        unit) or 90/400-day-old ones (stale in any unit), so swapping the unit
+        passed all of them — while in production it would reap every session
+        line idle more than 30 minutes and silently break --resume.
+        """
+        task_root = tmp_path / "tasks"
+        lock_dir = tmp_path / "lock"
+        task_root.mkdir()
+        lock_dir.mkdir()
+        pdir = task_root / "t.claude-preserve"
+        pdir.mkdir()
+        (pdir / "f").write_text("x", encoding="utf-8")
+        _age_minutes(pdir / "f", 45)
+        _age_minutes(pdir, 45)
+
+        result = _run_snippet(_reap_harness(task_root, lock_dir, days=1), env={"PATH": flock_path})
+        assert result.returncode == 0, result.stderr
+        assert pdir.exists(), (
+            "a 45-minute-old preserve dir was reaped under a 1-DAY threshold; "
+            "the find expression is counting minutes"
+        )
+
+    def test_script_default_threshold_keeps_recent_history(self, tmp_path, flock_path):
+        """Pin the script's own fallback, which no harness ever exercised."""
+        default_days = _script_default_preserve_days()
+        task_root = tmp_path / "tasks"
+        lock_dir = tmp_path / "lock"
+        task_root.mkdir()
+        lock_dir.mkdir()
+        pdir = task_root / "t.claude-preserve"
+        pdir.mkdir()
+        (pdir / "f").write_text("x", encoding="utf-8")
+        _age(pdir / "f", 20)
+        _age(pdir, 20)
+
+        result = _run_snippet(
+            _reap_harness(task_root, lock_dir, days=default_days), env={"PATH": flock_path}
+        )
+        assert result.returncode == 0, result.stderr
+        assert pdir.exists(), (
+            f"20-day-old history reaped under the script default of {default_days} "
+            f"days; lowering that default silently shortens --resume's memory"
+        )

--- a/tests/issues/2403/test_task_tree_reclaim.py
+++ b/tests/issues/2403/test_task_tree_reclaim.py
@@ -66,9 +66,48 @@ def _gnu_find() -> bool:
 requires_gnu_find = pytest.mark.skipif(
     not _gnu_find(), reason="requires GNU findutils (-quit / relative -newermt); BSD find on macOS"
 )
-requires_flock = pytest.mark.skipif(
-    shutil.which("flock") is None, reason="requires flock(1); absent on macOS"
-)
+_FLOCK_SHIM = """#!/usr/bin/env python3
+# Minimal flock(1) for platforms without util-linux (macOS). Covers the forms
+# used here: `flock -n <fd>` (the reaper) and `flock -x <fd>` (a test holding a
+# lock), on an already-open inherited descriptor.
+import fcntl, sys
+
+mode = fcntl.LOCK_EX
+nonblock = 0
+fds = []
+for arg in sys.argv[1:]:
+    if arg == "-n":
+        nonblock = fcntl.LOCK_NB
+    elif arg == "-x":
+        mode = fcntl.LOCK_EX
+    elif arg == "-s":
+        mode = fcntl.LOCK_SH
+    elif arg == "-u":
+        mode = fcntl.LOCK_UN
+    else:
+        fds.append(arg)
+try:
+    fcntl.flock(int(fds[0]), mode | nonblock)
+except (OSError, ValueError, IndexError):
+    sys.exit(1)
+"""
+
+
+@pytest.fixture
+def flock_path(tmp_path_factory):
+    """PATH containing a usable flock(1).
+
+    The lock branch is the only one production ever reaches, so skipping it off
+    Linux would leave it unverified on the machine where it is being written.
+    """
+    existing = shutil.which("flock")
+    if existing:
+        return os.environ.get("PATH", "/usr/bin:/bin")
+    shim_dir = tmp_path_factory.mktemp("flockshim")
+    shim = shim_dir / "flock"
+    shim.write_text(_FLOCK_SHIM, encoding="utf-8")
+    shim.chmod(0o755)
+    return f"{shim_dir}:{os.environ.get('PATH', '/usr/bin:/bin')}"
 
 
 def _make_tree(task_root: Path, task_id: str, *, with_claude: bool = True) -> dict[str, Path]:
@@ -237,6 +276,11 @@ class TestReapStalePreserveDirs:
         lock_dir.mkdir()
         task_dir = task_root / "some-task-id"
         (task_dir / "home").mkdir(parents=True)
+        # Age the child FIRST, per _age's contract. Leaving a fresh child makes
+        # the age gate short-circuit, so the glob scope is never exercised and
+        # widening it to "$task_root"/* — which would `rm -rf` live task trees
+        # as root — would go undetected.
+        _age(task_dir / "home", 400)
         _age(task_dir, 400)
 
         result = _run_snippet(_reap_harness(task_root, lock_dir))
@@ -306,8 +350,37 @@ class TestReapStalePreserveDirs:
             list(lock_dir.iterdir()) == []
         ), f"the sweep created lock files: {[p.name for p in lock_dir.iterdir()]}"
 
-    @requires_flock
-    def test_held_lock_protects_a_stale_looking_preserve(self, tmp_path):
+    def test_unheld_lock_still_reaps(self, tmp_path, flock_path):
+        """The only branch production ever takes.
+
+        The task lock is created on every run and unlinked nowhere, so for any
+        preserve dir that can exist its lock file exists too — same run, same
+        boot, and /run and /run/lock are cleared together. That makes the
+        `[ ! -e "$_plock" ]` short-circuit unreachable in production, and both
+        "is reaped" tests above go down it. Without this case, neutering the
+        flock branch entirely would leave the whole suite green while the leak
+        F1c exists to close stayed wide open.
+        """
+        task_root = tmp_path / "tasks"
+        lock_dir = tmp_path / "lock"
+        task_root.mkdir()
+        lock_dir.mkdir()
+        stale = task_root / "done.claude-preserve"
+        stale.mkdir()
+        (stale / "s.jsonl").write_text("{}", encoding="utf-8")
+        _age(stale / "s.jsonl", 90)
+        _age(stale, 90)
+        # Present but unheld: the task finished and released it.
+        (lock_dir / "openace-agent-task-done.lock").touch()
+
+        result = _run_snippet(_reap_harness(task_root, lock_dir), env={"PATH": flock_path})
+        assert result.returncode == 0, result.stderr
+        assert not stale.exists(), (
+            "a finished task's preserve dir survived even though its lock was "
+            "free — the flock branch is not actually reaping anything"
+        )
+
+    def test_held_lock_protects_a_stale_looking_preserve(self, tmp_path, flock_path):
         """Age alone is not a liveness test.
 
         The startup preserve-move and the restore bracket a window in which the
@@ -332,7 +405,7 @@ class TestReapStalePreserveDirs:
             + _reap_harness(task_root, lock_dir)
             + "\nexec 7>&-\n"
         )
-        result = _run_snippet(snippet)
+        result = _run_snippet(snippet, env={"PATH": flock_path})
         assert result.returncode == 0, result.stderr
         assert busy.exists(), "a locked (live) preserve dir was reaped"
         assert (busy / "s.jsonl").is_file()


### PR DESCRIPTION
## 问题

`scripts/openace-run-as.sh` 只有**启动时擦除**，没有**退出时回收**。每次 agent 运行用一个新的 session id，所以**每次运行永久留下一个目录**。生产上 46 个目录撑满 3.1G 的 `/run` tmpfs，之后**所有**工作流在 `openace-run-as` 处失败。

报错极具误导性：显示为 `Failed to access project dir`，看起来像权限/worktree 问题。真实原因是写签名注册表时 `printf` 撞上 ENOSPC；现场留下两个 0 字节的 `.next` 残骸。

**这个泄漏长期无人发现，很可能是因为一条错误的注释**：

```
# orphan dirs from killed attempts are reconciled by the scheduler on restart (#2020).
```

穷举核实（`app/`、`scripts/`、`k8s/`、systemd units、`install.sh`）：**该机制从未实现**。`_reconcile_orphan_sandboxes` 只改 DB 行 + 停远程 session，从不碰文件系统；`task_isolation.py` 只有 `ensure_task_runtime_dirs`（建），没有对应的拆。本 PR 一并改正这条注释。

空间构成实测：单目录最大 449M，其中 ~449M 全是 `tmp/pytest-of-openace-agent/pytest-{1,2,3}`（pytest tmpdir factory 默认保留最近 3 次），`home` 仅 444K。

## 改动

- **`reclaim_task_tree()`** — 先把 `.claude` 抢救到 preserve 路径，再删树。
  **定义位置在建树之前**：bash 在 trap **触发时**才解析函数名，定义在其他 cleanup 辅助函数旁边会让 cgroup fail-closed 的 `exit 66` 路径调用一个不存在的函数、什么都不回收。
- **布防点在 task setup**（而非建树之后），覆盖 `exit 66` / `exit 68` 两条早退与整个 preserve-move 窗口。HUP/INT/TERM 的 trap 一并前移：在它们存在之前，SIGTERM 直接打死 bash，EXIT trap 根本不运行。
- **`on_exit()` = runtime cleanup → reclaim → ACL 撤销**，每段 `|| true`。
  顺序是刻意的：orchestrator 在 SIGTERM 后 5 秒升级为 SIGKILL，三段共享这一个预算；而**两者可恢复性相反** —— 漏掉的 ACL 撤销会被下次调用从注册表重放补上，遗留的 task 树则没有任何补救。`|| true` 是因为 errexit 在 trap handler 内仍然生效，否则第一段失败就会跳过回收，而最可能导致它失败的正是 `/run` 写满 —— 本 issue 自身的现场条件。
- **`reap_stale_preserve_dirs()`** — F1 会把目录泄漏转换成 `.claude-preserve` 泄漏（每个 task_id 一个，只增不减），故一并关掉。作用域只有 `*.claude-preserve`，**绝不碰 task 目录**（那需要本脚本做不到的判活：Python 侧 `ensure_task_runtime_dirs` 建 task 树时从不加锁，但它也从不创建 `.claude-preserve`，这正是本清扫安全而 task 目录清扫不安全的原因）。
  判活用 `flock`，年龄只是**两次调用之间**那段窗口的兜底。**年龄测试走整棵树**：CLI 写的是嵌套的 `projects/<enc>/*.jsonl`，且 rename(2) 不改被改名 inode 的 mtime —— 按目录 mtime 判断会**优先删掉最活跃、寿命最长的 session**。
- **ACL 注册表**改为在**消费点**删除（而非截断），并在写入的同一步用 `umask 077` 重建。
  它**不能**放进 `reclaim_task_tree`：在 `exit 66` 这条早退路径上撤销尚未执行，在那里删掉记录会让 agent 账号的写 ACL **永久孤儿化**。

## 测试

`tests/issues/2403/`，25 passed / 1 skipped（skip 的是 macOS 无 `flock`）。

- **行为门**（`test_task_tree_reclaim.py`）：抽取函数体后对临时树**真跑**，不是 source grep。
- **接线锁**（`test_reclaim_wiring.py`）：比对源码位置而非字符串，覆盖三种行为测试看不见的破坏方式。文件头已标注它们**不计入行为覆盖**。

**变异测试**（逐条验证测试真的会红）：

| 变异 | 结果 |
|---|---|
| 年龄检查改读目录 inode | ✅ `test_old_directory_with_fresh_history_survives` 失败 |
| `rm -rf preserve` 逸出 `-d` guard | ✅ `test_second_execution_does_not_destroy_saved_history` 失败 |
| 去掉 `preserve_claude_dir` 的 `-n` 守卫 | ✅ `test_blank_preserve_path_aborts_instead_of_dropping_history` 失败 |
| 锁用 `8>`（O_CREAT）而非 `8<` | ⚠️ **未被捕获**（原声明有误，见下方更正） |

第三条变异**最初没被抓到** —— 当时那条测试把 `task_base` 设成空串，于是在第一个守卫就 return 了，根本没走到第二个守卫。已重写为「真实的树 + 空 preserve 路径」，因为那才是真正的数据丢失场景（`mv` 静默失败后 `rm -rf $task_base` 连历史一起删掉）。

`tests/issues/2020/` 与 `tests/issues/2035/` 全绿（2 个 `test_scheduler_concurrency` 失败已用 `origin/main` 干净 worktree 对照确认为**环境问题**：本机 `~/.open-ace/agent-launcher.conf` 设了 `agent_max_concurrent_workflows=3`）。

## 残余风险（不假装已解决）

F1 把泄漏从「无界累积」变成「峰值 = 并发数 × 单 task 峰值」。**并发上限已实测核实**：生产 `/etc/openace/agent-launcher.conf` 只有 agent 账号与 workspace roots 两项，**没有** `agent_max_concurrent_workflows` ⇒ 回落到代码默认 **10**（不是 3 —— `setup-cgroup-v2.sh` 显然从未在该宿主运行过）。

⇒ **最坏情况 10 × 449M ≈ 4.4G > 3.1G，仍会 ENOSPC。** 这是当前的真实配置，不是理论值。

缓解方向按优先级：
1. **pytest 保留策略**是唯一能砍掉峰值主项的杠杆（3 份 → 1 份即 449M → ~150M）。
2. 在 `agent-launcher.conf` 显式设置并发上限（**部署侧决策，需人工批准，不在本 PR 内**）。

另：`agent_task_cgroup_enabled` 缺失 ⇒ `task_cg_required=false` ⇒ **`exit 66` 目前在生产不会触发**。上面那条「定义位置」的 bug 因此当前**无生产影响**，但一旦按设计启用 cgroup 就立刻变成每次尝试都命中的高频路径。

## 拆出的后续工作

- **F2** — `kill -9` / OOM 路径的 task 目录 sweep。触发条件是「wrapper 自己的清理跑不完 5 秒」而非外部崩溃，且宿主重启时 tmpfs 自愈。做它需要新开 root 特权面（调度器跑 `User=openace`，对 root:root 的 task_root 无写权），并且对 Python 侧建的目录会误删活跃运行。
- **F3** — pytest 保留策略（见上，优先级高于 F2）。
- **k8s** — `agent-tasks` 是裸 `emptyDir: {}`，**无 `sizeLimit`**；且 Pod `runAsNonRoot` ⇒ wrapper 不被调用 ⇒ **本 PR 对 k8s 零作用**。

## 方案评审

方案经 **5 轮独立评审、46 条 findings**。其中我自己写下又被推翻的结论有三次：v3 的「布防标志」漏掉两条早退路径、v4 的「preserve 在运行期不存在」、v5 的「加锁后年龄只是兜底」。最后一轮唯一的阻塞项是「§6.1 的测试机制产不出它自己列的测试」—— F1c 当时写成内联 `for` 循环，`sed` 抽不出来，四条最关键的门会退化成 source-grep。改为具名函数后闭合。

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---

## 更正：变异表中一处覆盖率声明有误

独立审查发现，上表 `8>` / `8<` 那一行的声明是**错误的**：
`test_missing_lock_file_does_not_manufacture_one` 并不会因该变异而失败。
该测试根本不创建锁文件，`[ ! -e "$_plock" ]` 快速路径先短路返回，fd 8 从未
被打开——断言因此看不到重定向方向的差别。

该声明在早期轮次成立；`! -e` 快速路径是后来加的，声明没有跟着更新。
**代码本身是对的**（`8<` 不带 `O_CREAT`，正是所需语义），错的只是覆盖率主张。
这里明确更正而不是悄悄改表：一个没有测试支撑的"已覆盖"声明，比明说没覆盖更危险。
