### PR TITLE
fix(autonomous): see ruleset required checks, and only repair blocking ones (#2428)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,13 +155,13 @@ jobs:
 
       # pytest.ini's norecursedirs excludes tests/issues entirely, so nothing
       # under it is collected by the run above — ~4200 tests across 238 issue
-      # directories never execute here. Fixing that wholesale is tracked
-      # separately; until then, issue suites must opt in explicitly or they are
+      # directories never execute here. Fixing that wholesale is tracked in
+      # #2429; until then, issue suites must opt in explicitly or they are
       # written, reviewed, and merged without ever gating anything.
       - name: Issue regression suites (opt-in; see norecursedirs)
         timeout-minutes: 5
         run: |
-          pytest tests/issues/2403 -v \
+          pytest tests/issues/2403 tests/issues/2428 -v \
             -m "not postgres and not performance"
 
       - name: Upload coverage to Codecov

--- a/app/modules/workspace/autonomous/github_ops.py
+++ b/app/modules/workspace/autonomous/github_ops.py
@@ -1181,8 +1181,57 @@ class GitHubOps:
 
     @staticmethod
     def _is_not_found(stderr: str) -> bool:
+        """Whether ``stderr`` is GitHub reporting a definitive 404.
+
+        Anchored on the HTTP status gh prints, NOT on a bare ``not found``
+        substring: ``sudo: gh: command not found`` is a missing binary on the
+        service account's PATH, and treating that as "no branch protection"
+        would report an empty required set with no error at all — silently
+        voiding the fail-closed contract this helper feeds. ``not protected``
+        stays because gh emits it verbatim for an unprotected branch.
+        """
         lowered = (stderr or "").strip().lower()
-        return "404" in lowered or "not found" in lowered or "not protected" in lowered
+        # Exclude the shell/exec failures FIRST. gh is invoked through `sudo -u
+        # <account> gh …`, so a gh missing from that account's PATH surfaces as
+        # `sudo: gh: command not found` — Python found `sudo`, so no
+        # FileNotFoundError is raised and a bare `not found` substring test
+        # would classify a broken deployment as "this branch has no protection".
+        if "command not found" in lowered or "no such file" in lowered:
+            return False
+        # gh prints `gh: Not Found (HTTP 404)`; the raw REST body carries
+        # `"status":"404"`. Both are definitive absence.
+        return "404" in lowered or "not protected" in lowered
+
+    def _probe_gh_api(self, args: list[str]) -> subprocess.CompletedProcess:
+        """Run a read-only ``gh api`` probe, retrying transient failures.
+
+        ``_run_gh(check=False)`` returns the first non-zero exit immediately —
+        its retry loop is guarded by ``if check and result.returncode != 0``.
+        The required-check probes need ``check=False`` so they can inspect a
+        404, which meant a single ``Empty reply from server`` (this host reaches
+        github.com through a failover proxy) resolved to "source blind".
+
+        That is not a harmless degradation: a blind probe makes
+        ``get_branch_protection`` raise, ``_blocking_failures`` then treats
+        *every* failing check as blocking, and the workflow burns its bounded
+        CI-repair budget on checks that never gated the merge — the precise
+        failure this issue exists to remove. So transient errors are retried
+        here on the same schedule ``_run_gh`` uses for its checked calls.
+        """
+        result = self._run_gh(args, repo_scoped=False, check=False)
+        for attempt in range(1, GIT_NETWORK_RETRY_COUNT):
+            if result.returncode == 0 or not _is_transient_error(result.stderr, result.returncode):
+                return result
+            logger.warning(
+                "gh api probe transient error (attempt %d/%d), retrying in %ds: %s",
+                attempt,
+                GIT_NETWORK_RETRY_COUNT,
+                GIT_NETWORK_RETRY_INTERVAL,
+                (result.stderr or "").strip()[:200],
+            )
+            time.sleep(GIT_NETWORK_RETRY_INTERVAL)
+            result = self._run_gh(args, repo_scoped=False, check=False)
+        return result
 
     def _classic_required_contexts(self, repo: str, branch: str) -> tuple[list[str], str]:
         """Required checks declared by *classic* branch protection.
@@ -1194,10 +1243,8 @@ class GitHubOps:
         its own. Notably this endpoint requires admin scope, so the autonomous
         workflow's own PAT gets 403 here even though the branch is protected.
         """
-        result = self._run_gh(
-            self._gh_api_args([f"repos/{repo}/branches/{branch}/protection"]),
-            repo_scoped=False,
-            check=False,
+        result = self._probe_gh_api(
+            self._gh_api_args([f"repos/{repo}/branches/{branch}/protection"])
         )
         if result.returncode != 0:
             if self._is_not_found(result.stderr or ""):
@@ -1227,15 +1274,22 @@ class GitHubOps:
         source alone reports no required checks on such a repository.
 
         This endpoint needs only read access and returns the effective rules.
+
+        Paginated: it emits one entry per (ruleset x rule), so a repository with
+        an org-level ruleset stacked on repo-level ones can push the
+        ``required_status_checks`` rule past the first page. Without
+        ``--paginate`` that reads as "no required checks", which makes
+        ``_blocking_failures`` repair every failing check. Verified against the
+        live API: ``?per_page=1`` on this repo returns a ``Link: rel="next"``
+        header, so the pagination is real and not hypothetical.
         """
-        result = self._run_gh(
-            self._gh_api_args([f"repos/{repo}/rules/branches/{branch}"]),
-            repo_scoped=False,
-            check=False,
+        result = self._probe_gh_api(
+            self._gh_api_args(["--paginate", f"repos/{repo}/rules/branches/{branch}"])
         )
         if result.returncode != 0:
-            # 404 means the branch/endpoint is unknown, not that the probe
-            # failed — treat it as "no ruleset rules", same as classic.
+            # A branch with no rules answers 200 [] (verified live), so a 404
+            # here means the repo/endpoint itself is unknown rather than the
+            # probe having failed — treat it as "no ruleset rules", as classic.
             if self._is_not_found(result.stderr or ""):
                 return [], ""
             return [], (
@@ -1270,12 +1324,18 @@ class GitHubOps:
         A branch with neither yields an empty list, which remains a valid
         classification — every failing check is optional — not a probe failure.
 
-        Any other non-zero exit (403 permission, 5xx, network) raises
-        :class:`GitHubOpsError` so callers fail closed to ``indeterminate``
-        instead of guessing required/optional semantics they cannot observe.
-        This is the Phase B guard for #1989-class incidents where an
-        un-verifiable signal must never silently drive an irreversible
-        merge/repair decision.
+        Raises :class:`GitHubOpsError` only when **neither** source observed
+        anything and at least one was blind, because "no required checks" would
+        then be a guess (#1989).
+
+        Note the direction honestly: partial blindness (one source readable, the
+        other not) does NOT raise, so the required set can *understate*. That is
+        deliberate. GitHub is the final gate — understating produces a rejected
+        merge attempt and a visible policy pause, whereas raising makes
+        ``_blocking_failures`` treat every failing check as blocking and burn
+        the bounded CI-repair budget, which is the exact #2428 failure this
+        method exists to remove. Over-reporting blindness is the more damaging
+        error here, not the safer one.
         """
         repo = self.get_repo_name()
         contexts, classic_err = self._classic_required_contexts(repo, branch)

--- a/app/modules/workspace/autonomous/github_ops.py
+++ b/app/modules/workspace/autonomous/github_ops.py
@@ -1179,55 +1179,120 @@ class GitHubOps:
             "mergeable_state": str(data.get("mergeable_state") or "").strip().lower(),
         }
 
-    def get_branch_protection(self, branch: str = "main") -> dict:
-        """Return the branch-protection rules for ``branch`` (issue #2045 Phase B).
+    @staticmethod
+    def _is_not_found(stderr: str) -> bool:
+        lowered = (stderr or "").strip().lower()
+        return "404" in lowered or "not found" in lowered or "not protected" in lowered
 
-        Used by the merge-readiness classifier to distinguish required from
-        optional CI checks. Only ``required_status_checks`` is unpacked — that
-        is the only field the classifier consumes, so the rest of the protection
-        payload (required_reviews, enforce_admins, restrictions, ...) is ignored.
+    def _classic_required_contexts(self, repo: str, branch: str) -> tuple[list[str], str]:
+        """Required checks declared by *classic* branch protection.
 
-        A 404 (branch has no protection rules) returns an empty required-contexts
-        list rather than raising: "no required checks" is a valid classification
-        — every failing check is optional — not a probe failure.
-
-        Any other non-zero exit (403 permission, 5xx, network) raises
-        :class:`GitHubOpsError` so the classifier fails closed to
-        ``indeterminate`` instead of guessing required/optional semantics it
-        cannot observe. This is the Phase B guard for #1989-class incidents
-        where an un-verifiable signal must never silently drive an irreversible
-        merge/repair decision.
+        Returns ``(contexts, error)``. A 404 is a definitive "no classic
+        protection" and yields ``([], "")``. Any other failure yields
+        ``([], reason)`` — this source is blind, which the caller must weigh
+        against what the other source could see rather than treat as fatal on
+        its own. Notably this endpoint requires admin scope, so the autonomous
+        workflow's own PAT gets 403 here even though the branch is protected.
         """
-        repo = self.get_repo_name()
         result = self._run_gh(
             self._gh_api_args([f"repos/{repo}/branches/{branch}/protection"]),
             repo_scoped=False,
             check=False,
         )
         if result.returncode != 0:
-            stderr = (result.stderr or "").strip().lower()
-            # gh api surfaces HTTP 404 for an unprotected branch; that is a
-            # valid "no required checks" answer, not a probe failure.
-            if "404" in stderr or "not found" in stderr or "not protected" in stderr:
-                return {"required_status_checks": {"contexts": []}}
-            raise GitHubOpsError(
-                f"get_branch_protection({branch}) failed (exit {result.returncode}): "
+            if self._is_not_found(result.stderr or ""):
+                return [], ""
+            return [], (
+                f"classic protection unreadable (exit {result.returncode}): "
                 f"{(result.stderr or '').strip()}"
             )
         data = json.loads((result.stdout or "").strip() or "{}")
         rsc = data.get("required_status_checks") or {}
-        # GitHub returns the legacy string ``contexts`` array and/or the newer
-        # ``checks`` array of {context, integration_id, ...} objects. Merge both
-        # into a flat, de-duplicated required-check-name list.
         contexts: list[str] = []
-        for ctx in rsc.get("contexts", []) or []:
-            name = ctx.get("context") if isinstance(ctx, dict) else ctx
+        # GitHub returns the legacy string ``contexts`` array and/or the newer
+        # ``checks`` array of {context, integration_id, ...} objects.
+        for entry in list(rsc.get("contexts", []) or []) + list(rsc.get("checks", []) or []):
+            name = entry.get("context") if isinstance(entry, dict) else entry
             if name and name not in contexts:
                 contexts.append(name)
-        for chk in rsc.get("checks", []) or []:
-            name = chk.get("context") if isinstance(chk, dict) else chk
-            if name and name not in contexts:
+        return contexts, ""
+
+    def _ruleset_required_contexts(self, repo: str, branch: str) -> tuple[list[str], str]:
+        """Required checks declared by *rulesets* (issue #2428).
+
+        Rulesets are the modern replacement for classic branch protection, and
+        the classic endpoint does not describe them — it answers 404 for a
+        ruleset-protected branch, or 403 for a token without admin scope (which
+        is what the autonomous workflow's own PAT gets). Either way the classic
+        source alone reports no required checks on such a repository.
+
+        This endpoint needs only read access and returns the effective rules.
+        """
+        result = self._run_gh(
+            self._gh_api_args([f"repos/{repo}/rules/branches/{branch}"]),
+            repo_scoped=False,
+            check=False,
+        )
+        if result.returncode != 0:
+            # 404 means the branch/endpoint is unknown, not that the probe
+            # failed — treat it as "no ruleset rules", same as classic.
+            if self._is_not_found(result.stderr or ""):
+                return [], ""
+            return [], (
+                f"branch rules unreadable (exit {result.returncode}): "
+                f"{(result.stderr or '').strip()}"
+            )
+        rules = json.loads((result.stdout or "").strip() or "[]")
+        if not isinstance(rules, list):
+            return [], ""
+        contexts: list[str] = []
+        for rule in rules:
+            if not isinstance(rule, dict) or rule.get("type") != "required_status_checks":
+                continue
+            params = rule.get("parameters") or {}
+            for entry in params.get("required_status_checks", []) or []:
+                name = entry.get("context") if isinstance(entry, dict) else entry
+                if name and name not in contexts:
+                    contexts.append(name)
+        return contexts, ""
+
+    def get_branch_protection(self, branch: str = "main") -> dict:
+        """Return the required-check contexts enforced on ``branch``.
+
+        Used to distinguish required from optional CI checks. Only
+        ``required_status_checks`` is unpacked — that is the only field
+        consumers need.
+
+        Both enforcement mechanisms are consulted and unioned (issue #2428):
+        classic branch protection AND rulesets. Querying only the classic
+        endpoint made every ruleset-protected repository look unprotected.
+
+        A branch with neither yields an empty list, which remains a valid
+        classification — every failing check is optional — not a probe failure.
+
+        Any other non-zero exit (403 permission, 5xx, network) raises
+        :class:`GitHubOpsError` so callers fail closed to ``indeterminate``
+        instead of guessing required/optional semantics they cannot observe.
+        This is the Phase B guard for #1989-class incidents where an
+        un-verifiable signal must never silently drive an irreversible
+        merge/repair decision.
+        """
+        repo = self.get_repo_name()
+        contexts, classic_err = self._classic_required_contexts(repo, branch)
+        ruleset_contexts, ruleset_err = self._ruleset_required_contexts(repo, branch)
+        for name in ruleset_contexts:
+            if name not in contexts:
                 contexts.append(name)
+        # Fail closed only when nothing was positively observed AND at least one
+        # source was blind. A 403 on the classic endpoint is expected here (it
+        # needs admin scope), so it must not veto a successful ruleset read —
+        # but if neither source could see anything, "no required checks" would
+        # be a guess, and guessing is what #1989 forbids.
+        if not contexts and (classic_err or ruleset_err):
+            raise GitHubOpsError(
+                f"get_branch_protection({branch}) could not determine required checks: "
+                + "; ".join(e for e in (classic_err, ruleset_err) if e)
+            )
         return {"required_status_checks": {"contexts": contexts}}
 
     def find_existing_pr(self, head_branch: str) -> dict | None:

--- a/app/modules/workspace/autonomous/phases/merge.py
+++ b/app/modules/workspace/autonomous/phases/merge.py
@@ -94,7 +94,53 @@ NAME = "merge"
 logger = logging.getLogger(__name__)
 
 
-def _blocking_failures(gh, checks: list[dict], pr_number: int) -> list[dict]:
+def _required_contexts(gh, pr_number: int, base_branch: str) -> set[str] | None:
+    """Required-check contexts for ``base_branch``, or None if undeterminable.
+
+    None means "could not observe" and is distinct from an empty set, which
+    means "observed, and the branch requires nothing".
+    """
+    try:
+        protection = gh.get_branch_protection(base_branch)
+    except Exception as exc:  # noqa: BLE001 — degrade, never stall the merge
+        logger.warning(
+            "PR #%s: could not resolve required checks for '%s' (%s)",
+            pr_number,
+            base_branch,
+            exc,
+        )
+        return None
+    return set((protection.get("required_status_checks") or {}).get("contexts") or [])
+
+
+def _blocking_pending(gh, checks: list[dict], pr_number: int, base_branch: str) -> list[dict]:
+    """Pending checks that actually gate the merge (issue #2428).
+
+    The required/optional split applies to *pending* exactly as it does to
+    *failing*: a slow non-required job (``Critical PR E2E``, ``Full E2E``) must
+    not defer the merge every scheduler cycle. ``ReadinessService._partition_checks``
+    documents the same rule. Degrades to "all pending block" when the required
+    set cannot be observed, matching :func:`_blocking_failures`.
+    """
+    pending = [c for c in checks if c.get("bucket") == "pending"]
+    if not pending:
+        return []
+    required = _required_contexts(gh, pr_number, base_branch)
+    if not required:
+        return pending
+    blocking = [c for c in pending if (c.get("name") or "") in required]
+    ignored = [c for c in pending if (c.get("name") or "") not in required]
+    if ignored:
+        logger.info(
+            "PR #%s: not deferring for %d non-blocking pending check(s): %s",
+            pr_number,
+            len(ignored),
+            ", ".join(c.get("name") or "?" for c in ignored),
+        )
+    return blocking
+
+
+def _blocking_failures(gh, checks: list[dict], pr_number: int, base_branch: str) -> list[dict]:
     """Return the failing checks that actually block the merge (issue #2428).
 
     CI repair rounds are a bounded budget (``MAX_CI_REPAIR_ATTEMPTS``). Spending
@@ -117,15 +163,12 @@ def _blocking_failures(gh, checks: list[dict], pr_number: int) -> list[dict]:
     failed = [c for c in checks if c.get("bucket") == "fail"]
     if not failed:
         return []
-    try:
-        protection = gh.get_branch_protection("main")
-        required = set((protection.get("required_status_checks") or {}).get("contexts") or [])
-    except Exception as exc:  # noqa: BLE001 — degrade to the old behaviour, never stall
+    required = _required_contexts(gh, pr_number, base_branch)
+    if required is None:
         logger.warning(
-            "PR #%s: could not resolve required checks (%s); "
-            "treating all %d failing check(s) as blocking",
+            "PR #%s: required checks undeterminable; treating all %d failing check(s) "
+            "as blocking",
             pr_number,
-            exc,
             len(failed),
         )
         return failed
@@ -133,20 +176,21 @@ def _blocking_failures(gh, checks: list[dict], pr_number: int) -> list[dict]:
         # A genuinely unprotected branch has no merge gate to satisfy; keep the
         # previous behaviour rather than concluding nothing needs repair.
         logger.warning(
-            "PR #%s: branch 'main' reports no required checks; "
+            "PR #%s: branch '%s' reports no required checks; "
             "treating all %d failing check(s) as blocking",
             pr_number,
+            base_branch,
             len(failed),
         )
         return failed
-    blocking = [c for c in failed if c.get("name", "") in required]
-    skipped = [c for c in failed if c.get("name", "") not in required]
+    blocking = [c for c in failed if (c.get("name") or "") in required]
+    skipped = [c for c in failed if (c.get("name") or "") not in required]
     if skipped:
         logger.info(
             "PR #%s: ignoring %d non-blocking CI failure(s) for repair purposes: %s",
             pr_number,
             len(skipped),
-            ", ".join(c.get("name", "?") for c in skipped),
+            ", ".join(c.get("name") or "?" for c in skipped),
         )
     return blocking
 
@@ -161,6 +205,11 @@ def handle(ctx, deps) -> PhaseResult:
     gh = deps.gh
     pr_number = wf.get("github_pr_number")
     branch_name = wf.get("branch_name", "")
+    # The branch the PR targets — the one whose protection/ruleset defines which
+    # checks are required. Hardcoding "main" silently reports the wrong required
+    # set for any workflow targeting another base. Mirrors the
+    # ``original_branch_name or "main"`` idiom the orchestrator already uses.
+    base_branch = (wf.get("original_branch_name") or "main").strip() or "main"
 
     if pr_number:
         # Phase B (#2045): verify the PR head through the evidence contract
@@ -231,7 +280,7 @@ def handle(ctx, deps) -> PhaseResult:
                 raise GitHubOpsError(
                     f"Unable to query CI checks before merging PR #{pr_number}: {e}"
                 ) from e
-            failed = _blocking_failures(gh, checks, pr_number)
+            failed = _blocking_failures(gh, checks, pr_number, base_branch)
             if failed:
                 deps.host.start_ci_repair_round(wf, pr_number, failed)
                 return PhaseResult.retry()
@@ -245,7 +294,7 @@ def handle(ctx, deps) -> PhaseResult:
         # cycle instead of blocking (synchronous poll) or failing. The
         # scheduler re-enters the merge phase every ~10s.
         # (checks is empty for unstable PRs — no deferral needed.)
-        pending = [c for c in checks if c.get("bucket") == "pending"]
+        pending = _blocking_pending(gh, checks, pr_number, base_branch)
         if pending:
             logger.info(
                 "PR #%s: %d CI checks pending, deferring merge to next cycle",
@@ -278,11 +327,11 @@ def handle(ctx, deps) -> PhaseResult:
                     checks_err,
                 )
                 refreshed_checks = checks
-            failed = _blocking_failures(gh, refreshed_checks, pr_number)
+            failed = _blocking_failures(gh, refreshed_checks, pr_number, base_branch)
             if failed:
                 deps.host.start_ci_repair_round(wf, pr_number, failed)
                 return PhaseResult.retry()
-            pending = [c for c in refreshed_checks if c.get("bucket") == "pending"]
+            pending = _blocking_pending(gh, refreshed_checks, pr_number, base_branch)
 
             try:
                 merge_state = gh.get_pr_merge_state(pr_number)

--- a/app/modules/workspace/autonomous/phases/merge.py
+++ b/app/modules/workspace/autonomous/phases/merge.py
@@ -94,6 +94,63 @@ NAME = "merge"
 logger = logging.getLogger(__name__)
 
 
+def _blocking_failures(gh, checks: list[dict], pr_number: int) -> list[dict]:
+    """Return the failing checks that actually block the merge (issue #2428).
+
+    CI repair rounds are a bounded budget (``MAX_CI_REPAIR_ATTEMPTS``). Spending
+    one on a check that does not gate the merge is pure waste, and it is how
+    workflows exhausted the budget and died: wf227 burned all five rounds and
+    reported ``test (3.13)`` — a check ``main`` does not require. On this
+    repository only ``lint``, ``test (3.10/3.11/3.12)`` and ``build`` are
+    required; ``test (3.13/3.14)``, ``postgres-test``, ``schema-sync``,
+    ``performance-test`` and the E2E jobs are not.
+
+    ``ReadinessService.collect_actionable_ci_failures`` already implements this
+    split — with the #1989/#2034 lesson written into its docstring — but nothing
+    ever called it, so the live merge path repaired every failure regardless.
+
+    Falls back to "everything that failed" when the required set cannot be
+    determined. Deferring instead (the ReadinessService ``indeterminate``
+    semantic) would stall the workflow indefinitely, which is worse than the
+    status quo; repairing too much is merely wasteful.
+    """
+    failed = [c for c in checks if c.get("bucket") == "fail"]
+    if not failed:
+        return []
+    try:
+        protection = gh.get_branch_protection("main")
+        required = set((protection.get("required_status_checks") or {}).get("contexts") or [])
+    except Exception as exc:  # noqa: BLE001 — degrade to the old behaviour, never stall
+        logger.warning(
+            "PR #%s: could not resolve required checks (%s); "
+            "treating all %d failing check(s) as blocking",
+            pr_number,
+            exc,
+            len(failed),
+        )
+        return failed
+    if not required:
+        # A genuinely unprotected branch has no merge gate to satisfy; keep the
+        # previous behaviour rather than concluding nothing needs repair.
+        logger.warning(
+            "PR #%s: branch 'main' reports no required checks; "
+            "treating all %d failing check(s) as blocking",
+            pr_number,
+            len(failed),
+        )
+        return failed
+    blocking = [c for c in failed if c.get("name", "") in required]
+    skipped = [c for c in failed if c.get("name", "") not in required]
+    if skipped:
+        logger.info(
+            "PR #%s: ignoring %d non-blocking CI failure(s) for repair purposes: %s",
+            pr_number,
+            len(skipped),
+            ", ".join(c.get("name", "?") for c in skipped),
+        )
+    return blocking
+
+
 def handle(ctx, deps) -> PhaseResult:
     """Execute one merge-phase cycle.
 
@@ -174,7 +231,7 @@ def handle(ctx, deps) -> PhaseResult:
                 raise GitHubOpsError(
                     f"Unable to query CI checks before merging PR #{pr_number}: {e}"
                 ) from e
-            failed = [c for c in checks if c.get("bucket") == "fail"]
+            failed = _blocking_failures(gh, checks, pr_number)
             if failed:
                 deps.host.start_ci_repair_round(wf, pr_number, failed)
                 return PhaseResult.retry()
@@ -221,7 +278,7 @@ def handle(ctx, deps) -> PhaseResult:
                     checks_err,
                 )
                 refreshed_checks = checks
-            failed = [c for c in refreshed_checks if c.get("bucket") == "fail"]
+            failed = _blocking_failures(gh, refreshed_checks, pr_number)
             if failed:
                 deps.host.start_ci_repair_round(wf, pr_number, failed)
                 return PhaseResult.retry()

--- a/tests/issues/2428/test_blocking_failures_filter.py
+++ b/tests/issues/2428/test_blocking_failures_filter.py
@@ -50,7 +50,7 @@ def test_non_required_failures_do_not_trigger_repair():
         _check("schema-sync"),
         _check("lint", bucket="pass"),
     ]
-    assert _blocking_failures(_gh(), checks, 2425) == [], (
+    assert _blocking_failures(_gh(), checks, 2425, "main") == [], (
         "a repair round would be started — and an attempt consumed — for checks "
         "that do not block the merge"
     )
@@ -58,7 +58,7 @@ def test_non_required_failures_do_not_trigger_repair():
 
 def test_required_failures_are_returned():
     checks = [_check("lint"), _check("test (3.13)")]
-    result = _blocking_failures(_gh(), checks, 1)
+    result = _blocking_failures(_gh(), checks, 1, "main")
     assert [c["name"] for c in result] == ["lint"]
 
 
@@ -70,7 +70,7 @@ def test_mixed_failures_pass_only_the_blocking_ones_to_the_agent():
         _check("Critical PR E2E"),
         _check("test (3.11)"),
     ]
-    names = [c["name"] for c in _blocking_failures(_gh(), checks, 1)]
+    names = [c["name"] for c in _blocking_failures(_gh(), checks, 1, "main")]
     assert names == ["build", "test (3.11)"]
 
 
@@ -80,26 +80,26 @@ def test_passing_and_pending_checks_are_never_returned():
         _check("build", bucket="pending"),
         _check("test (3.10)", bucket="fail"),
     ]
-    names = [c["name"] for c in _blocking_failures(_gh(), checks, 1)]
+    names = [c["name"] for c in _blocking_failures(_gh(), checks, 1, "main")]
     assert names == ["test (3.10)"]
 
 
 def test_no_failures_short_circuits_without_an_api_call():
     """Do not pay for a protection lookup when there is nothing to filter."""
     gh = _gh()
-    assert _blocking_failures(gh, [_check("lint", bucket="pass")], 1) == []
+    assert _blocking_failures(gh, [_check("lint", bucket="pass")], 1, "main") == []
     gh.get_branch_protection.assert_not_called()
 
 
 def test_protection_lookup_failure_degrades_to_repairing_everything():
     """Must not stall: deferring forever is worse than repairing too much."""
     checks = [_check("test (3.13)"), _check("lint")]
-    result = _blocking_failures(_gh(raises=RuntimeError("HTTP 403")), checks, 1)
+    result = _blocking_failures(_gh(raises=RuntimeError("HTTP 403")), checks, 1, "main")
     assert [c["name"] for c in result] == ["test (3.13)", "lint"]
 
 
 def test_empty_required_set_degrades_to_repairing_everything():
     """An unprotected branch has no gate; do not conclude nothing needs repair."""
     checks = [_check("test (3.13)"), _check("lint")]
-    result = _blocking_failures(_gh(required=[]), checks, 1)
+    result = _blocking_failures(_gh(required=[]), checks, 1, "main")
     assert [c["name"] for c in result] == ["test (3.13)", "lint"]

--- a/tests/issues/2428/test_blocking_failures_filter.py
+++ b/tests/issues/2428/test_blocking_failures_filter.py
@@ -1,0 +1,105 @@
+"""Issue #2428: CI repair must only spend its budget on merge-blocking checks.
+
+``phases/merge.py`` started a repair round for every failing check:
+
+    failed = [c for c in checks if c.get("bucket") == "fail"]
+    if failed:
+        deps.host.start_ci_repair_round(wf, pr_number, failed)
+
+``MAX_CI_REPAIR_ATTEMPTS`` is 5, so a couple of non-blocking failures could
+exhaust the budget and kill the workflow. wf227 (issue #2328) died reporting
+``test (3.13)`` — a check ``main`` does not require.
+
+``ReadinessService.collect_actionable_ci_failures`` already implemented this
+split, citing the #1989/#2034 lesson, but nothing ever called it.
+
+The fallback direction matters: when the required set cannot be determined the
+filter must degrade to the old "repair everything" behaviour. Deferring (the
+ReadinessService ``indeterminate`` semantic) would stall the workflow forever.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from app.modules.workspace.autonomous.phases.merge import _blocking_failures
+
+REQUIRED = ["lint", "test (3.10)", "test (3.11)", "test (3.12)", "build"]
+
+
+def _gh(required=REQUIRED, raises: Exception | None = None):
+    gh = MagicMock()
+    if raises is not None:
+        gh.get_branch_protection.side_effect = raises
+    else:
+        gh.get_branch_protection.return_value = {
+            "required_status_checks": {"contexts": list(required)}
+        }
+    return gh
+
+
+def _check(name: str, bucket: str = "fail") -> dict:
+    return {"name": name, "bucket": bucket}
+
+
+def test_non_required_failures_do_not_trigger_repair():
+    """The wf227 shape: only optional checks are red."""
+    checks = [
+        _check("test (3.13)"),
+        _check("postgres-test"),
+        _check("schema-sync"),
+        _check("lint", bucket="pass"),
+    ]
+    assert _blocking_failures(_gh(), checks, 2425) == [], (
+        "a repair round would be started — and an attempt consumed — for checks "
+        "that do not block the merge"
+    )
+
+
+def test_required_failures_are_returned():
+    checks = [_check("lint"), _check("test (3.13)")]
+    result = _blocking_failures(_gh(), checks, 1)
+    assert [c["name"] for c in result] == ["lint"]
+
+
+def test_mixed_failures_pass_only_the_blocking_ones_to_the_agent():
+    """The repair agent should not be handed noise it cannot act on usefully."""
+    checks = [
+        _check("test (3.13)"),
+        _check("build"),
+        _check("Critical PR E2E"),
+        _check("test (3.11)"),
+    ]
+    names = [c["name"] for c in _blocking_failures(_gh(), checks, 1)]
+    assert names == ["build", "test (3.11)"]
+
+
+def test_passing_and_pending_checks_are_never_returned():
+    checks = [
+        _check("lint", bucket="pass"),
+        _check("build", bucket="pending"),
+        _check("test (3.10)", bucket="fail"),
+    ]
+    names = [c["name"] for c in _blocking_failures(_gh(), checks, 1)]
+    assert names == ["test (3.10)"]
+
+
+def test_no_failures_short_circuits_without_an_api_call():
+    """Do not pay for a protection lookup when there is nothing to filter."""
+    gh = _gh()
+    assert _blocking_failures(gh, [_check("lint", bucket="pass")], 1) == []
+    gh.get_branch_protection.assert_not_called()
+
+
+def test_protection_lookup_failure_degrades_to_repairing_everything():
+    """Must not stall: deferring forever is worse than repairing too much."""
+    checks = [_check("test (3.13)"), _check("lint")]
+    result = _blocking_failures(_gh(raises=RuntimeError("HTTP 403")), checks, 1)
+    assert [c["name"] for c in result] == ["test (3.13)", "lint"]
+
+
+def test_empty_required_set_degrades_to_repairing_everything():
+    """An unprotected branch has no gate; do not conclude nothing needs repair."""
+    checks = [_check("test (3.13)"), _check("lint")]
+    result = _blocking_failures(_gh(required=[]), checks, 1)
+    assert [c["name"] for c in result] == ["test (3.13)", "lint"]

--- a/tests/issues/2428/test_merge_wiring.py
+++ b/tests/issues/2428/test_merge_wiring.py
@@ -1,0 +1,230 @@
+"""Issue #2428: pin the required/optional split to the live merge path.
+
+``test_blocking_failures_filter.py`` imports ``_blocking_failures`` directly and
+proves the helper's logic. That says nothing about whether ``merge.handle``
+actually calls it — and the bug this issue exists to fix was precisely that:
+``ReadinessService.collect_actionable_ci_failures`` already implemented the
+split correctly, and nothing ever called it, so the live merge path repaired
+every failing check for months.
+
+Shipping ``_blocking_failures`` with only direct-import coverage would recreate
+that exact exposure. A review of PR #2430 confirmed it: reverting BOTH call
+sites in ``phases/merge.py`` back to
+
+    failed = [c for c in checks if c.get("bucket") == "fail"]
+
+left 240 tests passing. These tests drive ``merge.handle`` end to end so that
+mutation fails.
+
+The concrete production incident: workflow ``2d0c317d`` (issue #2328, PR #2425)
+burned all five CI-repair rounds and died reporting ``test (3.13)`` — a check
+``main`` does not require. Required on this repo is exactly
+``lint``, ``test (3.10/3.11/3.12)``, ``build`` (verified against the live
+ruleset API).
+"""
+
+from __future__ import annotations
+
+import threading
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+from app.modules.workspace.autonomous.evidence import Evidence, Verdict
+from app.modules.workspace.autonomous.github_ops import GitHubOpsError
+from app.modules.workspace.autonomous.phase_contract import WorkflowContext
+from app.modules.workspace.autonomous.phases import merge as merge_phase
+
+# The live required set for open-ace/open-ace main, from
+# `gh api repos/open-ace/open-ace/rules/branches/main`.
+REQUIRED = ["lint", "test (3.10)", "test (3.11)", "test (3.12)", "build"]
+
+
+def _ctx(workflow: dict) -> WorkflowContext:
+    return WorkflowContext(
+        workflow=workflow,
+        definition_snapshot=None,
+        repository_context=None,
+        session_bindings={},
+        cancellation=threading.Event(),
+    )
+
+
+def _deps(*, checks, required=REQUIRED, merge_raises=None, protection_raises=None):
+    host = MagicMock(name="host")
+    host.perform_git_cleanup.return_value = ("completed", "")
+    host.validate_pre_merge_change_scope.return_value = ""
+    host.sync_failed_pr_with_main.return_value = False
+    host.branch_contains_main.return_value = False
+
+    gh = MagicMock(name="gh")
+    # "clean" (not "unstable") so the handler enters the sync + CI-repair block;
+    # an unstable PR skips that block entirely via a pre-existing #2034 path.
+    gh.get_pr_merge_state.return_value = {"mergeable": True, "mergeable_state": "clean"}
+    gh.get_pr_checks.return_value = checks
+    if protection_raises is not None:
+        gh.get_branch_protection.side_effect = protection_raises
+    else:
+        gh.get_branch_protection.return_value = {
+            "required_status_checks": {"contexts": list(required)}
+        }
+    gh.merge_pr.side_effect = merge_raises
+    gh.merge_pr.return_value = None
+
+    evidence = MagicMock(name="evidence")
+    evidence.resolve_verified_pr_head.return_value = Evidence(
+        source="github_api",
+        subject="pr_head",
+        verdict=Verdict.CONFIRMED,
+        observed_at=datetime.now(timezone.utc),
+        verified_at=datetime.now(timezone.utc),
+        verification_method="cat-file -e",
+        commit_shas=("abc123",),
+        reason="",
+    )
+
+    deps = MagicMock(name="deps")
+    deps.host = host
+    deps.gh = gh
+    deps.evidence = evidence
+    deps.git_workspace = MagicMock(name="git_workspace")
+    return deps, host, gh
+
+
+def _wf(base: str | None = None) -> dict:
+    wf = {"github_pr_number": 2425, "branch_name": "auto-dev/2d0c317d-310"}
+    if base is not None:
+        wf["original_branch_name"] = base
+    return wf
+
+
+# ── call site 1: the pre-merge check query ────────────────────────────────
+
+
+def test_non_required_failure_neither_repairs_nor_blocks_the_merge():
+    """The #2328 incident, as a test.
+
+    `test (3.13)` failing must not consume a CI-repair round and must not stop
+    the merge. Reverting call site 1 to the unfiltered comprehension makes
+    start_ci_repair_round fire and merge_pr never run.
+    """
+    deps, host, gh = _deps(checks=[{"name": "test (3.13)", "bucket": "fail"}])
+    merge_phase.handle(_ctx(_wf()), deps)
+    host.start_ci_repair_round.assert_not_called()
+    gh.merge_pr.assert_called_once()
+
+
+def test_required_failure_still_starts_a_repair_round_and_defers():
+    """The filter must not swing the other way: a required failure still gates."""
+    deps, host, gh = _deps(checks=[{"name": "lint", "bucket": "fail"}])
+    result = merge_phase.handle(_ctx(_wf()), deps)
+    host.start_ci_repair_round.assert_called_once()
+    gh.merge_pr.assert_not_called()
+    assert result.outcome == "retry"
+
+
+def test_mixed_failures_repair_only_the_blocking_ones():
+    deps, host, gh = _deps(
+        checks=[
+            {"name": "test (3.13)", "bucket": "fail"},
+            {"name": "build", "bucket": "fail"},
+            {"name": "Critical PR E2E", "bucket": "fail"},
+        ]
+    )
+    merge_phase.handle(_ctx(_wf()), deps)
+    host.start_ci_repair_round.assert_called_once()
+    repaired = [c.get("name") for c in host.start_ci_repair_round.call_args[0][2]]
+    assert repaired == ["build"], f"repaired non-blocking checks: {repaired}"
+
+
+# ── call site 2: the post-rejection refresh ───────────────────────────────
+
+
+def test_non_required_failure_on_the_rejection_refresh_does_not_repair():
+    """Call site 2 is reached only after merge_pr is rejected.
+
+    Covered separately because reverting site 1 and site 2 are independent
+    mutations — the review confirmed each survives the suite on its own.
+    """
+    deps, host, gh = _deps(
+        checks=[],
+        merge_raises=GitHubOpsError("base branch policy prohibits the merge"),
+    )
+    gh.get_pr_checks.side_effect = [
+        [],  # pre-merge: nothing failing, so the merge is attempted
+        [{"name": "postgres-test", "bucket": "fail"}],  # refresh after rejection
+    ]
+    merge_phase.handle(_ctx(_wf()), deps)
+    host.start_ci_repair_round.assert_not_called()
+
+
+def test_required_failure_on_the_rejection_refresh_does_repair():
+    deps, host, gh = _deps(
+        checks=[],
+        merge_raises=GitHubOpsError("base branch policy prohibits the merge"),
+    )
+    gh.get_pr_checks.side_effect = [
+        [],
+        [{"name": "test (3.11)", "bucket": "fail"}],
+    ]
+    merge_phase.handle(_ctx(_wf()), deps)
+    host.start_ci_repair_round.assert_called_once()
+
+
+# ── the pending split (same bug class, other four lines) ──────────────────
+
+
+def test_non_required_pending_check_does_not_defer_the_merge():
+    """A slow optional job must not re-defer the merge every scheduler cycle."""
+    deps, host, gh = _deps(checks=[{"name": "Critical PR E2E", "bucket": "pending"}])
+    merge_phase.handle(_ctx(_wf()), deps)
+    gh.merge_pr.assert_called_once()
+
+
+def test_required_pending_check_still_defers_the_merge():
+    deps, host, gh = _deps(checks=[{"name": "build", "bucket": "pending"}])
+    result = merge_phase.handle(_ctx(_wf()), deps)
+    gh.merge_pr.assert_not_called()
+    assert result.outcome == "retry"
+
+
+# ── the base branch is the PR's, not a hardcoded "main" ───────────────────
+
+
+def test_required_checks_are_read_for_the_prs_actual_base_branch():
+    """Hardcoding "main" reports the wrong required set for any other base.
+
+    Without this the mocked gh ignores the argument, so `get_branch_protection("master")`
+    survives every test in the suite.
+    """
+    deps, host, gh = _deps(checks=[{"name": "lint", "bucket": "fail"}])
+    merge_phase.handle(_ctx(_wf(base="release/1.x")), deps)
+    assert gh.get_branch_protection.call_args[0][0] == "release/1.x"
+
+
+def test_base_branch_defaults_to_main_when_unset():
+    deps, host, gh = _deps(checks=[{"name": "lint", "bucket": "fail"}])
+    merge_phase.handle(_ctx(_wf()), deps)
+    assert gh.get_branch_protection.call_args[0][0] == "main"
+
+
+# ── degradation: an unobservable required set must fail closed ────────────
+
+
+def test_undeterminable_required_set_repairs_everything():
+    """Fail closed on blindness: better a wasted repair round than a bad merge.
+
+    Note this is exactly the path that reproduces the original bug, which is why
+    github_ops retries transient probe failures before giving up.
+    """
+    deps, host, gh = _deps(
+        checks=[{"name": "test (3.13)", "bucket": "fail"}],
+        protection_raises=GitHubOpsError("could not determine required checks"),
+    )
+    merge_phase.handle(_ctx(_wf()), deps)
+    host.start_ci_repair_round.assert_called_once()
+
+
+def test_branch_with_no_required_checks_repairs_everything():
+    deps, host, gh = _deps(checks=[{"name": "test (3.13)", "bucket": "fail"}], required=[])
+    merge_phase.handle(_ctx(_wf()), deps)
+    host.start_ci_repair_round.assert_called_once()

--- a/tests/issues/2428/test_ruleset_required_checks.py
+++ b/tests/issues/2428/test_ruleset_required_checks.py
@@ -1,0 +1,239 @@
+"""Issue #2428: required-check discovery must see rulesets, not just classic protection.
+
+``get_branch_protection`` queried only ``repos/{repo}/branches/{branch}/protection``.
+That endpoint does not describe rulesets — the modern replacement for classic
+branch protection — so on a ruleset-protected branch it reports nothing useful.
+Measured against the live API with the token the autonomous workflow actually
+uses:
+
+    classic: rc=1  Resource not accessible by personal access token (HTTP 403)
+    rules:   rc=0  [{"type":"required_status_checks", ...}]
+
+The classic endpoint needs admin scope, so the workflow's PAT gets 403 there,
+not the 404 one might assume. Both details matter:
+
+* a 403 must NOT veto a successful ruleset read, or discovery stays broken
+  exactly where it matters, and
+* when neither source observed anything, the call must still raise — "no
+  required checks" would be a guess, and guessing is what #1989 forbids.
+
+Downstream, required-check discovery is what stops CI repair from spending its
+bounded attempts on checks that do not gate the merge. Observed in production as
+wf227 / issue #2328: "PR #2425 CI failed after 5 automatic repair rounds:
+test (3.13)" — a check ``main`` does not require.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.modules.workspace.autonomous.github_ops import GitHubOps, GitHubOpsError
+
+CLASSIC = "branches/main/protection"
+RULES = "rules/branches/main"
+
+RULESET_BODY = json.dumps(
+    [
+        {"type": "deletion"},
+        {
+            "type": "required_status_checks",
+            "parameters": {
+                "required_status_checks": [
+                    {"context": "lint"},
+                    {"context": "test (3.10)"},
+                    {"context": "test (3.11)"},
+                    {"context": "test (3.12)"},
+                    {"context": "build"},
+                ]
+            },
+        },
+    ]
+)
+
+
+def _make_gh() -> GitHubOps:
+    """A real GitHubOps pinned to owner/repo (no network).
+
+    Mirrors the helper in ``tests/unit/test_readiness_contract.py``: the
+    ``_owner_repo_resolved`` flag short-circuits ``_resolve_owner_repo`` so
+    neither ``get_repo_name`` nor ``_gh_api_args`` shells out to git/gh.
+    """
+    gh = GitHubOps("/tmp/repo")
+    gh._repo_slug = "owner/repo"
+    gh._repo_host = "github.com"
+    gh._owner_repo = "owner/repo"
+    gh._owner_repo_resolved = True
+    return gh
+
+
+def _router(classic=None, rules=None):
+    """Dispatch on the endpoint so each source can be simulated independently."""
+
+    def fake_run(args, check=True, repo_scoped=True):
+        url = args[-1]
+        spec = classic if CLASSIC in url else rules if RULES in url else None
+        if spec is None:
+            raise AssertionError(f"unexpected endpoint: {url}")
+        return MagicMock(
+            returncode=spec.get("rc", 0),
+            stdout=spec.get("stdout", ""),
+            stderr=spec.get("stderr", ""),
+        )
+
+    return fake_run
+
+
+def _contexts(gh: GitHubOps) -> list[str]:
+    return gh.get_branch_protection("main")["required_status_checks"]["contexts"]
+
+
+def test_ruleset_protected_branch_reports_its_required_checks():
+    """The regression: classic 404s, the ruleset carries the real gate."""
+    gh = _make_gh()
+    router = _router(
+        classic={"rc": 1, "stderr": "gh: Not Found (HTTP 404)"},
+        rules={"rc": 0, "stdout": RULESET_BODY},
+    )
+    with patch.object(gh, "_run_gh", side_effect=router):
+        contexts = _contexts(gh)
+    assert contexts == ["lint", "test (3.10)", "test (3.11)", "test (3.12)", "build"], (
+        "a ruleset-protected branch still looks unprotected — every failing check "
+        "would be classified optional and CI repair would burn attempts on checks "
+        "that do not block the merge"
+    )
+
+
+def test_both_mechanisms_are_unioned_without_duplicates():
+    gh = _make_gh()
+    router = _router(
+        classic={
+            "rc": 0,
+            "stdout": '{"required_status_checks":{"contexts":["lint","legacy-only"]}}',
+        },
+        rules={"rc": 0, "stdout": RULESET_BODY},
+    )
+    with patch.object(gh, "_run_gh", side_effect=router):
+        contexts = _contexts(gh)
+    assert contexts.count("lint") == 1
+    assert "legacy-only" in contexts
+    assert "build" in contexts
+
+
+def test_genuinely_unprotected_branch_still_reports_none():
+    """Both sources 404 → empty list stays a valid answer, not an error."""
+    gh = _make_gh()
+    router = _router(
+        classic={"rc": 1, "stderr": "gh: Not Found (HTTP 404)"},
+        rules={"rc": 1, "stderr": "gh: Not Found (HTTP 404)"},
+    )
+    with patch.object(gh, "_run_gh", side_effect=router):
+        assert _contexts(gh) == []
+
+
+def test_empty_ruleset_list_is_not_an_error():
+    gh = _make_gh()
+    router = _router(
+        classic={"rc": 1, "stderr": "gh: Not Found (HTTP 404)"},
+        rules={"rc": 0, "stdout": "[]"},
+    )
+    with patch.object(gh, "_run_gh", side_effect=router):
+        assert _contexts(gh) == []
+
+
+def test_ruleset_without_status_check_rules_yields_none():
+    """A branch can carry rulesets that say nothing about checks."""
+    gh = _make_gh()
+    router = _router(
+        classic={"rc": 1, "stderr": "gh: Not Found (HTTP 404)"},
+        rules={"rc": 0, "stdout": json.dumps([{"type": "deletion"}, {"type": "non_fast_forward"}])},
+    )
+    with patch.object(gh, "_run_gh", side_effect=router):
+        assert _contexts(gh) == []
+
+
+def test_ruleset_permission_error_fails_closed():
+    """#1989: an un-verifiable signal must never silently drive a merge decision.
+
+    A 403 on the ruleset endpoint must raise so the classifier returns
+    ``indeterminate``, rather than degrading to "no required checks" and
+    declaring every failing check optional.
+    """
+    gh = _make_gh()
+    router = _router(
+        classic={"rc": 1, "stderr": "gh: Not Found (HTTP 404)"},
+        rules={"rc": 1, "stderr": "gh: Forbidden (HTTP 403)"},
+    )
+    with patch.object(gh, "_run_gh", side_effect=router):
+        with pytest.raises(GitHubOpsError):
+            gh.get_branch_protection("main")
+
+
+def test_classic_403_does_not_veto_a_successful_ruleset_read():
+    """This is the production case, and mocks alone would never have caught it.
+
+    The classic endpoint needs admin scope, so the autonomous workflow's own PAT
+    gets 403 there while the rules endpoint returns 200. Treating that 403 as
+    fatal leaves required-check discovery broken exactly where it matters.
+    """
+    gh = _make_gh()
+    router = _router(
+        classic={
+            "rc": 1,
+            "stderr": "gh: Resource not accessible by personal access token (HTTP 403)",
+        },
+        rules={"rc": 0, "stdout": RULESET_BODY},
+    )
+    with patch.object(gh, "_run_gh", side_effect=router):
+        contexts = _contexts(gh)
+    assert contexts == ["lint", "test (3.10)", "test (3.11)", "test (3.12)", "build"]
+
+
+def test_blind_on_both_sources_fails_closed():
+    """#1989: never guess. Nothing observed and a source was blind → raise."""
+    gh = _make_gh()
+    router = _router(
+        classic={"rc": 1, "stderr": "gh: Forbidden (HTTP 403)"},
+        rules={"rc": 1, "stderr": "gh: Server Error (HTTP 500)"},
+    )
+    with patch.object(gh, "_run_gh", side_effect=router):
+        with pytest.raises(GitHubOpsError):
+            gh.get_branch_protection("main")
+
+
+def test_classic_403_with_no_ruleset_rules_fails_closed():
+    """A clean ruleset read of [] cannot rule out invisible classic protection."""
+    gh = _make_gh()
+    router = _router(
+        classic={"rc": 1, "stderr": "gh: Forbidden (HTTP 403)"},
+        rules={"rc": 0, "stdout": "[]"},
+    )
+    with patch.object(gh, "_run_gh", side_effect=router):
+        with pytest.raises(GitHubOpsError):
+            gh.get_branch_protection("main")
+
+
+def test_malformed_ruleset_payload_is_tolerated():
+    """A dict instead of a list must not crash the merge gate."""
+    gh = _make_gh()
+    router = _router(
+        classic={"rc": 1, "stderr": "gh: Not Found (HTTP 404)"},
+        rules={"rc": 0, "stdout": '{"unexpected": true}'},
+    )
+    with patch.object(gh, "_run_gh", side_effect=router):
+        assert _contexts(gh) == []
+
+
+def test_plain_string_contexts_in_ruleset_are_accepted():
+    gh = _make_gh()
+    body = json.dumps(
+        [{"type": "required_status_checks", "parameters": {"required_status_checks": ["lint"]}}]
+    )
+    router = _router(
+        classic={"rc": 1, "stderr": "gh: Not Found (HTTP 404)"},
+        rules={"rc": 0, "stdout": body},
+    )
+    with patch.object(gh, "_run_gh", side_effect=router):
+        assert _contexts(gh) == ["lint"]

--- a/tests/issues/2428/test_ruleset_required_checks.py
+++ b/tests/issues/2428/test_ruleset_required_checks.py
@@ -237,3 +237,30 @@ def test_plain_string_contexts_in_ruleset_are_accepted():
     )
     with patch.object(gh, "_run_gh", side_effect=router):
         assert _contexts(gh) == ["lint"]
+
+
+# ── #2430 review follow-ups (N5, N2, N3) ─────────────────────────────────
+
+
+def test_missing_gh_binary_is_not_mistaken_for_an_unprotected_branch():
+    """`sudo: gh: command not found` must count as BLIND, never as a 404.
+
+    Python finds `sudo`, so no FileNotFoundError is raised; a bare "not found"
+    substring test classified a broken deployment as "this branch requires
+    nothing", which makes _blocking_failures skip every repair and silently
+    void the fail-closed contract.
+    """
+    from app.modules.workspace.autonomous.github_ops import GitHubOps
+
+    assert GitHubOps._is_not_found("sudo: gh: command not found") is False
+    assert GitHubOps._is_not_found("/bin/sh: 1: gh: not found") is False
+    assert GitHubOps._is_not_found("gh: No such file or directory") is False
+
+
+def test_real_gh_404_shapes_are_recognised():
+    from app.modules.workspace.autonomous.github_ops import GitHubOps
+
+    # The literal string gh emits, verified against the live API.
+    assert GitHubOps._is_not_found("gh: Not Found (HTTP 404)") is True
+    assert GitHubOps._is_not_found("HTTP 404: Not Found") is True
+    assert GitHubOps._is_not_found("Branch not protected") is True

--- a/tests/unit/test_readiness_contract.py
+++ b/tests/unit/test_readiness_contract.py
@@ -106,18 +106,20 @@ def test_get_branch_protection_permission_error_raises_for_fail_closed():
 
 
 def test_get_branch_protection_defaults_to_main_branch():
+    """Both enforcement sources are consulted, and both default to main."""
     gh = _make_gh()
-    captured: dict = {}
+    urls: list[str] = []
 
     def fake_run(args, check=True, repo_scoped=True):
-        captured["args"] = args
+        urls.append(args[-1])
         return MagicMock(
             returncode=0, stdout='{"required_status_checks":{"contexts":[]}}', stderr=""
         )
 
     with patch.object(gh, "_run_gh", side_effect=fake_run):
         gh.get_branch_protection()
-    assert "branches/main/protection" in captured["args"][-1]
+    assert any("branches/main/protection" in url for url in urls), urls
+    assert any("rules/branches/main" in url for url in urls), urls
 
 
 # ── ReadinessService.classify_merge_readiness (7-state) ─────────────────────


### PR DESCRIPTION
Fixes the CI-repair budget being spent on checks that do not block the merge.
See #2428 for the full evidence.

## 两个缺陷

### 1. required check 发现看不到 ruleset

`get_branch_protection()` 只查 classic branch protection 端点。`main` 用的是 **ruleset**，该端点不描述 ruleset。用**工作流实际使用的 PAT** 实测：

```
classic: rc=1  Resource not accessible by personal access token (HTTP 403)
rules:   rc=0  [{"type":"required_status_checks", ...}]
```

注意是 **403 而不是 404** —— classic 端点需要 admin 权限。原代码把 404 当作「无保护」这一合法答案，但 403 会直接 raise。

现在两个来源都查并取并集。**classic 的 403 不再否决一次成功的 ruleset 读取**；但若两个来源都没观察到任何东西，仍然 raise —— 那时「没有 required check」只是猜测，而猜测正是 #1989 禁止的。

### 2. required/optional 的区分是死代码

`ReadinessService.collect_actionable_ci_failures` 实现了完整的区分，docstring 里明写：

> Only required failures consume a bounded repair attempt — optional failures ... do NOT trigger repair (the **#1989/#2034 lesson**)

**但 `app/` 下没有任何地方调用它。** 真正跑的是 `phases/merge.py`：

```python
failed = [c for c in checks if c.get("bucket") == "fail"]
if failed:
    deps.host.start_ci_repair_round(wf, pr_number, failed)
```

于是每一个失败的 check 都消耗 5 次修复预算之一 —— 包括 `test (3.13/3.14)`、`postgres-test`、`schema-sync`、E2E，**没有一个阻塞合并**。

生产证据：wf227（#2328）`PR #2425 CI failed after 5 automatic repair rounds: test (3.13)`。

修复后只对阻塞的失败启动修复轮。**发现失败时退回旧行为（修所有）而不是 defer** —— defer 会让工作流永久停住，比多修几个 check 糟糕得多。

## 关于验证方式

第一版实现**全部 9 条 mock 测试都通过**，但对真实 API 仍然是坏的：它在 classic 的 403 上 raise，根本走不到 rules 端点。**是对线上 GitHub 的端到端验证抓到的**，mock 永远抓不到 —— 因为这个 bug 的本质是「哪个端点在这个仓库上存在」。

测试里因此保留了这条 403 场景，并在 docstring 里写明它是生产实况。

## 测试

`tests/issues/2428/`，18 条，全绿。变异测试：把实现退回「只查 classic」⇒ 4 条失败。

⚠️ `pytest.ini` 的 `norecursedirs` 排除了 `tests/issues`，所以这些测试**默认不在 CI 运行**（见 #2429，约 4200 条测试受影响）。本 PR 显式加了一步把 `tests/issues/2428` 接进 CI。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
