### PR TITLE
fix(remote-session): restore session state machine and token lifecycle

### DIFF
--- a/app/modules/workspace/api_key_proxy.py
+++ b/app/modules/workspace/api_key_proxy.py
@@ -20,7 +20,6 @@ from typing import Any, cast
 
 from app.modules.workspace.api_key_router import APIKeyRouter
 from app.repositories.database import DB_PATH, is_postgresql
-from app.utils.datetime_utils import ensure_utc_suffix
 from app.utils.security_env import get_encryption_key_material
 from app.utils.tool_names import TOOL_NAME_ALIASES, normalize_tool_name
 
@@ -571,6 +570,40 @@ class APIKeyProxyService:
         finally:
             conn.close()
 
+    def has_valid_proxy_token(self, session_id: str) -> bool:
+        """Return True if the session has at least one non-revoked, non-expired proxy token.
+
+        Used by the remote session restore path (Issue #2405): when a session is
+        already running on the agent, we only skip the restart if its process
+        still holds a valid token. If every issued token was revoked or has
+        expired, the running CLI would 401 every LLM call, so the restore must
+        restart the process with a freshly issued token.
+        """
+        if not session_id:
+            return False
+        now = datetime.now().isoformat()
+        conn = self._get_connection()
+        try:
+            cursor = conn.cursor()
+            cursor.execute(
+                f"""
+                SELECT 1 FROM proxy_token_jtis
+                WHERE session_id = {_param()}
+                  AND revoked_at IS NULL
+                  AND expires_at > {_param()}
+                LIMIT 1
+            """,
+                (session_id, now),
+            )
+            return cursor.fetchone() is not None
+        except Exception as e:
+            logger.warning(
+                "has_valid_proxy_token failed for %s: %s", session_id[:8], e
+            )
+            return False
+        finally:
+            conn.close()
+
     def _encrypt_key(self, api_key: str) -> str:
         """Encrypt an API key using Fernet (requires cryptography package)."""
         try:
@@ -874,8 +907,8 @@ class APIKeyProxyService:
                     "key_name": row["key_name"],
                     "base_url": row["base_url"],
                     "is_active": bool(row["is_active"]),
-                    "created_at": ensure_utc_suffix(row["created_at"]),
-                    "updated_at": ensure_utc_suffix(row["updated_at"]),
+                    "created_at": row["created_at"],
+                    "updated_at": row["updated_at"],
                     "cli_tools": row["cli_tools"],
                     "cli_settings": row["cli_settings"],
                     "scope": row["scope"] or "remote",

--- a/app/modules/workspace/api_key_proxy.py
+++ b/app/modules/workspace/api_key_proxy.py
@@ -226,8 +226,7 @@ class APIKeyProxyService:
         # api_key_store table is created by migration, but ensure it exists for
         # environments that don't run migrations
         # Issue #1894: Added resolved_ips and resolved_at for SSRF protection
-        cursor.execute(
-            f"""
+        cursor.execute(f"""
             CREATE TABLE IF NOT EXISTS api_key_store (
                 id {id_type},
                 tenant_id INTEGER,
@@ -249,11 +248,9 @@ class APIKeyProxyService:
                 resolved_at TIMESTAMP,
                 UNIQUE(tenant_id, provider, key_name)
             )
-        """
-        )
+        """)
 
-        cursor.execute(
-            f"""
+        cursor.execute(f"""
             CREATE TABLE IF NOT EXISTS proxy_token_jtis (
                 id {id_type},
                 jti TEXT NOT NULL UNIQUE,
@@ -279,8 +276,7 @@ class APIKeyProxyService:
                 terminated_at TIMESTAMP,
                 termination_reason TEXT
             )
-        """
-        )
+        """)
         cursor.execute(
             "CREATE INDEX IF NOT EXISTS idx_proxy_token_jtis_session ON proxy_token_jtis(session_id)"
         )
@@ -597,9 +593,7 @@ class APIKeyProxyService:
             )
             return cursor.fetchone() is not None
         except Exception as e:
-            logger.warning(
-                "has_valid_proxy_token failed for %s: %s", session_id[:8], e
-            )
+            logger.warning("has_valid_proxy_token failed for %s: %s", session_id[:8], e)
             return False
         finally:
             conn.close()

--- a/app/modules/workspace/api_key_proxy.py
+++ b/app/modules/workspace/api_key_proxy.py
@@ -20,6 +20,7 @@ from typing import Any, cast
 
 from app.modules.workspace.api_key_router import APIKeyRouter
 from app.repositories.database import DB_PATH, is_postgresql
+from app.utils.datetime_utils import ensure_utc_suffix
 from app.utils.security_env import get_encryption_key_material
 from app.utils.tool_names import TOOL_NAME_ALIASES, normalize_tool_name
 
@@ -901,8 +902,8 @@ class APIKeyProxyService:
                     "key_name": row["key_name"],
                     "base_url": row["base_url"],
                     "is_active": bool(row["is_active"]),
-                    "created_at": row["created_at"],
-                    "updated_at": row["updated_at"],
+                    "created_at": ensure_utc_suffix(row["created_at"]),
+                    "updated_at": ensure_utc_suffix(row["updated_at"]),
                     "cli_tools": row["cli_tools"],
                     "cli_settings": row["cli_settings"],
                     "scope": row["scope"] or "remote",

--- a/app/modules/workspace/api_key_proxy.py
+++ b/app/modules/workspace/api_key_proxy.py
@@ -227,7 +227,8 @@ class APIKeyProxyService:
         # api_key_store table is created by migration, but ensure it exists for
         # environments that don't run migrations
         # Issue #1894: Added resolved_ips and resolved_at for SSRF protection
-        cursor.execute(f"""
+        cursor.execute(
+            f"""
             CREATE TABLE IF NOT EXISTS api_key_store (
                 id {id_type},
                 tenant_id INTEGER,
@@ -249,9 +250,11 @@ class APIKeyProxyService:
                 resolved_at TIMESTAMP,
                 UNIQUE(tenant_id, provider, key_name)
             )
-        """)
+        """
+        )
 
-        cursor.execute(f"""
+        cursor.execute(
+            f"""
             CREATE TABLE IF NOT EXISTS proxy_token_jtis (
                 id {id_type},
                 jti TEXT NOT NULL UNIQUE,
@@ -277,7 +280,8 @@ class APIKeyProxyService:
                 terminated_at TIMESTAMP,
                 termination_reason TEXT
             )
-        """)
+        """
+        )
         cursor.execute(
             "CREATE INDEX IF NOT EXISTS idx_proxy_token_jtis_session ON proxy_token_jtis(session_id)"
         )

--- a/app/modules/workspace/remote_agent_manager.py
+++ b/app/modules/workspace/remote_agent_manager.py
@@ -1452,6 +1452,7 @@ class RemoteAgentManager:
         command: str,
         session_id: str,
         timeout: float = 5.0,
+        extra: dict[str, Any] | None = None,
     ) -> dict | None:
         """
         Send a command to an agent and wait for a response.
@@ -1465,6 +1466,7 @@ class RemoteAgentManager:
             command: Command name (e.g., "get_session_info").
             session_id: Target session ID.
             timeout: Maximum wait time in seconds.
+            extra: Optional extra payload fields merged into the command.
 
         Returns:
             Response dict if received within timeout, None otherwise.
@@ -1479,15 +1481,15 @@ class RemoteAgentManager:
             }
 
         # Send the command
-        self.send_command(
-            machine_id,
-            {
-                "type": "command",
-                "command": command,
-                "session_id": session_id,
-                "request_id": request_id,
-            },
-        )
+        payload: dict[str, Any] = {
+            "type": "command",
+            "command": command,
+            "session_id": session_id,
+            "request_id": request_id,
+        }
+        if extra:
+            payload.update(extra)
+        self.send_command(machine_id, payload)
 
         # Wait for response. The in-process Event handles the same-pod fast
         # path; the DB poll handles non-sticky deployments where the agent's
@@ -2155,6 +2157,21 @@ class RemoteAgentManager:
         with self._lock:
             self._session_end_flags[session_id] = True
             self._last_delivered.pop(session_id, None)  # Cleanup SSE state
+
+    def clear_session_end_flag(self, session_id: str) -> None:
+        """Clear the in-memory session-ended flag when a session becomes active.
+
+        ``is_session_ended`` consults this flag before hitting the DB. The flag
+        is set when a session reaches completed/error/stopped (or is restored
+        from DB on startup) but was never cleared when the session went back to
+        active — which made the SSE /stream endpoint close immediately with
+        ``[DONE]`` after a restore, starving the webui of live output (Issue #2404).
+        """
+        with self._lock:
+            if self._session_end_flags.pop(session_id, None):
+                logger.info(
+                    "Cleared stale session-ended flag for %s", session_id[:8]
+                )
 
     def _log_session_ended_db_failure_cached(self, session_id: str, minute: int) -> None:
         """Log DB failure for is_session_ended with rate limiting (Issue #1823).

--- a/app/modules/workspace/remote_agent_manager.py
+++ b/app/modules/workspace/remote_agent_manager.py
@@ -2169,9 +2169,7 @@ class RemoteAgentManager:
         """
         with self._lock:
             if self._session_end_flags.pop(session_id, None):
-                logger.info(
-                    "Cleared stale session-ended flag for %s", session_id[:8]
-                )
+                logger.info("Cleared stale session-ended flag for %s", session_id[:8])
 
     def _log_session_ended_db_failure_cached(self, session_id: str, minute: int) -> None:
         """Log DB failure for is_session_ended with rate limiting (Issue #1823).

--- a/app/modules/workspace/remote_session_manager.py
+++ b/app/modules/workspace/remote_session_manager.py
@@ -490,6 +490,10 @@ class RemoteSessionManager:
                 ha_pool.get("model_key_ids", {}).get(model, []) if model else []
             )
         self._session_manager.update_session(session)
+        # Newly (re)created session is active — defensively clear any stale
+        # in-memory "ended" flag so the SSE /stream endpoint streams live
+        # output instead of closing with [DONE] (Issue #2404).
+        self._agent_manager.clear_session_end_flag(session_id)
 
         # Also update the dedicated columns (list_sessions reads from columns, not context JSON)
         try:
@@ -536,6 +540,235 @@ class RemoteSessionManager:
             "model": model,
             "created_at": session.created_at.isoformat() if session.created_at else None,
         }
+
+    def _get_ha_metadata(self, session_id: str) -> dict[str, Any]:
+        """Best-effort reuse of the original session's HA routing metadata.
+
+        Reads the most recent non-revoked proxy-token record for the session
+        and returns the HA routing fields (candidate keys / model key ids) so a
+        restored session keeps the same key routing as the original.
+        """
+        try:
+            from app.repositories.database import adapt_sql, get_db_connection
+
+            with get_db_connection() as conn:
+                cursor = conn.cursor()
+                cursor.execute(
+                    adapt_sql(
+                        "SELECT metadata FROM proxy_token_jtis "
+                        "WHERE session_id = ? AND revoked_at IS NULL AND consumed_at IS NULL "
+                        "ORDER BY issued_at DESC LIMIT 1"
+                    ),
+                    (session_id,),
+                )
+                row = cursor.fetchone()
+            if not row:
+                return {}
+            raw = row["metadata"] if isinstance(row, dict) else row[0]
+            if isinstance(raw, str):
+                try:
+                    meta = json.loads(raw)
+                except (json.JSONDecodeError, TypeError):
+                    return {}
+            elif isinstance(raw, dict):
+                meta = raw
+            else:
+                return {}
+            out: dict[str, Any] = {}
+            for key in ("ha_candidate_keys", "ha_model_key_ids", "ha_settings"):
+                if meta.get(key):
+                    out[key] = meta[key]
+            return out
+        except Exception as e:
+            logger.warning(f"Failed to load HA metadata for session {session_id}: {e}")
+            return {}
+
+    def resume_terminated_session(
+        self,
+        session_id: str,
+        machine_id: str,
+        project_path: str,
+        cli_tool: str,
+        user_id: int,
+        model: str | None = None,
+        created_at: str | None = None,
+        tenant_id: int | None = None,
+    ) -> bool:
+        """Restart a terminated remote CLI session with ``--resume``.
+
+        The CLI resume target is the CLI conversation id (the qwen JSONL
+        filename), which differs from the open-ace ``session_id``. Prefer the
+        persisted ``cli_session_id``; for historical sessions that predate the
+        capture, locate the JSONL on the remote machine by cwd + creation time.
+        A fresh proxy token is issued so the restored CLI can authenticate.
+
+        Returns True if the start command was dispatched successfully.
+        """
+        try:
+            agent_mgr = self._agent_manager
+            if not agent_mgr.is_connected(machine_id):
+                logger.warning(
+                    "resume_terminated_session: machine %s not connected", machine_id[:8]
+                )
+                return False
+
+            machine = agent_mgr.get_machine(machine_id)
+            effective_tenant_id = tenant_id or (machine.get("tenant_id") if machine else None) or 1
+
+            # Idempotency guard: if the session is already running on the agent,
+            # do not dispatch a duplicate start_session. A duplicate start would
+            # fail with "Session already running"; its error status round trip
+            # would mark the session failed and revoke the still-valid proxy
+            # token of the live CLI process, 401-ing its LLM requests (Issue #2405).
+            try:
+                info = agent_mgr.send_command_with_response(
+                    machine_id=machine_id,
+                    command="get_session_info",
+                    session_id=session_id,
+                    timeout=5.0,
+                )
+                if info and info.get("is_running"):
+                    if self._api_key_proxy.has_valid_proxy_token(session_id):
+                        # The running CLI still holds a valid proxy token; a
+                        # duplicate start would be a no-op anyway, so skip.
+                        logger.info(
+                            "resume_terminated_session: session %s already running on machine %s with valid token; skip resume",
+                            session_id[:8],
+                            machine_id[:8],
+                        )
+                        self._session_manager.update_session_fields(
+                            session_id,
+                            {"status": "active"},
+                            require_tenant=False,
+                        )
+                        self._agent_manager.clear_session_end_flag(session_id)
+                        return True
+                    # The process is alive but every proxy token issued for it
+                    # was revoked or expired (e.g. an earlier error round trip)
+                    # — its LLM calls would 401. Fall through and restart the
+                    # process with a freshly issued token (Issue #2405).
+                    logger.info(
+                        "resume_terminated_session: session %s running but proxy token invalid; restarting with a fresh token",
+                        session_id[:8],
+                    )
+            except Exception as e:
+                logger.warning(
+                    "resume_terminated_session: idempotency check failed for %s: %s",
+                    session_id[:8],
+                    e,
+                )
+
+            # Resolve the CLI conversation id to resume
+            cli_session_id = ""
+            try:
+                session = self._session_manager.get_session(
+                    session_id, include_messages=False
+                )
+                if session:
+                    cli_session_id = session.cli_session_id or ""
+            except Exception as e:
+                logger.warning(
+                    "resume_terminated_session: session lookup failed for %s: %s",
+                    session_id[:8],
+                    e,
+                )
+            if not cli_session_id:
+                # Normalize created_at to an ISO string — a DB datetime object
+                # is otherwise serialized to an RFC-style string when the
+                # command is persisted, which the agent cannot parse.
+                created_at_arg = None
+                if created_at is not None:
+                    created_at_arg = (
+                        created_at.isoformat()
+                        if isinstance(created_at, datetime)
+                        else str(created_at)
+                    )
+                found = agent_mgr.send_command_with_response(
+                    machine_id=machine_id,
+                    command="find_session_jsonl",
+                    session_id=session_id,
+                    timeout=8.0,
+                    extra={"project_path": project_path, "created_at": created_at_arg},
+                )
+                if found and found.get("session_id"):
+                    cli_session_id = str(found["session_id"])
+                    logger.info(
+                        "resume_terminated_session: located JSONL %s for session %s",
+                        cli_session_id[:8],
+                        session_id[:8],
+                    )
+            if not cli_session_id:
+                logger.warning(
+                    "resume_terminated_session: no cli_session_id for session %s",
+                    session_id[:8],
+                )
+                return False
+
+            provider = self._cli_tool_to_provider(cli_tool)
+
+            # Fresh proxy token; reuse original HA routing metadata when present.
+            extra_payload: dict[str, Any] = {
+                "scope": "remote",
+                "tool_name": "qwen-code" if normalize_tool_name(cli_tool) == "qwen" else normalize_tool_name(cli_tool),
+            }
+            extra_payload.update(self._get_ha_metadata(session_id))
+            proxy_token = self._api_key_proxy.generate_proxy_token(
+                user_id=user_id,
+                session_id=session_id,
+                tenant_id=effective_tenant_id,
+                provider=provider,
+                extra_payload=extra_payload,
+            )
+
+            # CLI settings for the restored tool
+            cli_settings: dict[str, Any] = {}
+            settings_tool = {
+                "claude": "claude-code",
+                "qwen": "qwen-code",
+                "codex": "codex-cli",
+                "openclaw": "openclaw",
+                "zcode": "zcode",
+            }.get(normalize_tool_name(cli_tool), cli_tool)
+            tool_settings = self._api_key_proxy.get_cli_settings_for_tool(
+                effective_tenant_id, settings_tool
+            )
+            if tool_settings:
+                cli_settings[settings_tool] = tool_settings
+
+            # Rebind and dispatch start_session with --resume target
+            agent_mgr.bind_session(session_id, machine_id)
+            command: dict[str, Any] = {
+                "type": "command",
+                "command": "start_session",
+                "session_id": session_id,
+                "project_path": project_path,
+                "model": model,
+                "cli_tool": cli_tool,
+                "proxy_token": proxy_token,
+                "cli_settings": cli_settings,
+                "resume_session_id": cli_session_id,
+            }
+            agent_mgr.send_command(machine_id, command)
+
+            self._session_manager.update_session_fields(
+                session_id,
+                {"status": "active", "cli_session_id": cli_session_id},
+                require_tenant=False,
+            )
+            # The session is now active again — clear any stale in-memory
+            # "ended" flag so the SSE /stream endpoint does not close with
+            # [DONE] immediately (Issue #2404).
+            self._agent_manager.clear_session_end_flag(session_id)
+            logger.info(
+                "Resumed terminated session %s (cli_session_id=%s) on machine %s",
+                session_id[:8],
+                cli_session_id[:8],
+                machine_id[:8],
+            )
+            return True
+        except Exception as e:
+            logger.exception("resume_terminated_session failed for %s: %s", session_id[:8], e)
+            return False
 
     def _get_machine_id(self, session_id: str) -> str | None:
         """Get machine_id for a session, with DB fallback on restart.

--- a/app/modules/workspace/remote_session_manager.py
+++ b/app/modules/workspace/remote_session_manager.py
@@ -591,7 +591,7 @@ class RemoteSessionManager:
         cli_tool: str,
         user_id: int,
         model: str | None = None,
-        created_at: str | None = None,
+        created_at: datetime | str | None = None,
         tenant_id: int | None = None,
     ) -> bool:
         """Restart a terminated remote CLI session with ``--resume``.

--- a/app/modules/workspace/remote_session_manager.py
+++ b/app/modules/workspace/remote_session_manager.py
@@ -661,9 +661,7 @@ class RemoteSessionManager:
             # Resolve the CLI conversation id to resume
             cli_session_id = ""
             try:
-                session = self._session_manager.get_session(
-                    session_id, include_messages=False
-                )
+                session = self._session_manager.get_session(session_id, include_messages=False)
                 if session:
                     cli_session_id = session.cli_session_id or ""
             except Exception as e:
@@ -709,7 +707,11 @@ class RemoteSessionManager:
             # Fresh proxy token; reuse original HA routing metadata when present.
             extra_payload: dict[str, Any] = {
                 "scope": "remote",
-                "tool_name": "qwen-code" if normalize_tool_name(cli_tool) == "qwen" else normalize_tool_name(cli_tool),
+                "tool_name": (
+                    "qwen-code"
+                    if normalize_tool_name(cli_tool) == "qwen"
+                    else normalize_tool_name(cli_tool)
+                ),
             }
             extra_payload.update(self._get_ha_metadata(session_id))
             proxy_token = self._api_key_proxy.generate_proxy_token(

--- a/remote-agent/agent.py
+++ b/remote-agent/agent.py
@@ -628,10 +628,53 @@ class RemoteAgent:
                         "result": info or {"error": "Session not found"},
                     }
                 )
+        elif command == "find_session_jsonl":
+            # Find JSONL session file by project path (Issue #2404)
+            self._cmd_find_session_jsonl(data)
         elif command == "rotate_token":
             self._cmd_rotate_token(data)
         else:
             logger.warning("Unknown command: %s", command)
+
+    def _cmd_find_session_jsonl(self, data: dict[str, Any]) -> None:
+        """Handle a find_session_jsonl command from the server.
+
+        Finds the CLI session ID (JSONL filename) for a historical session
+        that predates the cli_session_id capture. Used by session resume.
+        """
+        request_id = data.get("request_id")
+        if not request_id:
+            logger.warning("find_session_jsonl: missing request_id")
+            return
+
+        # Extract parameters from extra dict
+        extra = data.get("extra", {})
+        cli_tool = data.get("cli_tool", extra.get("cli_tool", "qwen-code"))
+        project_path = extra.get("project_path", "")
+        created_at = extra.get("created_at")
+
+        if not project_path:
+            self._http_send(
+                {
+                    "type": "command_response",
+                    "machine_id": self.config.machine_id,
+                    "request_id": request_id,
+                    "result": {"error": "Missing project_path"},
+                }
+            )
+            return
+
+        # Call executor to find the JSONL file
+        result = self._executor.find_session_jsonl(cli_tool, project_path, created_at)
+
+        self._http_send(
+            {
+                "type": "command_response",
+                "machine_id": self.config.machine_id,
+                "request_id": request_id,
+                "result": result or {"error": "Session JSONL not found"},
+            }
+        )
 
     def _cmd_rotate_token(self, data: dict[str, Any]) -> None:
         """Handle a rotate_token command from the server.

--- a/remote-agent/agent.py
+++ b/remote-agent/agent.py
@@ -664,14 +664,18 @@ class RemoteAgent:
         permission_mode = data.get("permission_mode")
         allowed_tools = data.get("allowed_tools")
         cli_settings = data.get("cli_settings", {})
+        # CLI conversation id to resume (qwen JSONL filename). Differs from the
+        # open-ace session_id; only set when restoring a terminated session.
+        resume_session_id = data.get("resume_session_id")
 
         logger.info(
-            "Starting session %s: cli=%s path=%s model=%s mode=%s",
+            "Starting session %s: cli=%s path=%s model=%s mode=%s resume=%s",
             session_id[:8],
             cli_tool,
             project_path,
             model,
             permission_mode,
+            resume_session_id[:8] if resume_session_id else None,
         )
 
         # Apply CLI settings before starting session
@@ -686,17 +690,63 @@ class RemoteAgent:
             model=model,
             permission_mode=permission_mode,
             allowed_tools=allowed_tools,
+            resume_session_id=resume_session_id,
         )
 
         if result["success"]:
-            self._send_session_status(session_id, "running", result.get("pid"))
+            pid = result.get("pid")
+            self._send_session_status(session_id, "running", pid)
+            # For new (non-resume) qwen sessions, once the CLI's self-generated
+            # conversation id is discovered, report it so the server persists
+            # cli_session_id for future --resume.
+            if not resume_session_id and cli_tool in ("qwen-code-cli", "qwen"):
+                self._executor.register_cli_session_callback(
+                    session_id,
+                    lambda cli_sid: self._send_session_status(
+                        session_id, "running", pid, cli_session_id=cli_sid
+                    ),
+                )
         else:
-            self._send_session_status(session_id, "error")
-            self._send_session_output(
-                session_id,
-                f"Failed to start session: {result.get('error', 'unknown error')}",
-                "stderr",
-                is_complete=True,
+            error_msg = result.get("error", "unknown error")
+            if error_msg == "Session already running":
+                # Idempotent duplicate start: the session is already running on
+                # this agent (e.g. an auto/periodic restore raced a manual one).
+                # Report running, NOT error — an error status makes the server
+                # mark the session failed and revoke all of its proxy tokens,
+                # which 401s the still-alive CLI process and leaves the webui
+                # stuck on "Thinking..." (Issue #2405).
+                logger.info(
+                    "Session %s already running; duplicate start treated as no-op",
+                    session_id[:8],
+                )
+                self._send_session_status(session_id, "running")
+            else:
+                self._send_session_status(session_id, "error")
+                self._send_session_output(
+                    session_id,
+                    f"Failed to start session: {error_msg}",
+                    "stderr",
+                    is_complete=True,
+                )
+
+        # Acknowledge the command so the server can mark it 'responded'. Without
+        # this ack, persisted commands stay 'delivered' forever and the server
+        # re-delivers them every COMMAND_CLAIM_TIMEOUT_SECONDS (5 minutes),
+        # causing duplicate start_session dispatches that can revoke the proxy
+        # token of an already-running CLI process (Issue #2405).
+        request_id = data.get("command_id") or data.get("request_id")
+        if request_id:
+            self._http_send(
+                {
+                    "type": "command_response",
+                    "machine_id": self.config.machine_id,
+                    "request_id": request_id,
+                    "result": {
+                        "success": bool(result.get("success")),
+                        "pid": result.get("pid"),
+                        "error": result.get("error"),
+                    },
+                }
             )
 
     def _cmd_send_message(self, data: dict[str, Any]) -> None:

--- a/remote-agent/agent.py
+++ b/remote-agent/agent.py
@@ -696,16 +696,6 @@ class RemoteAgent:
         if result["success"]:
             pid = result.get("pid")
             self._send_session_status(session_id, "running", pid)
-            # For new (non-resume) qwen sessions, once the CLI's self-generated
-            # conversation id is discovered, report it so the server persists
-            # cli_session_id for future --resume.
-            if not resume_session_id and cli_tool in ("qwen-code-cli", "qwen"):
-                self._executor.register_cli_session_callback(
-                    session_id,
-                    lambda cli_sid: self._send_session_status(
-                        session_id, "running", pid, cli_session_id=cli_sid
-                    ),
-                )
         else:
             error_msg = result.get("error", "unknown error")
             if error_msg == "Session already running":

--- a/remote-agent/executor.py
+++ b/remote-agent/executor.py
@@ -933,10 +933,30 @@ class ProcessExecutor:
         model: str | None = None,
         permission_mode: str | None = None,
         allowed_tools: list[str] | None = None,
+        resume_session_id: str | None = None,
     ) -> dict[str, Any]:
         with self._lock:
-            if session_id in self._sessions and self._sessions[session_id].is_running:
-                return {"success": False, "error": "Session already running"}
+            existing = self._sessions.get(session_id)
+            if existing and existing.is_running:
+                if resume_session_id:
+                    # Restore semantics: the server issued a fresh proxy token
+                    # and expects the process restarted with it. The old process
+                    # may still hold a revoked/expired token and would 401 every
+                    # LLM call (Issue #2405). Stop it and fall through to start
+                    # again with the new token + --resume below.
+                    self._sessions.pop(session_id, None)
+                else:
+                    return {"success": False, "error": "Session already running"}
+
+        if existing is not None and resume_session_id:
+            try:
+                existing.stop()
+            except Exception as e:
+                logger.warning("Failed to stop stale session %s: %s", session_id[:8], e)
+            logger.info(
+                "Session %s already running; restarting with a fresh proxy token for resume",
+                session_id[:8],
+            )
 
         # ZCode runs a persistent app-server process driven by its own stdio
         # protocol (ZCode Protocol), not Claude's stream-json stdin. Route it

--- a/remote-agent/executor.py
+++ b/remote-agent/executor.py
@@ -1743,9 +1743,7 @@ class ProcessExecutor:
 
         base_dir = tool_dir_map.get(cli_tool)
         if not base_dir or not base_dir.exists():
-            logger.debug(
-                "find_session_jsonl: no session directory for %s", cli_tool
-            )
+            logger.debug("find_session_jsonl: no session directory for %s", cli_tool)
             return None
 
         # Parse created_at timestamp if provided
@@ -1756,9 +1754,7 @@ class ProcessExecutor:
                 created_at_clean = created_at.rstrip("Z")
                 created_dt = datetime.fromisoformat(created_at_clean)
             except ValueError:
-                logger.debug(
-                    "find_session_jsonl: invalid created_at format: %s", created_at
-                )
+                logger.debug("find_session_jsonl: invalid created_at format: %s", created_at)
 
         # Search for JSONL files matching project path
         best_match = None

--- a/remote-agent/executor.py
+++ b/remote-agent/executor.py
@@ -1711,6 +1711,110 @@ class ProcessExecutor:
             "cli_session_id": session._cli_session_id,
         }
 
+    def find_session_jsonl(
+        self, cli_tool: str, project_path: str, created_at: str | None = None
+    ) -> dict[str, Any] | None:
+        """Find a JSONL session file by project path and creation time.
+
+        Used by resume_terminated_session to locate the CLI session ID
+        (the JSONL filename) for historical sessions that predate the
+        cli_session_id capture.
+
+        Args:
+            cli_tool: CLI tool name (qwen-code, claude-code, etc.)
+            project_path: Project directory path
+            created_at: Optional ISO timestamp to match file creation time
+
+        Returns:
+            Dict with session_id if found, None otherwise.
+        """
+        from datetime import datetime
+
+        # Map CLI tool to session directory
+        tool_dir_map = {
+            "qwen-code": Path.home() / ".qwen" / "projects",
+            "qwen-code-cli": Path.home() / ".qwen" / "projects",
+            "qwen": Path.home() / ".qwen" / "projects",
+            "claude-code": Path.home() / ".claude" / "projects",
+            "claude": Path.home() / ".claude" / "projects",
+            "codex-cli": Path.home() / ".codex" / "sessions",
+            "codex": Path.home() / ".codex" / "sessions",
+        }
+
+        base_dir = tool_dir_map.get(cli_tool)
+        if not base_dir or not base_dir.exists():
+            logger.debug(
+                "find_session_jsonl: no session directory for %s", cli_tool
+            )
+            return None
+
+        # Parse created_at timestamp if provided
+        created_dt = None
+        if created_at:
+            try:
+                # Handle ISO format with optional Z suffix
+                created_at_clean = created_at.rstrip("Z")
+                created_dt = datetime.fromisoformat(created_at_clean)
+            except ValueError:
+                logger.debug(
+                    "find_session_jsonl: invalid created_at format: %s", created_at
+                )
+
+        # Search for JSONL files matching project path
+        best_match = None
+        best_match_time = None
+
+        try:
+            # Look for chats subdirectory (Claude/Qwen structure)
+            for jsonl_path in base_dir.rglob("*.jsonl"):
+                # Check if project path matches (encoded in directory name)
+                path_str = str(jsonl_path)
+                if project_path and project_path not in path_str:
+                    # Try encoded version (hyphens for special chars)
+                    encoded_path = project_path.replace("/", "-").replace("_", "-")
+                    if encoded_path not in path_str:
+                        continue
+
+                # If created_at provided, check file modification time
+                if created_dt:
+                    try:
+                        file_stat = jsonl_path.stat()
+                        file_mtime = datetime.fromtimestamp(file_stat.st_mtime)
+                        # Allow 60 second tolerance
+                        time_diff = abs((file_mtime - created_dt).total_seconds())
+                        if time_diff > 60:
+                            continue
+
+                        # Track best match by time proximity
+                        if best_match_time is None or time_diff < best_match_time:
+                            best_match_time = time_diff
+                            best_match = jsonl_path
+                    except OSError:
+                        continue
+                else:
+                    # No time filter, use first match
+                    session_id = jsonl_path.stem
+                    logger.info(
+                        "find_session_jsonl: found %s for project %s",
+                        session_id[:8],
+                        project_path[:32],
+                    )
+                    return {"session_id": session_id}
+
+            if best_match:
+                session_id = best_match.stem
+                logger.info(
+                    "find_session_jsonl: found %s for project %s (matched by time)",
+                    session_id[:8],
+                    project_path[:32],
+                )
+                return {"session_id": session_id}
+
+        except Exception as e:
+            logger.warning("find_session_jsonl: search failed: %s", e)
+
+        return None
+
     def cleanup_stopped(self) -> list[str]:
         """
         Remove sessions whose processes have exited.

--- a/tests/unit/test_remote_session_restore_2404.py
+++ b/tests/unit/test_remote_session_restore_2404.py
@@ -1,0 +1,184 @@
+"""
+Unit tests for Issue #2404/#2405/#2406: Remote session restore functionality.
+
+Tests for:
+- clear_session_end_flag: Clear stale session end flag
+- has_valid_proxy_token: Check if session has valid proxy token
+
+Note: find_session_jsonl tests are in remote-agent tests (requires remote-agent module).
+"""
+
+import os
+import tempfile
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestClearSessionEndFlag:
+    """Tests for clear_session_end_flag in remote_agent_manager.py."""
+
+    @pytest.fixture
+    def mock_manager(self):
+        """Create a mock RemoteAgentManager."""
+        from app.modules.workspace.remote_agent_manager import RemoteAgentManager
+
+        manager = MagicMock(spec=RemoteAgentManager)
+        manager._session_end_flags = {}
+        manager._lock = MagicMock()
+        manager._lock.__enter__ = MagicMock(return_value=None)
+        manager._lock.__exit__ = MagicMock(return_value=None)
+
+        # Implement the actual method
+        def clear_session_end_flag(session_id: str) -> None:
+            with manager._lock:
+                if manager._session_end_flags.pop(session_id, None):
+                    pass  # Logger call omitted for test
+
+        manager.clear_session_end_flag = clear_session_end_flag
+        return manager
+
+    def test_clear_existing_flag(self, mock_manager):
+        """Test clearing an existing session end flag."""
+        session_id = "test-session-123"
+        mock_manager._session_end_flags[session_id] = True
+
+        mock_manager.clear_session_end_flag(session_id)
+
+        assert session_id not in mock_manager._session_end_flags
+
+    def test_clear_nonexistent_flag(self, mock_manager):
+        """Test clearing a non-existent flag (no error)."""
+        session_id = "nonexistent-session"
+
+        # Should not raise
+        mock_manager.clear_session_end_flag(session_id)
+
+        assert session_id not in mock_manager._session_end_flags
+
+
+class TestHasValidProxyToken:
+    """Tests for has_valid_proxy_token in api_key_proxy.py."""
+
+    @pytest.fixture
+    def mock_service(self):
+        """Create a mock APIKeyProxyService."""
+        from app.modules.workspace.api_key_proxy import APIKeyProxyService
+        from app.utils.encryption_key_registry import reset_registry
+
+        reset_registry()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "test.db")
+            with patch.dict(
+                os.environ, {"OPENACE_ENCRYPTION_KEY": "test-key-12345678901234567890123"}
+            ):
+                service = APIKeyProxyService(db_path=db_path)
+                yield service
+        reset_registry()
+
+    def test_has_valid_proxy_token_no_session(self, mock_service):
+        """Test returns False for empty session ID."""
+        result = mock_service.has_valid_proxy_token("")
+        assert result is False
+
+    def test_has_valid_proxy_token_no_token(self, mock_service):
+        """Test returns False when no token exists."""
+        result = mock_service.has_valid_proxy_token("nonexistent-session-id")
+        assert result is False
+
+    def test_has_valid_proxy_token_with_valid_token(self, mock_service):
+        """Test returns True when valid token exists."""
+        from datetime import datetime, timedelta
+
+        # Create a proxy token record
+        session_id = "test-session-valid-token"
+        now = datetime.now()
+        expires_at = now + timedelta(hours=4)
+
+        conn = mock_service._get_connection()
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            INSERT INTO proxy_token_jtis (
+                jti, token_hash, session_id, provider, session_type, expires_at
+            ) VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "test-jti-valid",
+                "test-hash-valid",
+                session_id,
+                "test-provider",
+                "agent",
+                expires_at.isoformat(),
+            ),
+        )
+        conn.commit()
+        conn.close()
+
+        result = mock_service.has_valid_proxy_token(session_id)
+        assert result is True
+
+    def test_has_valid_proxy_token_with_expired_token(self, mock_service):
+        """Test returns False when token is expired."""
+        from datetime import datetime, timedelta
+
+        session_id = "test-session-expired-token"
+        now = datetime.now()
+        expires_at = now - timedelta(hours=1)  # Expired
+
+        conn = mock_service._get_connection()
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            INSERT INTO proxy_token_jtis (
+                jti, token_hash, session_id, provider, session_type, expires_at
+            ) VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "test-jti-expired",
+                "test-hash-expired",
+                session_id,
+                "test-provider",
+                "agent",
+                expires_at.isoformat(),
+            ),
+        )
+        conn.commit()
+        conn.close()
+
+        result = mock_service.has_valid_proxy_token(session_id)
+        assert result is False
+
+    def test_has_valid_proxy_token_with_revoked_token(self, mock_service):
+        """Test returns False when token is revoked."""
+        from datetime import datetime, timedelta
+
+        session_id = "test-session-revoked-token"
+        now = datetime.now()
+        expires_at = now + timedelta(hours=4)
+
+        conn = mock_service._get_connection()
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            INSERT INTO proxy_token_jtis (
+                jti, token_hash, session_id, provider, session_type, expires_at, revoked_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "test-jti-revoked",
+                "test-hash-revoked",
+                session_id,
+                "test-provider",
+                "agent",
+                expires_at.isoformat(),
+                now.isoformat(),  # revoked_at
+            ),
+        )
+        conn.commit()
+        conn.close()
+
+        result = mock_service.has_valid_proxy_token(session_id)
+        assert result is False


### PR DESCRIPTION
# Issue #2404+#2405+#2406: 远程会话恢复完整性

本 PR 修复远程会话恢复相关的3个关键问题。

## #2404: 恢复会话后 SSE 一直转圈

**根因**：gunicorn HUP reload 时 `_restore_in_memory_state` 把 DB 中 completed/error/stopped 会话全部写入 `_session_end_flags`（内存标记，只增不清）；会话恢复 active 后 `is_session_ended` 内存优先命中 → SSE 立即关闭

**修复**：
- `remote_agent_manager.py`: 新增 `clear_session_end_flag()`（pop 内存标记）
- `remote_session_manager.py`: 会话置 active / resume 成功 / 新建会话共 4 处调用点清除标记

## #2405: 恢复会话发消息报 401 token 失效

**根因**：`_cmd_start_session` 执行后只回 session_status、从不回 command_response ack → 命令永远 `delivered` → 每 5 分钟重新投递 → 旧 agent 代码把重复 start_session 的幂等情况报为 error → 服务器置会话 error → 连坐撤销该会话全部 proxy token

**修复**：
- `agent.py` `_cmd_start_session`: 结束前发送 command_response ack
- `executor.py` `start_session`: 带 `resume_session_id` 且已在运行 → 停旧进程、用新 token + `--resume` 重启
- `api_key_proxy.py`: 新增 `has_valid_proxy_token()`
- `remote_session_manager.py` `resume_terminated_session`: 幂等检查区分"有效 token 跳过" / "无 token 走恢复自愈"

## #2406: 恢复远程会话报 500 错误

**根因**：Issue #2407 的读取兜底过滤对 messages 元素直接调 `.get("role")`，但 `session_manager.get_messages` 返回的是 `SessionMessage` dataclass（有 `.role`/`.content`，无 `.get`）→ AttributeError → 500

**注意**：此修复已在 PR-2 (#2419) 中实现，本 PR 不重复修改 `remote.py`

## 拆分说明

本 PR 拆分自 #2414，作者为 papercatno1。

**Original Author:** papercatno1

Generated with Qwen Code