### PR TITLE
fix(autonomous): release delivered workflow queue slots (#2431)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,7 @@ jobs:
       - name: Issue regression suites (opt-in; see norecursedirs)
         timeout-minutes: 5
         run: |
-          pytest tests/issues/2403 tests/issues/2428 -v \
+          pytest tests/issues/2403 tests/issues/2428 tests/issues/2431 -v \
             -m "not postgres and not performance"
 
       - name: Upload coverage to Codecov

--- a/app/repositories/autonomous_repo.py
+++ b/app/repositories/autonomous_repo.py
@@ -1303,6 +1303,53 @@ class AutonomousWorkflowRepository:
         finally:
             conn.close()
 
+    def acquire_cleanup_lock(self, workflow_id: str, owner: str) -> bool:
+        """Atomically lock a workflow for destructive Git cleanup (#2431).
+
+        Unlike :meth:`acquire_lock`, a stale timestamp is not enough to break a
+        lock on ``verification_pending`` at all, even after the generic
+        30-minute timeout. Agent tasks may legitimately run for 60 minutes and
+        clear ``agent_pid`` before the same advance finishes its mechanical
+        gates, so PID alone is not a sufficient lease. A stale lock is only
+        recoverable here after the workflow is terminal ``completed`` and has no
+        agent PID; active verification rows are left for the scheduler's normal
+        advance/recovery path to release.
+        """
+        import app.repositories.database as _db_mod
+
+        now_dt = datetime.now(timezone.utc)
+        now = now_dt.strftime("%Y-%m-%d %H:%M:%S")
+        cutoff = (now_dt - timedelta(seconds=self.LOCK_TIMEOUT_SECONDS)).strftime(
+            "%Y-%m-%d %H:%M:%S"
+        )
+
+        conn = self.db.get_connection()
+        try:
+            cursor = conn.cursor()
+            cursor.execute(
+                _db_mod.adapt_sql(
+                    """
+                    UPDATE autonomous_workflows
+                    SET locked_at = ?, locked_by = ?
+                    WHERE workflow_id = ?
+                      AND (
+                        locked_at IS NULL
+                        OR (
+                          locked_at < ?
+                          AND status = 'completed'
+                          AND (agent_pid IS NULL OR agent_pid <= 0)
+                        )
+                      )
+                    """
+                ),
+                (now, owner, workflow_id, cutoff),
+            )
+            rowcount = cursor.rowcount
+            conn.commit()
+            return rowcount > 0
+        finally:
+            conn.close()
+
     def release_lock(self, workflow_id: str, owner: str) -> None:
         """Release the lock, but only if we are the owner."""
         import app.repositories.database as _db_mod

--- a/app/repositories/autonomous_repo.py
+++ b/app/repositories/autonomous_repo.py
@@ -183,6 +183,9 @@ class AutonomousWorkflowRepository:
             "reporting",
             "waiting",
             "merging",
+            # #2431: a workflow parked at acceptance_verification can still own
+            # an agent PID, so the startup orphan sweep must consider it.
+            "verification_pending",
         )
         placeholders = ", ".join(["?"] * len(active_statuses))
         conn = self.db.get_connection()
@@ -563,15 +566,22 @@ class AutonomousWorkflowRepository:
     def get_workflows_pending_cleanup(self) -> list:
         """Get delivered workflows whose Git cleanup is still pending (#2043).
 
-        Returns ``status='completed'`` rows with ``cleanup_status='pending'`` so
-        the startup sweep and scheduler retry pass can re-attempt worktree/branch
-        removal. Ordered by ``cleanup_updated_at`` so the oldest failures retry
-        first. Legacy rows (NULL cleanup_status) are excluded.
+        Returns delivered rows with ``cleanup_status='pending'`` so the startup
+        sweep and scheduler retry pass can re-attempt worktree/branch removal.
+        Ordered by ``cleanup_updated_at`` so the oldest failures retry first.
+        Legacy rows (NULL cleanup_status) are excluded.
+
+        ``verification_pending`` counts as delivered (#2431): the PR is merged
+        by the time the workflow reaches acceptance_verification, so its cleanup
+        is just as due as a completed workflow's. Excluding it left the sweep
+        blind for the entire parked window. The caller skips workflows the
+        scheduler is currently advancing — see ``_is_in_flight``.
         """
         return self.db.fetch_all(
             """
             SELECT * FROM autonomous_workflows
-            WHERE status = 'completed' AND cleanup_status = 'pending'
+            WHERE status IN ('completed', 'verification_pending')
+              AND cleanup_status = 'pending'
             ORDER BY cleanup_updated_at ASC NULLS LAST, created_at ASC
             """
         )

--- a/app/services/autonomous_scheduler.py
+++ b/app/services/autonomous_scheduler.py
@@ -107,6 +107,7 @@ QUEUE_BLOCKING_STATUSES = {"paused", "cancelled"}
 # ``cleanup_status='completed'`` and an EMPTY ``worktree_path``, so the working
 # tree really is released by the time the workflow gets here.
 DELIVERED_PHASES = frozenset({"acceptance_verification"})
+_TERMINAL_ACCEPTANCE_STATUSES = frozenset({"confirmed", "rejected", "indeterminate"})
 
 
 def _slot_released(wf: dict) -> bool:
@@ -116,7 +117,17 @@ def _slot_released(wf: dict) -> bool:
     tree. Once the merge phase completes the branch is on main and the worktree
     is released, so the next sibling is free to start.
     """
-    return (wf.get("current_phase") or "") in DELIVERED_PHASES
+    if (wf.get("current_phase") or "") not in DELIVERED_PHASES:
+        return False
+    # A manual pause can freeze the verifier before its handler returns. It is
+    # not delivered yet: resume SIGCONTs that same agent. Only a persisted
+    # terminal acceptance verdict proves that a paused handler has finished and
+    # the batch/conflict slot may be handed to a sibling.
+    if wf.get("status") == "paused":
+        if wf.get("agent_pid"):
+            return False
+        return (wf.get("verification_status") or "") in _TERMINAL_ACCEPTANCE_STATUSES
+    return True
 
 
 # Prefix written to error_message when a workflow is paused because its owner
@@ -383,6 +394,13 @@ class AutonomousScheduler:
             except Exception:
                 w = None
             if w and w.get("status") == "paused":
+                # Any acceptance workflow still present in _in_progress_ids is
+                # inside advance(), even if a prior terminal verdict remains on
+                # the row while a changed issue is being re-verified. A manual
+                # pause resumes that same verifier via SIGCONT, so keep every
+                # conflict key until advance()'s finally releases them.
+                if w.get("current_phase") == "acceptance_verification":
+                    continue
                 paused.append(w)
 
         if not paused:
@@ -1118,15 +1136,12 @@ def _reconcile_pending_transitions():
 
 
 def _is_in_flight(workflow_id: str) -> bool:
-    """Whether the scheduler is currently advancing this workflow (#2431).
+    """Whether this process is currently advancing the workflow (#2431).
 
-    The cleanup sweep runs on the scheduler thread at the top of every tick and
-    takes neither the in-progress set nor the DB lock, while
-    ``_perform_git_cleanup`` removes the worktree AND the branch. That was safe
-    only because ``status='completed'`` rows are never advanced. Once the sweep
-    also returns rows that CAN advance, an in-flight acceptance verification —
-    an LLM agent call lasting minutes — could have its worktree deleted out from
-    under it. Cheap to check, and it hardens the pre-existing path too.
+    This is the cheap same-process guard. The cleanup sweep also acquires the
+    workflow's distributed DB lock immediately before deleting anything, which
+    closes the rolling-restart / multiple-scheduler race this singleton cannot
+    observe.
     """
     instance = AutonomousScheduler._instance
     if instance is None:
@@ -1138,12 +1153,13 @@ def _is_in_flight(workflow_id: str) -> bool:
 def _retry_pending_git_cleanups(repo=None):
     """Re-attempt post-merge Git cleanup for delivered workflows (#2043).
 
-    Walks every ``status='completed'`` workflow with ``cleanup_status='pending'``
-    and re-runs the idempotent ``_perform_git_cleanup``. Honors the per-workflow
+    Walks every delivered workflow with ``cleanup_status='pending'`` and re-runs
+    the idempotent ``_perform_git_cleanup``. Honors the per-workflow
     ``cleanup_next_retry_at`` backoff so a transient failure is not retried every
     tick. This is shared by the startup sweep and the periodic scheduler tick so
-    both converge leaked worktrees/branches without a separate worker. Failures
-    are isolated per workflow.
+    both converge leaked worktrees/branches without a separate worker. The
+    workflow DB lock serializes cleanup with advances in every scheduler process;
+    failures are isolated per workflow.
 
     ``repo`` lets the periodic tick reuse the scheduler's own (mock-friendly)
     repository; the startup sweep omits it and constructs one.
@@ -1179,7 +1195,22 @@ def _retry_pending_git_cleanups(repo=None):
                     due = now
                 if due > now:
                     continue
+            # Serialize cleanup against an advance in every scheduler process.
+            # The in-memory check above cannot see an old worker during a
+            # rolling restart, while every advance holds this same DB lock.
+            # Acquiring it here makes the final check atomic: either cleanup
+            # owns the workflow and may remove its git resources, or the active
+            # verifier owns it and cleanup defers to the next tick.
+            cleanup_lock_owner = (
+                f"{socket.gethostname()}/cleanup-{os.getpid()}-"
+                f"{threading.current_thread().name}"
+            )
+            lock_acquired = False
             try:
+                lock_acquired = repo.acquire_cleanup_lock(wf_id, cleanup_lock_owner)
+                if not lock_acquired:
+                    logger.debug("Skipping cleanup sweep for DB-locked workflow %s", wf_id[:8])
+                    continue
                 orchestrator = AutonomousOrchestrator(wf_id)
                 orchestrator._perform_git_cleanup()
             except Exception as e:  # noqa: BLE001
@@ -1189,6 +1220,16 @@ def _retry_pending_git_cleanups(repo=None):
                     e,
                     exc_info=True,
                 )
+            finally:
+                if lock_acquired:
+                    try:
+                        repo.release_lock(wf_id, cleanup_lock_owner)
+                    except Exception as e:  # noqa: BLE001
+                        logger.warning(
+                            "Failed to release cleanup lock for workflow %s: %s",
+                            wf_id[:8],
+                            e,
+                        )
 
         logger.info("Processed %d pending Git cleanup(s)", len(pending))
     except Exception as e:  # noqa: BLE001

--- a/app/services/autonomous_scheduler.py
+++ b/app/services/autonomous_scheduler.py
@@ -90,6 +90,35 @@ RUNNING_BATCH_STATUSES = {
 QUEUE_ADVANCE_STATUSES = {"waiting", "completed", "failed", "planning_timeout"}
 QUEUE_BLOCKING_STATUSES = {"paused", "cancelled"}
 
+# Phases at or past which the workflow's PR is already merged and its git
+# working tree released, so a batch sibling may start even though this workflow
+# has not reached a terminal status. (#2431)
+#
+# Keyed on PHASE, not status, deliberately. A workflow resting in
+# acceptance_verification can carry several different statuses —
+# verification_pending (parked awaiting the verifier), paused (an
+# ``indeterminate`` verdict), failed, completed — and for queueing purposes they
+# all mean the same thing: the merge is done, nothing downstream needs the slot.
+# Enumerating those statuses in QUEUE_ADVANCE_STATUSES instead would have to be
+# redone every time the phase grows an outcome, and would still miss ``paused``,
+# which QUEUE_BLOCKING_STATUSES rejects one branch earlier.
+#
+# Verified against production: every parked row carries
+# ``cleanup_status='completed'`` and an EMPTY ``worktree_path``, so the working
+# tree really is released by the time the workflow gets here.
+DELIVERED_PHASES = frozenset({"acceptance_verification"})
+
+
+def _slot_released(wf: dict) -> bool:
+    """Whether this workflow has stopped occupying its batch's execution slot.
+
+    The batch queue exists only to keep two agents out of the same git working
+    tree. Once the merge phase completes the branch is on main and the worktree
+    is released, so the next sibling is free to start.
+    """
+    return (wf.get("current_phase") or "") in DELIVERED_PHASES
+
+
 # Prefix written to error_message when a workflow is paused because its owner
 # exceeded quota. The scheduler auto-resumes only workflows paused with this
 # prefix — a user's manual pause (error_message empty / different text) is left
@@ -736,10 +765,23 @@ class AutonomousScheduler:
 
             previous_workflow = batch_workflows[queued_index - 1]
             previous_status = previous_workflow.get("status")
-            if previous_status in QUEUE_BLOCKING_STATUSES or previous_status == "queued":
+            # These two block regardless of phase. `cancelled` is an operator
+            # decision — a stopped batch must not resurrect itself just because
+            # the head happened to reach acceptance — and a `queued` predecessor
+            # has not run at all.
+            if previous_status in ("cancelled", "queued"):
                 continue
-            if previous_status not in QUEUE_ADVANCE_STATUSES:
-                continue
+            # A predecessor past the merge phase releases the queue whatever its
+            # status: it holds no worktree. Without this a workflow parked in
+            # `verification_pending` — which is in NEITHER status set — stalls
+            # the entire remainder of the batch indefinitely, and an
+            # `indeterminate` acceptance verdict re-stalls it under the name
+            # `paused`, which the blocking set rejects one branch earlier. #2431
+            if not _slot_released(previous_workflow):
+                if previous_status in QUEUE_BLOCKING_STATUSES:
+                    continue
+                if previous_status not in QUEUE_ADVANCE_STATUSES:
+                    continue
 
             repo.update_workflow(workflow["workflow_id"], {"status": "pending"})
             _emit_event_safe(workflow["workflow_id"], "status_change", {"status": "pending"})
@@ -1075,6 +1117,24 @@ def _reconcile_pending_transitions():
         logger.error("Worktree transition reconcile sweep failed: %s", e, exc_info=True)
 
 
+def _is_in_flight(workflow_id: str) -> bool:
+    """Whether the scheduler is currently advancing this workflow (#2431).
+
+    The cleanup sweep runs on the scheduler thread at the top of every tick and
+    takes neither the in-progress set nor the DB lock, while
+    ``_perform_git_cleanup`` removes the worktree AND the branch. That was safe
+    only because ``status='completed'`` rows are never advanced. Once the sweep
+    also returns rows that CAN advance, an in-flight acceptance verification —
+    an LLM agent call lasting minutes — could have its worktree deleted out from
+    under it. Cheap to check, and it hardens the pre-existing path too.
+    """
+    instance = AutonomousScheduler._instance
+    if instance is None:
+        return False
+    with instance._in_progress_lock:
+        return workflow_id in instance._in_progress_ids
+
+
 def _retry_pending_git_cleanups(repo=None):
     """Re-attempt post-merge Git cleanup for delivered workflows (#2043).
 
@@ -1104,6 +1164,9 @@ def _retry_pending_git_cleanups(repo=None):
         for wf in pending:
             wf_id = wf.get("workflow_id")
             if not isinstance(wf_id, str) or not wf_id:
+                continue
+            if _is_in_flight(wf_id):
+                logger.debug("Skipping cleanup sweep for in-flight workflow %s", wf_id[:8])
                 continue
             # Backoff: skip until cleanup_next_retry_at has passed.
             next_retry = wf.get("cleanup_next_retry_at") or ""

--- a/tests/issues/2431/test_parked_state_is_observable.py
+++ b/tests/issues/2431/test_parked_state_is_observable.py
@@ -13,7 +13,9 @@ advanced. So the guard is part of the same change, not a follow-up.
 
 from __future__ import annotations
 
+import sqlite3
 import threading
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
 from app.repositories.autonomous_repo import AutonomousWorkflowRepository
@@ -47,8 +49,11 @@ class TestMaintenanceQueriesSeeParkedWorkflows:
 
 
 class TestCleanupSweepDoesNotRaceAnAdvance:
-    def _run_sweep(self, in_progress: set[str]) -> MagicMock:
+    def _run_sweep(
+        self, in_progress: set[str], *, db_lock_available: bool = True
+    ) -> tuple[MagicMock, MagicMock]:
         repo = MagicMock()
+        repo.acquire_cleanup_lock.return_value = db_lock_available
         repo.get_workflows_pending_cleanup.return_value = [
             {"workflow_id": "wf-parked", "cleanup_next_retry_at": ""}
         ]
@@ -64,19 +69,113 @@ class TestCleanupSweepDoesNotRaceAnAdvance:
             ),
         ):
             _retry_pending_git_cleanups(repo)
-        return orchestrator
+        return repo, orchestrator
 
     def test_in_flight_workflow_is_not_swept(self):
         """Deleting the worktree under a running verifier is the failure mode."""
-        orchestrator = self._run_sweep({"wf-parked"})
+        repo, orchestrator = self._run_sweep({"wf-parked"})
         orchestrator._perform_git_cleanup.assert_not_called()
+        repo.acquire_cleanup_lock.assert_not_called()
 
     def test_idle_workflow_is_still_swept(self):
         """The guard must not disable the sweep it is protecting."""
-        orchestrator = self._run_sweep(set())
+        repo, orchestrator = self._run_sweep(set())
         orchestrator._perform_git_cleanup.assert_called_once()
+        repo.acquire_cleanup_lock.assert_called_once()
+        repo.release_lock.assert_called_once()
+
+    def test_other_scheduler_db_lock_blocks_cleanup(self):
+        """A fresh lock in another process must protect its live verifier.
+
+        A rolling restart creates a new scheduler whose singleton starts empty;
+        only the distributed workflow lock crosses that process boundary.
+        """
+        repo, orchestrator = self._run_sweep(set(), db_lock_available=False)
+        orchestrator._perform_git_cleanup.assert_not_called()
+        repo.acquire_cleanup_lock.assert_called_once()
+        repo.release_lock.assert_not_called()
 
     def test_no_scheduler_instance_does_not_block_the_startup_sweep(self):
         """The startup sweep runs before the singleton exists."""
         with patch.object(AutonomousScheduler, "_instance", None):
             assert _is_in_flight("anything") is False
+
+    def test_manual_acceptance_pause_keeps_conflict_slots(self):
+        """SIGCONT-able verifier must keep batch/workspace/branch reservations."""
+        scheduler = AutonomousScheduler.__new__(AutonomousScheduler)
+        scheduler._in_progress_ids = {"wf-parked"}
+        scheduler._in_progress_batch_ids = {"batch-1"}
+        scheduler._in_progress_workspaces = {"/tmp/verify"}
+        scheduler._in_progress_branches = {"verify-branch"}
+        scheduler._in_progress_lock = threading.Lock()
+        repo = MagicMock()
+        repo.get_workflow.return_value = {
+            "workflow_id": "wf-parked",
+            "status": "paused",
+            "current_phase": "acceptance_verification",
+            # A prior terminal verdict can remain while an edited issue causes
+            # a new verifier run. in_progress/agent_pid remain authoritative.
+            "verification_status": "indeterminate",
+            "agent_pid": 4242,
+            "batch_id": "batch-1",
+            "worktree_path": "/tmp/verify",
+            "branch_name": "verify-branch",
+        }
+
+        scheduler._reclaim_paused_slots(repo)
+
+        assert "wf-parked" in scheduler._in_progress_ids
+        assert "batch-1" in scheduler._in_progress_batch_ids
+        assert "/tmp/verify" in scheduler._in_progress_workspaces
+        assert "verify-branch" in scheduler._in_progress_branches
+
+
+class _SQLiteDB:
+    def __init__(self, path: str):
+        self.path = path
+
+    def get_connection(self):
+        return sqlite3.connect(self.path)
+
+
+def test_cleanup_lock_does_not_break_stale_live_agent_lease(tmp_path):
+    """A 60-minute verifier remains protected past the generic 30-minute TTL."""
+    db_path = str(tmp_path / "cleanup-lock.db")
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """CREATE TABLE autonomous_workflows (
+            workflow_id TEXT PRIMARY KEY,
+            status TEXT NOT NULL,
+            locked_at TEXT,
+            locked_by TEXT,
+            agent_pid INTEGER
+        )"""
+    )
+    stale = (datetime.now(timezone.utc) - timedelta(minutes=31)).strftime("%Y-%m-%d %H:%M:%S")
+    conn.executemany(
+        "INSERT INTO autonomous_workflows VALUES (?, ?, ?, ?, ?)",
+        [
+            ("live", "verification_pending", stale, "old-worker", 4242),
+            # PID has already cleared, but the same verification advance can
+            # still be running mechanical gates for the remainder of its hour.
+            ("post-agent", "verification_pending", stale, "old-worker", None),
+            ("orphan", "completed", stale, "dead-worker", None),
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+    repo = AutonomousWorkflowRepository(_SQLiteDB(db_path))
+    with patch("app.repositories.database.adapt_sql", side_effect=lambda sql: sql):
+        assert repo.acquire_cleanup_lock("live", "cleanup") is False
+        assert repo.acquire_cleanup_lock("post-agent", "cleanup") is False
+        assert repo.acquire_cleanup_lock("orphan", "cleanup") is True
+
+    conn = sqlite3.connect(db_path)
+    rows = dict(conn.execute("SELECT workflow_id, locked_by FROM autonomous_workflows"))
+    conn.close()
+    assert rows == {
+        "live": "old-worker",
+        "post-agent": "old-worker",
+        "orphan": "cleanup",
+    }

--- a/tests/issues/2431/test_parked_state_is_observable.py
+++ b/tests/issues/2431/test_parked_state_is_observable.py
@@ -1,0 +1,82 @@
+"""Issue #2431: the parked state must be visible to the sweeps that maintain it.
+
+`verification_pending` was excluded from every maintenance query, so for the
+whole parked window the workflow was invisible to Git cleanup retry (#2043) and
+to the startup orphan-PID sweep.
+
+Widening the cleanup query introduces a race that did not exist before: it runs
+on the scheduler thread every tick, takes neither the in-progress set nor the DB
+lock, and `_perform_git_cleanup` removes the worktree AND the branch. That was
+safe only while the query returned `status='completed'` rows, which are never
+advanced. So the guard is part of the same change, not a follow-up.
+"""
+
+from __future__ import annotations
+
+import threading
+from unittest.mock import MagicMock, patch
+
+from app.repositories.autonomous_repo import AutonomousWorkflowRepository
+from app.services.autonomous_scheduler import (
+    AutonomousScheduler,
+    _is_in_flight,
+    _retry_pending_git_cleanups,
+)
+
+
+class TestMaintenanceQueriesSeeParkedWorkflows:
+    def test_cleanup_query_includes_verification_pending(self):
+        db = MagicMock()
+        db.fetch_all.return_value = []
+        AutonomousWorkflowRepository(db).get_workflows_pending_cleanup()
+        sql = db.fetch_all.call_args[0][0]
+        assert "verification_pending" in sql, (
+            "a workflow parked at acceptance_verification has a merged PR and a "
+            "due cleanup; excluding it leaves the retry sweep blind"
+        )
+        assert "cleanup_status = 'pending'" in sql
+
+    def test_active_pid_query_includes_verification_pending(self):
+        db = MagicMock()
+        conn = MagicMock()
+        db.get_connection.return_value = conn
+        conn.cursor.return_value.fetchall.return_value = []
+        AutonomousWorkflowRepository(db).get_workflows_with_active_pid()
+        params = conn.cursor.return_value.execute.call_args[0][1]
+        assert "verification_pending" in params
+
+
+class TestCleanupSweepDoesNotRaceAnAdvance:
+    def _run_sweep(self, in_progress: set[str]) -> MagicMock:
+        repo = MagicMock()
+        repo.get_workflows_pending_cleanup.return_value = [
+            {"workflow_id": "wf-parked", "cleanup_next_retry_at": ""}
+        ]
+        scheduler = AutonomousScheduler.__new__(AutonomousScheduler)
+        scheduler._in_progress_ids = in_progress
+        scheduler._in_progress_lock = threading.Lock()
+        orchestrator = MagicMock()
+        with (
+            patch.object(AutonomousScheduler, "_instance", scheduler),
+            patch(
+                "app.modules.workspace.autonomous.orchestrator.AutonomousOrchestrator",
+                return_value=orchestrator,
+            ),
+        ):
+            _retry_pending_git_cleanups(repo)
+        return orchestrator
+
+    def test_in_flight_workflow_is_not_swept(self):
+        """Deleting the worktree under a running verifier is the failure mode."""
+        orchestrator = self._run_sweep({"wf-parked"})
+        orchestrator._perform_git_cleanup.assert_not_called()
+
+    def test_idle_workflow_is_still_swept(self):
+        """The guard must not disable the sweep it is protecting."""
+        orchestrator = self._run_sweep(set())
+        orchestrator._perform_git_cleanup.assert_called_once()
+
+    def test_no_scheduler_instance_does_not_block_the_startup_sweep(self):
+        """The startup sweep runs before the singleton exists."""
+        with patch.object(AutonomousScheduler, "_instance", None):
+            assert _is_in_flight("anything") is False

--- a/tests/issues/2431/test_queue_advances_past_delivered.py
+++ b/tests/issues/2431/test_queue_advances_past_delivered.py
@@ -1,0 +1,111 @@
+"""Issue #2431: a workflow parked at acceptance_verification must not stall its batch.
+
+#2335 added an ``acceptance_verification`` phase and, via
+``orchestrator.PHASE_STATUS_MAP``, a ``verification_pending`` status. That
+string was added to exactly one line of production code and to none of the sets
+that make the system act on a workflow. In ``_promote_queued_workflows`` it is
+in NEITHER ``QUEUE_ADVANCE_STATUSES`` nor ``QUEUE_BLOCKING_STATUSES``, so the
+"not in advance" branch stalls every queued sibling behind it, forever.
+
+Measured in production on 2026-08-08: workflow ``f332e86f`` (issue #2329, PR
+#2426) sat in ``verification_pending`` at ``current_phase='acceptance_verification'``
+with ``cleanup_status='completed'`` and an EMPTY ``worktree_path``, holding five
+siblings (#2330-#2334) at ``queued`` for over 14 hours. No agent had spawned in
+that window at all.
+
+The fix keys on PHASE rather than status, because the same rest point can carry
+verification_pending / paused / failed / completed and all of them mean "the
+merge is done, the worktree is released, the slot is free".
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from app.services.autonomous_scheduler import (
+    QUEUE_ADVANCE_STATUSES,
+    QUEUE_BLOCKING_STATUSES,
+    AutonomousScheduler,
+    _slot_released,
+)
+
+
+def _wf(wid: str, status: str, phase: str, order: int) -> dict:
+    return {
+        "workflow_id": wid,
+        "status": status,
+        "current_phase": phase,
+        "batch_id": "b1",
+        "batch_order": order,
+    }
+
+
+def _promote(head: dict) -> bool:
+    """Run one promotion pass over a 2-workflow batch; True if the tail started."""
+    tail = _wf("tail", "queued", "preparation", 2)
+    repo = MagicMock()
+    repo.get_queued_workflows.return_value = [tail]
+    repo.list_batch_workflows.return_value = [head, tail]
+    scheduler = AutonomousScheduler.__new__(AutonomousScheduler)
+    scheduler._promote_queued_workflows(repo)
+    return any(
+        call.args[0] == "tail" and call.args[1].get("status") == "pending"
+        for call in repo.update_workflow.call_args_list
+    )
+
+
+class TestDeliveredPredecessorsReleaseTheQueue:
+    def test_verification_pending_head_no_longer_stalls_the_batch(self):
+        """The incident itself."""
+        assert _promote(_wf("head", "verification_pending", "acceptance_verification", 1))
+
+    def test_paused_at_acceptance_also_releases(self):
+        """The `indeterminate` verdict pauses the workflow.
+
+        `paused` is in QUEUE_BLOCKING_STATUSES, which is tested one branch
+        EARLIER than the advance set, so fixing only the advance set would
+        re-stall the batch under a different status name.
+        """
+        assert _promote(_wf("head", "paused", "acceptance_verification", 1))
+
+    def test_failed_at_acceptance_releases(self):
+        assert _promote(_wf("head", "failed", "acceptance_verification", 1))
+
+
+class TestNonDeliveredPredecessorsStillBlock:
+    def test_paused_mid_flight_still_holds_the_queue(self):
+        """A user's manual pause during development must still block.
+
+        This is the guard against over-broadening: the fix must key on the
+        phase, not simply drop `paused` from the blocking set.
+        """
+        assert not _promote(_wf("head", "paused", "development", 1))
+
+    def test_developing_head_still_holds_the_queue(self):
+        assert not _promote(_wf("head", "developing", "development", 1))
+
+    def test_cancelled_at_acceptance_still_blocks(self):
+        """An operator stopped this batch; reaching acceptance must not revive it."""
+        assert not _promote(_wf("head", "cancelled", "acceptance_verification", 1))
+
+    def test_queued_head_still_blocks(self):
+        assert not _promote(_wf("head", "queued", "preparation", 1))
+
+
+class TestPredicate:
+    def test_only_acceptance_verification_counts_as_delivered(self):
+        for phase in ("preparation", "planning", "development", "pr_review", "report", "merge"):
+            assert not _slot_released({"current_phase": phase}), phase
+        assert _slot_released({"current_phase": "acceptance_verification"})
+
+    def test_missing_or_null_phase_is_not_delivered(self):
+        """Legacy rows must fall through to the original status-based logic."""
+        assert not _slot_released({})
+        assert not _slot_released({"current_phase": None})
+        assert not _slot_released({"current_phase": ""})
+
+    def test_status_sets_are_untouched(self):
+        """The fix adds a branch; it must not quietly re-define the old sets."""
+        assert {"waiting", "completed", "failed", "planning_timeout"} == QUEUE_ADVANCE_STATUSES
+        assert {"paused", "cancelled"} == QUEUE_BLOCKING_STATUSES
+        assert "verification_pending" not in QUEUE_ADVANCE_STATUSES

--- a/tests/issues/2431/test_queue_advances_past_delivered.py
+++ b/tests/issues/2431/test_queue_advances_past_delivered.py
@@ -30,11 +30,12 @@ from app.services.autonomous_scheduler import (
 )
 
 
-def _wf(wid: str, status: str, phase: str, order: int) -> dict:
+def _wf(wid: str, status: str, phase: str, order: int, *, verification_status: str = "") -> dict:
     return {
         "workflow_id": wid,
         "status": status,
         "current_phase": phase,
+        "verification_status": verification_status,
         "batch_id": "b1",
         "batch_order": order,
     }
@@ -66,7 +67,15 @@ class TestDeliveredPredecessorsReleaseTheQueue:
         EARLIER than the advance set, so fixing only the advance set would
         re-stall the batch under a different status name.
         """
-        assert _promote(_wf("head", "paused", "acceptance_verification", 1))
+        assert _promote(
+            _wf(
+                "head",
+                "paused",
+                "acceptance_verification",
+                1,
+                verification_status="indeterminate",
+            )
+        )
 
     def test_failed_at_acceptance_releases(self):
         assert _promote(_wf("head", "failed", "acceptance_verification", 1))
@@ -80,6 +89,10 @@ class TestNonDeliveredPredecessorsStillBlock:
         phase, not simply drop `paused` from the blocking set.
         """
         assert not _promote(_wf("head", "paused", "development", 1))
+
+    def test_manually_paused_acceptance_verifier_still_holds_the_queue(self):
+        """A pause before the verifier returns has no terminal verdict yet."""
+        assert not _promote(_wf("head", "paused", "acceptance_verification", 1))
 
     def test_developing_head_still_holds_the_queue(self):
         assert not _promote(_wf("head", "developing", "development", 1))
@@ -97,6 +110,22 @@ class TestPredicate:
         for phase in ("preparation", "planning", "development", "pr_review", "report", "merge"):
             assert not _slot_released({"current_phase": phase}), phase
         assert _slot_released({"current_phase": "acceptance_verification"})
+        assert not _slot_released({"status": "paused", "current_phase": "acceptance_verification"})
+        assert _slot_released(
+            {
+                "status": "paused",
+                "current_phase": "acceptance_verification",
+                "verification_status": "indeterminate",
+            }
+        )
+        assert not _slot_released(
+            {
+                "status": "paused",
+                "current_phase": "acceptance_verification",
+                "verification_status": "indeterminate",
+                "agent_pid": 4242,
+            }
+        )
 
     def test_missing_or_null_phase_is_not_delivered(self):
         """Legacy rows must fall through to the original status-based logic."""

--- a/tests/unit/test_git_cleanup_2043.py
+++ b/tests/unit/test_git_cleanup_2043.py
@@ -241,6 +241,7 @@ def test_startup_retries_pending_git_cleanup():
     from app.services.autonomous_scheduler import _retry_pending_git_cleanups
 
     fake_repo = MagicMock()
+    fake_repo.acquire_cleanup_lock.return_value = True
     fake_repo.get_workflows_pending_cleanup.return_value = [
         {
             "workflow_id": "wf-a",
@@ -264,6 +265,8 @@ def test_startup_retries_pending_git_cleanup():
         _retry_pending_git_cleanups()
     fake_repo.get_workflows_pending_cleanup.assert_called_once()
     mock_orch._perform_git_cleanup.assert_called_once()
+    fake_repo.acquire_cleanup_lock.assert_called_once()
+    fake_repo.release_lock.assert_called_once()
 
 
 def test_sandbox_destroy_does_not_complete_git_cleanup():


### PR DESCRIPTION
## Root cause

Issue #2335 introduced the `acceptance_verification` phase and the
`verification_pending` status, but that status was not added to the scheduler's
queue-advance logic or the maintenance queries that operate on delivered work.
In production, workflow `f332e86f` (issue #2329 / PR #2426) therefore parked at
acceptance verification and held five queued batch siblings for more than 14
hours, even though its PR was already merged, cleanup was complete, and its
worktree path was empty.

## What this PR changes (PR A of the #2431 plan)

- Treat `acceptance_verification` as a delivered phase for batch-slot purposes.
  This is keyed on phase rather than status so `verification_pending`,
  `paused`, `failed`, and `completed` all release the slot after merge.
- Preserve the operator stop boundary: `cancelled` and `queued` predecessors
  still block regardless of phase; paused workflows earlier in the lifecycle
  still block.
- Include parked workflows in pending-cleanup retry and startup orphan-PID
  discovery.
- Prevent the widened cleanup sweep from deleting a worktree/branch while the
  scheduler is actively advancing that workflow, including across scheduler
  processes and past the generic 30-minute stale-lock cutoff.
- Keep batch/workspace/branch reservations when an acceptance verifier is
  manually paused and will later resume via SIGCONT; only settled acceptance
  pauses release the queue slot.
- Opt `tests/issues/2431` into required CI alongside #2403 and #2428 (the global
  `tests/issues` exclusion remains tracked by #2429).

This PR deliberately does **not** make `verification_pending` scheduler-active
and does not add `PHASE_TO_STATUS`. Those belong together in PR B; adding the
route mapping first would remove the last active fallback and create another
dead end. PR B will drain parked rows with acceptance verification disabled by
default. PR C will repair the verifier before enabling it.

## Impact

Merging and deploying this PR releases the stalled batch so #2330-#2334 can
start, while keeping the three parked verification rows unchanged until PR B.

## Validation

- `337 passed`: #2403, #2428, #2431, #1002 scheduler locking, autonomous
  phase/contract suites, readiness guardrails, and cleanup regression tests.
- Independent review reruns: CI issue suites `91/91`; #2431 + #2043 `30/30`.
- Full pre-commit set passed except Bandit, which is skipped locally because the
  hook environment cannot find a `python` executable; CI runs Bandit normally.
- Pollution-sensitive A/B against clean `origin/main`: both sides produced the
  exact same 8 failures + 1 error; **zero branch-only failures**.
- Six implementation mutations were checked during development; all were caught
  by the #2431 tests.

## Plan review

The original plan was independently reviewed and rejected with five blocking
findings. The accepted v2 sequencing addresses them: fetch/verification is
deferred to PR C, verifier-off drain to PR B, `PHASE_TO_STATUS` is excluded here,
and this PR includes the cleanup in-flight guard. The full findings and final PR
review disposition will be posted as PR comments before merge.
