### PR TITLE
fix(autonomous): drain verification pending workflows (#2431)

### DIFF
--- a/app/modules/workspace/autonomous/models.py
+++ b/app/modules/workspace/autonomous/models.py
@@ -102,6 +102,7 @@ class AutonomousWorkflow:
         "reporting",
         "waiting",
         "merging",
+        "verification_pending",
         "queued",
     )
 

--- a/app/modules/workspace/autonomous/phases/acceptance_verification.py
+++ b/app/modules/workspace/autonomous/phases/acceptance_verification.py
@@ -1,6 +1,8 @@
 """acceptance_verification phase handler (#2335).
 
-Independent post-merge verification: the workflow does NOT auto-close the issue
+Independent post-merge verification. The feature is opt-in while its gates are
+being hardened; when disabled, the handler completes immediately without
+running the verifier or changing the issue. When enabled, the workflow does NOT auto-close the issue
 on merge (autonomous PRs use ``Implements #N``, not ``Closes #N``). Instead this
 phase spawns a credentialless read-only verifier on the merged main SHA, runs a
 deterministic scope gate, aggregates per-item verdicts, and only closes the
@@ -35,6 +37,7 @@ from app.modules.workspace.autonomous.acceptance_snapshot import (
 from app.modules.workspace.autonomous.acceptance_verdicts import ItemVerdict, aggregate_verdicts
 from app.modules.workspace.autonomous.evidence import Verdict
 from app.modules.workspace.autonomous.phase_contract import PhaseResult
+from app.utils.config import is_acceptance_verification_enabled
 
 VERIFIED_BY = "acceptance-verifier-v1"
 
@@ -168,6 +171,12 @@ def _already_verified_for(wf: dict, merge_sha: str, snap_hash: str) -> dict | No
 
 
 def handle(ctx, deps) -> PhaseResult:
+    # Keep this guard before all context/dependency access. Parked production
+    # rows may have already released their worktrees and must drain safely while
+    # the verifier is opt-in.
+    if not is_acceptance_verification_enabled():
+        return PhaseResult.completed(next_phase="completed")
+
     wf = ctx.workflow
     issue_number = wf.get("github_issue_number")
     pr_number = wf.get("github_pr_number")

--- a/app/repositories/autonomous_repo.py
+++ b/app/repositories/autonomous_repo.py
@@ -553,12 +553,18 @@ class AutonomousWorkflowRepository:
         return where, params
 
     def get_active_workflows(self) -> list:
-        """Get all workflows that need processing."""
+        """Get all workflows that need processing.
+
+        ``verification_pending`` must remain paired with the
+        ``acceptance_verification`` phase/status mapping so delivered rows can
+        run the default-off drain path instead of becoming dead ends.
+        """
         return self.db.fetch_all(
             """
             SELECT * FROM autonomous_workflows
             WHERE status IN ('pending', 'preparing', 'planning', 'developing',
-                             'pr_review', 'reporting', 'waiting', 'merging')
+                             'pr_review', 'reporting', 'waiting', 'merging',
+                             'verification_pending')
             ORDER BY created_at ASC
             """
         )
@@ -597,7 +603,8 @@ class AutonomousWorkflowRepository:
             SELECT COUNT(*) as count FROM autonomous_workflows
             WHERE user_id = ? AND status IN ('pending', 'preparing', 'planning',
                                               'developing', 'pr_review', 'reporting',
-                                              'waiting', 'merging')
+                                              'waiting', 'merging',
+                                              'verification_pending')
             """,
             (user_id,),
         )

--- a/app/routes/autonomous.py
+++ b/app/routes/autonomous.py
@@ -172,6 +172,7 @@ PHASE_TO_STATUS = {
     "report": "reporting",
     "wait": "waiting",
     "merge": "merging",
+    "acceptance_verification": "verification_pending",
 }
 
 ISSUE_URL_RE = re.compile(r"^https://github\.com/[^/\s]+/[^/\s]+/issues/(\d+)(?:[/?#].*)?$", re.I)

--- a/app/services/autonomous_scheduler.py
+++ b/app/services/autonomous_scheduler.py
@@ -76,6 +76,7 @@ ACTIVE_WORKFLOW_STATUSES = {
     "reporting",
     "waiting",
     "merging",
+    "verification_pending",
 }
 
 RUNNING_BATCH_STATUSES = {

--- a/app/utils/config.py
+++ b/app/utils/config.py
@@ -76,6 +76,18 @@ def is_autonomous_enabled() -> bool:
     return bool(get_config_value("autonomous", "enabled", True))
 
 
+def is_acceptance_verification_enabled() -> bool:
+    """Check whether post-merge acceptance verification is enabled.
+
+    The verifier remains opt-in while its scope and legacy-pattern gates are
+    being hardened.  Keeping the default disabled lets workflows already
+    parked at ``verification_pending`` drain safely to completion.
+    """
+    # Fail closed: JSON strings such as "false" are truthy in Python and must
+    # never accidentally enable a verifier that is intentionally opt-in.
+    return get_config_value("autonomous", "acceptance_verification_enabled", False) is True
+
+
 def is_run_timeline_enabled() -> bool:
     """Check whether the persisted remote-session run timeline feature is enabled.
 

--- a/frontend/src/components/work/AutonomousWorkflowList.test.tsx
+++ b/frontend/src/components/work/AutonomousWorkflowList.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen, act } from '@/test/utils';
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { AutonomousWorkflowList } from './AutonomousWorkflowList';
+import { ACTIVE_WORKFLOW_STATUSES, AutonomousWorkflowList } from './AutonomousWorkflowList';
 import { useWorkflows } from '@/hooks/useAutonomous';
 import type { AutonomousWorkflow } from '@/api/autonomous';
 
@@ -115,7 +115,21 @@ describe('AutonomousWorkflowList', () => {
 
     const lastFilters = lastWorkflowFilters();
     expect(lastFilters?.status).toContain('pending');
+    expect(lastFilters?.status).toContain('verification_pending');
     expect(lastFilters?.status).not.toContain('queued');
+  });
+
+  it('renders verification_pending as an active acceptance state', () => {
+    mockWorkflowList([
+      workflow({ status: 'verification_pending', current_phase: 'acceptance_verification' }),
+    ]);
+
+    render(
+      <AutonomousWorkflowList selectedId={null} onSelect={vi.fn()} onClearSelection={vi.fn()} />
+    );
+
+    expect(ACTIVE_WORKFLOW_STATUSES).toContain('verification_pending');
+    expect(screen.getByText('Verifying acceptance')).toBeInTheDocument();
   });
 
   it('sends debounced search and resets to the first page', () => {

--- a/frontend/src/components/work/AutonomousWorkflowList.tsx
+++ b/frontend/src/components/work/AutonomousWorkflowList.tsx
@@ -37,6 +37,11 @@ const STATUS_CONFIG: Record<string, { variant: string; icon: string; labelKey: s
   reporting: { variant: 'info', icon: 'bi-file-text', labelKey: 'autoStatusReporting' },
   waiting: { variant: 'secondary', icon: 'bi-clock', labelKey: 'autoStatusWaiting' },
   merging: { variant: 'info', icon: 'bi-sign-merge-right', labelKey: 'autoStatusMerging' },
+  verification_pending: {
+    variant: 'info',
+    icon: 'bi-shield-check',
+    labelKey: 'autoStatusVerificationPending',
+  },
   completed: { variant: 'success', icon: 'bi-check-circle', labelKey: 'autoStatusCompleted' },
   failed: { variant: 'danger', icon: 'bi-x-circle', labelKey: 'autoStatusFailed' },
   cancelled: { variant: 'secondary', icon: 'bi-slash-circle', labelKey: 'autoStatusCancelled' },
@@ -59,13 +64,14 @@ export const ACTIVE_WORKFLOW_STATUSES = [
   'reporting',
   'waiting',
   'merging',
+  'verification_pending',
 ];
 
 const STATUS_FILTER_TABS = [
   { key: '', labelKey: 'autoFilterAll' },
   { key: 'queued', labelKey: 'autoFilterQueued' },
   {
-    key: 'pending,preparing,planning,developing,pr_review,reporting,waiting,merging,paused,planning_timeout',
+    key: 'pending,preparing,planning,developing,pr_review,reporting,waiting,merging,verification_pending,paused,planning_timeout',
     labelKey: 'autoFilterActive',
   },
   { key: 'completed', labelKey: 'autoFilterCompleted' },

--- a/frontend/src/components/work/WorkflowTimeline.tsx
+++ b/frontend/src/components/work/WorkflowTimeline.tsx
@@ -52,7 +52,9 @@ import type { Language } from '@/types';
 import {
   findForkMilestoneIndex,
   formatTokens,
+  getActiveStatusHintKey,
   getActivityHostMilestoneId,
+  getWorkflowPhaseLabelKey,
   getWorkflowSessionIdForMilestone,
   isAiMilestoneType,
   isDisplayableTimelineActivity,
@@ -105,27 +107,6 @@ const MILESTONE_DISPLAY: Record<string, { icon: string; color: string }> = {
 // worth viewing after the run finishes (the live activity stream is run-time only).
 const PLAN_CONTENT_TYPES = ['plan_created', 'plan_refined', 'plan_finalized'];
 const REVIEW_CONTENT_TYPES = ['plan_reviewed', 'pr_reviewed', 'pr_review_summary'];
-const PHASE_LABEL_KEYS: Record<string, string> = {
-  preparation: 'autoPhasePreparation',
-  planning: 'autoPhasePlanning',
-  development: 'autoPhaseDevelopment',
-  pr_review: 'autoPhasePRReview',
-  report: 'autoPhaseReport',
-  wait: 'autoPhaseWait',
-  merge: 'autoPhaseMerge',
-};
-
-const ACTIVE_STATUS_HINT_KEYS: Record<string, string> = {
-  queued: 'autoActiveHintQueued',
-  pending: 'autoActiveHintPending',
-  preparing: 'autoActiveHintPreparing',
-  planning: 'autoActiveHintPlanning',
-  developing: 'autoActiveHintDeveloping',
-  pr_review: 'autoActiveHintPrReview',
-  reporting: 'autoActiveHintReporting',
-  merging: 'autoActiveHintMerging',
-};
-
 const MILESTONE_ICON_COLORS: Record<string, string> = {
   dark: 'var(--text-primary)',
   info: 'var(--color-info)',
@@ -1065,12 +1046,9 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = ({
     milestones.length > 0 ? getMilestoneAnchorTime(milestones[0]) : workflow.created_at;
   const workflowStatusConfig = getAutonomousWorkflowStatusConfig(workflow.status);
   const workflowStatusLabel = t(workflowStatusConfig.labelKey, language);
-  const workflowPhaseLabel = t(
-    PHASE_LABEL_KEYS[workflow.current_phase] ?? 'autoPhasePreparation',
-    language
-  );
+  const workflowPhaseLabel = t(getWorkflowPhaseLabelKey(workflow.current_phase), language);
   const isLiveStatus = ACTIVE_WORKFLOW_STATUSES.includes(workflow.status);
-  const activeStatusHintKey = ACTIVE_STATUS_HINT_KEYS[workflow.status];
+  const activeStatusHintKey = getActiveStatusHintKey(workflow.status);
   const activeStatusHint = activeStatusHintKey ? t(activeStatusHintKey, language) : '';
   const latestMilestoneWithSession = [...milestones]
     .reverse()

--- a/frontend/src/components/work/WorkflowTimeline.utils.test.ts
+++ b/frontend/src/components/work/WorkflowTimeline.utils.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from 'vitest';
 
 import {
   findForkMilestoneIndex,
+  getActiveStatusHintKey,
   getActivityHostMilestoneId,
+  getWorkflowPhaseLabelKey,
   getWorkflowSessionIdForMilestone,
   isAiMilestoneType,
   isDisplayableTimelineActivity,
@@ -11,6 +13,17 @@ import {
 } from './WorkflowTimeline.utils';
 
 describe('WorkflowTimeline.utils', () => {
+  it('labels and explains the acceptance verification state', () => {
+    expect(getWorkflowPhaseLabelKey('acceptance_verification')).toBe(
+      'autoPhaseAcceptanceVerification'
+    );
+    expect(getActiveStatusHintKey('verification_pending')).toBe(
+      'autoActiveHintVerificationPending'
+    );
+    expect(getWorkflowPhaseLabelKey('unknown-phase')).toBe('autoPhasePreparation');
+    expect(getActiveStatusHintKey('completed')).toBeUndefined();
+  });
+
   it('filters empty assistant placeholders without hiding real activity events', () => {
     expect(isDisplayableTimelineActivity({ type: 'assistant' })).toBe(false);
     expect(isDisplayableTimelineActivity({ type: 'assistant', text: '   ' })).toBe(false);

--- a/frontend/src/components/work/WorkflowTimeline.utils.ts
+++ b/frontend/src/components/work/WorkflowTimeline.utils.ts
@@ -243,3 +243,33 @@ export function findForkMilestoneIndex(
 }
 
 export { formatTokens };
+const PHASE_LABEL_KEYS: Record<string, string> = {
+  preparation: 'autoPhasePreparation',
+  planning: 'autoPhasePlanning',
+  development: 'autoPhaseDevelopment',
+  pr_review: 'autoPhasePRReview',
+  report: 'autoPhaseReport',
+  wait: 'autoPhaseWait',
+  merge: 'autoPhaseMerge',
+  acceptance_verification: 'autoPhaseAcceptanceVerification',
+};
+
+const ACTIVE_STATUS_HINT_KEYS: Record<string, string> = {
+  queued: 'autoActiveHintQueued',
+  pending: 'autoActiveHintPending',
+  preparing: 'autoActiveHintPreparing',
+  planning: 'autoActiveHintPlanning',
+  developing: 'autoActiveHintDeveloping',
+  pr_review: 'autoActiveHintPrReview',
+  reporting: 'autoActiveHintReporting',
+  merging: 'autoActiveHintMerging',
+  verification_pending: 'autoActiveHintVerificationPending',
+};
+
+export function getWorkflowPhaseLabelKey(phase: string): string {
+  return PHASE_LABEL_KEYS[phase] ?? 'autoPhasePreparation';
+}
+
+export function getActiveStatusHintKey(status: string): string | undefined {
+  return ACTIVE_STATUS_HINT_KEYS[status];
+}

--- a/frontend/src/components/work/autonomousWorkflowStatus.test.ts
+++ b/frontend/src/components/work/autonomousWorkflowStatus.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+
+import { getAutonomousWorkflowStatusConfig } from './autonomousWorkflowStatus';
+
+describe('autonomousWorkflowStatus', () => {
+  it('does not fall back to Pending for verification_pending', () => {
+    expect(getAutonomousWorkflowStatusConfig('verification_pending')).toMatchObject({
+      labelKey: 'autoStatusVerificationPending',
+      icon: 'bi-shield-check',
+      tone: 'info',
+    });
+  });
+});

--- a/frontend/src/components/work/autonomousWorkflowStatus.ts
+++ b/frontend/src/components/work/autonomousWorkflowStatus.ts
@@ -62,6 +62,12 @@ export const AUTONOMOUS_WORKFLOW_STATUS_CONFIG: Record<string, AutonomousWorkflo
     labelKey: 'autoStatusMerging',
     tone: 'info',
   },
+  verification_pending: {
+    variant: 'info',
+    icon: 'bi-shield-check',
+    labelKey: 'autoStatusVerificationPending',
+    tone: 'info',
+  },
   completed: {
     variant: 'success',
     icon: 'bi-check-circle',

--- a/frontend/src/i18n/index.test.ts
+++ b/frontend/src/i18n/index.test.ts
@@ -183,10 +183,22 @@ describe('i18n', () => {
       'logout',
     ];
 
+    const acceptanceVerificationKeys = [
+      'autoStatusVerificationPending',
+      'autoPhaseAcceptanceVerification',
+      'autoActiveHintVerificationPending',
+    ];
+
     it.each(languages)('should have all essential keys in %s', (lang) => {
       essentialKeys.forEach((key) => {
         const translation = t(key, lang);
         expect(translation).not.toBe(key);
+      });
+    });
+
+    it.each(languages)('should describe acceptance verification in %s', (lang) => {
+      acceptanceVerificationKeys.forEach((key) => {
+        expect(t(key, lang)).not.toBe(key);
       });
     });
 

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -1613,6 +1613,7 @@ export const translations: Record<Language, Translations> = {
     autoStatusReporting: 'Reporting',
     autoStatusWaiting: 'Waiting',
     autoStatusMerging: 'Merging',
+    autoStatusVerificationPending: 'Verifying acceptance',
     autoStatusCompleted: 'Completed',
     autoStatusFailed: 'Failed',
     autoStatusCancelled: 'Cancelled',
@@ -1642,6 +1643,7 @@ export const translations: Record<Language, Translations> = {
     autoPhaseReport: 'Report',
     autoPhaseWait: 'Waiting',
     autoPhaseMerge: 'Merge',
+    autoPhaseAcceptanceVerification: 'Acceptance verification',
     autoTimeline: 'Timeline',
     autoRoundLabel: 'Round',
     autoDevRoundLabel: 'Development Round',
@@ -1752,6 +1754,8 @@ export const translations: Record<Language, Translations> = {
     autoActiveHintReporting:
       'Summarizing this round’s outputs and conclusions before switching to the next state.',
     autoActiveHintMerging: 'Merging the final changes and wrapping up this workflow.',
+    autoActiveHintVerificationPending:
+      'Finalizing the delivered workflow after its post-merge acceptance checkpoint.',
     autoBannerPaused: 'This workflow is paused. Resume it to continue the remaining steps.',
     autoAcceptanceOverrideTitle: 'Acceptance pending human review',
     autoAcceptanceOverrideDesc:
@@ -3406,6 +3410,7 @@ export const translations: Record<Language, Translations> = {
     autoStatusReporting: '报告生成',
     autoStatusWaiting: '等待需求',
     autoStatusMerging: '合并中',
+    autoStatusVerificationPending: '验收确认中',
     autoStatusCompleted: '已完成',
     autoStatusFailed: '失败',
     autoStatusCancelled: '已取消',
@@ -3434,6 +3439,7 @@ export const translations: Record<Language, Translations> = {
     autoPhaseReport: '进度报告',
     autoPhaseWait: '等待需求',
     autoPhaseMerge: '合并',
+    autoPhaseAcceptanceVerification: '验收确认',
     autoTimeline: '时间线',
     autoRoundLabel: '轮次',
     autoDevRoundLabel: '开发轮次',
@@ -3535,6 +3541,7 @@ export const translations: Record<Language, Translations> = {
     autoActiveHintPrReview: '正在审查实现结果并整理最终变更，完成后会进入收尾阶段。',
     autoActiveHintReporting: '正在整理本轮产出和结论，随后会切换到下一状态。',
     autoActiveHintMerging: '正在合并最终变更并收尾当前工作流。',
+    autoActiveHintVerificationPending: '正在通过合并后的验收检查点，并完成已交付工作流的收尾。',
     autoBannerPaused: '当前工作流已暂停，恢复后会继续执行剩余步骤。',
     autoAcceptanceOverrideTitle: '验收待人工复核',
     autoAcceptanceOverrideDesc:
@@ -4946,6 +4953,7 @@ export const translations: Record<Language, Translations> = {
     autoStatusReporting: 'レポート',
     autoStatusWaiting: '要件待ち',
     autoStatusMerging: 'マージ中',
+    autoStatusVerificationPending: '受け入れ確認中',
     autoStatusCompleted: '完了',
     autoStatusFailed: '失敗',
     autoStatusCancelled: 'キャンセル',
@@ -4975,6 +4983,7 @@ export const translations: Record<Language, Translations> = {
     autoPhaseReport: 'レポート',
     autoPhaseWait: '待機',
     autoPhaseMerge: 'マージ',
+    autoPhaseAcceptanceVerification: '受け入れ確認',
     autoTimeline: 'タイムライン',
     autoRoundLabel: 'ラウンド',
     autoDevRoundLabel: '開発ラウンド',
@@ -5081,6 +5090,8 @@ export const translations: Record<Language, Translations> = {
     autoActiveHintPrReview: '実装内容をレビューし、完了前の最終変更を整えています。',
     autoActiveHintReporting: 'このラウンドの成果と結論を整理してから次の状態へ進みます。',
     autoActiveHintMerging: '最終変更をマージして、このワークフローを締めくくっています。',
+    autoActiveHintVerificationPending:
+      'マージ後の受け入れチェックポイントを通過し、完了処理を進めています。',
     autoBannerPaused: 'このワークフローは一時停止中です。再開すると残りのステップを続行します。',
     autoAcceptanceOverrideTitle: '承認確認が人間のレビューを待っています',
     autoAcceptanceOverrideDesc:
@@ -6615,6 +6626,7 @@ export const translations: Record<Language, Translations> = {
     autoStatusReporting: '보고서',
     autoStatusWaiting: '요구사항 대기',
     autoStatusMerging: '병합 중',
+    autoStatusVerificationPending: '인수 확인 중',
     autoStatusCompleted: '완료',
     autoStatusFailed: '실패',
     autoStatusCancelled: '취소됨',
@@ -6644,6 +6656,7 @@ export const translations: Record<Language, Translations> = {
     autoPhaseReport: '보고서',
     autoPhaseWait: '대기',
     autoPhaseMerge: '병합',
+    autoPhaseAcceptanceVerification: '인수 확인',
     autoTimeline: '타임라인',
     autoRoundLabel: '라운드',
     autoDevRoundLabel: '개발 라운드',
@@ -6751,6 +6764,8 @@ export const translations: Record<Language, Translations> = {
     autoActiveHintPrReview: '구현 결과를 검토하고 완료 전에 최종 변경을 정리하는 중입니다.',
     autoActiveHintReporting: '이번 라운드의 산출물과 결론을 정리한 뒤 다음 상태로 전환합니다.',
     autoActiveHintMerging: '최종 변경을 병합하고 이 워크플로를 마무리하는 중입니다.',
+    autoActiveHintVerificationPending:
+      '병합 후 인수 확인 단계를 통과하고 전달된 워크플로를 마무리하고 있습니다.',
     autoBannerPaused: '이 워크플로는 일시정지 상태입니다. 재개하면 남은 단계를 계속 진행합니다.',
     autoAcceptanceOverrideTitle: '수락 확인이 사람 검토를 기다리는 중',
     autoAcceptanceOverrideDesc:

--- a/tests/issues/2335/conftest.py
+++ b/tests/issues/2335/conftest.py
@@ -1,0 +1,15 @@
+"""Run the original #2335 verifier tests with the opt-in feature enabled."""
+
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _enable_acceptance_verification():
+    with patch(
+        "app.modules.workspace.autonomous.phases.acceptance_verification."
+        "is_acceptance_verification_enabled",
+        return_value=True,
+    ):
+        yield

--- a/tests/issues/2431/test_drain_verification_pending.py
+++ b/tests/issues/2431/test_drain_verification_pending.py
@@ -1,0 +1,128 @@
+"""Issue #2431 PR B: parked verification rows must drain safely.
+
+The scheduler query and phase/status mapping are an atomic change.  Once the
+row is selected, the acceptance handler's default-off guard must run before it
+touches workflow context or verifier dependencies and complete the workflow.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from unittest.mock import MagicMock, patch
+
+from app.modules.workspace.autonomous.models import AutonomousWorkflow
+from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+from app.modules.workspace.autonomous.phases import acceptance_verification as av
+from app.repositories.autonomous_repo import AutonomousWorkflowRepository
+from app.routes.autonomous import PHASE_TO_STATUS
+from app.services.autonomous_scheduler import ACTIVE_WORKFLOW_STATUSES
+from app.utils import config as config_module
+
+
+class _SQLiteDB:
+    def __init__(self, path: str):
+        self.path = path
+
+    def _connect(self):
+        conn = sqlite3.connect(self.path)
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def fetch_all(self, sql: str, params=()):
+        with self._connect() as conn:
+            return [dict(row) for row in conn.execute(sql, params).fetchall()]
+
+    def fetch_one(self, sql: str, params=()):
+        with self._connect() as conn:
+            row = conn.execute(sql, params).fetchone()
+            return dict(row) if row is not None else None
+
+
+def _repository_with_parked_row(tmp_path) -> AutonomousWorkflowRepository:
+    db_path = str(tmp_path / "parked.db")
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """CREATE TABLE autonomous_workflows (
+                workflow_id TEXT PRIMARY KEY,
+                user_id INTEGER NOT NULL,
+                status TEXT NOT NULL,
+                created_at TEXT NOT NULL
+            )"""
+        )
+        conn.executemany(
+            "INSERT INTO autonomous_workflows VALUES (?, ?, ?, ?)",
+            [
+                ("parked", 7, "verification_pending", "2026-08-08T00:00:00Z"),
+                ("done", 7, "completed", "2026-08-08T00:01:00Z"),
+            ],
+        )
+    return AutonomousWorkflowRepository(_SQLiteDB(db_path))
+
+
+def test_parked_row_is_selected_and_counts_against_user_limit(tmp_path):
+    repo = _repository_with_parked_row(tmp_path)
+
+    assert [row["workflow_id"] for row in repo.get_active_workflows()] == ["parked"]
+    assert repo.count_active_workflows_by_user(7) == 1
+
+
+def test_phase_mapping_and_active_sets_move_together():
+    assert PHASE_TO_STATUS["acceptance_verification"] == "verification_pending"
+    assert "verification_pending" in ACTIVE_WORKFLOW_STATUSES
+    assert "verification_pending" in AutonomousWorkflow.ACTIVE_STATUSES
+
+
+def test_acceptance_verification_defaults_off():
+    with patch.object(config_module, "get_config_value", return_value=False) as get_value:
+        assert config_module.is_acceptance_verification_enabled() is False
+
+    get_value.assert_called_once_with("autonomous", "acceptance_verification_enabled", False)
+
+
+def test_acceptance_verification_can_be_explicitly_enabled():
+    with patch.object(config_module, "get_config_value", return_value=True):
+        assert config_module.is_acceptance_verification_enabled() is True
+
+
+def test_acceptance_verification_rejects_truthy_non_boolean_values():
+    with patch.object(config_module, "get_config_value", return_value="false"):
+        assert config_module.is_acceptance_verification_enabled() is False
+
+
+def test_flag_off_guard_runs_before_context_or_dependency_access():
+    """Broken sentinels prove the guard is the handler's first operation."""
+    with patch.object(av, "is_acceptance_verification_enabled", return_value=False):
+        result = av.handle(object(), object())
+
+    assert result.outcome == "completed"
+    assert result.next_phase == "completed"
+    assert result.workflow_patch == {}
+
+
+def test_flag_off_result_commits_parked_row_to_completed():
+    """Exercise the real commit entrypoint used after the handler returns."""
+    with patch.object(av, "is_acceptance_verification_enabled", return_value=False):
+        result = av.handle(object(), object())
+
+    orchestrator = AutonomousOrchestrator.__new__(AutonomousOrchestrator)
+    orchestrator._workflow_id = "parked"
+    orchestrator.repo = MagicMock()
+    orchestrator._emit = MagicMock()
+    orchestrator._commit_phase_result(result)
+
+    update = orchestrator.repo.update_workflow.call_args.args[1]
+    assert update["status"] == "completed"
+    assert update["current_phase"] == "acceptance_verification"
+    assert "completed_at" in update
+
+
+def test_flag_on_keeps_the_existing_verifier_path():
+    ctx = MagicMock()
+    ctx.workflow = {"verification_status": "confirmed"}
+    deps = MagicMock()
+
+    with patch.object(av, "is_acceptance_verification_enabled", return_value=True):
+        result = av.handle(ctx, deps)
+
+    assert result.outcome == "completed"
+    assert result.next_phase == "completed"


### PR DESCRIPTION
## Summary

- make `verification_pending` schedulable and keep phase/status mappings atomic
- add an acceptance-verification feature flag that defaults to **off** and drains parked rows directly to `completed`
- expose the verification state consistently in backend active sets and frontend status/timeline UI
- add regression coverage for the default-off guard, SQLite repository selection/counting, status maps, and all four UI languages

## Safety boundary

This is PR B of the reviewed #2431 recovery sequence. It deliberately does **not** enable the verifier. The existing verifier still has known correctness problems (merge SHA availability and over-broad legacy gates), which remain scoped to PR C.

The feature-flag check is the first operation in `acceptance_verification.handle()`. With the default configuration, existing parked production rows are selected by the scheduler and complete without reading workflow context, invoking verifier dependencies, or changing their GitHub issues.

## Validation

- `pytest tests/issues/2431 -q` — 27 passed
- related autonomous/concurrency/cleanup suites — 138 passed
- #2335 verifier suites excluding its documented pre-existing red test — 74 passed
- the excluded `test_multi_round_reject_fix_confirm_closes_issue` fails identically on clean `main` and this branch because of the known legacy-pattern gate defect
- frontend Vitest — 808 passed
- TypeScript — passed
- ESLint — 0 errors (2 pre-existing non-null assertion warnings)
- pre-commit — passed with local Bandit hook skipped because this machine has no `python` executable; CI runs Bandit

Closes #2431
