### PR TITLE
fix(autonomous): harden acceptance verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,7 @@ jobs:
       - name: Issue regression suites (opt-in; see norecursedirs)
         timeout-minutes: 5
         run: |
-          pytest tests/issues/2403 tests/issues/2428 tests/issues/2431 -v \
+          pytest tests/issues/2335 tests/issues/2403 tests/issues/2428 tests/issues/2431 -v \
             -m "not postgres and not performance"
 
       - name: Upload coverage to Codecov

--- a/app/modules/workspace/autonomous/acceptance_gates.py
+++ b/app/modules/workspace/autonomous/acceptance_gates.py
@@ -531,6 +531,7 @@ def run_mechanical_gates(
                     verdict=Verdict.INDETERMINATE,
                     evidence=[{"ref": "error", "note": f"gate raised: {exc!r}"}],
                     rationale="Mechanical gate failed to run; defaulting to indeterminate.",
+                    retryable=True,
                 )
             )
     return out

--- a/app/modules/workspace/autonomous/acceptance_gates.py
+++ b/app/modules/workspace/autonomous/acceptance_gates.py
@@ -1,6 +1,6 @@
 """Mechanical acceptance gates (#2335 S4).
 
-Five conservative, deterministic static-analysis checks that fold into the
+Conservative, deterministic static-analysis checks that fold into the
 acceptance verifier's issue-level aggregation alongside the scope gate and the
 LLM verifier verdicts. Each gate returns ``list[ItemVerdict]``.
 
@@ -504,15 +504,20 @@ def run_mechanical_gates(
     *,
     read_file: Callable[[str], str] | None = None,
 ) -> list[ItemVerdict]:
-    """Run all 5 mechanical gates and return a flat list of their verdicts.
+    """Run the production-safe mechanical gates and return their verdicts.
 
     Each gate is independently defensive — a gate that raises degrades to a
     single INDETERMINATE rather than aborting the whole verification.
+
+    ``legacy_pattern_gate`` is intentionally retired from this aggregate.  It
+    scans the full post-merge contents of every changed file, so it cannot tell
+    whether a broad regex match was introduced by the PR or merely pre-existed.
+    That made ordinary delivered changes falsely REJECTED.  The helper remains
+    available for focused tests while a future diff-aware replacement is built.
     """
     out: list[ItemVerdict] = []
     for gate in (
         negative_test_gate,
-        legacy_pattern_gate,
         call_chain_gate,
         deployment_gate,
         regression_gate,

--- a/app/modules/workspace/autonomous/acceptance_verdicts.py
+++ b/app/modules/workspace/autonomous/acceptance_verdicts.py
@@ -22,6 +22,9 @@ class ItemVerdict:
         default_factory=list
     )  # [{"ref": "file:line|git-diff", "note": "..."}]
     rationale: str = ""
+    # True only when INDETERMINATE came from a retryable probe/infrastructure
+    # failure rather than healthy-but-insufficient acceptance evidence.
+    retryable: bool = False
 
 
 def aggregate_verdicts(items: list[ItemVerdict]) -> str:

--- a/app/modules/workspace/autonomous/github_ops.py
+++ b/app/modules/workspace/autonomous/github_ops.py
@@ -11,11 +11,15 @@ import logging
 import os
 import pwd
 import re
+import shutil
 import subprocess
 import sys
 import time
+import uuid
 from pathlib import Path
 from urllib.parse import urlparse
+
+from app.utils.workspace import OPENACE_RM_WRAPPER
 
 logger = logging.getLogger(__name__)
 
@@ -711,6 +715,80 @@ class GitHubOps:
             return False
 
     # ── Repo Operations ────────────────────────────────────────────
+
+    def create_verification_worktree_dir(self, project_path: str) -> str:
+        """Allocate an empty verifier worktree directory as the repo owner.
+
+        ``git worktree add`` runs as ``system_account`` in multi-user mode, so
+        its destination must not be a service-owned ``tempfile.mkdtemp``
+        directory (which is mode 0700 and cannot be traversed cross-user).
+        Keep verifier checkouts under the repository's established
+        ``.worktrees`` root and create both the root and the unique child with
+        the same identity that will run git.
+        """
+        project_root = os.path.realpath(project_path)
+        if not project_root or not os.path.isabs(project_root):
+            raise GitHubOpsError("Cannot allocate verifier worktree under an invalid project path")
+        worktrees_root = os.path.join(project_root, ".worktrees")
+        kwargs = self._build_subprocess_kwargs()
+        kwargs.pop("cwd", None)
+        kwargs["timeout"] = 10
+
+        def _mkdir(args: list[str]) -> subprocess.CompletedProcess:
+            if self._needs_sudo():
+                account = self.system_account
+                assert account is not None
+                cmd = ["sudo", "-u", account, "mkdir", *args]
+            else:
+                cmd = ["mkdir", *args]
+            return subprocess.run(cmd, **kwargs)
+
+        root_result = _mkdir(["-p", "--", worktrees_root])
+        if root_result.returncode != 0:
+            raise GitHubOpsError(
+                "Cannot create verifier worktree root: " f"{(root_result.stderr or '').strip()}"
+            )
+
+        for _attempt in range(3):
+            path = os.path.join(worktrees_root, f"verify-{uuid.uuid4().hex}")
+            result = _mkdir(["-m", "700", "--", path])
+            if result.returncode == 0:
+                return path
+        raise GitHubOpsError(
+            "Cannot allocate a unique verifier worktree directory: "
+            f"{(result.stderr or '').strip()}"
+        )
+
+    def remove_verification_worktree_dir(self, path: str, project_path: str) -> None:
+        """Remove a verifier directory with the identity that owns it.
+
+        This is only the fallback after ``git worktree remove``. The strict
+        direct-child and ``verify-`` checks keep recursive deletion scoped to
+        directories allocated by :meth:`create_verification_worktree_dir`.
+        """
+        worktrees_root = os.path.realpath(os.path.join(project_path, ".worktrees"))
+        real_path = os.path.realpath(path)
+        _assert_path_contained(real_path, worktrees_root, label="verification worktree")
+        if os.path.dirname(real_path) != worktrees_root or not os.path.basename(
+            real_path
+        ).startswith("verify-"):
+            raise GitHubOpsError("Refusing to remove a non-verifier worktree directory")
+        if not self._needs_sudo():
+            shutil.rmtree(real_path, ignore_errors=True)
+            return
+        account = self.system_account
+        assert account is not None
+        result = subprocess.run(
+            ["sudo", OPENACE_RM_WRAPPER, account, real_path, "-r", "-f"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env=self._build_subprocess_kwargs().get("env"),
+        )
+        if result.returncode != 0:
+            raise GitHubOpsError(
+                f"Cannot remove verifier worktree directory: {(result.stderr or '').strip()}"
+            )
 
     def create_repo(self, name: str, private: bool = True, description: str = "") -> dict:
         """Create a new GitHub repository."""

--- a/app/modules/workspace/autonomous/github_ops.py
+++ b/app/modules/workspace/autonomous/github_ops.py
@@ -794,10 +794,24 @@ class GitHubOps:
         return json.loads(result.stdout.strip())
 
     def add_issue_comment(self, number: int, body: str) -> dict:
-        """Add a comment to an issue."""
+        """Add a comment to an issue, deduplicating an exact prior body.
+
+        Acceptance verification can be re-entered after a crash between the
+        GitHub mutation and the local workflow update.  Reading first makes the
+        externally-visible operation idempotent for that retry instead of
+        posting the same report twice.
+        """
+        for comment in self.list_issue_comments(number):
+            if comment.get("body") == body:
+                logger.info("Issue #%s already has the requested comment; skipping", number)
+                return {
+                    "number": number,
+                    "id": comment.get("id"),
+                    "deduplicated": True,
+                }
         self._run_gh(["issue", "comment", str(number), "--body", body], api_only=True)
         logger.info("Added comment to issue #%s", number)
-        return {"number": number}
+        return {"number": number, "deduplicated": False}
 
     def close_issue(self, number: int) -> dict:
         """Close an issue.
@@ -823,12 +837,93 @@ class GitHubOps:
     def list_issue_comments(self, number: int, since: str | None = None) -> list:
         """List comments on an issue, optionally since a timestamp."""
         args = ["issue", "view", str(number), "--comments", "--json", "comments"]
-        result = self._run_gh(args)
-        data = json.loads(result.stdout.strip())
+        result = self._run_gh(args, api_only=True)
+        data = json.loads((result.stdout or "").strip() or '{"comments": []}')
         comments = data.get("comments", [])
         if since:
             comments = [c for c in comments if c.get("createdAt", "") > since]
         return comments
+
+    def get_authenticated_login(self) -> str | None:
+        """Return the login associated with the configured bot credentials.
+
+        Without an explicit AI GitHub token, ``gh`` may inherit a repository
+        owner's personal login.  That identity must never be treated as the
+        autonomous service account for reopen decisions.
+        """
+        env = self._get_env()
+        if not env or not env.get("GH_TOKEN"):
+            return None
+        result = self._run_gh(
+            self._gh_api_args(["user", "--jq", ".login"]),
+            check=False,
+            repo_scoped=False,
+            api_only=True,
+        )
+        if result.returncode != 0:
+            return None
+        login = (result.stdout or "").strip()
+        return login or None
+
+    def get_issue_closure(self, number: int) -> dict | None:
+        """Return the current issue closure timestamp and its actual actor.
+
+        The issue view establishes that the issue is currently closed and gives
+        the authoritative ``closedAt`` timestamp.  The timeline API supplies
+        the actor for the latest close event.  Missing/ambiguous data returns
+        ``None`` so callers fail closed and never reopen a human's issue.
+        """
+        state_result = self._run_gh(
+            ["issue", "view", str(number), "--json", "state,closedAt"],
+            check=False,
+            api_only=True,
+        )
+        if state_result.returncode != 0:
+            return None
+        try:
+            issue = json.loads((state_result.stdout or "").strip() or "{}")
+        except json.JSONDecodeError:
+            return None
+        closed_at = issue.get("closedAt")
+        if str(issue.get("state") or "").lower() != "closed" or not closed_at:
+            return None
+
+        repo = self.get_repo_name()
+        if not repo:
+            return None
+        timeline_result = self._run_gh(
+            self._gh_api_args(
+                [
+                    "--paginate",
+                    f"repos/{repo}/issues/{number}/timeline",
+                    "--jq",
+                    '.[] | select(.event == "closed") | {closed_at: .created_at, closer_login: .actor.login}',
+                ]
+            ),
+            check=False,
+            repo_scoped=False,
+            api_only=True,
+        )
+        if timeline_result.returncode != 0:
+            return None
+        events: list[dict] = []
+        for line in (timeline_result.stdout or "").splitlines():
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(event, dict):
+                events.append(event)
+        if not events:
+            return None
+        matching = [event for event in events if event.get("closed_at") == closed_at]
+        if not matching:
+            return None
+        latest = matching[-1]
+        closer_login = latest.get("closer_login")
+        if not isinstance(closer_login, str) or not closer_login:
+            return None
+        return {"closed_at": closed_at, "closer_login": closer_login}
 
     def update_issue(self, number: int, title: str | None = None, body: str | None = None) -> dict:
         """Update an issue's title or body."""
@@ -1409,6 +1504,30 @@ class GitHubOps:
         )
         out = (result.stdout or "").strip()
         return out or None
+
+    def ensure_commit_available(self, commit_sha: str) -> bool:
+        """Fetch a merge commit into the local repository if it is absent.
+
+        ``gh pr merge`` completes server-side, so its merge SHA is not
+        necessarily present in the long-lived production clone.  Fetch the
+        exact object first, fall back to the reachable ``main`` ref for servers
+        that disallow raw-SHA wants, then verify the object before any diff or
+        worktree operation uses it.
+        """
+        if not re.fullmatch(r"[0-9a-fA-F]{7,40}", commit_sha or ""):
+            return False
+
+        def _present() -> bool:
+            result = self._run_git(["cat-file", "-e", f"{commit_sha}^{{commit}}"], check=False)
+            return result.returncode == 0
+
+        if _present():
+            return True
+        self._run_git(["fetch", "--no-tags", "origin", commit_sha], check=False)
+        if _present():
+            return True
+        self._run_git(["fetch", "--no-tags", "origin", "main"], check=False)
+        return _present()
 
     def _gh_api_args(self, extra: list[str]) -> list[str]:
         """Build a ``gh api`` arg list with GHES hostname handling.

--- a/app/modules/workspace/autonomous/github_ops.py
+++ b/app/modules/workspace/autonomous/github_ops.py
@@ -794,21 +794,32 @@ class GitHubOps:
         return json.loads(result.stdout.strip())
 
     def add_issue_comment(self, number: int, body: str) -> dict:
-        """Add a comment to an issue, deduplicating an exact prior body.
+        """Add a comment, deduplicating an exact prior body from this bot.
 
         Acceptance verification can be re-entered after a crash between the
         GitHub mutation and the local workflow update.  Reading first makes the
         externally-visible operation idempotent for that retry instead of
-        posting the same report twice.
+        posting the same report twice.  A human-authored copy is not proof that
+        the configured service account already posted its audit record.  When
+        bot identity cannot be established, fail closed for deduplication and
+        post the comment.
         """
-        for comment in self.list_issue_comments(number):
-            if comment.get("body") == body:
-                logger.info("Issue #%s already has the requested comment; skipping", number)
-                return {
-                    "number": number,
-                    "id": comment.get("id"),
-                    "deduplicated": True,
-                }
+        bot_login = self.get_authenticated_login()
+        if bot_login:
+            for comment in self.list_issue_comments(number):
+                author = comment.get("author") or {}
+                author_login = author.get("login") if isinstance(author, dict) else author
+                if (
+                    comment.get("body") == body
+                    and isinstance(author_login, str)
+                    and author_login.casefold() == bot_login.casefold()
+                ):
+                    logger.info("Issue #%s already has the requested bot comment; skipping", number)
+                    return {
+                        "number": number,
+                        "id": comment.get("id"),
+                        "deduplicated": True,
+                    }
         self._run_gh(["issue", "comment", str(number), "--body", body], api_only=True)
         logger.info("Added comment to issue #%s", number)
         return {"number": number, "deduplicated": False}
@@ -835,11 +846,52 @@ class GitHubOps:
         return {"number": number}
 
     def list_issue_comments(self, number: int, since: str | None = None) -> list:
-        """List comments on an issue, optionally since a timestamp."""
-        args = ["issue", "view", str(number), "--comments", "--json", "comments"]
-        result = self._run_gh(args, api_only=True)
-        data = json.loads((result.stdout or "").strip() or '{"comments": []}')
-        comments = data.get("comments", [])
+        """List every issue comment, optionally since a timestamp.
+
+        Use the paginated REST endpoint rather than ``gh issue view``'s
+        connection so an older matching bot comment cannot fall off the first
+        page and be posted again.  Output is normalized to the camelCase shape
+        used by the existing wait/report consumers.
+        """
+        try:
+            repo = self.get_repo_name()
+        except (GitHubOpsError, json.JSONDecodeError):
+            repo = ""
+        if repo:
+            result = self._run_gh(
+                self._gh_api_args(
+                    [
+                        "--paginate",
+                        f"repos/{repo}/issues/{number}/comments",
+                        "--jq",
+                        ".[] | {id, body, createdAt: .created_at, author: {login: .user.login}}",
+                    ]
+                ),
+                repo_scoped=False,
+                api_only=True,
+            )
+        else:
+            # Pre-remote repositories cannot form a REST path. Preserve the
+            # best-effort CLI fallback used before pagination hardening.
+            result = self._run_gh(
+                ["issue", "view", str(number), "--comments", "--json", "comments"],
+                api_only=True,
+            )
+        comments: list[dict] = []
+        for line in (result.stdout or "").splitlines():
+            try:
+                parsed = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(parsed, dict):
+                continue
+            # Compatibility with old/mocked ``gh issue view`` output keeps
+            # callers resilient while production uses NDJSON from ``--jq``.
+            nested = parsed.get("comments")
+            if isinstance(nested, list):
+                comments.extend(item for item in nested if isinstance(item, dict))
+            else:
+                comments.append(parsed)
         if since:
             comments = [c for c in comments if c.get("createdAt", "") > since]
         return comments

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -1887,6 +1887,11 @@ class AutonomousOrchestrator:
         # interrupts the current attempt without changing the workflow's active
         # phase/status, so the next process can retry it automatically.
         self._shutdown_requested = threading.Event()
+        # Bound by AutonomousScheduler after it acquires the distributed
+        # workflow lease. Direct/unit callers leave these unset and retain the
+        # legacy unfenced behavior.
+        self._scheduler_lock_owner: str | None = None
+        self._scheduler_lock_lost: threading.Event | None = None
 
         # Wire session_manager so agent sessions are persisted to DB
         from app.modules.workspace.session_manager import SessionManager
@@ -4313,6 +4318,7 @@ class AutonomousOrchestrator:
         but routing every transition through here makes phase/status mutation a
         single auditable path — the property Phase A requires.
         """
+        self._assert_scheduler_lock()
         patch: dict[str, object] = dict(result.workflow_patch)
 
         if result.outcome == "completed":
@@ -4955,9 +4961,24 @@ class AutonomousOrchestrator:
             repair_wf = self.workflow or repair_wf
         self._run_merge_ci_repair(repair_wf, gh, pr_number, failed_checks)
 
+    def _persist_workflow_update(self, updates: dict) -> dict | None:
+        """Persist one workflow patch, fenced by the scheduler lease when bound."""
+        lock_owner = getattr(self, "_scheduler_lock_owner", None)
+        if lock_owner:
+            updated = self.repo.update_workflow(
+                self._workflow_id,
+                updates,
+                required_lock_owner=lock_owner,
+            )
+            if updated is None:
+                self._mark_scheduler_lock_lost()
+                raise WorkflowPaused("Distributed workflow lock was lost")
+            return updated
+        return self.repo.update_workflow(self._workflow_id, updates)
+
     def _update_workflow(self, updates: dict):
         """Update workflow and emit event."""
-        self.repo.update_workflow(self._workflow_id, updates)
+        self._persist_workflow_update(updates)
         self._emit("workflow_updated", updates)
 
     def _cleanup_worktree_and_branch(
@@ -5050,6 +5071,7 @@ class AutonomousOrchestrator:
 
     def _accumulate_tokens(self, _result: AgentTaskResult):
         """Refresh workflow totals from the sessions linked to milestones."""
+        self._assert_scheduler_lock()
         self.repo.refresh_workflow_usage_from_sessions(self._workflow_id)
 
     def _persist_sandbox_attribution(self, result: AgentTaskResult) -> None:
@@ -5065,14 +5087,13 @@ class AutonomousOrchestrator:
         if not provider and not sandbox_id:
             return  # no sandbox ran (e.g. CLI not found before create)
         try:
-            self.repo.update_workflow(
-                self._workflow_id,
+            self._persist_workflow_update(
                 {
                     "sandbox_provider": provider,
                     "sandbox_id": sandbox_id,
                     "sandbox_generation": getattr(result, "sandbox_generation", None),
                     "sandbox_state": getattr(result, "sandbox_state", "") or None,
-                },
+                }
             )
         except Exception as e:  # pragma: no cover - best-effort attribution
             logger.warning(
@@ -5281,8 +5302,7 @@ class AutonomousOrchestrator:
     def _on_pid_registered(self, session_id: str, pid: int):
         """Persist agent subprocess PID to database for reliable cancel/pause."""
         try:
-            self.repo.update_workflow(
-                self._workflow_id,
+            self._persist_workflow_update(
                 {
                     "agent_pid": pid,
                     "agent_session_id": session_id,
@@ -5328,7 +5348,7 @@ class AutonomousOrchestrator:
                 updates["sandbox_remote_session_id"] = remote_session_id
             if effective_policy is not None:
                 updates["sandbox_effective_policy"] = json.dumps(effective_policy)
-            self.repo.update_workflow(self._workflow_id, updates)
+            self._persist_workflow_update(updates)
             logger.info(
                 "Registered sandbox %s (provider=%s) for workflow %s%s",
                 sandbox_id[:8],
@@ -5344,8 +5364,7 @@ class AutonomousOrchestrator:
         try:
             with self._session_lock:
                 if self._current_session_id == session_id:
-                    self.repo.update_workflow(
-                        self._workflow_id,
+                    self._persist_workflow_update(
                         {
                             "agent_pid": None,
                             "agent_session_id": "",
@@ -6396,8 +6415,58 @@ class AutonomousOrchestrator:
             for session_id in session_ids:
                 offsets.pop(session_id, None)
 
+    def bind_scheduler_lock(self, owner: str, lock_lost: threading.Event) -> None:
+        """Attach the scheduler's lease identity and shared loss signal."""
+        self._scheduler_lock_owner = owner
+        self._scheduler_lock_lost = lock_lost
+
+    def _mark_scheduler_lock_lost(self) -> None:
+        event = getattr(self, "_scheduler_lock_lost", None)
+        if event is not None:
+            event.set()
+        # Do not call prepare_for_shutdown() here: this helper can run from the
+        # PID-cleared callback while _session_lock is held, and re-entering that
+        # non-reentrant lock would deadlock. The heartbeat owns active process
+        # interruption; these signals fence every subsequent local action.
+        shutdown = getattr(self, "_shutdown_requested", None)
+        if shutdown is not None:
+            shutdown.set()
+        cancel = getattr(self, "_cancel_requested", None)
+        if cancel is not None:
+            cancel.set()
+
+    def ensure_scheduler_lock(self) -> bool:
+        """Refresh and fence the lease before an irreversible external action."""
+        owner = getattr(self, "_scheduler_lock_owner", None)
+        if not owner:
+            return not self._is_shutdown_requested()
+        lost = getattr(self, "_scheduler_lock_lost", None)
+        if lost is not None and lost.is_set():
+            return False
+        try:
+            held = self.repo.refresh_lock(self._workflow_id, owner)
+        except Exception:
+            logger.warning(
+                "Could not fence workflow %s before external mutation",
+                self._workflow_id[:8],
+                exc_info=True,
+            )
+            return False
+        if held:
+            return True
+        self._mark_scheduler_lock_lost()
+        return False
+
+    def _assert_scheduler_lock(self) -> None:
+        """Raise the pause control signal when this worker has been superseded."""
+        if not self.ensure_scheduler_lock():
+            raise WorkflowPaused("Distributed workflow lock was lost")
+
     def _is_shutdown_requested(self) -> bool:
         """Support lightweight test/legacy instances constructed without ``__init__``."""
+        lock_lost = getattr(self, "_scheduler_lock_lost", None)
+        if lock_lost is not None and lock_lost.is_set():
+            return True
         event = getattr(self, "_shutdown_requested", None)
         return bool(event and event.is_set())
 

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -6795,7 +6795,7 @@ class AutonomousOrchestrator:
             if gh is None:
                 return True
             res = gh.get_issue(int(issue_number))
-            return (res or {}).get("state", "open") == "open"
+            return str((res or {}).get("state", "open")).lower() == "open"
         except Exception:
             # Fail open: if we can't tell, don't spuriously reopen.
             return True
@@ -6815,6 +6815,16 @@ class AutonomousOrchestrator:
             return None
         gh = self._get_gh()
         if gh is None:
+            return None
+        try:
+            available = gh.ensure_commit_available(merge_sha)
+        except Exception:
+            logger.exception(
+                "acceptance verifier: failed to fetch merge commit locally: %s", merge_sha
+            )
+            return None
+        if not available:
+            logger.error("acceptance verifier: merge commit unavailable locally: %s", merge_sha)
             return None
         tmp_dir = tempfile.mkdtemp(prefix="ace-verify-")
         try:
@@ -6857,7 +6867,12 @@ class AutonomousOrchestrator:
 
         checkout_path = self._checkout_merged_main(merge_sha)
         if not checkout_path:
-            return {"verdicts": [], "snapshot": None, "verified_by": verified_by}
+            return {
+                "verdicts": [],
+                "snapshot": None,
+                "verified_by": verified_by,
+                "infra_error": "merged-main checkout failed",
+            }
         try:
             # Spawn the agent against the merged-main checkout, NOT the dev
             # worktree. We override worktree_path/project_path on a shallow
@@ -6878,9 +6893,22 @@ class AutonomousOrchestrator:
             )
         except Exception:
             logger.exception("acceptance verifier spawn failed for issue %s", issue_number)
-            return {"verdicts": [], "snapshot": None, "verified_by": verified_by}
+            return {
+                "verdicts": [],
+                "snapshot": None,
+                "verified_by": verified_by,
+                "infra_error": "verification agent spawn failed",
+            }
         finally:
             self._remove_verification_worktree(checkout_path)
+        if result is None or getattr(result, "success", False) is not True:
+            error_code = getattr(result, "error_code", None) if result is not None else None
+            return {
+                "verdicts": [],
+                "snapshot": None,
+                "verified_by": verified_by,
+                "infra_error": f"verification agent failed ({error_code or 'runner error'})",
+            }
         parsed = self._parse_verifier_output(result)
         parsed["verified_by"] = verified_by
         return parsed
@@ -6915,7 +6943,11 @@ class AutonomousOrchestrator:
 
         text = self._artifact_text(result) if result is not None else ""
         if not text:
-            return {"verdicts": [], "snapshot": None}
+            return {
+                "verdicts": [],
+                "snapshot": None,
+                "infra_error": "verification agent returned empty output",
+            }
         # Grab the last fenced ```json ... ``` block (the agent may preface reasoning).
         blocks = _re.findall(r"```(?:json)?\s*(\{.*?\})\s*```", text, _re.DOTALL)
         candidate = blocks[-1] if blocks else text
@@ -6925,9 +6957,30 @@ class AutonomousOrchestrator:
             logger.warning(
                 "acceptance verifier output was not valid JSON; treating as indeterminate"
             )
-            return {"verdicts": [], "snapshot": None}
+            return {
+                "verdicts": [],
+                "snapshot": None,
+                "infra_error": "verification agent output was not valid JSON",
+            }
         if not isinstance(parsed, dict):
-            return {"verdicts": [], "snapshot": None}
+            return {
+                "verdicts": [],
+                "snapshot": None,
+                "infra_error": "verification agent output was not an object",
+            }
+        verdicts = parsed.get("verdicts", [])
+        if not isinstance(verdicts, list) or any(not isinstance(item, dict) for item in verdicts):
+            return {
+                "verdicts": [],
+                "snapshot": None,
+                "infra_error": "verification agent verdicts were malformed",
+            }
+        if parsed.get("snapshot") is not None and not isinstance(parsed.get("snapshot"), dict):
+            return {
+                "verdicts": [],
+                "snapshot": None,
+                "infra_error": "verification agent snapshot was malformed",
+            }
         parsed.setdefault("verdicts", [])
         parsed.setdefault("snapshot", None)
         return parsed

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -17,7 +17,6 @@ import shlex
 import shutil
 import subprocess
 import sys
-import tempfile
 import threading
 import time
 import uuid
@@ -123,20 +122,28 @@ COMPLETION_KEYWORDS = [
 # ── Framework inference for test detection (Phase 1, P0) ────────────────
 
 
-def _remove_worktree_dir(gh, path: str) -> None:
+def _remove_worktree_dir(gh, path: str, project_path: str = "") -> None:
     """Best-effort removal of a (possibly registered) worktree dir (#2335 S5).
 
     Tries ``git worktree remove --force`` when a GitHubOps handle is available
-    (unregisters the worktree from the repo's metadata), then falls back to a
-    filesystem ``shutil.rmtree``. Never raises — this runs in cleanup paths.
+    (unregisters the worktree from the repo's metadata), then uses repository-
+    owner cleanup for verifier directories before a final filesystem fallback.
+    Never raises — this runs in cleanup paths.
     """
     if not path:
         return
     if gh is not None:
         try:
             gh._run_git(["worktree", "remove", path, "--force"])
+            return
         except Exception:
             pass
+        if project_path:
+            try:
+                gh.remove_verification_worktree_dir(path, project_path)
+                return
+            except Exception:
+                pass
     try:
         if os.path.isdir(path):
             shutil.rmtree(path, ignore_errors=True)
@@ -6895,14 +6902,23 @@ class AutonomousOrchestrator:
         if not available:
             logger.error("acceptance verifier: merge commit unavailable locally: %s", merge_sha)
             return None
-        tmp_dir = tempfile.mkdtemp(prefix="ace-verify-")
+        wf = self.workflow or {}
+        project_path = str(wf.get("project_path") or "")
+        if not project_path:
+            logger.error("acceptance verifier: project path unavailable")
+            return None
+        try:
+            tmp_dir = gh.create_verification_worktree_dir(project_path)
+        except Exception:
+            logger.exception("acceptance verifier: failed to allocate owner-readable worktree")
+            return None
         try:
             # Detached HEAD at the merge commit: a read-only throwaway view.
             gh._run_git(["worktree", "add", "--detach", tmp_dir, merge_sha])
         except Exception:
             logger.exception("acceptance verifier: failed to checkout merged main @ %s", merge_sha)
             # Clean up the empty dir so no half-created state lingers.
-            _remove_worktree_dir(gh, tmp_dir)
+            _remove_worktree_dir(gh, tmp_dir, project_path)
             return None
         return tmp_dir
 
@@ -6915,7 +6931,8 @@ class AutonomousOrchestrator:
         if not path:
             return
         gh = self._get_gh()
-        _remove_worktree_dir(gh, path)
+        wf = self.workflow or {}
+        _remove_worktree_dir(gh, path, str(wf.get("project_path") or ""))
 
     def _run_verification_agent(
         self, *, snapshot, merge_sha, base_sha, issue_number, pr_number

--- a/app/modules/workspace/autonomous/phase_contract.py
+++ b/app/modules/workspace/autonomous/phase_contract.py
@@ -157,6 +157,7 @@ class PhaseResult:
     def pause(
         *,
         workflow_patch: dict | None = None,
+        milestone_events: list[dict] | None = None,
         structured_error: object | None = None,
     ) -> PhaseResult:
         """Build a result that pauses the workflow (user-facing pause)."""
@@ -165,6 +166,7 @@ class PhaseResult:
             next_phase=None,
             next_status="paused",
             workflow_patch=workflow_patch or {},
+            milestone_events=milestone_events or [],
             structured_error=structured_error,
         )
 

--- a/app/modules/workspace/autonomous/phase_host.py
+++ b/app/modules/workspace/autonomous/phase_host.py
@@ -104,6 +104,9 @@ class PhaseHost(Protocol):
     def emit_audit_event(self, name: str, payload: dict) -> None:
         """Emit a generic audit event (e.g. acceptance_reopened_issue)."""
 
+    def ensure_scheduler_lock(self) -> bool:
+        """Fence the distributed lease before an irreversible external action."""
+
     # ── Merge-phase helpers (#2044 Phase B T10) ──────────────────────────
     # These are orchestrator-private methods (each tens-to-hundreds of lines,
     # with their own transitive ``self._`` calls) that the merge handler needs

--- a/app/modules/workspace/autonomous/phases/acceptance_verification.py
+++ b/app/modules/workspace/autonomous/phases/acceptance_verification.py
@@ -406,11 +406,18 @@ def handle(ctx, deps) -> PhaseResult:
         )
     extracted_payload = agent_out.get("snapshot")
     if extracted_payload is not None:
-        try:
-            snapshot = _validate_extracted_snapshot(extracted_payload)
-            snap_hash = hash_snapshot(snapshot)
-        except ValueError as exc:
-            agent_out["infra_error"] = f"verification agent returned invalid snapshot: {exc}"
+        if not snapshot_requires_extraction:
+            # The issue's convention snapshot is authoritative. A verifier
+            # must not replace it with an easier LLM-authored checklist.
+            agent_out["infra_error"] = (
+                "verification agent returned an unexpected snapshot for structured criteria"
+            )
+        else:
+            try:
+                snapshot = _validate_extracted_snapshot(extracted_payload)
+                snap_hash = hash_snapshot(snapshot)
+            except ValueError as exc:
+                agent_out["infra_error"] = f"verification agent returned invalid snapshot: {exc}"
     elif snapshot_requires_extraction and not agent_out.get("infra_error"):
         agent_out["infra_error"] = (
             "verification agent omitted the required extracted acceptance snapshot"

--- a/app/modules/workspace/autonomous/phases/acceptance_verification.py
+++ b/app/modules/workspace/autonomous/phases/acceptance_verification.py
@@ -12,7 +12,7 @@ Transitions:
   confirmed      -> close issue + acceptance report -> completed
   rejected       -> paused (delivered code is never marked failed; human reviews)
   indeterminate  -> paused (issue open; human provides missing evidence)
-  infrastructure -> retry (diagnostic report, no terminal milestone)
+  infrastructure -> retry up to 3 times, then pause for review
 
 Idempotent on the confirmed result: a re-entry whose ``verification_status`` is
 already ``confirmed`` is a terminal no-op (no re-close, no re-comment). A new
@@ -27,6 +27,7 @@ import dataclasses
 import fnmatch
 import json
 import time
+from typing import cast
 
 from app.modules.workspace.autonomous.acceptance_gates import run_mechanical_gates
 from app.modules.workspace.autonomous.acceptance_snapshot import (
@@ -40,6 +41,7 @@ from app.modules.workspace.autonomous.phase_contract import PhaseResult
 from app.utils.config import is_acceptance_verification_enabled
 
 VERIFIED_BY = "acceptance-verifier-v1"
+MAX_VERIFIER_INFRA_RETRIES = 3
 
 
 def _now_iso() -> str:
@@ -49,6 +51,45 @@ def _now_iso() -> str:
 def _snapshot_to_json(snapshot: AcceptanceSnapshot) -> str:
     """Full snapshot (incl. source/confidence) for round-trip persistence."""
     return json.dumps(dataclasses.asdict(snapshot), ensure_ascii=False)
+
+
+def _validate_extracted_snapshot(payload: object) -> AcceptanceSnapshot:
+    """Build a conservative LLM-extracted snapshot or raise ``ValueError``.
+
+    When the issue has no convention snapshot, this object becomes the source
+    of truth for checklist coverage and scope gates. Accepting unknown/missing
+    fields or wrong types would let a fabricated verdict bypass those gates.
+    """
+    expected_fields = {
+        "required_paths",
+        "checklist",
+        "non_scope",
+        "closure_constraints",
+    }
+    if not isinstance(payload, dict) or set(payload) != expected_fields:
+        raise ValueError("extracted snapshot fields were incomplete or unknown")
+
+    list_fields: dict[str, list[str]] = {}
+    for field_name in ("required_paths", "checklist", "non_scope"):
+        value = payload[field_name]
+        if not isinstance(value, list) or any(
+            not isinstance(item, str) or not item.strip() for item in value
+        ):
+            raise ValueError(f"extracted snapshot {field_name} was not a string list")
+        list_fields[field_name] = [item.strip() for item in value]
+    if not isinstance(payload["closure_constraints"], bool):
+        raise ValueError("extracted snapshot closure_constraints was not boolean")
+    if not list_fields["required_paths"] and not list_fields["checklist"]:
+        raise ValueError("extracted snapshot contained no verifiable criteria")
+
+    return AcceptanceSnapshot(
+        required_paths=list_fields["required_paths"],
+        checklist=list_fields["checklist"],
+        non_scope=list_fields["non_scope"],
+        closure_constraints=payload["closure_constraints"],
+        source="llm",
+        confidence="low",
+    )
 
 
 def _glob_matches(pattern: str, paths: list[str]) -> str | None:
@@ -76,6 +117,7 @@ def run_scope_gate(
                 verdict=Verdict.INDETERMINATE,
                 evidence=[{"ref": "git-diff:error", "note": f"scope diff failed: {exc!r}"}],
                 rationale="Required-path scope could not be read; verification must pause.",
+                retryable=True,
             )
         ]
     verdicts: list[ItemVerdict] = []
@@ -185,6 +227,25 @@ def _already_verified_for(wf: dict, merge_sha: str, snap_hash: str) -> dict | No
     return report
 
 
+def _prior_infra_retry_count(wf: dict, merge_sha: str, snap_hash: str) -> int:
+    """Return consecutive infra attempts for the current verification pair."""
+    raw = wf.get("verification_report")
+    if not raw:
+        return 0
+    try:
+        report = json.loads(raw) if isinstance(raw, str) else dict(raw)
+    except Exception:
+        return 0
+    if not isinstance(report, dict) or not report.get("infra_error"):
+        return 0
+    if report.get("merge_sha") != merge_sha or report.get("issue_acceptance_hash") != snap_hash:
+        return 0
+    try:
+        return max(0, int(report.get("infra_retry_count") or 0))
+    except (TypeError, ValueError):
+        return 0
+
+
 def handle(ctx, deps) -> PhaseResult:
     # Keep this guard before all context/dependency access. Parked production
     # rows may have already released their worktrees and must drain safely while
@@ -224,6 +285,8 @@ def handle(ctx, deps) -> PhaseResult:
             service_login = None
         closer_login = (closure or {}).get("closer_login") or ""
         if service_login and closer_login.casefold() == service_login.casefold():
+            if ctx.cancellation.is_set() is True or deps.host.ensure_scheduler_lock() is False:
+                return PhaseResult.retry()
             gh.reopen_issue(issue_number)
             deps.host.emit_audit_event(
                 "acceptance_reopened_issue",
@@ -244,12 +307,20 @@ def handle(ctx, deps) -> PhaseResult:
     if snapshot is None:
         snapshot = parse_acceptance_snapshot(_parse_issue_body(gh, issue_number))
     snap_hash = hash_snapshot(snapshot)
+    snapshot_requires_extraction = snapshot.source == "missing" or not (
+        snapshot.required_paths or snapshot.checklist
+    )
 
     # Idempotency (#2335 S5): if the verifier already settled THIS
     # (merge_sha, issue_acceptance_hash) pair to a terminal verdict, reuse the
     # prior result instead of re-running the (expensive) credentialless agent.
     # A changed merge SHA or an edited issue (new hash) misses and re-verifies.
-    prior = _already_verified_for(wf, merge_sha, snap_hash)
+    # An empty/missing snapshot was never a settled acceptance basis: force a
+    # fresh extraction even if an older build persisted a terminal-looking
+    # report for the same empty hash.
+    prior = (
+        None if snapshot_requires_extraction else _already_verified_for(wf, merge_sha, snap_hash)
+    )
     if prior is not None:
         prior_status = prior.get("status") or (wf.get("verification_status") or "")
         if prior_status == "confirmed":
@@ -287,35 +358,63 @@ def handle(ctx, deps) -> PhaseResult:
         )
         or {}
     )
-    verifier_verdicts = [
-        ItemVerdict(
-            item=v.get("item", ""),
-            verdict=_verdict_from_str(v.get("verdict")),
-            evidence=v.get("evidence") or [],
-            rationale=v.get("rationale", ""),
+    verifier_verdicts: list[ItemVerdict] = []
+    for index, raw_verdict in enumerate(agent_out.get("verdicts") or []):
+        if not isinstance(raw_verdict, dict):
+            agent_out["infra_error"] = "verification agent verdict fields were malformed"
+            continue
+        item = raw_verdict.get("item")
+        raw_status = raw_verdict.get("verdict")
+        evidence = raw_verdict.get("evidence")
+        rationale = raw_verdict.get("rationale", "")
+        valid_evidence = isinstance(evidence, list) and all(
+            isinstance(entry, dict)
+            and isinstance(entry.get("ref"), str)
+            and bool(entry.get("ref", "").strip())
+            and ("note" not in entry or isinstance(entry.get("note"), str))
+            for entry in evidence
         )
-        for v in (agent_out.get("verdicts") or [])
-    ]
-    if agent_out.get("infra_error"):
+        if (
+            not isinstance(item, str)
+            or not item.strip()
+            or raw_status not in {"confirmed", "rejected", "indeterminate"}
+            or not valid_evidence
+            or not isinstance(rationale, str)
+        ):
+            agent_out["infra_error"] = (
+                f"verification agent verdict fields were malformed at index {index}"
+            )
+            continue
+        evidence_items = cast(list[dict], evidence)
+        verdict = _verdict_from_str(raw_status)
+        if verdict in {Verdict.CONFIRMED, Verdict.REJECTED} and not evidence_items:
+            verdict = Verdict.INDETERMINATE
+            evidence_items = [
+                {
+                    "ref": "verifier:missing-evidence",
+                    "note": "A definitive verifier verdict had no concrete evidence reference.",
+                }
+            ]
+            rationale = "Definitive acceptance verdicts require concrete evidence."
         verifier_verdicts.append(
             ItemVerdict(
-                item="verifier:infrastructure",
-                verdict=Verdict.INDETERMINATE,
-                evidence=[
-                    {
-                        "ref": "verifier:infra-error",
-                        "note": str(agent_out["infra_error"]),
-                    }
-                ],
-                rationale="The verifier did not complete successfully; no acceptance decision was made.",
+                item=item.strip(),
+                verdict=verdict,
+                evidence=evidence_items,
+                rationale=rationale,
             )
         )
-    if agent_out.get("snapshot"):
+    extracted_payload = agent_out.get("snapshot")
+    if extracted_payload is not None:
         try:
-            snapshot = AcceptanceSnapshot(**agent_out["snapshot"])
+            snapshot = _validate_extracted_snapshot(extracted_payload)
             snap_hash = hash_snapshot(snapshot)
-        except Exception:
-            pass
+        except ValueError as exc:
+            agent_out["infra_error"] = f"verification agent returned invalid snapshot: {exc}"
+    elif snapshot_requires_extraction and not agent_out.get("infra_error"):
+        agent_out["infra_error"] = (
+            "verification agent omitted the required extracted acceptance snapshot"
+        )
 
     # A syntactically valid verifier response is not necessarily complete.  A
     # missing checklist verdict must never disappear from the aggregate and
@@ -357,10 +456,40 @@ def handle(ctx, deps) -> PhaseResult:
     # scope gate and the verifier findings.
     gate_verdicts = run_mechanical_gates(gh, snapshot, base_sha, merge_sha)
 
+    retryable_gate_items = [
+        verdict.item for verdict in scope_verdicts + gate_verdicts if verdict.retryable
+    ]
+    if retryable_gate_items and not agent_out.get("infra_error"):
+        agent_out["infra_error"] = "acceptance probes failed to run: " + ", ".join(
+            retryable_gate_items
+        )
+    if agent_out.get("infra_error"):
+        verifier_verdicts.append(
+            ItemVerdict(
+                item="verifier:infrastructure",
+                verdict=Verdict.INDETERMINATE,
+                evidence=[
+                    {
+                        "ref": "verifier:infra-error",
+                        "note": str(agent_out["infra_error"]),
+                    }
+                ],
+                rationale="The verifier did not complete successfully; no acceptance decision was made.",
+                retryable=True,
+            )
+        )
+
     status = aggregate_verdicts(scope_verdicts + gate_verdicts + verifier_verdicts)
+    if agent_out.get("infra_error"):
+        # A probe failure makes the overall attempt inconclusive even if some
+        # unrelated deterministic gate happened to reject.
+        status = "indeterminate"
     # verified_by records the verifier model/version when the agent surfaced it
     # (S5); fall back to the static runner tag otherwise.
     verified_by = agent_out.get("verified_by") or VERIFIED_BY
+    infra_retry_count = 0
+    if agent_out.get("infra_error"):
+        infra_retry_count = _prior_infra_retry_count(wf, merge_sha, snap_hash) + 1
     report = {
         "merge_sha": merge_sha,
         "issue_acceptance_hash": snap_hash,
@@ -389,6 +518,7 @@ def handle(ctx, deps) -> PhaseResult:
         ],
         "status": status,
         "infra_error": agent_out.get("infra_error") or None,
+        "infra_retry_count": infra_retry_count,
         "verified_at": _now_iso(),
     }
 
@@ -405,18 +535,6 @@ def handle(ctx, deps) -> PhaseResult:
         "verified_by": verified_by,
         "verification_attempt": (wf.get("verification_attempt") or 0) + 1,
     }
-    if agent_out.get("infra_error"):
-        # Infrastructure failures are not acceptance evidence and must not
-        # create a terminal milestone. Keep the workflow in its current phase
-        # so the scheduler can retry automatically; the attempt report remains
-        # persisted for diagnostics.
-        return PhaseResult.retry(
-            workflow_patch={
-                **common_patch,
-                "error_message": "Acceptance verifier infrastructure failure; retrying",
-            }
-        )
-
     milestone = {
         "workflow_id": wf.get("workflow_id"),
         "phase": "acceptance_verification",
@@ -427,9 +545,35 @@ def handle(ctx, deps) -> PhaseResult:
         "result_summary": report,
         "metadata": report,
     }
+    if agent_out.get("infra_error") and infra_retry_count < MAX_VERIFIER_INFRA_RETRIES:
+        # Infrastructure failures are not acceptance evidence and must not
+        # create a terminal milestone. Keep the workflow in its current phase
+        # so the scheduler can retry automatically; the attempt report remains
+        # persisted for diagnostics.
+        return PhaseResult.retry(
+            workflow_patch={
+                **common_patch,
+                "error_message": "Acceptance verifier infrastructure failure; retrying",
+            }
+        )
+    if agent_out.get("infra_error"):
+        return PhaseResult.pause(
+            workflow_patch={
+                **common_patch,
+                "error_message": (
+                    "Acceptance verifier infrastructure retries exhausted; awaiting review"
+                ),
+            },
+            milestone_events=[milestone],
+            structured_error={"message": "verifier-infrastructure-exhausted", "report": report},
+        )
 
     if status == "confirmed":
+        if ctx.cancellation.is_set() is True or deps.host.ensure_scheduler_lock() is False:
+            return PhaseResult.retry()
         gh.add_issue_comment(issue_number, _format_report_comment(report))
+        if ctx.cancellation.is_set() is True or deps.host.ensure_scheduler_lock() is False:
+            return PhaseResult.retry()
         gh.close_issue(issue_number)
         common_patch["issue_closed_by_workflow_at"] = _now_iso()
         return PhaseResult.completed(

--- a/app/modules/workspace/autonomous/phases/acceptance_verification.py
+++ b/app/modules/workspace/autonomous/phases/acceptance_verification.py
@@ -10,8 +10,7 @@ issue (as @open-ace-bot) on ``confirmed``.
 
 Transitions:
   confirmed      -> close issue + acceptance report -> completed
-  rejected       -> new development round (rejection report as feedback),
-                    or failed if the dev-round cap is exhausted
+  rejected       -> paused (delivered code is never marked failed; human reviews)
   indeterminate  -> paused (issue open; human provides missing evidence)
 
 Idempotent on the confirmed result: a re-entry whose ``verification_status`` is
@@ -67,7 +66,17 @@ def run_scope_gate(
     Returns one ``ItemVerdict`` per required path: CONFIRMED if a changed path
     matches (glob), REJECTED with the missing path as evidence otherwise.
     """
-    changed = gh.get_changed_files(base=base_sha, head=merge_sha) or []
+    try:
+        changed = gh.get_changed_files(base=base_sha, head=merge_sha) or []
+    except Exception as exc:  # noqa: BLE001 - git/API failures are inconclusive, not rejection
+        return [
+            ItemVerdict(
+                item="scope:changed-files",
+                verdict=Verdict.INDETERMINATE,
+                evidence=[{"ref": "git-diff:error", "note": f"scope diff failed: {exc!r}"}],
+                rationale="Required-path scope could not be read; verification must pause.",
+            )
+        ]
     verdicts: list[ItemVerdict] = []
     for path in required_paths:
         hit = _glob_matches(path, changed)
@@ -195,10 +204,29 @@ def handle(ctx, deps) -> PhaseResult:
         # Cannot verify yet (PR not merged / base unknown) — retry next cycle.
         return PhaseResult.retry()
 
-    # Reopen guard: if the issue was closed out-of-band before confirmation, reopen.
+    # Reopen only a closure performed by the configured service account.  A
+    # human-closed issue must stay closed.  The persisted
+    # issue_closed_by_workflow_at field cannot distinguish a human close from a
+    # GitHub auto-close caused by an agent-authored ``Closes #N`` commit, so use
+    # the actual timeline actor instead.
     if issue_number and not deps.host.issue_is_open(issue_number):
-        gh.reopen_issue(issue_number)
-        deps.host.emit_audit_event("acceptance_reopened_issue", {"issue": issue_number})
+        try:
+            closure = gh.get_issue_closure(int(issue_number))
+            service_login = gh.get_authenticated_login()
+        except Exception:  # noqa: BLE001 - uncertainty must preserve the human-visible state
+            closure = None
+            service_login = None
+        closer_login = (closure or {}).get("closer_login") or ""
+        if service_login and closer_login.casefold() == service_login.casefold():
+            gh.reopen_issue(issue_number)
+            deps.host.emit_audit_event(
+                "acceptance_reopened_issue",
+                {
+                    "issue": issue_number,
+                    "closer": closer_login,
+                    "closed_at": (closure or {}).get("closed_at"),
+                },
+            )
 
     # Build the acceptance snapshot (persisted; hash drives re-verification).
     snapshot = None
@@ -221,9 +249,9 @@ def handle(ctx, deps) -> PhaseResult:
         if prior_status == "confirmed":
             return PhaseResult.completed(next_phase="completed")
         if prior_status == "rejected":
-            # A prior rejection already transitioned to a new dev round (or
-            # failed at the cap). Replaying the verdict would double-advance;
-            # park indeterminately so the scheduler holds the current phase.
+            # Replaying the same rejected delivery must remain paused.  The
+            # merge worktree has already been cleaned up, so acceptance never
+            # tries to re-enter development on that deleted branch.
             return PhaseResult.pause(
                 workflow_patch={
                     "verification_status": "rejected",
@@ -262,6 +290,20 @@ def handle(ctx, deps) -> PhaseResult:
         )
         for v in (agent_out.get("verdicts") or [])
     ]
+    if agent_out.get("infra_error"):
+        verifier_verdicts.append(
+            ItemVerdict(
+                item="verifier:infrastructure",
+                verdict=Verdict.INDETERMINATE,
+                evidence=[
+                    {
+                        "ref": "verifier:infra-error",
+                        "note": str(agent_out["infra_error"]),
+                    }
+                ],
+                rationale="The verifier did not complete successfully; no acceptance decision was made.",
+            )
+        )
     if agent_out.get("snapshot"):
         try:
             snapshot = AcceptanceSnapshot(**agent_out["snapshot"])
@@ -344,19 +386,16 @@ def handle(ctx, deps) -> PhaseResult:
             milestone_events=[milestone],
         )
     if status == "rejected":
-        if deps.host.dev_round_cap_remaining(wf) > 0:
-            return PhaseResult.completed(
-                next_phase="development",
-                workflow_patch={
-                    **common_patch,
-                    "dev_round": (wf.get("dev_round") or 1) + 1,
-                    "error_message": "Acceptance verification rejected: see report",
-                },
-                milestone_events=[milestone],
-            )
-        return PhaseResult.failed(
-            structured_error={"message": "Acceptance rejected and dev rounds exhausted"},
-            workflow_patch=common_patch,
+        return PhaseResult.pause(
+            structured_error={
+                "message": "Acceptance verification rejected",
+                "report": report,
+            },
+            workflow_patch={
+                **common_patch,
+                "error_message": "Acceptance verification rejected; awaiting review",
+            },
+            milestone_events=[milestone],
         )
     # indeterminate
     return PhaseResult.pause(
@@ -364,5 +403,6 @@ def handle(ctx, deps) -> PhaseResult:
             **common_patch,
             "error_message": "Acceptance indeterminate: awaiting evidence",
         },
+        milestone_events=[milestone],
         structured_error={"message": "indeterminate", "report": report},
     )

--- a/app/modules/workspace/autonomous/phases/acceptance_verification.py
+++ b/app/modules/workspace/autonomous/phases/acceptance_verification.py
@@ -1,9 +1,9 @@
 """acceptance_verification phase handler (#2335).
 
-Independent post-merge verification. The feature is opt-in while its gates are
-being hardened; when disabled, the handler completes immediately without
-running the verifier or changing the issue. When enabled, the workflow does NOT auto-close the issue
-on merge (autonomous PRs use ``Implements #N``, not ``Closes #N``). Instead this
+Independent post-merge verification. When explicitly disabled, the handler
+completes immediately without running the verifier or changing the issue. When
+enabled, the workflow does NOT auto-close the issue on merge (autonomous PRs use
+``Implements #N``, not ``Closes #N``). Instead this
 phase spawns a credentialless read-only verifier on the merged main SHA, runs a
 deterministic scope gate, aggregates per-item verdicts, and only closes the
 issue (as @open-ace-bot) on ``confirmed``.
@@ -12,12 +12,13 @@ Transitions:
   confirmed      -> close issue + acceptance report -> completed
   rejected       -> paused (delivered code is never marked failed; human reviews)
   indeterminate  -> paused (issue open; human provides missing evidence)
+  infrastructure -> retry (diagnostic report, no terminal milestone)
 
 Idempotent on the confirmed result: a re-entry whose ``verification_status`` is
 already ``confirmed`` is a terminal no-op (no re-close, no re-comment). A new
 merge SHA or an edited issue (new ``issue_acceptance_hash``) re-runs the
-verifier naturally because the phase re-enters; full (merge_sha, hash) dedup
-of in-flight attempts is S5 polish.
+verifier naturally because the phase re-enters. Full (merge_sha, hash) dedup
+only reuses settled evidence; infrastructure failures always retry.
 """
 
 from __future__ import annotations
@@ -170,6 +171,11 @@ def _already_verified_for(wf: dict, merge_sha: str, snap_hash: str) -> dict | No
         return None
     if not isinstance(report, dict):
         return None
+    # Infrastructure failures are observations about an attempt, not settled
+    # acceptance evidence. A resume/retry for the same pair must run a fresh
+    # verifier instead of permanently replaying the transient failure.
+    if report.get("infra_error"):
+        return None
     # Match on the CURRENT pair: merge_sha + the hash at verify time. A changed
     # merge (new PR) or an edited issue (new hash) misses and re-verifies.
     if report.get("merge_sha") != merge_sha:
@@ -311,10 +317,42 @@ def handle(ctx, deps) -> PhaseResult:
         except Exception:
             pass
 
+    # A syntactically valid verifier response is not necessarily complete.  A
+    # missing checklist verdict must never disappear from the aggregate and
+    # let unrelated scope/gate confirmations close the issue.  Require an
+    # exact item match after harmless whitespace/case normalization; anything
+    # omitted remains explicitly indeterminate for human follow-up.
+    def _normalized_item(value: object) -> str:
+        return " ".join(str(value or "").split()).casefold()
+
+    covered_items = {
+        _normalized_item(verdict.item) for verdict in verifier_verdicts if verdict.item
+    }
+    for checklist_item in snapshot.checklist:
+        normalized = _normalized_item(checklist_item)
+        if normalized and normalized not in covered_items:
+            verifier_verdicts.append(
+                ItemVerdict(
+                    item=checklist_item,
+                    verdict=Verdict.INDETERMINATE,
+                    evidence=[
+                        {
+                            "ref": "verifier:missing-item",
+                            "note": "The verifier returned no verdict for this acceptance item.",
+                        }
+                    ],
+                    rationale=(
+                        "The verifier did not cover this checklist item; no acceptance "
+                        "decision was made for it."
+                    ),
+                )
+            )
+            covered_items.add(normalized)
+
     # Mechanical scope gate (deterministic): required paths must be in the diff.
     scope_verdicts = run_scope_gate(gh, snapshot.required_paths, base_sha, merge_sha)
 
-    # The other 5 mechanical gates (#2335 S4): conservative static-analysis
+    # The other 4 mechanical gates (#2335 S4): conservative static-analysis
     # checks whose verdicts fold into the issue-level aggregation alongside the
     # scope gate and the verifier findings.
     gate_verdicts = run_mechanical_gates(gh, snapshot, base_sha, merge_sha)
@@ -350,6 +388,7 @@ def handle(ctx, deps) -> PhaseResult:
             for v in verifier_verdicts
         ],
         "status": status,
+        "infra_error": agent_out.get("infra_error") or None,
         "verified_at": _now_iso(),
     }
 
@@ -366,9 +405,22 @@ def handle(ctx, deps) -> PhaseResult:
         "verified_by": verified_by,
         "verification_attempt": (wf.get("verification_attempt") or 0) + 1,
     }
+    if agent_out.get("infra_error"):
+        # Infrastructure failures are not acceptance evidence and must not
+        # create a terminal milestone. Keep the workflow in its current phase
+        # so the scheduler can retry automatically; the attempt report remains
+        # persisted for diagnostics.
+        return PhaseResult.retry(
+            workflow_patch={
+                **common_patch,
+                "error_message": "Acceptance verifier infrastructure failure; retrying",
+            }
+        )
+
     milestone = {
         "workflow_id": wf.get("workflow_id"),
         "phase": "acceptance_verification",
+        "round_number": common_patch["verification_attempt"],
         "milestone_type": "acceptance_verification",
         "status": status,
         "title": f"Acceptance verification: {status}",
@@ -382,7 +434,11 @@ def handle(ctx, deps) -> PhaseResult:
         common_patch["issue_closed_by_workflow_at"] = _now_iso()
         return PhaseResult.completed(
             next_phase="completed",
-            workflow_patch={**common_patch, "completed_at": _now_iso()},
+            workflow_patch={
+                **common_patch,
+                "completed_at": _now_iso(),
+                "error_message": None,
+            },
             milestone_events=[milestone],
         )
     if status == "rejected":

--- a/app/repositories/autonomous_repo.py
+++ b/app/repositories/autonomous_repo.py
@@ -1281,6 +1281,8 @@ class AutonomousWorkflowRepository:
 
         Returns True if the lock was acquired, False if already locked.
         Stale locks (older than LOCK_TIMEOUT_SECONDS) are broken automatically.
+        The scheduler renews live leases with :meth:`refresh_lock`, because
+        agent calls may legitimately run longer than this recovery timeout.
         """
         import app.repositories.database as _db_mod
 
@@ -1307,6 +1309,36 @@ class AutonomousWorkflowRepository:
             rowcount = cursor.rowcount
             conn.commit()
             return rowcount > 0
+        finally:
+            conn.close()
+
+    def refresh_lock(self, workflow_id: str, owner: str) -> bool:
+        """Renew a workflow lease only while ``owner`` still holds it.
+
+        Long agent phases can exceed :attr:`LOCK_TIMEOUT_SECONDS`. The
+        scheduler heartbeats through this compare-and-set update so another
+        process never treats a healthy advance as stale. ``False`` means
+        ownership was lost and the caller must stop the old advance.
+        """
+        import app.repositories.database as _db_mod
+
+        now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+        conn = self.db.get_connection()
+        try:
+            cursor = conn.cursor()
+            cursor.execute(
+                _db_mod.adapt_sql(
+                    """
+                    UPDATE autonomous_workflows
+                    SET locked_at = ?
+                    WHERE workflow_id = ? AND locked_by = ?
+                    """
+                ),
+                (now, workflow_id, owner),
+            )
+            refreshed = cursor.rowcount > 0
+            conn.commit()
+            return refreshed
         finally:
             conn.close()
 

--- a/app/repositories/autonomous_repo.py
+++ b/app/repositories/autonomous_repo.py
@@ -680,7 +680,11 @@ class AutonomousWorkflowRepository:
             conn.close()
 
     def update_workflow(
-        self, workflow_id: str, updates: dict, expected_values: dict | None = None
+        self,
+        workflow_id: str,
+        updates: dict,
+        expected_values: dict | None = None,
+        required_lock_owner: str | None = None,
     ) -> dict | None:
         """Update a workflow's fields. Returns updated record.
 
@@ -692,6 +696,8 @@ class AutonomousWorkflowRepository:
             workflow_id: Workflow UUID
             updates: Dict of fields to update
             expected_values: Optional dict of {field: old_value} for optimistic lock
+            required_lock_owner: Optional distributed-lock owner that must still
+                match for the update to commit (scheduler fencing).
 
         Returns:
             Updated workflow dict if successful, None if optimistic lock failed
@@ -724,6 +730,9 @@ class AutonomousWorkflowRepository:
 
         # ── Optimistic lock support (Phase 1, P0) ──────────────────────
         where_clauses = ["workflow_id = ?"]
+        if required_lock_owner:
+            where_clauses.append("locked_by = ?")
+            params.append(required_lock_owner)
         if expected_values:
             # Filter expected_values to retry fields only (保守策略)
             _RETRY_FIELDS = {"test_retries", "skip_retries", "dev_retries_on_test_fail"}
@@ -742,12 +751,13 @@ class AutonomousWorkflowRepository:
             affected_rows = cursor.rowcount
             conn.commit()
 
-            if expected_values and affected_rows == 0:
-                # Optimistic lock failed - concurrent modification detected
+            if (expected_values or required_lock_owner) and affected_rows == 0:
+                # Optimistic/fencing condition failed - concurrent modification detected
                 logger.warning(
-                    "Optimistic lock failed for workflow %s: expected_values=%s",
+                    "Conditional workflow update failed for %s: expected=%s lock_owner=%s",
                     workflow_id[:8],
                     expected_values,
+                    required_lock_owner,
                 )
                 return None
 
@@ -1339,6 +1349,34 @@ class AutonomousWorkflowRepository:
             refreshed = cursor.rowcount > 0
             conn.commit()
             return refreshed
+        finally:
+            conn.close()
+
+    def clear_agent_pid_if_lock_owner(self, workflow_id: str, owner: str) -> bool:
+        """Clear stale agent identity only while ``owner`` still holds the lease.
+
+        This is the scheduler-finally safety net. A superseded worker must not
+        clear the PID just registered by the replacement owner.
+        """
+        import app.repositories.database as _db_mod
+
+        now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+        conn = self.db.get_connection()
+        try:
+            cursor = conn.cursor()
+            cursor.execute(
+                _db_mod.adapt_sql(
+                    """
+                    UPDATE autonomous_workflows
+                    SET agent_pid = NULL, agent_session_id = '', updated_at = ?
+                    WHERE workflow_id = ? AND locked_by = ? AND agent_pid IS NOT NULL
+                    """
+                ),
+                (now, workflow_id, owner),
+            )
+            cleared = cursor.rowcount > 0
+            conn.commit()
+            return cleared
         finally:
             conn.close()
 

--- a/app/services/autonomous_scheduler.py
+++ b/app/services/autonomous_scheduler.py
@@ -46,6 +46,11 @@ _AGENT_LAUNCHER_CONF = os.environ.get("OPENACE_LAUNCHER_CONF", "/etc/openace/age
 _SANDBOX_TTL_SECONDS = int(os.environ.get("OPENACE_SANDBOX_TTL_SECONDS", "7200"))
 _SANDBOX_REAP_INTERVAL_SECONDS = float(os.environ.get("OPENACE_SANDBOX_REAP_INTERVAL", "300"))
 
+# Renew workflow DB leases well inside the repository's 30-minute stale-lock
+# window. Agent phases (including acceptance verification) can legitimately run
+# for 60 minutes, so a one-shot acquisition is not sufficient across processes.
+WORKFLOW_LOCK_HEARTBEAT_SECONDS = 60.0
+
 
 def get_max_concurrent_workflows() -> int:
     """Resolve the concurrency cap from agent-launcher.conf (default 3)."""
@@ -510,8 +515,10 @@ class AutonomousScheduler:
         from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
         from app.routes.autonomous import _get_repo
 
-        # Unique lock owner: hostname + thread name
-        lock_owner = f"{socket.gethostname()}/{threading.current_thread().name}"
+        # Include the PID: two scheduler processes on one host commonly reuse
+        # the same worker-thread name. Without a process-unique owner, an old
+        # worker's finally could release a newer process's replacement lease.
+        lock_owner = f"{socket.gethostname()}/{os.getpid()}/{threading.current_thread().name}"
         repo = _get_repo()
 
         # Get workflow's batch_id and git-conflict keys for cleanup
@@ -549,6 +556,15 @@ class AutonomousScheduler:
                 if branch and not was_waiting:
                     self._in_progress_branches.discard(branch)
             return workflow_id
+
+        heartbeat_stop = threading.Event()
+        heartbeat_thread = threading.Thread(
+            target=self._heartbeat_workflow_lock,
+            args=(repo, workflow_id, lock_owner, heartbeat_stop),
+            name=f"workflow-lock-{workflow_id[:8]}",
+            daemon=True,
+        )
+        heartbeat_thread.start()
 
         # Quota gate (fail-closed): a user over quota (or whose quota check
         # errored) must not advance. This scheduler is the lifecycle authority
@@ -620,6 +636,10 @@ class AutonomousScheduler:
                     )
             except Exception:
                 pass
+            # Stop and join the renewer before release so it cannot refresh a
+            # lease after this worker has relinquished ownership.
+            heartbeat_stop.set()
+            heartbeat_thread.join(timeout=1)
             # Release DB lock
             try:
                 repo.release_lock(workflow_id, lock_owner)
@@ -635,6 +655,32 @@ class AutonomousScheduler:
                 if branch and not was_waiting:
                     self._in_progress_branches.discard(branch)
         return workflow_id
+
+    def _heartbeat_workflow_lock(
+        self, repo, workflow_id: str, lock_owner: str, stop_event: threading.Event
+    ) -> None:
+        """Renew a live advance's distributed lock until the worker exits."""
+        while not stop_event.wait(WORKFLOW_LOCK_HEARTBEAT_SECONDS):
+            try:
+                if repo.refresh_lock(workflow_id, lock_owner):
+                    continue
+                logger.error(
+                    "Workflow %s lost its distributed lock; stopping old advance",
+                    workflow_id[:8],
+                )
+                with self._orchestrator_lock:
+                    orchestrator = self._running_orchestrators.get(workflow_id)
+                if orchestrator is not None:
+                    orchestrator.prepare_for_shutdown()
+                return
+            except Exception:
+                # A transient DB failure does not prove ownership was lost. Try
+                # again next tick; the cadence leaves ample room before expiry.
+                logger.warning(
+                    "Failed to refresh workflow lock for %s",
+                    workflow_id[:8],
+                    exc_info=True,
+                )
 
     @staticmethod
     def _batch_has_running_workflow(batch_workflows: list[dict]) -> bool:

--- a/app/services/autonomous_scheduler.py
+++ b/app/services/autonomous_scheduler.py
@@ -565,7 +565,6 @@ class AutonomousScheduler:
             name=f"workflow-lock-{workflow_id[:8]}",
             daemon=True,
         )
-        heartbeat_thread.start()
 
         # Quota gate (fail-closed): a user over quota (or whose quota check
         # errored) must not advance. This scheduler is the lifecycle authority
@@ -583,7 +582,10 @@ class AutonomousScheduler:
         # still release the DB lock and in-progress slot — otherwise a
         # quota-paused workflow would hold both forever.
         orchestrator = None
+        heartbeat_started = False
         try:
+            heartbeat_thread.start()
+            heartbeat_started = True
             # owner_id resolved above (alongside batch_id) for in-progress accounting.
             if owner_id is not None:
                 try:
@@ -631,6 +633,11 @@ class AutonomousScheduler:
         finally:
             with self._orchestrator_lock:
                 self._running_orchestrators.pop(workflow_id, None)
+            # Stop and join the renewer before any final mutation/release so it
+            # cannot refresh a lease after this worker relinquishes ownership.
+            heartbeat_stop.set()
+            if heartbeat_started:
+                heartbeat_thread.join(timeout=1)
             # Safety net: clear stale agent identity only if this worker still
             # owns the distributed lease. A superseded worker must not erase a
             # replacement process's freshly-registered PID.
@@ -638,10 +645,6 @@ class AutonomousScheduler:
                 repo.clear_agent_pid_if_lock_owner(workflow_id, lock_owner)
             except Exception:
                 pass
-            # Stop and join the renewer before release so it cannot refresh a
-            # lease after this worker has relinquished ownership.
-            heartbeat_stop.set()
-            heartbeat_thread.join(timeout=1)
             # Release DB lock
             try:
                 repo.release_lock(workflow_id, lock_owner)

--- a/app/services/autonomous_scheduler.py
+++ b/app/services/autonomous_scheduler.py
@@ -558,9 +558,10 @@ class AutonomousScheduler:
             return workflow_id
 
         heartbeat_stop = threading.Event()
+        lock_lost = threading.Event()
         heartbeat_thread = threading.Thread(
             target=self._heartbeat_workflow_lock,
-            args=(repo, workflow_id, lock_owner, heartbeat_stop),
+            args=(repo, workflow_id, lock_owner, heartbeat_stop, lock_lost),
             name=f"workflow-lock-{workflow_id[:8]}",
             daemon=True,
         )
@@ -604,8 +605,15 @@ class AutonomousScheduler:
                     return workflow_id
 
             orchestrator = AutonomousOrchestrator(workflow_id)
+            orchestrator.bind_scheduler_lock(lock_owner, lock_lost)
             with self._orchestrator_lock:
                 self._running_orchestrators[workflow_id] = orchestrator
+            # The heartbeat can lose the lease before the orchestrator is
+            # registered (and therefore cannot stop it directly). Fence that
+            # construction window before any phase is allowed to advance.
+            if lock_lost.is_set():
+                orchestrator.prepare_for_shutdown()
+                return workflow_id
             # stop() may race with this worker after its orchestrator snapshot.
             # Register first, then re-check the event so no new agent task can
             # start after graceful shutdown has begun.
@@ -623,17 +631,11 @@ class AutonomousScheduler:
         finally:
             with self._orchestrator_lock:
                 self._running_orchestrators.pop(workflow_id, None)
-            # Safety net: clear stale agent_pid if orchestrator failed to clean up
+            # Safety net: clear stale agent identity only if this worker still
+            # owns the distributed lease. A superseded worker must not erase a
+            # replacement process's freshly-registered PID.
             try:
-                wf_check = repo.get_workflow(workflow_id)
-                if wf_check and wf_check.get("agent_pid"):
-                    repo.update_workflow(
-                        workflow_id,
-                        {
-                            "agent_pid": None,
-                            "agent_session_id": "",
-                        },
-                    )
+                repo.clear_agent_pid_if_lock_owner(workflow_id, lock_owner)
             except Exception:
                 pass
             # Stop and join the renewer before release so it cannot refresh a
@@ -657,13 +659,19 @@ class AutonomousScheduler:
         return workflow_id
 
     def _heartbeat_workflow_lock(
-        self, repo, workflow_id: str, lock_owner: str, stop_event: threading.Event
+        self,
+        repo,
+        workflow_id: str,
+        lock_owner: str,
+        stop_event: threading.Event,
+        lock_lost: threading.Event,
     ) -> None:
         """Renew a live advance's distributed lock until the worker exits."""
         while not stop_event.wait(WORKFLOW_LOCK_HEARTBEAT_SECONDS):
             try:
                 if repo.refresh_lock(workflow_id, lock_owner):
                     continue
+                lock_lost.set()
                 logger.error(
                     "Workflow %s lost its distributed lock; stopping old advance",
                     workflow_id[:8],

--- a/app/utils/config.py
+++ b/app/utils/config.py
@@ -79,13 +79,13 @@ def is_autonomous_enabled() -> bool:
 def is_acceptance_verification_enabled() -> bool:
     """Check whether post-merge acceptance verification is enabled.
 
-    The verifier remains opt-in while its scope and legacy-pattern gates are
-    being hardened.  Keeping the default disabled lets workflows already
-    parked at ``verification_pending`` drain safely to completion.
+    The verifier is enabled by default now that its fail-safe paths have been
+    hardened. Operators can still disable it explicitly to make the acceptance
+    phase complete without running the verifier.
     """
-    # Fail closed: JSON strings such as "false" are truthy in Python and must
-    # never accidentally enable a verifier that is intentionally opt-in.
-    return get_config_value("autonomous", "acceptance_verification_enabled", False) is True
+    # Only a real JSON boolean controls the feature.  In particular, the string
+    # "false" must not become truthy through Python's bool() coercion.
+    return get_config_value("autonomous", "acceptance_verification_enabled", True) is True
 
 
 def is_run_timeline_enabled() -> bool:

--- a/tests/issues/2335/test_acceptance_flow_integration.py
+++ b/tests/issues/2335/test_acceptance_flow_integration.py
@@ -70,7 +70,14 @@ def test_reject_pauses_then_later_delivery_confirms_and_closes_issue():
     )
     deps.host.run_verification_agent.return_value = {
         "verdicts": [
-            {"item": "retention runs", "verdict": "confirmed", "evidence": [], "rationale": ""}
+            {
+                "item": "retention runs",
+                "verdict": "confirmed",
+                "evidence": [
+                    {"ref": "app/services/retention.py:1", "note": "implementation present"}
+                ],
+                "rationale": "",
+            }
         ],
         "snapshot": None,
     }

--- a/tests/issues/2335/test_acceptance_flow_integration.py
+++ b/tests/issues/2335/test_acceptance_flow_integration.py
@@ -1,6 +1,9 @@
-"""End-to-end-ish acceptance flow: the phase handler + scope gate + aggregation
-drive the workflow from merged -> rejected -> dev -> confirmed -> issue closed.
-The verifier agent is mocked (no real LLM in CI)."""
+"""End-to-end-ish acceptance flow across a rejected delivery and a later fix.
+
+Rejected delivered code pauses for review.  A separately delivered fix can then
+be verified and confirmed; the old, already-cleaned worktree is never re-entered.
+The verifier agent is mocked (no real LLM in CI).
+"""
 
 from unittest.mock import MagicMock
 
@@ -18,7 +21,7 @@ def _ctx(wf):
     )
 
 
-def test_reject_then_fix_then_confirm_closes_issue():
+def test_reject_pauses_then_later_delivery_confirms_and_closes_issue():
     wf = {
         "id": 1,
         "workflow_id": "w1",
@@ -32,24 +35,25 @@ def test_reject_then_fix_then_confirm_closes_issue():
         "dev_round": 1,
     }
 
-    # Round 1: required path missing -> REJECTED -> new dev round, issue stays open.
+    # Delivery 1: required path missing -> REJECTED -> pause, issue stays open.
     deps = MagicMock()
     deps.gh.get_issue.return_value = {"body": "## Scope\n- `app/services/retention.py`"}
     deps.gh.get_changed_files.return_value = []
     deps.host.run_verification_agent.return_value = {"verdicts": [], "snapshot": None}
     deps.host.issue_is_open.return_value = True
-    deps.host.dev_round_cap_remaining.return_value = 3
     r1 = av.handle(_ctx(wf), deps)
-    assert r1.outcome == "completed" and r1.next_phase == "development"
-    assert r1.workflow_patch["dev_round"] == 2
+    assert r1.outcome == "pause"
+    assert r1.workflow_patch["verification_status"] == "rejected"
+    deps.host.dev_round_cap_remaining.assert_not_called()
     deps.gh.close_issue.assert_not_called()
 
-    # Simulate the dev round landing the required file; re-verify. The fix
+    # Simulate a later, separately delivered fix and re-verify. The fix
     # includes a failure-path test (so the negative-test mechanical gate #2335
     # S4 sees coverage for the security/data-loss path) and wires the new
     # service module's caller (so the call-chain gate passes).
     wf.update(r1.workflow_patch)
-    wf["verification_status"] = None  # reset for the new round
+    wf["verification_status"] = None
+    wf["verification_merge_sha"] = "merge-fixed"
     deps.gh.get_changed_files.return_value = [
         "app/services/retention.py",
         "app/services/retention_runner.py",  # production caller for the service module

--- a/tests/issues/2335/test_acceptance_flow_widening.py
+++ b/tests/issues/2335/test_acceptance_flow_widening.py
@@ -1,6 +1,6 @@
 """#2335 S6: widened acceptance state-machine integration.
 
-Multi-round reject -> fix -> confirm -> close, the reopen guard (an externally
+Multi-delivery reject -> fix -> confirm -> close, the reopen guard (an externally
 closed issue is reopened before verifying), and idempotent re-entry on an
 already-confirmed workflow. The verifier agent is mocked (no real LLM in CI);
 this exercises the full phase-handler state machine.
@@ -39,9 +39,7 @@ def _base_wf(**overrides):
     return wf
 
 
-def _deps(
-    *, issue_open=True, dev_cap=3, changed_files=None, agent_verdicts=None, agent_snapshot=None
-):
+def _deps(*, issue_open=True, changed_files=None, agent_verdicts=None, agent_snapshot=None):
     deps = MagicMock()
     deps.gh.get_issue.return_value = {"body": "## Scope\n- `app/x.py`\n- `app/y.py`"}
     deps.gh.get_changed_files.return_value = changed_files if changed_files is not None else []
@@ -50,36 +48,35 @@ def _deps(
         "snapshot": agent_snapshot,
     }
     deps.host.issue_is_open.return_value = issue_open
-    deps.host.dev_round_cap_remaining.return_value = dev_cap
     return deps
 
 
-def test_multi_round_reject_fix_confirm_closes_issue():
-    """Round 1: scope missing both paths -> rejected -> dev round 2.
-    Round 2: one path present -> still rejected (one required path missing).
-    Round 3: both paths present + verifier confirms -> confirmed -> issue closed."""
+def test_multi_delivery_reject_fix_confirm_closes_issue():
+    """Rejected deliveries pause; a later complete delivery can confirm."""
     wf = _base_wf()
-    deps = _deps(dev_cap=5)
+    deps = _deps()
 
-    # Round 1: nothing changed -> both required paths REJECTED.
+    # Delivery 1: nothing changed -> both required paths REJECTED.
     deps.gh.get_changed_files.return_value = []
     r1 = av.handle(_ctx(wf), deps)
-    assert r1.outcome == "completed" and r1.next_phase == "development"
-    assert r1.workflow_patch["dev_round"] == 2
+    assert r1.outcome == "pause"
+    assert r1.workflow_patch["verification_status"] == "rejected"
     deps.gh.close_issue.assert_not_called()
     wf.update(r1.workflow_patch)
     wf["verification_status"] = None
+    wf["verification_merge_sha"] = "merge-2"
 
-    # Round 2: only x.py landed -> y.py still REJECTED.
+    # Delivery 2: only x.py landed -> y.py still REJECTED and paused.
     deps.gh.get_changed_files.return_value = ["app/x.py"]
     r2 = av.handle(_ctx(wf), deps)
-    assert r2.outcome == "completed" and r2.next_phase == "development"
-    assert r2.workflow_patch["dev_round"] == 3
+    assert r2.outcome == "pause"
+    assert r2.workflow_patch["verification_status"] == "rejected"
     deps.gh.close_issue.assert_not_called()
     wf.update(r2.workflow_patch)
     wf["verification_status"] = None
+    wf["verification_merge_sha"] = "merge-3"
 
-    # Round 3: both paths present + verifier confirms checklist.
+    # Delivery 3: both paths present + verifier confirms checklist.
     deps.gh.get_changed_files.return_value = ["app/x.py", "app/y.py"]
     deps.host.run_verification_agent.return_value = {
         "verdicts": [
@@ -100,11 +97,23 @@ def test_reopen_guard_reopens_externally_closed_issue_before_verifying():
     wf = _base_wf()
     deps = _deps(issue_open=False, changed_files=["app/x.py", "app/y.py"])
     deps.host.run_verification_agent.return_value = {"verdicts": [], "snapshot": None}
+    deps.gh.get_issue_closure.return_value = {
+        "closed_at": "2026-08-08T00:00:00Z",
+        "closer_login": "open-ace-bot",
+    }
+    deps.gh.get_authenticated_login.return_value = "open-ace-bot"
 
     av.handle(_ctx(wf), deps)
 
     deps.gh.reopen_issue.assert_called_once_with(777)
-    deps.host.emit_audit_event.assert_called_once_with("acceptance_reopened_issue", {"issue": 777})
+    deps.host.emit_audit_event.assert_called_once_with(
+        "acceptance_reopened_issue",
+        {
+            "issue": 777,
+            "closer": "open-ace-bot",
+            "closed_at": "2026-08-08T00:00:00Z",
+        },
+    )
 
 
 def test_idempotent_reentry_on_confirmed_is_terminal_noop():
@@ -121,15 +130,16 @@ def test_idempotent_reentry_on_confirmed_is_terminal_noop():
     deps.gh.add_issue_comment.assert_not_called()
 
 
-def test_rejected_at_dev_round_cap_transitions_to_failed():
-    """When dev_round_cap_remaining is 0, a rejection fails the workflow
-    instead of looping back to development."""
+def test_rejected_pauses_without_consulting_dev_round_cap():
+    """A rejected delivered merge pauses; it never re-enters development."""
     wf = _base_wf(dev_round=5)
-    deps = _deps(dev_cap=0, changed_files=[])  # both required paths missing
+    deps = _deps(changed_files=[])  # both required paths missing
 
     result = av.handle(_ctx(wf), deps)
 
-    assert result.outcome == "failed"
+    assert result.outcome == "pause"
+    assert result.workflow_patch["verification_status"] == "rejected"
+    deps.host.dev_round_cap_remaining.assert_not_called()
     deps.gh.close_issue.assert_not_called()
 
 

--- a/tests/issues/2335/test_acceptance_flow_widening.py
+++ b/tests/issues/2335/test_acceptance_flow_widening.py
@@ -80,7 +80,12 @@ def test_multi_delivery_reject_fix_confirm_closes_issue():
     deps.gh.get_changed_files.return_value = ["app/x.py", "app/y.py"]
     deps.host.run_verification_agent.return_value = {
         "verdicts": [
-            {"item": "x works", "verdict": "confirmed", "evidence": [], "rationale": ""},
+            {
+                "item": "x works",
+                "verdict": "confirmed",
+                "evidence": [{"ref": "app/x.py:1", "note": "implementation present"}],
+                "rationale": "",
+            },
         ],
         "snapshot": None,
     }

--- a/tests/issues/2335/test_acceptance_gates.py
+++ b/tests/issues/2335/test_acceptance_gates.py
@@ -10,8 +10,9 @@ git/IO is required.
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
+from app.modules.workspace.autonomous import acceptance_gates as gates_module
 from app.modules.workspace.autonomous.acceptance_gates import (
     call_chain_gate,
     deployment_gate,
@@ -21,6 +22,7 @@ from app.modules.workspace.autonomous.acceptance_gates import (
     run_mechanical_gates,
 )
 from app.modules.workspace.autonomous.acceptance_snapshot import AcceptanceSnapshot
+from app.modules.workspace.autonomous.acceptance_verdicts import ItemVerdict
 from app.modules.workspace.autonomous.evidence import Verdict
 
 
@@ -267,15 +269,34 @@ def test_regression_silent_when_only_todo_in_security_path():
 
 
 def test_run_mechanical_gates_returns_flat_list():
-    gh = _gh(["app/services/security/auth.py", "tests/test_auth.py"])
-    files = {
-        "app/services/security/auth.py": "def verify():\n    pass\n",
-        "tests/test_auth.py": "def test_x():\n    with pytest.raises(E):\n        verify()\n",
+    production_gate_names = (
+        "negative_test_gate",
+        "call_chain_gate",
+        "deployment_gate",
+        "regression_gate",
+    )
+    production_mocks = {
+        name: MagicMock(return_value=[ItemVerdict(item=name, verdict=Verdict.CONFIRMED)])
+        for name in production_gate_names
     }
-    verdicts = run_mechanical_gates(gh, AcceptanceSnapshot(), "b", "m", read_file=_reader(files))
-    # At least one verdict per gate (5 gates), flat list.
-    assert isinstance(verdicts, list)
-    assert all(hasattr(v, "verdict") for v in verdicts)
+    legacy_mock = MagicMock(
+        return_value=[ItemVerdict(item="legacy_pattern_gate", verdict=Verdict.REJECTED)]
+    )
+    patches = [patch.object(gates_module, name, mock) for name, mock in production_mocks.items()]
+    patches.append(patch.object(gates_module, "legacy_pattern_gate", legacy_mock))
+
+    for active_patch in patches:
+        active_patch.start()
+    try:
+        verdicts = run_mechanical_gates(_gh([]), AcceptanceSnapshot(), "b", "m")
+    finally:
+        for active_patch in reversed(patches):
+            active_patch.stop()
+
+    assert [verdict.item for verdict in verdicts] == list(production_gate_names)
+    for gate_mock in production_mocks.values():
+        gate_mock.assert_called_once()
+    legacy_mock.assert_not_called()
 
 
 def test_run_mechanical_gates_works_without_read_file():
@@ -291,9 +312,9 @@ def test_run_mechanical_gates_works_without_read_file():
         assert v.verdict in (Verdict.CONFIRMED, Verdict.REJECTED, Verdict.INDETERMINATE)
 
 
-def test_run_mechanical_gates_rejects_when_legacy_pattern_present():
+def test_run_mechanical_gates_ignores_retired_legacy_pattern():
     gh = _gh(["app/services/security/keys.py"])
     files = {"app/services/security/keys.py": "_sync_ssh_keys_legacy()\n"}
     verdicts = run_mechanical_gates(gh, AcceptanceSnapshot(), "b", "m", read_file=_reader(files))
-    # The legacy gate emits a REJECTED; at least one verdict is REJECTED.
-    assert any(v.verdict is Verdict.REJECTED for v in verdicts)
+
+    assert all("legacy" not in verdict.item for verdict in verdicts)

--- a/tests/issues/2335/test_acceptance_phase.py
+++ b/tests/issues/2335/test_acceptance_phase.py
@@ -54,7 +54,7 @@ def test_confirmed_closes_issue_and_completes():
     assert result.workflow_patch.get("issue_closed_by_workflow_at")
 
 
-def test_rejected_starts_new_dev_round():
+def test_rejected_pauses_without_reentering_deleted_development_worktree():
     wf = {
         "id": 1,
         "github_issue_number": 42,
@@ -71,15 +71,15 @@ def test_rejected_starts_new_dev_round():
     gh.get_changed_files.return_value = []  # scope gate: required path missing -> REJECTED
     deps = _deps(gh=gh)
     deps.host.run_verification_agent.return_value = {"verdicts": [], "snapshot": None}
-    deps.host.dev_round_cap_remaining.return_value = 2
     result = av.handle(_ctx(wf), deps)
-    assert result.outcome == "completed"
-    assert result.next_phase == "development"
-    assert result.workflow_patch.get("dev_round") == 2
+    assert result.outcome == "pause"
+    assert result.workflow_patch.get("dev_round") is None
+    assert result.workflow_patch["verification_status"] == "rejected"
+    deps.host.dev_round_cap_remaining.assert_not_called()
     deps.gh.close_issue.assert_not_called()
 
 
-def test_rejected_at_cap_fails():
+def test_rejected_pauses_for_review_regardless_of_old_round_cap():
     wf = {
         "id": 1,
         "github_issue_number": 42,
@@ -98,7 +98,9 @@ def test_rejected_at_cap_fails():
     deps.host.run_verification_agent.return_value = {"verdicts": [], "snapshot": None}
     deps.host.dev_round_cap_remaining.return_value = 0
     result = av.handle(_ctx(wf), deps)
-    assert result.outcome == "failed"
+    assert result.outcome == "pause"
+    assert result.workflow_patch["verification_status"] == "rejected"
+    deps.host.dev_round_cap_remaining.assert_not_called()
     deps.gh.close_issue.assert_not_called()
 
 
@@ -165,9 +167,39 @@ def test_closed_issue_reopened_when_not_confirmed():
     gh.get_changed_files.return_value = ["app/x.py"]
     deps = _deps(gh=gh)
     deps.host.issue_is_open.return_value = False  # auto-closed externally
+    deps.gh.get_issue_closure.return_value = {
+        "closed_at": "2026-08-08T00:00:00Z",
+        "closer_login": "open-ace-bot",
+    }
+    deps.gh.get_authenticated_login.return_value = "open-ace-bot"
     deps.host.run_verification_agent.return_value = {"verdicts": [], "snapshot": None}
     av.handle(_ctx(wf), deps)
     deps.gh.reopen_issue.assert_called_once_with(42)  # reopen guard fires before verifying
+
+
+def test_human_closed_issue_is_not_reopened():
+    wf = {
+        "id": 1,
+        "github_issue_number": 42,
+        "github_pr_number": 99,
+        "base_commit_sha": "base",
+        "verification_merge_sha": "merge",
+        "verification_status": None,
+        "issue_acceptance_snapshot": None,
+    }
+    deps = _deps(gh=MagicMock())
+    deps.host.issue_is_open.return_value = False
+    deps.gh.get_issue_closure.return_value = {
+        "closed_at": "2026-08-08T00:00:00Z",
+        "closer_login": "human-maintainer",
+    }
+    deps.gh.get_authenticated_login.return_value = "open-ace-bot"
+    deps.host.run_verification_agent.return_value = {"verdicts": [], "snapshot": None}
+
+    av.handle(_ctx(wf), deps)
+
+    deps.gh.reopen_issue.assert_not_called()
+    deps.host.emit_audit_event.assert_not_called()
 
 
 def test_snapshot_persistence_round_trips_source_and_confidence():

--- a/tests/issues/2335/test_acceptance_phase.py
+++ b/tests/issues/2335/test_acceptance_phase.py
@@ -41,7 +41,14 @@ def test_confirmed_closes_issue_and_completes():
     gh._run_git.return_value.stdout = "def f():\n    return 1\n"
     deps = _deps(gh=gh)
     deps.host.run_verification_agent.return_value = {
-        "verdicts": [{"item": "works", "verdict": "confirmed", "evidence": [], "rationale": ""}],
+        "verdicts": [
+            {
+                "item": "works",
+                "verdict": "confirmed",
+                "evidence": [{"ref": "app/x.py:1", "note": "implementation present"}],
+                "rationale": "",
+            }
+        ],
         "snapshot": None,
     }
     deps.host.issue_is_open.return_value = True

--- a/tests/issues/2335/test_verification_idempotency.py
+++ b/tests/issues/2335/test_verification_idempotency.py
@@ -52,11 +52,11 @@ def _persisted_snapshot_json():
 
     snap = AcceptanceSnapshot(
         required_paths=[],
-        checklist=[],
+        checklist=["works"],
         non_scope=[],
         closure_constraints=False,
-        source="missing",
-        confidence="low",
+        source="convention",
+        confidence="high",
     )
     return json.dumps(dataclasses.asdict(snap), ensure_ascii=False), hash_snapshot(snap)
 

--- a/tests/issues/2335/test_verifier_checkout.py
+++ b/tests/issues/2335/test_verifier_checkout.py
@@ -55,6 +55,7 @@ def test_checkout_merged_main_creates_temp_worktree_at_merge_sha(tmp_path):
         return MagicMock(stdout="", stderr="", returncode=0)
 
     gh._run_git = fake_run_git
+    gh.ensure_commit_available.return_value = True
     gh.repo_path = "/dev/repo"
 
     with patch.object(orch_mod.AutonomousOrchestrator, "_get_gh", return_value=gh):
@@ -62,6 +63,7 @@ def test_checkout_merged_main_creates_temp_worktree_at_merge_sha(tmp_path):
             path = orch._checkout_merged_main("abc123")
 
     assert path == str(tmp_path)
+    gh.ensure_commit_available.assert_called_once_with("abc123")
     # The first worktree-add command should target the merge sha in detached mode.
     add_cmds = [c for c in captured_cmds if c[:2] == ["worktree", "add"]]
     assert add_cmds, "expected a git worktree add"
@@ -82,6 +84,7 @@ def test_checkout_merged_main_returns_none_on_failure(tmp_path):
         return MagicMock(stdout="", stderr="", returncode=0)
 
     gh._run_git = fake_run_git
+    gh.ensure_commit_available.return_value = True
     gh.repo_path = "/dev/repo"
 
     with patch.object(orch_mod.AutonomousOrchestrator, "_get_gh", return_value=gh):
@@ -165,6 +168,7 @@ def test_run_verification_agent_cleans_up_checkout_on_exception():
     # Fail-safe: empty verdicts -> indeterminate, never confirmed.
     assert result["verdicts"] == []
     assert result["snapshot"] is None
+    assert result["infra_error"] == "verification agent spawn failed"
     mock_rm.assert_called_once()
 
 
@@ -186,7 +190,59 @@ def test_run_verification_agent_returns_empty_when_checkout_fails():
 
     assert result["verdicts"] == []
     assert result["snapshot"] is None
+    assert result["infra_error"] == "merged-main checkout failed"
     mock_spawn.assert_not_called()
+
+
+def test_run_verification_agent_signals_unsuccessful_agent_result():
+    orch = _make_orchestrator()
+    snapshot = MagicMock()
+    snapshot.to_canonical.return_value = {}
+    failed_result = MagicMock(success=False, error="secret provider detail", error_code="timeout")
+
+    with patch.object(
+        orch_mod.AutonomousOrchestrator, "_checkout_merged_main", return_value="/tmp/merged"
+    ):
+        with patch.object(orch_mod.AutonomousOrchestrator, "_remove_verification_worktree"):
+            with patch.object(
+                orch_mod.AutonomousOrchestrator, "_run_agent", return_value=failed_result
+            ):
+                result = orch._run_verification_agent(
+                    snapshot=snapshot,
+                    merge_sha="deadbeef",
+                    base_sha="base",
+                    issue_number=42,
+                    pr_number=99,
+                )
+
+    assert result["infra_error"] == "verification agent failed (timeout)"
+    assert "secret provider detail" not in result["infra_error"]
+
+
+def test_parse_valid_empty_verdict_response_is_not_an_infra_error():
+    orch = _make_orchestrator()
+    result = MagicMock()
+    with patch.object(
+        orch_mod.AutonomousOrchestrator,
+        "_artifact_text",
+        return_value='```json\n{"verdicts": [], "snapshot": null}\n```',
+    ):
+        parsed = orch._parse_verifier_output(result)
+
+    assert parsed == {"verdicts": [], "snapshot": None}
+
+
+def test_parse_malformed_verdict_shape_is_explicit_infra_error():
+    orch = _make_orchestrator()
+    result = MagicMock()
+    with patch.object(
+        orch_mod.AutonomousOrchestrator,
+        "_artifact_text",
+        return_value='```json\n{"verdicts": ["not-an-object"], "snapshot": null}\n```',
+    ):
+        parsed = orch._parse_verifier_output(result)
+
+    assert parsed["infra_error"] == "verification agent verdicts were malformed"
 
 
 def test_verified_by_records_model_version():

--- a/tests/issues/2335/test_verifier_checkout.py
+++ b/tests/issues/2335/test_verifier_checkout.py
@@ -9,9 +9,11 @@ checkout/spawn failure it returns empty verdicts (aggregates to
 from __future__ import annotations
 
 import os
+import stat
 from unittest.mock import MagicMock, patch
 
 from app.modules.workspace.autonomous import orchestrator as orch_mod
+from app.modules.workspace.autonomous.github_ops import OPENACE_RM_WRAPPER, GitHubOps
 
 
 def _make_orchestrator():
@@ -58,12 +60,13 @@ def test_checkout_merged_main_creates_temp_worktree_at_merge_sha(tmp_path):
     gh.ensure_commit_available.return_value = True
     gh.repo_path = "/dev/repo"
 
+    gh.create_verification_worktree_dir.return_value = str(tmp_path)
     with patch.object(orch_mod.AutonomousOrchestrator, "_get_gh", return_value=gh):
-        with patch.object(orch_mod.tempfile, "mkdtemp", return_value=str(tmp_path)):
-            path = orch._checkout_merged_main("abc123")
+        path = orch._checkout_merged_main("abc123")
 
     assert path == str(tmp_path)
     gh.ensure_commit_available.assert_called_once_with("abc123")
+    gh.create_verification_worktree_dir.assert_called_once_with("/dev/repo")
     # The first worktree-add command should target the merge sha in detached mode.
     add_cmds = [c for c in captured_cmds if c[:2] == ["worktree", "add"]]
     assert add_cmds, "expected a git worktree add"
@@ -79,7 +82,7 @@ def test_checkout_merged_main_returns_none_on_failure(tmp_path):
     gh = MagicMock()
 
     def fake_run_git(args, **_kw):
-        if args[:2] == ["worktree", "add"]:
+        if args[:2] in (["worktree", "add"], ["worktree", "remove"]):
             raise RuntimeError("boom")
         return MagicMock(stdout="", stderr="", returncode=0)
 
@@ -87,11 +90,12 @@ def test_checkout_merged_main_returns_none_on_failure(tmp_path):
     gh.ensure_commit_available.return_value = True
     gh.repo_path = "/dev/repo"
 
+    gh.create_verification_worktree_dir.return_value = str(tmp_path)
     with patch.object(orch_mod.AutonomousOrchestrator, "_get_gh", return_value=gh):
-        with patch.object(orch_mod.tempfile, "mkdtemp", return_value=str(tmp_path)):
-            path = orch._checkout_merged_main("abc123")
+        path = orch._checkout_merged_main("abc123")
 
     assert path is None
+    gh.remove_verification_worktree_dir.assert_called_once_with(str(tmp_path), "/dev/repo")
 
 
 def test_checkout_merged_main_does_not_create_worktree_when_commit_is_unavailable():
@@ -101,13 +105,70 @@ def test_checkout_merged_main_does_not_create_worktree_when_commit_is_unavailabl
     gh.ensure_commit_available.return_value = False
 
     with patch.object(orch_mod.AutonomousOrchestrator, "_get_gh", return_value=gh):
-        with patch.object(orch_mod.tempfile, "mkdtemp") as mock_mkdtemp:
-            path = orch._checkout_merged_main("abc123")
+        path = orch._checkout_merged_main("abc123")
 
     assert path is None
     gh.ensure_commit_available.assert_called_once_with("abc123")
-    mock_mkdtemp.assert_not_called()
+    gh.create_verification_worktree_dir.assert_not_called()
     gh._run_git.assert_not_called()
+
+
+def test_cross_user_verifier_directory_is_created_by_repository_owner():
+    """Cross-user allocation must not leave a service-owned 0700 target."""
+    gh = GitHubOps("/home/alice/repo", system_account="alice")
+    completed = MagicMock(returncode=0, stdout="", stderr="")
+    with (
+        patch.object(gh, "_needs_sudo", return_value=True),
+        patch(
+            "app.modules.workspace.autonomous.github_ops.subprocess.run",
+            return_value=completed,
+        ) as run,
+        patch("app.modules.workspace.autonomous.github_ops.uuid.uuid4") as make_uuid,
+    ):
+        make_uuid.return_value.hex = "a" * 32
+        path = gh.create_verification_worktree_dir("/home/alice/repo")
+
+    expected_root = os.path.join(os.path.realpath("/home/alice/repo"), ".worktrees")
+    assert path == os.path.join(expected_root, "verify-" + "a" * 32)
+    commands = [call.args[0] for call in run.call_args_list]
+    assert commands == [
+        ["sudo", "-u", "alice", "mkdir", "-p", "--", expected_root],
+        ["sudo", "-u", "alice", "mkdir", "-m", "700", "--", path],
+    ]
+
+
+def test_same_user_verifier_directory_is_private_and_owner_writable(tmp_path):
+    """The real allocator creates a traversable/writable 0700 dir for its owner."""
+    gh = GitHubOps(str(tmp_path))
+    path = gh.create_verification_worktree_dir(str(tmp_path))
+    try:
+        mode = stat.S_IMODE(os.stat(path).st_mode)
+        assert mode == 0o700
+        assert os.access(path, os.X_OK | os.W_OK)
+    finally:
+        gh.remove_verification_worktree_dir(path, str(tmp_path))
+
+
+def test_cross_user_verifier_cleanup_uses_owner_safe_wrapper():
+    """A service user never tries to rmtree a repository-owner 0700 directory."""
+    gh = GitHubOps("/home/alice/repo", system_account="alice")
+    project = os.path.realpath("/home/alice/repo")
+    path = os.path.join(project, ".worktrees", "verify-abc")
+    completed = MagicMock(returncode=0, stdout="", stderr="")
+    with (
+        patch.object(gh, "_needs_sudo", return_value=True),
+        patch(
+            "app.modules.workspace.autonomous.github_ops.subprocess.run",
+            return_value=completed,
+        ) as run,
+        patch("app.modules.workspace.autonomous.github_ops.shutil.rmtree") as rmtree,
+    ):
+        gh.remove_verification_worktree_dir(path, project)
+
+    cmd = run.call_args.args[0]
+    assert cmd[:3] == ["sudo", OPENACE_RM_WRAPPER, "alice"]
+    assert cmd[3:] == [path, "-r", "-f"]
+    rmtree.assert_not_called()
 
 
 def test_run_verification_agent_uses_merged_main_checkout(tmp_path):

--- a/tests/issues/2335/test_verifier_checkout.py
+++ b/tests/issues/2335/test_verifier_checkout.py
@@ -94,6 +94,22 @@ def test_checkout_merged_main_returns_none_on_failure(tmp_path):
     assert path is None
 
 
+def test_checkout_merged_main_does_not_create_worktree_when_commit_is_unavailable():
+    """A failed exact-SHA fetch stops before allocating or mutating a worktree."""
+    orch = _make_orchestrator()
+    gh = MagicMock()
+    gh.ensure_commit_available.return_value = False
+
+    with patch.object(orch_mod.AutonomousOrchestrator, "_get_gh", return_value=gh):
+        with patch.object(orch_mod.tempfile, "mkdtemp") as mock_mkdtemp:
+            path = orch._checkout_merged_main("abc123")
+
+    assert path is None
+    gh.ensure_commit_available.assert_called_once_with("abc123")
+    mock_mkdtemp.assert_not_called()
+    gh._run_git.assert_not_called()
+
+
 def test_run_verification_agent_uses_merged_main_checkout(tmp_path):
     """``_run_verification_agent`` spawns the agent with project_path = the temp checkout."""
     orch = _make_orchestrator()

--- a/tests/issues/2431/test_acceptance_verifier_hardening.py
+++ b/tests/issues/2431/test_acceptance_verifier_hardening.py
@@ -708,6 +708,29 @@ def test_lock_lost_before_orchestrator_registration_never_advances():
     repo.update_workflow.assert_not_called()
 
 
+def test_heartbeat_start_failure_still_releases_distributed_lock():
+    scheduler = AutonomousScheduler()
+    repo = MagicMock()
+    repo.get_workflow.return_value = {"workflow_id": "wf-start", "status": "planning"}
+    repo.acquire_lock.return_value = True
+    heartbeat_thread = MagicMock()
+    heartbeat_thread.start.side_effect = RuntimeError("thread unavailable")
+
+    with (
+        patch("app.routes.autonomous._get_repo", return_value=repo),
+        patch(
+            "app.modules.workspace.autonomous.orchestrator.AutonomousOrchestrator"
+        ) as orchestrator_cls,
+        patch.object(scheduler_module.threading, "Thread", return_value=heartbeat_thread),
+    ):
+        scheduler._advance_single("wf-start")
+
+    orchestrator_cls.assert_not_called()
+    heartbeat_thread.join.assert_not_called()
+    owner = repo.acquire_lock.call_args.args[1]
+    repo.release_lock.assert_called_once_with("wf-start", owner)
+
+
 def test_phase_commit_is_fenced_after_scheduler_lock_loss():
     orchestrator = AutonomousOrchestrator.__new__(AutonomousOrchestrator)
     orchestrator.repo = MagicMock()

--- a/tests/issues/2431/test_acceptance_verifier_hardening.py
+++ b/tests/issues/2431/test_acceptance_verifier_hardening.py
@@ -10,11 +10,14 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from app.modules.workspace.autonomous.acceptance_gates import (
     legacy_pattern_gate,
     run_mechanical_gates,
 )
 from app.modules.workspace.autonomous.acceptance_snapshot import AcceptanceSnapshot
+from app.modules.workspace.autonomous.acceptance_verdicts import ItemVerdict
 from app.modules.workspace.autonomous.evidence import Verdict
 from app.modules.workspace.autonomous.github_ops import GitHubOps
 from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
@@ -61,6 +64,7 @@ def test_scope_git_error_is_indeterminate_not_an_exception():
     assert len(verdicts) == 1
     assert verdicts[0].verdict is Verdict.INDETERMINATE
     assert verdicts[0].item == "scope:changed-files"
+    assert verdicts[0].retryable is True
 
 
 def test_broad_legacy_regex_is_retired_from_production_aggregate():
@@ -144,6 +148,78 @@ def test_infra_result_is_not_terminally_cached_and_resume_can_confirm():
     orchestrator._create_milestone.assert_called_once_with(**second.milestone_events[0])
 
 
+def test_infrastructure_retries_are_bounded_then_pause():
+    deps = MagicMock()
+    deps.gh.get_issue.return_value = {"body": "## Scope\n- `app/x.py`"}
+    deps.gh.get_changed_files.return_value = ["app/x.py"]
+    deps.gh._run_git.return_value.stdout = "def f():\n    return 1\n"
+    deps.host.issue_is_open.return_value = True
+    deps.host.run_verification_agent.return_value = {
+        "verdicts": [],
+        "snapshot": None,
+        "infra_error": "verification agent timed out",
+    }
+    workflow = _workflow()
+    outcomes = []
+
+    for _ in range(av.MAX_VERIFIER_INFRA_RETRIES):
+        result = av.handle(_ctx(workflow), deps)
+        outcomes.append(result)
+        workflow = {**workflow, **result.workflow_patch}
+
+    assert [result.outcome for result in outcomes] == ["retry", "retry", "pause"]
+    assert outcomes[-1].milestone_events
+    final_report = json.loads(outcomes[-1].workflow_patch["verification_report"])
+    assert final_report["infra_retry_count"] == av.MAX_VERIFIER_INFRA_RETRIES
+    assert deps.host.run_verification_agent.call_count == av.MAX_VERIFIER_INFRA_RETRIES
+
+
+@pytest.mark.parametrize("failing_probe", ["scope", "gate"])
+def test_retryable_probe_error_is_not_terminally_cached_and_can_recover(failing_probe):
+    deps = MagicMock()
+    deps.gh.get_issue.return_value = {"body": "## Scope\n- `app/x.py`"}
+    deps.host.issue_is_open.return_value = True
+    deps.host.run_verification_agent.side_effect = lambda **_kwargs: {
+        "verdicts": [],
+        "snapshot": None,
+    }
+    confirmed_scope = ItemVerdict(
+        item="app/x.py",
+        verdict=Verdict.CONFIRMED,
+        evidence=[{"ref": "git-diff:app/x.py", "note": "present"}],
+    )
+    failed_probe = ItemVerdict(
+        item=f"{failing_probe}:error",
+        verdict=Verdict.INDETERMINATE,
+        evidence=[{"ref": "error", "note": "bad object"}],
+        retryable=True,
+    )
+    scope_results = [[failed_probe], [confirmed_scope]] if failing_probe == "scope" else None
+    gate_results = [[failed_probe], []] if failing_probe == "gate" else None
+
+    with (
+        patch.object(
+            av,
+            "run_scope_gate",
+            side_effect=scope_results,
+            return_value=[confirmed_scope],
+        ),
+        patch.object(
+            av,
+            "run_mechanical_gates",
+            side_effect=gate_results,
+            return_value=[],
+        ),
+    ):
+        first = av.handle(_ctx(_workflow()), deps)
+        second = av.handle(_ctx({**_workflow(), **first.workflow_patch}), deps)
+
+    assert first.outcome == "retry"
+    assert second.outcome == "completed"
+    assert deps.host.run_verification_agent.call_count == 2
+    deps.gh.close_issue.assert_called_once_with(42)
+
+
 def test_missing_checklist_verdict_forces_indeterminate_and_never_closes_issue():
     deps = MagicMock()
     deps.gh.get_issue.return_value = {
@@ -179,6 +255,165 @@ def test_missing_checklist_verdict_forces_indeterminate_and_never_closes_issue()
         }
     ]
     deps.gh.add_issue_comment.assert_not_called()
+    deps.gh.close_issue.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("returned_snapshot", "error_fragment"),
+    [
+        (None, "omitted the required extracted acceptance snapshot"),
+        ({"bad": 1}, "returned invalid snapshot"),
+        (
+            {
+                "required_paths": [],
+                "checklist": [],
+                "non_scope": [],
+                "closure_constraints": False,
+            },
+            "contained no verifiable criteria",
+        ),
+    ],
+)
+def test_missing_issue_snapshot_cannot_close_from_invented_confirmed_verdict(
+    returned_snapshot, error_fragment
+):
+    deps = MagicMock()
+    deps.gh.get_issue.return_value = {"body": "No structured acceptance sections."}
+    deps.gh.get_changed_files.return_value = []
+    deps.host.issue_is_open.return_value = True
+    deps.host.run_verification_agent.return_value = {
+        "verdicts": [
+            {
+                "item": "invented",
+                "verdict": "confirmed",
+                "evidence": [{"ref": "app/x.py:1", "note": "not tied to issue"}],
+            }
+        ],
+        "snapshot": returned_snapshot,
+    }
+
+    result = av.handle(_ctx(_workflow()), deps)
+
+    assert result.outcome == "retry"
+    assert result.workflow_patch["verification_status"] == "indeterminate"
+    report = json.loads(result.workflow_patch["verification_report"])
+    assert error_fragment in report["infra_error"]
+    assert any(item["item"] == "verifier:infrastructure" for item in report["verifier"])
+    deps.gh.add_issue_comment.assert_not_called()
+    deps.gh.close_issue.assert_not_called()
+
+
+def test_valid_extracted_snapshot_drives_coverage_and_can_confirm():
+    deps = MagicMock()
+    deps.gh.get_issue.return_value = {"body": "Unstructured request text."}
+    deps.gh.get_changed_files.return_value = []
+    deps.host.issue_is_open.return_value = True
+    deps.host.run_verification_agent.return_value = {
+        "verdicts": [
+            {
+                "item": "The endpoint rejects expired tokens",
+                "verdict": "confirmed",
+                "evidence": [{"ref": "tests/test_auth.py:42", "note": "covered"}],
+            }
+        ],
+        "snapshot": {
+            "required_paths": [],
+            "checklist": ["The endpoint rejects expired tokens"],
+            "non_scope": [],
+            "closure_constraints": False,
+        },
+    }
+
+    result = av.handle(_ctx(_workflow()), deps)
+
+    assert result.outcome == "completed"
+    assert result.workflow_patch["verification_status"] == "confirmed"
+    persisted = json.loads(result.workflow_patch["issue_acceptance_snapshot"])
+    assert persisted["source"] == "llm"
+    assert persisted["confidence"] == "low"
+    deps.gh.close_issue.assert_called_once_with(42)
+
+
+def test_confirmed_checklist_verdict_without_evidence_is_indeterminate():
+    deps = MagicMock()
+    deps.gh.get_issue.return_value = {"body": "## Acceptance Criteria\n- [ ] security behavior"}
+    deps.gh.get_changed_files.return_value = []
+    deps.host.issue_is_open.return_value = True
+    deps.host.run_verification_agent.return_value = {
+        "verdicts": [
+            {
+                "item": "security behavior",
+                "verdict": "confirmed",
+                "evidence": [],
+                "rationale": "looks good",
+            }
+        ],
+        "snapshot": None,
+    }
+
+    result = av.handle(_ctx(_workflow()), deps)
+
+    assert result.outcome == "pause"
+    report = json.loads(result.workflow_patch["verification_report"])
+    assert report["verifier"][0]["verdict"] == "indeterminate"
+    assert report["verifier"][0]["evidence"][0]["ref"] == "verifier:missing-evidence"
+    deps.gh.close_issue.assert_not_called()
+
+
+def test_malformed_verdict_evidence_is_retryable_infrastructure():
+    deps = MagicMock()
+    deps.gh.get_issue.return_value = {"body": "## Acceptance Criteria\n- [ ] security behavior"}
+    deps.gh.get_changed_files.return_value = []
+    deps.host.issue_is_open.return_value = True
+    deps.host.run_verification_agent.return_value = {
+        "verdicts": [
+            {
+                "item": "security behavior",
+                "verdict": "confirmed",
+                "evidence": {"ref": "app/x.py:1"},
+                "rationale": [],
+            }
+        ],
+        "snapshot": None,
+    }
+
+    result = av.handle(_ctx(_workflow()), deps)
+
+    assert result.outcome == "retry"
+    report = json.loads(result.workflow_patch["verification_report"])
+    assert "verdict fields were malformed" in report["infra_error"]
+    deps.gh.close_issue.assert_not_called()
+
+
+def test_lost_scheduler_lock_blocks_confirmed_github_mutations():
+    deps = MagicMock()
+    deps.gh.get_issue.return_value = {"body": "## Scope\n- `app/x.py`"}
+    deps.gh.get_changed_files.return_value = ["app/x.py"]
+    deps.gh._run_git.return_value.stdout = "def f():\n    return 1\n"
+    deps.host.issue_is_open.return_value = True
+    deps.host.ensure_scheduler_lock.return_value = False
+    deps.host.run_verification_agent.return_value = {"verdicts": [], "snapshot": None}
+
+    result = av.handle(_ctx(_workflow()), deps)
+
+    assert result.outcome == "retry"
+    deps.gh.add_issue_comment.assert_not_called()
+    deps.gh.close_issue.assert_not_called()
+
+
+def test_lock_loss_after_comment_blocks_close_for_replacement_retry():
+    deps = MagicMock()
+    deps.gh.get_issue.return_value = {"body": "## Scope\n- `app/x.py`"}
+    deps.gh.get_changed_files.return_value = ["app/x.py"]
+    deps.gh._run_git.return_value.stdout = "def f():\n    return 1\n"
+    deps.host.issue_is_open.return_value = True
+    deps.host.ensure_scheduler_lock.side_effect = [True, False]
+    deps.host.run_verification_agent.return_value = {"verdicts": [], "snapshot": None}
+
+    result = av.handle(_ctx(_workflow()), deps)
+
+    assert result.outcome == "retry"
+    deps.gh.add_issue_comment.assert_called_once()
     deps.gh.close_issue.assert_not_called()
 
 
@@ -345,6 +580,15 @@ class _SQLiteDB:
     def get_connection(self):
         return sqlite3.connect(self.path)
 
+    def fetch_one(self, sql, params=()):
+        conn = sqlite3.connect(self.path)
+        conn.row_factory = sqlite3.Row
+        try:
+            row = conn.execute(sql, params).fetchone()
+            return dict(row) if row is not None else None
+        finally:
+            conn.close()
+
 
 def test_heartbeat_prevents_takeover_after_a_31_minute_agent_run(tmp_path):
     """Two repository instances model two scheduler processes sharing the DB."""
@@ -419,11 +663,133 @@ def test_lost_heartbeat_stops_the_old_orchestrator():
     repo.refresh_lock.return_value = False
     stop_event = MagicMock()
     stop_event.wait.return_value = False
+    lock_lost = threading.Event()
 
-    scheduler._heartbeat_workflow_lock(repo, "wf-lost", "old-owner", stop_event)
+    scheduler._heartbeat_workflow_lock(repo, "wf-lost", "old-owner", stop_event, lock_lost)
 
     repo.refresh_lock.assert_called_once_with("wf-lost", "old-owner")
+    assert lock_lost.is_set()
     orchestrator.prepare_for_shutdown.assert_called_once_with()
+
+
+def test_lock_lost_before_orchestrator_registration_never_advances():
+    scheduler = AutonomousScheduler()
+    repo = MagicMock()
+    repo.get_workflow.return_value = {"workflow_id": "wf-race", "status": "planning"}
+    repo.acquire_lock.return_value = True
+    repo.refresh_lock.return_value = False
+
+    class _InlineThread:
+        def __init__(self, *, target, args, **_kwargs):
+            self.target = target
+            self.args = args
+
+        def start(self):
+            self.target(*self.args)
+
+        def join(self, timeout=None):
+            return None
+
+    with (
+        patch("app.routes.autonomous._get_repo", return_value=repo),
+        patch(
+            "app.modules.workspace.autonomous.orchestrator.AutonomousOrchestrator"
+        ) as orchestrator_cls,
+        patch.object(scheduler_module.threading, "Thread", _InlineThread),
+        patch.object(scheduler_module, "WORKFLOW_LOCK_HEARTBEAT_SECONDS", 0),
+    ):
+        scheduler._advance_single("wf-race")
+
+    orchestrator = orchestrator_cls.return_value
+    orchestrator.bind_scheduler_lock.assert_called_once()
+    orchestrator.prepare_for_shutdown.assert_called_once_with()
+    orchestrator.advance.assert_not_called()
+    repo.clear_agent_pid_if_lock_owner.assert_called_once()
+    repo.update_workflow.assert_not_called()
+
+
+def test_phase_commit_is_fenced_after_scheduler_lock_loss():
+    orchestrator = AutonomousOrchestrator.__new__(AutonomousOrchestrator)
+    orchestrator.repo = MagicMock()
+    orchestrator._workflow_id = "wf-lost"
+    orchestrator._scheduler_lock_owner = "old-owner"
+    orchestrator._scheduler_lock_lost = threading.Event()
+    orchestrator._scheduler_lock_lost.set()
+    orchestrator._shutdown_requested = threading.Event()
+    orchestrator._create_milestone = MagicMock()
+
+    with pytest.raises(RuntimeError, match="Distributed workflow lock was lost"):
+        orchestrator._commit_phase_result(
+            PhaseResult.completed(next_phase="completed", milestone_events=[{"phase": "x"}])
+        )
+
+    orchestrator.repo.update_workflow.assert_not_called()
+    orchestrator._create_milestone.assert_not_called()
+
+
+def test_old_owner_cannot_clear_replacement_agent_pid(tmp_path):
+    db_path = str(tmp_path / "agent-pid-fence.db")
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """CREATE TABLE autonomous_workflows (
+            workflow_id TEXT PRIMARY KEY,
+            locked_by TEXT,
+            agent_pid INTEGER,
+            agent_session_id TEXT,
+            updated_at TEXT
+        )"""
+    )
+    conn.execute(
+        "INSERT INTO autonomous_workflows VALUES (?, ?, ?, ?, ?)",
+        ("wf-new", "new-owner", 999, "new-session", ""),
+    )
+    conn.commit()
+    conn.close()
+    repo = AutonomousWorkflowRepository(_SQLiteDB(db_path))
+
+    with patch("app.repositories.database.adapt_sql", side_effect=lambda sql: sql):
+        assert repo.clear_agent_pid_if_lock_owner("wf-new", "old-owner") is False
+
+    conn = sqlite3.connect(db_path)
+    row = conn.execute(
+        "SELECT locked_by, agent_pid, agent_session_id FROM autonomous_workflows"
+    ).fetchone()
+    conn.close()
+    assert row == ("new-owner", 999, "new-session")
+
+
+def test_workflow_update_requires_current_lock_owner(tmp_path):
+    db_path = str(tmp_path / "workflow-update-fence.db")
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """CREATE TABLE autonomous_workflows (
+            workflow_id TEXT PRIMARY KEY,
+            status TEXT,
+            locked_by TEXT,
+            updated_at TEXT
+        )"""
+    )
+    conn.execute(
+        "INSERT INTO autonomous_workflows VALUES (?, ?, ?, ?)",
+        ("wf-fenced", "verification_pending", "new-owner", ""),
+    )
+    conn.commit()
+    conn.close()
+    repo = AutonomousWorkflowRepository(_SQLiteDB(db_path))
+
+    with patch("app.repositories.autonomous_repo.adapt_sql", side_effect=lambda sql: sql):
+        assert (
+            repo.update_workflow(
+                "wf-fenced", {"status": "completed"}, required_lock_owner="old-owner"
+            )
+            is None
+        )
+        updated = repo.update_workflow(
+            "wf-fenced", {"status": "paused"}, required_lock_owner="new-owner"
+        )
+
+    assert updated is not None
+    assert updated["status"] == "paused"
 
 
 def test_issue_closure_combines_closed_at_with_latest_timeline_actor():

--- a/tests/issues/2431/test_acceptance_verifier_hardening.py
+++ b/tests/issues/2431/test_acceptance_verifier_hardening.py
@@ -334,6 +334,38 @@ def test_valid_extracted_snapshot_drives_coverage_and_can_confirm():
     deps.gh.close_issue.assert_called_once_with(42)
 
 
+def test_verifier_cannot_replace_structured_issue_snapshot():
+    deps = MagicMock()
+    deps.gh.get_issue.return_value = {"body": "## Acceptance Criteria\n- [ ] security behavior"}
+    deps.gh.get_changed_files.return_value = []
+    deps.host.issue_is_open.return_value = True
+    deps.host.run_verification_agent.return_value = {
+        "verdicts": [
+            {
+                "item": "easier substitute",
+                "verdict": "confirmed",
+                "evidence": [{"ref": "app/x.py:1", "note": "unrelated"}],
+                "rationale": "",
+            }
+        ],
+        "snapshot": {
+            "required_paths": [],
+            "checklist": ["easier substitute"],
+            "non_scope": [],
+            "closure_constraints": False,
+        },
+    }
+
+    result = av.handle(_ctx(_workflow()), deps)
+
+    assert result.outcome == "retry"
+    report = json.loads(result.workflow_patch["verification_report"])
+    assert "unexpected snapshot" in report["infra_error"]
+    persisted = json.loads(result.workflow_patch["issue_acceptance_snapshot"])
+    assert persisted["checklist"] == ["security behavior"]
+    deps.gh.close_issue.assert_not_called()
+
+
 def test_confirmed_checklist_verdict_without_evidence_is_indeterminate():
     deps = MagicMock()
     deps.gh.get_issue.return_value = {"body": "## Acceptance Criteria\n- [ ] security behavior"}

--- a/tests/issues/2431/test_acceptance_verifier_hardening.py
+++ b/tests/issues/2431/test_acceptance_verifier_hardening.py
@@ -3,7 +3,12 @@
 from __future__ import annotations
 
 import json
-from unittest.mock import MagicMock
+import os
+import sqlite3
+import threading
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 from app.modules.workspace.autonomous.acceptance_gates import (
     legacy_pattern_gate,
@@ -13,8 +18,11 @@ from app.modules.workspace.autonomous.acceptance_snapshot import AcceptanceSnaps
 from app.modules.workspace.autonomous.evidence import Verdict
 from app.modules.workspace.autonomous.github_ops import GitHubOps
 from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
-from app.modules.workspace.autonomous.phase_contract import WorkflowContext
+from app.modules.workspace.autonomous.phase_contract import PhaseResult, WorkflowContext
 from app.modules.workspace.autonomous.phases import acceptance_verification as av
+from app.repositories.autonomous_repo import AutonomousWorkflowRepository
+from app.services import autonomous_scheduler as scheduler_module
+from app.services.autonomous_scheduler import AutonomousScheduler
 
 
 def _result(*, returncode=0, stdout="", stderr=""):
@@ -69,7 +77,7 @@ def test_broad_legacy_regex_is_retired_from_production_aggregate():
     assert all(item.verdict is not Verdict.REJECTED for item in aggregate)
 
 
-def test_explicit_verifier_infra_error_forces_indeterminate_pause():
+def test_explicit_verifier_infra_error_retries_without_terminal_milestone():
     deps = MagicMock()
     deps.gh.get_issue.return_value = {"body": "## Scope\n- `app/x.py`"}
     deps.gh.get_changed_files.return_value = ["app/x.py"]
@@ -83,11 +91,95 @@ def test_explicit_verifier_infra_error_forces_indeterminate_pause():
 
     result = av.handle(_ctx(_workflow()), deps)
 
-    assert result.outcome == "pause"
+    assert result.outcome == "retry"
     assert result.workflow_patch["verification_status"] == "indeterminate"
+    assert result.milestone_events == []
     report = json.loads(result.workflow_patch["verification_report"])
     assert report["verifier"][0]["item"] == "verifier:infrastructure"
     assert "timed out" in report["verifier"][0]["evidence"][0]["note"]
+    assert report["infra_error"] == "verification agent timed out"
+
+
+def test_infra_result_is_not_terminally_cached_and_resume_can_confirm():
+    deps = MagicMock()
+    deps.gh.get_issue.return_value = {
+        "body": "## Acceptance Criteria\n- [ ] The endpoint rejects expired tokens"
+    }
+    deps.gh.get_changed_files.return_value = []
+    deps.gh._run_git.return_value.stdout = ""
+    deps.host.issue_is_open.return_value = True
+    deps.host.run_verification_agent.side_effect = [
+        {
+            "verdicts": [],
+            "snapshot": None,
+            "infra_error": "verification agent timed out",
+        },
+        {
+            "verdicts": [
+                {
+                    "item": "  THE endpoint rejects expired tokens ",
+                    "verdict": "confirmed",
+                    "evidence": [{"ref": "tests/test_auth.py:42", "note": "covered"}],
+                }
+            ],
+            "snapshot": None,
+        },
+    ]
+
+    first = av.handle(_ctx(_workflow()), deps)
+    resumed_workflow = {**_workflow(), **first.workflow_patch}
+    second = av.handle(_ctx(resumed_workflow), deps)
+
+    assert first.outcome == "retry"
+    assert second.outcome == "completed"
+    assert second.workflow_patch["verification_status"] == "confirmed"
+    assert deps.host.run_verification_agent.call_count == 2
+    deps.gh.close_issue.assert_called_once_with(42)
+
+    orchestrator = AutonomousOrchestrator.__new__(AutonomousOrchestrator)
+    orchestrator._update_workflow = MagicMock()
+    orchestrator._create_milestone = MagicMock()
+    orchestrator._commit_phase_result(first)
+    orchestrator._commit_phase_result(second)
+    orchestrator._create_milestone.assert_called_once_with(**second.milestone_events[0])
+
+
+def test_missing_checklist_verdict_forces_indeterminate_and_never_closes_issue():
+    deps = MagicMock()
+    deps.gh.get_issue.return_value = {
+        "body": (
+            "## Scope\n- `app/x.py`\n\n"
+            "## Acceptance Criteria\n- [ ] The endpoint rejects expired tokens"
+        )
+    }
+    deps.gh.get_changed_files.return_value = ["app/x.py"]
+    deps.gh._run_git.return_value.stdout = "def f():\n    return 1\n"
+    deps.host.issue_is_open.return_value = True
+    deps.host.run_verification_agent.return_value = {"verdicts": [], "snapshot": None}
+
+    result = av.handle(_ctx(_workflow()), deps)
+
+    assert result.outcome == "pause"
+    assert result.workflow_patch["verification_status"] == "indeterminate"
+    report = json.loads(result.workflow_patch["verification_report"])
+    assert report["verifier"] == [
+        {
+            "item": "The endpoint rejects expired tokens",
+            "verdict": "indeterminate",
+            "evidence": [
+                {
+                    "ref": "verifier:missing-item",
+                    "note": "The verifier returned no verdict for this acceptance item.",
+                }
+            ],
+            "rationale": (
+                "The verifier did not cover this checklist item; no acceptance "
+                "decision was made for it."
+            ),
+        }
+    ]
+    deps.gh.add_issue_comment.assert_not_called()
+    deps.gh.close_issue.assert_not_called()
 
 
 def test_rejection_pauses_instead_of_reentering_or_failing_delivered_work():
@@ -149,15 +241,189 @@ def test_merge_sha_is_fetched_and_verified_when_missing():
     ]
 
 
-def test_issue_comment_exact_body_is_idempotent():
+def test_issue_comment_exact_body_from_same_bot_is_idempotent():
     gh = GitHubOps("/repo")
-    gh.list_issue_comments = MagicMock(return_value=[{"id": 7, "body": "same report"}])
+    gh.get_authenticated_login = MagicMock(return_value="open-ace-bot")
+    gh.list_issue_comments = MagicMock(
+        return_value=[{"id": 7, "body": "same report", "author": {"login": "Open-Ace-Bot"}}]
+    )
     gh._run_gh = MagicMock()
 
     result = gh.add_issue_comment(42, "same report")
 
     assert result == {"number": 42, "id": 7, "deduplicated": True}
     gh._run_gh.assert_not_called()
+
+
+def test_issue_comment_same_body_from_human_does_not_deduplicate():
+    gh = GitHubOps("/repo")
+    gh.get_authenticated_login = MagicMock(return_value="open-ace-bot")
+    gh.list_issue_comments = MagicMock(
+        return_value=[{"id": 7, "body": "same report", "author": {"login": "maintainer"}}]
+    )
+    gh._run_gh = MagicMock()
+
+    result = gh.add_issue_comment(42, "same report")
+
+    assert result == {"number": 42, "deduplicated": False}
+    gh._run_gh.assert_called_once_with(
+        ["issue", "comment", "42", "--body", "same report"], api_only=True
+    )
+
+
+def test_issue_comment_unknown_bot_identity_does_not_trust_existing_author():
+    gh = GitHubOps("/repo")
+    gh.get_authenticated_login = MagicMock(return_value=None)
+    gh.list_issue_comments = MagicMock()
+    gh._run_gh = MagicMock()
+
+    result = gh.add_issue_comment(42, "same report")
+
+    assert result == {"number": 42, "deduplicated": False}
+    gh.list_issue_comments.assert_not_called()
+
+
+def test_issue_comment_listing_uses_paginated_rest_and_normalizes_pages():
+    gh = GitHubOps("/repo")
+    gh.get_repo_name = MagicMock(return_value="open-ace/open-ace")
+    gh._gh_api_args = MagicMock(side_effect=lambda args: ["api", *args])
+    gh._run_gh = MagicMock(
+        return_value=_result(
+            stdout=(
+                '{"id":1,"body":"first","createdAt":"2026-08-08T00:00:00Z",'
+                '"author":{"login":"bot"}}\n'
+                '{"id":2,"body":"second","createdAt":"2026-08-08T01:00:00Z",'
+                '"author":{"login":"human"}}\n'
+            )
+        )
+    )
+
+    comments = gh.list_issue_comments(42)
+
+    assert [comment["id"] for comment in comments] == [1, 2]
+    api_args = gh._gh_api_args.call_args.args[0]
+    assert "--paginate" in api_args
+    assert "repos/open-ace/open-ace/issues/42/comments" in api_args
+    gh._run_gh.assert_called_once_with(["api", *api_args], repo_scoped=False, api_only=True)
+
+
+def test_pause_result_commits_its_milestone_event():
+    milestone = {
+        "workflow_id": "wf-hardening",
+        "phase": "acceptance_verification",
+        "milestone_type": "acceptance_verification",
+        "status": "rejected",
+        "title": "Acceptance verification: rejected",
+    }
+    result = PhaseResult.pause(
+        workflow_patch={"verification_status": "rejected"},
+        milestone_events=[milestone],
+    )
+    orchestrator = AutonomousOrchestrator.__new__(AutonomousOrchestrator)
+    orchestrator._update_workflow = MagicMock()
+    orchestrator._create_milestone = MagicMock()
+
+    orchestrator._commit_phase_result(result)
+
+    committed_patch = orchestrator._update_workflow.call_args.args[0]
+    assert committed_patch["status"] == "paused"
+    assert committed_patch["verification_status"] == "rejected"
+    orchestrator._create_milestone.assert_called_once_with(**milestone)
+
+
+def test_ci_executes_the_issue_2335_verifier_regressions():
+    repo_root = Path(__file__).resolve().parents[3]
+    workflow = (repo_root / ".github" / "workflows" / "ci.yml").read_text()
+
+    assert "pytest tests/issues/2335 tests/issues/2403" in workflow
+
+
+class _SQLiteDB:
+    def __init__(self, path: str):
+        self.path = path
+
+    def get_connection(self):
+        return sqlite3.connect(self.path)
+
+
+def test_heartbeat_prevents_takeover_after_a_31_minute_agent_run(tmp_path):
+    """Two repository instances model two scheduler processes sharing the DB."""
+    db_path = str(tmp_path / "workflow-lock.db")
+    stale = (datetime.now(timezone.utc) - timedelta(minutes=31)).strftime("%Y-%m-%d %H:%M:%S")
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """CREATE TABLE autonomous_workflows (
+            workflow_id TEXT PRIMARY KEY,
+            locked_at TEXT,
+            locked_by TEXT,
+            agent_pid INTEGER
+        )"""
+    )
+    conn.execute(
+        "INSERT INTO autonomous_workflows VALUES (?, ?, ?, ?)",
+        ("wf-live", stale, "host/100/worker", 4242),
+    )
+    conn.commit()
+    conn.close()
+
+    first_repo = AutonomousWorkflowRepository(_SQLiteDB(db_path))
+    second_repo = AutonomousWorkflowRepository(_SQLiteDB(db_path))
+    with patch("app.repositories.database.adapt_sql", side_effect=lambda sql: sql):
+        # At minute 31 the original timestamp is stale, but the live scheduler
+        # heartbeat renews it before a peer's acquisition attempt.
+        assert first_repo.refresh_lock("wf-live", "host/100/worker") is True
+        assert second_repo.acquire_lock("wf-live", "host/200/worker") is False
+
+    conn = sqlite3.connect(db_path)
+    owner = conn.execute(
+        "SELECT locked_by FROM autonomous_workflows WHERE workflow_id = 'wf-live'"
+    ).fetchone()[0]
+    conn.close()
+    assert owner == "host/100/worker"
+
+
+def test_scheduler_heartbeats_with_a_pid_unique_owner():
+    scheduler = AutonomousScheduler()
+    repo = MagicMock()
+    repo.get_workflow.return_value = {"workflow_id": "wf-heartbeat", "status": "planning"}
+    repo.acquire_lock.return_value = True
+    repo.refresh_lock.return_value = True
+    heartbeat_seen = threading.Event()
+    repo.refresh_lock.side_effect = lambda *_args: heartbeat_seen.set() or True
+
+    def advance_until_heartbeat():
+        assert heartbeat_seen.wait(timeout=1)
+
+    with (
+        patch("app.routes.autonomous._get_repo", return_value=repo),
+        patch(
+            "app.modules.workspace.autonomous.orchestrator.AutonomousOrchestrator"
+        ) as orchestrator_cls,
+        patch.object(scheduler_module, "WORKFLOW_LOCK_HEARTBEAT_SECONDS", 0.001),
+    ):
+        orchestrator_cls.return_value.advance.side_effect = advance_until_heartbeat
+        scheduler._advance_single("wf-heartbeat")
+
+    owner = repo.acquire_lock.call_args.args[1]
+    assert f"/{os.getpid()}/" in owner
+    repo.refresh_lock.assert_called_with("wf-heartbeat", owner)
+    repo.release_lock.assert_called_once_with("wf-heartbeat", owner)
+
+
+def test_lost_heartbeat_stops_the_old_orchestrator():
+    scheduler = AutonomousScheduler.__new__(AutonomousScheduler)
+    orchestrator = MagicMock()
+    scheduler._orchestrator_lock = threading.Lock()
+    scheduler._running_orchestrators = {"wf-lost": orchestrator}
+    repo = MagicMock()
+    repo.refresh_lock.return_value = False
+    stop_event = MagicMock()
+    stop_event.wait.return_value = False
+
+    scheduler._heartbeat_workflow_lock(repo, "wf-lost", "old-owner", stop_event)
+
+    repo.refresh_lock.assert_called_once_with("wf-lost", "old-owner")
+    orchestrator.prepare_for_shutdown.assert_called_once_with()
 
 
 def test_issue_closure_combines_closed_at_with_latest_timeline_actor():

--- a/tests/issues/2431/test_acceptance_verifier_hardening.py
+++ b/tests/issues/2431/test_acceptance_verifier_hardening.py
@@ -1,0 +1,209 @@
+"""Regression coverage for the verifier hardening that enables #2335 safely."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+from app.modules.workspace.autonomous.acceptance_gates import (
+    legacy_pattern_gate,
+    run_mechanical_gates,
+)
+from app.modules.workspace.autonomous.acceptance_snapshot import AcceptanceSnapshot
+from app.modules.workspace.autonomous.evidence import Verdict
+from app.modules.workspace.autonomous.github_ops import GitHubOps
+from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+from app.modules.workspace.autonomous.phase_contract import WorkflowContext
+from app.modules.workspace.autonomous.phases import acceptance_verification as av
+
+
+def _result(*, returncode=0, stdout="", stderr=""):
+    return MagicMock(returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+def _ctx(workflow):
+    return WorkflowContext(
+        workflow=workflow,
+        definition_snapshot=None,
+        repository_context=None,
+        session_bindings=MagicMock(),
+        cancellation=MagicMock(),
+    )
+
+
+def _workflow():
+    return {
+        "workflow_id": "wf-hardening",
+        "github_issue_number": 42,
+        "github_pr_number": 99,
+        "base_commit_sha": "base",
+        "verification_merge_sha": "merge",
+        "verification_status": None,
+        "issue_acceptance_snapshot": None,
+        "dev_round": 5,
+    }
+
+
+def test_scope_git_error_is_indeterminate_not_an_exception():
+    gh = MagicMock()
+    gh.get_changed_files.side_effect = RuntimeError("bad object merge")
+
+    verdicts = av.run_scope_gate(gh, ["app/x.py"], "base", "merge")
+
+    assert len(verdicts) == 1
+    assert verdicts[0].verdict is Verdict.INDETERMINATE
+    assert verdicts[0].item == "scope:changed-files"
+
+
+def test_broad_legacy_regex_is_retired_from_production_aggregate():
+    gh = MagicMock()
+    gh.get_changed_files.return_value = ["app/views/tenant.py"]
+
+    def reader(_path):
+        return "if current.tenant_id == tenant_id:\n    return allowed\n"
+
+    legacy = legacy_pattern_gate(gh, AcceptanceSnapshot(), "base", "merge", read_file=reader)
+    aggregate = run_mechanical_gates(gh, AcceptanceSnapshot(), "base", "merge", read_file=reader)
+
+    assert any(item.verdict is Verdict.REJECTED for item in legacy)
+    assert all(item.verdict is not Verdict.REJECTED for item in aggregate)
+
+
+def test_explicit_verifier_infra_error_forces_indeterminate_pause():
+    deps = MagicMock()
+    deps.gh.get_issue.return_value = {"body": "## Scope\n- `app/x.py`"}
+    deps.gh.get_changed_files.return_value = ["app/x.py"]
+    deps.gh._run_git.return_value.stdout = "def f():\n    return 1\n"
+    deps.host.issue_is_open.return_value = True
+    deps.host.run_verification_agent.return_value = {
+        "verdicts": [],
+        "snapshot": None,
+        "infra_error": "verification agent timed out",
+    }
+
+    result = av.handle(_ctx(_workflow()), deps)
+
+    assert result.outcome == "pause"
+    assert result.workflow_patch["verification_status"] == "indeterminate"
+    report = json.loads(result.workflow_patch["verification_report"])
+    assert report["verifier"][0]["item"] == "verifier:infrastructure"
+    assert "timed out" in report["verifier"][0]["evidence"][0]["note"]
+
+
+def test_rejection_pauses_instead_of_reentering_or_failing_delivered_work():
+    deps = MagicMock()
+    deps.gh.get_issue.return_value = {"body": "## Scope\n- `app/x.py`"}
+    deps.gh.get_changed_files.return_value = []
+    deps.host.issue_is_open.return_value = True
+    deps.host.run_verification_agent.return_value = {"verdicts": [], "snapshot": None}
+
+    result = av.handle(_ctx(_workflow()), deps)
+
+    assert result.outcome == "pause"
+    assert result.workflow_patch["verification_status"] == "rejected"
+    assert "awaiting review" in result.workflow_patch["error_message"]
+    deps.host.dev_round_cap_remaining.assert_not_called()
+
+
+def test_reopen_guard_uses_actual_closer_identity():
+    deps = MagicMock()
+    deps.host.issue_is_open.return_value = False
+    deps.gh.get_issue_closure.return_value = {
+        "closed_at": "2026-08-08T00:00:00Z",
+        "closer_login": "human-maintainer",
+    }
+    deps.gh.get_authenticated_login.return_value = "open-ace-bot"
+    deps.gh.get_issue.return_value = {"body": ""}
+    deps.host.run_verification_agent.return_value = {"verdicts": [], "snapshot": None}
+
+    av.handle(_ctx(_workflow()), deps)
+
+    deps.gh.reopen_issue.assert_not_called()
+
+    deps.gh.get_issue_closure.return_value["closer_login"] = "Open-Ace-Bot"
+    av.handle(_ctx(_workflow()), deps)
+    deps.gh.reopen_issue.assert_called_once_with(42)
+
+
+def test_merge_sha_is_fetched_and_verified_when_missing():
+    gh = GitHubOps("/repo")
+    gh._run_git = MagicMock(
+        side_effect=[
+            _result(returncode=1),
+            _result(returncode=0),
+            _result(returncode=0),
+        ]
+    )
+
+    assert gh.ensure_commit_available("a" * 40) is True
+    assert gh._run_git.call_args_list[1].args[0] == [
+        "fetch",
+        "--no-tags",
+        "origin",
+        "a" * 40,
+    ]
+    assert gh._run_git.call_args_list[-1].args[0] == [
+        "cat-file",
+        "-e",
+        f"{'a' * 40}^{{commit}}",
+    ]
+
+
+def test_issue_comment_exact_body_is_idempotent():
+    gh = GitHubOps("/repo")
+    gh.list_issue_comments = MagicMock(return_value=[{"id": 7, "body": "same report"}])
+    gh._run_gh = MagicMock()
+
+    result = gh.add_issue_comment(42, "same report")
+
+    assert result == {"number": 42, "id": 7, "deduplicated": True}
+    gh._run_gh.assert_not_called()
+
+
+def test_issue_closure_combines_closed_at_with_latest_timeline_actor():
+    gh = GitHubOps("/repo")
+    gh._owner_repo_resolved = True
+    gh._owner_repo = "open-ace/open-ace"
+    gh._repo_slug = "open-ace/open-ace"
+    gh._run_gh = MagicMock(
+        side_effect=[
+            _result(stdout='{"state":"CLOSED","closedAt":"2026-08-08T00:00:00Z"}'),
+            _result(
+                stdout=(
+                    '{"closed_at":"2026-08-07T00:00:00Z","closer_login":"first"}\n'
+                    '{"closed_at":"2026-08-08T00:00:00Z","closer_login":"open-ace-bot"}\n'
+                )
+            ),
+        ]
+    )
+
+    assert gh.get_issue_closure(42) == {
+        "closed_at": "2026-08-08T00:00:00Z",
+        "closer_login": "open-ace-bot",
+    }
+
+
+def test_issue_closure_rejects_timeline_actor_from_a_different_close_event():
+    gh = GitHubOps("/repo")
+    gh._owner_repo_resolved = True
+    gh._owner_repo = "open-ace/open-ace"
+    gh._repo_slug = "open-ace/open-ace"
+    gh._run_gh = MagicMock(
+        side_effect=[
+            _result(stdout='{"state":"CLOSED","closedAt":"2026-08-08T00:00:00Z"}'),
+            _result(
+                stdout=('{"closed_at":"2026-08-07T00:00:00Z","closer_login":"open-ace-bot"}\n')
+            ),
+        ]
+    )
+
+    assert gh.get_issue_closure(42) is None
+
+
+def test_issue_open_check_accepts_github_uppercase_state():
+    orchestrator = AutonomousOrchestrator.__new__(AutonomousOrchestrator)
+    gh = MagicMock()
+    gh.get_issue.return_value = {"state": "OPEN"}
+    orchestrator._get_gh = MagicMock(return_value=gh)
+
+    assert orchestrator._issue_is_open(42) is True

--- a/tests/issues/2431/test_drain_verification_pending.py
+++ b/tests/issues/2431/test_drain_verification_pending.py
@@ -1,8 +1,8 @@
-"""Issue #2431 PR B: parked verification rows must drain safely.
+"""Issue #2431: parked verification rows drain safely and the verifier is controllable.
 
 The scheduler query and phase/status mapping are an atomic change.  Once the
-row is selected, the acceptance handler's default-off guard must run before it
-touches workflow context or verifier dependencies and complete the workflow.
+row is selected, an explicit flag-off guard must run before it touches workflow
+context or verifier dependencies and complete the workflow.
 """
 
 from __future__ import annotations
@@ -72,16 +72,16 @@ def test_phase_mapping_and_active_sets_move_together():
     assert "verification_pending" in AutonomousWorkflow.ACTIVE_STATUSES
 
 
-def test_acceptance_verification_defaults_off():
-    with patch.object(config_module, "get_config_value", return_value=False) as get_value:
-        assert config_module.is_acceptance_verification_enabled() is False
-
-    get_value.assert_called_once_with("autonomous", "acceptance_verification_enabled", False)
-
-
-def test_acceptance_verification_can_be_explicitly_enabled():
-    with patch.object(config_module, "get_config_value", return_value=True):
+def test_acceptance_verification_defaults_on_after_hardening():
+    with patch.object(config_module, "get_config_value", return_value=True) as get_value:
         assert config_module.is_acceptance_verification_enabled() is True
+
+    get_value.assert_called_once_with("autonomous", "acceptance_verification_enabled", True)
+
+
+def test_acceptance_verification_can_be_explicitly_disabled():
+    with patch.object(config_module, "get_config_value", return_value=False):
+        assert config_module.is_acceptance_verification_enabled() is False
 
 
 def test_acceptance_verification_rejects_truthy_non_boolean_values():


### PR DESCRIPTION
## Summary

- fetch and verify the server-side merge SHA before local diff/worktree use
- require strict extracted snapshots, complete checklist coverage, and concrete verifier evidence
- classify agent/scope/gate infrastructure failures as bounded retryable attempts (3, then pause)
- retire the broad full-file legacy-pattern gate from production aggregation
- pause rejected delivered work instead of failing or re-entering a cleaned worktree
- reopen only closures attributed to the configured bot using the matching timeline event
- deduplicate exact issue comments only for the configured bot, across all pages
- heartbeat workflow leases with PID-unique owners and fence DB/GitHub mutations after lock loss
- create verifier worktrees as the repository owner in cross-user deployments and clean them owner-safely
- enable the hardened verifier by default and gate the #2335 regressions in CI

## Verification

- CI opt-in issue suites: 223 passed
- expanded related issue/cleanup suites: 241 passed
- autonomous core suite: 118 passed
- pre-commit: all hooks passed, including mypy and Bandit

Fixes #2431
Refs #2335
