### PR TITLE
fix(scripts): preserve agent_task_preserve_max_age_days across setup re-runs (#2438)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,7 @@ jobs:
       - name: Issue regression suites (opt-in; see norecursedirs)
         timeout-minutes: 5
         run: |
-          pytest tests/issues/2335 tests/issues/2403 tests/issues/2428 tests/issues/2431 -v \
+          pytest tests/issues/2335 tests/issues/2403 tests/issues/2428 tests/issues/2431 tests/issues/2438 -v \
             -m "not postgres and not performance"
 
       - name: Upload coverage to Codecov

--- a/scripts/setup-cgroup-v2.sh
+++ b/scripts/setup-cgroup-v2.sh
@@ -44,6 +44,9 @@ CGROUP_ENABLED="on"
 CONCURRENCY=3
 WALL_CLOCK=3600
 CONF_PATH="/etc/openace/agent-launcher.conf"
+# agent_task_preserve_max_age_days default (days). Mirrors openace-run-as.sh so
+# an install and a missing-key fallback agree. See Issue #2438.
+PRESERVE_MAX_AGE_DAYS=30
 CGROUP_ROOT="/sys/fs/cgroup/openace-agent"
 SYSTEMD_UNIT="openace-cgroup-setup.service"
 DRY_RUN=false
@@ -250,6 +253,21 @@ fi
 existing_account="${existing_account:-openace-agent}"
 existing_roots="${existing_roots:-/home /workspace}"
 
+# Issue #2438: preserve the operator's stale-.claude reaper window across
+# re-runs. The strip below removes every agent_task_ line, so this key must be
+# re-read here and re-emitted in resource_block, or a custom value is silently
+# reset to the wrapper default.
+existing_preserve=""
+if [[ -f "$CONF_PATH" ]]; then
+    existing_preserve=$(sed -n 's/^agent_task_preserve_max_age_days=//p' "$CONF_PATH" 2>/dev/null | tr -d '"' | head -1)
+fi
+# Fail-safe: 0 would reap every session's history on each run; a non-numeric
+# value is corruption. Both fall back to the default rather than aborting the
+# install, mirroring openace-run-as.sh's own guard.
+case "$existing_preserve" in
+    ''|0|*[!0-9]*) existing_preserve="$PRESERVE_MAX_AGE_DAYS" ;;
+esac
+
 # Build the new resource block
 resource_block=$(cat <<EOF
 # Issue #2020: per-task runtime isolation and resource limits.
@@ -262,6 +280,7 @@ agent_task_pids_max=$PIDS_MAX
 agent_task_cpu_max="$CPU_MAX"
 agent_task_wall_clock_limit=$WALL_CLOCK
 agent_max_concurrent_workflows=$CONCURRENCY
+agent_task_preserve_max_age_days=$existing_preserve
 EOF
 )
 

--- a/tests/issues/2438/test_setup_cgroup_preserve.py
+++ b/tests/issues/2438/test_setup_cgroup_preserve.py
@@ -1,0 +1,76 @@
+"""Issue #2438: setup-cgroup-v2.sh must preserve agent_task_preserve_max_age_days.
+
+The script regenerates agent-launcher.conf by stripping every ``agent_task_``
+line and re-emitting only the resource keys it manages. It never re-emitted
+``agent_task_preserve_max_age_days``, so an operator's setting (the #2403 stale
+``.claude-preserve`` reaper window) was silently dropped on the next run and
+reset to the wrapper default.
+
+The script must run as root and probes ``/sys/fs/cgroup``, so it cannot be
+exercised behaviourally in CI. These are source assertions (wiring locks) in
+the style of ``tests/issues/2403/test_reclaim_wiring.py``: they pin that the
+preserve key is read, fail-safed, and re-emitted, and that the strip still
+drops the prefix so the key is emitted exactly once.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[3] / "scripts" / "setup-cgroup-v2.sh"
+SRC = SCRIPT.read_text(encoding="utf-8")
+LINES = SRC.splitlines()
+
+
+def _line_of(pattern: str, *, start: int = 0) -> int:
+    for index in range(start, len(LINES)):
+        if re.search(pattern, LINES[index]):
+            return index
+    raise AssertionError(f"pattern not found in {SCRIPT.name}: {pattern!r}")
+
+
+def test_resource_block_emits_preserve_age_key():
+    """The regenerated block must re-emit the preserve-age key.
+
+    Without it the strip-then-emit cycle deletes the key forever (the
+    regression). Mutation: delete the line → test fails.
+    """
+    assert "agent_task_preserve_max_age_days=$existing_preserve" in SRC
+
+
+def test_existing_preserve_read_from_conf():
+    """The operator's current value must be read from the conf before the strip
+    removes it."""
+    assert "agent_task_preserve_max_age_days=//p" in SRC
+    assert re.search(
+        r"sed -n .*agent_task_preserve_max_age_days=//p.*CONF_PATH", SRC, re.S
+    ), "expected a sed read of agent_task_preserve_max_age_days from $CONF_PATH"
+
+
+def test_preserve_age_fail_safe_rejects_zero_and_non_numeric():
+    """0 would reap every session's history each run; non-numeric is corruption.
+
+    Both must fall back to a default rather than abort the install, mirroring
+    the guard in openace-run-as.sh.
+    """
+    assert re.search(r"case .*existing_preserve", SRC), "expected a case guard on existing_preserve"
+    assert re.search(r"\*\[!0-9\]\*", SRC), "expected a non-digit rejection guard"
+    assert "PRESERVE_MAX_AGE_DAYS" in SRC
+
+
+def test_strip_still_removes_agent_task_prefix():
+    """The strip must keep dropping ``agent_task_`` so the key is emitted once,
+    not duplicated. The fix relies on re-emission, not on sparing the key.
+    """
+    assert re.search(r"grep -vE.*agent_task_", SRC)
+
+
+def test_fail_safe_normalizes_before_resource_block():
+    """existing_preserve must be normalized before the heredoc captures it."""
+    failsafe = _line_of(r"case .*existing_preserve")
+    heredoc = _line_of(r"<<EOF")
+    assert failsafe < heredoc, (
+        f"fail-safe at line {failsafe + 1} must precede the resource_block "
+        f"heredoc at line {heredoc + 1}"
+    )


### PR DESCRIPTION
## Problem (#2438)

`setup-cgroup-v2.sh` regenerates `agent-launcher.conf` by stripping every `agent_task_` line and re-emitting only the resource keys it manages. It never re-emitted `agent_task_preserve_max_age_days`, so an operator's setting (the #2403 stale `.claude-preserve` reaper window) was silently dropped on the next run and reset to the wrapper default.

## Fix

Read the existing value from the conf before the strip and re-emit it in the `resource_block` heredoc:
- `PRESERVE_MAX_AGE_DAYS=30` default (mirrors `openace-run-as.sh`).
- `existing_preserve` read via `sed`, fail-safed with a `case` guard: `0` / non-numeric → default (mirrors `openace-run-as.sh`'s own guard — corruption aborts neither the install nor reaps every session's history).
- `agent_task_preserve_max_age_days=$existing_preserve` added to the resource block.

The strip is unchanged — the key is correct because it is **re-emitted**, not because it is spared. Other `agent_task_*` keys were already re-emitted; only this one was missing.

## Tests

Source-assertion tests (`tests/issues/2438/`) in the style of `tests/issues/2403/test_reclaim_wiring.py` — the script must run as root and probes `/sys/fs/cgroup`, so it cannot be exercised behaviourally in CI. They pin: the key is read from the conf, fail-safed before the heredoc captures it, re-emitted in the resource block, and the strip still drops the prefix (emitted once). Fail-safe behavior verified for empty/0/non-numeric/valid inputs. Opted into CI (`ci.yml` issue-suites step).

## Deployment

Hot-patch `scripts/setup-cgroup-v2.sh` to prod + patch the install source so the next `install.sh` run doesn't revert it. No migration needed (the key is read from the existing conf at runtime).

Closes #2438