### PR TITLE
fix(scripts): prevent .claude preserve nesting when rm fails (#2442)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,7 @@ jobs:
       - name: Issue regression suites (opt-in; see norecursedirs)
         timeout-minutes: 5
         run: |
-          pytest tests/issues/2335 tests/issues/2403 tests/issues/2428 tests/issues/2431 tests/issues/2438 -v \
+          pytest tests/issues/2335 tests/issues/2403 tests/issues/2428 tests/issues/2431 tests/issues/2438 tests/issues/2442 -v \
             -m "not postgres and not performance"
 
       - name: Upload coverage to Codecov

--- a/app/modules/workspace/autonomous/agent_runner.py
+++ b/app/modules/workspace/autonomous/agent_runner.py
@@ -928,6 +928,11 @@ class AutonomousAgentRunner:
           breach, so timeouts/stops are never misreported here.
         """
         lowered = (stderr or "").lower()
+        if return_code == 70:
+            return (
+                "preserve_preparation_failed",
+                "Could not prepare .claude preserve directory; nesting guard aborted to protect --resume history",
+            )
         if "openace_cgroup_required" in lowered:
             return (
                 "task_resource_policy_unavailable",

--- a/scripts/openace-run-as.sh
+++ b/scripts/openace-run-as.sh
@@ -348,6 +348,21 @@ if [ "$isolated" = true ]; then
     # the reclaim in there would delete the freshly restored session history
     # before the agent even starts. Keeping it separate also lets tests extract
     # and run this function without cgroup/ACL/registry privileges.
+    # Issue #2442: move $1 (.claude) to $2 (preserve path). If the prior
+    # preserve dir cannot be removed, a following `mv` would nest source into
+    # the survivor and the next restore would hand Claude a mis-shaped tree,
+    # silently breaking --resume. Fail closed: rm failure returns non-zero so
+    # the caller decides (startup aborts via exit 70; reclaim logs). chmod 700
+    # is applied per #2403.
+    _move_to_preserve() {
+        local src="$1" dest="$2"
+        if [ -e "$dest" ] || [ -L "$dest" ]; then
+            rm -rf -- "$dest" 2>/dev/null || return 1
+        fi
+        mv -- "$src" "$dest" 2>/dev/null || return 1
+        chmod 700 "$dest" 2>/dev/null || true
+    }
+
     reclaim_task_tree() {
         [ -n "$task_base" ] || return 0
         [ -n "$preserve_claude_dir" ] || return 0
@@ -364,20 +379,13 @@ if [ "$isolated" = true ]; then
         # Do not "simplify" this to the FALSE branch — the TRUE branch is what
         # keeps #2035 --resume working.
         if [ -d "$task_home/.claude" ]; then
-            rm -rf -- "$preserve_claude_dir" 2>/dev/null || true
-            mv "$task_home/.claude" "$preserve_claude_dir" 2>/dev/null || true
-            # The preserve dir is a SIBLING of $task_base, so it inherits none
-            # of the `chmod 700` applied to the tree, and $task_root is created
-            # by `mkdir -p` under root's umask 022 (drwxr-xr-x). Without this
-            # the agent's ~/.claude — shell snapshots, settings.json,
-            # file-history copies of private source, plans, memory, todos, and
-            # the encoded project paths — sits world-readable under /run for
-            # the whole gap between two runs of a session line, and up to
-            # agent_task_preserve_max_age_days for an abandoned task. Before
-            # #2403 that layout existed only for the sub-millisecond startup
-            # window; reclaiming on exit makes it the steady state, so the mode
-            # has to be restored explicitly.
-            chmod 700 "$preserve_claude_dir" 2>/dev/null || true
+            # _move_to_preserve removes any prior preserve dir, moves .claude
+            # into it, and chmod 700 (the SIBLING-of-$task_base exposure noted
+            # in #2403). It fails closed on rm failure so mv cannot nest .claude
+            # into a survivor (#2442); reclaim only logs because errexit is live
+            # in this EXIT trap and an exit here would rewrite the status.
+            _move_to_preserve "$task_home/.claude" "$preserve_claude_dir" \
+                || log_audit "result=preserve_rescue_failed task=${task_id:-}"
         fi
         # Log rather than swallow: a partial rm on a full tmpfs is exactly the
         # condition this issue is about, and silence is why it went unnoticed
@@ -469,10 +477,10 @@ if [ "$isolated" = true ]; then
         trap 'exit 130' INT
         trap 'exit 143' TERM
         if [ -d "$task_home/.claude" ]; then
-            rm -rf -- "$preserve_claude_dir" 2>/dev/null || true
-            mv "$task_home/.claude" "$preserve_claude_dir" 2>/dev/null || true
-            # Same exposure as the reclaim path — see the comment there.
-            chmod 700 "$preserve_claude_dir" 2>/dev/null || true
+            if ! _move_to_preserve "$task_home/.claude" "$preserve_claude_dir"; then
+                echo "openace-run-as: cannot clear prior .claude-preserve dir; aborting to avoid nesting (Issue #2442)" >&2
+                exit 70
+            fi
         fi
         rm -rf -- "$task_base" 2>/dev/null || true
         mkdir -p "$task_home" "$task_tmp" "$task_cache" "$task_config" "$task_data"

--- a/tests/issues/2403/test_reclaim_wiring.py
+++ b/tests/issues/2403/test_reclaim_wiring.py
@@ -212,9 +212,11 @@ def test_history_is_rescued_by_rename_not_copy():
     copy, fails, is swallowed by `|| true`, and the following `rm -rf` then
     destroys the only remaining copy of the session history.
     """
-    body = re.search(r"^\s*reclaim_task_tree\(\) \{\n(.*?)^\s*\}$", SRC, re.MULTILINE | re.DOTALL)
-    assert body, "reclaim_task_tree() not found"
-    assert re.search(r'mv "\$task_home/\.claude" "\$preserve_claude_dir"', body.group(1))
+    # #2442 moved the rescue move into _move_to_preserve; the rename-not-copy
+    # invariant now lives there.
+    body = re.search(r"^\s*_move_to_preserve\(\) \{\n(.*?)^\s*\}$", SRC, re.MULTILINE | re.DOTALL)
+    assert body, "_move_to_preserve() not found"
+    assert re.search(r'mv -- "\$src" "\$dest"', body.group(1))
     assert "cp " not in body.group(1), "the rescue must be an atomic rename, not a copy"
 
 
@@ -284,13 +286,15 @@ def test_preserve_dir_mode_is_restored_after_every_move():
     would otherwise sit world-readable under /run for up to
     agent_task_preserve_max_age_days.
     """
-    moves = re.findall(r'mv "\$task_home/\.claude" "\$preserve_claude_dir"', SRC)
-    chmods = re.findall(r'chmod 700 "\$preserve_claude_dir"', SRC)
-    assert len(moves) == 2, f"expected the two known preserve-moves, found {len(moves)}"
-    assert len(chmods) == len(moves), (
-        f"{len(moves)} preserve-move(s) but {len(chmods)} chmod(s); every move "
-        f"must re-apply 0700 or the history is world-readable under /run"
-    )
+    # #2442 moved the move+chmod into _move_to_preserve; both preserve sites
+    # (startup + reclaim) call it, so the chmod invariant lives in the helper.
+    body = re.search(r"^\s*_move_to_preserve\(\) \{\n(.*?)^\s*\}$", SRC, re.MULTILINE | re.DOTALL)
+    assert body, "_move_to_preserve() not found"
+    helper = body.group(1)
+    assert re.search(r'mv -- "\$src" "\$dest"', helper), "helper must move"
+    assert re.search(r'chmod 700 "\$dest"', helper), "every move must re-apply 0700"
+    calls = SRC.count('_move_to_preserve "$task_home/.claude"')
+    assert calls >= 2, f"expected >=2 preserve-move call sites, found {calls}"
 
 
 def test_signal_traps_are_re_registered_outside_the_task_id_block():

--- a/tests/issues/2403/test_task_tree_reclaim.py
+++ b/tests/issues/2403/test_task_tree_reclaim.py
@@ -41,6 +41,13 @@ def _extract_function(name: str) -> str:
     return textwrap.dedent(match.group(0))
 
 
+# reclaim_task_tree calls _move_to_preserve (Issue #2442), so any harness that
+# runs it must define both. Extract them together once at import time.
+_RECLAIM_SRC = (
+    _extract_function("_move_to_preserve") + "\n" + _extract_function("reclaim_task_tree")
+)
+
+
 def _run_snippet(snippet: str, env: dict[str, str] | None = None) -> subprocess.CompletedProcess:
     full_env = {"PATH": os.environ.get("PATH", "/usr/bin:/bin")}
     full_env.update(env or {})
@@ -126,7 +133,7 @@ def _make_tree(task_root: Path, task_id: str, *, with_claude: bool = True) -> di
 def _reclaim_harness(task_root: Path, task_id: str) -> str:
     base = task_root / task_id
     return f"""
-{_extract_function("reclaim_task_tree")}
+{_RECLAIM_SRC}
 task_base={base!s}
 task_home={base!s}/home
 preserve_claude_dir={task_root!s}/{task_id}.claude-preserve
@@ -169,7 +176,7 @@ class TestReclaimTaskTree:
         sentinel.mkdir()
         (sentinel / "keep").write_text("keep", encoding="utf-8")
         snippet = f"""
-{_extract_function("reclaim_task_tree")}
+{_RECLAIM_SRC}
 task_base=""
 task_home=""
 preserve_claude_dir=""
@@ -191,7 +198,7 @@ echo "rc=$?"
         """
         paths = _make_tree(tmp_path, "t5")
         snippet = f"""
-{_extract_function("reclaim_task_tree")}
+{_RECLAIM_SRC}
 task_base={paths["base"]!s}
 task_home={paths["base"]!s}/home
 preserve_claude_dir=""
@@ -221,7 +228,7 @@ echo "rc=$?"
         try:
             snippet = f"""
 log_audit() {{ printf '%s\\n' "$1" >> {audit!s}; }}
-{_extract_function("reclaim_task_tree")}
+{_RECLAIM_SRC}
 task_base={paths["base"]!s}
 task_home={paths["base"]!s}/home
 preserve_claude_dir={victim!s}/t6.claude-preserve

--- a/tests/issues/2442/test_preserve_exit_code.py
+++ b/tests/issues/2442/test_preserve_exit_code.py
@@ -1,0 +1,24 @@
+"""Issue #2442: exit 70 (preserve prep failed) classifies distinctly.
+
+The startup site exits 70 when ``_move_to_preserve`` cannot clear the prior
+preserve dir. ``_classify_isolated_exit_code`` must map it to a structured code
+so the failure is reported as a nesting-guard abort, not a generic crash.
+"""
+
+from __future__ import annotations
+
+from app.modules.workspace.autonomous.agent_runner import AutonomousAgentRunner
+
+
+def test_exit_70_is_preserve_preparation_failed():
+    code, msg = AutonomousAgentRunner._classify_isolated_exit_code(70)
+    assert code == "preserve_preparation_failed"
+    assert msg and "preserve" in msg.lower()
+
+
+def test_exit_70_distinct_from_overloaded_66_and_repo_68():
+    # 66 is overloaded (cgroup/pre-flight via sentinel) and 68 is repo
+    # integrity; 70 must not collide with either.
+    assert (
+        AutonomousAgentRunner._classify_isolated_exit_code(70)[0] == "preserve_preparation_failed"
+    )

--- a/tests/issues/2442/test_preserve_nesting.py
+++ b/tests/issues/2442/test_preserve_nesting.py
@@ -1,0 +1,89 @@
+"""Issue #2442: a failed preserve-dir removal must not let mv nest .claude.
+
+If ``rm -rf "$preserve_claude_dir"`` fails (full tmpfs, permission), the
+survivor stays and ``mv .claude preserve`` nests .claude inside it; the next
+restore then hands Claude a mis-shaped tree and ``--resume`` silently loses
+history. The ``_move_to_preserve`` helper removes the prior dir and fails
+closed if it cannot, so the caller can abort (startup) or log (reclaim).
+
+Behavioural: extracts the helper from the script and runs it for real.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import textwrap
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[3] / "scripts" / "openace-run-as.sh"
+
+
+def _extract_function(name: str) -> str:
+    src = SCRIPT.read_text(encoding="utf-8")
+    m = re.search(
+        rf"^(?P<ind>[ \t]*){re.escape(name)}\(\) \{{\n(?P<body>.*?)^(?P=ind)\}}$",
+        src,
+        re.MULTILINE | re.DOTALL,
+    )
+    assert m, f"{name}() not found in {SCRIPT.name}"
+    return textwrap.dedent(m.group(0))
+
+
+def _run(snippet: str) -> subprocess.CompletedProcess:
+    env = {"PATH": os.environ.get("PATH", "/usr/bin:/bin")}
+    return subprocess.run(
+        ["bash", "-euo", "pipefail", "-c", snippet],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=60,
+    )
+
+
+def test_rm_failure_returns_nonzero_and_does_not_nest(tmp_path: Path):
+    fn = _extract_function("_move_to_preserve")
+    src = tmp_path / "src/.claude"
+    src.mkdir(parents=True)
+    (src / "f").write_text("x")
+    dest_parent = tmp_path / "dp"
+    dest_parent.mkdir()
+    dest = dest_parent / "preserve"
+    dest.mkdir()
+    os.chmod(dest_parent, 0o500)  # no write → rm -rf of child fails
+    try:
+        r = _run(fn + f'\n_move_to_preserve "{src}" "{dest}"')
+        assert r.returncode != 0, "rm failure must fail closed (non-zero)"
+        assert not (dest / ".claude").exists(), "mv must not nest source into surviving dest"
+        assert src.is_dir(), "source must be left in place when the move is skipped"
+    finally:
+        os.chmod(dest_parent, 0o700)
+
+
+def test_successful_move_is_chmod_700(tmp_path: Path):
+    fn = _extract_function("_move_to_preserve")
+    src = tmp_path / "src/.claude"
+    src.mkdir(parents=True)
+    (src / "f").write_text("x")
+    dest = tmp_path / "preserve"
+    r = _run(fn + f'\n_move_to_preserve "{src}" "{dest}"; echo ok')
+    assert r.returncode == 0, r.stderr
+    assert (dest / "f").read_text() == "x"
+    assert oct(os.stat(dest).st_mode & 0o777) == "0o700"
+
+
+def test_second_move_clears_prior_dest_without_nesting(tmp_path: Path):
+    fn = _extract_function("_move_to_preserve")
+    s1 = tmp_path / "s1/.claude"
+    s1.mkdir(parents=True)
+    (s1 / "a").write_text("1")
+    s2 = tmp_path / "s2/.claude"
+    s2.mkdir(parents=True)
+    (s2 / "b").write_text("2")
+    dest = tmp_path / "preserve"
+    assert _run(fn + f'\n_move_to_preserve "{s1}" "{dest}"; echo ok').returncode == 0
+    r2 = _run(fn + f'\n_move_to_preserve "{s2}" "{dest}"; echo ok')
+    assert r2.returncode == 0, r2.stderr
+    assert (dest / "b").read_text() == "2"
+    assert not (dest / ".claude").exists(), "second move must clear prior dest, not nest"

--- a/tests/issues/2442/test_preserve_wiring.py
+++ b/tests/issues/2442/test_preserve_wiring.py
@@ -1,0 +1,57 @@
+"""Issue #2442: both preserve sites must use the fail-closed helper.
+
+Source assertions (wiring locks), in the style of
+``tests/issues/2403/test_reclaim_wiring.py``. The behavioural proof that the
+helper itself works is in ``test_preserve_nesting.py``; these pin that the
+script actually calls it at both the startup and reclaim sites, with the
+right fail-closed policy at each (startup aborts; reclaim logs because it
+runs inside an EXIT trap where errexit would rewrite the exit code).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[3] / "scripts" / "openace-run-as.sh"
+SRC = SCRIPT.read_text(encoding="utf-8")
+LINES = SRC.splitlines()
+
+
+def test_helper_is_defined():
+    assert re.search(r"_move_to_preserve\(\) \{", SRC), "_move_to_preserve must be defined"
+
+
+def test_both_preserve_sites_call_helper():
+    n = SRC.count('_move_to_preserve "$task_home/.claude"')
+    assert n >= 2, f"expected >=2 call sites (startup + reclaim), found {n}"
+
+
+def test_no_bare_rm_rf_of_preserve_dir_remains():
+    for i, line in enumerate(LINES):
+        if "rm -rf" in line and "preserve_claude_dir" in line:
+            raise AssertionError(
+                f"bare `rm -rf ... preserve_claude_dir` at line {i + 1}; "
+                "must go through _move_to_preserve"
+            )
+
+
+def test_helper_contains_chmod_700():
+    start = SRC.index("_move_to_preserve() {")
+    region = SRC[start:]
+    end = region.index("\n}") + 2
+    assert "chmod 700" in region[:end], "helper must chmod 700 the preserve dir (#2403)"
+
+
+def test_startup_aborts_with_exit_70_on_failure():
+    assert "exit 70" in SRC, "startup must exit 70 when the preserve dir cannot be cleared"
+
+
+def test_reclaim_logs_instead_of_exiting_on_failure():
+    # reclaim runs inside an EXIT trap; errexit there would rewrite the exit
+    # code (per the trap comments), so it must `|| log_audit`, not exit.
+    assert re.search(
+        r"_move_to_preserve.*preserve_claude_dir.*\|\| log_audit",
+        SRC,
+        re.S,
+    ), "reclaim site must `|| log_audit` on failure (trap must not exit)"


### PR DESCRIPTION
## Problem (#2442)

`openace-run-as.sh` preserved `.claude` across runs with `rm -rf "$preserve_claude_dir" || true` then `mv .claude preserve || true`. If `rm -rf` failed (full tmpfs, permission), the survivor stayed and `mv` nested `.claude` inside it; the next restore handed Claude a mis-shaped tree and `--resume` silently lost history. #2403 doubled how often the path fires (reclaim on exit).

## Fix

Collect rm+mv+chmod into a `_move_to_preserve` helper that **fails closed**: rm failure returns non-zero, so `mv` never runs into a survivor.
- **startup site**: helper failure → `exit 70` (classified `preserve_preparation_failed` by `_classify_isolated_exit_code`, so it is reported, not a generic crash).
- **reclaim site** (inside the EXIT trap): helper failure → `|| log_audit` — it must NOT exit, because errexit is live in the trap and would rewrite the process exit status (per the #2403 trap comments), misclassifying the cgroup `exit 66` / repo-integrity `exit 68`.
- `chmod 700` preserved per #2403 (now inside the helper).

## Tests

- `tests/issues/2442/test_preserve_nesting.py` (behavioural): extracts `_move_to_preserve` and runs it — rm failure returns non-zero and does NOT nest; a successful move is chmod 700; a second move clears the prior dest without nesting.
- `tests/issues/2442/test_preserve_wiring.py`: both sites call the helper; no bare `rm -rf preserve` remains; helper chmod 700; startup `exit 70`; reclaim `|| log_audit` (trap-safe).
- `tests/issues/2442/test_preserve_exit_code.py`: `_classify_isolated_exit_code(70)` → `preserve_preparation_failed`, distinct from overloaded 66 / repo 68.
- Updated `tests/issues/2403/` to follow the refactor: the rename-not-copy and chmod-700 invariants now live in `_move_to_preserve`; harnesses define both functions via `_RECLAIM_SRC`.
- CI opt-in (`ci.yml`).

## Deployment

`openace-run-as.sh` is a **runtime** script (every agent task) and `agent_runner.py` is runtime Python — both need hot-patching to prod (`/home/openace`) + the install source patched so the next `install.sh` does not revert them. No migration.

Closes #2442