### PR TITLE
feat(autonomous): reset full CI-repair counter set on retry (#2443 PR-B)

### DIFF
--- a/app/routes/autonomous.py
+++ b/app/routes/autonomous.py
@@ -1216,6 +1216,16 @@ def retry_workflow(workflow_id):
         "status": status,
         "error_message": "",
         "retry_count": retry_count + 1,
+        # PR-B (#2443): reset the full CI-repair counter set + failure signature
+        # so a retried failed workflow starts CI repair from a clean state
+        # instead of being instantly re-exhausted by residual counts or a stale
+        # signature guard.
+        "ci_repair_attempts": 0,
+        "ci_repair_transient_retries": 0,
+        "ci_repair_no_change_retries": 0,
+        "ci_diagnostics_attempts": 0,
+        "last_ci_failure_signature": "",
+        "last_ci_failure_head_sha": "",
     }
     # Optional per-workflow scope bump (#2309): a failed round whose only
     # blocker was the changed-files cap can be retried with a higher limit

--- a/tests/issues/2443/test_retry_reset.py
+++ b/tests/issues/2443/test_retry_reset.py
@@ -1,0 +1,59 @@
+"""Issue #2443 PR-B: retry must reset the full CI-repair counter set.
+
+A CI-repair-exhausted workflow accumulates several counters + a failure
+signature. ``retry_workflow`` reset only ``status``/``error_message``/
+``retry_count``, so a retried failed workflow's first CI-repair round was
+instantly re-exhausted by residual counts and a stale signature guard (#2443
+plan review N2). PR-B resets the whole set.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+AUTONOMOUS = Path(__file__).resolve().parents[3] / "app/routes/autonomous.py"
+SRC = AUTONOMOUS.read_text(encoding="utf-8")
+
+# Every field a CI-repair-exhausted workflow accumulates. retry must zero/clear
+# ALL of them — resetting only ci_repair_attempts leaves the transient/no-change/
+# diagnostics counts and the stale signature, so the retried round re-exhausts.
+RESET_FIELDS = [
+    "ci_repair_attempts",
+    "ci_repair_transient_retries",
+    "ci_repair_no_change_retries",
+    "ci_diagnostics_attempts",
+    "last_ci_failure_signature",
+    "last_ci_failure_head_sha",
+]
+
+
+def _retry_updates_block() -> str:
+    match = re.search(
+        r"retry_updates\s*=\s*\{(?P<body>.*?)\n    _get_repo\(\)\.update_workflow",
+        SRC,
+        re.S,
+    )
+    assert match, "retry_updates block not found in autonomous.py"
+    return match.group("body")
+
+
+def test_retry_resets_full_ci_repair_counter_set():
+    body = _retry_updates_block()
+    missing = [f for f in RESET_FIELDS if f not in body]
+    assert not missing, f"retry_updates missing reset of: {missing}"
+
+
+def test_retry_resets_counters_to_zero_and_signature_to_empty():
+    body = _retry_updates_block()
+    for counter in (
+        "ci_repair_attempts",
+        "ci_repair_transient_retries",
+        "ci_repair_no_change_retries",
+        "ci_diagnostics_attempts",
+    ):
+        assert re.search(
+            rf'"{counter}"\s*:\s*0\b', body
+        ), f"{counter} must reset to 0, not just be present"
+    assert re.search(r'"last_ci_failure_signature"\s*:\s*""', body)
+    assert re.search(r'"last_ci_failure_head_sha"\s*:\s*""', body)


### PR DESCRIPTION
## #2443 PR-B — retry resets the full CI-repair counter set

Part 2 of 3 for #2443 (PR-A merged the Tier2 terminal report; PR-C will add Tier1 dev-round escalation).

### Problem
`retry_workflow` reset only `status`/`error_message`/`retry_count`, so a retried failed workflow's first CI-repair round was instantly re-exhausted by residual counts (transient/no_change/diagnostics) and a stale signature guard (#2443 plan review N2).

### Change
Reset the full set on retry: `ci_repair_attempts`, `ci_repair_transient_retries`, `ci_repair_no_change_retries`, `ci_diagnostics_attempts` → 0, and `last_ci_failure_signature`/`last_ci_failure_head_sha` → "". The retried round starts CI repair clean.

### Tests
- `tests/issues/2443/test_retry_reset.py`: retry_updates contains all six resets; counters → 0, signatures → "".
- CI guardrails + orchestrator characterization: 141 passed — no behavioral change.

### Notes
- Keeps #2443 open — only PR-C should finalize it. Subject and body avoid the GitHub auto-close keywords right beside the issue number (PR-A's subject accidentally shut it; reopened).
- `merge_fail_dev_rounds` (PR-C's new column) will be added to this same reset list in PR-C.