### PR TITLE
fix(autonomous): escalate Tier1 CI-repair exhaustion to a dev round (#2443 PR-C)

### DIFF
--- a/app/modules/workspace/autonomous/models.py
+++ b/app/modules/workspace/autonomous/models.py
@@ -83,6 +83,10 @@ class AutonomousWorkflow:
     ci_repair_no_change_retries: int = 0
     last_ci_failure_signature: str = ""
     last_ci_failure_head_sha: str = ""
+    # #2443 PR-C: how many times a Tier1 CI-repair exhaustion has escalated back
+    # to a fresh development round. Capped by MAX_MERGE_FAIL_DEV_ROUNDS; at the
+    # cap the workflow falls through to a Tier2 terminal report + failed.
+    merge_fail_dev_rounds: int = 0
     # Source of truth for AI-authored content language (en/zh/ja/ko). Set once
     # at creation; persisted content is generated in this language and rendered
     # verbatim (it does NOT switch per viewer). System-authored structured
@@ -173,6 +177,7 @@ class AutonomousWorkflow:
             "ci_repair_no_change_retries": self.ci_repair_no_change_retries,
             "last_ci_failure_signature": self.last_ci_failure_signature,
             "last_ci_failure_head_sha": self.last_ci_failure_head_sha,
+            "merge_fail_dev_rounds": self.merge_fail_dev_rounds,
             "content_language": self.content_language,
             "created_at": self.created_at.isoformat() if self.created_at else None,
             "updated_at": self.updated_at.isoformat() if self.updated_at else None,
@@ -244,6 +249,7 @@ class AutonomousWorkflow:
             ci_repair_no_change_retries=data.get("ci_repair_no_change_retries", 0),
             last_ci_failure_signature=data.get("last_ci_failure_signature", ""),
             last_ci_failure_head_sha=data.get("last_ci_failure_head_sha", ""),
+            merge_fail_dev_rounds=data.get("merge_fail_dev_rounds", 0),
             content_language=data.get("content_language", "en"),
             created_at=(
                 datetime.fromisoformat(data["created_at"]) if data.get("created_at") else None

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -1833,6 +1833,24 @@ PRE_COMMIT_CONVERGENCE_TIMEOUT = 600
 CI_PRE_COMMIT_SKIP = "bandit,no-commit-to-branch"
 MAX_CI_DIAGNOSTICS_ATTEMPTS = 6  # bound scheduler polls when failed job logs stay unavailable
 MAX_CLEANUP_ATTEMPTS = 10  # post-merge Git cleanup retries before giving up (#2043)
+# Cap on Tier1 CI-repair-exhaustion escalations back to a fresh development
+# round (#2443 PR-C). A Tier1 exhaustion (MAX / no-change / unchanged-signature)
+# means the PR branch and CI logs are still recoverable, so instead of terminal
+# `failed` we rebase the existing PR branch onto main, reset the CI-repair
+# counters, and re-enter development on the SAME PR/branch (ci_repair_context is
+# preserved so _get_ci_repair_prompt surfaces the prior failure). After this many
+# dev-round escalations the workflow falls through to a Tier2 terminal report +
+# `failed` — the repair is not converging and must not loop forever.
+MAX_MERGE_FAIL_DEV_ROUNDS = 3
+# Exhaustion categories that are recoverable (PR branch present, failure
+# actionable) and therefore eligible for a Tier1 dev-round escalation.
+_CI_REPAIR_TIER1_CATEGORIES = frozenset(
+    {
+        "ci_repair_exhausted",  # MAX_CI_REPAIR_ATTEMPTS reached
+        "ci_repair_no_change_exhausted",
+        "ci_repair_signature_unchanged",  # meaningful fingerprint unchanged
+    }
+)
 
 
 def _cleanup_backoff_time(attempts: int) -> str:
@@ -4718,6 +4736,122 @@ class AutonomousOrchestrator:
             error_message=body[:500],
         )
 
+    def _escalate_ci_repair_exhaustion(
+        self,
+        wf: dict,
+        pr_number: int,
+        *,
+        category: str,
+        reason: str,
+        attempts: int,
+        failure_names: str = "",
+        branch_name: str = "",
+    ) -> None:
+        """Route a CI-repair exhaustion to Tier1 (fresh dev round) or Tier2 (terminal).
+
+        #2443 PR-C. ``category`` distinguishes the two tiers:
+
+        * **Tier1** (``_CI_REPAIR_TIER1_CATEGORIES`` — MAX / no-change /
+          unchanged-signature): the PR branch and CI logs are recoverable, so a
+          fresh development pass may still succeed. While ``merge_fail_dev_rounds``
+          is under ``MAX_MERGE_FAIL_DEV_ROUNDS`` AND a PR branch exists, rebase
+          the existing branch onto main, reset the full CI-repair counter set,
+          and re-enter development on the SAME PR/branch.
+        * **Tier2** (every other category) or Tier1-at-cap: post the PR-A
+          terminal report and write absorbing ``failed``.
+
+        Replaces the PR-A ``_emit_ci_repair_terminal_report`` + ``failed`` pair
+        at the 3 Tier1 exhaustion sites; the 8 Tier2 sites keep PR-A's behavior.
+        """
+        merge_fail_dev_rounds = int(wf.get("merge_fail_dev_rounds", 0) or 0)
+        recoverable_branch = bool((wf.get("branch_name") or branch_name or "").strip())
+        if (
+            category in _CI_REPAIR_TIER1_CATEGORIES
+            and merge_fail_dev_rounds < MAX_MERGE_FAIL_DEV_ROUNDS
+            and recoverable_branch
+        ):
+            self._escalate_to_development_round(
+                wf,
+                pr_number,
+                reason=reason,
+                attempts=attempts,
+                branch_name=(wf.get("branch_name") or branch_name or ""),
+            )
+            return
+        # Tier2, or Tier1 at the dev-round cap: terminal report + absorbing failed.
+        self._emit_ci_repair_terminal_report(
+            wf,
+            pr_number,
+            category=category,
+            reason=reason,
+            attempts=attempts,
+            failure_names=failure_names,
+            branch_name=branch_name,
+        )
+        self._update_workflow({"status": "failed", "error_message": reason})
+
+    def _escalate_to_development_round(
+        self, wf: dict, pr_number: int, *, reason: str, attempts: int, branch_name: str
+    ) -> None:
+        """Re-enter development on the existing PR branch after a Tier1 exhaustion.
+
+        Rebase the PR branch onto current main first (best-effort — a sync
+        failure must not strand the workflow in ``failed``), record the
+        escalation, then transition to ``developing`` with a full CI-repair
+        counter reset. ``ci_repair_context`` is deliberately NOT cleared: the
+        development prompt's ``_get_ci_repair_prompt`` surfaces it so the fresh
+        dev round is aware of the prior CI failure rather than re-deriving the
+        same broken implementation blind (#2443 PR-C, plan N6).
+        """
+        dev_round = int(wf.get("dev_round", 1) or 1)
+        merge_fail_dev_rounds = int(wf.get("merge_fail_dev_rounds", 0) or 0)
+        if branch_name:
+            try:
+                gh = self._get_gh()
+                head_sha = ""
+                try:
+                    head_sha = gh.get_pr_head_sha(pr_number)
+                except Exception:
+                    pass
+                if head_sha:
+                    # Ignore the return: whether or not a sync push happened, the
+                    # branch is now current with main and development proceeds.
+                    self._sync_failed_pr_with_main(gh, branch_name, pr_number, head_sha)
+            except Exception as exc:
+                logger.warning(
+                    "Pre-development rebase failed for PR #%s (proceeding anyway): %s",
+                    pr_number,
+                    exc,
+                )
+        self._create_milestone(
+            phase="merge",
+            dev_round=dev_round,
+            round_number=attempts,
+            milestone_type="ci_repair_escalated_to_development",
+            status="completed",
+            title="CI repair exhausted — escalating to a fresh development round",
+            error_message=reason,
+        )
+        self._update_workflow(
+            {
+                "status": "developing",
+                "current_phase": "development",
+                "dev_round": dev_round + 1,
+                "merge_fail_dev_rounds": merge_fail_dev_rounds + 1,
+                # Full counter reset — a fresh dev round must not inherit stale
+                # CI-repair counts or a stale failure signature (mirrors
+                # retry_workflow, PR-B). ci_repair_context is intentionally left
+                # untouched (preserved as dev feedback).
+                "ci_repair_attempts": 0,
+                "ci_repair_transient_retries": 0,
+                "ci_repair_no_change_retries": 0,
+                "ci_diagnostics_attempts": 0,
+                "last_ci_failure_signature": "",
+                "last_ci_failure_head_sha": "",
+                "error_message": "",
+            }
+        )
+
     def _start_ci_repair_round(self, wf: dict, pr_number: int, failed_checks: list[dict]) -> None:
         """Repair merge-phase CI failures in-place on the existing PR branch."""
         dev_round = int(wf.get("dev_round", 1) or 1)
@@ -4783,14 +4917,13 @@ class AutonomousOrchestrator:
                     ),
                     error_message=message,
                 )
-                self._emit_ci_repair_terminal_report(
+                self._escalate_ci_repair_exhaustion(
                     wf,
                     pr_number,
                     category="ci_repair_no_change_exhausted",
                     reason=message,
                     attempts=previous_attempts,
                 )
-                self._update_workflow({"status": "failed", "error_message": message})
                 return
             # Don't increment ci_repair_attempts; bump the no-change counter
             # (reset to 0 on a change-producing round).
@@ -4846,15 +4979,15 @@ class AutonomousOrchestrator:
                 title="CI automatic repair limit reached",
                 error_message=message,
             )
-            self._emit_ci_repair_terminal_report(
+            self._escalate_ci_repair_exhaustion(
                 wf,
                 pr_number,
                 category="ci_repair_exhausted",
                 reason=message,
                 attempts=next_attempt,
                 failure_names=failure_names,
+                branch_name=branch_name,
             )
-            self._update_workflow({"status": "failed", "error_message": message})
             return
 
         # Resolve log evidence before consuming an attempt.  A repair agent
@@ -5032,15 +5165,15 @@ class AutonomousOrchestrator:
                 title="CI failures unchanged after automatic repair",
                 error_message=message,
             )
-            self._emit_ci_repair_terminal_report(
+            self._escalate_ci_repair_exhaustion(
                 wf,
                 pr_number,
                 category="ci_repair_signature_unchanged",
                 reason=message,
                 attempts=next_attempt,
                 failure_names=failure_names,
+                branch_name=branch_name,
             )
-            self._update_workflow({"status": "failed", "error_message": message})
             return
 
         context = self._build_ci_repair_context(wf, gh, pr_number, failed_checks)

--- a/app/repositories/autonomous_repo.py
+++ b/app/repositories/autonomous_repo.py
@@ -95,6 +95,7 @@ class AutonomousWorkflowRepository:
         "ci_repair_no_change_retries",
         "last_ci_failure_signature",
         "last_ci_failure_head_sha",
+        "merge_fail_dev_rounds",
         # Worktree transition journal for SIGKILL-resilient recovery (#2050).
         "worktree_transition_state",
         "transition_original_path",
@@ -319,8 +320,8 @@ class AutonomousWorkflowRepository:
                      parent_workflow_id, fork_milestone_id, user_feedback,
                      original_branch_name, content_language, system_account,
                      ci_repair_context, ci_repair_attempts, ci_diagnostics_attempts, ci_repair_transient_retries, ci_repair_no_change_retries, last_ci_failure_signature,
-                     last_ci_failure_head_sha, created_at, updated_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                     last_ci_failure_head_sha, merge_fail_dev_rounds, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 RETURNING *
                 """,
                 (
@@ -367,6 +368,7 @@ class AutonomousWorkflowRepository:
                     data.get("ci_repair_no_change_retries", 0),
                     data.get("last_ci_failure_signature", ""),
                     data.get("last_ci_failure_head_sha", ""),
+                    data.get("merge_fail_dev_rounds", 0),
                     now,
                     now,
                 ),
@@ -388,8 +390,8 @@ class AutonomousWorkflowRepository:
                      parent_workflow_id, fork_milestone_id, user_feedback,
                      original_branch_name, content_language, system_account,
                      ci_repair_context, ci_repair_attempts, ci_diagnostics_attempts, ci_repair_transient_retries, ci_repair_no_change_retries, last_ci_failure_signature,
-                     last_ci_failure_head_sha, created_at, updated_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                     last_ci_failure_head_sha, merge_fail_dev_rounds, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     workflow_id,
@@ -435,6 +437,7 @@ class AutonomousWorkflowRepository:
                     data.get("ci_repair_no_change_retries", 0),
                     data.get("last_ci_failure_signature", ""),
                     data.get("last_ci_failure_head_sha", ""),
+                    data.get("merge_fail_dev_rounds", 0),
                     now,
                     now,
                 ),

--- a/app/routes/autonomous.py
+++ b/app/routes/autonomous.py
@@ -1226,6 +1226,9 @@ def retry_workflow(workflow_id):
         "ci_diagnostics_attempts": 0,
         "last_ci_failure_signature": "",
         "last_ci_failure_head_sha": "",
+        # PR-C (#2443): reset the Tier1 dev-round escalation budget too, so a
+        # retried workflow gets a fresh MAX_MERGE_FAIL_DEV_ROUNDS allowance.
+        "merge_fail_dev_rounds": 0,
     }
     # Optional per-workflow scope bump (#2309): a failed round whose only
     # blocker was the changed-files cap can be retried with a higher limit

--- a/migrations/versions/20260809_001_add_merge_fail_dev_rounds.py
+++ b/migrations/versions/20260809_001_add_merge_fail_dev_rounds.py
@@ -1,0 +1,62 @@
+"""Add merge_fail_dev_rounds to autonomous_workflows.
+
+Revision ID: 20260809_001_add_merge_fail_dev_rounds
+Revises: 20260805_010_acceptance_verification_columns
+Create Date: 2026-08-09
+
+Issue: #2443 (PR-C)
+
+Counter for Tier1 CI-repair-exhaustion escalations back to a fresh development
+round. When a merge-phase PR exhausts automatic CI repair (MAX attempts,
+no-code-change, or an unchanged meaningful failure signature) and the PR branch
+is still recoverable, the orchestrator rebases the branch onto main and
+re-enters development instead of terminal-failing. This column bounds that
+escalation (``MAX_MERGE_FAIL_DEV_ROUNDS``); at the cap the workflow falls
+through to a Tier2 terminal report + ``failed``. ``retry_workflow`` zeroes it so
+a retried workflow gets a fresh allowance.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260809_001_add_merge_fail_dev_rounds"
+down_revision: str | None = "20260805_010_acceptance_verification_columns"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    """Add the merge_fail_dev_rounds column."""
+    connection = op.get_bind()
+    inspector = sa.inspect(connection)
+
+    if "autonomous_workflows" not in set(inspector.get_table_names()):
+        # Fresh databases create the column directly in CREATE TABLE; nothing
+        # to migrate here.
+        return
+
+    existing_columns = {col["name"] for col in inspector.get_columns("autonomous_workflows")}
+    if "merge_fail_dev_rounds" not in existing_columns:
+        op.add_column(
+            "autonomous_workflows",
+            sa.Column(
+                "merge_fail_dev_rounds",
+                sa.Integer(),
+                nullable=True,
+                server_default="0",
+            ),
+        )
+
+
+def downgrade() -> None:
+    """Remove the merge_fail_dev_rounds column."""
+    connection = op.get_bind()
+    inspector = sa.inspect(connection)
+
+    if "autonomous_workflows" not in set(inspector.get_table_names()):
+        return
+
+    existing_columns = {col["name"] for col in inspector.get_columns("autonomous_workflows")}
+    with op.batch_alter_table("autonomous_workflows") as batch_op:
+        if "merge_fail_dev_rounds" in existing_columns:
+            batch_op.drop_column("merge_fail_dev_rounds")

--- a/schema/schema-postgres.sql
+++ b/schema/schema-postgres.sql
@@ -515,7 +515,8 @@ CREATE TABLE autonomous_workflows (
     issue_acceptance_hash text,
     verified_by text,
     verification_session_id text,
-    issue_closed_by_workflow_at timestamp with time zone
+    issue_closed_by_workflow_at timestamp with time zone,
+    merge_fail_dev_rounds integer DEFAULT 0
 );
 
 CREATE SEQUENCE autonomous_workflows_id_seq

--- a/schema/schema-sqlite.sql
+++ b/schema/schema-sqlite.sql
@@ -355,7 +355,8 @@ CREATE TABLE autonomous_workflows (
  issue_acceptance_hash text,
  verified_by text,
  verification_session_id text,
- issue_closed_by_workflow_at TIMESTAMP
+ issue_closed_by_workflow_at TIMESTAMP,
+ merge_fail_dev_rounds integer DEFAULT 0
 );
 
 CREATE TABLE command_execution_evidence (

--- a/tests/issues/1574/test_ci_repair_verifiers.py
+++ b/tests/issues/1574/test_ci_repair_verifiers.py
@@ -137,8 +137,18 @@ def test_start_ci_repair_round_stays_in_merge_and_runs_merge_repair():
     assert "current_round" not in updates
 
 
-def test_start_ci_repair_round_fails_when_signature_unchanged_after_new_head():
-    from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+def test_start_ci_repair_round_escalates_when_signature_unchanged_after_new_head():
+    """A meaningful unchanged signature after a new head fires the give-up guard.
+
+    #2443 PR-C: ci_repair_signature_unchanged is a Tier1 category, so under the
+    dev-round cap (with a recoverable PR branch) it escalates to a fresh
+    development round instead of terminal-failing; at the cap it falls through
+    to failed. Either way the agent is NOT run again.
+    """
+    from app.modules.workspace.autonomous.orchestrator import (
+        MAX_MERGE_FAIL_DEV_ROUNDS,
+        AutonomousOrchestrator,
+    )
 
     failed_checks = [
         {"name": "lint", "state": "failure", "bucket": "fail", "link": "https://example.com"}
@@ -154,12 +164,14 @@ def test_start_ci_repair_round_fails_when_signature_unchanged_after_new_head():
     ).hexdigest()[:12]
     expected_fingerprint = f"lint::{expected_digest}"
 
+    # Under cap → Tier1 escalation to development.
     wf = _make_workflow(
         status="merging",
         current_phase="merge",
         ci_repair_attempts=1,
         last_ci_failure_signature=expected_fingerprint,
         last_ci_failure_head_sha="sha-old",
+        merge_fail_dev_rounds=0,
     )
     orch, mock_repo = _make_orchestrator(wf)
     gh = MagicMock()
@@ -172,8 +184,28 @@ def test_start_ci_repair_round_fails_when_signature_unchanged_after_new_head():
 
     orch._run_merge_ci_repair.assert_not_called()
     updates = mock_repo.update_workflow.call_args.args[1]
-    assert updates["status"] == "failed"
-    assert "CI 失败在自动修复后仍未变化" in updates["error_message"]
+    assert updates["status"] == "developing"
+
+    # At the dev-round cap → Tier2 fall-through to terminal failed, with the
+    # "signature still unchanged" reason recorded on the failed update.
+    wf_cap = _make_workflow(
+        status="merging",
+        current_phase="merge",
+        ci_repair_attempts=1,
+        last_ci_failure_signature=expected_fingerprint,
+        last_ci_failure_head_sha="sha-old",
+        merge_fail_dev_rounds=MAX_MERGE_FAIL_DEV_ROUNDS,
+    )
+    orch2, mock_repo2 = _make_orchestrator(wf_cap)
+    gh2 = MagicMock()
+    gh2.get_pr_head_sha.return_value = "sha-new"
+    gh2.get_check_failure_excerpt.return_value = excerpt
+    orch2._get_gh = MagicMock(return_value=gh2)
+    orch2._run_merge_ci_repair = MagicMock()
+    orch2._start_ci_repair_round(wf_cap, 1697, failed_checks)
+    cap_updates = mock_repo2.update_workflow.call_args.args[1]
+    assert cap_updates["status"] == "failed"
+    assert "CI 失败在自动修复后仍未变化" in cap_updates["error_message"]
 
 
 def test_run_merge_ci_repair_pushes_commit_and_stays_in_merge():

--- a/tests/issues/1855/test_ci_repair_no_excerpt_no_misfire.py
+++ b/tests/issues/1855/test_ci_repair_no_excerpt_no_misfire.py
@@ -148,10 +148,19 @@ def test_diagnostics_pending_milestone_closes_when_all_logs_arrive():
     )
 
 
-def test_meaningful_fingerprint_still_gives_up_when_unchanged():
+def test_meaningful_fingerprint_still_fires_guard_when_unchanged():
     """Sanity: when excerpt IS available and signature truly unchanged, the
-    guard still fires (regression guard for the layer-2 change)."""
-    from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+    guard still FIRES (regression guard for the layer-2 #1855 change).
+
+    #2443 PR-C changed what "fires" means: a meaningful unchanged signature is a
+    Tier1 exhaustion, so under the dev-round cap it escalates to a fresh
+    development round (``developing``) instead of terminal-``failed``; only at
+    the cap does it fall through to failed. Either way the guard fired: no
+    repair attempt is launched and the workflow leaves the merge-repair loop."""
+    from app.modules.workspace.autonomous.orchestrator import (
+        MAX_MERGE_FAIL_DEV_ROUNDS,
+        AutonomousOrchestrator,
+    )
 
     excerpt = "mypy....Failed\napp/baz.py:5 error: no-any-return\n"
     import hashlib
@@ -164,6 +173,7 @@ def test_meaningful_fingerprint_still_gives_up_when_unchanged():
     wf = _make_workflow(
         last_ci_failure_signature=expected_fingerprint,
         last_ci_failure_head_sha="sha-old",
+        merge_fail_dev_rounds=0,  # under cap → Tier1 escalation
     )
     orch, mock_repo = _make_orchestrator(wf)
     gh = MagicMock()
@@ -174,10 +184,26 @@ def test_meaningful_fingerprint_still_gives_up_when_unchanged():
 
     orch._start_ci_repair_round(wf, 1873, _FAILED_CHECKS)
 
-    # Guard fires → no repair, workflow failed.
+    # Guard fired: no repair attempt, and the workflow escalated to development.
     orch._run_merge_ci_repair.assert_not_called()
     last_updates = [c.args[1] for c in mock_repo.update_workflow.call_args_list]
-    assert any(u.get("status") == "failed" for u in last_updates)
+    assert any(u.get("status") == "developing" for u in last_updates)
+    assert not any(u.get("status") == "merging" for u in last_updates)
+    # At the cap the same guard instead falls through to terminal failed.
+    wf_cap = _make_workflow(
+        last_ci_failure_signature=expected_fingerprint,
+        last_ci_failure_head_sha="sha-old",
+        merge_fail_dev_rounds=MAX_MERGE_FAIL_DEV_ROUNDS,
+    )
+    orch2, mock_repo2 = _make_orchestrator(wf_cap)
+    gh2 = MagicMock()
+    gh2.get_pr_head_sha.return_value = "sha-new"
+    gh2.get_check_failure_excerpt.return_value = excerpt
+    orch2._get_gh = MagicMock(return_value=gh2)
+    orch2._run_merge_ci_repair = MagicMock()
+    orch2._start_ci_repair_round(wf_cap, 1873, _FAILED_CHECKS)
+    cap_updates = [c.args[1] for c in mock_repo2.update_workflow.call_args_list]
+    assert any(u.get("status") == "failed" for u in cap_updates)
 
 
 # ── Layer 1: REST-API check-run link falls back to gh run list ─────────

--- a/tests/issues/2187/test_ci_repair_no_change_deferral.py
+++ b/tests/issues/2187/test_ci_repair_no_change_deferral.py
@@ -13,7 +13,10 @@ Mirrors tests/issues/1820 (transient deferral) in structure.
 
 from unittest.mock import MagicMock, patch
 
-from app.modules.workspace.autonomous.orchestrator import MAX_CI_REPAIR_NO_CHANGE_RETRIES
+from app.modules.workspace.autonomous.orchestrator import (
+    MAX_CI_REPAIR_NO_CHANGE_RETRIES,
+    MAX_MERGE_FAIL_DEV_ROUNDS,
+)
 
 
 def _make_workflow(**overrides):
@@ -101,16 +104,24 @@ def test_no_change_deferred_does_not_increment_attempts():
     assert any(u.get("ci_repair_no_change_retries") == 1 for u in updates), "no-change counter 0→1"
 
 
-# ── 2. After MAX_CI_REPAIR_NO_CHANGE_RETRIES, workflow is marked failed ──
+# ── 2. After MAX_CI_REPAIR_NO_CHANGE_RETRIES, the workflow leaves the loop ──
 
 
-def test_no_change_retries_exhausted_marks_failed():
-    """When no-change retries hit the cap, the workflow fails with a dedicated
-    exhausted milestone and the agent is NOT run again."""
+def test_no_change_retries_exhausted_escalates_under_cap():
+    """When no-change retries hit the cap, the workflow leaves the repair loop.
+
+    #2443 PR-C: ci_repair_no_change_exhausted is a Tier1 category, so under the
+    dev-round cap (with a recoverable PR branch) it escalates to a fresh
+    development round instead of terminal-failing; only at the cap does it fall
+    through to failed. Either way the agent is NOT run again and the dedicated
+    exhausted milestone is recorded.
+    """
+    # Under cap → Tier1 escalation to development.
     wf = _make_workflow(
         error_message="CI repair deferred: agent produced no code changes",
         ci_repair_attempts=2,
         ci_repair_no_change_retries=MAX_CI_REPAIR_NO_CHANGE_RETRIES,
+        merge_fail_dev_rounds=0,
     )
     orch, mock_repo = _make_orchestrator(wf)
     gh = MagicMock()
@@ -123,12 +134,30 @@ def test_no_change_retries_exhausted_marks_failed():
 
     orch._run_merge_ci_repair.assert_not_called()
     updates = [c.args[1] for c in mock_repo.update_workflow.call_args_list]
-    assert any(u.get("status") == "failed" for u in updates)
-    assert any("no code changes" in (u.get("error_message") or "").lower() for u in updates)
+    assert any(u.get("status") == "developing" for u in updates)
+    assert not any(u.get("status") == "failed" for u in updates)
     assert any(
         c.args[0].get("milestone_type") == "ci_repair_no_change_exhausted"
         for c in mock_repo.create_milestone.call_args_list
     )
+
+    # At the dev-round cap → Tier2 fall-through to terminal failed.
+    wf_cap = _make_workflow(
+        error_message="CI repair deferred: agent produced no code changes",
+        ci_repair_attempts=2,
+        ci_repair_no_change_retries=MAX_CI_REPAIR_NO_CHANGE_RETRIES,
+        merge_fail_dev_rounds=MAX_MERGE_FAIL_DEV_ROUNDS,
+    )
+    orch2, mock_repo2 = _make_orchestrator(wf_cap)
+    gh2 = MagicMock()
+    gh2.get_pr_head_sha.return_value = "sha-new"
+    gh2.get_check_failure_excerpt.return_value = "schema-sync failed\n1 error"
+    orch2._get_gh = MagicMock(return_value=gh2)
+    orch2._run_merge_ci_repair = MagicMock()
+    orch2._start_ci_repair_round(wf_cap, 2187, _FAILED_CHECKS)
+    cap_updates = [c.args[1] for c in mock_repo2.update_workflow.call_args_list]
+    assert any(u.get("status") == "failed" for u in cap_updates)
+    assert any("no code changes" in (u.get("error_message") or "").lower() for u in cap_updates)
 
 
 # ── 3. Change-producing (fresh) round resets the no-change counter ──

--- a/tests/issues/2443/test_escalation.py
+++ b/tests/issues/2443/test_escalation.py
@@ -1,0 +1,290 @@
+"""Issue #2443 PR-C: route CI-repair exhaustion through tiered escalation.
+
+PR-A made an exhausting CI-repair terminal ``failed`` visible (a report on the
+issue). PR-B reset the full CI-repair counter set on retry. But the exhaustion
+itself was still *terminal* — a workflow whose PR hit ``MAX_CI_REPAIR_ATTEMPTS``
+(or whose failure signature refused to change, or whose agent kept producing no
+changes) silently died in ``failed`` even though the PR branch and CI logs were
+fully recoverable. A fresh development pass (re-derived implementation, aware of
+the prior CI failure via the preserved ``ci_repair_context``) can still succeed.
+
+PR-C splits the exhaustion sites into two tiers:
+
+* **Tier1** (recoverable: PR branch present, failure actionable) —
+  ``ci_repair_exhausted`` (MAX), ``ci_repair_no_change_exhausted``,
+  ``ci_repair_signature_unchanged``. While ``merge_fail_dev_rounds`` is under
+  ``MAX_MERGE_FAIL_DEV_ROUNDS``, rebase the existing PR branch onto main, reset
+  the full counter set, and re-enter *development* on the SAME PR/branch
+  (``ci_repair_context`` preserved → the dev prompt's ``_get_ci_repair_prompt``
+  surfaces it). At the cap, fall through to Tier2.
+* **Tier2** (truly stuck / unrecoverable) — transient/diagnostics exhaustion,
+  env mismatch, context overflow, branch drift, push failure, agent failure.
+  These keep PR-A's behavior: terminal report + ``failed``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from app.modules.workspace.autonomous.orchestrator import (
+    MAX_CI_REPAIR_ATTEMPTS,
+    MAX_CI_REPAIR_TRANSIENT_RETRIES,
+    MAX_MERGE_FAIL_DEV_ROUNDS,
+    AutonomousOrchestrator,
+)
+
+ORCH = Path(__file__).resolve().parents[3] / "app/modules/workspace/autonomous/orchestrator.py"
+ORCH_SRC = ORCH.read_text(encoding="utf-8")
+
+AUTONOMOUS_ROUTE = Path(__file__).resolve().parents[3] / "app/routes/autonomous.py"
+ROUTE_SRC = AUTONOMOUS_ROUTE.read_text(encoding="utf-8")
+
+TIER1_CATEGORIES = [
+    "ci_repair_exhausted",  # MAX_CI_REPAIR_ATTEMPTS reached
+    "ci_repair_no_change_exhausted",
+    "ci_repair_signature_unchanged",
+]
+TIER2_CATEGORIES = [
+    "ci_repair_environment_mismatch",
+    "ci_repair_context_overflow",
+    "ci_repair_branch_changed",
+    "ci_repair_push_failed",
+    "ci_repair_terminal",
+    "ci_repair_agent_failed",
+    "ci_repair_transient_exhausted",
+    "ci_repair_diagnostics_exhausted",
+]
+
+
+def _make_workflow(**overrides):
+    base = {
+        "workflow_id": "wf-2443",
+        "user_id": 1,
+        "status": "merging",
+        "current_phase": "merge",
+        "dev_round": 1,
+        "ci_repair_attempts": 0,
+        "ci_repair_transient_retries": 0,
+        "ci_repair_no_change_retries": 0,
+        "ci_diagnostics_attempts": 0,
+        "last_ci_failure_signature": "",
+        "last_ci_failure_head_sha": "",
+        "ci_repair_context": "",
+        "merge_fail_dev_rounds": 0,
+        "branch_name": "auto-dev/wf-2443",
+        "branch_strategy": "worktree",
+        "worktree_path": "/tmp/repo",
+        "preferred_worktree_path": "/tmp/repo",
+    }
+    base.update(overrides)
+    return base
+
+
+def _make_orchestrator(wf_data):
+    with (
+        patch("app.modules.workspace.autonomous.orchestrator.Database"),
+        patch(
+            "app.modules.workspace.autonomous.orchestrator.AutonomousWorkflowRepository"
+        ) as mock_repo_cls,
+    ):
+        mock_repo = MagicMock()
+        mock_repo.get_workflow.return_value = wf_data
+        mock_repo.list_milestones.return_value = []
+        mock_repo.create_milestone.return_value = {
+            "milestone_id": "ms-1",
+            "workflow_id": wf_data["workflow_id"],
+        }
+        mock_repo.create_event.return_value = {"id": 1}
+        mock_repo.update_workflow.return_value = wf_data
+        mock_repo_cls.return_value = mock_repo
+
+        orch = AutonomousOrchestrator(wf_data["workflow_id"])
+        orch.repo = mock_repo
+        orch.emitter = MagicMock()
+        orch._sync_failed_pr_with_main = MagicMock(return_value=False)
+    return orch, mock_repo
+
+
+_FAILED_CHECKS = [
+    {
+        "name": "lint",
+        "state": "failure",
+        "bucket": "fail",
+        "link": "https://github.com/open-ace/open-ace/runs/123",
+    }
+]
+
+
+def _gh(head_sha="sha-new", excerpt=""):
+    gh = MagicMock()
+    gh.get_pr_head_sha.return_value = head_sha
+    gh.get_check_failure_excerpt.return_value = excerpt
+    return gh
+
+
+# ── Tier1 behavioral: exhaustion escalates to a fresh development round ──
+
+
+def test_max_exhaustion_enters_dev_round_under_cap():
+    """MAX_CI_REPAIR_ATTEMPTS reached (Tier1) → re-enter development, not fail."""
+    wf = _make_workflow(
+        ci_repair_attempts=MAX_CI_REPAIR_ATTEMPTS,  # next_attempt = MAX+1
+        merge_fail_dev_rounds=0,
+        ci_repair_context="prior ci failure context",
+    )
+    orch, mock_repo = _make_orchestrator(wf)
+    orch._emit_ci_repair_terminal_report = MagicMock()  # Tier1 must not report
+    orch._get_gh = MagicMock(return_value=_gh())
+
+    orch._start_ci_repair_round(wf, 2400, _FAILED_CHECKS)
+
+    orch._emit_ci_repair_terminal_report.assert_not_called()
+    updates = [c.args[1] for c in mock_repo.update_workflow.call_args_list]
+    developing = [u for u in updates if u.get("status") == "developing"]
+    assert developing, "MAX exhaustion (Tier1, under cap) must escalate to development"
+    u = developing[-1]
+    assert u["current_phase"] == "development"
+    assert u["dev_round"] == 2
+    assert u["merge_fail_dev_rounds"] == 1
+    # Full counter reset — a fresh dev round must not inherit stale counts/signature.
+    assert u["ci_repair_attempts"] == 0
+    assert u["ci_repair_transient_retries"] == 0
+    assert u["ci_repair_no_change_retries"] == 0
+    assert u["ci_diagnostics_attempts"] == 0
+    assert u["last_ci_failure_signature"] == ""
+    assert u["last_ci_failure_head_sha"] == ""
+    assert u["error_message"] == ""
+    # ci_repair_context preserved (NOT cleared) so _get_ci_repair_prompt surfaces
+    # the prior CI failure in the new development prompt.
+    assert "ci_repair_context" not in u
+    assert not any(uu.get("status") == "failed" for uu in updates)
+
+
+def test_merge_fail_dev_round_cap_falls_through_to_terminal():
+    """At the dev-round cap, a Tier1 exhaustion falls through to Tier2 (report + failed)."""
+    wf = _make_workflow(
+        ci_repair_attempts=MAX_CI_REPAIR_ATTEMPTS,
+        merge_fail_dev_rounds=MAX_MERGE_FAIL_DEV_ROUNDS,  # at cap → Tier2
+    )
+    orch, mock_repo = _make_orchestrator(wf)
+    reported = []
+    orch._emit_ci_repair_terminal_report = lambda *a, **k: reported.append(k)
+    orch._get_gh = MagicMock(return_value=_gh())
+
+    orch._start_ci_repair_round(wf, 2400, _FAILED_CHECKS)
+
+    assert reported, "cap reached → Tier2 must post a terminal report"
+    updates = [c.args[1] for c in mock_repo.update_workflow.call_args_list]
+    assert any(u.get("status") == "failed" for u in updates)
+    assert not any(u.get("status") == "developing" for u in updates)
+
+
+def test_signature_unchanged_with_excerpt_is_tier1():
+    """A meaningful, unchanged failure signature (Tier1) escalates to dev, not fail."""
+    excerpt = "mypy....Failed\napp/baz.py:5 error: no-any-return\n"
+    digest = hashlib.sha256(
+        AutonomousOrchestrator._normalize_failure_excerpt(excerpt).encode()
+    ).hexdigest()[:12]
+    sig = f"lint::{digest}"
+    wf = _make_workflow(
+        ci_repair_attempts=1,  # next_attempt = 2, well under MAX
+        merge_fail_dev_rounds=0,
+        last_ci_failure_signature=sig,
+        last_ci_failure_head_sha="sha-old",
+    )
+    orch, mock_repo = _make_orchestrator(wf)
+    orch._emit_ci_repair_terminal_report = MagicMock()
+    orch._get_gh = MagicMock(return_value=_gh(head_sha="sha-new", excerpt=excerpt))
+
+    orch._start_ci_repair_round(wf, 2400, _FAILED_CHECKS)
+
+    orch._emit_ci_repair_terminal_report.assert_not_called()
+    updates = [c.args[1] for c in mock_repo.update_workflow.call_args_list]
+    assert any(
+        u.get("status") == "developing" for u in updates
+    ), "meaningful signature-unchanged exhaustion is Tier1 → must escalate to dev"
+    assert not any(u.get("status") == "failed" for u in updates)
+
+
+def test_no_branch_routes_to_tier2_even_for_tier1_category():
+    """No branch_name = cannot reuse the PR → Tier1 category falls through to Tier2."""
+    wf = _make_workflow(
+        ci_repair_attempts=MAX_CI_REPAIR_ATTEMPTS,
+        merge_fail_dev_rounds=0,
+        branch_name="",  # no recoverable PR branch
+    )
+    orch, mock_repo = _make_orchestrator(wf)
+    reported = []
+    orch._emit_ci_repair_terminal_report = lambda *a, **k: reported.append(k)
+    orch._get_gh = MagicMock(return_value=_gh())
+
+    orch._start_ci_repair_round(wf, 2400, _FAILED_CHECKS)
+
+    assert reported, "no branch_name → Tier2 terminal report even for a Tier1 category"
+    updates = [c.args[1] for c in mock_repo.update_workflow.call_args_list]
+    assert any(u.get("status") == "failed" for u in updates)
+    assert not any(u.get("status") == "developing" for u in updates)
+
+
+# ── Tier2 behavioral: genuinely-stuck exhaustion stays terminal ──
+
+
+def test_transient_exhausted_is_tier2():
+    """Transient-API exhaustion is Tier2: report + failed, never escalates."""
+    wf = _make_workflow(
+        error_message="CI repair deferred: transient API error - 503 upstream",
+        ci_repair_transient_retries=MAX_CI_REPAIR_TRANSIENT_RETRIES,
+        merge_fail_dev_rounds=0,
+    )
+    orch, mock_repo = _make_orchestrator(wf)
+    orch._emit_ci_repair_terminal_report = MagicMock()
+    orch._get_gh = MagicMock(return_value=_gh())
+
+    orch._start_ci_repair_round(wf, 2400, _FAILED_CHECKS)
+
+    orch._emit_ci_repair_terminal_report.assert_called_once()
+    updates = [c.args[1] for c in mock_repo.update_workflow.call_args_list]
+    assert any(u.get("status") == "failed" for u in updates)
+    assert not any(u.get("status") == "developing" for u in updates)
+
+
+# ── Wiring: tier routing is locked into the source ──
+
+
+def test_escalation_helper_and_constants_are_defined():
+    assert re.search(r"def _escalate_ci_repair_exhaustion\(", ORCH_SRC)
+    assert re.search(r"\bMAX_MERGE_FAIL_DEV_ROUNDS\b\s*=\s*\d", ORCH_SRC)
+    assert re.search(r"_CI_REPAIR_TIER1_CATEGORIES\b", ORCH_SRC)
+
+
+def test_tier1_categories_route_through_escalation_helper():
+    """The 3 Tier1 exhaustion sites call _escalate_ci_repair_exhaustion, not a
+    direct _emit + _update_workflow(failed)."""
+    for cat in TIER1_CATEGORIES:
+        assert f'category="{cat}"' in ORCH_SRC, f"Tier1 category {cat} missing"
+    # 3 call sites + 1 definition.
+    assert ORCH_SRC.count("_escalate_ci_repair_exhaustion(") >= 4
+
+
+def test_tier2_categories_still_report_and_fail_directly():
+    """The 8 Tier2 sites keep PR-A's direct report + failed (no regression)."""
+    for cat in TIER2_CATEGORIES:
+        assert f'category="{cat}"' in ORCH_SRC, f"Tier2 category {cat} missing"
+
+
+def test_retry_resets_merge_fail_dev_rounds():
+    """retry_workflow must zero merge_fail_dev_rounds so a retried workflow gets a
+    fresh Tier1 escalation budget (mirrors PR-B's full counter reset)."""
+    match = re.search(
+        r"retry_updates\s*=\s*\{(?P<body>.*?)\n    _get_repo\(\)\.update_workflow",
+        ROUTE_SRC,
+        re.S,
+    )
+    assert match, "retry_updates block not found in autonomous.py"
+    body = match.group("body")
+    assert re.search(
+        r'"merge_fail_dev_rounds"\s*:\s*0\b', body
+    ), "retry_updates must reset merge_fail_dev_rounds to 0"

--- a/tests/issues/2443/test_terminal_report.py
+++ b/tests/issues/2443/test_terminal_report.py
@@ -61,11 +61,18 @@ def test_helper_defined_and_uses_idempotent_milestone_type():
     assert "ci_repair_terminal_report_posted" not in ORCH_SRC
 
 
-def test_every_ci_repair_terminal_site_emits_a_report():
-    """Each CI-repair terminal ``_update_workflow({status:failed})`` must be
-    preceded by a terminal-report call. 11 terminal sites + 1 definition."""
+def test_every_tier2_terminal_site_emits_a_report():
+    """PR-C routed the 3 Tier1 exhaustion sites (MAX / no-change /
+    unchanged-signature) through ``_escalate_ci_repair_exhaustion`` instead of
+    emitting directly — under the dev-round cap they escalate to development
+    (no report, by design); at the cap / for Tier2 they fall through to a
+    report. So the direct ``_emit_ci_repair_terminal_report`` call sites are now
+    the 8 Tier2 categories + 1 inside the escalation helper's Tier2 branch, plus
+    the definition = 10. Tier1/Tier2 category coverage is locked in
+    test_escalation.py; this guards that the report wiring itself survives."""
     calls = ORCH_SRC.count("_emit_ci_repair_terminal_report(")
-    assert calls >= 12, (
-        f"expected >=11 call sites + 1 definition, found {calls}; a CI-repair "
-        "terminal site is missing its report"
+    assert calls == 10, (
+        f"expected 8 Tier2 direct + 1 escalation fallthrough + 1 def = 10, "
+        f"found {calls}; a CI-repair terminal site may be missing its report"
     )
+    assert "_escalate_ci_repair_exhaustion(" in ORCH_SRC

--- a/tests/issues/822/test_merge_conflict_detection.py
+++ b/tests/issues/822/test_merge_conflict_detection.py
@@ -891,19 +891,25 @@ class TestDoMergeDeferredRetry:
         ]
         assert started_milestones == []
 
-    def test_start_ci_repair_round_fails_when_signature_repeats(self):
-        """A repeated failed-check signature should stop the auto-repair loop.
+    def test_start_ci_repair_round_escalates_when_signature_repeats(self):
+        """A repeated failed-check signature fires the give-up guard (#822).
 
         Uses a real fine-grained fingerprint (name::sha256[:12] of the normalized
-        excerpt) so the give-up guard's signature comparison is meaningful. The
-        excerpt is mocked to be deterministic. Previously this test used the
-        pre-#1811 pipe format ("test (3.9)|failure|fail") which never matched
-        the new name::hash signature, so the guard never fired and the test
-        fell through to _build_ci_repair_context hitting an unmocked MagicMock.
+        excerpt) so the guard's signature comparison is meaningful. The excerpt
+        is mocked to be deterministic.
+
+        #2443 PR-C changed the guard's outcome: a meaningful repeated signature
+        is a Tier1 exhaustion, so under the dev-round cap it escalates to a
+        fresh development round (``developing``) rather than terminal-``failed``;
+        only at the cap does it fall through to ``failed``. Either way the guard
+        fired and the auto-repair loop stopped (no new repair attempt).
         """
         import hashlib
 
-        from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+        from app.modules.workspace.autonomous.orchestrator import (
+            MAX_MERGE_FAIL_DEV_ROUNDS,
+            AutonomousOrchestrator,
+        )
 
         excerpt = "FAILED tests/test_x.py::test_y - AssertionError\n"
         expected_digest = hashlib.sha256(
@@ -911,10 +917,12 @@ class TestDoMergeDeferredRetry:
         ).hexdigest()[:12]
         expected_fingerprint = f"test (3.9)::{expected_digest}"
 
+        # Under cap → Tier1 escalation to development.
         wf = _make_workflow(
             ci_repair_attempts=1,
             last_ci_failure_signature=expected_fingerprint,
             last_ci_failure_head_sha="sha-old",
+            merge_fail_dev_rounds=0,
         )
         o, _ = _make_orchestrator(wf)
         mock_gh = MagicMock()
@@ -928,7 +936,28 @@ class TestDoMergeDeferredRetry:
             [{"name": "test (3.9)", "bucket": "fail", "state": "failure"}],
         )
 
-        failure_update = o._update_workflow.call_args.args[0]
+        escalation_update = o._update_workflow.call_args.args[0]
+        assert escalation_update["status"] == "developing"
+
+        # At the dev-round cap → Tier2 fall-through to terminal failed, with the
+        # "signature still unchanged" reason recorded on the failed update.
+        wf_cap = _make_workflow(
+            ci_repair_attempts=1,
+            last_ci_failure_signature=expected_fingerprint,
+            last_ci_failure_head_sha="sha-old",
+            merge_fail_dev_rounds=MAX_MERGE_FAIL_DEV_ROUNDS,
+        )
+        o2, _ = _make_orchestrator(wf_cap)
+        mock_gh2 = MagicMock()
+        mock_gh2.get_pr_head_sha.return_value = "sha-new"
+        mock_gh2.get_check_failure_excerpt.return_value = excerpt
+        o2._get_gh = MagicMock(return_value=mock_gh2)
+        o2._start_ci_repair_round(
+            wf_cap,
+            1103,
+            [{"name": "test (3.9)", "bucket": "fail", "state": "failure"}],
+        )
+        failure_update = o2._update_workflow.call_args.args[0]
         assert failure_update["status"] == "failed"
         assert "仍未变化" in failure_update["error_message"]
 


### PR DESCRIPTION
## What

A merge-phase PR that **exhausted automatic CI repair** (MAX attempts, no-code-change, or an unchanged meaningful failure signature) silently died in `failed` — even though the PR branch and CI logs were fully recoverable. A fresh development pass (re-derived implementation, aware of the prior CI failure via the preserved `ci_repair_context`) can still succeed.

This is **PR-C, the final part of #2443**. PR-A (#2448) made the Tier2 terminal `failed` visible; PR-B (#2449) reset the full counter set on retry. PR-C stops the recoverable cases from dying in the first place.

## Change

Split the 11 CI-repair exhaustion sites into two tiers via a new `_escalate_ci_repair_exhaustion` helper:

- **Tier1 (recoverable)** — `ci_repair_exhausted` (MAX), `ci_repair_no_change_exhausted`, `ci_repair_signature_unchanged`. While `merge_fail_dev_rounds < MAX_MERGE_FAIL_DEV_ROUNDS` **and** a PR branch exists: rebase the existing branch onto main, reset the full CI-repair counter set (`ci_repair_attempts` / transient / no-change / diagnostics / signature / head-sha), and re-enter **development** on the **same** PR/branch. `ci_repair_context` is deliberately **preserved** so the development prompt's existing `_get_ci_repair_prompt` surfaces the prior CI failure to the new round. At the cap → fall through to Tier2.
- **Tier2 (genuinely stuck)** — transient/diagnostics exhaustion, env mismatch, context overflow, branch drift, push failure, agent failure. **Unchanged from PR-A**: terminal report + absorbing `failed`.

The 3 Tier1 sites previously did a direct `_emit_ci_repair_terminal_report` + `_update_workflow(failed)`; they now call `_escalate_ci_repair_exhaustion`. The 8 Tier2 sites keep PR-A's behavior (no regression).

`retry_workflow` now also resets `merge_fail_dev_rounds` (PR-B reset the other 6 counters).

New column `merge_fail_dev_rounds integer DEFAULT 0` (alembic migration `20260809_001` + regenerated schema snapshots).

## Why tiered

A blanket "escalate everything" would loop forever on a genuinely-broken PR (bad test, env mismatch). Tier1 categories are exactly those where the failure is actionable and the branch is recoverable; Tier2 categories are where a fresh dev round cannot help (infra outage, overflow, lost branch). `MAX_MERGE_FAIL_DEV_ROUNDS = 3` bounds Tier1 so a non-converging workflow eventually terminal-fails with a visible report.

## Tests

New `tests/issues/2443/test_escalation.py` (9 tests): behavioral (MAX→dev under cap, cap→Tier2, signature→dev, no-branch→Tier2, transient→Tier2) + wiring (helper/constants defined, Tier1 sites route through escalation, Tier2 sites unchanged, retry resets the new counter). Updated `#1855` and `#822` signature-repeat tests for the new Tier1 behavior (under cap → developing; at cap → failed).

Closes #2443.

🤖 Generated with [Claude Code](https://claude.com/claude-code)