### PR TITLE
fix(agent-runner): read Claude history from the per-task HOME (#2439)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,7 @@ jobs:
       - name: Issue regression suites (opt-in; see norecursedirs)
         timeout-minutes: 5
         run: |
-          pytest tests/issues/2335 tests/issues/2403 tests/issues/2428 tests/issues/2431 tests/issues/2438 tests/issues/2442 tests/issues/2443 -v \
+          pytest tests/issues/2335 tests/issues/2403 tests/issues/2428 tests/issues/2431 tests/issues/2438 tests/issues/2439 tests/issues/2442 tests/issues/2443 -v \
             -m "not postgres and not performance"
 
       - name: Upload coverage to Codecov

--- a/app/modules/workspace/autonomous/agent_runner.py
+++ b/app/modules/workspace/autonomous/agent_runner.py
@@ -39,6 +39,7 @@ from app.modules.workspace.autonomous.sandbox.types import SandboxSpec
 from app.modules.workspace.autonomous.task_isolation import (
     DEFAULT_TASK_ROOT,
     ensure_task_runtime_dirs,
+    task_runtime_dirs,
 )
 
 if TYPE_CHECKING:  # pragma: no cover - annotations only (PEP 563)
@@ -239,6 +240,10 @@ class _LocalSession:
     # Milestone this task belongs to — tags session_messages for per-phase detail views.
     milestone_id: str = ""
     system_account: str | None = None
+    # #2439: the per-attempt task_id whose HOME the CLI writes its session JSONL
+    # under. Drives per-task Claude-history resolution (_claude_projects_root);
+    # empty for legacy callers (fall back to the system account's passwd home).
+    task_id: str = ""
     # Distinct assistant message_ids counted toward request_count (dedup, since
     # claude emits multiple assistant events per message: thinking then text).
     _counted_message_ids: set = field(default_factory=set)
@@ -1025,8 +1030,19 @@ class AutonomousAgentRunner:
         return ""
 
     @staticmethod
-    def _resolve_home_dir(system_account: str | None) -> Path:
-        """Resolve the target user's home dir for Claude history lookups."""
+    def _resolve_home_dir(system_account: str | None, task_id: str | None = None) -> Path:
+        """Resolve the HOME whose .claude/projects the CLI writes session JSONL to.
+
+        With a per-attempt ``task_id`` (#2020 isolation), the CLI runs under the
+        per-task HOME (``/run/openace-agent-tasks/<task_id>/home``, set in
+        ``_build_env`` + the cross-user launcher), so its history lives there —
+        NOT under the system account's passwd home. Resolving the passwd home
+        here (#2439) returned the wrong directory, making the mtime session
+        fallback and the timeout usage replay silently miss. Fall back to the
+        passwd/system home only for legacy callers without a task_id.
+        """
+        if task_id:
+            return Path(task_runtime_dirs(task_id)["home"])
         if system_account:
             try:
                 pw_entry = pwd.getpwnam(system_account)
@@ -1037,9 +1053,9 @@ class AutonomousAgentRunner:
         return Path.home()
 
     @classmethod
-    def _claude_projects_root(cls, system_account: str | None) -> Path:
+    def _claude_projects_root(cls, system_account: str | None, task_id: str | None = None) -> Path:
         """Return the ~/.claude/projects root for the workflow owner."""
-        return cls._resolve_home_dir(system_account) / ".claude" / "projects"
+        return cls._resolve_home_dir(system_account, task_id) / ".claude" / "projects"
 
     @staticmethod
     def _read_text_as_user(path: Path, system_account: str | None) -> str:
@@ -1596,6 +1612,7 @@ class AutonomousAgentRunner:
         min_mtime_epoch: float,
         bound_cli_session_ids: set[str] | None = None,
         system_account: str | None = None,
+        task_id: str | None = None,
     ) -> str:
         """Find the latest Claude JSONL session created for the active worktree.
 
@@ -1612,7 +1629,7 @@ class AutonomousAgentRunner:
         if not encoded_project_path:
             return ""
 
-        project_dir = self._claude_projects_root(system_account) / encoded_project_path
+        project_dir = self._claude_projects_root(system_account, task_id) / encoded_project_path
         candidates = self._list_jsonl_files(project_dir, system_account)
         if not candidates:
             return ""
@@ -1691,7 +1708,7 @@ class AutonomousAgentRunner:
         if not cli_session_id or not session.encoded_project_path:
             return
         jsonl_path = (
-            self._claude_projects_root(session.system_account)
+            self._claude_projects_root(session.system_account, session.task_id)
             / session.encoded_project_path
             / f"{cli_session_id}.jsonl"
         )
@@ -1784,6 +1801,7 @@ class AutonomousAgentRunner:
                 session.started_at_epoch,
                 bound_cli_session_ids=bound_ids,
                 system_account=session.system_account,
+                task_id=session.task_id,
             )
             logger.warning(
                 "Using mtime fallback to resolve session (control_response missed) — "
@@ -2416,6 +2434,7 @@ class AutonomousAgentRunner:
             started_at_epoch=time.time(),
             milestone_id=milestone_id,
             system_account=system_account,
+            task_id=session_id,
             sandbox_handle=sandbox_handle,
             exec_handle=exec_handle,
             sandbox_provider=self._sandbox_provider,
@@ -2762,6 +2781,7 @@ class AutonomousAgentRunner:
             workspace_type=workspace_type,
             started_at_epoch=time.time(),
             milestone_id=milestone_id,
+            task_id=session_id,
         )
 
         collector = _ZcodeResultCollector(
@@ -3450,6 +3470,7 @@ class AutonomousAgentRunner:
             tracker = _LocalSession(
                 session_id=session_id,
                 process=None,  # type: ignore[arg-type]
+                task_id=session_id,
             )
             self._local_sessions[session_id] = tracker
 

--- a/tests/issues/2439/test_agent_runner_home.py
+++ b/tests/issues/2439/test_agent_runner_home.py
@@ -1,0 +1,101 @@
+"""Issue #2439: AgentRunner must read Claude history from the per-task HOME.
+
+The CLI runs under a per-attempt HOME (``/run/openace-agent-tasks/<task_id>/home``,
+set in ``_build_env`` + the cross-user launcher — #2020 isolation), so its
+session JSONL lives at ``<per-task home>/.claude/projects/...``. But
+``_resolve_home_dir`` / ``_claude_projects_root`` resolved the SYSTEM account's
+passwd home, so:
+
+- ``_find_latest_claude_session_id`` (the mtime fallback when the SDK
+  control_response is missed) scanned the wrong dir → empty/stale session id →
+  wrong ``--resume`` target;
+- ``_replay_usage_from_jsonl`` (the timeout path) read the wrong dir → silent
+  OSError → usage stays 0/0 (#723-style zero-cost round).
+
+Fix: thread ``task_id`` to the per-task home; fall back to the system home only
+for legacy callers without a task_id.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from app.modules.workspace.autonomous.agent_runner import AutonomousAgentRunner, _LocalSession
+from app.modules.workspace.autonomous.task_isolation import DEFAULT_TASK_ROOT, task_runtime_dirs
+
+
+def test_resolve_home_dir_uses_per_task_home_when_task_id_set():
+    home = AutonomousAgentRunner._resolve_home_dir("openace", task_id="wf-2439")
+    assert home == Path(task_runtime_dirs("wf-2439")["home"])
+    assert str(home).startswith(DEFAULT_TASK_ROOT)
+
+
+def test_task_id_takes_precedence_over_system_account():
+    # Even with a system_account, a task_id resolves to the per-task HOME (where
+    # the CLI actually writes), not the passwd home.
+    home = AutonomousAgentRunner._resolve_home_dir("root", task_id="abc-123")
+    assert home == Path(task_runtime_dirs("abc-123")["home"])
+
+
+def test_resolve_home_dir_falls_back_without_task_id():
+    assert AutonomousAgentRunner._resolve_home_dir(None) == Path.home()
+
+
+def test_claude_projects_root_uses_per_task_home():
+    root = AutonomousAgentRunner._claude_projects_root("openace", task_id="wf-2439")
+    assert root == Path(task_runtime_dirs("wf-2439")["home"]) / ".claude" / "projects"
+
+
+def test_claude_projects_root_falls_back_without_task_id():
+    expected = Path.home() / ".claude" / "projects"
+    assert AutonomousAgentRunner._claude_projects_root(None) == expected
+
+
+def test_local_session_carries_task_id_default_empty():
+    assert _LocalSession(session_id="s1", process=None).task_id == ""
+    assert _LocalSession(session_id="s2", process=None, task_id="wf-9").task_id == "wf-9"
+
+
+def test_find_latest_session_reads_per_task_projects_root():
+    """The mtime fallback must scan the per-task projects root, not the system home."""
+    runner = AutonomousAgentRunner.__new__(AutonomousAgentRunner)
+    captured = {}
+
+    def fake_list(project_dir, system_account):
+        captured["dir"] = project_dir
+        return []
+
+    runner._list_jsonl_files = MagicMock(side_effect=fake_list)
+    runner._find_latest_claude_session_id(
+        "encoded-proj", 0.0, system_account="openace", task_id="wf-2439"
+    )
+    assert captured["dir"] == (
+        Path(task_runtime_dirs("wf-2439")["home"]) / ".claude" / "projects" / "encoded-proj"
+    )
+
+
+def test_replay_usage_reads_per_task_projects_root():
+    """The timeout usage-replay must read the per-task JSONL path."""
+    runner = AutonomousAgentRunner.__new__(AutonomousAgentRunner)
+    captured = {}
+
+    def fake_read(path, system_account):
+        captured["path"] = path
+        raise OSError("stop")  # _replay swallows OSError → returns
+
+    runner._read_text_as_user = MagicMock(side_effect=fake_read)
+    session = _LocalSession(
+        session_id="s1",
+        process=None,
+        system_account="openace",
+        encoded_project_path="encoded-proj",
+        started_at_epoch=0.0,
+        task_id="wf-2439",
+    )
+    runner._replay_usage_from_jsonl(session, "cli-sid")
+    assert captured["path"] == (
+        Path(task_runtime_dirs("wf-2439")["home"])
+        / ".claude"
+        / "projects"
+        / "encoded-proj"
+        / "cli-sid.jsonl"
+    )


### PR DESCRIPTION
## What

`AgentRunner` resolved Claude session history from the **system account's passwd home**, but the CLI actually runs under a **per-attempt HOME** (`/run/openace-agent-tasks/<task_id>/home`, set in `_build_env` + the cross-user launcher — #2020 isolation). So its session JSONL lives at `<per-task home>/.claude/projects/`, and the two filesystem fallback paths read the wrong directory:

- `_find_latest_claude_session_id` (mtime fallback when the SDK `control_response` is missed) → scanned the wrong dir → empty/stale session id → wrong `--resume` target;
- `_replay_usage_from_jsonl` (timeout path, `total_tokens==0`) → read the wrong dir → silent `OSError` → usage stayed `0/0` (#723-style zero-cost round).

## Change

Thread `task_id` to `_resolve_home_dir` / `_claude_projects_root` so both resolve the **per-task HOME** (the CLI's actual write location) when a `task_id` is set; fall back to the passwd/system home only for legacy callers without one. The two affected callers read `session.task_id`; `_LocalSession` carries `task_id` (set to the run's task_id at all three tracker-creation sites — `_run_local`/`_run_zcode_appserver`/`_run_remote`, where `task_id=session_id` was already used for isolation). Cross-user reads still go through the existing `_read_text_as_user` / `_list_jsonl_files`.

The authoritative `cli_session_id` capture path (SDK stream) is **unchanged** — this fixes the two filesystem fallback paths only. `OPENACE_GIT_CACHE_ROOT` (which correctly uses the persistent system home) is untouched (it calls `_resolve_home_dir` without `task_id`).

## Tests

New `tests/issues/2439/test_agent_runner_home.py` (8 tests): per-task vs fallback resolution, `_LocalSession.task_id`, and that both fallback paths read the per-task projects root. Added `tests/issues/2439` to the opt-in CI issue suite (issue tests are excluded from the default `test(3.x)` job by `norecursedirs`). Backward-compatible: callers without `task_id` get the legacy system-home behavior.

Closes #2439.

🤖 Generated with [Claude Code](https://claude.com/claude-code)