### PR TITLE
fix(autonomous): pause (not fail) when pr_review auto-stage is blocked (#2441)

### DIFF
--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -10000,6 +10000,25 @@ class AutonomousOrchestrator:
             self._update_workflow({"status": "failed", "error_message": message})
             return False
 
+        def pause_fix(message: str) -> bool:
+            """Pause (not fail) when auto-staging pre-existing changes is blocked.
+
+            A dirty-worktree auto-stage failure is recoverable — most often a
+            cross-user object-DB permission error (the service user owns
+            .git/objects while the fix agent runs as system_account, so the write
+            is denied) that the operator can fix. Terminal ``failed`` stranded the
+            workflow: ``paused`` is reachable via POST /resume (after the operator
+            fixes the tree/perms), preserves the worktree for diagnosis, and aligns
+            pr_review with the dev/CI-repair paths, which warn-and-continue rather
+            than hard-failing on staging (#2441).
+            """
+            self.repo.update_milestone(
+                fix_ms.get("milestone_id", ""),
+                {"status": "failed", "error_message": message},
+            )
+            self._update_workflow({"status": "paused", "error_message": message})
+            return False
+
         fix_prompt = (
             AUTONOMOUS_CONTEXT
             + f"根据以下代码审查意见修改代码：\n\n{self._clean_agent_text(review_text)}\n\n"
@@ -10089,7 +10108,7 @@ class AutonomousOrchestrator:
                         gh.reset_hard_to(commit_before_staging)
                     except Exception:
                         pass
-                return fail_fix(
+                return pause_fix(
                     f"Worktree was dirty and auto-staging pre-existing changes failed: {exc}"
                 )
 

--- a/tests/unit/test_autonomous_ci_guardrails.py
+++ b/tests/unit/test_autonomous_ci_guardrails.py
@@ -2314,3 +2314,57 @@ def test_review_fix_rejects_dirty_worktree_when_pre_existing_changes_out_of_scop
         if isinstance(updates, dict) and updates.get("status") == "failed":
             failed_updates.append(updates)
     assert any("scope validation" in u.get("error_message", "") for u in failed_updates)
+
+
+def test_review_fix_stage_failure_marks_paused_not_failed():
+    """#2441: when auto-staging pre-existing dirty changes fails (e.g. a cross-user
+    object-DB permission error — the service user owns .git/objects while the fix
+    agent runs as system_account, so the write is denied), the workflow must PAUSE
+    (resumable via POST /resume, worktree preserved) rather than terminal-fail.
+    This aligns pr_review with the dev/CI-repair paths, which warn-and-continue
+    instead of hard-failing on staging. The fix agent must NOT run, and the tree is
+    reset to the pre-staging commit so no half-staged state is left behind."""
+    from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+    orch = AutonomousOrchestrator.__new__(AutonomousOrchestrator)
+    orch._workflow_id = "wf-stage-fail"
+    orch.repo = MagicMock()
+    orch.emitter = MagicMock()
+    orch._create_milestone = MagicMock(return_value={"milestone_id": "ms-fix"})
+    orch._accumulate_tokens = MagicMock()
+    orch._validate_autonomous_change_scope = MagicMock(return_value="")
+    orch._clean_agent_text = MagicMock(return_value="review feedback")
+    orch._run_agent_with_context_recovery = MagicMock()
+
+    gh = MagicMock()
+    gh.has_uncommitted_changes.return_value = True  # dirty → triggers auto-stage
+    gh.get_current_commit.return_value = "commit-pre-staging"
+    # Auto-stage itself fails (the cross-user object-DB write is denied).
+    gh.git_add_all = MagicMock(
+        side_effect=Exception("fatal: could not write .git/objects/ab/cdef123: permission denied")
+    )
+    gh.reset_hard_to = MagicMock()
+
+    wf = {
+        "workflow_id": "wf-stage-fail",
+        "worktree_path": "/tmp/repo",
+        "project_path": "/tmp/repo",
+        "cli_tool": "claude-code",
+        "dev_round": 1,
+        "branch_name": "auto-dev/wf-stage-fail",
+    }
+
+    result = orch._apply_pr_review_fix(wf, gh, 1, 1, "looks good", [], 1234)
+
+    # Stage failed → workflow paused (not failed); fix agent never ran.
+    assert result is False
+    orch._run_agent_with_context_recovery.assert_not_called()
+    statuses = []
+    for call in orch.repo.update_workflow.call_args_list:
+        updates = call.args[1] if len(call.args) > 1 else call.args[0]
+        if isinstance(updates, dict):
+            statuses.append(updates.get("status"))
+    assert "paused" in statuses, "stage failure must pause (resumable), not terminal-fail"
+    assert "failed" not in statuses, "stage failure must NOT hard-fail (#2441)"
+    # Tree reset to the pre-staging commit (no half-staged state left behind).
+    gh.reset_hard_to.assert_called_once_with("commit-pre-staging")


### PR DESCRIPTION
## What

`_apply_pr_review_fix` auto-stages pre-existing dirty changes so the fix agent starts from a clean tree. Cross-user, that git write hits the object DB (`.git/objects`, owned by the service user) while the fix agent runs as `system_account` — the write is denied. **pr_review was the only auto-commit path that hard-failed** (`status=failed`) instead of warning/deferring, stranding the workflow (`failed` isn't `/resume`-reachable; `/retry` restarts from scratch).

## Change

Route that staging failure to a new `pause_fix` → `status=paused` (mirrors `fail_fix` but paused). `paused` is reachable via `POST /resume` (after the operator fixes the tree/perms), preserves the worktree for diagnosis, and aligns pr_review with the dev/CI-repair paths (which warn-and-continue). The fix agent is not run; the tree is reset to the pre-staging commit (no half-staged state).

## Scope note

This fixes the **permanent-failed dead-end** (the reported symptom). The deeper root cause — cross-user object-DB writability (service user vs `system_account` share **no group**, so `chmod -R g+w` is a silent no-op, verified in the install scripts' bare `useradd -m`) — needs a shared-group / `git --shared=group` install-time fix and is **tracked as a follow-up** (the auto-stage still won't *succeed* cross-user after this PR; it just fails gracefully + resumably instead of terminal-failing). An independent review of the original plan flagged the chmod approach as broken; this is the revised minimal-scope fix.

## Test

`test_review_fix_stage_failure_marks_paused_not_failed` in `tests/unit/test_autonomous_ci_guardrails.py` (CI-gated): `git_add_all` raises → `paused` (not `failed`), fix agent not called, tree reset. Existing dirty-guard tests unchanged (no regression).

Closes #2441.

🤖 Generated with [Claude Code](https://claude.com/claude-code)