### PR TITLE
fix(scripts): shard the per-task agent flock onto a fixed lock set (#2437)

### DIFF
--- a/scripts/openace-run-as.sh
+++ b/scripts/openace-run-as.sh
@@ -294,25 +294,47 @@ if [ "$isolated" = true ]; then
                 ;;
         esac
     done
+    # #2437: shard the per-task mutex onto a FIXED lock-file set so /run/lock
+    # can't accumulate one openace-agent-task-<task_id>.lock per attempt
+    # (unbounded under task churn). The shard is a deterministic function of
+    # task_id (cksum mod N); cksum is POSIX (present on Linux AND macOS) and the
+    # shard is computed only here in the launcher (acquire + reaper) -- never in
+    # Python -- so there is no cross-language twin to keep in sync. Shard files
+    # are NEVER unlinked: the stable inode is what makes flock mutually exclusive
+    # forever (unlink + same-name re-open yields a different inode, letting a
+    # second opener grab a second lock). /run/lock clears on reboot, so the set
+    # is recreated lazily and stays bounded at N.
+    _TASK_LOCK_SHARDS=64
+    _task_lock_shard() {
+        # cksum prints "<crc> <length>"; take the crc (field 1) mod N.
+        _cs="$(printf '%s' "$1" | cksum)"
+        _crc="${_cs%% *}"
+        : $(( _shard = _crc % _TASK_LOCK_SHARDS ))
+        echo "$_shard"
+    }
     # Issue #2020: key the lock + registries off the attempt (task_id) when
     # present, so concurrent attempts on the same UID neither serialize on a
     # UID-level flock nor overwrite each other's ACL/signature registry. The
     # uid-* fallback preserves legacy single-attempt semantics for callers
     # that do not pass --task-id.
-    if [ -n "$task_id" ]; then
-        isolation_key="task-${task_id}"
-    else
-        isolation_key="uid-${target_uid}"
-    fi
-    acl_registry="/run/openace-agent-acl-${isolation_key}"
-    signature_registry="/run/openace-agent-git-signature-${isolation_key}"
-    signature_tmp="${signature_registry}.next"
     # Single source for the lock directory so the #2403 preserve reaper derives
     # peer lock paths exactly the way this run derives its own. Deliberately a
     # constant, not an environment override: redirecting it would silently break
     # mutual exclusion between concurrent attempts.
     _lock_dir="/run/lock"
-    exec 9>"${_lock_dir}/openace-agent-${isolation_key}.lock"
+    if [ -n "$task_id" ]; then
+        isolation_key="task-${task_id}"
+        # Only the mutex is sharded (#2437); the acl/signature registries stay
+        # 1:1 with the attempt (per-attempt data, must not collide).
+        _task_lock="${_lock_dir}/openace-agent-task-shard-$(_task_lock_shard "$task_id").lock"
+    else
+        isolation_key="uid-${target_uid}"
+        _task_lock="${_lock_dir}/openace-agent-${isolation_key}.lock"
+    fi
+    acl_registry="/run/openace-agent-acl-${isolation_key}"
+    signature_registry="/run/openace-agent-git-signature-${isolation_key}"
+    signature_tmp="${signature_registry}.next"
+    exec 9>"$_task_lock"
     flock -x 9
 
     # Per-attempt HOME/TMP/XDG runtime tree (#2020). Ephemeral parent under
@@ -418,13 +440,22 @@ if [ "$isolated" = true ]; then
                       -print -quit 2>/dev/null)" || continue
             [ -z "$_fresh" ] || continue
             _pid="${_pdir##*/}"; _pid="${_pid%.claude-preserve}"
-            _plock="${_lock_dir}/openace-agent-task-${_pid}.lock"
+            # #2437: the per-task lock is now a fixed shard (see the acquire
+            # block), so derive the SAME shard from this preserve dir's task_id
+            # and probe it. flock -n on the shard: acquire => no task on that
+            # shard is running => this task_id is not running => safe to reap;
+            # blocked => some task on the shard is live => skip (conservative --
+            # the dead preserve is reaped later when the shard frees). The reaper
+            # runs only in this launcher (cross-user/prod path); the same-user
+            # Python launch path takes no lock and invokes no reaper, so a
+            # lockless dev run can't be wrongly reaped here.
+            _plock="${_lock_dir}/openace-agent-task-shard-$(_task_lock_shard "$_pid").lock"
             # `8<` — read only, NO O_CREAT. flock(2) does not require write
-            # access, and this must never manufacture a lock file: lock files
-            # cannot be reclaimed safely (unlink then same-name open yields a
-            # different inode, so two holders stop excluding each other). A live
-            # run creates its lock before touching anything, so an absent lock
-            # file means no live run.
+            # access, and this must never manufacture a lock file: shard files
+            # are never unlinked (the stable inode is what keeps flock mutually
+            # exclusive), so creating extras would only ever add dead weight. A
+            # live run creates its shard on first acquire, so an absent shard
+            # file means no task has ever run on it => no live run.
             if [ ! -e "$_plock" ]; then
                 rm -rf -- "$_pdir" 2>/dev/null || true
                 continue

--- a/tests/issues/2403/test_reclaim_wiring.py
+++ b/tests/issues/2403/test_reclaim_wiring.py
@@ -321,3 +321,47 @@ def test_signal_traps_are_re_registered_outside_the_task_id_block():
         assert any(
             i > early for i in occurrences
         ), f"the only {signal_name} trap is inside the task_id block"
+
+
+# ── #2437: the per-task mutex is sharded, not one-file-per-task_id ────────
+
+
+def test_task_lock_is_sharded_not_one_file_per_task_id():
+    """#2437: the per-task mutex is sharded onto a FIXED lock-file set so /run/lock
+    can't accumulate one ``openace-agent-task-<task_id>.lock`` per attempt."""
+    assert re.search(r"_TASK_LOCK_SHARDS=\d+", SRC), "_TASK_LOCK_SHARDS not defined"
+    assert "_task_lock_shard() {" in SRC, "_task_lock_shard() undefined"
+    # the task_id branch acquires the shard file ...
+    assert 'openace-agent-task-shard-$(_task_lock_shard "$task_id").lock' in SRC
+    # ... via the _task_lock variable; the old direct per-task-id acquire is gone.
+    assert 'exec 9>"$_task_lock"' in SRC
+    assert (
+        'exec 9>"${_lock_dir}/openace-agent-${isolation_key}.lock"' not in SRC
+    ), "the old unbounded per-task-id lock acquire survives"
+
+
+def test_reaper_probes_the_shard_not_a_per_task_lock():
+    """The reaper derives the SAME shard from a preserve dir's task_id and probes
+    it; the old ``openace-agent-task-${_pid}.lock`` derivation must be gone (it
+    would point at a lock file that no longer exists under sharding)."""
+    assert 'openace-agent-task-shard-$(_task_lock_shard "$_pid").lock' in SRC
+    assert (
+        "openace-agent-task-${_pid}.lock" not in SRC
+    ), "the old per-task reaper lock derivation survives"
+
+
+def test_shard_files_are_never_unlinked():
+    """The stable inode is what makes flock mutually exclusive forever. Unlinking a
+    shard would let a second opener create a new inode under the same name and grab
+    a second lock. No rm/unlink may target the shard files."""
+    assert not re.search(
+        r"(^|\s)(rm|unlink)\b[^#]*openace-agent-task-shard", SRC
+    ), "a shard lock file is targeted by rm/unlink, breaking the no-double-lock invariant"
+
+
+def test_only_the_lock_is_sharded_registries_stay_per_attempt():
+    """The acl/signature registries are per-attempt data; only the mutex is sharded.
+    Collisions on the registries would corrupt them, so they must stay 1:1 with the
+    attempt (isolation_key)."""
+    assert 'acl_registry="/run/openace-agent-acl-${isolation_key}"' in SRC
+    assert 'signature_registry="/run/openace-agent-git-signature-${isolation_key}"' in SRC

--- a/tests/issues/2403/test_task_tree_reclaim.py
+++ b/tests/issues/2403/test_task_tree_reclaim.py
@@ -255,12 +255,29 @@ echo "rc=$?"
 
 def _reap_harness(task_root: Path, lock_dir: Path, days: object = 30) -> str:
     return f"""
+{_extract_function("_task_lock_shard")}
+_TASK_LOCK_SHARDS=64
 {_extract_function("reap_stale_preserve_dirs")}
 task_root={task_root!s}
 preserve_max_age_days={days}
 _lock_dir={lock_dir!s}
 reap_stale_preserve_dirs
 """
+
+
+def _shard_lock_name(task_id: str) -> str:
+    """The shard lock file NAME the reaper probes for task_id (#2437).
+
+    Runs the script's own ``_task_lock_shard`` (cksum-based) so the test always
+    agrees with the reaper, whatever the exact hash function. task_id is passed
+    as $1 to avoid any shell-quoting pitfall.
+    """
+    snippet = (
+        _extract_function("_task_lock_shard") + "\n_TASK_LOCK_SHARDS=64\n" + '_task_lock_shard "$1"'
+    )
+    result = subprocess.run(["bash", "-c", snippet, "_", task_id], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+    return f"openace-agent-task-shard-{result.stdout.strip()}.lock"
 
 
 def _age(path: Path, days: int) -> None:
@@ -410,8 +427,8 @@ class TestReapStalePreserveDirs:
         (stale / "s.jsonl").write_text("{}", encoding="utf-8")
         _age(stale / "s.jsonl", 90)
         _age(stale, 90)
-        # Present but unheld: the task finished and released it.
-        (lock_dir / "openace-agent-task-done.lock").touch()
+        # Present but unheld: the task finished and released its shard lock.
+        (lock_dir / _shard_lock_name("done")).touch()
 
         result = _run_snippet(_reap_harness(task_root, lock_dir), env={"PATH": flock_path})
         assert result.returncode == 0, result.stderr
@@ -436,7 +453,7 @@ class TestReapStalePreserveDirs:
         (busy / "s.jsonl").write_text("{}", encoding="utf-8")
         _age(busy / "s.jsonl", 90)
         _age(busy, 90)
-        lock_file = lock_dir / "openace-agent-task-live.lock"
+        lock_file = lock_dir / _shard_lock_name("live")
         lock_file.touch()
 
         # Hold the lock for the duration of the sweep, exactly as a live run would.
@@ -579,3 +596,32 @@ class TestAgeThresholdUnits:
             f"20-day-old history reaped under the script default of {default_days} "
             f"days; lowering that default silently shortens --resume's memory"
         )
+
+
+class TestTaskLockShard:
+    """#2437: the per-task mutex is sharded onto a FIXED lock-file set (N files),
+    chosen by a deterministic function of task_id. Exercises the real bash
+    _task_lock_shard so the determinism + bound are verified, not assumed."""
+
+    _SNIPPET = _extract_function("_task_lock_shard") + "\n_TASK_LOCK_SHARDS=64\n"
+
+    @staticmethod
+    def _shard(task_id: str) -> int:
+        result = subprocess.run(
+            ["bash", "-c", TestTaskLockShard._SNIPPET + '_task_lock_shard "$1"', "_", task_id],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stderr
+        return int(result.stdout.strip())
+
+    def test_shard_is_deterministic(self):
+        for tid in ("abc", "auto-dev/xyz", "wf-2437", "t", ""):
+            assert self._shard(tid) == self._shard(tid), f"non-deterministic shard for {tid!r}"
+
+    def test_shard_set_is_bounded_by_n(self):
+        shards = {self._shard(f"task-{i}") for i in range(200)}
+        assert all(0 <= s < 64 for s in shards), "a shard fell outside [0, 64)"
+        # 200 distinct task_ids map onto AT MOST 64 shards (the fixed set) — this
+        # is the bound that keeps /run/lock from accumulating one file per attempt.
+        assert len(shards) <= 64


### PR DESCRIPTION
## What

Each autonomous agent task left one `/run/lock/openace-agent-task-<task_id>.lock` behind, unbounded under task churn (#2403 reaps task dirs + `.claude-preserve` but never the lock — you can't safely `unlink` a held/possibly-waited lock, since a second opener could then create a new inode under the same name and grab a second lock).

## Change

**Shard the mutex onto a fixed set of N=64 lock files** chosen by a deterministic function of `task_id` (`cksum` mod N):
- `cksum` is POSIX (present on Linux AND macOS) and the shard is computed **only in the launcher** (acquire + reaper), never in Python → no cross-language twin to keep in sync.
- Shard files are **never unlinked** → the stable inode is what keeps `flock` mutually exclusive forever; `/run/lock` clears on reboot, so the set stays bounded at N.
- The acl/signature registries stay 1:1 with the attempt (per-attempt data); **only the mutex is sharded**.

**Reaper change** (forced — the old lock-liveness probe keyed the lock off the preserve dir's `task_id` 1:1, impossible against a many-to-one shard): the reaper derives the SAME shard from the preserve dir's `task_id` and `flock -n`'s it. Acquire ⇒ no task on that shard is running ⇒ this `task_id` is dead ⇒ reap (subject to the age gate); blocked ⇒ a task on that shard is live ⇒ skip (conservative; reaped later when the shard frees).

This liveness is sound for the path the reaper runs in: the **bash launcher / cross-user prod path**, where every task takes its shard lock. The same-user Python launch path takes no lock **and** invokes no reaper, so a lockless dev run can't be wrongly reaped (independent design review flagged the original "drop the probe" plan as unsafe for exactly this reason; the shard-`flock -n` probe resolves it).

## Tests

`tests/issues/2403/` (opt-in CI): 4 new wiring tests (shard func defined, acquire+reaper use the shard, shard files never unlinked, registries stay per-attempt) + 2 new behavioral tests (`_task_lock_shard` determinism + ≤N bound over 200 task_ids). Updated the existing held/unheld reaper tests to use the shard file. All 47 pass.

Closes #2437.

🤖 Generated with [Claude Code](https://claude.com/claude-code)