### PR TITLE
fix(autonomous): close test-evidence gate contract gaps + scope verdict to milestone (#2401, #2390)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,7 @@ jobs:
       - name: Issue regression suites (opt-in; see norecursedirs)
         timeout-minutes: 5
         run: |
-          pytest tests/issues/2335 tests/issues/2403 tests/issues/2428 tests/issues/2431 tests/issues/2438 tests/issues/2439 tests/issues/2442 tests/issues/2443 -v \
+          pytest tests/issues/2335 tests/issues/2390 tests/issues/2401 tests/issues/2403 tests/issues/2428 tests/issues/2431 tests/issues/2438 tests/issues/2439 tests/issues/2442 tests/issues/2443 -v \
             -m "not postgres and not performance"
 
       - name: Upload coverage to Codecov

--- a/app/modules/workspace/autonomous/command_evidence/recorder.py
+++ b/app/modules/workspace/autonomous/command_evidence/recorder.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import logging
 import queue as queue_module
+import shlex
 import threading
 from collections.abc import Callable
 from datetime import datetime, timezone
@@ -293,7 +294,10 @@ class CommandEvidenceRecorder:
                         # it. Without this an argv-only test run was invisible to the
                         # verdict → mis-judged NOT_RUN (#2401 c).
                         if not (isinstance(shell_command, str) and shell_command) and argv:
-                            shell_command = " ".join(argv)
+                            # shlex.join (not " ".join) so an arg containing spaces
+                            # re-quotes faithfully and _shell_tokens (shlex.split)
+                            # round-trips it back to the same tokens.
+                            shell_command = shlex.join(argv)
                     self.record_tool_use(
                         command_id=command_id,
                         session_id=session_id,

--- a/app/modules/workspace/autonomous/command_evidence/recorder.py
+++ b/app/modules/workspace/autonomous/command_evidence/recorder.py
@@ -279,8 +279,21 @@ class CommandEvidenceRecorder:
                         order.append(command_id)
                     tool_input = event.get("tool_input") or {}
                     shell_command = None
+                    argv = None
                     if isinstance(tool_input, dict):
                         shell_command = tool_input.get("command") or tool_input.get("cmd")
+                        raw_argv = tool_input.get("argv") or tool_input.get("args")
+                        if isinstance(raw_argv, list):
+                            argv = [str(part) for part in raw_argv]
+                        elif isinstance(raw_argv, str) and raw_argv.strip():
+                            argv = [raw_argv]
+                        # Argv-only providers carry no joined command; synthesize
+                        # one so BOTH recognition (_has_test_tool_call) AND parsing
+                        # (_resolve_framework / _parse_* read shell_command) can see
+                        # it. Without this an argv-only test run was invisible to the
+                        # verdict → mis-judged NOT_RUN (#2401 c).
+                        if not (isinstance(shell_command, str) and shell_command) and argv:
+                            shell_command = " ".join(argv)
                     self.record_tool_use(
                         command_id=command_id,
                         session_id=session_id,
@@ -288,6 +301,7 @@ class CommandEvidenceRecorder:
                         milestone_id=milestone_id,
                         tool_name=event.get("tool_name") or "",
                         shell_command=shell_command if isinstance(shell_command, str) else None,
+                        argv=argv,
                         sandbox_id=sandbox_id,
                         sandbox_generation=sandbox_generation,
                     )

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -1176,6 +1176,84 @@ def _is_test_path_execution(command: str) -> bool:
     return False
 
 
+# Tool names that ARE a shell, compared case-insensitively (#2401 b). One
+# canonical set so a new sandbox provider's shell tool name is added in exactly
+# one place; ``test_tool_name_contract`` pins that every provider-declared shell
+# tool name is a member. The old whitelist was closed + case-sensitive, so a
+# tool-name drift (``bash``/``terminal``/``execute_bash``/...) voided the gate
+# for any command — the same "ran the right tests, judged as not run" failure as
+# the original #2376 incident, but invisible because it is command-independent.
+_SHELL_TOOL_NAMES = frozenset(
+    {
+        "bash",
+        "sh",
+        "shell",
+        "zsh",
+        "run_shell_command",
+        "exec_command",
+        "execute_bash",
+        "local_shell",
+        "container.exec",
+        "terminal",
+        "run_terminal_cmd",
+    }
+)
+
+# Dedicated test-runner tool names (#2401 a). NOT fail-open: the tool name is
+# treated as ``argv[0]`` and run through the SAME recognition as a shell command,
+# so ``pytest`` (a runner token) is recognized while ``test``/``run_tests`` pass
+# only when the command carries a real runner. Before this, the name alone
+# returned True, so a tool literally named ``test`` running ``helm install`` (or
+# nothing) reached the authoritative PASSED verdict.
+_TEST_TOOL_NAMES = frozenset({"pytest", "run_tests", "test"})
+
+
+def _command_text(tool_input: dict) -> str:
+    """Resolve one command string from a tool_use input across provider shapes.
+
+    Providers spell the executed command differently: ``command``/``cmd`` carry a
+    joined shell string, while argv-style providers carry ``argv``/``args`` as a
+    token list (#2401 c). Reading only ``command``/``cmd`` made an argv-only
+    invocation invisible to the gate; join the list forms so recognition sees the
+    same text whatever the shape.
+    """
+    if not isinstance(tool_input, dict):
+        return ""
+    command = tool_input.get("command") or tool_input.get("cmd")
+    if isinstance(command, str) and command:
+        return command
+    for key in ("argv", "args"):
+        value = tool_input.get(key)
+        if isinstance(value, list) and value:
+            return " ".join(str(part) for part in value)
+        if isinstance(value, str) and value:
+            return value
+    return ""
+
+
+def _command_runs_tests(command: str, patterns_to_check) -> bool:
+    """Per-segment recognition: whether ``command`` runs tests.
+
+    Extracted from ``_has_test_tool_call`` (#2401) so the dedicated-tool-name and
+    shell-tool-name branches share one recognition path. Each executable segment
+    is checked after the read-only pre-filter (``_EXCLUDE_FLAG_TOKENS`` drops
+    ``--help``/``--version``/collection-only flags, which assert nothing); a
+    runner pattern or a direct ``tests/`` file execution marks it a run. The
+    per-segment split is load-bearing: matching the whole command would let a
+    surviving segment lend its eligibility to a filtered one.
+    """
+    for segment in _executable_segments(command):
+        tokens = _shell_tokens(segment)
+        if any(token in _EXCLUDE_FLAG_TOKENS for token in tokens):
+            continue
+        for pattern in patterns_to_check:
+            if _pattern_matches_segment(pattern, segment, tokens):
+                return True
+        if _is_test_path_execution(segment):
+            return True
+    return False
+
+
 def _has_test_tool_call(tool_calls: list, framework_type: str) -> bool:
     """Check if tool_calls contains a test framework execution command.
 
@@ -1221,34 +1299,34 @@ def _has_test_tool_call(tool_calls: list, framework_type: str) -> bool:
             (tc.get("tool", {}).get("input", {}) or {}) if isinstance(tc.get("tool"), dict) else {}
         )
 
-        # P2: Check non-Bash test tools first (pytest, run_tests, test)
-        if tool_name in ("pytest", "run_tests", "test"):
-            return True
+        lowered = tool_name.lower()
+        command = _command_text(tool_input)
 
-        # Then check Bash/run_shell_command for test commands
-        if tool_name in ("Bash", "Shell", "run_shell_command", "exec_command"):
-            cmd = tool_input.get("command") or tool_input.get("cmd") or ""
-            if not cmd:
+        # (a #2401) A dedicated test-runner tool name is NOT fail-open: prepend it
+        # as argv[0] and run the SAME per-segment recognition as a shell command.
+        # ``pytest`` is itself a runner token so a bare pytest tool is recognized;
+        # ``test``/``run_tests`` pass only when the command carries a real runner,
+        # so a tool named ``test`` running ``helm install`` (or nothing) no longer
+        # reaches the authoritative PASSED verdict. ``run_tests`` is added to the
+        # pattern set so a bare ``run_tests`` suite run is recognized (it is not a
+        # _BARE_RUNNER token, so it routes through the multiword matcher).
+        if lowered in _TEST_TOOL_NAMES:
+            synthetic = f"{lowered} {command}".strip()
+            if _command_runs_tests(synthetic, [*patterns_to_check, "run_tests"]):
+                return True
+            continue
+
+        # (b #2401) Shell tool names, matched case-insensitively against one
+        # canonical set (see _SHELL_TOOL_NAMES). Empty command → nothing to judge.
+        # Recognition is per segment: matching the whole command would let a
+        # surviving segment lend eligibility to a filtered one, so a one-token
+        # prefix could defeat the read-only filter:
+        #     python -c "print(1)" && grep -rn pytest tests/
+        if lowered in _SHELL_TOOL_NAMES:
+            if not command:
                 continue
-            # #2376: filter and match per segment. Both must be per-segment —
-            # matching the whole command would let a surviving segment lend its
-            # eligibility to a filtered one, so a one-token prefix would defeat
-            # the read-only filter:
-            #     python -c "print(1)" && grep -rn pytest tests/
-            for segment in _executable_segments(cmd):
-                tokens = _shell_tokens(segment)
-                # Note: -v (verbose) is NOT excluded — only help/version and
-                # the collection-only flags, which assert nothing.
-                if any(token in _EXCLUDE_FLAG_TOKENS for token in tokens):
-                    continue
-                for pattern in patterns_to_check:
-                    if _pattern_matches_segment(pattern, segment, tokens):
-                        return True
-                # Repo convention (#2376 Fix C): executing a file under tests/
-                # is a test run whatever the interpreter, which no pattern list
-                # can express. Checked last so the cheaper substring match wins.
-                if _is_test_path_execution(segment):
-                    return True
+            if _command_runs_tests(command, patterns_to_check):
+                return True
 
     return False
 
@@ -5502,6 +5580,28 @@ class AutonomousOrchestrator:
             command_evidences = CommandExecutionEvidenceRepository().query_by_session(session_id)
             if not command_evidences:
                 return ExecutionVerdict.NOT_RUN, [], "no command execution evidence"
+
+            # #2390: ``session_id`` is stable across dev rounds, so query_by_session
+            # accumulates prior rounds' evidence into this round's verdict —
+            # forcing the structured layer to defer (non-pytest → INCONCLUSIVE) or
+            # false-FAIL (pytest broad→targeted). Scope to the current test
+            # milestone, which each ``_run_test_phase`` stamps on its evidence.
+            # Narrow ONLY when stamping is present in this session: an unstamped
+            # legacy session keeps session scope rather than silently NOT_RUN
+            # (fail-closed, but never worse than today).
+            current_milestone_id = (test_ms.get("milestone_id") or "").strip()
+            if current_milestone_id and any((ce.milestone_id or "") for ce in command_evidences):
+                command_evidences = [
+                    ce
+                    for ce in command_evidences
+                    if (ce.milestone_id or "") == current_milestone_id
+                ]
+                if not command_evidences:
+                    return (
+                        ExecutionVerdict.NOT_RUN,
+                        [],
+                        "no command evidence for current test milestone",
+                    )
 
             # Only parse commands that look like test invocations; an ``echo``
             # or ``ls`` must not be fed to the generic parser as if it were a

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -1225,7 +1225,9 @@ def _command_text(tool_input: dict) -> str:
     for key in ("argv", "args"):
         value = tool_input.get(key)
         if isinstance(value, list) and value:
-            return " ".join(str(part) for part in value)
+            # shlex.join so an arg with spaces re-quotes faithfully and the
+            # downstream _shell_tokens (shlex.split) round-trips it.
+            return shlex.join([str(part) for part in value])
         if isinstance(value, str) and value:
             return value
     return ""

--- a/tests/issues/1532/test_tool_call_detection.py
+++ b/tests/issues/1532/test_tool_call_detection.py
@@ -72,10 +72,16 @@ class TestHasTestToolCall:
                 "python",
                 True,
             ),
-            # Non-Bash test tools (pytest, run_tests, test)
+            # Non-Bash test tools. #2401 closed the fail-open here: the
+            # unambiguous runner names pytest/run_tests still pass on the name
+            # (a provider names a tool that only when it runs tests), but the
+            # ambiguous ``test`` name alone no longer passes — it must carry a
+            # real runner, else a tool literally named ``test`` running nothing
+            # reached the authoritative PASSED verdict.
             ([{"tool": {"name": "pytest", "input": {}}}], "python", True),
             ([{"tool": {"name": "run_tests", "input": {}}}], "python", True),
-            ([{"tool": {"name": "test", "input": {}}}], "python", True),
+            ([{"tool": {"name": "test", "input": {}}}], "python", False),
+            ([{"tool": {"name": "test", "input": {"command": "pytest tests/"}}}], "python", True),
             # Empty/malformed tool_calls
             ([{}], "python", False),
             ([{"tool": {}}], "python", False),

--- a/tests/issues/2376/test_readonly_prefilter.py
+++ b/tests/issues/2376/test_readonly_prefilter.py
@@ -378,5 +378,17 @@ def test_argument_basename_does_not_veto_a_genuine_run(command):
 
 
 def test_dedicated_test_tool_names_still_recognized():
-    for name in ("pytest", "run_tests", "test"):
+    # #2401: the unambiguous runner names remain recognized on the name alone
+    # (a bare pytest/run_tests tool runs the suite), but the ambiguous ``test``
+    # name is no longer fail-open — it must carry a real runner. The old contract
+    # let ``name="test", input={}`` (and ``helm install`` under it) reach the
+    # authoritative PASSED verdict.
+    for name in ("pytest", "run_tests"):
         assert _has_test_tool_call([{"tool": {"name": name, "input": {}}}], "mixed") is True
+    assert _has_test_tool_call([{"tool": {"name": "test", "input": {}}}], "mixed") is False
+    assert (
+        _has_test_tool_call(
+            [{"tool": {"name": "test", "input": {"command": "pytest tests/"}}}], "mixed"
+        )
+        is True
+    )

--- a/tests/issues/2390/test_milestone_scoped_verdict.py
+++ b/tests/issues/2390/test_milestone_scoped_verdict.py
@@ -1,0 +1,122 @@
+"""The structured verdict is scoped to the current test milestone (#2390).
+
+``_compute_structured_test_verdict`` read evidence via ``query_by_session``, which
+is unbounded — ``session_id`` is stable across dev rounds, so a prior round's
+evidence accumulated into the current round's verdict. That forces the
+authoritative structured layer to defer (non-pytest → INCONCLUSIVE) or even
+false-FAIL (pytest broad→targeted) instead of confirming a clean current round.
+
+The fix scopes the session evidence to the current test milestone
+(``test_ms["milestone_id"]``), but only when milestone stamping is present in the
+session — an unstamped legacy session keeps session scope rather than silently
+resolving NOT_RUN. Method-level, repos mocked (mirrors tests/issues/2046).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from app.modules.workspace.autonomous.command_evidence.types import (
+    CommandExecutionEvidence,
+    ExecutionVerdict,
+)
+from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+_CMD_REPO = "app.repositories.command_evidence_repo.CommandExecutionEvidenceRepository"
+_TEST_REPO = "app.repositories.test_evidence_repo.TestExecutionEvidenceRepository"
+_RECORDER = (
+    "app.modules.workspace.autonomous.command_evidence.recorder.get_command_evidence_recorder"
+)
+
+
+def _orch() -> AutonomousOrchestrator:
+    orch = AutonomousOrchestrator.__new__(AutonomousOrchestrator)
+    orch._workflow_id = "wf-test"
+    orch.repo = MagicMock()
+    return orch
+
+
+def _ce(command_id: str, milestone_id: str, shell: str, exit_code: int, excerpt: str):
+    return CommandExecutionEvidence(
+        command_id=command_id,
+        session_id="sess-1",
+        milestone_id=milestone_id,
+        tool_name="Bash",
+        shell_command=shell,
+        exit_code=exit_code,
+        output_excerpt=excerpt,
+    )
+
+
+def _compute(command_evidences, framework, test_ms):
+    orch = _orch()
+    recorder_patch = patch(_RECORDER)
+    cmd_patch = patch(_CMD_REPO)
+    test_patch = patch(_TEST_REPO)
+    recorder_mock = recorder_patch.start()
+    cmd_mock = cmd_patch.start()
+    test_patch.start()
+    recorder_mock.return_value.is_noop = True
+    cmd_mock.return_value.query_by_session.return_value = command_evidences
+    try:
+        return orch._compute_structured_test_verdict(
+            SimpleNamespace(session_id="sess-1", tracking_session_id=None), framework, test_ms
+        )
+    finally:
+        recorder_patch.stop()
+        cmd_patch.stop()
+        test_patch.stop()
+
+
+def test_prior_round_failure_does_not_pollute_current_verdict():
+    # Round 1 (ms-old) failed a targeted npm run; round 2 (ms-cur) passed the
+    # suite. The session holds both.
+    rows = [
+        _ce("c1", "ms-old", "npm test -- foo", 1, "1 failing"),
+        _ce("c2", "ms-cur", "npm test", 0, "ok, all passing"),
+    ]
+    # Unscoped (no current milestone): the stale round-1 failure is undecidably
+    # (non-pytest) not-covered → the structured layer defers.
+    v_unscoped, _, _ = _compute(rows, "javascript", {})
+    assert v_unscoped == ExecutionVerdict.INCONCLUSIVE
+    # Scoped to the current milestone: only round-2's pass is considered.
+    v_scoped, ev, _ = _compute(rows, "javascript", {"milestone_id": "ms-cur"})
+    assert v_scoped == ExecutionVerdict.PASSED
+    assert len(ev) == 1
+
+
+def test_pytest_broad_fail_then_targeted_pass_across_rounds_is_not_false_failed():
+    # The pytest variant: a prior round's broad FAIL + this round's targeted PASS
+    # is *decidable* non-coverage → unscoped FAILED (a false failure). Scoping to
+    # the current round drops the stale broad fail. Scope-parseable commands only
+    # (no --cov/pipe/wrapper), else _pytest_test_scope returns None.
+    rows = [
+        _ce("c1", "ms-old", "pytest tests/", 1, "1 failed, 9 passed"),
+        _ce("c2", "ms-cur", "pytest tests/test_auth.py::test_login", 0, "1 passed"),
+    ]
+    v_unscoped, _, _ = _compute(rows, "python", {})
+    assert v_unscoped == ExecutionVerdict.FAILED
+    v_scoped, ev, _ = _compute(rows, "python", {"milestone_id": "ms-cur"})
+    assert v_scoped == ExecutionVerdict.PASSED
+    assert len(ev) == 1
+
+
+def test_unstamped_session_falls_back_to_session_scope():
+    # No row carries a milestone_id (legacy). Even with a current milestone, do
+    # NOT narrow — narrowing would drop everything and resolve NOT_RUN. Keep the
+    # session scope (current behavior).
+    rows = [_ce("c1", "", "pytest tests/", 0, "3 passed")]
+    v, ev, _ = _compute(rows, "python", {"milestone_id": "ms-cur"})
+    assert v == ExecutionVerdict.PASSED
+    assert len(ev) == 1
+
+
+def test_partial_stamping_current_milestone_empty_is_fail_closed():
+    # Stamping is present in the session (c-old has a milestone) but the current
+    # milestone has no evidence → NOT_RUN, never a wrong PASSED from stale rows.
+    rows = [_ce("c-old", "ms-old", "pytest tests/", 0, "3 passed")]
+    v, ev, reason = _compute(rows, "python", {"milestone_id": "ms-cur"})
+    assert v == ExecutionVerdict.NOT_RUN
+    assert ev == []
+    assert "current test milestone" in reason

--- a/tests/issues/2390/test_milestone_uniqueness.py
+++ b/tests/issues/2390/test_milestone_uniqueness.py
@@ -1,0 +1,65 @@
+"""Milestone-uniqueness invariant the #2390 scoping depends on.
+
+Scoping the verdict to ``test_ms["milestone_id"]`` isolates dev rounds only if a
+retry gets a *distinct* milestone id. That holds because every retry path marks
+the tests_run milestone ``failed`` before re-entry, and ``_find_existing_milestone``
+(the idempotency guard) only ever looks at ``in_progress``/``completed`` — a
+failed milestone is invisible to it, so a re-entry creates a fresh one. These
+tests pin that invariant so a future refactor cannot silently defeat #2390.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+
+def _orch() -> AutonomousOrchestrator:
+    orch = AutonomousOrchestrator.__new__(AutonomousOrchestrator)
+    orch._workflow_id = "wf-test"
+    orch.repo = MagicMock()
+    return orch
+
+
+def test_find_existing_milestone_only_queries_inprogress_and_completed():
+    # A failed milestone lives only in a status="failed" result set, which is
+    # never queried — so it can never be reused. If a refactor added "failed"
+    # here, a retry would merge into the prior round's milestone and defeat the
+    # #2390 scoping; this guards against that.
+    orch = _orch()
+    orch.repo.list_milestones.return_value = []
+    orch._find_existing_milestone(phase="tests_run", milestone_type="tests_run", dev_round=3)
+    queried_statuses = {
+        call.kwargs.get("status") for call in orch.repo.list_milestones.call_args_list
+    }
+    assert queried_statuses == {"in_progress", "completed"}
+    assert "failed" not in queried_statuses
+
+
+def test_failed_prior_tests_run_milestone_yields_no_match():
+    # With only a failed prior milestone (absent from in_progress/completed
+    # results), the guard returns None → a retry creates a fresh milestone id.
+    orch = _orch()
+    orch.repo.list_milestones.return_value = []  # failed one is in neither set
+    match = orch._find_existing_milestone(
+        phase="tests_run", milestone_type="tests_run", dev_round=3
+    )
+    assert match is None
+
+
+def test_completed_tests_run_milestone_at_same_round_is_reused():
+    # Documents the one benign reuse case: a *completed* (passed) tests_run
+    # milestone at the same dev_round is idempotently reused — but a passed round
+    # advances the workflow, it is not re-entered, so no distinct rounds merge.
+    orch = _orch()
+    completed = {"milestone_id": "ms-done", "milestone_type": "tests_run", "dev_round": 3}
+
+    def _list(_wf, phase, status):
+        return [completed] if status == "completed" else []
+
+    orch.repo.list_milestones.side_effect = _list
+    match = orch._find_existing_milestone(
+        phase="tests_run", milestone_type="tests_run", dev_round=3
+    )
+    assert match is completed

--- a/tests/issues/2401/test_authoritative_closure.py
+++ b/tests/issues/2401/test_authoritative_closure.py
@@ -1,0 +1,103 @@
+"""End-to-end: a fail-open tool name cannot reach the authoritative PASSED (#2401 a).
+
+The recognizer tests prove ``_has_test_tool_call`` rejects a bare ``test`` name;
+this proves the *wiring* — that the evidence filter in
+``_compute_structured_test_verdict`` uses the recognizer, so a
+``tool_name="test"`` row with an empty (or non-test) command and exit 0 is
+excluded and the run resolves NOT_RUN rather than the authoritative PASSED it
+reached before. Method-level, repos mocked (mirrors tests/issues/2046).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from app.modules.workspace.autonomous.command_evidence.types import (
+    CommandExecutionEvidence,
+    ExecutionVerdict,
+)
+from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+_CMD_REPO = "app.repositories.command_evidence_repo.CommandExecutionEvidenceRepository"
+_TEST_REPO = "app.repositories.test_evidence_repo.TestExecutionEvidenceRepository"
+_RECORDER = (
+    "app.modules.workspace.autonomous.command_evidence.recorder.get_command_evidence_recorder"
+)
+
+
+def _orch() -> AutonomousOrchestrator:
+    orch = AutonomousOrchestrator.__new__(AutonomousOrchestrator)
+    orch._workflow_id = "wf-test"
+    orch.repo = MagicMock()
+    return orch
+
+
+def _result(session_id: str = "sess-1") -> SimpleNamespace:
+    return SimpleNamespace(session_id=session_id, tracking_session_id=None)
+
+
+def _ce(
+    tool_name: str, shell: str, exit_code: int | None, excerpt: str
+) -> CommandExecutionEvidence:
+    return CommandExecutionEvidence(
+        command_id="c1",
+        session_id="sess-1",
+        milestone_id="ms-1",
+        tool_name=tool_name,
+        shell_command=shell,
+        exit_code=exit_code,
+        output_excerpt=excerpt,
+    )
+
+
+def _compute(command_evidences, framework="python", test_ms=None):
+    orch = _orch()
+    recorder_patch = patch(_RECORDER)
+    cmd_patch = patch(_CMD_REPO)
+    test_patch = patch(_TEST_REPO)
+    recorder_mock = recorder_patch.start()
+    cmd_mock = cmd_patch.start()
+    test_patch.start()
+    recorder_mock.return_value.is_noop = True
+    cmd_mock.return_value.query_by_session.return_value = command_evidences
+    try:
+        return orch._compute_structured_test_verdict(_result(), framework, test_ms or {})
+    finally:
+        recorder_patch.stop()
+        cmd_patch.stop()
+        test_patch.stop()
+
+
+def test_empty_named_test_evidence_cannot_reach_passed():
+    # Pre-#2401 this reached the authoritative PASSED (name branch → generic
+    # parser → exit 0 + output → MEDIUM PASSED). Now the row is not recognized as
+    # a test invocation, so there is no test command evidence → NOT_RUN.
+    verdict, evidences, reason = _compute([_ce("test", "", 0, "done")])
+    assert verdict != ExecutionVerdict.PASSED
+    assert verdict == ExecutionVerdict.NOT_RUN
+    assert evidences == []
+    assert "no test command evidence" in reason
+
+
+def test_non_test_command_under_test_name_cannot_reach_passed():
+    verdict, evidences, _ = _compute([_ce("test", "helm install mocha ./chart", 0, "deployed")])
+    assert verdict != ExecutionVerdict.PASSED
+    assert evidences == []
+
+
+def test_non_test_command_under_test_name_rejected_in_mixed_repo():
+    # In a mixed repo the pattern union includes ``mocha``; the artifact-op veto
+    # (``helm install mocha``) keeps it rejected.
+    verdict, evidences, _ = _compute(
+        [_ce("test", "helm install mocha ./chart", 0, "deployed")], framework="mixed"
+    )
+    assert verdict != ExecutionVerdict.PASSED
+    assert evidences == []
+
+
+def test_real_pytest_under_test_name_still_reaches_passed():
+    # The fix must not break a dedicated test tool that actually ran pytest.
+    verdict, evidences, _ = _compute([_ce("test", "pytest tests/", 0, "5 passed in 0.3s")])
+    assert verdict == ExecutionVerdict.PASSED
+    assert len(evidences) == 1

--- a/tests/issues/2401/test_recorder_argv.py
+++ b/tests/issues/2401/test_recorder_argv.py
@@ -1,0 +1,114 @@
+"""Recorder captures argv and synthesizes a command from it (#2401 c).
+
+The recognizer reading argv (test_tool_name_contract) is only half of (c): the
+authoritative verdict reads persisted ``CommandExecutionEvidence`` rows, and the
+recorder — the sole writer of those rows — previously stored only
+``command``/``cmd``. An argv-only provider therefore left ``shell_command`` empty
+*and* ``argv`` null, so both recognition and framework routing
+(``_resolve_framework`` reads ``shell_command``) were blind to it → the evidence
+was mis-judged NOT_RUN. This fixes it at the single write point: extract argv and,
+when there is no joined command, synthesize one from it.
+"""
+
+from __future__ import annotations
+
+from app.modules.workspace.autonomous.command_evidence import CommandExecutionEvidence
+from app.modules.workspace.autonomous.command_evidence.recorder import CommandEvidenceRecorder
+
+
+class _CapturingRepo:
+    """Minimal repo double: records every evidence passed to ``upsert``."""
+
+    def __init__(self) -> None:
+        self.upserts: list[CommandExecutionEvidence] = []
+
+    def upsert(self, evidence: CommandExecutionEvidence) -> int:
+        self.upserts.append(evidence)
+        return len(self.upserts)
+
+
+def _seed_row(repo: _CapturingRepo, command_id: str) -> CommandExecutionEvidence:
+    # The tool_use seed row carries the identity fields (tool_name/argv/command);
+    # the tool_result upsert carries none of them. Pick the seed.
+    return next(e for e in repo.upserts if e.command_id == command_id and e.tool_name)
+
+
+def _emit(event_log: list[dict]) -> _CapturingRepo:
+    repo = _CapturingRepo()
+    recorder = CommandEvidenceRecorder(repo=repo)
+    recorder.emit_from_event_log(
+        session_id="sess-argv",
+        workflow_id="wf-1",
+        milestone_id="ms-1",
+        event_log=event_log,
+    )
+    return repo
+
+
+def test_argv_only_tool_use_is_persisted_and_synthesized_into_command():
+    repo = _emit(
+        [
+            {
+                "type": "tool_use",
+                "tool_use_id": "tu1",
+                "tool_name": "Bash",
+                "tool_input": {"argv": ["pytest", "tests/", "-k", "auth"]},
+            },
+            {"type": "tool_result", "tool_use_id": "tu1", "exit_code": 0, "text": "3 passed"},
+        ]
+    )
+    seed = _seed_row(repo, "tu1")
+    assert seed.argv == ["pytest", "tests/", "-k", "auth"]
+    # Synthesized so _resolve_framework / recognition (which read shell_command)
+    # can see the argv-only command.
+    assert seed.shell_command == "pytest tests/ -k auth"
+
+
+def test_args_key_is_also_captured():
+    repo = _emit(
+        [
+            {
+                "type": "tool_use",
+                "tool_use_id": "tu1",
+                "tool_name": "run_shell_command",
+                "tool_input": {"args": ["vitest", "run"]},
+            },
+        ]
+    )
+    seed = _seed_row(repo, "tu1")
+    assert seed.argv == ["vitest", "run"]
+    assert seed.shell_command == "vitest run"
+
+
+def test_command_string_is_preferred_but_argv_is_still_stored():
+    repo = _emit(
+        [
+            {
+                "type": "tool_use",
+                "tool_use_id": "tu1",
+                "tool_name": "Bash",
+                "tool_input": {"command": "pytest tests/", "argv": ["ignored"]},
+            },
+        ]
+    )
+    seed = _seed_row(repo, "tu1")
+    # The joined command the provider actually executed wins for shell_command...
+    assert seed.shell_command == "pytest tests/"
+    # ...but the raw argv is preserved for observability.
+    assert seed.argv == ["ignored"]
+
+
+def test_command_only_tool_use_leaves_argv_none():
+    repo = _emit(
+        [
+            {
+                "type": "tool_use",
+                "tool_use_id": "tu1",
+                "tool_name": "Bash",
+                "tool_input": {"command": "pytest tests/"},
+            },
+        ]
+    )
+    seed = _seed_row(repo, "tu1")
+    assert seed.shell_command == "pytest tests/"
+    assert seed.argv is None

--- a/tests/issues/2401/test_tool_name_contract.py
+++ b/tests/issues/2401/test_tool_name_contract.py
@@ -120,22 +120,36 @@ class TestShellToolNamesAreNotFailClosed:
         assert _call(name, {"command": "ls -la"}) is False
 
     def test_every_provider_shell_tool_name_is_recognized(self):
-        # Contract guard (#2401 b): the shell tool-name string each provider/CLI
-        # actually emits into evidence must be a member of the gate's set. A new
-        # provider (or a renamed one) that adds a shell tool name here without
-        # adding it to _SHELL_TOOL_NAMES trips this test rather than silently
-        # voiding the gate. Sourced from AUTONOMOUS_DEV_ALLOWED_TOOLS +
-        # agent_runner's default tool_name.
+        # Contract guard (#2401 b): a shell tool name any provider emits into
+        # evidence must be a member of the gate's set, else a drift silently voids
+        # the gate. Derived from the REAL registry (not a hardcoded map) so a
+        # future provider added to AUTONOMOUS_DEV_ALLOWED_TOOLS with a shell tool
+        # name trips this test rather than passing unnoticed.
+        import re
+
+        from app.modules.workspace.autonomous.constants import AUTONOMOUS_DEV_ALLOWED_TOOLS
         from app.modules.workspace.autonomous.orchestrator import _SHELL_TOOL_NAMES
 
-        provider_shell_tool_names = {
-            "claude-code": "Bash",
-            "qwen-code-cli": "run_shell_command",
+        # Explicit truth for today's providers (documents the mapping).
+        assert "bash" in _SHELL_TOOL_NAMES  # claude-code emits "Bash"
+        assert "run_shell_command" in _SHELL_TOOL_NAMES  # qwen-code-cli
+
+        # Conservative shell markers — a `sh`/`bash`/`zsh` suffix, or `shell`/
+        # `terminal` — so a non-shell tool cannot false-trip this.
+        shell_marker = re.compile(r"(?:^|[_.])(?:ba|z)?sh$|shell|terminal", re.IGNORECASE)
+        registry_shell_tools = {
+            tool
+            for tools in AUTONOMOUS_DEV_ALLOWED_TOOLS.values()
+            for tool in tools
+            if shell_marker.search(tool)
         }
-        for cli, shell_tool in provider_shell_tool_names.items():
+        # Guard the guard: the marker must detect the known shells, so an empty
+        # set never passes vacuously.
+        assert {"Bash", "run_shell_command"} <= registry_shell_tools
+        for tool in registry_shell_tools:
             assert (
-                shell_tool.lower() in _SHELL_TOOL_NAMES
-            ), f"{cli} emits shell tool {shell_tool!r} not in _SHELL_TOOL_NAMES"
+                tool.lower() in _SHELL_TOOL_NAMES
+            ), f"registry shell tool {tool!r} not in _SHELL_TOOL_NAMES"
 
 
 class TestArgvIsNotInvisible:

--- a/tests/issues/2401/test_tool_name_contract.py
+++ b/tests/issues/2401/test_tool_name_contract.py
@@ -1,0 +1,157 @@
+"""Contract tests for the test-evidence gate's tool-name/input-key handling (#2401).
+
+These are NOT command-corpus tests. #2376's six review rounds hardened
+``_has_test_tool_call`` against every *command string* that could satisfy the
+gate without running tests. #2401 is orthogonal: two structural gaps that never
+touch the command string, so no command corpus can see them —
+
+  (a) fail-open — a dedicated tool name (``pytest``/``run_tests``/``test``)
+      returned ``True`` on the *name alone*, so ``name="test"`` running
+      ``helm install`` reached the authoritative PASSED verdict;
+  (b) fail-closed — the shell tool-name whitelist was closed + case-sensitive, so
+      ``bash``/``terminal``/``execute_bash``/... voided the gate for any command;
+  (c) argv-blind — recognition and persistence read only ``command``/``cmd``, so
+      an argv-only provider was invisible.
+
+The fix makes the tool name part of the recognized command (option 1 of the
+issue's "要么...要么"): the dedicated tool name is prepended as ``argv[0]`` and run
+through the SAME per-segment recognition, so ``test``/``run_tests`` only pass when
+a real runner is present while ``pytest`` (a runner token) still passes. Verified
+against the recognizer, not a mock.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.modules.workspace.autonomous.orchestrator import _has_test_tool_call
+
+
+def _call(name: str, tool_input: dict, framework_type: str = "python") -> bool:
+    return _has_test_tool_call([{"tool": {"name": name, "input": tool_input}}], framework_type)
+
+
+class TestDedicatedToolNameIsNotFailOpen:
+    """(a) A dedicated tool name must not pass on the name alone (#2401)."""
+
+    @pytest.mark.parametrize(
+        "name,command,framework",
+        [
+            # The issue's exact examples: a tool literally named ``test`` running a
+            # non-test command, and running nothing at all.
+            ("test", "helm install mocha ./chart", "python"),
+            # open-ace itself infers ``mixed`` (py + js markers), whose pattern
+            # union includes ``mocha`` — so this exercises the _is_artifact_operation
+            # veto (``helm install mocha`` is a chart op, not the mocha runner).
+            ("test", "helm install mocha ./chart", "mixed"),
+            ("test", "", "python"),
+            ("test", "echo done", "python"),
+            ("test", "ls -la", "python"),
+        ],
+    )
+    def test_dedicated_name_without_a_real_runner_is_rejected(self, name, command, framework):
+        # Only the ambiguous ``test`` name is checked here — it is the generic
+        # name a provider might reuse for a shell. ``pytest``/``run_tests`` are
+        # unambiguous runner names (trusted residual, below).
+        assert _call(name, {"command": command}, framework) is False
+
+    @pytest.mark.parametrize(
+        "name,command,framework",
+        [
+            # ``pytest`` is itself a runner token, so a bare pytest tool is a run.
+            ("pytest", "tests/ -k auth", "python"),
+            ("pytest", "", "python"),
+            # ``run_tests`` invoked bare runs the suite (unambiguous runner name).
+            ("run_tests", "", "python"),
+            # ``test`` passes only when the command carries a real runner — checked
+            # against the framework's own pattern set (pytest for python, npm/vitest
+            # for a mixed repo).
+            ("test", "pytest tests/test_auth.py", "python"),
+            ("test", "npm test", "mixed"),
+            ("test", "vitest run", "mixed"),
+        ],
+    )
+    def test_dedicated_name_with_a_real_runner_is_recognized(self, name, command, framework):
+        assert _call(name, {"command": command}, framework) is True
+
+    def test_unambiguous_runner_name_is_the_accepted_residual(self):
+        # Issue-sanctioned residual: ``pytest``/``run_tests`` are unambiguous
+        # runner names, so they are trusted whatever the command. A provider names
+        # a tool ``pytest``/``run_tests`` only when it runs tests; the drift the
+        # issue targets is the ambiguous ``test`` (closed above), not these.
+        assert _call("pytest", {"command": "echo hi"}) is True
+        assert _call("run_tests", {"command": "deploy.sh --prod"}) is True
+
+    def test_prepend_does_not_defeat_the_read_only_prefilter(self):
+        # Prepending the tool name must not lend eligibility to a read-only
+        # command: ``grep pytest tests/`` reads a test file, it does not run it.
+        assert _call("test", {"command": "grep -rn pytest tests/"}) is False
+
+
+class TestShellToolNamesAreNotFailClosed:
+    """(b) The shell tool-name set is case-insensitive and consolidated (#2401)."""
+
+    @pytest.mark.parametrize("name", ["bash", "Bash", "BASH", "bAsH"])
+    def test_shell_tool_names_are_case_insensitive(self, name):
+        # Before the fix only the exact-case ``Bash`` matched; a lower-case
+        # ``bash`` returned False for any command — a fail-closed drift.
+        assert _call(name, {"command": "pytest tests/"}) is True
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "sh",
+            "shell",
+            "zsh",
+            "terminal",
+            "execute_bash",
+            "local_shell",
+            "container.exec",
+            "run_terminal_cmd",
+            "run_shell_command",
+            "exec_command",
+        ],
+    )
+    def test_wider_shell_tool_names_reach_the_command_check(self, name):
+        # These provider/normalized shell tool names all voided the gate before
+        # (closed whitelist); each must now reach the per-segment recognition.
+        assert _call(name, {"command": "pytest tests/"}) is True
+        # ...and must still reject a non-test command (they are shells, checked).
+        assert _call(name, {"command": "ls -la"}) is False
+
+    def test_every_provider_shell_tool_name_is_recognized(self):
+        # Contract guard (#2401 b): the shell tool-name string each provider/CLI
+        # actually emits into evidence must be a member of the gate's set. A new
+        # provider (or a renamed one) that adds a shell tool name here without
+        # adding it to _SHELL_TOOL_NAMES trips this test rather than silently
+        # voiding the gate. Sourced from AUTONOMOUS_DEV_ALLOWED_TOOLS +
+        # agent_runner's default tool_name.
+        from app.modules.workspace.autonomous.orchestrator import _SHELL_TOOL_NAMES
+
+        provider_shell_tool_names = {
+            "claude-code": "Bash",
+            "qwen-code-cli": "run_shell_command",
+        }
+        for cli, shell_tool in provider_shell_tool_names.items():
+            assert (
+                shell_tool.lower() in _SHELL_TOOL_NAMES
+            ), f"{cli} emits shell tool {shell_tool!r} not in _SHELL_TOOL_NAMES"
+
+
+class TestArgvIsNotInvisible:
+    """(c) Recognition reads argv/args, not just command/cmd (#2401)."""
+
+    @pytest.mark.parametrize("key", ["argv", "args"])
+    def test_argv_only_input_is_recognized(self, key):
+        # An argv-style provider carries the command as a token list with no
+        # joined ``command``/``cmd`` string. Before the fix the recognizer read
+        # only command/cmd, so this invocation was invisible.
+        assert _call("Bash", {key: ["pytest", "tests/"]}) is True
+
+    def test_argv_only_non_test_command_is_still_rejected(self):
+        assert _call("Bash", {"argv": ["ls", "-la"]}) is False
+
+    def test_command_string_takes_precedence_over_argv(self):
+        # When both are present the joined command string wins (it is what the
+        # provider actually executed); argv is the fallback shape.
+        assert _call("Bash", {"command": "pytest tests/", "argv": ["ls"]}) is True

--- a/tests/issues/2431/test_acceptance_verifier_hardening.py
+++ b/tests/issues/2431/test_acceptance_verifier_hardening.py
@@ -602,7 +602,12 @@ def test_ci_executes_the_issue_2335_verifier_regressions():
     repo_root = Path(__file__).resolve().parents[3]
     workflow = (repo_root / ".github" / "workflows" / "ci.yml").read_text()
 
-    assert "pytest tests/issues/2335 tests/issues/2403" in workflow
+    # Membership, not adjacency: both dirs must be in the opt-in pytest line so
+    # their regressions run in CI (tests/issues/ is excluded by norecursedirs).
+    # An adjacency assertion brittle-breaks whenever another opt-in dir is
+    # inserted between them (#2454 added 2390/2401 there); assert presence.
+    assert "pytest tests/issues/2335 " in workflow
+    assert "tests/issues/2403" in workflow
 
 
 class _SQLiteDB:


### PR DESCRIPTION
## Summary

Two fail-closed bug fixes to the autonomous **test-evidence gate**, both
follow-ups from #2376. They edit the same function (`_compute_structured_test_verdict`)
so they ship together. The third follow-up, #2391 (requirer semantics), is a
behavior change that its own issue says must be reviewed and deployed separately —
it lands as a later PR, shadow-first.

Closes #2401. Closes #2390.

### #2401 (P1) — structural contract gaps in `_has_test_tool_call`

Gaps that never touch the command string, so #2376's command-corpus hardening
could not see them:

- **(a) fail-open** — dedicated tool names (`pytest`/`run_tests`/`test`) returned
  `True` on the **name alone**, so a tool literally named `test` running
  `helm install` (or nothing) reached the authoritative `PASSED` verdict
  (`_has_test_tool_call` → filter keeps the row → generic/exit-code parse →
  `PASSED` at MEDIUM → authoritative). The tool name is now prepended as
  `argv[0]` and run through the **same** per-segment recognition, so the
  ambiguous `test` passes only with a real runner in the command; the
  unambiguous `pytest`/`run_tests` stay trusted runner names.
- **(b) fail-closed** — the shell tool-name whitelist was closed + case-sensitive
  (`bash`/`terminal`/`execute_bash`/`local_shell`/`container.exec`/... voided the
  gate for any command — the original #2376 incident class, but
  command-independent). Consolidated into one case-insensitive
  `_SHELL_TOOL_NAMES` with a provider **contract test**.
- **(c) argv-blind** — recognition and the recorder read only `command`/`cmd`.
  The recorder now captures `argv`/`args` and synthesizes `shell_command` from
  it, so an argv-only provider is visible to both recognition **and** framework
  routing (`_resolve_framework`/`_parse_*`), not mis-judged `NOT_RUN`.

### #2390 — evidence query scoped to the current test milestone

`_compute_structured_test_verdict` read evidence via `query_by_session`
(unbounded). `session_id` is stable across dev rounds, so a prior round's
evidence polluted the current verdict — forcing the authoritative structured
layer to defer (non-pytest → `INCONCLUSIVE`) or **false-FAIL** (pytest
broad→targeted). Now scoped to the current test milestone (which each
`_run_test_phase` stamps on its evidence), narrowing only when milestone stamping
is present so a legacy unstamped session keeps session scope rather than silently
resolving `NOT_RUN`.

## Fail-closed analysis

No change can promote a failing/again-unrun run to `PASSED`; every failure mode
lands on the existing inconclusive→retry path.

| change | direction | worst case if wrong |
|--------|-----------|---------------------|
| 2401(a) name→command recognition | tighten fail-open | dedicated run with no runner token → heuristic fallback (retry), never a wrong PASSED |
| 2401(b) case-insensitive + wider set | open fail-closed | recognizes more shells; still command-checked |
| 2401(c) recorder argv + synth command | open fail-closed | more evidence visible + correctly routed |
| 2390 milestone scope | correctness | partial-fill → NOT_RUN → heuristic |

## Tests (mutation-verified)

- `tests/issues/2401/` — tool-name/argv contract, recorder argv capture, and an
  end-to-end authoritative-PASSED closure (a `tool_name="test"` empty/`helm`
  row cannot reach `PASSED`; restoring the fail-open makes it fail).
- `tests/issues/2390/` — cross-round scoping (non-pytest `INCONCLUSIVE` +
  pytest false-`FAILED` baselines both demonstrated) and the milestone-uniqueness
  invariant the scoping relies on.
- Corrected `tests/issues/1532` + `tests/issues/2376` assertions that encoded the
  fail-open (`name="test", input={}` → `True`).
- Added both dirs to the `ci.yml` opt-in list (`tests/issues/` is excluded by
  `norecursedirs`).

Full local run: 662 passed across the recognizer/gate/verdict/evidence suites +
the new dirs, 0 regressions. `black`/`isort`/`ruff`/`mypy` clean.

## Independent plan review (class-2 gate)

Two rounds, same reviewer, verified against source each round:

- **Round 1 → APPROVE WITH CHANGES** — 2 blockers + 3 corrections:
  - **B1**: the initial (c) plan was a no-op — `record_tool_use` is never passed
    `argv`, so the fix had to live in the recorder (done: `emit_from_event_log`).
  - **B2**: "require non-empty payload" still let `name="test", cmd="helm install"`
    reach PASSED; replaced with the synthesize-and-recognize approach above.
  - **C3**: the real pre-fix outcome is `INCONCLUSIVE` (non-pytest) / `FAILED`
    (pytest broad→targeted), not "non-pytest FAILED"; tests assert the correct
    baselines.
  - **C4**: requirer (PR2) must use precise path rules, not the loose tags.
  - **C5**: pinned the milestone-uniqueness invariant with a test.
- **Round 2 → APPROVE** — all five resolved and complete on the load-bearing
  mechanisms.
