### PR TITLE
test: prevent full E2E workspace-stub drift

### DIFF
--- a/tests/e2e/work/e2e_personal_files_upload_download.py
+++ b/tests/e2e/work/e2e_personal_files_upload_download.py
@@ -83,7 +83,12 @@ _rw = importlib.util.module_from_spec(_rspec)
 _rspec.loader.exec_module(_rw)
 _ws.get_workspace_base_dir = _rw.get_workspace_base_dir
 _ws.get_workspace_base_dirs = _rw.get_workspace_base_dirs
-_ws.OPENACE_CHOWN_WRAPPER = "/usr/local/bin/openace-chown"
+# Keep the standalone route stub aligned with every privileged workspace
+# wrapper imported by app/routes/fs.py.  Copying the constants from the real
+# module prevents a new wrapper from breaking full-E2E collection again.
+for _name in dir(_rw):
+    if _name.startswith("OPENACE_") and _name.endswith("_WRAPPER"):
+        setattr(_ws, _name, getattr(_rw, _name))
 _ws._is_wrapper_available = lambda p: False
 _ws.run_as_root_if_needed = lambda cmd: None
 

--- a/tests/unit/test_e2e_collection_contracts.py
+++ b/tests/unit/test_e2e_collection_contracts.py
@@ -1,0 +1,32 @@
+"""Regression tests for E2E modules with standalone import stubs."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.mark.regression
+def test_personal_files_e2e_route_stub_imports() -> None:
+    """The standalone fs route stub must track production workspace imports."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import runpy; "
+                "runpy.run_path('tests/e2e/work/e2e_personal_files_upload_download.py')"
+            ),
+        ],
+        cwd=PROJECT_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr

--- a/tests/unit/test_e2e_collection_contracts.py
+++ b/tests/unit/test_e2e_collection_contracts.py
@@ -19,6 +19,8 @@ def test_personal_files_e2e_route_stub_imports() -> None:
             sys.executable,
             "-c",
             (
+                # The default run_name is "<run_path>", so the module's
+                # __main__ browser/server entry point is intentionally skipped.
                 "import runpy; "
                 "runpy.run_path('tests/e2e/work/e2e_personal_files_upload_download.py')"
             ),


### PR DESCRIPTION
## What changed

- copy every `OPENACE_*_WRAPPER` constant from the real workspace module into the standalone personal-files E2E stub
- add a required-suite regression test that imports the standalone E2E module in a subprocess

## Root cause

The post-merge Extended Tests run collected `app/routes/fs.py` through `e2e_personal_files_upload_download.py`. The E2E stub only exposed `OPENACE_CHOWN_WRAPPER`, while the production route now also imports `OPENACE_RM_WRAPPER` and `OPENACE_WRITE_AS_WRAPPER`. That stopped all Full E2E tests during collection.

The stub now mirrors wrapper constants dynamically so future privileged-wrapper additions do not recreate the same failure class.

## Validation

- full E2E collection: 274 tests collected without errors
- `tests/unit/test_e2e_collection_contracts.py` plus `tests/issues/1469/test_extended_tests_runner.py`: 14 passed
- pre-commit on both changed files: passed

Refs #2429

Source failure: [Extended Tests run 31313240896](https://github.com/open-ace/open-ace/actions/runs/31313240896)