### PR TITLE
feat(autonomous): require test evidence per changed domain, shadow-first (#2391)

### DIFF
--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -227,6 +227,144 @@ def _infer_test_framework(project_path: str, cli_tool: str) -> str:
         return "unknown"
 
 
+# ── #2391 requirer semantics ────────────────────────────────────────────────
+# Derive which evidence *domains* a change requires from its changed paths — a
+# recognizer-independent path (it never touches _has_test_tool_call). A required
+# domain with no passing evidence is, under enforce mode, a fail-closed retry;
+# under the default shadow mode it is observation only.
+
+_REQUIRER_MODES = ("off", "shadow", "enforce")
+_FRONTEND_CODE_EXT = (".ts", ".tsx", ".js", ".jsx", ".vue", ".svelte")
+_DOC_EXT = (".md", ".rst", ".txt")
+# framework (TestExecutionEvidence.framework) → required-evidence domain. A
+# ``generic`` run (wrapper-invoked, no runner token) maps to no domain, so it
+# cannot vacuously "cover" a changed domain (#2391 review F2).
+_FRAMEWORK_TO_DOMAIN = {
+    "python": "python",
+    "javascript": "javascript",
+    "go": "go",
+    "rust": "rust",
+    "java": "java",
+}
+
+
+def _test_evidence_requirer_mode() -> str:
+    """Requirer rollout mode: ``off`` | ``shadow`` | ``enforce`` (default shadow).
+
+    Env-flag mechanism + ``OPENACE_`` prefix mirror ``OPENACE_MODEL_GATEWAY_MODE``
+    (the tri-state precedent). An unknown value falls back to the safe default.
+    """
+    mode = (os.environ.get("OPENACE_TEST_EVIDENCE_REQUIRER_MODE") or "shadow").strip().lower()
+    return mode if mode in _REQUIRER_MODES else "shadow"
+
+
+def _is_doc_path(path: str) -> bool:
+    lowered = path.lower()
+    return lowered.endswith(_DOC_EXT) or "/docs/" in lowered or lowered.startswith("docs/")
+
+
+def _requirer_python_suite_exists(tree_path: str) -> bool:
+    """Whether a python test suite exists in the tree the agent ran in.
+
+    Probes are cheap and best-effort; any error → not present (require nothing).
+    """
+    if not tree_path:
+        return False
+    try:
+        if os.path.exists(os.path.join(tree_path, "pytest.ini")):
+            return True
+        if os.path.isdir(os.path.join(tree_path, "tests")):
+            return True
+        pyproject = os.path.join(tree_path, "pyproject.toml")
+        if os.path.exists(pyproject):
+            with open(pyproject, encoding="utf-8", errors="replace") as handle:
+                if "[tool.pytest" in handle.read():
+                    return True
+    except OSError:
+        return False
+    return False
+
+
+def _requirer_js_suite_exists(tree_path: str) -> bool:
+    """Whether a JS test suite exists: ``frontend/package.json`` has a test script."""
+    if not tree_path:
+        return False
+    package_json = os.path.join(tree_path, "frontend", "package.json")
+    try:
+        if not os.path.exists(package_json):
+            return False
+        with open(package_json, encoding="utf-8", errors="replace") as handle:
+            scripts = json.load(handle).get("scripts") or {}
+        return any(name == "test" or name.startswith("test:") for name in scripts)
+    except (OSError, ValueError, AttributeError):
+        return False
+
+
+def _required_evidence_domains(changed_files: list | None, tree_path: str) -> set[str]:
+    """Evidence domains a change requires, derived from concrete changed paths.
+
+    Precise path rules (NOT the loose ``_analyze_changed_files`` tags): ``*.py``
+    under ``app``/``backend``/``tests`` (excluding e2e) → ``python``; a
+    ``frontend/**`` code file → ``javascript``. Docs-only changes require
+    nothing, and a domain is required only when its suite exists in ``tree_path``
+    (never hard-fail a repo that has no such suite). ``migrations/``, ``*.sh``,
+    ``tests/e2e/`` and a ``.ts`` outside ``frontend/`` are deliberately
+    de-scoped (fail-open). An empty/unavailable ``changed_files`` requires
+    nothing (fail-open — #2391 review F4).
+    """
+    normalized = [path.strip() for path in (changed_files or []) if path and path.strip()]
+    if not normalized or all(_is_doc_path(path) for path in normalized):
+        return set()
+
+    required: set[str] = set()
+    for path in normalized:
+        lowered = path.lower()
+        if lowered.endswith(".py") and (
+            path.startswith(("app/", "backend/"))
+            or (path.startswith("tests/") and not path.startswith("tests/e2e/"))
+        ):
+            required.add("python")
+        if path.startswith("frontend/") and lowered.endswith(_FRONTEND_CODE_EXT):
+            required.add("javascript")
+
+    if "python" in required and not _requirer_python_suite_exists(tree_path):
+        required.discard("python")
+    if "javascript" in required and not _requirer_js_suite_exists(tree_path):
+        required.discard("javascript")
+    return required
+
+
+def _evidence_domains_covered(structured_evidences: list | None) -> set[str]:
+    """Domains with an authoritative PASSED evidence in the (milestone-scoped) run.
+
+    ``generic``-framework evidence maps to no domain, so a wrapper-invoked run
+    that could not be attributed to a domain does not vacuously cover one
+    (#2391 review F2).
+    """
+    from app.modules.workspace.autonomous.command_evidence.test_evidence import ParserConfidence
+
+    authoritative = (ParserConfidence.HIGH.value, ParserConfidence.MEDIUM.value)
+    covered: set[str] = set()
+    for evidence in structured_evidences or []:
+        if (
+            evidence.verdict == ExecutionVerdict.PASSED.value
+            and evidence.parser_confidence in authoritative
+        ):
+            domain = _FRAMEWORK_TO_DOMAIN.get(evidence.framework)
+            if domain:
+                covered.add(domain)
+    return covered
+
+
+def _requirer_reason(missing: set[str]) -> str:
+    """Bilingual reason for a missing-domain enforce failure (#2391 review F10)."""
+    domains = ", ".join(sorted(missing))
+    return (
+        f"Changed {domains} but no passing {domains} test evidence in this run"
+        f" / 改动涉及 {domains} 但本轮未见对应的通过测试证据"
+    )
+
+
 def _has_strict_keyword_result(test_response_text: str, has_hallucination_desc: bool) -> bool:
     """Strict keyword detection with multiple conditions (Phase 1, P0).
 
@@ -4233,7 +4371,7 @@ class AutonomousOrchestrator:
 
         return scopes
 
-    def _build_test_execution_context(self, wf: dict, gh: GitHubOps) -> str:
+    def _build_test_execution_context(self, wf: dict, gh: GitHubOps) -> tuple[str, list[str]]:
         """Build a targeted validation brief for the test phase."""
         project_path = wf.get("worktree_path") or wf.get("project_path", "")
         framework_type = _infer_test_framework(project_path, wf.get("cli_tool", ""))
@@ -4338,7 +4476,9 @@ class AutonomousOrchestrator:
                 guardrail,
             ]
         )
-        return "\n".join(context).strip()
+        # Return the changed files alongside the brief so the #2391 requirer can
+        # reuse them (single fetch — no second git diff at the gate).
+        return "\n".join(context).strip(), changed_files
 
     def _post_github_comment(
         self,
@@ -5677,6 +5817,68 @@ class AutonomousOrchestrator:
             )
         except Exception as e:
             logger.debug("structured fallback event emit failed: %s", e)
+
+    def _apply_test_evidence_requirer(
+        self,
+        milestone_id: str,
+        changed_files: list | None,
+        tree_path: str,
+        structured_evidences: list | None,
+    ) -> tuple[str, set[str]]:
+        """Compute the requirer's ``(mode, missing-domains)`` and emit its shadow event.
+
+        Recognizer-independent (#2391): required domains derive from changed paths,
+        covered domains from the milestone-scoped structured evidence; ``missing =
+        required - covered``. Fail-open — any compute error returns an empty
+        ``missing`` (never blocks a run on its own failure), and the observability
+        emit is separately guarded so a DB error cannot raise into the gate.
+        ``off`` computes and emits nothing; ``shadow``/``enforce`` both emit, and
+        only the caller acts on ``missing`` (under ``enforce``).
+        """
+        mode = _test_evidence_requirer_mode()
+        if mode == "off":
+            return "off", set()
+        try:
+            required = _required_evidence_domains(changed_files, tree_path)
+            covered = _evidence_domains_covered(structured_evidences)
+            missing = required - covered
+        except Exception as exc:
+            logger.debug("test-evidence requirer compute failed: %s", exc)
+            return mode, set()
+        try:
+            self.repo.create_event(
+                {
+                    "workflow_id": self._workflow_id,
+                    "milestone_id": milestone_id,
+                    "event_type": "test_evidence_requirer_shadow",
+                    "event_data": json.dumps(
+                        {
+                            "mode": mode,
+                            "required": sorted(required),
+                            "covered": sorted(covered),
+                            "missing": sorted(missing),
+                            "changed_files": list(changed_files or []),
+                            "milestone_id": milestone_id,
+                            "tree_path": tree_path,
+                            # Per-evidence framework/confidence so a genuine miss is
+                            # distinguishable from the generic-framework (F2) and
+                            # cross-milestone (F3) misfires before flipping enforce.
+                            "evidences": [
+                                {
+                                    "framework": getattr(ev, "framework", ""),
+                                    "parser_confidence": getattr(ev, "parser_confidence", ""),
+                                    "verdict": getattr(ev, "verdict", ""),
+                                }
+                                for ev in (structured_evidences or [])
+                            ],
+                        },
+                        ensure_ascii=False,
+                    ),
+                }
+            )
+        except Exception as exc:
+            logger.debug("test-evidence requirer shadow emit failed: %s", exc)
+        return mode, missing
 
     def _on_pid_registered(self, session_id: str, pid: int):
         """Persist agent subprocess PID to database for reliable cancel/pause."""
@@ -9360,14 +9562,19 @@ class AutonomousOrchestrator:
             status="in_progress",
             title=f"Running tests round {dev_round}",
         )
+        requirer_changed_files: list[str] = []
         try:
-            targeted_test_context = self._build_test_execution_context(wf, gh)
+            targeted_test_context, requirer_changed_files = self._build_test_execution_context(
+                wf, gh
+            )
         except Exception as exc:
             logger.warning(
                 "Failed to build targeted test context for workflow %s: %s",
                 self._workflow_id[:8],
                 exc,
             )
+            # requirer_changed_files stays [] → the requirer requires nothing
+            # (fail-open) when the change set is unavailable.
             targeted_test_context = (
                 "## 本轮定向验证上下文\n"
                 "- 自动构建验证上下文失败，请先自行检查最终方案、改动文件和仓库测试约定，"
@@ -9779,6 +9986,27 @@ class AutonomousOrchestrator:
             )
         )
 
+        # #2391 requirer: derive the evidence domains this change *requires* from
+        # its changed paths and compare against the domains actually covered by
+        # passing evidence (recognizer-independent, fail-open). Shadow-emits an
+        # observability event always; only ``enforce`` mode acts on a missing
+        # domain, and only for a run that would otherwise proceed — not an
+        # inconclusive or skipped run (those have their own handling below). That
+        # is exactly the PASSED-but-unverified-domain case that flows straight to
+        # pr_review today.
+        requirer_mode, requirer_missing = self._apply_test_evidence_requirer(
+            test_ms.get("milestone_id", ""),
+            requirer_changed_files,
+            wf.get("worktree_path") or wf.get("project_path", ""),
+            _structured_evidences,
+        )
+        requirer_enforced = (
+            requirer_mode == "enforce"
+            and bool(requirer_missing)
+            and not test_result_inconclusive
+            and not tests_actually_skipped
+        )
+
         # Post test results to issue
         issue_number = wf.get("github_issue_number")
         if issue_number:
@@ -9801,6 +10029,14 @@ class AutonomousOrchestrator:
                 )
             elif tests_actually_skipped:
                 status_line = "⚠️ Tests were not actually run — see details below"
+            elif requirer_enforced:
+                # #2391 N1: the requirer retry fires below; without this arm the
+                # comment would read "All tests passed" and then re-run.
+                status_line = (
+                    "⚠️ Changed "
+                    + ", ".join(sorted(requirer_missing))
+                    + " but this run has no passing evidence for it — retrying"
+                )
             elif test_result.success:
                 status_line = "✅ All tests passed"
             else:
@@ -9826,6 +10062,25 @@ class AutonomousOrchestrator:
                     "Test execution is inconclusive: a test command was invoked, but no "
                     "structured TEST_STATUS or recognizable pass/fail output was captured"
                 )
+            self.repo.update_milestone(
+                test_ms.get("milestone_id", ""),
+                {"status": "failed", "error_message": message},
+            )
+            test_retries = int(wf.get("test_retries", 0) or 0) + 1
+            if test_retries <= MAX_TEST_RETRIES:
+                self._update_workflow({"test_retries": test_retries})
+                return
+            self._update_workflow({"status": "failed", "error_message": message})
+            return
+
+        # #2391 enforce: a required evidence domain (e.g. changed frontend) had no
+        # passing evidence, on a run that would otherwise proceed to pr_review.
+        # Force the same retry the inconclusive path uses, capped by
+        # MAX_TEST_RETRIES. ``requirer_enforced`` already excludes the
+        # inconclusive/skipped runs handled above/below, and is False in the
+        # default shadow mode — so this is a no-op until enforce is enabled.
+        if requirer_enforced:
+            message = _requirer_reason(requirer_missing)
             self.repo.update_milestone(
                 test_ms.get("milestone_id", ""),
                 {"status": "failed", "error_message": message},

--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -9986,14 +9986,31 @@ class AutonomousOrchestrator:
             )
         )
 
+        # #2391 F1 (PR review, enforce-phase): detect the agent's unfixable signal
+        # up here so the requirer guard below can exclude it. Situation B (an
+        # [UNFIXABLE] report) must keep taking its dev-round retry, never be
+        # preempted by the requirer's test retry. Cheap text scan; harmless on the
+        # early-return paths that don't reach Situation B.
+        test_response = self._artifact_visible_text(test_result) or self._artifact_text(test_result)
+        _unfixable_marker = "[UNFIXABLE]"
+        has_unfixable = _unfixable_marker in test_response
+        if not has_unfixable:
+            # Fallback: check legacy keywords for backward compatibility
+            _legacy_unfixable = [
+                "无法修复",
+                "不可修复",
+                "cannot fix",
+                "unable to fix",
+            ]
+            has_unfixable = any(kw in test_response.lower() for kw in _legacy_unfixable)
+
         # #2391 requirer: derive the evidence domains this change *requires* from
         # its changed paths and compare against the domains actually covered by
         # passing evidence (recognizer-independent, fail-open). Shadow-emits an
         # observability event always; only ``enforce`` mode acts on a missing
-        # domain, and only for a run that would otherwise proceed — not an
-        # inconclusive or skipped run (those have their own handling below). That
-        # is exactly the PASSED-but-unverified-domain case that flows straight to
-        # pr_review today.
+        # domain, and only for a run that would otherwise proceed to pr_review —
+        # excluding inconclusive, skipped, agent-session-failed (Situation A) and
+        # unfixable (Situation B) runs, each of which has its own handling below.
         requirer_mode, requirer_missing = self._apply_test_evidence_requirer(
             test_ms.get("milestone_id", ""),
             requirer_changed_files,
@@ -10005,6 +10022,8 @@ class AutonomousOrchestrator:
             and bool(requirer_missing)
             and not test_result_inconclusive
             and not tests_actually_skipped
+            and test_result.success
+            and not has_unfixable
         )
 
         # Post test results to issue
@@ -10077,8 +10096,8 @@ class AutonomousOrchestrator:
         # passing evidence, on a run that would otherwise proceed to pr_review.
         # Force the same retry the inconclusive path uses, capped by
         # MAX_TEST_RETRIES. ``requirer_enforced`` already excludes the
-        # inconclusive/skipped runs handled above/below, and is False in the
-        # default shadow mode — so this is a no-op until enforce is enabled.
+        # inconclusive/skipped/agent-failed/unfixable runs handled above/below,
+        # and is False in the default shadow mode — a no-op until enforce is on.
         if requirer_enforced:
             message = _requirer_reason(requirer_missing)
             self.repo.update_milestone(
@@ -10190,20 +10209,9 @@ class AutonomousOrchestrator:
                 )
                 return
 
-        # Situation B: test agent succeeded but reported unfixable failures
-        test_response = self._artifact_visible_text(test_result) or self._artifact_text(test_result)
-        _unfixable_marker = "[UNFIXABLE]"
-        has_unfixable = _unfixable_marker in test_response
-        if not has_unfixable:
-            # Fallback: check legacy keywords for backward compatibility
-            _legacy_unfixable = [
-                "无法修复",
-                "不可修复",
-                "cannot fix",
-                "unable to fix",
-            ]
-            has_unfixable = any(kw in test_response.lower() for kw in _legacy_unfixable)
-
+        # Situation B: test agent succeeded but reported unfixable failures.
+        # ``has_unfixable`` is computed above (so the #2391 requirer guard can
+        # exclude it); this is where an [UNFIXABLE] run takes its dev-round retry.
         if has_unfixable:
             dev_retries = wf.get("dev_retries_on_test_fail", 0) + 1
             if dev_retries <= MAX_DEV_RETRIES_ON_TEST_FAIL:

--- a/tests/issues/1647/test_targeted_test_phase.py
+++ b/tests/issues/1647/test_targeted_test_phase.py
@@ -110,7 +110,7 @@ def test_build_test_execution_context_prefers_frontend_scope(tmp_path):
     orch._gh.get_current_commit.return_value = "abc1234"
     orch._gh.get_commit_changed_files.return_value = ["frontend/src/styles/main.css"]
 
-    context = orch._build_test_execution_context(wf, orch._gh)
+    context, _changed_files = orch._build_test_execution_context(wf, orch._gh)
 
     assert "方案中的验证计划" in context
     assert "frontend/src/styles/main.css" in context
@@ -155,7 +155,7 @@ def test_build_test_execution_context_marks_shared_backend_for_broader_scope(tmp
     orch._gh.get_current_commit.return_value = "abc1234"
     orch._gh.get_commit_changed_files.return_value = ["app/utils/session_diagnostics.py"]
 
-    context = orch._build_test_execution_context(wf, orch._gh)
+    context, _changed_files = orch._build_test_execution_context(wf, orch._gh)
 
     assert "是否建议扩大测试范围：是" in context
     assert "共享后端依赖验证" in context

--- a/tests/issues/2376/test_gate_flags.py
+++ b/tests/issues/2376/test_gate_flags.py
@@ -109,7 +109,7 @@ def _run(orch, wf, *, verdict, text, tool_pass, tool_calls=None):
     orch._find_or_create_milestone = MagicMock(return_value={"milestone_id": "ms-1"})
     orch._run_agent = MagicMock(return_value=result)
     orch._runtime_environment_gate = MagicMock(return_value="")
-    orch._build_test_execution_context = MagicMock(return_value=None)
+    orch._build_test_execution_context = MagicMock(return_value=("", []))
     orch._project_runtime_contract = MagicMock(return_value="")
     orch._artifact_visible_text = MagicMock(return_value=text)
     orch._artifact_text = MagicMock(return_value=text)

--- a/tests/unit/test_autonomous_ci_guardrails.py
+++ b/tests/unit/test_autonomous_ci_guardrails.py
@@ -2005,7 +2005,7 @@ def test_nonstandard_report_with_real_test_evidence_does_not_retry():
     orch._workflow_id = "wf-1897"
     orch.repo = MagicMock()
     orch._create_milestone = MagicMock(return_value={"milestone_id": "ms-test"})
-    orch._build_test_execution_context = MagicMock(return_value="targeted")
+    orch._build_test_execution_context = MagicMock(return_value=("targeted", []))
     orch._accumulate_tokens = MagicMock()
     orch._post_github_comment = MagicMock()
     orch._emit = MagicMock()
@@ -2064,7 +2064,7 @@ def test_test_tool_call_without_result_is_inconclusive():
     orch._workflow_id = "wf-inconclusive"
     orch.repo = MagicMock()
     orch._create_milestone = MagicMock(return_value={"milestone_id": "ms-test"})
-    orch._build_test_execution_context = MagicMock(return_value="targeted")
+    orch._build_test_execution_context = MagicMock(return_value=("targeted", []))
     orch._accumulate_tokens = MagicMock()
     orch._post_github_comment = MagicMock()
     orch._emit = MagicMock()
@@ -2096,7 +2096,7 @@ def test_model_pass_summary_without_tool_result_is_inconclusive():
     orch._workflow_id = "wf-model-summary"
     orch.repo = MagicMock()
     orch._create_milestone = MagicMock(return_value={"milestone_id": "ms-test"})
-    orch._build_test_execution_context = MagicMock(return_value="targeted")
+    orch._build_test_execution_context = MagicMock(return_value=("targeted", []))
     orch._accumulate_tokens = MagicMock()
     orch._post_github_comment = MagicMock()
     orch._emit = MagicMock()
@@ -2125,7 +2125,7 @@ def test_text_pass_evidence_fallback_when_tool_result_missing():
     orch._workflow_id = "wf-1830-fallback"
     orch.repo = MagicMock()
     orch._create_milestone = MagicMock(return_value={"milestone_id": "ms-test"})
-    orch._build_test_execution_context = MagicMock(return_value="targeted")
+    orch._build_test_execution_context = MagicMock(return_value=("targeted", []))
     orch._accumulate_tokens = MagicMock()
     orch._post_github_comment = MagicMock()
     orch._emit = MagicMock()

--- a/tests/unit/test_test_evidence_requirer.py
+++ b/tests/unit/test_test_evidence_requirer.py
@@ -24,6 +24,7 @@ from app.modules.workspace.autonomous.command_evidence.test_evidence import (
 from app.modules.workspace.autonomous.command_evidence.types import ExecutionVerdict
 from app.modules.workspace.autonomous.models import AgentTaskResult
 from app.modules.workspace.autonomous.orchestrator import (
+    MAX_TEST_RETRIES,
     AutonomousOrchestrator,
     _evidence_domains_covered,
     _required_evidence_domains,
@@ -268,17 +269,31 @@ def _orchestrator(wf):
         return orch
 
 
-def _drive_test_phase(orch, wf, *, structured, changed_files, mode, monkeypatch):
+def _drive_test_phase(
+    orch,
+    wf,
+    *,
+    structured,
+    changed_files,
+    mode,
+    monkeypatch,
+    session_success=True,
+    response_text="243 passed in 3.0s",
+):
     """Drive ``_run_test_phase`` end-to-end with a scripted structured verdict,
     changed files, and a requirer mode; return the ``_update_workflow`` patches so
     the caller can assert the route taken. Mirrors the proven harness in
-    tests/issues/2376/test_gate_flags.py (which is collect-only in CI)."""
+    tests/issues/2376/test_gate_flags.py (which is collect-only in CI).
+
+    ``session_success`` / ``response_text`` let a caller drive the agent-session
+    failure (Situation A) and the ``[UNFIXABLE]`` report (Situation B), which the
+    enforce guard must not preempt."""
     monkeypatch.setenv("OPENACE_TEST_EVIDENCE_REQUIRER_MODE", mode)
     result = AgentTaskResult(
         session_id="sess",
-        response_text="243 passed in 3.0s",
-        visible_response_text="243 passed in 3.0s",
-        success=True,
+        response_text=response_text,
+        visible_response_text=response_text,
+        success=session_success,
         tool_calls=[{"tool": {"name": "Bash", "input": {"command": "python -m pytest tests/ -q"}}}],
     )
     patches: list[dict] = []
@@ -388,3 +403,94 @@ class TestEnforceControlFlow:
         # Both domains covered → no missing → proceeds even under enforce.
         assert any(patch_.get("current_phase") == "pr_review" for patch_ in patches), patches
         assert not any(patch_.get("test_retries") == 1 for patch_ in patches)
+
+    @staticmethod
+    def _requirer_status_posted(orch) -> bool:
+        """True if any posted issue comment carried the requirer's retry line."""
+        for call in orch._post_github_comment.call_args_list:
+            body = call.args[2] if len(call.args) > 2 else call.kwargs.get("body", "")
+            if "no passing evidence for it" in str(body):
+                return True
+        return False
+
+    def test_enforce_does_not_preempt_agent_session_failure(self, tmp_path, monkeypatch):
+        # PR-review F1 guard gap: a PASSED structured verdict can coexist with a
+        # FAILED agent session (pytest ran + was recorded, then the session timed
+        # out). With a missing domain under enforce, the requirer must NOT preempt
+        # Situation A's agent-failure retry. Mutation check: dropping
+        # ``test_result.success`` from the guard fires the requirer instead, which
+        # this test's silence assertion catches.
+        tree = _js_repo(tmp_path)
+        wf = _workflow(worktree_path=tree, project_path=tree)
+        orch = _orchestrator(wf)
+        patches = _drive_test_phase(
+            orch,
+            wf,
+            structured=(ExecutionVerdict.PASSED, [_ev("python", ExecutionVerdict.PASSED)], "ok"),
+            changed_files=["app/x.py", "frontend/src/a.tsx"],
+            mode="enforce",
+            monkeypatch=monkeypatch,
+            session_success=False,
+            response_text="fatal: agent session terminated",
+        )
+        assert any(patch_.get("test_retries") == 1 for patch_ in patches), patches
+        assert not self._requirer_status_posted(orch)
+        assert not any(patch_.get("current_phase") == "pr_review" for patch_ in patches)
+
+    def test_enforce_does_not_preempt_an_unfixable_report(self, tmp_path, monkeypatch):
+        # PR-review F1 guard gap: a PASSED structured verdict + an [UNFIXABLE]
+        # report must take Situation B's dev-round retry, not the requirer's test
+        # retry — different counter, and [UNFIXABLE] means "return to development",
+        # which a test rerun cannot satisfy. Mutation check: dropping
+        # ``not has_unfixable`` from the guard fires the requirer (test_retries)
+        # instead of the dev round.
+        tree = _js_repo(tmp_path)
+        wf = _workflow(worktree_path=tree, project_path=tree)
+        orch = _orchestrator(wf)
+        patches = _drive_test_phase(
+            orch,
+            wf,
+            structured=(ExecutionVerdict.PASSED, [_ev("python", ExecutionVerdict.PASSED)], "ok"),
+            changed_files=["app/x.py", "frontend/src/a.tsx"],
+            mode="enforce",
+            monkeypatch=monkeypatch,
+            response_text="243 passed, but the flaky harness is [UNFIXABLE]",
+        )
+        assert any(patch_.get("dev_round") == wf["dev_round"] + 1 for patch_ in patches), patches
+        assert not any(patch_.get("test_retries") == 1 for patch_ in patches)
+        assert not self._requirer_status_posted(orch)
+
+    def test_enforce_exhaustion_fails_the_workflow(self, tmp_path, monkeypatch):
+        # After MAX_TEST_RETRIES the requirer stops retrying and fails the run,
+        # mirroring the inconclusive path's cap.
+        tree = _js_repo(tmp_path)
+        wf = _workflow(worktree_path=tree, project_path=tree, test_retries=MAX_TEST_RETRIES)
+        orch = _orchestrator(wf)
+        patches = _drive_test_phase(
+            orch,
+            wf,
+            structured=(ExecutionVerdict.PASSED, [_ev("python", ExecutionVerdict.PASSED)], "ok"),
+            changed_files=["app/x.py", "frontend/src/a.tsx"],
+            mode="enforce",
+            monkeypatch=monkeypatch,
+        )
+        assert any(patch_.get("status") == "failed" for patch_ in patches), patches
+        assert not any(patch_.get("current_phase") == "pr_review" for patch_ in patches)
+
+    def test_enforce_is_suppressed_on_an_inconclusive_run(self, tmp_path, monkeypatch):
+        # A missing domain on an INCONCLUSIVE run takes the inconclusive retry, not
+        # the requirer branch (the guard's ``not test_result_inconclusive``).
+        tree = _js_repo(tmp_path)
+        wf = _workflow(worktree_path=tree, project_path=tree)
+        orch = _orchestrator(wf)
+        patches = _drive_test_phase(
+            orch,
+            wf,
+            structured=(ExecutionVerdict.INCONCLUSIVE, [], "inconclusive"),
+            changed_files=["app/x.py", "frontend/src/a.tsx"],
+            mode="enforce",
+            monkeypatch=monkeypatch,
+            response_text="a test command ran but produced no parseable result",
+        )
+        assert any(patch_.get("test_retries") == 1 for patch_ in patches), patches
+        assert not self._requirer_status_posted(orch)

--- a/tests/unit/test_test_evidence_requirer.py
+++ b/tests/unit/test_test_evidence_requirer.py
@@ -1,0 +1,390 @@
+"""Requirer semantics for the test-evidence gate (#2391).
+
+The gate is a *recognizer*: recognized test commands must pass, but a changed
+domain with no evidence is not required to have any — an app+frontend PR passes
+on pytest alone. #2391 adds a *requirer*: derive required evidence domains from
+changed paths (independent of the recognizer), and — under enforce mode — fail
+closed when a required domain has no passing evidence. Ships shadow-first, so on
+merge it is a no-op (emits an observability event only).
+
+Pure-function coverage here; the gate wiring is exercised at method level.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.modules.workspace.autonomous.command_evidence.test_evidence import (
+    ParserConfidence,
+    TestExecutionEvidence,
+)
+from app.modules.workspace.autonomous.command_evidence.types import ExecutionVerdict
+from app.modules.workspace.autonomous.models import AgentTaskResult
+from app.modules.workspace.autonomous.orchestrator import (
+    AutonomousOrchestrator,
+    _evidence_domains_covered,
+    _required_evidence_domains,
+    _test_evidence_requirer_mode,
+)
+
+pytestmark = [pytest.mark.regression, pytest.mark.issue(2391)]
+
+_STRUCTURED = (
+    "app.modules.workspace.autonomous.orchestrator."
+    "AutonomousOrchestrator._compute_structured_test_verdict"
+)
+_PASSING_TOOL = "app.modules.workspace.autonomous.orchestrator._has_passing_test_tool_result"
+
+
+@pytest.fixture
+def full_tree(tmp_path):
+    """A tree where BOTH the python and js suites exist, so suite-exists never
+    discards a domain — isolates the path→domain rules."""
+    (tmp_path / "pytest.ini").write_text("[pytest]\n")
+    frontend = tmp_path / "frontend"
+    frontend.mkdir()
+    (frontend / "package.json").write_text(json.dumps({"scripts": {"test": "vitest"}}))
+    return str(tmp_path)
+
+
+class TestRequiredEvidenceDomains:
+    @pytest.mark.parametrize(
+        "changed,expected",
+        [
+            (["app/x.py"], {"python"}),
+            (["backend/y.py"], {"python"}),
+            (["tests/unit/z.py"], {"python"}),
+            (["frontend/src/a.tsx"], {"javascript"}),
+            (["frontend/src/a.ts"], {"javascript"}),
+            (["app/x.py", "frontend/src/a.tsx"], {"python", "javascript"}),
+            # docs-only → nothing
+            (["README.md", "docs/guide.md"], set()),
+            (["app/x.py", "app/y.md"], {"python"}),  # not docs-ONLY
+            # C4 traps that must NOT misfire:
+            (["frontend/src/migration_wizard.tsx"], {"javascript"}),  # not python
+            (["frontend/README.md"], set()),  # doc under frontend
+            # de-scopes (F6): shell, e2e, migrations, .ts outside frontend, config
+            (["scripts/deploy.sh"], set()),
+            (["tests/e2e/test_flow.py"], set()),
+            (["migrations/0001_init.py"], set()),
+            (["src/app.ts"], set()),  # .ts outside frontend/
+            (["package-lock.json"], set()),
+            (["docs/cn/x.rst"], set()),
+        ],
+    )
+    def test_domain_derivation(self, changed, expected, full_tree):
+        assert _required_evidence_domains(changed, full_tree) == expected
+
+    def test_suite_absent_python_is_not_required(self, tmp_path):
+        # No pytest.ini / tests dir / pyproject pytest config → python not required
+        # even though a .py changed (never hard-fail a repo with no suite).
+        (tmp_path / "frontend").mkdir()
+        (tmp_path / "frontend" / "package.json").write_text(json.dumps({"scripts": {"test": "v"}}))
+        assert _required_evidence_domains(["app/x.py"], str(tmp_path)) == set()
+
+    def test_suite_absent_js_is_not_required(self, tmp_path):
+        (tmp_path / "pytest.ini").write_text("[pytest]\n")
+        assert _required_evidence_domains(["frontend/src/a.tsx"], str(tmp_path)) == set()
+
+    def test_empty_changed_files_requires_nothing(self, full_tree):
+        # Fail-open on no/unavailable changed files (F4).
+        assert _required_evidence_domains([], full_tree) == set()
+        assert _required_evidence_domains(None, full_tree) == set()
+
+
+def _ev(framework, verdict, confidence=ParserConfidence.HIGH):
+    return TestExecutionEvidence(
+        command_id="c",
+        framework=framework,
+        verdict=verdict.value if hasattr(verdict, "value") else verdict,
+        parser_confidence=confidence.value,
+    )
+
+
+class TestEvidenceDomainsCovered:
+    def test_passing_python_and_js_cover_their_domains(self):
+        evs = [
+            _ev("python", ExecutionVerdict.PASSED),
+            _ev("javascript", ExecutionVerdict.PASSED),
+        ]
+        assert _evidence_domains_covered(evs) == {"python", "javascript"}
+
+    def test_generic_covers_nothing(self):
+        # F2: a wrapper-invoked run parses as generic → maps to no domain.
+        assert _evidence_domains_covered([_ev("generic", ExecutionVerdict.PASSED)]) == set()
+
+    def test_failed_or_low_confidence_does_not_cover(self):
+        assert _evidence_domains_covered([_ev("python", ExecutionVerdict.FAILED)]) == set()
+        assert (
+            _evidence_domains_covered(
+                [_ev("python", ExecutionVerdict.PASSED, ParserConfidence.LOW)]
+            )
+            == set()
+        )
+
+    def test_empty_evidences(self):
+        assert _evidence_domains_covered([]) == set()
+        assert _evidence_domains_covered(None) == set()
+
+
+class TestRequirerMode:
+    def test_default_is_shadow(self, monkeypatch):
+        monkeypatch.delenv("OPENACE_TEST_EVIDENCE_REQUIRER_MODE", raising=False)
+        assert _test_evidence_requirer_mode() == "shadow"
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            ("off", "off"),
+            ("shadow", "shadow"),
+            ("enforce", "enforce"),
+            ("ENFORCE", "enforce"),
+            (" off ", "off"),
+            ("bogus", "shadow"),
+            ("", "shadow"),
+        ],
+    )
+    def test_mode_parsing(self, monkeypatch, value, expected):
+        monkeypatch.setenv("OPENACE_TEST_EVIDENCE_REQUIRER_MODE", value)
+        assert _test_evidence_requirer_mode() == expected
+
+
+class TestApplyRequirer:
+    """The gate-facing method: computes (mode, missing) and emits the shadow event."""
+
+    def _orch(self):
+        orch = AutonomousOrchestrator.__new__(AutonomousOrchestrator)
+        orch._workflow_id = "wf"
+        orch.repo = MagicMock()
+        return orch
+
+    def test_enforce_flags_missing_frontend_on_a_passed_python_run(self, full_tree, monkeypatch):
+        # The #2391 primary case (review F1): the run PASSED on python evidence,
+        # frontend changed but was never verified → missing={javascript}. This is
+        # exactly the run that flows straight to pr_review today.
+        monkeypatch.setenv("OPENACE_TEST_EVIDENCE_REQUIRER_MODE", "enforce")
+        orch = self._orch()
+        mode, missing = orch._apply_test_evidence_requirer(
+            "ms1",
+            ["app/x.py", "frontend/src/a.tsx"],
+            full_tree,
+            [_ev("python", ExecutionVerdict.PASSED)],
+        )
+        assert mode == "enforce"
+        assert missing == {"javascript"}
+
+    def test_shadow_emits_the_event_and_still_reports_missing(self, full_tree, monkeypatch):
+        monkeypatch.setenv("OPENACE_TEST_EVIDENCE_REQUIRER_MODE", "shadow")
+        orch = self._orch()
+        mode, missing = orch._apply_test_evidence_requirer(
+            "ms1",
+            ["app/x.py", "frontend/src/a.tsx"],
+            full_tree,
+            [_ev("python", ExecutionVerdict.PASSED)],
+        )
+        assert mode == "shadow"
+        assert missing == {"javascript"}
+        orch.repo.create_event.assert_called_once()
+        event = orch.repo.create_event.call_args[0][0]
+        assert event["event_type"] == "test_evidence_requirer_shadow"
+        payload = json.loads(event["event_data"])
+        assert payload["mode"] == "shadow"
+        assert set(payload["required"]) == {"python", "javascript"}
+        assert payload["covered"] == ["python"]
+        assert payload["missing"] == ["javascript"]
+        assert payload["changed_files"] == ["app/x.py", "frontend/src/a.tsx"]
+        # per-evidence framework/confidence carried for F2/F3 triage
+        assert payload["evidences"][0]["framework"] == "python"
+
+    def test_covered_domain_yields_no_missing(self, full_tree, monkeypatch):
+        monkeypatch.setenv("OPENACE_TEST_EVIDENCE_REQUIRER_MODE", "enforce")
+        orch = self._orch()
+        mode, missing = orch._apply_test_evidence_requirer(
+            "ms1",
+            ["app/x.py", "frontend/src/a.tsx"],
+            full_tree,
+            [_ev("python", ExecutionVerdict.PASSED), _ev("javascript", ExecutionVerdict.PASSED)],
+        )
+        assert missing == set()
+
+    def test_off_mode_computes_and_emits_nothing(self, full_tree, monkeypatch):
+        monkeypatch.setenv("OPENACE_TEST_EVIDENCE_REQUIRER_MODE", "off")
+        orch = self._orch()
+        mode, missing = orch._apply_test_evidence_requirer(
+            "ms1", ["frontend/src/a.tsx"], full_tree, []
+        )
+        assert mode == "off"
+        assert missing == set()
+        orch.repo.create_event.assert_not_called()
+
+    def test_never_raises_and_never_fabricates_missing_on_error(self, monkeypatch):
+        # Fail-open: an event-emit failure must not raise, and a tree with no
+        # suite requires nothing (so missing stays empty), never blocking a run.
+        monkeypatch.setenv("OPENACE_TEST_EVIDENCE_REQUIRER_MODE", "enforce")
+        orch = self._orch()
+        orch.repo.create_event.side_effect = RuntimeError("db down")
+        mode, missing = orch._apply_test_evidence_requirer(
+            "ms1", ["frontend/src/a.tsx"], "/does/not/exist", []
+        )
+        assert mode == "enforce"
+        assert missing == set()
+
+
+def _js_repo(tmp_path):
+    (tmp_path / "frontend").mkdir()
+    (tmp_path / "frontend" / "package.json").write_text('{"scripts": {"test": "vitest"}}')
+    (tmp_path / "pytest.ini").write_text("[pytest]\n")
+    return str(tmp_path)
+
+
+def _orchestrator(wf):
+    from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+    with (
+        patch("app.modules.workspace.autonomous.orchestrator.Database"),
+        patch(
+            "app.modules.workspace.autonomous.orchestrator.AutonomousWorkflowRepository"
+        ) as repo_cls,
+    ):
+        repo = MagicMock()
+        repo.get_workflow.return_value = wf
+        repo.list_milestones.return_value = []
+        repo.create_milestone.return_value = {
+            "milestone_id": "ms-1",
+            "workflow_id": wf["workflow_id"],
+        }
+        repo.update_workflow.return_value = wf
+        repo.update_milestone.return_value = {}
+        repo.create_event.return_value = {"id": 1}
+        repo_cls.return_value = repo
+        orch = AutonomousOrchestrator(wf["workflow_id"])
+        orch.repo = repo
+        orch.emitter = MagicMock()
+        orch._gh = MagicMock()
+        orch._gh.has_uncommitted_changes.return_value = False
+        return orch
+
+
+def _drive_test_phase(orch, wf, *, structured, changed_files, mode, monkeypatch):
+    """Drive ``_run_test_phase`` end-to-end with a scripted structured verdict,
+    changed files, and a requirer mode; return the ``_update_workflow`` patches so
+    the caller can assert the route taken. Mirrors the proven harness in
+    tests/issues/2376/test_gate_flags.py (which is collect-only in CI)."""
+    monkeypatch.setenv("OPENACE_TEST_EVIDENCE_REQUIRER_MODE", mode)
+    result = AgentTaskResult(
+        session_id="sess",
+        response_text="243 passed in 3.0s",
+        visible_response_text="243 passed in 3.0s",
+        success=True,
+        tool_calls=[{"tool": {"name": "Bash", "input": {"command": "python -m pytest tests/ -q"}}}],
+    )
+    patches: list[dict] = []
+    orch._update_workflow = lambda p: patches.append(p)
+    orch._post_github_comment = MagicMock()
+    orch._create_milestone = MagicMock(return_value={"milestone_id": "ms-1"})
+    orch._find_or_create_milestone = MagicMock(return_value={"milestone_id": "ms-1"})
+    orch._run_agent = MagicMock(return_value=result)
+    orch._runtime_environment_gate = MagicMock(return_value="")
+    orch._build_test_execution_context = MagicMock(return_value=("", changed_files))
+    orch._project_runtime_contract = MagicMock(return_value="")
+    orch._artifact_visible_text = MagicMock(return_value=result.response_text)
+    orch._artifact_text = MagicMock(return_value=result.response_text)
+    orch._shadow_compare_evidence = MagicMock()
+    orch._emit_structured_test_fallback = MagicMock()
+    orch._validate_test_report_format = MagicMock(return_value=(True, ""))
+    with (
+        patch(_STRUCTURED, return_value=structured),
+        patch(_PASSING_TOOL, return_value=False),
+    ):
+        orch._run_test_phase(wf, 1, orch._gh)
+    return patches
+
+
+def _workflow(**overrides):
+    base = {
+        "workflow_id": "wf-2391",
+        "user_id": 1,
+        "title": "T",
+        "status": "developing",
+        "requirements_text": "r",
+        "project_path": "/tmp/p",
+        "worktree_path": "/tmp/p",
+        "workspace_type": "local",
+        "cli_tool": "claude-code",
+        "branch_name": "auto-dev/x",
+        "branch_strategy": "new-branch",
+        "current_phase": "development",
+        "dev_round": 1,
+        "current_round": 1,
+        "github_issue_number": 4321,
+        "test_retries": 0,
+        "skip_retries": 0,
+        "dev_retries_on_test_fail": 0,
+        "error_message": "",
+    }
+    base.update(overrides)
+    return base
+
+
+class TestEnforceControlFlow:
+    """End-to-end: the enforce branch intercepts the otherwise-proceeding PASSED
+    path — the #2391 review F1 case that flows straight to pr_review today."""
+
+    def test_enforce_retries_a_passed_run_missing_a_changed_domain(self, tmp_path, monkeypatch):
+        tree = _js_repo(tmp_path)
+        wf = _workflow(worktree_path=tree, project_path=tree)
+        orch = _orchestrator(wf)
+        patches = _drive_test_phase(
+            orch,
+            wf,
+            structured=(ExecutionVerdict.PASSED, [_ev("python", ExecutionVerdict.PASSED)], "ok"),
+            changed_files=["app/x.py", "frontend/src/a.tsx"],
+            mode="enforce",
+            monkeypatch=monkeypatch,
+        )
+        # The enforce branch increments test_retries to 1 and returns; a proceeding
+        # run instead RESETS test_retries to 0 on its way to pr_review.
+        assert any(patch_.get("test_retries") == 1 for patch_ in patches), patches
+        assert not any(patch_.get("current_phase") == "pr_review" for patch_ in patches)
+
+    def test_shadow_does_not_gate_the_same_run(self, tmp_path, monkeypatch):
+        tree = _js_repo(tmp_path)
+        wf = _workflow(worktree_path=tree, project_path=tree)
+        orch = _orchestrator(wf)
+        patches = _drive_test_phase(
+            orch,
+            wf,
+            structured=(ExecutionVerdict.PASSED, [_ev("python", ExecutionVerdict.PASSED)], "ok"),
+            changed_files=["app/x.py", "frontend/src/a.tsx"],
+            mode="shadow",
+            monkeypatch=monkeypatch,
+        )
+        # Default shadow mode is a gate no-op: the run proceeds to pr_review.
+        assert any(patch_.get("current_phase") == "pr_review" for patch_ in patches), patches
+        assert not any(patch_.get("test_retries") == 1 for patch_ in patches)
+
+    def test_enforce_does_not_gate_when_the_domain_is_covered(self, tmp_path, monkeypatch):
+        tree = _js_repo(tmp_path)
+        wf = _workflow(worktree_path=tree, project_path=tree)
+        orch = _orchestrator(wf)
+        patches = _drive_test_phase(
+            orch,
+            wf,
+            structured=(
+                ExecutionVerdict.PASSED,
+                [
+                    _ev("python", ExecutionVerdict.PASSED),
+                    _ev("javascript", ExecutionVerdict.PASSED),
+                ],
+                "ok",
+            ),
+            changed_files=["app/x.py", "frontend/src/a.tsx"],
+            mode="enforce",
+            monkeypatch=monkeypatch,
+        )
+        # Both domains covered → no missing → proceeds even under enforce.
+        assert any(patch_.get("current_phase") == "pr_review" for patch_ in patches), patches
+        assert not any(patch_.get("test_retries") == 1 for patch_ in patches)


### PR DESCRIPTION
## Summary

The test-evidence gate is a **recognizer** only: recognized test commands must
pass, but a **changed domain with no evidence is not required to have any** — a PR
touching `app/**.py` + `frontend/**.tsx` satisfies the gate on pytest alone,
leaving the frontend unverified. This adds *requirer* semantics on a path
**independent of the recognizer** (it never touches `_has_test_tool_call`), as
#2391 requires.

Closes #2391.

Third and final follow-up from #2376 (after #2401 + #2390 in #2454). Per #2391's
own mandate, this behavior change is **reviewed and shipped separately** and
**shadow-first** — on merge it is a **gate no-op** (emits an observability event
only); enforcement is a later flag flip.

### What it does

- **`_required_evidence_domains(changed_files, tree_path)`** — precise path rules
  (`*.py` under `app`/`backend`/`tests` → `python`; a `frontend/**` code file →
  `javascript`), a **docs-only veto**, and a **suite-exists gate** so a repo with
  no such suite is never required (never hard-fails). `migrations/`,
  `*.sh`/`scripts/**`, `tests/e2e/`, and a `.ts` outside `frontend/` are
  deliberately de-scoped (fail-open).
- **`_evidence_domains_covered(structured_evidences)`** — domains with an
  authoritative PASSED evidence; a `generic`-framework run maps to **no** domain,
  so a wrapper-invoked run cannot vacuously cover one.
- **`_apply_test_evidence_requirer`** — computes `(mode, missing)` and emits a
  `test_evidence_requirer_shadow` event carrying `required`/`covered`/`missing` +
  per-evidence `framework`/`confidence` + both scope axes (for triage before
  enforce). **Fail-open**: any compute error → empty `missing`; the emit is
  separately guarded so a DB error cannot raise into the gate.
- **Gate wiring** — a dedicated **enforce branch** that OVERRIDES the PASSED
  path. This was the plan review's blocking finding (F1): the primary case flows
  straight to `pr_review` today because a PASSED verdict sets
  `structured_authoritative` and skips the retry branch. The branch mirrors the
  inconclusive retry (milestone-fail + `test_retries++`, capped by
  `MAX_TEST_RETRIES`), guarded to exclude inconclusive/skipped runs, plus a
  truthful `status_line` arm. `_build_test_execution_context` now returns the
  changed files it already fetched (single fetch — no second `git diff`).

### Rollout

`OPENACE_TEST_EVIDENCE_REQUIRER_MODE` ∈ `{off, shadow, enforce}`, default
**`shadow`** (env-flag precedent: `OPENACE_MODEL_GATEWAY_MODE`). Enforce is a
later tiny flag-flip PR, once shadow data on real workflows clears the documented
blockers: the **generic-framework covered misfire** (wrapper-invoked
`make test`/`tox`) and the **required(commit-diff)-vs-covered(milestone) scope
mismatch**.

## Fail-closed / open posture

`shadow` default = **zero** gate behavior change on merge. `enforce` is
fail-**closed** for a *detected* missing domain (forces the existing retry), but
fail-**open** when changed-files are unavailable or the requirer errors (never
blocks a run on its own failure). No path can promote a failing run to PASSED.

## Tests (`tests/unit/`, mutation-verified)

- domain derivation incl. the C4 traps (`frontend/src/migration_wizard.tsx` →
  `{javascript}` not python; `frontend/README.md` → ∅; `.ts` outside frontend →
  ∅); covered mapping incl. `generic→∅`; mode parsing; the compute/shadow-emit
  method; and **end-to-end enforce control flow** — enforce retries a
  PASSED-but-missing run (the F1 case), while shadow/covered proceed to
  `pr_review`.
- Each fix mutation-checked (force `missing` empty → detection tests fail;
  disable the enforce branch → the F1 e2e test fails).
- Full `python-core` A/B vs `origin/main`: **byte-identical failure sets — zero
  new failures** (the 17 pre-existing failures are in unrelated modules and fail
  identically on clean main). Adapted the three existing tests that call/mock
  `_build_test_execution_context` to its new tuple return.

New tests live in `tests/unit/` (post-#2455 convention: `tests/issues/` is a
collect-only quarantine), so they gate every PR via `python-core` — no `ci.yml`
edit needed.

## Independent plan review (class-2 gate)

Two rounds, verified against source:

- **Round 1 → APPROVE WITH CHANGES.** Blocking **F1**: "reuse the existing
  inconclusive retry" was wrong — a PASSED verdict flows *past* it to pr_review;
  the enforce path needs a dedicated branch overriding the PASSED path. Plus F2
  (generic-covered misfire), F3 (scope-axis mismatch), F4 (fail-open on
  fetch-failure, not fail-closed), F6–F10.
- **Round 2 → APPROVE.** All F1–F10 resolved; N1 (status_line arm), N2 (single
  fetch), N3 (worktree-preferred `tree_path`) folded in.
