### PR TITLE
ci: schedule quality workflows in Singapore time

### DIFF
--- a/.github/workflows/extended-tests.yml
+++ b/.github/workflows/extended-tests.yml
@@ -5,8 +5,9 @@ on:
     branches: [main, master]
     types: [opened, synchronize, reopened, labeled]
   schedule:
-    # Nightly full coverage; expensive cross-browser/performance checks are weekly.
-    - cron: '0 2 * * *'
+    # Daily at 01:18 Singapore time; expensive cross-browser/performance checks are weekly.
+    - cron: '18 1 * * *'
+      timezone: 'Asia/Singapore'
   workflow_dispatch:
     inputs:
       category:

--- a/.github/workflows/weekly-quality.yml
+++ b/.github/workflows/weekly-quality.yml
@@ -2,7 +2,9 @@ name: Weekly Quality
 
 on:
   schedule:
-    - cron: '0 4 * * 0'
+    # Saturday at 03:18 Singapore time.
+    - cron: '18 3 * * 6'
+      timezone: 'Asia/Singapore'
   workflow_dispatch:
 
 permissions:

--- a/tests/unit/test_scheduled_workflow_contracts.py
+++ b/tests/unit/test_scheduled_workflow_contracts.py
@@ -1,0 +1,25 @@
+"""Contracts for the repository's scheduled quality workflows."""
+
+from pathlib import Path
+
+import yaml
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _schedules(workflow_name):
+    workflow = PROJECT_ROOT / ".github" / "workflows" / workflow_name
+    data = yaml.load(workflow.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+    return data["on"]["schedule"]
+
+
+def test_nightly_runs_at_0118_singapore_time():
+    assert _schedules("extended-tests.yml") == [
+        {"cron": "18 1 * * *", "timezone": "Asia/Singapore"}
+    ]
+
+
+def test_weekly_runs_on_saturday_at_0318_singapore_time():
+    assert _schedules("weekly-quality.yml") == [
+        {"cron": "18 3 * * 6", "timezone": "Asia/Singapore"}
+    ]


### PR DESCRIPTION
## Summary

- run Nightly Extended Tests every day at 01:18 in `Asia/Singapore`
- run Weekly Quality every Saturday at 03:18 in `Asia/Singapore`
- use GitHub Actions' timezone-aware schedule syntax instead of manually converted UTC
- add unit contracts that pin both cron expressions and their IANA timezone

## Why

The previous schedules ran at the top of the UTC hour, where GitHub Actions is more likely to queue scheduled workflows. The requested Singapore-local times also deserve an explicit timezone in the workflow so future maintainers do not need to reverse-convert UTC.

## Validation

- `python3 -m pytest tests/unit/test_scheduled_workflow_contracts.py tests/unit/test_ci_runner.py -q` — 18 passed
- `pre-commit run --files .github/workflows/extended-tests.yml .github/workflows/weekly-quality.yml tests/unit/test_scheduled_workflow_contracts.py` — passed
- `git diff --check` — passed

Refs #2429