### PR TITLE
feat(ci): legacy issue failure baseline (Refs #2457)

### DIFF
--- a/.github/workflows/extended-tests.yml
+++ b/.github/workflows/extended-tests.yml
@@ -388,6 +388,7 @@ jobs:
           python scripts/legacy_issue_baseline.py compare \
             --baseline ci/legacy-issue-failures.json \
             --junit "artifacts/test-results/issues-*.xml" \
+            --exit-code-glob "artifacts/test-results/issues-*.exit-code" \
             --test-baseline .test-baseline.json \
             --json-output test-results/legacy-issue-diff.json \
             --markdown-output test-results/legacy-issue-summary.md

--- a/.github/workflows/extended-tests.yml
+++ b/.github/workflows/extended-tests.yml
@@ -389,6 +389,7 @@ jobs:
             --baseline ci/legacy-issue-failures.json \
             --junit "artifacts/test-results/issues-*.xml" \
             --exit-code-glob "artifacts/test-results/issues-*.exit-code" \
+            --shard-count 4 \
             --test-baseline .test-baseline.json \
             --json-output test-results/legacy-issue-diff.json \
             --markdown-output test-results/legacy-issue-summary.md

--- a/.github/workflows/extended-tests.yml
+++ b/.github/workflows/extended-tests.yml
@@ -247,7 +247,12 @@ jobs:
           playwright install chromium --with-deps
 
       - name: Run issue regression shard
+        # Known legacy failures make pytest exit non-zero; keep going so the
+        # JUnit + exit code are uploaded. The authoritative verdict comes from
+        # the legacy-issue-baseline comparator job below (handoff §4.6).
+        continue-on-error: true
         run: |
+          set +e
           python scripts/run_extended_tests.py \
             --category issues \
             --issue-numbers "${{ github.event.inputs.issue_numbers || '' }}" \
@@ -257,6 +262,7 @@ jobs:
             --reruns 1 \
             --timeout 240 \
             --junitxml "test-results/issues-${{ matrix.group }}.xml"
+          echo $? > "test-results/issues-${{ matrix.group }}.exit-code"
         env:
           CI: true
           HEADLESS: true
@@ -345,17 +351,69 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
+  legacy-issue-baseline:
+    name: Legacy issue failure baseline
+    # Authoritative gate for tests/issues known-failure debt. Runs even when a
+    # shard was cancelled/timed out (it then fails closed on completeness). Runs
+    # on schedule and on workflow_dispatch category=issues|all so PR branches can
+    # verify against the baseline. Never runs on PRs (full execution is nightly).
+    if: >-
+      always() &&
+      (github.event_name == 'schedule' ||
+       (github.event_name == 'workflow_dispatch' && (inputs.category == 'issues' || inputs.category == 'all'))) &&
+      needs.issue-tests.result != 'skipped'
+    needs: [issue-tests]
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: false
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+          cache: pip
+          cache-dependency-path: requirements-ci.lock
+      - name: Install dependencies
+        run: pip install -r requirements-ci.lock
+      - name: Download all shard reports
+        uses: actions/download-artifact@v7
+        with:
+          pattern: issue-tests-*
+          merge-multiple: true
+          path: artifacts
+      - name: Compare against failure baseline
+        run: |
+          python scripts/legacy_issue_baseline.py compare \
+            --baseline ci/legacy-issue-failures.json \
+            --junit "artifacts/test-results/issues-*.xml" \
+            --test-baseline .test-baseline.json \
+            --json-output test-results/legacy-issue-diff.json \
+            --markdown-output test-results/legacy-issue-summary.md
+      - name: Upload baseline artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: legacy-issue-baseline
+          path: |
+            test-results/legacy-issue-diff.json
+            test-results/legacy-issue-summary.md
+            artifacts/
+          if-no-files-found: ignore
+          retention-days: 14
+
   nightly-summary:
     name: Nightly Quality Gate
     if: always() && github.event_name == 'schedule'
-    needs: [nightly-python, full-e2e, issue-tests]
+    needs: [nightly-python, full-e2e, issue-tests, legacy-issue-baseline]
     runs-on: ubuntu-24.04
     steps:
       - name: Publish nightly result
         env:
           PYTHON_RESULT: ${{ needs.nightly-python.result }}
           E2E_RESULT: ${{ needs.full-e2e.result }}
-          ISSUE_RESULT: ${{ needs.issue-tests.result }}
+          LEGACY_RESULT: ${{ needs.legacy-issue-baseline.result }}
         run: |
           {
             echo "## Nightly quality gate"
@@ -363,11 +421,14 @@ jobs:
             echo "|---|---|"
             echo "| Python 3.10/3.11/3.14 | $PYTHON_RESULT |"
             echo "| Full Python E2E | $E2E_RESULT |"
-            echo "| Legacy issue shards | $ISSUE_RESULT |"
+            echo "| Legacy failure baseline | $LEGACY_RESULT |"
           } >> "$GITHUB_STEP_SUMMARY"
+          # The legacy comparator is the authoritative issue-debt verdict;
+          # issue-tests itself is non-blocking (continue-on-error transports JUnit).
+          # A missing/skipped/cancelled comparator must fail the gate.
           if [ "$PYTHON_RESULT" != success ] || \
              [ "$E2E_RESULT" != success ] || \
-             [ "$ISSUE_RESULT" != success ]; then
-            echo "::error::One or more nightly quality lanes failed; inspect their artifacts."
+             [ "$LEGACY_RESULT" != success ]; then
+            echo "::error::A nightly quality lane failed or the baseline comparator did not run."
             exit 1
           fi

--- a/.github/workflows/quarantine-probe.yml
+++ b/.github/workflows/quarantine-probe.yml
@@ -1,15 +1,16 @@
 name: Quarantine Probe
 
 # Weekly subprocess-level probe of ci/legacy-issue-quarantine.json nodeids.
-# pytest-timeout cannot kill a thread deadlock, so each nodeid runs in a
-# subprocess under `timeout` (hard kill). A quarantined nodeid that now PASSES
-# fails this job — its entry must be removed/updated, so quarantine cannot drift
-# silently. A nodeid that still deadlocks or fails is expected (known debt) and
-# the job stays green.
+# pytest-timeout cannot kill a thread deadlock, so scripts/ci/legacy_quarantine_probe.py
+# runs each nodeid in a subprocess under a hard timeout. Each entry declares an
+# expected_probe_outcome (timeout/pass/fail); a mismatch (recovered or behavior
+# changed) fails this job so the entry must be removed/updated — quarantine
+# cannot drift silently. Fail-closed on any quarantine config error.
 
 on:
   schedule:
-    - cron: '17 3 * * 1'
+    - cron: '18 3 * * 6'
+      timezone: 'Asia/Singapore'
   workflow_dispatch:
 
 permissions:
@@ -31,32 +32,12 @@ jobs:
       - name: Install dependencies
         run: pip install -r requirements-ci.lock
       - name: Probe quarantined nodeids (subprocess hard kill)
-        run: |
-          set +e
-          nodeids=$(python -c "import json;print('\n'.join(e['nodeid'] for e in json.load(open('ci/legacy-issue-quarantine.json'))['entries']))")
-          if [ -z "$nodeids" ]; then echo "No quarantined nodeids."; exit 0; fi
-          passed=0
-          while IFS= read -r nodeid; do
-            [ -z "$nodeid" ] && continue
-            echo "::group::probe: $nodeid"
-            timeout 180 python -m pytest "$nodeid" -m "not postgres" -p no:cacheprovider -q
-            rc=$?
-            if [ "$rc" -eq 0 ]; then
-              echo "::error::Quarantined nodeid PASSED — remove it from ci/legacy-issue-quarantine.json: $nodeid"
-              passed=1
-            elif [ "$rc" -eq 124 ]; then
-              echo "::notice::Still deadlocks (subprocess timeout) — expected quarantine debt: $nodeid"
-            else
-              echo "::notice::Still fails (exit $rc) — expected quarantine debt: $nodeid"
-            fi
-            echo "::endgroup::"
-          done <<< "$nodeids"
-          exit "$passed"
-      - name: Upload probe logs
+        run: python scripts/ci/legacy_quarantine_probe.py
+      - name: Upload probe artifacts
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: quarantine-probe
           path: test-results/
-          if-no-files-found: ignore
+          if-no-files-found: error
           retention-days: 14

--- a/.github/workflows/quarantine-probe.yml
+++ b/.github/workflows/quarantine-probe.yml
@@ -1,0 +1,62 @@
+name: Quarantine Probe
+
+# Weekly subprocess-level probe of ci/legacy-issue-quarantine.json nodeids.
+# pytest-timeout cannot kill a thread deadlock, so each nodeid runs in a
+# subprocess under `timeout` (hard kill). A quarantined nodeid that now PASSES
+# fails this job — its entry must be removed/updated, so quarantine cannot drift
+# silently. A nodeid that still deadlocks or fails is expected (known debt) and
+# the job stays green.
+
+on:
+  schedule:
+    - cron: '17 3 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  probe:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: false
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+          cache: pip
+          cache-dependency-path: requirements-ci.lock
+      - name: Install dependencies
+        run: pip install -r requirements-ci.lock
+      - name: Probe quarantined nodeids (subprocess hard kill)
+        run: |
+          set +e
+          nodeids=$(python -c "import json;print('\n'.join(e['nodeid'] for e in json.load(open('ci/legacy-issue-quarantine.json'))['entries']))")
+          if [ -z "$nodeids" ]; then echo "No quarantined nodeids."; exit 0; fi
+          passed=0
+          while IFS= read -r nodeid; do
+            [ -z "$nodeid" ] && continue
+            echo "::group::probe: $nodeid"
+            timeout 180 python -m pytest "$nodeid" -m "not postgres" -p no:cacheprovider -q
+            rc=$?
+            if [ "$rc" -eq 0 ]; then
+              echo "::error::Quarantined nodeid PASSED — remove it from ci/legacy-issue-quarantine.json: $nodeid"
+              passed=1
+            elif [ "$rc" -eq 124 ]; then
+              echo "::notice::Still deadlocks (subprocess timeout) — expected quarantine debt: $nodeid"
+            else
+              echo "::notice::Still fails (exit $rc) — expected quarantine debt: $nodeid"
+            fi
+            echo "::endgroup::"
+          done <<< "$nodeids"
+          exit "$passed"
+      - name: Upload probe logs
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: quarantine-probe
+          path: test-results/
+          if-no-files-found: ignore
+          retention-days: 14

--- a/ci/legacy-issue-failures.json
+++ b/ci/legacy-issue-failures.json
@@ -3782,7 +3782,7 @@
       "issue_number": "814",
       "nodeid": "tests/issues/814/test_worktree_path_selfheal.py::TestEnsureWorktreeSelfHeal::test_no_update_when_path_already_canonical",
       "outcome": "failure",
-      "summary": "app.modules.workspace.autonomous.github_ops.GitHubOpsError: Worktree branch mismatch (<MagicMock name='mock.get_current_branch()' id='139766050919888'> != auto-dev/1390d553) with uncommitted changes.…"
+      "summary": "app.modules.workspace.autonomous.github_ops.GitHubOpsError: Worktree branch mismatch (<MagicMock name='mock.get_current_branch()' id='140280809876752'> != auto-dev/1390d553) with uncommitted changes.…"
     },
     {
       "category": "test_body_exception",
@@ -3790,7 +3790,7 @@
       "issue_number": "814",
       "nodeid": "tests/issues/814/test_worktree_path_selfheal.py::TestEnsureWorktreeSelfHeal::test_normalizes_stale_dotdot_path_when_valid",
       "outcome": "failure",
-      "summary": "app.modules.workspace.autonomous.github_ops.GitHubOpsError: Worktree branch mismatch (<MagicMock name='mock.get_current_branch()' id='139766021823888'> != auto-dev/1390d553) with uncommitted changes.…"
+      "summary": "app.modules.workspace.autonomous.github_ops.GitHubOpsError: Worktree branch mismatch (<MagicMock name='mock.get_current_branch()' id='140280490027536'> != auto-dev/1390d553) with uncommitted changes.…"
     },
     {
       "category": "test_body_exception",
@@ -4198,7 +4198,7 @@
       "issue_number": "913",
       "nodeid": "tests/issues/913/test_pr909_review_feedback.py::TestGetCheckFailureExcerpt::test_ci_repair_context_skips_excerpt_failure",
       "outcome": "failure",
-      "summary": "assert '失败摘录' not in \"PR #42 在合并前...9645632912'>\""
+      "summary": "assert '失败摘录' not in \"PR #42 在合并前...9624972304'>\""
     },
     {
       "category": "test_body_exception",
@@ -4306,10 +4306,10 @@
     }
   ],
   "provenance": {
-    "generated_command": "python scripts/legacy_issue_baseline.py snapshot --junit /tmp/2457-artifacts/*/test-results/issues-*.xml --source-run 31347939641",
-    "reference_commit": "39fce2429b1a06e3331c8a09b11e62bf40c931e8",
-    "run_contract": "extended-tests issue-tests, --isolated-home --reruns 1 --timeout 240, 4 shards; tests/issues/604 hang skipped",
-    "source_run": "31347939641",
+    "generated_command": "python scripts/legacy_issue_baseline.py snapshot --junit /tmp/2457-r3/issue-tests-*/test-results/issues-*.xml --source-run 31349649530",
+    "reference_commit": "1de8acb17bd03da7a421dc846adbfd002e83987c",
+    "run_contract": "extended-tests issue-tests, --isolated-home --reruns 1 --timeout 240 --continue-on-collection-errors, 4 shards; tests/issues/604 hang skipped",
+    "source_run": "31349649530",
     "source_run_url": ""
   },
   "schema": "openace-legacy-issue-failures",

--- a/ci/legacy-issue-failures.json
+++ b/ci/legacy-issue-failures.json
@@ -1,0 +1,4318 @@
+{
+  "entries": [
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "1003",
+      "nodeid": "tests/issues/1003/test_session_usage_accounting.py::TestAddMessageCountUsageGate::test_autonomous_count_usage_false_leaves_counters",
+      "outcome": "failure",
+      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "1003",
+      "nodeid": "tests/issues/1003/test_session_usage_accounting.py::TestAddMessageCountUsageGate::test_legacy_count_usage_true_still_accumulates",
+      "outcome": "failure",
+      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "1003",
+      "nodeid": "tests/issues/1003/test_session_usage_accounting.py::TestIncrementSessionUsage::test_accumulates_across_calls",
+      "outcome": "failure",
+      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "1003",
+      "nodeid": "tests/issues/1003/test_session_usage_accounting.py::TestIncrementSessionUsage::test_starts_from_existing_value",
+      "outcome": "failure",
+      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "1003",
+      "nodeid": "tests/issues/1003/test_session_usage_accounting.py::TestMilestoneSessionInvariant::test_session_equals_sum_of_per_call_deltas",
+      "outcome": "failure",
+      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "1006",
+      "nodeid": "tests/issues/1006/e2e_conversation_history_default_dates.py::test_default_dates",
+      "outcome": "failure",
+      "summary": "playwright._impl._errors.TimeoutError: Locator.input_value: Timeout 30000ms exceeded."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "1071",
+      "nodeid": "tests/issues/1071/test_webui_session_id.py::TestListSessionsFilterWebui::test_webui_sessions_filtered_out",
+      "outcome": "failure",
+      "summary": "AttributeError: <module 'app.routes.workspace' from 'app/routes/workspace.py'> does not have the attribute 'Database'"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "1111",
+      "nodeid": "tests/issues/1111/test_sqlite_normalize_derived_tables.py::test_sqlite_upgrade_merges_qwen_alias_rows_before_normalization",
+      "outcome": "failure",
+      "summary": "subprocess.CalledProcessError: Command '['/opt/hostedtoolcache/Python/3.11.15/x64/bin/python', '-m', 'alembic', '-c', 'alembic.ini', 'upgrade', '017_add_usage_summary']' returned non-zero exit status…"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "1111",
+      "nodeid": "tests/issues/1111/test_sqlite_normalize_derived_tables.py::test_sqlite_upgrade_rebuilds_claude_summary_with_distinct_day_count",
+      "outcome": "failure",
+      "summary": "subprocess.CalledProcessError: Command '['/opt/hostedtoolcache/Python/3.11.15/x64/bin/python', '-m', 'alembic', '-c', 'alembic.ini', 'upgrade', '038_normalize_tool_names']' returned non-zero exit sta…"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "1125",
+      "nodeid": "tests/issues/1125/test_workspace_session_summary_contract.py::test_get_session_does_not_fallback_to_daily_messages",
+      "outcome": "failure",
+      "summary": "assert 500 == 404"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "1125",
+      "nodeid": "tests/issues/1125/test_workspace_session_summary_contract.py::test_get_session_keeps_agent_sessions_request_count",
+      "outcome": "failure",
+      "summary": "AttributeError: 'tuple' object has no attribute 'get_json'"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "1125",
+      "nodeid": "tests/issues/1125/test_workspace_session_summary_contract.py::test_list_sessions_hides_autonomous_tracking_wrappers",
+      "outcome": "failure",
+      "summary": "AssertionError: assert ['track-123',...l-claude-123'] == ['actual-claude-123']"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "1128",
+      "nodeid": "tests/issues/1128/test_session_message_transcript_contract.py::test_add_message_merges_duplicate_message_id_without_double_count",
+      "outcome": "failure",
+      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "1128",
+      "nodeid": "tests/issues/1128/test_session_message_transcript_contract.py::test_add_message_persists_structured_session_message_columns",
+      "outcome": "failure",
+      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "1128",
+      "nodeid": "tests/issues/1128/test_session_message_transcript_contract.py::test_append_transcript_message_is_summary_side_effect_free",
+      "outcome": "failure",
+      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "1128",
+      "nodeid": "tests/issues/1128/test_session_message_transcript_contract.py::test_llm_proxy_records_transcript_without_double_count",
+      "outcome": "failure",
+      "summary": "AssertionError: assert 0 == 1"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "1140",
+      "nodeid": "tests/issues/1140/test_zcode_dev_mode_and_session.py::test_session_line_updates_even_on_resume",
+      "outcome": "failure",
+      "summary": "AssertionError: _run_agent must not skip session line update on resume — see #525 where dev resumed a dead planning session forever"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "1277",
+      "nodeid": "tests/issues/1277/test_test_skip_false_positive.py::TestRetryCounterPersistence::test_skip_retries_persisted_on_test_skip",
+      "outcome": "failure",
+      "summary": "AssertionError: skip_retries=1 must be persisted when tests are skipped"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "1306",
+      "nodeid": "tests/issues/1306/test_host_url_replacement.py::test_get_user_webui_url_preserves_port_single_user",
+      "outcome": "failure",
+      "summary": "AssertionError: assert False"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "1306",
+      "nodeid": "tests/issues/1306/test_host_url_replacement.py::test_get_user_webui_url_with_host_url",
+      "outcome": "failure",
+      "summary": "AssertionError: assert False"
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "1329",
+      "nodeid": "tests/issues/1329/test_concurrent_limit.py::TestCheckUserConcurrentLimit::test_fail_open_on_exception",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: database is locked\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "1329",
+      "nodeid": "tests/issues/1329/test_concurrent_limit.py::TestCheckUserConcurrentLimit::test_returns_429_when_at_limit",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: database is locked\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "1329",
+      "nodeid": "tests/issues/1329/test_concurrent_limit.py::TestCheckUserConcurrentLimit::test_returns_none_when_under_limit",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: database is locked\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "1329",
+      "nodeid": "tests/issues/1329/test_concurrent_limit.py::TestCheckUserConcurrentLimit::test_uses_default_when_no_tenant",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: database is locked\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "1329",
+      "nodeid": "tests/issues/1329/test_concurrent_limit.py::TestCountActiveWorkflowsByUser::test_count_active_workflows_only",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: database is locked\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "1329",
+      "nodeid": "tests/issues/1329/test_concurrent_limit.py::TestCountActiveWorkflowsByUser::test_count_multiple_active_statuses",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: database is locked\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "1329",
+      "nodeid": "tests/issues/1329/test_concurrent_limit.py::TestCountActiveWorkflowsByUser::test_count_only_specific_user",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: database is locked\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "1329",
+      "nodeid": "tests/issues/1329/test_concurrent_limit.py::TestCountActiveWorkflowsByUser::test_count_zero_when_no_workflows",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: database is locked\""
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "1395",
+      "nodeid": "tests/issues/1395/test_cross_user_permissions.py::TestBuildAgentEnv::test_fallback_on_proxy_failure",
+      "outcome": "failure",
+      "summary": "RuntimeError: LLM proxy setup failed; refusing to launch autonomous agent with inherited credentials (set OPENACE_ALLOW_RAW_KEY_FALLBACK=1 only in development)."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "1395",
+      "nodeid": "tests/issues/1395/test_cross_user_permissions.py::TestPreparationWorktreeCleanup::test_clean_path_creates_worktree_directly",
+      "outcome": "failure",
+      "summary": "TypeError: Object of type MagicMock is not JSON serializable"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "1395",
+      "nodeid": "tests/issues/1395/test_cross_user_permissions.py::TestPreparationWorktreeCleanup::test_non_registered_residual_dir_left_in_place",
+      "outcome": "failure",
+      "summary": "TypeError: Object of type MagicMock is not JSON serializable"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "1395",
+      "nodeid": "tests/issues/1395/test_cross_user_permissions.py::TestPreparationWorktreeCleanup::test_registered_residual_removed_via_git",
+      "outcome": "failure",
+      "summary": "TypeError: Object of type MagicMock is not JSON serializable"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "1395",
+      "nodeid": "tests/issues/1395/test_cross_user_permissions.py::TestPreparationWorktreeCleanup::test_remove_failure_does_not_raise",
+      "outcome": "failure",
+      "summary": "TypeError: Object of type MagicMock is not JSON serializable"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "1395",
+      "nodeid": "tests/issues/1395/test_cross_user_permissions.py::TestRunAgentTaskSessionReactivation::test_completed_session_reactivated_to_active",
+      "outcome": "failure",
+      "summary": "AssertionError: assert call('sess-co..._tenant=False) == (('sess-compl...': None}), {})"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "1395",
+      "nodeid": "tests/issues/1395/test_cross_user_permissions.py::TestRunAgentTaskSessionReactivation::test_error_session_reactivated_to_active",
+      "outcome": "failure",
+      "summary": "AssertionError: assert call('sess-er..._tenant=False) == (('sess-error...': None}), {})"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "1395",
+      "nodeid": "tests/issues/1395/test_cross_user_permissions.py::TestSingleShotUserIdPropagation::test_single_shot_passes_real_user_id_to_env",
+      "outcome": "failure",
+      "summary": "TypeError: TestSingleShotUserIdPropagation.test_single_shot_passes_real_user_id_to_env.<locals>.fake_build_env() got an unexpected keyword argument 'task_id'"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "1395",
+      "nodeid": "tests/issues/1395/test_cross_user_permissions.py::test_isolated_wrapper_can_handle_signals_while_waiting_for_agent",
+      "outcome": "failure",
+      "summary": "assert 'trap cleanup_isolated EXIT' in '#!/bin/bash\\n# openace-run-as — cross-user agent launcher for AI autonomous development.\\n#\\n# Problem (Issue #1395): the open-ace service runs as the `openace…"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "1395",
+      "nodeid": "tests/issues/1395/test_cross_user_permissions.py::test_isolated_wrapper_normalizes_recovered_acls_before_git_baseline",
+      "outcome": "failure",
+      "summary": "assert 'signature_registry=\"/run/openace-agent-git-signature-${target_uid}\"' in '#!/bin/bash\\n# openace-run-as — cross-user agent launcher for AI autonomous development.\\n#\\n# Problem (Issue #1395): …"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "1395",
+      "nodeid": "tests/issues/1395/test_system_event_activity.py::TestSystemEventActivityForwarding::test_api_retry_triggers_activity",
+      "outcome": "failure",
+      "summary": "AttributeError: '_StubProcess' object has no attribute 'poll'"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "1395",
+      "nodeid": "tests/issues/1395/test_system_event_activity.py::TestSystemEventActivityForwarding::test_assistant_still_triggers_activity",
+      "outcome": "failure",
+      "summary": "AttributeError: '_StubProcess' object has no attribute 'poll'"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "1395",
+      "nodeid": "tests/issues/1395/test_system_event_activity.py::TestSystemEventActivityForwarding::test_init_triggers_activity",
+      "outcome": "failure",
+      "summary": "AttributeError: '_StubProcess' object has no attribute 'poll'"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "1395",
+      "nodeid": "tests/issues/1395/test_system_event_activity.py::TestSystemEventActivityForwarding::test_no_subtype_does_not_trigger",
+      "outcome": "failure",
+      "summary": "AttributeError: '_StubProcess' object has no attribute 'poll'"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "1395",
+      "nodeid": "tests/issues/1395/test_system_event_activity.py::TestSystemEventActivityForwarding::test_thinking_tokens_is_not_forwarded",
+      "outcome": "failure",
+      "summary": "AttributeError: '_StubProcess' object has no attribute 'poll'"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "1425",
+      "nodeid": "tests/issues/1425/test_language_sync.py::test_language_postmessage_sent",
+      "outcome": "failure",
+      "summary": "Failed: async def functions are not natively supported."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "1425",
+      "nodeid": "tests/issues/1425/test_language_sync.py::test_language_realtime_sync",
+      "outcome": "failure",
+      "summary": "Failed: async def functions are not natively supported."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "1425",
+      "nodeid": "tests/issues/1425/test_language_sync.py::test_language_url_parameter",
+      "outcome": "failure",
+      "summary": "Failed: async def functions are not natively supported."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "1425",
+      "nodeid": "tests/issues/1425/test_language_sync.py::test_language_url_parameter_update",
+      "outcome": "failure",
+      "summary": "Failed: async def functions are not natively supported."
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "144",
+      "nodeid": "tests/issues/144/e2e_file_changes_panel.py::test_panel_features",
+      "outcome": "error",
+      "summary": "failed on setup with \"AssertionError\""
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "165",
+      "nodeid": "tests/issues/165/test_remote_session_ux.py::test_a1_token_detail",
+      "outcome": "failure",
+      "summary": "AssertionError: Create session failed: 401 {\"error\":\"Authentication required\"}"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "165",
+      "nodeid": "tests/issues/165/test_remote_session_ux.py::test_a2_system_message_storage",
+      "outcome": "failure",
+      "summary": "AssertionError: Create session failed: 401 {\"error\":\"Authentication required\"}"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "165",
+      "nodeid": "tests/issues/165/test_remote_session_ux.py::test_a3_request_count_no_double_count",
+      "outcome": "failure",
+      "summary": "AssertionError: Create session failed: 401 {\"error\":\"Authentication required\"}"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "165",
+      "nodeid": "tests/issues/165/test_remote_session_ux.py::test_a4_abort_request",
+      "outcome": "failure",
+      "summary": "AssertionError: Create session failed: 401 {\"error\":\"Authentication required\"}"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "165",
+      "nodeid": "tests/issues/165/test_remote_session_ux.py::test_a5_allow_permanent",
+      "outcome": "failure",
+      "summary": "AssertionError: Create session failed: 401 {\"error\":\"Authentication required\"}"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "165",
+      "nodeid": "tests/issues/165/test_remote_session_ux.py::test_a6_quota_exceeded_detection",
+      "outcome": "failure",
+      "summary": "AssertionError: Create session failed: 401 {\"error\":\"Authentication required\"}"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "165",
+      "nodeid": "tests/issues/165/test_remote_session_ux.py::test_b1_reconnect_history",
+      "outcome": "failure",
+      "summary": "AssertionError: Create session failed: 401 {\"error\":\"Authentication required\"}"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "165",
+      "nodeid": "tests/issues/165/test_remote_session_ux.py::test_b2_abort_ui",
+      "outcome": "failure",
+      "summary": "AssertionError: Create session failed: 401 {\"error\":\"Authentication required\"}"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "165",
+      "nodeid": "tests/issues/165/test_remote_session_ux.py::test_b3_permission_permanent_ui",
+      "outcome": "failure",
+      "summary": "AssertionError: Create session failed: 401 {\"error\":\"Authentication required\"}"
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "166",
+      "nodeid": "tests/issues/166/test_launchd_env.py::test_qwen_cli",
+      "outcome": "error",
+      "summary": "failed on setup with \"file tests/issues/166/test_launchd_env.py, line 37"
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "166",
+      "nodeid": "tests/issues/166/test_stream_json_mode.py::test_stream_json_mode",
+      "outcome": "error",
+      "summary": "failed on setup with \"file tests/issues/166/test_stream_json_mode.py, line 32"
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "172",
+      "nodeid": "tests/issues/172/e2e_quota_enforcement.py::test_llm_proxy_fail_closed",
+      "outcome": "error",
+      "summary": "failed on setup with \"file tests/issues/172/e2e_quota_enforcement.py, line 209"
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "172",
+      "nodeid": "tests/issues/172/e2e_quota_enforcement.py::test_quota_check_endpoint",
+      "outcome": "error",
+      "summary": "failed on setup with \"file tests/issues/172/e2e_quota_enforcement.py, line 91"
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "172",
+      "nodeid": "tests/issues/172/e2e_quota_enforcement.py::test_quota_status_endpoint",
+      "outcome": "error",
+      "summary": "failed on setup with \"file tests/issues/172/e2e_quota_enforcement.py, line 108"
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "172",
+      "nodeid": "tests/issues/172/e2e_quota_enforcement.py::test_user_daily_stats",
+      "outcome": "error",
+      "summary": "failed on setup with \"file tests/issues/172/e2e_quota_enforcement.py, line 122"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "1760",
+      "nodeid": "tests/issues/1760/test_save_usage_tenant_and_workflow_annotation.py::test_update_agent_sessions_stats_writes_per_session_model",
+      "outcome": "failure",
+      "summary": "AttributeError: <module 'config' from 'tests/issues/610/../../../remote-agent/config.py'> has no attribute 'DB_DIR'"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "1778",
+      "nodeid": "tests/issues/1778/test_outbound_url_toctou.py::test_safe_request_disables_proxy_by_default",
+      "outcome": "failure",
+      "summary": "AssertionError: assert OrderedDict([...,127.0.0.1')]) == {}"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "1778",
+      "nodeid": "tests/issues/1778/test_outbound_url_toctou.py::test_safe_request_preserves_caller_provided_proxies",
+      "outcome": "failure",
+      "summary": "AssertionError: assert OrderedDict([...,127.0.0.1')]) == {'http': 'htt....example.com'}"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "1807",
+      "nodeid": "tests/issues/1807/test_webhook_round2_review.py::TestWebhookFailurePrefsUnbound::test_prefs_unbound_does_not_mask_real_exception",
+      "outcome": "failure",
+      "summary": "RuntimeError: db connection lost"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "1813",
+      "nodeid": "tests/issues/1813/test_pr_review_summary_before_ci.py::TestPrReviewSummaryBeforeCiCheck::test_review_content_filled_before_ci_return",
+      "outcome": "failure",
+      "summary": "AssertionError: pr_review_summary must be updated with non-empty review_content even when CI fails"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "1816",
+      "nodeid": "tests/issues/1816/test_ci_repair_context_overflow.py::test_review_fix_refuses_preexisting_dirty_tree_before_agent",
+      "outcome": "failure",
+      "summary": "AssertionError: Expected 'git_add_all' to not have been called. Called 1 times."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "1816",
+      "nodeid": "tests/issues/1816/test_ci_repair_context_overflow.py::test_stable_session_line_rebinds_once_and_preserves_usage[False]",
+      "outcome": "failure",
+      "summary": "AssertionError: expected call not found."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "1816",
+      "nodeid": "tests/issues/1816/test_ci_repair_context_overflow.py::test_stable_session_line_rebinds_once_and_preserves_usage[True]",
+      "outcome": "failure",
+      "summary": "AssertionError: expected call not found."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "1831",
+      "nodeid": "tests/issues/1831/test_orchestrator_failure_cleanup.py::TestAdvanceTimingDimension::test_transient_error_keeps_worktree",
+      "outcome": "failure",
+      "summary": "AssertionError: Expected '_mark_failed' to not have been called. Called 1 times."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "1857",
+      "nodeid": "tests/issues/1857/test_pr_review_duplicate_create.py::test_create_pr_already_exists_fails_when_retry_still_finds_nothing",
+      "outcome": "failure",
+      "summary": "AssertionError: should fail when recovery can't locate the existing PR"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "1857",
+      "nodeid": "tests/issues/1857/test_pr_review_duplicate_create.py::test_create_pr_already_exists_falls_back_to_find_existing_pr_without_url",
+      "outcome": "failure",
+      "summary": "AssertionError: Expected 'find_existing_pr' to be called once. Called 0 times."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "1857",
+      "nodeid": "tests/issues/1857/test_pr_review_duplicate_create.py::test_create_pr_already_exists_recovers_by_parsing_pr_url_from_error",
+      "outcome": "failure",
+      "summary": "AssertionError: PR number not parsed from error URL and persisted"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "1857",
+      "nodeid": "tests/issues/1857/test_pr_review_duplicate_create.py::test_create_pr_already_exists_retries_find_when_first_returns_none",
+      "outcome": "failure",
+      "summary": "AssertionError: assert 0 == 2"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "1857",
+      "nodeid": "tests/issues/1857/test_pr_review_duplicate_create.py::test_create_pr_unrecoverable_error_still_fails",
+      "outcome": "failure",
+      "summary": "AssertionError: non-'already exists' error should propagate, not be masked"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "1891",
+      "nodeid": "tests/issues/1891/test_usage_report_auth.py::TestUsageReportHttpIntegration::test_duplicate_report_is_idempotent_and_conflicting_replay_is_rejected",
+      "outcome": "failure",
+      "summary": "assert 0 == 2"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "1891",
+      "nodeid": "tests/issues/1891/test_usage_report_auth.py::TestUsageReportHttpIntegration::test_report_id_less_agent_has_explicit_short_migration_window[/api/remote/agent/message]",
+      "outcome": "failure",
+      "summary": "assert 0 == 150"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "1891",
+      "nodeid": "tests/issues/1891/test_usage_report_auth.py::TestUsageReportHttpIntegration::test_report_id_less_agent_has_explicit_short_migration_window[/api/remote/usage-report]",
+      "outcome": "failure",
+      "summary": "assert 0 == 150"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "1891",
+      "nodeid": "tests/issues/1891/test_usage_report_auth.py::TestUsageReportHttpIntegration::test_valid_bearer_updates_usage_and_audits_both_paths[/api/remote/agent/message]",
+      "outcome": "failure",
+      "summary": "assert 0 == 2"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "1891",
+      "nodeid": "tests/issues/1891/test_usage_report_auth.py::TestUsageReportHttpIntegration::test_valid_bearer_updates_usage_and_audits_both_paths[/api/remote/usage-report]",
+      "outcome": "failure",
+      "summary": "assert 0 == 2"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "1895",
+      "nodeid": "tests/issues/1895/test_redis_authentication.py::TestRedisPasswordFailClosed::test_development_allows_empty_redis_password_with_warning",
+      "outcome": "failure",
+      "summary": "RuntimeError: REDIS_PASSWORD not set in development mode. The entrypoint should auto-generate and persist this password. If running directly, set REDIS_PASSWORD explicitly."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "1895",
+      "nodeid": "tests/issues/1895/test_redis_authentication.py::TestRedisPasswordSpecialCharacters::test_password_with_backtick_handled_correctly",
+      "outcome": "failure",
+      "summary": "RuntimeError: REDIS_PASSWORD must be at least 24 characters long (got 13); current value is too short for production"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "1895",
+      "nodeid": "tests/issues/1895/test_redis_authentication.py::TestRedisPasswordSpecialCharacters::test_password_with_dollar_sign_handled_correctly",
+      "outcome": "failure",
+      "summary": "RuntimeError: REDIS_PASSWORD must be at least 24 characters long (got 13); current value is too short for production"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "1895",
+      "nodeid": "tests/issues/1895/test_redis_authentication.py::TestRedisPasswordSpecialCharacters::test_password_with_exclamation_handled_correctly",
+      "outcome": "failure",
+      "summary": "RuntimeError: REDIS_PASSWORD must be at least 24 characters long (got 13); current value is too short for production"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "1897",
+      "nodeid": "tests/issues/1897/test_dev_context_recovery.py::test_dev_context_overflow_recovers_on_fresh_session",
+      "outcome": "failure",
+      "summary": "AssertionError: expected call not found."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "1897",
+      "nodeid": "tests/issues/1897/test_retry_clears_in_progress.py::TestRetryClearsInProgress::test_retry_endpoint_calls_clear_in_progress",
+      "outcome": "failure",
+      "summary": "AssertionError: Expected 'clear_in_progress' to have been called once. Called 0 times."
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "198",
+      "nodeid": "tests/issues/198/e2e_audit_analysis_playwright.py::test_api_anomalies_with_status",
+      "outcome": "error",
+      "summary": "failed on setup with \"file tests/issues/198/e2e_audit_analysis_playwright.py, line 115"
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "198",
+      "nodeid": "tests/issues/198/e2e_audit_analysis_playwright.py::test_api_anomaly_status",
+      "outcome": "error",
+      "summary": "failed on setup with \"file tests/issues/198/e2e_audit_analysis_playwright.py, line 74"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "20",
+      "nodeid": "tests/issues/20/test_issue20.py::test_remote_data_fetch_interval",
+      "outcome": "failure",
+      "summary": "playwright._impl._errors.Error: Page.goto: net::ERR_CONNECTION_REFUSED at http://<host:port>/login"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "210",
+      "nodeid": "tests/issues/210/e2e_project_stats_accuracy.py::test_project_stats_accuracy",
+      "outcome": "failure",
+      "summary": "AssertionError: Stats API failed: 403"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "211",
+      "nodeid": "tests/issues/211/e2e_project_sort.py::test_project_sort",
+      "outcome": "failure",
+      "summary": "AssertionError: Stats API failed: 403"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "212",
+      "nodeid": "tests/issues/212/test_hostname_dedup.py::test_different_tenant_no_merge",
+      "outcome": "failure",
+      "summary": "sqlite3.OperationalError: no such table: registration_tokens"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "212",
+      "nodeid": "tests/issues/212/test_hostname_dedup.py::test_empty_hostname_no_merge",
+      "outcome": "failure",
+      "summary": "sqlite3.OperationalError: no such table: registration_tokens"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "212",
+      "nodeid": "tests/issues/212/test_hostname_dedup.py::test_invalid_token",
+      "outcome": "failure",
+      "summary": "sqlite3.OperationalError: no such table: registration_tokens"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "212",
+      "nodeid": "tests/issues/212/test_hostname_dedup.py::test_merge_cleans_in_memory_state",
+      "outcome": "failure",
+      "summary": "sqlite3.OperationalError: no such table: registration_tokens"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "212",
+      "nodeid": "tests/issues/212/test_hostname_dedup.py::test_merge_offline_duplicate",
+      "outcome": "failure",
+      "summary": "sqlite3.OperationalError: no such table: registration_tokens"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "212",
+      "nodeid": "tests/issues/212/test_hostname_dedup.py::test_merge_preserves_assignments",
+      "outcome": "failure",
+      "summary": "sqlite3.OperationalError: no such table: registration_tokens"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "212",
+      "nodeid": "tests/issues/212/test_hostname_dedup.py::test_merge_preserves_sessions",
+      "outcome": "failure",
+      "summary": "sqlite3.OperationalError: no such table: registration_tokens"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "212",
+      "nodeid": "tests/issues/212/test_hostname_dedup.py::test_new_machine_no_duplicate",
+      "outcome": "failure",
+      "summary": "sqlite3.OperationalError: no such table: registration_tokens"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "212",
+      "nodeid": "tests/issues/212/test_hostname_dedup.py::test_reject_online_duplicate",
+      "outcome": "failure",
+      "summary": "sqlite3.OperationalError: no such table: registration_tokens"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "2121",
+      "nodeid": "tests/issues/2121/test_sso_user_tenant_id.py::TestCreateUserFromSsoTenantId::test_uses_default_tenant_id_when_provider_not_found",
+      "outcome": "failure",
+      "summary": "assert None == 42"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "2121",
+      "nodeid": "tests/issues/2121/test_sso_user_tenant_id.py::TestCreateUserFromSsoTenantId::test_uses_default_tenant_id_when_provider_tenant_id_is_none",
+      "outcome": "failure",
+      "summary": "assert None == 42"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "22",
+      "nodeid": "tests/issues/22/test_issue22.py::TestOIDCSignatureVerification::test_jwks_caching",
+      "outcome": "failure",
+      "summary": "ValueError: Failed to fetch JWKS: 404 Client Error: Not Found for url: https://example.com/.well-known/jwks.json"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "221",
+      "nodeid": "tests/issues/221/test_tenant_form_validation.py::test_tenant_form_validation",
+      "outcome": "failure",
+      "summary": "Failed: async def functions are not natively supported."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "2335",
+      "nodeid": "tests/issues/2335/test_close_issue.py::test_close_issue_runs_as_service_user_with_bot_token",
+      "outcome": "failure",
+      "summary": "TypeError: object.__new__() takes exactly one argument (the type to instantiate)"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "2335",
+      "nodeid": "tests/issues/2335/test_close_issue.py::test_get_merge_commit_sha_none_when_empty",
+      "outcome": "failure",
+      "summary": "TypeError: object.__new__() takes exactly one argument (the type to instantiate)"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "2335",
+      "nodeid": "tests/issues/2335/test_close_issue.py::test_get_merge_commit_sha_returns_oid",
+      "outcome": "failure",
+      "summary": "TypeError: object.__new__() takes exactly one argument (the type to instantiate)"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "2335",
+      "nodeid": "tests/issues/2335/test_close_issue.py::test_reopen_issue_runs_as_service_user_with_bot_token",
+      "outcome": "failure",
+      "summary": "TypeError: object.__new__() takes exactly one argument (the type to instantiate)"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "2335",
+      "nodeid": "tests/issues/2335/test_verifier_checkout.py::test_cross_user_verifier_cleanup_uses_owner_safe_wrapper",
+      "outcome": "failure",
+      "summary": "TypeError: object.__new__() takes exactly one argument (the type to instantiate)"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "2335",
+      "nodeid": "tests/issues/2335/test_verifier_checkout.py::test_cross_user_verifier_directory_is_created_by_repository_owner",
+      "outcome": "failure",
+      "summary": "TypeError: object.__new__() takes exactly one argument (the type to instantiate)"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "2335",
+      "nodeid": "tests/issues/2335/test_verifier_checkout.py::test_same_user_verifier_directory_is_private_and_owner_writable",
+      "outcome": "failure",
+      "summary": "TypeError: object.__new__() takes exactly one argument (the type to instantiate)"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "241",
+      "nodeid": "tests/issues/241/test_pagination_migration_head.py::test_single_migration_head",
+      "outcome": "failure",
+      "summary": "AssertionError: assert '20260809_001...il_dev_rounds' == '20260715_001...lure_head_sha'"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "241",
+      "nodeid": "tests/issues/241/test_pagination_routes.py::TestGetSessionEnvelope::test_include_messages_returns_recent_page_and_metadata",
+      "outcome": "failure",
+      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "241",
+      "nodeid": "tests/issues/241/test_pagination_routes.py::TestGetSessionEnvelope::test_milestone_total_uses_conditional_count",
+      "outcome": "failure",
+      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "241",
+      "nodeid": "tests/issues/241/test_pagination_routes.py::TestGetSessionEnvelope::test_without_include_messages_has_no_pagination_envelope",
+      "outcome": "failure",
+      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "241",
+      "nodeid": "tests/issues/241/test_pagination_routes.py::TestMessagesEndpointWalk::test_cursor_walk_through_endpoint",
+      "outcome": "failure",
+      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "241",
+      "nodeid": "tests/issues/241/test_pagination_routes.py::TestMessagesEndpointWalk::test_limit_clamped_to_max_via_endpoint",
+      "outcome": "failure",
+      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "241",
+      "nodeid": "tests/issues/241/test_pagination_routes.py::TestMessagesEndpointWalk::test_lone_before_timestamp_is_ignored",
+      "outcome": "failure",
+      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "241",
+      "nodeid": "tests/issues/241/test_pagination_routes.py::TestOwnershipAnd404::test_admin_bypasses_owner_check",
+      "outcome": "failure",
+      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "241",
+      "nodeid": "tests/issues/241/test_pagination_routes.py::TestOwnershipAnd404::test_messages_endpoint_404_for_unknown_session",
+      "outcome": "failure",
+      "summary": "assert 500 == 404"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "241",
+      "nodeid": "tests/issues/241/test_pagination_routes.py::TestOwnershipAnd404::test_messages_endpoint_enforces_ownership_before_load",
+      "outcome": "failure",
+      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "241",
+      "nodeid": "tests/issues/241/test_pagination_routes.py::TestOwnershipAnd404::test_non_owner_gets_403",
+      "outcome": "failure",
+      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "241",
+      "nodeid": "tests/issues/241/test_pagination_routes.py::TestOwnershipAnd404::test_same_owner_wrong_tenant_gets_403",
+      "outcome": "failure",
+      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "241",
+      "nodeid": "tests/issues/241/test_pagination_routes.py::TestOwnershipAnd404::test_unknown_session_returns_404",
+      "outcome": "failure",
+      "summary": "assert 500 == 404"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "241",
+      "nodeid": "tests/issues/241/test_session_messages_pagination.py::TestCrossPageContinuity::test_full_walk_no_overlap_no_gap",
+      "outcome": "failure",
+      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "241",
+      "nodeid": "tests/issues/241/test_session_messages_pagination.py::TestCrossPageContinuity::test_has_more_flag_and_cursor_only_when_older_page_exists",
+      "outcome": "failure",
+      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "241",
+      "nodeid": "tests/issues/241/test_session_messages_pagination.py::TestDescReverseAdjacency::test_second_page_is_adjacent_not_oldest",
+      "outcome": "failure",
+      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "241",
+      "nodeid": "tests/issues/241/test_session_messages_pagination.py::TestEmptyAndDefaults::test_default_limit_used_when_none",
+      "outcome": "failure",
+      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "241",
+      "nodeid": "tests/issues/241/test_session_messages_pagination.py::TestEmptyAndDefaults::test_empty_session_returns_empty_page",
+      "outcome": "failure",
+      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "241",
+      "nodeid": "tests/issues/241/test_session_messages_pagination.py::TestInternalCallersUnaffected::test_get_session_full_history_when_requested",
+      "outcome": "failure",
+      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "241",
+      "nodeid": "tests/issues/241/test_session_messages_pagination.py::TestInternalCallersUnaffected::test_get_session_no_messages_by_default",
+      "outcome": "failure",
+      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "241",
+      "nodeid": "tests/issues/241/test_session_messages_pagination.py::TestLimitClamping::test_max_boundary_returns_exactly_max",
+      "outcome": "failure",
+      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "241",
+      "nodeid": "tests/issues/241/test_session_messages_pagination.py::TestLimitClamping::test_over_max_clamped_to_max",
+      "outcome": "failure",
+      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "241",
+      "nodeid": "tests/issues/241/test_session_messages_pagination.py::TestLimitClamping::test_zero_or_negative_falls_back_to_default",
+      "outcome": "failure",
+      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "241",
+      "nodeid": "tests/issues/241/test_session_messages_pagination.py::TestMilestoneCount::test_count_messages_total_and_milestone_scoped",
+      "outcome": "failure",
+      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "241",
+      "nodeid": "tests/issues/241/test_session_messages_pagination.py::TestMilestoneCount::test_get_messages_page_respects_milestone_filter",
+      "outcome": "failure",
+      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "241",
+      "nodeid": "tests/issues/241/test_session_messages_pagination.py::TestNullTimestampSafetyNet::test_schema_rejects_null_timestamp",
+      "outcome": "failure",
+      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "241",
+      "nodeid": "tests/issues/241/test_session_messages_pagination.py::TestSameTimestampTiebreak::test_identical_timestamps_ordered_by_id",
+      "outcome": "failure",
+      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "2431",
+      "nodeid": "tests/issues/2431/test_acceptance_verifier_hardening.py::test_issue_closure_combines_closed_at_with_latest_timeline_actor",
+      "outcome": "failure",
+      "summary": "TypeError: object.__new__() takes exactly one argument (the type to instantiate)"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "2431",
+      "nodeid": "tests/issues/2431/test_acceptance_verifier_hardening.py::test_issue_closure_rejects_timeline_actor_from_a_different_close_event",
+      "outcome": "failure",
+      "summary": "TypeError: object.__new__() takes exactly one argument (the type to instantiate)"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "2431",
+      "nodeid": "tests/issues/2431/test_acceptance_verifier_hardening.py::test_issue_comment_exact_body_from_same_bot_is_idempotent",
+      "outcome": "failure",
+      "summary": "TypeError: object.__new__() takes exactly one argument (the type to instantiate)"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "2431",
+      "nodeid": "tests/issues/2431/test_acceptance_verifier_hardening.py::test_issue_comment_listing_uses_paginated_rest_and_normalizes_pages",
+      "outcome": "failure",
+      "summary": "TypeError: object.__new__() takes exactly one argument (the type to instantiate)"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "2431",
+      "nodeid": "tests/issues/2431/test_acceptance_verifier_hardening.py::test_issue_comment_same_body_from_human_does_not_deduplicate",
+      "outcome": "failure",
+      "summary": "TypeError: object.__new__() takes exactly one argument (the type to instantiate)"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "2431",
+      "nodeid": "tests/issues/2431/test_acceptance_verifier_hardening.py::test_issue_comment_unknown_bot_identity_does_not_trust_existing_author",
+      "outcome": "failure",
+      "summary": "TypeError: object.__new__() takes exactly one argument (the type to instantiate)"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "2431",
+      "nodeid": "tests/issues/2431/test_acceptance_verifier_hardening.py::test_merge_sha_is_fetched_and_verified_when_missing",
+      "outcome": "failure",
+      "summary": "TypeError: object.__new__() takes exactly one argument (the type to instantiate)"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "25",
+      "nodeid": "tests/issues/25/test_issue25.py::test_issue25",
+      "outcome": "failure",
+      "summary": "playwright._impl._errors.TimeoutError: Page.fill: Timeout 30000ms exceeded."
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "394",
+      "nodeid": "tests/issues/394/e2e_terminal_tab.py::test_session_sync_api",
+      "outcome": "error",
+      "summary": "failed on setup with \"file tests/issues/394/e2e_terminal_tab.py, line 183"
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "394",
+      "nodeid": "tests/issues/394/e2e_terminal_tab.py::test_terminal_connection_and_interaction",
+      "outcome": "error",
+      "summary": "failed on setup with \"AssertionError\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "394",
+      "nodeid": "tests/issues/394/e2e_terminal_tab.py::test_terminal_option_in_modal",
+      "outcome": "error",
+      "summary": "failed on setup with \"AssertionError\""
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "394",
+      "nodeid": "tests/issues/394/e2e_terminal_tab.py::test_terminal_tab",
+      "outcome": "failure",
+      "summary": "AssertionError: Login failed: {\"error\":\"Invalid username or password\"}"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "4",
+      "nodeid": "tests/issues/4/test_conversation_history_icon.py::test_conversation_history_icon",
+      "outcome": "failure",
+      "summary": "Failed: async def functions are not natively supported."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "42",
+      "nodeid": "tests/issues/42/test_webui_manager.py::test_manager_get_user_webui_url_single_user",
+      "outcome": "failure",
+      "summary": "AssertionError: assert False"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "42",
+      "nodeid": "tests/issues/42/test_webui_manager.py::test_manager_instance_limit",
+      "outcome": "failure",
+      "summary": "TypeError: cannot unpack non-iterable NoneType object"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "435",
+      "nodeid": "tests/issues/435/e2e_api_key_toggle.py::test_api_key_toggle",
+      "outcome": "failure",
+      "summary": "assert 403 == 200"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "47",
+      "nodeid": "tests/issues/47/test_auto_refresh.py::test_auto_refresh_historical_date",
+      "outcome": "failure",
+      "summary": "TypeError: 'PlaywrightContextManager' object does not support the context manager protocol"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "47",
+      "nodeid": "tests/issues/47/test_auto_refresh.py::test_auto_refresh_today",
+      "outcome": "failure",
+      "summary": "TypeError: 'PlaywrightContextManager' object does not support the context manager protocol"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "477",
+      "nodeid": "tests/issues/477/test_browse_directory_auth.py::TestBrowseRemoteDirectoryAuthCheck::test_admin_user_has_access",
+      "outcome": "failure",
+      "summary": "assert 400 == 200"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "477",
+      "nodeid": "tests/issues/477/test_browse_directory_auth.py::TestBrowseRemoteDirectoryAuthCheck::test_admin_user_offline_machine",
+      "outcome": "failure",
+      "summary": "assert 400 == 200"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "477",
+      "nodeid": "tests/issues/477/test_browse_directory_auth.py::TestBrowseRemoteDirectoryAuthCheck::test_g_user_none_returns_401",
+      "outcome": "failure",
+      "summary": "RuntimeError: Working outside of request context."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "477",
+      "nodeid": "tests/issues/477/test_browse_directory_auth.py::TestBrowseRemoteDirectoryAuthCheck::test_g_user_without_id_returns_403",
+      "outcome": "failure",
+      "summary": "RuntimeError: Working outside of request context."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "477",
+      "nodeid": "tests/issues/477/test_browse_directory_auth.py::TestBrowseRemoteDirectoryAuthCheck::test_no_g_user_returns_401",
+      "outcome": "failure",
+      "summary": "RuntimeError: Working outside of request context."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "477",
+      "nodeid": "tests/issues/477/test_browse_directory_auth.py::TestBrowseRemoteDirectoryAuthCheck::test_normal_user_without_access_returns_403",
+      "outcome": "failure",
+      "summary": "assert 400 == 403"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "477",
+      "nodeid": "tests/issues/477/test_browse_directory_auth.py::TestBrowseRemoteDirectoryEdgeCases::test_machine_not_found_returns_404",
+      "outcome": "failure",
+      "summary": "assert 400 == 404"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "48",
+      "nodeid": "tests/issues/48/test_status_bar_usage.py::test_status_bar_usage",
+      "outcome": "failure",
+      "summary": "playwright._impl._errors.Error: Page.goto: net::ERR_CONNECTION_REFUSED at http://<host:port>/"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "48",
+      "nodeid": "tests/issues/48/test_status_bar_usage_v2.py::test_status_bar_improvements",
+      "outcome": "failure",
+      "summary": "playwright._impl._errors.Error: Page.goto: net::ERR_CONNECTION_REFUSED at http://<host:port>/"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "51",
+      "nodeid": "tests/issues/51/test_issue51.py::test_issue51",
+      "outcome": "failure",
+      "summary": "TypeError: object NoneType can't be used in 'await' expression"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "517",
+      "nodeid": "tests/issues/517/e2e_codex_comprehensive.py::test_agent_sessions_tokens",
+      "outcome": "failure",
+      "summary": "AssertionError: No codex sessions"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "517",
+      "nodeid": "tests/issues/517/e2e_codex_comprehensive.py::test_api_codex_alias",
+      "outcome": "failure",
+      "summary": "AssertionError: Not logged in"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "517",
+      "nodeid": "tests/issues/517/e2e_codex_comprehensive.py::test_api_messages_query",
+      "outcome": "failure",
+      "summary": "AssertionError: Not logged in"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "517",
+      "nodeid": "tests/issues/517/e2e_codex_comprehensive.py::test_api_sessions_list",
+      "outcome": "failure",
+      "summary": "AssertionError: Not logged in"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "517",
+      "nodeid": "tests/issues/517/e2e_codex_comprehensive.py::test_api_tools_list",
+      "outcome": "failure",
+      "summary": "AssertionError: codex not in tools: []"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "517",
+      "nodeid": "tests/issues/517/e2e_codex_comprehensive.py::test_api_usage_data",
+      "outcome": "failure",
+      "summary": "AssertionError: Usage API failed: 401"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "517",
+      "nodeid": "tests/issues/517/e2e_codex_comprehensive.py::test_content_block_types",
+      "outcome": "failure",
+      "summary": "AssertionError: No 'text' content_blocks"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "517",
+      "nodeid": "tests/issues/517/e2e_codex_comprehensive.py::test_daily_usage_tokens",
+      "outcome": "failure",
+      "summary": "TypeError: '>' not supported between instances of 'NoneType' and 'int'"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "517",
+      "nodeid": "tests/issues/517/e2e_codex_comprehensive.py::test_fetch_codex_data",
+      "outcome": "failure",
+      "summary": "AssertionError: fetch_codex.py failed: /opt/hostedtoolcache/Python/3.11.15/x64/bin/python: can't open file 'tests/scripts/fetch_codex.py': [Errno 2] No such file or directory"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "517",
+      "nodeid": "tests/issues/517/e2e_codex_comprehensive.py::test_remote_codex_capabilities",
+      "outcome": "failure",
+      "summary": "AssertionError: No connected remote machine with codex installed"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "517",
+      "nodeid": "tests/issues/517/e2e_codex_comprehensive.py::test_session_messages_content",
+      "outcome": "failure",
+      "summary": "AssertionError: No codex session_messages with metadata"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "517",
+      "nodeid": "tests/issues/517/e2e_codex_comprehensive.py::test_session_restore_codex_detail",
+      "outcome": "failure",
+      "summary": "AssertionError: Not logged in"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "517",
+      "nodeid": "tests/issues/517/e2e_codex_comprehensive.py::test_session_restore_url",
+      "outcome": "failure",
+      "summary": "AssertionError: Not logged in"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "517",
+      "nodeid": "tests/issues/517/e2e_codex_comprehensive.py::test_workspace_status_codex",
+      "outcome": "failure",
+      "summary": "AssertionError: Not logged in"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "517",
+      "nodeid": "tests/issues/517/e2e_codex_integration.py::test_agent_sessions_have_codex",
+      "outcome": "failure",
+      "summary": "AssertionError: No codex sessions in agent_sessions"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "517",
+      "nodeid": "tests/issues/517/e2e_codex_integration.py::test_api_codex_alias_resolution",
+      "outcome": "failure",
+      "summary": "AssertionError: Not logged in"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "517",
+      "nodeid": "tests/issues/517/e2e_codex_integration.py::test_api_messages_codex",
+      "outcome": "failure",
+      "summary": "AssertionError: Not logged in"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "517",
+      "nodeid": "tests/issues/517/e2e_codex_integration.py::test_api_session_detail",
+      "outcome": "failure",
+      "summary": "AssertionError: Not logged in"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "517",
+      "nodeid": "tests/issues/517/e2e_codex_integration.py::test_api_session_with_tokens",
+      "outcome": "failure",
+      "summary": "AssertionError: Not logged in"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "517",
+      "nodeid": "tests/issues/517/e2e_codex_integration.py::test_api_sessions_list_codex",
+      "outcome": "failure",
+      "summary": "AssertionError: Not logged in"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "517",
+      "nodeid": "tests/issues/517/e2e_codex_integration.py::test_api_usage_codex",
+      "outcome": "failure",
+      "summary": "AssertionError: GET /api/tool/codex/30 failed: 401 {\"error\":\"Authentication required\"}"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "517",
+      "nodeid": "tests/issues/517/e2e_codex_integration.py::test_api_usage_tools_includes_codex",
+      "outcome": "failure",
+      "summary": "AssertionError: GET /api/tools failed: 401"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "517",
+      "nodeid": "tests/issues/517/e2e_codex_integration.py::test_codex_content_block_types",
+      "outcome": "failure",
+      "summary": "AssertionError: No codex session_messages with metadata"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "517",
+      "nodeid": "tests/issues/517/e2e_codex_integration.py::test_codex_daily_messages",
+      "outcome": "failure",
+      "summary": "AssertionError: No codex daily_messages found"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "517",
+      "nodeid": "tests/issues/517/e2e_codex_integration.py::test_content_block_types_in_api",
+      "outcome": "failure",
+      "summary": "AssertionError: Not logged in"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "517",
+      "nodeid": "tests/issues/517/e2e_codex_integration.py::test_daily_usage_has_codex",
+      "outcome": "failure",
+      "summary": "AssertionError: No codex daily_usage rows found"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "517",
+      "nodeid": "tests/issues/517/e2e_codex_integration.py::test_fetch_codex_runs",
+      "outcome": "failure",
+      "summary": "AssertionError: fetch_codex.py failed: /opt/hostedtoolcache/Python/3.11.15/x64/bin/python: can't open file 'tests/scripts/fetch_codex.py': [Errno 2] No such file or directory"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "517",
+      "nodeid": "tests/issues/517/e2e_codex_integration.py::test_frontend_api_key_codex_option",
+      "outcome": "failure",
+      "summary": "playwright._impl._errors.Error: Page.goto: net::ERR_CONNECTION_REFUSED at http://<host:port>/login"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "517",
+      "nodeid": "tests/issues/517/e2e_codex_integration.py::test_frontend_assist_panel_codex",
+      "outcome": "failure",
+      "summary": "playwright._impl._errors.Error: Page.goto: net::ERR_CONNECTION_REFUSED at http://<host:port>/login"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "517",
+      "nodeid": "tests/issues/517/e2e_codex_integration.py::test_frontend_codex_session_detail",
+      "outcome": "failure",
+      "summary": "AssertionError: Not logged in"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "517",
+      "nodeid": "tests/issues/517/e2e_codex_integration.py::test_frontend_codex_sessions_page",
+      "outcome": "failure",
+      "summary": "playwright._impl._errors.Error: Page.goto: net::ERR_CONNECTION_REFUSED at http://<host:port>/login"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "517",
+      "nodeid": "tests/issues/517/e2e_codex_integration.py::test_session_messages_have_codex",
+      "outcome": "failure",
+      "summary": "AssertionError: No codex session_messages found"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "517",
+      "nodeid": "tests/issues/517/e2e_codex_real_session.py::test_codex_exec_conversation",
+      "outcome": "failure",
+      "summary": "AssertionError: Create session failed: 401 {\"error\":\"Authentication required\"}"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "517",
+      "nodeid": "tests/issues/517/e2e_codex_real_session.py::test_codex_quota_tracking",
+      "outcome": "failure",
+      "summary": "sqlite3.OperationalError: no such table: agent_sessions"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "517",
+      "nodeid": "tests/issues/517/e2e_codex_real_session.py::test_prerequisites",
+      "outcome": "failure",
+      "summary": "AssertionError: SSH to 192.168.64.3 failed: ssh: connect to host 192.168.64.3 port 22: Connection timed out"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "517",
+      "nodeid": "tests/issues/517/e2e_codex_real_session.py::test_remote_session_create_and_verify",
+      "outcome": "failure",
+      "summary": "AssertionError: Create failed: 401 {\"error\":\"Authentication required\"}"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "517",
+      "nodeid": "tests/issues/517/e2e_codex_real_session.py::test_session_restore",
+      "outcome": "failure",
+      "summary": "sqlite3.OperationalError: no such table: agent_sessions"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "517",
+      "nodeid": "tests/issues/517/e2e_codex_real_session.py::test_session_sync_verification",
+      "outcome": "failure",
+      "summary": "sqlite3.OperationalError: no such table: agent_sessions"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "517",
+      "nodeid": "tests/issues/517/e2e_codex_real_session.py::test_terminal_codex_launch",
+      "outcome": "failure",
+      "summary": "AssertionError: Terminal start failed: 401 {\"error\":\"Authentication required\"}"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "52",
+      "nodeid": "tests/issues/52/test_issue52.py::test_database_migration",
+      "outcome": "failure",
+      "summary": "AssertionError: linux_account 字段未添加到 users 表"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "52",
+      "nodeid": "tests/issues/52/test_issue52.py::test_get_all_users_includes_linux_account",
+      "outcome": "failure",
+      "summary": "KeyError: 'linux_account'"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "52",
+      "nodeid": "tests/issues/52/test_issue52.py::test_update_user_with_linux_account",
+      "outcome": "failure",
+      "summary": "AssertionError: 创建用户失败"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "53",
+      "nodeid": "tests/issues/53/test_add_user_button.py::test_issue53",
+      "outcome": "failure",
+      "summary": "TypeError: object NoneType can't be used in 'await' expression"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "54",
+      "nodeid": "tests/issues/54/test_issue54.py::TestIssue54::test_add_user_modal_fields",
+      "outcome": "failure",
+      "summary": "playwright._impl._errors.TimeoutError: Page.fill: Timeout 30000ms exceeded."
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "559",
+      "nodeid": "tests/issues/559/e2e_terminal_ws_handler.py::test_binary_echo",
+      "outcome": "error",
+      "summary": "failed on setup with \"file tests/issues/559/e2e_terminal_ws_handler.py, line 133"
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "559",
+      "nodeid": "tests/issues/559/e2e_terminal_ws_handler.py::test_invalid_token_rejected",
+      "outcome": "error",
+      "summary": "failed on setup with \"file tests/issues/559/e2e_terminal_ws_handler.py, line 169"
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "559",
+      "nodeid": "tests/issues/559/e2e_terminal_ws_handler.py::test_multiple_messages",
+      "outcome": "error",
+      "summary": "failed on setup with \"file tests/issues/559/e2e_terminal_ws_handler.py, line 151"
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "559",
+      "nodeid": "tests/issues/559/e2e_terminal_ws_handler.py::test_text_echo",
+      "outcome": "error",
+      "summary": "failed on setup with \"file tests/issues/559/e2e_terminal_ws_handler.py, line 118"
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "559",
+      "nodeid": "tests/issues/559/e2e_terminal_ws_handler.py::test_unknown_terminal_rejected",
+      "outcome": "error",
+      "summary": "failed on setup with \"file tests/issues/559/e2e_terminal_ws_handler.py, line 191"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "559",
+      "nodeid": "tests/issues/559/test_terminal_ws_handler.py::TestHandleVSCodeWs::test_cookie_token_can_authenticate_proxy_ws",
+      "outcome": "failure",
+      "summary": "AssertionError: expected call not found."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "559",
+      "nodeid": "tests/issues/559/test_terminal_ws_handler.py::TestHandleVSCodeWs::test_invalid_proxy_ws_token_closes",
+      "outcome": "failure",
+      "summary": "AssertionError: expected call not found."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "559",
+      "nodeid": "tests/issues/559/test_terminal_ws_handler.py::TestHandleVSCodeWs::test_proxy_path_bridges_to_matching_remote_path",
+      "outcome": "failure",
+      "summary": "AssertionError: expected call not found."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "584",
+      "nodeid": "tests/issues/584/test_create_remote_directory.py::TestAgentCreateDirectory::test_already_exists_returns_error",
+      "outcome": "failure",
+      "summary": "AssertionError: True is not false"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "584",
+      "nodeid": "tests/issues/584/test_create_remote_directory.py::TestAgentCreateDirectory::test_parent_not_exists_returns_error",
+      "outcome": "failure",
+      "summary": "AssertionError: 'Parent directory does not exist' not found in 'No existing ancestor directory found'"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "584",
+      "nodeid": "tests/issues/584/test_create_remote_directory.py::TestCreateRemoteDirectoryRoute::test_agent_creation_failure",
+      "outcome": "failure",
+      "summary": "AssertionError: 401 != 200"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "584",
+      "nodeid": "tests/issues/584/test_create_remote_directory.py::TestCreateRemoteDirectoryRoute::test_agent_timeout_returns_504",
+      "outcome": "failure",
+      "summary": "AssertionError: 401 != 504"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "584",
+      "nodeid": "tests/issues/584/test_create_remote_directory.py::TestCreateRemoteDirectoryRoute::test_machine_not_found_returns_404",
+      "outcome": "failure",
+      "summary": "AssertionError: 401 != 404"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "584",
+      "nodeid": "tests/issues/584/test_create_remote_directory.py::TestCreateRemoteDirectoryRoute::test_machine_offline_returns_503",
+      "outcome": "failure",
+      "summary": "AssertionError: 401 != 503"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "584",
+      "nodeid": "tests/issues/584/test_create_remote_directory.py::TestCreateRemoteDirectoryRoute::test_no_path_returns_400",
+      "outcome": "failure",
+      "summary": "AssertionError: 401 != 400"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "584",
+      "nodeid": "tests/issues/584/test_create_remote_directory.py::TestCreateRemoteDirectoryRoute::test_non_admin_no_access_returns_403",
+      "outcome": "failure",
+      "summary": "AssertionError: 401 != 403"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "584",
+      "nodeid": "tests/issues/584/test_create_remote_directory.py::TestCreateRemoteDirectoryRoute::test_path_too_long_returns_400",
+      "outcome": "failure",
+      "summary": "AssertionError: 401 != 400"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "584",
+      "nodeid": "tests/issues/584/test_create_remote_directory.py::TestCreateRemoteDirectoryRoute::test_send_command_failure_returns_500",
+      "outcome": "failure",
+      "summary": "AssertionError: 401 != 500"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "584",
+      "nodeid": "tests/issues/584/test_create_remote_directory.py::TestCreateRemoteDirectoryRoute::test_successful_creation",
+      "outcome": "failure",
+      "summary": "AssertionError: 401 != 200"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "60",
+      "nodeid": "tests/issues/60/test_language_sync.py::test_language_sync",
+      "outcome": "failure",
+      "summary": "Failed: async def functions are not natively supported."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "65",
+      "nodeid": "tests/issues/65/test_workspace_state_restore.py::test_workspace_state_restore",
+      "outcome": "failure",
+      "summary": "Failed: async def functions are not natively supported."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "673",
+      "nodeid": "tests/issues/673/test_session_filter_params.py::test_api_endpoint_integration",
+      "outcome": "failure",
+      "summary": "AssertionError: API 返回 401"
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "673",
+      "nodeid": "tests/issues/673/test_session_filter_params.py::test_combined_filter",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: table users has no column named name\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "673",
+      "nodeid": "tests/issues/673/test_session_filter_params.py::test_invalid_session_type_filter",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: table users has no column named name\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "673",
+      "nodeid": "tests/issues/673/test_session_filter_params.py::test_invalid_status_filter",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: table users has no column named name\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "673",
+      "nodeid": "tests/issues/673/test_session_filter_params.py::test_session_type_filter",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: table users has no column named name\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "673",
+      "nodeid": "tests/issues/673/test_session_filter_params.py::test_status_filter",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: table users has no column named name\""
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_agent_runner.py::TestStopSession::test_shutdown_during_remote_creation_stops_actual_before_prompt",
+      "outcome": "failure",
+      "summary": "assert False"
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_api.py::TestAuthRequired::test_create_requires_auth",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_api.py::TestAuthRequired::test_delete_requires_auth",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_api.py::TestAuthRequired::test_get_requires_auth",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_api.py::TestAuthRequired::test_list_requires_auth",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_api.py::TestAuthRequired::test_tools_requires_auth",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_api.py::TestCancelMilestone::test_cancel_milestone",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_api.py::TestCreateWorkflow::test_create_can_require_full_review_rounds",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_api.py::TestCreateWorkflow::test_create_missing_cli_tool",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_api.py::TestCreateWorkflow::test_create_missing_project_path",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_api.py::TestCreateWorkflow::test_create_missing_requirements",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_api.py::TestCreateWorkflow::test_create_new_project_no_path_needed",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_api.py::TestCreateWorkflow::test_create_success",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_api.py::TestCreateWorkflow::test_create_with_issue_url",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_api.py::TestCreateWorkflow::test_create_with_multiple_issue_selectors",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_api.py::TestCreateWorkflow::test_create_with_only_invalid_issue_selectors",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_api.py::TestDeleteBatch::test_delete_batch_forbidden_for_other_users",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_api.py::TestDeleteBatch::test_delete_batch_not_found",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_api.py::TestDeleteBatch::test_delete_batch_success",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_api.py::TestDeleteWorkflow::test_delete_not_found",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_api.py::TestDeleteWorkflow::test_delete_success",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_api.py::TestForkMilestone::test_fork_milestone",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_api.py::TestGetMilestoneSession::test_get_session_milestone_not_found",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_api.py::TestGetMilestoneSession::test_get_session_no_session_id",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_api.py::TestGetMilestoneSession::test_get_session_prefers_actual_cli_session_when_mapped",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_api.py::TestGetMilestoneSession::test_get_session_success",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_api.py::TestGetMilestoneSession::test_get_session_workflow_not_found",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_api.py::TestGetMilestoneSession::test_get_session_wrong_workflow",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_api.py::TestGetModels::test_get_models_exception_returns_empty",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_api.py::TestGetModels::test_get_models_no_keys_returns_empty",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_api.py::TestGetModels::test_get_models_remote_denies_without_access",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_api.py::TestGetModels::test_get_models_remote_derives_tenant_from_machine",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_api.py::TestGetModels::test_get_models_remote_lookup_failure_not_masked_as_success",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_api.py::TestGetModels::test_get_models_returns_normalized_models",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_api.py::TestGetTimeline::test_get_timeline",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_api.py::TestGetTimeline::test_get_timeline_backfills_diff_stats_per_milestone",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_api.py::TestGetTimeline::test_get_timeline_exposes_actual_llm_session_id",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_api.py::TestGetTools::test_get_tools",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_api.py::TestGetWorkflow::test_get_not_found",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_api.py::TestGetWorkflow::test_get_other_users_workflow_forbidden",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_api.py::TestGetWorkflow::test_get_parses_definition_snapshot",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_api.py::TestGetWorkflow::test_get_success",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_api.py::TestListWorkflows::test_list_admin_sees_all",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_api.py::TestListWorkflows::test_list_passes_search_limit_offset_and_status",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_api.py::TestListWorkflows::test_list_regular_user_filters_own",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_api.py::TestListWorkflows::test_list_success",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_api.py::TestMarkDone::test_mark_done",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_api.py::TestPauseWorkflow::test_pause_already_paused",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_api.py::TestPauseWorkflow::test_pause_success",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_api.py::TestResumeWorkflow::test_resume_not_paused",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_api.py::TestResumeWorkflow::test_resume_success",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_api.py::TestStopWorkflow::test_stop_cancels_queued_batch_siblings",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_api.py::TestStopWorkflow::test_stop_success",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_api.py::TestStreamWorkflowEvents::test_stream_requires_ownership",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_api.py::TestStreamWorkflowEvents::test_stream_returns_event_stream",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_api.py::TestStreamWorkflowEvents::test_stream_workflow_not_found",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_quota_gate.py::TestCreateWorkflowQuotaGate::test_over_quota_rejected",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_quota_gate.py::TestCreateWorkflowQuotaGate::test_quota_check_error_fail_closed_rejected",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_repo.py::TestAllowedFieldsFiltering::test_update_allows_only_whitelisted_fields",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_repo.py::TestAllowedFieldsFiltering::test_update_filters_out_empty_update_set",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_repo.py::TestAllowedFieldsFiltering::test_update_milestone_allowed_fields_filter",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_repo.py::TestAllowedFieldsFiltering::test_update_persists_transient_retry_count",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_repo.py::TestAllowedFieldsFiltering::test_update_workflow_coerces_booleans",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_repo.py::TestCIRoundTripPersistence::test_ci_repair_fields_round_trip",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_repo.py::TestCIRoundTripPersistence::test_worktree_and_preferred_paths_round_trip_together",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_repo.py::TestContentLanguagePersistence::test_defaults_to_en_when_omitted",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_repo.py::TestContentLanguagePersistence::test_explicit_content_language_round_trips",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_repo.py::TestContentLanguagePersistence::test_invalid_content_language_normalized_to_en",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_repo.py::TestContentLanguagePersistence::test_none_content_language_normalized_to_en",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_repo.py::TestEventCRUD::test_create_event",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_repo.py::TestEventCRUD::test_events_ordered_by_created_at",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_repo.py::TestEventCRUD::test_list_events",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_repo.py::TestEventCRUD::test_list_events_with_limit",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_repo.py::TestMilestoneCRUD::test_cancel_milestones_after",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_repo.py::TestMilestoneCRUD::test_create_milestone",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_repo.py::TestMilestoneCRUD::test_get_milestone",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_repo.py::TestMilestoneCRUD::test_list_milestones",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_repo.py::TestMilestoneCRUD::test_list_milestones_filter_dev_round",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_repo.py::TestMilestoneCRUD::test_list_milestones_filter_phase",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_repo.py::TestMilestoneCRUD::test_update_milestone",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_repo.py::TestWorkflowCRUD::test_create_workflow",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_repo.py::TestWorkflowCRUD::test_create_workflow_persists_require_full_review_rounds",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_repo.py::TestWorkflowCRUD::test_delete_batch_cascades",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_repo.py::TestWorkflowCRUD::test_delete_workflow",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_repo.py::TestWorkflowCRUD::test_delete_workflow_cascades",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_repo.py::TestWorkflowCRUD::test_get_active_workflows",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_repo.py::TestWorkflowCRUD::test_get_milestone_usage_summary",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_repo.py::TestWorkflowCRUD::test_get_workflow",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_repo.py::TestWorkflowCRUD::test_get_workflow_not_found",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_repo.py::TestWorkflowCRUD::test_list_workflows",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_repo.py::TestWorkflowCRUD::test_list_workflows_comma_separated_status",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_repo.py::TestWorkflowCRUD::test_list_workflows_filter_status",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_repo.py::TestWorkflowCRUD::test_list_workflows_filter_user",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_repo.py::TestWorkflowCRUD::test_list_workflows_search_and_pagination",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_repo.py::TestWorkflowCRUD::test_update_workflow",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_repo.py::TestWorkflowCRUD::test_update_workflow_empty",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_autonomous_repo.py::TestWorkflowCRUD::test_update_workflow_tokens",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsBranch::test_create_branch_from_base",
+      "outcome": "error",
+      "summary": "failed on setup with \"TypeError: object.__new__() takes exactly one argument (the type to instantiate)\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsBranch::test_create_branch_from_head",
+      "outcome": "error",
+      "summary": "failed on setup with \"TypeError: object.__new__() takes exactly one argument (the type to instantiate)\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsBranch::test_delete_branch",
+      "outcome": "error",
+      "summary": "failed on setup with \"TypeError: object.__new__() takes exactly one argument (the type to instantiate)\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsBranch::test_get_current_branch",
+      "outcome": "error",
+      "summary": "failed on setup with \"TypeError: object.__new__() takes exactly one argument (the type to instantiate)\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsBranch::test_get_current_commit",
+      "outcome": "error",
+      "summary": "failed on setup with \"TypeError: object.__new__() takes exactly one argument (the type to instantiate)\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsDiff::test_get_commit_diff",
+      "outcome": "error",
+      "summary": "failed on setup with \"TypeError: object.__new__() takes exactly one argument (the type to instantiate)\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsDiff::test_get_commit_diff_stats",
+      "outcome": "error",
+      "summary": "failed on setup with \"TypeError: object.__new__() takes exactly one argument (the type to instantiate)\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsDiff::test_get_diff",
+      "outcome": "error",
+      "summary": "failed on setup with \"TypeError: object.__new__() takes exactly one argument (the type to instantiate)\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsDiff::test_get_diff_stats",
+      "outcome": "error",
+      "summary": "failed on setup with \"TypeError: object.__new__() takes exactly one argument (the type to instantiate)\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsError::test_check_false_no_exception",
+      "outcome": "error",
+      "summary": "failed on setup with \"TypeError: object.__new__() takes exactly one argument (the type to instantiate)\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsError::test_gh_command_failure",
+      "outcome": "error",
+      "summary": "failed on setup with \"TypeError: object.__new__() takes exactly one argument (the type to instantiate)\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsError::test_gh_not_found",
+      "outcome": "error",
+      "summary": "failed on setup with \"TypeError: object.__new__() takes exactly one argument (the type to instantiate)\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsError::test_gh_timeout",
+      "outcome": "error",
+      "summary": "failed on setup with \"TypeError: object.__new__() takes exactly one argument (the type to instantiate)\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsGit::test_git_add_all",
+      "outcome": "error",
+      "summary": "failed on setup with \"TypeError: object.__new__() takes exactly one argument (the type to instantiate)\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsGit::test_git_commit",
+      "outcome": "error",
+      "summary": "failed on setup with \"TypeError: object.__new__() takes exactly one argument (the type to instantiate)\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsGit::test_git_commit_default_no_verify_flag",
+      "outcome": "error",
+      "summary": "failed on setup with \"TypeError: object.__new__() takes exactly one argument (the type to instantiate)\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsGit::test_git_commit_no_verify",
+      "outcome": "error",
+      "summary": "failed on setup with \"TypeError: object.__new__() takes exactly one argument (the type to instantiate)\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsGit::test_git_init",
+      "outcome": "error",
+      "summary": "failed on setup with \"TypeError: object.__new__() takes exactly one argument (the type to instantiate)\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsGit::test_git_push",
+      "outcome": "error",
+      "summary": "failed on setup with \"TypeError: object.__new__() takes exactly one argument (the type to instantiate)\""
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsInit::test_init",
+      "outcome": "failure",
+      "summary": "TypeError: object.__new__() takes exactly one argument (the type to instantiate)"
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsIssue::test_add_issue_comment",
+      "outcome": "error",
+      "summary": "failed on setup with \"TypeError: object.__new__() takes exactly one argument (the type to instantiate)\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsIssue::test_create_issue",
+      "outcome": "error",
+      "summary": "failed on setup with \"TypeError: object.__new__() takes exactly one argument (the type to instantiate)\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsIssue::test_create_issue_no_labels",
+      "outcome": "error",
+      "summary": "failed on setup with \"TypeError: object.__new__() takes exactly one argument (the type to instantiate)\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsIssue::test_get_issue",
+      "outcome": "error",
+      "summary": "failed on setup with \"TypeError: object.__new__() takes exactly one argument (the type to instantiate)\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsIssue::test_list_issue_comments",
+      "outcome": "error",
+      "summary": "failed on setup with \"TypeError: object.__new__() takes exactly one argument (the type to instantiate)\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsIssue::test_list_issue_comments_with_since",
+      "outcome": "error",
+      "summary": "failed on setup with \"TypeError: object.__new__() takes exactly one argument (the type to instantiate)\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsIssue::test_update_issue",
+      "outcome": "error",
+      "summary": "failed on setup with \"TypeError: object.__new__() takes exactly one argument (the type to instantiate)\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsPR::test_create_pr",
+      "outcome": "error",
+      "summary": "failed on setup with \"TypeError: object.__new__() takes exactly one argument (the type to instantiate)\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsPR::test_create_pr_draft",
+      "outcome": "error",
+      "summary": "failed on setup with \"TypeError: object.__new__() takes exactly one argument (the type to instantiate)\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsPR::test_get_pr",
+      "outcome": "error",
+      "summary": "failed on setup with \"TypeError: object.__new__() takes exactly one argument (the type to instantiate)\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsPR::test_get_pr_merge_state",
+      "outcome": "error",
+      "summary": "failed on setup with \"TypeError: object.__new__() takes exactly one argument (the type to instantiate)\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsPR::test_list_pr_comments",
+      "outcome": "error",
+      "summary": "failed on setup with \"TypeError: object.__new__() takes exactly one argument (the type to instantiate)\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsPR::test_list_pr_comments_empty",
+      "outcome": "error",
+      "summary": "failed on setup with \"TypeError: object.__new__() takes exactly one argument (the type to instantiate)\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsPR::test_merge_pr",
+      "outcome": "error",
+      "summary": "failed on setup with \"TypeError: object.__new__() takes exactly one argument (the type to instantiate)\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsRepo::test_create_repo",
+      "outcome": "error",
+      "summary": "failed on setup with \"TypeError: object.__new__() takes exactly one argument (the type to instantiate)\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsRepo::test_create_repo_public",
+      "outcome": "error",
+      "summary": "failed on setup with \"TypeError: object.__new__() takes exactly one argument (the type to instantiate)\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsRepo::test_get_repo_name",
+      "outcome": "error",
+      "summary": "failed on setup with \"TypeError: object.__new__() takes exactly one argument (the type to instantiate)\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsRepo::test_get_repo_name_fallback_no_remote",
+      "outcome": "error",
+      "summary": "failed on setup with \"TypeError: object.__new__() takes exactly one argument (the type to instantiate)\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsRepo::test_get_repo_url",
+      "outcome": "error",
+      "summary": "failed on setup with \"TypeError: object.__new__() takes exactly one argument (the type to instantiate)\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsWorktree::test_create_worktree",
+      "outcome": "error",
+      "summary": "failed on setup with \"TypeError: object.__new__() takes exactly one argument (the type to instantiate)\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsWorktree::test_create_worktree_with_base",
+      "outcome": "error",
+      "summary": "failed on setup with \"TypeError: object.__new__() takes exactly one argument (the type to instantiate)\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsWorktree::test_list_worktrees",
+      "outcome": "error",
+      "summary": "failed on setup with \"TypeError: object.__new__() takes exactly one argument (the type to instantiate)\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsWorktree::test_remove_worktree",
+      "outcome": "error",
+      "summary": "failed on setup with \"TypeError: object.__new__() takes exactly one argument (the type to instantiate)\""
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_orchestrator.py::TestOrchestratorMerge::test_merge_blocked_state_triggers_ci_repair",
+      "outcome": "failure",
+      "summary": "AssertionError: Expected 'mock' to have been called once. Called 0 times."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_orchestrator.py::TestOrchestratorMerge::test_merge_no_pr",
+      "outcome": "failure",
+      "summary": "assert 0 > 0"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_orchestrator.py::TestOrchestratorMerge::test_merge_pr_and_cleanup",
+      "outcome": "failure",
+      "summary": "AssertionError: Expected 'merge_pr' to be called once. Called 0 times."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_orchestrator.py::TestOrchestratorMerge::test_merge_unstable_skips_ci_repair",
+      "outcome": "failure",
+      "summary": "AssertionError: Expected 'merge_pr' to be called once. Called 0 times."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_orchestrator.py::TestOrchestratorMerge::test_merge_with_worktree_cleanup",
+      "outcome": "failure",
+      "summary": "AssertionError: Expected 'remove_worktree' to be called once. Called 0 times."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_orchestrator.py::TestOrchestratorPrReview::test_pr_creation_failure_raises",
+      "outcome": "failure",
+      "summary": "Failed: DID NOT RAISE GitHubOpsError"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_orchestrator.py::TestOrchestratorPrReview::test_pr_review_accumulates_tokens",
+      "outcome": "failure",
+      "summary": "AssertionError: expected call not found."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_orchestrator.py::TestOrchestratorPrReview::test_pr_review_approved_early_moves_to_report",
+      "outcome": "failure",
+      "summary": "AssertionError: assert 0 == 2"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_orchestrator.py::TestOrchestratorPrReview::test_pr_review_below_max_starts_fix",
+      "outcome": "failure",
+      "summary": "AssertionError: assert 0 == 2"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_orchestrator.py::TestOrchestratorPrReview::test_pr_review_first_round_creates_pr",
+      "outcome": "failure",
+      "summary": "AssertionError: Expected 'create_pr' to have been called once. Called 0 times."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_orchestrator.py::TestOrchestratorPrReview::test_pr_review_force_full_rounds_does_not_end_early",
+      "outcome": "failure",
+      "summary": "KeyError: 'current_round'"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_orchestrator.py::TestOrchestratorPrReview::test_pr_review_max_one_still_allows_fix_round",
+      "outcome": "failure",
+      "summary": "AssertionError: assert 0 == 3"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_orchestrator.py::TestOrchestratorPrReview::test_pr_review_max_rounds_moves_to_report",
+      "outcome": "failure",
+      "summary": "KeyError: 'current_phase'"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_orchestrator.py::TestOrchestratorPrReview::test_pr_review_max_two_caps_at_round_two",
+      "outcome": "failure",
+      "summary": "AssertionError: assert None == 'report'"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_orchestrator.py::TestOrchestratorPrReview::test_pr_review_max_two_full_flow_two_reviews_two_fixes",
+      "outcome": "failure",
+      "summary": "AssertionError: assert 0 == 2"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_orchestrator.py::TestOrchestratorPrReview::test_pr_review_posts_comment_to_pr",
+      "outcome": "failure",
+      "summary": "AssertionError: Expected 'add_pr_comment' to have been called."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_orchestrator.py::TestOrchestratorPrReview::test_pr_review_push_failure_blocks_pr_creation",
+      "outcome": "failure",
+      "summary": "Failed: DID NOT RAISE RuntimeError"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_orchestrator.py::TestOrchestratorPrReview::test_pr_review_pushes_branch_before_pr",
+      "outcome": "failure",
+      "summary": "AssertionError: Expected 'git_push' to have been called."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_orchestrator.py::TestOrchestratorPrReview::test_pr_review_uses_github_pr_diff_not_two_point_main_diff",
+      "outcome": "failure",
+      "summary": "IndexError: list index out of range"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_orchestrator.py::TestOrchestratorPreparation::test_preparation_branches_from_origin_main",
+      "outcome": "failure",
+      "summary": "TypeError: Object of type MagicMock is not JSON serializable"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_orchestrator.py::TestOrchestratorPreparation::test_preparation_creates_issue_and_branch",
+      "outcome": "failure",
+      "summary": "TypeError: Object of type MagicMock is not JSON serializable"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_orchestrator.py::TestOrchestratorPreparation::test_preparation_issue_url_no_text_reads_issue",
+      "outcome": "failure",
+      "summary": "TypeError: Object of type MagicMock is not JSON serializable"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_orchestrator.py::TestOrchestratorPreparation::test_preparation_persists_issue_number_from_url",
+      "outcome": "failure",
+      "summary": "TypeError: Object of type MagicMock is not JSON serializable"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_orchestrator.py::TestOrchestratorPreparation::test_preparation_reads_existing_issue",
+      "outcome": "failure",
+      "summary": "TypeError: Object of type MagicMock is not JSON serializable"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_orchestrator.py::TestOrchestratorPreparation::test_preparation_reads_issue_with_comments",
+      "outcome": "failure",
+      "summary": "TypeError: Object of type MagicMock is not JSON serializable"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_orchestrator.py::TestOrchestratorPreparation::test_preparation_worktree_strategy",
+      "outcome": "failure",
+      "summary": "app.modules.workspace.autonomous.github_ops.GitHubOpsError: Worktree created on wrong branch: expected auto-dev/test-wf-uuid, actual auto-dev/test-wf-"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "716",
+      "nodeid": "tests/issues/716/test_orchestrator.py::TestOrchestratorPreparation::test_preparation_worktree_uses_preferred_path_when_live_path_empty",
+      "outcome": "failure",
+      "summary": "TypeError: Object of type MagicMock is not JSON serializable"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "72",
+      "nodeid": "tests/issues/72/test_issue72.py::test_fullscreen",
+      "outcome": "failure",
+      "summary": "AttributeError: 'coroutine' object has no attribute 'chromium'"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "720",
+      "nodeid": "tests/issues/720/test_model_gateway_handler.py::TestGatewaySuccess::test_gateway_forward_success",
+      "outcome": "failure",
+      "summary": "assert 502 == 200"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "723",
+      "nodeid": "tests/issues/723/test_mtime_fallback.py::TestListCliSessionIdsForProject::test_returns_distinct_nonempty_ids",
+      "outcome": "failure",
+      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "723",
+      "nodeid": "tests/issues/723/test_orchestrator_dev_salvage.py::test_dev_not_salvaged_when_no_commit",
+      "outcome": "failure",
+      "summary": "AssertionError: dev failure with no commit should still mark the workflow failed"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "723",
+      "nodeid": "tests/issues/723/test_orchestrator_dev_salvage.py::test_dev_salvaged_on_timeout_with_commit",
+      "outcome": "failure",
+      "summary": "AssertionError: dev milestone should be completed when salvaged"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "733",
+      "nodeid": "tests/issues/733/test_orchestrator_733.py::TestDevelopmentCommitVerification::test_allows_different_commits",
+      "outcome": "failure",
+      "summary": "sqlite3.OperationalError: no such table: users"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "733",
+      "nodeid": "tests/issues/733/test_orchestrator_733.py::TestDevelopmentCommitVerification::test_auto_commit_failure_falls_back_to_fail",
+      "outcome": "failure",
+      "summary": "sqlite3.OperationalError: no such table: users"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "733",
+      "nodeid": "tests/issues/733/test_orchestrator_733.py::TestDevelopmentCommitVerification::test_auto_commits_uncommitted_changes",
+      "outcome": "failure",
+      "summary": "sqlite3.OperationalError: no such table: users"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "733",
+      "nodeid": "tests/issues/733/test_orchestrator_733.py::TestDevelopmentCommitVerification::test_detects_no_code_changes",
+      "outcome": "failure",
+      "summary": "sqlite3.OperationalError: no such table: users"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "733",
+      "nodeid": "tests/issues/733/test_orchestrator_733.py::TestDevelopmentCommitVerification::test_skip_check_when_agent_fails",
+      "outcome": "failure",
+      "summary": "sqlite3.OperationalError: no such table: users"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "733",
+      "nodeid": "tests/issues/733/test_orchestrator_733.py::TestDevelopmentCommitVerification::test_skip_check_when_commit_unavailable",
+      "outcome": "failure",
+      "summary": "sqlite3.OperationalError: no such table: users"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "733",
+      "nodeid": "tests/issues/733/test_orchestrator_733.py::TestFinalPlanAnnotation::test_final_plan_includes_last_review",
+      "outcome": "failure",
+      "summary": "sqlite3.OperationalError: no such table: users"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "733",
+      "nodeid": "tests/issues/733/test_orchestrator_733.py::TestFinalPlanAnnotation::test_final_plan_without_review",
+      "outcome": "failure",
+      "summary": "sqlite3.OperationalError: no such table: users"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "733",
+      "nodeid": "tests/issues/733/test_orchestrator_733.py::TestPermissionModePassthrough::test_default_permission_mode_is_auto_edit",
+      "outcome": "failure",
+      "summary": "sqlite3.OperationalError: no such table: users"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "733",
+      "nodeid": "tests/issues/733/test_orchestrator_733.py::TestPermissionModePassthrough::test_development_passes_permission_mode",
+      "outcome": "failure",
+      "summary": "sqlite3.OperationalError: no such table: users"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "733",
+      "nodeid": "tests/issues/733/test_orchestrator_733.py::TestPermissionModePassthrough::test_planning_passes_permission_mode",
+      "outcome": "failure",
+      "summary": "sqlite3.OperationalError: no such table: users"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "733",
+      "nodeid": "tests/issues/733/test_orchestrator_733.py::TestPlanningPromptConstraints::test_initial_plan_prompt_forbids_full_code",
+      "outcome": "failure",
+      "summary": "sqlite3.OperationalError: no such table: users"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "733",
+      "nodeid": "tests/issues/733/test_orchestrator_733.py::TestPlanningPromptConstraints::test_refined_plan_prompt_forbids_full_code",
+      "outcome": "failure",
+      "summary": "sqlite3.OperationalError: no such table: users"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "74",
+      "nodeid": "tests/issues/74/test_restore_button.py::test_restore_button",
+      "outcome": "failure",
+      "summary": "Failed: async def functions are not natively supported."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "740",
+      "nodeid": "tests/issues/740/test_batch1_session_wiring.py::TestBackwardCompatibility::test_do_development_still_works",
+      "outcome": "failure",
+      "summary": "AssertionError: assert False"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "740",
+      "nodeid": "tests/issues/740/test_batch1_session_wiring.py::TestBackwardCompatibility::test_do_planning_still_works",
+      "outcome": "failure",
+      "summary": "AssertionError: assert 0 == 2"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "740",
+      "nodeid": "tests/issues/740/test_batch1_session_wiring.py::TestRunAgentWrapper::test_run_agent_passes_pre_generated_session_id",
+      "outcome": "failure",
+      "summary": "TypeError: 'NoneType' object is not subscriptable"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "740",
+      "nodeid": "tests/issues/740/test_batch1_session_wiring.py::TestRunAgentWrapper::test_run_agent_tracks_session_id",
+      "outcome": "failure",
+      "summary": "AssertionError: assert None == 'sess-tracked-123'"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "740",
+      "nodeid": "tests/issues/740/test_batch1_session_wiring.py::TestRunAgentWrapper::test_run_agent_updates_on_each_call",
+      "outcome": "failure",
+      "summary": "AssertionError: assert None == 'track-review-1'"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "740",
+      "nodeid": "tests/issues/740/test_batch1_session_wiring.py::TestRunAgentWrapper::test_session_id_available_before_run_agent_task_returns",
+      "outcome": "failure",
+      "summary": "assert None is not None"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "740",
+      "nodeid": "tests/issues/740/test_batch1_session_wiring.py::TestStopPauseCancelsTask::test_pause_calls_cancel_running_task",
+      "outcome": "failure",
+      "summary": "sqlite3.OperationalError: database is locked"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "740",
+      "nodeid": "tests/issues/740/test_batch1_session_wiring.py::TestStopPauseCancelsTask::test_stop_calls_cancel_running_task",
+      "outcome": "failure",
+      "summary": "sqlite3.OperationalError: database is locked"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "740",
+      "nodeid": "tests/issues/740/test_batch2_idempotency_validation.py::TestRunAgentDbOptimization::test_run_agent_uses_passed_wf_for_timeout",
+      "outcome": "failure",
+      "summary": "TypeError: 'NoneType' object is not subscriptable"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "740",
+      "nodeid": "tests/issues/740/test_batch2_idempotency_validation.py::TestRunAgentDbOptimization::test_run_agent_without_wf_falls_back_to_db",
+      "outcome": "failure",
+      "summary": "TypeError: 'NoneType' object is not subscriptable"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "740",
+      "nodeid": "tests/issues/740/test_batch2_idempotency_validation.py::TestTimeoutConfig::test_run_agent_injects_workflow_timeout",
+      "outcome": "failure",
+      "summary": "TypeError: 'NoneType' object is not subscriptable"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "740",
+      "nodeid": "tests/issues/740/test_batch2_idempotency_validation.py::TestTimeoutConfig::test_run_agent_omits_timeout_when_not_set",
+      "outcome": "failure",
+      "summary": "TypeError: 'NoneType' object is not subscriptable"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "740",
+      "nodeid": "tests/issues/740/test_batch2_idempotency_validation.py::TestTimeoutConfig::test_run_agent_respects_explicit_timeout",
+      "outcome": "failure",
+      "summary": "TypeError: 'NoneType' object is not subscriptable"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "740",
+      "nodeid": "tests/issues/740/test_batch4_diff_api.py::TestGetMilestoneDiff::test_diff_falls_back_to_project_path",
+      "outcome": "failure",
+      "summary": "AssertionError: expected call not found."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "740",
+      "nodeid": "tests/issues/740/test_batch4_diff_api.py::TestGetMilestoneDiff::test_diff_uses_worktree_path_preferred",
+      "outcome": "failure",
+      "summary": "AssertionError: expected call not found."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "740",
+      "nodeid": "tests/issues/740/test_batch4_diff_api.py::TestWorkflowListStatusFilter::test_list_with_status_filter",
+      "outcome": "failure",
+      "summary": "AssertionError: 500 != 200"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "740",
+      "nodeid": "tests/issues/740/test_batch4_diff_api.py::TestWorkflowListStatusFilter::test_list_without_status_filter",
+      "outcome": "failure",
+      "summary": "AssertionError: 500 != 200"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "740",
+      "nodeid": "tests/issues/740/test_batch6_distributed_lock.py::TestRemoteMachineAdminValidation::test_allows_admin_remote_workflow",
+      "outcome": "failure",
+      "summary": "AssertionError: 500 != 201"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "740",
+      "nodeid": "tests/issues/740/test_batch6_distributed_lock.py::TestRemoteMachineAdminValidation::test_allows_local_workflow_without_check",
+      "outcome": "failure",
+      "summary": "AssertionError: 500 != 201"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "740",
+      "nodeid": "tests/issues/740/test_batch6_distributed_lock.py::TestRemoteMachineAdminValidation::test_allows_machine_admin_remote_workflow",
+      "outcome": "failure",
+      "summary": "AssertionError: 500 != 201"
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "76",
+      "nodeid": "tests/issues/76/test_menu.py::test_menu",
+      "outcome": "error",
+      "summary": "failed on setup with \"file tests/issues/76/test_menu.py, line 15"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "761",
+      "nodeid": "tests/issues/761/test_planning_restriction.py::TestPlanningTimeout::test_extension_adds_to_base_timeout",
+      "outcome": "failure",
+      "summary": "assert (1800 + 0) == 600"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "761",
+      "nodeid": "tests/issues/761/test_planning_restriction.py::TestPlanningTimeout::test_multiple_extensions_accumulate",
+      "outcome": "failure",
+      "summary": "assert (1800 + 600) == 1200"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "761",
+      "nodeid": "tests/issues/761/test_planning_restriction.py::TestPlanningTimeout::test_planning_timeout_constant",
+      "outcome": "failure",
+      "summary": "assert 1800 == 600"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "764",
+      "nodeid": "tests/issues/764/test_session_create_params.py::TestCreateSessionAcceptsWorkspaceParams::test_create_session_defaults_to_local",
+      "outcome": "failure",
+      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "764",
+      "nodeid": "tests/issues/764/test_session_create_params.py::TestCreateSessionAcceptsWorkspaceParams::test_create_session_includes_workspace_in_insert",
+      "outcome": "failure",
+      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "764",
+      "nodeid": "tests/issues/764/test_session_create_params.py::TestCreateSessionAcceptsWorkspaceParams::test_create_session_type_error_fixed",
+      "outcome": "failure",
+      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "764",
+      "nodeid": "tests/issues/764/test_session_create_params.py::TestCreateSessionAcceptsWorkspaceParams::test_create_session_with_workspace_type",
+      "outcome": "failure",
+      "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "786",
+      "nodeid": "tests/issues/786/test_ai_github_account.py::TestGitHubOpsEnvInjection::test_build_subprocess_kwargs_no_env",
+      "outcome": "failure",
+      "summary": "TypeError: object.__new__() takes exactly one argument (the type to instantiate)"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "786",
+      "nodeid": "tests/issues/786/test_ai_github_account.py::TestGitHubOpsEnvInjection::test_build_subprocess_kwargs_with_env",
+      "outcome": "failure",
+      "summary": "TypeError: object.__new__() takes exactly one argument (the type to instantiate)"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "786",
+      "nodeid": "tests/issues/786/test_ai_github_account.py::TestGitHubOpsEnvInjection::test_get_env_returns_dict_when_configured",
+      "outcome": "failure",
+      "summary": "TypeError: object.__new__() takes exactly one argument (the type to instantiate)"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "786",
+      "nodeid": "tests/issues/786/test_ai_github_account.py::TestGitHubOpsEnvInjection::test_get_env_returns_none_when_no_config",
+      "outcome": "failure",
+      "summary": "TypeError: object.__new__() takes exactly one argument (the type to instantiate)"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "786",
+      "nodeid": "tests/issues/786/test_ai_github_account.py::TestGitHubOpsEnvInjection::test_run_gh_injects_env",
+      "outcome": "failure",
+      "summary": "TypeError: object.__new__() takes exactly one argument (the type to instantiate)"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "786",
+      "nodeid": "tests/issues/786/test_ai_github_account.py::TestGitHubOpsEnvInjection::test_run_gh_no_env_when_not_configured",
+      "outcome": "failure",
+      "summary": "TypeError: object.__new__() takes exactly one argument (the type to instantiate)"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "786",
+      "nodeid": "tests/issues/786/test_ai_github_account.py::TestGitHubOpsEnvInjection::test_run_git_injects_env",
+      "outcome": "failure",
+      "summary": "TypeError: object.__new__() takes exactly one argument (the type to instantiate)"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "79",
+      "nodeid": "tests/issues/79/test_add_user_final.py::test_add_user",
+      "outcome": "failure",
+      "summary": "Failed: async def functions are not natively supported."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "79",
+      "nodeid": "tests/issues/79/test_add_user_save.py::test_add_user_save",
+      "outcome": "failure",
+      "summary": "Failed: async def functions are not natively supported."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "79",
+      "nodeid": "tests/issues/79/test_add_user_save_v2.py::test_add_user_save",
+      "outcome": "failure",
+      "summary": "Failed: async def functions are not natively supported."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "79",
+      "nodeid": "tests/issues/79/test_conversation_detail_modal.py::test_conversation_history_api",
+      "outcome": "failure",
+      "summary": "Failed: async def functions are not natively supported."
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "79",
+      "nodeid": "tests/issues/79/test_conversation_detail_modal.py::test_conversation_timeline_api",
+      "outcome": "error",
+      "summary": "failed on setup with \"file tests/issues/79/test_conversation_detail_modal.py, line 44"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "79",
+      "nodeid": "tests/issues/79/test_conversation_detail_modal.py::test_frontend_build",
+      "outcome": "failure",
+      "summary": "Failed: async def functions are not natively supported."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "79",
+      "nodeid": "tests/issues/79/test_issue79_conversation_detail.py::test_conversation_detail_modal",
+      "outcome": "failure",
+      "summary": "Failed: async def functions are not natively supported."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "79",
+      "nodeid": "tests/issues/79/test_role_filter.py::test_role_filter",
+      "outcome": "failure",
+      "summary": "Failed: async def functions are not natively supported."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "80",
+      "nodeid": "tests/issues/80/test_manage_language_dropdown.py::test_manage_language_dropdown",
+      "outcome": "failure",
+      "summary": "playwright._impl._errors.Error: Page.goto: net::ERR_CONNECTION_REFUSED at http://<host:port>/login"
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "811",
+      "nodeid": "tests/issues/811/test_unknown_user_filter.py::TestUnknownUserFilter::test_known_users_still_returned",
+      "outcome": "error",
+      "summary": "failed on setup with \"file tests/issues/811/test_unknown_user_filter.py, line 78"
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "811",
+      "nodeid": "tests/issues/811/test_unknown_user_filter.py::TestUnknownUserFilter::test_request_counts_correct",
+      "outcome": "error",
+      "summary": "failed on setup with \"file tests/issues/811/test_unknown_user_filter.py, line 91"
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "811",
+      "nodeid": "tests/issues/811/test_unknown_user_filter.py::TestUnknownUserFilter::test_unknown_user_filtered_out",
+      "outcome": "error",
+      "summary": "failed on setup with \"file tests/issues/811/test_unknown_user_filter.py, line 61"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "814",
+      "nodeid": "tests/issues/814/test_worktree_path_selfheal.py::TestEnsureWorktreeSelfHeal::test_no_update_when_path_already_canonical",
+      "outcome": "failure",
+      "summary": "app.modules.workspace.autonomous.github_ops.GitHubOpsError: Worktree branch mismatch (<MagicMock name='mock.get_current_branch()' id='139766050919888'> != auto-dev/1390d553) with uncommitted changes.…"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "814",
+      "nodeid": "tests/issues/814/test_worktree_path_selfheal.py::TestEnsureWorktreeSelfHeal::test_normalizes_stale_dotdot_path_when_valid",
+      "outcome": "failure",
+      "summary": "app.modules.workspace.autonomous.github_ops.GitHubOpsError: Worktree branch mismatch (<MagicMock name='mock.get_current_branch()' id='139766021823888'> != auto-dev/1390d553) with uncommitted changes.…"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "82",
+      "nodeid": "tests/issues/82/test_sidebar_collapse.py::test_sidebar_collapse",
+      "outcome": "failure",
+      "summary": "playwright._impl._errors.TimeoutError: Page.fill: Timeout 30000ms exceeded."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "82",
+      "nodeid": "tests/issues/82/test_sidebar_collapse_normal_user.py::test_sidebar_collapse_normal_user",
+      "outcome": "failure",
+      "summary": "playwright._impl._errors.TimeoutError: Page.fill: Timeout 30000ms exceeded."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "822",
+      "nodeid": "tests/issues/822/test_merge_conflict_detection.py::TestAddWorktreeExistingBranch::test_add_worktree_no_b_flag",
+      "outcome": "failure",
+      "summary": "TypeError: object.__new__() takes exactly one argument (the type to instantiate)"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "822",
+      "nodeid": "tests/issues/822/test_merge_conflict_detection.py::TestAddWorktreeExistingBranch::test_add_worktree_returns_path_and_branch",
+      "outcome": "failure",
+      "summary": "TypeError: object.__new__() takes exactly one argument (the type to instantiate)"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "822",
+      "nodeid": "tests/issues/822/test_merge_conflict_detection.py::TestDoMergeDeferredRetry::test_uses_graph_merge_base_and_backfills_stale_scope_base",
+      "outcome": "failure",
+      "summary": "AssertionError: assert [call(['fetch... check=False)] == [call(['fetch... check=False)]"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "822",
+      "nodeid": "tests/issues/822/test_merge_conflict_detection.py::TestGetConflictMarkerPaths::test_deleted_conflict_path_is_a_valid_marker_free_resolution",
+      "outcome": "failure",
+      "summary": "TypeError: object.__new__() takes exactly one argument (the type to instantiate)"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "822",
+      "nodeid": "tests/issues/822/test_merge_conflict_detection.py::TestGetConflictMarkerPaths::test_detects_custom_marker_size_larger_than_seven",
+      "outcome": "failure",
+      "summary": "TypeError: object.__new__() takes exactly one argument (the type to instantiate)"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "822",
+      "nodeid": "tests/issues/822/test_merge_conflict_detection.py::TestGetConflictMarkerPaths::test_no_matches_returns_empty_list",
+      "outcome": "failure",
+      "summary": "TypeError: object.__new__() takes exactly one argument (the type to instantiate)"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "822",
+      "nodeid": "tests/issues/822/test_merge_conflict_detection.py::TestGetConflictMarkerPaths::test_probe_failure_raises",
+      "outcome": "failure",
+      "summary": "TypeError: object.__new__() takes exactly one argument (the type to instantiate)"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "822",
+      "nodeid": "tests/issues/822/test_merge_conflict_detection.py::TestGetConflictMarkerPaths::test_returns_only_matching_conflict_files",
+      "outcome": "failure",
+      "summary": "TypeError: object.__new__() takes exactly one argument (the type to instantiate)"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "822",
+      "nodeid": "tests/issues/822/test_merge_conflict_detection.py::TestGetUnmergedPaths::test_query_failure_raises",
+      "outcome": "failure",
+      "summary": "TypeError: object.__new__() takes exactly one argument (the type to instantiate)"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "822",
+      "nodeid": "tests/issues/822/test_merge_conflict_detection.py::TestGetUnmergedPaths::test_returns_authoritative_u_stage_paths",
+      "outcome": "failure",
+      "summary": "TypeError: object.__new__() takes exactly one argument (the type to instantiate)"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "822",
+      "nodeid": "tests/issues/822/test_merge_conflict_detection.py::TestGetWorktreeChangedPaths::test_combines_tracked_unmerged_and_untracked_paths",
+      "outcome": "failure",
+      "summary": "TypeError: object.__new__() takes exactly one argument (the type to instantiate)"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "822",
+      "nodeid": "tests/issues/822/test_merge_conflict_detection.py::TestGetWorktreeChangedPaths::test_probe_failure_raises[0]",
+      "outcome": "failure",
+      "summary": "TypeError: object.__new__() takes exactly one argument (the type to instantiate)"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "822",
+      "nodeid": "tests/issues/822/test_merge_conflict_detection.py::TestGetWorktreeChangedPaths::test_probe_failure_raises[1]",
+      "outcome": "failure",
+      "summary": "TypeError: object.__new__() takes exactly one argument (the type to instantiate)"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "822",
+      "nodeid": "tests/issues/822/test_merge_conflict_detection.py::TestIndexSnapshot::test_parses_stage_zero_and_unmerged_entries",
+      "outcome": "failure",
+      "summary": "TypeError: object.__new__() takes exactly one argument (the type to instantiate)"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "822",
+      "nodeid": "tests/issues/822/test_merge_conflict_detection.py::TestIndexSnapshot::test_snapshot_probe_and_parse_fail_closed",
+      "outcome": "failure",
+      "summary": "TypeError: object.__new__() takes exactly one argument (the type to instantiate)"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "822",
+      "nodeid": "tests/issues/822/test_merge_conflict_detection.py::TestMergePrAutoFlag::test_auto_flag_adds_auto_arg",
+      "outcome": "failure",
+      "summary": "TypeError: object.__new__() takes exactly one argument (the type to instantiate)"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "822",
+      "nodeid": "tests/issues/822/test_merge_conflict_detection.py::TestMergePrAutoFlag::test_no_auto_by_default",
+      "outcome": "failure",
+      "summary": "TypeError: object.__new__() takes exactly one argument (the type to instantiate)"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "822",
+      "nodeid": "tests/issues/822/test_merge_conflict_detection.py::TestResolveCommit::test_empty_resolution_raises",
+      "outcome": "failure",
+      "summary": "TypeError: object.__new__() takes exactly one argument (the type to instantiate)"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "822",
+      "nodeid": "tests/issues/822/test_merge_conflict_detection.py::TestResolveCommit::test_resolves_ref_to_immutable_commit",
+      "outcome": "failure",
+      "summary": "TypeError: object.__new__() takes exactly one argument (the type to instantiate)"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "822",
+      "nodeid": "tests/issues/822/test_merge_conflict_detection.py::TestResolveMergeConflictsWorktreeIsolation::test_removes_existing_worktree_before_adding_temp",
+      "outcome": "failure",
+      "summary": "AssertionError: mock({'worktree_path': ''}) call not found"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "822",
+      "nodeid": "tests/issues/822/test_merge_conflict_detection.py::TestResolveMergeConflictsWorktreeIsolation::test_restores_worktree_even_on_resolution_failure",
+      "outcome": "failure",
+      "summary": "AssertionError: mock({'worktree_path': '/srv/repo/.worktrees/wf-822'}) call not found"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "826",
+      "nodeid": "tests/issues/826/test_plan_review_semantics.py::TestPlanningIntegration::test_approved_review_skips_refinement",
+      "outcome": "failure",
+      "summary": "app.modules.workspace.autonomous.github_ops.GitHubOpsError: trusted common_dir is not a .git directory: /tmp/test.git"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "826",
+      "nodeid": "tests/issues/826/test_plan_review_semantics.py::TestPlanningIntegration::test_plan_review_final_refine_failure_blocks_development",
+      "outcome": "failure",
+      "summary": "app.modules.workspace.autonomous.github_ops.GitHubOpsError: trusted common_dir is not a .git directory: /tmp/test.git"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "826",
+      "nodeid": "tests/issues/826/test_plan_review_semantics.py::TestPlanningIntegration::test_substantive_review_triggers_refinement",
+      "outcome": "failure",
+      "summary": "app.modules.workspace.autonomous.github_ops.GitHubOpsError: trusted common_dir is not a .git directory: /tmp/test.git"
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "863",
+      "nodeid": "tests/issues/863/e2e_ip_whitelist_input.py::test_api_ip_whitelist",
+      "outcome": "error",
+      "summary": "failed on setup with \"file tests/issues/863/e2e_ip_whitelist_input.py, line 95"
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "863",
+      "nodeid": "tests/issues/863/e2e_ip_whitelist_input.py::test_ui_ip_whitelist_dedupe",
+      "outcome": "error",
+      "summary": "failed on setup with \"AssertionError\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "863",
+      "nodeid": "tests/issues/863/e2e_ip_whitelist_input.py::test_ui_ip_whitelist_empty_lines",
+      "outcome": "error",
+      "summary": "failed on setup with \"AssertionError\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "863",
+      "nodeid": "tests/issues/863/e2e_ip_whitelist_input.py::test_ui_ip_whitelist_newline",
+      "outcome": "error",
+      "summary": "failed on setup with \"AssertionError\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "863",
+      "nodeid": "tests/issues/863/e2e_ip_whitelist_input.py::test_ui_ip_whitelist_trim",
+      "outcome": "error",
+      "summary": "failed on setup with \"AssertionError\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "886",
+      "nodeid": "tests/issues/886/test_cancel_fork_redesign.py::TestCancelMilestoneWithFeedback::test_cancel_creates_requirement_received_milestone",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "886",
+      "nodeid": "tests/issues/886/test_cancel_fork_redesign.py::TestCancelMilestoneWithFeedback::test_cancel_empty_feedback_succeeds",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "886",
+      "nodeid": "tests/issues/886/test_cancel_fork_redesign.py::TestCancelMilestoneWithFeedback::test_cancel_stores_feedback_on_workflow",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "886",
+      "nodeid": "tests/issues/886/test_cancel_fork_redesign.py::TestCancelMilestoneWithFeedback::test_cancel_without_feedback_succeeds",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "886",
+      "nodeid": "tests/issues/886/test_cancel_fork_redesign.py::TestForkListing::test_get_forks_empty",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "886",
+      "nodeid": "tests/issues/886/test_cancel_fork_redesign.py::TestForkListing::test_get_forks_returns_children",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "886",
+      "nodeid": "tests/issues/886/test_cancel_fork_redesign.py::TestForkMilestone::test_fork_copies_milestones",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "886",
+      "nodeid": "tests/issues/886/test_cancel_fork_redesign.py::TestForkMilestone::test_fork_creates_forked_milestone_on_parent",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "886",
+      "nodeid": "tests/issues/886/test_cancel_fork_redesign.py::TestForkMilestone::test_fork_creates_new_workflow",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "886",
+      "nodeid": "tests/issues/886/test_cancel_fork_redesign.py::TestForkMilestone::test_fork_forces_worktree_strategy",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "886",
+      "nodeid": "tests/issues/886/test_cancel_fork_redesign.py::TestForkMilestone::test_fork_pause_original",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "886",
+      "nodeid": "tests/issues/886/test_cancel_fork_redesign.py::TestForkRepoIntegration::test_copy_milestones_strips_inherited_fork_workflow_id",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "886",
+      "nodeid": "tests/issues/886/test_cancel_fork_redesign.py::TestForkRepoIntegration::test_copy_milestones_to_workflow",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "886",
+      "nodeid": "tests/issues/886/test_cancel_fork_redesign.py::TestForkRepoIntegration::test_create_and_list_forks",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "886",
+      "nodeid": "tests/issues/886/test_cancel_fork_redesign.py::TestForkRepoIntegration::test_create_milestone_persists_fork_workflow_id",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "886",
+      "nodeid": "tests/issues/886/test_cancel_fork_redesign.py::TestForkRepoIntegration::test_list_forks_empty",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "setup_error",
+      "exception_type": "",
+      "issue_number": "886",
+      "nodeid": "tests/issues/886/test_cancel_fork_redesign.py::TestResumeWithFeedback::test_resume_with_feedback",
+      "outcome": "error",
+      "summary": "failed on setup with \"sqlite3.OperationalError: no such column: deleted_at\""
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "91",
+      "nodeid": "tests/issues/91/test_management_button.py::test_admin_user",
+      "outcome": "failure",
+      "summary": "Failed: async def functions are not natively supported."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "91",
+      "nodeid": "tests/issues/91/test_management_button.py::test_normal_user",
+      "outcome": "failure",
+      "summary": "Failed: async def functions are not natively supported."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "913",
+      "nodeid": "tests/issues/913/test_pr909_review_feedback.py::TestGetCheckFailureExcerpt::test_ci_repair_context_skips_excerpt_failure",
+      "outcome": "failure",
+      "summary": "assert '失败摘录' not in \"PR #42 在合并前...9645632912'>\""
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "95",
+      "nodeid": "tests/issues/95/test_messages_ui.py::test_messages_ui",
+      "outcome": "failure",
+      "summary": "playwright._impl._errors.Error: Page.goto: net::ERR_CONNECTION_REFUSED at http://<host:port>/login"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "98",
+      "nodeid": "tests/issues/98/test_conversation_detail.py::test_conversation_detail",
+      "outcome": "failure",
+      "summary": "Failed: async def functions are not natively supported."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "98",
+      "nodeid": "tests/issues/98/test_data_update.py::test_data_update",
+      "outcome": "failure",
+      "summary": "Failed: async def functions are not natively supported."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "98",
+      "nodeid": "tests/issues/98/test_global_refresh.py::test_global_refresh",
+      "outcome": "failure",
+      "summary": "Failed: async def functions are not natively supported."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "98",
+      "nodeid": "tests/issues/98/test_refresh.py::test_messages_refresh",
+      "outcome": "failure",
+      "summary": "Failed: async def functions are not natively supported."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "98",
+      "nodeid": "tests/issues/98/test_refresh_detailed.py::test_messages_refresh_detailed",
+      "outcome": "failure",
+      "summary": "Failed: async def functions are not natively supported."
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "987",
+      "nodeid": "tests/issues/987/test_prompt_truncation.py::TestPostGithubComment::test_long_body_capped_with_notice",
+      "outcome": "failure",
+      "summary": "AssertionError: assert '截断' in 'BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB…"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "987",
+      "nodeid": "tests/issues/987/test_prompt_truncation.py::TestPrReviewPrompt::test_previous_review_content_not_reinjected_but_instruction_kept",
+      "outcome": "failure",
+      "summary": "IndexError: list index out of range"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "987",
+      "nodeid": "tests/issues/987/test_prompt_truncation.py::TestPrReviewPrompt::test_requirements_not_injected",
+      "outcome": "failure",
+      "summary": "IndexError: list index out of range"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "987",
+      "nodeid": "tests/issues/987/test_prompt_truncation.py::TestSummaryPrompt::test_last_pr_review_kept_last_fix_summary_removed",
+      "outcome": "failure",
+      "summary": "assert 0 >= 2"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "993",
+      "nodeid": "tests/issues/993/test_tldr.py::TestMilestoneTldrWrite::test_pr_reviewed_milestone_carries_tldr",
+      "outcome": "failure",
+      "summary": "AssertionError: pr_reviewed milestone update not captured"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "993",
+      "nodeid": "tests/issues/993/test_tldr.py::TestTldrInstruction::test_run_agent_appends_instruction",
+      "outcome": "failure",
+      "summary": "KeyError: 'prompt'"
+    },
+    {
+      "category": "test_body_exception",
+      "exception_type": "",
+      "issue_number": "996",
+      "nodeid": "tests/issues/996/test_agent_permissions.py::TestFixPhasePermissionsAndFallback::test_fix_salvages_uncommitted_when_agent_did_not_commit",
+      "outcome": "failure",
+      "summary": "AssertionError: Expected 'git_add_all' to have been called once. Called 2 times."
+    }
+  ],
+  "provenance": {
+    "generated_command": "python scripts/legacy_issue_baseline.py snapshot --junit /tmp/2457-artifacts/*/test-results/issues-*.xml --source-run 31347939641",
+    "reference_commit": "39fce2429b1a06e3331c8a09b11e62bf40c931e8",
+    "run_contract": "extended-tests issue-tests, --isolated-home --reruns 1 --timeout 240, 4 shards; tests/issues/604 hang skipped",
+    "source_run": "31347939641",
+    "source_run_url": ""
+  },
+  "schema": "openace-legacy-issue-failures",
+  "selection": "not postgres",
+  "version": 1
+}

--- a/ci/legacy-issue-failures.json
+++ b/ci/legacy-issue-failures.json
@@ -233,38 +233,6 @@
       "summary": "RuntimeError: LLM proxy setup failed; refusing to launch autonomous agent with inherited credentials (set OPENACE_ALLOW_RAW_KEY_FALLBACK=1 only in development)."
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "TypeError",
-      "issue_number": "1395",
-      "nodeid": "tests/issues/1395/test_cross_user_permissions.py::TestPreparationWorktreeCleanup::test_clean_path_creates_worktree_directly",
-      "outcome": "failure",
-      "summary": "TypeError: Object of type MagicMock is not JSON serializable"
-    },
-    {
-      "category": "test_body_exception",
-      "exception_type": "TypeError",
-      "issue_number": "1395",
-      "nodeid": "tests/issues/1395/test_cross_user_permissions.py::TestPreparationWorktreeCleanup::test_non_registered_residual_dir_left_in_place",
-      "outcome": "failure",
-      "summary": "TypeError: Object of type MagicMock is not JSON serializable"
-    },
-    {
-      "category": "test_body_exception",
-      "exception_type": "TypeError",
-      "issue_number": "1395",
-      "nodeid": "tests/issues/1395/test_cross_user_permissions.py::TestPreparationWorktreeCleanup::test_registered_residual_removed_via_git",
-      "outcome": "failure",
-      "summary": "TypeError: Object of type MagicMock is not JSON serializable"
-    },
-    {
-      "category": "test_body_exception",
-      "exception_type": "TypeError",
-      "issue_number": "1395",
-      "nodeid": "tests/issues/1395/test_cross_user_permissions.py::TestPreparationWorktreeCleanup::test_remove_failure_does_not_raise",
-      "outcome": "failure",
-      "summary": "TypeError: Object of type MagicMock is not JSON serializable"
-    },
-    {
       "category": "assertion_failure",
       "exception_type": "AssertionError",
       "issue_number": "1395",
@@ -3185,52 +3153,12 @@
       "summary": "IndexError: list index out of range"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "TypeError",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_orchestrator.py::TestOrchestratorPreparation::test_preparation_branches_from_origin_main",
       "outcome": "failure",
-      "summary": "TypeError: Object of type MagicMock is not JSON serializable"
-    },
-    {
-      "category": "test_body_exception",
-      "exception_type": "TypeError",
-      "issue_number": "716",
-      "nodeid": "tests/issues/716/test_orchestrator.py::TestOrchestratorPreparation::test_preparation_creates_issue_and_branch",
-      "outcome": "failure",
-      "summary": "TypeError: Object of type MagicMock is not JSON serializable"
-    },
-    {
-      "category": "test_body_exception",
-      "exception_type": "TypeError",
-      "issue_number": "716",
-      "nodeid": "tests/issues/716/test_orchestrator.py::TestOrchestratorPreparation::test_preparation_issue_url_no_text_reads_issue",
-      "outcome": "failure",
-      "summary": "TypeError: Object of type MagicMock is not JSON serializable"
-    },
-    {
-      "category": "test_body_exception",
-      "exception_type": "TypeError",
-      "issue_number": "716",
-      "nodeid": "tests/issues/716/test_orchestrator.py::TestOrchestratorPreparation::test_preparation_persists_issue_number_from_url",
-      "outcome": "failure",
-      "summary": "TypeError: Object of type MagicMock is not JSON serializable"
-    },
-    {
-      "category": "test_body_exception",
-      "exception_type": "TypeError",
-      "issue_number": "716",
-      "nodeid": "tests/issues/716/test_orchestrator.py::TestOrchestratorPreparation::test_preparation_reads_existing_issue",
-      "outcome": "failure",
-      "summary": "TypeError: Object of type MagicMock is not JSON serializable"
-    },
-    {
-      "category": "test_body_exception",
-      "exception_type": "TypeError",
-      "issue_number": "716",
-      "nodeid": "tests/issues/716/test_orchestrator.py::TestOrchestratorPreparation::test_preparation_reads_issue_with_comments",
-      "outcome": "failure",
-      "summary": "TypeError: Object of type MagicMock is not JSON serializable"
+      "summary": "AssertionError: assert (<MagicMock name='GitHubOps()._run_git().stdout.strip()' id='140659443529040'> == 'origin/main' or (1 > 1))"
     },
     {
       "category": "test_body_exception",
@@ -3241,12 +3169,12 @@
       "summary": "app.modules.workspace.autonomous.github_ops.GitHubOpsError: Worktree created on wrong branch: expected auto-dev/test-wf-uuid, actual auto-dev/test-wf-"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "TypeError",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_orchestrator.py::TestOrchestratorPreparation::test_preparation_worktree_uses_preferred_path_when_live_path_empty",
       "outcome": "failure",
-      "summary": "TypeError: Object of type MagicMock is not JSON serializable"
+      "summary": "AssertionError: expected call not found."
     },
     {
       "category": "test_body_exception",
@@ -3782,7 +3710,7 @@
       "issue_number": "814",
       "nodeid": "tests/issues/814/test_worktree_path_selfheal.py::TestEnsureWorktreeSelfHeal::test_no_update_when_path_already_canonical",
       "outcome": "failure",
-      "summary": "app.modules.workspace.autonomous.github_ops.GitHubOpsError: Worktree branch mismatch (<MagicMock name='mock.get_current_branch()' id='139708343395536'> != auto-dev/1390d553) with uncommitted changes.\u2026"
+      "summary": "app.modules.workspace.autonomous.github_ops.GitHubOpsError: Worktree branch mismatch (<MagicMock name='mock.get_current_branch()' id='140600398512272'> != auto-dev/1390d553) with uncommitted changes.\u2026"
     },
     {
       "category": "test_body_exception",
@@ -3790,7 +3718,7 @@
       "issue_number": "814",
       "nodeid": "tests/issues/814/test_worktree_path_selfheal.py::TestEnsureWorktreeSelfHeal::test_normalizes_stale_dotdot_path_when_valid",
       "outcome": "failure",
-      "summary": "app.modules.workspace.autonomous.github_ops.GitHubOpsError: Worktree branch mismatch (<MagicMock name='mock.get_current_branch()' id='139708308948880'> != auto-dev/1390d553) with uncommitted changes.\u2026"
+      "summary": "app.modules.workspace.autonomous.github_ops.GitHubOpsError: Worktree branch mismatch (<MagicMock name='mock.get_current_branch()' id='140600663599696'> != auto-dev/1390d553) with uncommitted changes.\u2026"
     },
     {
       "category": "test_body_exception",
@@ -4198,7 +4126,7 @@
       "issue_number": "913",
       "nodeid": "tests/issues/913/test_pr909_review_feedback.py::TestGetCheckFailureExcerpt::test_ci_repair_context_skips_excerpt_failure",
       "outcome": "failure",
-      "summary": "assert '\u5931\u8d25\u6458\u5f55' not in \"PR #42 \u5728\u5408\u5e76\u524d...6713164368'>\""
+      "summary": "assert '\u5931\u8d25\u6458\u5f55' not in \"PR #42 \u5728\u5408\u5e76\u524d...9180888144'>\""
     },
     {
       "category": "test_body_exception",
@@ -4306,11 +4234,11 @@
     }
   ],
   "provenance": {
-    "generated_command": "python scripts/legacy_issue_baseline.py snapshot --junit 'artifacts/test-results/issues-*.xml' --output ci/legacy-issue-failures.json --exit-code-glob 'artifacts/test-results/issues-*.exit-code' --shard-count 4 --quarantine ci/legacy-issue-quarantine.json --test-baseline .test-baseline.json --source-run 31359257263 --source-run-url https://github.com/open-ace/open-ace/actions/runs/31359257263 --reference-commit 56a165ab08fd77fc560398984763dc671e8f05b2 --run-contract 'extended-tests issue-tests --isolated-home --reruns 1 --timeout 240 --continue-on-collection-errors, 4 shards; 604 quarantined (deselect); CI-validated manifest'",
-    "reference_commit": "56a165ab08fd77fc560398984763dc671e8f05b2",
-    "run_contract": "extended-tests issue-tests --isolated-home --reruns 1 --timeout 240 --continue-on-collection-errors, 4 shards; 604 quarantined (deselect); CI-validated manifest",
-    "source_run": "31359257263",
-    "source_run_url": "https://github.com/open-ace/open-ace/actions/runs/31359257263"
+    "generated_command": "python scripts/legacy_issue_baseline.py snapshot --junit 'artifacts/test-results/issues-*.xml' --output ci/legacy-issue-failures.json --exit-code-glob 'artifacts/test-results/issues-*.exit-code' --shard-count 4 --quarantine ci/legacy-issue-quarantine.json --test-baseline .test-baseline.json --source-run 31382049159 --source-run-url https://github.com/open-ace/open-ace/actions/runs/31382049159 --reference-commit 1f45105e8a7e5ff713d97be3cdc836b525f0d3aa --run-contract 'extended-tests issue-tests --isolated-home --reruns 1 --timeout 240 --continue-on-collection-errors, 4 shards; 604 quarantined (deselect); post-main-sync (#2391 orchestrator refactor): 9 resolved, 2 changed test_body_exception->assertion_failure'",
+    "reference_commit": "1f45105e8a7e5ff713d97be3cdc836b525f0d3aa",
+    "run_contract": "extended-tests issue-tests --isolated-home --reruns 1 --timeout 240 --continue-on-collection-errors, 4 shards; 604 quarantined (deselect); post-main-sync (#2391 orchestrator refactor): 9 resolved, 2 changed test_body_exception->assertion_failure",
+    "source_run": "31382049159",
+    "source_run_url": "https://github.com/open-ace/open-ace/actions/runs/31382049159"
   },
   "schema": "openace-legacy-issue-failures",
   "selection": "not postgres",

--- a/ci/legacy-issue-failures.json
+++ b/ci/legacy-issue-failures.json
@@ -2,7 +2,7 @@
   "entries": [
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TenantResolutionError",
       "issue_number": "1003",
       "nodeid": "tests/issues/1003/test_session_usage_accounting.py::TestAddMessageCountUsageGate::test_autonomous_count_usage_false_leaves_counters",
       "outcome": "failure",
@@ -10,7 +10,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TenantResolutionError",
       "issue_number": "1003",
       "nodeid": "tests/issues/1003/test_session_usage_accounting.py::TestAddMessageCountUsageGate::test_legacy_count_usage_true_still_accumulates",
       "outcome": "failure",
@@ -18,7 +18,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TenantResolutionError",
       "issue_number": "1003",
       "nodeid": "tests/issues/1003/test_session_usage_accounting.py::TestIncrementSessionUsage::test_accumulates_across_calls",
       "outcome": "failure",
@@ -26,7 +26,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TenantResolutionError",
       "issue_number": "1003",
       "nodeid": "tests/issues/1003/test_session_usage_accounting.py::TestIncrementSessionUsage::test_starts_from_existing_value",
       "outcome": "failure",
@@ -34,7 +34,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TenantResolutionError",
       "issue_number": "1003",
       "nodeid": "tests/issues/1003/test_session_usage_accounting.py::TestMilestoneSessionInvariant::test_session_equals_sum_of_per_call_deltas",
       "outcome": "failure",
@@ -42,7 +42,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TimeoutError",
       "issue_number": "1006",
       "nodeid": "tests/issues/1006/e2e_conversation_history_default_dates.py::test_default_dates",
       "outcome": "failure",
@@ -50,7 +50,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "AttributeError",
       "issue_number": "1071",
       "nodeid": "tests/issues/1071/test_webui_session_id.py::TestListSessionsFilterWebui::test_webui_sessions_filtered_out",
       "outcome": "failure",
@@ -58,7 +58,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "CalledProcessError",
       "issue_number": "1111",
       "nodeid": "tests/issues/1111/test_sqlite_normalize_derived_tables.py::test_sqlite_upgrade_merges_qwen_alias_rows_before_normalization",
       "outcome": "failure",
@@ -66,15 +66,15 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "CalledProcessError",
       "issue_number": "1111",
       "nodeid": "tests/issues/1111/test_sqlite_normalize_derived_tables.py::test_sqlite_upgrade_rebuilds_claude_summary_with_distinct_day_count",
       "outcome": "failure",
       "summary": "subprocess.CalledProcessError: Command '['/opt/hostedtoolcache/Python/3.11.15/x64/bin/python', '-m', 'alembic', '-c', 'alembic.ini', 'upgrade', '038_normalize_tool_names']' returned non-zero exit sta…"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "1125",
       "nodeid": "tests/issues/1125/test_workspace_session_summary_contract.py::test_get_session_does_not_fallback_to_daily_messages",
       "outcome": "failure",
@@ -82,15 +82,15 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "AttributeError",
       "issue_number": "1125",
       "nodeid": "tests/issues/1125/test_workspace_session_summary_contract.py::test_get_session_keeps_agent_sessions_request_count",
       "outcome": "failure",
       "summary": "AttributeError: 'tuple' object has no attribute 'get_json'"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "1125",
       "nodeid": "tests/issues/1125/test_workspace_session_summary_contract.py::test_list_sessions_hides_autonomous_tracking_wrappers",
       "outcome": "failure",
@@ -98,7 +98,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TenantResolutionError",
       "issue_number": "1128",
       "nodeid": "tests/issues/1128/test_session_message_transcript_contract.py::test_add_message_merges_duplicate_message_id_without_double_count",
       "outcome": "failure",
@@ -106,7 +106,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TenantResolutionError",
       "issue_number": "1128",
       "nodeid": "tests/issues/1128/test_session_message_transcript_contract.py::test_add_message_persists_structured_session_message_columns",
       "outcome": "failure",
@@ -114,47 +114,47 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TenantResolutionError",
       "issue_number": "1128",
       "nodeid": "tests/issues/1128/test_session_message_transcript_contract.py::test_append_transcript_message_is_summary_side_effect_free",
       "outcome": "failure",
       "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "1128",
       "nodeid": "tests/issues/1128/test_session_message_transcript_contract.py::test_llm_proxy_records_transcript_without_double_count",
       "outcome": "failure",
       "summary": "AssertionError: assert 0 == 1"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "1140",
       "nodeid": "tests/issues/1140/test_zcode_dev_mode_and_session.py::test_session_line_updates_even_on_resume",
       "outcome": "failure",
       "summary": "AssertionError: _run_agent must not skip session line update on resume — see #525 where dev resumed a dead planning session forever"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "1277",
       "nodeid": "tests/issues/1277/test_test_skip_false_positive.py::TestRetryCounterPersistence::test_skip_retries_persisted_on_test_skip",
       "outcome": "failure",
       "summary": "AssertionError: skip_retries=1 must be persisted when tests are skipped"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "1306",
       "nodeid": "tests/issues/1306/test_host_url_replacement.py::test_get_user_webui_url_preserves_port_single_user",
       "outcome": "failure",
       "summary": "AssertionError: assert False"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "1306",
       "nodeid": "tests/issues/1306/test_host_url_replacement.py::test_get_user_webui_url_with_host_url",
       "outcome": "failure",
@@ -162,7 +162,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "1329",
       "nodeid": "tests/issues/1329/test_concurrent_limit.py::TestCheckUserConcurrentLimit::test_fail_open_on_exception",
       "outcome": "error",
@@ -170,7 +170,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "1329",
       "nodeid": "tests/issues/1329/test_concurrent_limit.py::TestCheckUserConcurrentLimit::test_returns_429_when_at_limit",
       "outcome": "error",
@@ -178,7 +178,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "1329",
       "nodeid": "tests/issues/1329/test_concurrent_limit.py::TestCheckUserConcurrentLimit::test_returns_none_when_under_limit",
       "outcome": "error",
@@ -186,7 +186,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "1329",
       "nodeid": "tests/issues/1329/test_concurrent_limit.py::TestCheckUserConcurrentLimit::test_uses_default_when_no_tenant",
       "outcome": "error",
@@ -194,7 +194,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "1329",
       "nodeid": "tests/issues/1329/test_concurrent_limit.py::TestCountActiveWorkflowsByUser::test_count_active_workflows_only",
       "outcome": "error",
@@ -202,7 +202,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "1329",
       "nodeid": "tests/issues/1329/test_concurrent_limit.py::TestCountActiveWorkflowsByUser::test_count_multiple_active_statuses",
       "outcome": "error",
@@ -210,7 +210,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "1329",
       "nodeid": "tests/issues/1329/test_concurrent_limit.py::TestCountActiveWorkflowsByUser::test_count_only_specific_user",
       "outcome": "error",
@@ -218,7 +218,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "1329",
       "nodeid": "tests/issues/1329/test_concurrent_limit.py::TestCountActiveWorkflowsByUser::test_count_zero_when_no_workflows",
       "outcome": "error",
@@ -226,7 +226,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "RuntimeError",
       "issue_number": "1395",
       "nodeid": "tests/issues/1395/test_cross_user_permissions.py::TestBuildAgentEnv::test_fallback_on_proxy_failure",
       "outcome": "failure",
@@ -234,7 +234,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "1395",
       "nodeid": "tests/issues/1395/test_cross_user_permissions.py::TestPreparationWorktreeCleanup::test_clean_path_creates_worktree_directly",
       "outcome": "failure",
@@ -242,7 +242,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "1395",
       "nodeid": "tests/issues/1395/test_cross_user_permissions.py::TestPreparationWorktreeCleanup::test_non_registered_residual_dir_left_in_place",
       "outcome": "failure",
@@ -250,7 +250,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "1395",
       "nodeid": "tests/issues/1395/test_cross_user_permissions.py::TestPreparationWorktreeCleanup::test_registered_residual_removed_via_git",
       "outcome": "failure",
@@ -258,23 +258,23 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "1395",
       "nodeid": "tests/issues/1395/test_cross_user_permissions.py::TestPreparationWorktreeCleanup::test_remove_failure_does_not_raise",
       "outcome": "failure",
       "summary": "TypeError: Object of type MagicMock is not JSON serializable"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "1395",
       "nodeid": "tests/issues/1395/test_cross_user_permissions.py::TestRunAgentTaskSessionReactivation::test_completed_session_reactivated_to_active",
       "outcome": "failure",
       "summary": "AssertionError: assert call('sess-co..._tenant=False) == (('sess-compl...': None}), {})"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "1395",
       "nodeid": "tests/issues/1395/test_cross_user_permissions.py::TestRunAgentTaskSessionReactivation::test_error_session_reactivated_to_active",
       "outcome": "failure",
@@ -282,23 +282,23 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "1395",
       "nodeid": "tests/issues/1395/test_cross_user_permissions.py::TestSingleShotUserIdPropagation::test_single_shot_passes_real_user_id_to_env",
       "outcome": "failure",
       "summary": "TypeError: TestSingleShotUserIdPropagation.test_single_shot_passes_real_user_id_to_env.<locals>.fake_build_env() got an unexpected keyword argument 'task_id'"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "1395",
       "nodeid": "tests/issues/1395/test_cross_user_permissions.py::test_isolated_wrapper_can_handle_signals_while_waiting_for_agent",
       "outcome": "failure",
       "summary": "assert 'trap cleanup_isolated EXIT' in '#!/bin/bash\\n# openace-run-as — cross-user agent launcher for AI autonomous development.\\n#\\n# Problem (Issue #1395): the open-ace service runs as the `openace…"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "1395",
       "nodeid": "tests/issues/1395/test_cross_user_permissions.py::test_isolated_wrapper_normalizes_recovered_acls_before_git_baseline",
       "outcome": "failure",
@@ -306,7 +306,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "AttributeError",
       "issue_number": "1395",
       "nodeid": "tests/issues/1395/test_system_event_activity.py::TestSystemEventActivityForwarding::test_api_retry_triggers_activity",
       "outcome": "failure",
@@ -314,7 +314,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "AttributeError",
       "issue_number": "1395",
       "nodeid": "tests/issues/1395/test_system_event_activity.py::TestSystemEventActivityForwarding::test_assistant_still_triggers_activity",
       "outcome": "failure",
@@ -322,7 +322,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "AttributeError",
       "issue_number": "1395",
       "nodeid": "tests/issues/1395/test_system_event_activity.py::TestSystemEventActivityForwarding::test_init_triggers_activity",
       "outcome": "failure",
@@ -330,7 +330,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "AttributeError",
       "issue_number": "1395",
       "nodeid": "tests/issues/1395/test_system_event_activity.py::TestSystemEventActivityForwarding::test_no_subtype_does_not_trigger",
       "outcome": "failure",
@@ -338,7 +338,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "AttributeError",
       "issue_number": "1395",
       "nodeid": "tests/issues/1395/test_system_event_activity.py::TestSystemEventActivityForwarding::test_thinking_tokens_is_not_forwarded",
       "outcome": "failure",
@@ -378,79 +378,79 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "AssertionError",
       "issue_number": "144",
       "nodeid": "tests/issues/144/e2e_file_changes_panel.py::test_panel_features",
       "outcome": "error",
       "summary": "failed on setup with \"AssertionError\""
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "165",
       "nodeid": "tests/issues/165/test_remote_session_ux.py::test_a1_token_detail",
       "outcome": "failure",
       "summary": "AssertionError: Create session failed: 401 {\"error\":\"Authentication required\"}"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "165",
       "nodeid": "tests/issues/165/test_remote_session_ux.py::test_a2_system_message_storage",
       "outcome": "failure",
       "summary": "AssertionError: Create session failed: 401 {\"error\":\"Authentication required\"}"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "165",
       "nodeid": "tests/issues/165/test_remote_session_ux.py::test_a3_request_count_no_double_count",
       "outcome": "failure",
       "summary": "AssertionError: Create session failed: 401 {\"error\":\"Authentication required\"}"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "165",
       "nodeid": "tests/issues/165/test_remote_session_ux.py::test_a4_abort_request",
       "outcome": "failure",
       "summary": "AssertionError: Create session failed: 401 {\"error\":\"Authentication required\"}"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "165",
       "nodeid": "tests/issues/165/test_remote_session_ux.py::test_a5_allow_permanent",
       "outcome": "failure",
       "summary": "AssertionError: Create session failed: 401 {\"error\":\"Authentication required\"}"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "165",
       "nodeid": "tests/issues/165/test_remote_session_ux.py::test_a6_quota_exceeded_detection",
       "outcome": "failure",
       "summary": "AssertionError: Create session failed: 401 {\"error\":\"Authentication required\"}"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "165",
       "nodeid": "tests/issues/165/test_remote_session_ux.py::test_b1_reconnect_history",
       "outcome": "failure",
       "summary": "AssertionError: Create session failed: 401 {\"error\":\"Authentication required\"}"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "165",
       "nodeid": "tests/issues/165/test_remote_session_ux.py::test_b2_abort_ui",
       "outcome": "failure",
       "summary": "AssertionError: Create session failed: 401 {\"error\":\"Authentication required\"}"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "165",
       "nodeid": "tests/issues/165/test_remote_session_ux.py::test_b3_permission_permanent_ui",
       "outcome": "failure",
@@ -506,23 +506,23 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "AttributeError",
       "issue_number": "1760",
       "nodeid": "tests/issues/1760/test_save_usage_tenant_and_workflow_annotation.py::test_update_agent_sessions_stats_writes_per_session_model",
       "outcome": "failure",
       "summary": "AttributeError: <module 'config' from 'tests/issues/610/../../../remote-agent/config.py'> has no attribute 'DB_DIR'"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "1778",
       "nodeid": "tests/issues/1778/test_outbound_url_toctou.py::test_safe_request_disables_proxy_by_default",
       "outcome": "failure",
       "summary": "AssertionError: assert OrderedDict([...,127.0.0.1')]) == {}"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "1778",
       "nodeid": "tests/issues/1778/test_outbound_url_toctou.py::test_safe_request_preserves_caller_provided_proxies",
       "outcome": "failure",
@@ -530,127 +530,127 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "RuntimeError",
       "issue_number": "1807",
       "nodeid": "tests/issues/1807/test_webhook_round2_review.py::TestWebhookFailurePrefsUnbound::test_prefs_unbound_does_not_mask_real_exception",
       "outcome": "failure",
       "summary": "RuntimeError: db connection lost"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "1813",
       "nodeid": "tests/issues/1813/test_pr_review_summary_before_ci.py::TestPrReviewSummaryBeforeCiCheck::test_review_content_filled_before_ci_return",
       "outcome": "failure",
       "summary": "AssertionError: pr_review_summary must be updated with non-empty review_content even when CI fails"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "1816",
       "nodeid": "tests/issues/1816/test_ci_repair_context_overflow.py::test_review_fix_refuses_preexisting_dirty_tree_before_agent",
       "outcome": "failure",
       "summary": "AssertionError: Expected 'git_add_all' to not have been called. Called 1 times."
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "1816",
       "nodeid": "tests/issues/1816/test_ci_repair_context_overflow.py::test_stable_session_line_rebinds_once_and_preserves_usage[False]",
       "outcome": "failure",
       "summary": "AssertionError: expected call not found."
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "1816",
       "nodeid": "tests/issues/1816/test_ci_repair_context_overflow.py::test_stable_session_line_rebinds_once_and_preserves_usage[True]",
       "outcome": "failure",
       "summary": "AssertionError: expected call not found."
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "1831",
       "nodeid": "tests/issues/1831/test_orchestrator_failure_cleanup.py::TestAdvanceTimingDimension::test_transient_error_keeps_worktree",
       "outcome": "failure",
       "summary": "AssertionError: Expected '_mark_failed' to not have been called. Called 1 times."
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "1857",
       "nodeid": "tests/issues/1857/test_pr_review_duplicate_create.py::test_create_pr_already_exists_fails_when_retry_still_finds_nothing",
       "outcome": "failure",
       "summary": "AssertionError: should fail when recovery can't locate the existing PR"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "1857",
       "nodeid": "tests/issues/1857/test_pr_review_duplicate_create.py::test_create_pr_already_exists_falls_back_to_find_existing_pr_without_url",
       "outcome": "failure",
       "summary": "AssertionError: Expected 'find_existing_pr' to be called once. Called 0 times."
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "1857",
       "nodeid": "tests/issues/1857/test_pr_review_duplicate_create.py::test_create_pr_already_exists_recovers_by_parsing_pr_url_from_error",
       "outcome": "failure",
       "summary": "AssertionError: PR number not parsed from error URL and persisted"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "1857",
       "nodeid": "tests/issues/1857/test_pr_review_duplicate_create.py::test_create_pr_already_exists_retries_find_when_first_returns_none",
       "outcome": "failure",
       "summary": "AssertionError: assert 0 == 2"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "1857",
       "nodeid": "tests/issues/1857/test_pr_review_duplicate_create.py::test_create_pr_unrecoverable_error_still_fails",
       "outcome": "failure",
       "summary": "AssertionError: non-'already exists' error should propagate, not be masked"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "1891",
       "nodeid": "tests/issues/1891/test_usage_report_auth.py::TestUsageReportHttpIntegration::test_duplicate_report_is_idempotent_and_conflicting_replay_is_rejected",
       "outcome": "failure",
       "summary": "assert 0 == 2"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "1891",
       "nodeid": "tests/issues/1891/test_usage_report_auth.py::TestUsageReportHttpIntegration::test_report_id_less_agent_has_explicit_short_migration_window[/api/remote/agent/message]",
       "outcome": "failure",
       "summary": "assert 0 == 150"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "1891",
       "nodeid": "tests/issues/1891/test_usage_report_auth.py::TestUsageReportHttpIntegration::test_report_id_less_agent_has_explicit_short_migration_window[/api/remote/usage-report]",
       "outcome": "failure",
       "summary": "assert 0 == 150"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "1891",
       "nodeid": "tests/issues/1891/test_usage_report_auth.py::TestUsageReportHttpIntegration::test_valid_bearer_updates_usage_and_audits_both_paths[/api/remote/agent/message]",
       "outcome": "failure",
       "summary": "assert 0 == 2"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "1891",
       "nodeid": "tests/issues/1891/test_usage_report_auth.py::TestUsageReportHttpIntegration::test_valid_bearer_updates_usage_and_audits_both_paths[/api/remote/usage-report]",
       "outcome": "failure",
@@ -658,7 +658,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "RuntimeError",
       "issue_number": "1895",
       "nodeid": "tests/issues/1895/test_redis_authentication.py::TestRedisPasswordFailClosed::test_development_allows_empty_redis_password_with_warning",
       "outcome": "failure",
@@ -666,7 +666,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "RuntimeError",
       "issue_number": "1895",
       "nodeid": "tests/issues/1895/test_redis_authentication.py::TestRedisPasswordSpecialCharacters::test_password_with_backtick_handled_correctly",
       "outcome": "failure",
@@ -674,7 +674,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "RuntimeError",
       "issue_number": "1895",
       "nodeid": "tests/issues/1895/test_redis_authentication.py::TestRedisPasswordSpecialCharacters::test_password_with_dollar_sign_handled_correctly",
       "outcome": "failure",
@@ -682,23 +682,23 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "RuntimeError",
       "issue_number": "1895",
       "nodeid": "tests/issues/1895/test_redis_authentication.py::TestRedisPasswordSpecialCharacters::test_password_with_exclamation_handled_correctly",
       "outcome": "failure",
       "summary": "RuntimeError: REDIS_PASSWORD must be at least 24 characters long (got 13); current value is too short for production"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "1897",
       "nodeid": "tests/issues/1897/test_dev_context_recovery.py::test_dev_context_overflow_recovers_on_fresh_session",
       "outcome": "failure",
       "summary": "AssertionError: expected call not found."
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "1897",
       "nodeid": "tests/issues/1897/test_retry_clears_in_progress.py::TestRetryClearsInProgress::test_retry_endpoint_calls_clear_in_progress",
       "outcome": "failure",
@@ -722,23 +722,23 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "Error",
       "issue_number": "20",
       "nodeid": "tests/issues/20/test_issue20.py::test_remote_data_fetch_interval",
       "outcome": "failure",
       "summary": "playwright._impl._errors.Error: Page.goto: net::ERR_CONNECTION_REFUSED at http://<host:port>/login"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "210",
       "nodeid": "tests/issues/210/e2e_project_stats_accuracy.py::test_project_stats_accuracy",
       "outcome": "failure",
       "summary": "AssertionError: Stats API failed: 403"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "211",
       "nodeid": "tests/issues/211/e2e_project_sort.py::test_project_sort",
       "outcome": "failure",
@@ -746,7 +746,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "212",
       "nodeid": "tests/issues/212/test_hostname_dedup.py::test_different_tenant_no_merge",
       "outcome": "failure",
@@ -754,7 +754,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "212",
       "nodeid": "tests/issues/212/test_hostname_dedup.py::test_empty_hostname_no_merge",
       "outcome": "failure",
@@ -762,7 +762,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "212",
       "nodeid": "tests/issues/212/test_hostname_dedup.py::test_invalid_token",
       "outcome": "failure",
@@ -770,7 +770,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "212",
       "nodeid": "tests/issues/212/test_hostname_dedup.py::test_merge_cleans_in_memory_state",
       "outcome": "failure",
@@ -778,7 +778,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "212",
       "nodeid": "tests/issues/212/test_hostname_dedup.py::test_merge_offline_duplicate",
       "outcome": "failure",
@@ -786,7 +786,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "212",
       "nodeid": "tests/issues/212/test_hostname_dedup.py::test_merge_preserves_assignments",
       "outcome": "failure",
@@ -794,7 +794,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "212",
       "nodeid": "tests/issues/212/test_hostname_dedup.py::test_merge_preserves_sessions",
       "outcome": "failure",
@@ -802,7 +802,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "212",
       "nodeid": "tests/issues/212/test_hostname_dedup.py::test_new_machine_no_duplicate",
       "outcome": "failure",
@@ -810,23 +810,23 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "212",
       "nodeid": "tests/issues/212/test_hostname_dedup.py::test_reject_online_duplicate",
       "outcome": "failure",
       "summary": "sqlite3.OperationalError: no such table: registration_tokens"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "2121",
       "nodeid": "tests/issues/2121/test_sso_user_tenant_id.py::TestCreateUserFromSsoTenantId::test_uses_default_tenant_id_when_provider_not_found",
       "outcome": "failure",
       "summary": "assert None == 42"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "2121",
       "nodeid": "tests/issues/2121/test_sso_user_tenant_id.py::TestCreateUserFromSsoTenantId::test_uses_default_tenant_id_when_provider_tenant_id_is_none",
       "outcome": "failure",
@@ -834,7 +834,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "ValueError",
       "issue_number": "22",
       "nodeid": "tests/issues/22/test_issue22.py::TestOIDCSignatureVerification::test_jwks_caching",
       "outcome": "failure",
@@ -850,7 +850,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "2335",
       "nodeid": "tests/issues/2335/test_close_issue.py::test_close_issue_runs_as_service_user_with_bot_token",
       "outcome": "failure",
@@ -858,7 +858,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "2335",
       "nodeid": "tests/issues/2335/test_close_issue.py::test_get_merge_commit_sha_none_when_empty",
       "outcome": "failure",
@@ -866,7 +866,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "2335",
       "nodeid": "tests/issues/2335/test_close_issue.py::test_get_merge_commit_sha_returns_oid",
       "outcome": "failure",
@@ -874,7 +874,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "2335",
       "nodeid": "tests/issues/2335/test_close_issue.py::test_reopen_issue_runs_as_service_user_with_bot_token",
       "outcome": "failure",
@@ -882,7 +882,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "2335",
       "nodeid": "tests/issues/2335/test_verifier_checkout.py::test_cross_user_verifier_cleanup_uses_owner_safe_wrapper",
       "outcome": "failure",
@@ -890,7 +890,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "2335",
       "nodeid": "tests/issues/2335/test_verifier_checkout.py::test_cross_user_verifier_directory_is_created_by_repository_owner",
       "outcome": "failure",
@@ -898,15 +898,15 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "2335",
       "nodeid": "tests/issues/2335/test_verifier_checkout.py::test_same_user_verifier_directory_is_private_and_owner_writable",
       "outcome": "failure",
       "summary": "TypeError: object.__new__() takes exactly one argument (the type to instantiate)"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "241",
       "nodeid": "tests/issues/241/test_pagination_migration_head.py::test_single_migration_head",
       "outcome": "failure",
@@ -914,7 +914,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TenantResolutionError",
       "issue_number": "241",
       "nodeid": "tests/issues/241/test_pagination_routes.py::TestGetSessionEnvelope::test_include_messages_returns_recent_page_and_metadata",
       "outcome": "failure",
@@ -922,7 +922,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TenantResolutionError",
       "issue_number": "241",
       "nodeid": "tests/issues/241/test_pagination_routes.py::TestGetSessionEnvelope::test_milestone_total_uses_conditional_count",
       "outcome": "failure",
@@ -930,7 +930,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TenantResolutionError",
       "issue_number": "241",
       "nodeid": "tests/issues/241/test_pagination_routes.py::TestGetSessionEnvelope::test_without_include_messages_has_no_pagination_envelope",
       "outcome": "failure",
@@ -938,7 +938,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TenantResolutionError",
       "issue_number": "241",
       "nodeid": "tests/issues/241/test_pagination_routes.py::TestMessagesEndpointWalk::test_cursor_walk_through_endpoint",
       "outcome": "failure",
@@ -946,7 +946,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TenantResolutionError",
       "issue_number": "241",
       "nodeid": "tests/issues/241/test_pagination_routes.py::TestMessagesEndpointWalk::test_limit_clamped_to_max_via_endpoint",
       "outcome": "failure",
@@ -954,7 +954,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TenantResolutionError",
       "issue_number": "241",
       "nodeid": "tests/issues/241/test_pagination_routes.py::TestMessagesEndpointWalk::test_lone_before_timestamp_is_ignored",
       "outcome": "failure",
@@ -962,15 +962,15 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TenantResolutionError",
       "issue_number": "241",
       "nodeid": "tests/issues/241/test_pagination_routes.py::TestOwnershipAnd404::test_admin_bypasses_owner_check",
       "outcome": "failure",
       "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "241",
       "nodeid": "tests/issues/241/test_pagination_routes.py::TestOwnershipAnd404::test_messages_endpoint_404_for_unknown_session",
       "outcome": "failure",
@@ -978,7 +978,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TenantResolutionError",
       "issue_number": "241",
       "nodeid": "tests/issues/241/test_pagination_routes.py::TestOwnershipAnd404::test_messages_endpoint_enforces_ownership_before_load",
       "outcome": "failure",
@@ -986,7 +986,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TenantResolutionError",
       "issue_number": "241",
       "nodeid": "tests/issues/241/test_pagination_routes.py::TestOwnershipAnd404::test_non_owner_gets_403",
       "outcome": "failure",
@@ -994,15 +994,15 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TenantResolutionError",
       "issue_number": "241",
       "nodeid": "tests/issues/241/test_pagination_routes.py::TestOwnershipAnd404::test_same_owner_wrong_tenant_gets_403",
       "outcome": "failure",
       "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "241",
       "nodeid": "tests/issues/241/test_pagination_routes.py::TestOwnershipAnd404::test_unknown_session_returns_404",
       "outcome": "failure",
@@ -1010,7 +1010,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TenantResolutionError",
       "issue_number": "241",
       "nodeid": "tests/issues/241/test_session_messages_pagination.py::TestCrossPageContinuity::test_full_walk_no_overlap_no_gap",
       "outcome": "failure",
@@ -1018,7 +1018,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TenantResolutionError",
       "issue_number": "241",
       "nodeid": "tests/issues/241/test_session_messages_pagination.py::TestCrossPageContinuity::test_has_more_flag_and_cursor_only_when_older_page_exists",
       "outcome": "failure",
@@ -1026,7 +1026,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TenantResolutionError",
       "issue_number": "241",
       "nodeid": "tests/issues/241/test_session_messages_pagination.py::TestDescReverseAdjacency::test_second_page_is_adjacent_not_oldest",
       "outcome": "failure",
@@ -1034,7 +1034,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TenantResolutionError",
       "issue_number": "241",
       "nodeid": "tests/issues/241/test_session_messages_pagination.py::TestEmptyAndDefaults::test_default_limit_used_when_none",
       "outcome": "failure",
@@ -1042,7 +1042,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TenantResolutionError",
       "issue_number": "241",
       "nodeid": "tests/issues/241/test_session_messages_pagination.py::TestEmptyAndDefaults::test_empty_session_returns_empty_page",
       "outcome": "failure",
@@ -1050,7 +1050,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TenantResolutionError",
       "issue_number": "241",
       "nodeid": "tests/issues/241/test_session_messages_pagination.py::TestInternalCallersUnaffected::test_get_session_full_history_when_requested",
       "outcome": "failure",
@@ -1058,7 +1058,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TenantResolutionError",
       "issue_number": "241",
       "nodeid": "tests/issues/241/test_session_messages_pagination.py::TestInternalCallersUnaffected::test_get_session_no_messages_by_default",
       "outcome": "failure",
@@ -1066,7 +1066,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TenantResolutionError",
       "issue_number": "241",
       "nodeid": "tests/issues/241/test_session_messages_pagination.py::TestLimitClamping::test_max_boundary_returns_exactly_max",
       "outcome": "failure",
@@ -1074,7 +1074,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TenantResolutionError",
       "issue_number": "241",
       "nodeid": "tests/issues/241/test_session_messages_pagination.py::TestLimitClamping::test_over_max_clamped_to_max",
       "outcome": "failure",
@@ -1082,7 +1082,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TenantResolutionError",
       "issue_number": "241",
       "nodeid": "tests/issues/241/test_session_messages_pagination.py::TestLimitClamping::test_zero_or_negative_falls_back_to_default",
       "outcome": "failure",
@@ -1090,7 +1090,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TenantResolutionError",
       "issue_number": "241",
       "nodeid": "tests/issues/241/test_session_messages_pagination.py::TestMilestoneCount::test_count_messages_total_and_milestone_scoped",
       "outcome": "failure",
@@ -1098,7 +1098,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TenantResolutionError",
       "issue_number": "241",
       "nodeid": "tests/issues/241/test_session_messages_pagination.py::TestMilestoneCount::test_get_messages_page_respects_milestone_filter",
       "outcome": "failure",
@@ -1106,7 +1106,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TenantResolutionError",
       "issue_number": "241",
       "nodeid": "tests/issues/241/test_session_messages_pagination.py::TestNullTimestampSafetyNet::test_schema_rejects_null_timestamp",
       "outcome": "failure",
@@ -1114,7 +1114,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TenantResolutionError",
       "issue_number": "241",
       "nodeid": "tests/issues/241/test_session_messages_pagination.py::TestSameTimestampTiebreak::test_identical_timestamps_ordered_by_id",
       "outcome": "failure",
@@ -1122,7 +1122,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "2431",
       "nodeid": "tests/issues/2431/test_acceptance_verifier_hardening.py::test_issue_closure_combines_closed_at_with_latest_timeline_actor",
       "outcome": "failure",
@@ -1130,7 +1130,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "2431",
       "nodeid": "tests/issues/2431/test_acceptance_verifier_hardening.py::test_issue_closure_rejects_timeline_actor_from_a_different_close_event",
       "outcome": "failure",
@@ -1138,7 +1138,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "2431",
       "nodeid": "tests/issues/2431/test_acceptance_verifier_hardening.py::test_issue_comment_exact_body_from_same_bot_is_idempotent",
       "outcome": "failure",
@@ -1146,7 +1146,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "2431",
       "nodeid": "tests/issues/2431/test_acceptance_verifier_hardening.py::test_issue_comment_listing_uses_paginated_rest_and_normalizes_pages",
       "outcome": "failure",
@@ -1154,7 +1154,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "2431",
       "nodeid": "tests/issues/2431/test_acceptance_verifier_hardening.py::test_issue_comment_same_body_from_human_does_not_deduplicate",
       "outcome": "failure",
@@ -1162,7 +1162,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "2431",
       "nodeid": "tests/issues/2431/test_acceptance_verifier_hardening.py::test_issue_comment_unknown_bot_identity_does_not_trust_existing_author",
       "outcome": "failure",
@@ -1170,7 +1170,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "2431",
       "nodeid": "tests/issues/2431/test_acceptance_verifier_hardening.py::test_merge_sha_is_fetched_and_verified_when_missing",
       "outcome": "failure",
@@ -1178,7 +1178,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TimeoutError",
       "issue_number": "25",
       "nodeid": "tests/issues/25/test_issue25.py::test_issue25",
       "outcome": "failure",
@@ -1194,7 +1194,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "AssertionError",
       "issue_number": "394",
       "nodeid": "tests/issues/394/e2e_terminal_tab.py::test_terminal_connection_and_interaction",
       "outcome": "error",
@@ -1202,15 +1202,15 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "AssertionError",
       "issue_number": "394",
       "nodeid": "tests/issues/394/e2e_terminal_tab.py::test_terminal_option_in_modal",
       "outcome": "error",
       "summary": "failed on setup with \"AssertionError\""
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "394",
       "nodeid": "tests/issues/394/e2e_terminal_tab.py::test_terminal_tab",
       "outcome": "failure",
@@ -1225,8 +1225,8 @@
       "summary": "Failed: async def functions are not natively supported."
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "42",
       "nodeid": "tests/issues/42/test_webui_manager.py::test_manager_get_user_webui_url_single_user",
       "outcome": "failure",
@@ -1234,15 +1234,15 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "42",
       "nodeid": "tests/issues/42/test_webui_manager.py::test_manager_instance_limit",
       "outcome": "failure",
       "summary": "TypeError: cannot unpack non-iterable NoneType object"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "435",
       "nodeid": "tests/issues/435/e2e_api_key_toggle.py::test_api_key_toggle",
       "outcome": "failure",
@@ -1250,7 +1250,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "47",
       "nodeid": "tests/issues/47/test_auto_refresh.py::test_auto_refresh_historical_date",
       "outcome": "failure",
@@ -1258,23 +1258,23 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "47",
       "nodeid": "tests/issues/47/test_auto_refresh.py::test_auto_refresh_today",
       "outcome": "failure",
       "summary": "TypeError: 'PlaywrightContextManager' object does not support the context manager protocol"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "477",
       "nodeid": "tests/issues/477/test_browse_directory_auth.py::TestBrowseRemoteDirectoryAuthCheck::test_admin_user_has_access",
       "outcome": "failure",
       "summary": "assert 400 == 200"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "477",
       "nodeid": "tests/issues/477/test_browse_directory_auth.py::TestBrowseRemoteDirectoryAuthCheck::test_admin_user_offline_machine",
       "outcome": "failure",
@@ -1282,7 +1282,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "RuntimeError",
       "issue_number": "477",
       "nodeid": "tests/issues/477/test_browse_directory_auth.py::TestBrowseRemoteDirectoryAuthCheck::test_g_user_none_returns_401",
       "outcome": "failure",
@@ -1290,7 +1290,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "RuntimeError",
       "issue_number": "477",
       "nodeid": "tests/issues/477/test_browse_directory_auth.py::TestBrowseRemoteDirectoryAuthCheck::test_g_user_without_id_returns_403",
       "outcome": "failure",
@@ -1298,23 +1298,23 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "RuntimeError",
       "issue_number": "477",
       "nodeid": "tests/issues/477/test_browse_directory_auth.py::TestBrowseRemoteDirectoryAuthCheck::test_no_g_user_returns_401",
       "outcome": "failure",
       "summary": "RuntimeError: Working outside of request context."
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "477",
       "nodeid": "tests/issues/477/test_browse_directory_auth.py::TestBrowseRemoteDirectoryAuthCheck::test_normal_user_without_access_returns_403",
       "outcome": "failure",
       "summary": "assert 400 == 403"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "477",
       "nodeid": "tests/issues/477/test_browse_directory_auth.py::TestBrowseRemoteDirectoryEdgeCases::test_machine_not_found_returns_404",
       "outcome": "failure",
@@ -1322,7 +1322,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "Error",
       "issue_number": "48",
       "nodeid": "tests/issues/48/test_status_bar_usage.py::test_status_bar_usage",
       "outcome": "failure",
@@ -1330,7 +1330,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "Error",
       "issue_number": "48",
       "nodeid": "tests/issues/48/test_status_bar_usage_v2.py::test_status_bar_improvements",
       "outcome": "failure",
@@ -1338,223 +1338,223 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "51",
       "nodeid": "tests/issues/51/test_issue51.py::test_issue51",
       "outcome": "failure",
       "summary": "TypeError: object NoneType can't be used in 'await' expression"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "517",
       "nodeid": "tests/issues/517/e2e_codex_comprehensive.py::test_agent_sessions_tokens",
       "outcome": "failure",
       "summary": "AssertionError: No codex sessions"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "517",
       "nodeid": "tests/issues/517/e2e_codex_comprehensive.py::test_api_codex_alias",
       "outcome": "failure",
       "summary": "AssertionError: Not logged in"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "517",
       "nodeid": "tests/issues/517/e2e_codex_comprehensive.py::test_api_messages_query",
       "outcome": "failure",
       "summary": "AssertionError: Not logged in"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "517",
       "nodeid": "tests/issues/517/e2e_codex_comprehensive.py::test_api_sessions_list",
       "outcome": "failure",
       "summary": "AssertionError: Not logged in"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "517",
       "nodeid": "tests/issues/517/e2e_codex_comprehensive.py::test_api_tools_list",
       "outcome": "failure",
       "summary": "AssertionError: codex not in tools: []"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "517",
       "nodeid": "tests/issues/517/e2e_codex_comprehensive.py::test_api_usage_data",
       "outcome": "failure",
       "summary": "AssertionError: Usage API failed: 401"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "517",
       "nodeid": "tests/issues/517/e2e_codex_comprehensive.py::test_content_block_types",
       "outcome": "failure",
       "summary": "AssertionError: No 'text' content_blocks"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "517",
       "nodeid": "tests/issues/517/e2e_codex_comprehensive.py::test_daily_usage_tokens",
       "outcome": "failure",
       "summary": "TypeError: '>' not supported between instances of 'NoneType' and 'int'"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "517",
       "nodeid": "tests/issues/517/e2e_codex_comprehensive.py::test_fetch_codex_data",
       "outcome": "failure",
       "summary": "AssertionError: fetch_codex.py failed: /opt/hostedtoolcache/Python/3.11.15/x64/bin/python: can't open file 'tests/scripts/fetch_codex.py': [Errno 2] No such file or directory"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "517",
       "nodeid": "tests/issues/517/e2e_codex_comprehensive.py::test_remote_codex_capabilities",
       "outcome": "failure",
       "summary": "AssertionError: No connected remote machine with codex installed"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "517",
       "nodeid": "tests/issues/517/e2e_codex_comprehensive.py::test_session_messages_content",
       "outcome": "failure",
       "summary": "AssertionError: No codex session_messages with metadata"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "517",
       "nodeid": "tests/issues/517/e2e_codex_comprehensive.py::test_session_restore_codex_detail",
       "outcome": "failure",
       "summary": "AssertionError: Not logged in"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "517",
       "nodeid": "tests/issues/517/e2e_codex_comprehensive.py::test_session_restore_url",
       "outcome": "failure",
       "summary": "AssertionError: Not logged in"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "517",
       "nodeid": "tests/issues/517/e2e_codex_comprehensive.py::test_workspace_status_codex",
       "outcome": "failure",
       "summary": "AssertionError: Not logged in"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "517",
       "nodeid": "tests/issues/517/e2e_codex_integration.py::test_agent_sessions_have_codex",
       "outcome": "failure",
       "summary": "AssertionError: No codex sessions in agent_sessions"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "517",
       "nodeid": "tests/issues/517/e2e_codex_integration.py::test_api_codex_alias_resolution",
       "outcome": "failure",
       "summary": "AssertionError: Not logged in"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "517",
       "nodeid": "tests/issues/517/e2e_codex_integration.py::test_api_messages_codex",
       "outcome": "failure",
       "summary": "AssertionError: Not logged in"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "517",
       "nodeid": "tests/issues/517/e2e_codex_integration.py::test_api_session_detail",
       "outcome": "failure",
       "summary": "AssertionError: Not logged in"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "517",
       "nodeid": "tests/issues/517/e2e_codex_integration.py::test_api_session_with_tokens",
       "outcome": "failure",
       "summary": "AssertionError: Not logged in"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "517",
       "nodeid": "tests/issues/517/e2e_codex_integration.py::test_api_sessions_list_codex",
       "outcome": "failure",
       "summary": "AssertionError: Not logged in"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "517",
       "nodeid": "tests/issues/517/e2e_codex_integration.py::test_api_usage_codex",
       "outcome": "failure",
       "summary": "AssertionError: GET /api/tool/codex/30 failed: 401 {\"error\":\"Authentication required\"}"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "517",
       "nodeid": "tests/issues/517/e2e_codex_integration.py::test_api_usage_tools_includes_codex",
       "outcome": "failure",
       "summary": "AssertionError: GET /api/tools failed: 401"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "517",
       "nodeid": "tests/issues/517/e2e_codex_integration.py::test_codex_content_block_types",
       "outcome": "failure",
       "summary": "AssertionError: No codex session_messages with metadata"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "517",
       "nodeid": "tests/issues/517/e2e_codex_integration.py::test_codex_daily_messages",
       "outcome": "failure",
       "summary": "AssertionError: No codex daily_messages found"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "517",
       "nodeid": "tests/issues/517/e2e_codex_integration.py::test_content_block_types_in_api",
       "outcome": "failure",
       "summary": "AssertionError: Not logged in"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "517",
       "nodeid": "tests/issues/517/e2e_codex_integration.py::test_daily_usage_has_codex",
       "outcome": "failure",
       "summary": "AssertionError: No codex daily_usage rows found"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "517",
       "nodeid": "tests/issues/517/e2e_codex_integration.py::test_fetch_codex_runs",
       "outcome": "failure",
@@ -1562,7 +1562,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "Error",
       "issue_number": "517",
       "nodeid": "tests/issues/517/e2e_codex_integration.py::test_frontend_api_key_codex_option",
       "outcome": "failure",
@@ -1570,15 +1570,15 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "Error",
       "issue_number": "517",
       "nodeid": "tests/issues/517/e2e_codex_integration.py::test_frontend_assist_panel_codex",
       "outcome": "failure",
       "summary": "playwright._impl._errors.Error: Page.goto: net::ERR_CONNECTION_REFUSED at http://<host:port>/login"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "517",
       "nodeid": "tests/issues/517/e2e_codex_integration.py::test_frontend_codex_session_detail",
       "outcome": "failure",
@@ -1586,23 +1586,23 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "Error",
       "issue_number": "517",
       "nodeid": "tests/issues/517/e2e_codex_integration.py::test_frontend_codex_sessions_page",
       "outcome": "failure",
       "summary": "playwright._impl._errors.Error: Page.goto: net::ERR_CONNECTION_REFUSED at http://<host:port>/login"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "517",
       "nodeid": "tests/issues/517/e2e_codex_integration.py::test_session_messages_have_codex",
       "outcome": "failure",
       "summary": "AssertionError: No codex session_messages found"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "517",
       "nodeid": "tests/issues/517/e2e_codex_real_session.py::test_codex_exec_conversation",
       "outcome": "failure",
@@ -1610,23 +1610,23 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "517",
       "nodeid": "tests/issues/517/e2e_codex_real_session.py::test_codex_quota_tracking",
       "outcome": "failure",
       "summary": "sqlite3.OperationalError: no such table: agent_sessions"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "517",
       "nodeid": "tests/issues/517/e2e_codex_real_session.py::test_prerequisites",
       "outcome": "failure",
       "summary": "AssertionError: SSH to 192.168.64.3 failed: ssh: connect to host 192.168.64.3 port 22: Connection timed out"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "517",
       "nodeid": "tests/issues/517/e2e_codex_real_session.py::test_remote_session_create_and_verify",
       "outcome": "failure",
@@ -1634,7 +1634,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "517",
       "nodeid": "tests/issues/517/e2e_codex_real_session.py::test_session_restore",
       "outcome": "failure",
@@ -1642,39 +1642,39 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "517",
       "nodeid": "tests/issues/517/e2e_codex_real_session.py::test_session_sync_verification",
       "outcome": "failure",
       "summary": "sqlite3.OperationalError: no such table: agent_sessions"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "517",
       "nodeid": "tests/issues/517/e2e_codex_real_session.py::test_terminal_codex_launch",
       "outcome": "failure",
       "summary": "AssertionError: Terminal start failed: 401 {\"error\":\"Authentication required\"}"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "52",
       "nodeid": "tests/issues/52/test_issue52.py::test_database_migration",
       "outcome": "failure",
       "summary": "AssertionError: linux_account 字段未添加到 users 表"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "52",
       "nodeid": "tests/issues/52/test_issue52.py::test_get_all_users_includes_linux_account",
       "outcome": "failure",
       "summary": "KeyError: 'linux_account'"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "52",
       "nodeid": "tests/issues/52/test_issue52.py::test_update_user_with_linux_account",
       "outcome": "failure",
@@ -1682,7 +1682,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "53",
       "nodeid": "tests/issues/53/test_add_user_button.py::test_issue53",
       "outcome": "failure",
@@ -1690,7 +1690,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TimeoutError",
       "issue_number": "54",
       "nodeid": "tests/issues/54/test_issue54.py::TestIssue54::test_add_user_modal_fields",
       "outcome": "failure",
@@ -1737,112 +1737,112 @@
       "summary": "failed on setup with \"file tests/issues/559/e2e_terminal_ws_handler.py, line 191"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "559",
       "nodeid": "tests/issues/559/test_terminal_ws_handler.py::TestHandleVSCodeWs::test_cookie_token_can_authenticate_proxy_ws",
       "outcome": "failure",
       "summary": "AssertionError: expected call not found."
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "559",
       "nodeid": "tests/issues/559/test_terminal_ws_handler.py::TestHandleVSCodeWs::test_invalid_proxy_ws_token_closes",
       "outcome": "failure",
       "summary": "AssertionError: expected call not found."
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "559",
       "nodeid": "tests/issues/559/test_terminal_ws_handler.py::TestHandleVSCodeWs::test_proxy_path_bridges_to_matching_remote_path",
       "outcome": "failure",
       "summary": "AssertionError: expected call not found."
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "584",
       "nodeid": "tests/issues/584/test_create_remote_directory.py::TestAgentCreateDirectory::test_already_exists_returns_error",
       "outcome": "failure",
       "summary": "AssertionError: True is not false"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "584",
       "nodeid": "tests/issues/584/test_create_remote_directory.py::TestAgentCreateDirectory::test_parent_not_exists_returns_error",
       "outcome": "failure",
       "summary": "AssertionError: 'Parent directory does not exist' not found in 'No existing ancestor directory found'"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "584",
       "nodeid": "tests/issues/584/test_create_remote_directory.py::TestCreateRemoteDirectoryRoute::test_agent_creation_failure",
       "outcome": "failure",
       "summary": "AssertionError: 401 != 200"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "584",
       "nodeid": "tests/issues/584/test_create_remote_directory.py::TestCreateRemoteDirectoryRoute::test_agent_timeout_returns_504",
       "outcome": "failure",
       "summary": "AssertionError: 401 != 504"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "584",
       "nodeid": "tests/issues/584/test_create_remote_directory.py::TestCreateRemoteDirectoryRoute::test_machine_not_found_returns_404",
       "outcome": "failure",
       "summary": "AssertionError: 401 != 404"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "584",
       "nodeid": "tests/issues/584/test_create_remote_directory.py::TestCreateRemoteDirectoryRoute::test_machine_offline_returns_503",
       "outcome": "failure",
       "summary": "AssertionError: 401 != 503"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "584",
       "nodeid": "tests/issues/584/test_create_remote_directory.py::TestCreateRemoteDirectoryRoute::test_no_path_returns_400",
       "outcome": "failure",
       "summary": "AssertionError: 401 != 400"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "584",
       "nodeid": "tests/issues/584/test_create_remote_directory.py::TestCreateRemoteDirectoryRoute::test_non_admin_no_access_returns_403",
       "outcome": "failure",
       "summary": "AssertionError: 401 != 403"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "584",
       "nodeid": "tests/issues/584/test_create_remote_directory.py::TestCreateRemoteDirectoryRoute::test_path_too_long_returns_400",
       "outcome": "failure",
       "summary": "AssertionError: 401 != 400"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "584",
       "nodeid": "tests/issues/584/test_create_remote_directory.py::TestCreateRemoteDirectoryRoute::test_send_command_failure_returns_500",
       "outcome": "failure",
       "summary": "AssertionError: 401 != 500"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "584",
       "nodeid": "tests/issues/584/test_create_remote_directory.py::TestCreateRemoteDirectoryRoute::test_successful_creation",
       "outcome": "failure",
@@ -1865,8 +1865,8 @@
       "summary": "Failed: async def functions are not natively supported."
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "673",
       "nodeid": "tests/issues/673/test_session_filter_params.py::test_api_endpoint_integration",
       "outcome": "failure",
@@ -1874,7 +1874,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "673",
       "nodeid": "tests/issues/673/test_session_filter_params.py::test_combined_filter",
       "outcome": "error",
@@ -1882,7 +1882,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "673",
       "nodeid": "tests/issues/673/test_session_filter_params.py::test_invalid_session_type_filter",
       "outcome": "error",
@@ -1890,7 +1890,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "673",
       "nodeid": "tests/issues/673/test_session_filter_params.py::test_invalid_status_filter",
       "outcome": "error",
@@ -1898,7 +1898,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "673",
       "nodeid": "tests/issues/673/test_session_filter_params.py::test_session_type_filter",
       "outcome": "error",
@@ -1906,15 +1906,15 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "673",
       "nodeid": "tests/issues/673/test_session_filter_params.py::test_status_filter",
       "outcome": "error",
       "summary": "failed on setup with \"sqlite3.OperationalError: table users has no column named name\""
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_agent_runner.py::TestStopSession::test_shutdown_during_remote_creation_stops_actual_before_prompt",
       "outcome": "failure",
@@ -1922,7 +1922,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_api.py::TestAuthRequired::test_create_requires_auth",
       "outcome": "error",
@@ -1930,7 +1930,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_api.py::TestAuthRequired::test_delete_requires_auth",
       "outcome": "error",
@@ -1938,7 +1938,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_api.py::TestAuthRequired::test_get_requires_auth",
       "outcome": "error",
@@ -1946,7 +1946,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_api.py::TestAuthRequired::test_list_requires_auth",
       "outcome": "error",
@@ -1954,7 +1954,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_api.py::TestAuthRequired::test_tools_requires_auth",
       "outcome": "error",
@@ -1962,7 +1962,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_api.py::TestCancelMilestone::test_cancel_milestone",
       "outcome": "error",
@@ -1970,7 +1970,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_api.py::TestCreateWorkflow::test_create_can_require_full_review_rounds",
       "outcome": "error",
@@ -1978,7 +1978,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_api.py::TestCreateWorkflow::test_create_missing_cli_tool",
       "outcome": "error",
@@ -1986,7 +1986,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_api.py::TestCreateWorkflow::test_create_missing_project_path",
       "outcome": "error",
@@ -1994,7 +1994,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_api.py::TestCreateWorkflow::test_create_missing_requirements",
       "outcome": "error",
@@ -2002,7 +2002,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_api.py::TestCreateWorkflow::test_create_new_project_no_path_needed",
       "outcome": "error",
@@ -2010,7 +2010,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_api.py::TestCreateWorkflow::test_create_success",
       "outcome": "error",
@@ -2018,7 +2018,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_api.py::TestCreateWorkflow::test_create_with_issue_url",
       "outcome": "error",
@@ -2026,7 +2026,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_api.py::TestCreateWorkflow::test_create_with_multiple_issue_selectors",
       "outcome": "error",
@@ -2034,7 +2034,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_api.py::TestCreateWorkflow::test_create_with_only_invalid_issue_selectors",
       "outcome": "error",
@@ -2042,7 +2042,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_api.py::TestDeleteBatch::test_delete_batch_forbidden_for_other_users",
       "outcome": "error",
@@ -2050,7 +2050,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_api.py::TestDeleteBatch::test_delete_batch_not_found",
       "outcome": "error",
@@ -2058,7 +2058,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_api.py::TestDeleteBatch::test_delete_batch_success",
       "outcome": "error",
@@ -2066,7 +2066,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_api.py::TestDeleteWorkflow::test_delete_not_found",
       "outcome": "error",
@@ -2074,7 +2074,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_api.py::TestDeleteWorkflow::test_delete_success",
       "outcome": "error",
@@ -2082,7 +2082,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_api.py::TestForkMilestone::test_fork_milestone",
       "outcome": "error",
@@ -2090,7 +2090,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_api.py::TestGetMilestoneSession::test_get_session_milestone_not_found",
       "outcome": "error",
@@ -2098,7 +2098,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_api.py::TestGetMilestoneSession::test_get_session_no_session_id",
       "outcome": "error",
@@ -2106,7 +2106,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_api.py::TestGetMilestoneSession::test_get_session_prefers_actual_cli_session_when_mapped",
       "outcome": "error",
@@ -2114,7 +2114,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_api.py::TestGetMilestoneSession::test_get_session_success",
       "outcome": "error",
@@ -2122,7 +2122,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_api.py::TestGetMilestoneSession::test_get_session_workflow_not_found",
       "outcome": "error",
@@ -2130,7 +2130,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_api.py::TestGetMilestoneSession::test_get_session_wrong_workflow",
       "outcome": "error",
@@ -2138,7 +2138,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_api.py::TestGetModels::test_get_models_exception_returns_empty",
       "outcome": "error",
@@ -2146,7 +2146,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_api.py::TestGetModels::test_get_models_no_keys_returns_empty",
       "outcome": "error",
@@ -2154,7 +2154,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_api.py::TestGetModels::test_get_models_remote_denies_without_access",
       "outcome": "error",
@@ -2162,7 +2162,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_api.py::TestGetModels::test_get_models_remote_derives_tenant_from_machine",
       "outcome": "error",
@@ -2170,7 +2170,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_api.py::TestGetModels::test_get_models_remote_lookup_failure_not_masked_as_success",
       "outcome": "error",
@@ -2178,7 +2178,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_api.py::TestGetModels::test_get_models_returns_normalized_models",
       "outcome": "error",
@@ -2186,7 +2186,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_api.py::TestGetTimeline::test_get_timeline",
       "outcome": "error",
@@ -2194,7 +2194,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_api.py::TestGetTimeline::test_get_timeline_backfills_diff_stats_per_milestone",
       "outcome": "error",
@@ -2202,7 +2202,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_api.py::TestGetTimeline::test_get_timeline_exposes_actual_llm_session_id",
       "outcome": "error",
@@ -2210,7 +2210,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_api.py::TestGetTools::test_get_tools",
       "outcome": "error",
@@ -2218,7 +2218,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_api.py::TestGetWorkflow::test_get_not_found",
       "outcome": "error",
@@ -2226,7 +2226,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_api.py::TestGetWorkflow::test_get_other_users_workflow_forbidden",
       "outcome": "error",
@@ -2234,7 +2234,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_api.py::TestGetWorkflow::test_get_parses_definition_snapshot",
       "outcome": "error",
@@ -2242,7 +2242,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_api.py::TestGetWorkflow::test_get_success",
       "outcome": "error",
@@ -2250,7 +2250,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_api.py::TestListWorkflows::test_list_admin_sees_all",
       "outcome": "error",
@@ -2258,7 +2258,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_api.py::TestListWorkflows::test_list_passes_search_limit_offset_and_status",
       "outcome": "error",
@@ -2266,7 +2266,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_api.py::TestListWorkflows::test_list_regular_user_filters_own",
       "outcome": "error",
@@ -2274,7 +2274,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_api.py::TestListWorkflows::test_list_success",
       "outcome": "error",
@@ -2282,7 +2282,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_api.py::TestMarkDone::test_mark_done",
       "outcome": "error",
@@ -2290,7 +2290,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_api.py::TestPauseWorkflow::test_pause_already_paused",
       "outcome": "error",
@@ -2298,7 +2298,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_api.py::TestPauseWorkflow::test_pause_success",
       "outcome": "error",
@@ -2306,7 +2306,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_api.py::TestResumeWorkflow::test_resume_not_paused",
       "outcome": "error",
@@ -2314,7 +2314,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_api.py::TestResumeWorkflow::test_resume_success",
       "outcome": "error",
@@ -2322,7 +2322,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_api.py::TestStopWorkflow::test_stop_cancels_queued_batch_siblings",
       "outcome": "error",
@@ -2330,7 +2330,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_api.py::TestStopWorkflow::test_stop_success",
       "outcome": "error",
@@ -2338,7 +2338,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_api.py::TestStreamWorkflowEvents::test_stream_requires_ownership",
       "outcome": "error",
@@ -2346,7 +2346,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_api.py::TestStreamWorkflowEvents::test_stream_returns_event_stream",
       "outcome": "error",
@@ -2354,7 +2354,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_api.py::TestStreamWorkflowEvents::test_stream_workflow_not_found",
       "outcome": "error",
@@ -2362,7 +2362,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_quota_gate.py::TestCreateWorkflowQuotaGate::test_over_quota_rejected",
       "outcome": "error",
@@ -2370,7 +2370,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_quota_gate.py::TestCreateWorkflowQuotaGate::test_quota_check_error_fail_closed_rejected",
       "outcome": "error",
@@ -2378,7 +2378,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_repo.py::TestAllowedFieldsFiltering::test_update_allows_only_whitelisted_fields",
       "outcome": "error",
@@ -2386,7 +2386,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_repo.py::TestAllowedFieldsFiltering::test_update_filters_out_empty_update_set",
       "outcome": "error",
@@ -2394,7 +2394,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_repo.py::TestAllowedFieldsFiltering::test_update_milestone_allowed_fields_filter",
       "outcome": "error",
@@ -2402,7 +2402,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_repo.py::TestAllowedFieldsFiltering::test_update_persists_transient_retry_count",
       "outcome": "error",
@@ -2410,7 +2410,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_repo.py::TestAllowedFieldsFiltering::test_update_workflow_coerces_booleans",
       "outcome": "error",
@@ -2418,7 +2418,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_repo.py::TestCIRoundTripPersistence::test_ci_repair_fields_round_trip",
       "outcome": "error",
@@ -2426,7 +2426,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_repo.py::TestCIRoundTripPersistence::test_worktree_and_preferred_paths_round_trip_together",
       "outcome": "error",
@@ -2434,7 +2434,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_repo.py::TestContentLanguagePersistence::test_defaults_to_en_when_omitted",
       "outcome": "error",
@@ -2442,7 +2442,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_repo.py::TestContentLanguagePersistence::test_explicit_content_language_round_trips",
       "outcome": "error",
@@ -2450,7 +2450,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_repo.py::TestContentLanguagePersistence::test_invalid_content_language_normalized_to_en",
       "outcome": "error",
@@ -2458,7 +2458,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_repo.py::TestContentLanguagePersistence::test_none_content_language_normalized_to_en",
       "outcome": "error",
@@ -2466,7 +2466,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_repo.py::TestEventCRUD::test_create_event",
       "outcome": "error",
@@ -2474,7 +2474,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_repo.py::TestEventCRUD::test_events_ordered_by_created_at",
       "outcome": "error",
@@ -2482,7 +2482,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_repo.py::TestEventCRUD::test_list_events",
       "outcome": "error",
@@ -2490,7 +2490,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_repo.py::TestEventCRUD::test_list_events_with_limit",
       "outcome": "error",
@@ -2498,7 +2498,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_repo.py::TestMilestoneCRUD::test_cancel_milestones_after",
       "outcome": "error",
@@ -2506,7 +2506,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_repo.py::TestMilestoneCRUD::test_create_milestone",
       "outcome": "error",
@@ -2514,7 +2514,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_repo.py::TestMilestoneCRUD::test_get_milestone",
       "outcome": "error",
@@ -2522,7 +2522,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_repo.py::TestMilestoneCRUD::test_list_milestones",
       "outcome": "error",
@@ -2530,7 +2530,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_repo.py::TestMilestoneCRUD::test_list_milestones_filter_dev_round",
       "outcome": "error",
@@ -2538,7 +2538,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_repo.py::TestMilestoneCRUD::test_list_milestones_filter_phase",
       "outcome": "error",
@@ -2546,7 +2546,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_repo.py::TestMilestoneCRUD::test_update_milestone",
       "outcome": "error",
@@ -2554,7 +2554,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_repo.py::TestWorkflowCRUD::test_create_workflow",
       "outcome": "error",
@@ -2562,7 +2562,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_repo.py::TestWorkflowCRUD::test_create_workflow_persists_require_full_review_rounds",
       "outcome": "error",
@@ -2570,7 +2570,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_repo.py::TestWorkflowCRUD::test_delete_batch_cascades",
       "outcome": "error",
@@ -2578,7 +2578,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_repo.py::TestWorkflowCRUD::test_delete_workflow",
       "outcome": "error",
@@ -2586,7 +2586,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_repo.py::TestWorkflowCRUD::test_delete_workflow_cascades",
       "outcome": "error",
@@ -2594,7 +2594,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_repo.py::TestWorkflowCRUD::test_get_active_workflows",
       "outcome": "error",
@@ -2602,7 +2602,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_repo.py::TestWorkflowCRUD::test_get_milestone_usage_summary",
       "outcome": "error",
@@ -2610,7 +2610,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_repo.py::TestWorkflowCRUD::test_get_workflow",
       "outcome": "error",
@@ -2618,7 +2618,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_repo.py::TestWorkflowCRUD::test_get_workflow_not_found",
       "outcome": "error",
@@ -2626,7 +2626,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_repo.py::TestWorkflowCRUD::test_list_workflows",
       "outcome": "error",
@@ -2634,7 +2634,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_repo.py::TestWorkflowCRUD::test_list_workflows_comma_separated_status",
       "outcome": "error",
@@ -2642,7 +2642,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_repo.py::TestWorkflowCRUD::test_list_workflows_filter_status",
       "outcome": "error",
@@ -2650,7 +2650,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_repo.py::TestWorkflowCRUD::test_list_workflows_filter_user",
       "outcome": "error",
@@ -2658,7 +2658,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_repo.py::TestWorkflowCRUD::test_list_workflows_search_and_pagination",
       "outcome": "error",
@@ -2666,7 +2666,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_repo.py::TestWorkflowCRUD::test_update_workflow",
       "outcome": "error",
@@ -2674,7 +2674,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_repo.py::TestWorkflowCRUD::test_update_workflow_empty",
       "outcome": "error",
@@ -2682,7 +2682,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_autonomous_repo.py::TestWorkflowCRUD::test_update_workflow_tokens",
       "outcome": "error",
@@ -2690,7 +2690,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsBranch::test_create_branch_from_base",
       "outcome": "error",
@@ -2698,7 +2698,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsBranch::test_create_branch_from_head",
       "outcome": "error",
@@ -2706,7 +2706,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsBranch::test_delete_branch",
       "outcome": "error",
@@ -2714,7 +2714,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsBranch::test_get_current_branch",
       "outcome": "error",
@@ -2722,7 +2722,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsBranch::test_get_current_commit",
       "outcome": "error",
@@ -2730,7 +2730,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsDiff::test_get_commit_diff",
       "outcome": "error",
@@ -2738,7 +2738,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsDiff::test_get_commit_diff_stats",
       "outcome": "error",
@@ -2746,7 +2746,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsDiff::test_get_diff",
       "outcome": "error",
@@ -2754,7 +2754,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsDiff::test_get_diff_stats",
       "outcome": "error",
@@ -2762,7 +2762,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsError::test_check_false_no_exception",
       "outcome": "error",
@@ -2770,7 +2770,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsError::test_gh_command_failure",
       "outcome": "error",
@@ -2778,7 +2778,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsError::test_gh_not_found",
       "outcome": "error",
@@ -2786,7 +2786,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsError::test_gh_timeout",
       "outcome": "error",
@@ -2794,7 +2794,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsGit::test_git_add_all",
       "outcome": "error",
@@ -2802,7 +2802,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsGit::test_git_commit",
       "outcome": "error",
@@ -2810,7 +2810,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsGit::test_git_commit_default_no_verify_flag",
       "outcome": "error",
@@ -2818,7 +2818,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsGit::test_git_commit_no_verify",
       "outcome": "error",
@@ -2826,7 +2826,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsGit::test_git_init",
       "outcome": "error",
@@ -2834,7 +2834,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsGit::test_git_push",
       "outcome": "error",
@@ -2842,7 +2842,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsInit::test_init",
       "outcome": "failure",
@@ -2850,7 +2850,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsIssue::test_add_issue_comment",
       "outcome": "error",
@@ -2858,7 +2858,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsIssue::test_create_issue",
       "outcome": "error",
@@ -2866,7 +2866,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsIssue::test_create_issue_no_labels",
       "outcome": "error",
@@ -2874,7 +2874,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsIssue::test_get_issue",
       "outcome": "error",
@@ -2882,7 +2882,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsIssue::test_list_issue_comments",
       "outcome": "error",
@@ -2890,7 +2890,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsIssue::test_list_issue_comments_with_since",
       "outcome": "error",
@@ -2898,7 +2898,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsIssue::test_update_issue",
       "outcome": "error",
@@ -2906,7 +2906,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsPR::test_create_pr",
       "outcome": "error",
@@ -2914,7 +2914,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsPR::test_create_pr_draft",
       "outcome": "error",
@@ -2922,7 +2922,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsPR::test_get_pr",
       "outcome": "error",
@@ -2930,7 +2930,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsPR::test_get_pr_merge_state",
       "outcome": "error",
@@ -2938,7 +2938,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsPR::test_list_pr_comments",
       "outcome": "error",
@@ -2946,7 +2946,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsPR::test_list_pr_comments_empty",
       "outcome": "error",
@@ -2954,7 +2954,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsPR::test_merge_pr",
       "outcome": "error",
@@ -2962,7 +2962,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsRepo::test_create_repo",
       "outcome": "error",
@@ -2970,7 +2970,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsRepo::test_create_repo_public",
       "outcome": "error",
@@ -2978,7 +2978,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsRepo::test_get_repo_name",
       "outcome": "error",
@@ -2986,7 +2986,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsRepo::test_get_repo_name_fallback_no_remote",
       "outcome": "error",
@@ -2994,7 +2994,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsRepo::test_get_repo_url",
       "outcome": "error",
@@ -3002,7 +3002,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsWorktree::test_create_worktree",
       "outcome": "error",
@@ -3010,7 +3010,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsWorktree::test_create_worktree_with_base",
       "outcome": "error",
@@ -3018,7 +3018,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsWorktree::test_list_worktrees",
       "outcome": "error",
@@ -3026,47 +3026,47 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_github_ops.py::TestGitHubOpsWorktree::test_remove_worktree",
       "outcome": "error",
       "summary": "failed on setup with \"TypeError: object.__new__() takes exactly one argument (the type to instantiate)\""
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_orchestrator.py::TestOrchestratorMerge::test_merge_blocked_state_triggers_ci_repair",
       "outcome": "failure",
       "summary": "AssertionError: Expected 'mock' to have been called once. Called 0 times."
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_orchestrator.py::TestOrchestratorMerge::test_merge_no_pr",
       "outcome": "failure",
       "summary": "assert 0 > 0"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_orchestrator.py::TestOrchestratorMerge::test_merge_pr_and_cleanup",
       "outcome": "failure",
       "summary": "AssertionError: Expected 'merge_pr' to be called once. Called 0 times."
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_orchestrator.py::TestOrchestratorMerge::test_merge_unstable_skips_ci_repair",
       "outcome": "failure",
       "summary": "AssertionError: Expected 'merge_pr' to be called once. Called 0 times."
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_orchestrator.py::TestOrchestratorMerge::test_merge_with_worktree_cleanup",
       "outcome": "failure",
@@ -3081,80 +3081,80 @@
       "summary": "Failed: DID NOT RAISE GitHubOpsError"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_orchestrator.py::TestOrchestratorPrReview::test_pr_review_accumulates_tokens",
       "outcome": "failure",
       "summary": "AssertionError: expected call not found."
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_orchestrator.py::TestOrchestratorPrReview::test_pr_review_approved_early_moves_to_report",
       "outcome": "failure",
       "summary": "AssertionError: assert 0 == 2"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_orchestrator.py::TestOrchestratorPrReview::test_pr_review_below_max_starts_fix",
       "outcome": "failure",
       "summary": "AssertionError: assert 0 == 2"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_orchestrator.py::TestOrchestratorPrReview::test_pr_review_first_round_creates_pr",
       "outcome": "failure",
       "summary": "AssertionError: Expected 'create_pr' to have been called once. Called 0 times."
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_orchestrator.py::TestOrchestratorPrReview::test_pr_review_force_full_rounds_does_not_end_early",
       "outcome": "failure",
       "summary": "KeyError: 'current_round'"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_orchestrator.py::TestOrchestratorPrReview::test_pr_review_max_one_still_allows_fix_round",
       "outcome": "failure",
       "summary": "AssertionError: assert 0 == 3"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_orchestrator.py::TestOrchestratorPrReview::test_pr_review_max_rounds_moves_to_report",
       "outcome": "failure",
       "summary": "KeyError: 'current_phase'"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_orchestrator.py::TestOrchestratorPrReview::test_pr_review_max_two_caps_at_round_two",
       "outcome": "failure",
       "summary": "AssertionError: assert None == 'report'"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_orchestrator.py::TestOrchestratorPrReview::test_pr_review_max_two_full_flow_two_reviews_two_fixes",
       "outcome": "failure",
       "summary": "AssertionError: assert 0 == 2"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_orchestrator.py::TestOrchestratorPrReview::test_pr_review_posts_comment_to_pr",
       "outcome": "failure",
@@ -3169,8 +3169,8 @@
       "summary": "Failed: DID NOT RAISE RuntimeError"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_orchestrator.py::TestOrchestratorPrReview::test_pr_review_pushes_branch_before_pr",
       "outcome": "failure",
@@ -3178,7 +3178,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "IndexError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_orchestrator.py::TestOrchestratorPrReview::test_pr_review_uses_github_pr_diff_not_two_point_main_diff",
       "outcome": "failure",
@@ -3186,7 +3186,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_orchestrator.py::TestOrchestratorPreparation::test_preparation_branches_from_origin_main",
       "outcome": "failure",
@@ -3194,7 +3194,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_orchestrator.py::TestOrchestratorPreparation::test_preparation_creates_issue_and_branch",
       "outcome": "failure",
@@ -3202,7 +3202,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_orchestrator.py::TestOrchestratorPreparation::test_preparation_issue_url_no_text_reads_issue",
       "outcome": "failure",
@@ -3210,7 +3210,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_orchestrator.py::TestOrchestratorPreparation::test_preparation_persists_issue_number_from_url",
       "outcome": "failure",
@@ -3218,7 +3218,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_orchestrator.py::TestOrchestratorPreparation::test_preparation_reads_existing_issue",
       "outcome": "failure",
@@ -3226,7 +3226,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_orchestrator.py::TestOrchestratorPreparation::test_preparation_reads_issue_with_comments",
       "outcome": "failure",
@@ -3234,7 +3234,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "GitHubOpsError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_orchestrator.py::TestOrchestratorPreparation::test_preparation_worktree_strategy",
       "outcome": "failure",
@@ -3242,7 +3242,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "716",
       "nodeid": "tests/issues/716/test_orchestrator.py::TestOrchestratorPreparation::test_preparation_worktree_uses_preferred_path_when_live_path_empty",
       "outcome": "failure",
@@ -3250,15 +3250,15 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "AttributeError",
       "issue_number": "72",
       "nodeid": "tests/issues/72/test_issue72.py::test_fullscreen",
       "outcome": "failure",
       "summary": "AttributeError: 'coroutine' object has no attribute 'chromium'"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "720",
       "nodeid": "tests/issues/720/test_model_gateway_handler.py::TestGatewaySuccess::test_gateway_forward_success",
       "outcome": "failure",
@@ -3266,23 +3266,23 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TenantResolutionError",
       "issue_number": "723",
       "nodeid": "tests/issues/723/test_mtime_fallback.py::TestListCliSessionIdsForProject::test_returns_distinct_nonempty_ids",
       "outcome": "failure",
       "summary": "app.utils.tenant_resolver.TenantResolutionError: Cannot resolve tenant for session write operation. Provide explicit tenant_id or ensure user has valid tenant assignment."
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "723",
       "nodeid": "tests/issues/723/test_orchestrator_dev_salvage.py::test_dev_not_salvaged_when_no_commit",
       "outcome": "failure",
       "summary": "AssertionError: dev failure with no commit should still mark the workflow failed"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "723",
       "nodeid": "tests/issues/723/test_orchestrator_dev_salvage.py::test_dev_salvaged_on_timeout_with_commit",
       "outcome": "failure",
@@ -3290,7 +3290,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "733",
       "nodeid": "tests/issues/733/test_orchestrator_733.py::TestDevelopmentCommitVerification::test_allows_different_commits",
       "outcome": "failure",
@@ -3298,7 +3298,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "733",
       "nodeid": "tests/issues/733/test_orchestrator_733.py::TestDevelopmentCommitVerification::test_auto_commit_failure_falls_back_to_fail",
       "outcome": "failure",
@@ -3306,7 +3306,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "733",
       "nodeid": "tests/issues/733/test_orchestrator_733.py::TestDevelopmentCommitVerification::test_auto_commits_uncommitted_changes",
       "outcome": "failure",
@@ -3314,7 +3314,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "733",
       "nodeid": "tests/issues/733/test_orchestrator_733.py::TestDevelopmentCommitVerification::test_detects_no_code_changes",
       "outcome": "failure",
@@ -3322,7 +3322,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "733",
       "nodeid": "tests/issues/733/test_orchestrator_733.py::TestDevelopmentCommitVerification::test_skip_check_when_agent_fails",
       "outcome": "failure",
@@ -3330,7 +3330,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "733",
       "nodeid": "tests/issues/733/test_orchestrator_733.py::TestDevelopmentCommitVerification::test_skip_check_when_commit_unavailable",
       "outcome": "failure",
@@ -3338,7 +3338,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "733",
       "nodeid": "tests/issues/733/test_orchestrator_733.py::TestFinalPlanAnnotation::test_final_plan_includes_last_review",
       "outcome": "failure",
@@ -3346,7 +3346,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "733",
       "nodeid": "tests/issues/733/test_orchestrator_733.py::TestFinalPlanAnnotation::test_final_plan_without_review",
       "outcome": "failure",
@@ -3354,7 +3354,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "733",
       "nodeid": "tests/issues/733/test_orchestrator_733.py::TestPermissionModePassthrough::test_default_permission_mode_is_auto_edit",
       "outcome": "failure",
@@ -3362,7 +3362,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "733",
       "nodeid": "tests/issues/733/test_orchestrator_733.py::TestPermissionModePassthrough::test_development_passes_permission_mode",
       "outcome": "failure",
@@ -3370,7 +3370,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "733",
       "nodeid": "tests/issues/733/test_orchestrator_733.py::TestPermissionModePassthrough::test_planning_passes_permission_mode",
       "outcome": "failure",
@@ -3378,7 +3378,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "733",
       "nodeid": "tests/issues/733/test_orchestrator_733.py::TestPlanningPromptConstraints::test_initial_plan_prompt_forbids_full_code",
       "outcome": "failure",
@@ -3386,7 +3386,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "733",
       "nodeid": "tests/issues/733/test_orchestrator_733.py::TestPlanningPromptConstraints::test_refined_plan_prompt_forbids_full_code",
       "outcome": "failure",
@@ -3401,16 +3401,16 @@
       "summary": "Failed: async def functions are not natively supported."
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "740",
       "nodeid": "tests/issues/740/test_batch1_session_wiring.py::TestBackwardCompatibility::test_do_development_still_works",
       "outcome": "failure",
       "summary": "AssertionError: assert False"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "740",
       "nodeid": "tests/issues/740/test_batch1_session_wiring.py::TestBackwardCompatibility::test_do_planning_still_works",
       "outcome": "failure",
@@ -3418,31 +3418,31 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "740",
       "nodeid": "tests/issues/740/test_batch1_session_wiring.py::TestRunAgentWrapper::test_run_agent_passes_pre_generated_session_id",
       "outcome": "failure",
       "summary": "TypeError: 'NoneType' object is not subscriptable"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "740",
       "nodeid": "tests/issues/740/test_batch1_session_wiring.py::TestRunAgentWrapper::test_run_agent_tracks_session_id",
       "outcome": "failure",
       "summary": "AssertionError: assert None == 'sess-tracked-123'"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "740",
       "nodeid": "tests/issues/740/test_batch1_session_wiring.py::TestRunAgentWrapper::test_run_agent_updates_on_each_call",
       "outcome": "failure",
       "summary": "AssertionError: assert None == 'track-review-1'"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "740",
       "nodeid": "tests/issues/740/test_batch1_session_wiring.py::TestRunAgentWrapper::test_session_id_available_before_run_agent_task_returns",
       "outcome": "failure",
@@ -3450,7 +3450,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "740",
       "nodeid": "tests/issues/740/test_batch1_session_wiring.py::TestStopPauseCancelsTask::test_pause_calls_cancel_running_task",
       "outcome": "failure",
@@ -3458,7 +3458,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "740",
       "nodeid": "tests/issues/740/test_batch1_session_wiring.py::TestStopPauseCancelsTask::test_stop_calls_cancel_running_task",
       "outcome": "failure",
@@ -3466,7 +3466,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "740",
       "nodeid": "tests/issues/740/test_batch2_idempotency_validation.py::TestRunAgentDbOptimization::test_run_agent_uses_passed_wf_for_timeout",
       "outcome": "failure",
@@ -3474,7 +3474,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "740",
       "nodeid": "tests/issues/740/test_batch2_idempotency_validation.py::TestRunAgentDbOptimization::test_run_agent_without_wf_falls_back_to_db",
       "outcome": "failure",
@@ -3482,7 +3482,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "740",
       "nodeid": "tests/issues/740/test_batch2_idempotency_validation.py::TestTimeoutConfig::test_run_agent_injects_workflow_timeout",
       "outcome": "failure",
@@ -3490,7 +3490,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "740",
       "nodeid": "tests/issues/740/test_batch2_idempotency_validation.py::TestTimeoutConfig::test_run_agent_omits_timeout_when_not_set",
       "outcome": "failure",
@@ -3498,63 +3498,63 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "740",
       "nodeid": "tests/issues/740/test_batch2_idempotency_validation.py::TestTimeoutConfig::test_run_agent_respects_explicit_timeout",
       "outcome": "failure",
       "summary": "TypeError: 'NoneType' object is not subscriptable"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "740",
       "nodeid": "tests/issues/740/test_batch4_diff_api.py::TestGetMilestoneDiff::test_diff_falls_back_to_project_path",
       "outcome": "failure",
       "summary": "AssertionError: expected call not found."
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "740",
       "nodeid": "tests/issues/740/test_batch4_diff_api.py::TestGetMilestoneDiff::test_diff_uses_worktree_path_preferred",
       "outcome": "failure",
       "summary": "AssertionError: expected call not found."
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "740",
       "nodeid": "tests/issues/740/test_batch4_diff_api.py::TestWorkflowListStatusFilter::test_list_with_status_filter",
       "outcome": "failure",
       "summary": "AssertionError: 500 != 200"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "740",
       "nodeid": "tests/issues/740/test_batch4_diff_api.py::TestWorkflowListStatusFilter::test_list_without_status_filter",
       "outcome": "failure",
       "summary": "AssertionError: 500 != 200"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "740",
       "nodeid": "tests/issues/740/test_batch6_distributed_lock.py::TestRemoteMachineAdminValidation::test_allows_admin_remote_workflow",
       "outcome": "failure",
       "summary": "AssertionError: 500 != 201"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "740",
       "nodeid": "tests/issues/740/test_batch6_distributed_lock.py::TestRemoteMachineAdminValidation::test_allows_local_workflow_without_check",
       "outcome": "failure",
       "summary": "AssertionError: 500 != 201"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "740",
       "nodeid": "tests/issues/740/test_batch6_distributed_lock.py::TestRemoteMachineAdminValidation::test_allows_machine_admin_remote_workflow",
       "outcome": "failure",
@@ -3569,24 +3569,24 @@
       "summary": "failed on setup with \"file tests/issues/76/test_menu.py, line 15"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "761",
       "nodeid": "tests/issues/761/test_planning_restriction.py::TestPlanningTimeout::test_extension_adds_to_base_timeout",
       "outcome": "failure",
       "summary": "assert (1800 + 0) == 600"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "761",
       "nodeid": "tests/issues/761/test_planning_restriction.py::TestPlanningTimeout::test_multiple_extensions_accumulate",
       "outcome": "failure",
       "summary": "assert (1800 + 600) == 1200"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "761",
       "nodeid": "tests/issues/761/test_planning_restriction.py::TestPlanningTimeout::test_planning_timeout_constant",
       "outcome": "failure",
@@ -3594,7 +3594,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TenantResolutionError",
       "issue_number": "764",
       "nodeid": "tests/issues/764/test_session_create_params.py::TestCreateSessionAcceptsWorkspaceParams::test_create_session_defaults_to_local",
       "outcome": "failure",
@@ -3602,7 +3602,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TenantResolutionError",
       "issue_number": "764",
       "nodeid": "tests/issues/764/test_session_create_params.py::TestCreateSessionAcceptsWorkspaceParams::test_create_session_includes_workspace_in_insert",
       "outcome": "failure",
@@ -3610,7 +3610,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TenantResolutionError",
       "issue_number": "764",
       "nodeid": "tests/issues/764/test_session_create_params.py::TestCreateSessionAcceptsWorkspaceParams::test_create_session_type_error_fixed",
       "outcome": "failure",
@@ -3618,7 +3618,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TenantResolutionError",
       "issue_number": "764",
       "nodeid": "tests/issues/764/test_session_create_params.py::TestCreateSessionAcceptsWorkspaceParams::test_create_session_with_workspace_type",
       "outcome": "failure",
@@ -3626,7 +3626,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "786",
       "nodeid": "tests/issues/786/test_ai_github_account.py::TestGitHubOpsEnvInjection::test_build_subprocess_kwargs_no_env",
       "outcome": "failure",
@@ -3634,7 +3634,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "786",
       "nodeid": "tests/issues/786/test_ai_github_account.py::TestGitHubOpsEnvInjection::test_build_subprocess_kwargs_with_env",
       "outcome": "failure",
@@ -3642,7 +3642,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "786",
       "nodeid": "tests/issues/786/test_ai_github_account.py::TestGitHubOpsEnvInjection::test_get_env_returns_dict_when_configured",
       "outcome": "failure",
@@ -3650,7 +3650,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "786",
       "nodeid": "tests/issues/786/test_ai_github_account.py::TestGitHubOpsEnvInjection::test_get_env_returns_none_when_no_config",
       "outcome": "failure",
@@ -3658,7 +3658,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "786",
       "nodeid": "tests/issues/786/test_ai_github_account.py::TestGitHubOpsEnvInjection::test_run_gh_injects_env",
       "outcome": "failure",
@@ -3666,7 +3666,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "786",
       "nodeid": "tests/issues/786/test_ai_github_account.py::TestGitHubOpsEnvInjection::test_run_gh_no_env_when_not_configured",
       "outcome": "failure",
@@ -3674,7 +3674,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "786",
       "nodeid": "tests/issues/786/test_ai_github_account.py::TestGitHubOpsEnvInjection::test_run_git_injects_env",
       "outcome": "failure",
@@ -3746,7 +3746,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "Error",
       "issue_number": "80",
       "nodeid": "tests/issues/80/test_manage_language_dropdown.py::test_manage_language_dropdown",
       "outcome": "failure",
@@ -3778,23 +3778,23 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "GitHubOpsError",
       "issue_number": "814",
       "nodeid": "tests/issues/814/test_worktree_path_selfheal.py::TestEnsureWorktreeSelfHeal::test_no_update_when_path_already_canonical",
       "outcome": "failure",
-      "summary": "app.modules.workspace.autonomous.github_ops.GitHubOpsError: Worktree branch mismatch (<MagicMock name='mock.get_current_branch()' id='140280809876752'> != auto-dev/1390d553) with uncommitted changes.…"
+      "summary": "app.modules.workspace.autonomous.github_ops.GitHubOpsError: Worktree branch mismatch (<MagicMock name='mock.get_current_branch()' id='139708343395536'> != auto-dev/1390d553) with uncommitted changes.…"
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "GitHubOpsError",
       "issue_number": "814",
       "nodeid": "tests/issues/814/test_worktree_path_selfheal.py::TestEnsureWorktreeSelfHeal::test_normalizes_stale_dotdot_path_when_valid",
       "outcome": "failure",
-      "summary": "app.modules.workspace.autonomous.github_ops.GitHubOpsError: Worktree branch mismatch (<MagicMock name='mock.get_current_branch()' id='140280490027536'> != auto-dev/1390d553) with uncommitted changes.…"
+      "summary": "app.modules.workspace.autonomous.github_ops.GitHubOpsError: Worktree branch mismatch (<MagicMock name='mock.get_current_branch()' id='139708308948880'> != auto-dev/1390d553) with uncommitted changes.…"
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TimeoutError",
       "issue_number": "82",
       "nodeid": "tests/issues/82/test_sidebar_collapse.py::test_sidebar_collapse",
       "outcome": "failure",
@@ -3802,7 +3802,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TimeoutError",
       "issue_number": "82",
       "nodeid": "tests/issues/82/test_sidebar_collapse_normal_user.py::test_sidebar_collapse_normal_user",
       "outcome": "failure",
@@ -3810,7 +3810,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "822",
       "nodeid": "tests/issues/822/test_merge_conflict_detection.py::TestAddWorktreeExistingBranch::test_add_worktree_no_b_flag",
       "outcome": "failure",
@@ -3818,15 +3818,15 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "822",
       "nodeid": "tests/issues/822/test_merge_conflict_detection.py::TestAddWorktreeExistingBranch::test_add_worktree_returns_path_and_branch",
       "outcome": "failure",
       "summary": "TypeError: object.__new__() takes exactly one argument (the type to instantiate)"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "822",
       "nodeid": "tests/issues/822/test_merge_conflict_detection.py::TestDoMergeDeferredRetry::test_uses_graph_merge_base_and_backfills_stale_scope_base",
       "outcome": "failure",
@@ -3834,7 +3834,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "822",
       "nodeid": "tests/issues/822/test_merge_conflict_detection.py::TestGetConflictMarkerPaths::test_deleted_conflict_path_is_a_valid_marker_free_resolution",
       "outcome": "failure",
@@ -3842,7 +3842,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "822",
       "nodeid": "tests/issues/822/test_merge_conflict_detection.py::TestGetConflictMarkerPaths::test_detects_custom_marker_size_larger_than_seven",
       "outcome": "failure",
@@ -3850,7 +3850,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "822",
       "nodeid": "tests/issues/822/test_merge_conflict_detection.py::TestGetConflictMarkerPaths::test_no_matches_returns_empty_list",
       "outcome": "failure",
@@ -3858,7 +3858,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "822",
       "nodeid": "tests/issues/822/test_merge_conflict_detection.py::TestGetConflictMarkerPaths::test_probe_failure_raises",
       "outcome": "failure",
@@ -3866,7 +3866,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "822",
       "nodeid": "tests/issues/822/test_merge_conflict_detection.py::TestGetConflictMarkerPaths::test_returns_only_matching_conflict_files",
       "outcome": "failure",
@@ -3874,7 +3874,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "822",
       "nodeid": "tests/issues/822/test_merge_conflict_detection.py::TestGetUnmergedPaths::test_query_failure_raises",
       "outcome": "failure",
@@ -3882,7 +3882,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "822",
       "nodeid": "tests/issues/822/test_merge_conflict_detection.py::TestGetUnmergedPaths::test_returns_authoritative_u_stage_paths",
       "outcome": "failure",
@@ -3890,7 +3890,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "822",
       "nodeid": "tests/issues/822/test_merge_conflict_detection.py::TestGetWorktreeChangedPaths::test_combines_tracked_unmerged_and_untracked_paths",
       "outcome": "failure",
@@ -3898,7 +3898,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "822",
       "nodeid": "tests/issues/822/test_merge_conflict_detection.py::TestGetWorktreeChangedPaths::test_probe_failure_raises[0]",
       "outcome": "failure",
@@ -3906,7 +3906,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "822",
       "nodeid": "tests/issues/822/test_merge_conflict_detection.py::TestGetWorktreeChangedPaths::test_probe_failure_raises[1]",
       "outcome": "failure",
@@ -3914,7 +3914,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "822",
       "nodeid": "tests/issues/822/test_merge_conflict_detection.py::TestIndexSnapshot::test_parses_stage_zero_and_unmerged_entries",
       "outcome": "failure",
@@ -3922,7 +3922,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "822",
       "nodeid": "tests/issues/822/test_merge_conflict_detection.py::TestIndexSnapshot::test_snapshot_probe_and_parse_fail_closed",
       "outcome": "failure",
@@ -3930,7 +3930,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "822",
       "nodeid": "tests/issues/822/test_merge_conflict_detection.py::TestMergePrAutoFlag::test_auto_flag_adds_auto_arg",
       "outcome": "failure",
@@ -3938,7 +3938,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "822",
       "nodeid": "tests/issues/822/test_merge_conflict_detection.py::TestMergePrAutoFlag::test_no_auto_by_default",
       "outcome": "failure",
@@ -3946,7 +3946,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "822",
       "nodeid": "tests/issues/822/test_merge_conflict_detection.py::TestResolveCommit::test_empty_resolution_raises",
       "outcome": "failure",
@@ -3954,23 +3954,23 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "TypeError",
       "issue_number": "822",
       "nodeid": "tests/issues/822/test_merge_conflict_detection.py::TestResolveCommit::test_resolves_ref_to_immutable_commit",
       "outcome": "failure",
       "summary": "TypeError: object.__new__() takes exactly one argument (the type to instantiate)"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "822",
       "nodeid": "tests/issues/822/test_merge_conflict_detection.py::TestResolveMergeConflictsWorktreeIsolation::test_removes_existing_worktree_before_adding_temp",
       "outcome": "failure",
       "summary": "AssertionError: mock({'worktree_path': ''}) call not found"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "822",
       "nodeid": "tests/issues/822/test_merge_conflict_detection.py::TestResolveMergeConflictsWorktreeIsolation::test_restores_worktree_even_on_resolution_failure",
       "outcome": "failure",
@@ -3978,7 +3978,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "GitHubOpsError",
       "issue_number": "826",
       "nodeid": "tests/issues/826/test_plan_review_semantics.py::TestPlanningIntegration::test_approved_review_skips_refinement",
       "outcome": "failure",
@@ -3986,7 +3986,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "GitHubOpsError",
       "issue_number": "826",
       "nodeid": "tests/issues/826/test_plan_review_semantics.py::TestPlanningIntegration::test_plan_review_final_refine_failure_blocks_development",
       "outcome": "failure",
@@ -3994,7 +3994,7 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "GitHubOpsError",
       "issue_number": "826",
       "nodeid": "tests/issues/826/test_plan_review_semantics.py::TestPlanningIntegration::test_substantive_review_triggers_refinement",
       "outcome": "failure",
@@ -4010,7 +4010,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "AssertionError",
       "issue_number": "863",
       "nodeid": "tests/issues/863/e2e_ip_whitelist_input.py::test_ui_ip_whitelist_dedupe",
       "outcome": "error",
@@ -4018,7 +4018,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "AssertionError",
       "issue_number": "863",
       "nodeid": "tests/issues/863/e2e_ip_whitelist_input.py::test_ui_ip_whitelist_empty_lines",
       "outcome": "error",
@@ -4026,7 +4026,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "AssertionError",
       "issue_number": "863",
       "nodeid": "tests/issues/863/e2e_ip_whitelist_input.py::test_ui_ip_whitelist_newline",
       "outcome": "error",
@@ -4034,7 +4034,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "AssertionError",
       "issue_number": "863",
       "nodeid": "tests/issues/863/e2e_ip_whitelist_input.py::test_ui_ip_whitelist_trim",
       "outcome": "error",
@@ -4042,7 +4042,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "886",
       "nodeid": "tests/issues/886/test_cancel_fork_redesign.py::TestCancelMilestoneWithFeedback::test_cancel_creates_requirement_received_milestone",
       "outcome": "error",
@@ -4050,7 +4050,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "886",
       "nodeid": "tests/issues/886/test_cancel_fork_redesign.py::TestCancelMilestoneWithFeedback::test_cancel_empty_feedback_succeeds",
       "outcome": "error",
@@ -4058,7 +4058,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "886",
       "nodeid": "tests/issues/886/test_cancel_fork_redesign.py::TestCancelMilestoneWithFeedback::test_cancel_stores_feedback_on_workflow",
       "outcome": "error",
@@ -4066,7 +4066,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "886",
       "nodeid": "tests/issues/886/test_cancel_fork_redesign.py::TestCancelMilestoneWithFeedback::test_cancel_without_feedback_succeeds",
       "outcome": "error",
@@ -4074,7 +4074,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "886",
       "nodeid": "tests/issues/886/test_cancel_fork_redesign.py::TestForkListing::test_get_forks_empty",
       "outcome": "error",
@@ -4082,7 +4082,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "886",
       "nodeid": "tests/issues/886/test_cancel_fork_redesign.py::TestForkListing::test_get_forks_returns_children",
       "outcome": "error",
@@ -4090,7 +4090,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "886",
       "nodeid": "tests/issues/886/test_cancel_fork_redesign.py::TestForkMilestone::test_fork_copies_milestones",
       "outcome": "error",
@@ -4098,7 +4098,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "886",
       "nodeid": "tests/issues/886/test_cancel_fork_redesign.py::TestForkMilestone::test_fork_creates_forked_milestone_on_parent",
       "outcome": "error",
@@ -4106,7 +4106,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "886",
       "nodeid": "tests/issues/886/test_cancel_fork_redesign.py::TestForkMilestone::test_fork_creates_new_workflow",
       "outcome": "error",
@@ -4114,7 +4114,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "886",
       "nodeid": "tests/issues/886/test_cancel_fork_redesign.py::TestForkMilestone::test_fork_forces_worktree_strategy",
       "outcome": "error",
@@ -4122,7 +4122,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "886",
       "nodeid": "tests/issues/886/test_cancel_fork_redesign.py::TestForkMilestone::test_fork_pause_original",
       "outcome": "error",
@@ -4130,7 +4130,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "886",
       "nodeid": "tests/issues/886/test_cancel_fork_redesign.py::TestForkRepoIntegration::test_copy_milestones_strips_inherited_fork_workflow_id",
       "outcome": "error",
@@ -4138,7 +4138,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "886",
       "nodeid": "tests/issues/886/test_cancel_fork_redesign.py::TestForkRepoIntegration::test_copy_milestones_to_workflow",
       "outcome": "error",
@@ -4146,7 +4146,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "886",
       "nodeid": "tests/issues/886/test_cancel_fork_redesign.py::TestForkRepoIntegration::test_create_and_list_forks",
       "outcome": "error",
@@ -4154,7 +4154,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "886",
       "nodeid": "tests/issues/886/test_cancel_fork_redesign.py::TestForkRepoIntegration::test_create_milestone_persists_fork_workflow_id",
       "outcome": "error",
@@ -4162,7 +4162,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "886",
       "nodeid": "tests/issues/886/test_cancel_fork_redesign.py::TestForkRepoIntegration::test_list_forks_empty",
       "outcome": "error",
@@ -4170,7 +4170,7 @@
     },
     {
       "category": "setup_error",
-      "exception_type": "",
+      "exception_type": "OperationalError",
       "issue_number": "886",
       "nodeid": "tests/issues/886/test_cancel_fork_redesign.py::TestResumeWithFeedback::test_resume_with_feedback",
       "outcome": "error",
@@ -4193,16 +4193,16 @@
       "summary": "Failed: async def functions are not natively supported."
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "913",
       "nodeid": "tests/issues/913/test_pr909_review_feedback.py::TestGetCheckFailureExcerpt::test_ci_repair_context_skips_excerpt_failure",
       "outcome": "failure",
-      "summary": "assert '失败摘录' not in \"PR #42 在合并前...9624972304'>\""
+      "summary": "assert '失败摘录' not in \"PR #42 在合并前...6713164368'>\""
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "Error",
       "issue_number": "95",
       "nodeid": "tests/issues/95/test_messages_ui.py::test_messages_ui",
       "outcome": "failure",
@@ -4249,8 +4249,8 @@
       "summary": "Failed: async def functions are not natively supported."
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "987",
       "nodeid": "tests/issues/987/test_prompt_truncation.py::TestPostGithubComment::test_long_body_capped_with_notice",
       "outcome": "failure",
@@ -4258,47 +4258,47 @@
     },
     {
       "category": "test_body_exception",
-      "exception_type": "",
+      "exception_type": "IndexError",
       "issue_number": "987",
       "nodeid": "tests/issues/987/test_prompt_truncation.py::TestPrReviewPrompt::test_previous_review_content_not_reinjected_but_instruction_kept",
       "outcome": "failure",
       "summary": "IndexError: list index out of range"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "987",
       "nodeid": "tests/issues/987/test_prompt_truncation.py::TestPrReviewPrompt::test_requirements_not_injected",
       "outcome": "failure",
       "summary": "IndexError: list index out of range"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "987",
       "nodeid": "tests/issues/987/test_prompt_truncation.py::TestSummaryPrompt::test_last_pr_review_kept_last_fix_summary_removed",
       "outcome": "failure",
       "summary": "assert 0 >= 2"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "993",
       "nodeid": "tests/issues/993/test_tldr.py::TestMilestoneTldrWrite::test_pr_reviewed_milestone_carries_tldr",
       "outcome": "failure",
       "summary": "AssertionError: pr_reviewed milestone update not captured"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "993",
       "nodeid": "tests/issues/993/test_tldr.py::TestTldrInstruction::test_run_agent_appends_instruction",
       "outcome": "failure",
       "summary": "KeyError: 'prompt'"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "",
+      "category": "assertion_failure",
+      "exception_type": "AssertionError",
       "issue_number": "996",
       "nodeid": "tests/issues/996/test_agent_permissions.py::TestFixPhasePermissionsAndFallback::test_fix_salvages_uncommitted_when_agent_did_not_commit",
       "outcome": "failure",
@@ -4306,10 +4306,10 @@
     }
   ],
   "provenance": {
-    "generated_command": "python scripts/legacy_issue_baseline.py snapshot --junit /tmp/2457-r3/issue-tests-*/test-results/issues-*.xml --source-run 31349649530",
-    "reference_commit": "1de8acb17bd03da7a421dc846adbfd002e83987c",
-    "run_contract": "extended-tests issue-tests, --isolated-home --reruns 1 --timeout 240 --continue-on-collection-errors, 4 shards; tests/issues/604 hang skipped",
-    "source_run": "31349649530",
+    "generated_command": "python scripts/legacy_issue_baseline.py snapshot --junit /tmp/2457-r4/issue-tests-*/test-results/issues-*.xml --source-run 31357513634",
+    "reference_commit": "6f80a5f6abbfd40519fa2cd7281515a8994034da",
+    "run_contract": "extended-tests issue-tests --isolated-home --reruns 1 --timeout 240 --continue-on-collection-errors, 4 shards; 604 quarantined (deselect); CI-validated manifest",
+    "source_run": "31357513634",
     "source_run_url": ""
   },
   "schema": "openace-legacy-issue-failures",

--- a/ci/legacy-issue-failures.json
+++ b/ci/legacy-issue-failures.json
@@ -134,7 +134,7 @@
       "issue_number": "1140",
       "nodeid": "tests/issues/1140/test_zcode_dev_mode_and_session.py::test_session_line_updates_even_on_resume",
       "outcome": "failure",
-      "summary": "AssertionError: _run_agent must not skip session line update on resume — see #525 where dev resumed a dead planning session forever"
+      "summary": "AssertionError: _run_agent must not skip session line update on resume \u2014 see #525 where dev resumed a dead planning session forever"
     },
     {
       "category": "assertion_failure",
@@ -294,7 +294,7 @@
       "issue_number": "1395",
       "nodeid": "tests/issues/1395/test_cross_user_permissions.py::test_isolated_wrapper_can_handle_signals_while_waiting_for_agent",
       "outcome": "failure",
-      "summary": "assert 'trap cleanup_isolated EXIT' in '#!/bin/bash\\n# openace-run-as — cross-user agent launcher for AI autonomous development.\\n#\\n# Problem (Issue #1395): the open-ace service runs as the `openace…"
+      "summary": "assert 'trap cleanup_isolated EXIT' in '#!/bin/bash\\n# openace-run-as \u2014 cross-user agent launcher for AI autonomous development.\\n#\\n# Problem (Issue #1395): the open-ace service runs as the `openace\u2026"
     },
     {
       "category": "assertion_failure",
@@ -302,7 +302,7 @@
       "issue_number": "1395",
       "nodeid": "tests/issues/1395/test_cross_user_permissions.py::test_isolated_wrapper_normalizes_recovered_acls_before_git_baseline",
       "outcome": "failure",
-      "summary": "assert 'signature_registry=\"/run/openace-agent-git-signature-${target_uid}\"' in '#!/bin/bash\\n# openace-run-as — cross-user agent launcher for AI autonomous development.\\n#\\n# Problem (Issue #1395): …"
+      "summary": "assert 'signature_registry=\"/run/openace-agent-git-signature-${target_uid}\"' in '#!/bin/bash\\n# openace-run-as \u2014 cross-user agent launcher for AI autonomous development.\\n#\\n# Problem (Issue #1395): \u2026"
     },
     {
       "category": "test_body_exception",
@@ -1662,7 +1662,7 @@
       "issue_number": "52",
       "nodeid": "tests/issues/52/test_issue52.py::test_database_migration",
       "outcome": "failure",
-      "summary": "AssertionError: linux_account 字段未添加到 users 表"
+      "summary": "AssertionError: linux_account \u5b57\u6bb5\u672a\u6dfb\u52a0\u5230 users \u8868"
     },
     {
       "category": "assertion_failure",
@@ -1678,7 +1678,7 @@
       "issue_number": "52",
       "nodeid": "tests/issues/52/test_issue52.py::test_update_user_with_linux_account",
       "outcome": "failure",
-      "summary": "AssertionError: 创建用户失败"
+      "summary": "AssertionError: \u521b\u5efa\u7528\u6237\u5931\u8d25"
     },
     {
       "category": "test_body_exception",
@@ -1870,7 +1870,7 @@
       "issue_number": "673",
       "nodeid": "tests/issues/673/test_session_filter_params.py::test_api_endpoint_integration",
       "outcome": "failure",
-      "summary": "AssertionError: API 返回 401"
+      "summary": "AssertionError: API \u8fd4\u56de 401"
     },
     {
       "category": "setup_error",
@@ -3782,7 +3782,7 @@
       "issue_number": "814",
       "nodeid": "tests/issues/814/test_worktree_path_selfheal.py::TestEnsureWorktreeSelfHeal::test_no_update_when_path_already_canonical",
       "outcome": "failure",
-      "summary": "app.modules.workspace.autonomous.github_ops.GitHubOpsError: Worktree branch mismatch (<MagicMock name='mock.get_current_branch()' id='139708343395536'> != auto-dev/1390d553) with uncommitted changes.…"
+      "summary": "app.modules.workspace.autonomous.github_ops.GitHubOpsError: Worktree branch mismatch (<MagicMock name='mock.get_current_branch()' id='139708343395536'> != auto-dev/1390d553) with uncommitted changes.\u2026"
     },
     {
       "category": "test_body_exception",
@@ -3790,7 +3790,7 @@
       "issue_number": "814",
       "nodeid": "tests/issues/814/test_worktree_path_selfheal.py::TestEnsureWorktreeSelfHeal::test_normalizes_stale_dotdot_path_when_valid",
       "outcome": "failure",
-      "summary": "app.modules.workspace.autonomous.github_ops.GitHubOpsError: Worktree branch mismatch (<MagicMock name='mock.get_current_branch()' id='139708308948880'> != auto-dev/1390d553) with uncommitted changes.…"
+      "summary": "app.modules.workspace.autonomous.github_ops.GitHubOpsError: Worktree branch mismatch (<MagicMock name='mock.get_current_branch()' id='139708308948880'> != auto-dev/1390d553) with uncommitted changes.\u2026"
     },
     {
       "category": "test_body_exception",
@@ -4198,7 +4198,7 @@
       "issue_number": "913",
       "nodeid": "tests/issues/913/test_pr909_review_feedback.py::TestGetCheckFailureExcerpt::test_ci_repair_context_skips_excerpt_failure",
       "outcome": "failure",
-      "summary": "assert '失败摘录' not in \"PR #42 在合并前...6713164368'>\""
+      "summary": "assert '\u5931\u8d25\u6458\u5f55' not in \"PR #42 \u5728\u5408\u5e76\u524d...6713164368'>\""
     },
     {
       "category": "test_body_exception",
@@ -4254,7 +4254,7 @@
       "issue_number": "987",
       "nodeid": "tests/issues/987/test_prompt_truncation.py::TestPostGithubComment::test_long_body_capped_with_notice",
       "outcome": "failure",
-      "summary": "AssertionError: assert '截断' in 'BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB…"
+      "summary": "AssertionError: assert '\u622a\u65ad' in 'BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB\u2026"
     },
     {
       "category": "test_body_exception",
@@ -4306,11 +4306,11 @@
     }
   ],
   "provenance": {
-    "generated_command": "python scripts/legacy_issue_baseline.py snapshot --junit artifacts/test-results/issues-*.xml --source-run 31357513634 --shard-count 4",
+    "generated_command": "python scripts/legacy_issue_baseline.py snapshot --junit 'artifacts/test-results/issues-*.xml' --output ci/legacy-issue-failures.json --exit-code-glob 'artifacts/test-results/issues-*.exit-code' --shard-count 4 --quarantine ci/legacy-issue-quarantine.json --test-baseline .test-baseline.json --source-run 31359257263 --source-run-url https://github.com/open-ace/open-ace/actions/runs/31359257263 --reference-commit 56a165ab08fd77fc560398984763dc671e8f05b2 --run-contract 'extended-tests issue-tests --isolated-home --reruns 1 --timeout 240 --continue-on-collection-errors, 4 shards; 604 quarantined (deselect); CI-validated manifest'",
     "reference_commit": "56a165ab08fd77fc560398984763dc671e8f05b2",
     "run_contract": "extended-tests issue-tests --isolated-home --reruns 1 --timeout 240 --continue-on-collection-errors, 4 shards; 604 quarantined (deselect); CI-validated manifest",
-    "source_run": "31357513634",
-    "source_run_url": "https://github.com/open-ace/open-ace/actions/runs/31357513634"
+    "source_run": "31359257263",
+    "source_run_url": "https://github.com/open-ace/open-ace/actions/runs/31359257263"
   },
   "schema": "openace-legacy-issue-failures",
   "selection": "not postgres",

--- a/ci/legacy-issue-failures.json
+++ b/ci/legacy-issue-failures.json
@@ -62,7 +62,7 @@
       "issue_number": "1111",
       "nodeid": "tests/issues/1111/test_sqlite_normalize_derived_tables.py::test_sqlite_upgrade_merges_qwen_alias_rows_before_normalization",
       "outcome": "failure",
-      "summary": "subprocess.CalledProcessError: Command '['/opt/hostedtoolcache/Python/3.11.15/x64/bin/python', '-m', 'alembic', '-c', 'alembic.ini', 'upgrade', '017_add_usage_summary']' returned non-zero exit status…"
+      "summary": "subprocess.CalledProcessError: Command '['python', '-m', 'alembic', '-c', 'alembic.ini', 'upgrade', '017_add_usage_summary']' returned non-zero exit status 255."
     },
     {
       "category": "test_body_exception",
@@ -70,7 +70,7 @@
       "issue_number": "1111",
       "nodeid": "tests/issues/1111/test_sqlite_normalize_derived_tables.py::test_sqlite_upgrade_rebuilds_claude_summary_with_distinct_day_count",
       "outcome": "failure",
-      "summary": "subprocess.CalledProcessError: Command '['/opt/hostedtoolcache/Python/3.11.15/x64/bin/python', '-m', 'alembic', '-c', 'alembic.ini', 'upgrade', '038_normalize_tool_names']' returned non-zero exit sta…"
+      "summary": "subprocess.CalledProcessError: Command '['python', '-m', 'alembic', '-c', 'alembic.ini', 'upgrade', '038_normalize_tool_names']' returned non-zero exit status 255."
     },
     {
       "category": "assertion_failure",
@@ -1414,7 +1414,7 @@
       "issue_number": "517",
       "nodeid": "tests/issues/517/e2e_codex_comprehensive.py::test_fetch_codex_data",
       "outcome": "failure",
-      "summary": "AssertionError: fetch_codex.py failed: /opt/hostedtoolcache/Python/3.11.15/x64/bin/python: can't open file 'tests/scripts/fetch_codex.py': [Errno 2] No such file or directory"
+      "summary": "AssertionError: fetch_codex.py failed: python: can't open file 'tests/scripts/fetch_codex.py': [Errno 2] No such file or directory"
     },
     {
       "category": "assertion_failure",
@@ -1558,7 +1558,7 @@
       "issue_number": "517",
       "nodeid": "tests/issues/517/e2e_codex_integration.py::test_fetch_codex_runs",
       "outcome": "failure",
-      "summary": "AssertionError: fetch_codex.py failed: /opt/hostedtoolcache/Python/3.11.15/x64/bin/python: can't open file 'tests/scripts/fetch_codex.py': [Errno 2] No such file or directory"
+      "summary": "AssertionError: fetch_codex.py failed: python: can't open file 'tests/scripts/fetch_codex.py': [Errno 2] No such file or directory"
     },
     {
       "category": "test_body_exception",
@@ -4306,11 +4306,11 @@
     }
   ],
   "provenance": {
-    "generated_command": "python scripts/legacy_issue_baseline.py snapshot --junit /tmp/2457-r4/issue-tests-*/test-results/issues-*.xml --source-run 31357513634",
-    "reference_commit": "6f80a5f6abbfd40519fa2cd7281515a8994034da",
+    "generated_command": "python scripts/legacy_issue_baseline.py snapshot --junit artifacts/test-results/issues-*.xml --source-run 31357513634 --shard-count 4",
+    "reference_commit": "56a165ab08fd77fc560398984763dc671e8f05b2",
     "run_contract": "extended-tests issue-tests --isolated-home --reruns 1 --timeout 240 --continue-on-collection-errors, 4 shards; 604 quarantined (deselect); CI-validated manifest",
     "source_run": "31357513634",
-    "source_run_url": ""
+    "source_run_url": "https://github.com/open-ace/open-ace/actions/runs/31357513634"
   },
   "schema": "openace-legacy-issue-failures",
   "selection": "not postgres",

--- a/ci/legacy-issue-quarantine.json
+++ b/ci/legacy-issue-quarantine.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "schema": "openace-legacy-issue-quarantine",
+  "entries": [
+    {
+      "nodeid": "tests/issues/604/test_llm_proxy_handler_1060.py::TestUpstreamQuotaExceededAlert::test_upstream_429_other_error_no_alert",
+      "reason": "Deadlocks the remote LLM-proxy failover loop in a background-thread wait that pytest-timeout cannot terminate; shard cannot complete while this runs.",
+      "owner": "richardhuang",
+      "tracking_issue": "https://github.com/open-ace/open-ace/issues/2466",
+      "exit_condition": "The remote LLM-proxy handler returns a non-deadlocking result (500/502) after exhausting failover keys; verified when the weekly subprocess probe for this nodeid passes.",
+      "expires_on": "2026-09-09"
+    }
+  ]
+}

--- a/ci/legacy-issue-quarantine.json
+++ b/ci/legacy-issue-quarantine.json
@@ -8,7 +8,8 @@
       "owner": "richardhuang",
       "tracking_issue": "https://github.com/open-ace/open-ace/issues/2466",
       "exit_condition": "The remote LLM-proxy handler returns a non-deadlocking result (500/502) after exhausting failover keys; verified when the weekly subprocess probe for this nodeid passes.",
-      "expires_on": "2026-09-09"
+      "expires_on": "2026-09-09",
+      "expected_probe_outcome": "timeout"
     }
   ]
 }

--- a/docs/TEST_LAYERS.md
+++ b/docs/TEST_LAYERS.md
@@ -137,3 +137,42 @@ Baseline 是防止测试静默消失的下限，不是覆盖率指标。降低 b
 `min_*`，并在 PR 中解释原因；新增测试只更新 `actual_*`，定期将 `min_*`
 向实际值收紧。最后重跑两个 collection suite。`ci/suites.json` 的
 `baseline_runbook` 字段固定指向本节，确保从 suite 清单可以发现本流程。
+
+### Legacy 失败基线（`ci/legacy-issue-failures.json`）
+
+这是与上面**完全不同**的另一类 baseline：它记录 `tests/issues/` 当前已审查的
+历史失败（assertion/error），不是 item/file 数量下限。两者必须同时生效，互不
+替代。详见 `docs/issue-2457-agent-handoff.md`。
+
+- 身份键 = `(nodeid, outcome, category)`。`nodeid` 由 `tests/issues/conftest.py`
+  的 `record_property("openace_nodeid", ...)` 注入（xunit2 不带 `file` 属性，故
+  必须由 conftest 提供权威 nodeid）。因此**生成 baseline 的 reference run 必须
+  在包含该 conftest 的提交上触发**。
+- `compare`（只读）是权威 gate：仅有 `known` 且完整 → exit 0（summary 仍列债务）；
+  出现 `new`/`changed`/`resolved`/任何 `collection_error`/`invalid` → 非零退出。
+  `collection_error` 永不进 baseline（collection gate 必须保持为零）；`resolved`
+  强制从 baseline 删除该 entry（包括 rerun 后转绿的失败），保证 baseline 持续收缩。
+- `snapshot`（显式 `--output`）生成候选 baseline 供人工 review，**拒绝**包含
+  `collection_error`。
+
+更新流程（只能由 PR 显式更新，CI 不得自动写回）：
+
+1. 在包含 `tests/issues/conftest.py` 的分支上触发
+   `workflow_dispatch category=issues`，等全部 4 shard 完成。
+2. 下载 `issue-tests-*` artifact，运行：
+
+   ```bash
+   python scripts/legacy_issue_baseline.py snapshot \
+     --junit '<下载的 test-results/issues-*.xml>' \
+     --source-run <run-id> --reference-commit <sha> \
+     --run-contract 'extended-tests issue-tests, --isolated-home --reruns 1 --timeout 240, 4 shards' \
+     --output ci/legacy-issue-failures.json
+   ```
+
+3. 在 PR 中说明全部新增 entries 来自哪次 reference run、按 outcome/category/issue
+   的分布，以及异常大户。降低/删除 entry 时同样在 PR 中逐条说明。
+4. 重跑一次 `category=issues`：仅已知失败时 `compare` exit 0。
+
+`run_extended_tests.py` 的 `require_review_threshold`（10%）同时是 comparator 的
+文件数地板来源，避免两套门禁口径不一致。Targeted（`--issue-numbers`）运行只在
+summary 标为 targeted，不冒充完整 nightly gate。

--- a/docs/issue-2457-agent-handoff.md
+++ b/docs/issue-2457-agent-handoff.md
@@ -1,0 +1,369 @@
+# Issue #2457 Agent 交接：Legacy issue quarantine 失败基线
+
+> 任务来源：[#2457](https://github.com/open-ace/open-ace/issues/2457)
+> Umbrella：[#2429](https://github.com/open-ace/open-ace/issues/2429)
+> 初始证据：[Extended Tests run 31313240896](https://github.com/open-ace/open-ace/actions/runs/31313240896)
+> 本文状态：实施交接与审查契约；完成实现后由 #2429 当前负责人审查。
+
+## 给实施 Agent 的启动指令
+
+1. 从包含本文的 `codex/2457-agent-handoff` 分支创建自己的 worktree/工作分支；
+   不要从旧的 #2455/#2456 分支继续。
+2. 完整阅读本文、`docs/TEST_LAYERS.md`、`tests/issues/README.md`、
+   `.test-baseline.json`、`scripts/run_extended_tests.py`、`ci/suites.json` 和
+   `.github/workflows/extended-tests.yml` 后再修改代码。
+3. 先在 #2457 留一条简短实施计划，明确 baseline schema、fail-closed completeness
+   和 workflow 聚合方式；如需改变本文 P0 契约，等待确认后再做。
+4. 在同一分支持续实现并创建 Draft PR；不要另外复制一份交接文档。
+5. 完成本文第 7 节自验后，在 #2457 通知当前负责人按第 8 节审查。
+
+## 1. 要交付的结果
+
+为 `tests/issues/` legacy quarantine 建立机器可读、可审查、fail-closed 的
+known-failure baseline。Nightly 必须同时满足：
+
+1. 已审查的历史失败仍清楚出现在 summary 和 artifact 中，但不会让 nightly
+   因同一批已知失败永远保持红色。
+2. 任意新增 collection error、执行 error 或 assertion failure 都让权威 gate
+   失败。
+3. 已知失败恢复为绿色时，CI 要求收缩 baseline，不能长期保留过期豁免。
+4. 报告缺失、XML 损坏、分片被取消或结果不完整时必须失败，不能把“没跑完”
+   当成“没有新失败”。
+5. Baseline 只能由经过 review 的仓库变更更新；CI 不得自动接受当前结果。
+
+完成后请创建 Draft PR，正文包含 `Refs #2457`，并逐项附上本文验收证据。
+不要在全部验收完成前关闭 #2457。
+
+## 2. 当前事实基线
+
+以 2026-08-09 的 `main` 为准：
+
+- `.test-baseline.json` 记录 `tests/issues/` 共 4,473 个可收集 item、446 个文件；
+  这是防止测试静默消失的 collection baseline，不是本任务要建立的失败豁免表。
+- `python scripts/ci.py run issue-collection` 已是 required PR gate；collection error
+  当前应为零。
+- `.github/workflows/extended-tests.yml` 每夜把 legacy issues 分成 4 个 shard，使用
+  `--isolated-home --reruns 1 --timeout 240 --junitxml ...` 执行。
+- 首次合并后全量运行中，已完成的三个 shard 共报告 3,429 项：
+
+  | Shard | Tests | Failures | Errors | Test step duration |
+  |---|---:|---:|---:|---:|
+  | 2/4 | 1,024 | 86 | 44 | 约 17m42s |
+  | 3/4 | 958 | 73 | 10 | 约 15m16s |
+  | 4/4 | 1,447 | 117 | 113 | 约 27m00s |
+
+  合计为 276 failures、167 errors。Shard 1 当时仍在运行，因此这三个 artifact
+  **不是完整初始 baseline**，不得直接提交为全量基线。
+- 真实 JUnit 使用 pytest xUnit XML；test identity 当前主要由 `<testcase
+  classname="..." name="...">` 表达。初始 artifact 未显式携带完整 pytest
+  `nodeid`，实现必须可靠恢复 identity，或为后续报告增加稳定的 nodeid property，
+  并兼容现有 artifact。
+- 失败主要聚类为旧 SQLite schema/fixture、认证和 tenant 契约漂移、过期 mock、
+  缺失 async/HTTP/Playwright fixture，以及依赖旧运行环境的 UI/API 工具。
+
+开始编码前重新读取 #2457 及其最新评论，并确认上述 workflow run 是否已生成
+shard 1 artifact。初始 baseline 必须来自同一 commit、同一运行契约下的一组完整
+报告；若单个运行因超时无法完成，可用更多临时非重叠批次采集，但必须证明所有
+预期 nodeid 被完整覆盖一次。
+
+## 3. 范围边界
+
+### 本任务包含
+
+- 解析一个或多个 pytest JUnit XML，并归一化为稳定 failure records。
+- 合并任意数量、任意分片方式的报告；结果不能依赖当前固定 4 路分片。
+- 生成候选 baseline 的显式命令，以及只读 compare 命令。
+- 对当前结果与 tracked baseline 做双向差异检查。
+- 生成机器可读 diff、Markdown summary 和可下载 artifact。
+- 把 comparator 接入完整 nightly/manual issue run，并让最终 quality gate 使用
+  comparator 的结论。
+- 添加足够的 unit/contract tests 与维护文档。
+
+### 本任务不包含
+
+- 一次性修复、删除或迁移所有 legacy tests。
+- 修改测试目录分类契约；继续遵守 `docs/TEST_LAYERS.md`。
+- 实施 #2458 的历史耗时分片算法。Baseline 合并必须与分片算法解耦。
+- 实施 #2459 的 workflow-dispatch 去重。
+- 通过放宽 timeout、删除断言、批量 `skip`/`xfail`、降低 collection baseline，
+  或吞掉 pytest 退出码来制造绿色结果。
+- 把 `tests/issues/` 升级成 PR required 全量执行。PR 仍只 required collection 和
+  已提升的 `legacy-pr` suite；全量执行属于 nightly/manual。
+
+如果实现确实需要触碰以上非目标，请先在 #2457 留言说明阻塞关系，不要静默扩 scope。
+
+## 4. 必须遵守的设计契约
+
+### 4.1 两类 baseline 不得混淆
+
+- `.test-baseline.json`：测试 item/file 数量下限，证明测试仍能收集且没有静默消失。
+- 新 failure baseline：只描述当前已审查的 legacy 非绿色结果。
+
+两者必须同时生效。Failure comparator 不得替代 `issue-collection`，也不得通过修改
+`.test-baseline.json` 掩盖缺失报告。
+
+### 4.2 Baseline identity 与 schema
+
+Tracked 文件应使用有版本号的 JSON，路径和命名可在 PR 中确定，但必须满足：
+
+- 顶层有 schema `version`。
+- 有 reference commit、source workflow run URL/ID、运行契约和生成命令等 provenance。
+- entries 按稳定键排序，重复生成 byte-stable。
+- 每条至少包含：
+  - 完整 pytest `nodeid`；
+  - 所属 issue number；
+  - outcome（至少区分 `failure` 与 `error`）；
+  - 稳定 error category；
+  - 可审查的异常类型或短摘要。
+- 绝对 runner 路径、时间戳、端口、临时 HOME、内存地址和大段 traceback 不得进入
+  identity key。
+- 不能只以 error message hash 为 identity；message 漂移不能让同一个失败无限新增。
+- 同一 nodeid 的重复或冲突结果不得静默覆盖，必须明确合并或报错。
+
+推荐 comparison key 为 `(nodeid, outcome, category)`；异常类型和归一化摘要用于
+review 展示。若采用其他 key，请在 PR 中解释为什么更稳定。
+
+### 4.3 分类至少要区分
+
+- collection/import error；
+- setup/fixture error；
+- teardown error；
+- timeout；
+- assertion failure；
+- test-body exception；
+- runner/infrastructure failure（报告缺失、取消、损坏、进程异常等）。
+
+分类规则必须版本化并由 fixture XML 测试覆盖。当前 collection gate 已清零，因此
+任何 collection error 都应硬失败，不允许新增到 baseline。
+
+### 4.4 双向 diff
+
+Comparator 至少输出：
+
+- `known`: 当前仍存在且与 baseline 匹配；
+- `new`: 当前出现但 baseline 不存在；
+- `resolved`: baseline 中存在但当前已恢复；
+- `changed`: 同一 nodeid 的 outcome/category 发生变化；
+- `invalid/incomplete`: 报告或覆盖证据不可信。
+
+退出语义：
+
+- 只有 `known`，且结果完整：成功，但 summary 仍列出债务数量和主要聚类。
+- 存在 `new`、`changed`、collection error 或 `invalid/incomplete`：失败。
+- 存在 `resolved`：失败并要求删除 stale baseline entry；这样才能保证 baseline
+  持续收缩。若选择不同退出策略，必须提供同等强度、不可忽略的收缩门禁。
+
+### 4.5 Fail-closed 完整性
+
+只解析“碰巧上传成功的 XML”不够。权威 compare 必须证明结果完整：
+
+- 所有预期 shard/batch artifact 均存在且 XML 可解析。
+- 每个报告包含可信 suite totals，合并结果无意外重复。
+- 执行前生成与 `-m "not postgres"` 相同选择语义的 machine-readable nodeid/file
+  manifest；compare 验证预期 nodeid 均有终态结果。
+- 完整运行的文件覆盖仍满足 `.test-baseline.json` 的 issues file baseline。
+- job timeout、workflow cancellation、缺失 artifact、零测试、部分 XML、未知 schema
+  version 全部失败。
+- Targeted `--issue-numbers` 运行必须在 summary 中标为 targeted，不能冒充完整
+  nightly。若支持 targeted compare，只能与所选 issue 的 baseline 子集比较。
+
+不要依赖 shard 编号作为 baseline identity；#2458 重排文件后，相同失败仍应匹配。
+
+### 4.6 CI 中允许的非阻塞方式
+
+Legacy pytest step 可以使用 step-level `continue-on-error` 作为“确保 JUnit 被上传”的
+传输机制，但仅当：
+
+1. pytest 原始退出码和 manifest 一并进入 artifact；
+2. 一个 `if: always()` 的后置 comparator 下载全部报告并 fail closed；
+3. `Nightly Quality Gate` 依赖 comparator 结论，而不是把 shard 的非阻塞状态当成绿；
+4. comparator 缺席或 skipped 时最终 gate 失败。
+
+禁止在没有权威 comparator 的情况下给整个 job/workflow 设置 `continue-on-error`。
+
+### 4.7 Baseline 更新
+
+- 默认命令只读，不修改 tracked 文件。
+- 生成候选 baseline 必须使用显式子命令和显式输出路径。
+- CI 不得把当前结果写回仓库、自动提交或自动扩 baseline。
+- Baseline 增长必须在 PR diff 中逐条可见，并在 PR 正文说明原因和 source run。
+- 初始 baseline 只能在完整 reference run 后生成；不允许手工抄写聚合数字代替 entries。
+
+## 5. 推荐实施顺序
+
+### Phase A：纯库与 fixture tests
+
+1. 定义 versioned schema、record 类型和稳定排序。
+2. 实现 JUnit parser、nodeid 解析/兼容、error classifier。
+3. 实现多报告 merge、完整性验证和双向 diff。
+4. 用最小 XML fixtures 覆盖 failure/error/skip、多个 suites、损坏 XML、重复 identity、
+   缺失报告、collection error 和绝对路径归一化。
+
+这一阶段不得依赖 GitHub API，保证本地与 Actions 使用完全相同代码。
+
+### Phase B：CLI 与报告
+
+建议提供类似接口（名称可调整，语义不可缺失）：
+
+```bash
+# 只读比较；默认不得修改 baseline
+python scripts/ci/legacy_issue_baseline.py compare \
+  --baseline ci/legacy-issue-failures.json \
+  --junit 'test-results/issues-*.xml' \
+  --manifest 'test-results/issues-*.manifest.json' \
+  --json-output test-results/legacy-issue-diff.json \
+  --markdown-output test-results/legacy-issue-summary.md
+
+# 显式生成候选文件，供人工 review
+python scripts/ci/legacy_issue_baseline.py snapshot \
+  --junit 'test-results/issues-*.xml' \
+  --manifest 'test-results/issues-*.manifest.json' \
+  --source-run 31313240896 \
+  --output /tmp/legacy-issue-failures.candidate.json
+```
+
+CLI 错误必须给出可行动信息：缺哪个报告、哪个 nodeid 新增、哪个 baseline entry 已
+resolved，以及应运行什么命令生成候选 diff。
+
+### Phase C：runner 与 workflow
+
+1. 让每个完整 issue batch 上传 JUnit、machine-readable manifest、pytest exit code 和
+   server log。
+2. 新增独立 comparator job，使用 `if: always()` 下载并合并所有 issue artifacts。
+3. 上传 JSON diff、Markdown summary、原始 JUnit/manifest；summary 展示 known/new/
+   resolved/changed/invalid 数量及按 issue/category 聚类。
+4. 让 `Nightly Quality Gate` 使用 comparator 的权威结果。
+5. `workflow_dispatch category=issues/all` 也执行相同 compare，以便 PR 分支做真实验证。
+6. 不改变 PR required `PR Gate` 的短路径，也不把昂贵全量 issue execution 加到每个 PR。
+
+### Phase D：初始 snapshot 与真实验证
+
+1. 从同一 commit、相同依赖 lock、相同 runner 契约采集完整报告。
+2. 生成候选 baseline，人工检查高密度 issue 与分类分布。
+3. 提交 baseline，并在 PR 解释全部新增 entries 都来自哪次 reference run。
+4. 在 PR head 上手动跑一次完整 `category=issues`：只有已知失败时 comparator 应成功。
+5. 用自动化测试或临时测试分支注入一个新 failure，证明 comparator 和最终 gate 会失败；
+   不要把故障注入提交到最终 PR。
+6. 删除一个候选 baseline entry 或修复一个 synthetic known failure，证明 `new` 和
+   `resolved` 两个方向都会阻断。
+
+## 6. 最低交付物
+
+- [ ] Versioned failure baseline JSON。
+- [ ] Parser/classifier/diff/completeness 实现。
+- [ ] 只读 compare 与显式 snapshot CLI。
+- [ ] Machine-readable execution manifest。
+- [ ] Unit XML fixtures 与 deterministic unit tests。
+- [ ] Extended Tests 的聚合 comparator job。
+- [ ] GitHub step summary 与可下载 JSON/Markdown/JUnit/manifest artifacts。
+- [ ] `docs/TEST_LAYERS.md` 或相邻运维文档中的 baseline 更新说明。
+- [ ] PR 正文中的 source run、真实验证链接、baseline diff 摘要和已知限制。
+
+## 7. 实施 Agent 自验清单
+
+### 数据与确定性
+
+- [ ] 同一组 XML 不同输入顺序生成完全相同的 snapshot。
+- [ ] Linux/macOS 绝对路径差异不会改变 identity。
+- [ ] 参数化测试、类方法和同名测试能生成唯一稳定 nodeid。
+- [ ] Baseline 每条 entry 都能映射到一个冻结 inventory 中的 issue number。
+- [ ] 没有 traceback、token、用户目录、数据库内容或其他敏感数据进入 tracked baseline。
+
+### Comparator 行为
+
+- [ ] 只有 known failures：exit 0，但 summary 明确显示债务。
+- [ ] 新 assertion failure：非零退出。
+- [ ] 新 setup/fixture error：非零退出。
+- [ ] outcome/category 变化：非零退出并显示 changed。
+- [ ] resolved entry：非零退出并要求收缩 baseline。
+- [ ] collection/import error：始终非零，不能 snapshot 为允许项。
+- [ ] 缺失/损坏/空/部分 JUnit：非零退出。
+- [ ] 缺 shard、取消 job、nodeid 覆盖不完整：非零退出。
+- [ ] 重复或冲突 identity：非零退出或经过有测试的显式聚合，绝不 last-write-wins。
+- [ ] Targeted run 不会被报告成完整全量 gate。
+
+### CI 行为
+
+- [ ] 原始 pytest 失败仍能上传 JUnit 和日志。
+- [ ] Comparator 即使上游失败或取消也会运行，并在证据不全时失败。
+- [ ] `Nightly Quality Gate` 只在 collection、deterministic suites、E2E 和 legacy
+      comparator 都满足各自契约时成功。
+- [ ] PR `PR Gate` 的 required 路径和预期耗时没有被 full legacy execution 拖长。
+- [ ] Manual `category=issues` 真实运行产生清晰 summary 和所有声明的 artifacts。
+- [ ] Workflow/job 权限保持最小化，不增加写仓库权限。
+
+### 仓库回归
+
+- [ ] `python scripts/ci.py doctor --strict`
+- [ ] 新增 baseline 单元测试全部通过。
+- [ ] `python scripts/ci.py run default-collection issue-collection legacy-pr python-core`
+- [ ] `pre-commit run --all-files`
+- [ ] GitHub PR 的 `PR Gate` 通过。
+- [ ] 完整 issue workflow 的真实 run URL 已附在 PR。
+
+如果本机 runtime 与 `.python-version` / `.nvmrc` 不符，不得用不匹配环境的结果声称
+本地与 GitHub 一致；应修正工具链或只报告已实际完成的验证。
+
+## 8. 我后续审查时使用的验收清单
+
+以下任一关键项失败，我会要求修改而不会批准：
+
+### P0：正确性与 fail-closed
+
+- [ ] Baseline 不是由部分 shard、手抄统计或自动接受当前结果生成。
+- [ ] 新 failure、error、collection error、报告缺失都会让最终权威 gate 失败。
+- [ ] 已知失败没有被 `skip`/`xfail`、删除断言或吞退出码隐藏。
+- [ ] Known failures 在成功 nightly 中仍可见、可下载、可定位到 nodeid/issue。
+- [ ] Resolved entries 会推动 baseline 收缩，不会永久豁免。
+- [ ] Comparator 对 shard 重排无感，不会与 #2458 冲突。
+
+### P1：可维护性与审查性
+
+- [ ] Schema 有版本、稳定排序、明确 provenance 和更新 runbook。
+- [ ] 分类规则简单、确定、测试充分；没有依赖脆弱的完整错误字符串。
+- [ ] CLI 默认只读，snapshot 是显式操作，baseline diff 适合人工 review。
+- [ ] Workflow 中只有一个权威 legacy conclusion，summary 不会把 advisory 状态冒充 gate。
+- [ ] 实现复用仓库 runner/lock，不建立第二套本地与 GitHub 行为。
+
+### P1：证据
+
+- [ ] Unit tests 覆盖 known/new/resolved/changed/invalid 全状态矩阵。
+- [ ] PR CI 全绿。
+- [ ] PR head 的真实 full issue run 证明 known-only 可通过 comparator。
+- [ ] 故障注入证据证明新增失败和缺失 artifact 都会阻断。
+- [ ] PR 量化 baseline 初始 entries、按 outcome/category/issue 的分布，并说明异常大户。
+
+### P2：范围与长期治理
+
+- [ ] PR 没有夹带 #2458/#2459 或大批 legacy test 行为修复。
+- [ ] 没有降低 `.test-baseline.json`，除非逐项解释了真实迁移/删除。
+- [ ] 文档明确下一批清债如何删除 baseline entry、迁移有价值测试并更新 #2429。
+
+## 9. 完成时的交接格式
+
+实施 Agent 在请求审查时，请在 #2457 和 PR 中同时提供：
+
+```text
+Implementation PR: <url>
+Reference run / commit: <url> / <sha>
+Full verification run: <url>
+
+Baseline:
+- total known entries:
+- failures / errors:
+- collection errors: 0
+- top issue directories:
+- top error categories:
+
+Fail-closed evidence:
+- new failure case:
+- resolved entry case:
+- missing/corrupt artifact case:
+
+Validation:
+- local commands and results:
+- PR Gate:
+- remaining limitations / follow-ups:
+```
+
+我会以本文第 8 节为审查标准；“脚本能运行”或“nightly 变绿”本身不构成验收。

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,6 +6,7 @@ python_functions = test_*
 addopts = -v --tb=short --import-mode=importlib
 filterwarnings =
     ignore::DeprecationWarning
+    ignore:record_property is incompatible with junit_family:pytest.PytestWarning
 
 # Test markers for different test types
 markers =

--- a/scripts/ci/legacy_quarantine_probe.py
+++ b/scripts/ci/legacy_quarantine_probe.py
@@ -1,21 +1,30 @@
 #!/usr/bin/env python3
 """Weekly probe of ci/legacy-issue-quarantine.json nodeids.
 
-Each entry declares an ``expected_probe_outcome`` (``timeout`` / ``pass`` /
-``fail``). The probe runs the nodeid in a subprocess under a hard timeout
-(pytest-timeout cannot kill a thread deadlock, so ``subprocess.run(timeout=)``
-is the kill mechanism) and compares the observed outcome to the declared one.
+Each entry declares an ``expected_probe_outcome`` of ``timeout`` (the only
+permitted value — see ``legacy_issue_baseline.PROBE_OUTCOMES``). The probe runs
+the nodeid in a subprocess under a hard timeout (pytest-timeout cannot kill a
+thread deadlock, so ``subprocess.run(timeout=)`` is the kill mechanism) and
+compares the observed outcome to the declared one.
 
 - match (e.g. still times out) → known quarantine debt, green.
-- mismatch (recovered, or behavior/infra changed) → the entry must be removed/
-  updated; the probe fails so quarantine cannot drift silently.
+- mismatch (recovered → ``pass``, or behavior/infra change → ``fail``) → the
+  entry must be removed/updated; the probe fails so quarantine cannot drift
+  silently. pytest rc 2-5 (collection/usage/internal) are never matchable and
+  always read as a probe failure.
 
 Fails closed on any quarantine config error (missing/corrupt/expired/invalid).
 Writes per-nodeid logs + a structured ``test-results/quarantine-probe-results.json``.
+
+CLI flags (``--quarantine`` / ``--hard-timeout`` / ``--pytest-timeout``
+/ ``--out-dir``) exist so contract tests can drive the real entry point from the
+repo root with a synthetic quarantine and a short timeout instead of waiting on
+the 604 deadlock.
 """
 
 from __future__ import annotations
 
+import argparse
 import datetime
 import importlib.util
 import json
@@ -24,10 +33,25 @@ import sys
 import time
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parents[1]
+# The hard subprocess timeout (subprocess.run timeout=) is the kill mechanism
+# that actually terminates a thread deadlock. pytest-timeout's soft ``--timeout``
+# is an optional courtesy (its thread method cannot interrupt a deadlock either);
+# the probe must not hard-fail if the plugin is absent.
+try:
+    import pytest_timeout  # noqa: F401
+
+    _HAS_PYTEST_TIMEOUT = True
+except ImportError:  # pragma: no cover - exercised in CI which has the plugin
+    _HAS_PYTEST_TIMEOUT = False
+
+# This script lives at scripts/ci/legacy_quarantine_probe.py — repo root is two
+# parents up. parents[1] would resolve to scripts/ and the import/quarantine
+# paths below would become scripts/scripts/... and scripts/ci/... (FileNotFoundError
+# at import time), so the probe would never reach config validation.
+ROOT = Path(__file__).resolve().parents[2]
 QUARANTINE = ROOT / "ci" / "legacy-issue-quarantine.json"
-OUTDIR = ROOT / "test-results"
 HARD_TIMEOUT = 180  # seconds — kills a thread deadlock pytest-timeout cannot
+PYTEST_TIMEOUT = 60  # seconds — soft per-test timeout pytest-timeout enforces
 
 
 def _load_lib():
@@ -41,16 +65,92 @@ def _load_lib():
     return mod
 
 
-def main() -> int:
+def _classify(timed_out: bool, rc: int) -> str:
+    if timed_out:
+        return "timeout"
+    return "pass" if rc == 0 else "fail"
+
+
+def _probe_entry(entry, *, hard_timeout: int, pytest_timeout: int, cwd: Path, outdir: Path):
+    """Run one quarantined nodeid in a subprocess and return its result record.
+
+    pytest-timeout cannot terminate a thread deadlock, so ``subprocess.run`` is
+    given ``hard_timeout`` as the kill mechanism. The returned dict is what gets
+    serialized into ``quarantine-probe-results.json``.
+    """
+    cmd = [
+        sys.executable,
+        "-m",
+        "pytest",
+        entry.nodeid,
+        "-m",
+        "not postgres",
+        "-p",
+        "no:cacheprovider",
+        "-q",
+        "--no-header",
+    ]
+    if _HAS_PYTEST_TIMEOUT:
+        # Soft per-test timeout; only added when pytest-timeout is installed.
+        # It cannot interrupt a thread deadlock — the subprocess hard timeout
+        # below is the real kill mechanism — but it gives cleaner diagnostics.
+        cmd += ["--timeout", str(pytest_timeout)]
+    start = time.monotonic()
+    timed_out = False
+    try:
+        proc = subprocess.run(cmd, cwd=cwd, capture_output=True, text=True, timeout=hard_timeout)
+        rc, stdout, stderr = proc.returncode, proc.stdout, proc.stderr
+    except subprocess.TimeoutExpired as exc:
+        rc, timed_out = 124, True
+        stdout = exc.stdout or ""
+        stderr = exc.stderr or ""
+        if isinstance(stdout, bytes):
+            stdout, stderr = stdout.decode(errors="replace"), stderr.decode(errors="replace")
+    duration = round(time.monotonic() - start, 1)
+
+    outcome = _classify(timed_out, rc)
+    matches = outcome == entry.expected_probe_outcome
+    slug = "".join(c if c.isalnum() else "_" for c in entry.nodeid)[:80]
+    (outdir / f"probe-{slug}.log").write_text(
+        f"$ {' '.join(cmd)}\nexit={rc} timed_out={timed_out} duration={duration}s "
+        f"expected={entry.expected_probe_outcome} outcome={outcome}\n\n"
+        f"--- stdout ---\n{stdout}\n--- stderr ---\n{stderr}\n"
+    )
+    return {
+        "nodeid": entry.nodeid,
+        "expected": entry.expected_probe_outcome,
+        "outcome": outcome,
+        "returncode": rc,
+        "timed_out": timed_out,
+        "duration_s": duration,
+        "matches": matches,
+        "owner": entry.owner,
+        "tracking_issue": entry.tracking_issue,
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--quarantine", default=str(QUARANTINE))
+    parser.add_argument("--hard-timeout", type=int, default=HARD_TIMEOUT)
+    parser.add_argument("--pytest-timeout", type=int, default=PYTEST_TIMEOUT)
+    parser.add_argument("--out-dir", default=str(ROOT / "test-results"))
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    quarantine = Path(args.quarantine)
+    outdir = Path(args.out_dir)
     lib = _load_lib()
-    if not QUARANTINE.exists():
+    if not quarantine.exists():
         print(
-            f"FATAL: {QUARANTINE} missing — cannot probe without the tracked exclusions.",
+            f"FATAL: {quarantine} missing — cannot probe without the tracked exclusions.",
             file=sys.stderr,
         )
         return 1
     try:
-        entries = lib.load_quarantine(QUARANTINE)
+        entries = lib.load_quarantine(quarantine)
     except Exception as exc:
         print(f"FATAL: cannot load quarantine: {exc}", file=sys.stderr)
         return 1
@@ -59,74 +159,27 @@ def main() -> int:
         print("FATAL: invalid quarantine:\n  " + "\n  ".join(invalid), file=sys.stderr)
         return 1
 
-    OUTDIR.mkdir(parents=True, exist_ok=True)
+    outdir.mkdir(parents=True, exist_ok=True)
     results = []
     changed = False
     for e in entries:
-        cmd = [
-            sys.executable,
-            "-m",
-            "pytest",
-            e.nodeid,
-            "-m",
-            "not postgres",
-            "-p",
-            "no:cacheprovider",
-            "-q",
-            "--no-header",
-            "--timeout",
-            "60",
-        ]
-        start = time.monotonic()
-        timed_out = False
-        try:
-            proc = subprocess.run(
-                cmd, cwd=ROOT, capture_output=True, text=True, timeout=HARD_TIMEOUT
-            )
-            rc, stdout, stderr = proc.returncode, proc.stdout, proc.stderr
-        except subprocess.TimeoutExpired as exc:
-            rc, timed_out = 124, True
-            stdout = exc.stdout or ""
-            stderr = exc.stderr or ""
-            if isinstance(stdout, bytes):
-                stdout, stderr = stdout.decode(errors="replace"), stderr.decode(errors="replace")
-        duration = round(time.monotonic() - start, 1)
-
-        if timed_out:
-            outcome = "timeout"
-        elif rc == 0:
-            outcome = "pass"
-        else:
-            outcome = "fail"
-        matches = outcome == e.expected_probe_outcome
-        if not matches:
+        result = _probe_entry(
+            e,
+            hard_timeout=args.hard_timeout,
+            pytest_timeout=args.pytest_timeout,
+            cwd=ROOT,
+            outdir=outdir,
+        )
+        results.append(result)
+        if not result["matches"]:
             changed = True
-
-        slug = "".join(c if c.isalnum() else "_" for c in e.nodeid)[:80]
-        (OUTDIR / f"probe-{slug}.log").write_text(
-            f"$ {' '.join(cmd)}\nexit={rc} timed_out={timed_out} duration={duration}s "
-            f"expected={e.expected_probe_outcome} outcome={outcome}\n\n"
-            f"--- stdout ---\n{stdout}\n--- stderr ---\n{stderr}\n"
-        )
-        results.append(
-            {
-                "nodeid": e.nodeid,
-                "expected": e.expected_probe_outcome,
-                "outcome": outcome,
-                "returncode": rc,
-                "timed_out": timed_out,
-                "duration_s": duration,
-                "matches": matches,
-                "owner": e.owner,
-                "tracking_issue": e.tracking_issue,
-            }
-        )
-        tag = "OK (expected)" if matches else "CHANGED"
+        tag = "OK (expected)" if result["matches"] else "CHANGED"
         print(
-            f"[{tag}] {e.nodeid}: expected={e.expected_probe_outcome} outcome={outcome} rc={rc} {duration}s"
+            f"[{tag}] {e.nodeid}: expected={result['expected']} outcome={result['outcome']} "
+            f"rc={result['returncode']} {result['duration_s']}s"
         )
 
-    (OUTDIR / "quarantine-probe-results.json").write_text(json.dumps(results, indent=2) + "\n")
+    (outdir / "quarantine-probe-results.json").write_text(json.dumps(results, indent=2) + "\n")
     return 1 if changed else 0
 
 

--- a/scripts/ci/legacy_quarantine_probe.py
+++ b/scripts/ci/legacy_quarantine_probe.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Weekly probe of ci/legacy-issue-quarantine.json nodeids.
+
+Each entry declares an ``expected_probe_outcome`` (``timeout`` / ``pass`` /
+``fail``). The probe runs the nodeid in a subprocess under a hard timeout
+(pytest-timeout cannot kill a thread deadlock, so ``subprocess.run(timeout=)``
+is the kill mechanism) and compares the observed outcome to the declared one.
+
+- match (e.g. still times out) → known quarantine debt, green.
+- mismatch (recovered, or behavior/infra changed) → the entry must be removed/
+  updated; the probe fails so quarantine cannot drift silently.
+
+Fails closed on any quarantine config error (missing/corrupt/expired/invalid).
+Writes per-nodeid logs + a structured ``test-results/quarantine-probe-results.json``.
+"""
+
+from __future__ import annotations
+
+import datetime
+import importlib.util
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+QUARANTINE = ROOT / "ci" / "legacy-issue-quarantine.json"
+OUTDIR = ROOT / "test-results"
+HARD_TIMEOUT = 180  # seconds — kills a thread deadlock pytest-timeout cannot
+
+
+def _load_lib():
+    spec = importlib.util.spec_from_file_location(
+        "_lib_baseline", str(ROOT / "scripts" / "legacy_issue_baseline.py")
+    )
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["_lib_baseline"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def main() -> int:
+    lib = _load_lib()
+    if not QUARANTINE.exists():
+        print(
+            f"FATAL: {QUARANTINE} missing — cannot probe without the tracked exclusions.",
+            file=sys.stderr,
+        )
+        return 1
+    try:
+        entries = lib.load_quarantine(QUARANTINE)
+    except Exception as exc:
+        print(f"FATAL: cannot load quarantine: {exc}", file=sys.stderr)
+        return 1
+    invalid = lib.validate_quarantine(entries, (), datetime.date.today().isoformat())
+    if invalid:
+        print("FATAL: invalid quarantine:\n  " + "\n  ".join(invalid), file=sys.stderr)
+        return 1
+
+    OUTDIR.mkdir(parents=True, exist_ok=True)
+    results = []
+    changed = False
+    for e in entries:
+        cmd = [
+            sys.executable,
+            "-m",
+            "pytest",
+            e.nodeid,
+            "-m",
+            "not postgres",
+            "-p",
+            "no:cacheprovider",
+            "-q",
+            "--no-header",
+            "--timeout",
+            "60",
+        ]
+        start = time.monotonic()
+        timed_out = False
+        try:
+            proc = subprocess.run(
+                cmd, cwd=ROOT, capture_output=True, text=True, timeout=HARD_TIMEOUT
+            )
+            rc, stdout, stderr = proc.returncode, proc.stdout, proc.stderr
+        except subprocess.TimeoutExpired as exc:
+            rc, timed_out = 124, True
+            stdout = exc.stdout or ""
+            stderr = exc.stderr or ""
+            if isinstance(stdout, bytes):
+                stdout, stderr = stdout.decode(errors="replace"), stderr.decode(errors="replace")
+        duration = round(time.monotonic() - start, 1)
+
+        if timed_out:
+            outcome = "timeout"
+        elif rc == 0:
+            outcome = "pass"
+        else:
+            outcome = "fail"
+        matches = outcome == e.expected_probe_outcome
+        if not matches:
+            changed = True
+
+        slug = "".join(c if c.isalnum() else "_" for c in e.nodeid)[:80]
+        (OUTDIR / f"probe-{slug}.log").write_text(
+            f"$ {' '.join(cmd)}\nexit={rc} timed_out={timed_out} duration={duration}s "
+            f"expected={e.expected_probe_outcome} outcome={outcome}\n\n"
+            f"--- stdout ---\n{stdout}\n--- stderr ---\n{stderr}\n"
+        )
+        results.append(
+            {
+                "nodeid": e.nodeid,
+                "expected": e.expected_probe_outcome,
+                "outcome": outcome,
+                "returncode": rc,
+                "timed_out": timed_out,
+                "duration_s": duration,
+                "matches": matches,
+                "owner": e.owner,
+                "tracking_issue": e.tracking_issue,
+            }
+        )
+        tag = "OK (expected)" if matches else "CHANGED"
+        print(
+            f"[{tag}] {e.nodeid}: expected={e.expected_probe_outcome} outcome={outcome} rc={rc} {duration}s"
+        )
+
+    (OUTDIR / "quarantine-probe-results.json").write_text(json.dumps(results, indent=2) + "\n")
+    return 1 if changed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/legacy_issue_baseline.py
+++ b/scripts/legacy_issue_baseline.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import argparse
 import dataclasses
+import datetime
 import glob
 import json
 import os
@@ -415,6 +416,105 @@ def build_expected_manifest(
 
 
 # ---------------------------------------------------------------------------
+# Quarantine — tracked, gate-visible exclusions for nodeids that cannot run
+# ---------------------------------------------------------------------------
+
+QUARANTINE_FILE = PROJECT_ROOT / "ci" / "legacy-issue-quarantine.json"
+_QUARANTINE_REQUIRED = (
+    "nodeid",
+    "reason",
+    "owner",
+    "tracking_issue",
+    "exit_condition",
+    "expires_on",
+)
+_QUARANTINE_DATE_RX = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+@dataclasses.dataclass(frozen=True)
+class QuarantineEntry:
+    nodeid: str
+    reason: str
+    owner: str
+    tracking_issue: str
+    exit_condition: str
+    expires_on: str
+
+
+def load_quarantine(path: str | Path) -> list[QuarantineEntry]:
+    text = Path(path).read_text()
+    obj = json.loads(text)
+    if obj.get("schema") != "openace-legacy-issue-quarantine":
+        raise BaselineError(f"unsupported quarantine schema: {obj.get('schema')!r}")
+    entries: list[QuarantineEntry] = []
+    for raw in obj.get("entries", []):
+        entries.append(QuarantineEntry(**{k: raw.get(k, "") for k in _QUARANTINE_REQUIRED}))
+    return entries
+
+
+def validate_quarantine(
+    entries: list[QuarantineEntry],
+    collectable_nodeids: Iterable[str],
+    today: str,
+) -> list[str]:
+    """Fail-closed validation of the quarantine list.
+
+    Returns invalid reasons for: missing/empty required fields, malformed
+    ``expires_on``, an expired entry, a duplicate nodeid, or an entry whose
+    nodeid is no longer collectable (stale after deletion/rename). Empty list
+    means valid.
+    """
+    collectable = set(collectable_nodeids)
+    seen: set[str] = set()
+    invalid: list[str] = []
+    for e in entries:
+        for field in _QUARANTINE_REQUIRED:
+            if not getattr(e, field).strip():
+                invalid.append(f"quarantine entry {e.nodeid!r} missing field '{field}'")
+        if not _QUARANTINE_DATE_RX.match(e.expires_on):
+            invalid.append(f"quarantine entry {e.nodeid!r} malformed expires_on {e.expires_on!r}")
+        elif e.expires_on < today:
+            invalid.append(f"quarantine entry {e.nodeid!r} expired on {e.expires_on}")
+        if e.nodeid in seen:
+            invalid.append(f"quarantine entry {e.nodeid!r} duplicated")
+        seen.add(e.nodeid)
+        if collectable and e.nodeid not in collectable:
+            invalid.append(
+                f"quarantine entry {e.nodeid!r} is no longer collectable "
+                "(remove it or update its nodeid)"
+            )
+    return invalid
+
+
+def _load_and_validate_quarantine(
+    path: str | Path, collectable_nodeids: Iterable[str]
+) -> dict[str, Any]:
+    """Load the quarantine list and validate it; return entries-as-dicts + invalids.
+
+    A missing file means no quarantine (empty). Validation failures (expired,
+    uncollectable, duplicate, missing fields) are returned as invalid reasons
+    so the caller can fail closed.
+    """
+    if not Path(path).exists():
+        return {"entries": [], "invalid": []}
+    entries = load_quarantine(path)
+    today = datetime.date.today().isoformat()
+    invalid = validate_quarantine(entries, collectable_nodeids, today)
+    as_dicts = [
+        {
+            "nodeid": e.nodeid,
+            "reason": e.reason,
+            "owner": e.owner,
+            "tracking_issue": e.tracking_issue,
+            "exit_condition": e.exit_condition,
+            "expires_on": e.expires_on,
+        }
+        for e in entries
+    ]
+    return {"entries": as_dicts, "invalid": invalid}
+
+
+# ---------------------------------------------------------------------------
 # Merge, completeness, bidirectional diff
 # ---------------------------------------------------------------------------
 
@@ -428,6 +528,7 @@ class CompareResult:
     changed: list[dict[str, Any]]
     invalid: list[str]
     collection_errors: list[dict[str, Any]]
+    quarantined: list[dict[str, Any]]
     observed_files: int
     expected_total: int
     targeted: bool
@@ -477,8 +578,10 @@ def compare(
     targeted: bool = False,
     exit_codes: dict[str, int] | None = None,
     expected_shard_count: int = 0,
+    quarantined: list[dict[str, Any]] | None = None,
 ) -> CompareResult:
     """Compute the bidirectional diff and fail-closed completeness verdict."""
+    quarantined = quarantined or []
     current_nodeids = {tc.nodeid for tc in parsed_testcases}
     if observed_files is None:
         observed_files = {_file_of(n) for n in current_nodeids}
@@ -496,6 +599,7 @@ def compare(
             [],
             [str(exc)],
             [],
+            quarantined,
             len(observed_files),
             len(list(expected_nodeids)),
             targeted,
@@ -560,6 +664,7 @@ def compare(
         changed=changed,
         invalid=invalid,
         collection_errors=collection_errors,
+        quarantined=quarantined,
         observed_files=len(observed_files),
         expected_total=len(expected_set),
         targeted=targeted,
@@ -607,6 +712,16 @@ def render_markdown(result: CompareResult) -> str:
             "### Known debt — top categories",
             "",
             *(f"- `{c}`: {n}" for c, n in known_by_cat.most_common(10)),
+            "",
+        ]
+    if result.quarantined:
+        lines += [
+            f"### Quarantined debt ({len(result.quarantined)} — excluded from execution, tracked)",
+            "",
+            *(
+                f"- `{e['nodeid']}` — owner `{e['owner']}`, expires `{e['expires_on']}` — {e['reason']} (exit: {e['exit_condition']}; {e['tracking_issue']})"
+                for e in result.quarantined
+            ),
             "",
         ]
     for label, items, fmt in (
@@ -785,6 +900,12 @@ def _cmd_compare(args: argparse.Namespace) -> int:
     else:
         em = build_expected_manifest(targeted=bool(args.targeted_issues))
         expected, targeted = em.nodeids, em.targeted
+    # Quarantine: tracked exclusions (must be collectable + non-expired). The
+    # quarantined nodeids are removed from the expected-executed set (so the
+    # shard's deselect + the manifest stay consistent) and reported as debt.
+    quarantine = _load_and_validate_quarantine(args.quarantine, expected)
+    quarantined_ids = {e["nodeid"] for e in quarantine["entries"]}
+    expected = [n for n in expected if n not in quarantined_ids]
     min_files, thr = _load_test_baseline(Path(args.test_baseline))
     observed = {_file_of(tc.nodeid) for tc in parsed}
     exit_codes = _load_exit_codes(args.exit_code_glob) if args.exit_code_glob else None
@@ -798,7 +919,12 @@ def _cmd_compare(args: argparse.Namespace) -> int:
         targeted=targeted,
         exit_codes=exit_codes,
         expected_shard_count=args.shard_count,
+        quarantined=quarantine["entries"],
     )
+    # quarantine validation problems fail closed
+    result.invalid.extend(quarantine["invalid"])
+    if quarantine["invalid"]:
+        result.exit_code = 1
     if args.json_output:
         _ensure_parent(args.json_output)
         Path(args.json_output).write_text(
@@ -852,6 +978,11 @@ def _cmd_snapshot(args: argparse.Namespace) -> int:
         expected = json.loads(Path(args.manifest).read_text()).get("nodeids", [])
     else:
         expected = build_expected_manifest().nodeids
+    # Quarantine entries are excluded from the expected-executed set (same as
+    # compare) and validated; an invalid/expired/stale quarantine fails closed.
+    quarantine = _load_and_validate_quarantine(args.quarantine, expected)
+    quarantined_ids = {e["nodeid"] for e in quarantine["entries"]}
+    expected = [n for n in expected if n not in quarantined_ids]
     min_files, thr = (
         _load_test_baseline(Path(args.test_baseline)) if args.test_baseline else (0, 0.0)
     )
@@ -864,10 +995,12 @@ def _cmd_snapshot(args: argparse.Namespace) -> int:
         exit_codes=exit_codes,
         expected_shard_count=args.shard_count,
     )
+    incomplete.extend(quarantine["invalid"])
     if incomplete:
         print(
-            "snapshot refused: reference run is not complete (baseline may only "
-            "come from a complete run). Reasons:\n  - " + "\n  - ".join(incomplete[:30]),
+            "snapshot refused: reference run is not complete / quarantine invalid "
+            "(baseline may only come from a complete run). Reasons:\n  - "
+            + "\n  - ".join(incomplete[:30]),
             file=sys.stderr,
         )
         return 2
@@ -906,6 +1039,7 @@ def build_parser() -> argparse.ArgumentParser:
     cmp.add_argument("--manifest", default="")
     cmp.add_argument("--test-baseline", default=str(TEST_BASELINE_FILE))
     cmp.add_argument("--exit-code-glob", default="")
+    cmp.add_argument("--quarantine", default=str(QUARANTINE_FILE))
     cmp.add_argument("--shard-count", type=int, default=4)
     cmp.add_argument("--json-output", default="")
     cmp.add_argument("--markdown-output", default="")
@@ -918,6 +1052,7 @@ def build_parser() -> argparse.ArgumentParser:
     snap.add_argument("--manifest", default="")
     snap.add_argument("--test-baseline", default=str(TEST_BASELINE_FILE))
     snap.add_argument("--exit-code-glob", default="")
+    snap.add_argument("--quarantine", default=str(QUARANTINE_FILE))
     snap.add_argument("--shard-count", type=int, default=4)
     snap.add_argument("--source-run", default="")
     snap.add_argument("--source-run-url", default="")

--- a/scripts/legacy_issue_baseline.py
+++ b/scripts/legacy_issue_baseline.py
@@ -1,0 +1,748 @@
+#!/usr/bin/env python3
+"""Legacy issue quarantine failure-baseline comparator.
+
+A pure-stdlib library (identical local + CI) that:
+
+* parses one or more pytest xUnit2 JUnit reports emitted by the legacy
+  ``tests/issues`` shards;
+* normalizes test identity to a stable ``(nodeid, outcome, category)`` key;
+* merges any number of shard reports and validates completeness against an
+  expected nodeid manifest (and the ``.test-baseline.json`` file floor);
+* produces a bidirectional diff (known/new/resolved/changed/invalid) and a
+  machine-readable + Markdown summary.
+
+``compare`` is read-only and is the authoritative gate. ``snapshot`` writes a
+reviewable candidate baseline to an explicit path. ``manifest`` emits the
+expected nodeid set. See ``docs/TEST_LAYERS.md`` and
+``docs/issue-2457-agent-handoff.md`` for the contract.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import fnmatch
+import glob
+import json
+import os
+import re
+import subprocess
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from typing import Any, Iterable
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_BASELINE = PROJECT_ROOT / "ci" / "legacy-issue-failures.json"
+TEST_BASELINE_FILE = PROJECT_ROOT / ".test-baseline.json"
+
+SCHEMA_VERSION = 1
+SCHEMA_NAME = "openace-legacy-issue-failures"
+DEFAULT_SELECTION = "not postgres"
+
+OUTCOMES = ("pass", "failure", "error", "skip")
+# Coarse, stable categories. ``setup_error`` deliberately folds setup/fixture/
+# teardown together so a phase flip cannot create a spurious ``changed``.
+CATEGORIES = (
+    "collection_error",
+    "setup_error",
+    "timeout",
+    "assertion_failure",
+    "test_body_exception",
+    "infrastructure_error",
+)
+
+
+class BaselineError(RuntimeError):
+    """A deterministic baseline configuration or comparison failure."""
+
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+
+def normalize_nodeid(nodeid: str, runner_root: str | None = None) -> str:
+    """Return a repo-relative nodeid anchored to ``tests/issues/...``.
+
+    Strips absolute runner roots, temp HOME prefixes, ports and whitespace.
+    Parametrized ``[...]`` suffixes are identity-bearing and preserved.
+    """
+    n = (nodeid or "").strip()
+    if runner_root and n.startswith(runner_root):
+        n = n[len(runner_root) :].lstrip("/")
+    m = re.search(r"(tests/issues/.*)$", n, re.S)
+    if m:
+        n = m.group(1)
+    return n.strip()
+
+
+@dataclasses.dataclass(frozen=True)
+class ParsedTestcase:
+    """A single testcase as parsed from JUnit, regardless of outcome."""
+
+    nodeid: str
+    outcome: str  # one of OUTCOMES
+    category: str
+    exception_type: str
+    summary: str
+
+    def as_failure(self) -> FailureRecord | None:
+        if self.outcome in ("failure", "error"):
+            return FailureRecord(
+                nodeid=self.nodeid,
+                issue_number=_issue_number_for(self.nodeid),
+                outcome=self.outcome,
+                category=self.category,
+                exception_type=self.exception_type,
+                summary=self.summary,
+            )
+        return None
+
+
+@dataclasses.dataclass(frozen=True)
+class FailureRecord:
+    nodeid: str
+    issue_number: str
+    outcome: str  # "failure" | "error"
+    category: str
+    exception_type: str
+    summary: str
+
+    @property
+    def key(self) -> tuple[str, str, str]:
+        return (self.nodeid, self.outcome, self.category)
+
+    def to_dict(self) -> dict[str, Any]:
+        return dataclasses.asdict(self)
+
+
+_ISSUE_RE = re.compile(r"tests/issues/(\d+)/")
+
+
+def _issue_number_for(nodeid: str) -> str:
+    m = _ISSUE_RE.search(nodeid)
+    return m.group(1) if m else "0"
+
+
+@dataclasses.dataclass
+class Baseline:
+    entries: list[FailureRecord]
+    provenance: dict[str, Any] | None = None
+    selection: str = DEFAULT_SELECTION
+    version: int = SCHEMA_VERSION
+    schema: str = SCHEMA_NAME
+
+    def to_json(self) -> str:
+        entries = sorted(
+            (e.to_dict() for e in self.entries),
+            key=lambda d: (d["nodeid"], d["outcome"], d["category"]),
+        )
+        obj: dict[str, Any] = {
+            "version": self.version,
+            "schema": self.schema,
+            "provenance": dict(sorted((self.provenance or {}).items())),
+            "selection": self.selection,
+            "entries": entries,
+        }
+        return json.dumps(obj, indent=2, sort_keys=True, ensure_ascii=False) + "\n"
+
+    @classmethod
+    def from_json(cls, text: str) -> Baseline:
+        obj = json.loads(text)
+        if obj.get("version") != SCHEMA_VERSION or obj.get("schema") != SCHEMA_NAME:
+            raise BaselineError(
+                f"Unsupported baseline schema: version={obj.get('version')!r} "
+                f"schema={obj.get('schema')!r}"
+            )
+        keep = ("nodeid", "issue_number", "outcome", "category", "exception_type", "summary")
+        entries = [FailureRecord(**{k: e[k] for k in keep}) for e in obj.get("entries", [])]
+        return cls(
+            entries=entries,
+            provenance=obj.get("provenance") or {},
+            selection=obj.get("selection", DEFAULT_SELECTION),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Classification
+# ---------------------------------------------------------------------------
+
+
+def _is_timeout(exception_type: str, message: str) -> bool:
+    blob = f"{exception_type} {message}".lower()
+    if "timeout" in exception_type.lower():
+        return True
+    return "timed out" in blob or "timeout" in blob
+
+
+def classify(
+    element: str, has_nodeid_property: bool, exception_type: str, message: str, nodeid: str
+) -> str:
+    """Map a JUnit ``<failure>``/``<error>`` to a stable category.
+
+    ``element`` is ``"failure"`` or ``"error"``. Collection errors are detected
+    by the absence of the ``openace_nodeid`` property (a collection failure
+    never creates a test item, so the autouse conftest fixture never ran).
+    """
+    if element == "failure":
+        return "assertion_failure" if exception_type == "AssertionError" else "test_body_exception"
+    # element == "error"
+    if not has_nodeid_property or "::" not in nodeid:
+        return "collection_error"
+    if _is_timeout(exception_type, message):
+        return "timeout"
+    return "setup_error"
+
+
+# ---------------------------------------------------------------------------
+# JUnit parsing
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass
+class SuiteTotals:
+    tests: int = 0
+    failures: int = 0
+    errors: int = 0
+    skipped: int = 0
+
+
+def _file_of(nodeid: str) -> str:
+    return nodeid.split("::", 1)[0]
+
+
+def reconstruct_nodeid(classname: str, name: str) -> str:
+    """Best-effort nodeid reconstruction from xunit2 classname+name.
+
+    xunit2 carries no ``file`` attribute. classname under importlib mode is a
+    dotted ``dir.dir.file.Class`` path; the class boundary is the first segment
+    matching ``Test*`` (``python_classes=Test*``). Collection errors have an
+    empty classname and a dotted module path in ``name``.
+    """
+    classname = (classname or "").strip()
+    if not classname:
+        return (name or "").strip().replace(".", "/") + ".py"
+    parts = classname.split(".")
+    cls_idx = next((i for i, p in enumerate(parts) if p.startswith("Test")), None)
+    if cls_idx is not None:
+        module_parts, class_parts = parts[:cls_idx], parts[cls_idx:]
+    else:
+        module_parts, class_parts = parts, []
+    module_path = "/".join(module_parts) + ".py"
+    if class_parts:
+        return f"{module_path}::{'::'.join(class_parts)}::{name}"
+    return f"{module_path}::{name}"
+
+
+def _short_summary(text: str, limit: int = 200) -> str:
+    text = (text or "").strip()
+    text = text.splitlines()[0] if text else ""
+    if len(text) > limit:
+        text = text[: limit - 1] + "…"
+    return text
+
+
+def _parse_testcase(tc: ET.Element) -> ParsedTestcase | None:
+    classname = tc.get("classname", "")
+    name = tc.get("name", "")
+    prop = tc.find("properties/property[@name='openace_nodeid']")
+    has_property = prop is not None and bool(prop.get("value"))
+    raw_nodeid = prop.get("value") if has_property else reconstruct_nodeid(classname, name)
+    nodeid = normalize_nodeid(raw_nodeid)
+    if not nodeid:
+        return None
+
+    failure = tc.find("failure")
+    error = tc.find("error")
+    skipped = tc.find("skipped")
+    if failure is not None:
+        element = "failure"
+        outcome = "failure"
+        node = failure
+    elif error is not None:
+        element = "error"
+        outcome = "error"
+        node = error
+    elif skipped is not None:
+        return ParsedTestcase(
+            nodeid, "skip", "skip", "", _short_summary(skipped.get("message", ""))
+        )
+    else:
+        return ParsedTestcase(nodeid, "pass", "pass", "", "")
+
+    exception_type = (node.get("type") or "").strip()
+    message = _short_summary(node.get("message") or (node.text or ""))
+    category = classify(element, has_property, exception_type, message, nodeid)
+    return ParsedTestcase(nodeid, outcome, category, exception_type, message)
+
+
+def parse_junit(path: str | Path) -> tuple[list[ParsedTestcase], SuiteTotals]:
+    """Parse one JUnit XML file into testcase records + aggregate totals."""
+    try:
+        tree = ET.parse(str(path))
+    except (ET.ParseError, OSError) as exc:
+        raise BaselineError(f"corrupt or unreadable JUnit XML: {path}: {exc}")
+    root = tree.getroot()
+    if root.tag == "testsuites":
+        suites = root.findall("testsuite")
+    elif root.tag == "testsuite":
+        suites = [root]
+    else:
+        raise BaselineError(f"unknown JUnit root element <{root.tag}> in {path}")
+    if not suites:
+        raise BaselineError(f"no <testsuite> in JUnit XML: {path}")
+
+    totals = SuiteTotals()
+    by_nodeid: dict[str, ParsedTestcase] = {}
+    for suite in suites:
+        a = suite.attrib
+        totals.tests += int(a.get("tests", 0) or 0)
+        totals.failures += int(a.get("failures", 0) or 0)
+        totals.errors += int(a.get("errors", 0) or 0)
+        totals.skipped += int(a.get("skipped", 0) or 0)
+        for tc in suite.findall("testcase"):
+            parsed = _parse_testcase(tc)
+            if parsed is not None:
+                by_nodeid[parsed.nodeid] = parsed  # last document order wins (rerun-safe)
+    if totals.tests == 0 and not by_nodeid:
+        raise BaselineError(f"zero tests in JUnit XML: {path}")
+    return list(by_nodeid.values()), totals
+
+
+# ---------------------------------------------------------------------------
+# Expected-nodeid manifest
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass
+class ExpectedManifest:
+    nodeids: list[str]
+    files: list[str]
+    selection: str
+    targeted: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        return dataclasses.asdict(self)
+
+
+def build_expected_manifest(
+    targets: Iterable[str] = ("tests/issues",),
+    selection: str = DEFAULT_SELECTION,
+    targeted: bool = False,
+) -> ExpectedManifest:
+    """Collect the expected nodeid set with ``-m "<selection>"`` semantics.
+
+    Uses ``--collect-only -qq`` (pytest 9 ``-q`` emits a tree view with no
+    parseable nodeids; ``-qq`` emits flat ``path::nodeid`` lines). Only lines
+    that start with ``tests/`` and contain ``::`` are kept, which drops the
+    warnings-summary source references and the ``N tests collected`` footer.
+    """
+    cmd = [
+        sys.executable,
+        "-m",
+        "pytest",
+        *targets,
+        "--collect-only",
+        "-qq",
+        "-m",
+        selection,
+    ]
+    proc = subprocess.run(
+        cmd,
+        cwd=PROJECT_ROOT,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    nodeids = sorted(
+        {
+            line.strip()
+            for line in proc.stdout.splitlines()
+            if line.startswith("tests/") and "::" in line
+        }
+    )
+    files = sorted({_file_of(n) for n in nodeids})
+    return ExpectedManifest(nodeids=nodeids, files=files, selection=selection, targeted=targeted)
+
+
+# ---------------------------------------------------------------------------
+# Merge, completeness, bidirectional diff
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass
+class CompareResult:
+    exit_code: int
+    known: list[dict[str, Any]]
+    new: list[dict[str, Any]]
+    resolved: list[str]
+    changed: list[dict[str, Any]]
+    invalid: list[str]
+    collection_errors: list[dict[str, Any]]
+    observed_files: int
+    expected_total: int
+    targeted: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        return dataclasses.asdict(self)
+
+
+def _failure_index(records: list[FailureRecord]) -> dict[tuple[str, str, str], FailureRecord]:
+    """Index failures by key; raise on conflicting same-key records."""
+    index: dict[tuple[str, str, str], FailureRecord] = {}
+    for r in records:
+        existing = index.get(r.key)
+        if existing is not None and (
+            existing.exception_type != r.exception_type or existing.summary != r.summary
+        ):
+            raise BaselineError(
+                f"conflicting results for {r.nodeid} "
+                f"({existing.exception_type}/{existing.summary!r} vs "
+                f"{r.exception_type}/{r.summary!r}); refusing last-write-wins"
+            )
+        index[r.key] = r
+    return index
+
+
+def compare(
+    baseline: Baseline,
+    parsed_testcases: list[ParsedTestcase],
+    expected_nodeids: Iterable[str],
+    *,
+    baseline_min_files: int = 0,
+    require_review_threshold_pct: float = 0.0,
+    observed_files: set[str] | None = None,
+    targeted: bool = False,
+) -> CompareResult:
+    """Compute the bidirectional diff and fail-closed completeness verdict."""
+    current_nodeids = {tc.nodeid for tc in parsed_testcases}
+    if observed_files is None:
+        observed_files = {_file_of(n) for n in current_nodeids}
+
+    current_failures = [tc.as_failure() for tc in parsed_testcases]
+    current_failures = [f for f in current_failures if f is not None]
+    try:
+        current_index = _failure_index(current_failures)
+    except BaselineError as exc:
+        return CompareResult(
+            1,
+            [],
+            [],
+            [],
+            [],
+            [str(exc)],
+            [],
+            len(observed_files),
+            len(list(expected_nodeids)),
+            targeted,
+        )
+    baseline_index = _failure_index(baseline.entries)
+
+    current_keys = set(current_index)
+    baseline_keys = set(baseline_index)
+    current_failure_nodeids = {k[0] for k in current_keys}
+    baseline_failure_nodeids = {k[0] for k in baseline_keys}
+
+    known = sorted(
+        (current_index[k].to_dict() for k in (current_keys & baseline_keys)),
+        key=lambda d: (d["nodeid"], d["outcome"], d["category"]),
+    )
+    new = sorted(
+        (
+            current_index[k].to_dict()
+            for k in (current_keys - baseline_keys)
+            if k[0] not in baseline_failure_nodeids
+        ),
+        key=lambda d: (d["nodeid"], d["outcome"], d["category"]),
+    )
+    changed: list[dict[str, Any]] = []
+    for n in sorted(current_failure_nodeids & baseline_failure_nodeids):
+        cur = next(k for k in current_keys if k[0] == n)
+        base = next(k for k in baseline_keys if k[0] == n)
+        if cur != base:
+            changed.append({"nodeid": n, "baseline": list(base), "current": list(cur)})
+
+    resolved = sorted(baseline_failure_nodeids - current_failure_nodeids)
+    collection_errors = sorted(
+        (f.to_dict() for f in current_failures if f.category == "collection_error"),
+        key=lambda d: (d["nodeid"], d["outcome"], d["category"]),
+    )
+
+    invalid: list[str] = []
+    expected_set = set(expected_nodeids)
+    missing = sorted(expected_set - current_nodeids)
+    for n in missing:
+        invalid.append(f"expected nodeid never observed: {n}")
+    if not parsed_testcases and expected_set:
+        invalid.append("no JUnit reports matched the glob; expected shard artifacts missing")
+    file_floor = baseline_min_files * (1 - require_review_threshold_pct / 100.0)
+    if baseline_min_files and len(observed_files) < file_floor:
+        invalid.append(
+            f"observed {len(observed_files)} files, below floor "
+            f"{file_floor:.0f} ({baseline_min_files} × "
+            f"{100 - require_review_threshold_pct:.0f}%)"
+        )
+    if targeted:
+        invalid.append(
+            "targeted run: compared against selected subset only, not a full nightly gate"
+        )
+
+    exit_code = (
+        0
+        if (not new and not changed and not resolved and not collection_errors and not invalid)
+        else 1
+    )
+
+    return CompareResult(
+        exit_code=exit_code,
+        known=known,
+        new=new,
+        resolved=resolved,
+        changed=changed,
+        invalid=invalid,
+        collection_errors=collection_errors,
+        observed_files=len(observed_files),
+        expected_total=len(expected_set),
+        targeted=targeted,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Reporting helpers
+# ---------------------------------------------------------------------------
+
+
+def _issue_dir(nodeid: str) -> str:
+    m = _ISSUE_RE.search(nodeid)
+    return f"tests/issues/{m.group(1)}" if m else "(unknown)"
+
+
+def _category_of_failure(d: dict[str, Any]) -> str:
+    return d.get("category", "")
+
+
+def render_markdown(result: CompareResult) -> str:
+    from collections import Counter
+
+    known_by_issue = Counter(_issue_dir(d["nodeid"]) for d in result.known)
+    known_by_cat = Counter(_category_of_failure(d) for d in result.known)
+    lines = [
+        "## Legacy issue failure baseline",
+        "",
+        f"- exit code: **{result.exit_code}**",
+        f"- known debt: {len(result.known)}  | new: {len(result.new)} | "
+        f"resolved: {len(result.resolved)} | changed: {len(result.changed)} | "
+        f"collection errors: {len(result.collection_errors)} | invalid: {len(result.invalid)}",
+        f"- observed files: {result.observed_files} / expected nodeids: {result.expected_total}"
+        + ("  *(targeted run — not a full nightly gate)*" if result.targeted else ""),
+        "",
+    ]
+    if result.known:
+        lines += [
+            "### Known debt — top issue directories",
+            "",
+            *(f"- `{d}`: {n}" for d, n in known_by_issue.most_common(10)),
+            "",
+        ]
+        lines += [
+            "### Known debt — top categories",
+            "",
+            *(f"- `{c}`: {n}" for c, n in known_by_cat.most_common(10)),
+            "",
+        ]
+    for label, items, fmt in (
+        (
+            "New failures",
+            result.new,
+            lambda d: f"- `{d['nodeid']}` [{d['category']}] {d['summary']}",
+        ),
+        (
+            "Resolved (remove from baseline)",
+            [{"nodeid": n} for n in result.resolved],
+            lambda d: f"- `{d['nodeid']}`",
+        ),
+        (
+            "Changed",
+            result.changed,
+            lambda d: f"- `{d['nodeid']}`: {d['baseline']} -> {d['current']}",
+        ),
+        (
+            "Collection errors (never baselined)",
+            result.collection_errors,
+            lambda d: f"- `{d['nodeid']}` {d['summary']}",
+        ),
+        ("Invalid / incomplete", [{"m": m} for m in result.invalid], lambda d: f"- {d['m']}"),
+    ):
+        if items:
+            lines += [f"### {label}", "", *(fmt(i) for i in items[:50]), ""]
+    return "\n".join(lines)
+
+
+def _load_junit_glob(pattern: str) -> list[ParsedTestcase]:
+    paths = sorted(glob.glob(pattern, recursive=True))
+    if not paths:
+        raise BaselineError(
+            f"no JUnit reports matched '{pattern}'; expected shard artifacts missing "
+            f"— run `snapshot` with a complete run to generate a candidate baseline"
+        )
+    merged: dict[str, ParsedTestcase] = {}
+    for p in paths:
+        testcases, _totals = parse_junit(p)
+        for tc in testcases:
+            merged[tc.nodeid] = tc  # shards are file-disjoint; last-write is safe
+    return list(merged.values())
+
+
+def _load_test_baseline(path: Path) -> tuple[int, float]:
+    try:
+        data = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        raise BaselineError(f"cannot read test baseline {path}: {exc}")
+    issues = data.get("layers", {}).get("issues", {})
+    return int(issues.get("min_files", 0) or 0), float(
+        data.get("tolerance", {}).get("require_review_threshold", 0) or 0
+    )
+
+
+def _write_summary(text: str) -> None:
+    path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if path:
+        with open(path, "a", encoding="utf-8") as handle:
+            handle.write(text + "\n")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _cmd_compare(args: argparse.Namespace) -> int:
+    baseline = Baseline.from_json(Path(args.baseline).read_text())
+    parsed = _load_junit_glob(args.junit)
+    if args.manifest:
+        manifest = json.loads(Path(args.manifest).read_text())
+        expected = manifest.get("nodeids", [])
+        targeted = bool(manifest.get("targeted"))
+    else:
+        em = build_expected_manifest(targeted=bool(args.targeted_issues))
+        expected, targeted = em.nodeids, em.targeted
+    min_files, thr = _load_test_baseline(Path(args.test_baseline))
+    observed = {_file_of(tc.nodeid) for tc in parsed}
+    result = compare(
+        baseline,
+        parsed,
+        expected,
+        baseline_min_files=min_files,
+        require_review_threshold_pct=thr,
+        observed_files=observed,
+        targeted=targeted,
+    )
+    if args.json_output:
+        Path(args.json_output).write_text(
+            json.dumps(result.to_dict(), indent=2, sort_keys=True) + "\n"
+        )
+    md = render_markdown(result)
+    if args.markdown_output:
+        Path(args.markdown_output).write_text(md + "\n")
+    _write_summary(md)
+    if result.exit_code:
+        head = (
+            "new failures: " + ", ".join(d["nodeid"] for d in result.new[:5])
+            if result.new
+            else (
+                result.invalid[0]
+                if result.invalid
+                else "baseline drift detected (resolved/changed/collection error)"
+            )
+        )
+        print(f"BASELINE FAIL: {head}", file=sys.stderr)
+    else:
+        print(f"BASELINE OK: {len(result.known)} known, 0 new, 0 resolved")
+    return result.exit_code
+
+
+def _cmd_snapshot(args: argparse.Namespace) -> int:
+    parsed = _load_junit_glob(args.junit)
+    failures: list[FailureRecord] = []
+    collection_errors: list[ParsedTestcase] = []
+    for tc in parsed:
+        f = tc.as_failure()
+        if f is None:
+            continue
+        if f.category == "collection_error":
+            collection_errors.append(tc)
+        else:
+            failures.append(f)
+    if collection_errors:
+        print(
+            "snapshot refused: collection errors cannot be baselined (the "
+            "collection gate must stay at zero). Offenders:\n  "
+            + "\n  ".join(tc.nodeid for tc in collection_errors[:50]),
+            file=sys.stderr,
+        )
+        return 2
+    provenance = {
+        "reference_commit": args.reference_commit or "",
+        "source_run": args.source_run or "",
+        "source_run_url": args.source_run_url or "",
+        "run_contract": args.run_contract or "",
+        "generated_command": (
+            f"python scripts/legacy_issue_baseline.py snapshot "
+            f"--junit {args.junit} --source-run {args.source_run or ''}"
+        ),
+    }
+    baseline = Baseline(entries=failures, provenance=provenance, selection=DEFAULT_SELECTION)
+    Path(args.output).write_text(baseline.to_json())
+    print(f"snapshot: {len(failures)} entries -> {args.output}")
+    return 0
+
+
+def _cmd_manifest(args: argparse.Namespace) -> int:
+    em = build_expected_manifest()
+    Path(args.output).write_text(json.dumps(em.to_dict(), indent=2, sort_keys=True) + "\n")
+    print(f"manifest: {len(em.nodeids)} nodeids / {len(em.files)} files -> {args.output}")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="action", required=True)
+
+    cmp = sub.add_parser("compare", help="read-only compare; authoritative gate")
+    cmp.add_argument("--baseline", default=str(DEFAULT_BASELINE))
+    cmp.add_argument("--junit", required=True)
+    cmp.add_argument("--manifest", default="")
+    cmp.add_argument("--test-baseline", default=str(TEST_BASELINE_FILE))
+    cmp.add_argument("--json-output", default="")
+    cmp.add_argument("--markdown-output", default="")
+    cmp.add_argument("--targeted-issues", action="store_true")
+    cmp.set_defaults(func=_cmd_compare)
+
+    snap = sub.add_parser("snapshot", help="generate a reviewable candidate baseline")
+    snap.add_argument("--junit", required=True)
+    snap.add_argument("--output", required=True)
+    snap.add_argument("--source-run", default="")
+    snap.add_argument("--source-run-url", default="")
+    snap.add_argument("--reference-commit", default="")
+    snap.add_argument("--run-contract", default="")
+    snap.set_defaults(func=_cmd_snapshot)
+
+    man = sub.add_parser("manifest", help="emit the expected nodeid set")
+    man.add_argument("--output", required=True)
+    man.set_defaults(func=_cmd_manifest)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return int(args.func(args))
+    except BaselineError as exc:
+        print(f"BASELINE ERROR: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/legacy_issue_baseline.py
+++ b/scripts/legacy_issue_baseline.py
@@ -428,7 +428,6 @@ _QUARANTINE_REQUIRED = (
     "exit_condition",
     "expires_on",
 )
-_QUARANTINE_DATE_RX = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
 
 @dataclasses.dataclass(frozen=True)
@@ -446,10 +445,25 @@ def load_quarantine(path: str | Path) -> list[QuarantineEntry]:
     obj = json.loads(text)
     if obj.get("schema") != "openace-legacy-issue-quarantine":
         raise BaselineError(f"unsupported quarantine schema: {obj.get('schema')!r}")
+    if obj.get("version") != 1:
+        raise BaselineError(f"unsupported quarantine version: {obj.get('version')!r}")
+    raw_entries = obj.get("entries")
+    if not isinstance(raw_entries, list):
+        raise BaselineError(f"quarantine entries must be a list, got {type(raw_entries).__name__}")
     entries: list[QuarantineEntry] = []
-    for raw in obj.get("entries", []):
+    for raw in raw_entries:
+        if not isinstance(raw, dict):
+            raise BaselineError(f"quarantine entry must be an object, got {type(raw).__name__}")
         entries.append(QuarantineEntry(**{k: raw.get(k, "") for k in _QUARANTINE_REQUIRED}))
     return entries
+
+
+def _is_real_date(value: str) -> bool:
+    try:
+        datetime.date.fromisoformat(value)
+        return True
+    except ValueError:
+        return False
 
 
 def validate_quarantine(
@@ -471,7 +485,7 @@ def validate_quarantine(
         for field in _QUARANTINE_REQUIRED:
             if not getattr(e, field).strip():
                 invalid.append(f"quarantine entry {e.nodeid!r} missing field '{field}'")
-        if not _QUARANTINE_DATE_RX.match(e.expires_on):
+        if not _is_real_date(e.expires_on):
             invalid.append(f"quarantine entry {e.nodeid!r} malformed expires_on {e.expires_on!r}")
         elif e.expires_on < today:
             invalid.append(f"quarantine entry {e.nodeid!r} expired on {e.expires_on}")
@@ -796,13 +810,17 @@ def _load_exit_codes(pattern: str) -> dict[str, int]:
     """Load shard pytest exit-code files (``issues-N.exit-code`` → int).
 
     Absent files are reported by the caller via the expected-shard count; a
-    present-but-unparseable file is a hard error.
+    present-but-unparseable file OR a duplicate basename (two paths writing the
+    same ``issues-N.exit-code``) is a hard error — never last-write-wins.
     """
     codes: dict[str, int] = {}
     for p in sorted(glob.glob(pattern, recursive=True)):
+        name = Path(p).name
+        if name in codes:
+            raise BaselineError(f"duplicate exit-code basename {name!r} ({p})")
         raw = Path(p).read_text().strip()
         try:
-            codes[Path(p).name] = int(raw)
+            codes[name] = int(raw)
         except ValueError as exc:
             raise BaselineError(f"unparseable exit-code file {p}: {raw!r}") from exc
     return codes
@@ -834,6 +852,10 @@ def verify_completeness(
     invalid: list[str] = []
     for n in sorted(expected_set - observed_nodeids):
         invalid.append(f"expected nodeid never observed: {n}")
+    # Bidirectional: an unexpected observed nodeid (e.g. a quarantined nodeid
+    # that ran anyway, or a stale artifact bundle) must also fail closed.
+    for n in sorted(observed_nodeids - expected_set):
+        invalid.append(f"unexpected observed nodeid (not in expected set): {n}")
     if not parsed and expected_set:
         invalid.append("no JUnit reports matched the glob; expected shard artifacts missing")
     for n in sorted(set(duplicates))[:50]:

--- a/scripts/legacy_issue_baseline.py
+++ b/scripts/legacy_issue_baseline.py
@@ -246,13 +246,17 @@ def _short_summary(text: str, limit: int = 200) -> str:
 
 
 # Environment-specific noise that must not leak into the tracked baseline
-# (handoff §4.2): absolute runner/workspace paths, ephemeral ports, temp HOME.
+# (handoff §4.2): absolute runner/workspace paths, ephemeral ports, temp HOME,
+# runner-specific Python toolcache binaries (e.g. /opt/hostedtoolcache/...).
 _RUNNER_PREFIX_RX = re.compile(r"/(?:[^/\s]+/)+open-ace/")
 _PORT_RX = re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}:\d+\b|\b(?:localhost|0\.0\.0\.0):\d+\b")
 _TMPHOME_RX = re.compile(r"\.openace-ci-[A-Za-z0-9_-]+")
+# Absolute python binaries: /opt/hostedtoolcache/Python/3.11.15/x64/bin/python3.11
+_PYBIN_RX = re.compile(r"/[^\s\"]*/bin/python\d?(?:\.\d+)*")
 
 
 def _scrub_env(text: str) -> str:
+    text = _PYBIN_RX.sub("python", text or "")
     text = _RUNNER_PREFIX_RX.sub("", text or "")
     text = _TMPHOME_RX.sub(".openace-ci-<tmp>", text)
     text = _PORT_RX.sub("<host:port>", text)
@@ -427,7 +431,10 @@ _QUARANTINE_REQUIRED = (
     "tracking_issue",
     "exit_condition",
     "expires_on",
+    "expected_probe_outcome",
 )
+# Valid machine-readable probe outcomes the entry may declare.
+PROBE_OUTCOMES = ("timeout", "pass", "fail")
 
 
 @dataclasses.dataclass(frozen=True)
@@ -438,6 +445,7 @@ class QuarantineEntry:
     tracking_issue: str
     exit_condition: str
     expires_on: str
+    expected_probe_outcome: str
 
 
 def load_quarantine(path: str | Path) -> list[QuarantineEntry]:
@@ -485,6 +493,11 @@ def validate_quarantine(
         for field in _QUARANTINE_REQUIRED:
             if not getattr(e, field).strip():
                 invalid.append(f"quarantine entry {e.nodeid!r} missing field '{field}'")
+        if e.expected_probe_outcome and e.expected_probe_outcome not in PROBE_OUTCOMES:
+            invalid.append(
+                f"quarantine entry {e.nodeid!r} invalid expected_probe_outcome "
+                f"{e.expected_probe_outcome!r} (choose from {PROBE_OUTCOMES})"
+            )
         if not _is_real_date(e.expires_on):
             invalid.append(f"quarantine entry {e.nodeid!r} malformed expires_on {e.expires_on!r}")
         elif e.expires_on < today:
@@ -1031,9 +1044,11 @@ def _cmd_snapshot(args: argparse.Namespace) -> int:
         "source_run": args.source_run or "",
         "source_run_url": args.source_run_url or "",
         "run_contract": args.run_contract or "",
+        # Reproducible, repo/artifact-relative command (no local /tmp paths).
         "generated_command": (
-            f"python scripts/legacy_issue_baseline.py snapshot "
-            f"--junit {args.junit} --source-run {args.source_run or ''}"
+            "python scripts/legacy_issue_baseline.py snapshot "
+            "--junit artifacts/test-results/issues-*.xml "
+            f"--source-run {args.source_run or '<run-id>'} --shard-count {args.shard_count}"
         ),
     }
     baseline = Baseline(entries=failures, provenance=provenance, selection=DEFAULT_SELECTION)

--- a/scripts/legacy_issue_baseline.py
+++ b/scripts/legacy_issue_baseline.py
@@ -476,6 +476,7 @@ def compare(
     observed_files: set[str] | None = None,
     targeted: bool = False,
     exit_codes: dict[str, int] | None = None,
+    expected_shard_count: int = 0,
 ) -> CompareResult:
     """Compute the bidirectional diff and fail-closed completeness verdict."""
     current_nodeids = {tc.nodeid for tc in parsed_testcases}
@@ -538,6 +539,7 @@ def compare(
         min_files=baseline_min_files,
         require_review_threshold_pct=require_review_threshold_pct,
         exit_codes=exit_codes,
+        expected_shard_count=expected_shard_count,
     )
     if targeted:
         invalid.append(
@@ -698,6 +700,7 @@ def verify_completeness(
     min_files: int = 0,
     require_review_threshold_pct: float = 0.0,
     exit_codes: dict[str, int] | None = None,
+    expected_shard_count: int = 0,
 ) -> list[str]:
     """Canonical fail-closed completeness checks shared by compare + snapshot.
 
@@ -720,18 +723,44 @@ def verify_completeness(
         invalid.append("no JUnit reports matched the glob; expected shard artifacts missing")
     for n in sorted(set(duplicates))[:50]:
         invalid.append(f"duplicate nodeid result (cross-shard/rerun conflict): {n}")
-    if exit_codes:
-        for name, code in sorted(exit_codes.items()):
-            if code not in (0, 1):
-                invalid.append(
-                    f"shard {name} exited {code} (infrastructure failure, not a test failure)"
-                )
+    invalid.extend(_check_exit_codes(exit_codes, expected_shard_count))
     floor = min_files * (1 - require_review_threshold_pct / 100.0)
     if min_files and len(observed_files) < floor:
         invalid.append(
             f"observed {len(observed_files)} files, below floor {floor:.0f} "
             f"({min_files} × {100 - require_review_threshold_pct:.0f}%)"
         )
+    return invalid
+
+
+def _check_exit_codes(exit_codes: dict[str, int] | None, expected_shard_count: int) -> list[str]:
+    """Validate shard exit-code cardinality + values.
+
+    With ``expected_shard_count`` set, require EXACTLY the N expected files
+    (``issues-{1..N}.exit-code``): missing/extra/duplicate/wrong-name or any
+    unparseable value fails closed. Without it, only non-{0,1} values fail.
+    """
+    invalid: list[str] = []
+    if expected_shard_count <= 0:
+        if exit_codes:
+            for name, code in sorted(exit_codes.items()):
+                if code not in (0, 1):
+                    invalid.append(
+                        f"shard {name} exited {code} (infrastructure failure, not a test failure)"
+                    )
+        return invalid
+    expected_names = {f"issues-{i}.exit-code" for i in range(1, expected_shard_count + 1)}
+    present = set(exit_codes or {})
+    for name in sorted(expected_names - present):
+        invalid.append(f"missing shard exit-code file: {name}")
+    for name in sorted(present - expected_names):
+        invalid.append(f"unexpected shard exit-code file: {name}")
+    for name in sorted(expected_names & present):
+        code = (exit_codes or {})[name]
+        if code not in (0, 1):
+            invalid.append(
+                f"shard {name} exited {code} (infrastructure failure, not a test failure)"
+            )
     return invalid
 
 
@@ -768,6 +797,7 @@ def _cmd_compare(args: argparse.Namespace) -> int:
         observed_files=observed,
         targeted=targeted,
         exit_codes=exit_codes,
+        expected_shard_count=args.shard_count,
     )
     if args.json_output:
         _ensure_parent(args.json_output)
@@ -832,6 +862,7 @@ def _cmd_snapshot(args: argparse.Namespace) -> int:
         min_files=min_files,
         require_review_threshold_pct=thr,
         exit_codes=exit_codes,
+        expected_shard_count=args.shard_count,
     )
     if incomplete:
         print(
@@ -875,6 +906,7 @@ def build_parser() -> argparse.ArgumentParser:
     cmp.add_argument("--manifest", default="")
     cmp.add_argument("--test-baseline", default=str(TEST_BASELINE_FILE))
     cmp.add_argument("--exit-code-glob", default="")
+    cmp.add_argument("--shard-count", type=int, default=4)
     cmp.add_argument("--json-output", default="")
     cmp.add_argument("--markdown-output", default="")
     cmp.add_argument("--targeted-issues", action="store_true")
@@ -886,6 +918,7 @@ def build_parser() -> argparse.ArgumentParser:
     snap.add_argument("--manifest", default="")
     snap.add_argument("--test-baseline", default=str(TEST_BASELINE_FILE))
     snap.add_argument("--exit-code-glob", default="")
+    snap.add_argument("--shard-count", type=int, default=4)
     snap.add_argument("--source-run", default="")
     snap.add_argument("--source-run-url", default="")
     snap.add_argument("--reference-commit", default="")

--- a/scripts/legacy_issue_baseline.py
+++ b/scripts/legacy_issue_baseline.py
@@ -175,19 +175,21 @@ def _is_timeout(exception_type: str, message: str) -> bool:
     return "timed out" in blob or "timeout" in blob
 
 
-def classify(
-    element: str, has_nodeid_property: bool, exception_type: str, message: str, nodeid: str
-) -> str:
+def classify(element: str, exception_type: str, message: str, nodeid: str) -> str:
     """Map a JUnit ``<failure>``/``<error>`` to a stable category.
 
     ``element`` is ``"failure"`` or ``"error"``. Collection errors are detected
-    by the absence of the ``openace_nodeid`` property (a collection failure
-    never creates a test item, so the autouse conftest fixture never ran).
+    by the nodeid carrying no ``::`` (a module that failed to import never
+    produces a test item, so its reconstructed identity is module-level). Do
+    NOT key on the ``openace_nodeid`` property's absence: setup errors can also
+    lack it when the autouse fixture did not get to run (e.g. an earlier
+    fixture failed), and those must be baselined as ``setup_error``, not refused
+    as collection errors.
     """
     if element == "failure":
         return "assertion_failure" if exception_type == "AssertionError" else "test_body_exception"
     # element == "error"
-    if not has_nodeid_property or "::" not in nodeid:
+    if "::" not in nodeid:
         return "collection_error"
     if _is_timeout(exception_type, message):
         return "timeout"
@@ -242,6 +244,20 @@ def _short_summary(text: str, limit: int = 200) -> str:
     return text
 
 
+# Environment-specific noise that must not leak into the tracked baseline
+# (handoff §4.2): absolute runner/workspace paths, ephemeral ports, temp HOME.
+_RUNNER_PREFIX_RX = re.compile(r"/(?:[^/\s]+/)+open-ace/")
+_PORT_RX = re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}:\d+\b|\b(?:localhost|0\.0\.0\.0):\d+\b")
+_TMPHOME_RX = re.compile(r"\.openace-ci-[A-Za-z0-9_-]+")
+
+
+def _scrub_env(text: str) -> str:
+    text = _RUNNER_PREFIX_RX.sub("", text or "")
+    text = _TMPHOME_RX.sub(".openace-ci-<tmp>", text)
+    text = _PORT_RX.sub("<host:port>", text)
+    return text
+
+
 def _parse_testcase(tc: ET.Element) -> ParsedTestcase | None:
     classname = tc.get("classname", "")
     name = tc.get("name", "")
@@ -271,8 +287,8 @@ def _parse_testcase(tc: ET.Element) -> ParsedTestcase | None:
         return ParsedTestcase(nodeid, "pass", "pass", "", "")
 
     exception_type = (node.get("type") or "").strip()
-    message = _short_summary(node.get("message") or (node.text or ""))
-    category = classify(element, has_property, exception_type, message, nodeid)
+    message = _short_summary(_scrub_env(node.get("message") or (node.text or "")))
+    category = classify(element, exception_type, message, nodeid)
     return ParsedTestcase(nodeid, outcome, category, exception_type, message)
 
 

--- a/scripts/legacy_issue_baseline.py
+++ b/scripts/legacy_issue_baseline.py
@@ -258,6 +258,29 @@ def _scrub_env(text: str) -> str:
     return text
 
 
+# pytest xunit2 commonly omits the ``type`` attribute on <failure>/<error>, so
+# recover the exception class from the stable message/text forms: a bare
+# ``assert`` statement, or a leading ``<dotted.ExceptionClass>:`` / the
+# traceback's ``E   <Class>:`` line.
+_ASSERT_RX = re.compile(r"^\s*assert\b")
+_EXC_CLASS_RX = re.compile(
+    r"(?:^|\n\s*E\s+)([A-Za-z_][\w.]*(?:Error|Exception|Warning|Cancelled|NotFound))\s*:"
+)
+
+
+def _extract_exception_type(type_attr: str | None, message: str | None, text: str | None) -> str:
+    if type_attr and type_attr.strip():
+        return type_attr.strip()
+    blob = f"{message or ''}\n{text or ''}"
+    for line in blob.splitlines():
+        if _ASSERT_RX.match(line):
+            return "AssertionError"
+    m = _EXC_CLASS_RX.search(blob)
+    if m:
+        return m.group(1).split(".")[-1]
+    return ""
+
+
 def _parse_testcase(tc: ET.Element) -> ParsedTestcase | None:
     classname = tc.get("classname", "")
     name = tc.get("name", "")
@@ -286,7 +309,7 @@ def _parse_testcase(tc: ET.Element) -> ParsedTestcase | None:
     else:
         return ParsedTestcase(nodeid, "pass", "pass", "", "")
 
-    exception_type = (node.get("type") or "").strip()
+    exception_type = _extract_exception_type(node.get("type"), node.get("message"), node.text)
     message = _short_summary(_scrub_env(node.get("message") or (node.text or "")))
     category = classify(element, exception_type, message, nodeid)
     return ParsedTestcase(nodeid, outcome, category, exception_type, message)
@@ -309,7 +332,7 @@ def parse_junit(path: str | Path) -> tuple[list[ParsedTestcase], SuiteTotals]:
         raise BaselineError(f"no <testsuite> in JUnit XML: {path}")
 
     totals = SuiteTotals()
-    by_nodeid: dict[str, ParsedTestcase] = {}
+    records: list[ParsedTestcase] = []
     for suite in suites:
         a = suite.attrib
         totals.tests += int(a.get("tests", 0) or 0)
@@ -319,10 +342,10 @@ def parse_junit(path: str | Path) -> tuple[list[ParsedTestcase], SuiteTotals]:
         for tc in suite.findall("testcase"):
             parsed = _parse_testcase(tc)
             if parsed is not None:
-                by_nodeid[parsed.nodeid] = parsed  # last document order wins (rerun-safe)
-    if totals.tests == 0 and not by_nodeid:
+                records.append(parsed)  # do NOT dedupe; conflicts detected downstream
+    if totals.tests == 0 and not records:
         raise BaselineError(f"zero tests in JUnit XML: {path}")
-    return list(by_nodeid.values()), totals
+    return records, totals
 
 
 # ---------------------------------------------------------------------------
@@ -377,13 +400,15 @@ def build_expected_manifest(
             if line.startswith("tests/") and "::" in line
         }
     )
-    if not nodeids:
-        # Degraded collection (pytest exited non-zero / import error / wrong
-        # flags). An empty expected set would silently disable the nodeid
-        # completeness check, so fail closed here.
+    if proc.returncode != 0:
+        # Partial/degraded collection (import error, usage error, etc.). Even
+        # with some nodeids, files that failed to import silently drop out of
+        # the expected set, so the completeness check would be unsound. Fail
+        # closed rather than trust a partial manifest.
         raise BaselineError(
-            "expected-nodeid manifest collected 0 nodeids "
-            f"(pytest exit {proc.returncode}); collection is degraded"
+            f"expected-nodeid manifest collection exited {proc.returncode} "
+            f"({len(nodeids)} nodeids parsed); collection is degraded — "
+            "resolve collection errors before comparing/snapshotting"
         )
     files = sorted({_file_of(n) for n in nodeids})
     return ExpectedManifest(nodeids=nodeids, files=files, selection=selection, targeted=targeted)
@@ -450,6 +475,7 @@ def compare(
     require_review_threshold_pct: float = 0.0,
     observed_files: set[str] | None = None,
     targeted: bool = False,
+    exit_codes: dict[str, int] | None = None,
 ) -> CompareResult:
     """Compute the bidirectional diff and fail-closed completeness verdict."""
     current_nodeids = {tc.nodeid for tc in parsed_testcases}
@@ -505,20 +531,14 @@ def compare(
         key=lambda d: (d["nodeid"], d["outcome"], d["category"]),
     )
 
-    invalid: list[str] = []
     expected_set = set(expected_nodeids)
-    missing = sorted(expected_set - current_nodeids)
-    for n in missing:
-        invalid.append(f"expected nodeid never observed: {n}")
-    if not parsed_testcases and expected_set:
-        invalid.append("no JUnit reports matched the glob; expected shard artifacts missing")
-    file_floor = baseline_min_files * (1 - require_review_threshold_pct / 100.0)
-    if baseline_min_files and len(observed_files) < file_floor:
-        invalid.append(
-            f"observed {len(observed_files)} files, below floor "
-            f"{file_floor:.0f} ({baseline_min_files} × "
-            f"{100 - require_review_threshold_pct:.0f}%)"
-        )
+    invalid = verify_completeness(
+        parsed_testcases,
+        expected_nodeids,
+        min_files=baseline_min_files,
+        require_review_threshold_pct=require_review_threshold_pct,
+        exit_codes=exit_codes,
+    )
     if targeted:
         invalid.append(
             "targeted run: compared against selected subset only, not a full nightly gate"
@@ -622,12 +642,11 @@ def _load_junit_glob(pattern: str) -> list[ParsedTestcase]:
             f"no JUnit reports matched '{pattern}'; expected shard artifacts missing "
             f"— run `snapshot` with a complete run to generate a candidate baseline"
         )
-    merged: dict[str, ParsedTestcase] = {}
+    merged: list[ParsedTestcase] = []
     for p in paths:
         testcases, _totals = parse_junit(p)
-        for tc in testcases:
-            merged[tc.nodeid] = tc  # shards are file-disjoint; last-write is safe
-    return list(merged.values())
+        merged.extend(testcases)  # do NOT dedupe across shards; conflicts detected in compare()
+    return merged
 
 
 def _load_test_baseline(path: Path) -> tuple[int, float]:
@@ -646,6 +665,74 @@ def _write_summary(text: str) -> None:
     if path:
         with open(path, "a", encoding="utf-8") as handle:
             handle.write(text + "\n")
+
+
+def _ensure_parent(path: str | Path) -> None:
+    """Create the parent directory of an output path (the comparator job runs
+    in a fresh checkout where ``test-results/`` does not exist yet)."""
+    parent = Path(path).parent
+    if str(parent) and parent != Path("."):
+        parent.mkdir(parents=True, exist_ok=True)
+
+
+def _load_exit_codes(pattern: str) -> dict[str, int]:
+    """Load shard pytest exit-code files (``issues-N.exit-code`` → int).
+
+    Absent files are reported by the caller via the expected-shard count; a
+    present-but-unparseable file is a hard error.
+    """
+    codes: dict[str, int] = {}
+    for p in sorted(glob.glob(pattern, recursive=True)):
+        raw = Path(p).read_text().strip()
+        try:
+            codes[Path(p).name] = int(raw)
+        except ValueError as exc:
+            raise BaselineError(f"unparseable exit-code file {p}: {raw!r}") from exc
+    return codes
+
+
+def verify_completeness(
+    parsed: list[ParsedTestcase],
+    expected_nodeids: Iterable[str],
+    *,
+    min_files: int = 0,
+    require_review_threshold_pct: float = 0.0,
+    exit_codes: dict[str, int] | None = None,
+) -> list[str]:
+    """Canonical fail-closed completeness checks shared by compare + snapshot.
+
+    Returns a list of human-readable invalid reasons (empty == complete).
+    """
+    seen: dict[str, ParsedTestcase] = {}
+    duplicates: list[str] = []
+    for tc in parsed:
+        if tc.nodeid in seen:
+            duplicates.append(tc.nodeid)
+        seen[tc.nodeid] = tc
+    observed_nodeids = set(seen)
+    observed_files = {_file_of(n) for n in observed_nodeids}
+    expected_set = set(expected_nodeids)
+
+    invalid: list[str] = []
+    for n in sorted(expected_set - observed_nodeids):
+        invalid.append(f"expected nodeid never observed: {n}")
+    if not parsed and expected_set:
+        invalid.append("no JUnit reports matched the glob; expected shard artifacts missing")
+    for n in sorted(set(duplicates))[:50]:
+        invalid.append(f"duplicate nodeid result (cross-shard/rerun conflict): {n}")
+    if exit_codes:
+        for name, code in sorted(exit_codes.items()):
+            if code not in (0, 1):
+                invalid.append(
+                    f"shard {name} exited {code} (infrastructure failure, not a test failure)"
+                )
+    floor = min_files * (1 - require_review_threshold_pct / 100.0)
+    if min_files and len(observed_files) < floor:
+        invalid.append(
+            f"observed {len(observed_files)} files, below floor {floor:.0f} "
+            f"({min_files} × {100 - require_review_threshold_pct:.0f}%)"
+        )
+    return invalid
 
 
 # ---------------------------------------------------------------------------
@@ -671,6 +758,7 @@ def _cmd_compare(args: argparse.Namespace) -> int:
         expected, targeted = em.nodeids, em.targeted
     min_files, thr = _load_test_baseline(Path(args.test_baseline))
     observed = {_file_of(tc.nodeid) for tc in parsed}
+    exit_codes = _load_exit_codes(args.exit_code_glob) if args.exit_code_glob else None
     result = compare(
         baseline,
         parsed,
@@ -679,13 +767,16 @@ def _cmd_compare(args: argparse.Namespace) -> int:
         require_review_threshold_pct=thr,
         observed_files=observed,
         targeted=targeted,
+        exit_codes=exit_codes,
     )
     if args.json_output:
+        _ensure_parent(args.json_output)
         Path(args.json_output).write_text(
             json.dumps(result.to_dict(), indent=2, sort_keys=True) + "\n"
         )
     md = render_markdown(result)
     if args.markdown_output:
+        _ensure_parent(args.markdown_output)
         Path(args.markdown_output).write_text(md + "\n")
     _write_summary(md)
     if result.exit_code:
@@ -724,6 +815,31 @@ def _cmd_snapshot(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
         return 2
+    # P0#2: a baseline may only come from a COMPLETE reference run. Refuse to
+    # snapshot a partial bundle (missing nodeids, duplicate/conflicting results,
+    # infrastructure exit codes, file-count regression).
+    if args.manifest:
+        expected = json.loads(Path(args.manifest).read_text()).get("nodeids", [])
+    else:
+        expected = build_expected_manifest().nodeids
+    min_files, thr = (
+        _load_test_baseline(Path(args.test_baseline)) if args.test_baseline else (0, 0.0)
+    )
+    exit_codes = _load_exit_codes(args.exit_code_glob) if args.exit_code_glob else None
+    incomplete = verify_completeness(
+        parsed,
+        expected,
+        min_files=min_files,
+        require_review_threshold_pct=thr,
+        exit_codes=exit_codes,
+    )
+    if incomplete:
+        print(
+            "snapshot refused: reference run is not complete (baseline may only "
+            "come from a complete run). Reasons:\n  - " + "\n  - ".join(incomplete[:30]),
+            file=sys.stderr,
+        )
+        return 2
     provenance = {
         "reference_commit": args.reference_commit or "",
         "source_run": args.source_run or "",
@@ -735,6 +851,7 @@ def _cmd_snapshot(args: argparse.Namespace) -> int:
         ),
     }
     baseline = Baseline(entries=failures, provenance=provenance, selection=DEFAULT_SELECTION)
+    _ensure_parent(args.output)
     Path(args.output).write_text(baseline.to_json())
     print(f"snapshot: {len(failures)} entries -> {args.output}")
     return 0
@@ -742,6 +859,7 @@ def _cmd_snapshot(args: argparse.Namespace) -> int:
 
 def _cmd_manifest(args: argparse.Namespace) -> int:
     em = build_expected_manifest()
+    _ensure_parent(args.output)
     Path(args.output).write_text(json.dumps(em.to_dict(), indent=2, sort_keys=True) + "\n")
     print(f"manifest: {len(em.nodeids)} nodeids / {len(em.files)} files -> {args.output}")
     return 0
@@ -756,6 +874,7 @@ def build_parser() -> argparse.ArgumentParser:
     cmp.add_argument("--junit", required=True)
     cmp.add_argument("--manifest", default="")
     cmp.add_argument("--test-baseline", default=str(TEST_BASELINE_FILE))
+    cmp.add_argument("--exit-code-glob", default="")
     cmp.add_argument("--json-output", default="")
     cmp.add_argument("--markdown-output", default="")
     cmp.add_argument("--targeted-issues", action="store_true")
@@ -764,6 +883,9 @@ def build_parser() -> argparse.ArgumentParser:
     snap = sub.add_parser("snapshot", help="generate a reviewable candidate baseline")
     snap.add_argument("--junit", required=True)
     snap.add_argument("--output", required=True)
+    snap.add_argument("--manifest", default="")
+    snap.add_argument("--test-baseline", default=str(TEST_BASELINE_FILE))
+    snap.add_argument("--exit-code-glob", default="")
     snap.add_argument("--source-run", default="")
     snap.add_argument("--source-run-url", default="")
     snap.add_argument("--reference-commit", default="")

--- a/scripts/legacy_issue_baseline.py
+++ b/scripts/legacy_issue_baseline.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 
 import argparse
 import dataclasses
-import fnmatch
 import glob
 import json
 import os
@@ -362,6 +361,14 @@ def build_expected_manifest(
             if line.startswith("tests/") and "::" in line
         }
     )
+    if not nodeids:
+        # Degraded collection (pytest exited non-zero / import error / wrong
+        # flags). An empty expected set would silently disable the nodeid
+        # completeness check, so fail closed here.
+        raise BaselineError(
+            "expected-nodeid manifest collected 0 nodeids "
+            f"(pytest exit {proc.returncode}); collection is degraded"
+        )
     files = sorted({_file_of(n) for n in nodeids})
     return ExpectedManifest(nodeids=nodeids, files=files, selection=selection, targeted=targeted)
 
@@ -389,8 +396,14 @@ class CompareResult:
 
 
 def _failure_index(records: list[FailureRecord]) -> dict[tuple[str, str, str], FailureRecord]:
-    """Index failures by key; raise on conflicting same-key records."""
+    """Index failures by key; raise on any conflict.
+
+    Two failure modes are rejected loudly (never last-write-wins): same key with
+    a different summary, and the same nodeid mapping to more than one key (e.g.
+    a hand-edited baseline carrying both ``failure`` and ``error`` for one node).
+    """
     index: dict[tuple[str, str, str], FailureRecord] = {}
+    nodeid_keys: dict[str, set[tuple[str, str, str]]] = {}
     for r in records:
         existing = index.get(r.key)
         if existing is not None and (
@@ -402,6 +415,13 @@ def _failure_index(records: list[FailureRecord]) -> dict[tuple[str, str, str], F
                 f"{r.exception_type}/{r.summary!r}); refusing last-write-wins"
             )
         index[r.key] = r
+        nodeid_keys.setdefault(r.nodeid, set()).add(r.key)
+    for nodeid, keys in nodeid_keys.items():
+        if len(keys) > 1:
+            raise BaselineError(
+                f"nodeid {nodeid} has multiple failure keys {sorted(keys)}; "
+                f"a test must have exactly one (outcome, category)"
+            )
     return index
 
 
@@ -618,7 +638,13 @@ def _write_summary(text: str) -> None:
 
 
 def _cmd_compare(args: argparse.Namespace) -> int:
-    baseline = Baseline.from_json(Path(args.baseline).read_text())
+    try:
+        baseline = Baseline.from_json(Path(args.baseline).read_text())
+    except OSError as exc:
+        raise BaselineError(
+            f"cannot read baseline {args.baseline}: {exc} "
+            f"— generate it with `snapshot` from a complete reference run"
+        ) from exc
     parsed = _load_junit_glob(args.junit)
     if args.manifest:
         manifest = json.loads(Path(args.manifest).read_text())

--- a/scripts/legacy_issue_baseline.py
+++ b/scripts/legacy_issue_baseline.py
@@ -26,6 +26,7 @@ import glob
 import json
 import os
 import re
+import shlex
 import subprocess
 import sys
 import xml.etree.ElementTree as ET
@@ -433,8 +434,15 @@ _QUARANTINE_REQUIRED = (
     "expires_on",
     "expected_probe_outcome",
 )
-# Valid machine-readable probe outcomes the entry may declare.
-PROBE_OUTCOMES = ("timeout", "pass", "fail")
+# Valid machine-readable probe outcomes an entry may declare. Only ``timeout``
+# is permitted: it is the only outcome that cannot mask a regression — a timeout
+# entry is green only while it genuinely still times out. ``pass`` is forbidden
+# because it would let a *recovered* test stay permanently deselected and the
+# weekly probe green; ``fail`` is forbidden because it is too coarse (pytest
+# rc 2-5 / no-tests / usage errors would all read as "expected fail"). If a
+# future debt type needs a non-timeout outcome, it must declare a precise,
+# machine-readable exit/failure fingerprint rather than reuse this enum.
+PROBE_OUTCOMES = ("timeout",)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -819,6 +827,64 @@ def _ensure_parent(path: str | Path) -> None:
         parent.mkdir(parents=True, exist_ok=True)
 
 
+# Canonical CI artifact-relative locations for snapshot inputs. The
+# extended-tests.yml ``legacy-issue-baseline`` job downloads the ``issue-tests-*``
+# shard artifacts (each carrying ``test-results/issues-N.xml`` and
+# ``issues-N.exit-code``) into ``artifacts/``, so a reproducible snapshot reads
+# them from here regardless of where the command is invoked.
+_JUNIT_GLOB_CANONICAL = "artifacts/test-results/issues-*.xml"
+_EXITCODE_GLOB_CANONICAL = "artifacts/test-results/issues-*.exit-code"
+
+
+def _repo_relative(path: str) -> str:
+    """Normalize a snapshot path to a stable repo-relative POSIX form."""
+    try:
+        return Path(path).resolve().relative_to(PROJECT_ROOT).as_posix()
+    except (ValueError, OSError):
+        return Path(path).as_posix()
+
+
+def _snapshot_generated_command(args: argparse.Namespace) -> str:
+    """Build a path-normalized, parameter-complete, executable snapshot command.
+
+    JUnit/exit-code globs are emitted in their canonical CI artifact-relative
+    form; single-file destinations are repo-relative. Every flag the run actually
+    used is recorded (including defaults) so copying the command reproduces the
+    baseline from any run's downloaded ``issue-tests-*`` artifacts. The result
+    MUST round-trip through :func:`build_parser` (``--output`` present, all flags
+    valid) — see ``test_baseline_provenance_round_trips``.
+    """
+    parts = [
+        "python",
+        "scripts/legacy_issue_baseline.py",
+        "snapshot",
+        "--junit",
+        _JUNIT_GLOB_CANONICAL,
+        "--output",
+        _repo_relative(args.output),
+    ]
+    if args.exit_code_glob:
+        parts += ["--exit-code-glob", _EXITCODE_GLOB_CANONICAL]
+    parts += ["--shard-count", str(args.shard_count)]
+    for flag, key in (
+        ("--manifest", "manifest"),
+        ("--quarantine", "quarantine"),
+        ("--test-baseline", "test_baseline"),
+    ):
+        value = getattr(args, key, "") or ""
+        if value:
+            parts += [flag, _repo_relative(value)]
+    if args.source_run:
+        parts += ["--source-run", args.source_run]
+    if args.source_run_url:
+        parts += ["--source-run-url", args.source_run_url]
+    if args.reference_commit:
+        parts += ["--reference-commit", args.reference_commit]
+    if args.run_contract:
+        parts += ["--run-contract", args.run_contract]
+    return shlex.join(parts)
+
+
 def _load_exit_codes(pattern: str) -> dict[str, int]:
     """Load shard pytest exit-code files (``issues-N.exit-code`` → int).
 
@@ -1044,12 +1110,9 @@ def _cmd_snapshot(args: argparse.Namespace) -> int:
         "source_run": args.source_run or "",
         "source_run_url": args.source_run_url or "",
         "run_contract": args.run_contract or "",
-        # Reproducible, repo/artifact-relative command (no local /tmp paths).
-        "generated_command": (
-            "python scripts/legacy_issue_baseline.py snapshot "
-            "--junit artifacts/test-results/issues-*.xml "
-            f"--source-run {args.source_run or '<run-id>'} --shard-count {args.shard_count}"
-        ),
+        # Reproducible, repo/artifact-relative, parameter-complete command that
+        # round-trips through build_parser (see _snapshot_generated_command).
+        "generated_command": _snapshot_generated_command(args),
     }
     baseline = Baseline(entries=failures, provenance=provenance, selection=DEFAULT_SELECTION)
     _ensure_parent(args.output)

--- a/scripts/run_extended_tests.py
+++ b/scripts/run_extended_tests.py
@@ -294,6 +294,12 @@ def build_pytest_command(args: argparse.Namespace) -> list[str]:
         raise ValueError(f"Test file count below baseline threshold for category: {args.category}")
 
     cmd = [sys.executable, "-m", "pytest", *targets, "-m", "not postgres"]
+    # Continue past per-file collection errors so every collectable nodeid gets a
+    # terminal result; otherwise one bad file aborts the shard and leaves the
+    # rest result-less, which the #2457 failure-baseline completeness gate would
+    # (correctly) reject. Collection errors are still surfaced in the JUnit and
+    # hard-failed by the comparator (never baselined).
+    cmd.append("--continue-on-collection-errors")
     if args.parallel > 0:
         cmd.extend(["-n", str(args.parallel)])
     if args.reruns > 0:

--- a/scripts/run_extended_tests.py
+++ b/scripts/run_extended_tests.py
@@ -279,6 +279,20 @@ def print_collection_manifest(files: list[str]) -> None:
     print("=" * 40 + "\n")
 
 
+def _quarantine_nodeids() -> list[str]:
+    """Read quarantined nodeids from ci/legacy-issue-quarantine.json (may be absent)."""
+    import json
+
+    path = PROJECT_ROOT / "ci" / "legacy-issue-quarantine.json"
+    if not path.exists():
+        return []
+    try:
+        data = json.loads(path.read_text())
+    except (OSError, ValueError):
+        return []
+    return [e["nodeid"] for e in data.get("entries", []) if e.get("nodeid")]
+
+
 def build_pytest_command(args: argparse.Namespace) -> list[str]:
     targets = select_targets(args)
     targets = apply_split(targets, args.split_total, args.split_group)
@@ -300,6 +314,12 @@ def build_pytest_command(args: argparse.Namespace) -> list[str]:
     # (correctly) reject. Collection errors are still surfaced in the JUnit and
     # hard-failed by the comparator (never baselined).
     cmd.append("--continue-on-collection-errors")
+    # Deselect nodeids tracked in ci/legacy-issue-quarantine.json (e.g. a test
+    # that deadlocks the shard). The same list is read by the comparator, which
+    # excludes them from the expected-executed set and reports them as debt, so
+    # the deselect + the manifest stay consistent (local == CI).
+    for nodeid in _quarantine_nodeids():
+        cmd.extend(["--deselect", nodeid])
     if args.parallel > 0:
         cmd.extend(["-n", str(args.parallel)])
     if args.reruns > 0:

--- a/scripts/run_extended_tests.py
+++ b/scripts/run_extended_tests.py
@@ -279,18 +279,46 @@ def print_collection_manifest(files: list[str]) -> None:
     print("=" * 40 + "\n")
 
 
-def _quarantine_nodeids() -> list[str]:
-    """Read quarantined nodeids from ci/legacy-issue-quarantine.json (may be absent)."""
-    import json
+def _quarantine_nodeids(path=None) -> list[str]:
+    """Read quarantined nodeids from ci/legacy-issue-quarantine.json.
 
-    path = PROJECT_ROOT / "ci" / "legacy-issue-quarantine.json"
+    Fail-closed: a missing, corrupt, wrong-schema/version, or expired entry must
+    NOT silently fall back to "no quarantine" — that would re-run a known-
+    deadlocking nodeid and hang the shard for the full job timeout. Any error
+    raises SystemExit and aborts the run. Expiry is checked so a stale quarantine
+    cannot silently keep deselecting; full nodeid-collectability is enforced by
+    the comparator (same shared loader).
+    """
+    import datetime
+    import importlib.util
+
+    if path is None:
+        path = PROJECT_ROOT / "ci" / "legacy-issue-quarantine.json"
+    path = Path(path)
     if not path.exists():
-        return []
+        raise SystemExit(
+            "ci/legacy-issue-quarantine.json is missing; refusing to run the "
+            "issue shard without the tracked exclusions (would deadlock)."
+        )
     try:
-        data = json.loads(path.read_text())
-    except (OSError, ValueError):
-        return []
-    return [e["nodeid"] for e in data.get("entries", []) if e.get("nodeid")]
+        # Reuse the comparator's strict loader (schema + version + entry types).
+        spec = importlib.util.spec_from_file_location(
+            "_lib_baseline", str(PROJECT_ROOT / "scripts" / "legacy_issue_baseline.py")
+        )
+        assert spec and spec.loader
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules["_lib_baseline"] = mod  # register before exec (dataclasses PEP 563)
+        spec.loader.exec_module(mod)
+        entries = mod.load_quarantine(path)
+        today = datetime.date.today().isoformat()
+        invalid = mod.validate_quarantine(entries, (), today)
+        if invalid:
+            raise SystemExit("invalid ci/legacy-issue-quarantine.json:\n  " + "\n  ".join(invalid))
+    except SystemExit:
+        raise
+    except Exception as exc:  # corrupt JSON, wrong schema, parse error, ...
+        raise SystemExit(f"cannot load ci/legacy-issue-quarantine.json: {exc}") from exc
+    return [e.nodeid for e in entries]
 
 
 def build_pytest_command(args: argparse.Namespace) -> list[str]:

--- a/tests/issues/1469/test_extended_tests_runner.py
+++ b/tests/issues/1469/test_extended_tests_runner.py
@@ -140,3 +140,51 @@ def test_frontend_build_check_fails_fast_when_dist_is_missing(tmp_path, monkeypa
 
     with pytest.raises(RuntimeError, match="Frontend build is missing"):
         run_extended_tests.ensure_frontend_built("critical")
+
+
+def _write_q(tmp_path, obj):
+    p = tmp_path / "q.json"
+    import json
+
+    p.write_text(json.dumps(obj))
+    return p
+
+
+def test_quarantine_loader_missing_file_fails_closed(tmp_path):
+    with pytest.raises(SystemExit):
+        run_extended_tests._quarantine_nodeids(path=tmp_path / "missing.json")
+
+
+def test_quarantine_loader_corrupt_fails_closed(tmp_path):
+    p = tmp_path / "q.json"
+    p.write_text("{not json")
+    with pytest.raises(SystemExit):
+        run_extended_tests._quarantine_nodeids(path=p)
+
+
+def test_quarantine_loader_bad_schema_fails_closed(tmp_path):
+    p = _write_q(tmp_path, {"version": 1, "schema": "wrong", "entries": []})
+    with pytest.raises(SystemExit):
+        run_extended_tests._quarantine_nodeids(path=p)
+
+
+def test_quarantine_loader_expired_entry_fails_closed(tmp_path):
+    p = _write_q(
+        tmp_path,
+        {
+            "version": 1,
+            "schema": "openace-legacy-issue-quarantine",
+            "entries": [
+                {
+                    "nodeid": "tests/issues/604/t.py::a",
+                    "reason": "r",
+                    "owner": "o",
+                    "tracking_issue": "t",
+                    "exit_condition": "e",
+                    "expires_on": "2020-01-01",
+                }
+            ],
+        },
+    )
+    with pytest.raises(SystemExit):
+        run_extended_tests._quarantine_nodeids(path=p)

--- a/tests/issues/604/test_llm_proxy_handler_1060.py
+++ b/tests/issues/604/test_llm_proxy_handler_1060.py
@@ -283,6 +283,15 @@ class TestUpstreamQuotaExceededAlert:
             call_kwargs = mock_notifier.create_alert.call_args.kwargs
             assert call_kwargs["metadata"]["quota_type"] == "platform"
 
+    @pytest.mark.skip(
+        reason=(
+            "Hangs in a background-thread wait that pytest-timeout cannot terminate, "
+            "deadlocking the whole tests/issues shard and blocking the legacy failure "
+            "baseline capture (#2457 Phase D). This is a runner-deadlock, not a hidden "
+            "failure; tracked under #2429 debt cleanup. Remove the skip once the test is "
+            "fixed/migrated."
+        )
+    )
     @patch(_HTTP_PATH)
     @patch(_QUOTA_PATH)
     @patch(_PROXY_PATH)

--- a/tests/issues/604/test_llm_proxy_handler_1060.py
+++ b/tests/issues/604/test_llm_proxy_handler_1060.py
@@ -283,22 +283,21 @@ class TestUpstreamQuotaExceededAlert:
             call_kwargs = mock_notifier.create_alert.call_args.kwargs
             assert call_kwargs["metadata"]["quota_type"] == "platform"
 
-    @pytest.mark.skip(
-        reason=(
-            "Hangs in a background-thread wait that pytest-timeout cannot terminate, "
-            "deadlocking the whole tests/issues shard and blocking the legacy failure "
-            "baseline capture (#2457 Phase D). This is a runner-deadlock, not a hidden "
-            "failure; tracked under #2429 debt cleanup. Remove the skip once the test is "
-            "fixed/migrated."
-        )
-    )
     @patch(_HTTP_PATH)
     @patch(_QUOTA_PATH)
     @patch(_PROXY_PATH)
     def test_upstream_429_other_error_no_alert(
         self, mock_get_proxy, mock_quota_cls, mock_http, remote_app
     ):
-        """Upstream 429 without 'quota exceeded' should not trigger alert."""
+        """Upstream 429 without 'quota exceeded' should not trigger alert.
+
+        NOTE: this test deadlocks the remote LLM-proxy failover loop (production
+        bug, #2466). It is excluded from the nightly shard via
+        ci/legacy-issue-quarantine.json (deselected, not skipped) so the run can
+        complete; a weekly subprocess probe re-runs it to detect when #2466 is
+        fixed. Do NOT add a bare pytest.mark.skip here — the quarantine is the
+        tracked, gate-visible mechanism.
+        """
         # Setup mocks
         mock_proxy = MagicMock()
         mock_proxy.validate_proxy_token.return_value = _mock_proxy_token()

--- a/tests/issues/conftest.py
+++ b/tests/issues/conftest.py
@@ -1,0 +1,18 @@
+"""Conftest for the legacy ``tests/issues`` quarantine.
+
+Embeds the authoritative pytest nodeid into every JUnit report so the legacy
+failure-baseline comparator (``scripts/legacy_issue_baseline.py``) has a stable,
+path-based identity that does not depend on reconstructing it from xunit2
+``classname``/``name`` (xunit2 carries no ``file`` attribute).
+
+This is the MANDATORY identity source for baseline generation: a reference run
+must include this conftest. It is inert without ``--junitxml``
+(``record_property`` then only stores the value on the item).
+"""
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _openace_nodeid(request, record_property):
+    record_property("openace_nodeid", request.node.nodeid)

--- a/tests/unit/test_legacy_issue_baseline.py
+++ b/tests/unit/test_legacy_issue_baseline.py
@@ -739,3 +739,36 @@ def test_compare_reports_quarantined_as_debt(tmp_path):
     )
     assert r.exit_code == 0  # quarantined is debt, not a failure
     assert r.quarantined == q
+
+
+def test_unexpected_observed_nodeid_fails_closed():
+    # P1 (bidirectional): observed - expected must also fail (e.g. a quarantined
+    # nodeid that ran anyway, or a stale artifact).
+    parsed = [_tc_parsed("tests/issues/716/t.py::a"), _tc_parsed("tests/issues/716/t.py::extra")]
+    r = _compare([], parsed, ["tests/issues/716/t.py::a"])
+    assert r.exit_code != 0
+    assert any("unexpected observed nodeid" in i and "extra" in i for i in r.invalid)
+
+
+def test_load_exit_codes_rejects_duplicate_basename(tmp_path):
+    # P1: two paths with the same issues-N.exit-code basename must not last-write-win.
+    (tmp_path / "a").mkdir()
+    (tmp_path / "b").mkdir()
+    (tmp_path / "a" / "issues-1.exit-code").write_text("0")
+    (tmp_path / "b" / "issues-1.exit-code").write_text("1")
+    with pytest.raises(lib.BaselineError):
+        lib._load_exit_codes(str(tmp_path / "**" / "issues-*.exit-code"))
+
+
+def test_quarantine_bad_calendar_date_rejected():
+    # P1: 2026-99-99 matches the old shape regex but is not a real date.
+    bad = lib.QuarantineEntry("tests/issues/604/t.py::a", "r", "o", "t", "e", "2026-99-99")
+    inv = lib.validate_quarantine([bad], ["tests/issues/604/t.py::a"], "2026-08-10")
+    assert any("malformed expires_on" in i for i in inv)
+
+
+def test_load_quarantine_rejects_wrong_version(tmp_path):
+    p = tmp_path / "q.json"
+    p.write_text('{"version": 99, "schema": "openace-legacy-issue-quarantine", "entries": []}')
+    with pytest.raises(lib.BaselineError):
+        lib.load_quarantine(p)

--- a/tests/unit/test_legacy_issue_baseline.py
+++ b/tests/unit/test_legacy_issue_baseline.py
@@ -1,0 +1,453 @@
+"""Unit + contract tests for the legacy issue failure baseline comparator."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+SPEC = importlib.util.spec_from_file_location(
+    "legacy_issue_baseline", ROOT / "scripts" / "legacy_issue_baseline.py"
+)
+assert SPEC and SPEC.loader
+lib = importlib.util.module_from_spec(SPEC)
+# Register before exec so dataclasses can resolve PEP 563 string annotations.
+sys.modules["legacy_issue_baseline"] = lib
+SPEC.loader.exec_module(lib)
+
+FailureRecord = lib.FailureRecord
+ParsedTestcase = lib.ParsedTestcase
+Baseline = lib.Baseline
+BaselineError = lib.BaselineError
+
+
+def _write(tmp_path: Path, name: str, text: str) -> Path:
+    p = tmp_path / name
+    p.write_text(text)
+    return p
+
+
+# Minimal xunit2 XML builders -------------------------------------------------
+
+
+def _xml(
+    testcases: str, tests: int = 1, failures: int = 0, errors: int = 0, skipped: int = 0
+) -> str:
+    return (
+        '<?xml version="1.0" encoding="utf-8"?>'
+        f'<testsuites><testsuite name="pytest" tests="{tests}" failures="{failures}" '
+        f'errors="{errors}" skipped="{skipped}">{testcases}</testsuite></testsuites>'
+    )
+
+
+def _tc(
+    name: str,
+    classname: str = "tests.issues.716.test_x",
+    *,
+    failure: str = "",
+    error: str = "",
+    skipped: str = "",
+    nodeid_prop: str = "",
+) -> str:
+    props = ""
+    if nodeid_prop:
+        props = f'<properties><property name="openace_nodeid" value="{nodeid_prop}"/></properties>'
+    child = ""
+    if failure:
+        child = f'<failure message="{failure}" type="AssertionError">{failure}</failure>'
+    elif error:
+        etype, msg = error.split(":", 1) if ":" in error else (error, "")
+        child = f'<error message="{msg}" type="{etype}">{msg}</error>'
+    elif skipped:
+        child = f'<skipped message="{skipped}"/>'
+    return f'<testcase classname="{classname}" name="{name}">{props}{child}</testcase>'
+
+
+# --- Task 1: schema ---------------------------------------------------------
+
+
+def test_normalize_nodeid_strips_runner_root_and_anchors():
+    n = lib.normalize_nodeid(
+        "/home/runner/work/open-ace/open-ace/tests/issues/716/test_x.py::test_y",
+        runner_root="/home/runner/work/open-ace/open-ace",
+    )
+    assert n == "tests/issues/716/test_x.py::test_y"
+
+
+def test_normalize_nodeid_keeps_params():
+    assert lib.normalize_nodeid("tests/issues/716/test_x.py::test_y[1-2]").endswith("::test_y[1-2]")
+
+
+def test_failure_record_key():
+    r = FailureRecord("a::b", "716", "failure", "assertion_failure", "AssertionError", "x")
+    assert r.key == ("a::b", "failure", "assertion_failure")
+
+
+def test_baseline_byte_stable_roundtrip(tmp_path):
+    recs = [
+        FailureRecord("tests/issues/9/t.py::b", "9", "error", "setup_error", "E", "s"),
+        FailureRecord(
+            "tests/issues/716/t.py::a", "716", "failure", "assertion_failure", "AssertionError", "x"
+        ),
+    ]
+    b = Baseline(entries=recs, provenance={"reference_commit": "abc", "source_run": "1"})
+    s1 = b.to_json()
+    s2 = Baseline.from_json(s1).to_json()
+    assert s1 == s2
+    obj = json.loads(s1)
+    assert obj["entries"][0]["nodeid"].endswith("716/t.py::a")  # sorted
+    assert obj["version"] == lib.SCHEMA_VERSION
+    assert "/home/" not in s1 and "openace_nodeid" not in s1
+
+
+def test_baseline_rejects_unknown_schema():
+    bad = json.dumps({"version": 99, "schema": lib.SCHEMA_NAME, "entries": []})
+    with pytest.raises(BaselineError):
+        Baseline.from_json(bad)
+
+
+# --- Task 2: classify -------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "element,exc,msg,nodeid,has_prop,expected",
+    [
+        (
+            "failure",
+            "AssertionError",
+            "assert 1==2",
+            "tests/issues/716/t.py::a",
+            True,
+            "assertion_failure",
+        ),
+        ("failure", "ValueError", "bad", "tests/issues/716/t.py::a", True, "test_body_exception"),
+        (
+            "error",
+            "TimeoutError",
+            "timed out after 240s",
+            "tests/issues/716/t.py::a",
+            True,
+            "timeout",
+        ),
+        ("error", "Exception", "", "tests/issues/716/t.py::a", True, "setup_error"),
+        ("error", "Exception", "", "tests.issues.716.test_broken", False, "collection_error"),
+    ],
+)
+def test_classify(element, exc, msg, nodeid, has_prop, expected):
+    assert lib.classify(element, has_prop, exc, msg, nodeid) == expected
+
+
+def test_classify_collection_word_in_normal_test_is_not_collection_error():
+    assert (
+        lib.classify("error", True, "Exception", "collection", "tests/issues/716/t.py::test_a")
+        == "setup_error"
+    )
+
+
+# --- Task 3: junit parser ---------------------------------------------------
+
+
+def test_parse_prefers_nodeid_property(tmp_path):
+    xml = _xml(
+        _tc(
+            "test_a",
+            classname="tests.issues.716.test_x",
+            failure="boom",
+            nodeid_prop="tests/issues/716/test_x.py::test_a",
+        ),
+        tests=1,
+        failures=1,
+    )
+    tcs, totals = lib.parse_junit(_write(tmp_path, "a.xml", xml))
+    assert tcs[0].nodeid == "tests/issues/716/test_x.py::test_a"
+    assert tcs[0].outcome == "failure"
+
+
+def test_parse_reconstruction_class_and_param(tmp_path):
+    # no property -> reconstruct from classname+name
+    xml = _xml(
+        _tc("test_bar[1-2]", classname="tests.issues.716.test_x.TestFoo", failure="x"),
+        tests=1,
+        failures=1,
+    )
+    tcs, _ = lib.parse_junit(_write(tmp_path, "a.xml", xml))
+    assert tcs[0].nodeid == "tests/issues/716/test_x.py::TestFoo::test_bar[1-2]"
+
+
+def test_parse_reconstruction_plain(tmp_path):
+    xml = _xml(
+        _tc("test_a", classname="tests.issues.517.e2e_codex", failure="x"), tests=1, failures=1
+    )
+    tcs, _ = lib.parse_junit(_write(tmp_path, "a.xml", xml))
+    assert tcs[0].nodeid == "tests/issues/517/e2e_codex.py::test_a"
+
+
+def test_parse_collection_error_shape(tmp_path):
+    # verified real shape: empty classname, dotted module name, <error>, no property
+    xml = _xml(
+        '<testcase classname="" name="tests.issues.517.test_broken"><error message="" type="Exception"></error></testcase>',
+        tests=1,
+        errors=1,
+    )
+    tcs, _ = lib.parse_junit(_write(tmp_path, "a.xml", xml))
+    assert tcs[0].category == "collection_error"
+    assert tcs[0].nodeid == "tests/issues/517/test_broken.py"
+    assert tcs[0].as_failure() is not None and tcs[0].as_failure().category == "collection_error"
+
+
+def test_parse_rerun_then_fail_dedupes(tmp_path):
+    # two testcases same nodeid (rerun + final), duplicate property -> 1 record
+    body = _tc("test_a", failure="x", nodeid_prop="tests/issues/716/t.py::test_a") + _tc(
+        "test_a", failure="x", nodeid_prop="tests/issues/716/t.py::test_a"
+    )
+    xml = _xml(body, tests=1, failures=1)
+    tcs, _ = lib.parse_junit(_write(tmp_path, "a.xml", xml))
+    assert len(tcs) == 1
+
+
+def test_parse_rerun_then_pass_keeps_parsed_for_completeness(tmp_path):
+    # final attempt is a pass: 0 FailureRecords but the nodeid is still tracked
+    body = _tc("test_a", nodeid_prop="tests/issues/716/t.py::test_a")  # no failure -> pass
+    xml = _xml(body, tests=1)
+    tcs, _ = lib.parse_junit(_write(tmp_path, "a.xml", xml))
+    assert len(tcs) == 1
+    assert tcs[0].as_failure() is None
+    assert tcs[0].outcome == "pass"
+
+
+def test_parse_corrupt_xml_raises(tmp_path):
+    with pytest.raises(BaselineError):
+        lib.parse_junit(_write(tmp_path, "a.xml", "<not xml<"))
+
+
+def test_parse_empty_raises(tmp_path):
+    with pytest.raises(BaselineError):
+        lib.parse_junit(_write(tmp_path, "a.xml", _xml("", tests=0)))
+
+
+# --- Task 4: manifest -------------------------------------------------------
+
+
+def test_manifest_parser_drops_warnings_and_footer(monkeypatch):
+    fake_out = (
+        "tests/issues/716/t.py::test_a\n"
+        "tests/issues/716/t.py::test_b\n"
+        "warnings summary\n"
+        "  tests/issues/559/e2e_terminal_ws_handler.py:28: PytestWarning\n"
+        "    some message\n"
+        "4475 tests collected in 2.1s\n"
+    )
+    captured = {}
+
+    class _Proc:
+        stdout = fake_out
+
+    def fake_run(cmd, **kw):
+        captured["cmd"] = cmd
+        return _Proc()
+
+    monkeypatch.setattr(lib.subprocess, "run", fake_run)
+    em = lib.build_expected_manifest()
+    assert em.nodeids == ["tests/issues/716/t.py::test_a", "tests/issues/716/t.py::test_b"]
+    assert em.files == ["tests/issues/716/t.py"]
+    assert "-qq" in captured["cmd"]
+
+
+def test_manifest_smoke_real_collection():
+    em = lib.build_expected_manifest()
+    assert len(em.nodeids) > 0
+    assert all(n.startswith("tests/") and "::" in n for n in em.nodeids)
+
+
+# --- Task 5: compare --------------------------------------------------------
+
+
+def _fail(nodeid, outcome="failure", category="assertion_failure"):
+    return FailureRecord(
+        nodeid,
+        nodeid.split("/")[2] if "/issues/" in nodeid else "0",
+        outcome,
+        category,
+        "AssertionError",
+        "x",
+    )
+
+
+def _tc_parsed(nodeid, outcome="failure", category="assertion_failure"):
+    return ParsedTestcase(nodeid, outcome, category, "AssertionError", "x")
+
+
+def _compare(baseline_entries, parsed, expected, *, min_files=0, thr=0.0):
+    return lib.compare(
+        Baseline(entries=baseline_entries),
+        parsed,
+        expected,
+        baseline_min_files=min_files,
+        require_review_threshold_pct=thr,
+    )
+
+
+def test_known_only_succeeds():
+    r = _compare(
+        [_fail("tests/issues/716/t.py::a")],
+        [_tc_parsed("tests/issues/716/t.py::a")],
+        ["tests/issues/716/t.py::a"],
+    )
+    assert r.exit_code == 0 and r.known and not r.new and not r.resolved
+
+
+def test_new_failure_fails():
+    r = _compare([], [_tc_parsed("tests/issues/716/t.py::b")], ["tests/issues/716/t.py::b"])
+    assert r.exit_code != 0 and r.new
+
+
+def test_changed_not_also_in_new():
+    base = [_fail("tests/issues/716/t.py::a", "error", "setup_error")]
+    cur = [_tc_parsed("tests/issues/716/t.py::a", "failure", "assertion_failure")]
+    r = _compare(base, cur, ["tests/issues/716/t.py::a"])
+    assert r.exit_code != 0 and r.changed
+    assert all(d["nodeid"] != "tests/issues/716/t.py::a" for d in r.new)
+
+
+def test_resolved_rerun_pass_or_deleted_forces_shrink():
+    # baselined failure now passes -> ParsedTestcase outcome=pass, no current failure -> resolved
+    r = _compare(
+        [_fail("tests/issues/716/t.py::a")],
+        [ParsedTestcase("tests/issues/716/t.py::a", "pass", "pass", "", "")],
+        ["tests/issues/716/t.py::a"],
+    )
+    assert r.exit_code != 0 and r.resolved == ["tests/issues/716/t.py::a"]
+
+
+def test_collection_error_always_fails_even_if_baselined():
+    base = [_fail("tests/issues/716/test_m.py", "error", "collection_error")]
+    cur = [_tc_parsed("tests/issues/716/test_m.py", "error", "collection_error")]
+    r = _compare(base, cur, ["tests/issues/716/test_m.py"])
+    assert r.exit_code != 0 and r.collection_errors
+
+
+def test_incomplete_coverage_fails():
+    r = _compare([], [], ["tests/issues/716/t.py::missing"])
+    assert r.exit_code != 0 and r.invalid
+
+
+def test_zero_reports_message():
+    r = _compare([], [], ["tests/issues/716/t.py::a"])
+    assert r.exit_code != 0
+    assert any("no JUnit reports" in i or "never observed" in i for i in r.invalid)
+
+
+def test_file_count_regression_fails():
+    parsed = [_tc_parsed(f"tests/issues/716/t.py::t{i}") for i in range(5)]
+    expected = [f"tests/issues/716/t.py::t{i}" for i in range(5)]
+    r = _compare([], parsed, expected, min_files=430, thr=10.0)
+    assert r.exit_code != 0 and any("below floor" in i for i in r.invalid)
+
+
+def test_conflict_same_key_different_summary_rejected():
+    a = ParsedTestcase(
+        "tests/issues/716/t.py::a", "failure", "assertion_failure", "AssertionError", "S1"
+    )
+    b = ParsedTestcase(
+        "tests/issues/716/t.py::a", "failure", "assertion_failure", "AssertionError", "S2"
+    )
+    r = _compare([], [a, b], ["tests/issues/716/t.py::a"])
+    assert r.exit_code != 0 and any("conflict" in i for i in r.invalid)
+
+
+def test_identical_dups_dedupe():
+    parsed = [_tc_parsed("tests/issues/716/t.py::a"), _tc_parsed("tests/issues/716/t.py::a")]
+    r = _compare([], parsed, ["tests/issues/716/t.py::a"])
+    # two identical records collapse to one (no conflict); with empty baseline it is one 'new'
+    assert len(r.new) == 1 and not r.invalid
+
+
+# --- Task 6: cli ------------------------------------------------------------
+
+
+def test_cli_compare_known_only_exits_zero(tmp_path, monkeypatch):
+    junit = _xml(
+        _tc("test_a", failure="boom", nodeid_prop="tests/issues/716/t.py::test_a"),
+        tests=1,
+        failures=1,
+    )
+    jp = _write(tmp_path, "issues-1.xml", junit)
+    baseline = Baseline(
+        entries=[
+            FailureRecord(
+                "tests/issues/716/t.py::test_a",
+                "716",
+                "failure",
+                "assertion_failure",
+                "AssertionError",
+                "boom",
+            )
+        ]
+    )
+    bp = _write(tmp_path, "baseline.json", baseline.to_json())
+    monkeypatch.setattr(
+        lib,
+        "build_expected_manifest",
+        lambda *a, **k: lib.ExpectedManifest(
+            ["tests/issues/716/t.py::test_a"], ["tests/issues/716/t.py"], "not postgres", False
+        ),
+    )
+    rc = lib.main(
+        [
+            "compare",
+            "--baseline",
+            str(bp),
+            "--junit",
+            str(jp),
+            "--test-baseline",
+            str(
+                _write(
+                    tmp_path,
+                    "tb.json",
+                    json.dumps(
+                        {
+                            "layers": {"issues": {"min_files": 1}},
+                            "tolerance": {"require_review_threshold": 10},
+                        }
+                    ),
+                )
+            ),
+            "--json-output",
+            str(tmp_path / "diff.json"),
+            "--markdown-output",
+            str(tmp_path / "sum.md"),
+        ]
+    )
+    assert rc == 0
+    assert json.loads((tmp_path / "diff.json").read_text())["exit_code"] == 0
+
+
+def test_cli_snapshot_refuses_collection_errors(tmp_path):
+    junit = _xml(
+        '<testcase classname="" name="tests.issues.716.test_broken"><error type="Exception"></error></testcase>',
+        tests=1,
+        errors=1,
+    )
+    jp = _write(tmp_path, "issues-1.xml", junit)
+    rc = lib.main(["snapshot", "--junit", str(jp), "--output", str(tmp_path / "out.json")])
+    assert rc == 2
+    assert not (tmp_path / "out.json").exists()
+
+
+def test_cli_snapshot_writes_baseline(tmp_path, monkeypatch):
+    junit = _xml(
+        _tc("test_a", failure="boom", nodeid_prop="tests/issues/716/t.py::test_a"),
+        tests=1,
+        failures=1,
+    )
+    jp = _write(tmp_path, "issues-1.xml", junit)
+    out = tmp_path / "out.json"
+    rc = lib.main(["snapshot", "--junit", str(jp), "--output", str(out), "--source-run", "123"])
+    assert rc == 0
+    b = Baseline.from_json(out.read_text())
+    assert len(b.entries) == 1
+    assert b.provenance["source_run"] == "123"

--- a/tests/unit/test_legacy_issue_baseline.py
+++ b/tests/unit/test_legacy_issue_baseline.py
@@ -795,3 +795,139 @@ def test_quarantine_invalid_probe_outcome_rejected():
         "tests/issues/604/t.py::a", "r", "o", "t", "e", "2099-01-01", "timeout"
     )
     assert lib.validate_quarantine([good], ["tests/issues/604/t.py::a"], "2026-08-10") == []
+
+
+def test_quarantine_probe_outcome_schema_is_timeout_only():
+    # P1: only "timeout" is a green-able probe outcome. "pass" would let a
+    # recovered test stay permanently deselected + always green; "fail" would
+    # lump pytest rc 2-5/no-tests/usage with rc=1. Both must be rejected.
+    for forbidden in ("pass", "fail"):
+        entry = lib.QuarantineEntry(
+            "tests/issues/604/t.py::a", "r", "o", "t", "e", "2099-01-01", forbidden
+        )
+        inv = lib.validate_quarantine([entry], ["tests/issues/604/t.py::a"], "2026-08-10")
+        assert any("invalid expected_probe_outcome" in i for i in inv), forbidden
+    assert lib.PROBE_OUTCOMES == ("timeout",)
+
+
+def test_snapshot_generated_command_is_complete_and_round_trips(tmp_path, monkeypatch):
+    # P1: generated_command must be parameter-complete (incl. --output, which is
+    # argparse-required) and round-trip through build_parser, so copying it from
+    # the baseline actually reproduces the snapshot.
+    junit = _xml(
+        _tc("test_a", failure="boom", nodeid_prop="tests/issues/716/t.py::test_a"),
+        tests=1,
+        failures=1,
+    )
+    jp = _write(tmp_path, "issues-1.xml", junit)
+    out = tmp_path / "out.json"
+    tb = _write(tmp_path, "tb.json", json.dumps({"layers": {"issues": {"min_files": 0}}}))
+    # The quarantine references a DIFFERENT nodeid that was deselected at run
+    # time (so it never appears in observed JUnit) — mirroring the real 604 flow.
+    q = _write(
+        tmp_path,
+        "q.json",
+        json.dumps(
+            {
+                "version": 1,
+                "schema": "openace-legacy-issue-quarantine",
+                "entries": [
+                    {
+                        "nodeid": "tests/issues/604/t.py::test_deadlocked",
+                        "reason": "r",
+                        "owner": "o",
+                        "tracking_issue": "t",
+                        "exit_condition": "e",
+                        "expires_on": "2099-01-01",
+                        "expected_probe_outcome": "timeout",
+                    }
+                ],
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        lib,
+        "build_expected_manifest",
+        lambda *a, **k: lib.ExpectedManifest(
+            ["tests/issues/716/t.py::test_a", "tests/issues/604/t.py::test_deadlocked"],
+            ["tests/issues/716/t.py", "tests/issues/604/t.py"],
+            "not postgres",
+            False,
+        ),
+    )
+    rc = lib.main(
+        [
+            "snapshot",
+            "--junit",
+            str(jp),
+            "--output",
+            str(out),
+            "--test-baseline",
+            str(tb),
+            "--shard-count",
+            "0",
+            "--quarantine",
+            str(q),
+            "--source-run",
+            "31359257263",
+            "--source-run-url",
+            "https://github.com/open-ace/open-ace/actions/runs/31359257263",
+            "--reference-commit",
+            "56a165ab08fd77fc560398984763dc671e8f05b2",
+            "--run-contract",
+            "4 shards; quarantined",
+        ]
+    )
+    assert rc == 0
+    gen = Baseline.from_json(out.read_text()).provenance["generated_command"]
+    # Round-trip: the recorded command must parse back through build_parser.
+    argv = lib.shlex.split(gen)[2:]  # drop "python scripts/legacy_issue_baseline.py"
+    parsed = lib.build_parser().parse_args(argv)
+    assert parsed.output  # --output present (argparse-required) and non-empty
+    assert parsed.source_run == "31359257263"
+    assert parsed.reference_commit == "56a165ab08fd77fc560398984763dc671e8f05b2"
+    assert parsed.source_run_url.endswith(parsed.source_run)
+    # The recorded output is the repo-relative/normalized form of the arg.
+    assert parsed.output == lib._repo_relative(str(out))
+
+
+def test_repo_relative_normalizes_repo_paths_only():
+    # Paths under the repo are relativized (no local checkout path leaks into the
+    # canonical command); paths outside the repo are left as-is (absolute).
+    assert lib._repo_relative(str(ROOT / "ci" / "x.json")) == "ci/x.json"
+    assert lib._repo_relative(str(ROOT / ".test-baseline.json")) == ".test-baseline.json"
+    outside = "/elsewhere/not/in/repo/x.json" if ROOT.as_posix() != "/" else "/outside/x.json"
+    assert lib._repo_relative(outside) == outside
+
+
+def test_committed_baseline_provenance_is_consistent_and_round_trips():
+    # P1: the SHIPPED baseline's provenance must be internally consistent
+    # (run URL/ID agree, reference_commit present) and its generated_command
+    # must round-trip through build_parser and equal what the code regenerates
+    # from the recorded params.
+    baseline_path = ROOT / "ci" / "legacy-issue-failures.json"
+    pv = json.loads(baseline_path.read_text())["provenance"]
+    assert pv["source_run_url"].endswith(pv["source_run"]), "run URL must match run id"
+    assert pv["reference_commit"], "reference_commit must be recorded"
+    gen = pv["generated_command"]
+    parsed = lib.build_parser().parse_args(lib.shlex.split(gen)[2:])
+    assert parsed.output == "ci/legacy-issue-failures.json"
+    assert parsed.source_run == pv["source_run"]
+    assert parsed.reference_commit == pv["reference_commit"]
+    assert parsed.source_run_url == pv["source_run_url"]
+    # Regenerating from the recorded params reproduces the exact command, so the
+    # shipped provenance is not hand-divergent from the generator.
+    args = lib.argparse.Namespace(
+        junit="artifacts/test-results/issues-*.xml",
+        output=parsed.output,
+        manifest=parsed.manifest,
+        test_baseline=parsed.test_baseline,
+        exit_code_glob=parsed.exit_code_glob,
+        quarantine=parsed.quarantine,
+        shard_count=parsed.shard_count,
+        source_run=parsed.source_run,
+        source_run_url=parsed.source_run_url,
+        reference_commit=parsed.reference_commit,
+        run_contract=parsed.run_contract,
+    )
+    assert lib._snapshot_generated_command(args) == gen

--- a/tests/unit/test_legacy_issue_baseline.py
+++ b/tests/unit/test_legacy_issue_baseline.py
@@ -114,36 +114,42 @@ def test_baseline_rejects_unknown_schema():
 
 
 @pytest.mark.parametrize(
-    "element,exc,msg,nodeid,has_prop,expected",
+    "element,exc,msg,nodeid,expected",
     [
         (
             "failure",
             "AssertionError",
             "assert 1==2",
             "tests/issues/716/t.py::a",
-            True,
             "assertion_failure",
         ),
-        ("failure", "ValueError", "bad", "tests/issues/716/t.py::a", True, "test_body_exception"),
+        ("failure", "ValueError", "bad", "tests/issues/716/t.py::a", "test_body_exception"),
         (
             "error",
             "TimeoutError",
             "timed out after 240s",
             "tests/issues/716/t.py::a",
-            True,
             "timeout",
         ),
-        ("error", "Exception", "", "tests/issues/716/t.py::a", True, "setup_error"),
-        ("error", "Exception", "", "tests.issues.716.test_broken", False, "collection_error"),
+        ("error", "Exception", "", "tests/issues/716/t.py::a", "setup_error"),
+        # setup error lacking the openace_nodeid property must NOT be collection_error
+        (
+            "error",
+            "Exception",
+            "failed on setup",
+            "tests/issues/144/e2e_x.py::test_a",
+            "setup_error",
+        ),
+        ("error", "Exception", "", "tests.issues.716.test_broken", "collection_error"),
     ],
 )
-def test_classify(element, exc, msg, nodeid, has_prop, expected):
-    assert lib.classify(element, has_prop, exc, msg, nodeid) == expected
+def test_classify(element, exc, msg, nodeid, expected):
+    assert lib.classify(element, exc, msg, nodeid) == expected
 
 
 def test_classify_collection_word_in_normal_test_is_not_collection_error():
     assert (
-        lib.classify("error", True, "Exception", "collection", "tests/issues/716/t.py::test_a")
+        lib.classify("error", "Exception", "collection", "tests/issues/716/t.py::test_a")
         == "setup_error"
     )
 
@@ -227,6 +233,21 @@ def test_parse_corrupt_xml_raises(tmp_path):
 def test_parse_empty_raises(tmp_path):
     with pytest.raises(BaselineError):
         lib.parse_junit(_write(tmp_path, "a.xml", _xml("", tests=0)))
+
+
+def test_parse_summary_scrubs_runner_paths_and_ports(tmp_path):
+    body = (
+        '<testcase classname="tests.issues.1071.test_x" name="test_a">'
+        '<properties><property name="openace_nodeid" value="tests/issues/1071/test_x.py::test_a"/></properties>'
+        '<failure message="AttributeError from /home/runner/work/open-ace/open-ace/app/routes/workspace.py at localhost:19888" type="AttributeError"></failure>'
+        "</testcase>"
+    )
+    xml = _xml(body, tests=1, failures=1)
+    tcs, _ = lib.parse_junit(_write(tmp_path, "a.xml", xml))
+    assert "/home/runner" not in tcs[0].summary
+    assert "localhost:19888" not in tcs[0].summary
+    assert "app/routes/workspace.py" in tcs[0].summary  # repo-relative retained
+    assert "<host:port>" in tcs[0].summary
 
 
 # --- Task 4: manifest -------------------------------------------------------

--- a/tests/unit/test_legacy_issue_baseline.py
+++ b/tests/unit/test_legacy_issue_baseline.py
@@ -469,6 +469,8 @@ def test_cli_compare_known_only_exits_zero(tmp_path, monkeypatch):
             str(tmp_path / "sum.md"),
             "--shard-count",
             "0",
+            "--quarantine",
+            str(tmp_path / "none.json"),
         ]
     )
     assert rc == 0
@@ -516,6 +518,8 @@ def test_cli_snapshot_writes_baseline(tmp_path, monkeypatch):
             str(tb),
             "--shard-count",
             "0",
+            "--quarantine",
+            str(tmp_path / "none.json"),
             "--source-run",
             "123",
         ]
@@ -599,6 +603,8 @@ def test_compare_creates_output_parent_dirs(tmp_path, monkeypatch):
             str(nested),
             "--shard-count",
             "0",
+            "--quarantine",
+            str(tmp_path / "none.json"),
         ]
     )
     assert rc == 0
@@ -678,3 +684,58 @@ def test_exit_code_cardinality_enforced(tmp_path):
     # exactly 4, all 0/1 -> pass (known-only)
     r = _res({f"issues-{i}.exit-code": (0 if i % 2 else 1) for i in range(1, 5)})
     assert r.exit_code == 0
+
+
+def _q(nodeid="tests/issues/604/t.py::a", expires="2099-01-01"):
+    return lib.QuarantineEntry(nodeid, "r", "o", "https://t", "exit", expires)
+
+
+def test_quarantine_valid_entry_passs():
+    inv = lib.validate_quarantine([_q()], ["tests/issues/604/t.py::a"], "2026-08-10")
+    assert inv == []
+
+
+def test_quarantine_expired_fails_closed():
+    inv = lib.validate_quarantine(
+        [_q(expires="2020-01-01")], ["tests/issues/604/t.py::a"], "2026-08-10"
+    )
+    assert any("expired" in i for i in inv)
+
+
+def test_quarantine_uncollectable_fails_closed():
+    inv = lib.validate_quarantine(
+        [_q(nodeid="tests/issues/604/t.py::gone")], ["tests/issues/604/t.py::a"], "2026-08-10"
+    )
+    assert any("no longer collectable" in i for i in inv)
+
+
+def test_quarantine_duplicate_and_missing_fields():
+    inv = lib.validate_quarantine(
+        [_q(), _q()],
+        ["tests/issues/604/t.py::a"],
+        "2026-08-10",
+    )
+    assert any("duplicated" in i for i in inv)
+    bad = lib.QuarantineEntry("tests/issues/604/t.py::a", "", "o", "t", "exit", "2099-01-01")
+    inv2 = lib.validate_quarantine([bad], ["tests/issues/604/t.py::a"], "2026-08-10")
+    assert any("missing field" in i for i in inv2)
+
+
+def test_compare_reports_quarantined_as_debt(tmp_path):
+    parsed = [_tc_parsed("tests/issues/716/t.py::a")]
+    base = Baseline(entries=[_fail("tests/issues/716/t.py::a")])
+    q = [
+        {
+            "nodeid": "tests/issues/604/t.py::x",
+            "reason": "deadlock",
+            "owner": "o",
+            "tracking_issue": "t",
+            "exit_condition": "e",
+            "expires_on": "2099-01-01",
+        }
+    ]
+    r = lib.compare(
+        base, parsed, ["tests/issues/716/t.py::a"], quarantined=q, expected_shard_count=0
+    )
+    assert r.exit_code == 0  # quarantined is debt, not a failure
+    assert r.quarantined == q

--- a/tests/unit/test_legacy_issue_baseline.py
+++ b/tests/unit/test_legacy_issue_baseline.py
@@ -205,14 +205,15 @@ def test_parse_collection_error_shape(tmp_path):
     assert tcs[0].as_failure() is not None and tcs[0].as_failure().category == "collection_error"
 
 
-def test_parse_rerun_then_fail_dedupes(tmp_path):
-    # two testcases same nodeid (rerun + final), duplicate property -> 1 record
+def test_parse_does_not_dedupe_duplicates(tmp_path):
+    # parse_junit returns ALL testcases; dedup/conflict detection is compare()'s
+    # job (never last-write-wins at parse time).
     body = _tc("test_a", failure="x", nodeid_prop="tests/issues/716/t.py::test_a") + _tc(
         "test_a", failure="x", nodeid_prop="tests/issues/716/t.py::test_a"
     )
     xml = _xml(body, tests=1, failures=1)
     tcs, _ = lib.parse_junit(_write(tmp_path, "a.xml", xml))
-    assert len(tcs) == 1
+    assert len(tcs) == 2
 
 
 def test_parse_rerun_then_pass_keeps_parsed_for_completeness(tmp_path):
@@ -266,6 +267,7 @@ def test_manifest_parser_drops_warnings_and_footer(monkeypatch):
 
     class _Proc:
         stdout = fake_out
+        returncode = 0
 
     def fake_run(cmd, **kw):
         captured["cmd"] = cmd
@@ -380,11 +382,13 @@ def test_conflict_same_key_different_summary_rejected():
     assert r.exit_code != 0 and any("conflict" in i for i in r.invalid)
 
 
-def test_identical_dups_dedupe():
+def test_duplicate_nodeids_flagged_as_conflict():
+    # P1#5: never last-write-wins. A nodeid appearing twice (even identically)
+    # is a cross-shard/rerun anomaly and must be flagged, not silently deduped.
     parsed = [_tc_parsed("tests/issues/716/t.py::a"), _tc_parsed("tests/issues/716/t.py::a")]
     r = _compare([], parsed, ["tests/issues/716/t.py::a"])
-    # two identical records collapse to one (no conflict); with empty baseline it is one 'new'
-    assert len(r.new) == 1 and not r.invalid
+    assert r.exit_code != 0
+    assert any("duplicate nodeid" in i for i in r.invalid)
 
 
 def test_multi_key_per_nodeid_rejected():
@@ -489,8 +493,158 @@ def test_cli_snapshot_writes_baseline(tmp_path, monkeypatch):
     )
     jp = _write(tmp_path, "issues-1.xml", junit)
     out = tmp_path / "out.json"
-    rc = lib.main(["snapshot", "--junit", str(jp), "--output", str(out), "--source-run", "123"])
+    tb = _write(tmp_path, "tb.json", json.dumps({"layers": {"issues": {"min_files": 0}}}))
+    # snapshot requires a complete reference run; stub the expected manifest so
+    # the single testcase satisfies completeness.
+    monkeypatch.setattr(
+        lib,
+        "build_expected_manifest",
+        lambda *a, **k: lib.ExpectedManifest(
+            ["tests/issues/716/t.py::test_a"], ["tests/issues/716/t.py"], "not postgres", False
+        ),
+    )
+    rc = lib.main(
+        [
+            "snapshot",
+            "--junit",
+            str(jp),
+            "--output",
+            str(out),
+            "--test-baseline",
+            str(tb),
+            "--source-run",
+            "123",
+        ]
+    )
     assert rc == 0
     b = Baseline.from_json(out.read_text())
     assert len(b.entries) == 1
     assert b.provenance["source_run"] == "123"
+
+
+def test_cli_snapshot_refuses_partial_run(tmp_path, monkeypatch):
+    # P0#2: snapshot must refuse a reference run missing expected nodeids.
+    junit = _xml(
+        _tc("test_a", failure="boom", nodeid_prop="tests/issues/716/t.py::test_a"),
+        tests=1,
+        failures=1,
+    )
+    jp = _write(tmp_path, "issues-1.xml", junit)
+    out = tmp_path / "out.json"
+    monkeypatch.setattr(
+        lib,
+        "build_expected_manifest",
+        lambda *a, **k: lib.ExpectedManifest(
+            ["tests/issues/716/t.py::test_a", "tests/issues/716/t.py::missing"],
+            ["tests/issues/716/t.py"],
+            "not postgres",
+            False,
+        ),
+    )
+    rc = lib.main(["snapshot", "--junit", str(jp), "--output", str(out)])
+    assert rc == 2
+    assert not out.exists()
+
+
+def test_compare_creates_output_parent_dirs(tmp_path, monkeypatch):
+    # P0#1: writing into a non-existent test-results/ must not FileNotFoundError.
+    junit = _xml(
+        _tc("test_a", failure="boom", nodeid_prop="tests/issues/716/t.py::test_a"),
+        tests=1,
+        failures=1,
+    )
+    jp = _write(tmp_path, "issues-1.xml", junit)
+    baseline = Baseline(
+        entries=[
+            FailureRecord(
+                "tests/issues/716/t.py::test_a",
+                "716",
+                "failure",
+                "assertion_failure",
+                "AssertionError",
+                "boom",
+            )
+        ]
+    )
+    bp = _write(tmp_path, "baseline.json", baseline.to_json())
+    tb = _write(
+        tmp_path,
+        "tb.json",
+        json.dumps(
+            {"layers": {"issues": {"min_files": 1}}, "tolerance": {"require_review_threshold": 10}}
+        ),
+    )
+    monkeypatch.setattr(
+        lib,
+        "build_expected_manifest",
+        lambda *a, **k: lib.ExpectedManifest(
+            ["tests/issues/716/t.py::test_a"], ["tests/issues/716/t.py"], "not postgres", False
+        ),
+    )
+    nested = tmp_path / "nested" / "sub" / "diff.json"
+    rc = lib.main(
+        [
+            "compare",
+            "--baseline",
+            str(bp),
+            "--junit",
+            str(jp),
+            "--test-baseline",
+            str(tb),
+            "--json-output",
+            str(nested),
+        ]
+    )
+    assert rc == 0
+    assert nested.exists()
+
+
+def test_manifest_fail_closed_on_nonzero_returncode(monkeypatch):
+    # P1#6: partial collection (non-zero exit) must fail closed even if some
+    # nodeids were parsed.
+    class _Proc:
+        stdout = "tests/issues/716/t.py::test_a\n"
+        returncode = 2
+
+    monkeypatch.setattr(lib.subprocess, "run", lambda *a, **k: _Proc())
+    with pytest.raises(lib.BaselineError):
+        lib.build_expected_manifest()
+
+
+def test_exception_type_extracted_from_message(tmp_path):
+    # P1#7: xunit2 omits type; recover it from the message form.
+    body = (
+        '<testcase classname="tests.issues.1071.t" name="test_a">'
+        '<properties><property name="openace_nodeid" value="tests/issues/1071/t.py::test_a"/></properties>'
+        '<failure message="app.utils.tenant_resolver.TenantResolutionError: cannot resolve" >tb</failure>'
+        "</testcase>"
+    )
+    tcs, _ = lib.parse_junit(_write(tmp_path, "a.xml", _xml(body, tests=1, failures=1)))
+    assert tcs[0].exception_type == "TenantResolutionError"
+    assert tcs[0].category == "test_body_exception"
+
+
+def test_exception_type_assertion_from_message(tmp_path):
+    body = (
+        '<testcase classname="tests.issues.716.t" name="test_a">'
+        '<properties><property name="openace_nodeid" value="tests/issues/716/t.py::test_a"/></properties>'
+        '<failure message="assert 1 == 2">tb</failure>'
+        "</testcase>"
+    )
+    tcs, _ = lib.parse_junit(_write(tmp_path, "a.xml", _xml(body, tests=1, failures=1)))
+    assert tcs[0].exception_type == "AssertionError"
+    assert tcs[0].category == "assertion_failure"
+
+
+def test_compare_infra_exit_code_fails_closed(tmp_path):
+    # P1#4: a shard pytest exit code of 2/3/4/5 (infrastructure) must fail even
+    # if the XML looks whole.
+    parsed = [_tc_parsed("tests/issues/716/t.py::a")]
+    r = lib.compare(
+        Baseline(entries=[_fail("tests/issues/716/t.py::a")]),
+        parsed,
+        ["tests/issues/716/t.py::a"],
+        exit_codes={"issues-2.exit-code": 2},
+    )
+    assert r.exit_code != 0
+    assert any("exited 2" in i for i in r.invalid)

--- a/tests/unit/test_legacy_issue_baseline.py
+++ b/tests/unit/test_legacy_issue_baseline.py
@@ -687,7 +687,7 @@ def test_exit_code_cardinality_enforced(tmp_path):
 
 
 def _q(nodeid="tests/issues/604/t.py::a", expires="2099-01-01"):
-    return lib.QuarantineEntry(nodeid, "r", "o", "https://t", "exit", expires)
+    return lib.QuarantineEntry(nodeid, "r", "o", "https://t", "exit", expires, "timeout")
 
 
 def test_quarantine_valid_entry_passs():
@@ -716,7 +716,9 @@ def test_quarantine_duplicate_and_missing_fields():
         "2026-08-10",
     )
     assert any("duplicated" in i for i in inv)
-    bad = lib.QuarantineEntry("tests/issues/604/t.py::a", "", "o", "t", "exit", "2099-01-01")
+    bad = lib.QuarantineEntry(
+        "tests/issues/604/t.py::a", "", "o", "t", "exit", "2099-01-01", "timeout"
+    )
     inv2 = lib.validate_quarantine([bad], ["tests/issues/604/t.py::a"], "2026-08-10")
     assert any("missing field" in i for i in inv2)
 
@@ -762,7 +764,9 @@ def test_load_exit_codes_rejects_duplicate_basename(tmp_path):
 
 def test_quarantine_bad_calendar_date_rejected():
     # P1: 2026-99-99 matches the old shape regex but is not a real date.
-    bad = lib.QuarantineEntry("tests/issues/604/t.py::a", "r", "o", "t", "e", "2026-99-99")
+    bad = lib.QuarantineEntry(
+        "tests/issues/604/t.py::a", "r", "o", "t", "e", "2026-99-99", "timeout"
+    )
     inv = lib.validate_quarantine([bad], ["tests/issues/604/t.py::a"], "2026-08-10")
     assert any("malformed expires_on" in i for i in inv)
 
@@ -772,3 +776,22 @@ def test_load_quarantine_rejects_wrong_version(tmp_path):
     p.write_text('{"version": 99, "schema": "openace-legacy-issue-quarantine", "entries": []}')
     with pytest.raises(lib.BaselineError):
         lib.load_quarantine(p)
+
+
+def test_scrub_strips_toolcache_python_binary():
+    # P1: runner-specific /opt/hostedtoolcache/.../bin/python must not leak.
+    s = lib._scrub_env("from /opt/hostedtoolcache/Python/3.11.15/x64/bin/python -m pytest")
+    assert "/opt/hostedtoolcache" not in s and "bin/python" not in s
+    assert "python" in s
+
+
+def test_quarantine_invalid_probe_outcome_rejected():
+    bad = lib.QuarantineEntry(
+        "tests/issues/604/t.py::a", "r", "o", "t", "e", "2099-01-01", "explodes"
+    )
+    inv = lib.validate_quarantine([bad], ["tests/issues/604/t.py::a"], "2026-08-10")
+    assert any("invalid expected_probe_outcome" in i for i in inv)
+    good = lib.QuarantineEntry(
+        "tests/issues/604/t.py::a", "r", "o", "t", "e", "2099-01-01", "timeout"
+    )
+    assert lib.validate_quarantine([good], ["tests/issues/604/t.py::a"], "2026-08-10") == []

--- a/tests/unit/test_legacy_issue_baseline.py
+++ b/tests/unit/test_legacy_issue_baseline.py
@@ -366,6 +366,28 @@ def test_identical_dups_dedupe():
     assert len(r.new) == 1 and not r.invalid
 
 
+def test_multi_key_per_nodeid_rejected():
+    # a single nodeid carrying two different (outcome,category) keys must not be
+    # silently collapsed (would let a resolved/changed entry drop silently)
+    a = ParsedTestcase("tests/issues/716/t.py::a", "failure", "assertion_failure", "E", "s")
+    b = ParsedTestcase("tests/issues/716/t.py::a", "error", "setup_error", "E2", "s2")
+    r = _compare([], [a, b], ["tests/issues/716/t.py::a"])
+    assert r.exit_code != 0 and any("multiple failure keys" in i for i in r.invalid)
+
+
+def test_targeted_run_marked_invalid_not_full_gate():
+    parsed = [_tc_parsed("tests/issues/716/t.py::a")]
+    r = lib.compare(
+        Baseline(entries=[]),
+        parsed,
+        ["tests/issues/716/t.py::a"],
+        baseline_min_files=0,
+        require_review_threshold_pct=0.0,
+        targeted=True,
+    )
+    assert r.exit_code != 0 and any("targeted run" in i for i in r.invalid)
+
+
 # --- Task 6: cli ------------------------------------------------------------
 
 

--- a/tests/unit/test_legacy_issue_baseline.py
+++ b/tests/unit/test_legacy_issue_baseline.py
@@ -467,6 +467,8 @@ def test_cli_compare_known_only_exits_zero(tmp_path, monkeypatch):
             str(tmp_path / "diff.json"),
             "--markdown-output",
             str(tmp_path / "sum.md"),
+            "--shard-count",
+            "0",
         ]
     )
     assert rc == 0
@@ -512,6 +514,8 @@ def test_cli_snapshot_writes_baseline(tmp_path, monkeypatch):
             str(out),
             "--test-baseline",
             str(tb),
+            "--shard-count",
+            "0",
             "--source-run",
             "123",
         ]
@@ -593,6 +597,8 @@ def test_compare_creates_output_parent_dirs(tmp_path, monkeypatch):
             str(tb),
             "--json-output",
             str(nested),
+            "--shard-count",
+            "0",
         ]
     )
     assert rc == 0
@@ -648,3 +654,27 @@ def test_compare_infra_exit_code_fails_closed(tmp_path):
     )
     assert r.exit_code != 0
     assert any("exited 2" in i for i in r.invalid)
+
+
+def test_exit_code_cardinality_enforced(tmp_path):
+    # P1#4/P0#2: with expected_shard_count=4, exactly issues-{1..4}.exit-code are
+    # required; 0/1/3 files, wrong names, and 2-5 codes all fail closed.
+    parsed = [_tc_parsed("tests/issues/716/t.py::a")]
+    base = Baseline(entries=[_fail("tests/issues/716/t.py::a")])
+    exp = ["tests/issues/716/t.py::a"]
+
+    def _res(codes):
+        return lib.compare(base, parsed, exp, exit_codes=codes, expected_shard_count=4)
+
+    # only 1 of 4 -> missing three
+    r = _res({"issues-1.exit-code": 1})
+    assert r.exit_code != 0 and any("missing shard exit-code" in i for i in r.invalid)
+    # all 4 but one exited 2 (infra) -> fail
+    r = _res({f"issues-{i}.exit-code": 0 for i in range(1, 5)} | {"issues-3.exit-code": 2})
+    assert r.exit_code != 0 and any("exited 2" in i for i in r.invalid)
+    # extra wrong-name file -> fail
+    r = _res({f"issues-{i}.exit-code": 0 for i in range(1, 5)} | {"issues-9.exit-code": 0})
+    assert r.exit_code != 0 and any("unexpected shard exit-code" in i for i in r.invalid)
+    # exactly 4, all 0/1 -> pass (known-only)
+    r = _res({f"issues-{i}.exit-code": (0 if i % 2 else 1) for i in range(1, 5)})
+    assert r.exit_code == 0

--- a/tests/unit/test_legacy_quarantine_probe.py
+++ b/tests/unit/test_legacy_quarantine_probe.py
@@ -1,0 +1,148 @@
+"""Contract tests for the weekly quarantine probe entry point.
+
+These run the REAL probe CLI (``scripts/ci/legacy_quarantine_probe.py``) from the
+repo root via subprocess — they exist primarily to prove the entry point imports
+and resolves the repo root correctly (the ``ROOT=parents[2]`` fix; ``parents[1]``
+crashed at import with FileNotFoundError) and that it fails closed on bad
+quarantine config. They also exercise the outcome-matching logic with synthetic
+slow/fast tests so a recovered or behavior-changed entry cannot stay green.
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+PROBE = PROJECT_ROOT / "scripts" / "ci" / "legacy_quarantine_probe.py"
+
+
+def _run_probe(
+    quarantine: Path, *, hard_timeout: int = 30, out_dir: Path
+) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [
+            sys.executable,
+            str(PROBE),
+            "--quarantine",
+            str(quarantine),
+            "--hard-timeout",
+            str(hard_timeout),
+            "--out-dir",
+            str(out_dir),
+        ],
+        cwd=PROJECT_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+
+def _write_quarantine(path: Path, nodeid: str) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "schema": "openace-legacy-issue-quarantine",
+                "entries": [
+                    {
+                        "nodeid": nodeid,
+                        "reason": "synthetic contract-test entry",
+                        "owner": "contract-test",
+                        "tracking_issue": "https://github.com/open-ace/open-ace/issues/2457",
+                        "exit_condition": "contract test only",
+                        "expires_on": "2099-01-01",
+                        "expected_probe_outcome": "timeout",
+                    }
+                ],
+            }
+        )
+    )
+
+
+def test_probe_entrypoint_fails_closed_on_missing_quarantine(tmp_path):
+    # P0: the entry point must import + resolve repo root, then fail closed
+    # (exit 1) on a missing quarantine — no FileNotFoundError at import time.
+    proc = _run_probe(tmp_path / "does-not-exist.json", out_dir=tmp_path)
+    assert proc.returncode == 1, proc.stderr
+    assert "missing" in proc.stderr.lower()
+
+
+def test_probe_entrypoint_fails_closed_on_corrupt_quarantine(tmp_path):
+    q = tmp_path / "q.json"
+    q.write_text("{ not valid json")
+    proc = _run_probe(q, out_dir=tmp_path)
+    assert proc.returncode == 1, proc.stderr
+    assert "cannot load quarantine" in proc.stderr.lower()
+
+
+def test_probe_entrypoint_fails_closed_on_expired_or_invalid(tmp_path):
+    q = tmp_path / "q.json"
+    q.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "schema": "openace-legacy-issue-quarantine",
+                "entries": [
+                    {
+                        "nodeid": "tests/issues/604/x.py::a",
+                        "reason": "r",
+                        "owner": "o",
+                        "tracking_issue": "t",
+                        "exit_condition": "e",
+                        "expires_on": "2000-01-01",  # expired
+                        "expected_probe_outcome": "timeout",
+                    }
+                ],
+            }
+        )
+    )
+    proc = _run_probe(q, out_dir=tmp_path)
+    assert proc.returncode == 1, proc.stderr
+    assert "invalid quarantine" in proc.stderr.lower()
+    assert "expired" in proc.stderr.lower()
+
+
+def test_probe_green_when_declared_timeout_still_times_out(tmp_path):
+    # A synthetic nodeid that hangs past the hard timeout → outcome "timeout"
+    # matches the declared "timeout" → exit 0 (known debt, green).
+    slow = tmp_path / "test_probe_slow.py"
+    slow.write_text("import time\n\ndef test_hang():\n    time.sleep(30)\n")
+    q = tmp_path / "q.json"
+    _write_quarantine(q, f"{slow}::test_hang")
+    proc = _run_probe(q, hard_timeout=3, out_dir=tmp_path)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    results = json.loads((tmp_path / "quarantine-probe-results.json").read_text())
+    assert results[0]["outcome"] == "timeout"
+    assert results[0]["timed_out"] is True
+    assert results[0]["matches"] is True
+
+
+def test_probe_fails_when_quarantined_nodeid_recovers(tmp_path):
+    # A synthetic nodeid that passes fast while declared "timeout" → outcome
+    # "pass" != "timeout" → exit 1 (recovered; must be removed from quarantine).
+    fast = tmp_path / "test_probe_fast.py"
+    fast.write_text("def test_ok():\n    assert True\n")
+    q = tmp_path / "q.json"
+    _write_quarantine(q, f"{fast}::test_ok")
+    proc = _run_probe(q, hard_timeout=20, out_dir=tmp_path)
+    assert proc.returncode == 1, proc.stdout + proc.stderr
+    results = json.loads((tmp_path / "quarantine-probe-results.json").read_text())
+    assert results[0]["outcome"] == "pass"
+    assert results[0]["matches"] is False
+
+
+def test_probe_writes_per_nodeid_log_artifact(tmp_path):
+    slow = tmp_path / "test_probe_slow.py"
+    slow.write_text("import time\n\ndef test_hang():\n    time.sleep(30)\n")
+    q = tmp_path / "q.json"
+    _write_quarantine(q, f"{slow}::test_hang")
+    proc = _run_probe(q, hard_timeout=3, out_dir=tmp_path)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    logs = list(tmp_path.glob("probe-*.log"))
+    assert logs, "expected a per-nodeid probe log artifact"
+    body = logs[0].read_text()
+    assert "expected=timeout" in body and "outcome=timeout" in body
+    assert "--- stdout ---" in body and "--- stderr ---" in body

--- a/tests/unit/test_scheduled_workflow_contracts.py
+++ b/tests/unit/test_scheduled_workflow_contracts.py
@@ -23,3 +23,12 @@ def test_weekly_runs_on_saturday_at_0318_singapore_time():
     assert _schedules("weekly-quality.yml") == [
         {"cron": "18 3 * * 6", "timezone": "Asia/Singapore"}
     ]
+
+
+def test_quarantine_probe_runs_weekly_on_saturday_at_0318_singapore_time():
+    # The weekly subprocess probe of ci/legacy-issue-quarantine.json nodeids must
+    # match the agreed cadence (Sat 03:18 SGT) so a recovered/behavior-changed
+    # quarantine entry is caught and cannot drift silently.
+    assert _schedules("quarantine-probe.yml") == [
+        {"cron": "18 3 * * 6", "timezone": "Asia/Singapore"}
+    ]


### PR DESCRIPTION
## Legacy issue failure baseline (Refs #2457) — ready for re-review

Machine-readable, fail-closed known-failure baseline for `tests/issues/`, wired as the authoritative nightly gate. Contract: `docs/issue-2457-agent-handoff.md` §4–§8.

### Handoff block (§9)
```
Implementation PR: https://github.com/open-ace/open-ace/pull/2462
Reference run / commit: https://github.com/open-ace/open-ace/actions/runs/31357513634 / 56a165ab
Full verification run: https://github.com/open-ace/open-ace/actions/runs/31359257263

Baseline (ci/legacy-issue-failures.json):
- total known entries: 538
- failures / errors: 343 / 195
- collection errors: 0
- top issue directories: tests/issues/716 (167), 517 (39), 241 (27), 822 (21), 740 (20)
- top error categories: test_body_exception (194), assertion_failure (149), setup_error (195)

Fail-closed evidence:
- new failure / resolved / changed: fault-injection proven (each → exit 1)
- missing/corrupt/partial XML or missing shard: cardinality + bidirectional → exit 1
- collection error: never baselined, always exit 1
- shard exit 2/3/4/5 (infra): exit-code cardinality check → exit 1
- runner quarantine missing/corrupt/expired: SystemExit (no silent re-run of the deadlock)

Validation:
- 71 unit/contract tests pass (50 baseline + 17 runner); ruff/black/isort/mypy clean
- PR Gate: green
- CI known-only: run 31359257263 → exit 0 (538 known, 0 new/resolved/changed/invalid, 1 quarantined)
- remaining limitations: build_expected_manifest is environment-dependent (89 collects locally but not in CI); the CI manifest (4478) is authoritative and matches the run. Weekly subprocess probe (quarantine-probe.yml) guards against quarantine drift.
```

### What changed (review rounds 1–3)
- **Library** (`scripts/legacy_issue_baseline.py`): versioned schema, xUnit2 parser (nodeid via conftest property + reconstruction fallback), exception_type recovery from message/text, classifier, expected-nodeid manifest (`-qq`), bidirectional completeness (`verify_completeness`: missing **and** unexpected nodeids, file floor, exact shard exit-code cardinality, duplicate/conflict detection), read-only `compare` / explicit `snapshot` / `manifest` CLI, env-scrubbing.
- **Quarantine** (`ci/legacy-issue-failures.json` + `ci/legacy-issue-quarantine.json`): machine-readable, gate-visible tracked exclusion for ONLY the exact 604 deadlocking nodeid (no globs); `nodeid/reason/owner/tracking_issue(#2466)/exit_condition/expires_on`; fail-closed validation (missing/malformed-date/expired/duplicate/uncollectable); comparator reports as separate "quarantined debt"; runner `--deselect`s (local==CI, strict loader); weekly subprocess probe.
- **Workflow** (`extended-tests.yml`): `continue-on-error` + exit-code capture on the pytest step; `legacy-issue-baseline` comparator job (`if: always()`, fail-closed); `nightly-summary` rewired to gate on the comparator.
- **Tests**: `tests/issues/conftest.py` (autouse `openace_nodeid`); `tests/issues/604` bare skip removed (now quarantined).

### Production deadlock
Filed separately as #2466 (remote LLM-proxy failover loop deadlocks on 429-without-quota); tracked in the quarantine entry; out of #2457 scope.

Marking ready for re-review — all P0/P1 items from rounds 1–3 addressed; CI known-only exit 0 achieved.
