### PR TITLE
fix(orchestrator): tolerate datetime in timeline event payloads (#2480)

### DIFF
--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -20,7 +20,7 @@ import sys
 import threading
 import time
 import uuid
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -2818,6 +2818,32 @@ class AutonomousOrchestrator:
             wf, canonical, decision, evidence_meta, local_sha, expected_sha
         )
 
+    @staticmethod
+    def _dump_event_data(data):
+        """Serialize a timeline event payload tolerating raw datetime/date.
+
+        Workflow patches (and thus emitted events) can carry DB timestamp
+        fields that psycopg2 returns as ``datetime``; the default JSON encoder
+        raises ``TypeError: Object of type datetime is not JSON serializable``
+        on those and fails the whole phase (b48179df regression at
+        acceptance_verification — PR #2465 merged, but the post-merge event
+        crashed). ``isoformat`` keeps timestamps machine-parseable; the ``str``
+        fallback makes emission robust to any other non-native type.
+        """
+
+        def _default(obj):
+            if isinstance(obj, (datetime, date)):
+                return obj.isoformat()
+            # Diagnostic events must never crash the phase on an odd type;
+            # leave a breadcrumb so an unexpected type (set/bytes/...) is visible.
+            logger.debug(
+                "event_data serialized non-native type %s via str fallback",
+                type(obj).__name__,
+            )
+            return str(obj)
+
+        return json.dumps(data, ensure_ascii=False, default=_default)
+
     def _emit(self, event_type: str, data: dict):
         """Emit a timeline event."""
         self.emitter.emit(self._workflow_id, event_type, data)
@@ -2825,7 +2851,7 @@ class AutonomousOrchestrator:
             {
                 "workflow_id": self._workflow_id,
                 "event_type": event_type,
-                "event_data": json.dumps(data, ensure_ascii=False),
+                "event_data": self._dump_event_data(data),
             }
         )
 

--- a/tests/unit/test_orchestrator_event_emit.py
+++ b/tests/unit/test_orchestrator_event_emit.py
@@ -1,0 +1,56 @@
+"""Regression: timeline event emission must survive datetime in the payload.
+
+Workflow patches can carry raw DB timestamp fields (e.g. ``verification_started_at``
+is a ``timestamp with time zone`` column that psycopg2 returns as ``datetime``).
+When such a patch is emitted as a timeline event, ``json.dumps`` used to raise
+``TypeError: Object of type datetime is not JSON serializable`` and fail the
+whole phase — caught on b48179df at acceptance_verification (PR #2465 merged
+fine; only the post-merge verification event crashed).
+"""
+
+import json
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import pytest
+
+pytestmark = [pytest.mark.regression, pytest.mark.issue(2480)]
+
+
+def _make_orch():
+    from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+    orch = AutonomousOrchestrator("wf-test")
+    orch.repo = MagicMock()
+    orch.repo.create_event.return_value = {"id": 1}
+    orch.emitter = MagicMock()
+    return orch
+
+
+def test_emit_serializes_datetime_in_event_data():
+    """_emit must not raise when event data carries a raw datetime."""
+    orch = _make_orch()
+    data = {
+        "status": "confirmed",
+        "verification_started_at": datetime(2026, 8, 10, 5, 13, tzinfo=timezone.utc),
+    }
+
+    orch._emit("status_change", data)
+
+    orch.repo.create_event.assert_called_once()
+    event_data = orch.repo.create_event.call_args[0][0]["event_data"]
+    parsed = json.loads(event_data)  # round-trips cleanly into valid JSON
+    assert parsed["status"] == "confirmed"
+    assert "2026" in parsed["verification_started_at"]
+
+
+def test_emit_serializes_nested_datetime():
+    """A datetime nested inside the payload must also survive (defense in depth)."""
+    orch = _make_orch()
+    data = {"patch": {"completed_at": datetime(2026, 8, 10, 5, 13, tzinfo=timezone.utc)}}
+
+    orch._emit("patch_applied", data)
+
+    event_data = orch.repo.create_event.call_args[0][0]["event_data"]
+    parsed = json.loads(event_data)
+    assert "2026" in parsed["patch"]["completed_at"]


### PR DESCRIPTION
## What

Fixes #2480 — the orchestrator's timeline-event emitter (`_emit`) crashed with `TypeError: Object of type datetime is not JSON serializable` when an event payload carried a raw `datetime`, failing the whole phase.

## Root cause

`_emit` did `json.dumps(data, ensure_ascii=False)` with no `default`. Workflow patches can carry raw DB timestamp fields (e.g. `verification_started_at`, a `timestamp with time zone` column psycopg2 returns as `datetime`). When such a patch is emitted as an event, serialization crashed.

**Caught on workflow b48179df**: PR #2465 merged fine, but the post-merge `acceptance_verification` event carried `verification_started_at` (set on a prior attempt) as a raw datetime → `_emit` crashed → workflow marked `failed` despite the work being delivered.

## Fix

- Add `_dump_event_data` helper: `datetime`/`date` → `isoformat()`, `str` fallback (with a `logger.debug` breadcrumb) for any other non-native type; route `_emit` through it.
- Regression test (`tests/unit/test_orchestrator_event_emit.py`): top-level + nested datetime no longer raises, round-trips to valid JSON.

The 3 other `event_data` json.dumps sites are already fail-safe (try/except + debug log), so left as-is. Out-of-scope follow-up noted in #2480: the SSE generator in `app/routes/autonomous.py` shares this class of bug.

## Verification

- `pytest tests/unit/test_orchestrator_event_emit.py` → 2 passed.
- Independent code review: APPROVE (root cause correctly targeted; scoping of the other fail-safe sites justified).
