### PR TITLE
fix(orchestrator): scope CI-repair pre-commit to changed files

### DIFF
--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -3415,11 +3415,14 @@ class AutonomousOrchestrator:
             "1. 保持在当前工作分支上修复，不要创建新的 PR，不要切换到其他分支。\n"
             "2. 不要进入新的代码审查、进度汇报或等待流程；当前唯一目标是让现有 PR 的 CI 通过。\n"
             "3. 必须优先根据 CI 工作流、失败日志摘录和仓库脚本定位问题，复现 CI 真实执行的命令。\n"
-            "4. 修复后必须重新运行 CI 的完整对应命令，而不是只运行单个 hook、单个文件或你认为相关的子集。\n"
+            "4. 修复后必须重新运行**完整的 pre-commit（所有 hook），但仅作用于你本次改动或 CI 失败涉及的文件**，"
+            "而不是只运行单个 hook；也**禁止 `--all-files` 全仓扫描**——隔离环境与 CI 的工具链版本可能不同，"
+            "全仓扫描会误改你未触碰的干净文件、撑破变更范围而被编排器的范围守卫拒绝。\n"
             "5. 如果命令中的 formatter / pre-commit hook 自动修改了文件并以非零状态退出，这只是修复过程，"
             "不代表验证完成；必须保留这些修改并重复运行同一完整命令，直到 exit 0 或确认存在不可自动修复的错误。\n"
             "6. 编排器已先把当前 main 合并进 PR 分支，因此对 "
-            "`SKIP=bandit,no-commit-to-branch pre-commit run --all-files` 必须原样运行并重复至 exit 0；"
+            "`SKIP=bandit,no-commit-to-branch pre-commit run --files <你改动的文件>`"
+            "（用 `git diff --name-only origin/main` 列出本次改动的文件）必须重复运行至 exit 0；"
             "Bandit 由 CI 独立检查。\n"
             "7. 不要执行 git add、git commit 或 git push；编排器会在范围校验通过后统一提交并推送。\n"
             "8. 结束时请明确说明：你复现了哪些完整命令、最终 exit code、修复了什么、还剩什么风险。\n"
@@ -3476,13 +3479,24 @@ class AutonomousOrchestrator:
         wf: dict,
         gh: GitHubOps,
         failed_checks: list[dict],
+        commit_before: str = "",
     ) -> tuple[bool, str]:
-        """Run the CI's full pre-commit command under the isolated agent account.
+        """Run the CI's pre-commit command (scoped to changed files) under the
+        isolated agent account.
 
         Some hooks intentionally modify files and return 1 on their first pass.
         A repair agent can mistake that for completion and push a still-red
-        branch. Re-run the full command until it is clean, while preserving the
-        same credentialless OS boundary used for all autonomous repository code.
+        branch. Re-run pre-commit on the round-local targets until clean, while
+        preserving the same credentialless OS boundary used for all autonomous
+        repository code.
+
+        The run is scoped via ``--files`` to the targets that differ from
+        ``commit_before`` (the PR remote head). Running ``--all-files`` instead
+        cascades into reformatting clean files whenever the isolated env's
+        toolchain drifts from CI's pinned versions — that blew past
+        ``MAX_AUTONOMOUS_CHANGED_FILES`` and failed whole workflows. When no
+        targets exist, convergence skips entirely (the agent changed nothing for
+        pre-commit to normalize); it never falls back to ``--all-files``.
 
         Returns ``(attempted, remaining_error)``. A remaining error is reported
         in the repair summary but does not discard safe hook edits: the next CI
@@ -3536,8 +3550,20 @@ class AutonomousOrchestrator:
             "GIT_TERMINAL_PROMPT": "0",
             "SKIP": CI_PRE_COMMIT_SKIP,
         }
+        # Scope pre-commit to the round-local targets (files differing from
+        # commit_before). --all-files would reformat clean files on toolchain
+        # drift and blow the change-scope guard. No targets → nothing to
+        # normalize; skip rather than fall back to the known-broken --all-files.
+        targets = self._collect_pre_commit_targets(gh, commit_before)
+        if not targets:
+            logger.info(
+                "Skipping pre-commit convergence: no round-local targets "
+                "(nothing differs from commit_before=%s)",
+                commit_before or "(unset)",
+            )
+            return False, ""
         command, cwd = AutonomousAgentRunner._wrap_agent_cmd(
-            [pre_commit, "run", "--all-files"],
+            [pre_commit, "run", "--files", *targets],
             project_path,
             isolated_account,
             env,
@@ -3577,9 +3603,42 @@ class AutonomousOrchestrator:
 
         concise_output = last_output[-4000:] if last_output else "no output"
         return True, (
-            "isolated `pre-commit run --all-files` did not reach exit 0 after "
+            "isolated `pre-commit run --files <targets>` did not reach exit 0 after "
             f"{passes_run} pass(es):\n{concise_output}"
         )
+
+    @staticmethod
+    def _collect_pre_commit_targets(gh: GitHubOps, commit_before: str) -> list[str]:
+        """Return the files the convergence pre-commit run may touch.
+
+        This is everything that differs from the round boundary ``commit_before``
+        (the PR remote head) — committed since that point *or* sitting in the
+        working tree. That set is a conservative superset of what the per-round
+        scope guard (``_validate_autonomous_change_scope`` with ``commit_before``)
+        counts — the guard may rebase its baseline to ``merge-base`` on a merge
+        commit, narrowing what it counts, but this set only ever spans
+        legitimate round-local files, so scoping pre-commit to it cannot blow
+        past ``MAX_AUTONOMOUS_CHANGED_FILES`` via toolchain-drift reformatting of
+        unrelated clean files (the scope-exceeded cascade). Git lookups degrade
+        fail-soft: a transient
+        error on one layer yields whatever the other layer returned, never an
+        exception (the caller would otherwise be tempted to fall back to
+        ``--all-files``, which is the bug being fixed).
+        """
+        committed: list[str] = []
+        if commit_before:
+            try:
+                committed = gh.get_changed_files(commit_before, "HEAD")
+            except Exception as exc:
+                logger.warning(
+                    "pre-commit target collection: committed-delta lookup failed: %s", exc
+                )
+        try:
+            working = gh.get_worktree_changed_paths()
+        except Exception as exc:
+            logger.warning("pre-commit target collection: working-tree lookup failed: %s", exc)
+            working = []
+        return sorted({path for path in (*committed, *working) if path})
 
     @staticmethod
     def _detect_and_push_ci_repair_changes(
@@ -3821,7 +3880,7 @@ class AutonomousOrchestrator:
         pre_commit_error = ""
         try:
             pre_commit_attempted, pre_commit_error = self._converge_pre_commit_fixes(
-                wf, gh, failed_checks
+                wf, gh, failed_checks, commit_before
             )
         except Exception as exc:
             # The isolated validation is defense-in-depth. Preserve the agent's
@@ -3863,7 +3922,8 @@ class AutonomousOrchestrator:
         )
         if pre_commit_attempted:
             validation_summary = (
-                pre_commit_error or "isolated `pre-commit run --all-files` converged with exit 0"
+                pre_commit_error
+                or "isolated pre-commit convergence (scoped to changed files) passed with exit 0"
             )
             summary = f"{summary}\n\nValidation: {validation_summary}".strip()
 

--- a/tests/unit/test_autonomous_ci_guardrails.py
+++ b/tests/unit/test_autonomous_ci_guardrails.py
@@ -1559,7 +1559,8 @@ def test_fresh_ci_repair_prompt_keeps_requirements_plan_and_diff():
     assert "APPROVED PLAN" in prompt
     assert "diff --git" in prompt
     assert "CI EXCERPT" in prompt
-    assert "pre-commit run --all-files" in prompt
+    assert "pre-commit run --files" in prompt
+    assert "pre-commit run --all-files" not in prompt
     assert "编排器已先把当前 main 合并进 PR 分支" in prompt
     assert "SKIP=bandit,no-commit-to-branch" in prompt
     assert "直到 exit 0" in prompt
@@ -1581,6 +1582,63 @@ def test_pre_commit_detection_requires_log_evidence():
     )
 
 
+def test_collect_pre_commit_targets_unions_committed_and_working_tree():
+    """Targets = everything differing from the round boundary (commit_before),
+    committed or in the working tree — the exact set the per-round scope guard
+    counts, so scoping pre-commit to it can't blow past the file limit via
+    toolchain-drift reformatting of unrelated clean files."""
+    from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+    gh = MagicMock()
+    gh.get_changed_files.return_value = ["app/a.py", "app/b.py"]
+    gh.get_worktree_changed_paths.return_value = ["app/b.py", "app/c.py"]
+
+    targets = AutonomousOrchestrator._collect_pre_commit_targets(gh, "base-sha")
+
+    assert targets == ["app/a.py", "app/b.py", "app/c.py"]
+    gh.get_changed_files.assert_called_once_with("base-sha", "HEAD")
+
+
+def test_collect_pre_commit_targets_empty_commit_before_uses_working_tree_only():
+    """When commit_before is unavailable (PR head lookup failed), fall back to
+    the working-tree layer rather than skipping — the agent's edits still need
+    normalizing."""
+    from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+    gh = MagicMock()
+    gh.get_worktree_changed_paths.return_value = ["app/c.py", "app/d.py"]
+
+    targets = AutonomousOrchestrator._collect_pre_commit_targets(gh, "")
+
+    assert targets == ["app/c.py", "app/d.py"]
+    gh.get_changed_files.assert_not_called()
+
+
+def test_collect_pre_commit_targets_empty_when_nothing_changed():
+    """No committed delta and a clean working tree → no targets → convergence
+    must skip (nothing to normalize)."""
+    from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+    gh = MagicMock()
+    gh.get_changed_files.return_value = []
+    gh.get_worktree_changed_paths.return_value = []
+
+    assert AutonomousOrchestrator._collect_pre_commit_targets(gh, "base-sha") == []
+
+
+def test_collect_pre_commit_targets_tolerates_git_lookup_failure():
+    """A transient git error collecting one layer must not crash convergence;
+    it degrades to whatever the other layer returned (fail-soft, never
+    fall back to --all-files)."""
+    from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+    gh = MagicMock()
+    gh.get_changed_files.side_effect = RuntimeError("dubious ownership")
+    gh.get_worktree_changed_paths.return_value = ["app/c.py"]
+
+    assert AutonomousOrchestrator._collect_pre_commit_targets(gh, "base-sha") == ["app/c.py"]
+
+
 def test_pre_commit_convergence_reruns_modified_hooks_as_isolated_agent():
     from app.modules.workspace.autonomous.agent_runner import AutonomousAgentRunner
     from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
@@ -1592,6 +1650,8 @@ def test_pre_commit_convergence_reruns_modified_hooks_as_isolated_agent():
     orch._select_project_python_runtime = MagicMock(return_value=(["python3"], ""))
     gh = MagicMock()
     gh.path_exists_as_user.return_value = True
+    gh.get_changed_files.return_value = ["app/a.py"]
+    gh.get_worktree_changed_paths.return_value = ["app/b.py"]
     failed_checks = [
         {
             "name": "lint",
@@ -1637,6 +1697,7 @@ def test_pre_commit_convergence_reruns_modified_hooks_as_isolated_agent():
             },
             gh,
             failed_checks,
+            commit_before="base-sha",
         )
 
     assert attempted
@@ -1644,7 +1705,9 @@ def test_pre_commit_convergence_reruns_modified_hooks_as_isolated_agent():
     assert run.call_count == 2
     wrap.assert_called_once()
     assert wrap.call_args.args[:3] == (
-        ["/usr/local/bin/pre-commit", "run", "--all-files"],
+        # Scoped to the round-local targets (committed + working-tree union),
+        # never --all-files (that cascades on toolchain drift → scope blow-up).
+        ["/usr/local/bin/pre-commit", "run", "--files", "app/a.py", "app/b.py"],
         "/private/repo",
         "openace-agent",
     )
@@ -1652,6 +1715,51 @@ def test_pre_commit_convergence_reruns_modified_hooks_as_isolated_agent():
     assert wrap.call_args.args[3]["SKIP"] == "bandit,no-commit-to-branch"
     assert run.call_args.kwargs["cwd"] is None
     assert run.call_args.kwargs["env"] is None
+
+
+def test_pre_commit_convergence_skips_when_no_round_local_targets():
+    """When nothing differs from commit_before, convergence must skip entirely
+    (return attempted=False) and NOT invoke pre-commit — running --all-files
+    here is exactly the toolchain-drift cascade that blows the scope guard."""
+    from app.modules.workspace.autonomous.agent_runner import AutonomousAgentRunner
+    from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+    orch = AutonomousOrchestrator.__new__(AutonomousOrchestrator)
+    orch._workflow_id = "wf-test"
+    orch._resolve_isolated_agent_account = MagicMock(return_value="openace-agent")
+    orch._resolve_system_account = MagicMock(return_value="repo-owner")
+    orch._select_project_python_runtime = MagicMock(return_value=(["python3"], ""))
+    gh = MagicMock()
+    gh.path_exists_as_user.return_value = True
+    gh.get_changed_files.return_value = []
+    gh.get_worktree_changed_paths.return_value = []
+    failed_checks = [{"name": "lint", "failure_excerpt": "pre-commit hook(s) made changes"}]
+
+    with (
+        patch(
+            "app.modules.workspace.autonomous.orchestrator.shutil.which",
+            side_effect=["/usr/local/bin/pre-commit", "/usr/bin/git"],
+        ),
+        patch.object(AutonomousAgentRunner, "is_isolated_launcher_available", return_value=True),
+        patch.object(AutonomousAgentRunner, "_wrap_agent_cmd") as wrap,
+        patch.object(
+            AutonomousAgentRunner,
+            "_resolve_agent_guard_bin",
+            return_value="/usr/local/libexec/openace-agent-bin",
+        ),
+        patch("app.modules.workspace.autonomous.orchestrator.subprocess.run") as run,
+    ):
+        attempted, error = orch._converge_pre_commit_fixes(
+            {"workspace_type": "local", "worktree_path": "/private/repo"},
+            gh,
+            failed_checks,
+            commit_before="base-sha",
+        )
+
+    assert attempted is False
+    assert error == ""
+    run.assert_not_called()
+    wrap.assert_not_called()
 
 
 def test_pre_commit_convergence_falls_back_to_same_user_without_launcher():
@@ -1666,6 +1774,9 @@ def test_pre_commit_convergence_falls_back_to_same_user_without_launcher():
     orch._select_project_python_runtime = MagicMock(return_value=(["python3"], ""))
     gh = MagicMock()
     gh.path_exists_as_user.return_value = True
+    # Provide round-local targets so convergence proceeds (it skips on empty).
+    gh.get_changed_files.return_value = ["app/a.py"]
+    gh.get_worktree_changed_paths.return_value = ["app/a.py"]
 
     modified = MagicMock(
         returncode=1,


### PR DESCRIPTION
## Problem

Autonomous CI-repair workflows repeatedly hit the change-scope guard (limit 60 files) with **130-160 files changed**, failing whole workflows.

**Root cause (code-confirmed):** both the CI-repair convergence (`orchestrator.py` `_converge_pre_commit_fixes`) and its agent prompt ran `pre-commit run --all-files`. When the isolated agent environment's toolchain drifts from CI's pinned hook versions (black/ruff/isort), `--all-files` reformats the *entire repo*. Those reformats get committed via `git_commit(no_verify=True)` and then rejected by `_validate_autonomous_change_scope` (limit `MAX_AUTONOMOUS_CHANGED_FILES=60`).

## Fix

Scope both pre-commit runs to **changed files** — the round-local targets that differ from the PR remote head (`commit_before`), which is exactly the set the per-round scope guard counts.

- **`_collect_pre_commit_targets(gh, commit_before)`** (new): union of committed-since-`commit_before` + working-tree changes. Fail-soft per layer (transient git error → degrade to the other layer).
- **`_converge_pre_commit_fixes`**: `[pre_commit, "run", "--all-files"]` → `[pre_commit, "run", "--files", *targets]`. When targets are empty it **skips entirely** (returns `attempted=False`) — never falls back to `--all-files` (fail-soft is skip + warn; CI remains authoritative).
- **Prompt #4/#6**: forbid `--all-files`; instruct running the full pre-commit hook suite scoped to the agent's own changed files (`pre-commit run --files <changed>`, list via `git diff --name-only origin/main`).
- Threaded `commit_before` (the PR remote head, already computed at the call site) into convergence so the target set aligns with the per-round scope-guard baseline.

## Why `--files` and not `--all-files`

CI's merge gate keeps main pre-commit-clean, so on a clean tree `--all-files` *should* only touch changed files. The drift breaks that assumption. Scoping to changed files is robust to drift: the drifted formatter can only touch files already in the agent's diff, not cascade to 145 unrelated clean files.

If CI is genuinely failing on a file the agent did not touch (pre-existing drift), scoping won't fix it — but convergence couldn't fix that anyway, and another repair round fires. The scope guard failing the workflow is strictly worse.

## Tests

`tests/unit/test_autonomous_ci_guardrails.py` (canonical layer, no new dirs):
- `_collect_pre_commit_targets`: union of committed+working-tree; empty-`commit_before` falls to working-tree; empty when nothing changed; tolerates per-layer git failure.
- convergence uses `--files <targets>`; **skips** (no subprocess) when no targets.
- prompt no longer contains `--all-files`.

## Out of scope

The dev-phase agent prompt does not run `--all-files`, so it needs no change for this bug. The separate "uncommitted dev changes" symptom (e.g. fa40beec) is a different failure under investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)