### PR TITLE
fix(orchestrator): pass workflow_id to verification agent spawn

### DIFF
--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -7636,6 +7636,7 @@ class AutonomousOrchestrator:
                 cli_tool=cli_tool,
                 model=model,
                 project_path=checkout_path,
+                workflow_id=self._workflow_id,
             )
         except Exception:
             logger.exception("acceptance verifier spawn failed for issue %s", issue_number)

--- a/tests/unit/test_orchestrator_verification_agent.py
+++ b/tests/unit/test_orchestrator_verification_agent.py
@@ -1,0 +1,46 @@
+"""Regression: the acceptance verifier spawn must pass workflow_id.
+
+``_run_verification_agent`` calls ``_run_agent`` to spawn the independent
+verifier. Every other ``_run_agent`` caller passes ``workflow_id`` (it is a
+required arg of ``AutonomousAgentRunner.run_agent_task``), but the verification
+call omitted it — so any workflow reaching acceptance_verification crashed with
+``TypeError: run_agent_task() missing 1 required positional argument:
+'workflow_id'`` (caught on b48179df / issue #2394 after the datetime fix let it
+reach this phase).
+"""
+
+from unittest.mock import MagicMock, PropertyMock, patch
+
+import pytest
+
+pytestmark = [pytest.mark.regression]
+
+
+def test_run_verification_agent_passes_workflow_id():
+    from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+    orch = AutonomousOrchestrator.__new__(AutonomousOrchestrator)
+    orch._workflow_id = "wf-verify-test"
+    orch._build_verification_prompt = MagicMock(return_value="verify prompt")
+    orch._checkout_merged_main = MagicMock(return_value="/tmp/merged-checkout")
+    orch._remove_verification_worktree = MagicMock()
+    # success=False so the method returns the infra_error dict early (no parsing).
+    orch._run_agent = MagicMock(return_value=MagicMock(success=False, error_code=""))
+
+    with patch.object(
+        type(orch),
+        "workflow",
+        new_callable=PropertyMock,
+        return_value={"cli_tool": "claude-code", "model": ""},
+    ):
+        orch._run_verification_agent(
+            snapshot=MagicMock(),
+            merge_sha="merge-sha",
+            base_sha="base-sha",
+            issue_number=2394,
+            pr_number=2465,
+        )
+
+    orch._run_agent.assert_called_once()
+    # The spawn must carry workflow_id like every other _run_agent caller.
+    assert orch._run_agent.call_args.kwargs.get("workflow_id") == "wf-verify-test"


### PR DESCRIPTION
## Problem
`_run_verification_agent` spawns the independent acceptance verifier via `_run_agent` but **omitted `workflow_id`** — a required arg of `AutonomousAgentRunner.run_agent_task`. Every other `_run_agent` caller passes it (CI-repair, dev, review, test, refine).

Without it, any workflow reaching `acceptance_verification` crashes:
```
TypeError: AutonomousAgentRunner.run_agent_task() missing 1 required positional argument: 'workflow_id'
```
Caught on b48179df / issue #2394 (after PR #2481's datetime fix let the workflow advance to this phase; the crash previously masqueraded as the datetime error).

## Fix
One line — add `workflow_id=self._workflow_id` to the verification `_run_agent` call (orchestrator.py:7630), matching the 5 sibling callers. The two other `_run_agent` callers that appear not to pass it (L6354, L6439) are `**kwargs` pass-through wrappers, so they're fine.

## Verification
- New regression test `test_run_verification_agent_passes_workflow_id` (red → green).
- pre-commit (black/isort/ruff/mypy/bandit) clean.
- Evidence: the prod traceback (`run_agent_task() missing workflow_id`) + grep confirming 7630 is the sole caller missing it.

## Scope
This unblocks the verification spawn. A **separate latent** issue remains: when verification *crashes*, the failure-recording DB write throws `can't adapt type 'dict'` — but that path is only reached on an exception, which this fix prevents. Queued for a follow-up if verification crashes for other reasons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)