### PR TITLE
fix(verification): serialize acceptance-verification milestone fields

### DIFF
--- a/app/modules/workspace/autonomous/phases/acceptance_verification.py
+++ b/app/modules/workspace/autonomous/phases/acceptance_verification.py
@@ -246,6 +246,33 @@ def _prior_infra_retry_count(wf: dict, merge_sha: str, snap_hash: str) -> int:
         return 0
 
 
+def _acceptance_milestone(*, workflow_id, attempt, status, report) -> dict:
+    """Build the acceptance-verification milestone row.
+
+    ``result_summary`` / ``metadata`` are DB columns inserted verbatim by
+    ``repo.create_milestone`` (no JSON serialization), so they must be strings
+    — passing the raw ``report`` dict crashed with ``can't adapt type 'dict'``
+    the moment a verdict was committed (#2394). ``metadata`` keeps the full
+    structured report as JSON; ``result_summary`` is a short readable line.
+    """
+    summary = (
+        f"status={status}; "
+        f"scope={len(report.get('scope', []))} "
+        f"gates={len(report.get('gates', []))} "
+        f"verifier={len(report.get('verifier', []))}"
+    )
+    return {
+        "workflow_id": workflow_id,
+        "phase": "acceptance_verification",
+        "round_number": attempt,
+        "milestone_type": "acceptance_verification",
+        "status": status,
+        "title": f"Acceptance verification: {status}",
+        "result_summary": summary,
+        "metadata": json.dumps(report, ensure_ascii=False),
+    }
+
+
 def handle(ctx, deps) -> PhaseResult:
     # Keep this guard before all context/dependency access. Parked production
     # rows may have already released their worktrees and must drain safely while
@@ -542,16 +569,12 @@ def handle(ctx, deps) -> PhaseResult:
         "verified_by": verified_by,
         "verification_attempt": (wf.get("verification_attempt") or 0) + 1,
     }
-    milestone = {
-        "workflow_id": wf.get("workflow_id"),
-        "phase": "acceptance_verification",
-        "round_number": common_patch["verification_attempt"],
-        "milestone_type": "acceptance_verification",
-        "status": status,
-        "title": f"Acceptance verification: {status}",
-        "result_summary": report,
-        "metadata": report,
-    }
+    milestone = _acceptance_milestone(
+        workflow_id=wf.get("workflow_id"),
+        attempt=common_patch["verification_attempt"],
+        status=status,
+        report=report,
+    )
     if agent_out.get("infra_error") and infra_retry_count < MAX_VERIFIER_INFRA_RETRIES:
         # Infrastructure failures are not acceptance evidence and must not
         # create a terminal milestone. Keep the workflow in its current phase

--- a/tests/unit/test_acceptance_verification_milestone.py
+++ b/tests/unit/test_acceptance_verification_milestone.py
@@ -1,0 +1,41 @@
+"""Regression: the acceptance-verification milestone must store string fields.
+
+The milestone built at the end of ``acceptance_verification.handle`` passed the
+raw ``report`` dict as both ``result_summary`` and ``metadata``.
+``repo.create_milestone`` inserts those columns verbatim (no json.dumps), so
+psycopg2 raised ``can't adapt type 'dict'`` and failed the whole phase the
+moment a verification verdict was committed (caught on b48179df / #2394).
+``verification_report`` (the workflow column) was already json-dumped; the
+milestone fields were the gap.
+"""
+
+import json
+
+import pytest
+
+pytestmark = [pytest.mark.regression]
+
+
+def test_acceptance_milestone_fields_are_strings():
+    from app.modules.workspace.autonomous.phases.acceptance_verification import (
+        _acceptance_milestone,
+    )
+
+    report = {
+        "merge_sha": "abc",
+        "status": "confirmed",
+        "scope": [{"item": "a", "verdict": "confirmed"}],
+        "gates": [],
+        "verifier": [{"item": "x"}, {"item": "y"}],
+    }
+    ms = _acceptance_milestone(workflow_id="wf-2394", attempt=1, status="confirmed", report=report)
+
+    # Both DB columns must be strings — a dict here crashes create_milestone.
+    assert isinstance(ms["result_summary"], str)
+    assert isinstance(ms["metadata"], str)
+    # metadata round-trips as JSON carrying the full structured report.
+    parsed = json.loads(ms["metadata"])
+    assert parsed["merge_sha"] == "abc"
+    assert parsed["verifier"] == [{"item": "x"}, {"item": "y"}]
+    # result_summary is a short human-readable line, not the raw dict.
+    assert "confirmed" in ms["result_summary"]


### PR DESCRIPTION
## Problem
After PR #2485 (workflow_id fix) let workflows reach the end of `acceptance_verification`, the phase crashed at milestone commit:
```
psycopg2.ProgrammingError: can't adapt type 'dict'
  advance → _commit_phase_result → _create_milestone → repo.create_milestone
```
The milestone built in `acceptance_verification.handle` passed the raw `report` dict as both `result_summary` and `metadata`. `repo.create_milestone` inserts those columns verbatim (no json.dumps), so a dict value is un-adaptable. (`verification_report`, the workflow column, was already json-dumped — the milestone fields were the gap.) Caught on b48179df / #2394.

## Fix
Extract `_acceptance_milestone(workflow_id, attempt, status, report)`:
- `metadata` = `json.dumps(report)` (full structured report, the intended use of metadata).
- `result_summary` = a short readable line (`status=…; scope=N gates=N verifier=N`), matching CI-repair's `result_summary=context[:200]` convention (short string, not a dict).

## Verification
- New regression test `test_acceptance_milestone_fields_are_strings` (red → green): asserts both fields are `str` + `metadata` round-trips as JSON.
- 29 verification/milestone unit tests pass; pre-commit (black/isort/ruff/mypy/bandit) clean.
- The one unrelated local failure (`test_dingtalk_org_sync` sqlite `%`-binding in its own user-creation) is pre-existing/environmental — not in this diff's scope; CI will confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)