### PR TITLE
fix(verifier): tolerate glm non-fenced/trailing-comma JSON output

### DIFF
--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -2112,6 +2112,129 @@ def _next_phase(current_phase: str) -> str:
     return current_phase
 
 
+def _extract_verifier_json(text: str) -> dict | None:
+    """Extract the acceptance verifier's JSON verdict object from agent output.
+
+    Tolerant of the glm family's common deviations from "ONLY a fenced JSON
+    block": prose prefaces, multiple/partial code fences, trailing commas
+    (``{"a":1,}``), and braces appearing inside string values. Returns the
+    parsed dict, or ``None`` when no JSON object can be recovered (the caller
+    records an infra_error and logs the raw text). ``None`` defers to
+    infra-retry — it never fabricates a verdict.
+    """
+    import json as _json
+    import re as _re
+
+    def _try_parse(candidate: str) -> dict | None:
+        candidate = (candidate or "").strip()
+        if not candidate:
+            return None
+        try:
+            parsed = _json.loads(candidate)
+        except Exception:
+            # glm models routinely emit trailing commas ({"a":1,}); strip them.
+            # String-aware so a ",}" inside a value (e.g. an evidence note
+            # containing a code snippet) is preserved, not mangled.
+            cleaned = _strip_trailing_commas(candidate)
+            try:
+                parsed = _json.loads(cleaned)
+            except Exception:
+                return None
+        return parsed if isinstance(parsed, dict) else None
+
+    def _strip_trailing_commas(s: str) -> str:
+        out: list[str] = []
+        in_str = False
+        escaped = False
+        i = 0
+        n = len(s)
+        while i < n:
+            ch = s[i]
+            if escaped:
+                out.append(ch)
+                escaped = False
+                i += 1
+                continue
+            if ch == "\\":
+                out.append(ch)
+                escaped = True
+                i += 1
+                continue
+            if ch == '"':
+                in_str = not in_str
+                out.append(ch)
+                i += 1
+                continue
+            if not in_str and ch == ",":
+                j = i + 1
+                while j < n and s[j].isspace():
+                    j += 1
+                if j < n and s[j] in "}]":
+                    i += 1  # drop the trailing comma
+                    continue
+            out.append(ch)
+            i += 1
+        return "".join(out)
+
+    def _first_balanced(s: str) -> str | None:
+        # First string-aware balanced { ... } substring; braces inside quoted
+        # strings are skipped so evidence text mentioning {} can't fool depth.
+        start = s.find("{")
+        while start != -1:
+            depth = 0
+            in_str = False
+            escaped = False
+            end = None
+            for i in range(start, len(s)):
+                ch = s[i]
+                if escaped:
+                    escaped = False
+                    continue
+                if ch == "\\":
+                    escaped = True
+                    continue
+                if ch == '"':
+                    in_str = not in_str
+                    continue
+                if in_str:
+                    continue
+                if ch == "{":
+                    depth += 1
+                elif ch == "}":
+                    depth -= 1
+                    if depth == 0:
+                        end = i
+                        break
+            if end is not None:
+                return s[start : end + 1]
+            start = s.find("{", start + 1)
+        return None
+
+    # 1) Prefer fenced ```json ... ``` regions (non-greedy per fence pair so two
+    #    blocks don't merge). The LAST region wins — the agent may preface with
+    #    an earlier partial draft. Within a region, take its first balanced {}.
+    fenced_regions = list(_re.finditer(r"```(?:json)?\s*(.*?)\s*```", text, _re.DOTALL))
+    for region in reversed(fenced_regions):
+        obj = _first_balanced(region.group(1))
+        if obj is not None:
+            parsed = _try_parse(obj)
+            if parsed is not None:
+                return parsed
+
+    # 2) No usable fenced region → balanced { ... } over the WHOLE text
+    #    (prose-wrapped / unfenced output). NOTE: this returns the FIRST
+    #    balanced object — if the agent writes prose with a JSON-shaped
+    #    reasoning object before the real verdict, that first object wins.
+    #    Bounded risk: a non-verdict dict lacks `verdicts`/`snapshot` and
+    #    downstream aggregates to indeterminate (never a false confirmed).
+    obj = _first_balanced(text)
+    if obj is not None:
+        parsed = _try_parse(obj)
+        if parsed is not None:
+            return parsed
+    return None
+
+
 class AutonomousOrchestrator:
     """Drives a single autonomous workflow through its phases."""
 
@@ -7685,9 +7808,6 @@ class AutonomousOrchestrator:
         )
 
     def _parse_verifier_output(self, result) -> dict:
-        import json as _json
-        import re as _re
-
         text = self._artifact_text(result) if result is not None else ""
         if not text:
             return {
@@ -7695,14 +7815,14 @@ class AutonomousOrchestrator:
                 "snapshot": None,
                 "infra_error": "verification agent returned empty output",
             }
-        # Grab the last fenced ```json ... ``` block (the agent may preface reasoning).
-        blocks = _re.findall(r"```(?:json)?\s*(\{.*?\})\s*```", text, _re.DOTALL)
-        candidate = blocks[-1] if blocks else text
-        try:
-            parsed = _json.loads(candidate)
-        except Exception:
+        # Tolerant extraction: fenced blocks, prose-wrapped, trailing commas,
+        # braces in strings (glm family deviates from "ONLY a fenced JSON block").
+        parsed = _extract_verifier_json(text)
+        if parsed is None:
             logger.warning(
-                "acceptance verifier output was not valid JSON; treating as indeterminate"
+                "acceptance verifier output was not valid JSON; treating as "
+                "indeterminate. raw_output=%s",
+                text[:1500],
             )
             return {
                 "verdicts": [],

--- a/tests/unit/test_verifier_json_parse.py
+++ b/tests/unit/test_verifier_json_parse.py
@@ -1,0 +1,81 @@
+"""Regression: the acceptance verifier's JSON extraction must tolerate glm output.
+
+The verifier agent (glm-5 on prod) routinely deviates from "ONLY a fenced JSON
+block": it prefaces with prose, omits/mismatches fences, and emits trailing
+commas. The old parser grabbed a fenced block else fell back to the WHOLE text
+under strict ``json.loads`` — so any deviation raised "verification agent output
+was not valid JSON", exhausted the infra-retry budget, and paused the workflow
+at acceptance_verification (b48179df / 6584f242, #29).
+"""
+
+import pytest
+
+pytestmark = [pytest.mark.regression]
+
+
+def _extract(text):
+    from app.modules.workspace.autonomous.orchestrator import _extract_verifier_json
+
+    return _extract_verifier_json(text)
+
+
+def test_clean_fenced_json_still_works():
+    text = '```json\n{"verdicts": [{"item": "a", "verdict": "confirmed"}]}\n```'
+    assert _extract(text) == {"verdicts": [{"item": "a", "verdict": "confirmed"}]}
+
+
+def test_fenced_json_with_prose_preface():
+    text = 'Here is my verification:\n```json\n{"verdicts": [], "snapshot": null}\n```'
+    assert _extract(text) == {"verdicts": [], "snapshot": None}
+
+
+def test_trailing_commas_tolerated():
+    # glm family frequently emits {"a":1,} style trailing commas.
+    text = (
+        '```json\n{"verdicts": [{"item": "a", "verdict": "confirmed",},], "snapshot": null,}\n```'
+    )
+    result = _extract(text)
+    assert result is not None
+    assert result["verdicts"] == [{"item": "a", "verdict": "confirmed"}]
+    assert result["snapshot"] is None
+
+
+def test_unfenced_prose_wrapped_json():
+    text = (
+        "I verified the merged changes against the snapshot. "
+        '{"verdicts": [{"item": "a", "verdict": "confirmed"}], "snapshot": null} '
+        "That is all."
+    )
+    assert _extract(text) == {"verdicts": [{"item": "a", "verdict": "confirmed"}], "snapshot": None}
+
+
+def test_trailing_comma_cleanup_preserves_comma_brace_inside_strings():
+    # Real trailing comma AND a string value containing ",}" — the in-string
+    # ",}" must be preserved, only the structural trailing comma stripped.
+    text = '{"verdicts": [{"item": "a", "note": "see file,}"}], "snapshot": null,}'
+    result = _extract(text)
+    assert result is not None
+    assert result["verdicts"][0]["note"] == "see file,}"
+    assert result["snapshot"] is None
+
+
+def test_braces_inside_string_values_do_not_break_depth():
+    text = '```json\n{"verdicts": [{"item": "a", "evidence": "uses {brace} here"}]}\n```'
+    result = _extract(text)
+    assert result is not None
+    assert result["verdicts"][0]["evidence"] == "uses {brace} here"
+
+
+def test_pure_prose_with_no_json_returns_none():
+    text = "The change looks correct but I could not produce structured output."
+    assert _extract(text) is None
+
+
+def test_last_fenced_block_wins_when_agent_prefaces_a_partial():
+    # Agent emits a partial/earlier block, then the real one.
+    text = (
+        '```json\n{"verdicts": [{"item": "partial"}\n```\n'
+        'final answer:\n```json\n{"verdicts": [{"item": "a", "verdict": "confirmed"}]}\n```'
+    )
+    result = _extract(text)
+    assert result == {"verdicts": [{"item": "a", "verdict": "confirmed"}]}


### PR DESCRIPTION
## Problem
The acceptance verifier agent (glm-5 on prod) routinely deviates from "reply with ONLY a fenced JSON block" — prose prefaces, multiple/partial fences, trailing commas. `_parse_verifier_output` grabbed a fenced block else fell back to the **whole text** under strict `json.loads`, so any deviation raised `verification agent output was not valid JSON`, exhausted the 5× infra-retry budget, and **paused the workflow at acceptance_verification** (b48179df + 6584f242, #29). It also never logged the raw text, so the failure was blind.

## Fix
New `_extract_verifier_json(text)` (module-level, unit-tested):
1. **Fenced regions first** — non-greedy per fence pair (so two blocks don't merge), **last region wins** (agent may preface with a partial draft).
2. **Balanced `{...}` fallback** over the whole text (prose-wrapped / unfenced), **string-aware** so braces inside evidence/rationale strings don't fool depth.
3. **Trailing-comma tolerance** (`{"a":1,}` — glm family habit), bounded cleanup loop.
4. Returns `None` when nothing recovers → caller keeps infra-retry. **Never fabricates a verdict.**

`_parse_verifier_output` now logs up to 1500 chars of raw output on failure → future verifier-output issues are diagnosable.

## Verification
- 7 new regression tests (clean fenced, prose-preface, trailing commas, unfenced prose-wrapped, braces-in-strings, pure-prose→None, last-fenced-wins). Red→green.
- 35 verification/acceptance/orchestrator unit tests pass; pre-commit (black/isort/ruff/mypy/bandit) clean.
- The one unrelated local failure (`test_dingtalk_org_sync` sqlite `%`-binding) is pre-existing — not in this diff; CI confirms.

## Note
This improves robustness for the common glm deviations. If glm-5 produces output this still can't parse, the new raw-text log will show exactly what, guiding a follow-up (stronger prompt / model swap). b48179df + 6584f242 (both PRs already merged) will be reset to re-verify after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)