### PR TITLE
fix(docker): correct code-server installation path for Debian

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -102,8 +102,10 @@ RUN echo "deb http://mirrors.aliyun.com/debian/ trixie main" > /etc/apt/sources.
     && npm config set registry https://registry.npmmirror.com/ \
     && npm install -g qwen-code-webui@0.2.40 @qwen-code/qwen-code@0.15.10 \
     # === code-server Installation (for local workspace VS Code button) ===
-    && curl -fsSL --connect-timeout 15 --max-time 300 https://code-server.dev/install.sh | sh -s -- --prefix=/usr/local \
-    && test -x /usr/local/bin/code-server \
+    # NOTE: On Debian, the install script uses deb package which ignores --prefix
+    # and always installs to /usr/bin/code-server
+    && curl -fsSL --connect-timeout 15 --max-time 300 https://code-server.dev/install.sh | sh -s -- \
+    && test -x /usr/bin/code-server \
     # === CLI Verification ===
     && test -f /usr/lib/node_modules/@qwen-code/qwen-code/cli.js \
     && test -x /usr/bin/qwen-code-webui \


### PR DESCRIPTION
## 问题

CI Docker 构建失败，错误发生在 `production` 阶段的 code-server 安装验证步骤：

```
&& test -x /usr/local/bin/code-server  # failed
```

## 根因分析

**错误的配置**（来自 PR #2479 的 commit 24d7c36）：
```dockerfile
&& curl -fsSL https://code-server.dev/install.sh | sh -s -- --prefix=/usr/local \
&& test -x /usr/local/bin/code-server \
```

**为什么失败**：
1. code-server 安装脚本在 Debian 系统上会检测到 apt 包管理器
2. 然后使用 deb 包安装，**会忽略 `--prefix` 参数**
3. 实际安装路径是 `/usr/bin/code-server`，不是 `/usr/local/bin/code-server`

## 修复

恢复正确的配置（来自 PR #2358 commit eb1c444）：
```dockerfile
&& curl -fsSL https://code-server.dev/install.sh | sh -s -- \
&& test -x /usr/bin/code-server \
```

## 历史背景

- **PR #2358 (eb1c444)**：修复过这个问题
- **PR #2479 (commit 24d7c36)**：又错误地引入了 `--prefix=/usr/local`

Fixes #2496