### PR TITLE
fix(alerts): add field aliases for frontend compatibility (Issue #2477)

### DIFF
--- a/app/modules/governance/alert_notifier.py
+++ b/app/modules/governance/alert_notifier.py
@@ -398,10 +398,22 @@ class Alert:
     action_text: str | None = None
 
     def to_dict(self) -> dict:
-        """Convert to dictionary for JSON serialization."""
+        """Convert to dictionary for JSON serialization.
+
+        Issue #2477: Frontend expects 'id', 'type', 'is_read' fields.
+        Keep 'alert_id', 'alert_type', 'read' for backward compatibility.
+        Deprecation planned: v2.0 will mark as deprecated, v3.0 will remove.
+        """
         return {
+            # Frontend-expected fields (Issue #2477)
+            "id": self.alert_id,
+            "type": self.alert_type,
+            "is_read": self.read,
+            # Original fields for backward compatibility
             "alert_id": self.alert_id,
             "alert_type": self.alert_type,
+            "read": self.read,
+            # Other fields
             "severity": self.severity,
             "title": self.title,
             "message": self.message,
@@ -410,7 +422,6 @@ class Alert:
             "tool_name": self.tool_name,
             "metadata": self.metadata,
             "created_at": self.created_at.isoformat(),
-            "read": self.read,
             "action_url": self.action_url,
             "action_text": self.action_text,
         }

--- a/frontend/src/api/alerts.ts
+++ b/frontend/src/api/alerts.ts
@@ -16,6 +16,9 @@ export interface Alert {
   is_read: boolean;
   created_at: string;
   metadata?: Record<string, unknown>;
+  tool_name?: string;
+  action_url?: string;
+  action_text?: string;
 }
 
 export interface AlertListResponse {


### PR DESCRIPTION
## 修复说明

关联 Issue：#2477

## 根因

告警管理页面删除和标记已读操作失败，根因是前后端字段名不匹配：

| 后端 `Alert.to_dict()` 返回 | 前端 `Alert` TypeScript 接口期望 |
|------------------------------|-----------------------------------|
| `alert_id` | `id` |
| `alert_type` | `type` |
| `read` | `is_read` |

前端调用 `handleDeleteAlert(alert.id)` 时，`alert.id` 为 `undefined`，导致 API 请求 `DELETE /api/alerts/undefined` 返回 404。

## 修复方案

在 `Alert.to_dict()` 方法中添加字段别名，保持向后兼容：
- `"id"` 作为 `alert_id` 的别名
- `"type"` 作为 `alert_type` 的别名
- `"is_read"` 作为 `read` 的别名

同时保留原字段 `alert_id`、`alert_type`、`read` 以确保向后兼容。

## 主要变更

- `app/modules/governance/alert_notifier.py` - Alert.to_dict() 添加 3 个字段别名
- `frontend/src/api/alerts.ts` - Alert 接口补充缺失的可选字段

## 测试

- **本地验证**：
  - 后端 to_dict() 正确返回 id/type/is_read 字段
  - TypeScript 类型检查通过
  - 前端构建成功
  - 后端单元测试通过 (10 passed)

## 风险

- **兼容性**：保留旧字段，不影响现有消费者
- **响应体积**：每条告警增加约 60-70 字节，可忽略
- **废弃计划**：v2.0 标记旧字段为 deprecated，v3.0 移除