### PR TITLE
fix(autonomous): defer merge-policy pause while CI settles (#27 follow-up)

### DIFF
--- a/app/modules/workspace/autonomous/phases/merge.py
+++ b/app/modules/workspace/autonomous/phases/merge.py
@@ -419,8 +419,44 @@ def handle(ctx, deps) -> PhaseResult:
                     raise
 
             if is_policy_rejection:
-                # With no failed/pending checks and no conflict evidence,
-                # repository policy requires external action (approval,
+                # A "policy" rejection text overlaps two situations GitHub
+                # reports with the same "repository rule violations" /
+                # "required status check" wording:
+                #
+                #  (a) a required status check is still PENDING for this head
+                #      — most often right after a sync/repair push, while an
+                #      aggregate required gate (whatever the repo names it)
+                #      has not yet propagated its own pending status.
+                #      ``_blocking_pending`` only defers for a pending check in
+                #      the required set, so it misses a pending *underlying*
+                #      job (e.g. ``test (3.10)`` under an aggregate gate) in
+                #      that window; GitHub concurrently reports ``blocked`` and
+                #      the workflow froze at a manual-recovery pause it could
+                #      never recover from (#27 follow-up; cf. 50ba8724 /
+                #      c0758607 / cd939cbf / 1c1b63f0).
+                #  (b) a genuine non-CI block (missing review, draft, required
+                #      signing) where every check has settled.
+                #
+                # Only (b) warrants a manual-recovery pause. (a) is transient:
+                # any pending check, or GitHub still computing
+                # (``mergeable_state == "unknown"``), means CI has not settled
+                # — keep polling instead of freezing. Both signals are bounded
+                # (pending checks complete; the unknown state resolves), so
+                # this cannot spin: a permanently-absent required context has
+                # no pending check and a known ``blocked`` state, so it still
+                # pauses for a human to fix the ruleset.
+                any_pending = any(c.get("bucket") == "pending" for c in refreshed_checks)
+                if any_pending or mergeable_state == "unknown":
+                    logger.info(
+                        "PR #%s: merge rejected by policy but CI has not "
+                        "settled (state=%s, any_pending=%s); deferring",
+                        pr_number,
+                        mergeable_state or "unknown",
+                        any_pending,
+                    )
+                    return PhaseResult.retry()
+                # No pending checks and GitHub has finished computing, yet
+                # repository policy still requires external action (approval,
                 # marking ready, or a rule change). Persist a manually
                 # recoverable pause instead of retrying forever.
                 state_label = mergeable_state or "unknown"

--- a/app/modules/workspace/autonomous/phases/merge.py
+++ b/app/modules/workspace/autonomous/phases/merge.py
@@ -129,14 +129,16 @@ def _blocking_pending(gh, checks: list[dict], pr_number: int, base_branch: str) 
     an aggregate gate (e.g. ``PR Gate``) reports its own status as pending while
     its underlying jobs run, so the filter normally catches the wait.
 
-    Known gap (pre-existing, rare): under an aggregate gate, a pending
-    *underlying* job whose name is not in the literal required set (e.g.
-    ``test (3.10)`` while ``required == {'PR Gate'}``) is classified as
-    non-blocking. In the narrow window before the gate's own pending status
-    propagates, the merge can be attempted, rejected, and paused at the policy
-    branch instead of deferred. The gate's pending status prevents this in the
-    common case; left for a follow-up rather than expanding this change (a full
-    fix trades off over-deferring on slow non-required jobs).
+    Note on the aggregate-gate propagation window: a pending *underlying* job
+    whose name is not in the literal required set (e.g. ``test (3.10)`` while
+    ``required == {'PR Gate'}``) is classified non-blocking HERE — this filter
+    governs only the pre-merge / post-rejection *required*-pending deferral,
+    where over-deferring on slow non-required jobs is the cost (#2428). In the
+    narrow window before the gate's own pending status propagates, such a job
+    used to reach the policy-pause branch and freeze the workflow. That freeze
+    is now prevented by the post-rejection transient guard in :func:`handle`
+    (any pending check OR ``mergeable_state == "unknown"`` defers before the
+    pause), so the gap no longer strands workflows.
     """
     pending = [c for c in checks if c.get("bucket") == "pending"]
     if not pending:
@@ -440,11 +442,18 @@ def handle(ctx, deps) -> PhaseResult:
                 # Only (b) warrants a manual-recovery pause. (a) is transient:
                 # any pending check, or GitHub still computing
                 # (``mergeable_state == "unknown"``), means CI has not settled
-                # — keep polling instead of freezing. Both signals are bounded
-                # (pending checks complete; the unknown state resolves), so
-                # this cannot spin: a permanently-absent required context has
-                # no pending check and a known ``blocked`` state, so it still
-                # pauses for a human to fix the ruleset.
+                # — keep polling instead of freezing. In practice this is
+                # bounded: pending checks complete and the unknown state
+                # resolves within minutes, so a workflow does not loop here
+                # indefinitely. A permanently-absent required context (a repo
+                # misconfig — required context with no provider) has no pending
+                # check and a known ``blocked`` state, so it still pauses for a
+                # human to fix the ruleset. ``PhaseResult.retry`` does not
+                # increment any counter, so the formal backstop for a
+                # degenerate stuck-pending/unknown (e.g. a runner that never
+                # times out, or a GitHub incident) is the
+                # monitor-autonomous-workflows sweep that re-classifies a
+                # workflow stuck in this phase.
                 any_pending = any(c.get("bucket") == "pending" for c in refreshed_checks)
                 if any_pending or mergeable_state == "unknown":
                     logger.info(

--- a/tests/autonomous/phases/test_merge.py
+++ b/tests/autonomous/phases/test_merge.py
@@ -248,3 +248,66 @@ def test_merge_aggregate_gate_lag_still_repairs_underlying_jobs():
     host.start_ci_repair_round.assert_called_once()
     repaired = {c.get("name") for c in host.start_ci_repair_round.call_args[0][2]}
     assert {"test (3.10)", "lint"} <= repaired, repaired
+
+
+# ── policy-pause transient defer (#27 follow-up) ──────────────────────────
+
+
+def test_merge_policy_block_with_pending_ci_defers_not_pauses():
+    """#27 follow-up: right after a sync/repair push, the aggregate required
+    gate's own pending status has not propagated, but its underlying jobs ARE
+    pending. ``_blocking_pending`` filters them (not in the required set), so the
+    merge is attempted and rejected with a generic policy error; GitHub reports
+    ``blocked``. The workflow must DEFER (CI has not settled) rather than freeze
+    at a manual-recovery pause it can never recover from. Reproduced by
+    50ba8724 / c0758607 / 1c1b63f0 / 67241d8d / 2d0c317d / cd939cbf."""
+    deps, host = _build_deps(
+        checks=[{"name": "test (3.10)", "bucket": "pending"}],
+        merge_state={"mergeable": True, "mergeable_state": "blocked"},
+        merge_raises=GitHubOpsError("base branch policy prohibits the merge"),
+    )
+    deps.gh.get_branch_protection.return_value = {
+        "required_status_checks": {"contexts": ["PR Gate"]}
+    }
+    result = merge_phase.handle(_ctx(_workflow()), deps)
+
+    assert result.outcome == "retry"
+    host.emit_status_change.assert_not_called()  # did not pause
+
+
+def test_merge_policy_block_with_unknown_state_defers_not_pauses():
+    """GitHub's mergeability is async: right after a push, ``mergeable_state``
+    is ``unknown`` while it recomputes. A merge attempted in that window is
+    rejected with a generic policy error. Defer (GitHub has not decided) instead
+    of pausing for manual recovery."""
+    deps, host = _build_deps(
+        checks=[],
+        merge_state={"mergeable": None, "mergeable_state": "unknown"},
+        merge_raises=GitHubOpsError("repository rule violations"),
+    )
+    deps.gh.get_branch_protection.return_value = {
+        "required_status_checks": {"contexts": ["PR Gate"]}
+    }
+    result = merge_phase.handle(_ctx(_workflow()), deps)
+
+    assert result.outcome == "retry"
+    host.emit_status_change.assert_not_called()
+
+
+def test_merge_policy_block_with_settled_ci_still_pauses():
+    """When CI has fully settled (no pending checks, state known and blocked), a
+    policy rejection is a genuine non-CI block (missing review / draft /
+    signing). The manual-recovery pause must still fire — the defer is only for
+    the transient CI-settling window, so genuine blocks are not masked."""
+    deps, host = _build_deps(
+        checks=[{"name": "PR Gate", "bucket": "pass"}],
+        merge_state={"mergeable": True, "mergeable_state": "blocked"},
+        merge_raises=GitHubOpsError("review is required"),
+    )
+    deps.gh.get_branch_protection.return_value = {
+        "required_status_checks": {"contexts": ["PR Gate"]}
+    }
+    result = merge_phase.handle(_ctx(_workflow()), deps)
+
+    assert result.outcome == "pause"
+    host.emit_status_change.assert_called_once()


### PR DESCRIPTION
## Problem

Six workflows froze at ``status=paused`` / ``current_phase=merge`` and never recovered:

| workflow | PR | attempts | checks (at pause+later) |
|---|---|---|---|
| 1c1b63f0 | 2436 | 1 | PR Gate FAIL (lint) |
| 50ba8724 | 2348 | 2 | UNSTABLE (only schema-sync) |
| c0758607 | 2487 | 0 | PR Gate FAIL (test 3.10-3.14) |
| 67241d8d | 2446 | 0 | PR Gate FAIL (test 3.11) |
| 2d0c317d | 2425 | 1 | PR Gate FAIL (lint+test) |
| cd939cbf | 2413 | 0 | CLEAN (nothing failing) |

The required check for ``main`` is the aggregate **PR Gate** (since the #2455 test-layout restructure), not the individual lint/test jobs.

## Root cause

In ``phases/merge.py``, the ``GitHubOpsError`` handler's ``is_policy_rejection`` branch paused whenever there were no completed required-failures and no required-pending checks. But a "policy" rejection text (``repository rule violations`` / ``required status check``) fires **transiently** while CI is still running for the head — most often right after a sync/repair push, when the aggregate required gate has not yet propagated its own pending status and its underlying jobs are pending but filtered out by ``_blocking_pending`` (their names are not in the literal required set ``{PR Gate}``).

In that window both ``_ci_repair_targets`` (fail bucket) and ``_blocking_pending`` (required-pending) return empty, GitHub concurrently reports ``blocked``, and the workflow froze at a manual-recovery pause. Once paused it stops cycling, so it never recovers even after CI later completes — which is why 5 of the 6 now show real required failures, one is UNSTABLE, and one is CLEAN, yet all are paused.

## Fix

Before pausing, **defer** (``PhaseResult.retry()``) when CI has not settled:

- any check is **pending**, OR
- ``mergeable_state == "unknown"`` (GitHub still computing).

Pause only when CI has fully settled (no pending, state known) yet policy still blocks — a genuine non-CI block (missing review / draft / signing).

**Generic** — no check name is hardcoded (the aggregate gate's pending propagation is irrelevant; we look at *any* pending check + GitHub's own unknown state). **Bounded** — pending checks complete and the unknown state resolves, so this cannot spin: a permanently-absent required context (no pending, known ``blocked``) still pauses for a human to fix the ruleset.

## Tests (TDD)

New in ``tests/autonomous/phases/test_merge.py``:
- ``test_merge_policy_block_with_pending_ci_defers_not_pauses`` — pending underlying job under aggregate gate → defer (was: pause). RED before / GREEN after.
- ``test_merge_policy_block_with_unknown_state_defers_not_pauses`` — ``mergeable_state=unknown`` → defer (was: pause). RED before / GREEN after.
- ``test_merge_policy_block_with_settled_ci_still_pauses`` — settled CI + review-required → still pause. Guard (GREEN before & after).

All 11 merge tests + 22 #2428 wiring tests pass locally.

This is the follow-up to PR #2492 (the ``_ci_repair_targets`` half of #27). It also covers the ``cd939cbf`` case (CLEAN+all-green yet blocked) in isolation.