### PR TITLE
feat(autonomous): worktree node_modules shim for frontend tests (#23)

### DIFF
--- a/app/modules/workspace/autonomous/git_workspace.py
+++ b/app/modules/workspace/autonomous/git_workspace.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import shlex
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
@@ -47,6 +48,72 @@ def _GitHubOps(*args, **kwargs):
     preserves the original (orchestrator-inlined) name-resolution semantics.
     """
     return _orchestrator_module.GitHubOps(*args, **kwargs)
+
+
+# Cache subdirs under ``node_modules`` that vite/vitest WRITE to at runtime.
+# These must be REAL worktree dirs (agent-writable via the existing per-worktree
+# ACL grant, ``scripts/openace-run-as.sh``) — NOT symlinks to the project
+# owner's main-clone node_modules, or the agent hits EACCES on vite's bundled-
+# config write to ``.vite-temp`` (#23: c88afdc0/83ffb529/ee678c63). Frozenset so
+# future vite/vitest versions can add dirs without code surgery.
+_FRONTEND_NODE_MODULES_CACHE_DIRS = frozenset({".vite-temp", ".vite", ".vitest", ".cache"})
+
+
+def _build_node_modules_shim_script(
+    wt_frontend: str,
+    main_node_modules: str,
+    cache_dirs: frozenset[str] = _FRONTEND_NODE_MODULES_CACHE_DIRS,
+) -> str:
+    """Build the shell script that injects a worktree-local ``node_modules`` (#23).
+
+    Symlinks every entry from the main clone's ``node_modules`` (instant reuse —
+    no ``npm install`` and no network) EXCEPT the writable cache dirs, which
+    become REAL worktree dirs. The script builds into a temp dir then atomically
+    ``mv``s it into place, so a mid-run failure leaves NO partial node_modules
+    (the worktree falls back to the pre-fix state, never a broken half-state).
+    Idempotent: a node_modules that is already populated is left untouched
+    (shimmed on a prior cycle, or the agent ran its own ``npm install``).
+
+    All paths are absolute and the script is ``cwd``-independent — the caller
+    runs it as ``system_account`` via :meth:`GitHubOps._run_as_account`, which
+    cannot take ``cwd`` under ``sudo -u`` (#1421).
+    """
+    cache_pattern = "|".join(sorted(cache_dirs))
+    cache_list = " ".join(sorted(cache_dirs))
+    wt_fe = shlex.quote(wt_frontend)
+    main_nm = shlex.quote(main_node_modules)
+    return f"""set -euo pipefail
+WT_FE={wt_fe}
+MAIN_NM={main_nm}
+WT_NM="$WT_FE/node_modules"
+# idempotent: leave an already-populated node_modules untouched
+if [ -d "$WT_NM" ] && [ -n "$(ls -A "$WT_NM" 2>/dev/null || true)" ]; then
+  exit 0
+fi
+# no main node_modules to reuse → clean no-op
+if [ ! -d "$MAIN_NM" ]; then
+  exit 0
+fi
+TMP="$WT_FE/.nm.shim.tmp.$$"
+rm -rf "$TMP"
+mkdir -p "$TMP"
+for entry in "$MAIN_NM"/.* "$MAIN_NM"/*; do
+  [ -e "$entry" ] || [ -L "$entry" ] || continue
+  name=$(basename "$entry")
+  [ "$name" = "." ] && continue
+  [ "$name" = ".." ] && continue
+  case "$name" in
+    {cache_pattern}) ;;  # cache dirs are made REAL below; never symlink them
+    *) ln -sfn "$entry" "$TMP/$name" ;;
+  esac
+done
+# Ensure ALL cache dirs exist as REAL worktree dirs — they may be absent from the
+# main clone (vite/vitest create them on-demand at runtime); symlinking them to
+# the owner's copies is the EACCES bug this shim fixes.
+for c in {cache_list}; do mkdir -p "$TMP/$c"; done
+rm -rf "$WT_NM"
+mv "$TMP" "$WT_NM"
+"""
 
 
 class GitWorkspaceService:
@@ -224,6 +291,7 @@ class GitWorkspaceService:
                     raise
                 except Exception as e:
                     logger.warning("Branch verification failed: %s", e)
+            self._ensure_frontend_node_modules_shim(canonical, main_gh, wf)
             return canonical
 
         # Worktree missing — recreate at the authoritative trusted commit.
@@ -302,7 +370,68 @@ class GitWorkspaceService:
         )
         # Reset cached gh so it picks up the restored worktree path.
         self._orch._gh = None
+        self._ensure_frontend_node_modules_shim(canonical, main_gh, wf)
         return canonical
+
+    def _ensure_frontend_node_modules_shim(
+        self, canonical: str, main_gh: GitHubOps, wf: dict
+    ) -> None:
+        """Idempotent, fail-soft injection of a worktree-local ``node_modules``.
+
+        Lets the agent run frontend (vitest) tests in its worktree instead of
+        falling back to the project owner's main clone and hitting EACCES on
+        ``node_modules/.vite-temp`` (#23). See :func:`_build_node_modules_shim_script`.
+
+        This runs on EVERY worktree-strategy workflow's critical path (both
+        return points of :meth:`ensure_worktree`), so it MUST NOT raise: any
+        failure is logged + recorded as a ``frontend_node_modules_shim_failed``
+        milestone and the worktree is used as-is (the agent falls back to the
+        pre-fix behavior — no worse than today).
+        """
+        try:
+            self._ensure_frontend_node_modules_shim_impl(canonical, main_gh)
+        except Exception as exc:  # noqa: BLE001 — fail-soft must never block the worktree
+            logger.warning(
+                "Worktree %s: frontend node_modules shim failed (fail-soft): %s",
+                canonical,
+                exc,
+            )
+            self._orch._create_milestone(
+                phase=wf.get("current_phase", "preparation"),
+                milestone_type="frontend_node_modules_shim_failed",
+                status="failed",
+                title="Frontend node_modules shim failed (fail-soft)",
+                error_message=str(exc)[:300],
+            )
+
+    def _ensure_frontend_node_modules_shim_impl(self, canonical: str, main_gh: GitHubOps) -> None:
+        # Derive the main clone root from the linked worktree's git common-dir
+        # (``dirname`` of the shared ``.git`` dir = the main clone). Mirrors the
+        # idiom in scripts/openace-run-as.sh.
+        res = main_gh._run_git(
+            ["rev-parse", "--path-format=absolute", "--git-common-dir"], check=False
+        )
+        if res.returncode != 0 or not (res.stdout or "").strip():
+            return  # not a linked worktree / can't resolve → no-op
+        main_root = os.path.dirname(os.path.normpath(res.stdout.strip()))
+        main_fe = os.path.join(main_root, "frontend")
+        # Gate on the main clone having a frontend install (checked as
+        # system_account — the service user may not read a user-private clone).
+        if not (
+            main_gh.path_exists_as_user(os.path.join(main_fe, "package.json"), file_only=True)
+            and main_gh.path_exists_as_user(os.path.join(main_fe, "node_modules"))
+        ):
+            return  # not a frontend project, or no install to reuse → no-op
+        script = _build_node_modules_shim_script(
+            os.path.join(canonical, "frontend"),
+            os.path.join(main_fe, "node_modules"),
+        )
+        r = main_gh._run_as_account(["bash", "-c", script], timeout=300)
+        if r.returncode != 0:
+            raise RuntimeError(
+                "node_modules shim script exited "
+                f"{r.returncode}: {(r.stderr or '').strip()[:300]}"
+            )
 
     def fail_recovery_closed(
         self,

--- a/app/modules/workspace/autonomous/git_workspace.py
+++ b/app/modules/workspace/autonomous/git_workspace.py
@@ -97,6 +97,7 @@ fi
 TMP="$WT_FE/.nm.shim.tmp.$$"
 rm -rf "$TMP"
 mkdir -p "$TMP"
+trap 'rm -rf "$TMP"' EXIT
 for entry in "$MAIN_NM"/.* "$MAIN_NM"/*; do
   [ -e "$entry" ] || [ -L "$entry" ] || continue
   name=$(basename "$entry")
@@ -405,16 +406,11 @@ class GitWorkspaceService:
             )
 
     def _ensure_frontend_node_modules_shim_impl(self, canonical: str, main_gh: GitHubOps) -> None:
-        # Derive the main clone root from the linked worktree's git common-dir
-        # (``dirname`` of the shared ``.git`` dir = the main clone). Mirrors the
-        # idiom in scripts/openace-run-as.sh.
-        res = main_gh._run_git(
-            ["rev-parse", "--path-format=absolute", "--git-common-dir"], check=False
-        )
-        if res.returncode != 0 or not (res.stdout or "").strip():
-            return  # not a linked worktree / can't resolve → no-op
-        main_root = os.path.dirname(os.path.normpath(res.stdout.strip()))
-        main_fe = os.path.join(main_root, "frontend")
+        # ``main_gh.repo_path`` is the workflow's project_path — the main clone
+        # the worktree branches from, and where the owner's ``npm install``
+        # lives. Reuse its ``frontend/node_modules`` (the worktree's is
+        # gitignored and absent).
+        main_fe = os.path.join(main_gh.repo_path, "frontend")
         # Gate on the main clone having a frontend install (checked as
         # system_account — the service user may not read a user-private clone).
         if not (

--- a/app/modules/workspace/autonomous/github_ops.py
+++ b/app/modules/workspace/autonomous/github_ops.py
@@ -368,6 +368,27 @@ class GitHubOps:
             return True
         return current_user != self.system_account
 
+    def _run_as_account(
+        self, argv: list[str], *, timeout: int = 180
+    ) -> subprocess.CompletedProcess:
+        """Run a non-git shell command as ``system_account`` (#23).
+
+        Mirrors ONLY the ``sudo -u`` wrapping of :meth:`_run_git` — not its
+        trusted-git-context machinery (``safe.directory``/hooksPath/fsmonitor),
+        which is git-specific; this runs ``mkdir``/``ln`` for the node_modules
+        shim. No ``cwd`` is accepted: under ``sudo -u`` the service user cannot
+        ``chdir`` into a user-private worktree (the PermissionError of #1421),
+        so callers must pass absolute paths. When the service already runs as
+        ``system_account`` (``_needs_sudo()`` False — single-user/CI), the
+        command runs directly.
+        """
+        if self._needs_sudo():
+            assert self.system_account is not None  # _needs_sudo() guarantees non-empty
+            cmd: list[str] = ["sudo", "-u", self.system_account, *argv]
+        else:
+            cmd = list(argv)
+        return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+
     def _resolve_owner_repo(self) -> str | None:
         """Resolve the ``owner/repo`` slug for the local repo's origin remote.
 

--- a/tests/autonomous/test_git_workspace_node_modules_shim.py
+++ b/tests/autonomous/test_git_workspace_node_modules_shim.py
@@ -1,0 +1,136 @@
+"""Worktree node_modules shim (#23).
+
+The autonomous agent runs frontend tests (vitest) in its worktree, but the
+worktree has no ``frontend/node_modules`` (gitignored), so the agent falls back
+to the project owner's main-clone node_modules and hits EACCES on
+``node_modules/.vite-temp`` (vite writes its bundled config there). The shim
+injects a worktree-local node_modules: symlinks each package from the main clone
+but creates the writable cache dirs (``.vite-temp``/``.vite``/``.vitest``/
+``.cache``) as REAL worktree dirs (covered by the existing per-worktree ACL grant).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+
+from app.modules.workspace.autonomous.git_workspace import (
+    _FRONTEND_NODE_MODULES_CACHE_DIRS,
+    _build_node_modules_shim_script,
+)
+
+
+def _make_main_clone_with_node_modules(main_root: str) -> str:
+    """Create a fake main clone with frontend/package.json + node_modules.
+
+    Returns the path to ``frontend/node_modules``. Includes a package dir, a
+    dotfile, and a pre-existing cache dir (stand-in for dwu-owned cache the
+    agent must NOT write through).
+    """
+    main_fe = os.path.join(main_root, "frontend")
+    main_nm = os.path.join(main_fe, "node_modules")
+    os.makedirs(os.path.join(main_nm, "react"))
+    with open(os.path.join(main_nm, "react", "index.js"), "w") as f:
+        f.write("x")
+    os.makedirs(os.path.join(main_nm, ".bin"))
+    with open(os.path.join(main_nm, ".package-lock.json"), "w") as f:
+        f.write("{}")
+    # a cache dir that already exists in the main clone (must become REAL in wt,
+    # not a symlink to this dwu-owned one)
+    os.makedirs(os.path.join(main_nm, ".vite-temp"))
+    with open(os.path.join(main_fe, "package.json"), "w") as f:
+        f.write("{}")
+    return main_nm
+
+
+def test_shim_symlinks_packages_and_makes_cache_dirs_real(tmp_path):
+    """Packages are symlinked from the main clone; cache dirs are REAL worktree
+    dirs (writable by the agent via the existing ACL grant), not symlinks."""
+    main_nm = _make_main_clone_with_node_modules(str(tmp_path / "main"))
+    wt_fe = tmp_path / "wt" / "frontend"
+    wt_fe.mkdir(parents=True)
+
+    script = _build_node_modules_shim_script(str(wt_fe), main_nm)
+    res = subprocess.run(["bash", "-c", script], capture_output=True, text=True)
+    assert res.returncode == 0, res.stderr
+
+    wt_nm = wt_fe / "node_modules"
+    # packages → symlinks to the main clone
+    assert (wt_nm / "react").is_symlink()
+    assert os.path.realpath(wt_nm / "react") == os.path.join(main_nm, "react")
+    assert (wt_nm / ".bin").is_symlink()
+    assert (wt_nm / ".package-lock.json").is_symlink()
+    # cache dirs → REAL dirs (not symlinks), writable
+    for cache in _FRONTEND_NODE_MODULES_CACHE_DIRS:
+        cache_path = wt_nm / cache
+        assert cache_path.is_dir(), f"{cache} should be a real dir"
+        assert not cache_path.is_symlink(), f"{cache} must NOT be a symlink (EACCES)"
+        assert os.access(cache_path, os.W_OK), f"{cache} should be writable"
+
+
+def test_shim_idempotent_skips_when_node_modules_populated(tmp_path):
+    """If the worktree already has a populated node_modules (shimmed before, or
+    the agent ran npm install), the shim is a no-op — it must not clobber it."""
+    main_nm = _make_main_clone_with_node_modules(str(tmp_path / "main"))
+    wt_fe = tmp_path / "wt" / "frontend"
+    wt_fe.mkdir(parents=True)
+    # pre-populate with something the agent created
+    (wt_fe / "node_modules").mkdir()
+    (wt_fe / "node_modules" / "agent-installed").mkdir()
+
+    script = _build_node_modules_shim_script(str(wt_fe), main_nm)
+    res = subprocess.run(["bash", "-c", script], capture_output=True, text=True)
+    assert res.returncode == 0, res.stderr
+
+    # the agent's content is preserved; nothing symlinked in
+    assert (wt_fe / "node_modules" / "agent-installed").is_dir()
+    assert not (wt_fe / "node_modules" / "react").exists()
+
+
+def test_shim_atomic_no_partial_state_on_missing_main(tmp_path):
+    """If the main clone has no node_modules, the shim is a no-op and leaves no
+    partial node_modules behind (clean fallback, not a broken half-state)."""
+    main_fe = tmp_path / "main" / "frontend"
+    main_fe.mkdir(parents=True)
+    (main_fe / "package.json").write_text("{}")  # frontend but NO node_modules
+    wt_fe = tmp_path / "wt" / "frontend"
+    wt_fe.mkdir(parents=True)
+
+    script = _build_node_modules_shim_script(str(wt_fe), str(main_fe / "node_modules"))
+    res = subprocess.run(["bash", "-c", script], capture_output=True, text=True)
+    # no main node_modules → nothing to link; the guard / empty-glob handles it
+    # cleanly, exit 0, and no partial node_modules with broken symlinks.
+    assert res.returncode == 0, res.stderr
+    wt_nm = wt_fe / "node_modules"
+    if wt_nm.exists():
+        # if created, it must not contain broken symlinks
+        for entry in wt_nm.iterdir():
+            assert entry.exists() or entry.is_symlink(), f"broken entry {entry}"
+
+
+def test_ensure_shim_fail_soft_swallows_error_and_milestones():
+    """The public wrapper runs on EVERY worktree-strategy workflow's critical
+    path, so it must NEVER raise: an impl error is swallowed and recorded as a
+    ``frontend_node_modules_shim_failed`` milestone, leaving the worktree usable.
+    """
+    from unittest.mock import MagicMock
+
+    from app.modules.workspace.autonomous.git_workspace import GitWorkspaceService
+
+    svc = GitWorkspaceService(MagicMock())
+    wf = {"current_phase": "development"}
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("boom")
+
+    svc._ensure_frontend_node_modules_shim_impl = _boom  # type: ignore[assignment]
+
+    # must not raise
+    svc._ensure_frontend_node_modules_shim("/tmp/wt", MagicMock(name="gh"), wf)
+
+    # the failure was recorded as a milestone (auditable), not raised
+    svc._orch._create_milestone.assert_called_once()
+    kwargs = svc._orch._create_milestone.call_args.kwargs
+    assert kwargs["milestone_type"] == "frontend_node_modules_shim_failed"
+    assert kwargs["status"] == "failed"
+    assert "boom" in kwargs["error_message"]


### PR DESCRIPTION
## Problem

Autonomous dev workflows with frontend tests fail with ``EACCES`` on ``node_modules/.vite-temp`` (c88afdc0 / 83ffb529 / ee678c63):

\`\`\`
cd /home/dwu/open-ace-01/open-ace/frontend && HOME=/tmp/vitest-home-openace-agent npm run test
Error: EACCES: permission denied, open
  '/home/dwu/open-ace-01/open-ace/frontend/node_modules/.vite-temp/vitest.config.ts.timestamp-…mjs'
\`\`\`

The worktree has **no** ``frontend/node_modules`` (gitignored), so the agent (openace-agent) falls back to the project owner's (dwu) main-clone node_modules; vite writes its bundled config to ``node_modules/.vite-temp`` (hardcoded, relative to node_modules), which is dwu-owned → EACCES → vitest startup fails → 0 tests → test-evidence gate fails the workflow. The agent's /tmp-config workaround → ``Cannot find module 'vitest/config'``.

## Fix

``ensure_worktree`` now injects a **worktree-local** ``node_modules``:
- **symlinks** each package from the main clone (instant reuse — no ``npm install``, no network);
- creates the writable cache dirs (``.vite-temp``/``.vite``/``.vitest``/``.cache``) as **REAL** worktree dirs.

The existing per-worktree ACL grant (``scripts/openace-run-as.sh``: ``find $project_dir … setfacl``, which prunes ``-type l``) already gives the agent rwX on real worktree dirs, so the cache dirs become agent-writable; package reads go through symlinks (read access already worked — the failure was a write). The agent no longer falls back to the main clone, and **isolation is preserved** (it writes only inside its worktree; the main clone is untouched).

### Hardening (per independent plan review)
- **fail-soft airtight**: the shim runs on every worktree-strategy workflow's critical path, so the public wrapper swallows every exception (logs + records a ``frontend_node_modules_shim_failed`` milestone); worktree creation can never be blocked by it.
- **atomic / no partial state**: the script builds into a temp dir then ``mv``s it into place — a mid-run failure leaves no broken half-state (clean fallback).
- **idempotent**: a populated ``node_modules`` (shimmed before, or the agent ran ``npm install``) is left untouched.
- **cwd-independent**: all paths absolute; the caller runs it as ``system_account`` via a new additive ``_run_as_account`` (mirrors ``_run_git``'s ``sudo -u`` wrapping only — not its git machinery; ``cwd`` is impossible under ``sudo -u`` (#1421)).
- **cache dirs unconditional**: created even if absent from the main clone (vite/vitest create them on-demand at runtime).

## Tests (TDD)

New ``tests/autonomous/test_git_workspace_node_modules_shim.py`` (real tmp dirs + bash, no sudo/git needed):
- packages symlinked, cache dirs REAL + writable.
- idempotent (populated node_modules untouched).
- atomic no-partial-state when main clone lacks node_modules.
- fail-soft wrapper swallows impl errors + records milestone.

All 127 autonomous tests pass; mypy/ruff/black/pydocstyle/bandit clean.

## Known gap (not addressed)

``resolve_merge_conflicts``'s temp worktree also runs the agent + tests; a frontend conflict there would hit the same EACCES. Left for a follow-up (frontend conflicts are rare; the failing workflows are all dev-phase).

## Deploy

Hotpatch: cp ``git_workspace.py`` + ``github_ops.py`` to ``/home/openace/app/...`` + restart ``openace-scheduler.service`` (no migration). Then reset c88afdc0/83ffb529/ee678c63 to ``developing`` and verify vitest starts (test_evidence shows collected>0, not framework-with-null-counts).