### PR TITLE
fix(autonomous): keep worktree_path on failed cleanup for self-heal

### DIFF
--- a/app/modules/workspace/autonomous/git_workspace.py
+++ b/app/modules/workspace/autonomous/git_workspace.py
@@ -687,19 +687,17 @@ class GitWorkspaceService:
                 # Must use the main repo's gh — a worktree can't remove itself.
                 main_gh = _GitHubOps(project_path, system_account=system_account)
                 main_gh.remove_worktree(worktree_path)
-                if reason == "failed":
-                    # Keep ``worktree_path`` so :meth:`ensure_worktree` recreates
-                    # the worktree on retry/reset — only the dir was removed above.
-                    # This realizes the cleanup docstring's promise ("_ensure_worktree
-                    # recreates it on the next cycle if retried/resumed"), which
-                    # clearing it here defeated: the empty-path guard then fell back
-                    # to the main clone instead of recreating, so a reset failed
-                    # workflow re-ran against the main clone and hit EACCES on
-                    # ``node_modules/.vite-temp`` (#23: c88afdc0/83ffb529/ee678c63).
-                    # Mirrors the dirty-retention branch above, which also keeps
-                    # worktree_path. The completed/merged path clears it below.
-                    pass
-                else:
+                # On the completed/merged path, clear worktree_path (the workflow
+                # is done). On the failed path, KEEP it: the dir was just removed,
+                # but the path lets _ensure_worktree recreate the worktree on
+                # retry/reset — realizing the cleanup docstring's promise
+                # ("_ensure_worktree recreates it on the next cycle if retried/
+                # resumed"), which clearing it defeated (the empty-path guard fell
+                # back to the main clone instead of recreating, so a reset failed
+                # workflow re-ran against the main clone and hit EACCES on
+                # node_modules/.vite-temp — #23: c88afdc0/83ffb529/ee678c63). This
+                # mirrors the dirty-retention branch above, which also keeps it.
+                if reason != "failed":
                     self._orch._update_workflow({"worktree_path": ""})
             if remove_branch and branch_name:
                 gh = _GitHubOps(project_path, system_account=system_account)

--- a/app/modules/workspace/autonomous/git_workspace.py
+++ b/app/modules/workspace/autonomous/git_workspace.py
@@ -687,7 +687,20 @@ class GitWorkspaceService:
                 # Must use the main repo's gh — a worktree can't remove itself.
                 main_gh = _GitHubOps(project_path, system_account=system_account)
                 main_gh.remove_worktree(worktree_path)
-                self._orch._update_workflow({"worktree_path": ""})
+                if reason == "failed":
+                    # Keep ``worktree_path`` so :meth:`ensure_worktree` recreates
+                    # the worktree on retry/reset — only the dir was removed above.
+                    # This realizes the cleanup docstring's promise ("_ensure_worktree
+                    # recreates it on the next cycle if retried/resumed"), which
+                    # clearing it here defeated: the empty-path guard then fell back
+                    # to the main clone instead of recreating, so a reset failed
+                    # workflow re-ran against the main clone and hit EACCES on
+                    # ``node_modules/.vite-temp`` (#23: c88afdc0/83ffb529/ee678c63).
+                    # Mirrors the dirty-retention branch above, which also keeps
+                    # worktree_path. The completed/merged path clears it below.
+                    pass
+                else:
+                    self._orch._update_workflow({"worktree_path": ""})
             if remove_branch and branch_name:
                 gh = _GitHubOps(project_path, system_account=system_account)
                 result = gh.delete_branch(branch_name)

--- a/app/routes/autonomous.py
+++ b/app/routes/autonomous.py
@@ -1249,11 +1249,13 @@ def retry_workflow(workflow_id):
             return jsonify({"error": "max_changed_files_override must be a positive integer"}), 400
         retry_updates["max_changed_files_override"] = new_limit
     # Restore worktree_path so _ensure_worktree recreates the worktree dir on
-    # the retry pass. Terminal-failure cleanup (_cleanup_worktree_and_branch)
-    # clears worktree_path after removing the dir; the canonical path survives
-    # in preferred_worktree_path, so rebind it here. Without this, an empty
-    # worktree_path makes _ensure_worktree fall back to project_path and later
-    # phases run against the main checkout (review P1-1; see also #2011/#1981).
+    # the retry pass. Since #2505, terminal-failure cleanup KEEPS worktree_path
+    # (pointing at the removed dir) so _ensure_worktree recreates it on retry —
+    # but a legacy workflow (or one that failed before that deploy) may still
+    # have an empty/stale path, so rebind to the canonical preferred_worktree_path.
+    # Without it, an empty worktree_path makes _ensure_worktree fall back to
+    # project_path and later phases run against the main checkout (review P1-1;
+    # see also #2011/#1981).
     preferred_wt = (workflow.get("preferred_worktree_path") or "").strip()
     if preferred_wt and workflow.get("branch_strategy") == "worktree":
         retry_updates["worktree_path"] = preferred_wt

--- a/tests/autonomous/test_git_workspace_node_modules_shim.py
+++ b/tests/autonomous/test_git_workspace_node_modules_shim.py
@@ -134,3 +134,76 @@ def test_ensure_shim_fail_soft_swallows_error_and_milestones():
     assert kwargs["milestone_type"] == "frontend_node_modules_shim_failed"
     assert kwargs["status"] == "failed"
     assert "boom" in kwargs["error_message"]
+
+
+def test_cleanup_failed_keeps_worktree_path_for_recreate(tmp_path):
+    """A terminally-failed workflow's worktree DIR is removed but ``worktree_path``
+    is KEPT so :meth:`ensure_worktree` recreates the worktree on retry/reset (#23).
+
+    The cleanup docstring already promises "_ensure_worktree recreates it on the
+    next cycle if retried/resumed", but clearing ``worktree_path`` here defeated
+    that: ``ensure_worktree``'s empty-path guard then falls back to the main
+    clone instead of recreating — so a reset failed workflow re-ran in the main
+    clone and hit EACCES on ``node_modules/.vite-temp`` (c88afdc0/83ffb529/
+    ee678c63). The completed/merged path still clears it (merged = done).
+    """
+    from unittest.mock import MagicMock, patch
+
+    from app.modules.workspace.autonomous.git_workspace import GitWorkspaceService
+
+    orch = MagicMock()
+    orch._workflow_id = "wid-failed-keep"
+    orch.workflow = {
+        "branch_name": "auto-dev/x",
+        "worktree_path": str(tmp_path / "wt"),
+        "project_path": str(tmp_path / "main"),
+        "user_id": None,
+    }
+    updates: list[dict] = []
+    orch._update_workflow.side_effect = lambda d: updates.append(d)
+
+    fake_gh = MagicMock()
+    fake_gh.has_uncommitted_changes.return_value = False  # clean → dir removed
+
+    with patch("app.modules.workspace.autonomous.orchestrator.GitHubOps", return_value=fake_gh):
+        svc = GitWorkspaceService(orch)
+        ok = svc.cleanup_worktree_and_branch(reason="failed", remove_worktree=True)
+
+    assert ok is True
+    fake_gh.remove_worktree.assert_called_once()
+    # worktree_path must NOT be cleared (no update setting it to "")
+    cleared = [u for u in updates if u.get("worktree_path") == ""]
+    assert cleared == [], f"failed-cleanup must keep worktree_path for recreate, got {updates}"
+
+
+def test_cleanup_completed_clears_worktree_path(tmp_path):
+    """The completed/merged path still clears ``worktree_path`` (the merged
+    workflow is done; ensure_worktree's empty-path guard correctly returns the
+    main clone for any post-merge probe)."""
+    from unittest.mock import MagicMock, patch
+
+    from app.modules.workspace.autonomous.git_workspace import GitWorkspaceService
+
+    orch = MagicMock()
+    orch._workflow_id = "wid-completed-clear"
+    orch.workflow = {
+        "branch_name": "auto-dev/y",
+        "worktree_path": str(tmp_path / "wt"),
+        "project_path": str(tmp_path / "main"),
+        "user_id": None,
+    }
+    updates: list[dict] = []
+    orch._update_workflow.side_effect = lambda d: updates.append(d)
+
+    fake_gh = MagicMock()  # completed path: no dirty guard, reclaimed directly
+
+    with patch("app.modules.workspace.autonomous.orchestrator.GitHubOps", return_value=fake_gh):
+        svc = GitWorkspaceService(orch)
+        ok = svc.cleanup_worktree_and_branch(
+            reason="completed", remove_worktree=True, remove_branch=True
+        )
+
+    assert ok is True
+    # worktree_path IS cleared for completed
+    cleared = [u for u in updates if u.get("worktree_path") == ""]
+    assert cleared, f"completed-cleanup must clear worktree_path, got {updates}"

--- a/tests/issues/1831/test_orchestrator_failure_cleanup.py
+++ b/tests/issues/1831/test_orchestrator_failure_cleanup.py
@@ -65,9 +65,10 @@ class TestCleanupWorktreeAndBranch:
         assert ok is True
         instance.remove_worktree.assert_called_once_with("/tmp/test-wt")
         instance.delete_branch.assert_not_called()  # keep_for_debug
-        # worktree_path cleared, branch_name NOT cleared.
+        # worktree_path is KEPT (dir removed above) so ensure_worktree recreates
+        # the worktree on retry/reset (#23); branch_name NOT cleared.
         updates = _update_calls(orch)
-        assert {"worktree_path": ""} in updates
+        assert not any(u.get("worktree_path") == "" for u in updates)
         assert not any("branch_name" in u for u in updates)
 
     @patch("app.modules.workspace.autonomous.orchestrator.GitHubOps")
@@ -246,7 +247,9 @@ class TestDirtyWorktreeGuard:
         assert ok is True
         instance.remove_worktree.assert_called_once_with("/tmp/test-wt")
         updates = _update_calls(orch)
-        assert {"worktree_path": ""} in updates
+        # worktree_path is KEPT (dir reclaimed above) so ensure_worktree
+        # recreates the worktree on retry/reset (#23).
+        assert not any(u.get("worktree_path") == "" for u in updates)
 
     @patch("app.modules.workspace.autonomous.orchestrator.GitHubOps")
     def test_dirty_retention_note_is_idempotent(self, mock_gh_cls):


### PR DESCRIPTION
## Problem

`cleanup_worktree_and_branch` cleared ``worktree_path`` after removing a failed workflow's worktree dir. This defeated the method's own docstring promise — *"\`_ensure_worktree\` recreates it on the next cycle if retried/resumed"* — because ``ensure_worktree``'s empty-path guard then fell back to the **main clone** instead of recreating the worktree.

Result: a failed-then-reset workflow re-ran against the main clone (the project owner's checkout) and hit ``EACCES`` on ``node_modules/.vite-temp`` (c88afdc0 / 83ffb529 / ee678c63): the owner's node_modules isn't writable by the agent (openace-agent), and the worktree node_modules shim (PR #2504) only applies inside a worktree.

## Fix

Keep ``worktree_path`` on the **failed** path (the dir is still removed above) so ``ensure_worktree`` recreates the worktree on retry/reset. The **completed/merged** path still clears it (merged = done). This mirrors the dirty-retention branch, which already keeps ``worktree_path``.

``_mark_failed`` never cleared it (only the convergence-point cleanup did) — so this is the single failure-path clearer.

## Tests (TDD)

- ``test_cleanup_failed_keeps_worktree_path_for_recreate`` — failed+clean → dir removed, ``worktree_path`` KEPT (RED before / GREEN after).
- ``test_cleanup_completed_clears_worktree_path`` — completed → ``worktree_path`` cleared (guard, GREEN before & after).
- Updated 2 legacy assertions in ``tests/issues/1831/`` that encoded the old "failed clears worktree_path" contract (these don't run in CI — ``tests/issues`` is excluded — but updated for local correctness). One pre-existing unrelated failure remains there (``_session_usage_offsets`` test rot).

129 autonomous tests pass; mypy/ruff/black/pydocstyle/bandit clean.

## Deploy + verify

Hotpatch (no migration): cp ``git_workspace.py`` + restart scheduler. The 3 workflows were already re-reset with ``worktree_path`` set (immediate unblock); this PR makes future failed-then-reset workflows self-heal without the manual reset step.