### PR TITLE
fix(projects): filter out non-project paths from project picker

### DIFF
--- a/app/routes/projects.py
+++ b/app/routes/projects.py
@@ -10,6 +10,7 @@ import logging
 import os
 import platform
 import pwd
+import re
 import subprocess
 
 from flask import Blueprint, g, jsonify, request
@@ -170,6 +171,32 @@ def api_get_projects():
     )
 
 
+# Patterns for paths that should NOT be shown as projects
+# These are user home directories, system directories, or other non-project paths
+_NON_PROJECT_PATH_PATTERNS = [
+    # Windows user home: C:\Users\xxx or C:\Users\xxx\
+    r"^[A-Za-z]:\\Users\\[^\\]+\\?$",
+    # Windows system directory: C:\Windows or C:\Windows\*
+    r"^[A-Za-z]:\\Windows(?:\\|$)",
+    # Linux root home
+    r"^/root/?$",
+    # Linux user home: /home/xxx or /home/xxx/
+    r"^/home/[^/]+/?$",
+]
+
+
+def _is_valid_project_path(path: str) -> bool:
+    """Check if path is a valid project path (not a user/system directory).
+
+    Filters out paths that are user home directories or system directories,
+    which should not be displayed as projects in the project picker.
+    """
+    for pattern in _NON_PROJECT_PATH_PATTERNS:
+        if re.match(pattern, path):
+            return False
+    return True
+
+
 def _fetch_remote_projects(user_id: int) -> list[dict]:
     r"""Return deduplicated remote/terminal workspace projects for a user.
 
@@ -196,6 +223,9 @@ def _fetch_remote_projects(user_id: int) -> list[dict]:
     for r in rows:
         path = r["project_path"]
         if not path or path in {o["path"] for o in out}:
+            continue
+        # Filter out non-project paths (user home, system directories)
+        if not _is_valid_project_path(path):
             continue
         name = path.replace("\\", "/").rstrip("/").split("/")[-1] or path
         out.append(

--- a/tests/unit/test_fetch_remote_projects.py
+++ b/tests/unit/test_fetch_remote_projects.py
@@ -169,3 +169,83 @@ class TestSessionHistorySync:
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
+
+
+class TestIsValidProjectPath:
+    """Tests for _is_valid_project_path function (Issue #2510)."""
+
+    def test_windows_user_home_is_invalid(self):
+        """Windows user home directory should be filtered out."""
+        from app.routes.projects import _is_valid_project_path
+
+        assert _is_valid_project_path(r"C:\Users\fan_q") is False
+        assert _is_valid_project_path("C:\\Users\\fan_q\\") is False  # noqa: E501
+        assert _is_valid_project_path(r"C:\Users\Administrator") is False
+
+    def test_windows_system_directory_is_invalid(self):
+        """Windows system directories should be filtered out."""
+        from app.routes.projects import _is_valid_project_path
+
+        assert _is_valid_project_path(r"C:\Windows\System32") is False
+        assert _is_valid_project_path(r"C:\Windows") is False
+
+    def test_linux_user_home_is_invalid(self):
+        """Linux user home directories should be filtered out."""
+        from app.routes.projects import _is_valid_project_path
+
+        assert _is_valid_project_path("/root") is False
+        assert _is_valid_project_path("/root/") is False
+        assert _is_valid_project_path("/home/user") is False
+        assert _is_valid_project_path("/home/qlfan/") is False
+
+    def test_valid_project_paths_are_accepted(self):
+        """Valid project paths should pass the filter."""
+        from app.routes.projects import _is_valid_project_path
+
+        # Windows project paths
+        assert _is_valid_project_path(r"C:\workspace") is True
+        assert _is_valid_project_path(r"C:\workspace\project1") is True
+        assert _is_valid_project_path(r"C:\Users\fan_q\project") is True
+        assert _is_valid_project_path(r"C:\Users\fan_q\.zcode\v2") is True
+
+        # Linux project paths
+        assert _is_valid_project_path("/home/user/project") is True
+        assert _is_valid_project_path("/root/workspace") is True
+        assert _is_valid_project_path("/opt/projects/app") is True
+
+    def test_fetch_remote_projects_filters_non_project_paths(self):
+        """Test that _fetch_remote_projects filters out non-project paths."""
+        from app.routes.projects import _fetch_remote_projects
+
+        mock_db = MagicMock()
+        mock_db.fetch_all.return_value = [
+            # Should be filtered out: Windows user home
+            {"project_path": r"C:\Users\fan_q", "remote_machine_id": "win-1"},
+            # Should be filtered out: Windows system directory
+            {"project_path": r"C:\Windows\System32", "remote_machine_id": "win-1"},
+            # Should be included: Valid project
+            {"project_path": r"C:\workspace", "remote_machine_id": "win-1"},
+            # Should be included: Subdirectory under user home (valid project)
+            {"project_path": r"C:\Users\fan_q\project", "remote_machine_id": "win-1"},
+            # Should be filtered out: Linux user home
+            {"project_path": "/home/qlfan", "remote_machine_id": "linux-1"},
+            # Should be included: Linux project
+            {"project_path": "/home/qlfan/workspace/open-ace", "remote_machine_id": "linux-1"},
+        ]
+
+        with (
+            patch("app.repositories.database.Database", return_value=mock_db),
+            patch("app.routes.projects.get_current_tenant_id", return_value=1),
+        ):
+            result = _fetch_remote_projects(user_id=1)
+
+        # Only 3 valid projects should be returned
+        paths = [r["path"] for r in result]
+        assert len(result) == 3
+        assert r"C:\workspace" in paths
+        assert r"C:\Users\fan_q\project" in paths
+        assert "/home/qlfan/workspace/open-ace" in paths
+        # Filtered out
+        assert r"C:\Users\fan_q" not in paths
+        assert r"C:\Windows\System32" not in paths
+        assert "/home/qlfan" not in paths


### PR DESCRIPTION
## Issue #2510: 项目选择器显示非项目路径

### 问题描述

升级到 v1.2.x 后，点击新建会话，本地工作区项目选择器显示了不应该显示的 Windows 路径：
- `C:\Users\[user]` (Windows 用户主目录)
- `C:\Windows\System32` (Windows 系统目录)
- 其他非项目目录

### 根因分析

PR #2478 添加了 `_fetch_remote_projects` 函数，从 `agent_sessions` 表获取 `remote` 和 `terminal` 类型的会话路径，合并到 `/api/projects` 返回结果中。

问题在于没有过滤非项目路径：
1. Windows 用户目录：`C:\Users\*` 是用户主目录，不是项目
2. Windows 系统目录：`C:\Windows\*` 是系统目录，不应显示
3. Linux 系统目录：`/root`、`/home` 等也可能被误记录

### 修复方案

在 `_fetch_remote_projects` 函数中添加路径过滤逻辑：

```python
# 过滤非项目路径的正则模式
_NON_PROJECT_PATH_PATTERNS = [
    r"^[A-Za-z]:\\Users\\[^\\]+\\?$",  # C:\Users\xxx
    r"^[A-Za-z]:\\Windows(?:\\|$)",        # C:\Windows*
    r"^/root/?$",                              # /root
    r"^/home/[^/]+/?$",                        # /home/xxx
]

def _is_valid_project_path(path: str) -> bool:
    """Check if path is a valid project path."""
    for pattern in _NON_PROJECT_PATH_PATTERNS:
        if re.match(pattern, path):
            return False
    return True
```

### 测试覆盖

添加 5 个新测试用例验证过滤逻辑：
- Windows 用户目录过滤
- Windows 系统目录过滤
- Linux 用户目录过滤
- 有效项目路径验证
- `_fetch_remote_projects` 集成测试

### 验证

```bash
pytest tests/unit/test_fetch_remote_projects.py -v
# 15 passed
```

Generated with Qwen Code (4-shotted by Qwen-Coder)