### PR TITLE
fix(verifier): recover truncated JSON + force JSON-only prompt for glm-5

### DIFF
--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -2210,6 +2210,117 @@ def _extract_verifier_json(text: str) -> dict | None:
             start = s.find("{", start + 1)
         return None
 
+    def _outer_balanced(s: str) -> str | None:
+        # Balanced { ... } starting at the FIRST { only — no skip-to-next.
+        # _first_balanced skips an unbalanced outer object and returns the
+        # first *inner* balanced object, which on a truncated root is a single
+        # verdict dict (no `verdicts` wrapper). _outer_balanced distinguishes
+        # "the outer object closed cleanly" from "it was truncated mid-object".
+        start = s.find("{")
+        if start == -1:
+            return None
+        depth = 0
+        in_str = False
+        escaped = False
+        for i in range(start, len(s)):
+            ch = s[i]
+            if escaped:
+                escaped = False
+                continue
+            if ch == "\\":
+                escaped = True
+                continue
+            if ch == '"':
+                in_str = not in_str
+                continue
+            if in_str:
+                continue
+            if ch == "{":
+                depth += 1
+            elif ch == "}":
+                depth -= 1
+                if depth == 0:
+                    return s[start : i + 1]
+        return None
+
+    def _closing_for(prefix: str) -> str | None:
+        # Close chars needed to balance prefix's still-open container stack
+        # (string-aware). Returns None when the prefix is malformed or ends
+        # inside an unterminated string (closing that would fabricate content).
+        stack: list[str] = []
+        in_str = False
+        escaped = False
+        for ch in prefix:
+            if escaped:
+                escaped = False
+                continue
+            if ch == "\\":
+                escaped = True
+                continue
+            if ch == '"':
+                in_str = not in_str
+                continue
+            if in_str:
+                continue
+            if ch in "{[":
+                stack.append(ch)
+            elif ch == "}":
+                if not stack or stack[-1] != "{":
+                    return None
+                stack.pop()
+            elif ch == "]":
+                if not stack or stack[-1] != "[":
+                    return None
+                stack.pop()
+        if in_str:
+            return None
+        return "".join("}" if c == "{" else "]" for c in reversed(stack))
+
+    def _repair_truncated_json_object(s: str) -> dict | None:
+        # Recover a JSON object the agent truncated mid-token (output-budget
+        # cut left it unbalanced). Records "safe" cut points — right after a
+        # structurally complete ``}``/``]`` that a separator or EOF follows —
+        # and for each (longest first) takes the prefix, appends the reverse
+        # of the open-container stack to close it, strips trailing commas, and
+        # tries to parse. Conservative: whatever the model was mid-way through
+        # is dropped, so an uncovered checklist item aggregates to indeterminate
+        # downstream (never a false confirmed). Returns None when nothing
+        # complete can be recovered. (#2394/#2328/#2349 infra-exhaustion.)
+        body = (s or "").strip()
+        brace0 = body.find("{")
+        if brace0 == -1:
+            return None
+        body = body[brace0:]
+        in_str = False
+        escaped = False
+        cuts: list[int] = []
+        for i, ch in enumerate(body):
+            if escaped:
+                escaped = False
+                continue
+            if ch == "\\":
+                escaped = True
+                continue
+            if ch == '"':
+                in_str = not in_str
+                continue
+            if in_str:
+                continue
+            if ch in "}]":
+                j = i + 1
+                while j < len(body) and body[j].isspace():
+                    j += 1
+                if j >= len(body) or body[j] in ",}]":
+                    cuts.append(i + 1)
+        for cut in sorted(set(cuts), reverse=True):
+            closers = _closing_for(body[:cut])
+            if closers is None:
+                continue
+            parsed = _try_parse(_strip_trailing_commas(body[:cut] + closers))
+            if parsed is not None:
+                return parsed
+        return None
+
     # 1) Prefer fenced ```json ... ``` regions (non-greedy per fence pair so two
     #    blocks don't merge). The LAST region wins — the agent may preface with
     #    an earlier partial draft. Within a region, take its first balanced {}.
@@ -2220,13 +2331,28 @@ def _extract_verifier_json(text: str) -> dict | None:
             parsed = _try_parse(obj)
             if parsed is not None:
                 return parsed
+        # A fenced region that opened JSON but never balanced (token-budget cut)
+        # before its closing fence: recover the complete prefix.
+        repaired = _repair_truncated_json_object(region.group(1))
+        if repaired is not None:
+            return repaired
 
-    # 2) No usable fenced region → balanced { ... } over the WHOLE text
-    #    (prose-wrapped / unfenced output). NOTE: this returns the FIRST
-    #    balanced object — if the agent writes prose with a JSON-shaped
-    #    reasoning object before the real verdict, that first object wins.
-    #    Bounded risk: a non-verdict dict lacks `verdicts`/`snapshot` and
-    #    downstream aggregates to indeterminate (never a false confirmed).
+    # 2) Whole-text OUTER object balanced? (prose-wrapped / unfenced output.)
+    obj = _outer_balanced(text)
+    if obj is not None:
+        parsed = _try_parse(obj)
+        if parsed is not None:
+            return parsed
+    # Truncated outer object (unbalanced root) — recover the complete prefix
+    # before falling back to any inner object.
+    repaired = _repair_truncated_json_object(text)
+    if repaired is not None:
+        return repaired
+    # 3) Last resort: a balanced object later in the text — the agent wrote
+    #    prose with a JSON-shaped reasoning object before the real verdict and
+    #    never produced the wrapper. Bounded risk: a non-verdict dict lacks
+    #    `verdicts`/`snapshot` and downstream aggregates to indeterminate
+    #    (never a false confirmed).
     obj = _first_balanced(text)
     if obj is not None:
         parsed = _try_parse(obj)
@@ -7819,20 +7945,26 @@ class AutonomousOrchestrator:
         return (
             "You are an INDEPENDENT acceptance verifier. The issue must NOT be considered done "
             "just because a PR merged. Verify the MERGED code (merge commit "
-            f"{merge_sha}, base {base_sha}) against this acceptance snapshot.\n\n"
+            f"{merge_sha}, base {base_sha}).\n\n"
+            "## OUTPUT FORMAT (mandatory)\n"
+            "Respond with a SINGLE fenced JSON object and NOTHING else. Do NOT write a summary, "
+            "heading, markdown report, or any prose before or after it — your first output after "
+            "the opening fence must be `{`. Keep each verdict to at most 2 evidence refs and each "
+            "note under 60 characters (terse evidence fits the output budget and avoids a "
+            "truncated, unparseable response).\n"
+            "```json\n"
+            '{"verdicts": [{"item": "...", "verdict": "confirmed|rejected|indeterminate", '
+            '"evidence": [{"ref": "file:line|git-diff", "note": "..."}], "rationale": "..."}], '
+            f'"snapshot": {snapshot_token}}}\n'
+            "```\n\n"
             f"Acceptance snapshot:\n{snap_dump}\n\n"
             f"{extraction_section}"
             "For each required_paths entry, confirm it was actually changed (use git diff/log). "
             "For each checklist item, determine confirmed/rejected/indeterminate against the merged "
             "code with a concrete file:line or git-diff evidence ref. Be CONSERVATIVE: if you cannot "
             "find concrete evidence, return indeterminate, not confirmed.\n\n"
-            "Reply with ONLY a fenced JSON block:\n"
-            "```json\n"
-            '{"verdicts": [{"item": "...", "verdict": "confirmed|rejected|indeterminate", '
-            '"evidence": [{"ref": "file:line|git-diff", "note": "..."}], "rationale": "..."}], '
-            f'"snapshot": {snapshot_token}}}\n'
-            "```\n"
-            f"{snapshot_note}"
+            f"{snapshot_note}\n"
+            "Output ONLY the fenced JSON object — no prose, no explanations."
         )
 
     def _parse_verifier_output(self, result) -> dict:

--- a/docs/superpowers/plans/2026-08-12-verifier-glm-prose-not-json.md
+++ b/docs/superpowers/plans/2026-08-12-verifier-glm-prose-not-json.md
@@ -1,0 +1,63 @@
+# Verifier glm-5 prose-not-JSON — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:test-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Stop glm-5 acceptance-verifier runs from stranding workflows at `acceptance_verification` with `infra_error: output was not valid JSON`, by (a) making the prompt force JSON-only output with terse evidence and (b) recovering truncated JSON in the extractor.
+
+**Architecture:** Two surgical edits in `app/modules/workspace/autonomous/orchestrator.py`. No schema, no new module.
+
+**Tech Stack:** Python, pytest.
+
+## Root cause (confirmed via prod scheduler logs, 2026-08-12)
+
+`journalctl -u openace-scheduler.service` shows the failing verifier runs. Of 4 sampled `raw_output`s:
+- **3 had ZERO JSON braces** — glm-5 emitted a markdown verification report (`## 验收总结`, `✅9/10 ❌...`) and never produced the mandated fenced JSON block. `_extract_verifier_json` returns `None` → `infra_error: output was not valid JSON` → 3 identical retries → pause.
+- **1 started JSON but was truncated** mid-object (open 11 / close 8) — `_first_balanced` finds no closing brace → `None` → same infra_error.
+
+Affects `2d0c317d` (#2328), `cd939cbf` (#2349), `b48179df` (#2394) — infra_retry 3/3/7. Prior fixes #29 (trailing-comma tolerance) and #30 (demand snapshot extraction) addressed adjacent symptoms but NOT the core "model emits prose instead of JSON" failure.
+
+## File Structure
+
+- Modify: `app/modules/workspace/autonomous/orchestrator.py`
+  - `_extract_verifier_json` (L2115) — add truncated-JSON recovery.
+  - `_build_verification_prompt` (L7786) — JSON-only contract first, cap evidence.
+- Test: `tests/unit/test_verifier_json_parse.py` (add truncation-recovery cases).
+- Test: `tests/unit/test_verifier_snapshot_prompt.py` (add JSON-only-contract cases).
+
+## Tasks
+
+### Task 1: Extractor recovers truncated fenced JSON
+
+**Files:**
+- Modify: `orchestrator.py:_extract_verifier_json` (add `_repair_truncated_json_object` helper)
+- Test: `tests/unit/test_verifier_json_parse.py`
+
+- [ ] **Step 1: Write failing tests** — truncated fenced block recovers the complete leading verdicts; truncated unfenced object recovers; mid-evidence-array truncation drops the incomplete verdict (conservative).
+- [ ] **Step 2: Run → RED** (`pytest tests/unit/test_verifier_json_parse.py -k truncated -v`)
+- [ ] **Step 3: Implement** `_repair_truncated_json_object` (string-aware stack walk; try progressively shorter cut points back to the last complete `}`/`]`, append reverse of open stack, strip trailing commas, `json.loads`; return longest parseable dict or None). Call it from `_extract_verifier_json` after the balanced attempts fail, before returning None.
+- [ ] **Step 4: Run → GREEN** (all extractor tests pass).
+- [ ] **Step 5: Commit.**
+
+### Task 2: Prompt forces JSON-only, caps evidence
+
+**Files:**
+- Modify: `orchestrator.py:_build_verification_prompt`
+- Test: `tests/unit/test_verifier_snapshot_prompt.py`
+
+- [ ] **Step 1: Write failing tests** — prompt leads with a JSON-only/no-preamble contract that appears BEFORE the snapshot dump; prompt caps evidence (≤2 refs, short notes); existing `_MARKER` extraction + snapshot-token tests stay green.
+- [ ] **Step 2: Run → RED.**
+- [ ] **Step 3: Implement** — move the format contract to the top of the prompt; add the evidence cap; reinforce "ONLY JSON, no prose" at the end; keep `_MARKER` and snapshot-token logic intact.
+- [ ] **Step 4: Run → GREEN** (all prompt tests pass).
+- [ ] **Step 5: Commit.**
+
+### Task 3: Review, PR, deploy, reset, verify
+
+- [ ] Independent code review (superpowers:requesting-code-review) on `gh pr diff`.
+- [ ] CI green (lint / test(3.10-3.12) / build).
+- [ ] Merge + deploy hotpatch (cp app/ + restart scheduler + curl :9091/livez).
+- [ ] Reset 2d0c317d/cd939cbf/b48179df → status=verification_pending, clear verification_report/status/attempt + retry fields, restore worktree_path per skill COALESCE.
+- [ ] Monitor → confirm the verifier produces parseable JSON and the workflows advance past acceptance_verification (no `not valid JSON` infra_error).
+
+## Safety
+
+Truncation recovery cannot false-confirm: any checklist item whose verdict was truncated is simply absent from the recovered `verdicts`, and `acceptance_verification.handle` (L464-483) forces absent checklist items to `indeterminate`, so the aggregate never becomes `confirmed` on incomplete evidence. A recovered malformed trailing verdict is dropped by the phase handler's per-verdict validation (L388-433). Both paths are conservative.

--- a/tests/unit/test_verifier_json_parse.py
+++ b/tests/unit/test_verifier_json_parse.py
@@ -79,3 +79,62 @@ def test_last_fenced_block_wins_when_agent_prefaces_a_partial():
     )
     result = _extract(text)
     assert result == {"verdicts": [{"item": "a", "verdict": "confirmed"}]}
+
+
+# --- Truncation recovery (prod: glm-5 sometimes starts JSON but the output is
+# cut off mid-object — token-budget exhaustion leaves an unbalanced fence).
+# Recovery must keep the COMPLETE leading verdicts and drop the trailing
+# incomplete one. Safe: a dropped checklist verdict becomes indeterminate
+# downstream (never a false confirmed). #2394/#2328/#2349 infra-exhaustion.
+
+
+def test_truncated_fenced_json_recovers_complete_prefix():
+    # Model wrote verdict "a" fully, then ran out of tokens mid-"rejected" on "b".
+    text = (
+        "Based on my verification:\n```json\n"
+        '{"verdicts": [{"item": "a", "verdict": "confirmed"}, '
+        '{"item": "b", "verdict": "reject'
+    )
+    result = _extract(text)
+    assert result is not None
+    items = [v["item"] for v in result["verdicts"]]
+    assert "a" in items  # complete verdict recovered
+    assert "b" not in items  # incomplete trailing verdict dropped
+
+
+def test_truncated_unfenced_json_recovers():
+    # Prose preface + an unfenced JSON object cut off before the closing brace.
+    text = (
+        "Here is my assessment: "
+        '{"verdicts": [{"item": "a", "verdict": "confirmed"}, '
+        '{"item": "b", "verdict": "rejected"}'
+    )
+    result = _extract(text)
+    assert result is not None
+    assert result["verdicts"] == [
+        {"item": "a", "verdict": "confirmed"},
+        {"item": "b", "verdict": "rejected"},
+    ]
+
+
+def test_truncation_mid_evidence_keeps_complete_verdict_prefix():
+    # Truncation inside a verdict's evidence array: keep the verdict with the
+    # evidence completed so far, drop the dangling incomplete ref.
+    text = (
+        "```json\n"
+        '{"verdicts": [{"item": "a", "verdict": "confirmed", '
+        '"evidence": [{"ref": "file.py:10"}, {"ref": "file.py'
+    )
+    result = _extract(text)
+    assert result is not None
+    assert len(result["verdicts"]) == 1
+    assert result["verdicts"][0]["item"] == "a"
+    # The first complete evidence ref survived; the truncated one is gone.
+    refs = [e["ref"] for e in result["verdicts"][0]["evidence"]]
+    assert "file.py:10" in refs
+
+
+def test_truncated_object_with_no_complete_element_returns_none():
+    # Cut off before ANY complete verdict — nothing safe to recover.
+    text = '```json\n{"verdicts": [{"item": "a", "verdict": "conf'
+    assert _extract(text) is None

--- a/tests/unit/test_verifier_snapshot_prompt.py
+++ b/tests/unit/test_verifier_snapshot_prompt.py
@@ -58,3 +58,43 @@ def test_prompt_fenced_snapshot_token_is_valid_json_both_cases():
     # No prose leaked into the value position.
     assert '"snapshot": null ' not in full_prompt
     assert '"snapshot": the' not in empty_prompt
+
+
+# --- glm-5 prose-instead-of-json compliance (prod 2026-08-12): the verifier
+# repeatedly emitted a markdown report ("## 验收总结 ✅9/10") and never produced
+# the fenced JSON block, stranding workflows with infra_error "not valid JSON".
+# The prompt must make JSON-only output unmissable and cap evidence so the JSON
+# fits the output budget (avoids truncation too).
+
+
+def test_prompt_leads_with_json_only_contract_before_snapshot():
+    prompt = _prompt(
+        AcceptanceSnapshot(required_paths=["app/x.py"], checklist=["done"], source="convention")
+    )
+    # A JSON-only mandate exists and appears BEFORE the acceptance snapshot dump
+    # so glm sees the format contract first, not last.
+    contract = "fenced JSON object"
+    assert contract in prompt
+    assert prompt.index(contract) < prompt.index("Acceptance snapshot")
+    # Explicit prohibition of prose/preamble.
+    lower = prompt.lower()
+    assert "nothing else" in lower or "no prose" in lower
+
+
+def test_prompt_caps_evidence_verbosity():
+    # Verbose evidence (5-11 refs/verdict, long notes) ballooned the JSON and
+    # exhausted the output budget mid-object. Cap refs + note length.
+    prompt = _prompt(
+        AcceptanceSnapshot(required_paths=["app/x.py"], checklist=["done"], source="convention")
+    )
+    lower = prompt.lower()
+    assert "at most 2" in lower or "at most two" in lower
+    assert "60 character" in lower or "60-char" in lower
+
+
+def test_prompt_reinforces_json_only_at_end():
+    prompt = _prompt(
+        AcceptanceSnapshot(required_paths=["app/x.py"], checklist=["done"], source="convention")
+    )
+    # Trailing reinforcement so glm doesn't drift into prose at the end.
+    assert "ONLY" in prompt


### PR DESCRIPTION
## Problem

The acceptance verifier (glm-5 on prod) repeatedly stranded workflows at `acceptance_verification` with `infra_error: output was not valid JSON`, exhausting the 3 infra-retries and pausing — affects 2d0c317d (#2328), cd939cbf (#2349), b48179df (#2394); infra_retry 3/3/7.

Prod scheduler logs show two failure modes:

1. **glm-5 ignored "reply with ONLY a fenced JSON block"** and emitted a markdown verification report (`## 验收总结 ✅9/10`) with **no JSON at all** (3 of 4 sampled failures).
2. **glm-5 started the JSON but the output was truncated** mid-object (output-budget cut), leaving an unbalanced fence.

Prior fixes (#29 trailing-comma tolerance, #30 demand snapshot extraction) addressed adjacent symptoms, not these.

## Fix

**Prompt (`_build_verification_prompt`):** lead with a mandatory JSON-only output contract (before the snapshot dump, where glm sees it first), forbid prose/preamble, cap each verdict to ≤2 evidence refs with <60-char notes (terse output fits the budget → avoids truncation), reinforce at the end.

**Extractor (`_extract_verifier_json`):** add truncated-JSON recovery. When the outer object is unbalanced, walk string-aware to safe cut points (after a complete `}`/`]`), append the reverse of the open-container stack to close it, strip trailing commas, and parse — returning the longest recoverable dict.

## Safety

Truncation recovery cannot false-confirm: whatever the model was mid-way through is dropped, so an uncovered checklist item is simply absent from `verdicts`, and `acceptance_verification.handle` (L464-483) forces absent checklist items to `indeterminate` — the aggregate never becomes `confirmed` on incomplete evidence. A recovered malformed trailing verdict is dropped by the phase handler's per-verdict validation (L388-433). Both paths are conservative.

## Tests

- `tests/unit/test_verifier_json_parse.py`: +4 cases (truncated fenced/unfenced, mid-evidence, no-complete-element → None). 12/12 pass.
- `tests/unit/test_verifier_snapshot_prompt.py`: +3 cases (JSON-only contract leads, evidence cap, reinforcement). 6/6 pass.
- Full acceptance suite (2335/2431 + verification agent): 143/143 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)