### PR TITLE
fix: GET request with Content-Type: application/json returns 400

### DIFF
--- a/app/auth/decorators.py
+++ b/app/auth/decorators.py
@@ -904,6 +904,8 @@ def _extract_target_tenant_id() -> int | None:
 
     Returns:
         int | None: Target tenant ID or None if cannot determine
+
+    Issue #2511: Only read request body for methods that have body (POST/PUT/PATCH).
     """
     target_tenant_id = None
     sources = []
@@ -913,16 +915,19 @@ def _extract_target_tenant_id() -> int | None:
         target_tenant_id = request.view_args["tenant_id"]
         sources.append(("url", target_tenant_id))
 
-    # 2. Request body (POST/PUT)
-    if request.is_json:
-        try:
-            body_tenant_id = request.json.get("tenant_id")
+    # 2. Request body (POST/PUT/PATCH only)
+    # Issue #2511: Only read body for methods that have body to avoid BadRequest on GET
+    if request.method in ("POST", "PUT", "PATCH") and request.is_json:
+        body = request.get_json(silent=True)
+        if isinstance(body, dict):
+            body_tenant_id = body.get("tenant_id")
             if body_tenant_id is not None:
-                sources.append(("body", int(body_tenant_id)))
-                if target_tenant_id is None:
-                    target_tenant_id = int(body_tenant_id)
-        except (TypeError, ValueError):
-            pass
+                try:
+                    sources.append(("body", int(body_tenant_id)))
+                    if target_tenant_id is None:
+                        target_tenant_id = int(body_tenant_id)
+                except (TypeError, ValueError):
+                    pass
 
     # 3. Query parameter
     query_tenant_id = request.args.get("tenant_id", type=int)
@@ -1546,17 +1551,20 @@ def api_key_admin_required(f=None):
 
             # 2. 提取请求中的 tenant_id
             # Issue #2327: 请求 tenant_id 是"目标选择"而非"授权凭据"
+            # Issue #2511: 只在 POST/PUT/PATCH 方法时读取 body，避免 GET 请求解析空 body 失败
             requested_tenant_id = None
 
             # 从 URL path 参数提取（如 /api/api-keys/<key_id> 不需要 tenant_id in path）
-            # 从 request body 提取（POST/PUT）
-            if request.is_json:
-                try:
-                    body_tenant_id = request.json.get("tenant_id")
+            # 从 request body 提取（POST/PUT/PATCH only）
+            if request.method in ("POST", "PUT", "PATCH") and request.is_json:
+                body = request.get_json(silent=True)
+                if isinstance(body, dict):
+                    body_tenant_id = body.get("tenant_id")
                     if body_tenant_id is not None:
-                        requested_tenant_id = int(body_tenant_id)
-                except (TypeError, ValueError):
-                    return jsonify({"error": "Invalid tenant_id in request body"}), 400
+                        try:
+                            requested_tenant_id = int(body_tenant_id)
+                        except (TypeError, ValueError):
+                            return jsonify({"error": "Invalid tenant_id in request body"}), 400
 
             # 从 query parameter 提取（GET）
             if requested_tenant_id is None:

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -18,7 +18,7 @@ describe('ApiClient', () => {
   });
 
   describe('get', () => {
-    it('should make a GET request', async () => {
+    it('should make a GET request without Content-Type header (Issue #2511)', async () => {
       const mockData = { message: 'success' };
       vi.mocked(fetch).mockResolvedValueOnce({
         ok: true,
@@ -28,11 +28,12 @@ describe('ApiClient', () => {
 
       const result = await client.get('/api/test');
 
+      // Issue #2511: GET requests should NOT have Content-Type header since there's no body
       expect(fetch).toHaveBeenCalledWith(
         '/api/test',
         expect.objectContaining({
           method: 'GET',
-          headers: expect.objectContaining({
+          headers: expect.not.objectContaining({
             'Content-Type': 'application/json',
           }),
         })
@@ -68,7 +69,7 @@ describe('ApiClient', () => {
   });
 
   describe('post', () => {
-    it('should make a POST request with body', async () => {
+    it('should make a POST request with body and Content-Type header (Issue #2511)', async () => {
       const mockData = { id: 1 };
       const requestBody = { name: 'test' };
       vi.mocked(fetch).mockResolvedValueOnce({
@@ -79,11 +80,15 @@ describe('ApiClient', () => {
 
       const result = await client.post('/api/test', requestBody);
 
+      // Issue #2511: POST requests WITH body should have Content-Type header
       expect(fetch).toHaveBeenCalledWith(
         '/api/test',
         expect.objectContaining({
           method: 'POST',
           body: JSON.stringify(requestBody),
+          headers: expect.objectContaining({
+            'Content-Type': 'application/json',
+          }),
         })
       );
       expect(result).toEqual(mockData);

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -116,10 +116,13 @@ class ApiClient {
 
     const url = `${this.baseUrl}${endpoint}`;
 
+    // Issue #2511: Only set Content-Type when there's a body to avoid HTTP semantic violation
     const requestHeaders: Record<string, string> = {
-      'Content-Type': 'application/json',
       ...headers,
     };
+    if (body) {
+      requestHeaders['Content-Type'] = 'application/json';
+    }
 
     // Create abort controller for timeout
     const controller = new AbortController();


### PR DESCRIPTION
## 修复说明

关联 Issue：#2511

## 根因

后端装饰器 `api_key_admin_required` 和 `_extract_target_tenant_id()` 对所有 HTTP 方法读取 `request.json`，而 `request.is_json` 仅检查 Content-Type 头，不检查请求是否真的有 body。当 GET 请求携带 `Content-Type: application/json` 但无 body 时，`request.json` 解析空串失败，抛出 werkzeug `BadRequest` 异常。

前端 `ApiClient.request()` 对所有请求无条件设置 `Content-Type: application/json`，加剧了这个问题。

## 修复方案

后端为主、前端为辅的纵深防御：
1. 后端装饰器仅在有 body 的 HTTP 方法（POST/PUT/PATCH）读取 request body
2. 使用 `request.get_json(silent=True)` 容忍解析失败
3. 添加 `isinstance(body, dict)` 类型检查
4. 前端仅在有 body 时设置 Content-Type 头

## 主要变更

- `app/auth/decorators.py`:
  - `_extract_target_tenant_id()`: 仅 POST/PUT/PATCH 时读取 body，使用 `get_json(silent=True)`
  - `api_key_admin_required`: 同上
- `frontend/src/api/client.ts`:
  - `ApiClient.request()`: 仅在有 body 时设置 Content-Type

## 测试

- 本地测试：42 个 auth decorator 单元测试全部通过
- 代码检查：ruff 和 prettier 检查通过

## 风险

- 兼容性：无风险，POST/PUT/PATCH 请求仍能正确读取 body 中的 tenant_id
- 性能：无影响
- 安全：无影响，授权逻辑不变