### PR TITLE
fix: add SMTP config link in notification preferences modal

### DIFF
--- a/frontend/src/components/features/management/QuotaAlerts.tsx
+++ b/frontend/src/components/features/management/QuotaAlerts.tsx
@@ -8,6 +8,7 @@
  */
 
 import React, { useState, useMemo, useEffect, useCallback } from 'react';
+import { Link } from 'react-router-dom';
 import { cn } from '@/utils';
 import { useQuotaUsage, useQuotaStats, useUpdateQuota, usePageRefresh } from '@/hooks';
 import { useLanguage } from '@/store';
@@ -910,7 +911,11 @@ export const QuotaAlerts: React.FC = () => {
                     }
                     placeholder="your@email.com"
                   />
-                  <small className="text-muted">{t('smtpSetupGuide4', language)}</small>
+                  <small className="text-muted">
+                    {t('smtpSetupGuide4QuotaPrefix', language)}{' '}
+                    <Link to="/manage/settings/smtp">{t('smtpConfiguration', language)}</Link>{' '}
+                    {t('smtpSetupGuide4QuotaSuffix', language)}
+                  </small>
                 </div>
               )}
               <div className="col-12">

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -982,6 +982,8 @@ export const translations: Record<Language, Translations> = {
     smtpSetupGuide3: 'Enter the sender email address',
     smtpSetupGuide4:
       'Click "Test Connection" to verify the configuration before enabling email notifications',
+    smtpSetupGuide4QuotaPrefix: 'Please test the connection on the',
+    smtpSetupGuide4QuotaSuffix: 'page first before enabling email notifications',
     smtpPort465AutoSSL: 'Port 465 automatically uses SSL connection',
     smtpSslConnectionSuccess: 'SMTP SSL connection test successful',
     smtpStarttlsConnectionSuccess: 'SMTP STARTTLS connection test successful',
@@ -2797,6 +2799,8 @@ export const translations: Record<Language, Translations> = {
     smtpSetupGuide2: '如果需要认证，输入 SMTP 凭证',
     smtpSetupGuide3: '输入发件人邮箱地址',
     smtpSetupGuide4: '点击"测试连接"验证配置后再启用邮件通知',
+    smtpSetupGuide4QuotaPrefix: '请先在',
+    smtpSetupGuide4QuotaSuffix: '页面测试连接成功后，再启用邮件通知',
     smtpPort465AutoSSL: '端口 465 自动使用 SSL 连接',
     smtpSslConnectionSuccess: 'SMTP SSL 连接测试成功',
     smtpStarttlsConnectionSuccess: 'SMTP STARTTLS 连接测试成功',


### PR DESCRIPTION
## 修复说明

关联 Issue：#2484

## 根因

翻译文本 `smtpSetupGuide4` 被错误复用到通知偏好弹窗（QuotaAlerts.tsx）。该文本提示用户"点击测试连接验证配置"，但弹窗中并没有该按钮 —— "测试连接"按钮位于 SMTP 配置页面（SmtpConfig.tsx）。

## 修复方案

采用方案 A：在弹窗中增加跳转链接，指向 SMTP 配置页面。

**具体变更**：
1. 在 `QuotaAlerts.tsx` 中导入 `Link` 组件
2. 将纯文本提示改为带链接的提示，用户可直接跳转到 `/manage/settings/smtp`
3. 添加新的翻译键 `smtpSetupGuide4QuotaPrefix` 和 `smtpSetupGuide4QuotaSuffix`

## 主要变更

- `frontend/src/components/features/management/QuotaAlerts.tsx`：添加 Link 组件，修改提示文本
- `frontend/src/i18n/index.ts`：添加翻译键

## 测试

- **类型检查**：已通过 TypeScript 类型检查
- **Lint 检查**：已通过 ESLint 检查，无新增错误
- **前端构建**：已成功构建

## 风险

- **兼容性风险**：无。仅修改 QuotaAlerts.tsx 组件，不影响 SMTP 配置页面现有功能
- **性能风险**：无。仅添加一个链接组件
- **安全风险**：无。使用标准 react-router-dom Link 组件
- **回归风险**：无。路由已验证存在

## 效果预览

**修复前**：
> 点击"测试连接"验证配置后再启用邮件通知（纯文本，无操作入口）

**修复后**：
> 请先在 [SMTP 配置](/manage/settings/smtp) 页面测试连接成功后，再启用邮件通知（可点击跳转）