### PR TITLE
fix(verifier): clear branch_name for detached merged-main checkout

### DIFF
--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -7750,6 +7750,13 @@ class AutonomousOrchestrator:
             verify_wf["worktree_path"] = checkout_path
             verify_wf["project_path"] = checkout_path
             verify_wf["branch_strategy"] = "worktree"
+            # The checkout is a `git worktree add --detach` on merged main, NOT
+            # the dev branch. Clear branch_name so _resolve_effective_repo_context
+            # yields an empty expected_branch — otherwise the post-run
+            # repo-integrity check (detached HEAD != auto-dev/<id>) false-flags a
+            # repo_integrity_violation ("Agent changed the workflow branch").
+            # The repo-escape guard is a separate check and still applies.
+            verify_wf["branch_name"] = ""
             result = self._run_agent(
                 verify_wf,
                 session_line="verification",

--- a/tests/unit/test_orchestrator_verification_agent.py
+++ b/tests/unit/test_orchestrator_verification_agent.py
@@ -44,3 +44,55 @@ def test_run_verification_agent_passes_workflow_id():
     orch._run_agent.assert_called_once()
     # The spawn must carry workflow_id like every other _run_agent caller.
     assert orch._run_agent.call_args.kwargs.get("workflow_id") == "wf-verify-test"
+
+
+def test_run_verification_agent_clears_branch_name_for_detached_checkout():
+    """The verifier runs in a ``--detach`` worktree on merged main, NOT the dev
+    branch. If ``verify_wf`` keeps the workflow's dev ``branch_name``, the
+    post-run repo-integrity check (``_validate_repo_context_after_run``) sees
+    detached HEAD != ``auto-dev/<id>`` and false-flags a
+    ``repo_integrity_violation`` ("Agent changed the workflow branch
+    unexpectedly"), stranding the workflow at acceptance_verification.
+
+    ``_run_verification_agent`` must clear ``branch_name`` on the verify copy so
+    the branch-mismatch check is skipped for the deliberately-detached checkout.
+    The repo-escape check (a different guard) still applies, so the verifier
+    remains confined to the checkout path. (prod b48179df / cd939cbf after the
+    glm JSON-tolerance deploy let the verifier reach this code path.)
+    """
+
+    from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+    orch = AutonomousOrchestrator.__new__(AutonomousOrchestrator)
+    orch._workflow_id = "wf-verify-branch"
+    orch._build_verification_prompt = MagicMock(return_value="verify prompt")
+    orch._checkout_merged_main = MagicMock(return_value="/tmp/merged-checkout")
+    orch._remove_verification_worktree = MagicMock()
+    orch._run_agent = MagicMock(return_value=MagicMock(success=False, error_code=""))
+
+    with patch.object(
+        type(orch),
+        "workflow",
+        new_callable=PropertyMock,
+        return_value={
+            "cli_tool": "claude-code",
+            "model": "",
+            "branch_name": "auto-dev/wf-verify-branch",
+            "worktree_path": "/home/x/open-ace/.worktrees/wf-verify-branch",
+        },
+    ):
+        orch._run_verification_agent(
+            snapshot=MagicMock(),
+            merge_sha="merge-sha",
+            base_sha="base-sha",
+            issue_number=2394,
+            pr_number=2465,
+        )
+
+    orch._run_agent.assert_called_once()
+    verify_wf = orch._run_agent.call_args.args[0]
+    # branch_name cleared so the detached-checkout branch-mismatch check skips.
+    assert verify_wf["branch_name"] == ""
+    # The merged-main checkout path is still bound.
+    assert verify_wf["worktree_path"] == "/tmp/merged-checkout"
+    assert verify_wf["project_path"] == "/tmp/merged-checkout"


### PR DESCRIPTION
## Problem

`_run_verification_agent` spawns the verifier in a `git worktree add --detach` worktree on merged main, but only overrode `worktree_path`/`project_path` on the verify copy — `branch_name` stayed as the workflow's dev branch (`auto-dev/<id>`).

The post-run repo-integrity check (`_validate_repo_context_after_run`) compares the worktree's actual branch (detached HEAD) against `expected_branch` (`auto-dev/<id>`), sees a mismatch, and false-flags a `repo_integrity_violation` ("Agent changed the workflow branch unexpectedly") — stranding the workflow at `acceptance_verification` with `infra_error: verification agent failed (repo_integrity_violation)`.

Prod: b48179df (#2394), cd939cbf (#2349). Surfaced after the glm JSON-tolerance fix (#2512) let the verifier produce parseable output and finally reach this code path (previously it failed earlier on "not valid JSON").

## Fix

Clear `branch_name` on the verify copy so `_resolve_effective_repo_context` yields an empty `expected_branch` and the branch-mismatch check skips for the deliberately-detached checkout. The branch guard targets the **dev** agent (detect tampering that redirects commits); a detached read-only verifier is legitimately not on the dev branch. The **repo-escape** guard (separate check) still confines the verifier to the checkout path.

## Test

`tests/unit/test_orchestrator_verification_agent.py`: asserts the `verify_wf` passed to `_run_agent` has `branch_name == ""` while the checkout path remains bound. Full verifier suite (137) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)