### PR TITLE
fix(pr_review): commit pending changes before push (No-commits 422)

### DIFF
--- a/app/modules/workspace/autonomous/phases/pr_review.py
+++ b/app/modules/workspace/autonomous/phases/pr_review.py
@@ -132,6 +132,18 @@ def _ensure_branch_and_push(gh, host, branch_name, entry_feature_head, entry_mai
             raise RuntimeError(
                 f"Branch mismatch before push: expected {branch_name}, actual {current_branch}"
             )
+    # Safety net: commit any uncommitted changes before push so the branch HEAD
+    # carries them. The dev phase auto-commits agent work, but changes made
+    # after that commit (a review-fix retry, a merge-main sync on a prior
+    # round) can stay uncommitted — create_pr then 422s with "No commits
+    # between main and branch" (#2468 fa40beec, #2477 b6348aac).
+    if gh.has_uncommitted_changes():
+        gh.git_add_all()
+        gh.git_commit("auto: stage pending changes before push", no_verify=True)
+        logger.info(
+            "Workflow %s pr_review: staged uncommitted changes before push",
+            host.workflow_id[:8],
+        )
     gh.git_push(branch=branch_name, force_with_lease=True)
 
 

--- a/tests/autonomous/phases/test_pr_review.py
+++ b/tests/autonomous/phases/test_pr_review.py
@@ -329,3 +329,39 @@ def test_pre_review_scope_violation_returns_failed():
     assert isinstance(result, PhaseResult)
     assert result.outcome == "failed"
     assert "scope violation" in result.structured_error.get("message", "")
+
+
+def test_ensure_branch_and_push_commits_uncommitted_changes_before_push():
+    """Uncommitted changes left after the dev phase's auto-commit (a review-fix
+    retry, a merge-main sync on a prior round) must be committed before push.
+    Otherwise the branch HEAD carries nothing new and create_pr 422s with "No
+    commits between main and branch" (#2468 fa40beec, #2477 b6348aac)."""
+    gh = _gh()
+    gh.get_current_branch.return_value = "feature-x"
+    gh.has_uncommitted_changes.return_value = True
+    host = _host()
+
+    pr_review_phase._ensure_branch_and_push(gh, host, "feature-x", "feat-sha", "main-sha")
+
+    gh.git_add_all.assert_called_once()
+    gh.git_commit.assert_called_once()
+    gh.git_push.assert_called_once()
+    # Ordering: stage the pending changes BEFORE the push.
+    kinds = [c[0] for c in gh.mock_calls if c[0] in ("git_add_all", "git_commit", "git_push")]
+    assert kinds.index("git_add_all") < kinds.index("git_push")
+    assert kinds.index("git_commit") < kinds.index("git_push")
+
+
+def test_ensure_branch_and_push_skips_commit_when_worktree_clean():
+    """A clean worktree must not get an empty safety commit (avoids noise / the
+    'nothing to commit' error path). Only stage when there are pending changes."""
+    gh = _gh()
+    gh.get_current_branch.return_value = "feature-x"
+    gh.has_uncommitted_changes.return_value = False
+    host = _host()
+
+    pr_review_phase._ensure_branch_and_push(gh, host, "feature-x", "feat-sha", "main-sha")
+
+    gh.git_add_all.assert_not_called()
+    gh.git_commit.assert_not_called()
+    gh.git_push.assert_called_once()


### PR DESCRIPTION
## Problem

`create_pr` 422s with "No commits between main and <branch>" when the branch HEAD carries no new commits — but the worktree has real uncommitted changes (retained with "uncommitted changes preserved for debug").

Root cause: the dev phase's auto-commit safety net only fires when the agent produced no commit of its own (gated on `not sha_changed`). Changes made AFTER the dev commit — a review-fix retry, a merge-main sync on a prior round — stay uncommitted, reach the push, and the branch HEAD has nothing new for create_pr.

Caught on #2468 (fa40beec) and #2477 (b6348aac): both retained worktrees had real dev changes (`remote_session_manager.py`, new scripts/tests) sitting uncommitted past the dev commit.

## Fix

Defense-in-depth safety commit at the push boundary (`_ensure_branch_and_push`): if the worktree still has uncommitted changes right before push, stage + commit them so the branch HEAD carries them. Idempotent — only fires when there are pending changes; a clean worktree gets no empty commit.

## Tests

`tests/autonomous/phases/test_pr_review.py`: +2 (commits uncommitted before push, ordering; skips on clean worktree). Existing pr_review suite (11) passes. (5 pre-existing unrelated failures in tests/issues/1857 fail on clean main too — not in CI opt-in.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)