### PR TITLE
fix: 修复告警管理页面字段名不匹配导致功能失效

### DIFF
--- a/frontend/src/api/alerts.ts
+++ b/frontend/src/api/alerts.ts
@@ -6,14 +6,14 @@ import { apiClient } from './client';
 
 // Types
 export interface Alert {
-  id: string;
+  alert_id: string;
   type: 'quota' | 'system' | 'security';
   severity: 'info' | 'warning' | 'critical';
   title: string;
   message: string;
   user_id?: number;
   username?: string;
-  is_read: boolean;
+  read: boolean;
   created_at: string;
   metadata?: Record<string, unknown>;
 }

--- a/frontend/src/components/features/management/QuotaAlerts.tsx
+++ b/frontend/src/components/features/management/QuotaAlerts.tsx
@@ -310,15 +310,15 @@ export const QuotaAlerts: React.FC = () => {
     return alerts.filter((alert) => {
       if (typeFilter && alert.type !== typeFilter) return false;
       if (severityFilter && alert.severity !== severityFilter) return false;
-      if (readFilter === 'read' && !alert.is_read) return false;
-      if (readFilter === 'unread' && alert.is_read) return false;
+      if (readFilter === 'read' && !alert.read) return false;
+      if (readFilter === 'unread' && alert.read) return false;
       return true;
     });
   }, [alerts, typeFilter, severityFilter, readFilter]);
 
   const alertStats = useMemo(() => {
     const total = filteredAlerts.length;
-    const unread = filteredAlerts.filter((a) => !a.is_read).length;
+    const unread = filteredAlerts.filter((a) => !a.read).length;
     const critical = filteredAlerts.filter((a) => a.severity === 'critical').length;
     return { total, unread, critical };
   }, [filteredAlerts]);
@@ -326,7 +326,7 @@ export const QuotaAlerts: React.FC = () => {
   const handleMarkAsRead = async (alertId: string) => {
     try {
       await alertsApi.markAsRead(alertId);
-      setAlerts((prev) => prev.map((a) => (a.id === alertId ? { ...a, is_read: true } : a)));
+      setAlerts((prev) => prev.map((a) => (a.alert_id === alertId ? { ...a, read: true } : a)));
       setUnreadCount((prev) => Math.max(0, prev - 1));
     } catch (err) {
       console.error('Failed to mark alert as read:', err);
@@ -336,7 +336,7 @@ export const QuotaAlerts: React.FC = () => {
   const handleMarkAllAsRead = async () => {
     try {
       await alertsApi.markAllAsRead();
-      setAlerts((prev) => prev.map((a) => ({ ...a, is_read: true })));
+      setAlerts((prev) => prev.map((a) => ({ ...a, read: true })));
       setUnreadCount(0);
     } catch (err) {
       console.error('Failed to mark all as read:', err);
@@ -348,7 +348,7 @@ export const QuotaAlerts: React.FC = () => {
     if (!(await confirm({ message: t('confirmDeleteAlert', language), variant: 'danger' }))) return;
     try {
       await alertsApi.deleteAlert(alertId);
-      setAlerts((prev) => prev.filter((a) => a.id !== alertId));
+      setAlerts((prev) => prev.filter((a) => a.alert_id !== alertId));
     } catch (err) {
       console.error('Failed to delete alert:', err);
     }
@@ -799,10 +799,10 @@ export const QuotaAlerts: React.FC = () => {
                 </thead>
                 <tbody>
                   {filteredAlerts.map((alert) => (
-                    <tr key={alert.id} className={cn(!alert.is_read && 'table-warning')}>
+                    <tr key={alert.alert_id} className={cn(!alert.read && 'table-warning')}>
                       <td>
                         <strong>{alert.title}</strong>
-                        {!alert.is_read && (
+                        {!alert.read && (
                           <Badge variant="primary" className="ms-2">
                             {t('new', language)}
                           </Badge>
@@ -831,11 +831,11 @@ export const QuotaAlerts: React.FC = () => {
                       </td>
                       <td>
                         <div className="btn-group btn-group-sm">
-                          {!alert.is_read && (
+                          {!alert.read && (
                             <Button
                               variant="outline-primary"
                               size="sm"
-                              onClick={() => handleMarkAsRead(alert.id)}
+                              onClick={() => handleMarkAsRead(alert.alert_id)}
                               title={t('markAsRead', language) ?? 'Mark as Read'}
                             >
                               <i className="bi bi-check" />
@@ -844,7 +844,7 @@ export const QuotaAlerts: React.FC = () => {
                           <Button
                             variant="outline-danger"
                             size="sm"
-                            onClick={() => handleDeleteAlert(alert.id)}
+                            onClick={() => handleDeleteAlert(alert.alert_id)}
                             title={t('delete', language) ?? 'Delete'}
                           >
                             <i className="bi bi-trash" />


### PR DESCRIPTION
## 修复说明

关联 Issue：#2474

## 根因

前后端字段名不匹配：
- 后端 `Alert.to_dict()` 返回 `alert_id` 和 `read` 字段
- 前端 `Alert` 接口期望 `id` 和 `is_read` 字段
- 字段名不匹配导致前端 `alert.id` 和 `alert.is_read` 均为 `undefined`，进而导致删除和标记已读功能失效

## 修复方案

修改前端以匹配后端字段名：
- 更新 `Alert` 接口：`id` → `alert_id`，`is_read` → `read`
- 更新 `QuotaAlerts.tsx` 中所有字段使用位置

## 主要变更

- `frontend/src/api/alerts.ts`: 修改 Alert 接口定义
- `frontend/src/components/features/management/QuotaAlerts.tsx`: 更新所有 `alert.id` 和 `alert.is_read` 使用位置

## 测试

- 测试环境：测试服务器
- TypeScript 编译：✅ 通过
- 单元测试：✅ 813 个测试全部通过
- 功能验证：已在测试环境部署，前端构建文件包含正确的字段名

## 风险

- 兼容性风险：无。改动仅限前端，不影响后端 API
- 性能风险：无
- 安全风险：无
- 回归风险：低

Generated with Qwen Code