### PR TITLE
fix: add tooltip to auto-refresh toggle in PageRefreshControl (Issue #2473)

### DIFF
--- a/frontend/src/components/common/PageRefreshControl.tsx
+++ b/frontend/src/components/common/PageRefreshControl.tsx
@@ -246,7 +246,7 @@ export const PageRefreshControl: React.FC<PageRefreshControlProps> = ({
               {showAutoRefreshToggle && (
                 <li>
                   <div className="dropdown-item-text">
-                    <div className="form-check form-switch">
+                    <div className="form-check form-switch" title={t('autoRefresh', language)}>
                       <input
                         className="form-check-input"
                         type="checkbox"
@@ -342,7 +342,10 @@ export const PageRefreshControl: React.FC<PageRefreshControlProps> = ({
 
       {/* Auto refresh toggle */}
       {showAutoRefreshToggle && (
-        <div className="form-check form-switch d-flex align-items-center mb-0">
+        <div
+          className="form-check form-switch d-flex align-items-center mb-0"
+          title={t('autoRefresh', language)}
+        >
           <input
             className="form-check-input"
             type="checkbox"


### PR DESCRIPTION
## 修复说明

关联 Issue：#2473

## 根因

组件存在两种模式（compact 和 full），两种模式下的自动刷新开关均未设置 `title` 属性，而刷新按钮正确设置了 `title`。用户悬停在自动刷新开关上时无 tooltip 提示。

## 修复方案

为 compact 和 full 模式下的自动刷新开关外层容器 `<div className="form-check form-switch">` 添加 `title={t('autoRefresh', language)}` 属性。

## 主要变更

- `frontend/src/components/common/PageRefreshControl.tsx`：
  - Compact 模式（第 172 行）：为 `<div className="form-check form-switch">` 添加 `title` 属性
  - Full 模式（第 344-346 行）：为 `<div className="form-check form-switch">` 添加 `title` 属性

## 测试

- 本地 lint 检查通过（0 errors）
- 手动验证：悬停在自动刷新开关区域显示 tooltip

## 风险

- 兼容性风险：无。只添加 HTML 属性，不改变组件行为或 API
- 性能风险：无。`title` 属性是原生 HTML 属性，无性能影响
- 安全风险：无。不涉及数据处理或安全相关逻辑
- 回归风险：无。修改范围明确，不影响其他组件