### PR TITLE
fix(verifier): put snapshot first when extraction required

### DIFF
--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -7936,7 +7936,8 @@ class AutonomousOrchestrator:
                 "criteria yourself, then return them in the `snapshot` field. Infer "
                 "required_paths from the bug/stack trace, and write a concrete, checkable "
                 "checklist (one statement per acceptance point). Without `snapshot` populated, "
-                "your verdict is INVALID and verification cannot proceed.\n\n"
+                "your verdict is INVALID and verification cannot proceed.\n"
+                "Output the `snapshot` object as the FIRST key in your JSON, before `verdicts`.\n\n"
             )
             # Valid JSON token (the object shape) so the fenced template glm
             # copies stays parseable — never interpolate prose into the value.
@@ -7945,10 +7946,25 @@ class AutonomousOrchestrator:
                 '"closure_constraints": false}'
             )
             snapshot_note = "Populate `snapshot` with the criteria you derived above."
+            # Snapshot FIRST in the template: the empty-`snapshot` slot shown
+            # before the extraction instruction primed glm to copy it empty and
+            # omit the field (cd939cbf #2349). Listing it first + the FIRST-key
+            # instruction above nudge glm to derive it before verdicts consume
+            # attention/budget.
+            json_template = (
+                '{"snapshot": ' + snapshot_token + ", "
+                '"verdicts": [{"item": "...", "verdict": "confirmed|rejected|indeterminate", '
+                '"evidence": [{"ref": "file:line|git-diff", "note": "..."}], "rationale": "..."}]}'
+            )
         else:
             extraction_section = ""
             snapshot_token = "null"
             snapshot_note = "Leave `snapshot` null — the criteria above are authoritative."
+            json_template = (
+                '{"verdicts": [{"item": "...", "verdict": "confirmed|rejected|indeterminate", '
+                '"evidence": [{"ref": "file:line|git-diff", "note": "..."}], "rationale": "..."}], '
+                '"snapshot": null}'
+            )
         return (
             "You are an INDEPENDENT acceptance verifier. The issue must NOT be considered done "
             "just because a PR merged. Verify the MERGED code (merge commit "
@@ -7960,9 +7976,7 @@ class AutonomousOrchestrator:
             "note under 60 characters (terse evidence fits the output budget and avoids a "
             "truncated, unparseable response).\n"
             "```json\n"
-            '{"verdicts": [{"item": "...", "verdict": "confirmed|rejected|indeterminate", '
-            '"evidence": [{"ref": "file:line|git-diff", "note": "..."}], "rationale": "..."}], '
-            f'"snapshot": {snapshot_token}}}\n'
+            f"{json_template}\n"
             "```\n\n"
             f"Acceptance snapshot:\n{snap_dump}\n\n"
             f"{extraction_section}"

--- a/tests/unit/test_verifier_snapshot_prompt.py
+++ b/tests/unit/test_verifier_snapshot_prompt.py
@@ -98,3 +98,19 @@ def test_prompt_reinforces_json_only_at_end():
     )
     # Trailing reinforcement so glm doesn't drift into prose at the end.
     assert "ONLY" in prompt
+
+
+def test_extraction_prompt_puts_snapshot_first_in_template():
+    """When the issue has no snapshot (extraction required), glm-5 routinely
+    returns verdicts but omits the `snapshot` field — burning infra-retries
+    (cd939cbf #2349). The JSON template shown BEFORE the extraction instruction
+    primed glm to copy its empty `snapshot` slot. Put `snapshot` FIRST in the
+    template + tell glm to output it first so it's produced before verdicts
+    consume attention/budget."""
+    snap = AcceptanceSnapshot()  # empty → extraction required
+    prompt = _prompt(snap)
+    fenced = prompt.split("```json", 1)[1].split("```", 1)[0]
+    assert fenced.index('"snapshot"') < fenced.index(
+        '"verdicts"'
+    ), "extraction-case template must list `snapshot` before `verdicts`"
+    assert "FIRST" in prompt or "first" in prompt


### PR DESCRIPTION
## Problem
For issues with no structured acceptance criteria, the verifier must extract them into the `snapshot` field. glm-5 routinely returned verdicts but OMITTED `snapshot` (cd939cbf #2349, 2d0c317d #2328) → `infra_error: omitted the required extracted acceptance snapshot` → 3 retries → pause. The JSON template shown BEFORE the extraction instruction listed an empty `snapshot` slot LAST, priming glm to copy it empty.

## Fix (extraction case only)
- List `snapshot` FIRST in the fenced JSON template (before `verdicts`).
- Add 'output snapshot as the FIRST key' to the REQUIRED extraction instruction.

Nudges glm to derive the snapshot before verdicts consume attention/budget. Non-extraction case unchanged. Conservative fallback unchanged (pause for human if still omitted).

## Tests
`test_verifier_snapshot_prompt.py`: +1 (snapshot before verdicts in extraction template). Verifier suite (108) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)