### PR TITLE
fix(verifier): surface rejected/inconclusive verdicts to humans (comment + milestone)

### DIFF
--- a/app/modules/workspace/autonomous/phases/acceptance_verification.py
+++ b/app/modules/workspace/autonomous/phases/acceptance_verification.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import dataclasses
 import fnmatch
 import json
+import logging
 import time
 from typing import cast
 
@@ -42,6 +43,8 @@ from app.utils.config import is_acceptance_verification_enabled
 
 VERIFIED_BY = "acceptance-verifier-v1"
 MAX_VERIFIER_INFRA_RETRIES = 3
+
+logger = logging.getLogger(__name__)
 
 
 def _now_iso() -> str:
@@ -171,21 +174,96 @@ def _parse_issue_body(gh, issue_number) -> str:
     return body if isinstance(body, str) else ""
 
 
+def _failed_items(report: dict) -> list[tuple[str, dict]]:
+    """Actionable items: scope/gates/verifier entries not confirmed."""
+    out: list[tuple[str, dict]] = []
+    for kind in ("scope", "gates", "verifier"):
+        for entry in report.get(kind, []):
+            if entry.get("verdict") != "confirmed":
+                out.append((kind, entry))
+    return out
+
+
+def _acceptance_summary(status: str, report: dict) -> str:
+    """Human-readable one-line summary for the milestone card.
+
+    On confirmed, counts suffice. On rejected/indeterminate, name the items
+    that failed so a human reading the card knows what to fix — not just
+    ``scope=1 gates=0``. Capped to stay a single readable line.
+    """
+    failed_names: list[str] = []
+    for _, entry in _failed_items(report):
+        name = entry.get("item")
+        if isinstance(name, str) and name.strip():
+            failed_names.append(name.strip())
+    if failed_names:
+        listed = ", ".join(failed_names[:6])
+        extra = f" (+{len(failed_names) - 6} more)" if len(failed_names) > 6 else ""
+        return f"status={status}; not-verified: {listed}{extra}"
+    return (
+        f"status={status}; "
+        f"scope={len(report.get('scope', []))} "
+        f"gates={len(report.get('gates', []))} "
+        f"verifier={len(report.get('verifier', []))}"
+    )
+
+
 def _format_report_comment(report: dict) -> str:
+    status = (report.get("status") or "").lower()
+    icon = {"confirmed": "✅", "rejected": "❌"}.get(status, "⚠️")
+    title = {
+        "confirmed": "Acceptance verified",
+        "rejected": "Acceptance not verified",
+    }.get(status, "Acceptance inconclusive")
     lines = [
-        "## ✅ Acceptance verified",
+        f"## {icon} {title}",
         f"**Merge SHA:** `{report.get('merge_sha')}`",
         f"**Verifier:** `{report.get('verified_by')}`",
-        "",
-        "**Scope gate:**",
     ]
-    for s in report.get("scope", []):
-        lines.append(f"- `{s['item']}` — {s['verdict']}")
-    if report.get("verifier"):
-        lines += ["", "**Verifier findings:**"]
-        for v in report["verifier"]:
-            lines.append(f"- {v['verdict']} — {v['item']}")
+    if status == "confirmed":
+        lines += ["", "**Scope gate:**"]
+        for s in report.get("scope", []):
+            lines.append(f"- `{s['item']}` — {s['verdict']}")
+        if report.get("verifier"):
+            lines += ["", "**Verifier findings:**"]
+            for v in report["verifier"]:
+                lines.append(f"- {v['verdict']} — {v['item']}")
+        return "\n".join(lines)
+    # rejected / indeterminate: surface WHAT failed so a human knows the next step.
+    failed = _failed_items(report)
+    if failed:
+        label = "Rejected / missing" if status == "rejected" else "Could not verify"
+        lines += ["", f"**{label}:**"]
+        for kind, entry in failed:
+            detail = entry.get("rationale") or ""
+            if not detail:
+                ev = entry.get("evidence") or []
+                if ev and isinstance(ev[0], dict):
+                    detail = ev[0].get("note", "")
+            tail = f" — {detail}" if detail else ""
+            lines.append(f"- [{kind}] `{entry.get('item')}` ({entry.get('verdict')}){tail}")
+    lines += [
+        "",
+        "**Next step:** address the items above, then resume the workflow to re-verify.",
+    ]
     return "\n".join(lines)
+
+
+def _post_verdict_comment(deps, issue_number, report) -> None:
+    """Best-effort: post the human-readable verdict as an issue comment so the
+    author sees WHAT failed + what to do. A comment failure must not block the
+    pause — the verdict is also persisted in the workflow/milestone.
+    """
+    if not issue_number:
+        return
+    try:
+        deps.gh.add_issue_comment(issue_number, _format_report_comment(report))
+    except Exception:
+        logger.warning(
+            "acceptance verifier: failed to post verdict comment for issue %s",
+            issue_number,
+            exc_info=True,
+        )
 
 
 _TERMINAL_VERIFICATION_STATUSES = frozenset({"confirmed", "rejected", "indeterminate"})
@@ -255,12 +333,7 @@ def _acceptance_milestone(*, workflow_id, attempt, status, report) -> dict:
     the moment a verdict was committed (#2394). ``metadata`` keeps the full
     structured report as JSON; ``result_summary`` is a short readable line.
     """
-    summary = (
-        f"status={status}; "
-        f"scope={len(report.get('scope', []))} "
-        f"gates={len(report.get('gates', []))} "
-        f"verifier={len(report.get('verifier', []))}"
-    )
+    summary = _acceptance_summary(status, report)
     return {
         "workflow_id": workflow_id,
         "phase": "acceptance_verification",
@@ -616,6 +689,7 @@ def handle(ctx, deps) -> PhaseResult:
             milestone_events=[milestone],
         )
     if status == "rejected":
+        _post_verdict_comment(deps, issue_number, report)
         return PhaseResult.pause(
             structured_error={
                 "message": "Acceptance verification rejected",
@@ -628,6 +702,7 @@ def handle(ctx, deps) -> PhaseResult:
             milestone_events=[milestone],
         )
     # indeterminate
+    _post_verdict_comment(deps, issue_number, report)
     return PhaseResult.pause(
         workflow_patch={
             **common_patch,

--- a/tests/issues/2335/test_acceptance_phase.py
+++ b/tests/issues/2335/test_acceptance_phase.py
@@ -226,3 +226,124 @@ def test_snapshot_persistence_round_trips_source_and_confidence():
     assert reloaded.source == "convention"
     assert reloaded.confidence == "high"
     assert reloaded.required_paths == ["app/x.py"]
+
+
+# --- Surface rejection/inconclusive verdicts to humans (issue comment + milestone) ---
+
+
+def test_rejected_posts_human_readable_comment():
+    """A rejected verdict must be surfaced as a GitHub comment so the issue
+    author sees WHAT failed + what to fix — not a silent DB-only pause."""
+    wf = {
+        "id": 1,
+        "github_issue_number": 42,
+        "github_pr_number": 99,
+        "base_commit_sha": "base",
+        "verification_merge_sha": "merge",
+        "issue_acceptance_hash": "h1",
+        "verification_status": None,
+        "issue_acceptance_snapshot": None,
+        "dev_round": 1,
+    }
+    gh = MagicMock()
+    gh.get_issue.return_value = {"body": "## Scope\n- `app/services/retention.py`"}
+    gh.get_changed_files.return_value = []  # scope gate rejects (required path missing)
+    deps = _deps(gh=gh)
+    deps.host.run_verification_agent.return_value = {"verdicts": [], "snapshot": None}
+    av.handle(_ctx(wf), deps)
+    deps.gh.add_issue_comment.assert_called_once()
+    issue_no, comment = deps.gh.add_issue_comment.call_args.args
+    assert issue_no == 42
+    assert "❌" in comment or "not verified" in comment.lower()
+    assert "retention.py" in comment  # the rejected required path is named
+
+
+def test_indeterminate_posts_human_readable_comment():
+    wf = {
+        "id": 1,
+        "github_issue_number": 42,
+        "github_pr_number": 99,
+        "base_commit_sha": "base",
+        "verification_merge_sha": "merge",
+        "issue_acceptance_hash": "h1",
+        "verification_status": None,
+        "issue_acceptance_snapshot": None,
+    }
+    gh = MagicMock()
+    gh.get_issue.return_value = {"body": "## Scope\n- `app/x.py`"}
+    gh.get_changed_files.return_value = ["app/x.py"]  # scope gate confirmed
+    deps = _deps(gh=gh)
+    deps.host.run_verification_agent.return_value = {
+        "verdicts": [
+            {
+                "item": "unclear criterion",
+                "verdict": "indeterminate",
+                "evidence": [{"ref": "verifier:missing", "note": "no concrete proof"}],
+                "rationale": "",
+            }
+        ],
+        "snapshot": None,
+    }
+    av.handle(_ctx(wf), deps)
+    deps.gh.add_issue_comment.assert_called_once()
+    _, comment = deps.gh.add_issue_comment.call_args.args
+    assert "⚠️" in comment or "inconclusive" in comment.lower()
+    assert "unclear criterion" in comment
+
+
+def test_format_report_comment_confirmed_uses_check_mark():
+    from app.modules.workspace.autonomous.phases.acceptance_verification import (
+        _format_report_comment,
+    )
+
+    report = {
+        "status": "confirmed",
+        "merge_sha": "s",
+        "verified_by": "v",
+        "scope": [{"item": "app/x.py", "verdict": "confirmed"}],
+        "gates": [],
+        "verifier": [],
+    }
+    assert "✅" in _format_report_comment(report)
+
+
+def test_format_report_comment_rejected_lists_failed_items():
+    from app.modules.workspace.autonomous.phases.acceptance_verification import (
+        _format_report_comment,
+    )
+
+    report = {
+        "status": "rejected",
+        "merge_sha": "s",
+        "verified_by": "v",
+        "scope": [
+            {
+                "item": "app/utils/datetime_utils.py",
+                "verdict": "rejected",
+                "evidence": [{"ref": "missing:datetime", "note": "absent"}],
+            }
+        ],
+        "gates": [
+            {"item": "regression:decorators", "verdict": "rejected", "rationale": "dec regressed"}
+        ],
+        "verifier": [],
+    }
+    comment = _format_report_comment(report)
+    assert "❌" in comment
+    assert "datetime_utils.py" in comment
+    assert "regression:decorators" in comment
+
+
+def test_acceptance_milestone_summary_includes_rejected_items():
+    from app.modules.workspace.autonomous.phases.acceptance_verification import (
+        _acceptance_milestone,
+    )
+
+    report = {
+        "status": "rejected",
+        "scope": [{"item": "app/utils/datetime_utils.py", "verdict": "rejected"}],
+        "gates": [],
+        "verifier": [],
+    }
+    ms = _acceptance_milestone(workflow_id="wf", attempt=1, status="rejected", report=report)
+    assert "datetime_utils.py" in ms["result_summary"]

--- a/tests/issues/2431/test_acceptance_verifier_hardening.py
+++ b/tests/issues/2431/test_acceptance_verifier_hardening.py
@@ -254,7 +254,10 @@ def test_missing_checklist_verdict_forces_indeterminate_and_never_closes_issue()
             ),
         }
     ]
-    deps.gh.add_issue_comment.assert_not_called()
+    # Indeterminate now surfaces to humans as an issue comment (what's missing).
+    deps.gh.add_issue_comment.assert_called_once()
+    _, comment = deps.gh.add_issue_comment.call_args.args
+    assert "rejects expired tokens" in comment
     deps.gh.close_issue.assert_not_called()
 
 


### PR DESCRIPTION
## Problem
Verifier posted a human-readable issue comment ONLY on `confirmed`. On `rejected`/`indeterminate` it paused silently — verdict in DB/internal-milestone only, so the issue author never saw WHY or what to do next.

## Fix
- `_format_report_comment` branches on status: rejected → ❌ lists failed items + rationale + next-step; indeterminate → ⚠️ lists missing items. confirmed unchanged.
- `_post_verdict_comment` (best-effort; failure logs, doesn't block pause). Called in rejected + indeterminate pause paths (idempotent — replay paths return before it).
- `_acceptance_milestone` `result_summary` names the failed items (not just `scope=N`) so the milestone card is readable.

## Tests
+rejected/indeterminate post comment; format ✅/❌; milestone summary names items. Flipped 2431's indeterminate `assert_not_called` → asserts a comment is posted (intended behavior change). Suite (150) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)