### PR TITLE
fix: add fallback tooltip for auto-refresh button in compact mode (Issue #2471)

### DIFF
--- a/frontend/src/components/common/PageRefreshControl.tsx
+++ b/frontend/src/components/common/PageRefreshControl.tsx
@@ -171,7 +171,8 @@ export const PageRefreshControl: React.FC<PageRefreshControlProps> = ({
       parts.push(`${t('nextRefresh', language)}: ${countdown}`);
     }
 
-    return parts.join('\n');
+    // Return timing info if available, otherwise fallback to default tooltip
+    return parts.length > 0 ? parts.join('\n') : t('autoRefresh', language);
   };
 
   /**


### PR DESCRIPTION
## 修复说明

关联 Issue：#2471

## 根因

compact 模式下，dropdown toggle 按钮的 `buildTooltip()` 函数在页面初次加载时返回空字符串，导致按钮悬停时无任何提示。

根因分析：
- `lastRefreshTime` 初始值为 `null`（页面初次加载）
- `showNextRefreshTime` 默认为 `false`
- 当两个条件都为 false 时，`parts` 数组为空，函数返回空字符串

## 修复方案

修改 `buildTooltip()` 函数，添加兜底文本：
- 当 `parts` 数组为空时，返回 `t('autoRefresh', language)` 作为默认 tooltip
- 使用已存在的 `autoRefresh` i18n key（支持英文、中文、日文、韩文）

## 主要变更

- `frontend/src/components/common/PageRefreshControl.tsx`
  - 修改 `buildTooltip()` 函数，添加兜底逻辑

## 测试

- 前端构建：✅ 成功
- 受影响页面：审计日志、会话历史、ROI 分析、异常检测、趋势分析、配额告警

## 风险

- 兼容性风险：无（向后兼容）
- 性能风险：无（仅添加一个简单条件判断）
- 安全风险：无
- 回归风险：无（仅影响 tooltip 显示）