### PR TITLE
fix: pre-migration check should use SUPPORT_ANCESTRY, not REQUIRE_HEAD

### DIFF
--- a/scripts/check_min_revision.py
+++ b/scripts/check_min_revision.py
@@ -2,10 +2,19 @@
 """Check database schema compatibility using Alembic revision graph.
 
 Issue #2330: Refactored to use SchemaCompatibilityService with Alembic graph validation.
+Issue #2534: Fixed regression where REQUIRE_HEAD blocked migrations in production.
 
 This checker is invoked by the package/Docker install scripts immediately
 before ``alembic upgrade head``. It exits non-zero when the database schema
 is incompatible with the application requirements.
+
+Policy Behavior:
+    - Default (--policy require_head): Uses SUPPORT_ANCESTRY for pre-migration check.
+      This allows any revision in the baseline lineage, enabling alembic upgrade head
+      to apply missing migrations.
+    - Runtime checks (web/scheduler startup) use check_schema_compatibility() in
+      schema_guard.py, which applies REQUIRE_HEAD to ensure services only run on
+      fully migrated databases.
 
 Fresh databases (no ``alembic_version`` table) are allowed through in development
 mode; production mode requires explicit migration before startup.
@@ -107,10 +116,11 @@ def main() -> int:
         "support_ancestry": CompatibilityPolicy.SUPPORT_ANCESTRY,
     }
 
-    # For backward compatibility, use SUPPORT_ANCESTRY in development mode
-    # This allows any revision in the baseline lineage (not just head)
-    env_mode = get_environment_mode()
-    if args.policy == "require_head" and env_mode == "development":
+    # Pre-migration check should always use SUPPORT_ANCESTRY
+    # to allow alembic upgrade head to apply missing migrations.
+    # REQUIRE_HEAD is only appropriate for runtime checks (web/scheduler startup).
+    # See Issue #2534 for the regression this fixes.
+    if args.policy == "require_head":
         policy = CompatibilityPolicy.SUPPORT_ANCESTRY
     else:
         policy = policy_map[args.policy]

--- a/scripts/check_min_revision.py
+++ b/scripts/check_min_revision.py
@@ -34,6 +34,7 @@ if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
 # Import new SchemaCompatibilityService
+from app.repositories.schema_guard import get_environment_mode
 from app.services.schema_compatibility_service import get_schema_compatibility_service
 from app.services.schema_compatibility_types import CompatibilityPolicy, SchemaErrorCategory
 from migrations.baseline import BASELINE_REVISION
@@ -151,7 +152,7 @@ def main() -> int:
                     )
                 else:
                     print(
-                        f"Database schema compatible (fresh database in {env_mode} mode)\n"
+                        f"Database schema compatible (fresh database)\n"
                         f"Policy: {policy.value}"
                     )
                 return 0

--- a/scripts/check_min_revision.py
+++ b/scripts/check_min_revision.py
@@ -152,8 +152,7 @@ def main() -> int:
                     )
                 else:
                     print(
-                        f"Database schema compatible (fresh database)\n"
-                        f"Policy: {policy.value}"
+                        f"Database schema compatible (fresh database)\n" f"Policy: {policy.value}"
                     )
                 return 0
 

--- a/scripts/check_min_revision.py
+++ b/scripts/check_min_revision.py
@@ -34,7 +34,6 @@ if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
 # Import new SchemaCompatibilityService
-from app.repositories.schema_guard import get_environment_mode
 from app.services.schema_compatibility_service import get_schema_compatibility_service
 from app.services.schema_compatibility_types import CompatibilityPolicy, SchemaErrorCategory
 from migrations.baseline import BASELINE_REVISION
@@ -124,9 +123,6 @@ def main() -> int:
         policy = CompatibilityPolicy.SUPPORT_ANCESTRY
     else:
         policy = policy_map[args.policy]
-
-    # Determine environment mode
-    env_mode = get_environment_mode()
 
     # Create database engine
     engine = sa.create_engine(database_url)


### PR DESCRIPTION
## 修复说明

关联 Issue：#2534

## 根因

PR #2436 将 `check_min_revision.py` 重构为在生产模式使用 `REQUIRE_HEAD` 策略。这导致"先有鸡还是先有蛋"问题：

- 预迁移检查要求 DB 必须已经是最新版本（REQUIRE_HEAD）
- 但检查失败时，`alembic upgrade head` 永远不会执行
- 结果：所有生产环境升级被阻塞

## 修复方案

将 `check_min_revision.py` 的默认策略从 `REQUIRE_HEAD` 改为 `SUPPORT_ANCESTRY`：

- 预迁移检查允许 baseline 后裔通过
- 安装脚本流程恢复正常：检查通过 → 应用迁移 → 服务启动
- 运行时检查（web/scheduler 启动）继续使用 `REQUIRE_HEAD`（通过 `check_schema_compatibility()`）

## 主要变更

- `scripts/check_min_revision.py`：修改策略选择逻辑
  - `--policy require_head`（默认）→ 使用 `SUPPORT_ANCESTRY`
  - 显式指定 `--policy support_n_1` 或 `--policy support_ancestry` → 按指定执行

## 测试

- 执行环境：本地开发环境
- 已运行测试：
  - `tests/unit/test_check_min_revision.py`：10 passed
  - `tests/unit/test_schema_compatibility_service.py`：25 passed
- 测试结果：✅ 全部通过

## 风险

- **兼容性**：无风险。预迁移检查恢复到旧版本行为
- **安全**：无风险。`SUPPORT_ANCESTRY` 仍然验证 DB 在 baseline 后裔中
- **回归**：低风险。开发模式行为不变