### PR TITLE
fix(i18n): ConfirmModal 确认弹窗按钮支持多语言翻译

### DIFF
--- a/frontend/src/components/common/Confirm.test.tsx
+++ b/frontend/src/components/common/Confirm.test.tsx
@@ -2,8 +2,25 @@
  * Tests for the global confirm dialog store and useConfirm accessor.
  */
 
-import { describe, it, expect, beforeEach } from 'vitest';
-import { useConfirmStore, useConfirm } from './Confirm';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { useConfirmStore, useConfirm, ConfirmHost } from './Confirm';
+
+// Mock language hook
+vi.mock('@/store', () => ({
+  useLanguage: () => 'zh',
+}));
+
+// Mock i18n
+vi.mock('@/i18n', () => ({
+  t: (key: string, lang: string) => {
+    const translations: Record<string, Record<string, string>> = {
+      en: { confirm: 'Confirm', cancel: 'Cancel' },
+      zh: { confirm: '确认', cancel: '取消' },
+    };
+    return translations[lang]?.[key] ?? key;
+  },
+}));
 
 describe('Confirm global store', () => {
   beforeEach(() => {
@@ -51,5 +68,60 @@ describe('useConfirm accessor', () => {
     const a = useConfirm();
     const b = useConfirm();
     expect(a).toBe(b);
+  });
+});
+
+describe('ConfirmHost i18n defaults', () => {
+  beforeEach(() => {
+    useConfirmStore.setState({ open: false, options: { message: '' }, resolve: null });
+  });
+
+  it('uses translated defaults when confirmText/cancelText are not provided', () => {
+    // Open the dialog without explicit button text
+    useConfirmStore.getState().confirm({ message: 'Are you sure?' });
+
+    render(<ConfirmHost />);
+
+    // Should show Chinese translations (mocked language is 'zh')
+    expect(screen.getByRole('button', { name: '确认' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '取消' })).toBeInTheDocument();
+  });
+
+  it('uses explicit confirmText/cancelText when provided', () => {
+    // Open the dialog with explicit button text
+    useConfirmStore.getState().confirm({
+      message: 'Delete item?',
+      confirmText: 'Yes, delete',
+      cancelText: 'No, keep',
+    });
+
+    render(<ConfirmHost />);
+
+    // Should show the explicit text, not translations
+    expect(screen.getByRole('button', { name: 'Yes, delete' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'No, keep' })).toBeInTheDocument();
+    // Translated defaults should NOT be present
+    expect(screen.queryByRole('button', { name: '确认' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: '取消' })).not.toBeInTheDocument();
+  });
+
+  it('settles false when cancel button is clicked', () => {
+    const promise = useConfirmStore.getState().confirm({ message: 'Confirm?' });
+    render(<ConfirmHost />);
+
+    fireEvent.click(screen.getByRole('button', { name: '取消' }));
+
+    expect(useConfirmStore.getState().open).toBe(false);
+    return expect(promise).resolves.toBe(false);
+  });
+
+  it('settles true when confirm button is clicked', async () => {
+    const promise = useConfirmStore.getState().confirm({ message: 'Confirm?' });
+    render(<ConfirmHost />);
+
+    fireEvent.click(screen.getByRole('button', { name: '确认' }));
+
+    expect(useConfirmStore.getState().open).toBe(false);
+    expect(await promise).toBe(true);
   });
 });

--- a/frontend/src/components/common/Confirm.tsx
+++ b/frontend/src/components/common/Confirm.tsx
@@ -14,6 +14,8 @@
 import React from 'react';
 import { create } from 'zustand';
 import { ConfirmModal } from './Modal';
+import { useLanguage } from '@/store';
+import { t } from '@/i18n';
 
 export type ConfirmVariant = 'danger' | 'warning' | 'primary';
 
@@ -67,6 +69,7 @@ export const ConfirmHost: React.FC = () => {
   const open = useConfirmStore((state) => state.open);
   const options = useConfirmStore((state) => state.options);
   const settle = useConfirmStore((state) => state.settle);
+  const language = useLanguage();
 
   return (
     <ConfirmModal
@@ -75,8 +78,8 @@ export const ConfirmHost: React.FC = () => {
       onConfirm={() => settle(true)}
       title={options.title ?? ''}
       message={options.message}
-      confirmText={options.confirmText}
-      cancelText={options.cancelText}
+      confirmText={options.confirmText ?? t('confirm', language)}
+      cancelText={options.cancelText ?? t('cancel', language)}
       variant={options.variant}
     />
   );


### PR DESCRIPTION
## Summary

Fixes #2539

ConfirmModal 确认弹窗的按钮文本在中文环境下仍显示英文 Cancel/Confirm，而非中文 取消/确认。

## Root Cause

`ConfirmHost` 在调用方未显式传入 `confirmText`/`cancelText` 时，将 `undefined` 透传给 `ConfirmModal`，后者回退到硬编码英文默认值。

## Fix

在 `ConfirmHost` 层统一修复（方案 A）：当 `options.confirmText`/`options.cancelText` 为 `undefined` 时，自动使用 i18n `t()` 获取当前语言的翻译作为默认值。

此方案修改一处即可解决所有 ~14 个调用点的问题，无需逐一修改。

## Changes

- **`Confirm.tsx`**: 导入 `useLanguage` 和 `t`，向 `ConfirmModal` 传递翻译默认值
- **`Confirm.test.tsx`**: 新增 4 个测试用例验证 `ConfirmHost` 的 i18n 行为

## Verification

- ✅ 全部 817 个前端测试通过（含新增 4 个）
- ✅ TypeScript 类型检查通过
- ✅ ESLint 无新增错误