### PR TITLE
fix(scheduler): exempt acceptance verifier from project_path conflict-lock

### DIFF
--- a/app/services/autonomous_scheduler.py
+++ b/app/services/autonomous_scheduler.py
@@ -325,7 +325,27 @@ class AutonomousScheduler:
         Issue #1573: For workflows in preparation phase without a branch_name,
         use a temporary key based on workflow_id to ensure conflict checking works
         even before preparation creates the branch.
+
+        Acceptance verification is exempt from the project_path lock: it runs
+        in its own ``git worktree add --detach`` checkout of the merged commit
+        (isolated, read-only, no branch checkout), and its persisted
+        ``worktree_path`` is empty (the verify worktree is created internally
+        and not persisted). Without this exemption the project_path fallback
+        below would key it on the shared repo and serialize it with same-repo
+        merge/dev workflows for the verifier's full agent run (10-90 min),
+        starving peers (workflow e274ec0e waited ~90 min behind cd939cbf).
+        git worktrees are designed for concurrent use (isolated index/HEAD,
+        append-only object store), so a detached verify worktree does not race
+        with a same-repo peer's worktree. The verifier's only other shared-repo
+        touch is a read-only ``git fetch`` (refs + FETCH_HEAD, which git
+        serializes internally); it does no push/branch/reset/commit on shared
+        refs. The per-workflow token still prevents the same verification from
+        being double-advanced.
         """
+        if wf.get("current_phase") == "acceptance_verification":
+            wf_id = wf.get("workflow_id", "")
+            return (f"acceptance:{wf_id}", "")
+
         workspace = wf.get("worktree_path") or wf.get("project_path") or ""
         branch = wf.get("branch_name") or ""
 

--- a/tests/unit/test_scheduler_acceptance_conflict_key.py
+++ b/tests/unit/test_scheduler_acceptance_conflict_key.py
@@ -1,0 +1,98 @@
+"""Regression: acceptance_verification must not serialize with same-repo
+workflows via the project_path conflict-lock.
+
+The verifier runs in an isolated ``git worktree add --detach`` checkout of the
+merged commit — it neither mutates the project_path working tree nor checks
+out the workflow's branch. Its persisted ``worktree_path`` is empty (the verify
+worktree is created internally and not persisted), so the project_path fallback
+in ``_conflict_keys`` otherwise keyed it on the shared repo. That held the
+repo's conflict-lock for the verifier's full agent run (10-90 min) and starved
+same-repo peers — workflow e274ec0e waited ~90 min behind cd939cbf's verifier
+in the same repo. git worktrees are designed for concurrent use (isolated
+index/HEAD, append-only object store), so a detached verify worktree does not
+race with a same-repo peer's worktree.
+"""
+
+import threading
+from unittest.mock import MagicMock
+
+from app.services.autonomous_scheduler import AutonomousScheduler
+
+
+def _verifier_wf(**overrides):
+    base = {
+        "workflow_id": "e274ec0e-bb68-46f6-b549-7a3b0936f3c0",
+        "current_phase": "acceptance_verification",
+        "status": "verification_pending",
+        "project_path": "/srv/open-ace",  # same repo as a running merge workflow
+        "worktree_path": "",  # persisted worktree_path is empty for verification
+        "branch_name": "auto-dev/e274ec0e",
+        "batch_id": "",
+    }
+    base.update(overrides)
+    return base
+
+
+def _scheduler(*, workspaces=None, branches=None, batches=None):
+    """Bypass __init__ — only the conflict-lock sets are needed."""
+    sched = AutonomousScheduler.__new__(AutonomousScheduler)
+    sched._in_progress_workspaces = set(workspaces or ())
+    sched._in_progress_branches = set(branches or ())
+    sched._in_progress_batch_ids = set(batches or ())
+    sched._in_progress_ids = set()
+    sched._in_progress_lock = threading.Lock()
+    return sched
+
+
+def test_acceptance_verifier_conflict_key_is_unique_not_project_path():
+    """_conflict_keys for acceptance_verification returns a per-workflow token
+    (and no branch), never the shared project_path."""
+    workspace, branch = AutonomousScheduler._conflict_keys(_verifier_wf())
+    assert workspace != "/srv/open-ace"
+    assert "e274ec0e" in workspace  # unique per workflow
+    assert branch == ""  # detached checkout — no branch
+
+
+def test_acceptance_verifier_not_blocked_by_same_repo_workflow():
+    """A verifier must NOT be skipped because a same-repo merge workflow holds
+    the project_path conflict-lock."""
+    sched = _scheduler(
+        workspaces={"/srv/open-ace"},  # held by the merge workflow
+        branches={"auto-dev/c0758607"},
+    )
+    assert sched._workflow_blocked_by_conflict_locks(_verifier_wf()) is False
+
+
+def test_acceptance_verifier_does_not_block_same_repo_workflow():
+    """Conversely, a running verifier (unique token reserved) must not block a
+    same-repo workflow that is itself keyed on project_path (new-branch /
+    primary-fallback with no worktree). Before the fix the verifier reserved
+    project_path and would have blocked this workflow."""
+    sched = _scheduler(workspaces={"acceptance:e274ec0e-bb68-46f6-b549-7a3b0936f3c0"})
+    same_repo_wf = {
+        "workflow_id": "c0758607-0000-0000-0000-000000000000",
+        "current_phase": "merge",
+        "status": "merging",
+        "project_path": "/srv/open-ace",
+        "worktree_path": "",  # keyed on project_path (new-branch / primary-fallback)
+        "branch_name": "auto-dev/c0758607",
+    }
+    assert sched._workflow_blocked_by_conflict_locks(same_repo_wf) is False
+
+
+def test_non_acceptance_workflow_still_serializes_on_project_path():
+    """The exemption is acceptance-only: a merge-phase workflow with no worktree
+    still falls back to project_path and serializes on it (unchanged behavior)."""
+    wf = {
+        "workflow_id": "c0758607-0000-0000-0000-000000000000",
+        "current_phase": "merge",
+        "status": "merging",
+        "project_path": "/srv/open-ace",
+        "worktree_path": "",  # between cycles / primary-fallback → project_path
+        "branch_name": "auto-dev/c0758607",
+    }
+    workspace, branch = AutonomousScheduler._conflict_keys(wf)
+    assert workspace == "/srv/open-ace"  # project_path fallback still applies
+    assert branch == "auto-dev/c0758607"
+    sched = _scheduler(workspaces={"/srv/open-ace"})
+    assert sched._workflow_blocked_by_conflict_locks(wf) is True


### PR DESCRIPTION
## Problem

The scheduler runs workflows concurrently (`MAX_CONCURRENT_WORKFLOWS=10` + ThreadPoolExecutor) but skips any workflow whose **conflict key** is held by an in-progress one. `acceptance_verification` was keyed on `project_path` (its persisted `worktree_path` is empty — the verify worktree is created internally and not persisted to the row), so a verifier held the shared repo's conflict-lock for its full 10–90min agent run and serialized with same-repo merge/dev workflows. Workflow **e274ec0e waited ~90min behind cd939cbf's verifier** in the same repo, despite the cap of 10.

## Root cause

`_conflict_keys(wf)` returns `(workspace=worktree_path or project_path, branch)`. For acceptance_verification, `worktree_path` is empty → fallback to `project_path` → the verifier collides with every same-repo workflow.

## Fix

`_conflict_keys` now early-returns `(f"acceptance:{workflow_id}", "")` for `current_phase == "acceptance_verification"`. The unique per-workflow token means a verifier neither blocks nor is blocked by same-repo workflows, while still preventing the same verification from double-advancing (its own token is reserved during `advance()`; `_in_progress_ids` is the primary double-advance guard anyway).

**Concurrency-safe** (independently reviewed): the verifier runs in an isolated `git worktree add --detach` checkout of the merged commit — read-only, no branch checkout, no push/reset/commit on shared refs. Its only other shared-repo touch is a read-only `git fetch` (serialized by git internally via `FETCH_HEAD` + append-only object store). git worktrees are designed for concurrent linked worktrees (isolated index/HEAD), so a detached verify worktree does not race with a same-repo peer's worktree. A paused verifier's slot is still kept (`_reclaim_paused_slots` skips acceptance), and a SIGKILL-leaked token blocks nothing (unique per workflow; cleared on restart).

## Scope

Acceptance-only. Same-repo merge-vs-merge serialization (a workflow with empty `worktree_path` between cycles / in primary-fallback) is unchanged — that's a separate, larger change (release-the-lock-mid-agent or worktree-path-granularity locking).

## Tests

New `tests/unit/test_scheduler_acceptance_conflict_key.py` (CI-gated): verifier key is unique/not project_path; verifier not blocked by a same-repo workflow; verifier doesn't block a project_path-keyed same-repo workflow; non-acceptance workflow still serializes on project_path. Canonical conflict-lock suites green (`tests/issues/1002/`, `tests/issues/2431/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)