### PR TITLE
fix: move ReportPreviewModal to component top level

### DIFF
--- a/frontend/src/components/features/management/ComplianceMgmt.tsx
+++ b/frontend/src/components/features/management/ComplianceMgmt.tsx
@@ -929,8 +929,7 @@ export const ComplianceMgmt: React.FC = () => {
             </div>
           )}
         </Modal>
-
-        </>
+      </>
     );
   };
 

--- a/frontend/src/components/features/management/ComplianceMgmt.tsx
+++ b/frontend/src/components/features/management/ComplianceMgmt.tsx
@@ -930,24 +930,7 @@ export const ComplianceMgmt: React.FC = () => {
           )}
         </Modal>
 
-        {/* Report Preview Modal */}
-        <ReportPreviewModal
-          isOpen={showReportPreviewModal}
-          onClose={() => setShowReportPreviewModal(false)}
-          htmlContent={previewHtmlContent}
-          reportType={previewReportType}
-          reportId={previewReportId}
-          onDownload={(fmt) => {
-            if (previewReportId) {
-              handleDownloadSavedReport(previewReportId, previewReportType, fmt);
-            } else {
-              // For newly generated report without saved ID, generate and download
-              handleGenerate();
-            }
-          }}
-          isDownloading={isGenerating}
-        />
-      </>
+        </>
     );
   };
 
@@ -1009,6 +992,24 @@ export const ComplianceMgmt: React.FC = () => {
 
       {/* Tab Content */}
       {activeTab === 'reports' ? renderReportsTab() : renderRetentionTab()}
+
+      {/* Report Preview Modal - Rendered at top level to work across all tabs */}
+      <ReportPreviewModal
+        isOpen={showReportPreviewModal}
+        onClose={() => setShowReportPreviewModal(false)}
+        htmlContent={previewHtmlContent}
+        reportType={previewReportType}
+        reportId={previewReportId}
+        onDownload={(fmt) => {
+          if (previewReportId) {
+            handleDownloadSavedReport(previewReportId, previewReportType, fmt);
+          } else {
+            // For newly generated report without saved ID, generate and download
+            handleGenerate();
+          }
+        }}
+        isDownloading={isGenerating}
+      />
     </div>
   );
 };


### PR DESCRIPTION
## 修复说明

关联 Issue：#2544

## 根因

`ReportPreviewModal` 组件被错误地放置在 `renderRetentionTab()` 函数内部，而触发它的预览按钮位于 `renderReportsTab()` 中。由于两个 tab 通过 `{activeTab === 'reports' ? renderReportsTab() : renderRetentionTab()}` 互斥渲染，当用户在 Reports tab 时，`showReportPreviewModal` 被设为 `true`，但 modal 组件不在当前渲染树中，导致 modal 无法显示。

## 修复方案

将 `<ReportPreviewModal>` 从 `renderRetentionTab()` 内部移动到主组件的 return 语句顶层，位于 tab 切换逻辑之后。使其独立于 tab 渲染逻辑，始终存在于 DOM 中，仅通过 `isOpen` 属性控制显示/隐藏。

## 主要变更

- 从 `renderRetentionTab()` 函数中删除 `ReportPreviewModal` 组件
- 在主 return 语句的 tab 切换逻辑之后添加 `ReportPreviewModal`
- 添加注释说明 modal 渲染在顶层的原因

## 测试

- 已执行：前端构建 `npm run build` 通过
- 需验证：
  - Reports tab → 点击 Saved Reports 预览按钮 → Modal 正常显示
  - Reports tab → Generate HTML 报告 → Modal 正常显示
  - Retention tab → 确认其他功能不受影响

## 风险

- 兼容性风险：无。状态变量已在组件顶层定义
- 回归风险：极低。原有功能保持不变