### PR TITLE
fix(content-filter): exempt autonomous requests + suppress PII false positives

### DIFF
--- a/app/modules/governance/content_filter.py
+++ b/app/modules/governance/content_filter.py
@@ -390,6 +390,38 @@ class ContentFilter:
         """
         self.invalidate_cache()
 
+    @staticmethod
+    def _luhn_check(value: str) -> bool:
+        """Luhn checksum — True if *value* is a plausible credit-card number.
+
+        Real cards (typically 15-16 digits) satisfy Luhn; commit SHAs and
+        timestamp-IDs (also 15 digits) do not. Used to suppress false-positive
+        credit-card matches that 403-blocked autonomous workflows (#2499).
+        """
+        digits = [int(c) for c in value if c.isdigit()]
+        if len(digits) < 12:
+            return False
+        total = 0
+        for i, d in enumerate(reversed(digits)):
+            if i % 2 == 1:
+                d *= 2
+                if d > 9:
+                    d -= 9
+            total += d
+        return total % 10 == 0
+
+    _DATE_LIKE = re.compile(r"\+?\d{4}([-\s/.]\d{1,2}){0,2}\Z")
+
+    @classmethod
+    def _looks_like_date(cls, value: str) -> bool:
+        """True if *value* is a date (YYYY-MM-DD / YYYY-MM), not a phone number.
+
+        International-phone false positives on dates like 2026-08-12 (#2499) are
+        dropped; real phones (which don't follow a 4-digit-year + short-groups
+        shape) are unaffected.
+        """
+        return bool(cls._DATE_LIKE.match(value.strip()))
+
     def check_content(
         self,
         content: str,
@@ -498,6 +530,15 @@ class ContentFilter:
         # Then check built-in PII patterns
         for pattern_name, compiled_pattern in self.compiled_patterns.items():
             matches = compiled_pattern.findall(content)
+            # Post-match false-positive suppression (#2499): autonomous prompts
+            # legitimately contain 15-digit commit SHAs / timestamp-IDs (matched
+            # as credit cards → critical → block) and dates like 2026-08-12
+            # (matched as international phones). Drop those before they enter
+            # matched_rules / escalate risk — real cards/phones are unaffected.
+            if matches and pattern_name in ("pii_credit_card", "pii_credit_card_amex"):
+                matches = [m for m in matches if self._luhn_check(m)]
+            elif matches and pattern_name == "pii_phone_intl":
+                matches = [m for m in matches if not self._looks_like_date(m)]
             if matches:
                 risk = self.risk_mapping.get(pattern_name, "medium")
                 matched_rules.append(

--- a/app/modules/workspace/llm_proxy_handler.py
+++ b/app/modules/workspace/llm_proxy_handler.py
@@ -742,6 +742,23 @@ def _gateway_error_response(resp: Any, gateway_key: str) -> tuple[Response, int]
         )
 
 
+def _is_autonomous_request(token_payload: dict | None) -> bool:
+    """Whether a proxy request originates from the autonomous agent runner.
+
+    The autonomous proxy token is minted with ``session_type="agent"``
+    (agent_runner.py); that claim rides in the validated token payload
+    (api_key_proxy.generate_proxy_token). Autonomous prompts are
+    system-generated/trusted and inherently carry commit SHAs, dates, and code
+    that the user-content filter's PII detectors false-positive on (15-digit
+    SHAs → credit cards → 403 block, #2499). Such requests skip the governance
+    content filter, which exists for user-submitted chat — not the system's own
+    prompts to its model.
+    """
+    if token_payload is None:
+        return False
+    return token_payload.get("session_type") == "agent"
+
+
 def _check_content_filter(
     user_id: int,
     username: str | None,
@@ -1081,13 +1098,25 @@ def handle_llm_proxy_request(
     # ── Content filter check for user input ──────────────────────────────
     # Check user messages for sensitive content before forwarding to LLM.
     # Block: return 403, Warn: log and continue, Redact: modify content.
-    username = g.user.get("username") if hasattr(g, "user") else None
-    content_filter_result = _check_content_filter(
-        user_id=user_id,
-        username=username,
-        request_body=request.get_data(),
-        tenant_id=tenant_id,
-    )
+    # Autonomous agent requests (session_type="agent") are exempt: their
+    # prompts are system-generated and inherently carry SHAs/dates/code that
+    # the PII detectors false-positive on — filtering them 403-blocked glm-5
+    # autonomous workflows (#2499). The filter governs user-submitted chat.
+    if _is_autonomous_request(token_payload):
+        logger.debug(
+            "Skipping content filter for autonomous agent request " "(user_id=%s, tenant_id=%s)",
+            user_id,
+            tenant_id,
+        )
+        content_filter_result = None
+    else:
+        username = g.user.get("username") if hasattr(g, "user") else None
+        content_filter_result = _check_content_filter(
+            user_id=user_id,
+            username=username,
+            request_body=request.get_data(),
+            tenant_id=tenant_id,
+        )
     if isinstance(content_filter_result, tuple):
         # Block: return error response
         return content_filter_result

--- a/tests/unit/test_content_filter.py
+++ b/tests/unit/test_content_filter.py
@@ -583,3 +583,57 @@ class TestCacheWithDatabaseRules:
         initial_hits = cf._cache_hits
         cf.check_content("another 456")
         assert cf._cache_hits > initial_hits
+
+
+class TestPiiFalsePositiveSuppression:
+    """Built-in PII detectors must not flag the digit-runs autonomous prompts
+    legitimately contain — 15-digit commit SHAs / timestamp-IDs (matched as
+    Amex credit cards → critical → block) and dates like 2026-08-12 (matched as
+    international phones). Regression for #2499 (glm-5 autonomous workflows
+    403-blocked by the content filter)."""
+
+    @pytest.mark.regression
+    def test_credit_card_amex_sha_not_flagged(self):
+        """A 15-digit commit SHA / timestamp-ID is NOT an Amex card (fails Luhn)
+        and must not be blocked."""
+        cf = ContentFilter(config={"block_high_risk": True})
+        result = cf.check_content("Commit 140506586314800 applied")
+        assert result.passed is True
+        assert not any(r["type"] == "pii_credit_card_amex" for r in result.matched_rules)
+
+    @pytest.mark.regression
+    def test_credit_card_amex_real_card_still_flagged(self):
+        """A valid-Luhn Amex test PAN is still detected + blocked."""
+        cf = ContentFilter(config={"block_high_risk": True})
+        result = cf.check_content("Card 378282246310005")
+        assert result.passed is False
+        assert any(r["type"] == "pii_credit_card_amex" for r in result.matched_rules)
+
+    @pytest.mark.regression
+    def test_credit_card_visa_real_card_still_flagged(self):
+        """A valid-Luhn Visa test PAN is still detected (16-digit card type)."""
+        cf = ContentFilter(config={"block_high_risk": True})
+        result = cf.check_content("Card 4111-1111-1111-1111")
+        assert result.passed is False
+        assert any(r["type"] == "pii_credit_card" for r in result.matched_rules)
+
+    @pytest.mark.regression
+    def test_phone_intl_date_not_flagged(self):
+        """A date like 2026-08-12 is not an international phone number."""
+        cf = ContentFilter(config={"redact_pii": True})
+        result = cf.check_content("Created 2026-08-12 by auto-dev")
+        assert not any(r["type"] == "pii_phone_intl" for r in result.matched_rules)
+
+    @pytest.mark.regression
+    def test_phone_intl_slash_date_not_flagged(self):
+        """Slash-separated dates (2026/08/12) are not phones either."""
+        cf = ContentFilter(config={"redact_pii": True})
+        result = cf.check_content("Built on 2026/08/12")
+        assert not any(r["type"] == "pii_phone_intl" for r in result.matched_rules)
+
+    @pytest.mark.regression
+    def test_phone_intl_real_phone_still_flagged(self):
+        """A real international phone number is still detected."""
+        cf = ContentFilter(config={"redact_pii": True})
+        result = cf.check_content("Call +86 138 0013 8000 now")
+        assert any(r["type"] == "pii_phone_intl" for r in result.matched_rules)

--- a/tests/unit/test_llm_proxy_autonomous_exempt.py
+++ b/tests/unit/test_llm_proxy_autonomous_exempt.py
@@ -1,0 +1,29 @@
+"""Autonomous agent requests are exempt from the user-content filter.
+
+Autonomous prompts are system-generated and inherently carry commit SHAs,
+dates, and code that trip the governance content_filter's PII detectors
+(15-digit SHAs → credit cards → critical → block), which 403-blocked glm-5
+autonomous workflows (#2499). The autonomous proxy token carries
+``session_type="agent"`` (agent_runner.py), so the handler gates the content
+filter on that claim.
+"""
+
+import pytest
+
+from app.modules.workspace.llm_proxy_handler import _is_autonomous_request
+
+
+@pytest.mark.regression
+def test_agent_session_type_is_autonomous():
+    assert _is_autonomous_request({"session_type": "agent"}) is True
+
+
+@pytest.mark.regression
+def test_terminal_session_type_is_not_autonomous():
+    assert _is_autonomous_request({"session_type": "terminal"}) is False
+
+
+@pytest.mark.regression
+def test_missing_session_type_is_not_autonomous():
+    assert _is_autonomous_request({}) is False
+    assert _is_autonomous_request(None) is False


### PR DESCRIPTION
## Problem

Autonomous workflows using **glm-5** (`#2131`/`#2187`/`#2499` + 21 chat sessions) were `403 Content blocked`-failed by the governance `content_filter`. Root cause traced end-to-end against primary evidence (agent session JSONL → 403 source → `content_filter` → audit `content_blocked` matched_rules → the actual matching rules):

- Autonomous prompts legitimately contain **15-digit commit SHAs / timestamp-IDs** (matched by `pii_credit_card_amex` → risk=critical → **block**), **dates** like `2026-08-12` (matched by `pii_phone_intl`), and the word "方案".
- `llm_proxy_handler` applied the user-content filter to autonomous (system-generated) requests just like user chat — no exemption.

## Fix (A + B)

**A — exempt autonomous requests** (`llm_proxy_handler.py`): the autonomous proxy token carries `session_type="agent"` (`agent_runner.py`, HMAC-signed into the validated token payload). Autonomous prompts are system-generated/trusted (inherently carry code/SHAs/dates) and are not user-submitted chat needing governance. Added `_is_autonomous_request(token_payload)` and gate `_check_content_filter` on it. The acceptance verifier uses the same `_run_agent` path, so it's exempt too.

**B — narrow built-in PII false positives** (`content_filter.py`, helps user chat too) — additive post-filters at the PII loop chokepoint that only REMOVE false-positive matches:
- `pii_credit_card` / `pii_credit_card_amex`: keep only **Luhn-valid** matches (real cards pass; commit SHAs/IDs fail).
- `pii_phone_intl`: drop **date-like** matches (`YYYY-MM-DD` / `YYYY-MM` / `YYYY/MM/DD`).

Real PII detection (real cards/phones) is unchanged — guarded by tests.

## Security review (independent reviewer — APPROVED)
- Exemption is HMAC-bound + scoped to `session_type=="agent"` (sole minter: `agent_runner.py`; no user-facing path can obtain it; `token_payload` is post-`validate_proxy_token`).
- Luhn correctly rejects the 15-digit SHA `140506586314800` (sum=54), accepts real Amex/Visa test PANs.
- Date-exclusion drops dates without affecting real international phones.
- 57 content_filter + exemption tests pass; no real-PII regression.

## Tests
`tests/unit/test_content_filter.py` (+`TestPiiFalsePositiveSuppression`): SHA-not-flagged, real-Amex/Visa-still-flagged, date/slash-date-not-flagged, real-phone-still-flagged. `tests/unit/test_llm_proxy_autonomous_exempt.py`: `_is_autonomous_request` for agent/terminal/missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)