### PR TITLE
fix(autonomous): record correct dev_round on merge-phase milestones

### DIFF
--- a/app/modules/workspace/autonomous/phases/merge.py
+++ b/app/modules/workspace/autonomous/phases/merge.py
@@ -215,6 +215,7 @@ def handle(ctx, deps) -> PhaseResult:
                 phase="merge",
                 milestone_type="pr_head_unverified",
                 status="in_progress",
+                dev_round=int(wf.get("dev_round", 1) or 1),
                 title=f"PR #{pr_number} head not verifiable; deferring merge",
                 error_message=head_ev.reason,
                 metadata=json.dumps({"evidence": head_ev.to_dict()}, ensure_ascii=False),
@@ -297,6 +298,7 @@ def handle(ctx, deps) -> PhaseResult:
                 phase="merge",
                 milestone_type="merged",
                 status="completed",
+                dev_round=int(wf.get("dev_round", 1) or 1),
                 title=f"PR #{pr_number} merged",
             )
         except GitHubOpsError as e:
@@ -430,6 +432,7 @@ def handle(ctx, deps) -> PhaseResult:
                         phase="merge",
                         milestone_type="merged",
                         status="failed",
+                        dev_round=int(wf.get("dev_round", 1) or 1),
                         title="PR merge failed",
                         error_message=f"Merge conflict resolution failed: {resolve_err}",
                     )

--- a/tests/autonomous/phases/test_merge.py
+++ b/tests/autonomous/phases/test_merge.py
@@ -86,10 +86,11 @@ def _build_deps(
     return deps, host
 
 
-def _workflow(pr_number: int | None = 123) -> dict:
+def _workflow(pr_number: int | None = 123, dev_round: int = 1) -> dict:
     return {
         "github_pr_number": pr_number,
         "branch_name": "feature-x",
+        "dev_round": dev_round,
     }
 
 
@@ -123,6 +124,28 @@ def test_merge_handle_success_returns_completed_phase_result():
     ), result.milestone_events
     # Terminal phase_change emitted through the host.
     host.emit_phase_change.assert_called_with({"phase": "completed"})
+
+
+def test_merged_milestone_records_workflow_dev_round():
+    """The merged milestone carries the workflow's current dev_round, not the
+    DB default 1.
+
+    Reproducer #2538: a workflow that merged in round 3 recorded its merged
+    milestone with dev_round=1 (the column default) while the round-3 dev /
+    CI-repair milestones correctly showed dev_round=3. The timeline UI groups
+    by dev_round, so the merged card (the latest by timestamp) was mis-placed
+    into the round-1 group, appearing out of order before the round-3 cards.
+    """
+    deps, host = _build_deps()
+    merge_phase.handle(_ctx(_workflow(dev_round=3)), deps)
+
+    merged_calls = [
+        c
+        for c in host.create_milestone_idempotent.call_args_list
+        if c.kwargs.get("milestone_type") == "merged"
+    ]
+    assert merged_calls, "merged milestone was not recorded on a clean merge"
+    assert merged_calls[-1].kwargs.get("dev_round") == 3
 
 
 def test_merge_handle_no_pr_number_skips_to_cleanup():


### PR DESCRIPTION
## Problem

The merge phase recorded its milestones (`merged` / `pr_head_unverified` / merge-failed) **without passing `dev_round`**, so the column fell back to its DB default of `1`. Other phases already pass the workflow's current dev_round explicitly:

| milestone source | passes dev_round? |
|---|---|
| `pr_review.py` milestones | ✅ yes (`dev_round=dev_round`) |
| orchestrator ci_repair milestones | ✅ yes |
| **`merge.py` milestones** | ❌ **no → DB default 1** |

On a multi-round workflow this mislabels the merge milestones. Reproducer **#2538**: merged in round 3, but its `merged`/`cleaned_up` milestones show `dev_round=1` while the round-3 dev/CI-repair milestones correctly show `dev_round=3`. The timeline UI groups by dev_round, so the merged card (latest by timestamp) was mis-placed into the round-1 group, appearing out of order ahead of the round-3 cards.

## Fix

Pass `dev_round=wf["dev_round"]` on the three merge-phase milestone calls (`merged` completed, `merged` failed, `pr_head_unverified`), matching the pr_review/orchestrator pattern. `wf` is already in scope (`wf = ctx.workflow` at the top of `handle()`).

## Test

`tests/autonomous/phases/test_merge.py::test_merged_milestone_records_workflow_dev_round` — a clean merge at dev_round=3 records the merged milestone with dev_round=3 (red→green verified; the 11 existing merge tests still pass).

Low-severity/cosmetic (the merge itself was correct; only the milestone metadata was wrong).

🤖 Generated with [Claude Code](https://claude.com/claude-code)