### PR TITLE
fix: schema_compatibility_service.py cursor-based query 修复 PostgreSQL 启动崩溃 (#2567)

### DIFF
--- a/app/repositories/schema_guard.py
+++ b/app/repositories/schema_guard.py
@@ -93,6 +93,48 @@ def _execute_scalar(connection: Any, query: str) -> Any:
     return result.scalar()
 
 
+def _execute_all(connection: Any, query: str) -> list[Any]:
+    """Execute a query and return all rows, compatible with all connection types.
+
+    Like :func:`_execute_scalar` but returns every row instead of just the first
+    value.  Normalises ``RealDictCursor`` dict rows to tuples so that positional
+    indexing (``row[0]``) works consistently across backends.
+
+    Supports:
+    - SQLAlchemy ``Connection`` (has ``.execute()``, no ``.cursor()``)
+    - ``PgConnectionWrapper`` / psycopg2 (has ``.cursor()``, no ``.execute()``)
+    - ``sqlite3.Connection`` (has both ``.cursor()`` and ``.execute()``)
+
+    Args:
+        connection: Database connection object.
+        query: SQL query to execute.
+
+    Returns:
+        List of rows.  Dict rows (from ``RealDictCursor``) are converted to
+        tuples so that ``row[0]`` always returns the first column.
+    """
+    if hasattr(connection, "cursor") and not hasattr(connection, "execute"):
+        # Raw psycopg2 / PgConnectionWrapper (has .cursor(), no .execute())
+        cursor = connection.cursor()
+        try:
+            cursor.execute(query)
+            rows = cursor.fetchall()
+        finally:
+            cursor.close()
+        # Normalise RealDictCursor dict rows to tuples for positional indexing
+        if rows and isinstance(rows[0], dict):
+            return [tuple(row.values()) for row in rows]
+        return rows
+    elif hasattr(connection, "cursor") and hasattr(connection, "execute"):
+        # sqlite3 raw connection (has both .cursor() and .execute())
+        # Use .execute() directly for consistency with SQLAlchemy path
+        pass  # fall through to the SQLAlchemy-like path below
+
+    # SQLAlchemy Connection (or sqlite3 via .execute())
+    result = connection.execute(sa.text(query))
+    return result.fetchall()
+
+
 def _table_exists(connection: Any, table_name: str) -> bool:
     """Check if a table exists, compatible with both SQLAlchemy and raw connections.
 

--- a/app/services/schema_compatibility_service.py
+++ b/app/services/schema_compatibility_service.py
@@ -15,7 +15,6 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-import sqlalchemy as sa
 from alembic.config import Config
 from alembic.script import ScriptDirectory
 

--- a/app/services/schema_compatibility_service.py
+++ b/app/services/schema_compatibility_service.py
@@ -291,31 +291,15 @@ class SchemaCompatibilityService:
         Returns:
             List of revision IDs, or None if table doesn't exist
         """
+        from app.repositories.schema_guard import _execute_all, _table_exists
+
         # Check if alembic_version table exists
         try:
-            # Use information_schema for PostgreSQL, sqlite_master for SQLite
-            if hasattr(connection, "dialect") and connection.dialect.name == "postgresql":
-                table_exists_query = (
-                    "SELECT EXISTS ("
-                    "SELECT 1 FROM information_schema.tables "
-                    "WHERE table_schema = 'public' AND table_name = 'alembic_version'"
-                    ")"
-                )
-            else:
-                table_exists_query = (
-                    "SELECT EXISTS ("
-                    "SELECT 1 FROM sqlite_master "
-                    "WHERE type='table' AND name='alembic_version'"
-                    ")"
-                )
-
-            result = connection.execute(sa.text(table_exists_query))
-            if not result.scalar():
+            if not _table_exists(connection, "alembic_version"):
                 return None
 
-            # Get all revisions (not just first row)
-            result = connection.execute(sa.text("SELECT version_num FROM alembic_version"))
-            rows = result.fetchall()
+            # Get all revisions (not just first row) — supports multiple heads
+            rows = _execute_all(connection, "SELECT version_num FROM alembic_version")
             return [str(row[0]) for row in rows] if rows else []
 
         except Exception as e:
@@ -608,24 +592,10 @@ class SchemaCompatibilityService:
 
     def _check_schema_metadata_exists(self, connection: Connection) -> bool:
         """Check if schema_metadata table exists (database-level guard)."""
-        try:
-            if hasattr(connection, "dialect") and connection.dialect.name == "postgresql":
-                query = (
-                    "SELECT EXISTS ("
-                    "SELECT 1 FROM information_schema.tables "
-                    "WHERE table_schema = 'public' AND table_name = 'schema_metadata'"
-                    ")"
-                )
-            else:
-                query = (
-                    "SELECT EXISTS ("
-                    "SELECT 1 FROM sqlite_master "
-                    "WHERE type='table' AND name='schema_metadata'"
-                    ")"
-                )
+        from app.repositories.schema_guard import _table_exists
 
-            result = connection.execute(sa.text(query))
-            return bool(result.scalar())
+        try:
+            return _table_exists(connection, "schema_metadata")
         except Exception as e:
             logger.debug(f"Error checking schema_metadata: {e}")
             return False


### PR DESCRIPTION
## 修复 Issue #2567

### 问题
`schema_compatibility_service.py` 的 `_get_current_database_heads()` 和 `_check_schema_metadata_exists()` 直接调用 `connection.execute()`，但在 PostgreSQL 环境下传入的 `PgConnectionWrapper`（包装 psycopg2 连接）没有 `.execute()` 方法，导致服务启动崩溃。

### 根因
psycopg2 连接对象只有 `.cursor()` 方法，没有 `.execute()`。新引入的 `SchemaCompatibilityService` 没有复用 `schema_guard.py` 中已有的跨连接类型 helper。

### 修复内容
1. **`schema_guard.py`**: 新增 `_execute_all()` helper
2. **`schema_compatibility_service.py`**: 修复 3 处 `connection.execute()` 调用

### 改动文件
| 文件 | 改动 |
|------|------|
| `app/repositories/schema_guard.py` | +42 行 |
| `app/services/schema_compatibility_service.py` | -38+12 行 |

Closes #2567