### PR TITLE
fix(autonomous): exclude merge-upstream files from cumulative scope diff

### DIFF
--- a/app/modules/workspace/autonomous/orchestrator.py
+++ b/app/modules/workspace/autonomous/orchestrator.py
@@ -3458,6 +3458,16 @@ class AutonomousOrchestrator:
                     # Use merge-base as the effective round base for scope validation.
                     # This only counts changes in the PR branch, not merge-introduced changes.
                     commit_before = effective_base
+                    # The merge's upstream files must also be excluded from the
+                    # CUMULATIVE range. Without this, a workflow that is many
+                    # commits behind main and syncs via a merge commit would
+                    # have its stale ``base_commit_sha`` (the branch-creation
+                    # point) produce a cumulative diff counting the merge's
+                    # hundreds of upstream files -> a false "scope exceeded".
+                    # We read cumulative_base from the workflow below; override
+                    # the in-memory view so it uses the merge-base too.
+                    wf = dict(wf)
+                    wf["base_commit_sha"] = effective_base
                     logger.info(
                         "Merge commit detected: using merge-base %s as effective round base",
                         effective_base[:12],

--- a/tests/unit/test_autonomous_scope_cumulative_merge.py
+++ b/tests/unit/test_autonomous_scope_cumulative_merge.py
@@ -1,0 +1,151 @@
+"""Regression tests for cumulative scope guard across an upstream merge.
+
+When an autonomous workflow that is many commits behind ``main`` syncs via a
+merge-upstream commit, the merge-commit exclusion rewrites the *current-round*
+base to the merge-base so upstream files are not counted against that round.
+The same rewrite must also apply to the *cumulative* range; otherwise the
+stale ``base_commit_sha`` (the branch-creation point) produces a cumulative
+diff that includes the merge's hundreds of upstream files and trips a false
+"scope exceeded".
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.modules.workspace.autonomous.orchestrator import AutonomousOrchestrator
+
+
+def _make_orchestrator():
+    orch = AutonomousOrchestrator.__new__(AutonomousOrchestrator)
+    orch._update_workflow = MagicMock()
+    return orch
+
+
+def test_cumulative_range_uses_merge_base_after_upstream_merge(monkeypatch):
+    """A merge-upstream commit must exclude upstream files from BOTH ranges.
+
+    Reproduces the prod symptom: a workflow far behind main merges upstream,
+    producing 194 changed files against the stale branch-creation base but
+    only ~50 real autonomous files against the merge-base. The guard must not
+    flag the merge's upstream files as scope exceeded.
+    """
+    # Lower the cap so the cumulative upstream file count (194) would trip the
+    # guard if the stale base were used, while the real delta (12) stays clean.
+    import app.modules.workspace.autonomous.orchestrator as orchestrator_module
+
+    monkeypatch.setattr(orchestrator_module, "MAX_AUTONOMOUS_CHANGED_FILES", 60)
+
+    orch = _make_orchestrator()
+    gh = MagicMock()
+
+    # The workflow was created far behind main; its persisted base is the old
+    # branch-creation point (stale once main advanced by hundreds of commits).
+    stale_branch_creation_base = "stale-base-aaa"
+    wf = {"base_commit_sha": stale_branch_creation_base}
+
+    # commit_after is a merge commit that brought main into the PR branch.
+    # The merge-base with main is the real autonomous branch point.
+    effective_merge_base = "merge-base-bbb"
+
+    def fake_run_git(args, check=True, **kwargs):
+        # rev-parse FETCH_HEAD during the merge-commit branch, plus the
+        # merge-base probe used to derive the effective round base.
+        if args[0] == "merge-base":
+            return MagicMock(returncode=0, stdout=f"{effective_merge_base}\n")
+        # fetch origin main
+        if args[0] == "fetch":
+            return MagicMock(returncode=0, stdout="")
+        return MagicMock(returncode=0, stdout="")
+
+    gh._run_git.side_effect = fake_run_git
+    gh.resolve_commit.return_value = "fetched-main-head"
+
+    # Against the effective merge-base, the real autonomous delta is small.
+    # Against the stale branch-creation base, the upstream merge's 194 files
+    # would be counted (the false positive).
+    def fake_changed_files(base, after):
+        if base == effective_merge_base:
+            return [f"app/real_{i}.py" for i in range(12)]
+        if base == stale_branch_creation_base:
+            return [f"upstream/file_{i}.py" for i in range(194)]
+        raise AssertionError(f"unexpected base passed to get_changed_files: {base!r}")
+
+    gh.get_changed_files.side_effect = fake_changed_files
+
+    with patch.object(orch, "_is_merge_commit", return_value=True):
+        reason = orch._validate_autonomous_change_scope(
+            gh, wf, "original-round-base", "merge-commit-head"
+        )
+
+    # The guard must not flag the merge's upstream files as scope exceeded.
+    assert reason == "", f"expected no scope violation, got: {reason}"
+    # The cumulative range must have used the effective merge-base, not the
+    # stale branch-creation base.
+    used_bases = [call.args[0] for call in gh.get_changed_files.call_args_list]
+    assert stale_branch_creation_base not in used_bases, (
+        "cumulative range used the stale branch-creation base; upstream merge "
+        "files would be mis-counted"
+    )
+    assert effective_merge_base in used_bases
+
+
+def test_genuinely_oversized_autonomous_change_is_still_blocked(monkeypatch):
+    """A real autonomous delta over the cap must still be flagged, even with a merge."""
+    import app.modules.workspace.autonomous.orchestrator as orchestrator_module
+
+    monkeypatch.setattr(orchestrator_module, "MAX_AUTONOMOUS_CHANGED_FILES", 60)
+
+    orch = _make_orchestrator()
+    gh = MagicMock()
+
+    effective_merge_base = "merge-base-bbb"
+    # Stale base equals the effective base here (no cumulative gap), so the
+    # only range checked is the real autonomous delta, which is oversized.
+    wf = {"base_commit_sha": effective_merge_base}
+
+    def fake_run_git(args, check=True, **kwargs):
+        if args[0] == "merge-base":
+            return MagicMock(returncode=0, stdout=f"{effective_merge_base}\n")
+        return MagicMock(returncode=0, stdout="")
+
+    gh._run_git.side_effect = fake_run_git
+    gh.resolve_commit.return_value = "fetched-main-head"
+
+    # 80 real autonomous files — genuinely over the 60-file cap.
+    gh.get_changed_files.return_value = [f"app/real_{i}.py" for i in range(80)]
+
+    with patch.object(orch, "_is_merge_commit", return_value=True):
+        reason = orch._validate_autonomous_change_scope(
+            gh, wf, "original-round-base", "merge-commit-head"
+        )
+
+    assert "scope exceeded" in reason
+    assert "80 files changed" in reason
+
+
+def test_non_merge_round_keeps_cumulative_base_unchanged(monkeypatch):
+    """A normal dev round with no merge must behave exactly as before."""
+    import app.modules.workspace.autonomous.orchestrator as orchestrator_module
+
+    monkeypatch.setattr(orchestrator_module, "MAX_AUTONOMOUS_CHANGED_FILES", 60)
+
+    orch = _make_orchestrator()
+    gh = MagicMock()
+
+    cumulative_base = "real-base-ccc"
+    wf = {"base_commit_sha": cumulative_base}
+
+    # Not a merge commit — so no merge-base rewrite should occur.
+    gh.get_changed_files.side_effect = [
+        ["app/a.py", "app/b.py"],  # current round
+        ["app/a.py", "app/b.py", "app/c.py"],  # cumulative
+    ]
+
+    with patch.object(orch, "_is_merge_commit", return_value=False):
+        reason = orch._validate_autonomous_change_scope(gh, wf, "round-base", "head")
+
+    assert reason == ""
+    # Cumulative range still uses the persisted base_commit_sha unchanged.
+    used_bases = [call.args[0] for call in gh.get_changed_files.call_args_list]
+    assert used_bases == ["round-base", cumulative_base]


### PR DESCRIPTION
## Problem

The autonomous scope guard (`_validate_autonomous_change_scope`) enforces
"an autonomous dev round may change <=60 files". It computes two diffs:

- **current-round base** — the diff for just this dev round
- **cumulative_base** — the diff since the workflow's `base_commit_sha`

When the current round's head is a merge commit that brought in `main`, the
existing merge-commit exclusion rewrote only the **current-round** base to the
merge-base so upstream files were not counted against that round. **But
`cumulative_base` still read the stale `wf['base_commit_sha']`** (the
branch-creation point), so a workflow far behind `main` that synced via a
merge commit got the merge's hundreds of upstream files counted in the
cumulative diff -> false "scope exceeded".

Prod symptom (issue #2499, workflow ee678c63): "194 files changed (limit 60)"
when the real autonomous delta was ~52 files.

## Root cause (confirmed against code)

`app/modules/workspace/autonomous/orchestrator.py`,
`_validate_autonomous_change_scope`:

- The merge-commit branch rewrites `commit_before` to the merge-base.
- Line ~3472 then reads `cumulative_base = wf.get("base_commit_sha")`
  **without** the same rewrite.
- Since the stale base differs from the rewritten `commit_before`, a
  cumulative range is appended and `get_changed_files(stale_base, head)`
  counts the upstream merge's files.

## Fix

Inside the already-gated merge-commit branch (only triggers when
`commit_after` is a merge commit AND merge-base derivation succeeds),
override the in-memory workflow base so `cumulative_base` also uses the
merge-base. This is **additive/gated**: a normal dev round with no merge
is untouched; the 60-file cap and fail-closed behavior are unchanged.

### Before

```python
if merge_base_result.returncode == 0 and effective_base:
    commit_before = effective_base
    logger.info(...)
```

### After

```python
if merge_base_result.returncode == 0 and effective_base:
    commit_before = effective_base
    wf = dict(wf)
    wf["base_commit_sha"] = effective_base
    logger.info(...)
```

## Tests (TDD)

New file: `tests/unit/test_autonomous_scope_cumulative_merge.py`

1. `test_cumulative_range_uses_merge_base_after_upstream_merge` — RED before
   fix (194 upstream files counted against stale base -> "scope exceeded"),
   GREEN after (cumulative range uses merge-base, real delta is 12 files).
2. `test_genuinely_oversized_autonomous_change_is_still_blocked` — guard
   test: 80 real autonomous files still flagged even with a merge commit.
3. `test_non_merge_round_keeps_cumulative_base_unchanged` — a normal dev
   round with no merge behaves exactly as before.

All 100 existing scope-guard tests pass (test_autonomous_ci_guardrails,
test_merge_commit_scope_validation, test_scope_override, pr_review,
repo_drift).

## Constraints honored

- Additive/gated only — shared module semantics unchanged for normal rounds.
- No `closes`/`fixes`/`resolves` near an issue number (auto-close trap).
- Does not merge or deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)