### PR TITLE
fix(frontend): API Key 管理页适配多租户隔离，platform_admin 支持租户选择器

### DIFF
--- a/frontend/src/api/remote.ts
+++ b/frontend/src/api/remote.ts
@@ -306,7 +306,8 @@ export const remoteApi = {
   deleteApiKey(keyId: number, tenantId?: number): Promise<{ success: boolean; message: string }> {
     // Backend resolves tenant_id from the query string for DELETE (Issue #2511);
     // apiClient.delete has no query param, so append it to the endpoint manually.
-    const query = tenantId !== undefined ? `?tenant_id=${encodeURIComponent(String(tenantId))}` : '';
+    const query =
+      tenantId !== undefined ? `?tenant_id=${encodeURIComponent(String(tenantId))}` : '';
     return apiClient.delete(`/api/api-keys/${keyId}${query}`);
   },
 

--- a/frontend/src/api/remote.ts
+++ b/frontend/src/api/remote.ts
@@ -304,7 +304,10 @@ export const remoteApi = {
   },
 
   deleteApiKey(keyId: number, tenantId?: number): Promise<{ success: boolean; message: string }> {
-    return apiClient.delete(`/api/api-keys/${keyId}`, { tenant_id: tenantId ?? 1 });
+    // Backend resolves tenant_id from the query string for DELETE (Issue #2511);
+    // apiClient.delete has no query param, so append it to the endpoint manually.
+    const query = tenantId !== undefined ? `?tenant_id=${encodeURIComponent(String(tenantId))}` : '';
+    return apiClient.delete(`/api/api-keys/${keyId}${query}`);
   },
 
   updateApiKey(data: UpdateApiKeyRequest): Promise<{ success: boolean; message: string }> {

--- a/frontend/src/components/features/management/APIKeyManagement.tsx
+++ b/frontend/src/components/features/management/APIKeyManagement.tsx
@@ -8,13 +8,14 @@
  * - Delete API key confirmation
  */
 
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import {
   useApiKeys,
   useStoreApiKey,
   useUpdateApiKey,
   useDeleteApiKey,
   usePageRefresh,
+  useAuth,
 } from '@/hooks';
 import { useLanguage } from '@/store';
 import { t } from '@/i18n';
@@ -29,9 +30,12 @@ import {
   EmptyState,
   Badge,
   PageRefreshControl,
+  useToast,
 } from '@/components/common';
 import type { BadgeVariant } from '@/components/common';
 import { createMatcherConfig } from '@/utils';
+import { canManageAllTenants } from '@/utils/permissions';
+import { tenantApi, type Tenant } from '@/api';
 import type { ApiKey } from '@/api';
 
 /**
@@ -144,7 +148,51 @@ const defaultZcodeSettings = `{
 
 export const APIKeyManagement: React.FC = () => {
   const language = useLanguage();
-  const { data: keysData, isLoading, isError, error, refetch } = useApiKeys();
+  const toast = useToast();
+
+  // Admin tenant selection (Issue #2579) - mirrors RemoteMachineManagement (#2535)
+  const { user } = useAuth();
+  const isAdmin = canManageAllTenants(user);
+  const [tenants, setTenants] = useState<Tenant[]>([]);
+  const [selectedTenantId, setSelectedTenantId] = useState<number | null>(null);
+  const selectedTenantIdRef = useRef<number | null>(null);
+  const [isLoadingTenants, setIsLoadingTenants] = useState(false);
+
+  // Compute effective tenant ID
+  const effectiveTenantId = isAdmin ? selectedTenantId : user?.tenant_id;
+
+  // Fetch tenants list for admin users
+  useEffect(() => {
+    if (!isAdmin) return;
+
+    setIsLoadingTenants(true);
+    tenantApi
+      .listTenants({ status: 'active', limit: 100 })
+      .then((result) => {
+        setTenants(result.tenants);
+        // Use ref to check, avoid triggering useEffect again
+        if (result.tenants.length > 0 && !selectedTenantIdRef.current) {
+          selectedTenantIdRef.current = result.tenants[0].id;
+          setSelectedTenantId(result.tenants[0].id);
+        }
+      })
+      .catch((err) => {
+        console.error('Failed to fetch tenants:', err);
+        toast.error(t('failedToLoadTenants', language) || 'Failed to load tenants');
+      })
+      .finally(() => {
+        setIsLoadingTenants(false);
+      });
+  }, [isAdmin, language, toast]);
+
+  // Sync ref with state
+  useEffect(() => {
+    selectedTenantIdRef.current = selectedTenantId;
+  }, [selectedTenantId]);
+
+  const { data: keysData, isLoading, isError, error, refetch } = useApiKeys(
+    effectiveTenantId ?? undefined
+  );
   const storeApiKey = useStoreApiKey();
   const updateApiKey = useUpdateApiKey();
   const deleteApiKey = useDeleteApiKey();
@@ -528,6 +576,7 @@ export const APIKeyManagement: React.FC = () => {
         scope: formData.scope,
         priority: formData.priority,
         weight: formData.weight,
+        tenant_id: effectiveTenantId ?? undefined,
       });
       setShowAddDialog(false);
       refetch();
@@ -573,6 +622,7 @@ export const APIKeyManagement: React.FC = () => {
         scope: formData.scope,
         priority: formData.priority,
         weight: formData.weight,
+        tenant_id: effectiveTenantId ?? undefined,
       });
       setShowEditDialog(false);
       setEditTarget(null);
@@ -591,7 +641,10 @@ export const APIKeyManagement: React.FC = () => {
   const handleDelete = async () => {
     if (!deleteTarget) return;
     try {
-      await deleteApiKey.mutateAsync({ keyId: deleteTarget.id });
+      await deleteApiKey.mutateAsync({
+        keyId: deleteTarget.id,
+        tenantId: effectiveTenantId ?? undefined,
+      });
       setShowDeleteDialog(false);
       setDeleteTarget(null);
       refetch();
@@ -599,6 +652,42 @@ export const APIKeyManagement: React.FC = () => {
       console.error('Failed to delete API key:', err);
     }
   };
+
+  // Tenant guards (Issue #2579): never fire a tenant-less list request for
+  // platform admins - wait for the tenant list to resolve first.
+  if (isAdmin && tenants.length === 0 && !isLoadingTenants) {
+    return (
+      <div className="api-key-management">
+        <EmptyState
+          icon="bi-building"
+          title={t('noTenantsAvailable', language) || 'No Tenants Available'}
+          description={
+            t('noTenantsDescription', language) ||
+            'Please contact system administrator to assign tenant permissions.'
+          }
+        />
+      </div>
+    );
+  }
+  if (isLoadingTenants || (isAdmin && !effectiveTenantId)) {
+    return (
+      <Loading size="lg" text={t('loadingTenants', language) || 'Loading tenant information...'} />
+    );
+  }
+  if (!isAdmin && !effectiveTenantId) {
+    return (
+      <div className="api-key-management">
+        <EmptyState
+          icon="bi-building"
+          title={t('noTenantConfigured', language) || 'No Tenant Configured'}
+          description={
+            t('noTenantDescription', language) ||
+            'Please contact system administrator to configure your tenant.'
+          }
+        />
+      </div>
+    );
+  }
 
   if (isLoading) {
     return <Loading size="lg" text={t('loading', language)} />;
@@ -610,6 +699,33 @@ export const APIKeyManagement: React.FC = () => {
 
   return (
     <div className="api-key-management">
+      {/* Tenant Selector - Only for admins */}
+      {isAdmin && (
+        <div className="card mb-3">
+          <div className="card-body">
+            <div className="row align-items-center">
+              <div className="col-md-4">
+                <label className="form-label mb-0">
+                  <i className="bi bi-building me-2" />
+                  {t('selectTenant', language) || 'Select Tenant'}
+                </label>
+              </div>
+              <div className="col-md-8">
+                <Select
+                  value={selectedTenantId?.toString() ?? ''}
+                  onChange={(value) => setSelectedTenantId(Number(value))}
+                  options={tenants.map((tenant) => ({
+                    value: tenant.id.toString(),
+                    label: tenant.name,
+                  }))}
+                  placeholder={t('selectTenantPlaceholder', language) || 'Choose a tenant'}
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
       {/* Header */}
       <div className="d-flex justify-content-between align-items-center mb-3">
         <h2>{t('apiKeys', language)}</h2>
@@ -699,6 +815,7 @@ export const APIKeyManagement: React.FC = () => {
                               updateApiKey.mutate({
                                 keyId: key.id,
                                 is_active: !key.is_active,
+                                tenant_id: effectiveTenantId ?? undefined,
                               });
                             }}
                             disabled={updateApiKey.isPending}

--- a/frontend/src/components/features/management/APIKeyManagement.tsx
+++ b/frontend/src/components/features/management/APIKeyManagement.tsx
@@ -190,9 +190,13 @@ export const APIKeyManagement: React.FC = () => {
     selectedTenantIdRef.current = selectedTenantId;
   }, [selectedTenantId]);
 
-  const { data: keysData, isLoading, isError, error, refetch } = useApiKeys(
-    effectiveTenantId ?? undefined
-  );
+  const {
+    data: keysData,
+    isLoading,
+    isError,
+    error,
+    refetch,
+  } = useApiKeys(effectiveTenantId ?? undefined);
   const storeApiKey = useStoreApiKey();
   const updateApiKey = useUpdateApiKey();
   const deleteApiKey = useDeleteApiKey();


### PR DESCRIPTION
Fixes #2579

## 背景
platform_admin 访问 API Key 管理页时所有操作均报 400 `Target tenant_id is required`。
根因：后端 `api_key_admin_required` 为 fail-closed 设计（Issue #2327 / #2511），
`platform_admin` / legacy `admin` 必须显式携带 `tenant_id`（POST/PUT 从 body 读，GET/DELETE 从 query 读），
而前端页面未传租户参数。

## 改动（仅 2 个前端文件，后端不动）

### 1. `frontend/src/api/remote.ts`
- `deleteApiKey(keyId, tenantId?)`：`tenant_id` 由 body 改为 **query string** 传参
  （`apiClient.delete` 第二参数是 body，后端 DELETE 不读 body 只读 query，原实现传不到后端）

### 2. `frontend/src/components/features/management/APIKeyManagement.tsx`
- 复用已合并的远程机器页修复模式（Issue #2535 / PR #2552）：
  - `useAuth()` + `canManageAllTenants(user)` 判定平台管理员
  - 管理员拉取 active 租户列表，默认选中第一个（ref 防重复触发），顶部显示租户选择器
  - `useApiKeys(effectiveTenantId)` 列表按租户隔离（queryKey 已含 tenantId）
  - 新增 / 编辑 / 启停 toggle / 删除 四处 mutate 全部携带 `tenant_id`
- 竞态兜底：租户列表加载完成前显示 Loading，不先发无参列表请求；
  管理员无可用租户 / 普通用户无租户时显示 EmptyState
- i18n：无需新增 key（`selectTenant`/`loadingTenants`/`noTenantsAvailable` 等已随 PR #2552 合并补齐）

## 验证
- [x] `tsc --noEmit` 通过
- [ ] platform_admin 实测：列表 / 新增 / 编辑 / 启停 / 删除 5 项操作
- [ ] 切换租户后列表随 queryKey 隔离刷新
- [ ] 普通 user / tenant_admin 不显示选择器且行为不变
