### PR TITLE
fix(install): keep package autostart PID in install directory

### DIFF
--- a/scripts/install-central/package-method/install.sh
+++ b/scripts/install-central/package-method/install.sh
@@ -4200,7 +4200,7 @@ install_local() {
 
         # Use nohup to run in background and save PID
         print_info "Starting web server on $host:$port as user '$DEPLOY_USER'..."
-        if ! su - "$DEPLOY_USER" -c "cd '$target_path' && AI_TOKEN_WEB_PORT=$port AI_TOKEN_WEB_HOST=$host nohup python3 server.py > logs/server.log 2>&1 & echo \$! > logs/server.pid"; then
+        if ! su - "$DEPLOY_USER" -c "cd '$target_path' && { AI_TOKEN_WEB_PORT=$port AI_TOKEN_WEB_HOST=$host nohup python3 server.py > '$target_path/logs/server.log' 2>&1 & echo \$! > '$pid_file'; }"; then
             print_error "Failed to start server as user '$DEPLOY_USER'"
             print_info "Check if user exists: id $DEPLOY_USER"
             echo ""
@@ -4343,7 +4343,7 @@ install_deploy() {
             # Start the server in background as the correct user
             print_info "Starting web server on $host:$port as user '$DEPLOY_USER' on remote..."
             local pid_file="$target_path/logs/server.pid"
-            if ! ssh "$remote" "su - '$DEPLOY_USER' -c \"cd '$target_path' && AI_TOKEN_WEB_PORT=$port AI_TOKEN_WEB_HOST=$host nohup python3 server.py > logs/server.log 2>&1 & echo \\\$! > logs/server.pid\""; then
+            if ! ssh "$remote" "su - '$DEPLOY_USER' -c \"cd '$target_path' && { AI_TOKEN_WEB_PORT=$port AI_TOKEN_WEB_HOST=$host nohup python3 server.py > '$target_path/logs/server.log' 2>&1 & echo \\\$! > '$pid_file'; }\""; then
                 print_error "Failed to start server on remote as user '$DEPLOY_USER'"
                 print_info "Check if user exists on remote: ssh $remote 'id $DEPLOY_USER'"
                 echo ""

--- a/tests/issues/2583/test_package_autostart_pid_path.py
+++ b/tests/issues/2583/test_package_autostart_pid_path.py
@@ -1,0 +1,48 @@
+"""Regression tests for package installer non-systemd auto-start (Issue #2583)."""
+
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+INSTALL_SH = PROJECT_ROOT / "scripts" / "install-central" / "package-method" / "install.sh"
+
+pytestmark = [pytest.mark.issue(2583), pytest.mark.regression]
+
+
+def _installer_text() -> str:
+    return INSTALL_SH.read_text(encoding="utf-8")
+
+
+def test_local_manual_start_groups_pid_write_in_target_directory() -> None:
+    """The local PID write must share the target-directory command group."""
+    text = _installer_text()
+
+    expected = (
+        'su - "$DEPLOY_USER" -c "cd \'$target_path\' && { '
+        "AI_TOKEN_WEB_PORT=$port AI_TOKEN_WEB_HOST=$host nohup python3 server.py "
+        "> '$target_path/logs/server.log' 2>&1 & "
+        "echo \\$! > '$pid_file'; }\""
+    )
+    assert expected in text
+
+
+def test_remote_manual_start_groups_pid_write_in_target_directory() -> None:
+    """The remote PID write must use the same grouped, absolute-path behavior."""
+    text = _installer_text()
+
+    expected = (
+        "ssh \"$remote\" \"su - '$DEPLOY_USER' -c \\\"cd '$target_path' && { "
+        "AI_TOKEN_WEB_PORT=$port AI_TOKEN_WEB_HOST=$host nohup python3 server.py "
+        "> '$target_path/logs/server.log' 2>&1 & "
+        "echo \\\\\\$! > '$pid_file'; }\\\"\""
+    )
+    assert expected in text
+
+
+def test_manual_start_does_not_write_relative_pid_or_log_paths() -> None:
+    """A login shell's working directory must not control log or PID placement."""
+    text = _installer_text()
+
+    assert "> logs/server.log" not in text
+    assert "> logs/server.pid" not in text

--- a/tests/unit/test_issue_2583_package_autostart_pid_path.py
+++ b/tests/unit/test_issue_2583_package_autostart_pid_path.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-PROJECT_ROOT = Path(__file__).resolve().parents[3]
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
 INSTALL_SH = PROJECT_ROOT / "scripts" / "install-central" / "package-method" / "install.sh"
 
 pytestmark = [pytest.mark.issue(2583), pytest.mark.regression]


### PR DESCRIPTION
## Summary

- group the non-systemd background launch and PID write after changing to the install directory
- use absolute install-directory paths for both server.log and server.pid`n- apply the same behavior to local package installs and remote package deployments
- add regression coverage for both nested shell command forms

## Root cause

The ungrouped & backgrounded the preceding cd ... && nohup ... list. The following echo $! > logs/server.pid therefore ran from the deployment user's login directory instead of the installation directory, causing startup to fail when that unrelated logs directory did not exist.

## Validation

- python -m pytest tests/issues/2583/test_package_autostart_pid_path.py -q (3 passed)
- python -m ruff check tests/issues/2583/test_package_autostart_pid_path.py`n- python -m ruff format --check tests/issues/2583/test_package_autostart_pid_path.py`n- git diff --check`n
Fixes #2583