### PR TITLE
fix(tests): align remote-endpoint tests with #2540 UUID + #2538 tenant isolation

### DIFF
--- a/tests/issues/1789/test_null_tenant_fail_closed.py
+++ b/tests/issues/1789/test_null_tenant_fail_closed.py
@@ -204,14 +204,17 @@ def test_check_session_access_denies_null_tenant_machine_admin(sqlite_db, monkey
         class _StubRemoteMgr:
             def __init__(self):
                 self._session_manager = manager
-                self._data = {"session_id": "tenant-two-session", "machine_id": "M1"}
+                self._data = {
+                    "session_id": "tenant-two-session",
+                    "machine_id": "90849a28-ea5d-503e-afe1-f2cea0832770",
+                }
 
             def get_session_status(self, session_id):
                 return self._data if session_id == "tenant-two-session" else None
 
         class _StubAgentMgr:
             def get_user_permission(self, machine_id, user_id):
-                # Null-tenant user 99 is an "admin" of machine M1 — the unguarded
+                # Null-tenant user 99 is an "admin" of machine 90849a28 — the unguarded
                 # machine-admin branch would let them in before the fix.
                 return "admin"
 

--- a/tests/issues/1789/test_null_tenant_fail_closed.py
+++ b/tests/issues/1789/test_null_tenant_fail_closed.py
@@ -226,5 +226,10 @@ def test_check_session_access_denies_null_tenant_machine_admin(sqlite_db, monkey
             "null-tenant machine-admin must be denied (fail closed), not admitted via the "
             "untenant-scoped machine-admin branch"
         )
+        # Issue #2538 changed the null-tenant denial from 403 to 404 ("Session
+        # not found") so a caller without a tenant cannot learn the session
+        # exists. The fail-closed property #1789 guards (a null-tenant user is
+        # never admitted) is preserved and in fact strengthened: #2538's check
+        # fires before the machine-admin branch is even reached.
         status_code = error[1]
-        assert status_code == 403, f"expected 403, got {status_code}"
+        assert status_code == 404, f"expected 404, got {status_code}"

--- a/tests/issues/1891/test_usage_report_auth.py
+++ b/tests/issues/1891/test_usage_report_auth.py
@@ -166,7 +166,7 @@ class TestAuthentication:
 
     def test_no_bearer_token_non_legacy(self, manager):
         """Non-legacy machine without Bearer should fail validation."""
-        machine_id = "machine-auth-001"
+        machine_id = "e421d788-6cb4-501f-80f3-b3517d5d26f3"
 
         # Register machine (non-legacy by default)
         reg_token = manager.create_registration_token(tenant_id=1, created_by=1)
@@ -182,7 +182,7 @@ class TestAuthentication:
 
     def test_invalid_bearer_token(self, manager):
         """Invalid Bearer token should fail validation."""
-        machine_id = "machine-auth-002"
+        machine_id = "2485f7ed-f6fe-5818-9195-56323e8c00d5"
 
         reg_token = manager.create_registration_token(tenant_id=1, created_by=1)
         result = manager.register_machine(
@@ -201,7 +201,7 @@ class TestAuthentication:
         reg_a = manager.create_registration_token(tenant_id=1, created_by=1)
         result_a = manager.register_machine(
             registration_token=reg_a,
-            machine_id="machine-a",
+            machine_id="37d94b90-228a-5358-84e8-bdd5fade8412",
             machine_name="Machine A",
         )
         token_a = result_a["agent_token"]
@@ -210,19 +210,21 @@ class TestAuthentication:
         reg_b = manager.create_registration_token(tenant_id=1, created_by=1)
         manager.register_machine(
             registration_token=reg_b,
-            machine_id="machine-b",
+            machine_id="4709fca1-753e-5786-a6fc-692812e1f4a2",
             machine_name="Machine B",
         )
 
         # A's token should NOT validate against B's machine_id
-        assert manager.validate_agent_token(token_a, "machine-b") is False
+        assert (
+            manager.validate_agent_token(token_a, "4709fca1-753e-5786-a6fc-692812e1f4a2") is False
+        )
 
         # A's token should validate against A's machine_id
-        assert manager.validate_agent_token(token_a, "machine-a") is True
+        assert manager.validate_agent_token(token_a, "37d94b90-228a-5358-84e8-bdd5fade8412") is True
 
     def test_valid_token_success(self, manager):
         """Valid Bearer token should pass validation."""
-        machine_id = "machine-auth-003"
+        machine_id = "1b717d0f-2cf4-50a8-9de9-d590292e4e51"
 
         reg_token = manager.create_registration_token(tenant_id=1, created_by=1)
         result = manager.register_machine(
@@ -238,7 +240,7 @@ class TestAuthentication:
 
     def test_revoked_token_fails(self, manager):
         """Revoked token should fail validation."""
-        machine_id = "machine-auth-004"
+        machine_id = "542ed065-8734-54c3-9ef6-3fd761a2a92c"
 
         reg_token = manager.create_registration_token(tenant_id=1, created_by=1)
         result = manager.register_machine(
@@ -267,7 +269,7 @@ class TestBindingValidation:
 
     def test_session_machine_binding_correct(self, manager, tmp_path):
         """Session should belong to correct machine."""
-        machine_id = "machine-bind-001"
+        machine_id = "0a9d854c-b7f9-552d-99b4-038819ca3c5e"
         session_id = "session-bind-001"
 
         reg_token = manager.create_registration_token(tenant_id=1, created_by=1)
@@ -288,8 +290,8 @@ class TestBindingValidation:
 
     def test_cross_machine_session_rejected(self, manager, tmp_path):
         """Session belonging to different machine should be rejected."""
-        machine_a = "machine-bind-a"
-        machine_b = "machine-bind-b"
+        machine_a = "7d6d5473-c046-5e3a-b293-0a4eb73b2761"
+        machine_b = "6c4cc7f6-b9bd-5904-b588-8e7937eacbcc"
         session_a = "session-bind-a"
 
         # Register both machines
@@ -327,7 +329,7 @@ class TestLegacyCompatibility:
 
     def test_legacy_machine_accepted(self, manager):
         """Legacy machine should be allowed without Bearer."""
-        machine_id = "machine-legacy-001"
+        machine_id = "947da314-615b-5a32-99e6-1890746a401d"
 
         reg_token = manager.create_registration_token(tenant_id=1, created_by=1)
         result = manager.register_machine(
@@ -351,7 +353,7 @@ class TestLegacyCompatibility:
 
     def test_non_legacy_requires_bearer(self, manager):
         """Non-legacy machine without Bearer should fail."""
-        machine_id = "machine-legacy-002"
+        machine_id = "5a8a0d74-d849-55f0-9746-2d1117ef426d"
 
         reg_token = manager.create_registration_token(tenant_id=1, created_by=1)
         result = manager.register_machine(
@@ -369,7 +371,7 @@ class TestLegacyCompatibility:
 
     def test_legacy_mode_can_be_cleared(self, manager):
         """Legacy mode should be clearable after Bearer auth."""
-        machine_id = "machine-legacy-003"
+        machine_id = "be1c1a7b-9bb7-5a3d-a60b-0b3e27861ea2"
 
         reg_token = manager.create_registration_token(tenant_id=1, created_by=1)
         manager.register_machine(
@@ -457,7 +459,7 @@ class TestValidRequests:
 
     def test_process_usage_report_basic(self, manager, tmp_path):
         """Basic usage report processing should work."""
-        machine_id = "machine-valid-001"
+        machine_id = "9c8bca3a-2469-524f-9851-edb786719e5c"
         session_id = "session-valid-001"
 
         # Setup
@@ -488,7 +490,7 @@ class TestValidRequests:
 
     def test_token_rotation_preserves_usage(self, manager):
         """Token rotation should not affect usage data."""
-        machine_id = "machine-valid-002"
+        machine_id = "501210ac-0d0f-547b-968c-f0fe5d0ff9b8"
 
         reg_token = manager.create_registration_token(tenant_id=1, created_by=1)
         result = manager.register_machine(
@@ -589,7 +591,7 @@ class TestUsageReportHttpIntegration:
         self, usage_http, path
     ):
         client, manager = usage_http
-        machine_id = "machine-http-noauth"
+        machine_id = "b92ad08a-40a6-5ea9-8217-3e4053576380"
         session_id = "session-http-noauth"
         _register_http_machine(manager, machine_id)
         _create_session_in_db(manager.db_path, session_id, machine_id)
@@ -610,7 +612,11 @@ class TestUsageReportHttpIntegration:
     def test_valid_bearer_updates_usage_and_audits_both_paths(self, usage_http, path):
         client, manager = usage_http
         suffix = "direct" if path.endswith("usage-report") else "message"
-        machine_id = f"machine-http-{suffix}"
+        machine_id = (
+            "baed6dc3-f0e6-5bae-a674-2a02c259d55b"
+            if suffix == "direct"
+            else "2495881c-0d5b-535d-9061-9f8858637284"
+        )
         session_id = f"session-http-{suffix}"
         token = _register_http_machine(manager, machine_id)
         _create_session_in_db(manager.db_path, session_id, machine_id)
@@ -642,13 +648,15 @@ class TestUsageReportHttpIntegration:
 
     def test_cross_machine_is_rejected_on_actual_agent_path(self, usage_http):
         client, manager = usage_http
-        token_a = _register_http_machine(manager, "machine-http-a")
-        _register_http_machine(manager, "machine-http-b")
-        _create_session_in_db(manager.db_path, "session-http-b", "machine-http-b")
+        token_a = _register_http_machine(manager, "60977ea0-4355-535d-9de6-123954ed95d5")
+        _register_http_machine(manager, "338433f6-52d3-5e96-a620-8edd26c7374f")
+        _create_session_in_db(
+            manager.db_path, "session-http-b", "338433f6-52d3-5e96-a620-8edd26c7374f"
+        )
 
         response = client.post(
             "/api/remote/agent/message",
-            json=_usage_payload("machine-http-a", "session-http-b"),
+            json=_usage_payload("60977ea0-4355-535d-9de6-123954ed95d5", "session-http-b"),
             headers={"Authorization": f"Bearer {token_a}"},
         )
 
@@ -666,7 +674,11 @@ class TestUsageReportHttpIntegration:
         session_user,
     ):
         client, manager = usage_http
-        machine_id = f"machine-http-bind-{session_tenant}-{session_user}"
+        machine_id = (
+            "c1a120cd-60c8-52bc-adb1-a90bafda2861"
+            if session_tenant == 2
+            else "533dac89-ce1d-5b14-88cb-cb434e95efee"
+        )
         session_id = f"session-http-bind-{session_tenant}-{session_user}"
         token = _register_http_machine(manager, machine_id)
         _create_session_in_db(
@@ -689,7 +701,7 @@ class TestUsageReportHttpIntegration:
 
     def test_duplicate_report_is_idempotent_and_conflicting_replay_is_rejected(self, usage_http):
         client, manager = usage_http
-        machine_id = "machine-http-replay"
+        machine_id = "4ba66546-7ee3-577e-aeb6-fefcb27fa8e3"
         session_id = "session-http-replay"
         token = _register_http_machine(manager, machine_id)
         _create_session_in_db(manager.db_path, session_id, machine_id)
@@ -721,8 +733,8 @@ class TestUsageReportHttpIntegration:
 
     def test_binding_failures_are_uniform_rate_limited_and_do_not_leak_victim_ids(self, usage_http):
         client, manager = usage_http
-        attacker_machine = "machine-http-attacker"
-        victim_machine = "machine-http-victim"
+        attacker_machine = "1c28d9ba-e22a-5d29-b513-d1c0dfbd6b00"
+        victim_machine = "fc2f9738-55a4-5d82-8fdb-c8f03d058cc1"
         victim_session = "session-http-victim-secret"
         token = _register_http_machine(manager, attacker_machine, tenant_id=1)
         _register_http_machine(manager, victim_machine, tenant_id=2, user_id=2)
@@ -776,7 +788,7 @@ class TestUsageReportHttpIntegration:
 
     def test_invalid_binding_hits_machine_limit_before_more_db_or_audit_work(self, usage_http):
         client, manager = usage_http
-        machine_id = "machine-http-binding-limit"
+        machine_id = "54e186d2-2497-5588-87ff-674cd51b4e3a"
         token = _register_http_machine(manager, machine_id)
         headers = {"Authorization": f"Bearer {token}"}
 
@@ -803,7 +815,7 @@ class TestUsageReportHttpIntegration:
 
     def test_invalid_token_audit_is_shared_and_bounded(self, usage_http):
         client, manager = usage_http
-        machine_id = "machine-http-auth-audit-limit"
+        machine_id = "0bbf4e0a-9391-5c3b-b436-771f6f213e56"
         _register_http_machine(manager, machine_id)
         payload = _usage_payload(machine_id, "session-auth-audit-limit")
 
@@ -834,7 +846,11 @@ class TestUsageReportHttpIntegration:
     def test_report_id_less_agent_has_explicit_short_migration_window(self, usage_http, path):
         client, manager = usage_http
         suffix = "legacy-direct" if path.endswith("usage-report") else "legacy-message"
-        machine_id = f"machine-http-{suffix}"
+        machine_id = (
+            "566db1eb-3777-5483-9b6a-173c08356adf"
+            if suffix == "legacy-direct"
+            else "e9ccc48e-2094-544e-b057-2bb964752f36"
+        )
         session_id = f"session-http-{suffix}"
         token = _register_http_machine(manager, machine_id)
         _create_session_in_db(manager.db_path, session_id, machine_id)
@@ -858,7 +874,7 @@ class TestUsageReportHttpIntegration:
 
     def test_report_id_less_agent_is_rejected_after_migration_deadline(self, usage_http):
         client, manager = usage_http
-        machine_id = "machine-http-legacy-expired"
+        machine_id = "c8d3136c-8df6-5466-b3e9-6c0fbfa2ecb3"
         session_id = "session-http-legacy-expired"
         token = _register_http_machine(manager, machine_id)
         _create_session_in_db(manager.db_path, session_id, machine_id)

--- a/tests/issues/604/test_session_models_route.py
+++ b/tests/issues/604/test_session_models_route.py
@@ -29,8 +29,8 @@ def app():
     return _app
 
 
-def _mock_user(user_id=1, role="admin"):
-    return {"id": user_id, "username": "testuser", "role": role}
+def _mock_user(user_id=1, role="admin", tenant_id=None):
+    return {"id": user_id, "username": "testuser", "role": role, "tenant_id": tenant_id}
 
 
 def _mock_proxy():
@@ -177,7 +177,10 @@ class TestSessionModelsRemoteByMachine:
         self, mock_extract, mock_auth, mock_get_aggr, mock_get_proxy, app
     ):
         mock_extract.return_value = "tok"
-        mock_auth.return_value = _mock_user(user_id=1)
+        # Machine belongs to tenant 1; the caller must be in the same tenant to
+        # pass the #2538 cross-tenant guard (get_session_models has no admin
+        # bypass), so model the admin as a tenant-1 user.
+        mock_auth.return_value = _mock_user(user_id=1, tenant_id=1)
 
         mock_agent_mgr = MagicMock()
         mock_agent_mgr.check_user_access.return_value = True

--- a/tests/issues/604/test_session_models_route.py
+++ b/tests/issues/604/test_session_models_route.py
@@ -197,7 +197,7 @@ class TestSessionModelsRemoteByMachine:
 
         client = app.test_client()
         resp = client.get(
-            "/api/workspace/session-models?workspace_type=remote&machine_id=mac-1",
+            "/api/workspace/session-models?workspace_type=remote&machine_id=b2b10214-1b8c-550f-8983-3fb0d3b2e480",
             headers={"Authorization": "Bearer tok"},
         )
 
@@ -227,7 +227,7 @@ class TestSessionModelsRemoteByMachine:
 
         client = app.test_client()
         resp = client.get(
-            "/api/workspace/session-models?workspace_type=remote&machine_id=mac-1",
+            "/api/workspace/session-models?workspace_type=remote&machine_id=b2b10214-1b8c-550f-8983-3fb0d3b2e480",
             headers={"Authorization": "Bearer tok"},
         )
 

--- a/tests/issues/610/test_remote_git_endpoints.py
+++ b/tests/issues/610/test_remote_git_endpoints.py
@@ -93,7 +93,7 @@ def mock_agent_mgr():
     mgr = MagicMock()
     mgr.check_user_access.return_value = True
     mgr.get_machine.return_value = {
-        "machine_id": "machine-001",
+        "machine_id": "83ce1ab1-5506-5836-9a77-cc5af1ccf7a5",
         "machine_name": "Test Machine",
         "status": "online",
     }
@@ -141,7 +141,9 @@ class TestRemoteGitStatus:
                 with patch.object(
                     remote_module, "get_remote_agent_manager", return_value=mock_agent_mgr
                 ):
-                    data, status = parse_response(remote_module.remote_git_status("machine-001"))
+                    data, status = parse_response(
+                        remote_module.remote_git_status("83ce1ab1-5506-5836-9a77-cc5af1ccf7a5")
+                    )
                     assert status == 401
                     assert data["error"] == "Unauthorized"
 
@@ -155,7 +157,9 @@ class TestRemoteGitStatus:
                 with patch.object(
                     remote_module, "get_remote_agent_manager", return_value=mock_agent_mgr
                 ):
-                    data, status = parse_response(remote_module.remote_git_status("machine-001"))
+                    data, status = parse_response(
+                        remote_module.remote_git_status("83ce1ab1-5506-5836-9a77-cc5af1ccf7a5")
+                    )
                     assert status == 401
                     assert data["error"] == "Unauthorized"
 
@@ -172,7 +176,9 @@ class TestRemoteGitStatus:
                 with patch.object(
                     remote_module, "get_remote_agent_manager", return_value=mock_agent_mgr
                 ):
-                    data, status = parse_response(remote_module.remote_git_status("machine-001"))
+                    data, status = parse_response(
+                        remote_module.remote_git_status("83ce1ab1-5506-5836-9a77-cc5af1ccf7a5")
+                    )
                     assert status == 403
                     assert data["error"] == "Access denied"
 
@@ -189,7 +195,9 @@ class TestRemoteGitStatus:
                 with patch.object(
                     remote_module, "get_remote_agent_manager", return_value=mock_agent_mgr
                 ):
-                    data, status = parse_response(remote_module.remote_git_status("machine-001"))
+                    data, status = parse_response(
+                        remote_module.remote_git_status("83ce1ab1-5506-5836-9a77-cc5af1ccf7a5")
+                    )
                     assert status == 404
                     assert data["error"] == "Machine not found"
 
@@ -206,7 +214,9 @@ class TestRemoteGitStatus:
                 with patch.object(
                     remote_module, "get_remote_agent_manager", return_value=mock_agent_mgr
                 ):
-                    data, status = parse_response(remote_module.remote_git_status("machine-001"))
+                    data, status = parse_response(
+                        remote_module.remote_git_status("83ce1ab1-5506-5836-9a77-cc5af1ccf7a5")
+                    )
                     assert status == 503
                     assert data["success"] is False
                     assert "not connected" in data["error"].lower()
@@ -223,7 +233,9 @@ class TestRemoteGitStatus:
                 with patch.object(
                     remote_module, "get_remote_agent_manager", return_value=mock_agent_mgr
                 ):
-                    data, status = parse_response(remote_module.remote_git_status("machine-001"))
+                    data, status = parse_response(
+                        remote_module.remote_git_status("83ce1ab1-5506-5836-9a77-cc5af1ccf7a5")
+                    )
                     assert status == 504
                     assert data["success"] is False
                     assert "timeout" in data["error"].lower()
@@ -241,7 +253,9 @@ class TestRemoteGitStatus:
                 with patch.object(
                     remote_module, "get_remote_agent_manager", return_value=mock_agent_mgr
                 ):
-                    data, status = parse_response(remote_module.remote_git_status("machine-001"))
+                    data, status = parse_response(
+                        remote_module.remote_git_status("83ce1ab1-5506-5836-9a77-cc5af1ccf7a5")
+                    )
                     assert status == 400
                     assert data["success"] is False
                     assert "path" in data["error"].lower()
@@ -268,7 +282,9 @@ class TestRemoteGitStatus:
                 with patch.object(
                     remote_module, "get_remote_agent_manager", return_value=mock_agent_mgr
                 ):
-                    data, status = parse_response(remote_module.remote_git_status("machine-001"))
+                    data, status = parse_response(
+                        remote_module.remote_git_status("83ce1ab1-5506-5836-9a77-cc5af1ccf7a5")
+                    )
                     assert status == 200
                     assert data["success"] is True
                     assert data["result"]["branch"] == "main"
@@ -291,14 +307,14 @@ class TestRemoteGitStatus:
                 with patch.object(
                     remote_module, "get_remote_agent_manager", return_value=mock_agent_mgr
                 ):
-                    remote_module.remote_git_status("machine-001")
+                    remote_module.remote_git_status("83ce1ab1-5506-5836-9a77-cc5af1ccf7a5")
 
                     mock_agent_mgr.send_command.assert_called_once()
                     call_args = mock_agent_mgr.send_command.call_args
                     machine_id = call_args[0][0]
                     command = call_args[0][1]
 
-                    assert machine_id == "machine-001"
+                    assert machine_id == "83ce1ab1-5506-5836-9a77-cc5af1ccf7a5"
                     assert command["type"] == "command"
                     assert command["command"] == "git_status"
                     assert command["project_path"] == "/home/user/myproject"
@@ -320,7 +336,9 @@ class TestRemoteGitStatus:
                 with patch.object(
                     remote_module, "get_remote_agent_manager", return_value=mock_agent_mgr
                 ):
-                    data, status = parse_response(remote_module.remote_git_status("machine-001"))
+                    data, status = parse_response(
+                        remote_module.remote_git_status("83ce1ab1-5506-5836-9a77-cc5af1ccf7a5")
+                    )
                     assert status == 200
                     assert data["success"] is False
                     assert "not installed" in data["error"]
@@ -342,7 +360,9 @@ class TestRemoteGitStatus:
                 with patch.object(
                     remote_module, "get_remote_agent_manager", return_value=mock_agent_mgr
                 ):
-                    data, status = parse_response(remote_module.remote_git_status("machine-001"))
+                    data, status = parse_response(
+                        remote_module.remote_git_status("83ce1ab1-5506-5836-9a77-cc5af1ccf7a5")
+                    )
                     assert status == 200
                     assert data["success"] is True
 
@@ -366,7 +386,9 @@ class TestRemoteGitDiff:
                 with patch.object(
                     remote_module, "get_remote_agent_manager", return_value=mock_agent_mgr
                 ):
-                    data, status = parse_response(remote_module.remote_git_diff("machine-001"))
+                    data, status = parse_response(
+                        remote_module.remote_git_diff("83ce1ab1-5506-5836-9a77-cc5af1ccf7a5")
+                    )
                     assert status == 401
 
     def test_non_admin_no_access_returns_403(
@@ -382,7 +404,9 @@ class TestRemoteGitDiff:
                 with patch.object(
                     remote_module, "get_remote_agent_manager", return_value=mock_agent_mgr
                 ):
-                    data, status = parse_response(remote_module.remote_git_diff("machine-001"))
+                    data, status = parse_response(
+                        remote_module.remote_git_diff("83ce1ab1-5506-5836-9a77-cc5af1ccf7a5")
+                    )
                     assert status == 403
                     assert data["error"] == "Access denied"
 
@@ -399,7 +423,9 @@ class TestRemoteGitDiff:
                 with patch.object(
                     remote_module, "get_remote_agent_manager", return_value=mock_agent_mgr
                 ):
-                    data, status = parse_response(remote_module.remote_git_diff("machine-001"))
+                    data, status = parse_response(
+                        remote_module.remote_git_diff("83ce1ab1-5506-5836-9a77-cc5af1ccf7a5")
+                    )
                     assert status == 404
                     assert data["error"] == "Machine not found"
 
@@ -416,7 +442,9 @@ class TestRemoteGitDiff:
                 with patch.object(
                     remote_module, "get_remote_agent_manager", return_value=mock_agent_mgr
                 ):
-                    data, status = parse_response(remote_module.remote_git_diff("machine-001"))
+                    data, status = parse_response(
+                        remote_module.remote_git_diff("83ce1ab1-5506-5836-9a77-cc5af1ccf7a5")
+                    )
                     assert status == 503
 
     def test_agent_timeout_returns_504(self, flask_app, remote_module, mock_agent_mgr, admin_user):
@@ -430,7 +458,9 @@ class TestRemoteGitDiff:
                 with patch.object(
                     remote_module, "get_remote_agent_manager", return_value=mock_agent_mgr
                 ):
-                    data, status = parse_response(remote_module.remote_git_diff("machine-001"))
+                    data, status = parse_response(
+                        remote_module.remote_git_diff("83ce1ab1-5506-5836-9a77-cc5af1ccf7a5")
+                    )
                     assert status == 504
 
     def test_missing_path_param_returns_400(
@@ -446,7 +476,9 @@ class TestRemoteGitDiff:
                 with patch.object(
                     remote_module, "get_remote_agent_manager", return_value=mock_agent_mgr
                 ):
-                    data, status = parse_response(remote_module.remote_git_diff("machine-001"))
+                    data, status = parse_response(
+                        remote_module.remote_git_diff("83ce1ab1-5506-5836-9a77-cc5af1ccf7a5")
+                    )
                     assert status == 400
                     assert data["success"] is False
                     assert "path" in data["error"].lower()
@@ -465,7 +497,9 @@ class TestRemoteGitDiff:
                 with patch.object(
                     remote_module, "get_remote_agent_manager", return_value=mock_agent_mgr
                 ):
-                    data, status = parse_response(remote_module.remote_git_diff("machine-001"))
+                    data, status = parse_response(
+                        remote_module.remote_git_diff("83ce1ab1-5506-5836-9a77-cc5af1ccf7a5")
+                    )
                     assert status == 400
                     assert data["success"] is False
                     assert "file" in data["error"].lower()
@@ -477,7 +511,9 @@ class TestRemoteGitDiff:
                 with patch.object(
                     remote_module, "get_remote_agent_manager", return_value=mock_agent_mgr
                 ):
-                    data, status = parse_response(remote_module.remote_git_diff("machine-001"))
+                    data, status = parse_response(
+                        remote_module.remote_git_diff("83ce1ab1-5506-5836-9a77-cc5af1ccf7a5")
+                    )
                     assert status == 400
 
     def test_successful_git_diff_response(
@@ -506,7 +542,9 @@ class TestRemoteGitDiff:
                 with patch.object(
                     remote_module, "get_remote_agent_manager", return_value=mock_agent_mgr
                 ):
-                    data, status = parse_response(remote_module.remote_git_diff("machine-001"))
+                    data, status = parse_response(
+                        remote_module.remote_git_diff("83ce1ab1-5506-5836-9a77-cc5af1ccf7a5")
+                    )
                     assert status == 200
                     assert data["success"] is True
                     assert "diff --git" in data["result"]["diff"]
@@ -527,14 +565,14 @@ class TestRemoteGitDiff:
                 with patch.object(
                     remote_module, "get_remote_agent_manager", return_value=mock_agent_mgr
                 ):
-                    remote_module.remote_git_diff("machine-001")
+                    remote_module.remote_git_diff("83ce1ab1-5506-5836-9a77-cc5af1ccf7a5")
 
                     mock_agent_mgr.send_command.assert_called_once()
                     call_args = mock_agent_mgr.send_command.call_args
                     machine_id = call_args[0][0]
                     command = call_args[0][1]
 
-                    assert machine_id == "machine-001"
+                    assert machine_id == "83ce1ab1-5506-5836-9a77-cc5af1ccf7a5"
                     assert command["command"] == "git_diff"
                     assert command["project_path"] == "/home/user/project"
                     assert command["file"] == "src/main.py"
@@ -556,7 +594,9 @@ class TestRemoteGitDiff:
                 with patch.object(
                     remote_module, "get_remote_agent_manager", return_value=mock_agent_mgr
                 ):
-                    data, status = parse_response(remote_module.remote_git_diff("machine-001"))
+                    data, status = parse_response(
+                        remote_module.remote_git_diff("83ce1ab1-5506-5836-9a77-cc5af1ccf7a5")
+                    )
                     assert status == 200
                     assert data["success"] is False
                     assert "not installed" in data["error"]
@@ -581,7 +621,9 @@ class TestRemoteGitFile:
                 with patch.object(
                     remote_module, "get_remote_agent_manager", return_value=mock_agent_mgr
                 ):
-                    data, status = parse_response(remote_module.remote_git_file("machine-001"))
+                    data, status = parse_response(
+                        remote_module.remote_git_file("83ce1ab1-5506-5836-9a77-cc5af1ccf7a5")
+                    )
                     assert status == 401
 
     def test_non_admin_no_access_returns_403(
@@ -597,7 +639,9 @@ class TestRemoteGitFile:
                 with patch.object(
                     remote_module, "get_remote_agent_manager", return_value=mock_agent_mgr
                 ):
-                    data, status = parse_response(remote_module.remote_git_file("machine-001"))
+                    data, status = parse_response(
+                        remote_module.remote_git_file("83ce1ab1-5506-5836-9a77-cc5af1ccf7a5")
+                    )
                     assert status == 403
 
     def test_machine_not_found_returns_404(
@@ -613,7 +657,9 @@ class TestRemoteGitFile:
                 with patch.object(
                     remote_module, "get_remote_agent_manager", return_value=mock_agent_mgr
                 ):
-                    data, status = parse_response(remote_module.remote_git_file("machine-001"))
+                    data, status = parse_response(
+                        remote_module.remote_git_file("83ce1ab1-5506-5836-9a77-cc5af1ccf7a5")
+                    )
                     assert status == 404
 
     def test_agent_not_connected_returns_503(
@@ -629,7 +675,9 @@ class TestRemoteGitFile:
                 with patch.object(
                     remote_module, "get_remote_agent_manager", return_value=mock_agent_mgr
                 ):
-                    data, status = parse_response(remote_module.remote_git_file("machine-001"))
+                    data, status = parse_response(
+                        remote_module.remote_git_file("83ce1ab1-5506-5836-9a77-cc5af1ccf7a5")
+                    )
                     assert status == 503
 
     def test_agent_timeout_returns_504(self, flask_app, remote_module, mock_agent_mgr, admin_user):
@@ -643,7 +691,9 @@ class TestRemoteGitFile:
                 with patch.object(
                     remote_module, "get_remote_agent_manager", return_value=mock_agent_mgr
                 ):
-                    data, status = parse_response(remote_module.remote_git_file("machine-001"))
+                    data, status = parse_response(
+                        remote_module.remote_git_file("83ce1ab1-5506-5836-9a77-cc5af1ccf7a5")
+                    )
                     assert status == 504
 
     def test_missing_path_param_returns_400(
@@ -658,7 +708,9 @@ class TestRemoteGitFile:
                 with patch.object(
                     remote_module, "get_remote_agent_manager", return_value=mock_agent_mgr
                 ):
-                    data, status = parse_response(remote_module.remote_git_file("machine-001"))
+                    data, status = parse_response(
+                        remote_module.remote_git_file("83ce1ab1-5506-5836-9a77-cc5af1ccf7a5")
+                    )
                     assert status == 400
 
     def test_missing_file_param_returns_400(
@@ -673,7 +725,9 @@ class TestRemoteGitFile:
                 with patch.object(
                     remote_module, "get_remote_agent_manager", return_value=mock_agent_mgr
                 ):
-                    data, status = parse_response(remote_module.remote_git_file("machine-001"))
+                    data, status = parse_response(
+                        remote_module.remote_git_file("83ce1ab1-5506-5836-9a77-cc5af1ccf7a5")
+                    )
                     assert status == 400
 
     def test_successful_git_file_response(
@@ -694,7 +748,9 @@ class TestRemoteGitFile:
                 with patch.object(
                     remote_module, "get_remote_agent_manager", return_value=mock_agent_mgr
                 ):
-                    data, status = parse_response(remote_module.remote_git_file("machine-001"))
+                    data, status = parse_response(
+                        remote_module.remote_git_file("83ce1ab1-5506-5836-9a77-cc5af1ccf7a5")
+                    )
                     assert status == 200
                     assert data["success"] is True
                     assert "import os" in data["result"]["content"]
@@ -716,14 +772,14 @@ class TestRemoteGitFile:
                 with patch.object(
                     remote_module, "get_remote_agent_manager", return_value=mock_agent_mgr
                 ):
-                    remote_module.remote_git_file("machine-001")
+                    remote_module.remote_git_file("83ce1ab1-5506-5836-9a77-cc5af1ccf7a5")
 
                     mock_agent_mgr.send_command.assert_called_once()
                     call_args = mock_agent_mgr.send_command.call_args
                     machine_id = call_args[0][0]
                     command = call_args[0][1]
 
-                    assert machine_id == "machine-001"
+                    assert machine_id == "83ce1ab1-5506-5836-9a77-cc5af1ccf7a5"
                     assert command["command"] == "git_file"
                     assert command["project_path"] == "/home/user/project"
                     assert command["file"] == "README.md"
@@ -745,7 +801,9 @@ class TestRemoteGitFile:
                 with patch.object(
                     remote_module, "get_remote_agent_manager", return_value=mock_agent_mgr
                 ):
-                    data, status = parse_response(remote_module.remote_git_file("machine-001"))
+                    data, status = parse_response(
+                        remote_module.remote_git_file("83ce1ab1-5506-5836-9a77-cc5af1ccf7a5")
+                    )
                     assert status == 200
                     assert data["success"] is False
                     assert "not found" in data["error"].lower()
@@ -766,7 +824,7 @@ class TestGitResultMessageHandler:
                 method="POST",
                 json={
                     "type": "git_result",
-                    "machine_id": "machine-001",
+                    "machine_id": "83ce1ab1-5506-5836-9a77-cc5af1ccf7a5",
                     "request_id": "req-abc-123",
                     "success": True,
                     "result": {"branch": "main", "files": []},
@@ -796,7 +854,7 @@ class TestGitResultMessageHandler:
                 method="POST",
                 json={
                     "type": "git_result",
-                    "machine_id": "machine-001",
+                    "machine_id": "83ce1ab1-5506-5836-9a77-cc5af1ccf7a5",
                     "request_id": "req-err-456",
                     "success": False,
                     "error": "git is not installed on this machine",
@@ -823,7 +881,7 @@ class TestGitResultMessageHandler:
                 method="POST",
                 json={
                     "type": "git_result",
-                    "machine_id": "machine-001",
+                    "machine_id": "83ce1ab1-5506-5836-9a77-cc5af1ccf7a5",
                     "success": True,
                     "result": {"diff": ""},
                 },
@@ -845,7 +903,7 @@ class TestGitResultMessageHandler:
                 method="POST",
                 json={
                     "type": "git_result",
-                    "machine_id": "machine-001",
+                    "machine_id": "83ce1ab1-5506-5836-9a77-cc5af1ccf7a5",
                     "request_id": "req-null-789",
                     "success": True,
                 },
@@ -907,7 +965,7 @@ class TestAccessControlEdgeCases:
                 with patch.object(
                     remote_module, "get_remote_agent_manager", return_value=mock_agent_mgr
                 ):
-                    remote_module.remote_git_status("machine-001")
+                    remote_module.remote_git_status("83ce1ab1-5506-5836-9a77-cc5af1ccf7a5")
                     # check_user_access should NOT be called for admin
                     mock_agent_mgr.check_user_access.assert_not_called()
 
@@ -929,8 +987,10 @@ class TestAccessControlEdgeCases:
                 with patch.object(
                     remote_module, "get_remote_agent_manager", return_value=mock_agent_mgr
                 ):
-                    remote_module.remote_git_status("machine-001")
-                    mock_agent_mgr.check_user_access.assert_called_once_with("machine-001", 42)
+                    remote_module.remote_git_status("83ce1ab1-5506-5836-9a77-cc5af1ccf7a5")
+                    mock_agent_mgr.check_user_access.assert_called_once_with(
+                        "83ce1ab1-5506-5836-9a77-cc5af1ccf7a5", 42
+                    )
 
 
 if __name__ == "__main__":

--- a/tests/issues/610/test_remote_vscode_endpoints.py
+++ b/tests/issues/610/test_remote_vscode_endpoints.py
@@ -89,7 +89,7 @@ class TestVSCodeStart(unittest.TestCase):
         with app.test_client() as client:
             resp = client.post(
                 "/api/remote/vscode/start",
-                json={"machine_id": "m1", "project_path": "/tmp"},
+                json={"machine_id": "810ceed8-fd1b-50f3-8bc1-609601d23ae9", "project_path": "/tmp"},
             )
             self.assertEqual(resp.status_code, 401)
 
@@ -117,7 +117,7 @@ class TestVSCodeStart(unittest.TestCase):
                 client,
                 "/api/remote/vscode/start",
                 "test-token-1-admin",
-                json={"machine_id": "m1"},
+                json={"machine_id": "810ceed8-fd1b-50f3-8bc1-609601d23ae9"},
             )
             self.assertEqual(resp.status_code, 400)
             data = resp.get_json()
@@ -147,7 +147,7 @@ class TestVSCodeStart(unittest.TestCase):
                 client,
                 "/api/remote/vscode/start",
                 "test-token-2-user",
-                json={"machine_id": "m1", "project_path": "/tmp"},
+                json={"machine_id": "810ceed8-fd1b-50f3-8bc1-609601d23ae9", "project_path": "/tmp"},
             )
             self.assertEqual(resp.status_code, 403)
 
@@ -162,7 +162,7 @@ class TestVSCodeStart(unittest.TestCase):
                 client,
                 "/api/remote/vscode/start",
                 "test-token-1-admin",
-                json={"machine_id": "m1", "project_path": "/tmp"},
+                json={"machine_id": "810ceed8-fd1b-50f3-8bc1-609601d23ae9", "project_path": "/tmp"},
             )
             self.assertEqual(resp.status_code, 503)
             data = resp.get_json()
@@ -180,7 +180,10 @@ class TestVSCodeStart(unittest.TestCase):
                 client,
                 "/api/remote/vscode/start",
                 "test-token-1-admin",
-                json={"machine_id": "m1", "project_path": "/home/user/project"},
+                json={
+                    "machine_id": "810ceed8-fd1b-50f3-8bc1-609601d23ae9",
+                    "project_path": "/home/user/project",
+                },
             )
             self.assertEqual(resp.status_code, 200)
             data = resp.get_json()
@@ -207,7 +210,7 @@ class TestVSCodeStart(unittest.TestCase):
                 client,
                 "/api/remote/vscode/start",
                 "test-token-5-user",
-                json={"machine_id": "m1", "project_path": "/tmp"},
+                json={"machine_id": "810ceed8-fd1b-50f3-8bc1-609601d23ae9", "project_path": "/tmp"},
             )
             self.assertEqual(resp.status_code, 200)
             data = resp.get_json()
@@ -230,7 +233,7 @@ class TestVSCodeStop(unittest.TestCase):
         with app.test_client() as client:
             resp = client.post(
                 "/api/remote/vscode/stop",
-                json={"vscode_id": "v1", "machine_id": "m1"},
+                json={"vscode_id": "v1", "machine_id": "810ceed8-fd1b-50f3-8bc1-609601d23ae9"},
             )
             self.assertEqual(resp.status_code, 401)
 
@@ -243,7 +246,7 @@ class TestVSCodeStop(unittest.TestCase):
                 client,
                 "/api/remote/vscode/stop",
                 "test-token-1-admin",
-                json={"machine_id": "m1"},
+                json={"machine_id": "810ceed8-fd1b-50f3-8bc1-609601d23ae9"},
             )
             self.assertEqual(resp.status_code, 400)
             data = resp.get_json()
@@ -285,7 +288,7 @@ class TestVSCodeStop(unittest.TestCase):
                 client,
                 "/api/remote/vscode/stop",
                 "test-token-2-user",
-                json={"vscode_id": "v1", "machine_id": "m1"},
+                json={"vscode_id": "v1", "machine_id": "810ceed8-fd1b-50f3-8bc1-609601d23ae9"},
             )
             self.assertEqual(resp.status_code, 403)
 
@@ -307,7 +310,10 @@ class TestVSCodeStop(unittest.TestCase):
                     client,
                     "/api/remote/vscode/stop",
                     "test-token-1-admin",
-                    json={"vscode_id": "vscode-123", "machine_id": "m1"},
+                    json={
+                        "vscode_id": "vscode-123",
+                        "machine_id": "810ceed8-fd1b-50f3-8bc1-609601d23ae9",
+                    },
                 )
         finally:
             vs_mod.vscode_info_store = original_store
@@ -324,7 +330,9 @@ class TestVSCodeStop(unittest.TestCase):
         self.assertEqual(cmd["vscode_id"], "vscode-123")
 
         # Verify mark_stopped was called to invalidate token (Issue #2183)
-        mock_store.mark_stopped.assert_called_once_with("m1", "vscode-123")
+        mock_store.mark_stopped.assert_called_once_with(
+            "810ceed8-fd1b-50f3-8bc1-609601d23ae9", "vscode-123"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -377,7 +385,7 @@ class TestVSCodeStatus(unittest.TestCase):
         original_store = vs_mod.vscode_info_store
         mock_store = MagicMock()
         mock_store.find_by_vscode_id.return_value = (
-            "m1",
+            "810ceed8-fd1b-50f3-8bc1-609601d23ae9",
             {
                 "status": "running",
                 "token": "browser-secret-token",
@@ -414,7 +422,7 @@ class TestVSCodeStatus(unittest.TestCase):
         original_store = vs_mod.vscode_info_store
         mock_store = MagicMock()
         mock_store.find_by_vscode_id.return_value = (
-            "m1",
+            "810ceed8-fd1b-50f3-8bc1-609601d23ae9",
             {
                 "status": "error",
                 "error": "code-server crashed",
@@ -449,7 +457,7 @@ class TestVSCodeStatus(unittest.TestCase):
         original_store = vs_mod.vscode_info_store
         mock_store = MagicMock()
         mock_store.find_by_vscode_id.return_value = (
-            "m1",
+            "810ceed8-fd1b-50f3-8bc1-609601d23ae9",
             {"status": "running", "token": "tok"},
         )
         vs_mod.vscode_info_store = mock_store
@@ -482,7 +490,7 @@ class TestVSCodeAttach(unittest.TestCase):
         with app.test_client() as client:
             resp = client.post(
                 "/api/remote/vscode/vs1/attach",
-                json={"machine_id": "m1"},
+                json={"machine_id": "810ceed8-fd1b-50f3-8bc1-609601d23ae9"},
             )
             self.assertEqual(resp.status_code, 401)
 
@@ -509,7 +517,7 @@ class TestVSCodeAttach(unittest.TestCase):
                 client,
                 "/api/remote/vscode/vs1/attach",
                 "test-token-5-user",
-                json={"machine_id": "m1"},
+                json={"machine_id": "810ceed8-fd1b-50f3-8bc1-609601d23ae9"},
             )
             self.assertEqual(resp.status_code, 403)
 
@@ -523,7 +531,7 @@ class TestVSCodeAttach(unittest.TestCase):
                 client,
                 "/api/remote/vscode/vs-123/attach",
                 "test-token-1-admin",
-                json={"machine_id": "m1"},
+                json={"machine_id": "810ceed8-fd1b-50f3-8bc1-609601d23ae9"},
             )
             self.assertEqual(resp.status_code, 200)
             data = resp.get_json()
@@ -592,7 +600,7 @@ class TestVSCodeProxy(unittest.TestCase):
         app, vs_mod, orig, mock_store = self._make_app_with_store(
             mgr,
             (
-                "m1",
+                "810ceed8-fd1b-50f3-8bc1-609601d23ae9",
                 {
                     "status": "running",
                     "token": "valid-token",
@@ -624,7 +632,7 @@ class TestVSCodeProxy(unittest.TestCase):
         app, vs_mod, orig, mock_store = self._make_app_with_store(
             mgr,
             (
-                "m1",
+                "810ceed8-fd1b-50f3-8bc1-609601d23ae9",
                 {
                     "status": "running",
                     "token": "correct-token",
@@ -652,7 +660,7 @@ class TestVSCodeProxy(unittest.TestCase):
         app, vs_mod, orig, mock_store = self._make_app_with_store(
             mgr,
             (
-                "m1",
+                "810ceed8-fd1b-50f3-8bc1-609601d23ae9",
                 {
                     "status": "pending",
                     "token": "valid-token",
@@ -679,7 +687,7 @@ class TestVSCodeProxy(unittest.TestCase):
         app, vs_mod, orig, mock_store = self._make_app_with_store(
             mgr,
             (
-                "m1",
+                "810ceed8-fd1b-50f3-8bc1-609601d23ae9",
                 {
                     "status": "running",
                     "token": "",  # empty stored token
@@ -704,7 +712,7 @@ class TestVSCodeProxy(unittest.TestCase):
         app, vs_mod, orig, mock_store = self._make_app_with_store(
             mgr,
             (
-                "m1",
+                "810ceed8-fd1b-50f3-8bc1-609601d23ae9",
                 {
                     "status": "running",
                     "token": "valid-token",
@@ -746,7 +754,7 @@ class TestVSCodeProxy(unittest.TestCase):
         app, vs_mod, orig, mock_store = self._make_app_with_store(
             mgr,
             (
-                "m1",
+                "810ceed8-fd1b-50f3-8bc1-609601d23ae9",
                 {
                     "status": "running",
                     "token": "valid-token",
@@ -838,7 +846,7 @@ class TestVSCodeStatusMessageHandler(unittest.TestCase):
 
         payload = {
             "type": "vscode_status",
-            "machine_id": "m1",
+            "machine_id": "810ceed8-fd1b-50f3-8bc1-609601d23ae9",
             "vscode_id": "vs-123",
             "status": "running",
             "http_url": "http://remote:8080",
@@ -884,13 +892,13 @@ class TestVSCodeStatusMessageHandler(unittest.TestCase):
         # Verify store.put was called with correct args
         mock_store.put.assert_called_once()
         call_args = mock_store.put.call_args
-        self.assertEqual(call_args[0][0], "m1")  # machine_id
+        self.assertEqual(call_args[0][0], "810ceed8-fd1b-50f3-8bc1-609601d23ae9")  # machine_id
         self.assertEqual(call_args[0][1], "vs-123")  # vscode_id
         stored_info = call_args[0][2]
         self.assertEqual(stored_info["status"], "running")
         self.assertEqual(stored_info["original_http_url"], "http://remote:8080")
         self.assertEqual(stored_info["original_token"], "original-vscode-token")
-        self.assertEqual(stored_info["machine_id"], "m1")
+        self.assertEqual(stored_info["machine_id"], "810ceed8-fd1b-50f3-8bc1-609601d23ae9")
         self.assertEqual(stored_info["project_path"], "/home/user/project")
         # A browser token should be generated (64 hex chars from secrets.token_hex(32))
         self.assertEqual(len(stored_info["token"]), 64)
@@ -901,7 +909,7 @@ class TestVSCodeStatusMessageHandler(unittest.TestCase):
 
         payload = {
             "type": "vscode_status",
-            "machine_id": "m1",
+            "machine_id": "810ceed8-fd1b-50f3-8bc1-609601d23ae9",
             "vscode_id": "vs-123",
             "status": "stopped",
         }
@@ -942,7 +950,9 @@ class TestVSCodeStatusMessageHandler(unittest.TestCase):
         self.assertTrue(data["success"])
 
         # Issue #2183: Should call mark_stopped instead of pop
-        mock_store.mark_stopped.assert_called_once_with("m1", "vs-123")
+        mock_store.mark_stopped.assert_called_once_with(
+            "810ceed8-fd1b-50f3-8bc1-609601d23ae9", "vs-123"
+        )
 
     def test_error_status_stores_error(self):
         """Error status stores the error message."""
@@ -950,7 +960,7 @@ class TestVSCodeStatusMessageHandler(unittest.TestCase):
 
         payload = {
             "type": "vscode_status",
-            "machine_id": "m1",
+            "machine_id": "810ceed8-fd1b-50f3-8bc1-609601d23ae9",
             "vscode_id": "vs-123",
             "status": "error",
             "error": "port already in use",
@@ -993,12 +1003,12 @@ class TestVSCodeStatusMessageHandler(unittest.TestCase):
 
         mock_store.put.assert_called_once()
         call_args = mock_store.put.call_args
-        self.assertEqual(call_args[0][0], "m1")
+        self.assertEqual(call_args[0][0], "810ceed8-fd1b-50f3-8bc1-609601d23ae9")
         self.assertEqual(call_args[0][1], "vs-123")
         stored_info = call_args[0][2]
         self.assertEqual(stored_info["status"], "error")
         self.assertEqual(stored_info["error"], "port already in use")
-        self.assertEqual(stored_info["machine_id"], "m1")
+        self.assertEqual(stored_info["machine_id"], "810ceed8-fd1b-50f3-8bc1-609601d23ae9")
 
     def test_not_found_status_cleans_up(self):
         """not_found status removes the store entry."""
@@ -1006,7 +1016,7 @@ class TestVSCodeStatusMessageHandler(unittest.TestCase):
 
         payload = {
             "type": "vscode_status",
-            "machine_id": "m1",
+            "machine_id": "810ceed8-fd1b-50f3-8bc1-609601d23ae9",
             "vscode_id": "vs-123",
             "status": "not_found",
         }
@@ -1046,7 +1056,7 @@ class TestVSCodeStatusMessageHandler(unittest.TestCase):
         self.assertEqual(status, 200)
         self.assertTrue(data["success"])
 
-        mock_store.pop.assert_called_once_with("m1", "vs-123")
+        mock_store.pop.assert_called_once_with("810ceed8-fd1b-50f3-8bc1-609601d23ae9", "vs-123")
 
     def test_missing_vscode_id_returns_success(self):
         """Missing vscode_id returns success without storing anything."""
@@ -1054,7 +1064,7 @@ class TestVSCodeStatusMessageHandler(unittest.TestCase):
 
         payload = {
             "type": "vscode_status",
-            "machine_id": "m1",
+            "machine_id": "810ceed8-fd1b-50f3-8bc1-609601d23ae9",
             # No vscode_id
             "status": "running",
             "http_url": "http://remote:8080",
@@ -1104,7 +1114,7 @@ class TestVSCodeStatusMessageHandler(unittest.TestCase):
 
         payload = {
             "type": "vscode_status",
-            "machine_id": "m1",
+            "machine_id": "810ceed8-fd1b-50f3-8bc1-609601d23ae9",
             "vscode_id": "vs-123",
             "status": "running",
             # No http_url

--- a/tests/issues/610/test_remote_vscode_endpoints.py
+++ b/tests/issues/610/test_remote_vscode_endpoints.py
@@ -141,6 +141,10 @@ class TestVSCodeStart(unittest.TestCase):
         """Non-admin user without machine access gets 403."""
         mgr = MagicMock()
         mgr.check_user_access.return_value = False
+        # Tenant-agnostic machine: skips the #2538 cross-tenant guard (a bare
+        # MagicMock tenant_id is non-None and would 404) so the test exercises
+        # its intended path — an unassigned user is denied with 403.
+        mgr.get_machine.return_value = {"tenant_id": None}
         app = _make_app(mgr)
         with app.test_client() as client:
             resp = _auth_post(
@@ -204,6 +208,10 @@ class TestVSCodeStart(unittest.TestCase):
         mgr = MagicMock()
         mgr.check_user_access.return_value = True
         mgr.is_agent_connected.return_value = True
+        # #2538 gates access on explicit assignment (get_user_permission), not
+        # check_user_access; model the non-admin as an assigned "user" so the
+        # start succeeds.
+        mgr.get_user_permission.return_value = "user"
         app = _make_app(mgr)
         with app.test_client() as client:
             resp = _auth_post(
@@ -282,6 +290,8 @@ class TestVSCodeStop(unittest.TestCase):
         """Non-admin without access gets 403."""
         mgr = MagicMock()
         mgr.check_user_access.return_value = False
+        # Tenant-agnostic machine (see TestVSCodeStart.test_access_denied_non_admin).
+        mgr.get_machine.return_value = {"tenant_id": None}
         app = _make_app(mgr)
         with app.test_client() as client:
             resp = _auth_post(
@@ -450,6 +460,8 @@ class TestVSCodeStatus(unittest.TestCase):
         """Non-admin without machine access gets 403."""
         mgr = MagicMock()
         mgr.check_user_access.return_value = False
+        # Tenant-agnostic machine (see TestVSCodeStart.test_access_denied_non_admin).
+        mgr.get_machine.return_value = {"tenant_id": None}
         app = _make_app(mgr)
 
         from app.modules.workspace import vscode_store as vs_mod
@@ -511,6 +523,8 @@ class TestVSCodeAttach(unittest.TestCase):
         """Non-admin without access gets 403."""
         mgr = MagicMock()
         mgr.check_user_access.return_value = False
+        # Tenant-agnostic machine (see TestVSCodeStart.test_access_denied_non_admin).
+        mgr.get_machine.return_value = {"tenant_id": None}
         app = _make_app(mgr)
         with app.test_client() as client:
             resp = _auth_post(

--- a/tests/issues/716/test_autonomous_api.py
+++ b/tests/issues/716/test_autonomous_api.py
@@ -53,7 +53,7 @@ def auto_db(tmp_path):
                 pass
 
 
-def _mock_auth(user_id=1, role="admin"):
+def _mock_auth(user_id=1, role="admin", tenant_id=None):
     """Patch auth to bypass authentication."""
     return patch(
         "app.auth.decorators._load_user_from_token",
@@ -62,6 +62,7 @@ def _mock_auth(user_id=1, role="admin"):
             "username": "admin" if role == "admin" else "testuser",
             "email": f"{role}@test.com",
             "role": role,
+            "tenant_id": tenant_id,
         },
     )
 
@@ -915,7 +916,10 @@ class TestGetModels:
         mock_mgr = MagicMock()
         mock_mgr.check_user_access.return_value = "admin"
         mock_mgr.get_machine.return_value = {"tenant_id": 7}
-        with _mock_auth():
+        # Caller must share the machine's tenant to clear the #2538 cross-tenant
+        # guard (get_available_models has no admin bypass); tenant-7 here so the
+        # derived tenant (also 7) still comes from the machine record below.
+        with _mock_auth(tenant_id=7):
             with (
                 patch(
                     "app.modules.workspace.api_key_proxy.APIKeyProxyService",

--- a/tests/issues/716/test_autonomous_api.py
+++ b/tests/issues/716/test_autonomous_api.py
@@ -928,11 +928,11 @@ class TestGetModels:
             ):
                 resp = client.get(
                     "/api/autonomous/models?tool=claude-code"
-                    "&workspace_type=remote&machine_id=m-42"
+                    "&workspace_type=remote&machine_id=eca8ab1a-ca78-50d6-80d0-849dbde5c3c9"
                 )
         assert resp.status_code == 200
         mock_mgr.check_user_access.assert_called_once()
-        mock_mgr.get_machine.assert_called_once_with("m-42")
+        mock_mgr.get_machine.assert_called_once_with("eca8ab1a-ca78-50d6-80d0-849dbde5c3c9")
         mock_proxy.get_tool_models.assert_called_once_with(
             tenant_id=7, tool_name="claude-code", scope="remote"
         )
@@ -955,7 +955,7 @@ class TestGetModels:
             ):
                 resp = client.get(
                     "/api/autonomous/models?tool=claude-code"
-                    "&workspace_type=remote&machine_id=m-42"
+                    "&workspace_type=remote&machine_id=eca8ab1a-ca78-50d6-80d0-849dbde5c3c9"
                 )
         assert resp.status_code == 404
         mock_proxy.get_tool_models.assert_not_called()
@@ -1004,7 +1004,7 @@ class TestGetModels:
             ):
                 resp = client.get(
                     "/api/autonomous/models?tool=claude-code"
-                    "&workspace_type=remote&machine_id=m-42"
+                    "&workspace_type=remote&machine_id=eca8ab1a-ca78-50d6-80d0-849dbde5c3c9"
                 )
         # Must not be a misleading "success, no models" — surface the failure.
         assert resp.status_code != 200


### PR DESCRIPTION
## What

Resolves the 37 recently-`new` `tests/issues/` failures flagged by the #2457 legacy-failure baseline comparator. Test-only — no production changes.

Two intertwined root causes on main, each masking the other:

1. **29 × #2540 UUID validator (`400`)** — `_validate_machine_id_format` (`app/routes/remote.py:635`) now 400-rejects non-UUID machine_ids; these tests used labels like `m-42`, `machine-001`, `mac-1`. Switched to stable UUIDs (uuid5 of `openace-test:<label>`).
2. **8 × #2538 tenant isolation (`404`)** — masked by the 400s above; cross/null-tenant machine + session access now returns 404. Each test's mock setup predated #2538 and modeled access without tenant scoping:
   - `604` / `716`: give the mock caller the machine's `tenant_id` (no admin bypass in `get_session_models` / `get_available_models`); 716's derived-tenant assertion still reads tenant 7 from the machine record.
   - `610/vscode` ×4 denied: model the machine as tenant-agnostic (`tenant_id=None`) so the #2538 guard is skipped and the intended 403 path runs.
   - `610/vscode` ×1 allowed: #2538's gate is `get_user_permission` (explicit assignment), not the old `check_user_access` gate — model the non-admin as an assigned `"user"`.
   - `1789`: #2538 changed the null-tenant denial from 403 to 404 ("Session not found", to avoid leaking session existence). The fail-closed property #1789 guards is preserved and strengthened — #2538 fires before the machine-admin branch is reached.

## Scope

- Test-only; does NOT touch the deferred TenantResolutionError session-write cluster (#2457 deferred that as a separate effort). The 8 here are #2538 *access-control* 404s — a distinct cluster.
- Baseline (`ci/legacy-issue-failures.json`) untouched (its shrink happens in the separate 212 PR).

## Verification

- Targeted: all 37 pass locally where reproducible.
- CI (dispatch `category=issues`, 4 shards): run 31671392894 — comparator **exit-0**: `new=0, resolved=0, changed=0, collection_errors=0, invalid=0, known=333`.
- pre-commit clean (black / isort / ruff / mypy).
- Independent review: **CLEAN** (zero objections; 5 controlled-negative tests confirmed each of the 8 exercises its intended production path).
- 5 local-only failures (`TestCreateWorkflow::*` MagicMock concurrent-limit; `test_remote_git_endpoints` `__spec__` import chain) are pre-existing macOS artifacts that reproduce on main and pass CI — untouched by this branch.

Refs #2457

🤖 Generated with [Claude Code](https://claude.com/claude-code)