### PR TITLE
fix(tests): model pr_review summary fresh-session retry in 1816

### DIFF
--- a/tests/issues/1816/test_ci_repair_context_overflow.py
+++ b/tests/issues/1816/test_ci_repair_context_overflow.py
@@ -491,6 +491,10 @@ def test_empty_review_or_summary_fails_closed(empty_stage):
                     '批准\nREVIEW_RESULT: {"verdict":"APPROVE",' '"blocking_findings":[]}'
                 ),
             ),
+            # fb680a17 retries an empty summary ONCE on a fresh session before
+            # failing closed; the retry must also come back empty so the
+            # fail-closed assertions below still hold for the summary stage.
+            empty,
             empty,
         ]
     orch._run_agent_with_context_recovery = MagicMock(side_effect=results)


### PR DESCRIPTION
## What

Resolves the 1 recently-`new` `tests/issues/1816` failure flagged by the #2457 legacy-failure baseline comparator. Test-only — no production changes.

## Root cause

`fb680a17` (merged via #2536) retries an empty pr_review summary ONCE on a fresh session (`session_line="fresh"`, `app/modules/workspace/autonomous/phases/pr_review.py:717-741`) before failing closed. The 1816 fail-closed test's `side_effect` only provided two results (review + empty summary), so the retry's third call exhausted the mock and raised `StopIteration`.

## Fix

Provide a third empty result so the retry is exercised and also comes back empty. The fail-closed assertions (workflow `failed` with "returned no result", `pr_review_summary` milestone failed) are unchanged and still hold — the test now models fb680a17's deliberate retry-then-fail-closed sequence.

The other 3 local failures in the file (`rebinds`×2, `review_fix_refuses`×1) are baseline-known entries — untouched.

## Verification

- Targeted: `test_empty_review_or_summary_fails_closed` passes both params; full file 24 passed / 3 baseline-known failures.
- CI (dispatch `category=issues`, 4 shards): run 31692686539 — comparator **exit-0**: `new=0, resolved=0, changed=0, collection_errors=0, invalid=0, known=333`.
- pre-commit clean (black / isort / ruff / mypy).

Refs #2457

🤖 Generated with [Claude Code](https://claude.com/claude-code)