### PR TITLE
fix(tests): create registration_tokens table in 212 hostname-dedup fixture (#2457)

### DIFF
--- a/ci/legacy-issue-failures.json
+++ b/ci/legacy-issue-failures.json
@@ -673,78 +673,6 @@
       "summary": "AssertionError: Stats API failed: 403"
     },
     {
-      "category": "test_body_exception",
-      "exception_type": "OperationalError",
-      "issue_number": "212",
-      "nodeid": "tests/issues/212/test_hostname_dedup.py::test_different_tenant_no_merge",
-      "outcome": "failure",
-      "summary": "sqlite3.OperationalError: no such table: registration_tokens"
-    },
-    {
-      "category": "test_body_exception",
-      "exception_type": "OperationalError",
-      "issue_number": "212",
-      "nodeid": "tests/issues/212/test_hostname_dedup.py::test_empty_hostname_no_merge",
-      "outcome": "failure",
-      "summary": "sqlite3.OperationalError: no such table: registration_tokens"
-    },
-    {
-      "category": "test_body_exception",
-      "exception_type": "OperationalError",
-      "issue_number": "212",
-      "nodeid": "tests/issues/212/test_hostname_dedup.py::test_invalid_token",
-      "outcome": "failure",
-      "summary": "sqlite3.OperationalError: no such table: registration_tokens"
-    },
-    {
-      "category": "test_body_exception",
-      "exception_type": "OperationalError",
-      "issue_number": "212",
-      "nodeid": "tests/issues/212/test_hostname_dedup.py::test_merge_cleans_in_memory_state",
-      "outcome": "failure",
-      "summary": "sqlite3.OperationalError: no such table: registration_tokens"
-    },
-    {
-      "category": "test_body_exception",
-      "exception_type": "OperationalError",
-      "issue_number": "212",
-      "nodeid": "tests/issues/212/test_hostname_dedup.py::test_merge_offline_duplicate",
-      "outcome": "failure",
-      "summary": "sqlite3.OperationalError: no such table: registration_tokens"
-    },
-    {
-      "category": "test_body_exception",
-      "exception_type": "OperationalError",
-      "issue_number": "212",
-      "nodeid": "tests/issues/212/test_hostname_dedup.py::test_merge_preserves_assignments",
-      "outcome": "failure",
-      "summary": "sqlite3.OperationalError: no such table: registration_tokens"
-    },
-    {
-      "category": "test_body_exception",
-      "exception_type": "OperationalError",
-      "issue_number": "212",
-      "nodeid": "tests/issues/212/test_hostname_dedup.py::test_merge_preserves_sessions",
-      "outcome": "failure",
-      "summary": "sqlite3.OperationalError: no such table: registration_tokens"
-    },
-    {
-      "category": "test_body_exception",
-      "exception_type": "OperationalError",
-      "issue_number": "212",
-      "nodeid": "tests/issues/212/test_hostname_dedup.py::test_new_machine_no_duplicate",
-      "outcome": "failure",
-      "summary": "sqlite3.OperationalError: no such table: registration_tokens"
-    },
-    {
-      "category": "test_body_exception",
-      "exception_type": "OperationalError",
-      "issue_number": "212",
-      "nodeid": "tests/issues/212/test_hostname_dedup.py::test_reject_online_duplicate",
-      "outcome": "failure",
-      "summary": "sqlite3.OperationalError: no such table: registration_tokens"
-    },
-    {
       "category": "assertion_failure",
       "exception_type": "AssertionError",
       "issue_number": "2121",
@@ -2667,8 +2595,8 @@
   ],
   "provenance": {
     "generated_command": "python scripts/legacy_issue_baseline.py snapshot --junit 'artifacts/test-results/issues-*.xml' --output ci/legacy-issue-failures.json --exit-code-glob 'artifacts/test-results/issues-*.exit-code' --shard-count 4 --quarantine ci/legacy-issue-quarantine.json --test-baseline .test-baseline.json --source-run 31382049159 --source-run-url https://github.com/open-ace/open-ace/actions/runs/31382049159 --reference-commit 1f45105e8a7e5ff713d97be3cdc836b525f0d3aa --run-contract 'extended-tests issue-tests --isolated-home --reruns 1 --timeout 240 --continue-on-collection-errors, 4 shards; 604 quarantined (deselect); post-main-sync (#2391 orchestrator refactor): 9 resolved, 2 changed test_body_exception->assertion_failure'",
-    "prune_note": "Targeted prune of 83 comparator-resolved nodeids (#2457 re-sync: object.__new__/723/#2332/ensure_cs_cookie/716-no-such-table) from run 31596249646; shrink-only.",
-    "prune_source_run_url": "https://github.com/open-ace/open-ace/actions/runs/31596249646",
+    "prune_note": "2026-08-13 prune 9 resolved: tests/issues/212/test_hostname_dedup.py no-such-table: registration_tokens cluster, fixed by adding the registration_tokens table to make_manager() (mirrors schema-sqlite.sql). Shrink-only.",
+    "prune_source_run_url": "https://github.com/open-ace/open-ace/actions/runs/31662464134",
     "recategorize_note": "2026-08-12 targeted re-categorize: 14 still-failing baseline entries shifted (test_body_exception/setup_error -> assertion_failure) because earlier #2457 fixes (object.__new__ polluter #398607d8, #2332 role drift) let their setup/early crash pass so they now reach their pre-existing assertions. No test was fixed or removed here; the (outcome,category,summary) keys were updated to match the current failure mode (what `snapshot` would emit). Affected: 517x2, 716/test_github_opsx2, 733x9, 786x1.",
     "recategorize_source_run_url": "https://github.com/open-ace/open-ace/actions/runs/31596249646",
     "reference_commit": "1f45105e8a7e5ff713d97be3cdc836b525f0d3aa",

--- a/tests/issues/212/test_hostname_dedup.py
+++ b/tests/issues/212/test_hostname_dedup.py
@@ -132,6 +132,21 @@ def make_manager():
     conn.execute(
         "CREATE TABLE IF NOT EXISTS users (" "id INTEGER PRIMARY KEY, " "username TEXT NOT NULL)"
     )
+    # registration_tokens is required by create_registration_token() and the
+    # consume/validate/cleanup paths in RemoteAgentManager; without it every
+    # test calling create_token() crashes with 'no such table' (the #2457
+    # 9-test cluster). Mirrors schema/schema-sqlite.sql:784-793.
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS registration_tokens ("
+        "id INTEGER PRIMARY KEY AUTOINCREMENT, "
+        "token_hash TEXT NOT NULL UNIQUE, "
+        "tenant_id INTEGER NOT NULL, "
+        "created_by INTEGER NOT NULL, "
+        "created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, "
+        "expires_at TIMESTAMP, "
+        "is_consumed INTEGER DEFAULT 0, "
+        "consumed_at TIMESTAMP)"
+    )
     conn.execute("INSERT OR IGNORE INTO users (id, username) VALUES (1, 'admin')")
     conn.execute("INSERT OR IGNORE INTO users (id, username) VALUES (2, 'user2')")
     conn.execute("INSERT OR IGNORE INTO users (id, username) VALUES (3, 'user3')")
@@ -238,6 +253,31 @@ def get_machine(mgr, machine_id):
 # ════════════════════════════════════════════
 #  Tests
 # ════════════════════════════════════════════
+
+
+def test_fixture_creates_registration_tokens_table():
+    """Lock the registration_tokens escape hatch (#2457).
+
+    make_manager() must create the registration_tokens table, or every test
+    that calls create_token() crashes with 'no such table: registration_tokens'
+    (the prior 9-test cluster). A direct schema assertion fails fast and
+    clearly at the fixture level instead of cascading 9 cryptic
+    OperationalError crashes if the table is ever dropped.
+    """
+    mgr = make_manager()
+    with mgr.db.connection() as conn:
+        row = (
+            conn.cursor()
+            .execute(
+                "SELECT name FROM sqlite_master "
+                "WHERE type='table' AND name='registration_tokens'"
+            )
+            .fetchone()
+        )
+    assert row is not None, (
+        "make_manager() must create the registration_tokens table "
+        "(create_registration_token reads/writes it)"
+    )
 
 
 def test_new_machine_no_duplicate():


### PR DESCRIPTION
## What

Resolves the 9 `tests/issues/212/test_hostname_dedup.py` failures (`sqlite3.OperationalError: no such table: registration_tokens`) tracked by the #2457 legacy-failure baseline, and prunes them from the baseline (333 → **324**, shrink-only).

Two commits:
1. `9b5ac322` — `make_manager()` now creates the `registration_tokens` table (mirrors `schema/schema-sqlite.sql:784-793`, 8 cols, `token_hash TEXT NOT NULL UNIQUE`). Without it every test calling `create_token()` crashed with "no such table" because `create_registration_token()` and the consume/validate/cleanup paths read/write it. Adds a fixture-level regression test (`test_fixture_creates_registration_tokens_table`, sqlite_master assertion) so a future fixture regression fails fast at the fixture instead of cascading 9 cryptic OperationalErrors.
2. `a311b556` — prunes the 9 resolved entries from `ci/legacy-issue-failures.json` (shrink-only; `provenance.prune_note` + `prune_source_run_url` recorded). No auto-grow; comparator fail-closed/quarantine semantics untouched.

## Scope

- Only issue 212 / registration_tokens (per the #2457 cluster instruction). No 673 users.name, no tenant resolver, no other debt mixed in.
- The previously-blocking main regressions were fixed in separate PRs: #2587 (37 × #2540/#2538 remote-endpoint tests) and #2590 (1816 pr_review summary retry). This branch is rebased on both.

## Verification

- Pre-fix state recorded: 9 failing nodeids on main (run 31662464134).
- Controlled negative: pre-fix reproduction confirmed the missing table was the sole cause; the new fixture assertion fails if the table is dropped.
- Local: `tests/issues/212/` 10/10 passed (9 fixed + 1 new regression test).
- CI (dispatch `category=issues`, 4 shards): run 31694625293 — comparator **exit-0**: `new=0, resolved=0, changed=0, collection_errors=0, invalid=0, known=324` (baseline 333→324, shrink-only).
- Independent plan review: CLEAN (zero objections) before implementation.
- pre-commit clean (black / isort / ruff / mypy).

Refs #2457

🤖 Generated with [Claude Code](https://claude.com/claude-code)